### PR TITLE
perf: scope worker cancellation to request ids

### DIFF
--- a/doc/dev-log/2026-07-11-strip-detail-and-preemption.md
+++ b/doc/dev-log/2026-07-11-strip-detail-and-preemption.md
@@ -131,6 +131,16 @@ strip/device proof.
 Adaptive policy (#189) and OCR isolation (#93) are valuable but orthogonal to
 the now-measured zoom-settle critical path.
 
-One separate follow-up was filed as #220: make native/Web Worker cancellation
-request-ID-scoped so a late cancel for a completed job cannot abort the urgent
-job that followed it.
+## Request-scoped cancellation (#220)
+
+The follow-up is implemented in the same branch. Native cancel-port messages
+and Web Worker `{kind:'cancel'}` messages now carry the target request id. Each
+worker compares that id with its active request before flipping the cooperative
+token, so a late cancel for a completed job cannot abort the urgent job that
+followed it.
+
+The native regression uses a private test hook to withhold request A's cancel
+until A has answered and request B has been dispatched, then delivers the stale
+id while B is walking a dense page. B completes non-null. The ordinary
+preemption/requeue tests remain green, and the example web build verifies the
+mirrored JS protocol.

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:isolate';
 import 'dart:typed_data';
 
@@ -8,6 +9,15 @@ import 'package:pdf_graphics/raster.dart'
     show StripPlan, StripPlanBinner, decodeStripPlan, encodeStripPlan;
 
 import 'render_worker.dart';
+
+/// Test hook: hold a requested cancellation until the cancelled job answers
+/// and the next queued request is dispatched. That deterministically recreates
+/// the late-signal race request-scoped cancellation must reject.
+bool debugDeferPdfRenderWorkerCancelUntilNextRequest = false;
+
+/// Number of stale request-scoped cancel messages ignored by native workers.
+/// Test/diagnostic counter; reset it before a focused probe.
+int debugPdfRenderWorkerIgnoredStaleCancels = 0;
 
 /// Native backend: a long-lived background isolate that opens its own
 /// [PdfDocument] from the bytes once and records pages on request, sending the
@@ -47,6 +57,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   int _seq = 0;
   bool _disposed = false;
   bool _spawnFailed = false;
+  int? _deferredCancelId;
 
   @override
   bool get isActive => !_disposed && !_spawnFailed;
@@ -67,6 +78,16 @@ class _IsolateRenderWorker extends PdfRenderWorker {
     _fromWorker.listen((message) {
       if (message is List<SendPort>) {
         handshake.complete(message);
+        return;
+      }
+      if (message is List<Object?> &&
+          message.isNotEmpty &&
+          message.first == 'cancelIgnored') {
+        debugPdfRenderWorkerIgnoredStaleCancels++;
+        developer.log(
+          'ignored stale cancel target=${message[1]} active=${message[2]}',
+          name: 'dart_pdf_editor.render_worker',
+        );
         return;
       }
       // [int id, TransferableTypedData? data, ...] - null means "render
@@ -101,6 +122,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
                 data.materialize().asUint8List(),
             ]);
       _pump();
+      _deliverDeferredCancelToNextRequest();
     });
     final isolate = await Isolate.spawn(
       _workerMain,
@@ -248,7 +270,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         if (_inFlight!.kind == _RequestKind.record) {
           _inFlight!.requeueAfterPreemption = true;
         }
-        _toCancelPort?.send(null);
+        _cancelRequest(_inFlight!);
       }
       return;
     }
@@ -330,10 +352,9 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   /// across callers, so preempting one would null a waiter shared with a
   /// caller that still wants it.
   ///
