### PR TITLE
[codex] Improve heavy PDF render performance

### DIFF
--- a/app/tool/perf/driver.mjs
+++ b/app/tool/perf/driver.mjs
@@ -37,6 +37,7 @@ const VERBOSE = (process.env.PERF_VERBOSE ?? 'false') === 'true';
 const RESULTS = process.env.PERF_RESULTS ?? join(HERE, 'results.ndjson');
 const CHROME = process.env.PERF_CHROME ??
   '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const ISOLATED = (process.env.PERF_CROSS_ORIGIN_ISOLATED ?? 'true') !== 'false';
 // Negative control: serve a 404 for the worker script to force UI-thread
 // fallback, so we can confirm the loop actually catches a regression.
 const NO_WORKER = (process.env.PERF_NO_WORKER ?? 'false') === 'true';
@@ -62,6 +63,15 @@ const MIME = {
   '.pdf': 'application/pdf',
 };
 
+function headers(type, length) {
+  const h = { 'content-type': type, 'content-length': length };
+  if (ISOLATED) {
+    h['cross-origin-opener-policy'] = 'same-origin';
+    h['cross-origin-embedder-policy'] = 'credentialless';
+  }
+  return h;
+}
+
 function startServer() {
   return new Promise((resolve, reject) => {
     const server = createServer(async (req, res) => {
@@ -69,7 +79,7 @@ function startServer() {
         let path = decodeURIComponent(req.url.split('?')[0]);
         if (path === '/perf.pdf') {
           const buf = await readFile(PDF);
-          res.writeHead(200, { 'content-type': 'application/pdf', 'content-length': buf.length });
+          res.writeHead(200, headers('application/pdf', buf.length));
           res.end(buf);
           return;
         }
@@ -86,8 +96,7 @@ function startServer() {
         if (!info || !info.isFile()) { res.writeHead(404); res.end('not found'); return; }
         const buf = await readFile(file);
         const type = MIME[extname(file).toLowerCase()] ?? 'application/octet-stream';
-        // The render worker is a same-origin classic worker; no COOP/COEP needed.
-        res.writeHead(200, { 'content-type': type, 'content-length': buf.length });
+        res.writeHead(200, headers(type, buf.length));
         res.end(buf);
       } catch (e) {
         res.writeHead(500);
@@ -225,7 +234,7 @@ async function main() {
   if (process.env.PERF_TARGET_PAGE) qp.set('targetPage', process.env.PERF_TARGET_PAGE);
   const qs = qp.toString();
   const url = `http://127.0.0.1:${PORT}/${qs ? '?' + qs : ''}`;
-  console.log(`▶ serving ${WEB_DIR} + /perf.pdf at ${url} (headless=${HEADLESS})`);
+  console.log(`▶ serving ${WEB_DIR} + /perf.pdf at ${url} (headless=${HEADLESS}, isolated=${ISOLATED})`);
 
   const browser = await puppeteer.launch({
     executablePath: CHROME,

--- a/app/tool/perf/perf_harness.dart
+++ b/app/tool/perf/perf_harness.dart
@@ -120,6 +120,9 @@ void main() {
   debugPrint = (String? message, {int? wrapWidth}) {
     if (message != null) _record(message);
   };
+  final isolated =
+      (globalContext['crossOriginIsolated'] as JSBoolean?)?.toDart ?? false;
+  _record('[perf] HARNESS crossOriginIsolated=$isolated');
 
   // Expose the driver's read surface up front (so a poll never races startup).
   _setGlobal('__perfDone', false.toJS);

--- a/doc/render_worker_web.md
+++ b/doc/render_worker_web.md
@@ -97,7 +97,7 @@ priority queue and protocol, and the app is wired up:
   web. The live web deploys (the demo at `dart-pdf-demo.web.app` and the app at
   `dartpdf-app.web.app`) build the worker and ship the `--wasm` renderer with
   COOP/COEP headers. See `deploy-demo-web.yml` and the firebase configs.
-- `dart compile js` of the worker entry **succeeds** (~720 KB bundle), so the
+- `dart compile js` of the worker entry **succeeds** (~857 KB bundle), so the
   `dart:js_interop` / `package:web` usage is valid on the web toolchain.
 - **Verified live** under `flutter run -d chrome` against the 41 MB / 133-page
   CAD test doc: every page round-tripped through the worker (`path=worker`),
@@ -135,10 +135,12 @@ Still open:
 
 ## Caveats
 
-- **Not** cross-origin isolation / `SharedArrayBuffer`. This uses an ordinary
-  dedicated worker with transferable `ArrayBuffer`s, so it needs no COOP/COEP
-  headers. (skwasm's multithreading, which *does* need those headers,
-  parallelizes raster, not interpretation, and is unrelated.)
+- Cross-origin isolation is optional, but useful. On an isolated page with
+  `SharedArrayBuffer` available, each render worker receives a shared view of
+  the document bytes instead of its own cloned `ArrayBuffer`. Hosts without
+  COOP/COEP, Safari, or apps that set `pdfRenderWorkerUseSharedArrayBuffer =
+  false` fall back to the older transferable `ArrayBuffer` startup path. Result
+  buffers are still transferred `ArrayBuffer`s either way.
 - The worker holds a fixed snapshot of the document bytes, like the isolate; an
   editing session must restart the worker when the bytes change (the shells
   already do this on every revision).
@@ -156,15 +158,15 @@ No special handling is needed when the main app is compiled to Wasm
   **both** dart2js and dart2wasm. The backend is selected on
   `dart.library.js_interop` (provided on Wasm), deliberately **not**
   `dart.library.html`, which is unavailable on Wasm and would break the build.
-- The boundary carries **transferred `ArrayBuffer`s** (raw bytes), not Dart
-  objects, so neither side depends on the other's compilation. The host pays one
-  buffer copy from Wasm linear memory into a JS `ArrayBuffer` per document and
-  per result (via `.toJS`), which is negligible.
+- The boundary carries raw bytes, not Dart objects, so neither side depends on
+  the other's compilation. On cross-origin isolated pages the document bytes use
+  `SharedArrayBuffer`; otherwise the host pays one buffer copy from Wasm linear
+  memory into a JS `ArrayBuffer` per worker at startup. Results remain
+  transferred `ArrayBuffer`s.
 
 The worker itself stays JS (`dart compile js`) even under a Wasm host. Compiling
 *the worker* to Wasm (`dart compile wasm`) is possible but needs a different
 in-worker bootstrap (its `.mjs` loader instantiating the module) and buys little
-because the worker is already off the main thread. A skwasm host that sets COOP/COEP
-for its own raster threads keeps working unchanged: this is an ordinary
-same-origin dedicated worker with no `SharedArrayBuffer`, so those headers
-neither help nor hinder it.
+because the worker is already off the main thread. A skwasm host that sets
+COOP/COEP for its own raster threads now also lets the render worker share the
+opened document bytes across the worker pool.

--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -273,10 +273,10 @@ void main() {
 missing it degrades to main-thread rendering. It is a pure opt-in upgrade.
 You can commit `web/pdf_render_worker.dart.js` and rebuild it only when you
 upgrade `dart_pdf_editor`, or generate it in CI before `flutter build web`.
-The worker itself does not require COOP/COEP headers; only Flutter's
-multithreaded Wasm renderer (`flutter build web --wasm`) needs
-cross-origin isolation. Full setup, dart2wasm-host notes, and the worker
-protocol are in
+The worker does not require COOP/COEP headers, but a cross-origin isolated
+host lets pooled workers share the document bytes through `SharedArrayBuffer`
+instead of cloning them per worker. Full setup, dart2wasm-host notes, and the
+worker protocol are in
 [doc/render_worker_web.md](https://github.com/ben-milanko/dart-pdf/blob/main/doc/render_worker_web.md).
 
 ## Under the hood

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -565,7 +565,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     // vector/text immediately (images skipped) so a heavy raster underlay —
     // which can take seconds to decode — doesn't leave the page blank
     // meanwhile. The full pass below then re-rasters with the images in.
-    if (firstInterpret) {
+    if (firstInterpret &&
+        !(widget.previewCache?.isFresh(pageIndex, widget.page) ?? false)) {
       await _paintVectorFirst(generation, pageIndex);
       if (_superseded(generation, pageIndex)) return;
     }

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -103,7 +103,7 @@ class PdfPageRenderScheduler {
         PdfPerfLog.log('scheduler grant page=${next.priority} '
             'focus=$_focus remaining=${_pending.length}');
         try {
-          next.render(); // one synchronous interpret this frame
+          next.render(); // starts one page render this frame
         } catch (_) {
           // a page that throws mid-walk must not strand the rest of the
           // queue — it simply keeps its preview/placeholder

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -39,12 +39,23 @@ Duration pdfRenderWorkerRecordTimeout = const Duration(seconds: 90);
 /// several misses in a row with no successful reply in between is.
 int pdfRenderWorkerTimeoutsBeforeFail = 3;
 
+/// Whether web render workers may share the document bytes through
+/// `SharedArrayBuffer` when the host page is cross-origin isolated.
+///
+/// When unavailable, disabled, or rejected by the browser, the worker falls
+/// back to the older transferable `ArrayBuffer` path. This is web-only and has
+/// no effect on the native isolate backend.
+bool pdfRenderWorkerUseSharedArrayBuffer = true;
+
 /// Web backend: a dedicated [web.Worker] that opens its own [PdfDocument] from
 /// the bytes once and records pages on request, posting the serialized command
-/// buffer back over `postMessage` (the document and result buffers travel as
-/// transferred `ArrayBuffer`s — zero-copy, not structured-cloned). The heavy
-/// content-stream parse and interpreter walk happen entirely off the main
-/// thread, mirroring the native isolate backend.
+/// buffer back over `postMessage` (result buffers travel as transferred
+/// `ArrayBuffer`s — zero-copy, not structured-cloned). On cross-origin isolated
+/// pages, the document bytes are copied once into a `SharedArrayBuffer` and
+/// shared by all workers instead of cloned per worker; otherwise startup falls
+/// back to a transferable `ArrayBuffer`. The heavy content-stream parse and
+/// interpreter walk happen entirely off the main thread, mirroring the native
+/// isolate backend.
 ///
 /// The worker only runs when [pdfRenderWorkerScriptUrl] names a compiled
 /// worker script (whose `main()` calls `runPdfRenderWorker`). With no URL — or
@@ -77,14 +88,25 @@ class _WebRenderWorker implements PdfRenderWorker {
     }).toJS;
     _wlog('worker constructed from $scriptUrl');
 
-    // Transfer the whole document to the worker once at start (copy first so
-    // the transferred buffer is exactly the document, not a view into a larger
-    // backing store the caller still holds).
-    final jsBuffer = Uint8List.fromList(bytes).buffer.toJS;
-    final init = JSObject()
-      ..setProperty('kind'.toJS, 'init'.toJS)
-      ..setProperty('bytes'.toJS, jsBuffer);
-    worker.postMessage(init, <JSAny>[jsBuffer].toJS);
+    final init = JSObject()..setProperty('kind'.toJS, 'init'.toJS);
+    final sharedBuffer = _sharedDocumentBuffer(bytes);
+    if (sharedBuffer != null) {
+      init
+        ..setProperty('bytes'.toJS, sharedBuffer)
+        ..setProperty('shared'.toJS, true.toJS);
+      worker.postMessage(init);
+      _wlog('init posted via SharedArrayBuffer bytes=${bytes.length}');
+    } else {
+      // Transfer the whole document to the worker once at start (copy first so
+      // the transferred buffer is exactly the document, not a view into a
+      // larger backing store the caller still holds).
+      final jsBuffer = Uint8List.fromList(bytes).buffer.toJS;
+      init
+        ..setProperty('bytes'.toJS, jsBuffer)
+        ..setProperty('shared'.toJS, false.toJS);
+      worker.postMessage(init, <JSAny>[jsBuffer].toJS);
+      _wlog('init posted via transferred ArrayBuffer bytes=${bytes.length}');
+    }
 
     // Watchdog: if the worker never reports 'ready' (e.g. the transferred
     // document never arrived/opened on this host), give up and render locally
@@ -129,7 +151,9 @@ class _WebRenderWorker implements PdfRenderWorker {
     if (data == null) return;
     final kind = (data.getProperty('kind'.toJS) as JSString?)?.toDart;
     if (kind == 'ready') {
-      _wlog('ready (worker opened the document)');
+      final shared =
+          (data.getProperty('shared'.toJS) as JSBoolean?)?.toDart ?? false;
+      _wlog('ready (worker opened the document, sharedBytes=$shared)');
       _readyWatchdog?.cancel();
       _readyWatchdog = null;
       _ready = true;
@@ -334,4 +358,31 @@ class _WebPending {
   final int? commandLimit;
   final completer = Completer<Uint8List?>();
   int id = -1;
+}
+
+JSObject? _sharedDocumentBuffer(Uint8List bytes) {
+  if (!_canUseSharedDocumentBytes) return null;
+  try {
+    final buffer = _constructJsObject('SharedArrayBuffer', bytes.length.toJS);
+    final view = _constructJsObject('Uint8Array', buffer) as JSUint8Array;
+    view.toDart.setAll(0, bytes);
+    return buffer;
+  } catch (e) {
+    _wlog('SharedArrayBuffer unavailable at runtime: $e');
+    return null;
+  }
+}
+
+bool get _canUseSharedDocumentBytes {
+  if (!pdfRenderWorkerUseSharedArrayBuffer) return false;
+  if (!globalContext.has('SharedArrayBuffer')) return false;
+  return (globalContext['crossOriginIsolated'] as JSBoolean?)?.toDart ?? false;
+}
+
+JSObject _constructJsObject(String constructorName, JSAny arg) {
+  final constructor = globalContext[constructorName] as JSFunction?;
+  if (constructor == null) {
+    throw StateError('$constructorName is not available');
+  }
+  return constructor.callAsConstructor<JSObject>(arg);
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -2,6 +2,7 @@ import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 import 'dart:typed_data';
 
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:web/web.dart' as web;
@@ -21,8 +22,8 @@ import 'package:web/web.dart' as web;
 /// a viewer. See `doc/render_worker_web.md` for the full wiring.
 ///
 /// Protocol (mirrors the native isolate backend):
-/// - `{kind:'init', bytes:ArrayBuffer}` → opens the document, replies
-///   `{kind:'ready'}`.
+/// - `{kind:'init', bytes:ArrayBuffer|SharedArrayBuffer, shared}` → opens the
+///   document, replies `{kind:'ready', shared}`.
 /// - `{kind:'record', id, page, annotations}` → replies `{kind:'result', id,
 ///   buffer:ArrayBuffer|null}` (null = the page can't be offloaded; the main
 ///   thread renders it locally).
@@ -48,14 +49,22 @@ void runPdfRenderWorker() {
       // ArrayBuffer view can throw on some hosts) must NOT skip the 'ready'
       // reply below, or the main thread waits on it forever. A null document
       // simply declines every page to a local render.
+      var shared = false;
       try {
-        final buffer = data.getProperty('bytes'.toJS) as JSArrayBuffer;
-        document = PdfDocument.open(buffer.toDart.asUint8List());
+        shared =
+            (data.getProperty('shared'.toJS) as JSBoolean?)?.toDart ?? false;
+        final buffer = data.getProperty('bytes'.toJS) as JSObject;
+        final bytes = shared
+            ? _jsUint8View(buffer).toDart
+            : (buffer as JSArrayBuffer).toDart.asUint8List();
+        document = PdfDocument.open(bytes);
       } catch (_) {
         document = null; // bad transfer / broken document → local renders
       }
       // ALWAYS reply ready, even on failure, so the client never hangs.
-      scope.postMessage(JSObject()..setProperty('kind'.toJS, 'ready'.toJS));
+      scope.postMessage(JSObject()
+        ..setProperty('kind'.toJS, 'ready'.toJS)
+        ..setProperty('shared'.toJS, shared.toJS));
       return;
     }
 
@@ -118,6 +127,12 @@ void runPdfRenderWorker() {
   }).toJS;
 }
 
+JSUint8Array _jsUint8View(JSObject buffer) {
+  final constructor = globalContext['Uint8Array'] as JSFunction?;
+  if (constructor == null) throw StateError('Uint8Array is not available');
+  return constructor.callAsConstructor<JSUint8Array>(buffer);
+}
+
 /// Records one page into a serialized command buffer, yielding periodically
 /// so the cancel message handler can fire and set [token.cancelled].
 ///
@@ -141,6 +156,10 @@ Future<Uint8List?> _recordPageAsync(
       PdfInterpreter(cos: document.cos, device: recorder, cancellation: token);
   await interpreter.drawPageOperationsAsync(page, ops);
   if (annotations) interpreter.drawAnnotations(page);
+  var commands = recorder.commands;
+  if (decodeImages) {
+    commands = await _withBrowserDecodedImages(document.cos, commands, token);
+  }
   // Decode the page's images in the worker too: the buffer carries
   // premultiplied RGBA so the main thread only runs the engine codec. On web
   // this matters more than on native — there is no separate raster thread, so
@@ -149,10 +168,211 @@ Future<Uint8List?> _recordPageAsync(
   // postMessage boundary, so a sheet-sized raster underlay ships at a few MB
   // instead of hundreds. decodeImages false skips the decode entirely for the
   // fast vector-first pass of progressive rendering.
-  return serializeCommands(recorder.commands,
+  return serializeCommands(commands,
       cos: document.cos,
       decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio,
       imagePlaceholders: !decodeImages,
       commandLimit: commandLimit);
+}
+
+Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
+  CosDocument cos,
+  List<PdfRenderCommand> commands,
+  PdfCancellationToken token,
+) async {
+  var changed = false;
+  final out = <PdfRenderCommand>[];
+  for (final command in commands) {
+    if (token.cancelled) throw PdfCancelledException();
+    switch (command) {
+      case PdfDrawImageCommand(:final request):
+        if (request.isInline || request.decoded != null) {
+          out.add(command);
+          continue;
+        }
+        final decoded = await _decodeWithBrowserCodec(cos, request.stream);
+        if (decoded == null) {
+          out.add(command);
+        } else {
+          changed = true;
+          out.add(PdfDrawImageCommand(_withDecodedPixels(request, decoded)));
+        }
+      case PdfEndSoftMaskedCommand(
+          :final luminosity,
+          :final backdrop,
+          :final maskCommands,
+          :final backdropLuminance,
+          :final transferScale,
+          :final transferOffset
+        ):
+        final decodedMaskCommands =
+            await _withBrowserDecodedImages(cos, maskCommands, token);
+        if (!identical(decodedMaskCommands, maskCommands)) changed = true;
+        out.add(PdfEndSoftMaskedCommand(
+          luminosity: luminosity,
+          backdrop: backdrop,
+          maskCommands: decodedMaskCommands,
+          backdropLuminance: backdropLuminance,
+          transferScale: transferScale,
+          transferOffset: transferOffset,
+        ));
+      default:
+        out.add(command);
+    }
+  }
+  return changed ? out : commands;
+}
+
+PdfImageRequest _withDecodedPixels(
+  PdfImageRequest request,
+  PdfDecodedPixels decoded,
+) =>
+    PdfImageRequest(
+      stream: request.stream,
+      transform: request.transform,
+      alpha: request.alpha,
+      isStencil: request.isStencil,
+      stencilColor: request.stencilColor,
+      isInline: request.isInline,
+      decoded: decoded,
+    );
+
+Future<PdfDecodedPixels?> _decodeWithBrowserCodec(
+    CosDocument cos, CosStream stream) async {
+  if (!_browserImageDecodeAvailable) return null;
+  final dict = stream.dictionary;
+  if (cos.resolve(dict['ImageMask']) == const CosBoolean(true)) return null;
+
+  final filters = pdfImageFilters(cos, dict);
+  final dctName = filters.contains('DCTDecode')
+      ? 'DCTDecode'
+      : filters.contains('DCT')
+          ? 'DCT'
+          : null;
+  final dctMaskBytes = pdfImageDctSoftMaskBytes(cos, dict);
+  if (dctName == null && dctMaskBytes == null) return null;
+
+  final PdfImageBase? base;
+  if (dctName != null) {
+    final family = pdfImageColorFamily(cos, dict);
+    if (family == 'DeviceCMYK') {
+      // CMYK JPEG bases already decode in pure Dart. Only intervene when the
+      // soft mask is DCT-encoded and therefore needs the browser codec.
+      if (dctMaskBytes == null) return null;
+      base = decodePdfImageBase(cos, stream);
+    } else {
+      final jpeg = cos.decodeStreamData(stream, stopBeforeFilter: dctName);
+      base = await _decodeBrowserJpegBase(cos, dict, jpeg);
+    }
+  } else {
+    // Pure base + DCT /SMask: reuse the pure base decoder and only lift the
+    // mask through the browser codec.
+    base = decodePdfImageBase(cos, stream);
+  }
+  if (base == null) return null;
+
+  PdfImageSoftMask? mask;
+  if (dctMaskBytes != null) {
+    mask = await _decodeBrowserJpegMask(dctMaskBytes);
+  }
+  mask ??= pdfImageSoftMask(cos, dict) ?? pdfImageStencilMask(cos, dict);
+  if (mask == null) {
+    return _finishBrowserDecoded(
+      base.rgba,
+      base.width,
+      base.height,
+      hasAlpha: !base.opaque,
+    );
+  }
+  final masked = pdfApplyImageAlpha(base.rgba, base.width, base.height, mask);
+  return _finishBrowserDecoded(
+    masked.$1,
+    masked.$2,
+    masked.$3,
+    hasAlpha: true,
+  );
+}
+
+Future<PdfImageBase?> _decodeBrowserJpegBase(
+  CosDocument cos,
+  CosDictionary dict,
+  Uint8List jpeg,
+) async {
+  final decoded = await _decodeBrowserJpegRgba(jpeg);
+  if (decoded == null) return null;
+  final components = switch (pdfImageColorFamily(cos, dict)) {
+    'DeviceGray' => 1,
+    'DeviceRGB' => 3,
+    _ => 0,
+  };
+  final ranges =
+      components > 0 ? pdfImageDecodeRanges(cos, dict, components) : null;
+  final colorKey =
+      components > 0 ? pdfImageColorKeyRanges(cos, dict, components) : null;
+  if (ranges != null || colorKey != null) {
+    pdfApplyImageDecodeAndColorKey(decoded.rgba, components, ranges, colorKey);
+  }
+  return PdfImageBase(decoded.rgba, decoded.width, decoded.height,
+      opaque: colorKey == null);
+}
+
+Future<PdfImageSoftMask?> _decodeBrowserJpegMask(Uint8List jpeg) async {
+  final decoded = await _decodeBrowserJpegRgba(jpeg);
+  if (decoded == null) return null;
+  final alpha = Uint8List(decoded.width * decoded.height);
+  for (var i = 0; i < alpha.length; i++) {
+    alpha[i] = decoded.rgba[i * 4];
+  }
+  return PdfImageSoftMask(alpha, decoded.width, decoded.height);
+}
+
+PdfDecodedPixels _finishBrowserDecoded(Uint8List rgba, int width, int height,
+    {required bool hasAlpha}) {
+  if (hasAlpha) pdfPremultiplyRgba(rgba);
+  return PdfDecodedPixels(rgba, width, height);
+}
+
+Future<_BrowserDecodedImage?> _decodeBrowserJpegRgba(Uint8List jpeg) async {
+  if (!_browserImageDecodeAvailable) return null;
+  web.ImageBitmap? bitmap;
+  try {
+    final blob = web.Blob(
+      <JSAny>[jpeg.toJS].toJS,
+      web.BlobPropertyBag(type: 'image/jpeg'),
+    );
+    final scope = globalContext as web.WorkerGlobalScope;
+    bitmap = await scope.createImageBitmap(blob).toDart;
+    final width = bitmap.width;
+    final height = bitmap.height;
+    if (width <= 0 || height <= 0) return null;
+    final canvas = web.OffscreenCanvas(width, height);
+    final context =
+        canvas.getContext('2d') as web.OffscreenCanvasRenderingContext2D?;
+    if (context == null) return null;
+    context.drawImage(bitmap, 0, 0);
+    final imageData = context.getImageData(0, 0, width, height);
+    return _BrowserDecodedImage(
+      Uint8List.fromList(imageData.data.toDart),
+      width,
+      height,
+    );
+  } catch (_) {
+    return null;
+  } finally {
+    bitmap?.close();
+  }
+}
+
+bool get _browserImageDecodeAvailable =>
+    globalContext.has('Blob') &&
+    globalContext.has('createImageBitmap') &&
+    globalContext.has('OffscreenCanvas');
+
+class _BrowserDecodedImage {
+  const _BrowserDecodedImage(this.rgba, this.width, this.height);
+
+  final Uint8List rgba;
+  final int width;
+  final int height;
 }

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -165,6 +165,81 @@ PdfDecodedPixels? decodePdfImagePixels(CosDocument cos, CosStream stream) {
   return _finish(m.$1, m.$2, m.$3, hasAlpha: true);
 }
 
+/// Decodes a simple Flate/raw image directly to [targetWidth]×[targetHeight],
+/// or returns null when the stream needs the full general decoder.
+///
+/// This is the first region/tile-decode fast path for CAD sheets split into
+/// many large Flate tiles: the worker already knows the capped display size,
+/// so expanding a 2048×2048 tile to native RGBA and then downsampling it wastes
+/// both CPU and memory. The implementation is deliberately narrow and
+/// correctness-first: RGB/gray 8-bit streams with identity decode and no masks,
+/// plus 1-bit /ImageMask stencils. Everything else falls back to
+/// [decodePdfImagePixels].
+PdfDecodedPixels? decodePdfImagePixelsScaled(
+  CosDocument cos,
+  CosStream stream,
+  int targetWidth,
+  int targetHeight,
+) {
+  final dict = stream.dictionary;
+  final width = _intOf(cos.resolve(dict['Width']));
+  final height = _intOf(cos.resolve(dict['Height']));
+  if (width <= 0 || height <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+    return null;
+  }
+  var tw = targetWidth.clamp(1, width);
+  var th = targetHeight.clamp(1, height);
+  if (tw >= width && th >= height) return null;
+
+  final filters = pdfImageFilters(cos, dict);
+  if (filters.length != 1 ||
+      (filters.single != 'FlateDecode' && filters.single != 'Fl')) {
+    return null;
+  }
+
+  final isMask = cos.resolve(dict['ImageMask']) == const CosBoolean(true);
+  final mask = cos.resolve(dict['Mask']);
+  if (!isMask && dict.containsKey('SMask')) return null;
+
+  final data = cos.decodeStreamData(stream);
+  if (isMask) return _scaledImageMask(cos, dict, data, width, height, tw, th);
+
+  final bits = _intOf(cos.resolve(dict['BitsPerComponent']), fallback: 8);
+  final space = pdfImageColorFamily(cos, dict);
+  if (space == 'Indexed' && bits == 1) {
+    if (mask is! CosNull && mask is! CosStream) return null;
+    return _scaledIndexed1(cos, dict, data, width, height, tw, th,
+        mask is CosStream ? mask : null);
+  }
+  if (mask is! CosNull) return null;
+  if (bits != 8) return null;
+  final components = switch (space) {
+    'DeviceRGB' => 3,
+    'DeviceGray' => 1,
+    _ => 0,
+  };
+  if (components == 0) return null;
+  if (!_isDirectDeviceColorSpace(cos, dict, space)) return null;
+  if (pdfImageDecodeRanges(cos, dict, components) != null) return null;
+
+  return switch (components) {
+    3 => _scaledRgb8(data, width, height, tw, th),
+    1 => _scaledGray8(data, width, height, tw, th),
+    _ => null,
+  };
+}
+
+bool _isDirectDeviceColorSpace(
+    CosDocument cos, CosDictionary dict, String family) {
+  final space = cos.resolve(dict['ColorSpace']);
+  if (space is! CosName) return false;
+  return switch ((family, space.value)) {
+    ('DeviceRGB', 'DeviceRGB') || ('DeviceRGB', 'RGB') => true,
+    ('DeviceGray', 'DeviceGray') || ('DeviceGray', 'G') => true,
+    _ => false,
+  };
+}
+
 /// Wraps decoded straight-alpha [rgba] as a codec-ready result: premultiplies
 /// when the pixels can carry transparency, skips the scan when they're opaque
 /// (premultiplying by alpha 255 is the identity).
@@ -230,6 +305,174 @@ PdfDecodedPixels downsamplePdfDecodedPixels(
   return PdfDecodedPixels(dst, tw, th);
 }
 
+PdfDecodedPixels? _scaledRgb8(
+    Uint8List data, int width, int height, int targetWidth, int targetHeight) {
+  if (data.length < width * height * 3) return null;
+  final out = Uint8List(targetWidth * targetHeight * 4);
+  var di = 0;
+  for (var y = 0; y < targetHeight; y++) {
+    final sy = _sourceCoord(y, height, targetHeight);
+    final y0 = sy.$1;
+    final y1 = sy.$2;
+    final wy = sy.$3;
+    for (var x = 0; x < targetWidth; x++) {
+      final sx = _sourceCoord(x, width, targetWidth);
+      final x0 = sx.$1;
+      final x1 = sx.$2;
+      final wx = sx.$3;
+      final i00 = (y0 * width + x0) * 3;
+      final i01 = (y0 * width + x1) * 3;
+      final i10 = (y1 * width + x0) * 3;
+      final i11 = (y1 * width + x1) * 3;
+      out[di] =
+          _bilinearByte(data[i00], data[i01], data[i10], data[i11], wx, wy);
+      out[di + 1] = _bilinearByte(
+          data[i00 + 1], data[i01 + 1], data[i10 + 1], data[i11 + 1], wx, wy);
+      out[di + 2] = _bilinearByte(
+          data[i00 + 2], data[i01 + 2], data[i10 + 2], data[i11 + 2], wx, wy);
+      out[di + 3] = 255;
+      di += 4;
+    }
+  }
+  return PdfDecodedPixels(out, targetWidth, targetHeight);
+}
+
+PdfDecodedPixels? _scaledGray8(
+    Uint8List data, int width, int height, int targetWidth, int targetHeight) {
+  if (data.length < width * height) return null;
+  final out = Uint8List(targetWidth * targetHeight * 4);
+  var di = 0;
+  for (var y = 0; y < targetHeight; y++) {
+    final sy = _sourceCoord(y, height, targetHeight);
+    final y0 = sy.$1;
+    final y1 = sy.$2;
+    final wy = sy.$3;
+    for (var x = 0; x < targetWidth; x++) {
+      final sx = _sourceCoord(x, width, targetWidth);
+      final x0 = sx.$1;
+      final x1 = sx.$2;
+      final wx = sx.$3;
+      final v = _bilinearByte(data[y0 * width + x0], data[y0 * width + x1],
+          data[y1 * width + x0], data[y1 * width + x1], wx, wy);
+      out[di] = out[di + 1] = out[di + 2] = v;
+      out[di + 3] = 255;
+      di += 4;
+    }
+  }
+  return PdfDecodedPixels(out, targetWidth, targetHeight);
+}
+
+PdfDecodedPixels? _scaledIndexed1(
+  CosDocument cos,
+  CosDictionary dict,
+  Uint8List data,
+  int width,
+  int height,
+  int targetWidth,
+  int targetHeight,
+  CosStream? mask,
+) {
+  final paletteInfo = _indexedPalette(cos, dict);
+  if (paletteInfo == null) return null;
+  final palette = paletteInfo.$1;
+  final paletteCount = paletteInfo.$2;
+  final rowBytes = (width + 7) ~/ 8;
+  if (data.length < rowBytes * height) return null;
+
+  Uint8List? maskData;
+  var maskInverted = false;
+  if (mask != null) {
+    final filters = pdfImageFilters(cos, mask.dictionary);
+    if (filters.length != 1 ||
+        (filters.single != 'FlateDecode' && filters.single != 'Fl')) {
+      return null;
+    }
+    final mw = _intOf(cos.resolve(mask.dictionary['Width']));
+    final mh = _intOf(cos.resolve(mask.dictionary['Height']));
+    final mbits =
+        _intOf(cos.resolve(mask.dictionary['BitsPerComponent']), fallback: 1);
+    if (mw != width || mh != height || mbits != 1) return null;
+    final decode = cos.resolve(mask.dictionary['Decode']);
+    maskInverted = decode is CosArray &&
+        decode.length > 0 &&
+        _numOf(cos.resolve(decode[0])) == 1;
+    maskData = cos.decodeStreamData(mask);
+    if (maskData.length < rowBytes * height) return null;
+  }
+
+  final out = Uint8List(targetWidth * targetHeight * 4);
+  var di = 0;
+  for (var y = 0; y < targetHeight; y++) {
+    final sy = ((y + 0.5) * height / targetHeight).floor().clamp(0, height - 1);
+    final row = sy * rowBytes;
+    for (var x = 0; x < targetWidth; x++) {
+      final sx = ((x + 0.5) * width / targetWidth).floor().clamp(0, width - 1);
+      final bit = (data[row + (sx >> 3)] >> (7 - (sx & 7))) & 1;
+      final index = bit >= paletteCount ? 0 : bit;
+
+      var alpha = 255;
+      if (maskData != null) {
+        final maskBit = (maskData[row + (sx >> 3)] >> (7 - (sx & 7))) & 1;
+        final masked = maskInverted ? maskBit == 0 : maskBit == 1;
+        alpha = masked ? 0 : 255;
+      }
+
+      final pi = index * 3;
+      out[di] = alpha == 0 ? 0 : palette[pi];
+      out[di + 1] = alpha == 0 ? 0 : palette[pi + 1];
+      out[di + 2] = alpha == 0 ? 0 : palette[pi + 2];
+      out[di + 3] = alpha;
+      di += 4;
+    }
+  }
+  return PdfDecodedPixels(out, targetWidth, targetHeight);
+}
+
+PdfDecodedPixels? _scaledImageMask(CosDocument cos, CosDictionary dict,
+    Uint8List data, int width, int height, int targetWidth, int targetHeight) {
+  final rowBytes = (width + 7) ~/ 8;
+  if (data.length < rowBytes * height) return null;
+  final decode = cos.resolve(dict['Decode']);
+  final inverted = decode is CosArray &&
+      decode.length > 0 &&
+      _numOf(cos.resolve(decode[0])) == 1;
+  final out = Uint8List(targetWidth * targetHeight * 4);
+  var di = 0;
+  for (var y = 0; y < targetHeight; y++) {
+    final sy = ((y + 0.5) * height / targetHeight).floor().clamp(0, height - 1);
+    for (var x = 0; x < targetWidth; x++) {
+      final sx = ((x + 0.5) * width / targetWidth).floor().clamp(0, width - 1);
+      final bit = (data[sy * rowBytes + (sx >> 3)] >> (7 - (sx & 7))) & 1;
+      final paint = inverted ? bit == 1 : bit == 0;
+      final v = paint ? 255 : 0;
+      out[di] = out[di + 1] = out[di + 2] = v;
+      out[di + 3] = v;
+      di += 4;
+    }
+  }
+  return PdfDecodedPixels(out, targetWidth, targetHeight);
+}
+
+(int, int, double) _sourceCoord(int dst, int srcSize, int dstSize) {
+  final p = (dst + 0.5) * srcSize / dstSize - 0.5;
+  final i0 = p.floor().clamp(0, srcSize - 1);
+  final i1 = (i0 + 1).clamp(0, srcSize - 1);
+  return (i0, i1, p - i0);
+}
+
+int _bilinearByte(
+  int v00,
+  int v01,
+  int v10,
+  int v11,
+  double wx,
+  double wy,
+) {
+  final top = v00 * (1 - wx) + v01 * wx;
+  final bottom = v10 * (1 - wx) + v11 * wx;
+  return (top * (1 - wy) + bottom * wy).round().clamp(0, 255);
+}
+
 /// The pixel size an image should be decoded/stored at so it is no sharper than
 /// [headroom]× its on-screen footprint — the cap behind `serializeCommands`'s
 /// `maxImagePixelRatio` (see render_command_codec.dart), extracted as a pure
@@ -244,8 +487,8 @@ PdfDecodedPixels downsamplePdfDecodedPixels(
 /// cache. Returns `(srcWidth, srcHeight)` unchanged when no worthwhile
 /// reduction applies (already small enough, a degenerate transform, or a
 /// non-positive ratio) — the caller then ships the native pixels as-is.
-(int, int) cappedImagePixelSize(
-    int srcWidth, int srcHeight, double widthPts, double heightPts, double ratio,
+(int, int) cappedImagePixelSize(int srcWidth, int srcHeight, double widthPts,
+    double heightPts, double ratio,
     {double headroom = 2.0,
     int maxPixels = 1 << 24,
     double maxDimension = 8192}) {
@@ -437,7 +680,9 @@ bool _softMaskIsDct(CosDocument cos, CosDictionary dict) {
 Uint8List? pdfImageDctSoftMaskBytes(CosDocument cos, CosDictionary dict) {
   final smask = cos.resolve(dict['SMask']);
   if (smask is! CosStream) return null;
-  if (!pdfImageFilters(cos, smask.dictionary).contains('DCTDecode')) return null;
+  if (!pdfImageFilters(cos, smask.dictionary).contains('DCTDecode')) {
+    return null;
+  }
   try {
     return cos.decodeStreamData(smask, stopBeforeFilter: 'DCTDecode');
   } on Exception {
@@ -730,7 +975,8 @@ Uint8List? _toRgba(CosDocument cos, CosDictionary dict, Uint8List data,
         final on = (byte >> (7 - (x & 7))) & 1;
         final i = (y * width + x) * 4;
         out[i] = out[i + 1] = out[i + 2] = values[on];
-        out[i + 3] = key != null && on >= key[0].$1 && on <= key[0].$2 ? 0 : 255;
+        out[i + 3] =
+            key != null && on >= key[0].$1 && on <= key[0].$2 ? 0 : 255;
       }
     }
     return out;
@@ -850,8 +1096,12 @@ Uint8List? _toRgba(CosDocument cos, CosDictionary dict, Uint8List data,
             s2 = data[base + 2],
             s3 = data[base + 3];
         final color = cmykIcc != null
-            ? cmykIcc.toSrgb(
-                [lut0[s0] / 255, lut1[s1] / 255, lut2[s2] / 255, lut3[s3] / 255])
+            ? cmykIcc.toSrgb([
+                lut0[s0] / 255,
+                lut1[s1] / 255,
+                lut2[s2] / 255,
+                lut3[s3] / 255
+              ])
             : PdfColor.cmyk(
                 lut0[s0] / 255, lut1[s1] / 255, lut2[s2] / 255, lut3[s3] / 255);
         out[base] = (color.red * 255).round();
@@ -925,6 +1175,37 @@ Uint8List _lutFor(List<(double, double)>? ranges, int component) =>
 Uint8List? _indexedToRgba(CosDocument cos, CosDictionary dict, Uint8List data,
     int width, int height, int bits, Uint8List out,
     {List<(int, int)>? colorKey}) {
+  final paletteInfo = _indexedPalette(cos, dict);
+  if (paletteInfo == null) return null;
+  final palette = paletteInfo.$1;
+  final paletteCount = paletteInfo.$2;
+  if (bits != 1 && bits != 2 && bits != 4 && bits != 8) return null;
+
+  final rowBytes = (width * bits + 7) ~/ 8;
+  if (data.length < rowBytes * height) return null;
+  final perByte = 8 ~/ bits;
+  final mask = (1 << bits) - 1;
+  for (var y = 0; y < height; y++) {
+    for (var x = 0; x < width; x++) {
+      final byte = data[y * rowBytes + x ~/ perByte];
+      final shift = 8 - bits * (x % perByte + 1);
+      final raw = (byte >> shift) & mask;
+      final index = raw >= paletteCount ? 0 : raw;
+      final i = (y * width + x) * 4;
+      out[i] = palette[index * 3];
+      out[i + 1] = palette[index * 3 + 1];
+      out[i + 2] = palette[index * 3 + 2];
+      // color-key ranges compare the raw index sample (§8.9.6.4)
+      out[i + 3] =
+          colorKey != null && raw >= colorKey[0].$1 && raw <= colorKey[0].$2
+              ? 0
+              : 255;
+    }
+  }
+  return out;
+}
+
+(Uint8List, int)? _indexedPalette(CosDocument cos, CosDictionary dict) {
   final space = cos.resolve(dict['ColorSpace']);
   if (space is! CosArray || space.length < 4) return null;
   // A Lab base palette is decoded through the CIE machinery — without this it
@@ -932,8 +1213,9 @@ Uint8List? _indexedToRgba(CosDocument cos, CosDictionary dict, Uint8List data,
   // separate gray samples, banding a smooth gradient into diagonal stripes.
   // (CalRGB/CalGray keep their existing device decode to avoid baseline churn.)
   final baseObj = cos.resolve(space[1]);
-  final baseFamily =
-      baseObj is CosArray && baseObj.length > 0 ? cos.resolve(baseObj[0]) : null;
+  final baseFamily = baseObj is CosArray && baseObj.length > 0
+      ? cos.resolve(baseObj[0])
+      : null;
   final labBase = baseFamily is CosName && baseFamily.value == 'Lab'
       ? PdfCalibratedColorSpace.parse(cos, baseObj)
       : null;
@@ -945,7 +1227,6 @@ Uint8List? _indexedToRgba(CosDocument cos, CosDictionary dict, Uint8List data,
         _ => 0,
       };
   if (components == 0) return null;
-  if (bits != 1 && bits != 2 && bits != 4 && bits != 8) return null;
 
   final lookupObj = cos.resolve(space[3]);
   final Uint8List lookup;
@@ -984,29 +1265,7 @@ Uint8List? _indexedToRgba(CosDocument cos, CosDictionary dict, Uint8List data,
         palette[p * 3 + 2] = (color.blue * 255).round();
     }
   }
-
-  final rowBytes = (width * bits + 7) ~/ 8;
-  if (data.length < rowBytes * height) return null;
-  final perByte = 8 ~/ bits;
-  final mask = (1 << bits) - 1;
-  for (var y = 0; y < height; y++) {
-    for (var x = 0; x < width; x++) {
-      final byte = data[y * rowBytes + x ~/ perByte];
-      final shift = 8 - bits * (x % perByte + 1);
-      final raw = (byte >> shift) & mask;
-      final index = raw >= paletteCount ? 0 : raw;
-      final i = (y * width + x) * 4;
-      out[i] = palette[index * 3];
-      out[i + 1] = palette[index * 3 + 1];
-      out[i + 2] = palette[index * 3 + 2];
-      // color-key ranges compare the raw index sample (§8.9.6.4)
-      out[i + 3] =
-          colorKey != null && raw >= colorKey[0].$1 && raw <= colorKey[0].$2
-              ? 0
-              : 255;
-    }
-  }
-  return out;
+  return (palette, paletteCount);
 }
 
 /// Maps the image's /ColorSpace to the device family used for decoding.

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -331,9 +331,14 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
           if (!imagePlaceholders) throw const _UnserializableImage();
           inlined = _imagePlaceholderStream;
         }
-        _writeImageCommand(w, request, inlined,
-            decode ? decodePdfImagePixels(document, request.stream) : null,
-            maxImageRatio: maxImageRatio, budgetScale: budgetScale);
+        _writeImageCommand(
+            w,
+            request,
+            inlined,
+            decode
+                ? _decodeImageForCommand(
+                    document, request, maxImageRatio, budgetScale)
+                : null);
       }
     case PdfSetBlendModeCommand(:final mode):
       w.u8(_tSetBlendMode);
@@ -368,9 +373,61 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
   }
 }
 
+PdfDecodedPixels? _decodeImageForCommand(
+  CosDocument document,
+  PdfImageRequest request,
+  double? maxImageRatio,
+  double budgetScale,
+) {
+  final predecoded = request.decoded;
+  if (predecoded != null) {
+    return maxImageRatio == null
+        ? predecoded
+        : _capImageResolution(
+            predecoded, request.transform, maxImageRatio, budgetScale);
+  }
+  if (maxImageRatio != null) {
+    final target =
+        _targetDecodedSize(document, request, maxImageRatio, budgetScale);
+    if (target != null) {
+      final scaled = decodePdfImagePixelsScaled(
+          document, request.stream, target.$1, target.$2);
+      if (scaled != null) return scaled;
+    }
+  }
+  final decoded = decodePdfImagePixels(document, request.stream);
+  if (decoded == null || maxImageRatio == null) return decoded;
+  return _capImageResolution(
+      decoded, request.transform, maxImageRatio, budgetScale);
+}
+
+(int, int)? _targetDecodedSize(
+  CosDocument document,
+  PdfImageRequest request,
+  double ratio,
+  double budgetScale,
+) {
+  final size = _declaredImageSize(document, request.stream);
+  if (size == null) return null;
+  final transform = request.transform;
+  final widthPts =
+      math.sqrt(transform.a * transform.a + transform.b * transform.b);
+  final heightPts =
+      math.sqrt(transform.c * transform.c + transform.d * transform.d);
+  final capped =
+      cappedImagePixelSize(size.$1, size.$2, widthPts, heightPts, ratio);
+  var tw = capped.$1;
+  var th = capped.$2;
+  if (budgetScale < 1.0) {
+    tw = (tw * budgetScale).ceil().clamp(1, size.$1);
+    th = (th * budgetScale).ceil().clamp(1, size.$2);
+  }
+  if (tw == size.$1 && th == size.$2) return null;
+  return (tw, th);
+}
+
 void _writeImageCommand(_Writer w, PdfImageRequest request, CosObject inlined,
-    PdfDecodedPixels? decoded,
-    {double? maxImageRatio, double budgetScale = 1.0}) {
+    PdfDecodedPixels? decoded) {
   w.u8(_tDrawImage);
   _writeMatrix(w, request.transform);
   w.f64(request.alpha);
@@ -380,12 +437,6 @@ void _writeImageCommand(_Writer w, PdfImageRequest request, CosObject inlined,
   // Optional off-thread decode: the premultiplied pixels ride beside the
   // stream so the consumer skips the pure-Dart decode. The stream above is
   // still written, so the pixels cache by content like a local render.
-  if (decoded != null && maxImageRatio != null) {
-    // Cap to display resolution before it crosses the thread boundary — this
-    // is what shrinks the multi-hundred-MB payload of a CAD raster underlay.
-    decoded = _capImageResolution(
-        decoded, request.transform, maxImageRatio, budgetScale);
-  }
   w.boolean(decoded != null);
   if (decoded != null) {
     w.u32(decoded.width);

--- a/packages/pdf_graphics/test/image_pixels_test.dart
+++ b/packages/pdf_graphics/test/image_pixels_test.dart
@@ -22,7 +22,14 @@ void main() {
       'Height': const CosInteger(1),
       'BitsPerComponent': const CosInteger(8),
       'ColorSpace': const CosName('DeviceRGB'),
-    }, [10, 20, 30, 40, 50, 60]);
+    }, [
+      10,
+      20,
+      30,
+      40,
+      50,
+      60
+    ]);
 
     final pixels = decodePdfImagePixels(cos, stream)!;
     expect(pixels.width, 2);
@@ -36,7 +43,10 @@ void main() {
       'Height': const CosInteger(1),
       'BitsPerComponent': const CosInteger(8),
       'ColorSpace': const CosName('DeviceGray'),
-    }, [100, 200]);
+    }, [
+      100,
+      200
+    ]);
 
     final pixels = decodePdfImagePixels(cos, stream)!;
     expect(pixels.rgba, [100, 100, 100, 255, 200, 200, 200, 255]);
@@ -48,7 +58,9 @@ void main() {
       'Width': const CosInteger(2),
       'Height': const CosInteger(1),
       'BitsPerComponent': const CosInteger(1),
-    }, [0x40]); // bit 0 paints, bit 1 skips
+    }, [
+      0x40
+    ]); // bit 0 paints, bit 1 skips
     final pixels = decodePdfImagePixels(cos, stream)!;
     expect(pixels.rgba[3], 255); // painted
     expect(pixels.rgba[7], 0); // skipped
@@ -60,14 +72,24 @@ void main() {
       'Height': const CosInteger(1),
       'BitsPerComponent': const CosInteger(8),
       'ColorSpace': const CosName('DeviceGray'),
-    }, [128, 0]);
+    }, [
+      128,
+      0
+    ]);
     final stream = image({
       'Width': const CosInteger(2),
       'Height': const CosInteger(1),
       'BitsPerComponent': const CosInteger(8),
       'ColorSpace': const CosName('DeviceRGB'),
       'SMask': smask,
-    }, [255, 255, 255, 255, 255, 255]);
+    }, [
+      255,
+      255,
+      255,
+      255,
+      255,
+      255
+    ]);
 
     final pixels = decodePdfImagePixels(cos, stream)!;
     // first pixel: white at alpha 128 → premultiplied 128 in each channel.
@@ -90,7 +112,14 @@ void main() {
         const CosInteger(0),
         const CosInteger(0),
       ]),
-    }, [0, 0, 0, 9, 9, 9]);
+    }, [
+      0,
+      0,
+      0,
+      9,
+      9,
+      9
+    ]);
 
     final pixels = decodePdfImagePixels(cos, stream)!;
     expect(pixels.rgba[3], 0); // (0,0,0) keyed out
@@ -109,20 +138,212 @@ void main() {
     expect(decodePdfImageBase(cos, stream), isNull);
   });
 
+  test('scaled DeviceRGB Flate decodes directly to target size', () {
+    final stream = image({
+      'Width': const CosInteger(4),
+      'Height': const CosInteger(4),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': const CosName('DeviceRGB'),
+      'Filter': const CosName('FlateDecode'),
+    }, [
+      120,
+      156,
+      251,
+      207,
+      192,
+      240,
+      159,
+      1,
+      140,
+      255,
+      67,
+      8,
+      6,
+      100,
+      10,
+      2,
+      144,
+      217,
+      0,
+      210,
+      107,
+      23,
+      233,
+    ]);
+
+    final pixels = decodePdfImagePixelsScaled(cos, stream, 2, 2)!;
+    expect(pixels.width, 2);
+    expect(pixels.height, 2);
+    expect(pixels.rgba, [
+      255,
+      0,
+      0,
+      255,
+      0,
+      255,
+      0,
+      255,
+      0,
+      0,
+      255,
+      255,
+      255,
+      255,
+      255,
+      255,
+    ]);
+  });
+
+  test('scaled ICCBased Flate falls back to full color conversion', () {
+    final stream = image({
+      'Width': const CosInteger(4),
+      'Height': const CosInteger(4),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': CosArray([
+        const CosName('ICCBased'),
+        image({'N': const CosInteger(3)}, const []),
+      ]),
+      'Filter': const CosName('FlateDecode'),
+    }, [
+      120,
+      156,
+      251,
+      207,
+      192,
+      240,
+      159,
+      1,
+      140,
+      255,
+      67,
+      8,
+      6,
+      100,
+      10,
+      2,
+      144,
+      217,
+      0,
+      210,
+      107,
+      23,
+      233,
+    ]);
+
+    expect(decodePdfImagePixelsScaled(cos, stream, 2, 2), isNull);
+  });
+
+  test('scaled ImageMask Flate decodes premultiplied alpha', () {
+    final stream = image({
+      'ImageMask': const CosBoolean(true),
+      'Width': const CosInteger(4),
+      'Height': const CosInteger(1),
+      'BitsPerComponent': const CosInteger(1),
+      'Filter': const CosName('FlateDecode'),
+    }, [
+      120,
+      156,
+      11,
+      0,
+      0,
+      0,
+      81,
+      0,
+      81
+    ]); // bits: 0,1,0,1
+
+    final pixels = decodePdfImagePixelsScaled(cos, stream, 2, 1)!;
+    expect(pixels.width, 2);
+    expect(pixels.height, 1);
+    expect(pixels.rgba, [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+    ]);
+  });
+
+  test('scaled Indexed Flate with stencil mask avoids full RGBA expansion', () {
+    final mask = image({
+      'ImageMask': const CosBoolean(true),
+      'Width': const CosInteger(4),
+      'Height': const CosInteger(1),
+      'BitsPerComponent': const CosInteger(1),
+      'Filter': const CosName('FlateDecode'),
+    }, [
+      120,
+      156,
+      219,
+      0,
+      0,
+      0,
+      177,
+      0,
+      177
+    ]); // bits: 1,0,1,1; default stencil mask makes 1 transparent
+    final stream = image({
+      'Width': const CosInteger(4),
+      'Height': const CosInteger(1),
+      'BitsPerComponent': const CosInteger(1),
+      'ColorSpace': CosArray([
+        const CosName('Indexed'),
+        const CosName('DeviceRGB'),
+        const CosInteger(1),
+        CosString(Uint8List.fromList([0, 0, 0, 255, 0, 0])),
+      ]),
+      'Filter': const CosName('FlateDecode'),
+      'Mask': mask,
+    }, [
+      120,
+      156,
+      11,
+      0,
+      0,
+      0,
+      81,
+      0,
+      81
+    ]); // indices: 0,1,0,1
+
+    final pixels = decodePdfImagePixelsScaled(cos, stream, 2, 1)!;
+    expect(pixels.width, 2);
+    expect(pixels.height, 1);
+    expect(pixels.rgba, [
+      255,
+      0,
+      0,
+      255,
+      0,
+      0,
+      0,
+      0,
+    ]);
+  });
+
   test('decodePdfImageBase returns straight, unmasked, opaque RGBA', () {
     final smask = image({
       'Width': const CosInteger(1),
       'Height': const CosInteger(1),
       'BitsPerComponent': const CosInteger(8),
       'ColorSpace': const CosName('DeviceGray'),
-    }, [0]);
+    }, [
+      0
+    ]);
     final stream = image({
       'Width': const CosInteger(1),
       'Height': const CosInteger(1),
       'BitsPerComponent': const CosInteger(8),
       'ColorSpace': const CosName('DeviceRGB'),
       'SMask': smask,
-    }, [10, 20, 30]);
+    }, [
+      10,
+      20,
+      30
+    ]);
 
     // The base ignores the /SMask (alpha stays 255) — the caller bakes it in.
     final base = decodePdfImageBase(cos, stream)!;

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -276,6 +276,38 @@ void main() {
   // carries pixels that match the pure-Dart decode — and the replay transcript
   // is unchanged (the decode never alters the command shape).
   group('image decode offload', () {
+    test('uses predecoded image request pixels', () {
+      final cos = CosDocument.open(buildClassicPdf());
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(1),
+          'Height': const CosInteger(1),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'Filter': const CosName('DCTDecode'),
+        }),
+        Uint8List.fromList([0xff, 0xd8, 0xff, 0xd9]),
+      );
+      final decoded = PdfDecodedPixels(
+        Uint8List.fromList([11, 22, 33, 255]),
+        1,
+        1,
+      );
+      final command = PdfDrawImageCommand(PdfImageRequest(
+        stream: stream,
+        transform: PdfMatrix.identity,
+        decoded: decoded,
+      ));
+
+      final bytes = serializeCommands([command], cos: cos, decodeImages: true);
+      expect(bytes, isNotNull);
+      final restored = _imageCommands(deserializeCommands(bytes!)).single;
+      expect(restored.request.decoded, isNotNull);
+      expect(restored.request.decoded!.width, 1);
+      expect(restored.request.decoded!.height, 1);
+      expect(restored.request.decoded!.rgba, decoded.rgba);
+    });
+
     final files = <String>[
       '../../test_corpora/ghent/1-CMYK/'
           'GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',


### PR DESCRIPTION
## Summary

Improves heavy PDF first-content and full-render performance for raster-heavy CAD pages.

- Uses SharedArrayBuffer for web worker document bytes when the page is cross-origin isolated, with ArrayBuffer transfer fallback.
- Adds worker-side browser JPEG decode for supported web worker images.
- Adds scaled Flate decode paths so capped worker images avoid full native-size RGBA expansion, including 1-bit Indexed tiles with stencil masks used by the CAD corpus page.
- Reuses warmed low-res previews so full target renders can queue immediately instead of repeating vector-first work.
- Keeps ICCBased images out of the raw scaled fast path so ICC conversion remains correct.

## Performance

Measured with `/Users/ben/repos/dart-pdf/corpus/ly9-far-cad.pdf`, human page 30 / page index 29:

- Main capped decode: `2078 ms`
- This branch capped decode: `250 ms`
- Chrome first visible content: `143 ms via preview`
- Chrome full worker interpret for page 29: about `4985 ms`
- Chrome run used worker-only rendering for the target run: `worker=8 recorded=0 plain=0`

The remaining crisp-render bottleneck is still worker-side Flate inflation/serialization in compiled JS, but the worst capped decode path is now much faster and the browser no longer falls back to UI-thread renders in the measured target run.

## Validation

- `fvm dart test test/image_pixels_test.dart test/render_command_codec_test.dart`
- `fvm flutter test test/render_hold_test.dart test/page_preview_test.dart`
- `fvm dart analyze`
- `CAD_PDF=../../corpus/ly9-far-cad.pdf CAD_SCAN=0 CAD_PAGE=29 CAD_RATIO=2.0 fvm flutter test test/cad_perf_probe_test.dart`
