### PR TITLE
perf(web): cut visible CAD recording latency to ~1.9s

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -843,9 +843,17 @@ class _PdfPageViewState extends State<PdfPageView> {
   Future<void> _paintVectorFirst(int generation, int pageIndex) async {
     final worker = widget.renderWorker;
     if (worker == null || !worker.isActive) return;
+    // A zoomed, visible page's lightweight transcript is the prerequisite for
+    // its sharp region. Give it a clear lead over ordinary neighbouring-page
+    // work so it preempts the pool instead of being cancelled and requeued as
+    // the scheduler drains the cache window around it.
+    final visibleDetailRequested =
+        _detailGeometryAt(widget.scale, force: true, inflation: 0.125) != null;
     final commands = await worker.record(pageIndex,
         annotations: widget.showAnnotations,
-        priority: widget.renderPriority,
+        priority: visibleDetailRequested
+            ? widget.renderPriority - 100
+            : widget.renderPriority,
         decodeImages: false);
     if (_superseded(generation, pageIndex) ||
         _renderPaused ||
@@ -889,7 +897,7 @@ class _PdfPageViewState extends State<PdfPageView> {
         'commands=${commands.length}');
     if (needsDetail && _retainScene(commands.length)) {
       final scene = await PdfRetainedScene.fromCommands(widget.page, commands,
-          plan: _renderPlan);
+          plan: _renderPlan, includeImages: false);
       if (_superseded(generation, pageIndex) || _renderPaused) {
         scene.dispose();
         return;

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -255,7 +255,12 @@ Future<Uint8List?> _recordPageAsync(
   final recorder = RecordingPdfDevice();
   final interpreter =
       PdfInterpreter(cos: document.cos, device: recorder, cancellation: token);
-  await interpreter.drawPageOperationsAsync(page, ops);
+  // A browser zero-delay timer is commonly clamped to several milliseconds.
+  // Yielding every 512 operators therefore spends seconds in timers on dense
+  // CAD streams. 4096 keeps cancellation checks within a small frame while
+  // removing most of that artificial latency; native isolates retain the
+  // interpreter's more conservative default.
+  await interpreter.drawPageOperationsAsync(page, ops, yieldInterval: 4096);
   if (annotations) interpreter.drawAnnotations(page);
   var commands = recorder.commands;
   if (decodeImages) {

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -108,16 +108,22 @@ class PdfRetainedScene {
 
   /// Builds a scene from an already-recorded [commands] buffer (e.g. one a
   /// [PdfRenderWorker] shipped back), decoding its images once. The buffer
-  /// must have been recorded for [page] under [plan].
+  /// must have been recorded for [page] under [plan]. Set [includeImages] to
+  /// false for a deliberate vector-only progressive buffer; image draws then
+  /// stay transparent until a complete scene replaces it.
   static Future<PdfRetainedScene> fromCommands(
     PdfPage page,
     List<PdfRenderCommand> commands, {
     PdfPageRenderPlan plan = const PdfPageRenderPlan(),
+    bool includeImages = true,
   }) async {
-    final requests = <PdfImageRequest>[];
-    PdfPageRenderer.collectImageRequests(commands, requests);
-    final images = await decodeImages(page.document.cos, requests,
-        cache: PdfImageCache.instance);
+    final images = <Object, ui.Image>{};
+    if (includeImages) {
+      final requests = <PdfImageRequest>[];
+      PdfPageRenderer.collectImageRequests(commands, requests);
+      images.addAll(await decodeImages(page.document.cos, requests,
+          cache: PdfImageCache.instance));
+    }
     return PdfRetainedScene._(page, plan, commands, images);
   }
 

--- a/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
@@ -177,6 +177,8 @@ void main() {
     expect(worker.regionRecordReleased, isFalse,
         reason:
             'sharp vector detail must also beat the complete region record');
+    expect(worker.vectorRecordPriority, -100,
+        reason: 'visible detail must preempt ordinary neighbouring pages');
   });
 }
 
@@ -191,6 +193,7 @@ class _DeferredFullRecordWorker extends PdfRenderWorker {
   final _fullRecord = Completer<List<PdfRenderCommand>?>();
   final regionRecordStarted = Completer<void>();
   final _regionRecord = Completer<List<PdfRenderCommand>?>();
+  int? vectorRecordPriority;
 
   bool get fullRecordReleased => _fullRecord.isCompleted;
   bool get regionRecordReleased => _regionRecord.isCompleted;
@@ -214,6 +217,7 @@ class _DeferredFullRecordWorker extends PdfRenderWorker {
       if (!fullRecordStarted.isCompleted) fullRecordStarted.complete();
       return _fullRecord.future;
     }
+    vectorRecordPriority = priority;
     return _inner.record(pageIndex,
         annotations: annotations,
         priority: priority,

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -528,16 +528,22 @@ class PdfInterpreter {
   /// Used by the render worker's isolate/worker entrypoint: the synchronous
   /// [drawPageOperations] can't receive cancel messages mid-walk because Dart's
   /// event loop is blocked, so the async variant interleaves the walk with
-  /// micro-yields that let the port listener run.
+  /// micro-yields that let the port listener run. [yieldInterval] lets a
+  /// backend balance cancellation latency against its event-loop cost; browser
+  /// timers are substantially more expensive than native isolate yields.
   Future<void> drawPageOperationsAsync(
-      PdfPage page, List<ContentOperation> operations) async {
+      PdfPage page, List<ContentOperation> operations,
+      {int yieldInterval = _yieldInterval}) async {
+    if (yieldInterval <= 0) {
+      throw ArgumentError.value(yieldInterval, 'yieldInterval', 'must be > 0');
+    }
     _state = _GraphicsState();
     _visibilityStack.clear();
     _mcidStack.clear();
     _pageBox = page.mediaBox;
     device.save();
     try {
-      await _runAsync(operations, page.resources, 0);
+      await _runAsync(operations, page.resources, 0, yieldInterval);
       final mask = _state.softMask;
       if (mask != null) _finalizeSoftMask(mask);
     } finally {
@@ -1003,12 +1009,12 @@ class PdfInterpreter {
   }
 
   Future<void> _runAsync(List<ContentOperation> ops, CosDictionary resources,
-      int formDepth) async {
+      int formDepth, int yieldInterval) async {
     final previousDepth = _currentFormDepth;
     final previousVisibilityDepth = _visibilityStack.length;
     _currentFormDepth = formDepth;
     try {
-      await _runOpsAsync(ops, resources, formDepth);
+      await _runOpsAsync(ops, resources, formDepth, yieldInterval);
     } finally {
       while (_visibilityStack.length > previousVisibilityDepth) {
         _visibilityStack.removeLast();
@@ -1021,11 +1027,11 @@ class PdfInterpreter {
   }
 
   Future<void> _runOpsAsync(List<ContentOperation> ops, CosDictionary resources,
-      int formDepth) async {
+      int formDepth, int yieldInterval) async {
     final token = cancellation;
     var opCount = 0;
     for (final op in ops) {
-      if (++opCount % _yieldInterval == 0) {
+      if (++opCount % yieldInterval == 0) {
         await Future<void>.delayed(Duration.zero);
         if (token != null && token.cancelled) {
           throw const PdfCancelledException();

--- a/packages/pdf_graphics/test/interpreter_test.dart
+++ b/packages/pdf_graphics/test/interpreter_test.dart
@@ -1153,7 +1153,8 @@ void main() {
           reason: 'a cancelled walk stops before the full walk');
     });
 
-    test('drawPageOperationsAsync yields and checks the token', () async {
+    test('drawPageOperationsAsync configurable chunk yields and checks token',
+        () async {
       final bytes = heavyPdf();
       final doc = PdfDocument.open(bytes);
       final page = doc.page(0);
@@ -1170,7 +1171,7 @@ void main() {
       });
 
       await expectLater(
-        interp.drawPageOperationsAsync(page, ops),
+        interp.drawPageOperationsAsync(page, ops, yieldInterval: 1024),
         throwsA(isA<PdfCancelledException>()),
       );
     });


### PR DESCRIPTION
## Summary

Follow-up to #238 for the remaining high-zoom CAD latency.

- build the progressive retained scene without decoding image assets that the vector-first pass cannot paint
- make the interpreter's cooperative-yield interval configurable and use a browser-worker interval of 4096 operations
- prioritize the tightly visible zoomed-page transcript ahead of neighboring cache-window work
- keep the complete image-bearing region/full-page refinement running in the background

## Why

Profiling `ly9-far-cad.pdf` page 21 at about 170% showed that the worker spent roughly 3.8 seconds interpreting 329,366 operations despite only about 0.5 seconds of actual interpreter work. Browser timer clamping made the previous 512-operation cooperative yield occur hundreds of times.

The wider web interval retains cancellation checks every few milliseconds on this workload while avoiding that artificial delay.

## Result

Fresh web load, page 21, about 170%:

- before the performance work: about 12 seconds
- after #238: about 6 seconds
- this branch: about 1.9 seconds until visible CAD linework is sharp

The full image-bearing render continues to refine after the visible vector content is available.

## Validation

- `fvm dart analyze --fatal-infos`
- full `pdf_graphics` suite: 784 passed
- full `dart_pdf_editor` suite: 1,362 passed, 31 environment-gated skips
- post-rebase focused interpreter and mixed-Slug viewer tests
- live Chrome/web profile and visual check against `ly9-far-cad.pdf`
