### PR TITLE
Increase PdfViewer maxZoom to 24x for deeper inspection

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -424,7 +424,7 @@ class PdfViewer extends StatefulWidget {
     this.initialFit = PdfViewerFit.page,
     this.initialViewport,
     this.minZoom = 0.25,
-    this.maxZoom = 6,
+    this.maxZoom = 24,
     this.doubleTapZoom = 2.5,
     this.backgroundColor,
     this.pageColor = const Color(0xFFFFFFFF),
@@ -551,6 +551,11 @@ class PdfViewer extends StatefulWidget {
   /// Smallest zoom factor; below 1 the page shrinks past fit-width and
   /// floats centered in the viewport.
   final double minZoom;
+
+  /// Largest zoom factor above fit-width. The default is intentionally high
+  /// for very wide engineering plots and long drawings: fit-width makes each
+  /// PDF point tiny on screen, and the deep-zoom detail patch keeps the
+  /// visible slice sharp without forcing a full-page raster at this scale.
   final double maxZoom;
   final double doubleTapZoom;
 

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -769,6 +769,21 @@ void main() {
     expect(controller.zoom, greaterThan(1));
   });
 
+  testWidgets('default max zoom supports deep inspection of long plots',
+      (tester) async {
+    final controller = await pumpViewer(tester);
+    final pointer = TestPointer(12, PointerDeviceKind.mouse);
+    pointer.hover(const Offset(400, 300));
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, -1000)));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+    expect(controller.zoom, greaterThan(6));
+  });
+
   testWidgets('tapping a URI link surfaces the action', (tester) async {
     final actions = <PdfAction>[];
     final annotations = <PdfAnnotation>[];


### PR DESCRIPTION
### Motivation
- Long engineering plots and very wide/long drawings require much deeper zoom than the previous 6× default so users can inspect fine detail.
- The viewer already provides a deep-zoom detail patch that keeps the visible slice sharp without forcing a full-page raster, so raising the default is safe.

### Description
- Increase the `PdfViewer` default `maxZoom` from `6` to `24` by changing the constructor default `this.maxZoom = 24` in `packages/dart_pdf_editor/lib/src/pdf_viewer.dart` and add a short doc comment for `maxZoom` explaining the rationale.
- Add a widget test `default max zoom supports deep inspection of long plots` to `packages/dart_pdf_editor/test/pdf_viewer_test.dart` that exercises ctrl+wheel zooming past the previous 6× limit.
- Run `dart format` on the modified files to keep style consistent.

### Testing
- Ran the viewer widget tests with `cd packages/dart_pdf_editor && fvm flutter test test/pdf_viewer_test.dart`, and the suite (including the new test) passed.
- Ran static analysis with `fvm dart analyze`, and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b6b4a008832ba610a0659575a1ae)