### PR TITLE
Fix eraser fade wash covering page content and spilling off the page

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -183,12 +183,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
 
   // circle eraser: the swipe's swept path (page space), the live-sliced
   // remainder per touched /Annots slot (painted over the faded
-  // original, so the preview shows exactly what the commit keeps),
-  // touched annotations' view rects (washed while pending), inkless
-  // slots that can only be deleted whole, and the ring cursor's view
-  // position (drag for any pointer, hover for a mouse)
+  // original, so the preview shows exactly what the commit keeps), the
+  // original strokes of each touched sliceable annotation (washed over
+  // so the baked-in ink fades without obscuring the page content around
+  // it — the wash follows the strokes, not the bounding box), inkless
+  // slots that can only be deleted whole (washed by their rect), and the
+  // ring cursor's view position (drag for any pointer, hover for a mouse)
   final List<(double, double)> _erasePath = [];
   final Map<int, _InkPaint> _eraseSliced = {};
+  final Map<int, _InkPaint> _eraseFade = {};
   final Map<int, Rect> _eraseRects = {};
   final Set<int> _eraseWholeSlots = {};
   Offset? _eraserCursor;
@@ -197,6 +200,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// Erase results kept painted until the new revision's raster lands —
   /// without them the old strokes pop back at full strength for a frame.
   List<Rect>? _afterEraseRects;
+  List<_InkPaint>? _afterEraseFade;
   List<_InkPaint>? _afterEraseInk;
 
   // in-place text editor: open after a free-text drag-out (new) or a
@@ -540,7 +544,20 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         }
         final sliced = pdfSliceInkStrokes(strokes, null, from, point, radius);
         if (sliced == null) continue;
-        _eraseRects[slot] ??= _geometry.toViewRect(annotation.rect);
+        // wash the original ink along its own strokes (padded for the
+        // baked-in pressure width + caps) rather than the whole bounding
+        // box, so surrounding page content isn't dimmed and the wash
+        // never spills off the page
+        _eraseFade.putIfAbsent(
+            slot,
+            () => (
+                  strokes: strokes,
+                  pressures:
+                      List<List<double>?>.filled(strokes.length, null),
+                  color: const Color(0xFF000000),
+                  strokeWidth:
+                      (annotation.borderWidth ?? 1) * _geometry.scale * 1.7 + 4,
+                ));
         _eraseSliced[slot] = (
           strokes: sliced.strokes,
           pressures: List<List<double>?>.filled(sliced.strokes.length, null),
@@ -560,6 +577,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   void _resetErase() {
     _erasePath.clear();
     _eraseSliced.clear();
+    _eraseFade.clear();
     _eraseWholeSlots.clear();
     _eraseRects.clear();
     _eraserCursor = null;
@@ -571,6 +589,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   void _commitErase() {
     final path = List.of(_erasePath);
     final rects = List.of(_eraseRects.values);
+    final fade = List.of(_eraseFade.values);
     final ink = List.of(_eraseSliced.values);
     final touched = _eraseSliced.isNotEmpty || _eraseWholeSlots.isNotEmpty;
     setState(_resetErase);
@@ -580,6 +599,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (identical(before, _controller.document)) return;
     _clearAfterimage();
     _afterEraseRects = rects;
+    _afterEraseFade = fade;
     _afterEraseInk = ink;
     _afterDocument = _controller.document;
   }
@@ -709,6 +729,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _afterText = null;
     _afterSignature = null;
     _afterEraseRects = null;
+    _afterEraseFade = null;
     _afterEraseInk = null;
     _afterDocument = null;
   }
@@ -2322,6 +2343,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                       ..._eraseRects.values,
                       ...?_afterEraseRects,
                     ],
+                    fadeInk: [
+                      ..._eraseFade.values,
+                      ...?_afterEraseFade,
+                    ],
                     fadeColor: widget.pageColor.withValues(alpha: 0.72),
                     eraserCursor: _tool == PdfEditTool.eraser || _rawErasing
                         ? _eraserCursor
