### PR TITLE
fix(windows): copy snapshots to the system clipboard

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Windows: Snapshots now copy to the system clipboard instead of failing with
+  "Could not copy snapshot to clipboard". The desktop clipboard channel had no
+  Windows handler, so the image never reached the OS clipboard.
 - Mobile: Recent files and the last session now reopen without a fresh pick.
   Opened PDFs are snapshotted into the app's private store, so tapping a Recent
   entry (or relaunching) reopens the document directly instead of showing "Pick

--- a/app/windows/runner/CMakeLists.txt
+++ b/app/windows/runner/CMakeLists.txt
@@ -8,6 +8,7 @@ project(runner LANGUAGES CXX)
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
+  "image_clipboard.cpp"
   "main.cpp"
   "utils.cpp"
   "win32_window.cpp"
@@ -34,6 +35,8 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 # dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
 target_link_libraries(${BINARY_NAME} PRIVATE "dwmapi.lib")
+# image_clipboard.cpp: WIC (PNG<->DIB) plus COM stream helpers.
+target_link_libraries(${BINARY_NAME} PRIVATE "windowscodecs.lib" "ole32.lib")
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/app/windows/runner/flutter_window.cpp
+++ b/app/windows/runner/flutter_window.cpp
@@ -6,10 +6,14 @@
 
 #include <string.h>
 
+#include <cstdint>
 #include <optional>
 #include <string>
+#include <variant>
+#include <vector>
 
 #include "flutter/generated_plugin_registrant.h"
