### PR TITLE
Fix Windows PDF open: deliver the file and open in a single window

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -388,7 +388,21 @@ class _EditorScreenState extends State<EditorScreen>
   }
 
   /// Opens a file the OS handed us (association, share, launch arg).
+  ///
+  /// If a tab already holds this exact path, focus it instead of opening a
+  /// duplicate. The same launch file can arrive twice — once via the
+  /// command-line launch args and once via the native `getInitialFile`
+  /// channel (Windows delivers both) — and re-opening an already-open
+  /// document from the OS should surface the existing tab, not stack copies.
   Future<void> _openIncoming(IncomingFile file) async {
+    final path = file.path;
+    if (path != null && path.isNotEmpty) {
+      final existing = _tabs.indexWhere((t) => t.originPath == path);
+      if (existing != -1) {
+        setState(() => _activeIndex = existing);
+        return;
+      }
+    }
     await _openLoadedBytes(
       file.bytes == null
           ? readPdfAtPath(file.path!)

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -242,4 +242,29 @@ void main() {
     expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
         FontWeight.w600);
   });
+
+  testWidgets('re-opening the same file focuses its tab instead of duplicating',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+
+    await openTab(tester, 'alpha.pdf', path: '/docs/alpha.pdf');
+    await openTab(tester, 'beta.pdf', path: '/docs/beta.pdf');
+    // beta was opened last, so it is the active tab.
+    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+        FontWeight.w600);
+
+    // The OS hands us alpha a second time (another "open with" of the same
+    // file, e.g. via the single-instance forwarder or both launch-arg and
+    // getInitialFile delivery on cold start).
+    await openTab(tester, 'alpha.pdf', path: '/docs/alpha.pdf');
+
+    // No duplicate tab, and alpha is now focused rather than re-loaded.
+    expect(tabTitle('alpha.pdf'), findsOneWidget);
+    expect(find.byTooltip('Close tab'), findsNWidgets(2));
+    expect(tester.widget<Text>(tabTitle('alpha.pdf')).style?.fontWeight,
+        FontWeight.w600);
+    expect(tester.widget<Text>(tabTitle('beta.pdf')).style?.fontWeight,
+        FontWeight.normal);
+  });
 }

--- a/app/windows/runner/flutter_window.cpp
+++ b/app/windows/runner/flutter_window.cpp
@@ -1,11 +1,43 @@
 #include "flutter_window.h"
 
+#include <flutter/encodable_value.h>
+#include <flutter/method_channel.h>
+#include <flutter/standard_method_codec.h>
+
+#include <string.h>
+
 #include <optional>
+#include <string>
 
 #include "flutter/generated_plugin_registrant.h"
+#include "utils.h"
 
-FlutterWindow::FlutterWindow(const flutter::DartProject& project)
-    : project_(project) {}
+namespace {
+
+// Reverse-DNS channel shared with the Dart IncomingFileService and every other
+// platform runner (macOS/iOS/Android).
+constexpr const char kIncomingChannelName[] = "dev.milanko.dartpdf/incoming";
+
+// Builds the {name, path} payload the Dart side's IncomingFileService decodes.
+flutter::EncodableValue FilePayload(const std::wstring& path) {
+  std::wstring name = path;
+  size_t slash = path.find_last_of(L"/\\");
+  if (slash != std::wstring::npos) {
+    name = path.substr(slash + 1);
+  }
+  return flutter::EncodableValue(flutter::EncodableMap{
+      {flutter::EncodableValue("name"),
+       flutter::EncodableValue(Utf8FromUtf16(name.c_str()))},
+      {flutter::EncodableValue("path"),
+       flutter::EncodableValue(Utf8FromUtf16(path.c_str()))},
+  });
+}
+
+}  // namespace
+
+FlutterWindow::FlutterWindow(const flutter::DartProject& project,
+                             std::wstring initial_file)
+    : project_(project), initial_file_(std::move(initial_file)) {}
 
 FlutterWindow::~FlutterWindow() {}
 
@@ -25,6 +57,31 @@ bool FlutterWindow::OnCreate() {
     return false;
   }
   RegisterPlugins(flutter_controller_->engine());
