### PR TITLE
Add right-click tab context menu (close / close others / close right / close all)

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -226,18 +226,98 @@ class _EditorScreenState extends State<EditorScreen>
   }
 
   /// Closes the tab at [index], confirming first when it has unsaved edits.
-  Future<void> _closeTab(int index) async {
-    final tab = _tabs[index];
-    if (tab.isDirty) {
-      final ok = await _confirmDiscard('"${tab.title}" has unsaved changes.');
+  Future<void> _closeTab(int index) => _closeTabs([_tabs[index]]);
+
+  /// Closes every tab in [targets] (tab objects, stable across the removals),
+  /// confirming once when any of them has unsaved edits. The previously active
+  /// document stays active wherever it lands; if it was closed, the selection
+  /// falls to a surviving neighbour.
+  Future<void> _closeTabs(List<DocumentTab> targets) async {
+    if (targets.isEmpty) return;
+    final dirty = targets.where((t) => t.isDirty).length;
+    if (dirty > 0) {
+      final ok = await _confirmDiscard(
+        dirty == 1
+            ? 'A document has unsaved changes.'
+            : '$dirty documents have unsaved changes.',
+      );
       if (!ok || !mounted) return;
     }
+    final active = _active;
     setState(() {
-      _tabs.remove(tab);
-      if (_activeIndex >= _tabs.length) _activeIndex = _tabs.length - 1;
-      if (_activeIndex < 0) _activeIndex = 0;
+      for (final tab in targets) {
+        _tabs.remove(tab);
+      }
+      // Keep the previously active document active when it survived.
+      final keep = active == null ? -1 : _tabs.indexOf(active);
+      if (keep >= 0) {
+        _activeIndex = keep;
+      } else {
+        if (_activeIndex >= _tabs.length) _activeIndex = _tabs.length - 1;
+        if (_activeIndex < 0) _activeIndex = 0;
+      }
     });
-    WidgetsBinding.instance.addPostFrameCallback((_) => tab.dispose());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      for (final tab in targets) {
+        tab.dispose();
+      }
+    });
+  }
+
+  /// Opens the right-click context menu for the tab at [index] at [position]
+  /// (global coordinates), offering Close / Close others / Close to the right /
+  /// Close all. Entries that would close nothing are disabled.
+  Future<void> _showTabMenu(int index, Offset position) async {
+    final tab = _tabs[index];
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox;
+    final selected = await showMenu<_TabMenuAction>(
+      context: context,
+      position: RelativeRect.fromRect(
+        position & const Size(40, 40),
+        Offset.zero & overlay.size,
+      ),
+      items: [
+        const PopupMenuItem(
+          key: ValueKey('tab-menu-close'),
+          value: _TabMenuAction.close,
+          child: Text('Close'),
+        ),
+        PopupMenuItem(
+          key: const ValueKey('tab-menu-close-others'),
+          value: _TabMenuAction.closeOthers,
+          enabled: _tabs.length > 1,
+          child: const Text('Close others'),
+        ),
+        PopupMenuItem(
+          key: const ValueKey('tab-menu-close-right'),
+          value: _TabMenuAction.closeRight,
+          enabled: index < _tabs.length - 1,
+          child: const Text('Close tabs to the right'),
+        ),
+        const PopupMenuDivider(),
+        const PopupMenuItem(
+          key: ValueKey('tab-menu-close-all'),
+          value: _TabMenuAction.closeAll,
+          child: Text('Close all'),
+        ),
+      ],
+    );
+    if (selected == null || !mounted) return;
+    // Re-resolve the tab's current position — nothing reorders while the modal
+    // menu is up, but indexing by identity is robust regardless.
+    final i = _tabs.indexOf(tab);
+    if (i < 0) return;
+    switch (selected) {
+      case _TabMenuAction.close:
+        await _closeTabs([tab]);
+      case _TabMenuAction.closeOthers:
+        await _closeTabs(_tabs.where((t) => t != tab).toList());
+      case _TabMenuAction.closeRight:
+        await _closeTabs(_tabs.sublist(i + 1));
+      case _TabMenuAction.closeAll:
+        await _closeTabs(List.of(_tabs));
+    }
   }
 
   Future<bool> _confirmDiscard(String message) async {
@@ -621,6 +701,8 @@ class _EditorScreenState extends State<EditorScreen>
           child: InkWell(
             borderRadius: BorderRadius.circular(8),
             onTap: () => setState(() => _activeIndex = index),
+            onSecondaryTapUp: (details) =>
+                _showTabMenu(index, details.globalPosition),
             child: Padding(
               padding: const EdgeInsets.only(left: 12, right: 2),
               child: Row(
@@ -648,6 +730,9 @@ class _EditorScreenState extends State<EditorScreen>
   }
 }
 
+/// The actions offered by a tab's right-click context menu.
+enum _TabMenuAction { close, closeOthers, closeRight, closeAll }
+
 /// Starts a tab drag immediately for mouse pointers (the desktop expectation —
 /// a mouse drag never means scrolling the strip) but only after a long press
 /// for touch and stylus, so finger drags still scroll the tab strip. Plain
@@ -664,6 +749,8 @@ class _TabDragStartListener extends ReorderableDragStartListener {
   Widget build(BuildContext context) {
     return Listener(
       onPointerDown: (event) {
+        // A right-click opens the tab context menu — never a drag-reorder.
+        if (event.buttons == kSecondaryButton) return;
         SliverReorderableList.maybeOf(context)?.startItemDragReorder(
           index: index,
           event: event,

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -1,0 +1,141 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/incoming_file.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    // The mock store is process-global; reset it so a prior test's persisted
+    // preferences never leak into this one.
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+
+  tearDown(() => prefs.dispose());
+
+  // Delivers a PDF to the running app the way the OS would (a warm-start
+  // "open with"), opening it in a new tab.
+  Future<void> openTab(WidgetTester tester, String name) async {
+    const codec = StandardMethodCodec();
+    final message = codec.encodeMethodCall(
+      MethodCall('openFile', {'name': name, 'bytes': buildClassicPdf()}),
+    );
+    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      IncomingFileService.channelName,
+      message,
+      (_) {},
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  // The tab title within the strip (scoped to the tab-strip ReorderableListView
+  // so it never matches the AppBar's active-document title nor the thumbnail
+  // sidebar's own reorderable list in the body).
+  Finder tabTitle(String name) => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: find.text(name),
+      );
+
+  // Right-clicks the tab labelled [name] to open its context menu.
+  Future<void> rightClickTab(WidgetTester tester, String name) async {
+    final gesture = await tester.startGesture(
+      tester.getCenter(tabTitle(name)),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> openTabs(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'alpha.pdf');
+    await openTab(tester, 'beta.pdf');
+    await openTab(tester, 'gamma.pdf');
+  }
+
+  testWidgets('right-click opens the tab context menu', (tester) async {
+    await openTabs(tester);
+
+    await rightClickTab(tester, 'beta.pdf');
+
+    expect(find.byKey(const ValueKey('tab-menu-close')), findsOneWidget);
+    expect(find.byKey(const ValueKey('tab-menu-close-others')), findsOneWidget);
+    expect(find.byKey(const ValueKey('tab-menu-close-right')), findsOneWidget);
+    expect(find.byKey(const ValueKey('tab-menu-close-all')), findsOneWidget);
+  });
+
+  testWidgets('Close others leaves only the clicked tab', (tester) async {
+    await openTabs(tester);
+
+    await rightClickTab(tester, 'beta.pdf');
+    await tester.tap(find.byKey(const ValueKey('tab-menu-close-others')));
+    await tester.pumpAndSettle();
+
+    expect(tabTitle('alpha.pdf'), findsNothing);
+    expect(tabTitle('gamma.pdf'), findsNothing);
+    expect(tabTitle('beta.pdf'), findsOneWidget);
+    expect(find.byTooltip('Close tab'), findsOneWidget);
+  });
+
+  testWidgets('Close tabs to the right keeps the clicked tab and its left',
+      (tester) async {
+    await openTabs(tester);
+
+    await rightClickTab(tester, 'beta.pdf');
+    await tester.tap(find.byKey(const ValueKey('tab-menu-close-right')));
+    await tester.pumpAndSettle();
+
+    expect(tabTitle('alpha.pdf'), findsOneWidget);
+    expect(tabTitle('beta.pdf'), findsOneWidget);
+    expect(tabTitle('gamma.pdf'), findsNothing);
+  });
+
+  testWidgets('Close right is disabled on the rightmost tab', (tester) async {
+    await openTabs(tester);
+
+    await rightClickTab(tester, 'gamma.pdf');
+
+    final item = tester.widget<PopupMenuItem<dynamic>>(
+      find.byKey(const ValueKey('tab-menu-close-right')),
+    );
+    expect(item.enabled, isFalse);
+  });
+
+  testWidgets('Close all removes every tab', (tester) async {
+    await openTabs(tester);
+
+    await rightClickTab(tester, 'alpha.pdf');
+    await tester.tap(find.byKey(const ValueKey('tab-menu-close-all')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('tab-strip')), findsNothing);
+    expect(find.byTooltip('Close tab'), findsNothing);
+  });
+
+  testWidgets('Close on the active tab activates a surviving neighbour',
+      (tester) async {
+    await openTabs(tester);
+    // gamma is active (last opened).
+
+    await rightClickTab(tester, 'gamma.pdf');
+    await tester.tap(find.byKey(const ValueKey('tab-menu-close')));
+    await tester.pumpAndSettle();
+
+    expect(tabTitle('gamma.pdf'), findsNothing);
+    // beta is now the rightmost survivor and becomes active.
+    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+        FontWeight.w600);
+  });
+}


### PR DESCRIPTION
## What

The desktop app's browser-style tab strip now has a right-click context menu, matching how Chrome/VS Code/etc. manage tabs:

- **Close**
- **Close others**
- **Close tabs to the right**
- **Close all**

Entries that would close nothing (Close others with one tab; Close to the right on the rightmost tab) are disabled.

## How

- `_closeTab(index)` now delegates to a new batch-aware `_closeTabs(List<DocumentTab>)` that operates on tab objects (stable across the removals), confirms unsaved changes **once** for the whole batch, and keeps the previously active document active wherever it lands (falling to a surviving neighbour when the active tab is itself closed).
- `_showTabMenu(index, globalPosition)` builds the popup via `showMenu`; the action re-resolves the tab by identity so it's robust even though nothing reorders while the modal menu is up.
- Wired in through the tab's `InkWell.onSecondaryTapUp`.
- `_TabDragStartListener` now ignores secondary-button (`kSecondaryButton`) pointer-downs, so a right-click opens the menu instead of starting a drag-reorder.

## Tests

`app/test/tabs_menu_test.dart` (6 tests): menu opens on right-click, Close others / Close to the right / Close all behave, Close-right is disabled on the rightmost tab, and closing the active tab activates a surviving neighbour. Existing `tabs_reorder_test.dart` still passes (the secondary-button guard doesn't affect primary-button drag reordering).

https://claude.ai/code/session_014mSZnhUozofHkxmLFKpFdU

---
_Generated by [Claude Code](https://claude.ai/code/session_014mSZnhUozofHkxmLFKpFdU)_