### PR TITLE
perf: reduce strip settle and worker replay latency

### DIFF
--- a/doc/dev-log/2026-07-11-strip-detail-and-preemption.md
+++ b/doc/dev-log/2026-07-11-strip-detail-and-preemption.md
@@ -1,0 +1,136 @@
+# 2026-07-11 — Deep-zoom combined jobs, first-present benchmark, record retry
+
+This session closes the first three remaining native strip-performance items:
+#219's display-shaped measurement, #214's combined region detail request, and
+#215's safe in-flight RECORD preemption.
+
+## Display-shaped settle measurement (#219)
+
+`strip_worker_latency_test.dart` remains the pixel-correctness harness: it
+calls `toImage` and then synchronously reads the whole raster back to RGBA.
+That last readback is useful for comparisons but is not part of the viewer's
+display path and dominated its reported totals.
+
+`strip_display_latency_test.dart` is the companion latency harness. It stops
+at the first `RawImage` frame containing the newly rasterized page, registers
+an `addTimingsCallback` for backends that expose `FrameTiming`, and never calls
+`toByteData`. On the Flutter test backend used here frame timings are not
+reported (the frame columns remain zero), so the pump wall time is retained as
+the portable first-present boundary. A one-pass Impeller run on
+`ly9-far-cad.pdf#4` (98.9k commands) produced:
+
+```
+path        binWait    build  toImage  present    first
+local           0.0    329.4     13.0      1.5    344.0
+worker        328.3     18.7     21.8      1.7    370.4
+primed          2.6     12.9     13.4      1.6     30.6
+```
+
+This matches the earlier inference: synchronous readback was obscuring the
+actual win. With the speculative plan warm, the display-shaped settle is about
+31 ms on this run rather than the ~493 ms readback-inclusive number.
+
+## One region-detail worker job (#214)
+
+Dense strip-routed detail patches previously had to choose between two partial
+paths: a region `record` supplied sharp image crops but replayed as the slow
+nested-picture path, while `binStrips` kept the fast flat strip path but reused
+the base scene's lower-resolution images. Issuing both independently would
+also serialize two queue waits on the single worker.
+
+The worker API now exposes `recordStripDetail`, returning `PdfStripDetail`:
+
+- `commands`: image pixels decoded/cropped for the visible PDF-space region;
+- `plan`: a `StripPlan` binned from those exact round-tripped commands and the
+  exact region device geometry.
+
+The native isolate sends the command and plan buffers as two
+`TransferableTypedData` payloads in one response. Pool routing uses the same
+static page affinity as ordinary strip bins; the full-page record cache passes
+the transient result through without retaining it. Unsupported backends
+inherit a null implementation and the page view falls back to its existing
+base-scene region bin.
+
+The worker's two-entry strip command LRU now keeps two views per page:
+
+- the original document-backed recording, needed to resolve and region-decode
+  image COS graphs;
+- the wire-round-tripped recording, needed for bit-exact ordinary strip plans.
+
+Keeping both avoids re-interpreting the page on every pan. A regression test
+caught why one view cannot serve both jobs: a detached wire command is correct
+for geometry replay but is not a safe source for a second COS image
+serialization.
+
+`PdfPageView` builds a transient retained scene from the combined commands and
+rasterizes the region through the matching plan. It therefore keeps painter
+order, strip-plan validation, and region-resolution images with one worker
+round trip.
+
+## Safe RECORD preemption (#215)
+
+The interpreter already yields cooperatively, so a higher-priority record can
+cancel a lower-priority in-flight walk. The remaining bug was policy:
+`PdfCachingRenderWorker` deduplicates concurrent records, so completing the
+interrupted backend request with null also completed every shared waiter with
+null.
+
+Priority preemption now marks an in-flight RECORD for retry. When its cancelled
+response arrives, the main-side worker queue requeues the same request behind
+the urgent page without completing its original future. The urgent page cuts
+in immediately, then every deduplicated waiter receives the retried record.
+The native isolate and Web Worker queues use the same policy.
+Explicit stale-page `cancel()` never sets the retry flag and keeps its previous
+queued-only semantics; superseded BIN/detail jobs remain disposable and are
+not retried.
+
+## Verification
+
+- Full workspace analyzer: clean.
+- Focused page-view/worker/preview/strip suite: 101 tests passed, including the
+  Ghent strip parity gate.
+- New combined-protocol tests verify the worker plan is byte-identical to a
+  local bin of the returned commands and that region image pixels ride in the
+  same response and rasterize successfully.
+- New preemption test uses two pages and two deduplicated low-priority waiters:
+  the urgent page completes first and both interrupted waiters later receive a
+  non-null record.
+- The display benchmark ran successfully against the local dense CAD corpus;
+  its missing-corpus path compiles and skips cleanly for normal CI machines.
+
+## #216 first pass: cheaper command-buffer decode
+
+The codec knows all collection lengths from the wire but grew the top-level
+command list, every path-segment list, and every glyph-placement list from
+empty. Those lists now start at their exact length (while remaining growable
+to preserve the public result's behavior), removing capacity reallocations on
+large CAD command streams.
+
+Large image payloads also no longer take an unconditional second copy during
+UI-isolate deserialization. Decoded RGBA planes and raw image streams of at
+least 1 MiB keep a `Uint8List.sublistView` of the transferred buffer. Small COS
+strings/streams still copy so a tiny value cannot pin a large buffer. The
+retained command list already owns the large payload for its lifetime, making
+the view the lower-memory representation as well as the faster one.
+
+`deserializeCommandsMicros` now exposes accumulated UI-side decode time to the
+performance probes, parallel to `decodeStripPlanMicros`. The codec suite covers
+large-payload zero-copy behavior, growable-list compatibility, and all existing
+round trips. The display harness measured 56.2 ms for the initial 98.9k-command
+decode on `ly9-far-cad.pdf#4` in the one-pass run above, confirming that this is
+still a material first-paint slice even after the allocation cleanup. This is a
+bounded first pass on #216; direct decode-to-picture and wire-level interning
+remain larger follow-ups that should be benchmarked before changing the format.
+
+## Next priority group
+
+The next native #216 increment is direct decode-to-picture / wire-level
+interning, which needs codec-level design and should be judged with the new
+first-present harness. Web parity (#217) follows; #218 depends on that web
+strip/device proof.
+Adaptive policy (#189) and OCR isolation (#93) are valuable but orthogonal to
+the now-measured zoom-settle critical path.
+
+One separate follow-up was filed as #220: make native/Web Worker cancellation
+request-ID-scoped so a late cancel for a completed job cannot abort the urgent
+job that followed it.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -1004,20 +1004,33 @@ class _PdfPageViewState extends State<PdfPageView> {
     ratio =
         math.min(ratio, _maxDimension / math.max(region.width, region.height));
 
-    // Strip-routed dense pages skip the worker's region record: replaying
-    // its picture is a nested-picture re-raster - the slow path strips
-    // exist to avoid - so they go straight to the strip region replay
-    // below (with a worker-binned plan when the scene is worker-backed).
-    // The region-resolution image re-decode the worker record offers is
-    // orthogonal and stays for canvas-routed pages.
+    // Dense strip-routed pages ask for one combined worker result: commands
+    // whose images were decoded for this region plus the StripPlan binned
+    // from those exact commands. That keeps the flat strip replay, restores
+    // region-resolution images, and pays one worker queue/transfer round trip
+    // instead of serial record + bin requests. Unsupported backends fall
+    // through to the retained base scene below.
     final heldScene = PdfPageView.retainedZoomReplay ? _scene : null;
     final stripDetail = heldScene != null && _stripReplayScene(heldScene);
+    final workerStripImage = stripDetail
+        ? await _detailStripImageFromWorker(
+            heldScene, region, ratio, widget.previewIndex, generation)
+        : null;
     final workerPicture = stripDetail
         ? null
         : await _detailPictureFromWorker(region, ratio, widget.previewIndex);
     if (!mounted || generation != _detailGeneration || _renderPaused) {
+      workerStripImage?.dispose();
       workerPicture?.dispose();
       return false;
+    }
+    if (workerStripImage != null) {
+      setState(() {
+        _detailImage?.dispose();
+        _detailImage = workerStripImage;
+        _detailFraction = fraction;
+      });
+      return true;
     }
     if (workerPicture != null) {
       final image =
@@ -1233,6 +1246,58 @@ class _PdfPageViewState extends State<PdfPageView> {
     _logImageStats(pageIndex, commands);
     return PdfPageRenderer.pictureFromCommandsWithPlan(
         widget.page, commands, _renderPlan);
+  }
+
+  Future<ui.Image?> _detailStripImageFromWorker(
+    PdfRetainedScene baseScene,
+    Rect rasterRegion,
+    double ratio,
+    int pageIndex,
+    int generation,
+  ) async {
+    if (!_workerBinningEligible) return null;
+    final worker = widget.renderWorker!;
+    final geometry =
+        baseScene.stripRegionGeometry(rasterRegion, pixelRatio: ratio);
+    final m = geometry.pageToDevice;
+    worker.cancelBinStrips(pageIndex, priority: widget.renderPriority);
+    final detail = await worker.recordStripDetail(
+      pageIndex,
+      annotations: baseScene.plan.annotations,
+      pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+      deviceWidth: geometry.width,
+      deviceHeight: geometry.height,
+      pixelRatio: ratio,
+      imageDecodeRegion: _pdfRegionForRasterRegion(rasterRegion),
+      priority: widget.renderPriority,
+    );
+    if (_abandoned(pageIndex) ||
+        generation != _detailGeneration ||
+        _renderPaused ||
+        detail == null) {
+      return null;
+    }
+    _logImageStats(pageIndex, detail.commands);
+    final scene = await PdfRetainedScene.fromCommands(
+      widget.page,
+      detail.commands,
+      plan: _renderPlan,
+    );
+    if (_abandoned(pageIndex) ||
+        generation != _detailGeneration ||
+        _renderPaused) {
+      scene.dispose();
+      return null;
+    }
+    try {
+      return await scene.rasterizeRegionStrips(
+        rasterRegion,
+        pixelRatio: ratio,
+        stripPlan: detail.plan,
+      );
+    } finally {
+      scene.dispose();
+    }
   }
 
   PdfRect _pdfRegionForRasterRegion(Rect region) {

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -71,6 +71,19 @@ int pdfRenderWorkerCacheBudgetBytes = defaultPdfRenderWorkerCacheBudgetBytes;
 /// guard covers native and pooled workers.
 Duration pdfRenderWorkerRecordTimeout = const Duration(seconds: 90);
 
+/// One combined deep-zoom worker result.
+///
+/// [commands] carry images decoded for the requested visible region and
+/// [plan] was binned from those exact commands and device geometry. The pair
+/// must be consumed together; using the plan with another command recording
+/// may trip the strip device's stale-plan guard.
+class PdfStripDetail {
+  const PdfStripDetail(this.commands, this.plan);
+
+  final List<PdfRenderCommand> commands;
+  final StripPlan plan;
+}
+
 /// Documents with at least this many pages use a [PdfPooledRenderWorker] via
 /// [startPdfRenderWorker]; shorter ones use a single worker because extra
 /// startup and memory usually cost more than the parallelism saves.
@@ -242,6 +255,32 @@ abstract class PdfRenderWorker {
     required int deviceWidth,
     required int deviceHeight,
     required double pixelRatio,
+    int priority = 0,
+  }) async =>
+      null;
+
+  /// Records a region-detail command buffer and bins that exact buffer for a
+  /// strip-routed deep-zoom patch in one worker job.
+  ///
+  /// A separate [record] followed by [binStrips] pays two queue/transfer
+  /// round trips and, because one platform worker serves jobs serially, the
+  /// two waits stack. This combined request decodes images for
+  /// [imageDecodeRegion] at [pixelRatio], bins the resulting commands for the
+  /// supplied device geometry, and returns both together. Replaying
+  /// [PdfStripDetail.commands] with [PdfStripDetail.plan] therefore preserves
+  /// painter order while giving the detail patch region-resolution images.
+  ///
+  /// The base implementation declines. Native workers override it; other
+  /// backends keep the existing base-scene strip fallback until they support
+  /// the combined protocol.
+  Future<PdfStripDetail?> recordStripDetail(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    required PdfRect imageDecodeRegion,
     int priority = 0,
   }) async =>
       null;
@@ -463,6 +502,28 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
       );
 
   @override
+  Future<PdfStripDetail?> recordStripDetail(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    required PdfRect imageDecodeRegion,
+    int priority = 0,
+  }) =>
+      _workers[_staticWorkerIndex(pageIndex)].recordStripDetail(
+        pageIndex,
+        annotations: annotations,
+        pageToDevice: pageToDevice,
+        deviceWidth: deviceWidth,
+        deviceHeight: deviceHeight,
+        pixelRatio: pixelRatio,
+        imageDecodeRegion: imageDecodeRegion,
+        priority: priority,
+      );
+
+  @override
   void cancelBinStrips(int pageIndex, {int priority = 0}) =>
       _workers[_staticWorkerIndex(pageIndex)]
           .cancelBinStrips(pageIndex, priority: priority);
@@ -671,6 +732,31 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
         deviceWidth: deviceWidth,
         deviceHeight: deviceHeight,
         pixelRatio: pixelRatio,
+        priority: priority,
+      );
+
+  /// Pure passthrough: region details are transient and geometry-specific,
+  /// like strip plans, so retaining them in the full-page record LRU would
+  /// evict reusable page buffers for data that cannot be reused.
+  @override
+  Future<PdfStripDetail?> recordStripDetail(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    required PdfRect imageDecodeRegion,
+    int priority = 0,
+  }) =>
+      _inner.recordStripDetail(
+        pageIndex,
+        annotations: annotations,
+        pageToDevice: pageToDevice,
+        deviceWidth: deviceWidth,
+        deviceHeight: deviceHeight,
+        pixelRatio: pixelRatio,
+        imageDecodeRegion: imageDecodeRegion,
         priority: priority,
       );
 

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -69,14 +69,37 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         handshake.complete(message);
         return;
       }
