### PR TITLE
Save styling preferences per annotation tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2053,3 +2053,33 @@ and the `canResizeSelected` tool gate; the "drag on a widget" test now
 asserts the widget MOVED (it used to assert nothing happened). Toolbar
 tooltip is now 'Form fields — tap to select, double-tap to fill, drag to
 add' (pdf_shell/toolbar tests that find it by tooltip updated).
+
+Per-tool style memory (Ben: "save the styling preferences per annotation
+tool"): each annotation tool now remembers its own colour, stroke,
+opacity, font, line style/endings and fills, so the yellow highlighter
+stays yellow while ink stays black across tool switches and sessions.
+The live single values in `PdfEditingPreferences` stay the source of
+truth the creation methods read (unchanged); on top of them sits a
+per-scope snapshot map `_toolStyles` (persisted as one JSON blob under
+`toolStyles`, colours as ARGB ints, enums by name). `beginStyleScope(
+scope, fields)` activates a scope — restoring its saved style into the
+live values by driving the public setters under a `_restoringScope`
+guard (so the load doesn't re-record) — and while a scope is active every
+style setter ALSO records its field into the slot via `_recordScoped`
+(only the `fields` the scope remembers). The controller's `tool` setter
+calls `beginStyleScope(_styleScopeKey(tool), _styleScopeFields(tool))`:
+key = the tool's name for the styled creators (ink/eraser/shapes/lines/
+measure/freeText/note/stamp), null for select/content/form/redact/
+signature (signature shares the global colour, which `_drawSignature`
+seeds from the drawn ink). The per-tool `fields` mirror each tool's
+toolbar strip — ink keeps stroke not endings, rectangle keeps fill not
+font, freeText keeps font + box colours, etc. Markup arms no tool, so
+`PdfEditingController.useMarkupStyleScope()` scopes 'markup' {color,
+opacity}; the toolbar calls it when the Markup strip opens
+(`_openGroupTap`) and when the mobile sheet's markup tab is selected.
+A tool with no saved slot inherits the current live value (no restore),
+so first use of each tool picks up the last-used style — independent
+thereafter. Tests: editing_preferences_test +4 (each tool keeps its own
+style, markup highlighter colour, no-slot inherits, persistence into a
+fresh session). The 14 Ghent render-baseline failures are pre-existing
+on this machine, unrelated.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -436,8 +436,81 @@ class PdfEditingController extends ChangeNotifier {
     _tool = value;
     if (value != PdfEditTool.select) _selected.clear();
     if (value != PdfEditTool.content) _selectedElement = null;
+    // each annotation tool remembers its own colour, stroke, opacity, … —
+    // arming one restores its saved style and routes further style changes
+    // back into its slot (see [PdfEditingPreferences.beginStyleScope])
+    preferences.beginStyleScope(
+        _styleScopeKey(value), _styleScopeFields(value));
     notifyListeners();
   }
+
+  /// The persisted-style scope key for [tool] — its [PdfEditTool] name for
+  /// the tools that create styled annotations, null for the others (select,
+  /// content, form, redact, signature, eraser-when-radius-only handled by
+  /// its own slot). See [preferences].
+  static String? _styleScopeKey(PdfEditTool? tool) => switch (tool) {
+        PdfEditTool.ink => 'ink',
+        PdfEditTool.eraser => 'eraser',
+        PdfEditTool.rectangle => 'rectangle',
+        PdfEditTool.ellipse => 'ellipse',
+        PdfEditTool.line => 'line',
+        PdfEditTool.arrow => 'arrow',
+        PdfEditTool.polyline => 'polyline',
+        PdfEditTool.polygon => 'polygon',
+        PdfEditTool.measureDistance => 'measureDistance',
+        PdfEditTool.measurePerimeter => 'measurePerimeter',
+        PdfEditTool.measureArea => 'measureArea',
+        PdfEditTool.freeText => 'freeText',
+        PdfEditTool.note => 'note',
+        PdfEditTool.stamp => 'stamp',
+        _ => null,
+      };
+
+  /// The style fields [tool] remembers — mirrors the controls its toolbar
+  /// strip exposes, so a rectangle keeps its fill but not a font, ink keeps
+  /// its stroke but not line endings, and so on.
+  static Set<String> _styleScopeFields(PdfEditTool? tool) => switch (tool) {
+        PdfEditTool.ink => const {'color', 'strokeWidth', 'opacity'},
+        PdfEditTool.eraser => const {'eraserRadius'},
+        PdfEditTool.rectangle ||
+        PdfEditTool.ellipse ||
+        PdfEditTool.polygon =>
+          const {'color', 'strokeWidth', 'opacity', 'lineStyle', 'shapeFillColor'},
+        PdfEditTool.line || PdfEditTool.polyline => const {
+            'color',
+            'strokeWidth',
+            'opacity',
+            'lineStyle',
+            'lineStartEnding',
+            'lineEndEnding',
+          },
+        PdfEditTool.arrow =>
+          const {'color', 'strokeWidth', 'opacity', 'lineStyle'},
+        PdfEditTool.measureDistance ||
+        PdfEditTool.measurePerimeter ||
+        PdfEditTool.measureArea =>
+          const {'color', 'strokeWidth', 'opacity'},
+        PdfEditTool.freeText => const {
+            'color',
+            'fontSize',
+            'fontFamily',
+            'opacity',
+            'textFillColor',
+            'textBorderColor',
+            'strokeWidth',
+          },
+        PdfEditTool.note => const {'color'},
+        PdfEditTool.stamp => const {'color', 'opacity'},
+        _ => const {},
+      };
+
+  /// Activates the text-markup style scope (highlight / underline / strike
+  /// out / squiggly) — they act on the text selection rather than arming a
+  /// tool, so the toolbar calls this when its Markup strip opens, giving
+  /// markup its own remembered colour and opacity (the classic yellow
+  /// highlighter that stays yellow). See [preferences].
+  void useMarkupStyleScope() =>
+      preferences.beginStyleScope('markup', const {'color', 'opacity'});
 
   /// The color new annotations are created with. Persisted (these four
   /// style properties live in [preferences]).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -81,6 +81,24 @@ class PdfEditingPreferences extends ChangeNotifier {
   Color? _shapeFillColor;
   PdfMeasurementScale? _measurementScale;
 
+  /// Per-tool style memory (see [beginStyleScope]). Keyed by an opaque
+  /// scope string (the controller uses tool names plus `'markup'`); each
+  /// slot holds the subset of style fields that tool remembers, JSON-
+  /// encoded (colors as ARGB ints, enums by name).
+  final Map<String, Map<String, Object?>> _toolStyles = {};
+
+  /// The active style scope, or null when style changes go only to the
+  /// shared defaults (select mode, restyling a selection). Set through
+  /// [beginStyleScope].
+  String? _styleScope;
+  Set<String> _styleScopeFields = const {};
+
+  /// While restoring a scope's stored style we drive the public setters,
+  /// so this suppresses the re-record back into the same slot.
+  bool _restoringScope = false;
+
+  static const _toolStylesKey = '${_prefix}toolStyles';
+
   /// Saved viewports per document (see [viewportFor]). Insertion order is
   /// least- to most-recently-touched, for LRU eviction past
   /// [_maxViewports].
@@ -188,6 +206,7 @@ class PdfEditingPreferences extends ChangeNotifier {
       if (shapeFill != null) _shapeFillColor = Color(shapeFill);
       final scale = store.getString('${_prefix}measurementScale');
       if (scale != null) _measurementScale = PdfMeasurementScale.decode(scale);
+      _loadToolStyles(store.getString(_toolStylesKey));
       final stamps = store.getStringList('${_prefix}customStamps');
       if (stamps != null) {
         _customStamps = List.unmodifiable([
@@ -279,6 +298,100 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (store != null) unawaited(write(store));
   }
 
+  // -------------------------------------------------------------------------
+  // per-tool style memory
+
+  void _loadToolStyles(String? source) {
+    if (source == null) return;
+    try {
+      final decoded = jsonDecode(source);
+      if (decoded is! Map) return;
+      decoded.forEach((key, value) {
+        if (key is String && value is Map) {
+          _toolStyles[key] = {
+            for (final entry in value.entries)
+              if (entry.key is String) entry.key as String: entry.value,
+          };
+        }
+      });
+    } catch (_) {
+      // corrupt blob — drop it, the defaults stand
+    }
+  }
+
+  void _writeToolStyles() =>
+      _write((s) => s.setString(_toolStylesKey, jsonEncode(_toolStyles)));
+
+  /// Activates the style scope [scope], remembering only [fields] under it,
+  /// and restores that scope's previously-saved style into the live values.
+  ///
+  /// While a scope is active every style setter ([color], [strokeWidth],
+  /// [opacity], [fontSize], [fontFamily], [lineStyle], the line endings,
+  /// the fill colors, [eraserRadius]) also records its new value under the
+  /// scope — so each annotation tool keeps its own colour, stroke and so on
+  /// across sessions. A null [scope] (select mode, or restyling a
+  /// selection) writes only the shared defaults.
+  void beginStyleScope(String? scope, Set<String> fields) {
+    if (scope == _styleScope && setEquals(fields, _styleScopeFields)) return;
+    _styleScope = scope;
+    _styleScopeFields = fields;
+    if (scope != null) _restoreScope(scope);
+  }
+
+  void _restoreScope(String scope) {
+    final slot = _toolStyles[scope];
+    if (slot == null || slot.isEmpty) return;
+    // drive the public setters (they update the live value and the shared
+    // default), guarding the re-record so this load doesn't rewrite the slot
+    _restoringScope = true;
+    try {
+      if (slot['color'] case final int v) color = Color(v);
+      if (slot['strokeWidth'] case final num v) strokeWidth = v.toDouble();
+      if (slot['eraserRadius'] case final num v) eraserRadius = v.toDouble();
+      if (slot['opacity'] case final num v) opacity = v.toDouble();
+      if (slot['fontSize'] case final num v) fontSize = v.toDouble();
+      if (slot['fontFamily'] case final String v) {
+        final font = PdfStandardFont.values.asNameMap()[v];
+        if (font != null) fontFamily = font;
+      }
+      if (slot['lineStyle'] case final String v) {
+        final style = PdfLineStyle.values.asNameMap()[v];
+        if (style != null) lineStyle = style;
+      }
+      if (slot['lineStartEnding'] case final String v) {
+        final ending = PdfLineEnding.values.asNameMap()[v];
+        if (ending != null) lineStartEnding = ending;
+      }
+      if (slot['lineEndEnding'] case final String v) {
+        final ending = PdfLineEnding.values.asNameMap()[v];
+        if (ending != null) lineEndEnding = ending;
+      }
+      if (slot.containsKey('textFillColor')) {
+        textFillColor = _colorOrNull(slot['textFillColor']);
+      }
+      if (slot.containsKey('textBorderColor')) {
+        textBorderColor = _colorOrNull(slot['textBorderColor']);
+      }
+      if (slot.containsKey('shapeFillColor')) {
+        shapeFillColor = _colorOrNull(slot['shapeFillColor']);
+      }
+    } finally {
+      _restoringScope = false;
+    }
+  }
+
+  static Color? _colorOrNull(Object? value) =>
+      value is int ? Color(value) : null;
+
+  /// Records [value] for [field] under the active scope when that scope
+  /// remembers the field. Called from the style setters.
+  void _recordScoped(String field, Object? value) {
+    if (_restoringScope || _styleScope == null) return;
+    if (!_styleScopeFields.contains(field)) return;
+    (_toolStyles[_styleScope!] ??= {})[field] = value;
+    _writeToolStyles();
+  }
+
   /// The color new annotations are created with.
   Color get color => _color;
 
@@ -286,6 +399,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _color) return;
     _color = value;
     _write((s) => s.setInt('${_prefix}color', value.toARGB32()));
+    _recordScoped('color', value.toARGB32());
     notifyListeners();
   }
 
@@ -296,6 +410,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _strokeWidth) return;
     _strokeWidth = value;
     _write((s) => s.setDouble('${_prefix}strokeWidth', value));
+    _recordScoped('strokeWidth', value);
     notifyListeners();
   }
 
