### PR TITLE
perf(dart_pdf_editor): speculative strip binning while the zoom gesture quiesces + in-flight bin preemption

### DIFF
--- a/doc/dev-log/2026-07-11-strip-speculative-bin.md
+++ b/doc/dev-log/2026-07-11-strip-speculative-bin.md
@@ -1,0 +1,150 @@
+# 2026-07-11 — Speculative strip binning during zoom quiescence
+
+Branch `perf/strip-settle-pipeline`, on top of #211 (worker-isolate strip
+binning). #211 moved the dense-page strip re-bin onto the render worker,
+but a production settle on ly9-far-cad.pdf p4 (98.9k commands) was still
+dominated by *waiting* for that bin. This session makes the wait overlap
+the viewer's own settle debounce.
+
+## The binWait decomposition
+
+Instrumenting the worker round-trip on ly9 p4 showed the warm bin wait
+(185–430 ms across zoom steps, ~290 ms typical, 355–380 ms on the
+benchmark machine below) is essentially the bin itself:
+
+- record ≈ 0 — the worker's `_BinCommandCache` hits on every settle after
+  the first (a zoom session hammers one page);
+- encode 4–38 ms; transfer ~free via `TransferableTypedData` even at the
+  9–21 MB a CAD-sheet plan weighs;
+- everything else is `StripPlanBinner.bin` walking 98.9k commands.
+
+Meanwhile the UI-side settle work is small: plan decode + engine-object
+build ≈ 20–35 ms, `toImage` ≈ 22–56 ms. So the perceived settle latency
+was ~binWait + ~60 ms.
+
+## The overlap: the viewer already waits 200 ms
+
+`_PdfViewerState._onTransformChanged` restarts a 200 ms `_settleTimer` on
+every matrix change and only then bumps `_renderScale`/`_settleGeneration`
+(pdf_viewer.dart). For that entire debounce the final geometry is already
+known and the worker sits idle. New flow:
+
+- `PdfPageView` gains `transformScale` (a `ValueListenable<double>`; the
+  viewer feeds it the live InteractiveViewer scale, null keeps the feature
+  inert for standalone uses / existing tests).
+- `_PdfPageViewState` listens; each change restarts a private 50 ms
+  one-shot (`_speculateDebounce`). **Why 50 ms, not every tick**: during
+  active motion matrix events arrive every frame, so the timer keeps
+  resetting and nothing fires; once motion pauses 50 ms we bin
+  speculatively — 150 ms of the viewer's 200 ms debounce then overlaps the
+  bin. Firing per tick would cancel-churn the worker continuously for no
+  benefit.
+- `_speculateStripPlan` (pdf_page_view.dart) re-checks the same
+  eligibility as the settle path via the shared `_workerBinningEligible`
+  (worker-recorded scene, live worker, no debug-delegate flags) plus
+  `retainedZoomReplay`/`_stripReplayScene`, computes the settle's scale,
+  and issues `worker.binStrips(...)` with exactly the settle's argument
+  construction at the SAME priority. The `(geometry, pixelRatio, future)`
+  triple is held in `_speculativeStripPlan`.
+- `_workerStripPlan`, on a full-page call, consumes the stored future when
+  the geometry matches EXACTLY (all six matrix doubles, width, height,
+  pixelRatio — they round-trip the wire codec bit-exactly, so `==` is
+  correct). Non-null → return it (`debugSpeculativePlanHits`). Null (the
+  speculative bin was cancelled/declined) → fall through to today's
+  cancel+request path. Geometry mismatch or a region call → drop it
+  (`debugSpeculativePlanMisses`), and the normal `cancelBinStrips` reaps
+  the stale worker job. `_setScene` clears the field — a speculative
+  geometry is meaningless against a new scene.
+
+## The scale-quantization mirroring contract
+
+The anticipated scale must be the one the settle will pass, so
+`_speculateStripPlan` mirrors the viewer's `_renderScale` rule EXACTLY:
+
+```dart
+final live = math.max(1.0, transformScale.value);
+final anticipated =
+    (live - widget.scale).abs() > 0.1 * widget.scale ? live : widget.scale;
+```
+
+Both sites carry cross-referencing comments (pdf_viewer.dart's settle,
+pdf_page_view.dart's speculation) — if the rule drifts, every speculation
+becomes a geometry miss and silently re-pays the full bin wait. The
+speculation also mirrors `_renderNow`'s staleness gate (skip when the
+effective ratio is within 1% of `_rasteredRatio`): the settle wouldn't
+re-raster the full page, and at deep zoom the pixel-capped ratio stops
+moving, so speculation never competes with the detail patch's region bins.
+`_desiredRatio`/`_effectiveRatio` grew `...At(double scale)` variants for
+this; the zero-arg forms delegate.
+
+## In-flight preemption, bin kind only
+
+`_IsolateRenderWorker._cancelKind` (render_worker_isolate.dart) used to
+drop only QUEUED requests. For the BIN kind it now also sends the
+cancel-port signal when `_inFlight` matches (kind, page, priority), so a
+superseded settle — or a speculative bin overtaken by a newer geometry —
+frees the worker mid-walk instead of running a stale ~300 ms bin to
+completion first (this also improves pan-at-deep-zoom, where a superseded
+region bin used to finish before the fresh one started). **Record cancels
+stay queued-only**: `PdfCachingRenderWorker` dedups in-flight records
+across callers, so preempting one would null a waiter shared with a caller
+that still wants it; strip plans are never shared (the caching wrapper
+passes bins straight through), so bins are safe to preempt. The signal
+keeps the benign pre-existing race the priority-preemption path already
+accepts: it can land after the job completed and cancel the NEXT job
+instead, whose caller then falls back to a local render/bin.
+
+## Benchmark (strip_worker_latency_test, Impeller/Metal, M-series)
+
+New (P) primed path: issue `binStrips`, wait out the 200 ms settle
+debounce the viewer gives for free, then measure the residual await + the
+identical build/toImage/readback — production speculation, modelled
+honestly.
+
+```
+strip settle latency (backend=impeller, mean ms/step over 3 passes x 5 steps, target 2382x1684 fit)
+page                         path          binWait    build  toImage  readback  uiBlock    total
+WAT_L0001_S.pdf#0            b-retained          -     50.0        -     568.2        -    618.2
+ly9-far-cad.pdf#4            L-local-bin       0.0    342.6     56.2     530.6    340.7    929.4
+ly9-far-cad.pdf#4            W-worker        371.1     32.8     23.7     441.8     40.8    869.4
+ly9-far-cad.pdf#4            P-primed         24.6     21.9     21.8     424.7     35.4    492.9
+INVOICE-1000664832.pdf#0     b-retained          -     10.0        -      96.2        -    106.2
+
+worker bin wait per settle by pass (worker-side caches warming):
+ly9-far-cad.pdf#4            binWait/settle by pass: 489.8  380.6  377.7  354.9  (pass 0 = cold)
+```
+
+The perceived settle wait (binWait + build + toImage) drops 448 → 68 ms.
+One honesty caveat: in the harness each P bin runs the SAME geometry the
+W bin just binned, so the process-global glyph/shape strip caches are
+maximally warm and the primed bin itself takes ~225 ms (fully covered by
+the 200 ms sleep bar 25 ms). In production the speculative bin is the
+*first* at its geometry (~355–380 ms warm here), so the expected residual
+is ~155–180 ms on this machine — still less than half of W, and the
+readback (which dwarfs everything and is unaffected) overlaps other work
+in the real viewer rather than being serially timed.
+
+## Tests
+
+- strip_plan_device_test: speculative hit (settle consumes the plan,
+  `debugSpeculativePlanHits == 1`, no mismatches) and miss (different
+  settle scale → miss counted, fresh plan still feeds the device).
+- render_worker_strips_test: `cancelBinStrips` preempts a matching
+  in-flight bin — needs the new `buildDenseVectorPdf` (4000 rects) so the
+  bin reliably spans the interpreter's every-512-ops yield points and the
+  cancel deterministically lands mid-walk; a tiny page can finish before
+  ever yielding and would return a plan instead of null.
+- Web worker compile gate re-run (`dart run dart_pdf_editor:build_web_worker`)
+  — the touched render_worker.dart stays Flutter-free.
+
+## Follow-ups
+
+- Region/detail-patch speculation: pans at deep zoom settle through
+  `stripRegionGeometry` bins that could be speculated from the live
+  translation the same way (the in-flight preemption half is already in).
+- The region image re-decode (`_detailPictureFromWorker`) and the region
+  strip bin are two separate worker round-trips for one settle; combining
+  them into one request would halve the deep-zoom patch latency.
+- The primed path's readback still dominates the harness total; the real
+  viewer never reads the full page back synchronously, so a
+  display-pipeline-shaped benchmark would show the win even larger.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -5,7 +5,8 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:pdf_document/pdf_document.dart';
-import 'package:pdf_graphics/pdf_graphics.dart' show PdfRenderCommand;
+import 'package:pdf_graphics/pdf_graphics.dart'
+    show PdfMatrix, PdfRenderCommand;
 
 import 'perf_log.dart';
 import 'preview_cache.dart';
