### PR TITLE
perf(render): faster content-stream tokenizer — interpreter now beats PDFium (#52)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -15,25 +15,31 @@ without error), scale 2.0 (144 DPI), best-of-3 render passes, on the
 development Mac. PDFium 5.9.0 / libpdfium 150.0.7869.0. Captured 2026-06-14
 with the #52 render-perf work in place (shared parse, image-decode cache +
 fast-paths, cross-render font cache, inline path construction, text-show
-memoisation).
+memoisation, and a rewritten content-stream tokenizer).
 
 | engine | throughput | ms/page | vs PDFium |
 |---|---|---|---|
 | **PDFium** (open + rasterize) | 48.5 pages/s | 20.6 | 1.00× |
-| **dart-pdf interpret** (pure Dart, no raster) | 43.9 pages/s | 22.8 | **1.10× slower** |
-| **dart-pdf render** (full Flutter raster + readback) | 15.3 pages/s | 65.3 | **3.16× slower** |
+| **dart-pdf interpret** (pure Dart, no raster) | 73.6 pages/s | 13.6 | **1.52× faster** |
+| **dart-pdf render** (full Flutter raster + readback) | 18.6 pages/s | 53.7 | **2.60× slower** |
 
 Takeaways:
 
-- **The pure-Dart engine is within 10% of PDFium** — parse + content-stream
-  interpretation, the code that runs on the VM and the web. This is the path
-  the optimization work targeted.
-- **The full render path is 3.16× slower, and that gap is now Flutter, not the
-  interpreter.** interpret is 22.8 ms/page but render is 65.3, so ~42 ms/page
-  is Flutter's GPU rasterization + `toImage`/`toByteData` readback — entirely
-  outside the interpreter. The per-file split confirms it: a single giant-image
-  page renders at 0.11× (1862 ms raster vs **16.7 ms interpret**), while
-  text/vector documents interpret *faster* than PDFium rasterizes them.
+- **The pure-Dart engine is now ~1.5× faster than PDFium** — parse +
+  content-stream interpretation, the code that runs on the VM and the web. The
+  content-stream tokenizer rewrite (faster number/keyword/name lexing, no
+  reference lookahead on content operands) roughly halved parse time and is
+  what flipped this from 1.10× *slower* to 1.52× *faster*.
+- **The full render path is 2.60× slower, and that gap is Flutter, not the
+  interpreter.** interpret is 13.6 ms/page but render is 53.7, so ~40 ms/page
+  is image decoding + Flutter's GPU rasterization + `toImage`/`toByteData`
+  readback. A phase split of the render path (scale 2): parse 13.5, collect
+  2.3, image decode 18.1, paint 7.3, **GPU rasterize 16.7**, readback 0.7
+  ms/page. The decode and rasterize costs dominate; both lean on platform
+  codecs / GPU that PDFium reaches via an in-process CPU bitmap (no GPU upload
+  or readback). The per-file split confirms it: a single giant-image page
+  renders at 0.11×, while text/vector documents interpret *faster* than PDFium
+  rasterizes them.
 
 Absolute milliseconds are machine-specific; the **ratios** are the portable
 number. Re-run with `benchmark/run.sh corpus 2 10` (see Quick start).

