### PR TITLE
Pace first-page interpretation to fix iPad fast-scroll hang

### DIFF
--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -22,6 +22,7 @@ export 'src/pdf_reader.dart';
 export 'src/pdf_reflow_view.dart';
 export 'src/pdf_viewer.dart';
 export 'src/preview_cache.dart';
+export 'src/render_scheduler.dart';
 export 'src/renderer.dart';
 export 'src/search_panel.dart';
 export 'src/scrollbar.dart';

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'package:pdf_document/pdf_document.dart';
 
 import 'preview_cache.dart';
+import 'render_scheduler.dart';
 import 'renderer.dart';
 
 /// Displays a single PDF page, rendered natively in Dart.
@@ -27,6 +28,7 @@ class PdfPageView extends StatefulWidget {
     this.showAnnotations = true,
     this.onRasterReady,
     this.renderHold,
+    this.renderScheduler,
     this.previewCache,
     this.previewIndex = 0,
   });
@@ -50,7 +52,19 @@ class PdfPageView extends StatefulWidget {
   /// flying past can't stall the frame rate. Held pages render as soon
   /// as it drops back to false. Pages that already have a picture are
   /// unaffected (re-rasters reuse it).
+  ///
+  /// Superseded by [renderScheduler] when one is supplied: the scheduler
+  /// both defers and paces the first interpret, so [renderHold] is only
+  /// consulted on its own (the bare-[PdfPageView] case).
   final ValueListenable<bool>? renderHold;
+
+  /// Paces this page's first (UI-thread) interpret against every other
+  /// page's, so a settling fast scroll can't fire them all in one frame.
+  /// When set, the page registers its first render here instead of
+  /// interpreting directly; the scheduler grants it a turn (see
+  /// [PdfPageRenderScheduler]). Re-rasters of an already-interpreted page
+  /// bypass it. Null falls back to [renderHold].
+  final PdfPageRenderScheduler? renderScheduler;
 
   /// Called whenever a full-page raster for the current [page] object
   /// lands on screen. Lets the editing overlay hold its just-committed
@@ -167,6 +181,10 @@ class _PdfPageViewState extends State<PdfPageView> {
       widget.renderHold?.addListener(_onRenderHoldChanged);
       _onRenderHoldChanged();
     }
+    if (!identical(oldWidget.renderScheduler, widget.renderScheduler)) {
+      oldWidget.renderScheduler?.cancel(this);
+      // the new scheduler picks this page up on its next _render
+    }
     if (!identical(oldWidget.previewCache, widget.previewCache) ||
         oldWidget.previewIndex != widget.previewIndex) {
       oldWidget.previewCache?.removeListener(_onPreviewCacheChanged);
@@ -194,6 +212,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   @override
   void dispose() {
     widget.renderHold?.removeListener(_onRenderHoldChanged);
+    widget.renderScheduler?.cancel(this);
     widget.previewCache?.removeListener(_onPreviewCacheChanged);
     _dropPicture();
     _image?.dispose();
@@ -239,14 +258,30 @@ class _PdfPageViewState extends State<PdfPageView> {
   }
 
   Future<void> _render() async {
-    // only the first interpretation is deferred: it walks the content
+    // Only the first interpretation is deferred: it walks the content
     // stream twice on the UI thread, which is what stalls fast scrolling
     // on heavy pages. With a picture cached, rendering is a raster-thread
-    // toImage and proceeds even during the hold.
-    if (_picture == null && (widget.renderHold?.value ?? false)) {
-      _holdPending = true;
-      return;
+    // toImage, so re-renders run directly.
+    if (_picture == null) {
+      final scheduler = widget.renderScheduler;
+      if (scheduler != null) {
+        // route the first walk through the viewer's paced drain so no
+        // frame interprets more than one page (a settling fast scroll
+        // used to release every held page in one event-loop turn)
+        scheduler.request(this, widget.previewIndex, _renderNow);
+        return;
+      }
+      if (widget.renderHold?.value ?? false) {
+        _holdPending = true;
+        return;
+      }
     }
+    await _renderNow();
+  }
+
+  /// The actual interpret + rasterize, run once the first render is no
+  /// longer gated (or directly for re-rasters of a cached picture).
+  Future<void> _renderNow() async {
     final generation = ++_renderGeneration;
     final picture = await (_picture ??= PdfPageRenderer.renderPicture(
         widget.page,
@@ -331,8 +366,17 @@ class _PdfPageViewState extends State<PdfPageView> {
     ratio =
         math.min(ratio, _maxDimension / math.max(region.width, region.height));
 
-    // never interpret during a hold — the next settle refreshes the patch
-    if (_picture == null && (widget.renderHold?.value ?? false)) return;
+    // never interpret the page for the first time inline here — that is
+    // the scheduler's job (or, bare, the hold's); the next settle
+    // refreshes the patch once the base picture lands
+    if (_picture == null) {
+      final scheduler = widget.renderScheduler;
+      if (scheduler != null) {
+        scheduler.request(this, widget.previewIndex, _renderNow);
+        return;
+      }
+      if (widget.renderHold?.value ?? false) return;
+    }
     final picture = await (_picture ??= PdfPageRenderer.renderPicture(
         widget.page,
         pageColor: widget.pageColor,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -19,6 +19,7 @@ import 'exact_extent_list.dart';
 import 'page_geometry.dart';
 import 'pdf_page_view.dart';
 import 'preview_cache.dart';
+import 'render_scheduler.dart';
 import 'scrollbar.dart';
 import 'theme.dart';
 
@@ -426,17 +427,21 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   Timer? _scrollSettleTimer;
   int _settleGeneration = 0;
 
-  /// True while the list is scrolling faster than pages can usefully
-  /// render — [PdfPageView.renderHold]: not-yet-interpreted pages keep
-  /// their paper placeholder instead of stalling the UI thread with
-  /// interpreter walks mid-fling (the stall is what made the scrollbar
-  /// leap on heavy documents). Cleared when the velocity estimate drops
-  /// or the scroll-settle timer fires.
-  final _renderHold = ValueNotifier<bool>(false);
+  /// Paces every page's first (UI-thread) interpret so no frame runs
+  /// more than one — [PdfPageRenderScheduler]. Its [holding] flag stands
+  /// in for the old render hold: while the list scrolls faster than
+  /// pages can usefully render, not-yet-interpreted pages keep their
+  /// preview/placeholder instead of stalling the UI thread mid-fling
+  /// (the stall is what made the scrollbar leap on heavy documents).
+  /// When scrolling settles, held pages drain one per frame, nearest the
+  /// viewport first, rather than all firing in one event-loop turn (the
+  /// burst that froze fast scrolling on iPad). Released when the velocity
+  /// estimate drops or the scroll-settle timer fires.
+  final _renderScheduler = PdfPageRenderScheduler();
 
   /// (frame timestamp, scroll pixels) samples from the last ~200ms,
-  /// at most one per frame, for the velocity estimate behind
-  /// [_renderHold].
+  /// at most one per frame, for the velocity estimate behind the
+  /// scheduler's hold.
   final List<(Duration, double)> _scrollSamples = [];
 
   /// Low-res previews painted while a page's full render is pending —
@@ -716,10 +721,12 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// detail patch, so the patch must follow once movement stops.
   void _onScrollForDetail() {
     _trackScrollVelocity();
+    // the scheduler drains held pages nearest the viewport first
+    _renderScheduler.focus = _controller.currentPage;
     _scrollSettleTimer?.cancel();
     _scrollSettleTimer = Timer(const Duration(milliseconds: 250), () {
       _scrollSamples.clear();
-      _renderHold.value = false;
+      _renderScheduler.holding = false;
       if (mounted) setState(() => _settleGeneration++);
       // the prerender pauses while the user scrolls; pick it back up
       _prerenderPreviews();
@@ -737,8 +744,15 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     _prerendering = true;
     try {
       while (mounted && widget.pagePreviews) {
-        if (_renderHold.value || (_scrollSettleTimer?.isActive ?? false)) {
+        if (_renderScheduler.holding || (_scrollSettleTimer?.isActive ?? false)) {
           return; // restarted by the settle timer
+        }
+        if (_renderScheduler.hasPending) {
+          // near pages are still draining their full render through the
+          // scheduler; don't compete for the UI thread this frame
+          await SchedulerBinding.instance.endOfFrame;
+          if (!mounted) return;
+          continue;
         }
         final pages = _pages;
         final index = _nextPreviewIndex(pages);
@@ -796,7 +810,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   }
 
   /// Estimates the scroll velocity over a ~200ms window of per-frame
-  /// samples and flips [_renderHold] past ~2 viewport-heights/second.
+  /// samples and holds the render scheduler past ~2 viewport-heights/sec.
   /// Frame timestamps (not wall clock) collapse the burst of listener
   /// calls a single wheel tick produces into one sample — an instant
   /// 100px jump must not read as infinite velocity.
@@ -818,7 +832,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     final velocity =
         (pixels - _scrollSamples.first.$2).abs() * 1e6 / span; // px/s
     final viewport = _scroll.position.viewportDimension;
-    _renderHold.value = velocity > math.max(800, 2 * viewport);
+    _renderScheduler.holding = velocity > math.max(800, 2 * viewport);
   }
 
   @override
@@ -914,7 +928,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     _scroll.dispose();
     _transform.dispose();
     _transformScale.dispose();
-    _renderHold.dispose();
+    _renderScheduler.dispose();
     _previews.dispose();
     _zoomAnimator.dispose();
     _panFlinger.dispose();
@@ -2229,7 +2243,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 onShowAnnotationMenu: _showSelectionMenu,
                 onShowFormFieldMenu: _showFormFieldMenu,
                 transformScale: _transformScale,
-                renderHold: _renderHold,
+                renderScheduler: _renderScheduler,
                 previewCache: widget.pagePreviews ? _previews : null,
               ),
             ),
@@ -2499,7 +2513,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.onShowAnnotationMenu,
     required this.onShowFormFieldMenu,
     required this.transformScale,
-    required this.renderHold,
+    required this.renderScheduler,
     required this.previewCache,
   });
 
@@ -2543,8 +2557,8 @@ class _PdfViewerPage extends StatefulWidget {
   /// by it to stay constant-size on screen while zoomed.
   final ValueListenable<double> transformScale;
 
-  /// See [PdfPageView.renderHold].
-  final ValueListenable<bool> renderHold;
+  /// See [PdfPageView.renderScheduler].
+  final PdfPageRenderScheduler renderScheduler;
 
   /// See [PdfPageView.previewCache]; null when previews are off.
   final PdfPagePreviewCache? previewCache;
@@ -2587,7 +2601,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         pageColor: widget.pageColor,
         showAnnotations: widget.showAnnotations,
         onRasterReady: _onRasterReady,
-        renderHold: widget.renderHold,
+        renderScheduler: widget.renderScheduler,
         previewCache: widget.previewCache,
         previewIndex: widget.index,
       ),

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart';
+
+/// Paces the first interpretation of PDF pages so a single frame never
+/// runs more than one synchronous content-stream walk.
+///
+/// Interpreting a page (the walk behind `PdfPageRenderer.renderPicture`)
+/// runs on the UI thread, and on heavy pages takes long enough to drop
+/// frames. The viewer holds those walks back during a fast scroll; the
+/// trap was the *release*. Every page in the cache window deferred
+/// against one shared flag, so when scrolling settled they all
+/// interpreted in the same event-loop turn — N heavy walks back to back,
+/// a multi-hundred-millisecond frozen frame (the iPad fast-scroll hang).
+///
+/// Pages register a [request] here instead of interpreting on their own.
+/// The scheduler grants requests one per frame, the one nearest the
+/// viewport ([focus]) first, and never while a fast scroll is in flight
+/// ([holding]) — so no frame runs more than one page's walk and the
+/// low-res previews cover everything still waiting its turn.
+class PdfPageRenderScheduler {
+  PdfPageRenderScheduler();
+
+  final _pending = <_RenderRequest>[];
+  bool _holding = false;
+  int _focus = 0;
+  bool _draining = false;
+  bool _disposed = false;
+
+  /// True while a fast scroll is in flight: the viewer raises it from its
+  /// velocity estimate. No request is granted while held; lowering it
+  /// drains the queue.
+  bool get holding => _holding;
+  set holding(bool value) {
+    if (_holding == value || _disposed) return;
+    _holding = value;
+    if (!_holding) _scheduleDrain();
+  }
+
+  /// The page index nearest the viewport. Pending requests closest to it
+  /// drain first, so what the user is looking at sharpens before
+  /// off-screen neighbours.
+  set focus(int index) => _focus = index;
+
+  /// Whether any page is still waiting for its first interpret. The
+  /// background preview prerender yields while this is true, so the two
+  /// can't both walk a page in the same frame.
+  bool get hasPending => _pending.isNotEmpty;
+
+  /// Registers (or refreshes) [token]'s request to run its first
+  /// interpret. [render] is invoked on the UI thread when the request's
+  /// turn comes; [priority] is the page index, ranked against [focus].
+  /// Calling again for the same [token] (a re-layout before the grant)
+  /// just refreshes it — the page is interpreted at most once.
+  void request(Object token, int priority, VoidCallback render) {
+    if (_disposed) return;
+    for (final r in _pending) {
+      if (identical(r.token, token)) {
+        r
+          ..priority = priority
+          ..render = render;
+        _scheduleDrain();
+        return;
+      }
+    }
+    _pending.add(_RenderRequest(token, priority, render));
+    _scheduleDrain();
+  }
+
+  /// Withdraws [token]'s pending request — its page rendered another way,
+  /// or was disposed before its turn.
+  void cancel(Object token) {
+    _pending.removeWhere((r) => identical(r.token, token));
+  }
+
+  void _scheduleDrain() {
+    if (_draining || _holding || _disposed || _pending.isEmpty) return;
+    _draining = true;
+    // off the current build/layout stack (request fires from layout) and
+    // off the synchronous gesture turn, so the first grant lands after
+    // this frame rather than blocking it
+    scheduleMicrotask(_drain);
+  }
+
+  Future<void> _drain() async {
+    try {
+      while (!_disposed && !_holding && _pending.isNotEmpty) {
+        // the pending request nearest the viewport focus
+        var pick = 0;
+        var best = (_pending[0].priority - _focus).abs();
+        for (var i = 1; i < _pending.length; i++) {
+          final distance = (_pending[i].priority - _focus).abs();
+          if (distance < best) {
+            best = distance;
+            pick = i;
+          }
+        }
+        final next = _pending.removeAt(pick);
+        try {
+          next.render(); // one synchronous interpret this frame
+        } catch (_) {
+          // a page that throws mid-walk must not strand the rest of the
+          // queue — it simply keeps its preview/placeholder
+        }
+        // let the engine breathe before the next walk: paint the frame
+        // this produced, service input, run animations. endOfFrame
+        // schedules a frame when idle so the drain can't stall;
+        // deliberately not a Timer (those pend in widget tests).
+        await SchedulerBinding.instance.endOfFrame;
+      }
+    } finally {
+      _draining = false;
+    }
+  }
+
+  /// Drops all pending requests and stops granting. Safe to call more
+  /// than once.
+  void dispose() {
+    _disposed = true;
+    _pending.clear();
+  }
+}
+
+class _RenderRequest {
+  _RenderRequest(this.token, this.priority, this.render);
+  final Object token;
+  int priority;
+  VoidCallback render;
+}

--- a/packages/dart_pdf_editor/test/render_scheduler_test.dart
+++ b/packages/dart_pdf_editor/test/render_scheduler_test.dart
@@ -1,0 +1,101 @@
+// The render scheduler paces every page's first (UI-thread) interpret so
+// a settling fast scroll can't fire them all in one event-loop turn — the
+// burst that froze fast scrolling on iPad. These tests pin the pacing,
+// the priority order, and the hold gate.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+void main() {
+  testWidgets('requests drain paced — never a synchronous burst', (tester) async {
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    final order = <int>[];
+    scheduler.focus = 5;
+    for (final i in [0, 5, 6, 9]) {
+      scheduler.request('t$i', i, () => order.add(i));
+    }
+
+    // nothing runs in the turn that registered them (the old fan-out ran
+    // every held page's walk right here)
+    expect(order, isEmpty);
+
+    await tester.pump();
+    // a frame in: some progress, but not the whole queue at once
+    expect(order, isNotEmpty);
+    expect(order.length, lessThan(4));
+
+    // the nearest-the-viewport page drains first
+    expect(order.first, 5);
+
+    for (var i = 0; i < 6; i++) {
+      await tester.pump();
+    }
+    // every page interpreted, closest-to-focus order
+    expect(order, [5, 6, 9, 0]);
+  });
+
+  testWidgets('holding blocks grants until released', (tester) async {
+    final scheduler = PdfPageRenderScheduler()..holding = true;
+    addTearDown(scheduler.dispose);
+    var ran = false;
+    scheduler.request('a', 0, () => ran = true);
+
+    for (var i = 0; i < 3; i++) {
+      await tester.pump();
+    }
+    expect(ran, isFalse, reason: 'held while a fast scroll is in flight');
+    expect(scheduler.hasPending, isTrue);
+
+    scheduler.holding = false;
+    for (var i = 0; i < 2; i++) {
+      await tester.pump();
+    }
+    expect(ran, isTrue);
+    expect(scheduler.hasPending, isFalse);
+  });
+
+  testWidgets('cancel withdraws a pending request', (tester) async {
+    final scheduler = PdfPageRenderScheduler()..holding = true;
+    addTearDown(scheduler.dispose);
+    var ran = false;
+    scheduler.request('a', 0, () => ran = true);
+    scheduler.cancel('a');
+    expect(scheduler.hasPending, isFalse);
+
+    scheduler.holding = false;
+    for (var i = 0; i < 3; i++) {
+      await tester.pump();
+    }
+    expect(ran, isFalse);
+  });
+
+  testWidgets('re-requesting a token interprets it once', (tester) async {
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    var count = 0;
+    // a re-layout before the grant refreshes the same request
+    scheduler.request('a', 0, () => count++);
+    scheduler.request('a', 0, () => count++);
+    expect(scheduler.hasPending, isTrue);
+
+    for (var i = 0; i < 4; i++) {
+      await tester.pump();
+    }
+    expect(count, 1);
+  });
+
+  testWidgets('a render that throws does not strand the queue', (tester) async {
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    var reached = false;
+    scheduler
+      ..request('bad', 0, () => throw StateError('boom'))
+      ..request('good', 1, () => reached = true);
+
+    for (var i = 0; i < 4; i++) {
+      await tester.pump();
+    }
+    expect(reached, isTrue);
+    expect(scheduler.hasPending, isFalse);
+  });
+}


### PR DESCRIPTION
## Symptom

Hangs when scrolling fast on iPad in a release build — the UI freezes for a noticeable beat, most often right as a fast scroll comes to rest.

## Root cause

It's the render hold's **release**, not the hold itself.

Heavy pages interpret their content stream **synchronously on the UI thread** (`PdfPageRenderer.renderPicture`'s first/collector pass runs before its first `await`). To keep that off the frame budget during a fling, every page in the cache window deferred its first interpret against a single shared `_renderHold` `ValueNotifier`. When the 250 ms scroll-settle timer dropped that flag, **every held page's listener fired in the same event-loop turn** — so N heavy pages each ran a full content-stream walk back to back, one frozen frame of 0.5–2 s on heavy CAD pages. The binary velocity gate also let go during a fling's deceleration tail, so pages scrolling in during the tail interpreted inline too.

Release-build/iPad specifically: on a real device at real (ProMotion) scroll speeds the flings are long and fast, so the frozen frame stands out starkly against otherwise-smooth motion; a debug build is uniformly slow and masks it.

## Fix

Replace the shared boolean with **`PdfPageRenderScheduler`** (`render_scheduler.dart`). Pages register their first interpret rather than running it directly; the scheduler grants requests **one per frame**, **nearest the viewport first**, and **never while a fast scroll is in flight**. No single frame runs more than one page's walk, and the existing low-res previews cover everything still waiting its turn — so both the settle burst and the fling-tail stutter are gone.

- The preview prerender yields while the scheduler has near-page work, so the two can't both walk a page in the same frame.
- `PdfPageView` keeps its `renderHold` param for bare-widget use; the viewer drives the scheduler from the same velocity estimate that drove the hold.
- The scheduler uses `scheduleMicrotask` + `await endOfFrame` (no `Timer`, so it stays clean in widget tests, matching the prerender loop's pattern).

## Tests

- New `render_scheduler_test.dart` (5): pacing (no synchronous burst), nearest-focus order, hold gate, cancel, single-interpret-per-token, and a throwing render not stranding the queue.
- `render_hold_test`, `page_preview_test`, `editing_fling_test`, `pdf_viewer_test`, `pdf_scrollbar_test`, `wheel_scroll_test`, `page_color_test` all green.
- Full `dart_pdf_editor` suite green except the 14 `ghent_render_test` overprint/DeviceN baseline diffs, which are **pre-existing** (verified failing identically with this branch stashed — the known GWG overprint deviations noted in CLAUDE.md, untouched by this change).

https://claude.ai/code/session_014yC59igDnQnqHLWJ8TkMV8

---
_Generated by [Claude Code](https://claude.ai/code/session_014yC59igDnQnqHLWJ8TkMV8)_