### PR TITLE
Drag-and-drop to open or insert PDFs in the app

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -320,11 +320,34 @@ class _EditorScreenState extends State<EditorScreen>
     );
   }
 
-  /// Opens PDFs dropped onto the window (desktop and web). Non-PDFs are
-  /// ignored; each readable PDF opens in its own tab.
+  /// Handles PDFs dropped onto the window (desktop and web). Non-PDFs are
+  /// ignored. With an editable document already open, the drop offers a
+  /// choice — open each PDF in its own tab, or insert their pages into the
+  /// current document; with nothing open (or in read-only mode) each PDF
+  /// just opens in its own tab.
   Future<void> _onFilesDropped(List<DropItem> items) async {
-    for (final item in items) {
-      if (!item.name.toLowerCase().endsWith('.pdf')) continue;
+    final pdfs = [
+      for (final item in items)
+        if (item.name.toLowerCase().endsWith('.pdf')) item,
+    ];
+    if (pdfs.isEmpty) return;
+
+    final tab = _active;
+    final session = tab?.session;
+    if (session != null && !_readOnly) {
+      final action = await _promptDropAction(pdfs.length, tab!.title);
+      if (action == null || !mounted) return; // cancelled / disposed
+      if (action == _DropAction.insert) {
+        await _insertDropped(pdfs, session, tab.title);
+        return;
+      }
+    }
+    await _openDropped(pdfs);
+  }
+
+  /// Opens each dropped [pdfs] item in its own tab.
+  Future<void> _openDropped(List<DropItem> pdfs) async {
+    for (final item in pdfs) {
       // desktop_drop exposes a real path on desktop; on web it's a blob ref
       // we don't treat as a writable origin.
       final path = (!kIsWeb && item.path.isNotEmpty) ? item.path : null;
@@ -334,6 +357,67 @@ class _EditorScreenState extends State<EditorScreen>
         originPath: path,
       );
     }
+  }
+
+  /// Inserts the pages of each dropped PDF, appended in drop order, into the
+  /// active document's edit session. Unreadable files are skipped and
+  /// reported; the result is one undoable step per inserted file.
+  Future<void> _insertDropped(
+      List<DropItem> pdfs, PdfEditingController session, String title) async {
+    var inserted = 0;
+    final failed = <String>[];
+    for (final item in pdfs) {
+      try {
+        final bytes = await item.readAsBytes();
+        session.insertPagesFromBytes(bytes);
+        inserted++;
+      } catch (_) {
+        failed.add(item.name);
+      }
+    }
+    if (!mounted) return;
+    if (inserted == 0) {
+      _toast('Could not insert the dropped ${pdfs.length == 1 ? 'PDF' : 'PDFs'}');
+    } else if (failed.isEmpty) {
+      _toast(inserted == 1
+          ? 'Inserted pages into $title'
+          : 'Inserted $inserted PDFs into $title');
+    } else {
+      _toast('Inserted $inserted; could not read ${failed.join(', ')}');
+    }
+  }
+
+  /// Asks whether dropped PDFs (with a document already open) should open in
+  /// new tabs or have their pages inserted into the current document. Returns
+  /// null when cancelled.
+  Future<_DropAction?> _promptDropAction(int count, String title) {
+    final noun = count == 1 ? 'this PDF' : 'these $count PDFs';
+    final pages = count == 1 ? 'its pages' : 'their pages';
+    return showDialog<_DropAction>(
+      context: context,
+      builder: (context) => AlertDialog(
+        key: const ValueKey('drop-action-dialog'),
+        title: Text('Add dropped ${count == 1 ? 'PDF' : 'PDFs'}'),
+        content: Text('Open $noun in a new tab, or insert $pages into '
+            '"$title"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            key: const ValueKey('drop-action-open'),
+            onPressed: () => Navigator.of(context).pop(_DropAction.open),
+            child: Text(count == 1 ? 'Open in new tab' : 'Open in new tabs'),
+          ),
+          FilledButton(
+            key: const ValueKey('drop-action-insert'),
+            onPressed: () => Navigator.of(context).pop(_DropAction.insert),
+            child: const Text('Insert pages'),
+          ),
+        ],
+      ),
+    );
   }
 
   Future<void> _openRecent(RecentFile entry) async {
@@ -798,7 +882,12 @@ class _EditorScreenState extends State<EditorScreen>
           child: Stack(
             children: [
               Positioned.fill(child: _buildBody(tab)),
-              if (_dragging) const Positioned.fill(child: _DropOverlay()),
+              if (_dragging)
+                Positioned.fill(
+                  child: _DropOverlay(
+                    canInsert: tab?.session != null && !_readOnly,
+                  ),
+                ),
             ],
           ),
         ),