--- a/packages/pdf_cos/lib/src/content_parser.dart
+++ b/packages/pdf_cos/lib/src/content_parser.dart
@@ -29,6 +29,20 @@ class ContentStreamParser {
     while (true) {
       final t = parser.peekToken();
       if (t.type == CosTokenType.eof) break;
+      // Numbers are by far the most common operand; take them directly. In a
+      // content stream a bare `N G R` is never an indirect reference (those
+      // only exist in the document body), so skip parseObject's reference
+      // lookahead — matching how reference renderers read content streams.
+      if (t.type == CosTokenType.integer) {
+        parser.nextToken();
+        operands.add(CosInteger(t.intValue));
+        continue;
+      }
+      if (t.type == CosTokenType.real) {
+        parser.nextToken();
+        operands.add(CosReal(t.realValue));
+        continue;
+      }
       if (t.type == CosTokenType.arrayOpen) {
         operands.add(_parseLenientArray(parser));
         continue;
@@ -67,6 +81,12 @@ class ContentStreamParser {
           return CosArray(items);
         case CosTokenType.eof:
           return CosArray(items); // unterminated — keep what parsed
+        case CosTokenType.integer:
+          parser.nextToken();
+          items.add(CosInteger(t.intValue));
+        case CosTokenType.real:
+          parser.nextToken();
+          items.add(CosReal(t.realValue));
         case CosTokenType.arrayOpen:
           items.add(_parseLenientArray(parser));
         case CosTokenType.keyword:

--- a/packages/pdf_cos/lib/src/lexer.dart
+++ b/packages/pdf_cos/lib/src/lexer.dart
@@ -117,26 +117,37 @@ class CosLexer {
   }
 
   CosToken _number(int start) {
+    // Content streams are number-dense (every coordinate, colour, index), so
+    // this is the tokenizer's hottest path. Scan the digit/sign/dot run once
+    // and parse straight from the bytes — no per-char StringBuffer.
     var isReal = false;
-    final sb = StringBuffer();
-    while (position < bytes.length) {
-      final b = bytes[position];
+    var p = position;
+    while (p < bytes.length) {
+      final b = bytes[p];
       if (_isDigit(b) || b == 0x2B || b == 0x2D) {
-        sb.writeCharCode(b);
+        // digit or sign
       } else if (b == 0x2E) {
         isReal = true;
-        sb.writeCharCode(b);
       } else {
         break;
       }
-      position++;
+      p++;
     }
-    final raw = sb.toString();
+    position = p;
+
     if (!isReal) {
-      final v = int.tryParse(raw);
-      if (v == null) throw CosParseException('malformed number "$raw"', start);
-      return CosToken(CosTokenType.integer, start, v);
+      // Parse the integer directly when it can't overflow (≤18 digits); this
+      // is bit-for-bit identical to int.tryParse over the same byte range.
+      final v = _parseIntRange(start, p);
+      if (v != null) return CosToken(CosTokenType.integer, start, v);
+      // Overflowing or malformed: fall back to the exact string semantics.
+      final raw = String.fromCharCodes(bytes, start, p);
+      final iv = int.tryParse(raw);
+      if (iv == null) throw CosParseException('malformed number "$raw"', start);
+      return CosToken(CosTokenType.integer, start, iv);
     }
+
+    final raw = String.fromCharCodes(bytes, start, p);
     var s = raw;
     if (s.startsWith('.')) s = '0$s';
     if (s.startsWith('-.')) s = '-0${s.substring(1)}';
@@ -144,6 +155,30 @@ class CosLexer {
     final v = double.tryParse(s);
     if (v == null) throw CosParseException('malformed number "$raw"', start);
     return CosToken(CosTokenType.real, start, v);
+  }
+
+  /// Parses the integer in `bytes[start..end)` exactly as
+  /// `int.tryParse(String.fromCharCodes(bytes, start, end))` would — an
+  /// optional leading `+`/`-` then digits — but without allocating a string.
+  /// Returns null for malformed input or a mantissa long enough to risk
+  /// 64-bit overflow (≥19 digits), so the caller can fall back to the string
+  /// path with identical semantics.
+  int? _parseIntRange(int start, int end) {
+    var i = start;
+    var negative = false;
+    final first = bytes[i];
+    if (first == 0x2B || first == 0x2D) {
+      negative = first == 0x2D;
+      i++;
+    }
+    if (i >= end || end - i > 18) return null; // empty mantissa, or too long
+    var value = 0;
+    for (; i < end; i++) {
+      final d = bytes[i] - 0x30;
+      if (d < 0 || d > 9) return null; // embedded sign or junk
+      value = value * 10 + d;
+    }
+    return negative ? -value : value;
   }
 
   CosToken _literalString(int start) {
@@ -240,6 +275,21 @@ class CosLexer {
 
   CosToken _name(int start) {
     position++; // /
+    final nameStart = position;
+    // Fast path: a name with no `#XX` escape is just the regular-byte run, so
+    // build the string straight from the range (most names have no escapes).
+    while (position < bytes.length && isRegular(bytes[position])) {
+      if (bytes[position] == 0x23) {
+        return _nameWithEscapes(start, nameStart);
+      }
+      position++;
+    }
+    return CosToken(
+        CosTokenType.name, start, String.fromCharCodes(bytes, nameStart, position));
+  }
+
+  CosToken _nameWithEscapes(int start, int nameStart) {
+    position = nameStart;
     final out = BytesBuilder();
     while (position < bytes.length && isRegular(bytes[position])) {
       var b = bytes[position++];
@@ -258,14 +308,16 @@ class CosLexer {
   }
 
   CosToken _keyword(int start) {
-    final sb = StringBuffer();
-    while (position < bytes.length && isRegular(bytes[position])) {
-      sb.writeCharCode(bytes[position++]);
+    var p = position;
+    while (p < bytes.length && isRegular(bytes[p])) {
+      p++;
     }
-    if (sb.isEmpty) {
+    if (p == start) {
       throw CosParseException(
           'unexpected byte 0x${bytes[position].toRadixString(16)}', start);
     }
-    return CosToken(CosTokenType.keyword, start, sb.toString());
+    position = p;
+    return CosToken(
+        CosTokenType.keyword, start, String.fromCharCodes(bytes, start, p));
   }
 }

--- a/packages/pdf_cos/test/lexer_test.dart
+++ b/packages/pdf_cos/test/lexer_test.dart
@@ -31,6 +31,28 @@ void main() {
       expect(lex('-.5').realValue, -0.5);
       expect(lex('4.').realValue, 4.0);
     });
+
+    test('large integers parse exactly, matching int.tryParse', () {
+      // The direct byte parser handles ≤18-digit mantissas; longer ones (incl.
+      // the 19-digit int64 max) must fall back to the exact string path.
+      expect(lex('999999999999999999').intValue, 999999999999999999); // 18
+      expect(lex('9223372036854775807').intValue, 9223372036854775807); // max
+      expect(lex('+9223372036854775807').intValue, 9223372036854775807);
+    });
+
+    test('an integer that overflows int64 is malformed', () {
+      // int.tryParse returns null past the 64-bit range; the lexer must throw
+      // rather than silently wrap from the direct parse.
+      expect(() => lex('9223372036854775808'), throwsA(isA<Exception>()));
+      expect(() => lex('99999999999999999999'), throwsA(isA<Exception>()));
+    });
+
+    test('an embedded sign is malformed, not a silent number', () {
+      // `1-2` lexes as one number token; both the direct and string paths
+      // must reject it the same way.
+      expect(() => lex('1-2'), throwsA(isA<Exception>()));
+      expect(() => lex('--5'), throwsA(isA<Exception>()));
+    });
   });
 
   group('names', () {


### PR DESCRIPTION
## What

Rewrites the content-stream tokenizer hot path. Profiling the real-world
corpus showed content-stream parsing dominated the render path (~23 ms/page,
~3× the next interpreter cost), and the split was surprising: inflate is
cheap (1.6 ms/page), **tokenizing was ~34 ms/page** on the VM.

Two byte-identical changes cut tokenize to ~11.5 ms/page (~66%):

1. **Lexer** (`lexer.dart`): numbers, keywords, and escape-free names no longer
   build a per-token `StringBuffer` — they read straight from the byte range
   via `String.fromCharCodes`, which produces the *identical* string. Integers
   parse directly from bytes (≤18 digits; longer mantissas fall back to
   `int.tryParse`, so overflow/malformed input is rejected identically).

2. **ContentStreamParser** (`content_parser.dart`): number operands are taken
   directly instead of through `CosParser.parseObject`, skipping its `N G R`
   reference lookahead. A content stream never holds an indirect reference
   (those live only in the document body), so this matches how reference
   renderers read content — and removes the `_lookahead` list churn that ran on
   every integer operand. Applied inside TJ kerning arrays too.

## Impact (real-world corpus, scale 2, vs PDFium 5.9.0)

| engine | before | after |
|---|---|---|
| **dart-pdf interpret** (pure Dart) | 22.8 ms/page — 1.10× *slower* | **13.6 ms/page — 1.52× faster** |
| **dart-pdf render** (full Flutter raster) | 65.3 ms/page — 3.16× slower | **53.7 ms/page — 2.60× slower** |

The pure-Dart engine now **beats PDFium by ~1.5×**. The remaining render gap is
image decode (native codecs) + GPU rasterize/readback — structural Flutter
costs, not interpreter code (phase split documented in `benchmark/README.md`).

## Byte-identity

- `pdf_cos` (154, incl. new lexer edge-case tests) and `pdf_graphics` (603)
  suites green.
- Ghent render baselines unchanged at **+40 −14**, and all 14 pre-existing
  failure rasters byte-for-byte identical base-vs-after (stash diff `cmp`).
- `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)