### PR TITLE
feat: capture a local error log and attach it to feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/app_feedback.yml
@@ -80,6 +80,12 @@ body:
     attributes:
       label: Anything else?
       description: Add anything that might help. It is fine to leave this blank.
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: The app fills this in automatically when you use "Supply feedback…". It lists the app version, your platform, and any errors from this session - no document contents. You can edit or clear it before submitting.
+      render: text
   - type: checkboxes
     id: privacy
     attributes:

--- a/doc/dev-log/2026-07-10-app-error-logging.md
+++ b/doc/dev-log/2026-07-10-app-error-logging.md
@@ -1,0 +1,64 @@
+# 2026-07-10 - Local error logging attached to feedback
+
+Added an in-app diagnostics log to the example app (`pdf_viewer_example`) and
+wired it into the "Supply feedback…" flow so a bug report carries the
+session's errors.
+
+## Pieces
+
+- `example/lib/error_log.dart`
+  - `AppLog` (a `ChangeNotifier`) is a capped ring buffer (default 300) of
+    `AppLogEntry(time, level, message, error?, stackTrace?)`. Nothing is
+    written to disk or sent anywhere on its own - it lives for the session and
+    is surfaced only when the user opens feedback.
+  - `install()` chains `FlutterError.onError` and
+    `PlatformDispatcher.instance.onError` (preserving the previous handlers so
+    console reporting still runs) and returns a `runZonedGuarded` handler for
+    async errors. Idempotent.
+  - `buildDiagnosticsReport(...)` / `AppLog.buildReport(...)` render the plain
+    text report (header: app version, platform, capture time, count; then each
+    entry with a whitespace-collapsed error line and a stack trimmed to 12
+    frames). Kept as a free function taking injected `entries`/`environment`/
+    `now` so it's deterministic in tests.
+  - `kAppVersion` mirrors the example `pubspec.yaml` version - update both
+    together.
+- `example/lib/feedback.dart`
+  - `buildFeedbackUri(base, report, version, maxUrlLength)` prefills the GitHub
+    issue form's `version` and `diagnostics` fields. The report is attached
+    tail-first (recent events matter most) and binary-searched down to fit
+    under a 6000-char URL budget, with a truncation marker prepended; the full
+    report is still copied to the clipboard so nothing is lost.
+  - `showFeedbackDialog(...)` shows the report for review (selectable
+    monospace, live via `ListenableBuilder`), with Clear log / Copy
+    diagnostics / Open feedback form actions and an "Attach these diagnostics"
+    checkbox (default on). `onOpen` is injected so the host owns
+    url_launcher + toasts.
+- `main.dart`: `main()` installs the log and wraps `runApp` in
+  `runZonedGuarded`; the feedback menu item now calls `_openFeedback` (dialog)
+  instead of launching the raw URL; the previously silent font-load catch and
+  the document-open / save / export / OCR failure catches now record to
+  `AppLog`.
+- `.github/ISSUE_TEMPLATE/app_feedback.yml`: added a `diagnostics` textarea
+  (`render: text`) as the prefill target, described as auto-filled and
+  containing no document contents.
+
+## Gotchas
+
+- The clipboard copy inside "Open feedback form" is fire-and-forget
+  (`unawaited`, try/caught). Awaiting it gated the open when the clipboard
+  channel is absent/denied (headless tests, locked-down web) - opening is the
+  action and must not depend on the clipboard.
+- The diagnostics box is wrapped in `Flexible` with a `maxHeight` constraint
+  so the dialog doesn't overflow on short/mobile viewports (the default
+  800x600 test surface tripped this).
+
+## Tests
+
+- `example/test/error_log_test.dart` - ring buffer capacity/ordering/notify,
+  report contents + stack trimming, URL prefill + tail truncation.
+- `example/test/feedback_dialog_test.dart` - dialog opens the form with
+  version + diagnostics prefilled, the Attach toggle omits diagnostics, Copy
+  writes the report to the clipboard.
+
+(Pre-existing, unrelated: 8 example tests in demo_test/demo_document_test/
+editing_test fail on the branch base too.)

