### PR TITLE
Reconcile orphaned AcroFields where /Fields and page widgets disconnect

### DIFF
--- a/doc/dev-log.md
+++ b/doc/dev-log.md
@@ -3244,3 +3244,48 @@ throws before reaching the composite path. Tests:
 a DejaVu fallback for a glyph Liberation lacks, asserting the run switches
 fonts and the text round-trips through both /ToUnicodes;
 `editing_fonts_test.dart` asserts the trio resolves from assets.
+
+## Orphaned-AcroField reconciliation (macOS 26.5 / Quartz)
+
+Real-world ITF forms saved by a buggy macOS **26.5 (Build 25F71)** Quartz
+PDFContext (15.6.1 and the 25F80 patch are fine) leave the `/AcroForm
+/Fields` tree and the on-page widget annotations as **two disconnected
+copies of the same form**: the `/Fields` entries (merged field+widget
+dicts) appear on no page, while the visible page widgets carry the same
+fully-qualified `/T` but are absent from `/Fields` and have no `/Parent`.
+Read straight, `PdfAcroForm.fields` enumerated the invisible copies and
+missed everything the page actually shows, so filling silently updated the
+wrong dicts.
+
+Fix is a non-destructive model-level reconciliation in `form.dart`
+(`PdfAcroForm._reconcileOrphanWidgets`, run at the end of the cached
+`fields` getter — auto, lazy, no byte rewrite on open):
+
+- `_fieldTreeDicts()` = everything reachable from `/Fields` by descending
+  `/Kids`. `_orphanWidgetsByName()` = page `Widget` annots **not** in that
+  set, grouped by `_widgetFieldName` (own `/T` joined up any `/Parent`
+  chain). Both empty for well-formed forms → zero behavior change.
+- A `/Fields` terminal whose own widgets show on no page **adopts** the
+  matching orphan group (`PdfFormField._reconciled`); `widgets`, `value`,
+  and `isChecked` consult it first. Orphan groups with no `/Fields` entry
+  become **synthesized** terminal fields (`dict` = the page widget).
+- Value rule (user pick): the visible page widget's `/V` wins when set,
+  falling back to the `/Fields` copy — the producer split data across both,
+  page side is what the user sees. `reconciledWidgets` is public so
+  `form_editor`'s `_finishFieldEdit` strips the adopted widgets' stale `/V`
+  after a fill (skipping the dict itself for synthesized fields) so the
+  canonical value and regenerated appearance stay consistent.
+
+Filling needs no special-casing: `field.widgets` already returns the page
+copies, so `_regenerateVariableText` repaints the visible annotation and
+`_stageFormDict` stages it (page annots are indirect). The `/Fields` copy
+stays off-page so renderers walking page `/Annots` never double-draw.
+
+Tests: `pdf_test_fixtures.buildOrphanedAcroFormPdf()` reproduces the
+pattern (off-page `name`/`town` in `/Fields`; on-page `name`/`town`/`extra`
+orphans); `pdf_document/test/form_reconcile_test.dart` covers adoption,
+synthesis, `describeFields`, the well-formed no-op, and round-trip fills.
+`form_admin_test.dart`'s "widget no page lists" case now asserts on the
+in-memory editor doc — its old save/reopen relied on an *unstaged* page
+mutation, so the saved bytes actually retained an orphan widget that
+reconciliation (correctly) re-surfaced.

--- a/packages/pdf_document/lib/src/form.dart
+++ b/packages/pdf_document/lib/src/form.dart
@@ -53,6 +53,11 @@ class PdfAcroForm {
   List<PdfFormField>? _fields;
 
   /// All terminal (fillable) fields, depth-first across the field tree.
+  ///
+  /// After collecting the /Fields tree this reconciles the on-page widget
+  /// annotations that a broken producer left out of /Fields (see
+  /// [_reconcileOrphanWidgets]), so the list reflects what actually shows
+  /// on the page rather than the registered-but-invisible copies.
   List<PdfFormField> get fields => _fields ??= () {
         final out = <PdfFormField>[];
         final roots = document.cos.resolve(dict['Fields']);
@@ -64,6 +69,7 @@ class PdfAcroForm {
             }
           }
         }