+
+  // Bridge OS file opens to the Dart IncomingFileService. `getInitialFile`
+  // drains the cold-start launch file; warm-start opens arrive as `openFile`
+  // (see MessageHandler's WM_COPYDATA case).
+  incoming_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(), kIncomingChannelName,
+          &flutter::StandardMethodCodec::GetInstance());
+  incoming_channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) {
+        if (call.method_name() == "getInitialFile") {
+          if (initial_file_.empty()) {
+            result->Success();
+          } else {
+            std::wstring path = initial_file_;
+            initial_file_.clear();  // deliver the launch file exactly once
+            result->Success(FilePayload(path));
+          }
+        } else {
+          result->NotImplemented();
+        }
+      });
+
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
@@ -47,6 +104,14 @@ void FlutterWindow::OnDestroy() {
   Win32Window::OnDestroy();
 }
 
+void FlutterWindow::DeliverFileToFlutter(const std::wstring& path) {
+  if (!incoming_channel_ || path.empty()) {
+    return;
+  }
+  incoming_channel_->InvokeMethod(
+      "openFile", std::make_unique<flutter::EncodableValue>(FilePayload(path)));
+}
+
 LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
@@ -65,6 +130,27 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
     case WM_FONTCHANGE:
       flutter_controller_->engine()->ReloadSystemFonts();
       break;
+
+    case WM_COPYDATA: {
+      // A second instance forwarded a file to open in a new tab (see
+      // runner/main.cpp). Decode the path and hand it to Dart, then surface
+      // this window so the user sees the freshly opened document.
+      auto* cds = reinterpret_cast<COPYDATASTRUCT*>(lparam);
+      if (cds != nullptr && cds->dwData == kIncomingFileCopyDataMagic &&
+          cds->lpData != nullptr && cds->cbData >= sizeof(wchar_t)) {
+        const wchar_t* data = reinterpret_cast<const wchar_t*>(cds->lpData);
+        size_t max_chars = cds->cbData / sizeof(wchar_t);
+        std::wstring path(data, ::wcsnlen(data, max_chars));
+        if (!path.empty()) {
+          DeliverFileToFlutter(path);
+          if (::IsIconic(hwnd)) {
+            ::ShowWindow(hwnd, SW_RESTORE);
+          }
+          ::SetForegroundWindow(hwnd);
+        }
+      }
+      return TRUE;
+    }
   }
 
   return Win32Window::MessageHandler(hwnd, message, wparam, lparam);

--- a/app/windows/runner/flutter_window.h
+++ b/app/windows/runner/flutter_window.h
@@ -2,17 +2,28 @@
 #define RUNNER_FLUTTER_WINDOW_H_
 
 #include <flutter/dart_project.h>
+#include <flutter/encodable_value.h>
 #include <flutter/flutter_view_controller.h>
+#include <flutter/method_channel.h>
 
 #include <memory>
+#include <string>
 
 #include "win32_window.h"
 