@@ -2563,6 +2588,7 @@ class _EditingPreviewPainter extends CustomPainter {
     this.ghostLocalAngle = 0,
     required this.extraInk,
     this.fadeRects = const [],
+    this.fadeInk = const [],
     this.fadeColor = const Color(0x00000000),
     this.eraserCursor,
     this.eraserRadius = 0,
@@ -2634,11 +2660,17 @@ class _EditingPreviewPainter extends CustomPainter {
   /// the signature tool's live preview.
   final List<_InkPaint> extraInk;
 
-  /// Annotations the eraser swipe has marked: their view rects, washed
-  /// with [fadeColor] (the paper color, mostly opaque) so they read as
-  /// going — live during the swipe, and as the afterimage until the
-  /// deletion's raster lands.
+  /// Inkless annotations the eraser swipe will delete whole: their view
+  /// rects, washed with [fadeColor] (the paper color, mostly opaque) so
+  /// they read as going — live during the swipe, and as the afterimage
+  /// until the deletion's raster lands.
   final List<Rect> fadeRects;
+
+  /// Sliceable ink the eraser swipe has touched: the original strokes,
+  /// washed with [fadeColor] along their own paths (not the bounding
+  /// box) so the baked-in ink fades without dimming the page content
+  /// around it or spilling off the page.
+  final List<_InkPaint> fadeInk;
   final Color fadeColor;
 
   /// The circle eraser's ring cursor: view position and radius (the
@@ -2864,11 +2896,19 @@ class _EditingPreviewPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     // the wash goes under every stroke preview: the eraser's sliced
     // remainders (and any other pending ink) paint at full strength
-    // over their faded originals
+    // over their faded originals. Sliceable ink fades along its own
+    // strokes (so only the ink dims, not the page around it); inkless
+    // whole-delete annotations fall back to a rect wash, clipped to the
+    // page so it can't spill onto the viewer canvas.
+    for (final ink in fadeInk) {
+      _paintInk(canvas, ink.strokes, ink.pressures, fadeColor, ink.strokeWidth);
+    }
     if (fadeRects.isNotEmpty) {
       final wash = Paint()..color = fadeColor;
+      final page = Offset.zero & size;
       for (final rect in fadeRects) {
-        canvas.drawRect(rect.inflate(2), wash);
+        final clipped = rect.inflate(2).intersect(page);
+        if (!clipped.isEmpty) canvas.drawRect(clipped, wash);
       }
     }
 
@@ -3122,6 +3162,7 @@ class _EditingPreviewPainter extends CustomPainter {
       oldDelegate.ghostLocalAngle != ghostLocalAngle ||
       _inkChanged(oldDelegate.extraInk, extraInk) ||
       !listEquals(oldDelegate.fadeRects, fadeRects) ||
+      _inkChanged(oldDelegate.fadeInk, fadeInk) ||
       oldDelegate.fadeColor != fadeColor ||
       oldDelegate.eraserCursor != eraserCursor ||
       oldDelegate.eraserRadius != eraserRadius ||

--- a/packages/dart_pdf_editor/test/editing_eraser_test.dart
+++ b/packages/dart_pdf_editor/test/editing_eraser_test.dart
@@ -139,8 +139,10 @@ void main() {
         await tester.pump();
       }
       final painter = overlayPainter(tester);
-      // the touched annotation washes out...
-      expect((painter.fadeRects as List), hasLength(1));
+      // the touched annotation washes out along its own strokes (not the
+      // bounding box, so surrounding page content isn't dimmed)...
+      expect((painter.fadeInk as List), hasLength(1));
+      expect((painter.fadeRects as List), isEmpty);
       // ...and its sliced remainder (two pieces) paints over the wash
       final extraInk = painter.extraInk as List;
       expect(extraInk, hasLength(1));
@@ -168,7 +170,7 @@ void main() {
       // immediately after the commit (no raster yet) the wash and the
       // remainder keep painting so the old strokes don't pop back
       final painter = overlayPainter(tester);
-      expect((painter.fadeRects as List), hasLength(1));
+      expect((painter.fadeInk as List), hasLength(1));
       expect((painter.extraInk as List), hasLength(1));
     });
 


### PR DESCRIPTION
## Problem

When using the eraser tool, a semi-transparent box appeared that covered the page content **around** the ink and could extend **off the page** onto the viewer canvas.

## Cause

The eraser's live preview (and its afterimage, held until the new revision rasters) washed the **entire annotation bounding rectangle** with the paper color at 0.72 alpha. For any ink scribble, that bounding box is far larger than the strokes themselves, so it dimmed the surrounding page content; when the ink's bounds reached the page edge, the wash spilled past it.

## Fix

- **Sliceable ink** now washes along its own strokes (padded for the baked-in pressure width + round caps) instead of the bounding box — only the ink dims, the page around it stays untouched, and the wash can't reach beyond where the ink is.
- **Inkless whole-delete** annotations keep the rect wash (they have no `/InkList` to follow), but it is now clipped to the page bounds so it can never spill onto the viewer canvas.

Both the live preview and the post-commit afterimage use the new stroke-following wash.

## Tests

`editing_eraser_test.dart` updated to assert the touched ink populates `fadeInk` (stroke-following) with `fadeRects` empty. Full `editing_eraser_test.dart` and `editing_ipad_test.dart` (eraser group) pass; analyzer clean.

https://claude.ai/code/session_01SVgsXrA27cbtud9s39Lw5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVgsXrA27cbtud9s39Lw5W)_