### PR TITLE
Add alignment system for annotations

### DIFF
--- a/doc/dev-log/2026-06-24-annotation-alignment.md
+++ b/doc/dev-log/2026-06-24-annotation-alignment.md
@@ -1,0 +1,63 @@
+# Annotation alignment & distribution
+
+Added an alignment system for multi-selected annotations: line edges or
+centres up, and distribute spacing evenly. It rides entirely on the
+existing multi-select model and `moveAnnotation` — no new geometry in the
+PDF write path.
+
+## Pieces
+
+- **`pdf_document/src/annotation_align.dart`** (pure, VM-testable): the
+  `PdfAlignment` enum (left / horizontalCenter / right / top /
+  verticalCenter / bottom / distributeHorizontal / distributeVertical) and
+  `alignmentOffsets(List<PdfRect>, PdfAlignment)`, which returns a per-rect
+  `(dx, dy)` parallel to the input. All maths is in PDF user space (y up),
+  so `top` is the visually-highest edge. Exported from `pdf_document.dart`.
+  - Edge/centre alignment references the group's overall bounding box.
+  - Distribution holds the two extreme edges and equalises the *gaps*
+    between consecutive rects (gap-based, not centre-based — predictable
+    with differently-sized boxes). Free space = span − Σ widths, split
+    across `n-1` gaps; rects placed left-to-right (or bottom-to-top).
+  - Returns all-zero offsets below `alignment.minimumCount` (2 to align,
+    3 to distribute — the extremes anchor, so distribution only moves what
+    sits between them).
+
+- **`PdfEditingController.alignSelected(PdfAlignment)`** plus
+  `canAlignSelected` / `canDistributeSelected` getters
+  (`editing_controller.dart`, next to `moveSelected`). `_alignmentTargets()`
+  takes the selected annotations that share `selectedPage` — cross-page
+  alignment is meaningless, so the primary page wins and other pages'
+  selections are left alone. It computes offsets, drops the zero ones, and
+  applies the rest in **one** `apply(...)` revision via `moveAnnotation`
+  (so coordinate arrays — QuadPoints/L/Vertices/InkList — shift with the
+  /Rect, and one undo restores everything). Already-aligned selections move
+  nothing, so they add no revision.
+
+- **Toolbar** (`editing_toolbar.dart`): `_selectionStrip` grows an
+  `_alignmentCluster` when `canAlignSelected` — three edge buttons, a
+  divider, three more, a divider, two distribute buttons (disabled, but
+  still rendered for stable layout, until three are selected). Buttons key
+  off `pdf-align-<enum name>`. The strip card already scrolls horizontally,
+  so the extra width is free. `PdfAlignment` added to the toolbar's `show`
+  import.
+
+## Tests
+
+- `pdf_document/test/annotation_align_test.dart` — pure geometry (edges,
+  centres, gap equality, anchors held, too-few no-op, already-aligned →
+  zero offsets).
+- `dart_pdf_editor/test/editing_align_test.dart` — controller (can-flags,
+  single revision + undo, primary-page-only, no-op when aligned) and
+  toolbar (buttons appear only on multi-select, tap aligns, distribute
+  disables below three).
+
+## Notes / gotchas
+
+- `controller.bytes` is the raw incremental-save **buffer**, not a list of
+  revisions — its length grows by the appended revision's size, not by 1.
+  Assert `greaterThan`, and use `undo()` to prove single-revision grouping.
+- Mobile (`_mobileTrailing`) wasn't given the cluster — eight buttons don't
+  fit the dock row. The controller API works regardless; a mobile surface
+  (e.g. the tools sheet) can be wired later.
+- Distribution is gap-based and single-axis. Centre-based distribution and
+  smart drag-snapping guides are natural follow-ups but out of scope here.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2899,6 +2899,56 @@ class PdfEditingController extends ChangeNotifier {
     }, pages: [for (final (page, _) in targets) page]);
   }
 
