### PR TITLE
[codex] Optimize deep zoom image region decoding

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -680,6 +680,28 @@ class _PdfPageViewState extends State<PdfPageView> {
     ratio =
         math.min(ratio, _maxDimension / math.max(region.width, region.height));
 
+    final workerPicture =
+        await _detailPictureFromWorker(region, ratio, widget.previewIndex);
+    if (!mounted || generation != _detailGeneration) {
+      workerPicture?.dispose();
+      return;
+    }
+    if (workerPicture != null) {
+      final image =
+          await PdfPageRenderer.rasterizeRegion(workerPicture, region, ratio);
+      workerPicture.dispose();
+      if (!mounted || generation != _detailGeneration) {
+        image.dispose();
+        return;
+      }
+      setState(() {
+        _detailImage?.dispose();
+        _detailImage = image;
+        _detailFraction = fraction;
+      });
+      return;
+    }
+
     // never interpret the page for the first time inline here — that is
     // the scheduler's job (or, bare, the hold's); the next settle
     // refreshes the patch once the base picture lands
@@ -707,6 +729,58 @@ class _PdfPageViewState extends State<PdfPageView> {
       _detailImage = image;
       _detailFraction = fraction;
     });
+  }
+
+  Future<ui.Picture?> _detailPictureFromWorker(
+      Rect rasterRegion, double ratio, int pageIndex) async {
+    final worker = widget.renderWorker;
+    if (worker == null || !worker.isActive) return null;
+    final decodeRegion = _pdfRegionForRasterRegion(rasterRegion);
+    final commands = await worker.record(pageIndex,
+        annotations: widget.showAnnotations,
+        priority: widget.renderPriority,
+        imagePixelRatio: ratio,
+        imageDecodeRegion: decodeRegion);
+    if (_abandoned(pageIndex) || commands == null) return null;
+    _logImageStats(pageIndex, commands);
+    return PdfPageRenderer.pictureFromCommands(widget.page, commands,
+        pageColor: widget.pageColor, rotation: widget.rotation);
+  }
+
+  PdfRect _pdfRegionForRasterRegion(Rect region) {
+    final box = widget.page.cropBox;
+    final rotation =
+        ((widget.rotation ?? widget.page.rotation) % 360 + 360) % 360;
+    final points = <(double, double)>[
+      _pdfPointForRasterPoint(region.left, region.top, box, rotation),
+      _pdfPointForRasterPoint(region.right, region.top, box, rotation),
+      _pdfPointForRasterPoint(region.right, region.bottom, box, rotation),
+      _pdfPointForRasterPoint(region.left, region.bottom, box, rotation),
+    ];
+    var left = points.first.$1;
+    var right = points.first.$1;
+    var bottom = points.first.$2;
+    var top = points.first.$2;
+    for (final p in points.skip(1)) {
+      left = math.min(left, p.$1);
+      right = math.max(right, p.$1);
+      bottom = math.min(bottom, p.$2);
+      top = math.max(top, p.$2);
+    }
+    return PdfRect(left, bottom, right, top);
+  }
+
+  (double, double) _pdfPointForRasterPoint(
+      double x, double y, PdfRect box, int rotation) {
+    final w = box.width;
+    final h = box.height;
+    final (u, v) = switch (rotation) {
+      90 => (y, h - x),
+      180 => (w - x, h - y),
+      270 => (w - y, x),
+      _ => (x, y),
+    };
+    return (box.left + u, box.top - v);
   }
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'render_worker_stub.dart'
@@ -137,12 +138,20 @@ abstract class PdfRenderWorker {
   /// `PdfPageRenderer.pictureFromCommands(includeImages: false)` to paint the
   /// linework immediately, then records again with [decodeImages] true for the
   /// images. Default true (decode in the worker, the normal full render).
+  ///
+  /// [imageDecodeRegion] is a PDF page-space rectangle for a transient
+  /// deep-zoom/detail render. When set with [decodeImages] true, the worker
+  /// may decode only the intersecting source pixels of axis-aligned image
+  /// draws and retarget their transforms to that crop. Full-page cached
+  /// renders must leave this null; a region-specific buffer is only correct
+  /// for rasterizing that same visible slice.
   Future<List<PdfRenderCommand>?> record(int pageIndex,
       {bool annotations = true,
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit});
+      int? commandLimit,
+      PdfRect? imageDecodeRegion});
 
   /// Drops any QUEUED (not yet started) [record] request for [pageIndex] at
   /// [priority], completing its future with null — as if the page had declined
@@ -302,7 +311,8 @@ class PdfPooledRenderWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     final urgent = _urgentWorkerFor(priority);
     if (urgent != null) {
       return urgent.record(pageIndex,
@@ -310,7 +320,8 @@ class PdfPooledRenderWorker implements PdfRenderWorker {
           priority: priority,
           imagePixelRatio: imagePixelRatio,
           decodeImages: decodeImages,
-          commandLimit: commandLimit);
+          commandLimit: commandLimit,
+          imageDecodeRegion: imageDecodeRegion);
     }
     final worker = _lease(pageIndex, priority);
     try {
@@ -319,7 +330,8 @@ class PdfPooledRenderWorker implements PdfRenderWorker {
           priority: priority,
           imagePixelRatio: imagePixelRatio,
           decodeImages: decodeImages,
-          commandLimit: commandLimit);
+          commandLimit: commandLimit,
+          imageDecodeRegion: imageDecodeRegion);
     } finally {
       _release(pageIndex, priority, worker);
     }
@@ -369,9 +381,12 @@ class _PoolRoute {
   int count = 1;
 }
 
+typedef _RecordCacheKey = (int, bool, bool, int, int?, _RegionBucket?);
+
 /// Wraps a [PdfRenderWorker] with an LRU cache of completed [record] results,
 /// keyed by (page, annotations, decodeImages, image-ratio bucket,
-/// command-limit). The lazy
+/// command-limit, image-decode-region when decoded image bytes are present).
+/// The lazy
 /// page list recycles a [PdfPageView]'s State when it scrolls out of view and
 /// re-creates it on the way back, dropping the State's cached picture — so
 /// without this every scroll-back re-asks the worker to decode the page from
@@ -406,10 +421,9 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
 
   // LinkedHashMap iteration order doubles as LRU order: a hit re-inserts to
   // the end, eviction takes the oldest (first) key.
-  final _cache = <(int, bool, bool, int, int?), _CachedRecord>{};
+  final _cache = <_RecordCacheKey, _CachedRecord>{};
   // Keys whose decode is running now, so concurrent requests share one decode.
-  final _inflight =
-      <(int, bool, bool, int, int?), Future<List<PdfRenderCommand>?>>{};
+  final _inflight = <_RecordCacheKey, Future<List<PdfRenderCommand>?>>{};
   int _bytes = 0;
 
   @override
@@ -437,27 +451,34 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) {
     if (!_inner.isActive) {
       return _inner.record(pageIndex,
           annotations: annotations,
           priority: priority,
           imagePixelRatio: imagePixelRatio,
           decodeImages: decodeImages,
-          commandLimit: commandLimit);
+          commandLimit: commandLimit,
+          imageDecodeRegion: imageDecodeRegion);
     }
     final effectiveCommandLimit = decodeImages ? null : commandLimit;
+    final effectiveRegion = decodeImages ? imageDecodeRegion : null;
     final key = (
       pageIndex,
       annotations,
       decodeImages,
       _ratioBucket(imagePixelRatio),
       effectiveCommandLimit,
+      _regionBucket(effectiveRegion),
     );
-    final hit = _cache.remove(key);
+    final hit = _takeCached(key);
     if (hit != null) {
-      _cache[key] = hit; // re-insert: now most-recently used
       return Future.value(hit.commands);
+    }
+    if (key.$6 != null) {
+      final reusable = _takeCachedWeightless(_withoutRegion(key));
+      if (reusable != null) return Future.value(reusable.commands);
     }
     final pending = _inflight[key];
     if (pending != null) return pending; // a decode for this key is running
