### PR TITLE
Fix revision-cloud shape and add polygon cloud drawing

### DIFF
--- a/doc/dev-log/2026-07-09-revision-cloud-crop-fix.md
+++ b/doc/dev-log/2026-07-09-revision-cloud-crop-fix.md
@@ -1,0 +1,43 @@
+# Revision cloud: uncrop the puffs + preview the first polygon edge
+
+Follow-up to `2026-07-09-revision-cloud-shape-and-polygons.md`. Two reported
+defects: the committed cloud's scallops were clipped at the edges (corners
+rendered as flat brackets), and building a polygon cloud gave no feedback
+until the third vertex.
+
+## The crop
+
+`_appendCloudPath` draws each scallop's apex `arc * 1.15` past the polygon
+edge (plus half the stroke). For a rectangle every point of an edge sits on
+the box extreme, so the puffs protrude by the *full* bulge on all four sides.
+`_cloudPadding` returned exactly that bulge - but `_pointBounds` insets the
+`/Rect` and form BBox by only `pad / 2 + 1`, so the box was padded by roughly
+half the puff height and the form XObject clipped the outer half of every
+scallop (~5.5 pt at a 2 pt stroke; the visible "edges removed").
+
+Fix: `_cloudPadding` now returns `2 * arc * bulgeFactor + strokeWidth`, so
+after `_pointBounds` halves it the inset is `arc*1.15 + strokeWidth/2 + 1` -
+the full bulge plus half the stroke plus a point of margin. `annotation_editor.dart`.
+
+The new `annotation_editor_test.dart` case parses every `m`/`l`/`c` operand
+in the appearance stream, takes the path's bounding box, and asserts it (plus
+half the stroke) fits inside the form BBox - and that the puffs still bulge
+past the vertices. It fails on the old padding (path reaches 105.6, BBox
+starts at 111.1) and passes now.
+
+## The missing first-edge preview
+
+`_paintPathPreview` sent the cloud tool straight to `_paintCloudPolygon`,
+which needs 3+ points, so a polygon cloud with one vertex placed + the hover
+point (2 points) drew nothing at all - no rubber-band. It now falls back to
+the straight connecting path for < 3 points, so placing the first side gives
+feedback like every other poly tool. `editing_overlay.dart`. (The drag
+rectangle preview and the 3+-vertex polygon preview already drew clouds and
+are unchanged.)
+
+## Verified
+
+Rendered committed rectangle + triangle clouds to PNG (via
+`PdfPageRenderer.renderImage`): corners are now complete scallops, nothing
+clipped. `annotation_editor_test.dart` (all 71) and the three `editing_test`
+cloud widget tests pass; `dart analyze` clean on the touched files.

