### PR TITLE
Dock the editing toolbar below the page on phones

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -170,9 +170,12 @@ class PdfEditingToolbar extends StatefulWidget {
     Color(0xFF000000), // black
   ];
 
-  /// Below this width the dock collapses and tools move into a bottom
-  /// sheet. Above it, the desktop dock + contextual strip show.
-  static const _mobileBreakpoint = 600.0;
+  /// Below this width the dock collapses to a solid bar and tools move
+  /// into a bottom sheet. Above it, the desktop dock + contextual strip
+  /// show as floating cards. Hosts can read this to decide whether to
+  /// dock the toolbar (below this width it's a solid bar, so floating it
+  /// over the page would hide content) or let it float.
+  static const mobileBreakpoint = 600.0;
 
   @override
   State<PdfEditingToolbar> createState() => _PdfEditingToolbarState();
@@ -565,7 +568,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           listenable: Listenable.merge([controller, viewerController]),
           builder: (context, _) => LayoutBuilder(
             builder: (context, constraints) =>
-                constraints.maxWidth < PdfEditingToolbar._mobileBreakpoint
+                constraints.maxWidth < PdfEditingToolbar.mobileBreakpoint
                     ? _buildMobile(context)
                     : _buildDesktop(context),
           ),

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -534,6 +534,33 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       child: properties(bottomSheet: true),
                     ),
                 ];
+          // On a phone the toolbar collapses to a solid bar (see
+          // PdfEditingToolbar.mobileBreakpoint); floating it over the page
+          // there hides the bottom of the content behind it, so dock it
+          // below the viewer instead, where it takes its own layout space.
+          // Above the breakpoint it stays a set of transparent floating
+          // cards with the page showing through the gaps.
+          final showToolbar = features.toolbar && sheets.isEmpty;
+          final dockToolbar = showToolbar &&
+              constraints.maxWidth < PdfEditingToolbar.mobileBreakpoint;
+          final toolbar = !showToolbar
+              ? null
+              : PdfEditingToolbar(
+                  controller: session,
+                  viewerController: _viewer,
+                  // save lives in the header now, not the dock
+                  textPrompt: widget.textPrompt ?? showPdfTextPrompt,
+                  palette: widget.palette,
+                  tools: features.tools,
+                  groups: features.toolGroups,
+                  showMarkup: features.markup,
+                  showUndoRedo: features.undoRedo,
+                  showColor: features.colorControls,
+                  showStyle: features.styleControls,
+                  showFlatten: features.flatten,
+                  leading: widget.toolbarLeading,
+                  trailing: widget.toolbarTrailing,
+                );
           return Column(children: [
             if (features.headerBar)
               PdfShellBar(
@@ -615,9 +642,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 ],
               ),
             Expanded(
-              // the toolbar floats over the bottom of the content,
-              // Acrobat/Bluebeam-style, rather than sitting in a solid
-              // edge-to-edge bar below it
+              // on wide screens the toolbar floats over the bottom of the
+              // content, Acrobat/Bluebeam-style; on phones it docks below
+              // (see dockToolbar) so its solid bar never hides the page
               child: Stack(children: [
                 Positioned.fill(
                   // keyed so a panel appearing never recreates the viewer
@@ -653,31 +680,19 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       properties(bottomSheet: false),
                   ]),
                 ),
-                if (features.toolbar && sheets.isEmpty)
+                if (toolbar != null && !dockToolbar)
                   Positioned(
                     left: 0,
                     right: 0,
                     bottom: 0,
-                    child: PdfEditingToolbar(
-                      controller: session,
-                      viewerController: _viewer,
-                      // save lives in the header now, not the dock
-                      textPrompt: widget.textPrompt ?? showPdfTextPrompt,
-                      palette: widget.palette,
-                      tools: features.tools,
-                      groups: features.toolGroups,
-                      showMarkup: features.markup,
-                      showUndoRedo: features.undoRedo,
-                      showColor: features.colorControls,
-                      showStyle: features.styleControls,
-                      showFlatten: features.flatten,
-                      leading: widget.toolbarLeading,
-                      trailing: widget.toolbarTrailing,
-                    ),
+                    child: toolbar,
                   ),
                 if (sheets.isNotEmpty) pdfShellBottomSheets(sheets),
               ]),
             ),
+            // the mobile (solid-bar) toolbar docks below the content so it
+            // never covers the page; the floating variant stays in the Stack
+            if (toolbar != null && dockToolbar) toolbar,
           ]);
         },
       );

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -848,6 +848,39 @@ void main() {
           findsNothing);
       expect(tester.takeException(), isNull);
     });
+
+    testWidgets('phone: the editing toolbar docks below the viewer',
+        (tester) async {
+      // Below PdfEditingToolbar.mobileBreakpoint the toolbar is a solid
+      // bar; floating it over the page would hide the bottom of the
+      // content, so it docks below the viewer and takes its own space.
+      tester.view.physicalSize = const Size(400, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+
+      final toolbar = find.byType(PdfEditingToolbar);
+      expect(toolbar, findsOneWidget);
+      // docked = no vertical overlap with the viewer (the toolbar's top is
+      // at or below the viewer's bottom)
+      final viewerBottom = tester.getRect(find.byType(PdfViewer)).bottom;
+      final toolbarTop = tester.getRect(toolbar).top;
+      expect(toolbarTop, greaterThanOrEqualTo(viewerBottom - 0.5));
+    });
+
+    testWidgets('wide: the editing toolbar floats over the viewer',
+        (tester) async {
+      // Above the breakpoint the toolbar is transparent floating cards —
+      // it sits over the bottom of the page (Acrobat/Bluebeam-style).
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+
+      final toolbar = find.byType(PdfEditingToolbar);
+      expect(toolbar, findsOneWidget);
+      final viewerBottom = tester.getRect(find.byType(PdfViewer)).bottom;
+      final toolbarTop = tester.getRect(toolbar).top;
+      expect(toolbarTop, lessThan(viewerBottom),
+          reason: 'the floating toolbar overlaps the viewer');
+    });
   });
 
   group('shell header bar', () {


### PR DESCRIPTION
## Problem

On a phone the bottom editing toolbar floated over the page and hid the content behind it. Below `PdfEditingToolbar.mobileBreakpoint` (600px) the toolbar collapses to a **solid** bar, but `PdfEditorView` always placed it as a `Positioned(bottom: 0)` overlay inside the viewer `Stack` — so that solid bar covered the bottom of the page and the content under it was lost.

## Fix

`PdfEditorView` now **docks** the toolbar below the viewer (as its own `Column` child, taking real layout space) when it's in its mobile/solid-bar form, so it never overlaps the page. Above the breakpoint it keeps floating as the transparent Acrobat/Bluebeam-style cards, where the page shows through the gaps.

- Exposed `PdfEditingToolbar.mobileBreakpoint` (was a private constant) so the host makes the same docked-vs-floating decision the toolbar uses internally.
- The toolbar widget is built once and placed either in the `Stack` (floating) or after the `Expanded` viewer area (docked).

## Tests

`pdf_shell_test.dart` gains two cases:
- **phone**: at 400px wide the toolbar's top sits at/below the viewer's bottom (docked, no overlap).
- **wide**: above the breakpoint the toolbar overlaps the viewer (floating).

All existing shell and mobile-toolbar tests still pass; `dart analyze` is clean.

https://claude.ai/code/session_0175n8RDWgwroTNonKTKEvN1

---
_Generated by [Claude Code](https://claude.ai/code/session_0175n8RDWgwroTNonKTKEvN1)_