### PR TITLE
Add a dedicated full-area page thumbnail grid view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,14 @@ repainted via `viewportChanges` (a separate Listenable so scrolling
 doesn't spam controller listeners). `PdfViewer.initialFit` defaults to
 `PdfViewerFit.page` (whole first page visible, Chrome-style) — widget
 tests that do view-coordinate math pin `initialFit: PdfViewerFit.width`.
+`PdfThumbnailView` (same file, exported) is the full-area sibling: a
+reflowing `Wrap` grid with the strip's whole control set plus a header
+size slider (`thumbnailViewTileWidth` pref), custom drag reorder
+(`DragTarget`+`Draggable`/`LongPressDraggable`, mouse-immediate via a
+`MouseRegion` hover flag), and a "page picker" tap (`_PageTile.
+onActivatePage`). `PdfEditorView` overlays it over the live viewer as a
+view mode (`showThumbnailView`, toggled from View options alongside
+reflow; `altView` = reflow-or-grid suppresses the panels/toolbar).
 
 ## Development session log
 

--- a/doc/dev-log.md
+++ b/doc/dev-log.md
@@ -2554,3 +2554,55 @@ affected. Removed the whole staging apparatus + its
 `onnx_ocr_model_runner_test.dart` (it only exercised the dead path logic;
 the surviving `load()` is native-only, unverifiable in the sandbox per the
 #76 honesty posture). 30 package tests still green; analyzer clean.
+
+Dedicated page-grid view (Ben: "add a new view that is a dedicated
+thumbnail view ... all the same page controls as the strip ... allow
+changing the size of the thumbnails"): `PdfThumbnailView`
+(editing_thumbnails.dart, exported) — a full-area reflowing grid of page
+thumbnails with the strip's whole control set, plus a header size
+slider. Built in the SAME file as `PdfThumbnailSidebar` so it reuses the
+private `_PageTile`, `_PageThumbnail`, render-stamp-keyed `_ThumbnailCache`
+(serialized one-page-at-a-time rasters), `_PageActionsButton`, and the
+new shared `_PageSelectionBar` (the multi-select bulk bar — rotate/
+export/delete/clear, keys 'pdf-thumbnail-{rotate-selected-ccw,-cw,
+export-selected,delete-selected,clear-selection}' — extracted out of the
+sidebar's inline `_selectionAction` so both views expose identical keys).
+Layout: `Wrap` (not GridView — pages have mixed aspect ratios, so fixed
+grid cells don't fit) of `SizedBox(width: tileWidth)` tiles inside a
+`SingleChildScrollView` + the shared `PdfScrollbar`; footer 'pdf-
+thumbnail-view-add-page', per-tile rotate/delete reuse 'pdf-thumbnail-
+rotate-<i>'. Reorder is custom (`ReorderableListView` is list-only):
+`_GridPageCell` wraps each tile in a `DragTarget<int>` over an immediate
+`Draggable` (mouse) or `LongPressDraggable` (touch/stylus) — picked by a
+`MouseRegion` hover flag, so a finger drag still scrolls while a mouse
+picks up immediately; drop calls `controller.movePage(from, thisIndex)`
+(movePage lands the page AT the target index). `_PageTile` gained an
+optional `onActivatePage` so a plain tap is a "page picker" (jump the
+viewer + fire it) instead of the strip's plain jump; shift/⌘ taps still
+only extend the selection. Size lives in
+`PdfEditingPreferences.thumbnailViewTileWidth` (double?, clamped
+96–360, default 168, slider key 'pdf-thumbnail-view-size'); the raster
+bucket already snaps to 64px so slider drags don't re-render per pixel.
+Shell wiring (pdf_editor_view.dart): a new view mode alongside reflow —
+`gridActive = features.thumbnails && prefs.showThumbnailView`,
+`reflowActive` now gated `&& !gridActive`, `altView = reflow||grid` drives
+the panel/toolbar/header suppression (was `!reflowActive` everywhere). The
+grid is overlaid `Positioned.fill` OVER the still-mounted `PdfViewer`
+(opaque Material, so it eats taps) rather than swapped for it — so a
+tapped page scrolls the LIVE viewer before `onOpenPage` closes the grid to
+reveal it (swapping would unmount the viewer and lose the jump to the
+viewport-memory restore). Toggle is a View-options item 'pdf-shell-page-
+grid' (NOT a standalone header button — that pushed the Save button off
+an 800px header, breaking the existing save test; the menu costs zero
+header width and matches reflow). `_ViewOption.pageGrid` in shell_chrome.
+dart; pageGrid/reflow each clear the other since both replace the viewer.
+`showThumbnailView`/`thumbnailViewTileWidth` persist. Tests:
+editing_thumbnail_view_test.dart (10 — layout, add-page, page-picker tap,
+size slider→pref + pref→tile width, shift-select+delete, per-tile rotate,
+long-press drag reorder, export, read-only drops controls) and
+pdf_shell_test.dart +3 (view-options swaps in the grid + tap returns to
+page view, grid clears reflow, thumbnails:false hides the option). Gotcha:
+the long-press reorder test is the touch path (default test pointer never
+hovers → LongPressDraggable); `startGesture` then pump kLongPressTimeout
+before `moveTo`. PdfReader keeps only its read-only strip (its strip has
+no page controls, so "same controls as the strip" maps to the editor).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -70,6 +70,8 @@ class PdfEditingPreferences extends ChangeNotifier {
   bool _showAnnotations = true;
   bool _highlightFormFields = true;
   bool _showReflowView = false;
+  bool _showThumbnailView = false;
+  double? _thumbnailViewTileWidth;
   bool _showPropertiesPanel = false;
   bool _showSearchResultsPanel = false;
   bool _searchMatchCase = false;
@@ -185,6 +187,11 @@ class PdfEditingPreferences extends ChangeNotifier {
           _highlightFormFields;
       _showReflowView =
           store.getBool('${_prefix}showReflowView') ?? _showReflowView;
+      _showThumbnailView =
+          store.getBool('${_prefix}showThumbnailView') ?? _showThumbnailView;
+      _thumbnailViewTileWidth =
+          store.getDouble('${_prefix}thumbnailViewTileWidth') ??
+              _thumbnailViewTileWidth;
       _thumbnailSidebarWidth =
           store.getDouble('${_prefix}thumbnailSidebarWidth') ??
               _thumbnailSidebarWidth;
@@ -245,8 +252,7 @@ class PdfEditingPreferences extends ChangeNotifier {
         final key = entry['k'];
         final value = entry['v'];
         if (key is! String || value is! Map) continue;
-        final viewport =
-            PdfViewport.fromJson(Map<String, Object?>.from(value));
+        final viewport = PdfViewport.fromJson(Map<String, Object?>.from(value));
         if (viewport != null) result.add((key, viewport));
       }
     } catch (_) {
@@ -638,6 +644,32 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _showReflowView) return;
     _showReflowView = value;
     _write((s) => s.setBool('${_prefix}showReflowView', value));
+    notifyListeners();
+  }
+
+  /// Whether the host shows the dedicated full-area page thumbnail grid
+  /// (`PdfThumbnailView`) in place of the page viewer. A view mode, not a
+  /// docked panel — distinct from [showThumbnailSidebar].
+  bool get showThumbnailView => _showThumbnailView;
+
+  set showThumbnailView(bool value) {
+    if (value == _showThumbnailView) return;
+    _showThumbnailView = value;
+    _write((s) => s.setBool('${_prefix}showThumbnailView', value));
+    notifyListeners();
+  }
+
+  /// The page thumbnail grid's tile width, in logical pixels — the size
+  /// control in `PdfThumbnailView` drives it. Null until first changed,
+  /// where the widget's own default applies.
+  double? get thumbnailViewTileWidth => _thumbnailViewTileWidth;
+
+  set thumbnailViewTileWidth(double? value) {
+    if (value == _thumbnailViewTileWidth) return;
+    _thumbnailViewTileWidth = value;
+    _write((s) => value == null
+        ? s.remove('${_prefix}thumbnailViewTileWidth')
+        : s.setDouble('${_prefix}thumbnailViewTileWidth', value));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -258,34 +258,6 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     return offset;
   }
 
-  void _exportSelected() {
-    final onExport = widget.onExportPages;
-    if (onExport == null) return;
-    final bytes = widget.controller.exportSelectedPages();
-    if (bytes != null) onExport(bytes);
-  }
-
-  /// A compact icon button for the multi-select bar — tight enough that
-  /// several fit (and wrap) within the narrow strip.
-  Widget _selectionAction({
-    required String key,
-    required IconData icon,
-    required String tooltip,
-    required VoidCallback onPressed,
-  }) =>
-      IconButton(
-        key: ValueKey(key),
-        icon: Icon(icon, size: 18),
-        tooltip: tooltip,
-        style: IconButton.styleFrom(
-          padding: EdgeInsets.zero,
-          minimumSize: const Size(32, 32),
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          visualDensity: VisualDensity.compact,
-        ),
-        onPressed: onPressed,
-      );
-
   void _onResizeDelta(double delta) => setState(() {
         _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
       });
@@ -310,155 +282,108 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // baked into the list's own horizontal padding, which keeps the
     // scroll viewport full-width while the tiles stay centered.
     Widget buildList(double inset) => Material(
-      color: Theme.of(context).colorScheme.surfaceContainerLow,
-      // only document changes rebuild the list — viewer scrolling
-      // repaints the per-tile indicators alone
-      child: ListenableBuilder(
-        listenable: controller,
-        // the implicit desktop scrollbar is replaced by the
-        // viewer-style bar below
-        builder: (context, _) => Column(
-          children: [
-            // page-level file actions sit in a slim header at the top so
-            // they never collide with the floating editing toolbar (or a
-            // snackbar) that hugs the bottom of the viewport
-            if (widget.onPickPdfToInsert != null ||
-                widget.onExportPages != null)
-              Padding(
-                padding:
-                    EdgeInsets.fromLTRB(8 + inset, 2, _extraRightPadding + inset, 0),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        'Pages',
-                        style: Theme.of(context).textTheme.labelMedium,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    _PageActionsButton(
-                      controller: controller,
-                      viewerController: widget.viewerController,
-                      onPickPdfToInsert: widget.onPickPdfToInsert,
-                      onExportPages: widget.onExportPages,
-                    ),
-                  ],
-                ),
-              ),
-            // when more than one page is selected, a bar offers bulk
-            // actions on the selection (a single selection is just the
-            // navigation cursor — the per-tile delete handles it)
-            if (controller.selectedPageCount > 1)
-              Padding(
-                padding: EdgeInsets.fromLTRB(
-                    8 + inset, 2, _extraRightPadding + inset, 0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      '${controller.selectedPageCount} selected',
-                      style: Theme.of(context).textTheme.labelMedium,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    // a Wrap (not a Row) so the action buttons flow onto a
-                    // second line on the narrow strip instead of overflowing
-                    Wrap(
+          color: Theme.of(context).colorScheme.surfaceContainerLow,
+          // only document changes rebuild the list — viewer scrolling
+          // repaints the per-tile indicators alone
+          child: ListenableBuilder(
+            listenable: controller,
+            // the implicit desktop scrollbar is replaced by the
+            // viewer-style bar below
+            builder: (context, _) => Column(
+              children: [
+                // page-level file actions sit in a slim header at the top so
+                // they never collide with the floating editing toolbar (or a
+                // snackbar) that hugs the bottom of the viewport
+                if (widget.onPickPdfToInsert != null ||
+                    widget.onExportPages != null)
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(
+                        8 + inset, 2, _extraRightPadding + inset, 0),
+                    child: Row(
                       children: [
-                        if (widget.allowPageEditing) ...[
-                          _selectionAction(
-                            key: 'pdf-thumbnail-rotate-selected-ccw',
-                            icon: Icons.rotate_left,
-                            tooltip: 'Rotate selected pages left',
-                            onPressed: () =>
-                                controller.rotateSelectedPages(-90),
+                        Expanded(
+                          child: Text(
+                            'Pages',
+                            style: Theme.of(context).textTheme.labelMedium,
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          _selectionAction(
-                            key: 'pdf-thumbnail-rotate-selected-cw',
-                            icon: Icons.rotate_right,
-                            tooltip: 'Rotate selected pages right',
-                            onPressed: () =>
-                                controller.rotateSelectedPages(90),
-                          ),
-                        ],
-                        if (widget.onExportPages != null)
-                          _selectionAction(
-                            key: 'pdf-thumbnail-export-selected',
-                            icon: Icons.file_download_outlined,
-                            tooltip: 'Export selected pages',
-                            onPressed: _exportSelected,
-                          ),
-                        if (widget.allowPageEditing)
-                          _selectionAction(
-                            key: 'pdf-thumbnail-delete-selected',
-                            icon: Icons.delete_outline,
-                            tooltip: 'Delete selected pages',
-                            onPressed: () => controller.removeSelectedPages(),
-                          ),
-                        _selectionAction(
-                          key: 'pdf-thumbnail-clear-selection',
-                          icon: Icons.close,
-                          tooltip: 'Clear selection',
-                          onPressed: controller.clearPageSelection,
+                        ),
+                        _PageActionsButton(
+                          controller: controller,
+                          viewerController: widget.viewerController,
+                          onPickPdfToInsert: widget.onPickPdfToInsert,
+                          onExportPages: widget.onExportPages,
                         ),
                       ],
                     ),
-                  ],
-                ),
-              ),
-            Expanded(
-              child: ScrollConfiguration(
-                behavior:
-                    ScrollConfiguration.of(context).copyWith(scrollbars: false),
-                child: ReorderableListView.builder(
-                  scrollController: _scroll,
-                  buildDefaultDragHandles: false,
-                  padding:
-                      EdgeInsets.fromLTRB(inset, 8, _extraRightPadding + inset, 8),
-                  itemCount: controller.document.pageCount,
-                  onReorderItem: controller.movePage,
-                  itemBuilder: (context, index) {
-                    final tile = _PageTile(
-                      key: _tileKeys[index] ??= GlobalKey(),
-                      controller: controller,
-                      viewerController: widget.viewerController,
-                      pageIndex: index,
-                      pageColor: widget.pageColor,
-                      showAnnotations: widget.showAnnotations,
-                      allowPageEditing: widget.allowPageEditing,
-                      cache: _cache,
-                      tileWidth: _tileWidth,
-                      renderWorker: widget.renderWorker,
-                    );
-                    // without the drag listener no reorder can ever start
-                    return widget.allowPageEditing
-                        ? _ReorderDragStartListener(
-                            key: ValueKey(index), index: index, child: tile)
-                        : KeyedSubtree(key: ValueKey(index), child: tile);
-                  },
-                ),
-              ),
-            ),
-            // a footer to append a blank page; only when the strip
-            // is editable (a read-only strip is purely navigational)
-            if (widget.allowPageEditing)
-              Padding(
-                padding:
-                    EdgeInsets.fromLTRB(4 + inset, 2, _extraRightPadding + inset, 4),
-                child: TextButton.icon(
-                  key: const ValueKey('pdf-thumbnail-add-page'),
-                  icon: const Icon(Icons.add, size: 16),
-                  label: const Text('Add page'),
-                  style: TextButton.styleFrom(
-                    visualDensity: VisualDensity.compact,
-                    textStyle: Theme.of(context).textTheme.labelMedium,
                   ),
-                  onPressed: () => controller.addBlankPage(),
+                // when more than one page is selected, a bar offers bulk
+                // actions on the selection (a single selection is just the
+                // navigation cursor — the per-tile delete handles it)
+                if (controller.selectedPageCount > 1)
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(
+                        8 + inset, 2, _extraRightPadding + inset, 0),
+                    child: _PageSelectionBar(
+                      controller: controller,
+                      allowPageEditing: widget.allowPageEditing,
+                      onExportPages: widget.onExportPages,
+                    ),
+                  ),
+                Expanded(
+                  child: ScrollConfiguration(
+                    behavior: ScrollConfiguration.of(context)
+                        .copyWith(scrollbars: false),
+                    child: ReorderableListView.builder(
+                      scrollController: _scroll,
+                      buildDefaultDragHandles: false,
+                      padding: EdgeInsets.fromLTRB(
+                          inset, 8, _extraRightPadding + inset, 8),
+                      itemCount: controller.document.pageCount,
+                      onReorderItem: controller.movePage,
+                      itemBuilder: (context, index) {
+                        final tile = _PageTile(
+                          key: _tileKeys[index] ??= GlobalKey(),
+                          controller: controller,
+                          viewerController: widget.viewerController,
+                          pageIndex: index,
+                          pageColor: widget.pageColor,
+                          showAnnotations: widget.showAnnotations,
+                          allowPageEditing: widget.allowPageEditing,
+                          cache: _cache,
+                          tileWidth: _tileWidth,
+                          renderWorker: widget.renderWorker,
+                        );
+                        // without the drag listener no reorder can ever start
+                        return widget.allowPageEditing
+                            ? _ReorderDragStartListener(
+                                key: ValueKey(index), index: index, child: tile)
+                            : KeyedSubtree(key: ValueKey(index), child: tile);
+                      },
+                    ),
+                  ),
                 ),
-              ),
-          ],
-        ),
-      ),
-    );
+                // a footer to append a blank page; only when the strip
+                // is editable (a read-only strip is purely navigational)
+                if (widget.allowPageEditing)
+                  Padding(
+                    padding: EdgeInsets.fromLTRB(
+                        4 + inset, 2, _extraRightPadding + inset, 4),
+                    child: TextButton.icon(
+                      key: const ValueKey('pdf-thumbnail-add-page'),
+                      icon: const Icon(Icons.add, size: 16),
+                      label: const Text('Add page'),
+                      style: TextButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                        textStyle: Theme.of(context).textTheme.labelMedium,
+                      ),
+                      onPressed: () => controller.addBlankPage(),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
     // the same scrollbar the viewer paints, so every bar in the chrome
     // looks and behaves alike
     final scrollbar = PdfScrollbar(
@@ -508,6 +433,104 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
             ),
           ),
       ]),
+    );
+  }
+}
+
+/// The bulk-action bar shown above the tiles when more than one page is
+/// selected: rotate / export / delete the selection, and clear it. Shared
+/// by the docked strip ([PdfThumbnailSidebar]) and the full-area grid
+/// ([PdfThumbnailView]) so both expose the same controls and test keys.
+class _PageSelectionBar extends StatelessWidget {
+  const _PageSelectionBar({
+    required this.controller,
+    required this.allowPageEditing,
+    required this.onExportPages,
+  });
+
+  final PdfEditingController controller;
+  final bool allowPageEditing;
+  final void Function(Uint8List bytes)? onExportPages;
+
+  /// A compact icon button — tight enough that several fit (and wrap)
+  /// within the narrow strip.
+  Widget _action({
+    required String key,
+    required IconData icon,
+    required String tooltip,
+    required VoidCallback onPressed,
+  }) =>
+      IconButton(
+        key: ValueKey(key),
+        icon: Icon(icon, size: 18),
+        tooltip: tooltip,
+        style: IconButton.styleFrom(
+          padding: EdgeInsets.zero,
+          minimumSize: const Size(32, 32),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          visualDensity: VisualDensity.compact,
+        ),
+        onPressed: onPressed,
+      );
+
+  void _exportSelected() {
+    final onExport = onExportPages;
+    if (onExport == null) return;
+    final bytes = controller.exportSelectedPages();
+    if (bytes != null) onExport(bytes);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '${controller.selectedPageCount} selected',
+          style: Theme.of(context).textTheme.labelMedium,
+          overflow: TextOverflow.ellipsis,
+        ),
+        // a Wrap (not a Row) so the action buttons flow onto a second
+        // line on the narrow strip instead of overflowing
+        Wrap(
+          children: [
+            if (allowPageEditing) ...[
+              _action(
+                key: 'pdf-thumbnail-rotate-selected-ccw',
+                icon: Icons.rotate_left,
+                tooltip: 'Rotate selected pages left',
+                onPressed: () => controller.rotateSelectedPages(-90),
+              ),
+              _action(
+                key: 'pdf-thumbnail-rotate-selected-cw',
+                icon: Icons.rotate_right,
+                tooltip: 'Rotate selected pages right',
+                onPressed: () => controller.rotateSelectedPages(90),
+              ),
+            ],
+            if (onExportPages != null)
+              _action(
+                key: 'pdf-thumbnail-export-selected',
+                icon: Icons.file_download_outlined,
+                tooltip: 'Export selected pages',
+                onPressed: _exportSelected,
+              ),
+            if (allowPageEditing)
+              _action(
+                key: 'pdf-thumbnail-delete-selected',
+                icon: Icons.delete_outline,
+                tooltip: 'Delete selected pages',
+                onPressed: () => controller.removeSelectedPages(),
+              ),
+            _action(
+              key: 'pdf-thumbnail-clear-selection',
+              icon: Icons.close,
+              tooltip: 'Clear selection',
+              onPressed: controller.clearPageSelection,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }
@@ -602,6 +625,455 @@ class _PageActionsButton extends StatelessWidget {
   }
 }
 
+/// A dedicated, full-area page thumbnail grid — the same page controls
+/// as [PdfThumbnailSidebar] (tap to open a page, shift/⌘-click
+/// multi-select with a bulk-action bar, per-tile rotate/delete, drag to
+/// reorder, the page-actions menu, and the Add-page footer), laid out as
+/// a reflowing grid whose tile size the header's size control changes.
+/// Use it as a page-organizer view in place of the page viewer.
+///
+/// Unlike the strip, a plain tap is a "page picker": it scrolls the
+/// viewer to that page and fires [onOpenPage] (the host turns the grid
+/// off to reveal the page). Shift/⌘ clicks only extend the
+/// multi-selection, so a selection can be built without the view jumping.
+///
+/// The tiles reuse the strip's serialized, render-stamp-keyed thumbnail
+/// cache, so an edit re-rasterizes only the pages it touched. The chosen
+/// tile width persists via [PdfEditingPreferences.thumbnailViewTileWidth].
+///
+/// ```dart
+/// PdfThumbnailView(
+///   controller: editing,
+///   viewerController: viewerController,
+///   onOpenPage: (_) => setState(() => showGrid = false),
+/// )
+/// ```
+class PdfThumbnailView extends StatefulWidget {
+  const PdfThumbnailView({
+    super.key,
+    required this.controller,
+    required this.viewerController,
+    this.pageColor = const Color(0xFFFFFFFF),
+    this.showAnnotations = true,
+    this.allowPageEditing = true,
+    this.onPickPdfToInsert,
+    this.onExportPages,
+    this.onOpenPage,
+    this.renderWorker,
+    this.minTileWidth = 96,
+    this.maxTileWidth = 360,
+    this.defaultTileWidth = 168,
+  });
+
+  final PdfEditingController controller;
+
+  /// The viewer a tapped tile scrolls to (see [onOpenPage]).
+  final PdfViewerController viewerController;
+
+  /// Offloads tile interpretation to a background isolate — pass the same
+  /// worker the viewer uses. See [PdfThumbnailSidebar.renderWorker].
+  final PdfRenderWorker? renderWorker;
+
+  /// The paper color thumbnails render on (match the viewer's).
+  final Color pageColor;
+
+  /// Whether thumbnails render their annotations (match the viewer's).
+  final bool showAnnotations;
+
+  /// Whether pages can be reordered (drag), rotated, deleted, and added.
+  /// False makes the grid a read-only page picker.
+  final bool allowPageEditing;
+
+  /// Picks a PDF to insert after the current page; null hides the
+  /// "Insert PDF…" page-action. See [PdfThumbnailSidebar.onPickPdfToInsert].
+  final Future<Uint8List?> Function()? onPickPdfToInsert;
+
+  /// Receives the bytes of an exported page range; null hides the
+  /// "Export pages…" page-action and the selection bar's export.
+  final void Function(Uint8List bytes)? onExportPages;
+
+  /// Called after a plain tap scrolls the viewer to [pageIndex]. Hosts
+  /// that show the grid in place of the viewer turn it off here so the
+  /// chosen page shows.
+  final void Function(int pageIndex)? onOpenPage;
+
+  /// Clamps for the tile-size control.
+  final double minTileWidth;
+  final double maxTileWidth;
+
+  /// The tile width used until the size control (or a stored preference)
+  /// sets one.
+  final double defaultTileWidth;
+
+  @override
+  State<PdfThumbnailView> createState() => _PdfThumbnailViewState();
+}
+
+class _PdfThumbnailViewState extends State<PdfThumbnailView> {
+  final ScrollController _scroll = ScrollController();
+  final _ThumbnailCache _cache = _ThumbnailCache();
+
+  PdfEditingPreferences get _preferences => widget.controller.preferences;
+
+  double get _tileWidth =>
+      (_preferences.thumbnailViewTileWidth ?? widget.defaultTileWidth)
+          .clamp(widget.minTileWidth, widget.maxTileWidth);
+
+  @override
+  void initState() {
+    super.initState();
+    _preferences.addListener(_onPreferences);
+  }
+
+  @override
+  void didUpdateWidget(PdfThumbnailView old) {
+    super.didUpdateWidget(old);
+    if (!identical(old.controller.preferences, _preferences)) {
+      old.controller.preferences.removeListener(_onPreferences);
+      _preferences.addListener(_onPreferences);
+    }
+    // a different edit session: its render stamps restart at zero, so
+    // cached rasters keyed by the old session's stamps would collide
+    if (!identical(old.controller, widget.controller)) _cache.clear();
+  }
+
+  @override
+  void dispose() {
+    _preferences.removeListener(_onPreferences);
+    _scroll.dispose();
+    _cache.dispose();
+    super.dispose();
+  }
+
+  void _onPreferences() {
+    if (mounted) setState(() {});
+  }
+
+  void _openPage(int index) {
+    unawaited(widget.viewerController.jumpToPage(index));
+    widget.onOpenPage?.call(index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = widget.controller;
+    final tileWidth = _tileWidth;
+    // the scrollbar overlays the grid's right edge; keep content clear of it
+    const barClearance = PdfScrollbar.hitExtent;
+    // opaque so the grid eats every pointer in its area — a host overlays it
+    // over the live viewer, and a tap in a header/inter-tile gap must not
+    // fall through to the page underneath
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      child: Material(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        // only document changes rebuild the grid — viewer scrolling repaints
+        // the per-tile viewport indicators alone
+        child: ListenableBuilder(
+          listenable: controller,
+          builder: (context, _) => Column(
+            children: [
+              // header: title, the tile-size control, and the page-actions menu
+              Padding(
+                padding: const EdgeInsets.fromLTRB(12, 6, 4 + barClearance, 4),
+                child: Row(children: [
+                  Text('Pages', style: Theme.of(context).textTheme.titleSmall),
+                  const Spacer(),
+                  _ThumbnailSizeControl(
+                    value: tileWidth,
+                    min: widget.minTileWidth,
+                    max: widget.maxTileWidth,
+                    onChanged: (value) =>
+                        _preferences.thumbnailViewTileWidth = value,
+                  ),
+                  if (widget.onPickPdfToInsert != null ||
+                      widget.onExportPages != null)
+                    _PageActionsButton(
+                      controller: controller,
+                      viewerController: widget.viewerController,
+                      onPickPdfToInsert: widget.onPickPdfToInsert,
+                      onExportPages: widget.onExportPages,
+                    ),
+                ]),
+              ),
+              // bulk actions on the multi-selection, as in the strip
+              if (controller.selectedPageCount > 1)
+                Padding(
+                  padding:
+                      const EdgeInsets.fromLTRB(12, 0, 12 + barClearance, 4),
+                  child: _PageSelectionBar(
+                    controller: controller,
+                    allowPageEditing: widget.allowPageEditing,
+                    onExportPages: widget.onExportPages,
+                  ),
+                ),
+              const Divider(height: 1),
+              Expanded(
+                child: Stack(children: [
+                  Positioned.fill(
+                    child: ScrollConfiguration(
+                      // replaced by the viewer-style bar below
+                      behavior: ScrollConfiguration.of(context)
+                          .copyWith(scrollbars: false),
+                      child: SingleChildScrollView(
+                        controller: _scroll,
+                        padding: const EdgeInsets.fromLTRB(
+                            12, 12, 12 + barClearance, 12),
+                        child: Wrap(
+                          spacing: 12,
+                          runSpacing: 12,
+                          children: [
+                            for (var i = 0;
+                                i < controller.document.pageCount;
+                                i++)
+                              SizedBox(
+                                width: tileWidth,
+                                child: _GridPageCell(
+                                  key: ValueKey('pdf-thumbnail-grid-cell-$i'),
+                                  controller: controller,
+                                  viewerController: widget.viewerController,
+                                  pageIndex: i,
+                                  pageColor: widget.pageColor,
+                                  showAnnotations: widget.showAnnotations,
+                                  allowPageEditing: widget.allowPageEditing,
+                                  cache: _cache,
+                                  // the tile pads ~21px around the thumbnail
+                                  tileWidth: tileWidth - 21,
+                                  renderWorker: widget.renderWorker,
+                                  onActivatePage: _openPage,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 0,
+                    bottom: 0,
+                    right: 0,
+                    child: PdfScrollbar(
+                      scroll: _scroll,
+                      thumbKey:
+                          const ValueKey('pdf-thumbnail-view-scrollbar-thumb'),
+                    ),
+                  ),
+                ]),
+              ),
+              // a footer to append a blank page; editable grids only
+              if (widget.allowPageEditing)
+                Padding(
+                  padding: const EdgeInsets.all(4),
+                  child: TextButton.icon(
+                    key: const ValueKey('pdf-thumbnail-view-add-page'),
+                    icon: const Icon(Icons.add, size: 18),
+                    label: const Text('Add page'),
+                    onPressed: () => controller.addBlankPage(),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The header slider that sets the grid's tile width, flanked by small/
+/// large thumbnail glyphs.
+class _ThumbnailSizeControl extends StatelessWidget {
+  const _ThumbnailSizeControl({
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+  });
+
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurfaceVariant;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.photo_size_select_small, size: 18, color: color),
+        SizedBox(
+          width: 120,
+          child: Slider(
+            key: const ValueKey('pdf-thumbnail-view-size'),
+            value: value.clamp(min, max),
+            min: min,
+            max: max,
+            onChanged: onChanged,
+          ),
+        ),
+        Icon(Icons.photo_size_select_large, size: 22, color: color),
+      ],
+    );
+  }
+}
+
+/// One cell of the thumbnail grid: a [_PageTile] wrapped for drag-to-
+/// reorder. A mouse picks a tile up immediately (it hovers first, so the
+/// cell knows a pointer is present); touch and stylus need a long press,
+/// so a finger drag still scrolls the grid. Dropping onto another cell
+/// moves the page there ([PdfEditingController.movePage]). With
+/// [allowPageEditing] off the cell is the bare tile — read-only grids
+/// only navigate.
+class _GridPageCell extends StatefulWidget {
+  const _GridPageCell({
+    super.key,
+    required this.controller,
+    required this.viewerController,
+    required this.pageIndex,
+    required this.pageColor,
+    required this.showAnnotations,
+    required this.allowPageEditing,
+    required this.cache,
+    required this.tileWidth,
+    required this.renderWorker,
+    required this.onActivatePage,
+  });
+
+  final PdfEditingController controller;
+  final PdfViewerController viewerController;
+  final int pageIndex;
+  final Color pageColor;
+  final bool showAnnotations;
+  final bool allowPageEditing;
+  final _ThumbnailCache cache;
+  final double tileWidth;
+  final PdfRenderWorker? renderWorker;
+  final void Function(int pageIndex) onActivatePage;
+
+  @override
+  State<_GridPageCell> createState() => _GridPageCellState();
+}
+
+class _GridPageCellState extends State<_GridPageCell> {
+  // hovering with a mouse switches the cell to an immediate drag; touch
+  // never hovers, so it falls through to the long-press recognizer and a
+  // finger drag still scrolls the grid.
+  bool _hasMouse = false;
+
+  Widget _tile() => _PageTile(
+        controller: widget.controller,
+        viewerController: widget.viewerController,
+        pageIndex: widget.pageIndex,
+        pageColor: widget.pageColor,
+        showAnnotations: widget.showAnnotations,
+        allowPageEditing: widget.allowPageEditing,
+        cache: widget.cache,
+        tileWidth: widget.tileWidth,
+        renderWorker: widget.renderWorker,
+        onActivatePage: widget.onActivatePage,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final tile = _tile();
+    if (!widget.allowPageEditing) return tile;
+
+    final draggable = MouseRegion(
+      onEnter: (_) => setState(() => _hasMouse = true),
+      onExit: (_) => setState(() => _hasMouse = false),
+      child: _draggable(tile),
+    );
+    return DragTarget<int>(
+      // a page never drops onto itself
+      onWillAcceptWithDetails: (details) => details.data != widget.pageIndex,
+      // movePage lands the dragged page at this cell's index (§ moves the
+      // page so it ends up at [to])
+      onAcceptWithDetails: (details) =>
+          widget.controller.movePage(details.data, widget.pageIndex),
+      builder: (context, candidate, rejected) {
+        final scheme = Theme.of(context).colorScheme;
+        final active = candidate.isNotEmpty;
+        // a 2px frame, always laid out (transparent when idle), marks the
+        // cell a drop would land on — DecoratedBox paints it over the tile
+        // edge without reserving space, so the tile never shifts
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: active ? scheme.primary : Colors.transparent,
+              width: 2,
+            ),
+            color: active ? scheme.primary.withValues(alpha: 0.08) : null,
+          ),
+          child: draggable,
+        );
+      },
+    );
+  }
+
+  Widget _draggable(Widget tile) {
+    final feedback = _DragFeedback(
+      label: 'Page ${widget.pageIndex + 1}',
+      width: widget.tileWidth,
+    );
+    // dim the page being dragged in place, leaving a gap-marker
+    final placeholder = Opacity(opacity: 0.3, child: tile);
+    return _hasMouse
+        ? Draggable<int>(
+            data: widget.pageIndex,
+            dragAnchorStrategy: pointerDragAnchorStrategy,
+            feedback: feedback,
+            childWhenDragging: placeholder,
+            child: tile,
+          )
+        : LongPressDraggable<int>(
+            data: widget.pageIndex,
+            dragAnchorStrategy: pointerDragAnchorStrategy,
+            feedback: feedback,
+            childWhenDragging: placeholder,
+            child: tile,
+          );
+  }
+}
+
+/// The little card that rides the cursor while a grid tile is dragged.
+class _DragFeedback extends StatelessWidget {
+  const _DragFeedback({required this.label, required this.width});
+
+  final String label;
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        width: (width * 0.8).clamp(120.0, 260.0),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: scheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: scheme.primary, width: 1.5),
+          boxShadow: const [
+            BoxShadow(
+                color: Colors.black26, blurRadius: 8, offset: Offset(0, 4)),
+          ],
+        ),
+        child: Row(mainAxisSize: MainAxisSize.min, children: [
+          Icon(Icons.description_outlined, size: 18, color: scheme.primary),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(label,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(color: scheme.onSurface)),
+          ),
+        ]),
+      ),
+    );
+  }
+}
+
 /// Starts a tile drag immediately for mouse pointers (the desktop
 /// expectation — a mouse drag never means scrolling) but only after a
 /// long press for touch and stylus, so finger drags still scroll the
@@ -645,6 +1117,7 @@ class _PageTile extends StatelessWidget {
     required this.cache,
     required this.tileWidth,
     required this.renderWorker,
+    this.onActivatePage,
   });
 
   final PdfEditingController controller;
@@ -656,6 +1129,13 @@ class _PageTile extends StatelessWidget {
   final _ThumbnailCache cache;
   final double tileWidth;
   final PdfRenderWorker? renderWorker;
+
+  /// Overrides what a plain tap does after selecting the page. The strip
+  /// leaves this null and just scrolls the viewer to the page; the
+  /// full-area grid passes a handler that also dismisses the grid (a
+  /// "page picker" tap). Shift/⌘ clicks are unaffected — they only
+  /// extend the multi-selection, never navigate.
+  final void Function(int pageIndex)? onActivatePage;
 
   /// WCAG-style contrast ratio between two opaque colors.
   static double _contrast(Color a, Color b) {
@@ -679,7 +1159,12 @@ class _PageTile extends StatelessWidget {
       return;
     }
     controller.selectPage(pageIndex);
-    unawaited(viewerController.jumpToPage(pageIndex));
+    final activate = onActivatePage;
+    if (activate != null) {
+      activate(pageIndex);
+    } else {
+      unawaited(viewerController.jumpToPage(pageIndex));
+    }
   }
 
   @override

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -573,20 +573,43 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 bottomSheet: bottomSheet,
                 fontPicker: widget.fontPicker,
               );
+          // the dedicated full-area page grid, overlaid on the (still
+          // mounted) viewer so a tapped page can scroll it before the grid
+          // closes to reveal the page
+          PdfThumbnailView pageGrid() => PdfThumbnailView(
+                key: const ValueKey('pdf-shell-page-grid'),
+                controller: session,
+                viewerController: _viewer,
+                pageColor: pageColor,
+                showAnnotations: prefs.showAnnotations,
+                allowPageEditing: features.pageEditing,
+                onPickPdfToInsert:
+                    features.pageEditing ? widget.onPickPdfToInsert : null,
+                onExportPages: widget.onExportPages,
+                onOpenPage: (_) => prefs.showThumbnailView = false,
+                renderWorker: _worker,
+              );
 
-          final reflowActive = features.reflowView && prefs.showReflowView;
+          // the full-area page grid replaces the page viewer; it wins over
+          // reflow if both prefs are somehow on (the toggle below also
+          // clears reflow). [altView] is "the viewer is hidden" — it
+          // suppresses the docked panels, the editing toolbar, and the
+          // viewer-only header controls, just as reflow does.
+          final gridActive = features.thumbnails && prefs.showThumbnailView;
+          final reflowActive =
+              features.reflowView && prefs.showReflowView && !gridActive;
+          final altView = reflowActive || gridActive;
           final showThumbnailsPanel =
-              features.thumbnails && showThumbnails && !reflowActive;
+              features.thumbnails && showThumbnails && !altView;
           final showSearchPanel = features.search &&
               features.searchResultsPanel &&
               prefs.showSearchResultsPanel &&
-              !reflowActive;
+              !altView;
           final showAnnotationsPanel = features.annotationSidebar &&
               prefs.showAnnotationSidebar &&
-              !reflowActive;
-          final showPropertiesPanel = features.propertiesPanel &&
-              prefs.showPropertiesPanel &&
-              !reflowActive;
+              !altView;
+          final showPropertiesPanel =
+              features.propertiesPanel && prefs.showPropertiesPanel && !altView;
 
           final sheets = !useSheets
               ? const <Widget>[]
@@ -633,8 +656,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
           // below the viewer instead, where it takes its own layout space.
           // Above the breakpoint it stays a set of transparent floating
           // cards with the page showing through the gaps.
-          final showToolbar =
-              features.toolbar && sheets.isEmpty && !reflowActive;
+          final showToolbar = features.toolbar && sheets.isEmpty && !altView;
           final dockToolbar = showToolbar &&
               constraints.maxWidth < PdfEditingToolbar.mobileBreakpoint;
           final toolbar = !showToolbar
@@ -665,6 +687,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 context,
                 preferences: prefs,
                 reflow: features.reflowView,
+                pageGrid: features.thumbnails,
                 pageColor: features.pageColorEditable,
                 author: features.author,
                 authorName: session.author,
@@ -713,13 +736,13 @@ class _PdfEditorViewState extends State<PdfEditorView> {
             if (features.headerBar)
               PdfShellBar(
                 leading: [
-                  if (features.pageNumber && !reflowActive)
+                  if (features.pageNumber && !altView)
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: PdfPageNumberField(controller: _viewer),
                     ),
-                  if (!reflowActive) PdfShellZoomControl(controller: _viewer),
-                  if (features.search && !reflowActive) ...[
+                  if (!altView) PdfShellZoomControl(controller: _viewer),
+                  if (features.search && !altView) ...[
                     PdfSearchField(
                       controller: _viewer,
                       searchController: _searchField,
@@ -732,12 +755,12 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                   ],
                 ],
                 compactLeading: [
-                  if (features.pageNumber && !reflowActive)
+                  if (features.pageNumber && !altView)
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: PdfPageNumberField(controller: _viewer),
                     ),
-                  if (features.search && !reflowActive)
+                  if (features.search && !altView)
                     PdfSearchField(
                       controller: _viewer,
                       searchController: _searchField,
@@ -751,6 +774,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     PdfShellViewOptionsButton(
                         preferences: prefs,
                         reflow: features.reflowView,
+                        pageGrid: features.thumbnails,
                         pageColor: features.pageColorEditable,
                         author: features.author,
                         authorName: session.author,
@@ -774,7 +798,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     ),
                 ],
                 compactSheetChildren: [
-                  if (!reflowActive) PdfShellZoomControl(controller: _viewer),
+                  if (!altView) PdfShellZoomControl(controller: _viewer),
                 ],
                 compactControls: [
                   if (features.viewOptions) viewOptionsControl,
@@ -845,6 +869,11 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                       properties(bottomSheet: false),
                   ]),
                 ),
+                // the page grid covers the (still-mounted) viewer: a tap can
+                // scroll the live viewer underneath, then the grid closes to
+                // reveal the chosen page. Opaque, so the viewer takes no taps
+                // while it shows.
+                if (gridActive) Positioned.fill(child: pageGrid()),
                 if (toolbar != null && !dockToolbar)
                   Positioned(
                     left: 0,

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -678,7 +678,14 @@ void _maybeCloseShellControls(BuildContext context) {
   WidgetsBinding.instance.addPostFrameCallback((_) => scope.close());
 }
 
-enum _ViewOption { annotations, formHighlight, reflow, pageColor, author }
+enum _ViewOption {
+  annotations,
+  formHighlight,
+  reflow,
+  pageGrid,
+  pageColor,
+  author
+}
 
 Future<void> _selectViewOption(
   BuildContext context,
@@ -693,7 +700,13 @@ Future<void> _selectViewOption(
     case _ViewOption.formHighlight:
       preferences.highlightFormFields = !preferences.highlightFormFields;
     case _ViewOption.reflow:
+      // reflow and the page grid both replace the page viewer — only one
+      // can claim the area, so each clears the other
+      preferences.showThumbnailView = false;
       preferences.showReflowView = !preferences.showReflowView;
+    case _ViewOption.pageGrid:
+      preferences.showReflowView = false;
+      preferences.showThumbnailView = !preferences.showThumbnailView;
     case _ViewOption.pageColor:
       if (!pageColor) return;
       final color = await showPdfColorPicker(
@@ -712,6 +725,7 @@ Future<void> showPdfShellViewOptionsSheet(
   BuildContext context, {
   required PdfEditingPreferences preferences,
   bool reflow = false,
+  bool pageGrid = false,
   bool pageColor = true,
   bool author = false,
   String? authorName,
@@ -796,6 +810,23 @@ Future<void> showPdfShellViewOptionsSheet(
                     setSheetState(() {});
                   },
                 ),
+              if (pageGrid)
+                SwitchListTile(
+                  key: const ValueKey('pdf-shell-page-grid'),
+                  secondary: const Icon(Icons.view_module_outlined),
+                  title: const Text('Page grid'),
+                  value: preferences.showThumbnailView,
+                  onChanged: (_) async {
+                    await _selectViewOption(
+                      context,
+                      _ViewOption.pageGrid,
+                      preferences: preferences,
+                      pageColor: pageColor,
+                      onAuthorPressed: onAuthorPressed,
+                    );
+                    setSheetState(() {});
+                  },
+                ),
               if (pageColor)
                 ListTile(
                   key: const ValueKey('pdf-shell-page-color'),
@@ -850,6 +881,7 @@ class PdfShellViewOptionsButton extends StatelessWidget {
     super.key,
     required this.preferences,
     this.reflow = false,
+    this.pageGrid = false,
     this.pageColor = true,
     this.author = false,
     this.authorName,
@@ -858,6 +890,10 @@ class PdfShellViewOptionsButton extends StatelessWidget {
 
   final PdfEditingPreferences preferences;
   final bool reflow;
+
+  /// Whether the menu offers "Page grid" — the full-area page thumbnail
+  /// view (`PdfThumbnailView`) that replaces the page viewer.
+  final bool pageGrid;
 
   /// Whether the "Page color…" item is offered. With it false the paper
   /// color can't be changed here — for hosts that set [pageColor] from
@@ -918,6 +954,13 @@ class PdfShellViewOptionsButton extends StatelessWidget {
             value: _ViewOption.reflow,
             checked: preferences.showReflowView,
             child: const Text('Reflow text'),
+          ),
+        if (pageGrid)
+          CheckedPopupMenuItem(
+            key: const ValueKey('pdf-shell-page-grid'),
+            value: _ViewOption.pageGrid,
+            checked: preferences.showThumbnailView,
+            child: const Text('Page grid'),
           ),
         if (pageColor)
           PopupMenuItem(

--- a/packages/dart_pdf_editor/test/editing_thumbnail_view_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_view_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/gestures.dart' show kLongPressTimeout;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The "Page N" label a page draws, or '' for a blank page.
+String labelOf(PdfDocument doc, int index) {
+  final content = String.fromCharCodes(doc.page(index).contentBytes());
+  return RegExp(r'\((Page \d+)\)').firstMatch(content)?.group(1) ?? '';
+}
+
+List<String> labelsOf(PdfDocument doc) =>
+    [for (var i = 0; i < doc.pageCount; i++) labelOf(doc, i)];
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  // a roomy surface so every grid cell lays out and is hit-testable (the
+  // grid builds every child eagerly, but they still need to fit to tap)
+  void wideScreen(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1000, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  Future<({PdfEditingController editing, PdfViewerController viewer})> pumpGrid(
+    WidgetTester tester, {
+    int pages = 4,
+    bool allowPageEditing = true,
+    void Function(Uint8List bytes)? onExportPages,
+    void Function(int pageIndex)? onOpenPage,
+    PdfEditingController? controller,
+  }) async {
+    final editing =
+        controller ?? PdfEditingController(buildMultiPagePdf(pages));
+    final viewer = PdfViewerController();
+    if (controller == null) addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfThumbnailView(
+          controller: editing,
+          viewerController: viewer,
+          allowPageEditing: allowPageEditing,
+          onExportPages: onExportPages,
+          onOpenPage: onOpenPage,
+        ),
+      ),
+    ));
+    await tester.pump();
+    return (editing: editing, viewer: viewer);
+  }
+
+  // thumbnails rasterize on a serialized async queue; let it settle so no
+  // work outlives the test
+  Future<void> drain(WidgetTester tester) =>
+      tester.pump(const Duration(seconds: 2));
+
+  group('PdfThumbnailView', () {
+    testWidgets('lays out one cell per page', (tester) async {
+      wideScreen(tester);
+      await pumpGrid(tester, pages: 5);
+      for (var i = 0; i < 5; i++) {
+        expect(
+            find.byKey(ValueKey('pdf-thumbnail-grid-cell-$i')), findsOneWidget);
+      }
+      await drain(tester);
+    });
+
+    testWidgets('the Add page footer appends a blank page', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 2);
+      expect(refs.editing.document.pageCount, 2);
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-view-add-page')));
+      await tester.pump();
+      expect(refs.editing.document.pageCount, 3);
+      expect(labelOf(refs.editing.document, 2), '');
+      await drain(tester);
+    });
+
+    testWidgets('a plain tap opens the page: selects, jumps, and notifies',
+        (tester) async {
+      wideScreen(tester);
+      int? opened;
+      final refs = await pumpGrid(
+        tester,
+        pages: 4,
+        onOpenPage: (i) => opened = i,
+      );
+      await tester.tap(find.text('Page 3'));
+      await tester.pump();
+      expect(refs.editing.selectedPages, [2]);
+      expect(opened, 2);
+      await drain(tester);
+    });
+
+    testWidgets('the size slider changes the tile-width preference',
+        (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 3);
+      final prefs = refs.editing.preferences;
+      expect(prefs.thumbnailViewTileWidth, isNull);
+
+      // drag the slider toward "larger"
+      await tester.drag(find.byKey(const ValueKey('pdf-thumbnail-view-size')),
+          const Offset(40, 0));
+      await tester.pump();
+
+      final width = prefs.thumbnailViewTileWidth;
+      expect(width, isNotNull);
+      expect(width, greaterThan(96));
+      expect(width, lessThanOrEqualTo(360));
+      await drain(tester);
+    });
+
+    testWidgets('the tile width follows the preference', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 3);
+      refs.editing.preferences.thumbnailViewTileWidth = 300;
+      await tester.pump();
+      final size = tester
+          .getSize(find.byKey(const ValueKey('pdf-thumbnail-grid-cell-0')));
+      expect(size.width, moreOrLessEquals(300, epsilon: 0.5));
+      await drain(tester);
+    });
+
+    testWidgets('shift-click builds a selection the bar deletes',
+        (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 5);
+
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      expect(refs.editing.selectedPages, [1]);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 4'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(refs.editing.selectedPages, [1, 2, 3]);
+
+      expect(find.byKey(const ValueKey('pdf-thumbnail-delete-selected')),
+          findsOneWidget);
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-delete-selected')));
+      await tester.pump();
+      expect(labelsOf(refs.editing.document), ['Page 1', 'Page 5']);
+      expect(refs.editing.hasPageSelection, isFalse);
+      await drain(tester);
+    });
+
+    testWidgets('a per-tile rotate button turns one page', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 3);
+      await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-rotate-1')));
+      await tester.pump();
+      expect(refs.editing.document.page(0).rotation, 0);
+      expect(refs.editing.document.page(1).rotation, 90);
+      await drain(tester);
+    });
+
+    testWidgets('a long-press drag reorders pages', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 4);
+      expect(labelsOf(refs.editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 4']);
+
+      // touch is the default test pointer, so the cell waits for a long
+      // press before dragging — pick up page 1, drop it on page 3's cell
+      final from = tester
+          .getCenter(find.byKey(const ValueKey('pdf-thumbnail-grid-cell-0')));
+      final to = tester
+          .getCenter(find.byKey(const ValueKey('pdf-thumbnail-grid-cell-2')));
+      final gesture = await tester.startGesture(from);
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 100));
+      await gesture.moveTo(to);
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      // movePage(0, 2): page 1 lands at index 2
+      expect(labelsOf(refs.editing.document),
+          ['Page 2', 'Page 3', 'Page 1', 'Page 4']);
+      await drain(tester);
+    });
+
+    testWidgets('the selection bar exports the selection', (tester) async {
+      wideScreen(tester);
+      Uint8List? exported;
+      final refs = await pumpGrid(
+        tester,
+        pages: 4,
+        onExportPages: (bytes) => exported = bytes,
+      );
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 2'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(refs.editing.selectedPages, [0, 1]);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-export-selected')));
+      await tester.pump();
+      expect(exported, isNotNull);
+      expect(labelsOf(PdfDocument.open(exported!)), ['Page 1', 'Page 2']);
+      await drain(tester);
+    });
+
+    testWidgets('a read-only grid drops the editing controls', (tester) async {
+      wideScreen(tester);
+      await pumpGrid(tester, pages: 3, allowPageEditing: false);
+      // no footer, no per-tile rotate/delete, and no draggable cells
+      expect(find.byKey(const ValueKey('pdf-thumbnail-view-add-page')),
+          findsNothing);
+      expect(
+          find.byKey(const ValueKey('pdf-thumbnail-rotate-0')), findsNothing);
+      expect(find.byType(LongPressDraggable<int>), findsNothing);
+      expect(find.byType(Draggable<int>), findsNothing);
+      await drain(tester);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -275,6 +275,75 @@ void main() {
       expect(find.text('Hello, world!'), findsOneWidget);
     });
 
+    testWidgets('View options can swap in the full-area page grid',
+        (tester) async {
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      await pump(tester,
+          PdfEditorView(bytes: buildMultiPagePdf(3), preferences: prefs));
+      expect(find.byType(PdfThumbnailView), findsNothing);
+      expect(find.byType(PdfViewer), findsOneWidget);
+      expect(find.byType(PdfEditingToolbar), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-page-grid')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+
+      expect(prefs.showThumbnailView, isTrue);
+      expect(find.byType(PdfThumbnailView), findsOneWidget);
+      // the viewer stays mounted under the opaque grid (so a tap can scroll
+      // it), but the editing toolbar and the viewer-only header controls go
+      expect(find.byType(PdfViewer), findsOneWidget);
+      expect(find.byType(PdfEditingToolbar), findsNothing);
+      expect(find.byKey(const ValueKey('pdf-search-field')), findsNothing);
+      expect(find.byKey(const ValueKey('pdf-shell-zoom-menu')), findsNothing);
+
+      // tapping a page in the grid returns to the page view
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      expect(prefs.showThumbnailView, isFalse);
+      expect(find.byType(PdfThumbnailView), findsNothing);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('opening the page grid clears reflow', (tester) async {
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      prefs.showReflowView = true;
+      await pump(
+          tester, PdfEditorView(bytes: buildClassicPdf(), preferences: prefs));
+      expect(find.byType(PdfReflowView), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-page-grid')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+
+      expect(prefs.showReflowView, isFalse);
+      expect(prefs.showThumbnailView, isTrue);
+      expect(find.byType(PdfReflowView), findsNothing);
+      expect(find.byType(PdfThumbnailView), findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('thumbnails: false hides the page-grid view option',
+        (tester) async {
+      await pump(
+          tester,
+          PdfEditorView(
+              bytes: buildMultiPagePdf(2),
+              features: const PdfEditorFeatures(thumbnails: false)));
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('pdf-shell-page-grid')), findsNothing);
+    });
+
     testWidgets('reflowView: false hides editor reflow option', (tester) async {
       final prefs = PdfEditingPreferences();
       addTearDown(prefs.dispose);
@@ -586,8 +655,8 @@ void main() {
         tester,
         PdfEditorView(controller: editing, onSave: (_) {}),
       );
-      FilledButton saveButton() => tester.widget<FilledButton>(
-          find.byKey(const ValueKey('pdf-shell-save')));
+      FilledButton saveButton() => tester
+          .widget<FilledButton>(find.byKey(const ValueKey('pdf-shell-save')));
 
       // freshly opened: nothing to save, so the button is disabled
       expect(saveButton().onPressed, isNull);


### PR DESCRIPTION
## What

Adds **`PdfThumbnailView`** — a dedicated, full-area page thumbnail grid that complements the existing docked thumbnail strip (`PdfThumbnailSidebar`). It carries the strip's whole control set and adds a thumbnail-size control, as requested.

## The view

A reflowing grid of page thumbnails with:

- **Tap to open** a page — a "page picker" tap that scrolls the viewer there and returns to the page view.
- **Shift / ⌘-click multi-select** with the same bulk-action bar (rotate / export / delete / clear).
- **Per-tile rotate and delete**, and an **Add-page** footer.
- **Drag to reorder** pages.
- The **page-actions menu** (Insert PDF… / Export pages…).
- A **size slider** in the header that changes the tile size (mouse-wheel-free zoom of the thumbnails), persisted across sessions.

It reuses the strip's render-stamp-keyed thumbnail cache and tile widget, so an edit re-rasterizes only the pages it touched. The multi-select bar was factored into a shared widget so both views expose identical controls and test keys.

## How it's surfaced

In `PdfEditorView` it's a view mode beside reflow — toggled from **View options → "Page grid"** (kept out of the header button row so it adds no header width). When active it overlays the still-mounted viewer (opaque, so gap taps don't fall through) rather than replacing it, so a tapped page can scroll the live viewer before the grid closes to reveal it. Reflow and the grid each clear the other since both replace the viewer.

## Reorder gesture

`ReorderableListView` is list-only, so grid reorder is custom: each cell wraps the tile in a `DragTarget` over an immediate `Draggable` (mouse) or `LongPressDraggable` (touch/stylus), picked by a `MouseRegion` hover flag — so a finger drag still scrolls the grid while a mouse picks a page up immediately.

## Preferences

New persisted prefs: `showThumbnailView` (bool) and `thumbnailViewTileWidth` (double, clamped 96–360).

## Tests

- `editing_thumbnail_view_test.dart` (new, 10 tests): layout, page-picker tap, size slider ↔ preference ↔ tile width, shift-select + delete, per-tile rotate, long-press drag reorder, export, and read-only mode dropping the editing controls.
- `pdf_shell_test.dart` (+3): View options swaps in the grid and a tap returns to the page view, opening the grid clears reflow, and `thumbnails: false` hides the option.

Analyzer clean; the full `dart_pdf_editor` suite passes apart from 14 pre-existing `ghent_render_test` overprint/DeviceN baseline diffs (verified identical on a clean tree — the documented "overprint simulation isn't implemented" deviations, untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WbnnnA3qy9XWnzMKqFvcG

---
_Generated by [Claude Code](https://claude.ai/code/session_013WbnnnA3qy9XWnzMKqFvcG)_