+#include "image_clipboard.h"
 #include "utils.h"
 
 namespace {
@@ -17,6 +21,11 @@ namespace {
 // Reverse-DNS channel shared with the Dart IncomingFileService and every other
 // platform runner (macOS/iOS/Android).
 constexpr const char kIncomingChannelName[] = "dev.milanko.dartpdf/incoming";
+
+// Reverse-DNS channel that carries Snapshot rasters to/from the OS clipboard,
+// matching the macOS/Android runners (see image_clipboard.cpp).
+constexpr const char kImageClipboardChannelName[] =
+    "dev.milanko.dartpdf/image_clipboard";
 
 // Builds the {name, path} payload the Dart side's IncomingFileService decodes.
 flutter::EncodableValue FilePayload(const std::wstring& path) {
@@ -76,6 +85,39 @@ bool FlutterWindow::OnCreate() {
             std::wstring path = initial_file_;
             initial_file_.clear();  // deliver the launch file exactly once
             result->Success(FilePayload(path));
+          }
+        } else {
+          result->NotImplemented();
+        }
+      });
+
+  // Bridge the Snapshot tool's PNG raster to the Win32 clipboard so it can be
+  // pasted into other apps, and read images back for the paste providers.
+  image_clipboard_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(),
+          kImageClipboardChannelName,
+          &flutter::StandardMethodCodec::GetInstance());
+  image_clipboard_channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) {
+        if (call.method_name() == "copyPng") {
+          const auto* bytes =
+              std::get_if<std::vector<uint8_t>>(call.arguments());
+          if (bytes == nullptr) {
+            result->Error("bad_args", "copyPng expects PNG bytes");
+            return;
+          }
+          result->Success(flutter::EncodableValue(
+              CopyPngToClipboard(GetHandle(), *bytes)));
+        } else if (call.method_name() == "readImage") {
+          std::optional<std::vector<uint8_t>> png =
+              ReadImageFromClipboard(GetHandle());
+          if (png.has_value()) {
+            result->Success(flutter::EncodableValue(std::move(*png)));
+          } else {
+            result->Success();  // null: no image on the clipboard
           }
         } else {
           result->NotImplemented();

--- a/app/windows/runner/flutter_window.h
+++ b/app/windows/runner/flutter_window.h
@@ -50,6 +50,11 @@ class FlutterWindow : public Win32Window {
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       incoming_channel_;
 
+  // Channel that copies Snapshot rasters to / reads images from the Win32
+  // clipboard (`copyPng` / `readImage`). Created once the engine exists.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      image_clipboard_channel_;
+
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
 };

--- a/app/windows/runner/image_clipboard.cpp
+++ b/app/windows/runner/image_clipboard.cpp
@@ -1,0 +1,293 @@
+#include "image_clipboard.h"
+
+#include <objbase.h>
+#include <objidl.h>
+#include <ocidl.h>
+#include <wincodec.h>
+#include <wrl/client.h>
+
+#include <cstring>
+
+using Microsoft::WRL::ComPtr;
+
+namespace {
+
+// The registered clipboard format name browsers and Office use to exchange
+// lossless PNG images. Registered once; the returned id is stable per session.
+UINT PngClipboardFormat() {
+  static const UINT format = ::RegisterClipboardFormatW(L"PNG");
+  return format;
+}
+
+// COM apartment is initialized once per process in wWinMain (COINIT_-
+// APARTMENTTHREADED); the channel handler runs on that same UI thread.
+ComPtr<IWICImagingFactory> CreateWicFactory() {
+  ComPtr<IWICImagingFactory> factory;
+  ::CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                     IID_PPV_ARGS(&factory));
+  return factory;
+}
+
+// Decodes |png| into straight-alpha 32bpp BGRA pixels laid out top-down.
+// Returns false on any failure (bad data, unsupported format, OOM).
+bool DecodePngToBgra(IWICImagingFactory* factory,
+                     const std::vector<uint8_t>& png, UINT* width, UINT* height,
+                     std::vector<uint8_t>* pixels) {
+  if (factory == nullptr || png.empty()) {
+    return false;
+  }
+  ComPtr<IWICStream> stream;
+  if (FAILED(factory->CreateStream(&stream))) {
+    return false;
+  }
+  // InitializeFromMemory wants a non-const buffer but only reads from it.
+  if (FAILED(stream->InitializeFromMemory(const_cast<BYTE*>(png.data()),
+                                          static_cast<DWORD>(png.size())))) {
+    return false;
+  }
+  ComPtr<IWICBitmapDecoder> decoder;
+  if (FAILED(factory->CreateDecoderFromStream(
+          stream.Get(), nullptr, WICDecodeMetadataCacheOnDemand, &decoder))) {
+    return false;
+  }
+  ComPtr<IWICBitmapFrameDecode> frame;
+  if (FAILED(decoder->GetFrame(0, &frame))) {
+    return false;
+  }
+  ComPtr<IWICFormatConverter> converter;
+  if (FAILED(factory->CreateFormatConverter(&converter))) {
+    return false;
+  }
+  if (FAILED(converter->Initialize(frame.Get(), GUID_WICPixelFormat32bppBGRA,
+                                   WICBitmapDitherTypeNone, nullptr, 0.0,
+                                   WICBitmapPaletteTypeMedianCut))) {
+    return false;
+  }
+  if (FAILED(converter->GetSize(width, height)) || *width == 0 ||
+      *height == 0) {
+    return false;
+  }
+  const UINT stride = *width * 4;
+  const size_t total = static_cast<size_t>(stride) * *height;
+  pixels->resize(total);
+  return SUCCEEDED(converter->CopyPixels(
+      nullptr, stride, static_cast<UINT>(total), pixels->data()));
+}
+
+// Builds a CF_DIBV5 global block (BITMAPV5HEADER + bottom-up BGRA rows) from
+// the top-down BGRA |pixels|. Returns nullptr on allocation failure.
+HGLOBAL BuildDibV5(UINT width, UINT height,
+                   const std::vector<uint8_t>& pixels) {
+  const UINT stride = width * 4;
+  const size_t image_size = static_cast<size_t>(stride) * height;
+  const size_t total = sizeof(BITMAPV5HEADER) + image_size;
+  HGLOBAL handle = ::GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, total);
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  auto* buffer = static_cast<uint8_t*>(::GlobalLock(handle));
+  if (buffer == nullptr) {
+    ::GlobalFree(handle);
+    return nullptr;
+  }
+  auto* header = reinterpret_cast<BITMAPV5HEADER*>(buffer);
+  header->bV5Size = sizeof(BITMAPV5HEADER);
+  header->bV5Width = static_cast<LONG>(width);
+  header->bV5Height = static_cast<LONG>(height);  // positive => bottom-up rows
+  header->bV5Planes = 1;
+  header->bV5BitCount = 32;
+  header->bV5Compression = BI_BITFIELDS;
+  header->bV5SizeImage = static_cast<DWORD>(image_size);
+  header->bV5RedMask = 0x00FF0000;
+  header->bV5GreenMask = 0x0000FF00;
+  header->bV5BlueMask = 0x000000FF;
+  header->bV5AlphaMask = 0xFF000000;
+  header->bV5CSType = LCS_WINDOWS_COLOR_SPACE;
+  header->bV5Intent = LCS_GM_IMAGES;
+
+  uint8_t* dst = buffer + sizeof(BITMAPV5HEADER);
+  // Flip the top-down source into the bottom-up rows a DIB expects.
+  for (UINT row = 0; row < height; row++) {
+    const uint8_t* src =
+        pixels.data() + static_cast<size_t>(height - 1 - row) * stride;
+    std::memcpy(dst + static_cast<size_t>(row) * stride, src, stride);
+  }
+  ::GlobalUnlock(handle);
+  return handle;
+}
+
+// Copies |bytes| into a GMEM_MOVEABLE global block for SetClipboardData, which
+// takes ownership on success. Returns nullptr on allocation failure.
+HGLOBAL CopyToGlobal(const std::vector<uint8_t>& bytes) {
+  HGLOBAL handle = ::GlobalAlloc(GMEM_MOVEABLE, bytes.size());
+  if (handle == nullptr) {
+    return nullptr;
+  }
+  void* buffer = ::GlobalLock(handle);
+  if (buffer == nullptr) {
+    ::GlobalFree(handle);
+    return nullptr;
+  }
+  std::memcpy(buffer, bytes.data(), bytes.size());
+  ::GlobalUnlock(handle);
+  return handle;
+}
+
+// Reads all bytes out of an in-memory IStream backed by an HGLOBAL.
+bool ReadStreamBytes(IStream* stream, std::vector<uint8_t>* out) {
+  HGLOBAL handle = nullptr;
+  if (FAILED(::GetHGlobalFromStream(stream, &handle)) || handle == nullptr) {
+    return false;
+  }
+  const SIZE_T size = ::GlobalSize(handle);
+  void* buffer = ::GlobalLock(handle);
+  if (buffer == nullptr) {
+    return false;
+  }
+  out->assign(static_cast<uint8_t*>(buffer),
+              static_cast<uint8_t*>(buffer) + size);
+  ::GlobalUnlock(handle);
+  return true;
+}
+
+// Encodes a WIC bitmap source as PNG bytes.
+bool EncodeSourceToPng(IWICImagingFactory* factory, IWICBitmapSource* source,
+                       std::vector<uint8_t>* png) {
+  ComPtr<IStream> stream;
+  if (FAILED(::CreateStreamOnHGlobal(nullptr, TRUE, &stream))) {
+    return false;
+  }
+  ComPtr<IWICBitmapEncoder> encoder;
+  if (FAILED(factory->CreateEncoder(GUID_ContainerFormatPng, nullptr,
+                                    &encoder))) {
+    return false;
+  }
+  if (FAILED(encoder->Initialize(stream.Get(), WICBitmapEncoderNoCache))) {
+    return false;
+  }
+  ComPtr<IWICBitmapFrameEncode> frame;
+  ComPtr<IPropertyBag2> props;
+  if (FAILED(encoder->CreateNewFrame(&frame, &props))) {
+    return false;
+  }
+  if (FAILED(frame->Initialize(props.Get()))) {
+    return false;
+  }
+  if (FAILED(frame->WriteSource(source, nullptr))) {
+    return false;
+  }
+  if (FAILED(frame->Commit()) || FAILED(encoder->Commit())) {
+    return false;
+  }
+  return ReadStreamBytes(stream.Get(), png);
+}
+
+// Guard that opens the clipboard in the constructor and closes it in the
+// destructor so every early-return path releases it.
+class ClipboardGuard {
+ public:
+  explicit ClipboardGuard(HWND owner) : open_(::OpenClipboard(owner) != FALSE) {}
+  ~ClipboardGuard() {
+    if (open_) {
+      ::CloseClipboard();
+    }
+  }
+  bool open() const { return open_; }
+
+ private:
+  bool open_;
+};
+
+}  // namespace
+
+bool CopyPngToClipboard(HWND owner, const std::vector<uint8_t>& png) {
+  ComPtr<IWICImagingFactory> factory = CreateWicFactory();
+  UINT width = 0;
+  UINT height = 0;
+  std::vector<uint8_t> pixels;
+  if (!DecodePngToBgra(factory.Get(), png, &width, &height, &pixels)) {
+    return false;
+  }
+  HGLOBAL dib = BuildDibV5(width, height, pixels);
+  if (dib == nullptr) {
+    return false;
+  }
+  HGLOBAL raw_png = CopyToGlobal(png);
+  if (raw_png == nullptr) {
+    ::GlobalFree(dib);
+    return false;
+  }
+
+  ClipboardGuard clipboard(owner);
+  if (!clipboard.open()) {
+    ::GlobalFree(dib);
+    ::GlobalFree(raw_png);
+    return false;
+  }
+  ::EmptyClipboard();
+
+  // SetClipboardData takes ownership of the handle only when it succeeds; free
+  // whatever it rejects. Success of either format means a paste will work, so
+  // only report failure when both were rejected.
+  int placed = 0;
+  if (::SetClipboardData(CF_DIBV5, dib) != nullptr) {
+    placed++;
+  } else {
+    ::GlobalFree(dib);
+  }
+  if (::SetClipboardData(PngClipboardFormat(), raw_png) != nullptr) {
+    placed++;
+  } else {
+    ::GlobalFree(raw_png);
+  }
+  return placed > 0;
+}
+
+std::optional<std::vector<uint8_t>> ReadImageFromClipboard(HWND owner) {
+  ClipboardGuard clipboard(owner);
+  if (!clipboard.open()) {
+    return std::nullopt;
+  }
+
+  // Prefer a lossless PNG when a source app offered one (browsers, Office).
+  const UINT png_format = PngClipboardFormat();
+  if (::IsClipboardFormatAvailable(png_format)) {
+    HANDLE handle = ::GetClipboardData(png_format);
+    if (handle != nullptr) {
+      const SIZE_T size = ::GlobalSize(handle);
+      void* buffer = ::GlobalLock(handle);
+      if (buffer != nullptr && size > 0) {
+        std::vector<uint8_t> png(static_cast<uint8_t*>(buffer),
+                                 static_cast<uint8_t*>(buffer) + size);
+        ::GlobalUnlock(handle);
+        return png;
+      }
+      if (buffer != nullptr) {
+        ::GlobalUnlock(handle);
+      }
+    }
+  }
+
+  // Otherwise fall back to a bitmap the system synthesizes from CF_DIB and
+  // re-encode it as PNG. Ignore any alpha channel - pasted screenshots and
+  // DDB-derived bitmaps carry a zeroed alpha that would render fully clear.
+  if (::IsClipboardFormatAvailable(CF_BITMAP)) {
+    HBITMAP bitmap =
+        static_cast<HBITMAP>(::GetClipboardData(CF_BITMAP));
+    if (bitmap != nullptr) {
+      ComPtr<IWICImagingFactory> factory = CreateWicFactory();
+      if (factory) {
+        ComPtr<IWICBitmap> wic_bitmap;
+        if (SUCCEEDED(factory->CreateBitmapFromHBITMAP(
+                bitmap, nullptr, WICBitmapIgnoreAlpha, &wic_bitmap))) {
+          std::vector<uint8_t> png;
+          if (EncodeSourceToPng(factory.Get(), wic_bitmap.Get(), &png)) {
+            return png;
+          }
+        }
+      }
+    }
+  }
+
+  return std::nullopt;
+}