+  /// The selected annotations that share the primary selection's page, in
+  /// selection order — the candidates an alignment acts on. Aligning across
+  /// pages has no geometric meaning, so the primary page wins and other
+  /// pages' selections are left alone.
+  List<PdfAnnotation> _alignmentTargets() {
+    final page = selectedPage;
+    if (page == null) return const [];
+    final out = <PdfAnnotation>[];
+    for (final slot in _selected) {
+      if (slot.$1 != page) continue;
+      final annotation = _annotationAt(slot);
+      if (annotation != null) out.add(annotation);
+    }
+    return out;
+  }
+
+  /// Whether [alignSelected] can line the selection up: two or more
+  /// annotations selected on the primary selection's page.
+  bool get canAlignSelected => _alignmentTargets().length >= 2;
+
+  /// Whether [alignSelected] can distribute the selection: three or more
+  /// annotations on the primary page (the extremes anchor, so distribution
+  /// only moves anything with a rect in between).
+  bool get canDistributeSelected => _alignmentTargets().length >= 3;
+
+  /// Lines up (or spreads out) the selected annotations on the primary
+  /// page per [alignment], as one revision. Needs two annotations to align
+  /// and three to distribute; a no-op below that, or when the selection is
+  /// already aligned (nothing would move). The selection survives — a move
+  /// keeps each annotation's /Annots slot.
+  void alignSelected(PdfAlignment alignment) {
+    final page = selectedPage;
+    if (page == null) return;
+    final targets = _alignmentTargets();
+    if (targets.length < alignment.minimumCount) return;
+    final offsets =
+        alignmentOffsets([for (final a in targets) a.rect], alignment);
+    final moves = <(PdfAnnotation, double, double)>[];
+    for (var i = 0; i < targets.length; i++) {
+      final (:dx, :dy) = offsets[i];
+      if (dx != 0 || dy != 0) moves.add((targets[i], dx, dy));
+    }
+    if (moves.isEmpty) return;
+    apply((e) {
+      for (final (annotation, dx, dy) in moves) {
+        e.moveAnnotation(page, annotation, dx, dy);
+      }
+    }, pages: [page]);
+  }
+
   /// Re-homes the single selected annotation onto [targetPage], shifted
   /// by ([dx], [dy]) in page space — what a move drag dropped over a
   /// *different* page produces. The annotation leaves its source page and

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart'
-    show PdfLineEnding, PdfStandardFont, PdfTextAlign;
+    show PdfAlignment, PdfLineEnding, PdfStandardFont, PdfTextAlign;
 
 import '../pdf_viewer.dart';
 import '../toast.dart';
@@ -1076,6 +1076,13 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                 ),
             ]),
           ),
+          if (controller.canAlignSelected) ...[
+            const _StripDivider(),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 7),
+              child: _alignmentCluster(context),
+            ),
+          ],
           if (settings.isNotEmpty) ...[
             const _StripDivider(),
             Padding(
@@ -1087,6 +1094,48 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       ),
     );
     return _centeredCard(context, padding: EdgeInsets.zero, child: row);