-// A window that does nothing but host a Flutter view.
+// Identifies WM_COPYDATA messages that carry a file path forwarded from a
+// second instance of the app. The sender (runner/main.cpp) stamps the same
+// value so unrelated WM_COPYDATA traffic is ignored.
+constexpr ULONG_PTR kIncomingFileCopyDataMagic = 0x44504446;  // 'DPDF'
+
+// A window that hosts a Flutter view and bridges OS file opens to Dart.
 class FlutterWindow : public Win32Window {
  public:
   // Creates a new FlutterWindow hosting a Flutter view running |project|.
-  explicit FlutterWindow(const flutter::DartProject& project);
+  // |initial_file| is the document the app was launched with (cold start), or
+  // empty; the Dart side drains it once via `getInitialFile`.
+  explicit FlutterWindow(const flutter::DartProject& project,
+                         std::wstring initial_file = L"");
   virtual ~FlutterWindow();
 
  protected:
@@ -23,8 +34,21 @@ class FlutterWindow : public Win32Window {
                          LPARAM const lparam) noexcept override;
 
  private:
+  // Hands a file path to the Dart IncomingFileService as a warm-start open
+  // (a second instance forwarded it via WM_COPYDATA).
+  void DeliverFileToFlutter(const std::wstring& path);
+
   // The project to run.
   flutter::DartProject project_;
+
+  // The file the app was launched with, drained once by `getInitialFile`.
+  // Empty when the app was launched without a file.
+  std::wstring initial_file_;
+
+  // Channel to the Dart IncomingFileService: cold-start `getInitialFile` and
+  // warm-start `openFile`. Created once the engine exists in OnCreate.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      incoming_channel_;
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;

--- a/app/windows/runner/main.cpp
+++ b/app/windows/runner/main.cpp
@@ -2,8 +2,79 @@
 #include <flutter/flutter_view_controller.h>
 #include <windows.h>
 
+#include <string.h>
+
+#include <string>
+#include <vector>
+
 #include "flutter_window.h"
 #include "utils.h"
+
+namespace {
+
+// Process-wide single-instance guard. A second launch hands its file to the
+// already-running instance instead of opening a second window.
+constexpr const wchar_t kSingleInstanceMutexName[] =
+    L"dev.milanko.dartpdf.SingleInstance";
+
+// Window class of the main window (see runner/win32_window.cpp); a second
+// instance locates the running window by this class.
+constexpr const wchar_t kMainWindowClassName[] = L"DARTPDF_WIN32_WINDOW";
+
+// Returns the first `.pdf` path on the command line, or an empty string. This
+// is how Windows delivers a file association / "open with" — the path is the
+// first argument after the executable.
+std::wstring FirstPdfArgument() {
+  int argc = 0;
+  wchar_t** argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
+  if (argv == nullptr) {
+    return std::wstring();
+  }
+  std::wstring result;
+  for (int i = 1; i < argc; i++) {
+    std::wstring arg = argv[i];
+    if (arg.size() >= 4 &&
+        _wcsicmp(arg.c_str() + (arg.size() - 4), L".pdf") == 0) {
+      result = arg;
+      break;
+    }
+  }
+  ::LocalFree(argv);
+  return result;
+}
+
+// Brings an existing window to the foreground, restoring it if minimized.
+void SurfaceWindow(HWND hwnd) {
+  if (::IsIconic(hwnd)) {
+    ::ShowWindow(hwnd, SW_RESTORE);
+  }
+  ::SetForegroundWindow(hwnd);
+}
+
+// Locates the main window of an already-running instance, retrying briefly to
+// cover the race where the first instance owns the mutex but hasn't created
+// its window yet.
+HWND FindRunningInstanceWindow() {
+  for (int attempt = 0; attempt < 50; attempt++) {
+    HWND hwnd = ::FindWindowW(kMainWindowClassName, nullptr);
+    if (hwnd != nullptr) {
+      return hwnd;
+    }
+    ::Sleep(100);
+  }
+  return nullptr;
+}
+
+// Hands |path| to the running instance via WM_COPYDATA so it opens in a new tab.
+void ForwardFileToRunningInstance(HWND target, const std::wstring& path) {
+  COPYDATASTRUCT cds{};
+  cds.dwData = kIncomingFileCopyDataMagic;
+  cds.cbData = static_cast<DWORD>((path.size() + 1) * sizeof(wchar_t));
+  cds.lpData = const_cast<wchar_t*>(path.c_str());
+  ::SendMessageW(target, WM_COPYDATA, 0, reinterpret_cast<LPARAM>(&cds));
+}
+
+}  // namespace
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
@@ -17,6 +88,34 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // plugins.
   ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
 
+  const std::wstring initial_file = FirstPdfArgument();
+
+  // Single instance: if one is already running, hand it our file (so the
+  // document opens in a new tab of the existing window) and exit. If we can't
+  // find its window — it may be shutting down — fall through and start fresh.
+  HANDLE single_instance =
+      ::CreateMutexW(nullptr, FALSE, kSingleInstanceMutexName);
+  const bool already_running =
+      single_instance != nullptr && ::GetLastError() == ERROR_ALREADY_EXISTS;
+  if (already_running) {
+    HWND running = FindRunningInstanceWindow();
+    if (running != nullptr) {
+      // Let the running instance pull itself to the foreground past Windows'
+      // foreground lock (it calls SetForegroundWindow when it handles the
+      // forwarded file).
+      ::AllowSetForegroundWindow(ASFW_ANY);
+      if (!initial_file.empty()) {
+        ForwardFileToRunningInstance(running, initial_file);
+      }
+      SurfaceWindow(running);
+      if (single_instance != nullptr) {
+        ::CloseHandle(single_instance);
+      }
+      ::CoUninitialize();
+      return EXIT_SUCCESS;
+    }
+  }
+
   flutter::DartProject project(L"data");
 
   std::vector<std::string> command_line_arguments =
@@ -24,10 +123,13 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  FlutterWindow window(project);
+  FlutterWindow window(project, initial_file);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
   if (!window.Create(L"DartPDF", origin, size)) {
+    if (single_instance != nullptr) {
+      ::CloseHandle(single_instance);
+    }
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);
@@ -39,5 +141,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   }
 
   ::CoUninitialize();
