### PR TITLE
perf: adapt worker and preview tuning to runtime load

### DIFF
--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -101,6 +101,21 @@ Numbers and methodology are in
 [`benchmark/`](https://github.com/ben-milanko/dart-pdf/tree/main/benchmark).
 The harnesses diff dart-pdf against PDFium file by file.
 
+The drop-in shells use adaptive performance tuning by default. Auto selects a
+platform-, core-, and document-aware worker count, then adjusts safe preview
+and image-resolution knobs from observed render latency, result sizes, and
+frame jank. Use a controller to inspect it or choose a fixed configuration:
+
+```dart
+final performance = PdfPerformanceController(); // Auto
+
+PdfReader(bytes: pdfBytes, performance: performance);
+debugPrint('${performance.diagnostics}');
+
+// Applied when the document worker next starts; never resized mid-scroll.
+performance.mode = const PdfPerformanceMode.fixed(workerCount: 2);
+```
+
 ## Viewing
 
 - Zooming/panning viewer with fit-page and fit-width modes, deep-zoom

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -82,12 +82,6 @@ String pdfSavePathWithExtension(String path) {
 }
 
 void main() {
-  // Fan page decoding across a few workers so a raster-heavy document (every
-  // CAD sheet a multi-second image decode) warms several pages at once instead
-  // of one at a time. Each worker holds its own copy of the document, so this
-  // trades memory for throughput. The example exposes this in the AppBar so
-  // users can switch between the pooled and single-worker paths.
-  pdfRenderWorkerPoolSize = 3;
   // Diagnostics: turn on the in-app performance trace (interpret times,
   // render-hold/scheduler transitions, prerender warms, and frame JANK,
   // streamed to the browser console) without a rebuild by opening the demo
@@ -217,16 +211,17 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// [PdfEditorView] for the view-only [PdfReader]. App-wide.
   bool _readOnly = false;
 
-  bool _workerPoolEnabled = pdfRenderWorkerPoolSize > 1;
-  int _workerPoolSize =
-      pdfRenderWorkerPoolSize > 1 ? pdfRenderWorkerPoolSize : 3;
+  final PdfPerformanceController _performance = PdfPerformanceController();
   int _workerConfigEpoch = 0;
 
-  int get _effectiveWorkerPoolSize => _workerPoolEnabled ? _workerPoolSize : 1;
-
-  String get _workerPoolTooltip => _workerPoolEnabled
-      ? 'Worker pool: $_workerPoolSize workers'
-      : 'Worker pool off: single worker';
+  String get _workerPoolTooltip {
+    final mode = _performance.mode;
+    if (mode.isAuto) return 'Performance: Auto';
+    final count = mode.workerCount!;
+    return count == 1
+        ? 'Performance: single worker'
+        : 'Performance: $count workers';
+  }
 
   /// OCR connection settings, supplied through the credentials dialog and
   /// remembered for the app's lifetime (the API key is deliberately kept in
@@ -308,22 +303,16 @@ class _ViewerScreenState extends State<ViewerScreen> {
     };
   }
 
-  void _setWorkerPoolSize(int value) {
-    final nextSize = value <= 1 ? 1 : value;
-    if (nextSize == _effectiveWorkerPoolSize) return;
+  void _setPerformanceMode(int value) {
+    final next = value == 0
+        ? const PdfPerformanceMode.auto()
+        : PdfPerformanceMode.fixed(workerCount: value);
+    if (next == _performance.mode) return;
     setState(() {
-      if (nextSize == 1) {
-        _workerPoolEnabled = false;
-      } else {
-        _workerPoolEnabled = true;
-        _workerPoolSize = nextSize;
-      }
-      pdfRenderWorkerPoolSize = _effectiveWorkerPoolSize;
+      _performance.mode = next;
       _workerConfigEpoch++;
     });
-    _toast(_workerPoolEnabled
-        ? 'Worker pool: $_workerPoolSize workers'
-        : 'Worker pool off: single worker');
+    _toast(_workerPoolTooltip);
   }
 
   Key _pdfShellKey(_DocumentTab tab, String mode) =>
@@ -736,6 +725,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
     for (final tab in _tabs) {
       tab.dispose();
     }
+    _performance.dispose();
     super.dispose();
   }
 
@@ -1199,22 +1189,29 @@ class _ViewerScreenState extends State<ViewerScreen> {
               PopupMenuButton<int>(
                 key: const ValueKey('dartpdf-worker-pool-menu'),
                 tooltip: _workerPoolTooltip,
-                icon: Icon(
-                    _workerPoolEnabled ? Icons.memory : Icons.memory_outlined),
-                onSelected: _setWorkerPoolSize,
+                icon: Icon(_performance.mode.isAuto
+                    ? Icons.auto_awesome
+                    : Icons.memory),
+                onSelected: _setPerformanceMode,
                 itemBuilder: (context) => [
+                  CheckedPopupMenuItem<int>(
+                    key: const ValueKey('dartpdf-worker-pool-auto'),
+                    value: 0,
+                    checked: _performance.mode.isAuto,
+                    child: const Text('Auto'),
+                  ),
+                  const PopupMenuDivider(),
                   CheckedPopupMenuItem<int>(
                     key: const ValueKey('dartpdf-worker-pool-off'),
                     value: 1,
-                    checked: !_workerPoolEnabled,
-                    child: const Text('Worker pool off'),
+                    checked: _performance.mode.workerCount == 1,
+                    child: const Text('Single worker'),
                   ),
-                  const PopupMenuDivider(),
                   for (final size in const [2, 3, 4, 6])
                     CheckedPopupMenuItem<int>(
                       key: ValueKey('dartpdf-worker-pool-$size'),
                       value: size,
-                      checked: _workerPoolEnabled && _workerPoolSize == size,
+                      checked: _performance.mode.workerCount == size,
                       child: Text('$size workers'),
                     ),
                 ],
@@ -1281,6 +1278,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 documentId: tab.title,
                                 controller: tab.viewer,
                                 preferences: _prefs,
+                                performance: _performance,
                                 rasterCache: _rasterCache,
                                 textCache: _textCache,
                                 onAction: _onAction,
@@ -1292,6 +1290,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 documentId: tab.title,
                                 controller: tab.session,
                                 viewerController: tab.viewer,
+                                performance: _performance,
                                 rasterCache: _rasterCache,
                                 textCache: _textCache,
                                 onSave: (saved) => unawaited(_saveAs(saved)),

--- a/packages/dart_pdf_editor/example/test/tabs_test.dart
+++ b/packages/dart_pdf_editor/example/test/tabs_test.dart
@@ -87,29 +87,29 @@ void main() {
     expect(find.text('Compare with another PDF…'), findsOneWidget);
   });
 
-  testWidgets('worker pool menu toggles between pooled and single worker',
+  testWidgets('performance menu switches between Auto and fixed workers',
       (tester) async {
-    final oldPoolSize = pdfRenderWorkerPoolSize;
-    addTearDown(() => pdfRenderWorkerPoolSize = oldPoolSize);
-    pdfRenderWorkerPoolSize = 3;
-
     await openDemo(tester);
     final menu = find.byKey(const ValueKey('dartpdf-worker-pool-menu'));
     expect(menu, findsOneWidget);
-    expect(find.byTooltip('Worker pool: 3 workers'), findsOneWidget);
+    expect(find.byTooltip('Performance: Auto'), findsOneWidget);
 
     await tester.tap(menu);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('dartpdf-worker-pool-off')));
     await tester.pump();
-    expect(pdfRenderWorkerPoolSize, 1);
-    expect(find.byTooltip('Worker pool off: single worker'), findsOneWidget);
+    expect(find.byTooltip('Performance: single worker'), findsOneWidget);
 
     await tester.tap(menu);
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('dartpdf-worker-pool-4')));
     await tester.pump();
-    expect(pdfRenderWorkerPoolSize, 4);
-    expect(find.byTooltip('Worker pool: 4 workers'), findsOneWidget);
+    expect(find.byTooltip('Performance: 4 workers'), findsOneWidget);
+
+    await tester.tap(menu);
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('dartpdf-worker-pool-auto')));
+    await tester.pump();
+    expect(find.byTooltip('Performance: Auto'), findsOneWidget);
   });
 }

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -49,6 +49,7 @@ export 'src/pdf_page_view.dart';
 export 'src/pdf_reader.dart';
 export 'src/pdf_reflow_view.dart';
 export 'src/pdf_viewer.dart';
