### PR TITLE
Fix inline text editor drifting on the page when zooming

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -56,7 +56,12 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
   // The text field being edited, if any. Fields die with every revision,
   // so the name is the stable handle; the rest is layout captured at open.
   String? _editingField;
-  Rect? _editRect;
+  Rect? _editRect; // view space; derived from _editPageRect per build
+  // page space is the source of truth: a zoom that re-lays-out the page
+  // (the _layoutZoom regime changes geometry.scale) would leave a cached
+  // view rect stale, drifting the editor across the field — build
+  // refreshes _editRect from this through the live geometry
+  PdfRect? _editPageRect;
   PdfStandardFont _editFont = PdfStandardFont.helvetica;
   double _editSize = 12;
   bool _editMultiline = false;
@@ -101,6 +106,7 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
     setState(() {
       _editingField = field.name;
       _editRect = viewRect;
+      _editPageRect = widget.geometry.toPageRect(viewRect);
       _editMultiline = field.isMultiline;
       _editFont = tf == null
           ? PdfStandardFont.helvetica
@@ -150,10 +156,12 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
       setState(() {
         _editingField = null;
         _editRect = null;
+        _editPageRect = null;
       });
     } else {
       _editingField = null;
       _editRect = null;
+      _editPageRect = null;
     }
     _controller.setEditingText(false);
   }
@@ -246,6 +254,12 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
     }
 
     final geometry = widget.geometry;
