### PR TITLE
perf(dart_pdf_editor): worker-isolate strip binning, Impeller gate, stripZoomReplay default on

### DIFF
--- a/doc/dev-log/2026-07-10-strip-worker-binning.md
+++ b/doc/dev-log/2026-07-10-strip-worker-binning.md
@@ -1,0 +1,233 @@
+# 2026-07-10 — Worker-isolate strip binning, the Impeller gate, and default-on
+
+Branch `perf/strip-worker-binning`, stacked on `feat/strip-rendering`
+(PR #210). #210 left the strip zoom router opt-in for two reasons: no
+runtime backend detection, and the ~270 ms strip re-bin ran on the UI
+thread every settle. This session removes both — and, along the way,
+found and fixed a silent total-blackout bug in #210's Impeller path.
+
+## 1. Shared binning core (`StripBinningDevice`, pdf_graphics/raster)
+
+`StripPdfDevice`'s routing/state/flush logic moved to an abstract,
+dart:ui-free base in `pdf_graphics/lib/src/raster/strip_binning_device.dart`:
+blend/knockout/clip stacks, the generator feeds (hairline-stroke width
+adjustment, the glyph-outline loop), `stripFlattenTolerance`, and **every
+flush-point decision**, including `endSoftMasked`'s composite split (the
+base runs `drawMask()` between the halves so mask strips bin identically
+everywhere). Subclasses get `emitBatch(ordinal, StripBatchData?)` plus
+per-op delegate hooks.
+
+**The flush-ordinal parity invariant**: flush points are counted in the
+base — empty ones included — and batches are tagged with the ordinal of
+the flush point that emitted them. Because routing and flushing live
+*only* in the base, a headless replay of the same command list on another
+isolate produces batches that interleave at exactly the same ordinals as
+the live device. That is the entire correctness story of precomputed
+plans. Corollary: the debug-delegate flags change routing, so any of them
+being set forces local binning (worker isolates have their own statics).
+
+`StripBatchData`/`StripChunkData` (also pdf_graphics) carry the exact
+`drawVertices` upload arrays; the editor's `StripBatch` is now nothing
+but `ui.Vertices.raw` + `decodeImageFromPixels` around them.
+
+## 2. StripPlan + codec + StripPlanBinner
+
+`StripPlan` = { totalFlushPoints, deviceWidth/Height, pageToDevice (6
+doubles, bit-exact round-trip), tolerance, ordinal-tagged batches }.
+`encodeStripPlan`/`decodeStripPlan` write one compact Uint8List (bulk
+arrays as raw host-order bytes — producer and consumer are the same
+build), shipped as a single `TransferableTypedData`.
+`StripPlanBinner` is the headless subclass (delegates are no-ops);
+`replayCommandsCancellable` (render_command.dart) chunks the replay every
+1024 commands, yielding so a worker's cancel port can preempt mid-walk.
+
+## 3. Worker protocol: `binStrips` / `cancelBinStrips`
+
+`PdfRenderWorker.binStrips(page, {annotations, pageToDevice, deviceWidth,
+deviceHeight, pixelRatio, priority: 0})` — priority 0 because a zoom
+settle IS the visible page. Bins ride the native isolate's existing
+priority queue with their own cancel kind (a settle cancel can't drop the
+page's record and vice versa). The abstract base supplies a declining
+default (null → local bin) which the stub and web backends inherit; the
+web worker entry answers the `bin` message kind with null defensively.
+`PdfPooledRenderWorker` routes bins by the **static** page index — a zoom
+session hammers one page, so stable affinity keeps the worker-side caches
+warm, where least-loaded routing would re-record the page on every
+worker. `PdfCachingRenderWorker` passes bins straight through: a plan is
+only valid for the matrix it was binned for and every settle's is fresh.
+
+Worker side: on command-cache miss the isolate re-records the page
+(deterministic interpretation ⇒ matches the buffer the UI's scene came
+from), **round-trips it through the wire codec** so geometry carries the
+same float32 truncation as the UI's scene — making worker plans
+bit-identical to a local re-bin (asserted end-to-end in
+`render_worker_strips_test.dart` by comparing encoded plans, and in
+`strip_plan_device_test.dart` by byte-comparing rasters). The list is
+kept in a 2-entry (page, annotations) LRU; stable command identity across
+settles is what lets the process-global glyph/shape strip caches hit on
+repeat settles (measured below). Pages that can't round-trip (inline
+images) decline — the same pages `record` declines, so their scenes are
+locally recorded and never ask for plans anyway.
+
+## 4. Precomputed mode + verification/fallback semantics
+
+`StripPdfDevice(precomputed: plan)`: generator never feeds (no
+flatten/stroke/coverage cost); each flush point consumes the plan batch
+tagged with its ordinal. Guards, in order:
+
+- `usablePlan` (constructor): geometry must match exactly (dims, matrix
+  coefficient-for-coefficient, tolerance) and no debug-delegate flag may
+  be set — else the plan is dropped up front (stale geometry counts in
+  `totalPlanMismatches`) and the device bins locally.
+- `finish()`: verifies flush-point count and full batch consumption
+  **before painting anything**; a desync throws `StripPlanMismatchError`,
+  which `PdfRetainedScene`'s strip replays catch — recording discarded,
+  transparent re-run with local binning. `totalPlanPictures` counts
+  plan-fed pictures for tests/telemetry.
+- `debugVerifyPrecomputed` (test-only): bins locally too and
+  byte-compares every batch (ordinal presence, strip count, alphaBase,
+  vertex arrays, atlas bytes) against the plan.
+
+`PdfRetainedScene` grew `stripGeometry`/`stripRegionGeometry` — the page
+view sends those exact six coefficients to the worker, so the equality
+guard is exact, not epsilon-y — and `stripPlan:` params on the strip
+replay/rasterize entry points.
+
+## 5. PdfPageView: backend gate + plan wiring
+
+- **Impeller gate**: strip routing (both `_retainScene` at scene-adoption
+  time and `_stripReplayScene` at settle time — they must agree, or a
+  page retained for strips wouldn't strip) additionally requires
+  `ui.ImageFilter.isShaderFilterSupported`, public API that is true iff
+  Impeller is enabled (verified in 3.44.4 sky_engine painting.dart:4506).
+  `PdfPageView.debugStripZoomReplayBackendOverride` forces the decision
+  in tests (`flutter test` = software Skia).
+- Scenes track their origin (`_setScene(fromWorker:)`): only scenes built
+  from a worker-recorded buffer may consume worker plans. Locally
+  recorded scenes (worker declined, editing's `skipAnnotation`) keep
+  local binning — a worker re-record would ignore skipAnnotation and
+  carry f64 geometry, desyncing either content or bytes.
+- Zoom settle and deep-zoom region detail request a plan via
+  `_workerStripPlan` (cancels the page's still-queued bin first, so a
+  newer settle/pan supersedes an older one; the superseded caller's null
+  dies under its generation guard without a wasteful local re-bin), then
+  `rasterizeStrips/RegionStrips(stripPlan:)`; null plan = local bin,
+  exactly #210's behavior.
+- Strip-routed pages now skip `_detailPictureFromWorker` for the detail
+  patch: replaying its picture is a nested-picture re-raster — the slow
+  path strips exist to avoid. The region-resolution image re-decode that
+  path offers is orthogonal (stays for canvas-routed pages); combining it
+  with strip plans is a follow-up.
+- Queued bins are cancelled alongside record cancels on dispose and
+  page-recycle.
+
+## 6. The Impeller blackout bug (separate fix commit)
+
+While benchmarking, Impeller validation errors appeared: `Requested
+texture size (495503, 8) exceeds maximum supported size of (16384,
+16384)` … `Missing texture for VerticesSimpleBlendContents`. Impeller
+does not pass drawVertices texcoords to the fragment shader as varyings
+(Skia does): it renders the paint's runtime shader into a **snapshot
+texture covering the texcoord bounds** and samples that. Our u texcoords
+were *global alpha-texel indices* — ~500k on a dense CAD batch — so the
+snapshot failed validation and the batch drew **nothing**. ly9-far-cad
+p4 through #210's router rendered a blank page on Impeller (only the
+delegated logo painted); #210's Impeller settle numbers (380 ms) were
+timing an empty raster. The M0 probes and Ghent-sized parity pages never
+tripped it because their atlases are small.
+
+Fix: `StripBatchData` chunks by alpha-texel span too
+(`stripMaxAlphaColumnsPerDraw` = 8192, chosen under the 8192 max-texture
+floor of older Metal GPUs), texcoords are rebased per chunk, and a new
+`uBase` shader uniform (one `fragmentShader()` instance per chunk)
+restores the global origin. Solid strips now carry constant u = 0 — their
+sample is ignored and texel 0 always exists — so they never widen a
+chunk's bounds. After the fix ly9 renders the full sheet on Impeller with
+zero validation errors; software output is unchanged (parity 53/57
+relaxed, as documented).
+
+**Known environment deviation**: `strip_parity_test` under
+`--enable-impeller` sits at 22/57 relaxed on this machine — *at the base
+commit too*, identical numbers, so it predates this branch (the dev-log
+of #210 recorded 57/57 on some other setup). The diffs are edge-share
+~100% canvas-vs-strips AA character differences of Impeller's canvas;
+the strip side is CPU-binned and backend-independent. Left as is.
+
+## 7. Benchmarks (Impeller/Metal, M4, `strip_worker_latency_test.dart` + `zoom_latency_test.dart`, mean ms/settle over 3 passes × 5 zoom steps, 2382×1684 fit)
+
+ly9-far-cad p4 (98 936 commands — the only default file that strip-routes;
+WAT_L0001_S p0 records 12 741 commands, under the 20 000 ceiling, and
+keeps the flat retained replay, 585 ms/settle unchanged):
+
+| path | binWait | build | toImage | readback | **UI-block** | total |
+|---|---|---|---|---|---|---|
+| a-current (cached picture, pre-#210) | — | 3 | 81 | 1389 | ~3 | **1473** |
+| b-retained (flat replay) | — | 70 | 63 | 1319 | ~70 | 1453 |
+| L local-bin strips (#210 + blackout fix) | — | 343 | 31 | 394 | **341** | 768 |
+| W worker-plan strips (this branch) | 338 | 24 | 31 | 373 | **35** | 767 |
+
+- UI-block = the synchronous main-isolate sections (route/bin + tape
+  replay + plan decode; `totalRouteMicros`/`totalReplayMicros`/
+  `decodeStripPlanMicros`). The worker wait and GPU raster are awaited.
+- Strips reach sharp pixels ~2× sooner than the shipping path
+  (a-current 1473 → ~770 ms; #210's headline 380 ms was the blank-raster
+  artifact — the honest post-fix number is 622–768 ms depending on
+  harness, still the fastest path by far).
+- **Worker plans cut the settle's UI-thread blocking 341 → 35 ms**
+  (−90%), under the ≤80 ms flip criterion. The residual is plan decode
+  (~10 ms), `ui.Vertices.raw` creation, and the routing walk of the 99k
+  commands.
+- Worker-side steady state: bin wait per settle 449 (cold) → 385 → 339 →
+  291 ms across passes — the command-cache-stable glyph/shape strip
+  caches carry over, mirroring the local −42% effect at reduced scale
+  (each settle still has a fresh matrix, so only the cached-shape replay
+  cost drops, not the whole bin).
+- Office control (INVOICE, 545 commands): 91 ms/settle via b-retained,
+  untouched code path, no regression.
+
+## 8. Default flip
+
+`PdfPageView.stripZoomReplay` now defaults **true**: the Impeller gate
+makes it inert on software/web, worker binning keeps the UI thread
+under ~35 ms per settle on the worst corpus page, and the no-worker
+fallback (local bin, 341 ms blocked but sharp ~2× sooner) is the honest
+cost of the fastest available settle. Kill switch unchanged (set false).
+
+## 9. Web status
+
+Protocol stubbed only: the web client's `binStrips` inherits the
+declining default (null → local bin — itself unreachable today because
+`isShaderFilterSupported` is false on web), and the worker entry answers
+the `bin` message kind with null so a future client can't hang a slot.
+`dart run dart_pdf_editor:build_web_worker` (ci.yml's gate) compiles
+green. Wiring real web strip binning (and web strip routing generally)
+stays out of scope until strips are proven on a web backend.
+
+## 10. Follow-ups
+
+- Region detail: combine worker strip plans with region-cropped image
+  re-decode (today strip-routed pages reuse the scene's base-resolution
+  images at deep zoom).
+- The Impeller-canvas parity deviation (22/57 relaxed on this machine,
+  pre-existing) deserves its own investigation — likely MSAA/AA character
+  of Impeller's path rendering, not a strips defect.
+- `zoom_latency_test`'s (d) path now reflects real Impeller drawing;
+  #210's dev-log table numbers for (d) should be read with this session's
+  correction in mind.
+- Consider making `stripMaxAlphaColumnsPerDraw` adaptive if a device
+  reports a smaller max texture size than 8192 (none known under
+  Impeller's Metal/Vulkan floors).
+
+## Files
+
+- pdf_graphics: `src/raster/strip_binning_device.dart`,
+  `strip_batch_data.dart`, `strip_plan.dart` (+ `raster.dart` exports),
+  `src/render_command.dart` (range + cancellable replay),
+  `test/raster/strip_plan_test.dart`.
+- dart_pdf_editor: `src/strips/strip_device.dart` (subclass + precomputed
+  mode), `strip_batch.dart` (engine wrapper), `shaders/pdf_strips.frag`
+  (uBase), `src/render_worker*.dart` (protocol), `src/retained_scene.dart`
+  (geometry helpers + stripPlan), `src/pdf_page_view.dart` (gate, scene
+  origin, plan wiring, default), tests: `strip_plan_device_test.dart`,
+  `render_worker_strips_test.dart`, `strip_worker_latency_test.dart`,
+  updated `strip_zoom_router_test.dart`.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -13,6 +13,7 @@ import 'render_scheduler.dart';
 import 'render_worker.dart';
 import 'renderer.dart';
 import 'retained_scene.dart';
+import 'strips/strip_device.dart';
 
 /// Displays a single PDF page, rendered natively in Dart.
 ///
@@ -189,18 +190,24 @@ class PdfPageView extends StatefulWidget {
   /// (fixed atlas-decode/replay overhead, and Impeller already rasterizes
   /// light flat pictures quickly).
   ///
-  /// Default FALSE, and it must stay off on software backends: the SkSL
-  /// interpreter runs the coverage shader per fragment, making strips ~2x
-  /// slower than the canvas there, and there is no reliable runtime
-  /// Impeller detection - so the embedding app opts in where it knows its
-  /// backend (measured on Impeller/Metal: a dense CAD sheet reaches sharp
-  /// pixels ~3.5x sooner per zoom settle). The honest trade: the strip
-  /// re-bin runs on the UI thread (~300 ms per settle on that CAD sheet),
-  /// blocking longer than the nested re-raster's cheap UI-thread half but
-  /// finishing far sooner overall. Off-thread strip generation in the
-  /// render worker (the strip core is deliberately dart:ui-free for
-  /// exactly that) is the path to default-on.
+  /// Strip routing only engages on Impeller
+  /// (`ui.ImageFilter.isShaderFilterSupported`, public API that is true iff
+  /// Impeller is the runtime backend): software Skia's SkSL interpreter
+  /// runs the coverage shader per fragment, making strips ~2x slower than
+  /// the canvas there, so on software/web backends this flag is inert and
+  /// dense pages keep the classic cached-picture zoom path. Measured on
+  /// Impeller/Metal: the dense CAD sheet reaches sharp pixels ~4x sooner
+  /// per zoom settle - and with a render worker attached the ~270 ms strip
+  /// re-bin runs on the worker isolate ([PdfRenderWorker.binStrips]), so
+  /// the UI thread only uploads the precomputed batches and replays the
+  /// tape. Without a worker (or when it declines) the re-bin runs locally
+  /// on the UI thread, the honest cost of the fastest available settle.
   static bool stripZoomReplay = false;
+
+  /// Test hook for the Impeller gate: `flutter test` runs on software Skia
+  /// where `ui.ImageFilter.isShaderFilterSupported` is false, so strip
+  /// router tests force the decision. Null (production) asks the engine.
+  static bool? debugStripZoomReplayBackendOverride;
 
   @override
   State<PdfPageView> createState() => _PdfPageViewState();
@@ -336,6 +343,8 @@ class _PdfPageViewState extends State<PdfPageView> {
       // screen. The in-flight one can't be preempted; this clears the backlog.
       oldWidget.renderWorker
           ?.cancel(oldWidget.previewIndex, priority: oldWidget.renderPriority);
+      oldWidget.renderWorker?.cancelBinStrips(oldWidget.previewIndex,
+          priority: oldWidget.renderPriority);
     }
     if (!identical(oldWidget.previewCache, widget.previewCache) ||
         oldWidget.previewIndex != widget.previewIndex) {
@@ -408,6 +417,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     // fallback). No-op if nothing is queued for it.
     widget.renderWorker
         ?.cancel(widget.previewIndex, priority: widget.renderPriority);
+    widget.renderWorker?.cancelBinStrips(widget.previewIndex,
+        priority: widget.renderPriority);
     widget.previewCache?.removeListener(_onPreviewCacheChanged);
     _dropPicture();
     _image?.dispose();
@@ -426,10 +437,21 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// Adopts [scene] as the page's retained scene, disposing the previous
   /// one. Outstanding pictures replayed from the old scene keep painting
   /// (they hold their own image refs); only new replays need the new scene.
-  void _setScene(PdfRetainedScene? scene) {
+  ///
+  /// [fromWorker] marks a scene built from a worker-recorded command buffer
+  /// (its geometry carries the wire codec's float32 truncation and its
+  /// content matches what the worker would re-record). ONLY such scenes may
+  /// consume worker-binned strip plans; locally-recorded scenes - the
+  /// worker declined, or an editing flow recorded with skipAnnotation -
+  /// keep local binning, because a worker re-record could desync from them.
+  void _setScene(PdfRetainedScene? scene, {bool fromWorker = false}) {
     _scene?.dispose();
     _scene = scene;
+    _sceneFromWorker = scene != null && fromWorker;
   }
+
+  /// Whether [_scene] came from the render worker (see [_setScene]).
+  bool _sceneFromWorker = false;
 
   void _dropDetail() {
     _detailGeneration++;
@@ -512,8 +534,9 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// Both paths go through a recorded command buffer, so alongside the
   /// picture they also return the [PdfRetainedScene] built from that same
   /// buffer (null when [PdfPageView.retainedZoomReplay] is off) - the caller
-  /// adopts it once the render is known not to be superseded.
-  Future<(ui.Picture, PdfRetainedScene?)?> _interpretPicture() async {
+  /// adopts it once the render is known not to be superseded - and whether
+  /// the buffer came from the worker (see [_setScene]'s fromWorker).
+  Future<(ui.Picture, PdfRetainedScene?, bool)?> _interpretPicture() async {
     final pageIndex = widget.previewIndex;
     final worker = widget.renderWorker;
     if (worker != null && worker.isActive) {
@@ -533,15 +556,16 @@ class _PdfPageViewState extends State<PdfPageView> {
       // what the worker exists to avoid. Note we DON'T gate on the render
       // generation here: a newer same-page render (e.g. a zoom mid-interpret)
       // reuses this very future, so the picture must still be produced for it.
-      if (_abandoned(pageIndex)) return (_emptyPicture(), null);
+      if (_abandoned(pageIndex)) return (_emptyPicture(), null, false);
       if (commands != null) {
         if (_renderPaused) return null;
         _lastInterpretPath = 'worker';
         _logImageStats(pageIndex, commands);
-        return _replayableFromCommands(commands);
+        final (picture, scene) = await _replayableFromCommands(commands);
+        return (picture, scene, true);
       }
     }
-    if (_abandoned(pageIndex)) return (_emptyPicture(), null);
+    if (_abandoned(pageIndex)) return (_emptyPicture(), null, false);
     if (_renderPaused) return null;
     // The worker may be active yet decline this page (it returns null), in
     // which case the interpret runs here - the log must say so, not 'worker'.
@@ -551,6 +575,7 @@ class _PdfPageViewState extends State<PdfPageView> {
         await PdfPageRenderer.renderPictureRecordedWithPlan(
             widget.page, _renderPlan),
         null,
+        false,
       );
     }
     // Same record + decode renderPictureRecordedWithPlan runs internally,
@@ -563,9 +588,9 @@ class _PdfPageViewState extends State<PdfPageView> {
       // path serves this page's zooms.
       final picture = scene.replay(pixelRatio: 1);
       scene.dispose();
-      return (picture, null);
+      return (picture, null, false);
     }
-    return (scene.replay(pixelRatio: 1), scene);
+    return (scene.replay(pixelRatio: 1), scene, false);
   }
 
   /// Whether a page recorded as [commandCount] top-level commands should
@@ -576,13 +601,24 @@ class _PdfPageViewState extends State<PdfPageView> {
   static bool _retainScene(int commandCount) =>
       PdfPageView.retainedZoomReplay &&
       (commandCount <= PdfPageView.retainedZoomReplayMaxCommands ||
-          PdfPageView.stripZoomReplay);
+          (PdfPageView.stripZoomReplay && _stripBackendSupported));
+
+  /// Whether the runtime backend draws strip batches profitably: Impeller
+  /// only (`ui.ImageFilter.isShaderFilterSupported` is public API that is
+  /// true iff Impeller is enabled). Consulted by BOTH the retention
+  /// decision ([_retainScene], at scene-adoption time) and the settle
+  /// router ([_stripReplayScene]) so a dense page retained for strips
+  /// actually strips - the two must never disagree.
+  static bool get _stripBackendSupported =>
+      PdfPageView.debugStripZoomReplayBackendOverride ??
+      ui.ImageFilter.isShaderFilterSupported;
 
   /// Whether [scene]'s zoom re-rasters route through the strip device: the
-  /// opt-in flag, and only above the ceiling (under it the flat canvas
-  /// replay wins - see [PdfPageView.stripZoomReplay]).
+  /// flag, the Impeller backend gate, and only above the ceiling (under it
+  /// the flat canvas replay wins - see [PdfPageView.stripZoomReplay]).
   static bool _stripReplayScene(PdfRetainedScene scene) =>
       PdfPageView.stripZoomReplay &&
+      _stripBackendSupported &&
       scene.commands.length > PdfPageView.retainedZoomReplayMaxCommands;
 
   /// Builds the picture (and, unless [PdfPageView.retainedZoomReplay] is
@@ -638,7 +674,7 @@ class _PdfPageViewState extends State<PdfPageView> {
           scene.dispose();
           return;
         }
-        _setScene(scene);
+        _setScene(scene, fromWorker: true);
         _picture = Future.value(scene.replay(pixelRatio: 1));
       } else {
         _picture = PdfPageRenderer.pictureFromCommandsWithPlan(
@@ -746,14 +782,17 @@ class _PdfPageViewState extends State<PdfPageView> {
         if (!_superseded(generation, pageIndex)) _render();
         return;
       }
-      final (interpretedPicture, interpretedScene) = interpreted;
+      final (interpretedPicture, interpretedScene, sceneFromWorker) =
+          interpreted;
       if (_superseded(generation, pageIndex)) {
         interpretedPicture.dispose();
         interpretedScene?.dispose();
         return;
       }
       _picture = Future.value(interpretedPicture);
-      if (interpretedScene != null) _setScene(interpretedScene);
+      if (interpretedScene != null) {
+        _setScene(interpretedScene, fromWorker: sceneFromWorker);
+      }
       picture = interpretedPicture;
     }
     sw.stop();
@@ -785,15 +824,23 @@ class _PdfPageViewState extends State<PdfPageView> {
       // one is held - Impeller rasterizes that several times faster than the
       // nested drawPicture re-raster, with byte-identical output. Dense
       // pages retained under PdfPageView.stripZoomReplay re-bin through the
-      // strip shader device instead. Fallback paths (no scene, or the kill
-      // switch) re-raster the cached picture.
+      // strip shader device instead - with the re-bin itself offloaded to
+      // the render worker when the scene is worker-backed (the plan comes
+      // back precomputed; null plan = local bin). Fallback paths (no scene,
+      // or the kill switch) re-raster the cached picture.
       final scene = PdfPageView.retainedZoomReplay ? _scene : null;
-      final image = scene != null
-          ? await (_stripReplayScene(scene)
-              ? scene.rasterizeStrips(pixelRatio: effective)
-              : scene.rasterize(pixelRatio: effective))
-          : await PdfPageRenderer.rasterize(
-              picture, _renderPlan.pageSize(widget.page), effective);
+      final ui.Image image;
+      if (scene != null && _stripReplayScene(scene)) {
+        final stripPlan = await _workerStripPlan(scene, pixelRatio: effective);
+        if (_superseded(generation, pageIndex)) return;
+        image = await scene.rasterizeStrips(
+            pixelRatio: effective, stripPlan: stripPlan);
+      } else if (scene != null) {
+        image = await scene.rasterize(pixelRatio: effective);
+      } else {
+        image = await PdfPageRenderer.rasterize(
+            picture, _renderPlan.pageSize(widget.page), effective);
+      }
       if (_superseded(generation, pageIndex)) {
         image.dispose();
         return;
@@ -877,8 +924,17 @@ class _PdfPageViewState extends State<PdfPageView> {
     ratio =
         math.min(ratio, _maxDimension / math.max(region.width, region.height));
 
-    final workerPicture =
-        await _detailPictureFromWorker(region, ratio, widget.previewIndex);
+    // Strip-routed dense pages skip the worker's region record: replaying
+    // its picture is a nested-picture re-raster - the slow path strips
+    // exist to avoid - so they go straight to the strip region replay
+    // below (with a worker-binned plan when the scene is worker-backed).
+    // The region-resolution image re-decode the worker record offers is
+    // orthogonal and stays for canvas-routed pages.
+    final heldScene = PdfPageView.retainedZoomReplay ? _scene : null;
+    final stripDetail = heldScene != null && _stripReplayScene(heldScene);
+    final workerPicture = stripDetail
+        ? null
+        : await _detailPictureFromWorker(region, ratio, widget.previewIndex);
     if (!mounted || generation != _detailGeneration || _renderPaused) {
       workerPicture?.dispose();
       return false;
@@ -917,13 +973,25 @@ class _PdfPageViewState extends State<PdfPageView> {
     }
     // Same replay-over-nested-raster swap as the full-page path: the deep-
     // zoom patch replays only [region] from the retained scene when held
-    // (through the strip device for dense pages under stripZoomReplay).
+    // (through the strip device for dense pages under stripZoomReplay,
+    // worker-binned when the scene is worker-backed - a pan at deep zoom
+    // fires these repeatedly, so each fresh region cancels the previous
+    // region's still-queued bin inside _workerStripPlan).
     final scene = PdfPageView.retainedZoomReplay ? _scene : null;
-    final image = scene != null
-        ? await (_stripReplayScene(scene)
-            ? scene.rasterizeRegionStrips(region, pixelRatio: ratio)
-            : scene.rasterizeRegion(region, pixelRatio: ratio))
-        : await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
+    final ui.Image image;
+    if (scene != null && _stripReplayScene(scene)) {
+      final stripPlan =
+          await _workerStripPlan(scene, pixelRatio: ratio, region: region);
+      if (!mounted || generation != _detailGeneration || _renderPaused) {
+        return false;
+      }
+      image = await scene.rasterizeRegionStrips(region,
+          pixelRatio: ratio, stripPlan: stripPlan);
+    } else if (scene != null) {
+      image = await scene.rasterizeRegion(region, pixelRatio: ratio);
+    } else {
+      image = await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
+    }
     if (!mounted || generation != _detailGeneration || _renderPaused) {
       image.dispose();
       return false;
@@ -934,6 +1002,46 @@ class _PdfPageViewState extends State<PdfPageView> {
       _detailFraction = fraction;
     });
     return true;
+  }
+
+  /// Asks the render worker to bin this page's strips for the exact device
+  /// geometry the strip replay is about to construct ([stripGeometry] /
+  /// [stripRegionGeometry] of [scene]), or null to bin locally: no worker /
+  /// worker declined, a locally-recorded scene (see [_setScene]'s
+  /// fromWorker), or a debug-delegate flag forcing local routing (the
+  /// worker isolate has its own statics and would bin the full routing,
+  /// desyncing flush ordinals).
+  ///
+  /// Any still-queued bin for this page is cancelled first, so a newer
+  /// settle/region supersedes an older one in the worker queue; the
+  /// cancelled caller's null resolves under a stale generation and is
+  /// discarded by its guard without falling back to a local bin.
+  Future<StripPlan?> _workerStripPlan(PdfRetainedScene scene,
+      {required double pixelRatio, Rect? region}) async {
+    if (!_sceneFromWorker) return null;
+    final worker = widget.renderWorker;
+    if (worker == null || !worker.isActive) return null;
+    if (StripPdfDevice.debugDelegateAll ||
+        StripPdfDevice.debugDelegateFills ||
+        StripPdfDevice.debugDelegateStrokes ||
+        StripPdfDevice.debugDelegateText) {
+      return null;
+    }
+    final geometry = region == null
+        ? scene.stripGeometry(pixelRatio: pixelRatio)
+        : scene.stripRegionGeometry(region, pixelRatio: pixelRatio);
+    final m = geometry.pageToDevice;
+    worker.cancelBinStrips(widget.previewIndex,
+        priority: widget.renderPriority);
+    return worker.binStrips(
+      widget.previewIndex,
+      annotations: scene.plan.annotations,
+      pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+      deviceWidth: geometry.width,
+      deviceHeight: geometry.height,
+      pixelRatio: pixelRatio,
+      priority: widget.renderPriority,
+    );
   }
 
   Future<ui.Picture?> _detailPictureFromWorker(

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -181,14 +181,24 @@ class PdfPageView extends StatefulWidget {
   /// retained replay costs about one frame.
   static int retainedZoomReplayMaxCommands = 20000;
 
-  /// Opt-in strip routing for pages ABOVE [retainedZoomReplayMaxCommands]:
-  /// when true they DO retain their scene, and zoom-driven re-rasters (full
-  /// page and deep-zoom detail patch) replay it through the sparse-strip
-  /// shader device ([PdfRetainedScene.rasterizeStrips]) at the new ratio
-  /// instead of re-rasterizing the cached nested picture. Pages under the
-  /// ceiling keep the flat canvas replay - strips lose on office pages
-  /// (fixed atlas-decode/replay overhead, and Impeller already rasterizes
-  /// light flat pictures quickly).
+  /// Strip routing for pages ABOVE [retainedZoomReplayMaxCommands]: they DO
+  /// retain their scene, and zoom-driven re-rasters (full page and deep-zoom
+  /// detail patch) replay it through the sparse-strip shader device
+  /// ([PdfRetainedScene.rasterizeStrips]) at the new ratio instead of
+  /// re-rasterizing the cached nested picture. Pages under the ceiling keep
+  /// the flat canvas replay - strips lose on office pages (fixed
+  /// atlas-decode/replay overhead, and Impeller already rasterizes light
+  /// flat pictures quickly).
+  ///
+  /// Default TRUE since worker-isolate strip binning landed: the two
+  /// concerns that kept #210's router opt-in are gone. (1) Backend: the
+  /// Impeller gate below turns the flag off automatically where strips
+  /// lose, so no host knowledge is needed. (2) UI-thread cost: with a
+  /// render worker attached the ~340 ms re-bin runs off-thread and the
+  /// settle blocks the UI ~35 ms (measured, ly9-far-cad p4) - decode the
+  /// plan, create engine objects, replay the tape. Set false to restore
+  /// the cached-picture zoom path for dense pages if a regression is ever
+  /// suspected in the field.
   ///
   /// Strip routing only engages on Impeller
   /// (`ui.ImageFilter.isShaderFilterSupported`, public API that is true iff
@@ -202,7 +212,7 @@ class PdfPageView extends StatefulWidget {
   /// the UI thread only uploads the precomputed batches and replays the
   /// tape. Without a worker (or when it declines) the re-bin runs locally
   /// on the UI thread, the honest cost of the fastest available settle.
-  static bool stripZoomReplay = false;
+  static bool stripZoomReplay = true;
 
   /// Test hook for the Impeller gate: `flutter test` runs on software Skia
   /// where `ui.ImageFilter.isShaderFilterSupported` is false, so strip

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart' show StripPlan;
 
 import 'render_worker_stub.dart'
     if (dart.library.io) 'render_worker_isolate.dart'
@@ -107,6 +108,8 @@ PdfRenderWorker startPdfRenderWorker(Uint8List bytes,
 /// editing session must dispose and restart the worker when the document's
 /// bytes change (or simply not use one).
 abstract class PdfRenderWorker {
+  const PdfRenderWorker();
+
   /// Starts the platform's worker over [bytes] (the document image the page
   /// indices passed to [record] refer to). Native: a long-lived background
   /// isolate that opens its own [PdfDocument]. Web: a Web Worker over the
@@ -205,6 +208,53 @@ abstract class PdfRenderWorker {
   /// [PdfPageView] does this by abandoning when it is unmounted or superseded.
   void cancel(int pageIndex, {int priority = 0});
 
+  /// Bins page [pageIndex]'s sparse strips off-thread for the exact device
+  /// geometry a strip-routed zoom settle is about to rasterize, returning a
+  /// [StripPlan] the caller feeds to `StripPdfDevice(precomputed:)` (via
+  /// `PdfRetainedScene.rasterizeStrips(stripPlan:)`), or null when the page
+  /// can't be binned off-thread - the platform has no worker, the worker
+  /// failed/was disposed/was cancelled, or the page declines - and the
+  /// caller bins locally.
+  ///
+  /// [pageToDevice] is the six coefficients (a, b, c, d, e, f) of the
+  /// page-space -> device-pixel [PdfMatrix] the consuming device will be
+  /// constructed with (the scene's own zoom/region transform); they round-
+  /// trip bit-exactly, so the device's stale-plan guard can compare them
+  /// with `==`. [deviceWidth]/[deviceHeight] are the strip viewport in
+  /// pixels and [pixelRatio] the ratio baked into the matrix.
+  ///
+  /// [annotations] must match the recording the caller's retained scene was
+  /// built from - the worker re-records the page in its own isolate
+  /// (interpretation is deterministic, so the command list matches the
+  /// scene's) and replays it through a headless strip binner.
+  ///
+  /// [priority] shares [record]'s queue ordering; the default 0 is the
+  /// on-screen page - a zoom settle IS the visible page, so it preempts
+  /// background prefetch exactly like a visible record.
+  ///
+  /// The base implementation declines (null): platforms and wrappers that
+  /// don't offload strip binning - the stub and the web worker today -
+  /// inherit it.
+  Future<StripPlan?> binStrips(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    int priority = 0,
+  }) async =>
+      null;
+
+  /// Drops any QUEUED (not yet started) [binStrips] request for [pageIndex]
+  /// at [priority], completing its future with null. Superseded settles
+  /// call this so the worker's next slot bins the geometry the user is
+  /// actually looking at instead of a stale one; the abandoning caller must
+  /// not fall back to a local bin for the superseded settle (PdfPageView's
+  /// generation guard takes care of that). In-flight preemption rides the
+  /// same cooperative cancellation as [cancel].
+  void cancelBinStrips(int pageIndex, {int priority = 0}) {}
+
   /// Whether this worker actually offloads. False for the null fallback, so
   /// callers can skip the round-trip and render locally without asking.
   bool get isActive;
@@ -243,7 +293,7 @@ abstract class PdfRenderWorker {
 /// bypass the ordinary pool through a lazily-created one-off worker. A page
 /// jump should not wait behind several already-started background records that
 /// cannot receive cancellation until their synchronous parse step yields.
-class PdfPooledRenderWorker implements PdfRenderWorker {
+class PdfPooledRenderWorker extends PdfRenderWorker {
   /// Starts [size] platform workers over copies of [bytes]. [size] is clamped to
   /// at least 1; a pool of 1 is just a single worker with this routing wrapper.
   PdfPooledRenderWorker(Uint8List bytes, int size)
@@ -381,6 +431,38 @@ class PdfPooledRenderWorker implements PdfRenderWorker {
     _cancelWorkerFor(pageIndex, priority).cancel(pageIndex, priority: priority);
   }
 
+  /// Strip binning routes by the STATIC page index, not the least-loaded
+  /// worker: each worker keeps a small per-isolate command cache (plus the
+  /// process-global glyph/shape strip caches) warm for the pages it has
+  /// binned, and a zoom session hammers ONE page with a fresh geometry per
+  /// settle - stable affinity turns every settle after the first into a
+  /// command-cache hit, while least-loaded routing would scatter the
+  /// settles across workers and re-record the page on each of them.
+  @override
+  Future<StripPlan?> binStrips(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    int priority = 0,
+  }) =>
+      _workers[_staticWorkerIndex(pageIndex)].binStrips(
+        pageIndex,
+        annotations: annotations,
+        pageToDevice: pageToDevice,
+        deviceWidth: deviceWidth,
+        deviceHeight: deviceHeight,
+        pixelRatio: pixelRatio,
+        priority: priority,
+      );
+
+  @override
+  void cancelBinStrips(int pageIndex, {int priority = 0}) =>
+      _workers[_staticWorkerIndex(pageIndex)]
+          .cancelBinStrips(pageIndex, priority: priority);
+
   @override
   void dispose() {
     _routes.clear();
@@ -446,7 +528,7 @@ typedef _RecordCacheKey = (int, bool, bool, int, int?, _RegionBucket?);
 /// requests pile up before any finishes. Sharing the in-flight future collapses
 /// those repeats into one decode per page. A scrolled-away page is cancelled
 /// for every sharer at once, which is correct - none of them want it any more.
-class PdfCachingRenderWorker implements PdfRenderWorker {
+class PdfCachingRenderWorker extends PdfRenderWorker {
   PdfCachingRenderWorker(this._inner, {int? budgetBytes})
       : _budgetBytes = budgetBytes ?? pdfRenderWorkerCacheBudgetBytes;
 
@@ -563,6 +645,34 @@ class PdfCachingRenderWorker implements PdfRenderWorker {
   @override
   void cancel(int pageIndex, {int priority = 0}) =>
       _inner.cancel(pageIndex, priority: priority);
+
+  /// Pure passthrough - strip plans are never cached. A plan is only valid
+  /// for the exact zoom/region matrix it was binned for, and every settle
+  /// carries a fresh one, so a cache entry could never be re-used (and a
+  /// CAD-sheet plan is tens of MB the LRU would evict real records for).
+  @override
+  Future<StripPlan?> binStrips(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    int priority = 0,
+  }) =>
+      _inner.binStrips(
+        pageIndex,
+        annotations: annotations,
+        pageToDevice: pageToDevice,
+        deviceWidth: deviceWidth,
+        deviceHeight: deviceHeight,
+        pixelRatio: pixelRatio,
+        priority: priority,
+      );
+
+  @override
+  void cancelBinStrips(int pageIndex, {int priority = 0}) =>
+      _inner.cancelBinStrips(pageIndex, priority: priority);
 
   @override
   void dispose() {

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart'
+    show StripPlan, StripPlanBinner, decodeStripPlan, encodeStripPlan;
 
 import 'render_worker.dart';
 
@@ -20,10 +22,16 @@ import 'render_worker.dart';
 /// arrives while a lower-priority one is in flight, the worker cancels the
 /// in-flight job mid-walk (cooperative preemption via [PdfCancellationToken])
 /// and serves the urgent request next.
+///
+/// The same queue also serves [PdfRenderWorker.binStrips]: strip-binning
+/// requests ride the identical priority/cancel/preemption machinery, they
+/// just carry a different payload (device geometry in, an encoded [StripPlan]
+/// out) and are cancelled through [PdfRenderWorker.cancelBinStrips] so a
+/// record and a bin for the same page never cancel each other.
 PdfRenderWorker startRenderWorker(Uint8List bytes) =>
     _IsolateRenderWorker(bytes);
 
-class _IsolateRenderWorker implements PdfRenderWorker {
+class _IsolateRenderWorker extends PdfRenderWorker {
   _IsolateRenderWorker(Uint8List bytes) {
     unawaited(_spawn(bytes));
   }
@@ -101,8 +109,9 @@ class _IsolateRenderWorker implements PdfRenderWorker {
       int? commandLimit,
       PdfRect? imageDecodeRegion}) async {
     if (_disposed || _spawnFailed) return null;
-    final request = _PendingRequest(priority, _seq++, pageIndex, annotations,
-        imagePixelRatio, decodeImages, commandLimit, imageDecodeRegion);
+    final request = _PendingRequest.record(priority, _seq++, pageIndex,
+        annotations, imagePixelRatio, decodeImages, commandLimit,
+        imageDecodeRegion);
     _queue.add(request);
     _pump();
     final bytes = await request.completer.future;
@@ -111,6 +120,31 @@ class _IsolateRenderWorker implements PdfRenderWorker {
       return deserializeCommands(bytes);
     } catch (_) {
       return null; // corrupt buffer → render locally rather than crash
+    }
+  }
+
+  @override
+  Future<StripPlan?> binStrips(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    int priority = 0,
+  }) async {
+    if (_disposed || _spawnFailed) return null;
+    final request = _PendingRequest.bin(priority, _seq++, pageIndex,
+        annotations, List.of(pageToDevice), deviceWidth, deviceHeight,
+        pixelRatio);
+    _queue.add(request);
+    _pump();
+    final bytes = await request.completer.future;
+    if (bytes == null) return null;
+    try {
+      return decodeStripPlan(bytes);
+    } catch (_) {
+      return null; // corrupt plan → bin locally rather than crash
     }
   }
 
@@ -154,27 +188,52 @@ class _IsolateRenderWorker implements PdfRenderWorker {
     }
     final request = _queue.removeAt(best)..id = _nextId++;
     _inFlight = request;
-    port.send([
-      request.id,
-      request.pageIndex,
-      request.annotations,
-      request.imagePixelRatio,
-      request.decodeImages,
-      request.commandLimit,
-      request.imageDecodeRegion?.left,
-      request.imageDecodeRegion?.bottom,
-      request.imageDecodeRegion?.right,
-      request.imageDecodeRegion?.top,
-    ]);
+    if (request.kind == _RequestKind.record) {
+      port.send([
+        'record',
+        request.id,
+        request.pageIndex,
+        request.annotations,
+        request.imagePixelRatio,
+        request.decodeImages,
+        request.commandLimit,
+        request.imageDecodeRegion?.left,
+        request.imageDecodeRegion?.bottom,
+        request.imageDecodeRegion?.right,
+        request.imageDecodeRegion?.top,
+      ]);
+    } else {
+      port.send([
+        'bin',
+        request.id,
+        request.pageIndex,
+        request.annotations,
+        request.pageToDevice,
+        request.deviceWidth,
+        request.deviceHeight,
+        request.binPixelRatio,
+      ]);
+    }
   }
 
   @override
-  void cancel(int pageIndex, {int priority = 0}) {
+  void cancel(int pageIndex, {int priority = 0}) =>
+      _cancelKind(_RequestKind.record, pageIndex, priority);
+
+  @override
+  void cancelBinStrips(int pageIndex, {int priority = 0}) =>
+      _cancelKind(_RequestKind.bin, pageIndex, priority);
+
+  /// Drops matching QUEUED requests of one [kind]. Completing with null makes
+  /// their futures resolve to a local render/bin - the abandoning caller
+  /// ignores that. Kinds cancel independently so a superseded zoom settle
+  /// can't drop the page's pending record (or vice versa).
+  void _cancelKind(_RequestKind kind, int pageIndex, int priority) {
     if (_disposed) return;
-    // Drop matching QUEUED requests. Completing with null makes their record()
-    // futures resolve to a local render - the abandoning caller ignores that.
     _queue.removeWhere((request) {
-      if (request.pageIndex != pageIndex || request.priority != priority) {
+      if (request.kind != kind ||
+          request.pageIndex != pageIndex ||
+          request.priority != priority) {
         return false;
       }
       if (!request.completer.isCompleted) request.completer.complete(null);
@@ -206,9 +265,11 @@ class _IsolateRenderWorker implements PdfRenderWorker {
   }
 }
 
-/// One queued record request and its pending result.
+enum _RequestKind { record, bin }
+
+/// One queued request (a page record or a strip bin) and its pending result.
 class _PendingRequest {
-  _PendingRequest(
+  _PendingRequest.record(
       this.priority,
       this.seq,
       this.pageIndex,
@@ -216,16 +277,40 @@ class _PendingRequest {
       this.imagePixelRatio,
       this.decodeImages,
       this.commandLimit,
-      this.imageDecodeRegion);
+      this.imageDecodeRegion)
+      : kind = _RequestKind.record,
+        pageToDevice = null,
+        deviceWidth = 0,
+        deviceHeight = 0,
+        binPixelRatio = 0;
 
+  _PendingRequest.bin(this.priority, this.seq, this.pageIndex,
+      this.annotations, this.pageToDevice, this.deviceWidth, this.deviceHeight,
+      this.binPixelRatio)
+      : kind = _RequestKind.bin,
+        imagePixelRatio = null,
+        decodeImages = false,
+        commandLimit = null,
+        imageDecodeRegion = null;
+
+  final _RequestKind kind;
   final int priority;
   final int seq;
   final int pageIndex;
   final bool annotations;
+
+  // record-only
   final double? imagePixelRatio;
   final bool decodeImages;
   final int? commandLimit;
   final PdfRect? imageDecodeRegion;
+
+  // bin-only
+  final List<double>? pageToDevice; // a, b, c, d, e, f
+  final int deviceWidth;
+  final int deviceHeight;
+  final double binPixelRatio;
+
   final completer = Completer<Uint8List?>();
   int id = -1;
 }
@@ -240,9 +325,9 @@ class _WorkerInit {
   final TransferableTypedData bytes;
 }
 
-/// Isolate entrypoint: open the document once, then serve record requests
-/// until the worker is killed. Uses [drawPageOperationsAsync] so the event
-/// loop can receive cancel messages mid-walk.
+/// Isolate entrypoint: open the document once, then serve record and bin
+/// requests until the worker is killed. Uses the async walks so the event
+/// loop can receive cancel messages mid-job.
 void _workerMain(_WorkerInit init) {
   final requests = ReceivePort();
   final cancelPort = ReceivePort();
@@ -255,6 +340,8 @@ void _workerMain(_WorkerInit init) {
     document = null; // a broken document fails every page → all local renders
   }
 
+  final binCommands = _BinCommandCache();
+
   PdfCancellationToken? activeToken;
   cancelPort.listen((_) {
     activeToken?.cancelled = true;
@@ -262,35 +349,48 @@ void _workerMain(_WorkerInit init) {
 
   requests.listen((message) async {
     final request = message as List<Object?>;
-    final id = request[0] as int;
-    final pageIndex = request[1] as int;
-    final annotations = request[2] as bool;
-    final imagePixelRatio = request[3] as double?;
-    final decodeImages = request[4] as bool;
-    final commandLimit = request.length > 5 ? request[5] as int? : null;
-    final imageDecodeRegion = request.length > 9 &&
-            request[6] != null &&
-            request[7] != null &&
-            request[8] != null &&
-            request[9] != null
-        ? PdfRect(request[6] as double, request[7] as double,
-            request[8] as double, request[9] as double)
-        : null;
+    final kind = request[0] as String;
+    final id = request[1] as int;
+    final pageIndex = request[2] as int;
+    final annotations = request[3] as bool;
 
     final token = PdfCancellationToken();
     activeToken = token;
     Uint8List? buffer;
     try {
       if (document != null) {
-        buffer = await _recordPageAsync(
-            document,
-            pageIndex,
-            annotations,
-            imagePixelRatio,
-            decodeImages,
-            commandLimit,
-            imageDecodeRegion,
-            token);
+        if (kind == 'bin') {
+          buffer = await _binStripsAsync(
+              document,
+              binCommands,
+              pageIndex,
+              annotations,
+              (request[4] as List<Object?>).cast<double>(),
+              request[5] as int,
+              request[6] as int,
+              request[7] as double,
+              token);
+        } else {
+          final imagePixelRatio = request[4] as double?;
+          final decodeImages = request[5] as bool;
+          final commandLimit = request[6] as int?;
+          final imageDecodeRegion = request[7] != null &&
+                  request[8] != null &&
+                  request[9] != null &&
+                  request[10] != null
+              ? PdfRect(request[7] as double, request[8] as double,
+                  request[9] as double, request[10] as double)
+              : null;
+          buffer = await _recordPageAsync(
+              document,
+              pageIndex,
+              annotations,
+              imagePixelRatio,
+              decodeImages,
+              commandLimit,
+              imageDecodeRegion,
+              token);
+        }
       }
     } on PdfCancelledException {
       buffer = null;
@@ -333,4 +433,78 @@ Future<Uint8List?> _recordPageAsync(
       imageDecodeRegion: imageDecodeRegion,
       imagePlaceholders: !decodeImages,
       commandLimit: commandLimit);
+}
+
+/// Bins one page's strips for the requested device geometry and returns the
+/// encoded [StripPlan], or null when the page can't be binned (bad index,
+/// unserializable content, cancellation).
+Future<Uint8List?> _binStripsAsync(
+    PdfDocument document,
+    _BinCommandCache cache,
+    int pageIndex,
+    bool annotations,
+    List<double> matrix,
+    int deviceWidth,
+    int deviceHeight,
+    double pixelRatio,
+    PdfCancellationToken token) async {
+  final commands =
+      await cache.commandsFor(document, pageIndex, annotations, token);
+  if (commands == null) return null;
+  final binner = StripPlanBinner(
+    pageToDevice: PdfMatrix(
+        matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]),
+    deviceWidth: deviceWidth,
+    deviceHeight: deviceHeight,
+    pixelRatio: pixelRatio,
+  );
+  await binner.bin(commands, cancellation: token);
+  return encodeStripPlan(binner.finish());
+}
+
+/// Tiny per-worker LRU of the command lists strip bins replay, keyed
+/// (pageIndex, annotations). A zoom session hammers one page with a fresh
+/// geometry per settle, so 2 entries is plenty - and keeping the SAME list
+/// across settles preserves the object identity of glyph outlines and paths,
+/// which is what makes the process-global GlyphStripCache/ShapeStripCache
+/// hits (the −42% steady-state effect) carry over to repeat settles.
+///
+/// The recorded commands are round-tripped through the wire codec before
+/// caching so path/glyph geometry carries the same float32 truncation as the
+/// buffer the UI's scene was built from ([serializeCommands] stores path
+/// coordinates as float32): strips binned here are then bit-identical to a
+/// local re-bin of that scene. Pages whose content can't round-trip (an
+/// inline image with page-resource dependencies) decline - the same pages
+/// [PdfRenderWorker.record] declines, so their scenes were locally recorded
+/// and never ask for worker plans anyway.
+class _BinCommandCache {
+  final _entries = <(int, bool), List<PdfRenderCommand>>{};
+  static const int _capacity = 2;
+
+  Future<List<PdfRenderCommand>?> commandsFor(PdfDocument document,
+      int pageIndex, bool annotations, PdfCancellationToken token) async {
+    final key = (pageIndex, annotations);
+    final hit = _entries.remove(key);
+    if (hit != null) {
+      _entries[key] = hit; // re-insert: most-recently used
+      return hit;
+    }
+    if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
+    final page = document.page(pageIndex);
+    final ops = ContentStreamParser.parse(page.contentBytes());
+    final recorder = RecordingPdfDevice();
+    final interpreter = PdfInterpreter(
+        cos: document.cos, device: recorder, cancellation: token);
+    await interpreter.drawPageOperationsAsync(page, ops);
+    if (annotations) interpreter.drawAnnotations(page);
+    final buffer = serializeCommands(recorder.commands,
+        cos: document.cos, decodeImages: false, imagePlaceholders: true);
+    if (buffer == null) return null;
+    final commands = deserializeCommands(buffer);
+    _entries[key] = commands;
+    while (_entries.length > _capacity) {
+      _entries.remove(_entries.keys.first);
+    }
+    return commands;
+  }
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -10,7 +10,7 @@ import 'render_worker.dart';
 /// locally exactly as it did before the worker existed.
 PdfRenderWorker startRenderWorker(Uint8List bytes) => const _NullRenderWorker();
 
-class _NullRenderWorker implements PdfRenderWorker {
+class _NullRenderWorker extends PdfRenderWorker {
   const _NullRenderWorker();
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -77,7 +77,7 @@ PdfRenderWorker startRenderWorker(Uint8List bytes) {
   }
 }
 
-class _WebRenderWorker implements PdfRenderWorker {
+class _WebRenderWorker extends PdfRenderWorker {
   _WebRenderWorker(Uint8List bytes, String scriptUrl) {
     final worker = web.Worker(scriptUrl.toJS);
     _worker = worker;

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -77,6 +77,20 @@ void runPdfRenderWorker() {
       return;
     }
 
+    if (kind == 'bin') {
+      // Strip-plan binning is not offloaded on the web yet (the web client's
+      // binStrips inherits the declining default and never sends this), but
+      // reply null rather than silently dropping the message so a future or
+      // mismatched client degrades to a local bin instead of hanging its
+      // in-flight slot.
+      final id = (data.getProperty('id'.toJS) as JSNumber).toDartInt;
+      scope.postMessage(JSObject()
+        ..setProperty('kind'.toJS, 'result'.toJS)
+        ..setProperty('id'.toJS, id.toJS)
+        ..setProperty('buffer'.toJS, null));
+      return;
+    }
+
     if (kind != 'record') return;
     final id = (data.getProperty('id'.toJS) as JSNumber).toDartInt;
     final page = (data.getProperty('page'.toJS) as JSNumber).toDartInt;

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -22,6 +22,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'canvas_device.dart';
 import 'image_decoder.dart';
 import 'renderer.dart';
+import 'render_worker.dart';
 import 'strips/strip_device.dart';
 
 /// A page retained as a replayable scene: the recorded interpreter command
@@ -162,6 +163,40 @@ class PdfRetainedScene {
     replayCommands(commands, CanvasPdfDevice(canvas, images: _images));
   }
 
+  /// The strip device geometry a full-page strip replay at [pixelRatio]
+  /// uses: the page->device-pixel matrix and the viewport in pixels. Public
+  /// so [PdfPageView] can send the EXACT same six coefficients to
+  /// [PdfRenderWorker.binStrips] that [replayStrips] will construct its
+  /// device with - the plan's stale-geometry guard compares them with `==`.
+  ({PdfMatrix pageToDevice, int width, int height}) stripGeometry(
+      {required double pixelRatio}) {
+    final size = pageSize;
+    return (
+      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(
+          page, size, page.cropBox,
+          rotation: plan.rotation, pixelRatio: pixelRatio),
+      width: (size.width * pixelRatio).ceil().clamp(1, 1 << 14),
+      height: (size.height * pixelRatio).ceil().clamp(1, 1 << 14),
+    );
+  }
+
+  /// [stripGeometry]'s region variant - mirrors [replayRegionStrips]'s
+  /// device construction (the page matrix concatenated with the region
+  /// translation, viewport = the region raster).
+  ({PdfMatrix pageToDevice, int width, int height}) stripRegionGeometry(
+      Rect region,
+      {required double pixelRatio}) {
+    return (
+      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(
+              page, pageSize, page.cropBox,
+              rotation: plan.rotation, pixelRatio: pixelRatio)
+          .concat(PdfMatrix.translation(
+              -region.left * pixelRatio, -region.top * pixelRatio)),
+      width: (region.width * pixelRatio).ceil().clamp(1, 1 << 14),
+      height: (region.height * pixelRatio).ceil().clamp(1, 1 << 14),
+    );
+  }
+
   /// Replays the retained commands through a [StripPdfDevice] instead of
   /// [CanvasPdfDevice]: fills/strokes/outline glyphs are re-binned into
   /// sparse strips at [pixelRatio] and drawn as shader-carrying
@@ -174,75 +209,89 @@ class PdfRetainedScene {
   /// re-bin. Still zero re-interpretation and zero image re-decoding: the
   /// walk is a command replay and the image map is the scene's own.
   ///
+  /// [stripPlan] skips even the re-bin: a worker-binned [StripPlan] for
+  /// this exact geometry (see [stripGeometry] and
+  /// [PdfRenderWorker.binStrips]) is consumed batch-by-batch, so the UI
+  /// thread only creates engine objects and replays the tape. A stale or
+  /// desynced plan transparently falls back to a local re-bin (counted in
+  /// [StripPdfDevice.totalPlanMismatches]).
+  ///
   /// Batching telemetry accumulates on [StripPdfDevice.totalFlushes] /
   /// `totalStripQuads` / `totalAtlasTexels`; call
   /// [StripPdfDevice.resetStats] around a step to read per-step deltas.
-  Future<ui.Picture> replayStrips({required double pixelRatio}) async {
+  Future<ui.Picture> replayStrips(
+      {required double pixelRatio, StripPlan? stripPlan}) async {
     assert(!_disposed, 'replay after dispose');
-    final size = pageSize;
-    final width = (size.width * pixelRatio).ceil().clamp(1, 1 << 14);
-    final height = (size.height * pixelRatio).ceil().clamp(1, 1 << 14);
-    final recorder = ui.PictureRecorder();
-    final canvas = Canvas(recorder)..scale(pixelRatio);
-    PdfPageRenderer.preparePageCanvas(canvas, page, plan);
-    final device = StripPdfDevice(
-      canvas,
-      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(
-          page, size, page.cropBox,
-          rotation: plan.rotation, pixelRatio: pixelRatio),
-      deviceWidth: width,
-      deviceHeight: height,
-      pixelRatio: pixelRatio,
-      images: _images,
-    );
     try {
-      replayCommands(commands, device);
-      await device.finish(); // must precede endRecording
-      return recorder.endRecording();
-    } finally {
-      device.dispose();
+      return await _stripPicture(stripGeometry(pixelRatio: pixelRatio), null,
+          pixelRatio, stripPlan);
+    } on StripPlanMismatchError {
+      // The plan desynced mid-walk (only detectable at finish, before any
+      // painting committed): discard and re-bin locally.
+      return _stripPicture(
+          stripGeometry(pixelRatio: pixelRatio), null, pixelRatio, null);
     }
   }
 
   /// Region variant of [replayStrips]: only [region] (page points, y-down
   /// raster space, like [replayRegion]) lands at the picture origin, at
   /// [pixelRatio]. The strip viewport is the region raster, so offscreen
-  /// geometry is clipped during binning rather than drawn.
+  /// geometry is clipped during binning rather than drawn. A [stripPlan]
+  /// must have been binned for [stripRegionGeometry] of the same region.
   Future<ui.Picture> replayRegionStrips(Rect region,
-      {required double pixelRatio}) async {
+      {required double pixelRatio, StripPlan? stripPlan}) async {
     assert(!_disposed, 'replay after dispose');
-    final width = (region.width * pixelRatio).ceil().clamp(1, 1 << 14);
-    final height = (region.height * pixelRatio).ceil().clamp(1, 1 << 14);
+    final geometry = stripRegionGeometry(region, pixelRatio: pixelRatio);
+    try {
+      return await _stripPicture(geometry, region, pixelRatio, stripPlan);
+    } on StripPlanMismatchError {
+      return _stripPicture(geometry, region, pixelRatio, null);
+    }
+  }
+
+  /// Shared device construction + replay for the strip paths. [region] null
+  /// is the full page. Throws [StripPlanMismatchError] (recording discarded,
+  /// nothing painted) when [stripPlan] desyncs.
+  Future<ui.Picture> _stripPicture(
+      ({PdfMatrix pageToDevice, int width, int height}) geometry,
+      Rect? region,
+      double pixelRatio,
+      StripPlan? stripPlan) async {
     final recorder = ui.PictureRecorder();
-    final canvas = Canvas(recorder)
-      ..scale(pixelRatio)
-      ..translate(-region.left, -region.top);
+    final canvas = Canvas(recorder)..scale(pixelRatio);
+    if (region != null) canvas.translate(-region.left, -region.top);
     PdfPageRenderer.preparePageCanvas(canvas, page, plan);
     final device = StripPdfDevice(
       canvas,
-      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(
-              page, pageSize, page.cropBox,
-              rotation: plan.rotation, pixelRatio: pixelRatio)
-          .concat(PdfMatrix.translation(
-              -region.left * pixelRatio, -region.top * pixelRatio)),
-      deviceWidth: width,
-      deviceHeight: height,
+      pageToDevice: geometry.pageToDevice,
+      deviceWidth: geometry.width,
+      deviceHeight: geometry.height,
       pixelRatio: pixelRatio,
       images: _images,
+      precomputed: stripPlan,
     );
+    final ui.Picture picture;
     try {
+      final sw = Stopwatch()..start();
       replayCommands(commands, device);
+      StripPdfDevice.totalRouteMicros += sw.elapsedMicroseconds;
       await device.finish(); // must precede endRecording
-      return recorder.endRecording();
-    } finally {
+      picture = recorder.endRecording();
+    } catch (_) {
+      recorder.endRecording().dispose();
       device.dispose();
+      rethrow;
     }
+    device.dispose();
+    return picture;
   }
 
   /// Convenience: [replayStrips] + `toImage`, the strip-router counterpart
   /// of [rasterize].
-  Future<ui.Image> rasterizeStrips({required double pixelRatio}) async {
-    final picture = await replayStrips(pixelRatio: pixelRatio);
+  Future<ui.Image> rasterizeStrips(
+      {required double pixelRatio, StripPlan? stripPlan}) async {
+    final picture =
+        await replayStrips(pixelRatio: pixelRatio, stripPlan: stripPlan);
     try {
       final size = pageSize;
       return await picture.toImage(
@@ -257,8 +306,9 @@ class PdfRetainedScene {
   /// Convenience: [replayRegionStrips] + `toImage`, the strip-router
   /// counterpart of [rasterizeRegion].
   Future<ui.Image> rasterizeRegionStrips(Rect region,
-      {required double pixelRatio}) async {
-    final picture = await replayRegionStrips(region, pixelRatio: pixelRatio);
+      {required double pixelRatio, StripPlan? stripPlan}) async {
+    final picture = await replayRegionStrips(region,
+        pixelRatio: pixelRatio, stripPlan: stripPlan);
     try {
       return await picture.toImage(
         (region.width * pixelRatio).ceil().clamp(1, 1 << 14),

--- a/packages/dart_pdf_editor/lib/src/strips/strip_batch.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_batch.dart
@@ -1,29 +1,36 @@
-// One flushed batch of sparse strips, converted from the StripGenerator's
-// SoA buffer into the exact upload shapes the shader path draws: quad
-// vertices (positions in device pixels, texcoords addressing the alpha
-// atlas, per-vertex ARGB colors) plus the batch's rgba8888 alpha atlas.
-//
-// Texcoord contract (mirrored by shaders/pdf_strips.frag): u interpolates
-// the global alpha-texel index across the quad (fragment centers land at
-// index + .5), v is the local strip row - [0,4) mixed, [4,8) solid.
+// One flushed batch of sparse strips, wrapped from the portable
+// [StripBatchData] arrays (built in pdf_graphics, possibly on a worker
+// isolate) into the engine objects the shader path draws: `ui.Vertices.raw`
+// per chunk plus the decoded rgba8888 alpha atlas. This side does NOTHING
+// but engine-object creation - the array-building loop lives with the
+// binning core so worker-side plans ship draw-ready data.
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:pdf_graphics/raster.dart';
 
-/// Alpha atlas width in texels (4 bytes each -> 4 KB rows).
-const int stripAtlasWidth = 1024;
-
-/// ui.Vertices indices are Uint16, so one draw holds at most
-/// 65535 / 4 quads; batches chunk at this many strips per draw.
-const int stripMaxQuadsPerDraw = 16000;
+export 'package:pdf_graphics/raster.dart'
+    show StripBatchData, StripChunkData, stripAtlasWidth, stripMaxQuadsPerDraw;
 
 /// A flush batch: everything needed to draw its strips with one shader
 /// paint - [chunks] drawVertices calls sharing one [atlas].
 class StripBatch {
-  StripBatch._(this.chunks, this.atlasPixels, this.atlasWidth,
-      this.atlasHeight, this.stripCount);
+  /// Wraps portable batch [data] in engine vertex objects. The atlas image
+  /// is decoded separately ([decodeAtlas]) because `decodeImageFromPixels`
+  /// is asynchronous.
+  StripBatch.fromData(StripBatchData data)
+      : chunks = [
+          for (final chunk in data.chunks)
+            ui.Vertices.raw(ui.VertexMode.triangles, chunk.positions,
+                textureCoordinates: chunk.textureCoordinates,
+                colors: chunk.colors,
+                indices: chunk.indices),
+        ],
+        atlasPixels = data.atlasPixels,
+        atlasWidth = data.atlasWidth,
+        atlasHeight = data.atlasHeight,
+        stripCount = data.stripCount;
 
   final List<ui.Vertices> chunks;
   final Uint8List atlasPixels; // rgba8888, atlasWidth * atlasHeight * 4
@@ -36,87 +43,9 @@ class StripBatch {
 
   /// Snapshots [strips] (the generator reuses its buffers, so all data is
   /// copied) into draw-ready form, or null when the buffer is empty.
-  ///
-  /// The per-strip color word is passed through to the vertex colors
-  /// unchanged and must therefore be straight (non-premultiplied) ARGB -
-  /// Skia premultiplies vertex colors before BlendMode.modulate multiplies
-  /// them with the shader's coverage.
   static StripBatch? of(StripBuffer strips) {
-    final n = strips.length;
-    if (n == 0) return null;
-
-    final chunks = <ui.Vertices>[];
-    for (var start = 0; start < n; start += stripMaxQuadsPerDraw) {
-      final count =
-          (n - start) < stripMaxQuadsPerDraw ? (n - start) : stripMaxQuadsPerDraw;
-      final positions = Float32List(count * 8);
-      final texs = Float32List(count * 8);
-      final colors = Int32List(count * 4);
-      final indices = Uint16List(count * 6);
-      for (var k = 0; k < count; k++) {
-        final i = start + k;
-        final xy = strips.xy[i];
-        final x = (xy & 0xFFFF).toDouble();
-        final y = (xy >> 16).toDouble();
-        final wf = strips.widthFlags[i];
-        final w = (wf & 0xFFFF).toDouble();
-        final solid = wf & stripFlagSolid != 0;
-
-        final p = k * 8;
-        positions[p] = x;
-        positions[p + 1] = y;
-        positions[p + 2] = x + w;
-        positions[p + 3] = y;
-        positions[p + 4] = x;
-        positions[p + 5] = y + 4;
-        positions[p + 6] = x + w;
-        positions[p + 7] = y + 4;
-
-        // u: global texel index range; v: [0,4) mixed, [4,8) solid. Solid
-        // quads keep u in [0,w) so the (ignored) sample stays in-atlas.
-        final u0 = solid ? 0.0 : strips.alphaOffset[i].toDouble();
-        final u1 = u0 + w;
-        final v0 = solid ? 4.0 : 0.0;
-        final v1 = v0 + 4;
-        texs[p] = u0;
-        texs[p + 1] = v0;
-        texs[p + 2] = u1;
-        texs[p + 3] = v0;
-        texs[p + 4] = u0;
-        texs[p + 5] = v1;
-        texs[p + 6] = u1;
-        texs[p + 7] = v1;
-
-        final color = strips.color[i];
-        final c = k * 4;
-        colors[c] = color;
-        colors[c + 1] = color;
-        colors[c + 2] = color;
-        colors[c + 3] = color;
-
-        final vBase = k * 4;
-        final ix = k * 6;
-        indices[ix] = vBase;
-        indices[ix + 1] = vBase + 1;
-        indices[ix + 2] = vBase + 2;
-        indices[ix + 3] = vBase + 1;
-        indices[ix + 4] = vBase + 3;
-        indices[ix + 5] = vBase + 2;
-      }
-      chunks.add(ui.Vertices.raw(ui.VertexMode.triangles, positions,
-          textureCoordinates: texs, colors: colors, indices: indices));
-    }
-
-    // Alpha atlas: column texels row-major by global index, final row
-    // zero-padded. Always at least one texel so solid-only batches still
-    // have a valid sampler target.
-    final cols = strips.alphaColumns;
-    final rows = cols == 0 ? 1 : (cols + stripAtlasWidth - 1) ~/ stripAtlasWidth;
-    final pixels = Uint8List(stripAtlasWidth * rows * 4);
-    if (cols > 0) {
-      pixels.setRange(0, cols * 4, strips.alphas);
-    }
-    return StripBatch._(chunks, pixels, stripAtlasWidth, rows, n);
+    final data = StripBatchData.of(strips, 0);
+    return data == null ? null : StripBatch.fromData(data);
   }
 
   /// Decodes [atlasPixels] into the GPU-sampled [atlas] image. rgba8888

--- a/packages/dart_pdf_editor/lib/src/strips/strip_batch.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_batch.dart
@@ -11,7 +11,12 @@ import 'dart:ui' as ui;
 import 'package:pdf_graphics/raster.dart';
 
 export 'package:pdf_graphics/raster.dart'
-    show StripBatchData, StripChunkData, stripAtlasWidth, stripMaxQuadsPerDraw;
+    show
+        StripBatchData,
+        StripChunkData,
+        stripAtlasWidth,
+        stripMaxAlphaColumnsPerDraw,
+        stripMaxQuadsPerDraw;
 
 /// A flush batch: everything needed to draw its strips with one shader
 /// paint - [chunks] drawVertices calls sharing one [atlas].
@@ -27,12 +32,19 @@ class StripBatch {
                 colors: chunk.colors,
                 indices: chunk.indices),
         ],
+        chunkAlphaBases = [
+          for (final chunk in data.chunks) chunk.alphaBase,
+        ],
         atlasPixels = data.atlasPixels,
         atlasWidth = data.atlasWidth,
         atlasHeight = data.atlasHeight,
         stripCount = data.stripCount;
 
   final List<ui.Vertices> chunks;
+
+  /// Per-chunk texcoord origin (global alpha-texel index), fed to the
+  /// shader's uBase - see [StripChunkData.alphaBase].
+  final List<int> chunkAlphaBases;
   final Uint8List atlasPixels; // rgba8888, atlasWidth * atlasHeight * 4
   final int atlasWidth;
   final int atlasHeight;

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -7,6 +7,11 @@
 // Everything else (images, gradients, meshes, substituted text, non-normal
 // blends, knockout groups) delegates to the ordinary CanvasPdfDevice.
 //
+// The routing/state/flush logic lives in pdf_graphics' StripBinningDevice
+// (dart:ui-free) so a worker isolate can bin the exact same batches; this
+// subclass only owns the dart:ui half: the tape of fallback closures, the
+// StripBatch uploads, and the shader draw.
+//
 // Because dart:ui has no synchronous pixels->ui.Image path, the device
 // records its work on a tape (strip batches interleaved with fallback
 // device ops in painter's order) during the synchronous interpreter walk
@@ -27,13 +32,7 @@ import 'package:pdf_graphics/raster.dart';
 import '../canvas_device.dart';
 import 'strip_batch.dart';
 
-/// Curve-flattening tolerance (device px) for strip-routed paths. The
-/// raster core's 0.25 default (the GPU experiment's) leaves curve edges up
-/// to 0.25 px off the true curve - against Skia's much finer flattening
-/// that showed up as 50/255 coverage diffs on glyph-sized cubics. 0.02 px
-/// keeps curve-edge parity within a few counts for ~3.5x the segment count
-/// on curves (Wang's n grows with 1/sqrt(tolerance)); lines are unaffected.
-const double stripFlattenTolerance = 0.02;
+export 'package:pdf_graphics/raster.dart' show stripFlattenTolerance;
 
 /// [PdfDevice] that batches strip-rasterized paint into shader draws and
 /// routes everything else through an internal [CanvasPdfDevice] fallback.
@@ -41,46 +40,34 @@ const double stripFlattenTolerance = 0.02;
 /// Usage: construct per page, feed it a full interpreter walk, then
 /// `await finish()` before ending the picture recording; call [dispose]
 /// after `endRecording()` to release the atlas images.
-class StripPdfDevice implements PdfDevice {
+class StripPdfDevice extends StripBinningDevice {
   StripPdfDevice(
     this.canvas, {
-    required this.pageToDevice,
-    required this.deviceWidth,
-    required this.deviceHeight,
-    required this.pixelRatio,
+    required super.pageToDevice,
+    required super.deviceWidth,
+    required super.deviceHeight,
+    required super.pixelRatio,
     this.images = const {},
-  }) : _deviceToPage = _invertToMatrix4(pageToDevice) {
-    _generator.begin(deviceWidth, deviceHeight);
-  }
+  })  : _deviceToPage = _invertToMatrix4(pageToDevice),
+        super(
+          delegateAll: debugDelegateAll,
+          delegateFills: debugDelegateFills,
+          delegateStrokes: debugDelegateStrokes,
+          delegateText: debugDelegateText,
+        );
 
   final ui.Canvas canvas;
-
-  /// Page space (PDF user space, y-up) -> device pixels (y-down), including
-  /// /Rotate and [pixelRatio]. Must match the canvas transform in effect
-  /// when [finish] paints, or the strips land off the page.
-  final PdfMatrix pageToDevice;
-
-  final int deviceWidth;
-  final int deviceHeight;
-
-  /// The ratio baked into [pageToDevice]; recorded strips are only valid at
-  /// this ratio.
-  final double pixelRatio;
 
   /// Pre-decoded images for the fallback device (same map as
   /// [CanvasPdfDevice.images]).
   final Map<Object, ui.Image> images;
 
-  final StripGenerator _generator = StripGenerator();
   final Float64List _deviceToPage;
 
   /// Painter's-order tape: [StripBatch]es interleaved with fallback ops.
   final List<Object> _tape = [];
   final List<StripBatch> _batches = [];
 
-  PdfBlendMode _blend = PdfBlendMode.normal;
-  final List<bool> _groupKnockout = [];
-  final List<bool> _savedClip = [];
   bool _finished = false;
 
   // ---- stats (aggregated across devices for the benchmark) --------------
@@ -121,6 +108,11 @@ class StripPdfDevice implements PdfDevice {
 
   /// Debug: route every paint through the fallback (no strips at all) to
   /// isolate tape/pipeline effects from strip rasterization quality.
+  ///
+  /// The debug-delegate flags change ROUTING, so they force local binning:
+  /// callers must not feed a device a worker-binned plan while any of them
+  /// is set (the worker isolate carries its own statics and would bin the
+  /// full routing, desyncing flush ordinals).
   static bool debugDelegateAll = false;
 
   /// Debug: per-primitive fallback routing, for parity bisection.
@@ -128,32 +120,12 @@ class StripPdfDevice implements PdfDevice {
   static bool debugDelegateStrokes = false;
   static bool debugDelegateText = false;
 
-  /// Whether paint ops may take the strip path right now: normal blend and
-  /// not directly inside a knockout group (knockout elements composite with
-  /// BlendMode.src, which the batched srcOver quads can't express).
-  bool get _stripsActive =>
-      !debugDelegateAll &&
-      _blend == PdfBlendMode.normal &&
-      (_groupKnockout.isEmpty || !_groupKnockout.last);
+  // ---- StripBinningDevice hooks ------------------------------------------
 
-  /// Straight (non-premultiplied) ARGB for ui.Vertices colors; Skia
-  /// premultiplies before BlendMode.modulate applies the coverage.
-  static int _argb(PdfColor color, double alpha) {
-    int ch(double v) {
-      final c = v < 0 ? 0.0 : (v > 1 ? 1.0 : v);
-      return (c * 255 + 0.5).toInt();
-    }
-
-    return (ch(alpha) << 24) |
-        (ch(color.red) << 16) |
-        (ch(color.green) << 8) |
-        ch(color.blue);
-  }
-
-  void _flush() {
-    final batch = StripBatch.of(_generator.strips);
-    if (batch == null) return;
-    _generator.strips.reset();
+  @override
+  void emitBatch(int ordinal, StripBatchData? data) {
+    if (data == null) return;
+    final batch = StripBatch.fromData(data);
     _tape.add(batch);
     _batches.add(batch);
     totalFlushes++;
@@ -161,9 +133,8 @@ class StripPdfDevice implements PdfDevice {
     totalAtlasTexels += batch.atlasWidth * batch.atlasHeight;
   }
 
-  /// Records a fallback op that paints: pending strips must land first.
-  void _delegatePaint(void Function(CanvasPdfDevice d) op) {
-    _flush();
+  /// Records a fallback op that paints (the base already flushed).
+  void _paint(void Function(CanvasPdfDevice d) op) {
     totalDelegatedPaints++;
     _tape.add(op);
   }
@@ -171,152 +142,78 @@ class StripPdfDevice implements PdfDevice {
   /// Records a fallback op that only mutates state (no pixels).
   void _state(void Function(CanvasPdfDevice d) op) => _tape.add(op);
 
-  // ---- PdfDevice --------------------------------------------------------
+  @override
+  void delegateSave() => _state((d) => d.save());
 
   @override
-  void save() {
-    _savedClip.add(false);
-    _state((d) => d.save());
-  }
+  void delegateRestore() => _state((d) => d.restore());
 
   @override
-  void restore() {
-    // Strips batched under a clip must draw before the restore pops it.
-    if (_savedClip.isNotEmpty && _savedClip.removeLast()) _flush();
-    _state((d) => d.restore());
-  }
+  void delegateClipPath(PdfPath path, PdfFillRule rule) =>
+      _state((d) => d.clipPath(path, rule));
 
   @override
-  void clipPath(PdfPath path, PdfFillRule rule) {
-    _flush(); // strips batched before the clip must not be clipped by it
-    if (_savedClip.isNotEmpty) _savedClip[_savedClip.length - 1] = true;
-    _state((d) => d.clipPath(path, rule));
-  }
+  void delegateSetBlendMode(PdfBlendMode mode) =>
+      _state((d) => d.setBlendMode(mode));
 
   @override
-  void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {
-    if (!_stripsActive || debugDelegateFills) {
-      _delegatePaint((d) => d.fillPath(path, color, rule, alpha));
-      return;
-    }
-    _generator.fillPath(path, pageToDevice, rule, _argb(color, alpha),
-        tolerance: stripFlattenTolerance);
-  }
+  void delegateBeginGroup(double alpha, {required bool knockout}) =>
+      _state((d) => d.beginGroup(alpha, knockout: knockout));
 
   @override
-  void strokePath(
-      PdfPath path, PdfColor color, PdfStroke stroke, double alpha) {
-    if (!_stripsActive || debugDelegateStrokes) {
-      _delegatePaint((d) => d.strokePath(path, color, stroke, alpha));
-      return;
-    }
-    // Skia renders strokes thinner than one device pixel as a 1-px hairline
-    // with the alpha modulated by the width (not a true sub-pixel band);
-    // match it so thin CAD/print linework is parity-identical.
-    var deviceStroke = stroke;
-    var a = alpha;
-    final sf = pageToDevice.scaleFactor;
-    final deviceWidth = stroke.width * sf;
-    if (deviceWidth < 1 && sf > 0) {
-      deviceStroke = stroke.copyWith(width: 1 / sf);
-      if (deviceWidth > 0) a *= deviceWidth;
-    }
-    _generator.strokePath(path, pageToDevice, deviceStroke, _argb(color, a),
-        tolerance: stripFlattenTolerance);
-  }
+  void delegateEndGroup() => _state((d) => d.endGroup());
 
   @override
-  void fillPathGradient(
-      PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) {
-    _delegatePaint((d) => d.fillPathGradient(path, rule, gradient, alpha));
-  }
+  void delegateBeginSoftMasked() => _state((d) => d.beginSoftMasked());
 
   @override
-  void fillMesh(PdfMesh mesh, double alpha) {
-    _delegatePaint((d) => d.fillMesh(mesh, alpha));
-  }
-
-  @override
-  void drawText(PdfTextRun run) {
-    if (run.invisible) return;
-    final glyphs = run.glyphs;
-    if (!_stripsActive ||
-        debugDelegateText ||
-        glyphs == null ||
-        !run.fill ||
-        run.strokeColor != null ||
-        run.gradient != null) {
-      // substituted-font runs, stroked/gradient text, knockout/blended runs
-      _delegatePaint((d) => d.drawText(run));
-      return;
-    }
-    final color = _argb(run.color, 1);
-    for (final glyph in glyphs) {
-      final outline = glyph.outline;
-      if (outline == null) continue;
-      final emToDevice = PdfMatrix.translation(glyph.offset, glyph.offsetY)
-          .concat(run.transform)
-          .concat(pageToDevice);
-      _generator.fillOutline(FlattenedOutline.of(outline), emToDevice, color);
-    }
-  }
-
-  @override
-  void drawImage(PdfImageRequest request) {
-    _delegatePaint((d) => d.drawImage(request));
-  }
-
-  @override
-  void setBlendMode(PdfBlendMode mode) {
-    _blend = mode;
-    _state((d) => d.setBlendMode(mode));
-  }
-
-  @override
-  void beginGroup(double alpha, {bool knockout = false}) {
-    _flush(); // the group's layer must not capture earlier strips
-    _groupKnockout.add(knockout);
-    _state((d) => d.beginGroup(alpha, knockout: knockout));
-  }
-
-  @override
-  void endGroup() {
-    _flush(); // strips inside the group must land inside its layer
-    if (_groupKnockout.isNotEmpty) _groupKnockout.removeLast();
-    _state((d) => d.endGroup());
-  }
-
-  @override
-  void beginSoftMasked() {
-    _flush(); // earlier strips must not be captured by the content layer
-    _groupKnockout.add(false);
-    _state((d) => d.beginSoftMasked());
-  }
-
-  @override
-  void endSoftMasked({
+  void delegateBeginSoftMaskComposite({
     required bool luminosity,
     required PdfRect backdrop,
-    required void Function() drawMask,
-    double backdropLuminance = 0,
-    double transferScale = 1,
-    double transferOffset = 0,
+    required double backdropLuminance,
+    required double transferScale,
+    required double transferOffset,
   }) {
-    _flush(); // masked content strips land inside the content layer
-    if (_groupKnockout.isNotEmpty) _groupKnockout.removeLast();
+    // The mask group's draws happen at interpret time and append to the
+    // tape between the composite halves - the fallback's own endSoftMasked
+    // would re-run them at replay time instead.
     _state((d) => d.beginSoftMaskComposite(
         luminosity: luminosity,
         backdrop: backdrop,
         backdropLuminance: backdropLuminance,
         transferScale: transferScale,
         transferOffset: transferOffset));
-    // The mask group's draws happen NOW (interpret time) and append to the
-    // tape between the composite halves - the fallback's own endSoftMasked
-    // would re-run them at replay time instead.
-    drawMask();
-    _flush();
-    _state((d) => d.finishSoftMaskComposite());
   }
+
+  @override
+  void delegateFinishSoftMaskComposite() =>
+      _state((d) => d.finishSoftMaskComposite());
+
+  @override
+  void delegateFillPath(
+          PdfPath path, PdfColor color, PdfFillRule rule, double alpha) =>
+      _paint((d) => d.fillPath(path, color, rule, alpha));
+
+  @override
+  void delegateStrokePath(
+          PdfPath path, PdfColor color, PdfStroke stroke, double alpha) =>
+      _paint((d) => d.strokePath(path, color, stroke, alpha));
+
+  @override
+  void delegateFillPathGradient(
+          PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) =>
+      _paint((d) => d.fillPathGradient(path, rule, gradient, alpha));
+
+  @override
+  void delegateFillMesh(PdfMesh mesh, double alpha) =>
+      _paint((d) => d.fillMesh(mesh, alpha));
+
+  @override
+  void delegateDrawText(PdfTextRun run) => _paint((d) => d.drawText(run));
+
+  @override
+  void delegateDrawImage(PdfImageRequest request) =>
+      _paint((d) => d.drawImage(request));
 
   // ---- painting ---------------------------------------------------------
 
@@ -327,7 +224,7 @@ class StripPdfDevice implements PdfDevice {
   Future<void> finish() async {
     assert(!_finished, 'StripPdfDevice.finish() called twice');
     _finished = true;
-    _flush();
+    flushPending();
     final sw = Stopwatch()..start();
     final program = await _loadProgram();
     await Future.wait([for (final b in _batches) b.decodeAtlas()]);

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -32,7 +32,14 @@ import 'package:pdf_graphics/raster.dart';
 import '../canvas_device.dart';
 import 'strip_batch.dart';
 
-export 'package:pdf_graphics/raster.dart' show stripFlattenTolerance;
+export 'package:pdf_graphics/raster.dart'
+    show
+        StripPlan,
+        StripPlanBinner,
+        StripPlanMismatchError,
+        decodeStripPlan,
+        encodeStripPlan,
+        stripFlattenTolerance;
 
 /// [PdfDevice] that batches strip-rasterized paint into shader draws and
 /// routes everything else through an internal [CanvasPdfDevice] fallback.
@@ -41,20 +48,97 @@ export 'package:pdf_graphics/raster.dart' show stripFlattenTolerance;
 /// `await finish()` before ending the picture recording; call [dispose]
 /// after `endRecording()` to release the atlas images.
 class StripPdfDevice extends StripBinningDevice {
-  StripPdfDevice(
-    this.canvas, {
+  /// [precomputed] feeds the device a worker-binned [StripPlan] instead of
+  /// binning locally: generator feeds are skipped entirely and each flush
+  /// point consumes the plan batch tagged with its ordinal. The plan must
+  /// have been binned for this exact geometry - [usablePlan] guards that
+  /// (and the debug-delegate flags, which force local binning) - and
+  /// [finish] verifies the flush-point count and full consumption before
+  /// painting anything, throwing [StripPlanMismatchError] on desync so the
+  /// caller can transparently re-run with local binning.
+  factory StripPdfDevice(
+    ui.Canvas canvas, {
+    required PdfMatrix pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    Map<Object, ui.Image> images = const {},
+    StripPlan? precomputed,
+  }) =>
+      StripPdfDevice._(
+        canvas,
+        usablePlan(precomputed,
+            pageToDevice: pageToDevice,
+            deviceWidth: deviceWidth,
+            deviceHeight: deviceHeight),
+        pageToDevice: pageToDevice,
+        deviceWidth: deviceWidth,
+        deviceHeight: deviceHeight,
+        pixelRatio: pixelRatio,
+        images: images,
+      );
+
+  StripPdfDevice._(
+    this.canvas,
+    this._plan, {
     required super.pageToDevice,
     required super.deviceWidth,
     required super.deviceHeight,
     required super.pixelRatio,
-    this.images = const {},
+    required this.images,
   })  : _deviceToPage = _invertToMatrix4(pageToDevice),
         super(
+          // A usable plan replaces local binning entirely; the debug
+          // verification mode bins locally TOO so emitBatch can compare.
+          binningEnabled: _plan == null || debugVerifyPrecomputed,
           delegateAll: debugDelegateAll,
           delegateFills: debugDelegateFills,
           delegateStrokes: debugDelegateStrokes,
           delegateText: debugDelegateText,
         );
+
+  /// The validated precomputed plan (null = local binning) and the index of
+  /// the next unconsumed plan batch.
+  final StripPlan? _plan;
+  int _planNext = 0;
+
+  /// Whether this device consumes a precomputed plan (after validation).
+  bool get usesPrecomputedPlan => _plan != null;
+
+  /// Validates [plan] for a device about to be constructed with this
+  /// geometry: null when no plan, when any debug-delegate flag forces local
+  /// binning (the flags change ROUTING and the plan's producer ran without
+  /// them), or - counted in [totalPlanMismatches] - when the plan was binned
+  /// for different geometry (stale zoom/region). The matrix comparison is
+  /// exact: the six coefficients round-trip bit-exactly through the worker.
+  static StripPlan? usablePlan(
+    StripPlan? plan, {
+    required PdfMatrix pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+  }) {
+    if (plan == null) return null;
+    if (debugDelegateAll ||
+        debugDelegateFills ||
+        debugDelegateStrokes ||
+        debugDelegateText) {
+      return null;
+    }
+    final m = plan.pageToDevice;
+    if (plan.deviceWidth != deviceWidth ||
+        plan.deviceHeight != deviceHeight ||
+        plan.tolerance != stripFlattenTolerance ||
+        m.a != pageToDevice.a ||
+        m.b != pageToDevice.b ||
+        m.c != pageToDevice.c ||
+        m.d != pageToDevice.d ||
+        m.e != pageToDevice.e ||
+        m.f != pageToDevice.f) {
+      totalPlanMismatches++;
+      return null;
+    }
+    return plan;
+  }
 
   final ui.Canvas canvas;
 
@@ -83,6 +167,19 @@ class StripPdfDevice extends StripBinningDevice {
   static int totalAtlasDecodeMicros = 0;
   static int totalReplayMicros = 0;
 
+  /// Time spent synchronously routing the command list through the device
+  /// (binning included when local; only routing + plan-batch upload when
+  /// precomputed) - accumulated by [PdfRetainedScene]'s strip replays. With
+  /// [totalReplayMicros] this is the UI-thread-blocking share of a settle.
+  static int totalRouteMicros = 0;
+
+  /// Precomputed plans rejected (stale geometry) or failing verification at
+  /// [finish] - each one transparently fell back to local binning.
+  static int totalPlanMismatches = 0;
+
+  /// Pictures painted from a verified precomputed plan (no local binning).
+  static int totalPlanPictures = 0;
+
   static void resetStats() {
     totalFlushes = 0;
     totalStripQuads = 0;
@@ -90,6 +187,9 @@ class StripPdfDevice extends StripBinningDevice {
     totalDelegatedPaints = 0;
     totalAtlasDecodeMicros = 0;
     totalReplayMicros = 0;
+    totalRouteMicros = 0;
+    totalPlanMismatches = 0;
+    totalPlanPictures = 0;
   }
 
   int get flushCount => _batches.length;
@@ -120,10 +220,27 @@ class StripPdfDevice extends StripBinningDevice {
   static bool debugDelegateStrokes = false;
   static bool debugDelegateText = false;
 
+  /// Debug/test: with a precomputed plan, ALSO bin locally at every flush
+  /// point and assert the plan's batch matches (ordinal presence, strip
+  /// count, vertex arrays, atlas bytes) - the strongest form of the
+  /// flush-ordinal parity invariant. Test-only; throws [StateError] on the
+  /// first divergence.
+  static bool debugVerifyPrecomputed = false;
+
   // ---- StripBinningDevice hooks ------------------------------------------
 
   @override
   void emitBatch(int ordinal, StripBatchData? data) {
+    final plan = _plan;
+    if (plan != null) {
+      StripBatchData? planData;
+      if (_planNext < plan.batches.length &&
+          plan.batches[_planNext].flushOrdinal == ordinal) {
+        planData = plan.batches[_planNext++];
+      }
+      if (debugVerifyPrecomputed) _verifyAgainstPlan(ordinal, data, planData);
+      data = planData;
+    }
     if (data == null) return;
     final batch = StripBatch.fromData(data);
     _tape.add(batch);
@@ -225,6 +342,20 @@ class StripPdfDevice extends StripBinningDevice {
     assert(!_finished, 'StripPdfDevice.finish() called twice');
     _finished = true;
     flushPending();
+    final plan = _plan;
+    if (plan != null &&
+        (flushPointCount != plan.totalFlushPoints ||
+            _planNext != plan.batches.length)) {
+      // Desync is only detectable once the walk is complete; nothing has
+      // painted yet (painting starts below), so the caller can discard the
+      // recording and re-run with local binning.
+      totalPlanMismatches++;
+      throw StripPlanMismatchError(
+          'flush points: device $flushPointCount vs plan '
+          '${plan.totalFlushPoints}; consumed $_planNext of '
+          '${plan.batches.length} batches');
+    }
+    if (plan != null && !debugVerifyPrecomputed) totalPlanPictures++;
     final sw = Stopwatch()..start();
     final program = await _loadProgram();
     await Future.wait([for (final b in _batches) b.decodeAtlas()]);
@@ -255,6 +386,55 @@ class StripPdfDevice extends StripBinningDevice {
   /// coverage shader (wrong output - quantifies the runtime-effect cost of
   /// software rasterization).
   static bool debugNoShader = false;
+
+  /// debugVerifyPrecomputed: byte-compares the locally-binned [local] batch
+  /// with the plan's [fromPlan] at flush point [ordinal].
+  static void _verifyAgainstPlan(
+      int ordinal, StripBatchData? local, StripBatchData? fromPlan) {
+    void fail(String what) => throw StateError(
+        'precomputed plan diverges at flush point $ordinal: $what');
+    if ((local == null) != (fromPlan == null)) {
+      fail('local ${local == null ? 'empty' : 'batch'} vs plan '
+          '${fromPlan == null ? 'empty' : 'batch'}');
+    }
+    if (local == null || fromPlan == null) return;
+    if (local.stripCount != fromPlan.stripCount) {
+      fail('stripCount ${local.stripCount} vs ${fromPlan.stripCount}');
+    }
+    if (local.atlasWidth != fromPlan.atlasWidth ||
+        local.atlasHeight != fromPlan.atlasHeight) {
+      fail('atlas ${local.atlasWidth}x${local.atlasHeight} vs '
+          '${fromPlan.atlasWidth}x${fromPlan.atlasHeight}');
+    }
+    bool bytesEqual(List<int> a, List<int> b) {
+      if (a.length != b.length) return false;
+      for (var i = 0; i < a.length; i++) {
+        if (a[i] != b[i]) return false;
+      }
+      return true;
+    }
+
+    if (!bytesEqual(local.atlasPixels, fromPlan.atlasPixels)) {
+      fail('atlas bytes differ');
+    }
+    if (local.chunks.length != fromPlan.chunks.length) {
+      fail('chunk count ${local.chunks.length} vs ${fromPlan.chunks.length}');
+    }
+    for (var c = 0; c < local.chunks.length; c++) {
+      final a = local.chunks[c], b = fromPlan.chunks[c];
+      if (a.positions.length != b.positions.length ||
+          !bytesEqual(a.indices, b.indices) ||
+          !bytesEqual(a.colors, b.colors)) {
+        fail('chunk $c vertex data differs');
+      }
+      for (var i = 0; i < a.positions.length; i++) {
+        if (a.positions[i] != b.positions[i] ||
+            a.textureCoordinates[i] != b.textureCoordinates[i]) {
+          fail('chunk $c float data differs at $i');
+        }
+      }
+    }
+  }
 
   void _drawBatch(ui.FragmentProgram program, StripBatch batch) {
     final paint = ui.Paint();

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -422,7 +422,8 @@ class StripPdfDevice extends StripBinningDevice {
     }
     for (var c = 0; c < local.chunks.length; c++) {
       final a = local.chunks[c], b = fromPlan.chunks[c];
-      if (a.positions.length != b.positions.length ||
+      if (a.alphaBase != b.alphaBase ||
+          a.positions.length != b.positions.length ||
           !bytesEqual(a.indices, b.indices) ||
           !bytesEqual(a.colors, b.colors)) {
         fail('chunk $c vertex data differs');
@@ -437,19 +438,23 @@ class StripPdfDevice extends StripBinningDevice {
   }
 
   void _drawBatch(ui.FragmentProgram program, StripBatch batch) {
-    final paint = ui.Paint();
-    if (!debugNoShader) {
-      paint.shader = program.fragmentShader()
-        ..setFloat(0, batch.atlasWidth.toDouble())
-        ..setFloat(1, batch.atlasHeight.toDouble())
-        ..setImageSampler(0, batch.atlas!);
-    }
     canvas.save();
     canvas.transform(_deviceToPage);
-    for (final chunk in batch.chunks) {
+    for (var i = 0; i < batch.chunks.length; i++) {
+      final paint = ui.Paint();
+      if (!debugNoShader) {
+        // One shader instance per chunk: texcoords are chunk-relative (so
+        // Impeller's shader-snapshot texture stays within limits) and uBase
+        // restores the chunk's global alpha-texel origin.
+        paint.shader = program.fragmentShader()
+          ..setFloat(0, batch.atlasWidth.toDouble())
+          ..setFloat(1, batch.atlasHeight.toDouble())
+          ..setFloat(2, batch.chunkAlphaBases[i].toDouble())
+          ..setImageSampler(0, batch.atlas!);
+      }
       // no-shader mode draws the vertex colors directly (wrong coverage,
       // representative triangle-raster cost)
-      canvas.drawVertices(chunk,
+      canvas.drawVertices(batch.chunks[i],
           debugNoShader ? ui.BlendMode.srcOver : ui.BlendMode.modulate, paint);
     }
     canvas.restore();

--- a/packages/dart_pdf_editor/lib/strips.dart
+++ b/packages/dart_pdf_editor/lib/strips.dart
@@ -2,7 +2,10 @@
 /// strokes, and outline text into drawVertices + FragmentShader draws;
 /// everything else delegates to the canvas device in painter's order.
 /// Not exported from the main dart_pdf_editor barrel - the device wins on
-/// GPU backends (Impeller) but loses on software Skia, so hosts opt in.
+/// GPU backends (Impeller) but loses on software Skia; PdfPageView's zoom
+/// router uses it automatically behind a runtime Impeller gate
+/// (ui.ImageFilter.isShaderFilterSupported), so hosts only import this for
+/// direct/off-label use.
 library;
 
 export 'src/strips/strip_batch.dart';

--- a/packages/dart_pdf_editor/shaders/pdf_strips.frag
+++ b/packages/dart_pdf_editor/shaders/pdf_strips.frag
@@ -26,6 +26,11 @@ precision highp float;
 #include <flutter/runtime_effect.glsl>
 
 uniform vec2 uAtlasSize; // alpha atlas size in texels
+// Chunk texcoord origin: u interpolates CHUNK-RELATIVE texel indices so a
+// draw's texcoord bounds stay small enough for Impeller's shader-snapshot
+// texture (it evaluates this shader over the texcoord bounds and samples
+// the result); uBase adds the chunk's global offset back.
+uniform float uBase;
 uniform sampler2D uAtlas;
 
 out vec4 fragColor;
@@ -33,7 +38,7 @@ out vec4 fragColor;
 void main() {
   vec2 uv = FlutterFragCoord().xy; // texcoord space per the M0 probe
   float solid = step(4.0, uv.y);
-  float t = floor(uv.x);
+  float t = floor(uv.x) + uBase;
   float ax = mod(t, uAtlasSize.x);
   float ay = floor(t / uAtlasSize.x);
   vec4 texel = texture(uAtlas, (vec2(ax, ay) + 0.5) / uAtlasSize);

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -493,7 +493,7 @@ void main() {
   });
 }
 
-class _PreviewWorker implements PdfRenderWorker {
+class _PreviewWorker extends PdfRenderWorker {
   final calls = <(int, bool, double?)>[];
 
   @override
@@ -525,7 +525,7 @@ class _PreviewWorker implements PdfRenderWorker {
   void dispose() {}
 }
 
-class _DecliningWorker implements PdfRenderWorker {
+class _DecliningWorker extends PdfRenderWorker {
   final calls = <(int, bool, double?)>[];
 
   @override
@@ -550,7 +550,7 @@ class _DecliningWorker implements PdfRenderWorker {
   void dispose() {}
 }
 
-class _VectorOnlyWorker implements PdfRenderWorker {
+class _VectorOnlyWorker extends PdfRenderWorker {
   final commandLimits = <int?>[];
 
   @override

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -1,0 +1,254 @@
+// The binStrips worker protocol:
+//
+//  - native isolate end-to-end: a worker-binned StripPlan is bit-identical
+//    to a local StripPlanBinner run over the same worker-recorded command
+//    buffer (the worker re-records in its own isolate and round-trips
+//    through the wire codec, so geometry carries the same float32
+//    truncation as the buffer the caller's scene holds);
+//  - the isolate queue's kind-scoped cancel (cancelBinStrips drops queued
+//    bins without touching queued records, and vice versa);
+//  - pool routing by the STATIC page index (worker-side command-cache
+//    affinity) for both binStrips and cancelBinStrips;
+//  - the caching wrapper passes bins straight through (plans are never
+//    cached - every settle has a fresh matrix);
+//  - the abstract default (which the stub and web backends inherit)
+//    declines with null.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+
+import 'strip_zoom_router_test.dart' show buildVectorPdf;
+
+List<double> _coeffs(PdfMatrix m) => [m.a, m.b, m.c, m.d, m.e, m.f];
+
+void main() {
+  testWidgets('isolate binStrips matches a local bin of the recorded buffer',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildVectorPdf();
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+
+      final commands = await worker.record(0);
+      expect(commands, isNotNull);
+
+      final size = PdfPageRenderer.pageSize(page);
+      const ratio = 2.0;
+      final matrix = PdfPageRenderer.pageToDeviceMatrix(
+          page, size, page.cropBox,
+          pixelRatio: ratio);
+      final width = (size.width * ratio).ceil();
+      final height = (size.height * ratio).ceil();
+
+      final plan = await worker.binStrips(0,
+          annotations: true,
+          pageToDevice: _coeffs(matrix),
+          deviceWidth: width,
+          deviceHeight: height,
+          pixelRatio: ratio);
+      expect(plan, isNotNull, reason: 'a vector page must bin off-thread');
+      expect(plan!.batches, isNotEmpty);
+      expect(plan.deviceWidth, width);
+      expect(plan.deviceHeight, height);
+      expect(plan.pageToDevice.a, matrix.a);
+      expect(plan.pageToDevice.f, matrix.f);
+      expect(plan.tolerance, stripFlattenTolerance);
+
+      final local = StripPlanBinner(
+        pageToDevice: matrix,
+        deviceWidth: width,
+        deviceHeight: height,
+        pixelRatio: ratio,
+      );
+      await local.bin(commands!);
+      final localPlan = local.finish();
+      expect(encodeStripPlan(plan), encodeStripPlan(localPlan),
+          reason: 'worker and local binning of the same buffer must be '
+              'bit-identical');
+
+      // A repeat settle at a different geometry serves from the worker-side
+      // command cache and stays consistent.
+      const ratio2 = 3.0;
+      final matrix2 = PdfPageRenderer.pageToDeviceMatrix(
+          page, size, page.cropBox,
+          pixelRatio: ratio2);
+      final plan2 = await worker.binStrips(0,
+          annotations: true,
+          pageToDevice: _coeffs(matrix2),
+          deviceWidth: (size.width * ratio2).ceil(),
+          deviceHeight: (size.height * ratio2).ceil(),
+          pixelRatio: ratio2);
+      expect(plan2, isNotNull);
+      expect(plan2!.totalFlushPoints, plan.totalFlushPoints,
+          reason: 'flush structure is geometry-independent');
+    });
+  });
+
+  testWidgets('cancelBinStrips drops queued bins, not queued records',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildVectorPdf();
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+
+      // Queue both before the spawn handshake can complete, then cancel the
+      // bin: its future must resolve null while the record still runs.
+      final record = worker.record(0);
+      final bin = worker.binStrips(0,
+          annotations: true,
+          pageToDevice: const [1, 0, 0, 1, 0, 0],
+          deviceWidth: 100,
+          deviceHeight: 100,
+          pixelRatio: 1);
+      worker.cancelBinStrips(0);
+      expect(await bin, isNull, reason: 'cancelled bin resolves null');
+      expect(await record, isNotNull,
+          reason: 'the record must survive a bin cancel for the same page');
+
+      // And the mirror: cancel() must not touch a queued bin.
+      final worker2 = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker2.dispose);
+      final record2 = worker2.record(0);
+      final bin2 = worker2.binStrips(0,
+          annotations: true,
+          pageToDevice: const [1, 0, 0, 1, 0, 0],
+          deviceWidth: 100,
+          deviceHeight: 100,
+          pixelRatio: 1);
+      worker2.cancel(0);
+      expect(await record2, isNull, reason: 'cancelled record resolves null');
+      expect(await bin2, isNotNull,
+          reason: 'the bin must survive a record cancel for the same page');
+    });
+  });
+
+  test('pool routes binStrips by the static page index', () async {
+    final workers = [for (var i = 0; i < 3; i++) _BinLogWorker()];
+    final pool = PdfPooledRenderWorker.fromWorkers(workers);
+    addTearDown(pool.dispose);
+
+    await pool.binStrips(4,
+        annotations: true,
+        pageToDevice: const [1, 0, 0, 1, 0, 0],
+        deviceWidth: 10,
+        deviceHeight: 10,
+        pixelRatio: 1);
+    expect(workers[4 % 3].binCalls, [4]);
+    expect(workers[0].binCalls, isEmpty);
+    expect(workers[2].binCalls, isEmpty);
+
+    pool.cancelBinStrips(4, priority: 7);
+    expect(workers[4 % 3].binCancels, [(4, 7)]);
+    expect(workers[0].binCancels, isEmpty);
+  });
+
+  test('caching wrapper passes bins straight through (never cached)',
+      () async {
+    final inner = _BinLogWorker();
+    final caching = PdfCachingRenderWorker(inner);
+    addTearDown(caching.dispose);
+
+    Future<StripPlan?> bin() => caching.binStrips(2,
+        annotations: true,
+        pageToDevice: const [1, 0, 0, 1, 0, 0],
+        deviceWidth: 10,
+        deviceHeight: 10,
+        pixelRatio: 1);
+    await bin();
+    await bin(); // identical args - still no caching
+    expect(inner.binCalls, [2, 2]);
+
+    caching.cancelBinStrips(2, priority: 3);
+    expect(inner.binCancels, [(2, 3)]);
+  });
+
+  test('the abstract default declines (stub/web behavior)', () async {
+    final worker = _DefaultWorker();
+    final plan = await worker.binStrips(0,
+        annotations: true,
+        pageToDevice: const [1, 0, 0, 1, 0, 0],
+        deviceWidth: 10,
+        deviceHeight: 10,
+        pixelRatio: 1);
+    expect(plan, isNull);
+    worker.cancelBinStrips(0); // must be a harmless no-op
+  });
+}
+
+/// Minimal fake that logs binStrips traffic and returns an empty plan.
+class _BinLogWorker extends PdfRenderWorker {
+  final binCalls = <int>[];
+  final binCancels = <(int, int)>[];
+
+  @override
+  bool get isActive => true;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio,
+          bool decodeImages = true,
+          int? commandLimit,
+          PdfRect? imageDecodeRegion}) async =>
+      null;
+
+  @override
+  Future<StripPlan?> binStrips(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    int priority = 0,
+  }) async {
+    binCalls.add(pageIndex);
+    return StripPlan(
+      totalFlushPoints: 0,
+      deviceWidth: deviceWidth,
+      deviceHeight: deviceHeight,
+      pageToDevice: PdfMatrix(pageToDevice[0], pageToDevice[1],
+          pageToDevice[2], pageToDevice[3], pageToDevice[4], pageToDevice[5]),
+      tolerance: stripFlattenTolerance,
+      batches: const [],
+    );
+  }
+
+  @override
+  void cancelBinStrips(int pageIndex, {int priority = 0}) =>
+      binCancels.add((pageIndex, priority));
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() {}
+}
+
+/// Overrides nothing strip-related: exercises the abstract class defaults
+/// the stub and web backends inherit.
+class _DefaultWorker extends PdfRenderWorker {
+  @override
+  bool get isActive => false;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio,
+          bool decodeImages = true,
+          int? commandLimit,
+          PdfRect? imageDecodeRegion}) async =>
+      null;
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() {}
+}

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -31,7 +31,7 @@ PdfImageRequest? _firstImage(List<PdfRenderCommand> commands) {
 /// PdfPageView's worker render path - including the progressive vector-first
 /// pass - runs deterministically under pump(). Honors [decodeImages] exactly
 /// like the real backends.
-class _SyncWorker implements PdfRenderWorker {
+class _SyncWorker extends PdfRenderWorker {
   _SyncWorker(this._bytes);
 
   final Uint8List _bytes;
@@ -900,7 +900,7 @@ void main() {
 /// A [PdfRenderWorker] that records each [record] call and returns a synthetic
 /// buffer of a chosen decoded weight - for exercising [PdfCachingRenderWorker]
 /// without a real isolate or document.
-class _CountingWorker implements PdfRenderWorker {
+class _CountingWorker extends PdfRenderWorker {
   _CountingWorker({this.decodedPixels = 0, this.returnNull = false});
 
   /// Decoded pixels carried by each returned buffer (an N×N image, so the
@@ -954,7 +954,7 @@ class _CountingWorker implements PdfRenderWorker {
   }
 }
 
-class _ManualWorker implements PdfRenderWorker {
+class _ManualWorker extends PdfRenderWorker {
   final calls = <(int, bool, bool, double?)>[];
   final priorities = <int>[];
   final cancels = <(int, int)>[];
@@ -1004,7 +1004,7 @@ class _ManualWorker implements PdfRenderWorker {
   }
 }
 
-class _HangingWorker implements PdfRenderWorker {
+class _HangingWorker extends PdfRenderWorker {
   final callsByKey = <(int, int), int>{};
   final cancels = <(int, int)>[];
   final _pending = <Completer<List<PdfRenderCommand>?>>[];

--- a/packages/dart_pdf_editor/test/strip_plan_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_plan_device_test.dart
@@ -1,0 +1,241 @@
+// Precomputed strip plans through StripPdfDevice / PdfRetainedScene:
+//
+//  - a plan binned headlessly (StripPlanBinner) over the scene's own
+//    commands rasterizes byte-identically to the device's local binning,
+//    full page and region, with debugVerifyPrecomputed asserting the
+//    batch-sequence parity along the way;
+//  - a worker-binned plan (native isolate end to end) is byte-identical
+//    too - the whole point of the offload;
+//  - a doctored/stale plan transparently falls back to local binning
+//    (counted in totalPlanMismatches, output still correct);
+//  - debug-delegate flags force local binning even when a plan is offered.
+//
+// Like strip_zoom_router_test, the tester.runAsync raster comparisons run
+// before any widget-pumping tests in this file.
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'strip_zoom_router_test.dart' show buildVectorPdf;
+import 'strip_zoom_router_test.dart' as router;
+
+Future<Uint8List> _rgba(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();
+
+Future<StripPlan> _localPlan(PdfRetainedScene scene,
+    {required double pixelRatio, Rect? region}) async {
+  final geometry = region == null
+      ? scene.stripGeometry(pixelRatio: pixelRatio)
+      : scene.stripRegionGeometry(region, pixelRatio: pixelRatio);
+  final binner = StripPlanBinner(
+    pageToDevice: geometry.pageToDevice,
+    deviceWidth: geometry.width,
+    deviceHeight: geometry.height,
+    pixelRatio: pixelRatio,
+  );
+  await binner.bin(scene.commands);
+  return binner.finish();
+}
+
+void main() {
+  testWidgets('a precomputed plan rasterizes byte-identically to local '
+      'binning (verified batch-by-batch)', (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(buildVectorPdf());
+      final scene = await PdfRetainedScene.record(doc.page(0));
+      addTearDown(scene.dispose);
+
+      for (final ratio in [1.0, 2.4]) {
+        final plan = await _localPlan(scene, pixelRatio: ratio);
+        expect(plan.batches, isNotEmpty);
+
+        StripPdfDevice.resetStats();
+        StripPdfDevice.debugVerifyPrecomputed = true;
+        final ui.Image planned;
+        try {
+          planned =
+              await scene.rasterizeStrips(pixelRatio: ratio, stripPlan: plan);
+        } finally {
+          StripPdfDevice.debugVerifyPrecomputed = false;
+        }
+        final local = await scene.rasterizeStrips(pixelRatio: ratio);
+        expect(StripPdfDevice.totalPlanMismatches, 0);
+        expect(await _rgba(planned), await _rgba(local),
+            reason: 'plan-fed raster must match local binning at $ratio');
+        planned.dispose();
+        local.dispose();
+      }
+
+      // Region variant, mirrored geometry.
+      const region = Rect.fromLTWH(290, 300, 200, 150);
+      final regionPlan =
+          await _localPlan(scene, pixelRatio: 2, region: region);
+      StripPdfDevice.resetStats();
+      final planned = await scene.rasterizeRegionStrips(region,
+          pixelRatio: 2, stripPlan: regionPlan);
+      final local = await scene.rasterizeRegionStrips(region, pixelRatio: 2);
+      expect(StripPdfDevice.totalPlanMismatches, 0);
+      expect(StripPdfDevice.totalPlanPictures, 1);
+      expect(await _rgba(planned), await _rgba(local));
+      planned.dispose();
+      local.dispose();
+    });
+  });
+
+  testWidgets('a worker-binned plan rasterizes byte-identically end to end',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildVectorPdf();
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+
+      final commands = await worker.record(0);
+      expect(commands, isNotNull);
+      final scene = await PdfRetainedScene.fromCommands(page, commands!);
+      addTearDown(scene.dispose);
+
+      const ratio = 2.0;
+      final geometry = scene.stripGeometry(pixelRatio: ratio);
+      final m = geometry.pageToDevice;
+      final plan = await worker.binStrips(0,
+          annotations: true,
+          pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+          deviceWidth: geometry.width,
+          deviceHeight: geometry.height,
+          pixelRatio: ratio);
+      expect(plan, isNotNull);
+
+      StripPdfDevice.resetStats();
+      final planned =
+          await scene.rasterizeStrips(pixelRatio: ratio, stripPlan: plan);
+      expect(StripPdfDevice.totalPlanMismatches, 0);
+      expect(StripPdfDevice.totalPlanPictures, 1,
+          reason: 'the worker plan must actually be consumed');
+      final local = await scene.rasterizeStrips(pixelRatio: ratio);
+      expect(await _rgba(planned), await _rgba(local),
+          reason: 'worker-binned plan must raster like a local bin');
+      planned.dispose();
+      local.dispose();
+    });
+  });
+
+  testWidgets('a desynced plan falls back to local binning transparently',
+      (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(buildVectorPdf());
+      final scene = await PdfRetainedScene.record(doc.page(0));
+      addTearDown(scene.dispose);
+
+      const ratio = 2.0;
+      final good = await _localPlan(scene, pixelRatio: ratio);
+      // Doctored: right geometry, wrong flush structure - only detectable
+      // at finish, after the whole walk consumed it.
+      final doctored = StripPlan(
+        totalFlushPoints: good.totalFlushPoints + 1,
+        deviceWidth: good.deviceWidth,
+        deviceHeight: good.deviceHeight,
+        pageToDevice: good.pageToDevice,
+        tolerance: good.tolerance,
+        batches: good.batches,
+      );
+      StripPdfDevice.resetStats();
+      final fallback = await scene.rasterizeStrips(
+          pixelRatio: ratio, stripPlan: doctored);
+      expect(StripPdfDevice.totalPlanMismatches, 1,
+          reason: 'the desync must be counted');
+      expect(StripPdfDevice.totalPlanPictures, 0);
+      final local = await scene.rasterizeStrips(pixelRatio: ratio);
+      expect(await _rgba(fallback), await _rgba(local),
+          reason: 'the fallback re-bin must produce the correct raster');
+      fallback.dispose();
+      local.dispose();
+
+      // Stale geometry (a plan for another zoom level) is rejected up
+      // front - cheaper, same fallback.
+      StripPdfDevice.resetStats();
+      final stale = await scene.rasterizeStrips(
+          pixelRatio: 3.0, stripPlan: good);
+      expect(StripPdfDevice.totalPlanMismatches, 1);
+      expect(StripPdfDevice.totalPlanPictures, 0);
+      final local3 = await scene.rasterizeStrips(pixelRatio: 3.0);
+      expect(await _rgba(stale), await _rgba(local3));
+      stale.dispose();
+      local3.dispose();
+    });
+  });
+
+  testWidgets('debug-delegate flags force local binning over an offered plan',
+      (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(buildVectorPdf());
+      final scene = await PdfRetainedScene.record(doc.page(0));
+      addTearDown(scene.dispose);
+
+      const ratio = 2.0;
+      final plan = await _localPlan(scene, pixelRatio: ratio);
+      StripPdfDevice.debugDelegateFills = true;
+      addTearDown(() => StripPdfDevice.debugDelegateFills = false);
+      StripPdfDevice.resetStats();
+      final image =
+          await scene.rasterizeStrips(pixelRatio: ratio, stripPlan: plan);
+      // The plan is ignored (not a mismatch - a debug mode), fills went to
+      // the canvas fallback, strokes still binned locally.
+      expect(StripPdfDevice.totalPlanPictures, 0);
+      expect(StripPdfDevice.totalPlanMismatches, 0);
+      expect(StripPdfDevice.totalDelegatedPaints, greaterThan(0));
+      image.dispose();
+    });
+  });
+
+  // Widget-level end to end (runs LAST - see the header note): a zoom
+  // settle on a worker-backed, strip-routed page consumes a worker-binned
+  // plan instead of binning on the UI thread.
+  testWidgets('PdfPageView settles dense worker-backed pages from a plan',
+      (tester) async {
+    PdfPageView.retainedZoomReplayMaxCommands = 0; // every page is "dense"
+    PdfPageView.stripZoomReplay = true;
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+      PdfPageView.stripZoomReplay = false;
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+    });
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildVectorPdf();
+    final doc = PdfDocument.open(bytes);
+    final page = doc.page(0);
+    late PdfRenderWorker worker;
+    await tester.runAsync(() async {
+      worker = PdfRenderWorker.start(bytes);
+    });
+    addTearDown(worker.dispose);
+
+    Widget at(double scale) => Center(
+        child: SizedBox(
+            width: 612,
+            child:
+                PdfPageView(page: page, scale: scale, renderWorker: worker)));
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    await router.settleRaster(tester, 612);
+
+    await tester.pumpWidget(at(3));
+    final zoomed = await router.settleRaster(tester, 612 * 3);
+    expect(zoomed.width, 612 * 3);
+    expect(StripPdfDevice.totalPlanPictures, greaterThan(0),
+        reason: 'the settle must consume a worker-binned plan');
+    expect(StripPdfDevice.totalPlanMismatches, 0);
+  });
+}

--- a/packages/dart_pdf_editor/test/strip_plan_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_plan_device_test.dart
@@ -206,7 +206,7 @@ void main() {
     PdfPageView.debugStripZoomReplayBackendOverride = true;
     addTearDown(() {
       PdfPageView.retainedZoomReplayMaxCommands = 20000;
-      PdfPageView.stripZoomReplay = false;
+      PdfPageView.stripZoomReplay = true; // the default
       PdfPageView.debugStripZoomReplayBackendOverride = null;
     });
     tester.view.devicePixelRatio = 1.0;

--- a/packages/dart_pdf_editor/test/strip_worker_latency_test.dart
+++ b/packages/dart_pdf_editor/test/strip_worker_latency_test.dart
@@ -1,0 +1,332 @@
+// Worker-binned strip settles vs #210's local-bin path (the measurement
+// behind flipping PdfPageView.stripZoomReplay's default).
+//
+// For each corpus page, a worker-backed retained scene runs the zoom
+// sequence through:
+//
+//   (L) local-bin   - scene.replayStrips(ratio): the strip re-bin runs on
+//                     this (the UI) thread, #210's shipping path;
+//   (W) worker-plan - worker.binStrips(...) off-thread, then
+//                     scene.replayStrips(ratio, stripPlan:): the UI thread
+//                     only decodes the plan, creates engine objects, and
+//                     replays the tape.
+//
+// Reported per path: total settle latency (bin/plan wait + build + toImage
+// + readback) and the UI-THREAD BLOCKING share - the synchronous sections
+// only: route+bin (StripPdfDevice.totalRouteMicros), tape replay
+// (totalReplayMicros), and for (W) the plan decode (decodeStripPlanMicros).
+// The worker wait and the GPU raster are awaited, not blocking.
+//
+// Passes: pass 0 warms codec/shader/worker caches and is discarded; the
+// per-pass worker bin wait is also printed so the worker-side command/
+// glyph/shape cache steady-state effect is visible.
+//
+// Run on Impeller (the only backend that strip-routes in production):
+//
+//   cd packages/dart_pdf_editor
+//   ZOOM_CORPUS_DIR=/Users/ben/repos/dart-pdf/corpus \
+//     fvm flutter test --enable-impeller test/strip_worker_latency_test.dart
+//
+// Skips cleanly when the corpus directory is absent.
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/raster.dart' as raster show decodeStripPlanMicros;
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+const zoomSequence = [1.0, 1.5, 2.4, 1.2, 3.0];
+const targetWidth = 2382.0;
+const targetHeight = 1684.0;
+const _maxPixels = 1 << 24;
+const _maxDimension = 8192.0;
+
+const _defaultFiles = [
+  'WAT_L0001_S.pdf', // the WAT CAD sheet from #210's numbers
+  'ly9-far-cad.pdf#4', // heaviest ly9 sheet (~99k retained commands)
+  'INVOICE-1000664832.pdf', // office control: under the ceiling, no strips
+];
+
+double _effectiveRatio(Size size, double desired) {
+  final width = math.max(1.0, size.width);
+  final height = math.max(1.0, size.height);
+  var ratio = desired;
+  ratio = math.min(ratio, math.sqrt(_maxPixels / (width * height)));
+  ratio = math.min(ratio, _maxDimension / math.max(width, height));
+  return math.max(ratio, 0.05);
+}
+
+class _PathSample {
+  double planWaitMs = 0; // (W) worker bin round-trip wall
+  double buildMs = 0; // replayStrips wall
+  double rasterMs = 0; // toImage
+  double readbackMs = 0; // toByteData
+  double uiBlockMs = 0; // synchronous UI-thread sections
+  int n = 0;
+
+  void add(
+      {required double planWait,
+      required double build,
+      required double rasterize,
+      required double readback,
+      required double uiBlock}) {
+    planWaitMs += planWait;
+    buildMs += build;
+    rasterMs += rasterize;
+    readbackMs += readback;
+    uiBlockMs += uiBlock;
+    n++;
+  }
+
+  double _mean(double v) => n == 0 ? 0 : v / n;
+  double get meanPlanWait => _mean(planWaitMs);
+  double get meanBuild => _mean(buildMs);
+  double get meanRaster => _mean(rasterMs);
+  double get meanReadback => _mean(readbackMs);
+  double get meanUiBlock => _mean(uiBlockMs);
+  double get meanTotal =>
+      meanPlanWait + meanBuild + meanRaster + meanReadback;
+}
+
+Future<(ui.Image, double, double)> _timeRaster(
+    ui.Picture picture, int width, int height) async {
+  final sw = Stopwatch()..start();
+  final image =
+      await picture.toImage(width.clamp(1, 1 << 14), height.clamp(1, 1 << 14));
+  final rasterMs = sw.elapsedMicroseconds / 1000.0;
+  sw
+    ..reset()
+    ..start();
+  await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  final readbackMs = sw.elapsedMicroseconds / 1000.0;
+  return (image, rasterMs, readbackMs);
+}
+
+void main() {
+  final corpusDir = Platform.environment['ZOOM_CORPUS_DIR'] ?? '../../corpus';
+  final backend = Platform.environment['ZOOM_BACKEND'] ?? 'default';
+  final passes =
+      int.tryParse(Platform.environment['ZOOM_LATENCY_PASSES'] ?? '') ?? 3;
+  final filesEnv = Platform.environment['STRIP_WORKER_FILES'];
+  final fileNames = filesEnv == null || filesEnv.trim().isEmpty
+      ? _defaultFiles
+      : filesEnv.split(',').map((s) => s.trim()).toList();
+
+  testWidgets('strip settle latency: local bin vs worker plan',
+      (tester) async {
+    final dir = Directory(corpusDir);
+    if (!dir.existsSync()) {
+      markTestSkipped('corpus directory not found at $corpusDir '
+          '(set ZOOM_CORPUS_DIR); skipping the strip worker harness');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+
+      final rows = <String>[];
+      final binWaitRows = <String>[];
+
+      for (final entry in fileNames) {
+        final hash = entry.lastIndexOf('#');
+        final name = hash < 0 ? entry : entry.substring(0, hash);
+        final filePage =
+            hash < 0 ? 0 : int.tryParse(entry.substring(hash + 1)) ?? 0;
+        final path = name.startsWith('/') ? name : '${dir.path}/$name';
+        final file = File(path);
+        if (!file.existsSync()) {
+          // ignore: avoid_print
+          print('strip-worker-latency: $path missing, skipped');
+          continue;
+        }
+        final bytes = file.readAsBytesSync();
+        final doc = PdfDocument.open(bytes);
+        final pageIndex = filePage.clamp(0, doc.pageCount - 1);
+        final page = doc.page(pageIndex);
+        const plan = PdfPageRenderPlan();
+        final size = plan.pageSize(page);
+        final fit = [targetWidth / size.width, targetHeight / size.height]
+            .reduce((a, b) => a < b ? a : b);
+
+        final worker = PdfRenderWorker.startUncached(bytes);
+        final commands = await worker.record(pageIndex,
+            imagePixelRatio: _effectiveRatio(size, fit));
+        if (commands == null) {
+          // ignore: avoid_print
+          print('strip-worker-latency: $entry declined by the worker, '
+              'skipped (would keep local binning in production)');
+          worker.dispose();
+          continue;
+        }
+        final scene =
+            await PdfRetainedScene.fromCommands(page, commands, plan: plan);
+        final label = '${name.split('/').last}#$pageIndex';
+        final overCeiling = scene.commands.length >
+            PdfPageView.retainedZoomReplayMaxCommands;
+        // ignore: avoid_print
+        print('strip-worker-latency: $label commands=${scene.commands.length}'
+            ' stripRouted=$overCeiling'
+            '${overCeiling ? '' : ' (control: keeps the flat canvas replay)'}');
+
+        if (!overCeiling) {
+          // Office control: the page never strip-routes; its settle path
+          // (scene.rasterize, untouched by this work) is timed for the
+          // regression row.
+          final s = _PathSample();
+          for (var pass = 0; pass <= passes; pass++) {
+            for (final zoom in zoomSequence) {
+              final ratio = _effectiveRatio(size, fit * zoom);
+              final sw = Stopwatch()..start();
+              final image = await scene.rasterize(pixelRatio: ratio);
+              final total = sw.elapsedMicroseconds / 1000.0;
+              await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+              final readback =
+                  sw.elapsedMicroseconds / 1000.0 - total;
+              image.dispose();
+              if (pass > 0) {
+                s.add(
+                    planWait: 0,
+                    build: total,
+                    rasterize: 0,
+                    readback: readback,
+                    uiBlock: 0);
+              }
+            }
+          }
+          rows.add('${label.padRight(28).substring(0, 28)} '
+              '${'b-retained'.padRight(12)} '
+              '${'-'.padLeft(8)} ${s.meanBuild.toStringAsFixed(1).padLeft(8)} '
+              '${'-'.padLeft(8)} '
+              '${s.meanReadback.toStringAsFixed(1).padLeft(9)} '
+              '${'-'.padLeft(8)} ${s.meanTotal.toStringAsFixed(1).padLeft(8)}');
+          scene.dispose();
+          worker.dispose();
+          continue;
+        }
+
+        final local = _PathSample();
+        final workerPlan = _PathSample();
+        final perPassBinWait = List<double>.filled(passes + 1, 0);
+
+        for (var pass = 0; pass <= passes; pass++) {
+          final record = pass > 0;
+          for (final zoom in zoomSequence) {
+            final ratio = _effectiveRatio(size, fit * zoom);
+            final w = (size.width * ratio).ceil();
+            final h = (size.height * ratio).ceil();
+
+            // (L) local bin on this thread.
+            StripPdfDevice.resetStats();
+            var t = Stopwatch()..start();
+            final localPicture = await scene.replayStrips(pixelRatio: ratio);
+            final buildL = t.elapsedMicroseconds / 1000.0;
+            final uiBlockL = (StripPdfDevice.totalRouteMicros +
+                    StripPdfDevice.totalReplayMicros) /
+                1000.0;
+            final (imageL, rasterL, readbackL) =
+                await _timeRaster(localPicture, w, h);
+            localPicture.dispose();
+            imageL.dispose();
+            if (record) {
+              local.add(
+                  planWait: 0,
+                  build: buildL,
+                  rasterize: rasterL,
+                  readback: readbackL,
+                  uiBlock: uiBlockL);
+            }
+
+            // (W) worker-binned plan.
+            StripPdfDevice.resetStats();
+            final decode0 = raster.decodeStripPlanMicros;
+            final geometry = scene.stripGeometry(pixelRatio: ratio);
+            final m = geometry.pageToDevice;
+            t = Stopwatch()..start();
+            final stripPlan = await worker.binStrips(pageIndex,
+                annotations: true,
+                pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+                deviceWidth: geometry.width,
+                deviceHeight: geometry.height,
+                pixelRatio: ratio);
+            final planWait = t.elapsedMicroseconds / 1000.0;
+            expect(stripPlan, isNotNull,
+                reason: '$label must bin off-thread');
+            t = Stopwatch()..start();
+            final plannedPicture = await scene.replayStrips(
+                pixelRatio: ratio, stripPlan: stripPlan);
+            final buildW = t.elapsedMicroseconds / 1000.0;
+            expect(StripPdfDevice.totalPlanMismatches, 0);
+            expect(StripPdfDevice.totalPlanPictures, 1,
+                reason: 'the plan must actually be consumed');
+            final uiBlockW = (StripPdfDevice.totalRouteMicros +
+                    StripPdfDevice.totalReplayMicros +
+                    (raster.decodeStripPlanMicros - decode0)) /
+                1000.0;
+            final (imageW, rasterW, readbackW) =
+                await _timeRaster(plannedPicture, w, h);
+            plannedPicture.dispose();
+            imageW.dispose();
+            perPassBinWait[pass] += planWait;
+            if (record) {
+              workerPlan.add(
+                  planWait: planWait,
+                  build: buildW,
+                  rasterize: rasterW,
+                  readback: readbackW,
+                  uiBlock: uiBlockW);
+            }
+          }
+        }
+
+        for (final (key, s) in [('L-local-bin', local), ('W-worker', workerPlan)]) {
+          rows.add('${label.padRight(28).substring(0, 28)} '
+              '${key.padRight(12)} '
+              '${s.meanPlanWait.toStringAsFixed(1).padLeft(8)} '
+              '${s.meanBuild.toStringAsFixed(1).padLeft(8)} '
+              '${s.meanRaster.toStringAsFixed(1).padLeft(8)} '
+              '${s.meanReadback.toStringAsFixed(1).padLeft(9)} '
+              '${s.meanUiBlock.toStringAsFixed(1).padLeft(8)} '
+              '${s.meanTotal.toStringAsFixed(1).padLeft(8)}');
+        }
+        binWaitRows.add('${label.padRight(28).substring(0, 28)} '
+            'binWait/settle by pass: ${[
+          for (var p = 0; p <= passes; p++)
+            (perPassBinWait[p] / zoomSequence.length).toStringAsFixed(1)
+        ].join('  ')}  (pass 0 = cold)');
+
+        scene.dispose();
+        worker.dispose();
+      }
+
+      if (rows.isEmpty) {
+        markTestSkipped('no test PDFs found under $corpusDir');
+        return;
+      }
+      // ignore: avoid_print
+      print('\nstrip settle latency (backend=$backend, mean ms/step over '
+          '$passes passes x ${zoomSequence.length} steps, '
+          'target ${targetWidth.toInt()}x${targetHeight.toInt()} fit)');
+      // ignore: avoid_print
+      print('${'page'.padRight(28)} ${'path'.padRight(12)} '
+          '${'binWait'.padLeft(8)} ${'build'.padLeft(8)} '
+          '${'toImage'.padLeft(8)} ${'readback'.padLeft(9)} '
+          '${'uiBlock'.padLeft(8)} ${'total'.padLeft(8)}');
+      for (final row in rows) {
+        // ignore: avoid_print
+        print(row);
+      }
+      // ignore: avoid_print
+      print('\nworker bin wait per settle by pass (worker-side command/'
+          'glyph/shape caches warming):');
+      for (final row in binWaitRows) {
+        // ignore: avoid_print
+        print(row);
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 15)));
+}

--- a/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
+++ b/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
@@ -73,7 +73,8 @@ double _meanAbsDiff(Uint8List a, Uint8List b) {
 
 /// Pumps until the page's RawImage raster reaches [width] px (the async
 /// strip replay takes a few event-loop turns for the atlas decode).
-Future<ui.Image> _settleRaster(WidgetTester tester, int width) async {
+/// Shared with strip_plan_device_test.
+Future<ui.Image> settleRaster(WidgetTester tester, int width) async {
   for (var i = 0; i < 40; i++) {
     await tester.runAsync(
         () => Future<void>.delayed(const Duration(milliseconds: 5)));
@@ -135,9 +136,14 @@ void main() {
       (tester) async {
     PdfPageView.retainedZoomReplayMaxCommands = 0; // every page is "dense"
     PdfPageView.stripZoomReplay = true;
+    // flutter test runs on software Skia where the Impeller gate
+    // (ui.ImageFilter.isShaderFilterSupported) is false; force it on so the
+    // router logic itself is exercised.
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
     addTearDown(() {
       PdfPageView.retainedZoomReplayMaxCommands = 20000;
       PdfPageView.stripZoomReplay = false;
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
     });
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -149,13 +155,13 @@ void main() {
 
     StripPdfDevice.resetStats();
     await tester.pumpWidget(at(1));
-    final base = await _settleRaster(tester, 612);
+    final base = await settleRaster(tester, 612);
     expect(base.width, 612);
 
     // the zoom settle must re-bin through the strip device
     StripPdfDevice.resetStats();
     await tester.pumpWidget(at(3));
-    final zoomed = await _settleRaster(tester, 612 * 3);
+    final zoomed = await settleRaster(tester, 612 * 3);
     expect(zoomed.width, 612 * 3);
     expect(StripPdfDevice.totalStripQuads, greaterThan(0),
         reason: 'the zoom re-raster must have binned strip quads');
@@ -165,9 +171,13 @@ void main() {
       'flag off: over-ceiling pages keep the cached-picture path, '
       'no strip activity', (tester) async {
     PdfPageView.retainedZoomReplayMaxCommands = 0;
-    expect(PdfPageView.stripZoomReplay, isFalse,
-        reason: 'stripZoomReplay must default off');
-    addTearDown(() => PdfPageView.retainedZoomReplayMaxCommands = 20000);
+    PdfPageView.stripZoomReplay = false;
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+      PdfPageView.stripZoomReplay = false;
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+    });
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
     final doc = PdfDocument.open(buildVectorPdf());
@@ -178,14 +188,42 @@ void main() {
 
     StripPdfDevice.resetStats();
     await tester.pumpWidget(at(1));
-    final base = await _settleRaster(tester, 612);
+    final base = await settleRaster(tester, 612);
     expect(base.width, 612);
 
     await tester.pumpWidget(at(3));
-    final zoomed = await _settleRaster(tester, 612 * 3);
+    final zoomed = await settleRaster(tester, 612 * 3);
     expect(zoomed.width, 612 * 3);
     expect(StripPdfDevice.totalFlushes, 0,
         reason: 'flag off must never touch the strip device');
   });
 
+  testWidgets(
+      'backend gate off: the flag is inert on non-Impeller backends',
+      (tester) async {
+    PdfPageView.retainedZoomReplayMaxCommands = 0;
+    PdfPageView.stripZoomReplay = true;
+    PdfPageView.debugStripZoomReplayBackendOverride = false; // "software"
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+      PdfPageView.stripZoomReplay = false;
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+    });
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final doc = PdfDocument.open(buildVectorPdf());
+    final page = doc.page(0);
+    Widget at(double scale) => Center(
+        child:
+            SizedBox(width: 612, child: PdfPageView(page: page, scale: scale)));
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    await settleRaster(tester, 612);
+    await tester.pumpWidget(at(3));
+    final zoomed = await settleRaster(tester, 612 * 3);
+    expect(zoomed.width, 612 * 3);
+    expect(StripPdfDevice.totalFlushes, 0,
+        reason: 'the gate must keep strips off software backends');
+  });
 }

--- a/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
+++ b/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
@@ -89,6 +89,13 @@ Future<ui.Image> settleRaster(WidgetTester tester, int width) async {
 }
 
 void main() {
+  test('stripZoomReplay defaults ON, guarded by the Impeller gate', () {
+    expect(PdfPageView.stripZoomReplay, isTrue,
+        reason: 'worker binning + the backend gate made this the default');
+    expect(PdfPageView.debugStripZoomReplayBackendOverride, isNull,
+        reason: 'production asks the engine (isShaderFilterSupported)');
+  });
+
   testWidgets('strip replay stays visually equivalent to the canvas replay',
       (tester) async {
     await tester.runAsync(() async {
@@ -142,7 +149,7 @@ void main() {
     PdfPageView.debugStripZoomReplayBackendOverride = true;
     addTearDown(() {
       PdfPageView.retainedZoomReplayMaxCommands = 20000;
-      PdfPageView.stripZoomReplay = false;
+      PdfPageView.stripZoomReplay = true; // the default
       PdfPageView.debugStripZoomReplayBackendOverride = null;
     });
     tester.view.devicePixelRatio = 1.0;
@@ -175,7 +182,7 @@ void main() {
     PdfPageView.debugStripZoomReplayBackendOverride = true;
     addTearDown(() {
       PdfPageView.retainedZoomReplayMaxCommands = 20000;
-      PdfPageView.stripZoomReplay = false;
+      PdfPageView.stripZoomReplay = true; // the default
       PdfPageView.debugStripZoomReplayBackendOverride = null;
     });
     tester.view.devicePixelRatio = 1.0;
@@ -206,7 +213,7 @@ void main() {
     PdfPageView.debugStripZoomReplayBackendOverride = false; // "software"
     addTearDown(() {
       PdfPageView.retainedZoomReplayMaxCommands = 20000;
-      PdfPageView.stripZoomReplay = false;
+      PdfPageView.stripZoomReplay = true; // the default
       PdfPageView.debugStripZoomReplayBackendOverride = null;
     });
     tester.view.devicePixelRatio = 1.0;

--- a/packages/pdf_graphics/lib/raster.dart
+++ b/packages/pdf_graphics/lib/raster.dart
@@ -13,3 +13,4 @@ export 'src/raster/stroke_contours.dart';
 export 'src/raster/strip_batch_data.dart';
 export 'src/raster/strip_binning_device.dart';
 export 'src/raster/strip_generator.dart';
+export 'src/raster/strip_plan.dart';

--- a/packages/pdf_graphics/lib/raster.dart
+++ b/packages/pdf_graphics/lib/raster.dart
@@ -10,4 +10,6 @@ library;
 
 export 'src/raster/flatten.dart';
 export 'src/raster/stroke_contours.dart';
+export 'src/raster/strip_batch_data.dart';
+export 'src/raster/strip_binning_device.dart';
 export 'src/raster/strip_generator.dart';

--- a/packages/pdf_graphics/lib/src/raster/strip_batch_data.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_batch_data.dart
@@ -1,0 +1,151 @@
+// One flushed batch of sparse strips in engine-free form: the exact upload
+// shapes a `drawVertices` shader path needs (quad positions in device
+// pixels, texcoords addressing the alpha atlas, per-vertex ARGB colors,
+// triangle indices) plus the batch's rgba8888 alpha atlas bytes. Pure Dart -
+// the dart_pdf_editor side wraps these arrays in `ui.Vertices.raw` and
+// `decodeImageFromPixels` without touching the data again, and a worker
+// isolate can build/ship them without dart:ui.
+//
+// Texcoord contract (mirrored by shaders/pdf_strips.frag): u interpolates
+// the global alpha-texel index across the quad (fragment centers land at
+// index + .5), v is the local strip row - [0,4) mixed, [4,8) solid.
+import 'dart:typed_data';
+
+import 'strip_generator.dart';
+
+/// Alpha atlas width in texels (4 bytes each -> 4 KB rows).
+const int stripAtlasWidth = 1024;
+
+/// `ui.Vertices` indices are Uint16, so one draw holds at most
+/// 65535 / 4 quads; batches chunk at this many strips per draw.
+const int stripMaxQuadsPerDraw = 16000;
+
+/// One `drawVertices`-sized slice of a [StripBatchData]: raw vertex arrays
+/// for up to [stripMaxQuadsPerDraw] strip quads.
+class StripChunkData {
+  StripChunkData(this.positions, this.textureCoordinates, this.colors,
+      this.indices);
+
+  /// Quad corner positions in device pixels, 8 floats per strip.
+  final Float32List positions;
+
+  /// Texcoords per the atlas contract above, 8 floats per strip.
+  final Float32List textureCoordinates;
+
+  /// Straight (non-premultiplied) ARGB per vertex, 4 ints per strip.
+  final Int32List colors;
+
+  /// Two triangles per quad, 6 indices per strip.
+  final Uint16List indices;
+}
+
+/// A flush batch in portable form: everything needed to draw its strips
+/// with one shader paint - [chunks] draw calls sharing one alpha atlas -
+/// tagged with the [flushOrdinal] of the flush point that emitted it.
+class StripBatchData {
+  StripBatchData._(this.flushOrdinal, this.chunks, this.atlasPixels,
+      this.atlasWidth, this.atlasHeight, this.stripCount);
+
+  /// Test/codec seam: builds a batch from already-materialized arrays.
+  StripBatchData.raw(this.flushOrdinal, this.chunks, this.atlasPixels,
+      this.atlasWidth, this.atlasHeight, this.stripCount);
+
+  /// Which flush point (0-based, counting every flush point including empty
+  /// ones) of the binning walk emitted this batch. A headless binner and a
+  /// live device replaying the same command list produce the same ordinals -
+  /// the parity invariant precomputed strip plans ride on.
+  final int flushOrdinal;
+
+  final List<StripChunkData> chunks;
+  final Uint8List atlasPixels; // rgba8888, atlasWidth * atlasHeight * 4
+  final int atlasWidth;
+  final int atlasHeight;
+  final int stripCount;
+
+  /// Snapshots [strips] (the generator reuses its buffers, so all data is
+  /// copied) into draw-ready form, or null when the buffer is empty.
+  ///
+  /// The per-strip color word is passed through to the vertex colors
+  /// unchanged and must therefore be straight (non-premultiplied) ARGB -
+  /// Skia premultiplies vertex colors before BlendMode.modulate multiplies
+  /// them with the shader's coverage.
+  static StripBatchData? of(StripBuffer strips, int flushOrdinal) {
+    final n = strips.length;
+    if (n == 0) return null;
+
+    final chunks = <StripChunkData>[];
+    for (var start = 0; start < n; start += stripMaxQuadsPerDraw) {
+      final count = (n - start) < stripMaxQuadsPerDraw
+          ? (n - start)
+          : stripMaxQuadsPerDraw;
+      final positions = Float32List(count * 8);
+      final texs = Float32List(count * 8);
+      final colors = Int32List(count * 4);
+      final indices = Uint16List(count * 6);
+      for (var k = 0; k < count; k++) {
+        final i = start + k;
+        final xy = strips.xy[i];
+        final x = (xy & 0xFFFF).toDouble();
+        final y = (xy >> 16).toDouble();
+        final wf = strips.widthFlags[i];
+        final w = (wf & 0xFFFF).toDouble();
+        final solid = wf & stripFlagSolid != 0;
+
+        final p = k * 8;
+        positions[p] = x;
+        positions[p + 1] = y;
+        positions[p + 2] = x + w;
+        positions[p + 3] = y;
+        positions[p + 4] = x;
+        positions[p + 5] = y + 4;
+        positions[p + 6] = x + w;
+        positions[p + 7] = y + 4;
+
+        // u: global texel index range; v: [0,4) mixed, [4,8) solid. Solid
+        // quads keep u in [0,w) so the (ignored) sample stays in-atlas.
+        final u0 = solid ? 0.0 : strips.alphaOffset[i].toDouble();
+        final u1 = u0 + w;
+        final v0 = solid ? 4.0 : 0.0;
+        final v1 = v0 + 4;
+        texs[p] = u0;
+        texs[p + 1] = v0;
+        texs[p + 2] = u1;
+        texs[p + 3] = v0;
+        texs[p + 4] = u0;
+        texs[p + 5] = v1;
+        texs[p + 6] = u1;
+        texs[p + 7] = v1;
+
+        final color = strips.color[i];
+        final c = k * 4;
+        colors[c] = color;
+        colors[c + 1] = color;
+        colors[c + 2] = color;
+        colors[c + 3] = color;
+
+        final vBase = k * 4;
+        final ix = k * 6;
+        indices[ix] = vBase;
+        indices[ix + 1] = vBase + 1;
+        indices[ix + 2] = vBase + 2;
+        indices[ix + 3] = vBase + 1;
+        indices[ix + 4] = vBase + 3;
+        indices[ix + 5] = vBase + 2;
+      }
+      chunks.add(StripChunkData(positions, texs, colors, indices));
+    }
+
+    // Alpha atlas: column texels row-major by global index, final row
+    // zero-padded. Always at least one texel so solid-only batches still
+    // have a valid sampler target.
+    final cols = strips.alphaColumns;
+    final rows =
+        cols == 0 ? 1 : (cols + stripAtlasWidth - 1) ~/ stripAtlasWidth;
+    final pixels = Uint8List(stripAtlasWidth * rows * 4);
+    if (cols > 0) {
+      pixels.setRange(0, cols * 4, strips.alphas);
+    }
+    return StripBatchData._(
+        flushOrdinal, chunks, pixels, stripAtlasWidth, rows, n);
+  }
+}

--- a/packages/pdf_graphics/lib/src/raster/strip_batch_data.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_batch_data.dart
@@ -20,11 +20,31 @@ const int stripAtlasWidth = 1024;
 /// 65535 / 4 quads; batches chunk at this many strips per draw.
 const int stripMaxQuadsPerDraw = 16000;
 
+/// Maximum alpha-texel span (u texcoord range) of one draw's strips.
+///
+/// Impeller does not pass drawVertices texcoords to the fragment shader as
+/// raw varyings the way Skia does: it renders the paint's shader into a
+/// snapshot texture covering the texcoord BOUNDS and samples that, so a
+/// batch whose global alpha indices ran to ~500k texels (a dense CAD sheet)
+/// asked for a 500k x 8 snapshot - over the 16384 max texture size - and
+/// drew NOTHING (silent blank strips on exactly the pages the router
+/// targets). Chunks therefore also split by alpha span, with texcoords
+/// REBASED to each chunk's first alpha texel ([StripChunkData.alphaBase],
+/// added back by the shader's uBase uniform), keeping every snapshot within
+/// 8192 x 8. A single strip wider than the cap still draws alone (its span
+/// is bounded by the 16384 viewport clamp, inside the texture limit).
+const int stripMaxAlphaColumnsPerDraw = 8192;
+
 /// One `drawVertices`-sized slice of a [StripBatchData]: raw vertex arrays
 /// for up to [stripMaxQuadsPerDraw] strip quads.
 class StripChunkData {
-  StripChunkData(this.positions, this.textureCoordinates, this.colors,
-      this.indices);
+  StripChunkData(this.alphaBase, this.positions, this.textureCoordinates,
+      this.colors, this.indices);
+
+  /// Global alpha-texel index of this chunk's texcoord origin: the shader
+  /// computes the atlas index as `uBase + u` so per-chunk u stays within
+  /// [stripMaxAlphaColumnsPerDraw] (see that constant for why).
+  final int alphaBase;
 
   /// Quad corner positions in device pixels, 8 floats per strip.
   final Float32List positions;
@@ -74,10 +94,31 @@ class StripBatchData {
     if (n == 0) return null;
 
     final chunks = <StripChunkData>[];
-    for (var start = 0; start < n; start += stripMaxQuadsPerDraw) {
-      final count = (n - start) < stripMaxQuadsPerDraw
-          ? (n - start)
-          : stripMaxQuadsPerDraw;
+    var start = 0;
+    while (start < n) {
+      // Chunk end: capped by quad count (Uint16 indices) and by the alpha
+      // span of the chunk's MIXED strips (Impeller snapshot limit; alpha
+      // offsets are appended monotonically, so a streaming scan suffices).
+      // Solid strips carry constant u = 0 (their sample is ignored) and
+      // never widen the span.
+      var base = -1;
+      var end = start;
+      while (end < n && end - start < stripMaxQuadsPerDraw) {
+        final wf = strips.widthFlags[end];
+        if (wf & stripFlagSolid == 0) {
+          final off = strips.alphaOffset[end];
+          final w = wf & 0xFFFF;
+          if (base < 0) base = off;
+          if (off + w - base > stripMaxAlphaColumnsPerDraw && end > start) {
+            break;
+          }
+        }
+        end++;
+      }
+      if (end == start) end = start + 1; // lone over-wide strip: own chunk
+      if (base < 0) base = 0; // solid-only chunk
+
+      final count = end - start;
       final positions = Float32List(count * 8);
       final texs = Float32List(count * 8);
       final colors = Int32List(count * 4);
@@ -101,10 +142,13 @@ class StripBatchData {
         positions[p + 6] = x + w;
         positions[p + 7] = y + 4;
 
-        // u: global texel index range; v: [0,4) mixed, [4,8) solid. Solid
-        // quads keep u in [0,w) so the (ignored) sample stays in-atlas.
-        final u0 = solid ? 0.0 : strips.alphaOffset[i].toDouble();
-        final u1 = u0 + w;
+        // u: chunk-relative texel index range (the shader adds the chunk's
+        // alphaBase back); v: [0,4) mixed, [4,8) solid. Solid quads carry
+        // constant u = 0 - the sample is ignored (cov = 1) and the atlas
+        // always has a texel 0, so the dead fetch stays in-atlas without
+        // widening the chunk's texcoord bounds.
+        final u0 = solid ? 0.0 : (strips.alphaOffset[i] - base).toDouble();
+        final u1 = solid ? 0.0 : u0 + w;
         final v0 = solid ? 4.0 : 0.0;
         final v1 = v0 + 4;
         texs[p] = u0;
@@ -132,7 +176,8 @@ class StripBatchData {
         indices[ix + 4] = vBase + 3;
         indices[ix + 5] = vBase + 2;
       }
-      chunks.add(StripChunkData(positions, texs, colors, indices));
+      chunks.add(StripChunkData(base, positions, texs, colors, indices));
+      start = end;
     }
 
     // Alpha atlas: column texels row-major by global index, final row

--- a/packages/pdf_graphics/lib/src/raster/strip_binning_device.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_binning_device.dart
@@ -1,0 +1,336 @@
+// The routing/state/flush core of sparse-strip rendering, shared between
+// the live shader device (dart_pdf_editor's StripPdfDevice) and headless
+// worker-side binning (StripPlanBinner). Pure Dart - no dart:ui.
+//
+// THE CRITICAL INVARIANT this class exists to hold: the sequence of flush
+// points and the strip-vs-delegate routing of EVERY op are decided only
+// here, so a headless replay of the same command list on another isolate
+// produces strip batches that interleave at exactly the same flush points
+// as the UI-side device. Subclasses only decide what to DO with a batch
+// (upload + tape it, collect it into a plan, verify it) and where the
+// delegated ops go (a CanvasPdfDevice tape, or nowhere).
+import 'package:pdf_document/pdf_document.dart' show PdfRect;
+
+import '../color.dart';
+import '../device.dart';
+import '../matrix.dart';
+import '../mesh.dart';
+import '../path.dart';
+import '../shading.dart';
+import 'flatten.dart';
+import 'strip_batch_data.dart';
+import 'strip_generator.dart';
+
+/// Curve-flattening tolerance (device px) for strip-routed paths. The
+/// raster core's 0.25 default (the GPU experiment's) leaves curve edges up
+/// to 0.25 px off the true curve - against Skia's much finer flattening
+/// that showed up as 50/255 coverage diffs on glyph-sized cubics. 0.02 px
+/// keeps curve-edge parity within a few counts for ~3.5x the segment count
+/// on curves (Wang's n grows with 1/sqrt(tolerance)); lines are unaffected.
+const double stripFlattenTolerance = 0.02;
+
+/// Straight (non-premultiplied) ARGB for strip vertex colors; the engine
+/// premultiplies vertex colors before BlendMode.modulate applies coverage.
+int stripArgbColor(PdfColor color, double alpha) {
+  int ch(double v) {
+    final c = v < 0 ? 0.0 : (v > 1 ? 1.0 : v);
+    return (c * 255 + 0.5).toInt();
+  }
+
+  return (ch(alpha) << 24) |
+      (ch(color.red) << 16) |
+      (ch(color.green) << 8) |
+      ch(color.blue);
+}
+
+/// [PdfDevice] base that bins solid fills, strokes, and embedded-outline
+/// text into sparse strips ([StripGenerator]) and routes everything else -
+/// and every flush-point decision - through abstract hooks.
+///
+/// Strip-routed ops feed [generator]; at every flush point (a delegated
+/// paint, a clip, a restore that pops a clip, group/soft-mask boundaries,
+/// and the final [flushPending]) the generator's accumulated strips are
+/// snapshotted into a [StripBatchData] and handed to [emitBatch] together
+/// with the flush point's ordinal. Empty flush points still count an
+/// ordinal (and call [emitBatch] with null data) so ordinals line up
+/// across isolates.
+///
+/// With [binningEnabled] false the generator is never fed or flushed -
+/// routing and flush ordinals are still tracked identically, which is how
+/// the precomputed-plan device consumes worker-binned batches without
+/// paying any flatten/bin cost.
+///
+/// The per-primitive delegate predicates ([delegateAll]/[delegateFills]/
+/// [delegateStrokes]/[delegateText]) are instance state, captured at
+/// construction from whatever debug switches the subclass exposes - they
+/// are part of the routing decision, so any of them being set on one side
+/// but not the other desyncs flush ordinals. Worker plans must not be used
+/// while a debug-delegate flag is set (the worker isolate has its own
+/// statics and would bin the full routing).
+abstract class StripBinningDevice implements PdfDevice {
+  StripBinningDevice({
+    required this.pageToDevice,
+    required this.deviceWidth,
+    required this.deviceHeight,
+    required this.pixelRatio,
+    this.binningEnabled = true,
+    this.delegateAll = false,
+    this.delegateFills = false,
+    this.delegateStrokes = false,
+    this.delegateText = false,
+  }) {
+    if (binningEnabled) generator.begin(deviceWidth, deviceHeight);
+  }
+
+  /// Page space (PDF user space, y-up) -> device pixels (y-down), including
+  /// /Rotate and [pixelRatio].
+  final PdfMatrix pageToDevice;
+
+  final int deviceWidth;
+  final int deviceHeight;
+
+  /// The ratio baked into [pageToDevice]; binned strips are only valid at
+  /// this ratio.
+  final double pixelRatio;
+
+  /// Whether strip-routed ops actually feed [generator]. False in
+  /// precomputed-plan mode: routing and flush ordinals still advance, but
+  /// no flatten/stroke-expansion/coverage work runs.
+  final bool binningEnabled;
+
+  /// Debug routing predicates (see the class doc).
+  final bool delegateAll;
+  final bool delegateFills;
+  final bool delegateStrokes;
+  final bool delegateText;
+
+  final StripGenerator generator = StripGenerator();
+
+  PdfBlendMode _blend = PdfBlendMode.normal;
+  final List<bool> _groupKnockout = [];
+  final List<bool> _savedClip = [];
+  int _flushOrdinal = 0;
+
+  /// Flush points seen so far (every flush point counts, empty or not).
+  int get flushPointCount => _flushOrdinal;
+
+  /// Delegated paint ops routed through the fallback so far.
+  int delegatedPaintCount = 0;
+
+  /// Whether paint ops may take the strip path right now: normal blend and
+  /// not directly inside a knockout group (knockout elements composite with
+  /// BlendMode.src, which batched srcOver quads can't express).
+  bool get stripsActive =>
+      !delegateAll &&
+      _blend == PdfBlendMode.normal &&
+      (_groupKnockout.isEmpty || !_groupKnockout.last);
+
+  /// Runs one flush point: snapshots the generator's strips (when binning)
+  /// and hands them to [emitBatch] with this point's ordinal. Call once
+  /// more from the subclass's finish step so trailing strips land.
+  void flushPending() {
+    final ordinal = _flushOrdinal++;
+    StripBatchData? data;
+    if (binningEnabled) {
+      data = StripBatchData.of(generator.strips, ordinal);
+      if (data != null) generator.strips.reset();
+    }
+    emitBatch(ordinal, data);
+  }
+
+  void _delegatePaint(void Function() forward) {
+    flushPending(); // pending strips must land under the delegated paint
+    delegatedPaintCount++;
+    forward();
+  }
+
+  // ---- abstract hooks ----------------------------------------------------
+
+  /// Called at every flush point with the strips binned since the previous
+  /// one ([data] null when nothing was binned, or when [binningEnabled] is
+  /// off). [ordinal] is the flush point's 0-based index.
+  void emitBatch(int ordinal, StripBatchData? data);
+
+  /// Delegated state ops (no pixels; not flush points except [clipPath] and
+  /// the group boundaries, which the base flushes before forwarding).
+  void delegateSave();
+  void delegateRestore();
+  void delegateClipPath(PdfPath path, PdfFillRule rule);
+  void delegateSetBlendMode(PdfBlendMode mode);
+  void delegateBeginGroup(double alpha, {required bool knockout});
+  void delegateEndGroup();
+  void delegateBeginSoftMasked();
+
+  /// The two halves of the soft-mask composite. The base runs the mask
+  /// group's `drawMask()` between them - through THIS device, so mask-group
+  /// strips bin (and flush) identically on every subclass.
+  void delegateBeginSoftMaskComposite({
+    required bool luminosity,
+    required PdfRect backdrop,
+    required double backdropLuminance,
+    required double transferScale,
+    required double transferOffset,
+  });
+  void delegateFinishSoftMaskComposite();
+
+  /// Delegated paint ops (the base flushes before each).
+  void delegateFillPath(
+      PdfPath path, PdfColor color, PdfFillRule rule, double alpha);
+  void delegateStrokePath(
+      PdfPath path, PdfColor color, PdfStroke stroke, double alpha);
+  void delegateFillPathGradient(
+      PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha);
+  void delegateFillMesh(PdfMesh mesh, double alpha);
+  void delegateDrawText(PdfTextRun run);
+  void delegateDrawImage(PdfImageRequest request);
+
+  // ---- PdfDevice ----------------------------------------------------------
+
+  @override
+  void save() {
+    _savedClip.add(false);
+    delegateSave();
+  }
+
+  @override
+  void restore() {
+    // Strips batched under a clip must draw before the restore pops it.
+    if (_savedClip.isNotEmpty && _savedClip.removeLast()) flushPending();
+    delegateRestore();
+  }
+
+  @override
+  void clipPath(PdfPath path, PdfFillRule rule) {
+    flushPending(); // strips batched before the clip must not be clipped
+    if (_savedClip.isNotEmpty) _savedClip[_savedClip.length - 1] = true;
+    delegateClipPath(path, rule);
+  }
+
+  @override
+  void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {
+    if (!stripsActive || delegateFills) {
+      _delegatePaint(() => delegateFillPath(path, color, rule, alpha));
+      return;
+    }
+    if (!binningEnabled) return;
+    generator.fillPath(path, pageToDevice, rule, stripArgbColor(color, alpha),
+        tolerance: stripFlattenTolerance);
+  }
+
+  @override
+  void strokePath(
+      PdfPath path, PdfColor color, PdfStroke stroke, double alpha) {
+    if (!stripsActive || delegateStrokes) {
+      _delegatePaint(() => delegateStrokePath(path, color, stroke, alpha));
+      return;
+    }
+    if (!binningEnabled) return;
+    // Skia renders strokes thinner than one device pixel as a 1-px hairline
+    // with the alpha modulated by the width (not a true sub-pixel band);
+    // match it so thin CAD/print linework is parity-identical.
+    var deviceStroke = stroke;
+    var a = alpha;
+    final sf = pageToDevice.scaleFactor;
+    final hairWidth = stroke.width * sf;
+    if (hairWidth < 1 && sf > 0) {
+      deviceStroke = stroke.copyWith(width: 1 / sf);
+      if (hairWidth > 0) a *= hairWidth;
+    }
+    generator.strokePath(
+        path, pageToDevice, deviceStroke, stripArgbColor(color, a),
+        tolerance: stripFlattenTolerance);
+  }
+
+  @override
+  void fillPathGradient(
+      PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) {
+    _delegatePaint(() => delegateFillPathGradient(path, rule, gradient, alpha));
+  }
+
+  @override
+  void fillMesh(PdfMesh mesh, double alpha) {
+    _delegatePaint(() => delegateFillMesh(mesh, alpha));
+  }
+
+  @override
+  void drawText(PdfTextRun run) {
+    if (run.invisible) return;
+    final glyphs = run.glyphs;
+    if (!stripsActive ||
+        delegateText ||
+        glyphs == null ||
+        !run.fill ||
+        run.strokeColor != null ||
+        run.gradient != null) {
+      // substituted-font runs, stroked/gradient text, knockout/blended runs
+      _delegatePaint(() => delegateDrawText(run));
+      return;
+    }
+    if (!binningEnabled) return;
+    final color = stripArgbColor(run.color, 1);
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline == null) continue;
+      final emToDevice = PdfMatrix.translation(glyph.offset, glyph.offsetY)
+          .concat(run.transform)
+          .concat(pageToDevice);
+      generator.fillOutline(FlattenedOutline.of(outline), emToDevice, color);
+    }
+  }
+
+  @override
+  void drawImage(PdfImageRequest request) {
+    _delegatePaint(() => delegateDrawImage(request));
+  }
+
+  @override
+  void setBlendMode(PdfBlendMode mode) {
+    _blend = mode;
+    delegateSetBlendMode(mode);
+  }
+
+  @override
+  void beginGroup(double alpha, {bool knockout = false}) {
+    flushPending(); // the group's layer must not capture earlier strips
+    _groupKnockout.add(knockout);
+    delegateBeginGroup(alpha, knockout: knockout);
+  }
+
+  @override
+  void endGroup() {
+    flushPending(); // strips inside the group must land inside its layer
+    if (_groupKnockout.isNotEmpty) _groupKnockout.removeLast();
+    delegateEndGroup();
+  }
+
+  @override
+  void beginSoftMasked() {
+    flushPending(); // earlier strips must not be captured by the layer
+    _groupKnockout.add(false);
+    delegateBeginSoftMasked();
+  }
+
+  @override
+  void endSoftMasked({
+    required bool luminosity,
+    required PdfRect backdrop,
+    required void Function() drawMask,
+    double backdropLuminance = 0,
+    double transferScale = 1,
+    double transferOffset = 0,
+  }) {
+    flushPending(); // masked content strips land inside the content layer
+    if (_groupKnockout.isNotEmpty) _groupKnockout.removeLast();
+    delegateBeginSoftMaskComposite(
+        luminosity: luminosity,
+        backdrop: backdrop,
+        backdropLuminance: backdropLuminance,
+        transferScale: transferScale,
+        transferOffset: transferOffset);
+    // The mask group's draws happen NOW and route through this device, so
+    // they bin/flush between the composite halves on every subclass.
+    drawMask();
+    flushPending();
+    delegateFinishSoftMaskComposite();
+  }
+}

--- a/packages/pdf_graphics/lib/src/raster/strip_plan.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_plan.dart
@@ -1,0 +1,371 @@
+// A precomputed strip-binning result and its wire codec: everything a
+// StripPdfDevice needs to skip the flatten/stroke-expansion/coverage work
+// of a zoom re-bin because a worker isolate already did it. Pure Dart -
+// the plan crosses the isolate boundary as one Uint8List (a single
+// TransferableTypedData on native, postMessage-transferable on the web).
+import 'dart:typed_data';
+
+import '../interpreter.dart' show PdfCancellationToken;
+import '../matrix.dart';
+import '../render_command.dart';
+import 'strip_batch_data.dart';
+import 'strip_binning_device.dart';
+
+/// The strip batches of one full binning walk, tagged with the geometry
+/// they were binned for. Only valid for a device with the exact same
+/// [pageToDevice] matrix, viewport, and [tolerance]; the consuming device
+/// verifies [totalFlushPoints] and full batch consumption at finish and
+/// falls back to local binning on any mismatch.
+class StripPlan {
+  StripPlan({
+    required this.totalFlushPoints,
+    required this.deviceWidth,
+    required this.deviceHeight,
+    required this.pageToDevice,
+    required this.tolerance,
+    required this.batches,
+  });
+
+  /// Flush points the binning walk counted (empty ones included) - must
+  /// equal the consuming device's own count for the plan to be valid.
+  final int totalFlushPoints;
+
+  final int deviceWidth;
+  final int deviceHeight;
+
+  /// Page space -> device pixels, exactly as the consuming device will be
+  /// constructed (the six coefficients round-trip bit-exactly).
+  final PdfMatrix pageToDevice;
+
+  /// The flatten tolerance the strips were binned at
+  /// ([stripFlattenTolerance] everywhere today; carried for the guard).
+  final double tolerance;
+
+  /// Non-empty batches ordered by [StripBatchData.flushOrdinal].
+  final List<StripBatchData> batches;
+}
+
+/// Thrown when a [StripPlan] does not match the device consuming it
+/// (stale geometry, or a flush-ordinal/batch-count desync). Callers catch
+/// it, discard the picture, and re-run with local binning.
+class StripPlanMismatchError extends Error {
+  StripPlanMismatchError(this.message);
+  final String message;
+
+  @override
+  String toString() => 'StripPlanMismatchError: $message';
+}
+
+/// Headless subclass of the binning core: collects the [StripBatchData]
+/// emitted at each flush point (delegated ops are no-ops) into a
+/// [StripPlan]. Feed it the page's command list with [bin] - which honors
+/// a [PdfCancellationToken] cooperatively - then take [finish]'s plan.
+class StripPlanBinner extends StripBinningDevice {
+  StripPlanBinner({
+    required super.pageToDevice,
+    required super.deviceWidth,
+    required super.deviceHeight,
+    required super.pixelRatio,
+  });
+
+  final List<StripBatchData> batches = [];
+  bool _finished = false;
+
+  @override
+  void emitBatch(int ordinal, StripBatchData? data) {
+    if (data != null) batches.add(data);
+  }
+
+  /// Replays [commands] through the binning core, yielding to the event
+  /// loop (and checking [cancellation]) every ~1024 commands so a worker's
+  /// cancel message can preempt a long walk - the same cooperative scheme
+  /// as the worker's record path.
+  Future<void> bin(List<PdfRenderCommand> commands,
+          {PdfCancellationToken? cancellation}) =>
+      replayCommandsCancellable(commands, this, cancellation: cancellation);
+
+  /// Runs the final flush point and packages the plan. Call exactly once,
+  /// after every command has been replayed.
+  StripPlan finish() {
+    assert(!_finished, 'StripPlanBinner.finish() called twice');
+    _finished = true;
+    flushPending();
+    return StripPlan(
+      totalFlushPoints: flushPointCount,
+      deviceWidth: deviceWidth,
+      deviceHeight: deviceHeight,
+      pageToDevice: pageToDevice,
+      tolerance: stripFlattenTolerance,
+      batches: batches,
+    );
+  }
+
+  // Delegated ops paint nothing here - the live device replays them from
+  // its own retained scene; the plan only carries strips.
+  @override
+  void delegateSave() {}
+  @override
+  void delegateRestore() {}
+  @override
+  void delegateClipPath(path, rule) {}
+  @override
+  void delegateSetBlendMode(mode) {}
+  @override
+  void delegateBeginGroup(double alpha, {required bool knockout}) {}
+  @override
+  void delegateEndGroup() {}
+  @override
+  void delegateBeginSoftMasked() {}
+  @override
+  void delegateBeginSoftMaskComposite(
+      {required luminosity,
+      required backdrop,
+      required double backdropLuminance,
+      required double transferScale,
+      required double transferOffset}) {}
+  @override
+  void delegateFinishSoftMaskComposite() {}
+  @override
+  void delegateFillPath(path, color, rule, double alpha) {}
+  @override
+  void delegateStrokePath(path, color, stroke, double alpha) {}
+  @override
+  void delegateFillPathGradient(path, rule, gradient, double alpha) {}
+  @override
+  void delegateFillMesh(mesh, double alpha) {}
+  @override
+  void delegateDrawText(run) {}
+  @override
+  void delegateDrawImage(request) {}
+}
+
+// ---- codec ----------------------------------------------------------------
+//
+// Layout (version byte first, scalars big-endian like render_command_codec;
+// the bulk vertex/atlas arrays are written as raw host-order bytes - both
+// ends of the wire are the same build on the same architecture, and every
+// supported platform is little-endian):
+//
+//   u8  version
+//   u32 totalFlushPoints, u32 deviceWidth, u32 deviceHeight
+//   f64 x6 pageToDevice, f64 tolerance
+//   u32 batchCount, then per batch:
+//     u32 flushOrdinal, u32 stripCount, u32 atlasWidth, u32 atlasHeight
+//     u32 atlasByteLength + raw atlas bytes
+//     u32 chunkCount, then per chunk:
+//       u32 quadCount
+//       raw positions (quadCount*8 f32), texcoords (quadCount*8 f32),
+//           colors (quadCount*4 i32), indices (quadCount*6 u16)
+
+const int _planFormatVersion = 1;
+
+/// Telemetry: microseconds spent in [decodeStripPlan] (accumulated) - this
+/// runs on the consuming (UI) isolate, so it counts toward the residual
+/// UI-thread cost of a worker-binned settle.
+int decodeStripPlanMicros = 0;
+
+/// Serializes [plan] into one compact buffer (see the layout above).
+Uint8List encodeStripPlan(StripPlan plan) {
+  final w = _PlanWriter();
+  w.u8(_planFormatVersion);
+  w.u32(plan.totalFlushPoints);
+  w.u32(plan.deviceWidth);
+  w.u32(plan.deviceHeight);
+  final m = plan.pageToDevice;
+  w.f64(m.a);
+  w.f64(m.b);
+  w.f64(m.c);
+  w.f64(m.d);
+  w.f64(m.e);
+  w.f64(m.f);
+  w.f64(plan.tolerance);
+  w.u32(plan.batches.length);
+  for (final batch in plan.batches) {
+    w.u32(batch.flushOrdinal);
+    w.u32(batch.stripCount);
+    w.u32(batch.atlasWidth);
+    w.u32(batch.atlasHeight);
+    w.raw(batch.atlasPixels);
+    w.u32(batch.chunks.length);
+    for (final chunk in batch.chunks) {
+      final quads = chunk.positions.length ~/ 8;
+      w.u32(quads);
+      w.rawView(chunk.positions.buffer, chunk.positions.offsetInBytes,
+          chunk.positions.lengthInBytes);
+      w.rawView(
+          chunk.textureCoordinates.buffer,
+          chunk.textureCoordinates.offsetInBytes,
+          chunk.textureCoordinates.lengthInBytes);
+      w.rawView(chunk.colors.buffer, chunk.colors.offsetInBytes,
+          chunk.colors.lengthInBytes);
+      w.rawView(chunk.indices.buffer, chunk.indices.offsetInBytes,
+          chunk.indices.lengthInBytes);
+    }
+  }
+  return w.takeBytes();
+}
+
+/// Decodes a buffer produced by [encodeStripPlan]. Throws on a version or
+/// structure mismatch (producer and consumer ship together; a mismatch is
+/// a programming error, and callers treat any throw as "no plan").
+StripPlan decodeStripPlan(Uint8List bytes) {
+  final sw = Stopwatch()..start();
+  final r = _PlanReader(bytes);
+  final version = r.u8();
+  if (version != _planFormatVersion) {
+    throw StateError('strip plan version $version != $_planFormatVersion');
+  }
+  final totalFlushPoints = r.u32();
+  final deviceWidth = r.u32();
+  final deviceHeight = r.u32();
+  final matrix =
+      PdfMatrix(r.f64(), r.f64(), r.f64(), r.f64(), r.f64(), r.f64());
+  final tolerance = r.f64();
+  final batchCount = r.u32();
+  final batches = <StripBatchData>[];
+  for (var i = 0; i < batchCount; i++) {
+    final flushOrdinal = r.u32();
+    final stripCount = r.u32();
+    final atlasWidth = r.u32();
+    final atlasHeight = r.u32();
+    final atlasPixels = r.rawBytes();
+    final chunkCount = r.u32();
+    final chunks = <StripChunkData>[];
+    for (var c = 0; c < chunkCount; c++) {
+      final quads = r.u32();
+      chunks.add(StripChunkData(
+        r.f32List(quads * 8),
+        r.f32List(quads * 8),
+        r.i32List(quads * 4),
+        r.u16List(quads * 6),
+      ));
+    }
+    batches.add(StripBatchData.raw(
+        flushOrdinal, chunks, atlasPixels, atlasWidth, atlasHeight,
+        stripCount));
+  }
+  final plan = StripPlan(
+    totalFlushPoints: totalFlushPoints,
+    deviceWidth: deviceWidth,
+    deviceHeight: deviceHeight,
+    pageToDevice: matrix,
+    tolerance: tolerance,
+    batches: batches,
+  );
+  decodeStripPlanMicros += sw.elapsedMicroseconds;
+  return plan;
+}
+
+class _PlanWriter {
+  Uint8List _buf = Uint8List(1 << 16);
+  late ByteData _view = ByteData.view(_buf.buffer);
+  int _len = 0;
+
+  void _ensure(int extra) {
+    final need = _len + extra;
+    if (need <= _buf.length) return;
+    var cap = _buf.length * 2;
+    while (cap < need) {
+      cap *= 2;
+    }
+    final grown = Uint8List(cap)..setRange(0, _len, _buf);
+    _buf = grown;
+    _view = ByteData.view(grown.buffer);
+  }
+
+  void u8(int v) {
+    _ensure(1);
+    _buf[_len++] = v & 0xff;
+  }
+
+  void u32(int v) {
+    _ensure(4);
+    _view.setUint32(_len, v);
+    _len += 4;
+  }
+
+  void f64(double v) {
+    _ensure(8);
+    _view.setFloat64(_len, v);
+    _len += 8;
+  }
+
+  /// A length-prefixed raw byte run.
+  void raw(Uint8List xs) {
+    u32(xs.length);
+    _ensure(xs.length);
+    _buf.setRange(_len, _len + xs.length, xs);
+    _len += xs.length;
+  }
+
+  /// Raw bytes of a typed-data view, unprefixed (the element count travels
+  /// separately).
+  void rawView(ByteBuffer buffer, int offsetInBytes, int lengthInBytes) {
+    _ensure(lengthInBytes);
+    _buf.setRange(_len, _len + lengthInBytes,
+        Uint8List.view(buffer, offsetInBytes, lengthInBytes));
+    _len += lengthInBytes;
+  }
+
+  Uint8List takeBytes() =>
+      Uint8List.fromList(Uint8List.sublistView(_buf, 0, _len));
+}
+
+class _PlanReader {
+  _PlanReader(this._bytes) : _data = ByteData.sublistView(_bytes);
+
+  final Uint8List _bytes;
+  final ByteData _data;
+  int _o = 0;
+
+  int u8() => _data.getUint8(_o++);
+
+  int u32() {
+    final v = _data.getUint32(_o);
+    _o += 4;
+    return v;
+  }
+
+  double f64() {
+    final v = _data.getFloat64(_o);
+    _o += 8;
+    return v;
+  }
+
+  Uint8List rawBytes() {
+    final n = u32();
+    final out = Uint8List.fromList(Uint8List.sublistView(_bytes, _o, _o + n));
+    _o += n;
+    return out;
+  }
+
+  // The bulk reads copy into freshly-allocated (aligned) typed arrays; a
+  // view over the transferred buffer could be misaligned and would pin the
+  // whole buffer alive.
+  Float32List f32List(int n) {
+    final out = Float32List(n);
+    out.buffer
+        .asUint8List()
+        .setRange(0, n * 4, Uint8List.sublistView(_bytes, _o, _o + n * 4));
+    _o += n * 4;
+    return out;
+  }
+
+  Int32List i32List(int n) {
+    final out = Int32List(n);
+    out.buffer
+        .asUint8List()
+        .setRange(0, n * 4, Uint8List.sublistView(_bytes, _o, _o + n * 4));
+    _o += n * 4;
+    return out;
+  }
+
+  Uint16List u16List(int n) {
+    final out = Uint16List(n);
+    out.buffer
+        .asUint8List()
+        .setRange(0, n * 2, Uint8List.sublistView(_bytes, _o, _o + n * 2));
+    _o += n * 2;
+    return out;
+  }
+}

--- a/packages/pdf_graphics/lib/src/raster/strip_plan.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_plan.dart
@@ -153,7 +153,7 @@ class StripPlanBinner extends StripBinningDevice {
 //     u32 flushOrdinal, u32 stripCount, u32 atlasWidth, u32 atlasHeight
 //     u32 atlasByteLength + raw atlas bytes
 //     u32 chunkCount, then per chunk:
-//       u32 quadCount
+//       u32 quadCount, u32 alphaBase
 //       raw positions (quadCount*8 f32), texcoords (quadCount*8 f32),
 //           colors (quadCount*4 i32), indices (quadCount*6 u16)
 
@@ -190,6 +190,7 @@ Uint8List encodeStripPlan(StripPlan plan) {
     for (final chunk in batch.chunks) {
       final quads = chunk.positions.length ~/ 8;
       w.u32(quads);
+      w.u32(chunk.alphaBase);
       w.rawView(chunk.positions.buffer, chunk.positions.offsetInBytes,
           chunk.positions.lengthInBytes);
       w.rawView(
@@ -234,6 +235,7 @@ StripPlan decodeStripPlan(Uint8List bytes) {
     for (var c = 0; c < chunkCount; c++) {
       final quads = r.u32();
       chunks.add(StripChunkData(
+        r.u32(),
         r.f32List(quads * 8),
         r.f32List(quads * 8),
         r.i32List(quads * 4),

--- a/packages/pdf_graphics/lib/src/render_command.dart
+++ b/packages/pdf_graphics/lib/src/render_command.dart
@@ -2,6 +2,7 @@ import 'package:pdf_document/pdf_document.dart';
 
 import 'color.dart';
 import 'device.dart';
+import 'interpreter.dart' show PdfCancellationToken, PdfCancelledException;
 import 'mesh.dart';
 import 'path.dart';
 import 'shading.dart';
@@ -139,8 +140,14 @@ class PdfEndSoftMaskedCommand extends PdfRenderCommand {
 /// Replays [commands] into [device], reproducing the original interpreter
 /// callbacks in order. The dispatch is total over the [PdfRenderCommand]
 /// hierarchy - adding a command without a case here is a compile error.
-void replayCommands(List<PdfRenderCommand> commands, PdfDevice device) {
-  for (final command in commands) {
+///
+/// [start]/[end] replay only that index range (used by the cancellable
+/// chunked replay below without copying slices of a 100k-command buffer).
+void replayCommands(List<PdfRenderCommand> commands, PdfDevice device,
+    {int start = 0, int? end}) {
+  final stop = end ?? commands.length;
+  for (var i = start; i < stop; i++) {
+    final command = commands[i];
     switch (command) {
       case PdfSaveCommand():
         device.save();
@@ -195,5 +202,28 @@ void replayCommands(List<PdfRenderCommand> commands, PdfDevice device) {
           drawMask: () => replayCommands(maskCommands, device),
         );
     }
+  }
+}
+
+/// [replayCommands] in cooperative chunks: every [checkInterval] commands
+/// it checks [cancellation] and yields to the event loop, so a message
+/// (e.g. a render worker's cancel port) can preempt a long replay mid-walk
+/// by throwing [PdfCancelledException] - the same scheme the interpreter's
+/// async walk uses. Soft-mask groups replay atomically inside their
+/// enclosing command.
+Future<void> replayCommandsCancellable(
+    List<PdfRenderCommand> commands, PdfDevice device,
+    {PdfCancellationToken? cancellation, int checkInterval = 1024}) async {
+  for (var i = 0; i < commands.length; i += checkInterval) {
+    if (cancellation != null) {
+      // Yield first so a cancel that arrived during the previous chunk gets
+      // its listener run before the next chunk starts.
+      await Future<void>.delayed(Duration.zero);
+      if (cancellation.cancelled) throw const PdfCancelledException();
+    }
+    final end = i + checkInterval < commands.length
+        ? i + checkInterval
+        : commands.length;
+    replayCommands(commands, device, start: i, end: end);
   }
 }

--- a/packages/pdf_graphics/test/raster/strip_plan_test.dart
+++ b/packages/pdf_graphics/test/raster/strip_plan_test.dart
@@ -1,0 +1,237 @@
+// StripPlanBinner + strip-plan codec:
+//
+//  - flush-ordinal semantics of the shared binning core on synthetic
+//    command sequences (delegated paints, clips incl. restore-pops-clip,
+//    nested/knockout groups, soft masks with the mask drawn between the
+//    composite halves, blend-mode switches, empty flushes) - the parity
+//    invariant precomputed plans ride on;
+//  - cooperative cancellation of the chunked replay;
+//  - encodeStripPlan/decodeStripPlan round-trip fidelity.
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart' show PdfRect;
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:test/test.dart';
+
+PdfPath rect(double l, double t, double r, double b) => PdfPath([
+      PdfMoveTo(l, t),
+      PdfLineTo(r, t),
+      PdfLineTo(r, b),
+      PdfLineTo(l, b),
+      const PdfClosePath(),
+    ]);
+
+StripPlanBinner binner({int w = 64, int h = 64}) => StripPlanBinner(
+      pageToDevice: PdfMatrix.identity,
+      deviceWidth: w,
+      deviceHeight: h,
+      pixelRatio: 1,
+    );
+
+void fill(PdfDevice d, PdfPath path) =>
+    d.fillPath(path, PdfColor.black, PdfFillRule.nonzero, 1);
+
+PdfImageRequest dummyImage() => PdfImageRequest(
+      stream: CosStream(CosDictionary(), Uint8List(0)),
+      transform: PdfMatrix.identity,
+    );
+
+void main() {
+  test('delegated paints are flush points; trailing strips flush at finish',
+      () {
+    final b = binner();
+    fill(b, rect(2, 2, 10, 10));
+    fill(b, rect(12, 2, 20, 10));
+    b.drawImage(dummyImage()); // delegated paint -> flush ordinal 0
+    fill(b, rect(2, 12, 10, 20));
+    final plan = b.finish(); // final flush -> ordinal 1
+
+    expect(plan.totalFlushPoints, 2);
+    expect(plan.batches.map((x) => x.flushOrdinal), [0, 1]);
+    expect(b.delegatedPaintCount, 1);
+    expect(plan.batches[0].stripCount, greaterThan(0));
+    expect(plan.batches[1].stripCount, greaterThan(0));
+  });
+
+  test('clip flushes before it applies; restore pops the clip with a flush',
+      () {
+    final b = binner();
+    fill(b, rect(2, 2, 10, 10));
+    b.save();
+    b.clipPath(rect(0, 0, 32, 32), PdfFillRule.nonzero); // flush 0 (batch)
+    fill(b, rect(4, 4, 8, 8));
+    b.restore(); // pops the clip -> flush 1 (batch)
+    fill(b, rect(20, 20, 30, 30));
+    final plan = b.finish(); // flush 2 (batch)
+
+    expect(plan.totalFlushPoints, 3);
+    expect(plan.batches.map((x) => x.flushOrdinal), [0, 1, 2]);
+  });
+
+  test('empty flush points still count ordinals but emit no batch', () {
+    final b = binner();
+    b.save();
+    b.clipPath(rect(0, 0, 32, 32), PdfFillRule.nonzero); // flush 0, empty
+    fill(b, rect(4, 4, 8, 8));
+    b.restore(); // flush 1 (batch)
+    final plan = b.finish(); // flush 2, empty
+
+    expect(plan.totalFlushPoints, 3);
+    expect(plan.batches.map((x) => x.flushOrdinal), [1]);
+  });
+
+  test('knockout group delegates its fills; ordinary group re-enables', () {
+    final b = binner();
+    b.beginGroup(1, knockout: true); // flush 0 (empty)
+    fill(b, rect(2, 2, 10, 10)); // knockout -> delegated -> flush 1 (empty)
+    b.beginGroup(0.5); // nested non-knockout -> flush 2 (empty)
+    fill(b, rect(4, 4, 8, 8)); // strips active again (top of stack wins)
+    b.endGroup(); // flush 3 (batch)
+    fill(b, rect(2, 2, 10, 10)); // directly in knockout -> delegated, flush 4
+    b.endGroup(); // flush 5 (empty)
+    fill(b, rect(20, 20, 30, 30)); // binned
+    final plan = b.finish(); // flush 6 (batch)
+
+    expect(plan.totalFlushPoints, 7);
+    expect(plan.batches.map((x) => x.flushOrdinal), [3, 6]);
+    expect(b.delegatedPaintCount, 2);
+  });
+
+  test('non-normal blend modes delegate until normal returns', () {
+    final b = binner();
+    b.setBlendMode(PdfBlendMode.multiply); // state, not a flush point
+    fill(b, rect(2, 2, 10, 10)); // delegated -> flush 0 (empty)
+    b.setBlendMode(PdfBlendMode.normal);
+    fill(b, rect(12, 2, 20, 10)); // binned
+    final plan = b.finish(); // flush 1 (batch)
+
+    expect(plan.totalFlushPoints, 2);
+    expect(plan.batches.map((x) => x.flushOrdinal), [1]);
+    expect(b.delegatedPaintCount, 1);
+  });
+
+  test('soft mask: content flushes at the boundary, mask strips land between '
+      'the composite halves', () {
+    final b = binner();
+    b.beginSoftMasked(); // flush 0 (empty)
+    fill(b, rect(2, 2, 10, 10)); // masked content
+    b.endSoftMasked(
+      luminosity: true,
+      backdrop: const PdfRect(0, 0, 64, 64),
+      drawMask: () => fill(b, rect(0, 0, 32, 32)), // mask group strips
+    ); // flush 1 (content batch), mask draw, flush 2 (mask batch)
+    final plan = b.finish(); // flush 3 (empty)
+
+    expect(plan.totalFlushPoints, 4);
+    expect(plan.batches.map((x) => x.flushOrdinal), [1, 2]);
+  });
+
+  test('substituted text delegates, outline text bins', () {
+    final glyph = PdfGlyphPlacement(offset: 0, outline: rect(0, 0, 0.5, 0.6));
+    final b = binner();
+    b.drawText(PdfTextRun(
+      text: 'x',
+      transform: const PdfMatrix(16, 0, 0, 16, 4, 20),
+      color: PdfColor.black,
+      width: 0.5,
+      glyphs: [glyph],
+    )); // binned
+    b.drawText(PdfTextRun(
+      text: 'y',
+      transform: const PdfMatrix(16, 0, 0, 16, 4, 40),
+      color: PdfColor.black,
+      width: 0.5,
+    )); // no glyphs -> delegated -> flush 0 (batch: the outline glyph)
+    final plan = b.finish(); // flush 1 (empty)
+
+    expect(plan.totalFlushPoints, 2);
+    expect(plan.batches.map((x) => x.flushOrdinal), [0]);
+    expect(b.delegatedPaintCount, 1);
+  });
+
+  test('two binners over one command list produce identical plans', () async {
+    final commands = <PdfRenderCommand>[
+      PdfFillPathCommand(rect(2, 2, 30, 30), PdfColor.black,
+          PdfFillRule.nonzero, 1),
+      PdfStrokePathCommand(rect(8, 8, 24, 24), const PdfColor(1, 0, 0),
+          const PdfStroke(width: 2), 0.8),
+      PdfDrawImageCommand(dummyImage()),
+      PdfFillPathCommand(rect(40, 40, 60, 60), const PdfColor(0, 0, 1),
+          PdfFillRule.evenOdd, 0.5),
+    ];
+    Future<Uint8List> run() async {
+      final b = binner();
+      await b.bin(commands);
+      return encodeStripPlan(b.finish());
+    }
+
+    expect(await run(), await run());
+  });
+
+  test('cancellation token aborts the chunked replay', () async {
+    final commands = <PdfRenderCommand>[
+      for (var i = 0; i < 4000; i++)
+        PdfFillPathCommand(
+            rect(2, 2, 10, 10), PdfColor.black, PdfFillRule.nonzero, 1),
+    ];
+    final b = binner();
+    final token = PdfCancellationToken();
+    // Flip the token from the event loop: the replay yields between chunks,
+    // so the cancel lands mid-walk exactly like a worker's cancel port.
+    Future<void>.delayed(Duration.zero, () => token.cancelled = true);
+    await expectLater(
+        b.bin(commands, cancellation: token),
+        throwsA(isA<PdfCancelledException>()));
+  });
+
+  test('codec round-trips a real plan bit-exactly', () async {
+    final b = StripPlanBinner(
+      pageToDevice: const PdfMatrix(2.5, 0, 0, -2.5, 3.25, 170.125),
+      deviceWidth: 160,
+      deviceHeight: 176,
+      pixelRatio: 2.5,
+    );
+    // Fractional edges force mixed-coverage strips (atlas bytes) alongside
+    // solid runs; a delegated paint splits the plan into two batches.
+    fill(b, rect(1.25, 1.5, 30.75, 12.25));
+    b.strokePath(rect(4, 20, 40, 40), const PdfColor(0, 0.5, 1),
+        const PdfStroke(width: 1.3), 0.7);
+    b.drawImage(dummyImage());
+    fill(b, rect(10.1, 50.2, 55.9, 60.8));
+    final plan = b.finish();
+    expect(plan.batches.length, 2);
+
+    final decoded = decodeStripPlan(encodeStripPlan(plan));
+    expect(decoded.totalFlushPoints, plan.totalFlushPoints);
+    expect(decoded.deviceWidth, plan.deviceWidth);
+    expect(decoded.deviceHeight, plan.deviceHeight);
+    expect(decoded.tolerance, plan.tolerance);
+    expect(decoded.pageToDevice.a, plan.pageToDevice.a);
+    expect(decoded.pageToDevice.b, plan.pageToDevice.b);
+    expect(decoded.pageToDevice.c, plan.pageToDevice.c);
+    expect(decoded.pageToDevice.d, plan.pageToDevice.d);
+    expect(decoded.pageToDevice.e, plan.pageToDevice.e);
+    expect(decoded.pageToDevice.f, plan.pageToDevice.f);
+    expect(decoded.batches.length, plan.batches.length);
+    for (var i = 0; i < plan.batches.length; i++) {
+      final a = plan.batches[i], d = decoded.batches[i];
+      expect(d.flushOrdinal, a.flushOrdinal);
+      expect(d.stripCount, a.stripCount);
+      expect(d.atlasWidth, a.atlasWidth);
+      expect(d.atlasHeight, a.atlasHeight);
+      expect(d.atlasPixels, a.atlasPixels);
+      expect(d.chunks.length, a.chunks.length);
+      for (var c = 0; c < a.chunks.length; c++) {
+        expect(d.chunks[c].positions, a.chunks[c].positions);
+        expect(d.chunks[c].textureCoordinates,
+            a.chunks[c].textureCoordinates);
+        expect(d.chunks[c].colors, a.chunks[c].colors);
+        expect(d.chunks[c].indices, a.chunks[c].indices);
+      }
+    }
+    // And the re-encode of the decode is byte-identical.
+    expect(encodeStripPlan(decoded), encodeStripPlan(plan));
+  });
+}

--- a/packages/pdf_graphics/test/raster/strip_plan_test.dart
+++ b/packages/pdf_graphics/test/raster/strip_plan_test.dart
@@ -224,6 +224,7 @@ void main() {
       expect(d.atlasPixels, a.atlasPixels);
       expect(d.chunks.length, a.chunks.length);
       for (var c = 0; c < a.chunks.length; c++) {
+        expect(d.chunks[c].alphaBase, a.chunks[c].alphaBase);
         expect(d.chunks[c].positions, a.chunks[c].positions);
         expect(d.chunks[c].textureCoordinates,
             a.chunks[c].textureCoordinates);


### PR DESCRIPTION
Follow-up to #210, which shipped the dense-page strip zoom router opt-in for two reasons: no runtime backend detection, and the ~270 ms strip re-bin ran on the UI thread every zoom settle. This PR removes both and flips `PdfPageView.stripZoomReplay` to **default on**. It also fixes a silent Impeller blackout bug that shipped in #210.

## What's here (5 commits, reviewable in order)

1. **Shared binning core** (`StripBinningDevice` + `StripBatchData` in `pdf_graphics/raster`, dart:ui-free): all routing/state/**flush-point** decisions — including the soft-mask composite split — live in one base class, so a headless replay of the same command list on another isolate produces batches that interleave at exactly the same flush ordinals as the live device. `StripPdfDevice` is now just the dart:ui half (tape, `ui.Vertices.raw`, atlas decode, shader draw). Behavior-neutral refactor, committed and verified separately.
2. **`binStrips` on the render worker**: the worker re-records the page in-isolate (2-entry LRU), bins through a headless `StripPlanBinner` (cooperative cancellation, same preemption semantics as `record`), and ships a `StripPlan` as one transferable buffer via a compact binary codec. The worker round-trips its recording through the command wire codec so plans are **bit-identical** to a local re-bin of the UI's scene (asserted end-to-end). Pool routes bins by static page index (cache affinity); caching wrapper passes through; stub/web decline → local bin. Web worker `dart compile js` gate stays green.
3. **Precomputed device mode + verification**: `StripPdfDevice(precomputed:)` skips all flatten/bin cost and consumes plan batches by flush ordinal. Guards: exact geometry match up front; flush-count + full-consumption check in `finish()` **before painting** (`StripPlanMismatchError` → transparent local-bin re-run, counted in telemetry); `debugVerifyPrecomputed` byte-compares every batch in tests.
4. **Fix: dense strip batches drew NOTHING on Impeller** (bug shipped in #210): Impeller renders a drawVertices runtime shader into a snapshot texture spanning the texcoord bounds; our global alpha-texel u coordinates (~500k on ly9) exceeded the 16384 texture limit — validation failure, blank batch. ly9-far-cad rendered a blank page through #210's router, so **#210's Impeller settle numbers were timing an empty raster**. Fixed by chunking on alpha span (8192, under older Metal GPUs' floor), per-chunk rebased texcoords + a `uBase` shader uniform; solid strips carry constant u=0. ly9 now renders fully on Impeller with zero validation errors; software output unchanged.
5. **Backend gate + default flip**: strip routing (retention and settle decisions, kept consistent) requires `ui.ImageFilter.isShaderFilterSupported` — public dart:ui API, true iff Impeller is enabled. `stripZoomReplay` now defaults **true**: inert on software/web, worker-binned on Impeller, #210's local bin as the no-worker fallback. Only worker-backed scenes consume plans (locally recorded scenes, e.g. editing's `skipAnnotation`, keep local binning). `debugStripZoomReplayBackendOverride` for tests.

## Zoom settle, ly9-far-cad p4 (98.9k commands; Impeller/Metal, mean ms/settle, 3×5 steps, 2382×1684)

| path | bin wait (off-thread) | **UI-thread block** | total |
|---|---|---|---|
| cached picture (pre-#210) | — | ~3 | **1473** |
| flat retained replay (#208) | — | ~70 | 1453 |
| strips, local bin (#210 + blackout fix) | — | **341** | 768 |
| **strips, worker plan (this PR)** | 338 | **35** | **767** |

Worker bin wait warms 449→291 ms/settle on repeat settles (command LRU + glyph/shape strip caches carry over in the worker). WAT_L0001_S p0 records 12,741 commands — under the 20k ceiling, so it keeps flat replay by design (585 ms, unchanged). Office control untouched (91 ms).

## Verification

- Root `dart analyze` clean; pdf_graphics raster suite green; dart_pdf_editor full suite green on software (Ghent baselines untouched); strip/plan/worker/router/retained suites green under `--enable-impeller`. All re-verified after rebasing onto the #210 squash-merge.
- Pre-existing, not from this branch: `strip_parity_test --enable-impeller` scores 22/57 relaxed on this machine at the #210 base commit too (Impeller-canvas AA character difference; documented in the dev-log).
- Dev-log: `doc/dev-log/2026-07-10-strip-worker-binning.md`.

Follow-ups: combine region-resolution image re-decode with strip plans for the deep-zoom detail patch on strip-routed pages; web-worker strip binning if strip routing ever proves out on CanvasKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)