--- a/packages/dart_pdf_editor/example/lib/error_log.dart
+++ b/packages/dart_pdf_editor/example/lib/error_log.dart
@@ -1,0 +1,267 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+/// The app version reported in diagnostics. Keep in sync with the `version`
+/// field in `pubspec.yaml`; it is surfaced to feedback reviewers so a report
+/// can be matched to a build.
+const String kAppVersion = '1.4.0';
+
+/// Severity of a captured [AppLogEntry].
+enum AppLogLevel {
+  info,
+  warning,
+  error;
+
+  String get label => switch (this) {
+        AppLogLevel.info => 'INFO',
+        AppLogLevel.warning => 'WARN',
+        AppLogLevel.error => 'ERROR',
+      };
+}
+
+/// A single line in the in-app diagnostics log: a timestamp, a severity, a
+/// human-readable message, and - for failures - the originating error object
+/// and its stack trace.
+@immutable
+class AppLogEntry {
+  const AppLogEntry({
+    required this.time,
+    required this.level,
+    required this.message,
+    this.error,
+    this.stackTrace,
+  });
+
+  final DateTime time;
+  final AppLogLevel level;
+  final String message;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  /// Renders the entry as plain text for the diagnostics report. Stack traces
+  /// are trimmed to [stackFrames] frames so a report stays scannable and the
+  /// prefilled feedback URL stays within a browser's length budget.
+  String format({int stackFrames = 12}) {
+    final buffer = StringBuffer()
+      ..write(_formatTimestamp(time))
+      ..write('  ')
+      ..write(level.label.padRight(5))
+      ..write('  ')
+      ..write(message);
+    if (error != null) {
+      buffer
+        ..write('\n        ')
+        ..write(_collapseWhitespace(error.toString()));
+    }
+    final stack = stackTrace;
+    if (stack != null) {
+      final frames = stack
+          .toString()
+          .split('\n')
+          .where((line) => line.trim().isNotEmpty)
+          .take(stackFrames);
+      for (final frame in frames) {
+        buffer
+          ..write('\n          ')
+          ..write(frame.trim());
+      }
+    }
+    return buffer.toString();
+  }
+}
+
+/// A capped, in-memory ring buffer of diagnostic events for the running app.
+///
+/// Nothing is written to disk or sent anywhere on its own: the log lives only
+/// for the session and is surfaced to the user on demand, so they can review
+/// it and choose to attach it to a GitHub feedback issue. Installing it hooks
+/// Flutter's error reporters so uncaught framework and platform errors land
+/// here automatically; the app can also record its own breadcrumbs through
+/// [info]/[warning]/[error].
+class AppLog extends ChangeNotifier {
+  AppLog({this.capacity = 300});
+
+  /// The shared instance the app and the feedback flow read from.
+  static final AppLog instance = AppLog();
+
+  /// The most events retained. Older events fall off the front once the
+  /// buffer is full - recent context is what a bug report needs.
+  final int capacity;
+
+  final Queue<AppLogEntry> _entries = Queue<AppLogEntry>();
+
+  bool _installed = false;
+
+  /// A snapshot of the retained events, oldest first.
+  List<AppLogEntry> get entries => List.unmodifiable(_entries);
+
+  bool get isEmpty => _entries.isEmpty;
+
+  /// Records an event. [error]/[stackTrace] are optional and only meaningful
+  /// for warnings and errors. Notifies listeners so an open diagnostics view
+  /// refreshes live.
+  void record(
+    AppLogLevel level,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+  }) {
+    _entries.add(AppLogEntry(
+      time: DateTime.now(),
+      level: level,
+      message: message,
+      error: error,
+      stackTrace: stackTrace,
+    ));
+    while (_entries.length > capacity) {
+      _entries.removeFirst();
+    }
+    notifyListeners();
+  }
+
+  void info(String message) => record(AppLogLevel.info, message);
+
+  void warning(String message, {Object? error, StackTrace? stackTrace}) =>
+      record(AppLogLevel.warning, message,
+          error: error, stackTrace: stackTrace);
+
+  void error(String message, {Object? error, StackTrace? stackTrace}) =>
+      record(AppLogLevel.error, message,
+          error: error, stackTrace: stackTrace);
+
+  /// Clears the buffer (offered from the diagnostics view so a user can start
+  /// a clean capture before reproducing a problem).
+  void clear() {
+    _entries.clear();
+    notifyListeners();
+  }
+
+  /// Installs framework error hooks so uncaught errors are captured without
+  /// each call site having to remember to log. Chains the previous handlers
+  /// so the default console reporting still runs. Idempotent.
+  ///
+  /// Returns a zone error handler suitable for `runZonedGuarded`, capturing
+  /// asynchronous errors that escape the framework's own reporting.
+  void Function(Object, StackTrace) install() {
+    if (!_installed) {
+      _installed = true;
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = (FlutterErrorDetails details) {
+        record(
+          AppLogLevel.error,
+          _describeFlutterError(details),
+          error: details.exception,
+          stackTrace: details.stack,
+        );
+        previousOnError?.call(details);
+      };
+
+      final previousPlatformOnError = PlatformDispatcher.instance.onError;
+      PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+        record(AppLogLevel.error, 'Uncaught platform error',
+            error: error, stackTrace: stack);
+        return previousPlatformOnError?.call(error, stack) ?? false;
+      };
+    }
+    return (Object error, StackTrace stack) {
+      record(AppLogLevel.error, 'Uncaught error',
+          error: error, stackTrace: stack);
+    };
+  }
+
+  /// Builds the plain-text diagnostics report a user attaches to feedback.
+  /// [now] and [environment] are injectable so the output is deterministic in
+  /// tests.
+  String buildReport({
+    DiagnosticsEnvironment environment = const DiagnosticsEnvironment(),
+    DateTime? now,
+  }) =>
+      buildDiagnosticsReport(
+        entries: entries,
+        environment: environment,
+        now: now,
+      );
+}
+
+/// Runtime facts included at the head of a diagnostics report. Kept as a
+/// value object (rather than read from globals) so reports are reproducible in
+/// tests and the platform label can be overridden.
+@immutable
+class DiagnosticsEnvironment {
+  const DiagnosticsEnvironment({
+    this.appVersion = kAppVersion,
+    this.platform,
+    this.isWeb,
+  });
+
+  /// Captures the current platform/version from Flutter's constants.
+  factory DiagnosticsEnvironment.current() => DiagnosticsEnvironment(
+        platform: kIsWeb ? 'Web' : _platformName(defaultTargetPlatform),
+        isWeb: kIsWeb,
+      );
+
+  final String appVersion;
+  final String? platform;
+  final bool? isWeb;
+
+  String get platformLabel => platform ?? 'unknown';
+}
+
+/// Renders [entries] and [environment] into the report body. Free function so
+/// it can be unit-tested without a Flutter binding.
+String buildDiagnosticsReport({
+  required List<AppLogEntry> entries,
+  DiagnosticsEnvironment environment = const DiagnosticsEnvironment(),
+  DateTime? now,
+}) {
+  final buffer = StringBuffer()
+    ..writeln('DartPDF app diagnostics')
+    ..writeln('App version: ${environment.appVersion}')
+    ..writeln('Platform: ${environment.platformLabel}');
+  if (now != null) {
+    buffer.writeln('Captured: ${_formatTimestamp(now)}');
+  }
+  buffer
+    ..writeln('Log entries: ${entries.length}')
+    ..writeln();
+  if (entries.isEmpty) {
+    buffer.writeln('(no events recorded this session)');
+  } else {
+    for (final entry in entries) {
+      buffer.writeln(entry.format());
+    }
+  }
+  return buffer.toString().trimRight();
+}
+
+String _describeFlutterError(FlutterErrorDetails details) {
+  final context = details.context?.toString();
+  final library = details.library;
+  if (context != null && context.isNotEmpty) {
+    return 'Flutter error ($context)';
+  }
+  if (library != null && library.isNotEmpty) {
+    return 'Flutter error in $library';
+  }
+  return 'Flutter error';
+}
+
+String _platformName(TargetPlatform platform) => switch (platform) {
+      TargetPlatform.android => 'Android',
+      TargetPlatform.iOS => 'iOS',
+      TargetPlatform.macOS => 'macOS',
+      TargetPlatform.windows => 'Windows',
+      TargetPlatform.linux => 'Linux',
+      TargetPlatform.fuchsia => 'Fuchsia',
+    };
+
+String _formatTimestamp(DateTime time) {
+  final t = time.toUtc();
+  String two(int v) => v.toString().padLeft(2, '0');
+  return '${t.year}-${two(t.month)}-${two(t.day)} '
+      '${two(t.hour)}:${two(t.minute)}:${two(t.second)}Z';
+}
+
+String _collapseWhitespace(String value) =>
+    value.replaceAll(RegExp(r'\s+'), ' ').trim();

