### PR TITLE
Panels and thumbnail strip become bottom sheets on small screens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1895,3 +1895,44 @@ and the editor never closes); the choice /V stores the EXPORT value ('L'
 not 'Large'); don't tap-test suppression with the ink tool armed (the
 dot's 800ms auto-commit timer trips !timersPending) — assert the layer's
 absence with find.byType(FormInteractionLayer) instead.
+
+Bottom-sheet panels on small screens (Ben: "the panels and strips should
+be bottom sheets on small screens"): below `pdfShellCompactWidth` (700,
+the existing compact threshold) the shells float the side panels and the
+thumbnail strip up from the bottom instead of docking them — a docked
+280px panel crowds the page out on a phone. `pdfShellUseBottomSheets(
+constraints)` + `pdfShellBottomSheets(sheets)` + `PdfPanelBottomSheet`
+all live in shell_chrome.dart (package-private). Each panel
+(PdfThumbnailSidebar/PdfAnnotationSidebar/PdfAnnotationPropertiesPanel/
+PdfSearchResultsPanel) gained a `bottomSheet` bool (default false): when
+true it fills its parent (no fixed-width SizedBox), drops the side resize
+grip, and the scrollbar/list clearance loses the grip width — factored
+through local `showGrip`/`onLeftEdge` flags so the grip-side scrollbar
+inset goes to 0. The thumbnail strip is the exception: it keeps its
+preferred-width tile column `Center`ed in the wider sheet rather than
+stretching one giant thumbnail to phone width (raster resolution, reorder,
+and delete all keep working unchanged); a grid/horizontal strip was
+rejected as too invasive for `_PageTile`'s AspectRatio layout.
+`PdfPanelBottomSheet` is the chrome: rounded top, a drag handle that
+swipes down to dismiss (onVerticalDragEnd primaryVelocity > 200) plus a
+titled header with a close button (keys 'pdf-shell-<panel>-sheet-close');
+`pdfShellBottomSheets` lays the active sheets out in a bottom-anchored
+Column (Positioned.fill + Align.bottomCenter, so the clear area above
+keeps scrolling/tapping the page through to the viewer), each `Flexible`
++ capped at 0.55 of the content height — one sheet rises to 55%, several
+share the area evenly without overflowing off the top. The shells build
+panel closures `panel({required bool bottomSheet})` and switch on
+`useSheets`: docked panels go in the Row (`!useSheets`), sheet-wrapped
+ones go in `pdfShellBottomSheets`; closing a sheet flips the panel's
+visibility preference off (showThumbnailSidebar/showAnnotationSidebar/
+showPropertiesPanel/showSearchResultsPanel). PdfEditorView hides the
+floating toolbar while a sheet is open (`features.toolbar &&
+sheets.isEmpty`) since the sheet covers the bottom; PdfReader (thumbnails
+only) grew a Stack around its viewer Row to host the overlay. The
+thumbnail compact default (`pdfShellShowThumbnailSidebar` — closed on
+compact unless an explicit pref) is unchanged; an explicit on shows the
+strip as a sheet. Tests: pdf_shell_test.dart +4 (compact toggles open a
+sheet, the close button hides it + clears the pref, wide stays docked
+with a resize grip, the reader strip is a sheet). Gotcha: the default
+800x600 test surface is ABOVE 700, so existing shell tests stay docked
+untouched; `compactScreen` (600x800) drives the sheet path.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -38,6 +38,7 @@ class PdfAnnotationPropertiesPanel extends StatefulWidget {
     this.minWidth = 200,
     this.maxWidth = 420,
     this.showAuthor = true,
+    this.bottomSheet = false,
   });
 
   final PdfEditingController controller;