-      // [int id, TransferableTypedData? data] - null means "render locally".
+      // [int id, TransferableTypedData? data, ...] - null means "render
+      // locally". Combined strip-detail responses carry command and plan
+      // buffers as two separately transferable payloads.
       final response = message as List<Object?>;
       final id = response[0] as int;
       final request = _inFlight;
       if (request == null || request.id != id) return; // stale (disposed)
       _inFlight = null;
-      final data = response[1] as TransferableTypedData?;
-      request.completer.complete(data?.materialize().asUint8List());
+      final first = response[1] as TransferableTypedData?;
+      if (first == null && request.requeueAfterPreemption && !_disposed) {
+        // A higher-priority page cut in while this RECORD was interpreting.
+        // Keep its original future alive and put the work back behind the
+        // urgent request. PdfCachingRenderWorker may have several callers
+        // sharing that future; completing null here would make every waiter
+        // lose the record even though only its worker time slice was
+        // preempted. Explicit cancel() never sets this flag and still drops a
+        // stale queued record immediately.
+        request
+          ..requeueAfterPreemption = false
+          ..id = -1;
+        _queue.add(request);
+        _pump();
+        return;
+      }
+      request.completer.complete(first == null
+          ? null
+          : [
+              first.materialize().asUint8List(),
+              for (final data in response.skip(2).cast<TransferableTypedData>())
+                data.materialize().asUint8List(),
+            ]);
       _pump();
     });
     final isolate = await Isolate.spawn(
@@ -120,10 +143,10 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         imageDecodeRegion);
     _queue.add(request);
     _pump();
