### PR TITLE
app: re-open last session's documents on startup

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -18,6 +18,7 @@ import 'incoming_file.dart';
 import 'ocr.dart';
 import 'printing.dart';
 import 'recents.dart';
+import 'session_store.dart';
 import 'settings_screen.dart';
 import 'update.dart';
 import 'web_launch.dart';
@@ -79,9 +80,15 @@ class _EditorScreenState extends State<EditorScreen>
   PdfEditingPreferences get _prefs => widget.prefs;
 
   final _recents = RecentsStore();
+  final _session = SessionStore();
   final _incoming = IncomingFileService();
   final _ocr = OnDeviceOcr();
   StreamSubscription<IncomingFile>? _incomingSub;
+
+  /// Gates session persistence until the previous session has been read back,
+  /// so an early tab open (e.g. an OS file-open) doesn't clobber the stored set
+  /// before [_restoreSession] has had a chance to re-open it.
+  bool _sessionLoaded = false;
 
   /// The update checker, owned here unless the host injected one.
   late final UpdateService _updates =
@@ -120,6 +127,9 @@ class _EditorScreenState extends State<EditorScreen>
     startWebLaunchQueue(_openIncoming);
     final doc = widget.initialDocument;
     if (doc != null) _openBytes(doc.bytes, doc.title);
+    // Re-open the documents that were open when the app last closed, unless the
+    // app was launched to open a specific file (that explicit target wins).
+    unawaited(_restoreSession());
     if (widget.autoCheckUpdates && UpdateService.supported) {
       _updates.addListener(_onUpdateStatus);
       unawaited(_startupUpdateCheck());
@@ -216,6 +226,72 @@ class _EditorScreenState extends State<EditorScreen>
     return proceed ? ui.AppExitResponse.exit : ui.AppExitResponse.cancel;
   }
 
+  // --- session restore -----------------------------------------------------
+
+  /// True when the app was launched to open a specific document (a screenshot/
+  /// test harness document, or a `.pdf` passed on the command line). In that
+  /// case the explicit target wins and we don't also restore the last session.
+  bool get _hasExplicitLaunchTarget =>
+      widget.initialDocument != null ||
+      (!kIsWeb &&
+          widget.launchArgs
+              .any((a) => a.toLowerCase().endsWith('.pdf')));
+
+  /// Re-opens the file-backed documents that were open when the app last closed.
+  /// Runs once at startup, then enables session persistence so this run's open
+  /// set is captured for next time. Documents whose file has since moved or been
+  /// deleted are dropped silently rather than surfacing an error tab.
+  Future<void> _restoreSession() async {
+    final documents = await _session.load();
+    if (mounted && !_hasExplicitLaunchTarget) {
+      for (final doc in documents) {
+        // Skip anything already open (e.g. an OS file-open that arrived first).
+        if (_tabs.any((t) => t.originPath == doc.path)) continue;
+        await _reopenSessionDocument(doc);
+        if (!mounted) return;
+      }
+    }
+    _sessionLoaded = true;
+    unawaited(_persistSession());
+  }
+
+  Future<void> _reopenSessionDocument(SessionDocument doc) async {
+    final loading = _openLoading(doc.title, originPath: doc.path);
+    try {
+      final bytes = await readPdfAtPath(doc.path);
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
+      final opened = _replaceLoadingTab(
+        loading,
+        DocumentTab.document(
+          title: doc.title,
+          bytes: bytes,
+          preferences: _prefs,
+          originPath: doc.path,
+        ),
+      );
+      if (opened) _recents.add(title: doc.title, path: doc.path);
+    } catch (_) {
+      // The file is gone (moved/deleted): drop the placeholder quietly.
+      if (mounted) await _closeTabs([loading]);
+    }
+  }
+
+  /// Persists the current open set (file-backed tabs, in order) so the next
+  /// launch can restore it. A no-op until the previous session has been read
+  /// back, so early opens can't clobber the stored set before [_restoreSession].
+  Future<void> _persistSession() async {
+    if (!_sessionLoaded) return;
+    final documents = <SessionDocument>[];
+    final seen = <String>{};
+    for (final tab in _tabs) {
+      final path = tab.originPath;
+      if (path == null || path.isEmpty || !seen.add(path)) continue;
+      documents.add(SessionDocument(title: tab.title, path: path));
+    }
+    await _session.save(documents);
+  }
+
   // --- opening -------------------------------------------------------------
 
   /// Opens [bytes] in a brand-new tab and makes it active, recording a recent.
@@ -238,6 +314,7 @@ class _EditorScreenState extends State<EditorScreen>
       _tabs.add(tab);
       _activeIndex = _tabs.length - 1;
     });
