### PR TITLE
perf(render): share the content-stream parse + scan-only image collect (#52)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -38,9 +38,19 @@ class PdfPageRenderer {
       bool Function(PdfAnnotation)? skipAnnotation}) async {
     final cos = page.document.cos;
 
+    // Parsing the content stream (and decompressing it) dominates rendering on
+    // graphics-rich pages, and the page is interpreted twice here — once to
+    // discover images to decode, once to paint. Parse it once and feed both.
+    final pageOps = ContentStreamParser.parse(page.contentBytes());
+
+    // Discover the images to decode with a scan-only interpretation: it walks
+    // the same content (so it sees every image — including those drawn by
+    // Type3 glyphs and tiling patterns) but skips the path/text/colour/shading
+    // build work, so the collect walk is a fraction of the paint walk.
     final collector = ImageCollector();
-    final collecting = PdfInterpreter(cos: cos, device: collector)
-      ..drawPage(page);
+    final collecting =
+        PdfInterpreter(cos: cos, device: collector, scanImagesOnly: true)
+          ..drawPageOperations(page, pageOps);
     if (annotations) collecting.drawAnnotations(page, skip: skipAnnotation);
     final images = await decodeImages(cos, collector.streams);
 
@@ -82,7 +92,7 @@ class PdfPageRenderer {
 
     final painting = PdfInterpreter(
         cos: cos, device: CanvasPdfDevice(canvas, images: images))
-      ..drawPage(page);
+      ..drawPageOperations(page, pageOps);
     if (annotations) painting.drawAnnotations(page, skip: skipAnnotation);
     return recorder.endRecording();
   }
@@ -97,7 +107,7 @@ class PdfPageRenderer {
     final cos = page.document.cos;
 
     final collector = ImageCollector();
-    PdfInterpreter(cos: cos, device: collector)
+    PdfInterpreter(cos: cos, device: collector, scanImagesOnly: true)
         .drawAnnotation(page, annotation);
     final images = await decodeImages(cos, collector.streams);
 

--- a/packages/dart_pdf_editor/test/benchmark_phases_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_phases_test.dart
@@ -1,0 +1,162 @@
+// Deep phase-split probe for the full-render path, to see where the per-page
+// time goes:
+//   - collect : interpreter pass #1 (image discovery; scan-only after PR #52)
+//   - decode  : decodeImages (Flutter image codecs)
+//   - paint   : interpreter pass #2 into CanvasPdfDevice (build canvas ops)
+//   - toImage : rasterize the recorded picture
+//   - readback: toByteData(rawRgba)
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_DIR=../../test_corpora/ghent PDF_BENCHMARK_SCALE=2 \
+//   PDF_BENCHMARK_MAX_PAGES=10 \
+//     fvm flutter test test/benchmark_phases_test.dart
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/image_decoder.dart';
+import 'package:dart_pdf_editor/src/canvas_device.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+void main() {
+  final dir = Platform.environment['PDF_BENCHMARK_DIR'];
+  final scale =
+      double.tryParse(Platform.environment['PDF_BENCHMARK_SCALE'] ?? '') ?? 2.0;
+  final maxPages =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_MAX_PAGES'] ?? '') ?? 10;
+
+  testWidgets('render phase breakdown', (tester) async {
+    if (dir == null) {
+      markTestSkipped('set PDF_BENCHMARK_DIR');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final files = Directory(dir)
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+      var pages = 0;
+      var parseUs = 0, collectUs = 0, decodeUs = 0, paintUs = 0, imgUs = 0;
+      var rbUs = 0;
+      var imgPages = 0;
+      var warmed = false;
+
+      for (final file in files) {
+        PdfDocument doc;
+        try {
+          doc = PdfDocument.open(file.readAsBytesSync());
+        } catch (_) {
+          continue;
+        }
+        final limit = maxPages <= 0
+            ? doc.pageCount
+            : (doc.pageCount < maxPages ? doc.pageCount : maxPages);
+        for (var i = 0; i < limit; i++) {
+          try {
+            final page = doc.page(i);
+            final cos = page.document.cos;
+            final size = PdfPageRenderer.pageSize(page);
+            final box = page.cropBox;
+
+            if (!warmed) {
+              final w = await PdfPageRenderer.renderPicture(page);
+              final wi = await PdfPageRenderer.rasterize(w, size, scale);
+              await wi.toByteData(format: ui.ImageByteFormat.rawRgba);
+              wi.dispose();
+              w.dispose();
+              warmed = true;
+            }
+
+            final sw = Stopwatch()..start();
+            // parse the page content once and share it across both passes —
+            // exactly what renderPicture does.
+            final pageOps = ContentStreamParser.parse(page.contentBytes());
+            parseUs += sw.elapsedMicroseconds;
+
+            sw
+              ..reset()
+              ..start();
+            // collect pass — scan-only image discovery (matches renderPicture)
+            final collector = ImageCollector();
+            final collecting = PdfInterpreter(
+                cos: cos, device: collector, scanImagesOnly: true)
+              ..drawPageOperations(page, pageOps);
+            collecting.drawAnnotations(page);
+            collectUs += sw.elapsedMicroseconds;
+
+            sw
+              ..reset()
+              ..start();
+            final images = await decodeImages(cos, collector.streams);
+            decodeUs += sw.elapsedMicroseconds;
+            if (collector.streams.isNotEmpty) imgPages++;
+
+            sw
+              ..reset()
+              ..start();
+            final recorder = ui.PictureRecorder();
+            final canvas = Canvas(recorder);
+            canvas.drawRect(Offset.zero & size, Paint()..color = Colors.white);
+            canvas.translate(0, box.height);
+            canvas.scale(1, -1);
+            canvas.translate(-box.left, -box.bottom);
+            final painting = PdfInterpreter(
+                cos: cos, device: CanvasPdfDevice(canvas, images: images))
+              ..drawPageOperations(page, pageOps);
+            painting.drawAnnotations(page);
+            final pic = recorder.endRecording();
+            paintUs += sw.elapsedMicroseconds;
+
+            sw
+              ..reset()
+              ..start();
+            final img = await PdfPageRenderer.rasterize(pic, size, scale);
+            imgUs += sw.elapsedMicroseconds;
+
+            sw
+              ..reset()
+              ..start();
+            await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+            rbUs += sw.elapsedMicroseconds;
+
+            img.dispose();
+            pic.dispose();
+            for (final im in images.values) {
+              im.dispose();
+            }
+            pages++;
+          } catch (_) {}
+        }
+      }
+
+      String per(int us) => (us / 1000 / pages).toStringAsFixed(1);
+      final total = parseUs + collectUs + decodeUs + paintUs + imgUs + rbUs;
+      // ignore: avoid_print
+      print('\n=== deep render breakdown ($pages pages, $imgPages with images, '
+          'scale $scale) ===');
+      // ignore: avoid_print
+      print('  parse    (shared, once):   ${per(parseUs)} ms/page');
+      // ignore: avoid_print
+      print('  collect  (scan walk):      ${per(collectUs)} ms/page');
+      // ignore: avoid_print
+      print('  decode   (image codecs):   ${per(decodeUs)} ms/page');
+      // ignore: avoid_print
+      print('  paint    (interp pass 2):  ${per(paintUs)} ms/page');
+      // ignore: avoid_print
+      print('  toImage  (rasterize):      ${per(imgUs)} ms/page');
+      // ignore: avoid_print
+      print('  readback (toByteData):     ${per(rbUs)} ms/page');
+      // ignore: avoid_print
+      print('  TOTAL:                     ${per(total)} ms/page');
+    });
+  }, timeout: const Timeout(Duration(minutes: 60)));
+}

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -160,12 +160,26 @@ class _ActiveSoftMask {
 /// shadings, patterns, soft masks, Type3 fonts, and annotation
 /// appearance streams.
 class PdfInterpreter {
-  PdfInterpreter({required this.cos, required this.device});
+  PdfInterpreter(
+      {required this.cos, required this.device, bool scanImagesOnly = false})
+      : _scanImages = scanImagesOnly;
 
   final CosDocument cos;
   final PdfDevice device;
 
   static const _maxFormDepth = 16;
+
+  // When true, the interpreter only walks the content to discover image draw
+  // requests — it skips the image-free build work (path segment lists, glyph
+  // outlines, colour/ICC conversion, shadings, text runs, and the no-op device
+  // paint calls). Every image source — image/form XObjects, inline images,
+  // Type3 glyph procs, tiling patterns, soft-mask groups — reaches the device
+  // through `_run`, which runs on this same instance, so the flag is inherited
+  // by every nested stream and the discovered image set is identical to a full
+  // interpretation. It lets a render's decode-collect pass cost a fraction of a
+  // pass instead of a redundant second full interpretation (see
+  // PdfPageRenderer.renderPicture).
+  final bool _scanImages;
 
   var _state = _GraphicsState();
   final List<_GraphicsState> _stateStack = [];
@@ -189,6 +203,13 @@ class PdfInterpreter {
   double _startX = 0, _startY = 0;
   PdfFillRule? _pendingClip;
 
+  // While scanning for images we don't build the segment list — only the
+  // current path's page-space bounding box, which is all a tiling-pattern fill
+  // needs to bound its tile loop (over-estimating the box only runs extra
+  // tiles, never misses an image). Reset after each paint, like _segments.
+  double _scanMinX = double.infinity, _scanMinY = double.infinity;
+  double _scanMaxX = double.negativeInfinity, _scanMaxY = double.negativeInfinity;
+
   // text matrices
   PdfMatrix _textMatrix = PdfMatrix.identity;
   PdfMatrix _lineMatrix = PdfMatrix.identity;
@@ -200,13 +221,21 @@ class PdfInterpreter {
   bool _textClipPending = false;
   final List<PdfPathSegment> _textClipSegments = [];
 
-  void drawPage(PdfPage page) {
+  void drawPage(PdfPage page) =>
+      drawPageOperations(page, ContentStreamParser.parse(page.contentBytes()));
+
+  /// Runs an already-parsed page content stream. Parsing (and the underlying
+  /// stream decompression) dominates rendering on graphics-rich pages, so a
+  /// renderer that interprets a page more than once — e.g. the image-collect
+  /// pass and the paint pass in PdfPageRenderer.renderPicture — parses the
+  /// content once and feeds the same [operations] to both passes.
+  void drawPageOperations(PdfPage page, List<ContentOperation> operations) {
     _state = _GraphicsState();
     _visibilityStack.clear();
     _pageBox = page.mediaBox;
     device.save();
     try {
-      _run(ContentStreamParser.parse(page.contentBytes()), page.resources, 0);
+      _run(operations, page.resources, 0);
       final mask = _state.softMask;
       if (mask != null) _finalizeSoftMask(mask);
     } finally {
@@ -771,17 +800,25 @@ class PdfInterpreter {
           _state.strokeColor =
               PdfColor.cmyk(_num(o, 0), _num(o, 1), _num(o, 2), _num(o, 3));
         case 'cs':
+          // Selecting a fill space clears the pattern (tracked while scanning);
+          // the space's tint/ICC machinery only matters for resolving colours,
+          // which scanning skips.
+          _state.fillPattern = null;
+          if (_scanImages) break;
           _state.fillComponents = _componentsOf(resources, o);
           _state.fillTintTransform = _tintTransformOf(resources, o);
           _state.fillCalibrated = _calibratedColorSpaceOf(resources, o);
           _state.fillIcc = _iccProfileOf(resources, o);
-          _state.fillPattern = null;
         case 'CS':
+          if (_scanImages) break;
           _state.strokeComponents = _componentsOf(resources, o);
           _state.strokeTintTransform = _tintTransformOf(resources, o);
           _state.strokeCalibrated = _calibratedColorSpaceOf(resources, o);
           _state.strokeIcc = _iccProfileOf(resources, o);
         case 'sc' || 'scn':
+          // The fill pattern is tracked even while scanning — a tiling pattern
+          // fill runs the cell content (which can draw images). The resolved
+          // fill colour, though, is never needed when only collecting images.
           _state.fillPattern = null;
           if (o.isNotEmpty && o.last is CosName) {
             _state.fillPattern =
@@ -790,11 +827,13 @@ class PdfInterpreter {
               for (final v in o)
                 if (v is CosInteger || v is CosReal) _numOf(v),
             ];
-          } else {
+          } else if (!_scanImages) {
             _state.fillColor = _tintedColor(_state.fillTintTransform,
                 _state.fillCalibrated, _state.fillIcc, o, _state.fillColor);
           }
         case 'SC' || 'SCN':
+          // Stroke colour never affects which images are drawn.
+          if (_scanImages) break;
           if (o.isNotEmpty && o.last is CosName) {
             // stroke patterns: approximate with the pattern's average color
             final color = _patternAverageColor(
@@ -893,7 +932,8 @@ class PdfInterpreter {
           if (_contentVisible) _drawInlineImage(o);
 
         case 'sh':
-          if (_contentVisible) _applyShading(resources, o);
+          // Shadings are gradients/meshes — never images.
+          if (_contentVisible && !_scanImages) _applyShading(resources, o);
 
         // --- marked content, compatibility, Type3 metrics ---
         case 'BDC':
@@ -1054,18 +1094,35 @@ class PdfInterpreter {
   void _moveTo(double x, double y) {
     _currentX = _startX = x;
     _currentY = _startY = y;
+    if (_scanImages) {
+      _scanPoint(_state.ctm.transformX(x, y), _state.ctm.transformY(x, y));
+      return;
+    }
     _addPoint(x, y, (px, py) => _segments.add(PdfMoveTo(px, py)));
   }
 
   void _lineTo(double x, double y) {
     _currentX = x;
     _currentY = y;
+    if (_scanImages) {
+      _scanPoint(_state.ctm.transformX(x, y), _state.ctm.transformY(x, y));
+      return;
+    }
     _addPoint(x, y, (px, py) => _segments.add(PdfLineTo(px, py)));
   }
 
   void _curveTo(
       double x1, double y1, double x2, double y2, double x3, double y3) {
     final m = _state.ctm;
+    if (_scanImages) {
+      // The Bézier hull (control points included) bounds the curve.
+      _scanPoint(m.transformX(x1, y1), m.transformY(x1, y1));
+      _scanPoint(m.transformX(x2, y2), m.transformY(x2, y2));
+      _scanPoint(m.transformX(x3, y3), m.transformY(x3, y3));
+      _currentX = x3;
+      _currentY = y3;
+      return;
+    }
     _segments.add(PdfCubicTo(
       m.transformX(x1, y1),
       m.transformY(x1, y1),
@@ -1079,12 +1136,50 @@ class PdfInterpreter {
   }
 
   void _closePath() {
-    _segments.add(const PdfClosePath());
+    // In scan mode the box already covers every point; nothing to add.
+    if (!_scanImages) _segments.add(const PdfClosePath());
     _currentX = _startX;
     _currentY = _startY;
   }
 
+  void _scanPoint(double px, double py) {
+    if (px < _scanMinX) _scanMinX = px;
+    if (py < _scanMinY) _scanMinY = py;
+    if (px > _scanMaxX) _scanMaxX = px;
+    if (py > _scanMaxY) _scanMaxY = py;
+  }
+
+  void _resetScanBox() {
+    _scanMinX = _scanMinY = double.infinity;
+    _scanMaxX = _scanMaxY = double.negativeInfinity;
+  }
+
   void _paint({PdfFillRule? fill, bool stroke = false}) {
+    // Image scan: no segment list was built. Only a tiling pattern fill draws
+    // images (its cell content can), and it just needs the fill area's bounds
+    // to know which tiles to run — so hand it the path's bounding box as a
+    // rectangle. Solid/shading fills, strokes, and clips draw no images.
+    if (_scanImages) {
+      final pattern = _state.fillPattern;
+      if (fill != null &&
+          _contentVisible &&
+          _isTilingPattern(pattern) &&
+          _scanMinX <= _scanMaxX) {
+        _fillWithPattern(
+            PdfPath([
+              PdfMoveTo(_scanMinX, _scanMinY),
+              PdfLineTo(_scanMaxX, _scanMinY),
+              PdfLineTo(_scanMaxX, _scanMaxY),
+              PdfLineTo(_scanMinX, _scanMaxY),
+              const PdfClosePath(),
+            ]),
+            fill,
+            pattern!);
+      }
+      _pendingClip = null;
+      _resetScanBox();
+      return;
+    }
     final path = PdfPath(_segments);
     if (!path.isEmpty && _contentVisible) {
       if (fill != null) {
@@ -1515,8 +1610,12 @@ class PdfInterpreter {
     final buffer = StringBuffer();
     final emScale = size * _state.horizontalScale;
     // a non-null (possibly empty-outlined) glyph list tells devices the font
-    // is embedded, so they must not substitute
-    final glyphs = (font.hasOutlines || font.isType3) && emScale != 0
+    // is embedded, so they must not substitute. In image-scan mode we never
+    // emit the run, so skip building outlines — but the Type3 loop below still
+    // runs each glyph's CharProc (a content stream that can draw images).
+    final glyphs = !_scanImages &&
+            (font.hasOutlines || font.isType3) &&
+            emScale != 0
         ? <PdfGlyphPlacement>[]
         : null;
     // Vertical writing mode (§9.7.4.3): glyphs stack downward. The pen advances
@@ -1560,7 +1659,7 @@ class PdfInterpreter {
       }
     }
 
-    if (size != 0 && _contentVisible) {
+    if (size != 0 && _contentVisible && !_scanImages) {
       // text rendering matrix: em space → page space (§9.4.4).
       // Mode 3 (invisible) still emits the run — flagged, so painting
       // devices skip it — because it IS the text of OCR'd scans, and

--- a/packages/pdf_graphics/test/image_scan_parity_test.dart
+++ b/packages/pdf_graphics/test/image_scan_parity_test.dart
@@ -1,0 +1,98 @@
+// The image-scan interpreter mode (`scanImagesOnly: true`) must discover
+// exactly the same image draw requests as a full interpretation — otherwise a
+// rendered page would be missing (or needlessly decode) an image. This walks
+// the checked-in corpora and, page by page, asserts the two passes collect the
+// identical set of image streams.
+//
+//   cd packages/pdf_graphics && fvm dart test test/image_scan_parity_test.dart
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:test/test.dart';
+
+/// Records the image requests an interpreter emits, keyed so the same image
+/// maps to the same key across two passes: XObject images by stream identity
+/// (the xref cache hands back the same instance), inline images by content.
+class _ImageRecorder implements PdfDevice {
+  final List<String> keys = [];
+
+  @override
+  void drawImage(PdfImageRequest request) {
+    if (request.isInline) {
+      final bytes = request.stream.rawBytes;
+      var sum = 0;
+      for (final b in bytes) {
+        sum = (sum + b) % 0x7fffffff;
+      }
+      keys.add('inline:${request.stream.dictionary}:${bytes.length}:$sum');
+    } else {
+      keys.add('xobj:${identityHashCode(request.stream)}');
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Set<String> _collect(PdfDocument doc, int pageIndex, {required bool scan}) {
+  final page = doc.page(pageIndex);
+  final rec = _ImageRecorder();
+  PdfInterpreter(cos: doc.cos, device: rec, scanImagesOnly: scan)
+    ..drawPage(page)
+    ..drawAnnotations(page);
+  return rec.keys.toSet();
+}
+
+void main() {
+  for (final corpus in ['../../test_corpora/ghent', '../../test_corpora/pdfjs']) {
+    final dir = Directory(corpus);
+    if (!dir.existsSync()) continue;
+    final files = dir
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+        .toList()
+      ..sort((a, b) => a.path.compareTo(b.path));
+
+    group('image-scan parity: ${corpus.split('/').last}', () {
+      for (final file in files) {
+        test(file.path.split('/').last, () {
+          final Uint8List bytes;
+          final PdfDocument doc;
+          try {
+            bytes = file.readAsBytesSync();
+            doc = PdfDocument.open(bytes);
+          } catch (_) {
+            return; // unopenable fixture — not this test's concern
+          }
+          final int pages;
+          try {
+            pages = doc.pageCount;
+          } catch (_) {
+            return;
+          }
+          final limit = pages < 10 ? pages : 10;
+          for (var i = 0; i < limit; i++) {
+            Set<String> full, scan;
+            try {
+              full = _collect(doc, i, scan: false);
+            } catch (_) {
+              continue; // a page the full interpreter can't even walk
+            }
+            scan = _collect(doc, i, scan: true);
+            // The scan must never MISS an image the full pass draws. (It may,
+            // in principle, over-collect; that only wastes a decode — so the
+            // strong check is full ⊆ scan, and we also assert equality to catch
+            // any divergence early.)
+            expect(scan.containsAll(full), isTrue,
+                reason: 'page $i: scan missed ${full.difference(scan)}');
+            expect(scan, equals(full),
+                reason: 'page $i: scan/full image sets differ');
+          }
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION
Implements **(A)** from #52: eliminate the redundant work in `PdfPageRenderer.renderPicture`, which interprets each page twice (collect images to decode, then paint).

## Root cause

Profiling (the phase-split probe added here) showed the cost is **not** rasterization or GPU readback (~6–17 ms/page combined) — it's the Dart-side `renderPicture`, and the dominant piece is **content-stream parsing**, which both passes did independently:

| heavy page | decompress | **parse** | interpret walk |
|---|---|---|---|
| document.pdf | 8.3 | **170.1** | 19.7 |
| a31FD… | 6.2 | **130.1** | 6.5 |
| Combined Design Pack | 3.9 | **78.3** | 4.8 |

## Changes

1. **Parse once, share both passes.** `PdfInterpreter.drawPageOperations(page, ops)` runs a pre-parsed content stream; `drawPage` delegates to it. `renderPicture` parses the page once and feeds the same op list to the collect and paint passes — eliminating a redundant parse (+ decompress) per page.
2. **Scan-only collect pass** (`PdfInterpreter(scanImagesOnly: true)`). It walks the same content — so it discovers every image, including those drawn by **Type3 glyph procs** and **tiling patterns** (every image source reaches the device through `_run`, which inherits the flag) — but skips the image-free build work: path segment lists (it tracks only a bounding box, which is all a tiling-pattern fill needs), glyph outlines, colour/ICC conversion, shadings, text runs, and the no-op device paint calls.

## Result

Full render breakdown, real-world corpus (245 pages, scale 2):

| phase | before | after |
|---|---|---|
| parse | ~2× (in both passes) | 24.5 (shared, once) |
| collect | 27.7 (full interp) | 3.2 (scan walk) |
| paint | 34.2 (incl. parse) | 12.1 |
| decode | 26.9 | 22.8 |
| toImage | 16.3 | 16.6 |
| **total** | **105.8** | **80.0 ms/page (−24%)** |

vs PDFium 22.0 ms/page: **4.6× → 3.6×**. (Ghent is decode-bound, so its total barely moves: 102.8 → 100.1.)

## Correctness

- **New parity test** (`image_scan_parity_test.dart`): the scan pass collects the **identical** image set as a full interpretation, page by page, across the Ghent + pdf.js corpora — **225 pages, all pass** (covers Type3 GWG090, tiling, inline images, soft masks).
- **Ghent render baselines unchanged**: 40 pass / 14 fail — the *same* 14 pre-existing machine-specific diffs documented in CLAUDE.md, **no new failures**. The paint pass and rendered output are untouched.
- Interpreter suite (38), pure-Dart Ghent + pdf.js corpus suites (225), and the inline-image render test pass. `dart analyze` clean.

Adds `benchmark_phases_test.dart` (the render phase-split probe used above; `PDF_BENCHMARK_DIR=<corpus> flutter test test/benchmark_phases_test.dart`).

Follow-ups from #52 remain: (B) cross-render decoded-image cache, (C) paint-pass hotspots, (D) image-codec speedups.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
