### PR TITLE
Bold/italic text-box fonts + font/outline/fill in the style popup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1948,3 +1948,40 @@ and the `canResizeSelected` tool gate; the "drag on a widget" test now
 asserts the widget MOVED (it used to assert nothing happened). Toolbar
 tooltip is now 'Form fields — tap to select, double-tap to fill, drag to
 add' (pdf_shell/toolbar tests that find it by tooltip updated).
+
+Bold/italic text-box fonts (Ben: font selection + outline/fill in the
+style popup, expand font choices): `PdfStandardFont` grew from 3 to all
+12 base-14 text faces — `PdfStandardFontFamily {sans, serif, mono}` is
+the family axis, orthogonal to `isBold`/`isItalic`; `styled(family,
+{bold, italic})` + `withBold`/`withItalic` pick a variant. New AFM width
+tables (`timesBoldWidths`/`timesItalicWidths`/`timesBoldItalicWidths`;
+Helvetica oblique reuses upright widths, Courier stays flat 600).
+Resource names: existing `Helv`/`TiRo`/`Cour` kept for the regular faces
+(backward-compatible /DA), variants get detectable names (`HelvBold`,
+`TimesBoldItalic`, `CourBoldObl`…) — `tryFromName` now detects family by
+substring AND bold (`bold`) / italic (`italic`/`oblique`/`obl`), so our
+short /DA names and foreign producers' both round-trip with style. The
+Times variants use `Times*` (not `Ti*`) names so `times`-substring family
+detection fires. Rendering was already style-aware: canvas_device's
+`_styleFor` keys FontWeight/FontStyle off `name.contains('Bold')`/
+`'Italic'`/`'Oblique'`, so the variant /BaseFont paints correctly with no
+font-engine change (verified by editing_font_render_test: timesBold lays
+more ink than times, italic renders). UI: shared package-private
+`FontStyleToggles` (editing_font_controls.dart, NOT exported) — a B/I
+toggle pair that flips one axis of the current family; the toolbar
+`_StyleMenu` now has a family SegmentedButton (Sans/Serif/Mono, bound to
+`.family`) + a 'Style' row of toggles, and the properties panel's font
+dropdown switched to a family dropdown + the same toggles. The font chip
+label shows the suffix (' B'/' I'/' BI'). Properties panel also gained
+the missing 'Outline' swatch for FreeText (`pdf-prop-text-border` →
+`restyleSelectedText(border:)`; the toolbar already had 'Text border').
+The two inline-editor `_uiFamily` switches (overlay + form layer) map by
+`.family` now and set fontWeight/fontStyle so the live editor previews
+bold/italic. Toggle keys 'pdf-font-bold'/'-italic' (toolbar) and
+'pdf-prop-font-bold'/'-italic' (panel). Tests: annotation_editor_test
+(12-variant coverage, name round-trips with style, bold-italic /BaseFont
++ /Widths), editing_text_edit_test (toolbar B/I toggles + family keeps
+style), editing_properties_test (panel B/I toggles + the outline row),
+editing_font_render_test (end-to-end raster). The existing 'Serif'/'Mono'
+tap tests still pass — tapping a family with no B/I set yields the base
+variant.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_font_controls.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_font_controls.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+/// A Bold / Italic toggle pair that picks the matching base-14 variant of
+/// [font]'s current family (Sans/Serif/Mono). Reports the new font — same
+/// family, the toggled style — through [onChanged].
+///
+/// Package-internal chrome shared by the toolbar style popup and the
+/// annotation properties panel; not part of the public API.
+class FontStyleToggles extends StatelessWidget {
+  const FontStyleToggles({
+    super.key,
+    required this.font,
+    required this.onChanged,
+    this.keyPrefix = 'pdf-font',
+  });
+
+  /// The font whose bold/italic state the toggles reflect.
+  final PdfStandardFont font;
+
+  /// Called with the variant of [font]'s family carrying the new style.
+  final ValueChanged<PdfStandardFont> onChanged;
+
+  /// Prefix for the toggle keys (`<prefix>-bold` / `<prefix>-italic`), so
+  /// the toolbar and the panel get distinct ones.
+  final String keyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    Widget toggle({
+      required Key key,
+      required String label,
+      required String tooltip,
+      required bool selected,
+      required FontWeight weight,
+      required FontStyle style,
+      required VoidCallback onTap,
+    }) =>
+        Tooltip(
+          message: tooltip,
+          child: InkWell(
+            key: key,
+            onTap: onTap,
+            customBorder: const CircleBorder(),
+            child: Container(
+              width: 28,
+              height: 28,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: selected ? scheme.primary : Colors.transparent,
+                border: Border.all(
+                    color: selected ? scheme.primary : scheme.outline),
+              ),
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: weight,
+                  fontStyle: style,
+                  color: selected ? scheme.onPrimary : scheme.onSurface,
+                ),
+              ),
+            ),
+          ),
+        );
+    return Row(mainAxisSize: MainAxisSize.min, children: [
+      toggle(
+        key: ValueKey('$keyPrefix-bold'),
+        label: 'B',
+        tooltip: 'Bold',
+        selected: font.isBold,
+        weight: FontWeight.bold,
+        style: FontStyle.normal,
+        onTap: () => onChanged(font.withBold(!font.isBold)),
+      ),
+      const SizedBox(width: 8),
+      toggle(
+        key: ValueKey('$keyPrefix-italic'),
+        label: 'I',
+        tooltip: 'Italic',
+        selected: font.isItalic,
+        weight: FontWeight.normal,
+        style: FontStyle.italic,
+        onTap: () => onChanged(font.withItalic(!font.isItalic)),
+      ),
+    ]);
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -81,10 +81,10 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
 
   /// The flutter font family visually matching a base-14 [font] — the
   /// same substitution the renderer and the inline editor use.