-    final bytes = await request.completer.future;
-    if (bytes == null) return null;
+    final buffers = await request.completer.future;
+    if (buffers == null) return null;
     try {
-      return deserializeCommands(bytes);
+      return deserializeCommands(buffers.single);
     } catch (_) {
       return null; // corrupt buffer → render locally rather than crash
     }
@@ -151,12 +174,49 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         pixelRatio);
     _queue.add(request);
     _pump();
-    final bytes = await request.completer.future;
-    if (bytes == null) return null;
+    final buffers = await request.completer.future;
+    if (buffers == null) return null;
     try {
-      return decodeStripPlan(bytes);
+      return decodeStripPlan(buffers.single);
     } catch (_) {
       return null; // corrupt plan → bin locally rather than crash
+    }
+  }
+
+  @override
+  Future<PdfStripDetail?> recordStripDetail(
+    int pageIndex, {
+    required bool annotations,
+    required List<double> pageToDevice,
+    required int deviceWidth,
+    required int deviceHeight,
+    required double pixelRatio,
+    required PdfRect imageDecodeRegion,
+    int priority = 0,
+  }) async {
+    if (_disposed || _spawnFailed) return null;
+    final request = _PendingRequest.detail(
+      priority,
+      _seq++,
+      pageIndex,
+      annotations,
+      List.of(pageToDevice),
+      deviceWidth,
+      deviceHeight,
+      pixelRatio,
+      imageDecodeRegion,
+    );
+    _queue.add(request);
+    _pump();
+    final buffers = await request.completer.future;
+    if (buffers == null || buffers.length != 2) return null;
+    try {
+      return PdfStripDetail(
+        deserializeCommands(buffers[0]),
+        decodeStripPlan(buffers[1]),
+      );
+    } catch (_) {
+      return null;
     }
   }
 
@@ -185,6 +245,9 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         }
       }
       if (_queue[bestQueued].priority < _inFlight!.priority) {
+        if (_inFlight!.kind == _RequestKind.record) {
+          _inFlight!.requeueAfterPreemption = true;
+        }
         _toCancelPort?.send(null);
       }
       return;
@@ -214,7 +277,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         request.imageDecodeRegion?.right,
         request.imageDecodeRegion?.top,
       ]);
-    } else {
+    } else if (request.kind == _RequestKind.bin) {
       port.send([
         'bin',
         request.id,
@@ -225,6 +288,21 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         request.deviceHeight,
         request.binPixelRatio,
       ]);
+    } else {
+      port.send([
+        'detail',
+        request.id,
+        request.pageIndex,
+        request.annotations,
+        request.pageToDevice,
+        request.deviceWidth,
+        request.deviceHeight,
+        request.binPixelRatio,
+        request.imageDecodeRegion!.left,
+        request.imageDecodeRegion!.bottom,
+        request.imageDecodeRegion!.right,
+        request.imageDecodeRegion!.top,
+      ]);
     }
   }
 
@@ -233,8 +311,10 @@ class _IsolateRenderWorker extends PdfRenderWorker {
       _cancelKind(_RequestKind.record, pageIndex, priority);
 
   @override
-  void cancelBinStrips(int pageIndex, {int priority = 0}) =>
-      _cancelKind(_RequestKind.bin, pageIndex, priority);
+  void cancelBinStrips(int pageIndex, {int priority = 0}) {
+    _cancelKind(_RequestKind.bin, pageIndex, priority);
+    _cancelKind(_RequestKind.detail, pageIndex, priority);
+  }
 
   /// Drops matching QUEUED requests of one [kind]. Completing with null makes
   /// their futures resolve to a local render/bin - the abandoning caller
@@ -299,7 +379,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   }
 }
 