@@ -47,6 +48,7 @@ class PdfPageView extends StatefulWidget {
     this.trustContentStamp = false,
     this.destructiveStamp = 0,
     this.renderWorker,
+    this.transformScale,
   });
 
   final PdfPage page;
@@ -63,6 +65,15 @@ class PdfPageView extends StatefulWidget {
   /// thread. Image-bearing pages and the null fallback render locally. Must
   /// be a worker started over the same bytes [page] belongs to.
   final PdfRenderWorker? renderWorker;
+
+  /// The viewer's LIVE zoom scale (the InteractiveViewer matrix's scale on
+  /// every change), as opposed to [scale], which the viewer only updates at
+  /// the debounced zoom settle. When set alongside [renderWorker], a dense
+  /// strip-routed page uses it to bin its strip plan speculatively while the
+  /// gesture quiesces: the settle then consumes the already-in-flight worker
+  /// plan instead of starting the ~290 ms bin from scratch. Null (the
+  /// default) disables speculation; settles behave exactly as before.
+  final ValueListenable<double>? transformScale;
 
   /// Shared low-res previews (see [PdfPagePreviewCache]): while this
   /// page's full render is pending - most visibly under [renderHold]
@@ -196,7 +207,11 @@ class PdfPageView extends StatefulWidget {
   /// lose, so no host knowledge is needed. (2) UI-thread cost: with a
   /// render worker attached the ~340 ms re-bin runs off-thread and the
   /// settle blocks the UI ~35 ms (measured, ly9-far-cad p4) - decode the
-  /// plan, create engine objects, replay the tape. Set false to restore
+  /// plan, create engine objects, replay the tape. With [transformScale]
+  /// wired (the viewer does), the bin is additionally requested
+  /// speculatively while the zoom gesture quiesces, so most of the worker's
+  /// bin wall time overlaps the viewer's own 200 ms settle debounce and the
+  /// settle only waits for the residual. Set false to restore
   /// the cached-picture zoom path for dense pages if a regression is ever
   /// suspected in the field.
   ///
@@ -218,6 +233,22 @@ class PdfPageView extends StatefulWidget {
   /// where `ui.ImageFilter.isShaderFilterSupported` is false, so strip
   /// router tests force the decision. Null (production) asks the engine.
   static bool? debugStripZoomReplayBackendOverride;
+
+  /// Settles that consumed a speculatively-binned worker strip plan (the
+  /// [transformScale]-driven pre-request matched the settle's geometry
+  /// exactly and resolved to a plan). Test telemetry, following the
+  /// [StripPdfDevice.totalPlanMismatches] pattern.
+  static int debugSpeculativePlanHits = 0;
+
+  /// Speculative worker strip plans that were dropped unconsumed (the
+  /// settle asked for a different geometry, a region bin superseded them,
+  /// or the scene changed) or resolved null when consumed.
+  static int debugSpeculativePlanMisses = 0;
+
+  static void debugResetSpeculativeStats() {
+    debugSpeculativePlanHits = 0;
+    debugSpeculativePlanMisses = 0;
+  }
 
   @override
   State<PdfPageView> createState() => _PdfPageViewState();
@@ -281,7 +312,27 @@ class _PdfPageViewState extends State<PdfPageView> {
     super.initState();
     widget.renderHold?.addListener(_onRenderHoldChanged);
     widget.previewCache?.addListener(_onPreviewCacheChanged);
+    widget.transformScale?.addListener(_onTransformScaleChanged);
     _refreshPreview();
+  }
+
+  /// How long the live transform must stay quiet before a speculative strip
+  /// bin fires. During active motion matrix events arrive every frame, so
+  /// this timer keeps resetting and nothing fires; once motion pauses 50 ms
+  /// we bin speculatively - 150 ms of the viewer's 200 ms settle debounce
+  /// then overlaps the ~290 ms worker bin. Firing on every tick instead
+  /// would cancel-churn the worker continuously for no benefit.
+  static const _speculateDebounce = Duration(milliseconds: 50);
+
+  Timer? _speculateTimer;
+
+  /// The in-flight/completed speculative worker bin (geometry + future) the
+  /// next full-page settle may consume. See [_speculateStripPlan].
+  _SpeculativeStripPlan? _speculativeStripPlan;
+
+  void _onTransformScaleChanged() {
+    _speculateTimer?.cancel();
+    _speculateTimer = Timer(_speculateDebounce, _speculateStripPlan);
   }
 
   void _onRenderHoldChanged() {
@@ -345,6 +396,10 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (!identical(oldWidget.renderScheduler, widget.renderScheduler)) {
       oldWidget.renderScheduler?.cancel(this);
       // the new scheduler picks this page up on its next _render
+    }
+    if (!identical(oldWidget.transformScale, widget.transformScale)) {
+      oldWidget.transformScale?.removeListener(_onTransformScaleChanged);
+      widget.transformScale?.addListener(_onTransformScaleChanged);
     }
     if (oldWidget.previewIndex != widget.previewIndex) {
       // The lazy list reused this State for a different page (it scrolled into
@@ -420,6 +475,11 @@ class _PdfPageViewState extends State<PdfPageView> {
   @override
   void dispose() {
     widget.renderHold?.removeListener(_onRenderHoldChanged);
+    widget.transformScale?.removeListener(_onTransformScaleChanged);
+    _speculateTimer?.cancel();
+    // any pending speculative bin is reaped by the cancelBinStrips below;
+    // its null result resolves into a future nobody awaits any more
+    _speculativeStripPlan = null;
     widget.renderScheduler?.cancel(this);
     // Scrolled out of the cache window: drop this page's queued worker request
     // so the worker's next slot serves a page still on screen (the abandoned
@@ -427,8 +487,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     // fallback). No-op if nothing is queued for it.
     widget.renderWorker
         ?.cancel(widget.previewIndex, priority: widget.renderPriority);
-    widget.renderWorker?.cancelBinStrips(widget.previewIndex,
-        priority: widget.renderPriority);
+    widget.renderWorker
+        ?.cancelBinStrips(widget.previewIndex, priority: widget.renderPriority);
     widget.previewCache?.removeListener(_onPreviewCacheChanged);
     _dropPicture();
     _image?.dispose();
@@ -458,6 +518,10 @@ class _PdfPageViewState extends State<PdfPageView> {
     _scene?.dispose();
     _scene = scene;
     _sceneFromWorker = scene != null && fromWorker;
+    // a speculative bin's geometry was computed against the previous scene;
+    // with the scene identity changed it is meaningless, so drop it (the
+    // next _workerStripPlan's cancelBinStrips reaps the worker-side job)
+    _speculativeStripPlan = null;
   }
 
   /// Whether [_scene] came from the render worker (see [_setScene]).
@@ -474,21 +538,28 @@ class _PdfPageViewState extends State<PdfPageView> {
   }
 
   /// The resolution the current zoom actually wants, uncapped.
-  double _desiredRatio() {
+  double _desiredRatio() => _desiredRatioAt(widget.scale);
+
+  /// [_desiredRatio] at an explicit [scale] instead of [PdfPageView.scale],
+  /// so speculation can price the scale a settle is ABOUT to apply.
+  double _desiredRatioAt(double scale) {
     final size = _renderPlan.pageSize(widget.page);
     final width = math.max(1.0, size.width);
     // pages display fit-width, so the raster must match the on-screen
     // width - a 612pt page across a wide window needs far more pixels
     // than its nominal point size
     final fitWidth = (_layoutWidth ?? width) / width;
-    return math.max(fitWidth * (_pixelRatio ?? 1.0) * widget.scale, 0.05);
+    return math.max(fitWidth * (_pixelRatio ?? 1.0) * scale, 0.05);
   }
 
-  double _effectiveRatio() {
+  double _effectiveRatio() => _effectiveRatioAt(widget.scale);
+
+  /// [_effectiveRatio] at an explicit [scale] (see [_desiredRatioAt]).
+  double _effectiveRatioAt(double scale) {
     final size = _renderPlan.pageSize(widget.page);
     final width = math.max(1.0, size.width);
     final height = math.max(1.0, size.height);
-    var ratio = _desiredRatio();
+    var ratio = _desiredRatioAt(scale);
     ratio = math.min(ratio, math.sqrt(_maxPixels / (width * height)));
     ratio = math.min(ratio, _maxDimension / math.max(width, height));
     return math.max(ratio, 0.05);
@@ -677,8 +748,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       _lastInterpretPath = 'worker';
       if (_retainScene(commands.length)) {
         // No images to decode, so this completes synchronously in practice.
-        final scene = await PdfRetainedScene.fromCommands(
-            widget.page, commands,
+        final scene = await PdfRetainedScene.fromCommands(widget.page, commands,
             plan: _renderPlan);
         if (_superseded(generation, pageIndex)) {
           scene.dispose();
@@ -1014,32 +1084,126 @@ class _PdfPageViewState extends State<PdfPageView> {
     return true;
   }
 
-  /// Asks the render worker to bin this page's strips for the exact device
-  /// geometry the strip replay is about to construct ([stripGeometry] /
-  /// [stripRegionGeometry] of [scene]), or null to bin locally: no worker /
-  /// worker declined, a locally-recorded scene (see [_setScene]'s
-  /// fromWorker), or a debug-delegate flag forcing local routing (the
-  /// worker isolate has its own statics and would bin the full routing,
-  /// desyncing flush ordinals).
-  ///
-  /// Any still-queued bin for this page is cancelled first, so a newer
-  /// settle/region supersedes an older one in the worker queue; the
-  /// cancelled caller's null resolves under a stale generation and is
-  /// discarded by its guard without falling back to a local bin.
-  Future<StripPlan?> _workerStripPlan(PdfRetainedScene scene,
-      {required double pixelRatio, Rect? region}) async {
-    if (!_sceneFromWorker) return null;
+  /// Whether worker strip binning may be asked for at all - shared by
+  /// [_workerStripPlan] and [_speculateStripPlan] so the two paths' guards
+  /// can't drift: a worker-recorded scene, a live worker, and no
+  /// debug-delegate flag forcing local routing (the worker isolate has its
+  /// own statics and would bin the full routing, desyncing flush ordinals).
+  bool get _workerBinningEligible {
+    if (!_sceneFromWorker) return false;
     final worker = widget.renderWorker;
-    if (worker == null || !worker.isActive) return null;
+    if (worker == null || !worker.isActive) return false;
     if (StripPdfDevice.debugDelegateAll ||
         StripPdfDevice.debugDelegateFills ||
         StripPdfDevice.debugDelegateStrokes ||
         StripPdfDevice.debugDelegateText) {
-      return null;
+      return false;
     }
+    return true;
+  }
+
+  /// Fired by [_speculateTimer] once the live transform has been quiet for
+  /// [_speculateDebounce]: pre-requests the worker strip plan for the
+  /// geometry the upcoming zoom settle will ask for, so the ~290 ms worker
+  /// bin overlaps the viewer's 200 ms settle debounce instead of starting
+  /// after it. [_workerStripPlan] consumes the stored future when the
+  /// settle's geometry matches exactly.
+  void _speculateStripPlan() {
+    final transformScale = widget.transformScale;
+    if (!mounted || transformScale == null || _renderPaused) return;
+    if (!PdfPageView.retainedZoomReplay) return;
+    final scene = _scene;
+    if (scene == null || !_stripReplayScene(scene)) return;
+    if (!_workerBinningEligible) return;
+    // Anticipate the scale the settle will pass: this mirrors the viewer's
+    // _renderScale quantization in _PdfViewerState._onTransformChanged
+    // (pdf_viewer.dart) EXACTLY and the two must stay in sync - a drift
+    // makes every speculation a geometry miss, silently re-paying the full
+    // bin wait the feature exists to avoid.
+    final live = math.max(1.0, transformScale.value);
+    final anticipated =
+        (live - widget.scale).abs() > 0.1 * widget.scale ? live : widget.scale;
+    final eff = _effectiveRatioAt(anticipated);
+    // Mirror _renderNow's staleness gate: when the settle won't re-raster
+    // the full page (resolution unchanged within 1%), don't bin for it.
+    // This also keeps speculation quiet at deep zoom, where the effective
+    // ratio is pixel-capped and stops moving - it must never compete with
+    // the detail patch's region bins.
+    if (_image != null &&
+        _rasteredRatio != null &&
+        (eff - _rasteredRatio!).abs() <= _rasteredRatio! * 0.01) {
+      return;
+    }
+    final geometry = scene.stripGeometry(pixelRatio: eff);
+    final pending = _speculativeStripPlan;
+    if (pending != null && pending.matches(geometry, eff)) return; // no churn
+    final worker = widget.renderWorker!;
+    // supersede any previous speculative bin (queued or in-flight)
+    worker.cancelBinStrips(widget.previewIndex,
+        priority: widget.renderPriority);
+    final m = geometry.pageToDevice;
+    _speculativeStripPlan = _SpeculativeStripPlan(
+      geometry,
+      eff,
+      worker.binStrips(
+        widget.previewIndex,
+        annotations: scene.plan.annotations,
+        pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+        deviceWidth: geometry.width,
+        deviceHeight: geometry.height,
+        pixelRatio: eff,
+        // the SAME priority as the settle's own bin, so speculation is
+        // never preempted by (nor preempts) equal-priority work
+        priority: widget.renderPriority,
+      ),
+    );
+  }
+
+  /// Asks the render worker to bin this page's strips for the exact device
+  /// geometry the strip replay is about to construct ([stripGeometry] /
+  /// [stripRegionGeometry] of [scene]), or null to bin locally: no worker /
+  /// worker declined, a locally-recorded scene (see [_setScene]'s
+  /// fromWorker), or a debug-delegate flag forcing local routing (see
+  /// [_workerBinningEligible]).
+  ///
+  /// A full-page call first checks [_speculativeStripPlan]: when the
+  /// transform-quiescence speculation already requested this EXACT geometry
+  /// (all six matrix coefficients, width, height, pixelRatio), the stored
+  /// future is consumed instead of starting a fresh bin - the worker has
+  /// been binning through the viewer's settle debounce, so only the
+  /// residual wait is paid.
+  ///
+  /// Otherwise any still-queued or in-flight bin for this page is cancelled
+  /// first, so a newer settle/region supersedes an older one in the worker
+  /// queue; the cancelled caller's null resolves under a stale generation
+  /// and is discarded by its guard without falling back to a local bin.
+  Future<StripPlan?> _workerStripPlan(PdfRetainedScene scene,
+      {required double pixelRatio, Rect? region}) async {
+    if (!_workerBinningEligible) return null;
+    final worker = widget.renderWorker!;
     final geometry = region == null
         ? scene.stripGeometry(pixelRatio: pixelRatio)
         : scene.stripRegionGeometry(region, pixelRatio: pixelRatio);
+    final speculative = _speculativeStripPlan;
+    if (speculative != null) {
+      _speculativeStripPlan = null;
+      if (region == null && speculative.matches(geometry, pixelRatio)) {
+        final plan = await speculative.plan;
+        if (plan != null) {
+          PdfPageView.debugSpeculativePlanHits++;
+          return plan;
+        }
+        // The speculative bin was cancelled/declined (a preemption, a
+        // worker death). Fall through to a fresh request - exactly today's
+        // semantics for a settle that finds no plan in flight.
+        PdfPageView.debugSpeculativePlanMisses++;
+      } else {
+        // Wrong geometry (or a region bin): the cancelBinStrips below
+        // reaps the stale speculative job; its stored future resolves null
+        // unobserved.
+        PdfPageView.debugSpeculativePlanMisses++;
+      }
+    }
     final m = geometry.pageToDevice;
     worker.cancelBinStrips(widget.previewIndex,
         priority: widget.renderPriority);
@@ -1166,5 +1330,35 @@ class _PdfPageViewState extends State<PdfPageView> {
         }),
       );
     });
+  }
+}
+
+/// A worker strip bin requested speculatively while the zoom gesture was
+/// quiescing (see `_PdfPageViewState._speculateStripPlan`): the exact device
+/// geometry it was binned for, and the in-flight/completed plan future the
+/// settle consumes when its geometry matches.
+class _SpeculativeStripPlan {
+  _SpeculativeStripPlan(this.geometry, this.pixelRatio, this.plan);
+
+  final ({PdfMatrix pageToDevice, int width, int height}) geometry;
+  final double pixelRatio;
+  final Future<StripPlan?> plan;
+
+  /// Exact match only - all six matrix coefficients, the pixel viewport,
+  /// and the ratio compare with `==` (the coefficients round-trip the wire
+  /// codec bit-exactly, so a matching settle really is the same geometry).
+  bool matches(({PdfMatrix pageToDevice, int width, int height}) other,
+      double otherPixelRatio) {
+    final a = geometry.pageToDevice;
+    final b = other.pageToDevice;
+    return pixelRatio == otherPixelRatio &&
+        geometry.width == other.width &&
+        geometry.height == other.height &&
+        a.a == b.a &&
+        a.b == b.b &&
+        a.c == b.c &&
+        a.d == b.d &&
+        a.e == b.e &&
+        a.f == b.f;
   }
 }

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1308,6 +1308,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       final zoomed = target > 1.01;
       setState(() {
         if (zoomed != _zoomed) _zoomed = zoomed;
+        // NOTE: this quantization rule (max(1, scale), 10% dead band) is
+        // mirrored by _PdfPageViewState._speculateStripPlan to anticipate
+        // the settle's scale while the gesture quiesces - keep the two in
+        // sync or every speculative strip bin becomes a geometry miss.
         if ((target - _renderScale).abs() > 0.1 * _renderScale) {
           _renderScale = target;
         }
@@ -4869,6 +4873,9 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         renderScheduler: widget.renderScheduler,
         previewCache: widget.previewCache,
         renderWorker: widget.renderWorker,
+        // the live matrix scale lets dense strip-routed pages bin their
+        // settle's strip plan speculatively while the gesture quiesces
+        transformScale: widget.transformScale,
         previewIndex: widget.index,
       ),
       if (annotationLayerController != null)

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -247,12 +247,16 @@ abstract class PdfRenderWorker {
       null;
 
   /// Drops any QUEUED (not yet started) [binStrips] request for [pageIndex]
-  /// at [priority], completing its future with null. Superseded settles
-  /// call this so the worker's next slot bins the geometry the user is
-  /// actually looking at instead of a stale one; the abandoning caller must
-  /// not fall back to a local bin for the superseded settle (PdfPageView's
-  /// generation guard takes care of that). In-flight preemption rides the
-  /// same cooperative cancellation as [cancel].
+  /// at [priority], completing its future with null - and, on the native
+  /// isolate backend, also preempts a matching IN-FLIGHT bin cooperatively
+  /// so the worker abandons the stale geometry mid-walk (its future resolves
+  /// null too). Superseded settles and overtaken speculative bins call this
+  /// so the worker bins the geometry the user is actually looking at instead
+  /// of a stale one; the abandoning caller must not fall back to a local bin
+  /// for the superseded settle (PdfPageView's generation guard takes care of
+  /// that). Unlike [cancel], the in-flight preemption is safe here because
+  /// strip plans are never shared between callers (the caching wrapper
+  /// passes bins straight through).
   void cancelBinStrips(int pageIndex, {int priority = 0}) {}
 
   /// Whether this worker actually offloads. False for the null fallback, so

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -109,8 +109,14 @@ class _IsolateRenderWorker extends PdfRenderWorker {
       int? commandLimit,
       PdfRect? imageDecodeRegion}) async {
     if (_disposed || _spawnFailed) return null;
-    final request = _PendingRequest.record(priority, _seq++, pageIndex,
-        annotations, imagePixelRatio, decodeImages, commandLimit,
+    final request = _PendingRequest.record(
+        priority,
+        _seq++,
+        pageIndex,
+        annotations,
+        imagePixelRatio,
+        decodeImages,
+        commandLimit,
         imageDecodeRegion);
     _queue.add(request);
     _pump();
@@ -134,8 +140,14 @@ class _IsolateRenderWorker extends PdfRenderWorker {
     int priority = 0,
   }) async {
     if (_disposed || _spawnFailed) return null;
-    final request = _PendingRequest.bin(priority, _seq++, pageIndex,
-        annotations, List.of(pageToDevice), deviceWidth, deviceHeight,
+    final request = _PendingRequest.bin(
+        priority,
+        _seq++,
+        pageIndex,
+        annotations,
+        List.of(pageToDevice),
+        deviceWidth,
+        deviceHeight,
         pixelRatio);
     _queue.add(request);
     _pump();
@@ -228,6 +240,20 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   /// their futures resolve to a local render/bin - the abandoning caller
   /// ignores that. Kinds cancel independently so a superseded zoom settle
   /// can't drop the page's pending record (or vice versa).
+  ///
+  /// For the BIN kind only, a matching IN-FLIGHT job is also preempted (the
+  /// cancel-port signal makes the worker abandon the stale bin mid-walk and
+  /// reply null; the abandoning caller ignores it), so a superseded settle -
+  /// or a speculative bin overtaken by a newer geometry - frees the worker
+  /// immediately instead of running to completion first. Record cancels
+  /// stay queued-only: [PdfCachingRenderWorker] dedups in-flight records
+  /// across callers, so preempting one would null a waiter shared with a
+  /// caller that still wants it.
+  ///
+  /// The in-flight signal carries a benign pre-existing race (the same one
+  /// the priority-preemption path in [_pump] accepts): it can land on the
+  /// worker after the job already completed and cancel the NEXT job instead,
+  /// whose caller then resolves null and falls back to a local render/bin.
   void _cancelKind(_RequestKind kind, int pageIndex, int priority) {
     if (_disposed) return;
     _queue.removeWhere((request) {
@@ -239,6 +265,14 @@ class _IsolateRenderWorker extends PdfRenderWorker {
       if (!request.completer.isCompleted) request.completer.complete(null);
       return true;
     });
+    final inFlight = _inFlight;
+    if (kind == _RequestKind.bin &&
+        inFlight != null &&
+        inFlight.kind == kind &&
+        inFlight.pageIndex == pageIndex &&
+        inFlight.priority == priority) {
+      _toCancelPort?.send(null);
+    }
   }
 
   @override
@@ -284,8 +318,14 @@ class _PendingRequest {
         deviceHeight = 0,
         binPixelRatio = 0;
 
-  _PendingRequest.bin(this.priority, this.seq, this.pageIndex,
-      this.annotations, this.pageToDevice, this.deviceWidth, this.deviceHeight,
+  _PendingRequest.bin(
+      this.priority,
+      this.seq,
+      this.pageIndex,
+      this.annotations,
+      this.pageToDevice,
+      this.deviceWidth,
+      this.deviceHeight,
       this.binPixelRatio)
       : kind = _RequestKind.bin,
         imagePixelRatio = null,

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -7,12 +7,17 @@
 //    truncation as the buffer the caller's scene holds);
 //  - the isolate queue's kind-scoped cancel (cancelBinStrips drops queued
 //    bins without touching queued records, and vice versa);
+//  - cancelBinStrips also preempts a matching IN-FLIGHT bin (the worker
+//    abandons it mid-walk and the future resolves null) - what lets a
+//    newer speculative/settle geometry supersede a running stale bin;
 //  - pool routing by the STATIC page index (worker-side command-cache
 //    affinity) for both binStrips and cancelBinStrips;
 //  - the caching wrapper passes bins straight through (plans are never
 //    cached - every settle has a fresh matrix);
 //  - the abstract default (which the stub and web backends inherit)
 //    declines with null.
+import 'dart:typed_data';
+
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -22,6 +27,43 @@ import 'package:pdf_graphics/raster.dart';
 import 'strip_zoom_router_test.dart' show buildVectorPdf;
 
 List<double> _coeffs(PdfMatrix m) => [m.a, m.b, m.c, m.d, m.e, m.f];
+
+/// A one-page PDF dense enough (thousands of interpreter ops) that a bin
+/// job reliably spans several of the worker's cooperative yield points, so
+/// an in-flight cancel deterministically lands mid-walk.
+Uint8List buildDenseVectorPdf({int rects = 4000}) {
+  final content = StringBuffer();
+  for (var i = 0; i < rects; i++) {
+    final x = (i * 7) % 550;
+    final y = (i * 13) % 730;
+    content.write('${(i % 10) / 10} 0 0 rg $x $y 8 6 re f ');
+  }
+  final body = content.toString();
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << >> >>',
+    '<< /Length ${body.length} >>\nstream\n$body\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
 
 void main() {
   testWidgets('isolate binStrips matches a local bin of the recorded buffer',
@@ -123,6 +165,38 @@ void main() {
       expect(await record2, isNull, reason: 'cancelled record resolves null');
       expect(await bin2, isNotNull,
           reason: 'the bin must survive a record cancel for the same page');
+    });
+  });
+
+  testWidgets('cancelBinStrips preempts a matching in-flight bin',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildDenseVectorPdf();
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+      // Warm up so the isolate is spawned and idle: the next binStrips is
+      // dispatched (in flight) synchronously, not parked in the queue.
+      expect(await worker.record(0), isNotNull);
+
+      Future<StripPlan?> bin() => worker.binStrips(0,
+          annotations: true,
+          pageToDevice: const [1, 0, 0, 1, 0, 0],
+          deviceWidth: 612,
+          deviceHeight: 792,
+          pixelRatio: 1);
+
+      final stale = bin(); // in flight on the worker now
+      worker.cancelBinStrips(0); // same (page, priority): preempt mid-walk
+      expect(
+          await stale.timeout(const Duration(seconds: 30)), isNull,
+          reason: 'the preempted in-flight bin must resolve null');
+
+      // The worker survives the preemption and serves the next identical
+      // request with a real plan.
+      final fresh = await bin().timeout(const Duration(seconds: 30));
+      expect(fresh, isNotNull,
+          reason: 'a fresh bin after the preemption must succeed');
+      expect(fresh!.batches, isNotEmpty);
     });
   });
 

--- a/packages/dart_pdf_editor/test/strip_plan_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_plan_device_test.dart
@@ -238,4 +238,125 @@ void main() {
         reason: 'the settle must consume a worker-binned plan');
     expect(StripPdfDevice.totalPlanMismatches, 0);
   });
+
+  // Speculative binning: while the gesture quiesces (the live transformScale
+  // stops moving for 50 ms), the page pre-requests the worker plan for the
+  // geometry the settle will ask for; the settle then consumes it instead of
+  // starting a fresh bin.
+  testWidgets('a zoom settle consumes the plan speculated while the gesture '
+      'quiesced', (tester) async {
+    PdfPageView.retainedZoomReplayMaxCommands = 0; // every page is "dense"
+    PdfPageView.stripZoomReplay = true;
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
+    PdfPageView.debugResetSpeculativeStats();
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+      PdfPageView.stripZoomReplay = true; // the default
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+      PdfPageView.debugResetSpeculativeStats();
+    });
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildVectorPdf();
+    final doc = PdfDocument.open(bytes);
+    final page = doc.page(0);
+    late PdfRenderWorker worker;
+    await tester.runAsync(() async {
+      worker = PdfRenderWorker.start(bytes);
+    });
+    addTearDown(worker.dispose);
+
+    final live = ValueNotifier<double>(1.0);
+    addTearDown(live.dispose);
+    Widget at(double scale, int settleGeneration) => Center(
+        child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+                page: page,
+                scale: scale,
+                settleGeneration: settleGeneration,
+                renderWorker: worker,
+                transformScale: live)));
+
+    await tester.pumpWidget(at(1, 0));
+    await router.settleRaster(tester, 612);
+
+    // The gesture moves to 3x, then quiesces past the 50 ms debounce: the
+    // page speculatively requests the worker bin for the settle's geometry.
+    live.value = 3.0;
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(PdfPageView.debugSpeculativePlanHits, 0);
+    expect(PdfPageView.debugSpeculativePlanMisses, 0);
+
+    // The viewer's settle: the same quantized scale, a bumped generation.
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(3, 1));
+    final zoomed = await router.settleRaster(tester, 612 * 3);
+    expect(zoomed.width, 612 * 3);
+    expect(PdfPageView.debugSpeculativePlanHits, 1,
+        reason: 'the settle must consume the speculative plan');
+    expect(PdfPageView.debugSpeculativePlanMisses, 0);
+    expect(StripPdfDevice.totalPlanPictures, greaterThan(0),
+        reason: 'the speculative plan must feed the strip device');
+    expect(StripPdfDevice.totalPlanMismatches, 0);
+  });
+
+  testWidgets('a settle at a different scale than speculated misses and '
+      'still renders from a fresh worker plan', (tester) async {
+    PdfPageView.retainedZoomReplayMaxCommands = 0; // every page is "dense"
+    PdfPageView.stripZoomReplay = true;
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
+    PdfPageView.debugResetSpeculativeStats();
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+      PdfPageView.stripZoomReplay = true; // the default
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+      PdfPageView.debugResetSpeculativeStats();
+    });
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildVectorPdf();
+    final doc = PdfDocument.open(bytes);
+    final page = doc.page(0);
+    late PdfRenderWorker worker;
+    await tester.runAsync(() async {
+      worker = PdfRenderWorker.start(bytes);
+    });
+    addTearDown(worker.dispose);
+
+    final live = ValueNotifier<double>(1.0);
+    addTearDown(live.dispose);
+    Widget at(double scale, int settleGeneration) => Center(
+        child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+                page: page,
+                scale: scale,
+                settleGeneration: settleGeneration,
+                renderWorker: worker,
+                transformScale: live)));
+
+    await tester.pumpWidget(at(1, 0));
+    await router.settleRaster(tester, 612);
+
+    // Speculate for 2x...
+    live.value = 2.0;
+    await tester.pump(const Duration(milliseconds: 60));
+
+    // ...but settle at 3x: wrong geometry, so the speculative plan is
+    // dropped (a miss) and a fresh request serves the settle - output is
+    // still a plan-fed strip raster at the right size.
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(3, 1));
+    final zoomed = await router.settleRaster(tester, 612 * 3);
+    expect(zoomed.width, 612 * 3);
+    expect(PdfPageView.debugSpeculativePlanHits, 0);
+    expect(PdfPageView.debugSpeculativePlanMisses, 1,
+        reason: 'the mismatched speculation must be counted');
+    expect(StripPdfDevice.totalPlanPictures, greaterThan(0),
+        reason: 'a fresh worker plan must still land');
+    expect(StripPdfDevice.totalPlanMismatches, 0);
+  });
 }

