### PR TITLE
Don't flash heavy pages blank after an ink markup

### DIFF
--- a/doc/dev-log/2026-06-22-ink-commit-page-flash.md
+++ b/doc/dev-log/2026-06-22-ink-commit-page-flash.md
@@ -1,0 +1,63 @@
+# Fix: heavy CAD page flashes blank after an ink markup commit
+
+## Symptom
+
+On a heavy CAD page, finishing an ink markup made the **whole page flash
+blank** for a moment before re-appearing with the stroke baked in. The
+stroke itself was fine; the page content under it vanished and came back.
+
+## Cause
+
+`finishInk()` commits the strokes through `apply()`, which swaps in a new
+`PdfDocument` and bumps the edited page's *render stamp*
+(`pageRenderStamp`). The viewer passes that stamp to `PdfPageView` as
+`contentStamp`, and `PdfPageView.didUpdateWidget` **nulled `_image`**
+(dropped the on-screen raster) on every `contentStamp` change, then
+re-interpreted the page. On a heavy page that re-interpret is slow, so for
+its duration the page painted the blank paper placeholder while only the
+committed-ink overlay stayed up — the flash.
+
+The blanking was added for redaction safety: after a burn, keeping the old
+raster would briefly show the *removed* content. But it fired for **every**
+content edit, including purely additive ones (ink, highlights, shapes),
+where the old raster is still correct for everything except the new mark —
+and the new mark is already drawn on top by the editing overlay
+(`committedInkOn` / `rasterCurrent`) until the fresh raster lands.
+
+## Fix
+
+Split the signal into additive vs destructive:
+
+- `PdfEditingController` now tracks `pageDestructiveStamp` alongside
+  `pageRenderStamp` (`_destructiveStamps` / `_destructiveStampEpoch`,
+  `_bumpDestructiveStamps`). Only `applyRedactions` (`_resetTo`) bumps it.
+- The viewer threads `destructiveStamp` through `_PdfViewerPage` into
+  `PdfPageView`.
+- `PdfPageView.didUpdateWidget` now blanks `_image`/`_preview` (and drops
+  the detail patch) **only** when `pageEpoch` (structural slot reuse) or
+  `destructiveStamp` changes. A plain `contentStamp` advance still
+  re-interprets, but keeps the old raster painted until the new one
+  replaces it (`_dropPicture` nulls `_rasteredRatio`, so `_renderNow` still
+  re-rasters) — exactly the zoom-settle behavior. No blank flash.
+
+This also matches the pre-existing comment on the epoch path: "a
+same-geometry edit keeps the raster while the render holds."
+
+## Notes / gotchas
+
+- Content edits that *change* existing content (delete element, replace
+  text) intentionally stay on the additive path: they go through `apply`,
+  not `_resetTo`, so the old content lingers for a frame (smooth update)
+  rather than flashing. Only a redaction burn — where lingering exposes
+  deleted content — is treated as destructive.
+- The detail (deep-zoom) patch is only force-dropped when we blank;
+  otherwise it follows through `_updateDetail`'s generation guard, the same
+  way the scale-change path already relied on it.
+
+## Tests
+
+- `test/pdf_page_view_test.dart`: additive `contentStamp` bump keeps the
+  raster under a render hold; `destructiveStamp` bump drops it.
+- `test/editing_redaction_test.dart`: ink commit advances the render stamp
+  but not the destructive stamp; a burn advances the destructive stamp on
+  every page.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -262,34 +262,24 @@ class PdfEditingController extends ChangeNotifier {
   int pageRenderStamp(int pageIndex) =>
       _renderStampEpoch + (_renderStamps[pageIndex] ?? 0);
 
-  /// Destructive-render stamps: like [_renderStamps], but bumped only by
-  /// edits that *remove* existing page content (a redaction burn), as
-  /// opposed to the additive ones (ink, highlights, shapes, fills) that
-  /// merely lay new marks on top. The viewer keeps the on-screen raster
-  /// painted across an additive edit — so a heavy page never flashes blank
-  /// while the new render lands — but must drop it on a destructive one, so
-  /// the removed content can't linger on screen (or in a fast-scroll
-  /// preview) for even a frame.
-  final Map<int, int> _destructiveStamps = {};
+  /// Destructive-render epoch: bumped only by edits that *remove* existing
+  /// page content (a redaction burn), as opposed to the additive ones (ink,
+  /// highlights, shapes, fills) that merely lay new marks on top. The viewer
+  /// keeps the on-screen raster painted across an additive edit — so a heavy
+  /// page never flashes blank while the new render lands — but must drop it
+  /// on a destructive one, so the removed content can't linger on screen (or
+  /// in a fast-scroll preview) for even a frame. A burn recompacts the whole
+  /// file (every page may have changed), so this is a single all-pages
+  /// counter rather than a per-page map.
   int _destructiveStampEpoch = 0;
 
-  void _bumpDestructiveStamps(Set<int>? pages) {
-    if (pages == null) {
-      _destructiveStampEpoch++;
-    } else {
-      for (final page in pages) {
-        _destructiveStamps[page] = (_destructiveStamps[page] ?? 0) + 1;
-      }
-    }
-  }
-
-  /// A value that changes whenever content was *removed* from [pageIndex]
-  /// (see [_destructiveStamps]); stable across additive edits, undo, and
-  /// redo of other pages. The viewer uses it to decide whether to blank the
-  /// held raster (destructive) or keep it up until the re-render lands
-  /// (additive).
-  int pageDestructiveStamp(int pageIndex) =>
-      _destructiveStampEpoch + (_destructiveStamps[pageIndex] ?? 0);
+  /// A value that changes whenever content was *removed* from any page (see
+  /// [_destructiveStampEpoch]); stable across additive edits, undo, and redo.
+  /// The viewer uses it to decide whether to blank the held raster
+  /// (destructive) or keep it up until the re-render lands (additive). Takes
+  /// a page index to mirror [pageRenderStamp]'s shape, though the burn that
+  /// drives it is always document-wide.
+  int pageDestructiveStamp(int pageIndex) => _destructiveStampEpoch;
 
   PdfDocument _document;
 
@@ -1214,7 +1204,7 @@ class PdfEditingController extends ChangeNotifier {
     // a burn removes content irreversibly — mark it destructive so the
     // viewer blanks each page's raster instead of holding the (now
     // un-redacted) one up while the fresh render lands
-    _bumpDestructiveStamps(null);
+    _destructiveStampEpoch++;
     _document = PdfDocument.open(bytes, password: _password);
     _invalidateElements();
     notifyListeners();

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -262,6 +262,35 @@ class PdfEditingController extends ChangeNotifier {
   int pageRenderStamp(int pageIndex) =>
       _renderStampEpoch + (_renderStamps[pageIndex] ?? 0);
 
+  /// Destructive-render stamps: like [_renderStamps], but bumped only by
+  /// edits that *remove* existing page content (a redaction burn), as
+  /// opposed to the additive ones (ink, highlights, shapes, fills) that
+  /// merely lay new marks on top. The viewer keeps the on-screen raster
+  /// painted across an additive edit — so a heavy page never flashes blank
+  /// while the new render lands — but must drop it on a destructive one, so
+  /// the removed content can't linger on screen (or in a fast-scroll
+  /// preview) for even a frame.
+  final Map<int, int> _destructiveStamps = {};
+  int _destructiveStampEpoch = 0;
+
+  void _bumpDestructiveStamps(Set<int>? pages) {
+    if (pages == null) {
+      _destructiveStampEpoch++;
+    } else {
+      for (final page in pages) {
+        _destructiveStamps[page] = (_destructiveStamps[page] ?? 0) + 1;
+      }
+    }
+  }
+
+  /// A value that changes whenever content was *removed* from [pageIndex]
+  /// (see [_destructiveStamps]); stable across additive edits, undo, and
+  /// redo of other pages. The viewer uses it to decide whether to blank the
+  /// held raster (destructive) or keep it up until the re-render lands
+  /// (additive).
+  int pageDestructiveStamp(int pageIndex) =>
+      _destructiveStampEpoch + (_destructiveStamps[pageIndex] ?? 0);
+
   PdfDocument _document;
 
   /// The document at the current revision. Changes identity on every
@@ -1182,6 +1211,10 @@ class PdfEditingController extends ChangeNotifier {
     _hardModified = true;
     _selected.clear();
     _bumpRenderStamps(null); // every page may have changed
+    // a burn removes content irreversibly — mark it destructive so the
+    // viewer blanks each page's raster instead of holding the (now
+    // un-redacted) one up while the fresh render lands
+    _bumpDestructiveStamps(null);
     _document = PdfDocument.open(bytes, password: _password);
     _invalidateElements();
     notifyListeners();

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -36,6 +36,7 @@ class PdfPageView extends StatefulWidget {
     this.previewIndex = 0,
     this.pageEpoch = 0,
     this.contentStamp = 0,
+    this.destructiveStamp = 0,
     this.renderWorker,
   });
 
@@ -79,11 +80,22 @@ class PdfPageView extends StatefulWidget {
   /// This page's content stamp (see [_PdfViewerPage.contentStamp]). Unlike
   /// [pageEpoch] it is per-page, so a content-only same-geometry edit that
   /// changed *this* page advances it while leaving untouched pages alone.
-  /// When it changes the held raster and preview are the pre-edit content —
-  /// most dangerously after a redaction burn, where keeping them would
-  /// flash the removed glyphs/images during a fast scroll — so both drop
-  /// and the page re-renders. 0 outside an editing session (never changes).
+  /// When it changes the page re-renders, but the held raster and preview
+  /// stay painted until the fresh render replaces them — an additive edit
+  /// (ink, a highlight, a shape) on a heavy page must not flash the page
+  /// blank, and the just-added markup rides on top through the editing
+  /// overlay until the new raster (with it baked in) lands. 0 outside an
+  /// editing session (never changes).
   final int contentStamp;
+
+  /// This page's [PdfEditingController.pageDestructiveStamp]. Unlike
+  /// [contentStamp] it advances only when an edit *removed* content from
+  /// this page (a redaction burn). When it changes the held raster and
+  /// preview are dropped immediately — keeping the pre-edit (un-redacted)
+  /// content up, even for the frame before the re-render lands or in a
+  /// fast-scroll preview, would expose the very content the burn deleted.
+  /// 0 outside an editing session (never changes).
+  final int destructiveStamp;
 
   /// While true, a page that has not been interpreted yet keeps its
   /// paper placeholder instead of starting the (UI-thread) interpreter
@@ -246,28 +258,39 @@ class _PdfPageViewState extends State<PdfPageView> {
       _preview = null;
       _refreshPreview();
     }
-    if (oldWidget.pageEpoch != widget.pageEpoch ||
-        oldWidget.contentStamp != widget.contentStamp) {
+    final blanked = oldWidget.pageEpoch != widget.pageEpoch ||
+        oldWidget.destructiveStamp != widget.destructiveStamp;
+    if (blanked) {
       // Either a structural document change reused this State for a different
       // page at the same slot (pageEpoch; previewIndex unchanged, so the
-      // branches above don't fire), or this page's own content changed in a
-      // same-geometry edit (contentStamp — a redaction burn, a fill). Either
-      // way the held raster and preview are stale: drop them so a fast scroll
-      // can't flash the old (or, after a redaction, removed) content; the
-      // preview cache (cleared for changed pages) and _render below repaint.
+      // branches above don't fire), or content was removed from this page in
+      // a same-geometry edit (destructiveStamp — a redaction burn). Either
+      // way the held raster and preview show content that must not linger:
+      // drop them so neither the gap before the re-render nor a fast-scroll
+      // preview can flash the old (or, after a redaction, removed) content;
+      // the preview cache (cleared for changed pages) and _render below
+      // repaint. An *additive* same-geometry edit (ink, a highlight, a
+      // shape — contentStamp only) deliberately does NOT land here: its old
+      // raster stays painted until the fresh one replaces it.
       _image?.dispose();
       _image = null;
       _preview?.dispose();
       _preview = null;
     }
-    if (oldWidget.pageEpoch != widget.pageEpoch ||
+    if (blanked ||
         oldWidget.contentStamp != widget.contentStamp ||
         !identical(oldWidget.page, widget.page) ||
         oldWidget.rotation != widget.rotation ||
         oldWidget.pageColor != widget.pageColor ||
         oldWidget.showAnnotations != widget.showAnnotations) {
+      // Re-interpret at the new content/page. Unless we blanked above, the
+      // old raster (and detail patch) stay up until the new render replaces
+      // them — _dropPicture nulls _rasteredRatio so _renderNow still re-
+      // rasters — so an additive edit on a heavy page never flashes blank.
+      // Only drop the detail patch when we already blanked, so a redaction
+      // or slot reuse can't keep a stale sharp slice over the cleared base.
       _dropPicture();
-      _dropDetail();
+      if (blanked) _dropDetail();
       _render();
     } else if (oldWidget.scale != widget.scale ||
         oldWidget.settleGeneration != widget.settleGeneration) {

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1420,6 +1420,13 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// when not editing (no content can change under the viewer).
   int _contentStamp(int index) => widget.editing?.pageRenderStamp(index) ?? 0;
 
+  /// Page [index]'s current destructive-content stamp (advances only when an
+  /// edit removed content — a redaction burn), or 0 when not editing. Lets
+  /// the page view keep its raster across additive edits but drop it on a
+  /// destructive one.
+  int _destructiveStamp(int index) =>
+      widget.editing?.pageDestructiveStamp(index) ?? 0;
+
   /// Records the content stamp of every current page as the baseline the
   /// cached previews now reflect (after a swap, a prerender pass, or first
   /// build).
@@ -3526,6 +3533,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 settleGeneration: _settleGeneration,
                 pageEpoch: _pageEpoch,
                 contentStamp: _contentStamp(index),
+                destructiveStamp: _destructiveStamp(index),
                 matches: _controller._matchesOn(index),
                 currentMatch: _controller._currentMatch >= 0
                     ? _controller._matches[_controller._currentMatch]
@@ -3918,6 +3926,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.settleGeneration,
     required this.pageEpoch,
     required this.contentStamp,
+    required this.destructiveStamp,
     required this.matches,
     required this.currentMatch,
     required this.selection,
@@ -3970,11 +3979,17 @@ class _PdfViewerPage extends StatefulWidget {
   final int pageEpoch;
 
   /// This page's [PdfEditingController.pageRenderStamp]: changes when the
-  /// page's *content* changed in a same-geometry edit revision (a redaction
-  /// burn, a fill, an annotation edit). A reused [PdfPageView] State drops
-  /// its stale raster/preview rather than painting the pre-edit content
-  /// while the new render lands. 0 outside an editing session.
+  /// page's *content* changed in a same-geometry edit revision (a fill, an
+  /// annotation edit). A reused [PdfPageView] State re-renders but keeps
+  /// painting its current raster until the new one lands, so an additive
+  /// edit never flashes the page blank. 0 outside an editing session.
   final int contentStamp;
+
+  /// This page's [PdfEditingController.pageDestructiveStamp]: advances only
+  /// when content was *removed* (a redaction burn). A reused [PdfPageView]
+  /// State drops its raster immediately on a change so the deleted content
+  /// can't linger on screen. 0 outside an editing session.
+  final int destructiveStamp;
   final List<PdfTextMatch> matches;
   final PdfTextMatch? currentMatch;
   final List<PdfTextQuad> selection;
@@ -4081,6 +4096,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         settleGeneration: widget.settleGeneration,
         pageEpoch: widget.pageEpoch,
         contentStamp: widget.contentStamp,
+        destructiveStamp: widget.destructiveStamp,
         pageColor: widget.pageColor,
         showAnnotations: widget.showAnnotations,
         onRasterReady: _onRasterReady,

--- a/packages/dart_pdf_editor/test/editing_redaction_test.dart
+++ b/packages/dart_pdf_editor/test/editing_redaction_test.dart
@@ -53,6 +53,28 @@ void main() {
       expect(editing.hasRedactionMarks, isFalse);
     });
 
+    test('only a burn advances the destructive stamp; ink does not', () {
+      final editing = controller(2);
+      addTearDown(editing.dispose);
+      final before = editing.pageDestructiveStamp(0);
+      final otherBefore = editing.pageDestructiveStamp(1);
+
+      // an additive edit (ink) bumps the render stamp but not the
+      // destructive one — the viewer keeps page 0's raster up across it
+      final renderBefore = editing.pageRenderStamp(0);
+      editing.addInkStroke(0, const [(72, 72), (200, 200)]);
+      editing.finishInk();
+      expect(editing.pageRenderStamp(0), greaterThan(renderBefore));
+      expect(editing.pageDestructiveStamp(0), before);
+
+      // a redaction burn removes content — every page's destructive stamp
+      // advances so the viewer drops the (un-redacted) rasters at once
+      editing.addRedaction(0, const PdfRect(60, 715, 200, 748));
+      expect(editing.applyRedactions(), isTrue);
+      expect(editing.pageDestructiveStamp(0), greaterThan(before));
+      expect(editing.pageDestructiveStamp(1), greaterThan(otherBefore));
+    });
+
     test('applyRedactions is a no-op with nothing marked', () {
       final editing = controller();
       addTearDown(editing.dispose);

--- a/packages/dart_pdf_editor/test/pdf_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_page_view_test.dart
@@ -113,6 +113,56 @@ void main() {
     expect(tester.widget<RawImage>(find.byType(RawImage)).image!.height, 1008);
   });
 
+  testWidgets('an additive content edit keeps the raster; a destructive one '
+      'drops it', (tester) async {
+    // After finishing an ink markup on a heavy page the document swaps and
+    // the page's contentStamp advances. The old raster must stay painted
+    // until the new render lands (the just-drawn markup rides on top via the
+    // editing overlay) — otherwise the whole page flashes blank while the
+    // slow re-interpret runs. A redaction burn, by contrast, advances the
+    // destructiveStamp and must drop the (un-redacted) raster at once.
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final doc = PdfDocument.open(buildClassicPdf());
+    final page = doc.page(0);
+    final hold = ValueNotifier<bool>(false);
+    addTearDown(hold.dispose);
+    Widget at({int content = 0, int destructive = 0}) => Center(
+        child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+                page: page,
+                contentStamp: content,
+                destructiveStamp: destructive,
+                renderHold: hold)));
+
+    await tester.pumpWidget(at());
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    expect(find.byType(RawImage), findsOneWidget);
+
+    // Hold renders (as the viewer does while a heavy page re-interprets).
+    // An additive edit (contentStamp bump) keeps the raster on screen.
+    hold.value = true;
+    await tester.pumpWidget(at(content: 1));
+    await tester.pump();
+    expect(find.byType(RawImage), findsOneWidget,
+        reason: 'an additive edit must not flash the page blank');
+
+    // A destructive edit (destructiveStamp bump) drops the raster at once so
+    // the removed content can't linger before the re-render lands.
+    await tester.pumpWidget(at(content: 1, destructive: 1));
+    await tester.pump();
+    expect(find.byType(RawImage), findsNothing,
+        reason: 'a destructive edit drops the stale raster immediately');
+
+    // Releasing the hold re-renders.
+    hold.value = false;
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    expect(find.byType(RawImage), findsOneWidget);
+  });
+
   testWidgets('raster resolution is capped at deep zoom', (tester) async {
     final doc = PdfDocument.open(buildClassicPdf());
     await tester.pumpWidget(


### PR DESCRIPTION
## Problem

On a heavy CAD page, finishing an ink markup made the **entire page flash blank** for a moment before re-appearing with the stroke baked in. The stroke itself stayed put; the page content underneath vanished and came back.

## Cause

`finishInk()` commits strokes through `apply()`, which swaps in a new `PdfDocument` and bumps the edited page's render stamp (`pageRenderStamp`). The viewer feeds that to `PdfPageView` as `contentStamp`, and `PdfPageView.didUpdateWidget` **dropped the on-screen raster** (`_image = null`) on every `contentStamp` change before re-interpreting. On a heavy page that re-interpret is slow, so for its duration the page painted the blank paper placeholder while only the committed-ink overlay stayed up — the flash.

That blanking exists for redaction safety (after a burn, keeping the old raster would briefly show *removed* content). But it fired for **every** content edit, including purely additive ones (ink, highlights, shapes), where the old raster is still correct for everything except the new mark — and the new mark is already drawn on top by the editing overlay until the fresh raster lands.

## Fix

Split additive vs destructive:

- `PdfEditingController` now tracks `pageDestructiveStamp` alongside `pageRenderStamp`; only `applyRedactions` (a burn) bumps it.
- The viewer threads `destructiveStamp` through `_PdfViewerPage` into `PdfPageView`.
- `PdfPageView.didUpdateWidget` blanks its raster only on a structural slot reuse (`pageEpoch`) or a `destructiveStamp` change. A plain `contentStamp` advance still re-interprets, but keeps the old raster painted until the new one replaces it — the same way the zoom-settle path already behaves. No blank flash.

Content edits that *change* existing content (delete element, replace text) stay on the additive path (smooth in-place update); only a redaction burn — where lingering would expose deleted content — drops the raster immediately.

## Tests

- `pdf_page_view_test.dart`: an additive `contentStamp` bump keeps the raster under a render hold; a `destructiveStamp` bump drops it.
- `editing_redaction_test.dart`: an ink commit advances the render stamp but not the destructive stamp; a burn advances the destructive stamp on every page.

All existing page-view, render-hold, preview, redaction, and ipad/ink suites pass; `dart analyze` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfsEG8rn7t5HjXrVc3hd26)_