### PR TITLE
Reduce pencil latency with forward-extrapolated stroke prediction

### DIFF
--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -13,6 +13,7 @@ export 'src/editing/editing_signature.dart';
 export 'src/editing/editing_stamps.dart';
 export 'src/editing/editing_thumbnails.dart';
 export 'src/editing/editing_toolbar.dart';
+export 'src/editing/stroke_prediction.dart';
 export 'src/editing/text_prompt.dart';
 export 'src/page_geometry.dart';
 export 'src/page_number_field.dart';

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -13,6 +13,7 @@ import '../page_geometry.dart';
 import '../renderer.dart';
 import '../theme.dart';
 import 'editing_controller.dart';
+import 'stroke_prediction.dart';
 import 'text_prompt.dart';
 
 /// One page's editing layer: captures the armed tool's gestures in page
@@ -35,6 +36,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.onPanViewportEnd,
     this.rasterCurrent = true,
     this.zoom = 1,
+    this.predictStrokes = true,
     this.formImagePicker,
     this.onShowAnnotationMenu,
     this.onShowFormFieldMenu,
@@ -80,6 +82,11 @@ class EditingPageOverlay extends StatefulWidget {
   /// to stay constant-size on screen at any zoom. Page-content previews
   /// (ink, shapes, the drag ghost) scale with the page on purpose.
   final double zoom;
+
+  /// See [PdfViewer.predictStrokes]. When true the in-progress ink layer
+  /// draws a forward-extrapolated lead so the painted line keeps up with
+  /// the pen tip.
+  final bool predictStrokes;
 
   /// Opens the annotation context menu at a global position — the
   /// selection action chip's "more" button and the touch long-press,
@@ -2652,11 +2659,25 @@ class _ActiveStrokePainter extends CustomPainter {
     final stroke = _state._activeStroke;
     if (stroke == null || stroke.isEmpty) return;
     final geometry = _state._geometry;
+    var display = stroke;
+    var pressures = _state._activeStrokePressures;
+    // a forward-extrapolated lead so the line keeps up with the pen tip —
+    // display only, recomputed each repaint (so the next real sample
+    // replaces it) and never folded into the committed stroke
+    if (_state.widget.predictStrokes) {
+      final lead = pdfPredictStrokeLead(stroke);
+      if (lead.isNotEmpty) {
+        display = [...stroke, ...lead];
+        if (pressures != null) {
+          pressures = [...pressures, for (final _ in lead) pressures.last];
+        }
+      }
+    }
     _paintInkStrokes(
       canvas,
       geometry,
-      [stroke],
-      [_state._activeStrokePressures],
+      [display],
+      [pressures],
       _state._controller.color,
       _state._controller.strokeWidth * geometry.scale,
     );

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -156,6 +156,19 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   List<(double, double)>? _activeStroke;
   List<double>? _activeStrokePressures;
 
+  /// Repaint signal for the in-progress stroke. Appending a point during a
+  /// pencil/mouse stroke bumps this instead of calling setState, so the
+  /// dedicated active-stroke layer (its own RepaintBoundary) re-rasterizes
+  /// without rebuilding the overlay subtree or the heavy preview painter —
+  /// the difference between a per-point widget rebuild and a per-point
+  /// repaint, which is what the pen latency was paying for. Every mutation
+  /// of [_activeStroke]/[_activeStrokePressures] must call [_bumpActiveStroke]
+  /// (the painter's shouldRepaint stays false — this Listenable is the only
+  /// thing that drives it, including the clear on commit/bail).
+  final ValueNotifier<int> _activeStrokeRepaint = ValueNotifier<int>(0);
+
+  void _bumpActiveStroke() => _activeStrokeRepaint.value++;
+
   /// The latest normalized pressure of the pointer being tracked, or null
   /// for devices that don't report pressure (finger, mouse).
   double? _pointerPressure;
@@ -412,10 +425,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // hold the auto-commit while this stroke is on the page
         _controller.beginInkStroke();
         final pressure = _pointerPressure;
-        setState(() {
-          _activeStroke = [_geometry.toPagePoint(event.localPosition)];
-          _activeStrokePressures = pressure == null ? null : [pressure];
-        });
+        // no setState: the active stroke lives on its own repaint layer
+        _activeStroke = [_geometry.toPagePoint(event.localPosition)];
+        _activeStrokePressures = pressure == null ? null : [pressure];
+        _bumpActiveStroke();
       }
     }
   }
