### PR TITLE
Add document tabs to the example app

### DIFF
--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -85,37 +85,33 @@ class ViewerScreen extends StatefulWidget {
 }
 
 class _ViewerScreenState extends State<ViewerScreen> {
-  final _controller = PdfViewerController();
-
   PdfEditingPreferences get _prefs => widget.prefs;
 
-  /// The open document's bytes — PdfEditorView/PdfReader own the rest
-  /// (edit session, search, panels, toolbar).
-  Uint8List? _bytes;
-  String _title = '';
-  String? _error;
+  /// One entry per open document. Each tab owns its own edit session and
+  /// viewer controller, so switching tabs preserves each document's
+  /// edits, undo history, and any demo-specific state.
+  final List<_DocumentTab> _tabs = [];
+  int _activeIndex = 0;
+
+  _DocumentTab? get _active =>
+      _tabs.isEmpty ? null : _tabs[_activeIndex.clamp(0, _tabs.length - 1)];
 
   /// Demo of the two drop-in widgets: the toggle swaps the full
-  /// [PdfEditorView] for the view-only [PdfReader].
+  /// [PdfEditorView] for the view-only [PdfReader]. App-wide.
   bool _readOnly = false;
-
-  // app state the interactive demo's PDF links and overlays manipulate
-  bool _isDemo = false;
-  int _counter = 0;
-  bool _switchOn = false;
-  final _noteField = TextEditingController();
 
   /// GoTo and the standard named page actions never get here (the viewer
   /// follows them itself). Custom-scheme URIs are dispatched as app
   /// commands — the conventional way a PDF drives its host app — and
   /// anything else just gets described in a snackbar.
   void _onAction(PdfAction action, PdfAnnotation annotation) {
+    final tab = _active;
     if (action is PdfUriAction) {
       final uri = Uri.tryParse(action.uri);
       if (uri?.scheme == 'app') {
         switch (uri!.host) {
           case 'counter':
-            setState(() => _counter++);
+            if (tab != null) setState(() => tab.counter++);
             return;
           case 'message':
             _toast(uri.queryParameters['text'] ?? 'No message');
@@ -160,18 +156,42 @@ class _ViewerScreenState extends State<ViewerScreen> {
       ));
   }
 
+  /// Opens [bytes] in a brand-new tab and makes it the active one.
   void _openBytes(Uint8List bytes, String title, {bool isDemo = false}) {
     setState(() {
-      _bytes = bytes;
-      _title = title;
-      _error = null;
-      _isDemo = isDemo;
-      if (isDemo) _counter = 0;
+      _tabs.add(_DocumentTab.document(
+        title: title,
+        bytes: bytes,
+        preferences: _prefs,
+        isDemo: isDemo,
+      ));
+      _activeIndex = _tabs.length - 1;
+    });
+  }
+
+  /// Adds a tab that just reports an open failure.
+  void _openError(String title, String error) {
+    setState(() {
+      _tabs.add(_DocumentTab.error(title: title, error: error));
+      _activeIndex = _tabs.length - 1;
     });
   }
 
   void _openDemo() =>
       _openBytes(buildDemoPdf(), 'Feature showcase', isDemo: true);
+
+  /// Disposes the tab at [index] and drops it, keeping a sensible tab
+  /// active. The controllers are torn down after the frame so the
+  /// outgoing viewer can detach from them cleanly first.
+  void _closeTab(int index) {
+    final tab = _tabs[index];
+    setState(() {
+      _tabs.removeAt(index);
+      if (_activeIndex >= _tabs.length) _activeIndex = _tabs.length - 1;
+      if (_activeIndex < 0) _activeIndex = 0;
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) => tab.dispose());
+  }
 
   /// Pins [child] into a page slot at its design size in PDF points and
   /// lets it scale with the page, so the overlays hold together at any
@@ -187,11 +207,13 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// Flutter widgets pinned into the slots the demo document draws.
   List<Widget> _demoOverlays(
       BuildContext context, int pageIndex, PdfPageGeometry geometry) {
+    final tab = _active;
+    if (tab == null) return const [];
     switch (pageIndex) {
       case 0:
         return [
           _slot(geometry, DemoLayout.counterBadge,
-              _CounterBadge(count: _counter)),
+              _CounterBadge(count: tab.counter)),
         ];
       case 1:
         return [
@@ -200,8 +222,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
             geometry,
             DemoLayout.counter,
             _CounterControl(
-              count: _counter,
-              onChanged: (value) => setState(() => _counter = value),
+              count: tab.counter,
+              onChanged: (value) => setState(() => tab.counter = value),
             ),
           ),
           _slot(
@@ -209,8 +231,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
             DemoLayout.toggle,
             FittedBox(
               child: Switch(
-                value: _switchOn,
-                onChanged: (value) => setState(() => _switchOn = value),
+                value: tab.switchOn,
+                onChanged: (value) => setState(() => tab.switchOn = value),
               ),
             ),
           ),
@@ -225,7 +247,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
               ),
               child: TextField(
                 key: const ValueKey('demo-note'),
-                controller: _noteField,
+                controller: tab.noteField,
                 decoration: const InputDecoration(
                   hintText: 'Type here - this text box floats above the page',
                   isDense: true,
@@ -256,8 +278,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
 
   @override
   void dispose() {
-    _controller.dispose();
-    _noteField.dispose();
+    for (final tab in _tabs) {
+      tab.dispose();
+    }
     super.dispose();
   }
 
@@ -267,16 +290,16 @@ class _ViewerScreenState extends State<ViewerScreen> {
     try {
       _openBytes(await file.readAsBytes(), file.name);
     } catch (e) {
-      setState(() => _error = 'Could not open ${file.name}\n$e');
+      _openError(file.name, 'Could not open ${file.name}\n$e');
     }
   }
 
   Future<void> _openPath(String path) async {
+    final name = path.split(RegExp(r'[/\\]')).last;
     try {
-      final bytes = await XFile(path).readAsBytes();
-      _openBytes(bytes, path.split(RegExp(r'[/\\]')).last);
+      _openBytes(await XFile(path).readAsBytes(), name);
     } catch (e) {
-      setState(() => _error = 'Could not open $path\n$e');
+      _openError(name, 'Could not open $path\n$e');
     }
   }
 
@@ -319,31 +342,41 @@ class _ViewerScreenState extends State<ViewerScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final bytes = _bytes;
+    final tab = _active;
     return Scaffold(
       appBar: AppBar(
-        title: Text(_title.isEmpty ? 'dart-pdf viewer' : _title,
-            overflow: TextOverflow.ellipsis),
+        title: Text(tab == null || tab.title.isEmpty
+            ? 'dart-pdf viewer'
+            : tab.title, overflow: TextOverflow.ellipsis),
+        // a browser-style tab strip under the title; hidden until the
+        // first document is open
+        bottom: _tabs.isEmpty
+            ? null
+            : PreferredSize(
+                preferredSize: const Size.fromHeight(_tabStripHeight),
+                child: _buildTabStrip(),
+              ),
         actions: [
-          ListenableBuilder(
-            listenable: _controller,
-            builder: (context, _) => !_controller.hasSelection
-                ? const SizedBox.shrink()
-                : IconButton(
-                    icon: const Icon(Icons.copy),
-                    tooltip: 'Copy selected text (⌘C)',
-                    onPressed: () async {
-                      await _controller.copySelection();
-                      if (!context.mounted) return;
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('Copied to clipboard'),
-                          duration: Duration(seconds: 1),
-                        ),
-                      );
-                    },
-                  ),
-          ),
+          if (tab?.viewer != null)
+            ListenableBuilder(
+              listenable: tab!.viewer!,
+              builder: (context, _) => !tab.viewer!.hasSelection
+                  ? const SizedBox.shrink()
+                  : IconButton(
+                      icon: const Icon(Icons.copy),
+                      tooltip: 'Copy selected text (⌘C)',
+                      onPressed: () async {
+                        await tab.viewer!.copySelection();
+                        if (!context.mounted) return;
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Copied to clipboard'),
+                            duration: Duration(seconds: 1),
+                          ),
+                        );
+                      },
+                    ),
+            ),
           // every plain action is compact: the row overflows an 800px
           // window (the widget-test viewport included) at full density
           IconButton(
@@ -378,62 +411,186 @@ class _ViewerScreenState extends State<ViewerScreen> {
           IconButton(
             visualDensity: VisualDensity.compact,
             icon: const Icon(Icons.auto_awesome),
-            tooltip: 'Open the interactive demo',
+            tooltip: 'Open the interactive demo in a new tab',
             onPressed: _openDemo,
           ),
           IconButton(
             visualDensity: VisualDensity.compact,
             icon: const Icon(Icons.folder_open),
-            tooltip: 'Open PDF',
+            tooltip: 'Open PDF in a new tab',
             onPressed: _pickFile,
           ),
         ],
       ),
-      body: switch ((bytes, _error)) {
-        (_, final String error) => Center(
-            child: Text(error, textAlign: TextAlign.center),
-          ),
-        (null, _) => Center(
-            child: Column(
+      // each tab is keyed so switching rebuilds against its own
+      // controllers (which keep the edits and scroll position alive);
+      // only the active tab is mounted, so there's one viewer at a time
+      body: tab == null
+          ? Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  FilledButton.icon(
+                    onPressed: _pickFile,
+                    icon: const Icon(Icons.folder_open),
+                    label: const Text('Open a PDF'),
+                  ),
+                  const SizedBox(height: 12),
+                  FilledButton.tonalIcon(
+                    onPressed: _openDemo,
+                    icon: const Icon(Icons.auto_awesome),
+                    label: const Text('Try the interactive demo'),
+                  ),
+                ],
+              ),
+            )
+          : tab.error != null
+              ? Center(child: Text(tab.error!, textAlign: TextAlign.center))
+              // the two drop-in widgets carry all the PDF chrome (search,
+              // page number, panels, toolbar) — the app supplies the edit
+              // session, its file handling, and the demo's app-side wiring
+              : _readOnly
+                  ? PdfReader(
+                      key: ValueKey(tab),
+                      bytes: tab.session!.bytes,
+                      controller: tab.viewer,
+                      preferences: _prefs,
+                      onAction: _onAction,
+                      pageOverlayBuilder: tab.isDemo ? _demoOverlays : null,
+                    )
+                  : PdfEditorView(
+                      key: ValueKey(tab),
+                      controller: tab.session,
+                      viewerController: tab.viewer,
+                      onSave: (saved) => unawaited(_saveAs(saved)),
+                      onAction: _onAction,
+                      pageOverlayBuilder: tab.isDemo ? _demoOverlays : null,
+                      annotationMenuBuilder: _annotationMenuActions,
+                      formImagePicker: _pickFormImage,
+                    ),
+    );
+  }
+
+  /// The horizontally scrolling row of open-document tabs plus the
+  /// new-tab button.
+  Widget _buildTabStrip() {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.surface,
+      child: SizedBox(
+        height: _tabStripHeight,
+        child: Row(
+          children: [
+            Expanded(
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                itemCount: _tabs.length,
+                itemBuilder: (context, i) => _buildTab(i),
+              ),
+            ),
+            IconButton(
+              visualDensity: VisualDensity.compact,
+              icon: const Icon(Icons.add),
+              tooltip: 'Open PDF in a new tab',
+              onPressed: _pickFile,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTab(int index) {
+    final tab = _tabs[index];
+    final selected = index == _activeIndex;
+    final scheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 5),
+      child: Material(
+        color: selected
+            ? scheme.secondaryContainer
+            : scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: () => setState(() => _activeIndex = index),
+          child: Padding(
+            padding: const EdgeInsets.only(left: 12, right: 2),
+            child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                FilledButton.icon(
-                  onPressed: _pickFile,
-                  icon: const Icon(Icons.folder_open),
-                  label: const Text('Open a PDF'),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 160),
+                  child: Text(
+                    tab.title.isEmpty ? 'Untitled' : tab.title,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontWeight:
+                          selected ? FontWeight.w600 : FontWeight.normal,
+                      color: selected
+                          ? scheme.onSecondaryContainer
+                          : scheme.onSurfaceVariant,
+                    ),
+                  ),
                 ),
-                const SizedBox(height: 12),
-                FilledButton.tonalIcon(
-                  onPressed: _openDemo,
-                  icon: const Icon(Icons.auto_awesome),
-                  label: const Text('Try the interactive demo'),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 16),
+                  visualDensity: VisualDensity.compact,
+                  padding: EdgeInsets.zero,
+                  constraints:
+                      const BoxConstraints(minWidth: 30, minHeight: 30),
+                  tooltip: 'Close tab',
+                  onPressed: () => _closeTab(index),
                 ),
               ],
             ),
           ),
-        // the two drop-in widgets carry all the PDF chrome (search,
-        // page number, panels, toolbar) — the app only supplies bytes,
-        // its file handling, and the demo's app-side wiring
-        (final Uint8List data, _) => _readOnly
-            ? PdfReader(
-                bytes: data,
-                controller: _controller,
-                preferences: _prefs,
-                onAction: _onAction,
-                pageOverlayBuilder: _isDemo ? _demoOverlays : null,
-              )
-            : PdfEditorView(
-                bytes: data,
-                viewerController: _controller,
-                preferences: _prefs,
-                onSave: (saved) => unawaited(_saveAs(saved)),
-                onAction: _onAction,
-                pageOverlayBuilder: _isDemo ? _demoOverlays : null,
-                annotationMenuBuilder: _annotationMenuActions,
-                formImagePicker: _pickFormImage,
-              ),
-      },
+        ),
+      ),
     );
