### PR TITLE
[codex] Add content image replacement workflow

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -120,8 +120,9 @@ enum PdfEditTool {
   image,
 
   /// Tap to select a page content element (text run, path, image); the
-  /// selection can be deleted or, for text, rewritten. Edits the page's
-  /// content stream itself, not annotations.
+  /// selection can be deleted, text can be rewritten, and images can be
+  /// replaced. Edits remove from the page's content stream itself; replacement
+  /// images are inserted as movable image stamps.
   content,
 
   /// Interactive forms: tap a field widget to fill it (text fields open
@@ -3726,6 +3727,16 @@ class PdfEditingController extends ChangeNotifier {
       selectedElement?.kind == PdfElementKind.text &&
       (selectedElement?.text?.isNotEmpty ?? false);
 
+  /// Whether the selected element is an image-like content draw that can be
+  /// removed from the page stream and replaced by an image stamp in the same
+  /// bounds.
+  bool get canReplaceSelectedElementImage {
+    final element = selectedElement;
+    return element?.bounds != null &&
+        (element?.kind == PdfElementKind.image ||
+            element?.kind == PdfElementKind.inlineImage);
+  }
+
   /// Selects the topmost content element whose bounds contain ([x], [y])
   /// on [pageIndex]; clears the selection when nothing is hit. Bounds are
   /// approximate (see [PdfContentElement.bounds]).
@@ -3780,6 +3791,50 @@ class PdfEditingController extends ChangeNotifier {
             fallbackFonts: fallbackFonts),
         pages: [selected.$1]);
     return count;
+  }
+
+  /// Replaces the selected page-content image with [imageBytes] (PNG or JPEG).
+  ///
+  /// The original image draw is removed from the content stream and the new
+  /// image is inserted as a stamp annotation fitted into the same page-space
+  /// bounds. This keeps the replacement movable/resizable while ensuring the
+  /// old baked-in image is not left underneath it. Returns false when the
+  /// selection is not a replaceable image or [imageBytes] cannot be decoded.
+  bool replaceSelectedElementImage(Uint8List imageBytes) {
+    final selected = _selectedElement;
+    final element = selectedElement;
+    final bounds = element?.bounds;
+    if (selected == null ||
+        element == null ||
+        bounds == null ||
+        !canReplaceSelectedElementImage ||
+        bounds.width <= 0 ||
+        bounds.height <= 0) {
+      return false;
+    }
+    final PdfEmbeddableImage image;
+    try {
+      image = PdfEmbeddableImage.decode(imageBytes);
+    } catch (_) {
+      return false;
+    }
+    final aspect = image.height == 0 ? 1.0 : image.width / image.height;
+    var w = bounds.width, h = bounds.height;
+    if (w / h > aspect) {
+      w = h * aspect;
+    } else {
+      h = w / aspect;
+    }
+    final cx = (bounds.left + bounds.right) / 2;
+    final cy = (bounds.bottom + bounds.top) / 2;
+    final elements = elementsOn(selected.$1);
+    return apply(
+        (e) => e
+          ..deleteElements(elements, [element.id])
+          ..addImageStamp(selected.$1,
+              PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image,
+              opacity: preferences.opacity, author: author),
+        pages: [selected.$1]);
   }
 
   /// Edits the selected text element and re-flows its whole paragraph via

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -14,6 +14,9 @@ import 'editing_signature.dart';
 import 'editing_stamps.dart';
 import 'thumbnail_cache.dart';
 
+PdfEmbeddableImage _decodeEmbeddableImage(Uint8List bytes) =>
+    PdfEmbeddableImage.decode(bytes);
+
 /// The annotation tools a [PdfEditingController] can arm.
 ///
 /// Text markups (highlight, underline, strike-out, squiggly) are not