--- a/doc/dev-log/2026-07-09-revision-cloud-shape-and-polygons.md
+++ b/doc/dev-log/2026-07-09-revision-cloud-shape-and-polygons.md
@@ -1,0 +1,57 @@
+# Revision cloud: real puffs + polygon input
+
+## What changed
+
+Two things about the cloudy `/BE` border effect ("revision cloud"):
+
+1. **The scallops looked like a stamp perforation, not a cloud.** The old
+   generator drew a shallow, tangent-footed ripple whose arc radius was tied
+   to the (usually hairline) stroke width - `max(4, strokeWidth * 3)` - so a
+   default 2 pt stroke got ~6 pt bumps, dozens of them, each barely lifting
+   off the edge. Rewrote it as proper revision-cloud puffs: each scallop is
+   two quarter-arc Béziers that **leave the edge perpendicular** (so adjacent
+   puffs meet in a cusp/neck) and bulge outward, with a fixed arc radius
+   `max(12, strokeWidth * 4)` in page points and a 1.15x bulge so the puffs
+   read as slightly-overlapping circles. Scallops are spread one per arc
+   diameter (`round(edgeLen / (2*arc))`, min 1), and the bulge is capped at
+   `arc * 1.15` so a lone puff on an awkward-length edge can't balloon past
+   the padded `/Rect`.
+
+2. **The cloud tool could only make rectangles.** Now it's a hybrid: **drag**
+   still rubber-bands a rectangle, but a **tap** drops a free-form vertex and
+   each further tap extends it - **double-tap finishes** (same close gesture
+   as the polygon/polyline tools). Once one vertex is down the tool is "in
+   progress" and a stray drag is ignored instead of restarting a rectangle.
+
+## Where
+
+- `pdf_document` `annotation_editor.dart`: `_appendCloudPath` (the appearance
+  stream), plus `_cloudArcRadius` / `_cloudBulgeFactor` and a `_cloudPadding`
+  that now matches the real puff height (`arc * 1.15 + strokeWidth`) so the
+  `/Rect` and form BBox contain the scallops.
+- `dart_pdf_editor` `editing_overlay.dart`: `_cloudPath` mirrors the same
+  math for the live preview/afterimage. It maps the page-unit arc radius into
+  view space (`max(12 * geometry.scale, strokeWidth * 4)`) so the preview
+  lines up scallop-for-scallop with the committed appearance. Input wiring:
+  `_onTapUp` adds a vertex for the cloud tool, `_onDoubleTap`/`_finishPolyPath`
+  commit it via the new `PdfEditingController.addCloudPolygonPoints`, `_panStart`
+  bails while a cloud polygon is in progress, and the build-time
+  `_polyPoints` clear + `_onHover` rubber-band now keep the cloud tool alive
+  even though it is deliberately *not* in `_polyTool` (that set adds points on
+  pointer-down, which would kill the drag-rectangle path).
+
+## Gotchas
+
+- The preview painter (`_paintPathPreview`) and afterimage were already
+  cloud-aware; only the *input* side (tap-to-add / double-tap-to-finish) was
+  missing, so most of the change is gesture plumbing, not painting.
+- Tap-to-add rides `onTapUp` (not pointer-down like the other poly tools) on
+  purpose: `onTapUp` fires for a tap but not a drag, which is exactly the
+  drag-vs-click arbitration the hybrid needs. The double-tap's extra coincident
+  taps are dropped by the existing `distance >= 2` vertex de-dup.
+
+## Tuning harness
+
+Geometry was tuned against a Chromium screenshot of a faithful JS port of the
+Dart algorithm (rectangle CW/CCW + triangle, `/Rect` box overlaid to confirm
+the padding contains the puffs) rather than eyeballed blind.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1660,25 +1660,35 @@ class PdfEditingController extends ChangeNotifier {
       pages: [pageIndex],
       contentPages: const <int>[]);
 
-  void addCloudPolygon(int pageIndex, PdfRect rect) => apply(
-      (e) => e.addPolygon(
-            pageIndex,
-            [
-              (rect.left, rect.bottom),
-              (rect.right, rect.bottom),
-              (rect.right, rect.top),
-              (rect.left, rect.top),
-            ],
-            strokeColor: _colorValue,
-            strokeWidth: preferences.strokeWidth,
-            fillColor: _rgbOf(preferences.shapeFillColor),
-            opacity: preferences.opacity,
-            dashPattern: _lineDashPattern,
-            cloudy: true,
-            author: author,
-          ),
-      pages: [pageIndex],
-      contentPages: const <int>[]);
+  /// Drag out a rectangular cloudy /Polygon from an axis-aligned [rect].
+  void addCloudPolygon(int pageIndex, PdfRect rect) => addCloudPolygonPoints(
+        pageIndex,
+        [
+          (rect.left, rect.bottom),
+          (rect.right, rect.bottom),
+          (rect.right, rect.top),
+          (rect.left, rect.top),
+        ],
+      );
+
+  /// Click out a cloudy /Polygon from an arbitrary vertex list (3+ points).
+  void addCloudPolygonPoints(
+          int pageIndex, List<(double, double)> points) =>
+      apply(
+        (e) => e.addPolygon(
+          pageIndex,
+          points,
+          strokeColor: _colorValue,
+          strokeWidth: preferences.strokeWidth,
+          fillColor: _rgbOf(preferences.shapeFillColor),
+          opacity: preferences.opacity,
+          dashPattern: _lineDashPattern,
+          cloudy: true,
+          author: author,
+        ),
+        pages: [pageIndex],
+        contentPages: const <int>[],
+      );
 
   // ---------------------------------------------------------------------
   // measurements (§12.9)

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -973,6 +973,13 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _tool == PdfEditTool.measureArc ||
       _tool == PdfEditTool.measureVolume;
 
