### PR TITLE
Fix Dependabot pub workspace updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,11 @@ updates:
         patterns:
           - "*"
 
-  # Pub dependencies, per workspace package. Grouped to keep PR noise down.
+  # Pub dependencies for the whole workspace. Pub workspaces must resolve
+  # from the root; running Dependabot inside member directories fails with
+  # "Only apply dependency_services to the root of the workspace."
   - package-ecosystem: pub
-    directories:
-      - /packages/pdf_cos
-      - /packages/pdf_document
-      - /packages/pdf_graphics
-      - /packages/dart_pdf_editor
-      - /packages/dart_pdf_editor/example
-      - /packages/pdf_test_fixtures
+    directory: /
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
### Motivation
- The Dependabot pub update run failed with `dependency_file_not_resolvable` because pub workspaces must be resolved from the workspace root.

### Description
- Change the pub Dependabot entry from member `directories:` to root `directory: /`.
- Keep the internal workspace package ignores so Dependabot does not try to update local packages published together by release tags.

### Testing
- Parsed `.github/dependabot.yml` as YAML locally.
- Verified the failing Dependabot run log reports: `Only apply dependency_services to the root of the workspace.`