-enum _RequestKind { record, bin }
+enum _RequestKind { record, bin, detail }
 
 /// One queued request (a page record or a strip bin) and its pending result.
 class _PendingRequest {
@@ -333,6 +413,21 @@ class _PendingRequest {
         commandLimit = null,
         imageDecodeRegion = null;
 
+  _PendingRequest.detail(
+      this.priority,
+      this.seq,
+      this.pageIndex,
+      this.annotations,
+      this.pageToDevice,
+      this.deviceWidth,
+      this.deviceHeight,
+      this.binPixelRatio,
+      this.imageDecodeRegion)
+      : kind = _RequestKind.detail,
+        imagePixelRatio = null,
+        decodeImages = true,
+        commandLimit = null;
+
   final _RequestKind kind;
   final int priority;
   final int seq;
@@ -351,7 +446,8 @@ class _PendingRequest {
   final int deviceHeight;
   final double binPixelRatio;
 
-  final completer = Completer<Uint8List?>();
+  final completer = Completer<List<Uint8List>?>();
+  bool requeueAfterPreemption = false;
   int id = -1;
 }
 
@@ -397,6 +493,7 @@ void _workerMain(_WorkerInit init) {
     final token = PdfCancellationToken();
     activeToken = token;
     Uint8List? buffer;
+    Uint8List? detailPlanBuffer;
     try {
       if (document != null) {
         if (kind == 'bin') {
@@ -410,6 +507,22 @@ void _workerMain(_WorkerInit init) {
               request[6] as int,
               request[7] as double,
               token);
+        } else if (kind == 'detail') {
+          final result = await _recordStripDetailAsync(
+            document,
+            binCommands,
+            pageIndex,
+            annotations,
+            (request[4] as List<Object?>).cast<double>(),
+            request[5] as int,
+            request[6] as int,
+            request[7] as double,
+            PdfRect(request[8] as double, request[9] as double,
+                request[10] as double, request[11] as double),
+            token,
+          );
+          buffer = result?.$1;
+          detailPlanBuffer = result?.$2;
         } else {
           final imagePixelRatio = request[4] as double?;
           final decodeImages = request[5] as bool;
@@ -438,10 +551,20 @@ void _workerMain(_WorkerInit init) {
       buffer = null; // any failure → caller renders this page locally
     }
     activeToken = null;
-    init.reply.send([
-      id,
-      buffer == null ? null : TransferableTypedData.fromList([buffer]),
-    ]);
+    if (buffer == null) {
+      init.reply.send([id, null]);
+    } else if (detailPlanBuffer != null) {
+      init.reply.send([
+        id,
+        TransferableTypedData.fromList([buffer]),
+        TransferableTypedData.fromList([detailPlanBuffer]),
+      ]);
+    } else {
+      init.reply.send([
+        id,
+        TransferableTypedData.fromList([buffer])
+      ]);
+    }
   });
 }
 
@@ -502,6 +625,52 @@ Future<Uint8List?> _binStripsAsync(
   return encodeStripPlan(binner.finish());
 }
 
+/// Produces the two halves of a deep-zoom detail patch in one queued worker
+/// job. The cached weightless recording avoids another content-stream parse
+/// after the page's first strip settle; only the region image decode and the
+/// cancellable bin replay repeat as the viewport moves.
+Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
+  PdfDocument document,
+  _BinCommandCache cache,
+  int pageIndex,
+  bool annotations,
+  List<double> matrix,
+  int deviceWidth,
+  int deviceHeight,
+  double pixelRatio,
+  PdfRect imageDecodeRegion,
+  PdfCancellationToken token,
+) async {
+  final sourceCommands =
+      await cache.sourceCommandsFor(document, pageIndex, annotations, token);
+  if (sourceCommands == null) return null;
+  if (token.cancelled) throw const PdfCancelledException();
+
+  final commandBuffer = serializeCommands(
+    sourceCommands,
+    cos: document.cos,
+    decodeImages: true,
+    maxImagePixelRatio: pixelRatio,
+    imageDecodeRegion: imageDecodeRegion,
+  );
+  if (commandBuffer == null) return null;
+  if (token.cancelled) throw const PdfCancelledException();
+
+  // Bin the exact round-tripped commands the UI receives. Region image
+  // cropping can retarget image transforms, so planning from baseCommands
+  // would make the pair structurally inconsistent.
+  final commands = deserializeCommands(commandBuffer);
+  final binner = StripPlanBinner(
+    pageToDevice: PdfMatrix(
+        matrix[0], matrix[1], matrix[2], matrix[3], matrix[4], matrix[5]),
+    deviceWidth: deviceWidth,
+    deviceHeight: deviceHeight,
+    pixelRatio: pixelRatio,
+  );
+  await binner.bin(commands, cancellation: token);
+  return (commandBuffer, encodeStripPlan(binner.finish()));
+}
+
 /// Tiny per-worker LRU of the command lists strip bins replay, keyed
 /// (pageIndex, annotations). A zoom session hammers one page with a fresh
 /// geometry per settle, so 2 entries is plenty - and keeping the SAME list
@@ -518,11 +687,25 @@ Future<Uint8List?> _binStripsAsync(
 /// [PdfRenderWorker.record] declines, so their scenes were locally recorded
 /// and never ask for worker plans anyway.
 class _BinCommandCache {
-  final _entries = <(int, bool), List<PdfRenderCommand>>{};
+  final _entries = <(int, bool), _BinCommandEntry>{};
   static const int _capacity = 2;
 
   Future<List<PdfRenderCommand>?> commandsFor(PdfDocument document,
-      int pageIndex, bool annotations, PdfCancellationToken token) async {
+          int pageIndex, bool annotations, PdfCancellationToken token) async =>
+      (await _entryFor(document, pageIndex, annotations, token))?.wireCommands;
+
+  /// Original document-backed commands for a fresh serialization that must
+  /// resolve/decode image COS streams. The wire-round-tripped commands used by
+  /// [commandsFor] deliberately detach that object graph; feeding those back
+  /// to [serializeCommands] works for vector geometry but can no longer safely
+  /// resolve every image dependency.
+  Future<List<PdfRenderCommand>?> sourceCommandsFor(PdfDocument document,
+          int pageIndex, bool annotations, PdfCancellationToken token) async =>
+      (await _entryFor(document, pageIndex, annotations, token))
+          ?.sourceCommands;
+
+  Future<_BinCommandEntry?> _entryFor(PdfDocument document, int pageIndex,
+      bool annotations, PdfCancellationToken token) async {
     final key = (pageIndex, annotations);
     final hit = _entries.remove(key);
     if (hit != null) {
@@ -540,11 +723,21 @@ class _BinCommandCache {
     final buffer = serializeCommands(recorder.commands,
         cos: document.cos, decodeImages: false, imagePlaceholders: true);
     if (buffer == null) return null;
-    final commands = deserializeCommands(buffer);
-    _entries[key] = commands;
+    final entry = _BinCommandEntry(
+      recorder.commands,
+      deserializeCommands(buffer),
+    );
+    _entries[key] = entry;
     while (_entries.length > _capacity) {
       _entries.remove(_entries.keys.first);
     }
-    return commands;
+    return entry;
   }
+}
+
+class _BinCommandEntry {
+  const _BinCommandEntry(this.sourceCommands, this.wireCommands);
+
+  final List<PdfRenderCommand> sourceCommands;
+  final List<PdfRenderCommand> wireCommands;
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -176,6 +176,15 @@ class _WebRenderWorker extends PdfRenderWorker {
     _wlog('result page=${request.pageIndex} '
         '${bytes == null ? 'declined (null) → local' : '${bytes.length}B → worker'}'
         '${err == null ? '' : '\n  worker error: $err'}');
+    if (bytes == null && request.requeueAfterPreemption && !_disposed) {
+      request
+        ..requeueAfterPreemption = false
+        ..id = -1;
+      _queue.add(request);
+      _wlog('requeued preempted shared record page=${request.pageIndex}');
+      _pump();
+      return;
+    }
     request.completer.complete(bytes);
     _pump();
   }
@@ -230,6 +239,7 @@ class _WebRenderWorker extends PdfRenderWorker {
         }
       }
       if (_queue[bestQueued].priority < _inFlight!.priority) {
+        _inFlight!.requeueAfterPreemption = true;
         worker.postMessage(JSObject()..setProperty('kind'.toJS, 'cancel'.toJS));
       }
       return;
@@ -376,6 +386,7 @@ class _WebPending {
   final int? commandLimit;
   final PdfRect? imageDecodeRegion;
   final completer = Completer<Uint8List?>();
+  bool requeueAfterPreemption = false;
   int id = -1;
 }
 

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -17,6 +17,7 @@
 //  - the abstract default (which the stub and web backends inherit)
 //    declines with null.
 import 'dart:typed_data';
+import 'dart:ui' show Rect;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,6 +25,7 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_graphics/raster.dart';
 
+import 'render_seam_test.dart' show buildStripsPdf;
 import 'strip_zoom_router_test.dart' show buildVectorPdf;
 
 List<double> _coeffs(PdfMatrix m) => [m.a, m.b, m.c, m.d, m.e, m.f];
@@ -65,7 +67,133 @@ Uint8List buildDenseVectorPdf({int rects = 4000}) {
   return Uint8List.fromList(buffer.toString().codeUnits);
 }
 
+Uint8List _buildTwoPageDenseVectorPdf({int rects = 8000}) {
+  final dense = StringBuffer();
+  for (var i = 0; i < rects; i++) {
+    dense.write('${(i % 10) / 10} 0 0 rg '
+        '${(i * 7) % 550} ${(i * 13) % 730} 8 6 re f ');
+  }
+  const urgent = '0 0 1 rg 20 20 100 100 re f';
+  final body = dense.toString();
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 5 0 R /Resources << >> >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 6 0 R /Resources << >> >>',
+    '<< /Length ${body.length} >>\nstream\n$body\nendstream',
+    '<< /Length ${urgent.length} >>\nstream\n$urgent\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
+
 void main() {
+  testWidgets(
+      'isolate returns region commands and matching strip plan together',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildVectorPdf();
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+
+      final size = PdfPageRenderer.pageSize(page);
+      const ratio = 2.0;
+      final matrix = PdfPageRenderer.pageToDeviceMatrix(
+          page, size, page.cropBox,
+          pixelRatio: ratio);
+      final detail = await worker.recordStripDetail(
+        0,
+        annotations: true,
+        pageToDevice: _coeffs(matrix),
+        deviceWidth: (size.width * ratio).ceil(),
+        deviceHeight: (size.height * ratio).ceil(),
+        pixelRatio: ratio,
+        imageDecodeRegion: PdfRect(0, 0, size.width / 2, size.height / 2),
+      );
+
+      expect(detail, isNotNull);
+      expect(detail!.commands, isNotEmpty);
+      expect(detail.plan.batches, isNotEmpty);
+      final local = StripPlanBinner(
+        pageToDevice: matrix,
+        deviceWidth: (size.width * ratio).ceil(),
+        deviceHeight: (size.height * ratio).ceil(),
+        pixelRatio: ratio,
+      );
+      await local.bin(detail.commands);
+      expect(encodeStripPlan(detail.plan), encodeStripPlan(local.finish()),
+          reason: 'the returned plan must describe the returned commands, '
+              'not a separate base recording');
+    });
+  });
+
+  testWidgets('combined detail decodes region images in the worker',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildStripsPdf();
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+      final size = PdfPageRenderer.pageSize(page);
+      const ratio = 2.0;
+      final matrix = PdfPageRenderer.pageToDeviceMatrix(
+          page, size, page.cropBox,
+          pixelRatio: ratio);
+      expect(await worker.record(0, decodeImages: false), isNotNull,
+          reason: 'the image page must support a weightless recording');
+      expect(
+          await worker.record(0,
+              imagePixelRatio: ratio,
+              imageDecodeRegion: const PdfRect(0, 0, 100, 100)),
+          isNotNull,
+          reason: 'the image page must support a region decode');
+      final detail = await worker.recordStripDetail(
+        0,
+        annotations: true,
+        pageToDevice: _coeffs(matrix),
+        deviceWidth: (size.width * ratio).ceil(),
+        deviceHeight: (size.height * ratio).ceil(),
+        pixelRatio: ratio,
+        imageDecodeRegion: const PdfRect(0, 0, 100, 100),
+      );
+      expect(detail, isNotNull);
+      expect(PdfPageRenderer.decodedImageStats(detail!.commands).$1,
+          greaterThan(0),
+          reason: 'region image pixels must ride in the combined response');
+
+      final scene = await PdfRetainedScene.fromCommands(page, detail.commands);
+      final image = await scene.rasterizeRegionStrips(
+        const Rect.fromLTWH(0, 0, 100, 100),
+        pixelRatio: ratio,
+        stripPlan: detail.plan,
+      );
+      expect(image.width, 200);
+      expect(image.height, 200);
+      image.dispose();
+      scene.dispose();
+    });
+  });
+
   testWidgets('isolate binStrips matches a local bin of the recorded buffer',
       (tester) async {
     await tester.runAsync(() async {
@@ -187,8 +315,7 @@ void main() {
 
       final stale = bin(); // in flight on the worker now
       worker.cancelBinStrips(0); // same (page, priority): preempt mid-walk
-      expect(
-          await stale.timeout(const Duration(seconds: 30)), isNull,
+      expect(await stale.timeout(const Duration(seconds: 30)), isNull,
           reason: 'the preempted in-flight bin must resolve null');
 
       // The worker survives the preemption and serves the next identical
@@ -197,6 +324,39 @@ void main() {
       expect(fresh, isNotNull,
           reason: 'a fresh bin after the preemption must succeed');
       expect(fresh!.batches, isNotEmpty);
+    });
+  });
+
+  testWidgets('priority preemption requeues a shared in-flight record',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = _buildTwoPageDenseVectorPdf();
+      final backend = PdfRenderWorker.startUncached(bytes);
+      // Complete the spawn handshake so page 0 is already in flight when the
+      // urgent page is submitted, rather than both merely being sorted in the
+      // startup queue.
+      expect(await backend.record(1), isNotNull);
+      final worker = PdfCachingRenderWorker(backend);
+      addTearDown(worker.dispose);
+
+      final completionOrder = <String>[];
+      final lowA = worker.record(0, priority: 10).then((value) {
+        completionOrder.add('low');
+        return value;
+      });
+      final lowB = worker.record(0, priority: 10);
+      final urgent = worker.record(1, priority: 0).then((value) {
+        completionOrder.add('urgent');
+        return value;
+      });
+
+      expect(await urgent.timeout(const Duration(seconds: 30)), isNotNull);
+      expect(await lowA.timeout(const Duration(seconds: 30)), isNotNull,
+          reason: 'the interrupted shared record must be retried, not nulled');
+      expect(await lowB.timeout(const Duration(seconds: 30)), isNotNull,
+          reason: 'every deduplicated waiter must receive the retried record');
+      expect(completionOrder.first, 'urgent',
+          reason: 'the visible page must still cut ahead of the prefetch');
     });
   });
 
@@ -220,8 +380,7 @@ void main() {
     expect(workers[0].binCancels, isEmpty);
   });
 
