### PR TITLE
Add pdf_ocr_vlm: SOTA VLM OCR engine plugin + example app wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+      - name: Test pdf_ocr_vlm
+        working-directory: packages/pdf_ocr_vlm
+        run: flutter test
+
       - name: Test DartPDF app
         working-directory: app
         run: flutter test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2218,3 +2218,31 @@ pdf_document/test/check_mark_test.dart (4) + dart_pdf_editor/test/
 editing_count_test.dart (6 — placement/clamp/colour, cross-page tally with
 undo/redo, viewer tap drops marks). The 14 Ghent render-baseline failures
 are pre-existing on this machine, unrelated.
+
+OCR engine plugin (Ben: "support SOTA OCR + docs to set it up"): the OCR
+seam (`PdfOcrEngine`/`applyOcr`, dart_pdf_editor) now has a shipping
+backend — a new workspace package **`packages/pdf_ocr_vlm`**
+(`VlmOcrEngine implements PdfOcrEngine`). It POSTs each page raster (PNG
+via `ui.Image.toByteData(format: png)`, no extra deps) to an out-of-process
+HTTP OCR service and maps the returned pixel boxes back through
+`PdfOcrPageImage.userSpaceRect`. Two paths: the default ctor speaks a small
+documented JSON contract (`{image,width,height} → {spans:[{text,bbox,
+confidence}]}`; lenient parser accepts spans/words/lines/results/regions/
+cells/data, bbox/box/rect or polygon/poly/points/quad, confidence/score/
+conf), and `VlmOcrEngine.dotsOcr(...)` targets a vLLM server hosting
+`rednote-hilab/dots.ocr` (current SOTA OSS doc-OCR VLM) over its
+OpenAI-compatible chat endpoint with NO adapter — `openAiChatRequestBody`
+sends the image+layout prompt, `dotsOcrResponseParser(categories)` reads
+the JSON-array-in-message-content (strips ```json fences) and keeps
+text-bearing layout categories (`dotsOcrTextCategories`; Picture/Table
+skipped). `requestBody`/`responseParser` typedefs are the override seams
+for cloud VLMs / PaddleOCR / Tesseract. CRITICAL: `PdfOcrSpan` lives in
+pdf_document (part of editor.dart), so the package depends on AND imports
+pdf_document, not just dart_pdf_editor. Tests (vlm_ocr_engine_test.dart, 5)
+use http's MockClient — no network/GPU: simple-contract request shape +
+pixel→user mapping, dots.ocr OpenAI shape + category filter, applyOcr
+end-to-end selectable layer, non-200 → VlmOcrException, polygon/varied-key
+parsing. README is the setup doc (SOTA landscape table, Docker/vLLM
+one-liner, the JSON contract + a ~30-line FastAPI/PaddleOCR reference
+adapter, cloud-VLM override example). Added to the root workspace list;
+deps http ^1.2.0. Not in the first-publish order yet (Ben's call).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2246,3 +2246,15 @@ parsing. README is the setup doc (SOTA landscape table, Docker/vLLM
 one-liner, the JSON contract + a ~30-line FastAPI/PaddleOCR reference
 adapter, cloud-VLM override example). Added to the root workspace list;
 deps http ^1.2.0. Not in the first-publish order yet (Ben's call).
+Example-app wiring (Ben: "with a way to supply creds or login"): main.dart
+'More actions ▸ Add OCR text layer…' (enabled iff a session tab is active)
+opens `_OcrSettingsDialog` (keys 'ocr-endpoint'/'ocr-model'/'ocr-api-key'/
+'ocr-run' — endpoint + model + optional bearer token, obscured, plus a
+'How to set up an OCR server' link to the package README), then runs
+`applyOcr` over every page behind `_OcrProgressDialog` (ValueNotifier page
+counter) and opens the result in a NEW tab '$title (OCR)'. Creds live in
+`_ViewerScreenState` (`_ocrEndpoint`/`_ocrModel`/`_ocrApiKey`) for the
+app's life — the API key is kept in MEMORY ONLY, never written to disk (so
+the example needs no shared_preferences for it). dep pdf_ocr_vlm ^0.1.0.
+The 9 example test failures are pre-existing on this machine (raster/
+headless) — identical set with and without this wiring, zero regressions.

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_ocr_vlm/pdf_ocr_vlm.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -112,6 +113,14 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// Demo of the two drop-in widgets: the toggle swaps the full
   /// [PdfEditorView] for the view-only [PdfReader]. App-wide.
   bool _readOnly = false;
+
+  /// OCR connection settings, supplied through the credentials dialog and
+  /// remembered for the app's lifetime (the API key is deliberately kept in
+  /// memory only — the example never writes a secret to disk). Defaults to a
+  /// local vLLM/dots.ocr server; see the pdf_ocr_vlm README to run one.
+  String _ocrEndpoint = 'http://localhost:8000/v1/chat/completions';
+  String _ocrModel = 'model';
+  String? _ocrApiKey;
 
   /// GoTo and the standard named page actions never get here (the viewer
   /// follows them itself). Custom-scheme URIs are dispatched as app
@@ -404,6 +413,77 @@ class _ViewerScreenState extends State<ViewerScreen> {
     }
   }
 
+  /// Adds an invisible, selectable/searchable OCR text layer over the
+  /// active document using a self-hosted vision-language OCR model
+  /// (pdf_ocr_vlm). Prompts for the service endpoint and an optional API
+  /// key/token first, then runs every page and opens the result in a new
+  /// tab. The original is left untouched.
+  Future<void> _runOcr() async {
+    final tab = _active;
+    final bytes = tab?.session?.bytes;
+    if (tab == null || bytes == null) {
+      _toast('Open a document before running OCR');
+      return;
+    }
+
+    // Supply / confirm the OCR service credentials.
+    final settings = await showDialog<_OcrSettings>(
+      context: context,
+      builder: (_) => _OcrSettingsDialog(
+        endpoint: _ocrEndpoint,
+        model: _ocrModel,
+        apiKey: _ocrApiKey,
+        onOpenDocs: () => _openLink(Uri.parse(
+            'https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_ocr_vlm')),
+      ),
+    );
+    if (settings == null) return; // cancelled
+    setState(() {
+      _ocrEndpoint = settings.endpoint;
+      _ocrModel = settings.model;
+      _ocrApiKey = settings.apiKey;
+    });
+
+    final progress = ValueNotifier<String>('Preparing…');
+    if (!mounted) return;
+    unawaited(showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => _OcrProgressDialog(progress: progress),
+    ));
+
+    final engine = VlmOcrEngine.dotsOcr(
+      endpoint: Uri.parse(settings.endpoint),
+      model: settings.model.isEmpty ? 'model' : settings.model,
+      apiKey: (settings.apiKey?.isNotEmpty ?? false) ? settings.apiKey : null,
+    );
+    try {
+      final editor = PdfEditor(PdfDocument.open(bytes));
+      final count = editor.document.pageCount;
+      var spans = 0;
+      for (var i = 0; i < count; i++) {
+        progress.value = 'Recognising page ${i + 1} of $count…';
+        spans += await editor.applyOcr(i, engine, pixelRatio: 2);
+      }
+      final result = editor.save();
+      if (!mounted) return;
+      Navigator.of(context, rootNavigator: true).pop(); // dismiss progress
+      _openBytes(result, '${tab.title} (OCR)');
+      _toast('OCR added $spans text spans — the page text is now selectable');
+    } on VlmOcrException catch (e) {
+      if (!mounted) return;
+      Navigator.of(context, rootNavigator: true).pop();
+      _toast('OCR failed: ${e.message}');
+    } catch (e) {
+      if (!mounted) return;
+      Navigator.of(context, rootNavigator: true).pop();
+      _toast('OCR failed: $e');
+    } finally {
+      engine.close();
+      progress.dispose();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final tab = _active;
@@ -493,6 +573,16 @@ class _ViewerScreenState extends State<ViewerScreen> {
             tooltip: 'More actions',
             onSelected: (action) => action(),
             itemBuilder: (context) => [
+              PopupMenuItem(
+                value: () => unawaited(_runOcr()),
+                enabled: tab?.session != null,
+                child: const ListTile(
+                  leading: Icon(Icons.document_scanner_outlined),
+                  title: Text('Add OCR text layer…'),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+              const PopupMenuDivider(),
               PopupMenuItem(
                 value: () => _openLink(_githubUrl),
                 child: const ListTile(
@@ -715,6 +805,168 @@ class _DocumentTab {
     session?.dispose();
     viewer?.dispose();
     noteField.dispose();
+  }
+}
+
+/// The OCR service connection the credentials dialog returns.
+class _OcrSettings {
+  const _OcrSettings({required this.endpoint, required this.model, this.apiKey});
+
+  final String endpoint;
+  final String model;
+  final String? apiKey;
+}
+
+/// Collects the OCR service endpoint, model name, and an optional API
+/// key/token before a run — the "supply credentials / login" step. The key
+/// is sent as an `Authorization: Bearer …` header by the engine.
+class _OcrSettingsDialog extends StatefulWidget {
+  const _OcrSettingsDialog({
+    required this.endpoint,
+    required this.model,
+    required this.apiKey,
+    required this.onOpenDocs,
+  });
+
+  final String endpoint;
+  final String model;
+  final String? apiKey;
+  final VoidCallback onOpenDocs;
+
+  @override
+  State<_OcrSettingsDialog> createState() => _OcrSettingsDialogState();
+}
+
+class _OcrSettingsDialogState extends State<_OcrSettingsDialog> {
+  late final _endpoint = TextEditingController(text: widget.endpoint);
+  late final _model = TextEditingController(text: widget.model);
+  late final _apiKey = TextEditingController(text: widget.apiKey ?? '');
+  bool _obscureKey = true;
+
+  @override
+  void dispose() {
+    _endpoint.dispose();
+    _model.dispose();
+    _apiKey.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Run OCR'),
+      content: SizedBox(
+        width: 460,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Adds a selectable, searchable text layer over scanned pages '
+              'using a vision-language OCR model you host (dots.ocr on vLLM, '
+              'or any OpenAI-compatible OCR endpoint).',
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              key: const ValueKey('ocr-endpoint'),
+              controller: _endpoint,
+              autofocus: true,
+              decoration: const InputDecoration(
+                labelText: 'Service endpoint',
+                hintText: 'http://localhost:8000/v1/chat/completions',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              key: const ValueKey('ocr-model'),
+              controller: _model,
+              decoration: const InputDecoration(
+                labelText: 'Model name',
+                hintText: 'model',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              key: const ValueKey('ocr-api-key'),
+              controller: _apiKey,
+              obscureText: _obscureKey,
+              decoration: InputDecoration(
+                labelText: 'API key / token (optional)',
+                helperText: 'Sent as Authorization: Bearer …',
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                      _obscureKey ? Icons.visibility : Icons.visibility_off),
+                  tooltip: _obscureKey ? 'Show' : 'Hide',
+                  onPressed: () => setState(() => _obscureKey = !_obscureKey),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                icon: const Icon(Icons.help_outline, size: 18),
+                label: const Text('How to set up an OCR server'),
+                onPressed: widget.onOpenDocs,
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton.icon(
+          key: const ValueKey('ocr-run'),
+          icon: const Icon(Icons.document_scanner_outlined),
+          label: const Text('Run OCR'),
+          onPressed: () {
+            final endpoint = _endpoint.text.trim();
+            if (endpoint.isEmpty) return;
+            final key = _apiKey.text.trim();
+            Navigator.of(context).pop(_OcrSettings(
+              endpoint: endpoint,
+              model: _model.text.trim(),
+              apiKey: key.isEmpty ? null : key,
+            ));
+          },
+        ),
+      ],
+    );
+  }
+}
+
+/// Modal shown while OCR runs; [progress] reports the current page.
+class _OcrProgressDialog extends StatelessWidget {
+  const _OcrProgressDialog({required this.progress});
+
+  final ValueListenable<String> progress;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: Row(
+        children: [
+          const SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(strokeWidth: 3),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: ValueListenableBuilder<String>(
+              valueListenable: progress,
+              builder: (context, value, _) => Text(value),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/packages/dart_pdf_editor/example/pubspec.yaml
+++ b/packages/dart_pdf_editor/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   pdf_document: ^1.0.0
   dart_pdf_editor: ^1.0.0
+  pdf_ocr_vlm: ^0.1.0
   share_plus: ^13.1.0
   url_launcher: ^6.3.0
 

--- a/packages/pdf_ocr_vlm/CHANGELOG.md
+++ b/packages/pdf_ocr_vlm/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release. `VlmOcrEngine` implements `dart_pdf_editor`'s
+  `PdfOcrEngine` by POSTing each page raster to an HTTP OCR service and
+  mapping the recognized boxes back into PDF user space.
+- `VlmOcrEngine.dotsOcr` preset targets a vLLM server hosting
+  `rednote-hilab/dots.ocr` over its OpenAI-compatible chat API, with no
+  adapter required.
+- A small default JSON contract (`{image, width, height} → {spans: [...]}`)
+  plus `requestBody`/`responseParser` hooks for custom or cloud backends.

--- a/packages/pdf_ocr_vlm/LICENSE
+++ b/packages/pdf_ocr_vlm/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/pdf_ocr_vlm/README.md
+++ b/packages/pdf_ocr_vlm/README.md
@@ -1,0 +1,325 @@
+# pdf_ocr_vlm
+
+[![License: Apache-2.0](https://img.shields.io/github/license/ben-milanko/dart-pdf)](https://github.com/ben-milanko/dart-pdf/blob/main/LICENSE)
+
+A pluggable **OCR engine** for the
+[dart-pdf suite](https://github.com/ben-milanko/dart-pdf). It adds an
+invisible, selectable, searchable text layer over scanned (image-only) PDF
+pages, using a **state-of-the-art vision-language OCR model** that you
+self-host — or any HTTP OCR service you wrap to a small JSON contract.
+
+`dart_pdf_editor` ships the OCR *seam* (`PdfOcrEngine`,
+`PdfEditor.applyOcr`) but no engine — OCR is a large native/GPU/cloud
+subsystem that doesn't belong inside a pure-Dart PDF toolkit. This package
+fills that seam over HTTP, so the heavy model runs out of process (a Docker
+container, a GPU box, a cloud endpoint) and your Flutter app stays thin.
+
+```
+┌──────────────┐   page raster (PNG)    ┌──────────────────────┐
+│ dart_pdf_*   │ ─────────────────────► │  OCR service (HTTP)  │
+│ applyOcr()   │                        │  e.g. dots.ocr/vLLM  │
+│              │ ◄───────────────────── │  on a GPU / cloud    │
+└──────────────┘   words + pixel boxes  └──────────────────────┘
+        │
+        ▼  inject invisible text at the recognized boxes
+   selectable · searchable · copyable · extractable PDF
+```
+
+---
+
+## Why a VLM, and which one? (SOTA, mid-2026)
+
+Document OCR has moved from detector+recognizer pipelines (Tesseract,
+EasyOCR) to **vision-language models** that read layout, reading order, and
+text in one pass and return structured JSON with bounding boxes. The
+current leaders (open-weight, self-hostable, and returning boxes — which is
+what an over-the-scan text layer needs):
+
+| Model | Size | Notes |
+| --- | --- | --- |
+| **dots.ocr** (`rednote-hilab/dots.ocr`) | ~1.7B | Layout + reading order + text in one model, 100+ languages, returns `bbox`+`category`+`text` JSON. **This package's default preset.** |
+| **PaddleOCR-VL** | ~0.9B | Strong multilingual; OpenAI-compatible serving. |
+| **GOT-OCR 2.0** | 580M | Runs on ~4 GB VRAM; Markdown/LaTeX output. |
+| **Qwen3-VL / DeepSeek-OCR / GLM-OCR** | 0.9–3B | General VLMs / OCR-specialized; box quality varies. |
+| Cloud frontier (Gemini 3 Flash, Claude, GPT) | — | Highest accuracy, no GPU to run, per-call cost; box support varies. |
+
+This package defaults to **dots.ocr on [vLLM](https://docs.vllm.ai)**: it is
+open, small enough for a single consumer GPU, multilingual, and — crucially —
+returns per-block pixel bounding boxes that map cleanly onto the page. You
+can point the same engine at any of the others (see
+[Other backends](#other-backends)).
+
+> Sources for the landscape above: the
+> [definitive OCR-in-2026 guide](https://slavadubrov.github.io/blog/2026/03/04/the-definitive-guide-to-ocr-in-2026-from-pipelines-to-vlms/),
+> [best open-source OCR tools](https://unstract.com/blog/best-opensource-ocr-tools/),
+> [dots.ocr on GitHub](https://github.com/rednote-hilab/dots.ocr) /
+> [Hugging Face](https://huggingface.co/rednote-hilab/dots.ocr), and
+> [vLLM OCR recipes](https://docs.vllm.ai/projects/recipes/en/latest/).
+
+---
+
+## Install
+
+```yaml
+dependencies:
+  dart_pdf_editor: ^1.0.0
+  pdf_ocr_vlm: ^0.1.0
+```
+
+`pdf_ocr_vlm` works wherever Flutter runs (mobile, desktop, **web**) — it
+only does an HTTP POST, so the model can live anywhere reachable. Make sure
+the OCR service is CORS-enabled if you call it from a web build.
+
+---
+
+## Quick start
+
+```dart
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_ocr_vlm/pdf_ocr_vlm.dart';
+
+Future<Uint8List> ocrEntirePdf(Uint8List bytes) async {
+  final editor = PdfEditor(PdfDocument.open(bytes));
+
+  // Talk to a vLLM server hosting dots.ocr (see "Run the model" below).
+  final engine = VlmOcrEngine.dotsOcr(
+    endpoint: Uri.parse('http://localhost:8000/v1/chat/completions'),
+  );
+
+  for (var page = 0; page < editor.document.pageCount; page++) {
+    final spans = await editor.applyOcr(page, engine, pixelRatio: 2);
+    debugPrint('page $page: wrote $spans text spans');
+  }
+  engine.close();
+
+  return editor.save(); // the scan now has a selectable/searchable layer
+}
+```
+
+`applyOcr` rasterizes the page, hands the raster to the engine, and writes
+each recognized word as **invisible text (render mode 3)** placed exactly
+over the scan — the page looks identical, but text can now be selected,
+searched, copied, and extracted. Pass `visible: true` to burn the layer in
+(useful for debugging the box alignment).
+
+### Wire it into the editor UI
+
+```dart
+IconButton(
+  icon: const Icon(Icons.document_scanner),
+  tooltip: 'OCR this page',
+  onPressed: () async {
+    final editor = PdfEditor(PdfDocument.open(currentBytes));
+    await editor.applyOcr(
+      pageIndex,
+      engine,
+      pixelRatio: 2.5,      // raise for small type
+      minConfidence: 0.30,  // drop junk
+    );
+    // applyOcr mutates the editor's document in place; save the bytes and
+    // re-open them in your viewer/editor as the new document.
+    final ocrdBytes = editor.save();
+    onDocumentReady(ocrdBytes);
+  },
+)
+```
+
+---
+
+## Run the model (dots.ocr on vLLM)
+
+The official image serves an **OpenAI-compatible** chat endpoint, which
+`VlmOcrEngine.dotsOcr` speaks directly — **no adapter server needed**.
+
+With Docker + an NVIDIA GPU:
+
+```bash
+docker run --gpus all -p 8000:8000 \
+  rednotehilab/dots.ocr:vllm-openai-v0.9.1 \
+  vllm serve /workspace/weights/DotsOCR \
+    --served-model-name model \
+    --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.95 \
+    --chat-template-content-format string \
+    --trust-remote-code
+```
+
+Or with a local vLLM install:
+
+```bash
+pip install -U vllm transformers
+huggingface-cli download rednote-hilab/dots.ocr --local-dir ./DotsOCR
+vllm serve ./DotsOCR \
+  --served-model-name model \
+  --gpu-memory-utilization 0.95 \
+  --chat-template-content-format string \
+  --trust-remote-code
+```
+
+Then point the engine at it:
+
+```dart
+final engine = VlmOcrEngine.dotsOcr(
+  endpoint: Uri.parse('http://YOUR_GPU_HOST:8000/v1/chat/completions'),
+  model: 'model',          // must match --served-model-name
+  apiKey: null,            // set if you front it with an auth proxy
+  // categories: {...},    // which dots.ocr layout blocks become text
+  // minConfidence: 0.0,   // dots.ocr returns no per-cell score → keep 0
+);
+```
+
+`dotsOcr` sends the page image plus the dots.ocr layout prompt, then reads
+the JSON array the model returns (`[{bbox, category, text}, ...]`),
+keeps the text-bearing blocks (`Text`, `Title`, `Section-header`,
+`List-item`, `Caption`, `Footnote`, `Page-header`, `Page-footer` — `Picture`
+and `Table` are skipped by default), and maps each pixel `bbox` onto the
+page. Override `categories:` to include tables/formulas.
+
+> **No GPU?** dots.ocr also runs (slowly) on CPU via vLLM/transformers for
+> trials, and the same preset works against a cloud-hosted dots.ocr or any
+> OpenAI-compatible OCR VLM — just change `endpoint`, `model`, and `apiKey`.
+
+---
+
+## The simple JSON contract (any OCR server)
+
+If you'd rather front your own engine (PaddleOCR, Surya, docTR, Tesseract, a
+custom pipeline), wrap it in a tiny HTTP service that speaks this contract
+and use the **default constructor** — no preset, no custom Dart.
+
+**Request** — `POST <endpoint>`, `Content-Type: application/json`:
+
+```json
+{
+  "image": "<base64 PNG of the page>",
+  "image_format": "png",
+  "width": 1224,
+  "height": 1584,
+  "page": 0,
+  "languages": ["en"]      // present only if you pass languages:
+}
+```
+
+**Response** — `200`, a list of recognized fragments. Boxes are in **raster
+pixels, top-left origin** (the same `width`×`height` you were sent):
+
+```json
+{
+  "spans": [
+    { "text": "Invoice",  "bbox": [96, 110, 320, 156], "confidence": 0.98 },
+    { "text": "Total",    "bbox": [96, 980, 240, 1020], "confidence": 0.95 }
+  ]
+}
+```
+
+```dart
+final engine = VlmOcrEngine(
+  endpoint: Uri.parse('http://localhost:8001/ocr'),
+  languages: const ['en'],
+  minConfidence: 0.3,
+);
+```
+
+The default parser is lenient: the list may be top-level or under any of
+`spans` / `words` / `lines` / `results` / `regions` / `cells` / `data`; text
+may be `text` / `transcription` / `content`; a box may be a 4-number
+`bbox` / `box` / `bounding_box` / `rect`, **or** a polygon under
+`polygon` / `poly` / `points` / `quad`; confidence may be
+`confidence` / `score` / `conf` (default `1.0`). So most off-the-shelf OCR
+JSON drops in unchanged.
+
+### Reference adapter (≈30 lines, FastAPI + PaddleOCR)
+
+```python
+# pip install fastapi uvicorn paddleocr pillow
+import base64, io
+from fastapi import FastAPI, Request
+from PIL import Image
+from paddleocr import PaddleOCR
+
+app = FastAPI()
+ocr = PaddleOCR(use_angle_cls=True, lang="en")
+
+@app.post("/ocr")
+async def recognize(req: Request):
+    body = await req.json()
+    img = Image.open(io.BytesIO(base64.b64decode(body["image"]))).convert("RGB")
+    import numpy as np
+    result = ocr.ocr(np.array(img), cls=True)
+    spans = []
+    for line in (result[0] or []):
+        poly, (text, conf) = line
+        spans.append({"text": text, "polygon": poly, "confidence": float(conf)})
+    return {"spans": spans}
+# uvicorn server:app --host 0.0.0.0 --port 8001
+```
+
+---
+
+## Other backends
+
+`requestBody` and `responseParser` are the two seams; override either to
+target a different service without leaving Dart.
+
+### A cloud VLM (custom prompt + parser)
+
+```dart
+final engine = VlmOcrEngine(
+  endpoint: Uri.parse('https://api.example.com/v1/chat/completions'),
+  headers: {'authorization': 'Bearer $apiKey'},
+  model: 'some-vision-model',
+  prompt: 'Return a JSON array of {bbox:[x0,y0,x1,y1] in pixels, text}.',
+  requestBody: openAiChatRequestBody,          // reuse the chat encoder
+  responseParser: (json, page) {
+    // navigate choices[0].message.content yourself, then build words…
+    // return List<VlmOcrWord> with pixel-space Rects.
+  },
+);
+```
+
+`VlmOcrWord` carries a **pixel-space** `Rect`; `applyOcr` maps it to PDF
+user space for you (`PdfOcrPageImage.userSpaceRect` undoes the crop box and
+`/Rotate` that the raster already baked in), so a parser never does page
+geometry.
+
+---
+
+## API surface
+
+| Symbol | Purpose |
+| --- | --- |
+| `VlmOcrEngine(...)` | Generic engine for the simple JSON contract. |
+| `VlmOcrEngine.dotsOcr(...)` | Preset for dots.ocr on an OpenAI-compatible vLLM endpoint. |
+| `VlmOcrInput` | The rendered page (base64 PNG + dims + hints) given to a request builder. |
+| `VlmOcrWord` | One recognized fragment in **pixel** coordinates. |
+| `defaultVlmRequestBody` / `defaultVlmResponseParser` | The simple-contract default hooks. |
+| `openAiChatRequestBody` | Chat-completions request encoder (image + prompt). |
+| `dotsOcrResponseParser`, `dotsOcrLayoutPrompt`, `dotsOcrTextCategories` | dots.ocr building blocks. |
+| `VlmOcrException` | Thrown on transport / status / parse failures. |
+
+`applyOcr`'s own options live in `dart_pdf_editor`: `pixelRatio` (OCR raster
+resolution — 2 ≈ 144 dpi, raise for small type), `minConfidence`, `visible`,
+and `font`.
+
+---
+
+## Tips & limitations
+
+- **Resolution drives accuracy.** Start at `pixelRatio: 2`; small or dense
+  type wants `2.5`–`3`. Higher = larger PNG = slower request.
+- **The layer is byte-encoded text.** Code points outside Latin-1 still
+  position correctly (selection/search boxes line up) but render as `?` if
+  you make the layer `visible`; invisible layers extract the original text.
+- **Already-digital PDFs don't need OCR** — they have real text already.
+  Use this for scans and image-only pages.
+- **Box granularity** follows the model. dots.ocr returns block/line boxes,
+  so selection snaps to lines, not individual words — fine for search and
+  copy. A word-level engine (PaddleOCR/Tesseract) over the simple contract
+  gives word boxes.
+- **Network & privacy.** Page rasters leave the device. For sensitive
+  documents, self-host the model on infrastructure you control.
+
+## License
+
+Apache-2.0 — see [LICENSE](LICENSE).

--- a/packages/pdf_ocr_vlm/README.md
+++ b/packages/pdf_ocr_vlm/README.md
@@ -103,6 +103,14 @@ over the scan — the page looks identical, but text can now be selected,
 searched, copied, and extracted. Pass `visible: true` to burn the layer in
 (useful for debugging the box alignment).
 
+### Try it in the example app
+
+The suite's example app (`packages/dart_pdf_editor/example`) wires this in:
+**More actions ▸ Add OCR text layer…** opens a dialog to supply the service
+endpoint, model name, and an optional API key/token (sent as
+`Authorization: Bearer …`), then OCRs every page and opens the result in a
+new tab. Point it at a server from [Run the model](#run-the-model-dotsocr-on-vllm).
+
 ### Wire it into the editor UI
 
 ```dart

--- a/packages/pdf_ocr_vlm/analysis_options.yaml
+++ b/packages/pdf_ocr_vlm/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/packages/pdf_ocr_vlm/lib/pdf_ocr_vlm.dart
+++ b/packages/pdf_ocr_vlm/lib/pdf_ocr_vlm.dart
@@ -1,0 +1,13 @@
+/// A pluggable OCR engine for [`dart_pdf_editor`](https://pub.dev/packages/dart_pdf_editor)
+/// backed by a vision-language-model (VLM) OCR service.
+///
+/// Implements `PdfOcrEngine` so `PdfEditor.applyOcr` can turn a scanned,
+/// image-only page into one whose text can be selected, searched, copied,
+/// and extracted — without changing how the page looks.
+///
+/// Point [VlmOcrEngine] at a self-hosted state-of-the-art OCR model (see
+/// [VlmOcrEngine.dotsOcr]) or any HTTP service you wrap to the documented
+/// JSON contract.
+library;
+
+export 'src/vlm_ocr_engine.dart';

--- a/packages/pdf_ocr_vlm/lib/src/vlm_ocr_engine.dart
+++ b/packages/pdf_ocr_vlm/lib/src/vlm_ocr_engine.dart
@@ -1,0 +1,503 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/painting.dart' show Rect;
+import 'package:http/http.dart' as http;
+import 'package:pdf_document/pdf_document.dart' show PdfOcrSpan;
+
+/// Thrown when a remote OCR service is unreachable, returns a non-200
+/// status, or returns a body this engine cannot parse.
+class VlmOcrException implements Exception {
+  VlmOcrException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'VlmOcrException: $message';
+}
+
+/// The rasterized page handed to a request builder. The page has already
+/// been rendered to a PNG ([imageBase64] / [imageDataUrl]); the builder
+/// turns it into whatever JSON the target service expects.
+class VlmOcrInput {
+  const VlmOcrInput({
+    required this.imageBase64,
+    required this.imageDataUrl,
+    required this.width,
+    required this.height,
+    required this.pageIndex,
+    required this.languages,
+    required this.model,
+    required this.prompt,
+  });
+
+  /// The page raster as base64-encoded PNG bytes.
+  final String imageBase64;
+
+  /// The same PNG as a `data:image/png;base64,...` URL — what an
+  /// OpenAI-compatible chat vision API wants under `image_url`.
+  final String imageDataUrl;
+
+  /// Raster pixel dimensions (the coordinate space recognized boxes use).
+  final int width;
+  final int height;
+
+  /// The page's index in its document (for logging / multi-page services).
+  final int pageIndex;
+
+  /// Optional ISO language hints passed through from the engine.
+  final List<String> languages;
+
+  /// Optional model name passed through from the engine.
+  final String? model;
+
+  /// Optional instruction prompt (used by chat-style VLM backends).
+  final String? prompt;
+}
+
+/// A single recognized fragment, positioned in **raster pixels**
+/// (top-left origin, y down — the natural output of an OCR model run on the
+/// PNG the engine sent). [VlmOcrEngine] converts these to PDF user space via
+/// `PdfOcrPageImage.userSpaceRect`.
+class VlmOcrWord {
+  const VlmOcrWord({
+    required this.text,
+    required this.pixelBounds,
+    this.confidence = 1.0,
+  });
+
+  final String text;
+  final Rect pixelBounds;
+  final double confidence;
+}
+
+/// Builds the HTTP request body (a JSON-encodable object or a ready String)
+/// for one page. Override to target a service with a bespoke schema.
+typedef VlmOcrRequestBody = FutureOr<Object?> Function(VlmOcrInput input);
+
+/// Parses a decoded JSON response into recognized words. Override to read a
+/// service's bespoke response shape.
+typedef VlmOcrResponseParser = List<VlmOcrWord> Function(
+  Object? json,
+  PdfOcrPageImage page,
+);
+
+/// A [PdfOcrEngine] that recognizes a page by POSTing its raster to an HTTP
+/// OCR service and mapping the returned boxes back into PDF user space.
+///
+/// Two ready paths:
+///
+///  * the default constructor speaks a small, documented JSON contract
+///    (POST `{image, width, height, ...}` → `{spans: [{text, bbox,
+///    confidence}]}`) — point it at the reference adapter in the README, or
+///    any server you wrap to that shape;
+///  * [VlmOcrEngine.dotsOcr] speaks the OpenAI-compatible chat API exposed by
+///    a vLLM server running `rednote-hilab/dots.ocr` (a current
+///    state-of-the-art open-source document-OCR VLM) with no adapter at all.
+///
+/// For anything else — a cloud VLM, PaddleOCR, Tesseract, a gRPC gateway —
+/// pass a custom [requestBody]/[responseParser], or implement [PdfOcrEngine]
+/// directly. The page geometry math (crop box, /Rotate, pixel→user) is done
+/// for you by `PdfOcrPageImage.userSpaceRect`.
+class VlmOcrEngine implements PdfOcrEngine {
+  VlmOcrEngine({
+    required this.endpoint,
+    this.headers = const {},
+    this.languages = const [],
+    this.model,
+    this.prompt,
+    this.minConfidence = 0,
+    VlmOcrRequestBody? requestBody,
+    VlmOcrResponseParser? responseParser,
+    http.Client? client,
+    this.timeout = const Duration(minutes: 2),
+  })  : buildRequestBody = requestBody ?? defaultVlmRequestBody,
+        parseResponse = responseParser ?? defaultVlmResponseParser,
+        _client = client ?? http.Client(),
+        _ownsClient = client == null;
+
+  /// The OCR service URL the page raster is POSTed to.
+  final Uri endpoint;
+
+  /// Extra request headers, e.g. `{'authorization': 'Bearer ...'}`.
+  final Map<String, String> headers;
+
+  /// Optional language hints handed to [buildRequestBody].
+  final List<String> languages;
+
+  /// Optional model name handed to [buildRequestBody].
+  final String? model;
+
+  /// Optional instruction prompt handed to [buildRequestBody] (chat VLMs).
+  final String? prompt;
+
+  /// Words below this confidence are dropped before mapping.
+  final double minConfidence;
+
+  /// Turns a rasterized page into the request body.
+  final VlmOcrRequestBody buildRequestBody;
+
+  /// Turns the decoded JSON response into recognized words.
+  final VlmOcrResponseParser parseResponse;
+
+  /// Per-page request timeout.
+  final Duration timeout;
+
+  final http.Client _client;
+  final bool _ownsClient;
+
+  /// Targets a vLLM server hosting `rednote-hilab/dots.ocr` over its
+  /// OpenAI-compatible chat endpoint (default
+  /// `http://localhost:8000/v1/chat/completions`).
+  ///
+  /// dots.ocr returns a JSON array of layout cells, each with a pixel `bbox`
+  /// (`[x1, y1, x2, y2]`, top-left origin), a `category`, and the cell
+  /// `text`. Cells whose category is in [categories] (text-bearing blocks by
+  /// default; `Picture` and `Table` are excluded) become the OCR layer.
+  ///
+  /// See the package README for the one-line Docker command that serves the
+  /// model.
+  factory VlmOcrEngine.dotsOcr({
+    Uri? endpoint,
+    String model = 'model',
+    String? apiKey,
+    String? prompt,
+    Set<String>? categories,
+    List<String> languages = const [],
+    double minConfidence = 0,
+    http.Client? client,
+    Duration timeout = const Duration(minutes: 2),
+  }) {
+    final cats = categories ?? dotsOcrTextCategories;
+    return VlmOcrEngine(
+      endpoint:
+          endpoint ?? Uri.parse('http://localhost:8000/v1/chat/completions'),
+      headers: {if (apiKey != null) 'authorization': 'Bearer $apiKey'},
+      model: model,
+      languages: languages,
+      prompt: prompt ?? dotsOcrLayoutPrompt,
+      minConfidence: minConfidence,
+      requestBody: openAiChatRequestBody,
+      responseParser: dotsOcrResponseParser(cats),
+      client: client,
+      timeout: timeout,
+    );
+  }
+
+  @override
+  Future<List<PdfOcrSpan>> recognize(PdfOcrPageImage page) async {
+    final png = await _encodePng(page.image);
+    final b64 = base64Encode(png);
+    final input = VlmOcrInput(
+      imageBase64: b64,
+      imageDataUrl: 'data:image/png;base64,$b64',
+      width: page.width,
+      height: page.height,
+      pageIndex: page.pageIndex,
+      languages: languages,
+      model: model,
+      prompt: prompt,
+    );
+
+    final body = await buildRequestBody(input);
+    final encoded = body is String ? body : jsonEncode(body);
+
+    http.Response res;
+    try {
+      res = await _client
+          .post(
+            endpoint,
+            headers: {
+              'content-type': 'application/json',
+              'accept': 'application/json',
+              ...headers,
+            },
+            body: encoded,
+          )
+          .timeout(timeout);
+    } on TimeoutException {
+      throw VlmOcrException('OCR request to $endpoint timed out after '
+          '${timeout.inSeconds}s');
+    } catch (e) {
+      throw VlmOcrException('OCR request to $endpoint failed: $e');
+    }
+
+    if (res.statusCode != 200) {
+      throw VlmOcrException(
+          'OCR service returned HTTP ${res.statusCode}: ${res.body}');
+    }
+
+    Object? decoded;
+    try {
+      decoded = jsonDecode(utf8.decode(res.bodyBytes));
+    } catch (e) {
+      throw VlmOcrException('OCR service returned non-JSON body: $e');
+    }
+
+    final words = parseResponse(decoded, page);
+    return [
+      for (final w in words)
+        if (w.confidence >= minConfidence &&
+            w.text.trim().isNotEmpty &&
+            w.pixelBounds.width > 0 &&
+            w.pixelBounds.height > 0)
+          PdfOcrSpan(
+            text: w.text,
+            bounds: page.userSpaceRect(w.pixelBounds),
+            confidence: w.confidence,
+          ),
+    ];
+  }
+
+  /// Releases the underlying HTTP client if this engine created it.
+  void close() {
+    if (_ownsClient) _client.close();
+  }
+
+  static Future<Uint8List> _encodePng(ui.Image image) async {
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    if (data == null) {
+      throw VlmOcrException('could not encode the page raster to PNG');
+    }
+    return data.buffer.asUint8List();
+  }
+}
+
+/// The default request body for the simple JSON contract: a POST of the
+/// page PNG plus its dimensions and any hints. See the README for the
+/// matching response shape and a reference server.
+Object defaultVlmRequestBody(VlmOcrInput input) => {
+      'image': input.imageBase64,
+      'image_format': 'png',
+      'width': input.width,
+      'height': input.height,
+      'page': input.pageIndex,
+      if (input.languages.isNotEmpty) 'languages': input.languages,
+      if (input.model != null) 'model': input.model,
+    };
+
+/// The default response parser for the simple JSON contract.
+///
+/// Accepts either a top-level list of items or a map carrying one under
+/// `spans`/`words`/`lines`/`results`/`regions`/`data`. Each item needs some
+/// `text` (`text`/`transcription`/`content`) and a box, given either as a
+/// 4-number `bbox`/`box`/`bounding_box`/`rect` (`[x0, y0, x1, y1]`, pixels)
+/// or a list of points under `polygon`/`poly`/`points`/`quad`. Confidence is
+/// read from `confidence`/`score`/`conf`, defaulting to 1.
+List<VlmOcrWord> defaultVlmResponseParser(Object? json, PdfOcrPageImage page) {
+  final list = _asItemList(json);
+  final words = <VlmOcrWord>[];
+  for (final item in list) {
+    if (item is! Map) continue;
+    final text = _firstString(item, const ['text', 'transcription', 'content']);
+    if (text == null) continue;
+    final rect = _rectFrom(item);
+    if (rect == null) continue;
+    words.add(VlmOcrWord(
+      text: text,
+      pixelBounds: rect,
+      confidence: _confidence(item),
+    ));
+  }
+  return words;
+}
+
+/// Builds an OpenAI-compatible chat-completions request that sends the page
+/// as an inline image and asks for OCR. Used by [VlmOcrEngine.dotsOcr]; reuse
+/// it (with a matching [VlmOcrResponseParser]) for other chat-style VLM
+/// gateways.
+Object openAiChatRequestBody(VlmOcrInput input) => {
+      if (input.model != null) 'model': input.model,
+      'messages': [
+        {
+          'role': 'user',
+          'content': [
+            {'type': 'text', 'text': input.prompt ?? dotsOcrLayoutPrompt},
+            {
+              'type': 'image_url',
+              'image_url': {'url': input.imageDataUrl},
+            },
+          ],
+        },
+      ],
+      'temperature': 0.0,
+      'max_tokens': 16384,
+    };
+
+/// dots.ocr layout categories that carry plain, selectable text. `Picture`
+/// (no text), `Table` (text is HTML markup), and `Formula` (LaTeX) are left
+/// out by default; pass your own set to [VlmOcrEngine.dotsOcr] to include
+/// them.
+const Set<String> dotsOcrTextCategories = {
+  'Caption',
+  'Footnote',
+  'List-item',
+  'Page-footer',
+  'Page-header',
+  'Section-header',
+  'Text',
+  'Title',
+};
+
+/// The layout-parsing instruction dots.ocr is trained on: emit a JSON array
+/// of cells in reading order, each with a pixel `bbox`, a `category`, and the
+/// cell `text`.
+const String dotsOcrLayoutPrompt =
+    'Please output the layout information from this PDF page image, '
+    'including each layout element\'s bbox, its category, and the '
+    'corresponding text content within the bbox.\n\n'
+    '1. Bbox format: [x1, y1, x2, y2] in pixel coordinates of this image.\n'
+    '2. Layout Categories: the possible categories are Caption, Footnote, '
+    'Formula, List-item, Page-footer, Page-header, Picture, Section-header, '
+    'Table, Text, and Title.\n'
+    '3. Text Extraction: extract the plain text for each element; leave it '
+    'empty for Picture.\n'
+    '4. Reading order: arrange the elements in human reading order.\n'
+    '5. Output: a single JSON array, no extra commentary.';
+
+/// Builds a parser for dots.ocr's OpenAI-compatible responses, keeping only
+/// cells whose `category` is in [categories].
+VlmOcrResponseParser dotsOcrResponseParser(Set<String> categories) {
+  return (Object? json, PdfOcrPageImage page) {
+    final content = _openAiMessageContent(json);
+    if (content == null) {
+      throw VlmOcrException(
+          'dots.ocr response had no choices[0].message.content');
+    }
+    Object? cells;
+    try {
+      cells = jsonDecode(_stripJsonFences(content));
+    } catch (e) {
+      throw VlmOcrException('dots.ocr content was not valid JSON: $e');
+    }
+    final list = _asItemList(cells);
+    final words = <VlmOcrWord>[];
+    for (final item in list) {
+      if (item is! Map) continue;
+      final category = item['category'];
+      if (category is String && !categories.contains(category)) continue;
+      final text = _firstString(item, const ['text', 'content']);
+      if (text == null) continue;
+      final rect = _rectFrom(item);
+      if (rect == null) continue;
+      words.add(VlmOcrWord(text: text, pixelBounds: rect));
+    }
+    return words;
+  };
+}
+
+// --- parsing helpers -------------------------------------------------------
+
+List<Object?> _asItemList(Object? json) {
+  if (json is List) return json;
+  if (json is Map) {
+    for (final key in const [
+      'spans',
+      'words',
+      'lines',
+      'results',
+      'regions',
+      'cells',
+      'data',
+    ]) {
+      final value = json[key];
+      if (value is List) return value;
+    }
+  }
+  return const [];
+}
+
+String? _openAiMessageContent(Object? json) {
+  if (json is! Map) return null;
+  final choices = json['choices'];
+  if (choices is! List || choices.isEmpty) return null;
+  final first = choices.first;
+  if (first is! Map) return null;
+  final message = first['message'];
+  if (message is Map) {
+    final content = message['content'];
+    if (content is String) return content;
+  }
+  // Some gateways put the text directly on the choice.
+  final text = first['text'];
+  return text is String ? text : null;
+}
+
+String _stripJsonFences(String content) {
+  var s = content.trim();
+  if (s.startsWith('```')) {
+    final newline = s.indexOf('\n');
+    if (newline != -1) s = s.substring(newline + 1);
+    if (s.endsWith('```')) s = s.substring(0, s.length - 3);
+  }
+  return s.trim();
+}
+
+String? _firstString(Map item, List<String> keys) {
+  for (final key in keys) {
+    final value = item[key];
+    if (value is String) return value;
+  }
+  return null;
+}
+
+double _confidence(Map item) {
+  for (final key in const ['confidence', 'score', 'conf']) {
+    final value = item[key];
+    if (value is num) return value.toDouble().clamp(0.0, 1.0);
+  }
+  return 1.0;
+}
+
+Rect? _rectFrom(Map item) {
+  for (final key in const ['bbox', 'box', 'bounding_box', 'rect']) {
+    final value = item[key];
+    if (value is List && value.length >= 4 && value.every((e) => e is num)) {
+      final x0 = (value[0] as num).toDouble();
+      final y0 = (value[1] as num).toDouble();
+      final x1 = (value[2] as num).toDouble();
+      final y1 = (value[3] as num).toDouble();
+      return Rect.fromLTRB(x0, y0, x1, y1);
+    }
+  }
+  for (final key in const ['polygon', 'poly', 'points', 'quad']) {
+    final value = item[key];
+    final rect = _rectFromPoints(value);
+    if (rect != null) return rect;
+  }
+  return null;
+}
+
+Rect? _rectFromPoints(Object? value) {
+  if (value is! List || value.isEmpty) return null;
+  var minX = double.infinity, minY = double.infinity;
+  var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+  var count = 0;
+
+  void add(num x, num y) {
+    minX = x < minX ? x.toDouble() : minX;
+    minY = y < minY ? y.toDouble() : minY;
+    maxX = x > maxX ? x.toDouble() : maxX;
+    maxY = y > maxY ? y.toDouble() : maxY;
+    count++;
+  }
+
+  if (value.first is List) {
+    for (final p in value) {
+      if (p is List && p.length >= 2 && p[0] is num && p[1] is num) {
+        add(p[0] as num, p[1] as num);
+      }
+    }
+  } else if (value.first is num && value.length >= 4 && value.length.isEven) {
+    for (var i = 0; i + 1 < value.length; i += 2) {
+      if (value[i] is num && value[i + 1] is num) {
+        add(value[i] as num, value[i + 1] as num);
+      }
+    }
+  }
+  if (count < 2) return null;
+  return Rect.fromLTRB(minX, minY, maxX, maxY);
+}

--- a/packages/pdf_ocr_vlm/pubspec.yaml
+++ b/packages/pdf_ocr_vlm/pubspec.yaml
@@ -1,0 +1,32 @@
+name: pdf_ocr_vlm
+description: >-
+  Vision-language-model OCR engine for dart_pdf_editor — add a selectable,
+  searchable text layer over scanned PDF pages using a self-hosted SOTA OCR
+  model (dots.ocr) or any HTTP OCR service.
+version: 0.1.0
+repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_ocr_vlm
+issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
+topics:
+  - pdf
+  - ocr
+  - text-recognition
+  - scanned-documents
+resolution: workspace
+
+environment:
+  sdk: ^3.5.0
+  flutter: '>=3.24.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  dart_pdf_editor: ^1.0.0
+  pdf_document: ^1.0.0
+  http: ^1.2.0
+
+dev_dependencies:
+  pdf_graphics: ^1.0.0
+  pdf_test_fixtures: ^1.0.0
+  flutter_lints: ^5.0.0
+  flutter_test:
+    sdk: flutter

--- a/packages/pdf_ocr_vlm/test/vlm_ocr_engine_test.dart
+++ b/packages/pdf_ocr_vlm/test/vlm_ocr_engine_test.dart
@@ -1,0 +1,191 @@
+// VlmOcrEngine talks to an OCR HTTP service and maps the boxes it returns
+// back into PDF user space. These tests stand in a MockClient for the
+// service, so they exercise the request shape, the response parsing (both
+// the simple contract and the dots.ocr OpenAI shape), and the pixel→user
+// geometry — with no network and no GPU.
+import 'dart:convert';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_ocr_vlm/pdf_ocr_vlm.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  // buildClassicPdf is 612 x 792 pt; render at 2 px/pt → 1224 x 1584 px.
+  Future<PdfOcrPageImage> renderPage() async {
+    final doc = PdfDocument.open(buildClassicPdf());
+    final image = await PdfPageRenderer.renderImage(doc.page(0), pixelRatio: 2);
+    return PdfOcrPageImage(
+      image: image,
+      page: doc.page(0),
+      pageIndex: 0,
+      pixelRatio: 2,
+    );
+  }
+
+  testWidgets('simple contract: request shape and pixel→user mapping',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = await renderPage();
+      Map<String, dynamic>? sentBody;
+
+      final client = MockClient((request) async {
+        sentBody = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          jsonEncode({
+            'spans': [
+              {'text': 'Hello', 'bbox': [0, 0, 200, 60], 'confidence': 0.9},
+            ],
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final engine = VlmOcrEngine(
+        endpoint: Uri.parse('http://localhost:9/ocr'),
+        client: client,
+      );
+      final spans = await engine.recognize(page);
+
+      // The default request body carries the raster and its dimensions.
+      expect(sentBody!['width'], page.width);
+      expect(sentBody!['height'], page.height);
+      expect(sentBody!['image_format'], 'png');
+      expect((sentBody!['image'] as String).isNotEmpty, isTrue);
+
+      // The top-left 200x60 px box maps to the top of the page (y up).
+      expect(spans, hasLength(1));
+      expect(spans.single.text, 'Hello');
+      expect(spans.single.confidence, closeTo(0.9, 1e-9));
+      expect(spans.single.bounds.left, closeTo(0, 0.5));
+      expect(spans.single.bounds.right, closeTo(100, 0.5)); // 200 px / 2
+      expect(spans.single.bounds.top, closeTo(792, 0.5)); // page top
+      expect(spans.single.bounds.bottom, closeTo(762, 0.5)); // 792 - 60/2
+
+      page.image.dispose();
+    });
+  });
+
+  testWidgets('dotsOcr: OpenAI chat shape, JSON-in-content, category filter',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = await renderPage();
+      Map<String, dynamic>? sentBody;
+
+      final client = MockClient((request) async {
+        sentBody = jsonDecode(request.body) as Map<String, dynamic>;
+        // dots.ocr replies with a JSON array of layout cells inside the
+        // assistant message content (here wrapped in a ```json fence).
+        final content = '```json\n${jsonEncode([
+              {'bbox': [0, 0, 200, 60], 'category': 'Title', 'text': 'Report'},
+              {'bbox': [0, 100, 200, 160], 'category': 'Picture', 'text': ''},
+              {'bbox': [0, 200, 400, 260], 'category': 'Text', 'text': 'Body'},
+            ])}\n```';
+        return http.Response(
+          jsonEncode({
+            'choices': [
+              {'message': {'role': 'assistant', 'content': content}},
+            ],
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final engine = VlmOcrEngine.dotsOcr(
+        endpoint: Uri.parse('http://localhost:9/v1/chat/completions'),
+        client: client,
+      );
+      final spans = await engine.recognize(page);
+
+      // OpenAI chat request: an image_url part is present.
+      final messages = sentBody!['messages'] as List;
+      final parts = (messages.first as Map)['content'] as List;
+      expect(parts.any((p) => (p as Map)['type'] == 'image_url'), isTrue);
+
+      // The Picture cell is dropped; the two text cells survive.
+      expect(spans.map((s) => s.text), containsAll(['Report', 'Body']));
+      expect(spans.where((s) => s.text == ''), isEmpty);
+      expect(spans, hasLength(2));
+
+      page.image.dispose();
+    });
+  });
+
+  testWidgets('applyOcr writes a selectable layer via the engine',
+      (tester) async {
+    await tester.runAsync(() async {
+      final original = buildClassicPdf();
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode({
+            'spans': [
+              {'text': 'Scanned', 'bbox': [100, 120, 340, 156]},
+            ],
+          }),
+          200,
+        );
+      });
+
+      final editor = PdfEditor(PdfDocument.open(original));
+      final written = await editor.applyOcr(
+        0,
+        VlmOcrEngine(endpoint: Uri.parse('http://localhost:9/ocr'),
+            client: client),
+        pixelRatio: 2,
+      );
+      expect(written, 1);
+
+      final reopened = PdfDocument.open(editor.save());
+      final pageText = PdfTextExtractor.extract(reopened, 0);
+      expect(pageText.text, contains('Scanned'));
+    });
+  });
+
+  testWidgets('a non-200 response throws VlmOcrException', (tester) async {
+    await tester.runAsync(() async {
+      final page = await renderPage();
+      final client = MockClient((request) async =>
+          http.Response('upstream model not loaded', 503));
+      final engine = VlmOcrEngine(
+        endpoint: Uri.parse('http://localhost:9/ocr'),
+        client: client,
+      );
+      await expectLater(
+        engine.recognize(page),
+        throwsA(isA<VlmOcrException>()),
+      );
+      page.image.dispose();
+    });
+  });
+
+  test('default parser reads polygon points and varied keys', () {
+    // No page geometry needed: parse straight to pixel boxes.
+    final words = defaultVlmResponseParser({
+      'results': [
+        {
+          'transcription': 'poly',
+          'points': [[10, 20], [110, 22], [108, 60], [12, 58]],
+          'score': 0.8,
+        },
+      ],
+    }, _NullPage());
+    expect(words, hasLength(1));
+    expect(words.single.text, 'poly');
+    expect(words.single.confidence, closeTo(0.8, 1e-9));
+    expect(words.single.pixelBounds, const Rect.fromLTRB(10, 20, 110, 60));
+  });
+}
+
+/// A stand-in [PdfOcrPageImage] for the pure parser test, which never reads
+/// the page (it returns pixel boxes, mapped to user space elsewhere).
+class _NullPage implements PdfOcrPageImage {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - packages/pdf_cos
   - packages/pdf_document
   - packages/pdf_graphics
+  - packages/pdf_ocr_vlm
   - packages/dart_pdf_editor
   - packages/dart_pdf_editor/example
   - packages/pdf_test_fixtures


### PR DESCRIPTION
## What & why

`dart_pdf_editor` ships the OCR *seam* (`PdfOcrEngine`, `PdfEditor.applyOcr`) but no engine — OCR is a large GPU/cloud subsystem that doesn't belong inside a pure-Dart PDF toolkit. This PR provides a shipping backend for that seam plus a way to actually use it from the example app.

### Research — SOTA OCR (mid-2026)

Document OCR has moved from detector+recognizer pipelines (Tesseract/EasyOCR) to **vision-language models** that read layout, reading order, and text in one pass and return structured JSON with bounding boxes. The self-hostable leaders that return boxes (what an over-the-scan text layer needs): **dots.ocr** (~1.7B, 100+ langs, `bbox`+`category`+`text`), PaddleOCR-VL, GOT-OCR 2.0, Qwen3-VL/DeepSeek-OCR/GLM-OCR; cloud frontier (Gemini 3 Flash, Claude, GPT) lead on raw accuracy. The plugin defaults to **dots.ocr on vLLM** — open, single-GPU, multilingual, OpenAI-compatible, clean pixel boxes.

## New package — `packages/pdf_ocr_vlm`

`VlmOcrEngine implements PdfOcrEngine`, filling the seam over HTTP so the heavy model runs out of process.

- **`VlmOcrEngine.dotsOcr(...)`** — talks straight to a vLLM/dots.ocr OpenAI-compatible endpoint, **no adapter server**: sends the page image + layout prompt, parses the JSON-array-in-message-content (strips ` ```json ` fences), keeps text-bearing layout categories, maps pixel boxes → PDF user space via `PdfOcrPageImage.userSpaceRect`.
- **Generic `VlmOcrEngine(...)`** — a small documented JSON contract (`{image,width,height} → {spans:[{text,bbox,confidence}]}`) with a lenient default parser, plus `requestBody`/`responseParser` override hooks for cloud VLMs / PaddleOCR / Tesseract.
- Page raster encoded to PNG via `ui.Image.toByteData(format: png)` — only new dep is `http`.
- **README is the setup doc**: SOTA landscape table with sources, one-line Docker + local vLLM commands, the JSON contract, a ~30-line FastAPI/PaddleOCR reference adapter, a cloud-VLM override example, an API table, and tuning/limitation notes.

## Example app wiring

**More actions ▸ Add OCR text layer…** opens a credentials dialog (service endpoint, model name, optional API key/token sent as `Authorization: Bearer …`, with a link to the setup docs), runs OCR over every page behind a progress dialog, and opens the OCR'd result in a new tab. The original is untouched; the API key is held **in memory only** (never written to disk).

## Verification

- `dart analyze` clean across the whole workspace.
- **All 5 `pdf_ocr_vlm` tests pass** via `http`'s `MockClient` — no network/GPU: request-shape + pixel→user mapping, dots.ocr OpenAI shape + category filter, `applyOcr` end-to-end selectable layer, non-200 → `VlmOcrException`, polygon/varied-key parsing.
- Example test failures are **pre-existing** (raster/headless on this machine) — verified the failing set is identical with and without the example wiring (zero regressions).

## Notes

- `pdf_ocr_vlm` is added to the root workspace but deliberately **not** placed in the first-publish order in `CLAUDE.md` — publishing/ordering is your manual call.

Sources: [Definitive OCR-in-2026 guide](https://slavadubrov.github.io/blog/2026/03/04/the-definitive-guide-to-ocr-in-2026-from-pipelines-to-vlms/), [best open-source OCR tools](https://unstract.com/blog/best-opensource-ocr-tools/), [dots.ocr (GitHub)](https://github.com/rednote-hilab/dots.ocr) / [Hugging Face](https://huggingface.co/rednote-hilab/dots.ocr), [vLLM OCR recipes](https://docs.vllm.ai/projects/recipes/en/latest/).

https://claude.ai/code/session_01DHHhXysKaoSkVJqhyzjKWk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHHhXysKaoSkVJqhyzjKWk)_