### PR TITLE
Show feedback when flattening annotations or form fields

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -934,8 +934,9 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   /// Bakes every page's annotation appearances into its content and
-  /// removes the annotations.
-  void flattenAllAnnotations() => apply((editor) {
+  /// removes the annotations. Returns whether anything was flattened
+  /// (false when no page carried a flattenable annotation).
+  bool flattenAllAnnotations() => apply((editor) {
         for (var i = 0; i < _document.pageCount; i++) {
           editor.flattenAnnotations(i);
         }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -163,6 +163,46 @@ class PdfEditingToolbar extends StatelessWidget {
     controller.replaceSelectedElementText(text);
   }
 
+  /// Bakes every annotation into its page and reports the result — the
+  /// flattened content looks identical to the live annotations, so
+  /// without this toast the button appears to do nothing.
+  void _flatten(BuildContext context) {
+    final flattened = controller.flattenAllAnnotations();
+    _flattenToast(
+      context,
+      flattened
+          ? 'Annotations flattened into the pages'
+          : 'No annotations to flatten',
+      undoable: flattened,
+    );
+  }
+
+  void _flattenForm(BuildContext context) {
+    final flattened = controller.flattenFormFields();
+    _flattenToast(
+      context,
+      flattened
+          ? 'Form fields flattened into the pages'
+          : 'No form fields to flatten',
+      undoable: flattened,
+    );
+  }
+
+  void _flattenToast(BuildContext context, String message,
+      {required bool undoable}) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    messenger
+      ..clearSnackBars()
+      ..showSnackBar(SnackBar(
+        content: Text(message),
+        behavior: SnackBarBehavior.floating,
+        action: undoable && controller.canUndo
+            ? SnackBarAction(label: 'Undo', onPressed: controller.undo)
+            : null,
+      ));
+  }
+
   Future<void> _editSelectedText(BuildContext context) async {
     final annotation = controller.selectedAnnotation;
     if (annotation == null) return;
@@ -372,7 +412,7 @@ class PdfEditingToolbar extends StatelessWidget {
                     tooltip: 'Flatten form — bake values into the pages',
                     onPressed: controller.acroForm == null
                         ? null
-                        : controller.flattenFormFields,
+                        : () => _flattenForm(context),
                   ),
                 ],
                 if (controller.selectedElement != null) ...[
@@ -448,7 +488,7 @@ class PdfEditingToolbar extends StatelessWidget {
                   IconButton(
                     icon: const Icon(Icons.layers),
                     tooltip: 'Flatten annotations into the pages',
-                    onPressed: controller.flattenAllAnnotations,
+                    onPressed: () => _flatten(context),
                   ),
                 if (onSave != null)
                   IconButton(

--- a/packages/dart_pdf_editor/test/editing_flatten_test.dart
+++ b/packages/dart_pdf_editor/test/editing_flatten_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> pumpToolbar(
+    WidgetTester tester,
+    PdfEditingController editing,
+    PdfViewerController viewer,
+  ) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: editing.document,
+            controller: viewer,
+            editing: editing,
+          ),
+        ),
+        bottomNavigationBar: PdfEditingToolbar(
+          controller: editing,
+          viewerController: viewer,
+        ),
+      ),
+    ));
+    await tester.pump();
+  }
+
+  group('flatten controller', () {
+    test('flattenAllAnnotations reports whether anything was flattened', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      // a fresh page carries no flattenable annotations
+      expect(editing.flattenAllAnnotations(), isFalse);
+
+      editing.addRectangle(0, const PdfRect(100, 100, 200, 150));
+      expect(editing.document.page(0).annotations, isNotEmpty);
+
+      expect(editing.flattenAllAnnotations(), isTrue);
+      expect(editing.document.page(0).annotations, isEmpty);
+    });
+  });
+
+  group('flatten feedback in the toolbar', () {
+    testWidgets('flattening annotations shows a SnackBar with Undo',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 100, 200, 150));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await pumpToolbar(tester, editing, viewer);
+
+      final flatten = find.byTooltip('Flatten annotations into the pages');
+      final toolbarScrollable = find.descendant(
+          of: find.byType(PdfEditingToolbar),
+          matching: find.byType(Scrollable));
+      await tester.scrollUntilVisible(flatten, 100,
+          scrollable: toolbarScrollable);
+      await tester.tap(flatten);
+      // let the SnackBar finish animating in so its action is hit-testable
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(find.text('Annotations flattened into the pages'), findsOneWidget);
+      expect(find.widgetWithText(SnackBarAction, 'Undo'), findsOneWidget);
+      expect(editing.document.page(0).annotations, isEmpty);
+
+      // the Undo action restores the annotation
+      await tester.tap(find.text('Undo'));
+      await tester.pump();
+      expect(editing.document.page(0).annotations, isNotEmpty);
+    });
+
+    testWidgets('flattening with nothing to flatten shows an info SnackBar',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await pumpToolbar(tester, editing, viewer);
+
+      final flatten = find.byTooltip('Flatten annotations into the pages');
+      final toolbarScrollable = find.descendant(
+          of: find.byType(PdfEditingToolbar),
+          matching: find.byType(Scrollable));
+      await tester.scrollUntilVisible(flatten, 100,
+          scrollable: toolbarScrollable);
+      await tester.tap(flatten);
+      await tester.pump();
+
+      expect(find.text('No annotations to flatten'), findsOneWidget);
+      // nothing changed, so there is no Undo offered
+      expect(find.widgetWithText(SnackBarAction, 'Undo'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Flattening the annotations doesn't show any feedback to the user. Flattening bakes each annotation's appearance into the page content and removes the annotation, so the page looks **identical** afterwards — the toolbar button appeared to do nothing, with no way to tell it worked.

## Change

Both flatten buttons in `PdfEditingToolbar` now report their result through a floating `SnackBar`:

- **Annotations flattened** / **Form fields flattened into the pages** — with an **Undo** action when something actually changed.
- **No annotations to flatten** / **No form fields to flatten** — an info message when nothing was flattenable (e.g. a page with only links/widgets that have no appearance, or an empty page).

Supporting change: `PdfEditingController.flattenAllAnnotations` now returns `bool` (whether anything was flattened), mirroring `flattenFormFields`, so the toolbar can pick the right message and offer Undo. The toast is fed through a shared `_flattenToast` helper guarded by `ScaffoldMessenger.maybeOf` (no-op when there's no messenger).

## Tests

New `test/editing_flatten_test.dart`:
- controller: `flattenAllAnnotations` returns `false` on a page with nothing flattenable and `true` after a real annotation is added (and clears it).
- toolbar widget: tapping flatten shows the success SnackBar + working Undo; the empty case shows the info SnackBar with no Undo.

Existing `editing_form_test` and `pdf_shell_test` suites still pass.

https://claude.ai/code/session_01Kdpsx4FEJcE3xBLvWaZEgW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kdpsx4FEJcE3xBLvWaZEgW)_