### PR TITLE
fix(pdf_graphics): re-sharpen all image types under deep zoom

### DIFF
--- a/doc/dev-log/2026-07-09-deep-zoom-image-fallback.md
+++ b/doc/dev-log/2026-07-09-deep-zoom-image-fallback.md
@@ -1,0 +1,63 @@
+# Deep-zoom detail patch: re-decode every image type, not just Flate
+
+## Symptom
+
+At high zoom, raster images (a scanned map, a logo) looked soft while text
+stayed crisp. Text is vector, so it re-sharpens at any zoom; images are
+raster and re-sharpen only when the deep-zoom detail patch re-decodes the
+visible slice at higher resolution.
+
+The detail patch (`PdfPageView._updateDetail` →
+`_detailPictureFromWorker` → `serializeCommands(imageDecodeRegion:)`) was
+added in the resolution-cap follow-up (see
+[2026-06-25-image-resolution-cap.md](2026-06-25-image-resolution-cap.md)),
+so region re-decode already existed. But it only re-sharpened a narrow
+class of images.
+
+## Root cause
+
+`serializeCommands`'s region path (`_decodeImageForCommand` in
+`pdf_graphics/render_command_codec.dart`) re-decoded the visible slice
+through `decodePdfImagePixelsRegionScaled` - a deliberately narrow fast
+path that only handles **single-filter Flate** RGB/gray 8-bit and
+Indexed-1-bit streams (plus 1-bit `/ImageMask` stencils). For anything
+else the general decoder handles - an Indexed **8-bit** palette
+(PNG-origin), an image with an `/SMask` (a transparent logo), an
+ICC/CalRGB/Lab/Separation colour space, 16-bit, a stacked filter - the
+fast path returns `null`.
+
+When it returned `null`, the code fell straight through to the full-page
+`_capImageResolution` branch, which caps to ~2× the image's on-screen
+footprint at the **base** ratio. So those images stayed pinned at the
+page-raster cap under deep zoom - exactly the asymmetry the detail patch
+exists to remove. (Genuine platform-codec images - non-CMYK DCT/JPEG -
+still decode `null` in pure Dart and ship un-decoded at native
+resolution, so they were already sharp; they are not the issue.)
+
+## Fix
+
+In the region branch, when the fast path declines (`decoded == null`,
+in-region, no predecoded pixels) fall back to decoding the whole image
+once via the general `decodePdfImagePixels` and crop+downsample it to the
+visible region with the existing `_cropDownsampleDecodedPixels`. Every
+decodable image type now re-sharpens on zoom, keyed per region+resolution
+by `_regionKeyStream` like the fast-path result. If the general decoder
+also declines (returns `null`) the old full-page-cap fall-through is
+unchanged.
+
+Cost: the fallback decodes the full source image on the worker to crop a
+small slice, where the Flate fast path decodes only the crop. This is
+symmetric with the base render (which already decodes these images fully
+via the same `decodePdfImagePixels`), runs off the UI thread, fires only
+on settle, and is region-cached - acceptable for the sharpness win.
+
+## Tests
+
+- `render_command_codec_test.dart` "imageDecodeRegion sharpens images the
+  fast path declines (SMask)" - an `/SMask`'d DeviceRGB image (the fast
+  path is asserted to decline it) still comes back cropped, retargeted,
+  and premultiplied through the fallback.
+
+Ghent render baselines are untouched: the region re-decode is worker-only
+and gated on `imageDecodeRegion`, which the direct (no-worker) Ghent
+render path never sets.

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -426,7 +426,7 @@ _CommandImage? _decodeImageForCommand(
       : _imageRegionPlan(
           document, request, imageDecodeRegion, maxImageRatio, budgetScale);
   if (regionPlan != null) {
-    final decoded = regionPlan.outside
+    var decoded = regionPlan.outside
         ? _transparentPixel
         : predecoded == null
             ? decodePdfImagePixelsRegionScaled(
@@ -448,6 +448,31 @@ _CommandImage? _decodeImageForCommand(
                 regionPlan.targetWidth,
                 regionPlan.targetHeight,
               );
+    // The fast region decoder ([decodePdfImagePixelsRegionScaled]) only handles
+    // single-filter Flate RGB/gray/indexed streams; for any other image the
+    // general decoder handles - an Indexed 8-bit palette, an /SMask'd logo, an
+    // ICC/Lab/Separation colour space, 16-bit, a stacked filter - it returns
+    // null. Falling through from here would leave the visible slice at the
+    // full-page 2x cap, so those images stay soft under deep zoom while vector
+    // text sharpens - the exact asymmetry the detail patch exists to remove.
+    // Decode the whole image once and crop+downsample it to the visible region
+    // instead, so every decodable image type re-sharpens on zoom. (Images that
+    // need the platform JPEG codec still decode null here and ship un-decoded
+    // at native resolution, so they are already sharp.)
+    if (decoded == null && !regionPlan.outside && predecoded == null) {
+      final full = decodePdfImagePixels(document, request.stream);
+      if (full != null) {
+        decoded = _cropDownsampleDecodedPixels(
+          full,
+          regionPlan.sourceX,
+          regionPlan.sourceY,
+          regionPlan.sourceWidth,
+          regionPlan.sourceHeight,
+          regionPlan.targetWidth,
+          regionPlan.targetHeight,
+        );
+      }
+    }
     if (decoded != null) {
       final croppedRequest = _copyImageRequest(request,
           transform: regionPlan.transform, decoded: decoded);

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -386,6 +386,71 @@ void main() {
       expect(decoded.rgba, [0, 0, 0, 0]);
     });
 
+    test('imageDecodeRegion sharpens images the fast path declines (SMask)',
+        () {
+      // An /SMask'd image (a transparent logo, say) is exactly the kind the
+      // fast region decoder bails on, so before the general-decoder fallback it
+      // would drop through to the full-page cap and stay soft under deep zoom.
+      // Here the visible slice must still come back cropped + region-keyed.
+      final cos = CosDocument.open(buildClassicPdf());
+      final baseRaw = <int>[];
+      for (var y = 0; y < 4; y++) {
+        for (var x = 0; x < 4; x++) {
+          baseRaw.addAll([x * 40, y * 50, 7]);
+        }
+      }
+      final smask = CosStream(
+        CosDictionary({
+          'Type': const CosName('XObject'),
+          'Subtype': const CosName('Image'),
+          'Width': const CosInteger(4),
+          'Height': const CosInteger(4),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceGray'),
+          'Filter': const CosName('FlateDecode'),
+        }),
+        Uint8List.fromList(zlib.encode(List<int>.filled(16, 128))),
+      );
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(4),
+          'Height': const CosInteger(4),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'Filter': const CosName('FlateDecode'),
+          'SMask': smask,
+        }),
+        Uint8List.fromList(zlib.encode(baseRaw)),
+      );
+      // The fast Flate region path must decline this (SMask present), so the
+      // fallback under test is the only way a region result comes back.
+      expect(
+        decodePdfImagePixelsRegionScaled(cos, stream, 1, 2, 1, 1, 1, 1),
+        isNull,
+      );
+      final command = PdfDrawImageCommand(PdfImageRequest(
+        stream: stream,
+        transform: const PdfMatrix(400, 0, 0, 400, 100, 200),
+      ));
+
+      final bytes = serializeCommands([command],
+          cos: cos,
+          decodeImages: true,
+          maxImagePixelRatio: 100,
+          imageDecodeRegion: const PdfRect(200, 300, 300, 400));
+
+      expect(bytes, isNotNull);
+      final restored = _imageCommands(deserializeCommands(bytes!)).single;
+      // Retargeted to the cropped slice, same as the fast-path region case.
+      expect(restored.request.transform.a, 100);
+      expect(restored.request.transform.d, 100);
+      final decoded = restored.request.decoded!;
+      expect(decoded.width, 1);
+      expect(decoded.height, 1);
+      // Base [40,100,7] premultiplied by the mask's alpha 128.
+      expect(decoded.rgba, [20, 50, 3, 128]);
+    });
+
     final files = <String>[
       '../../test_corpora/ghent/1-CMYK/'
           'GWG166_Softmasks_Images_DeviceCMYK_X4.pdf',


### PR DESCRIPTION
## Summary

At high zoom, raster images (a scanned map, a logo) rendered soft while text stayed crisp. Text is vector so it re-sharpens at any zoom; images re-sharpen only when the deep-zoom detail patch re-decodes the visible page slice at higher resolution.

The detail patch (`PdfPageView._updateDetail` → `serializeCommands(imageDecodeRegion:)`) already re-decoded the visible region, but only through `decodePdfImagePixelsRegionScaled` — a narrow fast path that only handles **single-filter Flate** RGB/gray 8-bit, Indexed-1-bit, and 1-bit stencils. For any other decodable image — an Indexed **8-bit** palette (PNG-origin), an image with an `/SMask` (a transparent logo), an ICC/CalRGB/Lab/Separation colour space, 16-bit, a stacked filter — the fast path returned `null` and the code fell through to the full-page 2× cap, pinning those images at page-raster resolution under deep zoom.

This adds a fallback: when the fast path declines an in-region image, decode the whole image once via the general `decodePdfImagePixels` and crop+downsample it to the visible region (reusing the existing `_cropDownsampleDecodedPixels`), region-keyed like the fast-path result. Every decodable image type now re-sharpens on zoom. Platform-codec images (non-CMYK DCT/JPEG) still ship un-decoded at native resolution — unchanged, and already sharp.

## Affected packages

- [x] `pdf_graphics`
- [x] Documentation / CI / repository metadata only (dev-log note)

## Change type

- [x] Bug fix
- [x] Rendering change

## Validation

- [x] `fvm dart analyze` (changed files, clean)
- [x] `cd packages/pdf_graphics && fvm dart test` (render_command_codec, image_pixels, image_downsample suites pass)

The `dart_pdf_editor` Flutter suite was not re-run: the change is confined to the pure-Dart worker/serialize path in `pdf_graphics`, exercised end-to-end by the codec tests. The region re-decode is worker-only and gated on `imageDecodeRegion`, so the direct (no-worker) Ghent render baselines are unaffected.

## PDF fixtures and screenshots

Regression covered by a programmatic fixture — an `/SMask`'d DeviceRGB image the fast path is asserted to decline, which still returns cropped, retargeted, premultiplied pixels through the fallback.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Trade-off: the fallback decodes the full source image on the worker to crop a small slice, where the Flate fast path decodes only the crop. This is symmetric with the base render (which already decodes these images fully via the same `decodePdfImagePixels`), runs off the UI thread, fires only on settle, and is region-cached. See `doc/dev-log/2026-07-09-deep-zoom-image-fallback.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSm6soEBXQ2W9SFSBkeQcj)_