+  }
+}
+
+/// Height of the AppBar's tab strip.
+const double _tabStripHeight = 42;
+
+/// One open document. Holds its own edit session and viewer controller
+/// so switching tabs preserves edits, undo history, scroll position,
+/// and any demo-specific overlay state.
+class _DocumentTab {
+  _DocumentTab.document({
+    required this.title,
+    required Uint8List bytes,
+    required PdfEditingPreferences preferences,
+    this.isDemo = false,
+  })  : session = PdfEditingController(bytes, preferences: preferences),
+        viewer = PdfViewerController(),
+        error = null;
+
+  _DocumentTab.error({required this.title, required this.error})
+      : session = null,
+        viewer = null,
+        isDemo = false;
+
+  final String title;
+  final String? error;
+  final bool isDemo;
+
+  /// Null for an error tab. Shared preferences are owned by the app, so
+  /// they outlive the tab.
+  final PdfEditingController? session;
+  final PdfViewerController? viewer;
+
+  // demo-specific state the PDF links and overlays drive, per document
+  int counter = 0;
+  bool switchOn = false;
+  final noteField = TextEditingController();
+
+  void dispose() {
+    session?.dispose();
+    viewer?.dispose();
+    noteField.dispose();
   }
 }
 

--- a/packages/dart_pdf_editor/example/test/demo_test.dart
+++ b/packages/dart_pdf_editor/example/test/demo_test.dart
@@ -75,7 +75,9 @@ void main() {
     expect(tester.widget<Switch>(find.byType(Switch)).value, isTrue);
 
     // the counter control edits the same state the page-1 link increments
-    await tester.tap(find.byIcon(Icons.add));
+    // (.first: the page overlay's button — the AppBar tab strip's new-tab
+    // '+' is also an Icons.add, and Scaffold mounts the body before the bar)
+    await tester.tap(find.byIcon(Icons.add).first);
     await tester.pump(const Duration(milliseconds: 400));
     expect(plainText('1'), findsWidgets);
 

--- a/packages/dart_pdf_editor/example/test/tabs_test.dart
+++ b/packages/dart_pdf_editor/example/test/tabs_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_viewer_example/main.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  Future<void> openDemo(WidgetTester tester) async {
+    // the mock store is process-global: start every test from defaults
+    SharedPreferences.setMockInitialValues({});
+    await tester.pumpWidget(const ViewerApp());
+    await tester.pump();
+  }
+
+  // each open document carries one 'Close tab' button in the strip
+  Finder closeButtons() => find.byTooltip('Close tab');
+
+  testWidgets('app launches with a single document tab', (tester) async {
+    await openDemo(tester);
+    expect(closeButtons(), findsOneWidget);
+    expect(find.byType(PdfViewer), findsOneWidget);
+  });
+
+  testWidgets('the AppBar demo action opens a second tab', (tester) async {
+    await openDemo(tester);
+    await tester.tap(find.byTooltip('Open the interactive demo in a new tab'));
+    await tester.pump();
+
+    // two tabs now, but still exactly one mounted viewer (only the active
+    // tab is rendered)
+    expect(closeButtons(), findsNWidgets(2));
+    expect(find.byType(PdfViewer), findsOneWidget);
+  });
+
+  testWidgets('closing a tab drops it and keeps another active',
+      (tester) async {
+    await openDemo(tester);
+    await tester.tap(find.byTooltip('Open the interactive demo in a new tab'));
+    await tester.pump();
+    expect(closeButtons(), findsNWidgets(2));
+
+    await tester.tap(closeButtons().last);
+    await tester.pump();
+    // the post-frame controller teardown runs; pump it through
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(closeButtons(), findsOneWidget);
+    expect(find.byType(PdfViewer), findsOneWidget);
+  });
+
+  testWidgets('closing the last tab shows the open prompt', (tester) async {
+    await openDemo(tester);
+    await tester.tap(closeButtons());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    // no tabs, no strip, no viewer — just the empty-state buttons
+    expect(closeButtons(), findsNothing);
+    expect(find.byType(PdfViewer), findsNothing);
+    expect(find.text('Open a PDF'), findsOneWidget);
+    expect(find.text('Try the interactive demo'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
The example app can now hold several documents open at once in a browser-style tab strip, instead of replacing the single open document each time.

## What changed

- **Per-tab state.** The viewer screen manages a `List<_DocumentTab>` with an active index. Each tab owns its own `PdfEditingController` and `PdfViewerController`, so switching tabs preserves that document's edits, undo history, scroll position, and the demo overlay state (counter / switch / note field). Error tabs (open failures) carry a message instead.
- **Single mounted viewer.** Only the active tab is rendered (keyed by tab), so there's always exactly one `PdfViewer` in the tree — switching swaps to that tab's controllers, which keep its session alive.
- **Tab strip.** A horizontally scrolling row of tab chips (title + close button) plus a `+` new-tab button lives in the `AppBar.bottom`. The AppBar's "open PDF" and "open demo" actions and the `+` button all open new tabs. Closing the last tab returns to the open-a-file prompt.

## Tests

- `demo_test` now scopes the demo counter-control add button with `.first` (the new-tab `+` is also an `Icons.add`, and Scaffold mounts the body before the AppBar).
- New `tabs_test.dart` covers launch-with-one-tab, opening a second tab, closing a tab, and closing the last tab.

All example tests pass (`flutter test`) and `dart analyze lib test` is clean.

https://claude.ai/code/session_01UQniu3adwuwpHsrei8qufW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQniu3adwuwpHsrei8qufW)_