### PR TITLE
Close (×) button on docked sidebar panels (desktop)

### DIFF
--- a/doc/dev-log/2026-06-24-docked-panel-close-button.md
+++ b/doc/dev-log/2026-06-24-docked-panel-close-button.md
@@ -1,0 +1,44 @@
+# Docked sidebar panels get a close (×) button on desktop
+
+On a narrow screen the side panels float up as bottom sheets, and
+`PdfPanelBottomSheet` gives each a titled header with a close ×. On a wide
+(desktop) screen the same panels dock into the `Row` beside the viewer
+(`pdf_editor_view.dart`, `pdf_reader.dart`) and had no in-panel way to
+dismiss them — only the header's panel-toggle buttons. This adds the
+matching little × to the docked layout.
+
+## Shape
+
+- New shared `PdfSidebarCloseButton` in `editing_panel.dart` — a compact
+  `IconButton(Icons.close, size 18)` with a "Close" tooltip. The desktop
+  counterpart of the sheet chrome's close button.
+- Each of the four panels (`PdfThumbnailSidebar`, `PdfSearchResultsPanel`,
+  `PdfAnnotationSidebar`, `PdfAnnotationPropertiesPanel`) gained an
+  optional `onClose`. The button renders **only** when `onClose != null &&
+  !bottomSheet` — a bottom sheet still supplies its own × via
+  `PdfPanelBottomSheet`, so the guard prevents a double close button when
+  the breakpoint flips.
+- Both shells wire `onClose: bottomSheet ? null : () => prefs.showXPanel =
+  false`, flipping the same visibility preference the header toggle drives.
+
+## Where the × sits per panel
+
+The panels don't share a header shape, so the button slots into each
+panel's existing top region rather than adding a uniform title bar:
+
+- **Thumbnails**: into the existing "Pages" header row, wrapped so the ×
+  stays put even when the row swaps to the multi-select bar (2+ pages
+  selected). Left-docked, so the row's right padding already clears the
+  scrollbar + resize grip via `_extraRightPadding`.
+- **Annotations**: beside the filter `TextField` (a `Row` with the field
+  `Expanded`). Right-docked → grip on the left, no extra inset needed.
+- **Search results** / **Properties**: neither has a persistent docked
+  header (search hides its options bar when docked; properties goes
+  straight to content), so each gets a slim header row `[Expanded(title),
+  ×]` above the body. Search is left-docked, so its header right padding
+  adds `PdfSidebarResizeGrip.width` when the grip rides that edge so the ×
+  clears it; properties is right-docked and needs no inset.
+
+Keys for tests: `pdf-thumbnail-panel-close`, `pdf-annotation-panel-close`,
+`pdf-search-panel-close`, `pdf-properties-panel-close`. Covered by
+`pdf_shell_test.dart` "wide: a docked panel's close button hides it".

--- a/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
@@ -4,6 +4,29 @@ import 'package:flutter/material.dart';
 /// grip rides the opposite (inner) edge — the one facing the viewer.
 enum PdfSidebarSide { left, right }
 
+/// A compact close (×) button for a docked sidebar panel's header — the
+/// desktop counterpart of the bottom sheet's close button (which the
+/// sheet chrome supplies on its own). A panel renders this in its header
+/// only when the host wires an `onClose` and the panel is docked, not a
+/// sheet.
+class PdfSidebarCloseButton extends StatelessWidget {
+  const PdfSidebarCloseButton({
+    super.key,
+    required this.onPressed,
+  });
+
+  /// Dismisses the panel — the shells turn its visibility preference off.
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) => IconButton(
+        icon: const Icon(Icons.close, size: 18),
+        tooltip: 'Close',
+        visualDensity: VisualDensity.compact,
+        onPressed: onPressed,
+      );
+}
+
 /// The draggable divider on a sidebar's inner edge: an invisible 8px
 /// hit strip with a hairline down the middle that thickens and tints on
 /// hover and while dragging. Reports width deltas already signed toward

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -44,6 +44,7 @@ class PdfAnnotationPropertiesPanel extends StatefulWidget {
     this.maxWidth = 420,
     this.showAuthor = true,
     this.bottomSheet = false,
+    this.onClose,
     this.fontPicker,
   });
 
