### PR TITLE
Add text box alignment controls

### DIFF
--- a/doc/dev-log.md
+++ b/doc/dev-log.md
@@ -2554,3 +2554,38 @@ affected. Removed the whole staging apparatus + its
 `onnx_ocr_model_runner_test.dart` (it only exercised the dead path logic;
 the surviving `load()` is native-only, unverifiable in the sandbox per the
 #76 honesty posture). 30 package tests still green; analyzer clean.
+
+Free-text box alignment — left/center/right controls for FreeText
+annotations. The PDF `/Q` quadding (0/1/2) is the model: new `PdfTextAlign`
+enum in `pdf_document`'s `content_writer.dart` (alongside
+`PdfTextDirection`), `quadding`/`fromQuadding` both ways. Threaded through
+`addFreeText`/`addFreeTextRich` and the `_freeTextContent`/
+`_freeTextRichContent` generators as an optional `align`; line-x is now
+`_lineX(align, vr, width, pad)` (left = `vr.left+pad`, right =
+`vr.right-pad-width`, center = `vr.left+(vr.width-width)/2` — the pad
+cancels, so center is centered within the padded box). Key subtlety: the
+old code *conflated* `/Q==2` with RTL — `addFreeText` wrote `Q=2` only when
+the text resolved RTL, and the resize path recovered direction from `/Q`
+via `_annotationTextDirection`. Decoupled: when `align` is null the
+generator still falls back to direction (`_alignForDirection`: RTL→right,
+else left) so default output is byte-identical, but `/Q` now means absolute
+alignment. The resize/regenerate path (`restyleAnnotation` FreeText case)
+passes `textDirection: auto` + `align: style.alignment` (read from `/Q` via
+the new `PdfFreeTextStyle.alignment`), so direction comes from the text and
+alignment from `/Q` — no more double-reversing an LTR right-aligned box.
+`_annotationTextDirection` deleted (only that one caller). Editor side:
+`PdfEditingPreferences.textAlign` is **nullable** — null = "follow
+direction" (so typing Arabic still auto-right-aligns and the RTL inline
+test still sees `/Q==2`); a non-null value is an explicit user choice.
+Controller `addFreeText`/`addFreeTextRich`/`placeFreeText` pass
+`align: preferences.textAlign`; `_rewriteSelected`/`_rewriteSelectedRich`
+preserve the box's own `parsed.alignment` across text/font/size edits;
+`restyleSelectedText(align:)`, `selectedTextAlign`, and
+`setSelectedTextAlign` (sets the default *and* restyles the selection).
+`textAlign` is in the freeText style scope so it persists per-tool. UI:
+shared `TextAlignToggles` (3 icon circles, mirrors `FontStyleToggles`) in
+`editing_font_controls.dart`, wired into the toolbar tune popup (`Align`
+row under `Style`) and the properties panel `_textStyleControls`. Default
+path renders identically to before; the only behaviour change is the rare
+"force RTL direction onto LTR text" edge case, which now no longer reverses
+on resize (arguably the prior bug).

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Free text: align a text box left, center, or right. The alignment buttons
+  sit in the text style popup and the annotation properties panel — they
+  apply to the selected box and set the default for new boxes (remembered
+  per the text tool). New boxes still follow the text direction until you
+  pick an alignment.
+
 ## 1.2.2
 
 - View rotation: rotate the displayed page in 90° steps without changing the

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -566,6 +566,7 @@ class PdfEditingController extends ChangeNotifier {
             'color',
             'fontSize',
             'fontFamily',
+            'textAlign',
             'opacity',
             'textFillColor',
             'textBorderColor',
@@ -626,6 +627,13 @@ class PdfEditingController extends ChangeNotifier {
     }
     preferences.fontFamily = value;
   }
+
+  /// Horizontal alignment (left/center/right) new free-text boxes are
+  /// created with, or null (the default) to follow the text direction —
+  /// left for LTR, right for RTL. Persisted.
+  PdfTextAlign? get textAlign => preferences.textAlign;
+
+  set textAlign(PdfTextAlign? value) => preferences.textAlign = value;
 
   PdfEmbeddedFont? _activeFont;
 
