### PR TITLE
feat: add callout annotation tool

### DIFF
--- a/doc/dev-log/2026-07-09-callout-tool.md
+++ b/doc/dev-log/2026-07-09-callout-tool.md
@@ -72,3 +72,36 @@ joined to a point on the page by a leader line that ends in an arrow.
 Gotcha worth remembering: the 800×600 default test surface clips
 `view(x, y)` taps whose page-y is small - a commit tap must land inside the
 viewport (page-y ≳ 333 at `PdfViewerFit.width`).
+
+## Follow-up: preview arrow + independent terminus/box editing
+
+Review feedback drove three UX fixes:
+
+1. **Drag preview shows the arrow.** `_paintPathPreview` now draws an open
+   arrowhead at the *first* point for `PdfEditTool.callout` (the terminus is
+   the drag start, not the end like the arrow tool), matching the committed
+   `/OpenArrow`.
+2. **Leader stays visible while the box editor is open.** The preview painter
+   gained a `calloutLeader: (terminus, box, color, width)?` field, fed by
+   `_calloutLeaderPreview()`. `_paintCalloutLeader` draws the leader from the
+   terminus to the box's nearest edge + arrow, so the arrow doesn't vanish
+   between release and commit. The same helper feeds the leader while the
+   terminus handle is being dragged.
+3. **Terminus and text box move independently** (Bluebeam's model). New model
+   primitive `PdfEditor.reshapeCallout(annotation, {box, target})` rebuilds
+   `/CL`/`/RD`/`/Rect`/appearance from a new box and/or terminus, keeping the
+   other fixed and preserving text + style + ending. Wiring:
+   - `PdfAnnotation.calloutBox` reads the text-box sub-rect (/Rect inset by
+     /RD) - the counterpart to `calloutLine`.
+   - Overlay `_selectedViewRect` returns `calloutBox` for a callout, so the
+     resize handles + selection chrome hug the box, not the /Rect that also
+     encloses the leader/arrow. `resizeSelected`/`resizeSelectedLocal`
+     intercept callouts → `reshapeCallout(box:)` instead of scaling `/CL`.
+   - Overlay `_selectedVertexPoints` returns `[terminus]` for a callout, so
+     the Line/PolyLine vertex-handle machinery gives it one draggable handle
+     at the arrow tip; `_commitVertexDrag` routes callouts to
+     `reshapeSelectedCalloutTarget`. `showHandles` stays true (a callout isn't
+     `_selectedLineFamily`), so box handles and the terminus handle coexist.
+   Move (dragging the body) still translates the whole callout - only the
+   scale handle and the terminus handle are independent, which is what the
+   "scale handle scales both" complaint was about.

--- a/doc/dev-log/2026-07-09-callout-tool.md
+++ b/doc/dev-log/2026-07-09-callout-tool.md
@@ -1,0 +1,74 @@
+# Callout tool
+
+Added a Bluebeam-style **Callout** annotation tool: a `/FreeText` text box
+joined to a point on the page by a leader line that ends in an arrow.
+
+## Model (`pdf_document`)
+
+- `PdfEditor.addCallout(pageIndex, boxRect, text, target, {...})` in
+  `annotation_editor.dart`. It writes a `FreeText` annotation carrying the
+  callout-specific entries on top of what `addFreeText` writes:
+  - `/IT /FreeTextCallout`
+  - `/CL` - the leader points, arrow tip **first**, box attachment **last**
+    (§12.5.6.19). `_calloutLine(box, target)` picks the box edge nearest the
+    target and adds a short horizontal/vertical knee stub into the box, so the
+    leader reads as `[target, knee, attach]` (or `[target, attach]` when a
+    knee would be degenerate, e.g. the target lands inside the box).
+  - `/LE` - a **single** name (the arrow style on the tip), unlike a Line's
+    two-element `/LE`.
+  - `/RD` - the inset from the enclosing `/Rect` to the text box, so the box
+    is a sub-rect of `/Rect` (which must also enclose the leader + arrowhead).
+- The appearance is composed by `_calloutContent`: `_lineContent` draws the
+  leader + arrowhead (reusing the Line tool's `_drawEnding`), then
+  `_freeTextContent` draws the box on top. To merge the two writers a small
+  `ContentWriter.append(other)` was added (content_writer.dart).
+- `/Rect` == form `/BBox` == `_pointBounds([box corners, ...CL,
+  ...endingExtent])`, so the whole markup survives §12.5.5 appearance fitting.
+- **Reading it back:** `PdfAnnotation.isCallout` and `.calloutLine`
+  (annotation.dart) mirror the existing `.line`/`.vertices` getters. `/CL`
+  was already carried through every move/resize/rotate point-mapping loop
+  (`['QuadPoints', 'L', 'Vertices', 'CL']`), so the dict coordinates scale for
+  free.
+- **Resize/restyle regeneration:** the single `case 'FreeText':` in
+  `_regenerateResizedAppearance` now detects a callout (via `_calloutInfo`)
+  and redraws the leader + box together - mapping `/CL` and the `/RD` box
+  sub-rect through the same from→to affine the Line case uses, and rewriting
+  `/RD` to match. Both resize and restyle funnel through this case, so the
+  leader recolors with the box border on restyle. Move needs nothing extra:
+  the appearance is in page space and the identity BBox→/Rect fit translates
+  it. Plain free text (no `/CL`) keeps the old whole-rect path.
+
+## Editor UI (`dart_pdf_editor`)
+
+- New `PdfEditTool.callout`. Only one exhaustive switch (the overlay's
+  `_panStart`) needed a new arm to compile; the rest carry `default`/`_`.
+- Placement mirrors Bluebeam: **press at the terminus, drag to where the box
+  goes**. `editing_overlay._panEnd` routes a callout drag to
+  `_openCalloutEditor`, which remembers the terminus as a page-space point
+  (`_textEditCalloutTarget`) and opens the same inline box editor free text
+  uses. A plain tap (no drag) makes the tap the terminus and offsets the box.
+  `_commitTextEdit` calls `controller.addCallout(...)` when a target is set.
+  During the drag a leader-line preview is shown by extending `dragLine` to
+  the callout tool.
+- `PdfEditingController.addCallout` dispatches to the model with the box
+  styling from the free-text preferences plus the stroke color/width for the
+  arrow. The callout tool shares free text's style scope (font/box colors/
+  align/opacity) via `_styleScopeFields`.
+- Toolbar: a "Callout" chip in the **Insert** group (so it inherits the
+  insert group's font/box controls). Shortcut **Q** (Bluebeam's), in
+  `tool_shortcuts.dart`. The sidebar and properties panel label a callout
+  "Callout" with a chat-bubble icon (branching on `isCallout`, since the
+  subtype is still `FreeText`).
+
+## Tests
+
+- `pdf_document/test/callout_test.dart` - creation (`/IT`/`/CL`/`/LE`/`/RD`,
+  Rect enclosure, appearance has the arrow + text), the `calloutLine` getter,
+  and resize keeping it a callout.
+- `dart_pdf_editor/test/editing_callout_test.dart` - controller `addCallout`,
+  the drag-to-place flow through the overlay (leader points back at the
+  terminus), empty-box no-op, and a save/reload round-trip.
+
+Gotcha worth remembering: the 800×600 default test surface clips
+`view(x, y)` taps whose page-y is small - a commit tap must land inside the
+viewport (page-y ≳ 333 at `PdfViewerFit.width`).

--- a/doc/dev-log/2026-07-09-callout-tool.md
+++ b/doc/dev-log/2026-07-09-callout-tool.md
@@ -105,3 +105,33 @@ Review feedback drove three UX fixes:
    Move (dragging the body) still translates the whole callout - only the
    scale handle and the terminus handle are independent, which is what the
    "scale handle scales both" complaint was about.
+
+## Follow-up 2: stroke persistence, autosize scope, draggable base
+
+Three more review fixes:
+
+4. **Arrow width no longer changes when the terminus moves.** The leader
+   width/color weren't persisted independently of the box border, so a
+   callout with no distinct box border (the common case) lost its `/BS` and
+   `reshapeCallout` fell back to width 1. Fixed by making a callout's box
+   outline and leader **one shared stroke** (Bluebeam's model): `addCallout`
+   takes `strokeColor`/`strokeWidth` (dropped the separate `borderColor`/
+   `lineColor`/`lineWidth`), always writes `/BS` and a `/DA` `RG`, and the
+   controller falls the stroke back to the text color. `reshapeCallout` reads
+   the width/color straight back from `/BS`+`/DA`, so it round-trips.
+5. **Autosize only fits the text box.** `_autosizeTextRect` anchored on
+   `annotation.rect` (which for a callout spans the leader + arrow); it now
+   anchors on `annotation.calloutBox`, and the resize already routes through
+   `reshapeCallout(box:)`, so the terminus stays put.
+6. **The arrow base is draggable along the box.** `_calloutLine` now takes an
+   optional `attach` (clamped to the box perimeter via `_clampToBoxPerimeter`;
+   knee derived from the edge it lands on). `reshapeCallout(attach:)` pins the
+   base; when only the box changes it carries the base across by its relative
+   position and re-snaps to the new perimeter; when only the target changes it
+   leaves the base put. The overlay exposes a **second** vertex handle:
+   `_selectedVertexPoints` returns `[terminus, base]`, `_panEnd` captures the
+   dragged handle index, and `_commitVertexDrag(points, handle:)` routes
+   index 0 → `reshapeSelectedCalloutTarget`, index 1 →
+   `reshapeSelectedCalloutBase`. `PdfAnnotation.calloutLine.last` is the base.
+   The leader preview now carries `(terminus, base)` (was `(terminus, box)`)
+   so it's accurate while either handle drags.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -145,6 +145,11 @@ enum PdfEditTool {
   /// Drag out a box, then type the text shown inside it (/FreeText).
   freeText,
 
+  /// Drag from the terminus you're pointing at to where the text box goes,
+  /// then type the text (a /FreeText callout with a leader line and arrow,
+  /// like Bluebeam's Callout tool).
+  callout,
+
   /// Tap to place a sticky note (/Text).
   note,
 
@@ -873,6 +878,7 @@ class PdfEditingController extends ChangeNotifier {
         PdfEditTool.measureArc => 'measureArc',
         PdfEditTool.measureVolume => 'measureVolume',
         PdfEditTool.freeText => 'freeText',
+        PdfEditTool.callout => 'callout',
         PdfEditTool.note => 'note',
         PdfEditTool.stamp => 'stamp',
         PdfEditTool.count => 'count',
@@ -922,7 +928,7 @@ class PdfEditingController extends ChangeNotifier {
         PdfEditTool.measureArc ||
         PdfEditTool.measureVolume =>
           const {'color', 'strokeWidth', 'opacity'},
-        PdfEditTool.freeText => const {
+        PdfEditTool.freeText || PdfEditTool.callout => const {
             'color',
             'fontSize',
             'fontFamily',
@@ -1934,6 +1940,27 @@ class PdfEditingController extends ChangeNotifier {
           author: author),
       pages: [pageIndex],
       contentPages: const <int>[]);
+
+  /// Places a callout: a [text] box at [rect] with a leader line pointing at
+  /// [target] on the page (both in page space). Mirrors [addFreeText] for the
+  /// box styling and points the arrow with the tool's stroke color/width.
+  void addCallout(
+          int pageIndex, PdfRect rect, String text, (double, double) target) =>
+      apply(
+          (e) => e.addCallout(pageIndex, rect, text, target,
+              fontSize: preferences.fontSize,
+              font: _activeFont ?? preferences.fontFamily,
+              align: preferences.textAlign,
+              color: _colorValue,
+              fillColor: _rgbOf(preferences.textFillColor),
+              borderColor: _rgbOf(preferences.textBorderColor),
+              borderWidth: preferences.strokeWidth,
+              lineColor: _rgbOf(preferences.textBorderColor) ?? _colorValue,
+              lineWidth: preferences.strokeWidth,
+              pageRotation: _page(pageIndex).rotation,
+              author: author),
+          pages: [pageIndex],
+          contentPages: const <int>[]);
 
   void addFreeTextRich(
           int pageIndex, PdfRect rect, List<PdfFreeTextRun> runs) =>

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1953,10 +1953,10 @@ class PdfEditingController extends ChangeNotifier {
               align: preferences.textAlign,
               color: _colorValue,
               fillColor: _rgbOf(preferences.textFillColor),
-              borderColor: _rgbOf(preferences.textBorderColor),
-              borderWidth: preferences.strokeWidth,
-              lineColor: _rgbOf(preferences.textBorderColor) ?? _colorValue,
-              lineWidth: preferences.strokeWidth,
+              // the box outline and leader share one stroke; fall back to the
+              // text color so the arrow always has a definite color/width
+              strokeColor: _rgbOf(preferences.textBorderColor) ?? _colorValue,
+              strokeWidth: preferences.strokeWidth,
               pageRotation: _page(pageIndex).rotation,
               author: author),
           pages: [pageIndex],
@@ -4121,6 +4121,18 @@ class PdfEditingController extends ChangeNotifier {
         contentPages: const <int>[]);
   }
 
+  /// Moves a selected callout's arrow base (where the leader meets the text
+  /// box) to [attach], snapped to the box perimeter. The box and terminus
+  /// stay put. A no-op unless a single callout is selected.
+  void reshapeSelectedCalloutBase((double, double) attach) {
+    final annotation = selectedAnnotation;
+    if (annotation == null || !annotation.isCallout) return;
+    apply(
+        (e) => e.reshapeCallout(_selected.last.$1, annotation, attach: attach),
+        pages: [_selected.last.$1],
+        contentPages: const <int>[]);
+  }
+
   /// Resizes the selected form-field [widget] so its /Rect becomes [to],
   /// regenerating the field's appearance ([PdfEditor.resizeFormWidget]).
   /// The field is re-resolved by name inside the save (fields die with
@@ -4378,10 +4390,13 @@ class PdfEditingController extends ChangeNotifier {
     final height = math.max(18.0, lines.length * size * 1.2 + 2 * pad);
     final page = _page(_selected.last.$1);
     final bounds = page.cropBox;
-    final left = annotation.rect.left
+    // a callout autosizes its text box, not the /Rect that also spans the
+    // leader + arrow: anchor at the box's top-left so the arrow stays put
+    final anchor = annotation.calloutBox ?? annotation.rect;
+    final left = anchor.left
         .clamp(bounds.left, math.max(bounds.left, bounds.right - width))
         .toDouble();
-    final top = annotation.rect.top
+    final top = anchor.top
         .clamp(math.min(bounds.top, bounds.bottom + height), bounds.top)
         .toDouble();
     return PdfRect(left, top - height, left + width, top);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4093,11 +4093,30 @@ class PdfEditingController extends ChangeNotifier {
       _resizeWidget(_selected.last, to);
       return;
     }
+    if (annotation.isCallout) {
+      // a callout's resize handles size the text box; the terminus stays
+      // put and the leader stretches (Bluebeam's model)
+      apply((e) => e.reshapeCallout(_selected.last.$1, annotation, box: to),
+          pages: [_selected.last.$1], contentPages: const <int>[]);
+      return;
+    }
     apply(
         (e) => e.resizeAnnotation(_selected.last.$1, annotation, to,
             flipX: flipX,
             flipY: flipY,
             pageRotation: _page(_selected.last.$1).rotation),
+        pages: [_selected.last.$1],
+        contentPages: const <int>[]);
+  }
+
+  /// Moves a selected callout's arrow terminus to [target] (page space),
+  /// leaving the text box where it is - the leader stretches to follow.
+  /// A no-op unless a single callout is selected.
+  void reshapeSelectedCalloutTarget((double, double) target) {
+    final annotation = selectedAnnotation;
+    if (annotation == null || !annotation.isCallout) return;
+    apply(
+        (e) => e.reshapeCallout(_selected.last.$1, annotation, target: target),
         pages: [_selected.last.$1],
         contentPages: const <int>[]);
   }
@@ -4143,6 +4162,13 @@ class PdfEditingController extends ChangeNotifier {
     if (annotation.subtype == 'Widget') {
       // widgets never rotate, so the local frame is the rect itself
       _resizeWidget(_selected.last, localTo);
+      return;
+    }
+    if (annotation.isCallout) {
+      apply(
+          (e) => e.reshapeCallout(_selected.last.$1, annotation, box: localTo),
+          pages: [_selected.last.$1],
+          contentPages: const <int>[]);
       return;
     }
     apply(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1384,10 +1384,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_controller.selectedPage != widget.pageIndex) return null;
     final annotation = _controller.selectedAnnotation;
     if (annotation == null) return null;
-    // a callout exposes just its terminus (the arrow tip) as a draggable
-    // handle, so the arrow can be re-aimed without touching the text box
+    // a callout exposes two handles: the terminus (arrow tip, index 0) and
+    // the base where the leader meets the box (index 1), so each can be
+    // dragged without disturbing the other or the text box
     if (annotation.calloutLine case final line?) {
-      return [_geometry.toViewOffset(line.first.$1, line.first.$2)];
+      return [
+        _geometry.toViewOffset(line.first.$1, line.first.$2),
+        _geometry.toViewOffset(line.last.$1, line.last.$2),
+      ];
     }
     if (annotation.line case final line?) {
       return [
@@ -2337,10 +2341,26 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _openTextEditor(viewRect, existing: false);
   }
 
-  /// The leader (terminus, box, color, width) to keep painted so a callout's
-  /// arrow stays visible: while its terminus handle is being dragged, and
+  /// The nearest point on [box]'s perimeter to [p] (view space, y-down) -
+  /// where the leader meets the box before the base is pinned.
+  static Offset _nearestBoxEdge(Rect box, Offset p) {
+    if (p.dx < box.left) {
+      return Offset(box.left, p.dy.clamp(box.top, box.bottom));
+    }
+    if (p.dx > box.right) {
+      return Offset(box.right, p.dy.clamp(box.top, box.bottom));
+    }
+    if (p.dy < box.top) return Offset(p.dx.clamp(box.left, box.right), box.top);
+    if (p.dy > box.bottom) {
+      return Offset(p.dx.clamp(box.left, box.right), box.bottom);
+    }
+    return box.center;
+  }
+
+  /// The leader (terminus, base, color, width) to keep painted so a callout's
+  /// arrow stays visible: while a terminus/base handle is being dragged, and
   /// while the box editor is open placing a new one. Null otherwise.
-  (Offset, Rect, Color, double)? _calloutLeaderPreview() {
+  (Offset, Offset, Color, double)? _calloutLeaderPreview() {
     if (_vertexHandle != null && _vertexPoints != null) {
       final annotation = _controller.selectedAnnotation;
       final box = _selectedViewRect;
@@ -2351,19 +2371,24 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         final style = annotation.freeTextStyle;
         final rgb = style?.borderColor ?? style?.color ?? 0x000000;
         final width = (style?.borderWidth ?? 1) * _geometry.scale;
+        final terminus = _vertexPoints!.first;
+        final base = _vertexPoints!.length > 1
+            ? _vertexPoints![1]
+            : _nearestBoxEdge(box, terminus);
         return (
-          _vertexPoints!.first,
-          box,
+          terminus,
+          base,
           Color(0xFF000000 | rgb),
           width > 0 ? width : _geometry.scale,
         );
       }
     }
     if (_textEditCalloutTarget != null && _textEditRect != null) {
+      final terminus = _geometry.toViewOffset(
+          _textEditCalloutTarget!.$1, _textEditCalloutTarget!.$2);
       return (
-        _geometry.toViewOffset(
-            _textEditCalloutTarget!.$1, _textEditCalloutTarget!.$2),
-        _textEditRect!,
+        terminus,
+        _nearestBoxEdge(_textEditRect!, terminus),
         _controller.textBorderColor ?? _controller.color,
         _controller.strokeWidth * _geometry.scale,
       );
@@ -2973,6 +2998,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final resizeFlipX = _resizeFlipX;
     final resizeFlipY = _resizeFlipY;
     final vertexPoints = _vertexHandle != null ? _vertexPoints : null;
+    final vertexHandle = _vertexHandle;
     final rotating = _rotateStartAngle != null;
     final rotateDelta = _rotateDelta;
     final marquee = _marqueeStart != null && _marqueeCurrent != null
@@ -3054,7 +3080,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           to: _selectedViewRect,
           rotation: rotateDelta);
     } else if (vertexPoints != null) {
-      _commitVertexDrag(vertexPoints);
+      _commitVertexDrag(vertexPoints, handle: vertexHandle);
     } else if (resizeRect != null) {
       final wrapStyle = _textResizeStyle;
       // captured before the commit: a Square/Circle regenerates at a
@@ -3251,12 +3277,18 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         depth: depth);
   }
 
-  void _commitVertexDrag(List<Offset> points) {
+  void _commitVertexDrag(List<Offset> points, {int? handle}) {
     final annotation = _controller.selectedAnnotation;
     if (annotation != null && annotation.isCallout && points.isNotEmpty) {
-      // the single handle is the terminus: re-aim the arrow, box stays put
-      _controller
-          .reshapeSelectedCalloutTarget(_geometry.toPagePoint(points.first));
+      // handle 0 is the terminus (re-aim the arrow), handle 1 is the base
+      // (slide where the leader meets the box); both leave the box in place
+      final idx = (handle ?? 0).clamp(0, points.length - 1);
+      final page = _geometry.toPagePoint(points[idx]);
+      if (idx == 1) {
+        _controller.reshapeSelectedCalloutBase(page);
+      } else {
+        _controller.reshapeSelectedCalloutTarget(page);
+      }
       return;
     }
     final tool = _selectedLineTool;
@@ -5195,10 +5227,10 @@ class _EditingPreviewPainter extends CustomPainter {
   final Rect? dragRect;
   final (Offset, Offset)? dragLine;
 
-  /// A callout leader to paint from its terminus to a text box while the box
-  /// is being placed/edited (before the annotation exists) or while its
-  /// terminus is being dragged: (terminus, box, color, strokeWidth).
-  final (Offset, Rect, Color, double)? calloutLeader;
+  /// A callout leader to paint from its terminus to its base while the box is
+  /// being placed/edited (before the annotation exists) or while the terminus
+  /// or base handle is being dragged: (terminus, base, color, strokeWidth).
+  final (Offset, Offset, Color, double)? calloutLeader;
   final List<Offset>? dragPath;
 
   /// The interior fill for an in-progress polygon [dragPath], so drawing a
@@ -5842,29 +5874,13 @@ class _EditingPreviewPainter extends CustomPainter {
     }
   }
 
-  /// Paints a callout leader from [terminus] to the edge of [box] nearest
-  /// it, with the open arrow at the terminus - mirrors the model's
-  /// `_calloutLine` + `/OpenArrow` so the on-screen preview matches what the
-  /// committed annotation draws.
+  /// Paints a callout leader from [terminus] to [base] with the open arrow at
+  /// the terminus - mirrors the model's `/OpenArrow` so the on-screen preview
+  /// matches what the committed annotation draws.
   void _paintCalloutLeader(
-      Canvas canvas, Offset terminus, Rect box, Color color, double width) {
-    // the attachment point on the box edge nearest the terminus (view space
-    // is y-down, so "top"/"bottom" are the model's flipped counterparts, but
-    // the nearest-edge geometry is symmetric)
-    late Offset attach;
-    if (terminus.dx < box.left) {
-      attach = Offset(box.left, terminus.dy.clamp(box.top, box.bottom));
-    } else if (terminus.dx > box.right) {
-      attach = Offset(box.right, terminus.dy.clamp(box.top, box.bottom));
-    } else if (terminus.dy < box.top) {
-      attach = Offset(terminus.dx.clamp(box.left, box.right), box.top);
-    } else if (terminus.dy > box.bottom) {
-      attach = Offset(terminus.dx.clamp(box.left, box.right), box.bottom);
-    } else {
-      attach = box.center; // terminus inside the box
-    }
+      Canvas canvas, Offset terminus, Offset base, Color color, double width) {
     _paintPathPreview(
-        canvas, [terminus, attach], PdfEditTool.callout, color, null, width,
+        canvas, [terminus, base], PdfEditTool.callout, color, null, width,
         false);
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -738,6 +738,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   PdfRect? _textEditPageRect;
   bool _textEditExisting = false;
   PdfEditTool? _textEditTool;
+  // when non-null the open editor is a callout: this is the page-space point
+  // (the terminus) the committed box's leader line will point at
+  (double, double)? _textEditCalloutTarget;
   late final _RichTextEditingController _textEditText =
       _RichTextEditingController()..addListener(_onTextEditChanged);
   late final FocusNode _textEditFocus = FocusNode(onKeyEvent: _onTextEditKey)
@@ -2318,6 +2321,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     });
   }
 
+  /// Opens the inline text editor for a callout: the same box editor as
+  /// free text, but remembering the page-space [target] the leader line will
+  /// point at so the commit builds a callout instead of a plain box.
+  void _openCalloutEditor(Rect viewRect, Offset terminus) {
+    _textEditCalloutTarget = _geometry.toPagePoint(terminus);
+    _openTextEditor(viewRect, existing: false);
+  }
+
   /// Opens the inline editor over a text field's widget, prefilled with
   /// its value - the form tool's tap-to-fill. The commit goes into the
   /// field's /V instead of creating an annotation.
@@ -2394,6 +2405,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final color = _textEditColor;
     final fill = _textEditFill;
     final rotation = _textEditRotation;
+    final calloutTarget = _textEditCalloutTarget;
     _closeTextEditor();
     final before = _controller.document;
     if (existing) {
@@ -2403,7 +2415,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         _controller.setSelectedText(text);
       }
     } else if (text.isNotEmpty) {
-      if (richRuns != null) {
+      if (calloutTarget != null) {
+        _controller.addCallout(
+            widget.pageIndex, _geometry.toPageRect(rect), text, calloutTarget);
+      } else if (richRuns != null) {
         _controller.addFreeTextRich(
             widget.pageIndex, _geometry.toPageRect(rect), richRuns);
       } else {
@@ -2468,6 +2483,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // close because the user clicked another widget (e.g. a toolbar field)
     // does not - that new focus must be left alone
     final ownedFocus = _textEditFocus.hasFocus;
+    _textEditCalloutTarget = null;
     if (mounted) {
       setState(() {
         _textEditRect = null;
@@ -2557,6 +2573,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             PdfEditTool.measureSlope ||
             PdfEditTool.calibrate ||
             PdfEditTool.freeText ||
+            PdfEditTool.callout ||
             PdfEditTool.stamp ||
             PdfEditTool.image ||
             PdfEditTool.redact ||
@@ -3089,6 +3106,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         _commitLineDrag(dragStart, dragCurrent);
         return;
       }
+      if (_tool == PdfEditTool.callout) {
+        // the drag draws the leader: press at the terminus, release where
+        // the box goes. A too-short drag drops a default-offset box.
+        final short = (dragCurrent - dragStart).distance < 8;
+        final anchor = short ? dragStart + const Offset(28, -28) : dragCurrent;
+        _openCalloutEditor(_defaultPlacementRect(anchor), dragStart);
+        return;
+      }
       if (viewRect.width < 4 || viewRect.height < 4) return; // a click
       if (_tool == PdfEditTool.freeText) {
         // type into the box just dragged out, instead of a dialog
@@ -3603,6 +3628,13 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // tapping without dragging out a box opens a default-sized one
         _openTextEditor(_defaultPlacementRect(details.localPosition),
             existing: false);
+      case PdfEditTool.callout:
+        // a plain tap makes the tap the terminus and offsets the box; a drag
+        // (handled in _panEnd) instead aims the box where the drag released
+        _openCalloutEditor(
+            _defaultPlacementRect(
+                details.localPosition + const Offset(28, -28)),
+            details.localPosition);
       case PdfEditTool.stamp:
         final stamp = _controller.activeStamp;
         if (stamp != null) {
@@ -4508,7 +4540,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                         : null,
                     dragLine: _dragStart != null &&
                             _dragCurrent != null &&
-                            _lineDragTool
+                            (_lineDragTool || _tool == PdfEditTool.callout)
                         ? (_dragStart!, _dragCurrent!)
                         : null,
                     dragPath: polyPreview,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1313,7 +1313,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   Rect? get _selectedViewRect {
     if (_controller.selectedPage != widget.pageIndex) return null;
     final annotation = _controller.selectedAnnotation;
-    return annotation == null ? null : _geometry.toViewRect(annotation.rect);
+    if (annotation == null) return null;
+    // a callout's chrome hugs the text box, not the /Rect that also
+    // encloses the leader + arrow, so resize handles size the box alone
+    return _geometry.toViewRect(annotation.calloutBox ?? annotation.rect);
   }
 
   /// View rects of the marked (unburned) /Redact annotations on this page,
@@ -1381,6 +1384,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_controller.selectedPage != widget.pageIndex) return null;
     final annotation = _controller.selectedAnnotation;
     if (annotation == null) return null;
+    // a callout exposes just its terminus (the arrow tip) as a draggable
+    // handle, so the arrow can be re-aimed without touching the text box
+    if (annotation.calloutLine case final line?) {
+      return [_geometry.toViewOffset(line.first.$1, line.first.$2)];
+    }
     if (annotation.line case final line?) {
       return [
         _geometry.toViewOffset(line.$1.$1, line.$1.$2),
@@ -2329,6 +2337,40 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _openTextEditor(viewRect, existing: false);
   }
 
+  /// The leader (terminus, box, color, width) to keep painted so a callout's
+  /// arrow stays visible: while its terminus handle is being dragged, and
+  /// while the box editor is open placing a new one. Null otherwise.
+  (Offset, Rect, Color, double)? _calloutLeaderPreview() {
+    if (_vertexHandle != null && _vertexPoints != null) {
+      final annotation = _controller.selectedAnnotation;
+      final box = _selectedViewRect;
+      if (annotation != null &&
+          annotation.isCallout &&
+          box != null &&
+          _vertexPoints!.isNotEmpty) {
+        final style = annotation.freeTextStyle;
+        final rgb = style?.borderColor ?? style?.color ?? 0x000000;
+        final width = (style?.borderWidth ?? 1) * _geometry.scale;
+        return (
+          _vertexPoints!.first,
+          box,
+          Color(0xFF000000 | rgb),
+          width > 0 ? width : _geometry.scale,
+        );
+      }
+    }
+    if (_textEditCalloutTarget != null && _textEditRect != null) {
+      return (
+        _geometry.toViewOffset(
+            _textEditCalloutTarget!.$1, _textEditCalloutTarget!.$2),
+        _textEditRect!,
+        _controller.textBorderColor ?? _controller.color,
+        _controller.strokeWidth * _geometry.scale,
+      );
+    }
+    return null;
+  }
+
   /// Opens the inline editor over a text field's widget, prefilled with
   /// its value - the form tool's tap-to-fill. The commit goes into the
   /// field's /V instead of creating an annotation.
@@ -3210,10 +3252,16 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   void _commitVertexDrag(List<Offset> points) {
+    final annotation = _controller.selectedAnnotation;
+    if (annotation != null && annotation.isCallout && points.isNotEmpty) {
+      // the single handle is the terminus: re-aim the arrow, box stays put
+      _controller
+          .reshapeSelectedCalloutTarget(_geometry.toPagePoint(points.first));
+      return;
+    }
     final tool = _selectedLineTool;
     if (tool == null) return;
     final style = _controller.selectedAnnotationStyle;
-    final annotation = _controller.selectedAnnotation;
     final opacity = style?.opacity ?? 1;
     final before = _controller.document;
     _controller.reshapeSelectedLine(
@@ -4543,6 +4591,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                             (_lineDragTool || _tool == PdfEditTool.callout)
                         ? (_dragStart!, _dragCurrent!)
                         : null,
+                    calloutLeader: _calloutLeaderPreview(),
                     dragPath: polyPreview,
                     dragPathFill: (_tool == PdfEditTool.polygon ||
                                 _tool == PdfEditTool.cloudPolygon) &&
@@ -5083,6 +5132,7 @@ class _EditingPreviewPainter extends CustomPainter {
     required this.pressures,
     required this.dragRect,
     required this.dragLine,
+    this.calloutLeader,
     required this.dragPath,
     this.dragPathFill,
     required this.dashed,
@@ -5144,6 +5194,11 @@ class _EditingPreviewPainter extends CustomPainter {
 
   final Rect? dragRect;
   final (Offset, Offset)? dragLine;
+
+  /// A callout leader to paint from its terminus to a text box while the box
+  /// is being placed/edited (before the annotation exists) or while its
+  /// terminus is being dragged: (terminus, box, color, strokeWidth).
+  final (Offset, Rect, Color, double)? calloutLeader;
   final List<Offset>? dragPath;
 
   /// The interior fill for an in-progress polygon [dragPath], so drawing a
@@ -5767,6 +5822,50 @@ class _EditingPreviewPainter extends CustomPainter {
             ..color = color
             ..style = PaintingStyle.fill);
     }
+    if (tool == PdfEditTool.callout) {
+      // the terminus (arrow tip) is the FIRST point; draw the open arrow
+      // there, matching the /OpenArrow the committed callout carries
+      final tip = points.first;
+      final from = points[1];
+      final arrow = _arrowHead(tip, from, width);
+      canvas.drawPath(
+          Path()
+            ..moveTo(arrow.$1.dx, arrow.$1.dy)
+            ..lineTo(tip.dx, tip.dy)
+            ..lineTo(arrow.$2.dx, arrow.$2.dy),
+          Paint()
+            ..color = color
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = width
+            ..strokeCap = StrokeCap.round
+            ..strokeJoin = StrokeJoin.round);
+    }
+  }
+
+  /// Paints a callout leader from [terminus] to the edge of [box] nearest
+  /// it, with the open arrow at the terminus - mirrors the model's
+  /// `_calloutLine` + `/OpenArrow` so the on-screen preview matches what the
+  /// committed annotation draws.
+  void _paintCalloutLeader(
+      Canvas canvas, Offset terminus, Rect box, Color color, double width) {
+    // the attachment point on the box edge nearest the terminus (view space
+    // is y-down, so "top"/"bottom" are the model's flipped counterparts, but
+    // the nearest-edge geometry is symmetric)
+    late Offset attach;
+    if (terminus.dx < box.left) {
+      attach = Offset(box.left, terminus.dy.clamp(box.top, box.bottom));
+    } else if (terminus.dx > box.right) {
+      attach = Offset(box.right, terminus.dy.clamp(box.top, box.bottom));
+    } else if (terminus.dy < box.top) {
+      attach = Offset(terminus.dx.clamp(box.left, box.right), box.top);
+    } else if (terminus.dy > box.bottom) {
+      attach = Offset(terminus.dx.clamp(box.left, box.right), box.bottom);
+    } else {
+      attach = box.center; // terminus inside the box
+    }
+    _paintPathPreview(
+        canvas, [terminus, attach], PdfEditTool.callout, color, null, width,
+        false);
   }
 
   Path _dashPath(Path path, double width) {
@@ -5892,6 +5991,10 @@ class _EditingPreviewPainter extends CustomPainter {
           canvas, dragPath!, tool, color, dragPathFill, strokeWidth, dashed);
     } else if (dragRect case final rect?) {
       _paintShapePreview(canvas, rect, tool, color, strokeWidth);
+    }
+
+    if (calloutLeader case final leader?) {
+      _paintCalloutLeader(canvas, leader.$1, leader.$2, leader.$3, leader.$4);
     }
 
     for (final rect in redactionRects) {
@@ -6167,6 +6270,7 @@ class _EditingPreviewPainter extends CustomPainter {
       oldDelegate.strokeWidth != strokeWidth ||
       !listEquals(oldDelegate.redactionRects, redactionRects) ||
       oldDelegate.dragRect != dragRect ||
+      oldDelegate.calloutLeader != calloutLeader ||
       oldDelegate.dragPathFill != dragPathFill ||
       oldDelegate.selectionRect != selectionRect ||
       !listEquals(oldDelegate.extraSelectionRects, extraSelectionRects) ||

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -738,8 +738,11 @@ class _PdfAnnotationPropertiesPanelState
     final slot = _controller.selectedAnnotationSlot!;
     return [
       ListTile(
-        leading: Icon(_icon(annotation.subtype)),
-        title: Text(_label(annotation.subtype)),
+        leading: Icon(annotation.isCallout
+            ? Icons.chat_bubble_outline
+            : _icon(annotation.subtype)),
+        title: Text(
+            annotation.isCallout ? 'Callout' : _label(annotation.subtype)),
         subtitle: Text('Page ${slot.$1 + 1}'),
       ),
       ..._styleControls(annotation),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -271,7 +271,9 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   /// subtitle.
   String _title(PdfAnnotation annotation) => annotation is PdfWidgetAnnotation
       ? _fieldLabel(annotation.fieldType)
-      : _label(annotation.subtype);
+      : annotation.isCallout
+          ? 'Callout'
+          : _label(annotation.subtype);
 
   bool _matches(String query, int pageIndex, PdfAnnotation annotation) {
     if (query.isEmpty) return true;
@@ -333,7 +335,11 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                 value: _checked.contains(slot),
                 onChanged: selectable ? (_) => _toggle(slot) : null,
               )
-            : Icon(_icon(annotation.subtype), size: 20),
+            : Icon(
+                annotation.isCallout
+                    ? Icons.chat_bubble_outline
+                    : _icon(annotation.subtype),
+                size: 20),
         title: Text(_title(annotation)),
         subtitle: detail.isEmpty
             ? null

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -335,6 +335,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         Icons.text_fields,
         [
           _GroupTool.tool(PdfEditTool.freeText, Icons.text_fields, 'Text box'),
+          _GroupTool.tool(PdfEditTool.callout, Icons.chat_bubble_outline,
+              'Callout - drag from the point to where the box goes'),
           _GroupTool.tool(
               PdfEditTool.note, Icons.sticky_note_2_outlined, 'Note'),
           _GroupTool.tool(PdfEditTool.stamp, Icons.approval, 'Stamp'),

--- a/packages/dart_pdf_editor/lib/src/editing/tool_shortcuts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/tool_shortcuts.dart
@@ -30,6 +30,7 @@ const Map<PdfEditTool, LogicalKeyboardKey> pdfEditToolShortcuts = {
   PdfEditTool.line: LogicalKeyboardKey.keyL,
   PdfEditTool.arrow: LogicalKeyboardKey.keyA,
   PdfEditTool.freeText: LogicalKeyboardKey.keyT,
+  PdfEditTool.callout: LogicalKeyboardKey.keyQ,
   PdfEditTool.note: LogicalKeyboardKey.keyN,
   PdfEditTool.stamp: LogicalKeyboardKey.keyS,
   PdfEditTool.image: LogicalKeyboardKey.keyI,

--- a/packages/dart_pdf_editor/test/editing_callout_test.dart
+++ b/packages/dart_pdf_editor/test/editing_callout_test.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('callout through the controller', () {
+    test('addCallout builds a FreeText callout pointing at the target', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..author = 'Ben'
+        ..addCallout(
+            0, const PdfRect(300, 600, 460, 660), 'Look here', (120, 500));
+
+      final annot = editing.document.page(0).annotations.single;
+      expect(annot.subtype, 'FreeText');
+      expect(annot.isCallout, isTrue);
+      expect(annot.contents, 'Look here');
+      final line = annot.calloutLine!;
+      expect(line.first, (120.0, 500.0), reason: 'leader tip is the target');
+      expect(annot.rect.left, lessThanOrEqualTo(120));
+      expect(annot.rect.bottom, lessThanOrEqualTo(500));
+    });
+
+    test('the callout tool exposes the color/font controls', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..tool = PdfEditTool.callout;
+      // the callout tool exposes the same box controls as free text
+      expect(editing.toolUsesColor, isTrue);
+    });
+  });
+
+  group('callout tool in the viewer', () {
+    const scale = 800 / 612;
+    Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
+
+    Future<void> drag(WidgetTester tester, Offset from, Offset to) async {
+      final gesture = await tester.startGesture(from);
+      await gesture.moveTo(Offset.lerp(from, to, 0.5)!);
+      await gesture.moveTo(to);
+      await gesture.up();
+      await tester.pump();
+    }
+
+    Future<void> settle(WidgetTester tester) =>
+        tester.pumpAndSettle(const Duration(milliseconds: 300));
+
+    Future<void> tap(WidgetTester tester, Offset position) async {
+      await tester.tapAt(position);
+      await tester.pump(const Duration(milliseconds: 400));
+    }
+
+    Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    const editorKey = ValueKey('pdf-freetext-editor');
+
+    testWidgets('dragging from the terminus to the box places a callout',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.tool = PdfEditTool.callout;
+      await tester.pump();
+
+      // press at the terminus (what we point at), release where the box goes
+      await drag(tester, view(150, 500), view(360, 660));
+
+      // the box editor opens in place, nothing committed yet
+      expect(find.byKey(editorKey), findsOneWidget);
+      expect(editing.isEditingText, isTrue);
+      expect(editing.document.page(0).annotations, isEmpty);
+
+      await tester.enterText(find.byKey(editorKey), 'Callout body');
+      await tap(tester, view(450, 400)); // commit outside the box
+
+      expect(find.byKey(editorKey), findsNothing);
+      final annot = editing.document.page(0).annotations.single;
+      expect(annot.isCallout, isTrue);
+      expect(annot.contents, 'Callout body');
+      final line = annot.calloutLine!;
+      // the leader points back at the terminus we pressed on
+      expect(line.first.$1, closeTo(150, 2));
+      expect(line.first.$2, closeTo(500, 2));
+      await settle(tester);
+    });
+
+    testWidgets('an empty callout box commits nothing', (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.tool = PdfEditTool.callout;
+      await tester.pump();
+
+      await drag(tester, view(150, 500), view(360, 660));
+      expect(find.byKey(editorKey), findsOneWidget);
+      await tap(tester, view(450, 400)); // commit with no text
+
+      expect(editing.document.page(0).annotations, isEmpty);
+      await settle(tester);
+    });
+  });
+
+  test('callout survives a save/reload round-trip', () {
+    final editing = PdfEditingController(buildMultiPagePdf(1))
+      ..addCallout(0, const PdfRect(300, 600, 460, 660), 'persist', (120, 500));
+    final reopened = PdfDocument.open(editing.bytes);
+    final annot = reopened.page(0).annotations.single;
+    expect(annot.isCallout, isTrue);
+    expect(annot.calloutLine!.first, (120.0, 500.0));
+    final ap = latin1
+        .decode(reopened.cos.decodeStreamData(annot.normalAppearance!));
+    expect(ap, contains('Tj'));
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_callout_test.dart
+++ b/packages/dart_pdf_editor/test/editing_callout_test.dart
@@ -118,6 +118,26 @@ void main() {
       expect(editing.document.page(0).annotations, isEmpty);
       await settle(tester);
     });
+
+    testWidgets('a plain tap makes the tap the terminus and offsets the box',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.tool = PdfEditTool.callout;
+      await tester.pump();
+
+      await tap(tester, view(250, 500)); // no drag: the tap is the terminus
+      expect(find.byKey(editorKey), findsOneWidget);
+
+      await tester.enterText(find.byKey(editorKey), 'Tapped callout');
+      await tap(tester, view(450, 400)); // commit
+
+      final annot = editing.document.page(0).annotations.single;
+      expect(annot.isCallout, isTrue);
+      final line = annot.calloutLine!;
+      expect(line.first.$1, closeTo(250, 2));
+      expect(line.first.$2, closeTo(500, 2));
+      await settle(tester);
+    });
   });
 
   test('callout survives a save/reload round-trip', () {

--- a/packages/dart_pdf_editor/test/editing_callout_test.dart
+++ b/packages/dart_pdf_editor/test/editing_callout_test.dart
@@ -31,6 +31,37 @@ void main() {
       // the callout tool exposes the same box controls as free text
       expect(editing.toolUsesColor, isTrue);
     });
+
+    test('resizing a selected callout resizes the box, not the arrow', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (120, 500));
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      final terminus0 =
+          editing.document.page(0).annotations.single.calloutLine!.first;
+
+      editing.resizeSelected(const PdfRect(320, 610, 520, 690));
+
+      final a = editing.document.page(0).annotations.single;
+      expect(a.isCallout, isTrue);
+      expect(a.calloutLine!.first, terminus0, reason: 'arrow tip stays put');
+      expect(a.calloutBox!.left, closeTo(320, 0.5));
+      expect(a.calloutBox!.right, closeTo(520, 0.5));
+    });
+
+    test('reshapeSelectedCalloutTarget moves only the arrow', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (120, 500));
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      final box0 = editing.document.page(0).annotations.single.calloutBox!;
+
+      editing.reshapeSelectedCalloutTarget((560, 630));
+
+      final a = editing.document.page(0).annotations.single;
+      expect(a.calloutLine!.first, (560.0, 630.0));
+      expect(a.calloutBox!.left, closeTo(box0.left, 0.5));
+      expect(a.calloutBox!.top, closeTo(box0.top, 0.5));
+      expect(a.calloutBox!.bottom, closeTo(box0.bottom, 0.5));
+    });
   });
 
   group('callout tool in the viewer', () {
@@ -116,6 +147,29 @@ void main() {
       await tap(tester, view(450, 400)); // commit with no text
 
       expect(editing.document.page(0).annotations, isEmpty);
+      await settle(tester);
+    });
+
+    testWidgets('dragging the terminus handle re-aims the arrow, box stays',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (150, 480));
+      editing.tool = PdfEditTool.select;
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+      final box0 = editing.document.page(0).annotations.single.calloutBox!;
+
+      // the terminus handle sits at the arrow tip (150, 480); drag it away
+      await drag(tester, view(150, 480), view(230, 430));
+      await tester.pump();
+
+      final a = editing.document.page(0).annotations.single;
+      expect(a.isCallout, isTrue);
+      final tip = a.calloutLine!.first;
+      expect(tip.$1, closeTo(230, 6), reason: 'arrow tip followed the drag');
+      expect(tip.$2, closeTo(430, 6));
+      expect(a.calloutBox!.left, closeTo(box0.left, 1), reason: 'box unmoved');
+      expect(a.calloutBox!.top, closeTo(box0.top, 1));
       await settle(tester);
     });
 

--- a/packages/dart_pdf_editor/test/editing_callout_test.dart
+++ b/packages/dart_pdf_editor/test/editing_callout_test.dart
@@ -48,6 +48,22 @@ void main() {
       expect(a.calloutBox!.right, closeTo(520, 0.5));
     });
 
+    test('autosize fits the box and leaves the arrow tip alone', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..fontSize = 14
+        ..addCallout(0, const PdfRect(300, 600, 700, 700), 'Hi', (120, 500));
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      final tip0 =
+          editing.document.page(0).annotations.single.calloutLine!.first;
+
+      editing.autosizeSelectedTextBox();
+
+      final a = editing.document.page(0).annotations.single;
+      expect(a.isCallout, isTrue);
+      expect(a.calloutLine!.first, tip0, reason: 'arrow tip untouched');
+      expect(a.calloutBox!.width, lessThan(400), reason: 'box shrank to fit');
+    });
+
     test('reshapeSelectedCalloutTarget moves only the arrow', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (120, 500));
@@ -170,6 +186,34 @@ void main() {
       expect(tip.$2, closeTo(430, 6));
       expect(a.calloutBox!.left, closeTo(box0.left, 1), reason: 'box unmoved');
       expect(a.calloutBox!.top, closeTo(box0.top, 1));
+      await settle(tester);
+    });
+
+    testWidgets('dragging the base handle slides the base, box + tip stay',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      editing.addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (150, 630));
+      editing.tool = PdfEditTool.select;
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+      final a0 = editing.document.page(0).annotations.single;
+      final tip0 = a0.calloutLine!.first;
+      final base0 = a0.calloutLine!.last; // ~ (300, 630) on the left edge
+      final box0 = a0.calloutBox!;
+
+      // the base handle sits at the attach point; drag it inside toward the
+      // top edge - it snaps onto the perimeter there
+      await drag(tester, view(base0.$1, base0.$2), view(400, 640));
+      await tester.pump();
+
+      final a = editing.document.page(0).annotations.single;
+      expect(a.calloutLine!.first, tip0, reason: 'arrow tip unchanged');
+      final base = a.calloutLine!.last;
+      expect((base.$1 - base0.$1).abs() + (base.$2 - base0.$2).abs(),
+          greaterThan(5),
+          reason: 'the base moved');
+      expect(a.calloutBox!.left, closeTo(box0.left, 1), reason: 'box unmoved');
+      expect(a.calloutBox!.right, closeTo(box0.right, 1));
       await settle(tester);
     });
 

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -320,6 +320,22 @@ class PdfAnnotation {
     return points;
   }
 
+  /// The text-box sub-rect of a callout (§12.5.6.19): [rect] inset by /RD,
+  /// distinct from /Rect which also encloses the leader line and arrowhead.
+  /// Null when this is not a callout.
+  PdfRect? get calloutBox {
+    if (!isCallout) return null;
+    final rd = document.cos.resolve(dict['RD']);
+    double d(int i) {
+      if (rd is! CosArray || rd.items.length <= i) return 0;
+      return _number(document.cos.resolve(rd.items[i])) ?? 0;
+    }
+
+    final r = rect;
+    return PdfRect(
+        r.left + d(0), r.bottom + d(3), r.right - d(2), r.top - d(1));
+  }
+
   /// The /Measure dictionary (§12.9): the scale and unit formats a
   /// measurement annotation (Line/PolyLine/Polygon) carries. Null when
   /// the annotation has no /Measure.

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -295,6 +295,31 @@ class PdfAnnotation {
     return points;
   }
 
+  /// True when this is a FreeText callout (§12.5.6.19): a text box joined
+  /// to a point on the page by a leader line (/CL) that ends in an arrow.
+  bool get isCallout {
+    if (subtype != 'FreeText') return false;
+    final it = document.cos.resolve(dict['IT']);
+    return it is CosName && it.value == 'FreeTextCallout';
+  }
+
+  /// The callout leader-line points (/CL, §12.5.6.19) in page space - the
+  /// first point is the arrow tip on the page, the last touches the text
+  /// box. Null when this is not a callout or carries no usable /CL.
+  List<(double, double)>? get calloutLine {
+    if (!isCallout) return null;
+    final raw = document.cos.resolve(dict['CL']);
+    if (raw is! CosArray || raw.items.length < 4) return null;
+    final points = <(double, double)>[];
+    for (var i = 0; i + 1 < raw.items.length; i += 2) {
+      final x = _number(document.cos.resolve(raw.items[i]));
+      final y = _number(document.cos.resolve(raw.items[i + 1]));
+      if (x == null || y == null) return null;
+      points.add((x, y));
+    }
+    return points;
+  }
+
   /// The /Measure dictionary (§12.9): the scale and unit formats a
   /// measurement annotation (Line/PolyLine/Polygon) carries. Null when
   /// the annotation has no /Measure.

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1684,10 +1684,8 @@ extension PdfAnnotationEditing on PdfEditor {
     PdfTextAlign? align,
     int color = 0x000000,
     int? fillColor,
-    int? borderColor = 0xD02020,
-    double borderWidth = 1,
-    int? lineColor,
-    double lineWidth = 1,
+    int strokeColor = 0xD02020,
+    double strokeWidth = 1,
     PdfLineEnding ending = PdfLineEnding.openArrow,
     int? pageRotation,
     String? author,
@@ -1705,17 +1703,19 @@ extension PdfAnnotationEditing on PdfEditor {
     final effectiveFont = unicodeFont ?? font;
     if (font is PdfEmbeddedFont) font.resetUsage();
 
-    final leaderColor = lineColor ?? borderColor ?? color;
+    // A callout's box outline and leader share one stroke (color + width),
+    // as in Bluebeam - and it's always persisted (/BS width + /DA RG) so a
+    // later reshape reproduces the same arrow instead of guessing.
     final callout = _calloutLine(boxRect, target);
     // /Rect and BBox must cover the box, the leader, and the arrowhead.
     final endingPoints =
-        _endingExtent(ending, callout.first, callout[1], lineWidth);
+        _endingExtent(ending, callout.first, callout[1], strokeWidth);
     final rect = _pointBounds([
       (boxRect.left, boxRect.bottom),
       (boxRect.right, boxRect.top),
       ...callout,
       ...endingPoints,
-    ], math.max(borderWidth, lineWidth));
+    ], strokeWidth);
 
     final w = _calloutContent(boxRect, callout, text,
         fontSize: fontSize,
@@ -1724,17 +1724,16 @@ extension PdfAnnotationEditing on PdfEditor {
         align: align,
         color: color,
         fillColor: fillColor,
-        borderColor: borderColor,
-        borderWidth: borderWidth,
-        lineColor: leaderColor,
-        lineWidth: lineWidth,
+        borderColor: strokeColor,
+        borderWidth: strokeWidth,
+        lineColor: strokeColor,
+        lineWidth: strokeWidth,
         ending: ending,
         pageRotation: effectivePageRotation);
 
     String rgb(int c) =>
         ContentWriter.rgbComponents(c).map(ContentWriter.fmt).join(' ');
-    final da = '${rgb(color)} rg '
-        '${borderColor != null ? '${rgb(borderColor)} RG ' : ''}'
+    final da = '${rgb(color)} rg ${rgb(strokeColor)} RG '
         '/${effectiveFont.resourceName} ${ContentWriter.fmt(fontSize)} Tf';
     final dict = _markupDict('FreeText', rect, fillColor ?? color, text, author)
       ..['DA'] = CosString.fromText(da)
@@ -1742,11 +1741,9 @@ extension PdfAnnotationEditing on PdfEditor {
       ..['CL'] = _pointArray(callout)
       ..['LE'] = CosName(ending.pdfName)
       ..['RD'] = _rdArray(rect, boxRect)
+      ..['BS'] = _borderStyle(strokeWidth)
       ..['Q'] = CosInteger(align?.quadding ??
           (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0));
-    if (borderColor != null && borderWidth > 0) {
-      dict['BS'] = _borderStyle(borderWidth);
-    }
     final CosDictionary fontResource;
     if (unicodeFont != null) {
       fontResource = unicodeFont.buildResource(_updater.addObject);
@@ -1765,34 +1762,69 @@ extension PdfAnnotationEditing on PdfEditor {
 
   /// The leader-line points for a callout whose text box is [box] and whose
   /// arrow points at [target]: `[target, knee, attach]`, where `attach`
-  /// meets the box edge nearest the target and `knee` gives the leader a
-  /// short stub into the box (Acrobat/Bluebeam house style). Collapses to
-  /// `[target, attach]` when a knee would be degenerate.
-  List<(double, double)> _calloutLine(PdfRect box, (double, double) target) {
+  /// meets the box (the caller's [attach], clamped to the perimeter, else the
+  /// edge nearest the target) and `knee` gives the leader a short stub out of
+  /// that edge (Acrobat/Bluebeam house style). Collapses to `[target, attach]`
+  /// when a knee would be degenerate.
+  List<(double, double)> _calloutLine(PdfRect box, (double, double) target,
+      {(double, double)? attach}) {
+    final a = attach != null
+        ? _clampToBoxPerimeter(box, attach)
+        : _calloutAttach(box, target);
+    final knee = _calloutKnee(box, a, target);
+    return knee == null ? [target, a] : [target, knee, a];
+  }
+
+  /// Where the leader meets [box] when the base isn't pinned: the point on the
+  /// edge facing [target].
+  (double, double) _calloutAttach(PdfRect box, (double, double) target) {
     final (tx, ty) = target;
-    const stub = 14.0;
     if (tx < box.left) {
-      final y = ty.clamp(box.bottom + 2, box.top - 2).toDouble();
-      final k = box.left - math.min(stub, (box.left - tx) * 0.5);
-      return [target, (k, y), (box.left, y)];
+      return (box.left, ty.clamp(box.bottom + 2, box.top - 2).toDouble());
     }
     if (tx > box.right) {
-      final y = ty.clamp(box.bottom + 2, box.top - 2).toDouble();
-      final k = box.right + math.min(stub, (tx - box.right) * 0.5);
-      return [target, (k, y), (box.right, y)];
+      return (box.right, ty.clamp(box.bottom + 2, box.top - 2).toDouble());
     }
     final x = tx.clamp(box.left + 2, box.right - 2).toDouble();
-    if (ty > box.top) {
-      final k = box.top + math.min(stub, (ty - box.top) * 0.5);
-      return [target, (x, k), (x, box.top)];
+    if (ty > box.top) return (x, box.top);
+    if (ty < box.bottom) return (x, box.bottom);
+    return (x, (box.bottom + box.top) / 2); // target inside the box
+  }
+
+  /// A short stub out of the edge [a] sits on, toward [target] - null when the
+  /// target is on the box's side of that edge (a straight leader reads better).
+  (double, double)? _calloutKnee(
+      PdfRect box, (double, double) a, (double, double) target) {
+    const stub = 14.0;
+    const eps = 0.5;
+    final (ax, ay) = a;
+    final (tx, ty) = target;
+    if ((ax - box.left).abs() < eps && tx < box.left) {
+      return (box.left - math.min(stub, (box.left - tx) * 0.5), ay);
     }
-    if (ty < box.bottom) {
-      final k = box.bottom - math.min(stub, (box.bottom - ty) * 0.5);
-      return [target, (x, k), (x, box.bottom)];
+    if ((ax - box.right).abs() < eps && tx > box.right) {
+      return (box.right + math.min(stub, (tx - box.right) * 0.5), ay);
     }
-    // Target lands inside the box: a straight stub to the near edge.
-    final cy = (box.bottom + box.top) / 2;
-    return [target, (x, cy)];
+    if ((ay - box.top).abs() < eps && ty > box.top) {
+      return (ax, box.top + math.min(stub, (ty - box.top) * 0.5));
+    }
+    if ((ay - box.bottom).abs() < eps && ty < box.bottom) {
+      return (ax, box.bottom - math.min(stub, (box.bottom - ty) * 0.5));
+    }
+    return null;
+  }
+
+  /// Snaps [p] onto the nearest point of [box]'s perimeter - how a dragged
+  /// arrow base stays glued to the text box edge.
+  (double, double) _clampToBoxPerimeter(PdfRect box, (double, double) p) {
+    final (px, py) = p;
+    final dl = (px - box.left).abs(), dr = (px - box.right).abs();
+    final db = (py - box.bottom).abs(), dt = (py - box.top).abs();
+    final m = math.min(math.min(dl, dr), math.min(db, dt));
+    if (m == dl) return (box.left, py.clamp(box.bottom, box.top).toDouble());
+    if (m == dr) return (box.right, py.clamp(box.bottom, box.top).toDouble());
+    if (m == db) return (px.clamp(box.left, box.right).toDouble(), box.bottom);
+    return (px.clamp(box.left, box.right).toDouble(), box.top);
   }
 
   /// The /RD (rectangle differences, §12.5.6.19) insets - left, top, right,
@@ -1883,15 +1915,32 @@ extension PdfAnnotationEditing on PdfEditor {
   /// /Rect, and the appearance. Returns false when [annotation] is not a
   /// callout this editor can reproduce.
   bool reshapeCallout(int pageIndex, PdfAnnotation annotation,
-      {PdfRect? box, (double, double)? target}) {
+      {PdfRect? box, (double, double)? target, (double, double)? attach}) {
     final info = _calloutInfo(annotation);
     if (info == null) return false;
     final style = annotation.freeTextStyle;
     if (style == null) return false;
     final stdFont = PdfStandardFont.tryFromName(style.fontName);
     if (stdFont == null) return false;
-    final newBox = box ?? _boxFromRd(annotation, annotation.rect);
+    final oldBox = _boxFromRd(annotation, annotation.rect);
+    final newBox = box ?? oldBox;
     final newTarget = target ?? info.line.first;
+    // Keep the arrow base pinned where the user left it: use an explicit
+    // [attach], else carry the current base across a box move/resize by its
+    // relative position on the box, then snap it to the (new) perimeter.
+    final currentAttach = info.line.last;
+    final (double, double) mappedAttach;
+    if (box != null && oldBox.width > 0 && oldBox.height > 0) {
+      final sx = newBox.width / oldBox.width;
+      final sy = newBox.height / oldBox.height;
+      mappedAttach = (
+        newBox.left + (currentAttach.$1 - oldBox.left) * sx,
+        newBox.bottom + (currentAttach.$2 - oldBox.bottom) * sy,
+      );
+    } else {
+      mappedAttach = currentAttach;
+    }
+    final newAttach = attach ?? mappedAttach;
     final text = annotation.contents ?? '';
 
     PdfUnicodeFont? unicodeFont;
@@ -1901,7 +1950,7 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     final PdfTextFont effectiveFont = unicodeFont ?? stdFont;
 
-    final callout = _calloutLine(newBox, newTarget);
+    final callout = _calloutLine(newBox, newTarget, attach: newAttach);
     final leaderColor = style.borderColor ?? style.color;
     final leaderWidth = style.borderWidth > 0 ? style.borderWidth : 1.0;
     final endingPoints =

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1876,6 +1876,79 @@ extension PdfAnnotationEditing on PdfEditor {
         rect.top - d(1));
   }
 
+  /// Rebuilds a callout from a new text [box] and/or arrow [target] (page
+  /// space), keeping the other where it is - so the box and terminus move
+  /// independently (Bluebeam's model: dragging one stretches the leader).
+  /// Preserves the text, style, and arrow ending; regenerates /CL, /RD,
+  /// /Rect, and the appearance. Returns false when [annotation] is not a
+  /// callout this editor can reproduce.
+  bool reshapeCallout(int pageIndex, PdfAnnotation annotation,
+      {PdfRect? box, (double, double)? target}) {
+    final info = _calloutInfo(annotation);
+    if (info == null) return false;
+    final style = annotation.freeTextStyle;
+    if (style == null) return false;
+    final stdFont = PdfStandardFont.tryFromName(style.fontName);
+    if (stdFont == null) return false;
+    final newBox = box ?? _boxFromRd(annotation, annotation.rect);
+    final newTarget = target ?? info.line.first;
+    final text = annotation.contents ?? '';
+
+    PdfUnicodeFont? unicodeFont;
+    if (text.codeUnits.any((c) => c > 0xFF)) {
+      unicodeFont = PdfUnicodeFont(stdFont);
+      unicodeFont.resetUsage();
+    }
+    final PdfTextFont effectiveFont = unicodeFont ?? stdFont;
+
+    final callout = _calloutLine(newBox, newTarget);
+    final leaderColor = style.borderColor ?? style.color;
+    final leaderWidth = style.borderWidth > 0 ? style.borderWidth : 1.0;
+    final endingPoints =
+        _endingExtent(info.ending, callout.first, callout[1], leaderWidth);
+    final rect = _pointBounds([
+      (newBox.left, newBox.bottom),
+      (newBox.right, newBox.top),
+      ...callout,
+      ...endingPoints,
+    ], math.max(style.borderWidth, leaderWidth));
+
+    final pageRotation = _appearancePageRotation(pageIndex, null);
+    final w = _calloutContent(newBox, callout, text,
+        fontSize: style.fontSize,
+        font: effectiveFont,
+        textDirection: PdfTextDirection.auto,
+        align: style.alignment,
+        color: style.color,
+        fillColor: style.fillColor,
+        borderColor: style.borderColor,
+        borderWidth: style.borderWidth,
+        lineColor: leaderColor,
+        lineWidth: leaderWidth,
+        ending: info.ending,
+        pageRotation: pageRotation);
+
+    final dict = annotation.dict;
+    dict['Rect'] = _rectArray(rect);
+    dict['CL'] = _pointArray(callout);
+    dict['RD'] = _rdArray(rect, newBox);
+    final fontResource = unicodeFont != null
+        ? unicodeFont.buildResource(_updater.addObject)
+        : _standardFont(stdFont);
+    final form = annotation.normalAppearance;
+    if (form != null) {
+      _replaceAppearance(dict, form, rect, w,
+          resources: _resources(font: fontResource));
+    } else {
+      dict['AP'] = CosDictionary({
+        'N': _updater
+            .addObject(_form(rect, w, resources: _resources(font: fontResource)))
+      });
+    }
+    _markAnnotationChanged(pageIndex, dict);
+    return true;
+  }
+
   /// Adds a rich free-text annotation whose appearance can switch font,
   /// size, and text color between [runs].
   ///

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -1664,6 +1664,218 @@ extension PdfAnnotationEditing on PdfEditor {
     );
   }
 
+  /// Adds a callout annotation (§12.5.6.19): a /FreeText text box drawn at
+  /// [boxRect] joined to [target] on the page by a leader line that ends in
+  /// [ending] (an open arrow by default). Bluebeam's Callout tool.
+  ///
+  /// The annotation carries `/IT /FreeTextCallout`, the leader points in
+  /// `/CL` (arrow tip first, box attachment last), the arrow style in `/LE`,
+  /// and `/RD` (the inset from the enclosing /Rect to the text box). The
+  /// appearance draws both the leader with its arrowhead and the text box,
+  /// and /Rect encloses the two so the markup survives §12.5.5 fitting.
+  void addCallout(
+    int pageIndex,
+    PdfRect boxRect,
+    String text,
+    (double, double) target, {
+    double fontSize = 12,
+    PdfTextFont font = PdfStandardFont.helvetica,
+    PdfTextDirection textDirection = PdfTextDirection.auto,
+    PdfTextAlign? align,
+    int color = 0x000000,
+    int? fillColor,
+    int? borderColor = 0xD02020,
+    double borderWidth = 1,
+    int? lineColor,
+    double lineWidth = 1,
+    PdfLineEnding ending = PdfLineEnding.openArrow,
+    int? pageRotation,
+    String? author,
+    String? name,
+  }) {
+    final effectivePageRotation =
+        _appearancePageRotation(pageIndex, pageRotation);
+    // Match addFreeText's non-Latin-1 handling: wrap a base-14 face in a
+    // Type0 Identity-H font so the appearance can encode any code point.
+    PdfUnicodeFont? unicodeFont;
+    if (font is PdfStandardFont && text.codeUnits.any((c) => c > 0xFF)) {
+      unicodeFont = PdfUnicodeFont(font);
+      unicodeFont.resetUsage();
+    }
+    final effectiveFont = unicodeFont ?? font;
+    if (font is PdfEmbeddedFont) font.resetUsage();
+
+    final leaderColor = lineColor ?? borderColor ?? color;
+    final callout = _calloutLine(boxRect, target);
+    // /Rect and BBox must cover the box, the leader, and the arrowhead.
+    final endingPoints =
+        _endingExtent(ending, callout.first, callout[1], lineWidth);
+    final rect = _pointBounds([
+      (boxRect.left, boxRect.bottom),
+      (boxRect.right, boxRect.top),
+      ...callout,
+      ...endingPoints,
+    ], math.max(borderWidth, lineWidth));
+
+    final w = _calloutContent(boxRect, callout, text,
+        fontSize: fontSize,
+        font: effectiveFont,
+        textDirection: textDirection,
+        align: align,
+        color: color,
+        fillColor: fillColor,
+        borderColor: borderColor,
+        borderWidth: borderWidth,
+        lineColor: leaderColor,
+        lineWidth: lineWidth,
+        ending: ending,
+        pageRotation: effectivePageRotation);
+
+    String rgb(int c) =>
+        ContentWriter.rgbComponents(c).map(ContentWriter.fmt).join(' ');
+    final da = '${rgb(color)} rg '
+        '${borderColor != null ? '${rgb(borderColor)} RG ' : ''}'
+        '/${effectiveFont.resourceName} ${ContentWriter.fmt(fontSize)} Tf';
+    final dict = _markupDict('FreeText', rect, fillColor ?? color, text, author)
+      ..['DA'] = CosString.fromText(da)
+      ..['IT'] = const CosName('FreeTextCallout')
+      ..['CL'] = _pointArray(callout)
+      ..['LE'] = CosName(ending.pdfName)
+      ..['RD'] = _rdArray(rect, boxRect)
+      ..['Q'] = CosInteger(align?.quadding ??
+          (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0));
+    if (borderColor != null && borderWidth > 0) {
+      dict['BS'] = _borderStyle(borderWidth);
+    }
+    final CosDictionary fontResource;
+    if (unicodeFont != null) {
+      fontResource = unicodeFont.buildResource(_updater.addObject);
+    } else if (font is PdfEmbeddedFont) {
+      fontResource = font.buildResource(_updater.addObject);
+    } else {
+      fontResource = _standardFont(font as PdfStandardFont);
+    }
+    _addAnnotation(
+      pageIndex,
+      dict,
+      _form(rect, w, resources: _resources(font: fontResource)),
+      name: name,
+    );
+  }
+
+  /// The leader-line points for a callout whose text box is [box] and whose
+  /// arrow points at [target]: `[target, knee, attach]`, where `attach`
+  /// meets the box edge nearest the target and `knee` gives the leader a
+  /// short stub into the box (Acrobat/Bluebeam house style). Collapses to
+  /// `[target, attach]` when a knee would be degenerate.
+  List<(double, double)> _calloutLine(PdfRect box, (double, double) target) {
+    final (tx, ty) = target;
+    const stub = 14.0;
+    if (tx < box.left) {
+      final y = ty.clamp(box.bottom + 2, box.top - 2).toDouble();
+      final k = box.left - math.min(stub, (box.left - tx) * 0.5);
+      return [target, (k, y), (box.left, y)];
+    }
+    if (tx > box.right) {
+      final y = ty.clamp(box.bottom + 2, box.top - 2).toDouble();
+      final k = box.right + math.min(stub, (tx - box.right) * 0.5);
+      return [target, (k, y), (box.right, y)];
+    }
+    final x = tx.clamp(box.left + 2, box.right - 2).toDouble();
+    if (ty > box.top) {
+      final k = box.top + math.min(stub, (ty - box.top) * 0.5);
+      return [target, (x, k), (x, box.top)];
+    }
+    if (ty < box.bottom) {
+      final k = box.bottom - math.min(stub, (box.bottom - ty) * 0.5);
+      return [target, (x, k), (x, box.bottom)];
+    }
+    // Target lands inside the box: a straight stub to the near edge.
+    final cy = (box.bottom + box.top) / 2;
+    return [target, (x, cy)];
+  }
+
+  /// The /RD (rectangle differences, §12.5.6.19) insets - left, top, right,
+  /// bottom - from the annotation [rect] to the text [box] within it.
+  CosArray _rdArray(PdfRect rect, PdfRect box) => CosArray([
+        CosReal(box.left - rect.left),
+        CosReal(rect.top - box.top),
+        CosReal(rect.right - box.right),
+        CosReal(box.bottom - rect.bottom),
+      ]);
+
+  /// Builds a callout's appearance: the leader line with its arrowhead
+  /// (drawn first, in page space) and the text box on top.
+  ContentWriter _calloutContent(
+    PdfRect boxRect,
+    List<(double, double)> callout,
+    String text, {
+    required double fontSize,
+    required PdfTextFont font,
+    required PdfTextDirection textDirection,
+    PdfTextAlign? align,
+    required int color,
+    required int? fillColor,
+    required int? borderColor,
+    required double borderWidth,
+    required int lineColor,
+    required double lineWidth,
+    required PdfLineEnding ending,
+    int pageRotation = 0,
+  }) {
+    final leader = _lineContent(callout,
+        strokeColor: lineColor,
+        strokeWidth: lineWidth,
+        dashPattern: null,
+        closed: false,
+        fillColor: null,
+        startEnding: ending,
+        endEnding: PdfLineEnding.none,
+        hasAlpha: false);
+    final box = _freeTextContent(boxRect, text,
+        fontSize: fontSize,
+        font: font,
+        textDirection: textDirection,
+        align: align,
+        color: color,
+        fillColor: fillColor,
+        borderColor: borderColor,
+        borderWidth: borderWidth,
+        pageRotation: pageRotation);
+    return ContentWriter()
+      ..append(leader)
+      ..append(box);
+  }
+
+  /// Reads a callout's leader line (/CL) and arrow (/LE) when [a] is a
+  /// /FreeTextCallout, else null.
+  ({List<(double, double)> line, PdfLineEnding ending})? _calloutInfo(
+      PdfAnnotation a) {
+    final line = a.calloutLine;
+    if (line == null || line.length < 2) return null;
+    final le = document.cos.resolve(a.dict['LE']);
+    final ending = le is CosName
+        ? PdfLineEnding.fromName(le.value)
+        : PdfLineEnding.openArrow;
+    return (line: line, ending: ending);
+  }
+
+  /// The text-box sub-rect of a callout: [rect] inset by /RD (§12.5.6.19),
+  /// falling back to the whole rect when /RD is absent or malformed.
+  PdfRect _boxFromRd(PdfAnnotation a, PdfRect rect) {
+    final rd = document.cos.resolve(a.dict['RD']);
+    double d(int i) {
+      if (rd is! CosArray || rd.items.length <= i) return 0;
+      final v = document.cos.resolve(rd.items[i]);
+      if (v is CosInteger) return v.value.toDouble();
+      if (v is CosReal) return v.value;
+      return 0;
+    }
+
+    return PdfRect(rect.left + d(0), rect.bottom + d(3), rect.right - d(2),
+        rect.top - d(1));
+  }
+
   /// Adds a rich free-text annotation whose appearance can switch font,
   /// size, and text color between [runs].
   ///
@@ -3326,17 +3538,54 @@ extension PdfAnnotationEditing on PdfEditor {
           unicodeFont.resetUsage();
         }
         final PdfTextFont effectiveFont = unicodeFont ?? stdFont;
-        final w = _freeTextContent(to, text,
-            fontSize: style.fontSize,
-            font: effectiveFont,
-            // direction follows the text; /Q carries the explicit alignment
-            textDirection: PdfTextDirection.auto,
-            align: style.alignment,
-            color: style.color,
-            fillColor: style.fillColor,
-            borderColor: style.borderColor,
-            borderWidth: style.borderWidth,
-            pageRotation: pageRotation);
+        // A callout draws its leader line and box together, and its text box
+        // is a sub-rect of /Rect, so map both through the resize and keep /RD
+        // and /CL in step rather than filling the whole rect with text.
+        final callout = _calloutInfo(annotation);
+        final ContentWriter w;
+        if (callout != null) {
+          final from = annotation.rect;
+          final sx = from.width == 0 ? 1.0 : to.width / from.width;
+          final sy = from.height == 0 ? 1.0 : to.height / from.height;
+          (double, double) map((double, double) p) => (
+                to.left + (p.$1 - from.left) * sx,
+                to.bottom + (p.$2 - from.bottom) * sy,
+              );
+          final line = [for (final p in callout.line) map(p)];
+          final oldBox = _boxFromRd(annotation, from);
+          final box = PdfRect(
+            to.left + (oldBox.left - from.left) * sx,
+            to.bottom + (oldBox.bottom - from.bottom) * sy,
+            to.left + (oldBox.right - from.left) * sx,
+            to.bottom + (oldBox.top - from.bottom) * sy,
+          );
+          dict['RD'] = _rdArray(to, box);
+          w = _calloutContent(box, line, text,
+              fontSize: style.fontSize,
+              font: effectiveFont,
+              textDirection: PdfTextDirection.auto,
+              align: style.alignment,
+              color: style.color,
+              fillColor: style.fillColor,
+              borderColor: style.borderColor,
+              borderWidth: style.borderWidth,
+              lineColor: style.borderColor ?? style.color,
+              lineWidth: style.borderWidth > 0 ? style.borderWidth : 1,
+              ending: callout.ending,
+              pageRotation: pageRotation);
+        } else {
+          w = _freeTextContent(to, text,
+              fontSize: style.fontSize,
+              font: effectiveFont,
+              // direction follows the text; /Q carries the explicit alignment
+              textDirection: PdfTextDirection.auto,
+              align: style.alignment,
+              color: style.color,
+              fillColor: style.fillColor,
+              borderColor: style.borderColor,
+              borderWidth: style.borderWidth,
+              pageRotation: pageRotation);
+        }
         final CosDictionary fontResource = unicodeFont != null
             ? unicodeFont.buildResource(_updater.addObject)
             : _standardFont(stdFont);

--- a/packages/pdf_document/lib/src/content_writer.dart
+++ b/packages/pdf_document/lib/src/content_writer.dart
@@ -288,6 +288,11 @@ class ContentWriter {
           double a, double b, double c, double d, double e, double f) =>
       op('cm', [a, b, c, d, e, f]);
 
+  /// Appends [other]'s buffered operators verbatim. Lets a caller compose
+  /// content built by two helpers - e.g. a callout's leader line and its
+  /// text box - into a single stream.
+  void append(ContentWriter other) => _buffer.write(other._buffer.toString());
+
   Uint8List takeBytes() =>
       Uint8List.fromList(latin1.encode(_buffer.toString()));
 

--- a/packages/pdf_document/test/callout_test.dart
+++ b/packages/pdf_document/test/callout_test.dart
@@ -85,6 +85,45 @@ void main() {
     expect(line.last.$1, 300.0, reason: 'attaches to the box left edge');
   });
 
+  test('the leader attaches to the box edge nearest the target', () {
+    // box is (300,600)-(460,660): left=300 right=460 bottom=600 top=660
+    ((double, double), List<(double, double)>) place((double, double) target) {
+      final doc = roundTrip(
+          (e) => e.addCallout(0, const PdfRect(300, 600, 460, 660), 'x', target));
+      final line = doc.page(0).annotations.single.calloutLine!;
+      return (line.last, line);
+    }
+
+    // target to the right -> attaches on the right edge (x == 460)
+    expect(place((560, 630)).$1.$1, 460);
+    // target above -> attaches on the top edge (y == 660)
+    expect(place((380, 760)).$1.$2, 660);
+    // target below -> attaches on the bottom edge (y == 600)
+    expect(place((380, 500)).$1.$2, 600);
+    // target inside the box -> a straight 2-point leader, no knee
+    expect(place((380, 630)).$2, hasLength(2));
+  });
+
+  test('restyling a callout regenerates its leader + box', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addCallout(
+        0, const PdfRect(300, 600, 460, 660), 'restyle me', (120, 500),
+        color: 0x000000);
+    final doc0 = PdfDocument.open(editor.save());
+    final annot0 = doc0.page(0).annotations.single;
+
+    final editor2 = PdfEditor(doc0);
+    editor2.restyleAnnotation(0, annot0, color: 0x2060C0);
+    final doc = PdfDocument.open(editor2.save());
+    final annot = doc.page(0).annotations.single;
+
+    expect(annot.isCallout, isTrue);
+    expect(annot.calloutLine!.first, (120.0, 500.0));
+    final content = appearanceText(doc, annot);
+    expect(content, contains('120 500 m'), reason: 'leader still drawn');
+    expect(content, contains(' Tj'), reason: 'text still drawn');
+  });
+
   test('a plain free text is not a callout', () {
     final doc = roundTrip((e) =>
         e.addFreeText(0, const PdfRect(72, 600, 240, 680), 'plain text'));

--- a/packages/pdf_document/test/callout_test.dart
+++ b/packages/pdf_document/test/callout_test.dart
@@ -132,6 +132,56 @@ void main() {
     expect(annot.calloutLine, isNull);
   });
 
+  test('reshapeCallout with a new box keeps the terminus fixed', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addCallout(
+        0, const PdfRect(300, 600, 460, 660), 'move box', (120, 500));
+    final doc0 = PdfDocument.open(editor.save());
+    final a0 = doc0.page(0).annotations.single;
+    final terminus0 = a0.calloutLine!.first;
+
+    final editor2 = PdfEditor(doc0);
+    expect(
+        editor2.reshapeCallout(0, a0, box: const PdfRect(340, 620, 500, 680)),
+        isTrue);
+    final a = PdfDocument.open(editor2.save()).page(0).annotations.single;
+
+    expect(a.isCallout, isTrue);
+    expect(a.calloutLine!.first, terminus0, reason: 'terminus unchanged');
+    expect(a.calloutBox!.left, closeTo(340, 0.5));
+    expect(a.calloutBox!.top, closeTo(680, 0.5));
+  });
+
+  test('reshapeCallout with a new target keeps the box fixed', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addCallout(
+        0, const PdfRect(300, 600, 460, 660), 'move arrow', (120, 500));
+    final doc0 = PdfDocument.open(editor.save());
+    final a0 = doc0.page(0).annotations.single;
+    final box0 = a0.calloutBox!;
+
+    final editor2 = PdfEditor(doc0);
+    expect(editor2.reshapeCallout(0, a0, target: (560, 630)), isTrue);
+    final a = PdfDocument.open(editor2.save()).page(0).annotations.single;
+
+    expect(a.calloutLine!.first, (560.0, 630.0), reason: 'terminus moved');
+    expect(a.calloutBox!.left, closeTo(box0.left, 0.5));
+    expect(a.calloutBox!.right, closeTo(box0.right, 0.5));
+    expect(a.calloutBox!.top, closeTo(box0.top, 0.5));
+    expect(a.calloutBox!.bottom, closeTo(box0.bottom, 0.5));
+    // leader now attaches to the right edge, following the moved target
+    expect(a.calloutLine!.last.$1, closeTo(box0.right, 0.5));
+  });
+
+  test('reshapeCallout refuses a plain free text', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addFreeText(0, const PdfRect(72, 600, 240, 680), 'plain');
+    final doc0 = PdfDocument.open(editor.save());
+    final a0 = doc0.page(0).annotations.single;
+    final editor2 = PdfEditor(doc0);
+    expect(editor2.reshapeCallout(0, a0, target: (10, 10)), isFalse);
+  });
+
   test('resizing a callout scales its leader and keeps it a callout', () {
     final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
     editor.addCallout(

--- a/packages/pdf_document/test/callout_test.dart
+++ b/packages/pdf_document/test/callout_test.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  PdfDocument roundTrip(void Function(PdfEditor) edit) {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    edit(editor);
+    return PdfDocument.open(editor.save());
+  }
+
+  String appearanceText(PdfDocument doc, PdfAnnotation annot) {
+    final stream = annot.normalAppearance;
+    expect(stream, isNotNull, reason: 'annotation must carry /AP /N');
+    return latin1.decode(doc.cos.decodeStreamData(stream!));
+  }
+
+  List<double> numbers(PdfDocument doc, CosObject? raw) {
+    final arr = doc.cos.resolve(raw) as CosArray;
+    return [
+      for (final item in arr.items)
+        switch (doc.cos.resolve(item)) {
+          CosInteger(:final value) => value.toDouble(),
+          CosReal(:final value) => value,
+          _ => double.nan,
+        }
+    ];
+  }
+
+  test('callout is a FreeText with /IT, /CL, /LE, /RD and a leader + box', () {
+    final doc = roundTrip((e) => e.addCallout(
+          0,
+          const PdfRect(300, 600, 460, 660),
+          'See this detail',
+          (120, 500),
+          author: 'Ben',
+        ));
+    final annot = doc.page(0).annotations.single;
+    expect(annot.subtype, 'FreeText');
+    expect(annot.isCallout, isTrue);
+    expect(annot.contents, 'See this detail');
+    expect((doc.cos.resolve(annot.dict['IT']) as CosName).value,
+        'FreeTextCallout');
+    expect((doc.cos.resolve(annot.dict['LE']) as CosName).value, 'OpenArrow');
+
+    // /CL starts at the arrow tip (the target) and ends on the box edge.
+    final cl = numbers(doc, annot.dict['CL']);
+    expect(cl.length, anyOf(4, 6));
+    expect(cl[0], 120);
+    expect(cl[1], 500);
+    expect(cl[cl.length - 2], 300, reason: 'last CL point meets the box left');
+
+    // /RD is non-negative on every side and the box fits inside /Rect.
+    final rd = numbers(doc, annot.dict['RD']);
+    expect(rd, hasLength(4));
+    expect(rd.every((v) => v >= -0.001), isTrue);
+
+    // /Rect encloses the arrow tip well below the text box.
+    final rect = annot.rect;
+    expect(rect.left, lessThanOrEqualTo(120));
+    expect(rect.bottom, lessThanOrEqualTo(500));
+    expect(rect.top, greaterThanOrEqualTo(660));
+
+    // The appearance draws the arrowhead (a fill) and the wrapped text.
+    final content = appearanceText(doc, annot);
+    expect(content, contains('120 500 m'),
+        reason: 'leader starts at the arrow tip');
+    expect(content, contains('BT'));
+    expect(content, contains('/Helv 12 Tf'));
+    expect(content, contains(' Tj'));
+  });
+
+  test('calloutLine getter reads the /CL points back', () {
+    final doc = roundTrip((e) => e.addCallout(
+          0,
+          const PdfRect(300, 600, 460, 660),
+          'x',
+          (120, 500),
+        ));
+    final line = doc.page(0).annotations.single.calloutLine!;
+    expect(line.first, (120.0, 500.0));
+    expect(line.last.$1, 300.0, reason: 'attaches to the box left edge');
+  });
+
+  test('a plain free text is not a callout', () {
+    final doc = roundTrip((e) =>
+        e.addFreeText(0, const PdfRect(72, 600, 240, 680), 'plain text'));
+    final annot = doc.page(0).annotations.single;
+    expect(annot.isCallout, isFalse);
+    expect(annot.calloutLine, isNull);
+  });
+
+  test('resizing a callout scales its leader and keeps it a callout', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addCallout(
+        0, const PdfRect(300, 600, 460, 660), 'detail', (120, 500));
+    final doc0 = PdfDocument.open(editor.save());
+    final annot0 = doc0.page(0).annotations.single;
+    final grown = PdfRect(annot0.rect.left, annot0.rect.bottom,
+        annot0.rect.right + 80, annot0.rect.top + 40);
+
+    final editor2 = PdfEditor(doc0);
+    editor2.resizeAnnotation(0, annot0, grown);
+    final doc = PdfDocument.open(editor2.save());
+    final annot = doc.page(0).annotations.single;
+
+    expect(annot.isCallout, isTrue);
+    expect(annot.rect.width, closeTo(grown.width, 0.5));
+    // The leader still starts at the (scaled) arrow tip and the appearance
+    // still draws text - not a stretched blur.
+    final line = annot.calloutLine!;
+    expect(line.length, greaterThanOrEqualTo(2));
+    final content = appearanceText(doc, annot);
+    expect(content, contains(' Tj'));
+    expect(content, contains('Tf'));
+  });
+}

--- a/packages/pdf_document/test/callout_test.dart
+++ b/packages/pdf_document/test/callout_test.dart
@@ -169,8 +169,79 @@ void main() {
     expect(a.calloutBox!.right, closeTo(box0.right, 0.5));
     expect(a.calloutBox!.top, closeTo(box0.top, 0.5));
     expect(a.calloutBox!.bottom, closeTo(box0.bottom, 0.5));
-    // leader now attaches to the right edge, following the moved target
-    expect(a.calloutLine!.last.$1, closeTo(box0.right, 0.5));
+    // the base stays pinned where it was (left edge) - moving the arrow tip
+    // doesn't slide the base around the box
+    expect(a.calloutLine!.last.$1, closeTo(box0.left, 0.5));
+  });
+
+  double bsWidth(PdfDocument doc, PdfAnnotation a) {
+    final bs = doc.cos.resolve(a.dict['BS']) as CosDictionary;
+    return switch (doc.cos.resolve(bs['W'])) {
+      CosInteger(:final value) => value.toDouble(),
+      CosReal(:final value) => value,
+      _ => double.nan,
+    };
+  }
+
+  test('the leader keeps its stroke width when the terminus moves', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    // a callout with no separate box border still has a definite stroke
+    editor.addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (120, 500),
+        strokeColor: 0x000000, strokeWidth: 3);
+    final doc0 = PdfDocument.open(editor.save());
+    final a0 = doc0.page(0).annotations.single;
+    // /BS persists the width even without a distinct box-border color
+    expect(bsWidth(doc0, a0), 3);
+
+    final e2 = PdfEditor(doc0);
+    e2.reshapeCallout(0, a0, target: (140, 520));
+    final doc = PdfDocument.open(e2.save());
+    final a = doc.page(0).annotations.single;
+    expect(bsWidth(doc, a), 3,
+        reason: 'arrow width unchanged after moving the terminus');
+  });
+
+  test('reshapeCallout with a new attach slides the base along the box', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (120, 500));
+    final doc0 = PdfDocument.open(editor.save());
+    final a0 = doc0.page(0).annotations.single;
+    final terminus0 = a0.calloutLine!.first;
+
+    final e2 = PdfEditor(doc0);
+    // drag the base toward the top edge; it snaps onto the perimeter
+    expect(e2.reshapeCallout(0, a0, attach: (380, 655)), isTrue);
+    final a = PdfDocument.open(e2.save()).page(0).annotations.single;
+
+    expect(a.calloutLine!.first, terminus0, reason: 'terminus unchanged');
+    final base = a.calloutLine!.last;
+    // snapped to the top edge (y == 660), x near where we dragged
+    expect(base.$2, closeTo(660, 0.5));
+    expect(base.$1, closeTo(380, 0.5));
+    expect(a.calloutBox!.left, closeTo(300, 0.5), reason: 'box unchanged');
+  });
+
+  test('the base keeps its relative edge position when the box resizes', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addCallout(0, const PdfRect(300, 600, 460, 660), 'x', (120, 500));
+    final doc0 = PdfDocument.open(editor.save());
+    final a0 = doc0.page(0).annotations.single;
+    // pin the base at the top edge, mid-box
+    final e1 = PdfEditor(doc0);
+    e1.reshapeCallout(0, a0, attach: (380, 660));
+    final doc1 = PdfDocument.open(e1.save());
+    final a1 = doc1.page(0).annotations.single;
+    expect(a1.calloutLine!.last.$2, closeTo(660, 0.5));
+
+    // grow the box; the base rides the top edge to the same fraction across
+    final e2 = PdfEditor(doc1);
+    e2.reshapeCallout(0, a1, box: const PdfRect(300, 600, 500, 700));
+    final a2 = PdfDocument.open(e2.save()).page(0).annotations.single;
+    final base = a2.calloutLine!.last;
+    expect(base.$2, closeTo(700, 0.5), reason: 'still on the (new) top edge');
+    // was at x=380 in a 160-wide box starting at 300 => 50% across;
+    // new box is 200 wide starting at 300 => 400
+    expect(base.$1, closeTo(400, 1));
   });
 
   test('reshapeCallout refuses a plain free text', () {


### PR DESCRIPTION
## Summary

Adds a Bluebeam-style **Callout** annotation tool: a `/FreeText` text box joined to a point on the page by a leader line that ends in an arrow. Two-point placement — drag from the terminus (what you're pointing at) to where the text box goes, then type.

**Model (`pdf_document`)** — `PdfEditor.addCallout(page, boxRect, text, target, …)` writes a `FreeText` annotation carrying, on top of what `addFreeText` writes:
- `/IT /FreeTextCallout`
- `/CL` — the leader points, arrow tip **first**, box attachment **last** (§12.5.6.19). `_calloutLine` attaches to the box edge nearest the target and adds a short knee stub into the box.
- `/LE` — a single arrow name on the tip.
- `/RD` — the inset from `/Rect` to the text box, so the box is a sub-rect of a `/Rect` that also encloses the leader + arrowhead (survives the §12.5.5 appearance fit).

The appearance composes the leader + arrowhead (reusing the Line tool's `_drawEnding`) with the text box, via a new `ContentWriter.append`. `PdfAnnotation.isCallout` / `.calloutLine` read it back. FreeText resize/restyle regeneration was extended to redraw the leader + box together (mapping `/CL` and the `/RD` sub-rect through the resize affine); move needs nothing extra.

**Editor UI (`dart_pdf_editor`)** — new `PdfEditTool.callout`: drag-to-place through the overlay (with a leader-line drag preview), a plain tap uses the tap as the terminus, `controller.addCallout` dispatch, a "Callout" chip in the Insert toolbar group, the **Q** shortcut, and a Callout label/chat-bubble icon in the sidebar and properties panel (branching on `isCallout`, since the subtype stays `FreeText`).

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (clean at repo root)
- [x] `cd packages/pdf_document && fvm dart test` (new `callout_test.dart` + annotation editor/restyle/line-ending/clipboard suites)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (new `editing_callout_test.dart` + tool-shortcuts/sidebar/properties/text-edit/shape-resize/broad editing suites)
- [x] Real PDF corpus parse/render smoke test (rendered a sample callout page — box, border, fill, knee'd leader, and arrowhead all correct)

If any relevant check was not run, explain why: full corpus/Ghent sweeps not run; the change is additive to annotation authoring and the FreeText regeneration branch is gated on `/CL` so existing free text is untouched.

## PDF fixtures and screenshots

Sample callout built programmatically in the tests (`buildClassicPdf` + `addCallout`); no external fixtures added. The rasterized sample shows the yellow-filled, blue-bordered box with a knee'd leader line ending in an open arrow at the terminus.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `/LE` on a callout is a **single** name (arrow on the tip), unlike a Line's two-element `/LE` — handled in both the writer and `_calloutInfo`.
- Resize scales the whole callout proportionally (box + leader together), which keeps the text readable rather than stretched.
- Follow-up ideas, out of scope here: multiple leader lines from one box, independently dragging the terminus vs. the box, and per-callout arrow-style/leader-color controls in the properties panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015r4R5a6dzMGu4kvKTc7hU1

---
_Generated by [Claude Code](https://claude.ai/code/session_015r4R5a6dzMGu4kvKTc7hU1)_