### PR TITLE
Keep ink cursor at stroke end

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -601,6 +601,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // hold the auto-commit while this stroke is on the page
         _controller.beginInkStroke();
         final pressure = _pointerPressure;
+        _penCursor = event.localPosition;
         // no setState: the active stroke lives on its own repaint layer
         _activeStroke = [_geometry.toPagePoint(event.localPosition)];
         _activeStrokePressures = pressure == null ? null : [pressure];
@@ -642,6 +643,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _eraseAt(event.localPosition);
     } else if (_activeStroke != null) {
       // hot path: append + repaint the stroke layer only, no rebuild
+      _penCursor = event.localPosition;
       _activeStroke!.add(_geometry.toPagePoint(event.localPosition));
       _activeStrokePressures
           ?.add(_pointerPressure ?? _activeStrokePressures!.last);
@@ -1661,6 +1663,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // hold the auto-commit while this stroke is on the page
         _controller.beginInkStroke();
         final pressure = _pointerPressure;
+        // While the mouse is pressed, hover events stop. Keep the painted
+        // pen cursor's stored position moving with the drag so it reappears
+        // at the stroke end, not where the stroke started.
+        _penCursor = position;
         // no setState: the active stroke lives on its own repaint layer
         _activeStroke = [_geometry.toPagePoint(position)];
         // the first event decides: a pressure device varies the whole
@@ -1934,6 +1940,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _reportMovePreview();
     } else if (_activeStroke != null) {
       // hot path: append + repaint the stroke layer only, no rebuild
+      _penCursor = position;
       _activeStroke!.add(_geometry.toPagePoint(position));
       _activeStrokePressures
           ?.add(_pointerPressure ?? _activeStrokePressures!.last);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -3582,6 +3582,9 @@ class _ActiveStrokePainter extends CustomPainter {
 
   final _EditingPageOverlayState _state;
 
+  @visibleForTesting
+  Offset? get debugPenCursor => _state._penCursor;
+
   @override
   void paint(Canvas canvas, Size size) {
     final stroke = _state._activeStroke;
@@ -3609,10 +3612,43 @@ class _ActiveStrokePainter extends CustomPainter {
       _state._controller.color,
       _state._controller.strokeWidth * geometry.scale,
     );
+    final cursor = _state._penCursor;
+    if (cursor != null && _state._tool == PdfEditTool.ink) {
+      _paintPenCursor(
+        canvas,
+        cursor,
+        strokeWidth: _state._controller.strokeWidth * geometry.scale,
+        chromeScale: _state._chromeScale,
+        color: _state._controller.color,
+        opacity: _state._controller.opacity,
+      );
+    }
   }
 
   @override
   bool shouldRepaint(_ActiveStrokePainter oldDelegate) => false;
+}
+
+void _paintPenCursor(
+  Canvas canvas,
+  Offset center, {
+  required double strokeWidth,
+  required double chromeScale,
+  required Color color,
+  required double opacity,
+}) {
+  final r = math.max(strokeWidth / 2, 1.5 * chromeScale);
+  canvas.drawCircle(
+      center, r + 1.5 * chromeScale, Paint()..color = const Color(0x33000000));
+  canvas.drawCircle(
+      center, r, Paint()..color = color.withValues(alpha: opacity));
+  canvas.drawCircle(
+      center,
+      r,
+      Paint()
+        ..color = const Color(0xB3FFFFFF)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1 * chromeScale);
 }
 
 class _EditingPreviewPainter extends CustomPainter {
@@ -4270,18 +4306,14 @@ class _EditingPreviewPainter extends CustomPainter {
     // to the stroke width, with a halo + hairline so it reads on any page
     final pen = penCursor;
     if (pen != null) {
-      final r = math.max(strokeWidth / 2, 1.5 * chromeScale);
-      canvas.drawCircle(
-          pen, r + 1.5 * chromeScale, Paint()..color = const Color(0x33000000));
-      canvas.drawCircle(
-          pen, r, Paint()..color = color.withValues(alpha: penOpacity));
-      canvas.drawCircle(
-          pen,
-          r,
-          Paint()
-            ..color = const Color(0xB3FFFFFF)
-            ..style = PaintingStyle.stroke
-            ..strokeWidth = 1 * chromeScale);
+      _paintPenCursor(
+        canvas,
+        pen,
+        strokeWidth: strokeWidth,
+        chromeScale: chromeScale,
+        color: color,
+        opacity: penOpacity,
+      );
     }
 
     // the rotate knob's cursor: a curved arrow (no system rotation cursor)

--- a/packages/dart_pdf_editor/test/editing_cursor_test.dart
+++ b/packages/dart_pdf_editor/test/editing_cursor_test.dart
@@ -143,6 +143,27 @@ void main() {
     expect((painter.color as Color).toARGB32(), 0xFF1565C0);
   });
 
+  testWidgets('the ink cursor follows a mouse-drawn stroke', (tester) async {
+    final editing = await pumpViewer(tester);
+    editing
+      ..inkCommitDelay = null
+      ..tool = PdfEditTool.ink;
+    await tester.pump();
+
+    final start = view(250, 450);
+    final end = view(330, 420);
+    await hoverAt(tester, start);
+    final g = await tester.startGesture(start, kind: PointerDeviceKind.mouse);
+    await tester.pump();
+
+    await g.moveTo(end);
+    await tester.pump();
+    await g.up();
+    await tester.pump();
+
+    expect(overlayPainter(tester).penCursor, end);
+  });
+
   testWidgets('leaving the page retracts the painted pen dot', (tester) async {
     final editing = await pumpViewer(tester);
     editing.tool = PdfEditTool.ink;

--- a/packages/dart_pdf_editor/test/editing_cursor_test.dart
+++ b/packages/dart_pdf_editor/test/editing_cursor_test.dart
@@ -22,6 +22,16 @@ dynamic overlayPainter(WidgetTester tester) => tester
         .first)
     .painter;
 
+dynamic activeStrokePainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.descendant(
+      of: find.byType(EditingPageOverlay),
+      matching: find.byType(CustomPaint),
+    ))
+    .map((paint) => paint.painter)
+    .singleWhere(
+      (painter) => painter.runtimeType.toString() == '_ActiveStrokePainter',
+    );
+
 /// The overlay's own MouseRegion cursor (the one wrapping the preview
 /// painter) — what the system shows while hovering.
 MouseCursor regionCursor(WidgetTester tester) {
@@ -158,6 +168,7 @@ void main() {
 
     await g.moveTo(end);
     await tester.pump();
+    expect(activeStrokePainter(tester).debugPenCursor, end);
     await g.up();
     await tester.pump();
 


### PR DESCRIPTION
### Motivation
- The painted pen-preview cursor could remain at the stroke start after finishing a mouse/trackpad-drawn ink stroke, leaving the system cursor visually misplaced relative to the completed ink annotation.

### Description
- Update `EditingPageOverlay` to track the painted pen cursor (`_penCursor`) during ink strokes for both raw-driven pointers and gesture-driven mouse/trackpad drags so the preview dot follows the pointer and reappears at the stroke end (`packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart`).
- Set `_penCursor` on pointer-down and continuously update it on pointer-move / drag update paths where in-progress strokes are appended, so the painted cursor isn't left at the initial press point.
- Add a regression widget test `the ink cursor follows a mouse-drawn stroke` to `packages/dart_pdf_editor/test/editing_cursor_test.dart` that draws an ink stroke with a mouse and asserts the painted pen cursor is at the final pointer position.

### Testing
- Ran the widget test: `cd packages/dart_pdf_editor && fvm flutter test test/editing_cursor_test.dart`, which passed after applying the fix (an initial failing run was used to guide the change and was resolved). 
- Ran static analysis: `fvm dart analyze`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b7596d5c832b95f8ffcf2f5a7c2e)