### PR TITLE
Cap embedded-image resolution in the render worker to fix raster jank

### DIFF
--- a/.github/workflows/preview-app-web.yml
+++ b/.github/workflows/preview-app-web.yml
@@ -104,8 +104,18 @@ jobs:
       # No channelId -> the action creates an ephemeral preview channel keyed
       # to this PR and comments the URL on it. The channel expires on its own.
       # The target hosting site (dartpdf-app) comes from app/firebase.json.
+      #
+      # continue-on-error: the channel `releases` POST is the one
+      # non-idempotent Hosting call, and on GitHub runners the API
+      # intermittently drops the keep-alive socket ("premature close").
+      # firebase-tools retries, the first attempt already created the release,
+      # and the retry fails with FAILED_PRECONDITION "supplied version ... is
+      # the current active version" — so the deploy succeeded but the action
+      # exits 1. The recover step below confirms the freshly finalized release
+      # and reuses its URL; a genuine failure (no recent release) still fails.
       - id: deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
+        continue-on-error: true
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           disableComment: true
@@ -114,13 +124,53 @@ jobs:
           expires: 7d
           entryPoint: app
 
+      - id: recover
+        name: Recover the preview URL after a transient release retry error
+        if: steps.deploy.outcome == 'failure'
+        working-directory: app
+        env:
+          FIREBASE_SITE: dartpdf-app
+          FIREBASE_PROJECT: dart-pdf-demo
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
+          FIREBASE_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_PDF_DEMO }}
+        run: |
+          printf '%s' "$FIREBASE_SA" > "$GOOGLE_APPLICATION_CREDENTIALS"
+          npx -y firebase-tools@latest hosting:channel:list \
+            --site "$FIREBASE_SITE" --project "$FIREBASE_PROJECT" --json \
+            > channels.json
+          node -e '
+            const fs = require("fs");
+            const data = JSON.parse(fs.readFileSync("channels.json", "utf8"));
+            const r = data.result;
+            const chans = Array.isArray(r) ? r : ((r && r.channels) || []);
+            const re = new RegExp("^pr" + process.env.PR_NUMBER + "(-|$)");
+            const ch = chans.find(c => re.test(String(c.name || "").split("/").pop()));
+            if (!ch || !ch.release) {
+              console.error("No channel/release for PR " + process.env.PR_NUMBER + "; deploy genuinely failed.");
+              process.exit(1);
+            }
+            // Only treat the failure as benign if the release was finalized in
+            // this run; a stale release means the deploy really did fail.
+            const age = Date.now() - (Date.parse(ch.updateTime || ch.release.releaseTime || 0) || 0);
+            if (!(age >= 0 && age < 30 * 60 * 1000)) {
+              console.error("Channel release is " + Math.round(age / 1000) + "s old; deploy genuinely failed.");
+              process.exit(1);
+            }
+            const out = process.env.GITHUB_OUTPUT;
+            fs.appendFileSync(out, "details_url=" + ch.url + "\n");
+            fs.appendFileSync(out, "expire_time_formatted=" + (ch.expireTime || "") + "\n");
+            console.log("Recovered preview URL " + ch.url + " (release " + Math.round(age / 1000) + "s old).");
+          '
+          rm -f "$GOOGLE_APPLICATION_CREDENTIALS" channels.json
+
       - name: Comment preview URL
         uses: actions/github-script@v9
         env:
           PREVIEW_LABEL: DartPDF app preview
           PREVIEW_MARKER: dartpdf-app-preview
-          PREVIEW_URL: ${{ steps.deploy.outputs.details_url }}
-          PREVIEW_EXPIRES: ${{ steps.deploy.outputs.expire_time_formatted }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.details_url || steps.recover.outputs.details_url }}
+          PREVIEW_EXPIRES: ${{ steps.deploy.outputs.expire_time_formatted || steps.recover.outputs.expire_time_formatted }}
         with:
           script: |
             const marker = `<!-- ${{ env.PREVIEW_MARKER }} -->`;

--- a/.github/workflows/preview-demo-web.yml
+++ b/.github/workflows/preview-demo-web.yml
@@ -99,8 +99,18 @@ jobs:
 
       # No channelId -> the action creates an ephemeral preview channel keyed
       # to this PR and comments the URL on it. The channel expires on its own.
+      #
+      # continue-on-error: the channel `releases` POST is the one
+      # non-idempotent Hosting call, and on GitHub runners the API
+      # intermittently drops the keep-alive socket ("premature close").
+      # firebase-tools retries, the first attempt already created the release,
+      # and the retry fails with FAILED_PRECONDITION "supplied version ... is
+      # the current active version" — so the deploy succeeded but the action
+      # exits 1. The recover step below confirms the freshly finalized release
+      # and reuses its URL; a genuine failure (no recent release) still fails.
       - id: deploy
         uses: FirebaseExtended/action-hosting-deploy@v0
+        continue-on-error: true
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           disableComment: true
@@ -109,13 +119,53 @@ jobs:
           expires: 7d
           entryPoint: packages/dart_pdf_editor/example
 
+      - id: recover
+        name: Recover the preview URL after a transient release retry error
+        if: steps.deploy.outcome == 'failure'
+        working-directory: packages/dart_pdf_editor/example
+        env:
+          FIREBASE_SITE: dart-pdf-demo
+          FIREBASE_PROJECT: dart-pdf-demo
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/firebase-sa.json
+          FIREBASE_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_PDF_DEMO }}
+        run: |
+          printf '%s' "$FIREBASE_SA" > "$GOOGLE_APPLICATION_CREDENTIALS"
+          npx -y firebase-tools@latest hosting:channel:list \
+            --site "$FIREBASE_SITE" --project "$FIREBASE_PROJECT" --json \
+            > channels.json
+          node -e '
+            const fs = require("fs");
+            const data = JSON.parse(fs.readFileSync("channels.json", "utf8"));
+            const r = data.result;
+            const chans = Array.isArray(r) ? r : ((r && r.channels) || []);
+            const re = new RegExp("^pr" + process.env.PR_NUMBER + "(-|$)");
+            const ch = chans.find(c => re.test(String(c.name || "").split("/").pop()));
+            if (!ch || !ch.release) {
+              console.error("No channel/release for PR " + process.env.PR_NUMBER + "; deploy genuinely failed.");
+              process.exit(1);
+            }
+            // Only treat the failure as benign if the release was finalized in
+            // this run; a stale release means the deploy really did fail.
+            const age = Date.now() - (Date.parse(ch.updateTime || ch.release.releaseTime || 0) || 0);
+            if (!(age >= 0 && age < 30 * 60 * 1000)) {
+              console.error("Channel release is " + Math.round(age / 1000) + "s old; deploy genuinely failed.");
+              process.exit(1);
+            }
+            const out = process.env.GITHUB_OUTPUT;
+            fs.appendFileSync(out, "details_url=" + ch.url + "\n");
+            fs.appendFileSync(out, "expire_time_formatted=" + (ch.expireTime || "") + "\n");
+            console.log("Recovered preview URL " + ch.url + " (release " + Math.round(age / 1000) + "s old).");
+          '
+          rm -f "$GOOGLE_APPLICATION_CREDENTIALS" channels.json
+
       - name: Comment preview URL
         uses: actions/github-script@v9
         env:
           PREVIEW_LABEL: Example demo preview
           PREVIEW_MARKER: dart-pdf-demo-preview
-          PREVIEW_URL: ${{ steps.deploy.outputs.details_url }}
-          PREVIEW_EXPIRES: ${{ steps.deploy.outputs.expire_time_formatted }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.details_url || steps.recover.outputs.details_url }}
+          PREVIEW_EXPIRES: ${{ steps.deploy.outputs.expire_time_formatted || steps.recover.outputs.expire_time_formatted }}
         with:
           script: |
             const marker = `<!-- ${{ env.PREVIEW_MARKER }} -->`;

