### PR TITLE
Add an insert-image tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1948,3 +1948,36 @@ and the `canResizeSelected` tool gate; the "drag on a widget" test now
 asserts the widget MOVED (it used to assert nothing happened). Toolbar
 tooltip is now 'Form fields — tap to select, double-tap to fill, drag to
 add' (pdf_shell/toolbar tests that find it by tooltip updated).
+
+Insert image (Ben: "allow inserting an image into the PDF"): a new
+`PdfEditTool.image` inserts a PNG/JPEG as a /Stamp annotation, so it
+inherits select/move/resize/rotate/delete for free. pdf_document:
+`PdfEditor.addImageStamp(pageIndex, rect, PdfEmbeddableImage, {opacity,
+author, name})` (annotation_editor.dart) registers the image XObject via
+`image.toXObject` and writes an appearance that `cm`-maps the unit image
+onto the rect (BBox = rect, so the §12.5.5 fit is the identity);
+`_resources` gained an `xObject:` param. CRITICAL: the stamp carries NO
+/Contents, so `pdfCanRestyleAnnotation` returns false — the restyle path
+(`_regenerateStyledAppearance` case 'Stamp') would regenerate a /Stamp as
+a TEXT stamp and wipe the picture; resize falls through to the stretch
+path (Stamp isn't in `_regenerateResizedAppearance`), which scales the
+form matrix so the image scales with the box, and rotate bakes the matrix
+like any stamp. Controller (editing_controller.dart): `placeImage(page,
+x, y, bytes, {maxSize: 200})` (tap — aspect-preserving box clamped to 90%
+of the crop box, centered on the tap) and `addImageInRect(page, box,
+bytes)` (drag-out — fits the image within the dragged box); both decode
+ONCE (`PdfEmbeddableImage.decode`, junk → false, no revision) and reuse
+the decoded image in the apply closure. UI: `PdfImagePicker = Future<
+Uint8List?> Function(BuildContext)` (text_prompt.dart), threaded
+`PdfViewer.imagePicker` → _PdfViewerPage → EditingPageOverlay (overlay
+`_onTapUp`/`_commitRect` image branches await the picker then call
+place/addInRect); `PdfEditorView.imagePicker`; toolbar Insert group gained
+an Icons.image_outlined button. Example: `_pickImage` (file_selector,
+reuses `_imageTypeGroup`) wired into PdfEditorView. No afterimage (tap-
+placed, like text stamps — the picker dialog covers the re-render). Tests:
+pdf_document image_stamp_test.dart (4 — XObject in appearance, not
+restyleable, resize stretches keeping /Img0, opacity→ca) and
+dart_pdf_editor editing_image_test.dart (7 — placeImage aspect/clamp,
+addImageInRect fit, junk reject, viewer tool tap runs picker / cancel /
+no-picker). Pre-existing example/test failures (7, Text("0") duplicate
++ others) are unrelated — present without this change.

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -41,6 +41,12 @@ Future<Uint8List?> _pickFormImage(BuildContext context, PdfFormField field) =>
     openFile(acceptedTypeGroups: const [_imageTypeGroup])
         .then((file) => file?.readAsBytes());
 
+/// The image tool's picker: inserts the chosen PNG or JPEG as a stamp
+/// annotation the user can move, resize, and rotate.
+Future<Uint8List?> _pickImage(BuildContext context) =>
+    openFile(acceptedTypeGroups: const [_imageTypeGroup])
+        .then((file) => file?.readAsBytes());
+
 void main() => runApp(const ViewerApp());
 
 class ViewerApp extends StatefulWidget {
@@ -563,6 +569,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
                       pageOverlayBuilder: tab.isDemo ? _demoOverlays : null,
                       annotationMenuBuilder: _annotationMenuActions,
                       formImagePicker: _pickFormImage,
+                      imagePicker: _pickImage,
                     ),
     );
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -76,6 +76,13 @@ enum PdfEditTool {
   /// ([PdfEditingController.signature]) as an Ink annotation.
   signature,
 
+  /// Insert a raster image (PNG or JPEG). Tapping places it at a default
+  /// size; dragging out a box fits it within the box. The picked image
+  /// comes from [PdfViewer.imagePicker]; with none the tool does nothing.
+  /// The image becomes a /Stamp annotation, so it can be moved, resized,
+  /// rotated, and deleted like any other annotation.
+  image,
+
   /// Tap to select a page content element (text run, path, image); the
   /// selection can be deleted or, for text, rewritten. Edits the page's
   /// content stream itself, not annotations.
@@ -1014,6 +1021,61 @@ class PdfEditingController extends ChangeNotifier {
               opacity: preferences.opacity,
               author: author),
           pages: [pageIndex]);