@@ -1261,8 +1350,15 @@ class _TabDragStartListener extends ReorderableDragStartListener {
 
 /// The translucent "drop a PDF here" scrim shown while a file is dragged over
 /// the window.
+/// How a drop should be handled when a document is already open.
+enum _DropAction { open, insert }
+
 class _DropOverlay extends StatelessWidget {
-  const _DropOverlay();
+  const _DropOverlay({this.canInsert = false});
+
+  /// Whether the drop can be inserted into the open document (vs. only
+  /// opened in a new tab) — drives the hint text.
+  final bool canInsert;
 
   @override
   Widget build(BuildContext context) {
@@ -1284,7 +1380,7 @@ class _DropOverlay extends StatelessWidget {
               Icon(Icons.file_download_outlined,
                   size: 40, color: scheme.primary),
               const SizedBox(height: 8),
-              const Text('Drop PDF to open'),
+              Text(canInsert ? 'Drop PDF to open or insert' : 'Drop PDF to open'),
             ],
           ),
         ),

--- a/app/test/drop_insert_test.dart
+++ b/app/test/drop_insert_test.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/incoming_file.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+
+  tearDown(() => prefs.dispose());
+
+  // Delivers a PDF to the running app the way the OS would (a warm-start
+  // "open with"), opening it in a new tab.
+  Future<void> openTab(WidgetTester tester, String name, Uint8List bytes) async {
+    const codec = StandardMethodCodec();
+    final message = codec.encodeMethodCall(
+      MethodCall('openFile', {'name': name, 'bytes': bytes}),
+    );
+    await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      IncomingFileService.channelName,
+      message,
+      (_) {},
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  // Drives the desktop_drop channel the way the Linux platform side does when
+  // a file is dropped on the window. Only a path is delivered — the bytes are
+  // read lazily later — so no real file is needed to exercise the drop's
+  // branching (show the action dialog / add a loading tab). The drop point is
+  // the centre of the surface so it lands inside the editor body (DropTarget
+  // only reports a done event for in-bounds drops).
+  Future<void> dropPdf(WidgetTester tester, String name) async {
+    final size = tester.view.physicalSize / tester.view.devicePixelRatio;
+    const codec = StandardMethodCodec();
+    final message = codec.encodeMethodCall(
+      MethodCall('performOperation_linux', <dynamic>[
+        Uri.file('/dartpdf-test/$name').toString(),
+        <double>[size.width / 2, size.height / 2],
+      ]),
+    );
+    unawaited(
+      tester.binding.defaultBinaryMessenger
+          .handlePlatformMessage('desktop_drop', message, (_) {}),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Finder tabTitle(String name) => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: find.text(name),
+      );
+
+  testWidgets('dropping onto an open document offers open or insert',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'base.pdf', buildMultiPagePdf(2));
+
+    await dropPdf(tester, 'extra.pdf');
+
+    expect(find.byKey(const ValueKey('drop-action-dialog')), findsOneWidget);
+    expect(find.byKey(const ValueKey('drop-action-insert')), findsOneWidget);
+    expect(find.byKey(const ValueKey('drop-action-open')), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  testWidgets('choosing insert keeps a single document (no new tab)',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'base.pdf', buildMultiPagePdf(2));
+
+    await dropPdf(tester, 'extra.pdf');
+    await tester.tap(find.byKey(const ValueKey('drop-action-insert')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350)); // dialog dismiss
+
+    // Insert merges into the open document rather than opening a tab.
+    expect(find.byKey(const ValueKey('drop-action-dialog')), findsNothing);
+    expect(tabTitle('extra.pdf'), findsNothing);
+    expect(tabTitle('base.pdf'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  testWidgets('choosing open adds the dropped PDF as a new tab',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'base.pdf', buildMultiPagePdf(2));
+
+    await dropPdf(tester, 'extra.pdf');
+    await tester.tap(find.byKey(const ValueKey('drop-action-open')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350)); // dialog dismiss
+
+    expect(find.byKey(const ValueKey('drop-action-dialog')), findsNothing);
+    expect(tabTitle('extra.pdf'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  testWidgets('dropping with nothing open skips the prompt and opens a tab',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+
+    await dropPdf(tester, 'lonely.pdf');
+
+    expect(find.byKey(const ValueKey('drop-action-dialog')), findsNothing);
+    expect(tabTitle('lonely.pdf'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+}

--- a/app/test/drop_insert_test.dart
+++ b/app/test/drop_insert_test.dart
@@ -10,6 +10,14 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 
+// These tests exercise the *branching* a drop takes — show the open/insert
+// dialog when a document is open, and route to the right action — by driving
+// the desktop_drop channel directly. They deliberately do not read real files:
+// the bytes a dropped item carries are read lazily through dart:io, whose
+// futures never complete under the widget tester's fake clock (and the read is
+// triggered from a UI tap, so it can't be wrapped in runAsync either). The
+// actual page copy is covered by the editor package's insertPagesFrom* tests;
+// here we assert the synchronous effects each branch produces.
 void main() {
   late PdfEditingPreferences prefs;
 

--- a/doc/dev-log/2026-06-22-app-drag-drop-open-or-insert.md
+++ b/doc/dev-log/2026-06-22-app-drag-drop-open-or-insert.md
@@ -1,0 +1,45 @@
+# App drag-and-drop: open or insert
+
+The `/app` already wrapped its editor body in a `desktop_drop`
+`DropTarget` (`app/lib/editor_screen.dart`) that opened every dropped PDF
+in a new tab. This session adds the second behavior the drop should offer
+— inserting the dropped pages into the document that's already open.
+
+## What changed
+
+`_onFilesDropped` now:
+
+1. Filters the dropped items to `.pdf` names up front.
+2. If there's an active, editable session (`tab.session != null` and not
+   read-only), shows `_promptDropAction` — an `AlertDialog`
+   (`ValueKey('drop-action-dialog')`) offering **Open in new tab(s)** /
+   **Insert pages** / Cancel.
+3. On *insert*, `_insertDropped` reads each PDF and calls
+   `PdfEditingController.insertPagesFromBytes` (appends, one undoable step
+   per file), reporting the result via a toast.
+4. On *open* (or with nothing open / in read-only mode), `_openDropped`
+   keeps the original per-file new-tab behavior.
+
+`_DropOverlay` gained a `canInsert` flag so the drag hint reads
+"Drop PDF to open or insert" when an editable document is open.
+
+## Testing gotchas (widget test of an OS drop)
+
+`app/test/drop_insert_test.dart` drives the `desktop_drop` channel
+directly (`performOperation_linux` with a path + centre-of-surface
+offset; `DropTarget` only fires `onDragDone` for an in-bounds point, and
+its Linux branch fires even without a prior `entered`). Two traps:
+
+- **No real file I/O.** `File.writeAsBytes`/`XFile.readAsBytes` return
+  real-event-loop Futures that never complete under the widget tester's
+  fake clock, so awaiting them hangs the test to its timeout. The drop
+  only needs a *path* (bytes are read lazily, later), so the test passes a
+  synthetic `/dartpdf-test/<name>.pdf` and never touches disk. It asserts
+  the synchronous branch effects instead: the dialog appears; the *open*
+  branch adds a loading tab (added before the byte read) so the title
+  shows in the tab strip; the *insert* branch adds no tab. The actual page
+  copy is covered by the editor package's `insertPagesFrom*` tests.
+- **Dialog dismiss needs time.** After tapping a dialog action, pump past
+  the ~200 ms route-pop transition (the test pumps 350 ms) before
+  asserting the dialog is gone. `pumpAndSettle` is unusable here because
+  the open branch's loading spinner animates forever.

--- a/doc/dev-log/2026-06-22-app-drag-drop-open-or-insert.md
+++ b/doc/dev-log/2026-06-22-app-drag-drop-open-or-insert.md
@@ -39,6 +39,14 @@ its Linux branch fires even without a prior `entered`). Two traps:
   branch adds a loading tab (added before the byte read) so the title
   shows in the tab strip; the *insert* branch adds no tab. The actual page
   copy is covered by the editor package's `insertPagesFrom*` tests.
+  `tester.runAsync` does **not** rescue this: the read is triggered by a
+  UI tap (which needs frame pumps `runAsync` can't do), and the
+  `await readAsBytes` continuation is bound to the fake-async zone, so even
+  with the file written and the real read completed inside `runAsync`, the
+  continuation (insert + toast) never runs — the document stays unchanged
+  and no snackbar appears. Codecov flags the ~16 read/toast glue lines as
+  uncovered; `codecov/patch` still passes, and the branching that matters
+  is covered.
 - **Dialog dismiss needs time.** After tapping a dialog action, pump past
   the ~200 ms route-pop transition (the test pumps 350 ms) before
   asserting the dialog is gone. `pumpAndSettle` is unusable here because


### PR DESCRIPTION
## What

The `/app` already accepted PDFs dropped onto the window (via the existing `desktop_drop` `DropTarget`), opening each in a new tab. This PR extends that so a drop can also **insert** the dropped pages into the document that's already open.

## Behavior

- **Nothing open / read-only mode:** unchanged — each dropped PDF opens in its own tab.
- **An editable document is open:** the drop shows a small dialog offering **Open in new tab(s)** vs **Insert pages** (or Cancel).
  - *Insert* appends each dropped PDF's pages into the current document via `PdfEditingController.insertPagesFromBytes` (one undoable step per file), with a toast summarizing the result and any unreadable files.
  - *Open* keeps the original per-file new-tab behavior.
- The drag overlay now reads **"Drop PDF to open or insert"** when an editable document is open.

## Implementation

All in `app/lib/editor_screen.dart`:
- `_onFilesDropped` filters to PDFs, then branches on whether an editable session is active.
- New `_promptDropAction`, `_insertDropped`, and `_openDropped` helpers.
- `_DropOverlay` gained a `canInsert` flag driving the hint text.

## Tests

`app/test/drop_insert_test.dart` drives the `desktop_drop` channel directly and covers: the action dialog appears on drop over an open doc; choosing *insert* keeps a single document (no new tab); choosing *open* adds a new tab; and dropping with nothing open skips the prompt and opens a tab. See the dev-log note for the widget-test gotchas (no real file I/O under the fake clock; pump past the dialog dismiss).

`dart analyze` is clean and all four tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013P57AxNA6icD3AkBCALcQh

---
_Generated by [Claude Code](https://claude.ai/code/session_013P57AxNA6icD3AkBCALcQh)_