### PR TITLE
Auto-scroll the viewport while dragging a selection to its edge

### DIFF
--- a/doc/dev-log/2026-06-22-edit-drag-edge-autoscroll.md
+++ b/doc/dev-log/2026-06-22-edit-drag-edge-autoscroll.md
@@ -1,0 +1,50 @@
+# Edit-drag edge auto-scroll
+
+When a region/selection drag in the editing overlay reaches the viewport
+edge, the viewer now keeps scrolling in that direction so you can drag past
+what's on screen — snapshot rects, marquee (shift) selection, moves,
+resizes, vertex drags, shape drag-outs. The held pointer re-tracks onto the
+content scrolled under it, so the drag keeps growing; a manual shift-scroll
+mid-drag tracks the same way.
+
+## How it works
+
+`EditingPageOverlay` gained an `edgeAutoScroll` callback (wired in
+`pdf_viewer.dart` to `_PdfViewerState._edgeAutoScrollDelta`). The viewer
+owns the viewport geometry, so it computes the per-frame pan delta: it reads
+its own render box's global rect, measures how deep the drag pointer sits in
+a 60px edge band, and ramps the speed linearly to 16 logical px/frame at the
+rim. The delta is divided by the transform zoom because `onPanViewport`
+(`_touchGrabPanBy`) deltas are list-space, then fed straight through the
+existing grab-pan path (`_scrollbarScrollBy`/`_scrollbarPanBy`, which already
+clamp at the scroll extents — so the drag just stops growing at the content
+bounds, no runaway).
+
+The overlay drives the loop with a `Ticker` (`_autoScrollTicker`), started in
+`_panUpdate` whenever a region drag is active (`_autoScrollDragActive`) and
+stopped in `_panEnd` / `_bailActiveGesture` / `dispose`. The mixin changed
+from `SingleTickerProviderStateMixin` to `TickerProviderStateMixin` because
+`_flashController` already held the single ticker.
+
+## The key coordinate insight
+
+The drag's "current" point is kept in the overlay's **page-local** view
+space, which is **scroll-invariant** — a point on the page has the same
+local coordinates no matter where the page is scrolled. So the ticker
+re-derives the pointer each frame with `box.globalToLocal(global)`: a
+stationary screen pointer maps to a *moving* page-local point as the page
+scrolls under it, and `delta = current - start` (both page-local) is exactly
+the page-space drag delta with no scroll offset to subtract. That's why the
+same mechanism fixes manual shift-scroll tracking for free — the ticker runs
+for the whole drag, not just at the edge, and re-applies on any layout
+change. `_panUpdate`'s per-drag branch logic was extracted into
+`_applyDragPosition(position)` so both the gesture and the ticker share it.
+
+A redundant-rebuild guard (`_autoScrollLastLocal`) skips re-applying when the
+re-derived local hasn't moved (held pointer, no scroll).
+
+## Tests
+
+`test/editing_autoscroll_test.dart`: a snapshot drag held at the bottom edge
+keeps panning across idle frames and stops on lift; a drag held away from the
+edges does not scroll; a drag to the top edge scrolls back up.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -414,6 +415,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.showAnnotations = true,
     this.onPanViewport,
     this.onPanViewportEnd,
+    this.edgeAutoScroll,
     this.rasterCurrent = true,
     this.zoom = 1,
     this.predictStrokes = true,
