### PR TITLE
perf: streamline dense canvas replay runs

### DIFF
--- a/doc/dev-log/2026-07-11-canvas-replay-runs.md
+++ b/doc/dev-log/2026-07-11-canvas-replay-runs.md
@@ -1,0 +1,43 @@
+# Canvas replay paint runs
+
+Issue #226 followed the command-scope compaction work: its pinned CAD page
+(`corpus/ly9-far-cad.pdf`, page 4) reached the UI isolate as 34,130 commands,
+but constructing the canvas picture still took about 53 ms.
+
+The first implementation tried the issue's most conservative geometry merge:
+combine only consecutive, identical, opaque fills or simple strokes whose
+1-point-inflated bounds were pairwise disjoint. It was rejected. The page's
+bounds overlap heavily, so 29,075 eligible fill commands still produced 29,048
+draws and 3,182 simple strokes still produced 3,099 draws. Bounds checks and
+buffering regressed construction from 52.8 ms to 60.6 ms.
+
+The shape probe found a safer opportunity in the same compacted runs:
+
+- 29,075 solid fills;
+- 3,326 strokes, of which 3,218 are exactly one `moveTo`/`lineTo` pair;
+- 1,814 consecutive styles across 32,401 paint commands.
+
+`CanvasPdfDevice` now keeps the last immutable solid fill/stroke `Paint`, keyed
+by every field that reaches the engine (color, alpha, effective blend, and
+stroke geometry). Flutter snapshots `Paint` at each draw, so reusing the object
+does not alter earlier commands. Undashed two-segment strokes use
+`Canvas.drawLine` directly instead of constructing a `ui.Path`; every command
+remains an independent draw in its original order.
+
+The diagnostic test can switch both optimizations off and measures all variants
+in one process. Twelve warmed passes on the pinned page:
+
+- baseline: 53.0 ms;
+- prepared Paints: 52.2 ms;
+- prepared Paints + direct lines: 49.9 ms (5.8% lower).
+
+On the 326-command first page of
+`Flutter_CTO_Report_2024_by_LeanCode.pdf`, 50 warmed passes measured 1.1 ms →
+0.5 ms, so the constant last-style checks do not add a light-page tax.
+
+Focused tests compare raw RGBA bytes against the old fresh-Paint/drawPath route
+across fill rules, alpha, transforms, line widths/caps, crossings, and a
+zero-length round-cap dot. The Ghent baseline and PDF.js render corpus pass
+without changes. Strip command replay, binning, flush ordinals, and cancellation
+are untouched; delegated canvas operations merely use the equivalent primitive
+when their tape is painted.

