### PR TITLE
Fix UI hang on rapid zoom (especially on web)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -98,6 +98,13 @@ class _PdfPageViewState extends State<PdfPageView> {
   double? _pixelRatio;
   double? _layoutWidth;
 
+  /// The effective pixel ratio [_image] was last rasterized at. A settle
+  /// that only moved the detail patch (scale unchanged) must not re-read
+  /// the whole page back off the GPU — an expensive, uncancellable
+  /// `toImage` on web — so [_renderNow] skips the full-page raster when
+  /// this still matches.
+  double? _rasteredRatio;
+
   ui.Image? _detailImage;
   Rect? _detailFraction; // patch placement as fractions of the page
   int _detailGeneration = 0;
@@ -199,13 +206,13 @@ class _PdfPageViewState extends State<PdfPageView> {
       _dropPicture();
       _dropDetail();
       _render();
-    } else if (oldWidget.scale != widget.scale) {
+    } else if (oldWidget.scale != widget.scale ||
+        oldWidget.settleGeneration != widget.settleGeneration) {
+      // scale change re-rasters the page; a settle that only moved the
+      // viewport refreshes the detail patch. Both route through _render so
+      // they pace and coalesce through the scheduler (_renderNow skips the
+      // full-page raster when the resolution is unchanged).
       _render();
-    } else if (oldWidget.settleGeneration != widget.settleGeneration) {
-      // viewport settled somewhere new: refresh only the detail patch
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) _updateDetail();
-      });
     }
   }
 
@@ -224,6 +231,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   void _dropPicture() {
     _picture?.then((picture) => picture.dispose());
     _picture = null;
+    _rasteredRatio = null; // the next picture must re-raster, not be skipped
   }
 
   void _dropDetail() {
@@ -258,23 +266,25 @@ class _PdfPageViewState extends State<PdfPageView> {
   }
 
   Future<void> _render() async {
-    // Only the first interpretation is deferred: it walks the content
-    // stream twice on the UI thread, which is what stalls fast scrolling
-    // on heavy pages. With a picture cached, rendering is a raster-thread
-    // toImage, so re-renders run directly.
-    if (_picture == null) {
-      final scheduler = widget.renderScheduler;
-      if (scheduler != null) {
-        // route the first walk through the viewer's paced drain so no
-        // frame interprets more than one page (a settling fast scroll
-        // used to release every held page in one event-loop turn)
-        scheduler.request(this, widget.previewIndex, _renderNow);
-        return;
-      }
-      if (widget.renderHold?.value ?? false) {
-        _holdPending = true;
-        return;
-      }
+    final scheduler = widget.renderScheduler;
+    if (scheduler != null) {
+      // Route the first interpret AND every re-raster (zoom settle,
+      // detail-patch follow) through the scheduler: it dedupes per page
+      // (token), paces one render per frame, and defers while a scroll or
+      // zoom is in flight. The first interpret walks the content stream
+      // twice on the UI thread — what stalls fast scrolling on heavy
+      // pages. Re-rasters are a `toImage`, cheap on a raster thread but a
+      // single-threaded GPU readback on web: rapid zoom in/out used to
+      // fire one uncancellable readback per settle and they piled up,
+      // freezing the UI. Coalescing collapses them to the latest.
+      scheduler.request(this, widget.previewIndex, _renderNow);
+      return;
+    }
+    // The bare PdfPageView (no scheduler) defers only the first interpret
+    // behind renderHold; cached re-rasters run directly.
+    if (_picture == null && (widget.renderHold?.value ?? false)) {
+      _holdPending = true;
+      return;
     }
     await _renderNow();
   }
@@ -288,27 +298,40 @@ class _PdfPageViewState extends State<PdfPageView> {
         pageColor: widget.pageColor,
         annotations: widget.showAnnotations));
     if (!mounted || generation != _renderGeneration) return;
-    final image = await PdfPageRenderer.rasterize(
-        picture, PdfPageRenderer.pageSize(widget.page), _effectiveRatio());
-    if (!mounted || generation != _renderGeneration) {
-      image.dispose();
-      return;
-    }
-    // the previous raster stays up (transform-scaled) until this replaces
-    // it, so zooming never flashes white
-    setState(() {
-      _image?.dispose();
-      _image = image;
-      _preview?.dispose();
-      _preview = null;
-    });
-    widget.onRasterReady?.call();
-    // feed the preview cache from the picture we already paid to
-    // interpret — this is how previews appear for pages the background
-    // prerender hasn't reached (and refresh after edits)
-    final cache = widget.previewCache;
-    if (cache != null && !cache.isFresh(widget.previewIndex, widget.page)) {
-      unawaited(cache.putFromPicture(widget.previewIndex, widget.page, picture));
+    final effective = _effectiveRatio();
+    // Skip the full-page readback when the cached raster is already at
+    // this resolution: a settle that only moved the detail patch reaches
+    // here too (one combined callback paces base + detail through the
+    // scheduler), and re-reading the whole page off the GPU is the
+    // expensive part on web.
+    final stale = _image == null ||
+        _rasteredRatio == null ||
+        (effective - _rasteredRatio!).abs() > _rasteredRatio! * 0.01;
+    if (stale) {
+      final image = await PdfPageRenderer.rasterize(
+          picture, PdfPageRenderer.pageSize(widget.page), effective);
+      if (!mounted || generation != _renderGeneration) {
+        image.dispose();
+        return;
+      }
+      // the previous raster stays up (transform-scaled) until this
+      // replaces it, so zooming never flashes white
+      setState(() {
+        _image?.dispose();
+        _image = image;
+        _rasteredRatio = effective;
+        _preview?.dispose();
+        _preview = null;
+      });
+      widget.onRasterReady?.call();
+      // feed the preview cache from the picture we already paid to
+      // interpret — this is how previews appear for pages the background
+      // prerender hasn't reached (and refresh after edits)
+      final cache = widget.previewCache;
+      if (cache != null && !cache.isFresh(widget.previewIndex, widget.page)) {
+        unawaited(
+            cache.putFromPicture(widget.previewIndex, widget.page, picture));
+      }
     }
     await _updateDetail();
   }

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -730,9 +730,17 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   void _onTransformChanged() {
     _transformScale.value = _transform.value.getMaxScaleOnAxis();
     _controller._bumpViewport();
+    // hold re-rasterization while the zoom is moving: the existing rasters
+    // scale under the transform meanwhile (cheap, briefly blurry). Without
+    // this, rapid zoom in/out fired a fresh full-resolution toImage per
+    // settle, and on web (single-threaded, uncancellable GPU readback)
+    // they piled up and froze the UI. The settle below releases the hold,
+    // and the scheduler then drains a single coalesced render per page.
+    _renderScheduler.holding = true;
     _settleTimer?.cancel();
     _settleTimer = Timer(const Duration(milliseconds: 200), () {
       if (!mounted) return;
+      _renderScheduler.holding = false;
       final target = math.max(1.0, _transform.value.getMaxScaleOnAxis());
       // wheel zoom never fires onInteractionEnd, so the pan flag also
       // settles here
@@ -745,6 +753,8 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
         // any settled transform change moves the deep-zoom detail patch
         _settleGeneration++;
       });
+      // the background prerender yields while the hold is up; pick it back up
+      _prerenderPreviews();
     });
   }
 