@@ -77,6 +78,12 @@ class PdfAnnotationPropertiesPanel extends StatefulWidget {
   /// grip) for hosting inside a bottom sheet on a small screen, rather
   /// than as a fixed-width docked column.
   final bool bottomSheet;
+
+  /// Closes the docked panel — the host turns its visibility preference
+  /// off. When given (and not a [bottomSheet]) a close (×) button appears
+  /// in the panel's header. Null leaves the panel with no close button (a
+  /// bottom sheet supplies its own).
+  final VoidCallback? onClose;
 
   @override
   State<PdfAnnotationPropertiesPanel> createState() =>
@@ -269,8 +276,7 @@ class _PdfAnnotationPropertiesPanelState
         onFormatChanged: (format) => _preferences.colorPickerFormat = format);
     if (picked != null) {
       _controller.restyleSelectedText(
-          border: (_rgb(picked),),
-          borderWidth: _controller.strokeWidth);
+          border: (_rgb(picked),), borderWidth: _controller.strokeWidth);
     }
   }
 
@@ -562,8 +568,7 @@ class _PdfAnnotationPropertiesPanelState
           TextAlignToggles(
             keyPrefix: 'pdf-prop-text-align',
             align: _controller.selectedTextAlign ?? PdfTextAlign.left,
-            onChanged: (align) =>
-                _controller.restyleSelectedText(align: align),
+            onChanged: (align) => _controller.restyleSelectedText(align: align),
           ),
         ]),
       ),
@@ -788,53 +793,74 @@ class _PdfAnnotationPropertiesPanelState
   @override
   Widget build(BuildContext context) {
     final showGrip = widget.resizable && !widget.bottomSheet;
-    final onLeftEdge = !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    final onLeftEdge =
+        !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    // the docked panel's close button rides a slim header; a bottom sheet
+    // supplies its own in its sheet chrome
+    final closeable = !widget.bottomSheet && widget.onClose != null;
     final content = Material(
-            color: Theme.of(context).colorScheme.surfaceContainerLow,
-            child: ListenableBuilder(
-              listenable: _controller,
-              builder: (context, _) {
-                final annotation = _controller.selectedAnnotation;
-                _syncFields(annotation);
-                if (annotation == null) {
-                  return const Center(
-                    child: Padding(
-                      padding: EdgeInsets.all(24),
-                      child: Text('Select an annotation to see its properties',
-                          textAlign: TextAlign.center),
-                    ),
-                  );
-                }
-                final count = _controller.selectedAnnotationSlots.length;
-                final children = count == 1
-                    ? _buildSingle(annotation)
-                    : _buildMulti(annotation, count);
-                final barClearance = PdfScrollbar.hitExtent +
-                    (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
-                return Stack(children: [
-                  ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(context)
-                        .copyWith(scrollbars: false),
-                    child: ListView(
-                        controller: _scroll,
-                        padding: EdgeInsets.only(right: barClearance),
-                        children: children),
+      color: Theme.of(context).colorScheme.surfaceContainerLow,
+      child: Column(children: [
+        if (closeable)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 4, 0),
+            child: Row(children: [
+              Expanded(
+                child: Text('Properties',
+                    style: Theme.of(context).textTheme.titleSmall),
+              ),
+              PdfSidebarCloseButton(
+                key: const ValueKey('pdf-properties-panel-close'),
+                onPressed: widget.onClose!,
+              ),
+            ]),
+          ),
+        Expanded(
+          child: ListenableBuilder(
+            listenable: _controller,
+            builder: (context, _) {
+              final annotation = _controller.selectedAnnotation;
+              _syncFields(annotation);
+              if (annotation == null) {
+                return const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Text('Select an annotation to see its properties',
+                        textAlign: TextAlign.center),
                   ),
-                  Positioned(
-                    top: 0,
-                    bottom: 0,
-                    right:
-                        showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
-                    child: PdfScrollbar(
-                      scroll: _scroll,
-                      thumbKey:
-                          const ValueKey('pdf-properties-scrollbar-thumb'),
-                    ),
+                );
+              }
+              final count = _controller.selectedAnnotationSlots.length;
+              final children = count == 1
+                  ? _buildSingle(annotation)
+                  : _buildMulti(annotation, count);
+              final barClearance = PdfScrollbar.hitExtent +
+                  (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
+              return Stack(children: [
+                ScrollConfiguration(
+                  behavior: ScrollConfiguration.of(context)
+                      .copyWith(scrollbars: false),
+                  child: ListView(
+                      controller: _scroll,
+                      padding: EdgeInsets.only(right: barClearance),
+                      children: children),
+                ),
+                Positioned(
+                  top: 0,
+                  bottom: 0,
+                  right:
+                      showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
+                  child: PdfScrollbar(
+                    scroll: _scroll,
+                    thumbKey: const ValueKey('pdf-properties-scrollbar-thumb'),
                   ),
-                ]);
-              },
-            ),
-          );
+                ),
+              ]);
+            },
+          ),
+        ),
+      ]),
+    );
     if (widget.bottomSheet) return content;
     return SizedBox(
       width: _width,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -49,6 +49,7 @@ class PdfAnnotationSidebar extends StatefulWidget {
     this.minWidth = 200,
     this.maxWidth = 480,
     this.bottomSheet = false,
+    this.onClose,
   });
 
   final PdfEditingController controller;
