### PR TITLE
chore: union-merge append-only docs to cut PR conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Append-only files: both sides almost always add new entries at the end,
+# so a normal 3-way merge conflicts on every concurrent PR. The built-in
+# `union` driver resolves these by keeping both sides' lines instead of
+# emitting conflict markers — no manual resolution, just both entries
+# present (review the ordering when it matters; these files are narrative,
+# not code).
+doc/dev-log.md     merge=union
+**/CHANGELOG.md     merge=union


### PR DESCRIPTION
Add a `.gitattributes` marking append-only narrative files with git's built-in `merge=union` driver: `doc/dev-log.md` and `**/CHANGELOG.md`.

These files are append-only — every concurrent PR adds an entry at the end, so a normal 3-way merge conflicts on each one. Across the current open PRs, `doc/dev-log.md` conflicted on nearly all of them and the CHANGELOGs on several more; they were the bulk of the conflict load and every one was resolved by simply keeping both entries. `merge=union` does that automatically: git keeps both sides' lines instead of emitting conflict markers — no manual resolution. The two appended blocks' ordering isn't guaranteed, but these are prose logs, not code.

The driver only takes effect for merges once `.gitattributes` is present in the branches, so it helps going forward (it did not retroactively fix the PRs already resolved by hand). Verified with `git check-attr merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)