### PR TITLE
perf(dart_pdf_editor): flat retained-scene replay for zoom re-raster

### DIFF
--- a/doc/dev-log/2026-07-10-retained-zoom-mainline.md
+++ b/doc/dev-log/2026-07-10-retained-zoom-mainline.md
@@ -1,0 +1,162 @@
+# 2026-07-10 — Retained-scene zoom replay, mainlined (perf/retained-zoom-replay)
+
+Productizes the zoom-retained experiment's headline win for main: on zoom
+settle, `PdfPageView` now replays the page's retained command transcript
+into a fresh **flat** picture at the new ratio instead of re-rasterizing
+the **nested** cached `ui.Picture` (`scale` + `drawPicture` + `toImage`).
+Impeller rasterizes the flat replay several times faster; output is
+byte-identical. No strips, no shaders — this branch is cut from `main`
+and carries only the strips-free pieces of the experiment.
+
+## What landed
+
+- `lib/src/retained_scene.dart` — `PdfRetainedScene` (extracted from the
+  experiment's `strips/strip_scene.dart`, renamed; all strip references
+  gone): `record` (one interpret + one image-decode pass),
+  `fromCommands` (adopts a worker-recorded buffer; decodes via the new
+  public `PdfPageRenderer.collectImageRequests`), synchronous
+  `replay({pixelRatio})` / `replayRegion`, `rasterize`/`rasterizeRegion`
+  with the renderer's exact clamps, scene-owned decoded images
+  (disposed with the scene; replayed pictures hold their own refs).
+  Exported from the main barrel.
+- `lib/src/renderer.dart` — public `preparePageCanvas` (the
+  background + page-transform preamble, so the scene replays under the
+  renderer's exact transform stack) and `collectImageRequests`
+  (previously private).
+- `lib/src/pdf_page_view.dart` — the actual wiring (below).
+- `test/retained_scene_test.dart` — the regression anchor: replay
+  rasters **byte-identical** to `PdfPageRenderer.rasterize` at ratios
+  0.7/1.0/2.4 plus a region at 3.0.
+- `test/zoom_latency_test.dart` — corpus-gated harness (skips cleanly
+  without a corpus): per-zoom-step cost of (a) cached-picture re-raster
+  vs (b) retained replay vs (c) full re-render, plus first-render-delta
+  and retained-footprint reporting.
+
+## Wiring points in pdf_page_view.dart
+
+1. **Kill switch + density ceiling**: `PdfPageView.retainedZoomReplay`
+   (static, default true; false restores the previous behavior
+   everywhere) and `PdfPageView.retainedZoomReplayMaxCommands` (static,
+   default 20 000; pages recording more top-level commands never retain
+   a scene and keep the classic path — see the CAD note below). Both
+   gates live in one `_retainScene(commandCount)` helper; `_renderNow`
+   and `_updateDetail` need no threshold logic of their own because an
+   over-ceiling page simply has no scene.
+2. **State**: `_scene` field alongside `_picture`; `_setScene` disposes
+   the predecessor; `_dropPicture` (content change, epoch bump,
+   dispose) also drops the scene — scenes die with the document
+   revision, so the editing controller's swaps and the slot-recycling
+   machinery see exactly the lifetime the picture already had.
+3. **Scene production** — every interpret already flows through a
+   recorded command buffer, so retention is free:
+   - `_interpretPicture` now returns `(picture, scene?)`; the worker
+     branch adopts the worker's buffer via
+     `PdfRetainedScene.fromCommands`, the local branch records via
+     `PdfRetainedScene.record`. In both, the cached picture IS
+     `scene.replay(pixelRatio: 1)` — pair consistency by construction.
+     `_renderNow` adopts the scene only after the superseded check
+     (same discipline as the picture).
+   - `_paintVectorFirst`'s image-free fast path (the complete page)
+     also retains the scene. The image-skipped partial buffer is NOT
+     retained (it isn't the page).
+4. **Zoom re-raster** (`_renderNow`, stale-ratio branch): when a scene
+   is held, `scene.rasterize(pixelRatio: effective)` replaces
+   `PdfPageRenderer.rasterize(picture, ...)`. The `_rasteredRatio`
+   guard, scheduler pacing/coalescing, `_superseded` checks, preview
+   cache feeding, and progressive vector-first semantics are untouched.
+5. **Deep-zoom detail patch** (`_updateDetail` local fallback):
+   `scene.rasterizeRegion(region, pixelRatio: ratio)` replaces
+   `rasterizeRegion(picture, ...)`. The worker detail path is
+   deliberately unchanged — it re-records with region-capped image
+   decodes (sharper images at deep zoom), a quality feature replay
+   can't reproduce from base-resolution scene images.
+6. `/Rotate` is baked into the scene's plan (`preparePageCanvas` +
+   `plan.pageSize`); rotation changes drop the picture AND scene via
+   the existing `nonContentVisualChanged` branch, as do pageColor /
+   showAnnotations changes (annotations are recorded into the scene).
+
+## Numbers (Impeller, `--enable-impeller`, mean ms/step, 3 passes × zoom [1.0, 1.5, 2.4, 1.2, 3.0], 2382×1684 fit)
+
+before = (a) cached-picture re-raster (the old path), after = (b)
+retained replay (the new path); (c) full re-render for reference.
+Totals include the harness's toByteData readback; "app" = build +
+toImage (the readback is a harness artifact — the viewer keeps the
+texture on the GPU — but on Impeller `toImage` can defer raster work
+into the readback, so both views are shown).
+
+| page | before app | after app | before total | after total | (c) total |
+|---|---:|---:|---:|---:|---:|
+| CTO report #0 (office, images) | 44.9 | **15.8** (0.35×) | 499.4 | 430.1 | 425.8 |
+| Invoice #0 (office, text) | 6.9 | 7.7 (parity) | 96.2 | 94.4 | 94.9 |
+| ly9-far-cad #4 (99k commands) | 65.1 | 123.6 | 1409.9 | 1425.0 | 1837.4 |
+
+(Software backend, from the experiment sessions: before ≈ after within
+noise on every page — the toImage software raster dominates both — so
+the swap is neutral there.)
+
+- Office/image pages are the win case: the nested-picture re-raster
+  penalty under Impeller (structural, reproduced across four runs at
+  1.9×–6.5×) disappears. Text pages already at the raster floor are
+  unchanged.
+- **CAD density ceiling** (`PdfPageView.retainedZoomReplayMaxCommands`,
+  default 20 000): replaying 99k commands costs ~65 ms on the UI thread
+  per zoom settle, where the old path's `drawPicture` wrap was ~3 ms
+  (the raster then lands off the UI thread / deferred) - totals are a
+  wash, but the UI thread isn't. Pages recording more top-level
+  commands than the ceiling do **not retain a scene at all** and keep
+  the classic cached-picture zoom path: not-retaining (rather than
+  retaining-but-not-replaying) also skips the command buffer's ~31 MB
+  on exactly the pages where replay is never used. Office pages record
+  a few hundred commands; at 20k the worst-case retained replay is
+  ~15 ms, about one frame. The final Impeller run confirms the routing:
+  report/invoice → `viewerPath=b-retained` (rows unchanged), ly9-far-cad
+  #4 (98 936 commands) → `viewerPath=a-current`, i.e. its zoom row is
+  the "before" row again (64.7 ms app-relevant / 1370.6 total).
+
+## First-render cost delta
+
+None by construction: the local path already interpreted through
+`renderPictureRecordedWithPlan` (record → decode → replay); the scene
+path performs the identical steps and simply keeps the buffer + images
+instead of discarding them. Measured (Impeller run):
+record+decode+replay1x vs interpret = -62.6 ms (report), -19.9
+(invoice), -83.4 (CAD) — negative only because the interpret sample
+runs first and warms the image cache; the honest statement is ~0.
+
+## Memory (retained per live page, alongside the existing raster + picture)
+
+Rough Dart-heap estimate (object headers + boxed doubles; harness
+`_sceneFootprint`):
+
+- CTO report: 542 commands / 2.0k segments → **~124 KB**
+- Invoice: 545 commands / 0.4k segments / 628 glyphs → **~72 KB**
+- ly9-far-cad #4: 98.9k commands / 540k segments / 33.6k glyphs →
+  **~31 MB**
+
+Decoded images add no new memory: the scene's map holds clones of
+`PdfImageCache` masters the render already kept. The engine-side
+picture also still exists (unchanged from before). So the delta is the
+command buffer itself: negligible for office pages — and the CAD-scale
+buffer is never retained, because such pages sit above the
+`retainedZoomReplayMaxCommands` ceiling and keep the classic path
+(see above). Retained memory in practice is therefore bounded by
+ceiling × ~56 B/command plus path segments, well under a MB/page for
+anything that actually replays.
+
+## Verification
+
+- `retained_scene_test.dart`: byte-identity full-page ×3 ratios +
+  region — PASS.
+- `pdf_page_view_test.dart`: new widget test pins the over-ceiling
+  fallback (`retainedZoomReplayMaxCommands = 0` forces every page onto
+  the cached-picture path; zoom re-rasters still land at the right
+  geometry) — PASS.
+- Full `dart_pdf_editor` suite under the new default (includes every
+  `editing_*` widget test — they pump `PdfViewer`/`PdfPageView` — and
+  `ghent_render_test` against unchanged checked-in baselines):
+  **1285 passed**, 24 env-gated skips.
+- `corpus_render_test` over `/Users/ben/repos/dart-pdf/corpus` (~50
+  real-world files): PASS (renders to a scratch dir).
+- `render_smoke_test` on INVOICE-1000664832 p0, ly9-far-cad p4,
+  Flutter_CTO_Report p0: PASS.
+- `fvm dart analyze`: clean.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -53,6 +53,7 @@ export 'src/raster_cache.dart';
 export 'src/render_scheduler.dart';
 export 'src/render_worker.dart';
 export 'src/renderer.dart';
+export 'src/retained_scene.dart';
 export 'src/search_panel.dart';
 export 'src/scrollbar.dart';
 export 'src/theme.dart';

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -12,11 +12,16 @@ import 'preview_cache.dart';
 import 'render_scheduler.dart';
 import 'render_worker.dart';
 import 'renderer.dart';
+import 'retained_scene.dart';
 
 /// Displays a single PDF page, rendered natively in Dart.
 ///
-/// The page is interpreted once into a [ui.Picture]; changing [scale] only
-/// re-rasterizes that cached picture, so zoom-driven re-renders are cheap.
+/// The page is interpreted once into a [ui.Picture] and, by default, its
+/// command transcript is retained as a [PdfRetainedScene]; changing [scale]
+/// replays that scene into a fresh flat picture at the new resolution -
+/// no re-interpretation, no image re-decoding, and no nested-picture
+/// re-raster (which Impeller rasterizes several times slower than a flat
+/// replay of the same draws).
 /// Past the full-page raster caps, a detail patch covering the visible
 /// part of the page (inflated for panning headroom) renders at full
 /// resolution on top of the capped base - single patch, not a tile grid,
@@ -152,12 +157,43 @@ class PdfPageView extends StatefulWidget {
   /// patch can follow the viewport without the viewer knowing about it.
   final int settleGeneration;
 
+  /// Kill switch for the retained-scene zoom replay. When true (the
+  /// default) the page's recorded command buffer and decoded images are
+  /// retained alongside the cached picture, and zoom re-rasters replay them
+  /// into a flat picture at the new ratio - byte-identical output
+  /// (retained_scene_test.dart), several times faster under Impeller. Set
+  /// false to restore the previous behavior (re-rasterize the cached
+  /// [ui.Picture]) if a regression is ever suspected in the field.
+  static bool retainedZoomReplay = true;
+
+  /// Command-count ceiling above which a page does NOT retain its scene and
+  /// keeps the classic cached-picture zoom path.
+  ///
+  /// Replay cost is linear in the command count and runs on the UI thread
+  /// (~0.7 µs/command measured), so a dense CAD sheet - the corpus stress
+  /// case records ~99k commands - would pay ~65 ms of UI-thread replay per
+  /// zoom settle where the nested-picture path pays ~3 ms and ships the
+  /// raster off-thread. Not retaining (rather than retaining-but-not-
+  /// replaying) also skips the command buffer's memory (~31 MB for that
+  /// sheet) on exactly the pages where replay is never used. Office pages
+  /// record a few hundred commands; at the 20k default a worst-case
+  /// retained replay costs about one frame.
+  static int retainedZoomReplayMaxCommands = 20000;
+
   @override
   State<PdfPageView> createState() => _PdfPageViewState();
 }
 
 class _PdfPageViewState extends State<PdfPageView> {
   Future<ui.Picture>? _picture;
+
+  /// The page retained as a replayable scene (commands + decoded images),
+  /// produced by the same interpret that yielded [_picture]. Zoom re-rasters
+  /// replay it into a flat picture at the new ratio instead of re-reading
+  /// the nested cached picture. Null on fallback paths (then the classic
+  /// [_picture] re-raster runs) and when [PdfPageView.retainedZoomReplay]
+  /// is off. Lives and dies with [_picture] (see [_dropPicture]).
+  PdfRetainedScene? _scene;
   ui.Image? _image;
   int _renderGeneration = 0;
   double? _pixelRatio;
@@ -361,7 +397,16 @@ class _PdfPageViewState extends State<PdfPageView> {
   void _dropPicture() {
     _picture?.then((picture) => picture.dispose());
     _picture = null;
+    _setScene(null); // the scene transcribes the same content as the picture
     _rasteredRatio = null; // the next picture must re-raster, not be skipped
+  }
+
+  /// Adopts [scene] as the page's retained scene, disposing the previous
+  /// one. Outstanding pictures replayed from the old scene keep painting
+  /// (they hold their own image refs); only new replays need the new scene.
+  void _setScene(PdfRetainedScene? scene) {
+    _scene?.dispose();
+    _scene = scene;
   }
 
   void _dropDetail() {
@@ -441,7 +486,12 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// records the page on a background isolate and replays the returned
   /// command buffer here (cheap); image-bearing pages come back null and
   /// fall through to the local recorded render.
-  Future<ui.Picture?> _interpretPicture() async {
+  ///
+  /// Both paths go through a recorded command buffer, so alongside the
+  /// picture they also return the [PdfRetainedScene] built from that same
+  /// buffer (null when [PdfPageView.retainedZoomReplay] is off) - the caller
+  /// adopts it once the render is known not to be superseded.
+  Future<(ui.Picture, PdfRetainedScene?)?> _interpretPicture() async {
     final pageIndex = widget.previewIndex;
     final worker = widget.renderWorker;
     if (worker != null && worker.isActive) {
@@ -461,22 +511,64 @@ class _PdfPageViewState extends State<PdfPageView> {
       // what the worker exists to avoid. Note we DON'T gate on the render
       // generation here: a newer same-page render (e.g. a zoom mid-interpret)
       // reuses this very future, so the picture must still be produced for it.
-      if (_abandoned(pageIndex)) return _emptyPicture();
+      if (_abandoned(pageIndex)) return (_emptyPicture(), null);
       if (commands != null) {
         if (_renderPaused) return null;
         _lastInterpretPath = 'worker';
         _logImageStats(pageIndex, commands);
-        return PdfPageRenderer.pictureFromCommandsWithPlan(
-            widget.page, commands, _renderPlan);
+        return _replayableFromCommands(commands);
       }
     }
-    if (_abandoned(pageIndex)) return _emptyPicture();
+    if (_abandoned(pageIndex)) return (_emptyPicture(), null);
     if (_renderPaused) return null;
     // The worker may be active yet decline this page (it returns null), in
     // which case the interpret runs here - the log must say so, not 'worker'.
     _lastInterpretPath = 'recorded';
-    return PdfPageRenderer.renderPictureRecordedWithPlan(
-        widget.page, _renderPlan);
+    if (!PdfPageView.retainedZoomReplay) {
+      return (
+        await PdfPageRenderer.renderPictureRecordedWithPlan(
+            widget.page, _renderPlan),
+        null,
+      );
+    }
+    // Same record + decode renderPictureRecordedWithPlan runs internally,
+    // but the command buffer and decoded images are kept for zoom replays
+    // instead of being discarded after the 1:1 replay below.
+    final scene = await PdfRetainedScene.record(widget.page, plan: _renderPlan);
+    if (!_retainScene(scene.commands.length)) {
+      // Too dense to replay per zoom settle: take the 1:1 picture (it holds
+      // its own image refs) and drop the scene - the classic cached-picture
+      // path serves this page's zooms.
+      final picture = scene.replay(pixelRatio: 1);
+      scene.dispose();
+      return (picture, null);
+    }
+    return (scene.replay(pixelRatio: 1), scene);
+  }
+
+  /// Whether a page recorded as [commandCount] top-level commands should
+  /// retain its scene - the [PdfPageView.retainedZoomReplay] switch plus the
+  /// [PdfPageView.retainedZoomReplayMaxCommands] density ceiling.
+  static bool _retainScene(int commandCount) =>
+      PdfPageView.retainedZoomReplay &&
+      commandCount <= PdfPageView.retainedZoomReplayMaxCommands;
+
+  /// Builds the picture (and, unless [PdfPageView.retainedZoomReplay] is
+  /// off, the retained scene) from a recorded command buffer. One decode
+  /// pass serves both, and the picture IS the scene's own 1:1 replay, so
+  /// the pair can never disagree.
+  Future<(ui.Picture, PdfRetainedScene?)> _replayableFromCommands(
+      List<PdfRenderCommand> commands) async {
+    if (!_retainScene(commands.length)) {
+      return (
+        await PdfPageRenderer.pictureFromCommandsWithPlan(
+            widget.page, commands, _renderPlan),
+        null,
+      );
+    }
+    final scene = await PdfRetainedScene.fromCommands(widget.page, commands,
+        plan: _renderPlan);
+    return (scene.replay(pixelRatio: 1), scene);
   }
 
   /// Progressive rendering's fast first pass: records the page WITHOUT decoding
@@ -502,11 +594,24 @@ class _PdfPageViewState extends State<PdfPageView> {
 
     if (!PdfPageRenderer.hasImageDraws(commands)) {
       // Image-free page: this fast buffer already is the complete page. Cache
-      // it so the full pass reuses it instead of recording a second time; the
-      // normal raster path below paints it.
+      // it (and its retained scene) so the full pass reuses it instead of
+      // recording a second time; the normal raster path below paints it.
       _lastInterpretPath = 'worker';
-      _picture = PdfPageRenderer.pictureFromCommandsWithPlan(
-          widget.page, commands, _renderPlan);
+      if (_retainScene(commands.length)) {
+        // No images to decode, so this completes synchronously in practice.
+        final scene = await PdfRetainedScene.fromCommands(
+            widget.page, commands,
+            plan: _renderPlan);
+        if (_superseded(generation, pageIndex)) {
+          scene.dispose();
+          return;
+        }
+        _setScene(scene);
+        _picture = Future.value(scene.replay(pixelRatio: 1));
+      } else {
+        _picture = PdfPageRenderer.pictureFromCommandsWithPlan(
+            widget.page, commands, _renderPlan);
+      }
       return;
     }
 
@@ -609,12 +714,15 @@ class _PdfPageViewState extends State<PdfPageView> {
         if (!_superseded(generation, pageIndex)) _render();
         return;
       }
+      final (interpretedPicture, interpretedScene) = interpreted;
       if (_superseded(generation, pageIndex)) {
-        interpreted.dispose();
+        interpretedPicture.dispose();
+        interpretedScene?.dispose();
         return;
       }
-      _picture = Future.value(interpreted);
-      picture = interpreted;
+      _picture = Future.value(interpretedPicture);
+      if (interpretedScene != null) _setScene(interpretedScene);
+      picture = interpretedPicture;
     }
     sw.stop();
     // Bail before logging when superseded - an abandoned interpret (page
@@ -641,8 +749,15 @@ class _PdfPageViewState extends State<PdfPageView> {
         _render();
         return;
       }
-      final image = await PdfPageRenderer.rasterize(
-          picture, _renderPlan.pageSize(widget.page), effective);
+      // Replay the retained scene into a flat picture at the new ratio when
+      // one is held - Impeller rasterizes that several times faster than the
+      // nested drawPicture re-raster, with byte-identical output. Fallback
+      // paths (no scene, or the kill switch) re-raster the cached picture.
+      final scene = PdfPageView.retainedZoomReplay ? _scene : null;
+      final image = scene != null
+          ? await scene.rasterize(pixelRatio: effective)
+          : await PdfPageRenderer.rasterize(
+              picture, _renderPlan.pageSize(widget.page), effective);
       if (_superseded(generation, pageIndex)) {
         image.dispose();
         return;
@@ -764,7 +879,12 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (!mounted || generation != _detailGeneration || _renderPaused) {
       return false;
     }
-    final image = await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
+    // Same replay-over-nested-raster swap as the full-page path: the deep-
+    // zoom patch replays only [region] from the retained scene when held.
+    final scene = PdfPageView.retainedZoomReplay ? _scene : null;
+    final image = scene != null
+        ? await scene.rasterizeRegion(region, pixelRatio: ratio)
+        : await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
     if (!mounted || generation != _detailGeneration || _renderPaused) {
       image.dispose();
       return false;

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -231,7 +231,7 @@ class PdfPageRenderer {
       PdfPage page, List<PdfRenderCommand> commands, PdfPageRenderPlan plan,
       {bool includeImages = true}) async {
     final requests = <PdfImageRequest>[];
-    if (includeImages) _collectImageRequests(commands, requests);
+    if (includeImages) collectImageRequests(commands, requests);
     final images = requests.isEmpty
         ? const <Object, ui.Image>{}
         : await decodeImages(page.document.cos, requests,
@@ -259,7 +259,7 @@ class PdfPageRenderer {
   static (int count, int pixels) decodedImageStats(
       List<PdfRenderCommand> commands) {
     final requests = <PdfImageRequest>[];
-    _collectImageRequests(commands, requests);
+    collectImageRequests(commands, requests);
     var count = 0;
     var pixels = 0;
     for (final request in requests) {
@@ -277,20 +277,20 @@ class PdfPageRenderer {
   /// to decide whether a slower full (image-decoding) pass needs to follow it.
   static bool hasImageDraws(List<PdfRenderCommand> commands) {
     final requests = <PdfImageRequest>[];
-    _collectImageRequests(commands, requests);
+    collectImageRequests(commands, requests);
     return requests.isNotEmpty;
   }
 
   /// Gathers every image draw request in [commands], descending into soft-mask
   /// groups (whose own commands can draw images), in replay order.
-  static void _collectImageRequests(
+  static void collectImageRequests(
       List<PdfRenderCommand> commands, List<PdfImageRequest> out) {
     for (final command in commands) {
       switch (command) {
         case PdfDrawImageCommand(:final request):
           out.add(request);
         case PdfEndSoftMaskedCommand(:final maskCommands):
-          _collectImageRequests(maskCommands, out);
+          collectImageRequests(maskCommands, out);
         default:
           break;
       }
@@ -416,6 +416,19 @@ class PdfPageRenderer {
     } finally {
       scaled.dispose();
     }
+  }
+
+  /// Paints the paper background and sets [canvas] up in PDF user space for
+  /// [page] under [plan] - the shared preamble every replay target runs
+  /// before feeding interpreter output (or a recorded command buffer) to a
+  /// painting device. Public so alternative replay paths ([PdfRetainedScene])
+  /// reuse the exact transform stack instead of duplicating it.
+  static void preparePageCanvas(
+      Canvas canvas, PdfPage page, PdfPageRenderPlan plan) {
+    final size = plan.pageSize(page);
+    _paintBackground(canvas, size, plan.pageColor);
+    _applyPageTransform(canvas, page, size, page.cropBox,
+        rotation: plan.rotation);
   }
 
   /// Rasterizes only [region] (in page points, y-down raster space) of a

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -1,0 +1,174 @@
+/// Record a page once, replay it at any scale without re-interpreting the
+/// content stream or re-decoding its images.
+///
+/// The classic zoom path caches a [ui.Picture] and re-rasterizes it on every
+/// settle ([PdfPageRenderer.rasterize] - a `drawPicture` + `toImage`). A
+/// nested `drawPicture` re-raster is measurably slower under Impeller than
+/// rasterizing a freshly recorded flat picture of the same draws (~4-6x on
+/// image-heavy pages), and the cached picture is a black box that cannot be
+/// re-fed through a painting device. [PdfRetainedScene] keeps the page one
+/// level higher - as the interpreter's own [PdfRenderCommand] transcript plus
+/// the decoded [ui.Image]s it needs - so a zoom rebuilds a flat picture at
+/// the new scale from retained data alone. Nothing is parsed and no codec
+/// runs after [record] returns.
+library;
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/painting.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'canvas_device.dart';
+import 'image_decoder.dart';
+import 'renderer.dart';
+
+/// A page retained as a replayable scene: the recorded interpreter command
+/// buffer plus its decoded images, both produced exactly once in [record].
+///
+/// [replay] is synchronous - it only re-issues canvas calls - which is the
+/// point: the interpret (content-stream parse + walk) and the image decodes,
+/// the two costs a zoom must never pay again, happened up front. The scene
+/// owns its decoded images; dispose it with [dispose] when the page leaves
+/// the cache window (outstanding pictures keep painting - `ui.Image.dispose`
+/// on a picture-referenced image is safe, the picture holds its own ref).
+class PdfRetainedScene {
+  PdfRetainedScene._(this.page, this.plan, this.commands, this._images);
+
+  /// The page this scene replays. Must stay open (the scene borrows nothing
+  /// from it after [record], but callers naturally keep both together).
+  final PdfPage page;
+
+  /// The display inputs the scene was recorded under (paper color,
+  /// annotations, rotation). A different plan needs a new recording -
+  /// annotations are baked into [commands].
+  final PdfPageRenderPlan plan;
+
+  /// The interpreter's transcript of the page, in paint order.
+  final List<PdfRenderCommand> commands;
+
+  /// Decoded images keyed by [pdfImageKey], owned by this scene.
+  final Map<Object, ui.Image> _images;
+
+  bool _disposed = false;
+
+  /// Page size in points after the plan's rotation - the raster size at
+  /// pixelRatio 1.
+  Size get pageSize => plan.pageSize(page);
+
+  /// Interprets [page] once into a retained scene: one recording walk (which
+  /// also discovers every image the page draws, including inside soft-mask
+  /// groups) followed by one decode pass. This is the only step that touches
+  /// the content stream or an image codec.
+  ///
+  /// Decodes share [PdfImageCache.instance] like every other render path, so
+  /// recording a page the viewer already showed is decode-free.
+  static Future<PdfRetainedScene> record(
+    PdfPage page, {
+    PdfPageRenderPlan plan = const PdfPageRenderPlan(),
+    bool Function(PdfAnnotation)? skipAnnotation,
+  }) async {
+    final cos = page.document.cos;
+    final pageOps = ContentStreamParser.parse(page.contentBytes());
+    final recorder = RecordingPdfDevice();
+    final recording = PdfInterpreter(cos: cos, device: recorder)
+      ..drawPageOperations(page, pageOps);
+    if (plan.annotations) recording.drawAnnotations(page, skip: skipAnnotation);
+    final images = await decodeImages(cos, recorder.imageRequests,
+        cache: PdfImageCache.instance);
+    return PdfRetainedScene._(page, plan, recorder.commands, images);
+  }
+
+  /// Builds a scene from an already-recorded [commands] buffer (e.g. one a
+  /// [PdfRenderWorker] shipped back), decoding its images once. The buffer
+  /// must have been recorded for [page] under [plan].
+  static Future<PdfRetainedScene> fromCommands(
+    PdfPage page,
+    List<PdfRenderCommand> commands, {
+    PdfPageRenderPlan plan = const PdfPageRenderPlan(),
+  }) async {
+    final requests = <PdfImageRequest>[];
+    PdfPageRenderer.collectImageRequests(commands, requests);
+    final images = await decodeImages(page.document.cos, requests,
+        cache: PdfImageCache.instance);
+    return PdfRetainedScene._(page, plan, commands, images);
+  }
+
+  /// Replays the retained commands into a fresh picture with [pixelRatio]
+  /// baked into the canvas transform, so `picture.toImage(width * ratio,
+  /// height * ratio)` rasterizes it 1:1. Synchronous: no interpretation, no
+  /// decoding - only canvas calls.
+  ///
+  /// Unlike re-rasterizing a cached picture, the replay re-issues every draw
+  /// into a flat picture at the new transform - which Impeller rasterizes
+  /// significantly faster than a nested `drawPicture` at a new scale. The
+  /// output is pixel-identical to the cached-picture path (asserted
+  /// byte-for-byte in retained_scene_test.dart).
+  ui.Picture replay({required double pixelRatio}) {
+    assert(!_disposed, 'replay after dispose');
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)..scale(pixelRatio);
+    _replayOnto(canvas);
+    return recorder.endRecording();
+  }
+
+  /// Region variant of [replay]: only [region] (page points, y-down raster
+  /// space - the same space [PdfPageRenderer.rasterizeRegion] takes) lands at
+  /// the picture origin, at [pixelRatio]. The deep-zoom detail patch replays
+  /// through this without re-interpreting.
+  ui.Picture replayRegion(Rect region, {required double pixelRatio}) {
+    assert(!_disposed, 'replay after dispose');
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)
+      ..scale(pixelRatio)
+      ..translate(-region.left, -region.top);
+    _replayOnto(canvas);
+    return recorder.endRecording();
+  }
+
+  /// Convenience: [replay] + `toImage` at the exact raster size, clamped to
+  /// the engine's texture limit like [PdfPageRenderer.rasterize].
+  Future<ui.Image> rasterize({required double pixelRatio}) async {
+    final picture = replay(pixelRatio: pixelRatio);
+    try {
+      final size = pageSize;
+      return await picture.toImage(
+        (size.width * pixelRatio).ceil().clamp(1, 1 << 14),
+        (size.height * pixelRatio).ceil().clamp(1, 1 << 14),
+      );
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  /// Convenience: [replayRegion] + `toImage`, mirror of
+  /// [PdfPageRenderer.rasterizeRegion].
+  Future<ui.Image> rasterizeRegion(Rect region,
+      {required double pixelRatio}) async {
+    final picture = replayRegion(region, pixelRatio: pixelRatio);
+    try {
+      return await picture.toImage(
+        (region.width * pixelRatio).ceil().clamp(1, 1 << 14),
+        (region.height * pixelRatio).ceil().clamp(1, 1 << 14),
+      );
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  void _replayOnto(Canvas canvas) {
+    PdfPageRenderer.preparePageCanvas(canvas, page, plan);
+    replayCommands(commands, CanvasPdfDevice(canvas, images: _images));
+  }
+
+  /// Releases the scene's decoded images. Pictures already returned by
+  /// [replay] keep painting (they hold their own image refs); further
+  /// replays are an error.
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    for (final image in _images.values) {
+      image.dispose();
+    }
+  }
+}

--- a/packages/dart_pdf_editor/test/pdf_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_page_view_test.dart
@@ -40,6 +40,37 @@ void main() {
     expect(zoomed.width, 612 * 3);
   });
 
+  testWidgets(
+      'pages denser than retainedZoomReplayMaxCommands zoom via the '
+      'cached-picture fallback', (tester) async {
+    // Force every page over the density ceiling: no scene is retained and
+    // the zoom re-raster must take the classic nested-picture path (the
+    // same code retainedZoomReplay=false uses). Same assertions as the
+    // retained-path test above - the two paths are byte-identical, so only
+    // the raster geometry is observable.
+    PdfPageView.retainedZoomReplayMaxCommands = 0;
+    addTearDown(() => PdfPageView.retainedZoomReplayMaxCommands = 20000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final doc = PdfDocument.open(buildClassicPdf());
+    final page = doc.page(0);
+    Widget at(double scale) => Center(
+        child:
+            SizedBox(width: 612, child: PdfPageView(page: page, scale: scale)));
+
+    await tester.pumpWidget(at(1));
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    final base = tester.widget<RawImage>(find.byType(RawImage)).image!;
+    expect(base.width, 612);
+
+    await tester.pumpWidget(at(3));
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    final zoomed = tester.widget<RawImage>(find.byType(RawImage)).image!;
+    expect(zoomed.width, 612 * 3);
+  });
+
   testWidgets('raster resolution follows the on-screen width', (tester) async {
     // Regression: rasters were sized from the page's nominal point size,
     // so a page stretched across a wide window (or a big external

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -1,0 +1,71 @@
+// PdfRetainedScene correctness: a replayed scene must rasterize
+// byte-identically to the shipping cached-picture zoom path at every scale -
+// same commands, same decoded images, same canvas transform stack, so any
+// divergence is a bug in the scene's plumbing.
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+Future<ByteData> _bytes(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!;
+
+void main() {
+  testWidgets('retained-scene replay matches the cached-picture raster',
+      (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(buildClassicPdf());
+      final page = doc.page(0);
+      const plan = PdfPageRenderPlan();
+      final size = plan.pageSize(page);
+
+      final picture =
+          await PdfPageRenderer.renderPictureRecordedWithPlan(page, plan);
+      final scene = await PdfRetainedScene.record(page, plan: plan);
+
+      for (final ratio in [0.7, 1.0, 2.4]) {
+        final current = await PdfPageRenderer.rasterize(picture, size, ratio);
+        final retained = await scene.rasterize(pixelRatio: ratio);
+        expect(retained.width, current.width, reason: 'ratio $ratio');
+        expect(retained.height, current.height, reason: 'ratio $ratio');
+        final a = await _bytes(current);
+        final b = await _bytes(retained);
+        expect(a.buffer.asUint8List(), b.buffer.asUint8List(),
+            reason: 'raster mismatch at ratio $ratio');
+        current.dispose();
+        retained.dispose();
+      }
+
+      // Region replay mirrors rasterizeRegion.
+      final region = Rect.fromLTWH(
+          size.width / 4, size.height / 4, size.width / 2, size.height / 2);
+      final currentRegion =
+          await PdfPageRenderer.rasterizeRegion(picture, region, 3.0);
+      final retainedRegion =
+          await scene.rasterizeRegion(region, pixelRatio: 3.0);
+      expect(retainedRegion.width, currentRegion.width);
+      expect(retainedRegion.height, currentRegion.height);
+      final a = await _bytes(currentRegion);
+      final b = await _bytes(retainedRegion);
+      expect(a.buffer.asUint8List(), b.buffer.asUint8List(),
+          reason: 'region raster mismatch');
+      currentRegion.dispose();
+      retainedRegion.dispose();
+
+      // Replay is synchronous and reusable: two replays from one recording.
+      final p1 = scene.replay(pixelRatio: 1.0);
+      final p2 = scene.replay(pixelRatio: 2.0);
+      expect(scene.commands, isNotEmpty);
+      p1.dispose();
+      p2.dispose();
+
+      scene.dispose();
+      picture.dispose();
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/zoom_latency_test.dart
+++ b/packages/dart_pdf_editor/test/zoom_latency_test.dart
@@ -1,0 +1,345 @@
+// Zoom-settle latency harness (Track C, retained-scene zoom experiment).
+//
+// Measures the per-step cost of re-rendering a page at a new zoom level for
+// three paths, at a scale-to-fit baseline for a ~2382x1684 target device:
+//
+//   (a) current   - the shipping pdf_page_view path: a cached ui.Picture is
+//                   re-rasterized via PdfPageRenderer.rasterize (drawPicture
+//                   at the new ratio + toImage).
+//   (b) retained  - PdfRetainedScene.replay: the recorded command buffer is
+//                   re-issued through CanvasPdfDevice at the new ratio (no
+//                   re-interpret, no re-decode), then toImage.
+//   (c) full      - reference: full re-render (re-interpret + decode via the
+//                   warm PdfImageCache + paint) then toImage.
+//
+// Each timed step splits into build (picture production), raster (toImage)
+// and readback (toByteData(rawRgba), forcing full realization so GPU-backed
+// backends can't defer the raster past the clock). Run both ways:
+//
+//   cd packages/dart_pdf_editor
+//   ZOOM_CORPUS_DIR=/Users/ben/repos/dart-pdf/corpus \
+//     fvm flutter test test/zoom_latency_test.dart
+//   ZOOM_CORPUS_DIR=/Users/ben/repos/dart-pdf/corpus \
+//     fvm flutter test --enable-impeller test/zoom_latency_test.dart
+//
+// Skips cleanly when the corpus directory is absent (it is git-ignored and
+// only exists in the main checkout). Override the page set with
+// ZOOM_LATENCY_FILES (comma-separated, relative to the corpus dir or
+// absolute) and ZOOM_LATENCY_PAGE (page index, default 0); passes with
+// ZOOM_LATENCY_PASSES (default 3); label the backend column with
+// ZOOM_BACKEND (e.g. "impeller") since the flag is invisible from inside.
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+/// The zoom sequence a settle-by-settle pinch session produces.
+const zoomSequence = [1.0, 1.5, 2.4, 1.2, 3.0];
+
+/// Target device size the page is scale-to-fit into at zoom 1.
+const targetWidth = 2382.0;
+const targetHeight = 1684.0;
+
+// pdf_page_view's full-page raster caps, applied identically to every path
+// so the numbers reflect what the viewer would actually rasterize.
+const _maxPixels = 1 << 24;
+const _maxDimension = 8192.0;
+
+const _defaultFiles = [
+  'Flutter_CTO_Report_2024_by_LeanCode.pdf', // office: report, text + images
+  'INVOICE-1000664832.pdf', // office: invoice, text-heavy
+  // CAD: the known dense-vector stress case; page 4 is its heaviest sheet
+  // (~677k content operators - page 0 is a light title sheet).
+  'ly9-far-cad.pdf#4',
+];
+
+class _Sample {
+  double buildMs = 0;
+  double rasterMs = 0;
+  double readbackMs = 0;
+  int n = 0;
+
+  void add(double build, double raster, double readback) {
+    buildMs += build;
+    rasterMs += raster;
+    readbackMs += readback;
+    n++;
+  }
+
+  double get meanBuild => n == 0 ? 0 : buildMs / n;
+  double get meanRaster => n == 0 ? 0 : rasterMs / n;
+  double get meanReadback => n == 0 ? 0 : readbackMs / n;
+  double get meanTotal => meanBuild + meanRaster + meanReadback;
+}
+
+/// Rough Dart-heap footprint of a retained command buffer: object headers +
+/// boxed doubles for path segments, glyph placements, and the command shells
+/// themselves. Order-of-magnitude honesty for the memory report, not an
+/// exact accounting.
+(int commands, int segments, int glyphs, int bytes) _sceneFootprint(
+    List<PdfRenderCommand> commands) {
+  var cmds = 0, segments = 0, glyphs = 0;
+  void walk(List<PdfRenderCommand> list) {
+    for (final c in list) {
+      cmds++;
+      switch (c) {
+        case PdfFillPathCommand(:final path):
+          segments += path.segments.length;
+        case PdfFillPathGradientCommand(:final path):
+          segments += path.segments.length;
+        case PdfStrokePathCommand(:final path):
+          segments += path.segments.length;
+        case PdfClipPathCommand(:final path):
+          segments += path.segments.length;
+        case PdfDrawTextCommand(:final run):
+          glyphs += run.glyphs?.length ?? run.text.length;
+        case PdfEndSoftMaskedCommand(:final maskCommands):
+          walk(maskCommands);
+        default:
+          break;
+      }
+    }
+  }
+
+  walk(commands);
+  // ~56 B/command shell, ~48 B/segment (object header + 2-6 boxed-in-line
+  // doubles + list slot), ~40 B/glyph placement.
+  return (cmds, segments, glyphs, cmds * 56 + segments * 48 + glyphs * 40);
+}
+
+/// The zoom path PdfPageView takes for a page of this density: retained
+/// replay (b) up to the command ceiling, the classic cached-picture
+/// re-raster (a) above it (or when the kill switch is off).
+String _viewerPath(int commandCount) => PdfPageView.retainedZoomReplay &&
+        commandCount <= PdfPageView.retainedZoomReplayMaxCommands
+    ? 'b-retained'
+    : 'a-current';
+
+double _effectiveRatio(Size size, double desired) {
+  final width = math.max(1.0, size.width);
+  final height = math.max(1.0, size.height);
+  var ratio = desired;
+  ratio = math.min(ratio, math.sqrt(_maxPixels / (width * height)));
+  ratio = math.min(ratio, _maxDimension / math.max(width, height));
+  return math.max(ratio, 0.05);
+}
+
+Future<(ui.Image, double, double)> _timeRaster(
+    ui.Picture picture, int width, int height) async {
+  final sw = Stopwatch()..start();
+  final image = await picture.toImage(
+      width.clamp(1, 1 << 14), height.clamp(1, 1 << 14));
+  final rasterMs = sw.elapsedMicroseconds / 1000.0;
+  sw
+    ..reset()
+    ..start();
+  await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  final readbackMs = sw.elapsedMicroseconds / 1000.0;
+  return (image, rasterMs, readbackMs);
+}
+
+void main() {
+  final corpusDir = Platform.environment['ZOOM_CORPUS_DIR'] ?? '../../corpus';
+  final backend = Platform.environment['ZOOM_BACKEND'] ?? 'default';
+  final pageIndex =
+      int.tryParse(Platform.environment['ZOOM_LATENCY_PAGE'] ?? '') ?? 0;
+  final passes =
+      int.tryParse(Platform.environment['ZOOM_LATENCY_PASSES'] ?? '') ?? 3;
+  final filesEnv = Platform.environment['ZOOM_LATENCY_FILES'];
+  final fileNames = filesEnv == null || filesEnv.trim().isEmpty
+      ? _defaultFiles
+      : filesEnv.split(',').map((s) => s.trim()).toList();
+
+  testWidgets('zoom-settle latency: cached-picture vs retained-scene vs full',
+      (tester) async {
+    final dir = Directory(corpusDir);
+    if (!dir.existsSync()) {
+      markTestSkipped('corpus directory not found at $corpusDir '
+          '(set ZOOM_CORPUS_DIR); skipping the zoom latency harness');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+
+      final rows = <String>[];
+      final stepRows = <String>[];
+
+      for (final entry in fileNames) {
+        // "name.pdf#12" selects a page for that file; bare names use
+        // ZOOM_LATENCY_PAGE.
+        final hash = entry.lastIndexOf('#');
+        final name = hash < 0 ? entry : entry.substring(0, hash);
+        final filePage = hash < 0
+            ? pageIndex
+            : int.tryParse(entry.substring(hash + 1)) ?? pageIndex;
+        final path = name.startsWith('/') ? name : '${dir.path}/$name';
+        final file = File(path);
+        if (!file.existsSync()) {
+          // ignore: avoid_print
+          print('zoom-latency: $path missing, skipped');
+          continue;
+        }
+        final doc = PdfDocument.open(file.readAsBytesSync());
+        final page = doc.page(filePage.clamp(0, doc.pageCount - 1));
+        const plan = PdfPageRenderPlan();
+        final size = plan.pageSize(page);
+        final fit = [targetWidth / size.width, targetHeight / size.height]
+            .reduce((a, b) => a < b ? a : b);
+
+        // --- Untimed one-off costs (reported for context) ---------------
+        var sw = Stopwatch()..start();
+        final cachedPicture =
+            await PdfPageRenderer.renderPictureRecordedWithPlan(page, plan);
+        final interpretMs = sw.elapsedMicroseconds / 1000.0;
+        sw = Stopwatch()..start();
+        final scene = await PdfRetainedScene.record(page, plan: plan);
+        final recordMs = sw.elapsedMicroseconds / 1000.0;
+
+        final label = '${name.split('/').last}#$filePage';
+        final (cmds, segments, glyphs, bytes) = _sceneFootprint(scene.commands);
+        // The retained scene's first render replays commands to a picture
+        // like renderPictureRecordedWithPlan does, so the record-cost delta
+        // vs the old first render is (record+decode + replay) - interpret.
+        final sw2 = Stopwatch()..start();
+        scene.replay(pixelRatio: 1).dispose();
+        final replayMs = sw2.elapsedMicroseconds / 1000.0;
+        // ignore: avoid_print
+        print('zoom-latency: $label page=$filePage '
+            'size=${size.width.toStringAsFixed(0)}x'
+            '${size.height.toStringAsFixed(0)}pt fit=${fit.toStringAsFixed(2)} '
+            'commands=${scene.commands.length} '
+            'interpret=${interpretMs.toStringAsFixed(1)}ms '
+            'record+decode=${recordMs.toStringAsFixed(1)}ms '
+            'replay1x=${replayMs.toStringAsFixed(1)}ms '
+            'firstRenderDelta=${(recordMs + replayMs - interpretMs).toStringAsFixed(1)}ms '
+            'footprint: cmds=$cmds segs=$segments glyphs=$glyphs '
+            '~${(bytes / 1024).toStringAsFixed(0)}KB '
+            // Which measured path PdfPageView actually takes for this page
+            // under the retainedZoomReplayMaxCommands density ceiling.
+            'viewerPath=${_viewerPath(scene.commands.length)}');
+
+        final samples = {
+          'a-current': _Sample(),
+          'b-retained': _Sample(),
+          'c-full': _Sample(),
+        };
+        final perStep = {
+          for (final key in samples.keys)
+            key: [for (final _ in zoomSequence) _Sample()],
+        };
+
+        // pass 0 is warmup (codec/shader/pipeline caches) and is discarded
+        for (var pass = 0; pass <= passes; pass++) {
+          final record = pass > 0;
+          for (var step = 0; step < zoomSequence.length; step++) {
+            final ratio = _effectiveRatio(size, fit * zoomSequence[step]);
+            final w = (size.width * ratio).ceil();
+            final h = (size.height * ratio).ceil();
+
+            // (a) current: re-rasterize the cached ui.Picture (what
+            // pdf_page_view._renderNow does via PdfPageRenderer.rasterize).
+            var t = Stopwatch()..start();
+            final scaledRecorder = ui.PictureRecorder();
+            Canvas(scaledRecorder)
+              ..scale(ratio)
+              ..drawPicture(cachedPicture);
+            final scaled = scaledRecorder.endRecording();
+            final buildA = t.elapsedMicroseconds / 1000.0;
+            final (imageA, rasterA, readbackA) = await _timeRaster(scaled, w, h);
+            scaled.dispose();
+            imageA.dispose();
+            if (record) {
+              samples['a-current']!.add(buildA, rasterA, readbackA);
+              perStep['a-current']![step].add(buildA, rasterA, readbackA);
+            }
+
+            // (b) retained scene: replay the command buffer at the new ratio.
+            t = Stopwatch()..start();
+            final replayed = scene.replay(pixelRatio: ratio);
+            final buildB = t.elapsedMicroseconds / 1000.0;
+            final (imageB, rasterB, readbackB) =
+                await _timeRaster(replayed, w, h);
+            replayed.dispose();
+            imageB.dispose();
+            if (record) {
+              samples['b-retained']!.add(buildB, rasterB, readbackB);
+              perStep['b-retained']![step].add(buildB, rasterB, readbackB);
+            }
+
+            // (c) full re-render: re-interpret + decode (warm cache) + paint.
+            t = Stopwatch()..start();
+            final full =
+                await PdfPageRenderer.renderPictureRecordedWithPlan(page, plan);
+            final fullRecorder = ui.PictureRecorder();
+            Canvas(fullRecorder)
+              ..scale(ratio)
+              ..drawPicture(full);
+            final fullScaled = fullRecorder.endRecording();
+            final buildC = t.elapsedMicroseconds / 1000.0;
+            final (imageC, rasterC, readbackC) =
+                await _timeRaster(fullScaled, w, h);
+            fullScaled.dispose();
+            full.dispose();
+            imageC.dispose();
+            if (record) {
+              samples['c-full']!.add(buildC, rasterC, readbackC);
+              perStep['c-full']![step].add(buildC, rasterC, readbackC);
+            }
+          }
+        }
+
+        for (final entry in samples.entries) {
+          final s = entry.value;
+          rows.add('${label.padRight(44).substring(0, 44)} '
+              '${entry.key.padRight(11)} '
+              '${s.meanBuild.toStringAsFixed(1).padLeft(8)} '
+              '${s.meanRaster.toStringAsFixed(1).padLeft(8)} '
+              '${s.meanReadback.toStringAsFixed(1).padLeft(9)} '
+              '${s.meanTotal.toStringAsFixed(1).padLeft(8)}');
+        }
+        for (var step = 0; step < zoomSequence.length; step++) {
+          final parts = [
+            for (final key in samples.keys)
+              '$key=${perStep[key]![step].meanTotal.toStringAsFixed(1)}'
+          ];
+          stepRows.add('${label.padRight(44).substring(0, 44)} '
+              'zoom=${zoomSequence[step].toStringAsFixed(1)} '
+              '${parts.join('  ')}');
+        }
+
+        scene.dispose();
+        cachedPicture.dispose();
+      }
+
+      if (rows.isEmpty) {
+        markTestSkipped('no test PDFs found under $corpusDir');
+        return;
+      }
+      // ignore: avoid_print
+      print('\nzoom-settle latency (backend=$backend, mean ms/step over '
+          '$passes passes x ${zoomSequence.length} steps, '
+          'target ${targetWidth.toInt()}x${targetHeight.toInt()} fit)');
+      // ignore: avoid_print
+      print('${'page'.padRight(44)} ${'path'.padRight(11)} '
+          '${'build'.padLeft(8)} ${'toImage'.padLeft(8)} '
+          '${'readback'.padLeft(9)} ${'total'.padLeft(8)}');
+      for (final row in rows) {
+        // ignore: avoid_print
+        print(row);
+      }
+      // ignore: avoid_print
+      print('\nper-zoom-step totals (ms, build+toImage+readback):');
+      for (final row in stepRows) {
+        // ignore: avoid_print
+        print(row);
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 15)));
+}


### PR DESCRIPTION
## Summary

Zooming a page currently re-rasterizes by wrapping the cached `ui.Picture` in a new picture (`scale` + `drawPicture`) and calling `toImage`. On Impeller that nested-picture raster is heavily penalized. This PR retains the page's interpreted `PdfRenderCommand` buffer as a `PdfRetainedScene` and, on zoom-driven re-raster (full and deep-zoom region), replays it into a **flat** picture at the new ratio instead — no re-interpret, no re-decode, and output **byte-identical** to the current path (pinned by test at 3 ratios + region).

First-render cost is ~zero by construction: the local render path already interpreted through record→replay internally and discarded the buffer; now it keeps it. Worker-rendered pages adopt their existing command buffers directly.

## Numbers (Impeller/Metal, mean ms per zoom step, 2382×1684, UI-thread-relevant build+toImage)

| page | before | after |
|---|---:|---:|
| image-heavy report | 34.4–44.9 | **15.2–15.8 (~0.35×)** |
| light invoice | 6.9 | 7.7 (floor parity) |
| 99k-command CAD sheet | 65.1 | 64.7 (routed to old path by ceiling) |

Software backends are neutral (raster dominates both paths). Numbers from `test/zoom_latency_test.dart`, which now prints the `viewerPath=` routing per page.

## Design

- `PdfPageView.retainedZoomReplay` — static kill switch, default on; off restores the old paths exactly.
- `PdfPageView.retainedZoomReplayMaxCommands` (default 20 000) — pages above the ceiling never retain a scene and stay on the cached-picture path: replay costs ~0.7 µs/command of UI-thread time, so the ceiling caps worst-case replay at ~a frame, and skipping retention saves the ~31 MB command buffer on exactly the pages that can't use it (office pages retain ~72–124 KB).
- Scenes live and die with the page's picture (`_dropPicture`), so revision swaps, epoch bumps, and destructive edits keep their existing semantics; editing selection machinery untouched.
- `lib/src/retained_scene.dart` (`PdfRetainedScene`): record-once / replay-at-any-ratio with owned decoded-image lifetime; exported from the package barrel.
- Worker deep-zoom detail path intentionally unchanged (its region-capped image re-decode is sharper at deep zoom).

## Verification

- Byte-identity: `retained_scene_test.dart` (replay vs `PdfPageRenderer.rasterize`, 3 ratios + region) — pass.
- Over-ceiling fallback pinned by a new `pdf_page_view_test.dart` widget test.
- Full `dart_pdf_editor` suite (1285 incl. all `editing_*` widget tests and Ghent baselines, unchanged), 49-file corpus render sweep, render smoke on report/invoice/CAD pages — all green; analyzer clean.
- Dev-log: `doc/dev-log/2026-07-10-retained-zoom-mainline.md` (part of the shader-rendering experiment; cross-track summary on `experiment/strip-shader`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)