### PR TITLE
Add printing to the app

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Print the open document through the OS print dialog on every platform
+  (browser print on the web), from ⌘P / Ctrl+P or the DartPDF menu.
+
 ## 1.2.2
 
 - View rotation, deeper zoom, and smoother touch scrolling in the viewer.

--- a/app/README.md
+++ b/app/README.md
@@ -22,6 +22,8 @@ This is the **product app**. The SDK's feature showcase lives separately in
 - Tabs, light/dark theme, read-only mode, document compare.
 - Dirty-state tracking with a save indicator; **Save** overwrites the original
   file in place (desktop), **Save as** / share / download elsewhere.
+- **Print** the open document (⌘P / Ctrl+P, or the DartPDF menu) through the OS
+  print dialog on every platform, including browser print on the web.
 - Discard prompts on tab-close and app-quit; reopening a document restores its
   scroll position and zoom.
 
@@ -74,6 +76,7 @@ native OS-integration paths still want on-device confirmation:
 | Drag-and-drop onto window | n/a | n/a | ☐ | ☐ | ☐ | ☐ |
 | Edit → Save overwrites the original | n/a* | n/a* | ☐ | ☐ | ☐ | n/a* |
 | OCR a scanned PDF | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
+| Print via the OS dialog (⌘P / Ctrl+P) | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
 | Reopen restores viewport | ☐ | ☐ | ☐ | ☐ | ☐ | ☐ |
 
 \* In-place save is desktop-only today; mobile/web fall back to share/download

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -15,6 +15,7 @@ import 'document_tab.dart';
 import 'file_io.dart';
 import 'incoming_file.dart';
 import 'ocr.dart';
+import 'printing.dart';
 import 'recents.dart';
 import 'settings_screen.dart';
 import 'update.dart';
@@ -39,6 +40,7 @@ class EditorScreen extends StatefulWidget {
     this.initialDocument,
     this.updateService,
     this.autoCheckUpdates = false,
+    this.printDocument,
   });
 
   final PdfEditingPreferences prefs;
@@ -60,6 +62,12 @@ class EditorScreen extends StatefulWidget {
   /// plain widget tests stay hermetic — no startup network traffic. The
   /// Settings panel can still check on demand regardless.
   final bool autoCheckUpdates;
+
+  /// Override for the print action. Tests inject a fake to assert the menu and
+  /// shortcut wiring without the real `printing` plugin (its method channel is
+  /// unavailable under flutter_test). Production leaves this null and the screen
+  /// falls back to [printPdfBytes].
+  final PdfPrinter? printDocument;
 
   @override
   State<EditorScreen> createState() => _EditorScreenState();
@@ -568,6 +576,31 @@ class _EditorScreenState extends State<EditorScreen>
     if (result.message != null) _toast(result.message!);
   }
 
+  // --- printing ------------------------------------------------------------
+
+  /// Hands the active document to the OS print dialog (the `printing` plugin —
+  /// native dialog on desktop/mobile, browser print on the web). The current
+  /// revision is printed, so unsaved edits are included. A failed or
+  /// unavailable backend surfaces as a toast rather than throwing.
+  Future<void> _print(DocumentTab tab) async {
+    final bytes = tab.session?.bytes;
+    if (bytes == null) return;
+    try {
+      await (widget.printDocument ?? printPdfBytes)(
+        bytes: bytes,
+        title: tab.title,
+      );
+    } catch (_) {
+      if (mounted) _toast('Could not print ${tab.title}');
+    }
+  }
+
+  /// Prints the active document, if one is open — bound to ⌘P / Ctrl+P.
+  void _printActive() {
+    final tab = _active;
+    if (tab?.session != null) unawaited(_print(tab!));
+  }
+
   // --- link actions --------------------------------------------------------
 
   /// GoTo and named page actions never reach here (the viewer follows them).
