### PR TITLE
Full PDF Table 176 line-ending vocabulary + start/end picker

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -450,6 +450,19 @@ class PdfEditingController extends ChangeNotifier {
 
   set dashedStroke(bool value) => preferences.dashedStroke = value;
 
+  /// The line ending new /Line and /PolyLine annotations carry at their
+  /// start vertex (§12.5.6.7). Persisted.
+  PdfLineEnding get lineStartEnding => preferences.lineStartEnding;
+
+  set lineStartEnding(PdfLineEnding value) =>
+      preferences.lineStartEnding = value;
+
+  /// The line ending new /Line and /PolyLine annotations carry at their
+  /// end vertex (§12.5.6.7). Persisted.
+  PdfLineEnding get lineEndEnding => preferences.lineEndEnding;
+
+  set lineEndEnding(PdfLineEnding value) => preferences.lineEndEnding = value;
+
   /// The background fill new text boxes get, or null for none (the
   /// default — a bare text box, like before). Persisted.
   Color? get textFillColor => preferences.textFillColor;
@@ -752,6 +765,10 @@ class PdfEditingController extends ChangeNotifier {
           author: author),
       pages: [pageIndex]);
 
+  /// Adds a line from [start] to [end]. With [arrow] the end carries a
+  /// closed arrowhead (the dedicated arrow tool); otherwise the start and
+  /// end endings come from the persisted [PdfEditingPreferences]
+  /// ([lineStartEnding] / [lineEndEnding]).
   void addLine(int pageIndex, (double, double) start, (double, double) end,
           {bool arrow = false}) =>
       apply(
@@ -760,7 +777,11 @@ class PdfEditingController extends ChangeNotifier {
               strokeWidth: preferences.strokeWidth,
               opacity: preferences.opacity,
               dashed: preferences.dashedStroke,
-              endEnding: arrow ? PdfLineEnding.closedArrow : PdfLineEnding.none,
+              startEnding:
+                  arrow ? PdfLineEnding.none : preferences.lineStartEnding,
+              endEnding: arrow
+                  ? PdfLineEnding.closedArrow
+                  : preferences.lineEndEnding,
               author: author),
           pages: [pageIndex]);
 
@@ -770,6 +791,8 @@ class PdfEditingController extends ChangeNotifier {
           strokeWidth: preferences.strokeWidth,
           opacity: preferences.opacity,
           dashed: preferences.dashedStroke,
+          startEnding: preferences.lineStartEnding,
+          endEnding: preferences.lineEndEnding,
           author: author),
       pages: [pageIndex]);
 
@@ -1704,6 +1727,39 @@ class PdfEditingController extends ChangeNotifier {
       return;
     }
     apply((e) => e.reshapeLineAnnotation(_selected.last.$1, annotation, points),
+        pages: [_selected.last.$1]);
+  }
+
+  /// Whether the single selected annotation is a /Line or /PolyLine whose
+  /// endings can be set ([setSelectedLineEndings]).
+  bool get canSetLineEndings {
+    final annotation = selectedAnnotation;
+    return _selected.length == 1 &&
+        annotation != null &&
+        (annotation.subtype == 'Line' || annotation.subtype == 'PolyLine') &&
+        annotation.normalAppearance != null;
+  }
+
+  /// The start/end line endings of the selected /Line or /PolyLine, or
+  /// null when no such single annotation is selected — for the ending
+  /// picker to show.
+  (PdfLineEnding, PdfLineEnding)? get selectedLineEndings {
+    final annotation = selectedAnnotation;
+    if (annotation == null || _selected.length != 1) return null;
+    return pdfLineEndings(annotation);
+  }
+
+  /// Swaps the start and/or end ending of the selected /Line or
+  /// /PolyLine in place — one revision, one undo, and the annotation
+  /// keeps its /Annots slot and object number. Pass null for an axis to
+  /// leave it unchanged.
+  void setSelectedLineEndings(
+      {PdfLineEnding? start, PdfLineEnding? end}) {
+    final annotation = selectedAnnotation;
+    if (annotation == null || !canSetLineEndings) return;
+    apply(
+        (e) => e.setLineEndings(_selected.last.$1, annotation,
+            startEnding: start, endEnding: end),
         pages: [_selected.last.$1]);
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -3,7 +3,8 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter/painting.dart';
-import 'package:pdf_document/pdf_document.dart' show PdfStandardFont;
+import 'package:pdf_document/pdf_document.dart'
+    show PdfLineEnding, PdfStandardFont;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'editing_color_picker.dart' show PdfColorFormat;
@@ -50,6 +51,8 @@ class PdfEditingPreferences extends ChangeNotifier {
   PdfStandardFont _fontFamily = PdfStandardFont.helvetica;
   double _opacity = 1;
   bool _dashedStroke = false;
+  PdfLineEnding _lineStartEnding = PdfLineEnding.none;
+  PdfLineEnding _lineEndEnding = PdfLineEnding.none;
   bool _fingerDrawsInk = true;
   bool _showThumbnailSidebar = true;
   bool _hasShowThumbnailSidebarPreference = false;
@@ -94,6 +97,16 @@ class PdfEditingPreferences extends ChangeNotifier {
       }
       _opacity = store.getDouble('${_prefix}opacity') ?? _opacity;
       _dashedStroke = store.getBool('${_prefix}dashedStroke') ?? _dashedStroke;
+      final lineStart = store.getString('${_prefix}lineStartEnding');
+      if (lineStart != null) {
+        _lineStartEnding =
+            PdfLineEnding.values.asNameMap()[lineStart] ?? _lineStartEnding;
+      }
+      final lineEnd = store.getString('${_prefix}lineEndEnding');
+      if (lineEnd != null) {
+        _lineEndEnding =
+            PdfLineEnding.values.asNameMap()[lineEnd] ?? _lineEndEnding;
+      }
       _fingerDrawsInk =
           store.getBool('${_prefix}fingerDrawsInk') ?? _fingerDrawsInk;
       const thumbnailSidebarKey = '${_prefix}showThumbnailSidebar';
@@ -235,6 +248,28 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _dashedStroke) return;
     _dashedStroke = value;
     _write((s) => s.setBool('${_prefix}dashedStroke', value));
+    notifyListeners();
+  }
+
+  /// The line ending drawn at the *start* of new /Line and /PolyLine
+  /// annotations (§12.5.6.7). Defaults to [PdfLineEnding.none].
+  PdfLineEnding get lineStartEnding => _lineStartEnding;
+
+  set lineStartEnding(PdfLineEnding value) {
+    if (value == _lineStartEnding) return;
+    _lineStartEnding = value;
+    _write((s) => s.setString('${_prefix}lineStartEnding', value.name));
+    notifyListeners();
+  }
+
+  /// The line ending drawn at the *end* of new /Line and /PolyLine
+  /// annotations (§12.5.6.7). Defaults to [PdfLineEnding.none].
+  PdfLineEnding get lineEndEnding => _lineEndEnding;
+
+  set lineEndEnding(PdfLineEnding value) {
+    if (value == _lineEndEnding) return;
+    _lineEndEnding = value;
+    _write((s) => s.setString('${_prefix}lineEndEnding', value.name));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -2,7 +2,8 @@ import 'dart:typed_data';
 
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
-import 'package:pdf_document/pdf_document.dart' show PdfStandardFont;
+import 'package:pdf_document/pdf_document.dart'
+    show PdfLineEnding, PdfStandardFont;
 
 import '../pdf_viewer.dart';
 import 'editing_color_picker.dart';
@@ -649,6 +650,72 @@ class _StyleMenuState extends State<_StyleMenu> {
     );
   }
 