--- a/packages/dart_pdf_editor/test/strip_worker_latency_test.dart
+++ b/packages/dart_pdf_editor/test/strip_worker_latency_test.dart
@@ -9,7 +9,13 @@
 //   (W) worker-plan - worker.binStrips(...) off-thread, then
 //                     scene.replayStrips(ratio, stripPlan:): the UI thread
 //                     only decodes the plan, creates engine objects, and
-//                     replays the tape.
+//                     replays the tape;
+//   (P) primed      - worker.binStrips(...) issued 200 ms BEFORE the settle
+//                     is measured (the debounce the viewer gives for free -
+//                     PdfPageView's transformScale speculation), then the
+//                     RESIDUAL wait of that same future + the identical
+//                     build/toImage/readback. Models production speculation
+//                     honestly: the worker bins while the gesture settles.
 //
 // Reported per path: total settle latency (bin/plan wait + build + toImage
 // + readback) and the UI-THREAD BLOCKING share - the synchronous sections
@@ -211,6 +217,7 @@ void main() {
 
         final local = _PathSample();
         final workerPlan = _PathSample();
+        final primed = _PathSample();
         final perPassBinWait = List<double>.filled(passes + 1, 0);
 
         for (var pass = 0; pass <= passes; pass++) {
@@ -280,10 +287,57 @@ void main() {
                   readback: readbackW,
                   uiBlock: uiBlockW);
             }
+
+            // (P) primed: issue the bin, then wait out the 200 ms settle
+            // debounce the viewer gives for free (the speculative bin fires
+            // ~50 ms into it; being generous to neither side, the full
+            // debounce is modelled). Only the residual await is the settle's
+            // perceived bin wait.
+            StripPdfDevice.resetStats();
+            final decodeP0 = raster.decodeStripPlanMicros;
+            final primedFuture = worker.binStrips(pageIndex,
+                annotations: true,
+                pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+                deviceWidth: geometry.width,
+                deviceHeight: geometry.height,
+                pixelRatio: ratio);
+            await Future<void>.delayed(const Duration(milliseconds: 200));
+            t = Stopwatch()..start();
+            final primedPlan = await primedFuture;
+            final planWaitP = t.elapsedMicroseconds / 1000.0;
+            expect(primedPlan, isNotNull,
+                reason: '$label must bin off-thread (primed)');
+            t = Stopwatch()..start();
+            final primedPicture = await scene.replayStrips(
+                pixelRatio: ratio, stripPlan: primedPlan);
+            final buildP = t.elapsedMicroseconds / 1000.0;
+            expect(StripPdfDevice.totalPlanMismatches, 0);
+            expect(StripPdfDevice.totalPlanPictures, 1,
+                reason: 'the primed plan must actually be consumed');
+            final uiBlockP = (StripPdfDevice.totalRouteMicros +
+                    StripPdfDevice.totalReplayMicros +
+                    (raster.decodeStripPlanMicros - decodeP0)) /
+                1000.0;
+            final (imageP, rasterP, readbackP) =
+                await _timeRaster(primedPicture, w, h);
+            primedPicture.dispose();
+            imageP.dispose();
+            if (record) {
+              primed.add(
+                  planWait: planWaitP,
+                  build: buildP,
+                  rasterize: rasterP,
+                  readback: readbackP,
+                  uiBlock: uiBlockP);
+            }
           }
         }
 