@@ -307,6 +422,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _eraserRadius) return;
     _eraserRadius = value;
     _write((s) => s.setDouble('${_prefix}eraserRadius', value));
+    _recordScoped('eraserRadius', value);
     notifyListeners();
   }
 
@@ -317,6 +433,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _fontSize) return;
     _fontSize = value;
     _write((s) => s.setDouble('${_prefix}fontSize', value));
+    _recordScoped('fontSize', value);
     notifyListeners();
   }
 
@@ -328,6 +445,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _fontFamily) return;
     _fontFamily = value;
     _write((s) => s.setString('${_prefix}fontFamily', value.name));
+    _recordScoped('fontFamily', value.name);
     notifyListeners();
   }
 
@@ -339,6 +457,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _opacity) return;
     _opacity = value;
     _write((s) => s.setDouble('${_prefix}opacity', value));
+    _recordScoped('opacity', value);
     notifyListeners();
   }
 
@@ -350,6 +469,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _lineStyle) return;
     _lineStyle = value;
     _write((s) => s.setString('${_prefix}lineStyle', value.name));
+    _recordScoped('lineStyle', value.name);
     notifyListeners();
   }
 
@@ -361,6 +481,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _lineStartEnding) return;
     _lineStartEnding = value;
     _write((s) => s.setString('${_prefix}lineStartEnding', value.name));
