### PR TITLE
Optimize batch annotation deletion

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2039,8 +2039,12 @@ class PdfEditingController extends ChangeNotifier {
     // surviving annotations may land in different slots
     _selected.clear();
     apply((e) {
+      final byPage = <int, List<PdfAnnotation>>{};
       for (final (page, annotation) in targets) {
-        e.removeAnnotation(page, annotation);
+        (byPage[page] ??= []).add(annotation);
+      }
+      for (final entry in byPage.entries) {
+        e.removeAnnotations(entry.key, entry.value);
       }
     }, pages: [for (final (page, _) in targets) page]);
   }

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1486,17 +1486,33 @@ extension PdfAnnotationEditing on PdfEditor {
 
   /// Removes [annotation] from the page, along with its popup, if any.
   void removeAnnotation(int pageIndex, PdfAnnotation annotation) {
+    removeAnnotations(pageIndex, [annotation]);
+  }
+
+  /// Removes [annotations] from the page, along with their popups, if any.
+  ///
+  /// This is equivalent to calling [removeAnnotation] for every annotation,
+  /// but scans and rewrites the page's /Annots array once. Use it for
+  /// multi-select deletes so large annotation sets do not pay an O(n × m)
+  /// identity scan plus one staged replacement per removed item.
+  void removeAnnotations(
+      int pageIndex, Iterable<PdfAnnotation> annotations) {
     final cos = document.cos;
     final page = document.page(pageIndex);
     final raw = page.dict['Annots'];
     final array = cos.resolve(raw);
     if (array is! CosArray) return;
-    final popup = cos.resolve(annotation.dict['Popup']);
+    final targets = Set<CosDictionary>.identity();
+    for (final annotation in annotations) {
+      targets.add(annotation.dict);
+      final popup = cos.resolve(annotation.dict['Popup']);
+      if (popup is CosDictionary) targets.add(popup);
+    }
+    if (targets.isEmpty) return;
     final before = array.items.length;
     array.items.removeWhere((item) {
       final resolved = cos.resolve(item);
-      return identical(resolved, annotation.dict) ||
-          (popup is CosDictionary && identical(resolved, popup));
+      return resolved is CosDictionary && targets.contains(resolved);
     });
     if (array.items.length == before) return;
     if (raw is CosReference) {

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -430,6 +430,25 @@ void main() {
     expect(reopened.page(0).annotations.length, before - 1);
   });
 
+  test('removeAnnotations deletes multiple annotations in one edit', () {
+    final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
+      ..addSquare(0, const PdfRect(100, 100, 200, 150))
+      ..addNote(0, 300, 700, 'remove me')
+      ..addCircle(0, const PdfRect(250, 100, 350, 150))
+      ..addFreeText(0, const PdfRect(120, 500, 260, 540), 'keep me');
+    final doc = PdfDocument.open(first.save());
+    final annotations = doc.page(0).annotations;
+
+    final editor = PdfEditor(doc)
+      ..removeAnnotations(0, [annotations[0], annotations[1], annotations[2]]);
+    final reopened = PdfDocument.open(editor.save());
+
+    final remaining = reopened.page(0).annotations;
+    expect(remaining, hasLength(1));
+    expect(remaining.single.subtype, 'FreeText');
+    expect(remaining.single.contents, 'keep me');
+  });
+
   test('bringAnnotationsToFront moves entries to the end of /Annots', () {
     final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
       ..addSquare(0, const PdfRect(100, 100, 200, 150))


### PR DESCRIPTION
### Motivation
- Multi-select / sidebar deletes were performing repeated per-annotation scans and staged replacements of the page `/Annots` array, causing noticeable delay for large selections.
- The goal is to scan/rewrite the page's `/Annots` array once per page for batch deletes and reduce the O(n × m) work performed for multi-item removals.

### Description
- Add `PdfEditor.removeAnnotations(int pageIndex, Iterable<PdfAnnotation>)` which removes many annotations (and their popups) with a single scan/rewrite of the page `/Annots` array; `removeAnnotation` delegates to this new batch API for consistency (`packages/pdf_document/lib/src/annotation_editor.dart`).
- Update `PdfEditingController.deleteAnnotations` to group selected targets by page and call the new `removeAnnotations` per page so one editor save handles each page's removals (`packages/dart_pdf_editor/lib/src/editing/editing_controller.dart`).
- Add a unit test covering multi-annotation deletion that verifies the expected surviving annotation (`packages/pdf_document/test/annotation_editor_test.dart`).

### Testing
- Ran static analysis with `dart analyze` and it reported no issues.
- Ran unit tests: `cd packages/pdf_document && dart test test/annotation_editor_test.dart` and `cd packages/dart_pdf_editor && flutter test test/editing_readonly_test.dart`, both passed.
- Performed an ad-hoc benchmark removing 300 annotations showing median single-item deletes = `~34,329µs` vs batched delete = `~9,585µs`, a ~`3.6×` speedup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3084891f78832bb7dc4041af3ea9e4)