### PR TITLE
Add Bluebeam-style Snapshot tool (raster + vector capture, vector paste-back)

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.1.0
 
+- Snapshot tool (`PdfEditTool.snapshot`, in the Edit toolbar): drag a
+  region to capture it, Bluebeam-style. The captured region is rendered to
+  a PNG handed to `PdfViewer.onSnapshot` (copy/save/share) AND kept on the
+  controller as detached **vector** graphics — paste it back into the PDF
+  with ⌘V/Ctrl+V or the right-click Paste (`PdfEditingController.
+  pasteSnapshot`) and it stays vector, crisp at any zoom.
 - Background rendering: heavy pages now interpret off the UI thread, so
   scrolling and drawing stay smooth on large/CAD documents.
   `PdfRenderWorker` runs page interpretation and image decode in a

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -423,6 +423,44 @@ class _ViewerScreenState extends State<ViewerScreen> {
     }
   }
 
+  /// Exports a Snapshot tool capture as a PNG image — a save dialog on
+  /// desktop, a download on the web, the share sheet on phones. The vector
+  /// copy of the same region stays on the editor's clipboard, so ⌘V/Ctrl+V
+  /// (or the right-click Paste) drops it back into the PDF as vectors.
+  Future<void> _saveSnapshot(BuildContext context, PdfSnapshot snapshot) async {
+    const name = 'snapshot.png';
+    final file =
+        XFile.fromData(snapshot.pngBytes, mimeType: 'image/png', name: name);
+    if (kIsWeb) {
+      await file.saveTo(name);
+      _toast('Downloaded $name — paste back into the PDF with Ctrl+V');
+      return;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android || TargetPlatform.iOS:
+        final box = context.findRenderObject() as RenderBox?;
+        final origin =
+            box == null ? null : box.localToGlobal(Offset.zero) & box.size;
+        await SharePlus.instance.share(ShareParams(
+          files: [file],
+          fileNameOverrides: [name],
+          sharePositionOrigin: origin ?? const Rect.fromLTWH(0, 0, 1, 1),
+        ));
+      default:
+        final location = await getSaveLocation(
+          suggestedName: name,
+          acceptedTypeGroups: const [_imageTypeGroup],
+        );
+        if (location == null) return;
+        try {
+          await file.saveTo(location.path);
+          _toast('Saved $name — paste back into the PDF with ⌘V');
+        } catch (e) {
+          _toast('Save failed: $e');
+        }
+    }
+  }
+
   /// Adds an invisible, selectable/searchable OCR text layer over the
   /// active document using a self-hosted vision-language OCR model
   /// (pdf_ocr_vlm). Prompts for the service endpoint and an optional API
@@ -671,6 +709,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
                           annotationMenuBuilder: _annotationMenuActions,
                           formImagePicker: _pickFormImage,
                           imagePicker: _pickImage,