@@ -636,6 +669,15 @@ class _EditorScreenState extends State<EditorScreen>
             ),
           ),
           PopupMenuItem(
+            key: const ValueKey('menu-print'),
+            value: () => unawaited(_print(tab!)),
+            child: const ListTile(
+              leading: Icon(Icons.print_outlined),
+              title: Text('Print…'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+          PopupMenuItem(
             value: _compareWith,
             child: const ListTile(
               leading: Icon(Icons.compare_arrows),
@@ -693,18 +735,29 @@ class _EditorScreenState extends State<EditorScreen>
         titleSpacing: _tabs.isEmpty ? null : 8,
         actions: _buildActions(tab),
       ),
-      body: DropTarget(
-        onDragEntered: (_) => setState(() => _dragging = true),
-        onDragExited: (_) => setState(() => _dragging = false),
-        onDragDone: (detail) {
-          setState(() => _dragging = false);
-          _onFilesDropped(detail.files);
+      body: CallbackShortcuts(
+        // ⌘P (macOS) / Ctrl+P (Windows, Linux, web) print the active document.
+        // Placed above the editor so the SDK's own shortcuts take precedence;
+        // an unhandled print key bubbles up to here.
+        bindings: <ShortcutActivator, VoidCallback>{
+          const SingleActivator(LogicalKeyboardKey.keyP, meta: true):
+              _printActive,
+          const SingleActivator(LogicalKeyboardKey.keyP, control: true):
+              _printActive,
         },
-        child: Stack(
-          children: [
-            Positioned.fill(child: _buildBody(tab)),
-            if (_dragging) const Positioned.fill(child: _DropOverlay()),
-          ],
+        child: DropTarget(
+          onDragEntered: (_) => setState(() => _dragging = true),
+          onDragExited: (_) => setState(() => _dragging = false),
+          onDragDone: (detail) {
+            setState(() => _dragging = false);
+            _onFilesDropped(detail.files);
+          },
+          child: Stack(
+            children: [
+              Positioned.fill(child: _buildBody(tab)),
+              if (_dragging) const Positioned.fill(child: _DropOverlay()),
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/printing.dart
+++ b/app/lib/printing.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:printing/printing.dart';
+
+/// Signature for the app's "Print…" action: hands a PDF's [bytes] to the
+/// platform print system under a job [title]. Injectable through
+/// [EditorScreen.printDocument] so widget tests can assert the wiring without
+/// driving the real print plugin (which needs platform channels).
+typedef PdfPrinter = Future<void> Function({
+  required Uint8List bytes,
+  required String title,
+});
+
+/// Sends [bytes] to the OS print dialog via the `printing` plugin, which covers
+/// iOS, Android, macOS, Windows, Linux, and the web. The document is already a
+/// finished PDF, so the layout callback returns it verbatim regardless of the
+/// paper [format] the user picks — the engine here renders, it doesn't reflow.
+Future<void> printPdfBytes({
+  required Uint8List bytes,
+  required String title,
+}) async {
+  await Printing.layoutPdf(
+    onLayout: (_) => bytes,
+    name: printJobName(title),
+  );
+}
+
+/// A clean print-job / suggested-filename label: the tab title without a
+/// trailing `.pdf`, falling back to a default when it would be empty.
+String printJobName(String title) {
+  var name = title.trim();
+  if (name.toLowerCase().endsWith('.pdf')) {
+    name = name.substring(0, name.length - 4).trim();
+  }
+  return name.isEmpty ? 'Document' : name;
+}

--- a/app/linux/flutter/generated_plugin_registrant.cc
+++ b/app/linux/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
+#include <printing/printing_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -17,6 +18,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) printing_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "PrintingPlugin");
+  printing_plugin_register_with_registrar(printing_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   file_selector_linux
+  printing
   url_launcher_linux
 )
 

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import desktop_drop
 import file_selector_macos
 import package_info_plus
+import printing
 import share_plus
 import shared_preferences_foundation
 import url_launcher_macos
@@ -16,6 +17,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
 </dict>
 </plist>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
 </dict>
 </plist>

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -28,6 +28,10 @@ dependencies:
   file_selector: ^1.0.3
   share_plus: ^13.1.0
   url_launcher: ^6.3.0
+  # Hands a finished PDF to the OS print dialog (iOS, Android, macOS, Windows,
+  # Linux, and the web). The engine here only renders pages, so the document
+  # bytes are printed verbatim — no re-layout.
+  printing: ^5.13.0
   shared_preferences: ^2.3.0
   desktop_drop: ^0.7.0
   # Polls GitHub Releases for a newer build (in-app update checker). Works on

--- a/app/test/print_menu_test.dart
+++ b/app/test/print_menu_test.dart
@@ -80,6 +80,23 @@ void main() {
     expect(String.fromCharCodes(printed!.take(5)), '%PDF-');
   });
 
+  testWidgets('a failing printer surfaces a toast', (tester) async {
+    await pumpWithDoc(
+      tester,
+      printDocument: ({required bytes, required title}) async {
+        throw StateError('no printer available');
+      },
+    );
+
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('menu-print')));
+    await tester.pump(); // reject the future
+    await tester.pump(); // show the snack bar
+
+    expect(find.text('Could not print Report.pdf'), findsOneWidget);
+  });
+
   testWidgets('Ctrl+P prints the active document', (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.linux;
     try {

--- a/app/test/print_menu_test.dart
+++ b/app/test/print_menu_test.dart
@@ -1,0 +1,107 @@
+// The Print action is wired into the DartPDF app menu (and ⌘P / Ctrl+P) when a
+// document is open. The real `printing` plugin needs platform channels, so
+// these tests inject a fake printer to assert the wiring end to end.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/printing.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+  tearDown(() => prefs.dispose());
+
+  Future<void> pumpWithDoc(
+    WidgetTester tester, {
+    PdfPrinter? printDocument,
+  }) async {
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        initialDocument: (bytes: buildClassicPdf(), title: 'Report.pdf'),
+        printDocument: printDocument,
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  testWidgets('the DartPDF menu offers Print with a document open',
+      (tester) async {
+    await pumpWithDoc(tester);
+
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('menu-print')), findsOneWidget);
+    expect(find.text('Print…'), findsOneWidget);
+  });
+
+  testWidgets('no Print entry without a document open', (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('menu-print')), findsNothing);
+  });
+
+  testWidgets('selecting Print hands the document to the printer',
+      (tester) async {
+    Uint8List? printed;
+    String? jobTitle;
+    await pumpWithDoc(
+      tester,
+      printDocument: ({required bytes, required title}) async {
+        printed = bytes;
+        jobTitle = title;
+      },
+    );
+
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('menu-print')));
+    await tester.pumpAndSettle();
+
+    expect(jobTitle, 'Report.pdf');
+    expect(printed, isNotNull);
+    expect(String.fromCharCodes(printed!.take(5)), '%PDF-');
+  });
+
+  testWidgets('Ctrl+P prints the active document', (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      var printCalls = 0;
+      await pumpWithDoc(
+        tester,
+        printDocument: ({required bytes, required title}) async {
+          printCalls += 1;
+        },
+      );
+
+      // Focus the viewer so the shortcut has somewhere to dispatch from.
+      await tester.tap(find.byType(PdfViewer), kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyP);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(printCalls, 1);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/app/test/printing_test.dart
+++ b/app/test/printing_test.dart
@@ -1,0 +1,65 @@
+// Unit coverage for the print wrapper: the job-name normaliser and the
+// `printPdfBytes` hand-off to the `printing` plugin. The real plugin talks over
+// the `net.nfet.printing` method channel, which we mock here — driving the
+// `onCompleted` callback so `Printing.layoutPdf` resolves without a platform.
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/printing.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('printJobName', () {
+    test('strips a trailing .pdf, case-insensitively', () {
+      expect(printJobName('Report.pdf'), 'Report');
+      expect(printJobName('SCAN.PDF'), 'SCAN');
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(printJobName('  Quarterly.pdf  '), 'Quarterly');
+    });
+
+    test('keeps a name that has no extension', () {
+      expect(printJobName('Untitled'), 'Untitled');
+    });
+
+    test('falls back to Document when nothing is left', () {
+      expect(printJobName('   '), 'Document');
+      expect(printJobName('.pdf'), 'Document');
+    });
+  });
+
+  test('printPdfBytes hands the document to the print plugin', () async {
+    const channel = MethodChannel('net.nfet.printing');
+    final messenger = binding.defaultBinaryMessenger;
+    final bytes = Uint8List.fromList('%PDF-1.7'.codeUnits);
+
+    String? sentName;
+    var printPdfCalls = 0;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method != 'printPdf') return null;
+      printPdfCalls += 1;
+      final args = call.arguments as Map;
+      sentName = args['name'] as String?;
+      // Mimic the platform finishing the job so layoutPdf's completer resolves.
+      await messenger.handlePlatformMessage(
+        channel.name,
+        channel.codec.encodeMethodCall(
+          MethodCall('onCompleted', <String, dynamic>{
+            'job': args['job'],
+            'completed': true,
+          }),
+        ),
+        (_) {},
+      );
+      return 1;
+    });
+    addTearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    await printPdfBytes(bytes: bytes, title: 'Report.pdf');
+
+    expect(printPdfCalls, 1);
+    expect(sentName, 'Report'); // the .pdf-stripped job name
+  });
+}

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
+#include <printing/printing_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -16,6 +17,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
+  PrintingPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PrintingPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   file_selector_windows
+  printing
   share_plus
   url_launcher_windows
 )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.1"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.9"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "77f475165e94b261745cf1032c751e2032b8ed92ccb2bf5716036db79320637d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.13"
   boolean_selector:
     dependency: transitive
     description:
@@ -487,6 +503,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
@@ -535,6 +559,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: transitive
+    description:
+      name: pdf
+      sha256: "517df47af468734a23c8b513c0c6a8a62357403ab1b8ab7fad1606576a9dbdd0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.13.0"
+  pdf_widget_wrapper:
+    dependency: transitive
+    description:
+      name: pdf_widget_wrapper
+      sha256: c930860d987213a3d58c7ec3b7ecf8085c3897f773e8dc23da9cae60a5d6d0f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -575,6 +615,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  printing:
+    dependency: transitive
+    description:
+      name: printing
+      sha256: f6cd14c768c1352dd37a958a3ee351aa9ce305b398218d3acd86389d5f7ecad1
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   process:
     dependency: transitive
     description:
@@ -591,6 +639,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   record_use:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Adds a **Print** action to the DartPDF app. It hands the open document's current revision to the OS print dialog via the [`printing`](https://pub.dev/packages/printing) plugin, which covers iOS, Android, macOS, Windows, Linux, and browser print on the web. The engine here only renders pages, so the finished PDF bytes are printed verbatim — no re-layout.

## How

- **`lib/printing.dart`** — a thin `printPdfBytes({bytes, title})` wrapper around `Printing.layoutPdf` (the layout callback returns the bytes unchanged regardless of paper size), plus a `printJobName` helper that strips the trailing `.pdf` for the job/file name. A `PdfPrinter` typedef is the injection seam.
- **`EditorScreen`** — new optional `printDocument` override (null in production → `printPdfBytes`). `_print` reads `tab.session.bytes`, so unsaved edits are included; failures surface as a toast instead of throwing.
- **Entry points** — a "Print…" item in the DartPDF app menu (shown when a document is open) and a **⌘P / Ctrl+P** shortcut. The shortcut uses a `CallbackShortcuts` placed *above* the editor, so the SDK's own shortcuts keep precedence and only an unhandled print key bubbles up.
- **macOS** — added the `com.apple.security.print` sandbox entitlement (debug + release); the app is sandboxed, so printing needs it.
- **Generated** — desktop plugin registrants (linux/macos/windows) and `pubspec.lock` regenerated by `flutter pub get` to register `PrintingPlugin`.

## Tests

New `test/print_menu_test.dart` covers: the menu entry appears with a document open, is absent otherwise, that selecting it hands the document bytes (`%PDF-…`) and title to the injected printer, and that Ctrl+P prints the active document. The full app suite (78 tests) passes and `dart analyze app` is clean.

## Notes

The real plugin needs platform channels (and a completer-based native round-trip), so tests inject a fake printer rather than driving the channel — mirroring how `updateService` is injected. README features list, manual device-test matrix, and an `Unreleased` CHANGELOG entry are updated; the pubspec version is intentionally left for the maintainer's release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XohsbpYp1Jx25Vg4EPVbGm)_