### PR TITLE
Reflow: surface images/diagrams inline and split lists

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -6,6 +6,9 @@
   text, decoded and laid out at their on-page aspect ratio in reading
   order; bullet/numbered lists read as separate, indented items.
   `PdfReflowView.showImages` (default true) toggles back to text-only.
+  The view now scrolls through a single non-lazy list so the scrollbar
+  no longer jumps as pages of differing heights (text vs. images) come
+  into view.
 
 ## 1.0.0
 

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Reflow reading view: images and diagrams now appear inline with the
+  text, decoded and laid out at their on-page aspect ratio in reading
+  order; bullet/numbered lists read as separate, indented items.
+  `PdfReflowView.showImages` (default true) toggles back to text-only.
+
 ## 1.0.0
 
 First stable release. Highlights since 0.1.0:

--- a/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
@@ -50,6 +50,7 @@ class _ReflowContent {
 class _PdfReflowViewState extends State<PdfReflowView> {
   late Future<_ReflowContent> _content;
   Map<Object, ui.Image> _ownedImages = const {};
+  final ScrollController _scrollController = ScrollController();
 
   @override
   void initState() {
@@ -68,6 +69,7 @@ class _PdfReflowViewState extends State<PdfReflowView> {
 
   @override
   void dispose() {
+    _scrollController.dispose();
     _disposeImages();
     super.dispose();
   }
@@ -130,18 +132,36 @@ class _PdfReflowViewState extends State<PdfReflowView> {
               ),
             );
           }
-          return ListView.builder(
-            key: const ValueKey('pdf-reflow-view'),
-            padding: widget.padding,
-            itemCount: pages.length,
-            itemBuilder: (context, index) => Center(
-              child: ConstrainedBox(
-                constraints: BoxConstraints(maxWidth: widget.maxWidth),
-                child: _ReflowPage(
-                  page: pages[index],
-                  images: content?.images ?? const {},
-                  showImages: widget.showImages,
-                ),
+          // A non-lazy scroll lays every page out once, so the total scroll
+          // extent is exact and the scrollbar thumb stays put. A lazy
+          // ListView estimates the extent from built children, which jumps
+          // as reflow pages of wildly different heights (text vs. tall image
+          // pages) come into view — the heights can't be precomputed because
+          // they depend on text wrap and image aspect ratio.
+          final imageMap = content?.images ?? const <Object, ui.Image>{};
+          return Scrollbar(
+            controller: _scrollController,
+            child: SingleChildScrollView(
+              key: const ValueKey('pdf-reflow-view'),
+              controller: _scrollController,
+              padding: widget.padding,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (final page in pages)
+                    Center(
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(maxWidth: widget.maxWidth),
+                        child: RepaintBoundary(
+                          child: _ReflowPage(
+                            page: page,
+                            images: imageMap,
+                            showImages: widget.showImages,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
               ),
             ),
           );

--- a/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
@@ -1,14 +1,19 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
+import 'image_decoder.dart';
+
 /// A text-first view of a PDF document.
 ///
 /// The PDF page graphics are not rendered here. Instead the content stream is
-/// interpreted for positioned text, then [PdfTextExtractor] infers visual
-/// lines, reading order, and paragraph blocks. This is useful for narrow
-/// screens and accessibility-style reading where fixed page layout is less
-/// important than continuous text.
+/// interpreted for positioned text and images, then [PdfTextExtractor] infers
+/// visual lines, reading order, and paragraph blocks, interleaving the page's
+/// figures and diagrams in place. This is useful for narrow screens and
+/// accessibility-style reading where fixed page layout is less important than
+/// continuous, reflowable content.
 class PdfReflowView extends StatefulWidget {
   const PdfReflowView({
     super.key,
@@ -16,6 +21,7 @@ class PdfReflowView extends StatefulWidget {
     this.backgroundColor,
     this.padding = const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
     this.maxWidth = 760,
+    this.showImages = true,
   });
 
   final PdfDocument document;
@@ -23,35 +29,80 @@ class PdfReflowView extends StatefulWidget {
   final EdgeInsetsGeometry padding;
   final double maxWidth;
 
+  /// Whether to interleave the page's images and diagrams with the text.
+  /// When false the view is text-only (the historical behaviour).
+  final bool showImages;
+
   @override
   State<PdfReflowView> createState() => _PdfReflowViewState();
 }
 
+class _ReflowContent {
+  const _ReflowContent(this.pages, this.images);
+
+  final List<PdfReflowPage> pages;
+
+  /// Decoded images keyed by [pdfImageKey]; a key is absent when the image
+  /// could not be decoded.
+  final Map<Object, ui.Image> images;
+}
+
 class _PdfReflowViewState extends State<PdfReflowView> {
-  late Future<List<PdfReflowPage>> _pages;
+  late Future<_ReflowContent> _content;
+  Map<Object, ui.Image> _ownedImages = const {};
 
   @override
   void initState() {
     super.initState();
-    _pages = _loadPages();
+    _content = _load();
   }
 
   @override
   void didUpdateWidget(PdfReflowView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(widget.document, oldWidget.document)) {
-      _pages = _loadPages();
+    if (!identical(widget.document, oldWidget.document) ||
+        widget.showImages != oldWidget.showImages) {
+      _content = _load();
     }
   }
 
-  Future<List<PdfReflowPage>> _loadPages() async {
+  @override
+  void dispose() {
+    _disposeImages();
+    super.dispose();
+  }
+
+  void _disposeImages() {
+    for (final image in _ownedImages.values) {
+      image.dispose();
+    }
+    _ownedImages = const {};
+  }
+
+  Future<_ReflowContent> _load() async {
     // Give the first frame a chance to show progress before long documents walk
     // every content stream.
     await Future<void>.delayed(Duration.zero);
-    return [
+    final pages = [
       for (var i = 0; i < widget.document.pageCount; i++)
         PdfTextExtractor.reflowPage(widget.document, i),
     ];
+    var images = const <Object, ui.Image>{};
+    if (widget.showImages) {
+      final requests = [
+        for (final page in pages)
+          for (final image in page.images) image.request,
+      ];
+      if (requests.isNotEmpty) {
+        images = await decodeImages(widget.document.cos, requests,
+            cache: PdfImageCache.instance);
+      }
+    }
+    // The decoded clones are ours to dispose; drop the previous load's set
+    // and hold the new one for the widget's life (and reloads).
+    _disposeImages();
+    _ownedImages = images;
+    return _ReflowContent(pages, images);
   }
 
   @override
@@ -61,17 +112,20 @@ class _PdfReflowViewState extends State<PdfReflowView> {
         widget.backgroundColor ?? theme.colorScheme.surfaceContainerLowest;
     return ColoredBox(
       color: background,
-      child: FutureBuilder<List<PdfReflowPage>>(
-        future: _pages,
+      child: FutureBuilder<_ReflowContent>(
+        future: _content,
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
-          final pages = snapshot.data ?? const <PdfReflowPage>[];
-          if (pages.every((page) => page.blocks.isEmpty)) {
+          final content = snapshot.data;
+          final pages = content?.pages ?? const <PdfReflowPage>[];
+          bool empty(PdfReflowPage page) =>
+              widget.showImages ? page.items.isEmpty : page.blocks.isEmpty;
+          if (pages.every(empty)) {
             return Center(
               child: Text(
-                'No extractable text',
+                'No extractable content',
                 style: theme.textTheme.bodyLarge,
               ),
             );
@@ -83,7 +137,11 @@ class _PdfReflowViewState extends State<PdfReflowView> {
             itemBuilder: (context, index) => Center(
               child: ConstrainedBox(
                 constraints: BoxConstraints(maxWidth: widget.maxWidth),
-                child: _ReflowPage(page: pages[index]),
+                child: _ReflowPage(
+                  page: pages[index],
+                  images: content?.images ?? const {},
+                  showImages: widget.showImages,
+                ),
               ),
             ),
           );
@@ -94,13 +152,22 @@ class _PdfReflowViewState extends State<PdfReflowView> {
 }
 
 class _ReflowPage extends StatelessWidget {
-  const _ReflowPage({required this.page});
+  const _ReflowPage({
+    required this.page,
+    required this.images,
+    required this.showImages,
+  });
 
   final PdfReflowPage page;
+  final Map<Object, ui.Image> images;
+  final bool showImages;
 
   @override
   Widget build(BuildContext context) {
-    if (page.blocks.isEmpty) return const SizedBox.shrink();
+    final items = showImages
+        ? page.items
+        : page.items.whereType<PdfReflowBlock>().toList();
+    if (items.isEmpty) return const SizedBox.shrink();
     final theme = Theme.of(context);
     final median = _median(page.blocks.map((block) => block.fontSize));
     return Padding(
@@ -115,15 +182,48 @@ class _ReflowPage extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 12),
-          for (final block in page.blocks)
+          for (final item in items)
             Padding(
               padding: const EdgeInsets.only(bottom: 12),
-              child: SelectableText(
-                block.text,
-                style: _styleFor(theme, block, median),
-              ),
+              child: switch (item) {
+                final PdfReflowBlock block => _block(theme, block, median),
+                final PdfReflowImage image => _image(theme, image),
+              },
             ),
         ],
+      ),
+    );
+  }
+
+  Widget _block(ThemeData theme, PdfReflowBlock block, double pageMedian) {
+    final text = SelectableText(
+      block.text,
+      style: _styleFor(theme, block, pageMedian),
+    );
+    if (!block.isListItem) return text;
+    // Hang the wrapped lines under the marker's text.
+    return Padding(
+      padding: const EdgeInsets.only(left: 16),
+      child: text,
+    );
+  }
+
+  Widget _image(ThemeData theme, PdfReflowImage image) {
+    final decoded = images[pdfImageKey(image.request)];
+    if (decoded == null) {
+      // Undecodable (or images turned off): leave a labelled placeholder so the
+      // reading position still reflects that something sat here.
+      return _ImagePlaceholder(aspectRatio: image.aspectRatio);
+    }
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(4),
+      child: AspectRatio(
+        aspectRatio: image.aspectRatio <= 0 ? 1 : image.aspectRatio,
+        child: RawImage(
+          image: decoded,
+          fit: BoxFit.contain,
+          filterQuality: FilterQuality.medium,
+        ),
       ),
     );
   }
@@ -138,6 +238,32 @@ class _ReflowPage extends StatelessWidget {
       fontWeight: block.fontSize >= pageMedian * 1.3
           ? FontWeight.w600
           : base.fontWeight,
+    );
+  }
+}
+
+class _ImagePlaceholder extends StatelessWidget {
+  const _ImagePlaceholder({required this.aspectRatio});
+
+  final double aspectRatio;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AspectRatio(
+      aspectRatio: aspectRatio <= 0 ? 1 : aspectRatio,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Center(
+          child: Icon(
+            Icons.image_outlined,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
@@ -44,6 +44,36 @@ Uint8List _doc(String content,
   ]);
 }
 
+/// A multi-page PDF; every page shares the `/F1` font and `/Im0` image
+/// resources, with [contents] supplying each page's content stream.
+Uint8List _multiPageDoc(List<String> contents) {
+  const hex = 'FF000000FF000000FFFFFFFF>';
+  final n = contents.length;
+  final fontObj = 3 + 2 * n;
+  final imageObj = 4 + 2 * n;
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [${[
+      for (var i = 0; i < n; i++) '${3 + 2 * i} 0 R'
+    ].join(' ')}] /Count $n >>',
+  ];
+  for (var i = 0; i < n; i++) {
+    final contentObj = 4 + 2 * i;
+    objects
+      ..add('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+          '/Contents $contentObj 0 R /Resources << /Font << /F1 $fontObj 0 R >> '
+          '/XObject << /Im0 $imageObj 0 R >> >> >>')
+      ..add('<< /Length ${contents[i].length} >>\n'
+          'stream\n${contents[i]}\nendstream');
+  }
+  objects
+    ..add('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>')
+    ..add('<< /Type /XObject /Subtype /Image /Width 2 /Height 2 '
+        '/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /ASCIIHexDecode '
+        '/Length ${hex.length} >>\nstream\n$hex\nendstream');
+  return _assemble(objects);
+}
+
 String _text(num x, num y, String text, {int size = 12}) =>
     'BT /F1 $size Tf $x $y Td ($text) Tj ET';
 
@@ -144,6 +174,42 @@ void main() {
       await _settle(tester);
 
       expect(find.text('No extractable content'), findsOneWidget);
+    });
+  });
+
+  testWidgets('scroll extent stays stable across scrolling', (tester) async {
+    await tester.runAsync(() async {
+      // Alternate tall image pages with short text pages: a lazy ListView's
+      // extent estimate would drift as the differing heights build, jumping
+      // the scrollbar. The non-lazy scroll keeps it exact.
+      final doc = PdfDocument.open(_multiPageDoc([
+        for (var i = 0; i < 6; i++)
+          i.isEven
+              ? '$_imageContent\n${_text(100, 440, 'Image page $i')}'
+              : _text(100, 700, 'Text page $i'),
+      ]));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: doc)),
+      ));
+      await _settle(tester);
+
+      // The outer scroll view's Scrollable is the first descendant of the
+      // keyed widget (the SelectableTexts add their own deeper ones).
+      final position = tester
+          .state<ScrollableState>(find
+              .descendant(
+                of: find.byKey(const ValueKey('pdf-reflow-view')),
+                matching: find.byType(Scrollable),
+              )
+              .first)
+          .position;
+      final before = position.maxScrollExtent;
+      expect(before, greaterThan(0));
+
+      position.jumpTo(position.maxScrollExtent);
+      await tester.pump();
+      // Exact extent: jumping to the end does not revise it.
+      expect(position.maxScrollExtent, before);
     });
   });
 

--- a/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
@@ -6,24 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
-/// A one-page PDF with two text paragraphs and a decodable 2×2 DeviceRGB image
-/// drawn between them.
-Uint8List _imagePdf() {
-  const hex = 'FF000000FF000000FFFFFFFF>';
-  const content = 'BT /F1 12 Tf 100 700 Td (Above the figure) Tj ET\n'
-      'q 200 0 0 120 100 480 cm /Im0 Do Q\n'
-      'BT /F1 12 Tf 100 360 Td (Below the figure) Tj ET';
-  final objects = <String>[
-    '<< /Type /Catalog /Pages 2 0 R >>',
-    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
-    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R '
-        '/Resources << /Font << /F1 5 0 R >> /XObject << /Im0 6 0 R >> >> >>',
-    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
-    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
-    '<< /Type /XObject /Subtype /Image /Width 2 /Height 2 '
-        '/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /ASCIIHexDecode '
-        '/Length ${hex.length} >>\nstream\n$hex\nendstream',
-  ];
+Uint8List _assemble(List<String> objects) {
   final buffer = StringBuffer('%PDF-1.4\n');
   final offsets = <int>[];
   for (var i = 0; i < objects.length; i++) {
@@ -43,13 +26,40 @@ Uint8List _imagePdf() {
   return ascii(buffer.toString());
 }
 
-Future<void> _settleReflow(WidgetTester tester) async {
-  // The view loads pages and decodes images off the first frame; poll until the
-  // FutureBuilder resolves (decoding needs real async via runAsync).
-  for (var i = 0; i < 50; i++) {
+/// A one-page PDF whose content is [content]; an `/Im0` image XObject (its
+/// stream body is [imageHex] decoded as ASCII-hex) and an `/F1` Helvetica
+/// font are available as resources.
+Uint8List _doc(String content,
+    {String imageHex = 'FF000000FF000000FFFFFFFF>'}) {
+  return _assemble([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R '
+        '/Resources << /Font << /F1 5 0 R >> /XObject << /Im0 6 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Type /XObject /Subtype /Image /Width 2 /Height 2 '
+        '/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /ASCIIHexDecode '
+        '/Length ${imageHex.length} >>\nstream\n$imageHex\nendstream',
+  ]);
+}
+
+String _text(num x, num y, String text, {int size = 12}) =>
+    'BT /F1 $size Tf $x $y Td ($text) Tj ET';
+
+const _imageContent = 'q 200 0 0 120 100 480 cm /Im0 Do Q';
+
+Uint8List _imagePdf() => _doc('${_text(100, 700, 'Above the figure')}\n'
+    '$_imageContent\n'
+    '${_text(100, 360, 'Below the figure')}');
+
+/// Pumps frames (driving real async for image decoding) until the
+/// FutureBuilder resolves and the loading spinner disappears.
+Future<void> _settle(WidgetTester tester) async {
+  for (var i = 0; i < 60; i++) {
     await tester.pump(const Duration(milliseconds: 16));
     await Future<void>.delayed(const Duration(milliseconds: 5));
-    if (find.text('Above the figure').evaluate().isNotEmpty) return;
+    if (find.byType(CircularProgressIndicator).evaluate().isEmpty) return;
   }
 }
 
@@ -60,7 +70,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(body: PdfReflowView(document: doc)),
       ));
-      await _settleReflow(tester);
+      await _settle(tester);
 
       expect(find.text('Above the figure'), findsOneWidget);
       expect(find.text('Below the figure'), findsOneWidget);
@@ -76,10 +86,84 @@ void main() {
           body: PdfReflowView(document: doc, showImages: false),
         ),
       ));
-      await _settleReflow(tester);
+      await _settle(tester);
 
       expect(find.text('Above the figure'), findsOneWidget);
       expect(find.byType(RawImage), findsNothing);
+    });
+  });
+
+  testWidgets('styles a heading and indents a list item', (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(_doc('${_text(100, 720, 'Big Heading', size: 24)}\n'
+          '${_text(100, 680, '- first item')}\n'
+          '${_text(100, 664, '- second item')}'));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: doc)),
+      ));
+      await _settle(tester);
+
+      expect(find.text('Big Heading'), findsOneWidget);
+      // The list items render and hang under a left-indent Padding.
+      expect(find.text('- first item'), findsOneWidget);
+      final indented = tester.widgetList<Padding>(find.ancestor(
+        of: find.text('- first item'),
+        matching: find.byType(Padding),
+      ));
+      expect(
+        indented.any((p) =>
+            p.padding.resolve(TextDirection.ltr).left == 16),
+        isTrue,
+      );
+    });
+  });
+
+  testWidgets('falls back to a placeholder for an undecodable image',
+      (tester) async {
+    await tester.runAsync(() async {
+      // The image declares 2x2 RGB (12 bytes) but provides one byte: decode
+      // fails, so the view surfaces a labelled placeholder instead.
+      final doc = PdfDocument.open(_doc(_imageContent, imageHex: '00>'));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: doc)),
+      ));
+      await _settle(tester);
+
+      expect(find.byType(RawImage), findsNothing);
+      expect(find.byIcon(Icons.image_outlined), findsOneWidget);
+    });
+  });
+
+  testWidgets('shows a message when there is no extractable content',
+      (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(_doc('')); // blank page
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: doc)),
+      ));
+      await _settle(tester);
+
+      expect(find.text('No extractable content'), findsOneWidget);
+    });
+  });
+
+  testWidgets('reloads when the document changes', (tester) async {
+    await tester.runAsync(() async {
+      final first = PdfDocument.open(_imagePdf());
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: first)),
+      ));
+      await _settle(tester);
+      expect(find.text('Above the figure'), findsOneWidget);
+
+      final second = PdfDocument.open(_doc(_text(100, 700, 'A different page')));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: second)),
+      ));
+      await _settle(tester);
+
+      expect(find.text('Above the figure'), findsNothing);
+      expect(find.text('A different page'), findsOneWidget);
     });
   });
 }

