### PR TITLE
Disable Save button when there are no changes to save

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -712,7 +712,11 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           IconButton(
             icon: const Icon(Icons.save_alt),
             tooltip: 'Save… (⌘S / Ctrl+S)',
-            onPressed: () => widget.onSave!(controller.bytes),
+            // disabled while the document matches what was opened — there's
+            // nothing to write until an edit bumps the revision cursor
+            onPressed: controller.isModified
+                ? () => widget.onSave!(controller.bytes)
+                : null,
           ),
         ],
         if (widget.trailing.isNotEmpty) ...[

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -485,7 +485,15 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         TextSelection(baseOffset: 0, extentOffset: _searchField.text.length);
   }
 
-  void _save() => widget.onSave?.call(_session.bytes);
+  /// Whether there's anything to save: false while the document still
+  /// matches what was opened, which disables the Save button (and makes
+  /// the ⌘S / Ctrl+S shortcut a no-op).
+  bool get _canSave => _session.isModified;
+
+  void _save() {
+    if (!_canSave) return;
+    widget.onSave?.call(_session.bytes);
+  }
 
   void _saveAs() => widget.onSaveAs?.call(_session.bytes);
 
@@ -762,7 +770,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       ),
                       icon: const Icon(Icons.save_alt, size: 18),
                       label: const Text('Save'),
-                      onPressed: _save,
+                      onPressed: _canSave ? _save : null,
                     ),
                 ],
                 compactSheetChildren: [
@@ -783,6 +791,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       key: const ValueKey('pdf-shell-save'),
                       icon: Icons.save_alt,
                       label: 'Save',
+                      enabled: _canSave,
                       onPressed: _save,
                     ),
                 ],

--- a/packages/dart_pdf_editor/test/editing_polish_test.dart
+++ b/packages/dart_pdf_editor/test/editing_polish_test.dart
@@ -185,6 +185,7 @@ void main() {
     testWidgets('disabled until there are unsaved changes', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       final viewer = PdfViewerController();
+      Uint8List? saved;
       addTearDown(editing.dispose);
       addTearDown(viewer.dispose);
       await tester.pumpWidget(MaterialApp(
@@ -192,7 +193,7 @@ void main() {
           body: PdfEditingToolbar(
             controller: editing,
             viewerController: viewer,
-            onSave: (_) {},
+            onSave: (bytes) => saved = bytes,
           ),
         ),
       ));
@@ -206,6 +207,11 @@ void main() {
       editing.addRectangle(0, const PdfRect(100, 550, 300, 650));
       await tester.pump();
       expect(saveButton().onPressed, isNotNull);
+
+      // pressing it hands the host the current revision's bytes
+      saveButton().onPressed!();
+      expect(saved, isNotNull);
+      expect(saved!.length, editing.bytes.length);
 
       // undoing back to the original disables it again
       editing.undo();

--- a/packages/dart_pdf_editor/test/editing_polish_test.dart
+++ b/packages/dart_pdf_editor/test/editing_polish_test.dart
@@ -181,6 +181,39 @@ void main() {
     });
   });
 
+  group('toolbar save button', () {
+    testWidgets('disabled until there are unsaved changes', (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+            onSave: (_) {},
+          ),
+        ),
+      ));
+      IconButton saveButton() => tester.widget<IconButton>(
+          find.widgetWithIcon(IconButton, Icons.save_alt));
+
+      // freshly opened: the document matches what was opened, nothing to save
+      expect(saveButton().onPressed, isNull);
+
+      // an edit enables it
+      editing.addRectangle(0, const PdfRect(100, 550, 300, 650));
+      await tester.pump();
+      expect(saveButton().onPressed, isNotNull);
+
+      // undoing back to the original disables it again
+      editing.undo();
+      await tester.pump();
+      expect(saveButton().onPressed, isNull);
+    });
+  });
+
   group('in the viewer', () {
     // 800px viewport over a 612pt page
     const scale = 800 / 612;

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -578,6 +578,31 @@ void main() {
       expect(find.byIcon(Icons.save_alt), findsNothing);
     });
 
+    testWidgets('save button is disabled until there are changes',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      await pump(
+        tester,
+        PdfEditorView(controller: editing, onSave: (_) {}),
+      );
+      FilledButton saveButton() => tester.widget<FilledButton>(
+          find.byKey(const ValueKey('pdf-shell-save')));
+
+      // freshly opened: nothing to save, so the button is disabled
+      expect(saveButton().onPressed, isNull);
+
+      // an edit enables it
+      editing.addRectangle(0, const PdfRect(100, 550, 300, 650));
+      await tester.pump();
+      expect(saveButton().onPressed, isNotNull);
+
+      // undoing back to the original disables it again
+      editing.undo();
+      await tester.pump();
+      expect(saveButton().onPressed, isNull);
+    });
+
     testWidgets('showSaveButton hides only the stock save control',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
@@ -593,6 +618,8 @@ void main() {
       );
       expect(find.byKey(const ValueKey('pdf-shell-save')), findsNothing);
 
+      // an edit so there's something to save (⌘S is a no-op otherwise)
+      editing.addRectangle(0, const PdfRect(100, 550, 300, 650));
       await tester.tap(find.byType(PdfViewer), kind: PointerDeviceKind.mouse);
       await tester.pump();
       await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
@@ -613,6 +640,8 @@ void main() {
           onSave: (bytes) => saved = bytes,
         ),
       );
+      // an edit so there's something to save (⌘S is a no-op otherwise)
+      editing.addRectangle(0, const PdfRect(100, 550, 300, 650));
       // focus the viewer the way a user would: click it, so the
       // shell's CallbackShortcuts has a focused descendant
       await tester.tap(find.byType(PdfViewer), kind: PointerDeviceKind.mouse);


### PR DESCRIPTION
## Summary

The Save controls in both editor shells were always enabled, even on a freshly opened document with nothing to write. This gates them on the editing session's existing `isModified` flag (true once an edit bumps the revision cursor, false again after undoing back to the original).

- **`PdfEditingToolbar`** — the floating dock's Save icon now disables while the document matches what was opened.
- **`PdfEditorView`** — the header Save button and its compact-sheet control disable likewise, and ⌘S / Ctrl+S becomes a no-op so the keyboard shortcut matches the button state.

**Save As is intentionally left untouched** — exporting a copy is useful even with no edits.

## Implementation notes

- Reused the controller's existing `isModified` getter (`_cursor > 0 || _hardModified`), so no new state was introduced. Both shells already rebuild their chrome inside a `ListenableBuilder` on the session, so the buttons flip live as edits/undo/redo happen.
- The shell's `_save()` now guards on `_canSave`, so the shortcut and button stay consistent.

## Tests

- Added `save button is disabled until there are changes` to `pdf_shell_test.dart`, covering the fresh-open → edit → undo transitions.
- Updated the two existing Ctrl+S shortcut tests to make an edit first (a no-op save is the new behavior on an unchanged document).
- Full `pdf_shell_test.dart` suite passes (52 tests); `dart analyze` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuPfQkqy4cybiCPDFZ2C2r

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuPfQkqy4cybiCPDFZ2C2r)_