### PR TITLE
feat(dart_pdf_editor): opt-in sparse-strip rendering + dense-page strip zoom router

### DIFF
--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -41,7 +41,20 @@ echo "== 3/3  dart-pdf render (Flutter rasterization) =="
   PDF_BENCHMARK_OUT="$OUT/dart-render.json" \
     $FLUTTER test test/benchmark_render_test.dart )
 
+if [[ "${RUN_STRIPS:-0}" == "1" ]]; then
+  echo "== extra: dart-pdf strips render (experimental shader device) =="
+  ( cd "$ROOT/packages/dart_pdf_editor" && \
+    PDF_BENCHMARK_DIR="$CORPUS" PDF_BENCHMARK_SCALE="$SCALE" \
+    PDF_BENCHMARK_MAX_PAGES="$MAX_PAGES" \
+    PDF_BENCHMARK_OUT="$OUT/dart-strips.json" \
+      $FLUTTER test test/benchmark_strip_render_test.dart )
+fi
+
 echo
 echo "== Comparison (baseline = PDFium) =="
+EXTRA_JSON=()
+[[ -f "$OUT/dart-strips.json" && "${RUN_STRIPS:-0}" == "1" ]] && \
+  EXTRA_JSON+=("$OUT/dart-strips.json")
 python3 "$ROOT/benchmark/compare.py" \
-  "$OUT/pdfium.json" "$OUT/dart-render.json" "$OUT/dart-interpret.json"
+  "$OUT/pdfium.json" "$OUT/dart-render.json" "$OUT/dart-interpret.json" \
+  ${EXTRA_JSON[@]+"${EXTRA_JSON[@]}"}

