### PR TITLE
Fix text annotations on rotated pages appearing sideways

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1284,7 +1284,8 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.textFillColor),
           borderColor: _rgbOf(preferences.textBorderColor),
           borderWidth: preferences.strokeWidth,
-          author: author),
+          author: author,
+          pageRotation: _document.page(pageIndex).rotation),
       pages: [pageIndex]);
 
   void addFreeTextRich(
@@ -1294,7 +1295,8 @@ class PdfEditingController extends ChangeNotifier {
               fillColor: _rgbOf(preferences.textFillColor),
               borderColor: _rgbOf(preferences.textBorderColor),
               borderWidth: preferences.strokeWidth,
-              author: author),
+              author: author,
+              pageRotation: _document.page(pageIndex).rotation),
           pages: [pageIndex]);
 
   /// Places [text] as a default-sized FreeText annotation centered on
@@ -1324,7 +1326,8 @@ class PdfEditingController extends ChangeNotifier {
             fillColor: _rgbOf(preferences.textFillColor),
             borderColor: _rgbOf(preferences.textBorderColor),
             borderWidth: preferences.strokeWidth,
-            author: author),
+            author: author,
+            pageRotation: _document.page(pageIndex).rotation),
         pages: [pageIndex]);
     if (!pasted) return false;
     tool = PdfEditTool.select;
@@ -1341,7 +1344,8 @@ class PdfEditingController extends ChangeNotifier {
           (e) => e.addStamp(pageIndex, rect, text,
               color: color ?? _colorValue,
               opacity: preferences.opacity,
-              author: author),
+              author: author,
+              pageRotation: _document.page(pageIndex).rotation),
           pages: [pageIndex]);
 
   /// Places [imageBytes] (PNG or JPEG) centered on ([x], [y]) in page
@@ -1368,7 +1372,9 @@ class PdfEditingController extends ChangeNotifier {
     return apply(
         (e) => e.addImageStamp(pageIndex,
             PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image,
-            opacity: preferences.opacity, author: author),
+            opacity: preferences.opacity,
+            author: author,
+            pageRotation: _document.page(pageIndex).rotation),
         pages: [pageIndex]);
   }
 
@@ -1395,7 +1401,9 @@ class PdfEditingController extends ChangeNotifier {
     return apply(
         (e) => e.addImageStamp(pageIndex,
             PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image,
-            opacity: preferences.opacity, author: author),
+            opacity: preferences.opacity,
+            author: author,
+            pageRotation: _document.page(pageIndex).rotation),
         pages: [pageIndex]);
   }
 
@@ -1543,7 +1551,8 @@ class PdfEditingController extends ChangeNotifier {
             PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), text,
             color: color ?? _colorValue,
             opacity: preferences.opacity,
-            author: author),
+            author: author,
+            pageRotation: _document.page(pageIndex).rotation),
         pages: [pageIndex]);
   }
 
@@ -1569,7 +1578,10 @@ class PdfEditingController extends ChangeNotifier {
     return apply(
         (e) => e.addCheckMark(pageIndex,
             PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
-            color: _colorValue, opacity: preferences.opacity, author: author),
+            color: _colorValue,
+            opacity: preferences.opacity,
+            author: author,
+            pageRotation: _document.page(pageIndex).rotation),
         pages: [pageIndex]);
   }
 
@@ -3156,10 +3168,14 @@ class PdfEditingController extends ChangeNotifier {
               borderWidth: borderWidth ??
                   ((parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1),
               author: by,
-              name: nm);
+              name: nm,
+              pageRotation: _document.page(page).rotation);
         case 'Stamp':
           e.addStamp(page, rect, text,
-              color: color ?? 0xC03030, author: by, name: nm);
+              color: color ?? 0xC03030,
+              author: by,
+              name: nm,
+              pageRotation: _document.page(page).rotation);
         default: // 'Text'
           e.addNote(page, rect.left, rect.top, text,
               color: color ?? 0xFFD100, author: by, name: nm);
