### PR TITLE
feat(viewer): launch hyperlinks from tapped /URI links

### DIFF
--- a/doc/dev-log/2026-06-25-launch-hyperlinks.md
+++ b/doc/dev-log/2026-06-25-launch-hyperlinks.md
@@ -1,0 +1,66 @@
+# Launching hyperlinks from the viewer
+
+Tapping a `/Link` whose action is `/URI` used to do nothing on its own —
+the viewer surfaced every URI to `PdfViewer.onAction` and left opening it
+to the host. So a plain web link in a PDF was inert unless the embedding
+app wired `url_launcher` itself. This adds built-in launching.
+
+## What changed
+
+`PdfViewer` now follows web hyperlinks itself.
+
+- New `PdfUrlLauncher` typedef (`Future<bool> Function(Uri)`) and
+  `PdfViewer.onLaunchUrl` (threaded through `PdfReader` too).
+- `_activate` routes `PdfUriAction` into `_openUri`, which calls
+  `onLaunchUrl ?? _launchExternalUrl`. The default opens the well-known
+  external schemes — `http`, `https`, `mailto`, `tel`, `sms` — through
+  `url_launcher`'s `launchUrl(..., LaunchMode.externalApplication)` and
+  returns `false` for anything else.
+- `url_launcher: ^6.3.0` is now a direct dependency of `dart_pdf_editor`
+  (it was already used by `app/` and the example). It is web-safe and
+  pulls in no `dart:io`, so the layering rules hold — only the top
+  `dart_pdf_editor` layer touches it.
+
+## The onAction fallback is preserved deliberately
+
+Custom schemes are the established convention for "a PDF drives its host
+app" (`app://counter/increment` in the demo), so they must still reach
+`onAction`. The contract is now:
+
+- `onLaunchUrl` returns `true` → the link is consumed, `onAction` never
+  fires for it.
+- returns `false`, throws, or the URI won't parse → the viewer falls
+  through to `onAction`, exactly as before.
+
+The default launcher's scheme allow-list is what makes `app://…` fall
+through untouched, which is why the existing `buildAnnotatedPdf`
+(`app://invoice/42`) test still expects `onAction`. A host that wants to
+open custom schemes, confirm before leaving, or route links into the app
+supplies its own `onLaunchUrl`; it sees every parseable URI, custom
+scheme included.
+
+`_openUri` wraps the launcher in try/catch so a platform with no
+`url_launcher` binding (or a launcher that throws) degrades to the
+`onAction` fallback instead of swallowing the tap.
+
+## Testing seam
+
+`url_launcher` can't reach a real platform in widget tests. Two seams:
+
+- The `onLaunchUrl` override is plain Dart — most tests pass a closure
+  that records the `Uri` (and return true/false/throw) and assert against
+  `onAction`. No platform mock needed.
+- For the *default* path (proving `http` actually reaches
+  `url_launcher`), `pdf_viewer_test.dart` swaps in a
+  `_FakeUrlLauncher extends UrlLauncherPlatform with
+  MockPlatformInterfaceMixin` via `UrlLauncherPlatform.instance` and taps
+  an `https` link in a one-page `buildUriLinkPdf` fixture. `plugin_-
+  platform_interface` + `url_launcher_platform_interface` are dev-only
+  deps for that fake.
+
+## Demo
+
+The example's page 1 gains a real `https://pub.dev/...` text link beneath
+the table of contents — the viewer opens it with zero host wiring, in
+contrast to the `app://` buttons above it that the demo dispatches through
+`onAction`. `demo_document_test` now expects 9 page-1 links (was 8).

--- a/packages/dart_pdf_editor/example/lib/demo_document.dart
+++ b/packages/dart_pdf_editor/example/lib/demo_document.dart
@@ -169,6 +169,18 @@ Uint8List buildDemoPdf() {
     tocLinks.add(_link(PdfRect(88, y - 6, 320, y + 14),
         '<< /S /GoTo /D [@PG$page@ 0 R /Fit] >>'));
   }