@@ -1280,6 +1288,7 @@ class PdfEditingController extends ChangeNotifier {
       (e) => e.addFreeText(pageIndex, rect, text,
           fontSize: preferences.fontSize,
           font: _activeFont ?? preferences.fontFamily,
+          align: preferences.textAlign,
           color: _colorValue,
           fillColor: _rgbOf(preferences.textFillColor),
           borderColor: _rgbOf(preferences.textBorderColor),
@@ -1292,6 +1301,7 @@ class PdfEditingController extends ChangeNotifier {
           int pageIndex, PdfRect rect, List<PdfFreeTextRun> runs) =>
       apply(
           (e) => e.addFreeTextRich(pageIndex, rect, runs,
+              align: preferences.textAlign,
               fillColor: _rgbOf(preferences.textFillColor),
               borderColor: _rgbOf(preferences.textBorderColor),
               borderWidth: preferences.strokeWidth,
@@ -1322,6 +1332,7 @@ class PdfEditingController extends ChangeNotifier {
         (e) => e.addFreeText(pageIndex, rect, value,
             fontSize: fontSize,
             font: _activeFont ?? preferences.fontFamily,
+            align: preferences.textAlign,
             color: _colorValue,
             fillColor: _rgbOf(preferences.textFillColor),
             borderColor: _rgbOf(preferences.textBorderColor),
@@ -2968,6 +2979,13 @@ class PdfEditingController extends ChangeNotifier {
     return _freeTextStyleOf(annotation!);
   }
 
+  /// The selected free-text annotation's horizontal alignment (its /Q
+  /// quadding), or null when the selection isn't a single free-text box.
+  PdfTextAlign? get selectedTextAlign {
+    if (!canRestyleSelectedText) return null;
+    return selectedAnnotation?.freeTextStyle?.alignment ?? PdfTextAlign.left;
+  }
+
   PdfRect _autosizeTextRect(PdfAnnotation annotation, String text,
       {required PdfStandardFont font, required double size}) {
     const pad = 3.0;
@@ -3014,6 +3032,7 @@ class PdfEditingController extends ChangeNotifier {
   void restyleSelectedText(
       {PdfStandardFont? font,
       double? size,
+      PdfTextAlign? align,
       (int?,)? fill,
       (int?,)? border,
       double? borderWidth}) {
@@ -3026,9 +3045,18 @@ class PdfEditingController extends ChangeNotifier {
     _rewriteSelected(annotation, annotation.contents ?? '',
         font: font ?? style.font,
         size: size ?? style.size,
+        align: align,
         fill: fill,
         border: border,
         borderWidth: borderWidth);
+  }
+
+  /// Sets the horizontal alignment of the selected free-text box (its /Q
+  /// quadding), regenerating its appearance, and makes it the default for
+  /// new boxes. A no-op when the selection isn't a single free-text box.
+  void setSelectedTextAlign(PdfTextAlign align) {
+    textAlign = align; // the new default either way
+    if (canRestyleSelectedText) restyleSelectedText(align: align);
   }
 
   /// Rewrites the selected free-text annotation in [font] — a base-14
@@ -3131,6 +3159,7 @@ class PdfEditingController extends ChangeNotifier {
   void _rewriteSelected(PdfAnnotation annotation, String text,
       {PdfTextFont? font,
       double? size,
+      PdfTextAlign? align,
       (int?,)? fill,
       (int?,)? border,
       double? borderWidth}) {
@@ -3158,6 +3187,8 @@ class PdfEditingController extends ChangeNotifier {
           e.addFreeText(page, rect, text,
               fontSize: size ?? style.size,
               font: font ?? style.font,
+              // keep the box's own alignment unless this edit changes it
+              align: align ?? parsed?.alignment ?? PdfTextAlign.left,
               color: parsed?.color ?? color ?? 0x000000,
               fillColor: fill != null ? fill.$1 : parsed?.fillColor,
               borderColor: border != null ? border.$1 : parsed?.borderColor,
@@ -3206,6 +3237,7 @@ class PdfEditingController extends ChangeNotifier {
     final changed = apply((e) {
       e.removeAnnotation(page, annotation);
       e.addFreeTextRich(page, rect, runs,
+          align: parsed?.alignment ?? PdfTextAlign.left,
           fillColor: parsed?.fillColor,
           borderColor: parsed?.borderColor,
           borderWidth: (parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_font_controls.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_font_controls.dart
@@ -88,3 +88,83 @@ class FontStyleToggles extends StatelessWidget {
     ]);
   }
 }
+
+/// A left / center / right alignment toggle group for a free-text box,
+/// reporting the chosen [PdfTextAlign] through [onChanged].
+///
+/// Package-internal chrome shared by the toolbar style popup and the
+/// annotation properties panel; not part of the public API.
+class TextAlignToggles extends StatelessWidget {
+  const TextAlignToggles({
+    super.key,
+    required this.align,
+    required this.onChanged,
+    this.keyPrefix = 'pdf-text-align',
+  });
+
+  /// The alignment the group highlights.
+  final PdfTextAlign align;
+
+  /// Called with the alignment the user picked.
+  final ValueChanged<PdfTextAlign> onChanged;
+
+  /// Prefix for the toggle keys (`<prefix>-left` / `-center` / `-right`),
+  /// so the toolbar and the panel get distinct ones.
+  final String keyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    Widget toggle({
+      required PdfTextAlign value,
+      required IconData icon,
+      required String tooltip,
+    }) {
+      final selected = value == align;
+      return Tooltip(
+        message: tooltip,
+        child: InkWell(
+          key: ValueKey('$keyPrefix-${value.name}'),
+          onTap: () => onChanged(value),
+          customBorder: const CircleBorder(),
+          child: Container(
+            width: 28,
+            height: 28,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: selected ? scheme.primary : Colors.transparent,
+              border: Border.all(
+                  color: selected ? scheme.primary : scheme.outline),
+            ),
+            child: Icon(
+              icon,
+              size: 17,
+              color: selected ? scheme.onPrimary : scheme.onSurface,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Row(mainAxisSize: MainAxisSize.min, children: [
+      toggle(
+        value: PdfTextAlign.left,
+        icon: Icons.format_align_left,
+        tooltip: 'Align left',
+      ),
+      const SizedBox(width: 8),
+      toggle(
+        value: PdfTextAlign.center,
+        icon: Icons.format_align_center,
+        tooltip: 'Align center',
+      ),
+      const SizedBox(width: 8),
+      toggle(
+        value: PdfTextAlign.right,
+        icon: Icons.format_align_right,
+        tooltip: 'Align right',
+      ),
+    ]);
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter/painting.dart';
 import 'package:pdf_document/pdf_document.dart'
-    show PdfLineEnding, PdfStandardFont;
+    show PdfLineEnding, PdfStandardFont, PdfTextAlign;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../viewport.dart';
@@ -53,6 +53,7 @@ class PdfEditingPreferences extends ChangeNotifier {
   double _eraserRadius = 8;
   double _fontSize = 14;
   PdfStandardFont _fontFamily = PdfStandardFont.helvetica;
+  PdfTextAlign? _textAlign;
   double _opacity = 1;
   PdfLineStyle _lineStyle = PdfLineStyle.solid;
   PdfLineEnding _lineStartEnding = PdfLineEnding.none;
@@ -133,6 +134,10 @@ class PdfEditingPreferences extends ChangeNotifier {
       if (fontFamily != null) {
         _fontFamily =
             PdfStandardFont.values.asNameMap()[fontFamily] ?? _fontFamily;
+      }
+      final textAlign = store.getString('${_prefix}textAlign');
+      if (textAlign != null) {
+        _textAlign = PdfTextAlign.values.asNameMap()[textAlign] ?? _textAlign;
       }
       _opacity = store.getDouble('${_prefix}opacity') ?? _opacity;
       final lineStyle = store.getString('${_prefix}lineStyle');
@@ -362,6 +367,10 @@ class PdfEditingPreferences extends ChangeNotifier {
         final font = PdfStandardFont.values.asNameMap()[v];
         if (font != null) fontFamily = font;
       }
+      if (slot.containsKey('textAlign')) {
+        final v = slot['textAlign'];
+        textAlign = v is String ? PdfTextAlign.values.asNameMap()[v] : null;
+      }
       if (slot['lineStyle'] case final String v) {
         final style = PdfLineStyle.values.asNameMap()[v];
         if (style != null) lineStyle = style;
@@ -454,6 +463,21 @@ class PdfEditingPreferences extends ChangeNotifier {
     _fontFamily = value;
     _write((s) => s.setString('${_prefix}fontFamily', value.name));
     _recordScoped('fontFamily', value.name);
+    notifyListeners();
+  }
+
+  /// Horizontal alignment (left/center/right) new free-text boxes are
+  /// created with — the box's /Q quadding. Null (the default) follows the
+  /// text direction: left for LTR, right for RTL. Persisted.
+  PdfTextAlign? get textAlign => _textAlign;
+
+  set textAlign(PdfTextAlign? value) {
+    if (value == _textAlign) return;
+    _textAlign = value;
+    _write((s) => value == null
+        ? s.remove('${_prefix}textAlign')
+        : s.setString('${_prefix}textAlign', value.name));
+    _recordScoped('textAlign', value?.name);
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -531,6 +531,18 @@ class _PdfAnnotationPropertiesPanelState
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         child: Row(children: [
+          const Expanded(child: Text('Align')),
+          TextAlignToggles(
+            keyPrefix: 'pdf-prop-text-align',
+            align: _controller.selectedTextAlign ?? PdfTextAlign.left,
+            onChanged: (align) =>
+                _controller.restyleSelectedText(align: align),
+          ),
+        ]),
+      ),
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        child: Row(children: [
           const Expanded(child: Text('More fonts')),
           PdfFontMenuButton(
             controller: _controller,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart'
-    show PdfLineEnding, PdfStandardFont;
+    show PdfLineEnding, PdfStandardFont, PdfTextAlign;
 
 import '../pdf_viewer.dart';
 import '../toast.dart';
@@ -2115,6 +2115,9 @@ class _StyleMenuState extends State<_StyleMenu> {
     }
   }
 
+  void _setTextAlign(PdfTextAlign align) =>
+      controller.setSelectedTextAlign(align);
+
   static int? _rgb(Color? color) =>
       color == null ? null : color.toARGB32() & 0xFFFFFF;
 
@@ -2514,6 +2517,18 @@ class _StyleMenuState extends State<_StyleMenu> {
                         FontStyleToggles(
                           font: selectedStyle?.font ?? controller.fontFamily,
                           onChanged: _setFont,
+                        ),
+                      ]),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: Row(children: [
+                        const SizedBox(width: 86, child: Text('Align')),
+                        TextAlignToggles(
+                          align: controller.selectedTextAlign ??
+                              controller.textAlign ??
+                              PdfTextAlign.left,
+                          onChanged: _setTextAlign,
                         ),
                       ]),
                     ),

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -76,6 +76,20 @@ void main() {
       expect(prefs.searchRegex, isFalse);
     });
 
+    test('textAlign resets to null (follow text direction)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final a = PdfEditingPreferences();
+      await a.ready;
+      a.textAlign = PdfTextAlign.right;
+      await pumpEventQueue();
+      a.textAlign = null; // clear the override, back to follow-direction
+      await pumpEventQueue();
+
+      final b = PdfEditingPreferences();
+      await b.ready;
+      expect(b.textAlign, isNull);
+    });
+
     test('a value set while loading is not clobbered by stored data', () async {
       SharedPreferences.setMockInitialValues(
           {'dart_pdf_editor.editing.strokeWidth': 9.0});

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
-import 'package:pdf_document/pdf_document.dart' show PdfLineEnding;
+import 'package:pdf_document/pdf_document.dart'
+    show PdfLineEnding, PdfTextAlign;
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -14,6 +15,7 @@ void main() {
       a.color = const Color(0xFF123456);
       a.strokeWidth = 5;
       a.fontSize = 18;
+      a.textAlign = PdfTextAlign.center;
       a.opacity = 0.5;
       a.fingerDrawsInk = false;
       a.showThumbnailSidebar = false; // non-default, so the write is real
@@ -34,6 +36,7 @@ void main() {
       expect(b.color, const Color(0xFF123456));
       expect(b.strokeWidth, 5);
       expect(b.fontSize, 18);
+      expect(b.textAlign, PdfTextAlign.center);
       expect(b.opacity, 0.5);
       expect(b.fingerDrawsInk, isFalse);
       expect(b.showThumbnailSidebar, isFalse);
@@ -56,6 +59,7 @@ void main() {
       expect(prefs.color, const Color(0xFFE53935));
       expect(prefs.strokeWidth, 2);
       expect(prefs.fontSize, 14);
+      expect(prefs.textAlign, isNull); // null = follow text direction
       expect(prefs.opacity, 1);
       expect(prefs.fingerDrawsInk, isTrue);
       // the thumbnail strip is on by default since 9bbfc87

--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -277,6 +277,29 @@ void main() {
       expect(editing.selectedTextStyle?.font, PdfStandardFont.timesBoldItalic);
     });
 
+    testWidgets('free text gets alignment controls', (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addFreeText(0, const PdfRect(100, 500, 320, 620), 'Hello');
+      addTearDown(editing.dispose);
+      await pumpPanel(tester, editing);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      // a fresh box starts left-aligned
+      expect(editing.selectedTextAlign, PdfTextAlign.left);
+      expect(find.byKey(const ValueKey('pdf-prop-text-align-center')),
+          findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-prop-text-align-center')));
+      await tester.pump();
+      expect(editing.selectedTextAlign, PdfTextAlign.center);
+      expect(editing.selectedAnnotation?.contents, 'Hello'); // text kept
+
+      await tester.tap(find.byKey(const ValueKey('pdf-prop-text-align-right')));
+      await tester.pump();
+      expect(editing.selectedTextAlign, PdfTextAlign.right);
+    });
+
     testWidgets('free text gets an outline (border) control', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addFreeText(0, const PdfRect(100, 500, 300, 620), 'Hello');

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -121,6 +121,16 @@ void main() {
           contains('22 Tf'));
     });
 
+    test('addFreeTextRich applies the alignment default', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..textAlign = PdfTextAlign.right;
+      editing.addFreeTextRich(0, const PdfRect(100, 600, 360, 650),
+          [const PdfFreeTextRun('Rich')]);
+
+      final style = editing.document.page(0).annotations.single.freeTextStyle!;
+      expect(style.alignment, PdfTextAlign.right);
+    });
+
     test('text fill and border preferences flow into new free text', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..strokeWidth = 3

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -737,6 +737,43 @@ void main() {
       expect(editing.fontFamily, PdfStandardFont.timesBoldItalic);
     });
 
+    testWidgets('the style menu sets text alignment for new text',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+          ),
+        ),
+      ));
+
+      await tester.scrollUntilVisible(
+          find.byKey(const ValueKey('pdf-group-insert')), 80);
+      await tester.tap(find.byKey(const ValueKey('pdf-group-insert')));
+      await tester.pump();
+      await tester.scrollUntilVisible(
+          find.byTooltip('Stroke, opacity, font'), 100,
+          scrollable: find.byType(Scrollable).first);
+      await tester.tap(find.byTooltip('Stroke, opacity, font'));
+      await tester.pumpAndSettle();
+
+      // no selection: the buttons set the creation default
+      expect(editing.textAlign, isNull);
+      await tester.tap(find.byKey(const ValueKey('pdf-text-align-center')));
+      await tester.pump();
+      expect(editing.textAlign, PdfTextAlign.center);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-text-align-right')));
+      await tester.pump();
+      expect(editing.textAlign, PdfTextAlign.right);
+    });
+
     testWidgets('the style menu sets text fill and border defaults',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -82,6 +82,45 @@ void main() {
       expect(editing.selectedAnnotation, isNotNull);
     });
 
+    test('textAlign preference flows into new free text', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..textAlign = PdfTextAlign.center
+        ..addFreeText(0, const PdfRect(100, 600, 360, 650), 'Centered');
+
+      final style = editing.document.page(0).annotations.single.freeTextStyle!;
+      expect(style.alignment, PdfTextAlign.center);
+    });
+
+    test('setSelectedTextAlign changes the box and the creation default', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addFreeText(0, const PdfRect(100, 600, 360, 650), 'Aligned');
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      expect(editing.selectedTextAlign, PdfTextAlign.left);
+
+      editing.setSelectedTextAlign(PdfTextAlign.right);
+
+      expect(editing.document.page(0).annotations.single.freeTextStyle!.alignment,
+          PdfTextAlign.right);
+      // the selection survives the rewrite
+      expect(editing.selectedTextAlign, PdfTextAlign.right);
+      // and right becomes the default for new boxes
+      expect(editing.textAlign, PdfTextAlign.right);
+    });
+
+    test('restyleSelectedText preserves alignment across a size change', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..textAlign = PdfTextAlign.center
+        ..addFreeText(0, const PdfRect(100, 600, 360, 650), 'Centered');
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      expect(editing.selectedTextAlign, PdfTextAlign.center);
+
+      editing.restyleSelectedText(size: 22);
+
+      expect(editing.selectedTextAlign, PdfTextAlign.center);
+      expect(editing.document.page(0).annotations.single.defaultAppearance,
+          contains('22 Tf'));
+    });
+
     test('text fill and border preferences flow into new free text', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..strokeWidth = 3

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Free-text annotations carry a horizontal alignment (left/center/right)
+  through the `/Q` quadding: `addFreeText` and `addFreeTextRich` take an
+  `align` argument, `PdfFreeTextStyle.alignment` reads it back, and resizing
+  or re-editing a box preserves it. Omitting `align` keeps the previous
+  behaviour — left for LTR text, right for RTL.
+
 ## 1.2.2
 
 - Embeddable fonts: `PdfEmbeddedFont.parse` reads a TrueType (`.ttf`) or

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:pdf_cos/pdf_cos.dart';
 
+import 'content_writer.dart';
 import 'document.dart';
 import 'measure.dart';
 import 'rect.dart';
@@ -308,6 +309,7 @@ class PdfAnnotation {
     final text = lastColor('rg') ?? gray() ?? 0x000000;
     final background = color;
     final width = borderWidth ?? 0;
+    final q = document.cos.resolve(dict['Q']);
     return PdfFreeTextStyle(
       fontName: tf.group(1)!,
       fontSize: size,
@@ -315,6 +317,7 @@ class PdfAnnotation {
       fillColor: background != null && background != text ? background : null,
       borderColor: lastColor('RG') ?? (width > 0 ? text : null),
       borderWidth: width,
+      alignment: PdfTextAlign.fromQuadding(q is CosInteger ? q.value : null),
     );
   }
 
@@ -463,6 +466,7 @@ class PdfFreeTextStyle {
     this.fillColor,
     this.borderColor,
     this.borderWidth = 0,
+    this.alignment = PdfTextAlign.left,
   });
 
   /// The /DA font resource name (e.g. `Helv`), unresolved.
@@ -478,6 +482,10 @@ class PdfFreeTextStyle {
   /// The box border color, or null for no border.
   final int? borderColor;
   final double borderWidth;
+
+  /// How the lines are aligned inside the box (the /Q quadding). Defaults
+  /// to [PdfTextAlign.left] when the annotation carries no /Q.
+  final PdfTextAlign alignment;
 }
 
 /// A /Link annotation: a clickable region with an action (§12.5.6.5).

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1254,6 +1254,7 @@ extension PdfAnnotationEditing on PdfEditor {
     double fontSize = 12,
     PdfTextFont font = PdfStandardFont.helvetica,
     PdfTextDirection textDirection = PdfTextDirection.auto,
+    PdfTextAlign? align,
     int color = 0x000000,
     int? fillColor,
     int? borderColor,
@@ -1281,6 +1282,7 @@ extension PdfAnnotationEditing on PdfEditor {
         fontSize: fontSize,
         font: effectiveFont,
         textDirection: textDirection,
+        align: align,
         color: color,
         fillColor: fillColor,
         borderColor: borderColor,
@@ -1294,8 +1296,8 @@ extension PdfAnnotationEditing on PdfEditor {
         '/${effectiveFont.resourceName} ${ContentWriter.fmt(fontSize)} Tf';
     final dict = _markupDict('FreeText', rect, fillColor ?? color, text, author)
       ..['DA'] = CosString.fromText(da)
-      ..['Q'] = CosInteger(
-          textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0);
+      ..['Q'] = CosInteger(align?.quadding ??
+          (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0));
     if (borderColor != null && borderWidth > 0) {
       dict['BS'] = _borderStyle(borderWidth);
     }
@@ -1327,6 +1329,7 @@ extension PdfAnnotationEditing on PdfEditor {
     PdfRect rect,
     List<PdfFreeTextRun> runs, {
     PdfTextDirection textDirection = PdfTextDirection.auto,
+    PdfTextAlign? align,
     int? fillColor,
     int? borderColor,
     double borderWidth = 1,
@@ -1358,6 +1361,7 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     final w = _freeTextRichContent(rect, effective,
         textDirection: textDirection,
+        align: align,
         fillColor: fillColor,
         borderColor: borderColor,
         borderWidth: borderWidth,
@@ -1372,8 +1376,8 @@ extension PdfAnnotationEditing on PdfEditor {
     final dict =
         _markupDict('FreeText', rect, fillColor ?? first.color, text, author)
           ..['DA'] = CosString.fromText(da)
-          ..['Q'] = CosInteger(
-              textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0);
+          ..['Q'] = CosInteger(align?.quadding ??
+              (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0));
     if (borderColor != null && borderWidth > 0) {
       dict['BS'] = _borderStyle(borderWidth);
     }
@@ -1394,6 +1398,7 @@ extension PdfAnnotationEditing on PdfEditor {
     required double fontSize,
     required PdfTextFont font,
     required PdfTextDirection textDirection,
+    PdfTextAlign? align,
     required int color,
     required int? fillColor,
     required int? borderColor,
@@ -1433,14 +1438,13 @@ extension PdfAnnotationEditing on PdfEditor {
     final firstY = vr.top - pad - fontSize * font.ascent / 1000;
     final lines = _wrap(text, fontSize, vr.width - 2 * pad, font: font);
     final resolvedDirection = textDirection.resolve(text);
+    final effectiveAlign = align ?? _alignForDirection(resolvedDirection);
     var prevX = 0.0;
     var prevY = 0.0;
     for (var i = 0; i < lines.length; i++) {
       final line = lines[i];
       final width = font.measure(line, fontSize);
-      final x = resolvedDirection == PdfTextDirection.rtl
-          ? vr.right - pad - width
-          : vr.left + pad;
+      final x = _lineX(effectiveAlign, vr, width, pad);
       final y = firstY - i * fontSize * 1.2;
       w.textAt(x - prevX, y - prevY);
       if (font is PdfUnicodeFont) {
@@ -1470,6 +1474,7 @@ extension PdfAnnotationEditing on PdfEditor {
     PdfRect rect,
     List<PdfFreeTextRun> runs, {
     required PdfTextDirection textDirection,
+    PdfTextAlign? align,
     required int? fillColor,
     required int? borderColor,
     required double borderWidth,
@@ -1498,6 +1503,7 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     final plain = runs.map((run) => run.text).join();
     final resolvedDirection = textDirection.resolve(plain);
+    final effectiveAlign = align ?? _alignForDirection(resolvedDirection);
     final lines = _wrapRich(runs, vr.width - 2 * pad);
     var top = vr.top - pad;
     var prevX = 0.0;
@@ -1518,9 +1524,7 @@ extension PdfAnnotationEditing on PdfEditor {
               math.max(max, run.style.fontSize * run.style.font.ascent / 1000));
       final lineHeight = line.runs.fold<double>(
           0, (max, run) => math.max(max, run.style.fontSize * 1.2));
-      var x = resolvedDirection == PdfTextDirection.rtl
-          ? vr.right - pad - line.width
-          : vr.left + pad;
+      var x = _lineX(effectiveAlign, vr, line.width, pad);
       final y = top - ascent;
       final drawRuns = resolvedDirection == PdfTextDirection.rtl
           ? line.runs.reversed
@@ -1554,6 +1558,24 @@ extension PdfAnnotationEditing on PdfEditor {
     if (pageRotation != 0) w.restore();
     return w;
   }
+
+  /// The default alignment when a free-text box gives none: right for an
+  /// RTL paragraph (so it hugs the right edge as before), left otherwise.
+  static PdfTextAlign _alignForDirection(PdfTextDirection direction) =>
+      direction == PdfTextDirection.rtl
+          ? PdfTextAlign.right
+          : PdfTextAlign.left;
+
+  /// The x where a line of width [width] starts so it sits at [align]
+  /// inside the padded visual rect [vr]. Centering cancels the padding, so
+  /// a centered line is centered within the full width.
+  static double _lineX(
+          PdfTextAlign align, PdfRect vr, double width, double pad) =>
+      switch (align) {
+        PdfTextAlign.left => vr.left + pad,
+        PdfTextAlign.center => vr.left + (vr.width - width) / 2,
+        PdfTextAlign.right => vr.right - pad - width,
+      };
 
   /// The rect in which text is laid out when [pageRotation] is active.
   /// For 90/270 rotations the visual dimensions (what the user sees on
@@ -2457,7 +2479,9 @@ extension PdfAnnotationEditing on PdfEditor {
         final w = _freeTextContent(to, text,
             fontSize: style.fontSize,
             font: effectiveFont,
-            textDirection: _annotationTextDirection(annotation),
+            // direction follows the text; /Q carries the explicit alignment
+            textDirection: PdfTextDirection.auto,
+            align: style.alignment,
             color: style.color,
             fillColor: style.fillColor,
             borderColor: style.borderColor,
@@ -3535,11 +3559,5 @@ extension PdfAnnotationEditing on PdfEditor {
       lines.add(line);
     }
     return lines;
-  }
-
-  PdfTextDirection _annotationTextDirection(PdfAnnotation annotation) {
-    final q = document.cos.resolve(annotation.dict['Q']);
-    if (q is CosInteger && q.value == 2) return PdfTextDirection.rtl;
-    return PdfTextDirection.auto;
   }
 }

--- a/packages/pdf_document/lib/src/content_writer.dart
+++ b/packages/pdf_document/lib/src/content_writer.dart
@@ -15,6 +15,31 @@ extension PdfTextDirectionResolution on PdfTextDirection {
   }
 }
 
+/// Horizontal alignment of the lines inside a free-text box, mapped to the
+/// /Q quadding value (§12.7.4.3): 0 left, 1 centered, 2 right.
+///
+/// When no alignment is given the appearance generator falls back to the
+/// text direction — left for LTR, right for RTL — so the default keeps the
+/// long-standing behaviour.
+enum PdfTextAlign {
+  left(0),
+  center(1),
+  right(2);
+
+  const PdfTextAlign(this.quadding);
+
+  /// The /Q quadding value this alignment is written as.
+  final int quadding;
+
+  /// The alignment for a /Q quadding value, defaulting to [left] for an
+  /// absent or unrecognized one.
+  static PdfTextAlign fromQuadding(int? quadding) => switch (quadding) {
+        1 => PdfTextAlign.center,
+        2 => PdfTextAlign.right,
+        _ => PdfTextAlign.left,
+      };
+}
+
 /// True when [text]'s first strong directional character is RTL.
 bool pdfTextLooksRtl(String text) {
   for (final rune in text.runes) {

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -1051,6 +1051,80 @@ void main() {
     expect(style.borderColor, isNull);
   });
 
+  test('PdfTextAlign maps to and from /Q quadding', () {
+    expect(PdfTextAlign.left.quadding, 0);
+    expect(PdfTextAlign.center.quadding, 1);
+    expect(PdfTextAlign.right.quadding, 2);
+    expect(PdfTextAlign.fromQuadding(0), PdfTextAlign.left);
+    expect(PdfTextAlign.fromQuadding(1), PdfTextAlign.center);
+    expect(PdfTextAlign.fromQuadding(2), PdfTextAlign.right);
+    expect(PdfTextAlign.fromQuadding(null), PdfTextAlign.left);
+    expect(PdfTextAlign.fromQuadding(7), PdfTextAlign.left);
+  });
+
+  test('free text alignment writes /Q and shifts the line', () {
+    PdfDocument make(PdfTextAlign align) => roundTrip((e) => e.addFreeText(
+          0,
+          const PdfRect(100, 600, 400, 640),
+          'Hi',
+          align: align,
+        ));
+
+    final left = make(PdfTextAlign.left);
+    final center = make(PdfTextAlign.center);
+    final right = make(PdfTextAlign.right);
+
+    int quad(PdfDocument d) =>
+        (d.cos.resolve(d.page(0).annotations.single.dict['Q']) as CosInteger)
+            .value;
+    expect(quad(left), 0);
+    expect(quad(center), 1);
+    expect(quad(right), 2);
+
+    // alignment round-trips through the parsed style
+    expect(left.page(0).annotations.single.freeTextStyle!.alignment,
+        PdfTextAlign.left);
+    expect(center.page(0).annotations.single.freeTextStyle!.alignment,
+        PdfTextAlign.center);
+    expect(right.page(0).annotations.single.freeTextStyle!.alignment,
+        PdfTextAlign.right);
+
+    double lineX(PdfDocument d) {
+      final content = appearanceText(d, d.page(0).annotations.single);
+      final m = RegExp(r'(-?[\d.]+) -?[\d.]+ Td').firstMatch(content);
+      return double.parse(m!.group(1)!);
+    }
+
+    // left hugs the padded left edge (100 + 3pt pad); center and right
+    // move the line progressively rightward in the 300pt-wide box
+    expect(lineX(left), closeTo(103, 0.5));
+    expect(lineX(center), greaterThan(lineX(left) + 20));
+    expect(lineX(right), greaterThan(lineX(center)));
+  });
+
+  test('resizing a centered free text box keeps it centered', () {
+    final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
+      ..addFreeText(0, const PdfRect(100, 600, 300, 640), 'Centered',
+          align: PdfTextAlign.center);
+    final doc = PdfDocument.open(first.save());
+    expect(doc.page(0).annotations.single.freeTextStyle!.alignment,
+        PdfTextAlign.center);
+
+    final editor = PdfEditor(doc)
+      ..resizeAnnotation(
+          0, doc.page(0).annotations.single, const PdfRect(100, 600, 500, 640));
+    final reopened = PdfDocument.open(editor.save());
+    final box = reopened.page(0).annotations.single;
+    // /Q (and so the alignment) survives the regenerated appearance
+    expect((reopened.cos.resolve(box.dict['Q']) as CosInteger).value, 1);
+    expect(box.freeTextStyle!.alignment, PdfTextAlign.center);
+
+    // the line is centered in the now-wider box: x is well past the left pad
+    final content = appearanceText(reopened, box);
+    final m = RegExp(r'(-?[\d.]+) -?[\d.]+ Td').firstMatch(content);
+    expect(double.parse(m!.group(1)!), greaterThan(150));
+  });
+
   test('resizeAnnotation rejects degenerate rects', () {
     final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
       ..addSquare(0, const PdfRect(100, 100, 200, 150));


### PR DESCRIPTION
## What

Adds left / center / right alignment controls for free-text annotations.

[alignment toggles]

In the editor the alignment buttons appear in two places:

- the text **style popup** (the toolbar's tune button) — an `Align` row under `Style`
- the annotation **properties panel** — an `Align` row under `Style`

They apply to the selected text box and set the default for new boxes. The default is remembered per the text tool (like font size / family).

## How it works

Alignment maps to the PDF `/Q` quadding value (§12.7.4.3): `0` left, `1` centered, `2` right.

**`pdf_document`**
- New `PdfTextAlign` enum (`content_writer.dart`, alongside `PdfTextDirection`) with `quadding` / `fromQuadding`.
- `addFreeText` / `addFreeTextRich` take an optional `align`; the `_freeTextContent` / `_freeTextRichContent` generators position each line via a shared `_lineX` helper (left = padded-left, right = padded-right, center = centered).
- `PdfFreeTextStyle.alignment` reads the alignment back from `/Q`.
- The resize / regenerate path now passes `textDirection: auto` + `align: style.alignment`, so direction is recovered from the text and alignment from `/Q`. This **decouples** the two — the old code conflated `/Q == 2` with RTL, which could double-reverse an LTR right-aligned box on resize.

**`dart_pdf_editor`**
- `PdfEditingPreferences.textAlign` is nullable: `null` (the default) means *follow the text direction* — so RTL text still auto-right-aligns — and a non-null value is an explicit choice. Persisted, and in the free-text style scope.
- Controller: creation paths pass `align: preferences.textAlign`; `_rewriteSelected` / `_rewriteSelectedRich` preserve the box's own alignment across text/font/size edits; new `selectedTextAlign`, `restyleSelectedText(align:)`, and `setSelectedTextAlign`.
- Shared `TextAlignToggles` widget (mirrors `FontStyleToggles`).

## Compatibility

When `align` is omitted the output is **byte-identical** to before (left for LTR, right for RTL), so existing and default-authored content render unchanged.

## Tests

- `pdf_document`: `/Q` is written and read back per alignment, lines shift left→center→right, and a centered box stays centered across a resize. `PdfTextAlign` ↔ quadding mapping.
- `dart_pdf_editor`: the `textAlign` preference flows into new boxes, `setSelectedTextAlign` updates the box and the default, alignment survives a size restyle, and the properties-panel alignment buttons work. The existing RTL inline-typing test (expects `/Q == 2`) still passes.

`fvm dart analyze` is clean across the workspace; the full `pdf_document` suite and the touched editor suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CNuqdNMJw2mscrjXxGheq

---
_Generated by [Claude Code](https://claude.ai/code/session_015CNuqdNMJw2mscrjXxGheq)_