+  /// A short human label for a line ending in the picker.
+  static String _endingLabel(PdfLineEnding ending) => switch (ending) {
+        PdfLineEnding.none => 'None',
+        PdfLineEnding.square => 'Square',
+        PdfLineEnding.circle => 'Circle',
+        PdfLineEnding.diamond => 'Diamond',
+        PdfLineEnding.openArrow => 'Open arrow',
+        PdfLineEnding.closedArrow => 'Closed arrow',
+        PdfLineEnding.butt => 'Butt',
+        PdfLineEnding.rOpenArrow => 'Open arrow (rev.)',
+        PdfLineEnding.rClosedArrow => 'Closed arrow (rev.)',
+        PdfLineEnding.slash => 'Slash',
+      };
+
+  /// One line-ending dropdown (start or end), each item previewed with a
+  /// tiny icon of the shape on a short segment. [atEnd] orients the
+  /// preview so the start picker draws its ending on the left.
+  Widget _lineEndingRow({
+    required BuildContext context,
+    required String label,
+    required String keyValue,
+    required bool atEnd,
+    required PdfLineEnding value,
+    required ValueChanged<PdfLineEnding> onChanged,
+  }) {
+    final color = Theme.of(context).colorScheme.onSurface;
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(children: [
+        SizedBox(width: 86, child: Text(label)),
+        Expanded(
+          child: DropdownButton<PdfLineEnding>(
+            key: ValueKey(keyValue),
+            isExpanded: true,
+            isDense: true,
+            value: value,
+            items: [
+              for (final ending in PdfLineEnding.values)
+                DropdownMenuItem(
+                  value: ending,
+                  child: Row(children: [
+                    SizedBox(
+                      width: 36,
+                      height: 14,
+                      child: CustomPaint(
+                        painter: _LineEndingPainter(ending,
+                            atEnd: atEnd, color: color),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Flexible(
+                      child: Text(_endingLabel(ending),
+                          overflow: TextOverflow.ellipsis),
+                    ),
+                  ]),
+                ),
+            ],
+            onChanged: (ending) {
+              if (ending != null) onChanged(ending);
+            },
+          ),
+        ),
+      ]),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return MenuAnchor(
@@ -672,6 +739,15 @@ class _StyleMenuState extends State<_StyleMenu> {
                 controller.opacity;
             // with a free text selected the rows show its own box style;
             // otherwise the creation defaults
+            // line endings: edit a selected /Line or /PolyLine in place,
+            // else set the creation defaults while a line tool is armed
+            final lineEndingTarget = controller.canSetLineEndings;
+            final showLineEndings = lineEndingTarget ||
+                controller.tool == PdfEditTool.line ||
+                controller.tool == PdfEditTool.polyline;
+            final lineEndings = lineEndingTarget
+                ? controller.selectedLineEndings!
+                : (controller.lineStartEnding, controller.lineEndEnding);
             final restyling = controller.canRestyleSelectedText;
             final boxStyle =
                 restyling ? controller.selectedAnnotation?.freeTextStyle : null;
@@ -749,6 +825,34 @@ class _StyleMenuState extends State<_StyleMenu> {
                       value: controller.dashedStroke,
                       onChanged: (value) => controller.dashedStroke = value,
                     ),
+                  if (showLineEndings) ...[
+                    _lineEndingRow(
+                      context: context,
+                      label: 'Line start',
+                      keyValue: 'pdf-line-start-ending',
+                      atEnd: false,
+                      value: lineEndings.$1,
+                      onChanged: (ending) {
+                        controller.lineStartEnding = ending;
+                        if (controller.canSetLineEndings) {
+                          controller.setSelectedLineEndings(start: ending);
+                        }
+                      },
+                    ),
+                    _lineEndingRow(
+                      context: context,
+                      label: 'Line end',
+                      keyValue: 'pdf-line-end-ending',
+                      atEnd: true,
+                      value: lineEndings.$2,
+                      onChanged: (ending) {
+                        controller.lineEndEnding = ending;
+                        if (controller.canSetLineEndings) {
+                          controller.setSelectedLineEndings(end: ending);
+                        }
+                      },
+                    ),
+                  ],
                   _slider(
                     label: 'Font size',
                     value: _draggingFontSize ??
@@ -862,6 +966,93 @@ class _StyleMenuState extends State<_StyleMenu> {
 }
 
 /// The "no color" swatch's red diagonal slash.
+/// Draws a short segment with [ending] rendered at one end — the preview
+/// icon for the line-ending dropdown. Purely indicative geometry (not the
+/// exact appearance the editor generates), oriented so [atEnd] puts the
+/// ending on the right.
+class _LineEndingPainter extends CustomPainter {
+  const _LineEndingPainter(this.ending, {required this.atEnd, required this.color});
+
+  final PdfLineEnding ending;
+  final bool atEnd;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final stroke = Paint()
+      ..color = color
+      ..strokeWidth = 1.2
+      ..strokeCap = StrokeCap.round
+      ..style = PaintingStyle.stroke;
+    final fill = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+    final cy = size.height / 2;
+    // the tip is the end the shape decorates; the line runs to the far side
+    final tipX = atEnd ? size.width - 2.0 : 2.0;
+    final farX = atEnd ? 2.0 : size.width - 2.0;
+    // unit vector from tip back along the line, and the perpendicular
+    final ux = farX > tipX ? 1.0 : -1.0;
+    final tip = Offset(tipX, cy);
+    canvas.drawLine(Offset(farX, cy), tip, stroke);
+    const s = 6.0; // characteristic size in preview px
+    Offset at(double along, double across) =>
+        Offset(tip.dx + ux * along, cy + across);
+    switch (ending) {
+      case PdfLineEnding.none:
+        break;
+      case PdfLineEnding.closedArrow:
+      case PdfLineEnding.openArrow:
+        final path = Path()
+          ..moveTo(at(s, -s * 0.4).dx, at(s, -s * 0.4).dy)
+          ..lineTo(tip.dx, tip.dy)
+          ..lineTo(at(s, s * 0.4).dx, at(s, s * 0.4).dy);
+        if (ending == PdfLineEnding.closedArrow) {
+          path.close();
+          canvas.drawPath(path, fill);
+        } else {
+          canvas.drawPath(path, stroke);
+        }
+      case PdfLineEnding.rClosedArrow:
+      case PdfLineEnding.rOpenArrow:
+        final path = Path()
+          ..moveTo(at(0, -s * 0.4).dx, at(0, -s * 0.4).dy)
+          ..lineTo(at(s, 0).dx, at(s, 0).dy)
+          ..lineTo(at(0, s * 0.4).dx, at(0, s * 0.4).dy);
+        if (ending == PdfLineEnding.rClosedArrow) {
+          path.close();
+          canvas.drawPath(path, fill);
+        } else {
+          canvas.drawPath(path, stroke);
+        }
+      case PdfLineEnding.diamond:
+        final path = Path()
+          ..moveTo(at(s * 0.5, 0).dx, at(s * 0.5, 0).dy)
+          ..lineTo(at(0, -s * 0.5).dx, at(0, -s * 0.5).dy)
+          ..lineTo(at(-s * 0.5, 0).dx, at(-s * 0.5, 0).dy)
+          ..lineTo(at(0, s * 0.5).dx, at(0, s * 0.5).dy)
+          ..close();
+        canvas.drawPath(path, fill);
+      case PdfLineEnding.square:
+        canvas.drawRect(
+            Rect.fromCenter(center: tip, width: s, height: s), fill);
+      case PdfLineEnding.circle:
+        canvas.drawCircle(tip, s * 0.5, fill);
+      case PdfLineEnding.butt:
+        canvas.drawLine(at(0, -s * 0.5), at(0, s * 0.5), stroke);
+      case PdfLineEnding.slash:
+        canvas.drawLine(
+            Offset(tip.dx - s * 0.3, cy + s * 0.5),
+            Offset(tip.dx + s * 0.3, cy - s * 0.5),
+            stroke);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_LineEndingPainter old) =>
+      old.ending != ending || old.atEnd != atEnd || old.color != color;
+}
+
 class _NoneSlashPainter extends CustomPainter {
   const _NoneSlashPainter();
 

--- a/packages/dart_pdf_editor/test/editing_line_endings_test.dart
+++ b/packages/dart_pdf_editor/test/editing_line_endings_test.dart
@@ -1,0 +1,152 @@
+// Line-ending picker: the controller threads the persisted start/end
+// endings into new lines and polylines, and restyles a selected
+// /Line or /PolyLine's endings in place. The toolbar's _StyleMenu exposes
+// two dropdowns while a line tool is armed or a line is selected.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('controller line endings', () {
+    test('new lines and polylines use the persisted endings', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..lineStartEnding = PdfLineEnding.circle
+        ..lineEndEnding = PdfLineEnding.closedArrow;
+      addTearDown(editing.dispose);
+
+      editing.addLine(0, (100, 100), (220, 160));
+      editing.addPolyLine(0, [(100, 220), (150, 260), (220, 230)]);
+
+      final line = editing.document.page(0).annotations[0];
+      final poly = editing.document.page(0).annotations[1];
+      expect(pdfLineEndings(line),
+          (PdfLineEnding.circle, PdfLineEnding.closedArrow));
+      expect(pdfLineEndings(poly),
+          (PdfLineEnding.circle, PdfLineEnding.closedArrow));
+    });
+
+    test('the arrow tool still forces a closed arrow at the end', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..lineStartEnding = PdfLineEnding.diamond
+        ..lineEndEnding = PdfLineEnding.none;
+      addTearDown(editing.dispose);
+
+      editing.addLine(0, (100, 100), (220, 160), arrow: true);
+      expect(pdfLineEndings(editing.document.page(0).annotations.single),
+          (PdfLineEnding.none, PdfLineEnding.closedArrow));
+    });
+
+    test('setSelectedLineEndings restyles in place, keeping the slot', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addLine(0, (100, 100), (220, 160))
+        ..addLine(0, (100, 240), (220, 300))
+        ..tool = PdfEditTool.select;
+      addTearDown(editing.dispose);
+
+      expect(editing.selectAnnotation(0, 1), isTrue);
+      expect(editing.canSetLineEndings, isTrue);
+      expect(editing.selectedLineEndings,
+          (PdfLineEnding.none, PdfLineEnding.none));
+
+      editing.setSelectedLineEndings(end: PdfLineEnding.openArrow);
+      // the selection survives — still slot 1
+      expect(editing.selectedAnnotationSlots, [(0, 1)]);
+      expect(editing.selectedLineEndings,
+          (PdfLineEnding.none, PdfLineEnding.openArrow));
+      // the other line is untouched
+      expect(pdfLineEndings(editing.document.page(0).annotations[0]),
+          (PdfLineEnding.none, PdfLineEnding.none));
+
+      // one undo reverts it
+      editing.undo();
+      expect(pdfLineEndings(editing.document.page(0).annotations[1]),
+          (PdfLineEnding.none, PdfLineEnding.none));
+    });
+
+    test('canSetLineEndings is false for shapes and multi-selection', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 100, 200, 200))
+        ..addLine(0, (100, 240), (220, 300))
+        ..tool = PdfEditTool.select;
+      addTearDown(editing.dispose);
+
+      editing.selectAnnotation(0, 0); // the square
+      expect(editing.canSetLineEndings, isFalse);
+      expect(editing.selectedLineEndings, isNull);
+
+      editing.selectAllAnnotationsOn(0); // both
+      expect(editing.canSetLineEndings, isFalse);
+    });
+  });
+
+  group('line-ending picker', () {
+    Future<void> openStyleMenu(WidgetTester tester) async {
+      await tester.scrollUntilVisible(
+          find.byTooltip('Stroke, opacity, font'), 100);
+      await tester.tap(find.byTooltip('Stroke, opacity, font'));
+      await tester.pumpAndSettle();
+    }
+
+    Widget host(PdfEditingController editing, PdfViewerController viewer) =>
+        MaterialApp(
+          home: Scaffold(
+            body: const SizedBox.expand(),
+            bottomNavigationBar: ListenableBuilder(
+              listenable: editing,
+              builder: (context, _) => PdfEditingToolbar(
+                controller: editing,
+                viewerController: viewer,
+              ),
+            ),
+          ),
+        );
+
+    testWidgets('two dropdowns appear with a line tool armed and set defaults',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..tool = PdfEditTool.line;
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(host(editing, viewer));
+      await openStyleMenu(tester);
+
+      expect(find.byKey(const ValueKey('pdf-line-start-ending')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-line-end-ending')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-line-end-ending')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Closed arrow').last);
+      await tester.pumpAndSettle();
+      expect(editing.lineEndEnding, PdfLineEnding.closedArrow);
+    });
+
+    testWidgets('the picker restyles a selected line in place', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addLine(0, (100, 100), (220, 160))
+        ..tool = PdfEditTool.select;
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      editing.selectAnnotation(0, 0);
+
+      await tester.pumpWidget(host(editing, viewer));
+      await openStyleMenu(tester);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-line-start-ending')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Diamond').last);
+      await tester.pumpAndSettle();
+
+      expect(editing.selectedLineEndings?.$1, PdfLineEnding.diamond);
+      expect(pdfLineEndings(editing.document.page(0).annotations.single)?.$1,
+          PdfLineEnding.diamond);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfLineEnding;
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -21,6 +22,8 @@ void main() {
       a.colorPickerFormat = PdfColorFormat.cmyk;
       a.highlightFormFields = false;
       a.showReflowView = true;
+      a.lineStartEnding = PdfLineEnding.circle;
+      a.lineEndEnding = PdfLineEnding.closedArrow;
       await pumpEventQueue(); // let the unawaited writes land
 
       final b = PdfEditingPreferences();
@@ -36,6 +39,8 @@ void main() {
       expect(b.colorPickerFormat, PdfColorFormat.cmyk);
       expect(b.highlightFormFields, isFalse);
       expect(b.showReflowView, isTrue);
+      expect(b.lineStartEnding, PdfLineEnding.circle);
+      expect(b.lineEndEnding, PdfLineEnding.closedArrow);
     });
 
     test('empty storage leaves the defaults', () async {
@@ -52,6 +57,8 @@ void main() {
       expect(prefs.showAnnotationSidebar, isFalse);
       expect(prefs.author, isNull);
       expect(prefs.colorPickerFormat, PdfColorFormat.hex);
+      expect(prefs.lineStartEnding, PdfLineEnding.none);
+      expect(prefs.lineEndEnding, PdfLineEnding.none);
       expect(prefs.highlightFormFields, isTrue);
       expect(prefs.showReflowView, isFalse);
     });

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -33,14 +33,55 @@ List<((double, double), (double, double))> pdfInkCurveControls(
   ];
 }
 
-/// Line ending styles supported by [PdfEditor.addLine].
+/// Line ending styles (§12.5.6.7, Table 176) drawn at a /Line or
+/// /PolyLine endpoint by [PdfEditor.addLine] / [PdfEditor.addPolyLine].
+///
+/// [pdfName] is the /LE name written to (and read back from) the
+/// dictionary. The geometry of each shape is produced by the appearance
+/// generator: closed shapes ([square], [circle], [diamond],
+/// [closedArrow], [rClosedArrow]) are filled, the rest stroked; the
+/// `r*` variants point the opposite way along the line.
 enum PdfLineEnding {
   none('None'),
-  closedArrow('ClosedArrow');
+  square('Square'),
+  circle('Circle'),
+  diamond('Diamond'),
+  openArrow('OpenArrow'),
+  closedArrow('ClosedArrow'),
+  butt('Butt'),
+  rOpenArrow('ROpenArrow'),
+  rClosedArrow('RClosedArrow'),
+  slash('Slash');
 
   const PdfLineEnding(this.pdfName);
 
   final String pdfName;
+
+  /// The matching ending for a /LE name, or [none] when unknown.
+  static PdfLineEnding fromName(String name) => values.firstWhere(
+        (ending) => ending.pdfName == name,
+        orElse: () => none,
+      );
+}
+
+/// The start/end line endings recorded on [annotation]'s /LE entry, or
+/// null when it is not a /Line or /PolyLine. Each defaults to
+/// [PdfLineEnding.none] when absent or unrecognized. Lets UI read the
+/// current endings without an editor instance (mirrors
+/// [pdfCanRestyleAnnotation]).
+(PdfLineEnding, PdfLineEnding)? pdfLineEndings(PdfAnnotation annotation) {
+  if (annotation.subtype != 'Line' && annotation.subtype != 'PolyLine') {
+    return null;
+  }
+  final le = annotation.document.cos.resolve(annotation.dict['LE']);
+  PdfLineEnding read(int index) {
+    if (le is! CosArray || le.length <= index) return PdfLineEnding.none;
+    final name = annotation.document.cos.resolve(le[index]);
+    if (name is! CosName) return PdfLineEnding.none;
+    return PdfLineEnding.fromName(name.value);
+  }
+
+  return (read(0), read(1));
 }
 
 /// Slices ink [strokes] with one stamp of a circular eraser swept from
@@ -803,14 +844,12 @@ extension PdfAnnotationEditing on PdfEditor {
       throw ArgumentError.value(end, 'end', 'must differ from start');
     }
     final points = [start, end];
-    final arrowPoints = <(double, double)>[
-      if (startEnding == PdfLineEnding.closedArrow)
-        ..._arrowHead(start, end, strokeWidth),
-      if (endEnding == PdfLineEnding.closedArrow)
-        ..._arrowHead(end, start, strokeWidth),
+    final endingPoints = <(double, double)>[
+      ..._endingExtent(startEnding, start, end, strokeWidth),
+      ..._endingExtent(endEnding, end, start, strokeWidth),
     ];
     final rect = _pointBounds(
-        [...points, ...arrowPoints], strokeWidth + (dashed ? strokeWidth : 0));
+        [...points, ...endingPoints], strokeWidth + (dashed ? strokeWidth : 0));
     final gs = _alphaState(opacity);
     final w = _lineContent(points,
         strokeColor: strokeColor,
@@ -838,7 +877,10 @@ extension PdfAnnotationEditing on PdfEditor {
         name: name);
   }
 
-  /// Adds a /PolyLine annotation through [vertices].
+  /// Adds a /PolyLine annotation through [vertices]. Per §12.5.6.7 a
+  /// /PolyLine may carry /LE endings on its first and last vertex —
+  /// [startEnding] is drawn at `vertices.first` (pointing back toward
+  /// `vertices[1]`), [endEnding] at `vertices.last`.
   void addPolyLine(
     int pageIndex,
     List<(double, double)> vertices, {
@@ -846,6 +888,8 @@ extension PdfAnnotationEditing on PdfEditor {
     double strokeWidth = 2,
     double opacity = 1,
     bool dashed = false,
+    PdfLineEnding startEnding = PdfLineEnding.none,
+    PdfLineEnding endEnding = PdfLineEnding.none,
     String? contents,
     String? author,
     String? name,
@@ -853,7 +897,12 @@ extension PdfAnnotationEditing on PdfEditor {
     if (vertices.length < 2) {
       throw ArgumentError.value(vertices, 'vertices', 'must have 2+ points');
     }
-    final rect = _pointBounds(vertices, strokeWidth);
+    final endingPoints = <(double, double)>[
+      ..._endingExtent(startEnding, vertices.first, vertices[1], strokeWidth),
+      ..._endingExtent(
+          endEnding, vertices.last, vertices[vertices.length - 2], strokeWidth),
+    ];
+    final rect = _pointBounds([...vertices, ...endingPoints], strokeWidth);
     final gs = _alphaState(opacity);
     final w = _lineContent(vertices,
         strokeColor: strokeColor,
@@ -861,9 +910,15 @@ extension PdfAnnotationEditing on PdfEditor {
         dashed: dashed,
         closed: false,
         fillColor: null,
+        startEnding: startEnding,
+        endEnding: endEnding,
         hasAlpha: gs != null);
     final dict = _markupDict('PolyLine', rect, strokeColor, contents, author)
       ..['Vertices'] = _pointArray(vertices)
+      ..['LE'] = CosArray([
+        CosName(startEnding.pdfName),
+        CosName(endEnding.pdfName),
+      ])
       ..['BS'] = _borderStyle(strokeWidth, dashed: dashed);
     _addAnnotation(
         pageIndex, dict, _form(rect, w, resources: _resources(extGState: gs)),
@@ -1224,16 +1279,15 @@ extension PdfAnnotationEditing on PdfEditor {
     final dashed = annotation.borderDash != null;
     final fill = subtype == 'Polygon' ? annotation.interiorColor : null;
     final endings = _lineEndings(annotation);
-    final arrowPoints = subtype == 'Line'
-        ? <(double, double)>[
-            if (endings.$1 == PdfLineEnding.closedArrow)
-              ..._arrowHead(points[0], points[1], width),
-            if (endings.$2 == PdfLineEnding.closedArrow)
-              ..._arrowHead(points[1], points[0], width),
-          ]
-        : const <(double, double)>[];
+    final endingPoints = subtype == 'Polygon'
+        ? const <(double, double)>[]
+        : <(double, double)>[
+            ..._endingExtent(endings.$1, points.first, points[1], width),
+            ..._endingExtent(
+                endings.$2, points.last, points[points.length - 2], width),
+          ];
     final rect =
-        _pointBounds([...points, ...arrowPoints], width + (dashed ? width : 0));
+        _pointBounds([...points, ...endingPoints], width + (dashed ? width : 0));
     final form = annotation.normalAppearance;
     final gs = _alphaState(form == null ? 1 : _appearanceOpacity(form));
     final w = _lineContent(points,
@@ -1267,6 +1321,44 @@ extension PdfAnnotationEditing on PdfEditor {
       });
     }
     _markAnnotationChanged(pageIndex, dict);
+  }
+
+  /// Sets the /LE line endings of a /Line or /PolyLine in place, keeping
+  /// the annotation's object number and /Annots slot. The appearance,
+  /// /Rect, and BBox regenerate from the current geometry with the new
+  /// endings; pass null for an axis to leave it unchanged. A no-op (and
+  /// returns false) for any other subtype, or when nothing changes.
+  bool setLineEndings(
+    int pageIndex,
+    PdfAnnotation annotation, {
+    PdfLineEnding? startEnding,
+    PdfLineEnding? endEnding,
+  }) {
+    final subtype = annotation.subtype;
+    if (subtype != 'Line' && subtype != 'PolyLine') return false;
+    final current = _lineEndings(annotation);
+    final start = startEnding ?? current.$1;
+    final end = endEnding ?? current.$2;
+    if (start == current.$1 && end == current.$2) return false;
+    final List<(double, double)> points;
+    if (subtype == 'Line') {
+      final line = annotation.line;
+      if (line == null) return false;
+      points = [line.$1, line.$2];
+    } else {
+      final vertices = annotation.vertices;
+      if (vertices == null || vertices.length < 2) return false;
+      points = vertices;
+    }
+    annotation.dict['LE'] = CosArray([
+      CosName(start.pdfName),
+      CosName(end.pdfName),
+    ]);
+    // re-wrap: the dict's /LE just changed under the caller's instance, and
+    // reshape reads the endings back through a fresh parse
+    reshapeLineAnnotation(
+        pageIndex, PdfAnnotation.fromDict(document, annotation.dict), points);
+    return true;
   }
 
   /// Sets [annotation]'s /Contents text in place.
@@ -1673,23 +1765,12 @@ extension PdfAnnotationEditing on PdfEditor {
     return true;
   }
 
-  (PdfLineEnding, PdfLineEnding) _lineEndings(PdfAnnotation annotation) {
-    if (annotation.subtype != 'Line') {
-      return (PdfLineEnding.none, PdfLineEnding.none);
-    }
-    final le = document.cos.resolve(annotation.dict['LE']);
-    PdfLineEnding read(int index) {
-      if (le is! CosArray || le.length <= index) return PdfLineEnding.none;
-      final name = document.cos.resolve(le[index]);
-      if (name is! CosName) return PdfLineEnding.none;
-      return PdfLineEnding.values.firstWhere(
-        (ending) => ending.pdfName == name.value,
-        orElse: () => PdfLineEnding.none,
-      );
-    }
-
-    return (read(0), read(1));
-  }
+  /// The endings recorded on [annotation]'s /LE entry — both
+  /// [PdfLineEnding.none] for subtypes that carry no endings
+  /// (/Polygon is closed; /PolyLine endings apply to its first and last
+  /// vertex per §12.5.6.7).
+  (PdfLineEnding, PdfLineEnding) _lineEndings(PdfAnnotation annotation) =>
+      pdfLineEndings(annotation) ?? (PdfLineEnding.none, PdfLineEnding.none);
 
   /// Restyles [annotation] in place: new colors, stroke width, or
   /// opacity at its current geometry, with the appearance regenerated —
@@ -2303,41 +2384,182 @@ extension PdfAnnotationEditing on PdfEditor {
       w.stroke();
     }
     if (dashed) w.dash(const []);
-    if (startEnding == PdfLineEnding.closedArrow) {
-      _drawArrowHead(w, points.first, points[1], strokeColor, strokeWidth);
-    }
-    if (endEnding == PdfLineEnding.closedArrow) {
-      _drawArrowHead(
-          w, points.last, points[points.length - 2], strokeColor, strokeWidth);
+    if (points.length >= 2) {
+      _drawEnding(w, startEnding, points.first, points[1], strokeColor,
+          strokeWidth);
+      _drawEnding(w, endEnding, points.last, points[points.length - 2],
+          strokeColor, strokeWidth);
     }
     return w;
   }
 
-  void _drawArrowHead(ContentWriter w, (double, double) tip,
-      (double, double) from, int color, double strokeWidth) {
-    final head = _arrowHead(tip, from, strokeWidth);
-    w
-      ..fillColor(color)
-      ..moveTo(tip.$1, tip.$2)
-      ..lineTo(head[0].$1, head[0].$2)
-      ..lineTo(head[1].$1, head[1].$2)
-      ..closePath()
-      ..fill();
-  }
-
-  List<(double, double)> _arrowHead(
-      (double, double) tip, (double, double) from, double strokeWidth) {
+  /// One line-ending shape (§12.5.6.7, Table 176) at endpoint [tip], with
+  /// the line arriving from [from]. The shape is oriented along the
+  /// segment: `u` points from the tip back into the line body, `p` is the
+  /// left-hand perpendicular. Closed shapes are returned with
+  /// `filled: true`; [PdfLineEnding.circle] additionally sets `isCircle`
+  /// (the [vertices] are then its four cardinal extent points, used for
+  /// bounds, and [radius]/[center] drive the Bézier draw).
+  ///
+  /// `r*` variants reverse the arrow direction (apex points into the line
+  /// instead of out of it). Returns null for [PdfLineEnding.none].
+  ({
+    List<(double, double)> vertices,
+    bool closed,
+    bool filled,
+    bool isCircle,
+    (double, double) center,
+    double radius,
+  })? _endingPath(PdfLineEnding kind, (double, double) tip,
+      (double, double) from, double strokeWidth) {
+    if (kind == PdfLineEnding.none) return null;
     final dx = from.$1 - tip.$1;
     final dy = from.$2 - tip.$2;
     final len = math.sqrt(dx * dx + dy * dy);
-    if (len < 1e-9) return [tip, tip];
-    final ux = dx / len, uy = dy / len;
-    final size = math.max(10.0, strokeWidth * 5);
-    final half = size * 0.38;
-    final bx = tip.$1 + ux * size;
-    final by = tip.$2 + uy * size;
+    final ux = len < 1e-9 ? 1.0 : dx / len;
+    final uy = len < 1e-9 ? 0.0 : dy / len;
     final px = -uy, py = ux;
-    return [(bx + px * half, by + py * half), (bx - px * half, by - py * half)];
+    final s = math.max(10.0, strokeWidth * 5);
+    (double, double) at(double along, double across) =>
+        (tip.$1 + ux * along + px * across, tip.$2 + uy * along + py * across);
+    switch (kind) {
+      case PdfLineEnding.closedArrow:
+      case PdfLineEnding.openArrow:
+        final hw = s * 0.38;
+        return (
+          // barb, apex (tip), barb — closed for the filled arrow
+          vertices: [at(s, hw), tip, at(s, -hw)],
+          closed: kind == PdfLineEnding.closedArrow,
+          filled: kind == PdfLineEnding.closedArrow,
+          isCircle: false,
+          center: tip,
+          radius: 0,
+        );
+      case PdfLineEnding.rClosedArrow:
+      case PdfLineEnding.rOpenArrow:
+        final hw = s * 0.38;
+        return (
+          // reversed: apex points into the line, barbs sit on the endpoint
+          vertices: [at(0, hw), at(s, 0), at(0, -hw)],
+          closed: kind == PdfLineEnding.rClosedArrow,
+          filled: kind == PdfLineEnding.rClosedArrow,
+          isCircle: false,
+          center: tip,
+          radius: 0,
+        );
+      case PdfLineEnding.diamond:
+        final r = s * 0.45;
+        return (
+          vertices: [at(r, 0), at(0, r), at(-r, 0), at(0, -r)],
+          closed: true,
+          filled: true,
+          isCircle: false,
+          center: tip,
+          radius: 0,
+        );
+      case PdfLineEnding.square:
+        final h = s * 0.35;
+        return (
+          vertices: [at(h, h), at(h, -h), at(-h, -h), at(-h, h)],
+          closed: true,
+          filled: true,
+          isCircle: false,
+          center: tip,
+          radius: 0,
+        );
+      case PdfLineEnding.circle:
+        final r = s * 0.4;
+        return (
+          vertices: [(tip.$1 + r, tip.$2), (tip.$1, tip.$2 + r),
+            (tip.$1 - r, tip.$2), (tip.$1, tip.$2 - r)],
+          closed: true,
+          filled: true,
+          isCircle: true,
+          center: tip,
+          radius: r,
+        );
+      case PdfLineEnding.butt:
+        final h = s * 0.45;
+        return (
+          vertices: [at(0, h), at(0, -h)],
+          closed: false,
+          filled: false,
+          isCircle: false,
+          center: tip,
+          radius: 0,
+        );
+      case PdfLineEnding.slash:
+        // a short line ~30° clockwise from perpendicular (60° from the
+        // line itself): rotate the line direction u by 60° CCW
+        final h = s * 0.5;
+        const c = 0.5, sn = 0.8660254037844387; // cos 60°, sin 60°
+        final sx = ux * c - uy * sn, sy = ux * sn + uy * c;
+        return (
+          vertices: [
+            (tip.$1 + sx * h, tip.$2 + sy * h),
+            (tip.$1 - sx * h, tip.$2 - sy * h),
+          ],
+          closed: false,
+          filled: false,
+          isCircle: false,
+          center: tip,
+          radius: 0,
+        );
+      case PdfLineEnding.none:
+        return null;
+    }
+  }
+
+  void _drawEnding(ContentWriter w, PdfLineEnding kind, (double, double) tip,
+      (double, double) from, int color, double strokeWidth) {
+    final shape = _endingPath(kind, tip, from, strokeWidth);
+    if (shape == null) return;
+    if (shape.isCircle) {
+      _drawCircle(w, shape.center, shape.radius);
+      w
+        ..fillColor(color)
+        ..fill();
+      return;
+    }
+    w.moveTo(shape.vertices.first.$1, shape.vertices.first.$2);
+    for (final (x, y) in shape.vertices.skip(1)) {
+      w.lineTo(x, y);
+    }
+    if (shape.filled) {
+      w
+        ..closePath()
+        ..fillColor(color)
+        ..fill();
+    } else {
+      if (shape.closed) w.closePath();
+      w
+        ..strokeColor(color)
+        ..lineWidth(strokeWidth)
+        ..lineCap(0)
+        ..stroke();
+    }
+  }
+
+  /// Appends a circle of [radius] about [center] as four cubic Béziers.
+  void _drawCircle(ContentWriter w, (double, double) center, double radius) {
+    const k = 0.5522847498307936; // 4/3·(√2−1)
+    final cx = center.$1, cy = center.$2, r = radius, kr = k * radius;
+    w
+      ..moveTo(cx + r, cy)
+      ..curveTo(cx + r, cy + kr, cx + kr, cy + r, cx, cy + r)
+      ..curveTo(cx - kr, cy + r, cx - r, cy + kr, cx - r, cy)
+      ..curveTo(cx - r, cy - kr, cx - kr, cy - r, cx, cy - r)
+      ..curveTo(cx + kr, cy - r, cx + r, cy - kr, cx + r, cy);
+  }
+
+  /// The extreme points an ending [kind] reaches at [tip] (line arriving
+  /// from [from]) — fed into [_pointBounds] so the appearance /Rect and
+  /// BBox cover the ending, not just the line.
+  List<(double, double)> _endingExtent(PdfLineEnding kind, (double, double) tip,
+      (double, double) from, double strokeWidth) {
+    final shape = _endingPath(kind, tip, from, strokeWidth);
+    if (shape == null) return const [];
+    return [tip, ...shape.vertices];
   }
 
   List<double> _dashPattern(double strokeWidth) =>

--- a/packages/pdf_document/test/line_ending_test.dart
+++ b/packages/pdf_document/test/line_ending_test.dart
@@ -1,0 +1,204 @@
+// Line-ending vocabulary (§12.5.6.7, Table 176): PdfEditor.addLine /
+// addPolyLine draw the full set of /LE endings, and PdfEditor.setLineEndings
+// swaps them in place. The appearance path geometry is KAT-checked on a
+// known horizontal segment so each shape's vertices are pinned exactly.
+
+import 'dart:convert';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+PdfDocument edited(PdfDocument doc, void Function(PdfEditor) edit) {
+  final editor = PdfEditor(doc);
+  edit(editor);
+  return PdfDocument.open(editor.save());
+}
+
+String content(PdfDocument doc, PdfAnnotation annotation) =>
+    latin1.decode(doc.cos.decodeStreamData(annotation.normalAppearance!));
+
+(String, String) leNames(PdfDocument doc, PdfAnnotation annotation) {
+  final le = doc.cos.resolve(annotation.dict['LE']) as CosArray;
+  return (
+    (doc.cos.resolve(le[0]) as CosName).value,
+    (doc.cos.resolve(le[1]) as CosName).value,
+  );
+}
+
+void main() {
+  // The END ending sits at (100, 0) with the line arriving from (0, 0):
+  // u points -x (back into the line), the left perpendicular p points -y.
+  // strokeWidth 2 gives the characteristic size s = max(10, 2*5) = 10.
+  PdfDocument lineWith(PdfLineEnding endEnding) => edited(
+        PdfDocument.open(buildMultiPagePdf(1)),
+        (e) => e.addLine(0, (0, 0), (100, 0),
+            strokeWidth: 2, endEnding: endEnding),
+      );
+
+  test('every ending name round-trips through /LE [start end]', () {
+    final doc = edited(
+      PdfDocument.open(buildMultiPagePdf(1)),
+      (e) => e.addLine(0, (0, 0), (100, 0),
+          startEnding: PdfLineEnding.diamond,
+          endEnding: PdfLineEnding.openArrow),
+    );
+    final line = doc.page(0).annotations.single;
+    expect(leNames(doc, line), ('Diamond', 'OpenArrow'));
+    expect(pdfLineEndings(line), (PdfLineEnding.diamond, PdfLineEnding.openArrow));
+  });
+
+  test('closedArrow: filled triangle barbs at (90, ±3.8), apex at the tip',
+      () {
+    final c = content(lineWith(PdfLineEnding.closedArrow),
+        lineWith(PdfLineEnding.closedArrow).page(0).annotations.single);
+    // barb, apex, barb — then close + fill
+    expect(c, contains('90 -3.8 m'));
+    expect(c, contains('100 0 l'));
+    expect(c, contains('90 3.8 l'));
+    expect(c, contains('f'));
+  });
+
+  test('openArrow: same barbs, stroked open V (no fill, no close)', () {
+    final doc = lineWith(PdfLineEnding.openArrow);
+    final c = content(doc, doc.page(0).annotations.single);
+    expect(c, contains('90 -3.8 m'));
+    expect(c, contains('100 0 l'));
+    expect(c, contains('90 3.8 l'));
+    // the V is stroked; the only fill in the stream is none for the ending
+    expect('S\n'.allMatches(c).length, greaterThanOrEqualTo(2));
+  });
+
+  test('rClosedArrow: reversed — apex into the line, barbs on the endpoint',
+      () {
+    final doc = lineWith(PdfLineEnding.rClosedArrow);
+    final c = content(doc, doc.page(0).annotations.single);
+    expect(c, contains('100 -3.8 m')); // barb at the endpoint
+    expect(c, contains('90 0 l')); // apex 10pt into the line
+    expect(c, contains('100 3.8 l'));
+    expect(c, contains('f'));
+  });
+
+  test('diamond: filled rhombus, half-diagonal 4.5 along u and p', () {
+    final doc = lineWith(PdfLineEnding.diamond);
+    final c = content(doc, doc.page(0).annotations.single);
+    // at(4.5,0)=(95.5,0)  at(0,4.5)=(100,-4.5)  at(-4.5,0)=(104.5,0)
+    expect(c, contains('95.5 0 m'));
+    expect(c, contains('100 -4.5 l'));
+    expect(c, contains('104.5 0 l'));
+    expect(c, contains('100 4.5 l'));
+    expect(c, contains('f'));
+  });
+
+  test('square: filled, axis-aligned to the line, half-side 3.5', () {
+    final doc = lineWith(PdfLineEnding.square);
+    final c = content(doc, doc.page(0).annotations.single);
+    // at(3.5,3.5)=(96.5,-3.5)  at(3.5,-3.5)=(96.5,3.5)
+    expect(c, contains('96.5 -3.5 m'));
+    expect(c, contains('96.5 3.5 l'));
+    expect(c, contains('103.5 3.5 l'));
+    expect(c, contains('103.5 -3.5 l'));
+    expect(c, contains('f'));
+  });
+
+  test('circle: filled, drawn as four cubic Béziers about the tip', () {
+    final doc = lineWith(PdfLineEnding.circle);
+    final c = content(doc, doc.page(0).annotations.single);
+    // radius 4, starts at (tip.x + r, tip.y) = (104, 0)
+    expect(c, contains('104 0 m'));
+    expect('c\n'.allMatches(c).length, greaterThanOrEqualTo(4));
+    expect(c, contains('f'));
+  });
+
+  test('butt: a stroked perpendicular bar, half-length 4.5', () {
+    final doc = lineWith(PdfLineEnding.butt);
+    final c = content(doc, doc.page(0).annotations.single);
+    // p points -y, so at(0,4.5)=(100,-4.5) to at(0,-4.5)=(100,4.5)
+    expect(c, contains('100 -4.5 m'));
+    expect(c, contains('100 4.5 l'));
+  });
+
+  test('slash: a stroked slanted line, ~60° from the line', () {
+    final doc = lineWith(PdfLineEnding.slash);
+    final c = content(doc, doc.page(0).annotations.single);
+    // u=(-1,0); rotate by 60° CCW -> (-0.5, -0.866); half-length 5
+    // (100 + (-0.5)*5, 0 + (-0.866)*5) = (97.5, -4.330)
+    expect(c, contains('97.5 -4.33 m'));
+    expect(c, contains('102.5 4.33 l'));
+  });
+
+  test('the /Rect grows to cover the ending geometry', () {
+    final plain = lineWith(PdfLineEnding.none);
+    final arrow = lineWith(PdfLineEnding.closedArrow);
+    final r0 = plain.page(0).annotations.single.rect;
+    final r1 = arrow.page(0).annotations.single.rect;
+    // the arrow reaches above/below the segment, so the rect is taller
+    expect(r1.height, greaterThan(r0.height));
+  });
+
+  test('polyline carries /LE on its first and last vertex', () {
+    final doc = edited(
+      PdfDocument.open(buildMultiPagePdf(1)),
+      (e) => e.addPolyLine(0, [(0, 0), (50, 40), (100, 0)],
+          strokeWidth: 2,
+          startEnding: PdfLineEnding.openArrow,
+          endEnding: PdfLineEnding.closedArrow),
+    );
+    final poly = doc.page(0).annotations.single;
+    expect(poly.subtype, 'PolyLine');
+    expect(leNames(doc, poly), ('OpenArrow', 'ClosedArrow'));
+    expect(pdfLineEndings(poly),
+        (PdfLineEnding.openArrow, PdfLineEnding.closedArrow));
+    // a closed (filled) arrowhead at the last vertex
+    expect(content(doc, poly), contains('f'));
+  });
+
+  test('setLineEndings swaps endings in place, keeping slot + object number',
+      () {
+    final doc = edited(
+      PdfDocument.open(buildMultiPagePdf(1)),
+      (e) => e.addLine(0, (0, 0), (100, 0), strokeWidth: 2, author: 'Ben'),
+    );
+    final before = doc.page(0).annotations.single;
+    final formRef = doc.cos.referenceTo(before.normalAppearance!)!;
+    expect(leNames(doc, before), ('None', 'None'));
+
+    final out = edited(
+        doc,
+        (e) => e.setLineEndings(0, before,
+            startEnding: PdfLineEnding.circle,
+            endEnding: PdfLineEnding.closedArrow));
+    final after = out.page(0).annotations.single;
+    expect(leNames(out, after), ('Circle', 'ClosedArrow'));
+    expect(after.author, 'Ben'); // identity survives the in-place edit
+    expect(after.line, ((0.0, 0.0), (100.0, 0.0))); // geometry unchanged
+    // the appearance now paints both endings — the circle sits at the
+    // start vertex (0,0), radius 4, so its Bézier starts at (4,0)
+    expect(content(out, after), contains('4 0 m')); // start circle
+    expect(content(out, after), contains('90 3.8 l')); // end arrow
+    // replaced, not re-added — the form keeps its object number
+    expect(out.cos.referenceTo(after.normalAppearance!)!.objectNumber,
+        formRef.objectNumber);
+  });
+
+  test('setLineEndings is a no-op when nothing changes or wrong subtype', () {
+    final doc = edited(
+      PdfDocument.open(buildMultiPagePdf(1)),
+      (e) {
+        e.addLine(0, (0, 0), (100, 0), endEnding: PdfLineEnding.closedArrow);
+        e.addSquare(0, const PdfRect(200, 200, 300, 300));
+      },
+    );
+    final line = doc.page(0).annotations[0];
+    final square = doc.page(0).annotations[1];
+    final editor = PdfEditor(doc);
+    expect(
+        editor.setLineEndings(0, line, endEnding: PdfLineEnding.closedArrow),
+        isFalse,
+        reason: 'unchanged endings');
+    expect(editor.setLineEndings(0, square, endEnding: PdfLineEnding.circle),
+        isFalse,
+        reason: 'not a line annotation');
+  });
+}


### PR DESCRIPTION
Rounds the line/polyline ending vocabulary out from just `none` +
`closedArrow` to the whole §12.5.6.7 Table 176 set, and exposes a
start/end picker. Lines, polylines, multi-vertex placement, and
`reshape`/restyle/resize/rotate already existed — this only extends the
ending styles.

## Model (`pdf_document`, `annotation_editor.dart`)
- `PdfLineEnding` gains `square`, `circle`, `diamond`, `openArrow`,
  `butt`, `rOpenArrow`, `rClosedArrow`, `slash` (plus a `fromName`
  helper), keeping `none` + `closedArrow`.
- New top-level `pdfLineEndings(annotation)` lets UI read an
  annotation's endings without an editor (mirrors
  `pdfCanRestyleAnnotation`).
- An `_endingPath` / `_drawEnding` / `_endingExtent` trio renders each
  shape oriented along the segment direction at the endpoint: closed
  kinds (square/circle/diamond/closed arrows) fill, the rest stroke;
  `r*` variants reverse the arrow direction. The appearance `/Rect` and
  BBox grow to cover the ending geometry.
- `addLine` threads both `startEnding` and `endEnding` (it already had
  the params); `addPolyLine` now takes them too and writes `/LE` on its
  first/last vertex. reshape/resize/restyle/rotate regenerate endings
  from the current `/L` or `/Vertices`.
- New `setLineEndings` swaps a Line/PolyLine's endings **in place**,
  keeping the object number and `/Annots` slot.

## Editor UI (`dart_pdf_editor`)
- Two start/end dropdowns with tiny preview icons in the `_StyleMenu`,
  shown while the line/polyline tool is armed or a Line/PolyLine is
  selected. Selecting restyles the selection in place via
  `setSelectedLineEndings`.
- Persisted `lineStartEnding` / `lineEndEnding` preferences, threaded
  through the controller's `addLine`/`addPolyLine`. The dedicated arrow
  tool still forces a closed arrow at the end.

## Tests
- `pdf_document/test/line_ending_test.dart` — KATs each ending's path
  vertices on a known horizontal segment, `/LE [start end]` round-trip,
  PolyLine endings, and in-place `setLineEndings` (slot + object number
  preserved).
- `dart_pdf_editor/test/editing_line_endings_test.dart` — picker sets
  endings on a new line and restyles a selected line; controller gates.
- Preference round-trip added to `editing_preferences_test.dart`.

The `pdf_graphics` renderer is untouched (endings live in the editor's
appearance generator, and corpus PDFs carry their own `/AP`), so the
Ghent/PDF.js pure-Dart passes stay green and no baselines move. The 14
Ghent render diffs in this environment are pre-existing CMYK/overprint
mismatches — verified identical on a clean tree.

https://claude.ai/code/session_01LXs4iVwx1HD8tfCGhf1nJs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXs4iVwx1HD8tfCGhf1nJs)_