@@ -431,11 +444,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_rawErasing) {
       _eraseAt(event.localPosition);
     } else if (_activeStroke != null) {
-      setState(() {
-        _activeStroke!.add(_geometry.toPagePoint(event.localPosition));
-        _activeStrokePressures
-            ?.add(_pointerPressure ?? _activeStrokePressures!.last);
-      });
+      // hot path: append + repaint the stroke layer only, no rebuild
+      _activeStroke!.add(_geometry.toPagePoint(event.localPosition));
+      _activeStrokePressures
+          ?.add(_pointerPressure ?? _activeStrokePressures!.last);
+      _bumpActiveStroke();
     }
   }
 
@@ -469,6 +482,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _signatureDrag = false;
       _signaturePreview = null;
     });
+    _bumpActiveStroke();
     // earlier strokes waiting in the buffer get their auto-commit back
     _controller.cancelInkStroke();
   }
@@ -498,6 +512,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _activeStroke = null;
       _activeStrokePressures = null;
     });
+    _bumpActiveStroke();
     if (canceled || stroke == null || stroke.isEmpty) {
       _controller.cancelInkStroke();
       return;
@@ -823,6 +838,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _ghost?.dispose();
     _afterGhost?.dispose();
     _flashController.dispose();
+    _activeStrokeRepaint.dispose();
     super.dispose();
   }
 
@@ -1153,12 +1169,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // hold the auto-commit while this stroke is on the page
         _controller.beginInkStroke();
         final pressure = _pointerPressure;
-        setState(() {
-          _activeStroke = [_geometry.toPagePoint(position)];
-          // the first event decides: a pressure device varies the whole
-          // stroke, anything else stays uniform
-          _activeStrokePressures = pressure == null ? null : [pressure];
-        });
+        // no setState: the active stroke lives on its own repaint layer
+        _activeStroke = [_geometry.toPagePoint(position)];
+        // the first event decides: a pressure device varies the whole
+        // stroke, anything else stays uniform
+        _activeStrokePressures = pressure == null ? null : [pressure];
+        _bumpActiveStroke();
       case PdfEditTool.rectangle ||
             PdfEditTool.ellipse ||
             PdfEditTool.line ||
@@ -1373,11 +1389,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     } else if (_moveStart != null) {
       setState(() => _moveCurrent = position);
     } else if (_activeStroke != null) {
-      setState(() {
-        _activeStroke!.add(_geometry.toPagePoint(position));
-        _activeStrokePressures
-            ?.add(_pointerPressure ?? _activeStrokePressures!.last);
-      });
+      // hot path: append + repaint the stroke layer only, no rebuild
+      _activeStroke!.add(_geometry.toPagePoint(position));
+      _activeStrokePressures
+          ?.add(_pointerPressure ?? _activeStrokePressures!.last);
+      _bumpActiveStroke();
     } else if (_dragStart != null) {
       setState(() => _dragCurrent = position);
     }
@@ -1428,6 +1444,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _viewportPanning = false;
       _signatureDrag = false;
     });
+    _bumpActiveStroke();
 
     if (panned) {
       // momentum: the fling continues in the viewer, which owns the
@@ -2278,14 +2295,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     color: _controller.color,
                     strokeWidth: _controller.strokeWidth * _geometry.scale,
                     geometry: _geometry,
-                    strokes: [
-                      ..._controller.strokesOn(widget.pageIndex),
-                      if (_activeStroke != null) _activeStroke!,
-                    ],
-                    pressures: [
-                      ..._controller.strokePressuresOn(widget.pageIndex),
-                      if (_activeStroke != null) _activeStrokePressures,
-                    ],
+                    // the in-progress stroke is NOT here — it rides its own
+                    // RepaintBoundary layer below so each appended point is a
+                    // repaint, not a rebuild of this whole painter
+                    strokes: _controller.strokesOn(widget.pageIndex),
+                    pressures: _controller.strokePressuresOn(widget.pageIndex),
                     dragRect: _dragStart != null && _dragCurrent != null
                         ? Rect.fromPoints(_dragStart!, _dragCurrent!)
                         : null,
@@ -2356,6 +2370,18 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     flashProgress: _flashController.value,
                   ),
                   size: Size.infinite,
