### PR TITLE
test(perf): automated real-world Chrome render-worker perf loop

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -51,3 +51,9 @@ app.*.map.json
 web/pdf_render_worker.dart.js
 web/pdf_render_worker.dart.js.map
 web/pdf_render_worker.dart.js.deps
+
+# Chrome perf-loop tooling artifacts (tool/perf/)
+tool/perf/node_modules/
+tool/perf/package-lock.json
+tool/perf/results.ndjson
+tool/perf/loop.log

--- a/app/tool/perf/README.md
+++ b/app/tool/perf/README.md
@@ -1,0 +1,63 @@
+# Automated real-world Chrome perf loop
+
+An unattended version of the manual `flutter run -d chrome` perf check: it
+loads the big CAD PDF in **real headless Chrome** (system Chrome, dart2js
+build), auto-scrolls every page, scrapes the `PdfPerfLog` trace + `FrameTiming`,
+and prints a verdict — repeatably, so a loop can chart trends and catch
+dart2js-only regressions (like the Int64 accessor bug) that VM tests can't.
+
+## Pieces
+
+- **`perf_harness.dart`** — a standalone Flutter web entrypoint (not the shipping
+  app). Fetches the PDF from `/perf.pdf`, mounts the real `PdfEditorView` with
+  the web render worker, enables `PdfPerfLog`, captures every `debugPrint` line
+  and every frame's timing, then auto-scrolls all pages. Exposes to the driver:
+  `window.__perfDone`, `__perfDump()`, `__perfFrames()`, `__perfError`. Scroll
+  knobs come from the URL query (`?maxPages=&dwell=&passes=&fast=`) so the
+  prebuilt bundle never needs a rebuild to vary the run.
+- **`driver.mjs`** — Node + `puppeteer-core` (system Chrome, no download). Serves
+  `build/web` + `/perf.pdf`, drives Chrome through the harness, waits for
+  `__perfDone`, parses the trace, prints a summary, and appends one JSON record
+  per run to `results.ndjson`.
+- **`build.sh`** — compiles the render worker + the harness bundle into
+  `app/build/web`. Run once per code change.
+- **`loop.sh N`** — runs the driver N times (alternating full + capped sweeps),
+  then reports the aggregate.
+- **`report.mjs`** — summarises `results.ndjson` (per-run table + aggregate;
+  flags FAIL and UI-thread-interpret regressions).
+
+## Usage
+
+```sh
+cd app/tool/perf
+npm install                       # once — pulls puppeteer-core only
+tool/perf/build.sh                # after any engine/app change (from app/)
+node driver.mjs                   # one run (full 133-page sweep)
+PERF_MAX_PAGES=40 node driver.mjs # one capped run (~30s)
+./loop.sh 8                       # eight runs + aggregate
+node report.mjs 20                # last 20 runs' trend
+```
+
+### Env (driver)
+
+| var | default | meaning |
+|-----|---------|---------|
+| `PERF_PDF` | `~/Downloads/MW307(TNT975)F-UPS-ZB.pdf` | PDF to serve at `/perf.pdf` |
+| `PERF_MAX_PAGES` | `0` (all) | cap pages scrolled (faster smoke) |
+| `PERF_DWELL_MS` | `220` | dwell on each page |
+| `PERF_FAST_PASS` | `1` | add a coarse fast-fling pass |
+| `PERF_HEADLESS` | `true` | `false` for a visible window |
+| `PERF_TIMEOUT` | `300` | overall budget, seconds |
+| `PERF_VERBOSE` | `false` | echo every browser console line |
+| `PERF_PORT` / `PERF_CHROME` | `8099` / system Chrome | server port / Chrome path |
+
+## Verdict
+
+`✓ PASS` — no harness/page errors, frames captured, pages visited. `◐ PASS
+(ui-interp)` — passed but some page interpreted on the UI thread
+(`path=plain`/`recorded`), the regression signal the worker offload exists to
+prevent. `✗ FAIL` — a fatal (startup crash, timeout) or any error line.
+
+The trace fields parsed: interpret-path counts (`worker`/`recorded`/`plain`),
+worker decode bytes + warm ms (the off-thread image decode), and the
+`FrameTiming` build-duration distribution (p50/p95/max, counts over 16/32/50ms).