--- a/app/windows/runner/image_clipboard.h
+++ b/app/windows/runner/image_clipboard.h
@@ -1,0 +1,27 @@
+#ifndef RUNNER_IMAGE_CLIPBOARD_H_
+#define RUNNER_IMAGE_CLIPBOARD_H_
+
+#include <windows.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+// Native side of the `dev.milanko.dartpdf/image_clipboard` method channel.
+// Flutter's built-in Clipboard only carries text, so putting a Snapshot raster
+// on the OS clipboard needs Win32 code. The macOS/Android runners implement the
+// same channel; Windows was the missing platform (snapshots reported "Could not
+// copy snapshot to clipboard").
+
+// Writes PNG-encoded |png| bytes to the Windows clipboard so a Snapshot can be
+// pasted into other apps. The image is offered both as a registered "PNG"
+// clipboard format (preferred by browsers and Office) and as a CF_DIBV5 bitmap
+// (understood by Paint and other legacy consumers). |owner| owns the clipboard
+// for the duration of the write. Returns true on success.
+bool CopyPngToClipboard(HWND owner, const std::vector<uint8_t>& png);
+
+// Reads an image off the Windows clipboard and returns it as PNG bytes, or
+// std::nullopt when the clipboard holds no image (or the conversion fails).
+std::optional<std::vector<uint8_t>> ReadImageFromClipboard(HWND owner);
+
+#endif  // RUNNER_IMAGE_CLIPBOARD_H_

