### PR TITLE
Label Firebase preview deployment comments

### DIFF
--- a/.github/workflows/preview-app-web.yml
+++ b/.github/workflows/preview-app-web.yml
@@ -102,10 +102,62 @@ jobs:
       # No channelId -> the action creates an ephemeral preview channel keyed
       # to this PR and comments the URL on it. The channel expires on its own.
       # The target hosting site (dartpdf-app) comes from app/firebase.json.
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - id: deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
+          disableComment: true
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_PDF_DEMO }}
           projectId: dart-pdf-demo
           expires: 7d
           entryPoint: app
+
+      - name: Comment preview URL
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_LABEL: DartPDF app preview
+          PREVIEW_MARKER: dartpdf-app-preview
+          PREVIEW_URL: ${{ steps.deploy.outputs.details_url }}
+          PREVIEW_EXPIRES: ${{ steps.deploy.outputs.expire_time_formatted }}
+        with:
+          script: |
+            const marker = `<!-- ${{ env.PREVIEW_MARKER }} -->`;
+            const label = process.env.PREVIEW_LABEL;
+            const url = process.env.PREVIEW_URL;
+            const expires = process.env.PREVIEW_EXPIRES;
+            const sha = context.sha.slice(0, 7);
+            const body = [
+              marker,
+              `### ${label}`,
+              '',
+              `Visit the **${label}** preview URL for this PR (updated for commit ${sha}):`,
+              '',
+              url,
+              '',
+              `(expires ${expires})`,
+              '',
+              '🔥 via Firebase Hosting GitHub Action 🌎',
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -99,10 +99,62 @@ jobs:
 
       # No channelId -> the action creates an ephemeral preview channel keyed
       # to this PR and comments the URL on it. The channel expires on its own.
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - id: deploy
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
+          disableComment: true
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_PDF_DEMO }}
           projectId: dart-pdf-demo
           expires: 7d
           entryPoint: packages/dart_pdf_editor/example
+
+      - name: Comment preview URL
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_LABEL: Example demo preview
+          PREVIEW_MARKER: dart-pdf-demo-preview
+          PREVIEW_URL: ${{ steps.deploy.outputs.details_url }}
+          PREVIEW_EXPIRES: ${{ steps.deploy.outputs.expire_time_formatted }}
+        with:
+          script: |
+            const marker = `<!-- ${{ env.PREVIEW_MARKER }} -->`;
+            const label = process.env.PREVIEW_LABEL;
+            const url = process.env.PREVIEW_URL;
+            const expires = process.env.PREVIEW_EXPIRES;
+            const sha = context.sha.slice(0, 7);
+            const body = [
+              marker,
+              `### ${label}`,
+              '',
+              `Visit the **${label}** preview URL for this PR (updated for commit ${sha}):`,
+              '',
+              url,
+              '',
+              `(expires ${expires})`,
+              '',
+              '🔥 via Firebase Hosting GitHub Action 🌎',
+            ].join('\n');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
### Motivation
- Firebase's default preview comment was indistinct and made it hard to tell the app vs example demo preview URLs apart.
- The goal is to post clear, labeled preview URLs for the two separate hosting targets so PRs show which preview is which.

### Description
- Updated `.github/workflows/preview-app-web.yml` to add `id: deploy` and `disableComment: true` to the `FirebaseExtended/action-hosting-deploy@v0` step and added a follow-up `actions/github-script` step that posts a labeled comment titled `DartPDF app preview` using a hidden marker `<!-- dartpdf-app-preview -->` so subsequent runs update the same bot comment.
- Updated `.github/workflows/preview-demo-web.yml` the same way but with the label `Example demo preview` and marker `<!-- dart-pdf-demo-preview -->`, and the `entryPoint` remains `packages/dart_pdf_editor/example` for the demo build.
- The scripted comment captures `details_url` and `expire_time_formatted` from the deploy step and updates an existing marker-based bot comment instead of creating duplicates.

### Testing
- Loaded both YAML workflows with `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "#{p} ok" }' .github/workflows/preview-app-web.yml .github/workflows/preview-demo-web.yml` which succeeded.
- Linted the workflows with `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/preview-app-web.yml .github/workflows/preview-demo-web.yml` which succeeded.
- An attempt to run `npx -y actionlint@latest` failed due to an npm packaging/executable issue, so `actionlint` was run via the Go tool instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30abfc890c832bad560ee083d9b5ee)