### PR TITLE
Add zoom control UI and controller zoom API; integrate into shell bar and compact sheet

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -694,6 +694,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: PdfPageNumberField(controller: _viewer),
                     ),
+                  if (!reflowActive) PdfShellZoomControl(controller: _viewer),
                   if (features.search && !reflowActive) ...[
                     PdfSearchField(
                       controller: _viewer,
@@ -705,6 +706,21 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       showOptions: !features.searchResultsPanel,
                     ),
                   ],
+                ],
+                compactLeading: [
+                  if (features.pageNumber && !reflowActive)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: PdfPageNumberField(controller: _viewer),
+                    ),
+                  if (features.search && !reflowActive)
+                    PdfSearchField(
+                      controller: _viewer,
+                      searchController: _searchField,
+                      focusNode: _searchFocus,
+                      preferences: prefs,
+                      showOptions: !features.searchResultsPanel,
+                    ),
                 ],
                 trailing: [
                   if (features.viewOptions)
@@ -732,6 +748,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       label: const Text('Save'),
                       onPressed: _save,
                     ),
+                ],
+                compactSheetChildren: [
+                  if (!reflowActive) PdfShellZoomControl(controller: _viewer),
                 ],
                 compactControls: [
                   if (features.viewOptions) viewOptionsControl,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -305,6 +305,22 @@ class _PdfReaderState extends State<PdfReader> {
                       padding: const EdgeInsets.symmetric(horizontal: 12),
                       child: PdfPageNumberField(controller: _viewer),
                     ),
+                  if (!prefs.showReflowView)
+                    PdfShellZoomControl(controller: _viewer),
+                ],
+                compactLeading: [
+                  if (features.search && !prefs.showReflowView)
+                    PdfSearchField(
+                      controller: _viewer,
+                      searchController: _searchField,
+                      focusNode: _searchFocus,
+                      preferences: prefs,
+                    ),
+                  if (features.pageNumber && !prefs.showReflowView)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      child: PdfPageNumberField(controller: _viewer),
+                    ),
                 ],
                 trailing: [
                   if (features.viewOptions)
@@ -323,6 +339,10 @@ class _PdfReaderState extends State<PdfReader> {
                             prefs.showThumbnailSidebar = !showThumbnails,
                       ),
                   ]),
