### PR TITLE
Add dart-pdf vs PDFium render benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ doc/api/
 # local test corpus of real-world PDFs (never committed)
 corpus/
 
+# generated benchmark JSON + comparison tables (benchmark/run.sh)
+benchmark/out/
+
 # render-regression failure dumps (ghent_render_test.dart)
 test_corpora/ghent/_failures/
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,133 @@
+# dart-pdf vs PDFium — render benchmarks
+
+Performance harnesses that time dart-pdf rendering against **PDFium** (the
+C++ engine Chrome uses) over the same corpus of PDFs, and emit a side-by-side
+comparison table (ms/page, pages/s, speedup ratio).
+
+PDFium comes from [`pypdfium2`](https://pypi.org/project/pypdfium2/), which
+bundles a prebuilt PDFium binary — no system PDFium build or `pdfium_test`
+needed.
+
+## What gets measured
+
+Three harnesses, all writing the same JSON schema so they line up file-by-file:
+
+| harness | engine | measures | needs |
+|---|---|---|---|
+| `pdfium_benchmark.py` | PDFium via pypdfium2 | open + rasterize to bitmap | `pip install pypdfium2` |
+| `benchmark_render_test.dart` | dart-pdf full pipeline | open + interpret + paint + `toImage` | fvm Flutter |
+| `benchmark_interpret.dart` | dart-pdf interpreter | open + interpret to a `NullDevice` (no raster) | fvm Dart |
+
+`benchmark_render_test.dart` is the **apples-to-apples** comparison with
+PDFium — both produce a rasterized bitmap at the same scale. dart-pdf's
+rasterization runs on Flutter's engine, so that harness is a `flutter test`
+file (it skips in CI unless `PDF_BENCHMARK_DIR` is set).
+
+`benchmark_interpret.dart` isolates dart-pdf's pure-Dart parse + content-stream
+work (the part that runs on the web and on the VM); it has no PDFium counterpart
+but is the fairer number for "how fast is the Dart code itself", since it
+excludes Flutter's GPU raster + readback.
+
+### Fair-comparison notes
+
+- **Scale.** PDFium `scale` and dart-pdf `pixelRatio` use the same unit:
+  `1.0` = 72 DPI = 1 px per PDF point. Both harnesses default to `2.0`.
+- **Timing boundaries.** File bytes are read up front and excluded. `openMs`
+  is parse/load; `renderMs` is the per-page render loop. The render harnesses
+  call `toByteData(rawRgba)` / touch the PDFium bitmap buffer to force the
+  rasterization to fully complete before the clock stops.
+- **Warmup.** Flutter's first raster pays one-time shader/engine warmup, which
+  inflates the first few files. Pass `--repeat 3` / `PDF_BENCHMARK_REPEAT=3`
+  to render the sweep several times and keep each file's fastest pass.
+- **Page cap.** Default 10 pages/file keeps long documents from dominating;
+  raise with `--max-pages 0` (all pages).
+- **Fonts.** `benchmark_render_test.dart` reuses the test suite's
+  `loadSystemFonts` (macOS font paths); on other platforms dart-pdf falls back,
+  which is fine for timing.
+
+## Quick start
+
+```bash
+pip install pypdfium2
+
+# one command: runs all three over test_corpora/pdfjs at scale 2, 10 pages/file
+benchmark/run.sh
+
+# or a custom corpus / scale / page cap
+benchmark/run.sh /path/to/pdfs 2 20
+```
+
+`run.sh` writes JSON into `benchmark/out/` (git-ignored) and prints the table.
+
+## Running a harness on its own
+
+```bash
+# PDFium
+python3 benchmark/pdfium_benchmark.py test_corpora/pdfjs \
+    --scale 2 --max-pages 10 --repeat 3 --out benchmark/out/pdfium.json
+
+# dart-pdf full render (Flutter)
+cd packages/dart_pdf_editor
+PDF_BENCHMARK_DIR=../../test_corpora/pdfjs PDF_BENCHMARK_SCALE=2 \
+PDF_BENCHMARK_MAX_PAGES=10 PDF_BENCHMARK_REPEAT=3 \
+PDF_BENCHMARK_OUT=../../benchmark/out/dart-render.json \
+  fvm flutter test test/benchmark_render_test.dart
+
+# dart-pdf interpret only (pure Dart VM)
+cd packages/pdf_graphics
+fvm dart run tool/benchmark_interpret.dart ../../test_corpora/pdfjs \
+    --max-pages 10 --out ../../benchmark/out/dart-interpret.json
+```
+
+## The comparison table
+
+```bash
+# first JSON is the baseline; speedup columns are baseline_ms / tool_ms
+python3 benchmark/compare.py benchmark/out/pdfium.json \
+    benchmark/out/dart-render.json benchmark/out/dart-interpret.json
+
+# options
+python3 benchmark/compare.py ... --md         # GitHub Markdown table
+python3 benchmark/compare.py ... --per-file    # every file (default: slowest 25)
+```
+
+Example (8-file pdfjs subset, scale 2 — illustrative, not a hardware-neutral
+result):
+
+```
+## Totals (pages all tools rendered without error)
+- pdfium: 7 pages = 131.6 pages/s (7.6 ms/page)
+- dart-pdf-render: 7 pages = 19.6 pages/s (50.9 ms/page)
+- dart-pdf-interpret: 7 pages = 155.0 pages/s (6.5 ms/page)
+```
+
+`err` in a cell means that tool failed on that file; the totals row only counts
+pages every tool rendered without error, and scales each file to the smallest
+page count the tools agree on, so the throughput numbers are comparable.
+
+## Corpus
+
+Anything works — point the harnesses at a directory (searched recursively) or a
+single file. The checked-in `test_corpora/pdfjs` (171 edge-case PDFs) and
+`test_corpora/ghent` (54 print-conformance PDFs) make a reproducible default;
+Ben's git-ignored `corpus/` (real-world CAD/scans/reports) is the realistic
+stress set:
+
+```bash
+benchmark/run.sh corpus 2 0      # all pages of every real-world PDF
+```
+
+## JSON schema
+
+```json
+{
+  "tool": "pdfium",
+  "scale": 2.0,
+  "maxPages": 10,
+  "engine": "pypdfium2 5.9.0 / libpdfium 150.0.7869.0",
+  "results": [
+    {"file": "foo.pdf", "pages": 3, "pagesRendered": 3,
+     "openMs": 1.2, "renderMs": 45.6, "error": null}
+  ]
+}
+```

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Line up benchmark JSON files (PDFium + dart-pdf) into a comparison table.
+
+    python3 benchmark/compare.py benchmark/out/pdfium.json \
+        benchmark/out/dart-render.json
+
+Each input is a payload from pdfium_benchmark.py, benchmark_interpret.dart, or
+benchmark_render_test.dart. The first file is the baseline; speedup columns are
+baseline_ms / tool_ms (>1 means the tool is faster than the baseline). Files
+that errored in a tool are shown as `err`. A totals row aggregates throughput
+(pages per second) over every page both tools rendered successfully.
+
+Pass --md for a GitHub-flavored Markdown table, --per-file to list every file
+(default shows only the slowest 25 by baseline render time plus totals).
+"""
+import argparse
+import json
+import sys
+
+
+def load(path):
+    with open(path) as fh:
+        payload = json.load(fh)
+    by_file = {}
+    for r in payload["results"]:
+        if r is not None:
+            by_file[r["file"]] = r
+    return payload, by_file
+
+
+def fmt_ms(r):
+    if r is None:
+        return "—"
+    if r.get("error"):
+        return "err"
+    return f"{r['renderMs']:.1f}"
+
+
+def per_page(r):
+    if r is None or r.get("error") or not r.get("pagesRendered"):
+        return None
+    return r["renderMs"] / r["pagesRendered"]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("json", nargs="+", help="benchmark JSON files; first = baseline")
+    ap.add_argument("--md", action="store_true", help="Markdown table")
+    ap.add_argument("--per-file", action="store_true", help="every file, not top 25")
+    args = ap.parse_args()
+
+    payloads = [load(p) for p in args.json]
+    labels = [pl[0]["tool"] for pl in payloads]
+    maps = [pl[1] for pl in payloads]
+    base_label = labels[0]
+
+    # Union of files, ordered by baseline render time (slowest first).
+    all_files = []
+    seen = set()
+    for _pl, m in payloads:
+        for f in m:
+            if f not in seen:
+                seen.add(f)
+                all_files.append(f)
+    base_map = maps[0]
+    all_files.sort(
+        key=lambda f: -(base_map.get(f, {}).get("renderMs", 0)
+                        if not base_map.get(f, {}).get("error") else 0))
+
+    print(f"# dart-pdf vs PDFium — render benchmark")
+    print()
+    for head, _m in payloads:
+        print(f"- **{head['tool']}**: {head.get('engine', '?')}  "
+              f"(scale {head.get('scale')}, max {head.get('maxPages')} pages/file)")
+    print()
+
+    cols = ["file", "pages"] + [f"{l} ms" for l in labels]
+    # speedup of each non-baseline tool vs baseline
+    for l in labels[1:]:
+        cols.append(f"{base_label}/{l}")
+
+    rows = []
+    for f in all_files:
+        recs = [m.get(f) for m in maps]
+        base = recs[0]
+        cells = [f, str((base or recs[0] or {}).get("pages", "?"))]
+        for r in recs:
+            cells.append(fmt_ms(r))
+        for r in recs[1:]:
+            bp, tp = per_page(base), per_page(r)
+            cells.append(f"{bp / tp:.2f}x" if (bp and tp) else "—")
+        rows.append(cells)
+
+    shown = rows if args.per_file else rows[:25]
+
+    # totals: aggregate over files every tool rendered without error
+    totals_pages = [0] * len(maps)
+    totals_ms = [0.0] * len(maps)
+    for f in all_files:
+        recs = [m.get(f) for m in maps]
+        if any(r is None or r.get("error") for r in recs):
+            continue
+        # only count pages all tools agree they rendered
+        common = min(r["pagesRendered"] for r in recs)
+        if common <= 0:
+            continue
+        for i, r in enumerate(recs):
+            # scale this file's time to the common page count
+            pp = per_page(r)
+            if pp is None:
+                continue
+            totals_pages[i] += common
+            totals_ms[i] += pp * common
+
+    def width(i):
+        return max(len(cols[i]), max((len(r[i]) for r in shown), default=0))
+
+    if args.md:
+        print("| " + " | ".join(cols) + " |")
+        print("|" + "|".join("---" for _ in cols) + "|")
+        for r in shown:
+            print("| " + " | ".join(r) + " |")
+    else:
+        ws = [width(i) for i in range(len(cols))]
+        print("  ".join(c.ljust(ws[i]) for i, c in enumerate(cols)))
+        print("  ".join("-" * ws[i] for i in range(len(cols))))
+        for r in shown:
+            print("  ".join(c.ljust(ws[i]) for i, c in enumerate(r)))
+
+    print()
+    print("## Totals (pages all tools rendered without error)")
+    for i, label in enumerate(labels):
+        if totals_pages[i] == 0:
+            print(f"- {label}: no comparable pages")
+            continue
+        pps = totals_pages[i] / (totals_ms[i] / 1000) if totals_ms[i] else float("inf")
+        print(f"- {label}: {totals_pages[i]} pages in {totals_ms[i] / 1000:.2f}s "
+              f"= {pps:.1f} pages/s ({totals_ms[i] / totals_pages[i]:.1f} ms/page)")
+    if len(labels) > 1 and totals_ms[0] and all(totals_ms[1:]):
+        base_pps = totals_pages[0] / (totals_ms[0] / 1000)
+        for i in range(1, len(labels)):
+            tool_pps = totals_pages[i] / (totals_ms[i] / 1000)
+            ratio = base_pps / tool_pps if tool_pps else float("inf")
+            faster = "faster" if ratio < 1 else "slower"
+            print(f"- {labels[i]} is {max(ratio, 1 / ratio):.2f}x {faster} "
+                  f"than {base_label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/pdfium_benchmark.py
+++ b/benchmark/pdfium_benchmark.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Benchmark PDFium (via pypdfium2) rendering, for comparison with dart-pdf.
+
+pypdfium2 bundles a prebuilt PDFium binary (the same engine Chrome uses), so
+no system PDFium install is required:
+
+    pip install pypdfium2
+    python3 benchmark/pdfium_benchmark.py test_corpora/pdfjs --scale 2 \
+        --out benchmark/out/pdfium.json
+
+The output JSON schema is shared with the dart-pdf harnesses
+(tool/benchmark_interpret.dart, test/benchmark_render_test.dart) so
+compare.py can line the tools up file-by-file:
+
+    {"tool": "pdfium", "scale": 2.0, "maxPages": 10,
+     "engine": "...", "results": [
+        {"file": "foo.pdf", "pages": 3, "pagesRendered": 3,
+         "openMs": 1.2, "renderMs": 45.6, "error": null}, ...]}
+
+`renderMs` is the wall time to rasterize `pagesRendered` pages to a bitmap at
+`scale` (1.0 == 72 DPI == 1px/pt, matching dart-pdf's pixelRatio). `openMs` is
+parse/load time. Both exclude file I/O (bytes are read up front).
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+try:
+    import pypdfium2 as pdfium
+except ImportError:
+    sys.exit("pypdfium2 not installed — run: pip install pypdfium2")
+
+
+def find_pdfs(root):
+    if os.path.isfile(root):
+        return [root]
+    out = []
+    for dirpath, _dirs, files in os.walk(root):
+        for name in sorted(files):
+            if name.lower().endswith(".pdf"):
+                out.append(os.path.join(dirpath, name))
+    out.sort()
+    return out
+
+
+def bench_file(path, scale, max_pages):
+    """Returns (pages, pages_rendered, open_ms, render_ms, error)."""
+    with open(path, "rb") as fh:
+        data = fh.read()
+
+    t0 = time.perf_counter()
+    try:
+        # autoclose=False: we hold `data` for the doc's lifetime.
+        doc = pdfium.PdfDocument(data)
+        n = len(doc)
+    except Exception as exc:  # noqa: BLE001 — record, don't crash the sweep
+        return (0, 0, (time.perf_counter() - t0) * 1000, 0.0, repr(exc))
+    open_ms = (time.perf_counter() - t0) * 1000
+
+    limit = n if max_pages <= 0 else min(n, max_pages)
+    rendered = 0
+    error = None
+    t1 = time.perf_counter()
+    try:
+        for i in range(limit):
+            page = doc[i]
+            bitmap = page.render(scale=scale)
+            # Touch the buffer so the rasterization can't be optimized away
+            # (FPDF_RenderPageBitmap is synchronous, but be explicit).
+            _ = len(bitmap.buffer)
+            bitmap.close()
+            page.close()
+            rendered += 1
+    except Exception as exc:  # noqa: BLE001
+        error = repr(exc)
+    render_ms = (time.perf_counter() - t1) * 1000
+    doc.close()
+    return (n, rendered, open_ms, render_ms, error)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("corpus", help="PDF file or directory (searched recursively)")
+    ap.add_argument("--scale", type=float, default=2.0,
+                    help="render scale; 1.0 == 72 DPI == dart-pdf pixelRatio 1")
+    ap.add_argument("--max-pages", type=int, default=10,
+                    help="cap pages rendered per file (<=0 = all)")
+    ap.add_argument("--repeat", type=int, default=1,
+                    help="render the whole sweep N times; keep the fastest")
+    ap.add_argument("--out", default=None, help="write JSON here (else stdout)")
+    args = ap.parse_args()
+
+    files = find_pdfs(args.corpus)
+    if not files:
+        sys.exit(f"no PDFs under {args.corpus}")
+
+    # Per file, keep the fastest render time across repeats (warm-cache best).
+    best = {}
+    for r in range(args.repeat):
+        for path in files:
+            pages, rendered, open_ms, render_ms, error = bench_file(
+                path, args.scale, args.max_pages)
+            prev = best.get(path)
+            better = prev is None or (error is None and (
+                prev["error"] is not None or render_ms < prev["renderMs"]))
+            if better:
+                best[path] = {
+                    "file": os.path.relpath(path, args.corpus)
+                            if os.path.isdir(args.corpus) else os.path.basename(path),
+                    "pages": pages,
+                    "pagesRendered": rendered,
+                    "openMs": round(open_ms, 3),
+                    "renderMs": round(render_ms, 3),
+                    "error": error,
+                }
+        print(f"  pdfium pass {r + 1}/{args.repeat} done ({len(files)} files)",
+              file=sys.stderr)
+
+    results = [best[p] for p in files]
+    payload = {
+        "tool": "pdfium",
+        "scale": args.scale,
+        "maxPages": args.max_pages,
+        "engine": f"pypdfium2 {pdfium.version.PYPDFIUM_INFO} / "
+                  f"libpdfium {pdfium.version.PDFIUM_INFO}",
+        "results": results,
+    }
+    text = json.dumps(payload, indent=2)
+    if args.out:
+        os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+        with open(args.out, "w") as fh:
+            fh.write(text)
+        print(f"wrote {args.out}", file=sys.stderr)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run the full dart-pdf vs PDFium render benchmark and print a comparison.
+#
+#   benchmark/run.sh [CORPUS_DIR] [SCALE] [MAX_PAGES]
+#
+# Defaults: corpus test_corpora/pdfjs, scale 2, 10 pages/file. Requires
+# pypdfium2 (pip install pypdfium2) and fvm Flutter. Writes JSON to
+# benchmark/out/ and prints the table to stdout.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CORPUS="${1:-$ROOT/test_corpora/pdfjs}"
+SCALE="${2:-2}"
+MAX_PAGES="${3:-10}"
+OUT="$ROOT/benchmark/out"
+mkdir -p "$OUT"
+
+DART="${DART:-fvm dart}"
+FLUTTER="${FLUTTER:-fvm flutter}"
+
+echo "== Corpus: $CORPUS  (scale $SCALE, $MAX_PAGES pages/file) =="
+
+echo "== 1/3  PDFium (pypdfium2) =="
+python3 "$ROOT/benchmark/pdfium_benchmark.py" "$CORPUS" \
+  --scale "$SCALE" --max-pages "$MAX_PAGES" --out "$OUT/pdfium.json"
+
+echo "== 2/3  dart-pdf interpret (pure Dart, no raster) =="
+( cd "$ROOT/packages/pdf_graphics" && \
+  $DART run tool/benchmark_interpret.dart "$CORPUS" \
+    --max-pages "$MAX_PAGES" --scale "$SCALE" --out "$OUT/dart-interpret.json" )
+
+echo "== 3/3  dart-pdf render (Flutter rasterization) =="
+( cd "$ROOT/packages/dart_pdf_editor" && \
+  PDF_BENCHMARK_DIR="$CORPUS" PDF_BENCHMARK_SCALE="$SCALE" \
+  PDF_BENCHMARK_MAX_PAGES="$MAX_PAGES" \
+  PDF_BENCHMARK_OUT="$OUT/dart-render.json" \
+    $FLUTTER test test/benchmark_render_test.dart )
+
+echo
+echo "== Comparison (baseline = PDFium) =="
+python3 "$ROOT/benchmark/compare.py" \
+  "$OUT/pdfium.json" "$OUT/dart-render.json" "$OUT/dart-interpret.json"

--- a/packages/dart_pdf_editor/test/benchmark_render_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_render_test.dart
@@ -1,0 +1,147 @@
+// Benchmarks dart-pdf's full page rasterization (interpret + paint + toImage),
+// the apples-to-apples comparison with PDFium. Rasterization needs Flutter, so
+// this rides `flutter test`'s headless engine — it is NOT a CI test and skips
+// unless PDF_BENCHMARK_DIR is set:
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_DIR=../../test_corpora/pdfjs \
+//   PDF_BENCHMARK_SCALE=2 PDF_BENCHMARK_MAX_PAGES=10 \
+//   PDF_BENCHMARK_OUT=../../benchmark/out/dart-render.json \
+//     fvm flutter test test/benchmark_render_test.dart
+//
+// Emits the JSON schema shared with the PDFium harness
+// (benchmark/pdfium_benchmark.py) so benchmark/compare.py lines the tools up
+// file-by-file. `renderMs` is the wall time to rasterize `pagesRendered` pages
+// to a bitmap at PDF_BENCHMARK_SCALE (1.0 == 72 DPI == pixelRatio 1, matching
+// PDFium's scale); `openMs` is parse/load. File I/O is excluded (bytes are read
+// up front). toByteData(rawRgba) forces the GPU→CPU readback so the raster is
+// fully realized before the clock stops.
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+void main() {
+  final dir = Platform.environment['PDF_BENCHMARK_DIR'];
+  final scale =
+      double.tryParse(Platform.environment['PDF_BENCHMARK_SCALE'] ?? '') ?? 2.0;
+  final maxPages =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_MAX_PAGES'] ?? '') ?? 10;
+  final repeat =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_REPEAT'] ?? '') ?? 1;
+  final outPath = Platform.environment['PDF_BENCHMARK_OUT'];
+
+  testWidgets('benchmarks dart-pdf rasterization vs PDFium', (tester) async {
+    if (dir == null) {
+      markTestSkipped('set PDF_BENCHMARK_DIR to run the render benchmark');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final corpus = Directory(dir);
+      final files = corpus
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+      final root = corpus.path.endsWith('/') ? corpus.path : '${corpus.path}/';
+      final best = <String, Map<String, Object?>>{};
+
+      for (var r = 0; r < repeat; r++) {
+        for (final file in files) {
+          final name = file.path.startsWith(root)
+              ? file.path.substring(root.length)
+              : file.uri.pathSegments.last;
+          final res =
+              await _benchFile(file, scale, maxPages, name);
+          final prev = best[file.path];
+          final better = prev == null ||
+              (res['error'] == null &&
+                  (prev['error'] != null ||
+                      (res['renderMs'] as double) <
+                          (prev['renderMs'] as double)));
+          if (better) {
+            best[file.path] = res;
+          }
+        }
+        // ignore: avoid_print
+        print('  dart-render pass ${r + 1}/$repeat done (${files.length} files)');
+      }
+
+      final payload = {
+        'tool': 'dart-pdf-render',
+        'scale': scale,
+        'maxPages': maxPages,
+        'engine': 'dart-pdf (PdfPageRenderer.renderImage, Flutter raster)',
+        'results': [for (final f in files) best[f.path]],
+      };
+      final text = const JsonEncoder.withIndent('  ').convert(payload);
+      if (outPath != null) {
+        File(outPath)
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(text);
+        // ignore: avoid_print
+        print('wrote $outPath');
+      } else {
+        // ignore: avoid_print
+        print(text);
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 60)));
+}
+
+Future<Map<String, Object?>> _benchFile(
+    File file, double scale, int maxPages, String name) async {
+  final bytes = file.readAsBytesSync();
+  final sw = Stopwatch()..start();
+  PdfDocument doc;
+  int pages;
+  try {
+    doc = PdfDocument.open(bytes);
+    pages = doc.pageCount;
+  } catch (e) {
+    return {
+      'file': name,
+      'pages': 0,
+      'pagesRendered': 0,
+      'openMs': sw.elapsedMicroseconds / 1000,
+      'renderMs': 0.0,
+      'error': e.toString(),
+    };
+  }
+  final openMs = sw.elapsedMicroseconds / 1000;
+
+  final limit = maxPages <= 0 ? pages : (pages < maxPages ? pages : maxPages);
+  var rendered = 0;
+  String? error;
+  final walk = Stopwatch()..start();
+  for (var i = 0; i < limit; i++) {
+    try {
+      final image = await PdfPageRenderer.renderImage(doc.page(i),
+              pixelRatio: scale)
+          .timeout(const Duration(seconds: 60));
+      // Force the readback so rasterization is fully realized, then free it.
+      await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      image.dispose();
+      rendered++;
+    } catch (e) {
+      error ??= 'page $i: $e';
+    }
+  }
+  walk.stop();
+  return {
+    'file': name,
+    'pages': pages,
+    'pagesRendered': rendered,
+    'openMs': double.parse(openMs.toStringAsFixed(3)),
+    'renderMs': double.parse((walk.elapsedMicroseconds / 1000).toStringAsFixed(3)),
+    'error': error,
+  };
+}

--- a/packages/pdf_graphics/tool/benchmark_interpret.dart
+++ b/packages/pdf_graphics/tool/benchmark_interpret.dart
@@ -1,0 +1,160 @@
+// Benchmarks dart-pdf's parse + content-stream interpretation, the pure-Dart
+// half of rendering (no rasterization — that needs Flutter; see
+// dart_pdf_editor/test/benchmark_render_test.dart). Runs on the Dart VM:
+//
+//   cd packages/pdf_graphics
+//   fvm dart run tool/benchmark_interpret.dart ../../test_corpora/pdfjs \
+//       --max-pages 10 --out ../../benchmark/out/dart-interpret.json
+//
+// Emits the JSON schema shared with the PDFium harness
+// (benchmark/pdfium_benchmark.py) so benchmark/compare.py can line the tools
+// up file-by-file. `renderMs` here is interpret-only wall time (the
+// interpreter walks the page to a NullDevice); `openMs` is parse/load.
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+/// Swallows every device call — the interpreter still does all the parsing,
+/// font shaping, and geometry work; only the paint sink is a no-op.
+class NullDevice implements PdfDevice {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _Args {
+  String corpus = '';
+  double scale = 1; // recorded for schema parity; interpret is scale-free
+  int maxPages = 10;
+  int repeat = 1;
+  String? out;
+}
+
+_Args _parse(List<String> argv) {
+  final a = _Args();
+  for (var i = 0; i < argv.length; i++) {
+    final arg = argv[i];
+    String next() => argv[++i];
+    switch (arg) {
+      case '--scale':
+        a.scale = double.parse(next());
+      case '--max-pages':
+        a.maxPages = int.parse(next());
+      case '--repeat':
+        a.repeat = int.parse(next());
+      case '--out':
+        a.out = next();
+      default:
+        if (arg.startsWith('--')) {
+          stderr.writeln('unknown flag $arg');
+          exit(2);
+        }
+        a.corpus = arg;
+    }
+  }
+  if (a.corpus.isEmpty) {
+    stderr.writeln('usage: benchmark_interpret.dart <corpus> [--max-pages N] '
+        '[--repeat N] [--scale S] [--out file.json]');
+    exit(2);
+  }
+  return a;
+}
+
+List<File> _findPdfs(String root) {
+  final entity = FileSystemEntity.typeSync(root);
+  if (entity == FileSystemEntityType.file) return [File(root)];
+  final files = Directory(root)
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  return files;
+}
+
+/// (pages, pagesInterpreted, openMs, interpretMs, error)
+(int, int, double, double, String?) _benchFile(File file, int maxPages) {
+  final bytes = file.readAsBytesSync();
+  final sw = Stopwatch()..start();
+  PdfDocument doc;
+  int pages;
+  try {
+    doc = PdfDocument.open(bytes);
+    pages = doc.pageCount;
+  } catch (e) {
+    return (0, 0, sw.elapsedMicroseconds / 1000, 0, e.toString());
+  }
+  final openMs = sw.elapsedMicroseconds / 1000;
+
+  final limit = maxPages <= 0 ? pages : (pages < maxPages ? pages : maxPages);
+  var interpreted = 0;
+  String? error;
+  final walk = Stopwatch()..start();
+  for (var i = 0; i < limit; i++) {
+    try {
+      PdfInterpreter(cos: doc.cos, device: NullDevice()).drawPage(doc.page(i));
+      interpreted++;
+    } catch (e) {
+      error ??= 'page $i: $e';
+    }
+  }
+  walk.stop();
+  return (pages, interpreted, openMs, walk.elapsedMicroseconds / 1000, error);
+}
+
+void main(List<String> argv) {
+  final args = _parse(argv);
+  final files = _findPdfs(args.corpus);
+  if (files.isEmpty) {
+    stderr.writeln('no PDFs under ${args.corpus}');
+    exit(1);
+  }
+  final corpusIsDir =
+      FileSystemEntity.typeSync(args.corpus) == FileSystemEntityType.directory;
+
+  final best = <String, Map<String, Object?>>{};
+  for (var r = 0; r < args.repeat; r++) {
+    for (final file in files) {
+      final (pages, did, openMs, interpMs, error) =
+          _benchFile(file, args.maxPages);
+      final name = corpusIsDir
+          ? file.path.substring(args.corpus.length).replaceAll(RegExp(r'^/'), '')
+          : file.uri.pathSegments.last;
+      final prev = best[file.path];
+      final better = prev == null ||
+          (error == null &&
+              (prev['error'] != null ||
+                  interpMs < (prev['renderMs'] as double)));
+      if (better) {
+        best[file.path] = {
+          'file': name,
+          'pages': pages,
+          'pagesRendered': did,
+          'openMs': double.parse(openMs.toStringAsFixed(3)),
+          'renderMs': double.parse(interpMs.toStringAsFixed(3)),
+          'error': error,
+        };
+      }
+    }
+    stderr.writeln('  dart-interpret pass ${r + 1}/${args.repeat} done '
+        '(${files.length} files)');
+  }
+
+  final payload = {
+    'tool': 'dart-pdf-interpret',
+    'scale': args.scale,
+    'maxPages': args.maxPages,
+    'engine': 'dart-pdf (pdf_graphics interpreter, NullDevice)',
+    'results': [for (final f in files) best[f.path]],
+  };
+  final text = const JsonEncoder.withIndent('  ').convert(payload);
+  final outPath = args.out;
+  if (outPath != null) {
+    final outFile = File(outPath)..parent.createSync(recursive: true);
+    outFile.writeAsStringSync(text);
+    stderr.writeln('wrote $outPath');
+  } else {
+    stdout.writeln(text);
+  }
+}


### PR DESCRIPTION
Performance harnesses that benchmark dart-pdf rendering against **PDFium** — the C++ engine Chrome uses — over the same corpus of PDFs, and emit a side-by-side comparison (ms/page, pages/s, speedup ratio).

PDFium comes from [`pypdfium2`](https://pypi.org/project/pypdfium2/), which bundles a prebuilt PDFium binary, so there's no system PDFium build or `pdfium_test` to set up — just `pip install pypdfium2`.

## What's here

Three harnesses, all writing one shared JSON schema so `compare.py` lines them up file-by-file:

| file | engine | measures | needs |
|---|---|---|---|
| `benchmark/pdfium_benchmark.py` | PDFium via pypdfium2 | open + rasterize to bitmap | `pip install pypdfium2` |
| `packages/dart_pdf_editor/test/benchmark_render_test.dart` | dart-pdf full pipeline | open + interpret + paint + `toImage` | fvm Flutter |
| `packages/pdf_graphics/tool/benchmark_interpret.dart` | dart-pdf interpreter | open + interpret to a `NullDevice` (no raster) | fvm Dart |

Plus `benchmark/compare.py` (the comparison table, `--md`/`--per-file`), `benchmark/run.sh` (one-command orchestration over `test_corpora/pdfjs`), and `benchmark/README.md`.

The render test is the **apples-to-apples** comparison with PDFium (both produce a rasterized bitmap at the same scale). It rides `flutter test`'s headless engine and **skips unless `PDF_BENCHMARK_DIR` is set**, so it stays out of CI — same opt-in pattern as `corpus_render_test.dart`. The interpret-only harness isolates dart-pdf's pure-Dart parse + content-stream work.

## Fair-comparison details (in the README)

- **Scale unit matches**: PDFium `scale` and dart-pdf `pixelRatio` are both `1.0` = 72 DPI = 1 px/pt; both default to `2.0`.
- **Timing boundaries**: file bytes read up front and excluded; `toByteData(rawRgba)` / touching the PDFium bitmap buffer forces the raster to fully complete before the clock stops.
- **Warmup matters**: Flutter pays one-time shader warmup — `--repeat`/`PDF_BENCHMARK_REPEAT` renders the sweep N times and keeps each file's fastest pass (in testing this moved dart-render from ~50 ms/page cold to ~5 ms/page warm).
- Per-file errors show as `err`; the totals row only counts pages every tool rendered without error, scaled to the common page count.

## Usage

```bash
pip install pypdfium2
benchmark/run.sh                      # test_corpora/pdfjs, scale 2, 10 pages/file
benchmark/run.sh /path/to/pdfs 2 20   # custom corpus / scale / page cap
```

`benchmark/out/` (generated JSON + tables) is git-ignored.

## Verification

All three harnesses ran end-to-end on an 8-file pdfjs subset; `dart analyze` is clean on the new Dart files; the comparison table and `--repeat` warm-up path both verified.

https://claude.ai/code/session_019x8VEU4MUTq8jKZsY94yy1

---
_Generated by [Claude Code](https://claude.ai/code/session_019x8VEU4MUTq8jKZsY94yy1)_