### PR TITLE
Preserve reading position when resizing side panels

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -933,6 +933,51 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     return offset;
   }
 
+  /// A page's slot extent in the scroll list, mirroring [itemExtentBuilder]:
+  /// the leading [PdfViewer.pageSpacing] belongs to every page but the first.
+  double _scrollExtentOf(int index) =>
+      _pageHeight(index) + (index == 0 ? 0 : widget.pageSpacing);
+
+  /// The list-space offset at which page [index]'s slot begins.
+  double _slotStart(int index) {
+    var offset = 0.0;
+    for (var i = 0; i < index; i++) {
+      offset += _scrollExtentOf(i);
+    }
+    return offset;
+  }
+
+  /// Page heights scale with [_viewWidth] (see [_pageHeight]), so when the
+  /// viewport width changes — most visibly while a side panel's resize grip
+  /// is dragged — a fixed scroll offset maps to a different page and the
+  /// document appears to scroll under the reader. This pins the reading
+  /// position: capture the page (and fraction within it) at the viewport top
+  /// under the OLD geometry, then re-derive the scroll offset once the new
+  /// width has laid out. Called from build while [_viewWidth] still holds the
+  /// previous width.
+  void _preserveReadingAnchor() {
+    final top = _scroll.offset;
+    var acc = 0.0;
+    var anchorPage = _pages.length - 1;
+    var fraction = 0.0;
+    for (var i = 0; i < _pages.length; i++) {
+      final extent = _scrollExtentOf(i);
+      if (top < acc + extent || i == _pages.length - 1) {
+        anchorPage = i;
+        fraction = extent > 0 ? ((top - acc) / extent).clamp(0.0, 1.0) : 0.0;
+        break;
+      }
+      acc += extent;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scroll.hasClients || _viewWidth <= 0) return;
+      final target = (_slotStart(anchorPage) +
+              fraction * _scrollExtentOf(anchorPage))
+          .clamp(0.0, _scroll.position.maxScrollExtent);
+      if ((target - _scroll.offset).abs() > 0.5) _scroll.jumpTo(target);
+    });
+  }
+
   void _onScroll() {
     if (_viewWidth <= 0 || !_scroll.hasClients) return;
     _controller._bumpViewport();
@@ -2100,6 +2145,15 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
             ? const Color(0xFF202124)
             : const Color(0xFF404347));
     return LayoutBuilder(builder: (context, constraints) {
+      // _viewWidth still holds the previous layout's width here; a change
+      // rescales every page, so pin the reading position before adopting it
+      // (skips the very first layout, where there is nothing to preserve).
+      if (_viewWidth > 0 &&
+          constraints.maxWidth != _viewWidth &&
+          _scroll.hasClients &&
+          _pages.isNotEmpty) {
+        _preserveReadingAnchor();
+      }
       _viewWidth = constraints.maxWidth;
       _viewHeight = constraints.maxHeight;
       if (!_appliedInitialFit && _viewWidth > 0 && _viewHeight > 0) {

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -71,6 +71,55 @@ void main() {
     expect(controller.currentPage, greaterThan(0));
   });
 
+  testWidgets('resizing a side panel preserves the reading position',
+      (tester) async {
+    // Page heights scale with the viewer width, so a panel resize that
+    // shrinks the viewport used to slide the document under the reader.
+    final controller = PdfViewerController();
+    // one document instance: rebuilding with a fresh PdfDocument would look
+    // like a swap and reset the viewport, masking the resize behavior.
+    final document = PdfDocument.open(buildMultiPagePdf(8));
+    Widget build(double panelWidth) => MaterialApp(
+          home: Scaffold(
+            body: Row(children: [
+              SizedBox(width: panelWidth, height: double.infinity),
+              Expanded(
+                child: PdfViewer(
+                  key: const ValueKey('viewer'),
+                  initialFit: PdfViewerFit.width,
+                  document: document,
+                  controller: controller,
+                ),
+              ),
+            ]),
+          ),
+        );
+
+    await tester.pumpWidget(build(100));
+    await tester.pump();
+
+    // park a middle page near the top, a little into it so the anchor
+    // fraction is non-trivial
+    controller.jumpToPage(3); // async; fire-and-pump (no fake-async await)
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    await tester.drag(find.byType(PdfViewer), const Offset(0, -120));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    final beforeTop = controller.visiblePageRegion(3)!.top;
+    expect(beforeTop, greaterThan(0));
+
+    // widen the panel: the viewer shrinks and every page rescales
+    await tester.pumpWidget(build(300));
+    await tester.pump(); // lay out at the new width
+    await tester.pump(); // run the post-frame re-anchor
+
+    final region = controller.visiblePageRegion(3);
+    expect(region, isNotNull,
+        reason: 'page 3 should still sit at the viewport top');
+    expect(region!.top, closeTo(beforeTop, 0.02),
+        reason: 'the same point of the page stays at the viewport top');
+  });
+
   testWidgets('search finds matches and tracks the current one',
       (tester) async {
     final controller = await pumpViewer(tester);


### PR DESCRIPTION
## Problem

Resizing the panels scrolls the page.

Dragging a sidebar's resize grip continuously changes the viewer's width. Page heights are laid out proportional to that width (`_pageHeight = aspect × _viewWidth × _layoutZoom`), but the scroll offset is fixed in list-space pixels. So every frame of the drag remapped the same offset onto a different page, and the document slid under the reader. (It isn't a gesture leak — the grip is an opaque, horizontal-only `GestureDetector` and the viewer is a sibling, not an ancestor.)

## Fix

The viewer's `LayoutBuilder` now pins the reading position across any width change:

1. Before adopting the new constraints (while `_viewWidth` still holds the previous width), capture the page — and the fraction within it — sitting at the viewport top.
2. Schedule a post-frame callback that re-derives the scroll offset for that same page+fraction under the new geometry and jumps to it.

This skips the very first layout (nothing to preserve) and only fires when the width actually changes, so window resizes get the same benefit for free. Added `_scrollExtentOf` / `_slotStart` helpers that mirror the list's `itemExtentBuilder` exactly (the leading page spacing belongs to every page but the first).

## Tests

New regression test `resizing a side panel preserves the reading position` in `pdf_viewer_test.dart`: parks page 3 near the viewport top, widens an adjacent panel, and asserts the same point of the page stays at the top. Verified it fails without the fix. Full `pdf_viewer_test.dart` and `editing_panels_test.dart` suites pass (51 tests).

https://claude.ai/code/session_017HjPt1xVq3EFhBqxuzWDAa

---
_Generated by [Claude Code](https://claude.ai/code/session_017HjPt1xVq3EFhBqxuzWDAa)_