@@ -3201,7 +3217,8 @@ class PdfEditingController extends ChangeNotifier {
           borderColor: parsed?.borderColor,
           borderWidth: (parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1,
           author: by,
-          name: nm);
+          name: nm,
+          pageRotation: _document.page(page).rotation);
       if (rotation != 0) {
         final added = _document.page(page).annotations;
         if (added.isNotEmpty) {

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1260,11 +1260,13 @@ extension PdfAnnotationEditing on PdfEditor {
     double borderWidth = 1,
     String? author,
     String? name,
+    int pageRotation = 0,
   }) {
     // The font accumulates which glyphs the appearance shows (so an
     // embedded font's /W and /ToUnicode cover exactly them); start fresh.
     if (font is PdfEmbeddedFont) font.resetUsage();
-    final w = _freeTextContent(rect, text,
+    final (bbox, matrix) = _rotatedFormSetup(rect, pageRotation);
+    final w = _freeTextContent(bbox, text,
         fontSize: fontSize,
         font: font,
         textDirection: textDirection,
@@ -1291,7 +1293,7 @@ extension PdfAnnotationEditing on PdfEditor {
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, w, resources: _resources(font: fontResource)),
+      _form(bbox, w, resources: _resources(font: fontResource), matrix: matrix),
       name: name,
     );
   }
@@ -1313,6 +1315,7 @@ extension PdfAnnotationEditing on PdfEditor {
     double borderWidth = 1,
     String? author,
     String? name,
+    int pageRotation = 0,
   }) {
     final nonEmpty = [
       for (final run in runs)
@@ -1323,7 +1326,8 @@ extension PdfAnnotationEditing on PdfEditor {
     for (final font in _richFonts(nonEmpty)) {
       if (font is PdfEmbeddedFont) font.resetUsage();
     }
-    final w = _freeTextRichContent(rect, nonEmpty,
+    final (bbox, matrix) = _rotatedFormSetup(rect, pageRotation);
+    final w = _freeTextRichContent(bbox, nonEmpty,
         textDirection: textDirection,
         fillColor: fillColor,
         borderColor: borderColor,
@@ -1346,7 +1350,9 @@ extension PdfAnnotationEditing on PdfEditor {
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, w, resources: _resources(font: _richFontResources(nonEmpty))),
+      _form(bbox, w,
+          resources: _resources(font: _richFontResources(nonEmpty)),
+          matrix: matrix),
       name: name,
     );
   }
@@ -1608,14 +1614,17 @@ extension PdfAnnotationEditing on PdfEditor {
     double opacity = 1,
     String? author,
     String? name,
+    int pageRotation = 0,
   }) {
-    final (w, gs) = _stampContent(rect, text, color, opacity);
+    final (bbox, matrix) = _rotatedFormSetup(rect, pageRotation);
+    final (w, gs) = _stampContent(bbox, text, color, opacity);
     _addAnnotation(
       pageIndex,
       _markupDict('Stamp', rect, color, text, author),
-      _form(rect, w,
+      _form(bbox, w,
           resources: _resources(
-              extGState: gs, font: _helvetica(bold: true, name: 'HelvB'))),
+              extGState: gs, font: _helvetica(bold: true, name: 'HelvB')),
+          matrix: matrix),
       name: name,
     );
   }
@@ -1666,13 +1675,17 @@ extension PdfAnnotationEditing on PdfEditor {
     double opacity = 1,
     String? author,
     String? name,
+    int pageRotation = 0,
   }) {
-    final (w, gs) = _checkMarkContent(rect, color, opacity);
+    final (bbox, matrix) = _rotatedFormSetup(rect, pageRotation);
+    final (w, gs) = _checkMarkContent(bbox, color, opacity);
     _addAnnotation(
       pageIndex,
       _markupDict('Stamp', rect, color, null, author)
         ..['Name'] = const CosName('Check'),
-      _form(rect, w, resources: gs == null ? null : _resources(extGState: gs)),
+      _form(bbox, w,
+          resources: gs == null ? null : _resources(extGState: gs),
+          matrix: matrix),
       name: name,
     );
   }
@@ -1715,25 +1728,26 @@ extension PdfAnnotationEditing on PdfEditor {
     double opacity = 1,
     String? author,
     String? name,
+    int pageRotation = 0,
   }) {
     final imageRef = _updater
         .addObject(image.toXObject((smask) => _updater.addObject(smask)));
+    final (bbox, matrix) = _rotatedFormSetup(rect, pageRotation);
     final w = ContentWriter();
     final gs = _alphaState(opacity);
     if (gs != null) w.extGState('GS0');
-    // a unit image (1×1 at the origin) mapped onto the rect in page space —
-    // the form's BBox is the rect, so the §12.5.5 fit is the identity
     w
       ..save()
-      ..concatMatrix(rect.width, 0, 0, rect.height, rect.left, rect.bottom)
+      ..concatMatrix(bbox.width, 0, 0, bbox.height, bbox.left, bbox.bottom)
       ..drawXObject('Img0')
       ..restore();
     _addAnnotation(
       pageIndex,
       _markupDict('Stamp', rect, 0xC03030, null, author),
-      _form(rect, w,
+      _form(bbox, w,
           resources: _resources(
-              extGState: gs, xObject: CosDictionary({'Img0': imageRef}))),
+              extGState: gs, xObject: CosDictionary({'Img0': imageRef})),
+          matrix: matrix),
       name: name,
     );
   }
