### PR TITLE
Reuse exact rasters for lightweight page revisits

### DIFF
--- a/packages/dart_pdf_editor/example/tool/showcase_sharpen_benchmark_test.dart
+++ b/packages/dart_pdf_editor/example/tool/showcase_sharpen_benchmark_test.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_viewer_example/demo_document.dart';
+
+int _percentile(List<int> values, double fraction) {
+  final sorted = [...values]..sort();
+  return sorted[(sorted.length * fraction).ceil() - 1];
+}
+
+void main() {
+  testWidgets('Feature Showcase page 6 exact-raster reuse latency',
+      (tester) async {
+    final document = PdfDocument.open(buildDemoPdf());
+    final page = document.page(5); // Annotations & forms.
+    final picture = await PdfPageRenderer.renderPicture(page);
+    addTearDown(picture.dispose);
+    final size = PdfPageRenderer.pageSize(page);
+    const ratio = 1.25;
+
+    // Warm the engine once, then measure the GPU readback a recycled page
+    // used to repeat on every visit.
+    final warmup = await PdfPageRenderer.rasterize(picture, size, ratio);
+    warmup.dispose();
+    final rasterMicros = <int>[];
+    late ui.Image seed;
+    for (var i = 0; i < 7; i++) {
+      final stopwatch = Stopwatch()..start();
+      final image = await PdfPageRenderer.rasterize(picture, size, ratio);
+      stopwatch.stop();
+      rasterMicros.add(stopwatch.elapsedMicroseconds);
+      if (i == 0) {
+        seed = image;
+      } else {
+        image.dispose();
+      }
+    }
+
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+    cache.putFullImage(
+      5,
+      page,
+      seed,
+      pageColor: const ui.Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: 0,
+    );
+    final width = seed.width;
+    final height = seed.height;
+    seed.dispose();
+
+    // Clone lookup is the optimized revisit path. Use enough samples for
+    // stable microsecond percentiles while keeping the opt-in run short.
+    final restoreMicros = <int>[];
+    for (var i = 0; i < 200; i++) {
+      final stopwatch = Stopwatch()..start();
+      final image = cache.fullImageFor(
+        5,
+        page,
+        width: width,
+        height: height,
+        pageColor: const ui.Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: 0,
+      );
+      stopwatch.stop();
+      expect(image, isNotNull);
+      restoreMicros.add(stopwatch.elapsedMicroseconds);
+      image!.dispose();
+    }
+
+    final rasterP50 = _percentile(rasterMicros, 0.5);
+    final rasterP90 = _percentile(rasterMicros, 0.9);
+    final restoreP50 = _percentile(restoreMicros, 0.5);
+    final restoreP90 = _percentile(restoreMicros, 0.9);
+    // ignore: avoid_print
+    print(const JsonEncoder.withIndent('  ').convert({
+      'page': 'Feature Showcase / Annotations & forms',
+      'raster': '${width}x$height',
+      'coldRasterP50Ms': rasterP50 / 1000,
+      'coldRasterP90Ms': rasterP90 / 1000,
+      'cacheRestoreP50Ms': restoreP50 / 1000,
+      'cacheRestoreP90Ms': restoreP90 / 1000,
+      'speedupP50': rasterP50 / (restoreP50 == 0 ? 0.5 : restoreP50),
+      'retainedMiB': width * height * 4 / (1 << 20),
+    }));
+
+    expect(restoreP90, lessThan(rasterP50));
+  });
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -704,7 +704,69 @@ class _PdfPageViewState extends State<PdfPageView> {
     return math.max(ratio, 0.05);
   }
 
+  (int width, int height) _rasterDimensions(double pixelRatio) {
+    final size = _renderPlan.pageSize(widget.page);
+    return (
+      (size.width * pixelRatio).ceil().clamp(1, 1 << 14),
+      (size.height * pixelRatio).ceil().clamp(1, 1 << 14),
+    );
+  }
+
+  /// Restores an exact recent-page raster without waiting for render hold.
+  ///
+  /// This path is deliberately ahead of the scheduler: the image has already
+  /// been interpreted and read back at the requested physical size, so using
+  /// it cannot introduce the UI-thread hitch that fast-scroll hold prevents.
+  bool _restoreFullRaster() {
+    final cache = widget.previewCache;
+    if (cache == null ||
+        _image != null ||
+        _slugPicture != null ||
+        _layoutWidth == null ||
+        _pixelRatio == null) {
+      return false;
+    }
+    final effective = _effectiveRatio();
+    final dimensions = _rasterDimensions(effective);
+    final image = cache.fullImageFor(
+      widget.previewIndex,
+      widget.page,
+      width: dimensions.$1,
+      height: dimensions.$2,
+      pageColor: widget.pageColor,
+      annotations: widget.showAnnotations,
+      rotation: widget.rotation,
+    );
+    if (image == null) return false;
+    widget.renderScheduler?.cancel(this);
+    _renderGeneration++;
+    setState(() {
+      _image = image;
+      _rasteredRatio = effective;
+      _preview?.dispose();
+      _preview = null;
+    });
+    PdfPerfLog.log('full-raster cache hit page=${widget.previewIndex} '
+        '${image.width}x${image.height}');
+    widget.onRasterReady?.call();
+    return true;
+  }
+
   Future<void> _render() async {
+    if (_restoreFullRaster()) return;
+    // A fit-scale cache restore has no retained picture/scene, but it already
+    // is the exact requested raster. A later scroll-settle generation must not
+    // interpret the page merely to discover that the readback is current.
+    // Zoomed pages still proceed: they may need a retained scene and visible
+    // detail patch even when the capped base raster happens to match.
+    final rastered = _rasteredRatio;
+    if (_picture == null &&
+        _image != null &&
+        rastered != null &&
+        widget.scale <= 1.05 &&
+        (_effectiveRatio() - rastered).abs() <= rastered * 0.01) {
+      return;
+    }
     final scheduler = widget.renderScheduler;
     if (scheduler != null) {
       // Route the first interpret AND every re-raster (zoom settle,
@@ -1278,6 +1340,7 @@ class _PdfPageViewState extends State<PdfPageView> {
         image.dispose();
         return;
       }
+      final cache = widget.previewCache;
       // the previous raster stays up (transform-scaled) until this
       // replaces it, so zooming never flashes white
       setState(() {
@@ -1287,10 +1350,17 @@ class _PdfPageViewState extends State<PdfPageView> {
         _preview?.dispose();
         _preview = null;
       });
+      cache?.putFullImage(
+        widget.previewIndex,
+        widget.page,
+        image,
+        pageColor: widget.pageColor,
+        annotations: widget.showAnnotations,
+        rotation: widget.rotation,
+      );
       // feed the preview cache from the picture we already paid to
       // interpret - this is how previews appear for pages the background
       // prerender hasn't reached (and refresh after edits)
-      final cache = widget.previewCache;
       if (cache != null &&
           !cache.isFresh(
             widget.previewIndex,

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -26,7 +26,13 @@ import 'renderer.dart';
 /// [imageFor] hands out [ui.Image.clone]s, so eviction can never pull
 /// pixels out from under a painting widget.
 class PdfPagePreviewCache extends ChangeNotifier {
-  PdfPagePreviewCache({this.longestSide = 200, this.capacity = 300});
+  PdfPagePreviewCache({
+    this.longestSide = 200,
+    this.capacity = 300,
+    this.maxFullRasterPixels = 8 << 20,
+    this.maxFullRasterEntryPixels = 4 << 20,
+  })  : assert(maxFullRasterPixels >= 0),
+        assert(maxFullRasterEntryPixels >= 0);
 
   /// Pixel size of a preview's longest side. Stretched to page size on
   /// screen the result is soft but recognizable - enough to navigate by.
@@ -35,10 +41,31 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// Maximum number of cached previews (LRU eviction past it).
   final int capacity;
 
+  /// Total pixel budget for exact, recently-viewed page rasters.
+  ///
+  /// These entries remove the soft-preview delay when a lazy page widget is
+  /// rebuilt during back-and-forth scrolling. The default is about 32 MiB of
+  /// RGBA pixels. Set to zero to keep only low-resolution previews.
+  final int maxFullRasterPixels;
+
+  /// Largest exact raster admitted to the recent-page cache.
+  ///
+  /// Oversized/high-zoom pages keep the existing preview + scheduled-render
+  /// path instead of consuming the whole budget. The default is about 16 MiB
+  /// of RGBA pixels, which covers ordinary document pages while excluding the
+  /// large CAD rasters this cache is not intended to retain.
+  final int maxFullRasterEntryPixels;
+
   // LinkedHashMap insertion order doubles as the LRU order: lookups
   // re-insert, eviction takes the first key.
   final _entries = <int, _PreviewEntry>{};
+  final _fullEntries = <int, _FullRasterEntry>{};
+  int _fullRasterPixels = 0;
   bool _disposed = false;
+
+  /// Pixels currently retained by the exact recent-page cache.
+  @visibleForTesting
+  int get debugFullRasterPixels => _fullRasterPixels;
 
   /// Optional persistent backing (see [PdfRasterCache]). When set, fresh
   /// previews are written through to disk as they render, and [loadFromDisk]
@@ -83,6 +110,75 @@ class PdfPagePreviewCache extends ChangeNotifier {
     if (entry == null) return null;
     _entries[index] = entry;
     return entry.image.clone();
+  }
+
+  /// Returns an exact cached raster matching this page and display geometry.
+  ///
+  /// The caller owns the returned clone. A mismatch is a miss: page content,
+  /// paper color, annotation visibility, rotation, and physical pixel size
+  /// all affect the baked raster.
+  ui.Image? fullImageFor(
+    int index,
+    PdfPage page, {
+    required int width,
+    required int height,
+    required Color pageColor,
+    required bool annotations,
+    required int? rotation,
+  }) {
+    final entry = _fullEntries.remove(index);
+    if (entry == null) return null;
+    _fullEntries[index] = entry;
+    if (!identical(entry.page, page) ||
+        entry.image.width != width ||
+        entry.image.height != height ||
+        entry.pageColor != pageColor ||
+        entry.annotations != annotations ||
+        entry.rotation != rotation) {
+      return null;
+    }
+    return entry.image.clone();
+  }
+
+  /// Retains a clone of a completed on-screen raster for immediate reuse.
+  ///
+  /// The cache is an LRU bounded by [maxFullRasterPixels], and rejects a
+  /// single image over [maxFullRasterEntryPixels]. Cloning shares the engine
+  /// image rather than performing another GPU readback.
+  void putFullImage(
+    int index,
+    PdfPage page,
+    ui.Image image, {
+    required Color pageColor,
+    required bool annotations,
+    required int? rotation,
+  }) {
+    if (_disposed) return;
+    final pixels = image.width * image.height;
+    if (maxFullRasterPixels == 0 ||
+        pixels > maxFullRasterEntryPixels ||
+        pixels > maxFullRasterPixels) {
+      return;
+    }
+    final old = _fullEntries.remove(index);
+    if (old != null) {
+      _fullRasterPixels -= old.pixels;
+      old.image.dispose();
+    }
+    final entry = _FullRasterEntry(
+      page,
+      image.clone(),
+      pageColor: pageColor,
+      annotations: annotations,
+      rotation: rotation,
+    );
+    _fullEntries[index] = entry;
+    _fullRasterPixels += entry.pixels;
+    while (_fullRasterPixels > maxFullRasterPixels && _fullEntries.isNotEmpty) {
+      final evicted = _fullEntries.remove(_fullEntries.keys.first)!;
+      _fullRasterPixels -= evicted.pixels;
+      evicted.image.dispose();
+    }
   }
 
   /// Whether any preview (fresh or stale) exists for page [index].
@@ -257,6 +353,16 @@ class PdfPagePreviewCache extends ChangeNotifier {
         _entries[index]!.page = pages[index];
       }
     }
+    for (final index in _fullEntries.keys.toList()) {
+      if (changed != null && changed(index)) {
+        final entry = _fullEntries.remove(index)!;
+        _fullRasterPixels -= entry.pixels;
+        entry.image.dispose();
+        dropped = true;
+      } else if (index < pages.length) {
+        _fullEntries[index]!.page = pages[index];
+      }
+    }
     if (dropped && !_disposed) notifyListeners();
   }
 
@@ -266,6 +372,11 @@ class PdfPagePreviewCache extends ChangeNotifier {
       entry.image.dispose();
     }
     _entries.clear();
+    for (final entry in _fullEntries.values) {
+      entry.image.dispose();
+    }
+    _fullEntries.clear();
+    _fullRasterPixels = 0;
     if (!_disposed) notifyListeners();
   }
 
@@ -276,6 +387,11 @@ class PdfPagePreviewCache extends ChangeNotifier {
       entry.image.dispose();
     }
     _entries.clear();
+    for (final entry in _fullEntries.values) {
+      entry.image.dispose();
+    }
+    _fullEntries.clear();
+    _fullRasterPixels = 0;
     super.dispose();
   }
 }
@@ -286,4 +402,22 @@ class _PreviewEntry {
   PdfPage page;
   final ui.Image image;
   final bool includesImages;
+}
+
+class _FullRasterEntry {
+  _FullRasterEntry(
+    this.page,
+    this.image, {
+    required this.pageColor,
+    required this.annotations,
+    required this.rotation,
+  });
+
+  PdfPage page;
+  final ui.Image image;
+  final Color pageColor;
+  final bool annotations;
+  final int? rotation;
+
+  int get pixels => image.width * image.height;
 }

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -60,6 +60,75 @@ void main() {
     clone.dispose();
   });
 
+  testWidgets('exact raster cache enforces entry and total pixel budgets',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final first = document.page(0);
+    final second = document.page(1);
+    final image = await PdfPageRenderer.renderImage(first, pixelRatio: 0.5);
+    addTearDown(image.dispose);
+    final pixels = image.width * image.height;
+    final cache = PdfPagePreviewCache(
+      maxFullRasterPixels: pixels + 1,
+      maxFullRasterEntryPixels: pixels,
+    );
+    addTearDown(cache.dispose);
+
+    void put(int index, PdfPage page) => cache.putFullImage(
+          index,
+          page,
+          image,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          rotation: null,
+        );
+
+    put(0, first);
+    expect(cache.debugFullRasterPixels, pixels);
+    put(1, second);
+    expect(cache.debugFullRasterPixels, pixels,
+        reason: 'the second exact raster evicts the first under the budget');
+    expect(
+      cache.fullImageFor(
+        0,
+        first,
+        width: image.width,
+        height: image.height,
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: null,
+      ),
+      isNull,
+    );
+    final retained = cache.fullImageFor(
+      1,
+      second,
+      width: image.width,
+      height: image.height,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    expect(retained, isNotNull);
+    retained!.dispose();
+
+    final rejecting = PdfPagePreviewCache(
+      maxFullRasterPixels: pixels,
+      maxFullRasterEntryPixels: pixels - 1,
+    );
+    addTearDown(rejecting.dispose);
+    rejecting.putFullImage(
+      0,
+      first,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    expect(rejecting.debugFullRasterPixels, 0,
+        reason: 'oversized pages remain on the scheduled render path');
+  });
+
   testWidgets('rebind drops previews of pages whose content changed',
       (tester) async {
     // A same-geometry edit revision rebinds previews to the new page objects
@@ -234,6 +303,56 @@ void main() {
     // the full render replaces the preview (which is dropped to free it)
     expect(fullRaster, findsOneWidget);
     expect(previewRaster, findsNothing);
+  });
+
+  testWidgets('a recycled page restores its exact raster through render hold',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+
+    Widget pageView({PdfPageRenderScheduler? scheduler}) => MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 400,
+              child: PdfPageView(
+                page: page,
+                previewCache: cache,
+                renderScheduler: scheduler,
+              ),
+            ),
+          ),
+        );
+
+    // First visit pays the normal interpret + GPU readback and leaves an
+    // exact, bounded cache entry above the lazy page widget.
+    await tester.pumpWidget(pageView());
+    for (var i = 0;
+        i < 50 &&
+            (fullRaster.evaluate().isEmpty || cache.debugFullRasterPixels == 0);
+        i++) {
+      await settle(tester);
+    }
+    expect(fullRaster, findsOneWidget);
+    expect(cache.debugFullRasterPixels, greaterThan(0));
+
+    // Simulate the lazy list disposing the off-screen page, then revisit it
+    // while fast-scroll hold is still raised. Reuse is safe ahead of the
+    // scheduler because this exact physical-size raster already exists.
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    final scheduler = PdfPageRenderScheduler()..holding = true;
+    addTearDown(scheduler.dispose);
+    await tester.pumpWidget(pageView(scheduler: scheduler));
+    await tester.pump();
+    await tester.pump();
+
+    expect(fullRaster, findsOneWidget,
+        reason: 'the recent exact raster should replace blur immediately');
+    expect(previewRaster, findsNothing);
+    expect(scheduler.hasPending, isFalse,
+        reason: 'a cache hit must not wait for scroll-settle release');
   });
 
   testWidgets('an on-screen render feeds the cache without re-interpreting',


### PR DESCRIPTION
## What changed

- retain a small LRU of exact, recently viewed full-page rasters alongside the existing low-resolution preview cache
- restore an exact raster ahead of fast-scroll render hold when page identity, paper color, annotation visibility, rotation, and physical pixel size all match
- skip the redundant fit-scale worker interpretation on the following settle
- cap retention at 8,388,608 pixels total (~32 MiB RGBA) and 4,194,304 pixels per page (~16 MiB), so large/high-zoom CAD pages keep the existing scheduled-render path
- add cache-budget and held-page-revisit regressions plus an opt-in Feature Showcase page-6 benchmark

## Why

When a lazy page widget scrolled out of the build window, its full raster was discarded while only the 200 px preview survived. Revisiting the lightweight Feature Showcase page therefore showed the blurred preview through the generic 250 ms fast-scroll hold and paid another GPU readback even though the page had already rendered.

The PDF work itself was not the bottleneck: the live web trace measured page 6 interpretation at 2.8–4.5 ms. The avoidable costs were the hold and repeated readback.

## Impact

Recently viewed ordinary pages can become sharp as soon as they rebuild, without weakening the render hold that protects scrolling on heavy CAD documents. Exact images are reference-counted clones and memory is bounded by pixel budgets.

Live web verification on the `Annotations & forms` page restored the 953×1233 raster while render hold was still on, about 193 ms before the previous release point. A capture 20 ms after revisiting was already sharp.

## Benchmark

`fvm flutter test tool/showcase_sharpen_benchmark_test.dart` from the example package:

- Feature Showcase page 6 raster: 765×990
- repeated GPU raster: 0.979 ms p50 / 1.446 ms p90
- exact-cache restore: 0.003 ms p50 / 0.003 ms p90
- p50 path reduction: 326×
- retained raster: 2.89 MiB

## Validation

- `fvm dart analyze --fatal-infos`
- 40 focused viewer/render tests across preview, render hold, scheduler, annotation visibility, and page color
- CI-equivalent web render-worker compilation
- opt-in Feature Showcase benchmark
- live in-app browser scroll/revisit trace