+
+  /// Places [imageBytes] (PNG or JPEG) centered on ([x], [y]) in page
+  /// space, [maxSize] points on its longest side, preserving the image's
+  /// aspect ratio and clamped so the whole image stays on the page.
+  /// Returns false when the bytes aren't a decodable PNG or JPEG.
+  bool placeImage(int pageIndex, double x, double y, Uint8List imageBytes,
+      {double maxSize = 200}) {
+    final PdfEmbeddableImage image;
+    try {
+      image = PdfEmbeddableImage.decode(imageBytes);
+    } catch (_) {
+      return false;
+    }
+    final box = _page(pageIndex).cropBox;
+    final aspect = image.height == 0 ? 1.0 : image.width / image.height;
+    var w = aspect >= 1 ? maxSize : maxSize * aspect;
+    var h = aspect >= 1 ? maxSize / aspect : maxSize;
+    final maxW = box.width * 0.9, maxH = box.height * 0.9;
+    if (w > maxW) (w, h) = (maxW, h * maxW / w);
+    if (h > maxH) (w, h) = (w * maxH / h, maxH);
+    final cx = x.clamp(box.left + w / 2, box.right - w / 2);
+    final cy = y.clamp(box.bottom + h / 2, box.top - h / 2);
+    return apply(
+        (e) => e.addImageStamp(pageIndex,
+            PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image,
+            opacity: preferences.opacity, author: author),
+        pages: [pageIndex]);
+  }
+
+  /// Inserts [imageBytes] (PNG or JPEG) fitted within [box] (page space),
+  /// centered and preserving the image's aspect ratio. The drag-out
+  /// counterpart of [placeImage]. Returns false when the bytes aren't a
+  /// decodable PNG or JPEG, or [box] is degenerate.
+  bool addImageInRect(int pageIndex, PdfRect box, Uint8List imageBytes) {
+    if (box.width <= 0 || box.height <= 0) return false;
+    final PdfEmbeddableImage image;
+    try {
+      image = PdfEmbeddableImage.decode(imageBytes);
+    } catch (_) {
+      return false;
+    }
+    final aspect = image.height == 0 ? 1.0 : image.width / image.height;
+    var w = box.width, h = box.height;
+    if (w / h > aspect) {
+      w = h * aspect;
+    } else {
+      h = w / aspect;
+    }
+    final cx = (box.left + box.right) / 2, cy = (box.bottom + box.top) / 2;
+    return apply(
+        (e) => e.addImageStamp(pageIndex,
+            PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image,
+            opacity: preferences.opacity, author: author),
+        pages: [pageIndex]);
+  }
 
   /// Adds a sticky note with its top-left corner at ([x], [y]).
   void addNote(int pageIndex, double x, double y, String text) => apply(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -38,6 +38,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.zoom = 1,
     this.predictStrokes = true,
     this.formImagePicker,
+    this.imagePicker,
     this.onShowAnnotationMenu,
     this.onShowFormFieldMenu,
   });
