### PR TITLE
Configure Android native library extraction settings

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
     <application
         android:label="DartPDF"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:extractNativeLibs="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/android/gradle.properties
+++ b/app/android/gradle.properties
@@ -4,3 +4,4 @@ android.useAndroidX=true
 android.newDsl=false
 # This builtInKotlin flag was added by the Flutter template
 android.builtInKotlin=false
+android.bundle.enableUncompressedNativeLibs=true

--- a/packages/dart_pdf_editor/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/dart_pdf_editor/example/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="pdf_viewer_example"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:extractNativeLibs="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/packages/dart_pdf_editor/example/android/gradle.properties
+++ b/packages/dart_pdf_editor/example/android/gradle.properties
@@ -4,3 +4,4 @@ android.useAndroidX=true
 android.newDsl=false
 # This builtInKotlin flag was added by the Flutter template
 android.builtInKotlin=false
+android.bundle.enableUncompressedNativeLibs=true


### PR DESCRIPTION
## Summary

Adds Android configuration to disable native library extraction and enable uncompressed native libraries in app bundles. This reduces app size by keeping native libraries compressed in the APK/AAB and avoiding extraction to disk.

Changes:
- Set `android:extractNativeLibs="false"` in AndroidManifest.xml for both main app and example app
- Enable `android.bundle.enableUncompressedNativeLibs=true` in gradle.properties for both projects

## Affected packages

- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Performance change

## Validation

- [x] No code logic changes — configuration only
- [x] Changes are isolated to Android build configuration files

## Notes for reviewers

These are standard Android optimizations that:
1. Prevent the system from extracting native libraries to `/data/app/` at install time
2. Allow the system to load native libraries directly from the compressed APK/AAB
3. Reduce installed app size and storage footprint

No functional changes or test impact.

https://claude.ai/code/session_01LeCc3E7qTUknYyK9xcyyXJ