### PR TITLE
Allow dragging to re-order document tabs

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -4,6 +4,7 @@ import 'dart:ui' show AppExitResponse;
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -519,24 +520,46 @@ class _EditorScreenState extends State<EditorScreen>
     ];
   }
 
+  /// Moves the tab at [oldIndex] to [newIndex] (drag-reorder), keeping the
+  /// currently active document active wherever it lands. [newIndex] is already
+  /// adjusted for the removed item (the `onReorderItem` convention).
+  void _reorderTabs(int oldIndex, int newIndex) {
+    setState(() {
+      final active = _tabs[_activeIndex.clamp(0, _tabs.length - 1)];
+      final moved = _tabs.removeAt(oldIndex);
+      _tabs.insert(newIndex, moved);
+      _activeIndex = _tabs.indexOf(active);
+    });
+  }
+
   Widget _buildTabStrip() {
     final scheme = Theme.of(context).colorScheme;
     return Material(
       color: scheme.surface,
       child: SizedBox(
         height: _tabStripHeight,
-        child: ListView.builder(
-          scrollDirection: Axis.horizontal,
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          itemCount: _tabs.length + 1,
-          itemBuilder: (context, i) => i < _tabs.length
-              ? _buildTab(i)
-              : IconButton(
-                  visualDensity: VisualDensity.compact,
-                  icon: const Icon(Icons.add),
-                  tooltip: 'Open PDF in a new tab',
-                  onPressed: _pickAndOpen,
-                ),
+        child: Row(
+          children: [
+            Expanded(
+              child: ReorderableListView.builder(
+                key: const ValueKey('tab-strip'),
+                scrollDirection: Axis.horizontal,
+                // The whole tab is the drag handle (see _buildTab); the stock
+                // trailing handles don't fit a horizontal tab strip.
+                buildDefaultDragHandles: false,
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                itemCount: _tabs.length,
+                onReorderItem: _reorderTabs,
+                itemBuilder: (context, i) => _buildTab(i),
+              ),
+            ),
+            IconButton(
+              visualDensity: VisualDensity.compact,
+              icon: const Icon(Icons.add),
+              tooltip: 'Open PDF in a new tab',
+              onPressed: _pickAndOpen,
+            ),
+          ],
         ),
       ),
     );
@@ -573,36 +596,72 @@ class _EditorScreenState extends State<EditorScreen>
       );
     }
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 5),
-      child: Material(
-        color: selected ? scheme.secondaryContainer : scheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(8),
-        child: InkWell(
+    // Dragging anywhere on the tab reorders it; the tap/close gestures still
+    // win when the pointer doesn't travel (gesture arena resolves drag vs tap).
+    return _TabDragStartListener(
+      key: ValueKey(tab),
+      index: index,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2, vertical: 5),
+        child: Material(
+          color: selected ? scheme.secondaryContainer : scheme.surfaceContainerHighest,
           borderRadius: BorderRadius.circular(8),
-          onTap: () => setState(() => _activeIndex = index),
-          child: Padding(
-            padding: const EdgeInsets.only(left: 12, right: 2),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 160),
-                  child: label(),
-                ),
-                IconButton(
-                  icon: const Icon(Icons.close, size: 16),
-                  visualDensity: VisualDensity.compact,
-                  padding: EdgeInsets.zero,
-                  constraints: const BoxConstraints(minWidth: 30, minHeight: 30),
-                  tooltip: 'Close tab',
-                  onPressed: () => _closeTab(index),
-                ),
-              ],
+          child: InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: () => setState(() => _activeIndex = index),
+            child: Padding(
+              padding: const EdgeInsets.only(left: 12, right: 2),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 160),
+                    child: label(),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 16),
+                    visualDensity: VisualDensity.compact,
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(minWidth: 30, minHeight: 30),
+                    tooltip: 'Close tab',
+                    onPressed: () => _closeTab(index),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Starts a tab drag immediately for mouse pointers (the desktop expectation —
+/// a mouse drag never means scrolling the strip) but only after a long press
+/// for touch and stylus, so finger drags still scroll the tab strip. Plain
+/// taps are unaffected: both recognizers claim the pointer only once it moves
+/// past the slop.
+class _TabDragStartListener extends ReorderableDragStartListener {
+  const _TabDragStartListener({
+    super.key,
+    required super.index,
+    required super.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (event) {
+        SliverReorderableList.maybeOf(context)?.startItemDragReorder(
+          index: index,
+          event: event,
+          recognizer: (event.kind == PointerDeviceKind.mouse
+              ? ImmediateMultiDragGestureRecognizer(debugOwner: this)
+              : DelayedMultiDragGestureRecognizer(debugOwner: this))
+            ..gestureSettings = MediaQuery.maybeGestureSettingsOf(context),
+        );
+      },
+      child: child,
     );
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -32,5 +32,8 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^5.0.0
 
+  # Programmatically-built PDFs for widget tests.
+  pdf_test_fixtures: ^1.0.0
+
 flutter:
   uses-material-design: true

--- a/app/test/tabs_reorder_test.dart
+++ b/app/test/tabs_reorder_test.dart
@@ -1,0 +1,104 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/incoming_file.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    // The mock store is process-global; reset it so a prior test's persisted
+    // preferences never leak into this one.
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+
+  tearDown(() => prefs.dispose());
+
+  // Delivers a PDF to the running app the way the OS would (a warm-start
+  // "open with"), opening it in a new tab.
+  Future<void> openTab(WidgetTester tester, String name) async {
+    const codec = StandardMethodCodec();
+    final message = codec.encodeMethodCall(
+      MethodCall('openFile', {'name': name, 'bytes': buildClassicPdf()}),
+    );
+    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      IncomingFileService.channelName,
+      message,
+      (_) {},
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  // The tab title within the strip (scoped to the tab-strip ReorderableListView
+  // so it never matches the AppBar's active-document title nor the thumbnail
+  // sidebar's own reorderable list in the body).
+  Finder tabTitle(String name) => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: find.text(name),
+      );
+
+  testWidgets('tabs render in a reorderable strip', (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+
+    await openTab(tester, 'alpha.pdf');
+    await openTab(tester, 'beta.pdf');
+
+    expect(find.byKey(const ValueKey('tab-strip')), findsOneWidget);
+    expect(tabTitle('alpha.pdf'), findsOneWidget);
+    expect(tabTitle('beta.pdf'), findsOneWidget);
+  });
+
+  testWidgets('dragging a tab reorders it and keeps the active document',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+
+    await openTab(tester, 'alpha.pdf');
+    await openTab(tester, 'beta.pdf');
+
+    // Opened in order, so alpha sits left of beta. The last-opened (beta) is
+    // active — the AppBar title reflects it.
+    expect(tester.getCenter(tabTitle('alpha.pdf')).dx,
+        lessThan(tester.getCenter(tabTitle('beta.pdf')).dx));
+
+    // Drag alpha to the right, past beta. A mouse drag reorders immediately
+    // (touch would need a long press, per _TabDragStartListener).
+    final gesture = await tester.startGesture(
+      tester.getCenter(tabTitle('alpha.pdf')),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump(); // register the drag recognizer on pointer-down
+    await gesture.moveBy(const Offset(30, 0)); // exceed slop → drag starts
+    await tester.pump(const Duration(milliseconds: 50));
+    for (var i = 0; i < 12; i++) {
+      await gesture.moveBy(const Offset(25, 0));
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    await gesture.up();
+    await tester.pump();
+    // Let the drop animation finish (the proxy overlay clears).
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pump(const Duration(milliseconds: 600));
+
+    // alpha is now to the right of beta.
+    expect(tester.getCenter(tabTitle('alpha.pdf')).dx,
+        greaterThan(tester.getCenter(tabTitle('beta.pdf')).dx));
+
+    // Both tabs survive and beta is still the active document (its tab keeps
+    // the selected weight while alpha reverts to normal).
+    expect(find.byTooltip('Close tab'), findsNWidgets(2));
+    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+        FontWeight.w600);
+    expect(tester.widget<Text>(tabTitle('alpha.pdf')).style?.fontWeight,
+        FontWeight.normal);
+  });
+}


### PR DESCRIPTION
## Summary

Makes the app's document tab strip drag-reorderable, so open documents can be rearranged by dragging a tab.

- The strip is now a horizontal `ReorderableListView`. A **mouse drag** on a tab reorders it **immediately** (the desktop expectation — a mouse drag never means scrolling the strip), while **touch/stylus** reorder only after a **long press**, so finger drags still scroll the strip. This mirrors the per-pointer recognizer the thumbnail sidebar already uses (`_TabDragStartListener`, an `ImmediateMultiDragGestureRecognizer` for mouse / `DelayedMultiDragGestureRecognizer` otherwise).
- The active document **follows its tab** wherever it lands (`_reorderTabs` re-finds the active tab object after the move).
- The new-tab (**+**) button is now **pinned at the right edge** of the strip instead of scrolling away as the last list item.
- Tap-to-select and the per-tab close button are unaffected — the gesture arena resolves tap vs. drag.

## Tests

New `app/test/tabs_reorder_test.dart` (2 tests): opens two tabs via the incoming-file `MethodChannel`, asserts the reorderable strip renders, and drives a mouse drag that moves the first tab past the second while verifying the active document keeps its selected styling. `pdf_test_fixtures` added as a dev dependency to build the PDFs.

- `flutter test` (app): all pass
- `dart analyze app/`: no issues

https://claude.ai/code/session_01MykG4umCCSMx6rGCjXEQyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MykG4umCCSMx6rGCjXEQyJ)_