--- a/packages/dart_pdf_editor/example/lib/feedback.dart
+++ b/packages/dart_pdf_editor/example/lib/feedback.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'error_log.dart';
+
+/// The plain-language GitHub issue form for app feedback. The diagnostics
+/// report is prefilled into the form's `diagnostics` field.
+final Uri kFeedbackFormUrl = Uri.parse(
+    'https://github.com/ben-milanko/dart-pdf/issues/new?template=app_feedback.yml');
+
+/// Browsers and GitHub both cap issue-prefill URLs. Stay comfortably under
+/// the ~8k practical ceiling; the untruncated report is still copied to the
+/// clipboard so nothing is lost.
+const int _maxFeedbackUrlLength = 6000;
+
+/// Builds the GitHub issue URL with the app version and, when [report] is
+/// given, the diagnostics prefilled into the form's `diagnostics` field.
+///
+/// The report is attached tail-first (most recent events are the most useful)
+/// and truncated so the whole URL stays under [maxUrlLength]; a truncation
+/// marker is prepended when that happens.
+Uri buildFeedbackUri(
+  Uri base, {
+  String? report,
+  String version = kAppVersion,
+  int maxUrlLength = _maxFeedbackUrlLength,
+}) {
+  final params = Map<String, String>.from(base.queryParameters)
+    ..['version'] = version;
+  if (report == null || report.isEmpty) {
+    return base.replace(queryParameters: params);
+  }
+
+  // Grow the attached report from the tail until the encoded URL would exceed
+  // the budget, then keep the largest prefix that fits.
+  String withReport(String value) => base
+      .replace(queryParameters: {...params, 'diagnostics': value})
+      .toString();
+
+  var attached = report;
+  if (withReport(attached).length > maxUrlLength) {
+    const marker = '[older entries truncated - full log copied to clipboard]\n';
+    // Binary-search the longest tail that fits under the budget.
+    var lo = 0;
+    var hi = report.length;
+    while (lo < hi) {
+      final mid = (lo + hi + 1) ~/ 2;
+      final tail = marker + report.substring(report.length - mid);
+      if (withReport(tail).length <= maxUrlLength) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    attached = marker + report.substring(report.length - lo);
+  }
+  return base.replace(queryParameters: {...params, 'diagnostics': attached});
+}
+
+/// Shows the feedback dialog: the user reviews the captured diagnostics,
+/// optionally copies them, and opens the GitHub feedback form with the report
+/// (and app version) prefilled.
+///
+/// [onOpen] launches the built URL (injected so the caller owns url_launcher
+/// and error toasts); [onCopied] fires after the report is copied so the host
+/// can toast. [log] defaults to the shared [AppLog].
+Future<void> showFeedbackDialog(
+  BuildContext context, {
+  required Future<void> Function(Uri url) onOpen,
+  VoidCallback? onCopied,
+  AppLog? log,
+}) {
+  final appLog = log ?? AppLog.instance;
+  return showDialog<void>(
+    context: context,
+    builder: (context) => _FeedbackDialog(
+      log: appLog,
+      onOpen: onOpen,
+      onCopied: onCopied,
+    ),
+  );
+}
+
+class _FeedbackDialog extends StatefulWidget {
+  const _FeedbackDialog({
+    required this.log,
+    required this.onOpen,
+    this.onCopied,
+  });
+
+  final AppLog log;
+  final Future<void> Function(Uri url) onOpen;
+  final VoidCallback? onCopied;
+
+  @override
+  State<_FeedbackDialog> createState() => _FeedbackDialogState();
+}
+
+class _FeedbackDialogState extends State<_FeedbackDialog> {
+  bool _includeDiagnostics = true;
+
+  String get _report => widget.log.buildReport(
+        environment: DiagnosticsEnvironment.current(),
+        now: DateTime.now(),
+      );
+
+  Future<void> _copy({bool notify = true}) async {
+    try {
+      await Clipboard.setData(ClipboardData(text: _report));
+      if (notify) widget.onCopied?.call();
+    } catch (_) {
+      // Clipboard access can be denied (locked-down web, headless tests);
+      // it's a convenience, so a failure must not block the feedback flow.
+    }
+  }
+
+  Future<void> _open() async {
+    final url = buildFeedbackUri(
+      kFeedbackFormUrl,
+      report: _includeDiagnostics ? _report : null,
+    );
+    if (_includeDiagnostics) {
+      // Copy too, so the full log is available to paste even when the URL had
+      // to truncate it - best-effort and fire-and-forget (opening is the
+      // action; a slow or denied clipboard must not delay it), no toast.
+      unawaited(_copy(notify: false));
+    }
+    if (mounted) Navigator.of(context).pop();
+    await widget.onOpen(url);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: const Text('Send feedback'),
+      content: SizedBox(
+        width: 520,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'The feedback form opens in your browser. The diagnostics below '
+              'are collected on this device only and are attached to help '
+              'reproduce the problem. Review them first - do not include '
+              'anything you would rather keep private.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            Flexible(
+              child: ListenableBuilder(
+                listenable: widget.log,
+                builder: (context, _) => Container(
+                  constraints: const BoxConstraints(maxHeight: 220),
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(6),
+                    border: Border.all(color: theme.dividerColor),
+                  ),
+                  child: Scrollbar(
+                    child: SingleChildScrollView(
+                      child: SelectableText(
+                        _report,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          fontFamily: 'monospace',
+                          height: 1.35,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 4),
+            CheckboxListTile(
+              value: _includeDiagnostics,
+              onChanged: (value) =>
+                  setState(() => _includeDiagnostics = value ?? true),
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+              dense: true,
+              title: const Text('Attach these diagnostics to the report'),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton.icon(
+          onPressed: widget.log.isEmpty
+              ? null
+              : () {
+                  widget.log.clear();
+                  setState(() {});
+                },
+          icon: const Icon(Icons.delete_outline),
+          label: const Text('Clear log'),
+        ),
+        TextButton.icon(
+          onPressed: _copy,
+          icon: const Icon(Icons.copy_outlined),
+          label: const Text('Copy diagnostics'),
+        ),
+        FilledButton.icon(
+          onPressed: _open,
+          icon: const Icon(Icons.open_in_new),
+          label: const Text('Open feedback form'),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -13,16 +13,14 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'demo_brand_assets.dart';
 import 'demo_document.dart';
+import 'error_log.dart';
+import 'feedback.dart';
 import 'persistent_cache.dart';
 import 'platform_fonts.dart';
 import 'recent_files.dart';
 
 /// The project's source repository, opened from the AppBar links menu.
 final _githubUrl = Uri.parse('https://github.com/ben-milanko/dart-pdf');
-
-/// A plain-language GitHub issue form for app feedback from end users.
-final _feedbackUrl = Uri.parse(
-    'https://github.com/ben-milanko/dart-pdf/issues/new?template=app_feedback.yml');
 
 /// The published Flutter package the example is built on.
 final _pubDevUrl = Uri.parse('https://pub.dev/packages/dart_pdf_editor');
@@ -99,7 +97,12 @@ void main() {
   if (Uri.base.queryParameters['perf'] == '1') {
     PdfPerfLog.enabled = true;
   }
-  runApp(const ViewerApp());
+  // Capture uncaught framework, platform, and async errors into the in-app
+  // log so a user can attach them to feedback (see AppLog / the feedback
+  // dialog). install() also returns the zone handler for the async path.
+  final onZoneError = AppLog.instance.install();
+  AppLog.instance.info('App started (version $kAppVersion)');
+  runZonedGuarded(() => runApp(const ViewerApp()), onZoneError);
 }
 
 class ViewerApp extends StatefulWidget {
@@ -134,8 +137,10 @@ class _ViewerAppState extends State<ViewerApp> {
   Future<void> _loadPlatformFonts() async {
     try {
       pdfPlatformFonts = await loadPlatformFonts();
-    } catch (_) {
+    } catch (e, s) {
       // Font discovery is best-effort; the menu degrades to its other choices.
+      AppLog.instance
+          .warning('Platform font discovery failed', error: e, stackTrace: s);
     }
   }
 
@@ -285,6 +290,16 @@ class _ViewerScreenState extends State<ViewerScreen> {
     }
   }
 
+  /// Opens the feedback dialog: the user reviews the diagnostics captured this
+  /// session and opens the GitHub feedback form with the report prefilled.
+  void _openFeedback() {
+    unawaited(showFeedbackDialog(
+      context,
+      onOpen: _openLink,
+      onCopied: () => _toast('Diagnostics copied to clipboard'),
+    ));
+  }
+
   void _cycleTheme() {
     _prefs.themeMode = switch (_prefs.themeMode) {
       ThemeMode.system => ThemeMode.light,
@@ -424,7 +439,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
         ),
         const PopupMenuDivider(),
         PopupMenuItem(
-          value: () => _openLink(_feedbackUrl),
+          value: _openFeedback,
           child: _appMenuTile(
             icon: Icons.feedback_outlined,
             title: 'Supply feedback…',
@@ -743,7 +758,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
         ),
       );
       unawaited(_recents.record(file.name, bytes));
-    } catch (e) {
+    } catch (e, s) {
+      AppLog.instance
+          .error('Could not open ${file.name}', error: e, stackTrace: s);
       if (!mounted) return;
       _replaceLoadingTab(
         loading,
@@ -780,7 +797,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
         ));
         _activeIndex = _tabs.length - 1;
       });
-    } catch (e) {
+    } catch (e, s) {
+      AppLog.instance
+          .error('Could not open ${file.name}', error: e, stackTrace: s);
       _openError(file.name, 'Could not open ${file.name}\n$e');
     }
   }
@@ -801,7 +820,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
         ),
       );
       unawaited(_recents.record(name, bytes));
-    } catch (e) {
+    } catch (e, s) {
+      AppLog.instance.error('Could not open $path', error: e, stackTrace: s);
       if (!mounted) return;
       _replaceLoadingTab(
         loading,
@@ -841,7 +861,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
         ),
       );
       unawaited(_recents.touch(entry.id));
-    } catch (e) {
+    } catch (e, s) {
+      AppLog.instance
+          .error('Could not reopen ${entry.title}', error: e, stackTrace: s);
       if (!mounted) return;
       _replaceLoadingTab(
         loading,
@@ -894,7 +916,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
           final path = pdfSavePathWithExtension(location.path);
           await file.saveTo(path);
           _toast('Saved to $path');
-        } catch (e) {
+        } catch (e, s) {
+          AppLog.instance.error('Save failed', error: e, stackTrace: s);
           _toast('Save failed: $e');
         }
     }
@@ -932,7 +955,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
         try {
           await file.saveTo(location.path);
           _toast('Saved $name - paste back into the PDF with ⌘V');
-        } catch (e) {
+        } catch (e, s) {
+          AppLog.instance.error('Save failed', error: e, stackTrace: s);
           _toast('Save failed: $e');
         }
     }
@@ -971,7 +995,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
       if (stem.isEmpty) stem = 'page';
       final name = '$stem-p${pageIndex + 1}.${isPng ? 'png' : 'jpg'}';
       await _saveImageBytes(bytes, name, isPng ? 'image/png' : 'image/jpeg');
-    } catch (e) {
+    } catch (e, s) {
+      AppLog.instance.error('Image export failed', error: e, stackTrace: s);
       if (mounted) _toast('Export failed: $e');
     }
   }