--- a/doc/dev-log/2026-06-25-image-resolution-cap.md
+++ b/doc/dev-log/2026-06-25-image-resolution-cap.md
@@ -1,0 +1,92 @@
+# Capping embedded-image resolution to kill raster-thread jank
+
+## Symptom
+
+Panning a 58 MB CAD document (mixed raster + vector, ~40+ sheet pages) on
+**web (CanvasKit/WASM)** janked badly — not during the drag, but as each
+scroll settled. A `PDF_PERF_LOG` (`?perf=1`) trace was decisive:
+
+- Every interpret was `path=worker` — the render worker was already doing
+  its job; interpretation was *not* the bottleneck.
+- Every janky frame was **raster-bound**: `build` was <10 ms while `raster`
+  ran 150–650 ms. So the cost was on CanvasKit's (single, on web) raster
+  thread, not the UI isolate.
+- The worker result sizes were the smoking gun: `webworker result page=30
+  639,867,067B` — a **640 MB** decoded-pixel payload for one page, and
+  ~70 MB each for pages 33–36. These pages embed full-resolution scanned
+  raster underlays (page 30 ≈ 160 megapixels, ~12 600²).
+
+Root cause: images were decoded, shipped across the worker boundary, drawn
+into the page picture, and rasterized (`picture.toImage`) at **native
+resolution**, regardless of the page's on-screen size. Two compounding
+effects:
+
+1. Each `toImage` of a picture wrapping a 640 MB texture is a 150–650 ms
+   single-threaded GPU readback on web.
+2. A single 640 MB image exceeds the whole `PdfImageCache` budget (256 MB),
+   so `put` keeps it only until the next insert evicts it — it **never
+   stays cached**. Every settle re-requested it from the worker (640 MB
+   `postMessage` again) and re-rasterized it, producing a *train* of
+   180–260 ms raster-jank frames at a fixed scroll position.
+
+## Fix
+
+Downsample each decoded image to ~display resolution **in the worker,
+before serialization**, so the giant buffer never crosses `postMessage`,
+fits the cache, and rasterizes in tens of ms.
+
+- `serializeCommands(..., maxImagePixelRatio:)` (pdf_graphics
+  `render_command_codec.dart`) caps each image after `decodePdfImagePixels`.
+  The cap target is `2× (drawn-size-in-points × ratio)` — i.e. ~2× the
+  pixels the image covers on screen (`PdfMatrix` column lengths give the
+  drawn point size; `ratio` is screen px/point incl. device pixel ratio).
+  Hard ceilings (`_maxImagePixels` = 1<<24, `_maxImageDimension` = 8192)
+  mirror the viewer's full-page raster caps so even a sheet-sized underlay
+  stays cacheable and within a GPU texture limit. Null ratio = historic
+  native behaviour; only consulted when `decodeImages: true` (worker path).
+- `downsamplePdfDecodedPixels` (pdf_graphics `image_pixels.dart`) — an
+  area-average (box filter) resampler over premultiplied RGBA. Local int
+  accumulators (safe on web's float64 ints and native 64-bit); never
+  upscales.
+- The `ratio` is threaded from the viewer through the worker protocol:
+  `PdfRenderWorker.record(..., imagePixelRatio:)` → isolate message
+  (`request[3]`) and web `postMessage` (`imageRatio` field) → both
+  `_recordPageAsync`s. `PdfPageView._interpretPicture` passes
+  `_effectiveRatio()`; the preview prerender and editing thumbnails pass
+  their (small) raster ratios so they no longer ship full-res underlays
+  just to be downscaled into a 200 px tile.
+
+### The cache-key trap
+
+`PdfImageCache` is process-wide and keys inline (worker-sourced) images by
+stream **content**. Once images are capped *per call*, the same source
+image can be decoded at two sizes — sharp for the on-screen page, tiny for
+its 200 px preview/thumbnail. Content-only keying would let one resolution
+evict and stand in for the other (a blurry page, or a needlessly huge
+preview). `pdfImageKey` now folds the decoded dimensions into the key
+(`PdfSizedImageKey`) when a request carries worker-decoded pixels, so each
+resolution caches independently. Local renders (`decoded == null`) keep the
+plain content key — unchanged.
+
+## Trade-off (chosen by the user)
+
+The deep-zoom detail patch (`PdfPageView._updateDetail`) re-rasters the
+visible region from the *same* cached picture — it does not re-decode — so
+under deep zoom an image softens at this cap rather than re-sharpening. The
+`2×` headroom keeps normal viewing (and one zoom-doubling) sharp; a future
+follow-up could have the detail patch re-decode the zoomed region at higher
+resolution. The absolute 16.7 Mpx ceiling is what actually fixes the cache
+thrash: every page now fits the 256 MB cache (~4 heavy pages), so a settled
+scroll reuses the raster instead of re-decoding it.
+
+## Tests
+
+- `pdf_graphics/test/image_downsample_test.dart` — box-filter correctness
+  (averaging, no-upscale, clamps, degenerate target).
+- `render_command_codec_test.dart` "image resolution cap" — tiny ratio
+  shrinks, huge/null ratio leaves native, transcript unchanged (pixels only).
+- `render_worker_test.dart` — end-to-end: `record(imagePixelRatio:)` ships
+  fewer pixels than the uncapped record.
+
+Ghent render baselines are untouched: the cap is worker-only and those
+tests render directly (no worker, no ratio).

--- a/doc/dev-log/2026-06-26-cad-perf-probe.md
+++ b/doc/dev-log/2026-06-26-cad-perf-probe.md
@@ -1,0 +1,152 @@
+# 2026-06-26 — CAD heavy-raster perf probe (testing loop)
+
+Ben reported the image-resolution cap "doesn't seem to be working" on the
+real 58 MB CAD file (LY9 FAR ... IFC.pdf). Built a reproducible testing loop
+and it pinned the behaviour immediately.
+
+## The loop
+
+`packages/dart_pdf_editor/test/cad_perf_probe_test.dart` drives the EXACT
+worker record path on the test isolate — interpret → `serializeCommands(
+decodeImages: true, maxImagePixelRatio: r)` → `deserializeCommands` →
+`decodedImageStats` / `pictureFromCommands` / `rasterize` — so the cap and the
+progressive vector-first pass are measurable without a browser or the compiled
+web worker. Skips unless a file is present (default `../../corpus/ly9-far-cad.pdf`,
+which is git-ignored, so CI skips it).
+
+```
+cd packages/dart_pdf_editor
+CAD_PDF=../../corpus/ly9-far-cad.pdf fvm flutter test test/cad_perf_probe_test.dart
+# knobs: CAD_PAGE (default: heaviest by scan), CAD_RATIO (px/pt, default 2.0),
+#        CAD_SCAN=0 to skip the per-page heavy-page scan
+```
+
+It prints per-page image megapixels (scan), then for the target page: native
+vs capped decoded MP, shipped buffer size, decode/serialize ms, full render
+ms, progressive vector-only first-paint ms, and asserts the cap honored its
+contract (decoded ≤ ~4×/0.9 the on-screen footprint, or a correct no-op).
+
+## What it found (page 29, a ~3868×1084 pt large-format sheet, 52 image layers)
+
+| ratio | cap result | decoded | buffer | full render | vector-first |
+|-------|-----------|---------|--------|-------------|--------------|
+| 0.3   | 8.3%      | 13.2 MP | 54 MB  | 143 ms      | 43 ms |
+| 0.5   | 23%       | 36.7 MP | 144 MB | 273 ms      | 45 ms |
+| 1.0   | 100%      | 159 MP  | 610 MB | ~1 s        | 75 ms |
+| 2.0   | 100%      | 159 MP  | 610 MB | 0.9–8.8 s   | 64 ms |
+
+Key facts:
+
+- **The cap only fires when zoomed far out (ratio ≲ 0.6).** At a normal retina
+  fit-to-window view (`_effectiveRatio` ≈ 2–2.5 for this sheet) it is a 100 %
+  no-op: 159 MP decoded, a **610 MB** RGBA command buffer, ~0.9 s+ raster. That
+  is exactly what Ben sees — the fix as built does nothing at the zoom he uses.
+- **Why the no-op is "correct" per the current contract:** the page's on-screen
+  image footprint at ratio 2.0 is **146.6 MP** — already ≈ native (159 MP). The
+  cap targets 2× the footprint, so there is nothing to trim. The images are not
+  individually oversized at this zoom.
+- **But footprint (146 MP) ≫ the page raster (16.78 MP, the maxPixels ceiling)
+  by ~8.7×.** The 52 layers overlap / overdraw heavily, so we decode and ship
+  ~8.7× more image pixels than the page raster can ever show. The per-image cap
+  can't see this; it would need a *page-pixel-budget* cap.
+- **Decode (~2–4 s) is not reduced by the cap** even when it fires: the codec
+  decodes at native resolution first, *then* box-filters down. The 2 s decode is
+  the same at ratio 0.3 as at 2.0. This is the phase-1 "downsample on decode"
+  gap — only a smaller *buffer*/raster is saved today, not the decode.
+- **Progressive vector-first paint is 43–75 ms** in this harness — linework
+  lands instantly. The progressive path itself works.
+
+## Conclusion / levers (not yet implemented — needs Ben's call)
+
+The stale-worker-bundle hypothesis is effectively ruled out: the cap is
+genuinely ineffective at retina zoom for this overlap-heavy page, by design.
+Ordered by impact at the zoom Ben actually uses:
+
+1. **Page-pixel-budget cap** (new): bound *total* decoded image pixels per page
+   to a small multiple of the page raster cap (≈16.78 MP), not each image to
+   its own footprint. Would cut 159 MP → ~33 MP at ratio 2.0. Architecturally
+   significant — changes cap semantics from per-image to page-aware.
+2. **Downsample-on-decode (phase 1)**: produce reduced RGBA directly so the
+   2–4 s native decode shrinks too (today only the buffer/raster shrink).
+3. **Progressive first paint**: already ~60 ms here; confirm it actually shows
+   in the app (if not, the web worker wiring, not the cap, is the suspect).
+
+## In-app verification: the cap was a stale-bundle no-op, then a re-decode storm
+
+Running the real file in Chrome (`flutter run -d chrome`, `?perf` log) showed the
+cap doing nothing — page 29 still shipped **641 MB**. Cause: the web worker is a
+precompiled `web/pdf_render_worker.dart.js` (git-ignored, rebuilt by CI on
+deploy), and the local copies were from **Jun 16**, before any cap code. Rebuilt
+both (`app/`, `example/`) with `dart run dart_pdf_editor:build_web_worker`; the
+cap then fired (page 4: 20.6→11.4 MB, progressive/`vector-first` live).
+
+But the rebuilt run exposed the real ceiling — **redundant + speculative worker
+decodes**, which the cap can't touch:
+
+- Each heavy page costs ~**8 s** to FlateDecode in the worker (sequential, one
+  isolate). All 52 images on page 29 are FlateDecode 2048×2048.
+- The worker decode is **uncached**, and `ListView` recycles a `PdfPageView`'s
+  State on scroll-out, dropping its `_picture` — so scroll-back re-decodes from
+  scratch. Observed page 22 decoded **7×**.
+- `previewWindow = 20` fired prefetch records for **±20 pages = 41 pages**, each
+  paying the full 8 s decode just to rasterize a 200px thumbnail (the cap
+  downsamples the output, not the decode). The single worker churned for 150 s+.
+
+### Landed (Bluebeam-study sequence step 1: cache + trim prefetch)
+
+Studied how Bluebeam/PDFium/Forge/Qoppa render large CAD (GPU raster, iterative
+LOD, viewport culling + tiling, prefetch+debounce, multithreaded tiles). It
+confirmed cache+prefetch as the cheap correct next step and flagged
+viewport-tile decode + a worker pool as the higher-ceiling follow-ups.
+
+- **`PdfCachingRenderWorker`** (`render_worker.dart`) — an LRU decorator around
+  the platform worker, keyed by (page, annotations, decodeImages, ratio bucket),
+  bounded by decoded bytes (default 96 MB), one-page-over-budget skipped, no
+  in-flight dedup (keeps it clear of the worker's cancel/priority logic).
+  `PdfRenderWorker.start` wraps every worker in it; cache dies with the worker
+  (new doc → new worker → fresh cache). A recycled page is now a map lookup, not
+  an 8 s re-decode. Test seam `PdfRenderWorker.startUncached` for the
+  queue/cancel/priority tests (caching short-circuits those by design). Library
+  stays Flutter-free so the web worker still compiles via `dart compile js` —
+  hence `startUncached` carries no `@visibleForTesting`. Tests in
+  `render_worker_test.dart` ("PdfCachingRenderWorker" group).
+- **`previewWindow` default 20 → 6** (`pdf_viewer.dart`) — bounds the prefetch
+  flood from 41 heavy decodes to 13; revisits are free now via the cache.
+
+Both changes are main-isolate only (no worker-bundle rebuild needed). Next per
+the agreed sequence: **viewport-culled tile decode** for the large-format
+sheets, then a **worker pool** for the serial 8 s-per-page floor.
+
+## Landed: page-pixel-budget cap (`_imageBudgetFactor = 2.5`)
+
+`serializeCommands` now runs a cheap declared-size pre-pass (`_imageBudgetScale`,
+no decode) and, when the per-image-capped target areas sum past
+`2.5 × 16.78 MP ≈ 42 MP`, applies a global linear downscale on top of the
+per-image cap (`_capImageResolution(..., budgetScale)`). Tunable via the new
+`imageBudgetFactor` param; threaded through the soft-mask recursion.
+
+Measured on page 29 (probe), retina zoom (ratio 2.0):
+
+| metric | before | after budget cap |
+|--------|--------|------------------|
+| decoded image pixels | 159 MP | **42 MP** |
+| command buffer shipped | 610 MB | **164 MB** (now under the 256 MB cache) |
+| full render | 0.9–8.8 s | **0.41 s** |
+| vector-first paint | — | ~0.05 s |
+
+The 164 MB buffer fits the decoded-image cache, so panning no longer thrashes
+it — the original jank cause. Tests: `pdf_graphics` "page image budget" group
+(forces the budget with a tiny factor on a Ghent image page), and the CAD probe
+asserts the binding ceiling at every zoom.
+
+## Phase 2 (downsample-on-decode) re-scoped — deferred
+
+Breakdown of the residual ~1.6 s decode: **all 52 images are FlateDecode
+2048×2048**, 27–69 ms each. zlib inflate is sequential — you cannot skip rows
+to decode at lower resolution, so the full 159 MP of samples must inflate
+regardless. Downsample-on-decode could only fuse the RGBA-expansion + box-filter
+passes (memory traffic), not the inflate floor → ceiling ~0.4–0.6 s on this
+file, off a **one-time, off-UI-thread** decode that the user never blocks on
+(linework is already up in ~50 ms). Low ROI; deferred pending real-app
+validation of the budget cap. The bundled decode_breakdown one-off lived in
+scratch.

--- a/doc/dev-log/2026-06-26-progressive-rendering.md
+++ b/doc/dev-log/2026-06-26-progressive-rendering.md
@@ -1,0 +1,56 @@
+# Progressive rendering: paint vector/text first, drop the raster in late
+
+## Why
+
+After the image-resolution cap landed, a heavy CAD page could still take
+~10 s to appear: the render worker decodes the page's raster underlay
+(JBIG2/CCITT/Flate over 100+ megapixels — a sequential, full-image decode)
+*before* it returns the command buffer, so the page stays blank until that
+finishes. Profiling the decode path showed the sample decode — not the RGBA
+expansion the cap removes — dominates that time and can't be skipped for
+these formats. So instead of shaving decode time, make the page *usable*
+while it decodes.
+
+## What
+
+A fast first pass that paints the page's vector/text immediately, then the
+existing full pass re-rasters with the images once they're decoded.
+
+- `PdfRenderWorker.record(..., decodeImages: false)` records the page but
+  ships its images **un-decoded** (just their streams), so the buffer comes
+  back in ~1 s even on a page whose underlay takes seconds. Threaded through
+  the abstract, isolate (`request[4]`), and web (`decodeImages` postMessage
+  field) backends; the web entry defaults it true so an older client still
+  decodes.
+- `PdfPageRenderer.pictureFromCommands(..., includeImages: false)` skips
+  image decoding entirely and replays with an empty image map — the
+  `CanvasPdfDevice` draws the linework and skips every image.
+- `PdfPageRenderer.hasImageDraws(commands)` tells the page whether a slow
+  full pass needs to follow the fast one.
+- `_PdfPageViewState._paintVectorFirst` (run from `_renderNow` on the first
+  interpret) does the fast record → vector-only picture → raster → paint.
+  It deliberately leaves `_rasteredRatio` null so the full pass's
+  resolution-unchanged guard doesn't skip the re-raster that brings the
+  images in, and only adopts its raster if the full pass hasn't already
+  landed. When the page draws no images the fast buffer is the whole page,
+  so it's cached as `_picture` and the full pass reuses it — no second
+  record.
+
+No color-conversion code changed, so Ghent/PDF.js baselines are untouched.
+
+## Trade-offs / follow-ups
+
+- Image-bearing pages now record twice (vector, then full) — the content
+  walk runs twice in the worker, off the UI thread. Wasteful for light
+  pages but invisible (both fast); the win is all on heavy pages. A future
+  optimization could have the worker keep the buffer and decode-on-demand
+  to avoid the second walk.
+- A full-page scan with little vector content shows mostly blank during the
+  fast pass (then fills in) — still strictly better than blank-for-10 s.
+- Still ahead (the other phases discussed): downsample-on-decode (drop the
+  489 MB allocation + filter pass) and re-decode the visible region sharper
+  on deep zoom.
+- Reminder: all of this runs in the worker bundle (`pdf_render_worker.dart.js`),
+  which is compiled separately — it must be rebuilt
+  (`dart run dart_pdf_editor:build_web_worker`) for the change to take effect
+  on web.

--- a/packages/dart_pdf_editor/example/tool/cad_web_perf.sh
+++ b/packages/dart_pdf_editor/example/tool/cad_web_perf.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Self-driven web perf harness for the heavy CAD sheet.
+# Builds the example web app so it auto-opens corpus/ly9-far-cad.pdf, stages the
+# PDF same-origin (no CORS), and serves build/web on :8753. Then drive Chrome to
+# http://127.0.0.1:8753/?perf=1 and read the [perf ...] console logs.
+#
+#   bash tool/cad_web_perf.sh            # build + stage + serve (foreground)
+#   bash tool/cad_web_perf.sh --serve    # skip rebuild, just (re)serve
+set -euo pipefail
+cd "$(dirname "$0")/.."                       # packages/dart_pdf_editor/example
+ROOT=../../..
+PDF="$ROOT/corpus/ly9-far-cad.pdf"
+PORT=8753
+
+if [[ "${1:-}" != "--serve" ]]; then
+  [[ -f "$PDF" ]] || { echo "missing $PDF" >&2; exit 1; }
+  fvm flutter build web --release --dart-define=PDF=cad.pdf
+  # worker bundle is git-ignored; rebuild if stale, then copy into the build
+  [[ -f web/pdf_render_worker.dart.js ]] || fvm dart run dart_pdf_editor:build_web_worker
+  cp web/pdf_render_worker.dart.js build/web/
+  cp "$PDF" build/web/cad.pdf
+fi
+echo "serving http://127.0.0.1:$PORT/?perf=1  (Ctrl-C to stop)"
+exec python3 -m http.server "$PORT" --bind 127.0.0.1 --directory build/web

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -1678,10 +1678,12 @@ class _PageThumbnailState extends State<_PageThumbnail> {
         // priority 2: thumbnails yield to the on-screen page (0) and its
         // previews (1); the heavy interpret runs on the isolate, only the
         // small replay + raster stays here. Image pages and the web
-        // fallback return null and rasterize locally as before.
+        // fallback return null and rasterize locally as before. The thumbnail
+        // rasterizes at [ratio], so cap the worker's images to that — no need
+        // to ship a full-resolution raster underlay for a thumbnail.
         final commands = worker != null && worker.isActive
             ? await worker.record(pageIndex,
-                annotations: annotations, priority: 2)
+                annotations: annotations, priority: 2, imagePixelRatio: ratio)
             : null;
         if (!mounted || _pendingKey != key) return;
         final ui.Image image;

--- a/packages/dart_pdf_editor/lib/src/image_decoder.dart
+++ b/packages/dart_pdf_editor/lib/src/image_decoder.dart
@@ -11,8 +11,41 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 /// the xref cache hands back the same [CosStream] on every interpretation
 /// pass. Inline images are re-synthesized each pass, so they key by value
 /// ([PdfInlineImageKey]) or the paint-time lookup could never hit.
-Object pdfImageKey(PdfImageRequest request) =>
-    request.isInline ? PdfInlineImageKey(request.stream) : request.stream;
+///
+/// A request carrying worker-decoded pixels ([PdfImageRequest.decoded]) folds
+/// those pixels' dimensions into the key: the worker caps each image to display
+/// resolution (see `serializeCommands`'s `maxImagePixelRatio`), so the *same*
+/// source image can be decoded at two sizes — sharp for the on-screen page,
+/// tiny for its 200px preview. Keying by content alone would let one resolution
+/// evict and stand in for the other (a blurry page, or a needlessly huge
+/// preview); the dimensions disambiguate them so each caches on its own.
+Object pdfImageKey(PdfImageRequest request) {
+  if (!request.isInline) return request.stream;
+  final content = PdfInlineImageKey(request.stream);
+  final decoded = request.decoded;
+  return decoded == null
+      ? content
+      : PdfSizedImageKey(content, decoded.width, decoded.height);
+}
+
+/// An [PdfInlineImageKey] qualified by a decoded resolution — see [pdfImageKey].
+class PdfSizedImageKey {
+  PdfSizedImageKey(this.content, this.width, this.height);
+
+  final PdfInlineImageKey content;
+  final int width;
+  final int height;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfSizedImageKey &&
+      other.width == width &&
+      other.height == height &&
+      other.content == content;
+
+  @override
+  int get hashCode => Object.hash(content, width, height);
+}
 
 /// Value identity for an inline image: its parameter dictionary plus the
 /// raw data bytes.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -5,8 +5,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:pdf_document/pdf_document.dart';
-import 'package:pdf_graphics/pdf_graphics.dart'
-    show PdfRenderCommand, PdfDrawImageCommand, PdfEndSoftMaskedCommand;
+import 'package:pdf_graphics/pdf_graphics.dart' show PdfRenderCommand;
 
 import 'perf_log.dart';
 import 'preview_cache.dart';
@@ -425,29 +424,15 @@ class _PdfPageViewState extends State<PdfPageView> {
   }
 
   /// Reports, when the perf log is on, how many images a worker buffer carries
-  /// and their total decoded ("capped") megapixels — the deciding number for
-  /// why a raster-heavy page is still slow: one oversized image escaping the
+  /// and their total decoded megapixels — the deciding number for why a
+  /// raster-heavy page is still slow: one oversized image escaping the
   /// resolution cap looks very different from many tiles each capped but
-  /// summing large. Cheap and skipped entirely when the log is off.
+  /// summing large. The walk lives in [PdfPageRenderer.decodedImageStats] (and
+  /// is tested there); this only formats the line, and is skipped entirely when
+  /// the log is off.
   void _logImageStats(int pageIndex, List<PdfRenderCommand> commands) {
     if (!PdfPerfLog.enabled) return;
-    var count = 0;
-    var pixels = 0;
-    void walk(List<PdfRenderCommand> cs) {
-      for (final c in cs) {
-        if (c is PdfDrawImageCommand) {
-          final d = c.request.decoded;
-          if (d != null) {
-            count++;
-            pixels += d.width * d.height;
-          }
-        } else if (c is PdfEndSoftMaskedCommand) {
-          walk(c.maskCommands);
-        }
-      }
-    }
-
-    walk(commands);
+    final (count, pixels) = PdfPageRenderer.decodedImageStats(commands);
     if (count > 0) {
       PdfPerfLog.log('images page=$pageIndex count=$count '
           'decodedMpx=${(pixels / 1e6).toStringAsFixed(1)}');

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -174,6 +174,13 @@ class _PdfPageViewState extends State<PdfPageView> {
   // the detail patch takes over for the visible region.
   static const _maxPixels = 1 << 24;
   static const _maxDimension = 8192.0;
+  // Pixel budget for the progressive vector-first preview raster — a fraction
+  // of [_maxPixels]. The preview is transient (the full pass re-rasterizes at
+  // [_effectiveRatio] on settle), so bounding it keeps rasterizing a dense
+  // large-format CAD sheet's linework (~8000px wide, tens of thousands of
+  // vector ops) off the ~300ms GPU-raster spike that stutters a mid-scroll
+  // page-in. Normal-sized pages fit well under this, so they are unaffected.
+  static const _previewMaxPixels = 1 << 21;
 
   @override
   void initState() {
@@ -357,6 +364,20 @@ class _PdfPageViewState extends State<PdfPageView> {
     return math.max(ratio, 0.05);
   }
 
+  /// Resolution for the progressive vector-first preview raster: [_effectiveRatio]
+  /// further bounded by [_previewMaxPixels] so a dense large-format sheet paints
+  /// its linework quickly instead of spiking the GPU raster thread. The full
+  /// pass re-rasterizes at [_effectiveRatio] once the page settles, so the only
+  /// visible effect is a briefly softer preview while actively scrolling.
+  double _vectorFirstRatio() {
+    final size = PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
+    final width = math.max(1.0, size.width);
+    final height = math.max(1.0, size.height);
+    final ratio =
+        math.min(_effectiveRatio(), math.sqrt(_previewMaxPixels / (width * height)));
+    return math.max(ratio, 0.05);
+  }
+
   Future<void> _render() async {
     final scheduler = widget.renderScheduler;
     if (scheduler != null) {
@@ -460,7 +481,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     }
     final image = await PdfPageRenderer.rasterize(picture,
         PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation),
-        _effectiveRatio());
+        _vectorFirstRatio());
     picture.dispose();
     // Adopt the vector raster only if the full pass hasn't already landed (a
     // landed full raster has a non-null _rasteredRatio). Deliberately leave

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -5,6 +5,8 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart'
+    show PdfRenderCommand, PdfDrawImageCommand, PdfEndSoftMaskedCommand;
 
 import 'perf_log.dart';
 import 'preview_cache.dart';
@@ -408,6 +410,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       if (_abandoned(pageIndex)) return _emptyPicture();
       if (commands != null) {
         _lastInterpretPath = 'worker';
+        _logImageStats(pageIndex, commands);
         return PdfPageRenderer.pictureFromCommands(widget.page, commands,
             pageColor: widget.pageColor, rotation: widget.rotation);
       }
@@ -419,6 +422,36 @@ class _PdfPageViewState extends State<PdfPageView> {
     return PdfPageRenderer.renderPictureRecorded(widget.page,
         pageColor: widget.pageColor, annotations: widget.showAnnotations,
         rotation: widget.rotation);
+  }
+
+  /// Reports, when the perf log is on, how many images a worker buffer carries
+  /// and their total decoded ("capped") megapixels — the deciding number for
+  /// why a raster-heavy page is still slow: one oversized image escaping the
+  /// resolution cap looks very different from many tiles each capped but
+  /// summing large. Cheap and skipped entirely when the log is off.
+  void _logImageStats(int pageIndex, List<PdfRenderCommand> commands) {
+    if (!PdfPerfLog.enabled) return;
+    var count = 0;
+    var pixels = 0;
+    void walk(List<PdfRenderCommand> cs) {
+      for (final c in cs) {
+        if (c is PdfDrawImageCommand) {
+          final d = c.request.decoded;
+          if (d != null) {
+            count++;
+            pixels += d.width * d.height;
+          }
+        } else if (c is PdfEndSoftMaskedCommand) {
+          walk(c.maskCommands);
+        }
+      }
+    }
+
+    walk(commands);
+    if (count > 0) {
+      PdfPerfLog.log('images page=$pageIndex count=$count '
+          'decodedMpx=${(pixels / 1e6).toStringAsFixed(1)}');
+    }
   }
 
   /// Whether the page this render was for is gone — the widget unmounted, or

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -423,6 +423,62 @@ class _PdfPageViewState extends State<PdfPageView> {
         rotation: widget.rotation);
   }
 
+  /// Progressive rendering's fast first pass: records the page WITHOUT decoding
+  /// its images (so it returns quickly even when a raster underlay takes
+  /// seconds to decode) and paints the vector/text at once, images skipped.
+  /// The full pass in [_renderNow] then re-rasters with the images in. No-op
+  /// without an active worker (the local render already decodes inline).
+  ///
+  /// When the page draws no images the fast buffer is the whole page, so it is
+  /// cached as [_picture] for the full pass to reuse — no second record.
+  Future<void> _paintVectorFirst(int generation, int pageIndex) async {
+    final worker = widget.renderWorker;
+    if (worker == null || !worker.isActive) return;
+    final commands = await worker.record(pageIndex,
+        annotations: widget.showAnnotations,
+        priority: 0,
+        decodeImages: false);
+    if (_superseded(generation, pageIndex) || commands == null) return;
+
+    if (!PdfPageRenderer.hasImageDraws(commands)) {
+      // Image-free page: this fast buffer already is the complete page. Cache
+      // it so the full pass reuses it instead of recording a second time; the
+      // normal raster path below paints it.
+      _picture = PdfPageRenderer.pictureFromCommands(widget.page, commands,
+          pageColor: widget.pageColor, rotation: widget.rotation);
+      return;
+    }
+
+    final picture = await PdfPageRenderer.pictureFromCommands(
+        widget.page, commands,
+        pageColor: widget.pageColor,
+        rotation: widget.rotation,
+        includeImages: false);
+    if (_superseded(generation, pageIndex)) {
+      picture.dispose();
+      return;
+    }
+    final image = await PdfPageRenderer.rasterize(picture,
+        PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation),
+        _effectiveRatio());
+    picture.dispose();
+    // Adopt the vector raster only if the full pass hasn't already landed (a
+    // landed full raster has a non-null _rasteredRatio). Deliberately leave
+    // _rasteredRatio null so the full pass below is not skipped by its
+    // resolution-unchanged guard — it must re-raster to bring the images in.
+    if (_superseded(generation, pageIndex) || _rasteredRatio != null) {
+      image.dispose();
+      return;
+    }
+    setState(() {
+      _image?.dispose();
+      _image = image;
+      _preview?.dispose();
+      _preview = null;
+    });
+    PdfPerfLog.log('vector-first page=$pageIndex');
+  }
+
   /// Reports, when the perf log is on, how many images a worker buffer carries
   /// and their total decoded megapixels — the deciding number for why a
   /// raster-heavy page is still slow: one oversized image escaping the
@@ -468,6 +524,14 @@ class _PdfPageViewState extends State<PdfPageView> {
     final generation = ++_renderGeneration;
     final pageIndex = widget.previewIndex;
     final firstInterpret = _picture == null;
+    // Progressive first paint: on a page's first interpret, paint its
+    // vector/text immediately (images skipped) so a heavy raster underlay —
+    // which can take seconds to decode — doesn't leave the page blank
+    // meanwhile. The full pass below then re-rasters with the images in.
+    if (firstInterpret) {
+      await _paintVectorFirst(generation, pageIndex);
+      if (_superseded(generation, pageIndex)) return;
+    }
     final sw = Stopwatch()..start();
     final picture = await (_picture ??= _interpretPicture());
     sw.stop();

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -389,9 +389,15 @@ class _PdfPageViewState extends State<PdfPageView> {
     final pageIndex = widget.previewIndex;
     final worker = widget.renderWorker;
     if (worker != null && worker.isActive) {
-      // priority 0: the on-screen page preempts background prefetch
+      // priority 0: the on-screen page preempts background prefetch.
+      // imagePixelRatio caps embedded images to ~2x the page's on-screen
+      // resolution so a CAD raster underlay isn't decoded/shipped/rasterized
+      // at its native 100+ megapixels (the deep-zoom patch re-rasters the
+      // visible region for sharper zoom).
       final commands = await worker.record(pageIndex,
-          annotations: widget.showAnnotations, priority: 0);
+          annotations: widget.showAnnotations,
+          priority: 0,
+          imagePixelRatio: _effectiveRatio());
       // Abandoned while the worker ran — the State was disposed or the lazy
       // list recycled it onto another page (this is the cancel() path: a
       // cancelled request returns null). Skip the local fallback: the page is

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -487,7 +487,7 @@ class PdfViewer extends StatefulWidget {
     this.highlightFormFields = true,
     this.interactiveForms = true,
     this.pagePreviews = true,
-    this.previewWindow = 20,
+    this.previewWindow = 6,
     this.predictStrokes = true,
     this.renderWorker,
     this.rasterCache,
@@ -675,15 +675,19 @@ class PdfViewer extends StatefulWidget {
   final bool pagePreviews;
 
   /// How many pages on each side of the current page the background
-  /// prerender ([pagePreviews]) warms. Each preview is a full synchronous
-  /// interpreter walk, so on a heavy document warming every page stutters
-  /// the UI thread for seconds after open; bounding the proactive warm to
-  /// a window around the viewport keeps it focused on pages the user might
-  /// fast-scroll to. The window recenters automatically as the user
-  /// navigates. Pages outside the window still get a preview for free when
-  /// they're scrolled onto screen (their on-screen render feeds the cache).
-  /// `<= 0` warms every page (the historical behavior — fine for short
-  /// documents where warming everything is cheap).
+  /// prerender ([pagePreviews]) warms. Each preview drives a worker record
+  /// (or a synchronous interpreter walk without a worker), and on a
+  /// raster-heavy page that record pays the full image decode — seconds of
+  /// inflate + colour-convert — even though the preview only rasterizes a
+  /// ~200px thumbnail (the decode happens at native resolution, then
+  /// downsamples). A wide window therefore floods the single worker with
+  /// dozens of multi-second decodes, starving the on-screen page the user is
+  /// waiting on. Keeping the window small bounds that flood; revisits are
+  /// cheap anyway now that the worker caches completed records
+  /// ([PdfCachingRenderWorker]). The window recenters as the user navigates,
+  /// and pages outside it still get a preview for free when scrolled onto
+  /// screen (their on-screen render feeds the cache). `<= 0` warms every page
+  /// (historical behavior — fine for short, light documents).
   final int previewWindow;
 
   /// Draws a short speculative "lead" ahead of the pen while an ink stroke

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -117,9 +117,13 @@ class PdfPagePreviewCache extends ChangeNotifier {
       final sw = Stopwatch()..start();
       final size = PdfPageRenderer.pageSize(page, rotation: rotation);
       final ratio = _ratioFor(size);
-      // priority 1: prefetch yields to any on-screen page the worker owes
+      // priority 1: prefetch yields to any on-screen page the worker owes.
+      // The preview is rasterized at [ratio] (longest side ~200px), so cap the
+      // worker's images to that — a heavy raster underlay need not ship at full
+      // resolution just to be downscaled into a thumbnail.
       final commands = worker != null && worker.isActive
-          ? await worker.record(index, annotations: annotations, priority: 1)
+          ? await worker.record(index,
+              annotations: annotations, priority: 1, imagePixelRatio: ratio)
           : null;
       if (_disposed || isFresh(index, page)) return;
       final ui.Image image;

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -236,10 +236,30 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
     if (weight > _budgetBytes) return; // one page bigger than the cache itself
     _cache[key] = _CachedRecord(commands, weight);
     _bytes += weight;
-    while (_bytes > _budgetBytes && _cache.length > 1) {
-      final oldest = _cache.keys.first;
-      _bytes -= _cache.remove(oldest)!.weight;
+    // Evict the least-recently-used entries that actually hold bytes until
+    // under budget. The budget bounds DECODED image memory, so evicting a
+    // weight-0 buffer (a vector-first pass or an image-free page) frees
+    // nothing — yet it would have to be re-decoded on the next revisit. On a
+    // heavy CAD sheet the full-image buffers (tens of MB each) are exactly
+    // what blows the budget while the cheap vector-first buffers are the ones
+    // re-requested every scroll settle, so a blind oldest-first eviction
+    // discarded the very entries the cache exists to keep. Skip the costless
+    // ones and never evict the entry we just inserted.
+    while (_bytes > _budgetBytes) {
+      final victim = _oldestHeavyKey(except: key);
+      if (victim == null) break; // nothing left worth evicting
+      _bytes -= _cache.remove(victim)!.weight;
     }
+  }
+
+  /// The least-recently-used key whose buffer holds decoded bytes (weight > 0),
+  /// other than [except] (the entry just inserted, which we keep). Null when no
+  /// such entry exists — every remaining buffer is costless, so eviction stops.
+  (int, bool, bool, int)? _oldestHeavyKey({required (int, bool, bool, int) except}) {
+    for (final entry in _cache.entries) {
+      if (entry.value.weight > 0 && entry.key != except) return entry.key;
+    }
+    return null;
   }
 
   /// Quantises the image-pixel ratio so tiny per-frame jitter (a 1px layout

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -65,8 +65,19 @@ abstract class PdfRenderWorker {
   /// resolution the page will be shown at; a raster-heavy CAD sheet then ships
   /// a display-sized underlay instead of its native 100+ megapixels. Null
   /// leaves images at native resolution.
+  ///
+  /// [decodeImages] false records the page's vector/text but ships its images
+  /// un-decoded (just their streams), so the buffer comes back fast even on a
+  /// page whose raster underlay takes seconds to decode — the fast first pass
+  /// of progressive rendering. The caller replays it with
+  /// `PdfPageRenderer.pictureFromCommands(includeImages: false)` to paint the
+  /// linework immediately, then records again with [decodeImages] true for the
+  /// images. Default true (decode in the worker, the normal full render).
   Future<List<PdfRenderCommand>?> record(int pageIndex,
-      {bool annotations = true, int priority = 0, double? imagePixelRatio});
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true});
 
   /// Drops any QUEUED (not yet started) [record] request for [pageIndex] at
   /// [priority], completing its future with null — as if the page had declined

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -43,7 +43,22 @@ abstract class PdfRenderWorker {
   /// script at [pdfRenderWorkerScriptUrl] when one is configured (else a null
   /// worker). Platforms without either: a null worker whose [record] always
   /// defers to local rendering.
-  static PdfRenderWorker start(Uint8List bytes) => startRenderWorker(bytes);
+  ///
+  /// The platform worker is wrapped in a [PdfCachingRenderWorker] so a page
+  /// the lazy list recycles and rebuilds is served from cache instead of being
+  /// re-decoded from scratch (see that class). The cache is per-worker, so it
+  /// is fresh for each document.
+  static PdfRenderWorker start(Uint8List bytes) =>
+      PdfCachingRenderWorker(startRenderWorker(bytes));
+
+  /// The raw platform worker, NOT wrapped in [PdfCachingRenderWorker]. Test-
+  /// only: for exercising the inner queue/cancel/priority contract, which the
+  /// cache is designed to short-circuit (a cached page never re-enters the
+  /// queue). Production code uses [start]. (No `@visibleForTesting` annotation
+  /// because this library stays Flutter-free so the web worker can compile via
+  /// `dart compile js` without pulling in Flutter.)
+  static PdfRenderWorker startUncached(Uint8List bytes) =>
+      startRenderWorker(bytes);
 
   /// Records page [pageIndex] off-thread and returns its replayable command
   /// buffer (image XObjects decoded off-thread and attached), or null when the
@@ -104,4 +119,158 @@ abstract class PdfRenderWorker {
   /// Tears the worker down (kills the isolate, fails pending requests with
   /// null). Idempotent.
   void dispose();
+}
+
+/// Wraps a [PdfRenderWorker] with an LRU cache of completed [record] results,
+/// keyed by (page, annotations, decodeImages, image-ratio bucket). The lazy
+/// page list recycles a [PdfPageView]'s State when it scrolls out of view and
+/// re-creates it on the way back, dropping the State's cached picture — so
+/// without this every scroll-back re-asks the worker to decode the page from
+/// scratch (a multi-second inflate + colour-convert on a raster-heavy CAD
+/// sheet, observed re-running ~7× for one page during a single scroll). A
+/// page's bytes don't change under the worker (it holds a fixed snapshot), so
+/// a completed buffer stays valid for the worker's whole life — caching it
+/// makes a revisit a map lookup instead of a re-decode. The cache lives on the
+/// worker, so it is shared across every recycled page widget and dies with the
+/// worker (a new document opens a new worker, hence a fresh cache).
+///
+/// Bounded by total decoded image bytes ([budgetBytes]); the least-recently
+/// used entries evict first. A single buffer larger than the whole budget (a
+/// huge large-format sheet) is not cached at all rather than evicting
+/// everything else for one page.
+///
+/// In-flight requests are also deduplicated: a second record for a key whose
+/// decode is still running shares that pending future instead of starting a
+/// new decode. This is the dominant win on a fast scroll — the render
+/// scheduler re-grants the same window of pages every ~2s while the worker is
+/// still chewing through the first batch (each heavy page is a multi-second
+/// decode), so a completion-only cache never gets the chance to intercept; the
+/// requests pile up before any finishes. Sharing the in-flight future collapses
+/// those repeats into one decode per page. A scrolled-away page is cancelled
+/// for every sharer at once, which is correct — none of them want it any more.
+class PdfCachingRenderWorker implements PdfRenderWorker {
+  PdfCachingRenderWorker(this._inner, {int budgetBytes = 96 << 20})
+      : _budgetBytes = budgetBytes;
+
+  final PdfRenderWorker _inner;
+  final int _budgetBytes;
+
+  // LinkedHashMap iteration order doubles as LRU order: a hit re-inserts to
+  // the end, eviction takes the oldest (first) key.
+  final _cache = <(int, bool, bool, int), _CachedRecord>{};
+  // Keys whose decode is running now, so concurrent requests share one decode.
+  final _inflight = <(int, bool, bool, int), Future<List<PdfRenderCommand>?>>{};
+  int _bytes = 0;
+
+  @override
+  bool get isActive => _inner.isActive;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true}) {
+    if (!_inner.isActive) {
+      return _inner.record(pageIndex,
+          annotations: annotations,
+          priority: priority,
+          imagePixelRatio: imagePixelRatio,
+          decodeImages: decodeImages);
+    }
+    final key = (
+      pageIndex,
+      annotations,
+      decodeImages,
+      _ratioBucket(imagePixelRatio),
+    );
+    final hit = _cache.remove(key);
+    if (hit != null) {
+      _cache[key] = hit; // re-insert: now most-recently used
+      return Future.value(hit.commands);
+    }
+    final pending = _inflight[key];
+    if (pending != null) return pending; // a decode for this key is running
+    final future = _recordAndStore(key, pageIndex,
+        annotations: annotations,
+        priority: priority,
+        imagePixelRatio: imagePixelRatio,
+        decodeImages: decodeImages);
+    _inflight[key] = future;
+    return future;
+  }
+
+  Future<List<PdfRenderCommand>?> _recordAndStore(
+      (int, bool, bool, int) key, int pageIndex,
+      {required bool annotations,
+      required int priority,
+      required double? imagePixelRatio,
+      required bool decodeImages}) async {
+    try {
+      final commands = await _inner.record(pageIndex,
+          annotations: annotations,
+          priority: priority,
+          imagePixelRatio: imagePixelRatio,
+          decodeImages: decodeImages);
+      if (commands != null) _store(key, commands);
+      return commands;
+    } finally {
+      _inflight.remove(key);
+    }
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) =>
+      _inner.cancel(pageIndex, priority: priority);
+
+  @override
+  void dispose() {
+    _cache.clear();
+    _inflight.clear();
+    _bytes = 0;
+    _inner.dispose();
+  }
+
+  void _store((int, bool, bool, int) key, List<PdfRenderCommand> commands) {
+    final weight = _weigh(commands);
+    if (weight > _budgetBytes) return; // one page bigger than the cache itself
+    _cache[key] = _CachedRecord(commands, weight);
+    _bytes += weight;
+    while (_bytes > _budgetBytes && _cache.length > 1) {
+      final oldest = _cache.keys.first;
+      _bytes -= _cache.remove(oldest)!.weight;
+    }
+  }
+
+  /// Quantises the image-pixel ratio so tiny per-frame jitter (a 1px layout
+  /// wobble) still hits the cache, while a real zoom step lands in a new
+  /// bucket. Null (vector-first pass, no decode) gets its own bucket.
+  static int _ratioBucket(double? ratio) =>
+      ratio == null ? -1 : (ratio * 8).round();
+
+  /// A buffer's weight ≈ its decoded image bytes (premultiplied RGBA), which
+  /// dominate; command objects themselves are negligible. Recurses soft-mask
+  /// groups, matching what the worker actually decoded.
+  static int _weigh(List<PdfRenderCommand> commands) {
+    var bytes = 0;
+    void walk(List<PdfRenderCommand> cmds) {
+      for (final c in cmds) {
+        if (c is PdfDrawImageCommand) {
+          final d = c.request.decoded;
+          if (d != null) bytes += d.width * d.height * 4;
+        } else if (c is PdfEndSoftMaskedCommand) {
+          walk(c.maskCommands);
+        }
+      }
+    }
+
+    walk(commands);
+    return bytes;
+  }
+}
+
+class _CachedRecord {
+  _CachedRecord(this.commands, this.weight);
+  final List<PdfRenderCommand> commands;
+  final int weight;
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -58,8 +58,15 @@ abstract class PdfRenderWorker {
   /// [priority] orders the worker's single queue — lower is served first, so
   /// the on-screen page (0) preempts background prefetch (1) even though the
   /// isolate processes one page at a time.
+  ///
+  /// [imagePixelRatio] (screen pixels per page point, device pixel ratio
+  /// included) caps each decoded image to display resolution before it is
+  /// serialized — see `serializeCommands`'s `maxImagePixelRatio`. Pass the
+  /// resolution the page will be shown at; a raster-heavy CAD sheet then ships
+  /// a display-sized underlay instead of its native 100+ megapixels. Null
+  /// leaves images at native resolution.
   Future<List<PdfRenderCommand>?> record(int pageIndex,
-      {bool annotations = true, int priority = 0});
+      {bool annotations = true, int priority = 0, double? imagePixelRatio});
 
   /// Drops any QUEUED (not yet started) [record] request for [pageIndex] at
   /// [priority], completing its future with null — as if the page had declined

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -95,10 +95,11 @@ class _IsolateRenderWorker implements PdfRenderWorker {
   Future<List<PdfRenderCommand>?> record(int pageIndex,
       {bool annotations = true,
       int priority = 0,
-      double? imagePixelRatio}) async {
+      double? imagePixelRatio,
+      bool decodeImages = true}) async {
     if (_disposed || _spawnFailed) return null;
     final request = _PendingRequest(
-        priority, _seq++, pageIndex, annotations, imagePixelRatio);
+        priority, _seq++, pageIndex, annotations, imagePixelRatio, decodeImages);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -155,6 +156,7 @@ class _IsolateRenderWorker implements PdfRenderWorker {
       request.pageIndex,
       request.annotations,
       request.imagePixelRatio,
+      request.decodeImages,
     ]);
   }
 
@@ -199,13 +201,14 @@ class _IsolateRenderWorker implements PdfRenderWorker {
 /// One queued record request and its pending result.
 class _PendingRequest {
   _PendingRequest(this.priority, this.seq, this.pageIndex, this.annotations,
-      this.imagePixelRatio);
+      this.imagePixelRatio, this.decodeImages);
 
   final int priority;
   final int seq;
   final int pageIndex;
   final bool annotations;
   final double? imagePixelRatio;
+  final bool decodeImages;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }
@@ -246,14 +249,15 @@ void _workerMain(_WorkerInit init) {
     final pageIndex = request[1] as int;
     final annotations = request[2] as bool;
     final imagePixelRatio = request[3] as double?;
+    final decodeImages = request[4] as bool;
 
     final token = PdfCancellationToken();
     activeToken = token;
     Uint8List? buffer;
     try {
       if (document != null) {
-        buffer = await _recordPageAsync(
-            document, pageIndex, annotations, imagePixelRatio, token);
+        buffer = await _recordPageAsync(document, pageIndex, annotations,
+            imagePixelRatio, decodeImages, token);
       }
     } on PdfCancelledException {
       buffer = null;
@@ -270,8 +274,13 @@ void _workerMain(_WorkerInit init) {
 
 /// Records one page into a serialized command buffer, yielding periodically
 /// so the cancel port's listener can fire and set [token.cancelled].
-Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
-    bool annotations, double? imagePixelRatio, PdfCancellationToken token) async {
+Future<Uint8List?> _recordPageAsync(
+    PdfDocument document,
+    int pageIndex,
+    bool annotations,
+    double? imagePixelRatio,
+    bool decodeImages,
+    PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
   final ops = ContentStreamParser.parse(page.contentBytes());
@@ -282,6 +291,6 @@ Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
   if (annotations) interpreter.drawAnnotations(page);
   return serializeCommands(recorder.commands,
       cos: document.cos,
-      decodeImages: true,
+      decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio);
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -93,9 +93,12 @@ class _IsolateRenderWorker implements PdfRenderWorker {
 
   @override
   Future<List<PdfRenderCommand>?> record(int pageIndex,
-      {bool annotations = true, int priority = 0}) async {
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio}) async {
     if (_disposed || _spawnFailed) return null;
-    final request = _PendingRequest(priority, _seq++, pageIndex, annotations);
+    final request = _PendingRequest(
+        priority, _seq++, pageIndex, annotations, imagePixelRatio);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -147,7 +150,12 @@ class _IsolateRenderWorker implements PdfRenderWorker {
     }
     final request = _queue.removeAt(best)..id = _nextId++;
     _inFlight = request;
-    port.send([request.id, request.pageIndex, request.annotations]);
+    port.send([
+      request.id,
+      request.pageIndex,
+      request.annotations,
+      request.imagePixelRatio,
+    ]);
   }
 
   @override
@@ -190,12 +198,14 @@ class _IsolateRenderWorker implements PdfRenderWorker {
 
 /// One queued record request and its pending result.
 class _PendingRequest {
-  _PendingRequest(this.priority, this.seq, this.pageIndex, this.annotations);
+  _PendingRequest(this.priority, this.seq, this.pageIndex, this.annotations,
+      this.imagePixelRatio);
 
   final int priority;
   final int seq;
   final int pageIndex;
   final bool annotations;
+  final double? imagePixelRatio;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }
@@ -235,13 +245,15 @@ void _workerMain(_WorkerInit init) {
     final id = request[0] as int;
     final pageIndex = request[1] as int;
     final annotations = request[2] as bool;
+    final imagePixelRatio = request[3] as double?;
 
     final token = PdfCancellationToken();
     activeToken = token;
     Uint8List? buffer;
     try {
       if (document != null) {
-        buffer = await _recordPageAsync(document, pageIndex, annotations, token);
+        buffer = await _recordPageAsync(
+            document, pageIndex, annotations, imagePixelRatio, token);
       }
     } on PdfCancelledException {
       buffer = null;
@@ -259,7 +271,7 @@ void _workerMain(_WorkerInit init) {
 /// Records one page into a serialized command buffer, yielding periodically
 /// so the cancel port's listener can fire and set [token.cancelled].
 Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
-    bool annotations, PdfCancellationToken token) async {
+    bool annotations, double? imagePixelRatio, PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
   final ops = ContentStreamParser.parse(page.contentBytes());
@@ -269,5 +281,7 @@ Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
   await interpreter.drawPageOperationsAsync(page, ops);
   if (annotations) interpreter.drawAnnotations(page);
   return serializeCommands(recorder.commands,
-      cos: document.cos, decodeImages: true);
+      cos: document.cos,
+      decodeImages: true,
+      maxImagePixelRatio: imagePixelRatio);
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -17,7 +17,9 @@ class _NullRenderWorker implements PdfRenderWorker {
 
   @override
   Future<List<PdfRenderCommand>?> record(int pageIndex,
-          {bool annotations = true, int priority = 0}) async =>
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -19,7 +19,8 @@ class _NullRenderWorker implements PdfRenderWorker {
   Future<List<PdfRenderCommand>?> record(int pageIndex,
           {bool annotations = true,
           int priority = 0,
-          double? imagePixelRatio}) async =>
+          double? imagePixelRatio,
+          bool decodeImages = true}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -24,10 +24,20 @@ void _wlog(String m) => PdfPerfLog.log('webworker $m');
 /// this only fires when the worker is genuinely wedged.
 Duration pdfRenderWorkerReadyTimeout = const Duration(seconds: 12);
 
-/// How long to wait for a single [PdfRenderWorker.record] reply before treating
-/// the worker as unresponsive and falling back to local rendering. The worst
-/// real page records in well under a second, so this only fires on a hang.
-Duration pdfRenderWorkerRecordTimeout = const Duration(seconds: 20);
+/// How long to wait for a single [PdfRenderWorker.record] reply before giving up
+/// on that one in-flight page. A heavy large-format CAD sheet's image decode can
+/// genuinely take tens of seconds in the web worker (pure-Dart zlib inflate of a
+/// multi-megapixel raster, compiled to JS/WASM), so this is generous — it exists
+/// to free a wedged in-flight slot, not to police slow-but-progressing decodes.
+/// A single miss drops only its own page (see [_WebRenderWorker]); the worker
+/// keeps serving every other page. Only [pdfRenderWorkerTimeoutsBeforeFail]
+/// consecutive misses — the signature of a genuinely dead worker — tear it down.
+Duration pdfRenderWorkerRecordTimeout = const Duration(seconds: 90);
+
+/// Consecutive record timeouts that mark the worker dead (so the viewer stops
+/// round-tripping and renders locally). One slow page is not a dead worker;
+/// several misses in a row with no successful reply in between is.
+int pdfRenderWorkerTimeoutsBeforeFail = 3;
 
 /// Web backend: a dedicated [web.Worker] that opens its own [PdfDocument] from
 /// the bytes once and records pages on request, posting the serialized command
@@ -104,6 +114,11 @@ class _WebRenderWorker implements PdfRenderWorker {
   // record's reply. See pdfRenderWorkerReadyTimeout / pdfRenderWorkerRecordTimeout.
   Timer? _readyWatchdog;
   Timer? _recordWatchdog;
+  // Consecutive record watchdog misses with no reply in between. A healthy
+  // worker chewing through one heavy page resets this the moment any reply
+  // lands; only a run of misses ([pdfRenderWorkerTimeoutsBeforeFail]) condemns
+  // the worker as dead.
+  int _consecutiveTimeouts = 0;
 
   @override
   bool get isActive => !_disposed && !_failed;
@@ -127,6 +142,7 @@ class _WebRenderWorker implements PdfRenderWorker {
     _inFlight = null;
     _recordWatchdog?.cancel();
     _recordWatchdog = null;
+    _consecutiveTimeouts = 0; // a reply landed: the worker is alive
     final buffer = data.getProperty('buffer'.toJS) as JSArrayBuffer?;
     final bytes = buffer?.toDart.asUint8List();
     final err = (data.getProperty('error'.toJS) as JSString?)?.toDart;
@@ -212,18 +228,33 @@ class _WebRenderWorker implements PdfRenderWorker {
     worker.postMessage(message);
 
     // Watchdog: a record that never comes back wedges the single in-flight slot
-    // (and so every queued page) forever. Bound it — on a miss, treat the
-    // worker as unresponsive and degrade to local rendering for this and all
-    // subsequent pages.
+    // (and so every queued page) forever. Bound it — but a miss frees only THIS
+    // page (the worker keeps serving the rest), because a heavy sheet that is
+    // merely slow is not a dead worker. Killing the whole worker on one slow
+    // page is what dumped the entire document onto the UI thread. Only a run of
+    // misses with no reply in between condemns the worker.
     _recordWatchdog?.cancel();
     final inFlightId = request.id;
     _recordWatchdog = Timer(pdfRenderWorkerRecordTimeout, () {
       if (_disposed || _failed) return;
       if (_inFlight?.id != inFlightId) return; // already answered
-      _wlog('record watchdog fired for page=${request.pageIndex} after '
-          '${pdfRenderWorkerRecordTimeout.inSeconds}s — worker unresponsive; '
-          'falling back to local');
-      _fail();
+      _inFlight = null;
+      _recordWatchdog = null;
+      _consecutiveTimeouts++;
+      if (_consecutiveTimeouts >= pdfRenderWorkerTimeoutsBeforeFail) {
+        _wlog('record watchdog: page=${request.pageIndex} timed out after '
+            '${pdfRenderWorkerRecordTimeout.inSeconds}s — '
+            '$_consecutiveTimeouts misses in a row; worker is dead, '
+            'falling back to local for all pages');
+        _fail();
+        return;
+      }
+      _wlog('record watchdog: page=${request.pageIndex} timed out after '
+          '${pdfRenderWorkerRecordTimeout.inSeconds}s — dropping this page to '
+          'local; worker stays up ($_consecutiveTimeouts/'
+          '$pdfRenderWorkerTimeoutsBeforeFail before giving up)');
+      if (!request.completer.isCompleted) request.completer.complete(null);
+      _pump(); // serve the next queued page
     });
   }
 

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -139,13 +139,16 @@ class _WebRenderWorker implements PdfRenderWorker {
 
   @override
   Future<List<PdfRenderCommand>?> record(int pageIndex,
-      {bool annotations = true, int priority = 0}) async {
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio}) async {
     if (_disposed || _failed) {
       _wlog('record page=$pageIndex skipped (disposed=$_disposed '
           'failed=$_failed) → local');
       return null;
     }
-    final request = _WebPending(priority, _seq++, pageIndex, annotations);
+    final request =
+        _WebPending(priority, _seq++, pageIndex, annotations, imagePixelRatio);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -202,6 +205,8 @@ class _WebRenderWorker implements PdfRenderWorker {
       ..setProperty('id'.toJS, request.id.toJS)
       ..setProperty('page'.toJS, request.pageIndex.toJS)
       ..setProperty('annotations'.toJS, request.annotations.toJS);
+    final ratio = request.imagePixelRatio;
+    if (ratio != null) message.setProperty('imageRatio'.toJS, ratio.toJS);
     worker.postMessage(message);
 
     // Watchdog: a record that never comes back wedges the single in-flight slot
@@ -280,12 +285,14 @@ class _WebRenderWorker implements PdfRenderWorker {
 /// One queued record request and its pending result (mirrors the isolate
 /// backend's `_PendingRequest`).
 class _WebPending {
-  _WebPending(this.priority, this.seq, this.pageIndex, this.annotations);
+  _WebPending(this.priority, this.seq, this.pageIndex, this.annotations,
+      this.imagePixelRatio);
 
   final int priority;
   final int seq;
   final int pageIndex;
   final bool annotations;
+  final double? imagePixelRatio;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -141,14 +141,15 @@ class _WebRenderWorker implements PdfRenderWorker {
   Future<List<PdfRenderCommand>?> record(int pageIndex,
       {bool annotations = true,
       int priority = 0,
-      double? imagePixelRatio}) async {
+      double? imagePixelRatio,
+      bool decodeImages = true}) async {
     if (_disposed || _failed) {
       _wlog('record page=$pageIndex skipped (disposed=$_disposed '
           'failed=$_failed) → local');
       return null;
     }
-    final request =
-        _WebPending(priority, _seq++, pageIndex, annotations, imagePixelRatio);
+    final request = _WebPending(
+        priority, _seq++, pageIndex, annotations, imagePixelRatio, decodeImages);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -204,7 +205,8 @@ class _WebRenderWorker implements PdfRenderWorker {
       ..setProperty('kind'.toJS, 'record'.toJS)
       ..setProperty('id'.toJS, request.id.toJS)
       ..setProperty('page'.toJS, request.pageIndex.toJS)
-      ..setProperty('annotations'.toJS, request.annotations.toJS);
+      ..setProperty('annotations'.toJS, request.annotations.toJS)
+      ..setProperty('decodeImages'.toJS, request.decodeImages.toJS);
     final ratio = request.imagePixelRatio;
     if (ratio != null) message.setProperty('imageRatio'.toJS, ratio.toJS);
     worker.postMessage(message);
@@ -286,13 +288,14 @@ class _WebRenderWorker implements PdfRenderWorker {
 /// backend's `_PendingRequest`).
 class _WebPending {
   _WebPending(this.priority, this.seq, this.pageIndex, this.annotations,
-      this.imagePixelRatio);
+      this.imagePixelRatio, this.decodeImages);
 
   final int priority;
   final int seq;
   final int pageIndex;
   final bool annotations;
   final double? imagePixelRatio;
+  final bool decodeImages;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -69,6 +69,8 @@ void runPdfRenderWorker() {
     final page = (data.getProperty('page'.toJS) as JSNumber).toDartInt;
     final annotations =
         (data.getProperty('annotations'.toJS) as JSBoolean).toDart;
+    final imagePixelRatio =
+        (data.getProperty('imageRatio'.toJS) as JSNumber?)?.toDartDouble;
 
     final token = PdfCancellationToken();
     activeToken = token;
@@ -81,7 +83,8 @@ void runPdfRenderWorker() {
       final doc = document;
       try {
         if (doc != null) {
-          out = await _recordPageAsync(doc, page, annotations, token);
+          out = await _recordPageAsync(
+              doc, page, annotations, imagePixelRatio, token);
         }
       } on PdfCancelledException {
         out = null;
@@ -116,7 +119,7 @@ void runPdfRenderWorker() {
 /// Duplicated from the isolate backend deliberately: that file imports
 /// `dart:isolate`, which does not exist on web, so this entry can't share it.
 Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
-    bool annotations, PdfCancellationToken token) async {
+    bool annotations, double? imagePixelRatio, PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
   final ops = ContentStreamParser.parse(page.contentBytes());
@@ -129,6 +132,11 @@ Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
   // premultiplied RGBA so the main thread only runs the engine codec. On web
   // this matters more than on native — there is no separate raster thread, so
   // the pure-Dart inflate/colour-convert would otherwise block frames. #73.
+  // imagePixelRatio caps each image to display resolution before it crosses the
+  // postMessage boundary, so a sheet-sized raster underlay ships at a few MB
+  // instead of hundreds.
   return serializeCommands(recorder.commands,
-      cos: document.cos, decodeImages: true);
+      cos: document.cos,
+      decodeImages: true,
+      maxImagePixelRatio: imagePixelRatio);
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -71,6 +71,9 @@ void runPdfRenderWorker() {
         (data.getProperty('annotations'.toJS) as JSBoolean).toDart;
     final imagePixelRatio =
         (data.getProperty('imageRatio'.toJS) as JSNumber?)?.toDartDouble;
+    // Default true so an older client that doesn't send the flag still decodes.
+    final decodeImages =
+        (data.getProperty('decodeImages'.toJS) as JSBoolean?)?.toDart ?? true;
 
     final token = PdfCancellationToken();
     activeToken = token;
@@ -84,7 +87,7 @@ void runPdfRenderWorker() {
       try {
         if (doc != null) {
           out = await _recordPageAsync(
-              doc, page, annotations, imagePixelRatio, token);
+              doc, page, annotations, imagePixelRatio, decodeImages, token);
         }
       } on PdfCancelledException {
         out = null;
@@ -118,8 +121,13 @@ void runPdfRenderWorker() {
 ///
 /// Duplicated from the isolate backend deliberately: that file imports
 /// `dart:isolate`, which does not exist on web, so this entry can't share it.
-Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
-    bool annotations, double? imagePixelRatio, PdfCancellationToken token) async {
+Future<Uint8List?> _recordPageAsync(
+    PdfDocument document,
+    int pageIndex,
+    bool annotations,
+    double? imagePixelRatio,
+    bool decodeImages,
+    PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
   final ops = ContentStreamParser.parse(page.contentBytes());
@@ -134,9 +142,10 @@ Future<Uint8List?> _recordPageAsync(PdfDocument document, int pageIndex,
   // the pure-Dart inflate/colour-convert would otherwise block frames. #73.
   // imagePixelRatio caps each image to display resolution before it crosses the
   // postMessage boundary, so a sheet-sized raster underlay ships at a few MB
-  // instead of hundreds.
+  // instead of hundreds. decodeImages false skips the decode entirely for the
+  // fast vector-first pass of progressive rendering.
   return serializeCommands(recorder.commands,
       cos: document.cos,
-      decodeImages: true,
+      decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio);
 }

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -165,6 +165,27 @@ class PdfPageRenderer {
     return picture;
   }
 
+  /// Counts the decoded images a worker [commands] buffer carries and their
+  /// total pixels (recursing soft-mask groups). The deciding diagnostic for why
+  /// a raster-heavy page is slow: one oversized image escaping the resolution
+  /// cap looks very different from many tiles each capped but summing large.
+  /// Images shipped un-decoded (the platform-codec path) don't count.
+  static (int count, int pixels) decodedImageStats(
+      List<PdfRenderCommand> commands) {
+    final requests = <PdfImageRequest>[];
+    _collectImageRequests(commands, requests);
+    var count = 0;
+    var pixels = 0;
+    for (final request in requests) {
+      final decoded = request.decoded;
+      if (decoded != null) {
+        count++;
+        pixels += decoded.width * decoded.height;
+      }
+    }
+    return (count, pixels);
+  }
+
   /// Gathers every image draw request in [commands], descending into soft-mask
   /// groups (whose own commands can draw images), in replay order.
   static void _collectImageRequests(

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -140,12 +140,19 @@ class PdfPageRenderer {
   /// every other render path — the reconstructed streams key by content, so a
   /// page redrawn while scrolling reuses its decoded pixels instead of re-
   /// running the codec. An image-free buffer decodes nothing.
+  ///
+  /// [includeImages] false skips image decoding entirely and replays with an
+  /// empty image map, so the device draws the page's vector/text and skips
+  /// every image. This is the fast first pass of progressive rendering: a heavy
+  /// raster underlay can take many seconds to decode, so the page paints its
+  /// linework immediately and the images drop in on a later full pass.
   static Future<ui.Picture> pictureFromCommands(
       PdfPage page, List<PdfRenderCommand> commands,
       {Color pageColor = const Color(0xFFFFFFFF),
-      int? rotation}) async {
+      int? rotation,
+      bool includeImages = true}) async {
     final requests = <PdfImageRequest>[];
-    _collectImageRequests(commands, requests);
+    if (includeImages) _collectImageRequests(commands, requests);
     final images = requests.isEmpty
         ? const <Object, ui.Image>{}
         : await decodeImages(page.document.cos, requests,
@@ -184,6 +191,15 @@ class PdfPageRenderer {
       }
     }
     return (count, pixels);
+  }
+
+  /// Whether [commands] draws any image at all (decoded or not, including
+  /// inside soft-mask groups) — the cue the progressive vector-first pass uses
+  /// to decide whether a slower full (image-decoding) pass needs to follow it.
+  static bool hasImageDraws(List<PdfRenderCommand> commands) {
+    final requests = <PdfImageRequest>[];
+    _collectImageRequests(commands, requests);
+    return requests.isNotEmpty;
   }
 
   /// Gathers every image draw request in [commands], descending into soft-mask

--- a/packages/dart_pdf_editor/test/cad_perf_probe_test.dart
+++ b/packages/dart_pdf_editor/test/cad_perf_probe_test.dart
@@ -1,0 +1,282 @@
+// Diagnostic testing loop for the heavy-raster CAD jank work.
+//
+// It drives the EXACT code path a PdfRenderWorker runs off-thread
+// (interpret -> serializeCommands(decodeImages:true, maxImagePixelRatio:r))
+// on the test isolate, so the image-resolution cap and progressive
+// vector-first pass can be measured against a real file without a browser.
+//
+// Skips unless a file is present. Defaults to the local CAD corpus copy:
+//
+//   cd packages/dart_pdf_editor
+//   CAD_PDF=../../corpus/ly9-far-cad.pdf \
+//     fvm flutter test test/cad_perf_probe_test.dart
+//
+// Knobs:
+//   CAD_PDF     path to the PDF (default ../../corpus/ly9-far-cad.pdf)
+//   CAD_PAGE    0-based page to deep-probe (default: heaviest found by scan)
+//   CAD_RATIO   screen px per point for the cap (default 2.0; ~typical view)
+//   CAD_SCAN    '0' to skip the per-page heavy-page scan (default on)
+//
+// Reports, for the target page: native vs capped decoded megapixels, the
+// shipped command-buffer size (the bytes the worker hands the UI thread),
+// decode+serialize time, full render time, and the progressive vector-first
+// first-paint time. Asserts the cap actually shrinks an oversized underlay.
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+void main() {
+  final path = Platform.environment['CAD_PDF'] ?? '../../corpus/ly9-far-cad.pdf';
+  final ratio = double.tryParse(Platform.environment['CAD_RATIO'] ?? '') ?? 2.0;
+  final pageOverride = int.tryParse(Platform.environment['CAD_PAGE'] ?? '');
+  final doScan = (Platform.environment['CAD_SCAN'] ?? '1') != '0';
+
+  testWidgets('CAD heavy-raster render probe', (tester) async {
+    final file = File(path);
+    if (!file.existsSync()) {
+      markTestSkipped('set CAD_PDF to a real file (missing: $path)');
+      return;
+    }
+
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final bytes = file.readAsBytesSync();
+      final doc = PdfDocument.open(bytes);
+      _line('opened ${_mb(bytes.length)} - ${doc.pageCount} pages: $path');
+
+      // --- Pass A: cheap scan (no decode) to find the heavy raster page. ---
+      var target = pageOverride ?? 0;
+      if (doScan && pageOverride == null) {
+        final ranked = <_PageImages>[];
+        for (var i = 0; i < doc.pageCount; i++) {
+          final requests = _imageRequests(doc, i);
+          if (requests.isEmpty) continue;
+          var declaredMp = 0.0;
+          var drawnMp = 0.0;
+          for (final r in requests) {
+            declaredMp += _declaredPixels(doc, r) / 1e6;
+            final t = r.transform;
+            // transform column lengths == drawn size in points; at `ratio`
+            // px/pt that is the on-screen footprint the cap targets.
+            final wPts = _len(t.a, t.b);
+            final hPts = _len(t.c, t.d);
+            drawnMp += (wPts * ratio) * (hPts * ratio) / 1e6;
+          }
+          ranked.add(_PageImages(i, requests.length, declaredMp, drawnMp));
+        }
+        ranked.sort((a, b) => b.declaredMp.compareTo(a.declaredMp));
+        _line('--- heaviest pages by declared image megapixels ---');
+        for (final p in ranked.take(12)) {
+          _line('  page ${p.page}: ${p.count} img, '
+              '${p.declaredMp.toStringAsFixed(1)} MP native, '
+              '${p.drawnMp.toStringAsFixed(2)} MP on-screen @${ratio}x');
+        }
+        if (ranked.isNotEmpty) target = ranked.first.page;
+        if (ranked.isEmpty) _line('  (no image draws found on any page)');
+      }
+
+      _line('--- deep probe: page $target @ ratio ${ratio}x ---');
+      final page = doc.page(target);
+
+      // Interpret once (the off-thread walk) -> raw command buffer.
+      final interp = Stopwatch()..start();
+      final commands = _interpret(doc, target);
+      interp.stop();
+      _line('interpret: ${interp.elapsedMilliseconds} ms, '
+          '${commands.length} commands');
+
+      // Native decode (cap off): what the worker shipped before the fix.
+      final nativeSw = Stopwatch()..start();
+      final nativeBuf =
+          serializeCommands(commands, cos: doc.cos, decodeImages: true);
+      nativeSw.stop();
+      final nativeStats =
+          PdfPageRenderer.decodedImageStats(deserializeCommands(nativeBuf!));
+      _line('native  decode: ${nativeSw.elapsedMilliseconds} ms, '
+          '${nativeStats.$1} img, ${_mpStr(nativeStats.$2)} MP, '
+          'buffer ${_mb(nativeBuf.length)}');
+
+      // Capped decode (the fix): cap to ~2x on-screen at `ratio`.
+      final capSw = Stopwatch()..start();
+      final capBuf = serializeCommands(commands,
+          cos: doc.cos, decodeImages: true, maxImagePixelRatio: ratio);
+      capSw.stop();
+      final capCmds = deserializeCommands(capBuf!);
+      final capStats = PdfPageRenderer.decodedImageStats(capCmds);
+      _line('capped  decode: ${capSw.elapsedMilliseconds} ms, '
+          '${capStats.$1} img, ${_mpStr(capStats.$2)} MP, '
+          'buffer ${_mb(capBuf.length)}');
+
+      final shrink = nativeStats.$2 == 0
+          ? 1.0
+          : capStats.$2 / nativeStats.$2;
+      _line('cap shrank decoded pixels to '
+          '${(shrink * 100).toStringAsFixed(1)}% of native');
+
+      // The cap's contract: decode no sharper than headroom(2x) the on-screen
+      // footprint. When native pixels already sit at/under that, there is
+      // nothing to cut (the page genuinely carries that much imagery at this
+      // zoom) and a no-op is correct — so the meaningful invariant is the
+      // contract, not a fixed reduction.
+      final footprintPixels = _onScreenFootprintPixels(capCmds, ratio);
+      _line('on-screen footprint @${ratio}x: '
+          '${_mpStr(footprintPixels)} MP '
+          '(cap ceiling ~${_mpStr(footprintPixels * 4)} MP w/ 2x headroom)');
+
+      // Full render of the capped buffer (replay + raster).
+      final renderRatio = _renderRatio(page, ratio);
+      final size = PdfPageRenderer.pageSize(page);
+      final renderSw = Stopwatch()..start();
+      final picture = await PdfPageRenderer.pictureFromCommands(page, capCmds);
+      final image = await PdfPageRenderer.rasterize(picture, size, renderRatio);
+      await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      renderSw.stop();
+      _line('full render (capped): ${renderSw.elapsedMilliseconds} ms '
+          '-> ${image.width}x${image.height}');
+      picture.dispose();
+      image.dispose();
+
+      // Progressive first paint: vector/text only, no image decode.
+      final vecSw = Stopwatch()..start();
+      final vecBuf = serializeCommands(commands, cos: doc.cos);
+      final vecCmds = deserializeCommands(vecBuf!);
+      final vecPic = await PdfPageRenderer.pictureFromCommands(page, vecCmds,
+          includeImages: false);
+      final vecImg = await PdfPageRenderer.rasterize(vecPic, size, renderRatio);
+      await vecImg.toByteData(format: ui.ImageByteFormat.rawRgba);
+      vecSw.stop();
+      _line('progressive first paint (vector-only): '
+          '${vecSw.elapsedMilliseconds} ms');
+      vecPic.dispose();
+      vecImg.dispose();
+
+      // --- Assertions ---
+      // 1. The cap never invents pixels.
+      expect(capStats.$2, lessThanOrEqualTo(nativeStats.$2),
+          reason: 'capped pixels must never exceed native');
+      // 2. The cap honored its contract: each image decodes to no more than
+      //    headroom^2 (= 4x) its on-screen footprint, with two slacks baked
+      //    into cappedImagePixelSize — it leaves an image at native when a
+      //    resample would save <10% (the 0.9 skip threshold, so per-image
+      //    decoded can reach target/0.9) and ceil()s each edge. A no-op when
+      //    native already sits under that ceiling is correct. A failure here
+      //    means the cap math regressed or the worker bundle ships un-capped
+      //    images.
+      const headroomArea = 2.0 * 2.0;
+      const skipSlack = 1 / 0.9;
+      final perImageCeiling =
+          (footprintPixels * headroomArea * skipSlack).round() +
+              capStats.$1 * 16 +
+              (1 << 20);
+      // 3. The page-pixel budget bounds the TOTAL decoded pixels to
+      //    ~budgetFactor (2.5) x the 16.78 MP page raster cap, regardless of
+      //    overlap. Decoded pixels must sit under whichever ceiling binds.
+      const pageBudget = (2.5 * (1 << 24)) + (4 << 20); // + downsample slop
+      final ceiling = perImageCeiling < pageBudget ? perImageCeiling : pageBudget;
+      expect(capStats.$2.toDouble(), lessThanOrEqualTo(ceiling.toDouble()),
+          reason: 'capped pixels (${_mpStr(capStats.$2)} MP) exceed the '
+              'binding cap ceiling (${(ceiling / 1e6).toStringAsFixed(1)} MP) '
+              'for a ${_mpStr(footprintPixels)} MP footprint at ${ratio}x - '
+              'per-image or page-budget cap regressed, or worker is stale');
+    });
+  }, timeout: const Timeout(Duration(minutes: 20)));
+}
+
+/// Interprets [pageIndex] to a raw command buffer (no decode), exactly as
+/// the worker isolate's record path does.
+List<PdfRenderCommand> _interpret(PdfDocument doc, int pageIndex) {
+  final page = doc.page(pageIndex);
+  final ops = ContentStreamParser.parse(page.contentBytes());
+  final recorder = RecordingPdfDevice();
+  final interpreter = PdfInterpreter(cos: doc.cos, device: recorder);
+  interpreter.drawPageOperations(page, ops);
+  interpreter.drawAnnotations(page);
+  return recorder.commands;
+}
+
+/// Collects the image draw requests on a page without decoding.
+List<PdfImageRequest> _imageRequests(PdfDocument doc, int pageIndex) {
+  final requests = <PdfImageRequest>[];
+  for (final c in _interpret(doc, pageIndex)) {
+    _walk(c, requests);
+  }
+  return requests;
+}
+
+void _walk(PdfRenderCommand c, List<PdfImageRequest> out) {
+  if (c is PdfDrawImageCommand) {
+    out.add(c.request);
+  } else if (c is PdfEndSoftMaskedCommand) {
+    for (final m in c.maskCommands) {
+      _walk(m, out);
+    }
+  }
+}
+
+/// Sum of every image's on-screen footprint in pixels at [ratio] px/pt
+/// (drawn point size from the CTM column lengths). The cap targets
+/// `headroom^2` times this.
+int _onScreenFootprintPixels(List<PdfRenderCommand> commands, double ratio) {
+  final requests = <PdfImageRequest>[];
+  for (final c in commands) {
+    _walk(c, requests);
+  }
+  var total = 0.0;
+  for (final r in requests) {
+    final t = r.transform;
+    total += (_len(t.a, t.b) * ratio) * (_len(t.c, t.d) * ratio);
+  }
+  return total.round();
+}
+
+int _declaredPixels(PdfDocument doc, PdfImageRequest r) {
+  final dict = r.stream.dictionary;
+  final w = _intOf(doc.cos.resolve(dict['Width']));
+  final h = _intOf(doc.cos.resolve(dict['Height']));
+  return w * h;
+}
+
+int _intOf(CosObject? o) {
+  if (o is CosInteger) return o.value;
+  if (o is CosReal) return o.value.round();
+  return 0;
+}
+
+double _len(double a, double b) => math.sqrt(a * a + b * b);
+
+/// Mirrors PdfPageView._effectiveRatio's clamp (16.7 MP / 8192 px ceilings).
+double _renderRatio(PdfPage page, double desired) {
+  final size = PdfPageRenderer.pageSize(page);
+  final w = size.width < 1 ? 1.0 : size.width;
+  final h = size.height < 1 ? 1.0 : size.height;
+  var r = desired;
+  final byPixels = math.sqrt((1 << 24) / (w * h));
+  if (byPixels < r) r = byPixels;
+  final byDim = 8192.0 / (w > h ? w : h);
+  if (byDim < r) r = byDim;
+  return r < 0.05 ? 0.05 : r;
+}
+
+String _mpStr(int pixels) => (pixels / 1e6).toStringAsFixed(1);
+String _mb(int bytes) => '${(bytes / (1 << 20)).toStringAsFixed(1)} MB';
+
+void _line(String s) {
+  // ignore: avoid_print
+  print('[cad-probe] $s');
+}
+
+class _PageImages {
+  _PageImages(this.page, this.count, this.declaredMp, this.drawnMp);
+  final int page;
+  final int count;
+  final double declaredMp;
+  final double drawnMp;
+}

--- a/packages/dart_pdf_editor/test/editing_reflow_test.dart
+++ b/packages/dart_pdf_editor/test/editing_reflow_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// One-page Helvetica PDF whose content stream is [content].
 Uint8List buildParagraphPdf(String content) {
@@ -61,6 +62,12 @@ List<({String text, double bottom})> textRuns(PdfDocument doc) => [
     ];
 
 void main() {
+  // PdfEditingController loads PdfEditingPreferences (shared_preferences) from
+  // its constructor, fire-and-forget. Without the mock plugin that async load
+  // throws MissingPluginException *after* the test completes, failing it — so
+  // register the in-memory mock like the other editing tests do.
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
   group('reflowSelectedElementText (controller)', () {
     test('grows the paragraph and cascades the following line', () {
       final editing = PdfEditingController(buildParagraphPdf(paragraphContent));

--- a/packages/dart_pdf_editor/test/image_stats_test.dart
+++ b/packages/dart_pdf_editor/test/image_stats_test.dart
@@ -1,0 +1,60 @@
+// PdfPageRenderer.decodedImageStats: the diagnostic that counts a worker
+// buffer's decoded images and their total pixels (recursing soft-mask groups),
+// so a slow raster page's cause — one oversized image vs. many capped tiles —
+// is visible in the perf trace.
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+PdfDrawImageCommand _image(int width, int height, {bool decoded = true}) {
+  final stream = CosStream(CosDictionary(const {}), Uint8List(0));
+  return PdfDrawImageCommand(PdfImageRequest(
+    stream: stream,
+    transform: PdfMatrix.identity,
+    isInline: true,
+    decoded:
+        decoded ? PdfDecodedPixels(Uint8List(width * height * 4), width, height) : null,
+  ));
+}
+
+void main() {
+  test('counts decoded images and sums their pixels', () {
+    final stats = PdfPageRenderer.decodedImageStats([
+      _image(2, 3),
+      const PdfSaveCommand(),
+      _image(4, 5),
+    ]);
+    expect(stats, (2, 2 * 3 + 4 * 5));
+  });
+
+  test('ignores images shipped un-decoded (platform-codec path)', () {
+    final stats = PdfPageRenderer.decodedImageStats([
+      _image(10, 10, decoded: false),
+      _image(2, 2),
+    ]);
+    expect(stats, (1, 4));
+  });
+
+  test('descends into soft-mask groups', () {
+    final stats = PdfPageRenderer.decodedImageStats([
+      _image(3, 3),
+      PdfEndSoftMaskedCommand(
+        luminosity: true,
+        backdrop: const PdfRect(0, 0, 1, 1),
+        maskCommands: [_image(2, 2)],
+        backdropLuminance: 0,
+        transferScale: 1,
+        transferOffset: 0,
+      ),
+    ]);
+    expect(stats, (2, 3 * 3 + 2 * 2));
+  });
+
+  test('an image-free buffer reports zero', () {
+    expect(PdfPageRenderer.decodedImageStats(const [PdfSaveCommand()]), (0, 0));
+  });
+}

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -150,6 +150,10 @@ void main() {
           document: document,
           controller: controller,
           initialFit: PdfViewerFit.width,
+          // Warm the whole 8-page doc so the far pages (6, 7) pre-render from
+          // idle; the default window is deliberately small (it bounds the
+          // worker-decode flood) and would not reach distance 7.
+          previewWindow: 8,
         ),
       ),
     ));

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -163,6 +163,33 @@ void main() {
     });
   });
 
+  testWidgets('decodeImages:false records vector/text but ships images raw',
+      (tester) async {
+    await tester.runAsync(() async {
+      // The fast pass of progressive rendering: the page's image draws are
+      // present (so a full pass is known to be needed) but carry no decoded
+      // pixels, so the buffer comes back without paying the image decode.
+      final bytes = PdfImageDocument.fromImageBytes([_alphaPng()]);
+      final page = PdfDocument.open(bytes).page(0);
+      final worker = PdfRenderWorker.start(bytes);
+      addTearDown(worker.dispose);
+
+      final fast = await worker.record(0, decodeImages: false);
+      expect(fast, isNotNull);
+      expect(_firstImage(fast!)?.decoded, isNull,
+          reason: 'decodeImages:false ships the image stream, not its pixels');
+      expect(PdfPageRenderer.hasImageDraws(fast), isTrue,
+          reason: 'the image draw command is still in the buffer');
+
+      // includeImages:false replays the vector/text and skips the image, so the
+      // picture builds without decoding anything — the fast first paint.
+      final vector = await PdfPageRenderer.pictureFromCommands(page, fast,
+          includeImages: false);
+      addTearDown(vector.dispose);
+      expect(PdfPageRenderer.decodedImageStats(fast), (0, 0));
+    });
+  });
+
   testWidgets('an inline image still declines (null → local render)',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -8,7 +8,7 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
-import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:pdf_document/pdf_document.dart';
@@ -19,6 +19,56 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 PdfImageRequest? _firstImage(List<PdfRenderCommand> commands) {
   for (final c in commands) {
     if (c is PdfDrawImageCommand) return c.request;
+  }
+  return null;
+}
+
+/// A synchronous in-process [PdfRenderWorker] for widget tests: it records the
+/// page on the test isolate (no background isolate to spawn or await), so
+/// PdfPageView's worker render path — including the progressive vector-first
+/// pass — runs deterministically under pump(). Honors [decodeImages] exactly
+/// like the real backends.
+class _SyncWorker implements PdfRenderWorker {
+  _SyncWorker(this._bytes);
+
+  final Uint8List _bytes;
+  late final PdfDocument _doc = PdfDocument.open(_bytes);
+  bool _disposed = false;
+
+  @override
+  bool get isActive => !_disposed;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true}) async {
+    if (_disposed || pageIndex < 0 || pageIndex >= _doc.pageCount) return null;
+    final page = _doc.page(pageIndex);
+    final ops = ContentStreamParser.parse(page.contentBytes());
+    final recorder = RecordingPdfDevice();
+    final interpreter = PdfInterpreter(cos: _doc.cos, device: recorder)
+      ..drawPageOperations(page, ops);
+    if (annotations) interpreter.drawAnnotations(page);
+    final bytes = serializeCommands(recorder.commands,
+        cos: _doc.cos,
+        decodeImages: decodeImages,
+        maxImagePixelRatio: imagePixelRatio);
+    return bytes == null ? null : deserializeCommands(bytes);
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => _disposed = true;
+}
+
+/// The image of the first painted [RawImage], or null while none has rastered.
+ui.Image? _firstRasteredImage(WidgetTester tester) {
+  for (final raw in tester.widgetList<RawImage>(find.byType(RawImage))) {
+    if (raw.image != null) return raw.image;
   }
   return null;
 }
@@ -187,6 +237,43 @@ void main() {
           includeImages: false);
       addTearDown(vector.dispose);
       expect(PdfPageRenderer.decodedImageStats(fast), (0, 0));
+    });
+  });
+
+  testWidgets('PdfPageView renders an image page through the worker',
+      (tester) async {
+    await tester.runAsync(() async {
+      // Exercises PdfPageView's worker render path end to end: the progressive
+      // vector-first pass (record decodeImages:false → paint linework) and the
+      // full pass (record decodeImages:true → re-raster with the image), which
+      // no widget test covered before (the viewer's worker is normally null).
+      final bytes = PdfImageDocument.fromImageBytes([_alphaPng()]);
+      final page = PdfDocument.open(bytes).page(0);
+      final worker = _SyncWorker(bytes);
+      addTearDown(worker.dispose);
+
+      await tester.pumpWidget(MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 120,
+              height: 120,
+              child: PdfPageView(page: page, renderWorker: worker),
+            ),
+          ),
+        ),
+      ));
+
+      // Drive the async passes and their GPU rasters to completion.
+      ui.Image? rastered;
+      for (var i = 0; i < 80 && rastered == null; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        rastered = _firstRasteredImage(tester);
+      }
+      expect(rastered, isNotNull,
+          reason: 'the page rasterized through the worker render path');
     });
   });
 

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -4,11 +4,13 @@
 // (active, dispose, out-of-range) must behave. Runs on the Dart VM under
 // flutter_test, which supports isolates; every body uses tester.runAsync so
 // the isolate spawn and the GPU readback actually complete.
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/widgets.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:pdf_document/pdf_document.dart';
@@ -317,7 +319,7 @@ void main() {
   testWidgets('priority: the on-screen page preempts queued prefetch',
       (tester) async {
     await tester.runAsync(() async {
-      final worker = PdfRenderWorker.start(buildMultiPagePdf(2));
+      final worker = PdfRenderWorker.startUncached(buildMultiPagePdf(2));
       addTearDown(worker.dispose);
       await worker.record(0); // warm up: the isolate is now spawned and idle
 
@@ -362,7 +364,7 @@ void main() {
   testWidgets('cancel drops a queued request without disturbing others',
       (tester) async {
     await tester.runAsync(() async {
-      final worker = PdfRenderWorker.start(buildMultiPagePdf(3));
+      final worker = PdfRenderWorker.startUncached(buildMultiPagePdf(3));
       addTearDown(worker.dispose);
       await worker.record(0); // warm up: the isolate is spawned and idle
 
@@ -385,7 +387,7 @@ void main() {
 
   testWidgets('cancel does not preempt the in-flight request', (tester) async {
     await tester.runAsync(() async {
-      final worker = PdfRenderWorker.start(buildMultiPagePdf(2));
+      final worker = PdfRenderWorker.startUncached(buildMultiPagePdf(2));
       addTearDown(worker.dispose);
       await worker.record(0); // warm up
 
@@ -398,7 +400,7 @@ void main() {
 
   testWidgets('cancel only matches the given page and priority', (tester) async {
     await tester.runAsync(() async {
-      final worker = PdfRenderWorker.start(buildMultiPagePdf(3));
+      final worker = PdfRenderWorker.startUncached(buildMultiPagePdf(3));
       addTearDown(worker.dispose);
       await worker.record(0); // warm up
 
@@ -419,7 +421,7 @@ void main() {
   testWidgets('a higher-priority request preempts the in-flight job',
       (tester) async {
     await tester.runAsync(() async {
-      final worker = PdfRenderWorker.start(buildMultiPagePdf(2));
+      final worker = PdfRenderWorker.startUncached(buildMultiPagePdf(2));
       addTearDown(worker.dispose);
       await worker.record(0); // warm up: the isolate is spawned and idle
 
@@ -438,6 +440,141 @@ void main() {
           reason: 'the high-priority on-screen page always completes');
     });
   });
+
+  group('PdfCachingRenderWorker', () {
+    test('a repeat record for the same key hits the cache (no re-decode)',
+        () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner);
+      final first = await worker.record(7, imagePixelRatio: 2.0);
+      final second = await worker.record(7, imagePixelRatio: 2.0);
+      expect(inner.calls.length, 1, reason: 'the second record is a cache hit');
+      expect(identical(first, second), isTrue,
+          reason: 'the cached buffer is reused as-is');
+    });
+
+    test('a concurrent record for an in-flight key shares one decode',
+        () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner);
+      // Both fire before the first resolves — the second must share, not
+      // start a second decode (the fast-scroll re-grant storm).
+      final f1 = worker.record(3, imagePixelRatio: 2.0);
+      final f2 = worker.record(3, imagePixelRatio: 2.0);
+      final r1 = await f1;
+      final r2 = await f2;
+      expect(inner.calls.length, 1, reason: 'one decode shared by both');
+      expect(identical(r1, r2), isTrue);
+      // Once it completed it is cached, so a later record still hits.
+      await worker.record(3, imagePixelRatio: 2.0);
+      expect(inner.calls.length, 1);
+    });
+
+    test('ratio bucket, annotations, and decodeImages are part of the key',
+        () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner);
+      await worker.record(0, imagePixelRatio: 2.0);
+      await worker.record(0, imagePixelRatio: 2.0); // hit
+      await worker.record(0, imagePixelRatio: 4.0); // miss: different zoom
+      await worker.record(0, imagePixelRatio: 2.0, annotations: false); // miss
+      await worker.record(0, imagePixelRatio: 2.0, decodeImages: false); // miss
+      await worker.record(0, imagePixelRatio: 2.01); // hit: same bucket as 2.0
+      expect(inner.calls.length, 4);
+    });
+
+    test('a tiny ratio wobble stays in the same bucket', () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner);
+      await worker.record(0, imagePixelRatio: 2.50);
+      await worker.record(0, imagePixelRatio: 2.55); // 2.50*8=20, 2.55*8≈20.4→20
+      expect(inner.calls.length, 1);
+    });
+
+    test('LRU eviction past the byte budget forces a re-decode', () async {
+      // Each record weighs 8x8x4 = 256 bytes; a 300-byte budget holds one.
+      final inner = _CountingWorker(decodedPixels: 64);
+      final worker = PdfCachingRenderWorker(inner, budgetBytes: 300);
+      await worker.record(0, imagePixelRatio: 2.0); // cache: {0}
+      await worker.record(1, imagePixelRatio: 2.0); // cache: {1}, 0 evicted
+      await worker.record(0, imagePixelRatio: 2.0); // miss: 0 was evicted
+      expect(inner.calls.length, 3);
+      await worker.record(0, imagePixelRatio: 2.0); // hit: 0 is now newest
+      expect(inner.calls.length, 3);
+    });
+
+    test('null results are not cached', () async {
+      final inner = _CountingWorker(returnNull: true);
+      final worker = PdfCachingRenderWorker(inner);
+      await worker.record(0, imagePixelRatio: 2.0);
+      await worker.record(0, imagePixelRatio: 2.0);
+      expect(inner.calls.length, 2, reason: 'a declined page must re-ask');
+    });
+
+    test('record bypasses the cache while the inner worker is inactive',
+        () async {
+      final inner = _CountingWorker()..active = false;
+      final worker = PdfCachingRenderWorker(inner);
+      expect(worker.isActive, isFalse);
+      expect(await worker.record(0, imagePixelRatio: 2.0), isNull);
+    });
+
+    test('dispose clears the cache and tears down the inner worker', () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner);
+      await worker.record(0, imagePixelRatio: 2.0);
+      worker.dispose();
+      expect(inner.disposed, isTrue);
+    });
+  });
+}
+
+/// A [PdfRenderWorker] that records each [record] call and returns a synthetic
+/// buffer of a chosen decoded weight — for exercising [PdfCachingRenderWorker]
+/// without a real isolate or document.
+class _CountingWorker implements PdfRenderWorker {
+  _CountingWorker({this.decodedPixels = 0, this.returnNull = false});
+
+  /// Decoded pixels carried by each returned buffer (an N×N image, so the
+  /// cache weight is decodedPixels*4 bytes). 0 returns image-free commands.
+  final int decodedPixels;
+  final bool returnNull;
+  final calls = <(int, bool, bool, double?)>[];
+  bool active = true;
+  bool disposed = false;
+
+  @override
+  bool get isActive => active;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true}) async {
+    calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
+    if (returnNull || !active) return null;
+    if (decodedPixels == 0) {
+      return const [PdfSaveCommand(), PdfRestoreCommand()];
+    }
+    final side = math.sqrt(decodedPixels).round();
+    final pixels = PdfDecodedPixels(Uint8List(side * side * 4), side, side);
+    final request = PdfImageRequest(
+      stream: CosStream(CosDictionary(), Uint8List(0)),
+      transform: PdfMatrix.identity,
+      decoded: pixels,
+    );
+    return [PdfDrawImageCommand(request)];
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() {
+    active = false;
+    disposed = true;
+  }
 }
 
 /// A small RGBA PNG with a varying alpha channel (so it embeds with an /SMask).

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -503,6 +503,24 @@ void main() {
       expect(inner.calls.length, 3);
     });
 
+    test('weight-0 buffers survive eviction of heavy pages', () async {
+      // Budget holds one heavy (256-byte) page. The vector-first pass
+      // (decodeImages: false) weighs nothing, so blowing the budget with heavy
+      // full-image pages must not discard it — it would only be re-decoded.
+      final inner = _CountingWorker(decodedPixels: 64);
+      final worker = PdfCachingRenderWorker(inner, budgetBytes: 300);
+      await worker.record(0, imagePixelRatio: 2.0, decodeImages: false); // 0 B
+      await worker.record(1, imagePixelRatio: 2.0); // heavy, _bytes=256
+      await worker.record(2, imagePixelRatio: 2.0); // heavy, evicts page 1 only
+      expect(inner.calls.length, 3);
+      // The costless vector-first buffer is still cached: a hit, not a re-ask.
+      await worker.record(0, imagePixelRatio: 2.0, decodeImages: false);
+      expect(inner.calls.length, 3, reason: 'weight-0 buffer must be kept');
+      // The heavy page evicted to make room does have to re-decode.
+      await worker.record(1, imagePixelRatio: 2.0);
+      expect(inner.calls.length, 4, reason: 'page 1 was evicted');
+    });
+
     test('null results are not cached', () async {
       final inner = _CountingWorker(returnNull: true);
       final worker = PdfCachingRenderWorker(inner);
@@ -554,7 +572,10 @@ class _CountingWorker implements PdfRenderWorker {
       bool decodeImages = true}) async {
     calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
     if (returnNull || !active) return null;
-    if (decodedPixels == 0) {
+    // A vector-first pass (decodeImages: false) ships no decoded pixels, so its
+    // cached buffer weighs nothing — mirror that so the cache's weight-aware
+    // eviction can be exercised.
+    if (decodedPixels == 0 || !decodeImages) {
       return const [PdfSaveCommand(), PdfRestoreCommand()];
     }
     final side = math.sqrt(decodedPixels).round();

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -141,6 +141,28 @@ void main() {
     });
   });
 
+  testWidgets('imagePixelRatio caps a decoded image to display resolution',
+      (tester) async {
+    await tester.runAsync(() async {
+      // A Flate+SMask image decodes off-thread, so the worker ships its pixels
+      // and the cap can shrink them. A tiny ratio must yield fewer pixels than
+      // the uncapped record; the cap never upscales.
+      final bytes = PdfImageDocument.fromImageBytes([_alphaPng()]);
+      final worker = PdfRenderWorker.start(bytes);
+      addTearDown(worker.dispose);
+
+      final native = _firstImage((await worker.record(0))!)?.decoded;
+      final capped =
+          _firstImage((await worker.record(0, imagePixelRatio: 0.01))!)?.decoded;
+      expect(native, isNotNull);
+      expect(capped, isNotNull);
+      expect(capped!.width * capped.height,
+          lessThan(native!.width * native.height),
+          reason: 'a tiny display ratio must downsample the shipped pixels');
+      expect(capped.rgba.length, capped.width * capped.height * 4);
+    });
+  });
+
   testWidgets('an inline image still declines (null → local render)',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -13,6 +13,7 @@
 /// page goes crisp.
 library;
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:image/image.dart' as img;
@@ -227,6 +228,53 @@ PdfDecodedPixels downsamplePdfDecodedPixels(
     }
   }
   return PdfDecodedPixels(dst, tw, th);
+}
+
+/// The pixel size an image should be decoded/stored at so it is no sharper than
+/// [headroom]× its on-screen footprint — the cap behind `serializeCommands`'s
+/// `maxImagePixelRatio` (see render_command_codec.dart), extracted as a pure
+/// function so every branch is unit-testable without a giant fixture image.
+///
+/// [srcWidth]/[srcHeight] are the image's native pixels; [widthPts]/[heightPts]
+/// are its drawn size on the page in points (the column lengths of its CTM);
+/// [ratio] is screen pixels per point (device pixel ratio included). The target
+/// is `headroom × drawnPixels`, never upscaled past the source, and never past
+/// the hard ceilings ([maxDimension] per edge, [maxPixels] total) that keep a
+/// sheet-sized raster underlay within a GPU texture limit and the decoded-image
+/// cache. Returns `(srcWidth, srcHeight)` unchanged when no worthwhile
+/// reduction applies (already small enough, a degenerate transform, or a
+/// non-positive ratio) — the caller then ships the native pixels as-is.
+(int, int) cappedImagePixelSize(
+    int srcWidth, int srcHeight, double widthPts, double heightPts, double ratio,
+    {double headroom = 2.0,
+    int maxPixels = 1 << 24,
+    double maxDimension = 8192}) {
+  if (srcWidth < 1 || srcHeight < 1) return (srcWidth, srcHeight);
+  if (!(ratio > 0) || !(widthPts > 0) || !(heightPts > 0)) {
+    return (srcWidth, srcHeight);
+  }
+  // ceil() of a positive double is >= 1, so tw/th never under-run 1px.
+  var tw = (widthPts * ratio * headroom).ceil();
+  var th = (heightPts * ratio * headroom).ceil();
+  if (tw >= srcWidth && th >= srcHeight) return (srcWidth, srcHeight); // no up
+  if (tw > srcWidth) tw = srcWidth;
+  if (th > srcHeight) th = srcHeight;
+
+  final maxEdge = math.max(tw, th);
+  if (maxEdge > maxDimension) {
+    final s = maxDimension / maxEdge;
+    tw = (tw * s).floor().clamp(1, srcWidth);
+    th = (th * s).floor().clamp(1, srcHeight);
+  }
+  if (tw * th > maxPixels) {
+    final s = math.sqrt(maxPixels / (tw * th));
+    tw = (tw * s).floor().clamp(1, srcWidth);
+    th = (th * s).floor().clamp(1, srcHeight);
+  }
+
+  // Not worth a full-buffer resample for a sliver — keep the native pixels.
+  if (tw * th >= srcWidth * srcHeight * 0.9) return (srcWidth, srcHeight);
+  return (tw, th);
 }
 
 /// Premultiplies straight-alpha RGBA in place. `decodeImageFromPixels` treats

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -173,6 +173,62 @@ PdfDecodedPixels _finish(Uint8List rgba, int width, int height,
   return PdfDecodedPixels(rgba, width, height);
 }
 
+/// Area-average (box filter) downsample of premultiplied RGBA [pixels] to
+/// [targetWidth]×[targetHeight]. Each destination pixel is the mean of the
+/// source pixels in its cell, so a large raster underlay shrinks to the
+/// resolution it is actually displayed at — the whole point on heavy CAD
+/// sheets, where a 160-megapixel scan blocks the raster thread (and blows the
+/// decoded-image cache) when drawn into a page only a few thousand pixels wide.
+///
+/// Averaging premultiplied samples directly is correct: alpha rides along with
+/// the colour it weights. Never upscales — returns [pixels] unchanged when the
+/// target is at least as large on both axes. The caller passes target
+/// dimensions that already preserve the aspect it wants; this only resamples.
+PdfDecodedPixels downsamplePdfDecodedPixels(
+    PdfDecodedPixels pixels, int targetWidth, int targetHeight) {
+  final sw = pixels.width;
+  final sh = pixels.height;
+  var tw = targetWidth < 1 ? 1 : targetWidth;
+  var th = targetHeight < 1 ? 1 : targetHeight;
+  if (tw >= sw && th >= sh) return pixels; // already small enough; no upscale
+  if (tw > sw) tw = sw;
+  if (th > sh) th = sh;
+  final src = pixels.rgba;
+  final dst = Uint8List(tw * th * 4);
+  var di = 0;
+  for (var ty = 0; ty < th; ty++) {
+    final sy0 = ty * sh ~/ th;
+    var sy1 = (ty + 1) * sh ~/ th;
+    if (sy1 <= sy0) sy1 = sy0 + 1;
+    for (var tx = 0; tx < tw; tx++) {
+      final sx0 = tx * sw ~/ tw;
+      var sx1 = (tx + 1) * sw ~/ tw;
+      if (sx1 <= sx0) sx1 = sx0 + 1;
+      // Local int accumulators: a cell spans (sw/tw)·(sh/th) source pixels, so
+      // the worst sum is bounded by the source pixel count × 255 — well within
+      // a 64-bit int (native) and float64's 2^53 (web).
+      var r = 0, g = 0, b = 0, a = 0, n = 0;
+      for (var sy = sy0; sy < sy1; sy++) {
+        var si = (sy * sw + sx0) * 4;
+        for (var sx = sx0; sx < sx1; sx++) {
+          r += src[si];
+          g += src[si + 1];
+          b += src[si + 2];
+          a += src[si + 3];
+          si += 4;
+          n++;
+        }
+      }
+      dst[di] = r ~/ n;
+      dst[di + 1] = g ~/ n;
+      dst[di + 2] = b ~/ n;
+      dst[di + 3] = a ~/ n;
+      di += 4;
+    }
+  }
+  return PdfDecodedPixels(dst, tw, th);
+}
+
 /// Premultiplies straight-alpha RGBA in place. `decodeImageFromPixels` treats
 /// rgba8888 as premultiplied, so straight alpha would make transparent-but-
 /// colored pixels (a white backdrop under an /SMask cutout) composite

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -111,57 +111,21 @@ Uint8List? serializeCommands(List<PdfRenderCommand> commands,
   return w.takeBytes();
 }
 
-// A capped image never exceeds these — matching the viewer's full-page raster
-// caps ([_PdfPageViewState._maxPixels] / `_maxDimension`) so even a sheet-sized
-// underlay stays within a GPU texture limit, rasterizes in tens of ms not
-// hundreds, and fits the decoded-image cache (so a settled scroll reuses it
-// instead of re-decoding it every time).
-const int _maxImagePixels = 1 << 24; // ~16.7M px (64 MB RGBA)
-const double _maxImageDimension = 8192;
-
-// The on-screen pixels an image covers, scaled up by this much, is the
-// resolution it is decoded/shipped at — one zoom-doubling of headroom over the
-// base raster before the deep-zoom patch (which re-rasters the same picture)
-// softens it.
-const double _imageResolutionHeadroom = 2.0;
-
-/// Returns [decoded] resampled down to ~[ratio]× ([_imageResolutionHeadroom]×)
-/// the pixels it occupies on screen, or unchanged when it already fits or the
-/// reduction would be negligible. [transform] maps the unit image square to
-/// page points, so its column lengths are the image's drawn width/height in
-/// points; multiplying by [ratio] (px/point) gives the on-screen pixel size.
+/// Returns [decoded] resampled down to ~2× the pixels it occupies on screen
+/// (see [cappedImagePixelSize], whose ceilings match the viewer's full-page
+/// raster caps so a sheet-sized underlay stays within a GPU texture limit and
+/// the decoded-image cache), or unchanged when it already fits. [transform]
+/// maps the unit image square to page points, so its column lengths are the
+/// image's drawn width/height in points; [ratio] is screen px per point.
 PdfDecodedPixels _capImageResolution(
     PdfDecodedPixels decoded, PdfMatrix transform, double ratio) {
-  if (!(ratio > 0)) return decoded;
   final widthPts =
       math.sqrt(transform.a * transform.a + transform.b * transform.b);
   final heightPts =
       math.sqrt(transform.c * transform.c + transform.d * transform.d);
-  if (!(widthPts > 0) || !(heightPts > 0)) return decoded;
-
-  var tw = (widthPts * ratio * _imageResolutionHeadroom).ceil();
-  var th = (heightPts * ratio * _imageResolutionHeadroom).ceil();
-  if (tw >= decoded.width && th >= decoded.height) return decoded; // no upscale
-  if (tw > decoded.width) tw = decoded.width;
-  if (th > decoded.height) th = decoded.height;
-  if (tw < 1) tw = 1;
-  if (th < 1) th = 1;
-
-  // Hard ceilings so a monster sheet can't ship/rasterize an oversized texture.
-  final maxEdge = math.max(tw, th);
-  if (maxEdge > _maxImageDimension) {
-    final s = _maxImageDimension / maxEdge;
-    tw = (tw * s).floor().clamp(1, decoded.width);
-    th = (th * s).floor().clamp(1, decoded.height);
-  }
-  if (tw * th > _maxImagePixels) {
-    final s = math.sqrt(_maxImagePixels / (tw * th));
-    tw = (tw * s).floor().clamp(1, decoded.width);
-    th = (th * s).floor().clamp(1, decoded.height);
-  }
-
-  // Not worth a full-buffer copy for a sliver — keep the native pixels.
-  if (tw * th >= decoded.width * decoded.height * 0.9) return decoded;
+  final (tw, th) = cappedImagePixelSize(
+      decoded.width, decoded.height, widthPts, heightPts, ratio);
+  if (tw == decoded.width && th == decoded.height) return decoded;
   return downsamplePdfDecodedPixels(decoded, tw, th);
 }
 

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
@@ -83,16 +84,85 @@ class _UnserializableImage implements Exception {
 /// premultiplied RGBA beside the command, so the consumer skips the decode and
 /// only runs the engine codec — issue #73's image-decode offload. Images that
 /// need the platform JPEG codec carry no pixels and decode locally as before.
+///
+/// [maxImagePixelRatio] (screen pixels per page point, including the device
+/// pixel ratio) caps the resolution of each decoded image to ~2× the pixels it
+/// covers on screen — a giant raster underlay on a CAD sheet is shipped (and
+/// later rasterized, and cached) at display resolution instead of its native
+/// 100+ megapixels, which is what otherwise blocks the (single-threaded, on
+/// web) raster thread for hundreds of milliseconds every time a settled scroll
+/// re-rasters the page. Null leaves images at native resolution (the historic
+/// behavior). Only consulted when [decodeImages] is true. The deep-zoom detail
+/// patch re-rasters the visible region from the same picture, so under deep
+/// zoom an image softens at this cap rather than re-decoding sharper — the
+/// accepted trade for smooth panning of image-heavy sheets.
 Uint8List? serializeCommands(List<PdfRenderCommand> commands,
-    {CosDocument? cos, bool decodeImages = false}) {
+    {CosDocument? cos,
+    bool decodeImages = false,
+    double? maxImagePixelRatio}) {
   final w = _Writer();
   w.u8(_formatVersion);
   try {
-    _writeCommands(w, commands, cos, decode: decodeImages);
+    _writeCommands(w, commands, cos,
+        decode: decodeImages, maxImageRatio: maxImagePixelRatio);
   } on _UnserializableImage {
     return null;
   }
   return w.takeBytes();
+}
+
+// A capped image never exceeds these — matching the viewer's full-page raster
+// caps ([_PdfPageViewState._maxPixels] / `_maxDimension`) so even a sheet-sized
+// underlay stays within a GPU texture limit, rasterizes in tens of ms not
+// hundreds, and fits the decoded-image cache (so a settled scroll reuses it
+// instead of re-decoding it every time).
+const int _maxImagePixels = 1 << 24; // ~16.7M px (64 MB RGBA)
+const double _maxImageDimension = 8192;
+
+// The on-screen pixels an image covers, scaled up by this much, is the
+// resolution it is decoded/shipped at — one zoom-doubling of headroom over the
+// base raster before the deep-zoom patch (which re-rasters the same picture)
+// softens it.
+const double _imageResolutionHeadroom = 2.0;
+
+/// Returns [decoded] resampled down to ~[ratio]× ([_imageResolutionHeadroom]×)
+/// the pixels it occupies on screen, or unchanged when it already fits or the
+/// reduction would be negligible. [transform] maps the unit image square to
+/// page points, so its column lengths are the image's drawn width/height in
+/// points; multiplying by [ratio] (px/point) gives the on-screen pixel size.
+PdfDecodedPixels _capImageResolution(
+    PdfDecodedPixels decoded, PdfMatrix transform, double ratio) {
+  if (!(ratio > 0)) return decoded;
+  final widthPts =
+      math.sqrt(transform.a * transform.a + transform.b * transform.b);
+  final heightPts =
+      math.sqrt(transform.c * transform.c + transform.d * transform.d);
+  if (!(widthPts > 0) || !(heightPts > 0)) return decoded;
+
+  var tw = (widthPts * ratio * _imageResolutionHeadroom).ceil();
+  var th = (heightPts * ratio * _imageResolutionHeadroom).ceil();
+  if (tw >= decoded.width && th >= decoded.height) return decoded; // no upscale
+  if (tw > decoded.width) tw = decoded.width;
+  if (th > decoded.height) th = decoded.height;
+  if (tw < 1) tw = 1;
+  if (th < 1) th = 1;
+
+  // Hard ceilings so a monster sheet can't ship/rasterize an oversized texture.
+  final maxEdge = math.max(tw, th);
+  if (maxEdge > _maxImageDimension) {
+    final s = _maxImageDimension / maxEdge;
+    tw = (tw * s).floor().clamp(1, decoded.width);
+    th = (th * s).floor().clamp(1, decoded.height);
+  }
+  if (tw * th > _maxImagePixels) {
+    final s = math.sqrt(_maxImagePixels / (tw * th));
+    tw = (tw * s).floor().clamp(1, decoded.width);
+    th = (th * s).floor().clamp(1, decoded.height);
+  }
+
+  // Not worth a full-buffer copy for a sliver — keep the native pixels.
+  if (tw * th >= decoded.width * decoded.height * 0.9) return decoded;
+  return downsamplePdfDecodedPixels(decoded, tw, th);
 }
 
 /// Reconstructs the command buffer written by [serializeCommands].
@@ -104,10 +174,10 @@ List<PdfRenderCommand> deserializeCommands(Uint8List bytes) {
 }
 
 void _writeCommands(_Writer w, List<PdfRenderCommand> commands, CosDocument? cos,
-    {bool decode = false}) {
+    {bool decode = false, double? maxImageRatio}) {
   w.u32(commands.length);
   for (final command in commands) {
-    _writeCommand(w, command, cos, decode: decode);
+    _writeCommand(w, command, cos, decode: decode, maxImageRatio: maxImageRatio);
   }
 }
 
@@ -121,7 +191,7 @@ List<PdfRenderCommand> _readCommands(_Reader r) {
 }
 
 void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
-    {bool decode = false}) {
+    {bool decode = false, double? maxImageRatio}) {
   switch (command) {
     case PdfSaveCommand():
       w.u8(_tSave);
@@ -190,7 +260,12 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
       // Optional off-thread decode: the premultiplied pixels ride beside the
       // stream so the consumer skips the pure-Dart decode. The stream above is
       // still written, so the pixels cache by content like a local render.
-      final decoded = decode ? decodePdfImagePixels(cos, request.stream) : null;
+      var decoded = decode ? decodePdfImagePixels(cos, request.stream) : null;
+      // Cap to display resolution before it crosses the thread boundary — this
+      // is what shrinks the multi-hundred-MB payload of a CAD raster underlay.
+      if (decoded != null && maxImageRatio != null) {
+        decoded = _capImageResolution(decoded, request.transform, maxImageRatio);
+      }
       w.boolean(decoded != null);
       if (decoded != null) {
         w.u32(decoded.width);
@@ -222,7 +297,8 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
       w.f64(backdropLuminance);
       w.f64(transferScale);
       w.f64(transferOffset);
-      _writeCommands(w, maskCommands, cos, decode: decode); // nested
+      _writeCommands(w, maskCommands, cos,
+          decode: decode, maxImageRatio: maxImageRatio); // nested
   }
 }
 

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -96,19 +96,93 @@ class _UnserializableImage implements Exception {
 /// patch re-rasters the visible region from the same picture, so under deep
 /// zoom an image softens at this cap rather than re-decoding sharper — the
 /// accepted trade for smooth panning of image-heavy sheets.
+/// The page raster never exceeds this many pixels (the viewer's full-page
+/// raster cap), so it is also the natural unit for the page image budget.
+const int _maxImagePixels = 1 << 24;
+
+/// Total decoded image pixels per page are bounded to this multiple of
+/// [_maxImagePixels]. The per-image cap keeps each image near its own
+/// on-screen footprint, but a sheet layered from dozens of overlapping raster
+/// tiles can still sum to many times the page raster — only the topmost layer
+/// per pixel is ever shown, so the rest is decoded, shipped, and cached for
+/// nothing. This ceiling (~42 MP at the default) scales every image down to
+/// fit, bounding the command buffer and the decoded-image cache no matter how
+/// the sheet is layered. Larger keeps more sharpness on heavy overlap at the
+/// cost of a bigger payload.
+const double _imageBudgetFactor = 2.5;
+
 Uint8List? serializeCommands(List<PdfRenderCommand> commands,
     {CosDocument? cos,
     bool decodeImages = false,
-    double? maxImagePixelRatio}) {
+    double? maxImagePixelRatio,
+    double imageBudgetFactor = _imageBudgetFactor}) {
   final w = _Writer();
   w.u8(_formatVersion);
+  // Page-pixel budget: a global downscale applied on top of the per-image
+  // cap so the sum of all decoded images fits within a few page rasters. 1.0
+  // (no-op) unless decoding with a per-image cap active and the page's images
+  // overflow the budget.
+  var budgetScale = 1.0;
+  if (decodeImages && maxImagePixelRatio != null && cos != null) {
+    budgetScale = _imageBudgetScale(commands, cos, maxImagePixelRatio,
+        (imageBudgetFactor * _maxImagePixels).round());
+  }
   try {
     _writeCommands(w, commands, cos,
-        decode: decodeImages, maxImageRatio: maxImagePixelRatio);
+        decode: decodeImages,
+        maxImageRatio: maxImagePixelRatio,
+        budgetScale: budgetScale);
   } on _UnserializableImage {
     return null;
   }
   return w.takeBytes();
+}
+
+/// Linear downscale to apply to every image so the sum of the per-image-capped
+/// target areas fits within [budgetPixels]. 1.0 when the page already fits.
+/// Walks declared image dimensions only (no decode), descending soft-mask
+/// groups, so it is a cheap pre-pass before the decoding write pass. Images
+/// that ship un-decoded (platform-codec path) are counted too, so the scale is
+/// conservative when those are mixed in — acceptable, and they are rare on the
+/// raster-tiled sheets this targets.
+double _imageBudgetScale(List<PdfRenderCommand> commands, CosDocument cos,
+    double ratio, int budgetPixels) {
+  var total = 0;
+  void walk(List<PdfRenderCommand> cmds) {
+    for (final c in cmds) {
+      if (c is PdfDrawImageCommand) {
+        final size = _declaredImageSize(cos, c.request.stream);
+        if (size == null) continue;
+        final t = c.request.transform;
+        final wPts = math.sqrt(t.a * t.a + t.b * t.b);
+        final hPts = math.sqrt(t.c * t.c + t.d * t.d);
+        final (tw, th) =
+            cappedImagePixelSize(size.$1, size.$2, wPts, hPts, ratio);
+        total += tw * th;
+      } else if (c is PdfEndSoftMaskedCommand) {
+        walk(c.maskCommands);
+      }
+    }
+  }
+
+  walk(commands);
+  if (total == 0 || total <= budgetPixels) return 1.0;
+  return math.sqrt(budgetPixels / total);
+}
+
+/// The native pixel dimensions an image stream declares (`/Width`, `/Height`),
+/// or null when absent/degenerate. Cheap — no pixels are decoded.
+(int, int)? _declaredImageSize(CosDocument cos, CosStream stream) {
+  final w = _cosInt(cos.resolve(stream.dictionary['Width']));
+  final h = _cosInt(cos.resolve(stream.dictionary['Height']));
+  if (w == null || h == null || w < 1 || h < 1) return null;
+  return (w, h);
+}
+
+int? _cosInt(CosObject? o) {
+  if (o is CosInteger) return o.value;
+  if (o is CosReal) return o.value.round();
+  return null;
 }
 
 /// Returns [decoded] resampled down to ~2× the pixels it occupies on screen
@@ -117,14 +191,23 @@ Uint8List? serializeCommands(List<PdfRenderCommand> commands,
 /// the decoded-image cache), or unchanged when it already fits. [transform]
 /// maps the unit image square to page points, so its column lengths are the
 /// image's drawn width/height in points; [ratio] is screen px per point.
+/// [budgetScale] (≤1) is the page-budget downscale applied on top of the
+/// per-image cap (see [_imageBudgetScale]); 1.0 leaves the per-image result.
 PdfDecodedPixels _capImageResolution(
-    PdfDecodedPixels decoded, PdfMatrix transform, double ratio) {
+    PdfDecodedPixels decoded, PdfMatrix transform, double ratio,
+    [double budgetScale = 1.0]) {
   final widthPts =
       math.sqrt(transform.a * transform.a + transform.b * transform.b);
   final heightPts =
       math.sqrt(transform.c * transform.c + transform.d * transform.d);
-  final (tw, th) = cappedImagePixelSize(
+  final capped = cappedImagePixelSize(
       decoded.width, decoded.height, widthPts, heightPts, ratio);
+  var tw = capped.$1;
+  var th = capped.$2;
+  if (budgetScale < 1.0) {
+    tw = (tw * budgetScale).ceil().clamp(1, decoded.width);
+    th = (th * budgetScale).ceil().clamp(1, decoded.height);
+  }
   if (tw == decoded.width && th == decoded.height) return decoded;
   return downsamplePdfDecodedPixels(decoded, tw, th);
 }
@@ -138,10 +221,11 @@ List<PdfRenderCommand> deserializeCommands(Uint8List bytes) {
 }
 
 void _writeCommands(_Writer w, List<PdfRenderCommand> commands, CosDocument? cos,
-    {bool decode = false, double? maxImageRatio}) {
+    {bool decode = false, double? maxImageRatio, double budgetScale = 1.0}) {
   w.u32(commands.length);
   for (final command in commands) {
-    _writeCommand(w, command, cos, decode: decode, maxImageRatio: maxImageRatio);
+    _writeCommand(w, command, cos,
+        decode: decode, maxImageRatio: maxImageRatio, budgetScale: budgetScale);
   }
 }
 
@@ -155,7 +239,7 @@ List<PdfRenderCommand> _readCommands(_Reader r) {
 }
 
 void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
-    {bool decode = false, double? maxImageRatio}) {
+    {bool decode = false, double? maxImageRatio, double budgetScale = 1.0}) {
   switch (command) {
     case PdfSaveCommand():
       w.u8(_tSave);
@@ -228,7 +312,8 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
       // Cap to display resolution before it crosses the thread boundary — this
       // is what shrinks the multi-hundred-MB payload of a CAD raster underlay.
       if (decoded != null && maxImageRatio != null) {
-        decoded = _capImageResolution(decoded, request.transform, maxImageRatio);
+        decoded = _capImageResolution(
+            decoded, request.transform, maxImageRatio, budgetScale);
       }
       w.boolean(decoded != null);
       if (decoded != null) {
@@ -262,7 +347,9 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
       w.f64(transferScale);
       w.f64(transferOffset);
       _writeCommands(w, maskCommands, cos,
-          decode: decode, maxImageRatio: maxImageRatio); // nested
+          decode: decode,
+          maxImageRatio: maxImageRatio,
+          budgetScale: budgetScale); // nested
   }
 }
 

--- a/packages/pdf_graphics/test/image_downsample_test.dart
+++ b/packages/pdf_graphics/test/image_downsample_test.dart
@@ -1,0 +1,67 @@
+// Unit tests for the premultiplied-RGBA box-filter downsampler that caps a
+// CAD sheet's raster underlay to display resolution before it crosses the
+// render-worker boundary (see render_command_codec's maxImagePixelRatio).
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:test/test.dart';
+
+PdfDecodedPixels _solid(int w, int h, int r, int g, int b, int a) {
+  final rgba = Uint8List(w * h * 4);
+  for (var i = 0; i < w * h; i++) {
+    rgba[i * 4] = r;
+    rgba[i * 4 + 1] = g;
+    rgba[i * 4 + 2] = b;
+    rgba[i * 4 + 3] = a;
+  }
+  return PdfDecodedPixels(rgba, w, h);
+}
+
+void main() {
+  group('downsamplePdfDecodedPixels', () {
+    test('returns the same instance when no downscale is needed', () {
+      final src = _solid(4, 4, 10, 20, 30, 255);
+      expect(identical(downsamplePdfDecodedPixels(src, 4, 4), src), isTrue);
+      expect(identical(downsamplePdfDecodedPixels(src, 8, 8), src), isTrue,
+          reason: 'must never upscale');
+      // One axis already small enough but the other larger still resamples.
+      expect(identical(downsamplePdfDecodedPixels(src, 4, 2), src), isFalse);
+    });
+
+    test('averages a 2x2 block into one pixel', () {
+      // Four distinct pixels; the 1x1 result is their per-channel mean.
+      final rgba = Uint8List.fromList(<int>[
+        40, 80, 120, 160, //
+        0, 0, 0, 0, //
+        200, 200, 200, 200, //
+        100, 100, 100, 100, //
+      ]);
+      final out = downsamplePdfDecodedPixels(PdfDecodedPixels(rgba, 2, 2), 1, 1);
+      expect(out.width, 1);
+      expect(out.height, 1);
+      expect(out.rgba, equals(<int>[85, 95, 105, 115]));
+    });
+
+    test('halving a solid image preserves its colour and dimensions', () {
+      final out = downsamplePdfDecodedPixels(_solid(8, 6, 33, 66, 99, 200), 4, 3);
+      expect(out.width, 4);
+      expect(out.height, 3);
+      for (var i = 0; i < out.width * out.height; i++) {
+        expect(out.rgba.sublist(i * 4, i * 4 + 4), equals(<int>[33, 66, 99, 200]));
+      }
+    });
+
+    test('clamps a target larger than the source per axis', () {
+      final out = downsamplePdfDecodedPixels(_solid(6, 6, 1, 2, 3, 4), 10, 3);
+      expect(out.width, 6, reason: 'width target above source is clamped down');
+      expect(out.height, 3);
+    });
+
+    test('a degenerate target falls back to at least 1px', () {
+      final out = downsamplePdfDecodedPixels(_solid(6, 6, 9, 9, 9, 9), 0, 0);
+      expect(out.width, 1);
+      expect(out.height, 1);
+      expect(out.rgba, equals(<int>[9, 9, 9, 9]));
+    });
+  });
+}

--- a/packages/pdf_graphics/test/image_downsample_test.dart
+++ b/packages/pdf_graphics/test/image_downsample_test.dart
@@ -64,4 +64,53 @@ void main() {
       expect(out.rgba, equals(<int>[9, 9, 9, 9]));
     });
   });
+
+  group('cappedImagePixelSize', () {
+    // An image drawn at `pts` points wide/tall, displayed at `ratio` px/point,
+    // should cap to ~headroom×(pts·ratio) — here headroom defaults to 2.
+    test('caps to ~2x the on-screen footprint', () {
+      // 4000px native, drawn 100pt across, shown at 1px/pt → ~200px target.
+      expect(cappedImagePixelSize(4000, 4000, 100, 100, 1.0), (200, 200));
+    });
+
+    test('never upscales: a tiny native image is returned unchanged', () {
+      expect(cappedImagePixelSize(64, 64, 1000, 1000, 4.0), (64, 64));
+    });
+
+    test('a non-positive ratio leaves the image untouched', () {
+      expect(cappedImagePixelSize(4000, 4000, 100, 100, 0), (4000, 4000));
+      expect(cappedImagePixelSize(4000, 4000, 100, 100, -1), (4000, 4000));
+    });
+
+    test('a degenerate (zero-extent) transform leaves it untouched', () {
+      expect(cappedImagePixelSize(4000, 4000, 0, 100, 1.0), (4000, 4000));
+      expect(cappedImagePixelSize(4000, 4000, 100, 0, 1.0), (4000, 4000));
+    });
+
+    test('a zero-pixel source is returned as-is', () {
+      expect(cappedImagePixelSize(0, 10, 100, 100, 1.0), (0, 10));
+    });
+
+    test('clamps the long edge to maxDimension', () {
+      // Drawn enormous so the 2x footprint would exceed 8192 on the long edge;
+      // the cap scales both axes down preserving aspect.
+      final (w, h) = cappedImagePixelSize(40000, 20000, 9000, 4500, 1.0);
+      expect(w, lessThanOrEqualTo(8192));
+      expect(h, lessThanOrEqualTo(8192));
+      expect(w, greaterThan(h)); // 2:1 aspect preserved
+    });
+
+    test('clamps total area to maxPixels', () {
+      // A near-square huge draw that stays under 8192/edge but blows the
+      // 16.7Mpx area ceiling → scaled to fit it.
+      final (w, h) = cappedImagePixelSize(20000, 20000, 4000, 4000, 1.0);
+      expect(w * h, lessThanOrEqualTo(1 << 24));
+      expect(w, h); // square aspect preserved
+    });
+
+    test('skips a negligible (<10%) reduction', () {
+      // 2x footprint lands at ~96% of native — not worth resampling.
+      expect(cappedImagePixelSize(100, 100, 49, 49, 1.0), (100, 100));
+    });
+  });
 }

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -303,6 +303,87 @@ void main() {
       });
     }
   });
+
+  // maxImagePixelRatio caps each decoded image to ~display resolution before it
+  // crosses the worker boundary — the fix for raster-thread jank on CAD sheets
+  // whose embedded underlays are 100+ megapixels. A tiny ratio must shrink
+  // them; a null/huge ratio must leave them at native resolution; and the
+  // command transcript must be untouched either way (only the pixels change).
+  group('image resolution cap', () {
+    final files = <String>[
+      '../../test_corpora/ghent/1-CMYK/'
+          'GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',
+      '../../test_corpora/ghent/1-CMYK/GWG168_Softmasks_Vector_part1_X4.pdf',
+    ];
+    for (final path in files) {
+      final file = File(path);
+      final name = path.split('/').last;
+      test(name, () {
+        if (!file.existsSync()) {
+          markTestSkipped('$path not found');
+          return;
+        }
+        final doc = PdfDocument.open(file.readAsBytesSync());
+        var sawCapped = false;
+        for (var i = 0; i < doc.pageCount; i++) {
+          final page = doc.page(i);
+          final ops = ContentStreamParser.parse(page.contentBytes());
+          final recorder = RecordingPdfDevice();
+          PdfInterpreter(cos: doc.cos, device: recorder)
+              .drawPageOperations(page, ops);
+
+          final uncapped = serializeCommands(recorder.commands,
+              cos: doc.cos, decodeImages: true);
+          if (uncapped == null) continue; // inline image: page declines
+          // A tiny ratio drives every image to display resolution; a huge ratio
+          // can never downscale (the cap never upscales).
+          final capped = serializeCommands(recorder.commands,
+              cos: doc.cos, decodeImages: true, maxImagePixelRatio: 0.002);
+          final huge = serializeCommands(recorder.commands,
+              cos: doc.cos, decodeImages: true, maxImagePixelRatio: 1e6);
+          expect(capped, isNotNull);
+          expect(huge, isNotNull);
+
+          final native = _imageCommands(deserializeCommands(uncapped));
+          final small = _imageCommands(deserializeCommands(capped!));
+          final big = _imageCommands(deserializeCommands(huge!));
+
+          // The cap only changes pixels, never the command stream.
+          expect(_transcript(deserializeCommands(capped)),
+              equals(_transcript(deserializeCommands(uncapped))),
+              reason: '$name page $i transcript diverged under the cap');
+
+          for (var k = 0; k < native.length; k++) {
+            final nat = native[k].request.decoded;
+            final cap = small[k].request.decoded;
+            final hg = big[k].request.decoded;
+            if (nat == null) {
+              // Platform-codec image: ships no pixels regardless of the ratio.
+              expect(cap, isNull);
+              expect(hg, isNull);
+              continue;
+            }
+            expect(cap, isNotNull);
+            expect(hg, isNotNull);
+            // A huge ratio leaves native resolution untouched.
+            expect(hg!.width, nat.width);
+            expect(hg.height, nat.height);
+            // A tiny ratio never exceeds native and never under-runs 1px.
+            expect(cap!.width, lessThanOrEqualTo(nat.width));
+            expect(cap.height, lessThanOrEqualTo(nat.height));
+            expect(cap.width, greaterThanOrEqualTo(1));
+            expect(cap.height, greaterThanOrEqualTo(1));
+            expect(cap.rgba.length, cap.width * cap.height * 4);
+            if (cap.width < nat.width || cap.height < nat.height) {
+              sawCapped = true;
+            }
+          }
+        }
+        expect(sawCapped, isTrue,
+            reason: '$name capped no image — the test proved nothing');
+      });
+    }
+  });
 }
 
 /// Every image draw command in [commands], in replay (DFS) order, descending

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -384,6 +384,86 @@ void main() {
       });
     }
   });
+
+  // imageBudgetFactor bounds the TOTAL decoded pixels of a page to a multiple
+  // of the page raster cap, on top of the per-image cap — the fix for sheets
+  // layered from dozens of overlapping raster tiles, where each image is near
+  // its own footprint yet their sum dwarfs the raster. A tiny factor forces
+  // the page budget to bind even on these small pages: total decoded pixels
+  // must drop below the budget, while the command transcript stays identical.
+  group('page image budget', () {
+    final files = <String>[
+      '../../test_corpora/ghent/1-CMYK/'
+          'GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',
+    ];
+    for (final path in files) {
+      final file = File(path);
+      final name = path.split('/').last;
+      test(name, () {
+        if (!file.existsSync()) {
+          markTestSkipped('$path not found');
+          return;
+        }
+        final doc = PdfDocument.open(file.readAsBytesSync());
+        var sawBudgeted = false;
+        for (var i = 0; i < doc.pageCount; i++) {
+          final page = doc.page(i);
+          final ops = ContentStreamParser.parse(page.contentBytes());
+          final recorder = RecordingPdfDevice();
+          PdfInterpreter(cos: doc.cos, device: recorder)
+              .drawPageOperations(page, ops);
+
+          // Huge per-image ratio => the per-image cap is a no-op, isolating the
+          // page-budget effect. Default budget leaves these small pages native.
+          final native = serializeCommands(recorder.commands,
+              cos: doc.cos, decodeImages: true, maxImagePixelRatio: 1e6);
+          if (native == null) continue; // inline image: page declines
+          // A tiny budget (0.0005 * 16.78 MP ~ 8.4 Kpx) forces the page total
+          // down regardless of how the images are laid out.
+          const factor = 0.0005;
+          final budgeted = serializeCommands(recorder.commands,
+              cos: doc.cos,
+              decodeImages: true,
+              maxImagePixelRatio: 1e6,
+              imageBudgetFactor: factor);
+          expect(budgeted, isNotNull);
+
+          // The budget changes pixels only, never the command stream.
+          expect(_transcript(deserializeCommands(budgeted!)),
+              equals(_transcript(deserializeCommands(native))),
+              reason: '$name page $i transcript diverged under the budget');
+
+          final nativePixels = _decodedPixelSum(deserializeCommands(native));
+          final budgetedPixels =
+              _decodedPixelSum(deserializeCommands(budgeted));
+          if (nativePixels == 0) continue; // platform-codec only: nothing decoded
+          final budgetPixels = (factor * (1 << 24)).round();
+          // Total decoded pixels sit under the budget, plus a per-image ceil
+          // slop (each image rounds its target edges up).
+          final imageCount = _imageCommands(deserializeCommands(budgeted)).length;
+          expect(budgetedPixels,
+              lessThanOrEqualTo(budgetPixels + imageCount * 16 + 64),
+              reason: '$name page $i total decoded pixels ($budgetedPixels) '
+                  'exceed the page budget ($budgetPixels)');
+          expect(budgetedPixels, lessThan(nativePixels),
+              reason: '$name page $i budget did not shrink the page total');
+          sawBudgeted = true;
+        }
+        expect(sawBudgeted, isTrue,
+            reason: '$name page budget bound no page — proved nothing');
+      });
+    }
+  });
+}
+
+/// Sum of decoded pixels across every image draw (DFS, soft-mask groups too).
+int _decodedPixelSum(List<PdfRenderCommand> commands) {
+  var total = 0;
+  for (final c in _imageCommands(commands)) {
+    final d = c.request.decoded;
+    if (d != null) total += d.width * d.height;
+  }
+  return total;
 }
 
 /// Every image draw command in [commands], in replay (DFS) order, descending


### PR DESCRIPTION
## Problem

Panning a 58 MB CAD document (mixed raster + vector, ~40 sheet pages) on **web (CanvasKit/WASM)** janked badly as each scroll *settled*. A `PDF_PERF_LOG` (`?perf=1`) trace was decisive:

- Every interpret was `path=worker` — interpretation was **not** the bottleneck.
- Every janky frame was **raster-bound**: `build` <10 ms while `raster` ran **150–650 ms** → CanvasKit's (single, on web) raster thread.
- The worker payloads were the smoking gun: `webworker result page=30 639,867,067B` — a **640 MB** decoded-pixel buffer for one page (≈160 megapixel scanned underlay), ~70 MB each for several others.

Root cause: embedded images were decoded, shipped across the worker boundary, drawn into the page picture, and rasterized (`picture.toImage`) at **native resolution**, regardless of on-screen size. Two compounding effects:

1. Each `toImage` of a picture wrapping a 640 MB texture is a 150–650 ms single-threaded GPU readback on web.
2. A single 640 MB image exceeds the whole `PdfImageCache` budget (256 MB), so it **never stays cached** — every settle re-requested it (640 MB `postMessage` again) and re-rasterized it, producing a *train* of 180–260 ms raster-jank frames at a fixed scroll position.

## Fix

Downsample each decoded image to ~display resolution **in the worker, before serialization**, so the giant buffer never crosses `postMessage`, fits the cache, and rasterizes in tens of ms.

- **`serializeCommands(..., maxImagePixelRatio:)`** (pdf_graphics `render_command_codec.dart`) caps each image after `decodePdfImagePixels` to ~`2× (drawn-size-in-points × ratio)` — i.e. ~2× the pixels it covers on screen. Hard ceilings (16.7 Mpx / 8192 px) mirror the viewer's full-page raster caps. Null ratio = historic native behaviour; only consulted on the worker path (`decodeImages: true`).
- **`downsamplePdfDecodedPixels`** (pdf_graphics `image_pixels.dart`) — area-average (box filter) resampler over premultiplied RGBA; web-safe int accumulators; never upscales.
- The display **ratio is threaded** through `PdfRenderWorker.record(..., imagePixelRatio:)` (isolate `request[3]` + web `imageRatio` postMessage field). `PdfPageView._interpretPicture` passes `_effectiveRatio()`; the preview prerender and editing thumbnails pass their (small) raster ratios so they no longer ship full-res underlays just to be downscaled into a tile.
- **Cache-key fix:** `PdfImageCache` keys worker-sourced images by stream *content*. Capping per-call means the same source image can be decoded at two sizes (sharp on-screen vs. tiny preview); content-only keying would let one evict/stand-in for the other. `pdfImageKey` now folds the decoded dimensions into the key (`PdfSizedImageKey`) for worker-decoded images. Local renders (`decoded == null`) keep the plain key — unchanged.

## Trade-off (chosen)

The deep-zoom detail patch re-rasters the visible region from the *same* cached picture (no re-decode), so under deep zoom an image softens at this cap rather than re-sharpening. The `2×` headroom keeps normal viewing (and one zoom-doubling) sharp; a follow-up could re-decode the zoomed region at higher resolution. The absolute 16.7 Mpx ceiling is what fixes the cache thrash — every page now fits the 256 MB cache, so a settled scroll reuses the raster instead of re-decoding it.

## Tests

- `pdf_graphics/test/image_downsample_test.dart` — box-filter correctness (averaging, no-upscale, clamps, degenerate target).
- `render_command_codec_test.dart` "image resolution cap" — tiny ratio shrinks, huge/null leaves native, command transcript unchanged (pixels only).
- `render_worker_test.dart` — end-to-end: `record(imagePixelRatio:)` ships fewer pixels than the uncapped record.
- Full `pdf_graphics` suite (672), worker/image-decoder/cache/replay tests, and **Ghent render baselines** all pass — baselines untouched since the cap is worker-only and those tests render directly (no worker, no ratio).

See [`doc/dev-log/2026-06-25-image-resolution-cap.md`](doc/dev-log/2026-06-25-image-resolution-cap.md) for the full write-up.

> [!NOTE]
> This is diagnosed from the perf trace, not yet verified against the actual 58 MB file. Worth re-running the `?perf=1` trace after this lands to confirm the raster spikes and the cache thrash are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3HzyKM3khr7m5ww8x7RfA)_