+    _recordScoped('lineStartEnding', value.name);
     notifyListeners();
   }
 
@@ -372,6 +493,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _lineEndEnding) return;
     _lineEndEnding = value;
     _write((s) => s.setString('${_prefix}lineEndEnding', value.name));
+    _recordScoped('lineEndEnding', value.name);
     notifyListeners();
   }
 
@@ -547,6 +669,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     _write((s) => value == null
         ? s.remove('${_prefix}textFillColor')
         : s.setInt('${_prefix}textFillColor', value.toARGB32()));
+    _recordScoped('textFillColor', value?.toARGB32());
     notifyListeners();
   }
 
@@ -560,6 +683,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     _write((s) => value == null
         ? s.remove('${_prefix}textBorderColor')
         : s.setInt('${_prefix}textBorderColor', value.toARGB32()));
+    _recordScoped('textBorderColor', value?.toARGB32());
     notifyListeners();
   }
 
@@ -573,6 +697,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     _write((s) => value == null
         ? s.remove('${_prefix}shapeFillColor')
         : s.setInt('${_prefix}shapeFillColor', value.toARGB32()));
+    _recordScoped('shapeFillColor', value?.toARGB32());
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -330,6 +330,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     if (_groupForTool(controller.tool)?.id == group.id) return;
     controller.tool = group.defaultTool;
     if (controller.tool != null) viewerController.clearSelection();
