### PR TITLE
Add match-case, whole-word, and regex controls to search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2287,8 +2287,27 @@ Shell wiring: the editor shell (`PdfEditorView`) passes
 results panel carries the controls, keeping the compact (≤600px) header
 from pushing the annotation/properties toggles off-screen (the
 pdf-shell-annotations-toggle tap-misses otherwise); the reader (no results
-panel) keeps the inline field toggles. Tests: pdf_graphics
+panel) keeps the inline field toggles. Persistence (Ben follow-up: "the
+three toggles aren't persisted like sibling search prefs"):
+`PdfEditingPreferences.searchMatchCase/searchWholeWord/searchRegex` (three
+bool keys — NOT a `PdfSearchOptions` field, since editing_preferences sits
+below pdf_viewer and importing it would cycle pdf_viewer→editing_controller
+→editing_preferences→pdf_viewer); the now-stateful `_SearchOptionsBar`
+takes `preferences` and bridges: seeds the controller from the stored
+flags via `prefs.ready.then` in initState (after the frame, so
+setSearchOptions never fires during build; the prefs' _modified guard keeps
+a programmatic pre-load change winning) and write-throughs on every toggle.
+`PdfSearchField` gained a `preferences` param; both shells pass `prefs` to
+their field (and the panel already had it). Regex caveat documented (Ben:
+"runs synchronously with no ReDoS/timeout guard, undocumented"): dartdoc on
+`PdfSearchOptions.regex` and `findAll`'s regex param notes matching is
+synchronous on the calling thread with no timeout — fine for local desktop,
+a host exposing it to untrusted input should guard it (no isolate/timeout
+added; Ben called the desktop behaviour acceptable). Tests: pdf_graphics
 text_extraction_test (+2: whole-word boundaries, regex incl. invalid →
-empty); dart_pdf_editor search_navigation_test (+5: controller re-run per
+empty); dart_pdf_editor search_navigation_test (+6: controller re-run per
 option, no-query store, field toggles re-search, showOptions:false hides
-them, panel toggles).
+them, panel toggles, persist+seed via tester.runAsync for the async prefs
+load — a bare `await prefs.ready` hangs under widget-test FakeAsync) and
+editing_preferences_test (+3 assertions: round-trip + defaults for the
+three flags).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2258,3 +2258,37 @@ app's life — the API key is kept in MEMORY ONLY, never written to disk (so
 the example needs no shared_preferences for it). dep pdf_ocr_vlm ^0.1.0.
 The 9 example test failures are pre-existing on this machine (raster/
 headless) — identical set with and without this wiring, zero regressions.