+  /// The cloud tool is a hybrid: a drag rubber-bands a rectangle, but a
+  /// tap starts (and each further tap extends) a free-form vertex list -
+  /// finished by a double-tap. This is true once at least one vertex has
+  /// been placed, so a drag no longer restarts the shape as a rectangle.
+  bool get _cloudPolyInProgress =>
+      _tool == PdfEditTool.cloudPolygon && (_polyPoints?.isNotEmpty ?? false);
+
   /// The number of clicks a fixed-arity poly tool takes before it
   /// auto-finishes - three for the angle and arc takeoffs - or null for an
   /// open-ended poly tool (finished by a double-tap).
@@ -2525,6 +2532,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _selectPanStart(details);
       return;
     }
+    if (_cloudPolyInProgress) {
+      // committing a cloud by clicks: a stray drag must not rubber-band a
+      // rectangle over the vertices already placed
+      return;
+    }
     switch (_tool) {
       case null:
         break; // eyedropper only - taps, no drags
@@ -3261,6 +3273,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       points.add(finalPoint);
     }
     final closed = _tool == PdfEditTool.polygon ||
+        _tool == PdfEditTool.cloudPolygon ||
         _tool == PdfEditTool.measureArea ||
         _tool == PdfEditTool.measureVolume;
     final minPoints = _fixedPolyCount ?? (closed ? 3 : 2);
@@ -3299,7 +3312,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       default:
         // distance/slope are drag tools (handled elsewhere); a poly gesture
         // with no measure kind active is a plain poly annotation.
-        if (_tool == PdfEditTool.polygon) {
+        if (_tool == PdfEditTool.cloudPolygon) {
+          _controller.addCloudPolygonPoints(widget.pageIndex, pagePoints);
+        } else if (_tool == PdfEditTool.polygon) {
           _controller.addPolygon(widget.pageIndex, pagePoints);
         } else {
           _controller.addPolyLine(widget.pageIndex, pagePoints);
@@ -3318,8 +3333,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       tool: _tool!,
       color: _controller.color.withValues(alpha: opacity),
       // a polygon's interior fill (so the commit afterimage matches the
-      // filled appearance, not just its outline)
-      fillColor: _tool == PdfEditTool.polygon && fill != null
+      // filled appearance, not just its outline); the cloud fills its
+      // straight footprint the same way
+      fillColor: (_tool == PdfEditTool.polygon ||
+                  _tool == PdfEditTool.cloudPolygon) &&
+              fill != null
           ? fill.withValues(alpha: opacity)
           : null,
       strokeWidth: _controller.strokeWidth * _geometry.scale,
@@ -3562,6 +3580,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_polyTool) {
       return;
     }
+    if (_tool == PdfEditTool.cloudPolygon) {
+      // a tap (not a drag) drops a cloud vertex; double-tap finishes it
+      _addPolyPoint(details.localPosition);
+      return;
+    }
     final (x, y) = _geometry.toPagePoint(details.localPosition);
     if (_selectMode) {
       // tapping the already-selected free text edits it in place,
@@ -3653,7 +3676,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       }
       return;
     }
-    if (!_polyTool) return;
+    if (!_polyTool && _tool != PdfEditTool.cloudPolygon) return;
     _finishPolyPath(_polyDoubleTapPosition);
     _polyDoubleTapPosition = null;
   }