+                ),
+              ),
+              // The in-progress pencil/mouse stroke, isolated on its own
+              // RepaintBoundary and repainted via _activeStrokeRepaint. While
+              // a stroke is live nothing above rebuilds, so only this layer
+              // re-rasterizes per appended point — the latency fix.
+              Positioned.fill(
+                child: RepaintBoundary(
+                  child: CustomPaint(
+                    painter: _ActiveStrokePainter(this),
+                    size: Size.infinite,
+                  ),
                 ),
               ),
               // a free-text resize in flight: the text re-wrapped to the
@@ -2536,6 +2562,110 @@ class _EyedropperChip extends StatelessWidget {
   }
 }
 
+/// Paints page-space ink [strokes] with the committed appearance's
+/// Catmull-Rom smoothing and pressure-mapped width. Shared by the heavy
+/// preview painter (buffered/committed strokes) and the lightweight
+/// [_ActiveStrokePainter] (the single in-progress stroke).
+void _paintInkStrokes(
+    Canvas canvas,
+    PdfPageGeometry geometry,
+    List<List<(double, double)>> strokes,
+    List<List<double>?> pressures,
+    Color color,
+    double strokeWidth) {
+  final paint = Paint()
+    ..color = color
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = strokeWidth
+    ..strokeCap = StrokeCap.round
+    ..strokeJoin = StrokeJoin.round;
+
+  for (var s = 0; s < strokes.length; s++) {
+    final stroke = strokes[s];
+    final pressure = s < pressures.length ? pressures[s] : null;
+    if (stroke.isEmpty) continue;
+    if (stroke.length == 1) {
+      final p = geometry.toViewOffset(stroke.single.$1, stroke.single.$2);
+      final width = pressure == null
+          ? strokeWidth
+          : pdfInkStrokeWidth(strokeWidth, pressure.first);
+      canvas.drawCircle(p, width / 2, Paint()..color = color);
+      continue;
+    }
+    // the same Catmull-Rom smoothing the committed appearance uses
+    final controls = pdfInkCurveControls(stroke);
+    if (pressure != null) {
+      // matches the committed appearance: a stroked spline segment per
+      // point pair at its own pressure-mapped width, round caps as the
+      // seams
+      final segment = Paint()
+        ..color = color
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round;
+      for (var i = 0; i < stroke.length - 1; i++) {
+        final (xa, ya) = stroke[i];
+        final ((c1x, c1y), (c2x, c2y)) = controls[i];
+        final a = geometry.toViewOffset(xa, ya);
+        final c1 = geometry.toViewOffset(c1x, c1y);
+        final c2 = geometry.toViewOffset(c2x, c2y);
+        final b = geometry.toViewOffset(stroke[i + 1].$1, stroke[i + 1].$2);
+        segment.strokeWidth = pdfInkStrokeWidth(
+            strokeWidth, (pressure[i] + pressure[i + 1]) / 2);
+        canvas.drawPath(
+            Path()
+              ..moveTo(a.dx, a.dy)
+              ..cubicTo(c1.dx, c1.dy, c2.dx, c2.dy, b.dx, b.dy),
+            segment);
+      }
+      continue;
+    }
+    final start = geometry.toViewOffset(stroke.first.$1, stroke.first.$2);
+    final path = Path()..moveTo(start.dx, start.dy);
+    for (var i = 0; i < stroke.length - 1; i++) {
+      final ((c1x, c1y), (c2x, c2y)) = controls[i];
+      final c1 = geometry.toViewOffset(c1x, c1y);
+      final c2 = geometry.toViewOffset(c2x, c2y);
+      final p = geometry.toViewOffset(stroke[i + 1].$1, stroke[i + 1].$2);
+      path.cubicTo(c1.dx, c1.dy, c2.dx, c2.dy, p.dx, p.dy);
+    }
+    canvas.drawPath(path, paint);
+  }
+}
+
+/// The single in-progress pencil/mouse stroke, on its own RepaintBoundary.
+///
+/// Reads the live stroke buffers straight off the overlay state and repaints
+/// only when [_EditingPageOverlayState._activeStrokeRepaint] ticks — so a
+/// pointer-move appends a point and bumps the notifier without rebuilding the
+/// overlay or the heavy [_EditingPreviewPainter]. [shouldRepaint] stays false:
+/// the repaint Listenable is the sole driver (the start, every point, and the
+/// clear on commit/bail all tick it), and the buffers are mutated in place so
+/// the painter always sees the current points.
+class _ActiveStrokePainter extends CustomPainter {
+  _ActiveStrokePainter(this._state)
+      : super(repaint: _state._activeStrokeRepaint);
+
+  final _EditingPageOverlayState _state;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final stroke = _state._activeStroke;
+    if (stroke == null || stroke.isEmpty) return;
+    final geometry = _state._geometry;
+    _paintInkStrokes(
+      canvas,
+      geometry,
+      [stroke],
+      [_state._activeStrokePressures],
+      _state._controller.color,
+      _state._controller.strokeWidth * geometry.scale,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_ActiveStrokePainter oldDelegate) => false;
+}
+
 class _EditingPreviewPainter extends CustomPainter {
   _EditingPreviewPainter({
     required this.theme,
@@ -2707,65 +2837,9 @@ class _EditingPreviewPainter extends CustomPainter {
   /// Paints one set of page-space ink strokes with the committed
   /// appearance's smoothing and pressure mapping.
   void _paintInk(Canvas canvas, List<List<(double, double)>> strokes,
-      List<List<double>?> pressures, Color color, double strokeWidth) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = strokeWidth
-      ..strokeCap = StrokeCap.round
-      ..strokeJoin = StrokeJoin.round;
-
-    for (var s = 0; s < strokes.length; s++) {
-      final stroke = strokes[s];
-      final pressure = s < pressures.length ? pressures[s] : null;
-      if (stroke.isEmpty) continue;
-      if (stroke.length == 1) {
-        final p = geometry.toViewOffset(stroke.single.$1, stroke.single.$2);
-        final width = pressure == null
-            ? strokeWidth
-            : pdfInkStrokeWidth(strokeWidth, pressure.first);
-        canvas.drawCircle(p, width / 2, Paint()..color = color);
-        continue;
-      }
-      // the same Catmull-Rom smoothing the committed appearance uses
-      final controls = pdfInkCurveControls(stroke);
-      if (pressure != null) {
-        // matches the committed appearance: a stroked spline segment per
-        // point pair at its own pressure-mapped width, round caps as the
-        // seams
-        final segment = Paint()
-          ..color = color
-          ..style = PaintingStyle.stroke
-          ..strokeCap = StrokeCap.round;
-        for (var i = 0; i < stroke.length - 1; i++) {
-          final (xa, ya) = stroke[i];
-          final ((c1x, c1y), (c2x, c2y)) = controls[i];
-          final a = geometry.toViewOffset(xa, ya);
-          final c1 = geometry.toViewOffset(c1x, c1y);
-          final c2 = geometry.toViewOffset(c2x, c2y);
-          final b = geometry.toViewOffset(stroke[i + 1].$1, stroke[i + 1].$2);
-          segment.strokeWidth = pdfInkStrokeWidth(
-              strokeWidth, (pressure[i] + pressure[i + 1]) / 2);
-          canvas.drawPath(
-              Path()
-                ..moveTo(a.dx, a.dy)
-                ..cubicTo(c1.dx, c1.dy, c2.dx, c2.dy, b.dx, b.dy),
-              segment);
-        }
-        continue;
-      }
-      final start = geometry.toViewOffset(stroke.first.$1, stroke.first.$2);
-      final path = Path()..moveTo(start.dx, start.dy);
-      for (var i = 0; i < stroke.length - 1; i++) {
-        final ((c1x, c1y), (c2x, c2y)) = controls[i];
-        final c1 = geometry.toViewOffset(c1x, c1y);
-        final c2 = geometry.toViewOffset(c2x, c2y);
-        final p = geometry.toViewOffset(stroke[i + 1].$1, stroke[i + 1].$2);
-        path.cubicTo(c1.dx, c1.dy, c2.dx, c2.dy, p.dx, p.dy);
-      }
-      canvas.drawPath(path, paint);
-    }
-  }
+          List<List<double>?> pressures, Color color, double strokeWidth) =>
+      _paintInkStrokes(
+          canvas, geometry, strokes, pressures, color, strokeWidth);
 
   void _paintShapePreview(
       Canvas canvas, Rect rect, PdfEditTool? tool, Color color, double width) {

--- a/packages/dart_pdf_editor/lib/src/editing/stroke_prediction.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/stroke_prediction.dart
@@ -1,0 +1,79 @@
+import 'dart:math' as math;
+
+/// Forward-extrapolates a short speculative "lead" beyond the last sampled
+/// point of an in-progress ink stroke, to mask the input+render latency
+/// between the pen tip and the painted line — the pure-geometry analogue of
+/// PencilKit's predicted touches (which read the OS's hardware predictor).
+/// Display only: the returned points are drawn ahead of the stroke but never
+/// enter the committed /InkList.
+///
+/// [points] are the recent stroke samples in page space, oldest → newest.
+/// The lead starts from the last two samples' velocity, bends along the last
+/// three samples' curvature (the polyline's acceleration, scaled by
+/// [curvatureDamping]), and advances by [gain] times the last segment
+/// ([gain] 1.0 ≈ one more sample). [steps] predicted points are returned,
+/// each capped at [maxLeadFactor] times the last segment so a noisy
+/// acceleration estimate can't fling the line off the tip.
+///
+/// Returns an empty list — no prediction — when extrapolation would be
+/// unstable:
+///   * fewer than two samples (no velocity to extend),
+///   * a near-stationary pen (last segment shorter than [minSegment]), where
+///     prediction only adds jitter, or
+///   * a sharp direction reversal (the pen turned more than [maxTurn]
+///     radians), where forward extrapolation would shoot past the cusp.
+List<(double, double)> pdfPredictStrokeLead(
+  List<(double, double)> points, {
+  int steps = 1,
+  double gain = 0.9,
+  double curvatureDamping = 0.5,
+  double minSegment = 0.75,
+  double maxLeadFactor = 1.6,
+  double maxTurn = 2.0, // radians, ~115°
+}) {
+  if (points.length < 2 || steps < 1) return const [];
+  final (px, py) = points[points.length - 1];
+  final (qx, qy) = points[points.length - 2];
+  var vx = px - qx;
+  var vy = py - qy;
+  final speed = math.sqrt(vx * vx + vy * vy);
+  if (speed < minSegment) return const [];
+
+  // curvature from the last three samples — the change in velocity, so the
+  // lead follows an arc rather than flying off the last segment's tangent
+  var ax = 0.0, ay = 0.0;
+  if (points.length >= 3) {
+    final (rx, ry) = points[points.length - 3];
+    final pvx = qx - rx; // the previous segment's velocity
+    final pvy = qy - ry;
+    final pspeed = math.sqrt(pvx * pvx + pvy * pvy);
+    if (pspeed >= minSegment) {
+      // a reversal or hard corner: don't predict across the cusp
+      final cosTurn = (vx * pvx + vy * pvy) / (speed * pspeed);
+      if (math.acos(cosTurn.clamp(-1.0, 1.0)) > maxTurn) return const [];
+      ax = vx - pvx;
+      ay = vy - pvy;
+    }
+  }
+
+  final cap = speed * maxLeadFactor;
+  final lead = <(double, double)>[];
+  var cx = px, cy = py;
+  for (var k = 0; k < steps; k++) {
+    var dx = vx * gain + 0.5 * ax * gain * gain * curvatureDamping;
+    var dy = vy * gain + 0.5 * ay * gain * gain * curvatureDamping;
+    final len = math.sqrt(dx * dx + dy * dy);
+    if (len > cap && len > 0) {
+      final s = cap / len;
+      dx *= s;
+      dy *= s;
+    }
+    cx += dx;
+    cy += dy;
+    lead.add((cx, cy));
+    // carry the bent velocity forward so multi-step leads keep curving
+    vx += ax * curvatureDamping;
+    vy += ay * curvatureDamping;
+  }
+  return lead;
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -300,6 +300,7 @@ class PdfViewer extends StatefulWidget {
     this.showAnnotations = true,
     this.highlightFormFields = true,
     this.pagePreviews = true,
+    this.predictStrokes = true,
   });
 
   final PdfDocument document;
@@ -397,6 +398,17 @@ class PdfViewer extends StatefulWidget {
   /// session plus up to ~40 MB of preview pixels on very long
   /// documents.
   final bool pagePreviews;
+
+  /// Draws a short speculative "lead" ahead of the pen while an ink stroke
+  /// is in flight, forward-extrapolated from the recent samples' velocity
+  /// and curvature, to mask the input+render latency between the pencil
+  /// tip and the painted line the way PencilKit's predicted touches do.
+  /// The lead is display-only — it never enters the committed stroke — and
+  /// is suppressed when prediction would be unstable (too few samples, a
+  /// near-stationary pen, or a sharp direction reversal). Pure geometry, so
+  /// it helps every stylus platform; it approximates, but does not equal,
+  /// Apple's hardware predictor.
+  final bool predictStrokes;
 
   @override
   State<PdfViewer> createState() => _PdfViewerState();
@@ -2231,6 +2243,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 transformScale: _transformScale,
                 renderHold: _renderHold,
                 previewCache: widget.pagePreviews ? _previews : null,
+                predictStrokes: widget.predictStrokes,
               ),
             ),
           ),
@@ -2501,6 +2514,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.transformScale,
     required this.renderHold,
     required this.previewCache,
+    required this.predictStrokes,
   });
 
   final PdfPage page;