--- a/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// A one-page PDF with two text paragraphs and a decodable 2×2 DeviceRGB image
+/// drawn between them.
+Uint8List _imagePdf() {
+  const hex = 'FF000000FF000000FFFFFFFF>';
+  const content = 'BT /F1 12 Tf 100 700 Td (Above the figure) Tj ET\n'
+      'q 200 0 0 120 100 480 cm /Im0 Do Q\n'
+      'BT /F1 12 Tf 100 360 Td (Below the figure) Tj ET';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R '
+        '/Resources << /Font << /F1 5 0 R >> /XObject << /Im0 6 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Type /XObject /Subtype /Image /Width 2 /Height 2 '
+        '/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /ASCIIHexDecode '
+        '/Length ${hex.length} >>\nstream\n$hex\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
+Future<void> _settleReflow(WidgetTester tester) async {
+  // The view loads pages and decodes images off the first frame; poll until the
+  // FutureBuilder resolves (decoding needs real async via runAsync).
+  for (var i = 0; i < 50; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    if (find.text('Above the figure').evaluate().isNotEmpty) return;
+  }
+}
+
+void main() {
+  testWidgets('renders a placed image inline with the text', (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(_imagePdf());
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: doc)),
+      ));
+      await _settleReflow(tester);
+
+      expect(find.text('Above the figure'), findsOneWidget);
+      expect(find.text('Below the figure'), findsOneWidget);
+      expect(find.byType(RawImage), findsOneWidget);
+    });
+  });
+
+  testWidgets('showImages: false reads text-only, no image', (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(_imagePdf());
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfReflowView(document: doc, showImages: false),
+        ),
+      ));
+      await _settleReflow(tester);
+
+      expect(find.text('Above the figure'), findsOneWidget);
+      expect(find.byType(RawImage), findsNothing);
+    });
+  });
+}

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Reflow: `PdfReflowPage` now exposes `items` — text blocks and images
+  interleaved in reading order (`PdfReflowItem`/`PdfReflowImage`, with the
+  `blocks`/`images`/`text` getters unchanged). The extractor records placed
+  images with their page-space bounds and folds each into the read where it
+  sits, drops decorative rules and tiny icons, and de-duplicates repeated
+  watermarks. Bullet and numbered list items are split into their own
+  blocks (`PdfReflowBlock.isListItem`) instead of folding into the prose.
+
 ## 1.0.0
 
 First stable release. Changes since 0.1.0:

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -207,37 +207,88 @@ class PdfReflowLine {
   final double fontSize;
 }
 