+  }
+
+  /// The align/distribute buttons shown while two or more annotations are
+  /// selected: edge + centre alignment, then even-spacing distribution
+  /// (which needs three, so those disable below that). Each button defers
+  /// to [PdfEditingController.alignSelected].
+  Widget _alignmentCluster(BuildContext context) {
+    final canDistribute = controller.canDistributeSelected;
+    return Row(mainAxisSize: MainAxisSize.min, children: [
+      _alignButton(
+          PdfAlignment.left, Icons.align_horizontal_left, 'Align left'),
+      _alignButton(PdfAlignment.horizontalCenter,
+          Icons.align_horizontal_center, 'Align horizontal centers'),
+      _alignButton(
+          PdfAlignment.right, Icons.align_horizontal_right, 'Align right'),
+      const _MiniDivider(),
+      _alignButton(PdfAlignment.top, Icons.align_vertical_top, 'Align top'),
+      _alignButton(PdfAlignment.verticalCenter, Icons.align_vertical_center,
+          'Align vertical centers'),
+      _alignButton(PdfAlignment.bottom, Icons.align_vertical_bottom,
+          'Align bottom'),
+      const _MiniDivider(),
+      _alignButton(PdfAlignment.distributeHorizontal,
+          Icons.horizontal_distribute, 'Distribute horizontally',
+          enabled: canDistribute),
+      _alignButton(PdfAlignment.distributeVertical, Icons.vertical_distribute,
+          'Distribute vertically',
+          enabled: canDistribute),
+    ]);
+  }
+
+  /// One alignment button. Disabled buttons (distribution with too few
+  /// annotations) still render so the cluster's layout stays stable.
+  Widget _alignButton(PdfAlignment alignment, IconData icon, String tooltip,
+      {bool enabled = true}) {
+    return IconButton(
+      key: ValueKey('pdf-align-${alignment.name}'),
+      icon: Icon(icon),
+      tooltip: tooltip,
+      visualDensity: VisualDensity.compact,
+      onPressed: enabled ? () => controller.alignSelected(alignment) : null,
+    );
   }
 
   /// The strip shown while a page-content element is selected.