+    // re-derive the editor's view rect through the LIVE geometry: a zoom
+    // can re-lay-out the page (_layoutZoom) between open and now, so a
+    // cached view rect would have drifted off the field
+    if (_editPageRect != null) {
+      _editRect = geometry.toViewRect(_editPageRect!);
+    }
     final fields = _controller.formWidgetsOn(widget.pageIndex);
     // an edited field that vanished (undo, remote change) drops its editor
     if (_editingField != null &&

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -267,7 +267,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
 
   // in-place text editor: open after a free-text drag-out (new) or a
   // tap on the already-selected free text annotation (existing)
-  Rect? _textEditRect; // view space; null = closed
+  Rect? _textEditRect; // view space; null = closed; derived per build
+  // page space is the source of truth: a zoom that re-lays-out the page
+  // (the _layoutZoom regime changes _geometry.scale) would leave a cached
+  // view rect stale, so the box would drift across the page — build
+  // refreshes _textEditRect from this through the live geometry
+  PdfRect? _textEditPageRect;
   bool _textEditExisting = false;
   PdfEditTool? _textEditTool;
   late final TextEditingController _textEditText = TextEditingController();
@@ -1333,6 +1338,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _textEditText.text = existing ? (_controller.selectedText ?? '') : '';
     setState(() {
       _textEditRect = viewRect;
+      _textEditPageRect = _geometry.toPageRect(viewRect);
       _textEditExisting = existing;
       _textEditTool = _tool;
       _textEditFont = style?.font ?? _controller.fontFamily;
@@ -1368,6 +1374,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _textEditText.text = field.value ?? '';
     setState(() {
       _textEditRect = _geometry.toViewRect(rect);
+      _textEditPageRect = rect;
       _textEditExisting = false;
       _textEditTool = _tool;
       _textEditFieldName = field.name;
@@ -1457,10 +1464,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (mounted) {
       setState(() {
         _textEditRect = null;
+        _textEditPageRect = null;
         _textEditFieldName = null;
       });
     } else {
       _textEditRect = null;
+      _textEditPageRect = null;
       _textEditFieldName = null;
     }
     _controller.setEditingText(false);
@@ -2661,6 +2670,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_polyPoints != null && !_polyTool) {
       _polyPoints = null;
       _polyHover = null;
+    }
+    // re-derive the editor's view rect through the LIVE geometry: a zoom
+    // can re-lay-out the page (_layoutZoom) between open and now, so a
+    // cached view rect would have drifted across the page content
+    if (_textEditPageRect != null) {
+      _textEditRect = _geometry.toViewRect(_textEditPageRect!);
     }
     // switching tools mid-edit commits the text, like leaving the ink tool
     if (_textEditRect != null && _tool != _textEditTool) {

--- a/packages/dart_pdf_editor/test/editing_chrome_test.dart
+++ b/packages/dart_pdf_editor/test/editing_chrome_test.dart
@@ -1,8 +1,7 @@
-import 'dart:typed_data';
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -230,6 +229,69 @@ void main() {
         lineSeen = a2 > 150 && b2 > 150 && r2 < 120;
       }
       expect(lineSeen, isTrue);
+    });
+  });
+
+  group('inline text editor under a relayout zoom', () {
+    const editorKey = ValueKey('pdf-freetext-editor');
+    const box = PdfRect(100, 600, 300, 660);
+
+    testWidgets('an open editor rides the page when the layout zoom changes',
+        (tester) async {
+      // zooming below fit-width re-lays-out the page (the _layoutZoom
+      // regime changes geometry.scale): an editor that cached its view
+      // rect at open would drift off the page. It must track the box.
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addFreeText(0, box, 'Steady')
+        ..tool = PdfEditTool.select;
+      addTearDown(editing.dispose);
+      expect(editing.selectAnnotation(0, 0), isTrue);
+
+      final cropBox = editing.document.page(0).cropBox;
+      PdfPageGeometry geom(double pxpt) => PdfPageGeometry(
+            cropBox: cropBox,
+            rotation: 0,
+            viewSize: Size(cropBox.width * pxpt, cropBox.height * pxpt),
+          );
+      Widget tree(double pxpt) => MaterialApp(
+            home: Material(
+              child: Center(
+                child: SizedBox(
+                  width: cropBox.width * pxpt,
+                  height: cropBox.height * pxpt,
+                  child: EditingPageOverlay(
+                    controller: editing,
+                    pageIndex: 0,
+                    geometry: geom(pxpt),
+                    textPrompt: showPdfTextPrompt,
+                    zoom: 1,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+      // lay out at 0.5 px/pt and open the editor by tapping the box
+      await tester.pumpWidget(tree(0.5));
+      await tester.pump();
+      var origin = tester.getTopLeft(find.byType(EditingPageOverlay));
+      await tester.tapAt(origin + geom(0.5).toViewRect(box).center);
+      await tester.pump();
+      expect(find.byKey(editorKey), findsOneWidget);
+
+      // a zoom that re-lays-out the page larger (0.5 → 0.7 px/pt): the
+      // editor's top-left must follow the box's new view position, not
+      // stay pinned where it opened
+      await tester.pumpWidget(tree(0.7));
+      await tester.pump();
+      origin = tester.getTopLeft(find.byType(EditingPageOverlay));
+      expect(tester.getTopLeft(find.byKey(editorKey)) - origin,
+          offsetMoreOrLessEquals(geom(0.7).toViewRect(box).topLeft,
+              epsilon: 0.5));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
     });
   });
 }


### PR DESCRIPTION
## Problem

When zooming while a focused text box is on screen, the text box translates relative to the page content.

## Cause

Both inline text editors — the free-text editor (`editing_overlay.dart`) and the form-field editor (`editing_form_layer.dart`) — cached their position as a **view-space rect** captured at open time. Zooming below fit-width re-lays-out the page (the `_layoutZoom` regime, where `geometry.scale` changes rather than the InteractiveViewer transform). Once the page is re-laid-out, the cached view rect no longer maps to the same page rect, so the editor stays pinned at its old pixel offset while the page content scales around the crop-box origin — it drifts.

Above fit-width (zoom > 1) the page raster and the overlay are both children of the same transformed subtree, so they scale together and there's no drift; the bug is specific to the layout-zoom regime.

## Fix

Store the editor's rect in **page space** as the source of truth and re-derive the view rect through the *live* geometry on every build. The box now stays planted on the page through any zoom.

- `editing_overlay.dart`: added `_textEditPageRect`, set in both `_openTextEditor`/`_openFormTextEditor`, cleared in `_closeTextEditor`, and `_textEditRect` is refreshed from it at the top of `build`.
- `editing_form_layer.dart`: same pattern with `_editPageRect`.

## Test

Added a regression test in `editing_chrome_test.dart` that mounts a bare overlay, opens the editor by tapping a selected free-text box, then re-lays-out at a different layout zoom (0.5 → 0.7 px/pt) and asserts the editor's top-left tracks the page rect's new view position. Verified it fails without the fix and passes with it.

All editing suites green (`editing_chrome`, `editing_text_edit`, `editing_form`, `editing_form_interactive`, `editing_polish`).

https://claude.ai/code/session_01Symr4NhrKwQoihnhiE4qyY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Symr4NhrKwQoihnhiE4qyY)_