@@ -465,25 +486,33 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
         annotations: annotations,
         priority: priority,
         imagePixelRatio: imagePixelRatio,
-        decodeImages: decodeImages);
+        decodeImages: decodeImages,
+        imageDecodeRegion: effectiveRegion);
     _inflight[key] = future;
     return future;
   }
 
   Future<List<PdfRenderCommand>?> _recordAndStore(
-      (int, bool, bool, int, int?) key, int pageIndex,
+      _RecordCacheKey key, int pageIndex,
       {required bool annotations,
       required int priority,
       required double? imagePixelRatio,
-      required bool decodeImages}) async {
+      required bool decodeImages,
+      required PdfRect? imageDecodeRegion}) async {
     try {
       final commands = await _inner.record(pageIndex,
           annotations: annotations,
           priority: priority,
           imagePixelRatio: imagePixelRatio,
           decodeImages: decodeImages,
-          commandLimit: key.$5);
-      if (commands != null) _store(key, commands);
+          commandLimit: key.$5,
+          imageDecodeRegion: imageDecodeRegion);
+      if (commands != null) {
+        final weight = _weigh(commands);
+        final storeKey =
+            key.$6 != null && weight == 0 ? _withoutRegion(key) : key;
+        _store(storeKey, commands, weight);
+      }
       return commands;
     } finally {
       _inflight.remove(key);
@@ -502,10 +531,27 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
     _inner.dispose();
   }
 
