### PR TITLE
Rotate pages from the thumbnail strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2258,3 +2258,28 @@ app's life — the API key is kept in MEMORY ONLY, never written to disk (so
 the example needs no shared_preferences for it). dep pdf_ocr_vlm ^0.1.0.
 The 9 example test failures are pre-existing on this machine (raster/
 headless) — identical set with and without this wiring, zero regressions.
+
+Rotate pages from the thumbnail strip (Ben: "add a tool to rotate
+selected pages from the thumbnail strip"): `PdfEditor.rotatePages(indices,
+degrees)` (page_editor.dart) writes each page's /Rotate = current display
+rotation + degrees, normalized to 0/90/180/270, explicitly onto the page
+dict (overrides inherited /Rotate); degrees must be a multiple of 90, a
+full turn / empty selection is a no-op, out-of-range index throws. It's a
+visual edit only — the page tree/indices are untouched, so unlike
+move/remove it does NOT clear the page selection. Controller
+(editing_controller.dart): `rotatePages(indices, degrees)` (filters to
+valid indices, `apply(pages: targets)` so only those thumbnails
+re-render via pageRenderStamp; preserves `_selectedPages`) +
+`rotateSelectedPages([degrees = 90])` (operates on `_selectedPages`, no-op
+when empty). UI (editing_thumbnails.dart): the multi-select bar (shown at
+selectedPageCount > 1) gained rotate-left/right actions
+('pdf-thumbnail-rotate-selected-ccw'/'-cw'), and each tile a rotate-right
+button ('pdf-thumbnail-rotate-<index>', no Tooltip — Semantics label, like
+the delete button, so it's safe inside the ReorderableListView). The
+selection bar was reshaped into a count line + a `Wrap` of compact
+IconButtons (`_selectionAction`) so the (now up to five) actions flow onto
+a second line instead of overflowing the ~142px strip. Tests:
+pdf_document page_ops_test (rotate group — accumulation, CCW normalize,
+full-turn/empty no-op, non-quarter + out-of-range reject) and
+dart_pdf_editor editing_page_ops_test (controller round-trips + selection
+survives; strip widget tests for the bar + per-tile button).

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.1.0
 
+- Rotate pages from the thumbnail strip: a per-tile rotate-right button,
+  plus rotate-left/right actions in the multi-select bar.
+  `PdfEditingController.rotatePages`/`rotateSelectedPages` turn pages
+  clockwise (or counterclockwise) without shifting page indices, so the
+  page selection survives the edit.
 - Background rendering: heavy pages now interpret off the UI thread, so
   scrolling and drawing stay smooth on large/CAD documents.
   `PdfRenderWorker` runs page interpretation and image decode in a

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1555,6 +1555,28 @@ class PdfEditingController extends ChangeNotifier {
   Uint8List? exportSelectedPages() =>
       _selectedPages.isEmpty ? null : exportPages(selectedPages);
 
+  /// Rotates [indices] clockwise by [degrees] (a multiple of 90; negative
+  /// turns counterclockwise) in one edit (one undo). Rotation is a visual
+  /// change that does not shift page indices, so the page selection is
+  /// preserved. Returns false (a no-op) when nothing is given or the
+  /// rotation is a full turn.
+  bool rotatePages(Iterable<int> indices, int degrees) {
+    final targets = indices
+        .where((i) => i >= 0 && i < _document.pageCount)
+        .toSet()
+        .toList()
+      ..sort();
+    if (targets.isEmpty || degrees % 360 == 0) return false;
+    return apply((e) => e.rotatePages(targets, degrees), pages: targets);
+  }
+
+  /// Rotates the selected pages clockwise by [degrees] (default: 90; pass
+  /// -90 to turn counterclockwise) in one edit. A no-op (returns false)
+  /// when nothing is selected in the strip. The page selection is
+  /// preserved.
+  bool rotateSelectedPages([int degrees = 90]) =>
+      rotatePages(selectedPages, degrees);
+
   // ---------------------------------------------------------------------
   // selection
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -265,6 +265,27 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     if (bytes != null) onExport(bytes);
   }
 
+  /// A compact icon button for the multi-select bar — tight enough that
+  /// several fit (and wrap) within the narrow strip.
+  Widget _selectionAction({
+    required String key,
+    required IconData icon,
+    required String tooltip,
+    required VoidCallback onPressed,
+  }) =>
+      IconButton(
+        key: ValueKey(key),
+        icon: Icon(icon, size: 18),
+        tooltip: tooltip,
+        style: IconButton.styleFrom(
+          padding: EdgeInsets.zero,
+          minimumSize: const Size(32, 32),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          visualDensity: VisualDensity.compact,
+        ),
+        onPressed: onPressed,
+      );
+
   void _onResizeDelta(double delta) => setState(() {
         _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
       });
@@ -329,45 +350,57 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
             // navigation cursor — the per-tile delete handles it)
             if (controller.selectedPageCount > 1)
               Padding(
-                padding:
-                    EdgeInsets.fromLTRB(8 + inset, 2, _extraRightPadding + inset, 0),
-                child: Row(
+                padding: EdgeInsets.fromLTRB(
+                    8 + inset, 2, _extraRightPadding + inset, 0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Text(
-                        '${controller.selectedPageCount} selected',
-                        style: Theme.of(context).textTheme.labelMedium,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                    Text(
+                      '${controller.selectedPageCount} selected',
+                      style: Theme.of(context).textTheme.labelMedium,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    if (widget.onExportPages != null)
-                      IconButton(
-                        key: const ValueKey('pdf-thumbnail-export-selected'),
-                        icon: const Icon(Icons.file_download_outlined, size: 18),
-                        tooltip: 'Export selected pages',
-                        style: IconButton.styleFrom(
-                          visualDensity: VisualDensity.compact,
+                    // a Wrap (not a Row) so the action buttons flow onto a
+                    // second line on the narrow strip instead of overflowing
+                    Wrap(
+                      children: [
+                        if (widget.allowPageEditing) ...[
+                          _selectionAction(
+                            key: 'pdf-thumbnail-rotate-selected-ccw',
+                            icon: Icons.rotate_left,
+                            tooltip: 'Rotate selected pages left',
+                            onPressed: () =>
+                                controller.rotateSelectedPages(-90),
+                          ),
+                          _selectionAction(
+                            key: 'pdf-thumbnail-rotate-selected-cw',
+                            icon: Icons.rotate_right,
+                            tooltip: 'Rotate selected pages right',
+                            onPressed: () =>
+                                controller.rotateSelectedPages(90),
+                          ),
+                        ],
+                        if (widget.onExportPages != null)
+                          _selectionAction(
+                            key: 'pdf-thumbnail-export-selected',
+                            icon: Icons.file_download_outlined,
+                            tooltip: 'Export selected pages',
+                            onPressed: _exportSelected,
+                          ),
+                        if (widget.allowPageEditing)
+                          _selectionAction(
+                            key: 'pdf-thumbnail-delete-selected',
+                            icon: Icons.delete_outline,
+                            tooltip: 'Delete selected pages',
+                            onPressed: () => controller.removeSelectedPages(),
+                          ),
+                        _selectionAction(
+                          key: 'pdf-thumbnail-clear-selection',
+                          icon: Icons.close,
+                          tooltip: 'Clear selection',
+                          onPressed: controller.clearPageSelection,
                         ),
-                        onPressed: _exportSelected,
-                      ),
-                    if (widget.allowPageEditing)
-                      IconButton(
-                        key: const ValueKey('pdf-thumbnail-delete-selected'),
-                        icon: const Icon(Icons.delete_outline, size: 18),
-                        tooltip: 'Delete selected pages',
-                        style: IconButton.styleFrom(
-                          visualDensity: VisualDensity.compact,
-                        ),
-                        onPressed: () => controller.removeSelectedPages(),
-                      ),
-                    IconButton(
-                      key: const ValueKey('pdf-thumbnail-clear-selection'),
-                      icon: const Icon(Icons.close, size: 18),
-                      tooltip: 'Clear selection',
-                      style: IconButton.styleFrom(
-                        visualDensity: VisualDensity.compact,
-                      ),
-                      onPressed: controller.clearPageSelection,
+                      ],
                     ),
                   ],
                 ),
@@ -731,13 +764,28 @@ class _PageTile extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.labelMedium),
                 ),
+                // No Tooltip on these buttons: a Tooltip is an OverlayPortal,
+                // and an OverlayPortal inside a ReorderableListView item
+                // crashes when the item is reactivated during a layout pass
+                // (the strip's bottom-sheet LayoutBuilder, or a reorder) — it
+                // mutates the overlay's RenderObject mid-layout. A Semantics
+                // label keeps the buttons accessible without one.
+                if (allowPageEditing)
+                  Semantics(
+                    label: 'Rotate page right',
+                    button: true,
+                    child: IconButton(
+                      key: ValueKey('pdf-thumbnail-rotate-$pageIndex'),
+                      icon: const Icon(Icons.rotate_right, size: 16),
+                      style: IconButton.styleFrom(
+                        padding: EdgeInsets.zero,
+                        minimumSize: const Size(28, 28),
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      onPressed: () => controller.rotatePages([pageIndex], 90),
+                    ),
+                  ),
                 if (allowPageEditing && document.pageCount > 1)
-                  // No Tooltip here: a Tooltip is an OverlayPortal, and an
-                  // OverlayPortal inside a ReorderableListView item crashes
-                  // when the item is reactivated during a layout pass (the
-                  // strip's bottom-sheet LayoutBuilder, or a reorder) — it
-                  // mutates the overlay's RenderObject mid-layout. A
-                  // Semantics label keeps the button accessible without one.
                   Semantics(
                     label: 'Delete page',
                     button: true,

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -388,7 +388,7 @@ void main() {
       await tester.pump(const Duration(seconds: 2));
     });
 
-    testWidgets('the selection bar rotates the selected pages',
+    testWidgets('the selection bar rotates, exports, and clears',
         (tester) async {
       tester.view.physicalSize = const Size(800, 1400);
       tester.view.devicePixelRatio = 1.0;
@@ -398,10 +398,15 @@ void main() {
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);
       addTearDown(viewer.dispose);
+      Uint8List? exported;
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(
           body: Row(children: [
-            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            PdfThumbnailSidebar(
+              controller: editing,
+              viewerController: viewer,
+              onExportPages: (bytes) => exported = bytes,
+            ),
             const Expanded(child: SizedBox()),
           ]),
         ),
@@ -416,6 +421,7 @@ void main() {
       await tester.pump();
       expect(editing.selectedPages, [0, 1, 2]);
 
+      // rotate right, then left: the two cancel back to no rotation
       await tester.tap(
           find.byKey(const ValueKey('pdf-thumbnail-rotate-selected-cw')));
       await tester.pump();
@@ -425,6 +431,26 @@ void main() {
       expect(editing.document.page(3).rotation, 0);
       // the selection survives a visual rotation
       expect(editing.selectedPages, [0, 1, 2]);
+
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-thumbnail-rotate-selected-ccw')));
+      await tester.pump();
+      expect(editing.document.page(0).rotation, 0);
+      expect(editing.selectedPages, [0, 1, 2]);
+
+      // export hands the host the selected pages
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-export-selected')));
+      await tester.pump();
+      expect(exported, isNotNull);
+      expect(labelsOf(PdfDocument.open(exported!)),
+          ['Page 1', 'Page 2', 'Page 3']);
+
+      // clear empties the selection (and dismisses the bar)
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-clear-selection')));
+      await tester.pump();
+      expect(editing.hasPageSelection, isFalse);
       await tester.pump(const Duration(seconds: 2)); // drain tile renders
     });
 

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -196,6 +196,44 @@ void main() {
       addTearDown(editing.dispose);
       expect(editing.exportSelectedPages(), isNull);
     });
+
+    test('rotateSelectedPages turns the selection and keeps it', () {
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      addTearDown(editing.dispose);
+      editing.selectPage(0);
+      editing.togglePageSelection(2);
+      expect(editing.rotateSelectedPages(90), isTrue);
+      expect(editing.document.page(0).rotation, 90);
+      expect(editing.document.page(1).rotation, 0);
+      expect(editing.document.page(2).rotation, 90);
+      // a visual rotation does not shift indices, so the selection survives
+      expect(editing.selectedPages, [0, 2]);
+      editing.undo();
+      expect(editing.document.page(0).rotation, 0);
+    });
+
+    test('rotateSelectedPages counterclockwise normalizes', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      expect(editing.rotateSelectedPages(-90), isTrue);
+      expect(editing.document.page(1).rotation, 270);
+    });
+
+    test('rotateSelectedPages is a no-op with nothing selected', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      addTearDown(editing.dispose);
+      expect(editing.rotateSelectedPages(), isFalse);
+      expect(editing.isModified, isFalse);
+    });
+
+    test('rotatePages targets explicit indices', () {
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      expect(editing.rotatePages([1], 180), isTrue);
+      expect(editing.document.page(1).rotation, 180);
+      expect(editing.rotatePages([], 90), isFalse);
+    });
   });
 
   group('page range dialog', () {
@@ -347,6 +385,72 @@ void main() {
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
       await tester.pump();
       expect(editing.selectedPages, [0, 2]);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('the selection bar rotates the selected pages',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 3'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(editing.selectedPages, [0, 1, 2]);
+
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-thumbnail-rotate-selected-cw')));
+      await tester.pump();
+      expect(editing.document.page(0).rotation, 90);
+      expect(editing.document.page(1).rotation, 90);
+      expect(editing.document.page(2).rotation, 90);
+      expect(editing.document.page(3).rotation, 0);
+      // the selection survives a visual rotation
+      expect(editing.selectedPages, [0, 1, 2]);
+      await tester.pump(const Duration(seconds: 2)); // drain tile renders
+    });
+
+    testWidgets('a per-tile rotate button turns one page', (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-rotate-1')));
+      await tester.pump();
+      expect(editing.document.page(0).rotation, 0);
+      expect(editing.document.page(1).rotation, 90);
       await tester.pump(const Duration(seconds: 2));
     });
 

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.1.0
 
+- Page rotation: `PdfEditor.rotatePages(indices, degrees)` turns the named
+  pages clockwise by a multiple of 90° (negative for counterclockwise),
+  accumulating onto each page's current `/Rotate`.
 - Count tool: `PdfEditor.addCheckMark` places a Bluebeam-style check-mark
   stamp annotation (with `PdfAnnotation.isCheckMark`/`iconName`) — the
   building block for a running on-page tally.

--- a/packages/pdf_document/lib/src/page_editor.dart
+++ b/packages/pdf_document/lib/src/page_editor.dart
@@ -53,6 +53,33 @@ extension PdfPageOperations on PdfEditor {
         [for (var i = 0; i < count; i++) if (!doomed.contains(i)) leaves[i]]);
   }
 
+  /// Rotates the pages at [indices] clockwise by [degrees] (a multiple of
+  /// 90; negative turns counterclockwise), updating each page's /Rotate.
+  /// The new rotation is the page's current display rotation plus
+  /// [degrees], normalized to 0/90/180/270 and written explicitly onto the
+  /// page dictionary (so it overrides any value inherited from an ancestor).
+  void rotatePages(Iterable<int> indices, int degrees) {
+    if (degrees % 90 != 0) {
+      throw ArgumentError.value(
+          degrees, 'degrees', 'must be a multiple of 90');
+    }
+    final count = document.pageCount;
+    final targets = {...indices};
+    for (final i in targets) {
+      RangeError.checkValidIndex(i, null, 'indices', count);
+    }
+    if (targets.isEmpty || degrees % 360 == 0) return;
+    for (final i in targets) {
+      final page = document.page(i);
+      final dict = page.dict;
+      var next = (page.rotation + degrees) % 360;
+      if (next < 0) next += 360;
+      dict['Rotate'] = CosInteger(next);
+      _updater.markChanged(dict);
+    }
+    document.invalidatePageCache();
+  }
+
   /// Inserts a new blank page [at] the given index (default: appended at
   /// the end), sized [width] × [height] points (default: US Letter,
   /// 612 × 792). The page carries an empty /Resources dictionary and no

--- a/packages/pdf_document/test/page_ops_test.dart
+++ b/packages/pdf_document/test/page_ops_test.dart
@@ -75,6 +75,49 @@ void main() {
     });
   });
 
+  group('rotate', () {
+    test('rotatePages turns the named pages clockwise', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(3));
+      final editor = PdfEditor(doc)..rotatePages([0, 2], 90);
+      final out = reopened(editor);
+      expect(out.page(0).rotation, 90);
+      expect(out.page(1).rotation, 0);
+      expect(out.page(2).rotation, 90);
+    });
+
+    test('rotation accumulates onto the current display rotation', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(2));
+      final editor = PdfEditor(doc)
+        ..rotatePages([0], 90)
+        ..rotatePages([0], 90);
+      expect(reopened(editor).page(0).rotation, 180);
+    });
+
+    test('a counterclockwise turn normalizes to 0..270', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc)..rotatePages([0], -90);
+      expect(reopened(editor).page(0).rotation, 270);
+    });
+
+    test('a full turn (or no pages) changes nothing', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(2)))
+        ..rotatePages([0], 360)
+        ..rotatePages([], 90);
+      expect(editor.hasChanges, isFalse);
+    });
+
+    test('a non-quarter turn is rejected', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(2)));
+      expect(() => editor.rotatePages([0], 45), throwsArgumentError);
+      expect(editor.hasChanges, isFalse);
+    });
+
+    test('an out-of-range index is rejected', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(2)));
+      expect(() => editor.rotatePages([5], 90), throwsRangeError);
+    });
+  });
+
   group('insert blank page', () {
     test('appends a blank page sized to request', () {
       final doc = PdfDocument.open(buildMultiPagePdf(2));


### PR DESCRIPTION
## Summary

Adds a page-rotation tool to the thumbnail strip, as requested.

- **`pdf_document`** — `PdfEditor.rotatePages(indices, degrees)` writes each page's `/Rotate` = current display rotation + `degrees`, normalized to 0/90/180/270 and written explicitly onto the page dict (so it overrides any inherited `/Rotate`). `degrees` must be a multiple of 90 (negative turns counterclockwise); a full turn or empty selection is a no-op, an out-of-range index throws.
- **`dart_pdf_editor` controller** — `rotatePages(indices, degrees)` and `rotateSelectedPages([degrees = 90])`. Rotation is a visual edit that does **not** shift page indices, so unlike move/remove it preserves the page selection; `apply(pages: targets)` re-renders only the touched thumbnails.
- **Thumbnail strip UI** — a per-tile rotate-right button (`pdf-thumbnail-rotate-<index>`) beside the delete button, plus rotate-left/right actions in the multi-select bar (`pdf-thumbnail-rotate-selected-ccw`/`-cw`). The selection bar was reshaped into a count line + a `Wrap` of compact icon buttons so the (now up to five) actions flow onto a second line rather than overflowing the narrow strip. Per-tile buttons use a `Semantics` label instead of a `Tooltip` (an `OverlayPortal` inside a `ReorderableListView` item is unsafe).

## Tests

- `pdf_document/test/page_ops_test.dart` — new `rotate` group: accumulation, CCW normalization, full-turn/empty no-op, non-quarter + out-of-range rejection.
- `dart_pdf_editor/test/editing_page_ops_test.dart` — controller round-trips (selection survives, undo) plus widget tests for the selection bar and per-tile rotate button.

All touched suites pass and both packages analyze clean.

https://claude.ai/code/session_01EGb1F9fVXpcj1Xp4hHFhVk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGb1F9fVXpcj1Xp4hHFhVk)_