### PR TITLE
Force .pdf extension when exporting/saving pages

### DIFF
--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -74,9 +74,15 @@ Future<Uint8List?> pickImageBytes() async {
 String ensurePdfName(String name) {
   var trimmed = name.trim();
   if (trimmed.isEmpty) trimmed = 'document';
-  if (!trimmed.toLowerCase().endsWith('.pdf')) trimmed = '$trimmed.pdf';
-  return trimmed;
+  return ensurePdfExtension(trimmed);
 }
+
+/// Appends `.pdf` to [path] unless it already ends with it (case-insensitive).
+/// The desktop save dialog lets the user clear or change the extension, so the
+/// path it hands back can lack one — exported and saved files must still open
+/// as PDFs.
+String ensurePdfExtension(String path) =>
+    path.toLowerCase().endsWith('.pdf') ? path : '$path.pdf';
 
 /// The outcome of a save, with a message suitable for a toast (null = the
 /// user cancelled, so say nothing).
@@ -211,9 +217,12 @@ Future<SaveResult> saveBytesAs(
         acceptedTypeGroups: const [pdfTypeGroup],
       );
       if (location == null) return SaveResult.cancelled;
+      // The dialog returns the path verbatim — if the user cleared or changed
+      // the extension, force `.pdf` so the file still opens as a PDF.
+      final path = ensurePdfExtension(location.path);
       try {
-        await file.saveTo(location.path);
-        return SaveResult.saved(location.path);
+        await file.saveTo(path);
+        return SaveResult.saved(path);
       } catch (e) {
         return SaveResult.failed(e);
       }

--- a/app/test/file_io_test.dart
+++ b/app/test/file_io_test.dart
@@ -12,6 +12,14 @@ void main() {
     expect(ensurePdfName('  '), 'document.pdf');
   });
 
+  test('ensurePdfExtension forces .pdf on a chosen save path', () {
+    // The desktop save dialog can hand back a path with no/other extension.
+    expect(ensurePdfExtension('/home/ben/pages'), '/home/ben/pages.pdf');
+    expect(ensurePdfExtension('/home/ben/pages.PDF'), '/home/ben/pages.PDF');
+    expect(ensurePdfExtension('/home/ben/pages.pdf'), '/home/ben/pages.pdf');
+    expect(ensurePdfExtension(r'C:\Docs\export'), r'C:\Docs\export.pdf');
+  });
+
   test('saveBytesToPath overwrites the file in place', () async {
     final dir = await Directory.systemTemp.createTemp('dartpdf_test');
     addTearDown(() => dir.delete(recursive: true));

--- a/app/test/file_io_test.dart
+++ b/app/test/file_io_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dart_pdf_editor_app/file_io.dart';
@@ -41,4 +43,47 @@ void main() {
     expect(result.succeeded, isFalse);
     expect(result.message, startsWith('Save failed'));
   });
+
+  testWidgets('saveBytesAs forces .pdf when the save dialog drops the extension',
+      (tester) async {
+    // Drive the desktop branch: the dialog returns whatever path the user
+    // typed, so an extensionless choice must still be written as a `.pdf`.
+    // The platform override must be cleared before the test body returns (the
+    // binding asserts foundation debug vars are unset), so reset it inline.
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      late BuildContext ctx;
+      await tester.pumpWidget(Builder(builder: (context) {
+        ctx = context;
+        return const SizedBox.shrink();
+      }));
+
+      // Real file I/O and the platform-channel reply only complete on the live
+      // event loop, so the whole save must run inside runAsync.
+      await tester.runAsync(() async {
+        final dir = await Directory.systemTemp.createTemp('dartpdf_saveas');
+        final chosen = '${dir.path}/exported'; // user cleared the .pdf
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/file_selector'),
+          (call) async => call.method == 'getSavePath' ? chosen : null,
+        );
+        try {
+          final result = await saveBytesAs(
+              ctx, Uint8List.fromList([1, 2, 3, 4]), 'exported');
+
+          expect(result.succeeded, isTrue);
+          expect(result.path, '$chosen.pdf');
+          expect(await File('$chosen.pdf').readAsBytes(), [1, 2, 3, 4]);
+        } finally {
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/file_selector'),
+            null,
+          );
+          await dir.delete(recursive: true);
+        }
+      });
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }, timeout: const Timeout(Duration(seconds: 30)));
 }


### PR DESCRIPTION
## Problem

Exporting pages (and Save As) could produce a file with **no extension**. The desktop save dialog seeds a `.pdf` suggested name, but the user can clear or change it. `saveBytesAs` then wrote `file.saveTo(location.path)` using the chosen path **verbatim**, so the resulting file had whatever (or no) extension the user typed.

## Fix

`ensurePdfName` only guarded the *suggested* name, not the path the dialog returns. Extracted the extension logic into `ensurePdfExtension(path)` and applied it to the chosen `location.path` in the desktop branch of `saveBytesAs`, so exported pages and saved documents always end in `.pdf`. The returned `SaveResult.saved(path)` (used for recents / origin path) now reflects the corrected path too.

Web (browser download) and mobile (share sheet) already used the `.pdf`-guaranteed name, so only the desktop save-dialog path needed the fix.

## Tests

- New `ensurePdfExtension` unit test covers no-extension, `.pdf`, `.PDF` (case-insensitive), and a Windows-style path.
- `ensurePdfName` now delegates to `ensurePdfExtension`; existing tests still pass.

All `app/test/file_io_test.dart` tests pass and `dart analyze` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKiqDfMK9FfZe638ftVioJ)_