### PR TITLE
perf(web): offload dense Slug plans

### DIFF
--- a/doc/dev-log/2026-07-11-slug-worker-plans.md
+++ b/doc/dev-log/2026-07-11-slug-worker-plans.md
@@ -1,0 +1,56 @@
+# Dense web Slug plans
+
+Issue #227 follows the first transform-time Slug slice from #218. Ordinary
+image-free pages already kept one painter-order Slug picture under the web
+viewer transform, but pages above the retained-scene command ceiling could
+not: building the curve atlas locally would undo the worker offload from
+#224.
+
+This slice makes the Slug plan transferable:
+
+- `pdf_graphics` builds curve streams, atlases, and vertex arrays as pure
+  typed data. The native isolate and Web Worker can now produce them.
+- `StripPlan` carries Slug batches at exact strip flush ordinals, including
+  explicit fallback ordinals so a successful blank glyph run is not confused
+  with a minified/overflow fallback.
+- `StripPdfDevice` consumes the strip and Slug portions as one painter-order
+  tape. A plan is rejected if its Slug routing mode differs from the device.
+- `PdfPageView` requests a ratio-1 Slug plan for an over-ceiling image-free
+  page and never builds it locally. A declined plan keeps the existing
+  worker-planned raster route.
+
+The work also fixed a pre-existing async-cache trap exposed by the new
+sequence test: `StripPdfDevice` cached `Future<FragmentProgram>` instances.
+A future created in a widget test's dead FakeAsync zone stranded later tests.
+The device now caches resolved `FragmentProgram` values and returns them from
+fresh futures in the caller's current zone.
+
+## Measurement
+
+`slug_worker_latency_test.dart` on `corpus/WAT_L0001_S.pdf` page 0, software
+Skia test backend, cold run:
+
+- 12,021 retained commands
+- 2,840 Slug glyph quads, zero outline fallbacks
+- 6.12 MB encoded transferable plan
+- 481.6 ms worker wall time
+- 58.7 ms UI upload/replay time
+- 243.5 ms equivalent local Slug build
+
+The production gain is keeping the curve/band/atlas construction off the web
+UI thread. The worker time overlaps loading and does not repeat at each zoom:
+the transform-time picture is retained.
+
+## Validation
+
+- worker and local Slug plans encode bit-identically
+- planned and local Slug rasters are raw-RGBA identical
+- dense-page widget path consumes one plan and reuses one picture across zoom
+- strip-plan codec, cancellation, region-detail, and stale-plan tests pass
+- full `pdf_graphics` suite passes
+- full `dart_pdf_editor` suite passes (1,362 tests, 25 skips with local corpus)
+- web release build passes, including the skwasm dry run
+
+Image-bearing pages remain deliberately out of this slice. They require
+painter-order-preserving interleaved detail layers; a topmost text overlay is
+not correct when later page content occludes text.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -260,9 +260,10 @@ class PdfPageView extends StatefulWidget {
   /// than lifting glyphs into one topmost overlay), preserving text/vector
   /// occlusion, clips, groups, and soft masks exactly.
   ///
-  /// Dense pages above [retainedZoomReplayMaxCommands] keep the worker-planned
-  /// strip raster path. Building their Slug picture locally would put the
-  /// expensive bin walk back on the browser UI thread and undo #224.
+  /// Dense image-free pages above [retainedZoomReplayMaxCommands] receive a
+  /// worker-built Slug/strip plan and only upload/replay it on the UI thread;
+  /// if the worker declines they keep the ordinary worker-planned strip
+  /// raster path rather than binning Slug locally.
   /// Image-bearing pages also stay raster-backed so the deep-zoom region patch
   /// can continue replacing embedded images at their requested resolution.
   static bool webSlugGlyphLayer = true;
@@ -777,13 +778,14 @@ class _PdfPageViewState extends State<PdfPageView> {
       _stripBackendSupported &&
       scene.commands.length > PdfPageView.retainedZoomReplayMaxCommands;
 
-  static bool _slugPictureScene(PdfRetainedScene? scene) =>
+  bool _slugPictureScene(PdfRetainedScene? scene) =>
       scene != null &&
       PdfPageView.webSlugGlyphLayer &&
       (PdfPageView.debugWebSlugGlyphLayerBackendOverride ?? kIsWeb) &&
       scene.hasSlugTextCandidates &&
       !PdfPageRenderer.hasImageDraws(scene.commands) &&
-      scene.commands.length <= PdfPageView.retainedZoomReplayMaxCommands;
+      (scene.commands.length <= PdfPageView.retainedZoomReplayMaxCommands ||
+          _workerBinningEligible);
 
   /// Builds the picture (and, unless [PdfPageView.retainedZoomReplay] is
   /// off, the retained scene) from a recorded command buffer. One decode
@@ -986,43 +988,65 @@ class _PdfPageViewState extends State<PdfPageView> {
     // and painter order remains the command stream's exact order.
     if (_slugPictureScene(retainedScene) && !_slugPictureRejected) {
       if (_slugPicture == null) {
-        var slugStats = (quads: 0, fallbackOutlineRuns: 0);
-        final slugPicture = await retainedScene!.replayStrips(
-          pixelRatio: 1,
-          slugGlyphs: true,
-          onSlugStats: (stats) => slugStats = stats,
-        );
-        if (_superseded(generation, pageIndex)) {
-          slugPicture.dispose();
-          return;
-        }
-        // Minified or atlas-overflow outline runs fall back to pixel-aligned
-        // strips. Keeping that picture under a transform would blur those
-        // runs, so use the normal raster path unless every outline run took
-        // Slug and at least one glyph was emitted.
-        if (slugStats.quads == 0 || slugStats.fallbackOutlineRuns != 0) {
-          slugPicture.dispose();
-          _slugPictureRejected = true;
-        } else {
-          setState(() {
-            _slugPicture = slugPicture;
-            _image?.dispose();
-            _image = null;
-            _preview?.dispose();
-            _preview = null;
-            _rasteredRatio = effective;
-          });
-          _dropDetail();
-          final cache = widget.previewCache;
-          if (cache != null &&
-              !cache.isFresh(widget.previewIndex, widget.page,
-                  requireImages: true)) {
-            unawaited(cache.putFromPicture(
-                widget.previewIndex, widget.page, picture,
-                rotation: widget.rotation));
+        StripPlan? slugPlan;
+        final dense = retainedScene!.commands.length >
+            PdfPageView.retainedZoomReplayMaxCommands;
+        if (dense) {
+          slugPlan = await _workerSlugPlan(retainedScene);
+          // Layout/zoom can advance the raster generation while this one-off
+          // transform picture is building. It is scale-independent, so only
+          // a recycled page or replaced scene makes it stale.
+          if (_abandoned(pageIndex) || !identical(_scene, retainedScene)) {
+            if (mounted && !_abandoned(pageIndex)) _render();
+            return;
           }
-          widget.onRasterReady?.call();
-          return;
+          // Never rebuild a dense Slug plan locally: that is the UI-thread
+          // curve/bin walk this worker path exists to avoid.
+          if (slugPlan == null) {
+            _slugPictureRejected = true;
+          }
+        }
+        if (!_slugPictureRejected) {
+          var slugStats = (quads: 0, fallbackOutlineRuns: 0);
+          final slugPicture = await retainedScene.replayStrips(
+            pixelRatio: 1,
+            stripPlan: slugPlan,
+            slugGlyphs: true,
+            onSlugStats: (stats) => slugStats = stats,
+          );
+          if (_abandoned(pageIndex) || !identical(_scene, retainedScene)) {
+            slugPicture.dispose();
+            if (mounted && !_abandoned(pageIndex)) _render();
+            return;
+          }
+          // Minified or atlas-overflow outline runs fall back to pixel-aligned
+          // strips. Keeping that picture under a transform would blur those
+          // runs, so use the normal raster path unless every outline run took
+          // Slug and at least one glyph was emitted.
+          if (slugStats.quads == 0 || slugStats.fallbackOutlineRuns != 0) {
+            slugPicture.dispose();
+            _slugPictureRejected = true;
+          } else {
+            setState(() {
+              _slugPicture = slugPicture;
+              _image?.dispose();
+              _image = null;
+              _preview?.dispose();
+              _preview = null;
+              _rasteredRatio = effective;
+            });
+            _dropDetail();
+            final cache = widget.previewCache;
+            if (cache != null &&
+                !cache.isFresh(widget.previewIndex, widget.page,
+                    requireImages: true)) {
+              unawaited(cache.putFromPicture(
+                  widget.previewIndex, widget.page, picture,
+                  rotation: widget.rotation));
+            }
+            widget.onRasterReady?.call();
+            return;
+          }
         }
       } else {
         // No replay and no GPU readback on a zoom settle; the existing
@@ -1426,6 +1450,28 @@ class _PdfPageViewState extends State<PdfPageView> {
       deviceWidth: geometry.width,
       deviceHeight: geometry.height,
       pixelRatio: pixelRatio,
+      priority: widget.renderPriority,
+    );
+  }
+
+  /// Builds the one transform-time Slug picture for an over-ceiling page.
+  /// Unlike settle plans this is always ratio 1 and explicitly asks the
+  /// worker for Slug routing; a null result is not rebuilt locally.
+  Future<StripPlan?> _workerSlugPlan(PdfRetainedScene scene) async {
+    if (!_workerBinningEligible) return null;
+    final worker = widget.renderWorker!;
+    final geometry = scene.stripGeometry(pixelRatio: 1);
+    final m = geometry.pageToDevice;
+    worker.cancelBinStrips(widget.previewIndex,
+        priority: widget.renderPriority);
+    return worker.binStrips(
+      widget.previewIndex,
+      annotations: scene.plan.annotations,
+      pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+      deviceWidth: geometry.width,
+      deviceHeight: geometry.height,
+      pixelRatio: 1,
+      slugGlyphs: true,
       priority: widget.renderPriority,
     );
   }

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -242,6 +242,8 @@ abstract class PdfRenderWorker {
   /// built from - the worker re-records the page in its own isolate
   /// (interpretation is deterministic, so the command list matches the
   /// scene's) and replays it through a headless strip binner.
+  /// [slugGlyphs] additionally routes eligible embedded-outline text into
+  /// worker-transferable curve-atlas batches for a transform-time picture.
   ///
   /// [priority] shares [record]'s queue ordering; the default 0 is the
   /// on-screen page - a zoom settle IS the visible page, so it preempts
@@ -257,6 +259,7 @@ abstract class PdfRenderWorker {
     required int deviceWidth,
     required int deviceHeight,
     required double pixelRatio,
+    bool slugGlyphs = false,
     int priority = 0,
   }) async =>
       null;
@@ -491,6 +494,7 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
     required int deviceWidth,
     required int deviceHeight,
     required double pixelRatio,
+    bool slugGlyphs = false,
     int priority = 0,
   }) =>
       _workers[_staticWorkerIndex(pageIndex)].binStrips(
@@ -500,6 +504,7 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
         deviceWidth: deviceWidth,
         deviceHeight: deviceHeight,
         pixelRatio: pixelRatio,
+        slugGlyphs: slugGlyphs,
         priority: priority,
       );
 
@@ -725,6 +730,7 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
     required int deviceWidth,
     required int deviceHeight,
     required double pixelRatio,
+    bool slugGlyphs = false,
     int priority = 0,
   }) =>
       _inner.binStrips(
@@ -734,6 +740,7 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
         deviceWidth: deviceWidth,
         deviceHeight: deviceHeight,
         pixelRatio: pixelRatio,
+        slugGlyphs: slugGlyphs,
         priority: priority,
       );
 

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -182,6 +182,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
     required int deviceWidth,
     required int deviceHeight,
     required double pixelRatio,
+    bool slugGlyphs = false,
     int priority = 0,
   }) async {
     if (_disposed || _spawnFailed) return null;
@@ -193,7 +194,8 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         List.of(pageToDevice),
         deviceWidth,
         deviceHeight,
-        pixelRatio);
+        pixelRatio,
+        slugGlyphs);
     _queue.add(request);
     _pump();
     final buffers = await request.completer.future;
