### PR TITLE
perf(viewer): replay retained regions spatially

### DIFF
--- a/packages/dart_pdf_editor/example/lib/web_spatial_replay_benchmark.dart
+++ b/packages/dart_pdf_editor/example/lib/web_spatial_replay_benchmark.dart
@@ -1,0 +1,233 @@
+// Release Chrome A/B benchmark for #243. Run with
+// `bash tool/cad_web_spatial_replay_benchmark.sh` from the example directory.
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:web/web.dart' as web;
+
+const _cadUrl = String.fromEnvironment('CAD_PERF_URL');
+const _page = int.fromEnvironment('CAD_PERF_PAGE', defaultValue: 20);
+const _samples = int.fromEnvironment('CAD_PERF_SAMPLES', defaultValue: 5);
+final _ratio =
+    double.tryParse(const String.fromEnvironment('CAD_PERF_RATIO')) ?? 3.4;
+final _minSpeedup = double.tryParse(
+      const String.fromEnvironment('CAD_PERF_MIN_SPEEDUP'),
+    ) ??
+    1.15;
+final _maxCommandFraction = double.tryParse(
+      const String.fromEnvironment('CAD_PERF_MAX_COMMAND_FRACTION'),
+    ) ??
+    .70;
+
+void main() => runApp(const _BenchmarkApp());
+
+class _BenchmarkApp extends StatefulWidget {
+  const _BenchmarkApp();
+
+  @override
+  State<_BenchmarkApp> createState() => _BenchmarkAppState();
+}
+
+class _BenchmarkAppState extends State<_BenchmarkApp> {
+  String _status = 'Starting…';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => unawaited(_run()));
+  }
+
+  void _report(String value) {
+    // ignore: avoid_print
+    print('web-spatial-replay-benchmark: $value');
+    if (mounted) setState(() => _status = value);
+  }
+
+  Future<void> _run() async {
+    final previous = PdfRetainedScene.spatialRegionReplay;
+    PdfRenderWorker? worker;
+    PdfRetainedScene? scene;
+    try {
+      if (_cadUrl.isEmpty) throw StateError('CAD_PERF_URL is required');
+      if (_samples < 3) throw StateError('CAD_PERF_SAMPLES must be >= 3');
+      _report('loading $_cadUrl');
+      final response = await web.window.fetch(_cadUrl.toJS).toDart;
+      if (!response.ok) throw StateError('HTTP ${response.status}: $_cadUrl');
+      final bytes = (await response.arrayBuffer().toDart).toDart.asUint8List();
+      final document = PdfDocument.open(bytes);
+      final pageIndex = _page.clamp(0, document.pageCount - 1);
+      final page = document.page(pageIndex);
+      worker = PdfRenderWorker.startUncached(bytes);
+      final commands = await worker.record(
+        pageIndex,
+        annotations: true,
+        decodeImages: false,
+      );
+      if (commands == null) throw StateError('worker recording declined');
+      scene = await PdfRetainedScene.fromCommands(
+        page,
+        commands,
+        includeImages: false,
+      );
+      final size = scene.pageSize;
+      final regions = _panRegions(size, _samples + 1);
+
+      final buildClock = Stopwatch()..start();
+      final supported = scene.debugRegionReplaySupported;
+      buildClock.stop();
+      if (!supported) throw StateError('page is not spatial-index compatible');
+      final indexUnits = scene.debugRegionReplayUnitCount;
+      final indexBytes = scene.debugRegionReplayEstimatedBytes;
+
+      // Warm Skia/text caches in both modes on a region excluded from samples.
+      await _sample(scene, regions.first, false);
+      await _sample(scene, regions.first, true);
+
+      final full = <double>[];
+      final selective = <double>[];
+      final selectedCounts = <int>[];
+      for (var i = 0; i < _samples; i++) {
+        _report('sample ${i + 1}/$_samples');
+        final region = regions[i + 1];
+        if (i.isEven) {
+          full.add(await _sample(scene, region, false));
+          selective.add(await _sample(scene, region, true));
+          selectedCounts.add(scene.debugLastRegionReplayCommandCount);
+        } else {
+          selective.add(await _sample(scene, region, true));
+          selectedCounts.add(scene.debugLastRegionReplayCommandCount);
+          full.add(await _sample(scene, region, false));
+        }
+      }
+
+      // One byte-for-byte region comparison in the same release runtime.
+      final compareRegion = regions.last;
+      PdfRetainedScene.spatialRegionReplay = false;
+      final expected = await scene.rasterizeRegion(
+        compareRegion,
+        pixelRatio: _ratio,
+      );
+      PdfRetainedScene.spatialRegionReplay = true;
+      final actual = await scene.rasterizeRegion(
+        compareRegion,
+        pixelRatio: _ratio,
+      );
+      final expectedBytes =
+          await expected.toByteData(format: ui.ImageByteFormat.rawRgba);
+      final actualBytes =
+          await actual.toByteData(format: ui.ImageByteFormat.rawRgba);
+      final pixelEqual = _equalBytes(
+        expectedBytes!.buffer.asUint8List(),
+        actualBytes!.buffer.asUint8List(),
+      );
+      expected.dispose();
+      actual.dispose();
+
+      final fullP90 = _percentile(full, .9);
+      final selectiveP90 = _percentile(selective, .9);
+      final speedup = fullP90 / selectiveP90;
+      final worstSelected = selectedCounts.reduce(math.max);
+      final commandFraction = worstSelected / math.max(1, commands.length);
+      final result = 'page=${pageIndex + 1} ratio=$_ratio samples=$_samples\n'
+          'commands=${commands.length} units=$indexUnits '
+          'indexKB=${(indexBytes / 1024).toStringAsFixed(1)} '
+          'buildMs=${buildClock.elapsedMicroseconds / 1000}\n'
+          'full ms=${_list(full)} p90=${fullP90.toStringAsFixed(1)}\n'
+          'selective ms=${_list(selective)} p90=${selectiveP90.toStringAsFixed(1)}\n'
+          'selected=$selectedCounts worstFraction=${commandFraction.toStringAsFixed(3)}\n'
+          'p90 speedup=${speedup.toStringAsFixed(2)}x '
+          'reduction=${((1 - selectiveP90 / fullP90) * 100).toStringAsFixed(1)}%\n'
+          'pixelEqual=$pixelEqual';
+      await _publish('RESULT\n$result');
+      if (!pixelEqual) throw StateError('selective pixels differ');
+      if (speedup < _minSpeedup) {
+        throw StateError('speedup ${speedup.toStringAsFixed(2)}x is below '
+            'the ${_minSpeedup}x gate');
+      }
+      if (commandFraction > _maxCommandFraction) {
+        throw StateError(
+            'command fraction ${commandFraction.toStringAsFixed(3)} '
+            'exceeds the $_maxCommandFraction gate');
+      }
+      _report('PASS\n$result\nPress q in the terminal to stop.');
+    } catch (error, stack) {
+      await _publish('ERROR\n$error\n$stack');
+      _report('FAIL: $error');
+    } finally {
+      scene?.dispose();
+      worker?.dispose();
+      PdfRetainedScene.spatialRegionReplay = previous;
+    }
+  }
+
+  Future<double> _sample(
+    PdfRetainedScene scene,
+    ui.Rect region,
+    bool selective,
+  ) async {
+    PdfRetainedScene.spatialRegionReplay = selective;
+    final clock = Stopwatch()..start();
+    final image = await scene.rasterizeRegion(region, pixelRatio: _ratio);
+    await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+    image.dispose();
+    clock.stop();
+    return clock.elapsedMicroseconds / 1000;
+  }
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+        home: Scaffold(
+          backgroundColor: const Color(0xFF202124),
+          body: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Text(
+                'dart-pdf spatial replay benchmark\n\n$_status',
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.white, fontSize: 16),
+              ),
+            ),
+          ),
+        ),
+      );
+}
+
+Future<void> _publish(String result) async {
+  final endpoint = Uri.parse(_cadUrl).resolve(
+    '/__cad_web_spatial_replay_benchmark__?result=${Uri.encodeQueryComponent(result)}',
+  );
+  await web.window.fetch(endpoint.toString().toJS).toDart;
+}
+
+List<ui.Rect> _panRegions(ui.Size size, int count) {
+  final width = size.width * .44;
+  final height = size.height * .44;
+  final maxLeft = math.max(0.0, size.width - width);
+  final maxTop = math.max(0.0, size.height - height);
+  return List.generate(count, (i) {
+    final t = count == 1 ? 0.0 : i / (count - 1);
+    final y = (.5 + .5 * math.sin(t * math.pi * 2)) * maxTop;
+    return ui.Rect.fromLTWH(t * maxLeft, y, width, height);
+  });
+}
+
+double _percentile(List<double> values, double p) {
+  final sorted = [...values]..sort();
+  return sorted[((sorted.length - 1) * p).ceil()];
+}
+
+String _list(List<double> values) =>
+    '[${values.map((value) => value.toStringAsFixed(1)).join(', ')}]';
+
+bool _equalBytes(List<int> a, List<int> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/dart_pdf_editor/example/tool/cad_web_spatial_replay_benchmark.sh
+++ b/packages/dart_pdf_editor/example/tool/cad_web_spatial_replay_benchmark.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Release Chrome A/B for #243. Keeps the local CAD corpus out of git.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ROOT=../../..
+PDF="$ROOT/corpus/ly9-far-cad.pdf"
+PORT=${CAD_PERF_PORT:-8770}
+[[ -f "$PDF" ]] || { echo "missing $PDF" >&2; exit 1; }
+
+if [[ "${CAD_PERF_SKIP_WORKER_BUILD:-0}" != "1" ]]; then
+  fvm dart run dart_pdf_editor:build_web_worker \
+    --out ../assets/web/pdf_render_worker.dart.js
+fi
+
+python3 - "$ROOT/corpus" "$PORT" <<'PY' &
+import http.server, os, socketserver, sys, urllib.parse
+root, port = sys.argv[1], int(sys.argv[2])
+os.chdir(root)
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path == '/__cad_web_spatial_replay_benchmark__':
+            result = urllib.parse.parse_qs(parsed.query).get('result', [''])[0]
+            print('\nCAD_WEB_SPATIAL_REPLAY_BENCHMARK_' + result, flush=True)
+            self.send_response(204); self.end_headers(); return
+        super().do_GET()
+    def end_headers(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        super().end_headers()
+with socketserver.TCPServer(('127.0.0.1', port), Handler) as server:
+    server.serve_forever()
+PY
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+fvm flutter run -d chrome --release -t lib/web_spatial_replay_benchmark.dart \
+  --dart-define="CAD_PERF_URL=http://127.0.0.1:$PORT/ly9-far-cad.pdf" \
+  --dart-define="CAD_PERF_PAGE=${CAD_PERF_PAGE:-20}" \
+  --dart-define="CAD_PERF_RATIO=${CAD_PERF_RATIO:-3.4}" \
+  --dart-define="CAD_PERF_SAMPLES=${CAD_PERF_SAMPLES:-5}" \
+  --dart-define="CAD_PERF_MIN_SPEEDUP=${CAD_PERF_MIN_SPEEDUP:-1.15}" \
+  --dart-define="CAD_PERF_MAX_COMMAND_FRACTION=${CAD_PERF_MAX_COMMAND_FRACTION:-0.70}"

--- a/packages/dart_pdf_editor/lib/src/region_replay_index.dart
+++ b/packages/dart_pdf_editor/lib/src/region_replay_index.dart
@@ -1,0 +1,355 @@
+import 'dart:math' as math;
+
+import 'package:flutter/painting.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+/// Bounded, painter-order-preserving index for retained region replay.
+///
+/// Each entry is one independent paint operation plus a persistent snapshot
+/// of the clips and blend mode active at that point in the command stream.
+/// Transparency/soft-mask groups remain on the full-replay path: splitting a
+/// group would change its isolated compositing semantics.
+class PdfRegionReplayIndex {
+  PdfRegionReplayIndex._({
+    required this.supported,
+    required this.units,
+    required this.clipNodeCount,
+  });
+
+  factory PdfRegionReplayIndex.build(
+    List<PdfRenderCommand> commands, {
+    required int maxCommands,
+    int maxStateDepth = 128,
+  }) {
+    if (commands.length > maxCommands) {
+      return PdfRegionReplayIndex._(
+        supported: false,
+        units: const [],
+        clipNodeCount: 0,
+      );
+    }
+
+    final units = <PdfRegionReplayUnit>[];
+    final savedClips = <PdfRegionClipState?>[];
+    PdfRegionClipState? clips;
+    var blendMode = PdfBlendMode.normal;
+    var clipNodes = 0;
+
+    for (var i = 0; i < commands.length; i++) {
+      final command = commands[i];
+      switch (command) {
+        case PdfSaveCommand():
+          if (savedClips.length >= maxStateDepth) {
+            return PdfRegionReplayIndex._(
+              supported: false,
+              units: const [],
+              clipNodeCount: clipNodes,
+            );
+          }
+          savedClips.add(clips);
+        case PdfRestoreCommand():
+          if (savedClips.isEmpty) {
+            return PdfRegionReplayIndex._(
+              supported: false,
+              units: const [],
+              clipNodeCount: clipNodes,
+            );
+          }
+          clips = savedClips.removeLast();
+        case PdfClipPathCommand(:final path):
+          final bounds = pdfRenderPathBounds(path);
+          clips = PdfRegionClipState(
+            parent: clips,
+            command: command,
+            aggregateBounds: _clipIntersection(clips, bounds),
+            empty: (clips?.empty ?? false) ||
+                bounds == null ||
+                (clips?.aggregateBounds != null &&
+                    !_intersects(clips!.aggregateBounds!, bounds)),
+          );
+          clipNodes++;
+        case PdfSetBlendModeCommand(:final mode):
+          blendMode = mode;
+        case PdfBeginGroupCommand() ||
+              PdfEndGroupCommand() ||
+              PdfBeginSoftMaskedCommand() ||
+              PdfEndSoftMaskedCommand():
+          return PdfRegionReplayIndex._(
+            supported: false,
+            units: const [],
+            clipNodeCount: clipNodes,
+          );
+        default:
+          if (clips?.empty ?? false) continue;
+          var bounds = pdfRenderCommandBounds(command);
+          if (bounds == null) continue;
+          // Raster coverage and filtered image edges can extend just beyond
+          // mathematical geometry. Two page points conservatively cover a
+          // device pixel even below 1 px/pt while remaining highly selective.
+          bounds = _inflate(bounds, 2);
+          final clipBounds = clips?.aggregateBounds;
+          if (clipBounds != null) {
+            bounds = _intersection(bounds, clipBounds);
+            if (bounds == null) continue;
+          }
+          units.add(PdfRegionReplayUnit(
+            commandIndex: i,
+            bounds: bounds,
+            clips: clips,
+            blendMode: blendMode,
+          ));
+      }
+    }
+    if (savedClips.isNotEmpty) {
+      return PdfRegionReplayIndex._(
+        supported: false,
+        units: const [],
+        clipNodeCount: clipNodes,
+      );
+    }
+    return PdfRegionReplayIndex._(
+      supported: true,
+      units: List.unmodifiable(units),
+      clipNodeCount: clipNodes,
+    );
+  }
+
+  final bool supported;
+  final List<PdfRegionReplayUnit> units;
+  final int clipNodeCount;
+
+  /// Conservative retained-index estimate. The command geometry itself is
+  /// borrowed from the scene and is not counted twice.
+  int get estimatedBytes => units.length * 48 + clipNodeCount * 40;
+
+  /// Replays intersecting units in their original painter order.
+  int replay(
+    PdfRect region,
+    List<PdfRenderCommand> commands,
+    PdfDevice device,
+    Canvas canvas,
+  ) {
+    var replayed = 0;
+    for (final unit in units) {
+      if (!_intersects(unit.bounds, region)) continue;
+      canvas.save();
+      device.setBlendMode(unit.blendMode);
+      unit.clips?.replay(device);
+      replayCommands(
+        commands,
+        device,
+        start: unit.commandIndex,
+        end: unit.commandIndex + 1,
+      );
+      canvas.restore();
+      replayed++;
+    }
+    return replayed;
+  }
+}
+
+class PdfRegionReplayUnit {
+  const PdfRegionReplayUnit({
+    required this.commandIndex,
+    required this.bounds,
+    required this.clips,
+    required this.blendMode,
+  });
+
+  final int commandIndex;
+  final PdfRect bounds;
+  final PdfRegionClipState? clips;
+  final PdfBlendMode blendMode;
+}
+
+class PdfRegionClipState {
+  const PdfRegionClipState({
+    required this.parent,
+    required this.command,
+    required this.aggregateBounds,
+    required this.empty,
+  });
+
+  final PdfRegionClipState? parent;
+  final PdfClipPathCommand command;
+  final PdfRect? aggregateBounds;
+  final bool empty;
+
+  void replay(PdfDevice device) {
+    parent?.replay(device);
+    device.clipPath(command.path, command.rule);
+  }
+}
+
+PdfRect? pdfRenderCommandBounds(PdfRenderCommand command) {
+  switch (command) {
+    case PdfFillPathCommand(:final path) ||
+          PdfFillPathGradientCommand(:final path):
+      return pdfRenderPathBounds(path);
+    case PdfStrokePathCommand(:final path, :final stroke):
+      final bounds = pdfRenderPathBounds(path);
+      if (bounds == null) return null;
+      final joinScale = stroke.join == 0 ? math.max(1.0, stroke.miterLimit) : 1;
+      final radius = math.max(.5, stroke.width.abs() * .5 * joinScale);
+      return _inflate(bounds, radius);
+    case PdfFillMeshCommand(:final mesh):
+      if (mesh.vertices.isEmpty) return null;
+      var left = mesh.vertices.first.x;
+      var right = left;
+      var bottom = mesh.vertices.first.y;
+      var top = bottom;
+      for (final vertex in mesh.vertices.skip(1)) {
+        left = math.min(left, vertex.x);
+        right = math.max(right, vertex.x);
+        bottom = math.min(bottom, vertex.y);
+        top = math.max(top, vertex.y);
+      }
+      return PdfRect(left, bottom, right, top);
+    case PdfDrawTextCommand(:final run):
+      var bounds = _textBounds(run);
+      if (bounds == null) return null;
+      if (run.strokeColor != null) {
+        bounds = _inflate(bounds, math.max(.5, run.strokeWidth.abs() * .5));
+      }
+      return bounds;
+    case PdfDrawImageCommand(:final request):
+      return _matrixBounds(request.transform, 0, 0, 1, 1);
+    case PdfSaveCommand() ||
+          PdfRestoreCommand() ||
+          PdfClipPathCommand() ||
+          PdfSetBlendModeCommand() ||
+          PdfBeginGroupCommand() ||
+          PdfEndGroupCommand() ||
+          PdfBeginSoftMaskedCommand() ||
+          PdfEndSoftMaskedCommand():
+      return null;
+  }
+}
+
+PdfRect? _textBounds(PdfTextRun run) {
+  if (run.invisible) return null;
+  final glyphs = run.glyphs;
+  if (glyphs != null) {
+    PdfRect? out;
+    for (final glyph in glyphs) {
+      final outline = glyph.outline;
+      if (outline == null) continue;
+      final bounds = pdfRenderPathBounds(outline);
+      if (bounds == null) continue;
+      final mapped = _matrixBounds(
+        run.transform,
+        bounds.left + glyph.offset,
+        bounds.bottom + glyph.offsetY,
+        bounds.right + glyph.offset,
+        bounds.top + glyph.offsetY,
+      );
+      out = out == null ? mapped : _union(out, mapped);
+    }
+    // CanvasPdfDevice deliberately draws no substitute when a real glyph list
+    // exists but contains only blank/unavailable outlines.
+    return out;
+  }
+  if (run.text.isEmpty) return null;
+  // Deliberately wider than the extractor's conventional -.25..+.75 em:
+  // platform substitute fonts can carry accents, descenders, and bearings
+  // outside the nominal advance. A full em of horizontal and two em of
+  // vertical headroom is conservative for the system-font fallback.
+  return _matrixBounds(
+    run.transform,
+    math.min(-1, run.width - 1),
+    -2,
+    math.max(1, run.width + 1),
+    2,
+  );
+}
+
+PdfRect? pdfRenderPathBounds(PdfPath path) {
+  double? left, right, bottom, top;
+  void include(double x, double y) {
+    left = left == null ? x : math.min(left!, x);
+    right = right == null ? x : math.max(right!, x);
+    bottom = bottom == null ? y : math.min(bottom!, y);
+    top = top == null ? y : math.max(top!, y);
+  }
+
+  for (final segment in path.segments) {
+    switch (segment) {
+      case PdfMoveTo(:final x, :final y) || PdfLineTo(:final x, :final y):
+        include(x, y);
+      case PdfCubicTo(
+          :final x1,
+          :final y1,
+          :final x2,
+          :final y2,
+          :final x3,
+          :final y3
+        ):
+        // A cubic lies inside the convex hull of its endpoints/control points.
+        include(x1, y1);
+        include(x2, y2);
+        include(x3, y3);
+      case PdfClosePath():
+        break;
+    }
+  }
+  if (left == null) return null;
+  return PdfRect(left!, bottom!, right!, top!);
+}
+
+PdfRect _matrixBounds(
+  PdfMatrix matrix,
+  double left,
+  double bottom,
+  double right,
+  double top,
+) {
+  final points = <(double, double)>[
+    (matrix.transformX(left, bottom), matrix.transformY(left, bottom)),
+    (matrix.transformX(right, bottom), matrix.transformY(right, bottom)),
+    (matrix.transformX(right, top), matrix.transformY(right, top)),
+    (matrix.transformX(left, top), matrix.transformY(left, top)),
+  ];
+  return PdfRect(
+    points.map((point) => point.$1).reduce(math.min),
+    points.map((point) => point.$2).reduce(math.min),
+    points.map((point) => point.$1).reduce(math.max),
+    points.map((point) => point.$2).reduce(math.max),
+  );
+}
+
+PdfRect _inflate(PdfRect rect, double amount) => PdfRect(
+      rect.left - amount,
+      rect.bottom - amount,
+      rect.right + amount,
+      rect.top + amount,
+    );
+
+PdfRect? _clipIntersection(PdfRegionClipState? parent, PdfRect? next) {
+  if (parent?.empty ?? false) return null;
+  if (next == null) return null;
+  final existing = parent?.aggregateBounds;
+  return existing == null ? next : _intersection(existing, next);
+}
+
+PdfRect? _intersection(PdfRect a, PdfRect b) {
+  final left = math.max(a.left, b.left);
+  final bottom = math.max(a.bottom, b.bottom);
+  final right = math.min(a.right, b.right);
+  final top = math.min(a.top, b.top);
+  if (right < left || top < bottom) return null;
+  return PdfRect(left, bottom, right, top);
+}
+
+PdfRect _union(PdfRect a, PdfRect b) => PdfRect(
+      math.min(a.left, b.left),
+      math.min(a.bottom, b.bottom),
+      math.max(a.right, b.right),
+      math.max(a.top, b.top),
+    );
+
+bool _intersects(PdfRect a, PdfRect b) =>
+    a.right >= b.left &&
+    a.left <= b.right &&
+    a.top >= b.bottom &&
+    a.bottom <= b.top;

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -13,6 +13,7 @@
 /// runs after [record] returns.
 library;
 
+import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/painting.dart';
@@ -23,6 +24,7 @@ import 'canvas_device.dart';
 import 'image_decoder.dart';
 import 'renderer.dart';
 import 'render_worker.dart';
+import 'region_replay_index.dart';
 import 'strips/strip_device.dart';
 
 /// A page retained as a replayable scene: the recorded interpreter command
@@ -48,6 +50,26 @@ class PdfRetainedScene {
 
   /// The interpreter's transcript of the page, in paint order.
   final List<PdfRenderCommand> commands;
+
+  /// Enables the bounded selective path for ordinary retained region replay.
+  /// Unsupported command groups conservatively use the full transcript.
+  static bool spatialRegionReplay = true;
+
+  /// Hard construction bound for the spatial index. Larger transcripts keep
+  /// the historical full replay rather than retaining unbounded metadata.
+  static int spatialRegionReplayMaxCommands = 250000;
+
+  PdfRegionReplayIndex? _regionIndex;
+
+  /// Test/diagnostic counters for the most recent [replayRegion].
+  bool debugLastRegionReplayWasSelective = false;
+  int debugLastRegionReplayCommandCount = 0;
+
+  int get debugRegionReplayUnitCount => _ensureRegionIndex().units.length;
+  int get debugRegionReplayEstimatedBytes =>
+      _ensureRegionIndex().estimatedBytes;
+  bool get debugRegionReplaySupported => _ensureRegionIndex().supported;
+  bool get debugHasRegionReplayIndex => _regionIndex != null;
 
   /// Whether the transcript contains embedded-outline text that can benefit
   /// from the web Slug picture. Base-14/substituted text has no glyph
@@ -155,7 +177,7 @@ class PdfRetainedScene {
     final canvas = Canvas(recorder)
       ..scale(pixelRatio)
       ..translate(-region.left, -region.top);
-    _replayOnto(canvas);
+    _replayOnto(canvas, rasterRegion: region);
     return recorder.endRecording();
   }
 
@@ -189,9 +211,68 @@ class PdfRetainedScene {
     }
   }
 
-  void _replayOnto(Canvas canvas) {
+  void _replayOnto(Canvas canvas, {Rect? rasterRegion}) {
     PdfPageRenderer.preparePageCanvas(canvas, page, plan);
-    replayCommands(commands, CanvasPdfDevice(canvas, images: _images));
+    final device = CanvasPdfDevice(canvas, images: _images);
+    if (rasterRegion != null && spatialRegionReplay) {
+      final index = _ensureRegionIndex();
+      final pageRegion = _pageSpaceRegion(rasterRegion);
+      if (index.supported && pageRegion != null) {
+        debugLastRegionReplayWasSelective = true;
+        debugLastRegionReplayCommandCount =
+            index.replay(pageRegion, commands, device, canvas);
+        return;
+      }
+    }
+    debugLastRegionReplayWasSelective = false;
+    debugLastRegionReplayCommandCount = commands.length;
+    replayCommands(commands, device);
+  }
+
+  PdfRegionReplayIndex _ensureRegionIndex() =>
+      _regionIndex ??= PdfRegionReplayIndex.build(
+        commands,
+        maxCommands: spatialRegionReplayMaxCommands,
+      );
+
+  PdfRect? _pageSpaceRegion(Rect region) {
+    final inverse = PdfPageRenderer.pageToDeviceMatrix(
+      page,
+      pageSize,
+      page.cropBox,
+      rotation: plan.rotation,
+      pixelRatio: 1,
+    ).inverted();
+    if (inverse == null) return null;
+    final points = <(double, double)>[
+      (
+        inverse.transformX(region.left, region.top),
+        inverse.transformY(region.left, region.top)
+      ),
+      (
+        inverse.transformX(region.right, region.top),
+        inverse.transformY(region.right, region.top)
+      ),
+      (
+        inverse.transformX(region.right, region.bottom),
+        inverse.transformY(region.right, region.bottom)
+      ),
+      (
+        inverse.transformX(region.left, region.bottom),
+        inverse.transformY(region.left, region.bottom)
+      ),
+    ];
+    var left = points.first.$1;
+    var right = left;
+    var bottom = points.first.$2;
+    var top = bottom;
+    for (final point in points.skip(1)) {
+      left = math.min(left, point.$1);
+      right = math.max(right, point.$1);
+      bottom = math.min(bottom, point.$2);
+      top = math.max(top, point.$2);
+    }
+    return PdfRect(left, bottom, right, top);
   }
 
   /// The strip device geometry a full-page strip replay at [pixelRatio]
@@ -373,6 +454,7 @@ class PdfRetainedScene {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _regionIndex = null;
     for (final image in _images.values) {
       image.dispose();
     }

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -10,6 +10,7 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 Future<ByteData> _bytes(ui.Image image) async =>
@@ -68,4 +69,154 @@ void main() {
       picture.dispose();
     });
   });
+
+  testWidgets(
+      'region replay selects paints, preserves clips, and stays bounded',
+      (tester) async {
+    await tester.runAsync(() async {
+      final previousEnabled = PdfRetainedScene.spatialRegionReplay;
+      final previousMax = PdfRetainedScene.spatialRegionReplayMaxCommands;
+      addTearDown(() {
+        PdfRetainedScene.spatialRegionReplay = previousEnabled;
+        PdfRetainedScene.spatialRegionReplayMaxCommands = previousMax;
+      });
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final commands = <PdfRenderCommand>[
+        const PdfSaveCommand(),
+        PdfClipPathCommand(_rectPath(0, 580, 220, 792), PdfFillRule.nonzero),
+        PdfFillPathCommand(
+          _rectPath(20, 650, 100, 740),
+          const PdfColor(1, 0, 0),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        PdfFillPathCommand(
+          _rectPath(420, 650, 500, 740),
+          const PdfColor(0, 0, 1),
+          PdfFillRule.nonzero,
+          1,
+        ),
+        const PdfRestoreCommand(),
+        const PdfSetBlendModeCommand(PdfBlendMode.multiply),
+        PdfStrokePathCommand(
+          const PdfPath([
+            PdfMoveTo(30, 620),
+            PdfLineTo(180, 620),
+          ]),
+          const PdfColor(0, 0, 0),
+          const PdfStroke(width: 3),
+          1,
+        ),
+        PdfFillPathCommand(
+          _rectPath(440, 200, 520, 280),
+          const PdfColor(0, 1, 0),
+          PdfFillRule.nonzero,
+          1,
+        ),
+      ];
+      final scene = await PdfRetainedScene.fromCommands(
+        page,
+        commands,
+        includeImages: false,
+      );
+      addTearDown(scene.dispose);
+      expect(scene.debugHasRegionReplayIndex, isFalse,
+          reason: 'full-page creation must not build region metadata');
+      final fullPicture = scene.replay(pixelRatio: 1);
+      fullPicture.dispose();
+      expect(scene.debugHasRegionReplayIndex, isFalse,
+          reason: 'full-page replay remains on its unchanged fast path');
+
+      const region = Rect.fromLTWH(0, 0, 220, 220);
+      PdfRetainedScene.spatialRegionReplay = false;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 2);
+      PdfRetainedScene.spatialRegionReplay = true;
+      final actual = await scene.rasterizeRegion(region, pixelRatio: 2);
+      expect(
+        (await _bytes(actual)).buffer.asUint8List(),
+        (await _bytes(expected)).buffer.asUint8List(),
+      );
+      expected.dispose();
+      actual.dispose();
+
+      expect(scene.debugLastRegionReplayWasSelective, isTrue);
+      expect(
+          scene.debugLastRegionReplayCommandCount, lessThan(commands.length));
+      expect(scene.debugRegionReplayUnitCount, 3,
+          reason: 'the clipped-away and far-right paints are not indexed');
+      expect(scene.debugRegionReplayEstimatedBytes, lessThan(512));
+      scene.dispose();
+      expect(scene.debugHasRegionReplayIndex, isFalse,
+          reason: 'disposing the scene releases retained index metadata');
+    });
+  });
+
+  testWidgets('groups and over-budget transcripts fall back to full replay',
+      (tester) async {
+    await tester.runAsync(() async {
+      final previousMax = PdfRetainedScene.spatialRegionReplayMaxCommands;
+      addTearDown(
+          () => PdfRetainedScene.spatialRegionReplayMaxCommands = previousMax);
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final grouped = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          const PdfBeginGroupCommand(.5),
+          PdfFillPathCommand(
+            _rectPath(20, 650, 100, 740),
+            const PdfColor(1, 0, 0),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          const PdfEndGroupCommand(),
+        ],
+        includeImages: false,
+      );
+      addTearDown(grouped.dispose);
+      final image = await grouped.rasterizeRegion(
+        const Rect.fromLTWH(0, 0, 220, 220),
+        pixelRatio: 2,
+      );
+      image.dispose();
+      expect(grouped.debugLastRegionReplayWasSelective, isFalse);
+      expect(grouped.debugRegionReplaySupported, isFalse);
+
+      PdfRetainedScene.spatialRegionReplayMaxCommands = 1;
+      final bounded = await PdfRetainedScene.fromCommands(
+        page,
+        [
+          PdfFillPathCommand(
+            _rectPath(20, 650, 100, 740),
+            const PdfColor(1, 0, 0),
+            PdfFillRule.nonzero,
+            1,
+          ),
+          PdfFillPathCommand(
+            _rectPath(420, 650, 500, 740),
+            const PdfColor(0, 0, 1),
+            PdfFillRule.nonzero,
+            1,
+          ),
+        ],
+        includeImages: false,
+      );
+      addTearDown(bounded.dispose);
+      final boundedImage = await bounded.rasterizeRegion(
+        const Rect.fromLTWH(0, 0, 220, 220),
+        pixelRatio: 2,
+      );
+      boundedImage.dispose();
+      expect(bounded.debugLastRegionReplayWasSelective, isFalse);
+      expect(bounded.debugRegionReplaySupported, isFalse);
+    });
+  });
 }