@@ -50,6 +51,10 @@ class EditingPageOverlay extends StatefulWidget {
   /// How the form tool asks for a push-button field's image. With none,
   /// tapping a push button does nothing.
   final PdfFormImagePicker? formImagePicker;
+
+  /// How the image tool ([PdfEditTool.image]) asks for the picture to
+  /// insert. With none, the image tool does nothing.
+  final PdfImagePicker? imagePicker;
 
   /// The paper color the page is displayed with — the eyedropper's
   /// raster must match what's on screen.
@@ -1514,6 +1519,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             PdfEditTool.measureDistance ||
             PdfEditTool.freeText ||
             PdfEditTool.stamp ||
+            PdfEditTool.image ||
             PdfEditTool.redact:
         setState(() {
           _dragStart = position;
@@ -2133,6 +2139,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             title: 'Stamp text', initial: 'APPROVED');
         if (text == null || text.isEmpty) return;
         _controller.addStamp(widget.pageIndex, rect, text);
+      case PdfEditTool.image:
+        final picker = widget.imagePicker;
+        if (picker == null) return;
+        final bytes = await picker(context);
+        if (bytes == null) return;
+        _controller.addImageInRect(widget.pageIndex, rect, bytes);
       case PdfEditTool.form:
         _controller.addFormField(
             _controller.newFormFieldKind, widget.pageIndex, rect);
@@ -2331,6 +2343,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           if (text == null || text.isEmpty) return;
           _controller.placeTextStamp(widget.pageIndex, x, y, text);
         }
+      case PdfEditTool.image:
+        final picker = widget.imagePicker;
+        if (picker == null) return;
+        final bytes = await picker(context);
+        if (bytes == null) return;
+        _controller.placeImage(widget.pageIndex, x, y, bytes);
       case PdfEditTool.form:
         // single tap selects the field for move/resize/menu; double-tap
         // fills it (read mode is the no-tool path to just fill)

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -228,6 +228,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           _GroupTool.tool(
               PdfEditTool.note, Icons.sticky_note_2_outlined, 'Note'),
           _GroupTool.tool(PdfEditTool.stamp, Icons.approval, 'Stamp'),
+          _GroupTool.tool(PdfEditTool.image, Icons.image_outlined,
+              'Image — tap to place, or drag out a box'),
           _GroupTool.tool(PdfEditTool.signature, Icons.history_edu,
               'Signature — tap a page to place it'),
         ],

--- a/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
@@ -9,6 +9,11 @@ import 'package:pdf_document/pdf_document.dart' show PdfFormField;
 typedef PdfFormImagePicker = Future<Uint8List?> Function(
     BuildContext context, PdfFormField field);
 
