### PR TITLE
Add a right-click context menu to page thumbnails

### DIFF
--- a/doc/dev-log.md
+++ b/doc/dev-log.md
@@ -2554,3 +2554,37 @@ affected. Removed the whole staging apparatus + its
 `onnx_ocr_model_runner_test.dart` (it only exercised the dead path logic;
 the surviving `load()` is native-only, unverifiable in the sandbox per the
 #76 honesty posture). 30 package tests still green; analyzer clean.
+
+Thumbnail right-click menu: a page context menu on the thumbnail strip
+(`editing_thumbnails.dart`), opened by secondary tap on a tile
+(`_PageTile`'s `GestureDetector.onSecondaryTapUp`) — rotate left / right /
+180°, duplicate, insert blank page before / after, export (only when the
+sidebar's `onExportPages` is wired), delete. `_showPageTileMenu` mirrors
+the annotation menu's selection semantics: a right-click on a tile already
+in a multi-page strip selection keeps the whole selection (labels read
+"Delete 3 pages"); a right-click on an unselected tile first
+`selectPage`s it so the target is just that page ("Delete page"). The
+actions route to the existing selection-aware controller methods
+(`rotatePages`, `removeSelectedPages`, `addBlankPage(at:)`,
+`exportPages`) plus a new `PdfEditingController.duplicatePages(indices)`
+— deep-copies the picked pages and inserts them as one contiguous block
+after the last of them. Duplicate had to reopen the current `bytes` as a
+*separate* `PdfDocument` before `appendPagesFrom`, because that editor
+method refuses `identical(source.cos, document.cos)` (no copying a page
+into its own live document). Delete is disabled, not hidden, when it would
+empty the document (single page, or a selection covering every page),
+matching the controller's own no-op guards. Gotcha: the reorder drag
+listener (`_ReorderDragStartListener.onPointerDown`) used to start a drag
+for *every* mouse pointer-down, which swallowed the secondary tap — now it
+bails when `event.kind == mouse && event.buttons != kPrimaryButton`, so
+right/middle clicks fall through to the tile's tap recognizer while
+primary-button (and all touch/stylus) drags still reorder. Touch keeps the
+per-tile rotate/delete buttons and the multi-select bar; the menu is the
+desktop affordance. Tests in `editing_page_ops_test.dart`: a "thumbnail
+context menu" widget group (right-click via
+`tap(..., buttons: kSecondaryMouseButton, kind: mouse)`) covering each
+action, the multi-vs-single selection split, the disabled-delete guard,
+and a read-only strip (no menu without a handler; export-only with one),
+plus a `duplicatePages` unit group. 47 page-ops tests green; the existing
+reorder test (`editing_test.dart`) still passes both its long-press-touch
+and immediate-mouse drag paths; analyzer clean.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1669,6 +1669,29 @@ class PdfEditingController extends ChangeNotifier {
         indices: indices, at: at);
   }
 
+  /// Duplicates [indices] (deep-copying each page and everything it
+  /// references), inserting the copies as one contiguous block right
+  /// after the last of them and preserving their order. Returns false (a
+  /// no-op) when nothing valid is given. Structural page edits shift
+  /// indices, so the page selection is cleared first.
+  bool duplicatePages(Iterable<int> indices) {
+    final targets = indices
+        .where((i) => i >= 0 && i < _document.pageCount)
+        .toSet()
+        .toList()
+      ..sort();
+    if (targets.isEmpty) return false;
+    _selected.clear();
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
+    // appendPagesFrom refuses a page's own document object; reopening the
+    // current bytes gives a separate source, so a page can be copied back
+    // into the file it came from.
+    final source = PdfDocument.open(bytes, password: _password);
+    return apply((e) =>
+        e.appendPagesFrom(source, indices: targets, at: targets.last + 1));
+  }
+
   /// Exports [indices] (in that order) as a fresh standalone PDF, leaving
   /// this document untouched. See [PdfPageExtraction.extractPages].
   Uint8List exportPages(List<int> indices) => _document.extractPages(indices);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -20,7 +20,11 @@ import 'editing_preferences.dart';
 /// down to reorder pages (with a mouse just drag; on touch, long-press
 /// first so the list still scrolls), the per-tile button deletes a page
 /// (the last remaining page cannot be deleted), and the strip's footer
-/// appends a blank page. All of this needs [allowPageEditing].
+/// appends a blank page. Right-clicking a tile (secondary tap) opens a
+/// page context menu — rotate, duplicate, insert a blank page before or
+/// after, export (when [onExportPages] is given), delete — that acts on
+/// the strip's selection when the tile belongs to it. All of this (export
+/// aside) needs [allowPageEditing].
 ///
 /// Built to stay light on large documents: thumbnails are rasterized at
 /// tile resolution and cached, keyed by
@@ -425,6 +429,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                       pageColor: widget.pageColor,
                       showAnnotations: widget.showAnnotations,
                       allowPageEditing: widget.allowPageEditing,
+                      onExportPages: widget.onExportPages,
                       cache: _cache,
                       tileWidth: _tileWidth,
                       renderWorker: widget.renderWorker,
@@ -618,6 +623,12 @@ class _ReorderDragStartListener extends ReorderableDragStartListener {
   Widget build(BuildContext context) {
     return Listener(
       onPointerDown: (event) {
+        // a right- or middle-click is for the context menu, not a reorder
+        // drag — let the tile's secondary-tap recognizer have the pointer
+        if (event.kind == PointerDeviceKind.mouse &&
+            event.buttons != kPrimaryButton) {
+          return;
+        }
         SliverReorderableList.maybeOf(context)?.startItemDragReorder(
           index: index,
           event: event,
@@ -642,6 +653,7 @@ class _PageTile extends StatelessWidget {
     required this.pageColor,
     required this.showAnnotations,
     required this.allowPageEditing,
+    required this.onExportPages,
     required this.cache,
     required this.tileWidth,
     required this.renderWorker,
@@ -653,6 +665,7 @@ class _PageTile extends StatelessWidget {
   final Color pageColor;
   final bool showAnnotations;
   final bool allowPageEditing;
+  final void Function(Uint8List bytes)? onExportPages;
   final _ThumbnailCache cache;
   final double tileWidth;
   final PdfRenderWorker? renderWorker;
@@ -697,6 +710,17 @@ class _PageTile extends StatelessWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: _onTap,
+      // a right-click (or control-click on macOS) opens the page context
+      // menu — rotate / duplicate / insert / export / delete — operating
+      // on the strip's selection when this tile belongs to it
+      onSecondaryTapUp: (details) => _showPageTileMenu(
+        context: context,
+        position: details.globalPosition,
+        controller: controller,
+        pageIndex: pageIndex,
+        allowPageEditing: allowPageEditing,
+        onExportPages: onExportPages,
+      ),
       // a selected tile reads as a primary-framed, tinted chip behind the
       // thumbnail. The 1.5px frame is always laid out (transparent when
       // unselected) and paid back out of the padding, so selecting a tile
@@ -825,6 +849,148 @@ class _PageTile extends StatelessWidget {
     );
   }
 }
+
+/// The page actions a thumbnail's right-click (secondary tap) menu offers.
+enum _PageTileAction {
+  rotateLeft,
+  rotateRight,
+  rotate180,
+  duplicate,
+  insertBefore,
+  insertAfter,
+  export,
+  delete,
+}
+
+/// Shows the thumbnail context menu at [position] (global coordinates) for
+/// the page right-clicked. When that page is already part of a multi-page
+/// strip selection the actions span the whole selection; otherwise the
+/// menu first selects just that page (so its target is unambiguous), then
+/// acts on it alone. Resolves when the menu closes, after the picked
+/// action ran.
+///
+/// [allowPageEditing] gates the structural entries (rotate, duplicate,
+/// insert, delete); [onExportPages] gates Export — each is omitted when
+/// unavailable, so a read-only strip with no export handler never opens a
+/// menu at all.
+Future<void> _showPageTileMenu({
+  required BuildContext context,
+  required Offset position,
+  required PdfEditingController controller,
+  required int pageIndex,
+  required bool allowPageEditing,
+  required void Function(Uint8List bytes)? onExportPages,
+}) async {
+  final canExport = onExportPages != null;
+  if (!allowPageEditing && !canExport) return;
+  // right-clicking a tile that isn't already selected selects just it (a
+  // right-click on a tile that is part of a multi-selection keeps the
+  // selection), so the pages the menu acts on always include this one
+  if (!controller.isPageSelected(pageIndex)) controller.selectPage(pageIndex);
+  final targets = controller.selectedPages;
+  final multi = targets.length > 1;
+  final pageCount = controller.document.pageCount;
+
+  // "Duplicate page" / "Export 3 pages" — the verb's object reflects how
+  // many pages the action spans
+  String forPages(String verb) =>
+      multi ? '$verb ${targets.length} pages' : '$verb page';
+
+  final items = <PopupMenuEntry<_PageTileAction>>[
+    if (allowPageEditing) ...[
+      _pageMenuRow(_PageTileAction.rotateLeft,
+          tileKey: 'pdf-thumbnail-menu-rotate-left',
+          icon: Icons.rotate_left,
+          label: 'Rotate left'),
+      _pageMenuRow(_PageTileAction.rotateRight,
+          tileKey: 'pdf-thumbnail-menu-rotate-right',
+          icon: Icons.rotate_right,
+          label: 'Rotate right'),
+      _pageMenuRow(_PageTileAction.rotate180,
+          tileKey: 'pdf-thumbnail-menu-rotate-180',
+          icon: Icons.cached,
+          label: 'Rotate 180°'),
+      _pageMenuRow(_PageTileAction.duplicate,
+          tileKey: 'pdf-thumbnail-menu-duplicate',
+          icon: Icons.copy_all_outlined,
+          label: forPages('Duplicate')),
+      // insert is relative to the right-clicked page — a single insertion
+      // point — so it stays singular even under a multi-selection
+      _pageMenuRow(_PageTileAction.insertBefore,
+          tileKey: 'pdf-thumbnail-menu-insert-before',
+          icon: Icons.vertical_align_top,
+          label: 'Insert blank page before'),
+      _pageMenuRow(_PageTileAction.insertAfter,
+          tileKey: 'pdf-thumbnail-menu-insert-after',
+          icon: Icons.vertical_align_bottom,
+          label: 'Insert blank page after'),
+    ],
+    if (canExport)
+      _pageMenuRow(_PageTileAction.export,
+          tileKey: 'pdf-thumbnail-menu-export',
+          icon: Icons.file_download_outlined,
+          label: '${forPages('Export')}…'),
+    if (allowPageEditing)
+      _pageMenuRow(_PageTileAction.delete,
+          tileKey: 'pdf-thumbnail-menu-delete',
+          icon: Icons.delete_outline,
+          label: forPages('Delete'),
+          // a document must keep at least one page
+          enabled: multi ? targets.length < pageCount : pageCount > 1),
+  ];
+  if (items.isEmpty) return;
+
+  final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
+  final picked = await showMenu<_PageTileAction>(
+    context: context,
+    position:
+        RelativeRect.fromRect(position & Size.zero, Offset.zero & overlay.size),
+    items: items,
+  );
+  switch (picked) {
+    case null:
+      return;
+    case _PageTileAction.rotateLeft:
+      controller.rotatePages(targets, -90);
+    case _PageTileAction.rotateRight:
+      controller.rotatePages(targets, 90);
+    case _PageTileAction.rotate180:
+      controller.rotatePages(targets, 180);
+    case _PageTileAction.duplicate:
+      controller.duplicatePages(targets);
+    case _PageTileAction.insertBefore:
+      controller.addBlankPage(at: pageIndex);
+    case _PageTileAction.insertAfter:
+      controller.addBlankPage(at: pageIndex + 1);
+    case _PageTileAction.export:
+      onExportPages?.call(controller.exportPages(targets));
+    case _PageTileAction.delete:
+      controller.removeSelectedPages();
+  }
+}
+
+PopupMenuItem<_PageTileAction> _pageMenuRow(
+  _PageTileAction action, {
+  required String tileKey,
+  required IconData icon,
+  required String label,
+  bool enabled = true,
+}) =>
+    PopupMenuItem<_PageTileAction>(
+      key: ValueKey(tileKey),
+      value: action,
+      enabled: enabled,
+      child: Row(children: [
+        // PopupMenuItem dims only its text when disabled; match it on the icon
+        Builder(
+          builder: (context) => Icon(icon,
+              size: 18,
+              color: enabled ? null : Theme.of(context).disabledColor),
+        ),
+        const SizedBox(width: 10),
+        Flexible(child: Text(label, overflow: TextOverflow.ellipsis)),
+      ]),
+    );
 
 /// The check badge overlaid on a selected page's thumbnail — an
 /// unmistakable "this page is in the selection" marker that reads on any

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -70,6 +71,45 @@ void main() {
       final source = PdfDocument.open(buildMultiPagePdf(3));
       editing.insertPagesFrom(source, indices: [2]);
       expect(labelsOf(editing.document), ['Page 1', 'Page 3']);
+    });
+  });
+
+  group('duplicatePages', () {
+    test('copies one page right after itself', () {
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      expect(editing.duplicatePages([1]), isTrue);
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 2', 'Page 3']);
+    });
+
+    test('copies several pages as one contiguous block after the last', () {
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      addTearDown(editing.dispose);
+      // pages 1 and 3 (Page 2, Page 4) copied after the higher of them
+      expect(editing.duplicatePages([2, 0]), isTrue);
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 1', 'Page 3', 'Page 4']);
+    });
+
+    test('preserves the page content (a real glyph survives the copy)', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      addTearDown(editing.dispose);
+      editing.duplicatePages([0]);
+      expect(labelOf(editing.document, 1), 'Page 1');
+    });
+
+    test('is a no-op with nothing valid, and undo restores the count', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      addTearDown(editing.dispose);
+      expect(editing.duplicatePages(const []), isFalse);
+      expect(editing.duplicatePages([5]), isFalse); // out of range
+      expect(editing.document.pageCount, 2);
+
+      editing.duplicatePages([0]);
+      expect(editing.document.pageCount, 3);
+      editing.undo();
+      expect(editing.document.pageCount, 2);
     });
   });
 
@@ -543,6 +583,242 @@ void main() {
       editing.clearPageSelection();
       await tester.pump();
       expect(find.byIcon(Icons.check), findsNothing);
+      await tester.pump(const Duration(seconds: 2));
+    });
+  });
+
+  group('thumbnail context menu', () {
+    /// Pumps a sidebar over a [count]-page document.
+    Future<PdfEditingController> pumpStrip(
+      WidgetTester tester, {
+      int count = 4,
+      bool allowPageEditing = true,
+      void Function(Uint8List bytes)? onExportPages,
+    }) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(count));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(
+              controller: editing,
+              viewerController: viewer,
+              allowPageEditing: allowPageEditing,
+              onExportPages: onExportPages,
+            ),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    /// Right-clicks the tile labelled [label] and waits for the menu.
+    Future<void> rightClickTile(WidgetTester tester, String label) async {
+      await tester.tap(find.text(label),
+          buttons: kSecondaryMouseButton, kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('right-clicking a tile opens the menu and rotates the page',
+        (tester) async {
+      final editing = await pumpStrip(tester);
+
+      await rightClickTile(tester, 'Page 2');
+      // the right-click selected just that page
+      expect(editing.selectedPages, [1]);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-menu-rotate-right')),
+          findsOneWidget);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-rotate-right')));
+      await tester.pumpAndSettle();
+      expect(editing.document.page(0).rotation, 0);
+      expect(editing.document.page(1).rotation, 90);
+      await tester.pump(const Duration(seconds: 2)); // drain tile renders
+    });
+
+    testWidgets('the menu rotates left and a half turn', (tester) async {
+      final editing = await pumpStrip(tester);
+
+      await rightClickTile(tester, 'Page 1');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-rotate-left')));
+      await tester.pumpAndSettle();
+      expect(editing.document.page(0).rotation, 270);
+
+      await rightClickTile(tester, 'Page 1');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-rotate-180')));
+      await tester.pumpAndSettle();
+      expect(editing.document.page(0).rotation, 90);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('the menu deletes the right-clicked page', (tester) async {
+      final editing = await pumpStrip(tester);
+
+      await rightClickTile(tester, 'Page 2');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-delete')));
+      await tester.pumpAndSettle();
+      expect(labelsOf(editing.document), ['Page 1', 'Page 3', 'Page 4']);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('the menu duplicates the right-clicked page', (tester) async {
+      final editing = await pumpStrip(tester, count: 2);
+
+      await rightClickTile(tester, 'Page 1');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-duplicate')));
+      await tester.pumpAndSettle();
+      expect(labelsOf(editing.document), ['Page 1', 'Page 1', 'Page 2']);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('the menu inserts a blank page before and after',
+        (tester) async {
+      final editing = await pumpStrip(tester, count: 2);
+
+      await rightClickTile(tester, 'Page 2');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-insert-after')));
+      await tester.pumpAndSettle();
+      // a blank page lands after page 2 (index 2)
+      expect(labelsOf(editing.document), ['Page 1', 'Page 2', '']);
+
+      await rightClickTile(tester, 'Page 1');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-insert-before')));
+      await tester.pumpAndSettle();
+      expect(labelsOf(editing.document), ['', 'Page 1', 'Page 2', '']);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('the menu exports the right-clicked page to the host',
+        (tester) async {
+      Uint8List? exported;
+      final editing =
+          await pumpStrip(tester, onExportPages: (bytes) => exported = bytes);
+
+      await rightClickTile(tester, 'Page 3');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-export')));
+      await tester.pumpAndSettle();
+      expect(exported, isNotNull);
+      expect(labelsOf(PdfDocument.open(exported!)), ['Page 3']);
+      // the document itself is untouched by an export
+      expect(editing.document.pageCount, 4);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('right-clicking within a multi-selection spans the selection',
+        (tester) async {
+      final editing = await pumpStrip(tester, count: 5);
+
+      // build a 3-page selection
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 3'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(editing.selectedPages, [0, 1, 2]);
+
+      // right-clicking a tile already in the selection keeps it whole, and
+      // the menu's labels reflect the count
+      await rightClickTile(tester, 'Page 2');
+      expect(editing.selectedPages, [0, 1, 2]);
+      expect(find.text('Delete 3 pages'), findsOneWidget);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-delete')));
+      await tester.pumpAndSettle();
+      expect(labelsOf(editing.document), ['Page 4', 'Page 5']);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('right-clicking outside the selection re-selects just it',
+        (tester) async {
+      final editing = await pumpStrip(tester, count: 5);
+
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 3'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(editing.selectedPages, [0, 1, 2]);
+
+      // a right-click on a tile that is NOT part of the selection drops it
+      // and selects only the clicked page
+      await rightClickTile(tester, 'Page 5');
+      expect(editing.selectedPages, [4]);
+      expect(find.text('Delete page'), findsOneWidget);
+      // dismiss the menu without acting
+      await tester.tapAt(const Offset(700, 700));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('the delete entry is disabled on a single-page document',
+        (tester) async {
+      final editing = await pumpStrip(tester, count: 1);
+
+      await rightClickTile(tester, 'Page 1');
+      final delete =
+          tester.widget(find.byKey(const ValueKey('pdf-thumbnail-menu-delete')))
+              as PopupMenuItem;
+      expect(delete.enabled, isFalse);
+      expect(editing.document.pageCount, 1);
+      // dismiss
+      await tester.tapAt(const Offset(700, 700));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('a read-only strip with no export handler shows no menu',
+        (tester) async {
+      final editing = await pumpStrip(tester, allowPageEditing: false);
+
+      await rightClickTile(tester, 'Page 2');
+      // no editing actions, no export handler → nothing opens
+      expect(find.byKey(const ValueKey('pdf-thumbnail-menu-rotate-right')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-menu-export')),
+          findsNothing);
+      expect(editing.document.pageCount, 4);
+      await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('a read-only strip still offers export when given a handler',
+        (tester) async {
+      Uint8List? exported;
+      await pumpStrip(tester,
+          allowPageEditing: false, onExportPages: (bytes) => exported = bytes);
+
+      await rightClickTile(tester, 'Page 2');
+      // export is available, but the structural edits are not
+      expect(find.byKey(const ValueKey('pdf-thumbnail-menu-export')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-menu-rotate-right')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-menu-delete')),
+          findsNothing);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-menu-export')));
+      await tester.pumpAndSettle();
+      expect(exported, isNotNull);
+      expect(labelsOf(PdfDocument.open(exported!)), ['Page 2']);
       await tester.pump(const Duration(seconds: 2));
     });
   });


### PR DESCRIPTION
## What

Adds a right-click (secondary tap) context menu to the page thumbnails in `PdfThumbnailSidebar`, exposing the page operations that previously needed the per-tile buttons or the multi-select bar — now reachable directly from any tile.

The menu offers:

- **Rotate left** (90° CCW), **Rotate right** (90° CW), **Rotate 180°**
- **Duplicate** the page(s)
- **Insert blank page before** / **Insert blank page after** (relative to the clicked tile)
- **Export…** (only when the sidebar's `onExportPages` handler is wired)
- **Delete**

## Behavior

- **Selection-aware**, mirroring the annotation context menu: right-clicking a tile that's already part of a multi-page strip selection acts on the whole selection (labels read e.g. *"Delete 3 pages"*); right-clicking an unselected tile first selects just that page, so the target is unambiguous (*"Delete page"*).
- **Gated entries**: the structural actions require `allowPageEditing`; Export appears only when `onExportPages` is given. A read-only strip with no export handler doesn't open a menu at all; a read-only strip *with* a handler shows Export only.
- **Delete is disabled, not hidden**, when it would empty the document (the last page, or a selection covering every page) — matching the controller's existing no-op guards.

Actions route to the existing selection-aware controller methods (`rotatePages`, `removeSelectedPages`, `addBlankPage(at:)`, `exportPages`) plus a new `PdfEditingController.duplicatePages(indices)`, which deep-copies the picked pages and inserts them as one contiguous block after the last of them. (Duplicate reopens the current bytes as a separate `PdfDocument` first, because `appendPagesFrom` refuses to copy a page into its own live document.)

## Reorder interaction fix

The thumbnail reorder drag listener used to start a drag on *every* mouse pointer-down, which swallowed the secondary tap. It now ignores non-primary mouse buttons, so a right/middle click falls through to the tile's secondary-tap recognizer while primary-button and all touch/stylus drags still reorder. Touch keeps its per-tile buttons and the multi-select bar — the menu is the desktop affordance.

## Tests

- New `thumbnail context menu` widget-test group in `editing_page_ops_test.dart` covering each action, the multi- vs single-selection split, the disabled-delete guard, and the read-only/export-only cases.
- New `duplicatePages` unit-test group.
- 47 page-ops tests pass; the existing reorder test still passes both its long-press-touch and immediate-mouse drag paths; analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013AazKjbeZ9M9nrMQM6SM2G)_