### PR TITLE
[codex] Fix macOS app embedded dylib signing

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -217,6 +217,9 @@ jobs:
       - name: Build macOS
         working-directory: app
         run: flutter build macos --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
+      - name: Normalize macOS code signatures
+        working-directory: app
+        run: bash macos/resign_embedded_code.sh build/macos/Build/Products/Release/DartPDF.app
       - name: Package DMG (unsigned)
         working-directory: app
         run: |

--- a/app/RELEASING.md
+++ b/app/RELEASING.md
@@ -44,7 +44,7 @@ The web build is always served fresh, so it skips the check.
 |---|---|---|
 | Android | `app-release.apk`, `app-release.aab` | Debug keys unless a release keystore is configured (below) |
 | iOS | `…-ios-unsigned.zip` (`.app`) | **No**, not installable; needs your Apple signing |
-| macOS | `…-macos.dmg` | **No**, needs Developer ID signing + notarization |
+| macOS | `…-macos.dmg` | Ad-hoc signed for internal consistency; needs Developer ID signing + notarization for public distribution |
 | Windows | `…-windows-x64.zip` | **No**, needs an Authenticode cert / MSIX |
 | Linux | `…-linux-x64.tar.gz` | n/a |
 | Web | `…-web.zip` | n/a |
@@ -106,7 +106,10 @@ membership needed). What that means concretely:
   Store Connect to create the DartPDF app record and upload builds.
 - **iOS:** open `app/ios/Runner.xcworkspace`, pick the RES team, archive in Xcode
   (or add Fastlane), then upload to App Store Connect / TestFlight.
-- **macOS:** for the **App Store**, archive with the RES team and submit via
+- **macOS:** the CI DMG re-signs the `.app` and embedded native libraries
+  ad-hoc so unsigned builds do not mix third-party Team IDs at launch. This is
+  only a local consistency signature, not Developer ID signing. For the
+  **App Store**, archive with the RES team and submit via
   Xcode/Transporter. For a **notarized DMG** distributed outside the store, sign
   with RES's *Developer ID Application* cert
   (`codesign --deep --options runtime`), then `xcrun notarytool submit` with a

--- a/app/macos/resign_embedded_code.sh
+++ b/app/macos/resign_embedded_code.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 path/to/DartPDF.app" >&2
+  exit 64
+fi
+
+app_bundle="$1"
+if [[ ! -d "$app_bundle/Contents" ]]; then
+  echo "error: not a macOS .app bundle: $app_bundle" >&2
+  exit 64
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+frameworks_dir="$app_bundle/Contents/Frameworks"
+identity="${CODESIGN_IDENTITY:-${EXPANDED_CODE_SIGN_IDENTITY:-${CODE_SIGN_IDENTITY:--}}}"
+if [[ -z "$identity" ]]; then
+  identity="-"
+fi
+
+entitlements="${CODESIGN_ENTITLEMENTS:-}"
+if [[ -z "$entitlements" && -f "$script_dir/Runner/Release.entitlements" ]]; then
+  entitlements="$script_dir/Runner/Release.entitlements"
+fi
+
+sign_code() {
+  local path="$1"
+  echo "codesign: $path"
+  /usr/bin/codesign --force --sign "$identity" "$path"
+}
+
+if [[ -d "$frameworks_dir" ]]; then
+  while IFS= read -r -d '' file; do
+    if /usr/bin/file -b "$file" | grep -q 'Mach-O'; then
+      sign_code "$file"
+    fi
+  done < <(find "$frameworks_dir" -type f -print0)
+
+  while IFS= read -r -d '' framework; do
+    sign_code "$framework"
+  done < <(find "$frameworks_dir" -depth -type d -name '*.framework' -print0)
+fi
+
+app_sign_args=(--force --options runtime --sign "$identity")
+if [[ -n "$entitlements" ]]; then
+  app_sign_args+=(--entitlements "$entitlements")
+fi
+
+echo "codesign: $app_bundle"
+/usr/bin/codesign "${app_sign_args[@]}" "$app_bundle"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$app_bundle"


### PR DESCRIPTION
Fixes #180.

## Summary
- Adds `app/macos/resign_embedded_code.sh` to normalize macOS app bundle code signatures after Flutter builds the app.
- Re-signs embedded Mach-O dylibs, framework bundles, and then the `.app` with one identity; default is ad-hoc (`-`) for the unsigned CI artifact.
- Wires the script into the macOS release workflow before DMG packaging.
- Updates release docs to clarify that CI macOS artifacts are ad-hoc-signed for internal consistency, not Developer ID signed/notarized.

## Root Cause
The user crash report shows dyld aborting at launch because the app executable is ad-hoc signed with no Team ID, while `Contents/Frameworks/libonnxruntime.1.15.1.dylib` kept its upstream Team ID (`UBF8T346G9`). macOS rejects loading non-platform code with a different Team ID into the process.

The CocoaPods embed script can skip signing vendored dylibs in CI-like unsigned release builds, so the release artifact can leave the ONNX Runtime dylib with its original vendor signature.

## Validation
- `fvm flutter build macos --release`
- Reproduced the bad state by copying the upstream `onnxruntime` dylib into the built app: `TeamIdentifier=UBF8T346G9`; `codesign --verify --deep --strict` failed on `libonnxruntime.1.15.1.dylib`.
- Ran `bash macos/resign_embedded_code.sh build/macos/Build/Products/Release/DartPDF.app`.
- Verified repaired bundle: app and `libonnxruntime.1.15.1.dylib` both report `Signature=adhoc` and `TeamIdentifier=not set`.
- Verified app entitlements are preserved (`app-sandbox`, user-selected read/write, network client, print).
- `codesign --verify --deep --strict --verbose=2 build/macos/Build/Products/Release/DartPDF.app`
- `bash -n app/macos/resign_embedded_code.sh`
- `git diff --check`