-  test('caching wrapper passes bins straight through (never cached)',
-      () async {
+  test('caching wrapper passes bins straight through (never cached)', () async {
     final inner = _BinLogWorker();
     final caching = PdfCachingRenderWorker(inner);
     addTearDown(caching.dispose);
@@ -249,6 +408,16 @@ void main() {
         deviceHeight: 10,
         pixelRatio: 1);
     expect(plan, isNull);
+    final detail = await worker.recordStripDetail(
+      0,
+      annotations: true,
+      pageToDevice: const [1, 0, 0, 1, 0, 0],
+      deviceWidth: 10,
+      deviceHeight: 10,
+      pixelRatio: 1,
+      imageDecodeRegion: const PdfRect(0, 0, 10, 10),
+    );
+    expect(detail, isNull);
     worker.cancelBinStrips(0); // must be a harmless no-op
   });
 }
@@ -286,8 +455,8 @@ class _BinLogWorker extends PdfRenderWorker {
       totalFlushPoints: 0,
       deviceWidth: deviceWidth,
       deviceHeight: deviceHeight,
-      pageToDevice: PdfMatrix(pageToDevice[0], pageToDevice[1],
-          pageToDevice[2], pageToDevice[3], pageToDevice[4], pageToDevice[5]),
+      pageToDevice: PdfMatrix(pageToDevice[0], pageToDevice[1], pageToDevice[2],
+          pageToDevice[3], pageToDevice[4], pageToDevice[5]),
       tolerance: stripFlattenTolerance,
       batches: const [],
     );

--- a/packages/dart_pdf_editor/test/strip_display_latency_test.dart
+++ b/packages/dart_pdf_editor/test/strip_display_latency_test.dart
@@ -1,0 +1,282 @@
+// Display-pipeline-shaped companion to strip_worker_latency_test.dart.
+//
+// The older harness deliberately reads every raster back to RGBA so it can
+// double as a pixel-correctness probe. That synchronous readback is not part
+// of PdfPageView's settle path and can dwarf the latency a user sees. This
+// harness stops at the first RawImage frame carrying the newly-rasterized
+// page, records FrameTiming when the test backend exposes it, and never calls
+// ui.Image.toByteData.
+//
+// Run on Impeller with the same corpus used by the correctness harness:
+//
+//   cd packages/dart_pdf_editor
+//   ZOOM_CORPUS_DIR=/Users/ben/repos/dart-pdf/corpus \
+//     fvm flutter test --enable-impeller test/strip_display_latency_test.dart
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart' show deserializeCommandsMicros;
+import 'package:pdf_graphics/raster.dart' show StripPlan;
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+const _zoomSequence = [1.0, 1.5, 2.4, 1.2, 3.0];
+const _targetWidth = 2382.0;
+const _targetHeight = 1684.0;
+const _maxPixels = 1 << 24;
+const _maxDimension = 8192.0;
+const _defaultFiles = ['WAT_L0001_S.pdf', 'ly9-far-cad.pdf#4'];
+
+double _effectiveRatio(Size size, double desired) {
+  var ratio = desired;
+  ratio = math.min(ratio, math.sqrt(_maxPixels / (size.width * size.height)));
+  ratio = math.min(ratio, _maxDimension / math.max(size.width, size.height));
+  return math.max(ratio, 0.05);
+}
+
+class _Case {
+  const _Case(this.label, this.pageIndex, this.page, this.scene, this.worker,
+      this.fit, this.commandDecodeMs);
+
+  final String label;
+  final int pageIndex;
+  final PdfPage page;
+  final PdfRetainedScene scene;
+  final PdfRenderWorker worker;
+  final double fit;
+  final double commandDecodeMs;
+}
+
+class _Prepared {
+  const _Prepared(this.image, this.planWaitMs, this.buildMs, this.toImageMs);
+
+  final ui.Image image;
+  final double planWaitMs;
+  final double buildMs;
+  final double toImageMs;
+}
+
+class _Sample {
+  double planWaitMs = 0;
+  double buildMs = 0;
+  double toImageMs = 0;
+  double presentWallMs = 0;
+  double frameBuildMs = 0;
+  double frameRasterMs = 0;
+  double frameTotalMs = 0;
+  int n = 0;
+
+  void add(_Prepared prepared, _Presented presented) {
+    planWaitMs += prepared.planWaitMs;
+    buildMs += prepared.buildMs;
+    toImageMs += prepared.toImageMs;
+    presentWallMs += presented.wallMs;
+    frameBuildMs += presented.buildMs;
+    frameRasterMs += presented.rasterMs;
+    frameTotalMs += presented.totalMs;
+    n++;
+  }
+
+  double mean(double value) => n == 0 ? 0 : value / n;
+  double get firstPresentMs =>
+      mean(planWaitMs + buildMs + toImageMs + presentWallMs);
+}
+
+class _Presented {
+  const _Presented(this.wallMs, this.buildMs, this.rasterMs, this.totalMs);
+
+  final double wallMs;
+  final double buildMs;
+  final double rasterMs;
+  final double totalMs;
+}
+
+Future<_Prepared> _prepare(
+  _Case testCase,
+  double ratio,
+  String path,
+) async {
+  final geometry = testCase.scene.stripGeometry(pixelRatio: ratio);
+  final m = geometry.pageToDevice;
+  Future<StripPlan?> requestPlan() => testCase.worker.binStrips(
+        testCase.pageIndex,
+        annotations: true,
+        pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+        deviceWidth: geometry.width,
+        deviceHeight: geometry.height,
+        pixelRatio: ratio,
+      );
+
+  StripPlan? plan;
+  var planWaitMs = 0.0;
+  if (path == 'worker') {
+    final sw = Stopwatch()..start();
+    plan = await requestPlan();
+    planWaitMs = sw.elapsedMicroseconds / 1000.0;
+  } else if (path == 'primed') {
+    final pending = requestPlan();
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    final sw = Stopwatch()..start();
+    plan = await pending;
+    planWaitMs = sw.elapsedMicroseconds / 1000.0;
+  }
+  if (path != 'local' && plan == null) {
+    throw StateError('worker declined $path strip plan');
+  }
+
+  var sw = Stopwatch()..start();
+  final picture =
+      await testCase.scene.replayStrips(pixelRatio: ratio, stripPlan: plan);
+  final buildMs = sw.elapsedMicroseconds / 1000.0;
+  sw = Stopwatch()..start();
+  final image = await picture.toImage(
+    (testCase.scene.pageSize.width * ratio).ceil().clamp(1, 1 << 14),
+    (testCase.scene.pageSize.height * ratio).ceil().clamp(1, 1 << 14),
+  );
+  final toImageMs = sw.elapsedMicroseconds / 1000.0;
+  picture.dispose();
+  return _Prepared(image, planWaitMs, buildMs, toImageMs);
+}
+
+Future<_Presented> _present(WidgetTester tester, ui.Image image) async {
+  final timings = <FrameTiming>[];
+  void onTimings(List<FrameTiming> batch) => timings.addAll(batch);
+  SchedulerBinding.instance.addTimingsCallback(onTimings);
+  final sw = Stopwatch()..start();
+  await tester.pumpWidget(
+    Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(
+        child: RawImage(
+          key: ValueKey(image),
+          image: image,
+          fit: BoxFit.contain,
+        ),
+      ),
+    ),
+  );
+  final wallMs = sw.elapsedMicroseconds / 1000.0;
+  SchedulerBinding.instance.removeTimingsCallback(onTimings);
+  final timing = timings.isEmpty ? null : timings.last;
+  double ms(Duration? duration) =>
+      duration == null ? 0 : duration.inMicroseconds / 1000.0;
+  return _Presented(
+    wallMs,
+    ms(timing?.buildDuration),
+    ms(timing?.rasterDuration),
+    ms(timing?.totalSpan),
+  );
+}
+
+void main() {
+  final corpusDir = Platform.environment['ZOOM_CORPUS_DIR'] ?? '../../corpus';
+  final passes =
+      int.tryParse(Platform.environment['ZOOM_LATENCY_PASSES'] ?? '') ?? 3;
+  final filesEnv = Platform.environment['STRIP_WORKER_FILES'];
+  final files = filesEnv == null || filesEnv.trim().isEmpty
+      ? _defaultFiles
+      : filesEnv.split(',').map((value) => value.trim()).toList();
+
+  testWidgets('strip settle latency to first displayed frame', (tester) async {
+    final directory = Directory(corpusDir);
+    if (!directory.existsSync()) {
+      markTestSkipped('corpus directory not found at $corpusDir');
+      return;
+    }
+
+    final testCase = await tester.runAsync<_Case?>(() async {
+      await loadSystemFonts();
+      for (final entry in files) {
+        final hash = entry.lastIndexOf('#');
+        final name = hash < 0 ? entry : entry.substring(0, hash);
+        final requestedPage =
+            hash < 0 ? 0 : int.tryParse(entry.substring(hash + 1)) ?? 0;
+        final file =
+            File(name.startsWith('/') ? name : '${directory.path}/$name');
+        if (!file.existsSync()) continue;
+        final bytes = file.readAsBytesSync();
+        final document = PdfDocument.open(bytes);
+        final pageIndex = requestedPage.clamp(0, document.pageCount - 1);
+        final page = document.page(pageIndex);
+        final size = const PdfPageRenderPlan().pageSize(page);
+        final fit =
+            math.min(_targetWidth / size.width, _targetHeight / size.height);
+        final worker = PdfRenderWorker.startUncached(bytes);
+        final decodeBefore = deserializeCommandsMicros;
+        final commands = await worker.record(pageIndex,
+            imagePixelRatio: _effectiveRatio(size, fit));
+        final commandDecodeMs =
+            (deserializeCommandsMicros - decodeBefore) / 1000.0;
+        if (commands == null) {
+          worker.dispose();
+          continue;
+        }
+        final scene = await PdfRetainedScene.fromCommands(page, commands);
+        if (scene.commands.length <=
+            PdfPageView.retainedZoomReplayMaxCommands) {
+          scene.dispose();
+          worker.dispose();
+          continue;
+        }
+        return _Case('${name.split('/').last}#$pageIndex', pageIndex, page,
+            scene, worker, fit, commandDecodeMs);
+      }
+      return null;
+    });
+    if (testCase == null) {
+      markTestSkipped('no worker-backed strip-routed corpus page found');
+      return;
+    }
+    addTearDown(testCase.scene.dispose);
+    addTearDown(testCase.worker.dispose);
+
+    final samples = {
+      'local': _Sample(),
+      'worker': _Sample(),
+      'primed': _Sample(),
+    };
+    for (var pass = 0; pass <= passes; pass++) {
+      for (final zoom in _zoomSequence) {
+        final ratio =
+            _effectiveRatio(testCase.scene.pageSize, testCase.fit * zoom);
+        for (final path in samples.keys) {
+          final prepared =
+              (await tester.runAsync(() => _prepare(testCase, ratio, path)))!;
+          final presented = await _present(tester, prepared.image);
+          if (pass > 0) samples[path]!.add(prepared, presented);
+          await tester.pumpWidget(const SizedBox.shrink());
+          prepared.image.dispose();
+        }
+      }
+    }
+
+    // ignore: avoid_print
+    print('\nstrip first-present latency: ${testCase.label} '
+        '(mean ms, $passes passes x ${_zoomSequence.length} steps; '
+        'no pixel readback; initial command decode '
+        '${testCase.commandDecodeMs.toStringAsFixed(1)} ms)');
+    // ignore: avoid_print
+    print('${'path'.padRight(10)} ${'binWait'.padLeft(8)} '
+        '${'build'.padLeft(8)} ${'toImage'.padLeft(8)} '
+        '${'present'.padLeft(8)} ${'first'.padLeft(8)} '
+        '${'frmBuild'.padLeft(8)} ${'frmRast'.padLeft(8)} '
+        '${'frmTotal'.padLeft(8)}');
+    for (final entry in samples.entries) {
+      final sample = entry.value;
+      String value(double v) => sample.mean(v).toStringAsFixed(1).padLeft(8);
+      // ignore: avoid_print
+      print('${entry.key.padRight(10)} ${value(sample.planWaitMs)} '
+          '${value(sample.buildMs)} ${value(sample.toImageMs)} '
+          '${value(sample.presentWallMs)} '
+          '${sample.firstPresentMs.toStringAsFixed(1).padLeft(8)} '
+          '${value(sample.frameBuildMs)} ${value(sample.frameRasterMs)} '
+          '${value(sample.frameTotalMs)}');
+    }
+  }, timeout: const Timeout(Duration(minutes: 15)));
+}

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -52,6 +52,11 @@ import 'shading.dart';
 /// programming error, asserted on read.
 const int _formatVersion = 1;
 