+        _reconcileOrphanWidgets(out);
         return out;
       }();
 
@@ -145,6 +151,111 @@ class PdfAcroForm {
       out.add(PdfFormField._(this, node, name));
     }
   }
+
+  /// Some producers (notably the macOS 26.5 / Quartz build that re-saves
+  /// filled forms) leave the /AcroForm /Fields tree and the on-page widget
+  /// annotations as two disconnected copies of the same form: the /Fields
+  /// entries display on no page, while the visible page widgets carry the
+  /// same fully-qualified /T but are absent from /Fields (and have no
+  /// /Parent linking them in). Read straight, the form API would enumerate
+  /// the invisible copies and miss everything the user actually sees.
+  ///
+  /// This matches the unreferenced page widgets back to their /Fields entry
+  /// by name and adopts them as that field's widgets, so reading,
+  /// hit-testing, and filling all target the visible annotation. Page
+  /// widgets whose name has no /Fields entry at all become synthesized
+  /// terminal fields. A no-op for well-formed forms (no orphan widgets).
+  void _reconcileOrphanWidgets(List<PdfFormField> out) {
+    final orphans = _orphanWidgetsByName();
+    if (orphans.isEmpty) return;
+    final knownNames = {for (final f in out) f.name};
+    final consumed = <String>{};
+    for (final field in out) {
+      final group = orphans[field.name];
+      if (group == null) continue;
+      // only adopt when the field's own widgets show on no page — i.e. the
+      // /Fields copy is the invisible one; a field already on the page keeps
+      // its real widgets.
+      final onPage = field.widgets.any((w) => _pageIndexOf(w) >= 0);
+      if (onPage) continue;
+      field._reconciled = group;
+      consumed.add(field.name);
+    }
+    for (final entry in orphans.entries) {
+      if (consumed.contains(entry.key) || knownNames.contains(entry.key)) {
+        continue;
+      }
+      out.add(PdfFormField._(this, entry.value.first, entry.key)
+        .._reconciled = entry.value);
+    }
+  }
+
+  /// Page widget annotations not reachable from /Fields, grouped by their
+  /// fully-qualified name. These are the orphans [_reconcileOrphanWidgets]
+  /// adopts.
+  Map<String, List<CosDictionary>> _orphanWidgetsByName() {
+    final reachable = _fieldTreeDicts();
+    final out = <String, List<CosDictionary>>{};
+    final cos = document.cos;
+    for (final page in _pages) {
+      final annots = cos.resolve(page['Annots']);
+      if (annots is! CosArray) continue;
+      for (final item in annots.items) {
+        final w = cos.resolve(item);
+        if (w is! CosDictionary) continue;
+        final subtype = cos.resolve(w['Subtype']);
+        if (!(subtype is CosName && subtype.value == 'Widget')) continue;
+        if (reachable.contains(w)) continue;
+        final name = _widgetFieldName(w);
+        if (name == null) continue;
+        out.putIfAbsent(name, () => []).add(w);
+      }
+    }
+    return out;
+  }
+
+  /// Every dictionary reachable from /Fields by descending /Kids — field
+  /// nodes and the widget annotations properly linked under them.
+  Set<CosDictionary> _fieldTreeDicts() {
+    final cos = document.cos;
+    final out = <CosDictionary>{};
+    void mark(CosDictionary node) {
+      if (!out.add(node)) return;
+      final kids = cos.resolve(node['Kids']);
+      if (kids is CosArray) {
+        for (final item in kids.items) {
+          final kid = cos.resolve(item);
+          if (kid is CosDictionary) mark(kid);
+        }
+      }
+    }
+
+    final roots = cos.resolve(dict['Fields']);
+    if (roots is CosArray) {
+      for (final item in roots.items) {
+        final node = cos.resolve(item);
+        if (node is CosDictionary) mark(node);
+      }
+    }
+    return out;
+  }
+
+  /// The fully-qualified field name a stray widget claims: its own /T
+  /// joined with any /Parent /T parts (§12.7.3.2). Null when it carries no
+  /// /T anywhere up the chain.
+  String? _widgetFieldName(CosDictionary widget) {
+    final cos = document.cos;
+    final parts = <String>[];
+    CosDictionary? node = widget;
+    final visited = <CosDictionary>{};
+    while (node != null && visited.add(node)) {
+      final t = cos.resolve(node['T']);
+      if (t is CosString && t.text.isNotEmpty) parts.insert(0, t.text);
+      final parent = cos.resolve(node['Parent']);
+      node = parent is CosDictionary ? parent : null;
+    }
+    return parts.isEmpty ? null : parts.join('.');
+  }
 }
 
 /// Persistable metadata for one terminal field — what a template editor