-  /// The in-flight signal carries a benign pre-existing race (the same one
-  /// the priority-preemption path in [_pump] accepts): it can land on the
-  /// worker after the job already completed and cancel the NEXT job instead,
-  /// whose caller then resolves null and falls back to a local render/bin.
+  /// The cancel message carries the target request id. A signal that arrives
+  /// after that job replied is ignored by the worker instead of cancelling the
+  /// next request occupying the slot (issue #220).
   void _cancelKind(_RequestKind kind, int pageIndex, int priority) {
     if (_disposed) return;
     _queue.removeWhere((request) {
@@ -351,8 +372,31 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         inFlight.kind == kind &&
         inFlight.pageIndex == pageIndex &&
         inFlight.priority == priority) {
-      _toCancelPort?.send(null);
+      _cancelRequest(inFlight);
     }
+  }
+
+  void _cancelRequest(_PendingRequest request) {
+    if (debugDeferPdfRenderWorkerCancelUntilNextRequest) {
+      _deferredCancelId = request.id;
+      return;
+    }
+    _toCancelPort?.send(request.id);
+  }
+
+  void _deliverDeferredCancelToNextRequest() {
+    final id = _deferredCancelId;
+    if (!debugDeferPdfRenderWorkerCancelUntilNextRequest ||
+        id == null ||
+        _inFlight == null) {
+      return;
+    }
+    _deferredCancelId = null;
+    // Give the worker event loop time to enter the just-dispatched request;
+    // this branch exists only for the deterministic late-delivery test hook.
+    Timer(const Duration(milliseconds: 5), () {
+      if (!_disposed) _toCancelPort?.send(id);
+    });
   }
 
   @override
@@ -479,8 +523,16 @@ void _workerMain(_WorkerInit init) {
   final binCommands = _BinCommandCache();
 
   PdfCancellationToken? activeToken;
-  cancelPort.listen((_) {
-    activeToken?.cancelled = true;
+  int? activeRequestId;
+  cancelPort.listen((message) {
+    // A cancel can arrive after its target already replied and the next job
+    // became active. Ignore that stale id instead of aborting the next (often
+    // urgent) page. This is the native half of issue #220.
+    if (message is int && message == activeRequestId) {
+      activeToken?.cancelled = true;
+    } else if (message is int) {
+      init.reply.send(['cancelIgnored', message, activeRequestId]);
+    }
   });
 
   requests.listen((message) async {
@@ -492,6 +544,7 @@ void _workerMain(_WorkerInit init) {
 
     final token = PdfCancellationToken();
     activeToken = token;
+    activeRequestId = id;
     Uint8List? buffer;
     Uint8List? detailPlanBuffer;
     try {
@@ -550,7 +603,10 @@ void _workerMain(_WorkerInit init) {
     } catch (_) {
       buffer = null; // any failure → caller renders this page locally
     }
-    activeToken = null;
+    if (activeRequestId == id) {
+      activeToken = null;
+      activeRequestId = null;
+    }
     if (buffer == null) {
       init.reply.send([id, null]);
     } else if (detailPlanBuffer != null) {

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -162,6 +162,14 @@ class _WebRenderWorker extends PdfRenderWorker {
       _pump();
       return;
     }
+    if (kind == 'cancelIgnored') {
+      final target =
+          (data.getProperty('targetId'.toJS) as JSNumber?)?.toDartInt;
+      final active =
+          (data.getProperty('activeId'.toJS) as JSNumber?)?.toDartInt;
+      _wlog('ignored stale cancel target=$target active=$active');
+      return;
+    }
     if (kind != 'result') return;
     final id = (data.getProperty('id'.toJS) as JSNumber).toDartInt;
     final request = _inFlight;
@@ -240,7 +248,9 @@ class _WebRenderWorker extends PdfRenderWorker {
       }
       if (_queue[bestQueued].priority < _inFlight!.priority) {
         _inFlight!.requeueAfterPreemption = true;
-        worker.postMessage(JSObject()..setProperty('kind'.toJS, 'cancel'.toJS));
+        worker.postMessage(JSObject()
+          ..setProperty('kind'.toJS, 'cancel'.toJS)
+          ..setProperty('id'.toJS, _inFlight!.id.toJS));
       }
       return;
     }

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -31,12 +31,14 @@ import 'package:web/web.dart' as web;
 /// - `{kind:'record', id, page, annotations}` → replies `{kind:'result', id,
 ///   buffer:ArrayBuffer|null}` (null = the page can't be offloaded; the main
 ///   thread renders it locally).
-/// - `{kind:'cancel'}` → sets the active cancellation token so the in-flight
-///   interpreter walk abandons early, replying with `buffer:null`.
+/// - `{kind:'cancel', id}` → cancels only the matching active request, so a
+///   late message cannot abort its successor; a match abandons the interpreter
+///   walk early and replies with `buffer:null`.
 void runPdfRenderWorker() {
   final scope = globalContext as web.DedicatedWorkerGlobalScope;
   PdfDocument? document;
   PdfCancellationToken? activeToken;
+  int? activeRequestId;
 
   // The handler MUST stay synchronous (return void): `.toJS` cannot convert a
   // Future-returning function, so an `async` handler fails `dart compile js`
@@ -73,7 +75,19 @@ void runPdfRenderWorker() {
     }
 
     if (kind == 'cancel') {
-      activeToken?.cancelled = true;
+      final id = (data.getProperty('id'.toJS) as JSNumber?)?.toDartInt;
+      if (id != null && id == activeRequestId) {
+        activeToken?.cancelled = true;
+      } else if (id != null) {
+        final ignored = JSObject()
+          ..setProperty('kind'.toJS, 'cancelIgnored'.toJS)
+          ..setProperty('targetId'.toJS, id.toJS);
+        final active = activeRequestId;
+        if (active != null) {
+          ignored.setProperty('activeId'.toJS, active.toJS);
+        }
+        scope.postMessage(ignored);
+      }
       return;
     }
 
@@ -120,6 +134,7 @@ void runPdfRenderWorker() {
 
     final token = PdfCancellationToken();
     activeToken = token;
+    activeRequestId = id;
     // Fire-and-forget: launch the cancellable walk without awaiting it here, so
     // the message handler returns void (see the note above) while a subsequent
     // 'cancel' message can still flip token.cancelled mid-walk.
@@ -140,7 +155,10 @@ void runPdfRenderWorker() {
       }
       // Only clear the active token if it is still ours - a newer record may
       // have replaced it while this one was running.
-      if (identical(activeToken, token)) activeToken = null;
+      if (identical(activeToken, token)) {
+        activeToken = null;
+        activeRequestId = null;
+      }
 
       final result = JSObject()
         ..setProperty('kind'.toJS, 'result'.toJS)

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -20,6 +20,8 @@ import 'dart:typed_data';
 import 'dart:ui' show Rect;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/render_worker_isolate.dart'
+    as isolate_worker;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
@@ -73,7 +75,6 @@ Uint8List _buildTwoPageDenseVectorPdf({int rects = 8000}) {
     dense.write('${(i % 10) / 10} 0 0 rg '
         '${(i * 7) % 550} ${(i * 13) % 730} 8 6 re f ');
   }
-  const urgent = '0 0 1 rg 20 20 100 100 re f';
   final body = dense.toString();
   final objects = <String>[
     '<< /Type /Catalog /Pages 2 0 R >>',
@@ -83,7 +84,7 @@ Uint8List _buildTwoPageDenseVectorPdf({int rects = 8000}) {
     '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
         '/Contents 6 0 R /Resources << >> >>',
     '<< /Length ${body.length} >>\nstream\n$body\nendstream',
-    '<< /Length ${urgent.length} >>\nstream\n$urgent\nendstream',
+    '<< /Length ${body.length} >>\nstream\n$body\nendstream',
   ];
   final buffer = StringBuffer('%PDF-1.4\n');
   final offsets = <int>[];
@@ -357,6 +358,31 @@ void main() {
           reason: 'every deduplicated waiter must receive the retried record');
       expect(completionOrder.first, 'urgent',
           reason: 'the visible page must still cut ahead of the prefetch');
+    });
+  });
+
+  testWidgets('a late cancel id cannot abort the next worker request',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = _buildTwoPageDenseVectorPdf();
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+      isolate_worker.debugDeferPdfRenderWorkerCancelUntilNextRequest = true;
+      isolate_worker.debugPdfRenderWorkerIgnoredStaleCancels = 0;
+      addTearDown(() => isolate_worker
+          .debugDeferPdfRenderWorkerCancelUntilNextRequest = false);
+
+      // Warm the handshake, then let page 1 request preemption while page 0
+      // is already running. The test hook withholds page 0's cancel until its
+      // response has dispatched page 1, recreating the old cross-request race.
+      expect(await worker.record(1), isNotNull);
+      final first = worker.record(0, priority: 10);
+      final next = worker.record(1, priority: 0);
+      expect(await first.timeout(const Duration(seconds: 30)), isNotNull);
+      expect(await next.timeout(const Duration(seconds: 30)), isNotNull,
+          reason:
+              'page 0\'s late cancel must be ignored while page 1 is active');
+      expect(isolate_worker.debugPdfRenderWorkerIgnoredStaleCancels, 1);
     });
   });
 


### PR DESCRIPTION
## Summary

- scope native isolate cancellation messages to the active render request id
- mirror request-scoped cancellation in the web worker protocol
- ignore and diagnose stale cancellation messages instead of letting them abort a later request
- add a deterministic regression test for late cancellation delivery

Closes #220

## Validation

- `fvm flutter test test/render_worker_strips_test.dart test/render_worker_test.dart` (52 tests)
- `fvm dart analyze packages/dart_pdf_editor`
- `fvm flutter build web --debug` (from `packages/dart_pdf_editor/example`)