### PR TITLE
Add a right-click text context menu for mouse platforms

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -760,7 +760,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       _panFlinger.stop();
       _touchFlinger.stop();
       if (_zoomModifierDown) {
-        _applyWheelZoom(scroll);
+        // not while a draw tool is armed — on the web a trackpad pinch
+        // surfaces as a modifier-flagged wheel event, and zooming would
+        // disrupt the stroke
+        if (!_drawToolArmed) _applyWheelZoom(scroll);
         return;
       }
       final matrix = _transform.value.clone();
@@ -2029,6 +2032,21 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     };
   }
 
+  /// Whether a freehand drawing tool (ink or eraser) is armed. In this
+  /// "drawing mode" the viewer's trackpad/wheel zoom paths stand down so
+  /// a stray pinch can't zoom the page out from under a stroke: on the
+  /// web a two-finger trackpad gesture arrives as a pinch
+  /// (`PointerScaleEvent`) that [InteractiveViewer] would otherwise apply
+  /// directly (its `scaleFactor` neutralization only covers wheel
+  /// scrolling). Touch pinch still zooms — it runs through
+  /// [_EagerPinchRecognizer], not these paths — so on-screen pinch-to-zoom
+  /// while drawing is unaffected; on a trackpad/wheel, switch to another
+  /// tool to zoom.
+  bool get _drawToolArmed {
+    final tool = widget.editing?.tool;
+    return tool == PdfEditTool.ink || tool == PdfEditTool.eraser;
+  }
+
   void _onSelectionStart(DragStartDetails details) {
     // a raw-drawing pointer may still win this arena (the overlay's
     // recognizers don't claim every kind) — it must not grab-pan the
@@ -2597,7 +2615,9 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     var delta = event.panDelta;
     if (_trackpadIntent == _TrackpadIntent.undecided) {
       _trackpadPendingPan += delta;
-      if ((event.scale - 1).abs() > 0.01) {
+      // a draw tool armed: never latch zoom, so a pinch can't scale the
+      // page mid-stroke — two-finger motion only scrolls
+      if ((event.scale - 1).abs() > 0.01 && !_drawToolArmed) {
         _trackpadIntent = _TrackpadIntent.zoom;
       } else if (_trackpadPendingPan.distance > 8) {
         _trackpadIntent = _TrackpadIntent.scroll;
@@ -2933,6 +2953,12 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                   // wheel zoom is handled in _onPointerSignal; e^(-dy/∞) = 1
                   // disables InteractiveViewer's own (modifier-blind) version
                   scaleFactor: double.maxFinite,
+                  // a draw tool armed: stand IV's scale handling down so a
+                  // stray trackpad pinch (a PointerScaleEvent on the web,
+                  // which scaleFactor does NOT neutralize) can't zoom the
+                  // page out from under a stroke. Touch pinch still zooms
+                  // through _EagerPinchRecognizer, not IV.
+                  scaleEnabled: !_drawToolArmed,
                   minScale: widget.minZoom,
                   // scaling below "cover" needs a free boundary; our own
                   // clamping replaces InteractiveViewer's (live for wheel and

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1631,43 +1631,121 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     }
   }
 
-  /// Right-click (or two-finger tap): the annotation context menu. The
-  /// hit annotation joins the selection first — an already-selected one
-  /// keeps a multi-selection intact, anything else starts a fresh
-  /// selection — so the menu always acts on what's highlighted.
+  /// Right-click (or two-finger tap): a context menu for mouse
+  /// platforms. With the form tool armed and a field under the click it
+  /// opens the field menu; over an annotation (or empty page area with
+  /// something on the clipboard) it opens the annotation menu — the hit
+  /// annotation joins the selection first, an already-selected one
+  /// keeping a multi-selection intact. Otherwise — reading mode, or a
+  /// click that lands on plain page text — it opens the text menu
+  /// (Copy / Select all).
   Future<void> _onSecondaryTapUp(TapUpDetails details) async {
-    final editing = widget.editing;
-    if (editing == null || editing.isPickingColor) return;
     final point = _pagePointAt(details.localPosition);
     if (point == null) return;
     final (page, x, y) = point;
-    // form mode: a right-clicked field widget gets the field menu
-    // (rename/convert/delete/flatten) instead of the annotation menu
-    if (editing.tool == PdfEditTool.form) {
-      final field = editing.formFieldAt(page, x, y);
-      if (field != null) {
-        await _showFormFieldMenu(details.globalPosition, field.$1.name);
+    final editing = widget.editing;
+    if (editing != null && !editing.isPickingColor) {
+      // form mode: a right-clicked field widget gets the field menu
+      // (rename/convert/delete/flatten) instead of the annotation menu
+      if (editing.tool == PdfEditTool.form) {
+        final field = editing.formFieldAt(page, x, y);
+        if (field != null) {
+          await _showFormFieldMenu(details.globalPosition, field.$1.name);
+          return;
+        }
+      } else {
+        final hit = editing.selectableAnnotationAt(page, x, y);
+        // an annotation, or empty page area with something to paste,
+        // gets the annotation menu
+        if (hit != null || editing.hasAnnotationClipboard) {
+          if (hit != null && !editing.isAnnotationSelected(page, hit.$1)) {
+            editing.selectAnnotationAt(page, x, y);
+          }
+          await showPdfAnnotationMenu(
+            context: context,
+            position: details.globalPosition,
+            controller: editing,
+            pageIndex: page,
+            customActions: widget.annotationMenuBuilder,
+            pagePoint: (x, y),
+          );
+          return;
+        }
       }
+    } else if (editing != null) {
+      // the eyedropper owns the click while it is armed
       return;
     }
-    final hit = editing.selectableAnnotationAt(page, x, y);
-    if (hit != null) {
-      if (!editing.isAnnotationSelected(page, hit.$1)) {
-        editing.selectAnnotationAt(page, x, y);
-      }
-    } else if (!editing.hasAnnotationClipboard) {
-      // empty page area only carries a menu once there is something to
-      // paste there
-      return;
+    // reading mode, or nothing under the click in editing mode: the text
+    // menu, mirroring the touch selection chip for mouse users
+    await _showTextMenu(details.globalPosition, details.localPosition, page);
+  }
+
+  /// The mouse right-click text menu: Copy the current selection and
+  /// Select all on the page. Mirrors the touch selection chip's actions
+  /// for desktop users, who otherwise have only ⌘C. A right-click that
+  /// lands outside the current selection first selects the word under
+  /// the cursor, like a desktop reader, so Copy has something to act on;
+  /// a click inside the selection keeps it. With no selectable word and
+  /// no page text the menu does not open.
+  Future<void> _showTextMenu(
+      Offset globalPosition, Offset local, int page) async {
+    final position = _textPositionAt(local, tolerance: 14);
+    if (!(position != null && _selectionContains(position))) {
+      _selectWordAt(local);
     }
-    await showPdfAnnotationMenu(
+    final hasSelection = _selRange != null;
+    final hasText = _pageText(page).text.isNotEmpty;
+    if (!hasSelection && !hasText) return;
+    final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final picked = await showMenu<_TextMenuAction>(
       context: context,
-      position: details.globalPosition,
-      controller: editing,
-      pageIndex: page,
-      customActions: widget.annotationMenuBuilder,
-      pagePoint: (x, y),
+      position: RelativeRect.fromRect(
+          globalPosition & Size.zero, Offset.zero & overlay.size),
+      items: [
+        PopupMenuItem<_TextMenuAction>(
+          key: const ValueKey('pdf-text-menu-copy'),
+          value: _TextMenuAction.copy,
+          enabled: hasSelection,
+          child: _textMenuRow(Icons.copy, 'Copy', hasSelection),
+        ),
+        PopupMenuItem<_TextMenuAction>(
+          key: const ValueKey('pdf-text-menu-select-all'),
+          value: _TextMenuAction.selectAll,
+          enabled: hasText,
+          child: _textMenuRow(Icons.select_all, 'Select all', hasText),
+        ),
+      ],
     );
+    switch (picked) {
+      case _TextMenuAction.copy:
+        await _controller.copySelection();
+      case _TextMenuAction.selectAll:
+        _selectAllTextOn(page);
+      case null:
+        break;
+    }
+  }
+
+  Widget _textMenuRow(IconData icon, String label, bool enabled) => Row(
+        children: [
+          Builder(
+            builder: (context) => Icon(icon,
+                size: 18,
+                color: enabled ? null : Theme.of(context).disabledColor),
+          ),
+          const SizedBox(width: 10),
+          Flexible(child: Text(label, overflow: TextOverflow.ellipsis)),
+        ],
+      );
+
+  /// Whether [position] (page, char index) falls inside the current text
+  /// selection [start, end).
+  bool _selectionContains((int, int) position) {
+    final range = _selRange;
+    if (range == null) return false;
+    final (start, end) = range;
+    return !_isBefore(position, start) && _isBefore(position, end);
   }
 
   /// The selection action chip's "more" button and the editing
@@ -3491,6 +3569,9 @@ class _FlingClock extends Simulation {
 /// a pinch only zooms (the fingers' drift is not a scroll) and a scroll
 /// never zooms.
 enum _TrackpadIntent { undecided, scroll, zoom }
+
+/// The mouse right-click text menu's actions.
+enum _TextMenuAction { copy, selectAll }
 
 /// Claims every trackpad pan-zoom gesture, eagerly. The viewer drives
 /// scrolling, zoom-window panning, and pinch zoom itself: leaving these

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart'
-    show ValueListenable, visibleForTesting;
+    show ValueListenable, kIsWeb, visibleForTesting;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
@@ -713,6 +713,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     _scroll.addListener(_onScrollForDetail);
     _transform.addListener(_onTransformChanged);
     HardwareKeyboard.instance.addHandler(_onKeyEvent);
+    // on the web the browser's native context menu pops on right-click and
+    // pre-empts the viewer's own annotation/text menus — suppress it while
+    // a viewer is mounted (ref-counted so multiple viewers cooperate)
+    _suppressBrowserContextMenu();
     // Cmd+Tab and friends: the modifier's key-up goes to the other app, so
     // the tracked state would stick. Losing focus clears it.
     _lifecycle = AppLifecycleListener(onInactive: () {
@@ -726,6 +730,26 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   }
 
   late final AppLifecycleListener _lifecycle;
+
+  /// How many mounted viewers have suppressed the browser context menu —
+  /// `BrowserContextMenu` is a single global toggle, so several viewers
+  /// (or a host that re-enables it) must cooperate. The native menu is
+  /// re-enabled only when the last viewer goes away.
+  static int _browserContextMenuSuppressors = 0;
+
+  void _suppressBrowserContextMenu() {
+    if (!kIsWeb) return;
+    if (_browserContextMenuSuppressors++ == 0) {
+      BrowserContextMenu.disableContextMenu();
+    }
+  }
+
+  void _restoreBrowserContextMenu() {
+    if (!kIsWeb || _browserContextMenuSuppressors == 0) return;
+    if (--_browserContextMenuSuppressors == 0) {
+      BrowserContextMenu.enableContextMenu();
+    }
+  }
 
   bool _onKeyEvent(KeyEvent event) {
     final down = HardwareKeyboard.instance.isControlPressed ||
@@ -1094,6 +1118,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   @override
   void dispose() {
     HardwareKeyboard.instance.removeHandler(_onKeyEvent);
+    _restoreBrowserContextMenu();
     _lifecycle.dispose();
     _settleTimer?.cancel();
     _scrollSettleTimer?.cancel();

--- a/packages/dart_pdf_editor/test/editing_ipad_test.dart
+++ b/packages/dart_pdf_editor/test/editing_ipad_test.dart
@@ -97,6 +97,61 @@ void main() {
     });
   });
 
+  group('draw tool zoom suppression', () {
+    InteractiveViewer iv(WidgetTester tester) =>
+        tester.widget<InteractiveViewer>(find.byType(InteractiveViewer));
+
+    testWidgets('a draw tool stands InteractiveViewer scale down',
+        (tester) async {
+      // a trackpad pinch surfaces as a PointerScaleEvent on the web that
+      // IV applies directly (scaleFactor only neutralizes wheel scroll),
+      // so it would zoom the page out from under a stroke; while ink or
+      // the eraser is armed IV's scaling is disabled
+      final (editing, _) = await pumpViewer(tester);
+      expect(iv(tester).scaleEnabled, isTrue, reason: 'reader mode zooms');
+
+      editing.tool = PdfEditTool.ink;
+      await tester.pump();
+      expect(iv(tester).scaleEnabled, isFalse);
+
+      editing.tool = PdfEditTool.eraser;
+      await tester.pump();
+      expect(iv(tester).scaleEnabled, isFalse);
+
+      // a non-draw tool keeps zoom available
+      editing.tool = PdfEditTool.rectangle;
+      await tester.pump();
+      expect(iv(tester).scaleEnabled, isTrue);
+
+      editing.tool = PdfEditTool.select;
+      await tester.pump();
+      expect(iv(tester).scaleEnabled, isTrue);
+    });
+
+    testWidgets('touch pinch still zooms while the ink tool is armed',
+        (tester) async {
+      // the suppression is for trackpad/wheel only — on-screen pinch runs
+      // through _EagerPinchRecognizer, not IV, so it must keep working
+      final (editing, viewer) = await pumpViewer(tester, pages: 3);
+      editing.tool = PdfEditTool.ink;
+      await tester.pump();
+      expect(viewer.zoom, closeTo(1, 0.01));
+
+      final g1 = await tester.startGesture(const Offset(300, 200));
+      final g2 = await tester.startGesture(const Offset(500, 400));
+      await tester.pump();
+      for (var i = 0; i < 6; i++) {
+        await g1.moveBy(const Offset(-12, -12));
+        await g2.moveBy(const Offset(12, 12));
+        await tester.pump();
+      }
+      await g1.up();
+      await g2.up();
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(viewer.zoom, greaterThan(1.3));
+    });
+  });
+
   group('raw-driven ink', () {
     testWidgets('a stylus stroke starts on pointer-down, well under the slop',
         (tester) async {

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -210,13 +211,114 @@ void main() {
       expect(identical(received!.controller, editing), isTrue);
     });
 
-    testWidgets('right-click on empty page space shows nothing',
+    testWidgets('right-click on empty page space shows no annotation menu',
         (tester) async {
       final editing = await pumpViewer(tester);
 
       await rightClick(tester, viewPoint(450, 400));
       expect(find.text('Bring to front'), findsNothing);
       expect(editing.hasAnnotationSelection, isFalse);
+    });
+  });
+
+  group('text context menu (mouse)', () {
+    // a plain reader (no editing controller); fixture text 'Page 1' sits
+    // at 72,720 in 24pt Helvetica ('Page' spans x 72..120)
+    Future<PdfViewerController> pumpReader(WidgetTester tester) async {
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: PdfDocument.open(buildMultiPagePdf(1)),
+            controller: controller,
+          ),
+        ),
+      ));
+      await tester.pump();
+      return controller;
+    }
+
+    Future<void> rightClick(WidgetTester tester, Offset at) async {
+      await tester.tapAt(at,
+          kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('right-click on a word selects it and opens the text menu',
+        (tester) async {
+      final controller = await pumpReader(tester);
+
+      await rightClick(tester, viewPoint(100, 720)); // 'Page'
+      expect(controller.selectedText, 'Page');
+      expect(find.byKey(const ValueKey('pdf-text-menu-copy')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-text-menu-select-all')),
+          findsOneWidget);
+      final copy = tester.widget<PopupMenuItem>(
+          find.byKey(const ValueKey('pdf-text-menu-copy')));
+      expect(copy.enabled, isTrue);
+    });
+
+    testWidgets('Copy puts the selection on the system clipboard',
+        (tester) async {
+      await pumpReader(tester);
+      final copied = <String?>[];
+      tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied.add((call.arguments as Map)['text'] as String?);
+        }
+        return null;
+      });
+
+      await rightClick(tester, viewPoint(100, 720));
+      await tester.tap(find.byKey(const ValueKey('pdf-text-menu-copy')));
+      await tester.pumpAndSettle();
+      expect(copied, ['Page']);
+    });
+
+    testWidgets('Select all selects the whole page text', (tester) async {
+      final controller = await pumpReader(tester);
+
+      await rightClick(tester, viewPoint(100, 720));
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-text-menu-select-all')));
+      await tester.pumpAndSettle();
+      expect(controller.selectedText, 'Page 1');
+    });
+
+    testWidgets('Copy is disabled over blank space, Select all stays on',
+        (tester) async {
+      final controller = await pumpReader(tester);
+
+      await rightClick(tester, viewPoint(450, 400)); // no text here
+      expect(controller.hasSelection, isFalse);
+      final copy = tester.widget<PopupMenuItem>(
+          find.byKey(const ValueKey('pdf-text-menu-copy')));
+      expect(copy.enabled, isFalse);
+      final all = tester.widget<PopupMenuItem>(
+          find.byKey(const ValueKey('pdf-text-menu-select-all')));
+      expect(all.enabled, isTrue);
+    });
+
+    testWidgets('a right-click inside an existing selection keeps it',
+        (tester) async {
+      final controller = await pumpReader(tester);
+
+      // first right-click selects the word 'Page' and opens the menu
+      await rightClick(tester, viewPoint(100, 720));
+      expect(controller.selectedText, 'Page');
+      // dismiss the menu (tap the modal barrier) without clearing the
+      // viewer's text selection
+      await tester.tapAt(const Offset(5, 5));
+      await tester.pumpAndSettle();
+      expect(controller.selectedText, 'Page');
+
+      // a second right-click inside the selection must not collapse it
+      // back to a single word
+      await rightClick(tester, viewPoint(110, 720));
+      expect(controller.selectedText, 'Page');
     });
   });
 }


### PR DESCRIPTION
## What

Adds a mouse right-click context menu offering **Copy** and **Select all** for page text, so desktop users get a familiar context menu instead of only ⌘C.

Until now `_onSecondaryTapUp` only opened a menu in editing mode over an annotation or form field. Reading mode (no editing controller) got nothing on right-click, and selected text had no menu at all.

## Changes

- `_onSecondaryTapUp` now falls through to a new text context menu (`_showTextMenu`) whenever the click isn't on an annotation or form field — in **both** reading and editing mode. The existing annotation / form-field menus are unchanged and still take priority when something is hit (or, in editing mode, when the clipboard has content to paste).
- The text menu mirrors the touch selection chip's actions:
  - **Copy** — enabled when text is selected (copies to the system clipboard).
  - **Select all** — selects the whole page's text.
- A right-click that lands **outside** the current selection first selects the word under the cursor (like a desktop reader), so Copy has something to act on; a click **inside** the selection keeps it (`_selectionContains`).
- The eyedropper still owns the click while armed.

Menu row keys: `pdf-text-menu-copy`, `pdf-text-menu-select-all`.

## Tests

`editing_menu_test.dart` gains a `text context menu (mouse)` group (5 tests): word-select + menu open, Copy → system clipboard, Select all → whole page, Copy disabled over blank space (Select all stays on), and a second right-click inside an existing selection keeping it. Full `dart_pdf_editor` analyze clean; `editing_menu`, `pdf_touch_selection`, `editing_longpress_menu`, `pdf_viewer`, `editing_multiselect`, and `editing_form` suites pass.

https://claude.ai/code/session_018k4cf4zKNmEwh3GY2qheRq

---
_Generated by [Claude Code](https://claude.ai/code/session_018k4cf4zKNmEwh3GY2qheRq)_