+  _CachedRecord? _takeCached(_RecordCacheKey key) {
+    final hit = _cache.remove(key);
+    if (hit != null) {
+      _cache[key] = hit; // re-insert: now most-recently used
+    }
+    return hit;
+  }
+
+  _CachedRecord? _takeCachedWeightless(_RecordCacheKey key) {
+    final hit = _cache[key];
+    if (hit == null || hit.weight != 0) return null;
+    _cache.remove(key);
+    _cache[key] = hit; // re-insert: now most-recently used
+    return hit;
+  }
+
   void _store(
-      (int, bool, bool, int, int?) key, List<PdfRenderCommand> commands) {
-    final weight = _weigh(commands);
+      _RecordCacheKey key, List<PdfRenderCommand> commands, int weight) {
     if (weight > _budgetBytes) return; // one page bigger than the cache itself
+    final previous = _cache.remove(key);
+    if (previous != null) _bytes -= previous.weight;
     _cache[key] = _CachedRecord(commands, weight);
     _bytes += weight;
     // Evict the least-recently-used entries that actually hold bytes until
@@ -527,8 +573,7 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
   /// The least-recently-used key whose buffer holds decoded bytes (weight > 0),
   /// other than [except] (the entry just inserted, which we keep). Null when no
   /// such entry exists — every remaining buffer is costless, so eviction stops.
-  (int, bool, bool, int, int?)? _oldestHeavyKey(
-      {required (int, bool, bool, int, int?) except}) {
+  _RecordCacheKey? _oldestHeavyKey({required _RecordCacheKey except}) {
     for (final entry in _cache.entries) {
       if (entry.value.weight > 0 && entry.key != except) return entry.key;
     }
@@ -540,6 +585,12 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
   /// bucket. Null (vector-first pass, no decode) gets its own bucket.
   static int _ratioBucket(double? ratio) =>
       ratio == null ? -1 : (ratio * 8).round();
+
+  static _RegionBucket? _regionBucket(PdfRect? region) =>
+      region == null ? null : _RegionBucket(region);
+
+  static _RecordCacheKey _withoutRegion(_RecordCacheKey key) =>
+      (key.$1, key.$2, key.$3, key.$4, key.$5, null);
 
   /// A buffer's weight ≈ its decoded image bytes (premultiplied RGBA), which
   /// dominate; command objects themselves are negligible. Recurses soft-mask
@@ -566,4 +617,30 @@ class _CachedRecord {
   _CachedRecord(this.commands, this.weight);
   final List<PdfRenderCommand> commands;
   final int weight;
+}
+
+class _RegionBucket {
+  _RegionBucket(PdfRect region)
+      : left = _bucket(region.left),
+        bottom = _bucket(region.bottom),
+        right = _bucket(region.right),
+        top = _bucket(region.top);
+
+  final int left;
+  final int bottom;
+  final int right;
+  final int top;
+
+  static int _bucket(double value) => (value * 4).round();
+
+  @override
+  bool operator ==(Object other) =>
+      other is _RegionBucket &&
+      other.left == left &&
+      other.bottom == bottom &&
+      other.right == right &&
+      other.top == top;
+
+  @override
+  int get hashCode => Object.hash(left, bottom, right, top);
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -98,10 +98,11 @@ class _IsolateRenderWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     if (_disposed || _spawnFailed) return null;
     final request = _PendingRequest(priority, _seq++, pageIndex, annotations,
-        imagePixelRatio, decodeImages, commandLimit);
+        imagePixelRatio, decodeImages, commandLimit, imageDecodeRegion);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -160,6 +161,10 @@ class _IsolateRenderWorker implements PdfRenderWorker {
       request.imagePixelRatio,
       request.decodeImages,
       request.commandLimit,
+      request.imageDecodeRegion?.left,
+      request.imageDecodeRegion?.bottom,
+      request.imageDecodeRegion?.right,
+      request.imageDecodeRegion?.top,
     ]);
   }
 
@@ -203,8 +208,15 @@ class _IsolateRenderWorker implements PdfRenderWorker {
 
 /// One queued record request and its pending result.
 class _PendingRequest {
-  _PendingRequest(this.priority, this.seq, this.pageIndex, this.annotations,
-      this.imagePixelRatio, this.decodeImages, this.commandLimit);
+  _PendingRequest(
+      this.priority,
+      this.seq,
+      this.pageIndex,
+      this.annotations,
+      this.imagePixelRatio,
+      this.decodeImages,
+      this.commandLimit,
+      this.imageDecodeRegion);
 
   final int priority;
   final int seq;
@@ -213,6 +225,7 @@ class _PendingRequest {
   final double? imagePixelRatio;
   final bool decodeImages;
   final int? commandLimit;
+  final PdfRect? imageDecodeRegion;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }
@@ -255,14 +268,29 @@ void _workerMain(_WorkerInit init) {
     final imagePixelRatio = request[3] as double?;
     final decodeImages = request[4] as bool;
     final commandLimit = request.length > 5 ? request[5] as int? : null;
+    final imageDecodeRegion = request.length > 9 &&
+            request[6] != null &&
+            request[7] != null &&
+            request[8] != null &&
+            request[9] != null
+        ? PdfRect(request[6] as double, request[7] as double,
+            request[8] as double, request[9] as double)
+        : null;
 
     final token = PdfCancellationToken();
     activeToken = token;
     Uint8List? buffer;
     try {
       if (document != null) {
-        buffer = await _recordPageAsync(document, pageIndex, annotations,
-            imagePixelRatio, decodeImages, commandLimit, token);
+        buffer = await _recordPageAsync(
+            document,
+            pageIndex,
+            annotations,
+            imagePixelRatio,
+            decodeImages,
+            commandLimit,
+            imageDecodeRegion,
+            token);
       }
     } on PdfCancelledException {
       buffer = null;
@@ -286,6 +314,7 @@ Future<Uint8List?> _recordPageAsync(
     double? imagePixelRatio,
     bool decodeImages,
     int? commandLimit,
+    PdfRect? imageDecodeRegion,
     PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
@@ -301,6 +330,7 @@ Future<Uint8List?> _recordPageAsync(
       cos: document.cos,
       decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio,
+      imageDecodeRegion: imageDecodeRegion,
       imagePlaceholders: !decodeImages,
       commandLimit: commandLimit);
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'render_worker.dart';
@@ -21,7 +22,8 @@ class _NullRenderWorker implements PdfRenderWorker {
           int priority = 0,
           double? imagePixelRatio,
           bool decodeImages = true,
-          int? commandLimit}) async =>
+          int? commandLimit,
+          PdfRect? imageDecodeRegion}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -3,6 +3,7 @@ import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 import 'dart:typed_data';
 
+import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:web/web.dart' as web;
 
@@ -184,14 +185,15 @@ class _WebRenderWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     if (_disposed || _failed) {
       _wlog('record page=$pageIndex skipped (disposed=$_disposed '
           'failed=$_failed) → local');
       return null;
     }
     final request = _WebPending(priority, _seq++, pageIndex, annotations,
-        imagePixelRatio, decodeImages, commandLimit);
+        imagePixelRatio, decodeImages, commandLimit, imageDecodeRegion);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -252,6 +254,14 @@ class _WebRenderWorker implements PdfRenderWorker {
     if (ratio != null) message.setProperty('imageRatio'.toJS, ratio.toJS);
     final limit = request.commandLimit;
     if (limit != null) message.setProperty('commandLimit'.toJS, limit.toJS);
+    final region = request.imageDecodeRegion;
+    if (region != null) {
+      message
+        ..setProperty('regionLeft'.toJS, region.left.toJS)
+        ..setProperty('regionBottom'.toJS, region.bottom.toJS)
+        ..setProperty('regionRight'.toJS, region.right.toJS)
+        ..setProperty('regionTop'.toJS, region.top.toJS);
+    }
     worker.postMessage(message);
 
     // Watchdog: a record that never comes back wedges the single in-flight slot
@@ -346,8 +356,15 @@ class _WebRenderWorker implements PdfRenderWorker {
 /// One queued record request and its pending result (mirrors the isolate
 /// backend's `_PendingRequest`).
 class _WebPending {
-  _WebPending(this.priority, this.seq, this.pageIndex, this.annotations,
-      this.imagePixelRatio, this.decodeImages, this.commandLimit);
+  _WebPending(
+      this.priority,
+      this.seq,
+      this.pageIndex,
+      this.annotations,
+      this.imagePixelRatio,
+      this.decodeImages,
+      this.commandLimit,
+      this.imageDecodeRegion);
 
   final int priority;
   final int seq;
@@ -356,6 +373,7 @@ class _WebPending {
   final double? imagePixelRatio;
   final bool decodeImages;
   final int? commandLimit;
+  final PdfRect? imageDecodeRegion;
   final completer = Completer<Uint8List?>();
   int id = -1;
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -85,6 +85,20 @@ void runPdfRenderWorker() {
         (data.getProperty('decodeImages'.toJS) as JSBoolean?)?.toDart ?? true;
     final commandLimit =
         (data.getProperty('commandLimit'.toJS) as JSNumber?)?.toDartInt;
+    final regionLeft =
+        (data.getProperty('regionLeft'.toJS) as JSNumber?)?.toDartDouble;
+    final regionBottom =
+        (data.getProperty('regionBottom'.toJS) as JSNumber?)?.toDartDouble;
+    final regionRight =
+        (data.getProperty('regionRight'.toJS) as JSNumber?)?.toDartDouble;
+    final regionTop =
+        (data.getProperty('regionTop'.toJS) as JSNumber?)?.toDartDouble;
+    final imageDecodeRegion = regionLeft != null &&
+            regionBottom != null &&
+            regionRight != null &&
+            regionTop != null
+        ? PdfRect(regionLeft, regionBottom, regionRight, regionTop)
+        : null;
 
     final token = PdfCancellationToken();
     activeToken = token;
@@ -98,7 +112,7 @@ void runPdfRenderWorker() {
       try {
         if (doc != null) {
           out = await _recordPageAsync(doc, page, annotations, imagePixelRatio,
-              decodeImages, commandLimit, token);
+              decodeImages, commandLimit, imageDecodeRegion, token);
         }
       } on PdfCancelledException {
         out = null;
@@ -145,6 +159,7 @@ Future<Uint8List?> _recordPageAsync(
     double? imagePixelRatio,
     bool decodeImages,
     int? commandLimit,
+    PdfRect? imageDecodeRegion,
     PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
@@ -172,6 +187,7 @@ Future<Uint8List?> _recordPageAsync(
       cos: document.cos,
       decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio,
+      imageDecodeRegion: imageDecodeRegion,
       imagePlaceholders: !decodeImages,
       commandLimit: commandLimit);
 }

--- a/packages/dart_pdf_editor/test/cad_perf_probe_test.dart
+++ b/packages/dart_pdf_editor/test/cad_perf_probe_test.dart
@@ -16,6 +16,8 @@
 //   CAD_PAGE    0-based page to deep-probe (default: heaviest found by scan)
 //   CAD_RATIO   screen px per point for the cap (default 2.0; ~typical view)
 //   CAD_SCAN    '0' to skip the per-page heavy-page scan (default on)
+//   CAD_REGION  optional PDF-space decode region: left,bottom,right,top.
+//               Defaults to the middle half of the target page.
 //
 // Reports, for the target page: native vs capped decoded megapixels, the
 // shipped command-buffer size (the bytes the worker hands the UI thread),
@@ -115,6 +117,23 @@ void main() {
       _line('capped  decode: ${capSw.elapsedMilliseconds} ms, '
           '${capStats.$1} img, ${_mpStr(capStats.$2)} MP, '
           'buffer ${_mb(capBuf.length)}');
+
+      final decodeRegion = _decodeRegion(page);
+      final regionSw = Stopwatch()..start();
+      final regionBuf = serializeCommands(commands,
+          cos: doc.cos,
+          decodeImages: true,
+          maxImagePixelRatio: ratio,
+          imageDecodeRegion: decodeRegion);
+      regionSw.stop();
+      final regionCmds = deserializeCommands(regionBuf!);
+      final regionStats = PdfPageRenderer.decodedImageStats(regionCmds);
+      final regionShare = capStats.$2 == 0 ? 1.0 : regionStats.$2 / capStats.$2;
+      _line('region  decode: ${regionSw.elapsedMilliseconds} ms, '
+          '${regionStats.$1} img, ${_mpStr(regionStats.$2)} MP, '
+          'buffer ${_mb(regionBuf.length)}, '
+          'region=$decodeRegion '
+          '(${(regionShare * 100).toStringAsFixed(1)}% of capped pixels)');
 
       final shrink = nativeStats.$2 == 0 ? 1.0 : capStats.$2 / nativeStats.$2;
       _line('cap shrank decoded pixels to '
@@ -263,6 +282,23 @@ double _renderRatio(PdfPage page, double desired) {
   final byDim = 8192.0 / (w > h ? w : h);
   if (byDim < r) r = byDim;
   return r < 0.05 ? 0.05 : r;
+}
+
+PdfRect _decodeRegion(PdfPage page) {
+  final raw = Platform.environment['CAD_REGION'];
+  if (raw != null && raw.trim().isNotEmpty) {
+    final parts = raw.split(',').map((s) => double.tryParse(s.trim())).toList();
+    if (parts.length == 4 && parts.every((v) => v != null)) {
+      return PdfRect.normalized(parts[0]!, parts[1]!, parts[2]!, parts[3]!);
+    }
+  }
+  final box = page.cropBox;
+  return PdfRect(
+    box.left + box.width * 0.25,
+    box.bottom + box.height * 0.25,
+    box.left + box.width * 0.75,
+    box.bottom + box.height * 0.75,
+  );
 }
 
 String _mpStr(int pixels) => (pixels / 1e6).toStringAsFixed(1);

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -475,7 +475,8 @@ class _PreviewWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     calls.add((pageIndex, decodeImages, imagePixelRatio));
     final request = PdfImageRequest(
       stream: CosStream(CosDictionary(), Uint8List(0)),
@@ -506,7 +507,8 @@ class _DecliningWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     calls.add((pageIndex, decodeImages, imagePixelRatio));
     return null;
   }
@@ -530,7 +532,8 @@ class _VectorOnlyWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     commandLimits.add(commandLimit);
     return const [PdfSaveCommand(), PdfRestoreCommand()];
   }

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -47,7 +47,8 @@ class _SyncWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     if (_disposed || pageIndex < 0 || pageIndex >= _doc.pageCount) return null;
     final page = _doc.page(pageIndex);
     final previewOperationLimit = decodeImages ? null : commandLimit;
@@ -61,6 +62,7 @@ class _SyncWorker implements PdfRenderWorker {
         cos: _doc.cos,
         decodeImages: decodeImages,
         maxImagePixelRatio: imagePixelRatio,
+        imageDecodeRegion: imageDecodeRegion,
         imagePlaceholders: !decodeImages,
         commandLimit: commandLimit);
     return bytes == null ? null : deserializeCommands(bytes);
@@ -543,6 +545,46 @@ void main() {
       expect(inner.calls.length, 4);
     });
 
+    test('image decode region is part of the full-image cache key', () async {
+      final inner = _CountingWorker(decodedPixels: 64);
+      final worker = PdfCachingRenderWorker(inner);
+      const top = PdfRect(0, 400, 200, 600);
+      const sameBucket = PdfRect(0.01, 400, 200, 600);
+      const bottom = PdfRect(0, 0, 200, 200);
+
+      await worker.record(0, imagePixelRatio: 2.0, imageDecodeRegion: top);
+      await worker.record(0, imagePixelRatio: 2.0, imageDecodeRegion: top);
+      await worker.record(0,
+          imagePixelRatio: 2.0, imageDecodeRegion: sameBucket);
+      expect(inner.calls.length, 1,
+          reason: 'minor region jitter stays in the same cache bucket');
+
+      await worker.record(0, imagePixelRatio: 2.0, imageDecodeRegion: bottom);
+      expect(inner.calls.length, 2,
+          reason: 'a different viewport slice needs its own cropped buffer');
+
+      await worker.record(0,
+          imagePixelRatio: 2.0, decodeImages: false, imageDecodeRegion: bottom);
+      await worker.record(0,
+          imagePixelRatio: 2.0, decodeImages: false, imageDecodeRegion: top);
+      expect(inner.calls.length, 3,
+          reason: 'vector-only buffers ignore region because no images decode');
+    });
+
+    test('weight-0 region buffers reuse the page-wide cache key', () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner);
+      const top = PdfRect(0, 400, 200, 600);
+      const bottom = PdfRect(0, 0, 200, 200);
+
+      await worker.record(0, imagePixelRatio: 2.0, imageDecodeRegion: top);
+      await worker.record(0, imagePixelRatio: 2.0, imageDecodeRegion: bottom);
+      await worker.record(0, imagePixelRatio: 2.0);
+
+      expect(inner.calls.length, 1,
+          reason: 'vector-only pages must not cache duplicate region slices');
+    });
+
     test('a tiny ratio wobble stays in the same bucket', () async {
       final inner = _CountingWorker();
       final worker = PdfCachingRenderWorker(inner);
@@ -771,7 +813,8 @@ class _CountingWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) async {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) async {
     calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
     commandLimits.add(commandLimit);
     if (returnNull || !active) return null;
@@ -819,7 +862,8 @@ class _ManualWorker implements PdfRenderWorker {
       int priority = 0,
       double? imagePixelRatio,
       bool decodeImages = true,
-      int? commandLimit}) {
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) {
     calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
     priorities.add(priority);
     final completer = Completer<List<PdfRenderCommand>?>();

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -184,12 +184,48 @@ PdfDecodedPixels? decodePdfImagePixelsScaled(
   final dict = stream.dictionary;
   final width = _intOf(cos.resolve(dict['Width']));
   final height = _intOf(cos.resolve(dict['Height']));
+  return decodePdfImagePixelsRegionScaled(
+      cos, stream, 0, 0, width, height, targetWidth, targetHeight,
+      wholeImageOnlyIfDownscaled: true);
+}
+
+/// Decodes a rectangular source-region of a simple Flate/raw image directly to
+/// [targetWidth]×[targetHeight], or returns null when the stream needs the full
+/// general decoder.
+///
+/// [sourceX], [sourceY], [sourceWidth], and [sourceHeight] are native image
+/// pixels in the same top-left origin as decoded image samples. Unlike
+/// [decodePdfImagePixelsScaled], this may return a result even when
+/// [targetWidth]×[targetHeight] is the same size as the requested region: the
+/// crop itself is the saving. Used by deep-zoom worker detail renders, where a
+/// visible page slice should not ship the whole raster underlay.
+PdfDecodedPixels? decodePdfImagePixelsRegionScaled(
+  CosDocument cos,
+  CosStream stream,
+  int sourceX,
+  int sourceY,
+  int sourceWidth,
+  int sourceHeight,
+  int targetWidth,
+  int targetHeight, {
+  bool wholeImageOnlyIfDownscaled = false,
+}) {
+  final dict = stream.dictionary;
+  final width = _intOf(cos.resolve(dict['Width']));
+  final height = _intOf(cos.resolve(dict['Height']));
   if (width <= 0 || height <= 0 || targetWidth <= 0 || targetHeight <= 0) {
     return null;
   }
-  var tw = targetWidth.clamp(1, width);
-  var th = targetHeight.clamp(1, height);
-  if (tw >= width && th >= height) return null;
+  final sx = sourceX.clamp(0, width - 1);
+  final sy = sourceY.clamp(0, height - 1);
+  final sw = sourceWidth.clamp(1, width - sx);
+  final sh = sourceHeight.clamp(1, height - sy);
+  var tw = targetWidth.clamp(1, sw);
+  var th = targetHeight.clamp(1, sh);
+  final wholeImage = sx == 0 && sy == 0 && sw == width && sh == height;
+  if (wholeImage && wholeImageOnlyIfDownscaled && tw >= width && th >= height) {
+    return null;
+  }
 
   final filters = pdfImageFilters(cos, dict);
   if (filters.length != 1 ||
@@ -202,14 +238,17 @@ PdfDecodedPixels? decodePdfImagePixelsScaled(
   if (!isMask && dict.containsKey('SMask')) return null;
 
   final data = cos.decodeStreamData(stream);
-  if (isMask) return _scaledImageMask(cos, dict, data, width, height, tw, th);
+  if (isMask) {
+    return _scaledImageMaskRegion(
+        cos, dict, data, width, height, sx, sy, sw, sh, tw, th);
+  }
 
   final bits = _intOf(cos.resolve(dict['BitsPerComponent']), fallback: 8);
   final space = pdfImageColorFamily(cos, dict);
   if (space == 'Indexed' && bits == 1) {
     if (mask is! CosNull && mask is! CosStream) return null;
-    return _scaledIndexed1(cos, dict, data, width, height, tw, th,
-        mask is CosStream ? mask : null);
+    return _scaledIndexed1Region(cos, dict, data, width, height, sx, sy, sw, sh,
+        tw, th, mask is CosStream ? mask : null);
   }
   if (mask is! CosNull) return null;
   if (bits != 8) return null;
@@ -223,8 +262,8 @@ PdfDecodedPixels? decodePdfImagePixelsScaled(
   if (pdfImageDecodeRanges(cos, dict, components) != null) return null;
 
   return switch (components) {
-    3 => _scaledRgb8(data, width, height, tw, th),
-    1 => _scaledGray8(data, width, height, tw, th),
+    3 => _scaledRgb8Region(data, width, height, sx, sy, sw, sh, tw, th),
+    1 => _scaledGray8Region(data, width, height, sx, sy, sw, sh, tw, th),
     _ => null,
   };
 }
@@ -305,18 +344,29 @@ PdfDecodedPixels downsamplePdfDecodedPixels(
   return PdfDecodedPixels(dst, tw, th);
 }
 
-PdfDecodedPixels? _scaledRgb8(
-    Uint8List data, int width, int height, int targetWidth, int targetHeight) {
+PdfDecodedPixels? _scaledRgb8Region(
+  Uint8List data,
+  int width,
+  int height,
+  int sourceX,
+  int sourceY,
+  int sourceWidth,
+  int sourceHeight,
+  int targetWidth,
+  int targetHeight,
+) {
   if (data.length < width * height * 3) return null;
   final out = Uint8List(targetWidth * targetHeight * 4);
   var di = 0;
   for (var y = 0; y < targetHeight; y++) {
-    final sy = _sourceCoord(y, height, targetHeight);
+    final sy =
+        _sourceCoordInRegion(y, sourceY, sourceHeight, height, targetHeight);
     final y0 = sy.$1;
     final y1 = sy.$2;
     final wy = sy.$3;
     for (var x = 0; x < targetWidth; x++) {
-      final sx = _sourceCoord(x, width, targetWidth);
+      final sx =
+          _sourceCoordInRegion(x, sourceX, sourceWidth, width, targetWidth);
       final x0 = sx.$1;
       final x1 = sx.$2;
       final wx = sx.$3;
@@ -337,18 +387,29 @@ PdfDecodedPixels? _scaledRgb8(
   return PdfDecodedPixels(out, targetWidth, targetHeight);
 }
 
-PdfDecodedPixels? _scaledGray8(
-    Uint8List data, int width, int height, int targetWidth, int targetHeight) {
+PdfDecodedPixels? _scaledGray8Region(
+  Uint8List data,
+  int width,
+  int height,
+  int sourceX,
+  int sourceY,
+  int sourceWidth,
+  int sourceHeight,
+  int targetWidth,
+  int targetHeight,
+) {
   if (data.length < width * height) return null;
   final out = Uint8List(targetWidth * targetHeight * 4);
   var di = 0;
   for (var y = 0; y < targetHeight; y++) {
-    final sy = _sourceCoord(y, height, targetHeight);
+    final sy =
+        _sourceCoordInRegion(y, sourceY, sourceHeight, height, targetHeight);
     final y0 = sy.$1;
     final y1 = sy.$2;
     final wy = sy.$3;
     for (var x = 0; x < targetWidth; x++) {
-      final sx = _sourceCoord(x, width, targetWidth);
+      final sx =
+          _sourceCoordInRegion(x, sourceX, sourceWidth, width, targetWidth);
       final x0 = sx.$1;
       final x1 = sx.$2;
       final wx = sx.$3;
@@ -362,12 +423,16 @@ PdfDecodedPixels? _scaledGray8(
   return PdfDecodedPixels(out, targetWidth, targetHeight);
 }
 
-PdfDecodedPixels? _scaledIndexed1(
+PdfDecodedPixels? _scaledIndexed1Region(
   CosDocument cos,
   CosDictionary dict,
   Uint8List data,
   int width,
   int height,
+  int sourceX,
+  int sourceY,
+  int sourceWidth,
+  int sourceHeight,
   int targetWidth,
   int targetHeight,
   CosStream? mask,
@@ -403,10 +468,14 @@ PdfDecodedPixels? _scaledIndexed1(
   final out = Uint8List(targetWidth * targetHeight * 4);
   var di = 0;
   for (var y = 0; y < targetHeight; y++) {
-    final sy = ((y + 0.5) * height / targetHeight).floor().clamp(0, height - 1);
+    final sy = (sourceY + (y + 0.5) * sourceHeight / targetHeight)
+        .floor()
+        .clamp(0, height - 1);
     final row = sy * rowBytes;
     for (var x = 0; x < targetWidth; x++) {
-      final sx = ((x + 0.5) * width / targetWidth).floor().clamp(0, width - 1);
+      final sx = (sourceX + (x + 0.5) * sourceWidth / targetWidth)
+          .floor()
+          .clamp(0, width - 1);
       final bit = (data[row + (sx >> 3)] >> (7 - (sx & 7))) & 1;
       final index = bit >= paletteCount ? 0 : bit;
 
@@ -428,8 +497,19 @@ PdfDecodedPixels? _scaledIndexed1(
   return PdfDecodedPixels(out, targetWidth, targetHeight);
 }
 
-PdfDecodedPixels? _scaledImageMask(CosDocument cos, CosDictionary dict,
-    Uint8List data, int width, int height, int targetWidth, int targetHeight) {
+PdfDecodedPixels? _scaledImageMaskRegion(
+  CosDocument cos,
+  CosDictionary dict,
+  Uint8List data,
+  int width,
+  int height,
+  int sourceX,
+  int sourceY,
+  int sourceWidth,
+  int sourceHeight,
+  int targetWidth,
+  int targetHeight,
+) {
   final rowBytes = (width + 7) ~/ 8;
   if (data.length < rowBytes * height) return null;
   final decode = cos.resolve(dict['Decode']);
@@ -439,9 +519,13 @@ PdfDecodedPixels? _scaledImageMask(CosDocument cos, CosDictionary dict,
   final out = Uint8List(targetWidth * targetHeight * 4);
   var di = 0;
   for (var y = 0; y < targetHeight; y++) {
-    final sy = ((y + 0.5) * height / targetHeight).floor().clamp(0, height - 1);
+    final sy = (sourceY + (y + 0.5) * sourceHeight / targetHeight)
+        .floor()
+        .clamp(0, height - 1);
     for (var x = 0; x < targetWidth; x++) {
-      final sx = ((x + 0.5) * width / targetWidth).floor().clamp(0, width - 1);
+      final sx = (sourceX + (x + 0.5) * sourceWidth / targetWidth)
+          .floor()
+          .clamp(0, width - 1);
       final bit = (data[sy * rowBytes + (sx >> 3)] >> (7 - (sx & 7))) & 1;
       final paint = inverted ? bit == 1 : bit == 0;
       final v = paint ? 255 : 0;
@@ -453,10 +537,16 @@ PdfDecodedPixels? _scaledImageMask(CosDocument cos, CosDictionary dict,
   return PdfDecodedPixels(out, targetWidth, targetHeight);
 }
 
-(int, int, double) _sourceCoord(int dst, int srcSize, int dstSize) {
-  final p = (dst + 0.5) * srcSize / dstSize - 0.5;
-  final i0 = p.floor().clamp(0, srcSize - 1);
-  final i1 = (i0 + 1).clamp(0, srcSize - 1);
+(int, int, double) _sourceCoordInRegion(
+  int dst,
+  int sourceStart,
+  int sourceSize,
+  int fullSize,
+  int dstSize,
+) {
+  final p = sourceStart + (dst + 0.5) * sourceSize / dstSize - 0.5;
+  final i0 = p.floor().clamp(0, fullSize - 1);
+  final i1 = (i0 + 1).clamp(0, fullSize - 1);
   return (i0, i1, p - i0);
 }
 

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -97,10 +97,14 @@ class _UnserializableImage implements Exception {
 /// 100+ megapixels, which is what otherwise blocks the (single-threaded, on
 /// web) raster thread for hundreds of milliseconds every time a settled scroll
 /// re-rasters the page. Null leaves images at native resolution (the historic
-/// behavior). Only consulted when [decodeImages] is true. The deep-zoom detail
-/// patch re-rasters the visible region from the same picture, so under deep
-/// zoom an image softens at this cap rather than re-decoding sharper — the
-/// accepted trade for smooth panning of image-heavy sheets.
+/// behavior). Only consulted when [decodeImages] is true.
+///
+/// [imageDecodeRegion], when supplied, is a PDF page-space rectangle for the
+/// visible detail patch. Axis-aligned image draws are decoded only for the
+/// intersecting source pixels and their image transform is retargeted to the
+/// cropped page area; unsupported transforms fall back to the full scaled
+/// decode. The total decoded-image budget is also reduced to the region's own
+/// raster footprint, rather than the full-page raster budget.
 /// The page raster never exceeds this many pixels (the viewer's full-page
 /// raster cap), so it is also the natural unit for the page image budget.
 const int _maxImagePixels = 1 << 24;
@@ -116,10 +120,28 @@ const int _maxImagePixels = 1 << 24;
 /// cost of a bigger payload.
 const double _imageBudgetFactor = 1.0;
 
+int _imageBudgetPixels(double ratio, double factor,
+    {PdfRect? imageDecodeRegion}) {
+  var budget = (factor * _maxImagePixels).round();
+  if (imageDecodeRegion != null &&
+      imageDecodeRegion.width > 0 &&
+      imageDecodeRegion.height > 0 &&
+      ratio > 0) {
+    final regionPixels =
+        (imageDecodeRegion.width * imageDecodeRegion.height * ratio * ratio)
+            .round();
+    if (regionPixels > 0 && regionPixels < budget) {
+      budget = (factor * regionPixels).round().clamp(1, budget);
+    }
+  }
+  return budget;
+}
+
 Uint8List? serializeCommands(List<PdfRenderCommand> commands,
     {CosDocument? cos,
     bool decodeImages = false,
     double? maxImagePixelRatio,
+    PdfRect? imageDecodeRegion,
     double imageBudgetFactor = _imageBudgetFactor,
     bool imagePlaceholders = false,
     int? commandLimit}) {
@@ -131,13 +153,19 @@ Uint8List? serializeCommands(List<PdfRenderCommand> commands,
   // overflow the budget.
   var budgetScale = 1.0;
   if (decodeImages && maxImagePixelRatio != null && cos != null) {
-    budgetScale = _imageBudgetScale(commands, cos, maxImagePixelRatio,
-        (imageBudgetFactor * _maxImagePixels).round());
+    budgetScale = _imageBudgetScale(
+        commands,
+        cos,
+        maxImagePixelRatio,
+        _imageBudgetPixels(maxImagePixelRatio, imageBudgetFactor,
+            imageDecodeRegion: imageDecodeRegion),
+        imageDecodeRegion: imageDecodeRegion);
   }
   try {
     _writeCommands(w, commands, cos,
         decode: decodeImages,
         maxImageRatio: maxImagePixelRatio,
+        imageDecodeRegion: imageDecodeRegion,
         budgetScale: budgetScale,
         imagePlaceholders: imagePlaceholders && !decodeImages,
         commandLimit: commandLimit);
@@ -155,19 +183,27 @@ Uint8List? serializeCommands(List<PdfRenderCommand> commands,
 /// conservative when those are mixed in — acceptable, and they are rare on the
 /// raster-tiled sheets this targets.
 double _imageBudgetScale(List<PdfRenderCommand> commands, CosDocument cos,
-    double ratio, int budgetPixels) {
+    double ratio, int budgetPixels,
+    {PdfRect? imageDecodeRegion}) {
   var total = 0;
   void walk(List<PdfRenderCommand> cmds) {
     for (final c in cmds) {
       if (c is PdfDrawImageCommand) {
-        final size = _declaredImageSize(cos, c.request.stream);
-        if (size == null) continue;
-        final t = c.request.transform;
-        final wPts = math.sqrt(t.a * t.a + t.b * t.b);
-        final hPts = math.sqrt(t.c * t.c + t.d * t.d);
-        final (tw, th) =
-            cappedImagePixelSize(size.$1, size.$2, wPts, hPts, ratio);
-        total += tw * th;
+        final regionPlan = imageDecodeRegion == null
+            ? null
+            : _imageRegionPlan(cos, c.request, imageDecodeRegion, ratio, 1);
+        if (regionPlan != null) {
+          total += regionPlan.targetWidth * regionPlan.targetHeight;
+        } else {
+          final size = _declaredImageSize(cos, c.request.stream);
+          if (size == null) continue;
+          final t = c.request.transform;
+          final wPts = math.sqrt(t.a * t.a + t.b * t.b);
+          final hPts = math.sqrt(t.c * t.c + t.d * t.d);
+          final (tw, th) =
+              cappedImagePixelSize(size.$1, size.$2, wPts, hPts, ratio);
+          total += tw * th;
+        }
       } else if (c is PdfEndSoftMaskedCommand) {
         walk(c.maskCommands);
       }
@@ -233,6 +269,7 @@ void _writeCommands(
     _Writer w, List<PdfRenderCommand> commands, CosDocument? cos,
     {bool decode = false,
     double? maxImageRatio,
+    PdfRect? imageDecodeRegion,
     double budgetScale = 1.0,
     bool imagePlaceholders = false,
     int? commandLimit}) {
@@ -245,6 +282,7 @@ void _writeCommands(
     _writeCommand(w, command, cos,
         decode: decode,
         maxImageRatio: maxImageRatio,
+        imageDecodeRegion: imageDecodeRegion,
         budgetScale: budgetScale,
         imagePlaceholders: imagePlaceholders);
   }
@@ -262,6 +300,7 @@ List<PdfRenderCommand> _readCommands(_Reader r) {
 void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
     {bool decode = false,
     double? maxImageRatio,
+    PdfRect? imageDecodeRegion,
     double budgetScale = 1.0,
     bool imagePlaceholders = false}) {
   switch (command) {
@@ -324,21 +363,21 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
         _writeImageCommand(w, request, _imagePlaceholderStream, null);
       } else {
         final document = cos;
+        _CommandImage? decodedImage;
+        if (decode) {
+          decodedImage = _decodeImageForCommand(
+              document, request, maxImageRatio, budgetScale, imageDecodeRegion);
+        }
         CosObject inlined;
         try {
-          inlined = _inlineCos(document, request.stream, 0);
+          inlined = decodedImage?.streamForKey ??
+              _inlineCos(document, request.stream, 0);
         } catch (_) {
           if (!imagePlaceholders) throw const _UnserializableImage();
           inlined = _imagePlaceholderStream;
         }
-        _writeImageCommand(
-            w,
-            request,
-            inlined,
-            decode
-                ? _decodeImageForCommand(
-                    document, request, maxImageRatio, budgetScale)
-                : null);
+        _writeImageCommand(w, decodedImage?.request ?? request, inlined,
+            decodedImage?.decoded);
       }
     case PdfSetBlendModeCommand(:final mode):
       w.u8(_tSetBlendMode);
@@ -368,23 +407,60 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
       _writeCommands(w, maskCommands, cos,
           decode: decode,
           maxImageRatio: maxImageRatio,
+          imageDecodeRegion: imageDecodeRegion,
           budgetScale: budgetScale,
           imagePlaceholders: imagePlaceholders); // nested
   }
 }
 
-PdfDecodedPixels? _decodeImageForCommand(
+_CommandImage? _decodeImageForCommand(
   CosDocument document,
   PdfImageRequest request,
   double? maxImageRatio,
   double budgetScale,
+  PdfRect? imageDecodeRegion,
 ) {
   final predecoded = request.decoded;
+  final regionPlan = imageDecodeRegion == null
+      ? null
+      : _imageRegionPlan(
+          document, request, imageDecodeRegion, maxImageRatio, budgetScale);
+  if (regionPlan != null) {
+    final decoded = regionPlan.outside
+        ? _transparentPixel
+        : predecoded == null
+            ? decodePdfImagePixelsRegionScaled(
+                document,
+                request.stream,
+                regionPlan.sourceX,
+                regionPlan.sourceY,
+                regionPlan.sourceWidth,
+                regionPlan.sourceHeight,
+                regionPlan.targetWidth,
+                regionPlan.targetHeight,
+              )
+            : _cropDownsampleDecodedPixels(
+                predecoded,
+                regionPlan.sourceX,
+                regionPlan.sourceY,
+                regionPlan.sourceWidth,
+                regionPlan.sourceHeight,
+                regionPlan.targetWidth,
+                regionPlan.targetHeight,
+              );
+    if (decoded != null) {
+      final croppedRequest = _copyImageRequest(request,
+          transform: regionPlan.transform, decoded: decoded);
+      return _CommandImage(croppedRequest, decoded,
+          _regionKeyStream(request, regionPlan, decoded));
+    }
+  }
   if (predecoded != null) {
-    return maxImageRatio == null
+    final decoded = maxImageRatio == null
         ? predecoded
         : _capImageResolution(
             predecoded, request.transform, maxImageRatio, budgetScale);
+    return _CommandImage(_copyImageRequest(request, decoded: decoded), decoded);
   }
   if (maxImageRatio != null) {
     final target =
@@ -392,13 +468,19 @@ PdfDecodedPixels? _decodeImageForCommand(
     if (target != null) {
       final scaled = decodePdfImagePixelsScaled(
           document, request.stream, target.$1, target.$2);
-      if (scaled != null) return scaled;
+      if (scaled != null) {
+        return _CommandImage(
+            _copyImageRequest(request, decoded: scaled), scaled);
+      }
     }
   }
   final decoded = decodePdfImagePixels(document, request.stream);
-  if (decoded == null || maxImageRatio == null) return decoded;
-  return _capImageResolution(
-      decoded, request.transform, maxImageRatio, budgetScale);
+  if (decoded == null) return null;
+  final capped = maxImageRatio == null
+      ? decoded
+      : _capImageResolution(
+          decoded, request.transform, maxImageRatio, budgetScale);
+  return _CommandImage(_copyImageRequest(request, decoded: capped), capped);
 }
 
 (int, int)? _targetDecodedSize(
@@ -424,6 +506,214 @@ PdfDecodedPixels? _decodeImageForCommand(
   }
   if (tw == size.$1 && th == size.$2) return null;
   return (tw, th);
+}
+
+class _CommandImage {
+  const _CommandImage(this.request, this.decoded, [this.streamForKey]);
+
+  final PdfImageRequest request;
+  final PdfDecodedPixels decoded;
+  final CosStream? streamForKey;
+}
+
+class _ImageRegionPlan {
+  const _ImageRegionPlan({
+    required this.transform,
+    required this.sourceX,
+    required this.sourceY,
+    required this.sourceWidth,
+    required this.sourceHeight,
+    required this.targetWidth,
+    required this.targetHeight,
+    this.outside = false,
+  });
+
+  final PdfMatrix transform;
+  final int sourceX;
+  final int sourceY;
+  final int sourceWidth;
+  final int sourceHeight;
+  final int targetWidth;
+  final int targetHeight;
+  final bool outside;
+}
+
+final PdfDecodedPixels _transparentPixel =
+    PdfDecodedPixels(Uint8List.fromList([0, 0, 0, 0]), 1, 1);
+
+_ImageRegionPlan? _imageRegionPlan(
+  CosDocument document,
+  PdfImageRequest request,
+  PdfRect region,
+  double? ratio,
+  double budgetScale,
+) {
+  final size = _declaredImageSize(document, request.stream);
+  if (size == null) return null;
+  final imageWidth = size.$1;
+  final imageHeight = size.$2;
+  final t = request.transform;
+  const eps = 1e-9;
+  if (t.a.abs() <= eps ||
+      t.d.abs() <= eps ||
+      t.b.abs() > eps ||
+      t.c.abs() > eps) {
+    return null;
+  }
+
+  final imageLeft = math.min(t.e, t.e + t.a);
+  final imageRight = math.max(t.e, t.e + t.a);
+  final imageBottom = math.min(t.f, t.f + t.d);
+  final imageTop = math.max(t.f, t.f + t.d);
+  final visible =
+      PdfRect(imageLeft, imageBottom, imageRight, imageTop).intersect(region);
+  if (visible.width <= eps || visible.height <= eps) {
+    return _ImageRegionPlan(
+      transform: t,
+      sourceX: 0,
+      sourceY: 0,
+      sourceWidth: 1,
+      sourceHeight: 1,
+      targetWidth: 1,
+      targetHeight: 1,
+      outside: true,
+    );
+  }
+
+  final u0 = ((visible.left - t.e) / t.a).clamp(0.0, 1.0);
+  final u1 = ((visible.right - t.e) / t.a).clamp(0.0, 1.0);
+  final v0 = ((visible.bottom - t.f) / t.d).clamp(0.0, 1.0);
+  final v1 = ((visible.top - t.f) / t.d).clamp(0.0, 1.0);
+  final uMin = math.min(u0, u1);
+  final uMax = math.max(u0, u1);
+  final vMin = math.min(v0, v1);
+  final vMax = math.max(v0, v1);
+  if (uMax <= uMin || vMax <= vMin) return null;
+
+  final sx0 = (uMin * imageWidth).floor().clamp(0, imageWidth - 1);
+  final sx1 = (uMax * imageWidth).ceil().clamp(sx0 + 1, imageWidth);
+  // PDF image space is y-up; decoded samples are top-down. The visible v-range
+  // therefore maps to source rows [1-vMax, 1-vMin).
+  final sy0 = ((1 - vMax) * imageHeight).floor().clamp(0, imageHeight - 1);
+  final sy1 = ((1 - vMin) * imageHeight).ceil().clamp(sy0 + 1, imageHeight);
+  final sourceWidth = sx1 - sx0;
+  final sourceHeight = sy1 - sy0;
+  final unitX = sx0 / imageWidth;
+  final unitY = 1 - sy1 / imageHeight;
+  final unitWidth = sourceWidth / imageWidth;
+  final unitHeight = sourceHeight / imageHeight;
+  final croppedTransform =
+      PdfMatrix(unitWidth, 0, 0, unitHeight, unitX, unitY).concat(t);
+
+  var targetWidth = sourceWidth;
+  var targetHeight = sourceHeight;
+  if (ratio != null) {
+    final widthPts = math.sqrt(croppedTransform.a * croppedTransform.a +
+        croppedTransform.b * croppedTransform.b);
+    final heightPts = math.sqrt(croppedTransform.c * croppedTransform.c +
+        croppedTransform.d * croppedTransform.d);
+    final capped = cappedImagePixelSize(
+        sourceWidth, sourceHeight, widthPts, heightPts, ratio);
+    targetWidth = capped.$1;
+    targetHeight = capped.$2;
+    if (budgetScale < 1.0) {
+      targetWidth = (targetWidth * budgetScale).ceil().clamp(1, sourceWidth);
+      targetHeight = (targetHeight * budgetScale).ceil().clamp(1, sourceHeight);
+    }
+  }
+  return _ImageRegionPlan(
+    transform: croppedTransform,
+    sourceX: sx0,
+    sourceY: sy0,
+    sourceWidth: sourceWidth,
+    sourceHeight: sourceHeight,
+    targetWidth: targetWidth,
+    targetHeight: targetHeight,
+  );
+}
+
+PdfImageRequest _copyImageRequest(
+  PdfImageRequest request, {
+  PdfMatrix? transform,
+  PdfDecodedPixels? decoded,
+}) =>
+    PdfImageRequest(
+      stream: request.stream,
+      transform: transform ?? request.transform,
+      alpha: request.alpha,
+      isStencil: request.isStencil,
+      stencilColor: request.stencilColor,
+      isInline: request.isInline,
+      decoded: decoded ?? request.decoded,
+    );
+
+PdfDecodedPixels? _cropDownsampleDecodedPixels(
+  PdfDecodedPixels decoded,
+  int sourceX,
+  int sourceY,
+  int sourceWidth,
+  int sourceHeight,
+  int targetWidth,
+  int targetHeight,
+) {
+  if (sourceX < 0 ||
+      sourceY < 0 ||
+      sourceWidth <= 0 ||
+      sourceHeight <= 0 ||
+      sourceX + sourceWidth > decoded.width ||
+      sourceY + sourceHeight > decoded.height) {
+    return null;
+  }
+  final cropped = Uint8List(sourceWidth * sourceHeight * 4);
+  for (var y = 0; y < sourceHeight; y++) {
+    final srcOffset = ((sourceY + y) * decoded.width + sourceX) * 4;
+    final dstOffset = y * sourceWidth * 4;
+    cropped.setRange(
+        dstOffset, dstOffset + sourceWidth * 4, decoded.rgba, srcOffset);
+  }
+  final pixels = PdfDecodedPixels(cropped, sourceWidth, sourceHeight);
+  return downsamplePdfDecodedPixels(pixels, targetWidth, targetHeight);
+}
+
+CosStream _regionKeyStream(
+  PdfImageRequest request,
+  _ImageRegionPlan plan,
+  PdfDecodedPixels decoded,
+) {
+  final key = [
+    'region-v1',
+    _streamFingerprint(request.stream),
+    plan.sourceX,
+    plan.sourceY,
+    plan.sourceWidth,
+    plan.sourceHeight,
+    decoded.width,
+    decoded.height,
+    plan.transform.a,
+    plan.transform.b,
+    plan.transform.c,
+    plan.transform.d,
+    plan.transform.e,
+    plan.transform.f,
+    plan.outside,
+  ].join('|');
+  return CosStream(
+    CosDictionary({
+      'DartPdfRegionKey': CosString(Uint8List.fromList(utf8.encode(key))),
+    }),
+    Uint8List(0),
+  );
+}
+
+String _streamFingerprint(CosStream stream) {
+  var hash = 0x811c9dc5;
+  const prime = 0x01000193;
+  final bytes = stream.rawBytes;
+  for (final b in bytes) {
+    hash ^= b;
+    hash = (hash * prime) & 0xffffffff;
+  }
+  return '${stream.dictionary}|${bytes.length}|$hash';
 }
 
 void _writeImageCommand(_Writer w, PdfImageRequest request, CosObject inlined,

--- a/packages/pdf_graphics/test/image_pixels_test.dart
+++ b/packages/pdf_graphics/test/image_pixels_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
@@ -15,6 +16,9 @@ void main() {
 
   CosStream image(Map<String, CosObject> dict, List<int> data) =>
       CosStream(CosDictionary(dict), Uint8List.fromList(data));
+
+  CosStream flateImage(Map<String, CosObject> dict, List<int> data) => image(
+      {...dict, 'Filter': const CosName('FlateDecode')}, zlib.encode(data));
 
   test('DeviceRGB 8-bit decodes opaque, straight through', () {
     final stream = image({
@@ -190,6 +194,80 @@ void main() {
       255,
       255,
       255,
+      255,
+    ]);
+  });
+
+  test('region-scaled DeviceRGB Flate decodes only the requested crop', () {
+    final raw = <int>[];
+    for (var y = 0; y < 4; y++) {
+      for (var x = 0; x < 4; x++) {
+        raw.addAll([x * 40, y * 50, 7]);
+      }
+    }
+    final stream = flateImage({
+      'Width': const CosInteger(4),
+      'Height': const CosInteger(4),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': const CosName('DeviceRGB'),
+    }, raw);
+
+    final pixels =
+        decodePdfImagePixelsRegionScaled(cos, stream, 1, 1, 2, 2, 2, 2)!;
+    expect(pixels.width, 2);
+    expect(pixels.height, 2);
+    expect(pixels.rgba, [
+      40,
+      50,
+      7,
+      255,
+      80,
+      50,
+      7,
+      255,
+      40,
+      100,
+      7,
+      255,
+      80,
+      100,
+      7,
+      255,
+    ]);
+  });
+
+  test('region-scaled DeviceGray Flate preserves top-down source rows', () {
+    final stream = flateImage({
+      'Width': const CosInteger(3),
+      'Height': const CosInteger(3),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': const CosName('DeviceGray'),
+    }, [
+      10,
+      11,
+      12,
+      20,
+      21,
+      22,
+      30,
+      31,
+      32,
+    ]);
+
+    final pixels =
+        decodePdfImagePixelsRegionScaled(cos, stream, 1, 0, 1, 3, 1, 3)!;
+    expect(pixels.rgba, [
+      11,
+      11,
+      11,
+      255,
+      21,
+      21,
+      21,
+      255,
+      31,
+      31,
+      31,
       255,
     ]);
   });

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -308,6 +308,84 @@ void main() {
       expect(restored.request.decoded!.rgba, decoded.rgba);
     });
 
+    test('imageDecodeRegion crops pixels and retargets the image transform',
+        () {
+      final cos = CosDocument.open(buildClassicPdf());
+      final raw = <int>[];
+      for (var y = 0; y < 4; y++) {
+        for (var x = 0; x < 4; x++) {
+          raw.addAll([x * 40, y * 50, 7]);
+        }
+      }
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(4),
+          'Height': const CosInteger(4),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'Filter': const CosName('FlateDecode'),
+        }),
+        Uint8List.fromList(zlib.encode(raw)),
+      );
+      final command = PdfDrawImageCommand(PdfImageRequest(
+        stream: stream,
+        transform: const PdfMatrix(400, 0, 0, 400, 100, 200),
+      ));
+
+      final bytes = serializeCommands([command],
+          cos: cos,
+          decodeImages: true,
+          maxImagePixelRatio: 100,
+          imageDecodeRegion: const PdfRect(200, 300, 300, 400));
+
+      expect(bytes, isNotNull);
+      final restored = _imageCommands(deserializeCommands(bytes!)).single;
+      final transform = restored.request.transform;
+      expect(transform.a, 100);
+      expect(transform.b, 0);
+      expect(transform.c, 0);
+      expect(transform.d, 100);
+      expect(transform.e, 200);
+      expect(transform.f, 300);
+
+      final decoded = restored.request.decoded!;
+      expect(decoded.width, 1);
+      expect(decoded.height, 1);
+      expect(decoded.rgba, [40, 100, 7, 255]);
+    });
+
+    test('imageDecodeRegion skips off-region images with transparent pixels',
+        () {
+      final cos = CosDocument.open(buildClassicPdf());
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(1),
+          'Height': const CosInteger(1),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'Filter': const CosName('FlateDecode'),
+        }),
+        Uint8List.fromList(zlib.encode([255, 0, 0])),
+      );
+      final command = PdfDrawImageCommand(PdfImageRequest(
+        stream: stream,
+        transform: const PdfMatrix(10, 0, 0, 10, 0, 0),
+      ));
+
+      final bytes = serializeCommands([command],
+          cos: cos,
+          decodeImages: true,
+          maxImagePixelRatio: 1,
+          imageDecodeRegion: const PdfRect(100, 100, 110, 110));
+
+      expect(bytes, isNotNull);
+      final decoded =
+          _imageCommands(deserializeCommands(bytes!)).single.request.decoded!;
+      expect(decoded.width, 1);
+      expect(decoded.height, 1);
+      expect(decoded.rgba, [0, 0, 0, 0]);
+    });
+
     final files = <String>[
       '../../test_corpora/ghent/1-CMYK/'
           'GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',


### PR DESCRIPTION
Addresses #181.

## Summary
- Threads `imageDecodeRegion` through the render worker APIs, isolate worker, web worker, and `PdfPageView` detail-patch path.
- Crops axis-aligned Flate image decodes to the visible PDF-space region and retargets the image transform so deep-zoom patches avoid shipping full-page image buffers.
- Keeps full-page capped decoding as the fallback for unsupported/uncropped images, and keeps ICC images out of the raw scaled fast path.
- Fixes region-cache behavior so weight-0/vector-only region requests reuse the page-wide cache key instead of accumulating duplicate region slices.
- Adds focused coverage for region crop serialization, scaled pixel decoding, worker cache behavior, and the CAD performance probe.

## Performance
Fresh local probe on `corpus/ly9-far-cad.pdf`, page 30 (`CAD_PAGE=29 CAD_SCAN=0 CAD_REGION=3771.97,921.97,4731.97,1461.97`):

- Native decode: 1972 ms, 159.1 MP decoded, 610.2 MB command buffer.
- Capped full-page decode: 250 ms, 16.8 MP decoded, 67.6 MB command buffer.
- Visible-region decode: 43 ms, 2.1 MP decoded, 9.5 MB command buffer, 12.3% of capped pixels.
- Progressive vector-only first paint: 50 ms.
- Full capped render after decode: 401 ms to 7737x2169.

The region path cuts the command buffer by about 64x versus native decode and about 7x versus the capped full-page path for a centered 1920x1080 viewport-equivalent slice.

## Validation
- `fvm flutter test test/render_worker_test.dart`
- `fvm flutter test test/page_preview_test.dart`
- `fvm dart test test/image_pixels_test.dart test/render_command_codec_test.dart`
- `fvm dart analyze`
- `git diff --check`
- `CAD_PDF=../../corpus/ly9-far-cad.pdf CAD_PAGE=29 CAD_SCAN=0 CAD_REGION=3771.97,921.97,4731.97,1461.97 fvm flutter test test/cad_perf_probe_test.dart`