@@ -2548,6 +2562,9 @@ class _PdfViewerPage extends StatefulWidget {
 
   /// See [PdfPageView.previewCache]; null when previews are off.
   final PdfPagePreviewCache? previewCache;
+
+  /// See [PdfViewer.predictStrokes].
+  final bool predictStrokes;
 
   @override
   State<_PdfViewerPage> createState() => _PdfViewerPageState();
@@ -2657,6 +2674,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                               onShowFormFieldMenu: widget.onShowFormFieldMenu,
                               rasterCurrent: _rastered,
                               zoom: zoom,
+                              predictStrokes: widget.predictStrokes,
                             ),
                           ),
                         ),

--- a/packages/dart_pdf_editor/test/editing_prediction_test.dart
+++ b/packages/dart_pdf_editor/test/editing_prediction_test.dart
@@ -1,0 +1,108 @@
+// Item 3 of the pencil-latency work: the in-progress ink layer draws a
+// forward-extrapolated lead so the line keeps up with the pen tip. These
+// tests prove the lead reaches pixels (and that PdfViewer.predictStrokes
+// turns it off). The pure geometry is covered by stroke_prediction_test.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  // 800px viewport over a 612pt page (fit-width)
+  Future<PdfEditingController> pumpViewer(WidgetTester tester, GlobalKey boundary,
+      {required bool predict}) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1))
+      ..color = const Color(0xFFFF0000)
+      ..strokeWidth = 8;
+    addTearDown(editing.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: RepaintBoundary(
+          key: boundary,
+          child: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: PdfViewerController(),
+              editing: editing,
+              predictStrokes: predict,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return editing;
+  }
+
+  // Draws a horizontal stylus stroke (5 samples, 40px steps) and holds it,
+  // then reports whether a red pixel sits `beyond` px past the last sample
+  // along the stroke's line.
+  Future<bool> redBeyondLastSample(WidgetTester tester, GlobalKey boundary,
+      {required double beyond}) async {
+    const start = Offset(200, 300);
+    final g = await tester.startGesture(start, kind: PointerDeviceKind.stylus);
+    var last = start;
+    for (var i = 0; i < 4; i++) {
+      last += const Offset(40, 0);
+      await g.moveTo(last);
+    }
+    await tester.pump();
+
+    final image = await tester.runAsync(() async {
+      final render =
+          boundary.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+      return render.toImage();
+    });
+    final data = (await tester.runAsync(image!.toByteData))!;
+    int px(int x, int y) {
+      final i = (y * image.width + x) * 4;
+      return data.getUint8(i); // red channel
+    }
+
+    var sawRed = false;
+    final x = (last.dx + beyond).round();
+    for (var dy = -4; dy <= 4 && !sawRed; dy++) {
+      final r = px(x, last.dy.round() + dy);
+      // the line is opaque red over white paper; predicted ink reads red,
+      // bare paper reads white (r==255 but with g==b==255). The byte data is
+      // premultiplied straight RGBA, so check the green channel too.
+      final gi = (last.dy.round() + dy) * image.width * 4 + x * 4 + 1;
+      sawRed = r > 180 && data.getUint8(gi) < 140;
+    }
+    await g.up();
+    await tester.pump(const Duration(milliseconds: 900));
+    await tester.pump(const Duration(milliseconds: 400));
+    image.dispose();
+    return sawRed;
+  }
+
+  testWidgets('the predicted lead inks past the last real sample',
+      (tester) async {
+    final boundary = GlobalKey();
+    final editing = await pumpViewer(tester, boundary, predict: true);
+    editing.tool = PdfEditTool.ink;
+    await tester.pump();
+
+    // 20px beyond the last sample is within the ~0.9-segment lead (≈34px
+    // here) but well past the unpredicted round cap (~4px)
+    expect(await redBeyondLastSample(tester, boundary, beyond: 20), isTrue);
+  });
+
+  testWidgets('predictStrokes:false leaves the line at the last sample',
+      (tester) async {
+    final boundary = GlobalKey();
+    final editing = await pumpViewer(tester, boundary, predict: false);
+    editing.tool = PdfEditTool.ink;
+    await tester.pump();
+
+    expect(await redBeyondLastSample(tester, boundary, beyond: 20), isFalse);
+  });
+}

