### PR TITLE
Add browser-local OCR (Florence-2) and web bridge

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -640,10 +640,12 @@ class _EditorScreenState extends State<EditorScreen>
             PopupMenuItem(
               key: const ValueKey('menu-ocr'),
               value: () => unawaited(_runOcr()),
-              child: const ListTile(
-                leading: Icon(Icons.document_scanner_outlined),
-                title: Text('Add OCR text layer…'),
-                subtitle: Text('On-device · selectable text over scans'),
+              child: ListTile(
+                leading: const Icon(Icons.document_scanner_outlined),
+                title: const Text('Add OCR text layer…'),
+                subtitle: Text(kIsWeb
+                    ? 'AI in-browser · selectable text over scans'
+                    : 'On-device · selectable text over scans'),
                 contentPadding: EdgeInsets.zero,
               ),
             ),

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -613,6 +613,15 @@ class _EditorScreenState extends State<EditorScreen>
         tooltip: 'Open PDF in a new tab',
         onPressed: _pickAndOpen,
       ),
+      if (tab?.session != null && OnDeviceOcr.isSupported)
+        IconButton(
+          key: const ValueKey('ocr-action'),
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.document_scanner_outlined),
+          tooltip:
+              kIsWeb ? 'Add AI OCR text layer' : 'Add on-device OCR text layer',
+          onPressed: () => unawaited(_runOcr()),
+        ),
       PopupMenuButton<VoidCallback>(
         icon: const Icon(Icons.more_vert),
         tooltip: 'More',

--- a/app/lib/ocr.dart
+++ b/app/lib/ocr.dart
@@ -1,8 +1,8 @@
-// Native OCR is FFI/dart:io-backed (ONNX Runtime), which dart2js can't
+// Native OCR is FFI/dart:io-backed (ONNX Runtime), which web builds can't
 // compile, so the native implementation is only pulled in where dart:io exists.
-// On the web this resolves to a browser-local Florence-2 implementation,
-// keeping onnxruntime out of the web build while still offering OCR.
+// On the web this resolves to a browser-local Florence-2 implementation. Use
+// js_interop instead of html so both Wasm and dart2js web builds pick it up.
 // Other platforms get a stub.
 export 'ocr_stub.dart'
     if (dart.library.io) 'ocr_native.dart'
-    if (dart.library.html) 'ocr_web.dart';
+    if (dart.library.js_interop) 'ocr_web.dart';

--- a/app/lib/ocr.dart
+++ b/app/lib/ocr.dart
@@ -1,5 +1,8 @@
-// On-device OCR is FFI/dart:io-backed (ONNX Runtime), which dart2js can't
-// compile, so the real implementation is only pulled in where dart:io exists.
-// On the web this resolves to a stub whose OnDeviceOcr.isSupported is false,
-// keeping onnxruntime out of the web build entirely.
-export 'ocr_stub.dart' if (dart.library.io) 'ocr_native.dart';
+// Native OCR is FFI/dart:io-backed (ONNX Runtime), which dart2js can't
+// compile, so the native implementation is only pulled in where dart:io exists.
+// On the web this resolves to a browser-local Florence-2 implementation,
+// keeping onnxruntime out of the web build while still offering OCR.
+// Other platforms get a stub.
+export 'ocr_stub.dart'
+    if (dart.library.io) 'ocr_native.dart'
+    if (dart.library.html) 'ocr_web.dart';

--- a/app/lib/ocr_web.dart
+++ b/app/lib/ocr_web.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:js_util' as js_util;
-import 'dart:typed_data';
+import 'dart:js_interop';
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart' show Rect;
 import 'package:pdf_document/pdf_document.dart';
 
 import 'ocr_status.dart';
@@ -109,9 +107,14 @@ class OnDeviceOcr {
     }
   }
 
-  static bool get _hasBridge =>
-      js_util.hasProperty(js_util.globalThis, '__dartPdfOcrRecognize');
+  static bool get _hasBridge => _ocrBridge != null;
 }