--- a/packages/dart_pdf_editor/test/editing_align_test.dart
+++ b/packages/dart_pdf_editor/test/editing_align_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  group('PdfEditingController alignment', () {
+    /// Three differently-sized, scattered shapes on page 0.
+    ///   slot 0: left 100, bottom 600, 80x40   -> right 180, top 640
+    ///   slot 1: left 250, bottom 650, 60x30   -> right 310, top 680
+    ///   slot 2: left 400, bottom 500, 40x80   -> right 440, top 580
+    PdfEditingController threeShapes() =>
+        PdfEditingController(buildMultiPagePdf(2))
+          ..addRectangle(0, const PdfRect(100, 600, 180, 640))
+          ..addEllipse(0, const PdfRect(250, 650, 310, 680))
+          ..addRectangle(0, const PdfRect(400, 500, 440, 580));
+
+    const all = PdfRect(90, 490, 450, 690);
+
+    test('canAlign needs two; canDistribute needs three', () {
+      final editing = threeShapes();
+      addTearDown(editing.dispose);
+      expect(editing.canAlignSelected, isFalse);
+      expect(editing.canDistributeSelected, isFalse);
+
+      editing.selectAnnotationAt(0, 140, 620);
+      expect(editing.canAlignSelected, isFalse,
+          reason: 'one selected is not enough');
+
+      editing.selectAnnotationAt(0, 280, 665, toggle: true);
+      expect(editing.canAlignSelected, isTrue);
+      expect(editing.canDistributeSelected, isFalse,
+          reason: 'two is too few to distribute');
+
+      editing.selectAnnotationAt(0, 420, 540, toggle: true);
+      expect(editing.canDistributeSelected, isTrue);
+    });
+
+    test('align left puts every selected left edge on the minimum', () {
+      final editing = threeShapes();
+      addTearDown(editing.dispose);
+      editing.selectAnnotationsIn(0, all);
+      final revisions = editing.bytes.length;
+
+      editing.alignSelected(PdfAlignment.left);
+      final annotations = editing.document.page(0).annotations;
+      for (final a in annotations) {
+        expect(a.rect.left, closeTo(100, 0.5));
+      }
+      // sizes are preserved
+      expect(annotations[0].rect.width, closeTo(80, 0.5));
+      expect(annotations[2].rect.height, closeTo(80, 0.5));
+      // the move was saved (one incremental revision appended) and the
+      // selection survives
+      expect(editing.bytes.length, greaterThan(revisions));
+      expect(editing.selectedAnnotationSlots, [(0, 0), (0, 1), (0, 2)]);
+
+      // one undo restores them all
+      editing.undo();
+      expect(editing.document.page(0).annotations[1].rect.left,
+          closeTo(250, 0.5));
+    });
+
+    test('align top lines the highest edges up', () {
+      final editing = threeShapes();
+      addTearDown(editing.dispose);
+      editing.selectAnnotationsIn(0, all);
+      editing.alignSelected(PdfAlignment.top);
+      for (final a in editing.document.page(0).annotations) {
+        expect(a.rect.top, closeTo(680, 0.5));
+      }
+    });
+
+    test('horizontal centre aligns the midpoints', () {
+      final editing = threeShapes();
+      addTearDown(editing.dispose);
+      editing.selectAnnotationsIn(0, all);
+      editing.alignSelected(PdfAlignment.horizontalCenter);
+      // group spans left 100 .. right 440 -> centre 270
+      for (final a in editing.document.page(0).annotations) {
+        expect((a.rect.left + a.rect.right) / 2, closeTo(270, 0.5));
+      }
+    });
+
+    test('distribute horizontally equalises the gaps, holding the ends', () {
+      final editing = threeShapes();
+      addTearDown(editing.dispose);
+      editing.selectAnnotationsIn(0, all);
+      editing.alignSelected(PdfAlignment.distributeHorizontal);
+      final annotations = editing.document.page(0).annotations
+        ..sort((a, b) => a.rect.left.compareTo(b.rect.left));
+      // ends stay put
+      expect(annotations.first.rect.left, closeTo(100, 0.5));
+      expect(annotations.last.rect.right, closeTo(440, 0.5));
+      // gaps between consecutive boxes match
+      final gap1 = annotations[1].rect.left - annotations[0].rect.right;
+      final gap2 = annotations[2].rect.left - annotations[1].rect.right;
+      expect(gap1, closeTo(gap2, 0.5));
+    });
+
+    test('aligning an already-aligned selection adds no revision', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 600, 180, 640))
+        ..addRectangle(0, const PdfRect(100, 500, 160, 540));
+      addTearDown(editing.dispose);
+      editing.selectAnnotationsIn(0, const PdfRect(90, 490, 190, 650));
+      final revisions = editing.bytes.length;
+      editing.alignSelected(PdfAlignment.left); // already share left 100
+      expect(editing.bytes.length, revisions, reason: 'nothing moved');
+    });
+
+    test('alignment only touches the primary page', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2))
+        ..addRectangle(0, const PdfRect(100, 600, 180, 640))
+        ..addRectangle(0, const PdfRect(250, 600, 330, 640))
+        ..addRectangle(1, const PdfRect(400, 600, 440, 640));
+      addTearDown(editing.dispose);
+      // select two on page 0 and one on page 1; page 0 is primary (last
+      // selected via toggle decides, so select page 1's first then page 0)
+      editing.selectAnnotation(1, 0);
+      editing.selectAnnotationAt(0, 140, 620, toggle: true);
+      editing.selectAnnotationAt(0, 290, 620, toggle: true);
+      // primary page is 0
+      expect(editing.selectedPage, 0);
+      final page1Before = editing.document.page(1).annotations.single.rect;
+
+      editing.alignSelected(PdfAlignment.left);
+      for (final a in editing.document.page(0).annotations) {
+        expect(a.rect.left, closeTo(100, 0.5));
+      }
+      // the page-1 annotation is untouched
+      expect(editing.document.page(1).annotations.single.rect, page1Before);
+    });
+  });
+
+  group('alignment toolbar', () {
+    Future<PdfEditingController> pumpToolbar(WidgetTester tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 600, 180, 640))
+        ..addEllipse(0, const PdfRect(250, 650, 310, 680))
+        ..addRectangle(0, const PdfRect(400, 500, 440, 580));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfEditingToolbar(
+                controller: editing, viewerController: viewer),
+          ),
+        ),
+      ));
+      return editing;
+    }
+
+    testWidgets('align buttons appear only with a multi-selection',
+        (tester) async {
+      final editing = await pumpToolbar(tester);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-align-left')), findsNothing,
+          reason: 'a single selection has no alignment');
+
+      editing.selectAnnotationsIn(0, const PdfRect(90, 490, 450, 690));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-align-left')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-align-distributeHorizontal')),
+          findsOneWidget);
+    });
+
+    testWidgets('tapping align-right lines up the right edges', (tester) async {
+      final editing = await pumpToolbar(tester);
+      editing.selectAnnotationsIn(0, const PdfRect(90, 490, 450, 690));
+      await tester.pump();
+
+      await tester.tap(find.byKey(const ValueKey('pdf-align-right')));
+      await tester.pump();
+      for (final a in editing.document.page(0).annotations) {
+        expect(a.rect.right, closeTo(440, 0.5));
+      }
+    });
+
+    testWidgets('the distribute buttons disable below three selected',
+        (tester) async {
+      final editing = await pumpToolbar(tester);
+      editing.selectAnnotationsIn(0, const PdfRect(90, 590, 320, 690)); // two
+      await tester.pump();
+
+      final button = tester.widget<IconButton>(
+          find.byKey(const ValueKey('pdf-align-distributeHorizontal')));
+      expect(button.onPressed, isNull, reason: 'disabled with two selected');
+      // edge alignment is still live
+      final left = tester.widget<IconButton>(
+          find.byKey(const ValueKey('pdf-align-left')));
+      expect(left.onPressed, isNotNull);
+    });
+  });
+}