+                ],
+                compactSheetChildren: [
+                  if (!prefs.showReflowView)
+                    PdfShellZoomControl(controller: _viewer),
                 ],
                 compactControls: [
                   if (features.viewOptions)

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -207,6 +207,17 @@ class PdfViewerController extends ChangeNotifier {
 
   Future<void> jumpToPage(int index) async => _state?._jumpToPage(index);
 
+  /// Sets the viewer zoom around the center of the viewport.
+  ///
+  /// A zoom of 1 is fit-width/100%; values below 1 zoom out by relaying
+  /// the pages, and values above 1 zoom into a movable window over the
+  /// fit-width layout. The value is clamped to the attached viewer's
+  /// [PdfViewer.minZoom] and [PdfViewer.maxZoom].
+  void setZoom(double zoom) => _state?._setZoomFromController(zoom);
+
+  /// Resets the zoom to fit-width/100% around the center of the viewport.
+  void resetZoom() => setZoom(1);
+
   /// Scrolls — and zooms in when that helps — so [rect] (page space on
   /// [pageIndex]) sits centered in the viewport, filling around 40% of
   /// it. Never zooms out below 100% or in past [PdfViewer.maxZoom]. The
@@ -945,6 +956,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// InteractiveViewer transform (a window over fit-width pages); at or
   /// below 1 the pages themselves lay out smaller, so zooming out shows
   /// more of the document rather than a shrunken viewport.
+  void _setZoomFromController(double target) {
+    _zoomTo(target, Offset(_viewWidth / 2, _viewHeight / 2));
+  }
+
   void _zoomTo(double target, Offset focal) {
     final zoom = target.clamp(widget.minZoom, widget.maxZoom);
     if (zoom <= 1) {

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -323,15 +323,26 @@ class PdfShellBar extends StatelessWidget {
     super.key,
     required this.leading,
     required this.trailing,
+    this.compactLeading,
     this.compactControls = const [],
+    this.compactSheetChildren = const [],
   });
 
   final List<Widget> leading;
   final List<Widget> trailing;
+
+  /// Leading controls to keep directly in the header on compact layouts.
+  ///
+  /// When omitted, [leading] is reused. Pass a smaller set and move bulky
+  /// controls to [compactSheetChildren] to keep phone headers usable.
+  final List<Widget>? compactLeading;
+
   final List<PdfShellControlItem> compactControls;
+  final List<Widget> compactSheetChildren;
 
   Future<void> _showControls(BuildContext context) {
     final controls = compactControls;
+    final children = compactSheetChildren;
     return showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
@@ -355,30 +366,38 @@ class PdfShellBar extends StatelessWidget {
                   ],
                 ),
                 const SizedBox(height: 14),
-                const _ShellSheetSectionLabel('Shell'),
-                const SizedBox(height: 10),
-                GridView.count(
-                  crossAxisCount: 4,
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  childAspectRatio: 1.15,
-                  mainAxisSpacing: 6,
-                  crossAxisSpacing: 6,
-                  children: [
-                    for (final control in controls)
-                      _ShellControlTile(
-                        key: control.key,
-                        icon: control.icon,
-                        label: control.label,
-                        active: control.selected,
-                        enabled: control.enabled,
-                        onTap: () {
-                          Navigator.of(context).pop();
-                          control.onPressed();
-                        },
-                      ),
-                  ],
-                ),
+                if (children.isNotEmpty) ...[
+                  const _ShellSheetSectionLabel('View'),
+                  const SizedBox(height: 10),
+                  for (final child in children) child,
+                  const SizedBox(height: 14),
+                ],
+                if (controls.isNotEmpty) ...[
+                  const _ShellSheetSectionLabel('Shell'),
+                  const SizedBox(height: 10),
+                  GridView.count(
+                    crossAxisCount: 4,
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    childAspectRatio: 1.15,
+                    mainAxisSpacing: 6,
+                    crossAxisSpacing: 6,
+                    children: [
+                      for (final control in controls)
+                        _ShellControlTile(
+                          key: control.key,
+                          icon: control.icon,
+                          label: control.label,
+                          active: control.selected,
+                          enabled: control.enabled,
+                          onTap: () {
+                            Navigator.of(context).pop();
+                            control.onPressed();
+                          },
+                        ),
+                    ],
+                  ),
+                ],
               ],
             ),
           ),