-  static String _uiFamily(PdfStandardFont font) => switch (font) {
-        PdfStandardFont.helvetica => 'Helvetica',
-        PdfStandardFont.times => 'Times New Roman',
-        PdfStandardFont.courier => 'Courier',
+  static String _uiFamily(PdfStandardFont font) => switch (font.family) {
+        PdfStandardFontFamily.sans => 'Helvetica',
+        PdfStandardFontFamily.serif => 'Times New Roman',
+        PdfStandardFontFamily.mono => 'Courier',
       };
 
   void _onFocusChange() {
@@ -320,6 +320,10 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
               fontSize: _editSize * scale,
               height: 1.2,
               fontFamily: _uiFamily(_editFont),
+              fontWeight:
+                  _editFont.isBold ? FontWeight.bold : FontWeight.normal,
+              fontStyle:
+                  _editFont.isItalic ? FontStyle.italic : FontStyle.normal,
             ),
             decoration: InputDecoration(
               isCollapsed: true,
@@ -352,6 +356,8 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
               fontSize: size * widget.geometry.scale,
               height: 1.2,
               fontFamily: _uiFamily(font),
+              fontWeight: font.isBold ? FontWeight.bold : FontWeight.normal,
+              fontStyle: font.isItalic ? FontStyle.italic : FontStyle.normal,
             ),
           ),
         ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -2628,6 +2628,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           fontSize: size * _geometry.scale,
           height: 1.2,
           fontFamily: _uiFamily(font),
+          fontWeight: font.isBold ? FontWeight.bold : FontWeight.normal,
+          fontStyle: font.isItalic ? FontStyle.italic : FontStyle.normal,
         ),
       ),
     );
@@ -2642,10 +2644,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
 
   /// The Flutter font family that visually matches [font] — the same
   /// substitution the renderer uses for non-embedded base-14 fonts.
-  static String _uiFamily(PdfStandardFont font) => switch (font) {
-        PdfStandardFont.helvetica => 'Helvetica',
-        PdfStandardFont.times => 'Times New Roman',
-        PdfStandardFont.courier => 'Courier',
+  static String _uiFamily(PdfStandardFont font) => switch (font.family) {
+        PdfStandardFontFamily.sans => 'Helvetica',
+        PdfStandardFontFamily.serif => 'Times New Roman',
+        PdfStandardFontFamily.mono => 'Courier',
       };
 
   @override
@@ -3061,6 +3063,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                           fontSize: _textEditSize * _geometry.scale,
                           height: 1.2,
                           fontFamily: _uiFamily(_textEditFont),
+                          fontWeight: _textEditFont.isBold
+                              ? FontWeight.bold
+                              : FontWeight.normal,
+                          fontStyle: _textEditFont.isItalic
+                              ? FontStyle.italic
+                              : FontStyle.normal,
                         ),
                         decoration: InputDecoration(
                           isCollapsed: true,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -4,6 +4,7 @@ import 'package:pdf_document/pdf_document.dart';
 import '../scrollbar.dart';
 import 'editing_color_picker.dart';
 import 'editing_controller.dart';
+import 'editing_font_controls.dart';
 import 'editing_panel.dart';
 import 'editing_preferences.dart';
 
@@ -229,13 +230,31 @@ class _PdfAnnotationPropertiesPanelState
     if (picked != null) _controller.restyleSelected(fill: (picked,));
   }
 
