### PR TITLE
Cancel superseded searches so typing on heavy docs stays responsive

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1543,15 +1543,27 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   Future<List<PdfSearchResult>> _searchAllPages(String query) async {
     final results = <PdfSearchResult>[];
     for (var i = 0; i < _pages.length; i++) {
+      // A newer keystroke has superseded this search — stop grinding pages
+      // immediately instead of interpreting every remaining content stream
+      // (100–420ms each) only for the caller to discard the result. Without
+      // this, each keystroke on a heavy document stacks another full-document
+      // walk on the event loop and the field chugs: the next search sets
+      // _query as soon as it runs (during one of the yields below), so this
+      // cheap synchronous check lets the stale walk bail at the next page.
+      if (_controller._query != query) return const [];
       final text = await _extractText(i);
       for (final match in text.findAll(query)) {
         results.add(_snippetFor(text, match));
       }
-      // yield between pages so long documents don't freeze the UI
+      // Yield to the event loop every few pages so frames paint and the
+      // superseding search gets a chance to run (a microtask wouldn't let
+      // timers/rendering in, so this is a Duration.zero delay).
       if (i % 5 == 4) await Future<void>.delayed(Duration.zero);
     }
     return results;
   }
+
+  static final RegExp _whitespaceRun = RegExp(r'\s+');
 
   /// Context for one hit: the rest of its line, capped to a handful of
   /// words each side with ellipses marking what was cut.
@@ -1564,7 +1576,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     if (lineEnd < 0) lineEnd = s.length;
     final from = math.max(lineStart, match.start - beforeChars);
     final to = math.min(lineEnd, match.end + afterChars);
-    String squash(String part) => part.replaceAll(RegExp(r'\s+'), ' ');
+    String squash(String part) => part.replaceAll(_whitespaceRun, ' ');
     return PdfSearchResult(
       match: match,
       prefix: (from > lineStart ? '… ' : '') +


### PR DESCRIPTION
## Problem

Search "chugs" (stutters the UI) on a heavy/large document while typing the search term in.

## Root cause

`PdfViewerController.search()` runs `_searchAllPages`, which interprets **every page's content stream** to extract text (100–420ms each on graphics-rich/CAD pages). The loop only checked whether it had been superseded **after the whole loop finished** (`if (_query != query) return;`). So while typing, each debounced keystroke could kick off a new full-document walk, and the previous one kept grinding through all remaining pages anyway — stale walks stacked on the event loop and the field chugged.

## Fix

- Add a cheap per-page bail check inside the `_searchAllPages` loop. A newer `search()` sets `_query` synchronously the moment it runs (during one of the existing every-5-pages yields), so a superseded walk now stops at the next page boundary instead of finishing the whole document.
- The yield cadence is left unchanged (every 5 pages), which keeps single-search UI breathing and existing `pumpAndSettle`-based widget-test timing intact.
- Minor: hoist the whitespace-squash `RegExp` out of the per-match snippet builder so it isn't recompiled for every hit.

## Tests

`test/search_navigation_test.dart` (12) and `test/pdf_viewer_test.dart` (34) both pass; `dart analyze` on the package lib is clean.

https://claude.ai/code/session_01Jg64MsoLS6DVXrckUUcm5d

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg64MsoLS6DVXrckUUcm5d)_