### PR TITLE
Add content-delete drag tool (Bluebeam-style)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -97,6 +97,11 @@ enum PdfEditTool {
   /// content stream itself, not annotations.
   content,
 
+  /// Drag a rectangular region to delete every page-content element whose
+  /// bounds overlap it, like Bluebeam's content erase/delete tool. This
+  /// edits the page's content stream directly and ignores annotations.
+  contentDelete,
+
   /// Interactive forms: tap a field widget to fill it (text fields open
   /// an inline editor, check boxes and radio buttons toggle, choice
   /// fields offer their options), drag on empty page area to add a new
@@ -532,7 +537,13 @@ class PdfEditingController extends ChangeNotifier {
         PdfEditTool.rectangle ||
         PdfEditTool.ellipse ||
         PdfEditTool.polygon =>
-          const {'color', 'strokeWidth', 'opacity', 'lineStyle', 'shapeFillColor'},
+          const {
+            'color',
+            'strokeWidth',
+            'opacity',
+            'lineStyle',
+            'shapeFillColor'
+          },
         PdfEditTool.line || PdfEditTool.polyline => const {
             'color',
             'strokeWidth',
@@ -541,8 +552,12 @@ class PdfEditingController extends ChangeNotifier {
             'lineStartEnding',
             'lineEndEnding',
           },
-        PdfEditTool.arrow =>
-          const {'color', 'strokeWidth', 'opacity', 'lineStyle'},
+        PdfEditTool.arrow => const {
+            'color',
+            'strokeWidth',
+            'opacity',
+            'lineStyle'
+          },
         PdfEditTool.measureDistance ||
         PdfEditTool.measurePerimeter ||
         PdfEditTool.measureArea =>
@@ -950,9 +965,9 @@ class PdfEditingController extends ChangeNotifier {
   /// Marks a single rectangular region for redaction (a /Redact
   /// annotation, fill black). This is the MARK phase — nothing is removed
   /// until [applyRedactions]. Undoable like any other edit until burned.
-  void addRedaction(int pageIndex, PdfRect rect) => apply(
-      (e) => e.addRedaction(pageIndex, [rect], author: author),
-      pages: [pageIndex]);
+  void addRedaction(int pageIndex, PdfRect rect) =>
+      apply((e) => e.addRedaction(pageIndex, [rect], author: author),
+          pages: [pageIndex]);
 
   /// Marks the text runs in [quadsByPage] for redaction (one /Redact
   /// annotation per page, fill black), e.g. from a text selection. Mirrors
@@ -1034,9 +1049,8 @@ class PdfEditingController extends ChangeNotifier {
               dashPattern: _lineDashPattern,
               startEnding:
                   arrow ? PdfLineEnding.none : preferences.lineStartEnding,
-              endEnding: arrow
-                  ? PdfLineEnding.closedArrow
-                  : preferences.lineEndEnding,
+              endEnding:
+                  arrow ? PdfLineEnding.closedArrow : preferences.lineEndEnding,
               author: author),
           pages: [pageIndex]);
 
@@ -1393,8 +1407,8 @@ class PdfEditingController extends ChangeNotifier {
     final cx = x.clamp(box.left + s / 2, box.right - s / 2);
     final cy = y.clamp(box.bottom + s / 2, box.top - s / 2);
     return apply(
-        (e) => e.addCheckMark(pageIndex,
-            PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
+        (e) => e.addCheckMark(
+            pageIndex, PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
             color: _colorValue, opacity: preferences.opacity, author: author),
         pages: [pageIndex]);
   }
@@ -1583,9 +1597,8 @@ class PdfEditingController extends ChangeNotifier {
   /// returns false) when nothing is selected or the selection would empty
   /// the document — at least one page must remain. Clears the selection.
   bool removeSelectedPages() {
-    final doomed = _selectedPages
-        .where((i) => i >= 0 && i < _document.pageCount)
-        .toList();
+    final doomed =
+        _selectedPages.where((i) => i >= 0 && i < _document.pageCount).toList();
     if (doomed.isEmpty || doomed.length >= _document.pageCount) return false;
     _selected.clear();
     _selectedPages.clear();
@@ -2690,8 +2703,7 @@ class PdfEditingController extends ChangeNotifier {
   /// /PolyLine in place — one revision, one undo, and the annotation
   /// keeps its /Annots slot and object number. Pass null for an axis to
   /// leave it unchanged.
-  void setSelectedLineEndings(
-      {PdfLineEnding? start, PdfLineEnding? end}) {
+  void setSelectedLineEndings({PdfLineEnding? start, PdfLineEnding? end}) {
     final annotation = selectedAnnotation;
     if (annotation == null || !canSetLineEndings) return;
     apply(
@@ -3002,6 +3014,27 @@ class PdfEditingController extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool _intersects(PdfRect a, PdfRect b) {
+    final hit = a.intersect(b);
+    return hit.width > 0 && hit.height > 0;
+  }
+
+  /// Deletes every bounded page-content element that overlaps [rect].
+  /// Returns the number of elements removed. Unbounded elements (for
+  /// example full-page shadings whose geometry could not be tracked) are
+  /// left alone so a region drag only affects visible content in the box.
+  int deleteElementsInRect(int pageIndex, PdfRect rect) {
+    final elements = elementsOn(pageIndex);
+    final ids = [
+      for (final element in elements.elements)
+        if (element.bounds case final bounds? when _intersects(bounds, rect))
+          element.id,
+    ];
+    if (ids.isEmpty) return 0;
+    apply((e) => e.deleteElements(elements, ids), pages: [pageIndex]);
+    return ids.length;
+  }
+
   /// Deletes the selected content element from its page's content stream.
   void deleteSelectedElement() {
     final selected = _selectedElement;
@@ -3086,8 +3119,7 @@ class PdfEditingController extends ChangeNotifier {
     final form = acroForm;
     if (form == null) return const [];
     final annotations = _page(pageIndex).annotations;
-    final result =
-        <(PdfFormField, int, PdfAnnotation)>[];
+    final result = <(PdfFormField, int, PdfAnnotation)>[];
     for (final annotation in annotations) {
       if (annotation.subtype != 'Widget' ||
           annotation.isHidden ||

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -512,9 +512,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// A finger should pan the viewer (not draw): the draw tool is armed
   /// but finger-drawing is off, so touch is reserved for scrolling.
   bool get _fingerPansViewport =>
-      _drawTool &&
-      !_controller.fingerDrawsInk &&
-      widget.onPanViewport != null;
+      _drawTool && !_controller.fingerDrawsInk && widget.onPanViewport != null;
   bool get _polyTool =>
       _tool == PdfEditTool.polyline ||
       _tool == PdfEditTool.polygon ||
@@ -782,8 +780,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             slot,
             () => (
                   strokes: strokes,
-                  pressures:
-                      List<List<double>?>.filled(strokes.length, null),
+                  pressures: List<List<double>?>.filled(strokes.length, null),
                   color: const Color(0xFF000000),
                   strokeWidth:
                       (annotation.borderWidth ?? 1) * _geometry.scale * 1.7 + 4,
@@ -1679,7 +1676,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             PdfEditTool.stamp ||
             PdfEditTool.image ||
             PdfEditTool.redact ||
-            PdfEditTool.snapshot:
+            PdfEditTool.snapshot ||
+            PdfEditTool.contentDelete:
         setState(() {
           _dragStart = position;
           _dragCurrent = position;
@@ -1913,10 +1911,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // pointer delta rotates into the local frame
         final delta = position - _moveStart!;
         // holding Shift locks the original aspect ratio
-        final aspectRatio = HardwareKeyboard.instance.isShiftPressed &&
-                _resizeFrom!.height > 0
-            ? _resizeFrom!.width / _resizeFrom!.height
-            : null;
+        final aspectRatio =
+            HardwareKeyboard.instance.isShiftPressed && _resizeFrom!.height > 0
+                ? _resizeFrom!.width / _resizeFrom!.height
+                : null;
         final (resized, flipX, flipY) = _resizedRect(
             _resizeFrom!,
             _resizeHandle!,
@@ -2341,12 +2339,13 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             _controller.newFormFieldKind, widget.pageIndex, rect);
       case PdfEditTool.redact:
         _controller.addRedaction(widget.pageIndex, rect);
+      case PdfEditTool.contentDelete:
+        _controller.deleteElementsInRect(widget.pageIndex, rect);
       case PdfEditTool.snapshot:
         // always keep a vector copy on the clipboard so it can paste back
         // into the PDF (⌘V / the paste menu), Bluebeam-style; the host
         // callback is an optional export of the raster image on top
-        final vector =
-            _controller.copyVectorSnapshot(widget.pageIndex, rect);
+        final vector = _controller.copyVectorSnapshot(widget.pageIndex, rect);
         final handler = widget.onSnapshot;
         if (handler == null) return;
         // page raster space (post-/Rotate, y down) = view space / scale —
@@ -2354,7 +2353,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         final s = _geometry.scale;
         final region = Rect.fromLTRB(viewRect.left / s, viewRect.top / s,
             viewRect.right / s, viewRect.bottom / s);
-        final bytes = await _controller.captureSnapshot(widget.pageIndex, region,
+        final bytes = await _controller.captureSnapshot(
+            widget.pageIndex, region,
             pageColor: widget.pageColor, annotations: widget.showAnnotations);
         if (bytes == null || !mounted) return;
         await handler(
@@ -2988,11 +2988,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // a Square/Circle resize regenerates at a constant stroke width:
     // preview that (live during the drag, then the frozen afterimage)
     // instead of the ghost, whose line would stretch and snap back
-    final shapeResize = wrapResize == null &&
-            _resizeHandle != null &&
-            _resizeRect != null
-        ? _shapeResizeStyle(_resizeRect!, _resizeAngle)
-        : _afterShapeResize;
+    final shapeResize =
+        wrapResize == null && _resizeHandle != null && _resizeRect != null
+            ? _shapeResizeStyle(_resizeRect!, _resizeAngle)
+            : _afterShapeResize;
     // strokes beyond the pending ink: the committed-ink afterimage (held
     // until the new raster lands) and the signature tool's live preview
     final committedInk = widget.rasterCurrent
@@ -3166,8 +3165,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                         _marqueeStart != null && _marqueeCurrent != null
                             ? Rect.fromPoints(_marqueeStart!, _marqueeCurrent!)
                             : null,
-                    ghost:
-                        wrapResize == null && shapeResize == null ? _ghost : null,
+                    ghost: wrapResize == null && shapeResize == null
+                        ? _ghost
+                        : null,
                     shapeResize: shapeResize,
                     ghostFrom: _resizeHandle != null && _resizeAngle != 0
                         ? _resizeFrom
@@ -3184,7 +3184,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     // free-text resize lift: hide the original box's
                     // footprint with the page rendered without it (or an
                     // opaque-paper wash until that lands)
-                    resizeClean: wrapResize != null ? _resizeCleanPicture : null,
+                    resizeClean:
+                        wrapResize != null ? _resizeCleanPicture : null,
                     resizeHideRect: wrapResize != null ? _resizeFrom : null,
                     resizeHideAngle: _resizeAngle,
                     resizeHideWash: Color.alphaBlend(
@@ -3498,8 +3499,8 @@ void _paintInkStrokes(
         final c1 = geometry.toViewOffset(c1x, c1y);
         final c2 = geometry.toViewOffset(c2x, c2y);
         final b = geometry.toViewOffset(stroke[i + 1].$1, stroke[i + 1].$2);
-        segment.strokeWidth = pdfInkStrokeWidth(
-            strokeWidth, (pressure[i] + pressure[i + 1]) / 2);
+        segment.strokeWidth =
+            pdfInkStrokeWidth(strokeWidth, (pressure[i] + pressure[i + 1]) / 2);
         canvas.drawPath(
             Path()
               ..moveTo(a.dx, a.dy)
@@ -3829,6 +3830,16 @@ class _EditingPreviewPainter extends CustomPainter {
               ..strokeWidth = 1);
       case PdfEditTool.redact:
         paintRedactionHatch(canvas, rect);
+      case PdfEditTool.contentDelete:
+        // Same region marquee as Snapshot, but orange to signal permanent
+        // page-content edits rather than a read-only capture.
+        canvas.drawRect(rect, Paint()..color = _elementChrome.withAlpha(0x1A));
+        canvas.drawRect(
+            rect,
+            Paint()
+              ..color = _elementChrome
+              ..style = PaintingStyle.stroke
+              ..strokeWidth = 1 * chromeScale);
       case PdfEditTool.snapshot:
         // a selection marquee, like the region grab in a screenshot tool
         canvas.drawRect(rect, Paint()..color = _chrome.withAlpha(0x1A));
@@ -3859,10 +3870,8 @@ class _EditingPreviewPainter extends CustomPainter {
     }
     final layered = s.opacity < 1;
     if (layered) {
-      canvas.saveLayer(
-          s.rect.inflate(s.strokeWidth + 2),
-          Paint()
-            ..color = Color.fromRGBO(0, 0, 0, s.opacity.clamp(0.0, 1.0)));
+      canvas.saveLayer(s.rect.inflate(s.strokeWidth + 2),
+          Paint()..color = Color.fromRGBO(0, 0, 0, s.opacity.clamp(0.0, 1.0)));
     }
     final stroking = s.stroke != null && s.strokeWidth > 0;
     final inset = stroking ? s.strokeWidth / 2 : 0.0;
@@ -4227,8 +4236,8 @@ class _EditingPreviewPainter extends CustomPainter {
     final pen = penCursor;
     if (pen != null) {
       final r = math.max(strokeWidth / 2, 1.5 * chromeScale);
-      canvas.drawCircle(pen, r + 1.5 * chromeScale,
-          Paint()..color = const Color(0x33000000));
+      canvas.drawCircle(
+          pen, r + 1.5 * chromeScale, Paint()..color = const Color(0x33000000));
       canvas.drawCircle(
           pen, r, Paint()..color = color.withValues(alpha: penOpacity));
       canvas.drawCircle(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -297,6 +297,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     _ToolGroup('edit', 'Edit', Icons.design_services, [
       _GroupTool.tool(
           PdfEditTool.content, Icons.format_shapes, 'Edit page content'),
+      _GroupTool.tool(PdfEditTool.contentDelete, Icons.content_cut,
+          'Delete content — drag a region to remove page content'),
       _GroupTool.tool(PdfEditTool.form, Icons.ballot_outlined,
           'Form fields — tap to select, double-tap to fill, drag to add'),
       _GroupTool.tool(PdfEditTool.redact, Icons.gradient,
@@ -731,6 +733,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           icon: entry.icon,
           label: switch (tool) {
             PdfEditTool.content => 'Content',
+            PdfEditTool.contentDelete => 'Delete',
             PdfEditTool.form => 'Form',
             PdfEditTool.redact => 'Redact',
             PdfEditTool.snapshot => 'Snapshot',

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -304,6 +304,18 @@ void main() {
       expect(editing.elementsOn(0).elements.single.text, 'Page 1');
     });
 
+    test('deleteElementsInRect removes bounded content in a region', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      expect(
+          editing.deleteElementsInRect(0, const PdfRect(70, 715, 160, 750)), 1);
+      expect(editing.elementsOn(0).elements, isEmpty);
+
+      editing.undo();
+      expect(editing.deleteElementsInRect(0, const PdfRect(300, 300, 360, 360)),
+          0);
+      expect(editing.elementsOn(0).elements.single.text, 'Page 1');
+    });
+
     test('arming a non-content tool clears the element selection', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..tool = PdfEditTool.content;
@@ -860,6 +872,17 @@ void main() {
       await tester.tapAt(view(80, 725));
       await settle(tester);
       await tester.sendKeyEvent(LogicalKeyboardKey.delete);
+      await settle(tester);
+      expect(editing.elementsOn(0).elements, isEmpty);
+    });
+
+    testWidgets('the content delete tool drags a region to remove content',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester, pages: 1);
+      editing.tool = PdfEditTool.contentDelete;
+      await tester.pump();
+
+      await drag(tester, view(60, 755), view(180, 705));
       await settle(tester);
       expect(editing.elementsOn(0).elements, isEmpty);
     });


### PR DESCRIPTION
### Motivation
- Provide a Bluebeam-like content delete tool that erases page content (text/paths/images/forms) inside a dragged rectangular region instead of operating on annotations or producing a read-only snapshot. This complements the existing Snapshot tool and the single-element content editor.

### Description
- Add a new tool value `PdfEditTool.contentDelete` to the editing tool enum so it can be armed like other tools.
- Implement `PdfEditingController.deleteElementsInRect(pageIndex, rect)` with an `_intersects` helper; it collects bounded `PdfContentElement` ids whose bounds intersect the region and applies a single undoable edit via `PdfEditor.deleteElements`.
- Wire the editing overlay to start/track drag regions for `contentDelete`, commit the controller call on release, and render the drag marquee using an orange element-chrome so the UI reads as permanent page-content editing (marquee behavior mirrors `snapshot`).
- Expose the tool in the Edit toolbar (desktop/mobile labeled entry) and add unit/widget tests that cover controller behavior and in-view drag deletion.

### Testing
- Ran static analysis with `~/fvm/versions/3.44.2/bin/dart analyze` and it reported no issues. (No analyzer errors.)
- Ran widget/unit tests: `cd packages/dart_pdf_editor && ~/fvm/versions/3.44.2/bin/flutter test test/editing_snapshot_test.dart test/editing_test.dart` and `cd packages/dart_pdf_editor && ~/fvm/versions/3.44.2/bin/flutter test test/editing_test.dart`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308482399c832b8722adea76d4f356)