### PR TITLE
perf(graphics): stream dense content into one-pass recorders

### DIFF
--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -645,12 +645,11 @@ Future<Uint8List?> _recordPageAsync(
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
   final page = document.page(pageIndex);
   final previewOperationLimit = decodeImages ? null : commandLimit;
-  final ops = ContentStreamParser.parse(page.contentBytes(),
-      operationLimit: previewOperationLimit);
   final recorder = RecordingPdfDevice();
   final interpreter =
       PdfInterpreter(cos: document.cos, device: recorder, cancellation: token);
-  await interpreter.drawPageOperationsAsync(page, ops);
+  await interpreter.drawPageContentAsync(page, page.contentBytes(),
+      operationLimit: previewOperationLimit);
   if (annotations) interpreter.drawAnnotations(page);
   return serializeCommands(recorder.commands,
       cos: document.cos,
@@ -781,11 +780,10 @@ class _BinCommandCache {
     }
     if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
     final page = document.page(pageIndex);
-    final ops = ContentStreamParser.parse(page.contentBytes());
     final recorder = RecordingPdfDevice();
     final interpreter = PdfInterpreter(
         cos: document.cos, device: recorder, cancellation: token);
-    await interpreter.drawPageOperationsAsync(page, ops);
+    await interpreter.drawPageContentAsync(page, page.contentBytes());
     if (annotations) interpreter.drawAnnotations(page);
     final buffer = serializeCommands(recorder.commands,
         cos: document.cos,

--- a/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
@@ -20,6 +20,8 @@ class PdfWorkerTranscript {
 class PdfWorkerPhaseTimings {
   int parseUs = 0;
   int interpretUs = 0;
+  /// Combined parse + interpret time for incremental content streaming.
+  int streamUs = 0;
   int serializeUs = 0;
   int decodeUs = 0;
   int binUs = 0;
@@ -69,28 +71,27 @@ class PdfWorkerTranscriptCache {
     misses++;
     if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
     final page = document.page(pageIndex);
-    final parseClock = timings == null ? null : (Stopwatch()..start());
-    final ops = ContentStreamParser.parse(page.contentBytes());
-    if (parseClock != null) {
-      parseClock.stop();
-      timings!.parseUs += parseClock.elapsedMicroseconds;
-    }
     final recorder = RecordingPdfDevice();
     final interpreter = PdfInterpreter(
       cos: document.cos,
       device: recorder,
       cancellation: token,
     );
-    final interpretClock = timings == null ? null : (Stopwatch()..start());
+    final streamClock = timings == null ? null : (Stopwatch()..start());
     if (yieldInterval == null) {
-      await interpreter.drawPageOperationsAsync(page, ops);
+      await interpreter.drawPageContentAsync(page, page.contentBytes());
     } else {
-      await interpreter.drawPageOperationsAsync(
+      await interpreter.drawPageContentAsync(
         page,
-        ops,
+        page.contentBytes(),
         yieldInterval: yieldInterval,
       );
     }
+    if (streamClock != null) {
+      streamClock.stop();
+      timings!.streamUs += streamClock.elapsedMicroseconds;
+    }
+    final interpretClock = timings == null ? null : (Stopwatch()..start());
     if (annotations) interpreter.drawAnnotations(page);
     if (interpretClock != null) {
       interpretClock.stop();

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -691,6 +691,7 @@ class _WebRequestTrace {
   int workerUs = 0;
   int parseUs = 0;
   int interpretUs = 0;
+  int streamUs = 0;
   int serializeUs = 0;
   int decodeUs = 0;
   int binUs = 0;
@@ -702,6 +703,7 @@ class _WebRequestTrace {
     workerUs = _intProperty(data, 'workerUs');
     parseUs = _intProperty(data, 'parseUs');
     interpretUs = _intProperty(data, 'interpretUs');
+    streamUs = _intProperty(data, 'streamUs');
     serializeUs = _intProperty(data, 'serializeUs');
     decodeUs = _intProperty(data, 'decodeUs');
     binUs = _intProperty(data, 'binUs');
@@ -719,6 +721,7 @@ class _WebRequestTrace {
       'page=${request.pageIndex} outcome=$outcome '
       'queue=${_traceMs(queueUs)} worker=${_traceMs(workerUs)} '
       'parse=${_traceMs(parseUs)} interpret=${_traceMs(interpretUs)} '
+      'stream=${_traceMs(streamUs)} '
       'decode=${_traceMs(decodeUs)} serialize=${_traceMs(serializeUs)} '
       'bin=${_traceMs(binUs)} transfer=${_traceMs(transferUs)} '
       'deserialize=${_traceMs(deserializeUs)} total=${_traceMs(totalUs)} '

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -352,6 +352,7 @@ void _attachTimings(
     ..setProperty('workerUs'.toJS, workerUs.toJS)
     ..setProperty('parseUs'.toJS, timings.parseUs.toJS)
     ..setProperty('interpretUs'.toJS, timings.interpretUs.toJS)
+    ..setProperty('streamUs'.toJS, timings.streamUs.toJS)
     ..setProperty('serializeUs'.toJS, timings.serializeUs.toJS)
     ..setProperty('decodeUs'.toJS, timings.decodeUs.toJS)
     ..setProperty('binUs'.toJS, timings.binUs.toJS)
@@ -390,23 +391,24 @@ Future<Uint8List?> _recordPageAsync(
     // here would defeat their latency bound. Ordinary progressive records have
     // no limit and populate the shared transcript below.
     final previewOperationLimit = decodeImages ? null : commandLimit;
-    final parseClock = timings == null ? null : (Stopwatch()..start());
-    final ops = ContentStreamParser.parse(
-      page.contentBytes(),
-      operationLimit: previewOperationLimit,
-    );
-    if (parseClock != null) {
-      parseClock.stop();
-      timings!.parseUs += parseClock.elapsedMicroseconds;
-    }
     final recorder = RecordingPdfDevice();
     final interpreter = PdfInterpreter(
       cos: document.cos,
       device: recorder,
       cancellation: token,
     );
+    final streamClock = timings == null ? null : (Stopwatch()..start());
+    await interpreter.drawPageContentAsync(
+      page,
+      page.contentBytes(),
+      operationLimit: previewOperationLimit,
+      yieldInterval: 4096,
+    );
+    if (streamClock != null) {
+      streamClock.stop();
+      timings!.streamUs += streamClock.elapsedMicroseconds;
+    }
     final interpretClock = timings == null ? null : (Stopwatch()..start());
-    await interpreter.drawPageOperationsAsync(page, ops, yieldInterval: 4096);
     if (annotations) interpreter.drawAnnotations(page);
     if (interpretClock != null) {
       interpretClock.stop();

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -179,14 +179,13 @@ class PdfPageRenderer {
       PdfPage page, PdfPageRenderPlan plan,
       {bool Function(PdfAnnotation)? skipAnnotation}) async {
     final cos = page.document.cos;
-    final pageOps = ContentStreamParser.parse(page.contentBytes());
 
     // Record the page into a flat command buffer. This single walk also
     // discovers every image (the recording device's drawImage calls), so the
     // separate scan-only collect pass [renderPicture] runs is unnecessary here.
     final recorder = RecordingPdfDevice();
     final recording = PdfInterpreter(cos: cos, device: recorder)
-      ..drawPageOperations(page, pageOps);
+      ..drawPageContent(page, page.contentBytes());
     if (plan.annotations) recording.drawAnnotations(page, skip: skipAnnotation);
 
     final images = await decodeImages(cos, recorder.imageRequests,

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -118,10 +118,9 @@ class PdfRetainedScene {
     bool Function(PdfAnnotation)? skipAnnotation,
   }) async {
     final cos = page.document.cos;
-    final pageOps = ContentStreamParser.parse(page.contentBytes());
     final recorder = RecordingPdfDevice();
     final recording = PdfInterpreter(cos: cos, device: recorder)
-      ..drawPageOperations(page, pageOps);
+      ..drawPageContent(page, page.contentBytes());
     if (plan.annotations) recording.drawAnnotations(page, skip: skipAnnotation);
     final images = await decodeImages(cos, recorder.imageRequests,
         cache: PdfImageCache.instance);

--- a/packages/dart_pdf_editor/test/render_worker_transcript_cache_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_transcript_cache_test.dart
@@ -20,6 +20,7 @@ void main() {
     expect(firstTimings.transcriptHit, isFalse);
     expect(firstTimings.parseUs, greaterThanOrEqualTo(0));
     expect(firstTimings.interpretUs, greaterThanOrEqualTo(0));
+    expect(firstTimings.streamUs, greaterThanOrEqualTo(0));
     expect(firstTimings.serializeUs, greaterThanOrEqualTo(0));
     final hitTimings = PdfWorkerPhaseTimings();
     final hit = await cache.transcriptFor(
@@ -33,6 +34,7 @@ void main() {
     expect(hitTimings.transcriptHit, isTrue);
     expect(hitTimings.parseUs, 0);
     expect(hitTimings.interpretUs, 0);
+    expect(hitTimings.streamUs, 0);
     expect(hitTimings.serializeUs, 0);
     expect(cache.hits, 1);
     expect(cache.misses, 1);

--- a/packages/pdf_cos/lib/src/content_parser.dart
+++ b/packages/pdf_cos/lib/src/content_parser.dart
@@ -89,6 +89,16 @@ class ContentStreamParser {
   static CosObject _intObject(int value) =>
       (value >= -1 && value <= 256) ? _smallInts[value + 1] : CosInteger(value);
 
+  /// Opens [content] as an incremental operation cursor.
+  ///
+  /// Unlike [parse], the cursor does not retain operations after the caller
+  /// consumes them. This is useful for one-pass interpreters of very dense
+  /// streams, while callers that need replay or editing should keep using the
+  /// materialized list returned by [parse].
+  static ContentOperationCursor cursor(Uint8List content,
+          {int? operationLimit}) =>
+      ContentOperationCursor._(content, operationLimit: operationLimit);
+
   static List<ContentOperation> parse(Uint8List content,
       {int? operationLimit}) {
     // Drive the lexer directly rather than through [CosParser]: a content
@@ -99,51 +109,12 @@ class ContentStreamParser {
     // finished operation its own operand list (no copy, no clear) roughly
     // halves the parse.
     final operations = <ContentOperation>[];
-    if (operationLimit != null && operationLimit <= 0) return operations;
-    final lexer = CosLexer(content);
-    var operands = <CosObject>[];
-    bool addOperation(ContentOperation operation) {
-      operations.add(operation);
-      return operationLimit != null && operations.length >= operationLimit;
+    final reader = cursor(content, operationLimit: operationLimit);
+    ContentOperation? operation;
+    while ((operation = reader.nextOperation()) != null) {
+      operations.add(operation!);
     }
-
-    while (true) {
-      final t = lexer.nextToken();
-      switch (t.type) {
-        case CosTokenType.eof:
-          return operations;
-        // Numbers are by far the most common operand (every coordinate,
-        // colour, index); build them inline on the hot path.
-        case CosTokenType.integer:
-          operands.add(_intObject(t.intValue));
-        case CosTokenType.real:
-          operands.add(CosReal(t.realValue));
-        case CosTokenType.keyword:
-          final keyword = t.textValue;
-          // true/false/null are operands, not operators.
-          switch (keyword) {
-            case 'true':
-              operands.add(const CosBoolean(true));
-            case 'false':
-              operands.add(const CosBoolean(false));
-            case 'null':
-              operands.add(CosNull.instance);
-            case 'BI':
-              if (addOperation(_parseInlineImage(lexer))) return operations;
-              operands = <CosObject>[];
-            default:
-              // Hand the operation ownership of the operand list and start a
-              // fresh one - equivalent to `List.of(operands)` then clear,
-              // minus the element copy.
-              if (addOperation(ContentOperation(keyword, operands))) {
-                return operations;
-              }
-              operands = <CosObject>[];
-          }
-        default:
-          operands.add(_parseObject(lexer, t));
-      }
-    }
+    return operations;
   }
 
   /// Parses one operand object from [first] (already consumed). Mirrors
@@ -337,5 +308,81 @@ class ContentStreamParser {
     final afterOk =
         afterPos >= bytes.length || CosLexer.isWhitespace(bytes[afterPos]);
     return beforeOk && afterOk ? p : null;
+  }
+}
+
+/// Incremental reader for a flat PDF content stream.
+///
+/// Each call to [nextOperation] returns ownership of that operation's operand
+/// list. Once the caller drops the returned operation, no page-sized parsed
+/// representation remains live. Obtain a cursor with
+/// [ContentStreamParser.cursor].
+class ContentOperationCursor {
+  ContentOperationCursor._(Uint8List content, {this.operationLimit})
+      : _lexer = CosLexer(content),
+        _finished = operationLimit != null && operationLimit <= 0;
+
+  /// Maximum operations this cursor will emit, or null for the whole stream.
+  final int? operationLimit;
+
+  final CosLexer _lexer;
+  var _operands = <CosObject>[];
+  var _operationCount = 0;
+  bool _finished;
+
+  /// Number of operations emitted so far.
+  int get operationCount => _operationCount;
+
+  /// Whether EOF or [operationLimit] has been reached.
+  bool get isFinished => _finished;
+
+  /// Parses and returns the next operation, or null at the end of the stream.
+  ContentOperation? nextOperation() {
+    if (_finished) return null;
+    while (true) {
+      final token = _lexer.nextToken();
+      switch (token.type) {
+        case CosTokenType.eof:
+          _finished = true;
+          return null;
+        case CosTokenType.integer:
+          _operands.add(ContentStreamParser._intObject(token.intValue));
+        case CosTokenType.real:
+          _operands.add(CosReal(token.realValue));
+        case CosTokenType.keyword:
+          final keyword = token.textValue;
+          switch (keyword) {
+            case 'true':
+              _operands.add(const CosBoolean(true));
+              continue;
+            case 'false':
+              _operands.add(const CosBoolean(false));
+              continue;
+            case 'null':
+              _operands.add(CosNull.instance);
+              continue;
+            case 'BI':
+              final operation = ContentStreamParser._parseInlineImage(_lexer);
+              // Match the materialized parser's lenient boundary behavior:
+              // junk operands before BI do not leak into the following op.
+              _operands = <CosObject>[];
+              return _emit(operation);
+            default:
+              final operation = ContentOperation(keyword, _operands);
+              _operands = <CosObject>[];
+              return _emit(operation);
+          }
+        default:
+          _operands.add(ContentStreamParser._parseObject(_lexer, token));
+      }
+    }
+  }
+
+  ContentOperation _emit(ContentOperation operation) {
+    _operationCount++;
+    if (operationLimit != null && _operationCount >= operationLimit!) {
+      _finished = true;
+    }
+    return operation;
   }
 }

--- a/packages/pdf_cos/test/content_parser_test.dart
+++ b/packages/pdf_cos/test/content_parser_test.dart
@@ -77,6 +77,13 @@ void main() {
     expect(data.bytes, [0x00, 0xFF]);
   });
 
+  test('junk operands before an inline image do not leak past it', () {
+    final ops = ContentStreamParser.parse(
+        ascii('123 BI /W 1 /H 1 /CS /G /BPC 8 ID \x7f EI Q'));
+    expect(ops.map((op) => op.operator), ['BI', 'Q']);
+    expect(ops.last.operands, isEmpty);
+  });
+
   test('operationLimit returns a prefix on operation boundaries', () {
     final ops = ContentStreamParser.parse(
         ascii('q 1 0 0 1 50 50 cm BI /W 1 /H 1 /CS /G /BPC 8 ID \x7f EI Q'),
@@ -85,6 +92,28 @@ void main() {
     expect(ops.map((op) => op.operator), ['q', 'cm', 'BI']);
     final data = ops[2].operands[1] as CosString;
     expect(data.bytes, [0x7F]);
+  });
+
+  test('incremental cursor emits one operation at a time and honors its limit',
+      () {
+    final cursor = ContentStreamParser.cursor(
+      ascii('q 1 0 0 1 50 50 cm (Hello) Tj Q'),
+      operationLimit: 3,
+    );
+
+    expect(cursor.operationCount, 0);
+    expect(cursor.isFinished, isFalse);
+    expect(cursor.nextOperation()!.operator, 'q');
+    expect(cursor.operationCount, 1);
+    final matrix = cursor.nextOperation()!;
+    expect(matrix.operator, 'cm');
+    expect(matrix.operands, hasLength(6));
+    final text = cursor.nextOperation()!;
+    expect(text.operator, 'Tj');
+    expect((text.operands.single as CosString).text, 'Hello');
+    expect(cursor.isFinished, isTrue);
+    expect(cursor.nextOperation(), isNull);
+    expect(cursor.operationCount, 3);
   });
 
   test('DCT inline image ignores EI-like bytes before JPEG EOI', () {

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -498,8 +498,32 @@ class PdfInterpreter {
   final StringBuffer _textBuffer = StringBuffer();
   bool _textBufferInUse = false;
 
-  void drawPage(PdfPage page) =>
-      drawPageOperations(page, ContentStreamParser.parse(page.contentBytes()));
+  void drawPage(PdfPage page) => drawPageContent(page, page.contentBytes());
+
+  /// Parses and interprets [content] incrementally without retaining a
+  /// page-sized [ContentOperation] list.
+  ///
+  /// This is the preferred path when the content is consumed once. Renderers
+  /// that deliberately interpret the same page more than once should parse a
+  /// list once and use [drawPageOperations] for each pass instead.
+  void drawPageContent(PdfPage page, Uint8List content, {int? operationLimit}) {
+    _state = _GraphicsState();
+    _visibilityStack.clear();
+    _mcidStack.clear();
+    _pageBox = page.mediaBox;
+    device.save();
+    try {
+      _runCursor(
+        ContentStreamParser.cursor(content, operationLimit: operationLimit),
+        page.resources,
+        0,
+      );
+      final mask = _state.softMask;
+      if (mask != null) _finalizeSoftMask(mask);
+    } finally {
+      device.restore();
+    }
+  }
 
   /// Runs an already-parsed page content stream. Parsing (and the underlying
   /// stream decompression) dominates rendering on graphics-rich pages, so a
@@ -544,6 +568,36 @@ class PdfInterpreter {
     device.save();
     try {
       await _runAsync(operations, page.resources, 0, yieldInterval);
+      final mask = _state.softMask;
+      if (mask != null) _finalizeSoftMask(mask);
+    } finally {
+      device.restore();
+    }
+  }
+
+  /// Async, cancellable counterpart to [drawPageContent].
+  ///
+  /// Parsing and interpretation advance together, yielding after each
+  /// [yieldInterval] operations. This removes the uncancellable synchronous
+  /// parse prefix and avoids retaining every parsed operation in render
+  /// workers that only record the page once.
+  Future<void> drawPageContentAsync(PdfPage page, Uint8List content,
+      {int? operationLimit, int yieldInterval = _yieldInterval}) async {
+    if (yieldInterval <= 0) {
+      throw ArgumentError.value(yieldInterval, 'yieldInterval', 'must be > 0');
+    }
+    _state = _GraphicsState();
+    _visibilityStack.clear();
+    _mcidStack.clear();
+    _pageBox = page.mediaBox;
+    device.save();
+    try {
+      await _runCursorAsync(
+        ContentStreamParser.cursor(content, operationLimit: operationLimit),
+        page.resources,
+        0,
+        yieldInterval,
+      );
       final mask = _state.softMask;
       if (mask != null) _finalizeSoftMask(mask);
     } finally {
@@ -1008,6 +1062,24 @@ class PdfInterpreter {
     }
   }
 
+  void _runCursor(
+      ContentOperationCursor cursor, CosDictionary resources, int formDepth) {
+    final previousDepth = _currentFormDepth;
+    final previousVisibilityDepth = _visibilityStack.length;
+    _currentFormDepth = formDepth;
+    try {
+      _runCursorOps(cursor, resources, formDepth);
+    } finally {
+      while (_visibilityStack.length > previousVisibilityDepth) {
+        _visibilityStack.removeLast();
+      }
+      while (_mcidStack.length > previousVisibilityDepth) {
+        _mcidStack.removeLast();
+      }
+      _currentFormDepth = previousDepth;
+    }
+  }
+
   Future<void> _runAsync(List<ContentOperation> ops, CosDictionary resources,
       int formDepth, int yieldInterval) async {
     final previousDepth = _currentFormDepth;
@@ -1015,6 +1087,24 @@ class PdfInterpreter {
     _currentFormDepth = formDepth;
     try {
       await _runOpsAsync(ops, resources, formDepth, yieldInterval);
+    } finally {
+      while (_visibilityStack.length > previousVisibilityDepth) {
+        _visibilityStack.removeLast();
+      }
+      while (_mcidStack.length > previousVisibilityDepth) {
+        _mcidStack.removeLast();
+      }
+      _currentFormDepth = previousDepth;
+    }
+  }
+
+  Future<void> _runCursorAsync(ContentOperationCursor cursor,
+      CosDictionary resources, int formDepth, int yieldInterval) async {
+    final previousDepth = _currentFormDepth;
+    final previousVisibilityDepth = _visibilityStack.length;
+    _currentFormDepth = formDepth;
+    try {
+      await _runCursorOpsAsync(cursor, resources, formDepth, yieldInterval);
     } finally {
       while (_visibilityStack.length > previousVisibilityDepth) {
         _visibilityStack.removeLast();
@@ -1045,11 +1135,46 @@ class PdfInterpreter {
     }
   }
 
+  Future<void> _runCursorOpsAsync(ContentOperationCursor cursor,
+      CosDictionary resources, int formDepth, int yieldInterval) async {
+    final token = cancellation;
+    var opCount = 0;
+    while (true) {
+      final op = cursor.nextOperation();
+      if (op == null) return;
+      if (++opCount % yieldInterval == 0) {
+        await Future<void>.delayed(Duration.zero);
+        if (token != null && token.cancelled) {
+          throw const PdfCancelledException();
+        }
+      } else if (token != null &&
+          opCount & (_cancelCheckInterval - 1) == 0 &&
+          token.cancelled) {
+        throw const PdfCancelledException();
+      }
+      _execOp(op, resources, formDepth);
+    }
+  }
+
   void _runOps(
       List<ContentOperation> ops, CosDictionary resources, int formDepth) {
     final token = cancellation;
     var opCount = 0;
     for (final op in ops) {
+      if (token != null && ++opCount & (_cancelCheckInterval - 1) == 0) {
+        if (token.cancelled) throw const PdfCancelledException();
+      }
+      _execOp(op, resources, formDepth);
+    }
+  }
+
+  void _runCursorOps(
+      ContentOperationCursor cursor, CosDictionary resources, int formDepth) {
+    final token = cancellation;
+    var opCount = 0;
+    while (true) {
+      final op = cursor.nextOperation();
+      if (op == null) return;
       if (token != null && ++opCount & (_cancelCheckInterval - 1) == 0) {
         if (token.cancelled) throw const PdfCancelledException();
       }

--- a/packages/pdf_graphics/test/interpreter_test.dart
+++ b/packages/pdf_graphics/test/interpreter_test.dart
@@ -1176,6 +1176,55 @@ void main() {
       );
     });
 
+    test('drawPageContent streams the same device calls as a parsed list', () {
+      final bytes = heavyPdf();
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final content = page.contentBytes();
+
+      final materialized = RecordingDevice();
+      PdfInterpreter(cos: doc.cos, device: materialized).drawPageOperations(
+        page,
+        ContentStreamParser.parse(content),
+      );
+      final streaming = RecordingDevice();
+      PdfInterpreter(cos: doc.cos, device: streaming)
+          .drawPageContent(page, content);
+
+      expect(streaming.calls, materialized.calls);
+      expect(streaming.fills.length, materialized.fills.length);
+      expect(streaming.strokes.length, materialized.strokes.length);
+      expect(streaming.texts.length, materialized.texts.length);
+      expect(streaming.images.length, materialized.images.length);
+    });
+
+    test('drawPageContentAsync can cancel while parsing and interpreting',
+        () async {
+      final bytes = heavyPdf();
+      final doc = PdfDocument.open(bytes);
+      final page = doc.page(0);
+      final token = PdfCancellationToken();
+      final device = RecordingDevice();
+      final interpreter = PdfInterpreter(
+        cos: doc.cos,
+        device: device,
+        cancellation: token,
+      );
+
+      Future<void>.delayed(Duration.zero).then((_) {
+        token.cancelled = true;
+      });
+
+      await expectLater(
+        interpreter.drawPageContentAsync(
+          page,
+          page.contentBytes(),
+          yieldInterval: 1024,
+        ),
+        throwsA(isA<PdfCancelledException>()),
+      );
+    });
+
     test('no token means no cancellation overhead', () {
       final bytes = heavyPdf();
       final doc = PdfDocument.open(bytes);

--- a/packages/pdf_graphics/test/streaming_interpreter_test.dart
+++ b/packages/pdf_graphics/test/streaming_interpreter_test.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const fixtures = [
+    'operator-in-TJ-array.pdf',
+    'rotation.pdf',
+    'xobject-image.pdf',
+    'gradientfill.pdf',
+    'tiling-pattern-box.pdf',
+    'pattern_text_embedded_font.pdf',
+    'blendmode.pdf',
+    'knockout_smask.pdf',
+  ];
+
+  test('streaming and materialized interpretation are byte-equivalent', () {
+    for (final name in fixtures) {
+      final document = PdfDocument.open(
+        File('../../test_corpora/pdfjs/$name').readAsBytesSync(),
+      );
+      for (var pageIndex = 0;
+          pageIndex < math.min(2, document.pageCount);
+          pageIndex++) {
+        final page = document.page(pageIndex);
+        final content = page.contentBytes();
+
+        final materialized = RecordingPdfDevice();
+        PdfInterpreter(cos: document.cos, device: materialized)
+            .drawPageOperations(page, ContentStreamParser.parse(content));
+        final streamed = RecordingPdfDevice();
+        PdfInterpreter(cos: document.cos, device: streamed)
+            .drawPageContent(page, content);
+
+        final materializedBytes = serializeCommands(
+          materialized.commands,
+          cos: document.cos,
+          decodeImages: false,
+          imagePlaceholders: true,
+          compactStateScopes: true,
+        );
+        final streamedBytes = serializeCommands(
+          streamed.commands,
+          cos: document.cos,
+          decodeImages: false,
+          imagePlaceholders: true,
+          compactStateScopes: true,
+        );
+        expect(materializedBytes, isNotNull, reason: '$name page $pageIndex');
+        expect(streamedBytes, materializedBytes,
+            reason: '$name page $pageIndex');
+      }
+    }
+  });
+}

--- a/packages/pdf_graphics/tool/dense_content_benchmark.dart
+++ b/packages/pdf_graphics/tool/dense_content_benchmark.dart
@@ -1,0 +1,237 @@
+// A/B benchmark for incremental content parsing on one-pass recording paths.
+//
+// Run from packages/pdf_graphics. Page numbers are one-based:
+//
+//   fvm dart run tool/dense_content_benchmark.dart /path/to/file.pdf \
+//     --page 21 --repeat 9 --minimum-speedup 1.05
+//
+// Compare peak resident memory in separate processes (warmup zero avoids
+// carrying the other mode's high-water mark):
+//
+//   ... --page 21 --mode materialized --warmup 0 --repeat 1
+//   ... --page 21 --mode streaming --warmup 0 --repeat 1
+//
+// For lower-noise release measurements, compile and run the same harness:
+//
+//   fvm dart compile exe tool/dense_content_benchmark.dart \
+//     -o /tmp/dart-pdf-dense-benchmark
+//   /tmp/dart-pdf-dense-benchmark /path/to/file.pdf --page 21 --repeat 9
+//
+// Both modes record into the production RecordingPdfDevice. The materialized
+// mode retains every ContentOperation through interpretation; the streaming
+// mode keeps only the operation currently being executed.
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+class _Args {
+  String path = '';
+  int page = 21;
+  int repeat = 9;
+  int warmup = 2;
+  double minimumSpeedup = 1;
+  String mode = 'both';
+}
+
+class _Sample {
+  const _Sample(this.totalUs, this.parseUs, this.commandCount,
+      {this.operationCount});
+
+  final int totalUs;
+  final int parseUs;
+  final int commandCount;
+  final int? operationCount;
+}
+
+_Args _parseArgs(List<String> argv) {
+  final args = _Args();
+  for (var i = 0; i < argv.length; i++) {
+    String next(String flag) {
+      if (++i >= argv.length) {
+        stderr.writeln('missing value for $flag');
+        exit(2);
+      }
+      return argv[i];
+    }
+
+    switch (argv[i]) {
+      case '--page':
+        args.page = int.parse(next(argv[i]));
+      case '--repeat':
+        args.repeat = int.parse(next(argv[i]));
+      case '--warmup':
+        args.warmup = int.parse(next(argv[i]));
+      case '--minimum-speedup':
+        args.minimumSpeedup = double.parse(next(argv[i]));
+      case '--mode':
+        args.mode = next(argv[i]);
+      default:
+        if (argv[i].startsWith('--')) {
+          stderr.writeln('unknown flag ${argv[i]}');
+          exit(2);
+        }
+        args.path = argv[i];
+    }
+  }
+  if (args.path.isEmpty ||
+      args.page <= 0 ||
+      args.repeat <= 0 ||
+      !const {'both', 'materialized', 'streaming'}.contains(args.mode)) {
+    stderr.writeln('usage: dense_content_benchmark.dart <pdf> '
+        '[--page N] [--repeat N] [--warmup N] [--mode MODE] '
+        '[--minimum-speedup X]');
+    exit(2);
+  }
+  return args;
+}
+
+_Sample _materialized(PdfPage page, Uint8List content) {
+  PdfInterpreter.clearFontCache();
+  final total = Stopwatch()..start();
+  final parse = Stopwatch()..start();
+  final operations = ContentStreamParser.parse(content);
+  parse.stop();
+  final recorder = RecordingPdfDevice();
+  PdfInterpreter(cos: page.document.cos, device: recorder)
+      .drawPageOperations(page, operations);
+  total.stop();
+  return _Sample(
+    total.elapsedMicroseconds,
+    parse.elapsedMicroseconds,
+    recorder.commands.length,
+    operationCount: operations.length,
+  );
+}
+
+_Sample _streaming(PdfPage page, Uint8List content) {
+  PdfInterpreter.clearFontCache();
+  final total = Stopwatch()..start();
+  final recorder = RecordingPdfDevice();
+  PdfInterpreter(cos: page.document.cos, device: recorder)
+      .drawPageContent(page, content);
+  total.stop();
+  return _Sample(total.elapsedMicroseconds, 0, recorder.commands.length);
+}
+
+int _percentile(List<int> values, double fraction) {
+  final sorted = [...values]..sort();
+  final index = math.max(0, (sorted.length * fraction).ceil() - 1);
+  return sorted[index];
+}
+
+double _ms(int microseconds) => microseconds / 1000;
+
+Never _singleMode(
+  _Args args,
+  PdfPage page,
+  Uint8List content,
+) {
+  final materialized = args.mode == 'materialized';
+  for (var i = 0; i < args.warmup; i++) {
+    materialized ? _materialized(page, content) : _streaming(page, content);
+  }
+  final samples = <_Sample>[];
+  for (var i = 0; i < args.repeat; i++) {
+    samples.add(
+      materialized ? _materialized(page, content) : _streaming(page, content),
+    );
+  }
+  final totals = samples.map((sample) => sample.totalUs).toList();
+  final result = <String, Object?>{
+    'file': args.path.split(Platform.pathSeparator).last,
+    'page': args.page,
+    'mode': args.mode,
+    'contentBytes': content.length,
+    'operationCount': materialized ? samples.first.operationCount : null,
+    'commandCount': samples.first.commandCount,
+    'repeat': args.repeat,
+    'totalMs': totals.map(_ms).toList(),
+    'p50Ms': _ms(_percentile(totals, 0.5)),
+    'p90Ms': _ms(_percentile(totals, 0.9)),
+    'retainedParsedOperations':
+        materialized ? samples.first.operationCount : (content.isEmpty ? 0 : 1),
+    'maxRssBytes': ProcessInfo.maxRss,
+  };
+  stdout.writeln(const JsonEncoder.withIndent('  ').convert(result));
+  exit(0);
+}
+
+void main(List<String> argv) {
+  final args = _parseArgs(argv);
+  final bytes = File(args.path).readAsBytesSync();
+  final document = PdfDocument.open(bytes);
+  final pageIndex = args.page - 1;
+  if (pageIndex >= document.pageCount) {
+    stderr.writeln('page ${args.page} is outside 1..${document.pageCount}');
+    exit(2);
+  }
+  final page = document.page(pageIndex);
+  final content = page.contentBytes();
+  if (args.mode != 'both') _singleMode(args, page, content);
+
+  for (var i = 0; i < args.warmup; i++) {
+    _materialized(page, content);
+    _streaming(page, content);
+  }
+
+  final materialized = <_Sample>[];
+  final streaming = <_Sample>[];
+  for (var i = 0; i < args.repeat; i++) {
+    if (i.isEven) {
+      materialized.add(_materialized(page, content));
+      streaming.add(_streaming(page, content));
+    } else {
+      streaming.add(_streaming(page, content));
+      materialized.add(_materialized(page, content));
+    }
+  }
+
+  final operationCount = materialized.first.operationCount!;
+  final commandCount = materialized.first.commandCount;
+  if (materialized.any((sample) =>
+          sample.operationCount != operationCount ||
+          sample.commandCount != commandCount) ||
+      streaming.any((sample) => sample.commandCount != commandCount)) {
+    throw StateError('benchmark modes produced inconsistent output counts');
+  }
+
+  final materializedTotal = materialized.map((s) => s.totalUs).toList();
+  final materializedParse = materialized.map((s) => s.parseUs).toList();
+  final streamingTotal = streaming.map((s) => s.totalUs).toList();
+  final materializedP90 = _percentile(materializedTotal, 0.9);
+  final streamingP90 = _percentile(streamingTotal, 0.9);
+  final speedup = materializedP90 / streamingP90;
+  final reduction = 1 - streamingP90 / materializedP90;
+
+  final result = <String, Object>{
+    'file': args.path.split(Platform.pathSeparator).last,
+    'page': args.page,
+    'contentBytes': content.length,
+    'operationCount': operationCount,
+    'commandCount': commandCount,
+    'repeat': args.repeat,
+    'materializedTotalMs': materializedTotal.map(_ms).toList(),
+    'materializedParseMs': materializedParse.map(_ms).toList(),
+    'streamingTotalMs': streamingTotal.map(_ms).toList(),
+    'materializedP50Ms': _ms(_percentile(materializedTotal, 0.5)),
+    'materializedP90Ms': _ms(materializedP90),
+    'parseP90Ms': _ms(_percentile(materializedParse, 0.9)),
+    'streamingP50Ms': _ms(_percentile(streamingTotal, 0.5)),
+    'streamingP90Ms': _ms(streamingP90),
+    'speedup': speedup,
+    'latencyReduction': reduction,
+    'materializedRetainedOperations': operationCount,
+    'streamingRetainedOperations': operationCount == 0 ? 0 : 1,
+  };
+  stdout.writeln(const JsonEncoder.withIndent('  ').convert(result));
+
+  if (speedup < args.minimumSpeedup) {
+    stderr.writeln('speedup ${speedup.toStringAsFixed(2)}x is below '
+        '${args.minimumSpeedup.toStringAsFixed(2)}x');
+    exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- add an incremental `ContentOperationCursor` while preserving `ContentStreamParser.parse` for callers that need a materialized, replayable list
- add synchronous and cancellable async interpreter entry points that parse and execute together
- move one-pass recording paths—native/web workers, worker transcript caches, retained scenes, and recorded rendering—to the streaming path
- deliberately keep the ordinary two-pass renderer materialized so image collection and painting still share one parse
- add a reproducible AOT/JIT benchmark with isolated peak-RSS modes, cursor/cancellation regressions, and exact command-buffer parity across PDF.js fixtures

## Why

Dense CAD streams retained every parsed operation and operand until interpretation completed. On the densest measured `ly9-far-cad.pdf` sheet, that meant 677,313 operations remained live while the recorder generated 98,936 render commands. The retained parse graph created substantial allocation and GC work before the command transcript could be used.

The async worker path also had an uncancellable synchronous parse prefix. Streaming lets cancellation messages take effect at the same operation intervals used during interpretation.

## Performance

Release AOT, `ly9-far-cad.pdf` displayed page 5, 11.1 MB decoded content, nine alternating samples:

| Metric | Materialized | Streaming | Improvement |
| --- | ---: | ---: | ---: |
| p50 parse + record | 270.3 ms | 141.8 ms | 1.91x |
| p90 parse + record | 328.2 ms | 173.5 ms | **1.89x / 47.1%** |
| Live parsed operations | 677,313 | 1 | bounded |
| Peak RSS, isolated process | 262.1 MB | 120.9 MB | **−141.1 MB / 53.9%** |

Both modes emitted 98,936 render commands. The checked-in benchmark supports a minimum-speedup gate and separate `materialized`/`streaming` processes for peak-memory comparison.

## Validation

- `fvm dart analyze --fatal-infos`
- focused parser, interpreter, cancellation, worker-cache, retained-scene, and render-worker tests
- exact serialized command-buffer equality across eight checked-in PDF.js fixtures
- Ghent pure-Dart corpus: 54/54
- PDF.js pure-Dart corpus: 171/171
- Ghent raster/baseline corpus
- PDF.js raster smoke corpus: 164/164
- release web example build, including the web-worker call sites
- release AOT benchmark with a 1.2x minimum-speedup gate

Closes #244