@@ -408,6 +427,7 @@ class PdfShellBar extends StatelessWidget {
           child: LayoutBuilder(
             builder: (context, constraints) {
               if (pdfShellUseBottomSheets(constraints)) {
+                final compactHeader = compactLeading ?? leading;
                 return Row(
                   children: [
                     Expanded(
@@ -415,12 +435,13 @@ class PdfShellBar extends StatelessWidget {
                         scrollDirection: Axis.horizontal,
                         child: Row(children: [
                           const SizedBox(width: 8),
-                          ...leading,
+                          ...compactHeader,
                           const SizedBox(width: 4),
                         ]),
                       ),
                     ),
-                    if (compactControls.isNotEmpty)
+                    if (compactControls.isNotEmpty ||
+                        compactSheetChildren.isNotEmpty)
                       IconButton(
                         key: const ValueKey('pdf-shell-controls'),
                         visualDensity: VisualDensity.compact,
@@ -454,6 +475,97 @@ class PdfShellBar extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class PdfShellZoomControl extends StatefulWidget {
+  const PdfShellZoomControl({super.key, required this.controller});
+
+  final PdfViewerController controller;
+
+  @override
+  State<PdfShellZoomControl> createState() => _PdfShellZoomControlState();
+}
+
+class _PdfShellZoomControlState extends State<PdfShellZoomControl> {
+  static const List<double> _presets = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.viewportChanges.addListener(_changed);
+  }
+
+  @override
+  void didUpdateWidget(PdfShellZoomControl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller) return;
+    oldWidget.controller.viewportChanges.removeListener(_changed);
+    widget.controller.viewportChanges.addListener(_changed);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.viewportChanges.removeListener(_changed);
+    super.dispose();
+  }
+
+  void _changed() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final zoom = widget.controller.zoom;
+    final percent = (zoom * 100).round();
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        PopupMenuButton<double>(
+          key: const ValueKey('pdf-shell-zoom-menu'),
+          tooltip: 'Zoom',
+          initialValue: _nearestPreset(zoom),
+          onSelected: widget.controller.setZoom,
+          itemBuilder: (context) => [
+            for (final value in _presets)
+              PopupMenuItem<double>(
+                key: ValueKey('pdf-shell-zoom-${(value * 100).round()}'),
+                value: value,
+                child: Text('${(value * 100).round()}%'),
+              ),
+          ],
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  '$percent%',
+                  key: const ValueKey('pdf-shell-zoom-label'),
+                  style: Theme.of(context).textTheme.labelLarge,
+                ),
+                const Icon(Icons.arrow_drop_down),
+              ],
+            ),
+          ),
+        ),
+        IconButton(
+          key: const ValueKey('pdf-shell-zoom-reset'),
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.fit_screen),
+          tooltip: 'Reset zoom',
+          onPressed:
+              (zoom - 1).abs() < 0.005 ? null : widget.controller.resetZoom,
+        ),
+      ],
+    );
+  }
+
+  double? _nearestPreset(double zoom) {
+    for (final value in _presets) {
+      if ((value - zoom).abs() < 0.005) return value;
+    }
+    return null;
   }
 }
 

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -42,11 +42,38 @@ void main() {
           find.byKey(const ValueKey('pdf-page-number-field')), findsOneWidget);
       expect(
           find.byKey(const ValueKey('pdf-shell-view-options')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-zoom-menu')), findsOneWidget);
+      expect(
+          find.byKey(const ValueKey('pdf-shell-zoom-reset')), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-shell-thumbnails-toggle')),
           findsOneWidget);
       // view-only: no editing toolbar anywhere
       expect(find.byType(PdfEditingToolbar), findsNothing);
       expect(find.byType(PdfViewer), findsOneWidget);
+    });
+
+    testWidgets('zoom menu changes and resets viewer zoom', (tester) async {
+      final viewer = PdfViewerController();
+      addTearDown(viewer.dispose);
+      await pump(
+          tester, PdfReader(bytes: buildMultiPagePdf(2), controller: viewer));
+
+      expect(
+          find.byKey(const ValueKey('pdf-shell-zoom-label')), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-menu')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-150')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(viewer.zoom, closeTo(1.5, 0.01));
+      expect(find.text('150%'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-zoom-reset')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(viewer.zoom, closeTo(1, 0.01));
+      expect(find.text('100%'), findsOneWidget);
     });
 
     testWidgets('PdfReaderFeatures.none leaves just the pages', (tester) async {
@@ -798,10 +825,12 @@ void main() {
           find.byKey(const ValueKey('pdf-shell-view-options')), findsNothing);
       expect(find.byKey(const ValueKey('pdf-shell-annotations-toggle')),
           findsNothing);
+      expect(find.byKey(const ValueKey('pdf-shell-zoom-menu')), findsNothing);
 
       await openShellControls(tester);
 
       expect(find.text('Controls'), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-zoom-menu')), findsOneWidget);
       expect(
           find.byKey(const ValueKey('pdf-shell-view-options')), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-shell-annotations-toggle')),


### PR DESCRIPTION
### Motivation

- Expose programmatic zoom control and add an inline header control so users can change/reset zoom quickly.
- Surface zoom controls in compact layouts via the shell's controls sheet to keep phone headers compact while keeping zoom accessible.

### Description

- Added `setZoom` and `resetZoom` to `PdfViewerController` and wired them to a new `_setZoomFromController` in `_PdfViewerState` to apply an absolute zoom centered on the viewport. 
- Introduced `PdfShellZoomControl`, a header widget with a preset `PopupMenuButton` and a reset button, and added it into `PdfEditorView` and `PdfReader` header leading areas and compact sheet children. 
- Extended `PdfShellBar` with `compactLeading` and `compactSheetChildren` properties and updated the controls sheet to render view-specific children above the shell controls when present. 
- Updated tests in `test/pdf_shell_test.dart` to assert zoom UI presence, to exercise the zoom menu selection and reset behavior, and to verify compact-sheet placement.

### Testing

- Ran the package widget tests including the updated `pdf_shell_test.dart` which checks zoom menu and reset button presence and behavior, and they passed. 
- Executed `flutter test` for the package test suite and observed no failures for the modified tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308473d8d8832ba6beda7b36e4f9da)