### PR TITLE
Add autosize for free-text boxes and bind Alt+Z

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2772,6 +2772,39 @@ class PdfEditingController extends ChangeNotifier {
     return _freeTextStyleOf(annotation!);
   }
 
+  PdfRect _autosizeTextRect(PdfAnnotation annotation, String text,
+      {required PdfStandardFont font, required double size}) {
+    const pad = 3.0;
+    final lines = text.split('\n');
+    final maxLineWidth = lines.fold<double>(0, (max, line) {
+      final w = measureStandardText(line, size, font: font);
+      return w > max ? w : max;
+    });
+    final width = math.max(24.0, maxLineWidth + 2 * pad);
+    final height = math.max(18.0, lines.length * size * 1.2 + 2 * pad);
+    final page = _page(_selected.last.$1);
+    final bounds = page.cropBox;
+    final left = annotation.rect.left
+        .clamp(bounds.left, math.max(bounds.left, bounds.right - width))
+        .toDouble();
+    final top = annotation.rect.top
+        .clamp(math.min(bounds.top, bounds.bottom + height), bounds.top)
+        .toDouble();
+    return PdfRect(left, top - height, left + width, top);
+  }
+
+  /// Shrinks or grows the selected free-text annotation to the natural
+  /// bounds of its contents. Explicit newlines are preserved and the box is
+  /// anchored at its current top-left corner, clamped to the page crop box.
+  void autosizeSelectedTextBox() {
+    final annotation = selectedAnnotation;
+    if (annotation == null || !canRestyleSelectedText) return;
+    final style = _freeTextStyleOf(annotation);
+    final rect = _autosizeTextRect(annotation, annotation.contents ?? '',
+        font: style.font, size: style.size);
+    resizeSelected(rect);
+  }
+
   /// Rewrites the selected free-text annotation with a new [font] and/or
   /// [size], keeping its text, place, color, and author. The selection
   /// survives (the annotation keeps its /Annots slot).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1010,6 +1010,12 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                   tooltip: 'Edit annotation text',
                   onPressed: () => _editSelectedText(context),
                 ),
+              if (controller.canRestyleSelectedText)
+                IconButton(
+                  icon: const Icon(Icons.fit_screen),
+                  tooltip: 'Autosize text box (Alt+Z)',
+                  onPressed: controller.autosizeSelectedTextBox,
+                ),
             ]),
           ),
           if (settings.isNotEmpty) ...[

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3147,6 +3147,8 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                       editing.undo,
                   const SingleActivator(LogicalKeyboardKey.keyZ, control: true):
                       editing.undo,
+                  const SingleActivator(LogicalKeyboardKey.keyZ, alt: true):
+                      editing.autosizeSelectedTextBox,
                   const SingleActivator(LogicalKeyboardKey.keyZ,
                       meta: true, shift: true): editing.redo,
                   const SingleActivator(LogicalKeyboardKey.keyZ,

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -58,6 +58,26 @@ void main() {
       expect(annotation.defaultAppearance, contains('/Cour 18 Tf'));
     });
 
+    test('autosizeSelectedTextBox fits the selected box to its contents', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..fontFamily = PdfStandardFont.courier
+        ..fontSize = 18
+        ..addFreeText(0, const PdfRect(100, 600, 500, 720), 'Wide line\nshort');
+      expect(editing.selectAnnotation(0, 0), isTrue);
+
+      editing.autosizeSelectedTextBox();
+
+      final annotation = editing.document.page(0).annotations.single;
+      final expectedWidth =
+          measureStandardText('Wide line', 18, font: PdfStandardFont.courier) +
+              6;
+      expect(annotation.rect.left, 100);
+      expect(annotation.rect.top, 720);
+      expect(annotation.rect.width, closeTo(expectedWidth, 0.01));
+      expect(annotation.rect.height, closeTo(18 * 1.2 * 2 + 6, 0.01));
+      expect(editing.selectedAnnotation, isNotNull);
+    });
+
     test('text fill and border preferences flow into new free text', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..strokeWidth = 3
@@ -186,6 +206,35 @@ void main() {
       await tester.pump();
       return (editing, viewer);
     }
+
+    testWidgets('Alt+Z autosizes the selected free-text box', (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing
+        ..fontFamily = PdfStandardFont.courier
+        ..fontSize = 18
+        ..addFreeText(0, const PdfRect(100, 600, 500, 720), 'Wide line')
+        ..selectAnnotation(0, 0);
+      await tester.pump();
+
+      // Focus the viewer the way a user would before using a shortcut.
+      await tester.tapAt(view(400, 400));
+      await tester.pump();
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.altLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.altLeft);
+      await tester.pump();
+
+      final annotation = editing.document.page(0).annotations.single;
+      final expectedWidth =
+          measureStandardText('Wide line', 18, font: PdfStandardFont.courier) +
+              6;
+      expect(annotation.rect.width, closeTo(expectedWidth, 0.01));
+      await settle(tester);
+    });
 
     testWidgets('dragging out a text box opens an inline editor that commits',
         (tester) async {


### PR DESCRIPTION
### Motivation
- Provide a one-click / one-shortcut way to resize free-text annotations to fit their contents, preserving explicit newlines and keeping the box anchored to its top-left.
- Expose the action from the selection toolbar and make it accessible via a keyboard shortcut for faster editing workflows (Alt+Z).

### Description
- Added `_autosizeTextRect` and `autosizeSelectedTextBox()` to `PdfEditingController` to measure text with `measureStandardText`, compute natural width/height with padding, preserve explicit newlines, anchor at the current top-left, and clamp the box to the page crop box before calling `resizeSelected`.
- Added an autosize icon button to the selection strip in `editing_toolbar.dart` that calls `controller.autosizeSelectedTextBox()` when a single free-text annotation is selected.
- Bound `Alt+Z` in the viewer `CallbackShortcuts` to `editing.autosizeSelectedTextBox` so the user can trigger autosize via keyboard.
- Added unit/widget tests in `editing_text_edit_test.dart` to cover the controller autosize behavior and the Alt+Z shortcut path.
- Modified files: `packages/dart_pdf_editor/lib/src/editing/editing_controller.dart`, `packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart`, `packages/dart_pdf_editor/lib/src/pdf_viewer.dart`, and `packages/dart_pdf_editor/test/editing_text_edit_test.dart`.

### Testing
- Ran static analysis with `~/fvm/versions/3.44.2/bin/dart analyze` with no issues reported.
- Ran the focused test file with `cd packages/dart_pdf_editor && ~/fvm/versions/3.44.2/bin/flutter test test/editing_text_edit_test.dart` and the test suite (including the new autosize tests and the Alt+Z shortcut test) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308453d440832bb30a3ec090b0363c)