### PR TITLE
Defer app shell to speed web/WASM startup

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'editor_screen.dart';
@@ -19,6 +20,19 @@ class DartPdfEditorApp extends StatefulWidget {
 
 class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
   final _prefs = PdfEditingPreferences();
+
+  @override
+  void initState() {
+    super.initState();
+    // On web, point the render worker at its compiled script so page
+    // interpretation runs in a dedicated Web Worker (built by tool/build_web.sh;
+    // see doc/render_worker_web.md). Ignored on native, where the background
+    // isolate needs no script. With no compiled script present the worker simply
+    // degrades to local rendering, so this is safe even before a worker build.
+    if (kIsWeb) {
+      pdfRenderWorkerScriptUrl = 'pdf_render_worker.dart.js';
+    }
+  }
 
   @override
   void dispose() {

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,9 +1,9 @@
-import 'package:dart_pdf_editor/dart_pdf_editor.dart';
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
-import 'app.dart';
-import 'app_info.dart';
+import 'app.dart' deferred as app;
+import 'app_info.dart' deferred as app_info;
 
 /// On Windows and Linux the OS launches the app with the opened file as a
 /// command-line argument; the Flutter runner forwards it here.
@@ -11,18 +11,129 @@ Future<void> main(List<String> args) async {
   // PackageInfo (loaded below) needs the binding; ensure it before awaiting.
   WidgetsFlutterBinding.ensureInitialized();
 
-  // On web, point the render worker at its compiled script so page
-  // interpretation runs in a dedicated Web Worker (built by tool/build_web.sh;
-  // see doc/render_worker_web.md). Ignored on native, where the background
-  // isolate needs no script. With no compiled script present the worker simply
-  // degrades to local rendering, so this is safe even before a worker build.
-  if (kIsWeb) {
-    pdfRenderWorkerScriptUrl = 'pdf_render_worker.dart.js';
+  runApp(_DeferredApp(launchArgs: args));
+
+  // Do not block first paint or the initial loading unit on package metadata.
+  // The About box refreshes from this best-effort value after the shell is
+  // already on screen.
+  unawaited(_loadAppInfo());
+}
+
+Future<void> _loadAppInfo() async {
+  try {
+    await app_info.loadLibrary();
+    await app_info.AppInfo.load();
+  } catch (_) {
+    // Keep the fallback; the About box is non-critical.
+  }
+}
+
+class _DeferredApp extends StatefulWidget {
+  const _DeferredApp({required this.launchArgs});
+
+  final List<String> launchArgs;
+
+  @override
+  State<_DeferredApp> createState() => _DeferredAppState();
+}
+
+class _DeferredAppState extends State<_DeferredApp> {
+  Object? _error;
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
   }
 
-  // Resolve the About-box version from the build artifact so it tracks the
-  // pubspec version automatically. Best-effort; never blocks startup on error.
-  await AppInfo.load();
+  Future<void> _load() async {
+    try {
+      await app.loadLibrary();
+      if (mounted) setState(() => _loaded = true);
+    } catch (e) {
+      if (mounted) setState(() => _error = e);
+    }
+  }
 
-  runApp(DartPdfEditorApp(launchArgs: args));
+  @override
+  Widget build(BuildContext context) {
+    if (_loaded) {
+      return app.DartPdfEditorApp(launchArgs: widget.launchArgs);
+    }
+    return MaterialApp(
+      title: 'DartPDF',
+      theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
+      darkTheme: ThemeData(
+        colorSchemeSeed: Colors.indigo,
+        brightness: Brightness.dark,
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        body: Center(
+          child: _error == null
+              ? const _StartupIndicator()
+              : _StartupError(error: _error!),
+        ),
+      ),
+    );
+  }
+}
+
+class _StartupIndicator extends StatelessWidget {
+  const _StartupIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.picture_as_pdf_outlined, size: 56, color: colors.primary),
+        const SizedBox(height: 24),
+        const SizedBox(
+          width: 32,
+          height: 32,
+          child: CircularProgressIndicator(strokeWidth: 3),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Loading DartPDF…',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+      ],
+    );
+  }
+}
+
+class _StartupError extends StatelessWidget {
+  const _StartupError({required this.error});
+
+  final Object error;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.error_outline, size: 48, color: colors.error),
+          const SizedBox(height: 16),
+          Text(
+            'DartPDF failed to load',
+            style: Theme.of(context).textTheme.titleLarge,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '$error',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
 }


### PR DESCRIPTION
### Motivation
- The web/WASM initial load was slow because the full editor stack (large Flutter/Dart code) was pulled into the first loading unit and blocked first paint.
- Improve perceived startup time and reduce the size of the initial loading unit by deferring heavy editor code until after a lightweight shell is shown.

### Description
- Split the app entrypoint so the full editor is behind a deferred import: `import 'app.dart' deferred as app;` and `import 'app_info.dart' deferred as app_info;` in `app/lib/main.dart`.
- Replace the blocking startup with a minimal startup UI that immediately paints a progress/error indicator while the deferred `app` library is loaded in the background (`_DeferredApp` + `_StartupIndicator` / `_StartupError`).
- Make package metadata loading best-effort and non-blocking by moving `AppInfo.load()` to a background helper `_loadAppInfo()` that uses a deferred import so `package_info_plus` is not pulled into the initial unit.
- Move the web render-worker URL configuration (`pdfRenderWorkerScriptUrl = 'pdf_render_worker.dart.js'`) into `app/lib/app.dart` `initState()` so the main entrypoint no longer depends on the full editor package.

### Testing
- `git diff --check` passed locally after the change.
- Changes were committed successfully with the message `Improve web startup load`.
- `dart analyze` / `fvm`-based analysis and `dart format` could not be executed in this environment because `dart`/`fvm` are not available on `PATH`, so static analysis was not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fd8088384832b9d8f8bb8e5e437a7)