+                          onSnapshot: _saveSnapshot,
                         ),
     );
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2233,6 +2233,12 @@ class PdfEditingController extends ChangeNotifier {
   PdfVectorSnapshot? _snapshotClipboard;
   int _snapshotPasteCount = 0;
 
+  /// The object number of the captured form materialized by the last paste
+  /// of [_snapshotClipboard] into the current document — reused so repeat
+  /// pastes share one XObject instead of re-embedding the page content.
+  /// Reset whenever a fresh snapshot is captured.
+  int? _snapshotCapturedRef;
+
   /// Whether [pasteSnapshot] has a captured region to paste.
   bool get hasSnapshotClipboard => _snapshotClipboard != null;
 
@@ -2240,9 +2246,9 @@ class PdfEditingController extends ChangeNotifier {
   PdfVectorSnapshot? get snapshotClipboard => _snapshotClipboard;
 
   /// Captures [region] (PDF user space) of [pageIndex] as a detached
-  /// vector snapshot — the page graphics under the region, copied inline.
-  /// Read-only: the document is untouched. See
-  /// [PdfVectorSnapshotEditing.captureVectorSnapshot].
+  /// vector snapshot — the page graphics under the region, copied inline,
+  /// with the page's /Rotate baked in. Read-only: the document is
+  /// untouched. See [PdfVectorSnapshotEditing.captureVectorSnapshot].
   PdfVectorSnapshot captureVectorSnapshot(int pageIndex, PdfRect region) =>
       PdfEditor(_document).captureVectorSnapshot(pageIndex, region);
 
@@ -2254,6 +2260,7 @@ class PdfEditingController extends ChangeNotifier {
     final snapshot = captureVectorSnapshot(pageIndex, region);
     _snapshotClipboard = snapshot;
     _snapshotPasteCount = 0;
+    _snapshotCapturedRef = null;
     _clipboard = const [];
     notifyListeners();
     return snapshot;
@@ -2271,8 +2278,7 @@ class PdfEditingController extends ChangeNotifier {
     final snapshot = _snapshotClipboard;
     if (snapshot == null) return false;
     if (pageIndex < 0 || pageIndex >= _document.pageCount) return false;
-    final region = snapshot.region;
-    final w = region.width, h = region.height;
+    final w = snapshot.displayWidth, h = snapshot.displayHeight;
     if (w <= 0 || h <= 0) return false;
     double left, bottom;
     if (at != null) {
@@ -2280,18 +2286,21 @@ class PdfEditingController extends ChangeNotifier {
       bottom = at.$2 - h / 2;
     } else {
       final cascade = 12.0 * _snapshotPasteCount;
-      left = region.left + cascade;
-      bottom = region.bottom - cascade;
+      left = snapshot.region.left + cascade;
+      bottom = snapshot.region.bottom - cascade;
     }
     final box = _page(pageIndex).cropBox;
     left += _clampShift(left, left + w, box.left, box.right);
     bottom += _clampShift(bottom, bottom + h, box.bottom, box.top);
     final target = PdfRect(left, bottom, left + w, bottom + h);
-    final pasted = apply(
-        (e) => e.pasteVectorSnapshot(pageIndex, target, snapshot,
-            author: author),
-        pages: [pageIndex]);
+    int? captured;
+    final pasted = apply((e) {
+      captured = e.pasteVectorSnapshot(pageIndex, target, snapshot,
+          author: author, sharedObject: _snapshotCapturedRef);
+    }, pages: [pageIndex]);
     if (!pasted) return false;
+    // remember the shared captured form so repeat pastes reuse it
+    _snapshotCapturedRef = captured;
     _snapshotPasteCount++;
     tool = PdfEditTool.select;
     final total = _page(pageIndex).annotations.length;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 import 'dart:math' as math;
+import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:pdf_document/pdf_document.dart';
 
+import '../renderer.dart';
 import 'editing_measure.dart';
 import 'editing_preferences.dart';
 import 'line_style.dart';
@@ -108,6 +110,14 @@ enum PdfEditTool {
   /// selection. Marks render as a hatched preview until burned with
   /// [PdfEditingController.applyRedactions], which is irreversible.
   redact,
+
+  /// Drag out a rectangle to capture that region of the page as a raster
+  /// image, like Bluebeam's Snapshot. The captured PNG is rendered through
+  /// [PdfEditingController.captureSnapshot] and handed to
+  /// [PdfViewer.onSnapshot] — typically to copy it to the clipboard, save,
+  /// or share it; with no handler the tool does nothing. It only reads the
+  /// page: no annotation or page content is written.
+  snapshot,
 }
 
 /// Text-markup kinds for [PdfEditingController.addMarkup].
@@ -1637,6 +1647,37 @@ class PdfEditingController extends ChangeNotifier {
   /// should come through here.
   PdfPage pageAt(int index) => _page(index);
 
+  /// Renders [region] of page [pageIndex] to PNG bytes — the capture
+  /// behind the Snapshot tool ([PdfEditTool.snapshot]).
+  ///
+  /// [region] is page raster space: points with y down, after /Rotate —
+  /// i.e. a view position divided by the view scale (`PdfPageGeometry`).
+  /// The overlay therefore passes the dragged box straight through.
+  /// [pixelRatio] scales the output resolution (2 keeps a snapshot crisp
+  /// at 100% zoom). [pageColor] and [annotations] should match how the
+  /// page is displayed, so the snapshot looks like what's on screen.
+  /// Returns null for a degenerate (sub-pixel) region.
+  Future<Uint8List?> captureSnapshot(int pageIndex, Rect region,
+      {double pixelRatio = 2,
+      Color pageColor = const Color(0xFFFFFFFF),
+      bool annotations = true}) async {
+    if (region.width < 1 || region.height < 1) return null;
+    final picture = await PdfPageRenderer.renderPicture(pageAt(pageIndex),
+        pageColor: pageColor, annotations: annotations);
+    try {
+      final image =
+          await PdfPageRenderer.rasterizeRegion(picture, region, pixelRatio);
+      try {
+        final data = await image.toByteData(format: ui.ImageByteFormat.png);
+        return data?.buffer.asUint8List();
+      } finally {
+        image.dispose();
+      }
+    } finally {
+      picture.dispose();
+    }
+  }
+
   PdfAnnotation? _annotationAt((int, int) selected) {
     final (page, index) = selected;
     if (page < 0 || page >= _document.pageCount) return null;
@@ -2115,6 +2156,8 @@ class PdfEditingController extends ChangeNotifier {
     _clipboard = snapshots;
     _clipboardSourcePage = _selected.last.$1;
     _pasteCount = 0;
+    // the most recent copy wins ⌘V (see [copyVectorSnapshot])
+    _snapshotClipboard = null;
     notifyListeners();
     return snapshots.length;
   }
@@ -2176,6 +2219,85 @@ class PdfEditingController extends ChangeNotifier {
     _selected
       ..clear()
       ..addAll([for (var i = total - count; i < total; i++) (pageIndex, i)]);
+    notifyListeners();
+    return true;
+  }
+
+  // ---------------------------------------------------------------------
+  // snapshot clipboard (the Snapshot tool's vector paste)
+
+  /// The in-app snapshot clipboard: a detached vector copy of a page
+  /// region ([captureVectorSnapshot]) that survives edits, undo, and
+  /// document swaps. Filled by the Snapshot tool, consumed by
+  /// [pasteSnapshot].
+  PdfVectorSnapshot? _snapshotClipboard;
+  int _snapshotPasteCount = 0;
+
+  /// Whether [pasteSnapshot] has a captured region to paste.
+  bool get hasSnapshotClipboard => _snapshotClipboard != null;
+
+  /// The captured region on the snapshot clipboard, or null.
+  PdfVectorSnapshot? get snapshotClipboard => _snapshotClipboard;
+
+  /// Captures [region] (PDF user space) of [pageIndex] as a detached
+  /// vector snapshot — the page graphics under the region, copied inline.
+  /// Read-only: the document is untouched. See
+  /// [PdfVectorSnapshotEditing.captureVectorSnapshot].
+  PdfVectorSnapshot captureVectorSnapshot(int pageIndex, PdfRect region) =>
+      PdfEditor(_document).captureVectorSnapshot(pageIndex, region);
+
+  /// Captures [region] of [pageIndex] and keeps it on the snapshot
+  /// clipboard for [pasteSnapshot] — the copy half of the Snapshot tool.
+  /// The most recent copy wins, so this also drops the annotation
+  /// clipboard. Returns the captured snapshot.
+  PdfVectorSnapshot copyVectorSnapshot(int pageIndex, PdfRect region) {
+    final snapshot = captureVectorSnapshot(pageIndex, region);
+    _snapshotClipboard = snapshot;
+    _snapshotPasteCount = 0;
+    _clipboard = const [];
+    notifyListeners();
+    return snapshot;
+  }
+
+  /// Pastes the snapshot clipboard onto [pageIndex] as a vector /Stamp
+  /// annotation (movable / resizable / deletable), preserving the captured
+  /// graphics as vectors.
+  ///
+  /// With [at] the region centers on that page point (a right-click /
+  /// ⌘V at the cursor). Without it the paste keeps the captured position,
+  /// cascading 12pt down-right per repeat. The region always clamps into
+  /// the page's crop box. Returns whether anything was pasted.
+  bool pasteSnapshot(int pageIndex, {(double, double)? at}) {
+    final snapshot = _snapshotClipboard;
+    if (snapshot == null) return false;
+    if (pageIndex < 0 || pageIndex >= _document.pageCount) return false;
+    final region = snapshot.region;
+    final w = region.width, h = region.height;
+    if (w <= 0 || h <= 0) return false;
+    double left, bottom;
+    if (at != null) {
+      left = at.$1 - w / 2;
+      bottom = at.$2 - h / 2;
+    } else {
+      final cascade = 12.0 * _snapshotPasteCount;
+      left = region.left + cascade;
+      bottom = region.bottom - cascade;
+    }
+    final box = _page(pageIndex).cropBox;
+    left += _clampShift(left, left + w, box.left, box.right);
+    bottom += _clampShift(bottom, bottom + h, box.bottom, box.top);
+    final target = PdfRect(left, bottom, left + w, bottom + h);
+    final pasted = apply(
+        (e) => e.pasteVectorSnapshot(pageIndex, target, snapshot,
+            author: author),
+        pages: [pageIndex]);
+    if (!pasted) return false;
+    _snapshotPasteCount++;
+    tool = PdfEditTool.select;
+    final total = _page(pageIndex).annotations.length;
+    _selected
+      ..clear()
+      ..add((pageIndex, total - 1));
     notifyListeners();
     return true;
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
@@ -83,7 +83,10 @@ Future<void> showPdfAnnotationMenu({
   (double, double)? pagePoint,
 }) async {
   final request = PdfAnnotationMenuRequest._(controller, pageIndex);
-  final canPaste = controller.hasAnnotationClipboard;
+  // a captured snapshot pastes back as vector graphics; otherwise the
+  // annotation clipboard (the most recent copy wins)
+  final canPasteSnapshot = controller.hasSnapshotClipboard;
+  final canPaste = canPasteSnapshot || controller.hasAnnotationClipboard;
   final hasSelection = request.annotations.isNotEmpty;
   if (!hasSelection && !canPaste) return;
   final stock = <PdfAnnotationMenuItem>[
@@ -106,8 +109,9 @@ Future<void> showPdfAnnotationMenu({
       label: 'Paste',
       icon: Icons.paste,
       enabled: canPaste,
-      onSelected: (request) =>
-          request.controller.pasteAnnotations(pageIndex, at: pagePoint),
+      onSelected: (request) => canPasteSnapshot
+          ? request.controller.pasteSnapshot(pageIndex, at: pagePoint)
+          : request.controller.pasteAnnotations(pageIndex, at: pagePoint),
     ),
     if (hasSelection) ...[
       PdfAnnotationMenuItem(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -80,6 +80,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.predictStrokes = true,
     this.formImagePicker,
     this.imagePicker,
+    this.onSnapshot,
     this.onShowAnnotationMenu,
     this.onShowFormFieldMenu,
     this.onResolvePagePoint,
@@ -98,6 +99,10 @@ class EditingPageOverlay extends StatefulWidget {
   /// How the image tool ([PdfEditTool.image]) asks for the picture to
   /// insert. With none, the image tool does nothing.
   final PdfImagePicker? imagePicker;
+
+  /// Receives a region captured by the snapshot tool
+  /// ([PdfEditTool.snapshot]). With none, the snapshot tool does nothing.
+  final PdfSnapshotHandler? onSnapshot;
 
   /// The paper color the page is displayed with — the eyedropper's
   /// raster must match what's on screen.
@@ -1673,7 +1678,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             PdfEditTool.freeText ||
             PdfEditTool.stamp ||
             PdfEditTool.image ||
-            PdfEditTool.redact:
+            PdfEditTool.redact ||
+            PdfEditTool.snapshot:
         setState(() {
           _dragStart = position;
           _dragCurrent = position;
@@ -2335,6 +2341,30 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             _controller.newFormFieldKind, widget.pageIndex, rect);
       case PdfEditTool.redact:
         _controller.addRedaction(widget.pageIndex, rect);
+      case PdfEditTool.snapshot:
+        // always keep a vector copy on the clipboard so it can paste back
+        // into the PDF (⌘V / the paste menu), Bluebeam-style; the host
+        // callback is an optional export of the raster image on top
+        final vector =
+            _controller.copyVectorSnapshot(widget.pageIndex, rect);
+        final handler = widget.onSnapshot;
+        if (handler == null) return;
+        // page raster space (post-/Rotate, y down) = view space / scale —
+        // the same mapping the eyedropper's sampler uses
+        final s = _geometry.scale;
+        final region = Rect.fromLTRB(viewRect.left / s, viewRect.top / s,
+            viewRect.right / s, viewRect.bottom / s);
+        final bytes = await _controller.captureSnapshot(widget.pageIndex, region,
+            pageColor: widget.pageColor, annotations: widget.showAnnotations);
+        if (bytes == null || !mounted) return;
+        await handler(
+            context,
+            PdfSnapshot(
+              pageIndex: widget.pageIndex,
+              pageRect: rect,
+              pngBytes: bytes,
+              vector: vector,
+            ));
       default:
         break;
     }
@@ -3799,6 +3829,15 @@ class _EditingPreviewPainter extends CustomPainter {
               ..strokeWidth = 1);
       case PdfEditTool.redact:
         paintRedactionHatch(canvas, rect);
+      case PdfEditTool.snapshot:
+        // a selection marquee, like the region grab in a screenshot tool
+        canvas.drawRect(rect, Paint()..color = _chrome.withAlpha(0x1A));
+        canvas.drawRect(
+            rect,
+            Paint()
+              ..color = _chrome
+              ..style = PaintingStyle.stroke
+              ..strokeWidth = 1 * chromeScale);
       default:
         canvas.drawRect(rect, paint);
     }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -298,6 +298,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           'Form fields — tap to select, double-tap to fill, drag to add'),
       _GroupTool.tool(PdfEditTool.redact, Icons.gradient,
           'Redact — drag a region, then apply'),
+      _GroupTool.tool(PdfEditTool.snapshot, Icons.crop,
+          'Snapshot — drag a region to capture it (paste back as vector)'),
     ]),
   ];
 
@@ -722,6 +724,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             PdfEditTool.content => 'Content',
             PdfEditTool.form => 'Form',
             PdfEditTool.redact => 'Redact',
+            PdfEditTool.snapshot => 'Snapshot',
             _ => _entryLabel(entry),
           },
           tooltip: _entryTip(entry),

--- a/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:pdf_document/pdf_document.dart' show PdfFormField;
+import 'package:pdf_document/pdf_document.dart'
+    show PdfFormField, PdfRect, PdfVectorSnapshot;
 
 /// Supplies the image a tapped push-button field should be filled with
 /// — typically a file picker. Return null to leave the button alone.
@@ -13,6 +14,42 @@ typedef PdfFormImagePicker = Future<Uint8List?> Function(
 /// — typically a file picker. Return null to cancel. PNG and JPEG bytes
 /// are accepted ([PdfEditingController.placeImage]).
 typedef PdfImagePicker = Future<Uint8List?> Function(BuildContext context);
+
+/// A region of a page captured by the Snapshot tool ([PdfEditTool.snapshot])
+/// — Bluebeam-style: drag out a box and the page region under it is rendered
+/// to an image, handed to [PdfViewer.onSnapshot] for the host to copy, save,
+/// or share.
+class PdfSnapshot {
+  const PdfSnapshot({
+    required this.pageIndex,
+    required this.pageRect,
+    required this.pngBytes,
+    required this.vector,
+  });
+
+  /// The page the region was captured from.
+  final int pageIndex;
+
+  /// The captured region in PDF user space (points, origin bottom-left).
+  final PdfRect pageRect;
+
+  /// The captured region rendered to a PNG image — for copying to the
+  /// clipboard, saving, or sharing as a picture.
+  final Uint8List pngBytes;
+
+  /// The captured region as detached **vector** graphics, ready to paste
+  /// back into any PDF with [PdfVectorSnapshotEditing.pasteVectorSnapshot]
+  /// (or in-app via [PdfEditingController.pasteSnapshot]) — Bluebeam-style,
+  /// the snapshot stays sharp at any zoom.
+  final PdfVectorSnapshot vector;
+}
+
+/// Receives a region captured by the Snapshot tool ([PdfEditTool.snapshot])
+/// — typically to copy it to the system clipboard, save it to a file, or
+/// share it. With no handler ([PdfViewer.onSnapshot]) the Snapshot tool
+/// captures nothing.
+typedef PdfSnapshotHandler = Future<void> Function(
+    BuildContext context, PdfSnapshot snapshot);
 
 /// Signature of the prompt the editing UI uses to ask for annotation text
 /// (free text, notes, stamps). Returns null when the user cancels.

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -171,6 +171,7 @@ class PdfEditorView extends StatefulWidget {
     this.annotationMenuBuilder,
     this.formImagePicker,
     this.imagePicker,
+    this.onSnapshot,
     this.textPrompt,
     this.palette = PdfEditingToolbar.defaultPalette,
     this.toolbarLeading = const [],
@@ -245,6 +246,11 @@ class PdfEditorView extends StatefulWidget {
 
   /// See [PdfViewer.imagePicker].
   final PdfImagePicker? imagePicker;
+
+  /// See [PdfViewer.onSnapshot]. The snapshot tool always keeps a vector
+  /// copy on the clipboard for in-app paste; this callback additionally
+  /// exports the captured raster image (copy/save/share).
+  final PdfSnapshotHandler? onSnapshot;
 
   /// How dialog-based tools ask for text. Defaults to
   /// [showPdfTextPrompt], a Material dialog.
@@ -638,6 +644,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         annotationMenuBuilder: widget.annotationMenuBuilder,
                         formImagePicker: widget.formImagePicker,
                         imagePicker: widget.imagePicker,
+                        onSnapshot: widget.onSnapshot,
                         editingTextPrompt: widget.textPrompt,
                         initialFit: widget.initialFit,
                         backgroundColor: widget.backgroundColor,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -350,6 +350,7 @@ class PdfViewer extends StatefulWidget {
     this.annotationMenuBuilder,
     this.formImagePicker,
     this.imagePicker,
+    this.onSnapshot,
     this.pageSpacing = 12,
     this.initialFit = PdfViewerFit.page,
     this.initialViewport,
@@ -433,6 +434,11 @@ class PdfViewer extends StatefulWidget {
   /// insert — typically a file picker returning PNG or JPEG bytes. With
   /// none, the image tool does nothing.
   final PdfImagePicker? imagePicker;
+
+  /// Receives a region captured by the snapshot tool
+  /// ([PdfEditTool.snapshot]) — typically to copy it to the clipboard,
+  /// save it, or share it. With none, the snapshot tool does nothing.
+  final PdfSnapshotHandler? onSnapshot;
 
   final double pageSpacing;
 
@@ -1947,10 +1953,21 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// current page's cascade.
   void _onPaste() {
     final editing = widget.editing;
-    if (editing == null || !editing.hasAnnotationClipboard) return;
+    if (editing == null) return;
+    // a captured snapshot pastes back as vector graphics; otherwise the
+    // annotation clipboard (the most recent copy wins, mirroring the
+    // controller's clipboards)
+    final snapshot = editing.hasSnapshotClipboard;
+    if (!snapshot && !editing.hasAnnotationClipboard) return;
     final local = _lastPointerLocal;
     final point = local == null ? null : _pagePointAt(local);
-    if (point != null) {
+    if (snapshot) {
+      if (point != null) {
+        editing.pasteSnapshot(point.$1, at: (point.$2, point.$3));
+      } else {
+        editing.pasteSnapshot(_controller.currentPage);
+      }
+    } else if (point != null) {
       editing.pasteAnnotations(point.$1, at: (point.$2, point.$3));
     } else {
       editing.pasteAnnotations(_controller.currentPage);
@@ -2917,6 +2934,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                     widget.editingTextPrompt ?? showPdfTextPrompt,
                 formImagePicker: widget.formImagePicker,
                 imagePicker: widget.imagePicker,
+                onSnapshot: widget.onSnapshot,
                 onPanViewport: _grabPanBy,
                 onPanViewportEnd: _flingViewport,
                 onShowAnnotationMenu: _showSelectionMenu,
@@ -3272,6 +3290,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.editingTextPrompt,
     required this.formImagePicker,
     required this.imagePicker,
+    required this.onSnapshot,
     required this.onPanViewport,
     required this.onPanViewportEnd,
     required this.onShowAnnotationMenu,
@@ -3320,6 +3339,9 @@ class _PdfViewerPage extends StatefulWidget {
   final PdfTextPrompt editingTextPrompt;
   final PdfFormImagePicker? formImagePicker;
   final PdfImagePicker? imagePicker;
+
+  /// See [EditingPageOverlay.onSnapshot].
+  final PdfSnapshotHandler? onSnapshot;
   final void Function(Offset delta) onPanViewport;
 
   /// See [EditingPageOverlay.onPanViewportEnd].
@@ -3477,6 +3499,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                               textPrompt: widget.editingTextPrompt,
                               formImagePicker: widget.formImagePicker,
                               imagePicker: widget.imagePicker,
+                              onSnapshot: widget.onSnapshot,
                               pageColor: widget.pageColor,
                               showAnnotations: widget.showAnnotations,
                               onPanViewport: widget.onPanViewport,

--- a/packages/dart_pdf_editor/test/editing_snapshot_test.dart
+++ b/packages/dart_pdf_editor/test/editing_snapshot_test.dart
@@ -37,6 +37,48 @@ void main() {
       expect(editing.hasAnnotationSelection, isTrue);
     });
 
+    test('captureVectorSnapshot reads without filling the clipboard', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      final snap =
+          editing.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      expect(snap.region, const PdfRect(60, 700, 220, 740));
+      expect(editing.hasSnapshotClipboard, isFalse);
+      expect(editing.snapshotClipboard, isNull);
+    });
+
+    test('copying without a paste point cascades repeat pastes', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      expect(editing.snapshotClipboard, isNotNull);
+
+      expect(editing.pasteSnapshot(0), isTrue);
+      final first = editing.document.page(0).annotations.last.rect;
+      expect(editing.pasteSnapshot(0), isTrue);
+      final second = editing.document.page(0).annotations.last.rect;
+      // the second paste cascades 12pt down-right of the first
+      expect(second.left, closeTo(first.left + 12, 1e-6));
+      expect(second.bottom, closeTo(first.bottom - 12, 1e-6));
+    });
+
+    test('copying an annotation clears the snapshot clipboard (last wins)', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.addRectangle(0, const PdfRect(10, 10, 60, 60));
+      editing.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      expect(editing.hasSnapshotClipboard, isTrue);
+
+      editing.selectAnnotationAt(0, 35, 35);
+      expect(editing.copySelectedAnnotations(), 1);
+      // the annotation copy supersedes the snapshot on the clipboard
+      expect(editing.hasSnapshotClipboard, isFalse);
+      expect(editing.hasAnnotationClipboard, isTrue);
+    });
+
     test('pasteSnapshot with no clipboard is a no-op', () {
       SharedPreferences.setMockInitialValues({});
       final editing = PdfEditingController(buildMultiPagePdf(1));

--- a/packages/dart_pdf_editor/test/editing_snapshot_test.dart
+++ b/packages/dart_pdf_editor/test/editing_snapshot_test.dart
@@ -1,0 +1,140 @@
+// The Snapshot tool (PdfEditTool.snapshot): drag a region to capture it
+// as a raster image (handed to PdfViewer.onSnapshot) AND as detached
+// vector graphics kept on the clipboard for pasting back into the PDF.
+import 'dart:convert';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('PdfEditingController snapshot clipboard', () {
+    test('copyVectorSnapshot fills the clipboard; paste adds a vector stamp',
+        () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      addTearDown(editing.dispose);
+
+      expect(editing.hasSnapshotClipboard, isFalse);
+      editing.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      expect(editing.hasSnapshotClipboard, isTrue);
+
+      expect(editing.pasteSnapshot(1, at: (300, 400)), isTrue);
+      final stamp = editing.document.page(1).annotations.single;
+      expect(stamp.subtype, 'Stamp');
+      // natural size (160x40) centered on the paste point
+      expect(stamp.rect.width, closeTo(160, 1e-6));
+      expect(stamp.rect.height, closeTo(40, 1e-6));
+      expect((stamp.rect.left + stamp.rect.right) / 2, closeTo(300, 1e-6));
+      // pasting it back is vector: the appearance draws the captured form
+      final ap =
+          latin1.decode(editing.document.cos.decodeStreamData(stamp.normalAppearance!));
+      expect(ap, contains('/Cap Do'));
+      // the pasted stamp is selected for immediate move/resize
+      expect(editing.hasAnnotationSelection, isTrue);
+    });
+
+    test('pasteSnapshot with no clipboard is a no-op', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      expect(editing.pasteSnapshot(0), isFalse);
+      expect(editing.isModified, isFalse);
+    });
+
+    test('the snapshot clipboard clamps an oversized region into the page', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.copyVectorSnapshot(0, const PdfRect(0, 0, 600, 780));
+      expect(editing.pasteSnapshot(0, at: (10, 10)), isTrue);
+      final rect = editing.document.page(0).annotations.single.rect;
+      // pinned to the low edge of the 612x792 crop box
+      expect(rect.left, closeTo(0, 1e-6));
+      expect(rect.bottom, closeTo(0, 1e-6));
+    });
+  });
+
+  group('snapshot tool in the viewer', () {
+    const scale = 800 / 612;
+    Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+
+    Future<PdfEditingController> pumpEditor(WidgetTester tester,
+        {PdfSnapshotHandler? onSnapshot}) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+              onSnapshot: onSnapshot,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    testWidgets('dragging a region fills the vector clipboard', (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.tool = PdfEditTool.snapshot;
+      await tester.pump();
+
+      // copyVectorSnapshot runs synchronously on drag-end (no raster needed)
+      final gesture = await tester.startGesture(view(70, 740));
+      await gesture.moveTo(view(150, 710));
+      await gesture.moveTo(view(220, 700));
+      await gesture.up();
+      await tester.pump();
+
+      expect(editing.hasSnapshotClipboard, isTrue);
+      // nothing was written to the document by the capture itself
+      expect(editing.document.page(0).annotations, isEmpty);
+      expect(editing.isModified, isFalse);
+      // drain the viewer's double-tap timer left by the touch gesture
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('the host handler receives a PNG and a vector snapshot',
+        (tester) async {
+      PdfSnapshot? captured;
+      final editing = await pumpEditor(tester,
+          onSnapshot: (context, snap) async => captured = snap);
+      editing.tool = PdfEditTool.snapshot;
+      await tester.pump();
+
+      await tester.runAsync(() async {
+        final gesture = await tester.startGesture(view(70, 740));
+        await gesture.moveTo(view(150, 720));
+        await gesture.moveTo(view(220, 700));
+        await gesture.up();
+        // captureSnapshot renders + encodes a PNG (toImage) — let it finish
+        for (var i = 0; i < 50 && captured == null; i++) {
+          await tester.pump(const Duration(milliseconds: 20));
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+        }
+      });
+
+      expect(captured, isNotNull);
+      expect(captured!.pageIndex, 0);
+      expect(captured!.pngBytes, isNotEmpty);
+      // PNG magic number
+      expect(captured!.pngBytes.sublist(0, 4), [0x89, 0x50, 0x4E, 0x47]);
+      // the vector half pastes back into the document
+      expect(editing.pasteSnapshot(1, at: (300, 400)), isTrue);
+      expect(editing.document.page(1).annotations.single.subtype, 'Stamp');
+    });
+  });
+}

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.1.0
 
+- Vector snapshots: `PdfEditor.captureVectorSnapshot` captures a page
+  region as detached vector graphics (`PdfVectorSnapshot`) and
+  `pasteVectorSnapshot` re-materializes it onto any page as a /Stamp
+  annotation whose appearance *draws* the captured content — so a snapshot
+  pasted back into the PDF stays vector (crisp at any zoom), Bluebeam-style.
 - Count tool: `PdfEditor.addCheckMark` places a Bluebeam-style check-mark
   stamp annotation (with `PdfAnnotation.isCheckMark`/`iconName`) — the
   building block for a running on-page tally.

--- a/packages/pdf_document/lib/src/editor.dart
+++ b/packages/pdf_document/lib/src/editor.dart
@@ -25,6 +25,7 @@ part 'form_editor.dart';
 part 'ocr_editor.dart';
 part 'page_editor.dart';
 part 'signature_editor.dart';
+part 'vector_snapshot.dart';
 
 /// High-level editing session over a [PdfDocument].
 ///

--- a/packages/pdf_document/lib/src/vector_snapshot.dart
+++ b/packages/pdf_document/lib/src/vector_snapshot.dart
@@ -1,0 +1,110 @@
+part of 'editor.dart';
+
+/// A detached, **vector** copy of a rectangular region of a page — the page
+/// content and resources under the region, resolved and copied inline so
+/// the snapshot survives edits, undo, and even closing the source document.
+///
+/// It is the payload behind the Snapshot tool's "paste as vector":
+/// [PdfVectorSnapshotEditing.pasteVectorSnapshot] re-materializes it onto
+/// any page as a /Stamp annotation whose appearance *draws* the captured
+/// graphics, so it stays sharp at any zoom (unlike a raster snapshot) and
+/// stays movable/resizable/deletable like any annotation.
+///
+/// Capture with [PdfVectorSnapshotEditing.captureVectorSnapshot].
+///
+/// Page /Rotate is not baked in: the captured content keeps the source
+/// page's native (unrotated) orientation.
+class PdfVectorSnapshot {
+  PdfVectorSnapshot._(this.region, this._content, this._resources);
+
+  /// The captured region in the source page's user space (points, origin
+  /// bottom-left).
+  final PdfRect region;
+
+  /// The source page's content streams, decoded and concatenated — the
+  /// operators the appearance replays, clipped to [region] by the form's
+  /// BBox.
+  final Uint8List _content;
+
+  /// The source page's /Resources, deep-copied inline (fonts, images,
+  /// nested XObjects), detached from the source document.
+  final CosDictionary _resources;
+}
+
+/// Capturing and pasting vector regions ([PdfVectorSnapshot]) — the vector
+/// half of the Snapshot tool, complementing the raster capture in
+/// `dart_pdf_editor`.
+extension PdfVectorSnapshotEditing on PdfEditor {
+  /// Captures [region] (the source page's user space) of page [pageIndex]
+  /// as a detached vector snapshot. Read-only: the document is untouched.
+  ///
+  /// The whole page content travels with the snapshot; the region only
+  /// becomes a clip when the snapshot is pasted (the form's BBox), so a
+  /// capture is cheap and a paste shows exactly what was under the box.
+  PdfVectorSnapshot captureVectorSnapshot(int pageIndex, PdfRect region) {
+    final page = document.page(pageIndex);
+    final content = page.contentBytes();
+    final resources =
+        _SnapshotCopier(document).copy(page.resources) as CosDictionary;
+    return PdfVectorSnapshot._(region, content, resources);
+  }
+
+  /// Pastes [snapshot] onto page [pageIndex], scaled to fill [targetRect],
+  /// as a /Stamp annotation whose appearance draws the captured graphics
+  /// as vectors.
+  ///
+  /// The captured region becomes its own Form XObject — BBox = the source
+  /// region, content = the page's operators — so it clips to the region;
+  /// the annotation's appearance then maps that form onto [targetRect]
+  /// (§12.5.5 identity, like an image stamp).
+  void pasteVectorSnapshot(
+    int pageIndex,
+    PdfRect targetRect,
+    PdfVectorSnapshot snapshot, {
+    double opacity = 1,
+    String? author,
+    String? name,
+  }) {
+    final region = snapshot.region;
+    if (region.width <= 0 || region.height <= 0) return;
+
+    // the captured region as its own Form XObject: the BBox clips the page
+    // content to the region, in the source page's user space
+    final captured = CosStream(
+      CosDictionary({
+        'Type': const CosName('XObject'),
+        'Subtype': const CosName('Form'),
+        'BBox': _rectArray(region),
+        'Resources': _copyDetached(snapshot._resources) as CosDictionary,
+        'Length': CosInteger(snapshot._content.length),
+      }),
+      Uint8List.fromList(snapshot._content),
+    );
+    // the resources hold fonts / images / nested forms as inline streams —
+    // hoist them to indirect objects (§7.3.8) before the form references them
+    _hoistStreams(captured.dictionary);
+    final capturedRef = _updater.addObject(captured);
+
+    // the appearance maps the region box onto the target rect, then draws
+    // the captured form (which clips to its own BBox in source coordinates)
+    final sx = targetRect.width / region.width;
+    final sy = targetRect.height / region.height;
+    final w = ContentWriter();
+    final gs = _alphaState(opacity);
+    if (gs != null) w.extGState('GS0');
+    w
+      ..save()
+      ..concatMatrix(sx, 0, 0, sy, targetRect.left - sx * region.left,
+          targetRect.bottom - sy * region.bottom)
+      ..drawXObject('Cap')
+      ..restore();
+    _addAnnotation(
+      pageIndex,
+      _markupDict('Stamp', targetRect, 0x000000, null, author),
+      _form(targetRect, w,
+          resources: _resources(
+              extGState: gs, xObject: CosDictionary({'Cap': capturedRef}))),
+      name: name,
+    );
+  }
+}

--- a/packages/pdf_document/lib/src/vector_snapshot.dart
+++ b/packages/pdf_document/lib/src/vector_snapshot.dart
@@ -10,25 +10,44 @@ part of 'editor.dart';
 /// graphics, so it stays sharp at any zoom (unlike a raster snapshot) and
 /// stays movable/resizable/deletable like any annotation.
 ///
+/// The page's /Rotate is baked into the capture ([_matrix]/[displayWidth]/
+/// [displayHeight]), so a region snapped from a 90°/270° page pastes in the
+/// orientation it was displayed in.
+///
 /// Capture with [PdfVectorSnapshotEditing.captureVectorSnapshot].
 ///
-/// Page /Rotate is not baked in: the captured content keeps the source
-/// page's native (unrotated) orientation.
+/// Size note: the whole page's content stream travels with the snapshot
+/// (only the form BBox clips it), so a small snap of a content-heavy page
+/// still embeds that page's operators once. Repeated pastes of the *same*
+/// snapshot into one document share a single captured XObject rather than
+/// duplicating it (see [PdfVectorSnapshotEditing.pasteVectorSnapshot]).
 class PdfVectorSnapshot {
-  PdfVectorSnapshot._(this.region, this._content, this._resources);
+  PdfVectorSnapshot._(this.region, this.displayWidth, this.displayHeight,
+      this._content, this._resources, this._matrix);
 
   /// The captured region in the source page's user space (points, origin
-  /// bottom-left).
+  /// bottom-left), before /Rotate.
   final PdfRect region;
 
+  /// The region's displayed width and height — [region] rotated by the
+  /// page's /Rotate, so a 90°/270° page swaps the two. The natural paste
+  /// size.
+  final double displayWidth;
+  final double displayHeight;
+
   /// The source page's content streams, decoded and concatenated — the
-  /// operators the appearance replays, clipped to [region] by the form's
-  /// BBox.
+  /// operators the appearance replays (under [_matrix], clipped to the
+  /// form BBox).
   final Uint8List _content;
 
   /// The source page's /Resources, deep-copied inline (fonts, images,
   /// nested XObjects), detached from the source document.
   final CosDictionary _resources;
+
+  /// The cm mapping the page's user space onto an upright
+  /// `[0 0 displayWidth displayHeight]` box — translation for an unrotated
+  /// page, a rotation+translation for 90/180/270.
+  final List<double> _matrix;
 }
 
 /// Capturing and pasting vector regions ([PdfVectorSnapshot]) — the vector
@@ -38,64 +57,108 @@ extension PdfVectorSnapshotEditing on PdfEditor {
   /// Captures [region] (the source page's user space) of page [pageIndex]
   /// as a detached vector snapshot. Read-only: the document is untouched.
   ///
-  /// The whole page content travels with the snapshot; the region only
-  /// becomes a clip when the snapshot is pasted (the form's BBox), so a
-  /// capture is cheap and a paste shows exactly what was under the box.
+  /// The page's /Rotate is baked in, so the snapshot pastes the way the
+  /// region was displayed.
   PdfVectorSnapshot captureVectorSnapshot(int pageIndex, PdfRect region) {
     final page = document.page(pageIndex);
     final content = page.contentBytes();
     final resources =
         _SnapshotCopier(document).copy(page.resources) as CosDictionary;
-    return PdfVectorSnapshot._(region, content, resources);
+    final rx0 = region.left, ry0 = region.bottom;
+    final rx1 = region.right, ry1 = region.top;
+    final w = region.width, h = region.height;
+    // a cm mapping the page user space into an upright [0 0 dW dH] box,
+    // baking /Rotate (clockwise, matching the display); the box's width and
+    // height swap on quarter turns
+    final (List<double> matrix, double dW, double dH) = switch (page.rotation) {
+      90 => ([0, -1, 1, 0, -ry0, rx1], h, w),
+      180 => ([-1, 0, 0, -1, rx1, ry1], w, h),
+      270 => ([0, 1, -1, 0, ry1, -rx0], h, w),
+      _ => ([1, 0, 0, 1, -rx0, -ry0], w, h),
+    };
+    return PdfVectorSnapshot._(region, dW, dH, content, resources, matrix);
   }
 
   /// Pastes [snapshot] onto page [pageIndex], scaled to fill [targetRect],
-  /// as a /Stamp annotation whose appearance draws the captured graphics
-  /// as vectors.
+  /// as a /Stamp annotation whose appearance draws the captured graphics as
+  /// vectors.
   ///
-  /// The captured region becomes its own Form XObject — BBox = the source
-  /// region, content = the page's operators — so it clips to the region;
-  /// the annotation's appearance then maps that form onto [targetRect]
-  /// (§12.5.5 identity, like an image stamp).
-  void pasteVectorSnapshot(
+  /// The captured region becomes its own Form XObject (BBox =
+  /// `[0 0 displayWidth displayHeight]`, content = the page's operators
+  /// under the rotation matrix); the annotation's appearance scales that
+  /// box onto [targetRect].
+  ///
+  /// To avoid embedding the (whole-page) content once per paste, pass the
+  /// object number returned by an earlier paste of the *same* snapshot into
+  /// this document as [sharedObject]: when it still resolves to the
+  /// captured form, this paste references it instead of duplicating it.
+  /// Returns the captured form's object number (pass it back as
+  /// [sharedObject] next time), or -1 when nothing was pasted.
+  int pasteVectorSnapshot(
     int pageIndex,
     PdfRect targetRect,
     PdfVectorSnapshot snapshot, {
     double opacity = 1,
     String? author,
     String? name,
+    int? sharedObject,
   }) {
-    final region = snapshot.region;
-    if (region.width <= 0 || region.height <= 0) return;
+    final dW = snapshot.displayWidth, dH = snapshot.displayHeight;
+    if (dW <= 0 || dH <= 0 || targetRect.width <= 0 || targetRect.height <= 0) {
+      return sharedObject ?? -1;
+    }
 
-    // the captured region as its own Form XObject: the BBox clips the page
-    // content to the region, in the source page's user space
-    final captured = CosStream(
-      CosDictionary({
-        'Type': const CosName('XObject'),
-        'Subtype': const CosName('Form'),
-        'BBox': _rectArray(region),
-        'Resources': _copyDetached(snapshot._resources) as CosDictionary,
-        'Length': CosInteger(snapshot._content.length),
-      }),
-      Uint8List.fromList(snapshot._content),
-    );
-    // the resources hold fonts / images / nested forms as inline streams —
-    // hoist them to indirect objects (§7.3.8) before the form references them
-    _hoistStreams(captured.dictionary);
-    final capturedRef = _updater.addObject(captured);
+    // reuse an already-materialized captured form when one was handed back
+    // from a prior paste and still resolves — N pastes then share ONE
+    // XObject instead of embedding N copies of the page content
+    CosObject? existing;
+    if (sharedObject != null) {
+      try {
+        existing = document.cos.resolve(CosReference(sharedObject, 0));
+      } catch (_) {
+        existing = null;
+      }
+    }
+    final int capObject;
+    final CosReference capRef;
+    if (existing is CosStream &&
+        existing.dictionary['Subtype'] is CosName &&
+        (existing.dictionary['Subtype'] as CosName).value == 'Form') {
+      capObject = sharedObject!;
+      capRef = CosReference(sharedObject, 0);
+    } else {
+      final m = snapshot._matrix;
+      final body = BytesBuilder()
+        ..add(latin1.encode('q ${m.map(_fmtNum).join(' ')} cm\n'))
+        ..add(snapshot._content)
+        ..add(latin1.encode('\nQ'));
+      final bytes = body.takeBytes();
+      final captured = CosStream(
+        CosDictionary({
+          'Type': const CosName('XObject'),
+          'Subtype': const CosName('Form'),
+          'BBox': _rectArray(PdfRect(0, 0, dW, dH)),
+          'Resources': _copyDetached(snapshot._resources) as CosDictionary,
+          'Length': CosInteger(bytes.length),
+        }),
+        bytes,
+      );
+      // the resources hold fonts / images / nested forms as inline streams —
+      // hoist them to indirect objects (§7.3.8) before referencing the form
+      _hoistStreams(captured.dictionary);
+      capRef = _updater.addObject(captured);
+      capObject = capRef.objectNumber;
+    }
 
-    // the appearance maps the region box onto the target rect, then draws
-    // the captured form (which clips to its own BBox in source coordinates)
-    final sx = targetRect.width / region.width;
-    final sy = targetRect.height / region.height;
+    // the appearance scales the captured [0 0 dW dH] box onto the target rect
+    final sx = targetRect.width / dW;
+    final sy = targetRect.height / dH;
     final w = ContentWriter();
     final gs = _alphaState(opacity);
     if (gs != null) w.extGState('GS0');
     w
       ..save()
-      ..concatMatrix(sx, 0, 0, sy, targetRect.left - sx * region.left,
-          targetRect.bottom - sy * region.bottom)
+      ..concatMatrix(sx, 0, 0, sy, targetRect.left, targetRect.bottom)
       ..drawXObject('Cap')
       ..restore();
     _addAnnotation(
@@ -103,8 +166,14 @@ extension PdfVectorSnapshotEditing on PdfEditor {
       _markupDict('Stamp', targetRect, 0x000000, null, author),
       _form(targetRect, w,
           resources: _resources(
-              extGState: gs, xObject: CosDictionary({'Cap': capturedRef}))),
+              extGState: gs, xObject: CosDictionary({'Cap': capRef}))),
       name: name,
     );
+    return capObject;
   }
 }
+
+/// Formats a matrix component for a content stream — integers without a
+/// trailing `.0`.
+String _fmtNum(double v) =>
+    v == v.roundToDouble() ? v.toInt().toString() : v.toString();

--- a/packages/pdf_document/test/vector_snapshot_test.dart
+++ b/packages/pdf_document/test/vector_snapshot_test.dart
@@ -76,6 +76,16 @@ void main() {
       expect(ap, contains('2 0 0 4 10 20 cm'));
     });
 
+    test('pasting a degenerate (zero-area) region is a no-op', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(100, 100, 100, 140));
+      editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 50, 50), snap);
+      expect(editor.hasChanges, isFalse);
+      expect(doc.page(0).annotations, isEmpty);
+    });
+
     test('a detached snapshot survives further edits to the source', () {
       final doc = PdfDocument.open(buildMultiPagePdf(1));
       final editor = PdfEditor(doc);

--- a/packages/pdf_document/test/vector_snapshot_test.dart
+++ b/packages/pdf_document/test/vector_snapshot_test.dart
@@ -76,6 +76,23 @@ void main() {
       expect(ap, contains('2 0 0 4 10 20 cm'));
     });
 
+    test('paste with opacity < 1 adds an ExtGState alpha to the appearance', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      editor.pasteVectorSnapshot(0, const PdfRect(100, 100, 260, 140), snap,
+          opacity: 0.5);
+      final out = PdfDocument.open(editor.save());
+      final stamp = out.page(0).annotations.single;
+      final ap =
+          latin1.decode(out.cos.decodeStreamData(stamp.normalAppearance!));
+      expect(ap, contains('/GS0 gs'));
+      final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
+          as CosDictionary;
+      expect(out.cos.resolve(res['ExtGState']), isA<CosDictionary>());
+    });
+
     test('pasting a degenerate (zero-area) region is a no-op', () {
       final doc = PdfDocument.open(buildMultiPagePdf(1));
       final editor = PdfEditor(doc);

--- a/packages/pdf_document/test/vector_snapshot_test.dart
+++ b/packages/pdf_document/test/vector_snapshot_test.dart
@@ -42,18 +42,22 @@ void main() {
       final ap = latin1.decode(out.cos.decodeStreamData(stamp.normalAppearance!));
       expect(ap, contains('/Cap Do'));
 
-      // /Cap is a Form XObject whose BBox is the source region and whose
-      // content is the page's own operators — i.e. real vectors, not a raster
+      // /Cap is a Form XObject in an upright [0 0 dW dH] box whose content
+      // is the page's own operators under the capture matrix — i.e. real
+      // vectors, not a raster
       final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
           as CosDictionary;
       final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
       final cap = out.cos.resolve(xobj['Cap']) as CosStream;
       expect(_name(cap.dictionary['Subtype']), 'Form');
       final bbox = out.cos.resolve(cap.dictionary['BBox']) as CosArray;
+      // an unrotated page: the box is the region's size at the origin
       expect([for (final v in bbox.items) _num(out.cos.resolve(v))],
-          [60.0, 700.0, 220.0, 740.0]);
+          [0.0, 0.0, 160.0, 40.0]);
       final capContent = latin1.decode(out.cos.decodeStreamData(cap));
       expect(capContent, contains('(Page 1) Tj'));
+      // the capture matrix translates the region's origin to the box origin
+      expect(capContent, contains('1 0 0 1 -60 -700 cm'));
 
       // the page's font resource travels with the form (the text resolves)
       final capRes =
@@ -74,6 +78,74 @@ void main() {
       final ap = latin1.decode(out.cos.decodeStreamData(stamp.normalAppearance!));
       // cm: 2 0 0 4 (10 - 2*0) (20 - 4*0) = 2 0 0 4 10 20
       expect(ap, contains('2 0 0 4 10 20 cm'));
+    });
+
+    test('capture bakes the page /Rotate (90° swaps the displayed size)', () {
+      final doc = PdfDocument.open(buildNestedPageTreePdf());
+      expect(doc.page(0).rotation, 90); // sanity: page 0 is rotated
+      final editor = PdfEditor(doc);
+      // a 300x200 user-space region on a 90° page displays as 200x300
+      final snap = editor.captureVectorSnapshot(0, const PdfRect(50, 50, 350, 250));
+      expect(snap.displayWidth, 200);
+      expect(snap.displayHeight, 300);
+
+      editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 200, 300), snap);
+      final out = PdfDocument.open(editor.save());
+      final stamp = out.page(0).annotations.single;
+      final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
+          as CosDictionary;
+      final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
+      final cap = out.cos.resolve(xobj['Cap']) as CosStream;
+      final bbox = out.cos.resolve(cap.dictionary['BBox']) as CosArray;
+      expect([for (final v in bbox.items) _num(out.cos.resolve(v))],
+          [0.0, 0.0, 200.0, 300.0]);
+      // the baked rotation cm for a 90° page: [0 -1 1 0 -ry0 rx1]
+      expect(latin1.decode(out.cos.decodeStreamData(cap)),
+          contains('0 -1 1 0 -50 350 cm'));
+    });
+
+    test('repeat pastes of one snapshot share a single captured form', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      final ref1 =
+          editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 160, 40), snap);
+      final ref2 = editor.pasteVectorSnapshot(
+          0, const PdfRect(200, 0, 360, 40), snap,
+          sharedObject: ref1);
+      expect(ref2, ref1); // the second paste reuses the first form
+
+      final out = PdfDocument.open(editor.save());
+      final stamps = out.page(0).annotations;
+      expect(stamps, hasLength(2));
+      int capNum(PdfAnnotation a) {
+        final res = out.cos.resolve(a.normalAppearance!.dictionary['Resources'])
+            as CosDictionary;
+        final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
+        // stored as an indirect reference, not resolved inline
+        return (xobj.entries['Cap'] as CosReference).objectNumber;
+      }
+      expect(capNum(stamps[0]), capNum(stamps[1]));
+    });
+
+    test('paste with a stale shared object re-materializes the form', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      // a bogus object number doesn't resolve to a form — paste makes its own
+      final ref = editor.pasteVectorSnapshot(
+          0, const PdfRect(0, 0, 160, 40), snap,
+          sharedObject: 99999);
+      expect(ref, isNot(99999));
+      expect(ref, greaterThan(0));
+      final out = PdfDocument.open(editor.save());
+      final stamp = out.page(0).annotations.single;
+      final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
+          as CosDictionary;
+      final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
+      expect(out.cos.resolve(xobj['Cap']), isA<CosStream>());
     });
 
     test('paste with opacity < 1 adds an ExtGState alpha to the appearance', () {

--- a/packages/pdf_document/test/vector_snapshot_test.dart
+++ b/packages/pdf_document/test/vector_snapshot_test.dart
@@ -1,0 +1,100 @@
+// Vector snapshots (PdfVectorSnapshot): capturing a region of a page as
+// detached vector graphics and pasting it back as a /Stamp annotation
+// whose appearance *draws* the captured content (so it stays vector).
+import 'dart:convert';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+String _name(CosObject? o) => (o as CosName).value;
+
+double _num(CosObject o) => switch (o) {
+      CosInteger(:final value) => value.toDouble(),
+      CosReal(:final value) => value,
+      _ => throw StateError('not a number: $o'),
+    };
+
+void main() {
+  group('PdfVectorSnapshot', () {
+    test('capture detaches the region, content, and resources', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(2));
+      final snap = PdfEditor(doc)
+          .captureVectorSnapshot(0, const PdfRect(60, 700, 200, 740));
+      expect(snap.region, const PdfRect(60, 700, 200, 740));
+    });
+
+    test('paste makes a vector /Stamp drawing the captured form', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(2));
+      final editor = PdfEditor(doc);
+      // page 1's content draws "Page 1" near (72, 720) — inside this region
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      editor.pasteVectorSnapshot(1, const PdfRect(100, 100, 260, 140), snap);
+
+      final out = PdfDocument.open(editor.save());
+      final stamp = out.page(1).annotations.single;
+      expect(stamp.subtype, 'Stamp');
+      expect(stamp.rect, const PdfRect(100, 100, 260, 140));
+
+      // the appearance maps the captured form onto the rect and draws it
+      final ap = latin1.decode(out.cos.decodeStreamData(stamp.normalAppearance!));
+      expect(ap, contains('/Cap Do'));
+
+      // /Cap is a Form XObject whose BBox is the source region and whose
+      // content is the page's own operators — i.e. real vectors, not a raster
+      final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
+          as CosDictionary;
+      final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
+      final cap = out.cos.resolve(xobj['Cap']) as CosStream;
+      expect(_name(cap.dictionary['Subtype']), 'Form');
+      final bbox = out.cos.resolve(cap.dictionary['BBox']) as CosArray;
+      expect([for (final v in bbox.items) _num(out.cos.resolve(v))],
+          [60.0, 700.0, 220.0, 740.0]);
+      final capContent = latin1.decode(out.cos.decodeStreamData(cap));
+      expect(capContent, contains('(Page 1) Tj'));
+
+      // the page's font resource travels with the form (the text resolves)
+      final capRes =
+          out.cos.resolve(cap.dictionary['Resources']) as CosDictionary;
+      final fonts = out.cos.resolve(capRes['Font']) as CosDictionary;
+      expect(fonts.entries.keys, contains('F1'));
+    });
+
+    test('paste scales the captured region onto a differently sized rect', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      // a 100x50 source region pasted into a 200x200 box: sx=2, sy=4
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(0, 0, 100, 50));
+      editor.pasteVectorSnapshot(0, const PdfRect(10, 20, 210, 220), snap);
+      final out = PdfDocument.open(editor.save());
+      final stamp = out.page(0).annotations.single;
+      final ap = latin1.decode(out.cos.decodeStreamData(stamp.normalAppearance!));
+      // cm: 2 0 0 4 (10 - 2*0) (20 - 4*0) = 2 0 0 4 10 20
+      expect(ap, contains('2 0 0 4 10 20 cm'));
+    });
+
+    test('a detached snapshot survives further edits to the source', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      // mutate the document after capturing
+      editor.addSquare(0, const PdfRect(0, 0, 50, 50));
+      // the snapshot still pastes its original captured content
+      editor.pasteVectorSnapshot(0, const PdfRect(300, 300, 460, 340), snap);
+      final out = PdfDocument.open(editor.save());
+      final stamp = out
+          .page(0)
+          .annotations
+          .firstWhere((a) => a.rect == const PdfRect(300, 300, 460, 340));
+      final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
+          as CosDictionary;
+      final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
+      final cap = out.cos.resolve(xobj['Cap']) as CosStream;
+      expect(latin1.decode(out.cos.decodeStreamData(cap)), contains('(Page 1) Tj'));
+    });
+  });
+}