--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -43,7 +43,29 @@ class CanvasPdfDevice implements PdfDevice {
   @visibleForTesting
   static int get debugTextLayoutCacheLength => _textCache.length;
 
+  /// Diagnostic kill switches for the command replay benchmark.
+  @visibleForTesting
+  static bool debugReuseSolidPaints = true;
+  @visibleForTesting
+  static bool debugDrawSimpleLines = true;
+
   BlendMode _blend = BlendMode.srcOver;
+
+  // Most CAD command buffers contain tens of thousands of paths but only a
+  // handful of consecutive paint styles. ui.Canvas snapshots a Paint at each
+  // draw, so the immutable prepared object can be reused until a style field
+  // or effective blend mode changes. Keep just the last value (rather than a
+  // map): the command stream is run-grouped, and lookup/allocation overhead on
+  // light pages stays constant.
+  Paint? _fillPaint;
+  PdfColor? _fillColor;
+  double _fillAlpha = -1;
+  BlendMode? _fillBlend;
+  Paint? _strokePaint;
+  PdfColor? _strokeColor;
+  PdfStroke? _strokeStyle;
+  double _strokeAlpha = -1;
+  BlendMode? _strokeBlend;
 
   /// One entry per open transparency group: true while that group is a
   /// knockout group (§11.4.5). q/Q (save/restore) don't push here, so the
@@ -203,10 +225,7 @@ class CanvasPdfDevice implements PdfDevice {
   void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {
     canvas.drawPath(
       _toUiPath(path, rule),
-      Paint()
-        ..style = PaintingStyle.fill
-        ..color = _toColor(color, alpha)
-        ..blendMode = _elementBlend,
+      _solidFillPaint(color, alpha),
     );
   }
 
@@ -268,13 +287,60 @@ class CanvasPdfDevice implements PdfDevice {
   @override
   void strokePath(
       PdfPath path, PdfColor color, PdfStroke stroke, double alpha) {
+    final segments = path.segments;
+    if (debugDrawSimpleLines &&
+        stroke.dashArray.isEmpty &&
+        segments.length == 2) {
+      switch ((segments[0], segments[1])) {
+        case (
+            PdfMoveTo(:final x, :final y),
+            PdfLineTo(x: final x2, y: final y2)
+          ):
+          canvas.drawLine(Offset(x, y), Offset(x2, y2),
+              _solidStrokePaint(color, stroke, alpha));
+          return;
+        default:
+          break;
+      }
+    }
     var uiPath = _toUiPath(path, PdfFillRule.nonzero);
     if (stroke.dashArray.any((d) => d > 0)) {
       uiPath = _dashPath(uiPath, stroke.dashArray, stroke.dashPhase);
     }
     canvas.drawPath(
       uiPath,
-      Paint()
+      _solidStrokePaint(color, stroke, alpha),
+    );
+  }
+
+  Paint _solidFillPaint(PdfColor color, double alpha) {
+    final blend = _elementBlend;
+    if (!debugReuseSolidPaints) {
+      return Paint()
+        ..style = PaintingStyle.fill
+        ..color = _toColor(color, alpha)
+        ..blendMode = blend;
+    }
+    final cached = _fillPaint;
+    if (cached != null &&
+        _fillColor == color &&
+        _fillAlpha == alpha &&
+        _fillBlend == blend) {
+      return cached;
+    }
+    _fillColor = color;
+    _fillAlpha = alpha;
+    _fillBlend = blend;
+    return _fillPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = _toColor(color, alpha)
+      ..blendMode = blend;
+  }
+
+  Paint _solidStrokePaint(PdfColor color, PdfStroke stroke, double alpha) {
+    final blend = _elementBlend;
+    if (!debugReuseSolidPaints) {
+      return Paint()
         ..style = PaintingStyle.stroke
         ..color = _toColor(color, alpha)
         ..strokeWidth = stroke.width
@@ -289,8 +355,41 @@ class CanvasPdfDevice implements PdfDevice {
           _ => StrokeJoin.miter,
         }
         ..strokeMiterLimit = stroke.miterLimit
-        ..blendMode = _elementBlend,
-    );
+        ..blendMode = blend;
+    }
+    final cached = _strokePaint;
+    final style = _strokeStyle;
+    if (cached != null &&
+        _strokeColor == color &&
+        style != null &&
+        style.width == stroke.width &&
+        style.cap == stroke.cap &&
+        style.join == stroke.join &&
+        style.miterLimit == stroke.miterLimit &&
+        _strokeAlpha == alpha &&
+        _strokeBlend == blend) {
+      return cached;
+    }
+    _strokeColor = color;
+    _strokeStyle = stroke;
+    _strokeAlpha = alpha;
+    _strokeBlend = blend;
+    return _strokePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..color = _toColor(color, alpha)
+      ..strokeWidth = stroke.width
+      ..strokeCap = switch (stroke.cap) {
+        1 => StrokeCap.round,
+        2 => StrokeCap.square,
+        _ => StrokeCap.butt,
+      }
+      ..strokeJoin = switch (stroke.join) {
+        1 => StrokeJoin.round,
+        2 => StrokeJoin.bevel,
+        _ => StrokeJoin.miter,
+      }
+      ..strokeMiterLimit = stroke.miterLimit
+      ..blendMode = blend;
   }
 
   /// Rebuilds [source] as its dashed segments (§8.4.3.6). Zero-length

--- a/packages/dart_pdf_editor/test/canvas_line_replay_test.dart
+++ b/packages/dart_pdf_editor/test/canvas_line_replay_test.dart
@@ -1,0 +1,213 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/src/canvas_device.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+void main() {
+  testWidgets('direct simple-line replay is pixel-identical to drawPath',
+      (tester) async {
+    await tester.runAsync(() async {
+      final optimized = await _render(optimized: true);
+      final reference = await _render(optimized: false);
+      expect(optimized, orderedEquals(reference));
+    });
+  });
+
+  testWidgets('reused fill Paints are pixel-identical to fresh Paints',
+      (tester) async {
+    await tester.runAsync(() async {
+      final optimized = await _renderFills(optimized: true);
+      final reference = await _renderFills(optimized: false);
+      expect(optimized, orderedEquals(reference));
+    });
+  });
+}
+
+Future<Uint8List> _renderFills({required bool optimized}) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder)
+    ..translate(7.5, 5.25)
+    ..rotate(-0.08)
+    ..scale(1.2, 1.4);
+  final device = CanvasPdfDevice(canvas);
+  final draws = <(PdfPath, PdfColor, PdfFillRule, double)>[
+    (
+      const PdfPath([
+        PdfMoveTo(3, 4),
+        PdfLineTo(31, 5),
+        PdfLineTo(28, 29),
+        PdfClosePath(),
+      ]),
+      const PdfColor(0.8, 0.15, 0.25),
+      PdfFillRule.nonzero,
+      1,
+    ),
+    (
+      const PdfPath([
+        PdfMoveTo(22, 13),
+        PdfLineTo(58, 8),
+        PdfLineTo(63, 37),
+        PdfLineTo(29, 41),
+        PdfClosePath(),
+      ]),
+      const PdfColor(0.8, 0.15, 0.25),
+      PdfFillRule.evenOdd,
+      1,
+    ),
+    (
+      const PdfPath([
+        PdfMoveTo(7, 34),
+        PdfLineTo(42, 48),
+        PdfLineTo(15, 61),
+        PdfClosePath(),
+      ]),
+      const PdfColor(0.1, 0.45, 0.85),
+      PdfFillRule.nonzero,
+      0.55,
+    ),
+    // Returning to the first style proves later cache entries do not mutate
+    // paint snapshots already recorded in the picture.
+    (
+      const PdfPath([
+        PdfMoveTo(48, 43),
+        PdfLineTo(72, 52),
+        PdfLineTo(51, 65),
+        PdfClosePath(),
+      ]),
+      const PdfColor(0.8, 0.15, 0.25),
+      PdfFillRule.nonzero,
+      1,
+    ),
+  ];
+
+  for (final (path, color, rule, alpha) in draws) {
+    if (optimized) {
+      device.fillPath(path, color, rule, alpha);
+      continue;
+    }
+    final uiPath = ui.Path()
+      ..fillType = rule == PdfFillRule.evenOdd
+          ? ui.PathFillType.evenOdd
+          : ui.PathFillType.nonZero;
+    for (final segment in path.segments) {
+      switch (segment) {
+        case PdfMoveTo(:final x, :final y):
+          uiPath.moveTo(x, y);
+        case PdfLineTo(:final x, :final y):
+          uiPath.lineTo(x, y);
+        case PdfCubicTo():
+          uiPath.cubicTo(segment.x1, segment.y1, segment.x2, segment.y2,
+              segment.x3, segment.y3);
+        case PdfClosePath():
+          uiPath.close();
+      }
+    }
+    canvas.drawPath(
+      uiPath,
+      Paint()
+        ..style = PaintingStyle.fill
+        ..color = Color.from(
+          alpha: alpha,
+          red: color.red,
+          green: color.green,
+          blue: color.blue,
+        ),
+    );
+  }
+
+  final picture = recorder.endRecording();
+  final image = await picture.toImage(128, 96);
+  picture.dispose();
+  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  image.dispose();
+  return data!.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+}
+
+Future<Uint8List> _render({required bool optimized}) async {
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder)
+    ..translate(11.25, 9.5)
+    ..rotate(0.17)
+    ..scale(1.35, 1.15);
+  final device = CanvasPdfDevice(canvas);
+  final draws = <(PdfPath, PdfColor, PdfStroke, double)>[
+    (
+      const PdfPath([PdfMoveTo(2, 3), PdfLineTo(55, 7)]),
+      const PdfColor(0.85, 0.1, 0.2),
+      const PdfStroke(width: 0, cap: 0),
+      1,
+    ),
+    (
+      const PdfPath([PdfMoveTo(8, 18), PdfLineTo(62, 31)]),
+      const PdfColor(0.1, 0.35, 0.9),
+      const PdfStroke(width: 0.5, cap: 1),
+      0.65,
+    ),
+    (
+      const PdfPath([PdfMoveTo(4, 43), PdfLineTo(71, 17)]),
+      const PdfColor(0.15, 0.7, 0.3),
+      const PdfStroke(width: 3, cap: 2, join: 2, miterLimit: 4),
+      1,
+    ),
+    // A zero-length round-cap stroke exercises the PDF dot case.
+    (
+      const PdfPath([PdfMoveTo(46, 42), PdfLineTo(46, 42)]),
+      const PdfColor(0.85, 0.1, 0.2),
+      const PdfStroke(width: 5, cap: 1),
+      1,
+    ),
+    // Return to an earlier style: cached Paint objects must not mutate draws
+    // that have already been recorded by the canvas.
+    (
+      const PdfPath([PdfMoveTo(14, 51), PdfLineTo(68, 54)]),
+      const PdfColor(0.85, 0.1, 0.2),
+      const PdfStroke(width: 0, cap: 0),
+      1,
+    ),
+  ];
+
+  for (final (path, color, stroke, alpha) in draws) {
+    if (optimized) {
+      device.strokePath(path, color, stroke, alpha);
+    } else {
+      final move = path.segments[0] as PdfMoveTo;
+      final line = path.segments[1] as PdfLineTo;
+      final uiPath = ui.Path()
+        ..moveTo(move.x, move.y)
+        ..lineTo(line.x, line.y);
+      canvas.drawPath(
+        uiPath,
+        Paint()
+          ..style = PaintingStyle.stroke
+          ..color = Color.from(
+            alpha: alpha,
+            red: color.red,
+            green: color.green,
+            blue: color.blue,
+          )
+          ..strokeWidth = stroke.width
+          ..strokeCap = switch (stroke.cap) {
+            1 => StrokeCap.round,
+            2 => StrokeCap.square,
+            _ => StrokeCap.butt,
+          }
+          ..strokeJoin = switch (stroke.join) {
+            1 => StrokeJoin.round,
+            2 => StrokeJoin.bevel,
+            _ => StrokeJoin.miter,
+          }
+          ..strokeMiterLimit = stroke.miterLimit,
+      );
+    }
+  }
+
+  final picture = recorder.endRecording();
+  final image = await picture.toImage(128, 96);
+  picture.dispose();
+  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  image.dispose();
+  return data!.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+}