+  static int? _rgb(Color? color) =>
+      color == null ? null : color.toARGB32() & 0xFFFFFF;
+
+  Future<void> _pickTextBorder(Color? current) async {
+    final picked = await showPdfColorPicker(context,
+        initial: current ?? const Color(0xFF000000),
+        initialFormat: _preferences.colorPickerFormat,
+        onFormatChanged: (format) => _preferences.colorPickerFormat = format);
+    if (picked != null) {
+      _controller.restyleSelectedText(
+          border: (_rgb(picked),),
+          borderWidth: _controller.strokeWidth);
+    }
+  }
+
   Widget _section(String title) => Padding(
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
         child: Text(title, style: Theme.of(context).textTheme.labelLarge),
       );
 
   Widget _swatchRow(String label, Color? color,
-      {required Key key, required VoidCallback onTap, VoidCallback? onClear}) {
+      {required Key key,
+      required VoidCallback onTap,
+      VoidCallback? onClear,
+      String clearTooltip = 'No fill'}) {
     final scheme = Theme.of(context).colorScheme;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -244,7 +263,7 @@ class _PdfAnnotationPropertiesPanelState
         if (onClear != null)
           IconButton(
             icon: const Icon(Icons.format_color_reset_outlined, size: 18),
-            tooltip: 'No fill',
+            tooltip: clearTooltip,
             visualDensity: VisualDensity.compact,
             onPressed: color == null ? null : onClear,
           ),
@@ -422,31 +441,50 @@ class _PdfAnnotationPropertiesPanelState
     return children;
   }
 
-  List<Widget> _textStyleControls() {
+  List<Widget> _textStyleControls(PdfAnnotation annotation) {
     if (!_controller.canRestyleSelectedText) return const [];
     final style = _controller.selectedTextStyle;
     if (style == null) return const [];
+    final border = annotation.subtype == 'FreeText'
+        ? annotation.freeTextStyle?.borderColor
+        : null;
+    final borderColor = border == null ? null : Color(0xFF000000 | border);
     return [
       _section('Text'),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         child: Row(children: [
           const Expanded(child: Text('Font')),
-          DropdownButton<PdfStandardFont>(
+          DropdownButton<PdfStandardFontFamily>(
             key: const ValueKey('pdf-prop-font'),
-            value: style.font,
+            value: style.font.family,
             isDense: true,
             items: const [
               DropdownMenuItem(
-                  value: PdfStandardFont.helvetica, child: Text('Sans')),
+                  value: PdfStandardFontFamily.sans, child: Text('Sans')),
               DropdownMenuItem(
-                  value: PdfStandardFont.times, child: Text('Serif')),
+                  value: PdfStandardFontFamily.serif, child: Text('Serif')),
               DropdownMenuItem(
-                  value: PdfStandardFont.courier, child: Text('Mono')),
+                  value: PdfStandardFontFamily.mono, child: Text('Mono')),
             ],
-            onChanged: (font) {
-              if (font != null) _controller.restyleSelectedText(font: font);
+            onChanged: (family) {
+              if (family != null) {
+                _controller.restyleSelectedText(
+                    font: PdfStandardFont.styled(family,
+                        bold: style.font.isBold, italic: style.font.isItalic));
+              }
             },
+          ),
+        ]),
+      ),
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        child: Row(children: [
+          const Expanded(child: Text('Style')),
+          FontStyleToggles(
+            keyPrefix: 'pdf-prop-font',
+            font: style.font,
+            onChanged: (font) => _controller.restyleSelectedText(font: font),
           ),
         ]),
       ),
@@ -462,6 +500,12 @@ class _PdfAnnotationPropertiesPanelState
           setState(() => _draggingFontSize = null);
         },
       ),
+      if (annotation.subtype == 'FreeText')
+        _swatchRow('Outline', borderColor,
+            key: const ValueKey('pdf-prop-text-border'),
+            onTap: () => _pickTextBorder(borderColor),
+            onClear: () => _controller.restyleSelectedText(border: (null,)),
+            clearTooltip: 'No outline'),
     ];
   }
 
@@ -474,7 +518,7 @@ class _PdfAnnotationPropertiesPanelState
         subtitle: Text('Page ${slot.$1 + 1}'),
       ),
       ..._styleControls(annotation),
