### PR TITLE
perf(worker): cancel superseded prefetch (#73)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -202,6 +202,13 @@ class _PdfPageViewState extends State<PdfPageView> {
       oldWidget.renderScheduler?.cancel(this);
       // the new scheduler picks this page up on its next _render
     }
+    if (oldWidget.previewIndex != widget.previewIndex) {
+      // The lazy list reused this State for a different page (it scrolled into
+      // this slot): cancel the old page's queued worker request — the user
+      // scrolled past it, so decoding it now would only delay the page now on
+      // screen. The in-flight one can't be preempted; this clears the backlog.
+      oldWidget.renderWorker?.cancel(oldWidget.previewIndex, priority: 0);
+    }
     if (!identical(oldWidget.previewCache, widget.previewCache) ||
         oldWidget.previewIndex != widget.previewIndex) {
       oldWidget.previewCache?.removeListener(_onPreviewCacheChanged);
@@ -230,6 +237,11 @@ class _PdfPageViewState extends State<PdfPageView> {
   void dispose() {
     widget.renderHold?.removeListener(_onRenderHoldChanged);
     widget.renderScheduler?.cancel(this);
+    // Scrolled out of the cache window: drop this page's queued worker request
+    // so the worker's next slot serves a page still on screen (the abandoned
+    // result is ignored — _interpretPicture's !mounted guard skips the local
+    // fallback). No-op if nothing is queued for it.
+    widget.renderWorker?.cancel(widget.previewIndex, priority: 0);
     widget.previewCache?.removeListener(_onPreviewCacheChanged);
     _dropPicture();
     _image?.dispose();
@@ -305,22 +317,51 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// command buffer here (cheap); image-bearing pages come back null and
   /// fall through to the local recorded render.
   Future<ui.Picture> _interpretPicture() async {
+    final pageIndex = widget.previewIndex;
     final worker = widget.renderWorker;
     if (worker != null && worker.isActive) {
       // priority 0: the on-screen page preempts background prefetch
-      final commands = await worker.record(widget.previewIndex,
+      final commands = await worker.record(pageIndex,
           annotations: widget.showAnnotations, priority: 0);
+      // Abandoned while the worker ran — the State was disposed or the lazy
+      // list recycled it onto another page (this is the cancel() path: a
+      // cancelled request returns null). Skip the local fallback: the page is
+      // gone, so a re-interpret would burn the UI thread for nothing — exactly
+      // what the worker exists to avoid. Note we DON'T gate on the render
+      // generation here: a newer same-page render (e.g. a zoom mid-interpret)
+      // reuses this very future, so the picture must still be produced for it.
+      if (_abandoned(pageIndex)) return _emptyPicture();
       if (commands != null) {
         _lastInterpretPath = 'worker';
         return PdfPageRenderer.pictureFromCommands(widget.page, commands,
             pageColor: widget.pageColor);
       }
     }
+    if (_abandoned(pageIndex)) return _emptyPicture();
     // The worker may be active yet decline this page (it returns null), in
     // which case the interpret runs here — the log must say so, not 'worker'.
     _lastInterpretPath = 'recorded';
     return PdfPageRenderer.renderPictureRecorded(widget.page,
         pageColor: widget.pageColor, annotations: widget.showAnnotations);
+  }
+
+  /// Whether the page this render was for is gone — the widget unmounted, or
+  /// the lazy list recycled this State onto a different page. Picture
+  /// production stops here (no wasted local interpret); painting is gated
+  /// separately by [_superseded], which also rejects a stale generation.
+  bool _abandoned(int pageIndex) => !mounted || widget.previewIndex != pageIndex;
+
+  /// Whether a render started at ([generation], [pageIndex]) must not paint —
+  /// [_abandoned], or a newer render bumped the generation past this one.
+  bool _superseded(int generation, int pageIndex) =>
+      _abandoned(pageIndex) || generation != _renderGeneration;
+
+  /// A zero-op picture for an abandoned render. Never painted (the caller's
+  /// [_superseded] guards discard it); it only satisfies the return type.
+  ui.Picture _emptyPicture() {
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder);
+    return recorder.endRecording();
   }
 
   /// Which path [_interpretPicture] actually took, for the perf log — 'worker'
@@ -331,17 +372,21 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// longer gated (or directly for re-rasters of a cached picture).
   Future<void> _renderNow() async {
     final generation = ++_renderGeneration;
+    final pageIndex = widget.previewIndex;
     final firstInterpret = _picture == null;
     final sw = Stopwatch()..start();
     final picture = await (_picture ??= _interpretPicture());
     sw.stop();
+    // Bail before logging when superseded — an abandoned interpret (page
+    // recycled, disposed, or cancelled prefetch) never paints, so logging it
+    // as a 'recorded' interpret would be a phantom UI-thread cost.
+    if (_superseded(generation, pageIndex)) return;
     if (firstInterpret) {
-      PdfPerfLog.interpret(widget.previewIndex,
+      PdfPerfLog.interpret(pageIndex,
           path: _lastInterpretPath,
           interpretMs: sw.elapsedMicroseconds / 1000.0,
           first: true);
     }
-    if (!mounted || generation != _renderGeneration) return;
     final effective = _effectiveRatio();
     // Skip the full-page readback when the cached raster is already at
     // this resolution: a settle that only moved the detail patch reaches
@@ -354,7 +399,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (stale) {
       final image = await PdfPageRenderer.rasterize(
           picture, PdfPageRenderer.pageSize(widget.page), effective);
-      if (!mounted || generation != _renderGeneration) {
+      if (_superseded(generation, pageIndex)) {
         image.dispose();
         return;
       }

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -61,6 +61,21 @@ abstract class PdfRenderWorker {
   Future<List<PdfRenderCommand>?> record(int pageIndex,
       {bool annotations = true, int priority = 0});
 
+  /// Drops any QUEUED (not yet started) [record] request for [pageIndex] at
+  /// [priority], completing its future with null — as if the page had declined
+  /// to a local render. The single in-flight request can't be preempted (that
+  /// needs the worker to yield mid-walk); this only clears the backlog behind
+  /// it. A cheap no-op when nothing matches.
+  ///
+  /// The point is to cancel prefetch the user has scrolled past: a page that
+  /// left the viewport before its turn came no longer needs decoding, and
+  /// leaving its request queued would make the worker spend its next slot — and
+  /// ship a multi-megabyte decoded buffer — for a page nobody is looking at,
+  /// delaying the page that is. The caller that abandons a cancelled result
+  /// must not fall back to a local interpret (the work would be wasted);
+  /// [PdfPageView] does this by abandoning when it is unmounted or superseded.
+  void cancel(int pageIndex, {int priority = 0});
+
   /// Whether this worker actually offloads. False for the null fallback, so
   /// callers can skip the round-trip and render locally without asking.
   bool get isActive;

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -123,6 +123,21 @@ class _IsolateRenderWorker implements PdfRenderWorker {
   }
 
   @override
+  void cancel(int pageIndex, {int priority = 0}) {
+    if (_disposed) return;
+    // Drop matching QUEUED requests (the in-flight one can't be preempted).
+    // Completing with null makes their record() futures resolve to a local
+    // render — the abandoning caller ignores that.
+    _queue.removeWhere((request) {
+      if (request.pageIndex != pageIndex || request.priority != priority) {
+        return false;
+      }
+      if (!request.completer.isCompleted) request.completer.complete(null);
+      return true;
+    });
+  }
+
+  @override
   void dispose() {
     if (_disposed) return;
     _disposed = true;

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -21,5 +21,8 @@ class _NullRenderWorker implements PdfRenderWorker {
       null;
 
   @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
   void dispose() {}
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -149,6 +149,27 @@ class _WebRenderWorker implements PdfRenderWorker {
     worker.postMessage(message);
   }
 
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {
+    if (_disposed || _failed) return;
+    // Drop matching QUEUED requests (the in-flight one can't be preempted) so
+    // the worker's next slot serves a page the user is still looking at. The
+    // cancelled record() futures resolve null; the abandoning caller ignores
+    // them. Mirrors the isolate backend.
+    var dropped = 0;
+    _queue.removeWhere((request) {
+      if (request.pageIndex != pageIndex || request.priority != priority) {
+        return false;
+      }
+      if (!request.completer.isCompleted) request.completer.complete(null);
+      dropped++;
+      return true;
+    });
+    if (dropped > 0) {
+      _wlog('cancel page=$pageIndex priority=$priority dropped=$dropped queued');
+    }
+  }
+
   void _fail() {
     if (_failed) return;
     _failed = true;

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -222,6 +222,63 @@ void main() {
       }
     });
   });
+
+  testWidgets('cancel drops a queued request without disturbing others',
+      (tester) async {
+    await tester.runAsync(() async {
+      final worker = PdfRenderWorker.start(buildMultiPagePdf(3));
+      addTearDown(worker.dispose);
+      await worker.record(0); // warm up: the isolate is spawned and idle
+
+      // record() enqueues synchronously, so these resolve deterministically:
+      // page 0 goes in flight, pages 1 and 2 queue behind it.
+      final inFlight = worker.record(0, priority: 1);
+      final stale = worker.record(1, priority: 1);
+      final wanted = worker.record(2, priority: 1);
+      // Page 1 "scrolled away" before its turn — drop it from the queue.
+      worker.cancel(1, priority: 1);
+
+      expect(await stale, isNull,
+          reason: 'a cancelled queued request resolves to a local render');
+      expect(await inFlight, isNotNull,
+          reason: 'the in-flight request is untouched and still completes');
+      expect(await wanted, isNotNull,
+          reason: 'an unrelated queued request still completes');
+    });
+  });
+
+  testWidgets('cancel does not preempt the in-flight request', (tester) async {
+    await tester.runAsync(() async {
+      final worker = PdfRenderWorker.start(buildMultiPagePdf(2));
+      addTearDown(worker.dispose);
+      await worker.record(0); // warm up
+
+      final inFlight = worker.record(0, priority: 1); // now in flight
+      worker.cancel(0, priority: 1); // targets page 0, but it already started
+      expect(await inFlight, isNotNull,
+          reason: 'the single in-flight request cannot be cancelled');
+    });
+  });
+
+  testWidgets('cancel only matches the given page and priority', (tester) async {
+    await tester.runAsync(() async {
+      final worker = PdfRenderWorker.start(buildMultiPagePdf(3));
+      addTearDown(worker.dispose);
+      await worker.record(0); // warm up
+
+      final inFlight = worker.record(0, priority: 1);
+      final otherPriority = worker.record(1, priority: 2);
+      final target = worker.record(1, priority: 1);
+      // Same page as otherPriority, but a different priority bucket: only the
+      // priority-1 request for page 1 is dropped.
+      worker.cancel(1, priority: 1);
+
+      expect(await target, isNull, reason: 'the matching request is cancelled');
+      expect(await inFlight, isNotNull);
+      expect(await otherPriority, isNotNull,
+          reason: 'a same-page request at another priority is left alone');
+    });
+  });
 }
 
 /// A small RGBA PNG with a varying alpha channel (so it embeds with an /SMask).


### PR DESCRIPTION
## What

Issue #73 item 1 — **cancel prefetch the user has scrolled past**. When a page leaves the viewport before the render worker reaches its queued request, that request is now dropped instead of run, so the worker's next slot serves a page still on screen rather than decoding (and shipping a multi-megabyte buffer for) one nobody is looking at.

The single in-flight request still can't be preempted — that needs the worker to yield mid-walk (#73 item 3). This clears the **backlog behind** it, which is where equal-priority requests pile up: the scheduler grants one render per frame but doesn't await each `worker.record(priority:0)`, so during a post-settle storm several queue up, and ties break by submission order — a stale request for a page you scrolled past would otherwise run *before* the page you're now looking at.

## Changes

- **`PdfRenderWorker.cancel(pageIndex, {priority})`** removes a QUEUED request, completing its future null. Implemented in the isolate + web backends (mirrored one-in-flight priority queues); no-op in the null stub.
- **`PdfPageView`** cancels its priority-0 request when the lazy list recycles its `State` onto another page (`didUpdateWidget`) or disposes it (scrolled out of the cache window).
- A cancelled request must **not** fall back to a local interpret (that work would be wasted). `_interpretPicture` abandons to a zero-op picture when the page is gone (`_abandoned`), gated **separately** from the paint-time generation check (`_superseded`): a same-page re-render — e.g. a zoom mid-interpret — reuses that very future, so the picture must still be *produced* for it; only *painting* is gated on generation. `_renderNow` also skips the perf-log line for abandoned renders.

## Validation

Unit tests (`render_worker_test.dart`, +3): a cancelled queued request resolves null while the in-flight and unrelated requests complete; cancel can't preempt the in-flight one; cancel matches only the given page+priority.

Real-Chrome perf loop (`app/tool/perf`, MW307 41 MB / 133 pp):
- **Cancellation fires live** — `webworker cancel page=N priority=0 dropped=1 queued` for pages scrolled past during both the step and fast passes.
- **No regression** — fully offloaded (`worker` only, `recorded=0 plain=0`), no errors, build p95 ~4 ms, exactly ~1 frame >50 ms/run.
- **~20% fewer worker decodes per full sweep** — 106–111 vs ~136 on main: the worker stops decoding pages already scrolled past. warmMax stayed bounded (≤921 ms across runs) vs a 9051 ms outlier on main.

Full editor suite green except the 14 pre-existing Ghent render-baseline diffs (unrelated, documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)