### PR TITLE
test(editor): end-to-end cover the styled dialog's normal font menu

### DIFF
--- a/packages/dart_pdf_editor/test/editing_text_style_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_style_test.dart
@@ -109,7 +109,7 @@ void main() {
   group('Edit text & style toolbar action', () {
     Future<PdfEditingController> pumpToolbar(
       WidgetTester tester, {
-      required PdfStyledTextPrompt styledTextPrompt,
+      PdfStyledTextPrompt? styledTextPrompt,
     }) async {
       final editing = PdfEditingController(buildTextPdf(singleLine));
       final viewer = PdfViewerController();
@@ -123,7 +123,8 @@ void main() {
             builder: (context, _) => PdfEditingToolbar(
               controller: editing,
               viewerController: viewer,
-              styledTextPrompt: styledTextPrompt,
+              // default to the real prompt when none is supplied
+              styledTextPrompt: styledTextPrompt ?? showPdfStyledTextPrompt,
             ),
           ),
         ),
@@ -159,6 +160,38 @@ void main() {
       expect(editing.isModified, isTrue);
       final text = pageText(editing.document);
       expect(text, contains('0 0 1 rg'));
+    });
+
+    testWidgets('real dialog drives the normal font menu end to end',
+        (tester) async {
+      final editing = await pumpToolbar(tester); // real styled prompt
+      editing.tool = PdfEditTool.content;
+      expect(selectElementByText(editing, 'Hello World'), isTrue);
+      await tester.pump();
+
+      // open the real "Edit text & style" dialog
+      await tester.tap(find.byKey(const ValueKey('pdf-style-element-text')));
+      await tester.pumpAndSettle();
+      // its Font row is the normal picker button, not the fallback dropdown
+      expect(find.byKey(const ValueKey('pdf-styled-font')), findsOneWidget);
+
+      // open the shared font menu and pick the serif family
+      await tester.tap(find.byKey(const ValueKey('pdf-styled-font')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-font-std-serif')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-styled-ok')));
+      await tester.pumpAndSettle();
+
+      expect(editing.isModified, isTrue);
+      final doc = editing.document;
+      final fonts =
+          doc.cos.resolve(doc.page(0).resources['Font']) as CosDictionary;
+      final serif = fonts.entries.values
+          .map((v) => doc.cos.resolve(v))
+          .whereType<CosDictionary>()
+          .any((f) => f['BaseFont'] == const CosName('Times-Roman'));
+      expect(serif, isTrue, reason: 'the replacement switched to Times');
     });
 
     testWidgets('cancelling the prompt changes nothing', (tester) async {


### PR DESCRIPTION
## Summary

Follow-up to #207 (merged). Adds one end-to-end widget test that drives the real **Edit text & style** dialog through the shared font menu — select a content text element, open the dialog, tap the Font button, pick the serif family from the normal font menu, apply, and assert the replacement switched to Times.

This closes a coverage gap the stubbed-prompt tests left open: the toolbar's `_pickStyledFont` and the dialog's font-button path were never exercised because the existing toolbar tests stub `styledTextPrompt` entirely. Test-only — no production code changes.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [x] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (clean)
- [x] `cd packages/dart_pdf_editor && fvm flutter test test/editing_text_style_test.dart` (12 pass)

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Pure test addition on top of the merged #207. Uses the real `showPdfStyledTextPrompt`/`showPdfFontMenu` instead of a stub so the full pick-a-font flow is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F49h37toJsrSW1KmKu7MZH)_