-      ..._textStyleControls(),
+      ..._textStyleControls(annotation),
       _section('Content'),
       _textRow('Contents', _contents,
           key: const ValueKey('pdf-prop-contents'),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -3,11 +3,12 @@ import 'dart:typed_data';
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart'
-    show PdfLineEnding, PdfStandardFont;
+    show PdfLineEnding, PdfStandardFont, PdfStandardFontFamily;
 
 import '../pdf_viewer.dart';
 import 'editing_color_picker.dart';
 import 'editing_controller.dart';
+import 'editing_font_controls.dart';
 import 'editing_measure.dart';
 import 'editing_signature.dart';
 import 'editing_stamps.dart';
@@ -1858,12 +1859,16 @@ class _StyleMenuState extends State<_StyleMenu> {
   double? _draggingStroke;
   double? _draggingOpacity;
 
-  void _setFontFamily(PdfStandardFont font) {
+  void _setFont(PdfStandardFont font) {
     controller.fontFamily = font; // the new default either way
     if (controller.canRestyleSelectedText) {
       controller.restyleSelectedText(font: font);
     }
   }
+
+  void _setFontFamily(PdfStandardFontFamily family, PdfStandardFont current) =>
+      _setFont(PdfStandardFont.styled(family,
+          bold: current.isBold, italic: current.isItalic));
 
   static int? _rgb(Color? color) =>
       color == null ? null : color.toARGB32() & 0xFFFFFF;
@@ -2210,26 +2215,27 @@ class _StyleMenuState extends State<_StyleMenu> {
                         setState(() => _draggingFontSize = null);
                       },
                     ),
-                  if (fields.font)
+                  if (fields.font) ...[
                     Padding(
                       padding: const EdgeInsets.only(top: 4),
                       child: Row(children: [
                         const SizedBox(width: 86, child: Text('Font')),
                         Expanded(
-                          child: SegmentedButton<PdfStandardFont>(
+                          child: SegmentedButton<PdfStandardFontFamily>(
                             segments: const [
                               ButtonSegment(
-                                  value: PdfStandardFont.helvetica,
+                                  value: PdfStandardFontFamily.sans,
                                   label: Text('Sans')),
                               ButtonSegment(
-                                  value: PdfStandardFont.times,
+                                  value: PdfStandardFontFamily.serif,
                                   label: Text('Serif')),
                               ButtonSegment(
-                                  value: PdfStandardFont.courier,
+                                  value: PdfStandardFontFamily.mono,
                                   label: Text('Mono')),
                             ],
                             selected: {
-                              selectedStyle?.font ?? controller.fontFamily
+                              (selectedStyle?.font ?? controller.fontFamily)
+                                  .family
                             },
                             showSelectedIcon: false,
                             style: const ButtonStyle(
@@ -2237,12 +2243,24 @@ class _StyleMenuState extends State<_StyleMenu> {
                               padding: WidgetStatePropertyAll(
                                   EdgeInsets.symmetric(horizontal: 8)),
                             ),
-                            onSelectionChanged: (selection) =>
-                                _setFontFamily(selection.single),
+                            onSelectionChanged: (selection) => _setFontFamily(
+                                selection.single,
+                                selectedStyle?.font ?? controller.fontFamily),
                           ),
                         ),
                       ]),
                     ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Row(children: [
+                        const SizedBox(width: 86, child: Text('Style')),
+                        FontStyleToggles(
+                          font: selectedStyle?.font ?? controller.fontFamily,
+                          onChanged: _setFont,
+                        ),
+                      ]),
+                    ),
+                  ],
                   if (fields.boxColors && widget.showColor) ...[
                     _boxColorRow(
                       context: context,
@@ -2328,17 +2346,22 @@ class _FontChip extends StatelessWidget {
   final String tooltip;
   final VoidCallback onTap;
 
-  static String _familyLabel(PdfStandardFont font) => switch (font) {
-        PdfStandardFont.times => 'Serif',
-        PdfStandardFont.courier => 'Mono',
-        _ => 'Sans',
-      };
+  static String _familyLabel(PdfStandardFont font) {
+    final base = font.family.label;
+    final suffix = switch ((font.isBold, font.isItalic)) {
+      (true, true) => ' BI',
+      (true, false) => ' B',
+      (false, true) => ' I',
+      (false, false) => '',
+    };
+    return '$base$suffix';
+  }
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final style = controller.selectedTextStyle;
-    final family = style?.font ?? controller.fontFamily;
+    final font = style?.font ?? controller.fontFamily;
     final size = (style?.size ?? controller.fontSize).round();
     return Tooltip(
       message: tooltip,
@@ -2357,7 +2380,7 @@ class _FontChip extends StatelessWidget {
               const Text('Aa',
                   style: TextStyle(fontWeight: FontWeight.w700, fontSize: 14)),
               const SizedBox(width: 8),
-              Text(_familyLabel(family), style: const TextStyle(fontSize: 13)),
+              Text(_familyLabel(font), style: const TextStyle(fontSize: 13)),
               const SizedBox(width: 6),
               Text('$size',
                   style: TextStyle(

--- a/packages/dart_pdf_editor/test/editing_font_render_test.dart
+++ b/packages/dart_pdf_editor/test/editing_font_render_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+/// Renders a free-text box in [font] and counts how many pixels carry ink
+/// (any channel meaningfully below white) on the rasterized page.
+Future<int> _inkPixels(PdfStandardFont font) async {
+  final editor = PdfEditor(PdfDocument.open(buildClassicPdf()))
+    ..addFreeText(0, const PdfRect(72, 600, 320, 700), 'Bold italic test',
+        fontSize: 28, font: font);
+  final doc = PdfDocument.open(editor.save());
+  final image = await PdfPageRenderer.renderImage(doc.page(0));
+  final data = await image.toByteData();
+  var ink = 0;
+  for (var i = 0; i < data!.lengthInBytes; i += 4) {
+    if (data.getUint8(i) < 128) ink++;
+  }
+  return ink;
+}
+
+void main() {
+  testWidgets('bold free text paints more ink than the regular face',
+      (tester) async {
+    await tester.runAsync(() async {
+      final regular = await _inkPixels(PdfStandardFont.times);
+      final bold = await _inkPixels(PdfStandardFont.timesBold);
+      // the text must actually render…
+      expect(regular, greaterThan(50));
+      // …and the bold variant lays down visibly more ink.
+      expect(bold, greaterThan(regular));
+    });
+  });
+
+  testWidgets('italic free text renders without throwing', (tester) async {
+    await tester.runAsync(() async {
+      final italic = await _inkPixels(PdfStandardFont.timesBoldItalic);
+      expect(italic, greaterThan(50));
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -267,6 +267,39 @@ void main() {
       await tester.pumpAndSettle();
       expect(editing.selectedTextStyle?.font, PdfStandardFont.times);
       expect(editing.selectedAnnotation?.contents, 'Hello'); // text kept
+
+      // the Bold / Italic toggles pick the variant, keeping the family
+      await tester.tap(find.byKey(const ValueKey('pdf-prop-font-bold')));
+      await tester.pump();
+      expect(editing.selectedTextStyle?.font, PdfStandardFont.timesBold);
+      await tester.tap(find.byKey(const ValueKey('pdf-prop-font-italic')));
+      await tester.pump();
+      expect(editing.selectedTextStyle?.font, PdfStandardFont.timesBoldItalic);
+    });
+
+    testWidgets('free text gets an outline (border) control', (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addFreeText(0, const PdfRect(100, 500, 300, 620), 'Hello');
+      addTearDown(editing.dispose);
+      await pumpPanel(tester, editing);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      // no border yet
+      expect(editing.selectedAnnotation?.freeTextStyle?.borderColor, isNull);
+      // the outline row is present for free text
+      expect(
+          find.byKey(const ValueKey('pdf-prop-text-border')), findsOneWidget);
+
+      // setting a border directly through the controller (the swatch opens a
+      // modal picker) shows it round-trips, and clearing removes it
+      editing.restyleSelectedText(border: (0xFF0000,), borderWidth: 2);
+      await tester.pump();
+      expect(editing.selectedAnnotation?.freeTextStyle?.borderColor, 0xFF0000);
+
+      editing.restyleSelectedText(border: (null,));
+      await tester.pump();
+      expect(editing.selectedAnnotation?.freeTextStyle?.borderColor, isNull);
     });
 
     testWidgets('a multi-selection styles everything at once', (tester) async {

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -353,6 +353,18 @@ void main() {
       await tester.tap(find.text('Mono'));
       await tester.pump();
       expect(editing.fontFamily, PdfStandardFont.courier);
+
+      // the Bold / Italic toggles pick the matching base-14 variant
+      await tester.tap(find.byKey(const ValueKey('pdf-font-bold')));
+      await tester.pump();
+      expect(editing.fontFamily, PdfStandardFont.courierBold);
+      await tester.tap(find.byKey(const ValueKey('pdf-font-italic')));
+      await tester.pump();
+      expect(editing.fontFamily, PdfStandardFont.courierBoldOblique);
+      // switching family keeps the bold+italic style
+      await tester.tap(find.text('Serif'));
+      await tester.pump();
+      expect(editing.fontFamily, PdfStandardFont.timesBoldItalic);
     });
 
     testWidgets('the style menu sets text fill and border defaults',

--- a/packages/pdf_document/lib/src/content_writer.dart
+++ b/packages/pdf_document/lib/src/content_writer.dart
@@ -198,6 +198,39 @@ const List<int> timesRomanWidths = [
   278, 500, 500, 722, 500, 500, 444, 480, 200, 480, 541,
 ];
 
+/// AFM advance widths for Times-Bold, characters 32–126.
+const List<int> timesBoldWidths = [
+  250, 333, 555, 500, 500, 1000, 833, 278, 333, 333, 500, 570, 250, 333, //
+  250, 278, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 333, 333, //
+  570, 570, 570, 500, 930, 722, 667, 722, 722, 667, 611, 778, 778, 389, //
+  500, 778, 667, 944, 722, 778, 611, 778, 722, 556, 667, 722, 722, 1000, //
+  722, 722, 667, 333, 278, 333, 581, 500, 333, 500, 556, 444, 556, 444, //
+  333, 500, 556, 278, 333, 556, 278, 833, 556, 500, 556, 556, 444, 389, //
+  333, 556, 500, 722, 500, 500, 444, 394, 220, 394, 520,
+];
+
+/// AFM advance widths for Times-Italic, characters 32–126.
+const List<int> timesItalicWidths = [
+  250, 333, 420, 500, 500, 833, 778, 333, 333, 333, 500, 675, 250, 333, //
+  250, 278, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 333, 333, //
+  675, 675, 675, 500, 920, 611, 611, 667, 722, 611, 611, 722, 722, 333, //
+  444, 667, 556, 833, 667, 722, 611, 722, 611, 500, 556, 722, 611, 833, //
+  611, 556, 556, 389, 278, 389, 422, 500, 333, 500, 500, 444, 500, 444, //
+  278, 500, 500, 278, 278, 444, 278, 722, 500, 500, 500, 500, 389, 389, //
+  278, 500, 444, 667, 444, 444, 389, 400, 275, 400, 541,
+];
+
+/// AFM advance widths for Times-BoldItalic, characters 32–126.
+const List<int> timesBoldItalicWidths = [
+  250, 389, 555, 500, 500, 833, 778, 278, 333, 333, 500, 570, 250, 333, //
+  250, 278, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 333, 333, //
+  570, 570, 570, 500, 832, 667, 667, 667, 722, 667, 667, 722, 778, 389, //
+  500, 667, 611, 889, 722, 722, 611, 722, 667, 556, 611, 722, 667, 889, //
+  667, 611, 611, 333, 278, 333, 570, 500, 333, 500, 500, 444, 500, 444, //
+  333, 500, 556, 278, 278, 500, 278, 778, 556, 500, 500, 500, 389, 389, //
+  278, 556, 444, 667, 500, 444, 389, 348, 220, 348, 570,
+];
+
 /// Measures [text] in points at [fontSize], using base-14 Helvetica
 /// metrics. Characters outside 32–126 count as an average width.
 double measureHelvetica(String text, double fontSize, {bool bold = false}) {
@@ -209,22 +242,70 @@ double measureHelvetica(String text, double fontSize, {bool bold = false}) {
   return total * fontSize / 1000;
 }
 
-/// The standard one-byte fonts the editors write text with — a
-/// sans-serif, serif, and monospace pick from the PDF base-14 set, which
-/// every viewer renders without embedding.
+/// The three base-14 type families the editors write text with — a
+/// sans-serif, serif, and monospace pick that every viewer renders
+/// without embedding. The bold/italic variants of each are individual
+/// [PdfStandardFont] values; this is the axis the UI's family picker
+/// selects, orthogonal to the bold/italic toggles.
+enum PdfStandardFontFamily {
+  /// Helvetica.
+  sans('Sans'),
+
+  /// Times.
+  serif('Serif'),
+
+  /// Courier.
+  mono('Mono');
+
+  const PdfStandardFontFamily(this.label);
+
+  /// A short human label for a font picker.
+  final String label;
+}
+
+/// The standard one-byte fonts the editors write text with — the bold,
+/// italic, and bold-italic variants of a sans-serif, serif, and
+/// monospace pick from the PDF base-14 set, which every viewer renders
+/// without embedding.
 enum PdfStandardFont {
-  helvetica('Helvetica', 'Helv', 718, helveticaWidths, 556),
-  times('Times-Roman', 'TiRo', 683, timesRomanWidths, 500),
-  courier('Courier', 'Cour', 629, null, 600);
+  helvetica('Helvetica', 'Helv', 718, helveticaWidths, 556,
+      PdfStandardFontFamily.sans),
+  helveticaBold('Helvetica-Bold', 'HelvBold', 718, helveticaBoldWidths, 556,
+      PdfStandardFontFamily.sans, bold: true),
+  helveticaOblique('Helvetica-Oblique', 'HelvObl', 718, helveticaWidths, 556,
+      PdfStandardFontFamily.sans, italic: true),
+  helveticaBoldOblique('Helvetica-BoldOblique', 'HelvBoldObl', 718,
+      helveticaBoldWidths, 556, PdfStandardFontFamily.sans,
+      bold: true, italic: true),
+  times('Times-Roman', 'TiRo', 683, timesRomanWidths, 500,
+      PdfStandardFontFamily.serif),
+  timesBold('Times-Bold', 'TimesBold', 683, timesBoldWidths, 500,
+      PdfStandardFontFamily.serif, bold: true),
+  timesItalic('Times-Italic', 'TimesItalic', 683, timesItalicWidths, 500,
+      PdfStandardFontFamily.serif, italic: true),
+  timesBoldItalic('Times-BoldItalic', 'TimesBoldItalic', 683,
+      timesBoldItalicWidths, 500, PdfStandardFontFamily.serif,
+      bold: true, italic: true),
+  courier('Courier', 'Cour', 629, null, 600, PdfStandardFontFamily.mono),
+  courierBold('Courier-Bold', 'CourBold', 629, null, 600,
+      PdfStandardFontFamily.mono, bold: true),
+  courierOblique('Courier-Oblique', 'CourObl', 629, null, 600,
+      PdfStandardFontFamily.mono, italic: true),
+  courierBoldOblique('Courier-BoldOblique', 'CourBoldObl', 629, null, 600,
+      PdfStandardFontFamily.mono, bold: true, italic: true);
 
   const PdfStandardFont(this.baseFont, this.resourceName, this.ascent,
-      this._widths, this._fallbackWidth);
+      this._widths, this._fallbackWidth, this.family,
+      {bool bold = false, bool italic = false})
+      : isBold = bold,
+        isItalic = italic;
 
   /// The /BaseFont name.
   final String baseFont;
 
   /// The appearance-resource name used in /DA, following Acrobat's
-  /// conventions (Helv, TiRo, Cour).
+  /// short-name conventions (Helv, TiRo, Cour) with explicit suffixes
+  /// for the bold/italic variants.
   final String resourceName;
 
   /// Ascender height in thousandths of an em — where the first baseline
@@ -233,6 +314,15 @@ enum PdfStandardFont {
 
   final List<int>? _widths; // null: monospaced at [_fallbackWidth]
   final int _fallbackWidth;
+
+  /// The type family (sans/serif/mono) this is a variant of.
+  final PdfStandardFontFamily family;
+
+  /// Whether this is a bold variant.
+  final bool isBold;
+
+  /// Whether this is an italic (or oblique) variant.
+  final bool isItalic;
 
   /// AFM advance width of character [code] in thousandths of an em.
   int widthOf(int code) {
@@ -244,9 +334,31 @@ enum PdfStandardFont {
   /// Advance widths for characters 32–126 (the font dict's /Widths).
   List<int> get widths => _widths ?? List.filled(95, _fallbackWidth);
 
+  /// The variant of [family] with the requested [bold]/[italic] style.
+  static PdfStandardFont styled(PdfStandardFontFamily family,
+      {bool bold = false, bool italic = false}) {
+    for (final font in values) {
+      if (font.family == family &&
+          font.isBold == bold &&
+          font.isItalic == italic) {
+        return font;
+      }
+    }
+    return helvetica; // unreachable: every (family, bold, italic) exists
+  }
+
+  /// This font with bold turned on or off, same family and italic.
+  PdfStandardFont withBold(bool bold) =>
+      styled(family, bold: bold, italic: isItalic);
+
+  /// This font with italic turned on or off, same family and bold.
+  PdfStandardFont withItalic(bool italic) =>
+      styled(family, bold: isBold, italic: italic);
+
   /// Maps a /DA resource name or /BaseFont name leniently — other
   /// producers write /Times-Roman, /Georgia, /CourierNew and the like —
-  /// defaulting to [helvetica].
+  /// defaulting to [helvetica]. Bold and italic/oblique are recovered
+  /// from the name when present.
   static PdfStandardFont fromName(String name) =>
       tryFromName(name) ?? helvetica;
 
@@ -256,14 +368,23 @@ enum PdfStandardFont {
   /// unrecognized fonts alone rather than silently substitute.
   static PdfStandardFont? tryFromName(String name) {
     final n = name.toLowerCase();
+    PdfStandardFontFamily? family;
     if (n.contains('tiro') || n.contains('times') || n.contains('serif')) {
-      return times;
+      family = PdfStandardFontFamily.serif;
+    } else if (n.contains('cour') || n.contains('mono')) {
+      family = PdfStandardFontFamily.mono;
+    } else if (n.contains('helv') ||
+        n.contains('arial') ||
+        n.contains('sans')) {
+      family = PdfStandardFontFamily.sans;
     }
-    if (n.contains('cour') || n.contains('mono')) return courier;
-    if (n.contains('helv') || n.contains('arial') || n.contains('sans')) {
-      return helvetica;
-    }
-    return null;
+    if (family == null) return null;
+    final bold = n.contains('bold');
+    final italic = n.contains('italic') ||
+        n.contains('oblique') ||
+        n.contains('ital') ||
+        n.contains('obl');
+    return styled(family, bold: bold, italic: italic);
   }
 }
 

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -282,6 +282,68 @@ void main() {
     expect(PdfStandardFont.fromName('Arial'), PdfStandardFont.helvetica);
   });
 
+  test('standard fonts cover bold and italic variants', () {
+    // every (family, bold, italic) combination resolves to a distinct font
+    for (final family in PdfStandardFontFamily.values) {
+      for (final bold in [false, true]) {
+        for (final italic in [false, true]) {
+          final font =
+              PdfStandardFont.styled(family, bold: bold, italic: italic);
+          expect(font.family, family);
+          expect(font.isBold, bold);
+          expect(font.isItalic, italic);
+        }
+      }
+    }
+    expect(PdfStandardFont.values.length, 12);
+
+    // names round-trip with their style recovered
+    expect(PdfStandardFont.fromName('Helvetica-Bold'),
+        PdfStandardFont.helveticaBold);
+    expect(PdfStandardFont.fromName('Helvetica-BoldOblique'),
+        PdfStandardFont.helveticaBoldOblique);
+    expect(PdfStandardFont.fromName('Times-Italic'),
+        PdfStandardFont.timesItalic);
+    expect(PdfStandardFont.fromName('Times-BoldItalic'),
+        PdfStandardFont.timesBoldItalic);
+    expect(PdfStandardFont.fromName('Courier-Oblique'),
+        PdfStandardFont.courierOblique);
+    // our own short /DA resource names recover too
+    expect(PdfStandardFont.fromName('TimesBoldItalic'),
+        PdfStandardFont.timesBoldItalic);
+    expect(PdfStandardFont.fromName('CourBoldObl'),
+        PdfStandardFont.courierBoldOblique);
+
+    // withBold/withItalic flip one axis, keep the family
+    expect(PdfStandardFont.times.withBold(true), PdfStandardFont.timesBold);
+    expect(PdfStandardFont.timesBold.withItalic(true),
+        PdfStandardFont.timesBoldItalic);
+
+    // bold metrics differ from the regular face (AFM Times widths)
+    expect(measureStandardText('M', 1000, font: PdfStandardFont.times), 889);
+    expect(measureStandardText('M', 1000, font: PdfStandardFont.timesBold), 944);
+    expect(
+        measureStandardText('M', 1000, font: PdfStandardFont.timesItalic), 833);
+  });
+
+  test('bold-italic free text writes its variant /BaseFont and /Widths', () {
+    final doc = roundTrip((e) => e.addFreeText(
+        0, const PdfRect(72, 600, 240, 680), 'Bold italic',
+        fontSize: 12, font: PdfStandardFont.timesBoldItalic));
+    final annot = doc.page(0).annotations.single;
+    final da = doc.cos.resolve(annot.dict['DA']) as CosString;
+    expect(da.text, contains('/TimesBoldItalic 12 Tf'));
+    final res = doc.cos.resolve(annot.normalAppearance!.dictionary['Resources'])
+        as CosDictionary;
+    final fonts = doc.cos.resolve(res['Font']) as CosDictionary;
+    final font = doc.cos.resolve(fonts['TimesBoldItalic']) as CosDictionary;
+    expect((doc.cos.resolve(font['BaseFont']) as CosName).value,
+        'Times-BoldItalic');
+    final widths = doc.cos.resolve(font['Widths']) as CosArray;
+    // 'M' is code 77; Times-BoldItalic 'M' is 889/1000 em
+    expect((widths.items[77 - 32] as CosInteger).value, 889);
+  });
+
   test('note builds a 20pt icon at the given top-left corner', () {
     final doc = roundTrip(
         (e) => e.addNote(0, 500, 700, 'remember this', author: 'Ben'));


### PR DESCRIPTION
## What

Text boxes (free text) could already pick a font family (Sans/Serif/Mono) and set a fill + border from the toolbar's style popup, but:

- font choices were limited to **3 faces** — no bold or italic, and
- the **properties panel** had font/size/fill but was **missing the outline (border)** control.

This PR closes both gaps.

## Changes

**Font set — `PdfStandardFont` (pdf_document)**
- Expanded from 3 to all **12 base-14 text faces** (regular/bold/italic/bold-italic of Helvetica, Times, Courier).
- New `PdfStandardFontFamily {sans, serif, mono}` family axis, orthogonal to `isBold`/`isItalic`; `styled(family, {bold, italic})` + `withBold`/`withItalic` pick a variant.
- Added AFM width tables `timesBoldWidths` / `timesItalicWidths` / `timesBoldItalicWidths` (Helvetica obliques reuse upright widths; Courier stays flat 600).
- `tryFromName` now recovers **bold/italic from the name** as well as family, so generated `/DA` resource names and foreign producers' both round-trip with style. Regular faces keep their existing `Helv`/`TiRo`/`Cour` names (backward-compatible).

**UI**
- Shared package-private `FontStyleToggles` (B / I) widget.
- Toolbar style popup: family `SegmentedButton` (bound to `.family`) + a new **Style** row of bold/italic toggles. Font chip label shows the suffix (` B` / ` I` / ` BI`).
- Properties panel: font dropdown switched to a family dropdown + the same toggles, **and a new `Outline` swatch** for free text (`restyleSelectedText(border:)`).
- The inline text and form editors now map `fontWeight`/`fontStyle` per variant so live previews show bold/italic.

**Rendering** already keyed weight/style off the `/BaseFont` name (`canvas_device._styleFor`), so the new variants paint correctly with no font-engine change.

## Tests

- `annotation_editor_test`: 12-variant coverage, name round-trips with style, bold-italic `/BaseFont` + `/Widths`.
- `editing_text_edit_test` / `editing_properties_test`: B/I toggles, family-keeps-style, the new outline control.
- `editing_font_render_test` (new): end-to-end raster — bold lays down more ink than the regular face; italic renders.
- `dart analyze` clean across the repo. Pre-existing example-app test failures are unchanged by this PR (verified against baseline).

https://claude.ai/code/session_016wpwnR6UxbeYBHUeZBrtKf

---
_Generated by [Claude Code](https://claude.ai/code/session_016wpwnR6UxbeYBHUeZBrtKf)_