### PR TITLE
Add ⌘S / Ctrl+S save shortcut to PdfEditorView

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -493,7 +493,7 @@ class PdfEditingToolbar extends StatelessWidget {
                 if (onSave != null)
                   IconButton(
                     icon: const Icon(Icons.save_alt),
-                    tooltip: 'Save…',
+                    tooltip: 'Save… (⌘S / Ctrl+S)',
                     onPressed: () => onSave!(controller.bytes),
                   ),
                 if (trailing.isNotEmpty) ...[

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -137,9 +137,9 @@ class PdfEditorFeatures {
 /// The widget owns the edit session (undo/redo, revisions). Hosts that
 /// need programmatic access pass their own [controller] instead of
 /// [bytes] — exactly one of the two must be given. [onSave] receives
-/// the current revision's bytes from the toolbar's save button;
-/// [onDocumentChanged] fires after every revision (edit, undo, redo)
-/// for hosts that autosave.
+/// the current revision's bytes from the toolbar's save button or the
+/// ⌘S / Ctrl+S shortcut; [onDocumentChanged] fires after every revision
+/// (edit, undo, redo) for hosts that autosave.
 ///
 /// The widget is a plain body: give it bounded space (a [Scaffold]
 /// body, an [Expanded]...). Swapping [bytes] for a different document
@@ -191,8 +191,9 @@ class PdfEditorView extends StatefulWidget {
   final PdfEditorFeatures features;
 
   /// Receives the current revision's bytes when the toolbar's save
-  /// button is pressed; the button is hidden when null. Writing the
-  /// bytes somewhere is the app's job.
+  /// button is pressed or ⌘S / Ctrl+S is hit; the button (and the
+  /// shortcut) are off when null. Writing the bytes somewhere is the
+  /// app's job.
   final void Function(Uint8List bytes)? onSave;
 
   /// Called after every revision — edits, undo, redo — with the new
@@ -321,6 +322,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
     _searchField.selection =
         TextSelection(baseOffset: 0, extentOffset: _searchField.text.length);
   }
+
+  void _save() => widget.onSave?.call(_session.bytes);
 
   Future<void> _promptAuthor() async {
     final session = _session;
@@ -488,16 +491,22 @@ class _PdfEditorViewState extends State<PdfEditorView> {
     if (widget.viewerTheme != null) {
       body = PdfViewerTheme(data: widget.viewerTheme!, child: body);
     }
-    if (features.headerBar && features.search) {
-      body = CallbackShortcuts(
-        bindings: {
-          const SingleActivator(LogicalKeyboardKey.keyF, meta: true):
-              _focusSearch,
-          const SingleActivator(LogicalKeyboardKey.keyF, control: true):
-              _focusSearch,
-        },
-        child: body,
-      );
+    final bindings = <ShortcutActivator, VoidCallback>{
+      if (features.headerBar && features.search) ...{
+        const SingleActivator(LogicalKeyboardKey.keyF, meta: true):
+            _focusSearch,
+        const SingleActivator(LogicalKeyboardKey.keyF, control: true):
+            _focusSearch,
+      },
+      // ⌘S / Ctrl+S saves through the host's [onSave], the same path the
+      // toolbar's save button takes.
+      if (widget.onSave != null) ...{
+        const SingleActivator(LogicalKeyboardKey.keyS, meta: true): _save,
+        const SingleActivator(LogicalKeyboardKey.keyS, control: true): _save,
+      },
+    };
+    if (bindings.isNotEmpty) {
+      body = CallbackShortcuts(bindings: bindings, child: body);
     }
     return body;
   }

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -428,6 +429,29 @@ void main() {
     testWidgets('no onSave, no save button', (tester) async {
       await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(1)));
       expect(find.byIcon(Icons.save_alt), findsNothing);
+    });
+
+    testWidgets('Ctrl+S saves through onSave', (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      List<int>? saved;
+      await pump(
+        tester,
+        PdfEditorView(
+          controller: editing,
+          onSave: (bytes) => saved = bytes,
+        ),
+      );
+      // focus the viewer the way a user would: click it, so the
+      // shell's CallbackShortcuts has a focused descendant
+      await tester.tap(find.byType(PdfViewer), kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyS);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+      expect(saved, isNotNull);
+      expect(saved!.length, editing.bytes.length);
     });
 
     testWidgets('swapping bytes opens a fresh session', (tester) async {


### PR DESCRIPTION
## Summary

Adds a keyboard save shortcut to the editor shell: **⌘S** (macOS) / **Ctrl+S** now save the current revision through the host's `onSave` callback — the exact same path the toolbar's save button takes (`onSave(controller.bytes)`).

## Details

- `PdfEditorView` gains a `_save()` handler and binds `SingleActivator(keyS, meta/control)` in the shell's `CallbackShortcuts`. The previous `CallbackShortcuts` only mounted for the ⌘F search feature; the bindings are now built into one map so save works **independently** of whether search is enabled, and is active whenever `onSave != null`.
- Toolbar save button tooltip updated to `Save… (⌘S / Ctrl+S)`.
- Dartdocs on `PdfEditorView`/`onSave` note the shortcut.

The example app already wires `onSave` to its platform save flow, so ⌘S/Ctrl+S works there with no further changes.

## Tests

- New `pdf_shell_test.dart` case: *"Ctrl+S saves through onSave"* — focuses the viewer, sends Ctrl+S, asserts the host received the current bytes. Tapped with mouse kind to avoid leaving the viewer's double-tap timer pending.
- Full `pdf_shell_test.dart` suite passes; changed files analyze clean.

https://claude.ai/code/session_01NKKXdk8RXcntZNjJD6Jre9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKKXdk8RXcntZNjJD6Jre9)_