--- a/doc/dev-log/2026-07-10-strip-mainline.md
+++ b/doc/dev-log/2026-07-10-strip-mainline.md
@@ -1,0 +1,167 @@
+# 2026-07-10 — Mainlining sparse-strip rendering + stroke cache + zoom router
+
+Branch `feat/strip-rendering`, stacked on `perf/retained-zoom-replay`
+(PR #208, open at branch time — this PR rebases onto main once #208
+merges). Three phases: extraction of the strip experiment's productizable
+core, a new content-keyed stroke/fill strip cache, and the opt-in
+dense-page strip zoom router. Slug (curve-in-texture glyphs) stays
+shelved on `experiment/strip-shader` per the cross-track summary.
+
+## Phase 1 — extracted from `experiment/strip-shader` (strips only)
+
+- `pdf_graphics`: `lib/raster.dart` (minus the `curve_quads.dart`
+  export — Slug foundations excluded), `src/raster/{flatten,
+  stroke_contours,strip_generator}.dart` (incl. the glyph strip cache),
+  `test/raster/` (minus `curve_quads_test.dart`),
+  `tool/benchmark_strips.dart`.
+- `dart_pdf_editor`: `shaders/pdf_strips.frag` + `pdf_probe.frag` (+ the
+  pubspec `shaders:` entry, no `pdf_slug.frag`), `lib/strips.dart`,
+  `src/strips/{strip_device,strip_batch}.dart` (no `slug_batch.dart`),
+  the strip test set (`strip_device/probe/curve_probe/overlap_probe/
+  skia_calibration/debug/parity` + `benchmark_strip_render_test.dart`),
+  the `RUN_STRIPS=1` hunk in `benchmark/run.sh`.
+- `strip_device.dart` and the parity/benchmark tests were taken at their
+  **pre-Slug commits** (`e1ce718`/`baae230`) so no `slugGlyphs` flag or
+  `slugMinGlyphPx` guard ever landed here — outline text always goes to
+  strip binning.
+- Renderer plumbing: `PdfRenderDeviceMode` + `PdfPageRenderer.deviceMode`
+  + `_renderImageStrips` applied as a 3-way patch over #208's renderer
+  changes (they touch disjoint regions; `preparePageCanvas` from #208 and
+  the strips path coexist). `CanvasPdfDevice.endSoftMasked` split into
+  `beginSoftMaskComposite`/`finishSoftMaskComposite` (behaviorally
+  unchanged for canvas-only rendering; the whole file was checked out
+  from the branch because of its embedded NUL byte, then verified to
+  carry only the split).
+- Excluded as stray: `pdf_document/tool/_inspect_page.dart` (debug
+  helper) and the experiment dev-logs (they live on the branch).
+
+## Phase 2 — content-keyed stroke/fill strip cache (`ShapeStripCache`)
+
+Track A/C data said stroke expansion + binning dominate dense-CAD strip
+generation. The glyph cache's design — relocatable strip blobs,
+subpixel-phase quantization with y kept inside the 4-px strip row,
+cache-on-second-sight — applied to geometry with **no shared object
+identity**: the key is content (segment opcodes + point deltas from the
+first point at 1/64 px + stroke/fill params + tolerance + anchor
+subpixel phase), hashed to 32 bits with **full content verification on
+every hit** (collision → direct raster; 14 collisions corpus-wide,
+correctness never rides on the hash). First sights raster from the same
+quantized content later replays use, so pixels never shift with cache
+state (byte-identity tested in `shape_cache_test.dart`).
+
+Design points that came from measurement, not the plan:
+
+- **Generational rotation, not FIFO.** At a 16k entry cap, FIFO
+  per-entry eviction rebuild-stormed ly9-far-cad (~36k keys/render)
+  *slower than no cache at all* (165 vs 139 ms/page). Two generations
+  rotate wholesale (O(1) bulk drop, promote-on-verified-hit); each
+  generation (64k entries / 32 MB) holds a worst-case document's working
+  set. Steady state on the heavy corpus: ~48k entries / ~24 MB.
+- **The seen-filter is generational too.** A wholesale clear of the
+  second-sight set used to land — deterministically, both passes —
+  mid-corpus-sweep exactly when WAT_L0001_S rendered, so its keys never
+  got past first sight. A sliding window fixes that failure mode; a 2×
+  window was also tried to catch cross-sweep repeats and made everything
+  worse (202k vs 48k builds — sweep-scale one-shots thrashed the entry
+  generations). Cross-document-sweep reuse is not a pattern worth buying.
+- **1/8-px anchor quantization** (finer than the glyph cache's 1/4):
+  snapping a fill shifts whole edges, and at 1/4 px the Ghent parity
+  relaxed-edge gate dropped to 48/57 (< 90%). 1/8 px restores 53/57 on
+  software Skia (was 54 pre-cache; the two losses are the same
+  glyph-cache-era text pages plus one transparency page at mean 2.0x),
+  57/57 under Impeller. Hit rates barely moved (WAT 63.4% vs 64.9%).
+- **No-joins stroke pad**: single straight hatch/dimension segments (the
+  hot CAD case) skip the conservative `hw × miterLimit` bbox pad, which
+  otherwise pushed ordinary wide strokes into the offscreen bypass.
+- Only paths ≤ 64 segments attempt the cache (huge one-off boundary
+  paths must not pay the content walk + hash); > 512 px a side or not
+  fully in-viewport bypasses to the direct unquantized raster, exactly
+  like glyphs.
+
+### Numbers (interpret+stripgen, scale 2, ≤ 10 pages/file, repeat 2, M4)
+
+| corpus | cache off | cache on | Δ |
+|---|---|---|---|
+| real corpus mean (49 files, 255 pages) | 29.96 | 27.25 | −9.0% |
+| ly9-far-cad (in sweep) | 147.8 | 133.5 | −7.9% |
+| WAT_L0001_S (in sweep) | 106.9 | 104.4 | −2.4% |
+| ly9-far-cad (solo, repeat 3) | 149.9 | 124.8 | −16.7% |
+| WAT_L0001_S (solo, repeat 3) | 107.8 | 63.0 | **−41.6%** |
+
+Corpus hit rate 86%, no per-file regression > 10% and > 2 ms/page.
+The solo numbers are the product-relevant steady state (re-rendering
+one document, e.g. zoom re-bins); the in-sweep numbers approximate a
+first encounter under cross-file cache pressure (≈ neutral for WAT —
+its reuse is cross-page/cross-render, and 48 other files render between
+its passes). `benchmark_strips.dart` grew `--no-shape-cache` and a
+`shapeCache` stats block.
+
+## Phase 3 — dense-page strip zoom router (`PdfPageView.stripZoomReplay`)
+
+#208 made pages above `retainedZoomReplayMaxCommands` skip scene
+retention (flat replay was useless for them). Strips invert that: dense
+pages are the *best* replay case on Impeller. Opt-in wiring:
+
+- `PdfPageView.stripZoomReplay` static flag, **default false**. When
+  true, over-ceiling pages DO retain their scene and zoom-driven
+  re-rasters — full page and the deep-zoom detail patch — replay through
+  `StripPdfDevice` at the new ratio (`PdfRetainedScene.rasterizeStrips` /
+  `rasterizeRegionStrips`; `PdfPageRenderer.pageToDeviceMatrix` made
+  public as the transform seam). Under-ceiling pages keep #208's flat
+  replay — strips lose on office pages.
+- Default-off rationale: software Skia's SkSL interpreter makes the
+  strip shader ~2× slower than the canvas, and there is no reliable
+  runtime Impeller detection — the embedding app opts in where it knows
+  its backend. And the trade is honest: the re-bin runs on the UI thread
+  (~270 ms per settle on the CAD page below) — blocked longer, sharp
+  ~4× sooner. **Worker-isolate strip generation is the path to
+  default-on**: the strip core is deliberately dart:ui-free for exactly
+  that (bin off-thread, ship the SoA buffers back, upload + drawVertices
+  on the UI thread). Not built in this pass.
+
+### Zoom-settle latency (ly9-far-cad page 4, ~99k retained commands, Impeller/Metal, mean of 5 steps × 3 passes)
+
+| path | build | toImage | readback | total |
+|---|---|---|---|---|
+| a-current (cached picture) | 4 | 87 | 1485 | 1576 |
+| b-retained (flat replay) | 80 | 67 | 1364 | 1511 |
+| d-strips (router, flag on) | 268 | 14 | 98 | **380** |
+
+~4.2× faster to sharp pixels than the shipping path (the experiment's
+1446→414 on the same page, reproduced post-merge). The a/b readback
+dominance is Impeller deferring the actual raster of the 99k-path
+picture into `toByteData`; strips genuinely rasterize in the `toImage`.
+`zoom_latency_test.dart` grew the (d) strips path + per-step batching
+telemetry (~2 flushes/settle, 87–189k quads, 1.3–3.3 MB atlas).
+
+Tests: `strip_zoom_router_test.dart` — routing (flag on + over ceiling →
+strip telemetry ticks; flag off → exactly #208's cached-picture path,
+zero strip activity) and a strip-vs-canvas replay image sanity check
+(non-blank, mean diff ≤ 2/255, full page + region variant). Gotcha: the
+image-sanity test must run *before* the widget zoom tests in that file —
+after them, later `tester.runAsync` platform work (the
+`decodeImageFromPixels` inside the atlas upload) never completes.
+
+## Verification matrix
+
+- Root `fvm dart analyze`: clean.
+- `pdf_graphics`: 757 tests green (incl. 66 raster + Ghent/PDF.js corpus
+  passes).
+- `dart_pdf_editor`: 1304 green on software Skia; strip parity 53/57
+  relaxed-edge (gate ≥ 90%), Impeller parity 57/57; probes, device
+  tests, router tests green on both backends.
+- `corpus_render_test`: 49/49 rendered (canvas path untouched).
+- `ghent_render_test` vs checked-in baselines: green, no baseline
+  changes (the default render path is byte-identical to before).
+
+## Files
+
+- Phase 1: see the extraction commit (`007e352`).
+- Phase 2: `pdf_graphics/lib/src/raster/strip_generator.dart`
+  (`ShapeStripCache`, `CachedShapeStrips`, `StripGenerator.shapeCache`,
+  the content walk/quantized raster), `test/raster/shape_cache_test.dart`,
+  `tool/benchmark_strips.dart`.
+- Phase 3: `dart_pdf_editor/lib/src/pdf_page_view.dart` (flag + router),
+  `lib/src/retained_scene.dart` (strip replay seam),
+  `lib/src/renderer.dart` (`pageToDeviceMatrix` public),
+  `test/strip_zoom_router_test.dart`, `test/zoom_latency_test.dart`.

--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -131,6 +131,28 @@ class CanvasPdfDevice implements PdfDevice {
       double backdropLuminance = 0,
       double transferScale = 1,
       double transferOffset = 0}) {
+    beginSoftMaskComposite(
+        luminosity: luminosity,
+        backdrop: backdrop,
+        backdropLuminance: backdropLuminance,
+        transferScale: transferScale,
+        transferOffset: transferOffset);
+    drawMask();
+    finishSoftMaskComposite();
+  }
+
+  /// First half of [endSoftMasked]'s compositing: opens the dstIn layer the
+  /// mask group's content paints into (with the luminance/transfer colour
+  /// filter and the /BC backdrop). Split out for callers that must
+  /// interleave their own work with the mask draws - the strip device
+  /// flushes its batched quads between the mask content and
+  /// [finishSoftMaskComposite] - while keeping the exact canvas sequence.
+  void beginSoftMaskComposite(
+      {required bool luminosity,
+      required PdfRect backdrop,
+      double backdropLuminance = 0,
+      double transferScale = 1,
+      double transferOffset = 0}) {
     final hasTransfer = transferScale != 1 || transferOffset != 0;
     final paint = Paint()..blendMode = BlendMode.dstIn;
     if (luminosity) {
@@ -167,7 +189,11 @@ class CanvasPdfDevice implements PdfDevice {
         Paint()..color = Color.from(alpha: 1, red: g, green: g, blue: g),
       );
     }
-    drawMask();
+  }
+
+  /// Second half of [endSoftMasked]'s compositing: composites the mask into
+  /// the captured content (dstIn) and the masked content into the page.
+  void finishSoftMaskComposite() {
     canvas.restore(); // composite the mask into the content (dstIn)
     canvas.restore(); // composite the masked content into the page
     _knockout.removeLast();

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -180,6 +180,28 @@ class PdfPageView extends StatefulWidget {
   /// retained replay costs about one frame.
   static int retainedZoomReplayMaxCommands = 20000;
 
+  /// Opt-in strip routing for pages ABOVE [retainedZoomReplayMaxCommands]:
+  /// when true they DO retain their scene, and zoom-driven re-rasters (full
+  /// page and deep-zoom detail patch) replay it through the sparse-strip
+  /// shader device ([PdfRetainedScene.rasterizeStrips]) at the new ratio
+  /// instead of re-rasterizing the cached nested picture. Pages under the
+  /// ceiling keep the flat canvas replay - strips lose on office pages
+  /// (fixed atlas-decode/replay overhead, and Impeller already rasterizes
+  /// light flat pictures quickly).
+  ///
+  /// Default FALSE, and it must stay off on software backends: the SkSL
+  /// interpreter runs the coverage shader per fragment, making strips ~2x
+  /// slower than the canvas there, and there is no reliable runtime
+  /// Impeller detection - so the embedding app opts in where it knows its
+  /// backend (measured on Impeller/Metal: a dense CAD sheet reaches sharp
+  /// pixels ~3.5x sooner per zoom settle). The honest trade: the strip
+  /// re-bin runs on the UI thread (~300 ms per settle on that CAD sheet),
+  /// blocking longer than the nested re-raster's cheap UI-thread half but
+  /// finishing far sooner overall. Off-thread strip generation in the
+  /// render worker (the strip core is deliberately dart:ui-free for
+  /// exactly that) is the path to default-on.
+  static bool stripZoomReplay = false;
+
   @override
   State<PdfPageView> createState() => _PdfPageViewState();
 }
@@ -548,10 +570,20 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   /// Whether a page recorded as [commandCount] top-level commands should
   /// retain its scene - the [PdfPageView.retainedZoomReplay] switch plus the
-  /// [PdfPageView.retainedZoomReplayMaxCommands] density ceiling.
+  /// [PdfPageView.retainedZoomReplayMaxCommands] density ceiling. With
+  /// [PdfPageView.stripZoomReplay] on, over-ceiling pages retain too: their
+  /// zooms re-bin through the strip device instead of the flat replay.
   static bool _retainScene(int commandCount) =>
       PdfPageView.retainedZoomReplay &&
-      commandCount <= PdfPageView.retainedZoomReplayMaxCommands;
+      (commandCount <= PdfPageView.retainedZoomReplayMaxCommands ||
+          PdfPageView.stripZoomReplay);
+
+  /// Whether [scene]'s zoom re-rasters route through the strip device: the
+  /// opt-in flag, and only above the ceiling (under it the flat canvas
+  /// replay wins - see [PdfPageView.stripZoomReplay]).
+  static bool _stripReplayScene(PdfRetainedScene scene) =>
+      PdfPageView.stripZoomReplay &&
+      scene.commands.length > PdfPageView.retainedZoomReplayMaxCommands;
 
   /// Builds the picture (and, unless [PdfPageView.retainedZoomReplay] is
   /// off, the retained scene) from a recorded command buffer. One decode
@@ -751,11 +783,15 @@ class _PdfPageViewState extends State<PdfPageView> {
       }
       // Replay the retained scene into a flat picture at the new ratio when
       // one is held - Impeller rasterizes that several times faster than the
-      // nested drawPicture re-raster, with byte-identical output. Fallback
-      // paths (no scene, or the kill switch) re-raster the cached picture.
+      // nested drawPicture re-raster, with byte-identical output. Dense
+      // pages retained under PdfPageView.stripZoomReplay re-bin through the
+      // strip shader device instead. Fallback paths (no scene, or the kill
+      // switch) re-raster the cached picture.
       final scene = PdfPageView.retainedZoomReplay ? _scene : null;
       final image = scene != null
-          ? await scene.rasterize(pixelRatio: effective)
+          ? await (_stripReplayScene(scene)
+              ? scene.rasterizeStrips(pixelRatio: effective)
+              : scene.rasterize(pixelRatio: effective))
           : await PdfPageRenderer.rasterize(
               picture, _renderPlan.pageSize(widget.page), effective);
       if (_superseded(generation, pageIndex)) {
@@ -880,10 +916,13 @@ class _PdfPageViewState extends State<PdfPageView> {
       return false;
     }
     // Same replay-over-nested-raster swap as the full-page path: the deep-
-    // zoom patch replays only [region] from the retained scene when held.
+    // zoom patch replays only [region] from the retained scene when held
+    // (through the strip device for dense pages under stripZoomReplay).
     final scene = PdfPageView.retainedZoomReplay ? _scene : null;
     final image = scene != null
-        ? await scene.rasterizeRegion(region, pixelRatio: ratio)
+        ? await (_stripReplayScene(scene)
+            ? scene.rasterizeRegionStrips(region, pixelRatio: ratio)
+            : scene.rasterizeRegion(region, pixelRatio: ratio))
         : await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
     if (!mounted || generation != _detailGeneration || _renderPaused) {
       image.dispose();

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -458,7 +458,7 @@ class PdfPageRenderer {
 
     final device = StripPdfDevice(
       canvas,
-      pageToDevice: _pageToDeviceMatrix(page, size, box,
+      pageToDevice: pageToDeviceMatrix(page, size, box,
           rotation: plan.rotation, pixelRatio: pixelRatio),
       deviceWidth: width,
       deviceHeight: height,
@@ -489,8 +489,9 @@ class PdfPageRenderer {
 
   /// The page->device-pixel matrix matching [_applyPageTransform] followed
   /// by a [pixelRatio] canvas scale (geometric application order: crop-box
-  /// shift, y-flip, /Rotate, ratio).
-  static PdfMatrix _pageToDeviceMatrix(PdfPage page, Size size, PdfRect box,
+  /// shift, y-flip, /Rotate, ratio). Public so [PdfRetainedScene] can feed
+  /// a [StripPdfDevice] the exact transform its canvas preamble implies.
+  static PdfMatrix pageToDeviceMatrix(PdfPage page, Size size, PdfRect box,
       {int? rotation, required double pixelRatio}) {
     var m = PdfMatrix.translation(-box.left, -box.bottom)
         .concat(const PdfMatrix(1, 0, 0, -1, 0, 0))

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -8,6 +8,19 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'canvas_device.dart';
 import 'image_decoder.dart';
+import 'strips/strip_device.dart';
+
+/// Which device family [PdfPageRenderer.renderImageWithPlan] paints with.
+enum PdfRenderDeviceMode {
+  /// The stock [CanvasPdfDevice] pipeline (default).
+  canvas,
+
+  /// Experimental sparse-strip shader device ([StripPdfDevice]): solid
+  /// fills/strokes/outline text batch into drawVertices+FragmentShader
+  /// draws, everything else falls back to the canvas device. Only the
+  /// pixelRatio-aware bitmap path honors this; picture paths stay canvas.
+  strips,
+}
 
 /// Immutable display inputs for rendering a page.
 ///
@@ -383,11 +396,20 @@ class PdfPageRenderer {
     );
   }
 
+  /// Experimental device selector for [renderImageWithPlan]. Static so the
+  /// benchmark/parity harnesses (and a future viewer flag) can flip every
+  /// render path at once; strip pictures bake the pixel ratio in, so only
+  /// the bitmap path (which knows the ratio) participates.
+  static PdfRenderDeviceMode deviceMode = PdfRenderDeviceMode.canvas;
+
   /// Renders [page] to a bitmap using a pre-computed display [plan].
   static Future<ui.Image> renderImageWithPlan(PdfPage page,
       {required PdfPageRenderPlan plan,
       double pixelRatio = 1,
       bool recorded = false}) async {
+    if (deviceMode == PdfRenderDeviceMode.strips && !recorded) {
+      return _renderImageStrips(page, plan, pixelRatio);
+    }
     final picture = recorded
         ? await renderPictureRecordedWithPlan(page, plan)
         : await renderPictureWithPlan(page, plan);
@@ -396,6 +418,98 @@ class PdfPageRenderer {
     } finally {
       picture.dispose();
     }
+  }
+
+  /// Phase timing (microseconds) for the strips path, aggregated across
+  /// renders for the benchmark: interpret+strip-generation (the walk into
+  /// [StripPdfDevice]) and the final picture rasterization. Atlas-decode
+  /// and tape-replay phases live on [StripPdfDevice].
+  static int stripInterpretMicros = 0;
+  static int stripRasterMicros = 0;
+
+  /// Strip-device bitmap render: interpret once through [StripPdfDevice]
+  /// (recording strips + fallback ops in painter's order), then paint and
+  /// rasterize. The picture is recorded with [pixelRatio] baked in so the
+  /// strip quads are device-pixel-aligned - matching [rasterize]'s output
+  /// geometry for the same ratio.
+  static Future<ui.Image> _renderImageStrips(
+      PdfPage page, PdfPageRenderPlan plan, double pixelRatio) async {
+    final cos = page.document.cos;
+    final pageOps = ContentStreamParser.parse(page.contentBytes());
+
+    final collector = ImageCollector();
+    final collecting =
+        PdfInterpreter(cos: cos, device: collector, scanImagesOnly: true)
+          ..drawPageOperations(page, pageOps);
+    if (plan.annotations) collecting.drawAnnotations(page);
+    final images = await decodeImages(cos, collector.streams,
+        cache: PdfImageCache.instance);
+
+    final box = page.cropBox;
+    final size = plan.pageSize(page);
+    final width = (size.width * pixelRatio).ceil().clamp(1, 1 << 14);
+    final height = (size.height * pixelRatio).ceil().clamp(1, 1 << 14);
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.scale(pixelRatio);
+    _paintBackground(canvas, size, plan.pageColor);
+    _applyPageTransform(canvas, page, size, box, rotation: plan.rotation);
+
+    final device = StripPdfDevice(
+      canvas,
+      pageToDevice: _pageToDeviceMatrix(page, size, box,
+          rotation: plan.rotation, pixelRatio: pixelRatio),
+      deviceWidth: width,
+      deviceHeight: height,
+      pixelRatio: pixelRatio,
+      images: images,
+    );
+    final sw = Stopwatch()..start();
+    final painting = PdfInterpreter(cos: cos, device: device)
+      ..drawPageOperations(page, pageOps);
+    if (plan.annotations) painting.drawAnnotations(page);
+    stripInterpretMicros += sw.elapsedMicroseconds;
+    await device.finish();
+
+    final picture = recorder.endRecording();
+    sw.reset();
+    try {
+      final image = await picture.toImage(width, height);
+      stripRasterMicros += sw.elapsedMicroseconds;
+      return image;
+    } finally {
+      picture.dispose();
+      device.dispose();
+      for (final image in images.values) {
+        image.dispose();
+      }
+    }
+  }
+
+  /// The page->device-pixel matrix matching [_applyPageTransform] followed
+  /// by a [pixelRatio] canvas scale (geometric application order: crop-box
+  /// shift, y-flip, /Rotate, ratio).
+  static PdfMatrix _pageToDeviceMatrix(PdfPage page, Size size, PdfRect box,
+      {int? rotation, required double pixelRatio}) {
+    var m = PdfMatrix.translation(-box.left, -box.bottom)
+        .concat(const PdfMatrix(1, 0, 0, -1, 0, 0))
+        .concat(PdfMatrix.translation(0, box.height));
+    switch (rotation ?? page.rotation) {
+      case 90:
+        m = m
+            .concat(const PdfMatrix(0, 1, -1, 0, 0, 0))
+            .concat(PdfMatrix.translation(size.width, 0));
+      case 180:
+        m = m
+            .concat(const PdfMatrix(-1, 0, 0, -1, 0, 0))
+            .concat(PdfMatrix.translation(size.width, size.height));
+      case 270:
+        m = m
+            .concat(const PdfMatrix(0, -1, 1, 0, 0, 0))
+            .concat(PdfMatrix.translation(0, size.height));
+    }
+    return m.concat(PdfMatrix.scaled(pixelRatio, pixelRatio));
   }
 
   /// Rasterizes an already-recorded page [picture] (sized [size] points) -

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -22,6 +22,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'canvas_device.dart';
 import 'image_decoder.dart';
 import 'renderer.dart';
+import 'strips/strip_device.dart';
 
 /// A page retained as a replayable scene: the recorded interpreter command
 /// buffer plus its decoded images, both produced exactly once in [record].
@@ -159,6 +160,113 @@ class PdfRetainedScene {
   void _replayOnto(Canvas canvas) {
     PdfPageRenderer.preparePageCanvas(canvas, page, plan);
     replayCommands(commands, CanvasPdfDevice(canvas, images: _images));
+  }
+
+  /// Replays the retained commands through a [StripPdfDevice] instead of
+  /// [CanvasPdfDevice]: fills/strokes/outline glyphs are re-binned into
+  /// sparse strips at [pixelRatio] and drawn as shader-carrying
+  /// `drawVertices` batches; everything the strip device can't express
+  /// delegates to the canvas in painter's order. Async because the device's
+  /// alpha-atlas upload awaits `decodeImageFromPixels` inside `finish()`.
+  ///
+  /// The resulting picture is only valid at the recorded [pixelRatio]
+  /// (strip quads are device-pixel-aligned) - every zoom step is a fresh
+  /// re-bin. Still zero re-interpretation and zero image re-decoding: the
+  /// walk is a command replay and the image map is the scene's own.
+  ///
+  /// Batching telemetry accumulates on [StripPdfDevice.totalFlushes] /
+  /// `totalStripQuads` / `totalAtlasTexels`; call
+  /// [StripPdfDevice.resetStats] around a step to read per-step deltas.
+  Future<ui.Picture> replayStrips({required double pixelRatio}) async {
+    assert(!_disposed, 'replay after dispose');
+    final size = pageSize;
+    final width = (size.width * pixelRatio).ceil().clamp(1, 1 << 14);
+    final height = (size.height * pixelRatio).ceil().clamp(1, 1 << 14);
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)..scale(pixelRatio);
+    PdfPageRenderer.preparePageCanvas(canvas, page, plan);
+    final device = StripPdfDevice(
+      canvas,
+      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(
+          page, size, page.cropBox,
+          rotation: plan.rotation, pixelRatio: pixelRatio),
+      deviceWidth: width,
+      deviceHeight: height,
+      pixelRatio: pixelRatio,
+      images: _images,
+    );
+    try {
+      replayCommands(commands, device);
+      await device.finish(); // must precede endRecording
+      return recorder.endRecording();
+    } finally {
+      device.dispose();
+    }
+  }
+
+  /// Region variant of [replayStrips]: only [region] (page points, y-down
+  /// raster space, like [replayRegion]) lands at the picture origin, at
+  /// [pixelRatio]. The strip viewport is the region raster, so offscreen
+  /// geometry is clipped during binning rather than drawn.
+  Future<ui.Picture> replayRegionStrips(Rect region,
+      {required double pixelRatio}) async {
+    assert(!_disposed, 'replay after dispose');
+    final width = (region.width * pixelRatio).ceil().clamp(1, 1 << 14);
+    final height = (region.height * pixelRatio).ceil().clamp(1, 1 << 14);
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)
+      ..scale(pixelRatio)
+      ..translate(-region.left, -region.top);
+    PdfPageRenderer.preparePageCanvas(canvas, page, plan);
+    final device = StripPdfDevice(
+      canvas,
+      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(
+              page, pageSize, page.cropBox,
+              rotation: plan.rotation, pixelRatio: pixelRatio)
+          .concat(PdfMatrix.translation(
+              -region.left * pixelRatio, -region.top * pixelRatio)),
+      deviceWidth: width,
+      deviceHeight: height,
+      pixelRatio: pixelRatio,
+      images: _images,
+    );
+    try {
+      replayCommands(commands, device);
+      await device.finish(); // must precede endRecording
+      return recorder.endRecording();
+    } finally {
+      device.dispose();
+    }
+  }
+
+  /// Convenience: [replayStrips] + `toImage`, the strip-router counterpart
+  /// of [rasterize].
+  Future<ui.Image> rasterizeStrips({required double pixelRatio}) async {
+    final picture = await replayStrips(pixelRatio: pixelRatio);
+    try {
+      final size = pageSize;
+      return await picture.toImage(
+        (size.width * pixelRatio).ceil().clamp(1, 1 << 14),
+        (size.height * pixelRatio).ceil().clamp(1, 1 << 14),
+      );
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  /// Convenience: [replayRegionStrips] + `toImage`, the strip-router
+  /// counterpart of [rasterizeRegion].
+  Future<ui.Image> rasterizeRegionStrips(Rect region,
+      {required double pixelRatio}) async {
+    final picture = await replayRegionStrips(region, pixelRatio: pixelRatio);
+    try {
+      return await picture.toImage(
+        (region.width * pixelRatio).ceil().clamp(1, 1 << 14),
+        (region.height * pixelRatio).ceil().clamp(1, 1 << 14),
+      );
+    } finally {
+      picture.dispose();
+    }
   }
 
   /// Releases the scene's decoded images. Pictures already returned by

--- a/packages/dart_pdf_editor/lib/src/strips/strip_batch.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_batch.dart
@@ -1,0 +1,143 @@
+// One flushed batch of sparse strips, converted from the StripGenerator's
+// SoA buffer into the exact upload shapes the shader path draws: quad
+// vertices (positions in device pixels, texcoords addressing the alpha
+// atlas, per-vertex ARGB colors) plus the batch's rgba8888 alpha atlas.
+//
+// Texcoord contract (mirrored by shaders/pdf_strips.frag): u interpolates
+// the global alpha-texel index across the quad (fragment centers land at
+// index + .5), v is the local strip row - [0,4) mixed, [4,8) solid.
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:pdf_graphics/raster.dart';
+
+/// Alpha atlas width in texels (4 bytes each -> 4 KB rows).
+const int stripAtlasWidth = 1024;
+
+/// ui.Vertices indices are Uint16, so one draw holds at most
+/// 65535 / 4 quads; batches chunk at this many strips per draw.
+const int stripMaxQuadsPerDraw = 16000;
+
+/// A flush batch: everything needed to draw its strips with one shader
+/// paint - [chunks] drawVertices calls sharing one [atlas].
+class StripBatch {
+  StripBatch._(this.chunks, this.atlasPixels, this.atlasWidth,
+      this.atlasHeight, this.stripCount);
+
+  final List<ui.Vertices> chunks;
+  final Uint8List atlasPixels; // rgba8888, atlasWidth * atlasHeight * 4
+  final int atlasWidth;
+  final int atlasHeight;
+  final int stripCount;
+
+  /// Decoded alpha atlas; set by [decodeAtlas], disposed by [dispose].
+  ui.Image? atlas;
+
+  /// Snapshots [strips] (the generator reuses its buffers, so all data is
+  /// copied) into draw-ready form, or null when the buffer is empty.
+  ///
+  /// The per-strip color word is passed through to the vertex colors
+  /// unchanged and must therefore be straight (non-premultiplied) ARGB -
+  /// Skia premultiplies vertex colors before BlendMode.modulate multiplies
+  /// them with the shader's coverage.
+  static StripBatch? of(StripBuffer strips) {
+    final n = strips.length;
+    if (n == 0) return null;
+
+    final chunks = <ui.Vertices>[];
+    for (var start = 0; start < n; start += stripMaxQuadsPerDraw) {
+      final count =
+          (n - start) < stripMaxQuadsPerDraw ? (n - start) : stripMaxQuadsPerDraw;
+      final positions = Float32List(count * 8);
+      final texs = Float32List(count * 8);
+      final colors = Int32List(count * 4);
+      final indices = Uint16List(count * 6);
+      for (var k = 0; k < count; k++) {
+        final i = start + k;
+        final xy = strips.xy[i];
+        final x = (xy & 0xFFFF).toDouble();
+        final y = (xy >> 16).toDouble();
+        final wf = strips.widthFlags[i];
+        final w = (wf & 0xFFFF).toDouble();
+        final solid = wf & stripFlagSolid != 0;
+
+        final p = k * 8;
+        positions[p] = x;
+        positions[p + 1] = y;
+        positions[p + 2] = x + w;
+        positions[p + 3] = y;
+        positions[p + 4] = x;
+        positions[p + 5] = y + 4;
+        positions[p + 6] = x + w;
+        positions[p + 7] = y + 4;
+
+        // u: global texel index range; v: [0,4) mixed, [4,8) solid. Solid
+        // quads keep u in [0,w) so the (ignored) sample stays in-atlas.
+        final u0 = solid ? 0.0 : strips.alphaOffset[i].toDouble();
+        final u1 = u0 + w;
+        final v0 = solid ? 4.0 : 0.0;
+        final v1 = v0 + 4;
+        texs[p] = u0;
+        texs[p + 1] = v0;
+        texs[p + 2] = u1;
+        texs[p + 3] = v0;
+        texs[p + 4] = u0;
+        texs[p + 5] = v1;
+        texs[p + 6] = u1;
+        texs[p + 7] = v1;
+
+        final color = strips.color[i];
+        final c = k * 4;
+        colors[c] = color;
+        colors[c + 1] = color;
+        colors[c + 2] = color;
+        colors[c + 3] = color;
+
+        final vBase = k * 4;
+        final ix = k * 6;
+        indices[ix] = vBase;
+        indices[ix + 1] = vBase + 1;
+        indices[ix + 2] = vBase + 2;
+        indices[ix + 3] = vBase + 1;
+        indices[ix + 4] = vBase + 3;
+        indices[ix + 5] = vBase + 2;
+      }
+      chunks.add(ui.Vertices.raw(ui.VertexMode.triangles, positions,
+          textureCoordinates: texs, colors: colors, indices: indices));
+    }
+
+    // Alpha atlas: column texels row-major by global index, final row
+    // zero-padded. Always at least one texel so solid-only batches still
+    // have a valid sampler target.
+    final cols = strips.alphaColumns;
+    final rows = cols == 0 ? 1 : (cols + stripAtlasWidth - 1) ~/ stripAtlasWidth;
+    final pixels = Uint8List(stripAtlasWidth * rows * 4);
+    if (cols > 0) {
+      pixels.setRange(0, cols * 4, strips.alphas);
+    }
+    return StripBatch._(chunks, pixels, stripAtlasWidth, rows, n);
+  }
+
+  /// Decodes [atlasPixels] into the GPU-sampled [atlas] image. rgba8888
+  /// via decodeImageFromPixels is byte-exact (M0-verified); asynchronous,
+  /// so the strip device defers all drawing to its finish() replay.
+  Future<void> decodeAtlas() {
+    final completer = Completer<void>();
+    ui.decodeImageFromPixels(
+        atlasPixels, atlasWidth, atlasHeight, ui.PixelFormat.rgba8888,
+        (image) {
+      atlas = image;
+      completer.complete();
+    });
+    return completer.future;
+  }
+
+  void dispose() {
+    atlas?.dispose();
+    atlas = null;
+    for (final v in chunks) {
+      v.dispose();
+    }
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -1,0 +1,393 @@
+// Shader-driven strip rendering on stock dart:ui (Track B of the strip
+// experiment): solid fills, strokes, and embedded-outline text are
+// CPU-rasterized into sparse strips (pdf_graphics/raster.dart) and drawn
+// with ONE canvas.drawVertices per flush batch - a FragmentShader samples
+// per-column coverage from an rgba8888 alpha atlas and BlendMode.modulate
+// multiplies it with per-vertex colors (all M0-verified byte-accurate).
+// Everything else (images, gradients, meshes, substituted text, non-normal
+// blends, knockout groups) delegates to the ordinary CanvasPdfDevice.
+//
+// Because dart:ui has no synchronous pixels->ui.Image path, the device
+// records its work on a tape (strip batches interleaved with fallback
+// device ops in painter's order) during the synchronous interpreter walk
+// and paints everything in [finish], after the alpha atlases decode. Both
+// the batches and the fallback ops target the same canvas, so painter's
+// order is exactly the tape order.
+//
+// A strip picture is only valid at the pixel ratio it was recorded for:
+// the quads are device-pixel-aligned and the coverage was resolved at that
+// ratio (rescaling filters the strips like any raster).
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+
+import '../canvas_device.dart';
+import 'strip_batch.dart';
+
+/// Curve-flattening tolerance (device px) for strip-routed paths. The
+/// raster core's 0.25 default (the GPU experiment's) leaves curve edges up
+/// to 0.25 px off the true curve - against Skia's much finer flattening
+/// that showed up as 50/255 coverage diffs on glyph-sized cubics. 0.02 px
+/// keeps curve-edge parity within a few counts for ~3.5x the segment count
+/// on curves (Wang's n grows with 1/sqrt(tolerance)); lines are unaffected.
+const double stripFlattenTolerance = 0.02;
+
+/// [PdfDevice] that batches strip-rasterized paint into shader draws and
+/// routes everything else through an internal [CanvasPdfDevice] fallback.
+///
+/// Usage: construct per page, feed it a full interpreter walk, then
+/// `await finish()` before ending the picture recording; call [dispose]
+/// after `endRecording()` to release the atlas images.
+class StripPdfDevice implements PdfDevice {
+  StripPdfDevice(
+    this.canvas, {
+    required this.pageToDevice,
+    required this.deviceWidth,
+    required this.deviceHeight,
+    required this.pixelRatio,
+    this.images = const {},
+  }) : _deviceToPage = _invertToMatrix4(pageToDevice) {
+    _generator.begin(deviceWidth, deviceHeight);
+  }
+
+  final ui.Canvas canvas;
+
+  /// Page space (PDF user space, y-up) -> device pixels (y-down), including
+  /// /Rotate and [pixelRatio]. Must match the canvas transform in effect
+  /// when [finish] paints, or the strips land off the page.
+  final PdfMatrix pageToDevice;
+
+  final int deviceWidth;
+  final int deviceHeight;
+
+  /// The ratio baked into [pageToDevice]; recorded strips are only valid at
+  /// this ratio.
+  final double pixelRatio;
+
+  /// Pre-decoded images for the fallback device (same map as
+  /// [CanvasPdfDevice.images]).
+  final Map<Object, ui.Image> images;
+
+  final StripGenerator _generator = StripGenerator();
+  final Float64List _deviceToPage;
+
+  /// Painter's-order tape: [StripBatch]es interleaved with fallback ops.
+  final List<Object> _tape = [];
+  final List<StripBatch> _batches = [];
+
+  PdfBlendMode _blend = PdfBlendMode.normal;
+  final List<bool> _groupKnockout = [];
+  final List<bool> _savedClip = [];
+  bool _finished = false;
+
+  // ---- stats (aggregated across devices for the benchmark) --------------
+  static int totalFlushes = 0;
+  static int totalStripQuads = 0;
+  static int totalAtlasTexels = 0;
+  static int totalDelegatedPaints = 0;
+
+  /// Phase timing (microseconds), aggregated across devices: time awaiting
+  /// alpha-atlas decodes vs replaying the tape (drawVertices + fallback
+  /// ops). The interpret+strip-generation and toImage phases are timed by
+  /// the renderer (see PdfPageRenderer profiling statics).
+  static int totalAtlasDecodeMicros = 0;
+  static int totalReplayMicros = 0;
+
+  static void resetStats() {
+    totalFlushes = 0;
+    totalStripQuads = 0;
+    totalAtlasTexels = 0;
+    totalDelegatedPaints = 0;
+    totalAtlasDecodeMicros = 0;
+    totalReplayMicros = 0;
+  }
+
+  int get flushCount => _batches.length;
+
+  static Future<ui.FragmentProgram>? _programFuture;
+
+  static Future<ui.FragmentProgram> _loadProgram() =>
+      _programFuture ??= () async {
+        try {
+          return await ui.FragmentProgram.fromAsset('shaders/pdf_strips.frag');
+        } catch (_) {
+          return ui.FragmentProgram.fromAsset(
+              'packages/dart_pdf_editor/shaders/pdf_strips.frag');
+        }
+      }();
+
+  /// Debug: route every paint through the fallback (no strips at all) to
+  /// isolate tape/pipeline effects from strip rasterization quality.
+  static bool debugDelegateAll = false;
+
+  /// Debug: per-primitive fallback routing, for parity bisection.
+  static bool debugDelegateFills = false;
+  static bool debugDelegateStrokes = false;
+  static bool debugDelegateText = false;
+
+  /// Whether paint ops may take the strip path right now: normal blend and
+  /// not directly inside a knockout group (knockout elements composite with
+  /// BlendMode.src, which the batched srcOver quads can't express).
+  bool get _stripsActive =>
+      !debugDelegateAll &&
+      _blend == PdfBlendMode.normal &&
+      (_groupKnockout.isEmpty || !_groupKnockout.last);
+
+  /// Straight (non-premultiplied) ARGB for ui.Vertices colors; Skia
+  /// premultiplies before BlendMode.modulate applies the coverage.
+  static int _argb(PdfColor color, double alpha) {
+    int ch(double v) {
+      final c = v < 0 ? 0.0 : (v > 1 ? 1.0 : v);
+      return (c * 255 + 0.5).toInt();
+    }
+
+    return (ch(alpha) << 24) |
+        (ch(color.red) << 16) |
+        (ch(color.green) << 8) |
+        ch(color.blue);
+  }
+
+  void _flush() {
+    final batch = StripBatch.of(_generator.strips);
+    if (batch == null) return;
+    _generator.strips.reset();
+    _tape.add(batch);
+    _batches.add(batch);
+    totalFlushes++;
+    totalStripQuads += batch.stripCount;
+    totalAtlasTexels += batch.atlasWidth * batch.atlasHeight;
+  }
+
+  /// Records a fallback op that paints: pending strips must land first.
+  void _delegatePaint(void Function(CanvasPdfDevice d) op) {
+    _flush();
+    totalDelegatedPaints++;
+    _tape.add(op);
+  }
+
+  /// Records a fallback op that only mutates state (no pixels).
+  void _state(void Function(CanvasPdfDevice d) op) => _tape.add(op);
+
+  // ---- PdfDevice --------------------------------------------------------
+
+  @override
+  void save() {
+    _savedClip.add(false);
+    _state((d) => d.save());
+  }
+
+  @override
+  void restore() {
+    // Strips batched under a clip must draw before the restore pops it.
+    if (_savedClip.isNotEmpty && _savedClip.removeLast()) _flush();
+    _state((d) => d.restore());
+  }
+
+  @override
+  void clipPath(PdfPath path, PdfFillRule rule) {
+    _flush(); // strips batched before the clip must not be clipped by it
+    if (_savedClip.isNotEmpty) _savedClip[_savedClip.length - 1] = true;
+    _state((d) => d.clipPath(path, rule));
+  }
+
+  @override
+  void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {
+    if (!_stripsActive || debugDelegateFills) {
+      _delegatePaint((d) => d.fillPath(path, color, rule, alpha));
+      return;
+    }
+    _generator.fillPath(path, pageToDevice, rule, _argb(color, alpha),
+        tolerance: stripFlattenTolerance);
+  }
+
+  @override
+  void strokePath(
+      PdfPath path, PdfColor color, PdfStroke stroke, double alpha) {
+    if (!_stripsActive || debugDelegateStrokes) {
+      _delegatePaint((d) => d.strokePath(path, color, stroke, alpha));
+      return;
+    }
+    // Skia renders strokes thinner than one device pixel as a 1-px hairline
+    // with the alpha modulated by the width (not a true sub-pixel band);
+    // match it so thin CAD/print linework is parity-identical.
+    var deviceStroke = stroke;
+    var a = alpha;
+    final sf = pageToDevice.scaleFactor;
+    final deviceWidth = stroke.width * sf;
+    if (deviceWidth < 1 && sf > 0) {
+      deviceStroke = stroke.copyWith(width: 1 / sf);
+      if (deviceWidth > 0) a *= deviceWidth;
+    }
+    _generator.strokePath(path, pageToDevice, deviceStroke, _argb(color, a),
+        tolerance: stripFlattenTolerance);
+  }
+
+  @override
+  void fillPathGradient(
+      PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) {
+    _delegatePaint((d) => d.fillPathGradient(path, rule, gradient, alpha));
+  }
+
+  @override
+  void fillMesh(PdfMesh mesh, double alpha) {
+    _delegatePaint((d) => d.fillMesh(mesh, alpha));
+  }
+
+  @override
+  void drawText(PdfTextRun run) {
+    if (run.invisible) return;
+    final glyphs = run.glyphs;
+    if (!_stripsActive ||
+        debugDelegateText ||
+        glyphs == null ||
+        !run.fill ||
+        run.strokeColor != null ||
+        run.gradient != null) {
+      // substituted-font runs, stroked/gradient text, knockout/blended runs
+      _delegatePaint((d) => d.drawText(run));
+      return;
+    }
+    final color = _argb(run.color, 1);
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline == null) continue;
+      final emToDevice = PdfMatrix.translation(glyph.offset, glyph.offsetY)
+          .concat(run.transform)
+          .concat(pageToDevice);
+      _generator.fillOutline(FlattenedOutline.of(outline), emToDevice, color);
+    }
+  }
+
+  @override
+  void drawImage(PdfImageRequest request) {
+    _delegatePaint((d) => d.drawImage(request));
+  }
+
+  @override
+  void setBlendMode(PdfBlendMode mode) {
+    _blend = mode;
+    _state((d) => d.setBlendMode(mode));
+  }
+
+  @override
+  void beginGroup(double alpha, {bool knockout = false}) {
+    _flush(); // the group's layer must not capture earlier strips
+    _groupKnockout.add(knockout);
+    _state((d) => d.beginGroup(alpha, knockout: knockout));
+  }
+
+  @override
+  void endGroup() {
+    _flush(); // strips inside the group must land inside its layer
+    if (_groupKnockout.isNotEmpty) _groupKnockout.removeLast();
+    _state((d) => d.endGroup());
+  }
+
+  @override
+  void beginSoftMasked() {
+    _flush(); // earlier strips must not be captured by the content layer
+    _groupKnockout.add(false);
+    _state((d) => d.beginSoftMasked());
+  }
+
+  @override
+  void endSoftMasked({
+    required bool luminosity,
+    required PdfRect backdrop,
+    required void Function() drawMask,
+    double backdropLuminance = 0,
+    double transferScale = 1,
+    double transferOffset = 0,
+  }) {
+    _flush(); // masked content strips land inside the content layer
+    if (_groupKnockout.isNotEmpty) _groupKnockout.removeLast();
+    _state((d) => d.beginSoftMaskComposite(
+        luminosity: luminosity,
+        backdrop: backdrop,
+        backdropLuminance: backdropLuminance,
+        transferScale: transferScale,
+        transferOffset: transferOffset));
+    // The mask group's draws happen NOW (interpret time) and append to the
+    // tape between the composite halves - the fallback's own endSoftMasked
+    // would re-run them at replay time instead.
+    drawMask();
+    _flush();
+    _state((d) => d.finishSoftMaskComposite());
+  }
+
+  // ---- painting ---------------------------------------------------------
+
+  /// Decodes every batch's alpha atlas, then replays the tape onto
+  /// [canvas]: fallback ops drive a real [CanvasPdfDevice], strip batches
+  /// draw as shader-carrying drawVertices under the device->page transform.
+  /// Await before `endRecording()`; the device is unusable afterwards.
+  Future<void> finish() async {
+    assert(!_finished, 'StripPdfDevice.finish() called twice');
+    _finished = true;
+    _flush();
+    final sw = Stopwatch()..start();
+    final program = await _loadProgram();
+    await Future.wait([for (final b in _batches) b.decodeAtlas()]);
+    totalAtlasDecodeMicros += sw.elapsedMicroseconds;
+
+    sw.reset();
+    final fallback = CanvasPdfDevice(canvas, images: images);
+    for (final entry in _tape) {
+      if (entry is StripBatch) {
+        _drawBatch(program, entry);
+      } else {
+        (entry as void Function(CanvasPdfDevice))(fallback);
+      }
+    }
+    totalReplayMicros += sw.elapsedMicroseconds;
+  }
+
+  /// Releases the decoded atlas images and vertex buffers. Call after the
+  /// recording that [finish] painted into has ended (the picture keeps its
+  /// own references).
+  void dispose() {
+    for (final b in _batches) {
+      b.dispose();
+    }
+  }
+
+  /// Debug/benchmark: draw batches with a plain paint instead of the
+  /// coverage shader (wrong output - quantifies the runtime-effect cost of
+  /// software rasterization).
+  static bool debugNoShader = false;
+
+  void _drawBatch(ui.FragmentProgram program, StripBatch batch) {
+    final paint = ui.Paint();
+    if (!debugNoShader) {
+      paint.shader = program.fragmentShader()
+        ..setFloat(0, batch.atlasWidth.toDouble())
+        ..setFloat(1, batch.atlasHeight.toDouble())
+        ..setImageSampler(0, batch.atlas!);
+    }
+    canvas.save();
+    canvas.transform(_deviceToPage);
+    for (final chunk in batch.chunks) {
+      // no-shader mode draws the vertex colors directly (wrong coverage,
+      // representative triangle-raster cost)
+      canvas.drawVertices(chunk,
+          debugNoShader ? ui.BlendMode.srcOver : ui.BlendMode.modulate, paint);
+    }
+    canvas.restore();
+  }
+
+  static Float64List _invertToMatrix4(PdfMatrix pageToDevice) {
+    final inv = pageToDevice.inverted();
+    if (inv == null) {
+      throw ArgumentError('pageToDevice transform is degenerate');
+    }
+    return Float64List.fromList([
+      inv.a, inv.b, 0, 0, //
+      inv.c, inv.d, 0, 0, //
+      0, 0, 1, 0, //
+      inv.e, inv.f, 0, 1,
+    ]);
+  }
+}

--- a/packages/dart_pdf_editor/lib/strips.dart
+++ b/packages/dart_pdf_editor/lib/strips.dart
@@ -1,0 +1,9 @@
+/// Sparse-strip shader rendering: [StripPdfDevice] batches solid fills,
+/// strokes, and outline text into drawVertices + FragmentShader draws;
+/// everything else delegates to the canvas device in painter's order.
+/// Not exported from the main dart_pdf_editor barrel - the device wins on
+/// GPU backends (Impeller) but loses on software Skia, so hosts opt in.
+library;
+
+export 'src/strips/strip_batch.dart';
+export 'src/strips/strip_device.dart';

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -46,6 +46,13 @@ flutter:
   # Bundled fonts offered by the font menu. DejaVu is a permissive
   # Bitstream Vera / Arev licence; Fira Sans, Spectral and Lobster are
   # SIL Open Font Licence - see the *-LICENSE.txt files in assets/fonts/.
+  # Runtime fragment shaders for the sparse-strip render device (see
+  # doc/dev-log). flutter_tools compiles these per target; keep them
+  # inside the SkSL-safe subset (no dynamic loop bounds, bit ops,
+  # texelFetch).
+  shaders:
+    - shaders/pdf_probe.frag
+    - shaders/pdf_strips.frag
   assets:
     - assets/web/pdf_render_worker.dart.js
     - assets/fonts/DejaVuSans.ttf

--- a/packages/dart_pdf_editor/shaders/pdf_probe.frag
+++ b/packages/dart_pdf_editor/shaders/pdf_probe.frag
@@ -1,0 +1,43 @@
+#version 460 core
+
+// M0 feasibility probe for strip rendering (see doc/dev-log).
+// Answers, per backend:
+//   mode 0 - which coordinate space a runtime effect is evaluated in when
+//            drawn through canvas.drawVertices (positions vs texcoords).
+//   mode 1 - whether nearest-sampled texture() at half-texel centers reads
+//            exact texels from an rgba8888 data texture.
+//   mode 2 - RGBA channel select via a step-mask dot product (the SkSL-safe
+//            replacement for bit ops the strip shader will use).
+// Keep this inside the SkSL subset: no dynamic loop bounds, no bit ops,
+// no texelFetch (texelFetch also aborts impellerc's GLES2 stage).
+
+precision highp float;
+
+#include <flutter/runtime_effect.glsl>
+
+uniform vec2 uTexSize; // data texture size in texels
+uniform vec2 uMode;    // x: probe mode 0/1/2, y: channel row for mode 2
+uniform sampler2D uData;
+
+out vec4 fragColor;
+
+void main() {
+  vec2 p = FlutterFragCoord().xy;
+  if (uMode.x < 0.5) {
+    // Echo the evaluation-space coordinate into R/G.
+    fragColor = vec4(p.x / 255.0, p.y / 255.0, 0.0, 1.0);
+  } else if (uMode.x < 1.5) {
+    // Exact-texel read addressed by the evaluation-space coordinate.
+    vec2 ij = floor(p);
+    fragColor = texture(uData, (ij + 0.5) / uTexSize);
+  } else {
+    // Channel select: row 0..3 picks R/G/B/A as a coverage scalar.
+    vec2 ij = floor(p);
+    vec4 texel = texture(uData, (ij + 0.5) / uTexSize);
+    float row = uMode.y;
+    vec4 mask = vec4(step(abs(row - 0.0), 0.5), step(abs(row - 1.0), 0.5),
+                     step(abs(row - 2.0), 0.5), step(abs(row - 3.0), 0.5));
+    float cov = dot(texel, mask);
+    fragColor = vec4(cov, cov, cov, 1.0);
+  }
+}

--- a/packages/dart_pdf_editor/shaders/pdf_strips.frag
+++ b/packages/dart_pdf_editor/shaders/pdf_strips.frag
@@ -1,0 +1,47 @@
+#version 460 core
+
+// Sparse-strip coverage shader (Track B). One canvas.drawVertices call
+// draws every strip quad of a flush batch; this shader turns each fragment
+// into a coverage scalar and BlendMode.modulate multiplies it with the
+// quad's per-vertex color (M0 verified byte-accuracy of the whole chain on
+// both backends, and that the shader is evaluated in TEXCOORD space).
+//
+// Texcoord contract (see strip_batch.dart):
+//   u: global alpha-texel index - interpolates alphaOffset .. alphaOffset+w
+//      left to right across a mixed strip. Fragment centers land at
+//      index + 0.5, so floor(u) is the exact column texel index. The atlas
+//      is row-major by that index: texel t sits at (mod(t, atlasW),
+//      floor(t / atlasW)).
+//   v: local strip row - [0,4) for mixed strips (floor(v) = scanline 0..3
+//      selecting the R/G/B/A coverage channel via the step-mask dot, the
+//      SkSL-safe replacement for bit ops), [4,8) for solid strips
+//      (coverage 1, sampled texel ignored; solid quads carry u in [0,w) so
+//      the dead sample still lands inside the atlas).
+//
+// Keep inside the SkSL subset: no loops, no bit ops, no texelFetch
+// (texelFetch aborts impellerc's GLES2 stage).
+
+precision highp float;
+
+#include <flutter/runtime_effect.glsl>
+
+uniform vec2 uAtlasSize; // alpha atlas size in texels
+uniform sampler2D uAtlas;
+
+out vec4 fragColor;
+
+void main() {
+  vec2 uv = FlutterFragCoord().xy; // texcoord space per the M0 probe
+  float solid = step(4.0, uv.y);
+  float t = floor(uv.x);
+  float ax = mod(t, uAtlasSize.x);
+  float ay = floor(t / uAtlasSize.x);
+  vec4 texel = texture(uAtlas, (vec2(ax, ay) + 0.5) / uAtlasSize);
+  float row = floor(uv.y) - 4.0 * solid; // scanline 0..3 within the strip
+  vec4 mask = vec4(step(abs(row - 0.0), 0.5), step(abs(row - 1.0), 0.5),
+                   step(abs(row - 2.0), 0.5), step(abs(row - 3.0), 0.5));
+  float cov = mix(dot(texel, mask), 1.0, solid);
+  // Premultiplied white x coverage; vertex colors supply the paint color
+  // through BlendMode.modulate.
+  fragColor = vec4(cov);
+}

--- a/packages/dart_pdf_editor/test/benchmark_strip_render_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_strip_render_test.dart
@@ -1,0 +1,198 @@
+// Benchmarks full page rasterization through the experimental strip shader
+// device (interpret + strip-generate + atlas decode + tape replay +
+// toImage) - the Track B counterpart of benchmark_render_test.dart, same
+// JSON schema, engine "dart-pdf-strips". Skips unless PDF_BENCHMARK_DIR is
+// set:
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_DIR=../../test_corpora/pdfjs \
+//   PDF_BENCHMARK_SCALE=2 PDF_BENCHMARK_MAX_PAGES=10 \
+//   PDF_BENCHMARK_OUT=../../benchmark/out/dart-strips.json \
+//     fvm flutter test test/benchmark_strip_render_test.dart
+//
+// Besides the shared schema it reports strip statistics (flushes/page,
+// strip quads/page, alpha atlas KB/page, delegated paints/page) and the
+// phase split (interpret+stripgen / atlas decode / tape replay / raster)
+// as a top-level `stripStats` object plus a printed summary.
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+void main() {
+  final dir = Platform.environment['PDF_BENCHMARK_DIR'];
+  final scale =
+      double.tryParse(Platform.environment['PDF_BENCHMARK_SCALE'] ?? '') ?? 2.0;
+  final maxPages =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_MAX_PAGES'] ?? '') ?? 10;
+  final repeat =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_REPEAT'] ?? '') ?? 1;
+  final outPath = Platform.environment['PDF_BENCHMARK_OUT'];
+
+  testWidgets('benchmarks strip-device rasterization', (tester) async {
+    if (dir == null) {
+      markTestSkipped('set PDF_BENCHMARK_DIR to run the strip benchmark');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      PdfPageRenderer.deviceMode = PdfRenderDeviceMode.strips;
+      StripPdfDevice.debugNoShader =
+          Platform.environment['STRIP_BENCH_NO_SHADER'] == '1';
+      try {
+        final corpus = Directory(dir);
+        final files = corpus
+            .listSync(recursive: true)
+            .whereType<File>()
+            .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+            .toList()
+          ..sort((a, b) => a.path.compareTo(b.path));
+
+        final root =
+            corpus.path.endsWith('/') ? corpus.path : '${corpus.path}/';
+        final best = <String, Map<String, Object?>>{};
+
+        for (var r = 0; r < repeat; r++) {
+          // stats reflect the final pass (counters are process-global)
+          StripPdfDevice.resetStats();
+          PdfPageRenderer.stripInterpretMicros = 0;
+          PdfPageRenderer.stripRasterMicros = 0;
+          for (final file in files) {
+            final name = file.path.startsWith(root)
+                ? file.path.substring(root.length)
+                : file.uri.pathSegments.last;
+            final res = await _benchFile(file, scale, maxPages, name);
+            final prev = best[file.path];
+            final better = prev == null ||
+                (res['error'] == null &&
+                    (prev['error'] != null ||
+                        (res['renderMs'] as double) <
+                            (prev['renderMs'] as double)));
+            if (better) best[file.path] = res;
+          }
+          // ignore: avoid_print
+          print('  dart-strips pass ${r + 1}/$repeat done '
+              '(${files.length} files)');
+        }
+
+        var pages = 0;
+        var renderMs = 0.0;
+        for (final f in files) {
+          final r = best[f.path]!;
+          if (r['error'] != null) continue;
+          pages += r['pagesRendered'] as int;
+          renderMs += r['renderMs'] as double;
+        }
+        final stripStats = {
+          'pages': pages,
+          'renderMsPerPage': pages == 0
+              ? null
+              : double.parse((renderMs / pages).toStringAsFixed(2)),
+          'flushesPerPage':
+              pages == 0 ? null : StripPdfDevice.totalFlushes / pages,
+          'stripQuadsPerPage':
+              pages == 0 ? null : StripPdfDevice.totalStripQuads ~/ pages,
+          'atlasKBPerPage': pages == 0
+              ? null
+              : StripPdfDevice.totalAtlasTexels * 4 ~/ 1024 ~/ pages,
+          'delegatedPaintsPerPage':
+              pages == 0 ? null : StripPdfDevice.totalDelegatedPaints ~/ pages,
+          'interpretStripGenMsPerPage': pages == 0
+              ? null
+              : PdfPageRenderer.stripInterpretMicros / 1000 / pages,
+          'atlasDecodeMsPerPage': pages == 0
+              ? null
+              : StripPdfDevice.totalAtlasDecodeMicros / 1000 / pages,
+          'tapeReplayMsPerPage': pages == 0
+              ? null
+              : StripPdfDevice.totalReplayMicros / 1000 / pages,
+          'rasterMsPerPage': pages == 0
+              ? null
+              : PdfPageRenderer.stripRasterMicros / 1000 / pages,
+        };
+        // ignore: avoid_print
+        print('  strip stats: $stripStats');
+
+        final payload = {
+          'tool': 'dart-pdf-strips-render',
+          'scale': scale,
+          'maxPages': maxPages,
+          'engine': 'dart-pdf-strips (StripPdfDevice: drawVertices + '
+              'FragmentShader strips, canvas fallback)',
+          'stripStats': stripStats,
+          'results': [for (final f in files) best[f.path]],
+        };
+        final text = const JsonEncoder.withIndent('  ').convert(payload);
+        if (outPath != null) {
+          File(outPath)
+            ..parent.createSync(recursive: true)
+            ..writeAsStringSync(text);
+          // ignore: avoid_print
+          print('wrote $outPath');
+        } else {
+          // ignore: avoid_print
+          print(text);
+        }
+      } finally {
+        PdfPageRenderer.deviceMode = PdfRenderDeviceMode.canvas;
+        StripPdfDevice.debugNoShader = false;
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 60)));
+}
+
+Future<Map<String, Object?>> _benchFile(
+    File file, double scale, int maxPages, String name) async {
+  final bytes = file.readAsBytesSync();
+  final sw = Stopwatch()..start();
+  PdfDocument doc;
+  int pages;
+  try {
+    doc = PdfDocument.open(bytes);
+    pages = doc.pageCount;
+  } catch (e) {
+    return {
+      'file': name,
+      'pages': 0,
+      'pagesRendered': 0,
+      'openMs': sw.elapsedMicroseconds / 1000,
+      'renderMs': 0.0,
+      'error': e.toString(),
+    };
+  }
+  final openMs = sw.elapsedMicroseconds / 1000;
+
+  final limit = maxPages <= 0 ? pages : (pages < maxPages ? pages : maxPages);
+  var rendered = 0;
+  String? error;
+  final walk = Stopwatch()..start();
+  for (var i = 0; i < limit; i++) {
+    try {
+      final image = await PdfPageRenderer.renderImage(doc.page(i),
+              pixelRatio: scale)
+          .timeout(const Duration(seconds: 60));
+      // Force the readback so rasterization is fully realized, then free it.
+      await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      image.dispose();
+      rendered++;
+    } catch (e) {
+      error ??= 'page $i: $e';
+    }
+  }
+  walk.stop();
+  return {
+    'file': name,
+    'pages': pages,
+    'pagesRendered': rendered,
+    'openMs': double.parse(openMs.toStringAsFixed(3)),
+    'renderMs':
+        double.parse((walk.elapsedMicroseconds / 1000).toStringAsFixed(3)),
+    'error': error,
+  };
+}

--- a/packages/dart_pdf_editor/test/strip_curve_probe_test.dart
+++ b/packages/dart_pdf_editor/test/strip_curve_probe_test.dart
@@ -13,16 +13,19 @@ void main() {
       (tester) async {
     await tester.runAsync(() async {
       const w = 32, h = 32;
-      // glyph-ish bowl in em units (0..1), drawn at a 24-px em
+      // glyph-ish bowl in em units (0..1), drawn at a 24-px em. The first
+      // point sits at 0.125 em = 3.0 px so the fill path's anchor lands on
+      // the shape cache's 1/4-px quantization grid (see below).
       final em = PdfPath([
-        PdfMoveTo(0.1, 0.1),
+        PdfMoveTo(0.125, 0.125),
         PdfCubicTo(0.1, 0.9, 0.5, 1.0, 0.9, 0.55),
-        PdfCubicTo(0.8, 0.2, 0.4, 0.05, 0.1, 0.1),
+        PdfCubicTo(0.8, 0.2, 0.4, 0.05, 0.125, 0.125),
         const PdfClosePath(),
       ]);
-      // translation on the glyph cache's 1/4-px quantization grid so the
-      // em-cached path (which quantizes subpixel offsets) rasters at
-      // exactly this transform
+      // translation on the strip caches' 1/4-px quantization grid so both
+      // memoized paths raster at exactly this transform: the glyph cache
+      // quantizes the matrix offset (4.25, 3.75), the shape cache the
+      // transformed first point (7.25, 6.75)
       const emToDev = PdfMatrix(24, 0, 0, 24, 4.25, 3.75);
 
       Future<Uint8List> raster(void Function(ui.Canvas) draw) async {
@@ -40,9 +43,9 @@ void main() {
       }
 
       final skia = await raster((canvas) {
-        final path = ui.Path()..moveTo(0.1, 0.1);
+        final path = ui.Path()..moveTo(0.125, 0.125);
         path.cubicTo(0.1, 0.9, 0.5, 1.0, 0.9, 0.55);
-        path.cubicTo(0.8, 0.2, 0.4, 0.05, 0.1, 0.1);
+        path.cubicTo(0.8, 0.2, 0.4, 0.05, 0.125, 0.125);
         path.close();
         canvas.save();
         canvas.translate(4.25, 3.75);

--- a/packages/dart_pdf_editor/test/strip_curve_probe_test.dart
+++ b/packages/dart_pdf_editor/test/strip_curve_probe_test.dart
@@ -1,0 +1,184 @@
+// Probe: cubic-curve fill parity, strips vs Skia drawPath, at glyph-like
+// sizes - direct fillPath and the em-space cached fillOutline path.
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+void main() {
+  testWidgets('cubic blob: skia vs strips (direct + em-cached)',
+      (tester) async {
+    await tester.runAsync(() async {
+      const w = 32, h = 32;
+      // glyph-ish bowl in em units (0..1), drawn at a 24-px em
+      final em = PdfPath([
+        PdfMoveTo(0.1, 0.1),
+        PdfCubicTo(0.1, 0.9, 0.5, 1.0, 0.9, 0.55),
+        PdfCubicTo(0.8, 0.2, 0.4, 0.05, 0.1, 0.1),
+        const PdfClosePath(),
+      ]);
+      // translation on the glyph cache's 1/4-px quantization grid so the
+      // em-cached path (which quantizes subpixel offsets) rasters at
+      // exactly this transform
+      const emToDev = PdfMatrix(24, 0, 0, 24, 4.25, 3.75);
+
+      Future<Uint8List> raster(void Function(ui.Canvas) draw) async {
+        final rec = ui.PictureRecorder();
+        final canvas = ui.Canvas(rec);
+        canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 32, 32),
+            ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+        draw(canvas);
+        final pic = rec.endRecording();
+        final img = await pic.toImage(w, h);
+        final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+        img.dispose();
+        pic.dispose();
+        return data!.buffer.asUint8List();
+      }
+
+      final skia = await raster((canvas) {
+        final path = ui.Path()..moveTo(0.1, 0.1);
+        path.cubicTo(0.1, 0.9, 0.5, 1.0, 0.9, 0.55);
+        path.cubicTo(0.8, 0.2, 0.4, 0.05, 0.1, 0.1);
+        path.close();
+        canvas.save();
+        canvas.translate(4.25, 3.75);
+        canvas.scale(24, 24);
+        canvas.drawPath(path, ui.Paint()..color = const ui.Color(0xFF000000));
+        canvas.restore();
+      });
+
+      Future<Uint8List> viaDevice(void Function(StripPdfDevice) draw) async {
+        final rec = ui.PictureRecorder();
+        final canvas = ui.Canvas(rec);
+        canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 32, 32),
+            ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+        final d = StripPdfDevice(canvas,
+            pageToDevice: PdfMatrix.identity,
+            deviceWidth: w,
+            deviceHeight: h,
+            pixelRatio: 1);
+        draw(d);
+        await d.finish();
+        final pic = rec.endRecording();
+        final img = await pic.toImage(w, h);
+        final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+        img.dispose();
+        pic.dispose();
+        d.dispose();
+        return data!.buffer.asUint8List();
+      }
+
+      // direct fillPath: flattened in device space at 0.25 px (device path
+      // takes page-space geometry; pageToDevice is identity here, so map
+      // the em outline through emToDev by hand)
+      PdfPathSegment tx(PdfPathSegment s) => switch (s) {
+            PdfMoveTo(:final x, :final y) => PdfMoveTo(
+                emToDev.transformX(x, y), emToDev.transformY(x, y)),
+            PdfLineTo(:final x, :final y) => PdfLineTo(
+                emToDev.transformX(x, y), emToDev.transformY(x, y)),
+            PdfCubicTo() => PdfCubicTo(
+                emToDev.transformX(s.x1, s.y1),
+                emToDev.transformY(s.x1, s.y1),
+                emToDev.transformX(s.x2, s.y2),
+                emToDev.transformY(s.x2, s.y2),
+                emToDev.transformX(s.x3, s.y3),
+                emToDev.transformY(s.x3, s.y3)),
+            PdfClosePath() => s,
+          };
+      final devPath = PdfPath([for (final s in em.segments) tx(s)]);
+      final direct = await viaDevice((d) =>
+          d.fillPath(devPath, PdfColor.black, PdfFillRule.nonzero, 1));
+      // em-cached glyph path
+      final gen = StripGenerator()..begin(w, h);
+      final cachedBytes = await (() async {
+        final rec = ui.PictureRecorder();
+        final canvas = ui.Canvas(rec);
+        canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 32, 32),
+            ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+        final d = StripPdfDevice(canvas,
+            pageToDevice: PdfMatrix.identity,
+            deviceWidth: w,
+            deviceHeight: h,
+            pixelRatio: 1);
+        d.drawText(PdfTextRun(
+          text: 'x',
+          transform: emToDev,
+          color: PdfColor.black,
+          width: 1,
+          glyphs: [PdfGlyphPlacement(offset: 0, outline: em)],
+        ));
+        await d.finish();
+        final pic = rec.endRecording();
+        final img = await pic.toImage(w, h);
+        final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+        img.dispose();
+        pic.dispose();
+        d.dispose();
+        return data!.buffer.asUint8List();
+      })();
+      gen.begin(1, 1); // silence unused warning path
+
+      var maxDirect = 0, maxCached = 0;
+      int worstX = 0, worstY = 0;
+      for (var i = 0; i < w * h; i++) {
+        final dd = (skia[i * 4] - direct[i * 4]).abs();
+        final dc = (skia[i * 4] - cachedBytes[i * 4]).abs();
+        if (dd > maxDirect) maxDirect = dd;
+        if (dc > maxCached) {
+          maxCached = dc;
+          worstX = i % w;
+          worstY = i ~/ w;
+        }
+      }
+      // ignore: avoid_print
+      print('CURVE: max|skia-direct|=$maxDirect max|skia-emcached|=$maxCached '
+          'worst cached at ($worstX,$worstY): skia=${skia[(worstY * w + worstX) * 4]} '
+          'cached=${cachedBytes[(worstY * w + worstX) * 4]}');
+
+      // analytic ground truth at the worst pixel: dense flatten + winding
+      final fine = flattenPath(devPath, PdfMatrix.identity, tolerance: 1e-4);
+      final ring = fine[0].points;
+      double coverage(int px, int py) {
+        var inside = 0;
+        const ss = 64;
+        for (var sy = 0; sy < ss; sy++) {
+          for (var sx = 0; sx < ss; sx++) {
+            final x = px + (sx + 0.5) / ss, y = py + (sy + 0.5) / ss;
+            var wind = 0;
+            final n = ring.length ~/ 2;
+            for (var i = 0, j = n - 1; i < n; j = i++) {
+              final y0 = ring[2 * j + 1], y1 = ring[2 * i + 1];
+              if ((y0 > y) == (y1 > y)) continue;
+              final x0 = ring[2 * j], x1 = ring[2 * i];
+              final xc = x0 + (y - y0) * (x1 - x0) / (y1 - y0);
+              if (xc > x) wind += y1 > y0 ? 1 : -1;
+            }
+            if (wind != 0) inside++;
+          }
+        }
+        return inside / (ss * ss);
+      }
+
+      for (final (px, py) in [(worstX, worstY), (13, 6), (10, 25)]) {
+        final want = (255 * (1 - coverage(px, py))).round();
+        // ignore: avoid_print
+        print('CURVE-GT: ($px,$py) analytic=$want '
+            'skia=${skia[(py * w + px) * 4]} direct=${direct[(py * w + px) * 4]} '
+            'cached=${cachedBytes[(py * w + px) * 4]}');
+        // The strip raster must track the true curve area; Skia's own
+        // deviation here (~58 counts at the worst pixel when measured) is
+        // exactly why the parity gate classifies curve edges - do NOT
+        // assert on Skia.
+        expect((direct[(py * w + px) * 4] - want).abs(), lessThanOrEqualTo(4),
+            reason: 'direct strip coverage vs analytic at ($px,$py)');
+        expect((cachedBytes[(py * w + px) * 4] - want).abs(),
+            lessThanOrEqualTo(4),
+            reason: 'em-cached strip coverage vs analytic at ($px,$py)');
+      }
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/strip_debug_test.dart
+++ b/packages/dart_pdf_editor/test/strip_debug_test.dart
@@ -1,0 +1,87 @@
+// Scratch debug harness for the strip device (not part of the suite):
+// renders STRIP_DEBUG_PDF page STRIP_DEBUG_PAGE through both devices and
+// writes canvas/strips/diff PNGs to STRIP_DEBUG_OUT. Skips unless set.
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+void main() {
+  final pdf = Platform.environment['STRIP_DEBUG_PDF'];
+  final page = int.tryParse(Platform.environment['STRIP_DEBUG_PAGE'] ?? '0')!;
+  final out = Platform.environment['STRIP_DEBUG_OUT'] ?? '/tmp';
+  final ratio =
+      double.tryParse(Platform.environment['STRIP_DEBUG_RATIO'] ?? '2')!;
+
+  testWidgets('strip debug dump', (tester) async {
+    if (pdf == null) {
+      markTestSkipped('set STRIP_DEBUG_PDF');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final doc = PdfDocument.open(File(pdf).readAsBytesSync());
+      PdfPageRenderer.deviceMode = PdfRenderDeviceMode.canvas;
+      final a =
+          await PdfPageRenderer.renderImage(doc.page(page), pixelRatio: ratio);
+      PdfPageRenderer.deviceMode = PdfRenderDeviceMode.strips;
+      StripPdfDevice.debugDelegateAll =
+          Platform.environment['STRIP_DEBUG_DELEGATE_ALL'] == '1';
+      StripPdfDevice.debugDelegateFills =
+          Platform.environment['STRIP_DEBUG_DELEGATE_FILLS'] == '1';
+      StripPdfDevice.debugDelegateStrokes =
+          Platform.environment['STRIP_DEBUG_DELEGATE_STROKES'] == '1';
+      StripPdfDevice.debugDelegateText =
+          Platform.environment['STRIP_DEBUG_DELEGATE_TEXT'] == '1';
+      final b =
+          await PdfPageRenderer.renderImage(doc.page(page), pixelRatio: ratio);
+      PdfPageRenderer.deviceMode = PdfRenderDeviceMode.canvas;
+
+      Future<void> save(ui.Image img, String name) async {
+        final png = await img.toByteData(format: ui.ImageByteFormat.png);
+        File('$out/$name.png').writeAsBytesSync(png!.buffer.asUint8List());
+      }
+
+      await save(a, 'canvas');
+      await save(b, 'strips');
+
+      final pa = (await a.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!
+          .buffer
+          .asUint8List();
+      final pb = (await b.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!
+          .buffer
+          .asUint8List();
+      final w = a.width, h = a.height;
+      final diff = Uint8List(w * h * 4);
+      var count = 0;
+      for (var i = 0; i < w * h; i++) {
+        var d = 0;
+        for (var c = 0; c < 4; c++) {
+          final dc = (pa[i * 4 + c] - pb[i * 4 + c]).abs();
+          if (dc > d) d = dc;
+        }
+        diff[i * 4] = d > 8 ? 255 : 0;
+        diff[i * 4 + 1] = d > 2 ? 128 : (pa[i * 4 + 1] ~/ 3 + 170);
+        diff[i * 4 + 3] = 255;
+        if (d > 8) count++;
+      }
+      // ignore: avoid_print
+      print('DEBUG: ${w}x$h, ${(100 * count / (w * h)).toStringAsFixed(3)}% '
+          'differ >8');
+      final done = Completer<void>();
+      ui.decodeImageFromPixels(diff, w, h, ui.PixelFormat.rgba8888,
+          (img) async {
+        await save(img, 'diff');
+        done.complete();
+      });
+      await done.future;
+    });
+  }, timeout: const Timeout(Duration(minutes: 5)));
+}

--- a/packages/dart_pdf_editor/test/strip_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_device_test.dart
@@ -1,0 +1,172 @@
+// Unit tests for StripPdfDevice: byte-level coverage checks on synthetic
+// fills through the full shader path (strip generation -> atlas ->
+// drawVertices+FragmentShader -> raster), plus flush/fallback ordering.
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+PdfPath rect(double l, double t, double r, double b) => PdfPath([
+      PdfMoveTo(l, t),
+      PdfLineTo(r, t),
+      PdfLineTo(r, b),
+      PdfLineTo(l, b),
+      const PdfClosePath(),
+    ]);
+
+Future<Uint8List> renderStrips(
+    void Function(StripPdfDevice d) draw, int w, int h) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder);
+  canvas.drawRect(ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+      ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+  // identity page->device: device space IS canvas space
+  final device = StripPdfDevice(canvas,
+      pageToDevice: PdfMatrix.identity,
+      deviceWidth: w,
+      deviceHeight: h,
+      pixelRatio: 1,
+      images: const {});
+  draw(device);
+  await device.finish();
+  final picture = recorder.endRecording();
+  final image = await picture.toImage(w, h);
+  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  image.dispose();
+  picture.dispose();
+  device.dispose();
+  return data!.buffer.asUint8List();
+}
+
+int px(Uint8List b, int w, int x, int y, int c) => b[(y * w + x) * 4 + c];
+
+void main() {
+  testWidgets('integer-aligned black rect is exact', (tester) async {
+    await tester.runAsync(() async {
+      final bytes = await renderStrips(
+          (d) =>
+              d.fillPath(rect(4, 4, 20, 12), PdfColor.black, PdfFillRule.nonzero, 1),
+          24,
+          16);
+      expect(px(bytes, 24, 5, 5, 0), 0);
+      expect(px(bytes, 24, 19, 11, 0), 0); // last interior pixel
+      expect(px(bytes, 24, 3, 5, 0), 255); // left of rect
+      expect(px(bytes, 24, 20, 5, 0), 255); // right of rect
+      expect(px(bytes, 24, 5, 3, 0), 255); // above
+      expect(px(bytes, 24, 5, 12, 0), 255); // below
+    });
+  });
+
+  testWidgets('fractional edges get exact area coverage', (tester) async {
+    await tester.runAsync(() async {
+      // rect x in [4.25, 19.75], y in [5.5, 10.25]
+      final bytes = await renderStrips(
+          (d) => d.fillPath(rect(4.25, 5.5, 19.75, 10.25), PdfColor.black,
+              PdfFillRule.nonzero, 1),
+          24,
+          16);
+      int want(double cov) => (255 * (1 - cov)).round();
+      // interior
+      expect(px(bytes, 24, 10, 7, 0), 0);
+      // left column x=4: covered 0.75 horizontally, fully vertically at y=7
+      expect((px(bytes, 24, 4, 7, 0) - want(0.75)).abs(), lessThanOrEqualTo(2));
+      // right column x=19: 0.75
+      expect((px(bytes, 24, 19, 7, 0) - want(0.75)).abs(), lessThanOrEqualTo(2));
+      // top row y=5: 0.5
+      expect((px(bytes, 24, 10, 5, 0) - want(0.5)).abs(), lessThanOrEqualTo(2));
+      // bottom row y=10: 0.25
+      expect((px(bytes, 24, 10, 10, 0) - want(0.25)).abs(), lessThanOrEqualTo(2));
+      // corner x=4,y=5: 0.75*0.5
+      expect((px(bytes, 24, 4, 5, 0) - want(0.375)).abs(), lessThanOrEqualTo(2));
+    });
+  });
+
+  testWidgets('diagonal edge coverage matches analytic area', (tester) async {
+    await tester.runAsync(() async {
+      // right triangle (4,4) (20,4) (4,20): hypotenuse x+y=24
+      final path = PdfPath([
+        PdfMoveTo(4, 4),
+        PdfLineTo(20, 4),
+        PdfLineTo(4, 20),
+        const PdfClosePath(),
+      ]);
+      final bytes = await renderStrips(
+          (d) => d.fillPath(path, PdfColor.black, PdfFillRule.nonzero, 1),
+          24,
+          24);
+      // pixel (x,y) crossed by the diagonal: coverage = area of
+      // {(u,v) in pixel: u+v <= 24}
+      double cov(int x, int y) {
+        var inside = 0;
+        for (var sy = 0; sy < 64; sy++) {
+          for (var sx = 0; sx < 64; sx++) {
+            final u = x + (sx + 0.5) / 64, v = y + (sy + 0.5) / 64;
+            if (u + v <= 24 && u >= 4 && v >= 4) inside++;
+          }
+        }
+        return inside / 4096;
+      }
+
+      for (final (x, y) in const [(12, 11), (11, 12), (8, 15), (15, 8), (10, 13)]) {
+        final wantV = (255 * (1 - cov(x, y))).round();
+        expect((px(bytes, 24, x, y, 0) - wantV).abs(), lessThanOrEqualTo(3),
+            reason: 'diagonal pixel $x,$y: got ${px(bytes, 24, x, y, 0)} '
+                'want $wantV (cov ${cov(x, y)})');
+      }
+    });
+  });
+
+  testWidgets('translucent fill modulates like srcOver', (tester) async {
+    await tester.runAsync(() async {
+      final bytes = await renderStrips(
+          (d) => d.fillPath(rect(4, 4, 20, 12), const PdfColor(1, 0, 0),
+              PdfFillRule.nonzero, 0.5),
+          24,
+          16);
+      // 50% red over white: (255, 127.5, 127.5)
+      expect((px(bytes, 24, 10, 8, 0) - 255).abs(), lessThanOrEqualTo(2));
+      expect((px(bytes, 24, 10, 8, 1) - 128).abs(), lessThanOrEqualTo(2));
+      expect((px(bytes, 24, 10, 8, 2) - 128).abs(), lessThanOrEqualTo(2));
+    });
+  });
+
+  testWidgets('painter order: strips flush under delegated paints and clips',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = await renderStrips((d) {
+        // black rect via strips
+        d.fillPath(rect(0, 0, 24, 16), PdfColor.black, PdfFillRule.nonzero, 1);
+        // clip to the left half, then red rect via strips inside the clip
+        d.save();
+        d.clipPath(rect(0, 0, 12, 16), PdfFillRule.nonzero);
+        d.fillPath(
+            rect(0, 0, 24, 16), const PdfColor(1, 0, 0), PdfFillRule.nonzero, 1);
+        d.restore();
+        // green rect after restore, unclipped
+        d.fillPath(
+            rect(20, 0, 24, 16), const PdfColor(0, 1, 0), PdfFillRule.nonzero, 1);
+      }, 24, 16);
+      expect([px(bytes, 24, 6, 8, 0), px(bytes, 24, 6, 8, 1)], [255, 0],
+          reason: 'red inside clip');
+      expect([px(bytes, 24, 16, 8, 0), px(bytes, 24, 16, 8, 1)], [0, 0],
+          reason: 'black outside clip (red clipped away)');
+      expect([px(bytes, 24, 22, 8, 1)], [255], reason: 'green after restore');
+    });
+  });
+
+  testWidgets('stats: one flush for a batch of plain fills', (tester) async {
+    await tester.runAsync(() async {
+      StripPdfDevice.resetStats();
+      await renderStrips((d) {
+        for (var i = 0; i < 10; i++) {
+          d.fillPath(rect(i * 2.0, 0, i * 2.0 + 1.5, 8), PdfColor.black,
+              PdfFillRule.nonzero, 1);
+        }
+      }, 24, 16);
+      expect(StripPdfDevice.totalFlushes, 1);
+      expect(StripPdfDevice.totalDelegatedPaints, 0);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/strip_overlap_probe_test.dart
+++ b/packages/dart_pdf_editor/test/strip_overlap_probe_test.dart
@@ -1,0 +1,123 @@
+// Probe (not part of the suite): does compositing of two overlapping
+// strip-routed fills inside ONE flush batch match the canvas result?
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+void main() {
+  testWidgets('pink diagonal over grey box: strips vs canvas', (tester) async {
+    await tester.runAsync(() async {
+      const w = 32, h = 32;
+      final grey = PdfPath([
+        PdfMoveTo(4, 4),
+        PdfLineTo(28, 4),
+        PdfLineTo(28, 28),
+        PdfLineTo(4, 28),
+        const PdfClosePath(),
+      ]);
+      // diagonal-edged pink shape overlapping the grey box
+      final pink = PdfPath([
+        PdfMoveTo(8, 8),
+        PdfLineTo(24, 8),
+        PdfLineTo(8, 24),
+        const PdfClosePath(),
+      ]);
+      const greyC = PdfColor(134 / 255, 128 / 255, 128 / 255);
+      const pinkC = PdfColor(1, 170 / 255, 200 / 255);
+
+      Future<Uint8List> viaStrips({bool splitFlush = false}) async {
+        final rec = ui.PictureRecorder();
+        final canvas = ui.Canvas(rec);
+        canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 32, 32),
+            ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+        final d = StripPdfDevice(canvas,
+            pageToDevice: PdfMatrix.identity,
+            deviceWidth: w,
+            deviceHeight: h,
+            pixelRatio: 1);
+        d.fillPath(grey, greyC, PdfFillRule.nonzero, 1);
+        if (splitFlush) {
+          // force a flush boundary between the two fills
+          d.save();
+          d.clipPath(
+              PdfPath([
+                PdfMoveTo(0, 0),
+                PdfLineTo(32, 0),
+                PdfLineTo(32, 32),
+                PdfLineTo(0, 32),
+                const PdfClosePath(),
+              ]),
+              PdfFillRule.nonzero);
+          d.restore();
+        }
+        d.fillPath(pink, pinkC, PdfFillRule.nonzero, 1);
+        await d.finish();
+        final pic = rec.endRecording();
+        final img = await pic.toImage(w, h);
+        final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+        img.dispose();
+        pic.dispose();
+        d.dispose();
+        return data!.buffer.asUint8List();
+      }
+
+      Future<Uint8List> viaCanvas() async {
+        final rec = ui.PictureRecorder();
+        final canvas = ui.Canvas(rec);
+        canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 32, 32),
+            ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+        ui.Path toUi(PdfPath p) {
+          final out = ui.Path();
+          for (final s in p.segments) {
+            switch (s) {
+              case PdfMoveTo(:final x, :final y):
+                out.moveTo(x, y);
+              case PdfLineTo(:final x, :final y):
+                out.lineTo(x, y);
+              case PdfCubicTo():
+                out.cubicTo(s.x1, s.y1, s.x2, s.y2, s.x3, s.y3);
+              case PdfClosePath():
+                out.close();
+            }
+          }
+          return out;
+        }
+
+        canvas.drawPath(
+            toUi(grey), ui.Paint()..color = const ui.Color(0xFF868080));
+        canvas.drawPath(
+            toUi(pink), ui.Paint()..color = const ui.Color(0xFFFFAAC8));
+        final pic = rec.endRecording();
+        final img = await pic.toImage(w, h);
+        final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+        img.dispose();
+        pic.dispose();
+        return data!.buffer.asUint8List();
+      }
+
+      final a = await viaCanvas();
+      final b = await viaStrips();
+      final c = await viaStrips(splitFlush: true);
+
+      // sample along the pink diagonal edge (x+y = 32 crossing pixels):
+      // sequential srcOver of two overlapping strip fills must composite
+      // like the canvas, in one flush batch or across a flush boundary
+      for (final (x, y) in const [(15, 16), (16, 15), (12, 19), (19, 12), (10, 21)]) {
+        final o = (y * w + x) * 4;
+        // ignore: avoid_print
+        print('OVERLAP: ($x,$y) canvas=(${a[o]},${a[o + 1]},${a[o + 2]}) '
+            'strips1flush=(${b[o]},${b[o + 1]},${b[o + 2]}) '
+            'strips2flush=(${c[o]},${c[o + 1]},${c[o + 2]})');
+        for (var ch = 0; ch < 3; ch++) {
+          expect((b[o + ch] - a[o + ch]).abs(), lessThanOrEqualTo(2),
+              reason: 'one-flush overlap at ($x,$y) channel $ch');
+          expect((c[o + ch] - a[o + ch]).abs(), lessThanOrEqualTo(2),
+              reason: 'split-flush overlap at ($x,$y) channel $ch');
+        }
+      }
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/strip_parity_test.dart
+++ b/packages/dart_pdf_editor/test/strip_parity_test.dart
@@ -1,0 +1,235 @@
+// B1 gate: device-vs-device parity for the sparse-strip shader renderer.
+//
+// Every Ghent page is rendered twice in-process at the same pixel ratio -
+// once through the stock CanvasPdfDevice pipeline, once through
+// StripPdfDevice - and diffed with the ghent_render_test thresholds
+// (8/channel, 0.05% of pixels) plus a classified relaxed tier.
+//
+// Why a relaxed tier is needed (measured, see strip_curve_probe_test):
+// strip coverage is exact-area analytic AA, but Skia's own curve raster
+// deviates from the true area by up to ~0.2 coverage on cubic edges (a
+// glyph-sized cubic probe read analytic=77, strips=79, skia=135), and
+// Skia renders sub-device-pixel strokes as alpha-modulated 1-px hairlines.
+// Those disagreements sit exactly on high-contrast anti-aliased edges and
+// are cases where the strip raster is CLOSER to ground truth than the
+// canvas render, so pixel-level agreement there is neither achievable nor
+// desirable. A differing pixel is classified "edge" when the canvas
+// render's 3x3 neighborhood spans > 48/channel - the AA band of a
+// contrast boundary.
+//
+// Documented relaxed tolerance and gate:
+//   - every page renders non-blank,
+//   - structural (non-edge) pixels differing > 8/channel stay <= 0.05% of
+//     the page (the strict fraction, applied off-edge),
+//   - mean absolute channel difference <= 2.0/255 per page (backstop so
+//     "edge" cannot hide a systematically displaced or recolored render),
+//   - >= 90% of pages pass both.
+// The strict 8/0.05% and 16/0.2% whole-page distributions are reported for
+// the record. Run with the default backend AND with --enable-impeller.
+//
+// Impeller runs must set STRIP_PARITY_IMPELLER=1: Impeller rasterizes path
+// AA with 4x MSAA, quantizing the CANVAS baseline's edge coverage (its
+// simple-diagonal probe still reads within 2, but dense-page edges drift
+// to a mean diff of ~6/255) while the strip side is unchanged and
+// byte-accurate there too (strip_device_test passes under Impeller and a
+// delegate-everything render diffs 0.000%). The Impeller gate therefore
+// loosens to mean <= 8/255 and off-edge strict fraction <= 1% - it guards
+// the pipeline, not Impeller's AA quality; beating MSAA AA is Track A's
+// whole point.
+//
+// STRIP_PARITY_FILTER=<substring> narrows the file set for debugging.
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+const _pixelRatio = 2.0;
+const _strictChannel = 8;
+const _strictFraction = 0.0005;
+const _relaxedChannel = 16;
+const _relaxedFraction = 0.002;
+
+/// Channel range in the 3x3 neighborhood above which a pixel counts as
+/// sitting on a contrast edge (where analytic-vs-supersampled AA differs).
+const _edgeContrast = 48;
+
+/// Mean absolute channel difference allowed per page (backstop, 0..255).
+final double _maxMeanDiff = _impeller ? 8.0 : 2.0;
+
+/// Off-edge (structural) differing-pixel fraction allowed per page.
+final double _structuralFraction = _impeller ? 0.01 : _strictFraction;
+
+/// See the header: Impeller's MSAA canvas baseline needs looser thresholds.
+final bool _impeller = Platform.environment['STRIP_PARITY_IMPELLER'] == '1';
+
+class _PageStat {
+  _PageStat(this.name, this.page);
+  final String name;
+  final int page;
+  int pixels = 0;
+  int strictDiff = 0; // > 8/channel
+  int relaxedDiff = 0; // > 16/channel
+  int edgeDiff = 0; // strict-differing pixels on contrast edges
+  int diffSum = 0; // sum of max-channel abs differences
+  double ink = 0;
+
+  bool get strictPass => strictDiff <= pixels * _strictFraction;
+  bool get relaxedPass => relaxedDiff <= pixels * _relaxedFraction;
+  double get edgeShare => strictDiff == 0 ? 1 : edgeDiff / strictDiff;
+  double get meanDiff => diffSum / pixels;
+
+  /// The documented B1 relaxed-edge gate: off-edge strict fraction plus a
+  /// mean-difference backstop.
+  bool get structuralPass =>
+      (strictDiff - edgeDiff) <= pixels * _structuralFraction &&
+      meanDiff <= _maxMeanDiff;
+}
+
+void main() {
+  final root = Directory('../../test_corpora/ghent');
+  if (!root.existsSync()) {
+    test('strip parity', skip: 'test_corpora/ghent not found', () {});
+    return;
+  }
+  final filter = Platform.environment['STRIP_PARITY_FILTER'];
+
+  final files = root
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) =>
+          f.path.toLowerCase().endsWith('.pdf') &&
+          !f.path.contains('/_baselines/') &&
+          !f.path.contains('/_failures/') &&
+          !f.path.contains('/_renders/') &&
+          (filter == null || f.path.contains(filter)))
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+
+  testWidgets('strip device parity vs canvas device (Ghent)', (tester) async {
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final stats = <_PageStat>[];
+      try {
+        for (final file in files) {
+          final name = file.path.substring(root.path.length + 1);
+          final doc = PdfDocument.open(file.readAsBytesSync());
+          for (var i = 0; i < doc.pageCount; i++) {
+            PdfPageRenderer.deviceMode = PdfRenderDeviceMode.canvas;
+            final canvasImage = await PdfPageRenderer.renderImage(doc.page(i),
+                    pixelRatio: _pixelRatio)
+                .timeout(const Duration(seconds: 90));
+            PdfPageRenderer.deviceMode = PdfRenderDeviceMode.strips;
+            final stripImage = await PdfPageRenderer.renderImage(doc.page(i),
+                    pixelRatio: _pixelRatio)
+                .timeout(const Duration(seconds: 90));
+            try {
+              stats.add(await _diff(name, i, canvasImage, stripImage));
+            } finally {
+              canvasImage.dispose();
+              stripImage.dispose();
+            }
+          }
+        }
+      } finally {
+        PdfPageRenderer.deviceMode = PdfRenderDeviceMode.canvas;
+      }
+
+      // ---- distribution report ----
+      final pages = stats.length;
+      final strictPass = stats.where((s) => s.strictPass).length;
+      final relaxedPass = stats.where((s) => s.relaxedPass).length;
+      final structuralPass = stats.where((s) => s.structuralPass).length;
+      final blank = stats.where((s) => s.ink <= 0.0005).toList();
+      // ignore: avoid_print
+      print('STRIP-PARITY: $pages pages | strict(8/0.05%) pass '
+          '$strictPass (${(100 * strictPass / pages).toStringAsFixed(1)}%) | '
+          'whole-page 16/0.2% pass $relaxedPass '
+          '(${(100 * relaxedPass / pages).toStringAsFixed(1)}%) | '
+          'relaxed-edge gate pass $structuralPass '
+          '(${(100 * structuralPass / pages).toStringAsFixed(1)}%) | '
+          'blank ${blank.length}');
+      final failing = stats.where((s) => !s.strictPass).toList()
+        ..sort((a, b) => (b.strictDiff / b.pixels)
+            .compareTo(a.strictDiff / a.pixels));
+      for (final s in failing.take(15)) {
+        // ignore: avoid_print
+        print('  strict-fail ${s.name} p${s.page}: '
+            '>${_strictChannel}ch ${(100 * s.strictDiff / s.pixels).toStringAsFixed(3)}% '
+            '>${_relaxedChannel}ch ${(100 * s.relaxedDiff / s.pixels).toStringAsFixed(3)}% '
+            'edge-share ${(100 * s.edgeShare).toStringAsFixed(0)}% '
+            'mean ${s.meanDiff.toStringAsFixed(2)} '
+            '${s.structuralPass ? "(edge-only, within relaxed gate)" : "(STRUCTURAL)"}');
+      }
+
+      for (final s in blank) {
+        fail('${s.name} p${s.page}: strip render is (nearly) blank');
+      }
+      expect(structuralPass / pages, greaterThanOrEqualTo(0.9),
+          reason: 'B1 gate: >= 90% of pages within the documented relaxed '
+              'edge tolerance (off-edge >$_strictChannel/channel <= '
+              '${_strictFraction * 100}% of pixels, mean diff <= '
+              '$_maxMeanDiff/255)');
+    });
+  }, timeout: const Timeout(Duration(minutes: 60)));
+}
+
+Future<_PageStat> _diff(
+    String name, int page, ui.Image canvas, ui.Image strips) async {
+  final stat = _PageStat(name, page);
+  expect('${strips.width}x${strips.height}', '${canvas.width}x${canvas.height}',
+      reason: '$name p$page: raster size mismatch');
+  final a = (await canvas.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!
+      .buffer
+      .asUint8List();
+  final b = (await strips.toByteData(format: ui.ImageByteFormat.rawStraightRgba))!
+      .buffer
+      .asUint8List();
+  final w = canvas.width, h = canvas.height;
+  stat.pixels = w * h;
+
+  var ink = 0;
+  for (var i = 0; i < b.length; i += 4) {
+    if (b[i] < 250 || b[i + 1] < 250 || b[i + 2] < 250) ink++;
+  }
+  stat.ink = ink / stat.pixels;
+
+  for (var y = 0; y < h; y++) {
+    for (var x = 0; x < w; x++) {
+      final o = (y * w + x) * 4;
+      var d = 0;
+      for (var c = 0; c < 4; c++) {
+        final dc = (a[o + c] - b[o + c]).abs();
+        if (dc > d) d = dc;
+      }
+      stat.diffSum += d;
+      if (d <= _strictChannel) continue;
+      stat.strictDiff++;
+      if (d > _relaxedChannel) stat.relaxedDiff++;
+      if (_isEdge(a, w, h, x, y)) stat.edgeDiff++;
+    }
+  }
+  return stat;
+}
+
+/// Whether the canvas render has a contrast edge in the 3x3 patch at (x,y).
+bool _isEdge(Uint8List rgba, int w, int h, int x, int y) {
+  for (var c = 0; c < 3; c++) {
+    var lo = 255, hi = 0;
+    for (var dy = -1; dy <= 1; dy++) {
+      for (var dx = -1; dx <= 1; dx++) {
+        final nx = x + dx, ny = y + dy;
+        if (nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
+        final v = rgba[(ny * w + nx) * 4 + c];
+        if (v < lo) lo = v;
+        if (v > hi) hi = v;
+      }
+    }
+    if (hi - lo > _edgeContrast) return true;
+  }
+  return false;
+}

--- a/packages/dart_pdf_editor/test/strip_probe_test.dart
+++ b/packages/dart_pdf_editor/test/strip_probe_test.dart
@@ -1,0 +1,286 @@
+// M0 feasibility probes for shader-driven strip rendering.
+//
+// Verifies, on whatever backend `flutter test` is hosting (software Skia by
+// default, Impeller with --enable-impeller), the platform behaviors the strip
+// renderer depends on:
+//   1. which coordinate space a FragmentShader Paint is evaluated in when
+//      drawn via canvas.drawVertices with textureCoordinates,
+//   2. exact texel reads from an rgba8888 data texture via nearest-sampled
+//      texture() at half-texel centers,
+//   3. RGBA channel select with a step-mask dot (SkSL-safe),
+//   4. BlendMode.modulate combining vertex colors with shader coverage,
+//   5. the mutate-uniforms -> draw -> mutate pattern inside one picture.
+//
+// The tests PASS for either coordinate-space answer (texcoord or position);
+// the answer itself is printed as `PROBE:` lines and recorded in the dev-log.
+// They FAIL only when a dependency is genuinely broken (garbage coordinates,
+// inexact texel reads, wrong channel math).
+
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+
+const int _texSize = 64;
+
+/// Texel pattern: rows 0..31 are opaque (A=255) with R=i, G=j,
+/// B=(7i+13j)%256; rows 32..63 vary every channel including alpha.
+List<int> _texel(int i, int j) {
+  if (j < 32) return [i, j, (7 * i + 13 * j) % 256, 255];
+  return [(5 * i) % 256, (11 * j) % 256, (i + 2 * j) % 256, (9 * i + 3 * j) % 256];
+}
+
+Future<ui.Image> _makeDataTexture() {
+  final pixels = Uint8List(_texSize * _texSize * 4);
+  for (var j = 0; j < _texSize; j++) {
+    for (var i = 0; i < _texSize; i++) {
+      final t = _texel(i, j);
+      final o = (j * _texSize + i) * 4;
+      pixels[o] = t[0];
+      pixels[o + 1] = t[1];
+      pixels[o + 2] = t[2];
+      pixels[o + 3] = t[3];
+    }
+  }
+  final completer = Completer<ui.Image>();
+  ui.decodeImageFromPixels(
+      pixels, _texSize, _texSize, ui.PixelFormat.rgba8888, completer.complete);
+  return completer.future;
+}
+
+Future<ui.FragmentProgram> _loadProgram() async {
+  try {
+    return await ui.FragmentProgram.fromAsset('shaders/pdf_probe.frag');
+  } catch (_) {
+    return ui.FragmentProgram.fromAsset(
+        'packages/dart_pdf_editor/shaders/pdf_probe.frag');
+  }
+}
+
+ui.Vertices _quad(ui.Rect pos, ui.Rect tex, {int? color}) {
+  final positions = Float32List.fromList([
+    pos.left, pos.top, pos.right, pos.top, //
+    pos.left, pos.bottom, pos.right, pos.bottom,
+  ]);
+  final texs = Float32List.fromList([
+    tex.left, tex.top, tex.right, tex.top, //
+    tex.left, tex.bottom, tex.right, tex.bottom,
+  ]);
+  final indices = Uint16List.fromList([0, 1, 2, 1, 3, 2]);
+  return ui.Vertices.raw(ui.VertexMode.triangles, positions,
+      textureCoordinates: texs,
+      colors: color == null ? null : Int32List.fromList(List.filled(4, color)),
+      indices: indices);
+}
+
+Future<Uint8List> _renderToBytes(
+    void Function(ui.Canvas) draw, int w, int h) async {
+  final rec = ui.PictureRecorder();
+  draw(ui.Canvas(rec));
+  final pic = rec.endRecording();
+  final img = await pic.toImage(w, h);
+  final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+  img.dispose();
+  pic.dispose();
+  return data!.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+}
+
+int _px(Uint8List bytes, int w, int x, int y, int c) =>
+    bytes[(y * w + x) * 4 + c];
+
+void main() {
+  late ui.FragmentProgram program;
+  late ui.Image dataTexture;
+  // 'texcoord' | 'position', decided by the first probe and asserted
+  // consistent by the rest.
+  late String space;
+
+  ui.FragmentShader shaderFor(double mode, {double row = 0}) {
+    final s = program.fragmentShader();
+    s.setFloat(0, _texSize.toDouble());
+    s.setFloat(1, _texSize.toDouble());
+    s.setFloat(2, mode);
+    s.setFloat(3, row);
+    s.setImageSampler(0, dataTexture);
+    return s;
+  }
+
+  // Expected texel under the detected space for a quad drawn with
+  // pos origin (0,0) and tex origin (tx,ty).
+  List<int> expectedTexel(int x, int y, int tx, int ty) =>
+      space == 'texcoord' ? _texel(x + tx, y + ty) : _texel(x, y);
+
+  setUpAll(() async {
+    program = await _loadProgram();
+    dataTexture = await _makeDataTexture();
+  });
+
+  testWidgets('probe: coordinate space of drawVertices + FragmentShader',
+      (tester) async {
+    await tester.runAsync(() async {
+      final shader = shaderFor(0);
+      final bytes = await _renderToBytes((canvas) {
+        canvas.drawVertices(
+            _quad(const ui.Rect.fromLTRB(0, 0, 32, 32),
+                const ui.Rect.fromLTRB(100, 60, 132, 92)),
+            ui.BlendMode.srcOver,
+            ui.Paint()..shader = shader);
+      }, 32, 32);
+
+      String classify(int x, int y) {
+        final r = _px(bytes, 32, x, y, 0);
+        final g = _px(bytes, 32, x, y, 1);
+        bool near(int v, num want) => (v - want).abs() <= 1.5;
+        if (near(r, x + 100.5) && near(g, y + 60.5)) return 'texcoord';
+        if (near(r, x + 0.5) && near(g, y + 0.5)) return 'position';
+        return 'unknown(r=$r g=$g at $x,$y)';
+      }
+
+      final a = classify(4, 4);
+      final b = classify(20, 12);
+      expect(a, anyOf('texcoord', 'position'),
+          reason: 'shader evaluated in unrecognized space: $a');
+      expect(b, a, reason: 'inconsistent interpolation across the quad');
+      space = a;
+      // ignore: avoid_print
+      print('PROBE: drawVertices+FragmentShader evaluation space = $space');
+    });
+  });
+
+  testWidgets('probe: exact texel reads (identity mapping)', (tester) async {
+    await tester.runAsync(() async {
+      final shader = shaderFor(1);
+      final bytes = await _renderToBytes((canvas) {
+        canvas.drawVertices(
+            _quad(const ui.Rect.fromLTRB(0, 0, 32, 32),
+                const ui.Rect.fromLTRB(0, 0, 32, 32)),
+            ui.BlendMode.srcOver,
+            ui.Paint()..shader = shader);
+      }, 32, 32);
+
+      for (final p in const [(0, 0), (5, 9), (31, 31), (17, 3), (30, 1)]) {
+        final want = _texel(p.$1, p.$2);
+        for (var c = 0; c < 4; c++) {
+          expect((_px(bytes, 32, p.$1, p.$2, c) - want[c]).abs(),
+              lessThanOrEqualTo(1),
+              reason: 'texel ${p.$1},${p.$2} channel $c: '
+                  'got ${_px(bytes, 32, p.$1, p.$2, c)} want ${want[c]}');
+        }
+      }
+      // ignore: avoid_print
+      print('PROBE: exact texel reads via texture()+half-texel centers = OK');
+    });
+  });
+
+  testWidgets('probe: texcoord-offset texel reads follow detected space',
+      (tester) async {
+    await tester.runAsync(() async {
+      final shader = shaderFor(1);
+      final bytes = await _renderToBytes((canvas) {
+        canvas.drawVertices(
+            _quad(const ui.Rect.fromLTRB(0, 0, 32, 32),
+                const ui.Rect.fromLTRB(16, 8, 48, 40)),
+            ui.BlendMode.srcOver,
+            ui.Paint()..shader = shader);
+      }, 32, 32);
+
+      for (final p in const [(2, 3), (10, 20), (15, 15)]) {
+        final want = expectedTexel(p.$1, p.$2, 16, 8);
+        // Rows >= 32 in the texture have varying alpha; the raw framebuffer
+        // holds premultiplied values there, so only assert opaque texels.
+        if (want[3] != 255) continue;
+        for (var c = 0; c < 3; c++) {
+          expect((_px(bytes, 32, p.$1, p.$2, c) - want[c]).abs(),
+              lessThanOrEqualTo(1),
+              reason: 'offset texel ${p.$1},${p.$2} channel $c');
+        }
+      }
+      // ignore: avoid_print
+      print('PROBE: offset texcoords consistent with $space space = OK');
+    });
+  });
+
+  testWidgets('probe: RGBA channel select via step-mask dot', (tester) async {
+    await tester.runAsync(() async {
+      for (var row = 0; row < 4; row++) {
+        final shader = shaderFor(2, row: row.toDouble());
+        final bytes = await _renderToBytes((canvas) {
+          canvas.drawVertices(
+              _quad(const ui.Rect.fromLTRB(0, 0, 16, 16),
+                  const ui.Rect.fromLTRB(8, 40, 24, 56)),
+              ui.BlendMode.srcOver,
+              ui.Paint()..shader = shader);
+        }, 16, 16);
+        for (final p in const [(1, 2), (7, 11), (14, 5)]) {
+          final texel = expectedTexel(p.$1, p.$2, 8, 40);
+          expect((_px(bytes, 16, p.$1, p.$2, 0) - texel[row]).abs(),
+              lessThanOrEqualTo(1),
+              reason: 'channel $row at ${p.$1},${p.$2}: '
+                  'got ${_px(bytes, 16, p.$1, p.$2, 0)} want ${texel[row]}');
+        }
+      }
+      // ignore: avoid_print
+      print('PROBE: step-mask channel select = OK');
+    });
+  });
+
+  testWidgets('probe: BlendMode.modulate vertex color x shader coverage',
+      (tester) async {
+    await tester.runAsync(() async {
+      // Coverage = R channel of opaque texels (row < 32 => R = i).
+      final shader = shaderFor(2, row: 0);
+      const color = 0xFFC84020; // ARGB: a=255 r=200 g=64 b=32
+      final bytes = await _renderToBytes((canvas) {
+        canvas.drawVertices(
+            _quad(const ui.Rect.fromLTRB(0, 0, 32, 32),
+                const ui.Rect.fromLTRB(0, 0, 32, 32), color: color),
+            ui.BlendMode.modulate,
+            ui.Paint()..shader = shader);
+      }, 32, 32);
+
+      for (final p in const [(4, 4), (16, 8), (31, 30)]) {
+        final cov = _texel(p.$1, p.$2)[0] / 255.0;
+        final want = [200 * cov, 64 * cov, 32 * cov];
+        for (var c = 0; c < 3; c++) {
+          expect((_px(bytes, 32, p.$1, p.$2, c) - want[c]).abs(),
+              lessThanOrEqualTo(2.0),
+              reason: 'modulate channel $c at ${p.$1},${p.$2}: '
+                  'got ${_px(bytes, 32, p.$1, p.$2, c)} want ${want[c]}');
+        }
+      }
+      // ignore: avoid_print
+      print('PROBE: modulate vertex-color x coverage = OK');
+    });
+  });
+
+  testWidgets('probe: uniform mutation between draws in one picture',
+      (tester) async {
+    await tester.runAsync(() async {
+      // One shader instance: draw channel R at x<16, mutate to channel G,
+      // draw at x>=16. Both draws must reflect their own uniform values.
+      final shader = shaderFor(2, row: 0);
+      final bytes = await _renderToBytes((canvas) {
+        canvas.drawVertices(
+            _quad(const ui.Rect.fromLTRB(0, 0, 16, 16),
+                const ui.Rect.fromLTRB(0, 0, 16, 16)),
+            ui.BlendMode.srcOver,
+            ui.Paint()..shader = shader);
+        shader.setFloat(3, 1); // row -> G
+        canvas.drawVertices(
+            _quad(const ui.Rect.fromLTRB(16, 0, 32, 16),
+                const ui.Rect.fromLTRB(0, 0, 16, 16)),
+            ui.BlendMode.srcOver,
+            ui.Paint()..shader = shader);
+      }, 32, 16);
+
+      // Left half: coverage = R = i. Right half: coverage = G = j.
+      expect((_px(bytes, 32, 9, 4, 0) - 9).abs(), lessThanOrEqualTo(1),
+          reason: 'first draw should use pre-mutation uniforms');
+      expect((_px(bytes, 32, 25, 4, 0) - 4).abs(), lessThanOrEqualTo(1),
+          reason: 'second draw should use post-mutation uniforms');
+      // ignore: avoid_print
+      print('PROBE: per-draw uniform snapshot = OK');
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/strip_skia_calibration_test.dart
+++ b/packages/dart_pdf_editor/test/strip_skia_calibration_test.dart
@@ -1,0 +1,92 @@
+// Calibration probe (not part of the suite): how far does Skia's path AA
+// deviate from exact-area coverage on a diagonal edge, and how far does the
+// strip pipeline? Bounds the achievable strip-vs-canvas parity.
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+void main() {
+  testWidgets('skia vs analytic vs strips on a diagonal edge', (tester) async {
+    await tester.runAsync(() async {
+      const w = 24, h = 24;
+      // right triangle (4,4) (20,4) (4,20)
+      final tri = PdfPath([
+        PdfMoveTo(4, 4),
+        PdfLineTo(20, 4),
+        PdfLineTo(4, 20),
+        const PdfClosePath(),
+      ]);
+
+      Future<Uint8List> raster(void Function(ui.Canvas) draw) async {
+        final rec = ui.PictureRecorder();
+        final canvas = ui.Canvas(rec);
+        canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 24, 24),
+            ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+        draw(canvas);
+        final pic = rec.endRecording();
+        final img = await pic.toImage(w, h);
+        final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+        img.dispose();
+        pic.dispose();
+        return data!.buffer.asUint8List();
+      }
+
+      final skia = await raster((canvas) {
+        final path = ui.Path()
+          ..moveTo(4, 4)
+          ..lineTo(20, 4)
+          ..lineTo(4, 20)
+          ..close();
+        canvas.drawPath(path, ui.Paint()..color = const ui.Color(0xFF000000));
+      });
+
+      final stripsBytes = await (() async {
+        final rec = ui.PictureRecorder();
+        final canvas = ui.Canvas(rec);
+        canvas.drawRect(const ui.Rect.fromLTWH(0, 0, 24, 24),
+            ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+        final device = StripPdfDevice(canvas,
+            pageToDevice: PdfMatrix.identity,
+            deviceWidth: w,
+            deviceHeight: h,
+            pixelRatio: 1);
+        device.fillPath(tri, PdfColor.black, PdfFillRule.nonzero, 1);
+        await device.finish();
+        final pic = rec.endRecording();
+        final img = await pic.toImage(w, h);
+        final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+        img.dispose();
+        pic.dispose();
+        device.dispose();
+        return data!.buffer.asUint8List();
+      })();
+
+      double cov(int x, int y) {
+        var inside = 0;
+        for (var sy = 0; sy < 64; sy++) {
+          for (var sx = 0; sx < 64; sx++) {
+            final u = x + (sx + 0.5) / 64, v = y + (sy + 0.5) / 64;
+            if (u + v <= 24 && u >= 4 && v >= 4) inside++;
+          }
+        }
+        return inside / 4096;
+      }
+
+      // walk the diagonal; print (analytic, skia, strips) coverage
+      for (var y = 6; y <= 17; y += 1) {
+        final x = 24 - y - 1; // pixel crossed by u+v=24
+        final want = (255 * (1 - cov(x, y))).round();
+        final s = skia[(y * w + x) * 4];
+        final st = stripsBytes[(y * w + x) * 4];
+        // ignore: avoid_print
+        print('CAL: ($x,$y) analytic=$want skia=$s strips=$st '
+            'dSkia=${s - want} dStrips=${st - want}');
+        expect((st - want).abs(), lessThanOrEqualTo(2),
+            reason: 'strip coverage vs analytic at ($x,$y)');
+      }
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
+++ b/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
@@ -1,0 +1,191 @@
+// The dense-page strip zoom router (PdfPageView.stripZoomReplay):
+//
+//  - flag ON + page above retainedZoomReplayMaxCommands -> the scene IS
+//    retained and zoom re-rasters re-bin through StripPdfDevice
+//    (observable via the device's batching telemetry);
+//  - flag OFF -> exactly the #208 behavior: over-ceiling pages retain no
+//    scene and zoom via the classic cached-picture re-raster (no strip
+//    device activity at all);
+//  - image sanity: the strip replay of a retained scene stays visually
+//    equivalent to the canvas replay (non-blank, bounded mean diff - the
+//    devices differ only in AA coverage on edges, same tolerance family as
+//    the Ghent parity gate), for the full page and the region variant.
+//
+// The image-sanity test must run FIRST: after the widget zoom tests, later
+// tester.runAsync platform work in this same file (decodeImageFromPixels
+// inside the strip atlas upload) never completes - test files run in their
+// own isolates, so the order only matters within this file.
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// A one-page classic-xref PDF with solid vector content (fills + a
+/// stroke), so the strip device has geometry to bin (text through a
+/// non-embedded Type1 font would delegate to the canvas fallback).
+Uint8List buildVectorPdf() {
+  const content = '1 0 0 rg 72 600 200 100 re f '
+      '0 0 1 rg 300 300 150 220 re f '
+      '0 0.6 0 RG 6 w 72 100 m 500 250 l S';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
+Future<Uint8List> _rgba(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();
+
+double _meanAbsDiff(Uint8List a, Uint8List b) {
+  var sum = 0;
+  for (var i = 0; i < a.length; i++) {
+    sum += (a[i] - b[i]).abs();
+  }
+  return sum / a.length;
+}
+
+/// Pumps until the page's RawImage raster reaches [width] px (the async
+/// strip replay takes a few event-loop turns for the atlas decode).
+Future<ui.Image> _settleRaster(WidgetTester tester, int width) async {
+  for (var i = 0; i < 40; i++) {
+    await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)));
+    await tester.pump();
+    final images = find.byType(RawImage);
+    if (images.evaluate().isNotEmpty) {
+      final image = tester.widget<RawImage>(images).image;
+      if (image != null && image.width == width) return image;
+    }
+  }
+  fail('raster never reached $width px wide');
+}
+
+void main() {
+  testWidgets('strip replay stays visually equivalent to the canvas replay',
+      (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(buildVectorPdf());
+      final page = doc.page(0);
+      final scene = await PdfRetainedScene.record(page);
+      for (final ratio in [1.0, 2.4]) {
+        final canvasImage = await scene.rasterize(pixelRatio: ratio);
+        final stripImage = await scene.rasterizeStrips(pixelRatio: ratio);
+        expect(stripImage.width, canvasImage.width, reason: 'ratio $ratio');
+        expect(stripImage.height, canvasImage.height, reason: 'ratio $ratio');
+        final a = await _rgba(canvasImage);
+        final b = await _rgba(stripImage);
+        // non-blank: the fills must actually land
+        expect(b.any((v) => v < 128), isTrue,
+            reason: 'strip raster is blank at ratio $ratio');
+        // same tolerance family as the Ghent parity gate: the devices agree
+        // except for AA coverage on shape edges
+        expect(_meanAbsDiff(a, b), lessThanOrEqualTo(2.0),
+            reason: 'strip raster diverges at ratio $ratio');
+        canvasImage.dispose();
+        stripImage.dispose();
+      }
+
+      // region variant: same crop through both devices, over the blue rect
+      // (PDF y 300..520 = raster y 272..492 on the 792pt page)
+      const region = Rect.fromLTWH(290, 300, 200, 150);
+      final canvasRegion =
+          await scene.rasterizeRegion(region, pixelRatio: 2);
+      final stripRegion =
+          await scene.rasterizeRegionStrips(region, pixelRatio: 2);
+      expect(stripRegion.width, canvasRegion.width);
+      expect(stripRegion.height, canvasRegion.height);
+      final a = await _rgba(canvasRegion);
+      final b = await _rgba(stripRegion);
+      expect(b.any((v) => v < 128), isTrue, reason: 'region raster is blank');
+      expect(_meanAbsDiff(a, b), lessThanOrEqualTo(2.0));
+      canvasRegion.dispose();
+      stripRegion.dispose();
+      scene.dispose();
+    });
+  });
+  testWidgets(
+      'stripZoomReplay routes over-ceiling zooms through the strip device',
+      (tester) async {
+    PdfPageView.retainedZoomReplayMaxCommands = 0; // every page is "dense"
+    PdfPageView.stripZoomReplay = true;
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+      PdfPageView.stripZoomReplay = false;
+    });
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final doc = PdfDocument.open(buildVectorPdf());
+    final page = doc.page(0);
+    Widget at(double scale) => Center(
+        child:
+            SizedBox(width: 612, child: PdfPageView(page: page, scale: scale)));
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    final base = await _settleRaster(tester, 612);
+    expect(base.width, 612);
+
+    // the zoom settle must re-bin through the strip device
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(3));
+    final zoomed = await _settleRaster(tester, 612 * 3);
+    expect(zoomed.width, 612 * 3);
+    expect(StripPdfDevice.totalStripQuads, greaterThan(0),
+        reason: 'the zoom re-raster must have binned strip quads');
+  });
+
+  testWidgets(
+      'flag off: over-ceiling pages keep the cached-picture path, '
+      'no strip activity', (tester) async {
+    PdfPageView.retainedZoomReplayMaxCommands = 0;
+    expect(PdfPageView.stripZoomReplay, isFalse,
+        reason: 'stripZoomReplay must default off');
+    addTearDown(() => PdfPageView.retainedZoomReplayMaxCommands = 20000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final doc = PdfDocument.open(buildVectorPdf());
+    final page = doc.page(0);
+    Widget at(double scale) => Center(
+        child:
+            SizedBox(width: 612, child: PdfPageView(page: page, scale: scale)));
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    final base = await _settleRaster(tester, 612);
+    expect(base.width, 612);
+
+    await tester.pumpWidget(at(3));
+    final zoomed = await _settleRaster(tester, 612 * 3);
+    expect(zoomed.width, 612 * 3);
+    expect(StripPdfDevice.totalFlushes, 0,
+        reason: 'flag off must never touch the strip device');
+  });
+
+}

--- a/packages/dart_pdf_editor/test/zoom_latency_test.dart
+++ b/packages/dart_pdf_editor/test/zoom_latency_test.dart
@@ -11,6 +11,12 @@
 //                   re-interpret, no re-decode), then toImage.
 //   (c) full      - reference: full re-render (re-interpret + decode via the
 //                   warm PdfImageCache + paint) then toImage.
+//   (d) strips    - PdfRetainedScene.replayStrips: the command buffer is
+//                   re-binned into the sparse-strip shader device at the new
+//                   ratio (drawVertices + canvas fallback), then toImage -
+//                   pdf_page_view's over-ceiling path when
+//                   PdfPageView.stripZoomReplay is on. Per-step telemetry
+//                   (flushes/quads/atlas texels/delegated) prints alongside.
 //
 // Each timed step splits into build (picture production), raster (toImage)
 // and readback (toByteData(rawRgba), forcing full realization so GPU-backed
@@ -33,6 +39,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -116,11 +123,15 @@ class _Sample {
 
 /// The zoom path PdfPageView takes for a page of this density: retained
 /// replay (b) up to the command ceiling, the classic cached-picture
-/// re-raster (a) above it (or when the kill switch is off).
-String _viewerPath(int commandCount) => PdfPageView.retainedZoomReplay &&
-        commandCount <= PdfPageView.retainedZoomReplayMaxCommands
-    ? 'b-retained'
-    : 'a-current';
+/// re-raster (a) above it (or when the kill switch is off) - unless the
+/// opt-in strip router sends over-ceiling pages to (d).
+String _viewerPath(int commandCount) {
+  if (!PdfPageView.retainedZoomReplay) return 'a-current';
+  if (commandCount <= PdfPageView.retainedZoomReplayMaxCommands) {
+    return 'b-retained';
+  }
+  return PdfPageView.stripZoomReplay ? 'd-strips' : 'a-current';
+}
 
 double _effectiveRatio(Size size, double desired) {
   final width = math.max(1.0, size.width);
@@ -170,6 +181,7 @@ void main() {
 
       final rows = <String>[];
       final stepRows = <String>[];
+      final telemetryRows = <String>[];
 
       for (final entry in fileNames) {
         // "name.pdf#12" selects a page for that file; bare names use
@@ -229,7 +241,10 @@ void main() {
           'a-current': _Sample(),
           'b-retained': _Sample(),
           'c-full': _Sample(),
+          'd-strips': _Sample(),
         };
+        // per zoom step: flushes, quads, atlas texels, delegated paints
+        final stripStats = [for (final _ in zoomSequence) (0, 0, 0, 0)];
         final perStep = {
           for (final key in samples.keys)
             key: [for (final _ in zoomSequence) _Sample()],
@@ -292,6 +307,28 @@ void main() {
               samples['c-full']!.add(buildC, rasterC, readbackC);
               perStep['c-full']![step].add(buildC, rasterC, readbackC);
             }
+
+            // (d) retained scene through the strip device: re-bin at ratio
+            // (what pdf_page_view does for over-ceiling pages when
+            // PdfPageView.stripZoomReplay is on).
+            StripPdfDevice.resetStats();
+            t = Stopwatch()..start();
+            final stripPicture = await scene.replayStrips(pixelRatio: ratio);
+            final buildD = t.elapsedMicroseconds / 1000.0;
+            final (imageD, rasterD, readbackD) =
+                await _timeRaster(stripPicture, w, h);
+            stripPicture.dispose();
+            imageD.dispose();
+            if (record) {
+              samples['d-strips']!.add(buildD, rasterD, readbackD);
+              perStep['d-strips']![step].add(buildD, rasterD, readbackD);
+              stripStats[step] = (
+                StripPdfDevice.totalFlushes,
+                StripPdfDevice.totalStripQuads,
+                StripPdfDevice.totalAtlasTexels,
+                StripPdfDevice.totalDelegatedPaints,
+              );
+            }
           }
         }
 
@@ -312,6 +349,15 @@ void main() {
           stepRows.add('${label.padRight(44).substring(0, 44)} '
               'zoom=${zoomSequence[step].toStringAsFixed(1)} '
               '${parts.join('  ')}');
+        }
+
+        for (var step = 0; step < zoomSequence.length; step++) {
+          final (flushes, quads, texels, delegated) = stripStats[step];
+          telemetryRows.add('${label.padRight(44).substring(0, 44)} '
+              'zoom=${zoomSequence[step].toStringAsFixed(1)} '
+              'flushes=$flushes quads=$quads '
+              'atlasKB=${(texels * 4 / 1024).toStringAsFixed(0)} '
+              'delegated=$delegated');
         }
 
         scene.dispose();
@@ -337,6 +383,12 @@ void main() {
       // ignore: avoid_print
       print('\nper-zoom-step totals (ms, build+toImage+readback):');
       for (final row in stepRows) {
+        // ignore: avoid_print
+        print(row);
+      }
+      // ignore: avoid_print
+      print('\nstrip telemetry per zoom step (last pass, path d):');
+      for (final row in telemetryRows) {
         // ignore: avoid_print
         print(row);
       }

--- a/packages/pdf_graphics/lib/raster.dart
+++ b/packages/pdf_graphics/lib/raster.dart
@@ -1,0 +1,13 @@
+/// CPU sparse-strip rasterization core (vello_hybrid-style): adaptive path
+/// flattening, stroke-to-contour expansion, and 4-px strip generation with
+/// a column-major RGBA8888 alpha atlas.
+///
+/// Pure Dart - runs on the VM, on the web, and in worker isolates.
+/// Deliberately NOT exported from the main pdf_graphics barrel: this is the
+/// substrate for dart_pdf_editor's strip shader device (and future
+/// worker-isolate strip generation), not part of the stable device API.
+library;
+
+export 'src/raster/flatten.dart';
+export 'src/raster/stroke_contours.dart';
+export 'src/raster/strip_generator.dart';

--- a/packages/pdf_graphics/lib/src/raster/flatten.dart
+++ b/packages/pdf_graphics/lib/src/raster/flatten.dart
@@ -1,0 +1,370 @@
+// Adaptive path flattening for the CPU strip rasterizer, ported from the
+// flutter_gpu experiment's gpu_geometry.dart (semantics identical - Wang's
+// bound on the cubic's second differences picks the subdivision count).
+//
+// Everything here is pure Dart (no dart:ui, no dart:io) so it runs on the
+// VM, on the web, and inside worker isolates. All accumulation goes through
+// typed-array builders: the Dart VM boxes every element of a growable
+// List<double>, which made geometry generation the dominant CPU cost on
+// CAD-heavy pages before these existed.
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import '../matrix.dart';
+import '../path.dart';
+
+/// Growable Float64List: unboxed accumulation for geometry in device pixels.
+class DoubleBuilder {
+  Float64List _data;
+  int length = 0;
+
+  DoubleBuilder([int capacity = 256]) : _data = Float64List(capacity);
+
+  bool get isEmpty => length == 0;
+
+  void _ensure(int extra) {
+    if (length + extra <= _data.length) return;
+    var cap = _data.length * 2;
+    while (cap < length + extra) {
+      cap *= 2;
+    }
+    _data = Float64List(cap)..setRange(0, length, _data);
+  }
+
+  void add2(double a, double b) {
+    _ensure(2);
+    _data[length] = a;
+    _data[length + 1] = b;
+    length += 2;
+  }
+
+  void add6(double a, double b, double c, double d, double e, double f) {
+    _ensure(6);
+    final p = _data, n = length;
+    p[n] = a;
+    p[n + 1] = b;
+    p[n + 2] = c;
+    p[n + 3] = d;
+    p[n + 4] = e;
+    p[n + 5] = f;
+    length += 6;
+  }
+
+  double operator [](int i) => _data[i];
+
+  void operator []=(int i, double v) => _data[i] = v;
+
+  /// A view of the filled prefix. Valid until the next add.
+  Float64List get view => Float64List.sublistView(_data, 0, length);
+
+  void clear() => length = 0;
+}
+
+/// Growable Float32List: vertex/segment data in its final upload layout,
+/// emplaced without a conversion copy.
+class FloatBuilder {
+  Float32List _data;
+  int length = 0;
+
+  FloatBuilder([int capacity = 1024]) : _data = Float32List(capacity);
+
+  bool get isEmpty => length == 0;
+
+  double operator [](int i) => _data[i];
+
+  void _ensure(int extra) {
+    if (length + extra <= _data.length) return;
+    var cap = _data.length * 2;
+    while (cap < length + extra) {
+      cap *= 2;
+    }
+    _data = Float32List(cap)..setRange(0, length, _data);
+  }
+
+  void add2(double a, double b) {
+    _ensure(2);
+    _data[length] = a;
+    _data[length + 1] = b;
+    length += 2;
+  }
+
+  void add4(double a, double b, double c, double d) {
+    _ensure(4);
+    final p = _data, n = length;
+    p[n] = a;
+    p[n + 1] = b;
+    p[n + 2] = c;
+    p[n + 3] = d;
+    length += 4;
+  }
+
+  void add6(double a, double b, double c, double d, double e, double f) {
+    _ensure(6);
+    final p = _data, n = length;
+    p[n] = a;
+    p[n + 1] = b;
+    p[n + 2] = c;
+    p[n + 3] = d;
+    p[n + 4] = e;
+    p[n + 5] = f;
+    length += 6;
+  }
+
+  /// The filled bytes; hand straight to a texture/buffer upload (which
+  /// copies). sublistView bounds are element indices, not bytes.
+  ByteData get bytes => ByteData.sublistView(_data, 0, length);
+
+  /// A view of the filled prefix. Valid until the next add.
+  Float32List get view => Float32List.sublistView(_data, 0, length);
+
+  void clear() => length = 0;
+}
+
+/// One flattened subpath: `[x0,y0, x1,y1, ...]`.
+/// [points] is Float64List-backed (unboxed indexing).
+class FlatSubpath {
+  FlatSubpath(this.points, {required this.closed});
+
+  final Float64List points;
+  final bool closed;
+
+  int get pointCount => points.length ~/ 2;
+}
+
+/// Axis-aligned bounds of [subpaths], or null when empty.
+class FlatBounds {
+  FlatBounds(this.left, this.top, this.right, this.bottom);
+
+  double left, top, right, bottom;
+
+  void include(double x, double y) {
+    if (x < left) left = x;
+    if (x > right) right = x;
+    if (y < top) top = y;
+    if (y > bottom) bottom = y;
+  }
+
+  static FlatBounds? of(List<FlatSubpath> subpaths) {
+    FlatBounds? b;
+    for (final sub in subpaths) {
+      final p = sub.points;
+      for (var i = 0; i < p.length; i += 2) {
+        if (b == null) {
+          b = FlatBounds(p[i], p[i + 1], p[i], p[i + 1]);
+        } else {
+          b.include(p[i], p[i + 1]);
+        }
+      }
+    }
+    return b;
+  }
+}
+
+/// Flattens [path] through [transform] (page space -> device pixels) into
+/// polylines. Cubics subdivide adaptively to stay within [tolerance] device
+/// pixels of the true curve (Wang's bound on the second differences).
+List<FlatSubpath> flattenPath(PdfPath path, PdfMatrix transform,
+    {double tolerance = 0.25}) {
+  final out = <FlatSubpath>[];
+  DoubleBuilder? current;
+  var closed = false;
+  var startX = 0.0, startY = 0.0;
+  var lastX = 0.0, lastY = 0.0;
+
+  void finish() {
+    final done = current;
+    if (done != null && done.length >= 4) {
+      out.add(FlatSubpath(Float64List.fromList(done.view), closed: closed));
+    }
+    current = null;
+    closed = false;
+  }
+
+  for (final segment in path.segments) {
+    final cur = current;
+    switch (segment) {
+      case PdfMoveTo(:final x, :final y):
+        finish();
+        lastX = startX = transform.transformX(x, y);
+        lastY = startY = transform.transformY(x, y);
+        current = DoubleBuilder(64)..add2(startX, startY);
+      case PdfLineTo(:final x, :final y):
+        if (cur == null) continue;
+        lastX = transform.transformX(x, y);
+        lastY = transform.transformY(x, y);
+        cur.add2(lastX, lastY);
+      case PdfCubicTo():
+        if (cur == null) continue;
+        final x1 = transform.transformX(segment.x1, segment.y1);
+        final y1 = transform.transformY(segment.x1, segment.y1);
+        final x2 = transform.transformX(segment.x2, segment.y2);
+        final y2 = transform.transformY(segment.x2, segment.y2);
+        final x3 = transform.transformX(segment.x3, segment.y3);
+        final y3 = transform.transformY(segment.x3, segment.y3);
+        final d1 =
+            math.max((lastX - 2 * x1 + x2).abs(), (lastY - 2 * y1 + y2).abs());
+        final d2 =
+            math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
+        final d = math.max(d1, d2);
+        final n = d <= tolerance
+            ? 1
+            : math.sqrt(3 * d / (4 * tolerance)).ceil().clamp(1, 128);
+        for (var i = 1; i <= n; i++) {
+          final t = i / n;
+          final mt = 1 - t;
+          final a = mt * mt * mt, b = 3 * mt * mt * t, c = 3 * mt * t * t;
+          final e = t * t * t;
+          cur.add2(a * lastX + b * x1 + c * x2 + e * x3,
+              a * lastY + b * y1 + c * y2 + e * y3);
+        }
+        lastX = x3;
+        lastY = y3;
+      case PdfClosePath():
+        if (cur == null) continue;
+        if (lastX != startX || lastY != startY) {
+          cur.add2(startX, startY);
+        }
+        closed = true;
+        lastX = startX;
+        lastY = startY;
+        // `m ... h m ...` reuses the pen; a close ends the subpath here and
+        // a following lineTo would be malformed input - treat close as final.
+        finish();
+    }
+  }
+  finish();
+  return out;
+}
+
+/// Re-cuts [subpaths] into dash segments (§8.4.3.6). [pattern] and [phase]
+/// are already in device pixels. Zero-length "on" dashes survive as
+/// single-point subpaths so round caps still paint dots.
+List<FlatSubpath> dashSubpaths(
+    List<FlatSubpath> subpaths, List<double> pattern, double phase) {
+  final dashes = [
+    for (final d in pattern)
+      if (d >= 0) d,
+  ];
+  if (dashes.length.isOdd) dashes.addAll(List.of(dashes));
+  final cycle = dashes.fold(0.0, (a, b) => a + b);
+  if (dashes.isEmpty || cycle <= 0) return subpaths;
+
+  final out = <FlatSubpath>[];
+  void emit(DoubleBuilder b) {
+    if (b.length >= 2) {
+      out.add(FlatSubpath(Float64List.fromList(b.view), closed: false));
+    }
+  }
+
+  for (final sub in subpaths) {
+    final p = sub.points;
+    var index = 0;
+    var on = true;
+    var remaining = dashes[0];
+    var toSkip = phase.abs() % cycle;
+    while (toSkip > 0) {
+      if (toSkip >= remaining) {
+        toSkip -= remaining;
+        index = (index + 1) % dashes.length;
+        on = !on;
+        remaining = dashes[index];
+      } else {
+        remaining -= toSkip;
+        toSkip = 0;
+      }
+    }
+    DoubleBuilder? current = on ? (DoubleBuilder(32)..add2(p[0], p[1])) : null;
+    for (var i = 0; i + 3 < p.length; i += 2) {
+      var ax = p[i], ay = p[i + 1];
+      final bx = p[i + 2], by = p[i + 3];
+      var segLen = math.sqrt((bx - ax) * (bx - ax) + (by - ay) * (by - ay));
+      while (segLen > 1e-12) {
+        if (remaining >= segLen) {
+          remaining -= segLen;
+          segLen = 0;
+          if (on) {
+            current!.add2(bx, by);
+          }
+        } else {
+          final t = remaining / segLen;
+          final mx = ax + (bx - ax) * t, my = ay + (by - ay) * t;
+          if (on) {
+            current!.add2(mx, my);
+            emit(current);
+            current = null;
+          } else {
+            current = DoubleBuilder(32)..add2(mx, my);
+          }
+          ax = mx;
+          ay = my;
+          segLen -= remaining;
+          remaining = 0;
+        }
+        if (remaining <= 1e-12) {
+          index = (index + 1) % dashes.length;
+          on = !on;
+          remaining = dashes[index];
+          if (remaining <= 0 && cycle <= 1e-9) break;
+          if (on && current == null) current = DoubleBuilder(32)..add2(ax, ay);
+          if (!on && current != null) {
+            emit(current);
+            current = null;
+          }
+        }
+      }
+    }
+    if (current != null) emit(current);
+  }
+  return out;
+}
+
+/// Flattening tolerance for cached em-space glyph outlines, in em units.
+///
+/// The cache is scale-free (one flatten serves every occurrence of the
+/// glyph), so the tolerance is picked for the common text range: 1/1024 em
+/// keeps the polyline within 0.023 device px of the true curve at a 24-px
+/// em (12 pt text at pixel ratio 2) and within 0.125 px at a 128-px em.
+/// Ghent parity showed 1/256 was visible: at body-text sizes its ~0.1-px
+/// curve error against Skia's own flattening pushed glyph-edge pixels past
+/// the 8/channel diff threshold. Wang's bound scales point count with
+/// 1/sqrt(tolerance), so this costs only 2x the points of 1/256, flattened
+/// once per glyph.
+const double glyphFlattenTolerance = 1 / 1024;
+
+/// A glyph outline flattened once in em space (y-up, origin on the
+/// baseline) and cached per outline identity.
+///
+/// The font engine hands back the same [PdfPath] instance for every
+/// occurrence of a glyph ([PdfFontInfo.outlineFor] memoizes), so an
+/// [Expando] keyed by that identity gives a process-wide cache that dies
+/// with the font - the same pattern as the canvas device's `_glyphPaths`
+/// ui.Path cache. Callers transform the cached polylines straight into
+/// device space (see `StripGenerator.fillOutline`) instead of re-running
+/// adaptive flattening per occurrence.
+class FlattenedOutline {
+  FlattenedOutline._(this.subpaths);
+
+  /// Em-space polylines. Fill semantics: every subpath is implicitly closed.
+  final List<FlatSubpath> subpaths;
+
+  bool _boundsDone = false;
+  FlatBounds? _bounds;
+
+  /// Em-space bounds of the flattened outline (memoized), or null when the
+  /// outline is empty.
+  FlatBounds? get bounds {
+    if (!_boundsDone) {
+      _bounds = FlatBounds.of(subpaths);
+      _boundsDone = true;
+    }
+    return _bounds;
+  }
+
+  static final Expando<FlattenedOutline> _cache = Expando('FlattenedOutline');
+
+  /// The cached flattening of [outline], flattening on first sight.
+  static FlattenedOutline of(PdfPath outline) =>
+      _cache[outline] ??= FlattenedOutline._(flattenPath(
+          outline, PdfMatrix.identity,
+          tolerance: glyphFlattenTolerance));
+}

--- a/packages/pdf_graphics/lib/src/raster/strip_generator.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_generator.dart
@@ -1,0 +1,1079 @@
+// vello_hybrid-style sparse-strip generation: the CPU fine-rasterizes each
+// fill into 4-px-tall strip rows (font-rs signed-area accumulation +
+// prefix sum), then emits a compact SoA strip list where fully-covered
+// runs carry no alpha bytes and mixed columns append 4 coverage bytes
+// (one RGBA8888 texel) to a shared alpha atlas. A GPU consumer draws every
+// strip as a quad and samples the atlas; a CPU consumer can composite the
+// strips directly. Pure Dart - no dart:ui, no dart:io.
+//
+// Layout (all SoA, reused across pages):
+//  - xy:          x | y<<16 (u16|u16), strip origin in device px, y = row top
+//  - widthFlags:  width in columns (u16) | stripFlagSolid | stripFlagEvenOdd
+//  - alphaOffset: column index into [StripBuffer.alphas] (4 bytes/column),
+//                 or [stripSolidSentinel] for solid strips
+//  - color:       premultiplied RGBA8 in memory byte order r,g,b,a
+//                 (little-endian u32 r | g<<8 | b<<16 | a<<24)
+//  - alphas:      column-major coverage, 4 bytes per column = one RGBA8888
+//                 texel (byte k = scanline k of the strip row)
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import '../color.dart';
+import '../matrix.dart';
+import '../path.dart';
+import 'flatten.dart';
+import 'stroke_contours.dart';
+
+/// widthFlags bit: strip is fully covered - no alpha bytes, alphaOffset is
+/// [stripSolidSentinel].
+const int stripFlagSolid = 0x10000;
+
+/// widthFlags bit: the fill that produced this strip used the even-odd rule
+/// (informational - coverage is already resolved CPU-side).
+const int stripFlagEvenOdd = 0x20000;
+
+/// alphaOffset value for solid strips.
+const int stripSolidSentinel = 0xFFFFFFFF;
+
+/// Packs [color] at [alpha] into premultiplied RGBA8 (r | g<<8 | b<<16 |
+/// a<<24 - RGBA8888 memory byte order on little-endian targets).
+int premulRgba8(PdfColor color, double alpha) {
+  final af = alpha < 0 ? 0.0 : (alpha > 1 ? 1.0 : alpha);
+  final a = (af * 255 + 0.5).toInt();
+  int chan(double c) {
+    final v = c < 0 ? 0.0 : (c > 1 ? 1.0 : c);
+    return ((v * 255 + 0.5).toInt() * a + 127) ~/ 255;
+  }
+
+  return chan(color.red) |
+      (chan(color.green) << 8) |
+      (chan(color.blue) << 16) |
+      (a << 24);
+}
+
+/// The strip list under construction. Typed arrays grow geometrically and
+/// are reused across pages ([reset] keeps capacity).
+class StripBuffer {
+  int length = 0;
+  Uint32List xy = Uint32List(1024);
+  Uint32List widthFlags = Uint32List(1024);
+  Uint32List alphaOffset = Uint32List(1024);
+  Uint32List color = Uint32List(1024);
+
+  // Alpha atlas kept as u32 texels so solid/mixed columns append with one
+  // 4-byte store; exposed as bytes for RGBA8888 upload.
+  Uint32List _alphaTexels = Uint32List(4096);
+  int alphaColumns = 0;
+
+  /// Column-major coverage bytes (4 per column); length = 4 * alphaColumns.
+  Uint8List get alphas => Uint8List.sublistView(_alphaTexels, 0, alphaColumns);
+
+  /// The alpha atlas as whole texels (one u32 per column).
+  Uint32List get alphaTexels =>
+      Uint32List.sublistView(_alphaTexels, 0, alphaColumns);
+
+  void reset() {
+    length = 0;
+    alphaColumns = 0;
+  }
+
+  void _ensureStrips(int extra) {
+    if (length + extra <= xy.length) return;
+    var cap = xy.length * 2;
+    while (cap < length + extra) {
+      cap *= 2;
+    }
+    xy = Uint32List(cap)..setRange(0, length, xy);
+    widthFlags = Uint32List(cap)..setRange(0, length, widthFlags);
+    alphaOffset = Uint32List(cap)..setRange(0, length, alphaOffset);
+    color = Uint32List(cap)..setRange(0, length, color);
+  }
+
+  void _emit(int x, int y, int width, int flags, int alphaOff, int rgba) {
+    _ensureStrips(1);
+    final n = length;
+    xy[n] = x | (y << 16);
+    widthFlags[n] = width | flags;
+    alphaOffset[n] = alphaOff;
+    color[n] = rgba;
+    length = n + 1;
+  }
+
+  void _appendTexel(int texel) {
+    if (alphaColumns == _alphaTexels.length) {
+      _alphaTexels = Uint32List(_alphaTexels.length * 2)
+        ..setRange(0, alphaColumns, _alphaTexels);
+    }
+    _alphaTexels[alphaColumns++] = texel;
+  }
+
+  void _appendTexels(Uint32List texels) {
+    final need = alphaColumns + texels.length;
+    if (need > _alphaTexels.length) {
+      var cap = _alphaTexels.length * 2;
+      while (cap < need) {
+        cap *= 2;
+      }
+      _alphaTexels = Uint32List(cap)..setRange(0, alphaColumns, _alphaTexels);
+    }
+    _alphaTexels.setRange(alphaColumns, need, texels);
+    alphaColumns = need;
+  }
+}
+
+/// Fine-rasterizes fills, strokes, and glyph outlines into a [StripBuffer].
+///
+/// Per fill: flatten to device-space edges (Wang's bound, same semantics as
+/// [flattenPath]) -> clip to the viewport (x-clipping projects offscreen
+/// portions onto the viewport edge so winding is preserved) -> y-slice
+/// edges into 4-px strip rows via intrusive typed-array linked lists ->
+/// font-rs signed-area accumulation into a reused Float32List (4 scanlines
+/// x row width) -> per-column prefix sum -> fill rule (nonzero
+/// `min(1,|w|)`, even-odd triangle wave `|w - 2 round(w/2)|`) -> strip
+/// emission (zero runs skipped, all-255 runs of >= 2 columns become solid
+/// strips, mixed columns append alpha texels). Only the touched accumulator
+/// span is zeroed behind the scan.
+class StripGenerator {
+  final StripBuffer strips = StripBuffer();
+
+  /// Replayable glyph strip cache consulted by [fillOutline]. Defaults to
+  /// the process-wide [GlyphStripCache.shared]; set null to rasterize every
+  /// glyph directly (unquantized - the pre-cache behavior).
+  GlyphStripCache? glyphCache = GlyphStripCache.shared;
+
+  int _width = 0;
+  int _height = 0;
+  int _rowCount = 0;
+  int _stride = 0;
+
+  Float32List _accum = Float32List(0);
+  Int32List _rowHead = Int32List(0);
+  Int32List _rowMinX = Int32List(0);
+  Int32List _rowMaxX = Int32List(0);
+  Int32List _dirtyRows = Int32List(256);
+  int _dirtyCount = 0;
+
+  // Edge nodes, y-sliced per row: x0, y0, x1, y1 (y row-local 0..4, in the
+  // edge's own direction so the winding sign survives slicing).
+  Float32List _nodes = Float32List(4096);
+  Int32List _nodeNext = Int32List(1024);
+  int _nodeCount = 0;
+
+  // Pen state for the direct flatten-into-edges path.
+  double _penX = 0, _penY = 0, _startX = 0, _startY = 0;
+  bool _subpathOpen = false;
+
+  final StrokeContours _contours = StrokeContours();
+
+  int get width => _width;
+  int get height => _height;
+
+  /// Number of 4-px strip rows covering the viewport.
+  int get rowCount => _rowCount;
+
+  /// Starts a new page/batch: sets the device viewport (pixels) and clears
+  /// the strip buffer. Scratch buffers are kept and only grow.
+  void begin(int width, int height) {
+    _width = width;
+    _height = height;
+    _rowCount = (height + 3) >> 2;
+    _stride = width + 2;
+    if (_accum.length < 4 * _stride) {
+      _accum = Float32List(4 * _stride);
+    } else {
+      _accum.fillRange(0, 4 * _stride, 0); // defensive: restore invariant
+    }
+    if (_rowHead.length < _rowCount) {
+      _rowHead = Int32List(_rowCount);
+      _rowMinX = Int32List(_rowCount);
+      _rowMaxX = Int32List(_rowCount);
+    }
+    _rowHead.fillRange(0, _rowCount, -1);
+    _dirtyCount = 0;
+    _nodeCount = 0;
+    strips.reset();
+  }
+
+  /// Fills [path] (page space) mapped through [transform] into device
+  /// space. [rgba] is a premultiplied color from [premulRgba8].
+  void fillPath(PdfPath path, PdfMatrix transform, PdfFillRule rule, int rgba,
+      {double tolerance = 0.25}) {
+    if (path.isEmpty || _rowCount == 0) return;
+    // The bbox pre-cull is a full extra pass over the path; for tiny paths
+    // (the CAD common case: 4-segment quads by the tens of thousands)
+    // flatten-and-bin is just as cheap and the binning clips anyway.
+    if (path.segments.length > 8 && _cullPath(path, transform)) return;
+    _flattenEdges(path, transform, tolerance);
+    _finishShape(rule, rgba);
+  }
+
+  /// Strokes [path] (page space, stroke parameters in page space like
+  /// [PdfDevice.strokePath]) by expanding to closed contours and filling
+  /// them nonzero.
+  void strokePath(
+      PdfPath path, PdfMatrix transform, PdfStroke stroke, int rgba,
+      {double tolerance = 0.25}) {
+    if (path.isEmpty || _rowCount == 0) return;
+    final sf = transform.scaleFactor;
+    var subs = flattenPath(path, transform, tolerance: tolerance);
+    if (subs.isEmpty) return;
+    if (stroke.dashArray.isNotEmpty &&
+        stroke.dashArray.any((d) => d > 0)) {
+      subs = dashSubpaths(subs, [for (final d in stroke.dashArray) d * sf],
+          stroke.dashPhase * sf);
+    }
+    _contours.clear();
+    strokeToContours(subs,
+        width: stroke.width * sf,
+        cap: stroke.cap,
+        join: stroke.join,
+        miterLimit: stroke.miterLimit,
+        out: _contours);
+    fillContours(_contours, rgba);
+  }
+
+  /// Fills already-flattened device-space subpaths (each implicitly
+  /// closed - PDF fill semantics).
+  void fillSubpaths(List<FlatSubpath> subpaths, PdfFillRule rule, int rgba) {
+    if (subpaths.isEmpty || _rowCount == 0) return;
+    for (final sub in subpaths) {
+      _addRing(sub.points, 0, sub.points.length);
+    }
+    _finishShape(rule, rgba);
+  }
+
+  /// Fills stroke-expansion [contours] (device space) with the nonzero rule.
+  void fillContours(StrokeContours contours, int rgba) {
+    if (contours.isEmpty || _rowCount == 0) return;
+    for (var i = 0; i < contours.ringCount; i++) {
+      _addRingBuilder(
+          contours.points, contours.ringStart(i), contours.ringEnd(i));
+    }
+    _finishShape(PdfFillRule.nonzero, rgba);
+  }
+
+  /// Fills a cached em-space glyph [outline] through [emToDevice]
+  /// (em space -> device pixels): transform-and-bin, no re-flattening.
+  /// Glyph outlines fill nonzero (§9.4).
+  ///
+  /// With a [glyphCache] attached (the default), the glyph's emitted strips
+  /// are memoized per (outline identity, matrix quantized to 1/64,
+  /// subpixel offset quantized to 1/4 px) and replayed with an integer
+  /// translate + color override - repeat occurrences skip flattening,
+  /// binning, and fine raster entirely. Quantization moves a glyph by at
+  /// most 1/8 px; glyphs that leave the viewport (or exceed 512 px a side)
+  /// bypass the cache and render directly, unquantized.
+  void fillOutline(FlattenedOutline outline, PdfMatrix emToDevice, int rgba) {
+    if (_rowCount == 0) return;
+    final cache = glyphCache;
+    if (cache == null) {
+      _fillOutlineDirect(outline, emToDevice, rgba);
+      return;
+    }
+    _fillOutlineCached(cache, outline, emToDevice, rgba);
+  }
+
+  void _fillOutlineDirect(
+      FlattenedOutline outline, PdfMatrix emToDevice, int rgba) {
+    final a = emToDevice.a, b = emToDevice.b, c = emToDevice.c;
+    final d = emToDevice.d, e = emToDevice.e, f = emToDevice.f;
+    var any = false;
+    for (final sub in outline.subpaths) {
+      final p = sub.points;
+      final n = p.length;
+      if (n < 4) continue;
+      var firstX = 0.0, firstY = 0.0, prevX = 0.0, prevY = 0.0;
+      for (var i = 0; i < n; i += 2) {
+        final px = p[i], py = p[i + 1];
+        final x = a * px + c * py + e;
+        final y = b * px + d * py + f;
+        if (i == 0) {
+          firstX = prevX = x;
+          firstY = prevY = y;
+        } else {
+          _edge(prevX, prevY, x, y);
+          prevX = x;
+          prevY = y;
+        }
+      }
+      if (prevX != firstX || prevY != firstY) {
+        _edge(prevX, prevY, firstX, firstY);
+      }
+      any = true;
+    }
+    if (any) _finishShape(PdfFillRule.nonzero, rgba);
+  }
+
+  /// Cache-or-build-and-replay path of [fillOutline].
+  void _fillOutlineCached(GlyphStripCache cache, FlattenedOutline outline,
+      PdfMatrix emToDevice, int rgba) {
+    final bounds = outline.bounds;
+    if (bounds == null) return;
+
+    // Quantize: 2x2 in 1/64 steps, x offset in 1/4 px, y offset in 1/4 px
+    // within its 4-px strip row (strip y stays row-aligned under the
+    // integer part of the translate).
+    final qa = (emToDevice.a * 64).round();
+    final qb = (emToDevice.b * 64).round();
+    final qc = (emToDevice.c * 64).round();
+    final qd = (emToDevice.d * 64).round();
+    var ix = emToDevice.e.floor();
+    var qx = ((emToDevice.e - ix) * 4).round();
+    if (qx == 4) {
+      ix += 1;
+      qx = 0;
+    }
+    var iy = 4 * (emToDevice.f / 4).floor();
+    var qy = ((emToDevice.f - iy) * 4).round();
+    if (qy == 16) {
+      iy += 4;
+      qy = 0;
+    }
+
+    // Quantized matrix in the glyph-local frame (origin before the shift).
+    final la = qa / 64.0, lb = qb / 64.0, lc = qc / 64.0, ld = qd / 64.0;
+    final lx = qx * 0.25, ly = qy * 0.25;
+    // Device-space bbox of the em bounds through the local matrix.
+    var minX = double.infinity, minY = double.infinity;
+    var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+    for (final (ex, ey) in [
+      (bounds.left, bounds.top),
+      (bounds.right, bounds.top),
+      (bounds.left, bounds.bottom),
+      (bounds.right, bounds.bottom),
+    ]) {
+      final x = la * ex + lc * ey + lx;
+      final y = lb * ex + ld * ey + ly;
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    if (!(minX.isFinite && minY.isFinite && maxX.isFinite && maxY.isFinite)) {
+      return;
+    }
+    // Row-aligned local origin shift so the glyph rasters at non-negative
+    // coordinates in a tight scratch viewport.
+    final sx = minX.floor();
+    final sy = 4 * (minY / 4).floor();
+    final w = maxX.ceil() - sx + 1;
+    final h = maxY.ceil() - sy + 1;
+    final dx = ix + sx, dy = iy + sy; // replay translate (dy multiple of 4)
+    if (w > GlyphStripCache.maxGlyphSide ||
+        h > GlyphStripCache.maxGlyphSide ||
+        dx < 0 ||
+        dy < 0 ||
+        dx + w > _width ||
+        dy + h > _rowCount * 4) {
+      cache.bypasses++;
+      _fillOutlineDirect(outline, emToDevice, rgba);
+      return;
+    }
+
+    final key = (outline, qa, qb, qc, qd, qx, qy);
+    var entry = cache._lookup(key);
+    if (entry == null) {
+      // Cache on second sight: one-shot keys (CAD labels at continuous
+      // positions blow the subpixel key space) would pay the build/store
+      // cost for nothing - first occurrence rasters directly, using the
+      // same quantized matrix so the glyph doesn't shift when its later
+      // occurrences replay from the cache.
+      if (!cache._secondSight(
+          identityHashCode(outline), qa, qb, qc, qd, qx, qy)) {
+        _fillOutlineDirect(
+            outline, PdfMatrix(la, lb, lc, ld, ix + lx, iy + ly), rgba);
+        return;
+      }
+      final local = PdfMatrix(la, lb, lc, ld, lx - sx, ly - sy);
+      entry = cache._build(key, outline, local, w, h);
+    }
+    _replayGlyph(entry, dx, dy, rgba);
+  }
+
+  /// Copies a cached glyph's strips into the main buffer with an integer
+  /// translate and the current color.
+  void _replayGlyph(CachedGlyphStrips g, int dx, int dy, int rgba) {
+    final n = g.stripCount;
+    if (n == 0) return;
+    final buf = strips;
+    final alphaBase = buf.alphaColumns;
+    final data = g.data;
+    buf._appendTexels(
+        Uint32List.sublistView(data, 3 * n, 3 * n + g.alphaTexelCount));
+    buf._ensureStrips(n);
+    var at = buf.length;
+    final xy = buf.xy, wf = buf.widthFlags, ao = buf.alphaOffset;
+    final col = buf.color;
+    final dxy = dx | (dy << 16);
+    for (var i = 0; i < n; i++) {
+      xy[at] = data[i] + dxy;
+      wf[at] = data[n + i];
+      final a = data[2 * n + i];
+      ao[at] = a == stripSolidSentinel ? a : a + alphaBase;
+      col[at] = rgba;
+      at++;
+    }
+    buf.length = at;
+  }
+
+  // ---- culling ---------------------------------------------------------
+
+  /// True when the path's transformed control-point bbox (contains the
+  /// curves) cannot affect any visible column: fully above/below the
+  /// viewport, or fully to one side (a closed shape entirely off one side
+  /// contributes zero winding to visible columns).
+  bool _cullPath(PdfPath path, PdfMatrix m) {
+    var minX = double.infinity, minY = double.infinity;
+    var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+    void pt(double x, double y) {
+      final dx = m.transformX(x, y), dy = m.transformY(x, y);
+      if (dx < minX) minX = dx;
+      if (dx > maxX) maxX = dx;
+      if (dy < minY) minY = dy;
+      if (dy > maxY) maxY = dy;
+    }
+
+    for (final s in path.segments) {
+      switch (s) {
+        case PdfMoveTo(:final x, :final y):
+          pt(x, y);
+        case PdfLineTo(:final x, :final y):
+          pt(x, y);
+        case PdfCubicTo():
+          pt(s.x1, s.y1);
+          pt(s.x2, s.y2);
+          pt(s.x3, s.y3);
+        case PdfClosePath():
+          break;
+      }
+    }
+    if (maxX < minX) return true; // no points
+    return maxY <= 0 ||
+        minY >= _rowCount * 4.0 ||
+        maxX <= 0 ||
+        minX >= _width.toDouble();
+  }
+
+  // ---- flattening straight into edges ----------------------------------
+
+  void _flattenEdges(PdfPath path, PdfMatrix m, double tolerance) {
+    _subpathOpen = false;
+    for (final segment in path.segments) {
+      switch (segment) {
+        case PdfMoveTo(:final x, :final y):
+          _closeSubpath();
+          _penX = _startX = m.transformX(x, y);
+          _penY = _startY = m.transformY(x, y);
+          _subpathOpen = true;
+        case PdfLineTo(:final x, :final y):
+          if (!_subpathOpen) continue;
+          final dx = m.transformX(x, y), dy = m.transformY(x, y);
+          _edge(_penX, _penY, dx, dy);
+          _penX = dx;
+          _penY = dy;
+        case PdfCubicTo():
+          if (!_subpathOpen) continue;
+          final x1 = m.transformX(segment.x1, segment.y1);
+          final y1 = m.transformY(segment.x1, segment.y1);
+          final x2 = m.transformX(segment.x2, segment.y2);
+          final y2 = m.transformY(segment.x2, segment.y2);
+          final x3 = m.transformX(segment.x3, segment.y3);
+          final y3 = m.transformY(segment.x3, segment.y3);
+          final d1 = math.max((_penX - 2 * x1 + x2).abs(),
+              (_penY - 2 * y1 + y2).abs());
+          final d2 =
+              math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
+          final d = math.max(d1, d2);
+          final n = d <= tolerance
+              ? 1
+              : math.sqrt(3 * d / (4 * tolerance)).ceil().clamp(1, 128);
+          var px = _penX, py = _penY;
+          for (var i = 1; i <= n; i++) {
+            final t = i / n;
+            final mt = 1 - t;
+            final ba = mt * mt * mt,
+                bb = 3 * mt * mt * t,
+                bc = 3 * mt * t * t;
+            final be = t * t * t;
+            final qx = ba * _penX + bb * x1 + bc * x2 + be * x3;
+            final qy = ba * _penY + bb * y1 + bc * y2 + be * y3;
+            _edge(px, py, qx, qy);
+            px = qx;
+            py = qy;
+          }
+          _penX = x3;
+          _penY = y3;
+        case PdfClosePath():
+          if (!_subpathOpen) continue;
+          _closeSubpath();
+          _penX = _startX;
+          _penY = _startY;
+          _subpathOpen = true; // pen stays; a following lineTo reopens
+      }
+    }
+    _closeSubpath();
+  }
+
+  void _closeSubpath() {
+    if (!_subpathOpen) return;
+    if (_penX != _startX || _penY != _startY) {
+      _edge(_penX, _penY, _startX, _startY);
+    }
+    _subpathOpen = false;
+  }
+
+  void _addRing(Float64List pts, int start, int end) {
+    final n = end - start;
+    if (n < 6) return;
+    final firstX = pts[start], firstY = pts[start + 1];
+    var prevX = firstX, prevY = firstY;
+    for (var i = start + 2; i < end; i += 2) {
+      _edge(prevX, prevY, pts[i], pts[i + 1]);
+      prevX = pts[i];
+      prevY = pts[i + 1];
+    }
+    if (prevX != firstX || prevY != firstY) {
+      _edge(prevX, prevY, firstX, firstY);
+    }
+  }
+
+  void _addRingBuilder(DoubleBuilder pts, int start, int end) {
+    final n = end - start;
+    if (n < 6) return;
+    final firstX = pts[start], firstY = pts[start + 1];
+    var prevX = firstX, prevY = firstY;
+    for (var i = start + 2; i < end; i += 2) {
+      _edge(prevX, prevY, pts[i], pts[i + 1]);
+      prevX = pts[i];
+      prevY = pts[i + 1];
+    }
+    if (prevX != firstX || prevY != firstY) {
+      _edge(prevX, prevY, firstX, firstY);
+    }
+  }
+
+  // ---- clipping + binning ----------------------------------------------
+
+  /// Adds one device-space edge: clips y to the strip range, projects
+  /// out-of-viewport x onto the boundary (splitting at x = 0 / x = width so
+  /// winding is preserved exactly), and y-slices the pieces into rows.
+  void _edge(double x0, double y0, double x1, double y1) {
+    if (y0 == y1) return; // horizontal: no winding
+    if (!x0.isFinite || !y0.isFinite || !x1.isFinite || !y1.isFinite) {
+      return; // broken transforms produce NaN/inf geometry - drop it
+    }
+    final yLimit = _rowCount * 4.0;
+
+    // Parametric y-clip to [0, yLimit].
+    var t0 = 0.0, t1 = 1.0;
+    final dy = y1 - y0;
+    final ta = (0 - y0) / dy, tb = (yLimit - y0) / dy;
+    final tenter = ta < tb ? ta : tb, texit = ta < tb ? tb : ta;
+    if (tenter > t0) t0 = tenter;
+    if (texit < t1) t1 = texit;
+    if (t0 >= t1) return;
+    final dx = x1 - x0;
+    var ax = x0 + dx * t0, ay = y0 + dy * t0;
+    final bx = x0 + dx * t1, by = y0 + dy * t1;
+
+    // Split at x = 0 and x = width crossings (at most two interior
+    // breakpoints); out-of-range pieces become vertical edges on the
+    // boundary, preserving their winding contribution.
+    final w = _width.toDouble();
+    if (ax == bx) {
+      var cx = ax;
+      if (cx < 0) cx = 0;
+      if (cx > w) cx = w;
+      _binSegment(cx, ay, cx, by);
+      return;
+    }
+    // Breakpoint parameters along (ax..bx).
+    final inv = 1.0 / (bx - ax);
+    var s0 = (0 - ax) * inv; // crossing of x=0
+    var s1 = (w - ax) * inv; // crossing of x=width
+    if (s0 > s1) {
+      final tmp = s0;
+      s0 = s1;
+      s1 = tmp;
+    }
+    var prevS = 0.0;
+    var px = ax, py = ay;
+    void piece(double s) {
+      if (s <= prevS) return;
+      final cs = s < 1 ? s : 1.0;
+      if (cs <= prevS) return;
+      final qx = ax + (bx - ax) * cs, qy = ay + (by - ay) * cs;
+      final midX = (px + qx) * 0.5;
+      if (midX < 0) {
+        _binSegment(0, py, 0, qy);
+      } else if (midX > w) {
+        _binSegment(w, py, w, qy);
+      } else {
+        _binSegment(px, py, qx, qy);
+      }
+      px = qx;
+      py = qy;
+      prevS = cs;
+    }
+
+    if (s0 > 0 && s0 < 1) piece(s0);
+    if (s1 > 0 && s1 < 1) piece(s1);
+    piece(1);
+  }
+
+  /// Y-slices an in-viewport edge into 4-px rows and links the nodes.
+  void _binSegment(double x0, double y0, double x1, double y1) {
+    if (y0 == y1) return;
+    final down = y1 > y0;
+    final ymin = down ? y0 : y1, ymax = down ? y1 : y0;
+    final xAtMin = down ? x0 : x1, xAtMax = down ? x1 : x0;
+    final slope = (xAtMax - xAtMin) / (ymax - ymin); // dx/dy
+    final w = _width.toDouble();
+    var r0 = (ymin * 0.25).floor();
+    var r1 = (ymax * 0.25).ceil() - 1;
+    if (r0 < 0) r0 = 0;
+    if (r1 >= _rowCount) r1 = _rowCount - 1;
+    for (var r = r0; r <= r1; r++) {
+      final slabTop = r * 4.0;
+      final ys = ymin > slabTop ? ymin : slabTop;
+      final ye = ymax < slabTop + 4 ? ymax : slabTop + 4;
+      if (ye <= ys) continue;
+      // clamp against fp drift at the x-split breakpoints
+      var xs = xAtMin + (ys - ymin) * slope;
+      var xe = xAtMin + (ye - ymin) * slope;
+      if (xs < 0) {
+        xs = 0;
+      } else if (xs > w) {
+        xs = w;
+      }
+      if (xe < 0) {
+        xe = 0;
+      } else if (xe > w) {
+        xe = w;
+      }
+      // node in original direction so dy keeps its sign
+      if (down) {
+        _pushNode(r, xs, ys - slabTop, xe, ye - slabTop);
+      } else {
+        _pushNode(r, xe, ye - slabTop, xs, ys - slabTop);
+      }
+    }
+  }
+
+  void _pushNode(int r, double x0, double y0, double x1, double y1) {
+    var nc = _nodeCount;
+    if (4 * nc + 4 > _nodes.length) {
+      _nodes = Float32List(_nodes.length * 2)..setRange(0, 4 * nc, _nodes);
+      _nodeNext = Int32List(_nodeNext.length * 2)
+        ..setRange(0, nc, _nodeNext);
+    }
+    final base = 4 * nc;
+    _nodes[base] = x0;
+    _nodes[base + 1] = y0;
+    _nodes[base + 2] = x1;
+    _nodes[base + 3] = y1;
+    final head = _rowHead[r];
+    _nodeNext[nc] = head;
+    _rowHead[r] = nc;
+    _nodeCount = nc + 1;
+
+    final lo = x0 < x1 ? x0 : x1;
+    final hi = x0 < x1 ? x1 : x0;
+    final mn = lo.floor();
+    final mx = hi.ceil();
+    if (head == -1) {
+      if (_dirtyCount == _dirtyRows.length) {
+        _dirtyRows = Int32List(_dirtyRows.length * 2)
+          ..setRange(0, _dirtyCount, _dirtyRows);
+      }
+      _dirtyRows[_dirtyCount++] = r;
+      _rowMinX[r] = mn;
+      _rowMaxX[r] = mx;
+    } else {
+      if (mn < _rowMinX[r]) _rowMinX[r] = mn;
+      if (mx > _rowMaxX[r]) _rowMaxX[r] = mx;
+    }
+  }
+
+  // ---- fine raster + emission ------------------------------------------
+
+  void _finishShape(PdfFillRule rule, int rgba) {
+    final evenOdd = rule == PdfFillRule.evenOdd;
+    for (var d = 0; d < _dirtyCount; d++) {
+      final r = _dirtyRows[d];
+      _rasterizeRow(r, evenOdd, rgba);
+      _rowHead[r] = -1;
+    }
+    _dirtyCount = 0;
+    _nodeCount = 0;
+  }
+
+  void _rasterizeRow(int r, bool evenOdd, int rgba) {
+    final a = _accum;
+    final stride = _stride;
+    final nodes = _nodes;
+    final next = _nodeNext;
+
+    // font-rs signed-area accumulation, one unit scanline at a time.
+    var node = _rowHead[r];
+    while (node != -1) {
+      final base = 4 * node;
+      var xA = nodes[base];
+      final yA = nodes[base + 1];
+      var xB = nodes[base + 2];
+      final yB = nodes[base + 3];
+      node = next[node];
+      if (yA == yB) continue;
+      double p0y, p1y, dir;
+      if (yB > yA) {
+        p0y = yA;
+        p1y = yB;
+        dir = 1.0;
+      } else {
+        p0y = yB;
+        p1y = yA;
+        dir = -1.0;
+        final t = xA;
+        xA = xB;
+        xB = t;
+      }
+      final dxdy = (xB - xA) / (p1y - p0y);
+      var x = xA;
+      var yCur = p0y;
+      var yi = p0y.floor();
+      final yiLast = p1y.ceil() - 1;
+      if (yi < 0) yi = 0;
+      for (; yi <= yiLast && yi < 4; yi++) {
+        final rowBase = yi * stride;
+        final yNext = (yi + 1.0) < p1y ? (yi + 1.0) : p1y;
+        final dy = yNext - yCur;
+        // Stepwise x can drift one ulp past the (clamped) endpoints; a
+        // negative x would index the accumulator at -1 (glyph-local frames
+        // start exactly at 0, so this is not hypothetical).
+        var xnext = x + dxdy * dy;
+        if (xnext < 0) xnext = 0;
+        final d = dy * dir;
+        double xx0, xx1;
+        if (x < xnext) {
+          xx0 = x;
+          xx1 = xnext;
+        } else {
+          xx0 = xnext;
+          xx1 = x;
+        }
+        final x0floor = xx0.floorToDouble();
+        final x0i = x0floor.toInt();
+        final x1ceil = xx1.ceilToDouble();
+        final x1i = x1ceil.toInt();
+        if (x1i <= x0i + 1) {
+          // the crossing stays within one column
+          final xmf = 0.5 * (x + xnext) - x0floor;
+          a[rowBase + x0i] += d * (1 - xmf);
+          a[rowBase + x0i + 1] += d * xmf;
+        } else {
+          final s = 1 / (xx1 - xx0);
+          final x0f = xx0 - x0floor;
+          final a0 = 0.5 * s * (1 - x0f) * (1 - x0f);
+          final x1f = xx1 - x1ceil + 1;
+          final am = 0.5 * s * x1f * x1f;
+          a[rowBase + x0i] += d * a0;
+          if (x1i == x0i + 2) {
+            a[rowBase + x0i + 1] += d * (1 - a0 - am);
+          } else {
+            final a1 = s * (1.5 - x0f);
+            a[rowBase + x0i + 1] += d * (a1 - a0);
+            for (var xi = x0i + 2; xi < x1i - 1; xi++) {
+              a[rowBase + xi] += d * s;
+            }
+            final a2 = a1 + (x1i - x0i - 3) * s;
+            a[rowBase + x1i - 1] += d * (1 - a2 - am);
+          }
+          a[rowBase + x1i] += d * am;
+        }
+        x = xnext;
+        yCur = yNext;
+      }
+    }
+
+    // Prefix-sum + fill rule + strip emission over the touched span. The
+    // accumulator is zeroed behind the scan in the same pass (fused - no
+    // second traversal), with fast paths for fully-transparent and
+    // fully-covered columns (the two dominant cases: gaps between islands
+    // and fill interiors).
+    final x0 = _rowMinX[r];
+    final xMax = _rowMaxX[r];
+    var xEnd = xMax;
+    if (xEnd >= _width) xEnd = _width - 1;
+    final y = r << 2;
+    final buf = strips;
+    final baseFlags = evenOdd ? stripFlagEvenOdd : 0;
+    final s1 = stride, s2 = 2 * stride, s3 = 3 * stride;
+
+    var acc0 = 0.0, acc1 = 0.0, acc2 = 0.0, acc3 = 0.0;
+    var mode = 0; // 0 none, 1 solid run, 2 mixed strip
+    var runStart = 0;
+    var alphaStart = 0;
+    var pending = 0; // trailing all-255 columns inside a mixed strip
+
+    for (var x = x0; x <= xEnd; x++) {
+      final d0 = a[x];
+      if (d0 != 0) {
+        acc0 += d0;
+        a[x] = 0;
+      }
+      final d1 = a[s1 + x];
+      if (d1 != 0) {
+        acc1 += d1;
+        a[s1 + x] = 0;
+      }
+      final d2 = a[s2 + x];
+      if (d2 != 0) {
+        acc2 += d2;
+        a[s2 + x] = 0;
+      }
+      final d3 = a[s3 + x];
+      if (d3 != 0) {
+        acc3 += d3;
+        a[s3 + x] = 0;
+      }
+      // fill rule, manually inlined per scanline (hot loop)
+      var v0 = acc0, v1 = acc1, v2 = acc2, v3 = acc3;
+      if (evenOdd) {
+        v0 -= 2 * (v0 * 0.5).roundToDouble();
+        v1 -= 2 * (v1 * 0.5).roundToDouble();
+        v2 -= 2 * (v2 * 0.5).roundToDouble();
+        v3 -= 2 * (v3 * 0.5).roundToDouble();
+      }
+      if (v0 < 0) v0 = -v0;
+      if (v1 < 0) v1 = -v1;
+      if (v2 < 0) v2 = -v2;
+      if (v3 < 0) v3 = -v3;
+      int a32;
+      if (v0 == 0 && v1 == 0 && v2 == 0 && v3 == 0) {
+        a32 = 0;
+      } else if (v0 >= 1 && v1 >= 1 && v2 >= 1 && v3 >= 1) {
+        a32 = 0xFFFFFFFF;
+      } else {
+        if (v0 > 1) v0 = 1;
+        if (v1 > 1) v1 = 1;
+        if (v2 > 1) v2 = 1;
+        if (v3 > 1) v3 = 1;
+        a32 = (v0 * 255 + 0.5).toInt() |
+            ((v1 * 255 + 0.5).toInt() << 8) |
+            ((v2 * 255 + 0.5).toInt() << 16) |
+            ((v3 * 255 + 0.5).toInt() << 24);
+      }
+
+      if (a32 == 0) {
+        if (mode == 1) {
+          buf._emit(runStart, y, x - runStart, baseFlags | stripFlagSolid,
+              stripSolidSentinel, rgba);
+        } else if (mode == 2) {
+          if (pending >= 2) {
+            buf._emit(runStart, y, x - pending - runStart, baseFlags,
+                alphaStart, rgba);
+            buf._emit(x - pending, y, pending, baseFlags | stripFlagSolid,
+                stripSolidSentinel, rgba);
+          } else {
+            if (pending == 1) buf._appendTexel(0xFFFFFFFF);
+            buf._emit(runStart, y, x - runStart, baseFlags, alphaStart, rgba);
+          }
+        }
+        mode = 0;
+        pending = 0;
+      } else if (a32 == 0xFFFFFFFF) {
+        if (mode == 0) {
+          runStart = x;
+          mode = 1;
+        } else if (mode == 2) {
+          pending++;
+        }
+      } else {
+        if (mode == 0) {
+          runStart = x;
+          mode = 2;
+          alphaStart = buf.alphaColumns;
+          buf._appendTexel(a32);
+        } else if (mode == 1) {
+          final solidLen = x - runStart;
+          if (solidLen >= 2) {
+            buf._emit(runStart, y, solidLen, baseFlags | stripFlagSolid,
+                stripSolidSentinel, rgba);
+            runStart = x;
+            alphaStart = buf.alphaColumns;
+          } else {
+            // a single solid column joins the mixed strip as a 255-texel
+            alphaStart = buf.alphaColumns;
+            buf._appendTexel(0xFFFFFFFF);
+          }
+          mode = 2;
+          pending = 0;
+          buf._appendTexel(a32);
+        } else {
+          if (pending > 0) {
+            if (pending >= 2) {
+              buf._emit(runStart, y, x - pending - runStart, baseFlags,
+                  alphaStart, rgba);
+              buf._emit(x - pending, y, pending, baseFlags | stripFlagSolid,
+                  stripSolidSentinel, rgba);
+              runStart = x;
+              alphaStart = buf.alphaColumns;
+            } else {
+              buf._appendTexel(0xFFFFFFFF);
+            }
+            pending = 0;
+          }
+          buf._appendTexel(a32);
+        }
+      }
+    }
+    // end-of-row flush
+    final xAfter = xEnd + 1;
+    if (mode == 1) {
+      buf._emit(runStart, y, xAfter - runStart, baseFlags | stripFlagSolid,
+          stripSolidSentinel, rgba);
+    } else if (mode == 2) {
+      if (pending >= 2) {
+        buf._emit(runStart, y, xAfter - pending - runStart, baseFlags,
+            alphaStart, rgba);
+        buf._emit(xAfter - pending, y, pending, baseFlags | stripFlagSolid,
+            stripSolidSentinel, rgba);
+      } else {
+        if (pending == 1) buf._appendTexel(0xFFFFFFFF);
+        buf._emit(runStart, y, xAfter - runStart, baseFlags, alphaStart, rgba);
+      }
+    }
+
+    // The scan zeroed [x0, xEnd]; accumulation can also write up to
+    // xMax + 1 (the spill cell past ceil(max x)) - zero the tail.
+    var zEnd = xMax + 2;
+    if (zEnd > stride) zEnd = stride;
+    for (var x = xEnd + 1; x < zEnd; x++) {
+      a[x] = 0;
+      a[s1 + x] = 0;
+      a[s2 + x] = 0;
+      a[s3 + x] = 0;
+    }
+  }
+}
+
+/// Cache key: outline identity + quantized transform (2x2 in 1/64 steps,
+/// x offset in 1/4 px, y offset in 1/4 px within the 4-px strip row).
+typedef GlyphStripKey = (FlattenedOutline, int, int, int, int, int, int);
+
+/// One glyph's emitted strips in relocatable form, packed into a single
+/// allocation: `[xy... | widthFlags... | alphaOffset... | alphaTexels...]`
+/// with [stripCount] entries per strip section. xy is glyph-local
+/// (x | y<<16, y row-aligned), alphaOffset indexes the texel section,
+/// color is omitted (the replay overrides it). Immutable once built.
+class CachedGlyphStrips {
+  CachedGlyphStrips(this.data, this.stripCount, this.alphaTexelCount);
+
+  final Uint32List data;
+  final int stripCount;
+  final int alphaTexelCount;
+
+  int get alphaBytes => alphaTexelCount * 4;
+}
+
+/// LRU cache of rasterized glyph strips, replayed by [StripGenerator.fillOutline].
+///
+/// Keys are (immutable outline identity, quantized matrix), so entries
+/// never go stale - the caps just bound memory. One instance is safe to
+/// share across generators on the same isolate ([shared] is the default);
+/// entries retain their FlattenedOutline keys, so a hard [clear] releases
+/// font memory if needed.
+class GlyphStripCache {
+  GlyphStripCache({this.maxEntries = 32768, this.maxAlphaBytes = 32 << 20});
+
+  /// Process-wide default instance.
+  static final GlyphStripCache shared = GlyphStripCache();
+
+  /// Glyphs larger than this on either side (device px) bypass the cache.
+  static const int maxGlyphSide = 512;
+
+  final int maxEntries;
+  final int maxAlphaBytes;
+
+  final _entries = <GlyphStripKey, CachedGlyphStrips>{};
+  int _alphaBytes = 0;
+
+  int hits = 0;
+  int misses = 0;
+  int bypasses = 0;
+
+  /// First-sight draws that rendered directly (cache-on-second-sight gate).
+  int firstSights = 0;
+
+  int get entryCount => _entries.length;
+  int get alphaBytes => _alphaBytes;
+
+  void resetStats() {
+    hits = 0;
+    misses = 0;
+    bypasses = 0;
+    firstSights = 0;
+  }
+
+  void clear() {
+    _entries.clear();
+    _seen.clear();
+    _alphaBytes = 0;
+  }
+
+  /// Scratch generator for building entries (no cache of its own - the
+  /// builder calls the direct raster path explicitly).
+  StripGenerator? _scratch;
+
+  /// Approximate seen-before filter for the cache-on-second-sight gate.
+  /// Keyed by a HASH of the full key (collisions merely cache a one-shot
+  /// glyph early or delay a repeat by one draw - the exact record key
+  /// still guards entry correctness). Cleared wholesale when full.
+  final _seen = <int>{};
+  static const int _seenCap = 1 << 17;
+
+  bool _secondSight(
+      int outlineId, int qa, int qb, int qc, int qd, int qx, int qy) {
+    final h = Object.hash(outlineId, qa, qb, qc, qd, qx, qy);
+    if (_seen.contains(h)) return true;
+    if (_seen.length >= _seenCap) _seen.clear();
+    _seen.add(h);
+    firstSights++;
+    return false;
+  }
+
+  CachedGlyphStrips? _lookup(GlyphStripKey key) {
+    // Insertion-order (FIFO) eviction, no reinsert on hit: hits are the
+    // hot path and LinkedHashMap remove+insert per hit measurably churns;
+    // with thousands of entries FIFO evicts nearly as well as LRU here.
+    final entry = _entries[key];
+    if (entry != null) hits++;
+    return entry;
+  }
+
+  CachedGlyphStrips _build(GlyphStripKey key, FlattenedOutline outline,
+      PdfMatrix local, int w, int h) {
+    misses++;
+    final scratch = _scratch ??= (StripGenerator()..glyphCache = null);
+    scratch.begin(w, h);
+    scratch._fillOutlineDirect(outline, local, 0);
+    final s = scratch.strips;
+    final n = s.length;
+    final texels = s.alphaColumns;
+    final data = Uint32List(3 * n + texels);
+    data.setRange(0, n, s.xy);
+    data.setRange(n, 2 * n, s.widthFlags);
+    data.setRange(2 * n, 3 * n, s.alphaOffset);
+    data.setRange(3 * n, 3 * n + texels, s._alphaTexels);
+    final entry = CachedGlyphStrips(data, n, texels);
+    if (maxEntries > 0) {
+      _entries[key] = entry;
+      _alphaBytes += entry.alphaBytes;
+      while (_entries.length > maxEntries || _alphaBytes > maxAlphaBytes) {
+        final eldest = _entries.keys.first;
+        _alphaBytes -= _entries.remove(eldest)!.alphaBytes;
+      }
+    }
+    return entry;
+  }
+}

--- a/packages/pdf_graphics/lib/src/raster/strip_generator.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_generator.dart
@@ -141,6 +141,16 @@ class StripGenerator {
   /// glyph directly (unquantized - the pre-cache behavior).
   GlyphStripCache? glyphCache = GlyphStripCache.shared;
 
+  /// Replayable stroke/fill strip cache consulted by [fillPath] and
+  /// [strokePath] for small paths (repeated CAD symbols, hatch strokes,
+  /// dimension arrows). Content-keyed - repeated geometry rarely shares
+  /// object identity, so the key is the translation-invariant quantized
+  /// outline (1/64 px deltas from the first point) plus stroke/fill
+  /// parameters and a 1/8-px anchor subpixel phase (the glyph cache's
+  /// scheme, finer grid; y phase stays within the 4-px strip row so
+  /// replays are row-aligned). Set null to rasterize every path directly (unquantized).
+  ShapeStripCache? shapeCache = ShapeStripCache.shared;
+
   int _width = 0;
   int _height = 0;
   int _rowCount = 0;
@@ -196,9 +206,24 @@ class StripGenerator {
 
   /// Fills [path] (page space) mapped through [transform] into device
   /// space. [rgba] is a premultiplied color from [premulRgba8].
+  ///
+  /// With a [shapeCache] attached (the default), small paths are memoized
+  /// by content (quantized outline + subpixel phase) and replayed with an
+  /// integer translate + color override; see [ShapeStripCache].
   void fillPath(PdfPath path, PdfMatrix transform, PdfFillRule rule, int rgba,
       {double tolerance = 0.25}) {
     if (path.isEmpty || _rowCount == 0) return;
+    final cache = shapeCache;
+    if (cache != null &&
+        path.segments.length <= ShapeStripCache.maxSegments &&
+        _shapeCached(cache, path, transform, rule, null, rgba, tolerance)) {
+      return;
+    }
+    _fillPathDirect(path, transform, rule, rgba, tolerance);
+  }
+
+  void _fillPathDirect(PdfPath path, PdfMatrix transform, PdfFillRule rule,
+      int rgba, double tolerance) {
     // The bbox pre-cull is a full extra pass over the path; for tiny paths
     // (the CAD common case: 4-segment quads by the tens of thousands)
     // flatten-and-bin is just as cheap and the binning clips anyway.
@@ -210,10 +235,26 @@ class StripGenerator {
   /// Strokes [path] (page space, stroke parameters in page space like
   /// [PdfDevice.strokePath]) by expanding to closed contours and filling
   /// them nonzero.
+  ///
+  /// Cached like [fillPath] when a [shapeCache] is attached; stroke
+  /// parameters (device width, caps, joins, dashes - quantized to 1/64 px)
+  /// join the content key.
   void strokePath(
       PdfPath path, PdfMatrix transform, PdfStroke stroke, int rgba,
       {double tolerance = 0.25}) {
     if (path.isEmpty || _rowCount == 0) return;
+    final cache = shapeCache;
+    if (cache != null &&
+        path.segments.length <= ShapeStripCache.maxSegments &&
+        _shapeCached(cache, path, transform, PdfFillRule.nonzero, stroke,
+            rgba, tolerance)) {
+      return;
+    }
+    _strokePathDirect(path, transform, stroke, rgba, tolerance);
+  }
+
+  void _strokePathDirect(PdfPath path, PdfMatrix transform, PdfStroke stroke,
+      int rgba, double tolerance) {
     final sf = transform.scaleFactor;
     var subs = flattenPath(path, transform, tolerance: tolerance);
     if (subs.isEmpty) return;
@@ -392,14 +433,19 @@ class StripGenerator {
 
   /// Copies a cached glyph's strips into the main buffer with an integer
   /// translate and the current color.
-  void _replayGlyph(CachedGlyphStrips g, int dx, int dy, int rgba) {
-    final n = g.stripCount;
+  void _replayGlyph(CachedGlyphStrips g, int dx, int dy, int rgba) =>
+      _replayStrips(g.data, g.stripCount, g.alphaTexelCount, dx, dy, rgba);
+
+  /// Copies a relocatable strip blob (`[xy | widthFlags | alphaOffset |
+  /// alphaTexels]`, [n] strips) into the main buffer with an integer
+  /// translate and a color override.
+  void _replayStrips(
+      Uint32List data, int n, int alphaTexelCount, int dx, int dy, int rgba) {
     if (n == 0) return;
     final buf = strips;
     final alphaBase = buf.alphaColumns;
-    final data = g.data;
     buf._appendTexels(
-        Uint32List.sublistView(data, 3 * n, 3 * n + g.alphaTexelCount));
+        Uint32List.sublistView(data, 3 * n, 3 * n + alphaTexelCount));
     buf._ensureStrips(n);
     var at = buf.length;
     final xy = buf.xy, wf = buf.widthFlags, ao = buf.alphaOffset;
@@ -414,6 +460,410 @@ class StripGenerator {
       at++;
     }
     buf.length = at;
+  }
+
+  // ---- content-keyed stroke/fill strip cache -----------------------------
+
+  /// Scratch content record for the shape under consideration; layout in
+  /// [ShapeStripCache]'s doc comment. Reused across draws.
+  Int32List _shapeBuf = Int32List(512);
+  int _shapeLen = 0;
+
+  void _shapePush(int v) {
+    if (_shapeLen == _shapeBuf.length) {
+      _shapeBuf = Int32List(_shapeBuf.length * 2)
+        ..setRange(0, _shapeLen, _shapeBuf);
+    }
+    _shapeBuf[_shapeLen++] = v;
+  }
+
+  /// Tries the content-keyed cache path for a fill ([stroke] null) or
+  /// stroke. Returns true when the draw was fully handled (replayed, or
+  /// rasterized from the quantized content record); false sends the caller
+  /// to the direct, unquantized path (offscreen/oversized/degenerate
+  /// shapes - mirroring the glyph cache's bypass).
+  bool _shapeCached(ShapeStripCache cache, PdfPath path, PdfMatrix m,
+      PdfFillRule rule, PdfStroke? stroke, int rgba, double tolerance) {
+    // ---- build the content record (one transform pass over the path) ----
+    _shapeLen = 0;
+    final isStroke = stroke != null;
+    _shapePush((rule == PdfFillRule.evenOdd ? 1 : 0) | (isStroke ? 2 : 0));
+    _shapePush((tolerance * 1024).round());
+    final qxSlot = _shapeLen;
+    _shapePush(0); // qx - patched below once the anchor is known
+    final qySlot = _shapeLen;
+    _shapePush(0); // qy
+    var qWidth = 0, qCap = 0, qJoin = 0, qMiter = 0;
+    if (isStroke) {
+      final sf = m.scaleFactor;
+      qWidth = (stroke.width * sf * 64).round();
+      if (qWidth < 0 || qWidth > ShapeStripCache.maxShapeSide << 6) {
+        cache.bypasses++;
+        return false;
+      }
+      qCap = stroke.cap;
+      qJoin = stroke.join;
+      qMiter = (stroke.miterLimit * 64).round().clamp(0, 1 << 20);
+      _shapePush(qWidth);
+      _shapePush(qCap);
+      _shapePush(qJoin);
+      _shapePush(qMiter);
+      _shapePush((stroke.dashPhase * sf * 64).round().clamp(-(1 << 26),
+          1 << 26));
+      _shapePush(stroke.dashArray.length);
+      for (final d in stroke.dashArray) {
+        _shapePush((d * sf * 64).round().clamp(-(1 << 26), 1 << 26));
+      }
+    }
+    var hasAnchor = false;
+    var ax = 0.0, ay = 0.0;
+    var minDx = 0, maxDx = 0, minDy = 0, maxDy = 0;
+    // Whether the stroke can produce joins (>= 2 drawing segments in one
+    // subpath, a closing join, or a cubic - whose flattening joins at every
+    // polyline vertex). Single straight hatch/dimension segments - the hot
+    // CAD case - have none, so they skip the conservative miter pad.
+    var hasJoins = false;
+    var subpathDraws = 0;
+    // Quantized deltas beyond ~262k px can't be a cacheable small shape
+    // (and could stress 32-bit storage) - bail to the direct path.
+    const limit = 1 << 24;
+    var ok = true;
+    void pt(double x, double y) {
+      final dx = m.transformX(x, y), dy = m.transformY(x, y);
+      if (!dx.isFinite || !dy.isFinite) {
+        ok = false;
+        return;
+      }
+      if (!hasAnchor) {
+        ax = dx;
+        ay = dy;
+        hasAnchor = true;
+      }
+      final qdx = ((dx - ax) * 64).round();
+      final qdy = ((dy - ay) * 64).round();
+      if (qdx.abs() > limit || qdy.abs() > limit) {
+        ok = false;
+        return;
+      }
+      if (qdx < minDx) minDx = qdx;
+      if (qdx > maxDx) maxDx = qdx;
+      if (qdy < minDy) minDy = qdy;
+      if (qdy > maxDy) maxDy = qdy;
+      _shapePush(qdx);
+      _shapePush(qdy);
+    }
+
+    for (final segment in path.segments) {
+      switch (segment) {
+        case PdfMoveTo(:final x, :final y):
+          _shapePush(_shapeOpMove);
+          subpathDraws = 0;
+          pt(x, y);
+        case PdfLineTo(:final x, :final y):
+          _shapePush(_shapeOpLine);
+          if (++subpathDraws >= 2) hasJoins = true;
+          pt(x, y);
+        case PdfCubicTo():
+          _shapePush(_shapeOpCubic);
+          hasJoins = true;
+          pt(segment.x1, segment.y1);
+          pt(segment.x2, segment.y2);
+          pt(segment.x3, segment.y3);
+        case PdfClosePath():
+          _shapePush(_shapeOpClose);
+          if (subpathDraws >= 1) hasJoins = true;
+      }
+      if (!ok) return false;
+    }
+    if (!hasAnchor) return false;
+
+    // ---- anchor subpixel phase (the glyph cache's scheme, at 1/8 px:
+    // fills/strokes shift whole long edges when snapped, and the coarser
+    // 1/4-px grid measurably moved Ghent parity page means; 1/8 px halves
+    // the error for a 4x key-space cost the hit rates absorb). The y phase
+    // stays within the 4-px strip row so replays are row-aligned. ----
+    var ix = ax.floor();
+    var qx = ((ax - ix) * 8).round();
+    if (qx == 8) {
+      ix += 1;
+      qx = 0;
+    }
+    var iy = 4 * (ay / 4).floor();
+    var qy = ((ay - iy) * 8).round();
+    if (qy == 32) {
+      iy += 4;
+      qy = 0;
+    }
+    _shapeBuf[qxSlot] = qx;
+    _shapeBuf[qySlot] = qy;
+
+    // ---- local-frame bounds (from quantized content only, so every
+    // occurrence of a key derives the identical build frame) ----
+    final lx = qx * 0.125, ly = qy * 0.125;
+    var minX = lx + minDx / 64.0, maxX = lx + maxDx / 64.0;
+    var minY = ly + minDy / 64.0, maxY = ly + maxDy / 64.0;
+    if (isStroke) {
+      final width = qWidth / 64.0;
+      final hw = (width <= 0 ? 1.0 : width) / 2;
+      final joinFactor =
+          hasJoins && qJoin == 0 ? math.max(qMiter / 64.0, 1.0) : 1.0;
+      final capFactor = qCap == 2 ? 1.4143 : 1.0;
+      final pad = hw * math.max(joinFactor, capFactor) + 1.0;
+      minX -= pad;
+      minY -= pad;
+      maxX += pad;
+      maxY += pad;
+    }
+    final sx = minX.floor();
+    final sy = 4 * (minY / 4).floor();
+    final w = maxX.ceil() - sx + 1;
+    final h = maxY.ceil() - sy + 1;
+    final dx = ix + sx, dy = iy + sy; // replay translate (dy multiple of 4)
+    if (w > ShapeStripCache.maxShapeSide ||
+        h > ShapeStripCache.maxShapeSide ||
+        dx < 0 ||
+        dy < 0 ||
+        dx + w > _width ||
+        dy + h > _rowCount * 4) {
+      cache.bypasses++;
+      return false;
+    }
+
+    final hash = _shapeHash(_shapeBuf, _shapeLen);
+    final entry = cache._peek(hash);
+    if (entry != null) {
+      if (_shapeContentEquals(entry.content, _shapeBuf, _shapeLen)) {
+        cache.hits++;
+        cache._promote(hash, entry);
+        _replayStrips(
+            entry.data, entry.stripCount, entry.alphaTexelCount, dx, dy, rgba);
+        return true;
+      }
+      // 32-bit hash collision between distinct shapes: never replay - render
+      // this draw from its own quantized content. The stored entry stays.
+      cache.collisions++;
+      _rasterShapeContent(_shapeBuf, _shapeLen, ix.toDouble(), iy.toDouble(),
+          rgba);
+      return true;
+    }
+    if (!cache._secondSight(hash)) {
+      // First sight renders directly - but from the same quantized content,
+      // so this draw is byte-identical to the replays that follow once the
+      // key recurs (cache state never shifts pixels between renders).
+      _rasterShapeContent(_shapeBuf, _shapeLen, ix.toDouble(), iy.toDouble(),
+          rgba);
+      return true;
+    }
+    final built = cache._build(_shapeBuf, _shapeLen, hash, sx, sy, w, h);
+    _replayStrips(
+        built.data, built.stripCount, built.alphaTexelCount, dx, dy, rgba);
+    return true;
+  }
+
+  static bool _shapeContentEquals(Int32List stored, Int32List buf, int len) {
+    if (stored.length != len) return false;
+    for (var i = 0; i < len; i++) {
+      if (stored[i] != buf[i]) return false;
+    }
+    return true;
+  }
+
+  /// Jenkins one-at-a-time over the content ints; every step stays within
+  /// 32 bits (web-safe - no products past 2^53).
+  static int _shapeHash(Int32List c, int len) {
+    var h = 0x811c9dc5;
+    for (var i = 0; i < len; i++) {
+      h = (h + (c[i] & 0xFFFFFFFF)) & 0xFFFFFFFF;
+      h = (h + ((h << 10) & 0xFFFFFFFF)) & 0xFFFFFFFF;
+      h ^= h >>> 6;
+    }
+    h = (h + ((h << 3) & 0xFFFFFFFF)) & 0xFFFFFFFF;
+    h ^= h >>> 11;
+    h = (h + ((h << 15) & 0xFFFFFFFF)) & 0xFFFFFFFF;
+    return h;
+  }
+
+  static const int _shapeOpMove = 0;
+  static const int _shapeOpLine = 1;
+  static const int _shapeOpCubic = 2;
+  static const int _shapeOpClose = 3;
+
+  /// Rasterizes a shape content record with its anchor placed at
+  /// `(ox + qx/4, oy + qy/4)`: the first-sight/collision path passes the
+  /// anchor's integer device position, the cache build passes the local
+  /// frame shift. Mirrors the direct paths' semantics exactly (fill: pen
+  /// survives a close; stroke: flattenPath's close-is-final rule).
+  void _rasterShapeContent(Int32List c, int len, double ox, double oy,
+      int rgba) {
+    final flags = c[0];
+    final tolerance = c[1] / 1024.0;
+    final bx = ox + c[2] * 0.125;
+    final by = oy + c[3] * 0.125;
+    var p = 4;
+    if (flags & 2 != 0) {
+      final width = c[p++] / 64.0;
+      final cap = c[p++];
+      final join = c[p++];
+      final miterLimit = c[p++] / 64.0;
+      final phase = c[p++] / 64.0;
+      final nDash = c[p++];
+      List<double>? dashes;
+      var anyDash = false;
+      if (nDash > 0) {
+        dashes = List<double>.filled(nDash, 0);
+        for (var i = 0; i < nDash; i++) {
+          final d = c[p++] / 64.0;
+          dashes[i] = d;
+          if (d > 0) anyDash = true;
+        }
+      }
+      var subs = _flattenShapeContent(c, p, len, bx, by, tolerance);
+      if (subs.isEmpty) return;
+      if (anyDash) subs = dashSubpaths(subs, dashes!, phase);
+      _contours.clear();
+      strokeToContours(subs,
+          width: width,
+          cap: cap,
+          join: join,
+          miterLimit: miterLimit,
+          out: _contours);
+      fillContours(_contours, rgba);
+    } else {
+      _edgesFromShapeContent(c, p, len, bx, by, tolerance);
+      _finishShape(
+          flags & 1 != 0 ? PdfFillRule.evenOdd : PdfFillRule.nonzero, rgba);
+    }
+  }
+
+  /// [flattenPath] semantics over a content record (device-space quantized
+  /// points, already transformed).
+  List<FlatSubpath> _flattenShapeContent(
+      Int32List c, int start, int len, double bx, double by,
+      double tolerance) {
+    final out = <FlatSubpath>[];
+    DoubleBuilder? current;
+    var closed = false;
+    var startX = 0.0, startY = 0.0, lastX = 0.0, lastY = 0.0;
+
+    void finish() {
+      final done = current;
+      if (done != null && done.length >= 4) {
+        out.add(FlatSubpath(Float64List.fromList(done.view), closed: closed));
+      }
+      current = null;
+      closed = false;
+    }
+
+    var p = start;
+    while (p < len) {
+      final op = c[p++];
+      if (op == _shapeOpMove) {
+        finish();
+        lastX = startX = bx + c[p++] / 64.0;
+        lastY = startY = by + c[p++] / 64.0;
+        current = DoubleBuilder(64)..add2(startX, startY);
+      } else if (op == _shapeOpLine) {
+        final x = bx + c[p++] / 64.0, y = by + c[p++] / 64.0;
+        if (current == null) continue;
+        lastX = x;
+        lastY = y;
+        current!.add2(x, y);
+      } else if (op == _shapeOpCubic) {
+        final x1 = bx + c[p++] / 64.0, y1 = by + c[p++] / 64.0;
+        final x2 = bx + c[p++] / 64.0, y2 = by + c[p++] / 64.0;
+        final x3 = bx + c[p++] / 64.0, y3 = by + c[p++] / 64.0;
+        final cur = current;
+        if (cur == null) continue;
+        final d1 =
+            math.max((lastX - 2 * x1 + x2).abs(), (lastY - 2 * y1 + y2).abs());
+        final d2 =
+            math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
+        final d = math.max(d1, d2);
+        final n = d <= tolerance
+            ? 1
+            : math.sqrt(3 * d / (4 * tolerance)).ceil().clamp(1, 128);
+        for (var i = 1; i <= n; i++) {
+          final t = i / n;
+          final mt = 1 - t;
+          final a = mt * mt * mt, b = 3 * mt * mt * t, cc = 3 * mt * t * t;
+          final e = t * t * t;
+          cur.add2(a * lastX + b * x1 + cc * x2 + e * x3,
+              a * lastY + b * y1 + cc * y2 + e * y3);
+        }
+        lastX = x3;
+        lastY = y3;
+      } else {
+        // close
+        final cur = current;
+        if (cur == null) continue;
+        if (lastX != startX || lastY != startY) {
+          cur.add2(startX, startY);
+        }
+        closed = true;
+        lastX = startX;
+        lastY = startY;
+        finish();
+      }
+    }
+    finish();
+    return out;
+  }
+
+  /// [_flattenEdges] semantics over a content record.
+  void _edgesFromShapeContent(Int32List c, int start, int len, double bx,
+      double by, double tolerance) {
+    _subpathOpen = false;
+    var p = start;
+    while (p < len) {
+      final op = c[p++];
+      if (op == _shapeOpMove) {
+        _closeSubpath();
+        _penX = _startX = bx + c[p++] / 64.0;
+        _penY = _startY = by + c[p++] / 64.0;
+        _subpathOpen = true;
+      } else if (op == _shapeOpLine) {
+        final x = bx + c[p++] / 64.0, y = by + c[p++] / 64.0;
+        if (!_subpathOpen) continue;
+        _edge(_penX, _penY, x, y);
+        _penX = x;
+        _penY = y;
+      } else if (op == _shapeOpCubic) {
+        final x1 = bx + c[p++] / 64.0, y1 = by + c[p++] / 64.0;
+        final x2 = bx + c[p++] / 64.0, y2 = by + c[p++] / 64.0;
+        final x3 = bx + c[p++] / 64.0, y3 = by + c[p++] / 64.0;
+        if (!_subpathOpen) continue;
+        final d1 = math.max(
+            (_penX - 2 * x1 + x2).abs(), (_penY - 2 * y1 + y2).abs());
+        final d2 =
+            math.max((x1 - 2 * x2 + x3).abs(), (y1 - 2 * y2 + y3).abs());
+        final d = math.max(d1, d2);
+        final n = d <= tolerance
+            ? 1
+            : math.sqrt(3 * d / (4 * tolerance)).ceil().clamp(1, 128);
+        var px = _penX, py = _penY;
+        for (var i = 1; i <= n; i++) {
+          final t = i / n;
+          final mt = 1 - t;
+          final ba = mt * mt * mt, bb = 3 * mt * mt * t, bc = 3 * mt * t * t;
+          final be = t * t * t;
+          final qx = ba * _penX + bb * x1 + bc * x2 + be * x3;
+          final qy = ba * _penY + bb * y1 + bc * y2 + be * y3;
+          _edge(px, py, qx, qy);
+          px = qx;
+          py = qy;
+        }
+        _penX = x3;
+        _penY = y3;
+      } else {
+        // close
+        if (!_subpathOpen) continue;
+        _closeSubpath();
+        _penX = _startX;
+        _penY = _startY;
+        _subpathOpen = true; // pen stays; a following lineTo reopens
+      }
+    }
+    _closeSubpath();
   }
 
   // ---- culling ---------------------------------------------------------
@@ -1054,7 +1504,9 @@ class GlyphStripCache {
   CachedGlyphStrips _build(GlyphStripKey key, FlattenedOutline outline,
       PdfMatrix local, int w, int h) {
     misses++;
-    final scratch = _scratch ??= (StripGenerator()..glyphCache = null);
+    final scratch = _scratch ??= (StripGenerator()
+      ..glyphCache = null
+      ..shapeCache = null);
     scratch.begin(w, h);
     scratch._fillOutlineDirect(outline, local, 0);
     final s = scratch.strips;
@@ -1074,6 +1526,199 @@ class GlyphStripCache {
         _alphaBytes -= _entries.remove(eldest)!.alphaBytes;
       }
     }
+    return entry;
+  }
+}
+
+/// One shape's emitted strips in relocatable form (same packed layout as
+/// [CachedGlyphStrips]) plus the full content record the entry was keyed
+/// on - the map key is a 32-bit content hash, so every hit re-verifies the
+/// content before replaying (a collision falls back to direct raster, never
+/// to the wrong pixels).
+class CachedShapeStrips {
+  CachedShapeStrips(this.data, this.stripCount, this.alphaTexelCount,
+      this.content);
+
+  final Uint32List data;
+  final int stripCount;
+  final int alphaTexelCount;
+
+  /// The verified content record: `[flags, qTol, qx, qy,` stroke params +
+  /// dashes when flags bit 1 is set, `]` then interleaved segment opcodes
+  /// and 1/64-px quantized point deltas from the anchor.
+  final Int32List content;
+
+  /// Whole-entry footprint (strip blob + content record) - what the cache
+  /// budget counts, since shape entries are tiny and numerous (the strip
+  /// data, not the alpha texels, dominates).
+  int get dataBytes => data.lengthInBytes + content.lengthInBytes;
+}
+
+/// Content-keyed cache of rasterized stroke/fill strips, replayed by
+/// [StripGenerator.fillPath] and [StripGenerator.strokePath].
+///
+/// The glyph cache's design (relocatable strip blobs, subpixel-phase
+/// quantization with the y phase kept inside the 4-px strip row,
+/// cache-on-second-sight) applied to geometry without shared
+/// object identity: dense CAD sheets redraw the same hatch strokes,
+/// dimension arrows, and symbol fills thousands of times as distinct
+/// [PdfPath] instances, so the key is the shape's *content* - segment
+/// opcodes + point deltas from the first point quantized to 1/64 px,
+/// stroke/fill parameters, flatten tolerance, and the anchor's subpixel
+/// phase. Quantization moves geometry by at most 1/16 px (anchor snap) +
+/// 1/128 px (deltas) - half the glyph cache's budget, because snapping a
+/// fill shifts whole edges rather than one glyph.
+///
+/// Only paths with at most [maxSegments] segments attempt the cache (the
+/// content walk costs one transform pass + hash, which huge one-off
+/// clip/boundary paths must not pay), and - like glyphs - shapes larger
+/// than [maxShapeSide] device px or not fully inside the viewport bypass
+/// to the direct unquantized raster.
+class ShapeStripCache {
+  ShapeStripCache({this.maxEntries = 131072, this.maxBytes = 64 << 20});
+
+  /// Process-wide default instance.
+  static final ShapeStripCache shared = ShapeStripCache();
+
+  /// Shapes larger than this on either side (device px, stroke pad
+  /// included) bypass the cache.
+  static const int maxShapeSide = 512;
+
+  /// Paths with more segments than this never attempt the cache: the
+  /// content walk + hash would tax every huge one-off boundary path, and
+  /// plotted symbols/hatches stay far below it.
+  static const int maxSegments = 64;
+
+  /// Live-entry cap across both generations. Dense CAD documents carry
+  /// ~25-40k distinct small-shape keys per 10-page render; each generation
+  /// (half this cap) must hold a whole document's working set or its own
+  /// render rotates its early keys out and every recurrence turns into a
+  /// full rebuild (measured slower than no cache at all on ly9-far-cad at
+  /// a 16k cap). Steady state on the heavy corpus is ~40k entries /
+  /// ~20 MB; the cap is headroom, not expected occupancy.
+  final int maxEntries;
+
+  /// Byte budget over [CachedShapeStrips.dataBytes] (strip blob + content),
+  /// across both generations.
+  final int maxBytes;
+
+  // Two-generation storage: inserts and promotions go to the current
+  // generation; when it reaches half the budget the previous generation is
+  // dropped wholesale and the maps rotate. Unlike per-entry FIFO eviction
+  // (which at capacity churns one remove+alloc per insert forever and
+  // rebuild-storms on cyclic access), rotation reclaims memory in O(1)
+  // bulk drops and anything still hot survives via promotion on its next
+  // verified hit.
+  var _current = <int, CachedShapeStrips>{};
+  var _previous = <int, CachedShapeStrips>{};
+  int _currentBytes = 0;
+  int _previousBytes = 0;
+
+  int hits = 0;
+  int misses = 0;
+  int bypasses = 0;
+
+  /// First-sight draws that rendered directly (cache-on-second-sight gate).
+  int firstSights = 0;
+
+  /// Draws whose 32-bit content hash matched a stored entry with different
+  /// content; rendered directly (correctness never rides on the hash).
+  int collisions = 0;
+
+  int get entryCount => _current.length + _previous.length;
+  int get dataBytes => _currentBytes + _previousBytes;
+
+  void resetStats() {
+    hits = 0;
+    misses = 0;
+    bypasses = 0;
+    firstSights = 0;
+    collisions = 0;
+  }
+
+  void clear() {
+    _current = {};
+    _previous = {};
+    _currentBytes = 0;
+    _previousBytes = 0;
+    _seenA = {};
+    _seenB = {};
+  }
+
+  /// Scratch generator for building entries (its own caches off).
+  StripGenerator? _scratch;
+
+  // Approximate seen-before filter for the cache-on-second-sight gate,
+  // keyed by the content hash - also two rotating generations, so it
+  // behaves as a sliding window instead of periodic total amnesia (a
+  // wholesale clear used to land, deterministically, mid-way through the
+  // corpus sweep and reset the gate exactly when WAT_L0001_S rendered -
+  // its keys then never got past first sight).
+  // Window sizing is a measured trade: these generations (window = 64-128k
+  // sightings) comfortably span any single document's render, so zoom
+  // re-bins and page revisits always cache. A 2x window was tried to also
+  // catch repeats across a whole 49-file corpus sweep - it admitted so
+  // many sweep-scale one-shots that entry generations thrashed (202k vs
+  // 48k builds) and the corpus mean got worse, while WAT_L0001_S stayed
+  // flat. Cross-document-sweep reuse is not a pattern worth buying.
+  var _seenA = <int>{};
+  var _seenB = <int>{};
+  static const int _seenGenCap = 1 << 16;
+
+  bool _secondSight(int hash) {
+    if (_seenA.contains(hash) || _seenB.contains(hash)) return true;
+    if (_seenA.length >= _seenGenCap) {
+      _seenB = _seenA;
+      _seenA = {};
+    }
+    _seenA.add(hash);
+    firstSights++;
+    return false;
+  }
+
+  CachedShapeStrips? _peek(int hash) => _current[hash] ?? _previous[hash];
+
+  /// Moves a content-verified hit from the previous generation into the
+  /// current one so it survives the next rotation.
+  void _promote(int hash, CachedShapeStrips entry) {
+    final moved = _previous.remove(hash);
+    if (moved == null) return;
+    _previousBytes -= moved.dataBytes;
+    _insert(hash, moved);
+  }
+
+  void _insert(int hash, CachedShapeStrips entry) {
+    if (maxEntries <= 0) return;
+    if (_current.length >= (maxEntries >> 1).clamp(1, maxEntries) ||
+        _currentBytes >= maxBytes >> 1) {
+      _previous = _current;
+      _previousBytes = _currentBytes;
+      _current = {};
+      _currentBytes = 0;
+    }
+    _current[hash] = entry;
+    _currentBytes += entry.dataBytes;
+  }
+
+  CachedShapeStrips _build(
+      Int32List buf, int len, int hash, int sx, int sy, int w, int h) {
+    misses++;
+    final scratch = _scratch ??= (StripGenerator()
+      ..glyphCache = null
+      ..shapeCache = null);
+    scratch.begin(w, h);
+    scratch._rasterShapeContent(buf, len, -sx.toDouble(), -sy.toDouble(), 0);
+    final s = scratch.strips;
+    final n = s.length;
+    final texels = s.alphaColumns;
+    final data = Uint32List(3 * n + texels);
+    data.setRange(0, n, s.xy);
+    data.setRange(n, 2 * n, s.widthFlags);
+    data.setRange(2 * n, 3 * n, s.alphaOffset);
+    data.setRange(3 * n, 3 * n + texels, s._alphaTexels);
+    final content = Int32List(len)..setRange(0, len, buf);
+    final entry = CachedShapeStrips(data, n, texels, content);
+    _insert(hash, entry);
     return entry;
   }
 }

--- a/packages/pdf_graphics/lib/src/raster/stroke_contours.dart
+++ b/packages/pdf_graphics/lib/src/raster/stroke_contours.dart
@@ -1,0 +1,292 @@
+// Stroke expansion for the CPU strip rasterizer: turns stroked polylines
+// into closed polygon contours (per-segment quads, join wedges, caps) that
+// feed the nonzero fill kernel. Contours from one stroke overlap freely at
+// joins - every ring is normalized to the same winding orientation, so
+// overlap only pushes the nonzero winding count above 1, which
+// `min(1, |w|)` flattens back to full coverage (no cancellation).
+//
+// Geometry semantics match the flutter_gpu experiment's
+// appendStrokeTriangles except for hairlines: width is the full stroke
+// width in device pixels, drawn EXACTLY - a 0.5-px stroke becomes a
+// 0.5-px contour whose antialiased coverage is a half-covered band, the
+// same as Skia's sub-pixel stroking (the GPU experiment clamped to >= 1 px
+// because its aliased raster would otherwise drop thin strokes; a
+// coverage-based consumer must not - Ghent's 0.25-pt X patches showed the
+// clamp as a fat-stroke parity failure). Width <= 0 is the PDF hairline
+// ("thinnest renderable", §8.4.3.2) and draws 1 device px. Joins are
+// 0 miter (falling back to bevel past the miter limit), 1 round, 2 bevel;
+// caps are 0 butt, 1 round, 2 projecting square (§8.4.3.3-4). Dashing is
+// the caller's job via [dashSubpaths] - dashes are re-cut polylines, so
+// they flow through here unchanged.
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'flatten.dart';
+
+/// Closed polygon contours accumulated as one flat point list plus ring
+/// boundaries; reused across strokes (clear + refill, no reallocation).
+class StrokeContours {
+  final DoubleBuilder points = DoubleBuilder(512);
+  Int32List _ringEnds = Int32List(64);
+  int ringCount = 0;
+
+  int _ringStart = 0;
+
+  /// Start offset (in doubles) of ring [i] within [points].
+  int ringStart(int i) => i == 0 ? 0 : _ringEnds[i - 1];
+
+  /// End offset (exclusive, in doubles) of ring [i] within [points].
+  int ringEnd(int i) => _ringEnds[i];
+
+  bool get isEmpty => ringCount == 0;
+
+  void clear() {
+    points.clear();
+    ringCount = 0;
+    _ringStart = 0;
+  }
+
+  void _beginRing() {
+    _ringStart = points.length;
+  }
+
+  void _add(double x, double y) => points.add2(x, y);
+
+  /// Closes the ring under construction: drops degenerate rings, normalizes
+  /// winding so every ring in the set turns the same way (shoelace-positive),
+  /// and records the ring boundary.
+  void _endRing() {
+    final start = _ringStart;
+    final end = points.length;
+    final n = (end - start) ~/ 2;
+    if (n < 3) {
+      points.length = start; // degenerate: drop
+      return;
+    }
+    // Shoelace signed area; normalize to positive so nonzero winding of
+    // overlapping rings accumulates instead of cancelling.
+    var area = 0.0;
+    for (var i = 0, j = n - 1; i < n; j = i++) {
+      area += points[start + 2 * j] * points[start + 2 * i + 1] -
+          points[start + 2 * i] * points[start + 2 * j + 1];
+    }
+    if (area.abs() < 1e-12) {
+      points.length = start; // zero-area sliver: drop
+      return;
+    }
+    if (area < 0) {
+      // reverse the ring in place
+      for (var i = 0, j = n - 1; i < j; i++, j--) {
+        final xi = points[start + 2 * i];
+        final yi = points[start + 2 * i + 1];
+        points[start + 2 * i] = points[start + 2 * j];
+        points[start + 2 * i + 1] = points[start + 2 * j + 1];
+        points[start + 2 * j] = xi;
+        points[start + 2 * j + 1] = yi;
+      }
+    }
+    if (ringCount == _ringEnds.length) {
+      _ringEnds = Int32List(_ringEnds.length * 2)
+        ..setRange(0, ringCount, _ringEnds);
+    }
+    _ringEnds[ringCount++] = end;
+  }
+}
+
+/// Expands stroked [subpaths] (already flattened, already dashed, device
+/// pixels) into closed contours appended to [out]. See the library comment
+/// for parameter semantics.
+void strokeToContours(
+  List<FlatSubpath> subpaths, {
+  required double width,
+  required int cap,
+  required int join,
+  required double miterLimit,
+  required StrokeContours out,
+}) {
+  final hw = (width <= 0 ? 1.0 : width) / 2;
+
+  void wedge(double px, double py, double ax, double ay, double bx, double by) {
+    out._beginRing();
+    out._add(px, py);
+    out._add(ax, ay);
+    out._add(bx, by);
+    out._endRing();
+  }
+
+  // Circular-arc polygon fanned from (cx, cy); same step density as the GPU
+  // triangle fan (<= 0.35 rad per step).
+  void fan(double cx, double cy, double fromAngle, double sweep) {
+    final steps = math.max(2, (sweep.abs() / 0.35).ceil());
+    out._beginRing();
+    out._add(cx, cy);
+    for (var i = 0; i <= steps; i++) {
+      final a = fromAngle + sweep * i / steps;
+      out._add(cx + hw * math.cos(a), cy + hw * math.sin(a));
+    }
+    out._endRing();
+  }
+
+  void joinAt(double x, double y, double d0x, double d0y, double d1x,
+      double d1y, double n0x, double n0y, double n1x, double n1y) {
+    final cross = d0x * d1y - d0y * d1x;
+    if (cross.abs() < 1e-9) return; // collinear: quads already meet
+    // outer side is the turn's convex side
+    final outer0x = cross > 0 ? -n0x : n0x, outer0y = cross > 0 ? -n0y : n0y;
+    final outer1x = cross > 0 ? -n1x : n1x, outer1y = cross > 0 ? -n1y : n1y;
+    switch (join) {
+      case 1: // round
+        final a0 = math.atan2(outer0y, outer0x);
+        var sweep = math.atan2(outer1y, outer1x) - a0;
+        while (sweep > math.pi) {
+          sweep -= 2 * math.pi;
+        }
+        while (sweep < -math.pi) {
+          sweep += 2 * math.pi;
+        }
+        fan(x, y, a0, sweep);
+      case 2: // bevel
+        wedge(x, y, x + outer0x, y + outer0y, x + outer1x, y + outer1y);
+      default: // miter, bevel past the limit
+        final mx = outer0x + outer1x, my = outer0y + outer1y;
+        final mlen2 = mx * mx + my * my;
+        if (mlen2 < 1e-12) {
+          wedge(x, y, x + outer0x, y + outer0y, x + outer1x, y + outer1y);
+          return;
+        }
+        // miter point: along (m) scaled so its projection touches both
+        // offset lines
+        final scale = 2 * hw * hw / mlen2;
+        final px = mx * scale, py = my * scale;
+        final miterRatio = math.sqrt(px * px + py * py) / hw;
+        if (miterRatio > miterLimit) {
+          wedge(x, y, x + outer0x, y + outer0y, x + outer1x, y + outer1y);
+        } else {
+          out._beginRing();
+          out._add(x, y);
+          out._add(x + outer0x, y + outer0y);
+          out._add(x + px, y + py);
+          out._add(x + outer1x, y + outer1y);
+          out._endRing();
+        }
+    }
+  }
+
+  void squareCap(double x, double y, double dx, double dy) {
+    final nx = -dy * hw, ny = dx * hw;
+    final ex = x + dx * hw, ey = y + dy * hw;
+    out._beginRing();
+    out._add(x + nx, y + ny);
+    out._add(ex + nx, ey + ny);
+    out._add(ex - nx, ey - ny);
+    out._add(x - nx, y - ny);
+    out._endRing();
+  }
+
+  for (final sub in subpaths) {
+    // strip consecutive duplicates
+    final raw = sub.points;
+    final p = DoubleBuilder(raw.length);
+    for (var i = 0; i < raw.length; i += 2) {
+      final x = raw[i], y = raw[i + 1];
+      if (p.length >= 2 &&
+          (x - p[p.length - 2]).abs() < 1e-9 &&
+          (y - p[p.length - 1]).abs() < 1e-9) {
+        continue;
+      }
+      p.add2(x, y);
+    }
+    final pts = p.view;
+    var n = pts.length ~/ 2;
+    final closed = sub.closed && n > 2;
+    if (closed && pts[0] == pts[2 * n - 2] && pts[1] == pts[2 * n - 1]) n--;
+
+    if (n == 1) {
+      // isolated point: round/square caps paint a dot, butt paints nothing
+      if (cap == 1) {
+        fan(pts[0], pts[1], 0, math.pi);
+        fan(pts[0], pts[1], math.pi, math.pi);
+      } else if (cap == 2) {
+        out._beginRing();
+        out._add(pts[0] - hw, pts[1] - hw);
+        out._add(pts[0] + hw, pts[1] - hw);
+        out._add(pts[0] + hw, pts[1] + hw);
+        out._add(pts[0] - hw, pts[1] + hw);
+        out._endRing();
+      }
+      continue;
+    }
+    if (n < 2) continue;
+
+    final segs = closed ? n : n - 1;
+    var prevNx = 0.0, prevNy = 0.0, prevDirX = 0.0, prevDirY = 0.0;
+    for (var s = 0; s < segs; s++) {
+      final ax = pts[2 * s], ay = pts[2 * s + 1];
+      final bi = (s + 1) % n;
+      final bx = pts[2 * bi], by = pts[2 * bi + 1];
+      var dx = bx - ax, dy = by - ay;
+      final len = math.sqrt(dx * dx + dy * dy);
+      if (len < 1e-12) continue;
+      dx /= len;
+      dy /= len;
+      final nx = -dy * hw, ny = dx * hw;
+
+      // segment body quad
+      out._beginRing();
+      out._add(ax + nx, ay + ny);
+      out._add(bx + nx, by + ny);
+      out._add(bx - nx, by - ny);
+      out._add(ax - nx, ay - ny);
+      out._endRing();
+
+      // join with the previous segment at (ax, ay)
+      if (s > 0 || closed) {
+        if (s == 0 && closed) {
+          // the wrap join is emitted after the loop when prev* is known
+        } else {
+          joinAt(ax, ay, prevDirX, prevDirY, dx, dy, prevNx, prevNy, nx, ny);
+        }
+      }
+      prevNx = nx;
+      prevNy = ny;
+      prevDirX = dx;
+      prevDirY = dy;
+
+      if (closed && s == segs - 1) {
+        // wrap join at the start point between the last and first segments
+        var fdx = pts[2] - pts[0], fdy = pts[3] - pts[1];
+        final flen = math.sqrt(fdx * fdx + fdy * fdy);
+        if (flen > 1e-12) {
+          fdx /= flen;
+          fdy /= flen;
+          joinAt(pts[0], pts[1], dx, dy, fdx, fdy, nx, ny, -fdy * hw,
+              fdx * hw);
+        }
+      }
+    }
+
+    if (!closed) {
+      // caps at both open ends
+      var sdx = pts[2] - pts[0], sdy = pts[3] - pts[1];
+      final sl = math.sqrt(sdx * sdx + sdy * sdy);
+      var edx = pts[2 * n - 2] - pts[2 * n - 4],
+          edy = pts[2 * n - 1] - pts[2 * n - 3];
+      final el = math.sqrt(edx * edx + edy * edy);
+      if (sl > 1e-12 && el > 1e-12) {
+        sdx /= sl;
+        sdy /= sl;
+        edx /= el;
+        edy /= el;
+        if (cap == 1) {
+          final a = math.atan2(sdy, sdx);
+          fan(pts[0], pts[1], a + math.pi / 2, math.pi);
+          final b = math.atan2(edy, edx);
+          fan(pts[2 * n - 2], pts[2 * n - 1], b - math.pi / 2, math.pi);
+        } else if (cap == 2) {
+          squareCap(pts[0], pts[1], -sdx, -sdy);
+          squareCap(pts[2 * n - 2], pts[2 * n - 1], edx, edy);
+        }
+      }
+    }
+  }
+}

--- a/packages/pdf_graphics/test/raster/flatten_test.dart
+++ b/packages/pdf_graphics/test/raster/flatten_test.dart
@@ -1,0 +1,224 @@
+// Parity tests for the flattening port: the golden numbers mirror the
+// flutter_gpu experiment's gpu_geometry.dart semantics exactly (Wang's
+// bound subdivision count, close handling, dash re-cutting).
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FloatBuilder/DoubleBuilder', () {
+    test('grow past initial capacity and keep contents', () {
+      final b = FloatBuilder(4);
+      for (var i = 0; i < 100; i++) {
+        b.add2(i.toDouble(), (i * 2).toDouble());
+      }
+      expect(b.length, 200);
+      expect(b[0], 0);
+      expect(b[199], 198);
+      expect(b.bytes.lengthInBytes, 800);
+      b.clear();
+      expect(b.isEmpty, isTrue);
+    });
+
+    test('DoubleBuilder view is a prefix view', () {
+      final b = DoubleBuilder(2)..add2(1, 2);
+      b.add6(3, 4, 5, 6, 7, 8);
+      expect(b.view, [1, 2, 3, 4, 5, 6, 7, 8]);
+      b[0] = 9;
+      expect(b.view.first, 9);
+    });
+  });
+
+  group('flattenPath', () {
+    test('lines pass through transformed', () {
+      final path = PdfPath([
+        PdfMoveTo(0, 0),
+        PdfLineTo(10, 0),
+        PdfLineTo(10, 5),
+      ]);
+      final subs =
+          flattenPath(path, PdfMatrix(2, 0, 0, 2, 1, 1));
+      expect(subs, hasLength(1));
+      expect(subs[0].closed, isFalse);
+      expect(subs[0].points, [1, 1, 21, 1, 21, 11]);
+    });
+
+    test('cubic subdivides per Wang bound (golden: n = 6)', () {
+      // Control points (0,0) (10,0) (20,10) (30,10):
+      //   d1 = max(|0-20+20|, |0-0+10|)   = 10
+      //   d2 = max(|10-40+30|, |0-20+10|) = 10
+      //   n  = ceil(sqrt(3*10 / (4*0.25))) = ceil(sqrt(30)) = 6
+      final path = PdfPath([
+        PdfMoveTo(0, 0),
+        PdfCubicTo(10, 0, 20, 10, 30, 10),
+      ]);
+      final subs = flattenPath(path, PdfMatrix.identity);
+      expect(subs, hasLength(1));
+      final p = subs[0].points;
+      expect(p.length, (1 + 6) * 2);
+      // golden points: exact cubic samples at t = i/6
+      for (var i = 0; i <= 6; i++) {
+        final t = i / 6;
+        final mt = 1 - t;
+        final bx = 3 * mt * mt * t * 10 + 3 * mt * t * t * 20 + t * t * t * 30;
+        final by = 3 * mt * t * t * 10 + t * t * t * 10;
+        expect(p[2 * i], closeTo(bx, 1e-12));
+        expect(p[2 * i + 1], closeTo(by, 1e-12));
+      }
+    });
+
+    test('flattened cubic stays within tolerance of the true curve', () {
+      final path = PdfPath([
+        PdfMoveTo(0, 0),
+        PdfCubicTo(0, 55, 100, -55, 100, 0),
+      ]);
+      const tol = 0.25;
+      final subs = flattenPath(path, PdfMatrix.identity, tolerance: tol);
+      final p = subs[0].points;
+      // sample the true curve densely; every sample must be within ~tol of
+      // the polyline
+      double distToPolyline(double x, double y) {
+        var best = double.infinity;
+        for (var i = 0; i + 3 < p.length; i += 2) {
+          final ax = p[i], ay = p[i + 1], bx = p[i + 2], by = p[i + 3];
+          final vx = bx - ax, vy = by - ay;
+          final len2 = vx * vx + vy * vy;
+          var t = len2 == 0 ? 0.0 : ((x - ax) * vx + (y - ay) * vy) / len2;
+          t = t.clamp(0.0, 1.0);
+          final dx = x - (ax + vx * t), dy = y - (ay + vy * t);
+          final d = math.sqrt(dx * dx + dy * dy);
+          if (d < best) best = d;
+        }
+        return best;
+      }
+
+      for (var i = 0; i <= 500; i++) {
+        final t = i / 500;
+        final mt = 1 - t;
+        final bx = 3 * mt * mt * t * 0 +
+            3 * mt * t * t * 100 +
+            t * t * t * 100;
+        final by = 3 * mt * mt * t * 55 + 3 * mt * t * t * -55;
+        expect(distToPolyline(bx, by), lessThanOrEqualTo(tol * 1.05),
+            reason: 't=$t');
+      }
+    });
+
+    test('close appends the start point and marks the subpath closed', () {
+      final path = PdfPath([
+        PdfMoveTo(0, 0),
+        PdfLineTo(4, 0),
+        PdfLineTo(4, 4),
+        PdfClosePath(),
+      ]);
+      final subs = flattenPath(path, PdfMatrix.identity);
+      expect(subs, hasLength(1));
+      expect(subs[0].closed, isTrue);
+      expect(subs[0].points, [0, 0, 4, 0, 4, 4, 0, 0]);
+    });
+
+    test('m..h m.. produces two subpaths; drops empty ones', () {
+      final path = PdfPath([
+        PdfMoveTo(0, 0),
+        PdfLineTo(1, 0),
+        PdfClosePath(),
+        PdfMoveTo(5, 5),
+        PdfLineTo(6, 5),
+        PdfMoveTo(9, 9), // lone move: dropped
+      ]);
+      final subs = flattenPath(path, PdfMatrix.identity);
+      expect(subs, hasLength(2));
+      expect(subs[0].closed, isTrue);
+      expect(subs[1].closed, isFalse);
+      expect(subs[1].points, [5, 5, 6, 5]);
+    });
+
+    test('FlatBounds covers all subpaths', () {
+      final subs = flattenPath(
+          PdfPath([
+            PdfMoveTo(1, 2),
+            PdfLineTo(5, -3),
+            PdfMoveTo(-4, 0),
+            PdfLineTo(0, 7),
+          ]),
+          PdfMatrix.identity);
+      final b = FlatBounds.of(subs)!;
+      expect([b.left, b.top, b.right, b.bottom], [-4, -3, 5, 7]);
+    });
+  });
+
+  group('dashSubpaths', () {
+    FlatSubpath line(double x0, double y0, double x1, double y1) =>
+        FlatSubpath(Float64List.fromList([x0, y0, x1, y1]), closed: false);
+
+    test('golden: [4,2] over a length-10 line', () {
+      final out = dashSubpaths([line(0, 0, 10, 0)], [4, 2], 0);
+      expect(out, hasLength(2));
+      expect(out[0].points, [0, 0, 4, 0]);
+      expect(out[1].points, [6, 0, 10, 0]);
+    });
+
+    test('golden: phase 5 starts inside the gap', () {
+      final out = dashSubpaths([line(0, 0, 10, 0)], [4, 2], 5);
+      expect(out, hasLength(2));
+      expect(out[0].points, [1, 0, 5, 0]);
+      expect(out[1].points, [7, 0, 10, 0]);
+    });
+
+    test('odd pattern doubles (§8.4.3.6)', () {
+      final out = dashSubpaths([line(0, 0, 9, 0)], [3], 0);
+      // effective [3,3]: on 0-3, off 3-6, on 6-9
+      expect(out, hasLength(2));
+      expect(out[0].points, [0, 0, 3, 0]);
+      expect(out[1].points, [6, 0, 9, 0]);
+    });
+
+    test('empty/zero pattern passes through', () {
+      final subs = [line(0, 0, 10, 0)];
+      expect(dashSubpaths(subs, [], 0), same(subs));
+      expect(dashSubpaths(subs, [0, 0], 0), same(subs));
+    });
+
+    test('dashes continue across polyline corners', () {
+      final sub = FlatSubpath(
+          Float64List.fromList([0, 0, 5, 0, 5, 5]), closed: false);
+      final out = dashSubpaths([sub], [6, 2], 0);
+      // first dash runs 6 units: 5 along x then 1 down the corner
+      expect(out[0].points, [0, 0, 5, 0, 5, 1]);
+      expect(out[1].points, [5, 3, 5, 5]);
+    });
+  });
+
+  group('FlattenedOutline', () {
+    test('caches per outline identity', () {
+      final outline = PdfPath([
+        PdfMoveTo(0, 0),
+        PdfCubicTo(0.2, 0.6, 0.5, 0.7, 0.7, 0),
+        PdfClosePath(),
+      ]);
+      final a = FlattenedOutline.of(outline);
+      final b = FlattenedOutline.of(outline);
+      expect(identical(a, b), isTrue);
+      expect(a.subpaths, isNotEmpty);
+      // a different instance with equal segments flattens separately
+      final other = PdfPath(outline.segments);
+      expect(identical(FlattenedOutline.of(other), a), isFalse);
+    });
+
+    test('em-space flattening is fine enough for a 64-px em', () {
+      // half-circle-ish bowl in em units
+      final outline = PdfPath([
+        PdfMoveTo(0, 0),
+        PdfCubicTo(0, 0.55, 1, 0.55, 1, 0),
+        PdfClosePath(),
+      ]);
+      final flat = FlattenedOutline.of(outline);
+      final p = flat.subpaths[0].points;
+      // deviation from the true curve at 64 px/em must stay ~0.25 px
+      expect(p.length ~/ 2, greaterThan(8));
+    });
+  });
+}

--- a/packages/pdf_graphics/test/raster/glyph_cache_test.dart
+++ b/packages/pdf_graphics/test/raster/glyph_cache_test.dart
@@ -1,0 +1,173 @@
+// Glyph strip cache: replayed (hit) output must be byte-identical to the
+// freshly-built (miss) output, quantization stays within tolerance of the
+// uncached path, LRU caps hold, and bypasses fall back to direct raster.
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:test/test.dart';
+
+import 'reference_raster.dart';
+
+PdfPath glyphA() => PdfPath([
+      // A-ish triangle with a curved bowl and a hole
+      PdfMoveTo(0.1, 0.0),
+      PdfLineTo(0.35, 0.7),
+      PdfCubicTo(0.42, 0.85, 0.58, 0.85, 0.65, 0.7),
+      PdfLineTo(0.9, 0.0),
+      PdfLineTo(0.72, 0.0),
+      PdfLineTo(0.5, 0.55),
+      PdfLineTo(0.28, 0.0),
+      const PdfClosePath(),
+    ]);
+
+PdfPath glyphO() => PdfPath([
+      PdfMoveTo(0.5, 0.75),
+      PdfCubicTo(0.15, 0.75, 0.15, 0.05, 0.5, 0.05),
+      PdfCubicTo(0.85, 0.05, 0.85, 0.75, 0.5, 0.75),
+      const PdfClosePath(),
+      PdfMoveTo(0.5, 0.6),
+      PdfCubicTo(0.68, 0.6, 0.68, 0.2, 0.5, 0.2),
+      PdfCubicTo(0.32, 0.2, 0.32, 0.6, 0.5, 0.6),
+      const PdfClosePath(),
+    ]);
+
+/// Draws a small "text page": two glyph shapes at a sweep of positions,
+/// sizes, and subpixel phases.
+void drawTextPage(StripGenerator gen, {int color = 0xFF202020}) {
+  final a = FlattenedOutline.of(_outlineA);
+  final o = FlattenedOutline.of(_outlineO);
+  var x = 3.17;
+  for (var i = 0; i < 12; i++) {
+    final size = 12.0 + (i % 3) * 4.5;
+    final y = 20.0 + (i % 4) * 19.3 + i * 0.23;
+    gen.fillOutline(
+        i.isEven ? a : o, PdfMatrix(size, 0, 0, -size, x, y), color);
+    x += size * 0.62;
+  }
+}
+
+final _outlineA = glyphA();
+final _outlineO = glyphO();
+
+(Uint32List, Uint32List, Uint32List, Uint32List, Uint32List) snapshot(
+        StripBuffer b) =>
+    (
+      Uint32List.fromList(Uint32List.sublistView(b.xy, 0, b.length)),
+      Uint32List.fromList(Uint32List.sublistView(b.widthFlags, 0, b.length)),
+      Uint32List.fromList(Uint32List.sublistView(b.alphaOffset, 0, b.length)),
+      Uint32List.fromList(Uint32List.sublistView(b.color, 0, b.length)),
+      Uint32List.fromList(b.alphaTexels),
+    );
+
+void main() {
+  test('replayed (hit) output is byte-identical to freshly built (miss)', () {
+    final cache = GlyphStripCache();
+    final gen = (StripGenerator()..glyphCache = cache)..begin(120, 100);
+    // pass 1: first sights render directly (cache-on-second-sight gate)
+    drawTextPage(gen);
+    expect(cache.firstSights, greaterThan(0));
+    // pass 2: every draw is a fresh build (miss) or a hit - both replay
+    gen.begin(120, 100);
+    drawTextPage(gen);
+    final first = snapshot(gen.strips);
+    expect(cache.misses, greaterThan(0));
+    final missCount = cache.misses;
+
+    gen.begin(120, 100);
+    drawTextPage(gen);
+    final second = snapshot(gen.strips);
+    expect(cache.misses, missCount, reason: 'third pass must be all hits');
+    expect(cache.hits, greaterThan(0));
+    expect(second.$1, first.$1);
+    expect(second.$2, first.$2);
+    expect(second.$3, first.$3);
+    expect(second.$4, first.$4);
+    expect(second.$5, first.$5);
+  });
+
+  test('quantized cached raster stays close to the uncached path', () {
+    final cached = (StripGenerator()..glyphCache = GlyphStripCache())
+      ..begin(120, 100);
+    drawTextPage(cached);
+    final direct = (StripGenerator()..glyphCache = null)..begin(120, 100);
+    drawTextPage(direct);
+    final a = decodeStripCoverage(cached.strips, 120, 100);
+    final b = decodeStripCoverage(direct.strips, 120, 100);
+    // quantization moves glyphs <= 1/8 px; mean coverage impact is small
+    expect(meanAbsDiff(a, b), lessThanOrEqualTo(1.0));
+  });
+
+  test('grid-aligned draws replay identically across generators sharing a '
+      'cache', () {
+    final cache = GlyphStripCache();
+    final g0 = (StripGenerator()..glyphCache = cache)..begin(64, 64);
+    final g1 = (StripGenerator()..glyphCache = cache)..begin(64, 64);
+    final g2 = (StripGenerator()..glyphCache = cache)..begin(64, 64);
+    const m = PdfMatrix(20, 0, 0, -20, 8.25, 40.5); // on the 1/4-px grid
+    g0.fillOutline(FlattenedOutline.of(_outlineA), m, 0xFF000000); // 1st sight
+    g1.fillOutline(FlattenedOutline.of(_outlineA), m, 0xFF000000); // build
+    g2.fillOutline(FlattenedOutline.of(_outlineA), m, 0xFF000000); // hit
+    expect(decodeStripCoverage(g2.strips, 64, 64),
+        decodeStripCoverage(g1.strips, 64, 64));
+    expect(cache.firstSights, 1);
+    expect(cache.misses, 1);
+    expect(cache.hits, 1);
+  });
+
+  test('color override: replay carries the current fill color', () {
+    final gen = (StripGenerator()..glyphCache = GlyphStripCache())..begin(64, 64);
+    const m = PdfMatrix(20, 0, 0, -20, 4, 40);
+    gen.fillOutline(FlattenedOutline.of(_outlineA), m, 0x11223344);
+    final n1 = gen.strips.length;
+    gen.fillOutline(FlattenedOutline.of(_outlineA), m, 0x55667788);
+    for (var i = 0; i < n1; i++) {
+      expect(gen.strips.color[i], 0x11223344);
+    }
+    for (var i = n1; i < gen.strips.length; i++) {
+      expect(gen.strips.color[i], 0x55667788);
+    }
+  });
+
+  test('offscreen glyphs bypass the cache and still render clipped', () {
+    final cache = GlyphStripCache();
+    final gen = (StripGenerator()..glyphCache = cache)..begin(40, 40);
+    // glyph hanging off the left edge
+    const m = PdfMatrix(30, 0, 0, -30, -10, 30);
+    gen.fillOutline(FlattenedOutline.of(_outlineA), m, 0xFF000000);
+    expect(cache.bypasses, 1);
+    expect(cache.misses, 0);
+    final direct = (StripGenerator()..glyphCache = null)..begin(40, 40);
+    direct.fillOutline(FlattenedOutline.of(_outlineA), m, 0xFF000000);
+    expect(decodeStripCoverage(gen.strips, 40, 40),
+        decodeStripCoverage(direct.strips, 40, 40));
+  });
+
+  test('LRU eviction respects maxEntries', () {
+    final cache = GlyphStripCache(maxEntries: 3);
+    final gen = (StripGenerator()..glyphCache = cache)..begin(400, 40);
+    final o = FlattenedOutline.of(_outlineA);
+    // 5 distinct subpixel phases -> 5 keys, each drawn twice so the
+    // second-sight gate promotes them into the cache
+    for (var i = 0; i < 5; i++) {
+      final m = PdfMatrix(20, 0, 0, -20, 10 + i * 30 + i * 0.25, 30);
+      gen.fillOutline(o, m, 0xFF000000);
+      gen.fillOutline(o, m, 0xFF000000);
+    }
+    expect(cache.entryCount, 3);
+    expect(cache.misses, 5);
+  });
+
+  test('cache accounting tracks alpha bytes', () {
+    final cache = GlyphStripCache();
+    final gen = (StripGenerator()..glyphCache = cache)..begin(64, 64);
+    gen.fillOutline(FlattenedOutline.of(_outlineA),
+        const PdfMatrix(20, 0, 0, -20, 4, 40), 0xFF000000);
+    gen.fillOutline(FlattenedOutline.of(_outlineA),
+        const PdfMatrix(20, 0, 0, -20, 4, 40), 0xFF000000);
+    expect(cache.alphaBytes, greaterThan(0));
+    cache.clear();
+    expect(cache.alphaBytes, 0);
+    expect(cache.entryCount, 0);
+  });
+}

--- a/packages/pdf_graphics/test/raster/reference_raster.dart
+++ b/packages/pdf_graphics/test/raster/reference_raster.dart
@@ -1,0 +1,93 @@
+// Shared helpers for the strip-raster tests: a brute-force supersampling
+// reference rasterizer (winding-number point sampling, 16x16 or denser per
+// pixel) and a StripBuffer decoder that reconstructs the full coverage
+// image a strip consumer would composite.
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/raster.dart';
+
+/// Rasterizes closed [rings] (flat `[x,y,...]` polygons, device space) by
+/// supersampling [ss] x [ss] points per pixel with the winding-number rule
+/// ([evenOdd] selects the parity rule). Returns w*h coverage bytes.
+Uint8List referenceCoverage(
+    List<Float64List> rings, bool evenOdd, int w, int h,
+    {int ss = 16}) {
+  final out = Uint8List(w * h);
+  final samples = ss * ss;
+  for (var py = 0; py < h; py++) {
+    for (var px = 0; px < w; px++) {
+      var inside = 0;
+      for (var sy = 0; sy < ss; sy++) {
+        final y = py + (sy + 0.5) / ss;
+        for (var sx = 0; sx < ss; sx++) {
+          final x = px + (sx + 0.5) / ss;
+          var winding = 0;
+          for (final ring in rings) {
+            final n = ring.length ~/ 2;
+            for (var i = 0, j = n - 1; i < n; j = i++) {
+              final y0 = ring[2 * j + 1], y1 = ring[2 * i + 1];
+              if ((y0 > y) == (y1 > y)) continue;
+              final x0 = ring[2 * j], x1 = ring[2 * i];
+              final xCross = x0 + (y - y0) * (x1 - x0) / (y1 - y0);
+              if (xCross > x) winding += y1 > y0 ? 1 : -1;
+            }
+          }
+          final isIn = evenOdd ? winding.isOdd : winding != 0;
+          if (isIn) inside++;
+        }
+      }
+      out[py * w + px] = (inside * 255 + samples ~/ 2) ~/ samples;
+    }
+  }
+  return out;
+}
+
+/// Reconstructs the w*h coverage image described by [b]. Overlapping strips
+/// (possible across fills) keep the maximum coverage - the tests only ever
+/// decode a single shape, where strips never overlap.
+Uint8List decodeStripCoverage(StripBuffer b, int w, int h) {
+  final out = Uint8List(w * h);
+  final alphas = b.alphas;
+  for (var i = 0; i < b.length; i++) {
+    final x = b.xy[i] & 0xFFFF;
+    final y = b.xy[i] >> 16;
+    final width = b.widthFlags[i] & 0xFFFF;
+    final solid = b.widthFlags[i] & stripFlagSolid != 0;
+    final aOff = b.alphaOffset[i];
+    for (var col = 0; col < width; col++) {
+      for (var k = 0; k < 4; k++) {
+        final py = y + k;
+        final px = x + col;
+        if (py >= h || px >= w) continue;
+        final a = solid ? 255 : alphas[(aOff + col) * 4 + k];
+        final at = py * w + px;
+        if (a > out[at]) out[at] = a;
+      }
+    }
+  }
+  return out;
+}
+
+/// Mean absolute coverage difference in byte units (0..255).
+double meanAbsDiff(Uint8List a, Uint8List b) {
+  var sum = 0;
+  for (var i = 0; i < a.length; i++) {
+    sum += (a[i] - b[i]).abs();
+  }
+  return sum / a.length;
+}
+
+/// Extracts contour ring [i] as a flat Float64List (for the reference
+/// rasterizer).
+Float64List contourRing(StrokeContours c, int i) {
+  final start = c.ringStart(i), end = c.ringEnd(i);
+  final out = Float64List(end - start);
+  for (var k = start; k < end; k++) {
+    out[k - start] = c.points[k];
+  }
+  return out;
+}
+
+/// All rings of [c] as reference-rasterizer input.
+List<Float64List> contourRings(StrokeContours c) =>
+    [for (var i = 0; i < c.ringCount; i++) contourRing(c, i)];

--- a/packages/pdf_graphics/test/raster/shape_cache_test.dart
+++ b/packages/pdf_graphics/test/raster/shape_cache_test.dart
@@ -1,0 +1,255 @@
+// Shape (stroke/fill) strip cache: replayed (hit) output must be
+// byte-identical to the freshly-built (miss) output, content keying works
+// across distinct PdfPath instances (no shared identity), quantization
+// stays within tolerance of the uncached path, caps hold, and bypasses
+// fall back to direct raster.
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:test/test.dart';
+
+import 'reference_raster.dart';
+
+final int black = premulRgba8(PdfColor.black, 1);
+
+/// A CAD-ish arrowhead symbol at (x, y) - a fresh PdfPath every call, the
+/// way interpreters hand shapes to the device (no object identity).
+PdfPath arrow(double x, double y) => PdfPath([
+      PdfMoveTo(x, y),
+      PdfLineTo(x + 9, y + 3),
+      PdfLineTo(x + 9, y - 3),
+      const PdfClosePath(),
+    ]);
+
+/// A small circle-ish symbol of two cubics at (x, y).
+PdfPath knob(double x, double y) => PdfPath([
+      PdfMoveTo(x, y + 4),
+      PdfCubicTo(x - 5.4, y + 4, x - 5.4, y - 4, x, y - 4),
+      PdfCubicTo(x + 5.4, y - 4, x + 5.4, y + 4, x, y + 4),
+      const PdfClosePath(),
+    ]);
+
+/// A hatch stroke segment starting at (x, y).
+PdfPath tick(double x, double y) => PdfPath([
+      PdfMoveTo(x, y),
+      PdfLineTo(x + 11, y + 5),
+    ]);
+
+const PdfStroke thinStroke = PdfStroke(width: 1.2);
+
+/// Draws a symbol-heavy "CAD page": the same three shapes repeated at a
+/// sweep of positions and subpixel phases, plus strokes with parameters.
+void drawSymbolPage(StripGenerator gen, {int color = 0xFF303030}) {
+  for (var i = 0; i < 10; i++) {
+    final x = 8.0 + i * 13.0 + (i % 4) * 0.25;
+    gen.fillPath(arrow(x, 20 + (i % 3) * 22.5), PdfMatrix.identity,
+        PdfFillRule.nonzero, color);
+    gen.fillPath(knob(x, 45 + (i % 2) * 17.25), PdfMatrix.identity,
+        PdfFillRule.evenOdd, color);
+    gen.strokePath(
+        tick(x, 78 + (i % 3) * 6.0), PdfMatrix.identity, thinStroke, color);
+  }
+}
+
+(Uint32List, Uint32List, Uint32List, Uint32List, Uint32List) snapshot(
+        StripBuffer b) =>
+    (
+      Uint32List.fromList(Uint32List.sublistView(b.xy, 0, b.length)),
+      Uint32List.fromList(Uint32List.sublistView(b.widthFlags, 0, b.length)),
+      Uint32List.fromList(Uint32List.sublistView(b.alphaOffset, 0, b.length)),
+      Uint32List.fromList(Uint32List.sublistView(b.color, 0, b.length)),
+      Uint32List.fromList(b.alphaTexels),
+    );
+
+void main() {
+  test('replayed (hit) output is byte-identical to freshly built (miss)', () {
+    final cache = ShapeStripCache();
+    final gen = (StripGenerator()..shapeCache = cache)..begin(150, 110);
+    // pass 1: first sights render directly (cache-on-second-sight gate)
+    drawSymbolPage(gen);
+    expect(cache.firstSights, greaterThan(0));
+    // pass 2: every draw is a fresh build (miss) or a hit - both replay
+    gen.begin(150, 110);
+    drawSymbolPage(gen);
+    final first = snapshot(gen.strips);
+    expect(cache.misses, greaterThan(0));
+    final missCount = cache.misses;
+
+    gen.begin(150, 110);
+    drawSymbolPage(gen);
+    final second = snapshot(gen.strips);
+    expect(cache.misses, missCount, reason: 'third pass must be all hits');
+    expect(cache.hits, greaterThan(0));
+    expect(second.$1, first.$1);
+    expect(second.$2, first.$2);
+    expect(second.$3, first.$3);
+    expect(second.$4, first.$4);
+    expect(second.$5, first.$5);
+  });
+
+  test('content keying: distinct PdfPath instances share one entry', () {
+    final cache = ShapeStripCache();
+    final gen = (StripGenerator()..shapeCache = cache)..begin(80, 40);
+    // same shape content at integer translations: one key
+    gen.fillPath(arrow(10, 20), PdfMatrix.identity, PdfFillRule.nonzero,
+        black); // first sight
+    gen.fillPath(arrow(30, 24), PdfMatrix.identity, PdfFillRule.nonzero,
+        black); // build
+    gen.fillPath(arrow(51, 12), PdfMatrix.identity, PdfFillRule.nonzero,
+        black); // hit
+    expect(cache.firstSights, 1);
+    expect(cache.misses, 1);
+    expect(cache.hits, 1);
+    expect(cache.entryCount, 1);
+  });
+
+  test('quantized cached raster stays close to the uncached path', () {
+    final cached = (StripGenerator()..shapeCache = ShapeStripCache())
+      ..begin(150, 110);
+    drawSymbolPage(cached);
+    final direct = (StripGenerator()..shapeCache = null)..begin(150, 110);
+    drawSymbolPage(direct);
+    final a = decodeStripCoverage(cached.strips, 150, 110);
+    final b = decodeStripCoverage(direct.strips, 150, 110);
+    // quantization moves shapes <= 1/8 px; mean coverage impact is small
+    expect(meanAbsDiff(a, b), lessThanOrEqualTo(1.0));
+  });
+
+  test('grid-aligned draws replay identically across generators sharing a '
+      'cache', () {
+    final cache = ShapeStripCache();
+    final g0 = (StripGenerator()..shapeCache = cache)..begin(64, 64);
+    final g1 = (StripGenerator()..shapeCache = cache)..begin(64, 64);
+    final g2 = (StripGenerator()..shapeCache = cache)..begin(64, 64);
+    // anchor on the 1/4-px grid
+    g0.fillPath(knob(20.25, 30), PdfMatrix.identity, PdfFillRule.nonzero,
+        black); // 1st sight
+    g1.fillPath(knob(20.25, 30), PdfMatrix.identity, PdfFillRule.nonzero,
+        black); // build
+    g2.fillPath(knob(20.25, 30), PdfMatrix.identity, PdfFillRule.nonzero,
+        black); // hit
+    expect(decodeStripCoverage(g2.strips, 64, 64),
+        decodeStripCoverage(g1.strips, 64, 64));
+    expect(decodeStripCoverage(g0.strips, 64, 64),
+        decodeStripCoverage(g1.strips, 64, 64),
+        reason: 'first sight rasters from the same quantized content');
+    expect(cache.firstSights, 1);
+    expect(cache.misses, 1);
+    expect(cache.hits, 1);
+  });
+
+  test('stroke parameters join the key', () {
+    final cache = ShapeStripCache();
+    final gen = (StripGenerator()..shapeCache = cache)..begin(64, 64);
+    const wide = PdfStroke(width: 3);
+    const dashed = PdfStroke(width: 3, dashArray: [4, 2]);
+    for (var pass = 0; pass < 2; pass++) {
+      gen.strokePath(tick(10, 20), PdfMatrix.identity, thinStroke, black);
+      gen.strokePath(tick(10, 20), PdfMatrix.identity, wide, black);
+      gen.strokePath(tick(10, 20), PdfMatrix.identity, dashed, black);
+    }
+    // three distinct keys, each seen twice -> three entries
+    expect(cache.entryCount, 3);
+    expect(cache.firstSights, 3);
+    expect(cache.misses, 3);
+  });
+
+  test('color override: replay carries the current color', () {
+    final gen = (StripGenerator()..shapeCache = ShapeStripCache())
+      ..begin(64, 64);
+    gen.fillPath(
+        arrow(10, 20), PdfMatrix.identity, PdfFillRule.nonzero, 0x11223344);
+    final n1 = gen.strips.length;
+    gen.fillPath(
+        arrow(10, 20), PdfMatrix.identity, PdfFillRule.nonzero, 0x55667788);
+    for (var i = 0; i < n1; i++) {
+      expect(gen.strips.color[i], 0x11223344);
+    }
+    for (var i = n1; i < gen.strips.length; i++) {
+      expect(gen.strips.color[i], 0x55667788);
+    }
+  });
+
+  test('offscreen shapes bypass the cache and still render clipped', () {
+    final cache = ShapeStripCache();
+    final gen = (StripGenerator()..shapeCache = cache)..begin(40, 40);
+    final path = arrow(-4, 20); // hangs off the left edge
+    gen.fillPath(path, PdfMatrix.identity, PdfFillRule.nonzero, black);
+    expect(cache.bypasses, 1);
+    expect(cache.misses, 0);
+    final direct = (StripGenerator()..shapeCache = null)..begin(40, 40);
+    direct.fillPath(path, PdfMatrix.identity, PdfFillRule.nonzero, black);
+    expect(decodeStripCoverage(gen.strips, 40, 40),
+        decodeStripCoverage(direct.strips, 40, 40));
+  });
+
+  test('oversized paths skip the cache entirely', () {
+    final cache = ShapeStripCache();
+    final gen = (StripGenerator()..shapeCache = cache)..begin(64, 64);
+    // more segments than maxSegments: never walked/hashed
+    final segs = <PdfPathSegment>[PdfMoveTo(2, 2)];
+    for (var i = 0; i < ShapeStripCache.maxSegments + 8; i++) {
+      segs.add(PdfLineTo(2.0 + (i % 50), 3.0 + i * 0.7));
+    }
+    gen.fillPath(PdfPath(segs), PdfMatrix.identity, PdfFillRule.nonzero,
+        black);
+    expect(cache.bypasses, 0);
+    expect(cache.firstSights, 0);
+    expect(cache.entryCount, 0);
+  });
+
+  test('generational rotation bounds live entries at maxEntries', () {
+    final cache = ShapeStripCache(maxEntries: 4);
+    final gen = (StripGenerator()..shapeCache = cache)..begin(400, 40);
+    // 8 distinct shapes (arrow length varies) -> 8 keys, each drawn twice
+    // so the second-sight gate promotes them into the cache
+    PdfPath shape(int i) => PdfPath([
+          PdfMoveTo(10.0 + i * 30, 20),
+          PdfLineTo(19.0 + i * 30 + i, 23),
+          PdfLineTo(19.0 + i * 30 + i, 17),
+          const PdfClosePath(),
+        ]);
+    for (var i = 0; i < 8; i++) {
+      gen.fillPath(shape(i), PdfMatrix.identity, PdfFillRule.nonzero, black);
+      gen.fillPath(shape(i), PdfMatrix.identity, PdfFillRule.nonzero, black);
+    }
+    expect(cache.misses, 8);
+    expect(cache.entryCount, lessThanOrEqualTo(4));
+    expect(cache.entryCount, greaterThan(0));
+    // a key still present replays without a rebuild
+    final missCount = cache.misses;
+    gen.fillPath(shape(7), PdfMatrix.identity, PdfFillRule.nonzero, black);
+    expect(cache.misses, missCount, reason: 'newest key must still be live');
+    expect(cache.hits, greaterThan(0));
+  });
+
+  test('cache accounting tracks alpha bytes', () {
+    final cache = ShapeStripCache();
+    final gen = (StripGenerator()..shapeCache = cache)..begin(64, 64);
+    gen.fillPath(knob(20, 30), PdfMatrix.identity, PdfFillRule.nonzero,
+        black);
+    gen.fillPath(knob(20, 30), PdfMatrix.identity, PdfFillRule.nonzero,
+        black);
+    expect(cache.dataBytes, greaterThan(0));
+    cache.clear();
+    expect(cache.dataBytes, 0);
+    expect(cache.entryCount, 0);
+  });
+
+  test('dashed cached stroke matches the direct dashed raster on the grid',
+      () {
+    const stroke = PdfStroke(width: 2, dashArray: [5, 3], cap: 1);
+    final cache = ShapeStripCache();
+    final cached = (StripGenerator()..shapeCache = cache)..begin(64, 32);
+    // grid-aligned so quantization is exact
+    final path = PdfPath([PdfMoveTo(6, 16), PdfLineTo(58, 16)]);
+    cached.strokePath(path, PdfMatrix.identity, stroke, black); // 1st sight
+    cached.begin(64, 32);
+    cached.strokePath(path, PdfMatrix.identity, stroke, black); // build
+    final direct = (StripGenerator()..shapeCache = null)..begin(64, 32);
+    direct.strokePath(path, PdfMatrix.identity, stroke, black);
+    expect(decodeStripCoverage(cached.strips, 64, 32),
+        decodeStripCoverage(direct.strips, 64, 32));
+  });
+}

--- a/packages/pdf_graphics/test/raster/strip_generator_test.dart
+++ b/packages/pdf_graphics/test/raster/strip_generator_test.dart
@@ -132,7 +132,12 @@ void main() {
 
     test('fillSubpaths raw entry matches fillPath', () {
       const pts = [3.2, 3.7, 20.4, 5.1, 12.6, 19.3];
-      final a = StripGenerator()..begin(24, 24);
+      // fillSubpaths is the raw unquantized entry; pin the shape cache off
+      // so fillPath takes the same direct path (the cached path quantizes
+      // to the 1/4-px grid by design - see shape_cache_test.dart).
+      final a = StripGenerator()
+        ..shapeCache = null
+        ..begin(24, 24);
       a.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
           black);
       final b = StripGenerator()..begin(24, 24);

--- a/packages/pdf_graphics/test/raster/strip_generator_test.dart
+++ b/packages/pdf_graphics/test/raster/strip_generator_test.dart
@@ -1,0 +1,315 @@
+// Coverage correctness of the sparse-strip fine raster vs a brute-force
+// supersampling reference (tolerance +-2/255 mean per shape), plus the
+// strip-emission structure invariants (solid runs, alpha layout, sentinel,
+// packing, viewport clipping, buffer reuse).
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:test/test.dart';
+
+import 'reference_raster.dart';
+
+final int black = premulRgba8(PdfColor.black, 1);
+
+PdfPath polyPath(List<double> pts, {bool close = true}) {
+  final segs = <PdfPathSegment>[PdfMoveTo(pts[0], pts[1])];
+  for (var i = 2; i < pts.length; i += 2) {
+    segs.add(PdfLineTo(pts[i], pts[i + 1]));
+  }
+  if (close) segs.add(const PdfClosePath());
+  return PdfPath(segs);
+}
+
+Float64List ring(List<double> pts) => Float64List.fromList(pts);
+
+void expectCoverage(StripGenerator gen, List<Float64List> rings, bool evenOdd,
+    int w, int h,
+    {int ss = 16, double tol = 2.0}) {
+  final got = decodeStripCoverage(gen.strips, w, h);
+  final want = referenceCoverage(rings, evenOdd, w, h, ss: ss);
+  expect(meanAbsDiff(got, want), lessThanOrEqualTo(tol));
+}
+
+void main() {
+  group('coverage vs reference', () {
+    test('convex polygon (fractional pentagon)', () {
+      const pts = [4.3, 2.2, 19.7, 5.1, 21.4, 16.8, 11.0, 21.6, 2.6, 13.4];
+      final gen = StripGenerator()..begin(24, 24);
+      gen.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
+          black);
+      expectCoverage(gen, [ring(pts)], false, 24, 24);
+    });
+
+    test('self-intersecting star, nonzero', () {
+      // classic 5-point star drawn edge-to-edge (self-intersecting)
+      final pts = <double>[];
+      for (var i = 0; i < 5; i++) {
+        final a = -1.5707963267948966 + i * 4 * 3.141592653589793 / 5;
+        pts.addAll([12 + 10 * _cos(a), 12 + 10 * _sin(a)]);
+      }
+      final gen = StripGenerator()..begin(24, 24);
+      gen.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
+          black);
+      expectCoverage(gen, [ring(pts)], false, 24, 24);
+    });
+
+    test('self-intersecting star, even-odd (hollow core)', () {
+      final pts = <double>[];
+      for (var i = 0; i < 5; i++) {
+        final a = -1.5707963267948966 + i * 4 * 3.141592653589793 / 5;
+        pts.addAll([12 + 10 * _cos(a), 12 + 10 * _sin(a)]);
+      }
+      final gen = StripGenerator()..begin(24, 24);
+      gen.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.evenOdd,
+          black);
+      expectCoverage(gen, [ring(pts)], true, 24, 24);
+    });
+
+    test('nonzero hole ring vs even-odd', () {
+      // outer CW + inner CCW: nonzero keeps the hole
+      const outer = <double>[2.0, 2, 22, 2, 22, 22, 2, 22];
+      const innerRev = <double>[8.0, 16, 16, 16, 16, 8, 8, 8]; // reversed winding
+      final path = PdfPath([
+        PdfMoveTo(2, 2), PdfLineTo(22, 2), PdfLineTo(22, 22),
+        PdfLineTo(2, 22), const PdfClosePath(), //
+        PdfMoveTo(8, 16), PdfLineTo(16, 16), PdfLineTo(16, 8),
+        PdfLineTo(8, 8), const PdfClosePath(),
+      ]);
+      final gen = StripGenerator()..begin(24, 24);
+      gen.fillPath(path, PdfMatrix.identity, PdfFillRule.nonzero, black);
+      expectCoverage(gen, [ring(outer), ring(innerRev)], false, 24, 24);
+    });
+
+    test('thin sliver', () {
+      const pts = [1.0, 3.1, 23.0, 4.4, 1.0, 3.6];
+      final gen = StripGenerator()..begin(24, 8);
+      gen.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
+          black);
+      expectCoverage(gen, [ring(pts)], false, 24, 8, ss: 32, tol: 2.0);
+    });
+
+    test('subpixel rect', () {
+      const pts = [5.3, 5.2, 5.9, 5.2, 5.9, 5.75, 5.3, 5.75];
+      final gen = StripGenerator()..begin(12, 12);
+      gen.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
+          black);
+      expectCoverage(gen, [ring(pts)], false, 12, 12, ss: 32, tol: 1.0);
+    });
+
+    test('cubic blob through a transform', () {
+      final path = PdfPath([
+        PdfMoveTo(2, 2),
+        PdfCubicTo(10, 14, 14, 14, 22, 2),
+        const PdfClosePath(),
+      ]);
+      final m = PdfMatrix(1, 0.2, -0.1, 1, 2, 1);
+      final gen = StripGenerator()..begin(28, 24);
+      gen.fillPath(path, m, PdfFillRule.nonzero, black);
+      // reference: transform a dense flattening of the same curve
+      final flat = flattenPath(path, m, tolerance: 0.02);
+      expectCoverage(gen, [flat[0].points], false, 28, 24);
+    });
+
+    test('unclosed fill subpath closes implicitly', () {
+      final gen = StripGenerator()..begin(16, 16);
+      gen.fillPath(polyPath([2, 2, 14, 2, 14, 14], close: false),
+          PdfMatrix.identity, PdfFillRule.nonzero, black);
+      expectCoverage(gen, [
+        ring([2, 2, 14, 2, 14, 14])
+      ], false, 16, 16);
+    });
+
+    test('viewport clipping preserves winding (shape hangs off all edges)',
+        () {
+      const pts = <double>[-8, -6, 20, -9, 30, 18, 4, 30];
+      final gen = StripGenerator()..begin(16, 16);
+      gen.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
+          black);
+      expectCoverage(gen, [ring(pts)], false, 16, 16);
+    });
+
+    test('fillSubpaths raw entry matches fillPath', () {
+      const pts = [3.2, 3.7, 20.4, 5.1, 12.6, 19.3];
+      final a = StripGenerator()..begin(24, 24);
+      a.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
+          black);
+      final b = StripGenerator()..begin(24, 24);
+      b.fillSubpaths(
+          [FlatSubpath(ring(pts), closed: true)], PdfFillRule.nonzero, black);
+      expect(decodeStripCoverage(b.strips, 24, 24),
+          decodeStripCoverage(a.strips, 24, 24));
+    });
+
+    test('fillOutline (cached em-space glyph) matches fillPath', () {
+      // a glyph-ish outline in em units, drawn at a 20-px em
+      final outline = PdfPath([
+        PdfMoveTo(0.1, 0.0),
+        PdfLineTo(0.35, 0.7),
+        PdfCubicTo(0.42, 0.85, 0.58, 0.85, 0.65, 0.7),
+        PdfLineTo(0.9, 0.0),
+        PdfLineTo(0.72, 0.0),
+        PdfLineTo(0.5, 0.55),
+        PdfLineTo(0.28, 0.0),
+        const PdfClosePath(),
+      ]);
+      // em -> device: 20-px em, y-flip, baseline at y=22
+      const m = PdfMatrix(20, 0, 0, -20, 2, 22);
+      final direct = StripGenerator()..begin(24, 24);
+      direct.fillPath(outline, m, PdfFillRule.nonzero, black);
+      final cached = StripGenerator()..begin(24, 24);
+      cached.fillOutline(FlattenedOutline.of(outline), m, black);
+      final got = decodeStripCoverage(cached.strips, 24, 24);
+      final want = decodeStripCoverage(direct.strips, 24, 24);
+      // tolerances differ (em-space vs device-space flattening) but both
+      // are sub-pixel at a 20-px em
+      expect(meanAbsDiff(got, want), lessThanOrEqualTo(1.0));
+    });
+  });
+
+  group('strip emission structure', () {
+    test('interior solid runs carry no alphas; sentinel + flags set', () {
+      final gen = StripGenerator()..begin(32, 8);
+      // rect with fractional vertical edges, row-aligned horizontals
+      gen.fillPath(polyPath([1.5, 0, 30.5, 0, 30.5, 8, 1.5, 8]),
+          PdfMatrix.identity, PdfFillRule.nonzero, black);
+      final b = gen.strips;
+      // per row: mixed(1) solid(2..29) mixed(30)
+      expect(b.length, 6);
+      var solids = 0, mixed = 0;
+      for (var i = 0; i < b.length; i++) {
+        final w = b.widthFlags[i] & 0xFFFF;
+        if (b.widthFlags[i] & stripFlagSolid != 0) {
+          solids++;
+          expect(b.alphaOffset[i], stripSolidSentinel);
+          expect(w, 28);
+        } else {
+          mixed++;
+          expect(w, 1);
+          expect(b.alphaOffset[i], isNot(stripSolidSentinel));
+        }
+      }
+      expect(solids, 2);
+      expect(mixed, 4);
+      expect(b.alphaColumns, 4);
+      // half-covered vertical edge columns
+      for (final a in b.alphas) {
+        expect(a, inInclusiveRange(126, 129));
+      }
+    });
+
+    test('alpha bytes are column-major scanline coverage', () {
+      final gen = StripGenerator()..begin(12, 4);
+      // rect covering scanlines 0..1 fully, 2..3 not at all
+      gen.fillPath(polyPath([2, 0, 10, 0, 10, 2, 2, 2]), PdfMatrix.identity,
+          PdfFillRule.nonzero, black);
+      final b = gen.strips;
+      expect(b.length, 1);
+      expect(b.widthFlags[0] & stripFlagSolid, 0);
+      expect(b.widthFlags[0] & 0xFFFF, 8);
+      expect(b.alphaColumns, 8);
+      final alphas = b.alphas;
+      for (var col = 0; col < 8; col++) {
+        expect(alphas[col * 4 + 0], 255, reason: 'col $col scanline 0');
+        expect(alphas[col * 4 + 1], 255);
+        expect(alphas[col * 4 + 2], 0);
+        expect(alphas[col * 4 + 3], 0);
+      }
+    });
+
+    test('xy packing and strip row origin', () {
+      final gen = StripGenerator()..begin(16, 16);
+      gen.fillPath(polyPath([4, 9, 12, 9, 12, 11, 4, 11]), PdfMatrix.identity,
+          PdfFillRule.nonzero, black);
+      final b = gen.strips;
+      expect(b.length, 1);
+      expect(b.xy[0] & 0xFFFF, 4);
+      expect(b.xy[0] >> 16, 8, reason: 'row top of the 4-px row holding y=9');
+    });
+
+    test('even-odd flag recorded on emitted strips', () {
+      final gen = StripGenerator()..begin(8, 8);
+      gen.fillPath(polyPath([1, 1, 7, 1, 7, 7, 1, 7]), PdfMatrix.identity,
+          PdfFillRule.evenOdd, black);
+      final b = gen.strips;
+      expect(b.length, greaterThan(0));
+      for (var i = 0; i < b.length; i++) {
+        expect(b.widthFlags[i] & stripFlagEvenOdd, stripFlagEvenOdd);
+      }
+    });
+
+    test('premul color rides along per strip', () {
+      final gen = StripGenerator()..begin(8, 8);
+      final c = premulRgba8(const PdfColor(1, 0.5, 0), 0.5);
+      gen.fillPath(polyPath([0, 0, 8, 0, 8, 8, 0, 8]), PdfMatrix.identity,
+          PdfFillRule.nonzero, c);
+      final b = gen.strips;
+      expect(b.length, greaterThan(0));
+      expect(b.color[0], c);
+      expect(c >> 24, 128); // alpha
+      expect(c & 0xFF, 128); // r premultiplied
+    });
+
+    test('separate islands produce separate strips', () {
+      final gen = StripGenerator()..begin(24, 4);
+      final path = PdfPath([
+        PdfMoveTo(2, 0), PdfLineTo(6, 0), PdfLineTo(6, 4), PdfLineTo(2, 4),
+        const PdfClosePath(), //
+        PdfMoveTo(14, 0), PdfLineTo(20, 0), PdfLineTo(20, 4),
+        PdfLineTo(14, 4), const PdfClosePath(),
+      ]);
+      gen.fillPath(path, PdfMatrix.identity, PdfFillRule.nonzero, black);
+      final b = gen.strips;
+      expect(b.length, 2);
+      expect(b.xy[0] & 0xFFFF, 2);
+      expect(b.xy[1] & 0xFFFF, 14);
+      for (var i = 0; i < 2; i++) {
+        expect(b.widthFlags[i] & stripFlagSolid, stripFlagSolid);
+      }
+    });
+
+    test('begin() resets the buffer and generator state is reusable', () {
+      final gen = StripGenerator()..begin(16, 16);
+      gen.fillPath(polyPath([2, 2, 14, 2, 14, 14, 2, 14]), PdfMatrix.identity,
+          PdfFillRule.nonzero, black);
+      final firstLen = gen.strips.length;
+      expect(firstLen, greaterThan(0));
+      final firstCoverage = decodeStripCoverage(gen.strips, 16, 16);
+      gen.begin(16, 16);
+      expect(gen.strips.length, 0);
+      expect(gen.strips.alphaColumns, 0);
+      gen.fillPath(polyPath([2, 2, 14, 2, 14, 14, 2, 14]), PdfMatrix.identity,
+          PdfFillRule.nonzero, black);
+      expect(gen.strips.length, firstLen);
+      expect(decodeStripCoverage(gen.strips, 16, 16), firstCoverage);
+    });
+
+    test('multiple fills accumulate into one buffer', () {
+      final gen = StripGenerator()..begin(16, 16);
+      gen.fillPath(polyPath([1, 1, 7, 1, 7, 7, 1, 7]), PdfMatrix.identity,
+          PdfFillRule.nonzero, black);
+      final afterOne = gen.strips.length;
+      gen.fillPath(polyPath([9, 9, 15, 9, 15, 15, 9, 15]), PdfMatrix.identity,
+          PdfFillRule.nonzero, premulRgba8(const PdfColor(1, 0, 0), 1));
+      expect(gen.strips.length, greaterThan(afterOne));
+    });
+
+    test('offscreen shapes are culled to zero strips', () {
+      final gen = StripGenerator()..begin(16, 16);
+      for (final pts in <List<double>>[
+        [20.0, 2, 30, 2, 30, 12], // right of viewport
+        [-30.0, 2, -20, 2, -20, 12], // left (closed: zero net winding)
+        [2.0, -30, 12, -30, 12, -20], // above
+        [2.0, 20, 12, 20, 12, 30], // below
+      ]) {
+        gen.fillPath(polyPath(pts), PdfMatrix.identity, PdfFillRule.nonzero,
+            black);
+      }
+      expect(gen.strips.length, 0);
+    });
+  });
+}
+
+double _cos(double a) => math.cos(a);
+double _sin(double a) => math.sin(a);

--- a/packages/pdf_graphics/test/raster/stroke_contours_test.dart
+++ b/packages/pdf_graphics/test/raster/stroke_contours_test.dart
@@ -1,0 +1,243 @@
+// Stroke-expansion tests: contour structure (caps/joins/miter limit/dash)
+// plus coverage checks - the expanded contours, filled nonzero, must match
+// a brute-force rasterization of the geometrically expected shape.
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:test/test.dart';
+
+import 'reference_raster.dart';
+
+FlatSubpath poly(List<double> pts, {bool closed = false}) =>
+    FlatSubpath(Float64List.fromList(pts), closed: closed);
+
+double ringArea(Float64List r) {
+  final n = r.length ~/ 2;
+  var area = 0.0;
+  for (var i = 0, j = n - 1; i < n; j = i++) {
+    area += r[2 * j] * r[2 * i + 1] - r[2 * i] * r[2 * j + 1];
+  }
+  return area / 2;
+}
+
+bool ringHasPoint(Float64List r, double x, double y, {double tol = 1e-9}) {
+  for (var i = 0; i < r.length; i += 2) {
+    if ((r[i] - x).abs() < tol && (r[i + 1] - y).abs() < tol) return true;
+  }
+  return false;
+}
+
+void main() {
+  StrokeContours expand(List<FlatSubpath> subs,
+      {double width = 2,
+      int cap = 0,
+      int join = 0,
+      double miterLimit = 10}) {
+    final out = StrokeContours();
+    strokeToContours(subs,
+        width: width, cap: cap, join: join, miterLimit: miterLimit, out: out);
+    return out;
+  }
+
+  test('single segment, butt caps: one quad covering the exact rectangle',
+      () {
+    final c = expand([
+      poly([2, 6, 22, 6])
+    ], width: 4);
+    expect(c.ringCount, 1);
+    final ring = contourRing(c, 0);
+    expect(ringArea(ring).abs(), closeTo(20 * 4, 1e-9));
+
+    // coverage parity vs the exact rectangle
+    final gen = StripGenerator()..begin(24, 12);
+    gen.fillContours(c, premulRgba8(PdfColor.black, 1));
+    final got = decodeStripCoverage(gen.strips, 24, 12);
+    final want = referenceCoverage([
+      Float64List.fromList([2, 4, 22, 4, 22, 8, 2, 8])
+    ], false, 24, 12);
+    expect(meanAbsDiff(got, want), lessThanOrEqualTo(2.0));
+  });
+
+  test('all rings share one winding orientation', () {
+    final c = expand(
+        [
+          poly([2, 2, 20, 2, 20, 20, 2, 20, 2, 2], closed: true),
+          poly([4, 30, 28, 34, 6, 40]),
+        ],
+        width: 3,
+        cap: 1,
+        join: 1);
+    expect(c.ringCount, greaterThan(4));
+    for (var i = 0; i < c.ringCount; i++) {
+      expect(ringArea(contourRing(c, i)), greaterThan(0),
+          reason: 'ring $i must be shoelace-positive');
+    }
+  });
+
+  test('right-angle miter join places the miter point', () {
+    // L from (2,10) to (10,10) to (10,2), width 2 (hw 1): the outer corner
+    // miter point sits at (11,11).
+    final c = expand([
+      poly([2, 10, 10, 10, 10, 2])
+    ], width: 2, join: 0);
+    // 2 segment quads + 1 miter wedge (4 points)
+    expect(c.ringCount, 3);
+    var found = false;
+    for (var i = 0; i < c.ringCount; i++) {
+      if (ringHasPoint(contourRing(c, i), 11, 11)) found = true;
+    }
+    expect(found, isTrue, reason: 'miter point (11,11) missing');
+  });
+
+  test('bevel join has no miter point', () {
+    final c = expand([
+      poly([2, 10, 10, 10, 10, 2])
+    ], width: 2, join: 2);
+    expect(c.ringCount, 3);
+    for (var i = 0; i < c.ringCount; i++) {
+      expect(ringHasPoint(contourRing(c, i), 11, 11), isFalse);
+      // bevel wedge is a triangle
+      expect(contourRing(c, i).length ~/ 2, lessThanOrEqualTo(4));
+    }
+  });
+
+  test('miter limit falls back to bevel', () {
+    // right angle: miter ratio sqrt(2) ~ 1.414 > limit 1.2 -> bevel
+    final c = expand([
+      poly([2, 10, 10, 10, 10, 2])
+    ], width: 2, join: 0, miterLimit: 1.2);
+    for (var i = 0; i < c.ringCount; i++) {
+      expect(ringHasPoint(contourRing(c, i), 11, 11), isFalse);
+    }
+  });
+
+  test('round join emits an arc fan', () {
+    final c = expand([
+      poly([2, 10, 10, 10, 10, 2])
+    ], width: 2, join: 1);
+    expect(c.ringCount, 3);
+    var maxPts = 0;
+    for (var i = 0; i < c.ringCount; i++) {
+      final n = contourRing(c, i).length ~/ 2;
+      if (n > maxPts) maxPts = n;
+    }
+    expect(maxPts, greaterThan(4), reason: 'arc fan must have arc points');
+  });
+
+  test('square caps extend by half width; coverage matches', () {
+    final c = expand([
+      poly([4, 6, 20, 6])
+    ], width: 4, cap: 2);
+    // quad + two cap quads
+    expect(c.ringCount, 3);
+    final gen = StripGenerator()..begin(26, 12);
+    gen.fillContours(c, premulRgba8(PdfColor.black, 1));
+    final got = decodeStripCoverage(gen.strips, 26, 12);
+    final want = referenceCoverage([
+      Float64List.fromList([2, 4, 22, 4, 22, 8, 2, 8])
+    ], false, 26, 12);
+    expect(meanAbsDiff(got, want), lessThanOrEqualTo(2.0));
+  });
+
+  test('round caps cover the end circles', () {
+    final c = expand([
+      poly([8, 8, 20, 8])
+    ], width: 6, cap: 1);
+    final gen = StripGenerator()..begin(28, 16);
+    gen.fillContours(c, premulRgba8(PdfColor.black, 1));
+    final got = decodeStripCoverage(gen.strips, 28, 16);
+    // reference: rectangle + polygonal end circles (matching fan density is
+    // not required at +-2/255 mean with 3-px radius circles)
+    final circleL = <double>[];
+    final circleR = <double>[];
+    for (var i = 0; i < 32; i++) {
+      final a = 2 * math.pi * i / 32;
+      circleL.addAll([8 + 3 * math.cos(a), 8 + 3 * math.sin(a)]);
+      circleR.addAll([20 + 3 * math.cos(a), 8 + 3 * math.sin(a)]);
+    }
+    final want = referenceCoverage([
+      Float64List.fromList([8, 5, 20, 5, 20, 11, 8, 11]),
+      Float64List.fromList(circleL),
+      Float64List.fromList(circleR),
+    ], false, 28, 16);
+    expect(meanAbsDiff(got, want), lessThanOrEqualTo(2.0));
+  });
+
+  test('closed subpath strokes all four corners (wrap join)', () {
+    final c = expand([
+      poly([4, 4, 20, 4, 20, 20, 4, 20, 4, 4], closed: true)
+    ], width: 2, join: 0);
+    // 4 quads + 4 miter wedges
+    expect(c.ringCount, 8);
+    final gen = StripGenerator()..begin(26, 26);
+    gen.fillContours(c, premulRgba8(PdfColor.black, 1));
+    final got = decodeStripCoverage(gen.strips, 26, 26);
+    // reference: outer rect minus inner rect (evenodd two-ring polygon)
+    final want = referenceCoverage([
+      Float64List.fromList([3, 3, 21, 3, 21, 21, 3, 21]),
+      Float64List.fromList([5, 5, 19, 5, 19, 19, 5, 19]),
+    ], true, 26, 26);
+    expect(meanAbsDiff(got, want), lessThanOrEqualTo(2.0));
+  });
+
+  test('isolated point paints a dot for round/square caps, nothing for butt',
+      () {
+    for (final (cap, expectRings) in [(0, 0), (1, 2), (2, 1)]) {
+      final c = expand([
+        poly([5, 5, 5, 5])
+      ], width: 4, cap: cap);
+      expect(c.ringCount, expectRings, reason: 'cap $cap');
+    }
+  });
+
+  test('sub-pixel widths stroke exactly; width 0 is the 1-px hairline', () {
+    // 0.5-px stroke: half-covered band, like Skia's sub-pixel stroking
+    final thin = expand([
+      poly([2, 6, 22, 6])
+    ], width: 0.5);
+    expect(ringArea(contourRing(thin, 0)).abs(), closeTo(20 * 0.5, 1e-9));
+    // PDF width 0 = thinnest renderable = 1 device px
+    final hairline = expand([
+      poly([2, 6, 22, 6])
+    ], width: 0);
+    expect(ringArea(contourRing(hairline, 0)).abs(), closeTo(20 * 1, 1e-9));
+  });
+
+  test('dashed stroke through StripGenerator matches two rectangles', () {
+    final gen = StripGenerator()..begin(24, 12);
+    final path = PdfPath([PdfMoveTo(2, 6), PdfLineTo(22, 6)]);
+    gen.strokePath(
+        path,
+        PdfMatrix.identity,
+        PdfStroke(width: 4, dashArray: [8, 4]),
+        premulRgba8(PdfColor.black, 1));
+    final got = decodeStripCoverage(gen.strips, 24, 12);
+    final want = referenceCoverage([
+      Float64List.fromList([2, 4, 10, 4, 10, 8, 2, 8]),
+      Float64List.fromList([14, 4, 22, 4, 22, 8, 14, 8]),
+    ], false, 24, 12);
+    expect(meanAbsDiff(got, want), lessThanOrEqualTo(2.0));
+  });
+
+  test('diagonal stroke coverage matches the rotated rectangle', () {
+    final c = expand([
+      poly([4, 4, 20, 12])
+    ], width: 2);
+    expect(c.ringCount, 1);
+    final gen = StripGenerator()..begin(24, 16);
+    gen.fillContours(c, premulRgba8(PdfColor.black, 1));
+    final got = decodeStripCoverage(gen.strips, 24, 16);
+    // expected quad: offsets +-hw along the unit normal of (16,8)/17.889
+    const len = 17.88854381999832; // sqrt(16^2+8^2)
+    const nx = -8 / len, ny = 16 / len; // unit normal * hw(=1)
+    final want = referenceCoverage([
+      Float64List.fromList([
+        4 + nx, 4 + ny, 20 + nx, 12 + ny, //
+        20 - nx, 12 - ny, 4 - nx, 4 - ny,
+      ]),
+    ], false, 24, 16);
+    expect(meanAbsDiff(got, want), lessThanOrEqualTo(2.0));
+  });
+}

--- a/packages/pdf_graphics/tool/benchmark_strips.dart
+++ b/packages/pdf_graphics/tool/benchmark_strips.dart
@@ -174,6 +174,7 @@ class _Args {
   int maxPages = 10;
   int repeat = 1;
   bool glyphCache = true;
+  bool shapeCache = true;
   String? out;
 }
 
@@ -193,6 +194,8 @@ _Args _parse(List<String> argv) {
         a.out = next();
       case '--no-glyph-cache':
         a.glyphCache = false;
+      case '--no-shape-cache':
+        a.shapeCache = false;
       default:
         if (arg.startsWith('--')) {
           stderr.writeln('unknown flag $arg');
@@ -282,7 +285,8 @@ void main(List<String> argv) {
 
   // reused across pages and files
   final gen = StripGenerator()
-    ..glyphCache = args.glyphCache ? GlyphStripCache.shared : null;
+    ..glyphCache = args.glyphCache ? GlyphStripCache.shared : null
+    ..shapeCache = args.shapeCache ? ShapeStripCache.shared : null;
   final best = <String, Map<String, Object?>>{};
   for (var r = 0; r < args.repeat; r++) {
     for (final file in files) {
@@ -331,6 +335,7 @@ void main(List<String> argv) {
     totalAlphaBytes += s['alphaBytes'] as int;
   }
   final gc = GlyphStripCache.shared;
+  final sc = ShapeStripCache.shared;
   final summary = {
     'pages': totalPages,
     'glyphCache': args.glyphCache
@@ -345,6 +350,21 @@ void main(List<String> argv) {
                 ? null
                 : double.parse(
                     (gc.hits / (gc.hits + gc.misses)).toStringAsFixed(3)),
+          }
+        : null,
+    'shapeCache': args.shapeCache
+        ? {
+            'hits': sc.hits,
+            'misses': sc.misses,
+            'firstSights': sc.firstSights,
+            'bypasses': sc.bypasses,
+            'collisions': sc.collisions,
+            'entries': sc.entryCount,
+            'dataBytes': sc.dataBytes,
+            'hitRate': (sc.hits + sc.misses) == 0
+                ? null
+                : double.parse(
+                    (sc.hits / (sc.hits + sc.misses)).toStringAsFixed(3)),
           }
         : null,
     'renderMsPerPage':

--- a/packages/pdf_graphics/tool/benchmark_strips.dart
+++ b/packages/pdf_graphics/tool/benchmark_strips.dart
@@ -1,0 +1,378 @@
+// Benchmarks parse + interpret + sparse-strip generation (lib/raster.dart),
+// the pure-Dart CPU half of the shader-driven strip renderer (M1 gate of
+// the strip experiment; no GPU upload/draw - that needs Flutter). Runs on
+// the Dart VM:
+//
+//   cd packages/pdf_graphics
+//   fvm dart run tool/benchmark_strips.dart ../../corpus \
+//       --max-pages 10 --out ../../benchmark/out/dart-strips.json
+//
+// Emits the JSON schema shared with the other harnesses so
+// benchmark/compare.py can line the tools up file-by-file: `renderMs` is
+// interpret+strip-generate wall time per file; `openMs` is parse/load.
+// Extra per-file `strips` and top-level `stripStats` fields carry strip
+// counts, alpha atlas bytes, and solid-strip fractions (ignored by
+// compare.py).
+//
+// The headless device routes solid fills, strokes, and outline-glyph text
+// into a StripGenerator at the requested scale (device = page size x
+// scale); images, gradients, meshes, groups, and soft masks are counted
+// and skipped (Track B delegates those to the canvas fallback).
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+// (GlyphStripCache comes from raster.dart)
+
+/// Per-run strip + delegation statistics.
+class StripStats {
+  int strips = 0;
+  int solidStrips = 0;
+  int alphaBytes = 0;
+  int fills = 0;
+  int strokes = 0;
+  int glyphs = 0;
+  int substitutedRuns = 0;
+  int images = 0;
+  int gradients = 0;
+  int meshes = 0;
+  int groups = 0;
+  int softMasks = 0;
+  int clips = 0;
+
+  void addBuffer(StripBuffer b) {
+    strips += b.length;
+    alphaBytes += b.alphaColumns * 4;
+    for (var i = 0; i < b.length; i++) {
+      if (b.widthFlags[i] & stripFlagSolid != 0) solidStrips++;
+    }
+  }
+
+  Map<String, Object?> toJson() => {
+        'strips': strips,
+        'solidStrips': solidStrips,
+        'alphaBytes': alphaBytes,
+        'fills': fills,
+        'strokes': strokes,
+        'glyphs': glyphs,
+        'substitutedRuns': substitutedRuns,
+        'images': images,
+        'gradients': gradients,
+        'meshes': meshes,
+        'groups': groups,
+        'softMasks': softMasks,
+        'clips': clips,
+      };
+}
+
+/// Headless [PdfDevice] that strip-generates every solid paint primitive
+/// and counts everything the strip path would delegate.
+class StripBenchDevice implements PdfDevice {
+  StripBenchDevice(this.gen, this.pageToDevice, this.stats);
+
+  final StripGenerator gen;
+  final PdfMatrix pageToDevice;
+  final StripStats stats;
+
+  @override
+  void save() {}
+
+  @override
+  void restore() {}
+
+  @override
+  void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {
+    stats.fills++;
+    gen.fillPath(path, pageToDevice, rule, premulRgba8(color, alpha));
+  }
+
+  @override
+  void fillPathGradient(
+      PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) {
+    stats.gradients++;
+  }
+
+  @override
+  void fillMesh(PdfMesh mesh, double alpha) {
+    stats.meshes++;
+  }
+
+  @override
+  void strokePath(
+      PdfPath path, PdfColor color, PdfStroke stroke, double alpha) {
+    stats.strokes++;
+    gen.strokePath(path, pageToDevice, stroke, premulRgba8(color, alpha));
+  }
+
+  @override
+  void clipPath(PdfPath path, PdfFillRule rule) {
+    stats.clips++; // Track B clips GPU-side (canvas.clipPath), not here
+  }
+
+  @override
+  void drawText(PdfTextRun run) {
+    if (run.invisible) return;
+    final glyphs = run.glyphs;
+    if (glyphs == null) {
+      stats.substitutedRuns++; // no embedded outlines: canvas fallback
+      return;
+    }
+    if (run.gradient != null) stats.gradients++;
+    final color =
+        premulRgba8(run.fill ? run.color : (run.strokeColor ?? run.color), 1);
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline == null) continue;
+      stats.glyphs++;
+      final emToDevice = PdfMatrix.translation(glyph.offset, glyph.offsetY)
+          .concat(run.transform)
+          .concat(pageToDevice);
+      gen.fillOutline(FlattenedOutline.of(outline), emToDevice, color);
+    }
+  }
+
+  @override
+  void drawImage(PdfImageRequest request) {
+    stats.images++;
+  }
+
+  @override
+  void setBlendMode(PdfBlendMode mode) {}
+
+  @override
+  void beginGroup(double alpha, {bool knockout = false}) {
+    stats.groups++;
+  }
+
+  @override
+  void endGroup() {}
+
+  @override
+  void beginSoftMasked() {
+    stats.softMasks++;
+  }
+
+  @override
+  void endSoftMasked({
+    required bool luminosity,
+    required PdfRect backdrop,
+    required void Function() drawMask,
+    double backdropLuminance = 0,
+    double transferScale = 1,
+    double transferOffset = 0,
+  }) {
+    // masked content already arrived through the normal callbacks; the mask
+    // group itself is delegated work - skip drawMask.
+  }
+}
+
+class _Args {
+  String corpus = '';
+  double scale = 2;
+  int maxPages = 10;
+  int repeat = 1;
+  bool glyphCache = true;
+  String? out;
+}
+
+_Args _parse(List<String> argv) {
+  final a = _Args();
+  for (var i = 0; i < argv.length; i++) {
+    final arg = argv[i];
+    String next() => argv[++i];
+    switch (arg) {
+      case '--scale':
+        a.scale = double.parse(next());
+      case '--max-pages':
+        a.maxPages = int.parse(next());
+      case '--repeat':
+        a.repeat = int.parse(next());
+      case '--out':
+        a.out = next();
+      case '--no-glyph-cache':
+        a.glyphCache = false;
+      default:
+        if (arg.startsWith('--')) {
+          stderr.writeln('unknown flag $arg');
+          exit(2);
+        }
+        a.corpus = arg;
+    }
+  }
+  if (a.corpus.isEmpty) {
+    stderr.writeln('usage: benchmark_strips.dart <corpus> [--max-pages N] '
+        '[--repeat N] [--scale S] [--out file.json]');
+    exit(2);
+  }
+  return a;
+}
+
+List<File> _findPdfs(String root) {
+  final entity = FileSystemEntity.typeSync(root);
+  if (entity == FileSystemEntityType.file) return [File(root)];
+  final files = Directory(root)
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+      .toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  return files;
+}
+
+/// (pages, pagesRendered, openMs, renderMs, error, stats)
+(int, int, double, double, String?, StripStats) _benchFile(
+    File file, int maxPages, double scale, StripGenerator gen) {
+  final stats = StripStats();
+  final bytes = file.readAsBytesSync();
+  final sw = Stopwatch()..start();
+  PdfDocument doc;
+  int pages;
+  try {
+    doc = PdfDocument.open(bytes);
+    pages = doc.pageCount;
+  } catch (e) {
+    return (0, 0, sw.elapsedMicroseconds / 1000, 0, e.toString(), stats);
+  }
+  final openMs = sw.elapsedMicroseconds / 1000;
+
+  final limit = maxPages <= 0 ? pages : (pages < maxPages ? pages : maxPages);
+  var rendered = 0;
+  String? error;
+  final walk = Stopwatch()..start();
+  for (var i = 0; i < limit; i++) {
+    try {
+      final page = doc.page(i);
+      final box = page.cropBox;
+      final w = (box.width * scale).ceil();
+      final h = (box.height * scale).ceil();
+      if (w <= 0 || h <= 0) continue;
+      final pageToDevice = PdfMatrix(
+          scale, 0, 0, -scale, -box.left * scale, box.top * scale);
+      gen.begin(w, h);
+      final device = StripBenchDevice(gen, pageToDevice, stats);
+      PdfInterpreter(cos: doc.cos, device: device).drawPage(page);
+      stats.addBuffer(gen.strips);
+      rendered++;
+    } catch (e) {
+      error ??= 'page $i: $e';
+    }
+  }
+  walk.stop();
+  return (
+    pages,
+    rendered,
+    openMs,
+    walk.elapsedMicroseconds / 1000,
+    error,
+    stats
+  );
+}
+
+void main(List<String> argv) {
+  final args = _parse(argv);
+  final files = _findPdfs(args.corpus);
+  if (files.isEmpty) {
+    stderr.writeln('no PDFs under ${args.corpus}');
+    exit(1);
+  }
+  final corpusIsDir =
+      FileSystemEntity.typeSync(args.corpus) == FileSystemEntityType.directory;
+
+  // reused across pages and files
+  final gen = StripGenerator()
+    ..glyphCache = args.glyphCache ? GlyphStripCache.shared : null;
+  final best = <String, Map<String, Object?>>{};
+  for (var r = 0; r < args.repeat; r++) {
+    for (final file in files) {
+      final (pages, did, openMs, renderMs, error, stats) =
+          _benchFile(file, args.maxPages, args.scale, gen);
+      final name = corpusIsDir
+          ? file.path.substring(args.corpus.length).replaceAll(RegExp(r'^/'), '')
+          : file.uri.pathSegments.last;
+      final prev = best[file.path];
+      final better = prev == null ||
+          (error == null &&
+              (prev['error'] != null ||
+                  renderMs < (prev['renderMs'] as double)));
+      if (better) {
+        best[file.path] = {
+          'file': name,
+          'pages': pages,
+          'pagesRendered': did,
+          'openMs': double.parse(openMs.toStringAsFixed(3)),
+          'renderMs': double.parse(renderMs.toStringAsFixed(3)),
+          'error': error,
+          'strips': stats.toJson(),
+        };
+      }
+    }
+    stderr.writeln('  dart-strips pass ${r + 1}/${args.repeat} done '
+        '(${files.length} files)');
+  }
+
+  // Aggregate: per-page means over successfully rendered pages.
+  var totalPages = 0;
+  var totalMs = 0.0;
+  var totalStrips = 0;
+  var totalSolid = 0;
+  var totalAlphaBytes = 0;
+  for (final f in files) {
+    final r = best[f.path]!;
+    if (r['error'] != null) continue;
+    final did = r['pagesRendered'] as int;
+    if (did == 0) continue;
+    totalPages += did;
+    totalMs += r['renderMs'] as double;
+    final s = r['strips'] as Map<String, Object?>;
+    totalStrips += s['strips'] as int;
+    totalSolid += s['solidStrips'] as int;
+    totalAlphaBytes += s['alphaBytes'] as int;
+  }
+  final gc = GlyphStripCache.shared;
+  final summary = {
+    'pages': totalPages,
+    'glyphCache': args.glyphCache
+        ? {
+            'hits': gc.hits,
+            'misses': gc.misses,
+            'firstSights': gc.firstSights,
+            'bypasses': gc.bypasses,
+            'entries': gc.entryCount,
+            'alphaBytes': gc.alphaBytes,
+            'hitRate': (gc.hits + gc.misses) == 0
+                ? null
+                : double.parse(
+                    (gc.hits / (gc.hits + gc.misses)).toStringAsFixed(3)),
+          }
+        : null,
+    'renderMsPerPage':
+        totalPages == 0 ? null : double.parse((totalMs / totalPages).toStringAsFixed(2)),
+    'stripsPerPage': totalPages == 0 ? null : totalStrips ~/ totalPages,
+    'alphaBytesPerPage':
+        totalPages == 0 ? null : totalAlphaBytes ~/ totalPages,
+    'solidStripFraction': totalStrips == 0
+        ? null
+        : double.parse((totalSolid / totalStrips).toStringAsFixed(3)),
+  };
+  stderr.writeln('  summary: $summary');
+
+  final payload = {
+    'tool': 'dart-pdf-strips',
+    'scale': args.scale,
+    'maxPages': args.maxPages,
+    'engine': 'dart-pdf (pdf_graphics interpreter -> StripGenerator)',
+    'stripStats': summary,
+    'results': [for (final f in files) best[f.path]],
+  };
+  final text = const JsonEncoder.withIndent('  ').convert(payload);
+  final outPath = args.out;
+  if (outPath != null) {
+    final outFile = File(outPath)..parent.createSync(recursive: true);
+    outFile.writeAsStringSync(text);
+    stderr.writeln('wrote $outPath');
+  } else {
+    stdout.writeln(text);
+  }
+}


### PR DESCRIPTION
## Summary

Mainlines the sparse-strip shader rendering stack from the `experiment/strip-*` branches (see `doc/dev-log/2026-07-10-shader-experiment-summary.md` on `experiment/strip-shader`) as a fully **opt-in** feature, plus the two follow-ups it enables. Default rendering paths are byte-identical to before (Ghent baselines untouched, verified). Builds on the retained-scene zoom replay from #208; rebased onto main post-merge.

### What's included

1. **Strip core** (`pdf_graphics/lib/raster.dart`, pure Dart, dart:ui-free): Wang's-bound flattening, stroke→contour expansion, the sparse-strip fine rasterizer (anti-aliased by construction), glyph strip cache, corpus benchmark tool.
2. **`StripPdfDevice`** (`dart_pdf_editor/lib/strips.dart`): renders fills/strokes/outline text as one `drawVertices` + fragment shader (`shaders/pdf_strips.frag`) per flush, delegating everything else to `CanvasPdfDevice` in painter's order. Ghent device-vs-device parity: 57/57 on Impeller, 53/57 relaxed-edge on software Skia (edge-only diffs). Corpus-wide on Impeller it renders 28% faster than the Canvas device; on software backends it is slower (interpreted SkSL) — hence opt-in everywhere.
3. **Stroke/fill strip cache** (`ShapeStripCache`, new): content-keyed replay (translation-invariant 1/64-px geometry hash + stroke params, cache-on-second-sight, generational rotation, full content verification per hit):

| strip generation (scale 2, ms/page) | off | on |
|---|---:|---:|
| corpus mean | 29.96 | 27.25 (−9%) |
| WAT CAD sheet (steady state) | 107.8 | **63.0 (−42%)** |
| ly9-far-cad (solo) | 149.9 | 124.8 (−17%) |

4. **Dense-page strip zoom router** (`PdfPageView.stripZoomReplay`, static, **default false**): with the flag on, pages above `retainedZoomReplayMaxCommands` retain their scene and zoom-replay through strips instead of skipping retention:

| zoom settle, ly9-far-cad p4 (99k commands), Impeller | ms |
|---|---:|
| current cached-picture path | 1576 |
| flat retained replay (#208 — why dense pages skip it) | 1511 |
| **strip replay (this PR, flag on)** | **380 (~4.2×)** |

Default-off rationale (documented on the flag): software backends must never route here (2× SkSL regression) and there is no reliable runtime Impeller detection, so the embedding app opts in; re-bin costs ~270 ms of UI thread per settle on CAD-scale pages — the trade is blocked-longer vs 4× faster to sharp pixels. Worker-isolate strip generation (the core is dart:ui-free by design) is the documented path to default-on.

## Verification

- Root analyzer clean; `pdf_graphics` (757) + `dart_pdf_editor` (1304) suites green pre-rebase; post-rebase re-run of analyzer, the full raster suite, and the strip/router/scene/page-view tests — green (rebase over #207/#209 touched disjoint files).
- Strip/parity/router tests pass on both software and `--enable-impeller` backends.
- `corpus_render_test` 49/49; `ghent_render_test` green with checked-in baselines untouched (default path unchanged).
- Flag-off behavior is byte-for-byte #208 (tested: zero strip activity).
- Cached-vs-fresh byte-identity tests for both the glyph and shape caches.
- Dev-log: `doc/dev-log/2026-07-10-strip-mainline.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)