### PR DESCRIPTION
## What

A new **Snapshot tool** (`PdfEditTool.snapshot`) in the **Edit** toolbar group, matching Bluebeam: drag out a rectangle over the page to capture that region.

The capture does two things at once:

1. **Raster export** — the region is rendered to a PNG and handed to a new `PdfViewer.onSnapshot` host callback (copy to clipboard / save / share). The example app wires it to share/save.
2. **Vector capture + paste-back** — the same region is captured as detached **vector** graphics and kept on the controller's clipboard. Pasting it back into the PDF (⌘V/Ctrl+V or the right-click **Paste**) drops it in as a movable/resizable `/Stamp` annotation whose appearance *draws* the captured content, so it stays crisp at any zoom — not a flattened raster.

## How

**pdf_document**
- `PdfVectorSnapshot` + `PdfVectorSnapshotEditing.captureVectorSnapshot` / `pasteVectorSnapshot` (`vector_snapshot.dart`). A region's page content + `/Resources` are deep-copied inline (reusing the annotation-clipboard `_SnapshotCopier`/`_hoistStreams`), then pasted as a `/Stamp` whose appearance maps a clipped Form XObject (BBox = source region) onto the target rect — the same §12.5.5 identity pattern as image stamps. Page `/Rotate` is not baked (captured content keeps the source's native orientation).