@@ -61,6 +62,11 @@ class PdfAnnotationPropertiesPanel extends StatefulWidget {
   /// annotation's author can't be edited here — for hosts that set the
   /// author programmatically and lock it.
   final bool showAuthor;
+
+  /// Lays the panel out to fill its parent (full width, no side resize
+  /// grip) for hosting inside a bottom sheet on a small screen, rather
+  /// than as a fixed-width docked column.
+  final bool bottomSheet;
 
   @override
   State<PdfAnnotationPropertiesPanel> createState() =>
@@ -525,11 +531,9 @@ class _PdfAnnotationPropertiesPanelState
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: _width,
-      child: Stack(children: [
-        Positioned.fill(
-          child: Material(
+    final showGrip = widget.resizable && !widget.bottomSheet;
+    final onLeftEdge = !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    final content = Material(
             color: Theme.of(context).colorScheme.surfaceContainerLow,
             child: ListenableBuilder(
               listenable: _controller,
@@ -550,9 +554,7 @@ class _PdfAnnotationPropertiesPanelState
                     ? _buildSingle(annotation)
                     : _buildMulti(annotation, count);
                 final barClearance = PdfScrollbar.hitExtent +
-                    (widget.resizable && widget.side == PdfSidebarSide.left
-                        ? PdfSidebarResizeGrip.width
-                        : 0);
+                    (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
                 return Stack(children: [
                   ScrollConfiguration(
                     behavior: ScrollConfiguration.of(context)
@@ -566,9 +568,7 @@ class _PdfAnnotationPropertiesPanelState
                     top: 0,
                     bottom: 0,
                     right:
-                        widget.resizable && widget.side == PdfSidebarSide.left
-                            ? PdfSidebarResizeGrip.width
-                            : 0,
+                        showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
                     child: PdfScrollbar(
                       scroll: _scroll,
                       thumbKey:
@@ -578,9 +578,13 @@ class _PdfAnnotationPropertiesPanelState
                 ]);
               },
             ),
-          ),
-        ),
-        if (widget.resizable)
+          );
+    if (widget.bottomSheet) return content;
+    return SizedBox(
+      width: _width,
+      child: Stack(children: [
+        Positioned.fill(child: content),
+        if (showGrip)
           Positioned(
             top: 0,
             bottom: 0,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -48,6 +48,7 @@ class PdfAnnotationSidebar extends StatefulWidget {
     this.resizable = true,
     this.minWidth = 200,
     this.maxWidth = 480,
+    this.bottomSheet = false,
   });
 
   final PdfEditingController controller;
@@ -69,6 +70,11 @@ class PdfAnnotationSidebar extends StatefulWidget {
   /// Clamps for the dragged width.
   final double minWidth;
   final double maxWidth;
+
+  /// Lays the panel out to fill its parent (full width, no side resize
+  /// grip) for hosting inside a bottom sheet on a small screen, rather
+  /// than as a fixed-width docked column.
+  final bool bottomSheet;
 
   @override
   State<PdfAnnotationSidebar> createState() => _PdfAnnotationSidebarState();
@@ -350,11 +356,11 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: _width,
-      child: Stack(children: [
-        Positioned.fill(
-          child: Material(
+    // a bottom sheet supplies its own width and resize affordance, so the
+    // panel drops the side resize grip and fills its parent
+    final showGrip = widget.resizable && !widget.bottomSheet;
+    final onLeftEdge = !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    final content = Material(
             color: Theme.of(context).colorScheme.surfaceContainerLow,
             child: ListenableBuilder(
               listenable: widget.controller,
@@ -399,9 +405,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                 // keep the list clear of the overlay scrollbar's zone so
                 // the bar never covers a tile's trailing button
                 final barClearance = PdfScrollbar.hitExtent +
-                    (widget.resizable && widget.side == PdfSidebarSide.left
-                        ? PdfSidebarResizeGrip.width
-                        : 0);
+                    (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
                 final list = children.isEmpty
                     ? Center(
                         child: Text(listed > 0 && query.isNotEmpty
@@ -419,8 +423,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                         Positioned(
                           top: 0,
                           bottom: 0,
-                          right: widget.resizable &&
-                                  widget.side == PdfSidebarSide.left
+                          right: showGrip && onLeftEdge
                               ? PdfSidebarResizeGrip.width
                               : 0,
                           child: PdfScrollbar(
@@ -444,9 +447,13 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                 ]);
               },
             ),
-          ),
-        ),
-        if (widget.resizable)
+          );
+    if (widget.bottomSheet) return content;
+    return SizedBox(
+      width: _width,
+      child: Stack(children: [
+        Positioned.fill(child: content),
+        if (showGrip)
           Positioned(
             top: 0,
             bottom: 0,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -54,6 +54,7 @@ class PdfThumbnailSidebar extends StatefulWidget {
     this.maxWidth = 400,
     this.followsViewer = true,
     this.allowPageEditing = true,
+    this.bottomSheet = false,
   });
 
   final PdfEditingController controller;
@@ -93,6 +94,11 @@ class PdfThumbnailSidebar extends StatefulWidget {
   /// read-only viewer wants.
   final bool allowPageEditing;
 
+  /// Lays the strip out to fill its parent (full width, no side resize
+  /// grip) for hosting inside a bottom sheet on a small screen, rather
+  /// than as a fixed-width docked column.
+  final bool bottomSheet;
+
   /// How many thumbnails have actually been rasterized — cache misses
   /// only, across all sidebars. Tests assert on the deltas.
   @visibleForTesting
@@ -127,7 +133,9 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   /// bar never covers a tile. Tiles already pad 12px on their own.
   double get _barClearance =>
       PdfScrollbar.hitExtent +
-      (widget.resizable && widget.side == PdfSidebarSide.left
+      (widget.resizable &&
+              !widget.bottomSheet &&
+              widget.side == PdfSidebarSide.left
           ? PdfSidebarResizeGrip.width
           : 0);
 
@@ -240,7 +248,11 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   Widget build(BuildContext context) {
     final width = _width;
     final controller = widget.controller;
-    return SizedBox(
+    // a bottom sheet supplies its own width and resize affordance, so the
+    // strip drops the side resize grip; the tile column keeps its preferred
+    // width, centered in the wider sheet rather than stretched
+    final showGrip = widget.resizable && !widget.bottomSheet;
+    final body = SizedBox(
       width: width,
       child: Stack(children: [
         Positioned.fill(
@@ -290,7 +302,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
         Positioned(
           top: 0,
           bottom: 0,
-          right: widget.resizable && widget.side == PdfSidebarSide.left
+          right: showGrip && widget.side == PdfSidebarSide.left
               ? PdfSidebarResizeGrip.width
               : 0,
           child: PdfScrollbar(
@@ -298,7 +310,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
             thumbKey: const ValueKey('pdf-thumbnail-scrollbar-thumb'),
           ),
         ),
-        if (widget.resizable)
+        if (showGrip)
           Positioned(
             top: 0,
             bottom: 0,
@@ -313,6 +325,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
           ),
       ]),
     );
+    return widget.bottomSheet ? Center(child: body) : body;
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -378,6 +378,90 @@ class _PdfEditorViewState extends State<PdfEditorView> {
           final pageColor = widget.pageColor ?? prefs.pageColor;
           final showThumbnails =
               pdfShellShowThumbnailSidebar(prefs, constraints);
+          // on a narrow screen the panels float up from the bottom as
+          // sheets instead of docking to the side and crowding the page
+          final useSheets = pdfShellUseBottomSheets(constraints);
+
+          PdfThumbnailSidebar thumbnails({required bool bottomSheet}) =>
+              PdfThumbnailSidebar(
+                key: const ValueKey('pdf-shell-thumbnails'),
+                controller: session,
+                viewerController: _viewer,
+                pageColor: pageColor,
+                showAnnotations: prefs.showAnnotations,
+                allowPageEditing: features.pageEditing,
+                bottomSheet: bottomSheet,
+              );
+          PdfSearchResultsPanel searchResults({required bool bottomSheet}) =>
+              PdfSearchResultsPanel(
+                key: const ValueKey('pdf-shell-search-panel'),
+                controller: _viewer,
+                preferences: prefs,
+                bottomSheet: bottomSheet,
+              );
+          PdfAnnotationSidebar annotations({required bool bottomSheet}) =>
+              PdfAnnotationSidebar(
+                key: const ValueKey('pdf-shell-annotations'),
+                controller: session,
+                viewerController: _viewer,
+                bottomSheet: bottomSheet,
+              );
+          PdfAnnotationPropertiesPanel properties({required bool bottomSheet}) =>
+              PdfAnnotationPropertiesPanel(
+                key: const ValueKey('pdf-shell-properties'),
+                controller: session,
+                showAuthor: features.authorEditable,
+                bottomSheet: bottomSheet,
+              );
+
+          final showThumbnailsPanel = features.thumbnails && showThumbnails;
+          final showSearchPanel = features.search &&
+              features.searchResultsPanel &&
+              prefs.showSearchResultsPanel;
+          final showAnnotationsPanel =
+              features.annotationSidebar && prefs.showAnnotationSidebar;
+          final showPropertiesPanel =
+              features.propertiesPanel && prefs.showPropertiesPanel;
+
+          final sheets = !useSheets
+              ? const <Widget>[]
+              : <Widget>[
+                  if (showThumbnailsPanel)
+                    PdfPanelBottomSheet(
+                      key: const ValueKey('pdf-shell-thumbnails-sheet'),
+                      title: 'Pages',
+                      closeKey:
+                          const ValueKey('pdf-shell-thumbnails-sheet-close'),
+                      onClose: () => prefs.showThumbnailSidebar = false,
+                      child: thumbnails(bottomSheet: true),
+                    ),
+                  if (showSearchPanel)
+                    PdfPanelBottomSheet(
+                      key: const ValueKey('pdf-shell-search-sheet'),
+                      title: 'Search results',
+                      closeKey: const ValueKey('pdf-shell-search-sheet-close'),
+                      onClose: () => prefs.showSearchResultsPanel = false,
+                      child: searchResults(bottomSheet: true),
+                    ),
+                  if (showAnnotationsPanel)
+                    PdfPanelBottomSheet(
+                      key: const ValueKey('pdf-shell-annotations-sheet'),
+                      title: 'Annotations',
+                      closeKey:
+                          const ValueKey('pdf-shell-annotations-sheet-close'),
+                      onClose: () => prefs.showAnnotationSidebar = false,
+                      child: annotations(bottomSheet: true),
+                    ),
+                  if (showPropertiesPanel)
+                    PdfPanelBottomSheet(
+                      key: const ValueKey('pdf-shell-properties-sheet'),
+                      title: 'Properties',
+                      closeKey:
+                          const ValueKey('pdf-shell-properties-sheet-close'),
+                      onClose: () => prefs.showPropertiesPanel = false,
+                      child: properties(bottomSheet: true),
+                    ),
+                ];
           return Column(children: [
             if (features.headerBar)
               PdfShellBar(
@@ -465,56 +549,35 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                   // keyed so a panel appearing never recreates the viewer
                   // element (which would reset the reading position)
                   child: Row(children: [
-                    if (features.thumbnails && showThumbnails)
-                  PdfThumbnailSidebar(
-                    key: const ValueKey('pdf-shell-thumbnails'),
-                    controller: session,
-                    viewerController: _viewer,
-                    pageColor: pageColor,
-                    showAnnotations: prefs.showAnnotations,
-                    allowPageEditing: features.pageEditing,
-                  ),
-                if (features.search &&
-                    features.searchResultsPanel &&
-                    prefs.showSearchResultsPanel)
-                  PdfSearchResultsPanel(
-                    key: const ValueKey('pdf-shell-search-panel'),
-                    controller: _viewer,
-                    preferences: prefs,
-                  ),
-                Expanded(
-                  key: const ValueKey('pdf-shell-viewer'),
-                  child: PdfViewer(
-                    document: session.document,
-                    controller: _viewer,
-                    editing: session,
-                    onAction: widget.onAction,
-                    pageOverlayBuilder: widget.pageOverlayBuilder,
-                    annotationMenuBuilder: widget.annotationMenuBuilder,
-                    formImagePicker: widget.formImagePicker,
-                    editingTextPrompt: widget.textPrompt,
-                    initialFit: widget.initialFit,
-                    backgroundColor: widget.backgroundColor,
-                    pageColor: pageColor,
-                    showAnnotations: prefs.showAnnotations,
-                    highlightFormFields: prefs.highlightFormFields,
-                  ),
-                ),
-                if (features.annotationSidebar && prefs.showAnnotationSidebar)
-                  PdfAnnotationSidebar(
-                    key: const ValueKey('pdf-shell-annotations'),
-                    controller: session,
-                    viewerController: _viewer,
-                  ),
-                    if (features.propertiesPanel && prefs.showPropertiesPanel)
-                      PdfAnnotationPropertiesPanel(
-                        key: const ValueKey('pdf-shell-properties'),
-                        controller: session,
-                        showAuthor: features.authorEditable,
+                    if (showThumbnailsPanel && !useSheets)
+                      thumbnails(bottomSheet: false),
+                    if (showSearchPanel && !useSheets)
+                      searchResults(bottomSheet: false),
+                    Expanded(
+                      key: const ValueKey('pdf-shell-viewer'),
+                      child: PdfViewer(
+                        document: session.document,
+                        controller: _viewer,
+                        editing: session,
+                        onAction: widget.onAction,
+                        pageOverlayBuilder: widget.pageOverlayBuilder,
+                        annotationMenuBuilder: widget.annotationMenuBuilder,
+                        formImagePicker: widget.formImagePicker,
+                        editingTextPrompt: widget.textPrompt,
+                        initialFit: widget.initialFit,
+                        backgroundColor: widget.backgroundColor,
+                        pageColor: pageColor,
+                        showAnnotations: prefs.showAnnotations,
+                        highlightFormFields: prefs.highlightFormFields,
                       ),
+                    ),
+                    if (showAnnotationsPanel && !useSheets)
+                      annotations(bottomSheet: false),
+                    if (showPropertiesPanel && !useSheets)
+                      properties(bottomSheet: false),
                   ]),
                 ),
-                if (features.toolbar)
+                if (features.toolbar && sheets.isEmpty)
                   Positioned(
                     left: 0,
                     right: 0,
@@ -535,6 +598,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       trailing: widget.toolbarTrailing,
                     ),
                   ),
+                if (sheets.isNotEmpty) pdfShellBottomSheets(sheets),
               ]),
             ),
           ]);

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -225,6 +225,22 @@ class _PdfReaderState extends State<PdfReader> {
           final pageColor = widget.pageColor ?? prefs.pageColor;
           final showThumbnails =
               pdfShellShowThumbnailSidebar(prefs, constraints);
+          // on a narrow screen the strip floats up from the bottom as a
+          // sheet instead of docking to the side and crowding the page
+          final useSheets = pdfShellUseBottomSheets(constraints);
+          final showThumbnailsPanel =
+              features.thumbnails && showThumbnails && !prefs.showReflowView;
+
+          PdfThumbnailSidebar thumbnails({required bool bottomSheet}) =>
+              PdfThumbnailSidebar(
+                key: const ValueKey('pdf-shell-thumbnails'),
+                controller: _session,
+                viewerController: _viewer,
+                pageColor: pageColor,
+                showAnnotations: prefs.showAnnotations,
+                allowPageEditing: false,
+                bottomSheet: bottomSheet,
+              );
           return Column(children: [
             if (features.headerBar)
               PdfShellBar(
@@ -261,45 +277,51 @@ class _PdfReaderState extends State<PdfReader> {
             Expanded(
               // keyed so a panel appearing never recreates the viewer
               // element (which would reset the reading position)
-              child: Row(children: [
-                if (features.thumbnails &&
-                    showThumbnails &&
-                    !prefs.showReflowView)
-                  PdfThumbnailSidebar(
-                    key: const ValueKey('pdf-shell-thumbnails'),
-                    controller: _session,
-                    viewerController: _viewer,
-                    pageColor: pageColor,
-                    showAnnotations: prefs.showAnnotations,
-                    allowPageEditing: false,
-                  ),
-                Expanded(
-                  key: const ValueKey('pdf-shell-viewer'),
-                  // rebuilds on session changes too: filling a form
-                  // produces a revision, so the viewer must track
-                  // _session.document, not the build-time snapshot
-                  child: ListenableBuilder(
-                    listenable: _session,
-                    builder: (context, _) => prefs.showReflowView
-                        ? PdfReflowView(
-                            document: _session.document,
-                            backgroundColor: widget.backgroundColor,
-                          )
-                        : PdfViewer(
-                            document: _session.document,
-                            controller: _viewer,
-                            formController:
-                                features.fillForms ? _session : null,
-                            onAction: widget.onAction,
-                            pageOverlayBuilder: widget.pageOverlayBuilder,
-                            initialFit: widget.initialFit,
-                            backgroundColor: widget.backgroundColor,
-                            pageColor: pageColor,
-                            showAnnotations: prefs.showAnnotations,
-                            highlightFormFields: prefs.highlightFormFields,
-                          ),
-                  ),
+              child: Stack(children: [
+                Positioned.fill(
+                  child: Row(children: [
+                    if (showThumbnailsPanel && !useSheets)
+                      thumbnails(bottomSheet: false),
+                    Expanded(
+                      key: const ValueKey('pdf-shell-viewer'),
+                      // rebuilds on session changes too: filling a form
+                      // produces a revision, so the viewer must track
+                      // _session.document, not the build-time snapshot
+                      child: ListenableBuilder(
+                        listenable: _session,
+                        builder: (context, _) => prefs.showReflowView
+                            ? PdfReflowView(
+                                document: _session.document,
+                                backgroundColor: widget.backgroundColor,
+                              )
+                            : PdfViewer(
+                                document: _session.document,
+                                controller: _viewer,
+                                formController:
+                                    features.fillForms ? _session : null,
+                                onAction: widget.onAction,
+                                pageOverlayBuilder: widget.pageOverlayBuilder,
+                                initialFit: widget.initialFit,
+                                backgroundColor: widget.backgroundColor,
+                                pageColor: pageColor,
+                                showAnnotations: prefs.showAnnotations,
+                                highlightFormFields: prefs.highlightFormFields,
+                              ),
+                      ),
+                    ),
+                  ]),
                 ),
+                if (useSheets && showThumbnailsPanel)
+                  pdfShellBottomSheets([
+                    PdfPanelBottomSheet(
+                      key: const ValueKey('pdf-shell-thumbnails-sheet'),
+                      title: 'Pages',
+                      closeKey:
+                          const ValueKey('pdf-shell-thumbnails-sheet-close'),
+                      onClose: () => prefs.showThumbnailSidebar = false,
+                      child: thumbnails(bottomSheet: true),
+                    ),
+                  ]),
               ]),
             ),
           ]);

--- a/packages/dart_pdf_editor/lib/src/search_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/search_panel.dart
@@ -199,6 +199,7 @@ class PdfSearchResultsPanel extends StatefulWidget {
     this.resizable = true,
     this.minWidth = 200,
     this.maxWidth = 480,
+    this.bottomSheet = false,
   });
 
   final PdfViewerController controller;
@@ -219,6 +220,11 @@ class PdfSearchResultsPanel extends StatefulWidget {
   /// Clamps for the dragged width.
   final double minWidth;
   final double maxWidth;
+
+  /// Lays the panel out to fill its parent (full width, no side resize
+  /// grip) for hosting inside a bottom sheet on a small screen, rather
+  /// than as a fixed-width docked column.
+  final bool bottomSheet;
 
   @override
   State<PdfSearchResultsPanel> createState() => _PdfSearchResultsPanelState();
@@ -309,11 +315,9 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
   @override
   Widget build(BuildContext context) {
     final controller = widget.controller;
-    return SizedBox(
-      width: _width,
-      child: Stack(children: [
-        Positioned.fill(
-          child: Material(
+    final showGrip = widget.resizable && !widget.bottomSheet;
+    final onLeftEdge = !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    final content = Material(
             color: Theme.of(context).colorScheme.surfaceContainerLow,
             child: ListenableBuilder(
               listenable: controller,
@@ -338,9 +342,7 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
                   entries.add((header: null, result: i));
                 }
                 final barClearance = PdfScrollbar.hitExtent +
-                    (widget.resizable && widget.side == PdfSidebarSide.left
-                        ? PdfSidebarResizeGrip.width
-                        : 0);
+                    (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
                 final textTheme = Theme.of(context).textTheme;
                 return Stack(children: [
                   Column(children: [
@@ -391,9 +393,7 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
                     top: 0,
                     bottom: 0,
                     right:
-                        widget.resizable && widget.side == PdfSidebarSide.left
-                            ? PdfSidebarResizeGrip.width
-                            : 0,
+                        showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
                     child: PdfScrollbar(
                       scroll: _scroll,
                       thumbKey: const ValueKey('pdf-search-scrollbar-thumb'),
@@ -402,9 +402,13 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
                 ]);
               },
             ),
-          ),
-        ),
-        if (widget.resizable)
+          );
+    if (widget.bottomSheet) return content;
+    return SizedBox(
+      width: _width,
+      child: Stack(children: [
+        Positioned.fill(child: content),
+        if (showGrip)
           Positioned(
             top: 0,
             bottom: 0,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -11,6 +11,142 @@ import 'pdf_viewer.dart';
 
 const double pdfShellCompactWidth = 700;
 
+/// Whether the shell is narrow enough that side panels should give way to
+/// bottom sheets — a phone, or a small window. Below [pdfShellCompactWidth]
+/// a docked 280px panel would crowd the page out, so the shells float the
+/// panels (and the thumbnail strip) up from the bottom instead.
+bool pdfShellUseBottomSheets(BoxConstraints constraints) =>
+    constraints.maxWidth.isFinite && constraints.maxWidth < pdfShellCompactWidth;
+
+/// Fraction of the content area a single bottom-sheet panel rises to when
+/// it is the only one open; several share the area evenly.
+const double _pdfShellSheetHeightFactor = 0.55;
+
+/// Lays the active panel [sheets] out as bottom sheets, stacked above one
+/// another and anchored to the bottom of the content area. The space above
+/// the topmost sheet stays clear, so the page underneath keeps scrolling
+/// and taking taps. Returns a [Positioned] — drop it straight into the
+/// content [Stack] (only when [sheets] is non-empty).
+Widget pdfShellBottomSheets(List<Widget> sheets) {
+  return Positioned.fill(
+    child: LayoutBuilder(
+      builder: (context, constraints) {
+        // each sheet rises to a fraction of the area; the whole stack is
+        // capped at the area height so two open sheets share it rather than
+        // overflowing off the top
+        final maxSheet = constraints.maxHeight * _pdfShellSheetHeightFactor;
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: constraints.maxHeight),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final sheet in sheets)
+                  Flexible(
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(maxHeight: maxSheet),
+                      child: sheet,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    ),
+  );
+}
+
+/// The chrome around a side panel presented as a bottom sheet on a small
+/// screen: rounded top, a drag handle that swipes down to dismiss, and a
+/// titled header with a close button. The panel [child] fills the rest.
+class PdfPanelBottomSheet extends StatelessWidget {
+  const PdfPanelBottomSheet({
+    super.key,
+    required this.title,
+    required this.onClose,
+    required this.child,
+    this.closeKey,
+  });
+
+  /// The panel's name, shown in the header.
+  final String title;
+
+  /// Dismisses the sheet — the shells turn the panel's visibility
+  /// preference off.
+  final VoidCallback onClose;
+
+  /// The panel itself, built in its bottom-sheet layout (full width, no
+  /// side resize grip).
+  final Widget child;
+
+  /// A key for the close button, for tests.
+  final Key? closeKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.surfaceContainerLow,
+      elevation: 8,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // the handle and header swipe down to dismiss, the Material
+          // bottom-sheet idiom
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onVerticalDragEnd: (details) {
+              if ((details.primaryVelocity ?? 0) > 200) onClose();
+            },
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 10, bottom: 2),
+                  child: Container(
+                    width: 32,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: scheme.onSurfaceVariant.withValues(alpha: 0.4),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 4, 0),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(title,
+                            style: Theme.of(context).textTheme.titleSmall),
+                      ),
+                      IconButton(
+                        key: closeKey,
+                        icon: const Icon(Icons.close),
+                        tooltip: 'Close',
+                        visualDensity: VisualDensity.compact,
+                        onPressed: onClose,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}
+
 /// Persists a viewer's scroll position and zoom per document, so the
 /// shells reopen a document where the user left it.
 ///

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -484,4 +484,89 @@ void main() {
       expect(viewer.pageColor, const Color(0xFFEEF7EE));
     });
   });
+
+  // On a narrow screen the side panels and the thumbnail strip become
+  // bottom sheets instead of docking and crowding the page out.
+  group('bottom sheets on small screens', () {
+    testWidgets('compact: a toggled panel floats up as a bottom sheet',
+        (tester) async {
+      compactScreen(tester);
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+      expect(find.byType(PdfAnnotationSidebar), findsNothing);
+
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-shell-annotations-toggle')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+
+      // the panel is present, wrapped in a bottom sheet (its close button)
+      expect(find.byType(PdfAnnotationSidebar), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-annotations-sheet-close')),
+          findsOneWidget);
+      // and it does not dock a side resize grip
+      expect(find.byKey(const ValueKey('pdf-annotation-resize-grip')),
+          findsNothing);
+    });
+
+    testWidgets('compact: the sheet close button hides the panel',
+        (tester) async {
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      compactScreen(tester);
+      await pump(tester,
+          PdfEditorView(bytes: buildMultiPagePdf(2), preferences: prefs));
+
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-shell-properties-toggle')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      expect(find.byType(PdfAnnotationPropertiesPanel), findsOneWidget);
+
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-shell-properties-sheet-close')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      expect(find.byType(PdfAnnotationPropertiesPanel), findsNothing);
+      expect(prefs.showPropertiesPanel, isFalse);
+    });
+
+    testWidgets('wide: panels dock to the side, not a bottom sheet',
+        (tester) async {
+      // the default 800x600 test surface is above the compact width
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-shell-annotations-toggle')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      expect(find.byType(PdfAnnotationSidebar), findsOneWidget);
+      // docked: a side resize grip, no bottom-sheet chrome
+      expect(find.byKey(const ValueKey('pdf-annotation-resize-grip')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-annotations-sheet-close')),
+          findsNothing);
+    });
+
+    testWidgets('compact reader: the thumbnail strip is a bottom sheet',
+        (tester) async {
+      final prefs = PdfEditingPreferences();
+      await prefs.ready;
+      addTearDown(prefs.dispose);
+      compactScreen(tester);
+      await pump(
+          tester, PdfReader(bytes: buildMultiPagePdf(3), preferences: prefs));
+
+      // compact first run starts closed; toggle it on
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-shell-thumbnails-toggle')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+
+      expect(find.byType(PdfThumbnailSidebar), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-thumbnails-sheet-close')),
+          findsOneWidget);
+      // the strip's side resize grip is gone in sheet form
+      expect(find.byKey(const ValueKey('pdf-thumbnail-resize-grip')),
+          findsNothing);
+    });
+  });
 }


### PR DESCRIPTION
Below the compact width (`pdfShellCompactWidth`, 700 — the existing threshold the shells already use to auto-hide thumbnails), the drop-in shells (`PdfReader`/`PdfEditorView`) now float the side panels and the page-thumbnail strip up from the bottom as bottom sheets instead of docking them to the side, where a 280px column would crowd the page out on a phone.

## What changed

**Shared chrome** (`shell_chrome.dart`, package-private):
- `pdfShellUseBottomSheets(constraints)` — true when narrower than `pdfShellCompactWidth`.
- `PdfPanelBottomSheet` — rounded top, a drag handle that swipes down to dismiss, and a titled header with a close button.
- `pdfShellBottomSheets(sheets)` — lays the active sheets out in a bottom-anchored column (`Positioned.fill` + `Align.bottomCenter`, so the clear area above keeps scrolling/tapping the page through to the viewer), each `Flexible` and capped at 55% of the content height: one sheet rises to 55%, several share the area evenly without overflowing off the top.

**Panels** — each of `PdfThumbnailSidebar`, `PdfAnnotationSidebar`, `PdfAnnotationPropertiesPanel`, `PdfSearchResultsPanel` gained a `bottomSheet` bool (default `false`). When true the panel fills its parent (no fixed-width `SizedBox`), drops the side resize grip, and the scrollbar/list clearance loses the grip width. The thumbnail strip keeps its preferred-width tile column **centered** in the wider sheet rather than stretching one giant thumbnail to phone width — reorder, delete, and raster resolution all keep working unchanged.

**Shells** — build panel closures `panel({required bool bottomSheet})` and switch on `useSheets`: docked panels go in the `Row`, sheet-wrapped ones go in `pdfShellBottomSheets`. Closing a sheet flips the panel's visibility preference off. `PdfEditorView` hides the floating toolbar while a sheet is open (it would cover the bottom anyway); `PdfReader` grew a `Stack` around its viewer row to host the overlay.

The compact thumbnail default is unchanged (closed on compact unless an explicit preference); an explicit "on" now shows the strip as a sheet.

## Tests

`pdf_shell_test.dart` +4: a compact toggle opens a panel as a bottom sheet, the close button hides it and clears the preference, a wide screen still docks with a resize grip, and the reader's thumbnail strip becomes a sheet. The default 800×600 test surface is above 700, so the existing shell tests stay docked untouched; `compactScreen` (600×800) drives the sheet path. Analyzer clean; the panel suites (`editing_panels`/`editing_sidebar`/`editing_properties`/`search_navigation`/`pdf_theme`/`editing`/`page_color`/`annotations_visibility`) all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfHGouHnTtRMCCE8BJ2ZHc)_