### PR TITLE
Don't flash page content under a moved annotation's old location

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -985,12 +985,23 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   ///
   /// [flipX]/[flipY] mirror the afterimage so a resize that inverted the
   /// annotation stays inverted while the page re-renders.
+  ///
+  /// [washSource] paints the old on-raster footprint over with paper before
+  /// the new raster lands, so a resize/rotate's larger/spun old appearance
+  /// doesn't poke out behind the afterimage. A pure *move* leaves it false:
+  /// its source and destination are disjoint, so an opaque paper wash there
+  /// covers nothing the afterimage redraws — it just blanks the page content
+  /// under the old spot (most visibly *through* a translucent markup) until
+  /// the re-render lands, which reads as the content flashing back in. The
+  /// stale annotation lingering at the old spot instead is continuous with
+  /// the drag (it was painted there the whole time) and far less jarring.
   void _commitWithGhost(VoidCallback commit,
       {Rect? to,
       double rotation = 0,
       double localAngle = 0,
       bool flipX = false,
-      bool flipY = false}) {
+      bool flipY = false,
+      bool washSource = true}) {
     final from = localAngle == 0 ? _selectedViewRect : _selectionChrome?.$1;
     final source = _selectedViewRect;
     final ghost = _ghost;
@@ -1004,7 +1015,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _afterGhost = ghost;
     _afterGhostFrom = from;
     _afterGhostTo = to;
-    _afterGhostSourceRect = source;
+    _afterGhostSourceRect = washSource ? source : null;
     _afterGhostRotation = rotation;
     _afterGhostLocalAngle = localAngle;
     _afterGhostFlipX = flipX;
@@ -2087,8 +2098,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         }
       }
       final (x1, y1) = _geometry.toPagePoint(moveCurrent);
+      // a move's source and destination are disjoint, so don't wash the old
+      // spot — the opaque paper wash would blank the page content there
+      // until the re-render lands and then flash it back (see _commitWithGhost)
       _commitWithGhost(() => _controller.moveSelected(x1 - x0, y1 - y0),
-          to: _selectedViewRect?.shift(moveCurrent - moveStart));
+          to: _selectedViewRect?.shift(moveCurrent - moveStart),
+          washSource: false);
     } else if (stroke != null && stroke.isNotEmpty) {
       _controller.addInkStroke(widget.pageIndex, stroke,
           pressures: strokePressures);

--- a/packages/dart_pdf_editor/test/editing_polish_test.dart
+++ b/packages/dart_pdf_editor/test/editing_polish_test.dart
@@ -297,10 +297,16 @@ void main() {
       final data = await capture(tester, boundary);
       expect(patchHas(data, 800, 600, edge.dx, edge.dy, 4, strongRed), isTrue,
           reason: 'the moved annotation should stay painted post-commit');
+      // a move no longer washes the old spot: the opaque paper wash there
+      // would blank the page content under the previous location until the
+      // re-render lands, then flash it back. Instead the (stale) raster is
+      // left showing the square at its old place — continuous with the drag
+      // and consistent with how undo/redo leave the previous raster up — so
+      // its red border is still present here until the new raster lands.
       final oldEdge = view(100, 700) - const Offset(0, 33);
       expect(patchHas(data, 800, 600, oldEdge.dx, oldEdge.dy, 4, strongRed),
-          isFalse,
-          reason: 'the source position should be washed while rerendering');
+          isTrue,
+          reason: 'the old position is left to the stale raster, not washed');
       // let the double-tap recognizer's timer expire
       await tester.pump(const Duration(milliseconds: 400));
     });


### PR DESCRIPTION
## Problem

After dropping an annotation in a new location, the content under the previous location flashes.

When a move commits, the editing overlay keeps a "ghost" of the annotation painted at the **new** location as an afterimage until the page re-renders (`_commitWithGhost`). To suppress a duplicate, it also painted an **opaque paper wash** over the annotation's **old** on-raster footprint.

That wash is right for resize/rotate, where the old and new appearances overlap and a larger/spun old footprint would poke out behind the afterimage. But for a pure **move** the source and destination are disjoint, so the wash covers nothing the afterimage redraws — it just blanks the page content under the old location until the re-render lands, then flashes it back in. It's most visible for a stroke-only or translucent markup (highlight/underline/box), where the content *inside/under* the annotation was visible during the drag and the opaque wash destroys it.

## Fix

Add a `washSource` flag to `_commitWithGhost` (default `true`, so resize/rotate are unchanged) and pass `washSource: false` from the move commit. The old spot is now left to the stale raster — continuous with the drag (the original was painted there the whole time) and consistent with how undo/redo already leave the previous raster up until the re-render lands.

## Tests

- Updated `editing_polish_test.dart` "a moved annotation stays visible before the re-render": the old position is no longer washed, so the stale border is still present there until the new raster lands. The destination afterimage assertion is unchanged.
- `editing_polish_test`, `editing_drag_preview_test`, `editing_multiselect_test`, `editing_rotate_test` all pass; `dart analyze` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6ZTbBEZ4TWWBi5wEqLKUJ)_