@@ -75,6 +76,12 @@ class PdfAnnotationSidebar extends StatefulWidget {
   /// grip) for hosting inside a bottom sheet on a small screen, rather
   /// than as a fixed-width docked column.
   final bool bottomSheet;
+
+  /// Closes the docked panel — the host turns its visibility preference
+  /// off. When given (and not a [bottomSheet]) a close (×) button appears
+  /// beside the filter field. Null leaves the panel with no close button
+  /// (a bottom sheet supplies its own).
+  final VoidCallback? onClose;
 
   @override
   State<PdfAnnotationSidebar> createState() => _PdfAnnotationSidebarState();
@@ -265,27 +272,39 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   }
 
   Widget _searchField(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-      child: TextField(
-        key: const ValueKey('pdf-annotation-search'),
-        controller: _search,
-        onChanged: (_) => setState(() {}),
-        decoration: InputDecoration(
-          hintText: 'Search annotations',
-          isDense: true,
-          prefixIcon: const Icon(Icons.search, size: 18),
-          suffixIcon: _search.text.isEmpty
-              ? null
-              : IconButton(
-                  key: const ValueKey('pdf-annotation-search-clear'),
-                  icon: const Icon(Icons.close, size: 18),
-                  tooltip: 'Clear search',
-                  onPressed: () => setState(_search.clear),
-                ),
-          border: const OutlineInputBorder(),
-        ),
+    // the docked panel's close button rides the right of the filter row;
+    // a bottom sheet supplies its own in its sheet chrome
+    final closeable = !widget.bottomSheet && widget.onClose != null;
+    final field = TextField(
+      key: const ValueKey('pdf-annotation-search'),
+      controller: _search,
+      onChanged: (_) => setState(() {}),
+      decoration: InputDecoration(
+        hintText: 'Search annotations',
+        isDense: true,
+        prefixIcon: const Icon(Icons.search, size: 18),
+        suffixIcon: _search.text.isEmpty
+            ? null
+            : IconButton(
+                key: const ValueKey('pdf-annotation-search-clear'),
+                icon: const Icon(Icons.close, size: 18),
+                tooltip: 'Clear search',
+                onPressed: () => setState(_search.clear),
+              ),
+        border: const OutlineInputBorder(),
       ),
+    );
+    return Padding(
+      padding: EdgeInsets.fromLTRB(12, 8, closeable ? 4 : 12, 4),
+      child: closeable
+          ? Row(children: [
+              Expanded(child: field),
+              PdfSidebarCloseButton(
+                key: const ValueKey('pdf-annotation-panel-close'),
+                onPressed: widget.onClose!,
+              ),
+            ])
+          : field,
     );
   }
 
@@ -421,7 +440,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
     if (replying) {
       widgets.add(Padding(
         padding: const EdgeInsets.fromLTRB(56, 2, 12, 8),
-        child: Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
+        child:
+            Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: [
           TextField(
             key: const ValueKey('pdf-reply-field'),
             controller: _reply,
@@ -517,8 +537,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
         child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
           if (header.isNotEmpty)
             Text(header,
-                style: textTheme.labelSmall
-                    ?.copyWith(color: cs.onSurfaceVariant)),
+                style:
+                    textTheme.labelSmall?.copyWith(color: cs.onSurfaceVariant)),
           Text(comment.text, style: textTheme.bodySmall),
         ]),
       ),
@@ -556,115 +576,114 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
     // a bottom sheet supplies its own width and resize affordance, so the
     // panel drops the side resize grip and fills its parent
     final showGrip = widget.resizable && !widget.bottomSheet;
-    final onLeftEdge = !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    final onLeftEdge =
+        !widget.bottomSheet && widget.side == PdfSidebarSide.left;
     final content = Material(
-            color: Theme.of(context).colorScheme.surfaceContainerLow,
-            child: ListenableBuilder(
-              listenable: widget.controller,
-              builder: (context, _) {
-                final document = widget.controller.document;
-                if (!identical(document, _builtFor)) {
-                  // already rebuilding — adjust the state in place
-                  _builtFor = document;
-                  _checked.clear();
-                  _selecting = false;
-                  _pageTexts.clear();
-                  // a revision closes any open reply field (the sent reply
-                  // is what produced the new revision)
-                  _replyingTo = null;
-                }
-                final query = _search.text.trim().toLowerCase();
-                final children = <Widget>[];
-                var listed = 0;
-                for (var page = 0; page < document.pageCount; page++) {
-                  final annotations =
-                      widget.controller.pageAt(page).annotations;
-                  // map each thread to its root's dictionary so a tile can
-                  // render its replies and state inline
-                  final threadByDict = {
-                    for (final thread in widget.controller.commentThreads(page))
-                      thread.root.annotation.dict: thread,
-                  };
-                  final tiles = <Widget>[];
-                  for (var i = 0; i < annotations.length; i++) {
-                    final annotation = annotations[i];
-                    if (_unlisted.contains(annotation.subtype)) continue;
-                    // replies and review-state annotations are thread
-                    // content — shown nested under their root, not as their
-                    // own top-level rows
-                    if (annotation.isReply || annotation.isStateAnnotation) {
-                      continue;
-                    }
-                    listed++;
-                    if (!_matches(query, page, annotation)) continue;
-                    tiles.add(_tile(context, page, i, annotation));
-                    // a markup annotation hosts a comment thread
-                    if (!_unselectable.contains(annotation.subtype)) {
-                      tiles.addAll(_threadSection(
-                          context, page, annotation, threadByDict[annotation.dict]));
-                    }
-                  }
-                  if (tiles.isNotEmpty) {
-                    children
-                      ..add(Padding(
-                        padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-                        child: Text('Page ${page + 1}',
-                            style: Theme.of(context).textTheme.labelLarge),
-                      ))
-                      ..addAll(tiles);
-                  }
-                }
-                // the viewer-style scrollbar replaces the implicit
-                // desktop bar; it wraps only the list, so the
-                // multi-select header above stays clear of it. Stepped
-                // off the resize grip when the grip rides the same
-                // (right) edge.
-                // keep the list clear of the overlay scrollbar's zone so
-                // the bar never covers a tile's trailing button
-                final barClearance = PdfScrollbar.hitExtent +
-                    (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
-                final list = children.isEmpty
-                    ? Center(
-                        child: Text(listed > 0 && query.isNotEmpty
-                            ? 'No matching annotations'
-                            : 'No annotations'))
-                    : Stack(children: [
-                        ScrollConfiguration(
-                          behavior: ScrollConfiguration.of(context)
-                              .copyWith(scrollbars: false),
-                          child: ListView(
-                              controller: _scroll,
-                              padding: EdgeInsets.only(right: barClearance),
-                              children: children),
-                        ),
-                        Positioned(
-                          top: 0,
-                          bottom: 0,
-                          right: showGrip && onLeftEdge
-                              ? PdfSidebarResizeGrip.width
-                              : 0,
-                          child: PdfScrollbar(
-                            scroll: _scroll,
-                            thumbKey: const ValueKey(
-                                'pdf-annotation-scrollbar-thumb'),
-                          ),
-                        ),
-                      ]);
-                // one shape for both modes, with the list keyed: the
-                // header appearing must not move the list to a new
-                // element (the controller would sit attached to two
-                // scroll views for a frame)
-                return Column(children: [
-                  _searchField(context),
-                  if (_selecting) _selectionHeader(context),
-                  Expanded(
-                    key: const ValueKey('pdf-annotation-list'),
-                    child: list,
+      color: Theme.of(context).colorScheme.surfaceContainerLow,
+      child: ListenableBuilder(
+        listenable: widget.controller,
+        builder: (context, _) {
+          final document = widget.controller.document;
+          if (!identical(document, _builtFor)) {
+            // already rebuilding — adjust the state in place
+            _builtFor = document;
+            _checked.clear();
+            _selecting = false;
+            _pageTexts.clear();
+            // a revision closes any open reply field (the sent reply
+            // is what produced the new revision)
+            _replyingTo = null;
+          }
+          final query = _search.text.trim().toLowerCase();
+          final children = <Widget>[];
+          var listed = 0;
+          for (var page = 0; page < document.pageCount; page++) {
+            final annotations = widget.controller.pageAt(page).annotations;
+            // map each thread to its root's dictionary so a tile can
+            // render its replies and state inline
+            final threadByDict = {
+              for (final thread in widget.controller.commentThreads(page))
+                thread.root.annotation.dict: thread,
+            };
+            final tiles = <Widget>[];
+            for (var i = 0; i < annotations.length; i++) {
+              final annotation = annotations[i];
+              if (_unlisted.contains(annotation.subtype)) continue;
+              // replies and review-state annotations are thread
+              // content — shown nested under their root, not as their
+              // own top-level rows
+              if (annotation.isReply || annotation.isStateAnnotation) {
+                continue;
+              }
+              listed++;
+              if (!_matches(query, page, annotation)) continue;
+              tiles.add(_tile(context, page, i, annotation));
+              // a markup annotation hosts a comment thread
+              if (!_unselectable.contains(annotation.subtype)) {
+                tiles.addAll(_threadSection(
+                    context, page, annotation, threadByDict[annotation.dict]));
+              }
+            }
+            if (tiles.isNotEmpty) {
+              children
+                ..add(Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                  child: Text('Page ${page + 1}',
+                      style: Theme.of(context).textTheme.labelLarge),
+                ))
+                ..addAll(tiles);
+            }
+          }
+          // the viewer-style scrollbar replaces the implicit
+          // desktop bar; it wraps only the list, so the
+          // multi-select header above stays clear of it. Stepped
+          // off the resize grip when the grip rides the same
+          // (right) edge.
+          // keep the list clear of the overlay scrollbar's zone so
+          // the bar never covers a tile's trailing button
+          final barClearance = PdfScrollbar.hitExtent +
+              (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
+          final list = children.isEmpty
+              ? Center(
+                  child: Text(listed > 0 && query.isNotEmpty
+                      ? 'No matching annotations'
+                      : 'No annotations'))
+              : Stack(children: [
+                  ScrollConfiguration(
+                    behavior: ScrollConfiguration.of(context)
+                        .copyWith(scrollbars: false),
+                    child: ListView(
+                        controller: _scroll,
+                        padding: EdgeInsets.only(right: barClearance),
+                        children: children),
+                  ),
+                  Positioned(
+                    top: 0,
+                    bottom: 0,
+                    right:
+                        showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
+                    child: PdfScrollbar(
+                      scroll: _scroll,
+                      thumbKey:
+                          const ValueKey('pdf-annotation-scrollbar-thumb'),
+                    ),
                   ),
                 ]);
-              },
+          // one shape for both modes, with the list keyed: the
+          // header appearing must not move the list to a new
+          // element (the controller would sit attached to two
+          // scroll views for a frame)
+          return Column(children: [
+            _searchField(context),
+            if (_selecting) _selectionHeader(context),
+            Expanded(
+              key: const ValueKey('pdf-annotation-list'),
+              child: list,
             ),
-          );
+          ]);
+        },
+      ),
+    );
     if (widget.bottomSheet) return content;
     return SizedBox(
       width: _width,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -64,6 +64,7 @@ class PdfThumbnailSidebar extends StatefulWidget {
     this.followsViewer = true,
     this.allowPageEditing = true,
     this.bottomSheet = false,
+    this.onClose,
     this.onPickPdfToInsert,
     this.onExportPages,
     this.renderWorker,
@@ -115,6 +116,12 @@ class PdfThumbnailSidebar extends StatefulWidget {
   /// grip) for hosting inside a bottom sheet on a small screen, rather
   /// than as a fixed-width docked column.
   final bool bottomSheet;
+
+  /// Closes the docked panel — the host turns its visibility preference
+  /// off. When given (and not a [bottomSheet]) a close (×) button appears
+  /// in the strip's header. Null leaves the strip with no close button (a
+  /// bottom sheet supplies its own).
+  final VoidCallback? onClose;
 
   /// Picks a PDF to insert and returns its bytes (null = cancelled). When
   /// given, a "Insert PDF…" entry appears in the strip's page-actions
@@ -178,8 +185,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   /// happens while Shift is held, where the preview is actually visible —
   /// plain hovering never churns the list.
   void _setHover(int index, bool hovering) {
-    final next =
-        hovering ? index : (_hoverPage == index ? null : _hoverPage);
+    final next = hovering ? index : (_hoverPage == index ? null : _hoverPage);
     if (next == _hoverPage) return;
     _hoverPage = next;
     if (_shiftHeld && mounted) setState(() {});
@@ -345,33 +351,49 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                       8 + inset, 2, _extraRightPadding + inset, 2),
                   child: SizedBox(
                     height: 36,
-                    child: controller.selectedPageCount > 1
-                        ? _PageSelectionBar(
-                            controller: controller,
-                            allowPageEditing: widget.allowPageEditing,
-                            onExportPages: widget.onExportPages,
-                            compact: true,
-                          )
-                        : Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  'Pages',
-                                  style:
-                                      Theme.of(context).textTheme.labelMedium,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              ),
-                              if (widget.onPickPdfToInsert != null ||
-                                  widget.onExportPages != null)
-                                _PageActionsButton(
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: controller.selectedPageCount > 1
+                              ? _PageSelectionBar(
                                   controller: controller,
-                                  viewerController: widget.viewerController,
-                                  onPickPdfToInsert: widget.onPickPdfToInsert,
+                                  allowPageEditing: widget.allowPageEditing,
                                   onExportPages: widget.onExportPages,
+                                  compact: true,
+                                )
+                              : Row(
+                                  children: [
+                                    Expanded(
+                                      child: Text(
+                                        'Pages',
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .labelMedium,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                    if (widget.onPickPdfToInsert != null ||
+                                        widget.onExportPages != null)
+                                      _PageActionsButton(
+                                        controller: controller,
+                                        viewerController:
+                                            widget.viewerController,
+                                        onPickPdfToInsert:
+                                            widget.onPickPdfToInsert,
+                                        onExportPages: widget.onExportPages,
+                                      ),
+                                  ],
                                 ),
-                            ],
+                        ),
+                        // the docked strip's close button; a bottom sheet
+                        // supplies its own in its sheet chrome
+                        if (!widget.bottomSheet && widget.onClose != null)
+                          PdfSidebarCloseButton(
+                            key: const ValueKey('pdf-thumbnail-panel-close'),
+                            onPressed: widget.onClose!,
                           ),
+                      ],
+                    ),
                   ),
                 ),
                 Expanded(

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -540,6 +540,10 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 showAnnotations: prefs.showAnnotations,
                 allowPageEditing: features.pageEditing,
                 bottomSheet: bottomSheet,
+                // the sheet chrome carries its own close button
+                onClose: bottomSheet
+                    ? null
+                    : () => prefs.showThumbnailSidebar = false,
                 // page-level file actions live in the strip's footer; insert
                 // needs page editing on, export stands on its own
                 onPickPdfToInsert:
@@ -554,6 +558,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 controller: _viewer,
                 preferences: prefs,
                 bottomSheet: bottomSheet,
+                onClose: bottomSheet
+                    ? null
+                    : () => prefs.showSearchResultsPanel = false,
               );
           PdfAnnotationSidebar annotations({required bool bottomSheet}) =>
               PdfAnnotationSidebar(
@@ -562,6 +569,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 controller: session,
                 viewerController: _viewer,
                 bottomSheet: bottomSheet,
+                onClose: bottomSheet
+                    ? null
+                    : () => prefs.showAnnotationSidebar = false,
               );
           PdfAnnotationPropertiesPanel properties(
                   {required bool bottomSheet}) =>
@@ -571,6 +581,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 controller: session,
                 showAuthor: features.authorEditable,
                 bottomSheet: bottomSheet,
+                onClose: bottomSheet
+                    ? null
+                    : () => prefs.showPropertiesPanel = false,
                 fontPicker: widget.fontPicker,
               );
           // the dedicated full-area page grid, overlaid on the (still

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -287,6 +287,10 @@ class _PdfReaderState extends State<PdfReader> {
                 showAnnotations: prefs.showAnnotations,
                 allowPageEditing: false,
                 bottomSheet: bottomSheet,
+                // the sheet chrome carries its own close button
+                onClose: bottomSheet
+                    ? null
+                    : () => prefs.showThumbnailSidebar = false,
                 renderWorker: _worker,
               );
           return Column(children: [

--- a/packages/dart_pdf_editor/lib/src/search_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/search_panel.dart
@@ -217,6 +217,7 @@ class PdfSearchResultsPanel extends StatefulWidget {
     this.maxWidth = 480,
     this.bottomSheet = false,
     this.showOptions = true,
+    this.onClose,
   });
 
   final PdfViewerController controller;
@@ -246,6 +247,12 @@ class PdfSearchResultsPanel extends StatefulWidget {
   /// grip) for hosting inside a bottom sheet on a small screen, rather
   /// than as a fixed-width docked column.
   final bool bottomSheet;
+
+  /// Closes the docked panel — the host turns its visibility preference
+  /// off. When given (and not a [bottomSheet]) a close (×) button appears
+  /// in the panel's header. Null leaves the panel with no close button (a
+  /// bottom sheet supplies its own).
+  final VoidCallback? onClose;
 
   @override
   State<PdfSearchResultsPanel> createState() => _PdfSearchResultsPanelState();
@@ -414,29 +421,47 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
   Widget build(BuildContext context) {
     final controller = widget.controller;
     final showGrip = widget.resizable && !widget.bottomSheet;
-    final onLeftEdge = !widget.bottomSheet && widget.side == PdfSidebarSide.left;
+    final onLeftEdge =
+        !widget.bottomSheet && widget.side == PdfSidebarSide.left;
     final barInset = showGrip && onLeftEdge;
     final content = Material(
-            color: Theme.of(context).colorScheme.surfaceContainerLow,
-            child: ListenableBuilder(
-              listenable: controller,
-              builder: (context, _) => Column(children: [
-                if (widget.showOptions) ...[
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
-                    child: Align(
-                      alignment: Alignment.centerLeft,
-                      child: _SearchOptionsBar(
-                          controller: controller,
-                          preferences: widget.preferences),
-                    ),
-                  ),
-                  const Divider(height: 1),
-                ],
-                Expanded(child: _body(context, barInset: barInset)),
+      color: Theme.of(context).colorScheme.surfaceContainerLow,
+      child: ListenableBuilder(
+        listenable: controller,
+        builder: (context, _) => Column(children: [
+          // the docked panel's close button; a bottom sheet supplies
+          // its own in its sheet chrome
+          if (!widget.bottomSheet && widget.onClose != null)
+            Padding(
+              // clear the right-edge resize grip when it rides this side
+              padding: EdgeInsets.fromLTRB(
+                  16, 4, barInset ? PdfSidebarResizeGrip.width + 4 : 4, 0),
+              child: Row(children: [
+                Expanded(
+                  child: Text('Search results',
+                      style: Theme.of(context).textTheme.titleSmall),
+                ),
+                PdfSidebarCloseButton(
+                  key: const ValueKey('pdf-search-panel-close'),
+                  onPressed: widget.onClose!,
+                ),
               ]),
             ),
-          );
+          if (widget.showOptions) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: _SearchOptionsBar(
+                    controller: controller, preferences: widget.preferences),
+              ),
+            ),
+            const Divider(height: 1),
+          ],
+          Expanded(child: _body(context, barInset: barInset)),
+        ]),
+      ),
+    );
     if (widget.bottomSheet) return content;
     return SizedBox(
       width: _width,

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1089,27 +1089,88 @@ void main() {
           findsNothing);
     });
 
-    testWidgets('wide: a docked panel\'s close button hides it',
+    testWidgets('wide: every docked panel\'s close button hides it',
         (tester) async {
       final prefs = PdfEditingPreferences();
       addTearDown(prefs.dispose);
-      // the default 800x600 test surface is above the compact width
+      // the default 800x600 test surface is above the compact width, so
+      // panels dock to the side and carry their own little × (the sheet
+      // variants — and their close buttons — are not mounted here)
       await pump(tester,
           PdfEditorView(bytes: buildMultiPagePdf(2), preferences: prefs));
-      await tester.tap(
-          find.byKey(const ValueKey('pdf-shell-properties-toggle')),
-          kind: PointerDeviceKind.mouse);
-      await tester.pump();
-      expect(find.byType(PdfAnnotationPropertiesPanel), findsOneWidget);
 
-      // the docked panel carries its own little × (the sheet variants are
-      // not mounted on a wide screen)
-      final close = find.byKey(const ValueKey('pdf-properties-panel-close'));
+      // each panel: (toggle key, close key, panel type, "now closed" check).
+      // The thumbnails strip is shown by default; the rest start hidden, so
+      // their toggles open them first.
+      final cases = <({
+        String? toggle,
+        String close,
+        Type type,
+        bool Function() closed,
+      })>[
+        (
+          toggle: null,
+          close: 'pdf-thumbnail-panel-close',
+          type: PdfThumbnailSidebar,
+          closed: () => !prefs.showThumbnailSidebar,
+        ),
+        (
+          toggle: 'pdf-shell-search-results-toggle',
+          close: 'pdf-search-panel-close',
+          type: PdfSearchResultsPanel,
+          closed: () => !prefs.showSearchResultsPanel,
+        ),
+        (
+          toggle: 'pdf-shell-annotations-toggle',
+          close: 'pdf-annotation-panel-close',
+          type: PdfAnnotationSidebar,
+          closed: () => !prefs.showAnnotationSidebar,
+        ),
+        (
+          toggle: 'pdf-shell-properties-toggle',
+          close: 'pdf-properties-panel-close',
+          type: PdfAnnotationPropertiesPanel,
+          closed: () => !prefs.showPropertiesPanel,
+        ),
+      ];
+
+      for (final c in cases) {
+        if (c.toggle != null) {
+          await tester.tap(find.byKey(ValueKey(c.toggle!)),
+              kind: PointerDeviceKind.mouse);
+          await tester.pump();
+        }
+        expect(find.byType(c.type), findsOneWidget,
+            reason: 'panel ${c.type} should be docked open');
+        final close = find.byKey(ValueKey(c.close));
+        expect(close, findsOneWidget,
+            reason: '${c.type} should carry a docked close button');
+        await tester.tap(close, kind: PointerDeviceKind.mouse);
+        await tester.pump();
+        expect(find.byType(c.type), findsNothing,
+            reason: 'closing should hide ${c.type}');
+        expect(c.closed(), isTrue,
+            reason: 'closing should turn ${c.type}\'s preference off');
+      }
+    });
+
+    testWidgets('wide reader: the docked thumbnail strip has a close button',
+        (tester) async {
+      final prefs = PdfEditingPreferences();
+      await prefs.ready;
+      addTearDown(prefs.dispose);
+      // wide surface: the strip docks (shown by default) rather than
+      // floating up as a sheet
+      await pump(
+          tester, PdfReader(bytes: buildMultiPagePdf(3), preferences: prefs));
+      expect(find.byType(PdfThumbnailSidebar), findsOneWidget);
+
+      final close = find.byKey(const ValueKey('pdf-thumbnail-panel-close'));
       expect(close, findsOneWidget);
       await tester.tap(close, kind: PointerDeviceKind.mouse);
       await tester.pump();
-      expect(find.byType(PdfAnnotationPropertiesPanel), findsNothing);
-      expect(prefs.showPropertiesPanel, isFalse);
+      expect(find.byType(PdfThumbnailSidebar), findsNothing);
+      expect(prefs.showThumbnailSidebar, isFalse);
     });
 
     testWidgets('compact reader: the thumbnail strip is a bottom sheet',

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1089,6 +1089,29 @@ void main() {
           findsNothing);
     });
 
+    testWidgets('wide: a docked panel\'s close button hides it',
+        (tester) async {
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      // the default 800x600 test surface is above the compact width
+      await pump(tester,
+          PdfEditorView(bytes: buildMultiPagePdf(2), preferences: prefs));
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-shell-properties-toggle')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      expect(find.byType(PdfAnnotationPropertiesPanel), findsOneWidget);
+
+      // the docked panel carries its own little × (the sheet variants are
+      // not mounted on a wide screen)
+      final close = find.byKey(const ValueKey('pdf-properties-panel-close'));
+      expect(close, findsOneWidget);
+      await tester.tap(close, kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      expect(find.byType(PdfAnnotationPropertiesPanel), findsNothing);
+      expect(prefs.showPropertiesPanel, isFalse);
+    });
+
     testWidgets('compact reader: the thumbnail strip is a bottom sheet',
         (tester) async {
       final prefs = PdfEditingPreferences();


### PR DESCRIPTION
## What

On narrow screens the side panels float up as bottom sheets, each with a close × (`PdfPanelBottomSheet`). On a wide/desktop screen the same panels dock beside the viewer and had **no in-panel way to dismiss them** — only the header's panel-toggle buttons. This adds the matching little × to the docked layout, for all four panels in both shells.

## How

- New shared `PdfSidebarCloseButton` (`editing_panel.dart`) — a compact `IconButton(Icons.close)` with a "Close" tooltip; the desktop counterpart of the sheet chrome's close button.
- Each panel (`PdfThumbnailSidebar`, `PdfSearchResultsPanel`, `PdfAnnotationSidebar`, `PdfAnnotationPropertiesPanel`) gained an optional `onClose`. The × renders **only** when `onClose != null && !bottomSheet`, so a bottom sheet still uses its own close button (no double ×).
- `pdf_editor_view.dart` and `pdf_reader.dart` wire `onClose` to flip the same visibility preference (`showThumbnailSidebar`, `showSearchResultsPanel`, `showAnnotationSidebar`, `showPropertiesPanel`) the header toggles already drive.

The panels don't share a header shape, so the × slots into each panel's existing top region rather than adding a uniform title bar:

| Panel | Placement | Grip handling |
|---|---|---|
| Thumbnails | existing "Pages" header row (stays put across the multi-select swap) | left-docked; row already clears scrollbar+grip via `_extraRightPadding` |
| Annotations | beside the filter field | right-docked; grip on the left, no inset |
| Search results | new slim `[title, ×]` header (options bar is hidden when docked) | left-docked; header right padding adds grip width |
| Properties | new slim `[title, ×]` header (goes straight to content) | right-docked; no inset |

## Tests

`fvm flutter test` — affected suites green (125 in `pdf_shell_test.dart`). Added **"wide: a docked panel's close button hides it"** covering the new key `pdf-properties-panel-close` and the preference flip. Close-button keys: `pdf-thumbnail-panel-close`, `pdf-annotation-panel-close`, `pdf-search-panel-close`, `pdf-properties-panel-close`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDoFyTHL4vHToNvtpnLxhp)_