+    unawaited(_persistSession());
   }
 
   DocumentTab _openLoading(String title, {String? originPath}) {
@@ -257,6 +334,7 @@ class _EditorScreenState extends State<EditorScreen>
       _activeIndex = index;
     });
     loading.dispose();
+    unawaited(_persistSession());
     return true;
   }
 
@@ -457,6 +535,7 @@ class _EditorScreenState extends State<EditorScreen>
         tab.dispose();
       }
     });
+    unawaited(_persistSession());
   }
 
   /// Opens the right-click context menu for the tab at [index] at [position]
@@ -572,6 +651,8 @@ class _EditorScreenState extends State<EditorScreen>
       });
       if (result.path != null) {
         _recents.add(title: tab.title, path: result.path);
+        // A Save As gave the tab a reusable origin — remember it for next time.
+        unawaited(_persistSession());
       }
     }
     if (result.message != null) _toast(result.message!);
@@ -1046,6 +1127,7 @@ class _EditorScreenState extends State<EditorScreen>
       _tabs.insert(newIndex, moved);
       _activeIndex = _tabs.indexOf(active);
     });
+    unawaited(_persistSession());
   }
 
   Widget _buildTabStrip() {

--- a/app/lib/session_store.dart
+++ b/app/lib/session_store.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// One file-backed document that was open in the previous session, captured so
+/// the editor can re-open it on the next launch.
+@immutable
+class SessionDocument {
+  const SessionDocument({required this.title, required this.path});
+
+  /// The tab title (usually the file name) — shown while the file is read back.
+  final String title;
+
+  /// The reusable on-disk origin. Only documents with a path are tracked, so
+  /// every restored document can be read directly without a fresh pick.
+  final String path;
+
+  Map<String, dynamic> toJson() => {'t': title, 'p': path};
+
+  factory SessionDocument.fromJson(Map<String, dynamic> j) => SessionDocument(
+        title: (j['t'] as String?) ?? 'Untitled',
+        path: (j['p'] as String?) ?? '',
+      );
+}
+
+/// Persists the ordered list of file-backed documents currently open so the
+/// editor can re-open them the next time it launches ("restore last session").
+///
+/// Only documents with a reusable on-disk path are tracked — web and mobile
+/// picks have no path to read back from, so the session there is always empty
+/// and restore is a no-op. Backed by `shared_preferences`; when storage is
+/// unavailable (widget tests) it degrades to the in-memory list, mirroring how
+/// [RecentsStore] and [PdfEditingPreferences] handle the same case.
+class SessionStore {
+  static const _key = 'dart_pdf_editor_app.session';
+
+  List<SessionDocument> _documents = const [];
+
+  /// The most recently loaded/saved set of open documents, in tab order.
+  List<SessionDocument> get documents => List.unmodifiable(_documents);
+
+  /// Reads the persisted open-document list. Returns the (possibly empty) list
+  /// and also caches it in [documents].
+  Future<List<SessionDocument>> load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_key);
+      if (raw == null) return _documents;
+      final decoded = jsonDecode(raw);
+      if (decoded is! List) return _documents;
+      _documents = decoded
+          .whereType<Map>()
+          .map((m) => SessionDocument.fromJson(m.cast<String, dynamic>()))
+          .where((d) => d.path.isNotEmpty)
+          .toList();
+    } catch (_) {
+      // No storage (tests) — keep whatever is already in memory.
+    }
+    return _documents;
+  }
+
+  /// Replaces the persisted open-document list with [documents] (tab order).
+  Future<void> save(List<SessionDocument> documents) async {
+    _documents = List.unmodifiable(documents);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+          _key, jsonEncode(_documents.map((d) => d.toJson()).toList()));
+    } catch (_) {
+      // No storage — nothing to persist.
+    }
+  }
+}