--- a/doc/dev-log/2026-07-10-snapshot-clipboard-windows.md
+++ b/doc/dev-log/2026-07-10-snapshot-clipboard-windows.md
@@ -1,0 +1,52 @@
+# Snapshot → clipboard: implement the Windows native channel
+
+**Bug (1.4.0, Windows):** taking a Snapshot toasts "Could not copy snapshot
+to clipboard".
+
+## Root cause
+
+`c7f63c1` ("remove super_clipboard dependency") replaced the cross-platform
+`super_clipboard` writer with an app-owned method channel,
+`dev.milanko.dartpdf/image_clipboard` (`copyPng` / `readImage`, see
+`app/lib/image_clipboard_io.dart`). Native handlers were added for **macOS**
+(`MainFlutterWindow.swift`) and **Android** (`ImageClipboardProvider.kt`), but
+**Windows and Linux got none**. On Windows the `copyPng` invocation therefore
+throws `MissingPluginException`; `clipboardSnapshotHandler` catches it, reports
+`copied = false`, and the screen toasts the failure. (Web is fine - it uses the
+Async Clipboard API directly in `image_clipboard_web.dart`.)
+
+## Fix (Windows runner only)
+
+New `app/windows/runner/image_clipboard.{h,cpp}` implement the channel with
+Win32 + WIC:
+
+- **`CopyPngToClipboard`** decodes the PNG through WIC
+  (`GUID_WICPixelFormat32bppBGRA`), then places **two** clipboard formats so a
+  paste works everywhere: a registered `"PNG"` format (the raw bytes - what
+  browsers/Office prefer) and a `CF_DIBV5` bottom-up BGRA bitmap with the alpha
+  mask set (Paint and legacy consumers). Returns true if either format was
+  accepted; frees any handle `SetClipboardData` rejects (it only takes
+  ownership on success).
+- **`ReadImageFromClipboard`** (for the paste providers, matching macOS's
+  `readImage`) prefers the registered `"PNG"` format, else re-encodes the
+  system-synthesized `CF_BITMAP` (`CreateBitmapFromHBITMAP`,
+  `WICBitmapIgnoreAlpha` so DDB-derived bitmaps with a zeroed alpha don't come
+  back fully transparent) to PNG.
+
+Wiring:
+
+- `flutter_window.cpp` `OnCreate` registers the channel next to the existing
+  `incoming` channel, dispatching `copyPng`/`readImage` to the helpers with
+  `GetHandle()` as the clipboard owner. `flutter_window.h` holds the new
+  `image_clipboard_channel_` member.
+- `CMakeLists.txt` compiles `image_clipboard.cpp` and links
+  `windowscodecs.lib` + `ole32.lib` (WIC + `CreateStreamOnHGlobal`). COM is
+  already initialized process-wide in `wWinMain`
+  (`CoInitializeEx(COINIT_APARTMENTTHREADED)`), and the channel handler runs on
+  that same UI thread.
+
+## Not touched
+
+Linux has the identical gap (no `fl_method_channel` handler in
+`my_application.cc`); left for a follow-up since the report and this branch are
+Windows-scoped. The Dart side, macOS, Android, and web are unchanged.