+/// Supplies the image bytes the image tool ([PdfEditTool.image]) inserts
+/// — typically a file picker. Return null to cancel. PNG and JPEG bytes
+/// are accepted ([PdfEditingController.placeImage]).
+typedef PdfImagePicker = Future<Uint8List?> Function(BuildContext context);
+
 /// Signature of the prompt the editing UI uses to ask for annotation text
 /// (free text, notes, stamps). Returns null when the user cancels.
 typedef PdfTextPrompt = Future<String?> Function(

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -159,6 +159,7 @@ class PdfEditorView extends StatefulWidget {
     this.pageOverlayBuilder,
     this.annotationMenuBuilder,
     this.formImagePicker,
+    this.imagePicker,
     this.textPrompt,
     this.palette = PdfEditingToolbar.defaultPalette,
     this.toolbarLeading = const [],
@@ -219,6 +220,9 @@ class PdfEditorView extends StatefulWidget {
 
   /// See [PdfViewer.formImagePicker].
   final PdfFormImagePicker? formImagePicker;
+
+  /// See [PdfViewer.imagePicker].
+  final PdfImagePicker? imagePicker;
 
   /// How dialog-based tools ask for text. Defaults to
   /// [showPdfTextPrompt], a Material dialog.
@@ -492,6 +496,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     pageOverlayBuilder: widget.pageOverlayBuilder,
                     annotationMenuBuilder: widget.annotationMenuBuilder,
                     formImagePicker: widget.formImagePicker,
+                    imagePicker: widget.imagePicker,
                     editingTextPrompt: widget.textPrompt,
                     initialFit: widget.initialFit,
                     backgroundColor: widget.backgroundColor,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -341,6 +341,7 @@ class PdfViewer extends StatefulWidget {
     this.editingTextPrompt,
     this.annotationMenuBuilder,
     this.formImagePicker,
+    this.imagePicker,
     this.pageSpacing = 12,
     this.initialFit = PdfViewerFit.page,
     this.initialViewport,
@@ -406,6 +407,11 @@ class PdfViewer extends StatefulWidget {
   /// (signature and logo fields) — typically a file picker returning
   /// PNG or JPEG bytes. With none, tapping a push button does nothing.
   final PdfFormImagePicker? formImagePicker;
+
+  /// How the image tool ([PdfEditTool.image]) asks for the picture to
+  /// insert — typically a file picker returning PNG or JPEG bytes. With
+  /// none, the image tool does nothing.
+  final PdfImagePicker? imagePicker;
 
   final double pageSpacing;
 
@@ -2496,6 +2502,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 editingTextPrompt:
                     widget.editingTextPrompt ?? showPdfTextPrompt,
                 formImagePicker: widget.formImagePicker,
+                imagePicker: widget.imagePicker,
                 onPanViewport: _grabPanBy,
                 onPanViewportEnd: _flingViewport,
                 onShowAnnotationMenu: _showSelectionMenu,
@@ -2769,6 +2776,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.formController,
     required this.editingTextPrompt,
     required this.formImagePicker,
+    required this.imagePicker,
     required this.onPanViewport,
     required this.onPanViewportEnd,
     required this.onShowAnnotationMenu,
@@ -2812,6 +2820,7 @@ class _PdfViewerPage extends StatefulWidget {
 
   final PdfTextPrompt editingTextPrompt;
   final PdfFormImagePicker? formImagePicker;
+  final PdfImagePicker? imagePicker;
   final void Function(Offset delta) onPanViewport;
 
   /// See [EditingPageOverlay.onPanViewportEnd].
@@ -2942,6 +2951,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                               geometry: geometry,
                               textPrompt: widget.editingTextPrompt,
                               formImagePicker: widget.formImagePicker,
+                              imagePicker: widget.imagePicker,
                               pageColor: widget.pageColor,
                               showAnnotations: widget.showAnnotations,
                               onPanViewport: widget.onPanViewport,

--- a/packages/dart_pdf_editor/test/editing_image_test.dart
+++ b/packages/dart_pdf_editor/test/editing_image_test.dart
@@ -1,0 +1,156 @@
+// Inserting a raster image (PdfEditTool.image): the controller places it
+// as a stamp annotation, and the viewer's image tool runs the host picker
+// on tap / drag-out.
+import 'dart:convert';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// 2x2 RGBA-8 PNG (square; aspect 1).
+final _png = base64.decode('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0k'
+    'AAAAGUlEQVR4nGP4z8DwHwgbWBgZ/jNyicr7AgA3BAUOTnqjAAAAAABJRU5ErkJggg==');
+
+String appearance(PdfDocument doc, PdfAnnotation annot) =>
+    latin1.decode(doc.cos.decodeStreamData(annot.normalAppearance!));
+
+void main() {
+  group('PdfEditingController image insertion', () {
+    test('placeImage drops a square image at the tap, aspect preserved', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      expect(editing.placeImage(0, 300, 400, _png), isTrue);
+      final stamp = editing.document.page(0).annotations.single;
+      expect(stamp.subtype, 'Stamp');
+      // a 2x2 image: the placed box is square and centered on the tap
+      expect(stamp.rect.width, closeTo(stamp.rect.height, 1e-9));
+      expect((stamp.rect.left + stamp.rect.right) / 2, closeTo(300, 1e-9));
+      expect((stamp.rect.bottom + stamp.rect.top) / 2, closeTo(400, 1e-9));
+      expect(appearance(editing.document, stamp), contains('/Img0 Do'));
+    });
+
+    test('placeImage clamps the box to keep it on the page', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      // a tap near the corner: the box stays inside the 612x792 crop box
+      expect(editing.placeImage(0, 10, 10, _png), isTrue);
+      final rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.left, greaterThanOrEqualTo(0));
+      expect(rect.bottom, greaterThanOrEqualTo(0));
+      expect(rect.right, lessThanOrEqualTo(612));
+      expect(rect.top, lessThanOrEqualTo(792));
+    });
+
+    test('addImageInRect fits the image within the dragged box', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      // a 200x50 box; the square image fits to 50x50, centered
+      expect(
+          editing.addImageInRect(0, const PdfRect(100, 100, 300, 150), _png),
+          isTrue);
+      final rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.width, closeTo(50, 1e-9));
+      expect(rect.height, closeTo(50, 1e-9));
+      expect((rect.left + rect.right) / 2, closeTo(200, 1e-9));
+      expect((rect.bottom + rect.top) / 2, closeTo(125, 1e-9));
+    });
+
+    test('junk bytes are rejected without a revision', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      expect(editing.placeImage(0, 100, 100, Uint8List.fromList([1, 2, 3])),
+          isFalse);
+      expect(editing.addImageInRect(0, const PdfRect(0, 0, 100, 100),
+          Uint8List.fromList([1, 2, 3])), isFalse);
+      expect(editing.isModified, isFalse);
+    });
+  });
+
+  group('image tool in the viewer', () {
+    const scale = 800 / 612;
+    Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+
+    Future<void> tap(WidgetTester tester, Offset position) async {
+      await tester.tapAt(position);
+      await tester.pump(const Duration(milliseconds: 400));
+    }
+
+    Future<PdfEditingController> pumpEditor(WidgetTester tester,
+        {PdfImagePicker? imagePicker}) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+              imagePicker: imagePicker,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    testWidgets('tapping with the image tool runs the picker and inserts',
+        (tester) async {
+      var calls = 0;
+      final editing = await pumpEditor(tester, imagePicker: (context) {
+        calls++;
+        return Future.value(_png);
+      });
+      editing.tool = PdfEditTool.image;
+      await tester.pump();
+
+      await tap(tester, view(300, 400));
+      await tester.pump();
+      expect(calls, 1);
+      final stamp = editing.document.page(0).annotations.single;
+      expect(stamp.subtype, 'Stamp');
+      expect(appearance(editing.document, stamp), contains('/Img0 Do'));
+    });
+
+    testWidgets('a cancelled pick inserts nothing', (tester) async {
+      final editing = await pumpEditor(tester,
+          imagePicker: (context) => Future.value(null));
+      editing.tool = PdfEditTool.image;
+      await tester.pump();
+
+      await tap(tester, view(300, 400));
+      await tester.pump();
+      expect(editing.document.page(0).annotations, isEmpty);
+      expect(editing.isModified, isFalse);
+    });
+
+    testWidgets('with no picker the image tool does nothing', (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.tool = PdfEditTool.image;
+      await tester.pump();
+
+      await tap(tester, view(300, 400));
+      await tester.pump();
+      expect(editing.document.page(0).annotations, isEmpty);
+    });
+  });
+}

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1398,6 +1398,47 @@ extension PdfAnnotationEditing on PdfEditor {
     return (w, gs);
   }
 