@@ -184,6 +295,18 @@ class PdfFormField {
 
   /// Fully qualified name: partial /T names joined with dots.
   final String name;
+
+  /// On-page widget annotations adopted from outside /Fields by
+  /// [PdfAcroForm._reconcileOrphanWidgets], or null for a normally
+  /// structured field. When set, [widgets] returns these (they are what
+  /// the page actually shows) and [value]/[isChecked] consult them first.
+  List<CosDictionary>? _reconciled;
+
+  /// The widgets this field adopted from outside /Fields during
+  /// reconciliation (empty for well-formed fields). The field dictionary
+  /// drives their appearance; a filler clears their stale /V so the
+  /// canonical field value wins.
+  List<CosDictionary> get reconciledWidgets => _reconciled ?? const [];
 
   CosDocument get _cos => form.document.cos;
 
@@ -296,8 +419,21 @@ class PdfFormField {
   /// The current value as text: /V strings come back verbatim, button
   /// state names without the slash, multi-select arrays as their first
   /// string. Null when the field is empty.
+  ///
+  /// For a reconciled field the visible page widget's /V wins when set —
+  /// the producer split the form's data across both copies, and the page
+  /// side is what the user sees — falling back to the field's own /V.
   String? get value {
-    final v = inherited('V');
+    if (_reconciled != null) {
+      for (final widget in _reconciled!) {
+        final v = _valueText(_cos.resolve(widget['V']));
+        if (v != null && v.isNotEmpty) return v;
+      }
+    }
+    return _valueText(inherited('V'));
+  }
+
+  String? _valueText(CosObject? v) {
     if (v is CosString) return v.text;
     if (v is CosName) return v.value;
     if (v is CosArray && v.length > 0) {
@@ -309,13 +445,23 @@ class PdfFormField {
 
   /// Whether a check box or radio group is on (/V set and not /Off).
   bool get isChecked {
+    if (_reconciled != null) {
+      for (final widget in _reconciled!) {
+        final v = _cos.resolve(widget['V']);
+        if (v is CosName && v.value != 'Off') return true;
+        final as_ = _cos.resolve(widget['AS']);
+        if (as_ is CosName && as_.value != 'Off') return true;
+      }
+    }
     final v = inherited('V');
     return v is CosName && v.value != 'Off';
   }
 
-  /// The widget annotations displaying this field: its /Kids without a
+  /// The widget annotations displaying this field: the on-page copies
+  /// adopted by reconciliation when present, otherwise its /Kids without a
   /// /T of their own, or the field dictionary itself when merged.
   List<CosDictionary> get widgets {
+    if (_reconciled != null) return _reconciled!;
     final kids = _cos.resolve(dict['Kids']);
     if (kids is CosArray) {
       final out = <CosDictionary>[];

--- a/packages/pdf_document/lib/src/form_editor.dart
+++ b/packages/pdf_document/lib/src/form_editor.dart
@@ -601,6 +601,14 @@ extension PdfFormFilling on PdfEditor {
   }
 
   void _finishFieldEdit(PdfFormField field) {
+    // A reconciled field holds its canonical value on the /Fields dict we
+    // just wrote; the adopted page widgets may still carry the producer's
+    // stale /V, which would otherwise shadow it on read-back. Drop it so
+    // the field value and the regenerated appearance stay consistent.
+    for (final widget in field.reconciledWidgets) {
+      if (identical(widget, field.dict)) continue;
+      if (widget.entries.remove('V') != null) _stageFormDict(field, widget);
+    }
     _stageFormDict(field, field.dict);
     final form = field.form;
     if (form.needsAppearances) {

--- a/packages/pdf_document/test/form_admin_test.dart
+++ b/packages/pdf_document/test/form_admin_test.dart
@@ -136,8 +136,9 @@ void main() {
       annots.items.removeWhere(
           (item) => identical(doc.cos.resolve(item), field.dict));
       editor.removeField(field); // must not throw
-      expect(PdfAcroForm.of(PdfDocument.open(editor.save()))!
-          .fieldNamed('name'), isNull);
+      // the field is gone and not resurrected: with its widget on no page,
+      // orphan-widget reconciliation has nothing to re-adopt.
+      expect(editor.acroForm!.fieldNamed('name'), isNull);
     });
   });
 

--- a/packages/pdf_document/test/form_reconcile_test.dart
+++ b/packages/pdf_document/test/form_reconcile_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+/// Reconciling forms whose /AcroForm /Fields tree and on-page widget
+/// annotations are disconnected copies of the same form (the macOS
+/// 26.5 / Quartz "orphaned AcroField" defect). See
+/// [buildOrphanedAcroFormPdf].
+void main() {
+  PdfDocument open() => PdfDocument.open(buildOrphanedAcroFormPdf());
+
+  group('reading', () {
+    test('adopts on-page orphan widgets and surfaces their values', () {
+      final form = PdfAcroForm.of(open())!;
+
+      final name = form.fieldNamed('name')!;
+      // the off-page /Fields copy held the stale "old"; the visible widget
+      // wins.
+      expect(name.value, 'Jane');
+      expect(name.widgetPageIndex(0), 0, reason: 'now resolves to the page');
+      expect(name.widgetRect(0), const PdfRect(72, 700, 300, 724));
+      expect(name.reconciledWidgets, isNotEmpty);
+
+      final town = form.fieldNamed('town')!;
+      expect(town.value, isNull);
+      expect(town.widgetPageIndex(0), 0);
+    });
+
+    test('synthesizes a field for a page-only widget absent from /Fields', () {
+      final form = PdfAcroForm.of(open())!;
+      final extra = form.fieldNamed('extra');
+      expect(extra, isNotNull, reason: 'page-only widget becomes a field');
+      expect(extra!.value, 'Solo');
+      expect(extra.type, PdfFieldType.text);
+      expect(extra.widgetPageIndex(0), 0);
+    });
+
+    test('describeFields reports the visible page, not -1', () {
+      final infos = PdfAcroForm.of(open())!.describeFields();
+      expect(infos.map((i) => i.name),
+          containsAll(<String>['name', 'town', 'extra']));
+      expect(infos.every((i) => i.pageIndex == 0), isTrue,
+          reason: 'every field now maps to the page it shows on');
+    });
+
+    test('well-formed forms are untouched (no reconciliation)', () {
+      final form = PdfAcroForm.of(PdfDocument.open(buildAcroFormPdf()))!;
+      for (final field in form.fields) {
+        expect(field.reconciledWidgets, isEmpty);
+      }
+      // the prefilled single-widget field still reads its own /V
+      expect(form.fieldNamed('name')!.value, 'prefilled');
+    });
+  });
+
+  group('filling', () {
+    PdfDocument fill(void Function(PdfEditor, PdfAcroForm) edit) {
+      final editor = PdfEditor(open());
+      edit(editor, editor.acroForm!);
+      return PdfDocument.open(editor.save());
+    }
+
+    String appearance(PdfDocument doc, PdfFormField field, [int index = 0]) {
+      final cos = doc.cos;
+      final ap = cos.resolve(field.widgets[index]['AP']) as CosDictionary;
+      final n = cos.resolve(ap['N']) as CosStream;
+      return latin1.decode(cos.decodeStreamData(n));
+    }
+
+    test('writes through to the visible widget and reads back', () {
+      final doc =
+          fill((e, f) => e.setTextValue(f.fieldNamed('name')!, 'Updated'));
+      final name = PdfAcroForm.of(doc)!.fieldNamed('name')!;
+      expect(name.value, 'Updated', reason: 'no stale shadow on read-back');
+      // the regenerated appearance lives on the on-page widget
+      expect(appearance(doc, name), contains('(Updated) Tj'));
+      expect(name.widgetPageIndex(0), 0);
+    });
+
+    test('a synthesized page-only field fills normally', () {
+      final doc =
+          fill((e, f) => e.setTextValue(f.fieldNamed('extra')!, 'Filled'));
+      final extra = PdfAcroForm.of(doc)!.fieldNamed('extra')!;
+      expect(extra.value, 'Filled');
+      expect(appearance(doc, extra), contains('(Filled) Tj'));
+    });
+  });
+}

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -427,6 +427,70 @@ Uint8List buildAcroFormPdf() {
   return ascii(buffer.toString());
 }
 
+/// Builds a form with the "orphaned AcroField" defect some producers emit
+/// (notably a macOS 26.5 / Quartz build that re-saves filled forms): the
+/// /AcroForm /Fields tree and the on-page widget annotations are two
+/// disconnected copies of the same form.
+///
+/// - /Fields lists two terminal fields, `name` and `town`, as merged
+///   field+widget dicts that appear in **no** page /Annots. `name`
+///   carries a stale /V (`old`); `town` is empty.
+/// - The page /Annots shows three Widget annotations, none in /Fields and
+///   with no /Parent: `name` (same name as a /Fields entry, /V `Jane`),
+///   `town` (matching the empty /Fields entry, no /V), and `extra` (a
+///   page-only field with no /Fields entry at all, /V `Solo`).
+///
+/// A reader that only walks /Fields sees the invisible copies and misses
+/// what the page shows; reconciliation must adopt the page widgets.
+Uint8List buildOrphanedAcroFormPdf() {
+  final objects = <String>[
+    // 1: catalog — /Fields holds only the off-page copies (6, 7)
+    '<< /Type /Catalog /Pages 2 0 R /AcroForm << '
+        '/Fields [6 0 R 7 0 R] '
+        '/DA (/Helv 0 Tf 0 g) /DR << /Font << /Helv 5 0 R >> >> >> >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    // 3: page — /Annots lists only the orphan page widgets (8, 9, 10)
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Annots [8 0 R 9 0 R 10 0 R] >>',
+    '<< /Length 0 >>\nstream\n\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica '
+        '/Encoding /WinAnsiEncoding >>',
+    // 6: off-page /Fields copy of `name`, stale value
+    '<< /Type /Annot /Subtype /Widget /FT /Tx /T (name) '
+        '/Rect [72 700 300 724] /DA (/Helv 12 Tf 0 g) /V (old) >>',
+    // 7: off-page /Fields copy of `town`, empty
+    '<< /Type /Annot /Subtype /Widget /FT /Tx /T (town) '
+        '/Rect [72 660 300 684] /DA (/Helv 12 Tf 0 g) >>',
+    // 8: on-page orphan `name` — not in /Fields, the value the user sees
+    '<< /Type /Annot /Subtype /Widget /FT /Tx /T (name) '
+        '/Rect [72 700 300 724] /DA (/Helv 12 Tf 0 g) /V (Jane) >>',
+    // 9: on-page orphan `town` — not in /Fields, empty
+    '<< /Type /Annot /Subtype /Widget /FT /Tx /T (town) '
+        '/Rect [72 660 300 684] /DA (/Helv 12 Tf 0 g) >>',
+    // 10: on-page orphan `extra` — no /Fields entry at all
+    '<< /Type /Annot /Subtype /Widget /FT /Tx /T (extra) '
+        '/Rect [72 620 300 644] /DA (/Helv 12 Tf 0 g) /V (Solo) >>',
+  ];
+
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
 /// Builds a minimal TrueType font, unitsPerEm 1000, three glyphs:
 /// 0 = .notdef (empty), 1 = 'A' (triangle, advance 600),
 /// 2 = 'B' (square, advance 1000). The cmap is a (3,1) format 4 table.


### PR DESCRIPTION
## What & why

While investigating two batches of real ITF form PDFs, the second set turned out to have a genuine **orphaned-AcroField** defect. It correlates exactly with a buggy macOS build — **26.5 (Build 25F71) Quartz PDFContext** — that re-saves filled forms. (15.6.1 and the 25F80 patch produce clean files.)

When that build saves a filled form, the `/AcroForm /Fields` tree and the on-page widget annotations become **two disconnected copies of the same form**:

- **`/Fields` side:** merged field+widget dicts that appear in **no** page `/Annots` → invisible, unfillable orphans.
- **Page side:** widgets with the **same `/T`**, **no `/Parent`**, and **not in `/Fields`** → render and fill in lenient viewers but are invisible to the form API.

Measured on the affected files:

| File | macOS build | `/Fields` | Orphan page-widgets |
|---|---|---|---|
| ITF_14 | 26.5 (25F71) | 109 | 111 (107 name-match) |
| ITFASI1 | 26.5 (25F71) | 14 | 34 (6 match, 28 page-only) |
| ITFASI2 | 26.5 (25F71) | 123 | 124 (121 match) |
| ITFASI3 | 15.6.1 | 11 | 0 (clean) |
| ITFASI4 | 26.5.1 (25F80) | 72 | 0 (clean) |

Read straight, `PdfAcroForm.fields` enumerated the invisible copies and missed everything the page actually shows, so filling silently updated the wrong dicts.

## Approach

Non-destructive, model-level reconciliation in `form.dart` — runs automatically and lazily in the cached `fields` getter, **no byte rewrite on open**:

- A `/Fields` terminal whose own widgets show on no page **adopts** the matching on-page orphan widgets (`PdfFormField._reconciled`); `widgets`/`value`/`isChecked` consult them first.
- Page-only orphans (no `/Fields` entry at all) become **synthesized** terminal fields.
- **Value rule:** the visible page widget's `/V` wins when set, falling back to the `/Fields` copy — the producer split data across both, and the page side is what the user sees.
- Filling needs no special-casing (`field.widgets` already returns the page copies, so the appearance regenerates on the visible annotation); `form_editor`'s `_finishFieldEdit` clears the adopted widgets' stale `/V` so the canonical value and regenerated appearance stay consistent.
- **Well-formed forms are untouched** — both orphan sets are empty, zero behavior change.

## Tests

- `pdf_test_fixtures.buildOrphanedAcroFormPdf()` reproduces the disconnected-copies pattern.
- New `form_reconcile_test.dart`: adoption, synthesis, `describeFields`, the well-formed no-op, and round-trip fills (`pdf_document` suite green, 403 passing).
- `form_admin_test.dart`'s "widget no page lists" case now asserts on the in-memory editor doc — its old save/reopen relied on an *unstaged* page mutation, so the saved bytes actually retained an orphan widget that reconciliation correctly re-surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Rt3aR18MiqGTxC1nHsXxr

---
_Generated by [Claude Code](https://claude.ai/code/session_014Rt3aR18MiqGTxC1nHsXxr)_