+
+Search options (Ben: "the search panel should allow for additional
+controls, match case, full word, etc."): match-case / whole-word / regex
+toggles for document search. pdf_graphics `PdfPageText.findAll` grew
+`wholeWord` (matches bounded by non-word chars — `_isWholeWord`/
+`_isWordChar`, [0-9A-Za-z_]) and `regex` (Dart RegExp; an invalid pattern
+yields no matches rather than throwing; zero-width hits skipped) beside
+the existing `caseSensitive`; the literal path still advances by needle
+length and the shared `_matchAt` builds quads from start/end so snippets/
+highlights are mode-agnostic. `PdfSearchOptions` (pdf_viewer.dart,
+exported — matchCase/wholeWord/regex, const default, copyWith + value ==)
+rides `PdfViewerController.searchOptions`; `search(query, {options})`
+captures the options and guards supersession on BOTH query and options;
+`setSearchOptions(opts)` re-runs the active search live (or just stores
+them with no query). `_searchAllPages` threads them into findAll; the
+extracted-text cache is option-independent so it's reused. UI
+(search_panel.dart): shared private `_SearchOptionsBar` — three toggle
+IconButtons (glyphs 'Aa'/'W'/'.*', tooltips, selected = secondaryContainer
+fill, keys 'pdf-search-match-case'/'-whole-word'/'-regex') driving
+setSearchOptions. `PdfSearchField` shows it inline (flag `showOptions`,
+default true); `PdfSearchResultsPanel` shows it in a header bar above the
+results (flag `showOptions`, default true) — the panel build now wraps the
+state body (`_body`, extracted) under the options bar + a Divider, scrollbar
+scoped to the body. Options persist across clearSearch (VS Code style).
+Shell wiring: the editor shell (`PdfEditorView`) passes
+`showOptions: !features.searchResultsPanel` to its header field — the
+results panel carries the controls, keeping the compact (≤600px) header
+from pushing the annotation/properties toggles off-screen (the
+pdf-shell-annotations-toggle tap-misses otherwise); the reader (no results
+panel) keeps the inline field toggles. Tests: pdf_graphics
+text_extraction_test (+2: whole-word boundaries, regex incl. invalid →
+empty); dart_pdf_editor search_navigation_test (+5: controller re-run per
+option, no-query store, field toggles re-search, showOptions:false hides
+them, panel toggles).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -72,6 +72,9 @@ class PdfEditingPreferences extends ChangeNotifier {
   bool _showReflowView = false;
   bool _showPropertiesPanel = false;
   bool _showSearchResultsPanel = false;
+  bool _searchMatchCase = false;
+  bool _searchWholeWord = false;
+  bool _searchRegex = false;
   double? _thumbnailSidebarWidth;
   double? _annotationSidebarWidth;
   double? _propertiesPanelWidth;
@@ -193,6 +196,11 @@ class PdfEditingPreferences extends ChangeNotifier {
       _showSearchResultsPanel =
           store.getBool('${_prefix}showSearchResultsPanel') ??
               _showSearchResultsPanel;
+      _searchMatchCase =
+          store.getBool('${_prefix}searchMatchCase') ?? _searchMatchCase;
+      _searchWholeWord =
+          store.getBool('${_prefix}searchWholeWord') ?? _searchWholeWord;
+      _searchRegex = store.getBool('${_prefix}searchRegex') ?? _searchRegex;
       _propertiesPanelWidth =
           store.getDouble('${_prefix}propertiesPanelWidth') ??
               _propertiesPanelWidth;
@@ -768,6 +776,39 @@ class PdfEditingPreferences extends ChangeNotifier {
     _write((s) => value == null
         ? s.remove('${_prefix}searchPanelWidth')
         : s.setDouble('${_prefix}searchPanelWidth', value));
+    notifyListeners();
+  }
+
+  /// Whether document search matches case (see `PdfSearchOptions.matchCase`).
+  /// Persisted so the search toggles survive reopening the app.
+  bool get searchMatchCase => _searchMatchCase;
+
+  set searchMatchCase(bool value) {
+    if (value == _searchMatchCase) return;
+    _searchMatchCase = value;
+    _write((s) => s.setBool('${_prefix}searchMatchCase', value));
+    notifyListeners();
+  }
+
+  /// Whether document search matches whole words only (see
+  /// `PdfSearchOptions.wholeWord`). Persisted.
+  bool get searchWholeWord => _searchWholeWord;
+
+  set searchWholeWord(bool value) {
+    if (value == _searchWholeWord) return;
+    _searchWholeWord = value;
+    _write((s) => s.setBool('${_prefix}searchWholeWord', value));
+    notifyListeners();
+  }
+
+  /// Whether document search treats the query as a regular expression (see
+  /// `PdfSearchOptions.regex`). Persisted.
+  bool get searchRegex => _searchRegex;
+
+  set searchRegex(bool value) {
+    if (value == _searchRegex) return;
+    _searchRegex = value;
+    _write((s) => s.setBool('${_prefix}searchRegex', value));
     notifyListeners();
   }
 }

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -543,6 +543,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       controller: _viewer,
                       searchController: _searchField,
                       focusNode: _searchFocus,
+                      // the match-case / whole-word / regex controls live in
+                      // the results panel here, keeping the header compact
+                      showOptions: !features.searchResultsPanel,
                     ),
                     if (features.searchResultsPanel)
                       PdfShellToggleButton(

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -543,6 +543,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       controller: _viewer,
                       searchController: _searchField,
                       focusNode: _searchFocus,
+                      preferences: prefs,
                       // the match-case / whole-word / regex controls live in
                       // the results panel here, keeping the header compact
                       showOptions: !features.searchResultsPanel,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -283,6 +283,7 @@ class _PdfReaderState extends State<PdfReader> {
                       controller: _viewer,
                       searchController: _searchField,
                       focusNode: _searchFocus,
+                      preferences: prefs,
                     ),
                   if (features.pageNumber && !prefs.showReflowView)
                     Padding(

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -74,6 +74,11 @@ class PdfSearchOptions {
 
   /// When true, the query is a regular expression rather than literal text.
   /// An invalid pattern simply yields no matches.
+  ///
+  /// Matching runs synchronously on the calling (UI) thread with no
+  /// timeout, so a catastrophically backtracking pattern over a very large
+  /// page can briefly stall the frame — acceptable for local desktop use,
+  /// but a host exposing this to untrusted input should guard it.
   final bool regex;
 
   PdfSearchOptions copyWith({bool? matchCase, bool? wholeWord, bool? regex}) =>

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -54,6 +54,46 @@ class PdfSearchResult {
   int get pageIndex => match.pageIndex;
 }
 
+/// How a document search matches text: case sensitivity, whole-word
+/// boundaries, and regular-expression mode. Held by
+/// [PdfViewerController.searchOptions]; the search field and results panel
+/// expose them as toggle controls.
+class PdfSearchOptions {
+  const PdfSearchOptions({
+    this.matchCase = false,
+    this.wholeWord = false,
+    this.regex = false,
+  });
+
+  /// When true, an upper/lower-case difference fails the match.
+  final bool matchCase;
+
+  /// When true, only matches bounded by non-word characters count
+  /// (letters, digits, and underscore are word characters).
+  final bool wholeWord;
+
+  /// When true, the query is a regular expression rather than literal text.
+  /// An invalid pattern simply yields no matches.
+  final bool regex;
+
+  PdfSearchOptions copyWith({bool? matchCase, bool? wholeWord, bool? regex}) =>
+      PdfSearchOptions(
+        matchCase: matchCase ?? this.matchCase,
+        wholeWord: wholeWord ?? this.wholeWord,
+        regex: regex ?? this.regex,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfSearchOptions &&
+      other.matchCase == matchCase &&
+      other.wholeWord == wholeWord &&
+      other.regex == regex;
+
+  @override
+  int get hashCode => Object.hash(matchCase, wholeWord, regex);
+}
+
 /// A snapshot of a viewer's scroll position and zoom, for mirroring one
 /// [PdfViewer] onto another — the comparison view's synchronized panes.
 /// Read [PdfViewerController.viewSync], hand it to another controller's
@@ -84,6 +124,7 @@ class PdfViewerController extends ChangeNotifier {
   int _currentPage = 0;
   bool _searching = false;
   String _query = '';
+  PdfSearchOptions _searchOptions = const PdfSearchOptions();
   List<PdfSearchResult> _results = const [];
   List<PdfTextMatch> _matches = const [];
   int _currentMatch = -1;
@@ -100,6 +141,10 @@ class PdfViewerController extends ChangeNotifier {
   bool get isSearching => _searching;
   String get query => _query;
   int get matchCount => _matches.length;
+
+  /// How [search] matches text (case, whole word, regex). Change it with
+  /// [setSearchOptions], which re-runs the active search.
+  PdfSearchOptions get searchOptions => _searchOptions;
 
   /// Every hit of the current [query] in document order, with context
   /// snippets — what a search results panel lists.
@@ -218,10 +263,14 @@ class PdfViewerController extends ChangeNotifier {
     super.dispose();
   }
 
-  /// Searches the whole document and jumps to the first hit.
-  Future<void> search(String query) async {
+  /// Searches the whole document and jumps to the first hit. Pass [options]
+  /// to change how matching works (case, whole word, regex) for this and
+  /// subsequent searches; omit it to keep the current [searchOptions].
+  Future<void> search(String query, {PdfSearchOptions? options}) async {
     final state = _state;
     if (state == null) return;
+    if (options != null) _searchOptions = options;
+    final opts = _searchOptions;
     _query = query;
     _results = const [];
     _matches = const [];
@@ -229,14 +278,28 @@ class PdfViewerController extends ChangeNotifier {
     _searching = query.isNotEmpty;
     notifyListeners();
     if (query.isEmpty) return;
-    final results = await state._searchAllPages(query);
-    if (_query != query) return; // superseded by a newer search
+    final results = await state._searchAllPages(query, opts);
+    // superseded by a newer search (changed query or options)
+    if (_query != query || _searchOptions != opts) return;
     _results = results;
     _matches = [for (final result in results) result.match];
     _searching = false;
     _currentMatch = results.isEmpty ? -1 : 0;
     notifyListeners();
     if (_matches.isNotEmpty) state._showMatch(_matches[0]);
+  }
+
+  /// Sets the matching [options] and re-runs the current search with them,
+  /// landing on the first hit. With no active query it just stores the
+  /// options for the next [search].
+  void setSearchOptions(PdfSearchOptions options) {
+    if (options == _searchOptions) return;
+    _searchOptions = options;
+    if (_query.isNotEmpty) {
+      unawaited(search(_query, options: options));
+    } else {
+      notifyListeners();
+    }
   }
 
   void nextMatch() => _stepMatch(1);
@@ -1451,12 +1514,19 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     );
   }
 
-  Future<List<PdfSearchResult>> _searchAllPages(String query) async {
+  Future<List<PdfSearchResult>> _searchAllPages(
+      String query, PdfSearchOptions options) async {
     final results = <PdfSearchResult>[];
     for (var i = 0; i < _pages.length; i++) {
       final text =
           _textCache[i] ??= PdfTextExtractor.extract(widget.document, i);
-      for (final match in text.findAll(query)) {
+      final matches = text.findAll(
+        query,
+        caseSensitive: options.matchCase,
+        wholeWord: options.wholeWord,
+        regex: options.regex,
+      );
+      for (final match in matches) {
         results.add(_snippetFor(text, match));
       }
       // yield between pages so long documents don't freeze the UI

--- a/packages/dart_pdf_editor/lib/src/search_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/search_panel.dart
@@ -23,6 +23,7 @@ class PdfSearchField extends StatefulWidget {
     this.searchController,
     this.focusNode,
     this.hintText = 'Search',
+    this.showOptions = true,
   });
 
   final PdfViewerController controller;
@@ -30,6 +31,10 @@ class PdfSearchField extends StatefulWidget {
   /// The text box's width; the count and the stepper buttons sit
   /// outside it, appearing only while a query is live.
   final double width;
+
+  /// Whether to show the match-case / whole-word / regex toggle buttons
+  /// beside the field. They drive [PdfViewerController.searchOptions].
+  final bool showOptions;
 
   /// Optional external text controller — pass one to clear or prefill
   /// the field from the host (e.g. when a new document opens).
@@ -145,6 +150,11 @@ class _PdfSearchFieldState extends State<PdfSearchField> {
               onSubmitted: _onSubmitted,
             ),
           ),
+          if (widget.showOptions)
+            Padding(
+              padding: const EdgeInsets.only(left: 4),
+              child: _SearchOptionsBar(controller: controller),
+            ),
           if (hasQuery && !controller.isSearching) ...[
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 6),
@@ -200,12 +210,17 @@ class PdfSearchResultsPanel extends StatefulWidget {
     this.minWidth = 200,
     this.maxWidth = 480,
     this.bottomSheet = false,
+    this.showOptions = true,
   });
 
   final PdfViewerController controller;
 
   /// Persists the user-dragged width when provided.
   final PdfEditingPreferences? preferences;
+
+  /// Whether the panel shows the match-case / whole-word / regex toggle
+  /// controls in its header. They drive [PdfViewerController.searchOptions].
+  final bool showOptions;
 
   /// The default width — a persisted user-dragged width wins over it.
   final double width;
@@ -312,95 +327,106 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
     );
   }
 
+  /// The state-dependent body below the options bar: a hint, the spinner,
+  /// the "no matches" line, or the grouped results list with its scrollbar.
+  Widget _body(BuildContext context, {required bool barInset}) {
+    final controller = widget.controller;
+    if (controller.query.isEmpty) {
+      return _hint('Search the document to list every match here');
+    }
+    if (controller.isSearching) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final results = controller.searchResults;
+    if (results.isEmpty) {
+      return _hint('No matches for “${controller.query}”');
+    }
+    final entries = <_Entry>[];
+    int? page;
+    for (var i = 0; i < results.length; i++) {
+      if (results[i].pageIndex != page) {
+        page = results[i].pageIndex;
+        entries.add((header: page, result: null));
+      }
+      entries.add((header: null, result: i));
+    }
+    final barClearance =
+        PdfScrollbar.hitExtent + (barInset ? PdfSidebarResizeGrip.width : 0);
+    final textTheme = Theme.of(context).textTheme;
+    return Stack(children: [
+      Column(children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: Row(children: [
+            Expanded(
+              child: Text(
+                results.length == 1 ? '1 match' : '${results.length} matches',
+                style: textTheme.labelLarge,
+              ),
+            ),
+          ]),
+        ),
+        Expanded(
+          child: ScrollConfiguration(
+            behavior:
+                ScrollConfiguration.of(context).copyWith(scrollbars: false),
+            child: ListView.builder(
+              key: const ValueKey('pdf-search-results-list'),
+              controller: _scroll,
+              padding: EdgeInsets.only(right: barClearance, bottom: 8),
+              itemCount: entries.length,
+              itemBuilder: (context, index) {
+                final entry = entries[index];
+                if (entry.header != null) {
+                  return Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 10, 16, 2),
+                    child: Text('Page ${entry.header! + 1}',
+                        style: textTheme.labelMedium?.copyWith(
+                            color: Theme.of(context).colorScheme.primary)),
+                  );
+                }
+                return _resultTile(
+                    context, entry.result!, results[entry.result!]);
+              },
+            ),
+          ),
+        ),
+      ]),
+      Positioned(
+        top: 0,
+        bottom: 0,
+        right: barInset ? PdfSidebarResizeGrip.width : 0,
+        child: PdfScrollbar(
+          scroll: _scroll,
+          thumbKey: const ValueKey('pdf-search-scrollbar-thumb'),
+        ),
+      ),
+    ]);
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = widget.controller;
     final showGrip = widget.resizable && !widget.bottomSheet;
     final onLeftEdge = !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    final barInset = showGrip && onLeftEdge;
     final content = Material(
             color: Theme.of(context).colorScheme.surfaceContainerLow,
             child: ListenableBuilder(
               listenable: controller,
-              builder: (context, _) {
-                if (controller.query.isEmpty) {
-                  return _hint('Search the document to list every match here');
-                }
-                if (controller.isSearching) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                final results = controller.searchResults;
-                if (results.isEmpty) {
-                  return _hint('No matches for “${controller.query}”');
-                }
-                final entries = <_Entry>[];
-                int? page;
-                for (var i = 0; i < results.length; i++) {
-                  if (results[i].pageIndex != page) {
-                    page = results[i].pageIndex;
-                    entries.add((header: page, result: null));
-                  }
-                  entries.add((header: null, result: i));
-                }
-                final barClearance = PdfScrollbar.hitExtent +
-                    (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
-                final textTheme = Theme.of(context).textTheme;
-                return Stack(children: [
-                  Column(children: [
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-                      child: Row(children: [
-                        Expanded(
-                          child: Text(
-                            results.length == 1
-                                ? '1 match'
-                                : '${results.length} matches',
-                            style: textTheme.labelLarge,
-                          ),
-                        ),
-                      ]),
-                    ),
-                    Expanded(
-                      child: ScrollConfiguration(
-                        behavior: ScrollConfiguration.of(context)
-                            .copyWith(scrollbars: false),
-                        child: ListView.builder(
-                          key: const ValueKey('pdf-search-results-list'),
-                          controller: _scroll,
-                          padding:
-                              EdgeInsets.only(right: barClearance, bottom: 8),
-                          itemCount: entries.length,
-                          itemBuilder: (context, index) {
-                            final entry = entries[index];
-                            if (entry.header != null) {
-                              return Padding(
-                                padding:
-                                    const EdgeInsets.fromLTRB(16, 10, 16, 2),
-                                child: Text('Page ${entry.header! + 1}',
-                                    style: textTheme.labelMedium?.copyWith(
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .primary)),
-                              );
-                            }
-                            return _resultTile(
-                                context, entry.result!, results[entry.result!]);
-                          },
-                        ),
-                      ),
-                    ),
-                  ]),
-                  Positioned(
-                    top: 0,
-                    bottom: 0,
-                    right:
-                        showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
-                    child: PdfScrollbar(
-                      scroll: _scroll,
-                      thumbKey: const ValueKey('pdf-search-scrollbar-thumb'),
+              builder: (context, _) => Column(children: [
+                if (widget.showOptions) ...[
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: _SearchOptionsBar(controller: controller),
                     ),
                   ),
-                ]);
-              },
+                  const Divider(height: 1),
+                ],
+                Expanded(child: _body(context, barInset: barInset)),
+              ]),
             ),
           );
     if (widget.bottomSheet) return content;
@@ -423,5 +449,73 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
           ),
       ]),
     );
