### PR TITLE
Add Save As keyboard shortcut (Ctrl/Cmd+Shift+S)

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -35,6 +35,7 @@ class EditorScreen extends StatefulWidget {
     required this.prefs,
     this.launchArgs = const [],
     this.initialDocument,
+    this.saveBytesAsOverride,
   });
 
   final PdfEditingPreferences prefs;
@@ -46,6 +47,14 @@ class EditorScreen extends StatefulWidget {
   /// platform. Used by screenshot/integration harnesses (and handy in
   /// tests) to land directly in the editor without a file picker.
   final ({Uint8List bytes, String title})? initialDocument;
+
+  /// Test seam for save-as. Production uses the platform implementation in
+  /// [saveBytesAs].
+  final Future<SaveResult> Function(
+    BuildContext context,
+    Uint8List bytes,
+    String suggestedName,
+  )? saveBytesAsOverride;
 
   @override
   State<EditorScreen> createState() => _EditorScreenState();
@@ -465,11 +474,11 @@ class _EditorScreenState extends State<EditorScreen>
     final inPlace = !saveAs && tab.originPath != null && supportsInPlaceSave;
     var result = inPlace
         ? await saveBytesToPath(bytes, tab.originPath!)
-        : await saveBytesAs(context, bytes, tab.title);
+        : await _saveBytesAs(bytes, tab.title);
     if (!mounted) return;
     if (inPlace && !result.succeeded) {
       // The origin couldn't be written (moved, read-only) — offer save-as.
-      result = await saveBytesAs(context, bytes, tab.title);
+      result = await _saveBytesAs(bytes, tab.title);
       if (!mounted) return;
     }
     if (result.succeeded) {
@@ -482,6 +491,18 @@ class _EditorScreenState extends State<EditorScreen>
       }
     }
     if (result.message != null) _toast(result.message!);
+  }
+
+  Future<SaveResult> _saveBytesAs(Uint8List bytes, String suggestedName) {
+    final override = widget.saveBytesAsOverride;
+    if (override != null) return override(context, bytes, suggestedName);
+    return saveBytesAs(context, bytes, suggestedName);
+  }
+
+  void _saveActive({bool saveAs = false}) {
+    final tab = _active;
+    if (tab?.session == null) return;
+    unawaited(_save(tab!, saveAs: saveAs));
   }
 
   // --- link actions --------------------------------------------------------
@@ -596,7 +617,7 @@ class _EditorScreenState extends State<EditorScreen>
   @override
   Widget build(BuildContext context) {
     final tab = _active;
-    return Scaffold(
+    final scaffold = Scaffold(
       appBar: AppBar(
         leading: _buildAppMenu(tab),
         leadingWidth: _appMenuLeadingWidth,
@@ -619,6 +640,16 @@ class _EditorScreenState extends State<EditorScreen>
           ],
         ),
       ),
+    );
+    if (tab?.session == null) return scaffold;
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.keyS,
+            control: true, shift: true): () => _saveActive(saveAs: true),
+        const SingleActivator(LogicalKeyboardKey.keyS, meta: true, shift: true):
+            () => _saveActive(saveAs: true),
+      },
+      child: scaffold,
     );
   }
 

--- a/app/test/save_shortcuts_test.dart
+++ b/app/test/save_shortcuts_test.dart
@@ -1,0 +1,53 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/file_io.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+
+  tearDown(() => prefs.dispose());
+
+  testWidgets('Ctrl+Shift+S invokes Save as for the active document',
+      (tester) async {
+    var saveAsCalls = 0;
+    String? suggestedName;
+
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        initialDocument: (bytes: buildClassicPdf(), title: 'shortcut.pdf'),
+        saveBytesAsOverride: (context, bytes, name) async {
+          saveAsCalls += 1;
+          suggestedName = name;
+          return SaveResult.downloaded(name);
+        },
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    await tester.tap(find.byType(PdfViewer), kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.keyS);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    expect(saveAsCalls, 1);
+    expect(suggestedName, 'shortcut.pdf');
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide an app-level keyboard shortcut for invoking Save As on the active editable document so users can trigger a save-as flow via `Ctrl/Cmd+Shift+S`.

### Description
- Add an injectable test seam `saveBytesAsOverride` to `EditorScreen` so tests can intercept save-as behavior while production still uses `saveBytesAs`.
- Introduce `_saveBytesAs` helper and `_saveActive` to centralize save-as routing and active-document checks.
- Wrap the main scaffold in a `CallbackShortcuts` when an editable session is present and bind `SingleActivator(LogicalKeyboardKey.keyS, control: true, shift: true)` and the `meta` variant to call `_saveActive(saveAs: true)`.
- Add a widget test `app/test/save_shortcuts_test.dart` that opens a document, focuses the viewer, sends `Ctrl+Shift+S`, and verifies the override was invoked with the document name.

### Testing
- Ran `fvm dart analyze` with no issues reported.
- Ran widget tests: `cd app && fvm flutter test test/save_shortcuts_test.dart` and `cd app && fvm flutter test test/widget_test.dart test/save_shortcuts_test.dart`; all tests passed.
- Ran `dart format` on modified files to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30845cab94832bb5995cdcd7c4c084)