### PR TITLE
Add view rotation without changing page orientation

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1444,7 +1444,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final annotation = _controller.selectedAnnotation;
     if (annotation == null) return;
     unawaited(PdfPageRenderer.renderAnnotationPicture(
-            document.page(widget.pageIndex), annotation)
+            document.page(widget.pageIndex), annotation,
+            rotation: widget.geometry.rotation)
         .then((picture) {
       if (!mounted || _ghostKey != key) {
         picture?.dispose();
@@ -2883,7 +2884,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _samplerAnnotations = annotations;
       _sampler = null;
       _samplerFuture = PdfPageColorSampler.of(document.page(widget.pageIndex),
-              pageColor: pageColor, annotations: annotations)
+              pageColor: pageColor, annotations: annotations,
+              rotation: widget.geometry.rotation)
           .then((s) {
         // resolve the preview that was waiting on the raster
         if (mounted &&

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -24,6 +24,7 @@ class PdfPageView extends StatefulWidget {
   const PdfPageView({
     super.key,
     required this.page,
+    this.rotation,
     this.scale = 1,
     this.settleGeneration = 0,
     this.pageColor = const Color(0xFFFFFFFF),
@@ -37,6 +38,12 @@ class PdfPageView extends StatefulWidget {
   });
 
   final PdfPage page;
+
+  /// Display rotation override. When set, the page renders at this
+  /// rotation instead of its own /Rotate — the view rotation feature
+  /// rotates the display without modifying the document. Null (the
+  /// default) uses the page's own /Rotate.
+  final int? rotation;
 
   /// Offloads this page's interpretation (the content-stream parse + walk)
   /// to a background isolate when set and [showAnnotations] matches a
@@ -218,6 +225,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       _refreshPreview();
     }
     if (!identical(oldWidget.page, widget.page) ||
+        oldWidget.rotation != widget.rotation ||
         oldWidget.pageColor != widget.pageColor ||
         oldWidget.showAnnotations != widget.showAnnotations) {
       _dropPicture();
@@ -268,7 +276,7 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   /// The resolution the current zoom actually wants, uncapped.
   double _desiredRatio() {
-    final size = PdfPageRenderer.pageSize(widget.page);
+    final size = PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
     final width = math.max(1.0, size.width);
     // pages display fit-width, so the raster must match the on-screen
     // width — a 612pt page across a wide window needs far more pixels
@@ -278,7 +286,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   }
 
   double _effectiveRatio() {
-    final size = PdfPageRenderer.pageSize(widget.page);
+    final size = PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
     final width = math.max(1.0, size.width);
     final height = math.max(1.0, size.height);
     var ratio = _desiredRatio();
@@ -334,7 +342,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       if (commands != null) {
         _lastInterpretPath = 'worker';
         return PdfPageRenderer.pictureFromCommands(widget.page, commands,
-            pageColor: widget.pageColor);
+            pageColor: widget.pageColor, rotation: widget.rotation);
       }
     }
     if (_abandoned(pageIndex)) return _emptyPicture();
@@ -342,7 +350,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     // which case the interpret runs here — the log must say so, not 'worker'.
     _lastInterpretPath = 'recorded';
     return PdfPageRenderer.renderPictureRecorded(widget.page,
-        pageColor: widget.pageColor, annotations: widget.showAnnotations);
+        pageColor: widget.pageColor, annotations: widget.showAnnotations,
+        rotation: widget.rotation);
   }
 
   /// Whether the page this render was for is gone — the widget unmounted, or
@@ -398,7 +407,7 @@ class _PdfPageViewState extends State<PdfPageView> {
         (effective - _rasteredRatio!).abs() > _rasteredRatio! * 0.01;
     if (stale) {
       final image = await PdfPageRenderer.rasterize(
-          picture, PdfPageRenderer.pageSize(widget.page), effective);
+          picture, PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation), effective);
       if (_superseded(generation, pageIndex)) {
         image.dispose();
         return;
@@ -419,7 +428,8 @@ class _PdfPageViewState extends State<PdfPageView> {
       final cache = widget.previewCache;
       if (cache != null && !cache.isFresh(widget.previewIndex, widget.page)) {
         unawaited(
-            cache.putFromPicture(widget.previewIndex, widget.page, picture));
+            cache.putFromPicture(widget.previewIndex, widget.page, picture,
+                rotation: widget.rotation));
       }
     }
     await _updateDetail();
@@ -460,7 +470,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       ((visible.bottom - pageRect.top + visible.height / 2) / pageRect.height)
           .clamp(0.0, 1.0),
     );
-    final size = PdfPageRenderer.pageSize(widget.page);
+    final size = PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
     final region = Rect.fromLTRB(
       fraction.left * size.width,
       fraction.top * size.height,
@@ -492,7 +502,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     final picture = await (_picture ??= PdfPageRenderer.renderPicture(
         widget.page,
         pageColor: widget.pageColor,
-        annotations: widget.showAnnotations));
+        annotations: widget.showAnnotations,
+        rotation: widget.rotation));
     if (!mounted || generation != _detailGeneration) return;
     final image = await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
     if (!mounted || generation != _detailGeneration) {
@@ -508,7 +519,7 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   @override
   Widget build(BuildContext context) {
-    final size = PdfPageRenderer.pageSize(widget.page);
+    final size = PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
     final hasArea = size.width > 0 && size.height > 0;
     return LayoutBuilder(builder: (context, constraints) {
       final width = constraints.maxWidth;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -128,6 +128,7 @@ class PdfViewerController extends ChangeNotifier {
 
   int _pageCount = 0;
   int _currentPage = 0;
+  int _viewRotation = 0;
   bool _searching = false;
   String _query = '';
   PdfSearchOptions _searchOptions = const PdfSearchOptions();
@@ -139,6 +140,22 @@ class PdfViewerController extends ChangeNotifier {
 
   /// Zero-based index of the page nearest the viewport center.
   int get currentPage => _currentPage;
+
+  /// Extra rotation applied to every page's display, in degrees (0, 90,
+  /// 180, or 270). This is a view-only setting — the document's /Rotate
+  /// entries are untouched.
+  int get viewRotation => _viewRotation;
+
+  /// Rotates the view by [degrees] (typically ±90). The effective display
+  /// rotation of each page becomes `(page.rotation + viewRotation) % 360`.
+  /// This is a view-only transform — the PDF is not modified.
+  void rotateView(int degrees) {
+    final next = ((_viewRotation + degrees) % 360 + 360) % 360;
+    if (next == _viewRotation) return;
+    _viewRotation = next;
+    _state?._onViewRotationChanged();
+    notifyListeners();
+  }
 
   /// Current zoom factor (1 = fit width; below 1 the pages lay out
   /// smaller so more of the document is on screen).
@@ -1090,7 +1107,8 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
         await _previews.renderPreview(index, page,
             pageColor: widget.pageColor,
             annotations: widget.showAnnotations,
-            worker: widget.renderWorker);
+            worker: widget.renderWorker,
+            rotation: _effectiveRotation(index));
         if (!mounted) return;
         // breathe between interpreter walks — each is a synchronous
         // UI-thread chunk, so give the engine a frame for input and
@@ -1260,9 +1278,12 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// page count, same aspect ratio per page.
   bool _sameGeometryAs(PdfDocument document) {
     if (document.pageCount != _pages.length) return false;
+    final vr = _controller._viewRotation;
     for (var i = 0; i < _pages.length; i++) {
       final page = document.page(i);
-      final aspect = _isRotatedSideways(page)
+      final r = ((page.rotation + vr) % 360 + 360) % 360;
+      final sideways = r == 90 || r == 270;
+      final aspect = sideways
           ? page.cropBox.width / math.max(1e-6, page.cropBox.height)
           : page.cropBox.height / math.max(1e-6, page.cropBox.width);
       if ((aspect - _aspects[i]).abs() > 1e-6) return false;
@@ -1270,25 +1291,46 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     return true;
   }
 
+  /// The effective display rotation of page [index], combining the page's
+  /// own /Rotate and the controller's view rotation.
+  int _effectiveRotation(int index) =>
+      ((_pages[index].rotation + _controller._viewRotation) % 360 + 360) % 360;
+
   void _loadPages() {
     final count = widget.document.pageCount;
     _pages = [for (var i = 0; i < count; i++) widget.document.page(i)];
-    _aspects = [
-      for (final page in _pages)
-        _isRotatedSideways(page)
-            ? page.cropBox.width / math.max(1e-6, page.cropBox.height)
-            : page.cropBox.height / math.max(1e-6, page.cropBox.width),
-    ];
+    _recomputeAspects();
     _controller._setPageCount(count);
   }
 
+  void _recomputeAspects() {
+    _aspects = [
+      for (var i = 0; i < _pages.length; i++)
+        _isEffectivelySideways(i)
+            ? _pages[i].cropBox.width / math.max(1e-6, _pages[i].cropBox.height)
+            : _pages[i].cropBox.height / math.max(1e-6, _pages[i].cropBox.width),
+    ];
+  }
+
+  void _onViewRotationChanged() {
+    _recomputeAspects();
+    _previews.clear();
+    _bindRasterCache();
+    _previewAttempts.clear();
+    setState(() {});
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _prerenderPreviews();
+    });
+  }
+
   /// The disk-raster key for the current document under the current paper
-  /// color and annotation visibility — those are baked into a preview, so
-  /// changing either must not load a mismatched cached raster.
+  /// color, annotation visibility, and view rotation — those are baked into
+  /// a preview, so changing any must not load a mismatched cached raster.
   String? _rasterKey() {
     final id = widget.documentId;
     if (id == null) return null;
-    return '$id|${widget.pageColor.toARGB32()}|${widget.showAnnotations}';
+    final vr = _controller._viewRotation;
+    return '$id|${widget.pageColor.toARGB32()}|${widget.showAnnotations}|$vr';
   }
 
   /// Binds (or unbinds) the preview cache's persistent backing to the open
@@ -1309,8 +1351,11 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     });
   }
 
-  static bool _isRotatedSideways(PdfPage page) =>
-      page.rotation == 90 || page.rotation == 270;
+  bool _isEffectivelySideways(int index) {
+    final r = _effectiveRotation(index);
+    return r == 90 || r == 270;
+  }
+
 
   @override
   void dispose() {
@@ -1571,7 +1616,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     final pageWidth = _viewWidth * _layoutZoom;
     final geometry = PdfPageGeometry(
       cropBox: box,
-      rotation: page.rotation,
+      rotation: _effectiveRotation(index),
       viewSize: Size(pageWidth, _pageHeight(index)),
     );
     final target = geometry.toViewRect(rect);
@@ -1812,7 +1857,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     if (box.width <= 0 || box.height <= 0) return null;
     return PdfPageGeometry(
       cropBox: box,
-      rotation: _pages[index].rotation,
+      rotation: _effectiveRotation(index),
       viewSize: Size(_viewWidth * _layoutZoom, _pageHeight(index)),
     );
   }
@@ -3159,6 +3204,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
               widthFactor: _layoutZoom,
               child: _PdfViewerPage(
                 page: _pages[index],
+                effectiveRotation: _effectiveRotation(index),
                 index: index,
                 pageColor: widget.pageColor,
                 showAnnotations: widget.showAnnotations,
@@ -3523,6 +3569,7 @@ class _MoveDragPreviewPainter extends CustomPainter {
 class _PdfViewerPage extends StatefulWidget {
   const _PdfViewerPage({
     required this.page,
+    required this.effectiveRotation,
     required this.index,
     required this.pageColor,
     required this.showAnnotations,
@@ -3556,6 +3603,10 @@ class _PdfViewerPage extends StatefulWidget {
   });
 
   final PdfPage page;
+
+  /// The combined document + view rotation for this page.
+  final int effectiveRotation;
+
   final int index;
   final Color pageColor;
   final bool showAnnotations;
@@ -3668,6 +3719,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
     return Stack(children: [
       PdfPageView(
         page: widget.page,
+        rotation: widget.effectiveRotation,
         scale: widget.scale,
         settleGeneration: widget.settleGeneration,
         pageColor: widget.pageColor,
@@ -3685,7 +3737,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
           child: CustomPaint(
             painter: _FormFieldPainter(
               box: widget.page.cropBox,
-              rotation: widget.page.rotation,
+              rotation: widget.effectiveRotation,
               fields: widget.formFields,
               theme: PdfViewerTheme.of(context),
             ),
@@ -3695,7 +3747,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         child: CustomPaint(
           painter: _HighlightPainter(
             box: widget.page.cropBox,
-            rotation: widget.page.rotation,
+            rotation: widget.effectiveRotation,
             matches: widget.matches,
             currentMatch: widget.currentMatch,
             selection: widget.selection,
@@ -3720,7 +3772,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
           child: LayoutBuilder(builder: (context, constraints) {
             final geometry = PdfPageGeometry(
               cropBox: widget.page.cropBox,
-              rotation: widget.page.rotation,
+              rotation: widget.effectiveRotation,
               viewSize: constraints.biggest,
             );
             return Stack(children: [

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -110,11 +110,12 @@ class PdfPagePreviewCache extends ChangeNotifier {
   Future<void> renderPreview(int index, PdfPage page,
       {Color pageColor = const Color(0xFFFFFFFF),
       bool annotations = true,
-      PdfRenderWorker? worker}) async {
+      PdfRenderWorker? worker,
+      int? rotation}) async {
     if (_disposed || isFresh(index, page)) return;
     try {
       final sw = Stopwatch()..start();
-      final size = PdfPageRenderer.pageSize(page);
+      final size = PdfPageRenderer.pageSize(page, rotation: rotation);
       final ratio = _ratioFor(size);
       // priority 1: prefetch yields to any on-screen page the worker owes
       final commands = worker != null && worker.isActive
@@ -124,7 +125,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
       final ui.Image image;
       if (commands != null) {
         final picture = await PdfPageRenderer.pictureFromCommands(page, commands,
-            pageColor: pageColor);
+            pageColor: pageColor, rotation: rotation);
         try {
           image = await PdfPageRenderer.rasterize(picture, size, ratio);
         } finally {
@@ -135,7 +136,8 @@ class PdfPagePreviewCache extends ChangeNotifier {
             pixelRatio: ratio,
             pageColor: pageColor,
             annotations: annotations,
-            recorded: true);
+            recorded: true,
+            rotation: rotation);
       }
       sw.stop();
       PdfPerfLog.log('prerender page=$index '
@@ -151,10 +153,10 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// population as pages render on screen (raster-thread work only, no
   /// second interpreter walk). The picture stays owned by the caller.
   Future<void> putFromPicture(int index, PdfPage page,
-      ui.Picture picture) async {
+      ui.Picture picture, {int? rotation}) async {
     if (_disposed || isFresh(index, page)) return;
     try {
-      final size = PdfPageRenderer.pageSize(page);
+      final size = PdfPageRenderer.pageSize(page, rotation: rotation);
       final image =
           await PdfPageRenderer.rasterize(picture, size, _ratioFor(size));
       _store(index, page, image);

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -35,7 +35,8 @@ class PdfPageRenderer {
   static Future<ui.Picture> renderPicture(PdfPage page,
       {Color pageColor = const Color(0xFFFFFFFF),
       bool annotations = true,
-      bool Function(PdfAnnotation)? skipAnnotation}) async {
+      bool Function(PdfAnnotation)? skipAnnotation,
+      int? rotation}) async {
     final cos = page.document.cos;
 
     // Parsing the content stream (and decompressing it) dominates rendering on
@@ -56,12 +57,12 @@ class PdfPageRenderer {
         await decodeImages(cos, collector.streams, cache: PdfImageCache.instance);
 
     final box = page.cropBox;
-    final size = pageSize(page);
+    final size = pageSize(page, rotation: rotation);
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
 
     _paintBackground(canvas, size, pageColor);
-    _applyPageTransform(canvas, page, size, box);
+    _applyPageTransform(canvas, page, size, box, rotation: rotation);
 
     final painting = PdfInterpreter(
         cos: cos, device: CanvasPdfDevice(canvas, images: images))
@@ -95,7 +96,8 @@ class PdfPageRenderer {
   static Future<ui.Picture> renderPictureRecorded(PdfPage page,
       {Color pageColor = const Color(0xFFFFFFFF),
       bool annotations = true,
-      bool Function(PdfAnnotation)? skipAnnotation}) async {
+      bool Function(PdfAnnotation)? skipAnnotation,
+      int? rotation}) async {
     final cos = page.document.cos;
     final pageOps = ContentStreamParser.parse(page.contentBytes());
 
@@ -111,12 +113,12 @@ class PdfPageRenderer {
         cache: PdfImageCache.instance);
 
     final box = page.cropBox;
-    final size = pageSize(page);
+    final size = pageSize(page, rotation: rotation);
     final uiRecorder = ui.PictureRecorder();
     final canvas = Canvas(uiRecorder);
 
     _paintBackground(canvas, size, pageColor);
-    _applyPageTransform(canvas, page, size, box);
+    _applyPageTransform(canvas, page, size, box, rotation: rotation);
 
     replayCommands(recorder.commands, CanvasPdfDevice(canvas, images: images));
     final picture = uiRecorder.endRecording();
@@ -140,7 +142,8 @@ class PdfPageRenderer {
   /// running the codec. An image-free buffer decodes nothing.
   static Future<ui.Picture> pictureFromCommands(
       PdfPage page, List<PdfRenderCommand> commands,
-      {Color pageColor = const Color(0xFFFFFFFF)}) async {
+      {Color pageColor = const Color(0xFFFFFFFF),
+      int? rotation}) async {
     final requests = <PdfImageRequest>[];
     _collectImageRequests(commands, requests);
     final images = requests.isEmpty
@@ -149,11 +152,11 @@ class PdfPageRenderer {
             cache: PdfImageCache.instance);
 
     final box = page.cropBox;
-    final size = pageSize(page);
+    final size = pageSize(page, rotation: rotation);
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
     _paintBackground(canvas, size, pageColor);
-    _applyPageTransform(canvas, page, size, box);
+    _applyPageTransform(canvas, page, size, box, rotation: rotation);
     replayCommands(commands, CanvasPdfDevice(canvas, images: images));
     final picture = recorder.endRecording();
     for (final image in images.values) {
@@ -195,8 +198,9 @@ class PdfPageRenderer {
   /// Sets the canvas up in PDF user space: /Rotate, then the y-flip and crop
   /// box origin, so interpreter output (page space, y-up) lands correctly.
   static void _applyPageTransform(
-      Canvas canvas, PdfPage page, Size size, PdfRect box) {
-    switch (page.rotation) {
+      Canvas canvas, PdfPage page, Size size, PdfRect box,
+      {int? rotation}) {
+    switch (rotation ?? page.rotation) {
       case 90:
         canvas.translate(size.width, 0);
         canvas.rotate(math.pi / 2);
@@ -218,7 +222,7 @@ class PdfPageRenderer {
   /// 1 point) but with a transparent background — for live drag/resize
   /// previews. Null when the annotation has no appearance stream.
   static Future<ui.Picture?> renderAnnotationPicture(
-      PdfPage page, PdfAnnotation annotation) async {
+      PdfPage page, PdfAnnotation annotation, {int? rotation}) async {
     if (annotation.normalAppearance == null) return null;
     final cos = page.document.cos;
 
@@ -229,10 +233,10 @@ class PdfPageRenderer {
         await decodeImages(cos, collector.streams, cache: PdfImageCache.instance);
 
     final box = page.cropBox;
-    final size = pageSize(page);
+    final size = pageSize(page, rotation: rotation);
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
-    _applyPageTransform(canvas, page, size, box);
+    _applyPageTransform(canvas, page, size, box, rotation: rotation);
 
     PdfInterpreter(cos: cos, device: CanvasPdfDevice(canvas, images: images))
         .drawAnnotation(page, annotation);
@@ -248,14 +252,18 @@ class PdfPageRenderer {
       {double pixelRatio = 1,
       Color pageColor = const Color(0xFFFFFFFF),
       bool annotations = true,
-      bool recorded = false}) async {
+      bool recorded = false,
+      int? rotation}) async {
     final picture = recorded
         ? await renderPictureRecorded(page,
-            pageColor: pageColor, annotations: annotations)
+            pageColor: pageColor, annotations: annotations,
+            rotation: rotation)
         : await renderPicture(page,
-            pageColor: pageColor, annotations: annotations);
+            pageColor: pageColor, annotations: annotations,
+            rotation: rotation);
     try {
-      return await rasterize(picture, pageSize(page), pixelRatio);
+      return await rasterize(picture, pageSize(page, rotation: rotation),
+          pixelRatio);
     } finally {
       picture.dispose();
     }
@@ -307,15 +315,22 @@ class PdfPageRenderer {
   /// live preview) build a [PdfPageColorSampler] once instead.
   static Future<ui.Color?> sampleColor(PdfPage page, ui.Offset point,
           {Color pageColor = const Color(0xFFFFFFFF),
-          bool annotations = true}) async =>
+          bool annotations = true,
+          int? rotation}) async =>
       (await PdfPageColorSampler.of(page,
-              pageColor: pageColor, annotations: annotations))
+              pageColor: pageColor, annotations: annotations,
+              rotation: rotation))
           .colorAt(point);
 
-  /// Page size in points after applying /Rotate.
-  static Size pageSize(PdfPage page) {
+  /// Page size in points after applying rotation.
+  ///
+  /// [rotation] overrides the page's own /Rotate when set — the view
+  /// rotation feature uses this to display a page at a different
+  /// orientation without modifying the document.
+  static Size pageSize(PdfPage page, {int? rotation}) {
     final box = page.cropBox;
-    final swap = page.rotation == 90 || page.rotation == 270;
+    final r = rotation ?? page.rotation;
+    final swap = r == 90 || r == 270;
     return swap ? Size(box.height, box.width) : Size(box.width, box.height);
   }
 }
@@ -338,12 +353,13 @@ class PdfPageColorSampler {
   /// read the color the user actually sees.
   static Future<PdfPageColorSampler> of(PdfPage page,
       {Color pageColor = const Color(0xFFFFFFFF),
-      bool annotations = true}) async {
+      bool annotations = true,
+      int? rotation}) async {
     final picture = await PdfPageRenderer.renderPicture(page,
-        pageColor: pageColor, annotations: annotations);
+        pageColor: pageColor, annotations: annotations, rotation: rotation);
     try {
       final image = await PdfPageRenderer.rasterize(
-          picture, PdfPageRenderer.pageSize(page), 1);
+          picture, PdfPageRenderer.pageSize(page, rotation: rotation), 1);
       try {
         final data = await image.toByteData();
         if (data == null) {

--- a/packages/dart_pdf_editor/test/view_rotation_test.dart
+++ b/packages/dart_pdf_editor/test/view_rotation_test.dart
@@ -1,0 +1,295 @@
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// One 200×300 page with /Rotate [rotation] and a black 20×20 square
+/// at (100, 150)..(120, 170) in page space.
+Uint8List _buildRotatedPdf(int rotation) {
+  const content = '0 g 100 150 20 20 re f';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 300] '
+        '/Rotate $rotation /Contents 4 0 R >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
+void main() {
+  group('PdfViewerController.rotateView', () {
+    test('starts at 0', () {
+      final controller = PdfViewerController();
+      expect(controller.viewRotation, 0);
+    });
+
+    test('accumulates clockwise rotations', () {
+      final controller = PdfViewerController();
+      controller.rotateView(90);
+      expect(controller.viewRotation, 90);
+      controller.rotateView(90);
+      expect(controller.viewRotation, 180);
+      controller.rotateView(90);
+      expect(controller.viewRotation, 270);
+      controller.rotateView(90);
+      expect(controller.viewRotation, 0);
+    });
+
+    test('normalizes negative values', () {
+      final controller = PdfViewerController();
+      controller.rotateView(-90);
+      expect(controller.viewRotation, 270);
+      controller.rotateView(-90);
+      expect(controller.viewRotation, 180);
+    });
+
+    test('full turn is a no-op', () {
+      final controller = PdfViewerController();
+      var notified = false;
+      controller.addListener(() => notified = true);
+      controller.rotateView(360);
+      expect(controller.viewRotation, 0);
+      expect(notified, isFalse);
+    });
+
+    test('notifies listeners', () {
+      final controller = PdfViewerController();
+      var count = 0;
+      controller.addListener(() => count++);
+      controller.rotateView(90);
+      expect(count, 1);
+    });
+  });
+
+  group('PdfPageRenderer.pageSize with rotation override', () {
+    testWidgets('rotation override swaps dimensions', (tester) async {
+      await tester.runAsync(() async {
+        final doc = PdfDocument.open(_buildRotatedPdf(0));
+        final page = doc.page(0);
+        // /Rotate 0: 200×300
+        final normal = PdfPageRenderer.pageSize(page);
+        expect(normal.width, 200);
+        expect(normal.height, 300);
+        // override 90: 300×200
+        final rotated = PdfPageRenderer.pageSize(page, rotation: 90);
+        expect(rotated.width, 300);
+        expect(rotated.height, 200);
+        // override 180: same as 0
+        final flipped = PdfPageRenderer.pageSize(page, rotation: 180);
+        expect(flipped.width, 200);
+        expect(flipped.height, 300);
+        // override 270: swapped like 90
+        final rot270 = PdfPageRenderer.pageSize(page, rotation: 270);
+        expect(rot270.width, 300);
+        expect(rot270.height, 200);
+      });
+    });
+
+    testWidgets('composes with document /Rotate', (tester) async {
+      await tester.runAsync(() async {
+        // Page has /Rotate 90 → native size is 300×200
+        final doc = PdfDocument.open(_buildRotatedPdf(90));
+        final page = doc.page(0);
+        final native = PdfPageRenderer.pageSize(page);
+        expect(native.width, 300);
+        expect(native.height, 200);
+        // Override rotation=180 on a /Rotate 90 page → effective 180
+        final overridden = PdfPageRenderer.pageSize(page, rotation: 180);
+        expect(overridden.width, 200);
+        expect(overridden.height, 300);
+      });
+    });
+  });
+
+  group('renderer with rotation override produces correct pixels', () {
+    for (final viewRot in [90, 180, 270]) {
+      testWidgets(
+          '/Rotate 0 + rotation:$viewRot matches /Rotate $viewRot native',
+          (tester) async {
+        await tester.runAsync(() async {
+          // Render a page with /Rotate 0, overriding to viewRot
+          final doc0 = PdfDocument.open(_buildRotatedPdf(0));
+          final page0 = doc0.page(0);
+          final img0 = await PdfPageRenderer.renderImage(page0,
+              rotation: viewRot);
+
+          // Render a page with /Rotate=viewRot natively
+          final docR = PdfDocument.open(_buildRotatedPdf(viewRot));
+          final pageR = docR.page(0);
+          final imgR = await PdfPageRenderer.renderImage(pageR);
+
+          expect(img0.width, imgR.width);
+          expect(img0.height, imgR.height);
+
+          final data0 =
+              (await img0.toByteData(format: ImageByteFormat.rawRgba))!
+                  .buffer
+                  .asUint8List();
+          final dataR =
+              (await imgR.toByteData(format: ImageByteFormat.rawRgba))!
+                  .buffer
+                  .asUint8List();
+
+          // pixel-identical
+          expect(data0.length, dataR.length);
+          var diffPixels = 0;
+          for (var i = 0; i < data0.length; i += 4) {
+            if ((data0[i] - dataR[i]).abs() > 1 ||
+                (data0[i + 1] - dataR[i + 1]).abs() > 1 ||
+                (data0[i + 2] - dataR[i + 2]).abs() > 1) {
+              diffPixels++;
+            }
+          }
+          expect(diffPixels, 0,
+              reason: 'rotation:$viewRot on /Rotate 0 should match '
+                  '/Rotate $viewRot native render');
+        });
+      });
+    }
+  });
+
+  group('PdfPageGeometry with view rotation', () {
+    test('effective rotation round-trips coordinates', () {
+      // Simulate a /Rotate 0 page viewed at 90° view rotation
+      // → effective rotation = 90, view size swaps
+      const geometry = PdfPageGeometry(
+        cropBox: PdfRect(0, 0, 200, 300),
+        rotation: 90,
+        viewSize: Size(300, 200),
+      );
+      final (x, y) = geometry.toPagePoint(geometry.toViewOffset(110, 160));
+      expect(x, moreOrLessEquals(110));
+      expect(y, moreOrLessEquals(160));
+    });
+
+    for (final effective in [0, 90, 180, 270]) {
+      testWidgets(
+          'toViewOffset hits the rendered mark at effective rotation $effective',
+          (tester) async {
+        await tester.runAsync(() async {
+          // Always /Rotate 0, override with effective rotation
+          final doc = PdfDocument.open(_buildRotatedPdf(0));
+          final page = doc.page(0);
+          final image = await PdfPageRenderer.renderImage(page,
+              rotation: effective);
+          final size =
+              Size(image.width.toDouble(), image.height.toDouble());
+          final geometry = PdfPageGeometry(
+            cropBox: page.cropBox,
+            rotation: effective,
+            viewSize: size,
+          );
+          final data =
+              (await image.toByteData(format: ImageByteFormat.rawRgba))!
+                  .buffer
+                  .asUint8List();
+          int pixelAt(Offset view) {
+            final x = view.dx.round().clamp(0, image.width - 1);
+            final y = view.dy.round().clamp(0, image.height - 1);
+            return data[(y * image.width + x) * 4];
+          }
+
+          // center of the square (110, 160) must be dark
+          expect(pixelAt(geometry.toViewOffset(110, 160)), lessThan(50),
+              reason: 'mark center at effective=$effective');
+          // far from the square must be white
+          expect(pixelAt(geometry.toViewOffset(50, 50)), greaterThan(200),
+              reason: 'empty area at effective=$effective');
+        });
+      });
+    }
+  });
+
+  group('viewer integration', () {
+    Future<PdfViewerController> pumpViewer(WidgetTester tester,
+        {Uint8List? bytes}) async {
+      final controller = PdfViewerController();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: PdfDocument.open(bytes ?? buildMultiPagePdf(3)),
+            controller: controller,
+            pagePreviews: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+      return controller;
+    }
+
+    testWidgets('rotateView changes the page layout aspect',
+        (tester) async {
+      final controller = await pumpViewer(tester);
+      // 612×792 page at fit-width in 800×600: tall page
+      final sizeBefore = tester.getSize(find.byType(PdfPageView).first);
+      expect(sizeBefore.width, greaterThan(sizeBefore.height * 0.5),
+          reason: 'portrait page should be taller than wide');
+
+      controller.rotateView(90);
+      await tester.pump();
+
+      // After 90° view rotation the page should be landscape
+      final sizeAfter = tester.getSize(find.byType(PdfPageView).first);
+      expect(sizeAfter.width, greaterThan(sizeAfter.height),
+          reason: 'page should be wider after 90° view rotation');
+    });
+
+    testWidgets('rotateView 360° returns to original layout',
+        (tester) async {
+      final controller = await pumpViewer(tester);
+      final sizeBefore = tester.getSize(find.byType(PdfPageView).first);
+
+      controller.rotateView(90);
+      await tester.pump();
+      controller.rotateView(90);
+      await tester.pump();
+      controller.rotateView(90);
+      await tester.pump();
+      controller.rotateView(90);
+      await tester.pump();
+
+      final sizeAfter = tester.getSize(find.byType(PdfPageView).first);
+      expect(sizeAfter.width, closeTo(sizeBefore.width, 1));
+      expect(sizeAfter.height, closeTo(sizeBefore.height, 1));
+    });
+
+    testWidgets('rotateView with an already-rotated document composes',
+        (tester) async {
+      // /Rotate 90 doc → native landscape. View rotate 90 → portrait again
+      final controller =
+          await pumpViewer(tester, bytes: _buildRotatedPdf(90));
+      final sizeBefore = tester.getSize(find.byType(PdfPageView).first);
+      // /Rotate 90 on 200×300 → 300×200 landscape
+      expect(sizeBefore.width, greaterThan(sizeBefore.height));
+
+      controller.rotateView(90);
+      await tester.pump();
+
+      // effective = 180 → 200×300 portrait
+      final sizeAfter = tester.getSize(find.byType(PdfPageView).first);
+      expect(sizeAfter.height, greaterThan(sizeAfter.width));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `PdfViewerController.rotateView(int degrees)` and `viewRotation` getter for Acrobat-style "View > Rotate View" — rotates the visual display without modifying the document's `/Rotate` property
- Threads an optional `rotation` override through `PdfPageRenderer`, `PdfPageView`, `PdfPagePreviewCache`, and the editing overlay so the entire render pipeline honours the transient view rotation
- Effective rotation = `(page.rotation + viewRotation) % 360` — composes cleanly with documents that already carry `/Rotate`
- Preview/raster caches are keyed and invalidated by view rotation; thumbnails stay at the document's native orientation (matching Acrobat behaviour)

## Test plan

- [x] Controller API: `rotateView` accumulates, normalizes negatives, no-ops on full turn, notifies listeners (5 tests)
- [x] Renderer: `pageSize` with rotation override swaps dimensions correctly, composes with document `/Rotate` (2 tests)
- [x] Pixel verification: `/Rotate 0` rendered with `rotation: N` produces identical pixels to `/Rotate N` native render (3 tests)
- [x] Geometry: `PdfPageGeometry` round-trips coordinates at all effective rotations, `toViewOffset` hits the rendered mark (5 tests)
- [x] Viewer widget: layout aspect changes on rotation, 360° returns to original, composition with `/Rotate` document (3 tests)
- [x] Analyzer: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1UB4r72PxUSWXyD47FWrD

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1UB4r72PxUSWXyD47FWrD)_