@@ -462,6 +464,14 @@ class EditingPageOverlay extends StatefulWidget {
   /// viewer so a finger fling keeps its momentum (the overlay's pan path
   /// bypasses the list's scroll physics, which would otherwise carry it).
   final void Function(Velocity velocity)? onPanViewportEnd;
+
+  /// Per-frame edge auto-scroll for a region/selection drag. Given the drag
+  /// pointer's global position, returns the viewport scroll delta (this
+  /// overlay's local space, same as [onPanViewport]) to apply this frame so
+  /// the document keeps moving while the pointer rests against a viewport
+  /// edge — [Offset.zero] when the pointer is clear of every edge. With none,
+  /// dragging to the edge does not scroll the viewer.
+  final Offset Function(Offset globalPosition)? edgeAutoScroll;
 
   /// Whether the page raster on screen already shows the controller's
   /// current revision. While false (an edit just committed and the
@@ -583,7 +593,7 @@ const double _rotateHandleDistance = 22;
 const double _rotateSnapRadians = 3 * math.pi / 180;
 
 class _EditingPageOverlayState extends State<EditingPageOverlay>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   // shape/text/stamp drag
   Offset? _dragStart;
   Offset? _dragCurrent;
@@ -736,6 +746,17 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// so a drop over another page can be resolved to a page point (drag-end
   /// details carry no position).
   Offset? _moveCurrentGlobal;
+
+  // Edge auto-scroll: while a region/selection drag is in flight the ticker
+  // runs every frame, scrolling the viewer when the pointer rests against a
+  // viewport edge and re-tracking the held pointer onto the content scrolled
+  // under it (so the drag keeps growing during auto-scroll or a manual
+  // shift-scroll). [_autoScrollGlobal] is the latest pointer global position;
+  // [_autoScrollLastLocal] guards against redundant re-tracks.
+  late final Ticker _autoScrollTicker = createTicker(_onAutoScrollTick);
+  Offset? _autoScrollGlobal;
+  Offset? _autoScrollLastLocal;
+
   _Handle? _resizeHandle;
   Rect? _resizeFrom;
   Rect? _resizeRect;
@@ -1089,6 +1110,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _signatureDrag = false;
       _signaturePreview = null;
     });
+    _stopAutoScroll();
     _clearResizeClean();
     widget.onMoveDragPreview?.call(null);
     _bumpActiveStroke();
@@ -1704,6 +1726,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _clearSourceClean();
     _flashController.dispose();
     _activeStrokeRepaint.dispose();
+    _autoScrollTicker.dispose();
     super.dispose();
   }
 
@@ -2479,15 +2502,36 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       widget.onPanViewport?.call(details.delta);
       return;
     }
-    if (_marqueeStart != null) {
-      setState(() => _marqueeCurrent = position);
-      return;
-    }
     if (_signatureDrag) {
       setState(() => _signaturePreview = position);
       return;
     }
