### PR TITLE
Add editor toolbar builder

### DIFF
--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -58,6 +58,22 @@ PdfEditorView(
 )
 ```
 
+For fully custom editor chrome, replace the stock toolbar and drive the
+controller directly:
+
+```dart
+PdfEditorView(
+  bytes: pdfBytes,
+  toolbarBuilder: (context, editing, viewer) => BottomAppBar(
+    child: IconButton(
+      icon: const Icon(Icons.crop_square),
+      tooltip: 'Rectangle',
+      onPressed: () => editing.tool = PdfEditTool.rectangle,
+    ),
+  ),
+)
+```
+
 Try the [live demo](https://dart-pdf-demo.web.app) of the example app
 on Flutter web, with a built-in feature showcase document.
 

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -23,6 +23,19 @@ import 'search_panel.dart';
 import 'shell_chrome.dart';
 import 'theme.dart';
 
+/// Builds the editing toolbar for [PdfEditorView].
+///
+/// Hosts can return [PdfEditingToolbar] with their own configuration, wrap it,
+/// or replace it entirely with custom Material chrome that drives the supplied
+/// [PdfEditingController] and [PdfViewerController]. Returning null hides the
+/// toolbar for this build while leaving editing gestures and keyboard shortcuts
+/// active.
+typedef PdfEditorToolbarBuilder = Widget? Function(
+  BuildContext context,
+  PdfEditingController controller,
+  PdfViewerController viewerController,
+);
+
 /// Which pieces of chrome a [PdfEditorView] shows. Everything defaults
 /// on; turn features off rather than rebuilding the layout by hand.
 class PdfEditorFeatures {
@@ -201,6 +214,7 @@ class PdfEditorView extends StatefulWidget {
     this.toolShortcuts = pdfEditToolShortcuts,
     this.toolbarLeading = const [],
     this.toolbarTrailing = const [],
+    this.toolbarBuilder,
     this.initialFit = PdfViewerFit.page,
     this.backgroundColor,
     this.pageColor,
@@ -327,6 +341,20 @@ class PdfEditorView extends StatefulWidget {
 
   /// Custom widgets shown after the stock editing toolbar controls.
   final List<PdfEditingToolbarWidgetBuilder> toolbarTrailing;
+
+  /// Builds or replaces the bottom editing toolbar.
+  ///
+  /// This is the escape hatch for apps that need fully custom editor
+  /// components. The stock toolbar already supports hiding tool groups,
+  /// filtering individual tools, and adding [toolbarLeading] /
+  /// [toolbarTrailing] actions; use [toolbarBuilder] when the whole toolbar
+  /// should be host-owned instead. The builder receives the active edit session
+  /// and viewer controller, including internally owned instances when [bytes]
+  /// is used.
+  ///
+  /// [PdfEditorFeatures.toolbar] still gates this builder. Set that feature to
+  /// false to disable all toolbar chrome regardless of this value.
+  final PdfEditorToolbarBuilder? toolbarBuilder;
 
   /// See [PdfViewer.initialFit].
   final PdfViewerFit initialFit;
@@ -697,25 +725,26 @@ class _PdfEditorViewState extends State<PdfEditorView> {
               constraints.maxWidth < PdfEditingToolbar.mobileBreakpoint;
           final toolbar = !showToolbar
               ? null
-              : PdfEditingToolbar(
-                  controller: session,
-                  viewerController: _viewer,
-                  // save lives in the header now, not the dock
-                  textPrompt: widget.textPrompt ?? showPdfTextPrompt,
-                  imagePicker: widget.imagePicker,
-                  fontPicker: widget.fontPicker,
-                  palette: widget.palette,
-                  tools: features.tools,
-                  groups: features.toolGroups,
-                  toolShortcuts: _toolShortcuts,
-                  showMarkup: features.markup,
-                  showUndoRedo: features.undoRedo,
-                  showColor: features.colorControls,
-                  showStyle: features.styleControls,
-                  showFlatten: features.flatten,
-                  leading: widget.toolbarLeading,
-                  trailing: widget.toolbarTrailing,
-                );
+              : widget.toolbarBuilder?.call(context, session, _viewer) ??
+                  PdfEditingToolbar(
+                    controller: session,
+                    viewerController: _viewer,
+                    // save lives in the header now, not the dock
+                    textPrompt: widget.textPrompt ?? showPdfTextPrompt,
+                    imagePicker: widget.imagePicker,
+                    fontPicker: widget.fontPicker,
+                    palette: widget.palette,
+                    tools: features.tools,
+                    groups: features.toolGroups,
+                    toolShortcuts: _toolShortcuts,
+                    showMarkup: features.markup,
+                    showUndoRedo: features.undoRedo,
+                    showColor: features.colorControls,
+                    showStyle: features.styleControls,
+                    showFlatten: features.flatten,
+                    leading: widget.toolbarLeading,
+                    trailing: widget.toolbarTrailing,
+                  );
           final viewOptionsControl = PdfShellControlItem(
             key: const ValueKey('pdf-shell-view-options'),
             icon: Icons.display_settings_outlined,

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -685,6 +685,39 @@ void main() {
       expect(changed, 1);
     });
 
+    testWidgets('custom toolbar builder can replace the stock toolbar',
+        (tester) async {
+      var changed = 0;
+      await pump(
+        tester,
+        PdfEditorView(
+          bytes: buildMultiPagePdf(1),
+          toolbarBuilder: (context, editing, viewer) => Material(
+            child: IconButton(
+              key: const ValueKey('custom-toolbar-builder-rectangle'),
+              icon: const Icon(Icons.crop_square),
+              tooltip: 'Add host rectangle',
+              onPressed: () => editing.addRectangle(
+                0,
+                const PdfRect(100, 550, 180, 610),
+              ),
+            ),
+          ),
+          onDocumentChanged: (_) => changed++,
+        ),
+      );
+
+      expect(find.byType(PdfEditingToolbar), findsNothing);
+
+      await tester.tap(
+        find.byKey(const ValueKey('custom-toolbar-builder-rectangle')),
+        kind: PointerDeviceKind.mouse,
+      );
+      await tester.pump();
+
+      expect(changed, 1);
+    });
+
     testWidgets('external controller: edits flow through onDocumentChanged',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));


### PR DESCRIPTION
### Motivation
- Issue #195 requested a way to customize editor chrome beyond the existing per-tool hooks, so provide an escape hatch that lets hosts replace the whole toolbar without changing library internals.

### Description
- Add `PdfEditorToolbarBuilder` typedef and a `toolbarBuilder` parameter to `PdfEditorView` so hosts can supply a custom toolbar widget that receives the active `PdfEditingController` and `PdfViewerController`.
- Wire `widget.toolbarBuilder?.call(context, session, _viewer) ?? PdfEditingToolbar(...)` into the editor shell to let a null builder fall back to the stock toolbar while `PdfEditorFeatures.toolbar` still gates toolbar chrome.
- Document the pattern in `packages/dart_pdf_editor/README.md` with a usage example showing how to replace the stock toolbar and drive the controller directly.
- Add a widget test `custom toolbar builder can replace the stock toolbar` that verifies a host-provided toolbar replaces `PdfEditingToolbar` and can drive edits via the owned session.

### Testing
- Ran static analysis: `fvm dart analyze packages/dart_pdf_editor/lib/src/pdf_editor_view.dart packages/dart_pdf_editor/test/pdf_shell_test.dart` (no issues).
- Ran the widget test: `cd packages/dart_pdf_editor && fvm flutter test test/pdf_shell_test.dart --plain-name 'custom toolbar builder can replace the stock toolbar'` and it passed (All tests passed).
- Ran `dart format` on the edited files as part of the workflow (no formatting issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44c437f928832bbc096f1ab419b5d2)