### PR TITLE
ci: enforce 90% patch coverage on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,22 @@ jobs:
 
       - name: Test pdf_ocr_vlm
         working-directory: packages/pdf_ocr_vlm
-        run: flutter test
+        run: flutter test --coverage
+      - name: Upload pdf_ocr_vlm coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: packages/pdf_ocr_vlm/coverage/lcov.info
+          flags: pdf_ocr_vlm
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Test DartPDF app
         working-directory: app
-        run: flutter test
+        run: flutter test --coverage
+      - name: Upload app coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: app/coverage/lcov.info
+          flags: app
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,12 @@ flags:
   dart_pdf_editor:
     paths:
       - packages/dart_pdf_editor/lib
+  pdf_ocr_vlm:
+    paths:
+      - packages/pdf_ocr_vlm/lib
+  app:
+    paths:
+      - app/lib
 
 coverage:
   status:
@@ -26,7 +32,12 @@ coverage:
         informational: true
     patch:
       default:
-        informational: true
+        # New code (the PR diff) must be at least 90% covered.
+        target: 90%
+        # Allow a small slack so trivial diffs don't fail on rounding.
+        threshold: 1%
+        # Block the PR status when the diff drops below target.
+        informational: false
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
## What

Targets **90% patch coverage** on new PRs via Codecov.

### `codecov.yml`
- The `patch` status was `informational: true` (advisory only). It now has:
  - `target: 90%` — new code in the diff must be ≥90% covered
  - `threshold: 1%` — small slack so trivial diffs don't fail on rounding
  - `informational: false` — the status now **blocks** the PR check when the diff falls below target
- `project` status is left informational (unchanged) so overall coverage stays advisory.
- Added `pdf_ocr_vlm` and `app` flags so every package's `lib/` is mapped.

### `.github/workflows/ci.yml`
- `pdf_ocr_vlm` and `app` previously ran `flutter test` **without** coverage and never uploaded. Codecov only measures lines that appear in an uploaded report, so diffs in those two packages would have been invisible to the patch check. They now run `flutter test --coverage` and upload under their own flags, so the 90% target genuinely covers the whole repo.

## Notes
- The target applies to the PR diff only, not the existing codebase, so it won't retroactively fail on legacy uncovered code.

https://claude.ai/code/session_01CiTY6hwRkXZv9GJgZ463Du

---
_Generated by [Claude Code](https://claude.ai/code/session_01CiTY6hwRkXZv9GJgZ463Du)_