+  // A real web hyperlink (https): the viewer opens it itself via
+  // PdfViewer.onLaunchUrl, no app wiring needed — unlike the app:// links
+  // above, which the app dispatches through onAction.
+  const webLinkY = 166.0;
+  const webLinkLabel = 'Open dart-pdf on pub.dev (a real web link)';
+  page1
+    ..write('q 0.15 0.25 0.65 rg ')
+    ..write(_text(90, webLinkY, 12, webLinkLabel))
+    ..write('Q q 0.15 0.25 0.65 RG 0.5 w 90 ${_n(webLinkY - 2.5)} m '
+        '${_n(90 + webLinkLabel.length * 6.2)} ${_n(webLinkY - 2.5)} l S Q\n');
+  tocLinks.add(_link(PdfRect(88, webLinkY - 6, 380, webLinkY + 14),
+      '<< /S /URI /URI (https://pub.dev/packages/dart_pdf_editor) >>'));
 
   final page2 = StringBuffer()
     ..write(_text(72, 730, 22, 'Flutter widgets pinned to the page'))

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -218,10 +218,11 @@ class _ViewerScreenState extends State<ViewerScreen> {
   String _ocrModel = 'model';
   String? _ocrApiKey;
 
-  /// GoTo and the standard named page actions never get here (the viewer
-  /// follows them itself). Custom-scheme URIs are dispatched as app
-  /// commands — the conventional way a PDF drives its host app — and
-  /// anything else just gets described in a snackbar.
+  /// GoTo, the standard named page actions, and real web links (the
+  /// page's https pub.dev link) never get here — the viewer follows them
+  /// itself. Custom-scheme URIs are dispatched as app commands — the
+  /// conventional way a PDF drives its host app — and anything else just
+  /// gets described in a snackbar.
   void _onAction(PdfAction action, PdfAnnotation annotation) {
     final tab = _active;
     if (action is PdfUriAction) {

--- a/packages/dart_pdf_editor/example/test/demo_document_test.dart
+++ b/packages/dart_pdf_editor/example/test/demo_document_test.dart
@@ -17,8 +17,8 @@ void main() {
       final annots = doc.page(0).annotations;
       final links =
           annots.where((a) => a.subtype == 'Link').toList(growable: false);
-      // 4 original actions + 4 TOC GoTo entries
-      expect(links, hasLength(8));
+      // 4 app actions + 1 real web hyperlink + 4 TOC GoTo entries
+      expect(links, hasLength(9));
       expect(annots.where((a) => a.subtype == 'Widget'), hasLength(1));
     });
 

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -100,6 +100,7 @@ class PdfReader extends StatefulWidget {
     this.preferences,
     this.features = const PdfReaderFeatures(),
     this.onAction,
+    this.onLaunchUrl,
     this.pageOverlayBuilder,
     this.initialFit = PdfViewerFit.page,
     this.backgroundColor,
@@ -141,6 +142,9 @@ class PdfReader extends StatefulWidget {
 
   /// See [PdfViewer.onAction].
   final PdfActionHandler? onAction;
+
+  /// See [PdfViewer.onLaunchUrl].
+  final PdfUrlLauncher? onLaunchUrl;
 
   /// See [PdfViewer.pageOverlayBuilder].
   final PdfPageOverlayBuilder? pageOverlayBuilder;
@@ -400,6 +404,7 @@ class _PdfReaderState extends State<PdfReader> {
                                 formController:
                                     features.fillForms ? _session : null,
                                 onAction: widget.onAction,
+                                onLaunchUrl: widget.onLaunchUrl,
                                 pageOverlayBuilder: widget.pageOverlayBuilder,
                                 initialFit: widget.initialFit,
                                 backgroundColor: widget.backgroundColor,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -10,6 +10,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'editing/editing_controller.dart';
 import 'editing/editing_form_layer.dart';
@@ -449,6 +450,12 @@ enum PdfViewerFit {
 typedef PdfActionHandler = void Function(
     PdfAction action, PdfAnnotation annotation);
 
+/// Signature for [PdfViewer.onLaunchUrl]: open the hyperlink [uri] of a
+/// tapped /URI action. Returns whether it was opened — false hands the
+/// link back to [PdfViewer.onAction] so a custom scheme can still be
+/// dispatched there.
+typedef PdfUrlLauncher = Future<bool> Function(Uri uri);
+
 /// Signature for [PdfViewer.pageOverlayBuilder]: returns widgets stacked
 /// over one page. Use [geometry] to convert PDF coordinates to view
 /// coordinates, e.g. `Positioned.fromRect(rect: geometry.toViewRect(...))`.
@@ -466,6 +473,7 @@ class PdfViewer extends StatefulWidget {
     required this.document,
     this.controller,
     this.onAction,
+    this.onLaunchUrl,
     this.pageOverlayBuilder,
     this.editing,
     this.formController,
@@ -532,11 +540,24 @@ class PdfViewer extends StatefulWidget {
 
   /// Called when a tapped link or button carries an action the viewer
   /// doesn't follow itself. /GoTo destinations and the four standard
-  /// /Named page actions navigate internally and never reach this; URI,
-  /// JavaScript, and everything else is the app's call — the conventional
-  /// bridge for PDFs that drive the app is a URI action with a custom
-  /// scheme, dispatched here.
+  /// /Named page actions navigate internally and never reach this, and a
+  /// /URI action whose link [onLaunchUrl] opens is consumed there too;
+  /// JavaScript, unrecognized actions, and links [onLaunchUrl] declines
+  /// are the app's call — the conventional bridge for PDFs that drive the
+  /// app is a URI action with a custom scheme, dispatched here.
   final PdfActionHandler? onAction;
+
+  /// Opens the hyperlink of a tapped /URI action (and of a push button
+  /// whose action is a /URI). Defaults to launching well-known external
+  /// schemes — http, https, mailto, tel, sms — in the platform's default
+  /// handler via `url_launcher`, leaving custom schemes for [onAction].
+  ///
+  /// Replace it to widen or narrow what opens, to confirm before leaving
+  /// the document, or to route links into the app. Return false (or throw)
+  /// to decline a link; the viewer then surfaces it to [onAction], so the
+  /// custom-scheme convention keeps working. A link this opens never
+  /// reaches [onAction].
+  final PdfUrlLauncher? onLaunchUrl;
 
   /// Stacks app widgets over each page, positioned in PDF coordinates via
   /// the provided geometry. Overlays live in the page's transformed space,
@@ -2314,9 +2335,45 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
         _scrollToDestination(destination);
       case PdfNamedAction(:final name) when _handleNamedAction(name):
         break; // handled internally
+      case PdfUriAction():
+        unawaited(_openUri(action, annotation));
       default:
         widget.onAction?.call(action, annotation);
     }
+  }
+
+  /// Follows a tapped /URI link: hands it to [PdfViewer.onLaunchUrl] (the
+  /// default opens well-known external schemes via `url_launcher`), and
+  /// only when that declines — a custom scheme, an unparseable URI, or a
+  /// launch that failed — surfaces it to [PdfViewer.onAction] so the host
+  /// keeps the last word.
+  Future<void> _openUri(PdfUriAction action, PdfAnnotation annotation) async {
+    final uri = Uri.tryParse(action.uri);
+    if (uri != null) {
+      var opened = false;
+      try {
+        opened = await (widget.onLaunchUrl ?? _launchExternalUrl)(uri);
+      } catch (_) {
+        // A platform with no url_launcher binding, or a launcher that
+        // threw: treat it as declined and fall through to onAction.
+        opened = false;
+      }
+      if (opened) return;
+    }
+    if (mounted) widget.onAction?.call(action, annotation);
+  }
+
+  /// The default [PdfViewer.onLaunchUrl]: opens a hyperlink in the
+  /// platform's external handler, but only for the schemes a viewer is
+  /// expected to follow on its own. Custom schemes (the convention for
+  /// PDFs that drive their host app) return false so they reach
+  /// [PdfViewer.onAction].
+  static const _externalSchemes = {'http', 'https', 'mailto', 'tel', 'sms'};
+  static Future<bool> _launchExternalUrl(Uri uri) {
+    if (!_externalSchemes.contains(uri.scheme.toLowerCase())) {
+      return Future.value(false);
+    }
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 
   bool _handleNamedAction(String name) {

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -25,6 +25,9 @@ dependencies:
   pdf_document: ^1.2.3
   pdf_graphics: ^1.2.3
   shared_preferences: ^2.3.0
+  # Opens hyperlink (/URI) actions the viewer follows itself; see
+  # PdfViewer.onLaunchUrl. Web-safe, no dart:io.
+  url_launcher: ^6.3.0
   # Web-only: the Web Worker render backend (render_worker_web.dart) talks to a
   # Worker over package:web's typed bindings. A no-op everywhere else.
   web: ^1.1.0
@@ -34,6 +37,10 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  # Stub the url_launcher platform channel in the hyperlink-launch tests so
+  # they exercise the default launcher without a real platform binding.
+  plugin_platform_interface: ^2.1.8
+  url_launcher_platform_interface: ^2.3.2
 
 flutter:
   # Bundled fonts offered by the font menu. DejaVu is a permissive

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -8,11 +8,72 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_graphics/pdf_graphics.dart' show PdfTextExtractor;
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+/// Records the URLs the default [PdfViewer.onLaunchUrl] passes to
+/// url_launcher, standing in for a real platform binding in tests.
+class _FakeUrlLauncher extends UrlLauncherPlatform
+    with MockPlatformInterfaceMixin {
+  /// What [launchUrl] reports back — true means "opened".
+  bool result = true;
+  final launched = <String>[];
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launched.add(url);
+    return result;
+  }
+}
+
+/// A one-page PDF carrying a single /Link annotation whose /URI is [url],
+/// at /Rect [72 640 200 664] — the same spot as buildAnnotatedPdf's first
+/// link, so [annotView](136, 652) hits its center.
+Uint8List buildUriLinkPdf(String url) {
+  const content = 'BT /F1 24 Tf 72 720 Td (Link) Tj ET';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> '
+        '/Annots [ << /Type /Annot /Subtype /Link /Rect [72 640 200 664] '
+        '/A << /S /URI /URI ($url) >> >> ] >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
 
 void main() {
   Future<PdfViewerController> pumpViewer(WidgetTester tester,
-      {int pages = 5, Uint8List? bytes, PdfActionHandler? onAction}) async {
+      {int pages = 5,
+      Uint8List? bytes,
+      PdfActionHandler? onAction,
+      PdfUrlLauncher? onLaunchUrl}) async {
     final controller = PdfViewerController();
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -21,6 +82,7 @@ void main() {
           document: PdfDocument.open(bytes ?? buildMultiPagePdf(pages)),
           controller: controller,
           onAction: onAction,
+          onLaunchUrl: onLaunchUrl,
         ),
       ),
     ));
@@ -797,6 +859,8 @@ void main() {
   });
 
   testWidgets('tapping a URI link surfaces the action', (tester) async {
+    // The default launcher only opens well-known external schemes, so the
+    // fixture's app:// link falls through to onAction unchanged.
     final actions = <PdfAction>[];
     final annotations = <PdfAnnotation>[];
     await pumpViewer(tester, bytes: buildAnnotatedPdf(), onAction: (a, an) {
@@ -811,6 +875,79 @@ void main() {
     expect(actions, hasLength(1));
     expect((actions.single as PdfUriAction).uri, 'app://invoice/42');
     expect(annotations.single, isA<PdfLinkAnnotation>());
+  });
+
+  testWidgets('tapping an http link opens it via the default launcher',
+      (tester) async {
+    final fake = _FakeUrlLauncher();
+    final previous = UrlLauncherPlatform.instance;
+    UrlLauncherPlatform.instance = fake;
+    addTearDown(() => UrlLauncherPlatform.instance = previous);
+
+    final actions = <PdfAction>[];
+    await pumpViewer(tester,
+        bytes: buildUriLinkPdf('https://example.com/'),
+        onAction: (a, _) => actions.add(a));
+
+    await tester.tapAt(annotView(136, 652)); // the link center
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    // it was launched, and a link the viewer follows itself never reaches
+    // the onAction fallback
+    expect(fake.launched, ['https://example.com/']);
+    expect(actions, isEmpty);
+  });
+
+  testWidgets('onLaunchUrl takes over from the default and consumes the link',
+      (tester) async {
+    final opened = <Uri>[];
+    final actions = <PdfAction>[];
+    await pumpViewer(tester,
+        bytes: buildAnnotatedPdf(),
+        onLaunchUrl: (uri) async {
+          opened.add(uri);
+          return true;
+        },
+        onAction: (a, _) => actions.add(a));
+
+    await tester.tapAt(annotView(136, 652)); // the app:// URI link center
+    await tester.pump(const Duration(milliseconds: 400));
+
+    // onLaunchUrl sees every parseable URI, custom scheme included, and a
+    // link it opens does not fall through to onAction
+    expect(opened, [Uri.parse('app://invoice/42')]);
+    expect(actions, isEmpty);
+  });
+
+  testWidgets('a declined onLaunchUrl hands the link to onAction',
+      (tester) async {
+    final actions = <PdfAction>[];
+    await pumpViewer(tester,
+        bytes: buildAnnotatedPdf(),
+        onLaunchUrl: (uri) async => false,
+        onAction: (a, _) => actions.add(a));
+
+    await tester.tapAt(annotView(136, 652));
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(actions, hasLength(1));
+    expect((actions.single as PdfUriAction).uri, 'app://invoice/42');
+  });
+
+  testWidgets('a throwing onLaunchUrl still falls back to onAction',
+      (tester) async {
+    final actions = <PdfAction>[];
+    await pumpViewer(tester,
+        bytes: buildAnnotatedPdf(),
+        onLaunchUrl: (uri) async => throw StateError('no'),
+        onAction: (a, _) => actions.add(a));
+
+    await tester.tapAt(annotView(136, 652));
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(actions, hasLength(1));
+    expect((actions.single as PdfUriAction).uri, 'app://invoice/42');
   });
 
   testWidgets('tapping a GoTo link navigates instead of surfacing it',

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -978,6 +978,21 @@ void main() {
     expect(actions, isEmpty);
   });
 
+  testWidgets('a JavaScript button action surfaces to onAction',
+      (tester) async {
+    // The viewer follows GoTo/Named/URI itself; JavaScript (and other
+    // action types it has no handler for) are the host's call via onAction.
+    final actions = <PdfAction>[];
+    await pumpViewer(tester,
+        bytes: buildAnnotatedPdf(), onAction: (a, _) => actions.add(a));
+
+    await tester.tapAt(annotView(136, 532)); // the JavaScript push button
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(actions, hasLength(1));
+    expect((actions.single as PdfJavaScriptAction).script, 'app.alert(42)');
+  });
+
   testWidgets('hidden annotations neither fire nor change the cursor',
       (tester) async {
     final actions = <PdfAction>[];


### PR DESCRIPTION
## What & why

Tapping a `/Link` whose action is `/URI` used to do nothing on its own — the viewer surfaced *every* URI to `PdfViewer.onAction` and left opening it to the host. So a plain web link in a PDF was inert unless the embedding app wired `url_launcher` itself. This adds built-in launching: **`PdfViewer` now follows web hyperlinks on its own.**

## How

- New `PdfUrlLauncher` typedef (`Future<bool> Function(Uri)`) and `PdfViewer.onLaunchUrl` (threaded through `PdfReader` too).
- `_activate` routes `PdfUriAction` into `_openUri`, which calls `onLaunchUrl ?? _launchExternalUrl`. The default opens the well-known external schemes — `http`, `https`, `mailto`, `tel`, `sms` — through `url_launcher`'s `launchUrl(..., LaunchMode.externalApplication)` and returns `false` for anything else.
- `url_launcher: ^6.3.0` is now a **direct** dependency of `dart_pdf_editor` (it was already used by `app/` and the example). Web-safe, no `dart:io` — the layering rules hold, only the top `dart_pdf_editor` layer touches it.

## The `onAction` fallback is preserved deliberately

Custom schemes are the established convention for "a PDF drives its host app" (`app://counter/increment` in the demo), so they must still reach `onAction`. The contract is now:

- `onLaunchUrl` returns `true` → the link is consumed, `onAction` never fires for it.
- returns `false`, throws, or the URI won't parse → the viewer falls through to `onAction`, exactly as before.

The default launcher's scheme allow-list is what makes `app://…` fall through untouched, so the existing `buildAnnotatedPdf` (`app://invoice/42`) test still expects `onAction`. A host that wants to open custom schemes, confirm before leaving, or route links into the app supplies its own `onLaunchUrl`; it sees every parseable URI, custom scheme included. `_openUri` wraps the launcher in try/catch so a platform with no `url_launcher` binding degrades to the `onAction` fallback instead of swallowing the tap.

## Tests

`pdf_viewer_test.dart` gains five cases (all green, full file passes):
- an `https` link opens via the **default** launcher (a `_FakeUrlLauncher` swapped into `UrlLauncherPlatform.instance`) and never reaches `onAction`;
- `onLaunchUrl` takes over and consumes the link;
- a declined / a throwing `onLaunchUrl` both fall back to `onAction`;
- the existing custom-scheme test still routes to `onAction` unchanged.

`plugin_platform_interface` + `url_launcher_platform_interface` are dev-only deps for the fake.

## Demo

The example's page 1 gains a real `https://pub.dev/...` text link beneath the table of contents — the viewer opens it with zero host wiring, in contrast to the `app://` buttons above it. `demo_document_test` now expects 9 page-1 links (was 8).

## Notes

- Workspace `dart analyze`: clean.
- Two example tests (`demo_document_test` "form fields … appearances", `demo_test` "GoTo link … overlays are live") fail **identically on the clean `main` tree** before this change — pre-existing and out of scope. The page-1 link-count update here stays green.

See `doc/dev-log/2026-06-25-launch-hyperlinks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw9FzqLvp8Fhs4JSJ1jxNr)_