### PR TITLE
Show mobile toolbar colours only when relevant to the current tool

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -519,6 +519,12 @@ class PdfEditingController extends ChangeNotifier {
   void useMarkupStyleScope() =>
       preferences.beginStyleScope('markup', const {'color', 'opacity'});
 
+  /// Whether the armed [tool] creates annotations that carry a colour the
+  /// toolbar can offer — i.e. the tool's style scope remembers `color`.
+  /// False for tools that ignore colour (select, eraser, content, form,
+  /// redact, signature), so the colour swatches aren't shown beside them.
+  bool get toolUsesColor => _styleScopeFields(tool).contains('color');
+
   /// The color new annotations are created with. Persisted (these four
   /// style properties live in [preferences]).
   Color get color => preferences.color;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1277,29 +1277,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
               ),
             ]),
           ),
-          if (widget.showColor)
-            for (final color in widget.palette.take(3))
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 3),
-                child: InkWell(
-                  onTap: () => _applyColor(color),
-                  customBorder: const CircleBorder(),
-                  child: Container(
-                    width: 22,
-                    height: 22,
-                    decoration: BoxDecoration(
-                      color: color,
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: controller.color == color
-                            ? scheme.primary
-                            : scheme.outline,
-                        width: controller.color == color ? 3 : 1,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
+          ..._mobileTrailing(context),
           const SizedBox(width: 6),
           _GroupChip.toolsHandle(
             key: const ValueKey('pdf-tools-handle'),
@@ -1308,6 +1286,71 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         ]),
       ),
     );