--- a/packages/dart_pdf_editor/test/render_hold_test.dart
+++ b/packages/dart_pdf_editor/test/render_hold_test.dart
@@ -89,4 +89,54 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
     await waitFor(tester, fullRaster);
   });
+
+  testWidgets(
+      'a settle that does not change the zoom skips the full-page readback',
+      (tester) async {
+    // Rapid zoom in/out used to fire a fresh full-resolution toImage per
+    // settle even when the resolution was unchanged — uncancellable GPU
+    // readbacks that pile up and freeze the UI on web. A settle now only
+    // re-rasters the page when the effective resolution actually moved.
+    final document = PdfDocument.open(buildClassicPdf());
+    // a stable page object across rebuilds (the viewer passes a cached
+    // list); a fresh page() each build would drop the cached picture
+    final page = document.page(0);
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    var rasters = 0;
+
+    Widget build(double scale, int generation) => MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 400,
+              child: PdfPageView(
+                page: page,
+                scale: scale,
+                settleGeneration: generation,
+                renderScheduler: scheduler,
+                onRasterReady: () => rasters++,
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(build(1, 0));
+    await waitFor(tester, find.byType(RawImage));
+    expect(rasters, 1);
+
+    // a settle with the zoom unchanged (only the detail patch follows the
+    // viewport): no new full-page raster
+    await tester.pumpWidget(build(1, 1));
+    for (var i = 0; i < 5; i++) {
+      await settle(tester);
+    }
+    expect(rasters, 1, reason: 'a same-zoom settle must not re-read the page');
+
+    // a real zoom change re-rasters at the new resolution
+    await tester.pumpWidget(build(2, 2));
+    for (var i = 0; i < 20 && rasters < 2; i++) {
+      await settle(tester);
+    }
+    expect(rasters, 2, reason: 'a zoom change must re-raster the page');
+  });
 }


### PR DESCRIPTION
## Problem

Zooming in and out rapidly froze the viewer, most visibly on web.

Each time a zoom settled, the viewer bumped `_renderScale`/`_settleGeneration` and every visible `PdfPageView` re-rasterized its cached picture (`_renderNow`) **plus** its deep-zoom detail patch (`_updateDetail`) via `Picture.toImage`. Those cached-picture re-rasters **bypassed the render scheduler entirely** — the scheduler only paced the *first* interpret — and ran directly.

On web `toImage` is an uncancellable, single-threaded GPU readback (the detail patch alone can be up to ~16 MP). Rapid zoom in/out fires a fresh settle on each pause, so the readbacks piled up on the one web thread and stalled the UI. The `_renderGeneration`/`_detailGeneration` guards discarded the stale *results*, but the work still ran.

## Fix

- **Pace every re-raster through `PdfPageRenderScheduler`.** Both the zoom-settle re-raster and the detail-patch follow now route through `_render` → `scheduler.request`, which dedupes per page (token), paces one render per frame, and defers while motion is in flight. Coalescing collapses a burst of settles to the latest render per page. The bare `PdfPageView` (no scheduler) keeps running cached re-rasters directly.
- **Hold while a zoom is actively changing.** `_onTransformChanged` raises the scheduler's `holding` flag (the existing rasters scale under the transform meanwhile — cheap, briefly blurry) and the 200 ms settle releases it, then restarts the background preview prerender. This mirrors the existing scroll-velocity hold.
- **Skip redundant full-page readbacks.** A settle that only moved the viewport (zoom unchanged) reaches `_renderNow` too now; it skips the full-page `toImage` when the cached raster is already at the settled resolution (tracked via `_rasteredRatio`) and just refreshes the detail patch.

## Tests

- New regression test in `render_hold_test.dart`: a same-zoom settle does **not** re-read the page, while a real zoom change does.
- Full `dart_pdf_editor` suite green (`+669 ~2`); the 14 `ghent_render_test` baseline mismatches are pre-existing (verified identical on `main`/unmodified working tree) and unrelated to this change.

https://claude.ai/code/session_013ePyfMaHMyYc2YUToVcKeT

---
_Generated by [Claude Code](https://claude.ai/code/session_013ePyfMaHMyYc2YUToVcKeT)_