+    // markup arms no tool, so its style scope is set explicitly (after the
+    // tool reset above, which would otherwise clear it) — this is what lets
+    // the highlighter keep its own colour from the other tools'
+    if (group.id == 'markup') controller.useMarkupStyleScope();
   }
 
   /// Arms a tool from a group's strip / grid, routing measure and
@@ -1373,7 +1377,14 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                               key: ValueKey('pdf-group-tab-${g.id}'),
                               group: g,
                               active: g.id == tabId,
-                              onTap: () => setSheetState(() => tabId = g.id),
+                              onTap: () {
+                                setSheetState(() => tabId = g.id);
+                                // markup arms no tool — scope it so its
+                                // settings row edits markup's own style
+                                if (g.id == 'markup') {
+                                  controller.useMarkupStyleScope();
+                                }
+                              },
                             ),
                           ),
                       ]),

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -117,4 +117,74 @@ void main() {
       expect(editing.color, const Color(0xFF112233));
     });
   });
+
+  group('per-tool style memory', () {
+    test('each tool remembers its own style', () async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      await editing.preferences.ready;
+
+      editing.tool = PdfEditTool.ink;
+      editing.color = const Color(0xFFFF0000);
+      editing.strokeWidth = 6;
+
+      editing.tool = PdfEditTool.rectangle;
+      editing.color = const Color(0xFF0000FF);
+      editing.strokeWidth = 2;
+      editing.shapeFillColor = const Color(0xFF00FF00);
+
+      // arming the rectangle didn't disturb ink's remembered style
+      editing.tool = PdfEditTool.ink;
+      expect(editing.color, const Color(0xFFFF0000));
+      expect(editing.strokeWidth, 6);
+
+      editing.tool = PdfEditTool.rectangle;
+      expect(editing.color, const Color(0xFF0000FF));
+      expect(editing.strokeWidth, 2);
+      expect(editing.shapeFillColor, const Color(0xFF00FF00));
+    });
+
+    test('the markup scope keeps the highlighter its own colour', () async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      await editing.preferences.ready;
+
+      editing.useMarkupStyleScope();
+      editing.color = const Color(0xFFFFEB3B); // yellow
+
+      editing.tool = PdfEditTool.ink;
+      editing.color = const Color(0xFF000000); // black ink
+
+      editing.useMarkupStyleScope();
+      expect(editing.color, const Color(0xFFFFEB3B));
+    });
+
+    test('a tool with no saved style inherits the current value', () async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      await editing.preferences.ready;
+
+      editing.color = const Color(0xFF112233); // no tool armed (shared)
+      editing.tool = PdfEditTool.note; // never styled before
+      expect(editing.color, const Color(0xFF112233));
+    });
+
+    test('per-tool styles survive into a fresh session', () async {
+      SharedPreferences.setMockInitialValues({});
+      final first = PdfEditingController(buildMultiPagePdf(1));
+      await first.preferences.ready;
+      first.tool = PdfEditTool.ink;
+      first.color = const Color(0xFF8E24AA);
+      first.tool = PdfEditTool.rectangle;
+      first.color = const Color(0xFF00ACC1);
+      await pumpEventQueue(); // let the unawaited writes land
+
+      final second = PdfEditingController(buildMultiPagePdf(1));
+      await second.preferences.ready;
+      second.tool = PdfEditTool.ink;
+      expect(second.color, const Color(0xFF8E24AA));
+      second.tool = PdfEditTool.rectangle;
+      expect(second.color, const Color(0xFF00ACC1));
+    });
+  });
 }


