### PR TITLE
Fix garbled web OCR by tiling large pages for Florence-2

### DIFF
--- a/app/firebase.json
+++ b/app/firebase.json
@@ -19,11 +19,11 @@
       { "source": "/main.dart.mjs", "headers": [{ "key": "Cache-Control", "value": "no-cache" }] },
       { "source": "/pdf_render_worker.dart.js", "headers": [{ "key": "Cache-Control", "value": "no-cache" }] },
       {
-        "comment": "Cross-origin isolation: required for SharedArrayBuffer, which skwasm's multithreaded renderer uses. Without these, --wasm falls back to single-threaded skwasm_heavy. COEP:require-corp means every subresource must be same-origin or send CORP/CORS; the Flutter shell + skwasm assets are same-origin, and PDFs are loaded from the local file picker (not fetched), so this is safe here.",
+        "comment": "Cross-origin isolation: enables SharedArrayBuffer, which skwasm's multithreaded renderer uses (without it, --wasm falls back to single-threaded skwasm_heavy). COEP is `credentialless`, not `require-corp`: both isolate the page (crossOriginIsolated === true on Chromium/Firefox), but `require-corp` ALSO demands every cross-origin subresource send a CORP header — which broke the in-browser OCR (ocr_web.dart), whose first run pulls Transformers.js from jsDelivr and the Florence-2 model from HuggingFace's CDN; those don't send CORP, so the download failed with 'TypeError: Failed to fetch'. `credentialless` loads cross-origin resources without credentials instead of requiring CORP, so the OCR model fetch works while the renderer keeps its isolation. Safari has no credentialless support, so it just isn't cross-origin isolated there (single-threaded skwasm_heavy + working OCR) — an acceptable fallback. The Flutter shell + skwasm assets are same-origin; PDFs come from the local file picker (not fetched).",
         "source": "**",
         "headers": [
           { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
-          { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" }
+          { "key": "Cross-Origin-Embedder-Policy", "value": "credentialless" }
         ]
       }
     ]

--- a/app/lib/ocr_tiling.dart
+++ b/app/lib/ocr_tiling.dart
@@ -1,0 +1,229 @@
+import 'dart:math' as math;
+import 'dart:ui' show Offset, Rect;
+
+/// Pure (web-free) geometry and parsing for the browser OCR path, so the
+/// tiling, Florence-2 result parsing, and overlap de-duplication can be unit
+/// tested on the Dart VM — `ocr_web.dart` itself imports `dart:js_interop`
+/// and so can't be loaded by `flutter test`.
+///
+/// Florence-2 resizes every input image to a fixed 768x768 square before it
+/// looks at it, so handing it a whole multi-thousand-pixel scan crushes the
+/// text to a few unreadable pixels and the model hallucinates plausible
+/// tokens. The fix is to split the page raster into overlapping tiles that are
+/// already close to the model's input size, recognize each, then map the
+/// per-tile boxes back into full-page pixel space and drop the duplicates the
+/// overlaps produce ([ocrTiles] + [parseFlorenceSpans] + [mergeOcrSpans]).
+
+/// One recognized text run in raster-pixel space (top-left origin, y down) —
+/// the space tiles and an image-based OCR engine both work in, before the
+/// page geometry maps it to PDF user space.
+class OcrRawSpan {
+  const OcrRawSpan({
+    required this.text,
+    required this.box,
+    this.confidence = 1,
+  });
+
+  final String text;
+  final Rect box;
+  final double confidence;
+
+  /// A copy translated by ([dx], [dy]) — used to lift a tile-local box into
+  /// full-page pixel coordinates by its tile's origin.
+  OcrRawSpan shifted(double dx, double dy) => OcrRawSpan(
+        text: text,
+        box: box.shift(Offset(dx, dy)),
+        confidence: confidence,
+      );
+}
+
+/// Splits a [width] x [height] raster into a grid of overlapping tiles, each at
+/// most [tileSize] px on a side, with neighbours sharing about [overlap] px so
+/// a word straddling a seam stays wholly inside at least one tile. Tiles are
+/// clamped to the image bounds, so the right/bottom column may overlap its
+/// neighbour by more than [overlap]; a raster already within [tileSize] yields
+/// a single full-image tile.
+///
+/// The point is legibility: Florence-2 downsamples whatever it is given to
+/// 768x768, so each tile should be small enough that that downsample leaves
+/// the text readable. [tileSize] 1024 keeps small print legible while bounding
+/// the page to a handful of model calls.
+List<Rect> ocrTiles(
+  int width,
+  int height, {
+  int tileSize = 1024,
+  int overlap = 128,
+}) {
+  if (width <= 0 || height <= 0) return const [];
+  final int size = math.max(1, tileSize);
+  final int step = math.max(1, size - math.max(0, overlap));
+
+  // Tile-start offsets along one axis: step by `step` until a tile would run
+  // off the end, then place a final tile flush against the far edge so the
+  // whole extent is covered (the last two tiles overlap by whatever is left).
+  List<int> starts(int extent) {
+    if (extent <= size) return const [0];
+    final out = <int>[];
+    for (var s = 0; s < extent; s += step) {
+      if (s + size >= extent) {
+        out.add(extent - size);
+        break;
+      }
+      out.add(s);
+    }
+    return out;
+  }
+
+  final xs = starts(width);
+  final ys = starts(height);
+  final tiles = <Rect>[];
+  for (final y in ys) {
+    for (final x in xs) {
+      final w = math.min(size, width - x);
+      final h = math.min(size, height - y);
+      tiles.add(Rect.fromLTWH(x.toDouble(), y.toDouble(), w.toDouble(), h.toDouble()));
+    }
+  }
+  return tiles;
+}
+
+/// Parses a Florence-2 `<OCR_WITH_REGION>` (or plain `<OCR>`) result [payload]
+/// — already JSON-decoded — into raster-pixel spans. Boxes come back in
+/// whatever pixel space the model was given; for a tile that is tile-local, so
+/// the caller offsets each span by the tile origin ([OcrRawSpan.shifted]).
+///
+/// When the model returns only plain text with no boxes, a single span covers
+/// the whole [fallbackWidth] x [fallbackHeight] region (the tile, or the page).
+List<OcrRawSpan> parseFlorenceSpans(
+  Object? payload, {
+  required int fallbackWidth,
+  required int fallbackHeight,
+}) {
+  final map = _payload(payload);
+  final labels = _listOfStrings(map['labels']) ??
+      _listOfStrings(map['text']) ??
+      _listOfStrings(map['texts']);
+  final boxes = _listOfBoxes(map['quad_boxes']) ??
+      _listOfBoxes(map['quadBoxes']) ??
+      _listOfBoxes(map['bboxes']) ??
+      _listOfBoxes(map['boxes']);
+
+  if (labels != null && boxes != null) {
+    final spans = <OcrRawSpan>[];
+    final count = math.min(labels.length, boxes.length);
+    for (var i = 0; i < count; i++) {
+      final text = labels[i].trim();
+      final rect = boxes[i];
+      if (text.isEmpty || rect.width <= 0 || rect.height <= 0) continue;
+      spans.add(OcrRawSpan(text: text, box: rect));
+    }
+    return spans;
+  }
+
+  final text = _plainText(map).trim();
+  if (text.isEmpty) return const [];
+  return [
+    OcrRawSpan(
+      text: text,
+      box: Rect.fromLTWH(0, 0, fallbackWidth.toDouble(), fallbackHeight.toDouble()),
+    ),
+  ];
+}
+
+/// Collapses near-duplicate spans produced where tiles overlap: two spans whose
+/// text matches (trimmed, case-insensitive) and whose boxes overlap by more
+/// than [iouThreshold] keep only the higher-confidence one. O(n^2), which is
+/// fine for the few-hundred spans a page yields.
+List<OcrRawSpan> mergeOcrSpans(
+  List<OcrRawSpan> spans, {
+  double iouThreshold = 0.5,
+}) {
+  final kept = <OcrRawSpan>[];
+  for (final span in spans) {
+    final key = span.text.trim().toLowerCase();
+    var merged = false;
+    for (var i = 0; i < kept.length; i++) {
+      final other = kept[i];
+      if (other.text.trim().toLowerCase() != key) continue;
+      if (_iou(span.box, other.box) <= iouThreshold) continue;
+      if (span.confidence > other.confidence) kept[i] = span;
+      merged = true;
+      break;
+    }
+    if (!merged) kept.add(span);
+  }
+  return kept;
+}
+
+double _iou(Rect a, Rect b) {
+  final left = math.max(a.left, b.left);
+  final top = math.max(a.top, b.top);
+  final right = math.min(a.right, b.right);
+  final bottom = math.min(a.bottom, b.bottom);
+  if (right <= left || bottom <= top) return 0;
+  final inter = (right - left) * (bottom - top);
+  final union = a.width * a.height + b.width * b.height - inter;
+  return union > 0 ? inter / union : 0;
+}
+
+Map<String, Object?> _payload(Object? value) {
+  if (value is Map) {
+    final ocrWithRegion = value['<OCR_WITH_REGION>'];
+    if (ocrWithRegion is Map) return ocrWithRegion.cast<String, Object?>();
+    final ocr = value['<OCR>'];
+    if (ocr is Map) return ocr.cast<String, Object?>();
+    return value.cast<String, Object?>();
+  }
+  if (value is String) return {'text': value};
+  return const {};
+}
+
+List<String>? _listOfStrings(Object? value) {
+  if (value is String) return [value];
+  if (value is! List) return null;
+  return [
+    for (final item in value)
+      if (item != null) item.toString()
+  ];
+}
+
+List<Rect>? _listOfBoxes(Object? value) {
+  if (value is! List) return null;
+  final rects = <Rect>[];
+  for (final item in value) {
+    final rect = _rect(item);
+    if (rect != null) rects.add(rect);
+  }
+  return rects.isEmpty ? null : rects;
+}
+
+Rect? _rect(Object? value) {
+  if (value is! List || value.length < 4) return null;
+  final nums = [
+    for (final v in value)
+      if (v is num) v.toDouble()
+  ];
+  if (nums.length < 4) return null;
+  if (nums.length >= 8) {
+    // A quad (x0,y0,...,x3,y3): take its axis-aligned bounds.
+    var minX = double.infinity, minY = double.infinity;
+    var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+    for (var i = 0; i + 1 < nums.length; i += 2) {
+      final x = nums[i], y = nums[i + 1];
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+    }
+    return Rect.fromLTRB(minX, minY, maxX, maxY);
+  }
+  return Rect.fromLTRB(nums[0], nums[1], nums[2], nums[3]);
+}
+
+String _plainText(Map<String, Object?> payload) {
+  for (final key in const ['text', 'ocr', 'generated_text']) {
+    final value = payload[key];
+    if (value is String) return value;
+  }
+  return '';
+}

--- a/app/lib/ocr_web.dart
+++ b/app/lib/ocr_web.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 
 import 'ocr_status.dart';
+import 'ocr_tiling.dart';
 
 export 'ocr_status.dart';
 
@@ -125,120 +126,66 @@ class _BrowserOcrEngine implements PdfOcrEngine {
 
   @override
   Future<List<PdfOcrSpan>> recognize(PdfOcrPageImage page) async {
-    final png = await _encodePng(page.image);
-    final result = await _recognizeDataUrl(
-      'data:image/png;base64,${base64Encode(png)}',
-    );
-    return _spansFromFlorence(result, page);
-  }
-
-  static List<PdfOcrSpan> _spansFromFlorence(
-    Object? result,
-    PdfOcrPageImage page,
-  ) {
-    final payload = _payload(result);
-    final labels = _listOfStrings(payload['labels']) ??
-        _listOfStrings(payload['text']) ??
-        _listOfStrings(payload['texts']);
-    final boxes = _listOfBoxes(payload['quad_boxes']) ??
-        _listOfBoxes(payload['quadBoxes']) ??
-        _listOfBoxes(payload['bboxes']) ??
-        _listOfBoxes(payload['boxes']);
-
-    if (labels != null && boxes != null) {
-      final spans = <PdfOcrSpan>[];
-      final count = labels.length < boxes.length ? labels.length : boxes.length;
-      for (var i = 0; i < count; i++) {
-        final text = labels[i].trim();
-        final rect = boxes[i];
-        if (text.isEmpty || rect.width <= 0 || rect.height <= 0) continue;
-        spans.add(PdfOcrSpan(
-          text: text,
-          bounds: page.userSpaceRect(rect),
-          confidence: 1,
-        ));
+    // Florence-2 resizes whatever image it is handed to 768x768, so feeding it
+    // the whole page crushes small print to a few unreadable pixels and it
+    // hallucinates. Recognize the page in overlapping tiles small enough to
+    // survive that resize, lift each tile's boxes back into page-pixel space,
+    // then drop the duplicates the overlaps produce.
+    final image = page.image;
+    final tiles = ocrTiles(image.width, image.height);
+    final raw = <OcrRawSpan>[];
+    for (final tile in tiles) {
+      final png = await _encodeTilePng(image, tile);
+      final result = await _recognizeDataUrl(
+        'data:image/png;base64,${base64Encode(png)}',
+      );
+      final spans = parseFlorenceSpans(
+        result,
+        fallbackWidth: tile.width.round(),
+        fallbackHeight: tile.height.round(),
+      );
+      for (final span in spans) {
+        raw.add(span.shifted(tile.left, tile.top));
       }
-      return spans;
     }
-
-    final text = _plainText(payload).trim();
-    if (text.isEmpty) return const [];
     return [
-      PdfOcrSpan(
-        text: text,
-        bounds: page.userSpaceRect(
-          Rect.fromLTWH(0, 0, page.width.toDouble(), page.height.toDouble()),
+      for (final span in mergeOcrSpans(raw))
+        PdfOcrSpan(
+          text: span.text,
+          bounds: page.userSpaceRect(span.box),
+          confidence: span.confidence,
         ),
-        confidence: 1,
-      ),
     ];
   }
 
-  static Map<String, Object?> _payload(Object? value) {
-    if (value is Map) {
-      final ocrWithRegion = value['<OCR_WITH_REGION>'];
-      if (ocrWithRegion is Map) return ocrWithRegion.cast<String, Object?>();
-      final ocr = value['<OCR>'];
-      if (ocr is Map) return ocr.cast<String, Object?>();
-      return value.cast<String, Object?>();
+  /// Encodes the sub-rectangle [src] of [image] to PNG, the form the JS bridge
+  /// accepts. Cropping happens on the raster thread (draw the source rect into
+  /// a tile-sized image) so only the tile's pixels cross to JavaScript.
+  static Future<Uint8List> _encodeTilePng(ui.Image image, Rect src) async {
+    final w = src.width.round();
+    final h = src.height.round();
+    final recorder = ui.PictureRecorder();
+    final canvas = ui.Canvas(recorder);
+    canvas.drawImageRect(
+      image,
+      src,
+      Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+      ui.Paint(),
+    );
+    final picture = recorder.endRecording();
+    final ui.Image tile;
+    try {
+      tile = await picture.toImage(w, h);
+    } finally {
+      picture.dispose();
     }
-    if (value is String) return {'text': value};
-    return const {};
-  }
-
-  static List<String>? _listOfStrings(Object? value) {
-    if (value is String) return [value];
-    if (value is! List) return null;
-    return [
-      for (final item in value)
-        if (item != null) item.toString()
-    ];
-  }
-
-  static List<Rect>? _listOfBoxes(Object? value) {
-    if (value is! List) return null;
-    final rects = <Rect>[];
-    for (final item in value) {
-      final rect = _rect(item);
-      if (rect != null) rects.add(rect);
+    try {
+      final data = await tile.toByteData(format: ui.ImageByteFormat.png);
+      if (data == null) throw StateError('could not encode OCR tile to PNG');
+      return data.buffer.asUint8List();
+    } finally {
+      tile.dispose();
     }
-    return rects.isEmpty ? null : rects;
-  }
-
-  static Rect? _rect(Object? value) {
-    if (value is! List || value.length < 4) return null;
-    final nums = [
-      for (final v in value)
-        if (v is num) v.toDouble()
-    ];
-    if (nums.length < 4) return null;
-    if (nums.length >= 8) {
-      var minX = double.infinity, minY = double.infinity;
-      var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
-      for (var i = 0; i + 1 < nums.length; i += 2) {
-        final x = nums[i], y = nums[i + 1];
-        if (x < minX) minX = x;
-        if (y < minY) minY = y;
-        if (x > maxX) maxX = x;
-        if (y > maxY) maxY = y;
-      }
-      return Rect.fromLTRB(minX, minY, maxX, maxY);
-    }
-    return Rect.fromLTRB(nums[0], nums[1], nums[2], nums[3]);
-  }
-
-  static String _plainText(Map<String, Object?> payload) {
-    for (final key in const ['text', 'ocr', 'generated_text']) {
-      final value = payload[key];
-      if (value is String) return value;
-    }
-    return '';
-  }
-
-  static Future<Uint8List> _encodePng(ui.Image image) async {
-    final data = await image.toByteData(format: ui.ImageByteFormat.png);
-    if (data == null) throw StateError('could not encode page raster to PNG');
-    return data.buffer.asUint8List();
   }
 
   static Future<Object?> _recognizeDataUrl(String dataUrl) async {

--- a/app/test/ocr_tiling_test.dart
+++ b/app/test/ocr_tiling_test.dart
@@ -63,6 +63,18 @@ void main() {
     });
   });
 
+  group('OcrRawSpan', () {
+    test('shifted translates the box by the tile origin, keeping text/conf',
+        () {
+      const span = OcrRawSpan(
+          text: '20m', box: Rect.fromLTRB(10, 20, 30, 40), confidence: 0.8);
+      final moved = span.shifted(100, 200);
+      expect(moved.text, '20m');
+      expect(moved.confidence, 0.8);
+      expect(moved.box, const Rect.fromLTRB(110, 220, 130, 240));
+    });
+  });
+
   group('parseFlorenceSpans', () {
     test('reads the <OCR_WITH_REGION> labels + quad_boxes shape', () {
       final payload = {
@@ -93,6 +105,27 @@ void main() {
       final spans = parseFlorenceSpans(payload,
           fallbackWidth: 100, fallbackHeight: 100);
       expect(spans.single.box, const Rect.fromLTRB(5, 6, 25, 16));
+    });
+
+    test('reads the texts/boxes keys on an unwrapped payload', () {
+      // No <OCR…> wrapper, and the alternate `texts`/`boxes` key names.
+      final payload = {
+        'texts': ['Z'],
+        'boxes': [
+          [1, 2, 3, 4]
+        ],
+      };
+      final spans = parseFlorenceSpans(payload,
+          fallbackWidth: 10, fallbackHeight: 10);
+      expect(spans.single.text, 'Z');
+      expect(spans.single.box, const Rect.fromLTRB(1, 2, 3, 4));
+    });
+
+    test('treats a bare string payload as plain text', () {
+      final spans = parseFlorenceSpans('hello world',
+          fallbackWidth: 50, fallbackHeight: 12);
+      expect(spans.single.text, 'hello world');
+      expect(spans.single.box, const Rect.fromLTWH(0, 0, 50, 12));
     });
 
     test('falls back to one tile-sized span for boxless plain text', () {

--- a/app/test/ocr_tiling_test.dart
+++ b/app/test/ocr_tiling_test.dart
@@ -1,0 +1,156 @@
+// The browser OCR path tiles a page so Florence-2 sees legible sub-regions,
+// then maps each tile's boxes back and de-duplicates the overlaps. The tiling
+// geometry, Florence-2 result parsing, and merge are pure (no web imports) so
+// they run here on the VM; `ocr_web.dart` itself can't be loaded by the VM
+// test runner (it imports dart:js_interop).
+import 'dart:ui' show Rect;
+
+import 'package:dart_pdf_editor_app/ocr_tiling.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ocrTiles', () {
+    test('a small raster is a single full-image tile', () {
+      final tiles = ocrTiles(800, 600, tileSize: 1024);
+      expect(tiles, [const Rect.fromLTWH(0, 0, 800, 600)]);
+    });
+
+    test('a large raster is split into overlapping tiles that cover it all',
+        () {
+      const w = 2384, h = 1684; // an A3 page rendered at 2x.
+      const tileSize = 1024, overlap = 128;
+      final tiles = ocrTiles(w, h, tileSize: tileSize, overlap: overlap);
+
+      expect(tiles.length, greaterThan(1));
+
+      // No tile exceeds the model-friendly size, and every tile is inside the
+      // image.
+      for (final t in tiles) {
+        expect(t.width, lessThanOrEqualTo(tileSize.toDouble()));
+        expect(t.height, lessThanOrEqualTo(tileSize.toDouble()));
+        expect(t.left, greaterThanOrEqualTo(0));
+        expect(t.top, greaterThanOrEqualTo(0));
+        expect(t.right, lessThanOrEqualTo(w.toDouble()));
+        expect(t.bottom, lessThanOrEqualTo(h.toDouble()));
+      }
+
+      // The tiles must reach both far edges (nothing past the last tile is
+      // dropped).
+      expect(tiles.map((t) => t.right).reduce((a, b) => a > b ? a : b), w);
+      expect(tiles.map((t) => t.bottom).reduce((a, b) => a > b ? a : b), h);
+
+      // Every pixel center is inside at least one tile (sampled on a grid).
+      for (var y = 0; y < h; y += 53) {
+        for (var x = 0; x < w; x += 53) {
+          final covered = tiles.any((t) =>
+              x >= t.left && x < t.right && y >= t.top && y < t.bottom);
+          expect(covered, isTrue, reason: 'pixel ($x,$y) is in no tile');
+        }
+      }
+    });
+
+    test('neighbouring interior tiles overlap', () {
+      final tiles = ocrTiles(3000, 1000, tileSize: 1000, overlap: 200);
+      // First two columns share the same top row, so they should overlap in x.
+      final a = tiles[0];
+      final b = tiles[1];
+      expect(b.left, lessThan(a.right), reason: 'columns should overlap');
+    });
+
+    test('a degenerate size yields no tiles', () {
+      expect(ocrTiles(0, 100), isEmpty);
+      expect(ocrTiles(100, 0), isEmpty);
+    });
+  });
+
+  group('parseFlorenceSpans', () {
+    test('reads the <OCR_WITH_REGION> labels + quad_boxes shape', () {
+      final payload = {
+        '<OCR_WITH_REGION>': {
+          'labels': ['Hello', 'World'],
+          'quad_boxes': [
+            [10, 20, 50, 20, 50, 40, 10, 40],
+            [60, 22, 110, 22, 110, 42, 60, 42],
+          ],
+        },
+      };
+      final spans = parseFlorenceSpans(payload,
+          fallbackWidth: 1024, fallbackHeight: 1024);
+      expect(spans.map((s) => s.text), ['Hello', 'World']);
+      // The quad becomes its axis-aligned bounding box.
+      expect(spans.first.box, const Rect.fromLTRB(10, 20, 50, 40));
+    });
+
+    test('reads a 4-number bbox shape', () {
+      final payload = {
+        '<OCR_WITH_REGION>': {
+          'labels': ['A'],
+          'bboxes': [
+            [5, 6, 25, 16]
+          ],
+        },
+      };
+      final spans = parseFlorenceSpans(payload,
+          fallbackWidth: 100, fallbackHeight: 100);
+      expect(spans.single.box, const Rect.fromLTRB(5, 6, 25, 16));
+    });
+
+    test('falls back to one tile-sized span for boxless plain text', () {
+      final spans = parseFlorenceSpans(
+        {'<OCR>': {'text': 'just some text'}},
+        fallbackWidth: 320,
+        fallbackHeight: 64,
+      );
+      expect(spans.single.text, 'just some text');
+      expect(spans.single.box, const Rect.fromLTWH(0, 0, 320, 64));
+    });
+
+    test('drops empty labels and zero-area boxes', () {
+      final payload = {
+        '<OCR_WITH_REGION>': {
+          'labels': ['', 'Keep'],
+          'quad_boxes': [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [1, 1, 5, 1, 5, 9, 1, 9],
+          ],
+        },
+      };
+      final spans = parseFlorenceSpans(payload,
+          fallbackWidth: 10, fallbackHeight: 10);
+      expect(spans.map((s) => s.text), ['Keep']);
+    });
+  });
+
+  group('mergeOcrSpans', () {
+    test('collapses the same text from overlapping tiles', () {
+      final spans = [
+        const OcrRawSpan(text: '20m', box: Rect.fromLTRB(100, 100, 140, 120)),
+        // Same word seen again from the neighbouring tile, slightly shifted.
+        const OcrRawSpan(text: '20m', box: Rect.fromLTRB(102, 101, 142, 121)),
+        const OcrRawSpan(text: '30m', box: Rect.fromLTRB(300, 100, 340, 120)),
+      ];
+      final merged = mergeOcrSpans(spans);
+      expect(merged.length, 2);
+      expect(merged.map((s) => s.text).toSet(), {'20m', '30m'});
+    });
+
+    test('keeps identical text whose boxes are far apart', () {
+      final spans = [
+        const OcrRawSpan(text: '20m', box: Rect.fromLTRB(0, 0, 40, 20)),
+        const OcrRawSpan(text: '20m', box: Rect.fromLTRB(500, 400, 540, 420)),
+      ];
+      expect(mergeOcrSpans(spans).length, 2);
+    });
+
+    test('a duplicate keeps the higher-confidence span', () {
+      final spans = [
+        const OcrRawSpan(
+            text: 'x', box: Rect.fromLTRB(0, 0, 10, 10), confidence: 0.4),
+        const OcrRawSpan(
+            text: 'x', box: Rect.fromLTRB(1, 1, 11, 11), confidence: 0.9),
+      ];
+      final merged = mergeOcrSpans(spans);
+      expect(merged.single.confidence, 0.9);
+    });
+  });
+}

--- a/doc/dev-log.md
+++ b/doc/dev-log.md
@@ -2624,3 +2624,25 @@ and a read-only strip (no menu without a handler; export-only with one),
 plus a `duplicatePages` unit group. 47 page-ops tests green; the existing
 reorder test (`editing_test.dart`) still passes both its long-press-touch
 and immediate-mouse drag paths; analyzer clean.
+
+Web OCR "TypeError: Failed to fetch" (Ben, follow-on to the tiling fix). The
+deployed app is served cross-origin-isolated (`app/firebase.json`:
+COOP `same-origin` + COEP `require-corp`) so skwasm's multithreaded WASM
+renderer can use SharedArrayBuffer. But the browser-local OCR (`app/lib/ocr_web.dart`)
+pulls Transformers.js from jsDelivr and the Florence-2 model from HuggingFace's
+CDN on first run, and `require-corp` demands every cross-origin subresource send
+a CORP header — those CDNs don't, so the download was blocked and surfaced as
+`TypeError: Failed to fetch` (the engine's `onToast('OCR failed: $e')`). It was
+NOT a regression from the main merge (the COEP block predates it); the earlier
+garbled-but-working run was a local `flutter run`, which doesn't apply
+firebase.json headers. Fix (Ben's pick over self-hosting the model or
+investigating further): switch COEP to `credentialless`. Same page isolation
+(crossOriginIsolated stays true on Chromium/Firefox, so the multithreaded
+renderer is unaffected), but cross-origin resources load WITHOUT credentials
+instead of REQUIRING CORP, so the OCR model fetch goes through. Safari has no
+credentialless support → it just isn't isolated there (single-threaded
+skwasm_heavy + working OCR), an acceptable fallback. One-line header change +
+the rationale comment; strictly relaxes the policy, so nothing that worked under
+require-corp breaks. The deployed-app model inference still can't be exercised
+in-sandbox (no browser/WebGPU), and jsDelivr/HuggingFace are 403'd by the
+sandbox network policy, so the header behaviour is reasoned, not reproduced here.

--- a/doc/dev-log.md
+++ b/doc/dev-log.md
@@ -2554,3 +2554,39 @@ affected. Removed the whole staging apparatus + its
 `onnx_ocr_model_runner_test.dart` (it only exercised the dead path logic;
 the surviving `load()` is native-only, unverifiable in the sandbox per the
 #76 honesty posture). 30 package tests still green; analyzer clean.
+
+Web OCR tiling (Ben: "the OCR on web isn't working well" — a scanned A3 CAD
+drawing came back as a stream of hallucinated dimension tokens, "20m 30m
+15m 16.2M…"). Root cause is resolution, not the parser. The web path
+(`app/lib/ocr_web.dart`) renders each page at pixelRatio 2 and hands the
+*whole* image to browser-local Florence-2 (`onnx-community/Florence-2-base-ft`
+via Transformers.js, bridged through `window.__dartPdfOcrRecognize` in
+`app/web/index.html`). Florence-2's image processor hard-resizes any input to
+**768x768** (note the warmup `full([1,3,768,768])`), so a 1192x842pt page —
+here a 3310x2340 DCTDecode scan, no text layer, the entire page is one image
+XObject — rendered to 2384x1684 then crushed ~4x AND squished to square. Small
+dimension text becomes a few unreadable pixels, and a generative VLM fills the
+void with plausible tokens → the garbage output. Fix: **tile** the page into
+overlapping sub-regions small enough to survive the 768 resize, recognize each,
+lift the per-tile boxes back into page-pixel space, then drop the duplicates the
+overlaps produce. Split the testable geometry/parsing/merge into a new web-free
+module `app/lib/ocr_tiling.dart` (`ocrTiles` grid with edge-flush last tiles +
+coverage guarantee; `parseFlorenceSpans` — the old `_spansFromFlorence` JSON
+shape handling minus the user-space step, returns raster-pixel `OcrRawSpan`s;
+`mergeOcrSpans` — IoU+text de-dup) because `ocr_web.dart` imports
+`dart:js_interop` and so can't be loaded by the VM test runner. `ocr_web.dart`
+now crops each tile on the raster thread (`PictureRecorder`+`drawImageRect` →
+`toImage` → PNG) so only the tile's pixels cross to JS, offsets the returned
+boxes by the tile origin, merges, then maps to user space as before. No
+index.html change needed: the bridge already post-processes boxes against each
+input image's own size, so per-tile it returns tile-local pixels. Default tile
+1024px / overlap 128 → ~6 model calls for an A3 page at 2x (legible vs. one
+illegible call). The model inference itself stays sandbox-unverifiable (no
+WebGPU/Transformers.js here, same honesty posture as the native ONNX path);
+the tiling, parsing, and merge are unit-tested (`app/test/ocr_tiling_test.dart`,
+11 — coverage/overlap/edge tiles, the `<OCR_WITH_REGION>` + bbox + plain-text
+shapes, overlap de-dup). Florence-2-base-ft is still a weak doc-OCR model — for
+dense CAD the cloud VLM tier (`pdf_ocr_vlm` dots.ocr) or a detect+recognize
+model does better — but tiling removes the squish-to-illegibility that turned
+its output into hallucinated noise. Analyzer clean; existing
+ocr_menu/ocr_status tests still green.


### PR DESCRIPTION
## Problem

Web OCR returns hallucinated garbage on large scanned pages. For the reported A3 CAD drawing, the output was a stream of plausible-but-fake dimension tokens:

```
2.3 MAY 2020 … 20m 30m 15m 16.2M 15.0m 16 20m …
```

## Root cause — resolution, not the parser

The web path (`app/lib/ocr_web.dart`) renders each page and hands the **whole image** to browser-local Florence-2 (`onnx-community/Florence-2-base-ft` via Transformers.js, bridged through `window.__dartPdfOcrRecognize` in `app/web/index.html`). Florence-2's image processor **hard-resizes any input to 768×768** (see the warmup `full([1,3,768,768])`).

The reported file is a 1192×842 pt page whose content is a single **3310×2340 DCTDecode scan** — no text layer at all, so OCR is the right tool. Rendered at pixelRatio 2 (2384×1684) and then crushed ~4× **and** squished to a square, the small dimension text becomes a few unreadable pixels. A generative VLM fills that void with plausible tokens → the garbage above.

## Fix — tile the page

Split each page raster into overlapping sub-regions small enough to survive the 768 resize, recognize each, lift the per-tile boxes back into page-pixel space, then drop the duplicates the overlaps produce.

- **New web-free module `app/lib/ocr_tiling.dart`** — `ocrTiles` (grid with edge-flush last tiles + full coverage), `parseFlorenceSpans` (the old JSON-shape handling minus the user-space step, returning raster-pixel `OcrRawSpan`s), `mergeOcrSpans` (IoU + text de-dup). Split out because `ocr_web.dart` imports `dart:js_interop` and so can't be loaded by `flutter test`.
- **`ocr_web.dart`** crops each tile on the raster thread (`PictureRecorder` + `drawImageRect` → `toImage` → PNG, so only the tile's pixels cross to JS), offsets the returned boxes by the tile origin, merges, then maps to user space exactly as before.
- **No `index.html` change** — the JS bridge already post-processes boxes against each input image's own size, so per-tile it returns tile-local pixels.

Defaults: 1024 px tiles / 128 px overlap → ~6 model calls for an A3 page at 2× (legible) instead of one illegible call.

## Tests

`app/test/ocr_tiling_test.dart` (11) covers tile coverage/overlap/edge-flush, the `<OCR_WITH_REGION>` / bbox / plain-text result shapes, and overlap de-dup. Existing `ocr_menu` / `ocr_status` tests still pass; analyzer clean.

## Honesty note

The model inference itself stays sandbox-unverifiable (no WebGPU / Transformers.js here — same posture as the native ONNX path); only the pure tiling/parsing/merge is unit-tested. Florence-2-base-ft is still a weak doc-OCR model — for dense CAD the cloud VLM tier (`pdf_ocr_vlm` dots.ocr) or a dedicated detect+recognize model does better — but tiling removes the squish-to-illegibility that was turning its output into hallucinated noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMZLuzePGkd8ZUwM3PsQ6Q)_