-    if (_rotateStartAngle != null) {
+    if (_activeStroke != null) {
+      // hot path: append + repaint the stroke layer only, no rebuild
+      _penCursor = position;
+      _activeStroke!.add(_geometry.toPagePoint(position));
+      _activeStrokePressures
+          ?.add(_pointerPressure ?? _activeStrokePressures!.last);
+      _bumpActiveStroke();
+      return;
+    }
+    // region/selection drags (marquee, move, resize, vertex, shape/snapshot
+    // rect, rotate) track their current point in view space. Record the
+    // pointer's global position too: an edge auto-scroll tick re-derives the
+    // view-space point from it as the page scrolls under a held pointer.
+    _autoScrollGlobal = details.globalPosition;
+    _autoScrollLastLocal = position;
+    _applyDragPosition(position);
+    _maybeAutoScroll();
+  }
+
+  /// Applies a region drag's current pointer (view space) to whichever drag
+  /// is in flight — shared by [_panUpdate] and the edge auto-scroll tick so a
+  /// held pointer keeps tracking the page as it scrolls underneath.
+  void _applyDragPosition(Offset position) {
+    if (_marqueeStart != null) {
+      setState(() => _marqueeCurrent = position);
+    } else if (_rotateStartAngle != null) {
       final selected = _selectedViewRect;
       if (selected == null) return;
       setState(() {
@@ -2523,22 +2567,62 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         _resizeRect = _anchorResized(resized);
       });
     } else if (_moveStart != null) {
-      _moveCurrentGlobal = details.globalPosition;
+      _moveCurrentGlobal = _autoScrollGlobal;
       setState(() => _moveCurrent = position);
       // float the artwork above every page so a move dragged onto the
       // page below isn't clipped behind it (this overlay can't paint
       // over a sibling list item)
       _reportMovePreview();
-    } else if (_activeStroke != null) {
-      // hot path: append + repaint the stroke layer only, no rebuild
-      _penCursor = position;
-      _activeStroke!.add(_geometry.toPagePoint(position));
-      _activeStrokePressures
-          ?.add(_pointerPressure ?? _activeStrokePressures!.last);
-      _bumpActiveStroke();
     } else if (_dragStart != null) {
       setState(() => _dragCurrent = position);
     }
+  }
+
+  /// Drags whose region keeps growing while the pointer sits against the
+  /// viewport edge (and the viewer auto-scrolls under it).
+  bool get _autoScrollDragActive =>
+      _marqueeStart != null ||
+      _moveStart != null ||
+      _resizeHandle != null ||
+      _vertexHandle != null ||
+      _dragStart != null;
+
+  /// Runs the edge auto-scroll ticker for an in-flight region drag. The
+  /// ticker runs for the whole drag (not only at the edge) so a manual
+  /// shift-scroll mid-drag also re-tracks the held pointer onto the
+  /// newly revealed content.
+  void _maybeAutoScroll() {
+    if (widget.edgeAutoScroll == null || widget.onPanViewport == null) return;
+    if (!_autoScrollDragActive) return;
+    if (!_autoScrollTicker.isActive) _autoScrollTicker.start();
+  }
+
+  void _stopAutoScroll() {
+    if (_autoScrollTicker.isActive) _autoScrollTicker.stop();
+    _autoScrollGlobal = null;
+    _autoScrollLastLocal = null;
+  }
+
+  void _onAutoScrollTick(Duration _) {
+    final global = _autoScrollGlobal;
+    if (global == null || !_autoScrollDragActive) {
+      _stopAutoScroll();
+      return;
+    }
+    final box = context.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) return;
+    // Re-derive the view-space pointer: the page may have scrolled under a
+    // held pointer (the edge auto-scroll below, or a manual shift-scroll), so
+    // the same global point now lands on different content — grow the drag to
+    // it. The guard skips redundant rebuilds when nothing moved.
+    final local = box.globalToLocal(global);
+    if (local != _autoScrollLastLocal) {
+      _autoScrollLastLocal = local;
+      _applyDragPosition(local);
+    }
+    // Keep scrolling while the pointer rests in the viewport's edge band.
+    final delta = widget.edgeAutoScroll!(global);
+    if (delta != Offset.zero) widget.onPanViewport!(delta);
   }
 
   void _panEnd(DragEndDetails details) {
@@ -2608,6 +2692,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       // drop any drag cursor; the next hover recomputes it
       _cursor = MouseCursor.defer;
     });
+    _stopAutoScroll();
     // the in-flight lift is done; the afterimage covers the commit gap
     _clearResizeClean();
     // the floating move preview hands off to the commit's afterimage (or

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -2945,6 +2945,45 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     _scrollbarPanBy(-delta.dx);
   }
 
+  /// How thick the viewport's auto-scroll edge band is (logical px) and how
+  /// fast a drag pinned to the very edge scrolls (logical px per frame).
+  static const double _edgeScrollBand = 60;
+  static const double _edgeScrollMaxSpeed = 16;
+
+  /// Per-frame viewport scroll for an editing drag whose pointer rests in the
+  /// viewport's edge band. Given the drag pointer's [globalPosition], returns
+  /// the pan delta to feed [_touchGrabPanBy] (overlay-local space, zoom
+  /// divided out), or [Offset.zero] when the pointer is clear of every edge.
+  /// The ramp grows linearly from the band's inner edge to the viewport edge,
+  /// so the closer the pointer is to the rim the faster it scrolls.
+  Offset _edgeAutoScrollDelta(Offset globalPosition) {
+    final box = context.findRenderObject();
+    if (box is! RenderBox || !box.hasSize) return Offset.zero;
+    final origin = box.localToGlobal(Offset.zero);
+    final size = box.size;
+    double axis(double pos, double lo, double extent) {
+      if (extent <= 2 * _edgeScrollBand) return 0; // no room for two bands
+      final hi = lo + extent;
+      if (pos < lo + _edgeScrollBand) {
+        return _edgeScrollMaxSpeed *
+            ((lo + _edgeScrollBand - pos) / _edgeScrollBand).clamp(0.0, 1.0);
+      }
+      if (pos > hi - _edgeScrollBand) {
+        return -_edgeScrollMaxSpeed *
+            ((pos - (hi - _edgeScrollBand)) / _edgeScrollBand).clamp(0.0, 1.0);
+      }
+      return 0;
+    }
+
+    final dx = axis(globalPosition.dx, origin.dx, size.width);
+    final dy = axis(globalPosition.dy, origin.dy, size.height);
+    if (dx == 0 && dy == 0) return Offset.zero;
+    // [_touchGrabPanBy] deltas are list-space (the zoom transform divided
+    // out); the edge ramp is in on-screen px, so scale it back down.
+    final zoom = _transformScale.value;
+    return Offset(dx, dy) / (zoom == 0 ? 1 : zoom);
+  }
+
   /// Scroll-fling deceleration: velocity decays by e^-2 per second
   /// (≈ UIScrollView's "normal" rate), so a fling travels about half a
   /// second's worth of its release velocity. The tolerance stops the
