### PR TITLE
Fix web render worker compile break and hang on slow/silent worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
           cache: true
       - run: flutter pub get
       - run: dart analyze --fatal-infos
+      # Compile the web render worker. `dart analyze` does NOT catch
+      # `.toJS`-conversion errors (e.g. an async/Future-returning message
+      # handler), which only surface at `dart compile js` — the step the deploy
+      # workflows run. Gate it here so a broken worker can't merge green and
+      # silently ship a non-functional off-thread renderer.
+      - name: Compile web render worker
+        working-directory: packages/dart_pdf_editor/example
+        run: dart run dart_pdf_editor:build_web_worker
       - name: Activate coverage tool
         run: dart pub global activate coverage
 

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -14,6 +14,21 @@ import 'render_worker.dart';
 // disabled) — and show up in a user-captured trace when something declines.
 void _wlog(String m) => PdfPerfLog.log('webworker $m');
 
+/// How long to wait for the worker to post `'ready'` (it opens the document
+/// first) before giving up and rendering every page locally. The document
+/// bytes are transferred to the worker at start; on some hosts — notably a
+/// dart2wasm main app driving a dart2js worker — a large transfer or open can
+/// silently never complete, and with no bound the viewer would spin forever on
+/// such a document while small ones (a fast transfer/open) work. Generous: a
+/// healthy worker opens even a large CAD document in well under a second, so
+/// this only fires when the worker is genuinely wedged.
+Duration pdfRenderWorkerReadyTimeout = const Duration(seconds: 12);
+
+/// How long to wait for a single [PdfRenderWorker.record] reply before treating
+/// the worker as unresponsive and falling back to local rendering. The worst
+/// real page records in well under a second, so this only fires on a hang.
+Duration pdfRenderWorkerRecordTimeout = const Duration(seconds: 20);
+
 /// Web backend: a dedicated [web.Worker] that opens its own [PdfDocument] from
 /// the bytes once and records pages on request, posting the serialized command
 /// buffer back over `postMessage` (the document and result buffers travel as
@@ -60,6 +75,16 @@ class _WebRenderWorker implements PdfRenderWorker {
       ..setProperty('kind'.toJS, 'init'.toJS)
       ..setProperty('bytes'.toJS, jsBuffer);
     worker.postMessage(init, <JSAny>[jsBuffer].toJS);
+
+    // Watchdog: if the worker never reports 'ready' (e.g. the transferred
+    // document never arrived/opened on this host), give up and render locally
+    // rather than spin forever. Cancelled the moment 'ready' lands.
+    _readyWatchdog = Timer(pdfRenderWorkerReadyTimeout, () {
+      if (_ready || _disposed || _failed) return;
+      _wlog('ready watchdog fired after ${pdfRenderWorkerReadyTimeout.inSeconds}'
+          's — worker never opened the document; falling back to local');
+      _fail();
+    });
   }
 
   _WebRenderWorker.disabled() : _failed = true;