--- a/packages/dart_pdf_editor/test/command_replay_latency_test.dart
+++ b/packages/dart_pdf_editor/test/command_replay_latency_test.dart
@@ -34,6 +34,10 @@ void main() {
       final page = document.page(pageIndex);
       final worker = PdfRenderWorker.startUncached(bytes);
       addTearDown(worker.dispose);
+      addTearDown(() {
+        CanvasPdfDevice.debugReuseSolidPaints = true;
+        CanvasPdfDevice.debugDrawSimpleLines = true;
+      });
 
       Future<List<PdfRenderCommand>> record(bool decodeImages) async {
         final commands = await worker.record(
@@ -61,18 +65,30 @@ void main() {
 
       final vector = await measure(false);
       final full = await measure(true);
-      var replayMicros = 0;
-      for (var pass = -2; pass < passes; pass++) {
-        final sw = Stopwatch()..start();
-        final picture = await PdfPageRenderer.pictureFromCommands(
-          page,
-          vector.$1,
-          includeImages: false,
-        );
-        final elapsed = sw.elapsedMicroseconds;
-        picture.dispose();
-        if (pass >= 0) replayMicros += elapsed;
+      Future<double> replay(
+          {required bool reusePaints, required bool simpleLines}) async {
+        CanvasPdfDevice.debugReuseSolidPaints = reusePaints;
+        CanvasPdfDevice.debugDrawSimpleLines = simpleLines;
+        var micros = 0;
+        for (var pass = -2; pass < passes; pass++) {
+          final sw = Stopwatch()..start();
+          final picture = await PdfPageRenderer.pictureFromCommands(
+            page,
+            vector.$1,
+            includeImages: false,
+          );
+          final elapsed = sw.elapsedMicroseconds;
+          picture.dispose();
+          if (pass >= 0) micros += elapsed;
+        }
+        return micros / passes / 1000;
       }
+
+      final baseline = await replay(reusePaints: false, simpleLines: false);
+      final preparedPaint = await replay(reusePaints: true, simpleLines: false);
+      final optimized = await replay(reusePaints: true, simpleLines: true);
+      CanvasPdfDevice.debugReuseSolidPaints = true;
+      CanvasPdfDevice.debugDrawSimpleLines = true;
 
       // ignore: avoid_print
       print(
@@ -82,8 +98,9 @@ void main() {
           'decode=${vector.$2.toStringAsFixed(1)}ms; '
           'full commands=${full.$1.length} '
           'decode=${full.$2.toStringAsFixed(1)}ms; '
-          'vector picture='
-          '${(replayMicros / passes / 1000).toStringAsFixed(1)}ms');
+          'canvas baseline=${baseline.toStringAsFixed(1)}ms '
+          'preparedPaint=${preparedPaint.toStringAsFixed(1)}ms '
+          'directLines=${optimized.toStringAsFixed(1)}ms');
     });
   }, timeout: const Timeout(Duration(minutes: 10)));
 }


