### PR TITLE
Keep Slug pages sharp through deep-zoom pans

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -264,8 +264,10 @@ class PdfPageView extends StatefulWidget {
   /// worker-built Slug/strip plan and only upload/replay it on the UI thread;
   /// if the worker declines they keep the ordinary worker-planned strip
   /// raster path rather than binning Slug locally.
-  /// Image-bearing pages also stay raster-backed so the deep-zoom region patch
-  /// can continue replacing embedded images at their requested resolution.
+  /// Image-bearing pages keep the same complete painter-order picture. At a
+  /// capped deep zoom, a full-composite region raster supplies higher decode
+  /// resolution while stationary and is removed during the next live
+  /// transform so it cannot cover the sharp Slug base with stale raster text.
   static bool webSlugGlyphLayer = true;
 
   /// Test hook for [webSlugGlyphLayer]. Null uses [kIsWeb].
@@ -396,6 +398,12 @@ class _PdfPageViewState extends State<PdfPageView> {
       widget.transformChanges ?? widget.transformScale;
 
   void _onLiveTransformChanged() {
+    // A settled detail patch is a complete high-resolution raster composite.
+    // Drop it at the first live transform tick when a painter-order Slug
+    // picture sits underneath, so stale raster text cannot scale over and
+    // hide the transform-sharp glyphs during pinch/pan. The next settle
+    // rebuilds the complete detail composite for image resolution.
+    if (_slugPicture != null && _detailImage != null) _dropDetail();
     _speculateTimer?.cancel();
     _speculateTimer = Timer(_speculateDebounce, _speculateStripPlan);
   }
@@ -592,6 +600,8 @@ class _PdfPageViewState extends State<PdfPageView> {
   void _setScene(PdfRetainedScene? scene, {bool fromWorker = false}) {
     _scene?.dispose();
     _scene = scene;
+    _sceneHasImageDraws =
+        scene != null && PdfPageRenderer.hasImageDraws(scene.commands);
     _sceneFromWorker = scene != null && fromWorker;
     _slugPictureRejected = false;
     // a speculative bin's geometry was computed against the previous scene;
@@ -603,6 +613,12 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   /// Whether [_scene] came from the render worker (see [_setScene]).
   bool _sceneFromWorker = false;
+
+  /// Whether the retained command stream paints any PDF images.
+  ///
+  /// Cached at scene adoption so deep-zoom settles do not rescan a dense CAD
+  /// page's command list on every pan.
+  bool _sceneHasImageDraws = false;
 
   void _dropDetail() {
     _detailGeneration++;
@@ -783,7 +799,6 @@ class _PdfPageViewState extends State<PdfPageView> {
       PdfPageView.webSlugGlyphLayer &&
       (PdfPageView.debugWebSlugGlyphLayerBackendOverride ?? kIsWeb) &&
       scene.hasSlugTextCandidates &&
-      !PdfPageRenderer.hasImageDraws(scene.commands) &&
       (scene.commands.length <= PdfPageView.retainedZoomReplayMaxCommands ||
           _workerBinningEligible);
 
@@ -1044,6 +1059,10 @@ class _PdfPageViewState extends State<PdfPageView> {
                   widget.previewIndex, widget.page, picture,
                   rotation: widget.rotation));
             }
+            await _updateDetail();
+            if (_abandoned(pageIndex) || !identical(_scene, retainedScene)) {
+              return;
+            }
             widget.onRasterReady?.call();
             return;
           }
@@ -1053,7 +1072,10 @@ class _PdfPageViewState extends State<PdfPageView> {
         // picture will be painted under the new InteractiveViewer transform.
         _rasteredRatio = effective;
       }
-      if (_slugPicture != null) return;
+      if (_slugPicture != null) {
+        await _updateDetail();
+        return;
+      }
     }
     if (_slugPicture != null) {
       setState(() {
@@ -1131,6 +1153,17 @@ class _PdfPageViewState extends State<PdfPageView> {
   Future<bool> _updateDetail() async {
     final generation = ++_detailGeneration;
     if (_renderPaused) return false;
+
+    // A Slug page picture is already transform-sharp for text and vector
+    // content. Image-free pages therefore gain nothing from a deep-zoom
+    // raster patch: it only re-records the whole page in the worker, performs
+    // a GPU readback, and then scales stale pixels over the sharp picture
+    // during the next pan. Mixed pages still need the patch for sharper PDF
+    // images, so retain the normal path whenever the scene draws an image.
+    if (_slugPicture != null && !_sceneHasImageDraws) {
+      _dropDetail();
+      return true;
+    }
     final detailGeometry = _detailGeometryAt(widget.scale);
     if (detailGeometry == null) {
       _dropDetail();
@@ -1648,16 +1681,14 @@ class _PdfPageViewState extends State<PdfPageView> {
                     fit: BoxFit.contain,
                     filterQuality: FilterQuality.medium,
                   ),
-                if (slugPicture == null &&
-                    detail != null &&
-                    fraction != null &&
-                    w.isFinite)
+                if (detail != null && fraction != null && w.isFinite)
                   Positioned(
                     left: fraction.left * w,
                     top: fraction.top * h,
                     width: fraction.width * w,
                     height: fraction.height * h,
                     child: RawImage(
+                      key: const ValueKey('pdf-page-detail-image'),
                       image: detail,
                       fit: BoxFit.fill,
                       filterQuality: FilterQuality.medium,

--- a/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
@@ -1,0 +1,118 @@
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+Future<void> _waitFor(WidgetTester tester, Finder finder,
+    {String label = 'render'}) async {
+  for (var i = 0; i < 500; i++) {
+    await tester.pump();
+    final exception = tester.takeException();
+    if (exception != null) fail('$label failed: $exception');
+    if (finder.evaluate().isNotEmpty) return;
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+  }
+  fail('$label did not arrive');
+}
+
+void main() {
+  testWidgets('mixed Slug picture preserves image/text/vector painter order',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildEmbeddedFontImagePdf()).page(0);
+      final scene = await PdfRetainedScene.record(page);
+      addTearDown(scene.dispose);
+      expect(PdfPageRenderer.hasImageDraws(scene.commands), isTrue);
+      expect(scene.hasSlugTextCandidates, isTrue);
+
+      final picture = await scene.replayStrips(pixelRatio: 1, slugGlyphs: true);
+      final image = await picture.toImage(612, 792);
+      picture.dispose();
+      final pixels =
+          (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+              .buffer
+              .asUint8List();
+      image.dispose();
+      (int, int, int) rgb(int x, int y) {
+        final offset = (y * 612 + x) * 4;
+        return (pixels[offset], pixels[offset + 1], pixels[offset + 2]);
+      }
+
+      final imagePixel = rgb(60, 110);
+      expect(imagePixel.$3, greaterThan(imagePixel.$1),
+          reason: 'the pale-blue inline image must paint behind the text');
+      final glyphPixel = rgb(78, 80);
+      expect(glyphPixel.$1 + glyphPixel.$2 + glyphPixel.$3, lessThan(150),
+          reason: 'the embedded outline glyph must paint over the image');
+      final occluder = rgb(94, 80);
+      expect(occluder.$1, greaterThan(180));
+      expect(occluder.$2, lessThan(100));
+      expect(occluder.$3, lessThan(100),
+          reason: 'the later vector must still occlude Slug text');
+    });
+  });
+
+  testWidgets('detail raster yields to the mixed Slug base during live zoom',
+      (tester) async {
+    PdfPageView.webSlugGlyphLayer = true;
+    PdfPageView.debugWebSlugGlyphLayerBackendOverride = true;
+    addTearDown(() {
+      PdfPageView.webSlugGlyphLayer = true;
+      PdfPageView.debugWebSlugGlyphLayerBackendOverride = null;
+    });
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildEmbeddedFontImagePdf();
+    final page = PdfDocument.open(bytes).page(0);
+    final worker = PdfRenderWorker.startUncached(bytes);
+    final transform = ChangeNotifier();
+    addTearDown(worker.dispose);
+    addTearDown(transform.dispose);
+    Widget at(int settle) => Center(
+          child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+              page: page,
+              scale: 8,
+              settleGeneration: settle,
+              renderWorker: worker,
+              transformChanges: transform,
+            ),
+          ),
+        );
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(0));
+    final slug = find.byKey(const ValueKey('pdf-page-slug-picture'));
+    final detail = find.byKey(const ValueKey('pdf-page-detail-image'));
+    await _waitFor(tester, slug, label: 'mixed Slug picture');
+    await _waitFor(tester, detail, label: 'high-resolution detail');
+    final picture =
+        (tester.widget<CustomPaint>(slug).painter! as dynamic).picture;
+    final quads = StripPdfDevice.totalSlugQuads;
+
+    transform.notifyListeners();
+    await tester.pump();
+    expect(detail, findsNothing,
+        reason: 'stale raster text must not cover the sharp live base');
+    expect(slug, findsOneWidget);
+    expect(
+        identical(
+            (tester.widget<CustomPaint>(slug).painter! as dynamic).picture,
+            picture),
+        isTrue);
+
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pumpWidget(at(1));
+    await _waitFor(tester, detail, label: 'settled replacement detail');
+    expect(slug, findsOneWidget);
+    expect(StripPdfDevice.totalSlugQuads, quads,
+        reason: 'settles must reuse the transform-time Slug picture');
+  });
+}

--- a/packages/dart_pdf_editor/test/web_slug_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_page_test.dart
@@ -71,7 +71,9 @@ void main() {
         (tester.widget<CustomPaint>(slugFinder).painter! as dynamic).picture;
     final firstQuads = StripPdfDevice.totalSlugQuads;
 
-    await tester.pumpWidget(at(3));
+    await tester.pumpWidget(at(8));
+    await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 100)));
     await tester.pump();
     expect(slugFinder, findsOneWidget);
     final zoomPicture =
@@ -81,7 +83,7 @@ void main() {
     expect(StripPdfDevice.totalSlugQuads, firstQuads,
         reason: 'zoom must reuse the retained Slug picture without replaying');
     expect(find.byType(RawImage), findsNothing,
-        reason: 'zoom must not flatten the Slug layer into a new bitmap');
+        reason: 'an image-free Slug scene needs no deep-zoom raster patch');
   });
 
   testWidgets('substituted text keeps the cheaper raster path', (tester) async {

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -694,6 +694,57 @@ Uint8List buildEmbeddedFontPdf() {
   return out.takeBytes();
 }
 
+/// Embedded-font page with an inline RGB image behind the text and a solid
+/// vector rectangle painted after it. Exercises mixed image/Slug painter
+/// order: neither the image nor the later occluder may be lifted around text.
+Uint8List buildEmbeddedFontImagePdf() {
+  final font = buildTestTrueTypeFont();
+  const content = 'q 300 0 0 120 50 620 cm '
+      'BI /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 '
+      '/Filter /ASCIIHexDecode ID E0E8FF> EI Q '
+      'BT /F1 24 Tf 72 700 Td 0 0 0 rg (AB) Tj ET '
+      '0.9 0.2 0.2 rg 88 700 14 24 re f';
+  final bodies = <Uint8List>[
+    ascii('<< /Type /Catalog /Pages 2 0 R >>'),
+    ascii('<< /Type /Pages /Kids [3 0 R] /Count 1 >>'),
+    ascii('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>'),
+    ascii('<< /Length ${content.length} >>\nstream\n$content\nendstream'),
+    ascii('<< /Type /Font /Subtype /TrueType /BaseFont /TestFont '
+        '/FirstChar 65 /LastChar 66 /Widths [600 1000] '
+        '/Encoding /WinAnsiEncoding /FontDescriptor 7 0 R >>'),
+    (BytesBuilder()
+          ..add(ascii('<< /Length ${font.length} /Length1 ${font.length} >>'
+              '\nstream\n'))
+          ..add(font)
+          ..add(ascii('\nendstream')))
+        .takeBytes(),
+    ascii('<< /Type /FontDescriptor /FontName /TestFont /Flags 32 '
+        '/FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 '
+        '/Descent -200 /CapHeight 800 /StemV 80 /FontFile2 6 0 R >>'),
+  ];
+  final out = BytesBuilder()..add(ascii('%PDF-1.4\n'));
+  final offsets = <int>[];
+  for (var i = 0; i < bodies.length; i++) {
+    offsets.add(out.length);
+    out.add(ascii('${i + 1} 0 obj\n'));
+    out.add(bodies[i]);
+    out.add(ascii('\nendobj\n'));
+  }
+  final xrefOffset = out.length;
+  final buffer = StringBuffer()
+    ..write('xref\n0 ${bodies.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${bodies.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  out.add(ascii(buffer.toString()));
+  return out.takeBytes();
+}
+
 /// Builds a minimal CFF (Type1C) font: glyph 0 = .notdef, glyph 1 = an
 /// 800x800 square at the origin, mapped to character code 65 ('A') with
 /// advance width 660 (via nominalWidthX 600 + leading operand 60).


### PR DESCRIPTION
## Summary
- preserve painter order when Slug text shares a page with PDF images and later vector content
- drop stale mixed-page detail rasters during live transforms, then restore a complete high-resolution composite after settling
- skip deep-zoom detail rasterization entirely for image-free Slug pages, removing the worker re-record and GPU readback behind the ly9-far-cad.pdf page-90 delay

## Validation
- fvm dart analyze --fatal-infos
- fvm flutter test test/web_slug_page_test.dart test/web_slug_mixed_page_test.dart
- fvm flutter test (1,364 passed, 25 skipped)

Closes #231.