+
+@JS('__dartPdfOcrRecognize')
+external JSAny? get _ocrBridge;
+
+@JS('__dartPdfOcrRecognize')
+external JSPromise<JSString> _recognizeWithBrowserOcr(String imageDataUrl);
 
 class _BrowserOcrEngine implements PdfOcrEngine {
   Future<void> warmUp() async {
@@ -186,7 +189,10 @@ class _BrowserOcrEngine implements PdfOcrEngine {
   static List<String>? _listOfStrings(Object? value) {
     if (value is String) return [value];
     if (value is! List) return null;
-    return [for (final item in value) if (item != null) item.toString()];
+    return [
+      for (final item in value)
+        if (item != null) item.toString()
+    ];
   }
 
   static List<Rect>? _listOfBoxes(Object? value) {
@@ -201,7 +207,10 @@ class _BrowserOcrEngine implements PdfOcrEngine {
 
   static Rect? _rect(Object? value) {
     if (value is! List || value.length < 4) return null;
-    final nums = [for (final v in value) if (v is num) v.toDouble()];
+    final nums = [
+      for (final v in value)
+        if (v is num) v.toDouble()
+    ];
     if (nums.length < 4) return null;
     if (nums.length >= 8) {
       var minX = double.infinity, minY = double.infinity;
@@ -233,16 +242,8 @@ class _BrowserOcrEngine implements PdfOcrEngine {
   }
 
   static Future<Object?> _recognizeDataUrl(String dataUrl) async {
-    final promise = js_util.callMethod<Object?>(
-      js_util.globalThis,
-      '__dartPdfOcrRecognize',
-      [dataUrl],
-    );
-    final result = await js_util.promiseToFuture<Object?>(promise);
-    if (result is! String) {
-      throw StateError('browser OCR returned an unexpected response');
-    }
-    return jsonDecode(result);
+    final result = await _recognizeWithBrowserOcr(dataUrl).toDart;
+    return jsonDecode(result.toDart);
   }
 }
 
@@ -254,8 +255,8 @@ class _WebOcrConfirmDialog extends StatelessWidget {
     return AlertDialog(
       key: const ValueKey('ocr-web-settings'),
       title: const Text('Run AI OCR in this browser?'),
-      content: const ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: 520),
+      content: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
         child: Text(
           'Web OCR downloads a Florence-2 vision-language model and runs it '
           'locally with WebGPU/WASM through Transformers.js. The PDF pages stay '

--- a/app/lib/ocr_web.dart
+++ b/app/lib/ocr_web.dart
@@ -1,0 +1,278 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:js_util' as js_util;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/painting.dart' show Rect;
+import 'package:pdf_document/pdf_document.dart';
+
+import 'ocr_status.dart';
+
+export 'ocr_status.dart';
+
+/// Drives the app's browser-local OCR flow.
+///
+/// Native builds use `pdf_ocr_ondevice` with ONNX Runtime. Web builds cannot
+/// compile that FFI stack, so this implementation calls the JavaScript OCR
+/// bridge registered by `web/index.html`. That bridge loads a Florence-2
+/// vision-language model through Transformers.js and runs recognition in the
+/// browser; page images and OCR results do not go to an app OCR server.
+class OnDeviceOcr {
+  OnDeviceOcr();
+
+  /// The current job's progress, or null when nothing is running. The app bar
+  /// listens to this to show a progress chip with a cancel button.
+  final ValueNotifier<OcrJobStatus?> status = ValueNotifier(null);
+
+  bool _cancelled = false;
+
+  /// Web OCR is supported by the browser-local Florence-2 bridge.
+  static bool get isSupported => true;
+
+  /// Whether a job is in flight (only one runs at a time).
+  bool get isBusy => status.value != null;
+
+  void dispose() => status.dispose();
+
+  /// Asks the running job to stop. It finishes the current page request and
+  /// then bails without producing a result.
+  void cancel() {
+    if (isBusy) _cancelled = true;
+  }
+
+  /// Starts OCR over [bytes]. The first run confirms the model download, then
+  /// recognition runs entirely in the browser process.
+  Future<void> start(
+    BuildContext context, {
+    required Uint8List bytes,
+    required String title,
+    required void Function(String message) onToast,
+    required void Function(Uint8List result) onComplete,
+  }) async {
+    if (isBusy) {
+      onToast('OCR is already running — wait for it to finish or cancel it');
+      return;
+    }
+    if (!_hasBridge) {
+      onToast('Browser OCR failed to initialise');
+      return;
+    }
+
+    final approved = await showDialog<bool>(
+      context: context,
+      builder: (_) => const _WebOcrConfirmDialog(),
+    );
+    if (approved != true) return;
+    _cancelled = false;
+
+    final engine = _BrowserOcrEngine();
+    try {
+      status.value = OcrJobStatus(phase: OcrPhase.downloading, title: title);
+      await engine.warmUp();
+      if (_cancelled) {
+        onToast('OCR cancelled');
+        return;
+      }
+
+      final editor = PdfEditor(PdfDocument.open(bytes));
+      final count = editor.document.pageCount;
+      var spans = 0;
+      for (var i = 0; i < count; i++) {
+        if (_cancelled) break;
+        status.value = OcrJobStatus(
+          phase: OcrPhase.recognising,
+          title: title,
+          page: i + 1,
+          pageCount: count,
+        );
+        spans += await editor.applyOcr(i, engine, pixelRatio: 2);
+        await Future<void>.delayed(Duration.zero);
+      }
+      if (_cancelled) {
+        onToast('OCR cancelled after $spans text spans');
+        return;
+      }
+      status.value = OcrJobStatus(phase: OcrPhase.finishing, title: title);
+      final result = editor.save();
+      onToast(spans == 0
+          ? 'OCR found no text on these pages'
+          : 'OCR added $spans text spans — the page text is now selectable');
+      onComplete(result);
+    } catch (e) {
+      onToast('OCR failed: $e');
+    } finally {
+      status.value = null;
+    }
+  }
+
+  static bool get _hasBridge =>
+      js_util.hasProperty(js_util.globalThis, '__dartPdfOcrRecognize');
+}
+
+class _BrowserOcrEngine implements PdfOcrEngine {
+  Future<void> warmUp() async {
+    await _recognizeDataUrl(
+      'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==',
+    );
+  }
+
+  @override
+  Future<List<PdfOcrSpan>> recognize(PdfOcrPageImage page) async {
+    final png = await _encodePng(page.image);
+    final result = await _recognizeDataUrl(
+      'data:image/png;base64,${base64Encode(png)}',
+    );
+    return _spansFromFlorence(result, page);
+  }
+
+  static List<PdfOcrSpan> _spansFromFlorence(
+    Object? result,
+    PdfOcrPageImage page,
+  ) {
+    final payload = _payload(result);
+    final labels = _listOfStrings(payload['labels']) ??
+        _listOfStrings(payload['text']) ??
+        _listOfStrings(payload['texts']);
+    final boxes = _listOfBoxes(payload['quad_boxes']) ??
+        _listOfBoxes(payload['quadBoxes']) ??
+        _listOfBoxes(payload['bboxes']) ??
+        _listOfBoxes(payload['boxes']);
+
+    if (labels != null && boxes != null) {
+      final spans = <PdfOcrSpan>[];
+      final count = labels.length < boxes.length ? labels.length : boxes.length;
+      for (var i = 0; i < count; i++) {
+        final text = labels[i].trim();
+        final rect = boxes[i];
+        if (text.isEmpty || rect.width <= 0 || rect.height <= 0) continue;
+        spans.add(PdfOcrSpan(
+          text: text,
+          bounds: page.userSpaceRect(rect),
+          confidence: 1,
+        ));
+      }
+      return spans;
+    }
+
+    final text = _plainText(payload).trim();
+    if (text.isEmpty) return const [];
+    return [
+      PdfOcrSpan(
+        text: text,
+        bounds: page.userSpaceRect(
+          Rect.fromLTWH(0, 0, page.width.toDouble(), page.height.toDouble()),
+        ),
+        confidence: 1,
+      ),
+    ];
+  }
+
+  static Map<String, Object?> _payload(Object? value) {
+    if (value is Map) {
+      final ocrWithRegion = value['<OCR_WITH_REGION>'];
+      if (ocrWithRegion is Map) return ocrWithRegion.cast<String, Object?>();
+      final ocr = value['<OCR>'];
+      if (ocr is Map) return ocr.cast<String, Object?>();
+      return value.cast<String, Object?>();
+    }
+    if (value is String) return {'text': value};
+    return const {};
+  }
+
+  static List<String>? _listOfStrings(Object? value) {
+    if (value is String) return [value];
+    if (value is! List) return null;
+    return [for (final item in value) if (item != null) item.toString()];
+  }
+
+  static List<Rect>? _listOfBoxes(Object? value) {
+    if (value is! List) return null;
+    final rects = <Rect>[];
+    for (final item in value) {
+      final rect = _rect(item);
+      if (rect != null) rects.add(rect);
+    }
+    return rects.isEmpty ? null : rects;
+  }
+
+  static Rect? _rect(Object? value) {
+    if (value is! List || value.length < 4) return null;
+    final nums = [for (final v in value) if (v is num) v.toDouble()];
+    if (nums.length < 4) return null;
+    if (nums.length >= 8) {
+      var minX = double.infinity, minY = double.infinity;
+      var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+      for (var i = 0; i + 1 < nums.length; i += 2) {
+        final x = nums[i], y = nums[i + 1];
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (x > maxX) maxX = x;
+        if (y > maxY) maxY = y;
+      }
+      return Rect.fromLTRB(minX, minY, maxX, maxY);
+    }
+    return Rect.fromLTRB(nums[0], nums[1], nums[2], nums[3]);
+  }
+
+  static String _plainText(Map<String, Object?> payload) {
+    for (final key in const ['text', 'ocr', 'generated_text']) {
+      final value = payload[key];
+      if (value is String) return value;
+    }
+    return '';
+  }
+
+  static Future<Uint8List> _encodePng(ui.Image image) async {
+    final data = await image.toByteData(format: ui.ImageByteFormat.png);
+    if (data == null) throw StateError('could not encode page raster to PNG');
+    return data.buffer.asUint8List();
+  }
+
+  static Future<Object?> _recognizeDataUrl(String dataUrl) async {
+    final promise = js_util.callMethod<Object?>(
+      js_util.globalThis,
+      '__dartPdfOcrRecognize',
+      [dataUrl],
+    );
+    final result = await js_util.promiseToFuture<Object?>(promise);
+    if (result is! String) {
+      throw StateError('browser OCR returned an unexpected response');
+    }
+    return jsonDecode(result);
+  }
+}
+
+class _WebOcrConfirmDialog extends StatelessWidget {
+  const _WebOcrConfirmDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const ValueKey('ocr-web-settings'),
+      title: const Text('Run AI OCR in this browser?'),
+      content: const ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: 520),
+        child: Text(
+          'Web OCR downloads a Florence-2 vision-language model and runs it '
+          'locally with WebGPU/WASM through Transformers.js. The PDF pages stay '
+          'in this browser; only model files are fetched on first use.',
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const ValueKey('ocr-web-start'),
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Start OCR'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/test/ocr_menu_test.dart
+++ b/app/test/ocr_menu_test.dart
@@ -1,7 +1,8 @@
-// The on-device OCR action is wired into the More menu when a document is
-// open and the platform supports it (flutter_test's default platform is
-// android, so OnDeviceOcr.isSupported is true). Running the full flow needs a
-// downloaded model + platform channels, so this only asserts the entry point.
+// The on-device OCR action is wired into the app bar and More menu when a
+// document is open and the platform supports it (flutter_test's default
+// platform is android, so OnDeviceOcr.isSupported is true). Running the full
+// flow needs a downloaded model + platform channels, so this only asserts the
+// entry point.
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -34,6 +35,9 @@ void main() {
       (tester) async {
     await pumpWithDoc(tester);
 
+    expect(find.byKey(const ValueKey('ocr-action')), findsOneWidget);
+    expect(find.byTooltip('Add on-device OCR text layer'), findsOneWidget);
+
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
 
@@ -51,5 +55,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('menu-ocr')), findsNothing);
+    expect(find.byKey(const ValueKey('ocr-action')), findsNothing);
   });
 }

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -103,6 +103,96 @@
     }
   </style>
 
+  <!-- Browser-local OCR bridge. Flutter web calls __dartPdfOcrRecognize with
+       a page image data URL. Transformers.js and Florence-2 are fetched lazily
+       on first use, then recognition runs in the browser rather than on an OCR
+       app server. -->
+  <script>
+    (function () {
+      var florencePromise = null;
+      async function hasWebGpuFp16() {
+        try {
+          if (!navigator.gpu) return false;
+          var adapter = await navigator.gpu.requestAdapter();
+          return !!(adapter && adapter.features &&
+            adapter.features.has('shader-f16'));
+        } catch (_) {
+          return false;
+        }
+      }
+      async function florence() {
+        if (!florencePromise) {
+          florencePromise = (async function () {
+            var transformers = await import(
+              'https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0'
+            );
+            var modelId = 'onnx-community/Florence-2-base-ft';
+            var processor = await transformers.AutoProcessor
+              .from_pretrained(modelId);
+            var tokenizer = await transformers.AutoTokenizer
+              .from_pretrained(modelId);
+            var fp16 = await hasWebGpuFp16();
+            var model = await transformers.Florence2ForConditionalGeneration
+              .from_pretrained(modelId, {
+                device: navigator.gpu ? 'webgpu' : 'wasm',
+                dtype: {
+                  embed_tokens: fp16 ? 'fp16' : 'fp32',
+                  vision_encoder: fp16 ? 'fp16' : 'fp32',
+                  encoder_model: 'q4',
+                  decoder_model_merged: 'q4'
+                }
+              });
+            var textInputs = tokenizer('a');
+            var pixelValues = transformers.full([1, 3, 768, 768], 0.0);
+            await model.generate({
+              ...textInputs,
+              pixel_values: pixelValues,
+              max_new_tokens: 1
+            });
+            return {
+              model: model,
+              processor: processor,
+              tokenizer: tokenizer,
+              RawImage: transformers.RawImage
+            };
+          })();
+        }
+        return florencePromise;
+      }
+      window.__dartPdfOcrRecognize = async function (imageDataUrl) {
+        var bundle = await florence();
+        var image = await bundle.RawImage?.fromURL?.(imageDataUrl);
+        if (!image) {
+          var transformers = await import(
+            'https://cdn.jsdelivr.net/npm/@huggingface/transformers@4.2.0'
+          );
+          image = await transformers.RawImage.fromURL(imageDataUrl);
+        }
+        var imageSize = image.size;
+        var visionInputs = await bundle.processor(image);
+        var task = '<OCR_WITH_REGION>';
+        var prompts = bundle.processor.construct_prompts(task);
+        var textInputs = bundle.tokenizer(prompts);
+        var generatedIds = await bundle.model.generate({
+          ...textInputs,
+          ...visionInputs,
+          max_new_tokens: 1024,
+          num_beams: 1,
+          do_sample: false
+        });
+        var generatedText = bundle.tokenizer.batch_decode(generatedIds, {
+          skip_special_tokens: false
+        })[0];
+        var result = bundle.processor.post_process_generation(
+          generatedText,
+          task,
+          imageSize
+        );
+        return JSON.stringify(result);
+      };
+    })();
+  </script>
+
   <!-- File Handling API bridge: when the installed PWA is launched to open a
        .pdf, buffer the file(s) until the Dart side registers a consumer, then
        forward each as { name, bytes }. -->


### PR DESCRIPTION
### Motivation

- Provide OCR capability in web builds without pulling native ONNX runtime into the web bundle by running recognition locally in the browser via a Florence-2 model bridge.
- Surface an appropriate UI description on web so users understand OCR runs in-browser instead of on-device native engines.
- Keep native/desktop behavior unchanged while offering a browser-specific implementation that integrates with the existing OCR APIs.

### Description

- Added `ocr_web.dart` implementing `OnDeviceOcr` for web that calls a JavaScript bridge, runs Florence-2 via Transformers.js, decodes results and returns `PdfOcrSpan`s to the editor.
- Updated `ocr.dart` export to choose `ocr_native.dart` for `dart:io`, `ocr_web.dart` for `dart:html`, and `ocr_stub.dart` otherwise by changing the conditional exports.
- Added a browser bridge script to `app/web/index.html` that lazily imports Transformers.js, loads the Florence-2 model, and exposes `__dartPdfOcrRecognize(imageDataUrl)` which returns OCR JSON to Dart.
- Adjusted the editor menu subtitle to show a web-specific message (`AI in-browser · selectable text over scans`) using `kIsWeb` and tightened some `const` usage in the menu `ListTile`.

### Testing

- Ran `flutter analyze` which completed without issues.
- Executed `flutter test` and existing unit/widget tests passed.
- Performed a web smoke build with `flutter build web` and verified the web bundle initializes and the OCR bridge function is present in `index.html` (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fc0d2911c832b84bc4eb59bd4aab1)