### PR TITLE
Shift+drag marquee selection in default editing mode

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -647,6 +647,17 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// press) grab-pans the document instead of selecting text.
   bool _grabPanning = false;
 
+  /// A Shift+drag in default editing mode (no tool armed, nothing
+  /// selected) rubber-bands a marquee selection of annotations — the
+  /// same gesture the select tool offers, without arming it. The start
+  /// and current points are viewport-local (the selection detector's
+  /// own coordinate space, which the zoom transform maps to screen);
+  /// [_marqueePage] is the page the drag began on, so the box maps to
+  /// one page's user space even if it strays onto a neighbour.
+  Offset? _marqueeStart;
+  Offset? _marqueeCurrent;
+  int? _marqueePage;
+
   /// Set when a raw-pointer gesture (mouse double-click word select) has
   /// consumed the press, so the tap recognizer's late-firing callback for
   /// the same press must not clear it again. Reset on every pointer down.
@@ -1414,6 +1425,40 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     return null;
   }
 
+  /// The cumulative top offset (list coordinates) of page [index].
+  double _pageTop(int index) {
+    var top = 0.0;
+    for (var i = 0; i < index; i++) {
+      top += _pageHeight(i) + widget.pageSpacing;
+    }
+    return top;
+  }
+
+  /// The laid-out geometry of page [index], or null when it isn't
+  /// measurable yet (no width, junk crop box, out of range).
+  PdfPageGeometry? _pageGeometry(int index) {
+    if (_viewWidth <= 0 || index < 0 || index >= _pages.length) return null;
+    final box = _pages[index].cropBox;
+    if (box.width <= 0 || box.height <= 0) return null;
+    return PdfPageGeometry(
+      cropBox: box,
+      rotation: _pages[index].rotation,
+      viewSize: Size(_viewWidth * _layoutZoom, _pageHeight(index)),
+    );
+  }
+
+  /// Maps a viewport-local offset into page [index]'s view-box
+  /// coordinates (what [PdfPageGeometry] expects), without clamping — a
+  /// marquee dragged past the page edge still maps to sensible (possibly
+  /// out-of-page) user-space coordinates.
+  Offset _toPageView(int index, Offset local) {
+    final pageWidth = _viewWidth * _layoutZoom;
+    return Offset(
+      local.dx - (_viewWidth - pageWidth) / 2,
+      _scroll.offset + local.dy - _pageTop(index),
+    );
+  }
+
   /// Maps a pointer position to a text position. [tolerance] is in page
   /// units; pass infinity to snap to the nearest text while dragging.
   (int, int)? _textPositionAt(Offset local, {required double tolerance}) {
@@ -1608,8 +1653,16 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
 
   void _onHover(PointerHoverEvent event) {
     if (_grabPanning) return; // grabbing keeps its cursor mid-drag
+    final editing = widget.editing;
     final MouseCursor cursor;
-    if (_annotationAt(event.localPosition) != null ||
+    if (editing != null &&
+        editing.tool == null &&
+        !editing.isPickingColor &&
+        !editing.hasAnnotationSelection &&
+        HardwareKeyboard.instance.isShiftPressed) {
+      // Shift held in default editing mode: a drag rubber-bands a marquee
+      cursor = SystemMouseCursors.precise;
+    } else if (_annotationAt(event.localPosition) != null ||
         _selectableAnnotationAt(event.localPosition)) {
       cursor = SystemMouseCursors.click;
     } else if (_textPositionAt(event.localPosition, tolerance: 8) != null) {
@@ -1774,6 +1827,24 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     // document out from under its own stroke
     if (_kindDrawsInk(details.kind)) return;
     _focusNode.requestFocus();
+    // Shift+drag in default editing mode (no tool armed, nothing
+    // selected) rubber-bands a marquee selection — the gesture the
+    // select tool offers, without arming it. Shift forces the marquee
+    // over whatever is under the press (text, an annotation, empty
+    // page), so a normal drag still grab-pans or selects text.
+    if (_marqueeShouldStart(details)) {
+      // anchor at the pointer-down position, not where the pan was
+      // recognized past the slop — the box should start under the press
+      final start = _lastMouseDownLocal ?? details.localPosition;
+      final point = _pagePointAt(start);
+      if (point != null) {
+        _marqueePage = point.$1;
+        _marqueeStart = start;
+        setState(() => _marqueeCurrent = details.localPosition);
+        _controller._setSelection('');
+        return;
+      }
+    }
     if (_wordDrag) {
       // double-click-and-drag: anchor on the word under the original
       // press (the drag start has already moved past the touch slop)
@@ -1803,7 +1874,57 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     _controller._setSelection('');
   }
 
+  /// Whether [_onSelectionStart] should begin a marquee instead of a
+  /// text selection or grab-pan: a mouse/trackpad drag with Shift held,
+  /// in default editing mode (a tool would own the gesture, and a live
+  /// selection mounts the editing overlay, which marquees itself).
+  bool _marqueeShouldStart(DragStartDetails details) {
+    final editing = widget.editing;
+    if (editing == null ||
+        editing.tool != null ||
+        editing.isPickingColor ||
+        editing.hasAnnotationSelection) {
+      return false;
+    }
+    final kind = details.kind;
+    final mouseLike = kind == null ||
+        kind == PointerDeviceKind.mouse ||
+        kind == PointerDeviceKind.trackpad;
+    return mouseLike && HardwareKeyboard.instance.isShiftPressed;
+  }
+
+  /// Finishes a marquee drag: selects the annotations the box covers on
+  /// the page the drag began on. A box too small to be a deliberate drag
+  /// is treated as a click (no selection change).
+  void _commitMarquee() {
+    final editing = widget.editing;
+    final page = _marqueePage;
+    final start = _marqueeStart;
+    final current = _marqueeCurrent ?? start;
+    setState(() {
+      _marqueeStart = null;
+      _marqueeCurrent = null;
+      _marqueePage = null;
+    });
+    if (editing == null || page == null || start == null || current == null) {
+      return;
+    }
+    final box = Rect.fromPoints(start, current);
+    if (box.width < 4 && box.height < 4) return; // a click, not a drag
+    final geometry = _pageGeometry(page);
+    if (geometry == null || !_scroll.hasClients) return;
+    editing.selectAnnotationsIn(
+      page,
+      geometry.toPageRect(Rect.fromPoints(
+          _toPageView(page, box.topLeft), _toPageView(page, box.bottomRight))),
+    );
+  }
+
   void _onSelectionUpdate(DragUpdateDetails details) {
+    if (_marqueeStart != null) {
+      setState(() => _marqueeCurrent = details.localPosition);
+      return;
+    }
     if (_grabPanning) {
       _grabPanBy(details.delta);
       return;
@@ -1821,6 +1942,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   }
 
   void _onSelectionEnd(DragEndDetails details) {
+    if (_marqueeStart != null) {
+      _commitMarquee();
+      return;
+    }
     if (!_grabPanning) return;
     _grabPanning = false;
     setState(() => _hoverCursor = SystemMouseCursors.grab);
@@ -2401,6 +2526,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
         (Theme.of(context).brightness == Brightness.dark
             ? const Color(0xFF202124)
             : const Color(0xFF404347));
+    // the rubber-band marquee's chrome, matching the editing overlay's
+    final marqueeColor =
+        PdfViewerTheme.of(context).annotationChromeColor ??
+            const Color(0xFF1E88E5);
     return LayoutBuilder(builder: (context, constraints) {
       // _viewWidth still holds the previous layout's width here; a change
       // rescales every page, so pin the reading position before adopting it
@@ -2697,12 +2826,34 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                               child: ColoredBox(
                                 key: _listSpaceKey,
                                 color: canvasColor,
-                                // with ctrl/cmd held the list stops claiming wheel
-                                // events, so they reach the InteractiveViewer, which
-                                // zooms around the pointer
-                                child: IgnorePointer(
-                                  ignoring: _zoomModifierDown,
-                                  child: scrollable,
+                                child: Stack(
+                                  fit: StackFit.expand,
+                                  children: [
+                                    // with ctrl/cmd held the list stops claiming
+                                    // wheel events, so they reach the
+                                    // InteractiveViewer, which zooms around the
+                                    // pointer
+                                    IgnorePointer(
+                                      ignoring: _zoomModifierDown,
+                                      child: scrollable,
+                                    ),
+                                    // the Shift+drag marquee, drawn in this
+                                    // (list) space so it tracks the gesture and
+                                    // scales with the zoom transform
+                                    if (_marqueeStart != null &&
+                                        _marqueeCurrent != null)
+                                      Positioned.fill(
+                                        child: IgnorePointer(
+                                          child: CustomPaint(
+                                            painter: _MarqueePainter(
+                                              Rect.fromPoints(_marqueeStart!,
+                                                  _marqueeCurrent!),
+                                              marqueeColor,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                  ],
                                 ),
                               ),
                             ),
@@ -2748,6 +2899,31 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       );
     });
   }
+}
+
+/// Paints the Shift+drag rubber-band marquee (a translucent fill with a
+/// hairline border), in list space so the zoom transform scales it.
+class _MarqueePainter extends CustomPainter {
+  const _MarqueePainter(this.rect, this.color);
+
+  final Rect rect;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawRect(rect, Paint()..color = color.withAlpha(0x14));
+    canvas.drawRect(
+      rect,
+      Paint()
+        ..color = color
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_MarqueePainter oldDelegate) =>
+      oldDelegate.rect != rect || oldDelegate.color != color;
 }
 
 class _PdfViewerPage extends StatefulWidget {

--- a/packages/dart_pdf_editor/test/editing_multiselect_test.dart
+++ b/packages/dart_pdf_editor/test/editing_multiselect_test.dart
@@ -321,6 +321,50 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets(
+        'a shift+drag rubber-bands a selection with no tool armed',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      await addShapes(tester, editing);
+      expect(editing.tool, isNull);
+
+      // hold shift: a drag over both shapes rubber-bands them, the same
+      // gesture the select tool offers but without arming it
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      final gesture = await tester.startGesture(view(80, 730),
+          kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(view(200, 690));
+      await tester.pump();
+      await gesture.moveTo(view(340, 630));
+      await tester.pump();
+      await gesture.up();
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pump();
+
+      expect(editing.selectedAnnotationSlots, [(0, 0), (0, 1)]);
+      expect(editing.tool, isNull, reason: 'no tool got armed');
+      await settle(tester);
+    });
+
+    testWidgets('without shift, a mouse drag on empty area does not marquee',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      await addShapes(tester, editing);
+
+      final gesture = await tester.startGesture(view(80, 730),
+          kind: PointerDeviceKind.mouse);
+      await gesture.moveTo(view(200, 690));
+      await tester.pump();
+      await gesture.moveTo(view(340, 630));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      expect(editing.hasAnnotationSelection, isFalse,
+          reason: 'a plain drag grab-pans, it does not rubber-band');
+      await settle(tester);
+    });
+
     testWidgets('the delete key removes the whole selection as one undo step',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);


### PR DESCRIPTION
## What

In plain default editing mode — no tool armed, nothing selected — holding **Shift** while dragging now rubber-bands a marquee selection of the annotations the box covers. It's the same gesture the select tool offers, without arming it.

## Why

A marquee selection previously required either the select tool to be armed, or a selection to already exist (which mounts the editing overlay, whose own pan handler draws the marquee). In the common default/reader editing state, a mouse drag only ever grab-panned the document or selected text — there was no way to box-select annotations without first switching tools.

## How

All changes live in `pdf_viewer.dart`, in the viewer's existing mouse/trackpad selection pan path (the only drag handler active when no tool is armed and nothing is selected):

- `_onSelectionStart` begins a marquee when Shift is held in default editing mode (mouse/trackpad only). Shift forces the marquee over whatever is under the press, so a plain drag still grab-pans / selects text.
- The box is anchored at the **pointer-down** position (not where the pan was recognized past the slop) and maps to the page the drag began on, so it stays correct even if the pointer strays onto a neighbouring page.
- On release, `selectAnnotationsIn` selects the covered annotations; a box too small to be a deliberate drag is treated as a click.
- The box is painted in list space (`_MarqueePainter`) so it tracks the gesture and scales with the zoom transform, matching the overlay's chrome colour.
- The hover cursor switches to a crosshair while Shift is held, signalling the mode.

When a selection already exists or the select tool is armed, the editing overlay is mounted and continues to handle the marquee itself — this only fills the previously-uncovered default-mode gap.

## Tests

`editing_multiselect_test.dart`:
- a Shift+drag rubber-bands a selection with no tool armed
- without Shift, a mouse drag on empty area does not marquee (still grab-pans)

Full `dart_pdf_editor` analyze is clean and the viewer/selection suites pass. The 14 pre-existing `ghent_render_test` CMYK-overprint baseline failures are unrelated (they fail identically on the clean tree).

https://claude.ai/code/session_01NCVN4QTsyrsUUKv5jqp65i

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVN4QTsyrsUUKv5jqp65i)_