### PR TITLE
Hold Shift to lock aspect ratio when resizing annotations

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -898,7 +898,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         .shift(_rotatePoint(delta, Offset.zero, _resizeAngle) - delta);
   }
 
-  Rect _resizedRect(Rect from, _Handle handle, Offset delta) {
+  Rect _resizedRect(Rect from, _Handle handle, Offset delta,
+      {double? aspectRatio}) {
     final minSize = _minSizeView * _chromeScale;
     var left = from.left, top = from.top;
     var right = from.right, bottom = from.bottom;
@@ -919,6 +920,50 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         top = bottom - minSize;
       } else {
         bottom = top + minSize;
+      }
+    }
+    if (aspectRatio != null && aspectRatio > 0) {
+      var width = right - left;
+      var height = bottom - top;
+      if (handle.dx != 0 && handle.dy != 0) {
+        // corner: lock the off-axis to whichever side the pointer pushed
+        // harder (relative to the original size), then re-anchor at the
+        // fixed corner so the dragged corner tracks the pointer
+        if (width / from.width >= height / from.height) {
+          height = width / aspectRatio;
+        } else {
+          width = height * aspectRatio;
+        }
+        if (height < minSize) {
+          height = minSize;
+          width = height * aspectRatio;
+        }
+        if (width < minSize) {
+          width = minSize;
+          height = width / aspectRatio;
+        }
+        if (handle.dx < 0) {
+          left = right - width;
+        } else {
+          right = left + width;
+        }
+        if (handle.dy < 0) {
+          top = bottom - height;
+        } else {
+          bottom = top + height;
+        }
+      } else if (handle.dy == 0) {
+        // vertical edge: width drives, height follows about the center
+        height = math.max(width / aspectRatio, minSize);
+        final cy = from.center.dy;
+        top = cy - height / 2;
+        bottom = cy + height / 2;
+      } else {
+        // horizontal edge: height drives, width follows about the center
+        width = math.max(height * aspectRatio, minSize);
+        final cx = from.center.dx;
+        left = cx - width / 2;
+        right = cx + width / 2;
       }
     }
     return Rect.fromLTRB(left, top, right, bottom);
@@ -1312,12 +1357,18 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // a rotated selection's handles move along its own axes, so the
         // pointer delta rotates into the local frame
         final delta = position - _moveStart!;
+        // holding Shift locks the original aspect ratio
+        final aspectRatio = HardwareKeyboard.instance.isShiftPressed &&
+                _resizeFrom!.height > 0
+            ? _resizeFrom!.width / _resizeFrom!.height
+            : null;
         _resizeRect = _anchorResized(_resizedRect(
             _resizeFrom!,
             _resizeHandle!,
             _resizeAngle == 0
                 ? delta
-                : _rotatePoint(delta, Offset.zero, -_resizeAngle)));
+                : _rotatePoint(delta, Offset.zero, -_resizeAngle),
+            aspectRatio: aspectRatio));
       });
     } else if (_moveStart != null) {
       setState(() => _moveCurrent = position);

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -705,6 +705,36 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('Shift-dragging a corner handle keeps the aspect ratio',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750)) // 150×100 (3:2)
+        ..tool = PdfEditTool.select;
+      await tester.pump();
+      await tester.tapAt(view(175, 700));
+      await settle(tester);
+      expect(editing.selectedAnnotation, isNotNull);
+
+      // hold Shift across a bottom-right corner drag that only pushes the
+      // width out — the aspect lock must grow the height to match
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      const from = Offset(250, 650), to = Offset(330, 650);
+      final gesture = await tester.startGesture(view(from.dx, from.dy));
+      await gesture.moveTo(view((from.dx + to.dx) / 2, from.dy));
+      await gesture.moveTo(view(to.dx, to.dy));
+      await gesture.up();
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pump();
+
+      final rect = editing.selectedAnnotation!.rect;
+      expect(rect.width, greaterThan(150),
+          reason: 'the corner drag widened the box');
+      expect(rect.width / rect.height, closeTo(1.5, 0.05),
+          reason: 'Shift locked the 3:2 aspect, so the height grew too');
+      await settle(tester);
+    });
+
     testWidgets('ctrl+Z undoes, ctrl+shift+Z redoes', (tester) async {
       final (editing, _) = await pumpEditor(tester);
       editing.addRectangle(0, const PdfRect(100, 650, 250, 750));


### PR DESCRIPTION
## Summary

Resize-handle drags now constrain the new rect to the annotation's original aspect ratio while **Shift** is held — the standard "shift scaling" gesture from desktop editors.

- **Corner handles** drive the locked dimension off whichever axis the pointer pushed harder (relative to the original size), then re-anchor at the fixed (opposite) corner so the dragged corner still tracks the pointer.
- **Edge handles** grow the perpendicular dimension symmetrically about the center, so a width-edge drag scales height (and vice versa) proportionally.
- The constraint runs inside `_resizedRect` *before* `_anchorResized`, so it works in the rotated-resize local frame too (the pointer delta is already unrotated into the annotation's own axes there).
- Shift state is read live from `HardwareKeyboard.instance.isShiftPressed` on each pan update, so pressing/releasing Shift mid-drag toggles the lock.

The live drag preview, post-commit afterimage, and free-text re-wrap preview all consume the same `_resizeRect`, so the constrained box shows correctly throughout.

## Test

Added `editing_test.dart` › "Shift-dragging a corner handle keeps the aspect ratio": a Shift-held bottom-right corner drag that only pushes the width out must grow the height to preserve the 3:2 ratio. The ratio assertion is robust to gesture slop because the lock enforces the ratio on whatever final width the drag produces.

`editing_test.dart`, `editing_chrome_test.dart`, and `editing_rotate_test.dart` all pass.

https://claude.ai/code/session_01XeR3q9JSnBayY6cyTTcLJt

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeR3q9JSnBayY6cyTTcLJt)_