+  /// Inserts [image] (a decoded PNG or JPEG) as a /Stamp annotation whose
+  /// appearance draws it scaled to fill [rect].
+  ///
+  /// Modelled as a stamp so it inherits select/move/resize/rotate/delete
+  /// from the annotation machinery for free. It carries no /Contents, so
+  /// [pdfCanRestyleAnnotation] returns false — the restyle path would
+  /// regenerate a /Stamp as a *text* stamp and destroy the picture.
+  /// Resize stretches the appearance (the §12.5.5 BBox→Rect fit scales the
+  /// form matrix, so the image scales with the box) and rotate bakes the
+  /// matrix, exactly like any other stamp.
+  void addImageStamp(
+    int pageIndex,
+    PdfRect rect,
+    PdfEmbeddableImage image, {
+    double opacity = 1,
+    String? author,
+    String? name,
+  }) {
+    final imageRef = _updater
+        .addObject(image.toXObject((smask) => _updater.addObject(smask)));
+    final w = ContentWriter();
+    final gs = _alphaState(opacity);
+    if (gs != null) w.extGState('GS0');
+    // a unit image (1×1 at the origin) mapped onto the rect in page space —
+    // the form's BBox is the rect, so the §12.5.5 fit is the identity
+    w
+      ..save()
+      ..concatMatrix(rect.width, 0, 0, rect.height, rect.left, rect.bottom)
+      ..drawXObject('Img0')
+      ..restore();
+    _addAnnotation(
+      pageIndex,
+      _markupDict('Stamp', rect, 0xC03030, null, author),
+      _form(rect, w,
+          resources: _resources(
+              extGState: gs,
+              xObject: CosDictionary({'Img0': imageRef}))),
+      name: name,
+    );
+  }
+
   /// Removes [annotation] from the page, along with its popup, if any.
   void removeAnnotation(int pageIndex, PdfAnnotation annotation) {
     final cos = document.cos;
@@ -2954,13 +2995,15 @@ extension PdfAnnotationEditing on PdfEditor {
     return dict;
   }
 
-  CosDictionary? _resources({CosDictionary? extGState, CosDictionary? font}) {
-    if (extGState == null && font == null) return null;
+  CosDictionary? _resources(
+      {CosDictionary? extGState, CosDictionary? font, CosDictionary? xObject}) {
+    if (extGState == null && font == null && xObject == null) return null;
     final dict = CosDictionary();
     if (extGState != null) {
       dict['ExtGState'] = CosDictionary({'GS0': extGState});
     }
     if (font != null) dict['Font'] = font;
+    if (xObject != null) dict['XObject'] = xObject;
     return dict;
   }
 

--- a/packages/pdf_document/test/image_stamp_test.dart
+++ b/packages/pdf_document/test/image_stamp_test.dart
@@ -1,0 +1,88 @@
+// Inserting a raster image as a /Stamp annotation (PdfEditor.addImageStamp):
+// the picture rides an appearance XObject so it inherits move/resize/rotate
+// for free, and carries no /Contents so the text-stamp restyle never
+// regenerates over it.
+import 'dart:convert';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+// 2x2 RGBA-8 PNG (shared with image_pdf_test.dart / png_test.dart).
+final _png = base64.decode('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0k'
+    'AAAAGUlEQVR4nGP4z8DwHwgbWBgZ/jNyicr7AgA3BAUOTnqjAAAAAABJRU5ErkJggg==');
+
+void main() {
+  PdfDocument roundTrip(void Function(PdfEditor) edit) {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    edit(editor);
+    return PdfDocument.open(editor.save());
+  }
+
+  test('addImageStamp embeds an image XObject in a /Stamp appearance', () {
+    final image = PdfEmbeddableImage.decode(_png);
+    final doc = roundTrip(
+        (e) => e.addImageStamp(0, const PdfRect(100, 500, 220, 620), image));
+    final stamp = doc.page(0).annotations.single;
+    expect(stamp.subtype, 'Stamp');
+    // no /Contents: this is a picture, not a text stamp
+    expect(stamp.contents, anyOf(isNull, isEmpty));
+
+    final form = stamp.normalAppearance!;
+    final content = latin1.decode(doc.cos.decodeStreamData(form));
+    expect(content, contains('/Img0 Do'));
+    // the unit image is mapped onto the rect (width 120, height 120, at
+    // the rect's lower-left corner)
+    expect(content, contains('120 0 0 120 100 500 cm'));
+
+    final resources =
+        doc.cos.resolve(form.dictionary['Resources']) as CosDictionary;
+    final xobjects =
+        doc.cos.resolve(resources['XObject']) as CosDictionary;
+    final img = doc.cos.resolve(xobjects['Img0']) as CosStream;
+    expect((doc.cos.resolve(img.dictionary['Subtype']) as CosName).value,
+        'Image');
+    expect((doc.cos.resolve(img.dictionary['Width']) as CosInteger).value, 2);
+    expect((doc.cos.resolve(img.dictionary['Height']) as CosInteger).value, 2);
+  });
+
+  test('an image stamp is not restyleable (text-stamp regen would wipe it)',
+      () {
+    final image = PdfEmbeddableImage.decode(_png);
+    final doc = roundTrip(
+        (e) => e.addImageStamp(0, const PdfRect(0, 0, 100, 100), image));
+    final stamp = doc.page(0).annotations.single;
+    expect(pdfCanRestyleAnnotation(stamp), isFalse);
+  });
+
+  test('an image stamp resizes by stretching its appearance', () {
+    final image = PdfEmbeddableImage.decode(_png);
+    final doc = PdfDocument.open(buildClassicPdf());
+    final editor = PdfEditor(doc)
+      ..addImageStamp(0, const PdfRect(0, 0, 100, 100), image);
+    final reopened = PdfDocument.open(editor.save());
+    final stamp = reopened.page(0).annotations.single;
+
+    final resize = PdfEditor(reopened)
+      ..resizeAnnotation(0, stamp, const PdfRect(0, 0, 200, 50));
+    final after = PdfDocument.open(resize.save());
+    final resized = after.page(0).annotations.single;
+    expect(resized.subtype, 'Stamp');
+    expect(resized.rect.width, 200);
+    expect(resized.rect.height, 50);
+    // the picture survives the resize
+    final content = latin1.decode(
+        after.cos.decodeStreamData(resized.normalAppearance!));
+    expect(content, contains('/Img0 Do'));
+  });
+
+  test('an opacity sets an alpha graphics state', () {
+    final image = PdfEmbeddableImage.decode(_png);
+    final doc = roundTrip((e) => e.addImageStamp(
+        0, const PdfRect(0, 0, 100, 100), image,
+        opacity: 0.5));
+    final stamp = doc.page(0).annotations.single;
+    expect(stamp.appearanceOpacity, closeTo(0.5, 1e-9));
+  });
+}


### PR DESCRIPTION
## Allow inserting an image into the PDF

Adds a new **`PdfEditTool.image`** that inserts a PNG or JPEG into the document. The picture is modelled as a **`/Stamp` annotation**, so it inherits select / move / resize / rotate / delete from the existing annotation machinery for free — no new interaction code.

### How it works
- **`PdfEditor.addImageStamp(pageIndex, rect, PdfEmbeddableImage, {opacity, author, name})`** (`pdf_document`) — registers the image XObject (reusing `PdfEmbeddableImage` / `toXObject`, the same path as form button images) and writes an appearance that `cm`-maps the unit image onto the rect. The form BBox is the rect, so the §12.5.5 fit is the identity. `_resources` gained an `xObject:` parameter.
- **No `/Contents`** — this is the key safety detail. `pdfCanRestyleAnnotation` returns false for a contentless stamp, so the restyle path (which regenerates a `/Stamp` as a *text* stamp) never wipes the picture. Resize falls through to the §12.5.5 stretch path (Stamp isn't a regenerate subtype), scaling the form matrix so the image scales with the box; rotate bakes the matrix like any stamp.
- **Controller** (`PdfEditingController`): `placeImage(page, x, y, bytes, {maxSize: 200})` for tap-to-place (aspect-preserving box, clamped to 90% of the crop box, centered on the tap) and `addImageInRect(page, box, bytes)` for drag-out (fits the image within the dragged box). Both decode once, reject junk bytes without committing a revision, and reuse the decoded image in the apply closure.
- **UI plumbing**: new `PdfImagePicker` typedef and `PdfViewer.imagePicker` / `PdfEditorView.imagePicker`, threaded to the page overlay (tap and drag-out branches await the picker, then place). The toolbar's Insert group gained an image button. The example app wires a `file_selector` picker (reusing the existing image type group).

### Tests
- `pdf_document/test/image_stamp_test.dart` (4): image XObject in the appearance, not restyleable, resize stretches while keeping `/Img0`, opacity → `ca`.
- `dart_pdf_editor/test/editing_image_test.dart` (7): `placeImage` aspect/clamp, `addImageInRect` fit, junk rejection, and viewer tool tap running the picker / cancel / no-picker.

`dart analyze` is clean. The 7 failing tests under `example/test/` are **pre-existing on the branch** (verified by stashing these changes — `Text("0")` duplicate and related) and unrelated to this work.

---
_Generated by [Claude Code](https://claude.ai/code/session_0147sYaEyLLNWyMquvRcAgAX)_