@@ -643,7 +646,13 @@ class PdfEditingController extends ChangeNotifier {
         PdfEditTool.rectangle ||
         PdfEditTool.ellipse ||
         PdfEditTool.polygon =>
-          const {'color', 'strokeWidth', 'opacity', 'lineStyle', 'shapeFillColor'},
+          const {
+            'color',
+            'strokeWidth',
+            'opacity',
+            'lineStyle',
+            'shapeFillColor'
+          },
         PdfEditTool.line || PdfEditTool.polyline => const {
             'color',
             'strokeWidth',
@@ -652,8 +661,12 @@ class PdfEditingController extends ChangeNotifier {
             'lineStartEnding',
             'lineEndEnding',
           },
-        PdfEditTool.arrow =>
-          const {'color', 'strokeWidth', 'opacity', 'lineStyle'},
+        PdfEditTool.arrow => const {
+            'color',
+            'strokeWidth',
+            'opacity',
+            'lineStyle'
+          },
         PdfEditTool.measureDistance ||
         PdfEditTool.measurePerimeter ||
         PdfEditTool.measureArea ||
@@ -1186,9 +1199,9 @@ class PdfEditingController extends ChangeNotifier {
   /// Marks a single rectangular region for redaction (a /Redact
   /// annotation, fill black). This is the MARK phase — nothing is removed
   /// until [applyRedactions]. Undoable like any other edit until burned.
-  void addRedaction(int pageIndex, PdfRect rect) => apply(
-      (e) => e.addRedaction(pageIndex, [rect], author: author),
-      pages: [pageIndex]);
+  void addRedaction(int pageIndex, PdfRect rect) =>
+      apply((e) => e.addRedaction(pageIndex, [rect], author: author),
+          pages: [pageIndex]);
 
   /// Marks the text runs in [quadsByPage] for redaction (one /Redact
   /// annotation per page, fill black), e.g. from a text selection. Mirrors
@@ -1274,9 +1287,8 @@ class PdfEditingController extends ChangeNotifier {
               dashPattern: _lineDashPattern,
               startEnding:
                   arrow ? PdfLineEnding.none : preferences.lineStartEnding,
-              endEnding: arrow
-                  ? PdfLineEnding.closedArrow
-                  : preferences.lineEndEnding,
+              endEnding:
+                  arrow ? PdfLineEnding.closedArrow : preferences.lineEndEnding,
               author: author),
           pages: [pageIndex]);
 
@@ -1588,20 +1600,17 @@ class PdfEditingController extends ChangeNotifier {
     } catch (_) {
       return false;
     }
-    final box = _page(pageIndex).cropBox;
-    final aspect = image.height == 0 ? 1.0 : image.width / image.height;
-    var w = aspect >= 1 ? maxSize : maxSize * aspect;
-    var h = aspect >= 1 ? maxSize / aspect : maxSize;
-    final maxW = box.width * 0.9, maxH = box.height * 0.9;
-    if (w > maxW) (w, h) = (maxW, h * maxW / w);
-    if (h > maxH) (w, h) = (w * maxH / h, maxH);
-    final cx = x.clamp(box.left + w / 2, box.right - w / 2);
-    final cy = y.clamp(box.bottom + h / 2, box.top - h / 2);
-    return apply(
-        (e) => e.addImageStamp(pageIndex,
-            PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image,
-            opacity: preferences.opacity, author: author),
-        pages: [pageIndex]);
+    return _placeDecodedImage(pageIndex, x, y, image, maxSize: maxSize);
+  }
+
+  /// Async counterpart to [placeImage]. PNG preparation can be CPU-heavy for
+  /// large images, so the built-in UI uses this worker-backed path.
+  Future<bool> placeImageAsync(
+      int pageIndex, double x, double y, Uint8List imageBytes,
+      {double maxSize = 200}) async {
+    final image = await _decodeEmbeddableImageAsync(imageBytes);
+    if (image == null) return false;
+    return _placeDecodedImage(pageIndex, x, y, image, maxSize: maxSize);
   }
 
   /// Inserts [imageBytes] (PNG or JPEG) fitted within [box] (page space),
@@ -1616,6 +1625,47 @@ class PdfEditingController extends ChangeNotifier {
     } catch (_) {
       return false;
     }
+    return _addDecodedImageInRect(pageIndex, box, image);
+  }
+
+  /// Async counterpart to [addImageInRect]. See [placeImageAsync].
+  Future<bool> addImageInRectAsync(
+      int pageIndex, PdfRect box, Uint8List imageBytes) async {
+    if (box.width <= 0 || box.height <= 0) return false;
+    final image = await _decodeEmbeddableImageAsync(imageBytes);
+    if (image == null) return false;
+    return _addDecodedImageInRect(pageIndex, box, image);
+  }
+
+  Future<PdfEmbeddableImage?> _decodeEmbeddableImageAsync(
+      Uint8List imageBytes) async {
+    try {
+      return await compute(_decodeEmbeddableImage, imageBytes,
+          debugLabel: 'pdf-image-embed');
+    } catch (_) {
+      return null;
+    }
+  }
+
+  bool _placeDecodedImage(
+      int pageIndex, double x, double y, PdfEmbeddableImage image,
+      {required double maxSize}) {
+    final box = _page(pageIndex).cropBox;
+    final aspect = image.height == 0 ? 1.0 : image.width / image.height;
+    var w = aspect >= 1 ? maxSize : maxSize * aspect;
+    var h = aspect >= 1 ? maxSize / aspect : maxSize;
+    final maxW = box.width * 0.9, maxH = box.height * 0.9;
+    if (w > maxW) (w, h) = (maxW, h * maxW / w);
+    if (h > maxH) (w, h) = (w * maxH / h, maxH);
+    final cx = x.clamp(box.left + w / 2, box.right - w / 2);
+    final cy = y.clamp(box.bottom + h / 2, box.top - h / 2);
+    return _addImageStamp(pageIndex,
+        PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image);
+  }
+
+  bool _addDecodedImageInRect(
+      int pageIndex, PdfRect box, PdfEmbeddableImage image) {
+    if (box.width <= 0 || box.height <= 0) return false;
     final aspect = image.height == 0 ? 1.0 : image.width / image.height;
     var w = box.width, h = box.height;
     if (w / h > aspect) {
@@ -1624,9 +1674,13 @@ class PdfEditingController extends ChangeNotifier {
       h = w / aspect;
     }
     final cx = (box.left + box.right) / 2, cy = (box.bottom + box.top) / 2;
+    return _addImageStamp(pageIndex,
+        PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image);
+  }
+
+  bool _addImageStamp(int pageIndex, PdfRect rect, PdfEmbeddableImage image) {
     return apply(
-        (e) => e.addImageStamp(pageIndex,
-            PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2), image,
+        (e) => e.addImageStamp(pageIndex, rect, image,
             opacity: preferences.opacity, author: author),
         pages: [pageIndex]);
   }
@@ -1799,8 +1853,8 @@ class PdfEditingController extends ChangeNotifier {
     final cx = x.clamp(box.left + s / 2, box.right - s / 2);
     final cy = y.clamp(box.bottom + s / 2, box.top - s / 2);
     return apply(
-        (e) => e.addCheckMark(pageIndex,
-            PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
+        (e) => e.addCheckMark(
+            pageIndex, PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
             color: _colorValue, opacity: preferences.opacity, author: author),
         pages: [pageIndex]);
   }
@@ -2028,9 +2082,8 @@ class PdfEditingController extends ChangeNotifier {
   /// returns false) when nothing is selected or the selection would empty
   /// the document — at least one page must remain. Clears the selection.
   bool removeSelectedPages() {
-    final doomed = _selectedPages
-        .where((i) => i >= 0 && i < _document.pageCount)
-        .toList();
+    final doomed =
+        _selectedPages.where((i) => i >= 0 && i < _document.pageCount).toList();
     if (doomed.isEmpty || doomed.length >= _document.pageCount) return false;
     _selected.clear();
     _selectedPages.clear();
@@ -3234,8 +3287,7 @@ class PdfEditingController extends ChangeNotifier {
   /// /PolyLine in place — one revision, one undo, and the annotation
   /// keeps its /Annots slot and object number. Pass null for an axis to
   /// leave it unchanged.
-  void setSelectedLineEndings(
-      {PdfLineEnding? start, PdfLineEnding? end}) {
+  void setSelectedLineEndings({PdfLineEnding? start, PdfLineEnding? end}) {
     final annotation = selectedAnnotation;
     if (annotation == null || !canSetLineEndings) return;
     apply(
@@ -3267,8 +3319,7 @@ class PdfEditingController extends ChangeNotifier {
   /// Restyles the selected measurement's caption font and/or size in
   /// place — one revision, one undo, and the annotation keeps its /Annots
   /// slot and object number. Pass null for an axis to leave it unchanged.
-  void setSelectedMeasurementCaption(
-      {PdfStandardFont? font, double? size}) {
+  void setSelectedMeasurementCaption({PdfStandardFont? font, double? size}) {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRestyleMeasurementCaption) return;
     apply(
@@ -3731,7 +3782,10 @@ class PdfEditingController extends ChangeNotifier {
   /// removed from the page stream and replaced by an image stamp in the same
   /// bounds.
   bool get canReplaceSelectedElementImage {
-    final element = selectedElement;
+    return _isReplaceableImageElement(selectedElement);
+  }
+
+  bool _isReplaceableImageElement(PdfContentElement? element) {
     return element?.bounds != null &&
         (element?.kind == PdfElementKind.image ||
             element?.kind == PdfElementKind.inlineImage);
@@ -3807,7 +3861,7 @@ class PdfEditingController extends ChangeNotifier {
     if (selected == null ||
         element == null ||
         bounds == null ||
-        !canReplaceSelectedElementImage ||
+        !_isReplaceableImageElement(element) ||
         bounds.width <= 0 ||
         bounds.height <= 0) {
       return false;
@@ -3818,6 +3872,41 @@ class PdfEditingController extends ChangeNotifier {
     } catch (_) {
       return false;
     }
+    return _replaceElementImage(selected, element, bounds, image);
+  }
+
+  /// Async counterpart to [replaceSelectedElementImage]. The built-in toolbar
+  /// uses this so large PNG replacement does its decode/compress work off the
+  /// UI isolate before the PDF revision is committed.
+  Future<bool> replaceSelectedElementImageAsync(Uint8List imageBytes) async {
+    final selected = _selectedElement;
+    final element = selectedElement;
+    final bounds = element?.bounds;
+    if (selected == null ||
+        element == null ||
+        bounds == null ||
+        !_isReplaceableImageElement(element) ||
+        bounds.width <= 0 ||
+        bounds.height <= 0) {
+      return false;
+    }
+    final image = await _decodeEmbeddableImageAsync(imageBytes);
+    if (image == null || _selectedElement != selected) return false;
+    final current = selectedElement;
+    final currentBounds = current?.bounds;
+    if (current == null ||
+        currentBounds == null ||
+        current.id != element.id ||
+        !_isReplaceableImageElement(current) ||
+        currentBounds.width <= 0 ||
+        currentBounds.height <= 0) {
+      return false;
+    }
+    return _replaceElementImage(selected, current, currentBounds, image);
+  }
+
+  bool _replaceElementImage((int page, int id) selected,
+      PdfContentElement element, PdfRect bounds, PdfEmbeddableImage image) {
     final aspect = image.height == 0 ? 1.0 : image.width / image.height;
     var w = bounds.width, h = bounds.height;
     if (w / h > aspect) {
@@ -3854,12 +3943,10 @@ class PdfEditingController extends ChangeNotifier {
       return false;
     }
     var reflowed = false;
-    apply(
-        (e) => reflowed = e.reflowText(selected.$1, element.text!, text),
+    apply((e) => reflowed = e.reflowText(selected.$1, element.text!, text),
         pages: [selected.$1]);
     return reflowed;
   }
-
 
   // ---------------------------------------------------------------------
   // forms
@@ -3917,8 +4004,7 @@ class PdfEditingController extends ChangeNotifier {
     final form = acroForm;
     if (form == null) return const [];
     final annotations = _page(pageIndex).annotations;
-    final result =
-        <(PdfFormField, int, PdfAnnotation)>[];
+    final result = <(PdfFormField, int, PdfAnnotation)>[];
     for (final annotation in annotations) {
       if (annotation.subtype != 'Widget' ||
           annotation.isHidden ||
@@ -4014,6 +4100,15 @@ class PdfEditingController extends ChangeNotifier {
     } catch (_) {
       return false;
     }
+    return _fillField(name, const {PdfFieldType.pushButton},
+        (e, f) => e.setButtonImage(f, image));
+  }
+
+  /// Async counterpart to [setFormButtonImage]. See [placeImageAsync].
+  Future<bool> setFormButtonImageAsync(
+      String name, Uint8List imageBytes) async {
+    final image = await _decodeEmbeddableImageAsync(imageBytes);
+    if (image == null) return false;
     return _fillField(name, const {PdfFieldType.pushButton},
         (e, f) => e.setButtonImage(f, image));
   }
@@ -4166,8 +4261,7 @@ class PdfEditingController extends ChangeNotifier {
       size: size == 0 ? 12 : size,
       autoSize: size == 0,
       color: Color(0xFF000000 | (field.appearanceColor ?? 0)),
-      align: PdfTextAlign.values.firstWhere(
-          (a) => a.quadding == field.quadding,
+      align: PdfTextAlign.values.firstWhere((a) => a.quadding == field.quadding,
           orElse: () => PdfTextAlign.left),
       multiline: field.isMultiline,
     );

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -254,7 +254,9 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
         if (picker == null) return;
         final name = field.name;
         final bytes = await picker(context, field);
-        if (bytes != null) _controller.setFormButtonImage(name, bytes);
+        if (bytes != null) {
+          await _controller.setFormButtonImageAsync(name, bytes);
+        }
       case PdfFieldType.signature || PdfFieldType.unknown:
         break;
     }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -3116,7 +3116,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         if (picker == null) return;
         final bytes = await picker(context);
         if (bytes == null) return;
-        _controller.addImageInRect(widget.pageIndex, rect, bytes);
+        await _controller.addImageInRectAsync(widget.pageIndex, rect, bytes);
       case PdfEditTool.form:
         _controller.addFormField(
             _controller.newFormFieldKind, widget.pageIndex, rect);
@@ -3175,7 +3175,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         if (picker == null) return;
         final name = field.name;
         final bytes = await picker(context, field);
-        if (bytes != null) _controller.setFormButtonImage(name, bytes);
+        if (bytes != null) {
+          await _controller.setFormButtonImageAsync(name, bytes);
+        }
       case PdfFieldType.signature || PdfFieldType.unknown:
         break;
     }
@@ -3221,7 +3223,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _samplerAnnotations = annotations;
       _sampler = null;
       _samplerFuture = PdfPageColorSampler.of(document.page(widget.pageIndex),
-              pageColor: pageColor, annotations: annotations,
+              pageColor: pageColor,
+              annotations: annotations,
               rotation: widget.geometry.rotation)
           .then((s) {
         // resolve the preview that was waiting on the raster
@@ -3348,7 +3351,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         if (picker == null) return;
         final bytes = await picker(context);
         if (bytes == null) return;
-        _controller.placeImage(widget.pageIndex, x, y, bytes);
+        await _controller.placeImageAsync(widget.pageIndex, x, y, bytes);
       case PdfEditTool.form:
         // single tap selects the field for move/resize/menu; double-tap
         // fills it (read mode is the no-tool path to just fill)
@@ -3598,7 +3601,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final family = 'pdfedit-$key';
     // copy the bytes: loadFontFromList wants an owned, immutable list
     ui
-        .loadFontFromList(Uint8List.fromList(font.fontBytes), fontFamily: family)
+        .loadFontFromList(Uint8List.fromList(font.fontBytes),
+            fontFamily: family)
         .then((_) {
       _embeddedPreviewFamilies[key] = family;
       _embeddedFontsLoading.remove(key);
@@ -4308,9 +4312,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     resizeClean: wrapResize != null
                         ? _resizeCleanPicture
                         : _afterTextClean,
-                    resizeHideRect: wrapResize != null
-                        ? _resizeFrom
-                        : _afterTextHideRect,
+                    resizeHideRect:
+                        wrapResize != null ? _resizeFrom : _afterTextHideRect,
                     resizeHideAngle:
                         wrapResize != null ? _resizeAngle : _afterTextHideAngle,
                     resizeHideWash: Color.alphaBlend(
@@ -4427,22 +4430,22 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                             meta: true): _commitTextEdit,
                         const SingleActivator(LogicalKeyboardKey.enter,
                             control: true): _commitTextEdit,
-                        const SingleActivator(LogicalKeyboardKey.keyB,
-                            meta: true): () => _toggleInlineTextStyle(
-                              italic: false,
-                            ),
-                        const SingleActivator(LogicalKeyboardKey.keyB,
-                            control: true): () => _toggleInlineTextStyle(
-                              italic: false,
-                            ),
-                        const SingleActivator(LogicalKeyboardKey.keyI,
-                            meta: true): () => _toggleInlineTextStyle(
-                              italic: true,
-                            ),
-                        const SingleActivator(LogicalKeyboardKey.keyI,
-                            control: true): () => _toggleInlineTextStyle(
-                              italic: true,
-                            ),
+                        const SingleActivator(LogicalKeyboardKey.keyB, meta: true):
+                            () => _toggleInlineTextStyle(
+                                  italic: false,
+                                ),
+                        const SingleActivator(LogicalKeyboardKey.keyB, control: true):
+                            () => _toggleInlineTextStyle(
+                                  italic: false,
+                                ),
+                        const SingleActivator(LogicalKeyboardKey.keyI, meta: true):
+                            () => _toggleInlineTextStyle(
+                                  italic: true,
+                                ),
+                        const SingleActivator(LogicalKeyboardKey.keyI, control: true):
+                            () => _toggleInlineTextStyle(
+                                  italic: true,
+                                ),
                       },
                       child: Container(
                         // the chrome border lives in the inflate(2) gutter
@@ -4457,8 +4460,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                         // so the old rendering doesn't ghost through and read
                         // as a misaligned shadow behind the live text
                         color: _textEditFill ??
-                            widget.pageColor.withValues(
-                                alpha: _textEditExisting ? 1 : 0.3),
+                            widget.pageColor
+                                .withValues(alpha: _textEditExisting ? 1 : 0.3),
                         foregroundDecoration: BoxDecoration(
                           border: Border.all(
                               color: PdfViewerTheme.of(context)

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -244,6 +244,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// gesture), so the thumb needs its own state meanwhile.
   double? _dragOpacity;
 
+  bool _replacingElementImage = false;
+
   /// The seven dock groups, in order. Filtered by [PdfEditingToolbar.tools]
   /// and [PdfEditingToolbar.showMarkup] before display.
   static const _groups = <_ToolGroup>[
@@ -536,18 +538,23 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   Future<void> _replaceElementImage(BuildContext context) async {
     final picker = widget.imagePicker;
-    if (picker == null) return;
-    final bytes = await picker(context);
-    if (bytes == null) return;
-    final replaced = controller.replaceSelectedElementImage(bytes);
-    if (!replaced && context.mounted) {
-      ScaffoldMessenger.maybeOf(context)
-        ?..clearSnackBars()
-        ..showSnackBar(SnackBar(
-          content: const Text("Couldn't replace image"),
-          behavior: SnackBarBehavior.floating,
-          margin: pdfFloatingToastMargin(context),
-        ));
+    if (picker == null || _replacingElementImage) return;
+    setState(() => _replacingElementImage = true);
+    try {
+      final bytes = await picker(context);
+      if (bytes == null) return;
+      final replaced = await controller.replaceSelectedElementImageAsync(bytes);
+      if (!replaced && context.mounted) {
+        ScaffoldMessenger.maybeOf(context)
+          ?..clearSnackBars()
+          ..showSnackBar(SnackBar(
+            content: const Text("Couldn't replace image"),
+            behavior: SnackBarBehavior.floating,
+            margin: pdfFloatingToastMargin(context),
+          ));
+      }
+    } finally {
+      if (mounted) setState(() => _replacingElementImage = false);
     }
   }
 
@@ -1145,16 +1152,16 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     return Row(mainAxisSize: MainAxisSize.min, children: [
       _alignButton(
           PdfAlignment.left, Icons.align_horizontal_left, 'Align left'),
-      _alignButton(PdfAlignment.horizontalCenter,
-          Icons.align_horizontal_center, 'Align horizontal centers'),
+      _alignButton(PdfAlignment.horizontalCenter, Icons.align_horizontal_center,
+          'Align horizontal centers'),
       _alignButton(
           PdfAlignment.right, Icons.align_horizontal_right, 'Align right'),
       const _MiniDivider(),
       _alignButton(PdfAlignment.top, Icons.align_vertical_top, 'Align top'),
       _alignButton(PdfAlignment.verticalCenter, Icons.align_vertical_center,
           'Align vertical centers'),
-      _alignButton(PdfAlignment.bottom, Icons.align_vertical_bottom,
-          'Align bottom'),
+      _alignButton(
+          PdfAlignment.bottom, Icons.align_vertical_bottom, 'Align bottom'),
       const _MiniDivider(),
       _alignButton(PdfAlignment.distributeHorizontal,
           Icons.horizontal_distribute, 'Distribute horizontally',
@@ -1205,9 +1212,16 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           widget.imagePicker != null)
         IconButton(
           key: const ValueKey('pdf-replace-element-image'),
-          icon: const Icon(Icons.image_outlined),
+          icon: _replacingElementImage
+              ? const SizedBox.square(
+                  dimension: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.image_outlined),
           tooltip: 'Replace image',
-          onPressed: () => _replaceElementImage(context),
+          onPressed: _replacingElementImage
+              ? null
+              : () => _replaceElementImage(context),
         ),
     ]);
     return _centeredCard(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1519,6 +1519,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   Widget _buildMobile(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final tool = controller.tool;
+    final compactToolLabel = controller.selectedElement != null;
     return Container(
       decoration: BoxDecoration(
         color: scheme.surface,
@@ -1547,17 +1548,21 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             child: Row(children: [
               const SizedBox(width: 4),
               Icon(_activeToolIcon(tool), size: 22, color: scheme.primary),
-              const SizedBox(width: 8),
-              Flexible(
-                child: Text(
-                  _activeToolLabel(tool),
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontWeight: FontWeight.w600,
-                    fontSize: 14,
+              if (!compactToolLabel) ...[
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    _activeToolLabel(tool),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    softWrap: false,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 14,
+                    ),
                   ),
                 ),
-              ),
+              ],
             ]),
           ),
           ..._mobileTrailing(context),
@@ -1597,6 +1602,49 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             tooltip: 'Edit annotation text',
             visualDensity: VisualDensity.compact,
             onPressed: () => _editSelectedText(context),
+          ),
+      ];
+    }
+    if (controller.selectedElement != null) {
+      return [
+        IconButton(
+          key: const ValueKey('pdf-mobile-delete-element'),
+          icon: const Icon(Icons.delete_outline),
+          tooltip: 'Delete element',
+          visualDensity: VisualDensity.compact,
+          onPressed: controller.deleteSelectedElement,
+        ),
+        if (controller.canEditSelectedElementText) ...[
+          IconButton(
+            key: const ValueKey('pdf-replace-element-text'),
+            icon: const Icon(Icons.edit),
+            tooltip: 'Replace text',
+            visualDensity: VisualDensity.compact,
+            onPressed: () => _editElementText(context),
+          ),
+          IconButton(
+            key: const ValueKey('pdf-reflow-element-text'),
+            icon: const Icon(Icons.wrap_text),
+            tooltip: 'Reflow paragraph',
+            visualDensity: VisualDensity.compact,
+            onPressed: () => _reflowElementText(context),
+          ),
+        ],
+        if (controller.canReplaceSelectedElementImage &&
+            widget.imagePicker != null)
+          IconButton(
+            key: const ValueKey('pdf-replace-element-image'),
+            icon: _replacingElementImage
+                ? const SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.image_outlined),
+            tooltip: 'Replace image',
+            visualDensity: VisualDensity.compact,
+            onPressed: _replacingElementImage
+                ? null
+                : () => _replaceElementImage(context),
           ),
       ];
     }
@@ -1649,6 +1697,18 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   String _activeToolLabel(PdfEditTool? tool) {
     if (tool == null) return 'Select';
+    switch (tool) {
+      case PdfEditTool.content:
+        return 'Content';
+      case PdfEditTool.form:
+        return 'Form';
+      case PdfEditTool.redact:
+        return 'Redact';
+      case PdfEditTool.snapshot:
+        return 'Snapshot';
+      default:
+        break;
+    }
     for (final group in _groups) {
       for (final entry in group.tools) {
         if (entry.tool == tool) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -84,6 +84,7 @@ class PdfEditingToolbar extends StatefulWidget {
     required this.viewerController,
     this.onSave,
     this.textPrompt = showPdfTextPrompt,
+    this.imagePicker,
     this.fontPicker,
     this.palette = defaultPalette,
     this.tools,
@@ -110,6 +111,9 @@ class PdfEditingToolbar extends StatefulWidget {
 
   /// How the edit-text button asks for replacement text.
   final PdfTextPrompt textPrompt;
+
+  /// How selected page-content images are replaced from the element strip.
+  final PdfImagePicker? imagePicker;
 
   /// How the font menu's "Load font…" entry obtains a custom `.ttf`/`.otf`
   /// file. When null, only the standard families and bundled fonts are
@@ -524,6 +528,23 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           content: const Text(
               "Couldn't reflow — this isn't a single-column paragraph this "
               'tool can re-wrap. Try Replace text instead.'),
+          behavior: SnackBarBehavior.floating,
+          margin: pdfFloatingToastMargin(context),
+        ));
+    }
+  }
+
+  Future<void> _replaceElementImage(BuildContext context) async {
+    final picker = widget.imagePicker;
+    if (picker == null) return;
+    final bytes = await picker(context);
+    if (bytes == null) return;
+    final replaced = controller.replaceSelectedElementImage(bytes);
+    if (!replaced && context.mounted) {
+      ScaffoldMessenger.maybeOf(context)
+        ?..clearSnackBars()
+        ..showSnackBar(SnackBar(
+          content: const Text("Couldn't replace image"),
           behavior: SnackBarBehavior.floating,
           margin: pdfFloatingToastMargin(context),
         ));
@@ -1180,6 +1201,14 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           onPressed: () => _reflowElementText(context),
         ),
       ],
+      if (controller.canReplaceSelectedElementImage &&
+          widget.imagePicker != null)
+        IconButton(
+          key: const ValueKey('pdf-replace-element-image'),
+          icon: const Icon(Icons.image_outlined),
+          tooltip: 'Replace image',
+          onPressed: () => _replaceElementImage(context),
+        ),
     ]);
     return _centeredCard(
       context,

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -702,6 +702,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                   viewerController: _viewer,
                   // save lives in the header now, not the dock
                   textPrompt: widget.textPrompt ?? showPdfTextPrompt,
+                  imagePicker: widget.imagePicker,
                   fontPicker: widget.fontPicker,
                   palette: widget.palette,
                   tools: features.tools,

--- a/packages/dart_pdf_editor/test/editing_form_test.dart
+++ b/packages/dart_pdf_editor/test/editing_form_test.dart
@@ -109,14 +109,16 @@ void main() {
       expect(moved.bottom, closeTo(before.bottom - 10, 1e-6));
 
       // resize regenerates the appearance at the new size
-      final target =
-          PdfRect(moved.left, moved.bottom, moved.left + 240, moved.bottom + 40);
+      final target = PdfRect(
+          moved.left, moved.bottom, moved.left + 240, moved.bottom + 40);
       editing.resizeSelected(target);
       final resized = editing.acroForm!.fieldNamed('name')!.widgetRect(0)!;
       expect(resized.width, closeTo(240, 1e-6));
       expect(resized.height, closeTo(40, 1e-6));
       // the value is re-laid into the new box, not stretched
-      expect(widgetAppearance(editing.document, editing.acroForm!.fieldNamed('name')!),
+      expect(
+          widgetAppearance(
+              editing.document, editing.acroForm!.fieldNamed('name')!),
           contains('prefilled'));
 
       // delete drops the whole field, not just the /Annots entry
@@ -147,6 +149,15 @@ void main() {
       expect(widgetAppearance(editing.document, field), contains('/Img0 Do'));
       expect(editing.setFormButtonImage(name, buildClassicPdf()), isFalse,
           reason: 'not an image');
+    });
+
+    test('setFormButtonImageAsync fills a push button', () async {
+      final editing = controller();
+      final name = editing.addFormField(
+          PdfFormFieldKind.pushButton, 0, const PdfRect(400, 600, 500, 640))!;
+      expect(await editing.setFormButtonImageAsync(name, _png), isTrue);
+      final field = editing.acroForm!.fieldNamed(name)!;
+      expect(widgetAppearance(editing.document, field), contains('/Img0 Do'));
     });
 
     test('addFormField generates unique names and creates the form', () {
@@ -231,6 +242,21 @@ void main() {
 
     Future<void> settle(WidgetTester tester) =>
         tester.pumpAndSettle(const Duration(milliseconds: 300));
+
+    Future<void> waitForFieldImage(
+        WidgetTester tester, PdfEditingController editing, String name) async {
+      await tester.runAsync(() async {
+        for (var i = 0; i < 50; i++) {
+          final field = editing.acroForm!.fieldNamed(name);
+          if (field != null &&
+              widgetAppearance(editing.document, field).contains('/Img0 Do')) {
+            return;
+          }
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+      });
+      await tester.pump();
+    }
 
     Future<PdfEditingController> pumpEditor(WidgetTester tester,
         {PdfFormImagePicker? imagePicker, bool toolbar = false}) async {
@@ -404,7 +430,7 @@ void main() {
 
       await doubleTap(tester, view(430, 340));
       expect(picked?.name, 'Field 1');
-      await tester.pump();
+      await waitForFieldImage(tester, editing, 'Field 1');
       final field = editing.acroForm!.fieldNamed('Field 1')!;
       expect(widgetAppearance(editing.document, field), contains('/Img0 Do'));
       await settle(tester);
@@ -474,8 +500,7 @@ void main() {
 
       final flatten =
           find.byTooltip('Flatten form — bake values into the pages');
-      await tester.scrollUntilVisible(flatten, 80,
-          scrollable: stripScrollable);
+      await tester.scrollUntilVisible(flatten, 80, scrollable: stripScrollable);
       await tester.tap(flatten);
       await tester.pump();
       expect(editing.acroForm!.fields, isEmpty);

--- a/packages/dart_pdf_editor/test/editing_image_test.dart
+++ b/packages/dart_pdf_editor/test/editing_image_test.dart
@@ -55,14 +55,24 @@ void main() {
       addTearDown(editing.dispose);
 
       // a 200x50 box; the square image fits to 50x50, centered
-      expect(
-          editing.addImageInRect(0, const PdfRect(100, 100, 300, 150), _png),
+      expect(editing.addImageInRect(0, const PdfRect(100, 100, 300, 150), _png),
           isTrue);
       final rect = editing.document.page(0).annotations.single.rect;
       expect(rect.width, closeTo(50, 1e-9));
       expect(rect.height, closeTo(50, 1e-9));
       expect((rect.left + rect.right) / 2, closeTo(200, 1e-9));
       expect((rect.bottom + rect.top) / 2, closeTo(125, 1e-9));
+    });
+
+    test('placeImageAsync prepares the image off-thread and inserts', () async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      expect(await editing.placeImageAsync(0, 300, 400, _png), isTrue);
+      final stamp = editing.document.page(0).annotations.single;
+      expect(stamp.subtype, 'Stamp');
+      expect(appearance(editing.document, stamp), contains('/Img0 Do'));
     });
 
     test('junk bytes are rejected without a revision', () {
@@ -72,8 +82,10 @@ void main() {
 
       expect(editing.placeImage(0, 100, 100, Uint8List.fromList([1, 2, 3])),
           isFalse);
-      expect(editing.addImageInRect(0, const PdfRect(0, 0, 100, 100),
-          Uint8List.fromList([1, 2, 3])), isFalse);
+      expect(
+          editing.addImageInRect(
+              0, const PdfRect(0, 0, 100, 100), Uint8List.fromList([1, 2, 3])),
+          isFalse);
       expect(editing.isModified, isFalse);
     });
   });
@@ -85,6 +97,17 @@ void main() {
     Future<void> tap(WidgetTester tester, Offset position) async {
       await tester.tapAt(position);
       await tester.pump(const Duration(milliseconds: 400));
+    }
+
+    Future<void> waitForImageInsert(
+        WidgetTester tester, PdfEditingController editing) async {
+      await tester.runAsync(() async {
+        for (var i = 0; i < 50; i++) {
+          if (editing.document.page(0).annotations.isNotEmpty) return;
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+      });
+      await tester.pump();
     }
 
     Future<PdfEditingController> pumpEditor(WidgetTester tester,
@@ -123,7 +146,7 @@ void main() {
       await tester.pump();
 
       await tap(tester, view(300, 400));
-      await tester.pump();
+      await waitForImageInsert(tester, editing);
       expect(calls, 1);
       final stamp = editing.document.page(0).annotations.single;
       expect(stamp.subtype, 'Stamp');

--- a/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_mobile_toolbar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -11,9 +13,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   final swatch = find.byKey(const ValueKey('pdf-mobile-swatch-0'));
 
-  Future<PdfEditingController> pumpToolbar(WidgetTester tester) async {
+  Future<PdfEditingController> pumpToolbar(WidgetTester tester,
+      {Uint8List? bytes}) async {
     SharedPreferences.setMockInitialValues({});
-    final editing = PdfEditingController(buildAppearanceAnnotationsPdf());
+    final editing =
+        PdfEditingController(bytes ?? buildAppearanceAnnotationsPdf());
     final viewer = PdfViewerController();
     addTearDown(editing.dispose);
     addTearDown(viewer.dispose);
@@ -103,5 +107,27 @@ void main() {
     await tester.pump();
     expect(editing.hasAnnotationSelection, isFalse);
     expect(editing.isModified, isTrue, reason: 'the annotation was removed');
+  });
+
+  testWidgets('a selected content element surfaces mobile edit actions',
+      (tester) async {
+    final editing = await pumpToolbar(tester, bytes: buildMultiPagePdf(1));
+    editing.tool = PdfEditTool.content;
+    expect(editing.selectElementAt(0, 80, 725), isTrue);
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('pdf-mobile-delete-element')),
+        findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('pdf-replace-element-text')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('pdf-reflow-element-text')), findsOneWidget);
+    expect(swatch, findsNothing,
+        reason: 'content element actions take precedence over swatches');
+
+    await tester.tap(find.byKey(const ValueKey('pdf-mobile-delete-element')));
+    await tester.pump();
+    expect(editing.selectedElement, isNull);
+    expect(editing.elementsOn(0).elements, isEmpty);
   });
 }

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -11,6 +11,10 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
+// 2x2 RGBA PNG fixture used by image-content replacement tests.
+final _tinyPng = base64.decode('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0k'
+    'AAAAGUlEQVR4nGP4z8DwHwgbWBgZ/jNyicr7AgA3BAUOTnqjAAAAAABJRU5ErkJggg==');
+
 void main() {
   dynamic editingOverlayPainter(WidgetTester tester) {
     for (final paint
@@ -310,6 +314,35 @@ void main() {
 
       editing.undo();
       expect(editing.elementsOn(0).elements.single.text, 'Page 1');
+    });
+
+    test('replaceSelectedElementImage removes page content and inserts a stamp',
+        () {
+      final editing = PdfEditingController(PdfImageDocument.fromImageBytes(
+        [_tinyPng],
+        pageSize: const PdfPageSize(100, 100),
+        fit: PdfImageFit.fill,
+      ));
+      final elements = editing.elementsOn(0).elements;
+      expect(elements, hasLength(1));
+      expect(elements.single.kind, PdfElementKind.image);
+      expect(editing.selectElementAt(0, 50, 50), isTrue);
+      expect(editing.canReplaceSelectedElementImage, isTrue);
+
+      expect(editing.replaceSelectedElementImage(_tinyPng), isTrue);
+      expect(editing.selectedElement, isNull);
+      expect(editing.elementsOn(0).elements, isEmpty,
+          reason: 'the old baked-in image draw was removed');
+      final stamp = editing.document.page(0).annotations.single;
+      expect(stamp.subtype, 'Stamp');
+      expect(stamp.rect.left, closeTo(0, 0.01));
+      expect(stamp.rect.bottom, closeTo(0, 0.01));
+      expect(stamp.rect.right, closeTo(100, 0.01));
+      expect(stamp.rect.top, closeTo(100, 0.01));
+
+      editing.undo();
+      expect(editing.document.page(0).annotations, isEmpty);
+      expect(editing.elementsOn(0).elements.single.kind, PdfElementKind.image);
     });
 
     test('replaceSelectedElementText rewrites the run in place', () {
@@ -960,6 +993,45 @@ void main() {
       expect(editing.document.page(0).annotations, isEmpty);
       expect(editing.document.page(1).annotations, hasLength(1));
       expect(find.text('first note'), findsNothing);
+    });
+
+    testWidgets('the element toolbar replaces a selected page image',
+        (tester) async {
+      final editing = PdfEditingController(PdfImageDocument.fromImageBytes(
+        [_tinyPng],
+        pageSize: const PdfPageSize(100, 100),
+        fit: PdfImageFit.fill,
+      ));
+      final viewer = PdfViewerController();
+      var picks = 0;
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      expect(editing.selectElementAt(0, 50, 50), isTrue);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+            imagePicker: (_) async {
+              picks++;
+              return _tinyPng;
+            },
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final replace = find.byKey(const ValueKey('pdf-replace-element-image'));
+      expect(replace, findsOneWidget);
+      await tester.tap(replace);
+      await tester.pump();
+      await tester.pump();
+
+      expect(picks, 1);
+      expect(editing.elementsOn(0).elements, isEmpty);
+      expect(editing.document.page(0).annotations.single.subtype, 'Stamp');
     });
 
     testWidgets('the style menu drives stroke width and opacity',

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -345,6 +345,21 @@ void main() {
       expect(editing.elementsOn(0).elements.single.kind, PdfElementKind.image);
     });
 
+    test('replaceSelectedElementImageAsync uses the worker-backed path',
+        () async {
+      final editing = PdfEditingController(PdfImageDocument.fromImageBytes(
+        [_tinyPng],
+        pageSize: const PdfPageSize(100, 100),
+        fit: PdfImageFit.fill,
+      ));
+      addTearDown(editing.dispose);
+
+      expect(editing.selectElementAt(0, 50, 50), isTrue);
+      expect(await editing.replaceSelectedElementImageAsync(_tinyPng), isTrue);
+      expect(editing.elementsOn(0).elements, isEmpty);
+      expect(editing.document.page(0).annotations.single.subtype, 'Stamp');
+    });
+
     test('replaceSelectedElementText rewrites the run in place', () {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       editing.selectElementAt(0, 80, 725);
@@ -1027,6 +1042,12 @@ void main() {
       expect(replace, findsOneWidget);
       await tester.tap(replace);
       await tester.pump();
+      await tester.runAsync(() async {
+        for (var i = 0; i < 50; i++) {
+          if (editing.document.page(0).annotations.isNotEmpty) return;
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+      });
       await tester.pump();
 
       expect(picks, 1);


### PR DESCRIPTION
Fixes #171.

## Summary
- Add a content-tool image replacement path for selected baked-in page images and inline images.
- Remove the old page-content image draw, then insert the replacement as a movable/resizable image stamp fitted to the same bounds.
- Wire `PdfEditorView.imagePicker` into the stock editing toolbar and show a replace-image action for selected image content.
- Cover the controller mutation and toolbar button path in `editing_test.dart`.

## Notes
- Existing text content editing remains the same: text runs can still be selected, deleted, and rewritten/reflowed through the content tool.
- Replaced images are intentionally inserted as stamp annotations rather than rewriting the low-level XObject/image stream in place, so users can move, resize, restyle, undo, and sync them through the existing annotation pipeline.

## Validation
- `fvm flutter test test/editing_test.dart`
- `fvm dart analyze`
- `git diff --check`