### PR TITLE
Paste system clipboard text as FreeText annotations

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1162,6 +1162,45 @@ class PdfEditingController extends ChangeNotifier {
           author: author),
       pages: [pageIndex]);
 
+  /// Places [text] as a default-sized FreeText annotation centered on
+  /// ([x], [y]) in page space. This is used by keyboard paste from the
+  /// system text clipboard, so the text lands under the cursor like
+  /// annotation paste. The box is clamped into the page's crop box and
+  /// the new annotation is selected.
+  bool placeFreeText(int pageIndex, double x, double y, String text,
+      {double width = 220}) {
+    final value = text.trimRight();
+    if (value.trim().isEmpty) return false;
+    if (pageIndex < 0 || pageIndex >= _document.pageCount) return false;
+    final box = _page(pageIndex).cropBox;
+    final fontSize = preferences.fontSize;
+    final lineHeight = fontSize * 1.2;
+    final lines = value.split('\n').length.clamp(1, 12);
+    final w = width.clamp(48.0, box.width * 0.9);
+    final h = (lineHeight * lines + fontSize).clamp(24.0, box.height * 0.9);
+    final cx = x.clamp(box.left + w / 2, box.right - w / 2);
+    final cy = y.clamp(box.bottom + h / 2, box.top - h / 2);
+    final rect = PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2);
+    final pasted = apply(
+        (e) => e.addFreeText(pageIndex, rect, value,
+            fontSize: fontSize,
+            font: preferences.fontFamily,
+            color: _colorValue,
+            fillColor: _rgbOf(preferences.textFillColor),
+            borderColor: _rgbOf(preferences.textBorderColor),
+            borderWidth: preferences.strokeWidth,
+            author: author),
+        pages: [pageIndex]);
+    if (!pasted) return false;
+    tool = PdfEditTool.select;
+    final total = _page(pageIndex).annotations.length;
+    _selected
+      ..clear()
+      ..add((pageIndex, total - 1));
+    notifyListeners();
+    return true;
+  }
+
   void addStamp(int pageIndex, PdfRect rect, String text, {int? color}) =>
       apply(
           (e) => e.addStamp(pageIndex, rect, text,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2116,10 +2116,12 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// ⌘X/Ctrl+X: cut the selected annotations (copy + delete).
   void _onCut() => widget.editing?.cutSelectedAnnotations();
 
-  /// ⌘V/Ctrl+V: paste the annotation clipboard at the cursor — the page
-  /// and point under the last pointer, like the right-click paste. With
-  /// no pointer seen yet (touch / keyboard-only) it falls back to the
-  /// current page's cascade.
+  /// ⌘V/Ctrl+V: paste the in-app annotation/snapshot clipboard at the
+  /// cursor. When that clipboard is empty, read plain text from the
+  /// system clipboard and create a FreeText annotation at the same point.
+  /// With no pointer seen yet (touch / keyboard-only) annotation paste
+  /// falls back to the current page's cascade; text paste lands in the
+  /// current page's center.
   void _onPaste() {
     final editing = widget.editing;
     if (editing == null) return;
@@ -2127,7 +2129,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     // annotation clipboard (the most recent copy wins, mirroring the
     // controller's clipboards)
     final snapshot = editing.hasSnapshotClipboard;
-    if (!snapshot && !editing.hasAnnotationClipboard) return;
+    if (!snapshot && !editing.hasAnnotationClipboard) {
+      unawaited(_pasteSystemClipboardText(editing));
+      return;
+    }
     final local = _lastPointerLocal;
     final point = local == null ? null : _pagePointAt(local);
     if (snapshot) {
@@ -2141,6 +2146,25 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     } else {
       editing.pasteAnnotations(_controller.currentPage);
     }
+  }
+
+  Future<void> _pasteSystemClipboardText(PdfEditingController editing) async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    final text = data?.text;
+    if (text == null || text.trim().isEmpty) return;
+    if (!mounted || widget.editing != editing) return;
+    final local = _lastPointerLocal;
+    final point = local == null ? null : _pagePointAt(local);
+    if (point != null) {
+      editing.placeFreeText(point.$1, point.$2, point.$3, text);
+      return;
+    }
+    if (_pages.isEmpty) return;
+    final page = _controller.currentPage.clamp(0, _pages.length - 1).toInt();
+    if (page < 0 || page >= _pages.length) return;
+    final box = _pages[page].cropBox;
+    editing.placeFreeText(
+        page, (box.left + box.right) / 2, (box.bottom + box.top) / 2, text);
   }
 
   /// ⌘A/Ctrl+A: with the select tool armed (or an annotation selection

--- a/packages/dart_pdf_editor/test/editing_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_clipboard_test.dart
@@ -295,6 +295,32 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('Ctrl+V pastes system clipboard text as a text box',
+        (tester) async {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.getData') {
+          return const <String, Object?>{'text': 'Pasted note'};
+        }
+        return null;
+      });
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      final (editing, _) = await pumpEditor(tester);
+      await tester.tapAt(view(400, 400), kind: PointerDeviceKind.mouse);
+      await tester.pump();
+
+      await sendCtrl(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.subtype, 'FreeText');
+      expect(annotation.contents, 'Pasted note');
+      expect(annotation.rect, const PdfRect(290, 384.6, 510, 415.4));
+      expect(editing.selectedAnnotationSlots, [(0, 0)]);
+      await settle(tester);
+    });
+
     testWidgets('the context menu copies, and pastes at the click point',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);


### PR DESCRIPTION
### Motivation
- Allow plain-text pasted from the OS clipboard to become a FreeText annotation when the in-app annotation/snapshot clipboard is empty, so `⌘V`/`Ctrl+V` can place text under the cursor like a normal paste.

### Description
- Added `PdfEditingController.placeFreeText(int,double,double,String,{double})` to create a clamped, sized FreeText annotation using the current text preferences and select the new annotation.
- Updated viewer paste handling in `_onPaste()` so annotation/snapshot paste still takes priority but falls back to reading system plain-text via `Clipboard.getData` when the in-app clipboard is empty; the fallback calls a new helper `_pasteSystemClipboardText` which uses `placeFreeText` to insert at the pointer or page center.
- Added a widget test `Ctrl+V pastes system clipboard text as a text box` to `editing_clipboard_test.dart` that mocks `Clipboard.getData` and verifies subtype, contents, rect and selection.
- Reformatted touched files and kept existing annotation paste behavior intact (only extends paste to system text fallback).

### Testing
- Ran formatter and static analysis with `dart format` and `dart analyze` with no issues reported.
- Ran the widget test file with `cd packages/dart_pdf_editor && fvm flutter test test/editing_clipboard_test.dart` and all tests in that file passed.
- Ran `git diff --check` as part of validation (no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30842b8de4832b95ad9ec4bdb037c5)