+  if (single_instance != nullptr) {
+    ::CloseHandle(single_instance);
+  }
   return EXIT_SUCCESS;
 }

--- a/app/windows/runner/win32_window.cpp
+++ b/app/windows/runner/win32_window.cpp
@@ -16,7 +16,10 @@ namespace {
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
 
-constexpr const wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
+// App-unique window class. A second instance locates the running window by
+// this class name (see runner/main.cpp), so it must not be the generic Flutter
+// template name shared by every Flutter desktop app.
+constexpr const wchar_t kWindowClassName[] = L"DARTPDF_WIN32_WINDOW";
 
 /// Registry key for app theme preference.
 ///

--- a/doc/dev-log/2026-06-25-windows-file-open-single-instance.md
+++ b/doc/dev-log/2026-06-25-windows-file-open-single-instance.md
@@ -1,0 +1,73 @@
+# Windows file-open + single-instance runner
+
+After setting DartPDF as the default Windows app for `.pdf`, two bugs showed
+up:
+
+1. Double-clicking a PDF opened the DartPDF window but **not the document**.
+2. Opening a second PDF spawned a **new process/window** instead of a new tab
+   in the running app.
+
+## Root cause
+
+The Dart side was already complete. `IncomingFileService`
+(`app/lib/incoming_file.dart`) talks to one `MethodChannel`
+(`dev.milanko.dartpdf/incoming`): `getInitialFile` for the cold-start file,
+`openFile` for warm-start opens. `EditorScreen` listens to both and also opens
+`.pdf` paths from the command-line launch args (`_openLaunchArgs`). macOS, iOS,
+and Android all implement the native half of that channel.
+
+**Windows (and Linux) shipped the stock Flutter runner** — no channel handler
+and no single-instance logic:
+
+- Warm-start (issue 2): nothing forwarded a later "open with" to the running
+  instance, and nothing made the app single-instance, so every open launched a
+  fresh process.
+- Cold-start (issue 1): delivery relied solely on
+  `set_dart_entrypoint_arguments`, which is the only path and is brittle in the
+  field. There was no `getInitialFile` fallback like the other platforms have.
+
+## Fix (Windows runner — `app/windows/runner/`)
+
+- **`main.cpp`** — named-mutex single instance
+  (`dev.milanko.dartpdf.SingleInstance`). A second launch finds the running
+  window by class name (`FindWindowW`, retried ~5s to cover the
+  mutex-owned-but-window-not-yet-created race), forwards the first `.pdf`
+  argument via `WM_COPYDATA`, surfaces that window, and exits. The first
+  instance still gets the launch file two ways: as a dart entrypoint arg (so
+  `_hasExplicitLaunchTarget` keeps suppressing session restore) **and** through
+  the channel below.
+- **`flutter_window.{h,cpp}`** — creates the `dev.milanko.dartpdf/incoming`
+  `MethodChannel` once the engine exists. `getInitialFile` drains the
+  constructor-supplied launch file exactly once; the `WM_COPYDATA` case decodes
+  the forwarded path (guarded by a magic `dwData = 'DPDF'`), invokes `openFile`,
+  and brings the window to the foreground. Payload shape matches the other
+  runners: `{name, path}`, UTF-8 via the existing `Utf8FromUtf16`.
+- **`win32_window.cpp`** — renamed the window class from the generic
+  `FLUTTER_RUNNER_WIN32_WINDOW` to `DARTPDF_WIN32_WINDOW` so `FindWindowW`
+  locates *our* window and never another Flutter desktop app's. The class name
+  is duplicated as `kMainWindowClassName` in `main.cpp`; keep them in sync.
+
+## Fix (Dart — `app/lib/editor_screen.dart`)
+
+`_openIncoming` now focuses an already-open tab with the same `originPath`
+instead of opening a duplicate. The cold-start file can now arrive twice (launch
+arg + `getInitialFile`); this dedupe makes that a no-op, and as a bonus a
+repeated OS "open with" of an open document just surfaces its existing tab.
+Drag-drop (`_openDropped`) is unaffected — it has its own path and still opens
+duplicates on purpose.
+
+Test: `app/test/tabs_menu_test.dart` — "re-opening the same file focuses its tab
+instead of duplicating".
+
+## Couldn't verify the native build here
+
+No Windows/MSVC toolchain in this environment, so the C++ wasn't compiled. It
+uses the stable Flutter Windows C++ client-wrapper API (same one plugins use:
+`engine()->messenger()`, `MethodChannel<EncodableValue>`,
+`StandardMethodCodec::GetInstance()`). The Dart change + new widget test pass
+`fvm flutter test`. The Linux runner has the same gap but wasn't in scope
+(`my_application.cc` is still `G_APPLICATION_NON_UNIQUE`); worth a follow-up if
+Linux file associations matter.
+
+OS registration of the association is still the installer's job (MSIX manifest
+per `app/RELEASING.md`); this change only fixes the receive side.