**dart_pdf_editor**
- `PdfEditingController.captureSnapshot` (raster PNG via the renderer), `copyVectorSnapshot` / `pasteSnapshot` (in-app vector clipboard; most-recent-copy wins over the annotation clipboard).
- The snapshot tool drags out a selection marquee; on commit it fills the vector clipboard and, when `onSnapshot` is set, exports the raster.
- `⌘V`/`Ctrl+V` and the context-menu **Paste** route to `pasteSnapshot` when a snapshot is captured.
- `onSnapshot` threaded through `PdfViewer` → `_PdfViewerPage` → `EditingPageOverlay` and `PdfEditorView`; toolbar entry + label added to the Edit group.

## Tests
- `pdf_document/test/vector_snapshot_test.dart` — capture/paste, scaling onto a different rect, clip BBox = source region, detachment survives further edits (4 tests).
- `dart_pdf_editor/test/editing_snapshot_test.dart` — clipboard round-trip, oversize clamp, viewer drag fills the clipboard, host handler receives a PNG + vector (5 tests).

All affected suites pass (`pdf_document` full suite, plus the viewer/overlay/toolbar/menu/clipboard suites in `dart_pdf_editor`); `dart analyze` is clean. The 14 pre-existing Ghent render-baseline failures on this machine are unrelated.

## Notes
- The package stays plugin-free: the raster snapshot is delivered via a callback rather than touching a native image clipboard, so the host decides how to copy/save/share.

https://claude.ai/code/session_01CtUuvQRsJFr4KEKLtw6cHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtUuvQRsJFr4KEKLtw6cHs)_