@@ -3745,7 +3768,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         setState(() => _signaturePreview = event.localPosition);
       }
       cursor = SystemMouseCursors.precise;
-    } else if (_polyTool) {
+    } else if (_polyTool || _tool == PdfEditTool.cloudPolygon) {
+      // once a cloud vertex is down, the hover rubber-bands the next edge;
+      // before that the cloud tool still rubber-bands a rectangle on drag
       if (_polyPoints != null && event.localPosition != _polyHover) {
         setState(() => _polyHover = event.localPosition);
       }
@@ -4256,7 +4281,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             !identical(_afterDocument, _controller.document))) {
       _clearAfterimage();
     }
-    if (_polyPoints != null && !_polyTool) {
+    if (_polyPoints != null &&
+        !_polyTool &&
+        _tool != PdfEditTool.cloudPolygon) {
       _polyPoints = null;
       _polyHover = null;
     }
@@ -4445,9 +4472,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         onPanEnd: _panEnd,
         onTapUp: _onTapUp,
         onDoubleTapDown:
-            _polyTool || _tool == PdfEditTool.form ? _onDoubleTapDown : null,
+            _polyTool || _tool == PdfEditTool.cloudPolygon ||
+                    _tool == PdfEditTool.form
+                ? _onDoubleTapDown
+                : null,
         onDoubleTap:
-            _polyTool || _tool == PdfEditTool.form ? _onDoubleTap : null,
+            _polyTool || _tool == PdfEditTool.cloudPolygon ||
+                    _tool == PdfEditTool.form
+                ? _onDoubleTap
+                : null,
         child: MouseRegion(
           cursor: _cursor,
           onHover: _onHover,
@@ -5352,11 +5385,20 @@ class _EditingPreviewPainter extends CustomPainter {
           ..strokeJoin = StrokeJoin.round);
   }
 
+  /// Extra bulge past a semicircle so scallops read as overlapping puffs.
+  /// Mirrors `_cloudBulgeFactor` in pdf_document's annotation_editor so the
+  /// live preview matches the committed appearance stream.
+  static const double _cloudBulgeFactor = 1.15;
+
   Path _cloudPath(List<Offset> points, double strokeWidth) {
     final path = Path();
     if (points.length < 3) return path;
     final clockwise = _signedArea(points) < 0;
-    final radius = math.max(4.0, strokeWidth * 3.0);
+    // The appearance stream uses max(12, sw*4) *page* points; map that arc
+    // radius into view space (strokeWidth here is already scaled) so the
+    // preview and the saved cloud line up scallop-for-scallop.
+    final arc = math.max(12.0 * geometry.scale, strokeWidth * 4.0);
+    const k = 0.5522847498307936;
     var first = true;
     for (var i = 0; i < points.length; i++) {
       final a = points[i];
@@ -5364,36 +5406,38 @@ class _EditingPreviewPainter extends CustomPainter {
       final delta = b - a;
       final length = delta.distance;
       if (length < 0.01) continue;
-      final scallops = math.max(1, (length / (radius * 1.7)).round());
+      final scallops = math.max(1, (length / (2 * arc)).round());
       final unit = delta / length;
       final normal =
           clockwise ? Offset(-unit.dy, unit.dx) : Offset(unit.dy, -unit.dx);
-      const k = 0.5522847498307936;
+      final chord = length / scallops;
+      final r = chord / 2;
+      final bulge = math.min(r, arc) * _cloudBulgeFactor;
+      final ca = r * k; // apex control handle, along the edge
+      final cf = bulge * k; // foot control handle, perpendicular (outward)
       for (var j = 0; j < scallops; j++) {
         final t0 = j / scallops;
         final t1 = (j + 1) / scallops;
         final start = Offset.lerp(a, b, t0)!;
         final end = Offset.lerp(a, b, t1)!;
-        final chord = length / scallops;
-        final bulge = math.min(radius, chord * 0.55);
-        final mid = Offset.lerp(start, end, 0.5)! + normal * bulge;
+        final apex = Offset.lerp(start, end, 0.5)! + normal * bulge;
         if (first) {
           path.moveTo(start.dx, start.dy);
           first = false;
         }
         path.cubicTo(
-          start.dx + unit.dx * chord * k * 0.5,
-          start.dy + unit.dy * chord * k * 0.5,
-          mid.dx - unit.dx * chord * k * 0.5,
-          mid.dy - unit.dy * chord * k * 0.5,
-          mid.dx,
-          mid.dy,
+          start.dx + normal.dx * cf,
+          start.dy + normal.dy * cf,
+          apex.dx - unit.dx * ca,
+          apex.dy - unit.dy * ca,
+          apex.dx,
+          apex.dy,
         );
         path.cubicTo(
-          mid.dx + unit.dx * chord * k * 0.5,
-          mid.dy + unit.dy * chord * k * 0.5,
-          end.dx - unit.dx * chord * k * 0.5,
-          end.dy - unit.dy * chord * k * 0.5,
+          apex.dx + unit.dx * ca,
+          apex.dy + unit.dy * ca,
+          end.dx + normal.dx * cf,
+          end.dy + normal.dy * cf,
           end.dx,
           end.dy,
         );

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -5760,9 +5760,12 @@ class _EditingPreviewPainter extends CustomPainter {
               ..style = PaintingStyle.fill);
       }
     }
-    if (tool == PdfEditTool.cloudPolygon) {
+    if (tool == PdfEditTool.cloudPolygon && points.length >= 3) {
       _paintCloudPolygon(canvas, points, color, fillColor, width, dashed);
     } else {
+      // For the cloud tool with fewer than three vertices there is no cloud
+      // to draw yet, so this rubber-bands the straight edge instead - placing
+      // the first side of a polygon cloud still gives live feedback.
       canvas.drawPath(dashed ? _dashPath(path, width) : path, paint);
     }
     if (tool == PdfEditTool.arrow) {

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -577,6 +577,51 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('cloud polygon tool taps points and double-taps to finish',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing.tool = PdfEditTool.cloudPolygon;
+      await tester.pump();
+
+      await tester.tapAt(view(100, 700));
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.tapAt(view(250, 720));
+      await tester.pump(const Duration(milliseconds: 400));
+      // one vertex short of a closed polygon: nothing committed yet
+      expect(editing.document.page(0).annotations, isEmpty);
+
+      await tester.tapAt(view(180, 620));
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(view(180, 620));
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.subtype, 'Polygon');
+      expect(annotation.hasCloudyBorder, isTrue);
+      expect(annotation.vertices, hasLength(3),
+          reason: 'three tapped vertices, the double-tap not double-counted');
+      expect(annotation.vertices!.first.$1, closeTo(100, 1));
+      expect(annotation.vertices!.first.$2, closeTo(700, 1));
+      await settle(tester);
+    });
+
+    testWidgets('a drag after the first cloud vertex does not add a rectangle',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing.tool = PdfEditTool.cloudPolygon;
+      await tester.pump();
+
+      // place one vertex, then drag: the drag must be ignored, not commit a
+      // rectangle over the in-progress polygon
+      await tester.tapAt(view(120, 700));
+      await tester.pump(const Duration(milliseconds: 400));
+      await drag(tester, view(200, 650), view(300, 560));
+      await tester.pump();
+
+      expect(editing.document.page(0).annotations, isEmpty);
+      await settle(tester);
+    });
+
     testWidgets('dragging with the arrow tool adds a dashed Line',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -4048,9 +4048,16 @@ extension PdfAnnotationEditing on PdfEditor {
   double _cloudArcRadius(double strokeWidth) =>
       math.max(12.0, strokeWidth * 4.0);
 
+  /// Padding for the cloud's `/Rect` and form BBox. A scallop's apex sits
+  /// `_cloudArcRadius * _cloudBulgeFactor` past the polygon edge (plus half
+  /// the stroke) - and on a rectangle every point of an edge is at the box's
+  /// extreme, so the puffs protrude by the full bulge. `_pointBounds` insets
+  /// by only `pad / 2 + 1`, so the padding is doubled here; otherwise the
+  /// form BBox clips the outer half of every puff (the scallops render as
+  /// flattened brackets at the edges).
   double _cloudPadding(double strokeWidth) => math.max(
       _linePadding(strokeWidth),
-      _cloudArcRadius(strokeWidth) * _cloudBulgeFactor + strokeWidth);
+      2 * _cloudArcRadius(strokeWidth) * _cloudBulgeFactor + strokeWidth);
 
   ContentWriter _cloudPolygonContent(
     List<(double, double)> points, {

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -4038,8 +4038,19 @@ extension PdfAnnotationEditing on PdfEditor {
   double _linePadding(double strokeWidth, {bool dashed = false}) =>
       strokeWidth + (dashed ? strokeWidth : 0);
 
-  double _cloudPadding(double strokeWidth) =>
-      math.max(_linePadding(strokeWidth), math.max(4.0, strokeWidth * 3.0));
+  /// Extra bulge past a semicircle so the scallops read as overlapping
+  /// puffs (with cusps between them) instead of flat half-circles.
+  static const double _cloudBulgeFactor = 1.15;
+
+  /// Target radius of one cloud scallop, in page points. Independent of the
+  /// (usually hairline) stroke so the puffs stay fluffy; grows only when the
+  /// stroke itself is heavy enough to crowd them.
+  double _cloudArcRadius(double strokeWidth) =>
+      math.max(12.0, strokeWidth * 4.0);
+
+  double _cloudPadding(double strokeWidth) => math.max(
+      _linePadding(strokeWidth),
+      _cloudArcRadius(strokeWidth) * _cloudBulgeFactor + strokeWidth);
 
   ContentWriter _cloudPolygonContent(
     List<(double, double)> points, {
@@ -4082,7 +4093,8 @@ extension PdfAnnotationEditing on PdfEditor {
       ContentWriter w, List<(double, double)> points, double strokeWidth) {
     if (points.length < 3) return;
     final clockwise = _signedArea(points) < 0;
-    final radius = math.max(4.0, strokeWidth * 3.0);
+    final arc = _cloudArcRadius(strokeWidth);
+    const k = 0.5522847498307936;
     var first = true;
     for (var i = 0; i < points.length; i++) {
       final a = points[i];
@@ -4091,7 +4103,8 @@ extension PdfAnnotationEditing on PdfEditor {
       final dy = b.$2 - a.$2;
       final length = math.sqrt(dx * dx + dy * dy);
       if (length < 0.01) continue;
-      final scallops = math.max(1, (length / (radius * 1.7)).round());
+      // Spread whole scallops evenly along the edge, ~one per arc diameter.
+      final scallops = math.max(1, (length / (2 * arc)).round());
       final ux = dx / length;
       final uy = dy / length;
       // For clockwise polygons the interior is on the right side of each
@@ -4099,38 +4112,31 @@ extension PdfAnnotationEditing on PdfEditor {
       // normal to make the cloud bulge outward.
       final nx = clockwise ? -uy : uy;
       final ny = clockwise ? ux : -ux;
-      final k = 0.5522847498307936;
+      final chord = length / scallops;
+      final r = chord / 2; // half the foot-to-foot span
+      final bulge = math.min(r, arc) * _cloudBulgeFactor; // apex height
+      final ca = r * k; // apex control handle, along the edge
+      final cf = bulge * k; // foot control handle, perpendicular (outward)
       for (var j = 0; j < scallops; j++) {
         final t0 = j / scallops;
         final t1 = (j + 1) / scallops;
-        final mx0 = a.$1 + dx * t0;
-        final my0 = a.$2 + dy * t0;
-        final mx1 = a.$1 + dx * t1;
-        final my1 = a.$2 + dy * t1;
-        final chord = length / scallops;
-        final bulge = math.min(radius, chord * 0.55);
-        final cx = (mx0 + mx1) / 2 + nx * bulge;
-        final cy = (my0 + my1) / 2 + ny * bulge;
+        final sx = a.$1 + dx * t0;
+        final sy = a.$2 + dy * t0;
+        final ex = a.$1 + dx * t1;
+        final ey = a.$2 + dy * t1;
+        final apx = (sx + ex) / 2 + nx * bulge;
+        final apy = (sy + ey) / 2 + ny * bulge;
         if (first) {
-          w.moveTo(mx0, my0);
+          w.moveTo(sx, sy);
           first = false;
         }
-        w.curveTo(
-          mx0 + ux * chord * k * 0.5,
-          my0 + uy * chord * k * 0.5,
-          cx - ux * chord * k * 0.5,
-          cy - uy * chord * k * 0.5,
-          cx,
-          cy,
-        );
-        w.curveTo(
-          cx + ux * chord * k * 0.5,
-          cy + uy * chord * k * 0.5,
-          mx1 - ux * chord * k * 0.5,
-          my1 - uy * chord * k * 0.5,
-          mx1,
-          my1,
-        );
+        // Two quarter-arcs meeting at the apex: the feet leave the edge
+        // perpendicular (giving each puff a distinct neck/cusp), the apex
+        // runs parallel to the edge.
+        w.curveTo(sx + nx * cf, sy + ny * cf, apx - ux * ca, apy - uy * ca,
+            apx, apy);
+        w.curveTo(apx + ux * ca, apy + uy * ca, ex + nx * cf, ey + ny * cf,
+            ex, ey);
       }
     }
     w.closePath();

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -1107,6 +1107,81 @@ void main() {
     expect(content, contains('S\n'));
   });
 
+  test('cloud scallops stay inside the form BBox (no clipped puffs)', () {
+    // A rectangle's every edge lies on the box extreme, so the outward puffs
+    // protrude by the full bulge. If /Rect and the form BBox are not padded
+    // enough, the form XObject clips the outer half of each scallop.
+    final doc = roundTrip((e) {
+      e.addPolygon(
+        0,
+        [(120, 500), (420, 500), (420, 640), (120, 640)],
+        strokeWidth: 2,
+        cloudy: true,
+      );
+    });
+    final annotation = doc.page(0).annotations.single;
+    final bbox = doc.cos
+        .resolve(annotation.normalAppearance!.dictionary['BBox']) as CosArray;
+    double num(CosObject o) {
+      final r = doc.cos.resolve(o);
+      return switch (r) {
+        CosInteger(:final value) => value.toDouble(),
+        CosReal(:final value) => value,
+        _ => throw StateError('not a number: $r'),
+      };
+    }
+    final bx0 = num(bbox[0]);
+    final by0 = num(bbox[1]);
+    final bx1 = num(bbox[2]);
+    final by1 = num(bbox[3]);
+
+    // Walk every path-construction coordinate in the appearance stream and
+    // confirm it (plus half the stroke) lands inside the BBox.
+    final content = appearanceText(doc, annotation);
+    final tokens = content.split(RegExp(r'\s+'));
+    final nums = <double>[];
+    var minX = double.infinity, minY = double.infinity;
+    var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+    void point(double x, double y) {
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+    }
+
+    for (final token in tokens) {
+      final value = double.tryParse(token);
+      if (value != null) {
+        nums.add(value);
+        continue;
+      }
+      switch (token) {
+        case 'm':
+        case 'l':
+          if (nums.length >= 2) {
+            point(nums[nums.length - 2], nums[nums.length - 1]);
+          }
+        case 'c':
+          if (nums.length >= 6) {
+            for (var i = nums.length - 6; i < nums.length; i += 2) {
+              point(nums[i], nums[i + 1]);
+            }
+          }
+      }
+      nums.clear();
+    }
+
+    expect(maxX, greaterThan(minX), reason: 'sanity: some path was parsed');
+    const halfStroke = 1.0; // strokeWidth 2 / 2
+    expect(minX - halfStroke, greaterThanOrEqualTo(bx0));
+    expect(minY - halfStroke, greaterThanOrEqualTo(by0));
+    expect(maxX + halfStroke, lessThanOrEqualTo(bx1));
+    expect(maxY + halfStroke, lessThanOrEqualTo(by1));
+    // and the puffs really do bulge out past the polygon vertices
+    expect(maxY, greaterThan(640));
+    expect(minY, lessThan(500));
+  });
+
   test('resizing a dashed arrow regenerates with scaled endpoints', () {
     final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
       ..addLine(0, (100, 100), (200, 140),


### PR DESCRIPTION
## Summary

The cloudy `/BE` border ("revision cloud") rendered as a shallow, tangent-footed ripple — more like a stamp perforation than a cloud — because the arc radius was tied to the (usually hairline) stroke width (`max(4, strokeWidth * 3)`). This rewrites the shared cloud path generator as proper outward puffs and also makes the cloud tool support **polygon** clouds, not just rectangles.

**Shape.** Each scallop is now two quarter-arc Béziers that leave the edge **perpendicular** (so adjacent puffs meet in a cusp/neck) and bulge outward, with a fixed arc radius `max(12, strokeWidth * 4)` in page points and a 1.15× bulge so the puffs read as slightly-overlapping circles. Scallops spread one per arc diameter (`round(edgeLen / (2·arc))`, min 1), and the bulge is capped at `arc · 1.15` so a lone puff on an awkward-length edge can't balloon past the padded `/Rect`. `_cloudPadding` grows to match the real puff height. The live preview (`_cloudPath`) mirrors the same math and maps the page-unit arc radius into view space so it lines up scallop-for-scallop with the committed appearance stream.

**Input.** The cloud tool is now a hybrid: **drag** still rubber-bands a rectangle, but a **tap** drops a free-form vertex (each further tap extends it) and a **double-tap** finishes — committed through the new `PdfEditingController.addCloudPolygonPoints`. Once a vertex is placed a stray drag is ignored instead of restarting a rectangle.

Before/after of the shape (faithful port of the shared Dart algorithm) is in the session; the old ripple becomes even outward puffs matching a hand-drawn revision cloud.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Feature
- [x] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (clean, whole repo)
- [x] `cd packages/pdf_document && fvm dart test` (annotation_editor_test — cloud appearance still emits the expected `c`/`f`/`S` operators and padded `/Rect`)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (editing_test + editing_tool_shortcuts_test; added cloud-polygon tap/double-tap and drag-guard tests)

Full corpus/Ghent sweeps not run: the change only affects clouds this codebase generates, and no checked-in corpus exercises a generated cloud.

## PDF fixtures and screenshots

Before/after comparison delivered in the session (rectangle + triangle, stroke width 2). Geometry was tuned against a Chromium screenshot of a faithful JS port of the Dart algorithm, with the padded `/Rect` overlaid to confirm the puffs stay inside it.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` ← `pdf_document` ← `pdf_graphics` ← `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The preview painter (`_paintPathPreview`) and afterimage were already cloud-aware; only the *input* side (tap-to-add / double-tap-to-finish) was missing, so most of the editing change is gesture plumbing.
- Tap-to-add deliberately rides `onTapUp` rather than pointer-down (unlike the other poly tools, which is why the cloud tool is intentionally *not* in `_polyTool`): `onTapUp` fires for a tap but not a drag, giving the drag-vs-click arbitration the hybrid needs. Extra coincident taps from a double-tap are dropped by the existing `distance >= 2` vertex de-dup.
- The arc radius is a fixed page-unit size (`max(12, strokeWidth·4)`), so larger shapes get more puffs rather than bigger ones — matching how Adobe revision clouds behave. Easy to expose as a style/intensity control later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y53wUgp1Nj3MZGdXH5JLfZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y53wUgp1Nj3MZGdXH5JLfZ)_