-        for (final (key, s) in [('L-local-bin', local), ('W-worker', workerPlan)]) {
+        for (final (key, s) in [
+          ('L-local-bin', local),
+          ('W-worker', workerPlan),
+          ('P-primed', primed),
+        ]) {
           rows.add('${label.padRight(28).substring(0, 28)} '
               '${key.padRight(12)} '
               '${s.meanPlanWait.toStringAsFixed(1).padLeft(8)} '


### PR DESCRIPTION
Follow-up to #211 (worker-isolate strip binning). A production zoom settle on a dense CAD page was still dominated by *waiting* for the worker bin (~290 ms typical on ly9 p4's 98.9k commands). This overlaps that wait with the viewer's own 200 ms settle debounce, and lets a superseded bin be preempted mid-walk instead of running to completion.

## What changed

- **Speculative binning**: `PdfPageView` gains `transformScale` (a `ValueListenable<double>` fed the live InteractiveViewer scale; null keeps the feature inert). Each change restarts a 50 ms one-shot; when motion pauses, the page speculatively issues `binStrips` with exactly the settle's geometry/arguments, so ~150 ms of the viewer's debounce overlaps the bin. The settle consumes the stored plan on an exact geometry match (`debugSpeculativePlanHits`/`Misses`); any mismatch falls through to the existing cancel+request path.
- **Scale-quantization mirroring contract**: the speculation mirrors `_PdfViewerState`'s `_renderScale` rule and `_renderNow`'s 1% staleness gate exactly (cross-referencing comments at both sites) — drift would silently turn every speculation into a miss.
- **In-flight bin preemption**: `_IsolateRenderWorker._cancelKind` now sends the cancel-port signal for a matching in-flight BIN job, freeing the worker mid-walk. Record cancels stay queued-only because `PdfCachingRenderWorker` dedups in-flight records across callers; strip plans are never shared, so bins are safe to preempt. Also improves pan-at-deep-zoom (superseded region bins no longer run to completion first).

## Benchmark (strip_worker_latency_test, Impeller/Metal, M-series)

New (P) primed path models production speculation: issue `binStrips`, wait out the 200 ms debounce the viewer gives for free, then measure the residual.

| page | path | binWait | build | toImage | readback | total |
|---|---|---|---|---|---|---|
| ly9-far-cad.pdf#4 | L-local-bin | 0.0 | 342.6 | 56.2 | 530.6 | 929.4 |
| ly9-far-cad.pdf#4 | W-worker | 371.1 | 32.8 | 23.7 | 441.8 | 869.4 |
| ly9-far-cad.pdf#4 | P-primed | 24.6 | 21.9 | 21.8 | 424.7 | 492.9 |

Perceived settle wait (binWait + build + toImage) drops **448 → 68 ms**. Honesty caveat (in the dev-log): the harness's primed bin re-bins a just-binned geometry with maximally warm caches; in production the expected residual is ~155–180 ms on this machine — still under half of W — and the readback that dwarfs the totals is harness-only.

## Tests

- `strip_plan_device_test`: speculative hit (settle consumes the plan, no misses) and miss (different settle scale → miss counted, fresh plan still feeds the device).
- `render_worker_strips_test`: `cancelBinStrips` preempts a matching in-flight bin, using the new `buildDenseVectorPdf` (4000 rects) so the bin reliably spans the interpreter's yield points.
- `fvm dart analyze` clean; pdf_graphics `strip_plan_test` 10/10; `strip_zoom_router_test` green; web worker compile gate (`dart run dart_pdf_editor:build_web_worker`) passes.

Dev-log: `doc/dev-log/2026-07-11-strip-speculative-bin.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)