+/// Microseconds spent reconstructing worker command buffers on the consuming
+/// isolate. Accumulated for performance probes; this is the UI-thread half of
+/// the record path and intentionally mirrors `decodeStripPlanMicros`.
+int deserializeCommandsMicros = 0;
+
 // Command tags. Stable within a build; order mirrors the sealed hierarchy.
 const int _tSave = 0;
 const int _tRestore = 1;
@@ -259,10 +264,13 @@ PdfDecodedPixels _capImageResolution(
 
 /// Reconstructs the command buffer written by [serializeCommands].
 List<PdfRenderCommand> deserializeCommands(Uint8List bytes) {
+  final sw = Stopwatch()..start();
   final r = _Reader(bytes);
   final version = r.u8();
   assert(version == _formatVersion, 'render command format version mismatch');
-  return _readCommands(r);
+  final commands = _readCommands(r);
+  deserializeCommandsMicros += sw.elapsedMicroseconds;
+  return commands;
 }
 
 void _writeCommands(
@@ -290,9 +298,17 @@ void _writeCommands(
 
 List<PdfRenderCommand> _readCommands(_Reader r) {
   final n = r.u32();
-  final out = <PdfRenderCommand>[];
+  // The wire format gives us the exact count. Pre-size instead of growing a
+  // 100k-command CAD page through repeated capacity reallocations on the UI
+  // isolate. Keep the list growable to preserve deserializeCommands' public
+  // behavior for callers that append diagnostic commands.
+  final out = List<PdfRenderCommand>.filled(
+    n,
+    const PdfSaveCommand(),
+    growable: true,
+  );
   for (var i = 0; i < n; i++) {
-    out.add(_readCommand(r));
+    out[i] = _readCommand(r);
   }
   return out;
 }
@@ -808,7 +824,8 @@ PdfRenderCommand _readCommand(_Reader r) {
       if (r.boolean()) {
         final width = r.u32();
         final height = r.u32();
-        decoded = PdfDecodedPixels(r.bytes(), width, height);
+        decoded =
+            PdfDecodedPixels(r.bytes(allowLargeView: true), width, height);
       }
       // isInline forces value (content) cache keying on replay: the
       // reconstructed stream is a fresh object every record, so stream-identity
@@ -898,19 +915,19 @@ void _writePath(_Writer w, PdfPath path) {
 
 PdfPath _readPath(_Reader r) {
   final n = r.u32();
-  final segments = <PdfPathSegment>[];
+  final segments = List<PdfPathSegment>.filled(
+    n,
+    const PdfClosePath(),
+    growable: true,
+  );
   for (var i = 0; i < n; i++) {
-    switch (r.u8()) {
-      case 0:
-        segments.add(PdfMoveTo(r.f32(), r.f32()));
-      case 1:
-        segments.add(PdfLineTo(r.f32(), r.f32()));
-      case 2:
-        segments.add(
-            PdfCubicTo(r.f32(), r.f32(), r.f32(), r.f32(), r.f32(), r.f32()));
-      case 3:
-        segments.add(const PdfClosePath());
-    }
+    segments[i] = switch (r.u8()) {
+      0 => PdfMoveTo(r.f32(), r.f32()),
+      1 => PdfLineTo(r.f32(), r.f32()),
+      2 => PdfCubicTo(r.f32(), r.f32(), r.f32(), r.f32(), r.f32(), r.f32()),
+      3 => const PdfClosePath(),
+      _ => throw FormatException('unknown path segment tag'),
+    };
   }
   return PdfPath(segments);
 }
@@ -1068,13 +1085,17 @@ PdfTextRun _readTextRun(_Reader r) {
   List<PdfGlyphPlacement>? glyphs;
   if (r.boolean()) {
     final n = r.u32();
-    glyphs = <PdfGlyphPlacement>[];
+    glyphs = List<PdfGlyphPlacement>.filled(
+      n,
+      const PdfGlyphPlacement(offset: 0),
+      growable: true,
+    );
     for (var i = 0; i < n; i++) {
       final offset = r.f64();
       final offsetY = r.f64();
       final outline = r.boolean() ? _readPath(r) : null;
-      glyphs.add(PdfGlyphPlacement(
-          offset: offset, offsetY: offsetY, outline: outline));
+      glyphs[i] =
+          PdfGlyphPlacement(offset: offset, offsetY: offsetY, outline: outline);
     }
   }
   final invisible = r.boolean();
@@ -1220,7 +1241,7 @@ CosObject _readCos(_Reader r) {
       return CosArray([for (var i = 0; i < n; i++) _readCos(r)]);
     case _cStream:
       final dict = _readCos(r) as CosDictionary;
-      return CosStream(dict, r.bytes());
+      return CosStream(dict, r.bytes(allowLargeView: true));
     case _cDict:
       final n = r.u32();
       final entries = <String, CosObject>{};
@@ -1372,11 +1393,16 @@ class _Reader {
     return v.toInt();
   }
 
-  /// Reads a length-prefixed raw byte run as a copy (a sublist view would alias
-  /// the whole transferred buffer and keep it alive).
-  Uint8List bytes() {
+  /// Reads a length-prefixed raw byte run. Small values are copied so a tiny
+  /// COS string cannot pin a multi-megabyte transferred command buffer. Large
+  /// image streams/pixel planes may instead keep a zero-copy view: those bytes
+  /// dominate the buffer and are retained by the command list anyway, so
+  /// copying them only adds UI-thread latency and a second large allocation.
+  Uint8List bytes({bool allowLargeView = false}) {
     final n = u32();
-    final out = Uint8List.fromList(Uint8List.sublistView(_bytes, _o, _o + n));
+    final slice = Uint8List.sublistView(_bytes, _o, _o + n);
+    final out =
+        allowLargeView && n >= (1 << 20) ? slice : Uint8List.fromList(slice);
     _o += n;
     return out;
   }

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -308,6 +308,37 @@ void main() {
       expect(restored.request.decoded!.rgba, decoded.rgba);
     });
 
+    test('large decoded pixel planes stay zero-copy on deserialize', () {
+      final cos = CosDocument.open(buildClassicPdf());
+      final stream = CosStream(
+        CosDictionary({
+          'Width': const CosInteger(512),
+          'Height': const CosInteger(512),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'Filter': const CosName('DCTDecode'),
+        }),
+        Uint8List.fromList([0xff, 0xd8, 0xff, 0xd9]),
+      );
+      final decoded = PdfDecodedPixels(Uint8List(512 * 512 * 4), 512, 512);
+      final command = PdfDrawImageCommand(PdfImageRequest(
+        stream: stream,
+        transform: PdfMatrix.identity,
+        decoded: decoded,
+      ));
+
+      final bytes = serializeCommands([command], cos: cos, decodeImages: true)!;
+      final restored = _imageCommands(deserializeCommands(bytes)).single;
+      expect(restored.request.decoded!.rgba.buffer.lengthInBytes,
+          bytes.buffer.lengthInBytes,
+          reason: 'a large pixel payload should view the transferred buffer '
+              'instead of copying it again on the UI isolate');
+      // The public result remains growable after the pre-sizing optimization.
+      final commands = deserializeCommands(bytes);
+      commands.add(const PdfSaveCommand());
+      expect(commands, hasLength(2));
+    });
+
     test('imageDecodeRegion crops pixels and retargets the image transform',
         () {
       final cos = CosDocument.open(buildClassicPdf());


### PR DESCRIPTION
## What changed

- add a display-pipeline-shaped strip-settle benchmark that stops at first presentation and keeps synchronous pixel readback in the existing correctness harness
- combine region image decode and strip planning into one native worker request/response for dense deep-zoom patches
- keep interrupted shared RECORD futures alive by requeueing preempted work behind the urgent page on native and web workers
- reduce UI-side command decode allocation with pre-sized command/path/glyph lists and zero-copy views for large transferred image payloads
- expose `deserializeCommandsMicros` for continued #216 measurement

## Why

Dense CAD zoom settles were dominated by worker-plan wait, and the existing benchmark obscured the perceived latency with a synchronous full-raster readback that the viewer does not perform. Deep-zoom image sharpness and strip routing also had separate worker paths, while priority preemption could null every waiter sharing an interrupted record.

## Impact

On `ly9-far-cad.pdf#4` (98.9k commands), the display-shaped one-pass Impeller probe measured:

| path | first present |
|---|---:|
| local strip bin | 345.9 ms |
| worker strip bin | 354.4 ms |
| speculatively primed worker plan | 31.1 ms |

Initial command-buffer decode measured 56.2 ms, which remains the next #216 target.

## Validation

- `fvm dart analyze` — full workspace clean
- focused page-view/worker/preview/strip suite — 101 tests passed, including Ghent strip parity
- `fvm dart test test/render_command_codec_test.dart` — 25 tests passed
- `fvm flutter build web --debug` — succeeded
- real Impeller CAD display benchmark — succeeded

Closes #214
Closes #215
Closes #219
Progresses #216

Follow-up #220 tracks request-ID-scoped cancellation so a late cancellation cannot affect the next job.