--- a/packages/dart_pdf_editor/test/stroke_prediction_test.dart
+++ b/packages/dart_pdf_editor/test/stroke_prediction_test.dart
@@ -1,0 +1,67 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('pdfPredictStrokeLead', () {
+    test('needs at least two samples', () {
+      expect(pdfPredictStrokeLead(const []), isEmpty);
+      expect(pdfPredictStrokeLead(const [(0, 0)]), isEmpty);
+    });
+
+    test('extends straight motion along the velocity', () {
+      // velocity (10, 0), no curvature: lead = last + v * gain (0.9)
+      final lead = pdfPredictStrokeLead(const [(0, 0), (10, 0), (20, 0)]);
+      expect(lead, hasLength(1));
+      expect(lead.single.$1, closeTo(29, 1e-9));
+      expect(lead.single.$2, closeTo(0, 1e-9));
+    });
+
+    test('bends the lead along the stroke curvature', () {
+      // v = (10, 5), previous v = (10, 0): acceleration (0, 5) curves it up
+      final lead = pdfPredictStrokeLead(const [(0, 0), (10, 0), (20, 5)]);
+      expect(lead, hasLength(1));
+      // dx = 10*0.9 = 9 ; dy = 5*0.9 + 0.5*5*0.9^2*0.5 = 4.5 + 1.0125
+      expect(lead.single.$1, closeTo(29, 1e-6));
+      expect(lead.single.$2, closeTo(5 + 5.5125, 1e-6));
+    });
+
+    test('does not predict a near-stationary pen', () {
+      // last segment 0.5 < minSegment (0.75): extrapolation is just jitter
+      expect(pdfPredictStrokeLead(const [(0, 0), (0.5, 0)]), isEmpty);
+    });
+
+    test('does not predict across a sharp reversal', () {
+      // the pen doubled back (180°): a forward lead would overshoot the cusp
+      expect(pdfPredictStrokeLead(const [(0, 0), (10, 0), (2, 0)]), isEmpty);
+    });
+
+    test('caps the lead so a noisy estimate cannot fling off the tip', () {
+      // straight v = (10, 0), speed 10; cap = speed * maxLeadFactor
+      final lead = pdfPredictStrokeLead(
+        const [(0, 0), (10, 0), (20, 0)],
+        maxLeadFactor: 0.5,
+      );
+      expect(lead, hasLength(1));
+      // raw step would be 9; capped to 10 * 0.5 = 5 → 20 + 5
+      expect(lead.single.$1, closeTo(25, 1e-9));
+      expect(lead.single.$2, closeTo(0, 1e-9));
+    });
+
+    test('returns the requested number of forward steps', () {
+      final lead = pdfPredictStrokeLead(
+        const [(0, 0), (10, 0), (20, 0)],
+        steps: 2,
+      );
+      expect(lead, hasLength(2));
+      // straight motion: each step advances by v * gain (9)
+      expect(lead[0].$1, closeTo(29, 1e-9));
+      expect(lead[1].$1, closeTo(38, 1e-9));
+    });
+
+    test('a two-sample stroke predicts without curvature', () {
+      final lead = pdfPredictStrokeLead(const [(0, 0), (10, 0)]);
+      expect(lead, hasLength(1));
+      expect(lead.single.$1, closeTo(19, 1e-9));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements stroke prediction to mask input+render latency in the ink editor. While a stylus stroke is in flight, the in-progress layer now draws a short forward-extrapolated "lead" ahead of the pen tip, computed from the recent samples' velocity and curvature. The lead is display-only and never enters the committed stroke.

This is item 3 of the pencil-latency work:
1. ✅ Isolated the in-progress stroke on its own `RepaintBoundary` so each appended point triggers a repaint, not a rebuild of the heavy preview painter
2. ✅ Replaced `setState` calls in the hot path with a `ValueNotifier` to skip widget rebuilds
3. ✅ **This PR:** Added forward-extrapolated prediction to keep the visual line ahead of the pen tip

The prediction algorithm (`pdfPredictStrokeLead`) extends the last two samples' velocity, bends along the last three samples' curvature, and caps the lead to prevent instability. It gracefully degrades when prediction would be unreliable (too few samples, near-stationary pen, or sharp direction reversals).

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [x] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

All tests pass. New tests in `editing_prediction_test.dart` verify the lead reaches pixels and that `PdfViewer.predictStrokes` controls the feature. Pure geometry tests in `stroke_prediction_test.dart` cover the extrapolation algorithm.

## Notes for reviewers

**Key changes:**

1. **`stroke_prediction.dart` (new):** Pure-geometry `pdfPredictStrokeLead()` function that forward-extrapolates a short lead from recent stroke samples. Returns empty list when prediction would be unstable.

2. **`editing_overlay.dart`:**
   - Added `predictStrokes` parameter (defaults `true`) to `EditingPageOverlay`
   - Replaced `setState` calls in `_onPointerDown`, `_onPointerMove`, and `_onPointerUp` with direct mutations + `_bumpActiveStroke()` calls to skip rebuilds
   - Extracted ink painting logic into shared `_paintInkStrokes()` function
   - New `_ActiveStrokePainter` class paints only the in-progress stroke on its own `RepaintBoundary`, driven by `_activeStrokeRepaint` notifier
   - The in-progress stroke is no longer included in the heavy `_EditingPreviewPainter`

3. **`pdf_viewer.dart`:**
   - Added `predictStrokes` parameter (defaults `true`) to `PdfViewer`
   - Threaded through to `EditingPageOverlay`

4. **`dart_pdf_editor.dart`:** Exported `pdfPredictStrokeLead` for public use

**Performance impact:** The hot path (pointer move during ink stroke) now does a point append + notifier tick instead of `setState`, eliminating the widget rebuild and heavy painter repaint. The prediction itself is negligible (one extra list allocation per repaint, ~1-2 points).

**Compatibility:** The feature is opt-in via `PdfViewer.predictStrokes` and `EditingPageOverlay.predictStrokes`. Defaults to `true` but can be disabled if needed. The prediction is pure geometry and works on all stylus platforms (approximates but does not equal Apple's hardware predictor).

https://claude.ai/code/session_01Q55WSVEEawRSYPWKcC1oNN