@@ -1005,7 +1030,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
         try {
           await file.saveTo(location.path);
           _toast('Saved $name');
-        } catch (e) {
+        } catch (e, s) {
+          AppLog.instance.error('Save failed', error: e, stackTrace: s);
           _toast('Save failed: $e');
         }
     }
@@ -1124,11 +1150,13 @@ class _ViewerScreenState extends State<ViewerScreen> {
       Navigator.of(context, rootNavigator: true).pop(); // dismiss progress
       _openBytes(result, '${tab.title} (OCR)');
       _toast('OCR added $spans text spans - the page text is now selectable');
-    } on VlmOcrException catch (e) {
+    } on VlmOcrException catch (e, s) {
+      AppLog.instance.error('OCR failed: ${e.message}', error: e, stackTrace: s);
       if (!mounted) return;
       Navigator.of(context, rootNavigator: true).pop();
       _toast('OCR failed: ${e.message}');
-    } catch (e) {
+    } catch (e, s) {
+      AppLog.instance.error('OCR failed', error: e, stackTrace: s);
       if (!mounted) return;
       Navigator.of(context, rootNavigator: true).pop();
       _toast('OCR failed: $e');

--- a/packages/dart_pdf_editor/example/test/error_log_test.dart
+++ b/packages/dart_pdf_editor/example/test/error_log_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_viewer_example/error_log.dart';
+import 'package:pdf_viewer_example/feedback.dart';
+
+void main() {
+  group('AppLog', () {
+    test('records events oldest-first and notifies listeners', () {
+      final log = AppLog();
+      var notifications = 0;
+      log.addListener(() => notifications++);
+
+      log.info('one');
+      log.warning('two');
+      log.error('three');
+
+      expect(log.entries.map((e) => e.message), ['one', 'two', 'three']);
+      expect(log.entries.map((e) => e.level),
+          [AppLogLevel.info, AppLogLevel.warning, AppLogLevel.error]);
+      expect(notifications, 3);
+    });
+
+    test('caps at capacity, dropping the oldest events', () {
+      final log = AppLog(capacity: 3);
+      for (var i = 0; i < 5; i++) {
+        log.info('event $i');
+      }
+      expect(log.entries.length, 3);
+      expect(log.entries.map((e) => e.message),
+          ['event 2', 'event 3', 'event 4']);
+    });
+
+    test('clear empties the buffer and notifies', () {
+      final log = AppLog()..info('x');
+      var notified = false;
+      log.addListener(() => notified = true);
+      log.clear();
+      expect(log.isEmpty, isTrue);
+      expect(notified, isTrue);
+    });
+  });
+
+  group('buildDiagnosticsReport', () {
+    test('includes a header and every entry', () {
+      final now = DateTime.utc(2026, 7, 10, 12, 30, 0);
+      final entries = [
+        AppLogEntry(
+          time: DateTime.utc(2026, 7, 10, 12, 0, 0),
+          level: AppLogLevel.info,
+          message: 'App started',
+        ),
+        AppLogEntry(
+          time: DateTime.utc(2026, 7, 10, 12, 15, 0),
+          level: AppLogLevel.error,
+          message: 'Could not open sample.pdf',
+          error: StateError('bad xref'),
+          stackTrace: StackTrace.fromString('#0 frame one\n#1 frame two'),
+        ),
+      ];
+
+      final report = buildDiagnosticsReport(
+        entries: entries,
+        environment: const DiagnosticsEnvironment(
+          appVersion: '9.9.9',
+          platform: 'Web',
+          isWeb: true,
+        ),
+        now: now,
+      );
+
+      expect(report, contains('DartPDF app diagnostics'));
+      expect(report, contains('App version: 9.9.9'));
+      expect(report, contains('Platform: Web'));
+      expect(report, contains('Log entries: 2'));
+      expect(report, contains('App started'));
+      expect(report, contains('ERROR'));
+      expect(report, contains('Could not open sample.pdf'));
+      expect(report, contains('Bad state: bad xref'));
+      expect(report, contains('#0 frame one'));
+    });
+
+    test('describes an empty log', () {
+      final report = buildDiagnosticsReport(entries: const []);
+      expect(report, contains('Log entries: 0'));
+      expect(report, contains('(no events recorded this session)'));
+    });
+
+    test('trims long stack traces', () {
+      final frames =
+          List.generate(40, (i) => '#$i frame').join('\n');
+      final report = buildDiagnosticsReport(entries: [
+        AppLogEntry(
+          time: DateTime.utc(2026, 1, 1),
+          level: AppLogLevel.error,
+          message: 'boom',
+          stackTrace: StackTrace.fromString(frames),
+        ),
+      ]);
+      expect(report, contains('#0 frame'));
+      expect(report, contains('#11 frame'));
+      expect(report, isNot(contains('#12 frame')));
+    });
+  });
+
+  group('buildFeedbackUri', () {
+    final base = Uri.parse(
+        'https://github.com/ben-milanko/dart-pdf/issues/new?template=app_feedback.yml');
+
+    test('prefills version and preserves the template param', () {
+      final uri = buildFeedbackUri(base, version: '1.2.3');
+      expect(uri.queryParameters['template'], 'app_feedback.yml');
+      expect(uri.queryParameters['version'], '1.2.3');
+      expect(uri.queryParameters.containsKey('diagnostics'), isFalse);
+    });
+
+    test('attaches a short report verbatim', () {
+      final uri =
+          buildFeedbackUri(base, version: '1.2.3', report: 'short report');
+      expect(uri.queryParameters['diagnostics'], 'short report');
+    });
+
+    test('truncates a long report to keep the URL under the budget', () {
+      final report = List.generate(2000, (i) => 'line $i').join('\n');
+      final uri = buildFeedbackUri(base, report: report, maxUrlLength: 2000);
+      expect(uri.toString().length, lessThanOrEqualTo(2000));
+      final attached = uri.queryParameters['diagnostics']!;
+      expect(attached, contains('older entries truncated'));
+      // Keeps the tail (most recent events), not the head.
+      expect(attached, contains('line 1999'));
+      expect(attached, isNot(contains('line 0\n')));
+    });
+  });
+}

--- a/packages/dart_pdf_editor/example/test/feedback_dialog_test.dart
+++ b/packages/dart_pdf_editor/example/test/feedback_dialog_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_viewer_example/error_log.dart';
+import 'package:pdf_viewer_example/feedback.dart';
+
+void main() {
+  testWidgets('opens the feedback form with the diagnostics prefilled',
+      (tester) async {
+    final log = AppLog()
+      ..info('App started')
+      ..error('Could not open sample.pdf');
+    Uri? opened;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () => showFeedbackDialog(
+                context,
+                log: log,
+                onOpen: (url) async => opened = url,
+              ),
+              child: const Text('feedback'),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('feedback'));
+    await tester.pumpAndSettle();
+
+    // The captured events are shown for review.
+    expect(find.text('Send feedback'), findsOneWidget);
+    expect(find.textContaining('Could not open sample.pdf'), findsWidgets);
+
+    await tester.tap(find.text('Open feedback form'));
+    await tester.pumpAndSettle();
+
+    expect(opened, isNotNull);
+    expect(opened!.queryParameters['template'], 'app_feedback.yml');
+    expect(opened!.queryParameters['version'], kAppVersion);
+    expect(opened!.queryParameters['diagnostics'],
+        contains('Could not open sample.pdf'));
+  });
+
+  testWidgets('unchecking "Attach" omits the diagnostics', (tester) async {
+    final log = AppLog()..error('secret error');
+    Uri? opened;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: ElevatedButton(
+            onPressed: () => showFeedbackDialog(
+              context,
+              log: log,
+              onOpen: (url) async => opened = url,
+            ),
+            child: const Text('feedback'),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('feedback'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Attach these diagnostics to the report'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Open feedback form'));
+    await tester.pumpAndSettle();
+
+    expect(opened, isNotNull);
+    expect(opened!.queryParameters.containsKey('diagnostics'), isFalse);
+  });
+
+  testWidgets('Copy diagnostics writes the report to the clipboard',
+      (tester) async {
+    final log = AppLog()..info('breadcrumb');
+    String? clipboard;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboard = (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      },
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: ElevatedButton(
+            onPressed: () => showFeedbackDialog(
+              context,
+              log: log,
+              onOpen: (url) async {},
+            ),
+            child: const Text('feedback'),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('feedback'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Copy diagnostics'));
+    await tester.pumpAndSettle();
+
+    expect(clipboard, isNotNull);
+    expect(clipboard, contains('breadcrumb'));
+  });
+}


### PR DESCRIPTION
## Summary

Adds a local, in-app error-logging system to the example DartPDF app and attaches the captured diagnostics to the GitHub feedback flow.

- **`AppLog`** (`example/lib/error_log.dart`) — a capped in-memory ring buffer (default 300) of `AppLogEntry(time, level, message, error?, stackTrace?)`. `install()` chains `FlutterError.onError` and `PlatformDispatcher.onError` (preserving prior handlers) and returns a `runZonedGuarded` handler, so uncaught framework, platform, and async errors are captured automatically. The app also records breadcrumbs at the document-open, save, export, OCR, and (previously silent) font-load surfaces. `buildDiagnosticsReport(...)` renders a plain-text report (app version, platform, time, then each entry with a trimmed stack).
- **Feedback dialog** (`example/lib/feedback.dart`) — "Supply feedback…" now opens a review dialog showing the captured diagnostics, with Copy / Clear / Open actions and an "Attach diagnostics" toggle (default on). `buildFeedbackUri(...)` prefills the app version and a length-bounded, tail-first diagnostics report into the GitHub issue form; the full report is also copied to the clipboard so nothing is lost when the URL must truncate.
- **Nothing is persisted or transmitted on its own** — the log lives for the session and is only surfaced when the user chooses to send feedback.
- **Issue template** — added a `diagnostics` field to `app_feedback.yml` as the prefill target, described as auto-filled and free of document contents.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature

## Validation

- [x] `fvm dart analyze` (clean on the example package)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (example suite; the new `error_log_test.dart` + `feedback_dialog_test.dart` pass — 12/12)

The two new test files pass in full. Eight pre-existing example test failures in `demo_test`/`demo_document_test`/`editing_test` reproduce on the branch base too (verified via `git stash`) and are unrelated to this change.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`. (Change is confined to the example app.)
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output. (No parser/writer changes.)
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `kAppVersion` in `error_log.dart` mirrors the example `pubspec.yaml` version — update both together.
- The clipboard copy on "Open feedback form" is fire-and-forget so a denied/absent clipboard (locked-down web, headless tests) can't block opening the form.
- The diagnostics box uses a `Flexible` + `maxHeight` so the dialog doesn't overflow on short/mobile viewports.
- Session notes: `doc/dev-log/2026-07-10-app-error-logging.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKspd5Bc98qmYBbGrKp4QE)_