### PR TITLE
Document comparison: pixel + text diff with a synchronized compare view

### DIFF
--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -307,6 +307,29 @@ class _ViewerScreenState extends State<ViewerScreen> {
     }
   }
 
+  /// Opens a second PDF and compares it against the active document in a
+  /// new tab ([PdfComparisonView]). The active document is the "before".
+  Future<void> _compareWith() async {
+    final tab = _active;
+    final current = tab?.session?.bytes;
+    if (current == null) return;
+    final file = await openFile(acceptedTypeGroups: const [_pdfTypeGroup]);
+    if (file == null) return;
+    try {
+      final other = await file.readAsBytes();
+      setState(() {
+        _tabs.add(_DocumentTab.comparison(
+          title: 'Compare: ${tab!.title} ↔ ${file.name}',
+          before: current,
+          after: other,
+        ));
+        _activeIndex = _tabs.length - 1;
+      });
+    } catch (e) {
+      _openError(file.name, 'Could not open ${file.name}\n$e');
+    }
+  }
+
   Future<void> _openPath(String path) async {
     final name = path.split(RegExp(r'[/\\]')).last;
     try {
@@ -433,15 +456,26 @@ class _ViewerScreenState extends State<ViewerScreen> {
             tooltip: 'Open PDF in a new tab',
             onPressed: _pickFile,
           ),
-          // GitHub source + pub.dev package, kept in one slot so the
-          // action row stays inside the 800px test window
-          PopupMenuButton<Uri>(
-            icon: const Icon(Icons.link),
-            tooltip: 'Project links',
-            onSelected: _openLink,
+          // Compare + project links share one overflow slot so the action
+          // row stays inside the 800px test window (every standalone
+          // button would push it over).
+          PopupMenuButton<VoidCallback>(
+            icon: const Icon(Icons.more_vert),
+            tooltip: 'More actions',
+            onSelected: (action) => action(),
             itemBuilder: (context) => [
               PopupMenuItem(
-                value: _githubUrl,
+                value: _compareWith,
+                enabled: _active?.session != null,
+                child: const ListTile(
+                  leading: Icon(Icons.compare_arrows),
+                  title: Text('Compare with another PDF…'),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+              const PopupMenuDivider(),
+              PopupMenuItem(
+                value: () => _openLink(_githubUrl),
                 child: const ListTile(
                   leading: Icon(Icons.code),
                   title: Text('View source on GitHub'),
@@ -449,7 +483,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
                 ),
               ),
               PopupMenuItem(
-                value: _pubDevUrl,
+                value: () => _openLink(_pubDevUrl),
                 child: const ListTile(
                   leading: Icon(Icons.inventory_2_outlined),
                   title: Text('dart_pdf_editor on pub.dev'),
@@ -484,6 +518,12 @@ class _ViewerScreenState extends State<ViewerScreen> {
             )
           : tab.error != null
               ? Center(child: Text(tab.error!, textAlign: TextAlign.center))
+              : tab.isComparison
+              ? PdfComparisonView(
+                  key: ValueKey(tab),
+                  before: tab.compareBefore!,
+                  after: tab.compareAfter!,
+                )
               // the two drop-in widgets carry all the PDF chrome (search,
               // page number, panels, toolbar) — the app supplies the edit
               // session, its file handling, and the demo's app-side wiring
@@ -604,16 +644,39 @@ class _DocumentTab {
     this.isDemo = false,
   })  : session = PdfEditingController(bytes, preferences: preferences),
         viewer = PdfViewerController(),
-        error = null;
+        error = null,
+        compareBefore = null,
+        compareAfter = null;
 
   _DocumentTab.error({required this.title, required this.error})
       : session = null,
         viewer = null,
-        isDemo = false;
+        isDemo = false,
+        compareBefore = null,
+        compareAfter = null;
+
+  /// A document-comparison tab: hosts a [PdfComparisonView] over two
+  /// files. No edit session or viewer controller of its own.
+  _DocumentTab.comparison({
+    required this.title,
+    required Uint8List before,
+    required Uint8List after,
+  })  : session = null,
+        viewer = null,
+        isDemo = false,
+        error = null,
+        compareBefore = before,
+        compareAfter = after;
 
   final String title;
   final String? error;
   final bool isDemo;
+
+  /// The two documents a comparison tab diffs; null on every other tab.
+  final Uint8List? compareBefore;
+  final Uint8List? compareAfter;
+
+  bool get isComparison => compareAfter != null;
 
   /// Null for an error tab. Shared preferences are owned by the app, so
   /// they outlive the tab.

--- a/packages/dart_pdf_editor/example/test/tabs_test.dart
+++ b/packages/dart_pdf_editor/example/test/tabs_test.dart
@@ -59,4 +59,12 @@ void main() {
     expect(find.text('Open a PDF'), findsOneWidget);
     expect(find.text('Try the interactive demo'), findsOneWidget);
   });
+
+  testWidgets('the More menu offers comparing against another PDF',
+      (tester) async {
+    await openDemo(tester);
+    await tester.tap(find.byTooltip('More actions'));
+    await tester.pumpAndSettle();
+    expect(find.text('Compare with another PDF…'), findsOneWidget);
+  });
 }

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -2,6 +2,9 @@
 library;
 
 export 'src/canvas_device.dart';
+export 'src/comparison/comparison_view.dart';
+export 'src/comparison/document_comparison.dart';
+export 'src/comparison/page_comparison.dart';
 export 'src/editing/editing_color_picker.dart';
 export 'src/editing/editing_controller.dart';
 export 'src/editing/editing_menu.dart';

--- a/packages/dart_pdf_editor/lib/src/comparison/comparison_view.dart
+++ b/packages/dart_pdf_editor/lib/src/comparison/comparison_view.dart
@@ -1,0 +1,592 @@
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import '../editing/editing_panel.dart';
+import '../page_geometry.dart';
+import '../pdf_viewer.dart';
+import '../scrollbar.dart';
+import '../theme.dart';
+import 'document_comparison.dart';
+
+/// How a [PdfComparisonView] presents the two documents.
+enum PdfComparisonMode {
+  /// Two synchronized panes, scroll and zoom locked together.
+  sideBySide,
+
+  /// One pane showing the after document with a per-page colored diff
+  /// composited over it (removed red, added green, changed amber, the rest
+  /// dimmed).
+  overlay,
+}
+
+/// Compares two PDF documents visually.
+///
+/// Pairs the documents' pages, diffs their text, and presents the result
+/// as either synchronized side-by-side panes or a single overlay pane.
+/// A [PdfDiffNavigatorPanel] steps through the changes.
+class PdfComparisonView extends StatefulWidget {
+  const PdfComparisonView({
+    super.key,
+    required this.before,
+    required this.after,
+    this.initialMode = PdfComparisonMode.sideBySide,
+    this.showNavigator = true,
+    this.pixelRatio = 1.5,
+    this.viewerTheme,
+  });
+
+  /// The original ("before") document bytes.
+  final Uint8List before;
+
+  /// The revised ("after") document bytes.
+  final Uint8List after;
+
+  final PdfComparisonMode initialMode;
+
+  /// Whether to dock the diff navigator panel.
+  final bool showNavigator;
+
+  /// Resolution the overlay diff rasters render at.
+  final double pixelRatio;
+
+  /// Wraps both panes in a [PdfViewerTheme].
+  final PdfViewerThemeData? viewerTheme;
+
+  @override
+  State<PdfComparisonView> createState() => _PdfComparisonViewState();
+}
+
+class _PdfComparisonViewState extends State<PdfComparisonView> {
+  late PdfDocument _beforeDoc;
+  late PdfDocument _afterDoc;
+  late PdfComparisonController _comparison;
+  final PdfViewerController _beforeCtl = PdfViewerController();
+  final PdfViewerController _afterCtl = PdfViewerController();
+  _PdfSyncLink? _link;
+  late PdfComparisonMode _mode;
+
+  // Overlay-mode diff images, keyed by after-page index. Null while loading.
+  final Map<int, ui.Image?> _overlayImages = {};
+  final Set<int> _overlayLoading = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _mode = widget.initialMode;
+    _open();
+    _comparison.addListener(_onComparison);
+    // Build the change list after the first frame so the panes can attach.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _comparison.build();
+    });
+  }
+
+  void _open() {
+    _beforeDoc = PdfDocument.open(widget.before);
+    _afterDoc = PdfDocument.open(widget.after);
+    _comparison = PdfComparisonController(
+      before: _beforeDoc,
+      after: _afterDoc,
+      pixelRatio: widget.pixelRatio,
+    );
+  }
+
+  @override
+  void didUpdateWidget(PdfComparisonView old) {
+    super.didUpdateWidget(old);
+    if (!_sameBytes(old.before, widget.before) ||
+        !_sameBytes(old.after, widget.after)) {
+      _comparison.removeListener(_onComparison);
+      _comparison.dispose();
+      _disposeOverlays();
+      _open();
+      _comparison.addListener(_onComparison);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _comparison.build();
+      });
+    }
+  }
+
+  bool _sameBytes(Uint8List a, Uint8List b) => identical(a, b);
+
+  @override
+  void dispose() {
+    _link?.dispose();
+    _comparison.removeListener(_onComparison);
+    _comparison.dispose();
+    _beforeCtl.dispose();
+    _afterCtl.dispose();
+    _disposeOverlays();
+    super.dispose();
+  }
+
+  void _disposeOverlays() {
+    for (final image in _overlayImages.values) {
+      image?.dispose();
+    }
+    _overlayImages.clear();
+    _overlayLoading.clear();
+  }
+
+  void _onComparison() {
+    if (!mounted) return;
+    _frameCurrentChange();
+  }
+
+  void _frameCurrentChange() {
+    final index = _comparison.currentChange;
+    if (index < 0 || index >= _comparison.changes.length) return;
+    final change = _comparison.changes[index];
+    final page = change.afterPage ?? change.beforePage ?? 0;
+    final rect = change.afterBounds ?? change.beforeBounds;
+    // Drive the after pane; in side-by-side the sync link mirrors the
+    // before pane to the same scroll position.
+    if (rect != null) {
+      _afterCtl.showRect(page, rect);
+    } else {
+      _afterCtl.jumpToPage(page);
+    }
+  }
+
+  void _setMode(PdfComparisonMode mode) {
+    if (mode == _mode) return;
+    setState(() => _mode = mode);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget panes = _mode == PdfComparisonMode.sideBySide
+        ? _sideBySide()
+        : _overlayPane();
+    if (widget.viewerTheme != null) {
+      panes = PdfViewerTheme(data: widget.viewerTheme!, child: panes);
+    }
+    return Column(children: [
+      _PdfComparisonToolbar(
+        mode: _mode,
+        onMode: _setMode,
+        comparison: _comparison,
+      ),
+      const Divider(height: 1),
+      Expanded(
+        child: Row(children: [
+          if (widget.showNavigator)
+            PdfDiffNavigatorPanel(controller: _comparison),
+          if (widget.showNavigator) const VerticalDivider(width: 1),
+          Expanded(child: panes),
+        ]),
+      ),
+    ]);
+  }
+
+  Widget _sideBySide() {
+    // (Re)attach the sync link to the live controllers.
+    _link ??= _PdfSyncLink(_beforeCtl, _afterCtl);
+    return Row(children: [
+      Expanded(
+        child: _LabeledPane(
+          label: 'Before',
+          child: PdfViewer(
+            key: const ValueKey('pdf-compare-before'),
+            document: _beforeDoc,
+            controller: _beforeCtl,
+            initialFit: PdfViewerFit.width,
+          ),
+        ),
+      ),
+      const VerticalDivider(width: 1),
+      Expanded(
+        child: _LabeledPane(
+          label: 'After',
+          child: PdfViewer(
+            key: const ValueKey('pdf-compare-after'),
+            document: _afterDoc,
+            controller: _afterCtl,
+            initialFit: PdfViewerFit.width,
+          ),
+        ),
+      ),
+    ]);
+  }
+
+  Widget _overlayPane() {
+    // The overlay pane has no second viewer, so drop the link.
+    _link?.dispose();
+    _link = null;
+    return PdfViewer(
+      key: const ValueKey('pdf-compare-overlay'),
+      document: _afterDoc,
+      controller: _afterCtl,
+      initialFit: PdfViewerFit.width,
+      pageOverlayBuilder: _overlayBuilder,
+    );
+  }
+
+  List<Widget> _overlayBuilder(
+      BuildContext context, int pageIndex, PdfPageGeometry geometry) {
+    final image = _overlayImages[pageIndex];
+    if (image == null) {
+      _ensureOverlayImage(pageIndex);
+      return const [];
+    }
+    return [
+      Positioned.fromRect(
+        rect: geometry.toViewRect(geometry.cropBox),
+        child: IgnorePointer(
+          child: RawImage(
+            image: image,
+            fit: BoxFit.fill,
+            filterQuality: FilterQuality.low,
+          ),
+        ),
+      ),
+    ];
+  }
+
+  Future<void> _ensureOverlayImage(int afterPage) async {
+    if (_overlayImages.containsKey(afterPage) ||
+        _overlayLoading.contains(afterPage)) {
+      return;
+    }
+    final pairIndex = _comparison.pairForAfterPage(afterPage);
+    if (pairIndex < 0) return;
+    _overlayLoading.add(afterPage);
+    try {
+      final diff = await _comparison.pixelDiff(pairIndex);
+      final image = await diff.pixels.toImage();
+      if (!mounted) {
+        image.dispose();
+        return;
+      }
+      setState(() => _overlayImages[afterPage] = image);
+    } catch (_) {
+      // A page that fails to render leaves no overlay; the underlying page
+      // still shows.
+    } finally {
+      _overlayLoading.remove(afterPage);
+    }
+  }
+}
+
+/// Bidirectionally mirrors two viewers' scroll and zoom, with a guard so an
+/// applied change doesn't echo back.
+class _PdfSyncLink {
+  _PdfSyncLink(this.a, this.b) {
+    a.viewportChanges.addListener(_fromA);
+    b.viewportChanges.addListener(_fromB);
+  }
+
+  final PdfViewerController a;
+  final PdfViewerController b;
+  bool _busy = false;
+
+  void _fromA() => _mirror(a, b);
+  void _fromB() => _mirror(b, a);
+
+  void _mirror(PdfViewerController from, PdfViewerController to) {
+    if (_busy) return;
+    final sync = from.viewSync;
+    if (sync == null) return;
+    _busy = true;
+    try {
+      to.applyViewSync(sync);
+    } finally {
+      scheduleMicrotask(() => _busy = false);
+    }
+  }
+
+  void dispose() {
+    a.viewportChanges.removeListener(_fromA);
+    b.viewportChanges.removeListener(_fromB);
+  }
+}
+
+class _LabeledPane extends StatelessWidget {
+  const _LabeledPane({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Column(children: [
+      Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        color: scheme.surfaceContainerHighest,
+        child: Text(label, style: Theme.of(context).textTheme.labelMedium),
+      ),
+      Expanded(child: child),
+    ]);
+  }
+}
+
+class _PdfComparisonToolbar extends StatelessWidget {
+  const _PdfComparisonToolbar({
+    required this.mode,
+    required this.onMode,
+    required this.comparison,
+  });
+
+  final PdfComparisonMode mode;
+  final ValueChanged<PdfComparisonMode> onMode;
+  final PdfComparisonController comparison;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+      child: Row(children: [
+        SegmentedButton<PdfComparisonMode>(
+          key: const ValueKey('pdf-compare-mode'),
+          segments: const [
+            ButtonSegment(
+              value: PdfComparisonMode.sideBySide,
+              icon: Icon(Icons.view_column_outlined),
+              label: Text('Side by side'),
+            ),
+            ButtonSegment(
+              value: PdfComparisonMode.overlay,
+              icon: Icon(Icons.layers_outlined),
+              label: Text('Overlay'),
+            ),
+          ],
+          selected: {mode},
+          onSelectionChanged: (s) => onMode(s.first),
+        ),
+        const Spacer(),
+        ListenableBuilder(
+          listenable: comparison,
+          builder: (context, _) {
+            final count = comparison.changes.length;
+            final current = comparison.currentChange;
+            return Row(mainAxisSize: MainAxisSize.min, children: [
+              Text(
+                count == 0
+                    ? 'No changes'
+                    : '${current + 1} / $count changes',
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+              IconButton(
+                key: const ValueKey('pdf-compare-prev'),
+                tooltip: 'Previous change',
+                icon: const Icon(Icons.keyboard_arrow_up),
+                onPressed: count == 0 ? null : comparison.previousChange,
+              ),
+              IconButton(
+                key: const ValueKey('pdf-compare-next'),
+                tooltip: 'Next change',
+                icon: const Icon(Icons.keyboard_arrow_down),
+                onPressed: count == 0 ? null : comparison.nextChange,
+              ),
+            ]);
+          },
+        ),
+      ]),
+    );
+  }
+}
+
+/// Lists every change in a [PdfComparisonController], grouped by page —
+/// tap to jump, mirroring [PdfSearchResultsPanel]'s shape. The inner edge
+/// is draggable.
+class PdfDiffNavigatorPanel extends StatefulWidget {
+  const PdfDiffNavigatorPanel({
+    super.key,
+    required this.controller,
+    this.width = 280,
+    this.side = PdfSidebarSide.left,
+    this.resizable = true,
+    this.minWidth = 200,
+    this.maxWidth = 480,
+  });
+
+  final PdfComparisonController controller;
+  final double width;
+  final PdfSidebarSide side;
+  final bool resizable;
+  final double minWidth;
+  final double maxWidth;
+
+  @override
+  State<PdfDiffNavigatorPanel> createState() => _PdfDiffNavigatorPanelState();
+}
+
+class _PdfDiffNavigatorPanelState extends State<PdfDiffNavigatorPanel> {
+  final ScrollController _scroll = ScrollController();
+  double? _dragWidth;
+
+  double get _width =>
+      (_dragWidth ?? widget.width).clamp(widget.minWidth, widget.maxWidth);
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  void _onResizeDelta(double delta) => setState(() {
+        _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
+      });
+
+  Widget _hint(String message) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(message, textAlign: TextAlign.center),
+        ),
+      );
+
+  ({IconData icon, Color color, String prefix}) _style(
+      BuildContext context, PdfDiffChangeKind kind) {
+    switch (kind) {
+      case PdfDiffChangeKind.inserted:
+      case PdfDiffChangeKind.pageInserted:
+        return (icon: Icons.add, color: const Color(0xFF2E7D32), prefix: '');
+      case PdfDiffChangeKind.deleted:
+      case PdfDiffChangeKind.pageRemoved:
+        return (
+          icon: Icons.remove,
+          color: const Color(0xFFE53935),
+          prefix: ''
+        );
+      case PdfDiffChangeKind.replaced:
+        return (
+          icon: Icons.swap_horiz,
+          color: const Color(0xFFF57C00),
+          prefix: ''
+        );
+    }
+  }
+
+  Widget _tile(BuildContext context, int index, PdfDiffChange change) {
+    final scheme = Theme.of(context).colorScheme;
+    final style = _style(context, change.kind);
+    return ListTile(
+      key: ValueKey('pdf-diff-change-$index'),
+      dense: true,
+      leading: Icon(style.icon, color: style.color, size: 18),
+      selected: index == widget.controller.currentChange,
+      selectedTileColor: scheme.secondaryContainer,
+      selectedColor: scheme.onSecondaryContainer,
+      title: Text(
+        change.label.isEmpty ? '(empty)' : change.label,
+        style: Theme.of(context).textTheme.bodySmall,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      onTap: () => widget.controller.goToChange(index),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = widget.controller;
+    final barClearance = PdfScrollbar.hitExtent +
+        (widget.resizable && widget.side == PdfSidebarSide.left
+            ? PdfSidebarResizeGrip.width
+            : 0);
+    final textTheme = Theme.of(context).textTheme;
+    return SizedBox(
+      width: _width,
+      child: Stack(children: [
+        Positioned.fill(
+          child: Material(
+            color: Theme.of(context).colorScheme.surfaceContainerLow,
+            child: ListenableBuilder(
+              listenable: controller,
+              builder: (context, _) {
+                final changes = controller.changes;
+                if (changes.isEmpty) {
+                  return _hint('No differences between the two documents');
+                }
+                // Group entries by their display page with headers.
+                final entries = <({int? header, int? change})>[];
+                int? page;
+                for (var i = 0; i < changes.length; i++) {
+                  final p = changes[i].displayPage;
+                  if (p != page) {
+                    page = p;
+                    entries.add((header: p, change: null));
+                  }
+                  entries.add((header: null, change: i));
+                }
+                return Stack(children: [
+                  Column(children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                      child: Text(
+                        changes.length == 1
+                            ? '1 change'
+                            : '${changes.length} changes',
+                        style: textTheme.labelLarge,
+                      ),
+                    ),
+                    Expanded(
+                      child: ScrollConfiguration(
+                        behavior: ScrollConfiguration.of(context)
+                            .copyWith(scrollbars: false),
+                        child: ListView.builder(
+                          key: const ValueKey('pdf-diff-list'),
+                          controller: _scroll,
+                          padding: EdgeInsets.only(
+                              right: barClearance, bottom: 8),
+                          itemCount: entries.length,
+                          itemBuilder: (context, i) {
+                            final entry = entries[i];
+                            if (entry.header != null) {
+                              return Padding(
+                                padding:
+                                    const EdgeInsets.fromLTRB(16, 10, 16, 2),
+                                child: Text('Page ${entry.header! + 1}',
+                                    style: textTheme.labelMedium?.copyWith(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .primary)),
+                              );
+                            }
+                            return _tile(context, entry.change!,
+                                changes[entry.change!]);
+                          },
+                        ),
+                      ),
+                    ),
+                  ]),
+                  Positioned(
+                    top: 0,
+                    bottom: 0,
+                    right:
+                        widget.resizable && widget.side == PdfSidebarSide.left
+                            ? PdfSidebarResizeGrip.width
+                            : 0,
+                    child: PdfScrollbar(
+                      scroll: _scroll,
+                      thumbKey: const ValueKey('pdf-diff-scrollbar-thumb'),
+                    ),
+                  ),
+                ]);
+              },
+            ),
+          ),
+        ),
+        if (widget.resizable)
+          Positioned(
+            top: 0,
+            bottom: 0,
+            left: widget.side == PdfSidebarSide.right ? 0 : null,
+            right: widget.side == PdfSidebarSide.left ? 0 : null,
+            child: PdfSidebarResizeGrip(
+              key: const ValueKey('pdf-diff-resize-grip'),
+              side: widget.side,
+              onWidthDelta: _onResizeDelta,
+              onResizeEnd: () {},
+            ),
+          ),
+      ]),
+    );
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/comparison/document_comparison.dart
+++ b/packages/dart_pdf_editor/lib/src/comparison/document_comparison.dart
@@ -1,0 +1,243 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'page_comparison.dart';
+
+/// How two documents' pages line up.
+enum PdfPagePairKind {
+  /// Both documents have the page (compared in place).
+  matched,
+
+  /// Only the after document has it (added).
+  inserted,
+
+  /// Only the before document had it (removed).
+  removed,
+}
+
+/// One aligned page pair.
+class PdfPagePair {
+  const PdfPagePair({this.beforeIndex, this.afterIndex});
+
+  /// Page index in the before document, or null when inserted.
+  final int? beforeIndex;
+
+  /// Page index in the after document, or null when removed.
+  final int? afterIndex;
+
+  PdfPagePairKind get kind => beforeIndex == null
+      ? PdfPagePairKind.inserted
+      : afterIndex == null
+          ? PdfPagePairKind.removed
+          : PdfPagePairKind.matched;
+}
+
+/// What a [PdfDiffChange] is.
+enum PdfDiffChangeKind { inserted, deleted, replaced, pageInserted, pageRemoved }
+
+/// A single navigation stop in the diff — a text hunk on a page, or a whole
+/// inserted/removed page. Carries the page-space bounds on each side so a
+/// side-by-side view can frame both panes and an overlay can frame one.
+class PdfDiffChange {
+  const PdfDiffChange({
+    required this.kind,
+    required this.label,
+    this.beforePage,
+    this.afterPage,
+    this.beforeBounds,
+    this.afterBounds,
+  });
+
+  final PdfDiffChangeKind kind;
+
+  /// A short description for the navigator list.
+  final String label;
+
+  final int? beforePage;
+  final int? afterPage;
+  final PdfRect? beforeBounds;
+  final PdfRect? afterBounds;
+
+  /// The page index to surface this change on in the after document (or the
+  /// before document for a pure removal).
+  int get displayPage => afterPage ?? beforePage ?? 0;
+}
+
+/// Drives a document comparison view: it pairs the two documents' pages,
+/// computes a word-level text diff per matched page (a [PdfTextDiff]), and
+/// exposes the resulting changes as an ordered, navigable list — the
+/// model behind the diff navigator panel.
+///
+/// v1 pairs pages by index: matched in the common range, trailing extra
+/// pages on either side become inserted/removed. Mid-document insertions
+/// therefore mis-align following pages — a documented limitation; a
+/// content-similarity pairing is the planned upgrade.
+///
+/// Pixel diffs (for the overlay mode and CAD-style drawings without text)
+/// are produced lazily through [pixelDiff]; they are not part of the
+/// navigator list, which is text- and structure-driven.
+class PdfComparisonController extends ChangeNotifier {
+  PdfComparisonController({
+    required this.before,
+    required this.after,
+    this.pixelRatio = 1.5,
+  });
+
+  final PdfDocument before;
+  final PdfDocument after;
+
+  /// Resolution the overlay pixel diffs render at.
+  final double pixelRatio;
+
+  late final List<PdfPagePair> pairs = _pairPages();
+
+  List<PdfDiffChange> _changes = const [];
+  bool _built = false;
+  int _current = -1;
+
+  /// The ordered change list. Empty until [build] runs.
+  List<PdfDiffChange> get changes => _changes;
+
+  /// Index into [changes] of the active stop, or -1.
+  int get currentChange => _current;
+
+  bool get hasChanges => _changes.isNotEmpty;
+
+  /// Computes the text- and structure-level change list. Synchronous (no
+  /// rasterization); interprets each matched page once per side. Idempotent.
+  void build() {
+    if (_built) return;
+    _built = true;
+    _changes = _buildChanges();
+    _current = _changes.isEmpty ? -1 : 0;
+    notifyListeners();
+  }
+
+  void goToChange(int index) {
+    if (index < 0 || index >= _changes.length) return;
+    _current = index;
+    notifyListeners();
+  }
+
+  void nextChange() {
+    if (_changes.isEmpty) return;
+    _current = (_current + 1) % _changes.length;
+    notifyListeners();
+  }
+
+  void previousChange() {
+    if (_changes.isEmpty) return;
+    _current = (_current - 1 + _changes.length) % _changes.length;
+    notifyListeners();
+  }
+
+  final Map<int, PdfPageDiff> _pixelCache = {};
+
+  /// The pixel diff for pair [pairIndex], rendered once and cached.
+  Future<PdfPageDiff> pixelDiff(int pairIndex) async {
+    final cached = _pixelCache[pairIndex];
+    if (cached != null) return cached;
+    final pair = pairs[pairIndex];
+    final diff = await PdfPageComparison.comparePages(
+      pair.beforeIndex == null ? null : before.page(pair.beforeIndex!),
+      pair.afterIndex == null ? null : after.page(pair.afterIndex!),
+      pixelRatio: pixelRatio,
+    );
+    _pixelCache[pairIndex] = diff;
+    return diff;
+  }
+
+  /// The pair index that displays after-document page [afterIndex], or -1.
+  int pairForAfterPage(int afterIndex) {
+    for (var i = 0; i < pairs.length; i++) {
+      if (pairs[i].afterIndex == afterIndex) return i;
+    }
+    return -1;
+  }
+
+  List<PdfPagePair> _pairPages() {
+    final n = before.pageCount;
+    final m = after.pageCount;
+    return [
+      for (var i = 0; i < math.max(n, m); i++)
+        PdfPagePair(
+          beforeIndex: i < n ? i : null,
+          afterIndex: i < m ? i : null,
+        ),
+    ];
+  }
+
+  List<PdfDiffChange> _buildChanges() {
+    final changes = <PdfDiffChange>[];
+    for (final pair in pairs) {
+      switch (pair.kind) {
+        case PdfPagePairKind.inserted:
+          changes.add(PdfDiffChange(
+            kind: PdfDiffChangeKind.pageInserted,
+            afterPage: pair.afterIndex,
+            label: 'Page ${pair.afterIndex! + 1} added',
+          ));
+        case PdfPagePairKind.removed:
+          changes.add(PdfDiffChange(
+            kind: PdfDiffChangeKind.pageRemoved,
+            beforePage: pair.beforeIndex,
+            label: 'Page ${pair.beforeIndex! + 1} removed',
+          ));
+        case PdfPagePairKind.matched:
+          final beforeText =
+              PdfTextExtractor.extract(before, pair.beforeIndex!);
+          final afterText = PdfTextExtractor.extract(after, pair.afterIndex!);
+          final diff = PdfTextDiff.between(beforeText, afterText);
+          for (final hunk in diff.hunks) {
+            changes.add(PdfDiffChange(
+              kind: hunk.isInsertion
+                  ? PdfDiffChangeKind.inserted
+                  : hunk.isDeletion
+                      ? PdfDiffChangeKind.deleted
+                      : PdfDiffChangeKind.replaced,
+              beforePage: pair.beforeIndex,
+              afterPage: pair.afterIndex,
+              beforeBounds: _unionTokens(hunk.before),
+              afterBounds: _unionTokens(hunk.after),
+              label: _hunkLabel(hunk),
+            ));
+          }
+      }
+    }
+    return changes;
+  }
+}
+
+PdfRect? _unionTokens(List<PdfTextToken> tokens) {
+  PdfRect? box;
+  for (final t in tokens) {
+    final b = t.bounds;
+    if (b == null) continue;
+    box = box == null
+        ? b
+        : PdfRect(
+            math.min(box.left, b.left),
+            math.min(box.bottom, b.bottom),
+            math.max(box.right, b.right),
+            math.max(box.top, b.top),
+          );
+  }
+  return box;
+}
+
+String _hunkLabel(PdfTextDiffHunk hunk) {
+  String text(List<PdfTextToken> tokens) =>
+      tokens.map((t) => t.text).join(' ');
+  if (hunk.isInsertion) return _cap(text(hunk.after));
+  if (hunk.isDeletion) return _cap(text(hunk.before));
+  return '${_cap(text(hunk.before))} → ${_cap(text(hunk.after))}';
+}
+
+String _cap(String s, {int max = 60}) {
+  final collapsed = s.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (collapsed.length <= max) return collapsed;
+  return '${collapsed.substring(0, max - 1)}…';
+}

--- a/packages/dart_pdf_editor/lib/src/comparison/page_comparison.dart
+++ b/packages/dart_pdf_editor/lib/src/comparison/page_comparison.dart
@@ -1,0 +1,388 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/painting.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import '../page_geometry.dart';
+import '../renderer.dart';
+
+/// How a diff map colors its pixels.
+enum PdfDiffStyle {
+  /// Differing pixels solid red, matching pixels keep the first image.
+  /// Used by the Ghent baseline-failure dump (red marks over the render).
+  redOverImage,
+
+  /// Differing pixels red on an otherwise white field — the changes alone,
+  /// easy to spot. Used by the PDF.js comparison gallery.
+  redOnWhite,
+
+  /// Before/after semantics for document comparison: content only in the
+  /// "before" page is red (removed), content only in the "after" page is
+  /// green (added), content that changed in place is amber, and unchanged
+  /// content is dimmed toward white so the changes stand out.
+  beforeAfter,
+}
+
+/// Default per-channel difference treated as identical, matching the
+/// Ghent/PDF.js harnesses.
+const int kPdfDiffChannelTolerance = 8;
+
+/// The pixel-level result of comparing two equal-size RGBA rasters.
+class PdfPixelDiff {
+  PdfPixelDiff({
+    required this.width,
+    required this.height,
+    required this.differingPixels,
+    required this.totalPixels,
+    required Uint8List diffMap,
+    required Uint8List changedMask,
+  })  : _diffMap = diffMap,
+        _changedMask = changedMask;
+
+  final int width;
+  final int height;
+  final int differingPixels;
+  final int totalPixels;
+
+  /// RGBA pixels of the colored diff (see [PdfDiffStyle]); 4 bytes/pixel.
+  final Uint8List _diffMap;
+
+  /// One byte per pixel: 1 where the pixel differs, 0 elsewhere.
+  final Uint8List _changedMask;
+
+  double get differenceFraction =>
+      totalPixels == 0 ? 0 : differingPixels / totalPixels;
+
+  bool get hasChanges => differingPixels > 0;
+
+  /// The raw RGBA bytes of the colored diff, for tests that assert the
+  /// palette without a Flutter image binding.
+  @visibleForTesting
+  Uint8List get debugDiffMap => _diffMap;
+
+  /// Decodes the colored diff into an image. The caller disposes it.
+  Future<ui.Image> toImage() => _imageFromRgba(_diffMap, width, height);
+
+  /// Bounding boxes (raster-pixel coordinates) of clusters of changed
+  /// pixels, top-to-bottom — the navigation stops a diff viewer steps
+  /// through. Coarse-grid clustered, so a handful of boxes cover a page.
+  List<Rect> changeRegions({int cellSize = 24}) =>
+      _clusterRegions(_changedMask, width, height, cellSize);
+}
+
+/// Compares rendered PDF pages and builds diff images.
+///
+/// Factors the pixel comparison the Ghent and PDF.js render tests use
+/// (per-channel tolerance + differing-pixel fraction + a colored diff map)
+/// into one place so the comparison feature and those suites share it.
+class PdfPageComparison {
+  PdfPageComparison._();
+
+  /// Compares two equal-size RGBA buffers (4 bytes/pixel, straight alpha).
+  ///
+  /// A pixel differs when the largest absolute per-channel difference over
+  /// R, G, B exceeds [channelTolerance].
+  static PdfPixelDiff comparePixels(
+    Uint8List before,
+    Uint8List after, {
+    required int width,
+    required int height,
+    int channelTolerance = kPdfDiffChannelTolerance,
+    PdfDiffStyle style = PdfDiffStyle.beforeAfter,
+  }) {
+    assert(before.length == after.length);
+    final n = before.length;
+    final diffMap = Uint8List(n);
+    final changed = Uint8List(n ~/ 4);
+    var differing = 0;
+    for (var i = 0, p = 0; i < n; i += 4, p++) {
+      var maxDiff = 0;
+      for (var c = 0; c < 3; c++) {
+        final d = (before[i + c] - after[i + c]).abs();
+        if (d > maxDiff) maxDiff = d;
+      }
+      final differs = maxDiff > channelTolerance;
+      if (differs) {
+        differing++;
+        changed[p] = 1;
+      }
+      switch (style) {
+        case PdfDiffStyle.redOverImage:
+          diffMap[i] = differs ? 255 : before[i];
+          diffMap[i + 1] = differs ? 0 : before[i + 1];
+          diffMap[i + 2] = differs ? 0 : before[i + 2];
+        case PdfDiffStyle.redOnWhite:
+          diffMap[i] = 255;
+          diffMap[i + 1] = differs ? 0 : 255;
+          diffMap[i + 2] = differs ? 0 : 255;
+        case PdfDiffStyle.beforeAfter:
+          if (!differs) {
+            // ghost the unchanged content: blend ~80% toward white
+            diffMap[i] = _dim(after[i]);
+            diffMap[i + 1] = _dim(after[i + 1]);
+            diffMap[i + 2] = _dim(after[i + 2]);
+          } else {
+            final beforeInk = _isInk(before, i);
+            final afterInk = _isInk(after, i);
+            int r, g, b;
+            if (beforeInk && !afterInk) {
+              (r, g, b) = (0xE5, 0x39, 0x35); // removed — red
+            } else if (afterInk && !beforeInk) {
+              (r, g, b) = (0x2E, 0x7D, 0x32); // added — green
+            } else {
+              (r, g, b) = (0xF5, 0x7C, 0x00); // changed — amber
+            }
+            diffMap[i] = r;
+            diffMap[i + 1] = g;
+            diffMap[i + 2] = b;
+          }
+      }
+      diffMap[i + 3] = 255;
+    }
+    return PdfPixelDiff(
+      width: width,
+      height: height,
+      differingPixels: differing,
+      totalPixels: n ~/ 4,
+      diffMap: diffMap,
+      changedMask: changed,
+    );
+  }
+
+  /// Compares two already-rendered page images. They need not be the same
+  /// size — each is padded (top-left) onto a shared canvas the size of the
+  /// larger, with the extra area treated as page background, so inserted or
+  /// removed content near an edge still registers.
+  static Future<PdfPixelDiff> compareImages(
+    ui.Image before,
+    ui.Image after, {
+    int channelTolerance = kPdfDiffChannelTolerance,
+    PdfDiffStyle style = PdfDiffStyle.beforeAfter,
+    Color background = const Color(0xFFFFFFFF),
+  }) async {
+    final width = math.max(before.width, after.width);
+    final height = math.max(before.height, after.height);
+    final a = await _paddedPixels(before, width, height, background);
+    final b = await _paddedPixels(after, width, height, background);
+    return comparePixels(a, b,
+        width: width,
+        height: height,
+        channelTolerance: channelTolerance,
+        style: style);
+  }
+
+  /// Renders both pages at [pixelRatio] (matched scale) and compares them.
+  static Future<PdfPageDiff> comparePages(
+    PdfPage? before,
+    PdfPage? after, {
+    double pixelRatio = 1.5,
+    int channelTolerance = kPdfDiffChannelTolerance,
+    PdfDiffStyle style = PdfDiffStyle.beforeAfter,
+    Color pageColor = const Color(0xFFFFFFFF),
+  }) async {
+    // An inserted or removed page compares against a blank of the other's
+    // size, so the whole page reads as added/removed.
+    final beforeImage = before == null
+        ? null
+        : await PdfPageRenderer.renderImage(before,
+            pixelRatio: pixelRatio, pageColor: pageColor);
+    final afterImage = after == null
+        ? null
+        : await PdfPageRenderer.renderImage(after,
+            pixelRatio: pixelRatio, pageColor: pageColor);
+    try {
+      final width = math.max(
+          beforeImage?.width ?? afterImage?.width ?? 1,
+          afterImage?.width ?? beforeImage?.width ?? 1);
+      final height = math.max(
+          beforeImage?.height ?? afterImage?.height ?? 1,
+          afterImage?.height ?? beforeImage?.height ?? 1);
+      final a = await _paddedPixels(beforeImage, width, height, pageColor);
+      final b = await _paddedPixels(afterImage, width, height, pageColor);
+      final pixels = comparePixels(a, b,
+          width: width,
+          height: height,
+          channelTolerance: channelTolerance,
+          style: style);
+
+      final regionsPixels = pixels.changeRegions();
+      return PdfPageDiff(
+        pixels: pixels,
+        pixelRatio: pixelRatio,
+        regionsBefore: before == null
+            ? const []
+            : _toPageRects(regionsPixels, before, pixelRatio),
+        regionsAfter: after == null
+            ? const []
+            : _toPageRects(regionsPixels, after, pixelRatio),
+      );
+    } finally {
+      beforeImage?.dispose();
+      afterImage?.dispose();
+    }
+  }
+}
+
+/// A page-pair comparison: the pixel diff plus the changed regions in each
+/// page's own PDF coordinate space, ready for `showRect` navigation.
+class PdfPageDiff {
+  const PdfPageDiff({
+    required this.pixels,
+    required this.pixelRatio,
+    required this.regionsBefore,
+    required this.regionsAfter,
+  });
+
+  final PdfPixelDiff pixels;
+  final double pixelRatio;
+
+  /// Changed regions on the before page, PDF page space.
+  final List<PdfRect> regionsBefore;
+
+  /// Changed regions on the after page, PDF page space.
+  final List<PdfRect> regionsAfter;
+
+  double get differenceFraction => pixels.differenceFraction;
+  bool get hasChanges => pixels.hasChanges;
+}
+
+int _dim(int v) => 204 + (v * 51 ~/ 255);
+
+bool _isInk(Uint8List px, int i) =>
+    px[i] < 250 || px[i + 1] < 250 || px[i + 2] < 250;
+
+/// Reads [image] into an RGBA buffer of [width]×[height], background-filled
+/// and the image copied into the top-left. When the image already matches
+/// the size this is a straight read.
+Future<Uint8List> _paddedPixels(
+    ui.Image? image, int width, int height, Color background) async {
+  final out = Uint8List(width * height * 4);
+  // fill with the opaque background
+  final br = (background.r * 255).round();
+  final bg = (background.g * 255).round();
+  final bb = (background.b * 255).round();
+  for (var i = 0; i < out.length; i += 4) {
+    out[i] = br;
+    out[i + 1] = bg;
+    out[i + 2] = bb;
+    out[i + 3] = 255;
+  }
+  if (image == null) return out;
+  final data =
+      await image.toByteData(format: ui.ImageByteFormat.rawStraightRgba);
+  if (data == null) return out;
+  final src = data.buffer.asUint8List();
+  if (image.width == width && image.height == height) return src;
+  for (var y = 0; y < image.height && y < height; y++) {
+    final srcRow = y * image.width * 4;
+    final dstRow = y * width * 4;
+    final rowBytes = math.min(image.width, width) * 4;
+    out.setRange(dstRow, dstRow + rowBytes, src, srcRow);
+  }
+  return out;
+}
+
+Future<ui.Image> _imageFromRgba(Uint8List rgba, int width, int height) async {
+  final buffer = await ui.ImmutableBuffer.fromUint8List(rgba);
+  final descriptor = ui.ImageDescriptor.raw(buffer,
+      width: width, height: height, pixelFormat: ui.PixelFormat.rgba8888);
+  final codec = await descriptor.instantiateCodec();
+  return (await codec.getNextFrame()).image;
+}
+
+List<PdfRect> _toPageRects(List<Rect> pixelRects, PdfPage page, double ratio) {
+  final size = PdfPageRenderer.pageSize(page);
+  final geometry = PdfPageGeometry(
+      cropBox: page.cropBox, rotation: page.rotation, viewSize: size);
+  final maxX = size.width * ratio;
+  final maxY = size.height * ratio;
+  final out = <PdfRect>[];
+  for (final r in pixelRects) {
+    final clamped = Rect.fromLTRB(
+      r.left.clamp(0.0, maxX),
+      r.top.clamp(0.0, maxY),
+      r.right.clamp(0.0, maxX),
+      r.bottom.clamp(0.0, maxY),
+    );
+    if (clamped.width <= 0 || clamped.height <= 0) continue;
+    // raster pixels → raster points (the geometry's view space at scale 1)
+    final viewRect = Rect.fromLTRB(clamped.left / ratio, clamped.top / ratio,
+        clamped.right / ratio, clamped.bottom / ratio);
+    out.add(geometry.toPageRect(viewRect));
+  }
+  return out;
+}
+
+/// Coarse connected-component clustering of the changed-pixel mask: bins
+/// pixels into [cellSize] cells, unions 4-connected occupied cells, and
+/// returns each component's bounding box in raster pixels.
+List<Rect> _clusterRegions(
+    Uint8List changed, int width, int height, int cellSize) {
+  if (width == 0 || height == 0) return const [];
+  final gw = (width + cellSize - 1) ~/ cellSize;
+  final gh = (height + cellSize - 1) ~/ cellSize;
+  final occ = List<bool>.filled(gw * gh, false);
+  for (var y = 0; y < height; y++) {
+    final row = y * width;
+    final cy = (y ~/ cellSize) * gw;
+    for (var x = 0; x < width; x++) {
+      if (changed[row + x] != 0) occ[cy + x ~/ cellSize] = true;
+    }
+  }
+  final parent = List<int>.generate(gw * gh, (i) => i);
+  int find(int a) {
+    while (parent[a] != a) {
+      parent[a] = parent[parent[a]];
+      a = parent[a];
+    }
+    return a;
+  }
+
+  void union(int a, int b) {
+    final ra = find(a), rb = find(b);
+    if (ra != rb) parent[ra] = rb;
+  }
+
+  for (var gy = 0; gy < gh; gy++) {
+    for (var gx = 0; gx < gw; gx++) {
+      final c = gy * gw + gx;
+      if (!occ[c]) continue;
+      if (gx + 1 < gw && occ[c + 1]) union(c, c + 1);
+      if (gy + 1 < gh && occ[c + gw]) union(c, c + gw);
+    }
+  }
+  final boxes = <int, List<int>>{}; // root -> [minGx, minGy, maxGx, maxGy]
+  for (var gy = 0; gy < gh; gy++) {
+    for (var gx = 0; gx < gw; gx++) {
+      final c = gy * gw + gx;
+      if (!occ[c]) continue;
+      final r = find(c);
+      final b = boxes[r];
+      if (b == null) {
+        boxes[r] = [gx, gy, gx, gy];
+      } else {
+        b[0] = math.min(b[0], gx);
+        b[1] = math.min(b[1], gy);
+        b[2] = math.max(b[2], gx);
+        b[3] = math.max(b[3], gy);
+      }
+    }
+  }
+  final rects = <Rect>[
+    for (final b in boxes.values)
+      Rect.fromLTRB(
+        (b[0] * cellSize).toDouble(),
+        (b[1] * cellSize).toDouble(),
+        math.min(width, (b[2] + 1) * cellSize).toDouble(),
+        math.min(height, (b[3] + 1) * cellSize).toDouble(),
+      )
+  ];
+  rects.sort((a, b) {
+    final c = a.top.compareTo(b.top);
+    return c != 0 ? c : a.left.compareTo(b.left);
+  });
+  return rects;
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -46,6 +46,27 @@ class PdfSearchResult {
   int get pageIndex => match.pageIndex;
 }
 
+/// A snapshot of a viewer's scroll position and zoom, for mirroring one
+/// [PdfViewer] onto another — the comparison view's synchronized panes.
+/// Read [PdfViewerController.viewSync], hand it to another controller's
+/// [PdfViewerController.applyViewSync].
+class PdfViewSync {
+  const PdfViewSync({
+    required this.scrollPixels,
+    required this.layoutZoom,
+    required this.transform,
+  });
+
+  /// Vertical scroll offset, in list pixels at the current [layoutZoom].
+  final double scrollPixels;
+
+  /// Zoom applied by laying pages out smaller (≤ fit-width).
+  final double layoutZoom;
+
+  /// The InteractiveViewer transform (zoom above fit-width plus pan).
+  final Matrix4 transform;
+}
+
 /// Drives a [PdfViewer] and reports its state: current page, zoom, and
 /// search results. Listeners fire on any change.
 class PdfViewerController extends ChangeNotifier {
@@ -142,6 +163,18 @@ class PdfViewerController extends ChangeNotifier {
   /// null while the page is entirely off-screen.
   Rect? visiblePageRegion(int pageIndex) =>
       _state?._visibleFractionOf(pageIndex);
+
+  /// A snapshot of the viewer's scroll position and zoom, for mirroring it
+  /// onto another viewer (the comparison view's synchronized panes). Null
+  /// when no viewer is attached. Pair with [applyViewSync], and listen to
+  /// [viewportChanges] to know when to re-read it.
+  PdfViewSync? get viewSync => _state?._captureViewSync();
+
+  /// Mirrors [sync] onto this viewer: matches its scroll offset and zoom.
+  /// Geometry-dependent — it assumes both viewers lay their pages out the
+  /// same way (the comparison view pairs documents with matching page
+  /// geometry). Guard against feedback loops at the call site.
+  void applyViewSync(PdfViewSync sync) => _state?._applyViewSync(sync);
 
   void _bumpViewport() {
     if (SchedulerBinding.instance.schedulerPhase ==
@@ -976,6 +1009,36 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
           .clamp(0.0, _scroll.position.maxScrollExtent);
       if ((target - _scroll.offset).abs() > 0.5) _scroll.jumpTo(target);
     });
+  }
+
+  PdfViewSync _captureViewSync() => PdfViewSync(
+        scrollPixels: _scroll.hasClients ? _scroll.position.pixels : 0,
+        layoutZoom: _layoutZoom,
+        transform: _transform.value.clone(),
+      );
+
+  void _applyViewSync(PdfViewSync sync) {
+    void applyScrollAndTransform() {
+      _transform.value = sync.transform.clone();
+      if (_scroll.hasClients) {
+        final target =
+            sync.scrollPixels.clamp(0.0, _scroll.position.maxScrollExtent);
+        if ((target - _scroll.position.pixels).abs() > 0.5) {
+          _scroll.jumpTo(target);
+        }
+      }
+    }
+
+    // A layout-zoom change relays the pages out, so the new scroll metrics
+    // only exist after the next frame.
+    if ((_layoutZoom - sync.layoutZoom).abs() > 1e-6) {
+      setState(() => _layoutZoom = sync.layoutZoom);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) applyScrollAndTransform();
+      });
+    } else {
+      applyScrollAndTransform();
+    }
   }
 
   void _onScroll() {

--- a/packages/dart_pdf_editor/test/comparison_test.dart
+++ b/packages/dart_pdf_editor/test/comparison_test.dart
@@ -1,0 +1,227 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+/// A one-page 612×792 PDF drawing each `(x, y, text)` line at 18pt
+/// Helvetica.
+Uint8List _textPdf(List<(int, int, String)> lines) {
+  final content = lines
+      .map((l) => 'BT /F1 18 Tf ${l.$1} ${l.$2} Td (${l.$3}) Tj ET')
+      .join('\n');
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R '
+        '/Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
+void main() {
+  group('comparePixels', () {
+    test('classifies removed, added, changed and unchanged pixels', () {
+      // Four pixels in a 4×1 row: unchanged-black, removed, added, changed.
+      final before = Uint8List.fromList([
+        0, 0, 0, 255, // unchanged ink
+        0, 0, 0, 255, // removed (after is white)
+        255, 255, 255, 255, // added (after is ink)
+        0, 0, 0, 255, // changed (after is red)
+      ]);
+      final after = Uint8List.fromList([
+        0, 0, 0, 255,
+        255, 255, 255, 255,
+        0, 0, 0, 255,
+        255, 0, 0, 255,
+      ]);
+      final diff = PdfPageComparison.comparePixels(before, after,
+          width: 4, height: 1, style: PdfDiffStyle.beforeAfter);
+
+      expect(diff.differingPixels, 3); // the unchanged pixel is not counted
+      expect(diff.differenceFraction, closeTo(0.75, 1e-9));
+
+      final map = diff.debugDiffMap;
+      (int, int, int) px(int i) => (map[i * 4], map[i * 4 + 1], map[i * 4 + 2]);
+      // unchanged ink → dimmed grey (not dropped, not colored)
+      expect(px(0), (204, 204, 204));
+      // removed → red
+      expect(px(1), (0xE5, 0x39, 0x35));
+      // added → green
+      expect(px(2), (0x2E, 0x7D, 0x32));
+      // changed in place → amber
+      expect(px(3), (0xF5, 0x7C, 0x00));
+    });
+
+    test('unchanged content is dimmed, not dropped', () {
+      final px = Uint8List.fromList([0, 0, 0, 255]); // black, both sides
+      final diff = PdfPageComparison.comparePixels(px, px,
+          width: 1, height: 1, style: PdfDiffStyle.beforeAfter);
+      expect(diff.differingPixels, 0);
+      expect(diff.hasChanges, isFalse);
+    });
+
+    test('redOnWhite matches the PDF.js diff convention', () {
+      final before = Uint8List.fromList([0, 0, 0, 255, 0, 0, 0, 255]);
+      final after = Uint8List.fromList([0, 0, 0, 255, 255, 255, 255, 255]);
+      final diff = PdfPageComparison.comparePixels(before, after,
+          width: 2, height: 1, style: PdfDiffStyle.redOnWhite);
+      expect(diff.differingPixels, 1);
+    });
+
+    test('clusters changed pixels into regions', () {
+      const w = 48, h = 48;
+      final before = Uint8List(w * h * 4);
+      final after = Uint8List(w * h * 4);
+      for (var i = 0; i < before.length; i++) {
+        before[i] = 255;
+        after[i] = 255;
+      }
+      // a single 12×12 changed block at (24,24)
+      for (var y = 24; y < 36; y++) {
+        for (var x = 24; x < 36; x++) {
+          final i = (y * w + x) * 4;
+          after[i] = 0;
+          after[i + 1] = 0;
+          after[i + 2] = 0;
+        }
+      }
+      final diff = PdfPageComparison.comparePixels(before, after,
+          width: w, height: h);
+      final regions = diff.changeRegions();
+      expect(regions, hasLength(1));
+      expect(regions.single.contains(const Offset(30, 30)), isTrue);
+      // the top-left quadrant (unchanged) is not covered
+      expect(regions.single.contains(const Offset(5, 5)), isFalse);
+    });
+  });
+
+  group('comparePages (rendered)', () {
+    testWidgets('flags the changed region and not the unchanged one',
+        (tester) async {
+      await tester.runAsync(() async {
+        await loadSystemFonts();
+        // A header near the top is identical; B adds a footer low down.
+        final a = PdfDocument.open(_textPdf([(72, 720, 'Header')]));
+        final b = PdfDocument.open(
+            _textPdf([(72, 720, 'Header'), (72, 100, 'Footer note')]));
+
+        final diff = await PdfPageComparison.comparePages(a.page(0), b.page(0),
+            pixelRatio: 1.5);
+        expect(diff.hasChanges, isTrue);
+        expect(diff.regionsAfter, isNotEmpty);
+
+        // Every change sits low on the page (the footer at y≈100), so no
+        // region reaches up to the unchanged header at y≈720.
+        for (final region in diff.regionsAfter) {
+          expect(region.top, lessThan(400),
+              reason: 'changes should be confined to the footer area');
+        }
+      });
+    });
+
+    testWidgets('identical pages report no changes', (tester) async {
+      await tester.runAsync(() async {
+        await loadSystemFonts();
+        final a = PdfDocument.open(_textPdf([(72, 720, 'Stable text')]));
+        final diff = await PdfPageComparison.comparePages(a.page(0), a.page(0),
+            pixelRatio: 1.5);
+        expect(diff.hasChanges, isFalse);
+        expect(diff.differenceFraction, 0);
+      });
+    });
+  });
+
+  group('PdfComparisonController', () {
+    test('lists the text change between two documents', () {
+      final controller = PdfComparisonController(
+        before: PdfDocument.open(_textPdf([(72, 720, 'the quick brown fox')])),
+        after: PdfDocument.open(_textPdf([(72, 720, 'the quick red fox')])),
+      )..build();
+
+      expect(controller.hasChanges, isTrue);
+      final replaced = controller.changes
+          .where((c) => c.kind == PdfDiffChangeKind.replaced)
+          .toList();
+      expect(replaced, isNotEmpty);
+      expect(replaced.first.label, contains('brown'));
+      expect(replaced.first.label, contains('red'));
+      expect(controller.currentChange, 0);
+    });
+
+    test('identical documents have no changes', () {
+      final controller = PdfComparisonController(
+        before: PdfDocument.open(_textPdf([(72, 720, 'same')])),
+        after: PdfDocument.open(_textPdf([(72, 720, 'same')])),
+      )..build();
+      expect(controller.hasChanges, isFalse);
+      expect(controller.currentChange, -1);
+    });
+
+    test('pairs an appended page as inserted', () {
+      final controller = PdfComparisonController(
+        before: PdfDocument.open(buildMultiPagePdf(2)),
+        after: PdfDocument.open(buildMultiPagePdf(3)),
+      )..build();
+
+      expect(controller.pairs, hasLength(3));
+      expect(controller.pairs[2].kind, PdfPagePairKind.inserted);
+      final inserted = controller.changes
+          .where((c) => c.kind == PdfDiffChangeKind.pageInserted)
+          .toList();
+      expect(inserted, hasLength(1));
+      expect(inserted.single.afterPage, 2);
+    });
+
+    test('pairs a removed trailing page as removed', () {
+      final controller = PdfComparisonController(
+        before: PdfDocument.open(buildMultiPagePdf(3)),
+        after: PdfDocument.open(buildMultiPagePdf(2)),
+      )..build();
+
+      expect(controller.pairs[2].kind, PdfPagePairKind.removed);
+      final removed = controller.changes
+          .where((c) => c.kind == PdfDiffChangeKind.pageRemoved)
+          .toList();
+      expect(removed, hasLength(1));
+      expect(removed.single.beforePage, 2);
+    });
+
+    test('navigation steps and wraps', () {
+      final controller = PdfComparisonController(
+        before: PdfDocument.open(_textPdf([(72, 720, 'one two three')])),
+        after: PdfDocument.open(_textPdf([(72, 720, 'ONE two THREE')])),
+      )..build();
+      expect(controller.changes.length, greaterThanOrEqualTo(2));
+
+      controller.goToChange(0);
+      controller.nextChange();
+      expect(controller.currentChange, 1);
+      controller.previousChange();
+      expect(controller.currentChange, 0);
+      controller.previousChange();
+      expect(controller.currentChange, controller.changes.length - 1);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/comparison_view_test.dart
+++ b/packages/dart_pdf_editor/test/comparison_view_test.dart
@@ -1,0 +1,111 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  testWidgets('view sync mirrors scroll position onto the other pane',
+      (tester) async {
+    final docBytes = buildMultiPagePdf(5);
+    final a = PdfViewerController();
+    final b = PdfViewerController();
+    addTearDown(a.dispose);
+    addTearDown(b.dispose);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Row(children: [
+          Expanded(
+            child: PdfViewer(
+              document: PdfDocument.open(docBytes),
+              controller: a,
+              initialFit: PdfViewerFit.width,
+            ),
+          ),
+          Expanded(
+            child: PdfViewer(
+              document: PdfDocument.open(docBytes),
+              controller: b,
+              initialFit: PdfViewerFit.width,
+            ),
+          ),
+        ]),
+      ),
+    ));
+    await tester.pump();
+
+    // Jump the first pane to a later page, then mirror it onto the second
+    // via the public sync snapshot — the primitive the comparison view's
+    // sync link applies on every scroll.
+    a.jumpToPage(3);
+    await tester.pumpAndSettle();
+    expect(a.currentPage, 3);
+
+    b.applyViewSync(a.viewSync!);
+    await tester.pumpAndSettle();
+    expect(b.currentPage, a.currentPage);
+  });
+
+  testWidgets('comparison view lists changes and toggles mode',
+      (tester) async {
+    final before = _textPdf('the quick brown fox');
+    final after = _textPdf('the quick red fox');
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfComparisonView(before: before, after: after),
+      ),
+    ));
+    // build() runs after the first frame and notifies the navigator.
+    await tester.pump();
+    await tester.pump();
+
+    // Both panes mount in side-by-side mode.
+    expect(find.byKey(const ValueKey('pdf-compare-before')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-compare-after')), findsOneWidget);
+
+    // The navigator lists the replaced text.
+    expect(find.byKey(const ValueKey('pdf-diff-change-0')), findsOneWidget);
+
+    // Switch to overlay mode — one pane only.
+    await tester.tap(find.text('Overlay'));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('pdf-compare-overlay')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-compare-before')), findsNothing);
+  });
+}
+
+/// A one-page 612×792 PDF drawing [text] at 72,720 in 18pt Helvetica.
+List<int> _bytes(String s) => s.codeUnits;
+
+Uint8List _textPdf(String text) {
+  final content = 'BT /F1 18 Tf 72 720 Td ($text) Tj ET';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R '
+        '/Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(_bytes(buffer.toString()));
+}

--- a/packages/dart_pdf_editor/test/ghent_render_test.dart
+++ b/packages/dart_pdf_editor/test/ghent_render_test.dart
@@ -155,25 +155,20 @@ Future<void> _checkBaseline({
             .buffer
             .asUint8List();
 
-    var differing = 0;
-    final diffMap = Uint8List(pixels.length);
-    for (var i = 0; i < pixels.length; i += 4) {
-      var maxDiff = 0;
-      for (var c = 0; c < 3; c++) {
-        final d = (pixels[i + c] - expectedPixels[i + c]).abs();
-        if (d > maxDiff) maxDiff = d;
-      }
-      final differs = maxDiff > _channelTolerance;
-      if (differs) differing++;
-      diffMap[i] = differs ? 255 : pixels[i];
-      diffMap[i + 1] = differs ? 0 : pixels[i + 1];
-      diffMap[i + 2] = differs ? 0 : pixels[i + 2];
-      diffMap[i + 3] = 255;
-    }
-    final fraction = differing / (pixels.length ~/ 4);
+    // Shared with the PDF.js suite and the comparison feature: differing
+    // pixels marked red over the actual render.
+    final diff = PdfPageComparison.comparePixels(
+      pixels,
+      expectedPixels,
+      width: image.width,
+      height: image.height,
+      channelTolerance: _channelTolerance,
+      style: PdfDiffStyle.redOverImage,
+    );
+    final fraction = diff.differenceFraction;
 
     if (fraction > _maxDifferingFraction) {
-      await _writeFailure(root, name, page, image, diffMap);
+      await _writeFailure(root, name, page, image, diff);
     }
     expect(fraction, lessThanOrEqualTo(_maxDifferingFraction),
         reason: '$name page $page deviates from the baseline in '
@@ -186,7 +181,7 @@ Future<void> _checkBaseline({
 }
 
 Future<void> _writeFailure(Directory root, String name, int page,
-    ui.Image actual, Uint8List diffMap) async {
+    ui.Image actual, PdfPixelDiff diff) async {
   final dir = Directory('${root.path}/_failures')..createSync(recursive: true);
   final flat = name.replaceAll('/', '_');
 
@@ -194,13 +189,7 @@ Future<void> _writeFailure(Directory root, String name, int page,
   File('${dir.path}/$flat.p$page.actual.png')
       .writeAsBytesSync(png!.buffer.asUint8List());
 
-  final buffer = await ui.ImmutableBuffer.fromUint8List(diffMap);
-  final descriptor = ui.ImageDescriptor.raw(buffer,
-      width: actual.width,
-      height: actual.height,
-      pixelFormat: ui.PixelFormat.rgba8888);
-  final codec = await descriptor.instantiateCodec();
-  final diffImage = (await codec.getNextFrame()).image;
+  final diffImage = await diff.toImage();
   final diffPng = await diffImage.toByteData(format: ui.ImageByteFormat.png);
   File('${dir.path}/$flat.p$page.diff.png')
       .writeAsBytesSync(diffPng!.buffer.asUint8List());

--- a/packages/dart_pdf_editor/test/pdfjs_render_test.dart
+++ b/packages/dart_pdf_editor/test/pdfjs_render_test.dart
@@ -15,7 +15,6 @@
 // tool/pdfjs_baseline, then set PDFJS_BASELINE_DIR. If PDFJS_RENDER_OUT is
 // omitted during comparison, test_corpora/pdfjs/_renders is used.
 import 'dart:io';
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -215,52 +214,23 @@ Future<_Comparison> _compareBaseline({
         (await expected.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!
             .buffer
             .asUint8List();
-    final diffMap = Uint8List(actualPixels.length);
-    var differing = 0;
-    for (var i = 0; i < actualPixels.length; i += 4) {
-      var maxDiff = 0;
-      for (var c = 0; c < 3; c++) {
-        final d = (actualPixels[i + c] - expectedPixels[i + c]).abs();
-        if (d > maxDiff) maxDiff = d;
-      }
-      final differs = maxDiff > channelTolerance;
-      if (differs) differing++;
-      // Render only the red diff over a blank white field — no base image,
-      // so the changed pixels are easy to spot.
-      diffMap[i] = 255;
-      diffMap[i + 1] = differs ? 0 : 255;
-      diffMap[i + 2] = differs ? 0 : 255;
-      diffMap[i + 3] = 255;
-    }
-
-    final diff = await _imageFromRgba(
-      diffMap,
+    // Shared with the Ghent suite and the comparison feature: the changes
+    // alone, red on a white field.
+    final diff = PdfPageComparison.comparePixels(
+      actualPixels,
+      expectedPixels,
       width: actual.width,
       height: actual.height,
+      channelTolerance: channelTolerance,
+      style: PdfDiffStyle.redOnWhite,
     );
     return _Comparison(
-      differenceFraction: differing / (actualPixels.length ~/ 4),
-      diff: diff,
+      differenceFraction: diff.differenceFraction,
+      diff: await diff.toImage(),
     );
   } finally {
     expected.dispose();
   }
-}
-
-Future<ui.Image> _imageFromRgba(
-  Uint8List rgba, {
-  required int width,
-  required int height,
-}) async {
-  final buffer = await ui.ImmutableBuffer.fromUint8List(rgba);
-  final descriptor = ui.ImageDescriptor.raw(
-    buffer,
-    width: width,
-    height: height,
-    pixelFormat: ui.PixelFormat.rgba8888,
-  );
-  final codec = await descriptor.instantiateCodec();
-  return (await codec.getNextFrame()).image;
 }
 
 class _Comparison {

--- a/packages/pdf_graphics/lib/pdf_graphics.dart
+++ b/packages/pdf_graphics/lib/pdf_graphics.dart
@@ -16,4 +16,5 @@ export 'src/shading.dart';
 export 'src/matrix.dart';
 export 'src/mesh.dart';
 export 'src/path.dart';
+export 'src/text_diff.dart';
 export 'src/text_extraction.dart';

--- a/packages/pdf_graphics/lib/src/text_diff.dart
+++ b/packages/pdf_graphics/lib/src/text_diff.dart
@@ -1,0 +1,267 @@
+import 'dart:math' as math;
+
+import 'package:pdf_document/pdf_document.dart';
+
+import 'text_extraction.dart';
+
+/// A whitespace-delimited token of page text, with the page-space box it
+/// covers — the unit a [PdfTextDiff] aligns and the bounds a viewer
+/// highlights when it flags the token as changed.
+class PdfTextToken {
+  const PdfTextToken({
+    required this.text,
+    required this.start,
+    required this.end,
+    required this.bounds,
+  });
+
+  /// The token's characters (no surrounding whitespace).
+  final String text;
+
+  /// Half-open `[start, end)` range into the owning [PdfPageText.text].
+  final int start;
+  final int end;
+
+  /// The axis-aligned page-space box covering the token, or null when the
+  /// page exposed no geometry for it (rare — empty/degenerate runs).
+  final PdfRect? bounds;
+}
+
+/// Splits a page's extracted text into word tokens (maximal runs of
+/// non-whitespace) with their page-space bounds.
+///
+/// Bounds come from [PdfPageText.rectsFor], unioned across the runs a
+/// token spans, so a token broken across positioned runs still gets one
+/// covering box.
+List<PdfTextToken> tokenizePageText(PdfPageText page) {
+  final tokens = <PdfTextToken>[];
+  final text = page.text;
+  final pattern = RegExp(r'\S+');
+  for (final match in pattern.allMatches(text)) {
+    final start = match.start;
+    final end = match.end;
+    tokens.add(PdfTextToken(
+      text: text.substring(start, end),
+      start: start,
+      end: end,
+      bounds: _union(page.rectsFor(start, end)),
+    ));
+  }
+  return tokens;
+}
+
+PdfRect? _union(List<PdfRect> rects) {
+  if (rects.isEmpty) return null;
+  var left = rects.first.left;
+  var bottom = rects.first.bottom;
+  var right = rects.first.right;
+  var top = rects.first.top;
+  for (final r in rects.skip(1)) {
+    left = math.min(left, r.left);
+    bottom = math.min(bottom, r.bottom);
+    right = math.max(right, r.right);
+    top = math.max(top, r.top);
+  }
+  return PdfRect(left, bottom, right, top);
+}
+
+/// What a [PdfTextDiffSegment] represents.
+enum PdfTextDiffKind {
+  /// Tokens present, unchanged, in both pages.
+  equal,
+
+  /// Tokens only in the "after" page (added).
+  inserted,
+
+  /// Tokens only in the "before" page (removed).
+  deleted,
+}
+
+/// One run of the alignment between two pages' token streams.
+class PdfTextDiffSegment {
+  const PdfTextDiffSegment({
+    required this.kind,
+    required this.before,
+    required this.after,
+  });
+
+  final PdfTextDiffKind kind;
+
+  /// Tokens from the "before" page ([PdfTextDiffKind.equal] and
+  /// [PdfTextDiffKind.deleted]); empty for inserts.
+  final List<PdfTextToken> before;
+
+  /// Tokens from the "after" page ([PdfTextDiffKind.equal] and
+  /// [PdfTextDiffKind.inserted]); empty for deletes.
+  final List<PdfTextToken> after;
+}
+
+/// A contiguous change — one or more adjacent non-[PdfTextDiffKind.equal]
+/// segments, the unit a diff navigator steps through. A pure replace is a
+/// delete next to an insert, so a hunk carries both [before] and [after]
+/// tokens.
+class PdfTextDiffHunk {
+  const PdfTextDiffHunk({required this.before, required this.after});
+
+  /// Removed/replaced tokens, on the before page.
+  final List<PdfTextToken> before;
+
+  /// Added/replacing tokens, on the after page.
+  final List<PdfTextToken> after;
+
+  bool get isInsertion => before.isEmpty;
+  bool get isDeletion => after.isEmpty;
+}
+
+/// A word-level diff of two pages' extracted text, computed as a longest
+/// common subsequence over their token streams (a standard sequence diff),
+/// with each changed token mapped back to its page-space bounds for
+/// highlight overlays.
+class PdfTextDiff {
+  const PdfTextDiff(this.segments);
+
+  /// The alignment, in document order, alternating equal/changed runs.
+  final List<PdfTextDiffSegment> segments;
+
+  /// Diffs the extracted text of two pages.
+  factory PdfTextDiff.between(PdfPageText before, PdfPageText after) =>
+      PdfTextDiff(_diffTokens(
+          tokenizePageText(before), tokenizePageText(after)));
+
+  /// Diffs page [index] of two documents directly.
+  static PdfTextDiff betweenPages(
+          PdfDocument before, PdfDocument after, int index) =>
+      PdfTextDiff.between(
+        PdfTextExtractor.extract(before, index),
+        PdfTextExtractor.extract(after, index),
+      );
+
+  bool get hasChanges =>
+      segments.any((s) => s.kind != PdfTextDiffKind.equal);
+
+  /// Tokens removed from the before page.
+  List<PdfTextToken> get deletedTokens => [
+        for (final s in segments)
+          if (s.kind == PdfTextDiffKind.deleted) ...s.before
+      ];
+
+  /// Tokens added to the after page.
+  List<PdfTextToken> get insertedTokens => [
+        for (final s in segments)
+          if (s.kind == PdfTextDiffKind.inserted) ...s.after
+      ];
+
+  /// The changes grouped into contiguous hunks — adjacent delete/insert
+  /// segments merge so a replacement is one navigation stop, not two.
+  List<PdfTextDiffHunk> get hunks {
+    final hunks = <PdfTextDiffHunk>[];
+    final before = <PdfTextToken>[];
+    final after = <PdfTextToken>[];
+    void flush() {
+      if (before.isEmpty && after.isEmpty) return;
+      hunks.add(PdfTextDiffHunk(
+          before: List.of(before), after: List.of(after)));
+      before.clear();
+      after.clear();
+    }
+
+    for (final s in segments) {
+      if (s.kind == PdfTextDiffKind.equal) {
+        flush();
+      } else {
+        before.addAll(s.before);
+        after.addAll(s.after);
+      }
+    }
+    flush();
+    return hunks;
+  }
+}
+
+List<PdfTextDiffSegment> _diffTokens(
+    List<PdfTextToken> a, List<PdfTextToken> b) {
+  final n = a.length;
+  final m = b.length;
+  if (n == 0 && m == 0) return const [];
+
+  // LCS length table over token text equality.
+  final lcs = List.generate(n + 1, (_) => List<int>.filled(m + 1, 0));
+  for (var i = n - 1; i >= 0; i--) {
+    for (var j = m - 1; j >= 0; j--) {
+      if (a[i].text == b[j].text) {
+        lcs[i][j] = lcs[i + 1][j + 1] + 1;
+      } else {
+        lcs[i][j] = math.max(lcs[i + 1][j], lcs[i][j + 1]);
+      }
+    }
+  }
+
+  final segments = <PdfTextDiffSegment>[];
+  // Coalesce consecutive ops of the same kind into one segment.
+  final equalBefore = <PdfTextToken>[];
+  final equalAfter = <PdfTextToken>[];
+  final deleted = <PdfTextToken>[];
+  final inserted = <PdfTextToken>[];
+
+  void flushEqual() {
+    if (equalBefore.isEmpty) return;
+    segments.add(PdfTextDiffSegment(
+      kind: PdfTextDiffKind.equal,
+      before: List.of(equalBefore),
+      after: List.of(equalAfter),
+    ));
+    equalBefore.clear();
+    equalAfter.clear();
+  }
+
+  void flushChanges() {
+    if (deleted.isNotEmpty) {
+      segments.add(PdfTextDiffSegment(
+        kind: PdfTextDiffKind.deleted,
+        before: List.of(deleted),
+        after: const [],
+      ));
+      deleted.clear();
+    }
+    if (inserted.isNotEmpty) {
+      segments.add(PdfTextDiffSegment(
+        kind: PdfTextDiffKind.inserted,
+        before: const [],
+        after: List.of(inserted),
+      ));
+      inserted.clear();
+    }
+  }
+
+  var i = 0, j = 0;
+  while (i < n && j < m) {
+    if (a[i].text == b[j].text) {
+      flushChanges();
+      equalBefore.add(a[i]);
+      equalAfter.add(b[j]);
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      flushEqual();
+      deleted.add(a[i]);
+      i++;
+    } else {
+      flushEqual();
+      inserted.add(b[j]);
+      j++;
+    }
+  }
+  while (i < n) {
+    flushEqual();
+    deleted.add(a[i]);
+    i++;
+  }
+  while (j < m) {
+    flushEqual();
+    inserted.add(b[j]);
+    j++;
+  }
+  flushEqual();
+  flushChanges();
+  return segments;
+}

--- a/packages/pdf_graphics/test/text_diff_test.dart
+++ b/packages/pdf_graphics/test/text_diff_test.dart
@@ -1,0 +1,111 @@
+import 'dart:typed_data';
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+/// A one-page 612×792 PDF drawing each `(x, y, text)` line at 18pt
+/// Helvetica.
+Uint8List _textPdf(List<(int, int, String)> lines) {
+  final content = lines
+      .map((l) => 'BT /F1 18 Tf ${l.$1} ${l.$2} Td (${l.$3}) Tj ET')
+      .join('\n');
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R '
+        '/Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
+PdfPageText _text(List<(int, int, String)> lines) =>
+    PdfTextExtractor.extract(PdfDocument.open(_textPdf(lines)), 0);
+
+void main() {
+  test('tokenizes page text into words with bounds', () {
+    final tokens =
+        tokenizePageText(_text([(72, 720, 'the quick brown fox')]));
+    expect(tokens.map((t) => t.text), ['the', 'quick', 'brown', 'fox']);
+    for (final token in tokens) {
+      expect(token.bounds, isNotNull,
+          reason: 'every token should carry page-space bounds');
+    }
+    // bounds advance left-to-right across the line
+    expect(tokens[0].bounds!.left, lessThan(tokens[3].bounds!.left));
+  });
+
+  test('detects a replaced word, leaving the rest equal', () {
+    final before = _text([(72, 720, 'the quick brown fox')]);
+    final after = _text([(72, 720, 'the quick red fox')]);
+    final diff = PdfTextDiff.between(before, after);
+
+    expect(diff.hasChanges, isTrue);
+    expect(diff.deletedTokens.map((t) => t.text), ['brown']);
+    expect(diff.insertedTokens.map((t) => t.text), ['red']);
+
+    // 'the', 'quick' and 'fox' are unchanged — never flagged.
+    final changed = {
+      ...diff.deletedTokens.map((t) => t.text),
+      ...diff.insertedTokens.map((t) => t.text),
+    };
+    expect(changed, isNot(contains('the')));
+    expect(changed, isNot(contains('quick')));
+    expect(changed, isNot(contains('fox')));
+
+    // The replace is one hunk carrying both sides.
+    expect(diff.hunks, hasLength(1));
+    expect(diff.hunks.single.before.map((t) => t.text), ['brown']);
+    expect(diff.hunks.single.after.map((t) => t.text), ['red']);
+    expect(diff.hunks.single.isInsertion, isFalse);
+    expect(diff.hunks.single.isDeletion, isFalse);
+  });
+
+  test('detects a pure insertion', () {
+    final before = _text([(72, 720, 'alpha gamma')]);
+    final after = _text([(72, 720, 'alpha beta gamma')]);
+    final diff = PdfTextDiff.between(before, after);
+
+    expect(diff.deletedTokens, isEmpty);
+    expect(diff.insertedTokens.map((t) => t.text), ['beta']);
+    expect(diff.hunks.single.isInsertion, isTrue);
+  });
+
+  test('detects a pure deletion', () {
+    final before = _text([(72, 720, 'alpha beta gamma')]);
+    final after = _text([(72, 720, 'alpha gamma')]);
+    final diff = PdfTextDiff.between(before, after);
+
+    expect(diff.insertedTokens, isEmpty);
+    expect(diff.deletedTokens.map((t) => t.text), ['beta']);
+    expect(diff.hunks.single.isDeletion, isTrue);
+  });
+
+  test('identical pages report no changes', () {
+    final diff = PdfTextDiff.between(
+      _text([(72, 720, 'same text here')]),
+      _text([(72, 720, 'same text here')]),
+    );
+    expect(diff.hasChanges, isFalse);
+    expect(diff.hunks, isEmpty);
+  });
+}


### PR DESCRIPTION
Implements feature #4 — compare two PDF documents and present the differences as a visual (pixel) overlay and a text diff, in a synchronized comparison UI.

## Rendering / diff core

- **`PdfPageComparison`** (`dart_pdf_editor`) factors the pixel-compare that the Ghent and PDF.js render harnesses previously duplicated into one reusable API: per-channel tolerance, differing-pixel fraction, and a colored diff map. `PdfDiffStyle` picks the coloring:
  - `redOverImage` — Ghent baseline-failure dump
  - `redOnWhite` — PDF.js comparison gallery
  - `beforeAfter` — document comparison: **removed = red, added = green, changed = amber, unchanged = dimmed**
  - `comparePages` renders both pages at a matched scale (padding mismatched sizes), and coarse-grid connected-component clustering turns changed pixels into navigable regions, mapped back into each page's PDF space via `PdfPageGeometry`.
- **`PdfTextDiff`** (`pdf_graphics`, pure Dart) tokenizes two pages' extracted text and aligns the token streams with an **LCS sequence diff**, mapping each changed token back to its page-space bounds; adjacent edits coalesce into hunks.
- **`PdfComparisonController`** pairs pages **by index** (trailing extras read as inserted/removed — mid-document insertion is a documented v1 limitation, content-similarity pairing is the planned upgrade), builds a synchronous text/structure change list, and produces lazy per-page pixel diffs for the overlay.

## UI

- **`PdfComparisonView`** — synchronized **side-by-side** panes *and* an **overlay** pane (the diff composited over the after page), with a mode toggle.
- **`PdfDiffNavigatorPanel`** — a next/prev change list mirroring `PdfSearchResultsPanel`'s dock/resize/scrollbar shape.
- **Synchronized scroll/zoom** — new public `PdfViewerController.viewSync` / `applyViewSync` snapshot and mirror scroll + zoom; the view's sync link fans every scroll, wheel, drag, **and pinch** from one pane onto the other (pinch rides the existing `_zoomTo` → `viewportChanges` path, so no recognizer fork is needed).

## Shared, not forked

The Ghent and PDF.js suites now call the shared `comparePixels` with identical differing-pixel semantics, so their pass/fail behavior is unchanged.

## Tests

- `pdf_graphics/test/text_diff_test.dart` — tokenization + bounds, replace/insert/delete detection, unchanged tokens ignored.
- `dart_pdf_editor/test/comparison_test.dart` — palette classification, region clustering, rendered golden-ish diff (changed region flagged, unchanged not), identical-page no-op, LCS change listing, page insert/delete pairing, navigation wrap.
- `dart_pdf_editor/test/comparison_view_test.dart` — scroll-sync mirroring and the view's mode toggle / change list.

`fvm dart analyze` is clean across the workspace; the new test files pass locally.

https://claude.ai/code/session_01VB3T1Tvks62knVJ5NJJThx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VB3T1Tvks62knVJ5NJJThx)_