### PR TITLE
Fix double-click editing for FreeText annotations

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2258,10 +2258,33 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
         (event.localPosition - downLocal).distance >= kTouchSlop) {
       return; // it became a double-click-drag, handled by the pan flow
     }
+    if (_editingTextBoxAt(event.localPosition)) {
+      return; // let the editing overlay turn the click into in-place edit
+    }
     // the viewer's own tap recognizer fires after this raw event and
     // would immediately clear the selection made here
     _suppressTap = true;
     _selectWordAt(event.localPosition);
+  }
+
+  /// Whether a default/select-mode mouse click at [local] is over a
+  /// free-text annotation that the editing overlay can edit in place.
+  ///
+  /// The viewer detects mouse double-clicks from raw pointer events so
+  /// normal overlay buttons are not delayed by a double-tap recognizer.
+  /// Raw events also see clicks that land on the editing overlay, so a
+  /// double-click into a selected text box must stand down here; otherwise
+  /// the page-content word selector consumes the second click before the
+  /// overlay can open its inline editor.
+  bool _editingTextBoxAt(Offset local) {
+    final editing = widget.editing;
+    if (editing == null || editing.isPickingColor) return false;
+    final tool = editing.tool;
+    if (tool != null && tool != PdfEditTool.select) return false;
+    final point = _pagePointAt(local);
+    if (point == null) return false;
+    final hit = editing.selectableAnnotationAt(point.$1, point.$2, point.$3);
+    return hit?.$2.subtype == 'FreeText';
   }
 
   /// Whether a pointer of [kind] is drawing through the editing

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -285,6 +287,35 @@ void main() {
       expect(editing.isModified, isFalse,
           reason: 'backspace must not delete annotations or undo edits');
       expect(find.byKey(editorKey), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      await settle(tester);
+    });
+
+    testWidgets('mouse double-click on free text opens the inline editor',
+        (tester) async {
+      final (editing, viewer) = await pumpEditor(tester);
+      editing.addFreeText(0, const PdfRect(60, 700, 180, 750), 'Original');
+      await tester.pump();
+      editing.tool = PdfEditTool.select;
+      await tester.pump();
+
+      // This point also sits over the page-content word "Page". The
+      // viewer's raw mouse double-click word selector must stand down so
+      // the editing overlay can treat the second click as text-box edit.
+      final overTextBoxAndPageText = view(100, 720);
+      await tester.tapAt(overTextBoxAndPageText, kind: PointerDeviceKind.mouse);
+      await tester.pump(const Duration(milliseconds: 80));
+      expect(editing.selectedAnnotation?.subtype, 'FreeText');
+
+      await tester.tapAt(overTextBoxAndPageText, kind: PointerDeviceKind.mouse);
+      await tester.pump();
+
+      expect(find.byKey(editorKey), findsOneWidget);
+      expect(viewer.selectedText, isEmpty);
+      final field = tester.widget<TextField>(find.byKey(editorKey));
+      expect(field.controller!.text, 'Original');
 
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pump();


### PR DESCRIPTION
### Motivation
- Double-clicking a FreeText annotation that overlaps page text was being captured by the viewer's raw word-selection path, preventing the overlay from opening the inline text editor.
- The change ensures mouse double-clicks on editable text boxes are routed to the editing overlay instead of being swallowed by page-content selection.

### Description
- Short-circuit the mouse double-click handler in `_onPointerUp` to return early when the click is over an editable free-text annotation by calling a new helper ` _editingTextBoxAt(Offset)`. (`packages/dart_pdf_editor/lib/src/pdf_viewer.dart`).
- Implement ` _editingTextBoxAt(Offset)` to verify `widget.editing` exists, the tool state allows select-mode edits, map the pointer to a page point, and hit-test with `editing.selectableAnnotationAt(...)` returning true only for `FreeText` subtype. (`packages/dart_pdf_editor/lib/src/pdf_viewer.dart`).
- Add a regression widget test that double-clicks a FreeText box placed over selectable page text and asserts the inline editor opens while the viewer's page-text selection remains empty. (`packages/dart_pdf_editor/test/editing_text_edit_test.dart`).

### Testing
- Ran the modified widget tests with `cd packages/dart_pdf_editor && fvm flutter test test/editing_text_edit_test.dart`, and the full test run passed (all tests green).
- Ran static analysis with `fvm dart analyze`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308436a8b8832b994270108b0bab18)