### PR TITLE
Add GitHub and pub.dev links to the example app

### DIFF
--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -7,8 +7,15 @@ import 'package:flutter/services.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'demo_document.dart';
+
+/// The project's source repository, opened from the AppBar links menu.
+final _githubUrl = Uri.parse('https://github.com/ben-milanko/dart-pdf');
+
+/// The published Flutter package the example is built on.
+final _pubDevUrl = Uri.parse('https://pub.dev/packages/dart_pdf_editor');
 
 /// One filter, every platform: desktop and web match on the extension,
 /// Android on the MIME type, iOS/macOS on the uniform type identifier —
@@ -149,6 +156,12 @@ class _ViewerScreenState extends State<ViewerScreen> {
         },
       ),
     ];
+  }
+
+  Future<void> _openLink(Uri url) async {
+    if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
+      _toast('Could not open $url');
+    }
   }
 
   void _toast(String message) {
@@ -386,6 +399,31 @@ class _ViewerScreenState extends State<ViewerScreen> {
             icon: const Icon(Icons.folder_open),
             tooltip: 'Open PDF',
             onPressed: _pickFile,
+          ),
+          // GitHub source + pub.dev package, kept in one slot so the
+          // action row stays inside the 800px test window
+          PopupMenuButton<Uri>(
+            icon: const Icon(Icons.link),
+            tooltip: 'Project links',
+            onSelected: _openLink,
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: _githubUrl,
+                child: const ListTile(
+                  leading: Icon(Icons.code),
+                  title: Text('View source on GitHub'),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+              PopupMenuItem(
+                value: _pubDevUrl,
+                child: const ListTile(
+                  leading: Icon(Icons.inventory_2_outlined),
+                  title: Text('dart_pdf_editor on pub.dev'),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/packages/dart_pdf_editor/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/dart_pdf_editor/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import file_selector_macos
 import share_plus
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/dart_pdf_editor/example/pubspec.yaml
+++ b/packages/dart_pdf_editor/example/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   pdf_document: ^0.1.0
   dart_pdf_editor: ^0.1.0
   share_plus: ^13.1.0
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_lints: ^5.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -733,6 +733,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: transitive
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.32"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -741,6 +765,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
Adds a **Project links** popup menu to the example app's AppBar with two entries:

- **View source on GitHub** → https://github.com/ben-milanko/dart-pdf
- **dart_pdf_editor on pub.dev** → https://pub.dev/packages/dart_pdf_editor

Both open in an external browser via `url_launcher`.

### Notes
- Consolidated into a single `PopupMenuButton` action slot rather than two separate `IconButton`s — the example AppBar action row is already at its 800px-test-window limit (all actions are `VisualDensity.compact` for that reason).
- Added `url_launcher: ^6.3.0` to the example's `pubspec.yaml`; the macOS `GeneratedPluginRegistrant.swift` was regenerated to register the plugin.

### Testing
- `dart analyze` clean
- `flutter test` (example) — all 13 tests pass, no AppBar overflow

https://claude.ai/code/session_01MbxX7RZ9tKHvJxm6H6mUWc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbxX7RZ9tKHvJxm6H6mUWc)_