### PR DESCRIPTION
## Problem

After setting DartPDF as the default Windows app for `.pdf`:

1. **Opening a PDF opened an empty DartPDF window without the document.**
2. **Opening a second PDF spawned a new instance instead of a new tab.**

## Root cause

The Dart side was already complete: `IncomingFileService`
(`app/lib/incoming_file.dart`) talks to one `MethodChannel`
(`dev.milanko.dartpdf/incoming`) — `getInitialFile` for the cold-start file,
`openFile` for warm-start opens — and `EditorScreen` listens to both plus the
command-line launch args. **macOS, iOS, and Android implement the native half;
Windows shipped the stock Flutter runner** with no channel handler and no
single-instance logic. So a later "open with" always launched a fresh process,
and cold-start delivery leaned entirely on `set_dart_entrypoint_arguments`.

## Fix

**Windows runner (`app/windows/runner/`):**
- **`main.cpp`** — named-mutex single instance. A second launch finds the
  running window by class name (`FindWindowW`, retried to cover the
  mutex-owned-but-window-not-yet-created race), forwards the first `.pdf`
  argument via `WM_COPYDATA`, surfaces that window
  (`AllowSetForegroundWindow` past the foreground lock), and exits.
- **`flutter_window.{h,cpp}`** — create the `dev.milanko.dartpdf/incoming`
  `MethodChannel` once the engine exists. `getInitialFile` drains the
  constructor-supplied launch file exactly once; the `WM_COPYDATA` case
  (guarded by a `'DPDF'` magic) decodes the forwarded path, invokes `openFile`,
  and raises the window. `{name, path}` payload matches the other runners.
- **`win32_window.cpp`** — rename the window class from the generic
  `FLUTTER_RUNNER_WIN32_WINDOW` to `DARTPDF_WIN32_WINDOW` so a second instance
  finds *our* window, never another Flutter desktop app's.

**Dart (`app/lib/editor_screen.dart`):**
- `_openIncoming` now focuses an already-open tab with the same `originPath`
  instead of opening a duplicate. The cold-start file can now arrive twice
  (launch arg + `getInitialFile`); this makes that open exactly once, and a
  repeated OS "open with" of an open document just surfaces its tab. Drag-drop
  is unaffected (it has its own path and still opens duplicates on purpose).

## Tests
- New `app/test/tabs_menu_test.dart` case: re-opening the same file focuses its
  tab instead of duplicating.
- Full app suite green (`fvm flutter test`, 120 tests).

## Caveats
- **No Windows/MSVC toolchain in this environment, so the C++ was not
  compiled.** It uses the stable Flutter Windows C++ client-wrapper API that
  plugins use (`engine()->messenger()`, `MethodChannel<EncodableValue>`,
  `StandardMethodCodec::GetInstance()`). Please build the Windows runner before
  merging.
- The Linux runner has the same gap (`my_application.cc` is still
  `G_APPLICATION_NON_UNIQUE`) but was out of scope here — a reasonable
  follow-up if Linux file associations matter.
- OS registration of the `.pdf` association remains the installer's job (MSIX
  manifest, per `app/RELEASING.md`); this only fixes the receive side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHxAXYC5u3pTEvZxGfMAT5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHxAXYC5u3pTEvZxGfMAT5)_