### PR TITLE
Ensure example PDF saves keep .pdf extension

### DIFF
--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -51,6 +51,18 @@ Future<Uint8List?> _pickImage(BuildContext context) =>
     openFile(acceptedTypeGroups: const [_imageTypeGroup])
         .then((file) => file?.readAsBytes());
 
+@visibleForTesting
+String pdfSavePathWithExtension(String path) {
+  final trimmed = path.trimRight();
+  if (trimmed.isEmpty) return 'document.pdf';
+  final slash = trimmed.lastIndexOf('/');
+  final backslash = trimmed.lastIndexOf('\\');
+  final separator = slash > backslash ? slash : backslash;
+  final basename = trimmed.substring(separator + 1);
+  if (basename.toLowerCase().endsWith('.pdf')) return trimmed;
+  return '$trimmed.pdf';
+}
+
 void main() {
   // On web, point the render worker at its compiled script so the heavy page
   // interpretation + image decode run in a dedicated Web Worker instead of on
@@ -548,7 +560,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// tablets (where apps can't write outside their sandbox directly).
   Future<void> _saveAs(Uint8List bytes) async {
     final name = _saveFileName();
-    final file = XFile.fromData(bytes, mimeType: 'application/pdf');
+    final file = XFile.fromData(bytes, mimeType: 'application/pdf', name: name);
     if (kIsWeb) {
       await file.saveTo(name);
       _toast('Downloaded $name');
@@ -572,8 +584,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
         );
         if (location == null) return;
         try {
-          await file.saveTo(location.path);
-          _toast('Saved to ${location.path}');
+          final path = pdfSavePathWithExtension(location.path);
+          await file.saveTo(path);
+          _toast('Saved to $path');
         } catch (e) {
           _toast('Save failed: $e');
         }

--- a/packages/dart_pdf_editor/example/test/save_path_test.dart
+++ b/packages/dart_pdf_editor/example/test/save_path_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_viewer_example/main.dart';
+
+void main() {
+  test('pdfSavePathWithExtension appends pdf to extensionless paths', () {
+    expect(pdfSavePathWithExtension('/tmp/report'), '/tmp/report.pdf');
+    expect(pdfSavePathWithExtension(r'C:\Users\me\report'),
+        r'C:\Users\me\report.pdf');
+  });
+
+  test('pdfSavePathWithExtension preserves existing pdf extension', () {
+    expect(pdfSavePathWithExtension('/tmp/report.pdf'), '/tmp/report.pdf');
+    expect(pdfSavePathWithExtension('/tmp/report.PDF'), '/tmp/report.PDF');
+    expect(pdfSavePathWithExtension('/tmp.v1/report'), '/tmp.v1/report.pdf');
+  });
+}


### PR DESCRIPTION
### Motivation
- Desktop save dialogs can return extensionless paths which caused the example to write PDF bytes to files missing the `.pdf` suffix and share flows to lack a filename with the extension.

### Description
- Add `pdfSavePathWithExtension(String)` to normalize save-dialog paths and append `.pdf` when the chosen path has no PDF extension in `packages/dart_pdf_editor/example/lib/main.dart`.
- Pass the suggested PDF filename into `XFile.fromData(bytes, ..., name: name)` so share/download flows include a filename with the extension.
- Use the new helper to transform `location.path` before calling `file.saveTo(...)` for desktop saves.
- Add unit tests `packages/dart_pdf_editor/example/test/save_path_test.dart` that cover extensionless, Windows-style, and already-suffixed save paths.

### Testing
- Ran the example package unit tests with `cd packages/dart_pdf_editor/example && ~/fvm/versions/3.44.2/bin/flutter test test/save_path_test.dart`, and the tests passed.
- Ran static analysis with `~/fvm/versions/3.44.2/bin/dart analyze packages/dart_pdf_editor/example/lib/main.dart packages/dart_pdf_editor/example/test/save_path_test.dart`, and `dart analyze` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3084176098832b98b1bb1c5cf80f53)