### PR TITLE
Move on-device OCR inference off the UI isolate

### DIFF
--- a/packages/pdf_ocr_ondevice/CHANGELOG.md
+++ b/packages/pdf_ocr_ondevice/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Run downloaded ONNX OCR models on a long-lived worker isolate by default.
+  Page RGBA buffers transfer without a structured-message copy, and model
+  loading, preprocessing, inference, and post-processing no longer block the
+  UI isolate.
+
 ## 1.4.0
 
 - Version bump to align with `dart_pdf_editor` 1.4.0. Runtime maintenance keeps

--- a/packages/pdf_ocr_ondevice/README.md
+++ b/packages/pdf_ocr_ondevice/README.md
@@ -180,7 +180,11 @@ final model = PdfOcrModel(
 
 `OnDeviceOcrEngine` reads the page raster into an `OcrImage`, runs an
 `OcrModelRunner`, and maps each recognized line's pixel box to PDF user space
-via `PdfOcrPageImage.userSpaceRect`. The default `OnnxOcrModelRunner`:
+via `PdfOcrPageImage.userSpaceRect`. Downloaded models use an
+`IsolateOcrModelRunner` by default. It transfers the RGBA page buffer to a
+long-lived worker isolate that owns and reuses the ONNX sessions, keeping
+resize, normalization, detection, recognition, and post-processing off the UI
+isolate. The wrapped `OnnxOcrModelRunner`:
 
 1. resizes the page for detection (longest side ≤ limit, multiples of 32) and
    normalizes it (`toNchwFloat32`);
@@ -192,6 +196,11 @@ via `PdfOcrPageImage.userSpaceRect`. The default `OnnxOcrModelRunner`:
    against the model's dictionary.
 
 Everything except the two `OrtSession.run` calls is plain Dart and unit tested.
+
+Pass `useWorkerIsolate: false` to `fromDownloadedModel` only when debugging the
+inference pipeline on the calling isolate. Custom `OcrModelRunner`
+implementations can opt into the same worker transport by wrapping an unloaded,
+isolate-sendable runner in `IsolateOcrModelRunner`.
 
 ### Custom backend
 

--- a/packages/pdf_ocr_ondevice/lib/pdf_ocr_ondevice.dart
+++ b/packages/pdf_ocr_ondevice/lib/pdf_ocr_ondevice.dart
@@ -24,6 +24,7 @@ library;
 
 export 'src/ctc_decode.dart';
 export 'src/db_postprocess.dart' show DetectedBox, extractDetectionBoxes;
+export 'src/isolate_ocr_model_runner.dart';
 export 'src/model_manager.dart';
 export 'src/ocr_image.dart';
 export 'src/ocr_model.dart';

--- a/packages/pdf_ocr_ondevice/lib/src/isolate_ocr_model_runner.dart
+++ b/packages/pdf_ocr_ondevice/lib/src/isolate_ocr_model_runner.dart
@@ -1,0 +1,289 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter/painting.dart';
+
+import 'ocr_image.dart';
+import 'ocr_model_runner.dart';
+
+/// Runs an unloaded, isolate-sendable [OcrModelRunner] on a long-lived worker
+/// isolate.
+///
+/// Page RGBA bytes cross the isolate boundary as [TransferableTypedData], so
+/// the large raster is transferred instead of copied through a structured
+/// message. The wrapped runner is loaded and retained by the worker: native
+/// sessions are created once, reused for every page, and released there by
+/// [dispose]. Only the small recognized-line result returns to the UI isolate.
+///
+/// The supplied [runner] must not have been loaded yet, and its configuration
+/// fields must be isolate-sendable. [OnnxOcrModelRunner] satisfies both rules.
+class IsolateOcrModelRunner implements OcrModelRunner {
+  IsolateOcrModelRunner(this.runner, {this.debugName = 'pdf-ocr-worker'});
+
+  /// The unloaded runner configuration copied into the worker at [load].
+  final OcrModelRunner runner;
+
+  /// Name shown by isolate-aware profiling tools.
+  final String debugName;
+
+  Isolate? _isolate;
+  ReceivePort? _responses;
+  ReceivePort? _errors;
+  ReceivePort? _exits;
+  StreamSubscription<Object?>? _responseSubscription;
+  StreamSubscription<Object?>? _errorSubscription;
+  StreamSubscription<Object?>? _exitSubscription;
+  SendPort? _commands;
+  Completer<SendPort>? _ready;
+  Completer<void>? _disposeReply;
+  final Map<int, Completer<List<RecognizedTextLine>>> _pending = {};
+  Future<void>? _loadFuture;
+  var _nextRequest = 0;
+  var _disposed = false;
+  var _expectedExit = false;
+
+  @override
+  Future<void> load() {
+    if (_disposed) {
+      return Future.error(
+        StateError('IsolateOcrModelRunner.load() after dispose()'),
+      );
+    }
+    return _loadFuture ??= _start();
+  }
+
+  Future<void> _start() async {
+    final responses = ReceivePort();
+    final errors = ReceivePort();
+    final exits = ReceivePort();
+    _responses = responses;
+    _errors = errors;
+    _exits = exits;
+    final ready = Completer<SendPort>();
+    _ready = ready;
+    _responseSubscription = responses.listen(_onResponse);
+    _errorSubscription = errors.listen(_onIsolateError);
+    _exitSubscription = exits.listen(_onIsolateExit);
+    try {
+      _isolate = await Isolate.spawn<(SendPort, OcrModelRunner)>(
+        _runOcrWorker,
+        (responses.sendPort, runner),
+        debugName: debugName,
+        errorsAreFatal: true,
+        onError: errors.sendPort,
+        onExit: exits.sendPort,
+      );
+      _commands = await ready.future;
+    } catch (_) {
+      await _closePorts(kill: true);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<RecognizedTextLine>> recognize(OcrImage image) async {
+    if (_disposed) {
+      throw StateError('IsolateOcrModelRunner.recognize() after dispose()');
+    }
+    await load();
+    final commands = _commands;
+    if (commands == null) throw StateError('OCR worker did not start');
+    final id = _nextRequest++;
+    final result = Completer<List<RecognizedTextLine>>();
+    _pending[id] = result;
+    commands.send([
+      'recognize',
+      id,
+      image.width,
+      image.height,
+      TransferableTypedData.fromList([image.rgba]),
+    ]);
+    return result.future;
+  }
+
+  void _onResponse(Object? raw) {
+    if (raw is! List || raw.isEmpty) return;
+    switch (raw[0]) {
+      case 'ready':
+        final port = raw.length > 1 ? raw[1] : null;
+        if (port is SendPort && !(_ready?.isCompleted ?? true)) {
+          _ready!.complete(port);
+        }
+      case 'result':
+        if (raw.length < 3 || raw[1] is! int) return;
+        final completer = _pending.remove(raw[1] as int);
+        if (completer == null) return;
+        try {
+          final rows = raw[2] as List;
+          completer.complete([
+            for (final value in rows)
+              if (value case final List row when row.length >= 6)
+                RecognizedTextLine(
+                  text: row[0] as String,
+                  pixelBounds: Rect.fromLTRB(
+                    (row[1] as num).toDouble(),
+                    (row[2] as num).toDouble(),
+                    (row[3] as num).toDouble(),
+                    (row[4] as num).toDouble(),
+                  ),
+                  confidence: (row[5] as num).toDouble(),
+                ),
+          ]);
+        } catch (error, stack) {
+          completer.completeError(error, stack);
+        }
+      case 'error':
+        if (raw.length < 3 || raw[1] is! int) return;
+        _pending.remove(raw[1] as int)?.completeError(
+              StateError('OCR worker failed: ${raw[2]}'),
+              raw.length > 3 ? StackTrace.fromString('${raw[3]}') : null,
+            );
+      case 'fatal':
+        final error = StateError(
+          'OCR worker failed to start: ${raw.length > 1 ? raw[1] : 'unknown error'}',
+        );
+        _fail(
+          error,
+          raw.length > 2 ? StackTrace.fromString('${raw[2]}') : null,
+        );
+      case 'disposed':
+        _expectedExit = true;
+        final reply = _disposeReply;
+        if (reply != null && !reply.isCompleted) reply.complete();
+    }
+  }
+
+  void _onIsolateError(Object? raw) {
+    final values = raw is List ? raw : const [];
+    final error = StateError(
+      'OCR worker isolate error: ${values.isNotEmpty ? values[0] : raw}',
+    );
+    _fail(
+      error,
+      values.length > 1 ? StackTrace.fromString('${values[1]}') : null,
+    );
+  }
+
+  void _onIsolateExit(Object? _) {
+    if (_expectedExit) return;
+    _fail(StateError('OCR worker exited unexpectedly'));
+  }
+
+  void _fail(Object error, [StackTrace? stack]) {
+    final ready = _ready;
+    if (ready != null && !ready.isCompleted) {
+      ready.completeError(error, stack);
+    }
+    for (final pending in _pending.values) {
+      if (!pending.isCompleted) pending.completeError(error, stack);
+    }
+    _pending.clear();
+    final disposeReply = _disposeReply;
+    if (disposeReply != null && !disposeReply.isCompleted) {
+      disposeReply.completeError(error, stack);
+    }
+    unawaited(_closePorts(kill: true));
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    final loadFuture = _loadFuture;
+    if (loadFuture == null) return;
+    try {
+      try {
+        await loadFuture;
+      } catch (_) {
+        // Loading already reported its original error to the caller. Dispose
+        // remains best-effort so a cleanup in `finally` cannot replace that
+        // failure with the same worker-start error a second time.
+        return;
+      }
+      final commands = _commands;
+      if (commands != null) {
+        final reply = Completer<void>();
+        _disposeReply = reply;
+        commands.send(const ['dispose']);
+        await reply.future;
+      }
+    } finally {
+      await _closePorts(kill: true);
+    }
+  }
+
+  Future<void> _closePorts({required bool kill}) async {
+    if (kill) _isolate?.kill(priority: Isolate.immediate);
+    _isolate = null;
+    _commands = null;
+    await _responseSubscription?.cancel();
+    await _errorSubscription?.cancel();
+    await _exitSubscription?.cancel();
+    _responseSubscription = null;
+    _errorSubscription = null;
+    _exitSubscription = null;
+    _responses?.close();
+    _errors?.close();
+    _exits?.close();
+    _responses = null;
+    _errors = null;
+    _exits = null;
+  }
+}
+
+Future<void> _runOcrWorker((SendPort, OcrModelRunner) bootstrap) async {
+  final (responses, runner) = bootstrap;
+  final commands = ReceivePort();
+  var runnerLoaded = false;
+  try {
+    await runner.load();
+    runnerLoaded = true;
+    responses.send(['ready', commands.sendPort]);
+    await for (final raw in commands) {
+      if (raw is! List || raw.isEmpty) continue;
+      if (raw[0] == 'dispose') {
+        await runner.dispose();
+        runnerLoaded = false;
+        responses.send(const ['disposed']);
+        break;
+      }
+      if (raw[0] != 'recognize' || raw.length < 5) continue;
+      final id = raw[1] as int;
+      try {
+        final bytes =
+            (raw[4] as TransferableTypedData).materialize().asUint8List();
+        final lines = await runner.recognize(
+          OcrImage(rgba: bytes, width: raw[2] as int, height: raw[3] as int),
+        );
+        responses.send([
+          'result',
+          id,
+          [
+            for (final line in lines)
+              [
+                line.text,
+                line.pixelBounds.left,
+                line.pixelBounds.top,
+                line.pixelBounds.right,
+                line.pixelBounds.bottom,
+                line.confidence,
+              ],
+          ],
+        ]);
+      } catch (error, stack) {
+        responses.send(['error', id, '$error', '$stack']);
+      }
+    }
+  } catch (error, stack) {
+    responses.send(['fatal', '$error', '$stack']);
+  } finally {
+    commands.close();
+    if (runnerLoaded) {
+      try {
+        await runner.dispose();
+      } catch (_) {
+        // Preserve the original worker failure; disposal is best-effort here.
+      }
+    }
+  }
+}

--- a/packages/pdf_ocr_ondevice/lib/src/ondevice_ocr_engine.dart
+++ b/packages/pdf_ocr_ondevice/lib/src/ondevice_ocr_engine.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_document/pdf_document.dart' show PdfOcrSpan;
 
+import 'isolate_ocr_model_runner.dart';
 import 'model_manager.dart';
 import 'ocr_image.dart';
 import 'ocr_model.dart';
@@ -35,14 +36,16 @@ class OnDeviceOcrEngine implements PdfOcrEngine {
 
   /// Builds an engine that runs [model] from files already downloaded by
   /// [manager] on ONNX Runtime. Throws [PdfOcrModelException] if the model is
-  /// not downloaded.
+  /// not downloaded. Inference runs on a long-lived worker isolate by default;
+  /// set [useWorkerIsolate] false only to debug it on the calling isolate.
   static Future<OnDeviceOcrEngine> fromDownloadedModel(
     PdfOcrModelManager manager,
     PdfOcrModel model, {
     double minConfidence = 0,
+    bool useWorkerIsolate = true,
   }) async {
     final files = await manager.localFiles(model);
-    final runner = OnnxOcrModelRunner(
+    final onnxRunner = OnnxOcrModelRunner(
       detectionModelPath: files[model.detection.name]!.path,
       recognitionModelPath: files[model.recognition.name]!.path,
       dictionaryPath: files[model.dictionary.name]!.path,
@@ -51,6 +54,9 @@ class OnDeviceOcrEngine implements PdfOcrEngine {
       detectionStd: model.detectionStd,
       recognitionImageHeight: model.recognitionImageHeight,
     );
+    final OcrModelRunner runner = useWorkerIsolate
+        ? IsolateOcrModelRunner(onnxRunner, debugName: 'pdf-ocr-${model.id}')
+        : onnxRunner;
     return OnDeviceOcrEngine(runner, minConfidence: minConfidence);
   }
 

--- a/packages/pdf_ocr_ondevice/test/isolate_ocr_model_runner_test.dart
+++ b/packages/pdf_ocr_ondevice/test/isolate_ocr_model_runner_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_ocr_ondevice/pdf_ocr_ondevice.dart';
+
+class _BusyRunner implements OcrModelRunner {
+  _BusyRunner({this.fail = false, this.failLoad = false});
+
+  final bool fail;
+  final bool failLoad;
+  var _loaded = false;
+  var _calls = 0;
+
+  @override
+  Future<void> load() async {
+    if (failLoad) throw StateError('synthetic load failure');
+    _loaded = true;
+  }
+
+  @override
+  Future<List<RecognizedTextLine>> recognize(OcrImage image) async {
+    if (!_loaded) throw StateError('not loaded');
+    final stopwatch = Stopwatch()..start();
+    while (stopwatch.elapsedMilliseconds < 120) {
+      // Deliberately occupy the isolate with representative synchronous
+      // pre/post-processing work. A root-isolate runner would starve timers.
+    }
+    if (fail) throw StateError('synthetic inference failure');
+    _calls++;
+    return [
+      RecognizedTextLine(
+        text: '${image.width}x${image.height} call $_calls',
+        pixelBounds: const Rect.fromLTWH(1, 2, 3, 4),
+        confidence: 0.75,
+      ),
+    ];
+  }
+
+  @override
+  Future<void> dispose() async => _loaded = false;
+}
+
+OcrImage _image() => OcrImage(
+      rgba: Uint8List.fromList([10, 20, 30, 255, 40, 50, 60, 255]),
+      width: 2,
+      height: 1,
+    );
+
+void main() {
+  test('keeps the calling isolate responsive during inference', () async {
+    final runner = IsolateOcrModelRunner(_BusyRunner());
+    addTearDown(runner.dispose);
+    await runner.load();
+
+    var ticks = 0;
+    final heartbeat = Timer.periodic(
+      const Duration(milliseconds: 5),
+      (_) => ticks++,
+    );
+    final lines = await runner.recognize(_image());
+    heartbeat.cancel();
+
+    expect(
+      ticks,
+      greaterThan(3),
+      reason: 'worker inference must not starve the caller event loop',
+    );
+    expect(lines.single.text, '2x1 call 1');
+    expect(lines.single.pixelBounds, const Rect.fromLTWH(1, 2, 3, 4));
+    expect(lines.single.confidence, 0.75);
+  });
+
+  test('loads once and reuses the worker-owned runner', () async {
+    final runner = IsolateOcrModelRunner(_BusyRunner());
+    addTearDown(runner.dispose);
+
+    await runner.load();
+    await runner.load();
+    expect((await runner.recognize(_image())).single.text, endsWith('call 1'));
+    expect((await runner.recognize(_image())).single.text, endsWith('call 2'));
+  });
+
+  test(
+    'returns inference failures without killing the worker protocol',
+    () async {
+      final runner = IsolateOcrModelRunner(_BusyRunner(fail: true));
+      addTearDown(runner.dispose);
+
+      await expectLater(
+        runner.recognize(_image()),
+        throwsA(
+          isA<StateError>().having(
+            (error) => '$error',
+            'message',
+            contains('synthetic inference failure'),
+          ),
+        ),
+      );
+      await expectLater(
+        runner.recognize(_image()),
+        throwsA(isA<StateError>()),
+        reason: 'a page-level error must not terminate the long-lived worker',
+      );
+    },
+  );
+
+  test('a load failure is reported once and dispose remains safe', () async {
+    final runner = IsolateOcrModelRunner(_BusyRunner(failLoad: true));
+
+    await expectLater(
+      runner.load(),
+      throwsA(
+        isA<StateError>().having(
+          (error) => '$error',
+          'message',
+          contains('synthetic load failure'),
+        ),
+      ),
+    );
+    await expectLater(runner.dispose(), completes);
+  });
+}

--- a/packages/pdf_ocr_ondevice/test/ondevice_ocr_engine_test.dart
+++ b/packages/pdf_ocr_ondevice/test/ondevice_ocr_engine_test.dart
@@ -3,6 +3,8 @@
 // space - proven here with a fake runner (no ONNX), so the engine + geometry
 // are covered without a model. applyOcr then turns the spans into an
 // invisible, selectable text layer.
+import 'dart:io';
+
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -34,6 +36,49 @@ class _FakeRunner implements OcrModelRunner {
 }
 
 void main() {
+  test('downloaded models use the isolate runner by default', () async {
+    final temp = Directory.systemTemp.createTempSync('pdf_ocr_worker_test');
+    addTearDown(() {
+      if (temp.existsSync()) temp.deleteSync(recursive: true);
+    });
+    final model = PdfOcrModel(
+      id: 'worker-test',
+      displayName: 'Worker test',
+      detection: PdfOcrModelFile(
+        name: 'det.onnx',
+        url: Uri.parse('https://example.test/det.onnx'),
+      ),
+      recognition: PdfOcrModelFile(
+        name: 'rec.onnx',
+        url: Uri.parse('https://example.test/rec.onnx'),
+      ),
+      dictionary: PdfOcrModelFile(
+        name: 'dict.txt',
+        url: Uri.parse('https://example.test/dict.txt'),
+      ),
+    );
+    final manager = PdfOcrModelManager(cacheRoot: () async => temp);
+    addTearDown(manager.close);
+    final directory = await manager.directory(model);
+    directory.createSync(recursive: true);
+    for (final file in model.files) {
+      File('${directory.path}/${file.name}').writeAsBytesSync([1]);
+    }
+
+    final workerEngine =
+        await OnDeviceOcrEngine.fromDownloadedModel(manager, model);
+    expect(workerEngine.runner, isA<IsolateOcrModelRunner>());
+    await workerEngine.dispose();
+
+    final localEngine = await OnDeviceOcrEngine.fromDownloadedModel(
+      manager,
+      model,
+      useWorkerIsolate: false,
+    );
+    expect(localEngine.runner, isA<OnnxOcrModelRunner>());
+    await localEngine.dispose();
+  });
+
   testWidgets('maps a pixel line box to user space and loads once',
       (tester) async {
     await tester.runAsync(() async {
@@ -72,19 +117,24 @@ void main() {
     });
   });
 
-  testWidgets('drops lines below minConfidence and empty text',
-      (tester) async {
+  testWidgets('drops lines below minConfidence and empty text', (tester) async {
     await tester.runAsync(() async {
       final doc = PdfDocument.open(buildClassicPdf());
       final image = await PdfPageRenderer.renderImage(doc.page(0));
       final engine = OnDeviceOcrEngine(
         _FakeRunner(const [
           RecognizedTextLine(
-              text: 'keep', pixelBounds: Rect.fromLTWH(10, 10, 40, 12), confidence: 0.8),
+              text: 'keep',
+              pixelBounds: Rect.fromLTWH(10, 10, 40, 12),
+              confidence: 0.8),
           RecognizedTextLine(
-              text: 'drop', pixelBounds: Rect.fromLTWH(10, 30, 40, 12), confidence: 0.2),
+              text: 'drop',
+              pixelBounds: Rect.fromLTWH(10, 30, 40, 12),
+              confidence: 0.2),
           RecognizedTextLine(
-              text: '   ', pixelBounds: Rect.fromLTWH(10, 50, 40, 12), confidence: 0.9),
+              text: '   ',
+              pixelBounds: Rect.fromLTWH(10, 50, 40, 12),
+              confidence: 0.9),
         ]),
         minConfidence: 0.5,
       );


### PR DESCRIPTION
## Summary
- add a long-lived `IsolateOcrModelRunner` that transfers page RGBA buffers with `TransferableTypedData`
- create, reuse, and dispose ONNX sessions on the worker, moving preprocessing, detection, recognition, and post-processing off the UI isolate
- use the worker runner by default for downloaded models, with an explicit debug opt-out
- preserve page-level error recovery and safe cleanup after model-load failures

## Validation
- `fvm dart analyze --fatal-infos`
- full `pdf_ocr_ondevice` suite: 36 passed
- app OCR menu/status tests: 7 passed
- responsiveness regression proves a 120 ms CPU-bound inference does not starve caller-isolate timers

Closes #93.