### PR TITLE
ci: deploy PR test builds to a Firebase preview channel

### DIFF
--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -1,0 +1,49 @@
+name: Preview Demo Web
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/preview-demo-web.yml
+      - pubspec.yaml
+      - packages/pdf_cos/**
+      - packages/pdf_document/**
+      - packages/pdf_graphics/**
+      - packages/dart_pdf_editor/**
+
+concurrency:
+  group: demo-web-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    # Skip forks: secrets aren't available to pull_request runs from forks.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.2
+          channel: stable
+          cache: true
+
+      - run: flutter pub get
+
+      - run: flutter build web --release
+        working-directory: packages/dart_pdf_editor/example
+
+      # No channelId -> the action creates an ephemeral preview channel keyed
+      # to this PR and comments the URL on it. The channel expires on its own.
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_PDF_DEMO }}
+          projectId: dart-pdf-demo
+          expires: 7d
+          entryPoint: packages/dart_pdf_editor/example


### PR DESCRIPTION
## What

Adds a `Preview Demo Web` GitHub Actions workflow (`.github/workflows/preview-demo-web.yml`) that builds the example Flutter web app on pull requests and deploys it to an **ephemeral Firebase Hosting preview channel**, so reviewers get a live test build of the demo per PR.

## How it works

- Triggers on `pull_request` (scoped to the same paths as the existing live deploy).
- Builds `packages/dart_pdf_editor/example` with `flutter build web --release` (Flutter 3.44.2, matching `.fvmrc`/CI).
- Runs `FirebaseExtended/action-hosting-deploy@v0` with **no `channelId`** — the action mints a per-PR preview channel, deploys to it, and comments the preview URL on the PR. Channels expire after `7d`.
- `concurrency` is keyed per PR so new pushes cancel stale runs.
- Skips PRs from forks (the `FIREBASE_SERVICE_ACCOUNT_*` secret isn't exposed to fork runs).

This complements the existing `deploy-demo-web.yml`, which deploys the `live` channel on push to `main`. Both reuse the same `dart-pdf-demo` project and `FIREBASE_SERVICE_ACCOUNT_DART_PDF_DEMO` secret.

## Notes

- Requires the `FIREBASE_SERVICE_ACCOUNT_DART_PDF_DEMO` repo secret (already used by the live deploy) and the `dart-pdf-demo` Firebase project.

https://claude.ai/code/session_012jJ8PNyfTdo37AsHyVU6z2

---
_Generated by [Claude Code](https://claude.ai/code/session_012jJ8PNyfTdo37AsHyVU6z2)_