### PR TITLE
perf(pdf_cos): byte-level real parsing + operator interning in CosLexer

### DIFF
--- a/packages/pdf_cos/lib/src/lexer.dart
+++ b/packages/pdf_cos/lib/src/lexer.dart
@@ -147,6 +147,14 @@ class CosLexer {
       return CosToken(CosTokenType.integer, start, iv);
     }
 
+    // PDF reals have no exponent (§7.3.3): sign, digits, one dot. With ≤15
+    // significant digits, digits/10^frac is one exact integer divided by one
+    // exact power of ten - a single correctly-rounded division, bit-for-bit
+    // identical to double.parse - without the string allocation. Content
+    // streams are real-dense (every coordinate), so this is hot.
+    final fast = _parseRealRange(start, p);
+    if (fast != null) return CosToken(CosTokenType.real, start, fast);
+
     final raw = String.fromCharCodes(bytes, start, p);
     var s = raw;
     if (s.startsWith('.')) s = '0$s';
@@ -155,6 +163,47 @@ class CosLexer {
     final v = double.tryParse(s);
     if (v == null) throw CosParseException('malformed number "$raw"', start);
     return CosToken(CosTokenType.real, start, v);
+  }
+
+  static const List<double> _pow10 = [
+    1.0, 10.0, 100.0, 1e3, 1e4, 1e5, 1e6, 1e7, //
+    1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15,
+  ];
+
+  /// Parses the real in `bytes[start..end)` when it is a plain
+  /// `sign? digits* ('.' digits*)?` with ≤15 total digits; null otherwise
+  /// (multiple dots, embedded signs, digit-heavy) so the caller can fall
+  /// back to the string path with identical semantics.
+  double? _parseRealRange(int start, int end) {
+    var i = start;
+    var negative = false;
+    final first = bytes[i];
+    if (first == 0x2B || first == 0x2D) {
+      negative = first == 0x2D;
+      i++;
+    }
+    var digits = 0;
+    var nDigits = 0;
+    var fracCount = 0;
+    var sawDot = false;
+    var sawDigit = false;
+    for (; i < end; i++) {
+      final b = bytes[i];
+      if (b == 0x2E) {
+        if (sawDot) return null;
+        sawDot = true;
+      } else {
+        final d = b - 0x30;
+        if (d < 0 || d > 9) return null;
+        digits = digits * 10 + d;
+        nDigits++;
+        if (sawDot) fracCount++;
+        sawDigit = true;
+      }
+    }
+    if (!sawDigit || nDigits > 15) return null;
+    final v = digits / _pow10[fracCount];
+    return negative ? -v : v;
   }
 
   /// Parses the integer in `bytes[start..end)` exactly as
@@ -317,7 +366,25 @@ class CosLexer {
           'unexpected byte 0x${bytes[position].toRadixString(16)}', start);
     }
     position = p;
-    return CosToken(
-        CosTokenType.keyword, start, String.fromCharCodes(bytes, start, p));
+    return CosToken(CosTokenType.keyword, start, _internKeyword(start, p));
+  }
+
+  /// Interned strings for keywords up to 3 bytes, packed little-endian into
+  /// one int. Content streams repeat a tiny operator vocabulary millions of
+  /// times; handing back one shared string per spelling replaces a
+  /// String.fromCharCodes allocation per operator token.
+  static final Map<int, String> _keywordIntern = {};
+
+  String _internKeyword(int start, int end) {
+    final len = end - start;
+    if (len > 3) return String.fromCharCodes(bytes, start, end);
+    var packed = bytes[start];
+    if (len > 1) packed |= bytes[start + 1] << 8;
+    if (len > 2) packed |= bytes[start + 2] << 16;
+    final hit = _keywordIntern[packed];
+    if (hit != null) return hit;
+    final s = String.fromCharCodes(bytes, start, end);
+    if (_keywordIntern.length < 4096) _keywordIntern[packed] = s;
+    return s;
   }
 }

--- a/packages/pdf_cos/test/lexer_test.dart
+++ b/packages/pdf_cos/test/lexer_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:test/test.dart';
@@ -30,6 +32,33 @@ void main() {
       expect(lex('.5').realValue, 0.5);
       expect(lex('-.5').realValue, -0.5);
       expect(lex('4.').realValue, 4.0);
+    });
+
+    test('fast real path is bit-exact with double.parse', () {
+      // The byte-level real parser (≤15 digits, one dot, no exponent) must
+      // produce the identical double to the string path it replaces.
+      final rng = math.Random(42);
+      for (var i = 0; i < 20000; i++) {
+        final intDigits = rng.nextInt(8);
+        final fracDigits = rng.nextInt(15 - intDigits);
+        final sign = ['', '-', '+'][rng.nextInt(3)];
+        final intPart =
+            List.generate(intDigits, (_) => rng.nextInt(10)).join();
+        final fracPart =
+            List.generate(fracDigits, (_) => rng.nextInt(10)).join();
+        final s = '$sign$intPart.$fracPart';
+        if (intPart.isEmpty && fracPart.isEmpty) continue;
+        final normalized = [
+          if (sign == '-') '-',
+          if (intPart.isEmpty) '0' else intPart,
+          '.',
+          if (fracPart.isEmpty) '0' else fracPart,
+        ].join();
+        expect(lex(s).realValue, double.parse(normalized), reason: s);
+      }
+      // >15 digits falls back to the string path - still exact
+      expect(lex('123456789.0123456789').realValue,
+          double.parse('123456789.0123456789'));
     });
 
     test('large integers parse exactly, matching int.tryParse', () {


### PR DESCRIPTION
## What

Two allocation-free fast paths in `CosLexer`, extracted from the `experiment/flutter-gpu` branch — these are the non-GPU performance gains that fell out of GPU profiling and they benefit every consumer of pdf_cos (interpret, the production Canvas renderer, the editor):

- **Byte-level real parsing.** PDF reals have no exponent (ISO 32000 §7.3.3), so a real with ≤15 total digits parses directly from the byte buffer as one exact integer divided by one exact power of ten — a single correctly-rounded division, **bit-for-bit identical to `double.parse`**, with no `String.fromCharCodes` allocation. Unusual spellings (>15 digits, multiple dots, embedded signs) fall back to the existing string path unchanged, preserving the lenient-input semantics.
- **Operator keyword interning.** ≤3-byte keywords (`Tj`, `re`, `cm`, `l`, `m`, `f`, …) repeat a tiny vocabulary millions of times per CAD page; they now intern through a capped packed-int table instead of allocating a fresh string per token.

## Why

Content streams are real-dense — every coordinate, colour component, and matrix entry. GPU-side profiling showed `ContentStreamParser.parse` at 30–45% of heavy CAD page time, with the cost concentrated in per-real string allocation + `double.parse`.

## Measured (private 49-file real-world corpus, 255 pages, scale 2, best-of-3)

| benchmark | before | after |
|---|---|---|
| interpret (parse + display ops, no raster) | 17.1 ms/page | **12.8 ms/page** |
| Flutter Canvas full render | 61.3 ms/page | **52.0 ms/page (−15%)** |
| worst page parse (ly9-far-cad p5, ~29k converted-text fills) | 347 ms | 250 ms |

Interpret is now ~1.9× faster than PDFium on the same corpus (24.9 ms/page).

## Correctness

- New KAT: 20k random reals must lex to the identical double as `double.parse` (plus a >15-digit fallback case).
- Checked-in Ghent render baselines pass unchanged on this branch — the fast path is bit-exact in practice, not just by argument.
- All suites green: pdf_cos 198, pdf_document 590, pdf_graphics 691, dart_pdf_editor 1270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)