### PR DESCRIPTION
## What

Each annotation tool now remembers its **own** styling — colour, stroke width, opacity, font, line style/endings, and fill colours — so switching tools (and reopening the app) keeps each tool's look. The classic case: the highlighter stays yellow while ink stays black, instead of every tool sharing one colour.

## How

- **`PdfEditingPreferences`** gains a per-scope snapshot map, persisted as one JSON blob under `toolStyles` (colours as ARGB ints, enums by name). The existing single live values stay the source of truth that the creation methods read — nothing in the creation/`finishInk` paths changed.
  - `beginStyleScope(scope, fields)` activates a scope: it restores that scope's saved style into the live values (driving the public setters under a `_restoringScope` guard so the load doesn't re-record), and while a scope is active every style setter **also** records its field into the slot via `_recordScoped` (only the fields the scope remembers).
- **`PdfEditingController`** — the `tool` setter activates the armed tool's scope. The scope key is the tool's name for the styled creators (ink / eraser / shapes / lines / measure / free text / note / stamp), null for select/content/form/redact/signature (signature keeps sharing the global colour, which the toolbar seeds from the drawn ink). Per-tool `fields` mirror each tool's toolbar strip — ink keeps stroke not endings, rectangle keeps fill not font, free text keeps font + box colours, etc.
- **Markup** arms no tool, so `useMarkupStyleScope()` scopes `'markup'` {color, opacity}; the toolbar calls it when the Markup strip opens (desktop and the mobile sheet's markup tab).
- A tool with no saved slot **inherits the current live value** (no restore), so first use of each tool picks up the last-used style and is independent thereafter — and all pre-existing tests that set a style without arming a tool behave exactly as before.

## Tests

`editing_preferences_test.dart` +4: each tool keeps its own style; the markup highlighter keeps its colour; a tool with no slot inherits the current value; per-tool styles survive into a fresh session. Full `dart_pdf_editor` suite green except the 14 Ghent render-baseline diffs that are pre-existing on this machine (documented in CLAUDE.md), and `dart analyze` is clean.

https://claude.ai/code/session_01VDUWUu5Sde7nn5GJcKY6ZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDUWUu5Sde7nn5GJcKY6ZA)_