+  }
+}
+
+/// A compact row of toggle buttons for the search match options — case
+/// sensitivity, whole word, and regular expression — driving
+/// [PdfViewerController.searchOptions]. Shared by [PdfSearchField] and
+/// [PdfSearchResultsPanel].
+class _SearchOptionsBar extends StatelessWidget {
+  const _SearchOptionsBar({required this.controller});
+
+  final PdfViewerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final options = controller.searchOptions;
+
+    Widget toggle({
+      required String keyName,
+      required String glyph,
+      required String tooltip,
+      required bool selected,
+      required PdfSearchOptions next,
+    }) =>
+        IconButton(
+          key: ValueKey(keyName),
+          tooltip: tooltip,
+          isSelected: selected,
+          visualDensity: VisualDensity.compact,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 30, minHeight: 30),
+          style: IconButton.styleFrom(
+            backgroundColor: selected ? scheme.secondaryContainer : null,
+            foregroundColor: selected
+                ? scheme.onSecondaryContainer
+                : scheme.onSurfaceVariant,
+          ),
+          onPressed: () => controller.setSearchOptions(next),
+          icon: Text(
+            glyph,
+            style: const TextStyle(
+                fontSize: 13, fontWeight: FontWeight.w600, height: 1),
+          ),
+        );
+
+    return Row(mainAxisSize: MainAxisSize.min, children: [
+      toggle(
+        keyName: 'pdf-search-match-case',
+        glyph: 'Aa',
+        tooltip: 'Match case',
+        selected: options.matchCase,
+        next: options.copyWith(matchCase: !options.matchCase),
+      ),
+      toggle(
+        keyName: 'pdf-search-whole-word',
+        glyph: 'W',
+        tooltip: 'Whole word',
+        selected: options.wholeWord,
+        next: options.copyWith(wholeWord: !options.wholeWord),
+      ),
+      toggle(
+        keyName: 'pdf-search-regex',
+        glyph: '.*',
+        tooltip: 'Regular expression',
+        selected: options.regex,
+        next: options.copyWith(regex: !options.regex),
+      ),
+    ]);
   }
 }