+export 'src/performance_policy.dart';
 export 'src/preview_cache.dart';
 export 'src/raster_cache.dart';
 export 'src/render_scheduler.dart';

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -18,6 +18,8 @@ import 'editing/editing_toolbar.dart';
 import 'editing/text_prompt.dart';
 import 'editing/tool_shortcuts.dart';
 import 'page_number_field.dart';
+import 'perf_log.dart';
+import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
 import 'raster_cache.dart';
@@ -207,6 +209,7 @@ class PdfEditorView extends StatefulWidget {
     this.controller,
     this.viewerController,
     this.preferences,
+    this.performance,
     this.features = const PdfEditorFeatures(),
     this.onSave,
     this.onSaveAs,
@@ -279,6 +282,11 @@ class PdfEditorView extends StatefulWidget {
   /// The persisted preferences backing tool styles and panel state.
   /// Only with [bytes]; an external [controller] brings its own.
   final PdfEditingPreferences? preferences;
+
+  /// Optional adaptive/fixed performance controller. Null creates an owned
+  /// Auto controller. Worker-count recommendations apply only when this shell
+  /// naturally restarts its revision-bound worker.
+  final PdfPerformanceController? performance;
 
   final PdfEditorFeatures features;
 
@@ -418,6 +426,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   PdfEditingPreferences? _ownedPrefs;
   PdfViewerController? _ownedViewer;
   PdfViewportMemory? _viewportMemory;
+  PdfPerformanceController? _ownedPerformance;
 
   // Routes the Apple Pencil's native double-tap to the session's eraser
   // toggle. Created only on iOS (the only platform with the gesture) so the
@@ -449,6 +458,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
       widget.viewerController ?? (_ownedViewer ??= PdfViewerController());
 
   PdfEditingPreferences get _prefs => _session.preferences;
+
+  PdfPerformanceController get _performance =>
+      widget.performance ?? (_ownedPerformance ??= PdfPerformanceController());
 
   /// A stable key for the open document, or null when there is nothing to
   /// key a remembered position on - an external controller with no
@@ -483,6 +495,10 @@ class _PdfEditorViewState extends State<PdfEditorView> {
       _ownedSession = PdfEditingController(widget.bytes!, preferences: prefs);
     }
     _session.providedCustomStamps = widget.customStamps;
+    _performance.configureDocument(
+      pageCount: _session.document.pageCount,
+      documentBytes: _session.bytes.length,
+    );
     _syncFeatureLocks();
     _reportedLength = _session.bytes.length;
     _session.addListener(_onSessionChanged);
@@ -519,9 +535,11 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   void _syncWorker() {
     if (identical(_session.document, _workerDoc)) return;
     _worker?.dispose();
+    final workerCount = _performance.beginWorkerGeneration();
     _worker = startPdfRenderWorker(_session.bytes,
-        pageCount: _session.document.pageCount);
+        pageCount: _session.document.pageCount, workerCount: workerCount);
     _workerDoc = _session.document;
+    PdfPerfLog.log(_performance.diagnostics.toString());
   }
 
   void _syncFeatureLocks() {
@@ -541,6 +559,16 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   @override
   void didUpdateWidget(PdfEditorView oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.performance, widget.performance)) {
+      if (oldWidget.performance == null) {
+        _ownedPerformance?.dispose();
+        _ownedPerformance = null;
+      }
+      _performance.configureDocument(
+        pageCount: _session.document.pageCount,
+        documentBytes: _session.bytes.length,
+      );
+    }
     if (!mapEquals(widget.toolShortcuts, oldWidget.toolShortcuts)) {
       _toolShortcuts =
           Map<PdfEditTool, LogicalKeyboardKey>.of(widget.toolShortcuts);
@@ -567,6 +595,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
     _closeSession();
     _ownedPrefs?.dispose();
     _ownedViewer?.dispose();
+    _ownedPerformance?.dispose();
     _searchField.dispose();
     _searchFocus.dispose();
     super.dispose();
@@ -1018,6 +1047,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         showAnnotations: prefs.showAnnotations,
                         highlightFormFields: prefs.highlightFormFields,
                         renderWorker: _worker,
+                        performance: _performance,
                         rasterCache: widget.rasterCache,
                         textCache: widget.textCache,
                         documentId: _documentKey,

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -9,6 +9,7 @@ import 'package:pdf_graphics/pdf_graphics.dart'
     show PdfMatrix, PdfRenderCommand;
 
 import 'perf_log.dart';
+import 'performance_policy.dart';
 import 'preview_cache.dart';
 import 'render_scheduler.dart';
 import 'render_worker.dart';
@@ -48,6 +49,8 @@ class PdfPageView extends StatefulWidget {
     this.trustContentStamp = false,
     this.destructiveStamp = 0,
     this.renderWorker,
+    this.performance,
+    this.workerImagePixelRatioCap,
     this.transformScale,
     this.transformChanges,
   });
@@ -66,6 +69,13 @@ class PdfPageView extends StatefulWidget {
   /// thread. Image-bearing pages and the null fallback render locally. Must
   /// be a worker started over the same bytes [page] belongs to.
   final PdfRenderWorker? renderWorker;
+
+  /// Optional adaptive policy receiving first-render latency samples.
+  final PdfPerformanceController? performance;
+
+  /// Caps ordinary full-page worker image decode requests. Deep-zoom region
+  /// requests stay uncapped so visible image detail can sharpen on demand.
+  final double? workerImagePixelRatioCap;
 
   /// The viewer's LIVE zoom scale (the InteractiveViewer matrix's scale on
   /// every change), as opposed to [scale], which the viewer only updates at
@@ -660,7 +670,8 @@ class _PdfPageViewState extends State<PdfPageView> {
       final commands = await worker.record(pageIndex,
           annotations: widget.showAnnotations,
           priority: widget.renderPriority,
-          imagePixelRatio: _effectiveRatio());
+          imagePixelRatio: math.min(_effectiveRatio(),
+              widget.workerImagePixelRatioCap ?? double.infinity));
       // Abandoned while the worker ran - the State was disposed or the lazy
       // list recycled it onto another page (this is the cancel() path: a
       // cancelled request returns null). Skip the local fallback: the page is
@@ -672,7 +683,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       if (commands != null) {
         if (_renderPaused) return null;
         _lastInterpretPath = 'worker';
-        _logImageStats(pageIndex, commands);
+        _lastInterpretResultBytes = _logImageStats(pageIndex, commands);
         final (picture, scene) = await _replayableFromCommands(commands);
         return (picture, scene, true);
       }
@@ -694,6 +705,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     // but the command buffer and decoded images are kept for zoom replays
     // instead of being discarded after the 1:1 replay below.
     final scene = await PdfRetainedScene.record(widget.page, plan: _renderPlan);
+    _lastInterpretResultBytes = _logImageStats(pageIndex, scene.commands);
     if (!_retainScene(scene.commands.length)) {
       // Too dense to replay per zoom settle: take the 1:1 picture (it holds
       // its own image refs) and drop the scene - the classic cached-picture
@@ -777,6 +789,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       // it (and its retained scene) so the full pass reuses it instead of
       // recording a second time; the normal raster path below paints it.
       _lastInterpretPath = 'worker';
+      _lastInterpretResultBytes = 0;
       if (_retainScene(commands.length)) {
         // No images to decode, so this completes synchronously in practice.
         final scene = await PdfRetainedScene.fromCommands(widget.page, commands,
@@ -830,13 +843,13 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// summing large. The walk lives in [PdfPageRenderer.decodedImageStats] (and
   /// is tested there); this only formats the line, and is skipped entirely when
   /// the log is off.
-  void _logImageStats(int pageIndex, List<PdfRenderCommand> commands) {
-    if (!PdfPerfLog.enabled) return;
+  int _logImageStats(int pageIndex, List<PdfRenderCommand> commands) {
     final (count, pixels) = PdfPageRenderer.decodedImageStats(commands);
-    if (count > 0) {
+    if (count > 0 && PdfPerfLog.enabled) {
       PdfPerfLog.log('images page=$pageIndex count=$count '
           'decodedMpx=${(pixels / 1e6).toStringAsFixed(1)}');
     }
+    return pixels * 4;
   }
 
   /// Whether the page this render was for is gone - the widget unmounted, or
@@ -862,6 +875,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// Which path [_interpretPicture] actually took, for the perf log - 'worker'
   /// only when a command buffer came back and replayed, else 'recorded'.
   String _lastInterpretPath = 'recorded';
+  int? _lastInterpretResultBytes;
 
   /// The actual interpret + rasterize, run once the first render is no
   /// longer gated (or directly for re-rasters of a cached picture).
@@ -869,6 +883,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     final generation = ++_renderGeneration;
     final pageIndex = widget.previewIndex;
     final firstInterpret = _picture == null;
+    if (firstInterpret) _lastInterpretResultBytes = null;
+    final sw = Stopwatch()..start();
     if (_renderPaused) {
       _render();
       return;
@@ -882,7 +898,6 @@ class _PdfPageViewState extends State<PdfPageView> {
       await _paintVectorFirst(generation, pageIndex);
       if (_superseded(generation, pageIndex)) return;
     }
-    final sw = Stopwatch()..start();
     final cached = _picture;
     final ui.Picture picture;
     if (cached != null) {
@@ -916,6 +931,10 @@ class _PdfPageViewState extends State<PdfPageView> {
           path: _lastInterpretPath,
           interpretMs: sw.elapsedMicroseconds / 1000.0,
           first: true);
+      widget.performance?.observe(PdfPerformanceSample(
+        workerRecordDuration: sw.elapsed,
+        resultBytes: _lastInterpretResultBytes,
+      ));
     }
     final effective = _effectiveRatio();
     // Skip the full-page readback when the cached raster is already at

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -8,6 +8,8 @@ import 'editing/editing_controller.dart';
 import 'editing/editing_preferences.dart';
 import 'editing/editing_thumbnails.dart';
 import 'page_number_field.dart';
+import 'perf_log.dart';
+import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
 import 'raster_cache.dart';
@@ -105,6 +107,7 @@ class PdfReader extends StatefulWidget {
     this.documentId,
     this.controller,
     this.preferences,
+    this.performance,
     this.features = const PdfReaderFeatures(),
     this.onAction,
     this.onAnnotationTap,
@@ -145,6 +148,11 @@ class PdfReader extends StatefulWidget {
 
   /// The persisted display preferences. Defaults to a private instance.
   final PdfEditingPreferences? preferences;
+
+  /// Optional adaptive/fixed performance controller. Null creates an owned
+  /// Auto controller. Pass one to select fixed worker settings at runtime or
+  /// expose [PdfPerformanceController.diagnostics] in host UI.
+  final PdfPerformanceController? performance;
 
   final PdfReaderFeatures features;
 
@@ -187,6 +195,7 @@ class _PdfReaderState extends State<PdfReader> {
   PdfEditingPreferences? _ownedPrefs;
   PdfViewerController? _ownedViewer;
   PdfViewportMemory? _viewportMemory;
+  PdfPerformanceController? _ownedPerformance;
 
   // Offloads page interpretation to a background isolate (native; a no-op
   // fallback on web). Keyed to the session's current document: pure reading
@@ -202,6 +211,8 @@ class _PdfReaderState extends State<PdfReader> {
       widget.controller ?? (_ownedViewer ??= PdfViewerController());
 
   PdfEditingPreferences get _prefs => _session.preferences;
+  PdfPerformanceController get _performance =>
+      widget.performance ?? (_ownedPerformance ??= PdfPerformanceController());
 
   String get _documentKey => widget.documentId ?? pdfDocumentKey(widget.bytes);
 
@@ -221,6 +232,10 @@ class _PdfReaderState extends State<PdfReader> {
     final prefs =
         widget.preferences ?? (_ownedPrefs ??= PdfEditingPreferences());
     _session = PdfEditingController(widget.bytes, preferences: prefs);
+    _performance.configureDocument(
+      pageCount: _session.document.pageCount,
+      documentBytes: widget.bytes.length,
+    );
     _session.addListener(_syncWorker);
     _syncWorker();
   }
@@ -234,14 +249,26 @@ class _PdfReaderState extends State<PdfReader> {
   void _syncWorker() {
     if (identical(_session.document, _workerDoc)) return;
     _worker?.dispose();
+    final workerCount = _performance.beginWorkerGeneration();
     _worker = startPdfRenderWorker(_session.bytes,
-        pageCount: _session.document.pageCount);
+        pageCount: _session.document.pageCount, workerCount: workerCount);
     _workerDoc = _session.document;
+    PdfPerfLog.log(_performance.diagnostics.toString());
   }
 
   @override
   void didUpdateWidget(PdfReader oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.performance, widget.performance)) {
+      if (oldWidget.performance == null) {
+        _ownedPerformance?.dispose();
+        _ownedPerformance = null;
+      }
+      _performance.configureDocument(
+        pageCount: _session.document.pageCount,
+        documentBytes: widget.bytes.length,
+      );
+    }
     if (!identical(widget.bytes, oldWidget.bytes) ||
         widget.documentId != oldWidget.documentId) {
       final previous = _session;
@@ -261,6 +288,7 @@ class _PdfReaderState extends State<PdfReader> {
     _session.dispose();
     _ownedPrefs?.dispose();
     _ownedViewer?.dispose();
+    _ownedPerformance?.dispose();
     _searchField.dispose();
     _searchFocus.dispose();
     super.dispose();
@@ -455,6 +483,7 @@ class _PdfReaderState extends State<PdfReader> {
                           showAnnotations: prefs.showAnnotations,
                           highlightFormFields: prefs.highlightFormFields,
                           renderWorker: _worker,
+                          performance: _performance,
                           rasterCache: widget.rasterCache,
                           textCache: widget.textCache,
                           documentId: _documentKey,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -23,6 +23,7 @@ import 'editing/tool_shortcuts.dart';
 import 'exact_extent_list.dart';
 import 'page_geometry.dart';
 import 'perf_log.dart';
+import 'performance_policy.dart';
 import 'pdf_page_view.dart';
 import 'preview_cache.dart';
 import 'raster_cache.dart';
@@ -519,6 +520,7 @@ class PdfViewer extends StatefulWidget {
     this.predictStrokes = true,
     this.toolShortcuts = pdfEditToolShortcuts,
     this.renderWorker,
+    this.performance,
     this.rasterCache,
     this.textCache,
     this.documentId,
@@ -566,6 +568,11 @@ class PdfViewer extends StatefulWidget {
   /// always render locally. Null and the web fallback keep today's
   /// on-thread behavior.
   final PdfRenderWorker? renderWorker;
+
+  /// Optional adaptive performance policy. Worker counts are applied by the
+  /// owning shell when it starts [renderWorker]; the viewer consumes its
+  /// runtime-safe preview, vector-first, and image-cap tuning live.
+  final PdfPerformanceController? performance;
 
   /// Single-key shortcuts that arm editing tools while [editing] is active.
   ///
@@ -1071,6 +1078,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     _controller = widget.controller ?? PdfViewerController();
     _ownsController = widget.controller == null;
     _controller._state = this;
+    widget.performance?.addListener(_onPerformanceChanged);
+    if (widget.performance != null) {
+      SchedulerBinding.instance.addTimingsCallback(_onPerformanceTimings);
+    }
     // mounted already paused (overlaid by another view) - hold rendering from
     // the first frame so covered pages never interpret
     if (!widget.active) _renderScheduler.holding = true;
@@ -1102,6 +1113,23 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     // background preview prerender starts once the first frame (and the
     // scroll metrics the priority order needs) exists
     WidgetsBinding.instance.addPostFrameCallback((_) => _prerenderPreviews());
+  }
+
+  void _onPerformanceChanged() {
+    if (!mounted) return;
+    setState(() {});
+    WidgetsBinding.instance.addPostFrameCallback((_) => _prerenderPreviews());
+  }
+
+  void _onPerformanceTimings(List<FrameTiming> timings) {
+    final performance = widget.performance;
+    if (performance == null) return;
+    for (final timing in timings) {
+      if (timing.buildDuration > const Duration(milliseconds: 16) ||
+          timing.rasterDuration > const Duration(milliseconds: 16)) {
+        performance.observe(const PdfPerformanceSample(jankyFrame: true));
+      }
+    }
   }
 
   late final AppLifecycleListener _lifecycle;
@@ -1361,8 +1389,15 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     _prerendering = true;
     try {
       while (mounted && widget.pagePreviews && widget.active) {
-        final vectorOnly =
-            _vectorFirstPrefetch && (widget.renderWorker?.isActive ?? false);
+        final workerActive = widget.renderWorker?.isActive ?? false;
+        final motionVector = _vectorFirstPrefetch && workerActive;
+        final policyVector = !motionVector &&
+            workerActive &&
+            (widget.performance?.tuning.vectorFirstPreviews ?? false) &&
+            _nextPreviewIndex(_pages,
+                    requireImages: false, allowNearViewport: false) !=
+                null;
+        final vectorOnly = motionVector || policyVector;
         if (!vectorOnly &&
             (_renderScheduler.holding ||
                 (_scrollSettleTimer?.isActive ?? false))) {
@@ -1475,7 +1510,8 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   /// Vector-only warming stays at the configured window because it is cheap
   /// and weighs zero in [PdfCachingRenderWorker].
   int _effectivePreviewWindow({required bool requireImages}) {
-    final base = widget.previewWindow;
+    final base =
+        widget.performance?.tuning.previewWindow ?? widget.previewWindow;
     if (base <= 0 || !requireImages) return base;
 
     var window = base;
@@ -1565,6 +1601,16 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
   @override
   void didUpdateWidget(PdfViewer oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.performance, widget.performance)) {
+      oldWidget.performance?.removeListener(_onPerformanceChanged);
+      if (oldWidget.performance != null) {
+        SchedulerBinding.instance.removeTimingsCallback(_onPerformanceTimings);
+      }
+      widget.performance?.addListener(_onPerformanceChanged);
+      if (widget.performance != null) {
+        SchedulerBinding.instance.addTimingsCallback(_onPerformanceTimings);
+      }
+    }
     if (!identical(oldWidget.document, widget.document)) {
       // an edit-induced swap to a revision with the same page geometry
       // keeps the reading position; a genuinely different document resets
@@ -1820,6 +1866,10 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
 
   @override
   void dispose() {
+    widget.performance?.removeListener(_onPerformanceChanged);
+    if (widget.performance != null) {
+      SchedulerBinding.instance.removeTimingsCallback(_onPerformanceTimings);
+    }
     HardwareKeyboard.instance.removeHandler(_onKeyEvent);
     _restoreBrowserContextMenu();
     _lifecycle.dispose();
@@ -4083,6 +4133,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
                 renderScheduler: _renderScheduler,
                 previewCache: widget.pagePreviews ? _previews : null,
                 renderWorker: widget.renderWorker,
+                performance: widget.performance,
                 predictStrokes: widget.predictStrokes,
                 onTextEditClosed: _reclaimFocusAfterTextEdit,
               ),
@@ -4677,6 +4728,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.renderScheduler,
     required this.previewCache,
     required this.renderWorker,
+    required this.performance,
     required this.predictStrokes,
     required this.onTextEditClosed,
   });
@@ -4789,6 +4841,8 @@ class _PdfViewerPage extends StatefulWidget {
   /// See [PdfPageView.renderWorker]; null when interpretation runs on-thread.
   final PdfRenderWorker? renderWorker;
 
+  final PdfPerformanceController? performance;
+
   /// See [PdfViewer.predictStrokes].
   final bool predictStrokes;
 
@@ -4878,6 +4932,8 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         renderScheduler: widget.renderScheduler,
         previewCache: widget.previewCache,
         renderWorker: widget.renderWorker,
+        performance: widget.performance,
+        workerImagePixelRatioCap: widget.performance?.tuning.imagePixelRatioCap,
         // the live matrix scale lets dense strip-routed pages bin their
         // settle's strip plan speculatively while the gesture quiesces; the
         // full matrix additionally lets deep-zoom pans speculate their next

--- a/packages/dart_pdf_editor/lib/src/performance_policy.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_policy.dart
@@ -1,0 +1,419 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+import 'performance_processors.dart';
+
+/// Coarse runtime family used by the adaptive render policy.
+enum PdfPerformancePlatform { mobile, desktop, web, other }
+
+/// The current auto-policy posture. Exposed in diagnostics and tests.
+enum PdfPerformanceTier { conservative, balanced, throughput }
+
+/// Fixed performance settings or an adaptive policy with a worker ceiling.
+class PdfPerformanceMode {
+  const PdfPerformanceMode.auto({this.maxWorkers = 4})
+      : workerCount = null,
+        previewWindow = null,
+        imagePixelRatioCap = null,
+        vectorFirstPreviews = null;
+
+  const PdfPerformanceMode.fixed({
+    required int workerCount,
+    this.previewWindow = 6,
+    this.imagePixelRatioCap = double.infinity,
+    this.vectorFirstPreviews = false,
+  })  : workerCount = workerCount,
+        maxWorkers = workerCount;
+
+  final int? workerCount;
+  final int maxWorkers;
+  final int? previewWindow;
+  final double? imagePixelRatioCap;
+  final bool? vectorFirstPreviews;
+
+  bool get isAuto => workerCount == null;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfPerformanceMode &&
+      workerCount == other.workerCount &&
+      maxWorkers == other.maxWorkers &&
+      previewWindow == other.previewWindow &&
+      imagePixelRatioCap == other.imagePixelRatioCap &&
+      vectorFirstPreviews == other.vectorFirstPreviews;
+
+  @override
+  int get hashCode => Object.hash(workerCount, maxWorkers, previewWindow,
+      imagePixelRatioCap, vectorFirstPreviews);
+}
+
+/// Stable inputs known when a document worker is opened.
+class PdfPerformanceEnvironment {
+  const PdfPerformanceEnvironment({
+    required this.platform,
+    required this.logicalProcessors,
+    required this.pageCount,
+    required this.documentBytes,
+  });
+
+  factory PdfPerformanceEnvironment.detect({
+    required int pageCount,
+    required int documentBytes,
+  }) {
+    final platform = kIsWeb
+        ? PdfPerformancePlatform.web
+        : switch (defaultTargetPlatform) {
+            TargetPlatform.android ||
+            TargetPlatform.iOS ||
+            TargetPlatform.fuchsia =>
+              PdfPerformancePlatform.mobile,
+            TargetPlatform.linux ||
+            TargetPlatform.macOS ||
+            TargetPlatform.windows =>
+              PdfPerformancePlatform.desktop,
+          };
+    return PdfPerformanceEnvironment(
+      platform: platform,
+      logicalProcessors: detectedPdfLogicalProcessors,
+      pageCount: pageCount,
+      documentBytes: documentBytes,
+    );
+  }
+
+  final PdfPerformancePlatform platform;
+  final int logicalProcessors;
+  final int pageCount;
+  final int documentBytes;
+}
+
+/// One synthetic or observed performance sample. Durations are optional so
+/// callers can feed the signals they own without manufacturing the rest.
+class PdfPerformanceSample {
+  const PdfPerformanceSample({
+    this.workerRecordDuration,
+    this.fullRenderDuration,
+    this.resultBytes,
+    this.jankyFrame = false,
+  });
+
+  final Duration? workerRecordDuration;
+  final Duration? fullRenderDuration;
+  final int? resultBytes;
+  final bool jankyFrame;
+}
+
+/// Runtime knobs selected by [PdfPerformanceController].
+class PdfPerformanceTuning {
+  const PdfPerformanceTuning({
+    required this.tier,
+    required this.workerCount,
+    required this.previewWindow,
+    required this.imagePixelRatioCap,
+    required this.vectorFirstPreviews,
+  });
+
+  final PdfPerformanceTier tier;
+
+  /// Recommended count for the NEXT worker generation. Existing workers are
+  /// never resized in place.
+  final int workerCount;
+
+  /// Pages on each side of the viewport worth warming.
+  final int previewWindow;
+
+  /// Maximum display pixels per PDF point requested in ordinary full-page
+  /// worker records. Deep-zoom region requests remain uncapped.
+  final double imagePixelRatioCap;
+
+  /// Whether idle background warming should produce a vector/text preview
+  /// before paying for the full image-bearing preview.
+  final bool vectorFirstPreviews;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfPerformanceTuning &&
+      tier == other.tier &&
+      workerCount == other.workerCount &&
+      previewWindow == other.previewWindow &&
+      imagePixelRatioCap == other.imagePixelRatioCap &&
+      vectorFirstPreviews == other.vectorFirstPreviews;
+
+  @override
+  int get hashCode => Object.hash(tier, workerCount, previewWindow,
+      imagePixelRatioCap, vectorFirstPreviews);
+}
+
+/// Snapshot suitable for a diagnostics panel or support log.
+class PdfPerformanceDiagnostics {
+  const PdfPerformanceDiagnostics({
+    required this.mode,
+    required this.tuning,
+    required this.currentWorkerCount,
+    required this.pendingWorkerCount,
+    required this.observations,
+    required this.meanLatencyMs,
+    required this.meanResultBytes,
+    required this.jankFraction,
+  });
+
+  final PdfPerformanceMode mode;
+  final PdfPerformanceTuning tuning;
+  final int currentWorkerCount;
+  final int? pendingWorkerCount;
+  final int observations;
+  final double meanLatencyMs;
+  final double meanResultBytes;
+  final double jankFraction;
+
+  @override
+  String toString() {
+    final pending = pendingWorkerCount == null
+        ? ''
+        : ' pendingWorkers=$pendingWorkerCount(next restart)';
+    return 'performance mode=${mode.isAuto ? 'auto' : 'fixed'} '
+        'tier=${tuning.tier.name} workers=$currentWorkerCount$pending '
+        'preview=${tuning.previewWindow} imageCap='
+        '${tuning.imagePixelRatioCap.toStringAsFixed(2)} '
+        'vectorFirst=${tuning.vectorFirstPreviews} samples=$observations '
+        'latency=${meanLatencyMs.toStringAsFixed(1)}ms '
+        'resultKB=${(meanResultBytes / 1024).toStringAsFixed(0)} '
+        'jank=${(jankFraction * 100).toStringAsFixed(0)}%';
+  }
+}
+
+/// Deterministic policy functions, split from the controller for direct tests.
+class PdfPerformancePolicy {
+  const PdfPerformancePolicy._();
+
+  static PdfPerformanceTier initialTier(PdfPerformanceEnvironment env) =>
+      env.documentBytes >= (192 << 20) || env.pageCount >= 300
+          ? PdfPerformanceTier.conservative
+          : PdfPerformanceTier.balanced;
+
+  static int initialWorkerCount(
+      PdfPerformanceEnvironment env, PdfPerformanceMode mode) {
+    if (!mode.isAuto) return math.max(1, mode.workerCount!);
+    if (env.pageCount < 12) return 1;
+
+    final cores = env.logicalProcessors > 0 ? env.logicalProcessors : 4;
+    final available = math.max(1, cores - 1);
+    final platformBase = switch (env.platform) {
+      PdfPerformancePlatform.mobile => 2,
+      PdfPerformancePlatform.desktop => 3,
+      PdfPerformancePlatform.web => 3,
+      PdfPerformancePlatform.other => 2,
+    };
+    var count = math.min(platformBase, math.min(available, mode.maxWorkers));
+    if (env.documentBytes >= (256 << 20)) {
+      count = math.min(
+          count, env.platform == PdfPerformancePlatform.mobile ? 1 : 2);
+    }
+    if (env.documentBytes >= (512 << 20)) count = 1;
+    return math.max(1, count);
+  }
+
+  static PdfPerformanceTuning tuning({
+    required PdfPerformanceEnvironment environment,
+    required PdfPerformanceMode mode,
+    required PdfPerformanceTier tier,
+  }) {
+    if (!mode.isAuto) {
+      return PdfPerformanceTuning(
+        tier: PdfPerformanceTier.balanced,
+        workerCount: math.max(1, mode.workerCount!),
+        previewWindow: math.max(1, mode.previewWindow!),
+        imagePixelRatioCap: math.max(0.25, mode.imagePixelRatioCap!),
+        vectorFirstPreviews: mode.vectorFirstPreviews!,
+      );
+    }
+
+    final initial = initialWorkerCount(environment, mode);
+    final maxForMachine = math.max(
+      1,
+      math.min(
+          mode.maxWorkers,
+          environment.logicalProcessors > 0
+              ? math.max(1, environment.logicalProcessors - 1)
+              : mode.maxWorkers),
+    );
+    return switch (tier) {
+      PdfPerformanceTier.conservative => PdfPerformanceTuning(
+          tier: tier,
+          workerCount: math.max(1, initial - 1),
+          previewWindow: 2,
+          imagePixelRatioCap: 1.25,
+          vectorFirstPreviews: true,
+        ),
+      PdfPerformanceTier.balanced => PdfPerformanceTuning(
+          tier: tier,
+          workerCount: initial,
+          previewWindow: 6,
+          imagePixelRatioCap: 2,
+          vectorFirstPreviews: false,
+        ),
+      PdfPerformanceTier.throughput => PdfPerformanceTuning(
+          tier: tier,
+          workerCount: math.min(maxForMachine, initial + 1),
+          previewWindow: 10,
+          imagePixelRatioCap: 3,
+          vectorFirstPreviews: false,
+        ),
+    };
+  }
+}
+
+/// Owns adaptive state for one shell/viewer and exposes diagnostics.
+///
+/// Runtime-safe knobs update live. [beginWorkerGeneration] is the only method
+/// that applies a new worker count, so observations never resize a pool during
+/// scrolling; a changed recommendation remains visible as
+/// [PdfPerformanceDiagnostics.pendingWorkerCount] until the host naturally
+/// restarts the worker for a new document/revision.
+class PdfPerformanceController extends ChangeNotifier {
+  PdfPerformanceController({
+    PdfPerformanceMode mode = const PdfPerformanceMode.auto(),
+    PdfPerformanceEnvironment? environment,
+  })  : _mode = mode,
+        _environment = environment ??
+            const PdfPerformanceEnvironment(
+              platform: PdfPerformancePlatform.other,
+              logicalProcessors: 0,
+              pageCount: 1,
+              documentBytes: 0,
+            ) {
+    _tier = PdfPerformancePolicy.initialTier(_environment);
+    _tuning = PdfPerformancePolicy.tuning(
+        environment: _environment, mode: _mode, tier: _tier);
+  }
+
+  PdfPerformanceMode _mode;
+  late PdfPerformanceEnvironment _environment;
+  late PdfPerformanceTier _tier;
+  late PdfPerformanceTuning _tuning;
+  int _currentWorkerCount = 0;
+  int _observations = 0;
+  int _cooldownUntil = 0;
+  PdfPerformanceTier? _candidate;
+  int _candidateStreak = 0;
+  double _meanLatencyMs = 0;
+  double _meanResultBytes = 0;
+  double _jankFraction = 0;
+
+  PdfPerformanceMode get mode => _mode;
+  set mode(PdfPerformanceMode value) {
+    if (value == _mode) return;
+    _mode = value;
+    _candidate = null;
+    _candidateStreak = 0;
+    _recompute(forceNotify: true);
+  }
+
+  PdfPerformanceTuning get tuning => _tuning;
+
+  PdfPerformanceDiagnostics get diagnostics => PdfPerformanceDiagnostics(
+        mode: _mode,
+        tuning: _tuning,
+        currentWorkerCount: _currentWorkerCount,
+        pendingWorkerCount: _currentWorkerCount > 0 &&
+                _currentWorkerCount != _tuning.workerCount
+            ? _tuning.workerCount
+            : null,
+        observations: _observations,
+        meanLatencyMs: _meanLatencyMs,
+        meanResultBytes: _meanResultBytes,
+        jankFraction: _jankFraction,
+      );
+
+  void configureDocument({required int pageCount, required int documentBytes}) {
+    _environment = PdfPerformanceEnvironment.detect(
+        pageCount: pageCount, documentBytes: documentBytes);
+    _tier = PdfPerformancePolicy.initialTier(_environment);
+    _observations = 0;
+    _cooldownUntil = 0;
+    _candidate = null;
+    _candidateStreak = 0;
+    _meanLatencyMs = 0;
+    _meanResultBytes = 0;
+    _jankFraction = 0;
+    _recompute(forceNotify: true);
+  }
+
+  /// Applies the recommended count at a safe worker restart boundary.
+  int beginWorkerGeneration() {
+    final next = _tuning.workerCount;
+    if (_currentWorkerCount != next) {
+      _currentWorkerCount = next;
+      notifyListeners();
+    }
+    return next;
+  }
+
+  void observe(PdfPerformanceSample sample) {
+    if (!_mode.isAuto) return;
+    _observations++;
+    const alpha = 0.25;
+    final record = sample.workerRecordDuration?.inMicroseconds;
+    final render = sample.fullRenderDuration?.inMicroseconds;
+    final latencyMicros = math.max(record ?? 0, render ?? 0);
+    if (latencyMicros > 0) {
+      final value = latencyMicros / 1000;
+      _meanLatencyMs = _meanLatencyMs == 0
+          ? value
+          : _meanLatencyMs * (1 - alpha) + value * alpha;
+    }
+    if (sample.resultBytes case final bytes?) {
+      _meanResultBytes = _meanResultBytes == 0
+          ? bytes.toDouble()
+          : _meanResultBytes * (1 - alpha) + bytes * alpha;
+    }
+    _jankFraction = _observations == 1
+        ? (sample.jankyFrame ? 1 : 0)
+        : _jankFraction * (1 - alpha) + (sample.jankyFrame ? 1 : 0) * alpha;
+
+    final next = _classify(sample);
+    if (next == _tier) {
+      _candidate = null;
+      _candidateStreak = 0;
+      return;
+    }
+    if (_candidate == next) {
+      _candidateStreak++;
+    } else {
+      _candidate = next;
+      _candidateStreak = 1;
+    }
+    if (_candidateStreak < 3 || _observations < _cooldownUntil) return;
+    _tier = next;
+    _candidate = null;
+    _candidateStreak = 0;
+    _cooldownUntil = _observations + 5;
+    _recompute();
+  }
+
+  PdfPerformanceTier _classify(PdfPerformanceSample sample) {
+    final record = sample.workerRecordDuration?.inMicroseconds ?? 0;
+    final render = sample.fullRenderDuration?.inMicroseconds ?? 0;
+    final latencyMs = math.max(record, render) / 1000;
+    final resultBytes = sample.resultBytes;
+    if (latencyMs >= 120 ||
+        (resultBytes != null && resultBytes >= (12 << 20)) ||
+        sample.jankyFrame) {
+      return PdfPerformanceTier.conservative;
+    }
+    if (latencyMs > 0 &&
+        latencyMs < 35 &&
+        (resultBytes == null || resultBytes < (2 << 20))) {
+      return PdfPerformanceTier.throughput;
+    }
+    return PdfPerformanceTier.balanced;
+  }
+
+  void _recompute({bool forceNotify = false}) {
+    final next = PdfPerformancePolicy.tuning(
+        environment: _environment, mode: _mode, tier: _tier);
+    if (next == _tuning && !forceNotify) return;
+    _tuning = next;
+    notifyListeners();
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/performance_processors.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_processors.dart
@@ -1,0 +1,3 @@
+export 'performance_processors_stub.dart'
+    if (dart.library.io) 'performance_processors_io.dart'
+    if (dart.library.js_interop) 'performance_processors_web.dart';

--- a/packages/dart_pdf_editor/lib/src/performance_processors_io.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_processors_io.dart
@@ -1,0 +1,3 @@
+import 'dart:io';
+
+int get detectedPdfLogicalProcessors => Platform.numberOfProcessors;

--- a/packages/dart_pdf_editor/lib/src/performance_processors_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_processors_stub.dart
@@ -1,0 +1,1 @@
+int get detectedPdfLogicalProcessors => 0;

--- a/packages/dart_pdf_editor/lib/src/performance_processors_web.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_processors_web.dart
@@ -1,0 +1,4 @@
+import 'package:web/web.dart' as web;
+
+int get detectedPdfLogicalProcessors =>
+    web.window.navigator.hardwareConcurrency;

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:pdf_document/pdf_document.dart';
@@ -90,14 +91,15 @@ class PdfStripDetail {
 const int pdfRenderWorkerPoolMinPages = 12;
 
 /// Starts the right cached worker for a [pageCount]-page document: a pooled
-/// backend when the document is long enough and [pdfRenderWorkerPoolSize] asks
-/// for parallelism, otherwise a single platform worker.
+/// backend when the document is long enough and [workerCount] (or the global
+/// [pdfRenderWorkerPoolSize] fallback) asks for parallelism, otherwise a single
+/// platform worker.
 PdfRenderWorker startPdfRenderWorker(Uint8List bytes,
-    {required int pageCount}) {
-  final backend =
-      pdfRenderWorkerPoolSize > 1 && pageCount >= pdfRenderWorkerPoolMinPages
-          ? PdfPooledRenderWorker(bytes, pdfRenderWorkerPoolSize)
-          : startRenderWorker(bytes);
+    {required int pageCount, int? workerCount}) {
+  final count = math.max(1, workerCount ?? pdfRenderWorkerPoolSize);
+  final backend = count > 1 && pageCount >= pdfRenderWorkerPoolMinPages
+      ? PdfPooledRenderWorker(bytes, count)
+      : startRenderWorker(bytes);
   return PdfCachingRenderWorker(backend);
 }
 

--- a/packages/dart_pdf_editor/test/performance_policy_test.dart
+++ b/packages/dart_pdf_editor/test/performance_policy_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+PdfPerformanceEnvironment env({
+  PdfPerformancePlatform platform = PdfPerformancePlatform.desktop,
+  int cores = 8,
+  int pages = 100,
+  int bytes = 20 << 20,
+}) =>
+    PdfPerformanceEnvironment(
+      platform: platform,
+      logicalProcessors: cores,
+      pageCount: pages,
+      documentBytes: bytes,
+    );
+
+void main() {
+  test('Auto chooses conservative platform and memory-aware worker counts', () {
+    const auto = PdfPerformanceMode.auto();
+    expect(
+        PdfPerformancePolicy.initialWorkerCount(
+            env(platform: PdfPerformancePlatform.mobile), auto),
+        2);
+    expect(
+        PdfPerformancePolicy.initialWorkerCount(
+            env(platform: PdfPerformancePlatform.desktop), auto),
+        3);
+    expect(
+        PdfPerformancePolicy.initialWorkerCount(
+            env(platform: PdfPerformancePlatform.web, cores: 2), auto),
+        1);
+    expect(PdfPerformancePolicy.initialWorkerCount(env(pages: 6), auto), 1,
+        reason: 'short documents do not pay for a pool');
+    expect(
+        PdfPerformancePolicy.initialWorkerCount(env(bytes: 600 << 20), auto), 1,
+        reason: 'each worker holds its own document/decode working set');
+    expect(
+        PdfPerformancePolicy.initialWorkerCount(
+            env(cores: 32), const PdfPerformanceMode.auto(maxWorkers: 2)),
+        2);
+  });
+
+  test('fixed mode remains fixed under telemetry', () {
+    final controller = PdfPerformanceController(
+      mode: const PdfPerformanceMode.fixed(
+        workerCount: 5,
+        previewWindow: 7,
+        imagePixelRatioCap: 2.5,
+        vectorFirstPreviews: true,
+      ),
+      environment: env(),
+    );
+    addTearDown(controller.dispose);
+
+    expect(controller.beginWorkerGeneration(), 5);
+    for (var i = 0; i < 20; i++) {
+      controller.observe(const PdfPerformanceSample(
+        workerRecordDuration: Duration(seconds: 2),
+        resultBytes: 64 << 20,
+        jankyFrame: true,
+      ));
+    }
+    expect(controller.tuning.workerCount, 5);
+    expect(controller.tuning.previewWindow, 7);
+    expect(controller.tuning.imagePixelRatioCap, 2.5);
+    expect(controller.tuning.vectorFirstPreviews, isTrue);
+    expect(controller.diagnostics.observations, 0);
+  });
+
+  test('slow samples tune safe knobs live and defer worker resize', () {
+    final controller = PdfPerformanceController(
+        environment: env(platform: PdfPerformancePlatform.web));
+    addTearDown(controller.dispose);
+    expect(controller.beginWorkerGeneration(), 3);
+
+    for (var i = 0; i < 3; i++) {
+      controller.observe(const PdfPerformanceSample(
+        workerRecordDuration: Duration(milliseconds: 220),
+        resultBytes: 20 << 20,
+        jankyFrame: true,
+      ));
+    }
+
+    expect(controller.tuning.tier, PdfPerformanceTier.conservative);
+    expect(controller.tuning.previewWindow, 2);
+    expect(controller.tuning.imagePixelRatioCap, 1.25);
+    expect(controller.tuning.vectorFirstPreviews, isTrue);
+    expect(controller.diagnostics.currentWorkerCount, 3);
+    expect(controller.diagnostics.pendingWorkerCount, 2,
+        reason: 'the live pool is never resized during scrolling');
+    expect(controller.diagnostics.toString(), contains('next restart'));
+
+    expect(controller.beginWorkerGeneration(), 2);
+    expect(controller.diagnostics.pendingWorkerCount, isNull);
+  });
+
+  test('cheap samples widen warming only after hysteresis', () {
+    final controller = PdfPerformanceController(environment: env());
+    addTearDown(controller.dispose);
+    controller.beginWorkerGeneration();
+
+    const cheap = PdfPerformanceSample(
+      workerRecordDuration: Duration(milliseconds: 12),
+      resultBytes: 128 << 10,
+    );
+    controller.observe(cheap);
+    controller.observe(cheap);
+    expect(controller.tuning.tier, PdfPerformanceTier.balanced);
+    controller.observe(cheap);
+    expect(controller.tuning.tier, PdfPerformanceTier.throughput);
+    expect(controller.tuning.previewWindow, 10);
+    expect(controller.tuning.workerCount, 4);
+
+    // The five-observation cooldown prevents an immediate opposite swing.
+    const slow = PdfPerformanceSample(
+      workerRecordDuration: Duration(milliseconds: 500),
+      resultBytes: 32 << 20,
+      jankyFrame: true,
+    );
+    controller.observe(slow);
+    controller.observe(slow);
+    controller.observe(slow);
+    expect(controller.tuning.tier, PdfPerformanceTier.throughput);
+  });
+
+  test('alternating evidence does not oscillate the policy', () {
+    final controller = PdfPerformanceController(environment: env());
+    addTearDown(controller.dispose);
+    const slow = PdfPerformanceSample(
+        workerRecordDuration: Duration(milliseconds: 250), jankyFrame: true);
+    const cheap =
+        PdfPerformanceSample(workerRecordDuration: Duration(milliseconds: 10));
+    controller
+      ..observe(slow)
+      ..observe(cheap)
+      ..observe(slow)
+      ..observe(cheap);
+    expect(controller.tuning.tier, PdfPerformanceTier.balanced);
+  });
+
+  test('large documents start conservative before telemetry arrives', () {
+    final environment = env(pages: 500, bytes: 300 << 20);
+    final controller = PdfPerformanceController(environment: environment);
+    addTearDown(controller.dispose);
+    expect(controller.tuning.tier, PdfPerformanceTier.conservative);
+    expect(controller.tuning.previewWindow, 2);
+    expect(controller.tuning.vectorFirstPreviews, isTrue);
+    expect(controller.beginWorkerGeneration(), 1);
+  });
+}


### PR DESCRIPTION
## Summary

- add public Auto and fixed performance modes with platform/core/document-aware worker defaults
- adapt preview windows, vector-first warming, and ordinary image-resolution caps from render latency, decoded result size, and frame jank
- defer worker-count changes until a natural worker restart and expose current/pending settings through diagnostics
- wire the policy through PdfReader, PdfEditorView, PdfViewer, and PdfPageView; make Auto the example app default with fixed 1/2/3/4/6-worker choices
- use three-sample hysteresis plus a five-observation cooldown, with deterministic synthetic telemetry tests

Closes #189

## Validation

- fvm dart analyze — clean
- dart_pdf_editor full suite — 1,349 passed, 23 environment-gated skips
- focused policy/shell/worker/preview set — 133 passed
- example tabs test — 7 passed
- Flutter web release build — passed, including wasm dry run

## Baseline note

The example package's full test command still has existing failures in demo_document_test.dart and editing_test.dart. Both failures reproduce unchanged in an archived origin/main snapshot; the performance-menu test and the complete library suite pass on this branch.
