### PR TITLE
Preserve rotation when editing rotated text annotations

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2236,7 +2236,12 @@ class PdfEditingController extends ChangeNotifier {
       double? borderWidth}) {
     if (_selected.isEmpty) return;
     final page = _selected.last.$1;
-    final rect = annotation.rect;
+    // a rotated text box flattens to horizontal under plain remove +
+    // re-add (addFreeText/addStamp/addNote bake a horizontal matrix), so
+    // re-create it in its un-rotated local frame and re-apply the resting
+    // rotation afterwards — the same shape resizeAnnotationLocal uses.
+    final rotation = _appearanceRotationOf(annotation);
+    final rect = rotation == 0 ? annotation.rect : _localFrameOf(annotation);
     final color = annotation.color;
     final by = annotation.author; // a text edit doesn't change ownership
     final nm = annotation.name; // ... nor identity (sync tracks /NM)
@@ -2267,6 +2272,14 @@ class PdfEditingController extends ChangeNotifier {
           e.addNote(page, rect.left, rect.top, text,
               color: color ?? 0xFFD100, author: by, name: nm);
       }
+      // spin the freshly horizontal box back onto the resting rotation:
+      // the just-added annotation is the last /Annots entry
+      if (rotation != 0) {
+        final added = _document.page(page).annotations;
+        if (added.isNotEmpty) {
+          e.rotateAnnotation(page, added.last, rotation * 180 / math.pi);
+        }
+      }
     }, pages: [page]);
     // the rewritten annotation lands in the last /Annots slot — keep it
     // selected so consecutive restyles (a settings popup) stay anchored
@@ -2277,6 +2290,34 @@ class PdfEditingController extends ChangeNotifier {
         ..add((page, annotations.length - 1));
       notifyListeners();
     }
+  }
+
+  /// The page-space rotation baked into [annotation]'s appearance (radians
+  /// CCW, derived from its appearance quad), or 0 when it carries no
+  /// rotation or has no appearance stream.
+  static double _appearanceRotationOf(PdfAnnotation annotation) {
+    final quad = annotation.appearanceQuad;
+    if (quad == null) return 0;
+    final dx = quad[1].$1 - quad[0].$1;
+    final dy = quad[1].$2 - quad[0].$2;
+    if (dx == 0 && dy == 0) return 0;
+    final angle = math.atan2(dy, dx);
+    return angle.abs() < 0.005 ? 0 : angle;
+  }
+
+  /// The un-rotated local box of a rotated [annotation]: its appearance
+  /// quad's edge lengths about the quad center — the frame the text is
+  /// re-created in before [PdfEditor.rotateAnnotation] spins it back.
+  static PdfRect _localFrameOf(PdfAnnotation annotation) {
+    final quad = annotation.appearanceQuad!;
+    final (llx, lly) = quad[0];
+    final (lrx, lry) = quad[1];
+    final (urx, ury) = quad[2];
+    final (ulx, uly) = quad[3];
+    final cx = (llx + urx) / 2, cy = (lly + ury) / 2;
+    final w = math.sqrt((lrx - llx) * (lrx - llx) + (lry - lly) * (lry - lly));
+    final h = math.sqrt((ulx - llx) * (ulx - llx) + (uly - lly) * (uly - lly));
+    return PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2);
   }
 
   // ---------------------------------------------------------------------

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -277,6 +277,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   double _textEditSize = 14; // pt
   Color _textEditColor = const Color(0xFF000000);
   Color? _textEditFill; // the box background the commit will paint
+  // resting view-space rotation of the box being edited (radians,
+  // clockwise positive): nonzero only when editing already-rotated text,
+  // so the inline editor and afterimage sit on the artwork instead of
+  // snapping back to horizontal
+  double _textEditRotation = 0;
 
   // form-tool text fill: when set, the inline editor commits into this
   // field's /V instead of creating a free-text annotation
@@ -1330,9 +1335,22 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final annotation = existing ? _controller.selectedAnnotation : null;
     final parsed = annotation?.freeTextStyle;
     final annotationColor = parsed?.color ?? annotation?.color;