--- a/packages/pdf_document/lib/pdf_document.dart
+++ b/packages/pdf_document/lib/pdf_document.dart
@@ -3,6 +3,7 @@
 library;
 
 export 'src/annotation.dart';
+export 'src/annotation_align.dart';
 export 'src/attachment.dart';
 export 'src/cache_store.dart';
 export 'src/comments.dart';

--- a/packages/pdf_document/lib/src/annotation_align.dart
+++ b/packages/pdf_document/lib/src/annotation_align.dart
@@ -1,0 +1,136 @@
+import 'rect.dart';
+
+/// How a set of annotation rectangles should be lined up or spread out
+/// relative to one another. The first six values align an edge or centre
+/// line of every rect to a shared reference taken from the group's overall
+/// bounding box; the last two spread the rects so the gaps between them are
+/// equal.
+///
+/// All geometry is in PDF user space (origin bottom-left, y grows upward),
+/// so [top] is the visually-highest edge and [bottom] the lowest.
+enum PdfAlignment {
+  /// Move every rect so its left edge sits on the group's leftmost edge.
+  left,
+
+  /// Centre every rect horizontally on the group's horizontal midpoint.
+  horizontalCenter,
+
+  /// Move every rect so its right edge sits on the group's rightmost edge.
+  right,
+
+  /// Move every rect so its top edge sits on the group's highest edge.
+  top,
+
+  /// Centre every rect vertically on the group's vertical midpoint.
+  verticalCenter,
+
+  /// Move every rect so its bottom edge sits on the group's lowest edge.
+  bottom,
+
+  /// Spread the rects horizontally so the gaps between consecutive rects
+  /// are equal, holding the leftmost and rightmost edges fixed.
+  distributeHorizontal,
+
+  /// Spread the rects vertically so the gaps between consecutive rects are
+  /// equal, holding the lowest and highest edges fixed.
+  distributeVertical;
+
+  /// Whether this is a distribute (spread-evenly) operation rather than an
+  /// edge/centre alignment.
+  bool get isDistribute =>
+      this == distributeHorizontal || this == distributeVertical;
+
+  /// The fewest rects the operation is meaningful for: two to align, three
+  /// to distribute (the first and last are anchors, so distribution only
+  /// moves anything with a rect in between).
+  int get minimumCount => isDistribute ? 3 : 2;
+}
+
+/// Computes the translation to apply to each rect in [rects] to satisfy
+/// [alignment], returned as `(dx, dy)` offsets in PDF user space, parallel
+/// to (and in the same order as) [rects].
+///
+/// Returns all-zero offsets when there are too few rects for the operation
+/// ([PdfAlignment.minimumCount]). The caller applies the offsets by
+/// translating each annotation's /Rect (and its coordinate arrays) — see
+/// `PdfEditor.moveAnnotation`.
+List<({double dx, double dy})> alignmentOffsets(
+    List<PdfRect> rects, PdfAlignment alignment) {
+  final n = rects.length;
+  final offsets =
+      List<({double dx, double dy})>.filled(n, (dx: 0.0, dy: 0.0));
+  if (n < alignment.minimumCount) return offsets;
+
+  // The group's overall bounding box.
+  var minLeft = rects.first.left;
+  var minBottom = rects.first.bottom;
+  var maxRight = rects.first.right;
+  var maxTop = rects.first.top;
+  for (final r in rects) {
+    if (r.left < minLeft) minLeft = r.left;
+    if (r.bottom < minBottom) minBottom = r.bottom;
+    if (r.right > maxRight) maxRight = r.right;
+    if (r.top > maxTop) maxTop = r.top;
+  }
+
+  switch (alignment) {
+    case PdfAlignment.left:
+      for (var i = 0; i < n; i++) {
+        offsets[i] = (dx: minLeft - rects[i].left, dy: 0);
+      }
+    case PdfAlignment.right:
+      for (var i = 0; i < n; i++) {
+        offsets[i] = (dx: maxRight - rects[i].right, dy: 0);
+      }
+    case PdfAlignment.horizontalCenter:
+      final cx = (minLeft + maxRight) / 2;
+      for (var i = 0; i < n; i++) {
+        final c = (rects[i].left + rects[i].right) / 2;
+        offsets[i] = (dx: cx - c, dy: 0);
+      }
+    case PdfAlignment.top:
+      for (var i = 0; i < n; i++) {
+        offsets[i] = (dx: 0, dy: maxTop - rects[i].top);
+      }
+    case PdfAlignment.bottom:
+      for (var i = 0; i < n; i++) {
+        offsets[i] = (dx: 0, dy: minBottom - rects[i].bottom);
+      }
+    case PdfAlignment.verticalCenter:
+      final cy = (minBottom + maxTop) / 2;
+      for (var i = 0; i < n; i++) {
+        final c = (rects[i].bottom + rects[i].top) / 2;
+        offsets[i] = (dx: 0, dy: cy - c);
+      }
+    case PdfAlignment.distributeHorizontal:
+      // Hold the group's left and right edges; equalise the gaps between
+      // rects taken in left-to-right order. Total free space is the span
+      // minus the summed widths, divided across the n-1 gaps.
+      final order = [for (var i = 0; i < n; i++) i]
+        ..sort((a, b) => rects[a].left.compareTo(rects[b].left));
+      var summed = 0.0;
+      for (final r in rects) {
+        summed += r.width;
+      }
+      final gap = (maxRight - minLeft - summed) / (n - 1);
+      var cursor = minLeft;
+      for (final i in order) {
+        offsets[i] = (dx: cursor - rects[i].left, dy: 0);
+        cursor += rects[i].width + gap;
+      }
+    case PdfAlignment.distributeVertical:
+      final order = [for (var i = 0; i < n; i++) i]
+        ..sort((a, b) => rects[a].bottom.compareTo(rects[b].bottom));
+      var summed = 0.0;
+      for (final r in rects) {
+        summed += r.height;
+      }
+      final gap = (maxTop - minBottom - summed) / (n - 1);
+      var cursor = minBottom;
+      for (final i in order) {
+        offsets[i] = (dx: 0, dy: cursor - rects[i].bottom);
+        cursor += rects[i].height + gap;
+      }
+  }
+  return offsets;
+}