+/// One item in a reflowed page, placed in inferred reading order: either a
+/// text [PdfReflowBlock] or a [PdfReflowImage].
+sealed class PdfReflowItem {
+  const PdfReflowItem();
+
+  /// Page-space bounds of the item.
+  PdfRect get bounds;
+}
+
 /// One paragraph-like block in reading order.
-class PdfReflowBlock {
+class PdfReflowBlock extends PdfReflowItem {
   const PdfReflowBlock({
     required this.text,
     required this.bounds,
     required this.lines,
     required this.fontSize,
+    this.isListItem = false,
   });
 
   /// Text with line breaks removed and soft hyphens repaired.
   final String text;
 
   /// Page-space bounds of the source lines.
+  @override
   final PdfRect bounds;
 
   final List<PdfReflowLine> lines;
 
   /// Median source font size for display heuristics.
   final double fontSize;
+
+  /// True when the block begins with a bullet or numbered list marker, so a
+  /// reading view can indent it instead of folding it into the prose.
+  final bool isListItem;
 }
 
-/// A page's text reduced to paragraph blocks in inferred reading order.
+/// An image or diagram placed on the page, surfaced in the reflow view in
+/// reading order. The pixels are not decoded here ([pdf_graphics] is
+/// VM-only); decode [request] with the renderer's `decodeImages` to display
+/// it.
+class PdfReflowImage extends PdfReflowItem {
+  const PdfReflowImage({
+    required this.request,
+    required this.bounds,
+  });
+
+  /// The interpreter's draw request — carries the image stream and the
+  /// unit-square → page-space transform.
+  final PdfImageRequest request;
+
+  /// Page-space bounds the image was painted into.
+  @override
+  final PdfRect bounds;
+
+  /// Width over height of the placed image (1 when degenerate), for laying
+  /// the image out at its on-page aspect ratio.
+  double get aspectRatio =>
+      bounds.height <= 0 ? 1 : bounds.width / bounds.height;
+}
+
+/// A page's content reduced to text paragraph blocks and images in inferred
+/// reading order.
 class PdfReflowPage {
   const PdfReflowPage({
     required this.pageIndex,
-    required this.blocks,
+    required this.items,
   });
 
   final int pageIndex;
-  final List<PdfReflowBlock> blocks;
 
+  /// Text blocks and images interleaved in reading order.
+  final List<PdfReflowItem> items;
+
+  /// The text blocks only, in reading order.
+  List<PdfReflowBlock> get blocks =>
+      [for (final item in items) if (item is PdfReflowBlock) item];
+
+  /// The images only, in reading order.
+  List<PdfReflowImage> get images =>
+      [for (final item in items) if (item is PdfReflowImage) item];
+
+  /// The reading-order text — blocks joined with blank lines (images skipped).
   String get text => blocks.map((block) => block.text).join('\n\n');
 }
 
@@ -256,15 +307,21 @@ class PdfReflowDocument {
 class PdfTextExtractor {
   PdfTextExtractor._();
 
-  static PdfPageText extract(PdfDocument document, int pageIndex) {
+  static PdfPageText extract(PdfDocument document, int pageIndex) =>
+      _pageTextFrom(pageIndex, _interpret(document, pageIndex).runs);
+
+  static _ExtractionDevice _interpret(PdfDocument document, int pageIndex) {
     final device = _ExtractionDevice();
     PdfInterpreter(cos: document.cos, device: device)
         .drawPage(document.page(pageIndex));
+    return device;
+  }
 
+  static PdfPageText _pageTextFrom(int pageIndex, List<PdfTextRun> deviceRuns) {
     final buffer = StringBuffer();
     final runs = <PdfExtractedRun>[];
     PdfTextRun? previous;
-    for (final run in device.runs) {
+    for (final run in deviceRuns) {
       if (previous != null) {
         buffer.write(_separator(previous, run));
       }
@@ -295,9 +352,15 @@ class PdfTextExtractor {
         ],
       );
 
-  /// Extracts one page and infers paragraph blocks in reading order.
-  static PdfReflowPage reflowPage(PdfDocument document, int pageIndex) =>
-      PdfTextReflower.reflow(extract(document, pageIndex));
+  /// Extracts one page and infers paragraph blocks and images in reading
+  /// order.
+  static PdfReflowPage reflowPage(PdfDocument document, int pageIndex) {
+    final device = _interpret(document, pageIndex);
+    return PdfTextReflower.reflow(
+      _pageTextFrom(pageIndex, device.runs),
+      images: device.images,
+    );
+  }
 
   /// Joins consecutive runs: nothing when they abut (kerning splits inside a
   /// word), a space within a line, a newline on baseline changes.
@@ -318,16 +381,109 @@ class PdfTextExtractor {
 class PdfTextReflower {
   PdfTextReflower._();
 
-  static PdfReflowPage reflow(PdfPageText page) {
+  static PdfReflowPage reflow(PdfPageText page,
+      {List<PdfImageRequest> images = const []}) {
+    final reflowImages = _imagesFrom(images);
     final lines = _visualLines(page.runs);
     if (lines.isEmpty) {
-      return PdfReflowPage(pageIndex: page.pageIndex, blocks: const []);
+      // An image-only page (a scan, a full-page figure) still reads top-down.
+      return PdfReflowPage(
+        pageIndex: page.pageIndex,
+        items: _topDownItems(reflowImages),
+      );
     }
     final ordered = _orderLines(lines);
     return PdfReflowPage(
       pageIndex: page.pageIndex,
-      blocks: _paragraphs(ordered),
+      items: _interleave(_paragraphs(ordered), reflowImages),
     );
+  }
+
+  /// Drops decorative images (rules, spacers, tiny icons) and near-duplicate
+  /// re-draws (tiled backgrounds, repeated watermarks), keeping the figures
+  /// and diagrams a reader cares about.
+  static List<PdfReflowImage> _imagesFrom(List<PdfImageRequest> requests) {
+    const minSide = 24.0;
+    final out = <PdfReflowImage>[];
+    for (final request in requests) {
+      final bounds = _imageBounds(request.transform);
+      if (bounds.width < minSide || bounds.height < minSide) continue;
+      final duplicate = out.any((existing) =>
+          identical(existing.request.stream, request.stream) &&
+          _overlapFraction(existing.bounds, bounds) > 0.9);
+      if (duplicate) continue;
+      out.add(PdfReflowImage(request: request, bounds: bounds));
+    }
+    return out;
+  }
+
+  /// Page-space bounds of the unit image square under [transform].
+  static PdfRect _imageBounds(PdfMatrix transform) {
+    final xs = [
+      transform.transformX(0, 0),
+      transform.transformX(1, 0),
+      transform.transformX(1, 1),
+      transform.transformX(0, 1),
+    ];
+    final ys = [
+      transform.transformY(0, 0),
+      transform.transformY(1, 0),
+      transform.transformY(1, 1),
+      transform.transformY(0, 1),
+    ];
+    return PdfRect(xs.reduce(math.min), ys.reduce(math.min),
+        xs.reduce(math.max), ys.reduce(math.max));
+  }
+
+  /// Sorts reflow items top-to-bottom, then left-to-right.
+  static List<PdfReflowItem> _topDownItems(Iterable<PdfReflowItem> items) =>
+      [...items]..sort((a, b) {
+          final y = b.bounds.top.compareTo(a.bounds.top);
+          return y != 0 ? y : a.bounds.left.compareTo(b.bounds.left);
+        });
+
+  /// Folds images into the ordered text blocks. Each image inherits the
+  /// reading position of the nearest text block above it (in the same
+  /// column), so a figure lands where it sits on the page even in a
+  /// multi-column read; an image with no text above falls back to its
+  /// vertical position.
+  static List<PdfReflowItem> _interleave(
+      List<PdfReflowBlock> blocks, List<PdfReflowImage> images) {
+    if (images.isEmpty) return List<PdfReflowItem>.from(blocks);
+    final keyed = <(double, PdfReflowItem)>[
+      for (var i = 0; i < blocks.length; i++) (i.toDouble(), blocks[i]),
+      for (final image in images) (_imageOrderKey(image, blocks), image),
+    ];
+    keyed.sort((a, b) {
+      final k = a.$1.compareTo(b.$1);
+      return k != 0 ? k : b.$2.bounds.top.compareTo(a.$2.bounds.top);
+    });
+    return [for (final entry in keyed) entry.$2];
+  }
+
+  static double _imageOrderKey(
+      PdfReflowImage image, List<PdfReflowBlock> blocks) {
+    var follow = -1;
+    var bestGap = double.infinity;
+    for (var i = 0; i < blocks.length; i++) {
+      final b = blocks[i].bounds;
+      final overlap = _horizontalOverlap(b, image.bounds);
+      if (overlap <= math.min(b.width, image.bounds.width) * 0.1) continue;
+      final gap = b.bottom - image.bounds.top; // >= 0 when the block is above
+      if (gap >= 0 && gap < bestGap) {
+        bestGap = gap;
+        follow = i;
+      }
+    }
+    if (follow >= 0) return follow + 0.5;
+    // No overlapping block above: drop the image after the last block whose
+    // top sits above the image's vertical centre.
+    final centerY = (image.bounds.bottom + image.bounds.top) / 2;
+    var fallback = -1;
+    for (var i = 0; i < blocks.length; i++) {
+      if (blocks[i].bounds.top >= centerY) fallback = i;
+    }
+    return fallback + 0.5;
   }
 
   static List<PdfReflowLine> _visualLines(List<PdfExtractedRun> runs) {
@@ -481,7 +637,11 @@ class PdfTextReflower {
     var current = <PdfReflowLine>[];
     PdfReflowLine? previous;
     for (final line in lines) {
-      if (previous != null && _startsParagraph(previous, line)) {
+      // A bullet/numbered marker always begins a fresh block, so a list reads
+      // as separate items instead of collapsing into one run-on paragraph.
+      final newBlock = previous != null &&
+          (_startsListItem(line.text) || _startsParagraph(previous, line));
+      if (newBlock) {
         blocks.add(_blockFrom(current));
         current = <PdfReflowLine>[];
       }
@@ -491,6 +651,14 @@ class PdfTextReflower {
     if (current.isNotEmpty) blocks.add(_blockFrom(current));
     return blocks;
   }
+
+  /// A line that opens with a bullet glyph or an enumerator (`1.`, `a)`,
+  /// `(iv)`) followed by whitespace — the start of a list item.
+  static final RegExp _listMarker = RegExp(
+      r'^\s*([•‣◦⁃∙·▪●❖*\-–—]'
+      r'|\(?([0-9]{1,3}|[A-Za-z]|[ivxlcdmIVXLCDM]{1,5})[.)])\s+\S');
+
+  static bool _startsListItem(String text) => _listMarker.hasMatch(text);
 
   static bool _startsParagraph(PdfReflowLine previous, PdfReflowLine next) {
     final font = (previous.fontSize + next.fontSize) / 2;
@@ -526,6 +694,7 @@ class PdfTextReflower {
       bounds: _union(lines.map((line) => line.bounds)),
       lines: List.unmodifiable(lines),
       fontSize: _median(lines.map((line) => line.fontSize)),
+      isListItem: lines.isNotEmpty && _startsListItem(lines.first.text),
     );
   }
 }
@@ -606,6 +775,17 @@ PdfRect _union(Iterable<PdfRect> rects) {
 double _horizontalOverlap(PdfRect a, PdfRect b) =>
     math.max(0.0, math.min(a.right, b.right) - math.max(a.left, b.left));
 
+/// Area of the intersection of [a] and [b] over the smaller of their areas
+/// (0 when they don't overlap, 1 when one contains the other).
+double _overlapFraction(PdfRect a, PdfRect b) {
+  final w = _horizontalOverlap(a, b);
+  final h = math.max(0.0, math.min(a.top, b.top) - math.max(a.bottom, b.bottom));
+  final overlap = w * h;
+  if (overlap <= 0) return 0;
+  final smaller = math.min(a.width * a.height, b.width * b.height);
+  return smaller <= 0 ? 0 : overlap / smaller;
+}
+
 double _median(Iterable<double> values) {
   final sorted = [...values]..sort();
   if (sorted.isEmpty) return 0;
@@ -619,6 +799,7 @@ String _normalizeSpaces(String text) =>
 
 class _ExtractionDevice implements PdfDevice {
   final List<PdfTextRun> runs = [];
+  final List<PdfImageRequest> images = [];
 
   @override
   void drawText(PdfTextRun run) => runs.add(run);
@@ -639,7 +820,7 @@ class _ExtractionDevice implements PdfDevice {
   @override
   void clipPath(PdfPath path, PdfFillRule rule) {}
   @override
-  void drawImage(PdfImageRequest request) {}
+  void drawImage(PdfImageRequest request) => images.add(request);
 
   @override
   void setBlendMode(PdfBlendMode mode) {}

--- a/packages/pdf_graphics/test/text_extraction_test.dart
+++ b/packages/pdf_graphics/test/text_extraction_test.dart
@@ -164,6 +164,79 @@ void main() {
 
     expect(page.text, 'paragraph text');
   });
+
+  test('reflow splits a bullet list into separate list items', () {
+    final doc = PdfDocument.open(_buildTextPdf([
+      _textAt(72, 720, 'Shopping list'),
+      _textAt(72, 700, '- apples'),
+      _textAt(72, 686, '- pears'),
+      _textAt(72, 672, '1. flour'),
+    ]));
+
+    final page = PdfTextExtractor.reflowPage(doc, 0);
+
+    expect(page.blocks.map((block) => block.text), [
+      'Shopping list',
+      '- apples',
+      '- pears',
+      '1. flour',
+    ]);
+    expect(page.blocks.map((block) => block.isListItem),
+        [false, true, true, true]);
+  });
+
+  test('reflow surfaces a placed image among the text in reading order', () {
+    final doc = PdfDocument.open(_buildImagePdf());
+    final page = PdfTextExtractor.reflowPage(doc, 0);
+
+    // The image (drawn at y 500..620) sits between the two paragraphs.
+    expect(page.items, hasLength(3));
+    expect(page.items[0], isA<PdfReflowBlock>());
+    expect((page.items[0] as PdfReflowBlock).text, 'Above the figure');
+    expect(page.items[1], isA<PdfReflowImage>());
+    expect((page.items[2] as PdfReflowBlock).text, 'Below the figure');
+
+    final image = page.images.single;
+    expect(image.bounds.left, closeTo(100, 1e-6));
+    expect(image.bounds.right, closeTo(300, 1e-6));
+    expect(image.aspectRatio, closeTo(200 / 120, 1e-6));
+    // text-only view ignores images
+    expect(page.text, 'Above the figure\n\nBelow the figure');
+  });
+
+  test('reflow drops a tiny decorative image', () {
+    final doc = PdfDocument.open(_buildImagePdf(imageWidth: 8, imageHeight: 8));
+    final page = PdfTextExtractor.reflowPage(doc, 0);
+    expect(page.images, isEmpty);
+    expect(page.blocks, hasLength(2));
+  });
+}
+
+/// A one-page PDF with two text paragraphs and a single image XObject drawn
+/// between them via `cm`/`Do`. The image is placed at (100, 500) sized
+/// [imageWidth]×[imageHeight] in page units. The pixel data is ASCII-hex so
+/// the whole file stays 7-bit (reflow only records the draw request, but the
+/// fixture stays decodable for parity).
+Uint8List _buildImagePdf({double imageWidth = 200, double imageHeight = 120}) {
+  // 2×2 DeviceRGB: red, green, blue, white.
+  const hex = 'FF000000FF000000FFFFFFFF>';
+  final content = [
+    _textAt(100, 700, 'Above the figure'),
+    'q $imageWidth 0 0 $imageHeight 100 500 cm /Im0 Do Q',
+    _textAt(100, 400, 'Below the figure'),
+  ].join('\n');
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R '
+        '/Resources << /Font << /F1 5 0 R >> /XObject << /Im0 6 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Type /XObject /Subtype /Image /Width 2 /Height 2 '
+        '/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /ASCIIHexDecode '
+        '/Length ${hex.length} >>\nstream\n$hex\nendstream',
+  ];
+  return _assemblePdf(objects);
 }
 
 String _textAt(num x, num y, String text) =>
@@ -182,6 +255,10 @@ Uint8List _buildTextPdf(List<String> operations) {
     '<< /Length ${content.length} >>\nstream\n$content\nendstream',
     '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
   ];
+  return _assemblePdf(objects);
+}
+
+Uint8List _assemblePdf(List<String> objects) {
   final buffer = StringBuffer('%PDF-1.4\n');
   final offsets = <int>[];
   for (var i = 0; i < objects.length; i++) {

--- a/packages/pdf_graphics/test/text_extraction_test.dart
+++ b/packages/pdf_graphics/test/text_extraction_test.dart
@@ -210,6 +210,47 @@ void main() {
     expect(page.images, isEmpty);
     expect(page.blocks, hasLength(2));
   });
+
+  test('reflow orders an image-only page top to bottom', () {
+    final doc = PdfDocument.open(_imageDocWith(
+      'q 200 0 0 120 100 600 cm /Im0 Do Q\n'
+      'q 200 0 0 120 100 200 cm /Im0 Do Q',
+    ));
+    final page = PdfTextExtractor.reflowPage(doc, 0);
+
+    expect(page.blocks, isEmpty);
+    expect(page.text, '');
+    // Same stream, but distinct placements: both survive de-duplication and
+    // read highest-first.
+    expect(page.images, hasLength(2));
+    expect(page.images.first.bounds.bottom, closeTo(600, 1e-6));
+    expect(page.images.last.bounds.bottom, closeTo(200, 1e-6));
+  });
+
+  test('reflow de-duplicates a repeated watermark image', () {
+    final doc = PdfDocument.open(_imageDocWith([
+      _textAt(100, 700, 'Body text'),
+      'q 300 0 0 300 100 300 cm /Im0 Do Q',
+      'q 300 0 0 300 100 300 cm /Im0 Do Q',
+    ].join('\n')));
+    final page = PdfTextExtractor.reflowPage(doc, 0);
+
+    expect(page.images, hasLength(1));
+    expect(page.blocks.map((block) => block.text), ['Body text']);
+  });
+
+  test('reflow places an image above all text first', () {
+    final doc = PdfDocument.open(_imageDocWith([
+      'q 200 0 0 80 100 690 cm /Im0 Do Q', // top of the page, above all text
+      _textAt(100, 600, 'First paragraph'),
+      _textAt(100, 400, 'Second paragraph'),
+    ].join('\n')));
+    final page = PdfTextExtractor.reflowPage(doc, 0);
+
+    expect(page.items.first, isA<PdfReflowImage>());
+    expect((page.items[1] as PdfReflowBlock).text, 'First paragraph');
+    expect((page.items[2] as PdfReflowBlock).text, 'Second paragraph');
+  });
 }
 
 /// A one-page PDF with two text paragraphs and a single image XObject drawn
@@ -217,14 +258,18 @@ void main() {
 /// [imageWidth]×[imageHeight] in page units. The pixel data is ASCII-hex so
 /// the whole file stays 7-bit (reflow only records the draw request, but the
 /// fixture stays decodable for parity).
-Uint8List _buildImagePdf({double imageWidth = 200, double imageHeight = 120}) {
+Uint8List _buildImagePdf({double imageWidth = 200, double imageHeight = 120}) =>
+    _imageDocWith([
+      _textAt(100, 700, 'Above the figure'),
+      'q $imageWidth 0 0 $imageHeight 100 500 cm /Im0 Do Q',
+      _textAt(100, 400, 'Below the figure'),
+    ].join('\n'));
+
+/// A one-page PDF whose content is [content]; an `/Im0` 2×2 DeviceRGB image
+/// XObject and an `/F1` Helvetica font are available as resources.
+Uint8List _imageDocWith(String content) {
   // 2×2 DeviceRGB: red, green, blue, white.
   const hex = 'FF000000FF000000FFFFFFFF>';
-  final content = [
-    _textAt(100, 700, 'Above the figure'),
-    'q $imageWidth 0 0 $imageHeight 100 500 cm /Im0 Do Q',
-    _textAt(100, 400, 'Below the figure'),
-  ].join('\n');
   final objects = <String>[
     '<< /Type /Catalog /Pages 2 0 R >>',
     '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',


### PR DESCRIPTION
Improves the paragraph-aware reading view (text reflow) in two ways Ben asked about: making the text reflow better, and getting images/diagrams into the reflow view.

## Images & diagrams in the reflow view

The extractor's collecting device now records every placed image with its page-space bounds (computed from the draw transform), and the reflower:

- **interleaves images into reading order** — each figure inherits the reading position of the nearest text block above it in its column, so it lands where it sits on the page even in a multi-column read (image-only/scanned pages read top-down);
- **drops noise** — decorative rules, spacers, and tiny icons (< 24pt on a side) are filtered out, and repeated watermarks / tiled backgrounds are de-duplicated by stream identity + bounds overlap.

The Flutter `PdfReflowView` decodes those images through the existing `decodeImages` pipeline (shared cache, clones owned + disposed by the widget) and lays each out at its on-page aspect ratio in place. `PdfReflowView.showImages` (default **true**) toggles back to the old text-only behaviour; an undecodable image falls back to a labelled placeholder so the reading position is preserved.

## Better text reflow

Bullet and numbered list items (`•`, `-`, `1.`, `a)`, `(iv)` …) are now split into their own blocks (`PdfReflowBlock.isListItem`) and indented, instead of being folded into one run-on paragraph.

## API

`PdfReflowPage` gains an ordered `items` list (`PdfReflowItem`, a sealed base for `PdfReflowBlock` and the new `PdfReflowImage`). The existing `blocks` / `images` / `text` getters are unchanged, so current callers (e.g. `document_ai.dart`) keep working.

## Tests

- `pdf_graphics/test/text_extraction_test.dart`: list-item splitting, image collection + interleaving in reading order, aspect ratio, and tiny-image filtering.
- `dart_pdf_editor/test/pdf_reflow_view_test.dart`: the view renders a decoded image inline with text, and `showImages: false` reads text-only.

`fvm dart analyze` is clean across both packages; the new and existing reflow, `document_ai`, interpreter, text-diff, and shell suites pass.

https://claude.ai/code/session_014aezVwnGUDxnLQUn9115nd

---
_Generated by [Claude Code](https://claude.ai/code/session_014aezVwnGUDxnLQUn9115nd)_