+
+PdfPath _rectPath(double left, double bottom, double right, double top) =>
+    PdfPath([
+      PdfMoveTo(left, bottom),
+      PdfLineTo(right, bottom),
+      PdfLineTo(right, top),
+      PdfLineTo(left, top),
+      const PdfClosePath(),
+    ]);

--- a/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
+++ b/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+const _fixtures = <String>[
+  'rotation.pdf',
+  'xobject-image.pdf',
+  'gradientfill.pdf',
+  'tiling_patterns_variations.pdf',
+  'glyph_accent.pdf',
+  'blendmode.pdf',
+  'smaskdim.pdf',
+  'knockout_isolated_overlap.pdf',
+];
+
+void main() {
+  testWidgets('spatial region replay matches diverse PDF.js corpus pages',
+      (tester) async {
+    final previous = PdfRetainedScene.spatialRegionReplay;
+    addTearDown(() => PdfRetainedScene.spatialRegionReplay = previous);
+    await tester.runAsync(() async {
+      var selective = 0;
+      var fallback = 0;
+      for (final name in _fixtures) {
+        final bytes = File('../../test_corpora/pdfjs/$name').readAsBytesSync();
+        final document = PdfDocument.open(Uint8List.fromList(bytes));
+        if (document.pageCount == 0) continue;
+        final scene = await PdfRetainedScene.record(document.page(0));
+        try {
+          final size = scene.pageSize;
+          final region = Rect.fromLTWH(
+            size.width * .2,
+            size.height * .2,
+            size.width * .6,
+            size.height * .6,
+          );
+          PdfRetainedScene.spatialRegionReplay = false;
+          final expected = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+          PdfRetainedScene.spatialRegionReplay = true;
+          final actual = await scene.rasterizeRegion(region, pixelRatio: 1.5);
+          try {
+            expect(actual.width, expected.width, reason: name);
+            expect(actual.height, expected.height, reason: name);
+            expect(
+              await _bytes(actual),
+              await _bytes(expected),
+              reason: '$name region pixels',
+            );
+          } finally {
+            expected.dispose();
+            actual.dispose();
+          }
+          if (scene.debugLastRegionReplayWasSelective) {
+            selective++;
+          } else {
+            fallback++;
+          }
+        } finally {
+          scene.dispose();
+        }
+      }
+      expect(selective, greaterThanOrEqualTo(3));
+      expect(fallback, greaterThanOrEqualTo(1),
+          reason: 'transparency groups exercise conservative full replay');
+    });
+  });
+}
+
+Future<Uint8List> _bytes(ui.Image image) async =>
+    (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
+        .buffer
+        .asUint8List();


### PR DESCRIPTION
## Summary

- build a lazy, bounded painter-order index for retained-scene region replay
- snapshot active clip chains and blend state so selected commands preserve the original rendering semantics
- conservatively fall back to full replay for transparency/soft-mask groups, malformed or deeply nested state, and oversized transcripts
- leave full-page replay unchanged and release the index metadata with the retained scene
- add exact unit/corpus pixel comparisons and a release-Chrome CAD benchmark

## Why

`PdfRetainedScene.replayRegion` clipped and translated its output but still reissued the full retained command transcript. On dense CAD pages, off-region paths therefore consumed most of the Canvas replay time even though they could not affect the requested detail patch.

## Performance

Release Chrome, `ly9-far-cad.pdf` page 21 at 3.4x, five alternating samples:

| Metric | Full replay | Spatial replay |
| --- | ---: | ---: |
| p90 | 43.0 ms | 32.0 ms |
| Improvement |  | **1.34x / 25.6%** |

The page contains 2,476 retained commands and 1,802 indexed paint units. The worst sampled region selected 707 units (28.6% of commands). Index construction took 3.6 ms and retained approximately 84.5 KB. All benchmark pixels were byte-equal.

The benchmark enforces at least a 1.15x speedup, at most 70% selected commands, and exact output equality.

## Validation

- `fvm dart analyze --fatal-infos`
- `fvm flutter test test/retained_scene_test.dart test/spatial_region_corpus_test.dart test/pdf_page_view_test.dart test/strip_plan_device_test.dart test/web_slug_mixed_page_test.dart` (26 tests)
- exact region comparisons across eight checked-in PDF.js fixtures covering rotation, images, gradients, tiling patterns, glyph accents, blending, soft masks, and knockout groups
- five-sample release-Chrome CAD benchmark

Closes #243