@@ -74,6 +99,11 @@ class _WebRenderWorker implements PdfRenderWorker {
   // The worker posts 'ready' once it has opened the document; records sent
   // before then would race the open, so they queue until it lands.
   bool _ready = false;
+  // Watchdogs that bound how long we wait on a silent worker before degrading
+  // to local rendering: one for the initial 'ready', one for each in-flight
+  // record's reply. See pdfRenderWorkerReadyTimeout / pdfRenderWorkerRecordTimeout.
+  Timer? _readyWatchdog;
+  Timer? _recordWatchdog;
 
   @override
   bool get isActive => !_disposed && !_failed;
@@ -84,6 +114,8 @@ class _WebRenderWorker implements PdfRenderWorker {
     final kind = (data.getProperty('kind'.toJS) as JSString?)?.toDart;
     if (kind == 'ready') {
       _wlog('ready (worker opened the document)');
+      _readyWatchdog?.cancel();
+      _readyWatchdog = null;
       _ready = true;
       _pump();
       return;
@@ -93,6 +125,8 @@ class _WebRenderWorker implements PdfRenderWorker {
     final request = _inFlight;
     if (request == null || request.id != id) return; // stale (disposed)
     _inFlight = null;
+    _recordWatchdog?.cancel();
+    _recordWatchdog = null;
     final buffer = data.getProperty('buffer'.toJS) as JSArrayBuffer?;
     final bytes = buffer?.toDart.asUint8List();
     final err = (data.getProperty('error'.toJS) as JSString?)?.toDart;
@@ -169,6 +203,21 @@ class _WebRenderWorker implements PdfRenderWorker {
       ..setProperty('page'.toJS, request.pageIndex.toJS)
       ..setProperty('annotations'.toJS, request.annotations.toJS);
     worker.postMessage(message);
+
+    // Watchdog: a record that never comes back wedges the single in-flight slot
+    // (and so every queued page) forever. Bound it — on a miss, treat the
+    // worker as unresponsive and degrade to local rendering for this and all
+    // subsequent pages.
+    _recordWatchdog?.cancel();
+    final inFlightId = request.id;
+    _recordWatchdog = Timer(pdfRenderWorkerRecordTimeout, () {
+      if (_disposed || _failed) return;
+      if (_inFlight?.id != inFlightId) return; // already answered
+      _wlog('record watchdog fired for page=${request.pageIndex} after '
+          '${pdfRenderWorkerRecordTimeout.inSeconds}s — worker unresponsive; '
+          'falling back to local');
+      _fail();
+    });
   }
 
   @override
@@ -195,6 +244,7 @@ class _WebRenderWorker implements PdfRenderWorker {
   void _fail() {
     if (_failed) return;
     _failed = true;
+    _cancelWatchdogs();
     _failPending();
   }
 
@@ -202,9 +252,17 @@ class _WebRenderWorker implements PdfRenderWorker {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _cancelWatchdogs();
     _worker?.terminate();
     _worker = null;
     _failPending();
+  }
+
+  void _cancelWatchdogs() {
+    _readyWatchdog?.cancel();
+    _readyWatchdog = null;
+    _recordWatchdog?.cancel();
+    _recordWatchdog = null;
   }
 
   /// Resolves every in-flight and queued request to null (local render) — on

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -33,18 +33,28 @@ void runPdfRenderWorker() {
   PdfDocument? document;
   PdfCancellationToken? activeToken;
 
-  scope.onmessage = ((web.MessageEvent event) async {
+  // The handler MUST stay synchronous (return void): `.toJS` cannot convert a
+  // Future-returning function, so an `async` handler fails `dart compile js`
+  // ("invalid types in its function signature: Future<Null> Function(...)").
+  // The cancellable record below therefore runs in a fire-and-forget inner
+  // async closure instead of making the handler itself async.
+  scope.onmessage = ((web.MessageEvent event) {
     final data = event.data as JSObject?;
     if (data == null) return;
     final kind = (data.getProperty('kind'.toJS) as JSString?)?.toDart;
 
     if (kind == 'init') {
-      final buffer = data.getProperty('bytes'.toJS) as JSArrayBuffer;
+      // Extract AND open inside the try: a malformed transfer (the cast or the
+      // ArrayBuffer view can throw on some hosts) must NOT skip the 'ready'
+      // reply below, or the main thread waits on it forever. A null document
+      // simply declines every page to a local render.
       try {
+        final buffer = data.getProperty('bytes'.toJS) as JSArrayBuffer;
         document = PdfDocument.open(buffer.toDart.asUint8List());
       } catch (_) {
-        document = null; // a broken document fails every page → local renders
+        document = null; // bad transfer / broken document → local renders
       }
+      // ALWAYS reply ready, even on failure, so the client never hangs.
       scope.postMessage(JSObject()..setProperty('kind'.toJS, 'ready'.toJS));
       return;
     }
@@ -62,34 +72,41 @@ void runPdfRenderWorker() {
 
     final token = PdfCancellationToken();
     activeToken = token;
-    Uint8List? out;
-    String? error;
-    final doc = document;
-    try {
-      if (doc != null) {
-        out = await _recordPageAsync(doc, page, annotations, token);
+    // Fire-and-forget: launch the cancellable walk without awaiting it here, so
+    // the message handler returns void (see the note above) while a subsequent
+    // 'cancel' message can still flip token.cancelled mid-walk.
+    () async {
+      Uint8List? out;
+      String? error;
+      final doc = document;
+      try {
+        if (doc != null) {
+          out = await _recordPageAsync(doc, page, annotations, token);
+        }
+      } on PdfCancelledException {
+        out = null;
+      } catch (e, st) {
+        out = null; // any failure → the main thread renders this page locally
+        error = '$e\n$st';
       }
-    } on PdfCancelledException {
-      out = null;
-    } catch (e, st) {
-      out = null; // any failure → the main thread renders this page locally
-      error = '$e\n$st';
-    }
-    activeToken = null;
+      // Only clear the active token if it is still ours — a newer record may
+      // have replaced it while this one was running.
+      if (identical(activeToken, token)) activeToken = null;
 
-    final result = JSObject()
-      ..setProperty('kind'.toJS, 'result'.toJS)
-      ..setProperty('id'.toJS, id.toJS);
-    if (out == null) {
-      result.setProperty('buffer'.toJS, null);
-      if (error != null) result.setProperty('error'.toJS, error.toJS);
-      scope.postMessage(result);
-    } else {
-      // Copy to an exact-length buffer, then transfer it (zero-copy).
-      final jsBuffer = Uint8List.fromList(out).buffer.toJS;
-      result.setProperty('buffer'.toJS, jsBuffer);
-      scope.postMessage(result, <JSAny>[jsBuffer].toJS);
-    }
+      final result = JSObject()
+        ..setProperty('kind'.toJS, 'result'.toJS)
+        ..setProperty('id'.toJS, id.toJS);
+      if (out == null) {
+        result.setProperty('buffer'.toJS, null);
+        if (error != null) result.setProperty('error'.toJS, error.toJS);
+        scope.postMessage(result);
+      } else {
+        // Copy to an exact-length buffer, then transfer it (zero-copy).
+        final jsBuffer = Uint8List.fromList(out).buffer.toJS;
+        result.setProperty('buffer'.toJS, jsBuffer);
+        scope.postMessage(result, <JSAny>[jsBuffer].toJS);
+      }
+    }();
   }).toJS;
 }
 


### PR DESCRIPTION
## Problem

The deployed web demo (`--wasm`) spun forever when loading a large (41 MB / 133-page CAD) document — spinner never cleared, UI stayed responsive, no console error. Small PDFs rendered fine.

## Root cause

PR #133 made the Web Worker's `scope.onmessage` handler `async` (to `await` the new cancellable record). But `.toJS` **cannot convert a `Future`-returning function**, so `dart run dart_pdf_editor:build_web_worker` — the step the deploy/preview workflows run — has failed to compile the worker ever since:

```
Function converted via 'toJS' contains invalid types in its function
signature: 'Future<Null> Function(MessageEvent)'.
```

`dart analyze` does not catch `.toJS` errors, and **`ci.yml` never builds the worker** (only the deploy/preview workflows do), so the break merged green. With a broken/never-rebuilt worker and **no client-side timeout**, the viewer awaited the worker's `ready`/result forever.

## Fix

- **`render_worker_web_entry.dart`** — keep the message handler synchronous; run the cancellable record in a fire-and-forget inner `async` closure (cancel-mid-walk preserved). Move the `init` `ArrayBuffer` cast inside the `try` so `ready` is always posted even on a malformed transfer.
- **`render_worker_web.dart`** — add a ready watchdog (12s) and per-record watchdog (20s) that degrade to local rendering instead of hanging forever if the worker goes silent. Safety net independent of the compile bug.
- **`ci.yml`** — compile the web render worker so a `.toJS`/async break can't merge green again.

## Verification

- `dart run dart_pdf_editor:build_web_worker` now succeeds (clean ~852 KB bundle) — failed on `main` before this.
- Full-workspace `dart analyze` clean.
- `render_worker_test.dart` 12/12 (isolate backend; the web backend is browser-only and can't be VM-unit-tested — the isolate test covers the shared interface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)