### PR TITLE
Add shift-click multi-select to the thumbnail strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2153,3 +2153,36 @@ thereafter. Tests: editing_preferences_test +4 (each tool keeps its own
 style, markup highlighter colour, no-slot inherits, persistence into a
 fresh session). The 14 Ghent render-baseline failures are pre-existing
 on this machine, unrelated.
+
+Thumbnail multi-select (Ben: "shift click to multi select pages in the
+thumbnail strip"): the strip gained a page selection alongside the
+annotation selection. Controller (editing_controller.dart, "page
+selection" section): `_selectedPages` (a Set<int>) + `_pageSelectionAnchor`
+(the last plain/⌘ click — what a shift-click extends from); getters
+`selectedPages` (ascending), `hasPageSelection`, `selectedPageCount`,
+`isPageSelected`; gestures `selectPage` (plain — single + re-anchor),
+`togglePageSelection` (⌘/Ctrl — add/remove + re-anchor), `selectPageRange`
+(shift — contiguous anchor..index, replacing, anchor stays so a further
+shift re-extends from the same origin), `selectAllPages`,
+`clearPageSelection`; bulk ops `removeSelectedPages` (editor `removePages`,
+one undo, refused when it would empty the doc — at least one page must
+remain) and `exportSelectedPages` (= `exportPages(selectedPages)`, null
+when empty). Every structural page edit (move/remove/insert/addBlank)
+clears the page selection too (indices shift), beside the existing
+`_selected.clear()`. UI (editing_thumbnails.dart): `_PageTile._onTap`
+reads HardwareKeyboard — shift → selectPageRange, ⌘/Ctrl →
+togglePageSelection (neither navigates, so a selection builds without the
+viewport jumping), plain → selectPage + jumpToPage; a selected tile gets a
+primary-tinted rounded chip behind the thumbnail (a color-only
+BoxDecoration on the tile's Container adds no padding, so per-tile layout
+and `_estimateOffset` are unchanged — don't switch it back to Padding).
+When `selectedPageCount > 1` a selection bar shows above the list ('N
+selected' + export (keys 'pdf-thumbnail-export-selected', only with
+onExportPages) + delete ('pdf-thumbnail-delete-selected', only with
+allowPageEditing) + clear ('pdf-thumbnail-clear-selection')); a single
+selection is just the navigation cursor (the per-tile delete handles it).
+Tests: editing_page_ops_test.dart — a "page selection" controller group
+(11) + strip widget tests (shift-click range→delete, ctrl-click toggle);
+widget tests set tester.view 800×1400 so the lazy list builds every tile,
+and drive modifiers with sendKeyDownEvent/sendKeyUpEvent(LogicalKeyboardKey
+.shift/.controlLeft) around the tap.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1334,6 +1334,8 @@ class PdfEditingController extends ChangeNotifier {
   void movePage(int from, int to) {
     if (from == to) return;
     _selected.clear();
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
     apply((e) => e.movePage(from, to));
   }
 
@@ -1342,6 +1344,8 @@ class PdfEditingController extends ChangeNotifier {
   void removePage(int index) {
     if (_document.pageCount <= 1) return;
     _selected.clear();
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
     apply((e) => e.removePage(index));
   }
 
@@ -1353,6 +1357,8 @@ class PdfEditingController extends ChangeNotifier {
   /// selection is cleared first.
   void addBlankPage({double? width, double? height, int? at}) {
     _selected.clear();
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
     final insertAt = at ?? _document.pageCount;
     if (width == null && height == null && _document.pageCount > 0) {
       final neighbour =
@@ -1370,6 +1376,8 @@ class PdfEditingController extends ChangeNotifier {
   /// resources, fonts, images, annotations — is deep-copied across.
   void insertPagesFrom(PdfDocument source, {List<int>? indices, int? at}) {
     _selected.clear();
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
     apply((e) => e.appendPagesFrom(source, indices: indices, at: at));
   }
 
@@ -1389,6 +1397,104 @@ class PdfEditingController extends ChangeNotifier {
   /// Exports pages [start] through [end] inclusive as a standalone PDF.
   Uint8List exportPageRange(int start, int end) =>
       _document.extractPageRange(start, end);
+
+  // ---------------------------------------------------------------------
+  // page selection (the thumbnail strip's multi-select)
+
+  /// The set of selected page indices — the thumbnail strip's
+  /// click/shift-click/⌘-click selection. Distinct from the annotation
+  /// selection; it drives bulk page operations (delete, export). Any
+  /// structural page edit (move/remove/insert) shifts indices, so it is
+  /// cleared by those.
+  final Set<int> _selectedPages = {};
+
+  /// The anchor a shift-click extends a range from — the last page
+  /// clicked without shift (a plain or ⌘ click).
+  int? _pageSelectionAnchor;
+
+  /// The selected page indices, ascending. Empty when nothing is
+  /// selected in the strip.
+  List<int> get selectedPages => _selectedPages.toList()..sort();
+
+  bool get hasPageSelection => _selectedPages.isNotEmpty;
+
+  /// How many pages are selected in the strip.
+  int get selectedPageCount => _selectedPages.length;
+
+  bool isPageSelected(int index) => _selectedPages.contains(index);
+
+  /// Selects exactly [index] (clearing any previous selection) and makes
+  /// it the anchor for a subsequent [selectPageRange]. The plain-click
+  /// gesture.
+  void selectPage(int index) {
+    _pageSelectionAnchor = index;
+    if (_selectedPages.length == 1 && _selectedPages.contains(index)) return;
+    _selectedPages
+      ..clear()
+      ..add(index);
+    notifyListeners();
+  }
+
+  /// Toggles [index] in the selection (the ⌘/Ctrl-click gesture) and
+  /// re-anchors there so a following shift-click extends from it.
+  void togglePageSelection(int index) {
+    if (!_selectedPages.remove(index)) _selectedPages.add(index);
+    _pageSelectionAnchor = index;
+    notifyListeners();
+  }
+
+  /// Selects the contiguous range from the current anchor to [index]
+  /// (the shift-click gesture), replacing the selection. With no anchor
+  /// yet, behaves like [selectPage]. The anchor stays put, so a further
+  /// shift-click re-extends from the same origin.
+  void selectPageRange(int index) {
+    final anchor = _pageSelectionAnchor ?? index;
+    final lo = math.min(anchor, index);
+    final hi = math.max(anchor, index);
+    _pageSelectionAnchor = anchor;
+    _selectedPages
+      ..clear()
+      ..addAll([for (var i = lo; i <= hi; i++) i]);
+    notifyListeners();
+  }
+
+  /// Selects every page.
+  void selectAllPages() {
+    final all = {for (var i = 0; i < _document.pageCount; i++) i};
+    if (_selectedPages.length == all.length) return;
+    _selectedPages
+      ..clear()
+      ..addAll(all);
+    _pageSelectionAnchor = 0;
+    notifyListeners();
+  }
+
+  /// Clears the page selection.
+  void clearPageSelection() {
+    if (_selectedPages.isEmpty) return;
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
+    notifyListeners();
+  }
+
+  /// Removes the selected pages in one edit (one undo). Refused (a no-op,
+  /// returns false) when nothing is selected or the selection would empty
+  /// the document — at least one page must remain. Clears the selection.
+  bool removeSelectedPages() {
+    final doomed = _selectedPages
+        .where((i) => i >= 0 && i < _document.pageCount)
+        .toList();
+    if (doomed.isEmpty || doomed.length >= _document.pageCount) return false;
+    _selected.clear();
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
+    return apply((e) => e.removePages(doomed));
+  }
+
+  /// Exports the selected pages (ascending) as a fresh standalone PDF,
+  /// leaving this document untouched. Null when nothing is selected.
+  Uint8List? exportSelectedPages() =>
+      _selectedPages.isEmpty ? null : exportPages(selectedPages);
 
   // ---------------------------------------------------------------------
   // selection

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../page_range_dialog.dart';
 import '../pdf_viewer.dart';
@@ -251,6 +251,13 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     return offset;
   }
 
+  void _exportSelected() {
+    final onExport = widget.onExportPages;
+    if (onExport == null) return;
+    final bytes = widget.controller.exportSelectedPages();
+    if (bytes != null) onExport(bytes);
+  }
+
   void _onResizeDelta(double delta) => setState(() {
         _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
       });
@@ -300,6 +307,53 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                       viewerController: widget.viewerController,
                       onPickPdfToInsert: widget.onPickPdfToInsert,
                       onExportPages: widget.onExportPages,
+                    ),
+                  ],
+                ),
+              ),
+            // when more than one page is selected, a bar offers bulk
+            // actions on the selection (a single selection is just the
+            // navigation cursor — the per-tile delete handles it)
+            if (controller.selectedPageCount > 1)
+              Padding(
+                padding: EdgeInsets.fromLTRB(8, 2, _extraRightPadding, 0),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '${controller.selectedPageCount} selected',
+                        style: Theme.of(context).textTheme.labelMedium,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (widget.onExportPages != null)
+                      IconButton(
+                        key: const ValueKey('pdf-thumbnail-export-selected'),
+                        icon: const Icon(Icons.file_download_outlined, size: 18),
+                        tooltip: 'Export selected pages',
+                        style: IconButton.styleFrom(
+                          visualDensity: VisualDensity.compact,
+                        ),
+                        onPressed: _exportSelected,
+                      ),
+                    if (widget.allowPageEditing)
+                      IconButton(
+                        key: const ValueKey('pdf-thumbnail-delete-selected'),
+                        icon: const Icon(Icons.delete_outline, size: 18),
+                        tooltip: 'Delete selected pages',
+                        style: IconButton.styleFrom(
+                          visualDensity: VisualDensity.compact,
+                        ),
+                        onPressed: () => controller.removeSelectedPages(),
+                      ),
+                    IconButton(
+                      key: const ValueKey('pdf-thumbnail-clear-selection'),
+                      icon: const Icon(Icons.close, size: 18),
+                      tooltip: 'Clear selection',
+                      style: IconButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                      ),
+                      onPressed: controller.clearPageSelection,
                     ),
                   ],
                 ),
@@ -554,9 +608,28 @@ class _PageTile extends StatelessWidget {
     return (math.max(la, lb) + 0.05) / (math.min(la, lb) + 0.05);
   }
 
+  /// Tapping a tile selects it for the strip's multi-select and (for a
+  /// plain tap) navigates there. Shift extends a range from the anchor;
+  /// ⌘/Ctrl toggles the tile in the selection — neither navigates, so the
+  /// reader can build a selection without the viewport jumping around.
+  void _onTap() {
+    final keyboard = HardwareKeyboard.instance;
+    if (keyboard.isShiftPressed) {
+      controller.selectPageRange(pageIndex);
+      return;
+    }
+    if (keyboard.isMetaPressed || keyboard.isControlPressed) {
+      controller.togglePageSelection(pageIndex);
+      return;
+    }
+    controller.selectPage(pageIndex);
+    unawaited(viewerController.jumpToPage(pageIndex));
+  }
+
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
+    final selected = controller.isPageSelected(pageIndex);
     // the viewport mark paints over the paper, not the app surface: a
     // dark theme's light primary vanishes on a white thumbnail, so pick
     // whichever accent actually contrasts with the page color
@@ -565,11 +638,20 @@ class _PageTile extends StatelessWidget {
         ? scheme.primary
         : scheme.inversePrimary;
     final document = controller.document;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: () => unawaited(viewerController.jumpToPage(pageIndex)),
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: _onTap,
+      // a Container (not Padding) so a selected tile reads as a tinted
+      // chip behind the thumbnail; a color-only decoration adds no
+      // padding, so the per-tile layout (and _estimateOffset) is unchanged
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
+        decoration: selected
+            ? BoxDecoration(
+                color: scheme.primary.withValues(alpha: 0.14),
+                borderRadius: BorderRadius.circular(6),
+              )
+            : null,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -91,6 +92,112 @@ void main() {
     });
   });
 
