### PR TITLE
Defer ink commit when switching to eraser to avoid UI jank

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -454,8 +454,22 @@ class PdfEditingController extends ChangeNotifier {
 
   set tool(PdfEditTool? value) {
     if (value == _tool) return;
-    // leaving the ink tool commits the drawing, like lifting the pen
-    if (_tool == PdfEditTool.ink && value != PdfEditTool.ink) finishInk();
+    // leaving the ink tool commits the drawing, like lifting the pen.
+    //
+    // Switching directly from ink to the eraser is the latency-sensitive
+    // path used by Apple Pencil double-tap.  A pending ink commit can rewrite
+    // the PDF and trigger a raster refresh, which made the eraser button feel
+    // sticky.  Arm the eraser and repaint the toolbar/cursor first, then let
+    // the commit run in the next event-loop turn; the ink is still committed
+    // before any subsequent pointer event can erase it.
+    final deferInkCommit = _tool == PdfEditTool.ink &&
+        value == PdfEditTool.eraser &&
+        hasPendingInk;
+    if (_tool == PdfEditTool.ink &&
+        value != PdfEditTool.ink &&
+        !deferInkCommit) {
+      finishInk();
+    }
     // arming anything but the eraser by other means breaks the pencil
     // double-tap pairing (see [togglePencilEraser]) — the remembered tool
     // is only valid while the eraser stays the toggled-on partner
@@ -469,6 +483,7 @@ class PdfEditingController extends ChangeNotifier {
     preferences.beginStyleScope(
         _styleScopeKey(value), _styleScopeFields(value));
     notifyListeners();
+    if (deferInkCommit) Timer.run(finishInk);
   }
 
   // Apple Pencil double-tap eraser toggle: the tool that was armed when the

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -143,6 +143,23 @@ void main() {
       expect(editing.document.page(0).annotations.single.subtype, 'Ink');
     });
 
+    test('switching from ink to eraser defers the pending drawing commit',
+        () async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..tool = PdfEditTool.ink
+        ..addInkStroke(0, [(100, 100), (150, 130)])
+        ..tool = PdfEditTool.eraser;
+
+      expect(editing.tool, PdfEditTool.eraser);
+      expect(editing.hasPendingInk, isTrue,
+          reason: 'the eraser should arm before the PDF rewrite runs');
+      expect(editing.document.page(0).annotations, isEmpty);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(editing.hasPendingInk, isFalse);
+      expect(editing.document.page(0).annotations.single.subtype, 'Ink');
+    });
+
     test('addMarkup highlights the given quads', () {
       final editing = PdfEditingController(buildMultiPagePdf(2))
         ..addMarkup(PdfMarkupKind.highlight, {


### PR DESCRIPTION
### Motivation
- Switching directly from the ink tool to the eraser could trigger an immediate `finishInk()` PDF rewrite and raster refresh, making the eraser button feel sticky and causing a UI jank when using latency-sensitive workflows (Apple Pencil double-tap). 

### Description
- Change the `tool` setter in `PdfEditingController` to detect the ink→eraser transition with a pending ink (`hasPendingInk`) and avoid calling `finishInk()` synchronously. 
- When that path is detected a `deferInkCommit` flag is set; the controller still arms the eraser, calls `notifyListeners()`, and then schedules `finishInk()` via `Timer.run(finishInk)` so the UI can repaint first. 
- Add a regression test `switching from ink to eraser defers the pending drawing commit` in `packages/dart_pdf_editor/test/editing_test.dart` that asserts the eraser is active immediately and the pending ink commits on the next event-loop turn. 

### Testing
- Ran the new widget/unit test with `cd packages/dart_pdf_editor && fvm flutter test test/editing_test.dart --plain-name "switching from ink to eraser defers the pending drawing commit"`, and it passed. 
- Ran static analysis with `fvm dart analyze`, and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30846d4cd8832b8bb631667523456a)