### PR TITLE
Fix text box auto-size pushing content to the next line

### DIFF
--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Fix a free-text box auto-sized to its contents wrapping the last word onto
+  a new line: the wrapper's strict width test now tolerates the sub-point
+  floating-point round-off in `(lineWidth + 2*pad) - 2*pad`.
+
 ## 1.2.2
 
 - Embeddable fonts: `PdfEmbeddedFont.parse` reads a TrueType (`.ttf`) or

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -38,6 +38,16 @@ List<((double, double), (double, double))> pdfInkCurveControls(
 /// /Polygon area (shoelace).
 enum PdfMeasurementKind { distance, perimeter, area }
 
+/// Slack (in points) the word-wrappers allow before breaking a line.
+///
+/// A box auto-sized to its content sets its width to `lineWidth + 2*pad`,
+/// and the wrapper breaks at `width - 2*pad`. In exact arithmetic those
+/// cancel and the line fits, but `(w + 6) - 6` rounds to a hair *under* `w`
+/// in IEEE-754 doubles, so a strict `> maxWidth` test would wrap the last
+/// word onto a new line. This tolerance is far below a visible point yet
+/// orders of magnitude above the rounding noise.
+const double _wrapTolerance = 1e-6;
+
 /// One styled run inside a rich free-text annotation.
 ///
 /// A normal FreeText annotation has one `/DA` default appearance. Runs let
@@ -1640,7 +1650,7 @@ extension PdfAnnotationEditing on PdfEditor {
         }
         final text = String.fromCharCode(rune);
         final w = run.font.measure(text, run.fontSize);
-        if (width > 0 && width + w > maxWidth) flushLine();
+        if (width > 0 && width + w > maxWidth + _wrapTolerance) flushLine();
         addText(run, text);
       }
     }
@@ -3525,7 +3535,8 @@ extension PdfAnnotationEditing on PdfEditor {
       var line = '';
       for (final word in paragraph.split(' ')) {
         final candidate = line.isEmpty ? word : '$line $word';
-        if (line.isNotEmpty && font.measure(candidate, fontSize) > maxWidth) {
+        if (line.isNotEmpty &&
+            font.measure(candidate, fontSize) > maxWidth + _wrapTolerance) {
           lines.add(line);
           line = word;
         } else {

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -1009,6 +1009,32 @@ void main() {
         const PdfRect(100, 100, 450, 200));
   });
 
+  test('a box auto-sized to its line width keeps the text on one line', () {
+    // Auto-size sets the rect width to measure(line) + 2*pad (pad = 3), and
+    // the wrapper breaks at width - 2*pad. The two cancel in exact math, but
+    // `(w + 6) - 6` rounds to a hair under `w`, so a strict comparison used
+    // to push the last word onto a second line. These three lines reproduce
+    // that round-off at 12pt and 18pt Helvetica.
+    for (final (text, size) in const [
+      ('Date brown', 12.0),
+      ('Notes Total', 12.0),
+      ('Hello Customer', 18.0),
+    ]) {
+      const pad = 3.0;
+      final lineWidth = measureStandardText(text, size);
+      final width = lineWidth + 2 * pad;
+      final doc = roundTrip((e) => e.addFreeText(
+            0,
+            PdfRect(100, 600, 100 + width, 660),
+            text,
+            fontSize: size,
+          ));
+      final content = appearanceText(doc, doc.page(0).annotations.single);
+      expect(' Tj'.allMatches(content).length, 1,
+          reason: '"$text" at ${size}pt fits its own width on one line');
+    }
+  });
+
   test('free text persists and regenerates fill and border', () {
     final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
       ..addFreeText(0, const PdfRect(100, 100, 250, 180), 'styled box',


### PR DESCRIPTION
## Problem

Auto-sizing a free-text box (Alt+Z / the toolbar autosize button) to its contents sometimes pushed the last word of a line onto a new line, even though the box was sized to fit exactly.

## Root cause

A floating-point round-off. Auto-size sets the box width to `lineWidth + 2*pad` (`pad = 3`), and the appearance wrapper breaks lines at `width - 2*pad`. In exact arithmetic these cancel and the line fits, so the strict `> maxWidth` wrap test is `false`. But `(w + 6) - 6` rounds to a hair *under* `w` in IEEE-754 doubles (off by ~1e-14), so the strict comparison fired and wrapped.

The autosize and the wrapper share the *same* metric (`PdfStandardFont.measure` delegates to `measureStandardText`), so the mismatch is purely this `+pad … -pad` round-trip — not a measurement discrepancy. A sweep of realistic strings/sizes showed ~2% wrapping incorrectly at common font sizes (12pt/18pt).

## Fix

Add a sub-point tolerance (`1e-6`) to both word-wrappers (`_wrap` and `_wrapRich` in `annotation_editor.dart`) so a line that fits within rounding error is no longer broken. The tolerance is far below a visible point yet orders of magnitude above the rounding noise, so genuinely-overlong lines still wrap.

`form_editor.dart`'s wrapper has the same strict comparison, but its auto-size adjusts the *font size* within a fixed box — there's no `(w+6)−6` cancellation there — so it's left untouched.

## Testing

- New regression test in `annotation_editor_test.dart` reproduces the round-off at 12pt and 18pt and asserts a single `Tj` (one line). Verified it **fails** before the fix (`Actual: <2>` lines) and **passes** after.
- Full `pdf_document` suite (368 tests) and `dart_pdf_editor` `editing_text_edit_test.dart` (incl. the existing autosize test) pass.
- `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M6uwe3VWuS7MUX5DYfv1ia

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6uwe3VWuS7MUX5DYfv1ia)_