### PR TITLE
perf(web): keep Slug glyphs sharp through transform zoom

### DIFF
--- a/packages/dart_pdf_editor/example/tool/web_slug_probe.dart
+++ b/packages/dart_pdf_editor/example/tool/web_slug_probe.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+const _embeddedFontPdf =
+    'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4K'
+    'ZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50'
+    'IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAv'
+    'TWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvQ29udGVudHMgNCAwIFIgL1Jlc291cmNlcyA8'
+    'PCAvRm9udCA8PCAvRjEgNSAwIFIgPj4gPj4gPj4KZW5kb2JqCjQgMCBvYmoKPDwgL0xl'
+    'bmd0aCAzMyA+PgpzdHJlYW0KQlQgL0YxIDI0IFRmIDcyIDcwMCBUZCAoQUIpIFRqIEVU'
+    'CmVuZHN0cmVhbQplbmRvYmoKNSAwIG9iago8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAv'
+    'VHJ1ZVR5cGUgL0Jhc2VGb250IC9UZXN0Rm9udCAvRmlyc3RDaGFyIDY1IC9MYXN0Q2hh'
+    'ciA2NiAvV2lkdGhzIFs2MDAgMTAwMF0gL0VuY29kaW5nIC9XaW5BbnNpRW5jb2Rpbmcg'
+    'L0ZvbnREZXNjcmlwdG9yIDcgMCBSID4+CmVuZG9iago2IDAgb2JqCjw8IC9MZW5ndGgg'
+    'Mzc2IC9MZW5ndGgxIDM3NiA+PgpzdHJlYW0KAAEAAAAHAEAAAgAwY21hcAAAAAAAAAB8'
+    'AAAALGdseWYAAAAAAAAAqAAAAEBoZWFkAAAAAAAAAOgAAAA2aGhlYQAAAAAAAAEgAAAAJG'
+    'htdHgAAAAAAAABRAAAAAxsb2NhAAAAAAAAAVAAAAAIbWF4cAAAAAAAAAFYAAAAIAAAAAEA'
+    'AwABAAAADAAEACAAAAAEAAQAAQAAAEL//wAAAEH////AAAEAAAAAAAEAAAAAA+gD6AAC'
+    'AAABAQEAAAH0AfQAAAPo/BgAAAEAAAAAA+gD6AADAAABAQEBAAAD6AAA/BgAAAAAA+gAA'
+    'AABAAAAAAAAAAAAAF8PPPUAAAPoAAAAAAAAAAAAAAAAAAAAAAAAAAAD6APoAAAACAACA'
+    'AAAAAAAAAEAAAMg/zgAAAPoAAAAAAPoAAEAAAAAAAAAAAAAAAAAAAADAfQAAAJYAAAD6A'
+    'AAAAAAAAAPACAAAQAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAplbmRzdHJlYW0'
+    'KZW5kb2JqCjcgMCBvYmoKPDwgL1R5cGUgL0ZvbnREZXNjcmlwdG9yIC9Gb250TmFtZS'
+    'AvVGVzdEZvbnQgL0ZsYWdzIDMyIC9Gb250QkJveCBbMCAwIDEwMDAgMTAwMF0gL0l0YW'
+    'xpY0FuZ2xlIDAgL0FzY2VudCA4MDAgL0Rlc2NlbnQgLTIwMCAvQ2FwSGVpZ2h0IDgwMC'
+    'AvU3RlbVYgODAgL0ZvbnRGaWxlMiA2IDAgUiA+PgplbmRvYmoKeHJlZgowIDgKMDAwMD'
+    'AwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDA5IDAwMDAwIG4gCjAwMDAwMDAwNTggMDAw'
+    'MDAgbiAKMDAwMDAwMDExNSAwMDAwMCBuIAowMDAwMDAwMjQxIDAwMDAwIG4gCjAwMDA'
+    'wMDAzMjQgMDAwMDAgbiAKMDAwMDAwMDQ5MSAwMDAwMCBuIAowMDAwMDAwOTMxIDAwMD'
+    'AwIG4gCnRyYWlsZXIKPDwgL1NpemUgOCAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKMT'
+    'ExMwolJUVPRgo=';
+
+void main() => runApp(const _SlugProbeApp());
+
+class _SlugProbeApp extends StatefulWidget {
+  const _SlugProbeApp();
+
+  @override
+  State<_SlugProbeApp> createState() => _SlugProbeAppState();
+}
+
+class _SlugProbeAppState extends State<_SlugProbeApp> {
+  final _transform = TransformationController();
+  late final PdfDocument _document;
+  late final PdfPage _page;
+  late final Timer _telemetry;
+  int _lastQuads = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    StripPdfDevice.resetStats();
+    _document = PdfDocument.open(base64Decode(_embeddedFontPdf));
+    _page = _document.page(0);
+    _telemetry = Timer.periodic(const Duration(milliseconds: 250), (_) {
+      final quads = StripPdfDevice.totalSlugQuads;
+      if (quads == _lastQuads) return;
+      _lastQuads = quads;
+      debugPrint('[slug-probe] quads=$quads '
+          'stripQuads=${StripPdfDevice.totalStripQuads} '
+          'flushes=${StripPdfDevice.totalFlushes}');
+      if (mounted) setState(() {});
+    });
+  }
+
+  void _zoom(double scale) {
+    final matrix = Matrix4.identity()
+      ..setEntry(0, 0, scale)
+      ..setEntry(1, 1, scale);
+    _transform.value = matrix;
+    debugPrint('[slug-probe] transform=${scale}x '
+        'quads=${StripPdfDevice.totalSlugQuads}');
+  }
+
+  @override
+  void dispose() {
+    _telemetry.cancel();
+    _transform.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            title: const Text('Web Slug transform probe'),
+            actions: [
+              Text('quads ${StripPdfDevice.totalSlugQuads}'),
+              const SizedBox(width: 12),
+              TextButton(onPressed: () => _zoom(1), child: const Text('1x')),
+              TextButton(onPressed: () => _zoom(3), child: const Text('3x')),
+              const SizedBox(width: 12),
+            ],
+          ),
+          body: ClipRect(
+            child: InteractiveViewer(
+              transformationController: _transform,
+              constrained: false,
+              minScale: 1,
+              maxScale: 4,
+              child: SizedBox(
+                width: 612,
+                child: PdfPageView(page: _page),
+              ),
+            ),
+          ),
+        ),
+      );
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -242,6 +242,24 @@ class PdfPageView extends StatefulWidget {
   /// on the UI thread, the honest cost of the fastest available settle.
   static bool stripZoomReplay = true;
 
+  /// Keeps a Slug-routed retained picture live on web for ordinary-size
+  /// pages instead of flattening it into a bitmap on every zoom settle.
+  /// CanvasKit evaluates the curve shader under the current canvas transform,
+  /// so outline text stays sharp throughout a pinch and the page pays no
+  /// settle readback. The complete painter-order picture stays live (rather
+  /// than lifting glyphs into one topmost overlay), preserving text/vector
+  /// occlusion, clips, groups, and soft masks exactly.
+  ///
+  /// Dense pages above [retainedZoomReplayMaxCommands] keep the worker-planned
+  /// strip raster path. Building their Slug picture locally would put the
+  /// expensive bin walk back on the browser UI thread and undo #224.
+  /// Image-bearing pages also stay raster-backed so the deep-zoom region patch
+  /// can continue replacing embedded images at their requested resolution.
+  static bool webSlugGlyphLayer = true;
+
+  /// Test hook for [webSlugGlyphLayer]. Null uses [kIsWeb].
+  static bool? debugWebSlugGlyphLayerBackendOverride;
+
   /// Test hook for the Impeller gate: `flutter test` runs on software Skia
   /// where `ui.ImageFilter.isShaderFilterSupported` is false, so strip
   /// router tests force the decision. Null (production) asks the engine.
@@ -278,6 +296,12 @@ class PdfPageView extends StatefulWidget {
 
 class _PdfPageViewState extends State<PdfPageView> {
   Future<ui.Picture>? _picture;
+
+  /// Web-only retained strip picture whose outline-text draws use the Slug
+  /// curve shader. Unlike [_image], this remains vector/shader-backed under
+  /// the viewer's live transform and is reused across every zoom settle.
+  ui.Picture? _slugPicture;
+  bool _slugPictureRejected = false;
 
   /// The page retained as a replayable scene (commands + decoded images),
   /// produced by the same interpret that yielded [_picture]. Zoom re-rasters
@@ -375,13 +399,18 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// A background prerender landed somewhere; if this page is still
   /// showing its placeholder, its preview may just have arrived.
   void _onPreviewCacheChanged() {
-    if (!mounted || _image != null || _preview != null) return;
+    if (!mounted ||
+        _image != null ||
+        _slugPicture != null ||
+        _preview != null) {
+      return;
+    }
     setState(_refreshPreview);
   }
 
   void _refreshPreview() {
     final cache = widget.previewCache;
-    if (cache == null || _image != null) return;
+    if (cache == null || _image != null || _slugPicture != null) return;
     final next = cache.imageFor(widget.previewIndex);
     if (next == null) return; // keep whatever we already hold
     _preview?.dispose();
@@ -533,6 +562,8 @@ class _PdfPageViewState extends State<PdfPageView> {
   void _dropPicture() {
     _picture?.then((picture) => picture.dispose());
     _picture = null;
+    _slugPicture?.dispose();
+    _slugPicture = null;
     _setScene(null); // the scene transcribes the same content as the picture
     _rasteredRatio = null; // the next picture must re-raster, not be skipped
   }
@@ -551,6 +582,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     _scene?.dispose();
     _scene = scene;
     _sceneFromWorker = scene != null && fromWorker;
+    _slugPictureRejected = false;
     // a speculative bin's geometry was computed against the previous scene;
     // with the scene identity changed it is meaningless, so drop it (the
     // next _workerStripPlan's cancelBinStrips reaps the worker-side job)
@@ -732,6 +764,14 @@ class _PdfPageViewState extends State<PdfPageView> {
       PdfPageView.stripZoomReplay &&
       _stripBackendSupported &&
       scene.commands.length > PdfPageView.retainedZoomReplayMaxCommands;
+
+  static bool _slugPictureScene(PdfRetainedScene? scene) =>
+      scene != null &&
+      PdfPageView.webSlugGlyphLayer &&
+      (PdfPageView.debugWebSlugGlyphLayerBackendOverride ?? kIsWeb) &&
+      scene.hasSlugTextCandidates &&
+      !PdfPageRenderer.hasImageDraws(scene.commands) &&
+      scene.commands.length <= PdfPageView.retainedZoomReplayMaxCommands;
 
   /// Builds the picture (and, unless [PdfPageView.retainedZoomReplay] is
   /// off, the retained scene) from a recorded command buffer. One decode
@@ -918,6 +958,67 @@ class _PdfPageViewState extends State<PdfPageView> {
           first: true);
     }
     final effective = _effectiveRatio();
+    final retainedScene = PdfPageView.retainedZoomReplay ? _scene : null;
+
+    // On web, keep one Slug-routed picture live under the viewer transform.
+    // Record at 1 px/pt: Skia reevaluates the curve shader under later CTMs,
+    // which is the property this path exists to preserve. This replaces the
+    // base raster rather than overlaying it, so text is never double-painted
+    // and painter order remains the command stream's exact order.
+    if (_slugPictureScene(retainedScene) && !_slugPictureRejected) {
+      if (_slugPicture == null) {
+        var slugStats = (quads: 0, fallbackOutlineRuns: 0);
+        final slugPicture = await retainedScene!.replayStrips(
+          pixelRatio: 1,
+          slugGlyphs: true,
+          onSlugStats: (stats) => slugStats = stats,
+        );
+        if (_superseded(generation, pageIndex)) {
+          slugPicture.dispose();
+          return;
+        }
+        // Minified or atlas-overflow outline runs fall back to pixel-aligned
+        // strips. Keeping that picture under a transform would blur those
+        // runs, so use the normal raster path unless every outline run took
+        // Slug and at least one glyph was emitted.
+        if (slugStats.quads == 0 || slugStats.fallbackOutlineRuns != 0) {
+          slugPicture.dispose();
+          _slugPictureRejected = true;
+        } else {
+          setState(() {
+            _slugPicture = slugPicture;
+            _image?.dispose();
+            _image = null;
+            _preview?.dispose();
+            _preview = null;
+            _rasteredRatio = effective;
+          });
+          _dropDetail();
+          final cache = widget.previewCache;
+          if (cache != null &&
+              !cache.isFresh(widget.previewIndex, widget.page,
+                  requireImages: true)) {
+            unawaited(cache.putFromPicture(
+                widget.previewIndex, widget.page, picture,
+                rotation: widget.rotation));
+          }
+          widget.onRasterReady?.call();
+          return;
+        }
+      } else {
+        // No replay and no GPU readback on a zoom settle; the existing
+        // picture will be painted under the new InteractiveViewer transform.
+        _rasteredRatio = effective;
+      }
+      if (_slugPicture != null) return;
+    }
+    if (_slugPicture != null) {
+      setState(() {
+        _slugPicture?.dispose();
+        _slugPicture = null;
+        _rasteredRatio = null;
+      });
+    }
     // Skip the full-page readback when the cached raster is already at
     // this resolution: a settle that only moved the detail patch reaches
     // here too (one combined callback paces base + detail through the
@@ -939,7 +1040,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       // the render worker when the scene is worker-backed (the plan comes
       // back precomputed; null plan = local bin). Fallback paths (no scene,
       // or the kill switch) re-raster the cached picture.
-      final scene = PdfPageView.retainedZoomReplay ? _scene : null;
+      final scene = retainedScene;
       final ui.Image image;
       if (scene != null && _stripReplayScene(scene)) {
         final stripPlan = await _workerStripPlan(scene, pixelRatio: effective);
@@ -1448,11 +1549,17 @@ class _PdfPageViewState extends State<PdfPageView> {
           final h = inner.maxHeight;
           final detail = _detailImage;
           final fraction = _detailFraction;
+          final slugPicture = _slugPicture;
           return Stack(
               alignment: Alignment.topLeft,
               fit: StackFit.expand,
               children: [
-                if (_image == null)
+                if (slugPicture != null)
+                  CustomPaint(
+                    key: const ValueKey('pdf-page-slug-picture'),
+                    painter: _SlugPagePicturePainter(slugPicture, size),
+                  )
+                else if (_image == null)
                   // before the first render lands: the low-res preview if
                   // the cache has one (fast scroll past a known page), else
                   // a placeholder matching the paper so nothing flashes. A
@@ -1476,7 +1583,10 @@ class _PdfPageViewState extends State<PdfPageView> {
                     fit: BoxFit.contain,
                     filterQuality: FilterQuality.medium,
                   ),
-                if (detail != null && fraction != null && w.isFinite)
+                if (slugPicture == null &&
+                    detail != null &&
+                    fraction != null &&
+                    w.isFinite)
                   Positioned(
                     left: fraction.left * w,
                     top: fraction.top * h,
@@ -1493,6 +1603,32 @@ class _PdfPageViewState extends State<PdfPageView> {
       );
     });
   }
+}
+
+/// Paints a retained page picture into the page widget's fitted dimensions.
+/// The picture remains in PDF-point coordinates; the surrounding viewer's
+/// transform therefore reaches its Slug runtime shader instead of scaling a
+/// previously-rasterized image.
+class _SlugPagePicturePainter extends CustomPainter {
+  const _SlugPagePicturePainter(this.picture, this.sourceSize);
+
+  final ui.Picture picture;
+  final Size sourceSize;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (sourceSize.width <= 0 || sourceSize.height <= 0) return;
+    canvas.save();
+    canvas.scale(
+        size.width / sourceSize.width, size.height / sourceSize.height);
+    canvas.drawPicture(picture);
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant _SlugPagePicturePainter oldDelegate) =>
+      !identical(picture, oldDelegate.picture) ||
+      sourceSize != oldDelegate.sourceSize;
 }
 
 /// A worker strip bin requested speculatively while the zoom gesture was

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -49,6 +49,31 @@ class PdfRetainedScene {
   /// The interpreter's transcript of the page, in paint order.
   final List<PdfRenderCommand> commands;
 
+  /// Whether the transcript contains embedded-outline text that can benefit
+  /// from the web Slug picture. Base-14/substituted text has no glyph
+  /// outlines and stays on the cheaper normal raster path.
+  bool get hasSlugTextCandidates => _hasSlugText(commands);
+
+  static bool _hasSlugText(List<PdfRenderCommand> commands) {
+    for (final command in commands) {
+      switch (command) {
+        case PdfDrawTextCommand(:final run):
+          if (!run.invisible &&
+              run.glyphs != null &&
+              run.fill &&
+              run.strokeColor == null &&
+              run.gradient == null) {
+            return true;
+          }
+        case PdfEndSoftMaskedCommand(:final maskCommands):
+          if (_hasSlugText(maskCommands)) return true;
+        default:
+          break;
+      }
+    }
+    return false;
+  }
+
   /// Decoded images keyed by [pdfImageKey], owned by this scene.
   final Map<Object, ui.Image> _images;
 
@@ -172,8 +197,7 @@ class PdfRetainedScene {
       {required double pixelRatio}) {
     final size = pageSize;
     return (
-      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(
-          page, size, page.cropBox,
+      pageToDevice: PdfPageRenderer.pageToDeviceMatrix(page, size, page.cropBox,
           rotation: plan.rotation, pixelRatio: pixelRatio),
       width: (size.width * pixelRatio).ceil().clamp(1, 1 << 14),
       height: (size.height * pixelRatio).ceil().clamp(1, 1 << 14),
@@ -220,16 +244,20 @@ class PdfRetainedScene {
   /// `totalStripQuads` / `totalAtlasTexels`; call
   /// [StripPdfDevice.resetStats] around a step to read per-step deltas.
   Future<ui.Picture> replayStrips(
-      {required double pixelRatio, StripPlan? stripPlan}) async {
+      {required double pixelRatio,
+      StripPlan? stripPlan,
+      bool slugGlyphs = false,
+      void Function(({int quads, int fallbackOutlineRuns}))?
+          onSlugStats}) async {
     assert(!_disposed, 'replay after dispose');
     try {
       return await _stripPicture(stripGeometry(pixelRatio: pixelRatio), null,
-          pixelRatio, stripPlan);
+          pixelRatio, stripPlan, slugGlyphs, onSlugStats);
     } on StripPlanMismatchError {
       // The plan desynced mid-walk (only detectable at finish, before any
       // painting committed): discard and re-bin locally.
-      return _stripPicture(
-          stripGeometry(pixelRatio: pixelRatio), null, pixelRatio, null);
+      return _stripPicture(stripGeometry(pixelRatio: pixelRatio), null,
+          pixelRatio, null, slugGlyphs, onSlugStats);
     }
   }
 
@@ -239,13 +267,19 @@ class PdfRetainedScene {
   /// geometry is clipped during binning rather than drawn. A [stripPlan]
   /// must have been binned for [stripRegionGeometry] of the same region.
   Future<ui.Picture> replayRegionStrips(Rect region,
-      {required double pixelRatio, StripPlan? stripPlan}) async {
+      {required double pixelRatio,
+      StripPlan? stripPlan,
+      bool slugGlyphs = false,
+      void Function(({int quads, int fallbackOutlineRuns}))?
+          onSlugStats}) async {
     assert(!_disposed, 'replay after dispose');
     final geometry = stripRegionGeometry(region, pixelRatio: pixelRatio);
     try {
-      return await _stripPicture(geometry, region, pixelRatio, stripPlan);
+      return await _stripPicture(
+          geometry, region, pixelRatio, stripPlan, slugGlyphs, onSlugStats);
     } on StripPlanMismatchError {
-      return _stripPicture(geometry, region, pixelRatio, null);
+      return _stripPicture(
+          geometry, region, pixelRatio, null, slugGlyphs, onSlugStats);
     }
   }
 
@@ -256,7 +290,10 @@ class PdfRetainedScene {
       ({PdfMatrix pageToDevice, int width, int height}) geometry,
       Rect? region,
       double pixelRatio,
-      StripPlan? stripPlan) async {
+      StripPlan? stripPlan,
+      bool slugGlyphs,
+      void Function(({int quads, int fallbackOutlineRuns}))?
+          onSlugStats) async {
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder)..scale(pixelRatio);
     if (region != null) canvas.translate(-region.left, -region.top);
@@ -269,6 +306,7 @@ class PdfRetainedScene {
       pixelRatio: pixelRatio,
       images: _images,
       precomputed: stripPlan,
+      enableSlugGlyphs: slugGlyphs,
     );
     final ui.Picture picture;
     try {
@@ -276,6 +314,10 @@ class PdfRetainedScene {
       replayCommands(commands, device);
       StripPdfDevice.totalRouteMicros += sw.elapsedMicroseconds;
       await device.finish(); // must precede endRecording
+      onSlugStats?.call((
+        quads: device.slugQuadCount,
+        fallbackOutlineRuns: device.slugFallbackOutlineRuns,
+      ));
       picture = recorder.endRecording();
     } catch (_) {
       recorder.endRecording().dispose();

--- a/packages/dart_pdf_editor/lib/src/strips/slug_batch.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/slug_batch.dart
@@ -1,0 +1,311 @@
+// Slug glyph batching (B3): per-outline curve streams (built once, cached
+// by outline identity) assembled per flush into a slot-directory curve
+// atlas, drawn as glyph quads through shaders/pdf_slug.frag.
+//
+// Per-glyph data reaches the shader through the two texcoord floats alone
+// (vertex colors only modulate). A slot is one (outline, quantized px/em
+// scale) pair per batch; every occurrence of that glyph at that scale
+// shares the slot. Slots stack along v in cells of a per-batch constant
+// height (cellHeight, texcoord units == record-time device pixels):
+//   u = 2 + (emX - minX) * S      S = quantized px/em (the slot key)
+//   v = slot * cellHeight + 2 + (emY - minY) * S
+// (minX/minY are the slot's fixed-point-quantized band bbox, exactly what
+// the shader decodes from the directory, so the inversion is exact).
+//
+// Texcoord units MUST be device-pixel-scaled: Impeller evaluates
+// drawVertices runtime effects on an integer-aligned texcoord-unit grid
+// (it snapshots the effect at ~1 texel per unit and samples that with the
+// vertex UVs - measured, see the 2026-07-10 slug dev-log), so em-unit
+// texcoords would collapse a glyph to a single evaluated sample. The
+// 2-texel cell inset keeps Impeller's bilinear snapshot resampling from
+// bleeding across slot cells. Skia evaluates per fragment directly; both
+// backends see the same GLSL.
+//
+// The atlas starts with a 4-texel directory entry per slot (stream base as
+// a u16 pair, band geometry and AA scale - see pdf_slug.frag), followed by
+// the glyphs' relocatable texel streams verbatim (their internal offsets
+// are stream-relative by design, curve_quads.dart).
+//
+// The atlas is rebuilt per flush (streams are memcpys of cached bytes;
+// noted cost - a persistent cross-flush atlas is a later optimization).
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+
+/// Curve atlas width in texels.
+const int slugAtlasWidth = 512;
+
+/// Per-outline Slug data: the relocatable texel stream + band geometry,
+/// built once per outline identity ([of] memoizes via Expando, the same
+/// lifetime pattern as [FlattenedOutline]). [overflow] marks glyphs that
+/// exceed the band cap (or failed to encode) - callers use outline strips.
+class SlugGlyphData {
+  SlugGlyphData._(this.stream, this.texelCount, this.bandCount, this.minX,
+      this.minY, this.maxX, this.maxY, this.overflow)
+      : qMinX = stream == null ? 0 : fixedToEm(emToFixed(minX)),
+        qMinY = stream == null ? 0 : fixedToEm(emToFixed(minY));
+
+  final Uint8List? stream;
+  final int texelCount;
+  final int bandCount;
+  final double minX, minY, maxX, maxY;
+
+  /// [minX]/[minY] through the directory's fixed-point quantization - the
+  /// exact values the shader decodes, used for the texcoord mapping so the
+  /// em recovery inverts exactly.
+  final double qMinX, qMinY;
+
+  final bool overflow;
+
+  static final Expando<SlugGlyphData> _cache = Expando('SlugGlyphData');
+
+  /// One-time build cost accounting (microseconds / outlines built).
+  static int totalBuildMicros = 0;
+  static int totalBuilds = 0;
+
+  static final SlugGlyphData _overflow =
+      SlugGlyphData._(null, 0, 0, 0, 0, 0, 0, true);
+
+  static SlugGlyphData of(PdfPath outline) {
+    final cached = _cache[outline];
+    if (cached != null) return cached;
+    final sw = Stopwatch()..start();
+    SlugGlyphData result;
+    try {
+      final quads = outlineToQuads(outline);
+      final bands = buildBands(quads, bandCount: 8);
+      if (quads.isEmpty || bands.overflow) {
+        result = _overflow;
+      } else {
+        final stream = encodeGlyphStream(quads, bands);
+        result = SlugGlyphData._(stream, stream.length ~/ 4, bands.bandCount,
+            bands.minX, bands.minY, bands.maxX, bands.maxY, false);
+      }
+    } on ArgumentError {
+      result = _overflow; // stream too large
+    }
+    totalBuildMicros += sw.elapsedMicroseconds;
+    totalBuilds++;
+    _cache[outline] = result;
+    return result;
+  }
+}
+
+/// One flushed batch of Slug glyph quads sharing one curve atlas.
+class SlugBatch {
+  SlugBatch._(this.chunks, this.atlasPixels, this.atlasWidth, this.atlasHeight,
+      this.quadCount, this.cellHeight);
+
+  final List<ui.Vertices> chunks;
+  final Uint8List atlasPixels;
+  final int atlasWidth;
+  final int atlasHeight;
+  final int quadCount;
+
+  /// Slot cell stride along v, in texcoord units (integer-valued); the
+  /// shader's uCellH uniform.
+  final double cellHeight;
+
+  ui.Image? atlas;
+
+  Future<void> decodeAtlas() {
+    final completer = Completer<void>();
+    ui.decodeImageFromPixels(
+        atlasPixels, atlasWidth, atlasHeight, ui.PixelFormat.rgba8888, (image) {
+      atlas = image;
+      completer.complete();
+    });
+    return completer.future;
+  }
+
+  void dispose() {
+    atlas?.dispose();
+    atlas = null;
+    for (final v in chunks) {
+      v.dispose();
+    }
+  }
+}
+
+/// Accumulates one flush window's Slug quads and assembles the [SlugBatch].
+class SlugBatchBuilder {
+  final Map<(PdfPath, int, int), int> _slots = {};
+  final List<SlugGlyphData> _slotData = [];
+  final List<int> _slotQsx = [];
+  final List<int> _slotQsy = [];
+
+  final FloatBuilder _positions = FloatBuilder(256);
+  final FloatBuilder _texs = FloatBuilder(256);
+  final List<int> _colors = [];
+  final List<int> _quadSlot = [];
+  double _maxCellH = 0;
+  int _quadCount = 0;
+  double _minPX = double.infinity, _minPY = double.infinity;
+  double _maxPX = double.negativeInfinity, _maxPY = double.negativeInfinity;
+
+  bool get isEmpty => _quadCount == 0;
+  int get quadCount => _quadCount;
+  int get slotCount => _slotData.length;
+
+  /// Page-space bbox of the pending quads - lets the device keep batching
+  /// when later vector paints don't overlap any pending glyph (painter's
+  /// order only matters where pixels overlap).
+  bool overlaps(double minX, double minY, double maxX, double maxY) =>
+      _quadCount != 0 &&
+      minX <= _maxPX &&
+      maxX >= _minPX &&
+      minY <= _maxPY &&
+      maxY >= _minPY;
+
+  /// Upper bound on the built batch's texcoord v extent
+  /// (slots x cell height). Impeller snapshots the runtime effect over the
+  /// texcoord bounds at ~1 texel per unit, so callers should flush before
+  /// this approaches the max texture size (see StripPdfDevice).
+  double get estimatedVExtent => _slotData.length * (_maxCellH + 4);
+
+  /// Adds one glyph occurrence: [emToPage] places the em-space quad in
+  /// page space; [pxPerEmX]/[pxPerEmY] are the record-time device scales
+  /// (they set the shader's AA ramp width, the texcoord scale - texcoord
+  /// units are record-time device pixels - and quantize into the slot key
+  /// at 1/16 px/em).
+  void addGlyph(PdfPath outline, SlugGlyphData data, PdfMatrix emToPage,
+      double pxPerEmX, double pxPerEmY, int argb) {
+    final qsx = (pxPerEmX * 16).round().clamp(1, 0xFFFF);
+    final qsy = (pxPerEmY * 16).round().clamp(1, 0xFFFF);
+    final slot = _slots.putIfAbsent((outline, qsx, qsy), () {
+      _slotData.add(data);
+      _slotQsx.add(qsx);
+      _slotQsy.add(qsy);
+      return _slotData.length - 1;
+    });
+    final sx = qsx / 16.0, sy = qsy / 16.0;
+
+    // em bbox padded by exactly one device pixel so the AA ramp fits
+    final padX = 16.0 / qsx, padY = 16.0 / qsy;
+    final x0 = data.minX - padX, x1 = data.maxX + padX;
+    final y0 = data.minY - padY, y1 = data.maxY + padY;
+    // texcoords in device-pixel units, local to the slot cell (the slot's
+    // v base is patched in at build() once the max cell height is known);
+    // the 2-texel inset leaves a >=1-texel guard band around the cell.
+    final u0 = 2.0 + (x0 - data.qMinX) * sx;
+    final u1 = 2.0 + (x1 - data.qMinX) * sx;
+    final lv0 = 2.0 + (y0 - data.qMinY) * sy;
+    final lv1 = 2.0 + (y1 - data.qMinY) * sy;
+    if (lv1 > _maxCellH) _maxCellH = lv1;
+    // corners in em order (x0,y0) (x1,y0) (x0,y1) (x1,y1)
+    final px0 = emToPage.transformX(x0, y0), py0 = emToPage.transformY(x0, y0);
+    final px1 = emToPage.transformX(x1, y0), py1 = emToPage.transformY(x1, y0);
+    final px2 = emToPage.transformX(x0, y1), py2 = emToPage.transformY(x0, y1);
+    final px3 = emToPage.transformX(x1, y1), py3 = emToPage.transformY(x1, y1);
+    _positions.add4(px0, py0, px1, py1);
+    _positions.add4(px2, py2, px3, py3);
+    _minPX = math.min(_minPX, math.min(math.min(px0, px1), math.min(px2, px3)));
+    _maxPX = math.max(_maxPX, math.max(math.max(px0, px1), math.max(px2, px3)));
+    _minPY = math.min(_minPY, math.min(math.min(py0, py1), math.min(py2, py3)));
+    _maxPY = math.max(_maxPY, math.max(math.max(py0, py1), math.max(py2, py3)));
+    _texs.add4(u0, lv0, u1, lv0);
+    _texs.add4(u0, lv1, u1, lv1);
+    _quadSlot.add(slot);
+    _colors.add(argb);
+    _colors.add(argb);
+    _colors.add(argb);
+    _colors.add(argb);
+    _quadCount++;
+  }
+
+  /// Assembles the batch (atlas + vertices) and resets the builder.
+  /// Returns null when empty.
+  SlugBatch? build() {
+    if (_quadCount == 0) return null;
+
+    // ---- curve atlas: directory + concatenated streams ----
+    final slotCount = _slotData.length;
+    var total = 4 * slotCount;
+    final bases = Int32List(slotCount);
+    for (var i = 0; i < slotCount; i++) {
+      bases[i] = total;
+      total += _slotData[i].texelCount;
+    }
+    final height = math.max(1, (total + slugAtlasWidth - 1) ~/ slugAtlasWidth);
+    final pixels = Uint8List(slugAtlasWidth * height * 4);
+    final u16 = ByteData.sublistView(pixels);
+    void put(int texel, int lo, int hi) {
+      u16.setUint16(texel * 4, lo, Endian.little);
+      u16.setUint16(texel * 4 + 2, hi, Endian.little);
+    }
+
+    for (var i = 0; i < slotCount; i++) {
+      final d = _slotData[i];
+      final base = bases[i];
+      put(4 * i, base & 0xFFFF, base >> 16);
+      put(4 * i + 1, emToFixed(d.minY),
+          emToFixed((d.maxY - d.minY) / d.bandCount));
+      put(4 * i + 2, emToFixed(d.minX),
+          emToFixed((d.maxX - d.minX) / d.bandCount));
+      put(4 * i + 3, _slotQsx[i], _slotQsy[i]);
+      pixels.setRange(base * 4, base * 4 + d.stream!.length, d.stream!);
+    }
+
+    // ---- vertices (Uint16 indices cap quads per draw) ----
+    const maxQuads = 16000;
+    final chunks = <ui.Vertices>[];
+    final positions = _positions.view;
+    final texs = _texs.view;
+    // patch each quad's v by its slot's cell base, now that the constant
+    // cell height (max over slots, +2 trailing guard texels) is known
+    final cellH = (_maxCellH + 2).ceilToDouble();
+    for (var q = 0; q < _quadCount; q++) {
+      final vBase = _quadSlot[q] * cellH;
+      final t = q * 8;
+      texs[t + 1] += vBase;
+      texs[t + 3] += vBase;
+      texs[t + 5] += vBase;
+      texs[t + 7] += vBase;
+    }
+    for (var start = 0; start < _quadCount; start += maxQuads) {
+      final count = math.min(maxQuads, _quadCount - start);
+      final pos =
+          Float32List.sublistView(positions, start * 8, (start + count) * 8);
+      final tex = Float32List.sublistView(texs, start * 8, (start + count) * 8);
+      final colors = Int32List(count * 4);
+      for (var i = 0; i < count * 4; i++) {
+        colors[i] = _colors[start * 4 + i];
+      }
+      final indices = Uint16List(count * 6);
+      for (var q = 0; q < count; q++) {
+        final v = q * 4, ix = q * 6;
+        indices[ix] = v;
+        indices[ix + 1] = v + 1;
+        indices[ix + 2] = v + 2;
+        indices[ix + 3] = v + 1;
+        indices[ix + 4] = v + 3;
+        indices[ix + 5] = v + 2;
+      }
+      chunks.add(ui.Vertices.raw(
+          ui.VertexMode.triangles, Float32List.fromList(pos),
+          textureCoordinates: Float32List.fromList(tex),
+          colors: colors,
+          indices: indices));
+    }
+
+    final batch =
+        SlugBatch._(chunks, pixels, slugAtlasWidth, height, _quadCount, cellH);
+    _slots.clear();
+    _slotData.clear();
+    _slotQsx.clear();
+    _slotQsy.clear();
+    _positions.clear();
+    _texs.clear();
+    _colors.clear();
+    _quadSlot.clear();
+    _maxCellH = 0;
+    _quadCount = 0;
+    _minPX = _minPY = double.infinity;
+    _maxPX = _maxPY = double.negativeInfinity;
+    return batch;
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -67,20 +67,25 @@ class StripPdfDevice extends StripBinningDevice {
     Map<Object, ui.Image> images = const {},
     StripPlan? precomputed,
     double slugMinGlyphPx = 4,
-  }) =>
-      StripPdfDevice._(
-        canvas,
-        usablePlan(precomputed,
-            pageToDevice: pageToDevice,
-            deviceWidth: deviceWidth,
-            deviceHeight: deviceHeight),
-        pageToDevice: pageToDevice,
-        deviceWidth: deviceWidth,
-        deviceHeight: deviceHeight,
-        pixelRatio: pixelRatio,
-        images: images,
-        slugMinGlyphPx: slugMinGlyphPx,
-      );
+    bool? enableSlugGlyphs,
+  }) {
+    final slugEnabled = enableSlugGlyphs ?? slugGlyphs;
+    return StripPdfDevice._(
+      canvas,
+      usablePlan(precomputed,
+          pageToDevice: pageToDevice,
+          deviceWidth: deviceWidth,
+          deviceHeight: deviceHeight,
+          slugEnabled: slugEnabled),
+      pageToDevice: pageToDevice,
+      deviceWidth: deviceWidth,
+      deviceHeight: deviceHeight,
+      pixelRatio: pixelRatio,
+      images: images,
+      slugMinGlyphPx: slugMinGlyphPx,
+      slugEnabled: slugEnabled,
+    );
+  }
 
   StripPdfDevice._(
     this.canvas,
@@ -91,8 +96,9 @@ class StripPdfDevice extends StripBinningDevice {
     required super.pixelRatio,
     required this.images,
     required this.slugMinGlyphPx,
+    required bool slugEnabled,
   })  : _deviceToPage = _invertToMatrix4(pageToDevice),
-        _slugEnabled = slugGlyphs,
+        _slugEnabled = slugEnabled,
         super(
           // A usable plan replaces local binning entirely; the debug
           // verification mode bins locally TOO so emitBatch can compare.
@@ -122,9 +128,15 @@ class StripPdfDevice extends StripBinningDevice {
     required PdfMatrix pageToDevice,
     required int deviceWidth,
     required int deviceHeight,
+    bool slugEnabled = false,
   }) {
     if (plan == null) return null;
-    if (slugGlyphs) return null;
+    // Worker plans currently route outline text into strips. Slug changes
+    // that routing, so a caller explicitly recording a transform-time Slug
+    // picture must bin locally rather than consume a structurally different
+    // plan. The normal dense-page raster path keeps slugEnabled false and
+    // continues consuming worker plans unchanged.
+    if (slugEnabled) return null;
     if (debugDelegateAll ||
         debugDelegateFills ||
         debugDelegateStrokes ||
@@ -157,6 +169,12 @@ class StripPdfDevice extends StripBinningDevice {
   final double slugMinGlyphPx;
   SlugBatchBuilder? _slugBuilder;
   final List<SlugBatch> _slugBatches = [];
+  int _slugQuadCount = 0;
+  int _slugFallbackOutlineRuns = 0;
+
+  /// Per-device Slug routing result, unlike the aggregate benchmark stats.
+  int get slugQuadCount => _slugQuadCount;
+  int get slugFallbackOutlineRuns => _slugFallbackOutlineRuns;
 
   final ui.Canvas canvas;
 
@@ -388,6 +406,7 @@ class StripPdfDevice extends StripBinningDevice {
     // painter order without changing StripBinningDevice's flush ordinals.
     flushPending();
     if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, 1))) {
+      _slugFallbackOutlineRuns++;
       super.drawText(run);
       return;
     }
@@ -435,6 +454,7 @@ class StripPdfDevice extends StripBinningDevice {
     _slugBatches.add(batch);
     totalFlushes++;
     totalSlugQuads += batch.quadCount;
+    _slugQuadCount += batch.quadCount;
     totalSlugAtlasTexels += batch.atlasWidth * batch.atlasHeight;
   }
 

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -22,6 +22,7 @@
 // A strip picture is only valid at the pixel ratio it was recorded for:
 // the quads are device-pixel-aligned and the coverage was resolved at that
 // ratio (rescaling filters the strips like any raster).
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -30,6 +31,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_graphics/raster.dart';
 
 import '../canvas_device.dart';
+import 'slug_batch.dart';
 import 'strip_batch.dart';
 
 export 'package:pdf_graphics/raster.dart'
@@ -64,6 +66,7 @@ class StripPdfDevice extends StripBinningDevice {
     required double pixelRatio,
     Map<Object, ui.Image> images = const {},
     StripPlan? precomputed,
+    double slugMinGlyphPx = 4,
   }) =>
       StripPdfDevice._(
         canvas,
@@ -76,6 +79,7 @@ class StripPdfDevice extends StripBinningDevice {
         deviceHeight: deviceHeight,
         pixelRatio: pixelRatio,
         images: images,
+        slugMinGlyphPx: slugMinGlyphPx,
       );
 
   StripPdfDevice._(
@@ -86,7 +90,9 @@ class StripPdfDevice extends StripBinningDevice {
     required super.deviceHeight,
     required super.pixelRatio,
     required this.images,
+    required this.slugMinGlyphPx,
   })  : _deviceToPage = _invertToMatrix4(pageToDevice),
+        _slugEnabled = slugGlyphs,
         super(
           // A usable plan replaces local binning entirely; the debug
           // verification mode bins locally TOO so emitBatch can compare.
@@ -118,6 +124,7 @@ class StripPdfDevice extends StripBinningDevice {
     required int deviceHeight,
   }) {
     if (plan == null) return null;
+    if (slugGlyphs) return null;
     if (debugDelegateAll ||
         debugDelegateFills ||
         debugDelegateStrokes ||
@@ -139,6 +146,17 @@ class StripPdfDevice extends StripBinningDevice {
     }
     return plan;
   }
+
+  /// Experimental Slug glyph rendering (B3): outline text draws as
+  /// em-space quads evaluated by shaders/pdf_slug.frag against a per-flush
+  /// curve atlas instead of strip binning; glyphs whose band lists
+  /// overflow keep the strip path. Snapshotted per device at construction.
+  static bool slugGlyphs = false;
+
+  final bool _slugEnabled;
+  final double slugMinGlyphPx;
+  SlugBatchBuilder? _slugBuilder;
+  final List<SlugBatch> _slugBatches = [];
 
   final ui.Canvas canvas;
 
@@ -180,6 +198,10 @@ class StripPdfDevice extends StripBinningDevice {
   /// Pictures painted from a verified precomputed plan (no local binning).
   static int totalPlanPictures = 0;
 
+  /// Slug-mode stats: glyph quads drawn and curve-atlas texels uploaded.
+  static int totalSlugQuads = 0;
+  static int totalSlugAtlasTexels = 0;
+
   static void resetStats() {
     totalFlushes = 0;
     totalStripQuads = 0;
@@ -190,11 +212,14 @@ class StripPdfDevice extends StripBinningDevice {
     totalRouteMicros = 0;
     totalPlanMismatches = 0;
     totalPlanPictures = 0;
+    totalSlugQuads = 0;
+    totalSlugAtlasTexels = 0;
   }
 
   int get flushCount => _batches.length;
 
   static Future<ui.FragmentProgram>? _programFuture;
+  static Future<ui.FragmentProgram>? _slugProgramFuture;
 
   static Future<ui.FragmentProgram> _loadProgram() =>
       _programFuture ??= () async {
@@ -203,6 +228,16 @@ class StripPdfDevice extends StripBinningDevice {
         } catch (_) {
           return ui.FragmentProgram.fromAsset(
               'packages/dart_pdf_editor/shaders/pdf_strips.frag');
+        }
+      }();
+
+  static Future<ui.FragmentProgram> _loadSlugProgram() =>
+      _slugProgramFuture ??= () async {
+        try {
+          return await ui.FragmentProgram.fromAsset('shaders/pdf_slug.frag');
+        } catch (_) {
+          return ui.FragmentProgram.fromAsset(
+              'packages/dart_pdf_editor/shaders/pdf_slug.frag');
         }
       }();
 
@@ -332,6 +367,77 @@ class StripPdfDevice extends StripBinningDevice {
   void delegateDrawImage(PdfImageRequest request) =>
       _paint((d) => d.drawImage(request));
 
+  @override
+  void drawText(PdfTextRun run) {
+    final glyphs = run.glyphs;
+    if (!_slugEnabled ||
+        run.invisible ||
+        !stripsActive ||
+        delegateText ||
+        glyphs == null ||
+        !run.fill ||
+        run.strokeColor != null ||
+        run.gradient != null) {
+      super.drawText(run);
+      return;
+    }
+
+    // Finish strips that precede this run, then commit the complete run as one
+    // Slug batch immediately. Immediate commit is deliberately conservative
+    // while the worker-plan and glyph-layer paths are integrated: it preserves
+    // painter order without changing StripBinningDevice's flush ordinals.
+    flushPending();
+    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, 1))) {
+      super.drawText(run);
+      return;
+    }
+    _flushSlug();
+  }
+
+  static const double _slugMaxVExtent = 8192;
+
+  bool _addSlugRun(List<PdfGlyphPlacement> glyphs, PdfTextRun run, int color) {
+    final deviceTransform = run.transform.concat(pageToDevice);
+    final sx = math.sqrt(deviceTransform.a * deviceTransform.a +
+        deviceTransform.b * deviceTransform.b);
+    final sy = math.sqrt(deviceTransform.c * deviceTransform.c +
+        deviceTransform.d * deviceTransform.d);
+    if (math.max(sx, sy) < slugMinGlyphPx) return false;
+
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline != null && SlugGlyphData.of(outline).overflow) return false;
+    }
+
+    final builder = _slugBuilder ??= SlugBatchBuilder();
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline == null) continue;
+      final emToPage = PdfMatrix.translation(glyph.offset, glyph.offsetY)
+          .concat(run.transform);
+      builder.addGlyph(
+        outline,
+        SlugGlyphData.of(outline),
+        emToPage,
+        sx,
+        sy,
+        color,
+      );
+    }
+    if (builder.estimatedVExtent > _slugMaxVExtent) _flushSlug();
+    return true;
+  }
+
+  void _flushSlug() {
+    final batch = _slugBuilder?.build();
+    if (batch == null) return;
+    _tape.add(batch);
+    _slugBatches.add(batch);
+    totalFlushes++;
+    totalSlugQuads += batch.quadCount;
+    totalSlugAtlasTexels += batch.atlasWidth * batch.atlasHeight;
+  }
+
   // ---- painting ---------------------------------------------------------
 
   /// Decodes every batch's alpha atlas, then replays the tape onto
@@ -342,6 +448,7 @@ class StripPdfDevice extends StripBinningDevice {
     assert(!_finished, 'StripPdfDevice.finish() called twice');
     _finished = true;
     flushPending();
+    _flushSlug();
     final plan = _plan;
     if (plan != null &&
         (flushPointCount != plan.totalFlushPoints ||
@@ -358,7 +465,11 @@ class StripPdfDevice extends StripBinningDevice {
     if (plan != null && !debugVerifyPrecomputed) totalPlanPictures++;
     final sw = Stopwatch()..start();
     final program = await _loadProgram();
-    await Future.wait([for (final b in _batches) b.decodeAtlas()]);
+    final slugProgram = _slugBatches.isEmpty ? null : await _loadSlugProgram();
+    await Future.wait([
+      for (final b in _batches) b.decodeAtlas(),
+      for (final b in _slugBatches) b.decodeAtlas(),
+    ]);
     totalAtlasDecodeMicros += sw.elapsedMicroseconds;
 
     sw.reset();
@@ -366,6 +477,8 @@ class StripPdfDevice extends StripBinningDevice {
     for (final entry in _tape) {
       if (entry is StripBatch) {
         _drawBatch(program, entry);
+      } else if (entry is SlugBatch) {
+        _drawSlugBatch(slugProgram!, entry);
       } else {
         (entry as void Function(CanvasPdfDevice))(fallback);
       }
@@ -373,11 +486,35 @@ class StripPdfDevice extends StripBinningDevice {
     totalReplayMicros += sw.elapsedMicroseconds;
   }
 
+  /// Debug: slug shader diagnostic output mode (see pdf_slug.frag uDebug).
+  static double debugSlugMode = 0;
+
+  /// Debug: mode parameter (uDebug.y - e.g. curve index for mode 3).
+  static double debugSlugParam = 0;
+
+  /// Slug quads are page-space geometry - no device->page transform.
+  void _drawSlugBatch(ui.FragmentProgram program, SlugBatch batch) {
+    final shader = program.fragmentShader()
+      ..setFloat(0, batch.atlasWidth.toDouble())
+      ..setFloat(1, batch.atlasHeight.toDouble())
+      ..setFloat(2, debugSlugMode)
+      ..setFloat(3, debugSlugParam)
+      ..setFloat(4, batch.cellHeight)
+      ..setImageSampler(0, batch.atlas!);
+    final paint = ui.Paint()..shader = shader;
+    for (final chunk in batch.chunks) {
+      canvas.drawVertices(chunk, ui.BlendMode.modulate, paint);
+    }
+  }
+
   /// Releases the decoded atlas images and vertex buffers. Call after the
   /// recording that [finish] painted into has ended (the picture keeps its
   /// own references).
   void dispose() {
     for (final b in _batches) {
+      b.dispose();
+    }
+    for (final b in _slugBatches) {
       b.dispose();
     }
   }

--- a/packages/dart_pdf_editor/lib/strips.dart
+++ b/packages/dart_pdf_editor/lib/strips.dart
@@ -8,5 +8,6 @@
 /// direct/off-label use.
 library;
 
+export 'src/strips/slug_batch.dart';
 export 'src/strips/strip_batch.dart';
 export 'src/strips/strip_device.dart';

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -53,6 +53,7 @@ flutter:
   shaders:
     - shaders/pdf_probe.frag
     - shaders/pdf_strips.frag
+    - shaders/pdf_slug.frag
   assets:
     - assets/web/pdf_render_worker.dart.js
     - assets/fonts/DejaVuSans.ttf

--- a/packages/dart_pdf_editor/shaders/pdf_slug.frag
+++ b/packages/dart_pdf_editor/shaders/pdf_slug.frag
@@ -1,0 +1,200 @@
+#version 460 core
+
+// Slug-style glyph shader (B3): evaluates glyph coverage directly from
+// quadratic outlines packed in an rgba8888 curve atlas
+// (pdf_graphics/raster curve_quads.dart - see its header for the stream
+// layout and the AA formula; the Dart glyphCoverageAA is the reference
+// this shader mirrors step for step).
+//
+// Per-glyph data arrives through the two texcoord floats alone (vertex
+// colors are not readable in a runtime effect - they only modulate the
+// output): glyphs occupy virtual slot cells stacked along v with constant
+// stride uCellH, in DEVICE-PIXEL texcoord units (slug_batch.dart explains
+// why - Impeller evaluates this effect on an integer texcoord-unit grid):
+//   u = 2 + (emX - minX) * S       S = record-time device px per em
+//   v = slot * uCellH + 2 + (emY - minY) * S
+// so slot = floor(v / uCellH) and the em position inverts through the
+// slot's directory entry. A 4-texel directory entry per slot at the atlas
+// start supplies the glyph's stream base, band geometry, and S:
+//   dir 0: (baseLo, baseHi)   raw u16 pair, base = lo + hi * 65536
+//   dir 1: (minY, bandHeight) fixed-point em
+//   dir 2: (minX, bandWidth)  fixed-point em
+//   dir 3: (sx, sy)           px/em * 16, raw u16
+//
+// SkSL subset: constant-bound loops (MAX_CURVES_PER_BAND = 16) with early
+// break, no bit ops (16-bit LE pairs decode via dot products on the
+// 0..255-scaled channels), no texelFetch (half-texel-centered texture()
+// reads, M0-verified byte-exact).
+
+precision highp float;
+
+#include <flutter/runtime_effect.glsl>
+
+uniform vec2 uAtlasSize; // curve atlas size in texels
+uniform vec2 uDebug;     // x > 0.5: dump diagnostics (y = mode parameter)
+uniform float uCellH;    // slot cell stride along v, texcoord units
+uniform sampler2D uAtlas;
+
+out vec4 fragColor;
+
+// Reads texel [t] as two 16-bit little-endian unsigned values. Every
+// encoded value is an integer u16, but the sampler normalizes bytes to
+// [0,1] and the *255 rescale double-rounds: 7/255*255 can come back as
+// 7.0000003, which breaks exact comparisons (a loop `i >= count` break
+// that never fires walks past the band list into garbage refs - the bug
+// that cost the first B3 session). floor(+0.5) restores exact integers.
+vec2 readPair(float t) {
+  float ax = mod(t, uAtlasSize.x);
+  float ay = floor(t / uAtlasSize.x);
+  vec4 texel = texture(uAtlas, (vec2(ax, ay) + 0.5) / uAtlasSize);
+  return floor(vec2(dot(texel.rg, vec2(255.0, 65280.0)),
+                    dot(texel.ba, vec2(255.0, 65280.0))) + 0.5);
+}
+
+// Fixed-point pair -> em coordinates.
+vec2 readEm(float t) {
+  return (readPair(t) - 32768.0) / 8192.0;
+}
+
+void main() {
+  vec2 uv = FlutterFragCoord().xy; // texcoord space (M0)
+  if (uDebug.x > 3.5) {
+    // raw varying dump: u, v/8, fract(v)
+    fragColor = vec4(clamp(uv.x, 0.0, 1.0), clamp(uv.y / 8.0, 0.0, 1.0),
+        fract(uv.y), 1.0);
+    return;
+  }
+  float slot = floor(uv.y / uCellH);
+
+  vec2 dir0 = readPair(slot * 4.0);
+  float base = dir0.x + dir0.y * 65536.0;
+  vec2 dir1 = (readPair(slot * 4.0 + 1.0) - 32768.0) / 8192.0; // minY, bandH
+  vec2 dir2 = (readPair(slot * 4.0 + 2.0) - 32768.0) / 8192.0; // minX, bandW
+  vec2 dir3 = readPair(slot * 4.0 + 3.0) / 16.0;               // sx, sy
+
+  // invert the device-pixel texcoord mapping back to em space
+  float emX = dir2.x + (uv.x - 2.0) / dir3.x;
+  float emY = dir1.x + (uv.y - slot * uCellH - 2.0) / dir3.y;
+
+  float bandCount = readPair(base).x;
+
+  // Crossing counts/signs come from strict endpoint comparisons - never
+  // root-in-range tests - so joints (shared, fixed-point-identical
+  // endpoints) count exactly once. Mirrors _rayCrossings in
+  // curve_quads.dart.
+
+  // horizontal ray (+x): crossings of Y(t) = emY weighted by px distance
+  float hb = clamp(floor((emY - dir1.x) / dir1.y), 0.0, bandCount - 1.0);
+  vec2 hTable = readPair(base + 1.0 + hb); // list offset (relative), count
+  float covH = 0.0;
+  float dbgD = 0.0;
+  float dbgE0 = 0.0;
+  float dbgE1 = 0.0;
+  for (int i = 0; i < 16; i++) {
+    if (float(i) >= hTable.y) break;
+    float curveT = base + readPair(base + hTable.x + float(i)).x;
+    vec2 p0 = readEm(curveT);
+    vec2 pc = readEm(curveT + 1.0);
+    vec2 p1 = readEm(curveT + 2.0);
+    float e0 = p0.y - emY;
+    float e1 = p1.y - emY;
+    bool s0 = e0 > 0.0;
+    bool s1 = e1 > 0.0;
+    float a = e0 - 2.0 * (pc.y - emY) + e1;
+    float b = 2.0 * ((pc.y - emY) - e0);
+    // stable roots (see curve_quads.dart _rayCrossings): q never cancels,
+    // small root = e0/q, large root = q/a
+    float sq = sqrt(max(b * b - 4.0 * a * e0, 0.0));
+    float qq = -0.5 * (b + (b >= 0.0 ? sq : -sq));
+    float tA = abs(a) > 1e-12 ? qq / a : 2.0;
+    float tB = abs(qq) > 1e-12 ? e0 / qq : 2.0;
+    float d = 0.0;
+    if (s0 != s1) {
+      float t = (tB >= 0.0 && tB <= 1.0) ? tB : tA;
+      t = clamp(t, 0.0, 1.0);
+      float mt = 1.0 - t;
+      float xt = mt * mt * p0.x + 2.0 * mt * t * pc.x + t * t * p1.x;
+      float w = clamp((xt - emX) * dir3.x + 0.5, 0.0, 1.0);
+      d = s1 ? w : -w;
+    } else if (b * b - 4.0 * a * e0 > 0.0 &&
+        tA > 0.0 && tA < 1.0 && tB > 0.0 && tB < 1.0) {
+      float tMin = min(tA, tB);
+      float tMax = max(tA, tB);
+      float mtA = 1.0 - tMin;
+      float xA = mtA * mtA * p0.x + 2.0 * mtA * tMin * pc.x + tMin * tMin * p1.x;
+      float mtB = 1.0 - tMax;
+      float xB = mtB * mtB * p0.x + 2.0 * mtB * tMax * pc.x + tMax * tMax * p1.x;
+      float wMin = clamp((xA - emX) * dir3.x + 0.5, 0.0, 1.0);
+      float wMax = clamp((xB - emX) * dir3.x + 0.5, 0.0, 1.0);
+      d = s0 ? (wMax - wMin) : (wMin - wMax);
+    }
+    covH += d;
+    if (uDebug.x > 2.5 && abs(float(i) - uDebug.y) < 0.5) {
+      dbgD = d;
+      dbgE0 = e0;
+      dbgE1 = e1;
+    }
+  }
+
+  // vertical ray (+y): crossings of X(t) = emX, sign(-X'(t)) convention
+  float vb = clamp(floor((emX - dir2.x) / dir2.y), 0.0, bandCount - 1.0);
+  vec2 vTable = readPair(base + 1.0 + bandCount + vb);
+  float covV = 0.0;
+  for (int i = 0; i < 16; i++) {
+    if (float(i) >= vTable.y) break;
+    float curveT = base + readPair(base + vTable.x + float(i)).x;
+    vec2 p0 = readEm(curveT);
+    vec2 pc = readEm(curveT + 1.0);
+    vec2 p1 = readEm(curveT + 2.0);
+    float e0 = p0.x - emX;
+    float e1 = p1.x - emX;
+    bool s0 = e0 > 0.0;
+    bool s1 = e1 > 0.0;
+    float a = e0 - 2.0 * (pc.x - emX) + e1;
+    float b = 2.0 * ((pc.x - emX) - e0);
+    float sq = sqrt(max(b * b - 4.0 * a * e0, 0.0));
+    float qq = -0.5 * (b + (b >= 0.0 ? sq : -sq));
+    float tA = abs(a) > 1e-12 ? qq / a : 2.0;
+    float tB = abs(qq) > 1e-12 ? e0 / qq : 2.0;
+    if (s0 != s1) {
+      float t = (tB >= 0.0 && tB <= 1.0) ? tB : tA;
+      t = clamp(t, 0.0, 1.0);
+      float mt = 1.0 - t;
+      float yt = mt * mt * p0.y + 2.0 * mt * t * pc.y + t * t * p1.y;
+      float w = clamp((yt - emY) * dir3.y + 0.5, 0.0, 1.0);
+      covV += s1 ? -w : w;
+    } else if (b * b - 4.0 * a * e0 > 0.0 &&
+        tA > 0.0 && tA < 1.0 && tB > 0.0 && tB < 1.0) {
+      float tMin = min(tA, tB);
+      float tMax = max(tA, tB);
+      float mtA = 1.0 - tMin;
+      float yA = mtA * mtA * p0.y + 2.0 * mtA * tMin * pc.y + tMin * tMin * p1.y;
+      float mtB = 1.0 - tMax;
+      float yB = mtB * mtB * p0.y + 2.0 * mtB * tMax * pc.y + tMax * tMax * p1.y;
+      float wMin = clamp((yA - emY) * dir3.y + 0.5, 0.0, 1.0);
+      float wMax = clamp((yB - emY) * dir3.y + 0.5, 0.0, 1.0);
+      covV += s0 ? (wMin - wMax) : (wMax - wMin);
+    }
+  }
+
+  if (uDebug.x > 2.5) {
+    // per-curve H diagnostics for curve index uDebug.y
+    fragColor = vec4(dbgD * 0.25 + 0.5, dbgE0 * 0.25 + 0.5,
+        dbgE1 * 0.25 + 0.5, 1.0);
+    return;
+  }
+  if (uDebug.x > 1.5) {
+    // ray sums: |covH|, |covV|, signed covH
+    fragColor = vec4(clamp(abs(covH), 0.0, 1.0), clamp(abs(covV), 0.0, 1.0),
+        clamp(covH * 0.25 + 0.5, 0.0, 1.0), 1.0);
+    return;
+  }
+  if (uDebug.x > 0.5) {
+    fragColor = vec4(hb / 8.0, hTable.y / 16.0, emY / 4.0 + 0.5, 1.0);
+    return;
+  }
+  float cov = (min(abs(covH), 1.0) + min(abs(covV), 1.0)) * 0.5;
+  // premultiplied white x coverage; tint rides per-vertex colors through
+  // BlendMode.modulate, exactly like pdf_strips.frag
+  fragColor = vec4(cov);
+}

--- a/packages/dart_pdf_editor/test/slug_atlas_probe_test.dart
+++ b/packages/dart_pdf_editor/test/slug_atlas_probe_test.dart
@@ -1,0 +1,139 @@
+// Probe: walk the assembled slug atlas in Dart exactly like the shader
+// and compare against glyphCoverageAA - splits atlas-assembly bugs from
+// shader-semantics bugs.
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+// ignore: implementation_imports
+import 'package:pdf_graphics/src/fonts/truetype.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+void main() {
+  test('atlas walk matches glyphCoverageAA', () {
+    final font = TrueTypeFont.parse(
+        File('assets/fonts/DejaVuSans.ttf').readAsBytesSync())!;
+    final outline = font.outlineForGlyph(font.gidForUnicode(0x67))!; // g
+    final quads = outlineToQuads(outline);
+    final bands = buildBands(quads, bandCount: 8);
+    final data = SlugGlyphData.of(outline);
+    expect(data.overflow, isFalse);
+
+    final builder = SlugBatchBuilder();
+    const size = 24.0;
+    const emToPage = PdfMatrix(size, 0, 0, -size, 4, 22);
+    builder.addGlyph(outline, data, emToPage, size, size, 0xFF000000);
+    final batch = builder.build()!;
+    final px = batch.atlasPixels;
+    final u16 = ByteData.sublistView(px);
+    (double, double) pair(int t) => (
+          u16.getUint16(t * 4, Endian.little).toDouble(),
+          u16.getUint16(t * 4 + 2, Endian.little).toDouble(),
+        );
+    (double, double) em(int t) {
+      final (a, b) = pair(t);
+      return ((a - 32768) / 8192, (b - 32768) / 8192);
+    }
+
+    double walk(double emX, double emY) {
+      final (baseLo, baseHi) = pair(0);
+      final base = (baseLo + baseHi * 65536).toInt();
+      final (minY, bandH) = em(1);
+      final (minX, bandW) = em(2);
+      final (sx16, sy16) = pair(3);
+      final sx = sx16 / 16, sy = sy16 / 16;
+      final (bandCountD, _) = pair(base);
+      final bandCount = bandCountD.toInt();
+
+      double ray(bool vertical) {
+        final level = vertical ? emX : emY;
+        final bandIdx = vertical
+            ? ((emX - minX) / bandW).floor().clamp(0, bandCount - 1)
+            : ((emY - minY) / bandH).floor().clamp(0, bandCount - 1);
+        final tableTexel = base + 1 + (vertical ? bandCount : 0) + bandIdx;
+        final (offD, countD) = pair(tableTexel);
+        var cov = 0.0;
+        for (var i = 0; i < countD.toInt(); i++) {
+          final (refD, _) = pair(base + offD.toInt() + i);
+          final t0 = base + refD.toInt();
+          final (x0, y0) = em(t0);
+          final (cx, cy) = em(t0 + 1);
+          final (x1, y1) = em(t0 + 2);
+          final e0 = (vertical ? x0 : y0) - level;
+          final ec = (vertical ? cx : cy) - level;
+          final e1 = (vertical ? x1 : y1) - level;
+          final q0 = vertical ? y0 : x0;
+          final qc = vertical ? cy : cx;
+          final q1 = vertical ? y1 : x1;
+          final origin = vertical ? emY : emX;
+          final scale = vertical ? sy : sx;
+          final s0 = e0 > 0, s1 = e1 > 0;
+          final a = e0 - 2 * ec + e1;
+          final b = 2 * (ec - e0);
+          double at(double t) {
+            final mt = 1 - t;
+            return mt * mt * q0 + 2 * mt * t * qc + t * t * q1;
+          }
+
+          double weight(double t) =>
+              ((at(t) - origin) * scale + 0.5).clamp(0.0, 1.0);
+          final r = sqRoot(b * b - 4 * a * e0);
+          final q = -0.5 * (b + (b >= 0 ? r : -r));
+          final tA = a.abs() > 1e-12 ? q / a : 2.0;
+          final tB = q.abs() > 1e-12 ? e0 / q : 2.0;
+          if (s0 != s1) {
+            final t = (tB >= 0 && tB <= 1) ? tB : tA;
+            final w = weight(t.clamp(0.0, 1.0));
+            final up = vertical ? !s1 : s1;
+            cov += up ? w : -w;
+          } else if (b * b - 4 * a * e0 > 0 &&
+              tA > 0 && tA < 1 && tB > 0 && tB < 1) {
+            final wMin = weight(math.min(tA, tB));
+            final wMax = weight(math.max(tA, tB));
+            var sum = s0 ? (wMax - wMin) : (wMin - wMax);
+            if (vertical) sum = -sum;
+            cov += sum;
+          }
+        }
+        return cov;
+      }
+
+      final h = ray(false).abs().clamp(0.0, 1.0);
+      final v = ray(true).abs().clamp(0.0, 1.0);
+      return (h + v) / 2;
+    }
+
+    const m = emToPage;
+    final inv = m.inverted()!;
+    var worst = 0.0;
+    var sum = 0.0;
+    for (var py = 0; py < 32; py++) {
+      for (var pxi = 0; pxi < 32; pxi++) {
+        final ex = inv.transformX(pxi + 0.5, py + 0.5);
+        final ey = inv.transformY(pxi + 0.5, py + 0.5);
+        final want = glyphCoverageAA(quads, bands, ex, ey, size, size);
+        final got = walk(ex, ey);
+        final d = (got - want).abs() * 255;
+        sum += d;
+        if (d > worst) {
+          worst = d;
+          if (d > 16) {
+            // ignore: avoid_print
+            print('ATLAS-WALK worst ($pxi,$py) got=${got.toStringAsFixed(3)} '
+                'want=${want.toStringAsFixed(3)} em=($ex,$ey)');
+          }
+        }
+      }
+    }
+    // ignore: avoid_print
+    print('ATLAS-WALK: mean ${(sum / 1024).toStringAsFixed(2)} '
+        'max ${worst.toStringAsFixed(1)}');
+    batch.dispose();
+    expect(worst, lessThanOrEqualTo(16));
+  });
+}
+
+double sqRoot(double v) => v <= 0 ? 0 : math.sqrt(v);

--- a/packages/dart_pdf_editor/test/slug_micro_probe_test.dart
+++ b/packages/dart_pdf_editor/test/slug_micro_probe_test.dart
@@ -1,0 +1,112 @@
+// Minimal synthetic glyphs (square/circle/triangle) through the real slug
+// shader path, asserted against the Dart glyphCoverageAA reference.
+// Impeller runs must set SLUG_IMPELLER=1 (record-resolution snapshot
+// resampling widens the tolerance - see slug_test.dart).
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+Future<Uint8List> renderGlyph(PdfPath outline, PdfMatrix emToPage,
+    int w, int h) async {
+  StripPdfDevice.slugGlyphs = true;
+  try {
+    final rec = ui.PictureRecorder();
+    final canvas = ui.Canvas(rec);
+    canvas.drawRect(ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+        ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+    final device = StripPdfDevice(canvas,
+        pageToDevice: PdfMatrix.identity,
+        deviceWidth: w,
+        deviceHeight: h,
+        pixelRatio: 1);
+    device.drawText(PdfTextRun(
+      text: 'x',
+      transform: emToPage,
+      color: PdfColor.black,
+      width: 1,
+      glyphs: [PdfGlyphPlacement(offset: 0, outline: outline)],
+    ));
+    await device.finish();
+    final pic = rec.endRecording();
+    final img = await pic.toImage(w, h);
+    final data = await img.toByteData(format: ui.ImageByteFormat.rawRgba);
+    img.dispose();
+    pic.dispose();
+    device.dispose();
+    return data!.buffer.asUint8List();
+  } finally {
+    StripPdfDevice.slugGlyphs = false;
+  }
+}
+
+final bool _impeller = Platform.environment['SLUG_IMPELLER'] == '1';
+
+Future<void> check(String name, PdfPath outline) async {
+  const w = 32, h = 32;
+  const m = PdfMatrix(24, 0, 0, -24, 4, 28);
+  final got = await renderGlyph(outline, m, w, h);
+  final quads = outlineToQuads(outline);
+  final bands = buildBands(quads, bandCount: 8);
+  final inv = m.inverted()!;
+  var worst = 0;
+  var sum = 0.0;
+  var worstAt = '';
+  for (var py = 0; py < h; py++) {
+    for (var px = 0; px < w; px++) {
+      final ex = inv.transformX(px + 0.5, py + 0.5);
+      final ey = inv.transformY(px + 0.5, py + 0.5);
+      final want = (255 * (1 - glyphCoverageAA(quads, bands, ex, ey, 24, 24)))
+          .round();
+      final d = (got[(py * w + px) * 4] - want).abs();
+      sum += d;
+      if (d > worst) {
+        worst = d;
+        worstAt = '($px,$py) got=${got[(py * w + px) * 4]} want=$want '
+            'em=(${ex.toStringAsFixed(3)},${ey.toStringAsFixed(3)})';
+      }
+    }
+  }
+  // ignore: avoid_print
+  print('MICRO $name: mean ${(sum / (w * h)).toStringAsFixed(2)} max $worst '
+      '$worstAt');
+  expect(sum / (w * h), lessThanOrEqualTo(_impeller ? 8.0 : 0.5),
+      reason: '$name mean');
+  expect(worst, lessThanOrEqualTo(_impeller ? 224 : 8), reason: '$name max');
+}
+
+void main() {
+  testWidgets('square + circle + triangle micro glyphs', (tester) async {
+    await tester.runAsync(() async {
+      await check(
+          'square',
+          PdfPath([
+            PdfMoveTo(0.1, 0.1),
+            PdfLineTo(0.8, 0.1),
+            PdfLineTo(0.8, 0.7),
+            PdfLineTo(0.1, 0.7),
+            const PdfClosePath(),
+          ]));
+      await check(
+          'circle',
+          PdfPath([
+            PdfMoveTo(0.45, 0.8),
+            PdfCubicTo(0.05, 0.8, 0.05, 0.1, 0.45, 0.1),
+            PdfCubicTo(0.85, 0.1, 0.85, 0.8, 0.45, 0.8),
+            const PdfClosePath(),
+          ]));
+      await check(
+          'triangle',
+          PdfPath([
+            PdfMoveTo(0.1, 0.1),
+            PdfLineTo(0.85, 0.15),
+            PdfLineTo(0.4, 0.75),
+            const PdfClosePath(),
+          ]));
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/slug_shader_debug_test.dart
+++ b/packages/dart_pdf_editor/test/slug_shader_debug_test.dart
@@ -1,0 +1,113 @@
+// Diagnostic harness (set SLUG_DEBUG=1 to run): dumps the slug shader's
+// internals - raw uv varying, band selection, per-ray sums, per-curve H
+// contributions - through pdf_slug.frag's uDebug modes. This is the tool
+// that found both B3 platform bugs (the u16-decode double-rounding loop
+// overrun and Impeller's texcoord-grid snapshot evaluation); keep it.
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+// ignore: implementation_imports
+import 'package:pdf_graphics/src/fonts/truetype.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+Future<Uint8List> renderMode(double mode, double param) async {
+  final font = TrueTypeFont.parse(
+      File('assets/fonts/DejaVuSans.ttf').readAsBytesSync())!;
+  final outline = font.outlineForGlyph(font.gidForUnicode(0x67))!;
+  final r = PdfTextRun(
+    text: 'g',
+    transform: const PdfMatrix(24, 0, 0, -24, 4, 22),
+    color: const PdfColor(1, 1, 1),
+    width: 0.6,
+    glyphs: [PdfGlyphPlacement(offset: 0, outline: outline)],
+  );
+  StripPdfDevice.slugGlyphs = true;
+  StripPdfDevice.debugSlugMode = mode;
+  StripPdfDevice.debugSlugParam = param;
+  try {
+    final rec = ui.PictureRecorder();
+    final canvas = ui.Canvas(rec);
+    final device = StripPdfDevice(canvas,
+        pageToDevice: PdfMatrix.identity,
+        deviceWidth: 32,
+        deviceHeight: 32,
+        pixelRatio: 1);
+    device.drawText(r);
+    await device.finish();
+    final pic = rec.endRecording();
+    final img = await pic.toImage(32, 32);
+    final px = (await img.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();
+    img.dispose();
+    pic.dispose();
+    device.dispose();
+    return px;
+  } finally {
+    StripPdfDevice.slugGlyphs = false;
+    StripPdfDevice.debugSlugMode = 0;
+    StripPdfDevice.debugSlugParam = 0;
+  }
+}
+
+const probes = [(10, 13), (5, 13), (10, 14), (20, 13), (10, 20)];
+
+void main() {
+  if (Platform.environment['SLUG_DEBUG'] != '1') {
+    test('slug shader debug dumps', skip: 'set SLUG_DEBUG=1 to run', () {});
+    return;
+  }
+  testWidgets('dump raw uv varying', (tester) async {
+    await tester.runAsync(() async {
+      final px = await renderMode(4, 0);
+      for (final (x, y) in probes) {
+        final o = (y * 32 + x) * 4;
+        // ignore: avoid_print
+        print('DBG4 ($x,$y): u=${px[o] / 255} v=${px[o + 1] * 8 / 255} '
+            'fracv=${px[o + 2] / 255}');
+      }
+    });
+  });
+
+  testWidgets('dump shader band selection', (tester) async {
+    await tester.runAsync(() async {
+      final px = await renderMode(1, 0);
+      for (final (x, y) in probes) {
+        final o = (y * 32 + x) * 4;
+        // ignore: avoid_print
+        print('DBG1 ($x,$y): hb=${px[o] * 8 / 255} '
+            'count=${px[o + 1] * 16 / 255} emY=${(px[o + 2] / 255 - 0.5) * 4}');
+      }
+    });
+  });
+
+  testWidgets('dump ray sums', (tester) async {
+    await tester.runAsync(() async {
+      final px = await renderMode(2, 0);
+      for (final (x, y) in probes) {
+        final o = (y * 32 + x) * 4;
+        // ignore: avoid_print
+        print('DBG2 ($x,$y): |covH|=${px[o] / 255} |covV|=${px[o + 1] / 255} '
+            'covH=${(px[o + 2] / 255 - 0.5) * 4}');
+      }
+    });
+  });
+
+  testWidgets('dump per-curve H contributions', (tester) async {
+    await tester.runAsync(() async {
+      for (var i = 0; i < 8; i++) {
+        final px = await renderMode(3, i.toDouble());
+        for (final (x, y) in probes.take(2)) {
+          final o = (y * 32 + x) * 4;
+          // ignore: avoid_print
+          print('DBG3 i=$i ($x,$y): d=${(px[o] / 255 - 0.5) * 4} '
+              'e0=${(px[o + 1] / 255 - 0.5) * 4} '
+              'e1=${(px[o + 2] / 255 - 0.5) * 4}');
+        }
+      }
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/slug_test.dart
+++ b/packages/dart_pdf_editor/test/slug_test.dart
@@ -1,0 +1,307 @@
+// B3 Slug glyph rendering: shader-vs-Dart-reference exactness, text-page
+// slug-vs-strip-vs-canvas parity, batching stats, and the C2 sharpness
+// property (a recorded picture's Slug text stays sharp under canvas zoom,
+// unlike baked strips).
+//
+// Run with the default backend AND with --enable-impeller; Impeller runs
+// must set SLUG_IMPELLER=1. Impeller evaluates drawVertices runtime
+// effects on an integer texcoord-unit grid that ignores the CTM scale
+// (a snapshot sampled by the vertex UVs), so there the slug output is a
+// record-resolution glyph raster: exactness tolerances widen to resampling
+// error and the C2 zoom-sharpness property does not hold (slug only has to
+// match the baked-strip control).
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+// ignore: implementation_imports
+import 'package:pdf_graphics/src/fonts/truetype.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+final bool _impeller = Platform.environment['SLUG_IMPELLER'] == '1';
+
+TrueTypeFont? _font;
+TrueTypeFont get font => _font ??=
+    TrueTypeFont.parse(File('assets/fonts/DejaVuSans.ttf').readAsBytesSync())!;
+
+PdfPath outlineOf(String char) =>
+    font.outlineForGlyph(font.gidForUnicode(char.codeUnitAt(0)))!;
+
+/// A text run of [text] with real DejaVu outlines, em->page transform
+/// scale [size] at ([x], [y]) baseline (y-up page space assumed flipped by
+/// the caller's transform; these tests use y-down device==page space, so
+/// the transform flips em y).
+PdfTextRun run(String text, double size, double x, double y,
+    {PdfColor color = PdfColor.black}) {
+  final glyphs = <PdfGlyphPlacement>[];
+  var pen = 0.0;
+  for (final code in text.codeUnits) {
+    if (code == 0x20) {
+      pen += 0.32;
+      continue;
+    }
+    final gid = font.gidForUnicode(code);
+    glyphs.add(
+        PdfGlyphPlacement(offset: pen, outline: font.outlineForGlyph(gid)));
+    pen += font.advanceForGlyph(gid) ?? 0.6;
+  }
+  return PdfTextRun(
+    text: text,
+    transform: PdfMatrix(size, 0, 0, -size, x, y),
+    color: color,
+    width: pen,
+    glyphs: glyphs,
+  );
+}
+
+Future<Uint8List> pixelsOf(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();
+
+double meanDiff(Uint8List a, Uint8List b) {
+  var sum = 0;
+  for (var i = 0; i < a.length; i += 4) {
+    var d = 0;
+    for (var c = 0; c < 3; c++) {
+      final dc = (a[i + c] - b[i + c]).abs();
+      if (dc > d) d = dc;
+    }
+    sum += d;
+  }
+  return sum / (a.length ~/ 4);
+}
+
+/// Renders [draw] through a StripPdfDevice (identity page->device) into a
+/// [w]x[h] image; [slug] toggles Slug glyph mode for this render.
+Future<ui.Image> render(void Function(StripPdfDevice d) draw, int w, int h,
+    {required bool slug, double zoom = 1}) async {
+  final was = StripPdfDevice.slugGlyphs;
+  StripPdfDevice.slugGlyphs = slug;
+  try {
+    final rec = ui.PictureRecorder();
+    final canvas = ui.Canvas(rec);
+    canvas.drawRect(ui.Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+        ui.Paint()..color = const ui.Color(0xFFFFFFFF));
+    final device = StripPdfDevice(canvas,
+        pageToDevice: PdfMatrix.identity,
+        deviceWidth: w,
+        deviceHeight: h,
+        pixelRatio: 1);
+    draw(device);
+    await device.finish();
+    final picture = rec.endRecording();
+    // optionally replay the recorded picture under a canvas zoom (C2)
+    final outRec = ui.PictureRecorder();
+    final outCanvas = ui.Canvas(outRec);
+    outCanvas.scale(zoom);
+    outCanvas.drawPicture(picture);
+    final out = outRec.endRecording();
+    final image = await out.toImage((w * zoom).round(), (h * zoom).round());
+    picture.dispose();
+    out.dispose();
+    device.dispose();
+    return image;
+  } finally {
+    StripPdfDevice.slugGlyphs = was;
+  }
+}
+
+void main() {
+  testWidgets('slug shader matches the Dart glyphCoverageAA reference',
+      (tester) async {
+    await tester.runAsync(() async {
+      const w = 32, h = 32;
+      const size = 24.0;
+      final outline = outlineOf('g');
+      final quads = outlineToQuads(outline);
+      final bands = buildBands(quads, bandCount: 8);
+      expect(bands.overflow, isFalse);
+
+      final r = PdfTextRun(
+        text: 'g',
+        transform: const PdfMatrix(size, 0, 0, -size, 4, 22),
+        color: PdfColor.black,
+        width: 0.6,
+        glyphs: [PdfGlyphPlacement(offset: 0, outline: outline)],
+      );
+      final image = await render((d) => d.drawText(r), w, h, slug: true);
+      final got = await pixelsOf(image);
+      image.dispose();
+
+      // reference: shader formula in Dart, quantized scale like the slot
+      final sq = (size * 16).round() / 16.0;
+      const m = PdfMatrix(size, 0, 0, -size, 4, 22);
+      final inv = m.inverted()!;
+      var sum = 0.0;
+      var maxD = 0;
+      for (var py = 0; py < h; py++) {
+        for (var px = 0; px < w; px++) {
+          final ex = inv.transformX(px + 0.5, py + 0.5);
+          final ey = inv.transformY(px + 0.5, py + 0.5);
+          final cov = glyphCoverageAA(quads, bands, ex, ey, sq, sq);
+          final want = (255 * (1 - cov)).round();
+          final d = (got[(py * w + px) * 4] - want).abs();
+          sum += d;
+          if (d > maxD) maxD = d;
+        }
+      }
+      final mean = sum / (w * h);
+      // ignore: avoid_print
+      print('SLUG-REF: mean ${mean.toStringAsFixed(2)}/255 max $maxD/255');
+      for (var py = 0; py < h; py++) {
+        for (var px = 0; px < w; px++) {
+          final ex = inv.transformX(px + 0.5, py + 0.5);
+          final ey = inv.transformY(px + 0.5, py + 0.5);
+          final cov = glyphCoverageAA(quads, bands, ex, ey, sq, sq);
+          final want = (255 * (1 - cov)).round();
+          final d = (got[(py * w + px) * 4] - want).abs();
+          if (d > 32) {
+            // ignore: avoid_print
+            print('  WORST ($px,$py) got=${got[(py * w + px) * 4]} want=$want '
+                'em=(${ex.toStringAsFixed(4)},${ey.toStringAsFixed(4)}) '
+                'hband=${bands.bandFor(ey)} vband=${bands.vBandFor(ex)}');
+          }
+        }
+      }
+      // Skia: fixed-point curve quantization (1/8192 em) + float32 vs
+      // float64 land within a few counts; structural mismatch would be
+      // tens. Impeller: the snapshot resamples the glyph raster at the
+      // subpixel quad offset, so edges shift by up to a pixel's coverage.
+      expect(mean, lessThanOrEqualTo(_impeller ? 8.0 : 1.5));
+      expect(maxD, lessThanOrEqualTo(_impeller ? 192 : 24));
+    });
+  });
+
+  testWidgets('text page: slug vs strip vs canvas-style parity',
+      (tester) async {
+    await tester.runAsync(() async {
+      const w = 220, h = 64;
+      void page(StripPdfDevice d) {
+        d.drawText(run('Sphinx of black', 16, 6, 22));
+        d.drawText(run('quartz judge', 11, 6, 40,
+            color: const PdfColor(0.8, 0.1, 0.2)));
+        d.drawText(run('vow 42', 24, 6, 60));
+      }
+
+      final slugImg = await render(page, w, h, slug: true);
+      final stripImg = await render(page, w, h, slug: false);
+      final slugPx = await pixelsOf(slugImg);
+      final stripPx = await pixelsOf(stripImg);
+      slugImg.dispose();
+      stripImg.dispose();
+
+      final d = meanDiff(slugPx, stripPx);
+      // signed bias: negative = slug renders darker (higher coverage)
+      var signed = 0;
+      for (var i = 0; i < slugPx.length; i += 4) {
+        signed += slugPx[i] - stripPx[i];
+      }
+      // ignore: avoid_print
+      print('SLUG-TEXT: slug-vs-strip mean ${d.toStringAsFixed(2)}/255 '
+          'signed ${(signed / (slugPx.length / 4)).toStringAsFixed(2)}/255');
+      // Slug AA is dual-ray, strips are exact area coverage: text edges
+      // differ by design, but the page must agree closely overall.
+      expect(d, lessThanOrEqualTo(_impeller ? 8.0 : 4.0));
+
+      // Each run is committed as its own conservative painter-order window
+      // while the worker-plan and transform-time glyph-layer paths are wired.
+      // Pure text must still avoid strip rasterization entirely.
+      StripPdfDevice.resetStats();
+      final again = await render(page, w, h, slug: true);
+      again.dispose();
+      expect(StripPdfDevice.totalSlugQuads, greaterThan(20));
+      expect(StripPdfDevice.totalStripQuads, 0);
+      expect(StripPdfDevice.totalFlushes, 3);
+    });
+  });
+
+  testWidgets('minification guard: tiny text keeps the strip path',
+      (tester) async {
+    await tester.runAsync(() async {
+      StripPdfDevice.resetStats();
+      final image = await render(
+          (d) => d.drawText(run('tiny glyphs below guard', 3, 2, 12)), 80, 16,
+          slug: true);
+      image.dispose();
+      expect(StripPdfDevice.totalSlugQuads, 0,
+          reason: 'sub-guard text must not take the slug path');
+      expect(StripPdfDevice.totalStripQuads, greaterThan(0));
+    });
+  });
+
+  testWidgets('painter order: vector after slug text forces a window split',
+      (tester) async {
+    await tester.runAsync(() async {
+      const w = 64, h = 32;
+      final image = await render((d) {
+        d.drawText(run('gg', 24, 4, 26));
+        // opaque box painted AFTER the text must cover it
+        d.fillPath(
+            PdfPath([
+              PdfMoveTo(0, 0),
+              PdfLineTo(40, 0),
+              PdfLineTo(40, 32),
+              PdfLineTo(0, 32),
+              const PdfClosePath(),
+            ]),
+            const PdfColor(0, 0.6, 0),
+            PdfFillRule.nonzero,
+            1);
+      }, w, h, slug: true);
+      final px = await pixelsOf(image);
+      image.dispose();
+      // sample inside the box where the glyph would be: pure green
+      final o = (16 * w + 12) * 4;
+      expect(px[o], lessThanOrEqualTo(2), reason: 'text must be covered');
+      expect(px[o + 1], inInclusiveRange(140, 165));
+    });
+  });
+
+  testWidgets('C2 sharpness: recorded slug text survives 3x canvas zoom',
+      (tester) async {
+    await tester.runAsync(() async {
+      const w = 120, h = 40;
+      void page(StripPdfDevice d) {
+        d.drawText(run('Rgke 37', 18, 4, 30));
+      }
+
+      // sharp truth: freshly rendered at 3x (strip raster at real 3x res)
+      final sharp = await render((d) {
+        d.drawText(run('Rgke 37', 54, 12, 90));
+      }, w * 3, h * 3, slug: false);
+      // recorded at 1x, replayed under 3x canvas scale
+      final slugZoom = await render(page, w, h, slug: true, zoom: 3);
+      final stripZoom = await render(page, w, h, slug: false, zoom: 3);
+
+      final sharpPx = await pixelsOf(sharp);
+      final slugPx = await pixelsOf(slugZoom);
+      final stripPx = await pixelsOf(stripZoom);
+      sharp.dispose();
+      slugZoom.dispose();
+      stripZoom.dispose();
+
+      final slugErr = meanDiff(slugPx, sharpPx);
+      final stripErr = meanDiff(stripPx, sharpPx);
+      // ignore: avoid_print
+      print('SLUG-ZOOM: slug-picture@3x vs sharp ${slugErr.toStringAsFixed(2)}'
+          '/255, strip-picture@3x vs sharp ${stripErr.toStringAsFixed(2)}/255');
+      if (_impeller) {
+        // Impeller's texcoord-grid snapshot ignores the CTM: slug text is
+        // a record-resolution raster there, no sharper than baked strips.
+        expect(slugErr, lessThan(stripErr * 1.3),
+            reason: 'slug text must stay comparable to strips under zoom');
+        return;
+      }
+      // Skia evaluates the shader per fragment: slug quads re-resolve at
+      // the zoomed resolution (geometry stays exact; only the AA ramp
+      // keeps its recorded width), while baked strips scale like any
+      // raster.
+      expect(slugErr, lessThan(stripErr * 0.5),
+          reason: 'slug text must be dramatically sharper under zoom');
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/web_slug_fallback_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_fallback_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+Future<void> _waitForRaster(WidgetTester tester) async {
+  for (var i = 0; i < 200; i++) {
+    await tester.pump();
+    final exception = tester.takeException();
+    if (exception != null) fail('page raster failed: $exception');
+    if (find.byType(RawImage).evaluate().isNotEmpty) return;
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+  }
+  fail('page raster did not arrive');
+}
+
+void main() {
+  testWidgets('minified outline fallback is rejected once and rasterized',
+      (tester) async {
+    PdfPageView.webSlugGlyphLayer = true;
+    PdfPageView.debugWebSlugGlyphLayerBackendOverride = true;
+    addTearDown(() {
+      PdfPageView.webSlugGlyphLayer = true;
+      PdfPageView.debugWebSlugGlyphLayerBackendOverride = null;
+    });
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildEmbeddedFontPdf();
+    const fontSize = [0x32, 0x34, 0x20, 0x54, 0x66]; // "24 Tf"
+    for (var i = 0; i <= bytes.length - fontSize.length; i++) {
+      var match = true;
+      for (var j = 0; j < fontSize.length; j++) {
+        if (bytes[i + j] != fontSize[j]) match = false;
+      }
+      if (!match) continue;
+      bytes[i] = 0x20;
+      bytes[i + 1] = 0x33; // same-width " 3 Tf", xref stays valid
+      break;
+    }
+    final page = PdfDocument.open(bytes).page(0);
+    Widget at(double scale) => Center(
+          child: SizedBox(
+              width: 612, child: PdfPageView(page: page, scale: scale)),
+        );
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    await _waitForRaster(tester);
+    expect(find.byKey(const ValueKey('pdf-page-slug-picture')), findsNothing);
+    expect(StripPdfDevice.totalSlugQuads, 0);
+    expect(StripPdfDevice.totalStripQuads, greaterThan(0),
+        reason: 'the 3px outline run must trip the minification fallback');
+    final rejectedFlushes = StripPdfDevice.totalFlushes;
+
+    await tester.pumpWidget(at(3));
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 20)));
+    await tester.pump();
+    expect(StripPdfDevice.totalFlushes, rejectedFlushes,
+        reason: 'a rejected scene must not retry Slug on every settle');
+  });
+}

--- a/packages/dart_pdf_editor/test/web_slug_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_page_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+
+Future<void> _waitForSlugPicture(WidgetTester tester) async {
+  for (var i = 0; i < 200; i++) {
+    await tester.pump();
+    final exception = tester.takeException();
+    if (exception != null) fail('Slug page render failed: $exception');
+    if (find
+        .byKey(const ValueKey('pdf-page-slug-picture'))
+        .evaluate()
+        .isNotEmpty) {
+      return;
+    }
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+  }
+  fail('Slug page picture did not arrive');
+}
+
+Future<void> _waitForRaster(WidgetTester tester) async {
+  for (var i = 0; i < 200; i++) {
+    await tester.pump();
+    final exception = tester.takeException();
+    if (exception != null) fail('page raster failed: $exception');
+    if (find.byType(RawImage).evaluate().isNotEmpty) return;
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+  }
+  fail('page raster did not arrive');
+}
+
+void main() {
+  testWidgets('web Slug page picture survives zoom without re-recording',
+      (tester) async {
+    PdfPageView.webSlugGlyphLayer = true;
+    PdfPageView.debugWebSlugGlyphLayerBackendOverride = true;
+    addTearDown(() {
+      PdfPageView.webSlugGlyphLayer = true;
+      PdfPageView.debugWebSlugGlyphLayerBackendOverride = null;
+    });
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final page = PdfDocument.open(buildEmbeddedFontPdf()).page(0);
+    Widget at(double scale) => Center(
+          child: SizedBox(
+            width: 612,
+            child: PdfPageView(page: page, scale: scale),
+          ),
+        );
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    await _waitForSlugPicture(tester);
+    final slugFinder = find.byKey(const ValueKey('pdf-page-slug-picture'));
+    expect(slugFinder, findsOneWidget);
+    expect(find.byType(RawImage), findsNothing,
+        reason:
+            'the retained picture replaces, rather than overlays, the raster');
+    expect(StripPdfDevice.totalSlugQuads, greaterThan(0));
+    final firstPicture =
+        (tester.widget<CustomPaint>(slugFinder).painter! as dynamic).picture;
+    final firstQuads = StripPdfDevice.totalSlugQuads;
+
+    await tester.pumpWidget(at(3));
+    await tester.pump();
+    expect(slugFinder, findsOneWidget);
+    final zoomPicture =
+        (tester.widget<CustomPaint>(slugFinder).painter! as dynamic).picture;
+    expect(identical(zoomPicture, firstPicture), isTrue,
+        reason: 'zoom must keep the same transform-time picture alive');
+    expect(StripPdfDevice.totalSlugQuads, firstQuads,
+        reason: 'zoom must reuse the retained Slug picture without replaying');
+    expect(find.byType(RawImage), findsNothing,
+        reason: 'zoom must not flatten the Slug layer into a new bitmap');
+  });
+
+  testWidgets('substituted text keeps the cheaper raster path', (tester) async {
+    PdfPageView.webSlugGlyphLayer = true;
+    PdfPageView.debugWebSlugGlyphLayerBackendOverride = true;
+    addTearDown(() {
+      PdfPageView.webSlugGlyphLayer = true;
+      PdfPageView.debugWebSlugGlyphLayerBackendOverride = null;
+    });
+    final page = PdfDocument.open(buildClassicPdf()).page(0);
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(
+      Center(child: SizedBox(width: 612, child: PdfPageView(page: page))),
+    );
+    await _waitForRaster(tester);
+    expect(find.byKey(const ValueKey('pdf-page-slug-picture')), findsNothing);
+    expect(StripPdfDevice.totalSlugQuads, 0,
+        reason: 'Base-14 text has no outline glyphs for Slug to evaluate');
+  });
+}

--- a/packages/pdf_graphics/lib/raster.dart
+++ b/packages/pdf_graphics/lib/raster.dart
@@ -8,6 +8,7 @@
 /// worker-isolate strip generation), not part of the stable device API.
 library;
 
+export 'src/raster/curve_quads.dart';
 export 'src/raster/flatten.dart';
 export 'src/raster/stroke_contours.dart';
 export 'src/raster/strip_batch_data.dart';

--- a/packages/pdf_graphics/lib/src/raster/curve_quads.dart
+++ b/packages/pdf_graphics/lib/src/raster/curve_quads.dart
@@ -16,22 +16,39 @@
 // Coordinates are 16-bit fixed point: `u16 = round(em * 8192) + 32768`,
 // i.e. range [-4, +4) em with 1/8192 em resolution (~0.003 px at a 24-px
 // em); decode as `(u16 - 32768) / 8192`. Counts and offsets are raw u16
-// (no bias). Layout, by texel index:
+// (no bias). Offsets are RELATIVE to the glyph's own stream start, so
+// whole streams concatenate into a per-flush atlas unchanged (the shader
+// adds the stream base). Layout, by texel index within the stream:
 //
-//   0                      header: (bandCount, curveCount) raw
-//   1 .. bandCount         band table: (listOffset, curveCount) raw -
-//                          listOffset is the absolute texel index of the
-//                          band's reference list
-//   ...                    band reference lists: one texel per entry,
-//                          (curveTexelOffset, 0) raw - the absolute texel
-//                          index of the curve's first control point;
-//                          entries sorted by descending curve max-x so the
-//                          shader can early-out
-//   ...                    curve data: 3 texels per curve - p0, control,
-//                          p1 as fixed-point pairs
+//   0                        header: (bandCount, curveCount) raw -
+//                            bandCount applies to both axes
+//   1 .. bandCount           horizontal band table (bands stack along y;
+//                            the sample's y picks the band): (listOffset,
+//                            count) raw
+//   bandCount+1..2*bandCount vertical band table (bands stack along x;
+//                            the sample's x picks the band): (listOffset,
+//                            count) raw
+//   ...                      horizontal band reference lists: one texel
+//                            per entry, (curveTexelOffset, 0) raw -
+//                            sorted by descending curve max-x
+//   ...                      vertical band reference lists, sorted by
+//                            descending curve max-y
+//   ...                      curve data: 3 texels per curve - p0, control,
+//                            p1 as fixed-point pairs
 //
-// Band geometry (bandCount, minY, bandHeight and the glyph bbox) travels
-// as uniforms/vertex data, not texels - see [GlyphCurveTexture].
+// Band geometry (bandCount, bbox, band width/height) travels as
+// uniforms/vertex/directory data, not stream texels - see
+// [GlyphCurveTexture].
+//
+// ## Anti-aliased evaluation ([glyphCoverageAA], mirrored by the shader)
+//
+// Two winding rays per sample (Slug-style): horizontal (+x) accumulating
+// `sign(Y'(t)) * clamp((X(t) - x) * pxPerEmX + 0.5, 0, 1)` over the roots
+// of `Y(t) = y`, and vertical (+y) accumulating
+// `sign(-X'(t)) * clamp((Y(t) - y) * pxPerEmY + 0.5, 0, 1)` over the
+// roots of `X(t) = x`. Coverage = `(min(|covH|,1) + min(|covV|,1)) / 2`.
+// Deep inside both rays saturate to 1; at an edge the crossing root's
+// pixel-space distance ramps coverage linearly.
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -175,26 +192,41 @@ List<QuadCurve> outlineToQuads(PdfPath outline, {double tolerance = 1e-3}) {
 /// [overflow] - callers fall back to outline strips for that glyph.
 class GlyphBands {
   GlyphBands._(this.bandCount, this.minX, this.minY, this.maxX, this.maxY,
-      this.bands, this.overflow);
+      this.bands, this.vBands, this.overflow);
 
   static const int maxCurvesPerBandDefault = 16;
 
   final int bandCount;
   final double minX, minY, maxX, maxY;
 
-  /// Curve indices per band, sorted by descending max-x.
+  /// Horizontal bands (stacked along y, picked by the sample's y):
+  /// curve indices per band, sorted by descending max-x.
   final List<Uint16List> bands;
 
-  /// True when some band exceeds the per-band curve cap.
+  /// Vertical bands (stacked along x, picked by the sample's x):
+  /// curve indices per band, sorted by descending max-y. Feeds the
+  /// vertical AA ray.
+  final List<Uint16List> vBands;
+
+  /// True when some band (either axis) exceeds the per-band curve cap.
   final bool overflow;
 
   double get bandHeight =>
       bandCount == 0 ? 0 : (maxY - minY) / bandCount;
 
-  /// The band index sampling row [y] (em space) falls into, clamped.
+  double get bandWidth => bandCount == 0 ? 0 : (maxX - minX) / bandCount;
+
+  /// The horizontal band index sampling row [y] falls into, clamped.
   int bandFor(double y) {
     if (bandCount == 0) return 0;
     final b = ((y - minY) / bandHeight).floor();
+    return b < 0 ? 0 : (b >= bandCount ? bandCount - 1 : b);
+  }
+
+  /// The vertical band index sampling column [x] falls into, clamped.
+  int vBandFor(double x) {
+    if (bandCount == 0) return 0;
+    final b = ((x - minX) / bandWidth).floor();
     return b < 0 ? 0 : (b >= bandCount ? bandCount - 1 : b);
   }
 }
@@ -204,7 +236,7 @@ GlyphBands buildBands(List<QuadCurve> curves,
     {int bandCount = 8,
     int maxCurvesPerBand = GlyphBands.maxCurvesPerBandDefault}) {
   if (curves.isEmpty) {
-    return GlyphBands._(0, 0, 0, 0, 0, const [], false);
+    return GlyphBands._(0, 0, 0, 0, 0, const [], const [], false);
   }
   var minX = double.infinity, minY = double.infinity;
   var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
@@ -215,8 +247,11 @@ GlyphBands buildBands(List<QuadCurve> curves,
     maxY = math.max(maxY, c.maxY);
   }
   if (maxY <= minY) maxY = minY + 1e-6;
+  if (maxX <= minX) maxX = minX + 1e-6;
   final bandH = (maxY - minY) / bandCount;
-  final lists = List.generate(bandCount, (_) => <int>[]);
+  final bandW = (maxX - minX) / bandCount;
+  final hLists = List.generate(bandCount, (_) => <int>[]);
+  final vLists = List.generate(bandCount, (_) => <int>[]);
   for (var i = 0; i < curves.length; i++) {
     final c = curves[i];
     var b0 = ((c.minY - minY) / bandH).floor();
@@ -224,17 +259,31 @@ GlyphBands buildBands(List<QuadCurve> curves,
     if (b0 < 0) b0 = 0;
     if (b1 >= bandCount) b1 = bandCount - 1;
     for (var b = b0; b <= b1; b++) {
-      lists[b].add(i);
+      hLists[b].add(i);
+    }
+    var v0 = ((c.minX - minX) / bandW).floor();
+    var v1 = ((c.maxX - minX) / bandW).ceil() - 1;
+    if (v0 < 0) v0 = 0;
+    if (v1 >= bandCount) v1 = bandCount - 1;
+    for (var b = v0; b <= v1; b++) {
+      vLists[b].add(i);
     }
   }
   var overflow = false;
   final bands = <Uint16List>[];
-  for (final list in lists) {
+  for (final list in hLists) {
     if (list.length > maxCurvesPerBand) overflow = true;
     list.sort((a, b) => curves[b].maxX.compareTo(curves[a].maxX));
     bands.add(Uint16List.fromList(list));
   }
-  return GlyphBands._(bandCount, minX, minY, maxX, maxY, bands, overflow);
+  final vBands = <Uint16List>[];
+  for (final list in vLists) {
+    if (list.length > maxCurvesPerBand) overflow = true;
+    list.sort((a, b) => curves[b].maxY.compareTo(curves[a].maxY));
+    vBands.add(Uint16List.fromList(list));
+  }
+  return GlyphBands._(
+      bandCount, minX, minY, maxX, maxY, bands, vBands, overflow);
 }
 
 /// Winding number of the horizontal ray `x' > x` at em-space point
@@ -288,6 +337,85 @@ double _quadX(QuadCurve c, double t) {
   return mt * mt * c.x0 + 2 * mt * t * c.cx + t * t * c.x1;
 }
 
+/// Anti-aliased coverage at em-space (x, y), the Slug-style dual-ray
+/// evaluation the B3 shader mirrors step for step (see the library
+/// header for the formula). [pxPerEmX]/[pxPerEmY] are the glyph's
+/// device-pixels-per-em along each axis - they set the width of the AA
+/// ramp (one device pixel).
+///
+/// Robustness: crossing COUNTS and SIGNS come from strict endpoint
+/// comparisons (`p > level`), never from root-in-range tests - adjacent
+/// curves share endpoint values exactly (fixed-point encoding), so a
+/// crossing at a joint counts exactly once regardless of float noise in
+/// the root positions (which only nudge the AA ramp). Endpoints on the
+/// same side contribute either zero or a canceling double crossing
+/// (both roots strictly inside (0,1)).
+double glyphCoverageAA(List<QuadCurve> curves, GlyphBands bands, double x,
+    double y, double pxPerEmX, double pxPerEmY) {
+  if (bands.bandCount == 0) return 0;
+  var covH = 0.0;
+  for (final index in bands.bands[bands.bandFor(y)]) {
+    final c = curves[index];
+    covH += _rayCrossings(c.y0 - y, c.cy - y, c.y1 - y, c.x0, c.cx, c.x1, x,
+        pxPerEmX, false);
+  }
+  var covV = 0.0;
+  for (final index in bands.vBands[bands.vBandFor(x)]) {
+    final c = curves[index];
+    covV += _rayCrossings(c.x0 - x, c.cx - x, c.x1 - x, c.y0, c.cy, c.y1, y,
+        pxPerEmY, true);
+  }
+  final h = covH.abs().clamp(0.0, 1.0);
+  final v = covV.abs().clamp(0.0, 1.0);
+  return (h + v) / 2;
+}
+
+/// Signed, AA-weighted crossing sum of one quadratic against an axis ray.
+/// (e0,ec,e1) are the curve's level-relative coordinates along the ray's
+/// perpendicular axis; (q0,qc,q1) the coordinates along the ray; [origin]
+/// the sample position along the ray; [flipSign] selects the vertical
+/// ray's `sign(-X'(t))` convention.
+double _rayCrossings(double e0, double ec, double e1, double q0, double qc,
+    double q1, double origin, double pxPerEm, bool flipSign) {
+  final s0 = e0 > 0, s1 = e1 > 0;
+  final a = e0 - 2 * ec + e1;
+  final b = 2 * (ec - e0);
+
+  double at(double t) {
+    final mt = 1 - t;
+    return mt * mt * q0 + 2 * mt * t * qc + t * t * q1;
+  }
+
+  double weight(double t) =>
+      ((at(t) - origin) * pxPerEm + 0.5).clamp(0.0, 1.0);
+
+  // Numerically stable quadratic roots (Numerical Recipes): fixed-point
+  // rounding turns encoded LINES into near-degenerate quads (|a| ~ 1/8192
+  // em) where the textbook (-b + sqrt)/2a form cancels catastrophically
+  // and misplaces the crossing by the whole segment. q never cancels
+  // (same-sign addition); the small root is e0/q, the large one q/a.
+  final sq = math.sqrt(math.max(b * b - 4 * a * e0, 0));
+  final q = -0.5 * (b + (b >= 0 ? sq : -sq));
+  final tA = a.abs() > 1e-12 ? q / a : 2.0; // out-of-range when linear
+  final tB = q.abs() > 1e-12 ? e0 / q : 2.0;
+
+  if (s0 != s1) {
+    // exactly one crossing; sign from the endpoint sides alone
+    final t = (tB >= 0 && tB <= 1) ? tB : tA;
+    final w = weight(t.clamp(0.0, 1.0));
+    final up = flipSign ? !s1 : s1;
+    return up ? w : -w;
+  }
+  // same side: zero or a canceling pair, both roots strictly inside (0,1)
+  if (b * b - 4 * a * e0 <= 0) return 0;
+  if (!(tA > 0 && tA < 1 && tB > 0 && tB < 1)) return 0;
+  final wMin = weight(math.min(tA, tB));
+  final wMax = weight(math.max(tA, tB));
+  // both above: dips below - first crossing descends, second ascends
+  final sum = s0 ? (wMax - wMin) : (wMin - wMax);
+  return flipSign ? -sum : sum;
+}
+
 /// A glyph's curves + band tables packed for GPU consumption (layout in
 /// the library header). [pixels] is rgba8888 at [width] x [height] with
 /// zero padding; band geometry rides as plain fields for uniforms.
@@ -321,30 +449,54 @@ double fixedToEm(int u16) => (u16 - 32768) / 8192;
 /// addressability (65535 texels) - callers fall back to outline strips.
 GlyphCurveTexture encodeGlyphTexels(List<QuadCurve> curves, GlyphBands bands,
     {int width = 256}) {
+  final texels = encodeGlyphStream(curves, bands);
+  final texelCount = texels.length ~/ 4;
+  final height = math.max(1, (texelCount + width - 1) ~/ width);
+  final pixels = Uint8List(width * height * 4);
+  pixels.setRange(0, texels.length, texels);
+  return GlyphCurveTexture._(pixels, width, height, texelCount,
+      bands.bandCount, bands.minX, bands.minY, bands.maxX, bands.maxY,
+      bands.overflow);
+}
+
+/// The raw texel stream of one glyph (4 bytes per texel, layout in the
+/// library header), relocatable: all internal offsets are relative to the
+/// stream start, so streams concatenate into a per-flush atlas unchanged.
+/// Throws [ArgumentError] past u16 addressability - callers fall back to
+/// outline strips.
+Uint8List encodeGlyphStream(List<QuadCurve> curves, GlyphBands bands) {
   final bandCount = bands.bandCount;
   var refEntries = 0;
   for (final b in bands.bands) {
     refEntries += b.length;
   }
-  final texelCount = 1 + bandCount + refEntries + 3 * curves.length;
+  for (final b in bands.vBands) {
+    refEntries += b.length;
+  }
+  final texelCount = 1 + 2 * bandCount + refEntries + 3 * curves.length;
   if (texelCount > 0xFFFF) {
     throw ArgumentError('glyph curve stream too large: $texelCount texels');
   }
-  final height = math.max(1, (texelCount + width - 1) ~/ width);
-  final pixels = Uint8List(width * height * 4);
-  final u16 = ByteData.sublistView(pixels);
+  final bytes = Uint8List(texelCount * 4);
+  final u16 = ByteData.sublistView(bytes);
 
   void put(int texel, int lo, int hi) {
     u16.setUint16(texel * 4, lo, Endian.little);
     u16.setUint16(texel * 4 + 2, hi, Endian.little);
   }
 
-  final curveBase = 1 + bandCount + refEntries;
+  final curveBase = 1 + 2 * bandCount + refEntries;
   put(0, bandCount, curves.length);
-  var refAt = 1 + bandCount;
+  var refAt = 1 + 2 * bandCount;
   for (var b = 0; b < bandCount; b++) {
     put(1 + b, refAt, bands.bands[b].length);
     for (final curveIndex in bands.bands[b]) {
+      put(refAt++, curveBase + 3 * curveIndex, 0);
+    }
+  }
+  for (var b = 0; b < bandCount; b++) {
+    put(1 + bandCount + b, refAt, bands.vBands[b].length);
+    for (final curveIndex in bands.vBands[b]) {
       put(refAt++, curveBase + 3 * curveIndex, 0);
     }
   }
@@ -354,6 +506,5 @@ GlyphCurveTexture encodeGlyphTexels(List<QuadCurve> curves, GlyphBands bands,
     put(curveBase + 3 * i + 1, emToFixed(c.cx), emToFixed(c.cy));
     put(curveBase + 3 * i + 2, emToFixed(c.x1), emToFixed(c.y1));
   }
-  return GlyphCurveTexture._(pixels, width, height, texelCount, bandCount,
-      bands.minX, bands.minY, bands.maxX, bands.maxY, bands.overflow);
+  return bytes;
 }

--- a/packages/pdf_graphics/lib/src/raster/curve_quads.dart
+++ b/packages/pdf_graphics/lib/src/raster/curve_quads.dart
@@ -1,0 +1,359 @@
+// Slug-style glyph foundations (JCGT 2017, Lengyel: "GPU-Centered Font
+// Rendering Directly from Glyph Outlines"): cubic->quadratic conversion
+// with an em-space error bound, per-glyph horizontal band lists, and the
+// rgba8888 texel encoding a fragment shader reads the curves from.
+//
+// Pure Dart. The Dart-side winding evaluator ([glyphWindingAt]) mirrors
+// the eventual GLSL evaluation step by step and is the reference the B3
+// shader must match.
+//
+// ## Texel encoding (consumed by the B3 shader; byte-exact reads of
+// rgba8888 textures via nearest-sampled texture() are M0-verified)
+//
+// Every texel (4 bytes) holds two 16-bit little-endian values:
+// `r = lo(u), g = hi(u), b = lo(v), a = hi(v)`.
+//
+// Coordinates are 16-bit fixed point: `u16 = round(em * 8192) + 32768`,
+// i.e. range [-4, +4) em with 1/8192 em resolution (~0.003 px at a 24-px
+// em); decode as `(u16 - 32768) / 8192`. Counts and offsets are raw u16
+// (no bias). Layout, by texel index:
+//
+//   0                      header: (bandCount, curveCount) raw
+//   1 .. bandCount         band table: (listOffset, curveCount) raw -
+//                          listOffset is the absolute texel index of the
+//                          band's reference list
+//   ...                    band reference lists: one texel per entry,
+//                          (curveTexelOffset, 0) raw - the absolute texel
+//                          index of the curve's first control point;
+//                          entries sorted by descending curve max-x so the
+//                          shader can early-out
+//   ...                    curve data: 3 texels per curve - p0, control,
+//                          p1 as fixed-point pairs
+//
+// Band geometry (bandCount, minY, bandHeight and the glyph bbox) travels
+// as uniforms/vertex data, not texels - see [GlyphCurveTexture].
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import '../path.dart';
+
+/// One quadratic Bezier segment in em space (y-up, origin on the
+/// baseline): `p0 = (x0,y0)`, control `(cx,cy)`, `p1 = (x1,y1)`.
+class QuadCurve {
+  const QuadCurve(this.x0, this.y0, this.cx, this.cy, this.x1, this.y1);
+
+  final double x0, y0, cx, cy, x1, y1;
+
+  double get minX => math.min(x0, math.min(cx, x1));
+  double get maxX => math.max(x0, math.max(cx, x1));
+  double get minY => math.min(y0, math.min(cy, y1));
+  double get maxY => math.max(y0, math.max(cy, y1));
+
+  @override
+  String toString() => 'QuadCurve(($x0,$y0) ($cx,$cy) ($x1,$y1))';
+}
+
+/// Converts a glyph [outline] (em space; lines and cubics) into quadratic
+/// curves within [tolerance] em of the original geometry.
+///
+/// Lines become degenerate quads (control point at the midpoint), so one
+/// uniform curve type feeds the band evaluator. Subpaths close implicitly
+/// (fill semantics) - the returned set always forms closed loops, which
+/// the winding evaluation depends on.
+///
+/// Cubic->quad: the cubic is split into `n = ceil(cbrt(err0 / tolerance))`
+/// equal-parameter pieces, where `err0 = sqrt(3)/36 * |P3 - 3P2 + 3P1 - P0|`
+/// is the standard midpoint-parabola error bound for approximating the
+/// whole cubic with a single quadratic; per-piece error then falls as
+/// 1/n^3. Each piece's control point is `(3Q1 + 3Q2 - Q0 - Q3) / 4`.
+List<QuadCurve> outlineToQuads(PdfPath outline, {double tolerance = 1e-3}) {
+  final out = <QuadCurve>[];
+  var penX = 0.0, penY = 0.0, startX = 0.0, startY = 0.0;
+  var open = false;
+
+  void line(double x0, double y0, double x1, double y1) {
+    if (x0 == x1 && y0 == y1) return;
+    out.add(QuadCurve(x0, y0, (x0 + x1) / 2, (y0 + y1) / 2, x1, y1));
+  }
+
+  void close() {
+    if (!open) return;
+    line(penX, penY, startX, startY);
+    open = false;
+  }
+
+  for (final segment in outline.segments) {
+    switch (segment) {
+      case PdfMoveTo(:final x, :final y):
+        close();
+        penX = startX = x;
+        penY = startY = y;
+        open = true;
+      case PdfLineTo(:final x, :final y):
+        if (!open) continue;
+        line(penX, penY, x, y);
+        penX = x;
+        penY = y;
+      case PdfCubicTo():
+        if (!open) continue;
+        final p0x = penX, p0y = penY;
+        final p1x = segment.x1, p1y = segment.y1;
+        final p2x = segment.x2, p2y = segment.y2;
+        final p3x = segment.x3, p3y = segment.y3;
+        final dx = p3x - 3 * p2x + 3 * p1x - p0x;
+        final dy = p3y - 3 * p2y + 3 * p1y - p0y;
+        final err0 = math.sqrt(3) / 36 * math.sqrt(dx * dx + dy * dy);
+        final n = err0 <= tolerance
+            ? 1
+            : math.pow(err0 / tolerance, 1 / 3).ceil().clamp(1, 64);
+        // piece [t0,t1] endpoints and derivative-based inner Beziers
+        double bx(double t) {
+          final mt = 1 - t;
+          return mt * mt * mt * p0x +
+              3 * mt * mt * t * p1x +
+              3 * mt * t * t * p2x +
+              t * t * t * p3x;
+        }
+
+        double by(double t) {
+          final mt = 1 - t;
+          return mt * mt * mt * p0y +
+              3 * mt * mt * t * p1y +
+              3 * mt * t * t * p2y +
+              t * t * t * p3y;
+        }
+
+        double dbx(double t) {
+          final mt = 1 - t;
+          return 3 * mt * mt * (p1x - p0x) +
+              6 * mt * t * (p2x - p1x) +
+              3 * t * t * (p3x - p2x);
+        }
+
+        double dby(double t) {
+          final mt = 1 - t;
+          return 3 * mt * mt * (p1y - p0y) +
+              6 * mt * t * (p2y - p1y) +
+              3 * t * t * (p3y - p2y);
+        }
+
+        var qx0 = p0x, qy0 = p0y;
+        for (var i = 1; i <= n; i++) {
+          final t0 = (i - 1) / n, t1 = i / n;
+          final qx3 = i == n ? p3x : bx(t1), qy3 = i == n ? p3y : by(t1);
+          final dt = (t1 - t0) / 3;
+          // cubic piece inner controls from endpoint derivatives
+          final q1x = qx0 + dt * dbx(t0), q1y = qy0 + dt * dby(t0);
+          final q2x = qx3 - dt * dbx(t1), q2y = qy3 - dt * dby(t1);
+          // midpoint-parabola control for the piece
+          final cx = (3 * (q1x + q2x) - qx0 - qx3) / 4;
+          final cy = (3 * (q1y + q2y) - qy0 - qy3) / 4;
+          out.add(QuadCurve(qx0, qy0, cx, cy, qx3, qy3));
+          qx0 = qx3;
+          qy0 = qy3;
+        }
+        penX = p3x;
+        penY = p3y;
+      case PdfClosePath():
+        close();
+        penX = startX;
+        penY = startY;
+        open = true;
+    }
+  }
+  close();
+  return out;
+}
+
+/// Per-glyph horizontal band lists over a quadratic curve set.
+///
+/// The glyph's y-extent divides into [bandCount] uniform bands; each band
+/// lists the indices of every curve whose control-point y-range overlaps
+/// it, sorted by descending curve max-x (the shader walks the list and
+/// early-outs once curves lie entirely left of the sample). A band holding
+/// more than [maxCurvesPerBandDefault] (or the given cap) curves sets
+/// [overflow] - callers fall back to outline strips for that glyph.
+class GlyphBands {
+  GlyphBands._(this.bandCount, this.minX, this.minY, this.maxX, this.maxY,
+      this.bands, this.overflow);
+
+  static const int maxCurvesPerBandDefault = 16;
+
+  final int bandCount;
+  final double minX, minY, maxX, maxY;
+
+  /// Curve indices per band, sorted by descending max-x.
+  final List<Uint16List> bands;
+
+  /// True when some band exceeds the per-band curve cap.
+  final bool overflow;
+
+  double get bandHeight =>
+      bandCount == 0 ? 0 : (maxY - minY) / bandCount;
+
+  /// The band index sampling row [y] (em space) falls into, clamped.
+  int bandFor(double y) {
+    if (bandCount == 0) return 0;
+    final b = ((y - minY) / bandHeight).floor();
+    return b < 0 ? 0 : (b >= bandCount ? bandCount - 1 : b);
+  }
+}
+
+/// Builds [GlyphBands] for [curves]. Empty input yields zero bands.
+GlyphBands buildBands(List<QuadCurve> curves,
+    {int bandCount = 8,
+    int maxCurvesPerBand = GlyphBands.maxCurvesPerBandDefault}) {
+  if (curves.isEmpty) {
+    return GlyphBands._(0, 0, 0, 0, 0, const [], false);
+  }
+  var minX = double.infinity, minY = double.infinity;
+  var maxX = double.negativeInfinity, maxY = double.negativeInfinity;
+  for (final c in curves) {
+    minX = math.min(minX, c.minX);
+    maxX = math.max(maxX, c.maxX);
+    minY = math.min(minY, c.minY);
+    maxY = math.max(maxY, c.maxY);
+  }
+  if (maxY <= minY) maxY = minY + 1e-6;
+  final bandH = (maxY - minY) / bandCount;
+  final lists = List.generate(bandCount, (_) => <int>[]);
+  for (var i = 0; i < curves.length; i++) {
+    final c = curves[i];
+    var b0 = ((c.minY - minY) / bandH).floor();
+    var b1 = ((c.maxY - minY) / bandH).ceil() - 1;
+    if (b0 < 0) b0 = 0;
+    if (b1 >= bandCount) b1 = bandCount - 1;
+    for (var b = b0; b <= b1; b++) {
+      lists[b].add(i);
+    }
+  }
+  var overflow = false;
+  final bands = <Uint16List>[];
+  for (final list in lists) {
+    if (list.length > maxCurvesPerBand) overflow = true;
+    list.sort((a, b) => curves[b].maxX.compareTo(curves[a].maxX));
+    bands.add(Uint16List.fromList(list));
+  }
+  return GlyphBands._(bandCount, minX, minY, maxX, maxY, bands, overflow);
+}
+
+/// Winding number of the horizontal ray `x' > x` at em-space point
+/// (x, y), evaluated exactly the way the B3 shader will: pick the band
+/// for y, walk its (max-x descending) curve list with the early-out, and
+/// accumulate signed ray crossings from the quadratic roots of
+/// `Y(t) = y`, t in [0, 1).
+int glyphWindingAt(
+    List<QuadCurve> curves, GlyphBands bands, double x, double y) {
+  if (bands.bandCount == 0) return 0;
+  if (y < bands.minY || y > bands.maxY) return 0;
+  var winding = 0;
+  for (final index in bands.bands[bands.bandFor(y)]) {
+    final c = curves[index];
+    if (c.maxX <= x) break; // sorted descending: nothing further can cross
+    if (y < c.minY || y >= c.maxY) continue;
+    // Y(t) - y = a t^2 + b t + cc
+    final a = c.y0 - 2 * c.cy + c.y1;
+    final b = 2 * (c.cy - c.y0);
+    final cc = c.y0 - y;
+    if (a.abs() < 1e-12) {
+      // (near-)linear in y
+      if (b.abs() < 1e-12) continue; // horizontal: no crossing
+      final t = -cc / b;
+      if (t >= 0 && t < 1) {
+        final xt = _quadX(c, t);
+        if (xt > x) winding += b > 0 ? 1 : -1;
+      }
+      continue;
+    }
+    final disc = b * b - 4 * a * cc;
+    if (disc < 0) continue;
+    final sq = math.sqrt(disc);
+    for (final t in [(-b - sq) / (2 * a), (-b + sq) / (2 * a)]) {
+      if (t < 0 || t >= 1) continue;
+      final xt = _quadX(c, t);
+      if (xt <= x) continue;
+      final dy = 2 * a * t + b;
+      if (dy > 0) {
+        winding += 1;
+      } else if (dy < 0) {
+        winding -= 1;
+      }
+    }
+  }
+  return winding;
+}
+
+double _quadX(QuadCurve c, double t) {
+  final mt = 1 - t;
+  return mt * mt * c.x0 + 2 * mt * t * c.cx + t * t * c.x1;
+}
+
+/// A glyph's curves + band tables packed for GPU consumption (layout in
+/// the library header). [pixels] is rgba8888 at [width] x [height] with
+/// zero padding; band geometry rides as plain fields for uniforms.
+class GlyphCurveTexture {
+  GlyphCurveTexture._(this.pixels, this.width, this.height, this.texelCount,
+      this.bandCount, this.minX, this.minY, this.maxX, this.maxY,
+      this.overflow);
+
+  final Uint8List pixels;
+  final int width;
+  final int height;
+  final int texelCount;
+  final int bandCount;
+  final double minX, minY, maxX, maxY;
+  final bool overflow;
+
+  double get bandHeight => bandCount == 0 ? 0 : (maxY - minY) / bandCount;
+}
+
+/// Fixed-point encode: em coordinate -> biased u16 (see library header).
+int emToFixed(double v) {
+  final f = (v * 8192).round() + 32768;
+  return f < 0 ? 0 : (f > 0xFFFF ? 0xFFFF : f);
+}
+
+/// Fixed-point decode.
+double fixedToEm(int u16) => (u16 - 32768) / 8192;
+
+/// Packs [curves] + [bands] into texels (see the library header for the
+/// layout). Throws [ArgumentError] when the stream exceeds u16
+/// addressability (65535 texels) - callers fall back to outline strips.
+GlyphCurveTexture encodeGlyphTexels(List<QuadCurve> curves, GlyphBands bands,
+    {int width = 256}) {
+  final bandCount = bands.bandCount;
+  var refEntries = 0;
+  for (final b in bands.bands) {
+    refEntries += b.length;
+  }
+  final texelCount = 1 + bandCount + refEntries + 3 * curves.length;
+  if (texelCount > 0xFFFF) {
+    throw ArgumentError('glyph curve stream too large: $texelCount texels');
+  }
+  final height = math.max(1, (texelCount + width - 1) ~/ width);
+  final pixels = Uint8List(width * height * 4);
+  final u16 = ByteData.sublistView(pixels);
+
+  void put(int texel, int lo, int hi) {
+    u16.setUint16(texel * 4, lo, Endian.little);
+    u16.setUint16(texel * 4 + 2, hi, Endian.little);
+  }
+
+  final curveBase = 1 + bandCount + refEntries;
+  put(0, bandCount, curves.length);
+  var refAt = 1 + bandCount;
+  for (var b = 0; b < bandCount; b++) {
+    put(1 + b, refAt, bands.bands[b].length);
+    for (final curveIndex in bands.bands[b]) {
+      put(refAt++, curveBase + 3 * curveIndex, 0);
+    }
+  }
+  for (var i = 0; i < curves.length; i++) {
+    final c = curves[i];
+    put(curveBase + 3 * i, emToFixed(c.x0), emToFixed(c.y0));
+    put(curveBase + 3 * i + 1, emToFixed(c.cx), emToFixed(c.cy));
+    put(curveBase + 3 * i + 2, emToFixed(c.x1), emToFixed(c.y1));
+  }
+  return GlyphCurveTexture._(pixels, width, height, texelCount, bandCount,
+      bands.minX, bands.minY, bands.maxX, bands.maxY, bands.overflow);
+}

--- a/packages/pdf_graphics/test/raster/curve_quads_test.dart
+++ b/packages/pdf_graphics/test/raster/curve_quads_test.dart
@@ -205,6 +205,50 @@ void main() {
     });
   });
 
+  group('AA evaluator', () {
+    test('dual-ray AA coverage tracks supersampled area coverage', () {
+      for (final char in ['a', 'g', 'B', 'o']) {
+        final quads = outlineToQuads(outlineOf(char));
+        final bands = buildBands(quads, bandCount: 8);
+        const size = 24.0;
+        const w = 32, h = 32;
+        const m = PdfMatrix(size, 0, 0, -size, 4, 26);
+        final inv = m.inverted()!;
+        var sum = 0.0;
+        var maxD = 0.0;
+        for (var py = 0; py < h; py++) {
+          for (var px = 0; px < w; px++) {
+            // ground truth: supersampled binary winding (area coverage)
+            var inside = 0;
+            const ss = 8;
+            for (var sy = 0; sy < ss; sy++) {
+              for (var sx = 0; sx < ss; sx++) {
+                final ex = inv.transformX(px + (sx + 0.5) / ss, py + (sy + 0.5) / ss);
+                final ey = inv.transformY(px + (sx + 0.5) / ss, py + (sy + 0.5) / ss);
+                if (glyphWindingAt(quads, bands, ex, ey) != 0) inside++;
+              }
+            }
+            final want = inside / (ss * ss);
+            final ex = inv.transformX(px + 0.5, py + 0.5);
+            final ey = inv.transformY(px + 0.5, py + 0.5);
+            final got = glyphCoverageAA(quads, bands, ex, ey, size, size);
+            final d = (got - want).abs();
+            sum += d;
+            if (d > maxD) maxD = d;
+          }
+        }
+        final mean = 255 * sum / (w * h);
+        // ignore: avoid_print
+        print('AA-REF: "$char" mean ${mean.toStringAsFixed(2)}/255 '
+            'max ${(255 * maxD).toStringAsFixed(0)}/255');
+        // The dual-ray approximation is not exact area coverage (corners,
+        // thin features), but must track it closely on body text.
+        expect(mean, lessThanOrEqualTo(4.0),
+            reason: '"\$char" AA coverage drifts from area coverage');
+      }
+    });
+  });
+
   group('texel encoding', () {
     test('fixed point roundtrips within 1/8192 em', () {
       for (final v in [-3.999, -1.0, -0.123456, 0.0, 0.5, 1.25, 3.999]) {
@@ -231,10 +275,10 @@ void main() {
       expect(curveCount, quads.length);
 
       final decoded = <QuadCurve>[];
-      final decodedBands = <List<int>>[];
       final curveBase = 1 +
-          bandCount +
-          bands.bands.fold<int>(0, (a, b) => a + b.length);
+          2 * bandCount +
+          bands.bands.fold<int>(0, (a, b) => a + b.length) +
+          bands.vBands.fold<int>(0, (a, b) => a + b.length);
       for (var b = 0; b < bandCount; b++) {
         final (offset, count) = texel(1 + b);
         final refs = <int>[];
@@ -243,9 +287,16 @@ void main() {
           expect((curveTexel - curveBase) % 3, 0);
           refs.add((curveTexel - curveBase) ~/ 3);
         }
-        decodedBands.add(refs);
         expect(refs, bands.bands[b].toList(),
-            reason: 'band $b reference list');
+            reason: 'horizontal band $b reference list');
+        final (vOffset, vCount) = texel(1 + bandCount + b);
+        final vRefs = <int>[];
+        for (var i = 0; i < vCount; i++) {
+          final (curveTexel, _) = texel(vOffset + i);
+          vRefs.add((curveTexel - curveBase) ~/ 3);
+        }
+        expect(vRefs, bands.vBands[b].toList(),
+            reason: 'vertical band $b reference list');
       }
       for (var i = 0; i < curveCount; i++) {
         final (x0, y0) = texel(curveBase + 3 * i);

--- a/packages/pdf_graphics/test/raster/curve_quads_test.dart
+++ b/packages/pdf_graphics/test/raster/curve_quads_test.dart
@@ -1,0 +1,281 @@
+// Slug foundations: cubic->quad error bound, band construction, texel
+// encode/decode roundtrip, and band-evaluator winding/coverage vs the
+// strip fine raster - all exercised on real glyph outlines from a corpus
+// font (DejaVu Sans via the TrueType engine). The Dart evaluator is the
+// reference implementation for the eventual GLSL.
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:pdf_graphics/src/fonts/truetype.dart';
+import 'package:test/test.dart';
+
+import 'reference_raster.dart';
+
+TrueTypeFont? _loadDejaVu() {
+  for (final path in [
+    '../dart_pdf_editor/assets/fonts/DejaVuSans.ttf',
+    '../../packages/dart_pdf_editor/assets/fonts/DejaVuSans.ttf',
+  ]) {
+    final f = File(path);
+    if (f.existsSync()) return TrueTypeFont.parse(f.readAsBytesSync());
+  }
+  return null;
+}
+
+void main() {
+  final font = _loadDejaVu();
+  if (font == null) {
+    test('curve quads', skip: 'DejaVuSans.ttf not found', () {});
+    return;
+  }
+
+  PdfPath outlineOf(String char) {
+    final gid = font.gidForUnicode(char.codeUnitAt(0));
+    expect(gid, isNot(0), reason: 'glyph for "$char"');
+    final outline = font.outlineForGlyph(gid);
+    expect(outline, isNotNull, reason: 'outline for "$char"');
+    return outline!;
+  }
+
+  group('outlineToQuads', () {
+    test('quads stay within the em-space tolerance of the cubics', () {
+      const tol = 1e-3;
+      for (final char in ['a', 'g', 'B', 'S', 'e']) {
+        final outline = outlineOf(char);
+        // walk the original segments; for each cubic, compare dense cubic
+        // samples against the emitted quad chain covering it
+        final quads = outlineToQuads(outline, tolerance: tol);
+        // dense polyline of the whole quad set
+        final poly = <double>[];
+        for (final q in quads) {
+          for (var i = 0; i <= 16; i++) {
+            final t = i / 16;
+            final mt = 1 - t;
+            poly.add(mt * mt * q.x0 + 2 * mt * t * q.cx + t * t * q.x1);
+            poly.add(mt * mt * q.y0 + 2 * mt * t * q.cy + t * t * q.y1);
+          }
+        }
+        double distToPoly(double x, double y) {
+          var best = double.infinity;
+          for (var i = 0; i + 3 < poly.length; i += 2) {
+            final ax = poly[i], ay = poly[i + 1];
+            final bx = poly[i + 2], by = poly[i + 3];
+            final vx = bx - ax, vy = by - ay;
+            final len2 = vx * vx + vy * vy;
+            var t = len2 == 0 ? 0.0 : ((x - ax) * vx + (y - ay) * vy) / len2;
+            t = t.clamp(0.0, 1.0);
+            final dx = x - (ax + vx * t), dy = y - (ay + vy * t);
+            best = math.min(best, dx * dx + dy * dy);
+          }
+          return math.sqrt(best);
+        }
+
+        var penX = 0.0, penY = 0.0;
+        for (final s in outline.segments) {
+          switch (s) {
+            case PdfMoveTo(:final x, :final y) || PdfLineTo(:final x, :final y):
+              penX = x;
+              penY = y;
+            case PdfCubicTo():
+              for (var i = 0; i <= 24; i++) {
+                final t = i / 24;
+                final mt = 1 - t;
+                final bx = mt * mt * mt * penX +
+                    3 * mt * mt * t * s.x1 +
+                    3 * mt * t * t * s.x2 +
+                    t * t * t * s.x3;
+                final by = mt * mt * mt * penY +
+                    3 * mt * mt * t * s.y1 +
+                    3 * mt * t * t * s.y2 +
+                    t * t * t * s.y3;
+                // allow polyline sampling slack on top of the quad bound
+                expect(distToPoly(bx, by), lessThanOrEqualTo(tol * 1.5),
+                    reason: '"$char" cubic sample t=$t');
+              }
+              penX = s.x3;
+              penY = s.y3;
+            case PdfClosePath():
+              break;
+          }
+        }
+      }
+    });
+
+    test('every subpath closes (winding depends on closed loops)', () {
+      for (final char in ['a', 'g', 'B', 'o']) {
+        final quads = outlineToQuads(outlineOf(char));
+        // net edge vector sum of a closed loop set is zero-ish; stronger:
+        // each endpoint appears as a start point exactly as often
+        final starts = <String, int>{};
+        for (final q in quads) {
+          starts.update('${q.x0},${q.y0}', (v) => v + 1, ifAbsent: () => 1);
+          starts.update('${q.x1},${q.y1}', (v) => v - 1, ifAbsent: () => -1);
+        }
+        starts.removeWhere((_, v) => v == 0);
+        expect(starts, isEmpty, reason: '"$char" has unbalanced endpoints');
+      }
+    });
+  });
+
+  group('buildBands', () {
+    test('bands cover each curve\'s y-range, sorted by descending max x',
+        () {
+      final quads = outlineToQuads(outlineOf('g'));
+      final bands = buildBands(quads, bandCount: 8);
+      expect(bands.bandCount, 8);
+      for (var b = 0; b < bands.bandCount; b++) {
+        final y0 = bands.minY + b * bands.bandHeight;
+        final y1 = y0 + bands.bandHeight;
+        final inBand = bands.bands[b];
+        // sorted by descending max x
+        for (var i = 1; i < inBand.length; i++) {
+          expect(quads[inBand[i - 1]].maxX,
+              greaterThanOrEqualTo(quads[inBand[i]].maxX));
+        }
+        // every curve overlapping the band is listed
+        for (var i = 0; i < quads.length; i++) {
+          final overlaps = quads[i].maxY > y0 && quads[i].minY < y1;
+          if (overlaps) {
+            expect(inBand, contains(i),
+                reason: 'band $b must list curve $i');
+          }
+        }
+      }
+    });
+
+    test('overflow flags a band exceeding the cap', () {
+      // 17 horizontal-ish curves stacked into the same y range
+      final curves = [
+        for (var i = 0; i < 17; i++)
+          QuadCurve(0, i * 0.001, 0.5, i * 0.001, 1, i * 0.001 + 0.0005),
+      ];
+      final bands = buildBands(curves, bandCount: 1, maxCurvesPerBand: 16);
+      expect(bands.overflow, isTrue);
+      // real glyphs at 8 bands stay under the default cap
+      for (final char in ['a', 'g', 'B', 'o', 'S']) {
+        final b = buildBands(outlineToQuads(outlineOf(char)), bandCount: 8);
+        expect(b.overflow, isFalse, reason: '"$char" overflows 16/band');
+      }
+    });
+  });
+
+  group('band evaluator', () {
+    test('winding coverage matches the strip fine raster on real glyphs',
+        () {
+      for (final char in ['a', 'g', 'B', 'o']) {
+        final outline = outlineOf(char);
+        final quads = outlineToQuads(outline);
+        final bands = buildBands(quads, bandCount: 8);
+        expect(bands.overflow, isFalse);
+
+        // rasterize via strips at a 24-px em into a small viewport
+        const size = 24.0;
+        const w = 32, h = 32;
+        const m = PdfMatrix(size, 0, 0, -size, 4, 26); // em -> device, y-flip
+        final gen = StripGenerator()
+          ..glyphCache = null
+          ..begin(w, h);
+        gen.fillOutline(FlattenedOutline.of(outline), m, 0xFF000000);
+        final stripCov = decodeStripCoverage(gen.strips, w, h);
+
+        // band-evaluator coverage: supersample winding in em space
+        final inv = m.inverted()!;
+        final bandCov = Uint8List(w * h);
+        const ss = 8;
+        for (var py = 0; py < h; py++) {
+          for (var px = 0; px < w; px++) {
+            var inside = 0;
+            for (var sy = 0; sy < ss; sy++) {
+              for (var sx = 0; sx < ss; sx++) {
+                final dx = px + (sx + 0.5) / ss, dy = py + (sy + 0.5) / ss;
+                final ex = inv.transformX(dx, dy);
+                final ey = inv.transformY(dx, dy);
+                if (glyphWindingAt(quads, bands, ex, ey) != 0) inside++;
+              }
+            }
+            bandCov[py * w + px] = (inside * 255 + ss * ss ~/ 2) ~/ (ss * ss);
+          }
+        }
+        expect(meanAbsDiff(bandCov, stripCov), lessThanOrEqualTo(2.5),
+            reason: '"$char" band evaluation vs strip raster');
+      }
+    });
+  });
+
+  group('texel encoding', () {
+    test('fixed point roundtrips within 1/8192 em', () {
+      for (final v in [-3.999, -1.0, -0.123456, 0.0, 0.5, 1.25, 3.999]) {
+        expect((fixedToEm(emToFixed(v)) - v).abs(), lessThan(1 / 8192));
+      }
+    });
+
+    test('encode/decode roundtrip preserves curves, bands, and winding', () {
+      final outline = outlineOf('g');
+      final quads = outlineToQuads(outline);
+      final bands = buildBands(quads, bandCount: 8);
+      final tex = encodeGlyphTexels(quads, bands);
+      expect(tex.overflow, isFalse);
+      expect(tex.pixels.length, tex.width * tex.height * 4);
+
+      // decode side (mirrors the shader's reads)
+      final data = ByteData.sublistView(tex.pixels);
+      (int, int) texel(int i) => (
+            data.getUint16(i * 4, Endian.little),
+            data.getUint16(i * 4 + 2, Endian.little),
+          );
+      final (bandCount, curveCount) = texel(0);
+      expect(bandCount, 8);
+      expect(curveCount, quads.length);
+
+      final decoded = <QuadCurve>[];
+      final decodedBands = <List<int>>[];
+      final curveBase = 1 +
+          bandCount +
+          bands.bands.fold<int>(0, (a, b) => a + b.length);
+      for (var b = 0; b < bandCount; b++) {
+        final (offset, count) = texel(1 + b);
+        final refs = <int>[];
+        for (var i = 0; i < count; i++) {
+          final (curveTexel, _) = texel(offset + i);
+          expect((curveTexel - curveBase) % 3, 0);
+          refs.add((curveTexel - curveBase) ~/ 3);
+        }
+        decodedBands.add(refs);
+        expect(refs, bands.bands[b].toList(),
+            reason: 'band $b reference list');
+      }
+      for (var i = 0; i < curveCount; i++) {
+        final (x0, y0) = texel(curveBase + 3 * i);
+        final (cx, cy) = texel(curveBase + 3 * i + 1);
+        final (x1, y1) = texel(curveBase + 3 * i + 2);
+        decoded.add(QuadCurve(fixedToEm(x0), fixedToEm(y0), fixedToEm(cx),
+            fixedToEm(cy), fixedToEm(x1), fixedToEm(y1)));
+        expect((decoded[i].x0 - quads[i].x0).abs(), lessThan(1 / 8192));
+        expect((decoded[i].cy - quads[i].cy).abs(), lessThan(1 / 8192));
+      }
+
+      // winding from decoded curves matches the original at sample points
+      final decodedBandsObj = buildBands(decoded, bandCount: 8);
+      final rand = math.Random(7);
+      for (var i = 0; i < 200; i++) {
+        final x = bands.minX + rand.nextDouble() * (bands.maxX - bands.minX);
+        final y = bands.minY + rand.nextDouble() * (bands.maxY - bands.minY);
+        expect(glyphWindingAt(decoded, decodedBandsObj, x, y) != 0,
+            glyphWindingAt(quads, bands, x, y) != 0,
+            reason: 'inside/outside at ($x,$y)');
+      }
+    });
+
+    test('oversized curve streams throw (caller falls back to strips)', () {
+      final curves = [
+        for (var i = 0; i < 22000; i++)
+          QuadCurve(0, i * 1e-5, 0.5, i * 1e-5, 1, i * 1e-5 + 1e-5),
+      ];
+      final bands = buildBands(curves, bandCount: 1, maxCurvesPerBand: 1 << 20);
+      expect(() => encodeGlyphTexels(curves, bands), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add the pure-Dart cubic-to-quad, banding, fixed-point atlas, and dual-ray AA foundations for Slug-style glyph evaluation
- add the pdf_slug.frag runtime shader and conservative painter-order Slug batching in StripPdfDevice
- on web, keep one complete retained Slug picture under the viewer transform for eligible image-free embedded-outline pages, eliminating zoom-settle replay/readback for that page
- preserve PDF painter order by retaining the full scene picture instead of lifting text into a topmost overlay
- keep Base-14/substituted text, minified/overflow outline runs, dense worker-planned pages, and image-bearing deep-zoom pages on their existing raster paths
- include a standalone embedded-font web probe under example/tool/web_slug_probe.dart

## Measured / browser validation
- C2 control: recorded Slug picture at 3x differs from a sharp render by 1.78/255 mean; scaled strip picture differs by 5.43/255
- CanvasKit release probe: 2 Slug quads, 0 strip glyph quads; 1x to 3x transform remains at 2 quads (no replay/readback), no browser warnings
- skwasm release probe: same 2-quad/0-strip result and unchanged count at 3x, no browser warnings
- Slug vs strip page parity: 2.24/255 mean

## Validation
- fvm dart analyze (workspace)
- cd packages/pdf_graphics and fvm dart test (782 passed)
- cd packages/dart_pdf_editor and fvm flutter test (1,353 passed; 24 environment-gated skips)
- CanvasKit and skwasm release builds of the standalone web probe

Follow-up for dense and mixed image/text pages: #227.

Closes #218