@@ -2068,7 +2082,9 @@ extension PdfAnnotationEditing on PdfEditor {
         to.height <= 0) {
       throw ArgumentError('resizeAnnotation needs non-degenerate rects');
     }
-    final regenerated = _regenerateResizedAppearance(annotation, to);
+    final pageRotation = document.page(pageIndex).rotation;
+    final regenerated = _regenerateResizedAppearance(annotation, to,
+        pageRotation: pageRotation);
     if (!regenerated && (flipX || flipY)) {
       final form = annotation.normalAppearance;
       if (form != null) _flipFormArtwork(form, flipX: flipX, flipY: flipY);
@@ -2241,7 +2257,9 @@ extension PdfAnnotationEditing on PdfEditor {
       return;
     }
 
-    if (_regenerateResizedAppearance(annotation, localTo)) {
+    final pageRotation = document.page(pageIndex).rotation;
+    if (_regenerateResizedAppearance(annotation, localTo,
+        pageRotation: pageRotation)) {
       // a fresh, unrotated appearance at the local box — re-applying the
       // resting angle is then plain rotation (which also sets /Rect).
       // PdfAnnotation parses /Rect once, so rotate a re-wrapped view of
@@ -2326,7 +2344,7 @@ extension PdfAnnotationEditing on PdfEditor {
   /// [opacity], when given, replaces the alpha the old appearance
   /// carried — [restyleAnnotation]'s opacity path.
   bool _regenerateResizedAppearance(PdfAnnotation annotation, PdfRect to,
-      {double? opacity}) {
+      {double? opacity, int pageRotation = 0}) {
     final form = annotation.normalAppearance;
     if (form == null) return false;
     final dict = annotation.dict;
@@ -2348,7 +2366,8 @@ extension PdfAnnotationEditing on PdfEditor {
         if (style == null) return false;
         final font = PdfStandardFont.tryFromName(style.fontName);
         if (font == null) return false;
-        final w = _freeTextContent(to, annotation.contents ?? '',
+        final (bbox, matrix) = _rotatedFormSetup(to, pageRotation);
+        final w = _freeTextContent(bbox, annotation.contents ?? '',
             fontSize: style.fontSize,
             font: font,
             textDirection: _annotationTextDirection(annotation),
@@ -2356,8 +2375,9 @@ extension PdfAnnotationEditing on PdfEditor {
             fillColor: style.fillColor,
             borderColor: style.borderColor,
             borderWidth: style.borderWidth);
-        _replaceAppearance(dict, form, to, w,
-            resources: _resources(font: _standardFont(font)));
+        _replaceAppearance(dict, form, bbox, w,
+            resources: _resources(font: _standardFont(font)),
+            matrix: matrix);
         return true;
       case 'Line':
         final line = annotation.line;
@@ -2581,11 +2601,12 @@ extension PdfAnnotationEditing on PdfEditor {
     // re-wrap: /Rect and style entries are parsed at construction or
     // lazily, and the dict just changed under the caller's instance
     final annotation = PdfAnnotation.fromDict(document, dict);
+    final pageRotation = document.page(pageIndex).rotation;
     final quad = annotation.appearanceQuad;
     final theta = quad == null ? 0.0 : _quadRotation(quad);
     if (theta == 0) {
       if (!_regenerateStyledAppearance(annotation, annotation.rect,
-          opacity: opacity)) {
+          opacity: opacity, pageRotation: pageRotation)) {
         return false;
       }
       _markAnnotationChanged(pageIndex, dict);
@@ -2600,7 +2621,8 @@ extension PdfAnnotationEditing on PdfEditor {
     final h = math.sqrt((ulx - llx) * (ulx - llx) + (uly - lly) * (uly - lly));
     if (w < 1e-9 || h < 1e-9) return false;
     final local = PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2);
-    if (!_regenerateStyledAppearance(annotation, local, opacity: opacity)) {
+    if (!_regenerateStyledAppearance(annotation, local,
+        opacity: opacity, pageRotation: pageRotation)) {
       return false;
     }
     dict['Rect'] = _rectArray(local);
@@ -2613,7 +2635,7 @@ extension PdfAnnotationEditing on PdfEditor {
   /// subtypes (stamps, notes), which regenerate at their current size
   /// but never resize this way.
   bool _regenerateStyledAppearance(PdfAnnotation annotation, PdfRect to,
-      {double? opacity}) {
+      {double? opacity, int pageRotation = 0}) {
     switch (annotation.subtype) {
       case 'Square' ||
             'Circle' ||
@@ -2621,16 +2643,19 @@ extension PdfAnnotationEditing on PdfEditor {
             'Line' ||
             'PolyLine' ||
             'Polygon':
-        return _regenerateResizedAppearance(annotation, to, opacity: opacity);
+        return _regenerateResizedAppearance(annotation, to,
+            opacity: opacity, pageRotation: pageRotation);
       case 'Stamp':
         final form = annotation.normalAppearance;
         if (form == null) return false;
         final color = annotation.color ?? 0xC03030;
-        final (w, gs) = _stampContent(to, annotation.contents ?? '', color,
+        final (bbox, matrix) = _rotatedFormSetup(to, pageRotation);
+        final (w, gs) = _stampContent(bbox, annotation.contents ?? '', color,
             opacity ?? _appearanceOpacity(form));
-        _replaceAppearance(annotation.dict, form, to, w,
+        _replaceAppearance(annotation.dict, form, bbox, w,
             resources: _resources(
-                extGState: gs, font: _helvetica(bold: true, name: 'HelvB')));
+                extGState: gs, font: _helvetica(bold: true, name: 'HelvB')),
+            matrix: matrix);
         return true;
       case 'Text':
         final form = annotation.normalAppearance;
@@ -2674,8 +2699,8 @@ extension PdfAnnotationEditing on PdfEditor {
   /// the same apply resolve it.
   void _replaceAppearance(
       CosDictionary annot, CosStream oldForm, PdfRect bbox, ContentWriter w,
-      {CosDictionary? resources}) {
-    final form = _form(bbox, w, resources: resources);
+      {CosDictionary? resources, List<double>? matrix}) {
+    final form = _form(bbox, w, resources: resources, matrix: matrix);
     final cos = document.cos;
     final ref = cos.referenceTo(oldForm);
     if (ref != null) {
@@ -3263,7 +3288,7 @@ extension PdfAnnotationEditing on PdfEditor {
   /// annotation rect in page coordinates — the §12.5.5 algorithm then maps
   /// it onto /Rect as the identity.
   CosStream _form(PdfRect bbox, ContentWriter content,
-      {CosDictionary? resources}) {
+      {CosDictionary? resources, List<double>? matrix}) {
     final bytes = content.takeBytes();
     final dict = CosDictionary({
       'Type': const CosName('XObject'),
@@ -3272,7 +3297,50 @@ extension PdfAnnotationEditing on PdfEditor {
       'Length': CosInteger(bytes.length),
     });
     if (resources != null) dict['Resources'] = resources;
+    if (matrix != null) {
+      dict['Matrix'] = CosArray([for (final v in matrix) CosReal(v)]);
+    }
     return CosStream(dict, bytes);
+  }
+
+  /// For orientation-sensitive annotations on rotated pages, returns the
+  /// visual BBox (dimensions as the user sees them, origin at 0) and the
+  /// /Matrix that maps from visual space back to the page-space /Rect.
+  ///
+  /// On a /Rotate 0 page the BBox equals [rect] and no /Matrix is needed.
+  /// On a rotated page, width/height swap (90°/270°) and the content is
+  /// counter-rotated so text appears horizontal on screen.
+  (PdfRect bbox, List<double>? matrix) _rotatedFormSetup(
+      PdfRect rect, int pageRotation) {
+    if (pageRotation == 0) return (rect, null);
+    final swap = pageRotation == 90 || pageRotation == 270;
+    final vw = swap ? rect.height : rect.width;
+    final vh = swap ? rect.width : rect.height;
+    final bbox = PdfRect(0, 0, vw, vh);
+    final lcx = vw / 2, lcy = vh / 2;
+    final pcx = (rect.left + rect.right) / 2;
+    final pcy = (rect.bottom + rect.top) / 2;
+    // Counter-rotate by -pageRotation: cos/sin of the negated angle.
+    final double ca, sa;
+    switch (pageRotation) {
+      case 90:
+        ca = 0;
+        sa = -1;
+      case 180:
+        ca = -1;
+        sa = 0;
+      case 270:
+        ca = 0;
+        sa = 1;
+      default:
+        return (rect, null);
+    }
+    // PDF matrix [a b c d e f]: x'=ax+cy+e, y'=bx+dy+f
+    // Rotation -R about local center, then translate to page-space center.
+    final a = ca, b = sa, c = -sa, d = ca;
+    final e = pcx - a * lcx - c * lcy;
+    final f = pcy - b * lcx - d * lcy;
+    return (bbox, [a, b, c, d, e, f]);
   }
 
   /// Stages [annot] (with its appearance [form]) and links it into the

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -1124,4 +1124,64 @@ void main() {
         roundTrip((e) => e.addHighlight(0, const [PdfRect(72, 700, 200, 712)]));
     expect(doc.page(0).annotations.single.flags & 4, 4);
   });
+
+  test('FreeText on a rotated page carries a counter-rotation /Matrix', () {
+    final base = PdfDocument.open(buildClassicPdf());
+    final editor = PdfEditor(base)
+      ..rotatePages([0], 90)
+      ..addFreeText(0, const PdfRect(100, 100, 250, 140), 'rotated text',
+          pageRotation: 90);
+    final doc = PdfDocument.open(editor.save());
+    final annot = doc.page(0).annotations.single;
+    expect(annot.subtype, 'FreeText');
+    expect(annot.rect, const PdfRect(100, 100, 250, 140));
+
+    final form = annot.normalAppearance!;
+    final matrixArray =
+        doc.cos.resolve(form.dictionary['Matrix']) as CosArray;
+    expect(matrixArray, isNotNull, reason: '/Matrix must be present');
+    expect(matrixArray.length, 6);
+
+    final bboxArray =
+        doc.cos.resolve(form.dictionary['BBox']) as CosArray;
+    double bboxNum(int i) {
+      final v = doc.cos.resolve(bboxArray[i]);
+      return v is CosInteger ? v.value.toDouble() : (v as CosReal).value;
+    }
+    final bboxW = (bboxNum(2) - bboxNum(0)).abs();
+    final bboxH = (bboxNum(3) - bboxNum(1)).abs();
+    // For 90° rotation, visual dimensions are swapped: the BBox width
+    // should be the rect height and vice versa.
+    expect(bboxW, closeTo(40, 0.1)); // rect height
+    expect(bboxH, closeTo(150, 0.1)); // rect width
+
+    // The appearance text should use the visual bbox dimensions for layout.
+    final content = appearanceText(doc, annot);
+    expect(content, contains('Tj'), reason: 'text draws in the appearance');
+  });
+
+  test('Stamp on a rotated page carries a counter-rotation /Matrix', () {
+    final base = PdfDocument.open(buildClassicPdf());
+    final editor = PdfEditor(base)
+      ..rotatePages([0], 270)
+      ..addStamp(0, const PdfRect(100, 100, 250, 140), 'APPROVED',
+          pageRotation: 270);
+    final doc = PdfDocument.open(editor.save());
+    final annot = doc.page(0).annotations.single;
+    expect(annot.subtype, 'Stamp');
+
+    final form = annot.normalAppearance!;
+    final matrixArray =
+        doc.cos.resolve(form.dictionary['Matrix']) as CosArray;
+    expect(matrixArray, isNotNull, reason: '/Matrix must be present');
+  });
+
+  test('annotations on an unrotated page have no /Matrix', () {
+    final doc = roundTrip((e) => e.addFreeText(
+        0, const PdfRect(100, 100, 250, 140), 'no rotation'));
+    final form = doc.page(0).annotations.single.normalAppearance!;
+    final matrix = form.dictionary['Matrix'];
+    expect(matrix == null || matrix is CosNull, isTrue,
+        reason: 'no /Matrix on an unrotated page');
+  });
 }


### PR DESCRIPTION
## Summary
- After `rotatePages()`, newly created FreeText/Stamp/ImageStamp/CheckMark annotations appeared sideways because their appearance content was drawn in unrotated page coordinates, then the renderer's page transform rotated it again
- Added `_rotatedFormSetup()` helper in `annotation_editor.dart` that computes a counter-rotation `/Matrix` for the appearance form XObject — content draws in visual coordinates (user-facing orientation) and the matrix maps back to page space
- All 11 controller call sites in `editing_controller.dart` now pass `pageRotation: _document.page(pageIndex).rotation` to the editor's creation methods
- Shapes/Lines/Ink/Markups are geometry-based and orientation-agnostic — no change needed
- Resize and restyle paths also look up the page rotation so regenerated appearances stay correct

## Test plan
- [x] 3 new tests in `annotation_editor_test.dart`: FreeText on 90° page has /Matrix + swapped BBox dims, Stamp on 270° page has /Matrix, unrotated page has no /Matrix
- [x] All 51 existing annotation_editor_test tests pass
- [x] All 8 annotation_restyle_test tests pass
- [x] All 38 page_ops_test tests pass
- [x] `fvm dart analyze` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuFfvdUEP5LEWreVsNQ27Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuFfvdUEP5LEWreVsNQ27Y)_