### PR TITLE
Rotate text selection highlight with rotated text

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1768,7 +1768,12 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     return parts.join('\n');
   }
 
-  List<PdfRect> _selectionRectsOn(int pageIndex) {
+  List<PdfRect> _selectionRectsOn(int pageIndex) =>
+      [for (final quad in _selectionQuadsOn(pageIndex)) quad.bounds];
+
+  /// Baseline-aligned selection quads on [pageIndex], so the highlight
+  /// rotates with rotated text instead of painting an axis-aligned box.
+  List<PdfTextQuad> _selectionQuadsOn(int pageIndex) {
     final range = _selRange;
     if (range == null) return const [];
     final (start, end) = range;
@@ -1777,7 +1782,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     final from = pageIndex == start.$1 ? start.$2 : 0;
     final to = pageIndex == end.$1 ? end.$2 : text.text.length;
     if (from >= to) return const [];
-    return text.rectsFor(from, to);
+    return text.quadsFor(from, to);
   }
 
   void _showMatch(PdfTextMatch match) {
@@ -2158,7 +2163,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 currentMatch: _controller._currentMatch >= 0
                     ? _controller._matches[_controller._currentMatch]
                     : null,
-                selection: _selectionRectsOn(index),
+                selection: _selectionQuadsOn(index),
                 textSelection: _textSelectionOn(index),
                 overlayBuilder: widget.pageOverlayBuilder,
                 editing: editing,
@@ -2457,7 +2462,7 @@ class _PdfViewerPage extends StatefulWidget {
   final int settleGeneration;
   final List<PdfTextMatch> matches;
   final PdfTextMatch? currentMatch;
-  final List<PdfRect> selection;
+  final List<PdfTextQuad> selection;
 
   /// Touch selection chrome on this page (handles and the copy chip);
   /// null when the page shows none.
@@ -2678,7 +2683,7 @@ class _HighlightPainter extends CustomPainter {
   final int rotation;
   final List<PdfTextMatch> matches;
   final PdfTextMatch? currentMatch;
-  final List<PdfRect> selection;
+  final List<PdfTextQuad> selection;
   final PdfViewerThemeData theme;
 
   @override
@@ -2688,8 +2693,8 @@ class _HighlightPainter extends CustomPainter {
         PdfPageGeometry(cropBox: box, rotation: rotation, viewSize: size);
     final selected = Paint()
       ..color = theme.selectionColor ?? const Color(0x4D2196F3);
-    for (final rect in selection) {
-      canvas.drawRect(geometry.toViewRect(rect), selected);
+    for (final quad in selection) {
+      _paintQuad(canvas, geometry, quad, selected);
     }
     final normal = Paint()
       ..color = theme.searchMatchColor ?? const Color(0x66FFEB3B);
@@ -2697,10 +2702,21 @@ class _HighlightPainter extends CustomPainter {
       ..color = theme.currentSearchMatchColor ?? const Color(0x88FF9800);
     for (final match in matches) {
       final paint = identical(match, currentMatch) ? current : normal;
-      for (final rect in match.rects) {
-        canvas.drawRect(geometry.toViewRect(rect), paint);
+      for (final quad in match.quads) {
+        _paintQuad(canvas, geometry, quad, paint);
       }
     }
+  }
+
+  /// Maps the quad's four page-space corners into view space and fills the
+  /// resulting (possibly rotated) polygon, so highlights follow rotated
+  /// text instead of being axis-aligned boxes.
+  void _paintQuad(
+      Canvas canvas, PdfPageGeometry geometry, PdfTextQuad quad, Paint paint) {
+    final points = [
+      for (final (x, y) in quad.corners) geometry.toViewOffset(x, y),
+    ];
+    canvas.drawPath(Path()..addPolygon(points, true), paint);
   }
 
   @override

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -35,19 +35,56 @@ class PdfExtractedRun {
   final PdfRect bounds;
 }
 
-/// One search hit, with page-space rectangles for highlighting.
+/// Four page-space corners of a text span's highlight box, in perimeter
+/// order: lower-left, lower-right, upper-right, upper-left of the run's
+/// own baseline frame.
+///
+/// For horizontal text the quad is axis-aligned and matches [bounds];
+/// for rotated text the corners follow the glyph baseline, so a highlight
+/// painted as a quad rotates with the text instead of ballooning out to
+/// an axis-aligned bounding box.
+class PdfTextQuad {
+  const PdfTextQuad(this.corners);
+
+  /// The four `(x, y)` page-space points in perimeter order (ll, lr, ur,
+  /// ul). Always length 4.
+  final List<(double x, double y)> corners;
+
+  /// The axis-aligned page-space bounding box of the four corners.
+  PdfRect get bounds {
+    var minX = corners.first.$1, maxX = corners.first.$1;
+    var minY = corners.first.$2, maxY = corners.first.$2;
+    for (final (x, y) in corners) {
+      minX = math.min(minX, x);
+      maxX = math.max(maxX, x);
+      minY = math.min(minY, y);
+      maxY = math.max(maxY, y);
+    }
+    return PdfRect(minX, minY, maxX, maxY);
+  }
+}
+
+/// One search hit, with page-space geometry for highlighting.
 class PdfTextMatch {
   const PdfTextMatch({
     required this.pageIndex,
     required this.start,
     required this.end,
     required this.rects,
+    required this.quads,
   });
 
   final int pageIndex;
   final int start;
   final int end;
+
+  /// Axis-aligned bounding boxes (one per run touched), for scroll-to and
+  /// callers that only need a rough box.
   final List<PdfRect> rects;
+
+  /// Baseline-aligned quads (one per run touched), so highlights rotate
+  /// with rotated text.
+  final List<PdfTextQuad> quads;
 }
 
 /// The text content of one page, with geometry for search highlighting.
@@ -73,21 +110,30 @@ class PdfPageText {
       final index = haystack.indexOf(needle, from);
       if (index < 0) break;
       final end = index + needle.length;
+      final quads = quadsFor(index, end);
       matches.add(PdfTextMatch(
         pageIndex: pageIndex,
         start: index,
         end: end,
-        rects: rectsFor(index, end),
+        rects: [for (final quad in quads) quad.bounds],
+        quads: quads,
       ));
       from = end;
     }
     return matches;
   }
 
-  /// Page-space rectangles covering the characters [start]..[end] of
-  /// [text] — for search and selection highlights.
-  List<PdfRect> rectsFor(int start, int end) {
-    final rects = <PdfRect>[];
+  /// Axis-aligned page-space rectangles covering the characters
+  /// [start]..[end] of [text]. Convenience over [quadsFor] for callers
+  /// that don't need rotation (e.g. text-markup QuadPoints, scroll-to).
+  List<PdfRect> rectsFor(int start, int end) =>
+      [for (final quad in quadsFor(start, end)) quad.bounds];
+
+  /// Baseline-aligned page-space quads covering the characters
+  /// [start]..[end] of [text] — for selection and search highlights that
+  /// rotate with rotated text.
+  List<PdfTextQuad> quadsFor(int start, int end) {
+    final quads = <PdfTextQuad>[];
     for (final run in runs) {
       if (run.text.isEmpty) continue;
       final runEnd = run.startIndex + run.text.length;
@@ -98,9 +144,9 @@ class PdfPageText {
       // geometry arrives with the font engine
       final f0 = (overlapStart - run.startIndex) / run.text.length;
       final f1 = (overlapEnd - run.startIndex) / run.text.length;
-      rects.add(_boundsOf(run.transform, run.width * f0, run.width * f1));
+      quads.add(_quadOf(run.transform, run.width * f0, run.width * f1));
     }
-    return rects;
+    return quads;
   }
 
   /// The page text inside [rect] (page space): runs whose bounds center
@@ -518,29 +564,27 @@ class _Column {
   }
 }
 
-/// Bounding box of the em-space span [x0]..[x1] (with conventional 0.25 em
-/// descent and 0.75 em ascent) mapped through [transform].
-PdfRect _boundsOf(PdfMatrix transform, double x0, double x1) {
+/// Quad of the em-space span [x0]..[x1] (with conventional 0.25 em descent
+/// and 0.75 em ascent) mapped through [transform], in perimeter order
+/// (ll, lr, ur, ul). Rotated text yields a rotated parallelogram.
+PdfTextQuad _quadOf(PdfMatrix transform, double x0, double x1) {
   const descent = -0.25;
   const ascent = 0.75;
-  final xs = <double>[];
-  final ys = <double>[];
-  for (final (x, y) in [
-    (x0, descent),
-    (x1, descent),
-    (x0, ascent),
-    (x1, ascent),
-  ]) {
-    xs.add(transform.transformX(x, y));
-    ys.add(transform.transformY(x, y));
-  }
-  return PdfRect(
-    xs.reduce(math.min),
-    ys.reduce(math.min),
-    xs.reduce(math.max),
-    ys.reduce(math.max),
-  );
+  return PdfTextQuad([
+    for (final (x, y) in [
+      (x0, descent),
+      (x1, descent),
+      (x1, ascent),
+      (x0, ascent),
+    ])
+      (transform.transformX(x, y), transform.transformY(x, y)),
+  ]);
 }
+
+/// Axis-aligned bounding box of the em-space span [x0]..[x1] mapped
+/// through [transform].
+PdfRect _boundsOf(PdfMatrix transform, double x0, double x1) =>
+    _quadOf(transform, x0, x1).bounds;
 
 PdfRect _union(Iterable<PdfRect> rects) {
   final iterator = rects.iterator;

--- a/packages/pdf_graphics/test/text_extraction_test.dart
+++ b/packages/pdf_graphics/test/text_extraction_test.dart
@@ -72,6 +72,40 @@ void main() {
     expect(rect.right, closeTo(72 + perChar * 12, 1e-6));
   });
 
+  test('quadsFor matches the rect for horizontal text', () {
+    final doc = PdfDocument.open(buildClassicPdf());
+    final text = PdfTextExtractor.extract(doc, 0);
+    final quad = text.quadsFor(7, 12).single;
+    final ll = quad.corners[0];
+    final lr = quad.corners[1];
+    // horizontal baseline: the two baseline corners share y, advance in x
+    expect(lr.$2, closeTo(ll.$2, 1e-6));
+    expect(lr.$1, greaterThan(ll.$1));
+    // and the axis-aligned bounds equal the legacy rect
+    expect(quad.bounds, text.rectsFor(7, 12).single);
+  });
+
+  test('quadsFor rotates with rotated text', () {
+    // a 90° CCW text matrix: (x, y) -> (e - y, f + x), so the baseline
+    // runs straight up the page instead of across it
+    final doc = PdfDocument.open(_buildTextPdf([
+      'BT /F1 12 Tf 0 1 -1 0 100 100 Tm (Rotated) Tj ET',
+    ]));
+    final text = PdfTextExtractor.extract(doc, 0);
+    final quad = text.quadsFor(0, text.text.length).single;
+    final ll = quad.corners[0];
+    final lr = quad.corners[1];
+    // the baseline (ll -> lr) is vertical: same x, the advance is in y
+    expect(lr.$1, closeTo(ll.$1, 1e-6));
+    expect(lr.$2 - ll.$2, greaterThan(10));
+    // the rect still reports the enclosing axis-aligned box (covers the
+    // whole rotated quad, both wider and taller than zero)
+    final rect = text.rectsFor(0, text.text.length).single;
+    expect(rect, quad.bounds);
+    expect(rect.width, greaterThan(0));
+    expect(rect.height, greaterThan(0));
+  });
+
   test('multi-page documents extract per page', () {
     final doc = PdfDocument.open(buildMultiPagePdf(3));
     expect(PdfTextExtractor.extract(doc, 0).text, 'Page 1');


### PR DESCRIPTION
## Problem

Text highlights — both the selection fill and search-match fills — were painted as **axis-aligned boxes**. `PdfPageText.rectsFor` mapped each run's baseline frame through the run transform and then took the min/max of the four corners (`_boundsOf`). For rotated text (diagonal labels, vertical CAD callouts, rotated stamps) that bounding box ballooned out and ignored the text's angle, so selecting rotated text drew a big upright rectangle instead of tracking the glyphs.

Page-level `/Rotate` already worked (it rides through `PdfPageGeometry.toViewOffset`); this fixes per-run text rotation *within* a page.

## Change

- **`pdf_graphics`** — add `PdfTextQuad` (four page-space corners in perimeter order: ll, lr, ur, ul, plus an axis-aligned `bounds` getter) and `PdfPageText.quadsFor(start, end)`, which keeps the run's rotation instead of flattening to a box. `PdfTextMatch` now carries `quads` alongside `rects`. `rectsFor` and the public `selectionRectsOn` still report axis-aligned bounds, so markup QuadPoints and scroll-to are unchanged.
- **`dart_pdf_editor`** — `_HighlightPainter` maps each quad's four corners through the page geometry and fills the resulting polygon (`drawPath` + `addPolygon`) instead of `drawRect`. Selection feeds it via a new `_selectionQuadsOn`. For horizontal text the quad is axis-aligned and identical to the old rect.

## Tests

- `text_extraction_test.dart`: `quadsFor` matches the rect for horizontal text; `quadsFor` rotates with a 90° text matrix (baseline runs vertically) while `rectsFor` still reports the enclosing box.
- Existing viewer / theme / touch-selection suites pass unchanged; full `pdf_graphics` suite (336 tests) green; workspace analyze clean.

https://claude.ai/code/session_01SbZ4sBRFzvM9qm7t95M1T3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbZ4sBRFzvM9qm7t95M1T3)_