@@ -3585,6 +3624,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 onSnapshot: widget.onSnapshot,
                 onPanViewport: _touchGrabPanBy,
                 onPanViewportEnd: _flingViewport,
+                edgeAutoScroll: _edgeAutoScrollDelta,
                 onShowAnnotationMenu: _showSelectionMenu,
                 onShowFormFieldMenu: _showFormFieldMenu,
                 onResolvePagePoint: _resolvePagePointGlobal,
@@ -3975,6 +4015,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.onSnapshot,
     required this.onPanViewport,
     required this.onPanViewportEnd,
+    required this.edgeAutoScroll,
     required this.onShowAnnotationMenu,
     required this.onShowFormFieldMenu,
     required this.onResolvePagePoint,
@@ -4051,6 +4092,9 @@ class _PdfViewerPage extends StatefulWidget {
 
   /// See [EditingPageOverlay.onPanViewportEnd].
   final void Function(Velocity velocity) onPanViewportEnd;
+
+  /// See [EditingPageOverlay.edgeAutoScroll].
+  final Offset Function(Offset globalPosition) edgeAutoScroll;
 
   /// See [EditingPageOverlay.onShowAnnotationMenu].
   final void Function(Offset globalPosition, int pageIndex,
@@ -4218,6 +4262,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                               showAnnotations: widget.showAnnotations,
                               onPanViewport: widget.onPanViewport,
                               onPanViewportEnd: widget.onPanViewportEnd,
+                              edgeAutoScroll: widget.edgeAutoScroll,
                               onShowAnnotationMenu: widget.onShowAnnotationMenu,
                               onShowFormFieldMenu: widget.onShowFormFieldMenu,
                               onResolvePagePoint: widget.onResolvePagePoint,

--- a/packages/dart_pdf_editor/test/editing_autoscroll_test.dart
+++ b/packages/dart_pdf_editor/test/editing_autoscroll_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Edge auto-scroll: a region/selection drag (snapshot, marquee, move…) held
+// against the viewport edge keeps panning the document in that direction, so
+// you can drag past what's currently on screen. The held pointer re-tracks
+// onto the content scrolled under it, so the drag keeps growing.
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Future<PdfEditingController> pumpViewer(WidgetTester tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(6));
+    addTearDown(editing.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: editing.document,
+            editing: editing,
+            onSnapshot: (_, __) async {},
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return editing;
+  }
+
+  ScrollPosition scrollPosition(WidgetTester tester) =>
+      tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+
+  testWidgets('a snapshot drag held at the bottom edge keeps scrolling',
+      (tester) async {
+    final editing = await pumpViewer(tester);
+    editing.tool = PdfEditTool.snapshot;
+    await tester.pump();
+
+    // press mid-page and drag the rect down into the bottom edge band
+    final gesture = await tester.startGesture(const Offset(400, 300),
+        kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, 290)); // ≈ y 590, inside the band
+    await tester.pump();
+    final atEdge = scrollPosition(tester).pixels;
+
+    // holding still — no more pointer moves — keeps panning frame by frame
+    for (var i = 0; i < 4; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    final scrolled = scrollPosition(tester).pixels;
+    expect(scrolled, greaterThan(atEdge + 10));
+
+    // lifting stops it: the position holds across further frames
+    await gesture.up();
+    await tester.pump();
+    final rest = scrollPosition(tester).pixels;
+    for (var i = 0; i < 4; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    expect(scrollPosition(tester).pixels, rest);
+
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 400)); // double-tap timer
+  });
+
+  testWidgets('a drag away from the edges does not auto-scroll',
+      (tester) async {
+    final editing = await pumpViewer(tester);
+    editing.tool = PdfEditTool.snapshot;
+    await tester.pump();
+
+    final gesture = await tester.startGesture(const Offset(300, 250),
+        kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    await gesture.moveBy(const Offset(120, 60)); // stays well inside
+    await tester.pump();
+    final held = scrollPosition(tester).pixels;
+    for (var i = 0; i < 4; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    expect(scrollPosition(tester).pixels, held);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('dragging to the top edge scrolls back up', (tester) async {
+    final editing = await pumpViewer(tester);
+    // start partway down so there is room to scroll up
+    await tester.fling(find.byType(PdfViewer), const Offset(0, -400), 1000);
+    await tester.pumpAndSettle();
+    final start = scrollPosition(tester).pixels;
+    expect(start, greaterThan(60));
+
+    editing.tool = PdfEditTool.snapshot;
+    await tester.pump();
+
+    final gesture = await tester.startGesture(const Offset(400, 300),
+        kind: PointerDeviceKind.mouse);
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, -280)); // ≈ y 20, inside the top band
+    await tester.pump();
+    for (var i = 0; i < 4; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    expect(scrollPosition(tester).pixels, lessThan(start - 10));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+}


### PR DESCRIPTION
## What

When a region/selection drag in the editing overlay reaches the viewport edge, the viewer now keeps scrolling in that direction so you can drag past what's currently on screen. This covers every drag that grows a region:

- snapshot rects
- marquee (shift) selection
- annotation moves
- resizes and vertex drags
- shape/redaction drag-outs

The held pointer **re-tracks onto the content scrolled under it**, so the drag keeps growing as the page moves. A manual shift-scroll mid-drag now tracks the same way.

## How

`EditingPageOverlay` gained an `edgeAutoScroll` callback, wired in `pdf_viewer.dart` to `_PdfViewerState._edgeAutoScrollDelta`. The viewer owns the viewport geometry, so it computes the per-frame pan delta: it reads its own render box's global rect, measures how deep the drag pointer sits in a 60px edge band, and ramps the speed linearly to 16 logical px/frame at the rim (divided by the transform zoom, since `onPanViewport` deltas are list-space). The delta is fed straight through the existing grab-pan path (`_scrollbarScrollBy`/`_scrollbarPanBy`), which already clamps at the scroll extents — so the drag simply stops growing at the content bounds, no runaway.

The overlay drives the loop with a `Ticker` (`_autoScrollTicker`), started in `_panUpdate` whenever a region drag is active and stopped in `_panEnd`/`_bailActiveGesture`/`dispose`. The mixin moved from `SingleTickerProviderStateMixin` to `TickerProviderStateMixin` (the single ticker was already taken by `_flashController`).

### Coordinate insight

The drag's current point lives in the overlay's **page-local** view space, which is **scroll-invariant**. The ticker re-derives the pointer each frame with `box.globalToLocal(global)`: a stationary screen pointer maps to a *moving* page-local point as the page scrolls under it, and `delta = current − start` (both page-local) is exactly the page-space drag delta with no scroll offset to subtract. That's why the same mechanism fixes manual shift-scroll tracking for free — the ticker runs for the whole drag, not just at the edge. The shared `_applyDragPosition(position)` was extracted from `_panUpdate` so the gesture and the ticker drive the drag identically; a `_autoScrollLastLocal` guard skips redundant rebuilds when nothing moved.

## Tests

New `test/editing_autoscroll_test.dart`:
- a snapshot drag held at the bottom edge keeps panning across idle frames and stops on lift
- a drag held away from the edges does not scroll
- a drag to the top edge scrolls back up

`fvm dart analyze` is clean; the surrounding editing/viewer drag tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLeXhqStxBFQ359xa7jG8a)_