+  }
+
+  /// The mobile dock's trailing cluster, between the active-tool label and
+  /// the Tools handle. It shows only what's relevant to the moment so the
+  /// colour swatches never sit dead next to a tool that ignores them.
+  /// A selected annotation gets its own quick actions (delete, edit text) —
+  /// the better use of the space the request asks for, since those were
+  /// otherwise unreachable from the dock; an armed colour-using tool gets
+  /// the swatches; anything else leaves the space to the tool label.
+  List<Widget> _mobileTrailing(BuildContext context) {
+    if (controller.hasAnnotationSelection) {
+      return [
+        IconButton(
+          icon: const Icon(Icons.delete_outline),
+          tooltip: switch (controller.selectedAnnotationSlots.length) {
+            1 => 'Delete annotation',
+            final n => 'Delete $n annotations',
+          },
+          visualDensity: VisualDensity.compact,
+          onPressed: controller.deleteSelected,
+        ),
+        if (controller.canEditSelectedText)
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: 'Edit annotation text',
+            visualDensity: VisualDensity.compact,
+            onPressed: () => _editSelectedText(context),
+          ),
+      ];
+    }
+    if (widget.showColor && controller.toolUsesColor) {
+      return _mobileSwatches(context);
+    }
+    return const [];
+  }
+
+  /// The first three palette swatches, sized for the mobile dock.
+  List<Widget> _mobileSwatches(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    var i = 0;
+    return [
+      for (final color in widget.palette.take(3))
+        Padding(
+          key: ValueKey('pdf-mobile-swatch-${i++}'),
+          padding: const EdgeInsets.symmetric(horizontal: 3),
+          child: InkWell(
+            onTap: () => _applyColor(color),
+            customBorder: const CircleBorder(),
+            child: Container(
+              width: 22,
+              height: 22,
+              decoration: BoxDecoration(
+                color: color,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: controller.color == color
+                      ? scheme.primary
+                      : scheme.outline,
+                  width: controller.color == color ? 3 : 1,
+                ),
+              ),
+            ),
+          ),
+        ),
+    ];
   }
 
   IconData _activeToolIcon(PdfEditTool? tool) {

--- a/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// The mobile dock shows its colour swatches only when colour is relevant to
+// the moment — a colour-using tool armed, or a recolourable selection — and
+// gives the space to a selection's quick actions otherwise (Ben: "Only show
+// the colours on the mobile toolbar if it's relevant to the current tool").
+void main() {
+  final swatch = find.byKey(const ValueKey('pdf-mobile-swatch-0'));
+
+  Future<PdfEditingController> pumpToolbar(WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final editing = PdfEditingController(buildAppearanceAnnotationsPdf());
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        // a width under the 600px mobile breakpoint forces the dock layout
+        body: Align(
+          alignment: Alignment.bottomCenter,
+          child: SizedBox(
+            width: 380,
+            child: PdfEditingToolbar(
+                controller: editing, viewerController: viewer),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return editing;
+  }
+
+  test('toolUsesColor: true for painters, false for colourless tools', () {
+    SharedPreferences.setMockInitialValues({});
+    final c = PdfEditingController(buildAppearanceAnnotationsPdf());
+    addTearDown(c.dispose);
+
+    for (final tool in [
+      PdfEditTool.ink,
+      PdfEditTool.rectangle,
+      PdfEditTool.line,
+      PdfEditTool.freeText,
+      PdfEditTool.stamp,
+      PdfEditTool.measureDistance,
+    ]) {
+      c.tool = tool;
+      expect(c.toolUsesColor, isTrue, reason: '$tool paints in colour');
+    }
+    for (final tool in [PdfEditTool.eraser, PdfEditTool.form]) {
+      c.tool = tool;
+      expect(c.toolUsesColor, isFalse, reason: '$tool ignores colour');
+    }
+    c.tool = null;
+    expect(c.toolUsesColor, isFalse, reason: 'select ignores colour');
+  });
+
+  testWidgets('swatches hide for a colourless tool, show for a painter',
+      (tester) async {
+    final editing = await pumpToolbar(tester);
+
+    // resting (Select) — no colour to set
+    expect(swatch, findsNothing);
+
+    editing.tool = PdfEditTool.eraser;
+    await tester.pump();
+    expect(swatch, findsNothing, reason: 'the eraser ignores colour');
+
+    editing.tool = PdfEditTool.ink;
+    await tester.pump();
+    expect(swatch, findsOneWidget, reason: 'ink paints in colour');
+  });
+
+  testWidgets('a selection surfaces quick actions, not creation swatches',
+      (tester) async {
+    final editing = await pumpToolbar(tester);
+    editing.tool = PdfEditTool.ink; // swatches up while a colour tool is armed
+    await tester.pump();
+    expect(swatch, findsOneWidget);
+    expect(find.byIcon(Icons.delete_outline), findsNothing);
+
+    // slot 0 is the Square annotation — selectable, unlike the Link/Widget
+    // entries the link fixture carries; selecting arms the select tool
+    expect(editing.selectAnnotation(0, 0), isTrue);
+    await tester.pump();
+
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget,
+        reason: 'a selected annotation can be deleted from the dock');
+    expect(swatch, findsNothing,
+        reason: 'the creation swatches make way for the selection actions');
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
@@ -70,8 +70,14 @@ void main() {
     expect(swatch, findsNothing, reason: 'the eraser ignores colour');
 
     editing.tool = PdfEditTool.ink;
+    editing.color = const Color(0xFF123456); // a non-palette colour
     await tester.pump();
     expect(swatch, findsOneWidget, reason: 'ink paints in colour');
+
+    // tapping the swatch sets the creation colour
+    await tester.tap(swatch);
+    await tester.pump();
+    expect(editing.color, PdfEditingToolbar.defaultPalette.first);
   });
 
   testWidgets('a selection surfaces quick actions, not creation swatches',
@@ -91,5 +97,11 @@ void main() {
         reason: 'a selected annotation can be deleted from the dock');
     expect(swatch, findsNothing,
         reason: 'the creation swatches make way for the selection actions');
+
+    // and the action works: tapping it removes the annotation
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pump();
+    expect(editing.hasAnnotationSelection, isFalse);
+    expect(editing.isModified, isTrue, reason: 'the annotation was removed');
   });
 }


### PR DESCRIPTION
## What

The mobile editing dock showed three palette swatches next to the active tool **regardless of whether that tool uses colour** — they sat dead beside the eraser, the form/redact tools, and plain select mode.

Now the dock's trailing space is contextual:

- **A colour-using tool is armed** (ink, shapes, lines, free text, stamp, measure…) → the three swatches show, as before.
- **An annotation is selected** → the space goes to that selection's quick actions: **delete** and **edit text** (for text annotations). These were previously unreachable from the mobile dock — only via the on-page selection chip — so this is the "something better to do with the space" the request asked for.
- **Anything else** (eraser, form, redact, resting select) → no swatches; the tool label takes the room.

## How

- `PdfEditingController.toolUsesColor` — true when the armed tool's style scope remembers `color` (reuses the existing per-tool `_styleScopeFields` map), false for the colourless tools.
- `editing_toolbar.dart`: the inline swatch loop in `_buildMobile` is replaced by `_mobileTrailing()` (the contextual cluster) + `_mobileSwatches()` (factored, now keyed `pdf-mobile-swatch-N` for testability).

Keeping delete-actions and creation-swatches mutually exclusive also avoids the narrow-dock horizontal overflow that showing both together produced.

## Tests

`editing_mobile_toolbar_test.dart` (new): `toolUsesColor` truth table, swatches hidden for the eraser and shown for ink, and a selection swapping the swatches for a delete action. Full `dart_pdf_editor` suite analyses clean; `pdf_shell_test` and `editing_touch_toggle_test` pass unchanged.

https://claude.ai/code/session_019oidKJEmVTXtfuPBj12Gvx

---
_Generated by [Claude Code](https://claude.ai/code/session_019oidKJEmVTXtfuPBj12Gvx)_