--- a/packages/dart_pdf_editor/lib/src/search_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/search_panel.dart
@@ -24,6 +24,7 @@ class PdfSearchField extends StatefulWidget {
     this.focusNode,
     this.hintText = 'Search',
     this.showOptions = true,
+    this.preferences,
   });
 
   final PdfViewerController controller;
@@ -35,6 +36,10 @@ class PdfSearchField extends StatefulWidget {
   /// Whether to show the match-case / whole-word / regex toggle buttons
   /// beside the field. They drive [PdfViewerController.searchOptions].
   final bool showOptions;
+
+  /// When given, the match-case / whole-word / regex toggles persist to
+  /// (and seed from) these preferences, so they survive across sessions.
+  final PdfEditingPreferences? preferences;
 
   /// Optional external text controller — pass one to clear or prefill
   /// the field from the host (e.g. when a new document opens).
@@ -153,7 +158,8 @@ class _PdfSearchFieldState extends State<PdfSearchField> {
           if (widget.showOptions)
             Padding(
               padding: const EdgeInsets.only(left: 4),
-              child: _SearchOptionsBar(controller: controller),
+              child: _SearchOptionsBar(
+                  controller: controller, preferences: widget.preferences),
             ),
           if (hasQuery && !controller.isSearching) ...[
             Padding(
@@ -420,7 +426,9 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
                     padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
                     child: Align(
                       alignment: Alignment.centerLeft,
-                      child: _SearchOptionsBar(controller: controller),
+                      child: _SearchOptionsBar(
+                          controller: controller,
+                          preferences: widget.preferences),
                     ),
                   ),
                   const Divider(height: 1),
@@ -456,15 +464,57 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
 /// sensitivity, whole word, and regular expression — driving
 /// [PdfViewerController.searchOptions]. Shared by [PdfSearchField] and
 /// [PdfSearchResultsPanel].
-class _SearchOptionsBar extends StatelessWidget {
-  const _SearchOptionsBar({required this.controller});
+///
+/// With [preferences] the toggles persist: the bar seeds the controller
+/// from the stored values once they load, and a toggle writes back.
+class _SearchOptionsBar extends StatefulWidget {
+  const _SearchOptionsBar({required this.controller, this.preferences});
 
   final PdfViewerController controller;
+  final PdfEditingPreferences? preferences;
+
+  @override
+  State<_SearchOptionsBar> createState() => _SearchOptionsBarState();
+}
+
+class _SearchOptionsBarState extends State<_SearchOptionsBar> {
+  @override
+  void initState() {
+    super.initState();
+    // Seed the controller from the stored options once they have loaded.
+    // ready completes after the frame, so setSearchOptions runs outside any
+    // build; the prefs' own _modified guard means a programmatic change
+    // before load still wins.
+    final prefs = widget.preferences;
+    if (prefs != null) {
+      prefs.ready.then((_) {
+        if (!mounted) return;
+        final p = widget.preferences;
+        if (p == null) return;
+        widget.controller.setSearchOptions(PdfSearchOptions(
+          matchCase: p.searchMatchCase,
+          wholeWord: p.searchWholeWord,
+          regex: p.searchRegex,
+        ));
+      });
+    }
+  }
+
+  void _apply(PdfSearchOptions next) {
+    widget.controller.setSearchOptions(next);
+    final prefs = widget.preferences;
+    if (prefs != null) {
+      prefs
+        ..searchMatchCase = next.matchCase
+        ..searchWholeWord = next.wholeWord
+        ..searchRegex = next.regex;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    final options = controller.searchOptions;
+    final options = widget.controller.searchOptions;
 
     Widget toggle({
       required String keyName,
@@ -486,7 +536,7 @@ class _SearchOptionsBar extends StatelessWidget {
                 ? scheme.onSecondaryContainer
                 : scheme.onSurfaceVariant,
           ),
-          onPressed: () => controller.setSearchOptions(next),
+          onPressed: () => _apply(next),
           icon: Text(
             glyph,
             style: const TextStyle(

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -24,6 +24,9 @@ void main() {
       a.showReflowView = true;
       a.lineStartEnding = PdfLineEnding.circle;
       a.lineEndEnding = PdfLineEnding.closedArrow;
+      a.searchMatchCase = true;
+      a.searchWholeWord = true;
+      a.searchRegex = true;
       await pumpEventQueue(); // let the unawaited writes land
 
       final b = PdfEditingPreferences();
@@ -41,6 +44,9 @@ void main() {
       expect(b.showReflowView, isTrue);
       expect(b.lineStartEnding, PdfLineEnding.circle);
       expect(b.lineEndEnding, PdfLineEnding.closedArrow);
+      expect(b.searchMatchCase, isTrue);
+      expect(b.searchWholeWord, isTrue);
+      expect(b.searchRegex, isTrue);
     });
 
     test('empty storage leaves the defaults', () async {
@@ -61,6 +67,9 @@ void main() {
       expect(prefs.lineEndEnding, PdfLineEnding.none);
       expect(prefs.highlightFormFields, isTrue);
       expect(prefs.showReflowView, isFalse);
+      expect(prefs.searchMatchCase, isFalse);
+      expect(prefs.searchWholeWord, isFalse);
+      expect(prefs.searchRegex, isFalse);
     });
 
     test('a value set while loading is not clobbered by stored data', () async {

--- a/packages/dart_pdf_editor/test/search_navigation_test.dart
+++ b/packages/dart_pdf_editor/test/search_navigation_test.dart
@@ -125,6 +125,56 @@ void main() {
       await tester.pumpAndSettle(const Duration(milliseconds: 100));
     });
 
+    testWidgets('search options change matching and re-run live',
+        (tester) async {
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      // pages read 'Page 1', 'Page 2', 'Page 3'
+      await pumpViewer(tester, controller, buildMultiPagePdf(3));
+
+      // case-insensitive by default
+      unawaited(controller.search('page'));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.matchCount, 3);
+
+      // toggling match case re-runs the active search with no second call
+      controller.setSearchOptions(const PdfSearchOptions(matchCase: true));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.searchOptions.matchCase, isTrue);
+      expect(controller.matchCount, 0); // 'page' != 'Page'
+
+      // whole word: a substring no longer matches, the full word does
+      controller.setSearchOptions(const PdfSearchOptions(wholeWord: true));
+      unawaited(controller.search('Pag'));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.matchCount, 0);
+      unawaited(controller.search('Page'));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.matchCount, 3);
+
+      // regex mode; an invalid pattern yields nothing rather than throwing
+      controller.setSearchOptions(const PdfSearchOptions(regex: true));
+      unawaited(controller.search(r'Page \d'));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.matchCount, 3);
+      unawaited(controller.search('['));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.matchCount, 0);
+    });
+
+    testWidgets('setting options with no query just stores them',
+        (tester) async {
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      await pumpViewer(tester, controller, buildMultiPagePdf(2));
+
+      controller.setSearchOptions(const PdfSearchOptions(wholeWord: true));
+      await tester.pump();
+      expect(controller.searchOptions.wholeWord, isTrue);
+      expect(controller.query, isEmpty);
+      expect(controller.matchCount, 0);
+    });
+
     testWidgets('goToMatch makes a match current and navigates there',
         (tester) async {
       final controller = PdfViewerController();
@@ -282,6 +332,47 @@ void main() {
       await tester.pumpAndSettle(const Duration(milliseconds: 100));
     });
 
+    testWidgets('the option toggles drive the controller and re-search',
+        (tester) async {
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      await pumpViewer(tester, controller, buildMultiPagePdf(3),
+          above: PdfSearchField(controller: controller));
+
+      await tester.enterText(find.byKey(fieldKey), 'page');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.matchCount, 3);
+
+      // the three toggles are present
+      expect(find.byKey(const ValueKey('pdf-search-match-case')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-search-whole-word')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-search-regex')), findsOneWidget);
+
+      // tapping match case re-runs the live search
+      await tester.tap(find.byKey(const ValueKey('pdf-search-match-case')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.searchOptions.matchCase, isTrue);
+      expect(controller.matchCount, 0);
+
+      // and toggling it back restores the matches
+      await tester.tap(find.byKey(const ValueKey('pdf-search-match-case')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.searchOptions.matchCase, isFalse);
+      expect(controller.matchCount, 3);
+    });
+
+    testWidgets('showOptions: false hides the toggles', (tester) async {
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      await pumpViewer(tester, controller, buildMultiPagePdf(2),
+          above: PdfSearchField(controller: controller, showOptions: false));
+
+      expect(find.byKey(const ValueKey('pdf-search-match-case')), findsNothing);
+    });
+
     testWidgets('enter on a changed query searches afresh', (tester) async {
       final controller = PdfViewerController();
       addTearDown(controller.dispose);
@@ -339,6 +430,27 @@ void main() {
           isTrue);
       // any touch gesture leaves the viewer's double-tap timer pending
       await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('the panel hosts the option toggles and they re-search',
+        (tester) async {
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      await pumpViewer(tester, controller, buildMultiPagePdf(3),
+          beside: PdfSearchResultsPanel(controller: controller));
+
+      // toggles are present even before a query is entered
+      expect(find.byKey(const ValueKey('pdf-search-whole-word')),
+          findsOneWidget);
+
+      unawaited(controller.search('page'));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(find.text('3 matches'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-search-match-case')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      expect(controller.searchOptions.matchCase, isTrue);
+      expect(find.text('No matches for “page”'), findsOneWidget);
     });
 
     testWidgets('an unmatched query says so', (tester) async {

--- a/packages/dart_pdf_editor/test/search_navigation_test.dart
+++ b/packages/dart_pdf_editor/test/search_navigation_test.dart
@@ -364,6 +364,32 @@ void main() {
       expect(controller.matchCount, 3);
     });
 
+    testWidgets('toggles persist to and seed from preferences',
+        (tester) async {
+      // a stored option seeds the controller once preferences load
+      SharedPreferences.setMockInitialValues(
+          {'dart_pdf_editor.editing.searchWholeWord': true});
+      final preferences = PdfEditingPreferences();
+      addTearDown(preferences.dispose);
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      await pumpViewer(tester, controller, buildMultiPagePdf(2),
+          above: PdfSearchField(
+              controller: controller, preferences: preferences));
+
+      // let the async preference load (and the bar's seeding) run, then
+      // rebuild — the stored whole-word option lands on the controller
+      await tester.runAsync(() => preferences.ready);
+      await tester.pump();
+      expect(controller.searchOptions.wholeWord, isTrue);
+
+      // toggling match case writes through to the preferences immediately
+      await tester.tap(find.byKey(const ValueKey('pdf-search-match-case')));
+      await tester.pump();
+      expect(controller.searchOptions.matchCase, isTrue);
+      expect(preferences.searchMatchCase, isTrue);
+    });
+
     testWidgets('showOptions: false hides the toggles', (tester) async {
       final controller = PdfViewerController();
       addTearDown(controller.dispose);

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -100,27 +100,71 @@ class PdfPageText {
   final List<PdfExtractedRun> runs;
 
   /// Finds non-overlapping occurrences of [query].
-  List<PdfTextMatch> findAll(String query, {bool caseSensitive = false}) {
+  ///
+  /// With [wholeWord] only matches whose surrounding characters are not
+  /// letters/digits/underscore count. With [regex] the query is a Dart
+  /// regular expression (an invalid pattern yields no matches rather than
+  /// throwing). [caseSensitive] applies to both literal and regex search.
+  List<PdfTextMatch> findAll(
+    String query, {
+    bool caseSensitive = false,
+    bool wholeWord = false,
+    bool regex = false,
+  }) {
     if (query.isEmpty) return const [];
+    final matches = <PdfTextMatch>[];
+    if (regex) {
+      final RegExp pattern;
+      try {
+        pattern = RegExp(query, caseSensitive: caseSensitive, multiLine: true);
+      } on FormatException {
+        return const []; // invalid pattern — surface no matches, don't throw
+      }
+      for (final match in pattern.allMatches(text)) {
+        if (match.start == match.end) continue; // skip zero-width hits
+        if (wholeWord && !_isWholeWord(match.start, match.end)) continue;
+        matches.add(_matchAt(match.start, match.end));
+      }
+      return matches;
+    }
     final haystack = caseSensitive ? text : text.toLowerCase();
     final needle = caseSensitive ? query : query.toLowerCase();
-    final matches = <PdfTextMatch>[];
     var from = 0;
     while (true) {
       final index = haystack.indexOf(needle, from);
       if (index < 0) break;
       final end = index + needle.length;
-      final quads = quadsFor(index, end);
-      matches.add(PdfTextMatch(
-        pageIndex: pageIndex,
-        start: index,
-        end: end,
-        rects: [for (final quad in quads) quad.bounds],
-        quads: quads,
-      ));
+      if (!wholeWord || _isWholeWord(index, end)) {
+        matches.add(_matchAt(index, end));
+      }
       from = end;
     }
     return matches;
+  }
+
+  PdfTextMatch _matchAt(int start, int end) {
+    final quads = quadsFor(start, end);
+    return PdfTextMatch(
+      pageIndex: pageIndex,
+      start: start,
+      end: end,
+      rects: [for (final quad in quads) quad.bounds],
+      quads: quads,
+    );
+  }
+
+  /// Whether [text]`[start..end)` is bounded by non-word characters on both
+  /// sides (or the string edge) — the "match whole word" test.
+  bool _isWholeWord(int start, int end) =>
+      !_isWordChar(start - 1) && !_isWordChar(end);
+
+  bool _isWordChar(int index) {
+    if (index < 0 || index >= text.length) return false;
+    final c = text.codeUnitAt(index);
+    return (c >= 0x30 && c <= 0x39) || // 0-9
+        (c >= 0x41 && c <= 0x5A) || // A-Z
+        (c >= 0x61 && c <= 0x7A) || // a-z
+        c == 0x5F; // _
   }
 
   /// Axis-aligned page-space rectangles covering the characters

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -104,7 +104,9 @@ class PdfPageText {
   /// With [wholeWord] only matches whose surrounding characters are not
   /// letters/digits/underscore count. With [regex] the query is a Dart
   /// regular expression (an invalid pattern yields no matches rather than
-  /// throwing). [caseSensitive] applies to both literal and regex search.
+  /// throwing); matching is synchronous with no timeout, so a pathological
+  /// (catastrophically backtracking) pattern over a large page can block
+  /// the caller. [caseSensitive] applies to both literal and regex search.
   List<PdfTextMatch> findAll(
     String query, {
     bool caseSensitive = false,

--- a/packages/pdf_graphics/test/text_extraction_test.dart
+++ b/packages/pdf_graphics/test/text_extraction_test.dart
@@ -47,6 +47,33 @@ void main() {
     expect(text.findAll('HELLO', caseSensitive: true), isEmpty);
   });
 
+  test('whole-word search needs non-word boundaries', () {
+    final doc = PdfDocument.open(buildClassicPdf());
+    final text = PdfTextExtractor.extract(doc, 0); // 'Hello, world!'
+    // bounded by start/',' and by space/'!' — both whole words
+    expect(text.findAll('Hello', wholeWord: true), hasLength(1));
+    expect(text.findAll('world', wholeWord: true), hasLength(1));
+    // a substring of a longer word is not a whole word
+    expect(text.findAll('wor', wholeWord: true), isEmpty);
+    expect(text.findAll('ell', wholeWord: true), isEmpty);
+    // without the flag the substring still matches
+    expect(text.findAll('wor'), hasLength(1));
+  });
+
+  test('regex search matches a pattern; an invalid one yields nothing', () {
+    final doc = PdfDocument.open(buildClassicPdf());
+    final text = PdfTextExtractor.extract(doc, 0); // 'Hello, world!'
+    final match = text.findAll(r'w\w+d', regex: true).single;
+    expect(text.text.substring(match.start, match.end), 'world');
+    // case sensitivity flows through to regex
+    expect(text.findAll(r'WORLD', regex: true), hasLength(1));
+    expect(text.findAll(r'WORLD', regex: true, caseSensitive: true), isEmpty);
+    // whole-word combines with regex
+    expect(text.findAll(r'wor', regex: true, wholeWord: true), isEmpty);
+    // an invalid pattern surfaces no matches rather than throwing
+    expect(text.findAll('[', regex: true), isEmpty);
+  });
+
   test('positionNear maps page points to character offsets', () {
     final doc = PdfDocument.open(buildClassicPdf());
     final text = PdfTextExtractor.extract(doc, 0);


### PR DESCRIPTION
## Summary

Document search now supports **match case**, **whole word**, and **regular expression** matching, surfaced as toggle controls on both the search field and the results panel — addressing the request that "the search panel should allow for additional controls, match case, full word, etc."

## What changed

- **pdf_graphics** — `PdfPageText.findAll` gains `wholeWord` (matches bounded by non-word characters: `[0-9A-Za-z_]`) and `regex` (Dart `RegExp`) options beside the existing `caseSensitive`. An invalid regex yields no matches rather than throwing; the shared `_matchAt` helper builds quads from `start`/`end` so snippets and highlights work the same in every mode.
- **PdfViewerController** — new exported `PdfSearchOptions` value type (`matchCase` / `wholeWord` / `regex`, value equality, `copyWith`) on `searchOptions`. `search(query, {options})` captures the options and guards supersession on both query and options; `setSearchOptions(opts)` re-runs the active search live (or just stores them when there's no query). Options persist across `clearSearch` (VS Code style).
- **search_panel** — a shared `_SearchOptionsBar` (compact `Aa` / `W` / `.*` toggle buttons, keyed `pdf-search-match-case` / `-whole-word` / `-regex`) used by:
  - `PdfSearchField` — inline beside the field (`showOptions`, default true)
  - `PdfSearchResultsPanel` — in a header bar above the results (`showOptions`, default true)
- **Editor shell** — `PdfEditorView` passes `showOptions: !features.searchResultsPanel` to its header field so the results panel carries the controls and the compact (≤600px) header doesn't push the annotation/properties toggles off-screen. The reader (no results panel) keeps the inline field toggles.

## Tests

- `pdf_graphics/test/text_extraction_test.dart` (+2): whole-word boundary cases; regex matching including invalid pattern → empty.
- `dart_pdf_editor/test/search_navigation_test.dart` (+5): controller re-runs per option change, no-query store, field toggles re-search, `showOptions: false` hides them, panel hosts the toggles.

All affected suites pass (`text_extraction`, `search_navigation`, `pdf_shell`, `pdf_theme`, `pdf_viewer`, `ocr`, `comparison_view`) and `dart analyze` is clean across the repo.

https://claude.ai/code/session_01M5yMsRZHUaV5RnF6ruptds

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5yMsRZHUaV5RnF6ruptds)_