@@ -309,6 +311,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         request.deviceWidth,
         request.deviceHeight,
         request.binPixelRatio,
+        request.slugGlyphs,
       ]);
     } else {
       port.send([
@@ -439,7 +442,8 @@ class _PendingRequest {
         pageToDevice = null,
         deviceWidth = 0,
         deviceHeight = 0,
-        binPixelRatio = 0;
+        binPixelRatio = 0,
+        slugGlyphs = false;
 
   _PendingRequest.bin(
       this.priority,
@@ -449,7 +453,8 @@ class _PendingRequest {
       this.pageToDevice,
       this.deviceWidth,
       this.deviceHeight,
-      this.binPixelRatio)
+      this.binPixelRatio,
+      this.slugGlyphs)
       : kind = _RequestKind.bin,
         imagePixelRatio = null,
         decodeImages = false,
@@ -469,7 +474,8 @@ class _PendingRequest {
       : kind = _RequestKind.detail,
         imagePixelRatio = null,
         decodeImages = true,
-        commandLimit = null;
+        commandLimit = null,
+        slugGlyphs = false;
 
   final _RequestKind kind;
   final int priority;
@@ -488,6 +494,7 @@ class _PendingRequest {
   final int deviceWidth;
   final int deviceHeight;
   final double binPixelRatio;
+  final bool slugGlyphs;
 
   final completer = Completer<List<Uint8List>?>();
   bool requeueAfterPreemption = false;
@@ -558,6 +565,7 @@ void _workerMain(_WorkerInit init) {
               request[5] as int,
               request[6] as int,
               request[7] as double,
+              request[8] as bool,
               token);
         } else if (kind == 'detail') {
           final result = await _recordStripDetailAsync(
@@ -666,6 +674,7 @@ Future<Uint8List?> _binStripsAsync(
     int deviceWidth,
     int deviceHeight,
     double pixelRatio,
+    bool slugGlyphs,
     PdfCancellationToken token) async {
   final commands =
       await cache.commandsFor(document, pageIndex, annotations, token);
@@ -676,6 +685,7 @@ Future<Uint8List?> _binStripsAsync(
     deviceWidth: deviceWidth,
     deviceHeight: deviceHeight,
     pixelRatio: pixelRatio,
+    slugGlyphs: slugGlyphs,
   );
   await binner.bin(commands, cancellation: token);
   return encodeStripPlan(binner.finish());

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -235,6 +235,7 @@ class _WebRenderWorker extends PdfRenderWorker {
     required int deviceWidth,
     required int deviceHeight,
     required double pixelRatio,
+    bool slugGlyphs = false,
     int priority = 0,
   }) async {
     if (_disposed || _failed || pageToDevice.length != 6) return null;
@@ -247,6 +248,7 @@ class _WebRenderWorker extends PdfRenderWorker {
       deviceWidth,
       deviceHeight,
       pixelRatio,
+      slugGlyphs,
     );
     _queue.add(request);
     _pump();
@@ -330,7 +332,8 @@ class _WebRenderWorker extends PdfRenderWorker {
       message
         ..setProperty('deviceWidth'.toJS, request.deviceWidth.toJS)
         ..setProperty('deviceHeight'.toJS, request.deviceHeight.toJS)
-        ..setProperty('pixelRatio'.toJS, request.binPixelRatio.toJS);
+        ..setProperty('pixelRatio'.toJS, request.binPixelRatio.toJS)
+        ..setProperty('slugGlyphs'.toJS, request.slugGlyphs.toJS);
     }
     worker.postMessage(message);
 
@@ -464,7 +467,8 @@ class _WebPending {
         pageToDevice = null,
         deviceWidth = 0,
         deviceHeight = 0,
-        binPixelRatio = 0;
+        binPixelRatio = 0,
+        slugGlyphs = false;
 
   _WebPending.bin(
       this.priority,
@@ -474,7 +478,8 @@ class _WebPending {
       this.pageToDevice,
       this.deviceWidth,
       this.deviceHeight,
-      this.binPixelRatio)
+      this.binPixelRatio,
+      this.slugGlyphs)
       : kind = _WebRequestKind.bin,
         imagePixelRatio = null,
         decodeImages = false,
@@ -494,6 +499,7 @@ class _WebPending {
   final int deviceWidth;
   final int deviceHeight;
   final double binPixelRatio;
+  final bool slugGlyphs;
   final completer = Completer<Uint8List?>();
   bool requeueAfterPreemption = false;
   int id = -1;

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -36,7 +36,7 @@ import 'package:web/web.dart' as web;
 ///   late message cannot abort its successor; a match abandons the interpreter
 ///   walk early and replies with `buffer:null`.
 /// - `{kind:'bin', id, page, annotations, m0..m5, deviceWidth, deviceHeight,
-///   pixelRatio}` → replies with an encoded `StripPlan` in the same result
+///   pixelRatio, slugGlyphs}` → replies with an encoded `StripPlan` in the same result
 ///   shape (null = bin locally).
 void runPdfRenderWorker() {
   final scope = globalContext as web.DedicatedWorkerGlobalScope;
@@ -111,6 +111,8 @@ void runPdfRenderWorker() {
           (data.getProperty('deviceHeight'.toJS) as JSNumber).toDartInt;
       final pixelRatio =
           (data.getProperty('pixelRatio'.toJS) as JSNumber).toDartDouble;
+      final slugGlyphs =
+          (data.getProperty('slugGlyphs'.toJS) as JSBoolean?)?.toDart ?? false;
       final token = PdfCancellationToken();
       activeToken = token;
       activeRequestId = id;
@@ -129,6 +131,7 @@ void runPdfRenderWorker() {
               deviceWidth,
               deviceHeight,
               pixelRatio,
+              slugGlyphs,
               token,
             );
           }
@@ -285,6 +288,7 @@ Future<Uint8List?> _binStripsAsync(
   int deviceWidth,
   int deviceHeight,
   double pixelRatio,
+  bool slugGlyphs,
   PdfCancellationToken token,
 ) async {
   final commands =
@@ -296,6 +300,7 @@ Future<Uint8List?> _binStripsAsync(
     deviceWidth: deviceWidth,
     deviceHeight: deviceHeight,
     pixelRatio: pixelRatio,
+    slugGlyphs: slugGlyphs,
   );
   await binner.bin(commands, cancellation: token);
   return encodeStripPlan(binner.finish());

--- a/packages/dart_pdf_editor/lib/src/strips/slug_batch.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/slug_batch.dart
@@ -1,115 +1,39 @@
-// Slug glyph batching (B3): per-outline curve streams (built once, cached
-// by outline identity) assembled per flush into a slot-directory curve
-// atlas, drawn as glyph quads through shaders/pdf_slug.frag.
-//
-// Per-glyph data reaches the shader through the two texcoord floats alone
-// (vertex colors only modulate). A slot is one (outline, quantized px/em
-// scale) pair per batch; every occurrence of that glyph at that scale
-// shares the slot. Slots stack along v in cells of a per-batch constant
-// height (cellHeight, texcoord units == record-time device pixels):
-//   u = 2 + (emX - minX) * S      S = quantized px/em (the slot key)
-//   v = slot * cellHeight + 2 + (emY - minY) * S
-// (minX/minY are the slot's fixed-point-quantized band bbox, exactly what
-// the shader decodes from the directory, so the inversion is exact).
-//
-// Texcoord units MUST be device-pixel-scaled: Impeller evaluates
-// drawVertices runtime effects on an integer-aligned texcoord-unit grid
-// (it snapshots the effect at ~1 texel per unit and samples that with the
-// vertex UVs - measured, see the 2026-07-10 slug dev-log), so em-unit
-// texcoords would collapse a glyph to a single evaluated sample. The
-// 2-texel cell inset keeps Impeller's bilinear snapshot resampling from
-// bleeding across slot cells. Skia evaluates per fragment directly; both
-// backends see the same GLSL.
-//
-// The atlas starts with a 4-texel directory entry per slot (stream base as
-// a u16 pair, band geometry and AA scale - see pdf_slug.frag), followed by
-// the glyphs' relocatable texel streams verbatim (their internal offsets
-// are stream-relative by design, curve_quads.dart).
-//
-// The atlas is rebuilt per flush (streams are memcpys of cached bytes;
-// noted cost - a persistent cross-flush atlas is a later optimization).
+// dart:ui upload wrapper for pdf_graphics' worker-transferable Slug batches.
 import 'dart:async';
-import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_graphics/raster.dart';
 
-/// Curve atlas width in texels.
-const int slugAtlasWidth = 512;
+export 'package:pdf_graphics/raster.dart'
+    show
+        SlugBatchBuilder,
+        SlugBatchData,
+        SlugChunkData,
+        SlugGlyphData,
+        slugAtlasWidth;
 
-/// Per-outline Slug data: the relocatable texel stream + band geometry,
-/// built once per outline identity ([of] memoizes via Expando, the same
-/// lifetime pattern as [FlattenedOutline]). [overflow] marks glyphs that
-/// exceed the band cap (or failed to encode) - callers use outline strips.
-class SlugGlyphData {
-  SlugGlyphData._(this.stream, this.texelCount, this.bandCount, this.minX,
-      this.minY, this.maxX, this.maxY, this.overflow)
-      : qMinX = stream == null ? 0 : fixedToEm(emToFixed(minX)),
-        qMinY = stream == null ? 0 : fixedToEm(emToFixed(minY));
-
-  final Uint8List? stream;
-  final int texelCount;
-  final int bandCount;
-  final double minX, minY, maxX, maxY;
-
-  /// [minX]/[minY] through the directory's fixed-point quantization - the
-  /// exact values the shader decodes, used for the texcoord mapping so the
-  /// em recovery inverts exactly.
-  final double qMinX, qMinY;
-
-  final bool overflow;
-
-  static final Expando<SlugGlyphData> _cache = Expando('SlugGlyphData');
-
-  /// One-time build cost accounting (microseconds / outlines built).
-  static int totalBuildMicros = 0;
-  static int totalBuilds = 0;
-
-  static final SlugGlyphData _overflow =
-      SlugGlyphData._(null, 0, 0, 0, 0, 0, 0, true);
-
-  static SlugGlyphData of(PdfPath outline) {
-    final cached = _cache[outline];
-    if (cached != null) return cached;
-    final sw = Stopwatch()..start();
-    SlugGlyphData result;
-    try {
-      final quads = outlineToQuads(outline);
-      final bands = buildBands(quads, bandCount: 8);
-      if (quads.isEmpty || bands.overflow) {
-        result = _overflow;
-      } else {
-        final stream = encodeGlyphStream(quads, bands);
-        result = SlugGlyphData._(stream, stream.length ~/ 4, bands.bandCount,
-            bands.minX, bands.minY, bands.maxX, bands.maxY, false);
-      }
-    } on ArgumentError {
-      result = _overflow; // stream too large
-    }
-    totalBuildMicros += sw.elapsedMicroseconds;
-    totalBuilds++;
-    _cache[outline] = result;
-    return result;
-  }
-}
-
-/// One flushed batch of Slug glyph quads sharing one curve atlas.
 class SlugBatch {
-  SlugBatch._(this.chunks, this.atlasPixels, this.atlasWidth, this.atlasHeight,
-      this.quadCount, this.cellHeight);
+  SlugBatch.fromData(SlugBatchData data)
+      : chunks = [
+          for (final chunk in data.chunks)
+            ui.Vertices.raw(ui.VertexMode.triangles, chunk.positions,
+                textureCoordinates: chunk.textureCoordinates,
+                colors: chunk.colors,
+                indices: chunk.indices),
+        ],
+        atlasPixels = data.atlasPixels,
+        atlasWidth = data.atlasWidth,
+        atlasHeight = data.atlasHeight,
+        quadCount = data.quadCount,
+        cellHeight = data.cellHeight;
 
   final List<ui.Vertices> chunks;
   final Uint8List atlasPixels;
   final int atlasWidth;
   final int atlasHeight;
   final int quadCount;
-
-  /// Slot cell stride along v, in texcoord units (integer-valued); the
-  /// shader's uCellH uniform.
   final double cellHeight;
-
   ui.Image? atlas;
 
   Future<void> decodeAtlas() {
@@ -125,187 +49,8 @@ class SlugBatch {
   void dispose() {
     atlas?.dispose();
     atlas = null;
-    for (final v in chunks) {
-      v.dispose();
+    for (final vertices in chunks) {
+      vertices.dispose();
     }
-  }
-}
-
-/// Accumulates one flush window's Slug quads and assembles the [SlugBatch].
-class SlugBatchBuilder {
-  final Map<(PdfPath, int, int), int> _slots = {};
-  final List<SlugGlyphData> _slotData = [];
-  final List<int> _slotQsx = [];
-  final List<int> _slotQsy = [];
-
-  final FloatBuilder _positions = FloatBuilder(256);
-  final FloatBuilder _texs = FloatBuilder(256);
-  final List<int> _colors = [];
-  final List<int> _quadSlot = [];
-  double _maxCellH = 0;
-  int _quadCount = 0;
-  double _minPX = double.infinity, _minPY = double.infinity;
-  double _maxPX = double.negativeInfinity, _maxPY = double.negativeInfinity;
-
-  bool get isEmpty => _quadCount == 0;
-  int get quadCount => _quadCount;
-  int get slotCount => _slotData.length;
-
-  /// Page-space bbox of the pending quads - lets the device keep batching
-  /// when later vector paints don't overlap any pending glyph (painter's
-  /// order only matters where pixels overlap).
-  bool overlaps(double minX, double minY, double maxX, double maxY) =>
-      _quadCount != 0 &&
-      minX <= _maxPX &&
-      maxX >= _minPX &&
-      minY <= _maxPY &&
-      maxY >= _minPY;
-
-  /// Upper bound on the built batch's texcoord v extent
-  /// (slots x cell height). Impeller snapshots the runtime effect over the
-  /// texcoord bounds at ~1 texel per unit, so callers should flush before
-  /// this approaches the max texture size (see StripPdfDevice).
-  double get estimatedVExtent => _slotData.length * (_maxCellH + 4);
-
-  /// Adds one glyph occurrence: [emToPage] places the em-space quad in
-  /// page space; [pxPerEmX]/[pxPerEmY] are the record-time device scales
-  /// (they set the shader's AA ramp width, the texcoord scale - texcoord
-  /// units are record-time device pixels - and quantize into the slot key
-  /// at 1/16 px/em).
-  void addGlyph(PdfPath outline, SlugGlyphData data, PdfMatrix emToPage,
-      double pxPerEmX, double pxPerEmY, int argb) {
-    final qsx = (pxPerEmX * 16).round().clamp(1, 0xFFFF);
-    final qsy = (pxPerEmY * 16).round().clamp(1, 0xFFFF);
-    final slot = _slots.putIfAbsent((outline, qsx, qsy), () {
-      _slotData.add(data);
-      _slotQsx.add(qsx);
-      _slotQsy.add(qsy);
-      return _slotData.length - 1;
-    });
-    final sx = qsx / 16.0, sy = qsy / 16.0;
-
-    // em bbox padded by exactly one device pixel so the AA ramp fits
-    final padX = 16.0 / qsx, padY = 16.0 / qsy;
-    final x0 = data.minX - padX, x1 = data.maxX + padX;
-    final y0 = data.minY - padY, y1 = data.maxY + padY;
-    // texcoords in device-pixel units, local to the slot cell (the slot's
-    // v base is patched in at build() once the max cell height is known);
-    // the 2-texel inset leaves a >=1-texel guard band around the cell.
-    final u0 = 2.0 + (x0 - data.qMinX) * sx;
-    final u1 = 2.0 + (x1 - data.qMinX) * sx;
-    final lv0 = 2.0 + (y0 - data.qMinY) * sy;
-    final lv1 = 2.0 + (y1 - data.qMinY) * sy;
-    if (lv1 > _maxCellH) _maxCellH = lv1;
-    // corners in em order (x0,y0) (x1,y0) (x0,y1) (x1,y1)
-    final px0 = emToPage.transformX(x0, y0), py0 = emToPage.transformY(x0, y0);
-    final px1 = emToPage.transformX(x1, y0), py1 = emToPage.transformY(x1, y0);
-    final px2 = emToPage.transformX(x0, y1), py2 = emToPage.transformY(x0, y1);
-    final px3 = emToPage.transformX(x1, y1), py3 = emToPage.transformY(x1, y1);
-    _positions.add4(px0, py0, px1, py1);
-    _positions.add4(px2, py2, px3, py3);
-    _minPX = math.min(_minPX, math.min(math.min(px0, px1), math.min(px2, px3)));
-    _maxPX = math.max(_maxPX, math.max(math.max(px0, px1), math.max(px2, px3)));
-    _minPY = math.min(_minPY, math.min(math.min(py0, py1), math.min(py2, py3)));
-    _maxPY = math.max(_maxPY, math.max(math.max(py0, py1), math.max(py2, py3)));
-    _texs.add4(u0, lv0, u1, lv0);
-    _texs.add4(u0, lv1, u1, lv1);
-    _quadSlot.add(slot);
-    _colors.add(argb);
-    _colors.add(argb);
-    _colors.add(argb);
-    _colors.add(argb);
-    _quadCount++;
-  }
-
-  /// Assembles the batch (atlas + vertices) and resets the builder.
-  /// Returns null when empty.
-  SlugBatch? build() {
-    if (_quadCount == 0) return null;
-
-    // ---- curve atlas: directory + concatenated streams ----
-    final slotCount = _slotData.length;
-    var total = 4 * slotCount;
-    final bases = Int32List(slotCount);
-    for (var i = 0; i < slotCount; i++) {
-      bases[i] = total;
-      total += _slotData[i].texelCount;
-    }
-    final height = math.max(1, (total + slugAtlasWidth - 1) ~/ slugAtlasWidth);
-    final pixels = Uint8List(slugAtlasWidth * height * 4);
-    final u16 = ByteData.sublistView(pixels);
-    void put(int texel, int lo, int hi) {
-      u16.setUint16(texel * 4, lo, Endian.little);
-      u16.setUint16(texel * 4 + 2, hi, Endian.little);
-    }
-
-    for (var i = 0; i < slotCount; i++) {
-      final d = _slotData[i];
-      final base = bases[i];
-      put(4 * i, base & 0xFFFF, base >> 16);
-      put(4 * i + 1, emToFixed(d.minY),
-          emToFixed((d.maxY - d.minY) / d.bandCount));
-      put(4 * i + 2, emToFixed(d.minX),
-          emToFixed((d.maxX - d.minX) / d.bandCount));
-      put(4 * i + 3, _slotQsx[i], _slotQsy[i]);
-      pixels.setRange(base * 4, base * 4 + d.stream!.length, d.stream!);
-    }
-
-    // ---- vertices (Uint16 indices cap quads per draw) ----
-    const maxQuads = 16000;
-    final chunks = <ui.Vertices>[];
-    final positions = _positions.view;
-    final texs = _texs.view;
-    // patch each quad's v by its slot's cell base, now that the constant
-    // cell height (max over slots, +2 trailing guard texels) is known
-    final cellH = (_maxCellH + 2).ceilToDouble();
-    for (var q = 0; q < _quadCount; q++) {
-      final vBase = _quadSlot[q] * cellH;
-      final t = q * 8;
-      texs[t + 1] += vBase;
-      texs[t + 3] += vBase;
-      texs[t + 5] += vBase;
-      texs[t + 7] += vBase;
-    }
-    for (var start = 0; start < _quadCount; start += maxQuads) {
-      final count = math.min(maxQuads, _quadCount - start);
-      final pos =
-          Float32List.sublistView(positions, start * 8, (start + count) * 8);
-      final tex = Float32List.sublistView(texs, start * 8, (start + count) * 8);
-      final colors = Int32List(count * 4);
-      for (var i = 0; i < count * 4; i++) {
-        colors[i] = _colors[start * 4 + i];
-      }
-      final indices = Uint16List(count * 6);
-      for (var q = 0; q < count; q++) {
-        final v = q * 4, ix = q * 6;
-        indices[ix] = v;
-        indices[ix + 1] = v + 1;
-        indices[ix + 2] = v + 2;
-        indices[ix + 3] = v + 1;
-        indices[ix + 4] = v + 3;
-        indices[ix + 5] = v + 2;
-      }
-      chunks.add(ui.Vertices.raw(
-          ui.VertexMode.triangles, Float32List.fromList(pos),
-          textureCoordinates: Float32List.fromList(tex),
-          colors: colors,
-          indices: indices));
-    }
-
-    final batch =
-        SlugBatch._(chunks, pixels, slugAtlasWidth, height, _quadCount, cellH);
-    _slots.clear();
-    _slotData.clear();
-    _slotQsx.clear();
-    _slotQsy.clear();
-    _positions.clear();
-    _texs.clear();
-    _colors.clear();
-    _quadSlot.clear();
-    _maxCellH = 0;
-    _quadCount = 0;
-    _minPX = _minPY = double.infinity;
-    _maxPX = _maxPY = double.negativeInfinity;
-    return batch;
   }
 }

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -113,6 +113,8 @@ class StripPdfDevice extends StripBinningDevice {
   /// the next unconsumed plan batch.
   final StripPlan? _plan;
   int _planNext = 0;
+  int _planSlugNext = 0;
+  int _planSlugFallbackNext = 0;
 
   /// Whether this device consumes a precomputed plan (after validation).
   bool get usesPrecomputedPlan => _plan != null;
@@ -131,12 +133,7 @@ class StripPdfDevice extends StripBinningDevice {
     bool slugEnabled = false,
   }) {
     if (plan == null) return null;
-    // Worker plans currently route outline text into strips. Slug changes
-    // that routing, so a caller explicitly recording a transform-time Slug
-    // picture must bin locally rather than consume a structurally different
-    // plan. The normal dense-page raster path keeps slugEnabled false and
-    // continues consuming worker plans unchanged.
-    if (slugEnabled) return null;
+    if (plan.slugGlyphs != slugEnabled) return null;
     if (debugDelegateAll ||
         debugDelegateFills ||
         debugDelegateStrokes ||
@@ -219,6 +216,7 @@ class StripPdfDevice extends StripBinningDevice {
   /// Slug-mode stats: glyph quads drawn and curve-atlas texels uploaded.
   static int totalSlugQuads = 0;
   static int totalSlugAtlasTexels = 0;
+  static int totalSlugFallbackOutlineRuns = 0;
 
   static void resetStats() {
     totalFlushes = 0;
@@ -232,32 +230,42 @@ class StripPdfDevice extends StripBinningDevice {
     totalPlanPictures = 0;
     totalSlugQuads = 0;
     totalSlugAtlasTexels = 0;
+    totalSlugFallbackOutlineRuns = 0;
   }
 
   int get flushCount => _batches.length;
 
-  static Future<ui.FragmentProgram>? _programFuture;
-  static Future<ui.FragmentProgram>? _slugProgramFuture;
+  // Cache resolved engine values, never the Future itself. A Future created
+  // in a widget test's FakeAsync zone becomes unusable after that test; the
+  // resolved program is zone-independent and can be returned from a fresh
+  // Future in every caller's current zone.
+  static ui.FragmentProgram? _program;
+  static ui.FragmentProgram? _slugProgram;
 
-  static Future<ui.FragmentProgram> _loadProgram() =>
-      _programFuture ??= () async {
-        try {
-          return await ui.FragmentProgram.fromAsset('shaders/pdf_strips.frag');
-        } catch (_) {
-          return ui.FragmentProgram.fromAsset(
-              'packages/dart_pdf_editor/shaders/pdf_strips.frag');
-        }
-      }();
+  static Future<ui.FragmentProgram> _loadProgram() async {
+    final cached = _program;
+    if (cached != null) return cached;
+    final loaded = await _loadProgramAsset('shaders/pdf_strips.frag',
+        'packages/dart_pdf_editor/shaders/pdf_strips.frag');
+    return _program ??= loaded;
+  }
 
-  static Future<ui.FragmentProgram> _loadSlugProgram() =>
-      _slugProgramFuture ??= () async {
-        try {
-          return await ui.FragmentProgram.fromAsset('shaders/pdf_slug.frag');
-        } catch (_) {
-          return ui.FragmentProgram.fromAsset(
-              'packages/dart_pdf_editor/shaders/pdf_slug.frag');
-        }
-      }();
+  static Future<ui.FragmentProgram> _loadSlugProgram() async {
+    final cached = _slugProgram;
+    if (cached != null) return cached;
+    final loaded = await _loadProgramAsset('shaders/pdf_slug.frag',
+        'packages/dart_pdf_editor/shaders/pdf_slug.frag');
+    return _slugProgram ??= loaded;
+  }
+
+  static Future<ui.FragmentProgram> _loadProgramAsset(
+      String primary, String packagePath) async {
+    try {
+      return await ui.FragmentProgram.fromAsset(primary);
+    } catch (_) {
+      return ui.FragmentProgram.fromAsset(packagePath);
+    }
+  }
 
   /// Debug: route every paint through the fallback (no strips at all) to
   /// isolate tape/pipeline effects from strip rasterization quality.
@@ -405,12 +413,37 @@ class StripPdfDevice extends StripBinningDevice {
     // while the worker-plan and glyph-layer paths are integrated: it preserves
     // painter order without changing StripBinningDevice's flush ordinals.
     flushPending();
-    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, 1))) {
+    final plan = _plan;
+    if (plan != null) {
+      final ordinal = flushPointCount - 1;
+      if (_planSlugNext < plan.slugBatches.length &&
+          plan.slugBatches[_planSlugNext].flushOrdinal == ordinal) {
+        _addSlugBatch(plan.slugBatches[_planSlugNext++]);
+        return;
+      }
+      if (_planSlugFallbackNext >= plan.slugFallbackOrdinals.length ||
+          plan.slugFallbackOrdinals[_planSlugFallbackNext] != ordinal) {
+        // Slug-eligible run with no outline quads: successful no-op, not a
+        // fallback. This distinction is explicit in the worker plan so the
+        // UI never has to inspect outlines to recover routing.
+        return;
+      }
+      _planSlugFallbackNext++;
+      // The worker applied the same eligibility checks and routed this run
+      // into strips. With binning disabled, super only advances routing; its
+      // planned strip batch is consumed at the next flush point.
       _slugFallbackOutlineRuns++;
+      totalSlugFallbackOutlineRuns++;
       super.drawText(run);
       return;
     }
-    _flushSlug();
+    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, 1))) {
+      _slugFallbackOutlineRuns++;
+      totalSlugFallbackOutlineRuns++;
+      super.drawText(run);
+      return;
+    }
+    _flushSlug(flushPointCount - 1);
   }
 
   static const double _slugMaxVExtent = 8192;
@@ -443,13 +476,20 @@ class StripPdfDevice extends StripBinningDevice {
         color,
       );
     }
-    if (builder.estimatedVExtent > _slugMaxVExtent) _flushSlug();
+    if (builder.estimatedVExtent > _slugMaxVExtent) {
+      _flushSlug(flushPointCount - 1);
+    }
     return true;
   }
 
-  void _flushSlug() {
-    final batch = _slugBuilder?.build();
-    if (batch == null) return;
+  void _flushSlug(int ordinal) {
+    final data = _slugBuilder?.build(ordinal);
+    if (data == null) return;
+    _addSlugBatch(data);
+  }
+
+  void _addSlugBatch(SlugBatchData data) {
+    final batch = SlugBatch.fromData(data);
     _tape.add(batch);
     _slugBatches.add(batch);
     totalFlushes++;
@@ -468,11 +508,13 @@ class StripPdfDevice extends StripBinningDevice {
     assert(!_finished, 'StripPdfDevice.finish() called twice');
     _finished = true;
     flushPending();
-    _flushSlug();
+    _flushSlug(flushPointCount - 1);
     final plan = _plan;
     if (plan != null &&
         (flushPointCount != plan.totalFlushPoints ||
-            _planNext != plan.batches.length)) {
+            _planNext != plan.batches.length ||
+            _planSlugNext != plan.slugBatches.length ||
+            _planSlugFallbackNext != plan.slugFallbackOrdinals.length)) {
       // Desync is only detectable once the walk is complete; nothing has
       // painted yet (painting starts below), so the caller can discard the
       // recording and re-run with local binning.
@@ -480,7 +522,10 @@ class StripPdfDevice extends StripBinningDevice {
       throw StripPlanMismatchError(
           'flush points: device $flushPointCount vs plan '
           '${plan.totalFlushPoints}; consumed $_planNext of '
-          '${plan.batches.length} batches');
+          '${plan.batches.length} strip and $_planSlugNext of '
+          '${plan.slugBatches.length} Slug batches; consumed '
+          '$_planSlugFallbackNext of ${plan.slugFallbackOrdinals.length} '
+          'Slug fallbacks');
     }
     if (plan != null && !debugVerifyPrecomputed) totalPlanPictures++;
     final sw = Stopwatch()..start();

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -26,6 +26,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_graphics/raster.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 import 'render_seam_test.dart' show buildStripsPdf;
 import 'strip_zoom_router_test.dart' show buildVectorPdf;
@@ -256,6 +257,46 @@ void main() {
       expect(plan2, isNotNull);
       expect(plan2!.totalFlushPoints, plan.totalFlushPoints,
           reason: 'flush structure is geometry-independent');
+    });
+  });
+
+  testWidgets('isolate builds Slug batches bit-identically off-thread',
+      (tester) async {
+    await tester.runAsync(() async {
+      final bytes = buildEmbeddedFontPdf();
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+      final commands = await worker.record(0);
+      expect(commands, isNotNull);
+      final size = PdfPageRenderer.pageSize(page);
+      final matrix = PdfPageRenderer.pageToDeviceMatrix(
+          page, size, page.cropBox,
+          pixelRatio: 1);
+      final plan = await worker.binStrips(0,
+          annotations: true,
+          pageToDevice: _coeffs(matrix),
+          deviceWidth: size.width.ceil(),
+          deviceHeight: size.height.ceil(),
+          pixelRatio: 1,
+          slugGlyphs: true);
+      expect(plan, isNotNull);
+      expect(plan!.slugGlyphs, isTrue);
+      expect(plan.slugBatches, isNotEmpty);
+      expect(plan.slugQuadCount, greaterThan(0));
+      expect(plan.slugFallbackOutlineRuns, 0);
+
+      final local = StripPlanBinner(
+        pageToDevice: matrix,
+        deviceWidth: size.width.ceil(),
+        deviceHeight: size.height.ceil(),
+        pixelRatio: 1,
+        slugGlyphs: true,
+      );
+      await local.bin(commands!);
+      expect(encodeStripPlan(plan), encodeStripPlan(local.finish()),
+          reason: 'the UI must only upload worker-built Slug data');
     });
   });
 
@@ -504,6 +545,7 @@ class _BinLogWorker extends PdfRenderWorker {
     required int deviceWidth,
     required int deviceHeight,
     required double pixelRatio,
+    bool slugGlyphs = false,
     int priority = 0,
   }) async {
     binCalls.add(pageIndex);
@@ -515,6 +557,7 @@ class _BinLogWorker extends PdfRenderWorker {
           pageToDevice[3], pageToDevice[4], pageToDevice[5]),
       tolerance: stripFlattenTolerance,
       batches: const [],
+      slugGlyphs: slugGlyphs,
     );
   }
 

--- a/packages/dart_pdf_editor/test/slug_atlas_probe_test.dart
+++ b/packages/dart_pdf_editor/test/slug_atlas_probe_test.dart
@@ -10,7 +10,6 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_graphics/raster.dart';
 // ignore: implementation_imports
 import 'package:pdf_graphics/src/fonts/truetype.dart';
-import 'package:dart_pdf_editor/strips.dart';
 
 void main() {
   test('atlas walk matches glyphCoverageAA', () {
@@ -90,7 +89,10 @@ void main() {
             final up = vertical ? !s1 : s1;
             cov += up ? w : -w;
           } else if (b * b - 4 * a * e0 > 0 &&
-              tA > 0 && tA < 1 && tB > 0 && tB < 1) {
+              tA > 0 &&
+              tA < 1 &&
+              tB > 0 &&
+              tB < 1) {
             final wMin = weight(math.min(tA, tB));
             final wMax = weight(math.max(tA, tB));
             var sum = s0 ? (wMax - wMin) : (wMin - wMax);
@@ -131,7 +133,6 @@ void main() {
     // ignore: avoid_print
     print('ATLAS-WALK: mean ${(sum / 1024).toStringAsFixed(2)} '
         'max ${worst.toStringAsFixed(1)}');
-    batch.dispose();
     expect(worst, lessThanOrEqualTo(16));
   });
 }

--- a/packages/dart_pdf_editor/test/slug_worker_latency_test.dart
+++ b/packages/dart_pdf_editor/test/slug_worker_latency_test.dart
@@ -14,7 +14,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
-import 'package:pdf_graphics/pdf_graphics.dart';
 
 void main() {
   final path =

--- a/packages/dart_pdf_editor/test/slug_worker_latency_test.dart
+++ b/packages/dart_pdf_editor/test/slug_worker_latency_test.dart
@@ -1,0 +1,86 @@
+// Corpus probe for issue #227's dense transform-time Slug path.
+//
+//   cd packages/dart_pdf_editor
+//   SLUG_WORKER_PDF=../../corpus/ly9-far-cad.pdf \
+//   SLUG_WORKER_PAGE=4 fvm flutter test test/slug_worker_latency_test.dart
+//
+// Reports the off-thread plan wall time, transferred plan size, residual UI
+// upload/replay time, and the local-build time deliberately excluded from the
+// production path. Skips when the corpus file is absent or the selected page
+// is image-bearing / has no embedded-outline text.
+import 'dart:io';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+void main() {
+  final path =
+      Platform.environment['SLUG_WORKER_PDF'] ?? '../../corpus/ly9-far-cad.pdf';
+  final pageIndex =
+      int.tryParse(Platform.environment['SLUG_WORKER_PAGE'] ?? '') ?? 4;
+
+  testWidgets('dense Slug worker plan latency', (tester) async {
+    final file = File(path);
+    if (!file.existsSync()) {
+      markTestSkipped('corpus file missing: $path');
+      return;
+    }
+    await tester.runAsync(() async {
+      final bytes = file.readAsBytesSync();
+      final document = PdfDocument.open(bytes);
+      final index = pageIndex.clamp(0, document.pageCount - 1);
+      final page = document.page(index);
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
+      final commands = await worker.record(index, decodeImages: false);
+      expect(commands, isNotNull);
+      final scene = await PdfRetainedScene.fromCommands(page, commands!);
+      addTearDown(scene.dispose);
+      if (!scene.hasSlugTextCandidates ||
+          PdfPageRenderer.hasImageDraws(scene.commands)) {
+        markTestSkipped('page $index is not an image-free Slug candidate');
+        return;
+      }
+
+      final geometry = scene.stripGeometry(pixelRatio: 1);
+      final m = geometry.pageToDevice;
+      var sw = Stopwatch()..start();
+      final plan = await worker.binStrips(index,
+          annotations: true,
+          pageToDevice: [m.a, m.b, m.c, m.d, m.e, m.f],
+          deviceWidth: geometry.width,
+          deviceHeight: geometry.height,
+          pixelRatio: 1,
+          slugGlyphs: true);
+      final workerMs = sw.elapsedMicroseconds / 1000;
+      expect(plan, isNotNull);
+
+      StripPdfDevice.resetStats();
+      sw = Stopwatch()..start();
+      final planned = await scene.replayStrips(
+          pixelRatio: 1, stripPlan: plan, slugGlyphs: true);
+      final uploadMs = sw.elapsedMicroseconds / 1000;
+      planned.dispose();
+      expect(StripPdfDevice.totalPlanPictures, 1);
+
+      StripPdfDevice.resetStats();
+      sw = Stopwatch()..start();
+      final local = await scene.replayStrips(pixelRatio: 1, slugGlyphs: true);
+      final localMs = sw.elapsedMicroseconds / 1000;
+      local.dispose();
+
+      final planMb = encodeStripPlan(plan!).length / (1024 * 1024);
+      // ignore: avoid_print
+      print('SLUG-WORKER page=$index commands=${scene.commands.length} '
+          'quads=${plan.slugQuadCount} '
+          'fallbacks=${plan.slugFallbackOutlineRuns} '
+          'plan=${planMb.toStringAsFixed(2)}MB '
+          'worker=${workerMs.toStringAsFixed(1)}ms '
+          'ui=${uploadMs.toStringAsFixed(1)}ms '
+          'local=${localMs.toStringAsFixed(1)}ms');
+    });
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}

--- a/packages/dart_pdf_editor/test/strip_plan_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_plan_device_test.dart
@@ -20,6 +20,7 @@ import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 import 'strip_zoom_router_test.dart' show buildVectorPdf;
 import 'strip_zoom_router_test.dart' as router;
@@ -45,6 +46,39 @@ Future<StripPlan> _localPlan(PdfRetainedScene scene,
 }
 
 void main() {
+  testWidgets('worker-shaped Slug plan paints like local Slug routing',
+      (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(buildEmbeddedFontPdf());
+      final scene = await PdfRetainedScene.record(doc.page(0));
+      addTearDown(scene.dispose);
+      final geometry = scene.stripGeometry(pixelRatio: 1);
+      final binner = StripPlanBinner(
+        pageToDevice: geometry.pageToDevice,
+        deviceWidth: geometry.width,
+        deviceHeight: geometry.height,
+        pixelRatio: 1,
+        slugGlyphs: true,
+      );
+      await binner.bin(scene.commands);
+      final plan = binner.finish();
+      expect(plan.slugBatches, isNotEmpty);
+
+      final plannedPicture = await scene.replayStrips(
+          pixelRatio: 1, stripPlan: plan, slugGlyphs: true);
+      final localPicture =
+          await scene.replayStrips(pixelRatio: 1, slugGlyphs: true);
+      final planned =
+          await plannedPicture.toImage(geometry.width, geometry.height);
+      final local = await localPicture.toImage(geometry.width, geometry.height);
+      plannedPicture.dispose();
+      localPicture.dispose();
+      expect(await _rgba(planned), await _rgba(local));
+      planned.dispose();
+      local.dispose();
+    });
+  });
+
   testWidgets(
       'a precomputed plan rasterizes byte-identically to local '
       'binning (verified batch-by-batch)', (tester) async {

--- a/packages/dart_pdf_editor/test/web_slug_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_page_test.dart
@@ -19,7 +19,11 @@ Future<void> _waitForSlugPicture(WidgetTester tester) async {
     await tester
         .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
   }
-  fail('Slug page picture did not arrive');
+  fail('Slug page picture did not arrive '
+      '(planPictures=${StripPdfDevice.totalPlanPictures}, '
+      'slugQuads=${StripPdfDevice.totalSlugQuads}, '
+      'fallbacks=${StripPdfDevice.totalSlugFallbackOutlineRuns}, '
+      'mismatches=${StripPdfDevice.totalPlanMismatches})');
 }
 
 Future<void> _waitForRaster(WidgetTester tester) async {
@@ -97,5 +101,52 @@ void main() {
     expect(find.byKey(const ValueKey('pdf-page-slug-picture')), findsNothing);
     expect(StripPdfDevice.totalSlugQuads, 0,
         reason: 'Base-14 text has no outline glyphs for Slug to evaluate');
+  });
+
+  testWidgets('dense page consumes a worker Slug plan once', (tester) async {
+    PdfPageView.webSlugGlyphLayer = true;
+    PdfPageView.debugWebSlugGlyphLayerBackendOverride = true;
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
+    PdfPageView.retainedZoomReplayMaxCommands = 0;
+    addTearDown(() {
+      PdfPageView.webSlugGlyphLayer = true;
+      PdfPageView.debugWebSlugGlyphLayerBackendOverride = null;
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+    });
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildEmbeddedFontPdf();
+    final page = PdfDocument.open(bytes).page(0);
+    final worker = PdfRenderWorker.startUncached(bytes);
+    addTearDown(worker.dispose);
+    Widget at(double scale) => Center(
+          child: SizedBox(
+            width: 612,
+            child: PdfPageView(page: page, scale: scale, renderWorker: worker),
+          ),
+        );
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    await _waitForSlugPicture(tester);
+    expect(StripPdfDevice.totalPlanPictures, 1,
+        reason: 'dense Slug construction must consume the worker plan');
+    final finder = find.byKey(const ValueKey('pdf-page-slug-picture'));
+    final picture =
+        (tester.widget<CustomPaint>(finder).painter! as dynamic).picture;
+    final quads = StripPdfDevice.totalSlugQuads;
+
+    await tester.pumpWidget(at(3));
+    await tester.pump();
+    expect(
+        identical(
+            (tester.widget<CustomPaint>(finder).painter! as dynamic).picture,
+            picture),
+        isTrue);
+    expect(StripPdfDevice.totalSlugQuads, quads);
+    expect(StripPdfDevice.totalPlanPictures, 1,
+        reason: 'zoom must not request or upload another Slug plan');
   });
 }

--- a/packages/pdf_graphics/lib/raster.dart
+++ b/packages/pdf_graphics/lib/raster.dart
@@ -10,6 +10,7 @@ library;
 
 export 'src/raster/curve_quads.dart';
 export 'src/raster/flatten.dart';
+export 'src/raster/slug_batch_data.dart';
 export 'src/raster/stroke_contours.dart';
 export 'src/raster/strip_batch_data.dart';
 export 'src/raster/strip_binning_device.dart';

--- a/packages/pdf_graphics/lib/src/raster/slug_batch_data.dart
+++ b/packages/pdf_graphics/lib/src/raster/slug_batch_data.dart
@@ -1,0 +1,231 @@
+// Pure-Dart Slug curve-atlas planning. Worker isolates build these typed-data
+// batches; dart_pdf_editor only wraps them in ui.Vertices and uploads the
+// atlas. Keeping curve conversion here prevents dense web pages from putting
+// the expensive outline/band walk back on the browser UI thread.
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import '../matrix.dart';
+import '../path.dart';
+import 'curve_quads.dart';
+import 'flatten.dart';
+
+/// Curve atlas width in texels.
+const int slugAtlasWidth = 512;
+
+/// Maximum glyph quads in one drawVertices call (Uint16 indices).
+const int slugMaxQuadsPerDraw = 16000;
+
+/// Per-outline relocatable curve stream, memoized by outline identity.
+class SlugGlyphData {
+  SlugGlyphData._(this.stream, this.texelCount, this.bandCount, this.minX,
+      this.minY, this.maxX, this.maxY, this.overflow)
+      : qMinX = stream == null ? 0 : fixedToEm(emToFixed(minX)),
+        qMinY = stream == null ? 0 : fixedToEm(emToFixed(minY));
+
+  final Uint8List? stream;
+  final int texelCount;
+  final int bandCount;
+  final double minX, minY, maxX, maxY;
+  final double qMinX, qMinY;
+  final bool overflow;
+
+  static final Expando<SlugGlyphData> _cache = Expando('SlugGlyphData');
+  static int totalBuildMicros = 0;
+  static int totalBuilds = 0;
+  static final SlugGlyphData _overflow =
+      SlugGlyphData._(null, 0, 0, 0, 0, 0, 0, true);
+
+  static SlugGlyphData of(PdfPath outline) {
+    final cached = _cache[outline];
+    if (cached != null) return cached;
+    final sw = Stopwatch()..start();
+    SlugGlyphData result;
+    try {
+      final quads = outlineToQuads(outline);
+      final bands = buildBands(quads, bandCount: 8);
+      if (quads.isEmpty || bands.overflow) {
+        result = _overflow;
+      } else {
+        final stream = encodeGlyphStream(quads, bands);
+        result = SlugGlyphData._(stream, stream.length ~/ 4, bands.bandCount,
+            bands.minX, bands.minY, bands.maxX, bands.maxY, false);
+      }
+    } on ArgumentError {
+      result = _overflow;
+    }
+    totalBuildMicros += sw.elapsedMicroseconds;
+    totalBuilds++;
+    _cache[outline] = result;
+    return result;
+  }
+}
+
+/// One drawVertices-sized slice of a Slug batch.
+class SlugChunkData {
+  SlugChunkData(
+      this.positions, this.textureCoordinates, this.colors, this.indices);
+
+  final Float32List positions;
+  final Float32List textureCoordinates;
+  final Int32List colors;
+  final Uint16List indices;
+}
+
+/// One painter-order Slug batch in worker-transferable form.
+class SlugBatchData {
+  SlugBatchData(this.flushOrdinal, this.chunks, this.atlasPixels,
+      this.atlasWidth, this.atlasHeight, this.quadCount, this.cellHeight);
+
+  /// The strip flush point immediately preceding this text run.
+  final int flushOrdinal;
+  final List<SlugChunkData> chunks;
+  final Uint8List atlasPixels;
+  final int atlasWidth;
+  final int atlasHeight;
+  final int quadCount;
+  final double cellHeight;
+}
+
+/// Accumulates one painter-order Slug window without any dart:ui objects.
+class SlugBatchBuilder {
+  final Map<(PdfPath, int, int), int> _slots = {};
+  final List<SlugGlyphData> _slotData = [];
+  final List<int> _slotQsx = [];
+  final List<int> _slotQsy = [];
+  final FloatBuilder _positions = FloatBuilder(256);
+  final FloatBuilder _texs = FloatBuilder(256);
+  final List<int> _colors = [];
+  final List<int> _quadSlot = [];
+  double _maxCellH = 0;
+  int _quadCount = 0;
+  double _minPX = double.infinity, _minPY = double.infinity;
+  double _maxPX = double.negativeInfinity, _maxPY = double.negativeInfinity;
+
+  bool get isEmpty => _quadCount == 0;
+  int get quadCount => _quadCount;
+  int get slotCount => _slotData.length;
+
+  bool overlaps(double minX, double minY, double maxX, double maxY) =>
+      _quadCount != 0 &&
+      minX <= _maxPX &&
+      maxX >= _minPX &&
+      minY <= _maxPY &&
+      maxY >= _minPY;
+
+  double get estimatedVExtent => _slotData.length * (_maxCellH + 4);
+
+  void addGlyph(PdfPath outline, SlugGlyphData data, PdfMatrix emToPage,
+      double pxPerEmX, double pxPerEmY, int argb) {
+    final qsx = (pxPerEmX * 16).round().clamp(1, 0xFFFF);
+    final qsy = (pxPerEmY * 16).round().clamp(1, 0xFFFF);
+    final slot = _slots.putIfAbsent((outline, qsx, qsy), () {
+      _slotData.add(data);
+      _slotQsx.add(qsx);
+      _slotQsy.add(qsy);
+      return _slotData.length - 1;
+    });
+    final sx = qsx / 16.0, sy = qsy / 16.0;
+    final padX = 16.0 / qsx, padY = 16.0 / qsy;
+    final x0 = data.minX - padX, x1 = data.maxX + padX;
+    final y0 = data.minY - padY, y1 = data.maxY + padY;
+    final u0 = 2.0 + (x0 - data.qMinX) * sx;
+    final u1 = 2.0 + (x1 - data.qMinX) * sx;
+    final lv0 = 2.0 + (y0 - data.qMinY) * sy;
+    final lv1 = 2.0 + (y1 - data.qMinY) * sy;
+    if (lv1 > _maxCellH) _maxCellH = lv1;
+    final px0 = emToPage.transformX(x0, y0), py0 = emToPage.transformY(x0, y0);
+    final px1 = emToPage.transformX(x1, y0), py1 = emToPage.transformY(x1, y0);
+    final px2 = emToPage.transformX(x0, y1), py2 = emToPage.transformY(x0, y1);
+    final px3 = emToPage.transformX(x1, y1), py3 = emToPage.transformY(x1, y1);
+    _positions.add4(px0, py0, px1, py1);
+    _positions.add4(px2, py2, px3, py3);
+    _minPX = math.min(_minPX, math.min(math.min(px0, px1), math.min(px2, px3)));
+    _maxPX = math.max(_maxPX, math.max(math.max(px0, px1), math.max(px2, px3)));
+    _minPY = math.min(_minPY, math.min(math.min(py0, py1), math.min(py2, py3)));
+    _maxPY = math.max(_maxPY, math.max(math.max(py0, py1), math.max(py2, py3)));
+    _texs.add4(u0, lv0, u1, lv0);
+    _texs.add4(u0, lv1, u1, lv1);
+    _quadSlot.add(slot);
+    _colors.addAll([argb, argb, argb, argb]);
+    _quadCount++;
+  }
+
+  SlugBatchData? build([int flushOrdinal = 0]) {
+    if (_quadCount == 0) return null;
+    final slotCount = _slotData.length;
+    var total = 4 * slotCount;
+    final bases = Int32List(slotCount);
+    for (var i = 0; i < slotCount; i++) {
+      bases[i] = total;
+      total += _slotData[i].texelCount;
+    }
+    final height = math.max(1, (total + slugAtlasWidth - 1) ~/ slugAtlasWidth);
+    final pixels = Uint8List(slugAtlasWidth * height * 4);
+    final u16 = ByteData.sublistView(pixels);
+    void put(int texel, int lo, int hi) {
+      u16.setUint16(texel * 4, lo, Endian.little);
+      u16.setUint16(texel * 4 + 2, hi, Endian.little);
+    }
+
+    for (var i = 0; i < slotCount; i++) {
+      final d = _slotData[i];
+      final base = bases[i];
+      put(4 * i, base & 0xFFFF, base >> 16);
+      put(4 * i + 1, emToFixed(d.minY),
+          emToFixed((d.maxY - d.minY) / d.bandCount));
+      put(4 * i + 2, emToFixed(d.minX),
+          emToFixed((d.maxX - d.minX) / d.bandCount));
+      put(4 * i + 3, _slotQsx[i], _slotQsy[i]);
+      pixels.setRange(base * 4, base * 4 + d.stream!.length, d.stream!);
+    }
+
+    final positions = _positions.view;
+    final texs = _texs.view;
+    final cellH = (_maxCellH + 2).ceilToDouble();
+    for (var q = 0; q < _quadCount; q++) {
+      final vBase = _quadSlot[q] * cellH;
+      final t = q * 8;
+      texs[t + 1] += vBase;
+      texs[t + 3] += vBase;
+      texs[t + 5] += vBase;
+      texs[t + 7] += vBase;
+    }
+    final chunks = <SlugChunkData>[];
+    for (var start = 0; start < _quadCount; start += slugMaxQuadsPerDraw) {
+      final count = math.min(slugMaxQuadsPerDraw, _quadCount - start);
+      final pos = Float32List.fromList(
+          Float32List.sublistView(positions, start * 8, (start + count) * 8));
+      final tex = Float32List.fromList(
+          Float32List.sublistView(texs, start * 8, (start + count) * 8));
+      final colors =
+          Int32List.fromList(_colors.sublist(start * 4, (start + count) * 4));
+      final indices = Uint16List(count * 6);
+      for (var q = 0; q < count; q++) {
+        final v = q * 4, ix = q * 6;
+        indices[ix] = v;
+        indices[ix + 1] = v + 1;
+        indices[ix + 2] = v + 2;
+        indices[ix + 3] = v + 1;
+        indices[ix + 4] = v + 3;
+        indices[ix + 5] = v + 2;
+      }
+      chunks.add(SlugChunkData(pos, tex, colors, indices));
+    }
+    final batch = SlugBatchData(flushOrdinal, chunks, pixels, slugAtlasWidth,
+        height, _quadCount, cellH);
+    _slots.clear();
+    _slotData.clear();
+    _slotQsx.clear();
+    _slotQsy.clear();
+    _positions.clear();
+    _texs.clear();
+    _colors.clear();
+    _quadSlot.clear();
+    _maxCellH = 0;
+    _quadCount = 0;
+    _minPX = _minPY = double.infinity;
+    _maxPX = _maxPY = double.negativeInfinity;
+    return batch;
+  }
+}

--- a/packages/pdf_graphics/lib/src/raster/strip_plan.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_plan.dart
@@ -3,11 +3,14 @@
 // of a zoom re-bin because a worker isolate already did it. Pure Dart -
 // the plan crosses the isolate boundary as one Uint8List (a single
 // TransferableTypedData on native, postMessage-transferable on the web).
+import 'dart:math' as math;
 import 'dart:typed_data';
 
+import '../device.dart';
 import '../interpreter.dart' show PdfCancellationToken;
 import '../matrix.dart';
 import '../render_command.dart';
+import 'slug_batch_data.dart';
 import 'strip_batch_data.dart';
 import 'strip_binning_device.dart';
 
@@ -24,6 +27,11 @@ class StripPlan {
     required this.pageToDevice,
     required this.tolerance,
     required this.batches,
+    this.slugGlyphs = false,
+    this.slugBatches = const [],
+    this.slugQuadCount = 0,
+    this.slugFallbackOutlineRuns = 0,
+    this.slugFallbackOrdinals = const [],
   });
 
   /// Flush points the binning walk counted (empty ones included) - must
@@ -43,6 +51,13 @@ class StripPlan {
 
   /// Non-empty batches ordered by [StripBatchData.flushOrdinal].
   final List<StripBatchData> batches;
+
+  /// Whether outline text was routed into worker-built Slug batches.
+  final bool slugGlyphs;
+  final List<SlugBatchData> slugBatches;
+  final int slugQuadCount;
+  final int slugFallbackOutlineRuns;
+  final List<int> slugFallbackOrdinals;
 }
 
 /// Thrown when a [StripPlan] does not match the device consuming it
@@ -66,9 +81,18 @@ class StripPlanBinner extends StripBinningDevice {
     required super.deviceWidth,
     required super.deviceHeight,
     required super.pixelRatio,
+    this.slugGlyphs = false,
+    this.slugMinGlyphPx = 4,
   });
 
   final List<StripBatchData> batches = [];
+  final bool slugGlyphs;
+  final double slugMinGlyphPx;
+  final List<SlugBatchData> slugBatches = [];
+  SlugBatchBuilder? _slugBuilder;
+  int slugQuadCount = 0;
+  int slugFallbackOutlineRuns = 0;
+  final List<int> slugFallbackOrdinals = [];
   bool _finished = false;
 
   @override
@@ -97,7 +121,75 @@ class StripPlanBinner extends StripBinningDevice {
       pageToDevice: pageToDevice,
       tolerance: stripFlattenTolerance,
       batches: batches,
+      slugGlyphs: slugGlyphs,
+      slugBatches: slugBatches,
+      slugQuadCount: slugQuadCount,
+      slugFallbackOutlineRuns: slugFallbackOutlineRuns,
+      slugFallbackOrdinals: slugFallbackOrdinals,
     );
+  }
+
+  @override
+  void drawText(PdfTextRun run) {
+    final glyphs = run.glyphs;
+    if (!slugGlyphs ||
+        run.invisible ||
+        !stripsActive ||
+        delegateText ||
+        glyphs == null ||
+        !run.fill ||
+        run.strokeColor != null ||
+        run.gradient != null) {
+      super.drawText(run);
+      return;
+    }
+    flushPending();
+    if (!_addSlugRun(glyphs, run, stripArgbColor(run.color, 1))) {
+      slugFallbackOutlineRuns++;
+      slugFallbackOrdinals.add(flushPointCount - 1);
+      super.drawText(run);
+      return;
+    }
+    _flushSlug(flushPointCount - 1);
+  }
+
+  static const double _slugMaxVExtent = 8192;
+
+  bool _addSlugRun(List<PdfGlyphPlacement> glyphs, PdfTextRun run, int color) {
+    final deviceTransform = run.transform.concat(pageToDevice);
+    final sx = math.sqrt(deviceTransform.a * deviceTransform.a +
+        deviceTransform.b * deviceTransform.b);
+    final sy = math.sqrt(deviceTransform.c * deviceTransform.c +
+        deviceTransform.d * deviceTransform.d);
+    if (math.max(sx, sy) < slugMinGlyphPx) return false;
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline != null && SlugGlyphData.of(outline).overflow) return false;
+    }
+    final builder = _slugBuilder ??= SlugBatchBuilder();
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline == null) continue;
+      builder.addGlyph(
+          outline,
+          SlugGlyphData.of(outline),
+          PdfMatrix.translation(glyph.offset, glyph.offsetY)
+              .concat(run.transform),
+          sx,
+          sy,
+          color);
+    }
+    if (builder.estimatedVExtent > _slugMaxVExtent) {
+      _flushSlug(flushPointCount - 1);
+    }
+    return true;
+  }
+
+  void _flushSlug(int ordinal) {
+    final batch = _slugBuilder?.build(ordinal);
+    if (batch == null) return;
+    slugBatches.add(batch);
+    slugQuadCount += batch.quadCount;
   }
 
   // Delegated ops paint nothing here - the live device replays them from
@@ -149,6 +241,8 @@ class StripPlanBinner extends StripBinningDevice {
 //   u8  version
 //   u32 totalFlushPoints, u32 deviceWidth, u32 deviceHeight
 //   f64 x6 pageToDevice, f64 tolerance
+//   u8 slugGlyphs, u32 slugQuadCount, u32 slugFallbackOutlineRuns
+//   u32 slugFallbackOrdinalCount + ordinals
 //   u32 batchCount, then per batch:
 //     u32 flushOrdinal, u32 stripCount, u32 atlasWidth, u32 atlasHeight
 //     u32 atlasByteLength + raw atlas bytes
@@ -156,8 +250,12 @@ class StripPlanBinner extends StripBinningDevice {
 //       u32 quadCount, u32 alphaBase
 //       raw positions (quadCount*8 f32), texcoords (quadCount*8 f32),
 //           colors (quadCount*4 i32), indices (quadCount*6 u16)
+//   u32 slugBatchCount, then per batch:
+//     u32 flushOrdinal, u32 quadCount, u32 atlasWidth, u32 atlasHeight,
+//     f64 cellHeight, u32 atlasByteLength + raw atlas bytes
+//     u32 chunkCount, then per chunk: u32 quadCount + the same four arrays
 
-const int _planFormatVersion = 1;
+const int _planFormatVersion = 2;
 
 /// Telemetry: microseconds spent in [decodeStripPlan] (accumulated) - this
 /// runs on the consuming (UI) isolate, so it counts toward the residual
@@ -179,6 +277,13 @@ Uint8List encodeStripPlan(StripPlan plan) {
   w.f64(m.e);
   w.f64(m.f);
   w.f64(plan.tolerance);
+  w.u8(plan.slugGlyphs ? 1 : 0);
+  w.u32(plan.slugQuadCount);
+  w.u32(plan.slugFallbackOutlineRuns);
+  w.u32(plan.slugFallbackOrdinals.length);
+  for (final ordinal in plan.slugFallbackOrdinals) {
+    w.u32(ordinal);
+  }
   w.u32(plan.batches.length);
   for (final batch in plan.batches) {
     w.u32(batch.flushOrdinal);
@@ -191,6 +296,30 @@ Uint8List encodeStripPlan(StripPlan plan) {
       final quads = chunk.positions.length ~/ 8;
       w.u32(quads);
       w.u32(chunk.alphaBase);
+      w.rawView(chunk.positions.buffer, chunk.positions.offsetInBytes,
+          chunk.positions.lengthInBytes);
+      w.rawView(
+          chunk.textureCoordinates.buffer,
+          chunk.textureCoordinates.offsetInBytes,
+          chunk.textureCoordinates.lengthInBytes);
+      w.rawView(chunk.colors.buffer, chunk.colors.offsetInBytes,
+          chunk.colors.lengthInBytes);
+      w.rawView(chunk.indices.buffer, chunk.indices.offsetInBytes,
+          chunk.indices.lengthInBytes);
+    }
+  }
+  w.u32(plan.slugBatches.length);
+  for (final batch in plan.slugBatches) {
+    w.u32(batch.flushOrdinal);
+    w.u32(batch.quadCount);
+    w.u32(batch.atlasWidth);
+    w.u32(batch.atlasHeight);
+    w.f64(batch.cellHeight);
+    w.raw(batch.atlasPixels);
+    w.u32(batch.chunks.length);
+    for (final chunk in batch.chunks) {
+      final quads = chunk.positions.length ~/ 8;
+      w.u32(quads);
       w.rawView(chunk.positions.buffer, chunk.positions.offsetInBytes,
           chunk.positions.lengthInBytes);
       w.rawView(
@@ -222,6 +351,13 @@ StripPlan decodeStripPlan(Uint8List bytes) {
   final matrix =
       PdfMatrix(r.f64(), r.f64(), r.f64(), r.f64(), r.f64(), r.f64());
   final tolerance = r.f64();
+  final slugGlyphs = r.u8() != 0;
+  final slugQuadCount = r.u32();
+  final slugFallbackOutlineRuns = r.u32();
+  final slugFallbackOrdinalCount = r.u32();
+  final slugFallbackOrdinals = <int>[
+    for (var i = 0; i < slugFallbackOrdinalCount; i++) r.u32(),
+  ];
   final batchCount = r.u32();
   final batches = <StripBatchData>[];
   for (var i = 0; i < batchCount; i++) {
@@ -242,9 +378,31 @@ StripPlan decodeStripPlan(Uint8List bytes) {
         r.u16List(quads * 6),
       ));
     }
-    batches.add(StripBatchData.raw(
-        flushOrdinal, chunks, atlasPixels, atlasWidth, atlasHeight,
-        stripCount));
+    batches.add(StripBatchData.raw(flushOrdinal, chunks, atlasPixels,
+        atlasWidth, atlasHeight, stripCount));
+  }
+  final slugBatchCount = r.u32();
+  final slugBatches = <SlugBatchData>[];
+  for (var i = 0; i < slugBatchCount; i++) {
+    final flushOrdinal = r.u32();
+    final quadCount = r.u32();
+    final atlasWidth = r.u32();
+    final atlasHeight = r.u32();
+    final cellHeight = r.f64();
+    final atlasPixels = r.rawBytes();
+    final chunkCount = r.u32();
+    final chunks = <SlugChunkData>[];
+    for (var c = 0; c < chunkCount; c++) {
+      final quads = r.u32();
+      chunks.add(SlugChunkData(
+        r.f32List(quads * 8),
+        r.f32List(quads * 8),
+        r.i32List(quads * 4),
+        r.u16List(quads * 6),
+      ));
+    }
+    slugBatches.add(SlugBatchData(flushOrdinal, chunks, atlasPixels, atlasWidth,
+        atlasHeight, quadCount, cellHeight));
   }
   final plan = StripPlan(
     totalFlushPoints: totalFlushPoints,
@@ -253,6 +411,11 @@ StripPlan decodeStripPlan(Uint8List bytes) {
     pageToDevice: matrix,
     tolerance: tolerance,
     batches: batches,
+    slugGlyphs: slugGlyphs,
+    slugBatches: slugBatches,
+    slugQuadCount: slugQuadCount,
+    slugFallbackOutlineRuns: slugFallbackOutlineRuns,
+    slugFallbackOrdinals: slugFallbackOrdinals,
   );
   decodeStripPlanMicros += sw.elapsedMicroseconds;
   return plan;

--- a/packages/pdf_graphics/test/raster/strip_plan_test.dart
+++ b/packages/pdf_graphics/test/raster/strip_plan_test.dart
@@ -112,7 +112,8 @@ void main() {
     expect(b.delegatedPaintCount, 1);
   });
 
-  test('soft mask: content flushes at the boundary, mask strips land between '
+  test(
+      'soft mask: content flushes at the boundary, mask strips land between '
       'the composite halves', () {
     final b = binner();
     b.beginSoftMasked(); // flush 0 (empty)
@@ -153,8 +154,8 @@ void main() {
 
   test('two binners over one command list produce identical plans', () async {
     final commands = <PdfRenderCommand>[
-      PdfFillPathCommand(rect(2, 2, 30, 30), PdfColor.black,
-          PdfFillRule.nonzero, 1),
+      PdfFillPathCommand(
+          rect(2, 2, 30, 30), PdfColor.black, PdfFillRule.nonzero, 1),
       PdfStrokePathCommand(rect(8, 8, 24, 24), const PdfColor(1, 0, 0),
           const PdfStroke(width: 2), 0.8),
       PdfDrawImageCommand(dummyImage()),
@@ -170,6 +171,77 @@ void main() {
     expect(await run(), await run());
   });
 
+  test('Slug plan codec preserves painter-order curve batches', () async {
+    final b = StripPlanBinner(
+      pageToDevice: const PdfMatrix(2, 0, 0, -2, 0, 180),
+      deviceWidth: 200,
+      deviceHeight: 180,
+      pixelRatio: 2,
+      slugGlyphs: true,
+    );
+    b.drawText(PdfTextRun(
+      text: 'x',
+      transform: const PdfMatrix(20, 0, 0, 20, 8, 30),
+      color: PdfColor.black,
+      width: 0.5,
+      glyphs: [
+        PdfGlyphPlacement(offset: 0, outline: rect(0, 0, 0.5, 0.6)),
+      ],
+    ));
+    final plan = b.finish();
+    expect(plan.slugGlyphs, isTrue);
+    expect(plan.slugBatches, hasLength(1));
+    expect(plan.slugQuadCount, 1);
+    expect(plan.slugFallbackOutlineRuns, 0);
+    expect(plan.slugFallbackOrdinals, isEmpty);
+
+    final decoded = decodeStripPlan(encodeStripPlan(plan));
+    expect(decoded.slugGlyphs, isTrue);
+    expect(decoded.slugQuadCount, 1);
+    expect(decoded.slugFallbackOutlineRuns, 0);
+    expect(decoded.slugFallbackOrdinals, isEmpty);
+    expect(decoded.slugBatches.single.flushOrdinal,
+        plan.slugBatches.single.flushOrdinal);
+    expect(decoded.slugBatches.single.atlasPixels,
+        plan.slugBatches.single.atlasPixels);
+    expect(decoded.slugBatches.single.chunks.single.positions,
+        plan.slugBatches.single.chunks.single.positions);
+    expect(encodeStripPlan(decoded), encodeStripPlan(plan));
+  });
+
+  test('Slug plan distinguishes empty-success runs from true fallbacks', () {
+    final b = StripPlanBinner(
+      pageToDevice: const PdfMatrix(1, 0, 0, -1, 0, 100),
+      deviceWidth: 100,
+      deviceHeight: 100,
+      pixelRatio: 1,
+      slugGlyphs: true,
+    );
+    b.drawText(PdfTextRun(
+      text: ' ',
+      transform: const PdfMatrix(20, 0, 0, 20, 0, 20),
+      color: PdfColor.black,
+      width: 0.5,
+      glyphs: const [PdfGlyphPlacement(offset: 0)],
+    ));
+    b.drawText(PdfTextRun(
+      text: 'x',
+      transform: const PdfMatrix(2, 0, 0, 2, 0, 30),
+      color: PdfColor.black,
+      width: 0.5,
+      glyphs: [
+        PdfGlyphPlacement(offset: 0, outline: rect(0, 0, 0.5, 0.6)),
+      ],
+    ));
+    final plan = b.finish();
+    expect(plan.slugBatches, isEmpty);
+    expect(plan.slugFallbackOutlineRuns, 1);
+    expect(plan.slugFallbackOrdinals, [1],
+        reason: 'ordinal 0 is the eligible no-outline no-op');
+    expect(plan.batches.map((batch) => batch.flushOrdinal), [2],
+        reason: 'the minified fallback is binned into strips');
+  });
+
   test('cancellation token aborts the chunked replay', () async {
     final commands = <PdfRenderCommand>[
       for (var i = 0; i < 4000; i++)
@@ -181,8 +253,7 @@ void main() {
     // Flip the token from the event loop: the replay yields between chunks,
     // so the cancel lands mid-walk exactly like a worker's cancel port.
     Future<void>.delayed(Duration.zero, () => token.cancelled = true);
-    await expectLater(
-        b.bin(commands, cancellation: token),
+    await expectLater(b.bin(commands, cancellation: token),
         throwsA(isA<PdfCancelledException>()));
   });
 
@@ -226,8 +297,7 @@ void main() {
       for (var c = 0; c < a.chunks.length; c++) {
         expect(d.chunks[c].alphaBase, a.chunks[c].alphaBase);
         expect(d.chunks[c].positions, a.chunks[c].positions);
-        expect(d.chunks[c].textureCoordinates,
-            a.chunks[c].textureCoordinates);
+        expect(d.chunks[c].textureCoordinates, a.chunks[c].textureCoordinates);
         expect(d.chunks[c].colors, a.chunks[c].colors);
         expect(d.chunks[c].indices, a.chunks[c].indices);
       }


### PR DESCRIPTION
## Summary
- move Slug curve-atlas planning into pure-Dart transferable batches and carry them through native isolate + Web Worker strip plans
- let dense image-free pages keep one painter-order transform-time Slug picture without rebuilding curves on the browser UI thread
- encode explicit Slug fallback ordinals, preserve strip/Slug painter order, and fall back to the existing worker-planned raster path if a dense plan is declined
- cache resolved fragment programs instead of cross-zone Futures (fixes repeated viewer/test lifecycle hangs)
- add codec, worker bit-parity, raw-RGBA device parity, dense zoom-reuse, and corpus latency coverage

## Measurement
WAT_L0001_S.pdf page 0, cold software-Skia probe:
- 12,021 commands / 2,840 Slug quads / 0 fallbacks
- 6.12 MB transferable plan
- worker: 481.6 ms
- UI upload/replay: 58.7 ms
- excluded local build: 243.5 ms

## Validation
- fvm dart analyze
- full pdf_graphics suite
- full dart_pdf_editor suite: 1,362 passed, 25 skipped (local corpus enabled)
- focused worker/device/web Slug group
- example web release build, including successful skwasm dry run

Closes #227

The materially different image-bearing interleaved-layer work is tracked in #231.