### PR DESCRIPTION
## Summary

Fixes the 1.4.0 Windows bug where the Snapshot tool toasts **"Could not copy snapshot to clipboard"**.

In `c7f63c1` the app dropped `super_clipboard` and moved snapshot-to-clipboard onto an app-owned method channel, `dev.milanko.dartpdf/image_clipboard` (`copyPng` / `readImage`, see `app/lib/image_clipboard_io.dart`). Native handlers were added for **macOS** and **Android**, but **Windows got none** — so `copyPng` threw `MissingPluginException`, `clipboardSnapshotHandler` caught it and reported `copied = false`, and the screen showed the failure toast. (Web is unaffected; it uses the Async Clipboard API directly.)

This implements the channel in the Windows runner with Win32 + WIC:

- **`CopyPngToClipboard`** — decodes the PNG through WIC (32bpp BGRA) and places **two** clipboard formats so paste works everywhere: a registered `"PNG"` format (raw bytes, preferred by browsers/Office) and a `CF_DIBV5` bottom-up BGRA bitmap with alpha mask (Paint / legacy consumers). Reports success if either format is accepted; frees any handle `SetClipboardData` rejects.
- **`ReadImageFromClipboard`** (matching macOS's `readImage`, used by the paste providers) — prefers the registered `"PNG"` format, else re-encodes the system-synthesized `CF_BITMAP` to PNG (`WICBitmapIgnoreAlpha` so DDB-derived bitmaps don't come back fully transparent).
- Channel wired in `flutter_window.cpp` `OnCreate` alongside the existing `incoming` channel; `CMakeLists.txt` compiles the new source and links `windowscodecs.lib` + `ole32.lib`. COM is already initialized process-wide in `wWinMain`.

## Affected packages

- [x] Example app *(the `/app` desktop shell — Windows runner only)*
- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix

## Validation

Windows-native C++ only; it can't be built or exercised from this Linux CI environment (no MSVC/WIC toolchain), and none of the Dart packages or their tests changed. Verified by code review against the established Flutter Windows method-channel pattern and the macOS handler this mirrors.

- [ ] `fvm flutter pub get`
- [ ] `fvm dart analyze`
- [ ] Example app smoke test *(requires a Windows machine)*

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor` *(no Dart changed)*
- [x] No `dart:io` imports in any `lib/` directory
- [x] Layering is preserved
- [x] Parsers remain lenient / writers strict *(N/A — native runner only)*

## Notes for reviewers

- Needs a Windows machine to confirm end-to-end (copy a snapshot → paste into Paint and into a browser/Office).
- **Linux has the identical gap** (no clipboard handler in `my_application.cc`) — left for a follow-up since this report and branch are Windows-scoped.
- Dev-log: `doc/dev-log/2026-07-10-snapshot-clipboard-windows.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qq7TiWPuQ5SGVvpeJzZanG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq7TiWPuQ5SGVvpeJzZanG)_