### PR TITLE
Make the eraser size control discoverable

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -781,6 +781,10 @@ class _StyleMenuState extends State<_StyleMenu> {
             // with a restylable selection the stroke/opacity sliders
             // show — and change — its style; otherwise the defaults
             final restylingAnnotation = controller.canRestyleSelected;
+            // the eraser doesn't paint, so none of the stroke/opacity/
+            // font/line controls apply to it — while it's armed the menu
+            // collapses to just the eraser-size slider
+            final isEraser = controller.tool == PdfEditTool.eraser;
             final annotationStyle =
                 restylingAnnotation ? controller.selectedAnnotationStyle : null;
             final strokeValue = _draggingStroke ??
@@ -821,25 +825,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _slider(
-                    label: 'Stroke width',
-                    value: strokeValue,
-                    min: 0.5,
-                    max: 12,
-                    display: '${strokeValue.toStringAsFixed(1)} pt',
-                    onChanged: (v) {
-                      setState(() => _draggingStroke = v);
-                      if (!restylingAnnotation) controller.strokeWidth = v;
-                    },
-                    onChangeEnd: (v) {
-                      controller.strokeWidth = v;
-                      if (restylingAnnotation) {
-                        controller.restyleSelected(strokeWidth: v);
-                      }
-                      setState(() => _draggingStroke = null);
-                    },
-                  ),
-                  if (controller.tool == PdfEditTool.eraser)
+                  if (isEraser)
                     _slider(
                       key: const ValueKey('pdf-eraser-size'),
                       label: 'Eraser size',
@@ -850,25 +836,45 @@ class _StyleMenuState extends State<_StyleMenu> {
                       onChanged: (v) =>
                           controller.eraserRadius = v.roundToDouble(),
                     ),
-                  _slider(
-                    label: 'Opacity',
-                    value: opacityValue,
-                    min: 0.1,
-                    max: 1,
-                    display: '${(opacityValue * 100).round()}%',
-                    onChanged: (v) {
-                      setState(() => _draggingOpacity = v);
-                      if (!restylingAnnotation) controller.opacity = v;
-                    },
-                    onChangeEnd: (v) {
-                      controller.opacity = v;
-                      if (restylingAnnotation) {
-                        controller.restyleSelected(opacity: v);
-                      }
-                      setState(() => _draggingOpacity = null);
-                    },
-                  ),
-                  if (!restylingAnnotation)
+                  if (!isEraser)
+                    _slider(
+                      label: 'Stroke width',
+                      value: strokeValue,
+                      min: 0.5,
+                      max: 12,
+                      display: '${strokeValue.toStringAsFixed(1)} pt',
+                      onChanged: (v) {
+                        setState(() => _draggingStroke = v);
+                        if (!restylingAnnotation) controller.strokeWidth = v;
+                      },
+                      onChangeEnd: (v) {
+                        controller.strokeWidth = v;
+                        if (restylingAnnotation) {
+                          controller.restyleSelected(strokeWidth: v);
+                        }
+                        setState(() => _draggingStroke = null);
+                      },
+                    ),
+                  if (!isEraser)
+                    _slider(
+                      label: 'Opacity',
+                      value: opacityValue,
+                      min: 0.1,
+                      max: 1,
+                      display: '${(opacityValue * 100).round()}%',
+                      onChanged: (v) {
+                        setState(() => _draggingOpacity = v);
+                        if (!restylingAnnotation) controller.opacity = v;
+                      },
+                      onChangeEnd: (v) {
+                        controller.opacity = v;
+                        if (restylingAnnotation) {
+                          controller.restyleSelected(opacity: v);
+                        }
+                        setState(() => _draggingOpacity = null);
+                      },
+                    ),
+                  if (!isEraser && !restylingAnnotation)
                     SwitchListTile(
                       key: const ValueKey('pdf-dashed-stroke'),
                       dense: true,
@@ -877,7 +883,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                       value: controller.dashedStroke,
                       onChanged: (value) => controller.dashedStroke = value,
                     ),
-                  if (showLineEndings) ...[
+                  if (!isEraser && showLineEndings) ...[
                     _lineEndingRow(
                       context: context,
                       label: 'Line start',
@@ -905,63 +911,65 @@ class _StyleMenuState extends State<_StyleMenu> {
                       },
                     ),
                   ],
-                  _slider(
-                    label: 'Font size',
-                    value: _draggingFontSize ??
-                        selectedStyle?.size ??
-                        controller.fontSize,
-                    min: 8,
-                    max: 48,
-                    display:
-                        '${(_draggingFontSize ?? selectedStyle?.size ?? controller.fontSize).round()} pt',
-                    onChanged: (v) {
-                      setState(() => _draggingFontSize = v.roundToDouble());
-                      if (selectedStyle == null) {
-                        controller.fontSize = v.roundToDouble();
-                      }
-                    },
-                    onChangeEnd: (v) {
-                      final size = v.roundToDouble();
-                      controller.fontSize = size;
-                      if (controller.canRestyleSelectedText) {
-                        controller.restyleSelectedText(size: size);
-                      }
-                      setState(() => _draggingFontSize = null);
-                    },
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 4),
-                    child: Row(children: [
-                      const SizedBox(width: 86, child: Text('Font')),
-                      Expanded(
-                        child: SegmentedButton<PdfStandardFont>(
-                          segments: const [
-                            ButtonSegment(
-                                value: PdfStandardFont.helvetica,
-                                label: Text('Sans')),
-                            ButtonSegment(
-                                value: PdfStandardFont.times,
-                                label: Text('Serif')),
-                            ButtonSegment(
-                                value: PdfStandardFont.courier,
-                                label: Text('Mono')),
-                          ],
-                          selected: {
-                            selectedStyle?.font ?? controller.fontFamily
-                          },
-                          showSelectedIcon: false,
-                          style: const ButtonStyle(
-                            visualDensity: VisualDensity.compact,
-                            padding: WidgetStatePropertyAll(
-                                EdgeInsets.symmetric(horizontal: 8)),
+                  if (!isEraser)
+                    _slider(
+                      label: 'Font size',
+                      value: _draggingFontSize ??
+                          selectedStyle?.size ??
+                          controller.fontSize,
+                      min: 8,
+                      max: 48,
+                      display:
+                          '${(_draggingFontSize ?? selectedStyle?.size ?? controller.fontSize).round()} pt',
+                      onChanged: (v) {
+                        setState(() => _draggingFontSize = v.roundToDouble());
+                        if (selectedStyle == null) {
+                          controller.fontSize = v.roundToDouble();
+                        }
+                      },
+                      onChangeEnd: (v) {
+                        final size = v.roundToDouble();
+                        controller.fontSize = size;
+                        if (controller.canRestyleSelectedText) {
+                          controller.restyleSelectedText(size: size);
+                        }
+                        setState(() => _draggingFontSize = null);
+                      },
+                    ),
+                  if (!isEraser)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Row(children: [
+                        const SizedBox(width: 86, child: Text('Font')),
+                        Expanded(
+                          child: SegmentedButton<PdfStandardFont>(
+                            segments: const [
+                              ButtonSegment(
+                                  value: PdfStandardFont.helvetica,
+                                  label: Text('Sans')),
+                              ButtonSegment(
+                                  value: PdfStandardFont.times,
+                                  label: Text('Serif')),
+                              ButtonSegment(
+                                  value: PdfStandardFont.courier,
+                                  label: Text('Mono')),
+                            ],
+                            selected: {
+                              selectedStyle?.font ?? controller.fontFamily
+                            },
+                            showSelectedIcon: false,
+                            style: const ButtonStyle(
+                              visualDensity: VisualDensity.compact,
+                              padding: WidgetStatePropertyAll(
+                                  EdgeInsets.symmetric(horizontal: 8)),
+                            ),
+                            onSelectionChanged: (selection) =>
+                                _setFontFamily(selection.single),
                           ),
-                          onSelectionChanged: (selection) =>
-                              _setFontFamily(selection.single),
                         ),
-                      ),
-                    ]),
-                  ),
-                  if (widget.showColor) ...[
+                      ]),
+                    ),
+                  if (!isEraser && widget.showColor) ...[
                     _boxColorRow(
                       context: context,
                       label: 'Text fill',
@@ -983,10 +991,15 @@ class _StyleMenuState extends State<_StyleMenu> {
           },
         ),
       ],
-      builder: (context, menu, _) => IconButton(
-        icon: const Icon(Icons.tune),
-        tooltip: 'Stroke, opacity, font',
-        onPressed: () => menu.isOpen ? menu.close() : menu.open(),
+      builder: (context, menu, _) => ListenableBuilder(
+        listenable: controller,
+        builder: (context, _) => IconButton(
+          icon: const Icon(Icons.tune),
+          tooltip: controller.tool == PdfEditTool.eraser
+              ? 'Eraser size'
+              : 'Stroke, opacity, font',
+          onPressed: () => menu.isOpen ? menu.close() : menu.open(),
+        ),
       ),
     );
   }

--- a/packages/dart_pdf_editor/test/editing_eraser_test.dart
+++ b/packages/dart_pdf_editor/test/editing_eraser_test.dart
@@ -230,6 +230,39 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets('the tune menu collapses to the eraser size while armed',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+          ),
+        ),
+      ));
+
+      // arming the eraser relabels the tune button so the size control
+      // is discoverable, not hidden behind 'Stroke, opacity, font'
+      editing.tool = PdfEditTool.eraser;
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('Eraser size'), findsOneWidget);
+      expect(find.byTooltip('Stroke, opacity, font'), findsNothing);
+
+      await tester.scrollUntilVisible(find.byTooltip('Eraser size'), 100);
+      await tester.tap(find.byTooltip('Eraser size'));
+      await tester.pumpAndSettle();
+      // only the eraser slider shows — the paint-only controls are gone
+      expect(find.byKey(const ValueKey('pdf-eraser-size')), findsOneWidget);
+      expect(find.byType(Slider), findsOneWidget);
+      expect(find.text('Stroke width'), findsNothing);
+      expect(find.text('Font size'), findsNothing);
+    });
+
     test('the radius persists as a preference', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = PdfEditingPreferences();


### PR DESCRIPTION
## Problem

The eraser size *was* already adjustable, but only by opening the **"Stroke, opacity, font"** tune popup while the eraser tool was armed — where the size slider sat among a row of paint-only controls (stroke width, opacity, font size, font family, dashed line, line endings, text fill/border) that don't apply to erasing. Nothing hinted that an eraser user should open that menu, so changing the eraser size felt impossible.

## Change

While the eraser tool is armed:

- The tune popup **collapses to just the "Eraser size" slider** — every paint-only control is hidden (it doesn't apply to the eraser, which removes ink rather than drawing it).
- The tune button's **tooltip reads "Eraser size"** instead of "Stroke, opacity, font", making the control discoverable.

The persisted `eraserRadius` preference, the live ring cursor, and the 2–40 pt range are all unchanged — this is purely a discoverability/UX fix in `editing_toolbar.dart`. With no eraser armed, the menu and tooltip are exactly as before (the existing 3-slider layout test still passes).

## Tests

- New `editing_eraser_test` case: arming the eraser relabels the tune button and the menu shows only the eraser slider (no Stroke width / Font size).
- Existing eraser, style-menu, line-ending, text-edit and shell suites all green.

https://claude.ai/code/session_01VsVJJX9Gx9CwkACuUkGpKZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsVJJX9Gx9CwkACuUkGpKZ)_