### PR DESCRIPTION
## Summary

- reuse the last immutable solid fill/stroke Paint across compacted consecutive style runs
- replay undashed two-segment strokes with Canvas.drawLine, avoiding ui.Path construction for 3,218 of 3,326 strokes on the pinned CAD page
- keep every PDF paint command as an independent draw in original order; clips, winding, overlap coverage, groups, masks, and strip-plan ordinals are unchanged
- extend the command replay probe with same-process baseline/prepared-Paint/direct-line variants and add byte-exact focused parity tests

Closes #226

## Measured result

Twelve warmed passes on corpus/ly9-far-cad.pdf page 4:

- baseline: 53.0 ms
- prepared Paints: 52.2 ms
- prepared Paints + direct lines: 49.9 ms (5.8% lower)

Fifty warmed passes on a 326-command office page improved from 1.1 ms to 0.5 ms.

The initially proposed pairwise-disjoint geometry merge was measured and rejected: overlapping bounds meant it removed only 110 of 32,257 draws and regressed 52.8 ms to 60.6 ms. The dev log records that result and the selected path.

## Validation

- fvm dart analyze — clean
- dart_pdf_editor full suite — 1,355 passed, 24 environment-gated skips
- focused raw-RGBA parity — exact across fill rules, alpha, transforms, line caps/widths, crossings, and zero-length round-cap dots
- Ghent render baselines — passed without updates
- PDF.js render corpus — passed
- strip-device tests + 57-page strip parity gate — passed