--- a/app/test/session_restore_test.dart
+++ b/app/test/session_restore_test.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/incoming_file.dart';
+import 'package:dart_pdf_editor_app/session_store.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+  late Directory tempDir;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+    tempDir = Directory.systemTemp.createTempSync('dartpdf_session_test');
+  });
+
+  tearDown(() {
+    prefs.dispose();
+    tempDir.deleteSync(recursive: true);
+  });
+
+  // Writes a real PDF on disk so restore can read it back through the same
+  // path-based opener the desktop file pickers use.
+  String seedFile(String name) {
+    final path = '${tempDir.path}/$name';
+    File(path).writeAsBytesSync(Uint8List.fromList(buildClassicPdf()));
+    return path;
+  }
+
+  void seedSession(List<({String title, String path})> docs) {
+    SharedPreferences.setMockInitialValues({
+      'dart_pdf_editor_app.session': jsonEncode(
+          [for (final d in docs) {'t': d.title, 'p': d.path}]),
+    });
+  }
+
+  Finder tabTitle(String name) => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: find.text(name),
+      );
+
+  // The editor never settles (it keeps rasterizing), and restore performs real
+  // file I/O — which only progresses under runAsync. Pump a handful of real
+  // frames so each read can complete and swap its loading placeholder.
+  Future<void> pumpEditor(WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    await tester.pump();
+  }
+
+  testWidgets('re-opens the documents from the last session on startup',
+      (tester) async {
+    final a = seedFile('a.pdf');
+    final b = seedFile('b.pdf');
+    seedSession([(title: 'a.pdf', path: a), (title: 'b.pdf', path: b)]);
+
+    await pumpEditor(tester);
+
+    expect(tabTitle('a.pdf'), findsOneWidget);
+    expect(tabTitle('b.pdf'), findsOneWidget);
+  });
+
+  testWidgets('drops a session document whose file is gone, no error tab',
+      (tester) async {
+    seedSession([(title: 'missing.pdf', path: '${tempDir.path}/missing.pdf')]);
+
+    await pumpEditor(tester);
+
+    // Nothing opened — we land back on the welcome screen, no error placeholder.
+    expect(tabTitle('missing.pdf'), findsNothing);
+    expect(find.widgetWithText(FilledButton, 'Open a PDF'), findsOneWidget);
+  });
+
+  testWidgets('skips restore when launched to open a specific document',
+      (tester) async {
+    final a = seedFile('a.pdf');
+    seedSession([(title: 'a.pdf', path: a)]);
+
+    await tester.runAsync(() async {
+      await tester.pumpWidget(MaterialApp(
+        home: EditorScreen(
+          prefs: prefs,
+          initialDocument: (
+            bytes: Uint8List.fromList(buildClassicPdf()),
+            title: 'launched.pdf',
+          ),
+        ),
+      ));
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    await tester.pump();
+
+    expect(tabTitle('launched.pdf'), findsOneWidget);
+    expect(tabTitle('a.pdf'), findsNothing);
+  });
+
+  testWidgets('records the open documents so the next launch can restore them',
+      (tester) async {
+    // Start with no prior session, then open a file-backed document the way the
+    // OS hands one over. The open set should be persisted for next time.
+    final path = '${tempDir.path}/opened.pdf';
+    await pumpEditor(tester); // empty session: enables persistence
+
+    const codec = StandardMethodCodec();
+    final message = codec.encodeMethodCall(MethodCall('openFile', {
+      'name': 'opened.pdf',
+      'bytes': buildClassicPdf(),
+      'path': path,
+    }));
+    await tester.runAsync(() async {
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        IncomingFileService.channelName,
+        message,
+        (_) {},
+      );
+      for (var i = 0; i < 12; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    await tester.pump();
+
+    expect(tabTitle('opened.pdf'), findsOneWidget);
+    final persisted = await SessionStore().load();
+    expect(persisted.map((d) => d.path), [path]);
+  });
+}

--- a/app/test/session_store_test.dart
+++ b/app/test/session_store_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/session_store.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('save then load round-trips the open documents in order', () async {
+    final a = SessionStore();
+    await a.save(const [
+      SessionDocument(title: 'a.pdf', path: '/docs/a.pdf'),
+      SessionDocument(title: 'b.pdf', path: '/docs/b.pdf'),
+    ]);
+
+    final b = SessionStore();
+    final restored = await b.load();
+    expect(restored.map((d) => d.path), ['/docs/a.pdf', '/docs/b.pdf']);
+    expect(restored.map((d) => d.title), ['a.pdf', 'b.pdf']);
+  });
+
+  test('load is empty when nothing was persisted', () async {
+    final store = SessionStore();
+    expect(await store.load(), isEmpty);
+  });
+
+  test('save replaces the previous set', () async {
+    final store = SessionStore();
+    await store.save(const [SessionDocument(title: 'a.pdf', path: '/a.pdf')]);
+    await store.save(const [SessionDocument(title: 'c.pdf', path: '/c.pdf')]);
+
+    final reloaded = SessionStore();
+    expect((await reloaded.load()).single.path, '/c.pdf');
+  });
+
+  test('documents without a usable path are dropped on load', () async {
+    SharedPreferences.setMockInitialValues({
+      'dart_pdf_editor_app.session': '[{"t":"keep.pdf","p":"/k.pdf"},'
+          '{"t":"nopath.pdf","p":""},{"t":"missing.pdf"}]',
+    });
+    final store = SessionStore();
+    final restored = await store.load();
+    expect(restored.map((d) => d.path), ['/k.pdf']);
+  });
+}

--- a/doc/dev-log/2026-06-22-app-session-restore.md
+++ b/doc/dev-log/2026-06-22-app-session-restore.md
@@ -1,0 +1,50 @@
+# App session restore — re-open last session's PDFs
+
+The desktop/web app (`app/`) now re-opens the documents that were open when it
+last closed, instead of always booting into the empty welcome screen.
+
+## What landed
+
+- `app/lib/session_store.dart` — `SessionStore` + `SessionDocument`. Persists
+  the ordered list of *file-backed* open documents (title + reusable on-disk
+  path) under `shared_preferences` key `dart_pdf_editor_app.session`. Mirrors
+  `RecentsStore`'s degrade-to-memory behavior when storage is unavailable
+  (widget tests). Only documents with a non-empty path are tracked, so web and
+  mobile picks (no reusable handle) never persist and restore is a no-op there.
+- `app/lib/editor_screen.dart` wiring:
+  - `_restoreSession()` runs once from `initState`. It loads the stored set and
+    re-opens each entry through the same `_openLoading` → `readPdfAtPath` →
+    `_replaceLoadingTab` machinery the recents/file-open paths use. A file that
+    has since moved/been deleted drops its loading placeholder quietly
+    (`_closeTabs`) rather than leaving an error tab from a background restore.
+  - `_hasExplicitLaunchTarget` skips restore when the app was launched to open a
+    specific file (a screenshot/test `initialDocument`, or a `.pdf` on the
+    command line) — the explicit target wins. The macOS/mobile channel
+    "open with" is async and not pre-detected; restore there just dedupes by
+    `originPath` against anything already open.
+  - `_persistSession()` rewrites the stored set (file-backed tabs, in order)
+    after every tab mutation (`_addTab`, `_replaceLoadingTab`, `_closeTabs`,
+    `_reorderTabs`, and a Save As that gives a tab a new origin).
+  - `_sessionLoaded` gates persistence until the previous session has been read
+    back, so an early OS file-open can't clobber the stored set before
+    `_restoreSession` re-opens it. It flips true at the end of `_restoreSession`
+    (even when restore was skipped) so this run's opens are still captured.
+
+## Gotchas
+
+- Widget tests: real file I/O (`XFile.readAsBytes` behind `readPdfAtPath`) does
+  **not** progress under `flutter_test`'s fake-async zone. The restore tests
+  wrap pumping in `tester.runAsync` and interleave `tester.pump` with real
+  `Future.delayed` so each read completes and swaps its placeholder. The
+  `SharedPreferences` mock channel, by contrast, resolves under a plain pump.
+- The editor never settles (it keeps rasterizing pages), so the tests step a
+  fixed number of frames instead of `pumpAndSettle` — same pattern as
+  `tabs_menu_test.dart`.
+
+## Tests
+
+- `app/test/session_store_test.dart` — store round-trip, replace, empty load,
+  and dropping entries without a usable path.
+- `app/test/session_restore_test.dart` — restores last session's tabs on
+  startup, drops a vanished file with no error tab, skips restore on explicit
+  launch, and persists the open set after an OS file-open.


### PR DESCRIPTION
## What

The desktop/web app (`app/`) now **re-opens the documents that were open when it last closed**, instead of always booting into the empty welcome screen.

## How

- **`app/lib/session_store.dart`** — new `SessionStore` + `SessionDocument`. Persists the ordered list of *file-backed* open documents (title + reusable on-disk path) under the `shared_preferences` key `dart_pdf_editor_app.session`. Mirrors `RecentsStore`'s degrade-to-memory behavior when storage is unavailable (widget tests). Only documents with a non-empty path are tracked, so web/mobile picks (no reusable handle) never persist and restore is a no-op there.
- **`app/lib/editor_screen.dart`** wiring:
  - `_restoreSession()` runs once from `initState`, re-opening each stored entry through the same `_openLoading` → `readPdfAtPath` → `_replaceLoadingTab` machinery the recents/file-open paths already use. A file that has since moved/been deleted drops its loading placeholder quietly rather than leaving a stray error tab.
  - `_hasExplicitLaunchTarget` skips restore when the app was launched to open a specific file (a screenshot/test `initialDocument`, or a `.pdf` on the command line) — the explicit target wins. Otherwise restore dedupes by `originPath` against anything already open.
  - `_persistSession()` rewrites the stored set after every tab mutation (`_addTab`, `_replaceLoadingTab`, `_closeTabs`, `_reorderTabs`, and a Save As that gives a tab a new origin), gated by `_sessionLoaded` until the previous session has been read back so an early OS file-open can't clobber it.

## Tests

- `app/test/session_store_test.dart` — store round-trip, replace, empty load, dropping entries without a usable path.
- `app/test/session_restore_test.dart` — restores last session's tabs on startup, drops a vanished file with no error tab, skips restore on explicit launch, and persists the open set after an OS file-open.

Full app suite (115 tests) and `dart analyze app` both pass. See `doc/dev-log/2026-06-22-app-session-restore.md` for the design notes and the `flutter_test` runAsync gotcha around real file I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeBvuqBDiHjiHdJ1EAvSSH)_