+    // an already-rotated box edits in its rotated frame: take the chrome's
+    // un-rotated box + resting angle so the editor (and the committed
+    // afterimage) ride the artwork, not its axis-aligned bounds
+    var rect = viewRect;
+    var rotation = 0.0;
+    if (existing) {
+      final chrome = _selectionChrome;
+      if (chrome != null && chrome.$2 != 0) {
+        rect = chrome.$1;
+        rotation = chrome.$2;
+      }
+    }
     _textEditText.text = existing ? (_controller.selectedText ?? '') : '';
     setState(() {
-      _textEditRect = viewRect;
+      _textEditRect = rect;
+      _textEditRotation = rotation;
       _textEditExisting = existing;
       _textEditTool = _tool;
       _textEditFont = style?.font ?? _controller.fontFamily;
@@ -1368,6 +1386,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _textEditText.text = field.value ?? '';
     setState(() {
       _textEditRect = _geometry.toViewRect(rect);
+      _textEditRotation = 0;
       _textEditExisting = false;
       _textEditTool = _tool;
       _textEditFieldName = field.name;
@@ -1423,6 +1442,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final size = _textEditSize;
     final color = _textEditColor;
     final fill = _textEditFill;
+    final rotation = _textEditRotation;
     _closeTextEditor();
     final before = _controller.document;
     if (existing) {
@@ -1445,7 +1465,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       color: color,
       fill: fill,
       washed: existing,
-      rotation: 0,
+      rotation: rotation,
     );
     _afterDocument = _controller.document;
   }
@@ -3003,69 +3023,74 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
               if (_textEditRect != null)
                 Positioned.fromRect(
                   rect: _textEditRect!.inflate(2),
-                  child: CallbackShortcuts(
-                    bindings: {
-                      const SingleActivator(LogicalKeyboardKey.escape):
-                          _cancelTextEdit,
-                      const SingleActivator(LogicalKeyboardKey.enter,
-                          meta: true): _commitTextEdit,
-                      const SingleActivator(LogicalKeyboardKey.enter,
-                          control: true): _commitTextEdit,
-                    },
-                    child: Container(
-                      // the chrome border lives in the inflate(2) gutter
-                      // and paints as a FOREGROUND decoration: a regular
-                      // decoration border adds itself to the padding, and
-                      // any net inset shifts the text when the editor
-                      // opens — content must sit exactly on the box
-                      padding: const EdgeInsets.all(2),
-                      // the box's own fill when it has one; otherwise wash
-                      // the paper color over what's underneath: faint for a
-                      // fresh box, near-opaque when editing existing text
-                      // so the old rendering doesn't show through
-                      color: _textEditFill ??
-                          widget.pageColor.withValues(
-                              alpha: _textEditExisting ? 0.92 : 0.3),
-                      foregroundDecoration: BoxDecoration(
-                        border: Border.all(
-                            color: PdfViewerTheme.of(context)
-                                    .annotationChromeColor ??
-                                const Color(0xFF1E88E5),
-                            width: 1.5 * _chromeScale),
-                      ),
-                      child: TextField(
-                        key: ValueKey(_textEditFieldName == null
-                            ? 'pdf-freetext-editor'
-                            : 'pdf-form-text-editor'),
-                        controller: _textEditText,
-                        focusNode: _textEditFocus,
-                        autofocus: true,
-                        // single-line form fields edit single-line: Enter
-                        // commits instead of inserting a newline
-                        maxLines:
-                            _textEditFieldName == null || _textEditMultiline
-                                ? null
-                                : 1,
-                        expands:
-                            _textEditFieldName == null || _textEditMultiline,
-                        onSubmitted: (_) => _commitTextEdit(),
-                        textAlignVertical:
-                            _textEditFieldName == null || _textEditMultiline
-                                ? TextAlignVertical.top
-                                : TextAlignVertical.center,
-                        cursorColor: _textEditColor,
-                        // mirrors the committed appearance: same size in view
-                        // pixels, same 1.2 leading, matching family and color
-                        style: TextStyle(
-                          color: _textEditColor,
-                          fontSize: _textEditSize * _geometry.scale,
-                          height: 1.2,
-                          fontFamily: _uiFamily(_textEditFont),
+                  // identity at angle 0; spins the box about its center
+                  // onto the resting rotation when editing rotated text
+                  child: Transform.rotate(
+                    angle: _textEditRotation,
+                    child: CallbackShortcuts(
+                      bindings: {
+                        const SingleActivator(LogicalKeyboardKey.escape):
+                            _cancelTextEdit,
+                        const SingleActivator(LogicalKeyboardKey.enter,
+                            meta: true): _commitTextEdit,
+                        const SingleActivator(LogicalKeyboardKey.enter,
+                            control: true): _commitTextEdit,
+                      },
+                      child: Container(
+                        // the chrome border lives in the inflate(2) gutter
+                        // and paints as a FOREGROUND decoration: a regular
+                        // decoration border adds itself to the padding, and
+                        // any net inset shifts the text when the editor
+                        // opens — content must sit exactly on the box
+                        padding: const EdgeInsets.all(2),
+                        // the box's own fill when it has one; otherwise wash
+                        // the paper color over what's underneath: faint for a
+                        // fresh box, near-opaque when editing existing text
+                        // so the old rendering doesn't show through
+                        color: _textEditFill ??
+                            widget.pageColor.withValues(
+                                alpha: _textEditExisting ? 0.92 : 0.3),
+                        foregroundDecoration: BoxDecoration(
+                          border: Border.all(
+                              color: PdfViewerTheme.of(context)
+                                      .annotationChromeColor ??
+                                  const Color(0xFF1E88E5),
+                              width: 1.5 * _chromeScale),
                         ),
-                        decoration: InputDecoration(
-                          isCollapsed: true,
-                          border: InputBorder.none,
-                          contentPadding: EdgeInsets.all(3 * _geometry.scale),
+                        child: TextField(
+                          key: ValueKey(_textEditFieldName == null
+                              ? 'pdf-freetext-editor'
+                              : 'pdf-form-text-editor'),
+                          controller: _textEditText,
+                          focusNode: _textEditFocus,
+                          autofocus: true,
+                          // single-line form fields edit single-line: Enter
+                          // commits instead of inserting a newline
+                          maxLines:
+                              _textEditFieldName == null || _textEditMultiline
+                                  ? null
+                                  : 1,
+                          expands:
+                              _textEditFieldName == null || _textEditMultiline,
+                          onSubmitted: (_) => _commitTextEdit(),
+                          textAlignVertical:
+                              _textEditFieldName == null || _textEditMultiline
+                                  ? TextAlignVertical.top
+                                  : TextAlignVertical.center,
+                          cursorColor: _textEditColor,
+                          // mirrors the committed appearance: same size in view
+                          // pixels, same 1.2 leading, matching family and color
+                          style: TextStyle(
+                            color: _textEditColor,
+                            fontSize: _textEditSize * _geometry.scale,
+                            height: 1.2,
+                            fontFamily: _uiFamily(_textEditFont),
+                          ),
+                          decoration: InputDecoration(
+                            isCollapsed: true,
+                            border: InputBorder.none,
+                            contentPadding: EdgeInsets.all(3 * _geometry.scale),
+                          ),
                         ),
                       ),
                     ),

--- a/packages/dart_pdf_editor/test/editing_rotate_test.dart
+++ b/packages/dart_pdf_editor/test/editing_rotate_test.dart
@@ -130,6 +130,39 @@ void main() {
     picture.dispose();
   });
 
+  test('editing a rotated free text keeps it rotated', () {
+    final editing = PdfEditingController(buildMultiPagePdf(1))
+      ..fontSize = 18
+      ..addFreeText(0, const PdfRect(100, 650, 300, 700), 'before')
+      ..selectAnnotation(0, 0)
+      ..rotateSelected(30);
+    addTearDown(editing.dispose);
+
+    double angleOf(PdfAnnotation a) {
+      final quad = a.appearanceQuad!;
+      return math.atan2(quad[1].$2 - quad[0].$2, quad[1].$1 - quad[0].$1);
+    }
+
+    final before = angleOf(editing.document.page(0).annotations.single);
+    expect(before, closeTo(30 * math.pi / 180, 1e-3));
+
+    // editing the text re-creates the box; before the fix that baked a
+    // fresh horizontal matrix and the rotation was lost
+    editing
+      ..selectAnnotation(0, 0)
+      ..setSelectedText('after');
+    final edited = editing.document.page(0).annotations.single;
+    expect(edited.contents, 'after');
+    expect(angleOf(edited), closeTo(before, 1e-3));
+
+    // restyling (font/size) goes through the same path and must keep it too
+    editing
+      ..selectAnnotation(0, 0)
+      ..restyleSelectedText(size: 28);
+    expect(angleOf(editing.document.page(0).annotations.single),
+        closeTo(before, 1e-3));
+  });
+
   group('rotate handle in the viewer', () {
     // 800px viewport over a 612pt page
     const scale = 800 / 612;


### PR DESCRIPTION
## Problem

After rotating a text annotation, then editing its text, the text was set back to horizontal — and the inline editor previewed it horizontal too.

The cause: editing text goes through `_rewriteSelected`, which removes the annotation and re-adds it with `addFreeText`/`addStamp`. Those bake a **horizontal** appearance matrix, so the rotation was lost on every text or style edit (`setSelectedText` and `restyleSelectedText`).

## Fix

**Commit side (`editing_controller.dart`)** — `_rewriteSelected` now reads the annotation's resting rotation from its appearance quad, re-creates the box in its **un-rotated local frame**, and re-applies the rotation with `rotateAnnotation`. This is the same shape `resizeAnnotationLocal` / `_restyleRegenerate` already use to keep rotation across resizes/restyles. Unrotated annotations are byte-identical to before (rect stays `/Rect`, no rotate call).

**Preview side (`editing_overlay.dart`)** — the inline editor and the committed afterimage now ride the rotated artwork:
- `_openTextEditor` takes the selection chrome's un-rotated box + resting angle for existing rotated text.
- The inline `TextField` is wrapped in `Transform.rotate` (identity at angle 0, so unrotated editing is unchanged — the existing "opens without shifting the text" gotcha still holds).
- `_afterText` carries the angle so the frozen afterimage stays rotated until the new raster lands.

## Tests

Added a controller regression test (`editing_rotate_test.dart`): a free text rotated 30°, then text-edited and restyled, keeps its rotation (asserts the appearance-quad angle survives both `setSelectedText` and `restyleSelectedText`).

Ran the affected suites green: `editing_rotate_test`, `editing_text_edit_test`, `editing_test`, `editing_properties_test`, `editing_sync_test`, `editing_polish_test`, `editing_form_test` (129 tests).

Note: edits were applied by hand rather than via `dart format`, because the bundled 3.44.2 formatter uses the new "tall" style while the repo is on the old short style — running it rewrites unrelated lines. The change matches the surrounding style.

https://claude.ai/code/session_017jDDd8EHVAauAMrW4doGQH

---
_Generated by [Claude Code](https://claude.ai/code/session_017jDDd8EHVAauAMrW4doGQH)_