### PR TITLE
Add shell zoom controls

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -694,6 +694,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: PdfPageNumberField(controller: _viewer),
                     ),
+                  if (!reflowActive) PdfShellZoomControl(controller: _viewer),
                   if (features.search && !reflowActive) ...[
                     PdfSearchField(
                       controller: _viewer,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -305,6 +305,8 @@ class _PdfReaderState extends State<PdfReader> {
                       padding: const EdgeInsets.symmetric(horizontal: 12),
                       child: PdfPageNumberField(controller: _viewer),
                     ),
+                  if (!prefs.showReflowView)
+                    PdfShellZoomControl(controller: _viewer),
                 ],
                 trailing: [
                   if (features.viewOptions)

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -207,6 +207,17 @@ class PdfViewerController extends ChangeNotifier {
 
   Future<void> jumpToPage(int index) async => _state?._jumpToPage(index);
 
+  /// Sets the viewer zoom around the center of the viewport.
+  ///
+  /// A zoom of 1 is fit-width/100%; values below 1 zoom out by relaying
+  /// the pages, and values above 1 zoom into a movable window over the
+  /// fit-width layout. The value is clamped to the attached viewer's
+  /// [PdfViewer.minZoom] and [PdfViewer.maxZoom].
+  void setZoom(double zoom) => _state?._setZoomFromController(zoom);
+
+  /// Resets the zoom to fit-width/100% around the center of the viewport.
+  void resetZoom() => setZoom(1);
+
   /// Scrolls — and zooms in when that helps — so [rect] (page space on
   /// [pageIndex]) sits centered in the viewport, filling around 40% of
   /// it. Never zooms out below 100% or in past [PdfViewer.maxZoom]. The
@@ -945,6 +956,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// InteractiveViewer transform (a window over fit-width pages); at or
   /// below 1 the pages themselves lay out smaller, so zooming out shows
   /// more of the document rather than a shrunken viewport.
+  void _setZoomFromController(double target) {
+    _zoomTo(target, Offset(_viewWidth / 2, _viewHeight / 2));
+  }
+
   void _zoomTo(double target, Offset focal) {
     final zoom = target.clamp(widget.minZoom, widget.maxZoom);
     if (zoom <= 1) {

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -457,6 +457,97 @@ class PdfShellBar extends StatelessWidget {
   }
 }
 
+class PdfShellZoomControl extends StatefulWidget {
+  const PdfShellZoomControl({super.key, required this.controller});
+
+  final PdfViewerController controller;
+
+  @override
+  State<PdfShellZoomControl> createState() => _PdfShellZoomControlState();
+}
+
+class _PdfShellZoomControlState extends State<PdfShellZoomControl> {
+  static const List<double> _presets = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.viewportChanges.addListener(_changed);
+  }
+
+  @override
+  void didUpdateWidget(PdfShellZoomControl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller) return;
+    oldWidget.controller.viewportChanges.removeListener(_changed);
+    widget.controller.viewportChanges.addListener(_changed);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.viewportChanges.removeListener(_changed);
+    super.dispose();
+  }
+
+  void _changed() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final zoom = widget.controller.zoom;
+    final percent = (zoom * 100).round();
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        PopupMenuButton<double>(
+          key: const ValueKey('pdf-shell-zoom-menu'),
+          tooltip: 'Zoom',
+          initialValue: _nearestPreset(zoom),
+          onSelected: widget.controller.setZoom,
+          itemBuilder: (context) => [
+            for (final value in _presets)
+              PopupMenuItem<double>(
+                key: ValueKey('pdf-shell-zoom-${(value * 100).round()}'),
+                value: value,
+                child: Text('${(value * 100).round()}%'),
+              ),
+          ],
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '$percent%',
+                  key: const ValueKey('pdf-shell-zoom-label'),
+                  style: Theme.of(context).textTheme.labelLarge,
+                ),
+                const Icon(Icons.arrow_drop_down),
+              ],
+            ),
+          ),
+        ),
+        IconButton(
+          key: const ValueKey('pdf-shell-zoom-reset'),
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.fit_screen),
+          tooltip: 'Reset zoom',
+          onPressed:
+              (zoom - 1).abs() < 0.005 ? null : widget.controller.resetZoom,
+        ),
+      ],
+    );
+  }
+
+  double? _nearestPreset(double zoom) {
+    for (final value in _presets) {
+      if ((value - zoom).abs() < 0.005) return value;
+    }
+    return null;
+  }
+}
+
 class _ShellSheetSectionLabel extends StatelessWidget {
   const _ShellSheetSectionLabel(this.text);
 

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -42,11 +42,38 @@ void main() {
           find.byKey(const ValueKey('pdf-page-number-field')), findsOneWidget);
       expect(
           find.byKey(const ValueKey('pdf-shell-view-options')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-zoom-menu')), findsOneWidget);
+      expect(
+          find.byKey(const ValueKey('pdf-shell-zoom-reset')), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-shell-thumbnails-toggle')),
           findsOneWidget);
       // view-only: no editing toolbar anywhere
       expect(find.byType(PdfEditingToolbar), findsNothing);
       expect(find.byType(PdfViewer), findsOneWidget);
+    });
+
+    testWidgets('zoom menu changes and resets viewer zoom', (tester) async {
+      final viewer = PdfViewerController();
+      addTearDown(viewer.dispose);
+      await pump(
+          tester, PdfReader(bytes: buildMultiPagePdf(2), controller: viewer));
+
+      expect(
+          find.byKey(const ValueKey('pdf-shell-zoom-label')), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-menu')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-150')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(viewer.zoom, closeTo(1.5, 0.01));
+      expect(find.text('150%'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-reset')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(viewer.zoom, closeTo(1, 0.01));
+      expect(find.text('100%'), findsOneWidget);
     });
 
     testWidgets('PdfReaderFeatures.none leaves just the pages', (tester) async {


### PR DESCRIPTION
### Motivation
- Provide a user-facing zoom percentage control in the shell header so users can explicitly choose common zoom levels and quickly reset to fit-width/100%.
- Expose a simple programmatic API on the viewer controller so the shell can drive the viewer zoom centered on the viewport.

### Description
- Added public `PdfViewerController.setZoom(double)` and `PdfViewerController.resetZoom()` which drive an internal `_setZoomFromController` (centered on the viewport) and integrate with the existing layout/transform zoom behavior in `pdf_viewer.dart`.
- Implemented `PdfShellZoomControl` (dropdown + reset button) with common presets (50/75/100/125/150/200/300/400%) and wired it into the shell header in both `PdfEditorView` and `PdfReader` when not in reflow mode (`shell_chrome.dart`, `pdf_editor_view.dart`, `pdf_reader.dart`).
- Added widget tests that assert the zoom control presence, selecting a preset changes the attached `PdfViewerController.zoom`, and the reset button returns zoom to 100% (`packages/dart_pdf_editor/test/pdf_shell_test.dart`).

### Testing
- Ran static analysis with `~/fvm/versions/3.44.2/bin/dart analyze`, which reported no issues and succeeded. 
- Ran the shell widget tests with `cd packages/dart_pdf_editor && ~/fvm/versions/3.44.2/bin/flutter test test/pdf_shell_test.dart`, and the suite passed (including the new zoom-presets and reset assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308473d8d8832ba6beda7b36e4f9da)