--- a/packages/pdf_document/test/annotation_align_test.dart
+++ b/packages/pdf_document/test/annotation_align_test.dart
@@ -1,0 +1,120 @@
+import 'package:pdf_document/pdf_document.dart';
+import 'package:test/test.dart';
+
+/// Applies the computed offsets to [rects], returning the moved rects.
+List<PdfRect> _apply(List<PdfRect> rects, PdfAlignment alignment) {
+  final offsets = alignmentOffsets(rects, alignment);
+  return [
+    for (var i = 0; i < rects.length; i++)
+      PdfRect(
+        rects[i].left + offsets[i].dx,
+        rects[i].bottom + offsets[i].dy,
+        rects[i].right + offsets[i].dx,
+        rects[i].top + offsets[i].dy,
+      ),
+  ];
+}
+
+void main() {
+  group('alignmentOffsets', () {
+    // Three differently-sized boxes scattered around the page (y up).
+    //   a: left 10, bottom 10, 40x20  -> right 50,  top 30
+    //   b: left 100, bottom 200, 60x40 -> right 160, top 240
+    //   c: left 300, bottom 80, 20x60  -> right 320, top 140
+    final rects = [
+      const PdfRect(10, 10, 50, 30),
+      const PdfRect(100, 200, 160, 240),
+      const PdfRect(300, 80, 320, 140),
+    ];
+
+    test('too few rects is a no-op', () {
+      final one = [const PdfRect(0, 0, 10, 10)];
+      expect(alignmentOffsets(one, PdfAlignment.left),
+          [(dx: 0.0, dy: 0.0)]);
+      // Distribution needs three.
+      final two = [const PdfRect(0, 0, 10, 10), const PdfRect(50, 0, 60, 10)];
+      expect(alignmentOffsets(two, PdfAlignment.distributeHorizontal),
+          everyElement((dx: 0.0, dy: 0.0)));
+    });
+
+    test('align left puts every left edge on the minimum', () {
+      final out = _apply(rects, PdfAlignment.left);
+      expect(out.map((r) => r.left), everyElement(10));
+      // widths and vertical position untouched
+      expect(out[1].width, 60);
+      expect(out[1].bottom, 200);
+    });
+
+    test('align right puts every right edge on the maximum', () {
+      final out = _apply(rects, PdfAlignment.right);
+      expect(out.map((r) => r.right), everyElement(320));
+    });
+
+    test('align top puts every top edge on the maximum', () {
+      final out = _apply(rects, PdfAlignment.top);
+      expect(out.map((r) => r.top), everyElement(240));
+      expect(out[0].left, 10); // x untouched
+    });
+
+    test('align bottom puts every bottom edge on the minimum', () {
+      final out = _apply(rects, PdfAlignment.bottom);
+      expect(out.map((r) => r.bottom), everyElement(10));
+    });
+
+    test('horizontal centre lines up the midpoints', () {
+      final out = _apply(rects, PdfAlignment.horizontalCenter);
+      // group spans left 10 .. right 320 -> centre x 165
+      for (final r in out) {
+        expect((r.left + r.right) / 2, closeTo(165, 1e-9));
+      }
+    });
+
+    test('vertical centre lines up the midpoints', () {
+      final out = _apply(rects, PdfAlignment.verticalCenter);
+      // group spans bottom 10 .. top 240 -> centre y 125
+      for (final r in out) {
+        expect((r.bottom + r.top) / 2, closeTo(125, 1e-9));
+      }
+    });
+
+    test('distribute horizontally equalises the gaps and holds the ends', () {
+      final out = _apply(rects, PdfAlignment.distributeHorizontal);
+      // ends stay put
+      final byLeft = [...out]..sort((a, b) => a.left.compareTo(b.left));
+      expect(byLeft.first.left, 10);
+      expect(byLeft.last.right, 320);
+      // gaps between consecutive boxes are equal
+      final gap1 = byLeft[1].left - byLeft[0].right;
+      final gap2 = byLeft[2].left - byLeft[1].right;
+      expect(gap1, closeTo(gap2, 1e-9));
+      // widths preserved
+      expect(byLeft.map((r) => r.width), containsAll([40, 60, 20]));
+    });
+
+    test('distribute vertically equalises the gaps and holds the ends', () {
+      final out = _apply(rects, PdfAlignment.distributeVertical);
+      final byBottom = [...out]..sort((a, b) => a.bottom.compareTo(b.bottom));
+      expect(byBottom.first.bottom, 10);
+      expect(byBottom.last.top, 240);
+      final gap1 = byBottom[1].bottom - byBottom[0].top;
+      final gap2 = byBottom[2].bottom - byBottom[1].top;
+      expect(gap1, closeTo(gap2, 1e-9));
+    });
+
+    test('already-aligned input yields zero offsets', () {
+      final aligned = [
+        const PdfRect(10, 0, 50, 20),
+        const PdfRect(10, 100, 70, 140),
+      ];
+      expect(alignmentOffsets(aligned, PdfAlignment.left),
+          everyElement((dx: 0.0, dy: 0.0)));
+    });
+
+    test('minimumCount and isDistribute', () {
+      expect(PdfAlignment.left.minimumCount, 2);
+      expect(PdfAlignment.left.isDistribute, isFalse);
+      expect(PdfAlignment.distributeHorizontal.minimumCount, 3);
+      expect(PdfAlignment.distributeHorizontal.isDistribute, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds an **alignment system** for multi-selected annotations in the editor. With two or more annotations selected you can line them up by edge or centre; with three or more you can distribute them with even spacing — all in a single undoable revision.

| Operation | Behaviour |
|---|---|
| Align left / right | left/right edges meet the group's extreme edge |
| Align top / bottom | top/bottom edges meet the group's extreme edge (PDF y-up) |
| Align horizontal / vertical centres | midpoints line up on the group's centre |
| Distribute horizontally / vertically | gaps between consecutive boxes equalised, extreme edges held |

## How

- **`pdf_document/lib/src/annotation_align.dart`** — a pure, VM-testable `PdfAlignment` enum + `alignmentOffsets(List<PdfRect>, PdfAlignment)` that returns per-rect `(dx, dy)` in PDF user space. Edge/centre alignment references the group bounding box; distribution is gap-based (predictable with differently-sized boxes) and anchors the two extreme edges. Returns zero offsets below the minimum count (2 to align, 3 to distribute). Exported from `pdf_document.dart`.
- **`PdfEditingController.alignSelected(PdfAlignment)`** + `canAlignSelected` / `canDistributeSelected`. Acts on the selected annotations sharing the **primary** page (cross-page alignment is meaningless), drops zero-offset moves, and applies the rest in one `apply(...)` revision via `moveAnnotation` — so coordinate arrays (QuadPoints/L/Vertices/InkList) shift with the /Rect and one undo restores everything. An already-aligned selection adds no revision.
- **`PdfEditingToolbar`** — the multi-selection strip grows an alignment cluster (three edge buttons · three more · two distribute buttons). Distribute buttons render disabled until three are selected; the strip card already scrolls horizontally so the extra width is free.

## Scope notes

- Mobile dock isn't given the cluster (eight buttons don't fit the row); the controller API works regardless, so a mobile surface can be wired later.
- Distribution is gap-based and single-axis. Centre-based distribution and drag-time snapping guides are natural follow-ups, out of scope here.

## Tests

- `pdf_document/test/annotation_align_test.dart` — geometry (edges, centres, gap equality, anchors held, too-few no-op, already-aligned → zero offsets). `fvm dart test` ✅
- `dart_pdf_editor/test/editing_align_test.dart` — controller (can-flags, single revision + undo, primary-page-only) and toolbar (buttons appear only on multi-select, tap aligns, distribute disables below three). `fvm flutter test` ✅
- `fvm dart analyze` clean; existing multi-select / chrome / shape-style suites still green.

See `doc/dev-log/2026-06-24-annotation-alignment.md` for design notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WK2zAmzJjsWdWdpFoFNqJX)_