### PR TITLE
[codex] Improve heavy-page first paint performance

### DIFF
--- a/app/tool/perf/driver.mjs
+++ b/app/tool/perf/driver.mjs
@@ -116,17 +116,36 @@ function parse(lines, frames) {
     workerResultMax: 0,
     workerWarmMax: 0,
     prerender: { vector: 0, full: 0 },
+    target: {},
     jankCount: 0,
     errorLines: [],
     declines: 0,
     harness: {},
   };
   for (const line of lines) {
+    const stamp = line.match(/^\[perf ([\d.]+)\]/);
+    const atMs = stamp ? Number(stamp[1]) : null;
+    const targetStart = line.match(/HARNESS TARGET start page=(\d+)/);
+    if (targetStart && atMs != null) {
+      r.target.page = Number(targetStart[1]);
+      r.target.startMs = atMs;
+    }
+    const targetFirst = line.match(/HARNESS TARGET firstContent page=(\d+)/);
+    if (targetFirst && atMs != null && r.target.startMs != null) {
+      r.target.detectedMs = atMs - r.target.startMs;
+    }
     const m = line.match(/interpret page=(\d+) path=(\w+)/);
     if (m) {
       r.pages.add(Number(m[1]));
       const path = m[2];
       if (path in r.interpret) r.interpret[path]++; else r.interpret.other++;
+      if (atMs != null &&
+          r.target.startMs != null &&
+          r.target.firstContentMs == null &&
+          Number(m[1]) === r.target.page) {
+        r.target.firstContentMs = atMs - r.target.startMs;
+        r.target.kind = `interpret/${path}`;
+      }
     }
     const wr = line.match(/webworker result page=\d+ (\d+)B/);
     if (wr) {
@@ -138,6 +157,24 @@ function parse(lines, frames) {
     if (warm) r.workerWarmMax = Math.max(r.workerWarmMax, Number(warm[1]));
     const pre = line.match(/prerender page=\d+ (?:worker )?(vector|full) /);
     if (pre) r.prerender[pre[1]]++;
+    const vector = line.match(/vector-first page=(\d+)/);
+    if (vector &&
+        atMs != null &&
+        r.target.startMs != null &&
+        r.target.firstContentMs == null &&
+        Number(vector[1]) === r.target.page) {
+      r.target.firstContentMs = atMs - r.target.startMs;
+      r.target.kind = 'vector-first';
+    }
+    const preview = line.match(/preview-paint page=(\d+)/);
+    if (preview &&
+        atMs != null &&
+        r.target.startMs != null &&
+        r.target.firstContentMs == null &&
+        Number(preview[1]) === r.target.page) {
+      r.target.firstContentMs = atMs - r.target.startMs;
+      r.target.kind = 'preview';
+    }
     if (/JANK /.test(line)) r.jankCount++;
     if (/declin/i.test(line)) r.declines++;
     if (/error|exception|unsupported|cannot|failed/i.test(line) && /\[perf|webworker/.test(line)) {
@@ -185,6 +222,7 @@ async function main() {
   if (process.env.PERF_DWELL_MS) qp.set('dwell', process.env.PERF_DWELL_MS);
   if (process.env.PERF_PASSES) qp.set('passes', process.env.PERF_PASSES);
   if (process.env.PERF_FAST_PASS) qp.set('fast', process.env.PERF_FAST_PASS);
+  if (process.env.PERF_TARGET_PAGE) qp.set('targetPage', process.env.PERF_TARGET_PAGE);
   const qs = qp.toString();
   const url = `http://127.0.0.1:${PORT}/${qs ? '?' + qs : ''}`;
   console.log(`▶ serving ${WEB_DIR} + /perf.pdf at ${url} (headless=${HEADLESS})`);
@@ -237,7 +275,7 @@ async function main() {
     try { frames = JSON.parse(framesJson); } catch { /* ignore */ }
 
     result = { ...(result ?? {}), harnessError, lines: lines.length, ...parse(lines, frames) };
-    result.rawLineSample = lines.filter((l) => /interpret|webworker|HARNESS|JANK|error/i.test(l)).slice(0, 40);
+    result.rawLineSample = lines.filter((l) => /interpret|webworker|vector-first|preview-paint|HARNESS|JANK|error/i.test(l)).slice(0, 60);
   } catch (e) {
     fatal = String(e?.stack ?? e);
   } finally {
@@ -268,6 +306,9 @@ async function main() {
     console.log(`  interpret paths    worker=${i.worker} recorded=${i.recorded} plain=${i.plain} other=${i.other} declines=${result.declines}`);
     console.log(`  worker decode      max=${(result.workerResultMax / 1e6).toFixed(2)}MB total=${(result.workerResultBytes / 1e6).toFixed(1)}MB warmMax=${fmt(result.workerWarmMax)}ms`);
     console.log(`  prerender warms    vector=${result.prerender.vector} full=${result.prerender.full}`);
+    if (result.target?.firstContentMs != null) {
+      console.log(`  target first paint page=${result.target.page} ${fmt(result.target.firstContentMs)}ms via ${result.target.kind}`);
+    }
     console.log(`  frames             ${f.count}  buildP50=${fmt(f.buildP50)}ms p95=${fmt(f.buildP95)}ms max=${fmt(f.buildMax)}ms`);
     console.log(`  build over budget  >16ms=${f.buildOver16}  >32ms=${f.buildOver32}  >50ms=${f.buildOver50}   (PdfPerfLog JANK lines=${result.jankCount})`);
     if (result.errorLines?.length) {

--- a/app/tool/perf/perf_harness.dart
+++ b/app/tool/perf/perf_harness.dart
@@ -58,6 +58,7 @@ final int _passes =
     _qInt('passes', const int.fromEnvironment('PERF_PASSES', defaultValue: 1));
 final bool _fastPass = _qBool(
     'fast', const bool.fromEnvironment('PERF_FAST_PASS', defaultValue: true));
+final int _targetPage = _qInt('targetPage', -1);
 
 // ---------------------------------------------------------------------------
 // Capture: every debugPrint line + every frame's timing.
@@ -186,6 +187,10 @@ class _PerfHarnessAppState extends State<_PerfHarnessApp> {
       _setGlobal('__perfDone', true.toJS);
       return;
     }
+    if (_targetPage >= 0) {
+      await _driveTarget(count);
+      return;
+    }
 
     // Let the first visible page interpret before we start moving.
     await Future<void>.delayed(const Duration(milliseconds: 1500));
@@ -216,6 +221,31 @@ class _PerfHarnessAppState extends State<_PerfHarnessApp> {
     }
 
     // Settle so trailing prerenders/decodes land in the trace.
+    await Future<void>.delayed(const Duration(milliseconds: 1500));
+    _record(
+        '[perf] HARNESS DONE frames=${_frames.length} lines=${_lines.length}');
+    _setGlobal('__perfDone', true.toJS);
+  }
+
+  Future<void> _driveTarget(int count) async {
+    final target = _targetPage.clamp(0, count - 1);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    _record('[perf] HARNESS TARGET start page=$target');
+    PdfPerfLog.log('HARNESS TARGET start page=$target');
+    unawaited(_viewer.jumpToPage(target));
+
+    final vector = 'vector-first page=$target';
+    final full = 'interpret page=$target ';
+    final deadline = DateTime.now().add(const Duration(seconds: 30));
+    while (DateTime.now().isBefore(deadline)) {
+      if (_lines.any((line) => line.contains(vector) || line.contains(full))) {
+        _record('[perf] HARNESS TARGET firstContent page=$target');
+        PdfPerfLog.log('HARNESS TARGET firstContent page=$target');
+        break;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+    }
+
     await Future<void>.delayed(const Duration(milliseconds: 1500));
     _record(
         '[perf] HARNESS DONE frames=${_frames.length} lines=${_lines.length}');

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -33,6 +33,7 @@ class PdfPageView extends StatefulWidget {
     this.onRasterReady,
     this.renderHold,
     this.renderScheduler,
+    this.renderPriority = 0,
     this.previewCache,
     this.previewIndex = 0,
     this.pageEpoch = 0,
@@ -117,6 +118,11 @@ class PdfPageView extends StatefulWidget {
   /// [PdfPageRenderScheduler]). Re-rasters of an already-interpreted page
   /// bypass it. Null falls back to [renderHold].
   final PdfPageRenderScheduler? renderScheduler;
+
+  /// Worker queue priority for this page's on-screen record requests. Lower
+  /// values win. The viewer ranks the page nearest the viewport above cache-
+  /// window neighbours so a long jump paints the destination first.
+  final int renderPriority;
 
   /// Called whenever a full-page raster for the current [page] object
   /// lands on screen. Lets the editing overlay hold its just-committed
@@ -211,6 +217,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (next == null) return; // keep whatever we already hold
     _preview?.dispose();
     _preview = next;
+    PdfPerfLog.log('preview-paint page=${widget.previewIndex}');
   }
 
   @override
@@ -256,7 +263,8 @@ class _PdfPageViewState extends State<PdfPageView> {
       // this slot): cancel the old page's queued worker request — the user
       // scrolled past it, so decoding it now would only delay the page now on
       // screen. The in-flight one can't be preempted; this clears the backlog.
-      oldWidget.renderWorker?.cancel(oldWidget.previewIndex, priority: 0);
+      oldWidget.renderWorker
+          ?.cancel(oldWidget.previewIndex, priority: oldWidget.renderPriority);
     }
     if (!identical(oldWidget.previewCache, widget.previewCache) ||
         oldWidget.previewIndex != widget.previewIndex) {
@@ -318,7 +326,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     // so the worker's next slot serves a page still on screen (the abandoned
     // result is ignored — _interpretPicture's !mounted guard skips the local
     // fallback). No-op if nothing is queued for it.
-    widget.renderWorker?.cancel(widget.previewIndex, priority: 0);
+    widget.renderWorker
+        ?.cancel(widget.previewIndex, priority: widget.renderPriority);
     widget.previewCache?.removeListener(_onPreviewCacheChanged);
     _dropPicture();
     _image?.dispose();
@@ -421,7 +430,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       // visible region for sharper zoom).
       final commands = await worker.record(pageIndex,
           annotations: widget.showAnnotations,
-          priority: 0,
+          priority: widget.renderPriority,
           imagePixelRatio: _effectiveRatio());
       // Abandoned while the worker ran — the State was disposed or the lazy
       // list recycled it onto another page (this is the cancel() path: a
@@ -460,7 +469,9 @@ class _PdfPageViewState extends State<PdfPageView> {
     final worker = widget.renderWorker;
     if (worker == null || !worker.isActive) return;
     final commands = await worker.record(pageIndex,
-        annotations: widget.showAnnotations, priority: 0, decodeImages: false);
+        annotations: widget.showAnnotations,
+        priority: widget.renderPriority,
+        decodeImages: false);
     if (_superseded(generation, pageIndex) || commands == null) return;
 
     if (!PdfPageRenderer.hasImageDraws(commands)) {

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -150,8 +150,7 @@ class PdfViewerController extends ChangeNotifier {
   /// The logical label for zero-based [index] (e.g. "iv", "A-3"), or its
   /// 1-based physical number when the document carries no `/PageLabels` (or
   /// no viewer is attached). See [PdfPageLabels].
-  String pageLabel(int index) =>
-      _state?._pageLabelFor(index) ?? '${index + 1}';
+  String pageLabel(int index) => _state?._pageLabelFor(index) ?? '${index + 1}';
 
   /// The zero-based page index whose logical [pageLabel] equals [label]
   /// (case-sensitive), or null when none matches. Lets a page field accept
@@ -737,6 +736,8 @@ class PdfViewer extends StatefulWidget {
 }
 
 class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
+  static const int _jumpPreviewOperationLimit = 2000;
+
   late PdfViewerController _controller;
   bool _ownsController = false;
 
@@ -759,6 +760,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   Timer? _settleTimer;
   Timer? _scrollSettleTimer;
   int _settleGeneration = 0;
+  int? _jumpFocusPage;
 
   /// Bumped whenever the document is swapped for a revision whose page
   /// structure differs (insert/remove/reorder — the non-same-geometry path
@@ -1224,11 +1226,12 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   void _onScrollForDetail() {
     _trackScrollVelocity();
     // the scheduler drains held pages nearest the viewport first
-    _renderScheduler.focus = _controller.currentPage;
+    _renderScheduler.focus = _jumpFocusPage ?? _controller.currentPage;
     _scrollSettleTimer?.cancel();
     _scrollSettleTimer = Timer(const Duration(milliseconds: 250), () {
       _scrollSamples.clear();
       _vectorFirstPrefetch = false;
+      _jumpFocusPage = null;
       _renderScheduler.holding = false;
       if (mounted) setState(() => _settleGeneration++);
       // the prerender pauses while the user scrolls; pick it back up
@@ -1327,7 +1330,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       // bound the proactive warm to a window around the viewport — far
       // pages render on demand on arrival (render hold) and feed the
       // cache for free when scrolled through (putFromPicture)
-      final window = widget.previewWindow;
+      final window = _effectivePreviewWindow(requireImages: requireImages);
       if (window > 0 && distance > window) continue;
       if (requireImages) {
         if (_previewAttempts.contains(pages[i])) continue;
@@ -1343,6 +1346,39 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       }
     }
     return best;
+  }
+
+  /// Full-image preview warming should stay inside the worker cache's useful
+  /// horizon. Large documents and nearly-full decoded-image caches otherwise
+  /// spend worker time warming pages whose records are evicted before reuse.
+  /// Vector-only warming stays at the configured window because it is cheap
+  /// and weighs zero in [PdfCachingRenderWorker].
+  int _effectivePreviewWindow({required bool requireImages}) {
+    final base = widget.previewWindow;
+    if (base <= 0 || !requireImages) return base;
+
+    var window = base;
+    final pageCount = _pages.length;
+    if (pageCount >= 100) {
+      window = math.min(window, 2);
+    } else if (pageCount >= 50) {
+      window = math.min(window, 3);
+    } else if (pageCount >= 25) {
+      window = math.min(window, 4);
+    }
+
+    final worker = widget.renderWorker;
+    if (worker is PdfCachingRenderWorker) {
+      final pressure = worker.cachePressure;
+      if (pressure >= 0.85) {
+        window = math.min(window, 1);
+      } else if (pressure >= 0.65) {
+        window = math.min(window, 2);
+      } else if (pressure >= 0.45) {
+        window = math.min(window, 3);
+      }
+    }
+    return math.max(1, window);
   }
 
   /// Estimates the scroll velocity over a ~200ms window of per-frame
@@ -1422,8 +1458,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
         // redaction burn removes glyphs/images): drop its stale preview so
         // a fast scroll can't flash the deleted content, instead of
         // rebinding it. Untouched pages rebind in place as before.
-        _previews.rebind(_pages,
-            changed: (i) {
+        _previews.rebind(_pages, changed: (i) {
           final prev = _contentStamps[i];
           return prev != null && prev != _contentStamp(i);
         });
@@ -1548,7 +1583,8 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       for (var i = 0; i < _pages.length; i++)
         _isEffectivelySideways(i)
             ? _pages[i].cropBox.width / math.max(1e-6, _pages[i].cropBox.height)
-            : _pages[i].cropBox.height / math.max(1e-6, _pages[i].cropBox.width),
+            : _pages[i].cropBox.height /
+                math.max(1e-6, _pages[i].cropBox.width),
     ];
     _pointWidths = [
       for (var i = 0; i < _pages.length; i++)
@@ -1616,7 +1652,6 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     return r == 90 || r == 270;
   }
 
-
   @override
   void dispose() {
     HardwareKeyboard.instance.removeHandler(_onKeyEvent);
@@ -1649,8 +1684,9 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// == 1, transform identity): the widest page exactly fills the viewport.
   /// The public zoom is expressed against actual size (1 px/pt), so it is
   /// this scale times the fit-width multiplier ([_currentZoom]).
-  double get _fitWidthScale =>
-      (_maxPointWidth <= 0 || _viewWidth <= 0) ? 1 : _viewWidth / _maxPointWidth;
+  double get _fitWidthScale => (_maxPointWidth <= 0 || _viewWidth <= 0)
+      ? 1
+      : _viewWidth / _maxPointWidth;
 
   /// The on-screen scale the user sees, in logical pixels per PDF point,
   /// where 1.0 is actual size (100%) — independent of the viewport. This is
@@ -1783,10 +1819,19 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
 
   Future<void> _jumpToPage(int index) async {
     if (!_scroll.hasClients) return;
-    final target =
-        _pageOffset(index.clamp(0, _pages.length - 1)) + _zoomWindowDy;
+    final targetIndex = index.clamp(0, _pages.length - 1);
+    _jumpFocusPage = targetIndex;
+    _renderScheduler.focus = targetIndex;
+    final target = _pageOffset(targetIndex) + _zoomWindowDy;
+    final clamped = target.clamp(0.0, _scroll.position.maxScrollExtent);
+    final distance = (clamped - _scroll.position.pixels).abs();
+    if (distance > math.max(_viewHeight * 2, 2400.0)) {
+      _warmJumpTargetPreview(targetIndex);
+      _scroll.jumpTo(clamped);
+      return;
+    }
     await _scroll.animateTo(
-      target.clamp(0.0, _scroll.position.maxScrollExtent),
+      clamped,
       duration: const Duration(milliseconds: 250),
       curve: Curves.easeInOut,
     );
@@ -1875,8 +1920,8 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       // _pageLeft and the stored fraction is into the page's own width
       final pageView = _pageLeft(page) + viewport.left * _pageWidth(page);
       final tx = (-scale * pageView).clamp(_viewWidth * (1 - scale), 0.0);
-      final ty = (scale * (scroll - listTop))
-          .clamp(_viewHeight * (1 - scale), 0.0);
+      final ty =
+          (scale * (scroll - listTop)).clamp(_viewHeight * (1 - scale), 0.0);
       _transform.value = Matrix4.identity()
         ..translateByDouble(tx, ty, 0, 1)
         ..scaleByDouble(scale, scale, scale, 1);
@@ -1911,8 +1956,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     );
     final target = geometry.toViewRect(rect);
     // list space: pages are centered horizontally and stacked vertically
-    final center =
-        target.center + Offset(_pageLeft(index), _pageOffset(index));
+    final center = target.center + Offset(_pageLeft(index), _pageOffset(index));
     final fit = 0.4 *
         math.min(_viewWidth / math.max(target.width, 8),
             _viewHeight / math.max(target.height, 8));
@@ -3546,8 +3590,8 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     final scale = _transform.value.getMaxScaleOnAxis();
     final min = _viewWidth * (1 - scale);
     final target = tx > 0 ? 0.0 : min;
-    _hBounceController.animateWith(
-        SpringSimulation(_hBounceSpring, tx, target, 0));
+    _hBounceController
+        .animateWith(SpringSimulation(_hBounceSpring, tx, target, 0));
   }
 
   static const SpringDescription _hBounceSpring =
@@ -3715,6 +3759,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 pageEpoch: _pageEpoch,
                 contentStamp: _contentStamp(index),
                 destructiveStamp: _destructiveStamp(index),
+                renderPriority: _renderPriority(index),
                 matches: _controller._matchesOn(index),
                 currentMatch: _controller._currentMatch >= 0
                     ? _controller._matches[_controller._currentMatch]
@@ -4049,6 +4094,31 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       );
     });
   }
+
+  int _renderPriority(int pageIndex) =>
+      -1000 + (pageIndex - (_jumpFocusPage ?? _controller.currentPage)).abs();
+
+  void _warmJumpTargetPreview(int index) {
+    if (!widget.pagePreviews) return;
+    final worker = widget.renderWorker;
+    if (worker == null ||
+        !worker.isActive ||
+        index < 0 ||
+        index >= _pages.length) {
+      return;
+    }
+    final page = _pages[index];
+    if (_previews.isFresh(index, page)) return;
+    _previewVectorAttempts.add(page);
+    unawaited(_previews.renderPreview(index, page,
+        pageColor: widget.pageColor,
+        annotations: widget.showAnnotations,
+        worker: worker,
+        rotation: _effectiveRotation(index),
+        decodeImages: false,
+        priority: -2000,
+        commandLimit: _jumpPreviewOperationLimit));
+  }
 }
 
 /// Paints the Shift+drag rubber-band marquee (a translucent fill with a
@@ -4109,6 +4179,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.pageEpoch,
     required this.contentStamp,
     required this.destructiveStamp,
+    required this.renderPriority,
     required this.matches,
     required this.currentMatch,
     required this.selection,
@@ -4173,6 +4244,7 @@ class _PdfViewerPage extends StatefulWidget {
   /// State drops its raster immediately on a change so the deleted content
   /// can't linger on screen. 0 outside an editing session.
   final int destructiveStamp;
+  final int renderPriority;
   final List<PdfTextMatch> matches;
   final PdfTextMatch? currentMatch;
   final List<PdfTextQuad> selection;
@@ -4283,6 +4355,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         pageEpoch: widget.pageEpoch,
         contentStamp: widget.contentStamp,
         destructiveStamp: widget.destructiveStamp,
+        renderPriority: widget.renderPriority,
         pageColor: widget.pageColor,
         showAnnotations: widget.showAnnotations,
         onRasterReady: _onRasterReady,

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -115,7 +115,9 @@ class PdfPagePreviewCache extends ChangeNotifier {
       bool annotations = true,
       PdfRenderWorker? worker,
       int? rotation,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int priority = 1,
+      int? commandLimit}) async {
     if (_disposed || isFresh(index, page, requireImages: decodeImages)) return;
     if (!decodeImages && (worker == null || !worker.isActive)) {
       // A vector-first preview is only cheap through the worker. The local
@@ -134,9 +136,10 @@ class PdfPagePreviewCache extends ChangeNotifier {
       final commands = worker != null && worker.isActive
           ? await worker.record(index,
               annotations: annotations,
-              priority: 1,
+              priority: priority,
               imagePixelRatio: decodeImages ? ratio : null,
-              decodeImages: decodeImages)
+              decodeImages: decodeImages,
+              commandLimit: commandLimit)
           : null;
       if (!decodeImages && commands == null) {
         // Worker-declined vector warms must stay cheap. Falling back to
@@ -150,8 +153,8 @@ class PdfPagePreviewCache extends ChangeNotifier {
       final ui.Image image;
       var includesImages = decodeImages;
       if (commands != null) {
-        includesImages =
-            decodeImages || !PdfPageRenderer.hasImageDraws(commands);
+        includesImages = commandLimit == null &&
+            (decodeImages || !PdfPageRenderer.hasImageDraws(commands));
         final picture = await PdfPageRenderer.pictureFromCommands(
             page, commands,
             pageColor: pageColor,

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -122,7 +122,8 @@ abstract class PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true});
+      bool decodeImages = true,
+      int? commandLimit});
 
   /// Drops any QUEUED (not yet started) [record] request for [pageIndex] at
   /// [priority], completing its future with null — as if the page had declined
@@ -175,11 +176,17 @@ abstract class PdfRenderWorker {
 /// Normally wrapped in a [PdfCachingRenderWorker] (see [PdfRenderWorker.start]),
 /// which dedups concurrent requests for one page — so the cache, not the pool,
 /// prevents the same page being decoded by its worker twice at once.
+///
+/// Ultra-urgent records (currently the long-jump preview, priority -2000)
+/// bypass the ordinary pool through a lazily-created one-off worker. A page
+/// jump should not wait behind several already-started background records that
+/// cannot receive cancellation until their synchronous parse step yields.
 class PdfPooledRenderWorker implements PdfRenderWorker {
   /// Starts [size] platform workers over copies of [bytes]. [size] is clamped to
   /// at least 1; a pool of 1 is just a single worker with this routing wrapper.
   PdfPooledRenderWorker(Uint8List bytes, int size)
-      : _workers = List.generate(
+      : _urgentBytes = Uint8List.fromList(bytes),
+        _workers = List.generate(
           size < 1 ? 1 : size,
           (_) => startRenderWorker(Uint8List.fromList(bytes)),
           growable: false,
@@ -191,13 +198,18 @@ class PdfPooledRenderWorker implements PdfRenderWorker {
   /// teardown can be exercised with fakes instead of real platform workers.
   PdfPooledRenderWorker.fromWorkers(List<PdfRenderWorker> workers)
       : assert(workers.isNotEmpty),
+        _urgentBytes = null,
         _workers = List.of(workers, growable: false) {
     _loads = List.filled(_workers.length, 0);
   }
 
+  static const int _urgentPriority = -2000;
+
+  final Uint8List? _urgentBytes;
   final List<PdfRenderWorker> _workers;
   late final List<int> _loads;
   final _routes = <(int, int), _PoolRoute>{};
+  PdfRenderWorker? _urgentWorker;
 
   /// The static mapping used for a tie/fallback. Negative indices (none are
   /// expected) map through [int.abs] so routing never throws.
@@ -262,30 +274,47 @@ class PdfPooledRenderWorker implements PdfRenderWorker {
   /// (e.g. its watchdog gave up) only takes its own share of pages down to local
   /// rendering, the rest keep offloading.
   @override
-  bool get isActive => _workers.any((w) => w.isActive);
+  bool get isActive =>
+      _workers.any((w) => w.isActive) || (_urgentWorker?.isActive ?? false);
 
   @override
   Future<List<PdfRenderCommand>?> record(int pageIndex,
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int? commandLimit}) async {
+    final urgent = _urgentWorkerFor(priority);
+    if (urgent != null) {
+      return urgent.record(pageIndex,
+          annotations: annotations,
+          priority: priority,
+          imagePixelRatio: imagePixelRatio,
+          decodeImages: decodeImages,
+          commandLimit: commandLimit);
+    }
     final worker = _lease(pageIndex, priority);
     try {
       return await _workers[worker].record(pageIndex,
           annotations: annotations,
           priority: priority,
           imagePixelRatio: imagePixelRatio,
-          decodeImages: decodeImages);
+          decodeImages: decodeImages,
+          commandLimit: commandLimit);
     } finally {
       _release(pageIndex, priority, worker);
     }
   }
 
   @override
-  void cancel(int pageIndex, {int priority = 0}) =>
-      _cancelWorkerFor(pageIndex, priority)
-          .cancel(pageIndex, priority: priority);
+  void cancel(int pageIndex, {int priority = 0}) {
+    final urgent = _urgentWorkerFor(priority, start: false);
+    if (urgent != null) {
+      urgent.cancel(pageIndex, priority: priority);
+      return;
+    }
+    _cancelWorkerFor(pageIndex, priority).cancel(pageIndex, priority: priority);
+  }
 
   @override
   void dispose() {
@@ -296,6 +325,21 @@ class PdfPooledRenderWorker implements PdfRenderWorker {
     for (final worker in _workers) {
       worker.dispose();
     }
+    _urgentWorker?.dispose();
+    _urgentWorker = null;
+  }
+
+  PdfRenderWorker? _urgentWorkerFor(int priority, {bool start = true}) {
+    if (priority > _urgentPriority) return null;
+    final existing = _urgentWorker;
+    if (existing != null) {
+      if (existing.isActive) return existing;
+      existing.dispose();
+      _urgentWorker = null;
+    }
+    final bytes = _urgentBytes;
+    if (!start || bytes == null) return null;
+    return _urgentWorker = startRenderWorker(Uint8List.fromList(bytes));
   }
 }
 
@@ -307,7 +351,8 @@ class _PoolRoute {
 }
 
 /// Wraps a [PdfRenderWorker] with an LRU cache of completed [record] results,
-/// keyed by (page, annotations, decodeImages, image-ratio bucket). The lazy
+/// keyed by (page, annotations, decodeImages, image-ratio bucket,
+/// command-limit). The lazy
 /// page list recycles a [PdfPageView]'s State when it scrolls out of view and
 /// re-creates it on the way back, dropping the State's cached picture — so
 /// without this every scroll-back re-asks the worker to decode the page from
@@ -342,32 +387,53 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
 
   // LinkedHashMap iteration order doubles as LRU order: a hit re-inserts to
   // the end, eviction takes the oldest (first) key.
-  final _cache = <(int, bool, bool, int), _CachedRecord>{};
+  final _cache = <(int, bool, bool, int, int?), _CachedRecord>{};
   // Keys whose decode is running now, so concurrent requests share one decode.
-  final _inflight = <(int, bool, bool, int), Future<List<PdfRenderCommand>?>>{};
+  final _inflight =
+      <(int, bool, bool, int, int?), Future<List<PdfRenderCommand>?>>{};
   int _bytes = 0;
 
   @override
   bool get isActive => _inner.isActive;
+
+  /// Decoded image bytes currently retained by completed cached records.
+  ///
+  /// This is intentionally the same weight used for eviction, not a full heap
+  /// estimate. It gives callers a cheap signal for whether speculative warming
+  /// is likely to evict useful full-image records before they are reused.
+  int get cachedBytes => _bytes;
+
+  /// Maximum decoded image bytes this cache tries to retain.
+  int get cacheBudgetBytes => _budgetBytes;
+
+  /// Fraction of [cacheBudgetBytes] currently occupied by decoded image data.
+  double get cachePressure {
+    if (_budgetBytes <= 0) return 1;
+    return (_bytes / _budgetBytes).clamp(0.0, 1.0).toDouble();
+  }
 
   @override
   Future<List<PdfRenderCommand>?> record(int pageIndex,
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) {
+      bool decodeImages = true,
+      int? commandLimit}) {
     if (!_inner.isActive) {
       return _inner.record(pageIndex,
           annotations: annotations,
           priority: priority,
           imagePixelRatio: imagePixelRatio,
-          decodeImages: decodeImages);
+          decodeImages: decodeImages,
+          commandLimit: commandLimit);
     }
+    final effectiveCommandLimit = decodeImages ? null : commandLimit;
     final key = (
       pageIndex,
       annotations,
       decodeImages,
       _ratioBucket(imagePixelRatio),
+      effectiveCommandLimit,
     );
     final hit = _cache.remove(key);
     if (hit != null) {
@@ -386,7 +452,7 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
   }
 
   Future<List<PdfRenderCommand>?> _recordAndStore(
-      (int, bool, bool, int) key, int pageIndex,
+      (int, bool, bool, int, int?) key, int pageIndex,
       {required bool annotations,
       required int priority,
       required double? imagePixelRatio,
@@ -396,7 +462,8 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
           annotations: annotations,
           priority: priority,
           imagePixelRatio: imagePixelRatio,
-          decodeImages: decodeImages);
+          decodeImages: decodeImages,
+          commandLimit: key.$5);
       if (commands != null) _store(key, commands);
       return commands;
     } finally {
@@ -416,7 +483,8 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
     _inner.dispose();
   }
 
-  void _store((int, bool, bool, int) key, List<PdfRenderCommand> commands) {
+  void _store(
+      (int, bool, bool, int, int?) key, List<PdfRenderCommand> commands) {
     final weight = _weigh(commands);
     if (weight > _budgetBytes) return; // one page bigger than the cache itself
     _cache[key] = _CachedRecord(commands, weight);
@@ -440,8 +508,8 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
   /// The least-recently-used key whose buffer holds decoded bytes (weight > 0),
   /// other than [except] (the entry just inserted, which we keep). Null when no
   /// such entry exists — every remaining buffer is costless, so eviction stops.
-  (int, bool, bool, int)? _oldestHeavyKey(
-      {required (int, bool, bool, int) except}) {
+  (int, bool, bool, int, int?)? _oldestHeavyKey(
+      {required (int, bool, bool, int, int?) except}) {
     for (final entry in _cache.entries) {
       if (entry.value.weight > 0 && entry.key != except) return entry.key;
     }

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -97,10 +97,11 @@ class _IsolateRenderWorker implements PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int? commandLimit}) async {
     if (_disposed || _spawnFailed) return null;
     final request = _PendingRequest(priority, _seq++, pageIndex, annotations,
-        imagePixelRatio, decodeImages);
+        imagePixelRatio, decodeImages, commandLimit);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -158,6 +159,7 @@ class _IsolateRenderWorker implements PdfRenderWorker {
       request.annotations,
       request.imagePixelRatio,
       request.decodeImages,
+      request.commandLimit,
     ]);
   }
 
@@ -202,7 +204,7 @@ class _IsolateRenderWorker implements PdfRenderWorker {
 /// One queued record request and its pending result.
 class _PendingRequest {
   _PendingRequest(this.priority, this.seq, this.pageIndex, this.annotations,
-      this.imagePixelRatio, this.decodeImages);
+      this.imagePixelRatio, this.decodeImages, this.commandLimit);
 
   final int priority;
   final int seq;
@@ -210,6 +212,7 @@ class _PendingRequest {
   final bool annotations;
   final double? imagePixelRatio;
   final bool decodeImages;
+  final int? commandLimit;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }
@@ -251,6 +254,7 @@ void _workerMain(_WorkerInit init) {
     final annotations = request[2] as bool;
     final imagePixelRatio = request[3] as double?;
     final decodeImages = request[4] as bool;
+    final commandLimit = request.length > 5 ? request[5] as int? : null;
 
     final token = PdfCancellationToken();
     activeToken = token;
@@ -258,7 +262,7 @@ void _workerMain(_WorkerInit init) {
     try {
       if (document != null) {
         buffer = await _recordPageAsync(document, pageIndex, annotations,
-            imagePixelRatio, decodeImages, token);
+            imagePixelRatio, decodeImages, commandLimit, token);
       }
     } on PdfCancelledException {
       buffer = null;
@@ -281,10 +285,13 @@ Future<Uint8List?> _recordPageAsync(
     bool annotations,
     double? imagePixelRatio,
     bool decodeImages,
+    int? commandLimit,
     PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
-  final ops = ContentStreamParser.parse(page.contentBytes());
+  final previewOperationLimit = decodeImages ? null : commandLimit;
+  final ops = ContentStreamParser.parse(page.contentBytes(),
+      operationLimit: previewOperationLimit);
   final recorder = RecordingPdfDevice();
   final interpreter =
       PdfInterpreter(cos: document.cos, device: recorder, cancellation: token);
@@ -294,5 +301,6 @@ Future<Uint8List?> _recordPageAsync(
       cos: document.cos,
       decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio,
-      imagePlaceholders: !decodeImages);
+      imagePlaceholders: !decodeImages,
+      commandLimit: commandLimit);
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -20,7 +20,8 @@ class _NullRenderWorker implements PdfRenderWorker {
           {bool annotations = true,
           int priority = 0,
           double? imagePixelRatio,
-          bool decodeImages = true}) async =>
+          bool decodeImages = true,
+          int? commandLimit}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -91,7 +91,8 @@ class _WebRenderWorker implements PdfRenderWorker {
     // rather than spin forever. Cancelled the moment 'ready' lands.
     _readyWatchdog = Timer(pdfRenderWorkerReadyTimeout, () {
       if (_ready || _disposed || _failed) return;
-      _wlog('ready watchdog fired after ${pdfRenderWorkerReadyTimeout.inSeconds}'
+      _wlog(
+          'ready watchdog fired after ${pdfRenderWorkerReadyTimeout.inSeconds}'
           's — worker never opened the document; falling back to local');
       _fail();
     });
@@ -158,14 +159,15 @@ class _WebRenderWorker implements PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int? commandLimit}) async {
     if (_disposed || _failed) {
       _wlog('record page=$pageIndex skipped (disposed=$_disposed '
           'failed=$_failed) → local');
       return null;
     }
-    final request = _WebPending(
-        priority, _seq++, pageIndex, annotations, imagePixelRatio, decodeImages);
+    final request = _WebPending(priority, _seq++, pageIndex, annotations,
+        imagePixelRatio, decodeImages, commandLimit);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -201,8 +203,7 @@ class _WebRenderWorker implements PdfRenderWorker {
         }
       }
       if (_queue[bestQueued].priority < _inFlight!.priority) {
-        worker.postMessage(
-            JSObject()..setProperty('kind'.toJS, 'cancel'.toJS));
+        worker.postMessage(JSObject()..setProperty('kind'.toJS, 'cancel'.toJS));
       }
       return;
     }
@@ -225,6 +226,8 @@ class _WebRenderWorker implements PdfRenderWorker {
       ..setProperty('decodeImages'.toJS, request.decodeImages.toJS);
     final ratio = request.imagePixelRatio;
     if (ratio != null) message.setProperty('imageRatio'.toJS, ratio.toJS);
+    final limit = request.commandLimit;
+    if (limit != null) message.setProperty('commandLimit'.toJS, limit.toJS);
     worker.postMessage(message);
 
     // Watchdog: a record that never comes back wedges the single in-flight slot
@@ -275,7 +278,8 @@ class _WebRenderWorker implements PdfRenderWorker {
       return true;
     });
     if (dropped > 0) {
-      _wlog('cancel page=$pageIndex priority=$priority dropped=$dropped queued');
+      _wlog(
+          'cancel page=$pageIndex priority=$priority dropped=$dropped queued');
     }
   }
 
@@ -319,7 +323,7 @@ class _WebRenderWorker implements PdfRenderWorker {
 /// backend's `_PendingRequest`).
 class _WebPending {
   _WebPending(this.priority, this.seq, this.pageIndex, this.annotations,
-      this.imagePixelRatio, this.decodeImages);
+      this.imagePixelRatio, this.decodeImages, this.commandLimit);
 
   final int priority;
   final int seq;
@@ -327,6 +331,7 @@ class _WebPending {
   final bool annotations;
   final double? imagePixelRatio;
   final bool decodeImages;
+  final int? commandLimit;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -74,6 +74,8 @@ void runPdfRenderWorker() {
     // Default true so an older client that doesn't send the flag still decodes.
     final decodeImages =
         (data.getProperty('decodeImages'.toJS) as JSBoolean?)?.toDart ?? true;
+    final commandLimit =
+        (data.getProperty('commandLimit'.toJS) as JSNumber?)?.toDartInt;
 
     final token = PdfCancellationToken();
     activeToken = token;
@@ -86,8 +88,8 @@ void runPdfRenderWorker() {
       final doc = document;
       try {
         if (doc != null) {
-          out = await _recordPageAsync(
-              doc, page, annotations, imagePixelRatio, decodeImages, token);
+          out = await _recordPageAsync(doc, page, annotations, imagePixelRatio,
+              decodeImages, commandLimit, token);
         }
       } on PdfCancelledException {
         out = null;
@@ -127,10 +129,13 @@ Future<Uint8List?> _recordPageAsync(
     bool annotations,
     double? imagePixelRatio,
     bool decodeImages,
+    int? commandLimit,
     PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
-  final ops = ContentStreamParser.parse(page.contentBytes());
+  final previewOperationLimit = decodeImages ? null : commandLimit;
+  final ops = ContentStreamParser.parse(page.contentBytes(),
+      operationLimit: previewOperationLimit);
   final recorder = RecordingPdfDevice();
   final interpreter =
       PdfInterpreter(cos: document.cos, device: recorder, cancellation: token);
@@ -148,5 +153,6 @@ Future<Uint8List?> _recordPageAsync(
       cos: document.cos,
       decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio,
-      imagePlaceholders: !decodeImages);
+      imagePlaceholders: !decodeImages,
+      commandLimit: commandLimit);
 }

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -116,6 +116,23 @@ void main() {
     expect(cache.isFresh(0, page, requireImages: true), isTrue);
   });
 
+  testWidgets('command-limited previews stay partial without image draws',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final cache = PdfPagePreviewCache();
+    final worker = _VectorOnlyWorker();
+    addTearDown(cache.dispose);
+
+    await tester.runAsync(() => cache.renderPreview(0, page,
+        worker: worker, decodeImages: false, commandLimit: 2000));
+
+    expect(worker.commandLimits, [2000]);
+    expect(cache.isFresh(0, page), isTrue);
+    expect(cache.isFresh(0, page, requireImages: true), isFalse,
+        reason: 'a capped command prefix must not masquerade as complete');
+  });
+
   testWidgets('full page renders upgrade vector-only previews', (tester) async {
     final document = PdfDocument.open(buildClassicPdf());
     final page = document.page(0);
@@ -207,7 +224,7 @@ void main() {
     expect(cache.isFresh(0, page), isTrue);
   });
 
-  testWidgets('fast scroll shows previews of pages never seen on screen',
+  testWidgets('prerender warms previews of pages never seen on screen',
       (tester) async {
     final document = PdfDocument.open(buildMultiPagePdf(8));
     final controller = PdfViewerController();
@@ -236,19 +253,10 @@ void main() {
     expect(cache.has(6), isTrue);
     expect(cache.has(7), isTrue);
 
-    // a long fast jump: full renders stay held, but the destination
-    // pages paint their previews instead of blank paper
+    // A long jump now lands directly on the destination and may render it
+    // fully right away. The contract this test pins is the background warm:
+    // far pages received previews before they were ever built on screen.
     unawaited(controller.jumpToPage(6));
-    for (var i = 0; i < 5; i++) {
-      await tester.pump(const Duration(milliseconds: 60));
-      await tester.runAsync(
-          () => Future<void>.delayed(const Duration(milliseconds: 10)));
-    }
-    expect(fullRaster, findsNothing);
-    expect(previewRaster, findsWidgets);
-
-    // settled: the destination renders fully
-    await tester.pump(const Duration(milliseconds: 300));
     for (var i = 0; i < 50 && fullRaster.evaluate().isEmpty; i++) {
       await settle(tester);
     }
@@ -322,6 +330,38 @@ void main() {
     expect(cache.has(8), isTrue, reason: 'within ±3 of page 11 now');
   });
 
+  testWidgets('large documents shrink the full-image preview window',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(80));
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          document: document,
+          controller: controller,
+          initialFit: PdfViewerFit.width,
+          previewWindow: 8,
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    // Large documents cap full-image background warming to ±3 pages even when
+    // the configured window is wider. Vector-only passes still use the wider
+    // window during fast scrolling, but they do not count as image-fresh.
+    final cache = controller.debugPreviewCache!;
+    for (var i = 0; i < 100 && !cache.has(3); i++) {
+      await settle(tester);
+    }
+    expect(cache.has(3), isTrue, reason: 'inside the adaptive ±3 window');
+    for (var i = 0; i < 30; i++) {
+      await settle(tester);
+    }
+    expect(cache.isFresh(8, document.page(8), requireImages: true), isFalse,
+        reason: 'outside the adaptive full-image window');
+  });
+
   testWidgets('previewWindow <= 0 warms every page (short-doc behavior)',
       (tester) async {
     final document = PdfDocument.open(buildMultiPagePdf(12));
@@ -389,8 +429,7 @@ void main() {
     expect(cache.has(11), isTrue);
   });
 
-  testWidgets('pagePreviews: false keeps the blank-paper behavior',
-      (tester) async {
+  testWidgets('pagePreviews: false disables preview warming', (tester) async {
     final document = PdfDocument.open(buildMultiPagePdf(8));
     final controller = PdfViewerController();
     addTearDown(controller.dispose);
@@ -415,9 +454,12 @@ void main() {
       await tester.runAsync(
           () => Future<void>.delayed(const Duration(milliseconds: 10)));
     }
-    // no previews anywhere: flown-past and destination pages are blank
-    expect(find.byType(RawImage), findsNothing);
-    await tester.pump(const Duration(milliseconds: 300));
+    expect(controller.debugPreviewCache!.has(6), isFalse);
+    expect(previewRaster, findsNothing);
+    for (var i = 0; i < 50 && fullRaster.evaluate().isEmpty; i++) {
+      await settle(tester);
+    }
+    expect(fullRaster, findsWidgets);
   });
 }
 
@@ -432,7 +474,8 @@ class _PreviewWorker implements PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int? commandLimit}) async {
     calls.add((pageIndex, decodeImages, imagePixelRatio));
     final request = PdfImageRequest(
       stream: CosStream(CosDictionary(), Uint8List(0)),
@@ -462,9 +505,34 @@ class _DecliningWorker implements PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int? commandLimit}) async {
     calls.add((pageIndex, decodeImages, imagePixelRatio));
     return null;
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() {}
+}
+
+class _VectorOnlyWorker implements PdfRenderWorker {
+  final commandLimits = <int?>[];
+
+  @override
+  bool get isActive => true;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true,
+      int? commandLimit}) async {
+    commandLimits.add(commandLimit);
+    return const [PdfSaveCommand(), PdfRestoreCommand()];
   }
 
   @override

--- a/packages/dart_pdf_editor/test/render_hold_test.dart
+++ b/packages/dart_pdf_editor/test/render_hold_test.dart
@@ -54,7 +54,7 @@ void main() {
     await waitFor(tester, find.byType(RawImage));
   });
 
-  testWidgets('a fast jump holds page rendering until the scroll settles',
+  testWidgets('a long jump lands directly and renders the target',
       (tester) async {
     final document = PdfDocument.open(buildMultiPagePdf(8));
     final controller = PdfViewerController();
@@ -72,21 +72,13 @@ void main() {
     // an idle viewer renders normally
     await waitFor(tester, fullRaster);
 
-    // a long jump animates 250ms at far past the velocity threshold
+    // Long programmatic jumps no longer animate through the intermediate
+    // pages. They land directly on the target so the destination can render
+    // immediately instead of staying blank while the old fast-scroll hold
+    // waits for settle.
     unawaited(controller.jumpToPage(6));
-    for (var i = 0; i < 5; i++) {
-      await tester.pump(const Duration(milliseconds: 60));
-      // give an unheld render every chance to (wrongly) complete
-      await tester.runAsync(
-          () => Future<void>.delayed(const Duration(milliseconds: 10)));
-    }
-    // mid-flight and just arrived (settle pending): no page got a FULL
-    // render — page 0's raster is long unmounted, the destination is
-    // held. (Low-res previews are allowed: that's the fast-scroll
-    // preview feature, covered in page_preview_test.dart.)
-    expect(fullRaster, findsNothing);
-
-    // the scroll-settle timer releases the hold and the target renders
+    await tester.pump();
+    expect(controller.currentPage, 6);
     await tester.pump(const Duration(milliseconds: 300));
     await waitFor(tester, fullRaster);
   });

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -46,10 +46,13 @@ class _SyncWorker implements PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int? commandLimit}) async {
     if (_disposed || pageIndex < 0 || pageIndex >= _doc.pageCount) return null;
     final page = _doc.page(pageIndex);
-    final ops = ContentStreamParser.parse(page.contentBytes());
+    final previewOperationLimit = decodeImages ? null : commandLimit;
+    final ops = ContentStreamParser.parse(page.contentBytes(),
+        operationLimit: previewOperationLimit);
     final recorder = RecordingPdfDevice();
     final interpreter = PdfInterpreter(cos: _doc.cos, device: recorder)
       ..drawPageOperations(page, ops);
@@ -58,7 +61,8 @@ class _SyncWorker implements PdfRenderWorker {
         cos: _doc.cos,
         decodeImages: decodeImages,
         maxImagePixelRatio: imagePixelRatio,
-        imagePlaceholders: !decodeImages);
+        imagePlaceholders: !decodeImages,
+        commandLimit: commandLimit);
     return bytes == null ? null : deserializeCommands(bytes);
   }
 
@@ -280,6 +284,42 @@ void main() {
       expect(rastered, isNotNull,
           reason: 'the page rasterized through the worker render path');
     });
+  });
+
+  testWidgets('PdfPageView cancels recycled worker requests by renderPriority',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final worker = _ManualWorker();
+    addTearDown(worker.dispose);
+
+    Widget view(int index, int priority) => MediaQuery(
+          data: const MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: SizedBox(
+                width: 120,
+                height: 120,
+                child: PdfPageView(
+                  page: document.page(index),
+                  previewIndex: index,
+                  renderWorker: worker,
+                  renderPriority: priority,
+                ),
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(view(0, -997));
+    for (var i = 0; i < 10 && worker.calls.isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    expect(worker.calls.single.$1, 0);
+
+    await tester.pumpWidget(view(1, -996));
+    expect(worker.cancels, contains((0, -997)),
+        reason: 'lazy-list reuse must cancel the old queued priority');
   });
 
   testWidgets('an inline image still declines (null → local render)',
@@ -524,6 +564,40 @@ void main() {
       expect(inner.calls.length, 3);
     });
 
+    test('reports decoded-byte cache pressure', () async {
+      final inner = _CountingWorker(decodedPixels: 64);
+      final worker = PdfCachingRenderWorker(inner, budgetBytes: 512);
+
+      expect(worker.cacheBudgetBytes, 512);
+      expect(worker.cachedBytes, 0);
+      expect(worker.cachePressure, 0);
+
+      await worker.record(0, imagePixelRatio: 2.0);
+      expect(worker.cachedBytes, 256);
+      expect(worker.cachePressure, 0.5);
+
+      await worker.record(1, imagePixelRatio: 2.0);
+      expect(worker.cachedBytes, 512);
+      expect(worker.cachePressure, 1);
+    });
+
+    test('commandLimit is part of the vector-only cache key', () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner);
+
+      await worker.record(0, decodeImages: false, commandLimit: 500);
+      await worker.record(0, decodeImages: false, commandLimit: 500);
+      expect(inner.commandLimits, [500]);
+
+      await worker.record(0, decodeImages: false, commandLimit: 2000);
+      expect(inner.commandLimits, [500, 2000]);
+
+      await worker.record(0, decodeImages: true, commandLimit: 500);
+      await worker.record(0, decodeImages: true, commandLimit: 2000);
+      expect(inner.commandLimits, [500, 2000, null],
+          reason: 'full-image renders ignore preview command limits');
+    });
+
     test('weight-0 buffers survive eviction of heavy pages', () async {
       // Budget holds one heavy (256-byte) page. The vector-first pass
       // (decodeImages: false) weighs nothing, so blowing the budget with heavy
@@ -683,6 +757,7 @@ class _CountingWorker implements PdfRenderWorker {
   final int decodedPixels;
   final bool returnNull;
   final calls = <(int, bool, bool, double?)>[];
+  final commandLimits = <int?>[];
   final cancels = <(int, int)>[];
   bool active = true;
   bool disposed = false;
@@ -695,8 +770,10 @@ class _CountingWorker implements PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) async {
+      bool decodeImages = true,
+      int? commandLimit}) async {
     calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
+    commandLimits.add(commandLimit);
     if (returnNull || !active) return null;
     // A vector-first pass (decodeImages: false) ships no decoded pixels, so its
     // cached buffer weighs nothing — mirror that so the cache's weight-aware
@@ -727,6 +804,7 @@ class _CountingWorker implements PdfRenderWorker {
 
 class _ManualWorker implements PdfRenderWorker {
   final calls = <(int, bool, bool, double?)>[];
+  final priorities = <int>[];
   final cancels = <(int, int)>[];
   final _pending = <Completer<List<PdfRenderCommand>?>>[];
   bool active = true;
@@ -740,8 +818,10 @@ class _ManualWorker implements PdfRenderWorker {
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
-      bool decodeImages = true}) {
+      bool decodeImages = true,
+      int? commandLimit}) {
     calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
+    priorities.add(priority);
     final completer = Completer<List<PdfRenderCommand>?>();
     _pending.add(completer);
     return completer.future;

--- a/packages/pdf_cos/lib/src/content_parser.dart
+++ b/packages/pdf_cos/lib/src/content_parser.dart
@@ -34,7 +34,8 @@ class ContentStreamParser {
   static CosObject _intObject(int value) =>
       (value >= -1 && value <= 256) ? _smallInts[value + 1] : CosInteger(value);
 
-  static List<ContentOperation> parse(Uint8List content) {
+  static List<ContentOperation> parse(Uint8List content,
+      {int? operationLimit}) {
     // Drive the lexer directly rather than through [CosParser]: a content
     // stream is a flat token stream (no indirect references, so none of
     // parseObject's `N G R` lookahead applies), and on a 10 MB CAD page the
@@ -43,8 +44,14 @@ class ContentStreamParser {
     // finished operation its own operand list (no copy, no clear) roughly
     // halves the parse.
     final operations = <ContentOperation>[];
+    if (operationLimit != null && operationLimit <= 0) return operations;
     final lexer = CosLexer(content);
     var operands = <CosObject>[];
+    bool addOperation(ContentOperation operation) {
+      operations.add(operation);
+      return operationLimit != null && operations.length >= operationLimit;
+    }
+
     while (true) {
       final t = lexer.nextToken();
       switch (t.type) {
@@ -67,13 +74,15 @@ class ContentStreamParser {
             case 'null':
               operands.add(CosNull.instance);
             case 'BI':
-              operations.add(_parseInlineImage(lexer));
+              if (addOperation(_parseInlineImage(lexer))) return operations;
               operands = <CosObject>[];
             default:
               // Hand the operation ownership of the operand list and start a
               // fresh one — equivalent to `List.of(operands)` then clear,
               // minus the element copy.
-              operations.add(ContentOperation(keyword, operands));
+              if (addOperation(ContentOperation(keyword, operands))) {
+                return operations;
+              }
               operands = <CosObject>[];
           }
         default:
@@ -143,7 +152,7 @@ class ContentStreamParser {
               t.textValue == 'null') {
             items.add(_parseObject(lexer, t));
           }
-          // else: stray operator — drop it
+        // else: stray operator — drop it
         default:
           items.add(_parseObject(lexer, t));
       }

--- a/packages/pdf_cos/test/content_parser_test.dart
+++ b/packages/pdf_cos/test/content_parser_test.dart
@@ -76,6 +76,16 @@ void main() {
     expect(data.bytes, [0x00, 0xFF]);
   });
 
+  test('operationLimit returns a prefix on operation boundaries', () {
+    final ops = ContentStreamParser.parse(
+        ascii('q 1 0 0 1 50 50 cm BI /W 1 /H 1 /CS /G /BPC 8 ID \x7f EI Q'),
+        operationLimit: 3);
+
+    expect(ops.map((op) => op.operator), ['q', 'cm', 'BI']);
+    final data = ops[2].operands[1] as CosString;
+    expect(data.bytes, [0x7F]);
+  });
+
   test('DCT inline image ignores EI-like bytes before JPEG EOI', () {
     final bytes = BytesBuilder()
       ..add(ascii('q BI /W 1 /H 1 /CS /RGB /BPC 8 /F /DCT ID\r\n'))

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -121,7 +121,8 @@ Uint8List? serializeCommands(List<PdfRenderCommand> commands,
     bool decodeImages = false,
     double? maxImagePixelRatio,
     double imageBudgetFactor = _imageBudgetFactor,
-    bool imagePlaceholders = false}) {
+    bool imagePlaceholders = false,
+    int? commandLimit}) {
   final w = _Writer();
   w.u8(_formatVersion);
   // Page-pixel budget: a global downscale applied on top of the per-image
@@ -138,7 +139,8 @@ Uint8List? serializeCommands(List<PdfRenderCommand> commands,
         decode: decodeImages,
         maxImageRatio: maxImagePixelRatio,
         budgetScale: budgetScale,
-        imagePlaceholders: imagePlaceholders && !decodeImages);
+        imagePlaceholders: imagePlaceholders && !decodeImages,
+        commandLimit: commandLimit);
   } on _UnserializableImage {
     return null;
   }
@@ -232,9 +234,14 @@ void _writeCommands(
     {bool decode = false,
     double? maxImageRatio,
     double budgetScale = 1.0,
-    bool imagePlaceholders = false}) {
-  w.u32(commands.length);
-  for (final command in commands) {
+    bool imagePlaceholders = false,
+    int? commandLimit}) {
+  final length = commandLimit == null
+      ? commands.length
+      : math.min(commands.length, math.max(0, commandLimit));
+  w.u32(length);
+  for (var i = 0; i < length; i++) {
+    final command = commands[i];
     _writeCommand(w, command, cos,
         decode: decode,
         maxImageRatio: maxImageRatio,


### PR DESCRIPTION
## Summary

This PR improves heavy-page first-content performance for the viewer, targeting the CAD page-30 case from `corpus/ly9-far-cad.pdf`.

- Adds a direct long-jump path that immediately focuses the target page and warms a target preview.
- Adds command-limited vector preview recording for long-jump first paint while preserving full renders afterward.
- Routes ultra-urgent jump preview records through a dedicated worker so they do not wait behind background render jobs.
- Makes preview cache freshness aware of command-limited partial previews and command-limit cache keys.
- Keeps recycled `PdfPageView` worker cancellations aligned with the actual enqueued render priority.
- Extends the perf harness with target-page first-content measurement.

## Performance Proof

Command used for the final validation:

```bash
PERF_PDF=/Users/ben/repos/dart-pdf/corpus/ly9-far-cad.pdf \
PERF_RESULTS=/tmp/dart_pdf_perf_page30_target_pr_final.ndjson \
PERF_TARGET_PAGE=29 PERF_TIMEOUT=120 \
node app/tool/perf/driver.mjs
```

Final result on page 30 (`PERF_TARGET_PAGE=29`):

- `target first paint page=29 162.0ms via preview`
- earlier final runs: `179ms`, `175ms`
- comparison during development: direct long jump before the capped/urgent path was `10138ms`; capped parsing without urgent worker was around `956-1090ms`.

## Validation

- `fvm dart analyze`
- `cd packages/pdf_cos && fvm dart test test/content_parser_test.dart`
- `cd packages/dart_pdf_editor && fvm flutter test test/page_preview_test.dart test/render_worker_test.dart`
- `cd packages/dart_pdf_editor && fvm flutter test test/render_hold_test.dart`
- `cd packages/dart_pdf_editor && fvm flutter test test/pdf_viewer_test.dart`
- `app/tool/perf/build.sh`
- final Puppeteer target-page run listed above
