### PR TITLE
Record/replay render split (background-isolate rendering, milestone 1)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -60,21 +60,90 @@ class PdfPageRenderer {
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
 
-    // The paper is opaque white; [pageColor] washes over it. A
-    // translucent page color (e.g. a copy-type tint) thus reads as a
-    // wash on white rather than compositing onto the viewer canvas
-    // behind the page. A fully opaque color makes the white backing a
-    // no-op, so this is free in the common case.
+    _paintBackground(canvas, size, pageColor);
+    _applyPageTransform(canvas, page, size, box);
+
+    final painting = PdfInterpreter(
+        cos: cos, device: CanvasPdfDevice(canvas, images: images))
+      ..drawPageOperations(page, pageOps);
+    if (annotations) painting.drawAnnotations(page, skip: skipAnnotation);
+    final picture = recorder.endRecording();
+    // The picture retains its own reference to every drawn image, so the
+    // decode handles (clones from the cache, or fresh decodes) can be freed
+    // now — the cache keeps the masters for the next render.
+    for (final image in images.values) {
+      image.dispose();
+    }
+    return picture;
+  }
+
+  /// Renders [page] like [renderPicture] but by first recording the page's
+  /// interpreter callbacks into a portable [PdfRenderCommand] buffer (a
+  /// [RecordingPdfDevice]) and then replaying that buffer onto the canvas via
+  /// the unchanged [CanvasPdfDevice].
+  ///
+  /// The result is pixel-identical to [renderPicture] — the same canvas calls
+  /// happen in the same order — but the interpretation (the dominant cost: the
+  /// content-stream parse and walk) is now decoupled from the painting. This
+  /// is the seam the background-isolate work splits across: the recording half
+  /// is pure Dart and `dart:ui`-free, so it can move to a worker isolate, with
+  /// only this replay (cheap) and image decoding staying on the UI thread.
+  ///
+  /// For now both halves run on the calling isolate; this method exists so the
+  /// record/replay split can be exercised and proven equivalent before any
+  /// isolate machinery is introduced.
+  static Future<ui.Picture> renderPictureRecorded(PdfPage page,
+      {Color pageColor = const Color(0xFFFFFFFF),
+      bool annotations = true,
+      bool Function(PdfAnnotation)? skipAnnotation}) async {
+    final cos = page.document.cos;
+    final pageOps = ContentStreamParser.parse(page.contentBytes());
+
+    // Record the page into a flat command buffer. This single walk also
+    // discovers every image (the recording device's drawImage calls), so the
+    // separate scan-only collect pass [renderPicture] runs is unnecessary here.
+    final recorder = RecordingPdfDevice();
+    final recording = PdfInterpreter(cos: cos, device: recorder)
+      ..drawPageOperations(page, pageOps);
+    if (annotations) recording.drawAnnotations(page, skip: skipAnnotation);
+
+    final images = await decodeImages(cos, recorder.imageRequests,
+        cache: PdfImageCache.instance);
+
+    final box = page.cropBox;
+    final size = pageSize(page);
+    final uiRecorder = ui.PictureRecorder();
+    final canvas = Canvas(uiRecorder);
+
+    _paintBackground(canvas, size, pageColor);
+    _applyPageTransform(canvas, page, size, box);
+
+    replayCommands(recorder.commands, CanvasPdfDevice(canvas, images: images));
+    final picture = uiRecorder.endRecording();
+    for (final image in images.values) {
+      image.dispose();
+    }
+    return picture;
+  }
+
+  /// Paints the page paper under the content: an opaque white backing when
+  /// [pageColor] is translucent (so a tint washes over white rather than the
+  /// viewer canvas behind the page), then [pageColor]. A fully opaque colour
+  /// makes the white backing a no-op, so it is free in the common case.
+  static void _paintBackground(Canvas canvas, Size size, Color pageColor) {
     if (pageColor.a < 1.0) {
       canvas.drawRect(
         Offset.zero & size,
         Paint()..color = const Color(0xFFFFFFFF),
       );
     }
-    canvas.drawRect(
-      Offset.zero & size,
-      Paint()..color = pageColor,
-    );
+    canvas.drawRect(Offset.zero & size, Paint()..color = pageColor);
+  }
+
+  /// Sets the canvas up in PDF user space: /Rotate, then the y-flip and crop
+  /// box origin, so interpreter output (page space, y-up) lands correctly.
+  static void _applyPageTransform(
+      Canvas canvas, PdfPage page, Size size, PdfRect box) {
     switch (page.rotation) {
       case 90:
         canvas.translate(size.width, 0);
@@ -90,19 +159,6 @@ class PdfPageRenderer {
     canvas.translate(0, box.height);
     canvas.scale(1, -1);
     canvas.translate(-box.left, -box.bottom);
-
-    final painting = PdfInterpreter(
-        cos: cos, device: CanvasPdfDevice(canvas, images: images))
-      ..drawPageOperations(page, pageOps);
-    if (annotations) painting.drawAnnotations(page, skip: skipAnnotation);
-    final picture = recorder.endRecording();
-    // The picture retains its own reference to every drawn image, so the
-    // decode handles (clones from the cache, or fresh decodes) can be freed
-    // now — the cache keeps the masters for the next render.
-    for (final image in images.values) {
-      image.dispose();
-    }
-    return picture;
   }
 
   /// Renders one annotation's appearance into a picture in the same page
@@ -124,20 +180,7 @@ class PdfPageRenderer {
     final size = pageSize(page);
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
-    switch (page.rotation) {
-      case 90:
-        canvas.translate(size.width, 0);
-        canvas.rotate(math.pi / 2);
-      case 180:
-        canvas.translate(size.width, size.height);
-        canvas.rotate(math.pi);
-      case 270:
-        canvas.translate(0, size.height);
-        canvas.rotate(-math.pi / 2);
-    }
-    canvas.translate(0, box.height);
-    canvas.scale(1, -1);
-    canvas.translate(-box.left, -box.bottom);
+    _applyPageTransform(canvas, page, size, box);
 
     PdfInterpreter(cos: cos, device: CanvasPdfDevice(canvas, images: images))
         .drawAnnotation(page, annotation);

--- a/packages/dart_pdf_editor/test/render_record_replay_test.dart
+++ b/packages/dart_pdf_editor/test/render_record_replay_test.dart
@@ -1,0 +1,140 @@
+// Pixel-identity gate for the record/replay render split.
+//
+// [PdfPageRenderer.renderPictureRecorded] interprets a page into a portable
+// command buffer ([RecordingPdfDevice]) and replays it onto the canvas, where
+// [renderPicture] interprets straight onto the canvas. The two must rasterize
+// to byte-identical pixels — the replay issues exactly the same canvas calls.
+//
+// Unlike the Ghent/PDF.js golden suites this needs no stored baseline and is
+// platform-independent: both renders happen in the same process this run, so
+// font/antialiasing differences cancel and the comparison is the identity of
+// the two code paths, nothing else.
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+const _pixelRatio = 2.0;
+
+Uint8List _buildPdf(String content, {String mediaBox = '0 0 200 200'}) {
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [$mediaBox] /Contents 4 0 R '
+        '/Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xref = buffer.length;
+  buffer.write('xref\n0 ${objects.length + 1}\n0000000000 65535 f \n');
+  for (final o in offsets) {
+    buffer.write('${o.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer.write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n'
+      'startxref\n$xref\n%%EOF\n');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
+
+/// Renders [page] both ways and returns the differing-pixel fraction at an
+/// exact (zero-tolerance) comparison.
+Future<double> _compare(PdfPage page) async {
+  final direct = await PdfPageRenderer.renderPicture(page);
+  final recorded = await PdfPageRenderer.renderPictureRecorded(page);
+  final size = PdfPageRenderer.pageSize(page);
+  try {
+    final a = await PdfPageRenderer.rasterize(direct, size, _pixelRatio);
+    final b = await PdfPageRenderer.rasterize(recorded, size, _pixelRatio);
+    try {
+      expect('${a.width}x${a.height}', '${b.width}x${b.height}',
+          reason: 'recorded raster size differs');
+      final ap = (await a.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!
+          .buffer
+          .asUint8List();
+      final bp = (await b.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!
+          .buffer
+          .asUint8List();
+      return PdfPageComparison.comparePixels(ap, bp,
+              width: a.width, height: a.height, channelTolerance: 0)
+          .differenceFraction;
+    } finally {
+      a.dispose();
+      b.dispose();
+    }
+  } finally {
+    direct.dispose();
+    recorded.dispose();
+  }
+}
+
+void main() {
+  group('synthetic pages', () {
+    final cases = <String, String>{
+      'fills, strokes, dashes': 'q 0 0 1 rg 20 20 120 80 re f '
+          '1 0 0 RG 6 w [10 6] 0 d 20 160 m 180 40 l S Q',
+      'clip and curves': '0 0 1 0 k 30 30 140 140 re W n '
+          '20 20 m 60 180 140 180 180 20 c f',
+      'text': 'BT /F1 32 Tf 20 100 Td (Recorded!) Tj ET',
+      'inline image': 'q 100 0 0 100 50 50 cm '
+          'BI /W 4 /H 4 /CS /RGB /BPC 8 /F /AHx ID\n'
+          'e63030 ffffff e63030 ffffff\n'
+          'ffffff e63030 ffffff e63030\n'
+          'e63030 ffffff e63030 ffffff\n'
+          'ffffff e63030 ffffff e63030 >\nEI Q',
+      'alpha group': 'q /GShere gs 0 0 1 rg 20 20 100 100 re f Q',
+    };
+    cases.forEach((name, content) {
+      testWidgets(name, (tester) async {
+        await tester.runAsync(() async {
+          await loadSystemFonts();
+          final doc = PdfDocument.open(_buildPdf(content));
+          expect(await _compare(doc.page(0)), 0.0,
+              reason: '$name: recorded render is not pixel-identical');
+        });
+      });
+    });
+  });
+
+  // Real pages drive the callbacks the synthetic fixtures can't: transparency
+  // groups, luminosity + alpha soft masks (with their mask content), blend
+  // modes, axial/radial + mesh shadings, and decoded images.
+  group('corpus pages', () {
+    final files = <String>[
+      '../../test_corpora/ghent/1-CMYK/GWG168_Softmasks_Vector_part1_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/'
+          'GWG160_Transp_Basic_BM_DeviceCMYK_Non-knockout_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/'
+          'GWG161_Transp_Basic_BM_DeviceCMYK_Knockout_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/GWG061_Shading_x1a.pdf',
+    ];
+    for (final path in files) {
+      final file = File(path);
+      final name = path.split('/').last;
+      testWidgets(name, (tester) async {
+        if (!file.existsSync()) {
+          markTestSkipped('$path not found');
+          return;
+        }
+        await tester.runAsync(() async {
+          await loadSystemFonts();
+          final doc = PdfDocument.open(file.readAsBytesSync());
+          for (var i = 0; i < doc.pageCount; i++) {
+            expect(await _compare(doc.page(i)), 0.0,
+                reason: '$name page $i: recorded render not pixel-identical');
+          }
+        });
+      }, timeout: const Timeout(Duration(minutes: 2)));
+    }
+  });
+}

--- a/packages/pdf_graphics/lib/pdf_graphics.dart
+++ b/packages/pdf_graphics/lib/pdf_graphics.dart
@@ -17,5 +17,7 @@ export 'src/shading.dart';
 export 'src/matrix.dart';
 export 'src/mesh.dart';
 export 'src/path.dart';
+export 'src/recording_device.dart';
+export 'src/render_command.dart';
 export 'src/text_diff.dart';
 export 'src/text_extraction.dart';

--- a/packages/pdf_graphics/lib/src/recording_device.dart
+++ b/packages/pdf_graphics/lib/src/recording_device.dart
@@ -1,0 +1,116 @@
+import 'package:pdf_document/pdf_document.dart';
+
+import 'color.dart';
+import 'device.dart';
+import 'mesh.dart';
+import 'path.dart';
+import 'render_command.dart';
+import 'shading.dart';
+
+/// A [PdfDevice] that records every interpreter callback into a flat,
+/// replayable [commands] list instead of painting.
+///
+/// It performs no rendering and touches no `dart:ui`, so it can run anywhere
+/// the interpreter does — including a background isolate, where the heavy
+/// content-stream parse and walk happen — and its output ([commands]) is fed
+/// back through [replayCommands] into a real painting device on the side that
+/// owns the canvas. The recorded arguments are the interpreter's own value
+/// types ([PdfPath], [PdfColor], [PdfTextRun], …), all immutable, so the list
+/// is a faithful, side-effect-free transcript of the page.
+///
+/// Image requests are recorded verbatim ([PdfDrawImageCommand] keeps the
+/// [PdfImageRequest], including its [CosStream]); the side that replays
+/// decodes them as it does today. [imageRequests] exposes them in encounter
+/// order for callers that want to drive decoding off the recording rather
+/// than a separate scan pass.
+class RecordingPdfDevice implements PdfDevice {
+  /// The recorded top-level command sequence.
+  final List<PdfRenderCommand> commands = [];
+
+  /// Every image the page referenced, in the order the interpreter drew them
+  /// (including those inside soft-mask groups). The same list the device's
+  /// [drawImage] calls produced — useful for decoding ahead of replay.
+  final List<PdfImageRequest> imageRequests = [];
+
+  /// The list new commands append to. Normally [commands]; temporarily a
+  /// soft mask's nested list while its `drawMask` closure runs.
+  late List<PdfRenderCommand> _target = commands;
+
+  @override
+  void save() => _target.add(const PdfSaveCommand());
+
+  @override
+  void restore() => _target.add(const PdfRestoreCommand());
+
+  @override
+  void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) =>
+      _target.add(PdfFillPathCommand(path, color, rule, alpha));
+
+  @override
+  void fillPathGradient(
+          PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) =>
+      _target.add(PdfFillPathGradientCommand(path, rule, gradient, alpha));
+
+  @override
+  void fillMesh(PdfMesh mesh, double alpha) =>
+      _target.add(PdfFillMeshCommand(mesh, alpha));
+
+  @override
+  void strokePath(
+          PdfPath path, PdfColor color, PdfStroke stroke, double alpha) =>
+      _target.add(PdfStrokePathCommand(path, color, stroke, alpha));
+
+  @override
+  void clipPath(PdfPath path, PdfFillRule rule) =>
+      _target.add(PdfClipPathCommand(path, rule));
+
+  @override
+  void drawText(PdfTextRun run) => _target.add(PdfDrawTextCommand(run));
+
+  @override
+  void drawImage(PdfImageRequest request) {
+    imageRequests.add(request);
+    _target.add(PdfDrawImageCommand(request));
+  }
+
+  @override
+  void setBlendMode(PdfBlendMode mode) =>
+      _target.add(PdfSetBlendModeCommand(mode));
+
+  @override
+  void beginGroup(double alpha, {bool knockout = false}) =>
+      _target.add(PdfBeginGroupCommand(alpha, knockout: knockout));
+
+  @override
+  void endGroup() => _target.add(const PdfEndGroupCommand());
+
+  @override
+  void beginSoftMasked() => _target.add(const PdfBeginSoftMaskedCommand());
+
+  @override
+  void endSoftMasked({
+    required bool luminosity,
+    required PdfRect backdrop,
+    required void Function() drawMask,
+    double backdropLuminance = 0,
+    double transferScale = 1,
+    double transferOffset = 0,
+  }) {
+    // The captured content has already been recorded into the current target.
+    // Divert the mask group's own painting into a nested list, then record the
+    // end marker carrying it; replay rebuilds the drawMask closure from it.
+    final maskCommands = <PdfRenderCommand>[];
+    final saved = _target;
+    _target = maskCommands;
+    drawMask();
+    _target = saved;
+    _target.add(PdfEndSoftMaskedCommand(
+      luminosity: luminosity,
+      backdrop: backdrop,
+      maskCommands: maskCommands,
+      backdropLuminance: backdropLuminance,
+      transferScale: transferScale,
+      transferOffset: transferOffset,
+    ));
+  }
+}

--- a/packages/pdf_graphics/lib/src/render_command.dart
+++ b/packages/pdf_graphics/lib/src/render_command.dart
@@ -1,0 +1,199 @@
+import 'package:pdf_document/pdf_document.dart';
+
+import 'color.dart';
+import 'device.dart';
+import 'mesh.dart';
+import 'path.dart';
+import 'shading.dart';
+
+/// A flattened, replayable record of one [PdfDevice] call.
+///
+/// The interpreter's output interface ([PdfDevice]) is 13 callbacks whose
+/// arguments are almost entirely pure-Dart value types from `pdf_graphics`
+/// ([PdfPath], [PdfColor], [PdfMatrix], [PdfStroke], [PdfGradient],
+/// [PdfMesh], [PdfTextRun], …). A [RecordingPdfDevice] captures each call
+/// verbatim as one of these records; [replayCommands] feeds them straight
+/// back into another [PdfDevice] (the Flutter canvas device, a test
+/// recorder, …). The interpreter, the device interface, and the canvas
+/// device are unchanged — interpretation (the expensive parse + walk) and
+/// painting are merely decoupled, which is the prerequisite for running the
+/// interpret off the UI thread.
+///
+/// The command list is a flat sequence; the nesting of transparency groups
+/// and `q`/`Q` is implicit in the open/close pairing, exactly as the canvas
+/// device already tracks it. The one callback that carries control flow —
+/// [PdfDevice.endSoftMasked]'s `drawMask` closure — stores the mask group's
+/// own commands inline ([PdfEndSoftMaskedCommand.maskCommands]); replay
+/// reconstructs the closure from them.
+sealed class PdfRenderCommand {
+  const PdfRenderCommand();
+}
+
+/// `q` — [PdfDevice.save].
+class PdfSaveCommand extends PdfRenderCommand {
+  const PdfSaveCommand();
+}
+
+/// `Q` — [PdfDevice.restore].
+class PdfRestoreCommand extends PdfRenderCommand {
+  const PdfRestoreCommand();
+}
+
+/// [PdfDevice.fillPath].
+class PdfFillPathCommand extends PdfRenderCommand {
+  const PdfFillPathCommand(this.path, this.color, this.rule, this.alpha);
+  final PdfPath path;
+  final PdfColor color;
+  final PdfFillRule rule;
+  final double alpha;
+}
+
+/// [PdfDevice.fillPathGradient].
+class PdfFillPathGradientCommand extends PdfRenderCommand {
+  const PdfFillPathGradientCommand(
+      this.path, this.rule, this.gradient, this.alpha);
+  final PdfPath path;
+  final PdfFillRule rule;
+  final PdfGradient gradient;
+  final double alpha;
+}
+
+/// [PdfDevice.fillMesh].
+class PdfFillMeshCommand extends PdfRenderCommand {
+  const PdfFillMeshCommand(this.mesh, this.alpha);
+  final PdfMesh mesh;
+  final double alpha;
+}
+
+/// [PdfDevice.strokePath].
+class PdfStrokePathCommand extends PdfRenderCommand {
+  const PdfStrokePathCommand(this.path, this.color, this.stroke, this.alpha);
+  final PdfPath path;
+  final PdfColor color;
+  final PdfStroke stroke;
+  final double alpha;
+}
+
+/// [PdfDevice.clipPath].
+class PdfClipPathCommand extends PdfRenderCommand {
+  const PdfClipPathCommand(this.path, this.rule);
+  final PdfPath path;
+  final PdfFillRule rule;
+}
+
+/// [PdfDevice.drawText].
+class PdfDrawTextCommand extends PdfRenderCommand {
+  const PdfDrawTextCommand(this.run);
+  final PdfTextRun run;
+}
+
+/// [PdfDevice.drawImage].
+class PdfDrawImageCommand extends PdfRenderCommand {
+  const PdfDrawImageCommand(this.request);
+  final PdfImageRequest request;
+}
+
+/// [PdfDevice.setBlendMode].
+class PdfSetBlendModeCommand extends PdfRenderCommand {
+  const PdfSetBlendModeCommand(this.mode);
+  final PdfBlendMode mode;
+}
+
+/// [PdfDevice.beginGroup].
+class PdfBeginGroupCommand extends PdfRenderCommand {
+  const PdfBeginGroupCommand(this.alpha, {this.knockout = false});
+  final double alpha;
+  final bool knockout;
+}
+
+/// [PdfDevice.endGroup].
+class PdfEndGroupCommand extends PdfRenderCommand {
+  const PdfEndGroupCommand();
+}
+
+/// [PdfDevice.beginSoftMasked].
+class PdfBeginSoftMaskedCommand extends PdfRenderCommand {
+  const PdfBeginSoftMaskedCommand();
+}
+
+/// [PdfDevice.endSoftMasked]. The `drawMask` closure's device calls are
+/// captured in [maskCommands]; replay rebuilds the closure as a nested
+/// [replayCommands] over them.
+class PdfEndSoftMaskedCommand extends PdfRenderCommand {
+  const PdfEndSoftMaskedCommand({
+    required this.luminosity,
+    required this.backdrop,
+    required this.maskCommands,
+    this.backdropLuminance = 0,
+    this.transferScale = 1,
+    this.transferOffset = 0,
+  });
+  final bool luminosity;
+  final PdfRect backdrop;
+  final List<PdfRenderCommand> maskCommands;
+  final double backdropLuminance;
+  final double transferScale;
+  final double transferOffset;
+}
+
+/// Replays [commands] into [device], reproducing the original interpreter
+/// callbacks in order. The dispatch is total over the [PdfRenderCommand]
+/// hierarchy — adding a command without a case here is a compile error.
+void replayCommands(List<PdfRenderCommand> commands, PdfDevice device) {
+  for (final command in commands) {
+    switch (command) {
+      case PdfSaveCommand():
+        device.save();
+      case PdfRestoreCommand():
+        device.restore();
+      case PdfFillPathCommand(:final path, :final color, :final rule, :final alpha):
+        device.fillPath(path, color, rule, alpha);
+      case PdfFillPathGradientCommand(
+          :final path,
+          :final rule,
+          :final gradient,
+          :final alpha
+        ):
+        device.fillPathGradient(path, rule, gradient, alpha);
+      case PdfFillMeshCommand(:final mesh, :final alpha):
+        device.fillMesh(mesh, alpha);
+      case PdfStrokePathCommand(
+          :final path,
+          :final color,
+          :final stroke,
+          :final alpha
+        ):
+        device.strokePath(path, color, stroke, alpha);
+      case PdfClipPathCommand(:final path, :final rule):
+        device.clipPath(path, rule);
+      case PdfDrawTextCommand(:final run):
+        device.drawText(run);
+      case PdfDrawImageCommand(:final request):
+        device.drawImage(request);
+      case PdfSetBlendModeCommand(:final mode):
+        device.setBlendMode(mode);
+      case PdfBeginGroupCommand(:final alpha, :final knockout):
+        device.beginGroup(alpha, knockout: knockout);
+      case PdfEndGroupCommand():
+        device.endGroup();
+      case PdfBeginSoftMaskedCommand():
+        device.beginSoftMasked();
+      case PdfEndSoftMaskedCommand(
+          :final luminosity,
+          :final backdrop,
+          :final maskCommands,
+          :final backdropLuminance,
+          :final transferScale,
+          :final transferOffset
+        ):
+        device.endSoftMasked(
+          luminosity: luminosity,
+          backdrop: backdrop,
+          backdropLuminance: backdropLuminance,
+          transferScale: transferScale,
+          transferOffset: transferOffset,
+          drawMask: () => replayCommands(maskCommands, device),
+        );
+    }
+  }
+}

--- a/packages/pdf_graphics/test/render_command_test.dart
+++ b/packages/pdf_graphics/test/render_command_test.dart
@@ -1,0 +1,193 @@
+// Record/replay equivalence — the foundation of the background-isolate render
+// split. A page interpreted straight into a device must produce the EXACT same
+// sequence of device callbacks as the same page recorded into a
+// [RecordingPdfDevice] and then replayed via [replayCommands]. This is the
+// pure-Dart oracle (no dart:ui): it proves the recorder captures every call
+// faithfully, in order, and that the soft-mask `drawMask` closure round-trips
+// through the nested command list.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+/// Logs a detailed, deterministic transcript of every device call, recursing
+/// into soft-mask `drawMask` content so the transcript captures the full tree.
+class _TranscriptDevice implements PdfDevice {
+  final List<String> log = [];
+
+  static String _path(PdfPath p) {
+    final first = p.segments.isEmpty ? '' : p.segments.first.runtimeType;
+    return 'segs=${p.segments.length},first=$first';
+  }
+
+  static String _matrix(PdfMatrix m) =>
+      '[${m.a},${m.b},${m.c},${m.d},${m.e},${m.f}]';
+
+  static String _color(PdfColor c) => '${c.red},${c.green},${c.blue}';
+
+  @override
+  void save() => log.add('save');
+
+  @override
+  void restore() => log.add('restore');
+
+  @override
+  void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) =>
+      log.add('fill ${_path(path)} ${_color(color)} ${rule.name} $alpha');
+
+  @override
+  void fillPathGradient(
+          PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) =>
+      log.add('gradient ${_path(path)} ${rule.name} '
+          'radial=${gradient.isRadial} coords=${gradient.coords} $alpha');
+
+  @override
+  void fillMesh(PdfMesh mesh, double alpha) =>
+      log.add('mesh verts=${mesh.vertices.length} tris=${mesh.triangles.length} '
+          '$alpha');
+
+  @override
+  void strokePath(
+          PdfPath path, PdfColor color, PdfStroke stroke, double alpha) =>
+      log.add('stroke ${_path(path)} ${_color(color)} w=${stroke.width} '
+          'cap=${stroke.cap} join=${stroke.join} dash=${stroke.dashArray} '
+          '$alpha');
+
+  @override
+  void clipPath(PdfPath path, PdfFillRule rule) =>
+      log.add('clip ${_path(path)} ${rule.name}');
+
+  @override
+  void drawText(PdfTextRun run) => log.add('text "${run.text}" '
+      '${_matrix(run.transform)} ${_color(run.color)} fill=${run.fill} '
+      'invisible=${run.invisible} glyphs=${run.glyphs?.length}');
+
+  @override
+  void drawImage(PdfImageRequest request) =>
+      log.add('image ${_matrix(request.transform)} a=${request.alpha} '
+          'stencil=${request.isStencil} inline=${request.isInline}');
+
+  @override
+  void setBlendMode(PdfBlendMode mode) => log.add('blend ${mode.name}');
+
+  @override
+  void beginGroup(double alpha, {bool knockout = false}) =>
+      log.add('beginGroup $alpha knockout=$knockout');
+
+  @override
+  void endGroup() => log.add('endGroup');
+
+  @override
+  void beginSoftMasked() => log.add('beginSoftMasked');
+
+  @override
+  void endSoftMasked(
+      {required bool luminosity,
+      required PdfRect backdrop,
+      required void Function() drawMask,
+      double backdropLuminance = 0,
+      double transferScale = 1,
+      double transferOffset = 0}) {
+    log.add('endSoftMasked lum=$luminosity bd=$backdropLuminance '
+        'ts=$transferScale to=$transferOffset {');
+    drawMask();
+    log.add('}');
+  }
+}
+
+/// Interprets [content] straight into a transcript device.
+List<String> _direct(String content) {
+  final doc = CosDocument.open(buildClassicPdf());
+  final device = _TranscriptDevice();
+  PdfInterpreter(cos: doc, device: device).run(
+    ContentStreamParser.parse(Uint8List.fromList(content.codeUnits)),
+    CosDictionary(),
+  );
+  return device.log;
+}
+
+/// Interprets [content] into a recorder, then replays the buffer into a
+/// transcript device.
+List<String> _recorded(String content) {
+  final doc = CosDocument.open(buildClassicPdf());
+  final recorder = RecordingPdfDevice();
+  PdfInterpreter(cos: doc, device: recorder).run(
+    ContentStreamParser.parse(Uint8List.fromList(content.codeUnits)),
+    CosDictionary(),
+  );
+  final device = _TranscriptDevice();
+  replayCommands(recorder.commands, device);
+  return device.log;
+}
+
+void main() {
+  group('synthetic content', () {
+    final cases = <String, String>{
+      'fills and strokes':
+          'q 2 0 0 2 10 10 cm 0 0 1 rg 5 5 20 30 re f 1 0 0 RG 4 w '
+              '0 0 10 10 re S Q',
+      'dashed stroke': '[3 2] 0 d 1 w 10 10 m 90 90 l S',
+      'clip then fill': '0 0 5 5 re W n 0 0 1 rg 0 0 10 10 re f',
+      'text': 'BT /F1 24 Tf 72 720 Td (Hello, world!) Tj ET',
+      'nested q/Q': 'q q 0 0 1 1 re f Q q 1 1 2 2 re f Q Q',
+      'curves': '10 10 m 20 30 40 30 50 10 c f',
+    };
+    cases.forEach((name, content) {
+      test(name, () {
+        final direct = _direct(content);
+        expect(direct, isNotEmpty, reason: 'fixture should paint something');
+        expect(_recorded(content), equals(direct));
+      });
+    });
+  });
+
+  // Real pages exercise the serialization-fragile callbacks the synthetic
+  // cases can't reach: transparency groups, soft masks (luminosity + alpha,
+  // with their drawMask content), blend modes, mesh and axial/radial shadings,
+  // images, and knockout groups.
+  group('corpus pages', () {
+    final files = <String>[
+      '../../test_corpora/ghent/1-CMYK/GWG168_Softmasks_Vector_part1_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/GWG1610_Softmasks_Text_part1_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/'
+          'GWG160_Transp_Basic_BM_DeviceCMYK_Non-knockout_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/'
+          'GWG161_Transp_Basic_BM_DeviceCMYK_Knockout_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/GWG060_Shading_x1a.pdf',
+      '../../test_corpora/ghent/1-CMYK/GWG061_Shading_x1a.pdf',
+    ];
+    for (final path in files) {
+      final file = File(path);
+      final name = path.split('/').last;
+      test(name, () {
+        if (!file.existsSync()) {
+          markTestSkipped('$path not found');
+          return;
+        }
+        final doc = PdfDocument.open(file.readAsBytesSync());
+        for (var i = 0; i < doc.pageCount; i++) {
+          final page = doc.page(i);
+          final ops = ContentStreamParser.parse(page.contentBytes());
+
+          final direct = _TranscriptDevice();
+          PdfInterpreter(cos: doc.cos, device: direct)
+              .drawPageOperations(page, ops);
+
+          final recorder = RecordingPdfDevice();
+          PdfInterpreter(cos: doc.cos, device: recorder)
+              .drawPageOperations(page, ops);
+          final replayed = _TranscriptDevice();
+          replayCommands(recorder.commands, replayed);
+
+          expect(replayed.log, equals(direct.log),
+              reason: '$name page $i transcript diverged');
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
## What

First milestone of the background-isolate page-rendering work: split PDF page rendering into a **heavy, portable** half (parse + interpret) and a **cheap, `dart:ui`** half (canvas replay), and prove the split produces pixel-identical output. Both halves still run on the calling isolate — this lands and de-risks the seam before any isolate machinery, exactly as the brief recommends.

## Why

Today `PdfPageRenderer.renderPicture` interprets a page synchronously on the UI isolate; on heavy CAD pages the content-stream parse + walk alone is 300–500 ms, freezing scroll. `ui.Picture`/`ui.Canvas`/`ui.Image` can't cross isolate boundaries, so the fix can't just "run renderPicture in an isolate" — it has to be split into a portable command buffer (recordable anywhere) and a canvas replay (only this and image decode stay on the UI thread).

## Changes

**`pdf_graphics` (pure Dart, no `dart:ui` — keeps the layering rule):**
- `render_command.dart` — a sealed `PdfRenderCommand` model, one record per `PdfDevice` callback, all carrying the interpreter's own immutable value types (`PdfPath`, `PdfColor`, `PdfMatrix`, `PdfStroke`, `PdfGradient`, `PdfMesh`, `PdfTextRun`, `PdfImageRequest`). `replayCommands(commands, device)` dispatches them back into any `PdfDevice`. The dispatch is total over the hierarchy (adding a command without a replay case is a compile error).
- `recording_device.dart` — `RecordingPdfDevice implements PdfDevice` records every call into a flat list. Transparency-group / `q`-`Q` nesting is implicit in open/close pairing; the one callback with control flow, `endSoftMasked`'s `drawMask` closure, stores the mask group's commands inline as a nested list and replay rebuilds the closure from them.

**`dart_pdf_editor`:**
- `PdfPageRenderer.renderPictureRecorded` — records a page into the buffer, then replays it through the **unchanged** `CanvasPdfDevice`. The shared canvas setup (paper fill, `/Rotate`, y-flip) is factored into helpers so the existing synchronous `renderPicture` stays behaviour-identical (verified by the existing render tests).

## Tests

- `pdf_graphics/test/render_command_test.dart` — pure-Dart transcript-equivalence oracle: a page interpreted straight into a device must emit the exact same callback sequence as the same page recorded and replayed, including soft-mask `drawMask` content nesting. Covers synthetic content + soft-mask / transparency / knockout / shading corpus pages.
- `dart_pdf_editor/test/render_record_replay_test.dart` — **zero-tolerance** pixel-identity gate comparing `renderPicture` vs `renderPictureRecorded` rasters (both rendered in-process, so it's platform-independent and needs no stored baseline). Covers synthetic pages (fills/strokes/dashes/clip/curves/text/inline image/alpha group) and real soft-mask / transparency / blend / shading / image pages.

All new tests pass; existing render suites (`inline_image`, `transparency_group`, `knockout_group`, `mesh_shading`, `render_smoke`) and `dart analyze` are green.

## Not in this PR (subsequent milestones from the brief)

2. Image decode-to-RGBA split (return raw RGBA instead of `ui.Image`; isolate-safe DCT path).
3. Move the record half into a background isolate; transfer the buffer (binary serialization via `TransferableTypedData`); replay on main.
4. Isolate pool + per-document caching (open once, render by index).
5. Scheduler rework to dispatch concurrently; `_prerenderPreviews` reuse.
6. Web fallback gate + baseline sweep.

https://claude.ai/code/session_01P2Di1oRwtGNPeQzvQ3xWRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2Di1oRwtGNPeQzvQ3xWRD)_