--- a/app/tool/perf/build.sh
+++ b/app/tool/perf/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Compiles the render worker + the perf-harness web bundle into app/build/web,
+# ready for tool/perf/driver.mjs to serve and drive. Run once per code change;
+# the driver can then loop against the built bundle without rebuilding.
+#
+#   tool/perf/build.sh            # release build (default)
+#   PROFILE=1 tool/perf/build.sh  # profile build (Dart asserts off, source maps)
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."   # -> app/
+
+DART="${DART:-fvm dart}"
+FLUTTER="${FLUTTER:-fvm flutter}"
+MODE="--release"
+[ "${PROFILE:-0}" = "1" ] && MODE="--profile"
+
+echo "==> Building the render worker (web)"
+$DART run dart_pdf_editor:build_web_worker
+
+echo "==> flutter build web $MODE (harness entrypoint, PDF_PERF_LOG=true)"
+$FLUTTER build web $MODE \
+  --target tool/perf/perf_harness.dart \
+  --dart-define=PDF_PERF_LOG=true \
+  "$@"
+
+echo "==> Done. Harness bundle in app/build/web; worker beside index.html."

--- a/app/tool/perf/driver.mjs
+++ b/app/tool/perf/driver.mjs
@@ -1,0 +1,285 @@
+// Headless-Chrome driver for the render-worker web perf harness.
+//
+// Serves build/web (the harness bundle) plus the big PDF at /perf.pdf, drives
+// real Chrome through it via puppeteer-core (system Chrome, no download), waits
+// for the harness auto-scroll to finish, then scrapes the captured perf trace
+// and FrameTiming and prints a summary. Appends one JSON record per run to
+// results.ndjson so a loop can chart trends.
+//
+// Prereqs:  npm install            (in this dir; pulls puppeteer-core only)
+//           tool/perf/build.sh     (compiles the worker + harness into build/web)
+//
+// Run:      node driver.mjs
+//
+// Env:
+//   PERF_PORT      http port                         (default 8099)
+//   PERF_PDF       path to the PDF to serve          (default ~/Downloads/MW307...)
+//   PERF_WEB_DIR   static dir to serve               (default ../../build/web)
+//   PERF_HEADLESS  "false" for a visible window      (default true)
+//   PERF_TIMEOUT   overall budget, seconds           (default 300)
+//   PERF_VERBOSE   "true" to echo every console line  (default false)
+//   PERF_RESULTS   ndjson output path                (default ./results.ndjson)
+import { createServer } from 'node:http';
+import { readFile, stat, appendFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, extname, normalize, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import puppeteer from 'puppeteer-core';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.PERF_PORT ?? 8099);
+const WEB_DIR = normalize(process.env.PERF_WEB_DIR ?? join(HERE, '..', '..', 'build', 'web'));
+const PDF = process.env.PERF_PDF ?? join(homedir(), 'Downloads', 'MW307(TNT975)F-UPS-ZB.pdf');
+const HEADLESS = (process.env.PERF_HEADLESS ?? 'true') !== 'false';
+const TIMEOUT_S = Number(process.env.PERF_TIMEOUT ?? 300);
+const VERBOSE = (process.env.PERF_VERBOSE ?? 'false') === 'true';
+const RESULTS = process.env.PERF_RESULTS ?? join(HERE, 'results.ndjson');
+const CHROME = process.env.PERF_CHROME ??
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+// Negative control: serve a 404 for the worker script to force UI-thread
+// fallback, so we can confirm the loop actually catches a regression.
+const NO_WORKER = (process.env.PERF_NO_WORKER ?? 'false') === 'true';
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.css': 'text/css; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.ttf': 'font/ttf',
+  '.otf': 'font/otf',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.bin': 'application/octet-stream',
+  '.pdf': 'application/pdf',
+};
+
+function startServer() {
+  return new Promise((resolve, reject) => {
+    const server = createServer(async (req, res) => {
+      try {
+        let path = decodeURIComponent(req.url.split('?')[0]);
+        if (path === '/perf.pdf') {
+          const buf = await readFile(PDF);
+          res.writeHead(200, { 'content-type': 'application/pdf', 'content-length': buf.length });
+          res.end(buf);
+          return;
+        }
+        // Negative control: 404 the worker script so the app degrades to
+        // UI-thread render — the loop must then flag the regression.
+        if (NO_WORKER && path === '/pdf_render_worker.dart.js') {
+          res.writeHead(404); res.end('worker disabled'); return;
+        }
+        if (path === '/') path = '/index.html';
+        // Resolve inside WEB_DIR only (no traversal).
+        const file = normalize(join(WEB_DIR, path));
+        if (!file.startsWith(WEB_DIR)) { res.writeHead(403); res.end(); return; }
+        const info = await stat(file).catch(() => null);
+        if (!info || !info.isFile()) { res.writeHead(404); res.end('not found'); return; }
+        const buf = await readFile(file);
+        const type = MIME[extname(file).toLowerCase()] ?? 'application/octet-stream';
+        // The render worker is a same-origin classic worker; no COOP/COEP needed.
+        res.writeHead(200, { 'content-type': type, 'content-length': buf.length });
+        res.end(buf);
+      } catch (e) {
+        res.writeHead(500);
+        res.end(String(e));
+      }
+    });
+    server.on('error', reject);
+    server.listen(PORT, '127.0.0.1', () => resolve(server));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Trace parsing
+// ---------------------------------------------------------------------------
+function pctile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const i = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[i];
+}
+
+function parse(lines, frames) {
+  const r = {
+    interpret: { worker: 0, recorded: 0, plain: 0, other: 0 },
+    pages: new Set(),
+    workerResultBytes: 0,
+    workerResultMax: 0,
+    workerWarmMax: 0,
+    jankCount: 0,
+    errorLines: [],
+    declines: 0,
+    harness: {},
+  };
+  for (const line of lines) {
+    const m = line.match(/interpret page=(\d+) path=(\w+)/);
+    if (m) {
+      r.pages.add(Number(m[1]));
+      const path = m[2];
+      if (path in r.interpret) r.interpret[path]++; else r.interpret.other++;
+    }
+    const wr = line.match(/webworker result page=\d+ (\d+)B/);
+    if (wr) {
+      const b = Number(wr[1]);
+      r.workerResultBytes += b;
+      r.workerResultMax = Math.max(r.workerResultMax, b);
+    }
+    const warm = line.match(/worker warm=([\d.]+)ms/);
+    if (warm) r.workerWarmMax = Math.max(r.workerWarmMax, Number(warm[1]));
+    if (/JANK /.test(line)) r.jankCount++;
+    if (/declin/i.test(line)) r.declines++;
+    if (/error|exception|unsupported|cannot|failed/i.test(line) && /\[perf|webworker/.test(line)) {
+      r.errorLines.push(line.trim());
+    }
+    const hp = line.match(/HARNESS (pageCount|DONE|loaded|PASS) ?(.*)/);
+    if (hp) r.harness[hp[1]] = (hp[2] || '').trim() || true;
+  }
+  const builds = frames.map((f) => f.b).sort((a, b) => a - b);
+  const rasters = frames.map((f) => f.r).sort((a, b) => a - b);
+  r.frames = {
+    count: frames.length,
+    buildP50: pctile(builds, 50),
+    buildP95: pctile(builds, 95),
+    buildMax: builds.length ? builds[builds.length - 1] : 0,
+    rasterP95: pctile(rasters, 95),
+    buildOver16: builds.filter((b) => b > 16).length,
+    buildOver32: builds.filter((b) => b > 32).length,
+    buildOver50: builds.filter((b) => b > 50).length,
+  };
+  return r;
+}
+
+function fmt(n, d = 1) { return Number(n).toFixed(d); }
+
+async function main() {
+  if (!existsSync(WEB_DIR) || !existsSync(join(WEB_DIR, 'index.html'))) {
+    console.error(`✗ no harness build at ${WEB_DIR} — run tool/perf/build.sh first`);
+    process.exit(2);
+  }
+  if (!existsSync(PDF)) {
+    console.error(`✗ PDF not found: ${PDF} (set PERF_PDF)`);
+    process.exit(2);
+  }
+  if (!existsSync(CHROME)) {
+    console.error(`✗ Chrome not found: ${CHROME} (set PERF_CHROME)`);
+    process.exit(2);
+  }
+
+  const t0 = Date.now();
+  const server = await startServer();
+  // Scroll tunables ride the URL so the prebuilt harness needs no rebuild.
+  const qp = new URLSearchParams();
+  if (process.env.PERF_MAX_PAGES) qp.set('maxPages', process.env.PERF_MAX_PAGES);
+  if (process.env.PERF_DWELL_MS) qp.set('dwell', process.env.PERF_DWELL_MS);
+  if (process.env.PERF_PASSES) qp.set('passes', process.env.PERF_PASSES);
+  if (process.env.PERF_FAST_PASS) qp.set('fast', process.env.PERF_FAST_PASS);
+  const qs = qp.toString();
+  const url = `http://127.0.0.1:${PORT}/${qs ? '?' + qs : ''}`;
+  console.log(`▶ serving ${WEB_DIR} + /perf.pdf at ${url} (headless=${HEADLESS})`);
+
+  const browser = await puppeteer.launch({
+    executablePath: CHROME,
+    headless: HEADLESS ? 'shell' : false,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--window-size=1400,1000'],
+    defaultViewport: { width: 1400, height: 1000 },
+  });
+
+  let result = null;
+  let fatal = null;
+  try {
+    const pageErrors = [];
+    const page = await browser.newPage();
+    page.on('console', (msg) => { if (VERBOSE) console.log('  ‹console›', msg.text()); });
+    page.on('pageerror', (e) => { pageErrors.push(String(e)); console.error('  ‹pageerror›', String(e)); });
+
+    await page.goto(url, { waitUntil: 'load', timeout: 60_000 });
+
+    // Poll for the harness to finish (or its own error path), up to the budget.
+    // Bail fast on a startup crash: a pageerror with no harness output after a
+    // short grace means the app never came up — don't burn the whole budget.
+    const deadline = t0 + TIMEOUT_S * 1000;
+    let done = false;
+    while (Date.now() < deadline) {
+      done = await page.evaluate('window.__perfDone === true').catch(() => false);
+      if (done) break;
+      if (pageErrors.length) {
+        const progressed = await page.evaluate('(window.__perfDump && window.__perfDump().length) || 0').catch(() => 0);
+        if (!progressed && Date.now() - t0 > 12_000) { fatal = `startup crash: ${pageErrors[0]}`; break; }
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    if (!done && !fatal) fatal = `timeout after ${TIMEOUT_S}s waiting for __perfDone`;
+    if (pageErrors.length) (result ??= {}).pageErrors = pageErrors;
+
+    const harnessError = await page.evaluate('window.__perfError ?? null').catch(() => null);
+    const dump = await page.evaluate('window.__perfDump ? window.__perfDump() : ""').catch(() => '');
+    const framesJson = await page.evaluate('window.__perfFrames ? window.__perfFrames() : "[]"').catch(() => '[]');
+    const lines = dump ? dump.split('\n') : [];
+    let frames = [];
+    try { frames = JSON.parse(framesJson); } catch { /* ignore */ }
+
+    result = { ...(result ?? {}), harnessError, lines: lines.length, ...parse(lines, frames) };
+    result.rawLineSample = lines.filter((l) => /interpret|webworker|HARNESS|JANK|error/i.test(l)).slice(0, 40);
+  } catch (e) {
+    fatal = String(e?.stack ?? e);
+  } finally {
+    await browser.close().catch(() => {});
+    server.close();
+  }
+
+  const elapsed = (Date.now() - t0) / 1000;
+  const record = {
+    ts: new Date().toISOString(),
+    elapsedS: Number(elapsed.toFixed(1)),
+    headless: HEADLESS,
+    fatal,
+    ...(result ?? {}),
+  };
+  // pages is a Set — make it serialisable / summarisable.
+  const pagesVisited = result?.pages ? result.pages.size : 0;
+  if (record.pages) record.pages = pagesVisited;
+
+  // ---- Console summary ----
+  console.log('\n──────── perf run summary ────────');
+  if (fatal) console.log(`✗ FATAL: ${fatal}`);
+  if (result?.harnessError) console.log(`✗ harness error: ${String(result.harnessError).split('\n')[0]}`);
+  if (result) {
+    const i = result.interpret;
+    const f = result.frames;
+    console.log(`  pages visited      ${pagesVisited}`);
+    console.log(`  interpret paths    worker=${i.worker} recorded=${i.recorded} plain=${i.plain} other=${i.other} declines=${result.declines}`);
+    console.log(`  worker decode      max=${(result.workerResultMax / 1e6).toFixed(2)}MB total=${(result.workerResultBytes / 1e6).toFixed(1)}MB warmMax=${fmt(result.workerWarmMax)}ms`);
+    console.log(`  frames             ${f.count}  buildP50=${fmt(f.buildP50)}ms p95=${fmt(f.buildP95)}ms max=${fmt(f.buildMax)}ms`);
+    console.log(`  build over budget  >16ms=${f.buildOver16}  >32ms=${f.buildOver32}  >50ms=${f.buildOver50}   (PdfPerfLog JANK lines=${result.jankCount})`);
+    if (result.errorLines?.length) {
+      console.log(`  ⚠ error lines (${result.errorLines.length}):`);
+      for (const e of result.errorLines.slice(0, 5)) console.log(`      ${e}`);
+    }
+  }
+  console.log(`  elapsed            ${elapsed.toFixed(1)}s`);
+
+  // ---- Verdict ----
+  const ok = !fatal && !result?.harnessError && !(result?.errorLines?.length) &&
+    !(result?.pageErrors?.length) && pagesVisited > 0;
+  // A regression signal worth flagging (not a hard fail): any UI-thread plain
+  // interpret on a doc that should fully offload.
+  const regressed = result && (result.interpret.plain > 0 || result.interpret.recorded > 0);
+  record.ok = ok;
+  record.regressed = !!regressed;
+  console.log(ok ? (regressed ? '◐ PASS (with UI-thread interpret — see plain/recorded)' : '✓ PASS') : '✗ FAIL');
+  console.log('──────────────────────────────────\n');
+
+  await appendFile(RESULTS, JSON.stringify(record) + '\n').catch(() => {});
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/app/tool/perf/loop.sh
+++ b/app/tool/perf/loop.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Repeats the Chrome perf driver N times against the prebuilt harness, then
+# prints the aggregate. Alternates a full 133-page sweep with a faster capped
+# sweep so each cycle covers both steady-state and the worst raster pages.
+#
+#   tool/perf/build.sh        # once, after any code change
+#   tool/perf/loop.sh 8       # then loop 8 iterations
+#
+# Env passes through to driver.mjs (PERF_HEADLESS, PERF_TIMEOUT, PERF_VERBOSE…).
+set -uo pipefail
+cd "$(dirname "$0")"
+
+N="${1:-6}"
+echo "▶ perf loop: $N iteration(s)"
+for ((i = 1; i <= N; i++)); do
+  if (( i % 2 == 1 )); then
+    echo "── iter $i/$N: full sweep (133 pages) ──"
+    PERF_MAX_PAGES= PERF_FAST_PASS=1 node driver.mjs || true
+  else
+    echo "── iter $i/$N: fast capped sweep (40 pages) ──"
+    PERF_MAX_PAGES=40 PERF_FAST_PASS=1 node driver.mjs || true
+  fi
+done
+
+echo "▶ aggregate over the loop:"
+node report.mjs "$N"

--- a/app/tool/perf/package.json
+++ b/app/tool/perf/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dart-pdf-perf-driver",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Headless-Chrome driver for the dart-pdf render-worker web perf harness",
+  "dependencies": {
+    "puppeteer-core": "^23.0.0"
+  }
+}

--- a/app/tool/perf/perf_harness.dart
+++ b/app/tool/perf/perf_harness.dart
@@ -1,0 +1,241 @@
+// Automated real-world web-performance harness for the render worker.
+//
+// A standalone Flutter web entrypoint (NOT the shipping app) that loads a big
+// PDF over HTTP, mounts the real [PdfEditorView] with the web render worker
+// enabled, and then auto-scrolls every page while recording perf data — so an
+// off-browser driver (tool/perf/driver.mjs) can run it headless in real Chrome
+// and assert the decode/interpret offload keeps the UI thread smooth, exactly
+// the manual `flutter run -d chrome` check but repeatable and unattended.
+//
+// Build:  flutter build web --release --target tool/perf/perf_harness.dart \
+//           --dart-define=PDF_PERF_LOG=true
+// (the driver does this for you).
+//
+// Tunables (--dart-define):
+//   PERF_PDF_URL    URL to fetch the PDF from        (default /perf.pdf)
+//   PERF_DWELL_MS   pause on each page, ms           (default 220)
+//   PERF_MAX_PAGES  cap pages visited, 0 = all       (default 0)
+//   PERF_PASSES     number of full step passes       (default 1)
+//   PERF_FAST_PASS  add a coarse fast-fling pass     (default true)
+//
+// The driver reads three JS globals this installs:
+//   window.__perfDone   -> bool, true when the scroll script finishes
+//   window.__perfDump()  -> all captured debugPrint/[perf] lines, '\n'-joined
+//   window.__perfFrames()-> JSON [{b,r,t}] per FrameTiming (build/raster/total ms)
+//   window.__perfError   -> a fatal error string, if the harness threw
+import 'dart:async';
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+// ---------------------------------------------------------------------------
+// Tunables — read from the URL query string at runtime (so the driver can vary
+// them per run without a rebuild), each falling back to a --dart-define default.
+//   ?url=/perf.pdf&dwell=220&maxPages=0&passes=1&fast=1
+// ---------------------------------------------------------------------------
+final Map<String, String> _q = Uri.base.queryParameters;
+
+int _qInt(String key, int fallback) => int.tryParse(_q[key] ?? '') ?? fallback;
+bool _qBool(String key, bool fallback) {
+  final v = _q[key];
+  if (v == null) return fallback;
+  return v == '1' || v.toLowerCase() == 'true';
+}
+
+final String _pdfUrl = _q['url'] ??
+    const String.fromEnvironment('PERF_PDF_URL', defaultValue: '/perf.pdf');
+final int _dwellMs =
+    _qInt('dwell', const int.fromEnvironment('PERF_DWELL_MS', defaultValue: 220));
+final int _maxPages =
+    _qInt('maxPages', const int.fromEnvironment('PERF_MAX_PAGES', defaultValue: 0));
+final int _passes =
+    _qInt('passes', const int.fromEnvironment('PERF_PASSES', defaultValue: 1));
+final bool _fastPass =
+    _qBool('fast', const bool.fromEnvironment('PERF_FAST_PASS', defaultValue: true));
+
+// ---------------------------------------------------------------------------
+// Capture: every debugPrint line + every frame's timing.
+// ---------------------------------------------------------------------------
+final List<String> _lines = <String>[];
+final List<FrameTiming> _frames = <FrameTiming>[];
+
+void _record(String line) {
+  _lines.add(line);
+  // Mirror to the real console too, so a headful run / page.on('console')
+  // can watch live. Guarded — console must exist in a browser.
+  _consoleLog(line.toJS);
+}
+
+@JS('console.log')
+external void _consoleLog(JSAny? msg);
+
+@JS('fetch')
+external JSPromise<_FetchResponse> _fetch(String url);
+
+extension type _FetchResponse(JSObject _) implements JSObject {
+  external int get status;
+  external JSPromise<JSArrayBuffer> arrayBuffer();
+}
+
+Future<Uint8List> _loadPdf(String url) async {
+  final resp = await _fetch(url).toDart;
+  if (resp.status != 200) {
+    throw StateError('GET $url -> HTTP ${resp.status}');
+  }
+  final buffer = await resp.arrayBuffer().toDart;
+  return buffer.toDart.asUint8List();
+}
+
+String _framesJson() {
+  final out = _frames
+      .map((t) => {
+            'b': t.buildDuration.inMicroseconds / 1000.0,
+            'r': t.rasterDuration.inMicroseconds / 1000.0,
+            't': t.totalSpan.inMicroseconds / 1000.0,
+          })
+      .toList();
+  return jsonEncode(out);
+}
+
+void _setGlobal(String name, JSAny? value) =>
+    globalContext.setProperty(name.toJS, value);
+
+void main() {
+  // The binding must exist before we touch SchedulerBinding.instance.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Turn on the engine's perf trace and redirect ALL of it into our buffer.
+  // Reassigning debugPrint (a mutable foundation global) captures every
+  // PdfPerfLog line without the console throttle dropping any under load.
+  PdfPerfLog.enabled = true;
+  pdfRenderWorkerScriptUrl = 'pdf_render_worker.dart.js';
+  debugPrint = (String? message, {int? wrapWidth}) {
+    if (message != null) _record(message);
+  };
+
+  // Expose the driver's read surface up front (so a poll never races startup).
+  _setGlobal('__perfDone', false.toJS);
+  _setGlobal('__perfError', null);
+  _setGlobal('__perfDump', (() => _lines.join('\n').toJS).toJS);
+  _setGlobal('__perfFrames', (() => _framesJson().toJS).toJS);
+
+  // Record every frame's timing (not just jank) so the driver can compute
+  // p50/p95/max build times over the whole run.
+  SchedulerBinding.instance.addTimingsCallback(_frames.addAll);
+
+  runApp(const _PerfHarnessApp());
+}
+
+class _PerfHarnessApp extends StatefulWidget {
+  const _PerfHarnessApp();
+
+  @override
+  State<_PerfHarnessApp> createState() => _PerfHarnessAppState();
+}
+
+class _PerfHarnessAppState extends State<_PerfHarnessApp> {
+  final PdfViewerController _viewer = PdfViewerController();
+  Uint8List? _bytes;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _start();
+  }
+
+  Future<void> _start() async {
+    try {
+      _record('[perf] HARNESS load url=$_pdfUrl');
+      final bytes = await _loadPdf(_pdfUrl);
+      _record('[perf] HARNESS loaded bytes=${bytes.length}');
+      setState(() => _bytes = bytes);
+      // Let the first frame + the viewer's first page settle, then drive.
+      unawaited(_drive());
+    } catch (e, st) {
+      _record('[perf] HARNESS ERROR $e');
+      _setGlobal('__perfError', '$e\n$st'.toJS);
+      _setGlobal('__perfDone', true.toJS);
+      setState(() => _error = '$e');
+    }
+  }
+
+  Future<void> _drive() async {
+    // Wait for the page tree to resolve so pageCount is real.
+    final deadline = DateTime.now().add(const Duration(seconds: 30));
+    while (_viewer.pageCount <= 0 && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    final count = _viewer.pageCount;
+    _record('[perf] HARNESS pageCount=$count');
+    if (count <= 0) {
+      _setGlobal('__perfError', 'pageCount never became positive'.toJS);
+      _setGlobal('__perfDone', true.toJS);
+      return;
+    }
+
+    // Let the first visible page interpret before we start moving.
+    await Future<void>.delayed(const Duration(milliseconds: 1500));
+
+    final last = _maxPages > 0 ? (_maxPages.clamp(1, count)) : count;
+
+    for (var pass = 0; pass < _passes; pass++) {
+      _record('[perf] HARNESS PASS step $pass/$_passes pages=$last');
+      for (var i = 0; i < last; i++) {
+        await _viewer.jumpToPage(i); // animates ~250ms
+        await Future<void>.delayed(Duration(milliseconds: _dwellMs));
+      }
+    }
+
+    if (_fastPass && last > 8) {
+      // A coarse, fast sweep to stress the velocity hold / preview path:
+      // big strides, almost no dwell, forward then back.
+      _record('[perf] HARNESS PASS fast pages=$last');
+      final stride = (last / 12).ceil().clamp(1, last);
+      for (var i = 0; i < last; i += stride) {
+        await _viewer.jumpToPage(i);
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+      }
+      for (var i = last - 1; i >= 0; i -= stride) {
+        await _viewer.jumpToPage(i);
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+      }
+    }
+
+    // Settle so trailing prerenders/decodes land in the trace.
+    await Future<void>.delayed(const Duration(milliseconds: 1500));
+    _record('[perf] HARNESS DONE frames=${_frames.length} lines=${_lines.length}');
+    _setGlobal('__perfDone', true.toJS);
+  }
+
+  @override
+  void dispose() {
+    _viewer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'dart-pdf perf harness',
+      home: Scaffold(
+        body: _error != null
+            ? Center(child: Text('harness error: $_error'))
+            : _bytes == null
+                ? const Center(child: Text('loading…'))
+                : PdfEditorView(
+                    bytes: _bytes,
+                    documentId: 'perf-harness',
+                    viewerController: _viewer,
+                    initialFit: PdfViewerFit.width,
+                  ),
+      ),
+    );
+  }
+}

--- a/app/tool/perf/report.mjs
+++ b/app/tool/perf/report.mjs
@@ -1,0 +1,66 @@
+// Summarises results.ndjson: one line per run plus an aggregate, so a loop of
+// driver.mjs runs shows trend + variance and flags any regression.
+//   node report.mjs            # all runs
+//   node report.mjs 20         # last 20 runs
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FILE = process.env.PERF_RESULTS ?? join(HERE, 'results.ndjson');
+const last = Number(process.argv[2] ?? 0);
+
+const text = await readFile(FILE, 'utf8').catch(() => '');
+let runs = text.split('\n').filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+if (last > 0) runs = runs.slice(-last);
+if (!runs.length) { console.log('no runs in', FILE); process.exit(0); }
+
+const num = (v) => (typeof v === 'number' ? v : 0);
+const agg = (xs) => {
+  const s = xs.filter((x) => typeof x === 'number').sort((a, b) => a - b);
+  if (!s.length) return { min: 0, med: 0, max: 0 };
+  return { min: s[0], med: s[Math.floor(s.length / 2)], max: s[s.length - 1] };
+};
+
+console.log(`\n${runs.length} run(s) from ${FILE}\n`);
+const hdr = ['#', 'when', 'secs', 'pages', 'wkr', 'plain', 'p95', 'bMax', '>16', '>50', 'warmMax', 'verdict'];
+console.log(hdr.map((h, i) => h.padEnd([3, 20, 6, 6, 5, 6, 7, 7, 5, 5, 8, 12][i])).join(' '));
+runs.forEach((r, i) => {
+  const f = r.frames ?? {};
+  const verdict = r.fatal || r.harnessError || (r.errorLines?.length) || (r.pageErrors?.length)
+    ? 'FAIL' : (r.regressed ? 'PASS(ui-interp)' : 'PASS');
+  const cells = [
+    String(i + 1),
+    (r.ts ?? '').replace('T', ' ').slice(5, 19),
+    String(num(r.elapsedS)),
+    String(num(r.pages)),
+    String(r.interpret?.worker ?? 0),
+    String(r.interpret?.plain ?? 0),
+    num(f.buildP95).toFixed(1),
+    num(f.buildMax).toFixed(0),
+    String(num(f.buildOver16)),
+    String(num(f.buildOver50)),
+    num(r.workerWarmMax).toFixed(0),
+    verdict,
+  ];
+  console.log(cells.map((c, j) => c.padEnd([3, 20, 6, 6, 5, 6, 7, 7, 5, 5, 8, 12][j])).join(' '));
+});
+
+const fails = runs.filter((r) => r.fatal || r.harnessError || r.errorLines?.length || r.pageErrors?.length);
+const regr = runs.filter((r) => r.regressed);
+const p95 = agg(runs.map((r) => r.frames?.buildP95));
+const bmax = agg(runs.map((r) => r.frames?.buildMax));
+const warm = agg(runs.map((r) => r.workerWarmMax));
+const over50 = agg(runs.map((r) => r.frames?.buildOver50));
+
+console.log('\n──────── aggregate ────────');
+console.log(`  runs            ${runs.length}   FAIL=${fails.length}   regressed(ui-interp)=${regr.length}`);
+console.log(`  build p95 ms    min=${p95.min.toFixed(1)} med=${p95.med.toFixed(1)} max=${p95.max.toFixed(1)}`);
+console.log(`  build max ms    min=${bmax.min.toFixed(0)} med=${bmax.med.toFixed(0)} max=${bmax.max.toFixed(0)}`);
+console.log(`  frames >50ms    min=${over50.min} med=${over50.med} max=${over50.max}`);
+console.log(`  worker warmMax  min=${warm.min.toFixed(0)} med=${warm.med.toFixed(0)} max=${warm.max.toFixed(0)} ms`);
+if (fails.length) {
+  console.log('\n  ⚠ failing runs:');
+  for (const r of fails) console.log(`     ${r.ts}  ${r.fatal ?? r.harnessError ?? (r.errorLines?.[0]) ?? r.pageErrors?.[0]}`);
+}
+console.log('───────────────────────────\n');


### PR DESCRIPTION
## What

Adds `app/tool/perf/` — an unattended, repeatable version of the manual `flutter run -d chrome` perf check used to verify the render worker. It loads the big CAD PDF in **real headless Chrome** (system Chrome, dart2js build), auto-scrolls every page, scrapes the `PdfPerfLog` trace + `FrameTiming`, and prints a PASS/FAIL verdict — so the class of dart2js-only regression VM tests can't catch (e.g. the Int64 accessor bug) is now caught automatically.

## Pieces

- **`perf_harness.dart`** — standalone Flutter web entrypoint (not the shipping app). Fetches the PDF from `/perf.pdf`, mounts the real `PdfEditorView` + web render worker, enables `PdfPerfLog`, reassigns the mutable `debugPrint` global to capture every `[perf]` line (no console-throttle loss) plus every `FrameTiming`, then auto-scrolls all pages. Scroll knobs are URL query params (`?maxPages=&dwell=&passes=&fast=`) so the prebuilt bundle varies per run with no rebuild. Exposes `window.__perfDone/__perfDump()/__perfFrames()/__perfError`.
- **`driver.mjs`** — Node + `puppeteer-core` driving system Chrome headless (no Chromium download). Serves `build/web` + `/perf.pdf`, drives the harness, parses interpret-path counts + worker decode bytes/warm + `FrameTiming` build p50/p95/max, appends one JSON record per run to `results.ndjson`. Verdict `PASS` / `◐ PASS (ui-interp regression)` / `✗ FAIL`. `PERF_NO_WORKER=true` is a negative control (404s the worker script to force UI-thread fallback).
- **`build.sh` / `loop.sh` / `report.mjs` / `README.md`** — build once, loop N runs, aggregate the trend.

## Validation (MW307, 41 MB / 133 pages)

- **28/28 PASS, 0 regressions** — every page `path=worker`, build p95 **3.8–4.4 ms**, exactly **1 frame >50 ms per run** (max 86–118 ms). Matches the manual check, now reproducible and unattended.
- **Negative control has teeth**: with the worker 404'd, the loop correctly reports `worker=0 / recorded=N`, surfaces the `webworker onerror … falling back to local` line, and flips the verdict to **✗ FAIL**.

Generated artifacts (`node_modules`, `results.ndjson`, `loop.log`, `package-lock.json`) are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)