+  group('page selection', () {
+    test('selectPage selects one page and sets the anchor', () {
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      addTearDown(editing.dispose);
+      editing.selectPage(2);
+      expect(editing.selectedPages, [2]);
+      expect(editing.isPageSelected(2), isTrue);
+      expect(editing.hasPageSelection, isTrue);
+      expect(editing.selectedPageCount, 1);
+    });
+
+    test('selectPageRange extends a contiguous range from the anchor', () {
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      editing.selectPageRange(3);
+      expect(editing.selectedPages, [1, 2, 3]);
+    });
+
+    test('selectPageRange works backwards from the anchor', () {
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      addTearDown(editing.dispose);
+      editing.selectPage(3);
+      editing.selectPageRange(1);
+      expect(editing.selectedPages, [1, 2, 3]);
+    });
+
+    test('a second shift-range re-extends from the same anchor', () {
+      final editing = PdfEditingController(buildMultiPagePdf(6));
+      addTearDown(editing.dispose);
+      editing.selectPage(2);
+      editing.selectPageRange(4);
+      expect(editing.selectedPages, [2, 3, 4]);
+      // anchor stays at 2 — extend the other way, replacing the range
+      editing.selectPageRange(0);
+      expect(editing.selectedPages, [0, 1, 2]);
+    });
+
+    test('togglePageSelection adds then removes individual pages', () {
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      addTearDown(editing.dispose);
+      editing.selectPage(0);
+      editing.togglePageSelection(2);
+      editing.togglePageSelection(4);
+      expect(editing.selectedPages, [0, 2, 4]);
+      editing.togglePageSelection(2);
+      expect(editing.selectedPages, [0, 4]);
+    });
+
+    test('selectAllPages then clearPageSelection', () {
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      editing.selectAllPages();
+      expect(editing.selectedPages, [0, 1, 2]);
+      editing.clearPageSelection();
+      expect(editing.hasPageSelection, isFalse);
+    });
+
+    test('removeSelectedPages deletes the selection in one undo', () {
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      addTearDown(editing.dispose);
+      editing.selectPage(0);
+      editing.selectPageRange(1); // Page 1 and Page 2
+      expect(editing.removeSelectedPages(), isTrue);
+      expect(labelsOf(editing.document), ['Page 3', 'Page 4']);
+      expect(editing.hasPageSelection, isFalse);
+      editing.undo();
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 4']);
+    });
+
+    test('removeSelectedPages refuses to empty the document', () {
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      editing.selectAllPages();
+      expect(editing.removeSelectedPages(), isFalse);
+      expect(editing.document.pageCount, 3);
+    });
+
+    test('a structural page edit clears the selection', () {
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      editing.selectPageRange(3);
+      editing.addBlankPage();
+      expect(editing.hasPageSelection, isFalse);
+    });
+
+    test('exportSelectedPages builds a standalone PDF in page order', () {
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      addTearDown(editing.dispose);
+      editing.selectPage(3);
+      editing.togglePageSelection(1);
+      final bytes = editing.exportSelectedPages();
+      expect(bytes, isNotNull);
+      expect(labelsOf(PdfDocument.open(bytes!)), ['Page 2', 'Page 4']);
+      expect(editing.isModified, isFalse);
+    });
+
+    test('exportSelectedPages is null with nothing selected', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      addTearDown(editing.dispose);
+      expect(editing.exportSelectedPages(), isNull);
+    });
+  });
+
   group('page range dialog', () {
     testWidgets('returns the chosen 0-based inclusive range', (tester) async {
       ({int start, int end})? result;
@@ -169,6 +276,78 @@ void main() {
       await tester.pump();
       expect(editing.document.pageCount, 3);
       await tester.pump(const Duration(seconds: 2)); // drain tile renders
+    });
+
+    testWidgets('shift-click selects a range, then deletes it', (tester) async {
+      // a tall surface so every tile builds (the list is lazy)
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      // a plain tap selects one page (and anchors there)
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      expect(editing.selectedPages, [1]);
+
+      // shift-click extends the range from the anchor
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 4'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(editing.selectedPages, [1, 2, 3]);
+
+      // the selection bar appears; its delete removes the whole selection
+      expect(find.byKey(const ValueKey('pdf-thumbnail-delete-selected')),
+          findsOneWidget);
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-thumbnail-delete-selected')));
+      await tester.pump();
+      expect(labelsOf(editing.document), ['Page 1', 'Page 5']);
+      expect(editing.hasPageSelection, isFalse);
+      await tester.pump(const Duration(seconds: 2)); // drain tile renders
+    });
+
+    testWidgets('ctrl-click toggles pages into the selection', (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.tap(find.text('Page 3'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+      expect(editing.selectedPages, [0, 2]);
+      await tester.pump(const Duration(seconds: 2));
     });
 
     testWidgets('a read-only strip has no Add page footer', (tester) async {


### PR DESCRIPTION
## What

The thumbnail strip can now select multiple pages:

- **Plain click** — selects one page (and navigates there, as before).
- **Shift-click** — extends a contiguous range from the anchor (the last plain/⌘ click), replacing the selection. The anchor stays put, so a further shift-click re-extends from the same origin.
- **⌘/Ctrl-click** — toggles individual pages in and out of the selection.

Shift and ⌘/Ctrl clicks don't navigate, so a selection builds without the viewport jumping around.

Selected tiles get a primary-tinted chip behind the thumbnail. When more than one page is selected, a selection bar appears above the list — **N selected** plus **export** (when `onExportPages` is wired), **delete**, and **clear** buttons. A single selection is just the navigation cursor (the existing per-tile delete still handles it).

## How

`PdfEditingController` gains a page-selection model, distinct from the annotation selection:

- State: `_selectedPages` (a `Set<int>`) + `_pageSelectionAnchor`.
- Gestures: `selectPage`, `selectPageRange`, `togglePageSelection`, `selectAllPages`, `clearPageSelection`.
- Getters: `selectedPages` (ascending), `hasPageSelection`, `selectedPageCount`, `isPageSelected`.
- Bulk ops: `removeSelectedPages` (one undo via the editor's `removePages`; refused when it would empty the document) and `exportSelectedPages` (= `exportPages(selectedPages)`, null when empty).

Every structural page edit (move/remove/insert/addBlank) clears the page selection too, since page indices shift under it.

The strip's `_PageTile._onTap` reads `HardwareKeyboard` to pick the gesture; the selected-tile tint is a color-only `BoxDecoration` on the existing tile `Container` so per-tile layout (and `_estimateOffset`) is unchanged.

## Tests

`editing_page_ops_test.dart`:
- A `page selection` controller group (11 tests) covering anchor extension both directions, re-extension, toggle, select-all/clear, delete (with undo + empty-document refusal), structural-edit clearing, and export ordering.
- Strip widget tests: shift-click selects a range then the selection bar deletes it; ⌘/Ctrl-click toggles pages. They size `tester.view` to 800×1400 so the lazy list builds every tile, and drive modifiers with `sendKeyDownEvent`/`sendKeyUpEvent` around the tap.

All of `editing_page_ops_test.dart`, `editing_panels_test.dart`, `page_color_test.dart`, and `pdf_shell_test.dart` pass.

https://claude.ai/code/session_01UpDikrAqJPaF9fZD9ve37Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpDikrAqJPaF9fZD9ve37Z)_