### PR TITLE
Refactor editor mutations around a single impact transaction

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -21,7 +21,8 @@ PdfEmbeddableImage _decodeEmbeddableImage(Uint8List bytes) =>
     PdfEmbeddableImage.decode(bytes);
 
 Map<String, Object?> _replaceDocumentColorsOnWorker(
-    Map<String, Object?> message) {
+  Map<String, Object?> message,
+) {
   final document = PdfDocument.open(
     message['bytes']! as Uint8List,
     password: message['password']! as String,
@@ -42,6 +43,11 @@ Map<String, Object?> _replaceDocumentColorsOnWorker(
   return {
     'count': count,
     'bytes': editor.save(),
+    'visualPages': editor.impact.visualPages?.toList(),
+    'contentPages': editor.impact.contentPages?.toList(),
+    'annotationPages': editor.impact.annotationPages?.toList(),
+    'pageStructureChanged': editor.impact.pageStructureChanged,
+    'destructive': editor.impact.destructive,
   };
 }
 
@@ -284,9 +290,11 @@ class PdfEditingController extends ChangeNotifier {
     'username',
   ];
 
-  PdfEditingController(Uint8List bytes,
-      {String password = '', PdfEditingPreferences? preferences})
-      : _bytes = bytes,
+  PdfEditingController(
+    Uint8List bytes, {
+    String password = '',
+    PdfEditingPreferences? preferences,
+  })  : _bytes = bytes,
         _password = password,
         _revisions = [bytes.length],
         _document = PdfDocument.open(bytes, password: password),
@@ -330,16 +338,10 @@ class PdfEditingController extends ChangeNotifier {
   final List<int> _revisions;
   int _cursor = 0;
 
-  /// Parallels [_revisions]: the page indices each revision changed
-  /// visually (null = unknown, treat as all). Entry 0 - the original
-  /// document - is never consulted.
-  final List<Set<int>?> _revisionPages = [null];
-
-  /// Parallels [_revisions]: the page indices whose base page content image
-  /// changed (null = unknown, treat as all). Annotation-only revisions still
-  /// change [_revisionPages] so thumbnails refresh, but leave this empty so
-  /// the viewer can keep its expensive page/deep-zoom raster.
-  final List<Set<int>?> _revisionContentPages = [null];
+  /// Parallels [_revisions]: the consequences reported by the document
+  /// mutation that produced each revision. Entry 0 is the original document
+  /// and is never replayed.
+  final List<PdfEditImpact> _revisionImpacts = [PdfEditImpact.none];
 
   /// Render stamps: how many times each page's rendering has changed.
   /// [_renderStampEpoch] counts the all-pages bumps (structural edits,
@@ -424,26 +426,24 @@ class PdfEditingController extends ChangeNotifier {
   void undo() {
     if (!canUndo) return;
     final beforeLength = _revisions[_cursor];
-    final pages = _revisionPages[_cursor];
-    final contentPages = _revisionContentPages[_cursor];
+    final impact = _revisionImpacts[_cursor];
     // reverting revision N un-renders exactly the pages N touched
-    _bumpRenderStamps(pages);
-    _bumpContentRenderStamps(contentPages);
+    _bumpRenderStamps(impact.visualPages);
+    _bumpContentRenderStamps(impact.contentPages);
     _cursor--;
     _reopen();
-    _emitAnnotationChanges(beforeLength, pages);
+    _emitAnnotationChanges(beforeLength, impact.annotationPages);
   }
 
   void redo() {
     if (!canRedo) return;
     final beforeLength = _revisions[_cursor];
     _cursor++;
-    final pages = _revisionPages[_cursor];
-    final contentPages = _revisionContentPages[_cursor];
-    _bumpRenderStamps(pages);
-    _bumpContentRenderStamps(contentPages);
+    final impact = _revisionImpacts[_cursor];
+    _bumpRenderStamps(impact.visualPages);
+    _bumpContentRenderStamps(impact.contentPages);
     _reopen();
-    _emitAnnotationChanges(beforeLength, pages);
+    _emitAnnotationChanges(beforeLength, impact.annotationPages);
   }
 
   void _reopen() {
@@ -459,27 +459,28 @@ class PdfEditingController extends ChangeNotifier {
   /// changes. Redoable revisions are discarded, like any editor's redo
   /// stack on a fresh edit.
   ///
-  /// [pages] names the page indices the edit changes visually - it feeds
-  /// [pageRenderStamp], which lets page thumbnails skip re-rendering
-  /// pages an edit didn't touch. Omit it (null) when the affected pages
-  /// are unknown and every page's stamp is bumped.
-  ///
-  /// [contentPages] names the pages whose base page content image changed.
-  /// Omit it to conservatively mirror [pages]. Pass an empty iterable for
-  /// annotation-only edits that should update thumbnails/overlays without
-  /// invalidating deep-zoom page rasters.
-  bool apply(void Function(PdfEditor editor) edit,
-      {Iterable<int>? pages, Iterable<int>? contentPages}) {
+  /// The [PdfEditor] mutation reports its own [PdfEditor.impact], so callers
+  /// do not need to coordinate render caches, annotation sync, or structural
+  /// selection invalidation. [pages] and [contentPages] remain only for
+  /// source compatibility with older custom callers; package mutations do
+  /// not use them.
+  bool apply(
+    void Function(PdfEditor editor) edit, {
+    Iterable<int>? pages,
+    Iterable<int>? contentPages,
+  }) {
     final editor = PdfEditor(_document);
     edit(editor);
     if (!editor.hasChanges) return false;
+    final impact = pages != null || contentPages != null
+        ? PdfEditImpact.legacy(pages: pages, contentPages: contentPages)
+        : editor.impact;
     final saved = editor.save();
     final beforeLength = _revisions[_cursor];
     _commitSavedRevision(
       saved,
       beforeLength: beforeLength,
-      pages: pages,
-      contentPages: contentPages,
+      impact: impact,
     );
     return true;
   }
@@ -487,35 +488,34 @@ class PdfEditingController extends ChangeNotifier {
   void _commitSavedRevision(
     Uint8List saved, {
     required int beforeLength,
-    Iterable<int>? pages,
-    Iterable<int>? contentPages,
+    required PdfEditImpact impact,
   }) {
-    final touched = pages == null ? null : Set<int>.unmodifiable(pages);
-    final contentTouched =
-        contentPages == null ? touched : Set<int>.unmodifiable(contentPages);
     _revisions.removeRange(_cursor + 1, _revisions.length);
-    _revisionPages.removeRange(_cursor + 1, _revisionPages.length);
-    _revisionContentPages.removeRange(
-        _cursor + 1, _revisionContentPages.length);
+    _revisionImpacts.removeRange(_cursor + 1, _revisionImpacts.length);
     _bytes = saved;
     _revisions.add(saved.length);
-    _revisionPages.add(touched);
-    _revisionContentPages.add(contentTouched);
-    _bumpRenderStamps(touched);
-    _bumpContentRenderStamps(contentTouched);
+    _revisionImpacts.add(impact);
+    _bumpRenderStamps(impact.visualPages);
+    _bumpContentRenderStamps(impact.contentPages);
+    if (impact.destructive) _destructiveStampEpoch++;
     _cursor++;
     final selected = List.of(_selected);
     _document = PdfDocument.open(bytes, password: _password);
-    // annotations keep their /Annots slot across move/resize edits, so a
-    // still-valid selection survives the document swap
-    _selected
-      ..clear()
-      ..addAll([
+    // Existing controller mutations remap slots before committing when an
+    // /Annots edit shifts them. The transaction validates that post-mutation
+    // selection against the reopened revision in one place.
+    _selected.clear();
+    if (!impact.pageStructureChanged) {
+      _selected.addAll([
         for (final slot in selected)
-          if (_annotationAt(slot) != null) slot
+          if (_annotationAt(slot) != null) slot,
       ]);
+    } else {
+      _selectedPages.clear();
+      _pageSelectionAnchor = null;
+    }
     _invalidateElements();
-    _emitAnnotationChanges(beforeLength, touched);
+    _emitAnnotationChanges(beforeLength, impact.annotationPages);
     notifyListeners();
   }
 
@@ -529,31 +529,47 @@ class PdfEditingController extends ChangeNotifier {
   /// page is supplied. [parentPath] identifies the parent outline item; null
   /// adds a top-level bookmark. Returns false when the title/page/path is
   /// invalid or the edit stages no PDF changes.
-  bool addBookmark(String title,
-      {int? pageIndex, List<int>? parentPath, int? index, bool open = true}) {
+  bool addBookmark(
+    String title, {
+    int? pageIndex,
+    List<int>? parentPath,
+    int? index,
+    bool open = true,
+  }) {
     final text = title.trim();
     if (text.isEmpty) return false;
     final page = (pageIndex ?? 0);
     if (page < 0 || page >= _document.pageCount) return false;
     var resolvedParent = true;
-    final changed = apply((editor) {
-      final parent = parentPath == null
-          ? null
-          : _outlineRefAt(editor.document, parentPath);
-      if (parentPath != null && parent == null) {
-        resolvedParent = false;
-        return;
-      }
-      editor.addOutlineItem(text,
-          pageIndex: page, parent: parent, index: index, open: open);
-    }, pages: const <int>[], contentPages: const <int>[]);
+    final changed = apply(
+      (editor) {
+        final parent = parentPath == null
+            ? null
+            : _outlineRefAt(editor.document, parentPath);
+        if (parentPath != null && parent == null) {
+          resolvedParent = false;
+          return;
+        }
+        editor.addOutlineItem(
+          text,
+          pageIndex: page,
+          parent: parent,
+          index: index,
+          open: open,
+        );
+      },
+    );
     return resolvedParent && changed;
   }
 
   /// Edits an existing bookmark addressed by [path]. A null field is left
   /// unchanged. Page destinations are written as explicit `/Fit` destinations.
-  bool editBookmark(List<int> path,
-      {String? title, int? pageIndex, bool? open}) {
+  bool editBookmark(
+    List<int> path, {
+    String? title,
+    int? pageIndex,
+    bool? open,
+  }) {
     final text = title?.trim();
     if (text != null && text.isEmpty) return false;
     if (pageIndex != null &&
@@ -562,33 +578,39 @@ class PdfEditingController extends ChangeNotifier {
     }
     if (text == null && pageIndex == null && open == null) return false;
     var resolved = true;
-    final changed = apply((editor) {
-      final item = _outlineRefAt(editor.document, path);
-      if (item == null) {
-        resolved = false;
-        return;
-      }
-      if (text != null) editor.setOutlineTitle(item, text);
-      if (pageIndex != null) {
-        editor.setOutlineDestination(
-            item, PdfExplicitDestination.fit(pageIndex));
-      }
-      if (open != null) editor.setOutlineStyle(item, open: open);
-    }, pages: const <int>[], contentPages: const <int>[]);
+    final changed = apply(
+      (editor) {
+        final item = _outlineRefAt(editor.document, path);
+        if (item == null) {
+          resolved = false;
+          return;
+        }
+        if (text != null) editor.setOutlineTitle(item, text);
+        if (pageIndex != null) {
+          editor.setOutlineDestination(
+            item,
+            PdfExplicitDestination.fit(pageIndex),
+          );
+        }
+        if (open != null) editor.setOutlineStyle(item, open: open);
+      },
+    );
     return resolved && changed;
   }
 
   /// Deletes the bookmark at [path], including its child bookmark subtree.
   bool deleteBookmark(List<int> path) {
     var resolved = true;
-    final changed = apply((editor) {
-      final item = _outlineRefAt(editor.document, path);
-      if (item == null) {
-        resolved = false;
-        return;
-      }
-      editor.removeOutlineItem(item);
-    }, pages: const <int>[], contentPages: const <int>[]);
+    final changed = apply(
+      (editor) {
+        final item = _outlineRefAt(editor.document, path);
+        if (item == null) {
+          resolved = false;
+          return;
+        }
+        editor.removeOutlineItem(item);
+      },
+    );
     return resolved && changed;
   }
 
@@ -652,17 +674,22 @@ class PdfEditingController extends ChangeNotifier {
   /// from its bytes (a prefix of the live buffer): the editor mutates
   /// the in-memory COS of the document it ran on, so the pre-edit
   /// [PdfDocument] object is already contaminated with the edit.
-  void _emitAnnotationChanges(int beforeLength, Iterable<int>? pages) {
+  void _emitAnnotationChanges(
+    int beforeLength,
+    Iterable<int>? annotationPages,
+  ) {
     final feed = _changeFeed;
     if (feed == null || !feed.hasListener || _applyingRemote) return;
+    if (annotationPages != null && annotationPages.isEmpty) return;
     final before = PdfDocument.open(
-        Uint8List.sublistView(_bytes, 0, beforeLength),
-        password: _password);
-    // `pages` names render-changed pages; metadata edits (contents,
-    // author) pass an empty set because nothing repaints, yet the
-    // annotation content did change - diff everything for those.
-    final diffPages = pages != null && pages.isEmpty ? null : pages;
-    final changes = pdfDiffAnnotations(before, _document, pages: diffPages);
+      Uint8List.sublistView(_bytes, 0, beforeLength),
+      password: _password,
+    );
+    final changes = pdfDiffAnnotations(
+      before,
+      _document,
+      pages: annotationPages,
+    );
     if (changes.isNotEmpty) feed.add(changes);
   }
 
@@ -690,17 +717,20 @@ class PdfEditingController extends ChangeNotifier {
           final touched = {change.pageIndex, if (existing != null) existing.$1};
           // slots on the touched pages shift under the remove + append
           _selected.removeWhere((slot) => touched.contains(slot.$1));
-          return apply((e) => e.upsertAnnotation(change.pageIndex, snapshot),
-              pages: touched, contentPages: const <int>[]);
+          return apply(
+            (e) => e.upsertAnnotation(change.pageIndex, snapshot),
+          );
         case PdfAnnotationChangeKind.removed:
           final name = change.name;
           if (name == null) return false;
           final existing = findAnnotationByName(name);
           if (existing == null) return false;
           _selected.removeWhere((slot) => slot.$1 == existing.$1);
-          return apply((e) {
-            e.removeAnnotation(existing.$1, existing.$2);
-          }, pages: [existing.$1], contentPages: const <int>[]);
+          return apply(
+            (e) {
+              e.removeAnnotation(existing.$1, existing.$2);
+            },
+          );
       }
     } finally {
       _applyingRemote = false;
@@ -715,7 +745,7 @@ class PdfEditingController extends ChangeNotifier {
     var named = 0;
     _applyingRemote = true; // names are identity, not an annotation edit
     try {
-      apply((e) => named = e.nameAnnotations(), pages: const <int>[]);
+      apply((e) => named = e.nameAnnotations());
     } finally {
       _applyingRemote = false;
     }
@@ -731,15 +761,20 @@ class PdfEditingController extends ChangeNotifier {
     for (var pageIndex = 0; pageIndex < _document.pageCount; pageIndex++) {
       for (final annotation in _page(pageIndex).annotations) {
         if (annotation.name == null) continue;
-        final snapshot = PdfAnnotationSnapshot.capture(_document, annotation,
-            keepName: true);
+        final snapshot = PdfAnnotationSnapshot.capture(
+          _document,
+          annotation,
+          keepName: true,
+        );
         if (snapshot == null) continue;
-        changes.add(PdfAnnotationChange(
-          kind: PdfAnnotationChangeKind.created,
-          pageIndex: pageIndex,
-          name: annotation.name,
-          snapshot: snapshot,
-        ));
+        changes.add(
+          PdfAnnotationChange(
+            kind: PdfAnnotationChangeKind.created,
+            pageIndex: pageIndex,
+            name: annotation.name,
+            snapshot: snapshot,
+          ),
+        );
       }
     }
     return changes;
@@ -795,8 +830,12 @@ class PdfEditingController extends ChangeNotifier {
     // each annotation tool remembers its own colour, stroke, opacity, … -
     // arming one restores its saved style and routes further style changes
     // back into its slot (see [PdfEditingPreferences.beginStyleScope])
-    preferences.beginStyleScope(_styleScopeKey(value), _styleScopeFields(value),
-        defaults: _styleScopeDefaults(value), lockedFields: _lockedStyleFields);
+    preferences.beginStyleScope(
+      _styleScopeKey(value),
+      _styleScopeFields(value),
+      defaults: _styleScopeDefaults(value),
+      lockedFields: _lockedStyleFields,
+    );
     notifyListeners();
     if (deferInkCommit) Timer.run(finishInk);
   }
@@ -816,10 +855,13 @@ class PdfEditingController extends ChangeNotifier {
     if (value == _colorLocked) return;
     preferences.snapshotActiveStyleScope(lockedFields: _lockedStyleFields);
     _colorLocked = value;
-    preferences.beginStyleScope(_styleScopeKey(_tool), _styleScopeFields(_tool),
-        defaults: _styleScopeDefaults(_tool),
-        lockedFields: _lockedStyleFields,
-        forceRestore: true);
+    preferences.beginStyleScope(
+      _styleScopeKey(_tool),
+      _styleScopeFields(_tool),
+      defaults: _styleScopeDefaults(_tool),
+      lockedFields: _lockedStyleFields,
+      forceRestore: true,
+    );
     notifyListeners();
   }
 
@@ -892,7 +934,7 @@ class PdfEditingController extends ChangeNotifier {
         PdfEditTool.ink || PdfEditTool.highlight => const {
             'color',
             'strokeWidth',
-            'opacity',
+            'opacity'
           },
         PdfEditTool.eraser => const {'eraserRadius'},
         PdfEditTool.rectangle ||
@@ -904,7 +946,7 @@ class PdfEditingController extends ChangeNotifier {
             'strokeWidth',
             'opacity',
             'lineStyle',
-            'shapeFillColor'
+            'shapeFillColor',
           },
         PdfEditTool.line || PdfEditTool.polyline => const {
             'color',
@@ -959,9 +1001,13 @@ class PdfEditingController extends ChangeNotifier {
   /// tool, so the toolbar calls this when its Markup strip opens, giving
   /// markup its own remembered colour and opacity (the classic yellow
   /// highlighter that stays yellow). See [preferences].
-  void useMarkupStyleScope() =>
-      preferences.beginStyleScope('markup', const {'color', 'opacity'},
-          lockedFields: _lockedStyleFields);
+  void useMarkupStyleScope() => preferences.beginStyleScope(
+      'markup',
+      const {
+        'color',
+        'opacity',
+      },
+      lockedFields: _lockedStyleFields);
 
   /// Whether the armed [tool] creates annotations that carry a colour the
   /// toolbar can offer - i.e. the tool's style scope remembers `color`.
@@ -1250,8 +1296,11 @@ class PdfEditingController extends ChangeNotifier {
     if (hadSelection != hasEditingTextSelection) notifyListeners();
   }
 
-  bool restyleEditingTextSelection(
-      {PdfTextFont? font, double? size, int? color}) {
+  bool restyleEditingTextSelection({
+    PdfTextFont? font,
+    double? size,
+    int? color,
+  }) {
     if (!hasEditingTextSelection) return false;
     _editingTextStyleRequest = (font: font, size: size, color: color);
     _editingTextStyleRevision++;
@@ -1434,8 +1483,11 @@ class PdfEditingController extends ChangeNotifier {
   /// Buffers one drawn stroke; the buffer commits on its own after
   /// [inkCommitDelay], or through [finishInk].
   /// [pressures], when given, must hold one 0–1 value per stroke point.
-  void addInkStroke(int pageIndex, List<(double, double)> stroke,
-      {List<double>? pressures}) {
+  void addInkStroke(
+    int pageIndex,
+    List<(double, double)> stroke, {
+    List<double>? pressures,
+  }) {
     if (stroke.isEmpty) return;
     assert(pressures == null || pressures.length == stroke.length);
     _ink.putIfAbsent(pageIndex, () => []).add(List.of(stroke));
@@ -1457,25 +1509,31 @@ class PdfEditingController extends ChangeNotifier {
     final pressures = Map.of(_inkPressures);
     _ink.clear();
     _inkPressures.clear();
-    final committed = apply((editor) {
-      strokes.forEach((page, pageStrokes) {
-        if (pageStrokes.isNotEmpty) {
-          editor.addInk(page, pageStrokes,
+    final committed = apply(
+      (editor) {
+        strokes.forEach((page, pageStrokes) {
+          if (pageStrokes.isNotEmpty) {
+            editor.addInk(
+              page,
+              pageStrokes,
               color: _colorValue,
               strokeWidth: preferences.strokeWidth,
               opacity: preferences.opacity,
               pressures: pressures[page],
-              author: author);
-        }
-      });
-    }, pages: strokes.keys, contentPages: const <int>[]);
+              author: author,
+            );
+          }
+        });
+      },
+    );
     if (committed) {
       _committedInk = (
         document: _document,
         strokes: strokes,
         pressures: pressures,
-        color: preferences.color
-            .withValues(alpha: preferences.opacity.clamp(0.0, 1.0)),
+        color: preferences.color.withValues(
+          alpha: preferences.opacity.clamp(0.0, 1.0),
+        ),
         strokeWidth: preferences.strokeWidth,
       );
     }
@@ -1498,45 +1556,61 @@ class PdfEditingController extends ChangeNotifier {
   /// rects, e.g. from [PdfViewerController.selectionRectsOn]).
   void addMarkup(PdfMarkupKind kind, Map<int, List<PdfRect>> quadsByPage) {
     if (quadsByPage.values.every((quads) => quads.isEmpty)) return;
-    apply((editor) {
-      quadsByPage.forEach((page, quads) {
-        if (quads.isEmpty) return;
-        switch (kind) {
-          case PdfMarkupKind.highlight:
-            editor.addHighlight(page, quads,
+    apply(
+      (editor) {
+        quadsByPage.forEach((page, quads) {
+          if (quads.isEmpty) return;
+          switch (kind) {
+            case PdfMarkupKind.highlight:
+              editor.addHighlight(
+                page,
+                quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author);
-          case PdfMarkupKind.underline:
-            editor.addUnderline(page, quads,
+                author: author,
+              );
+            case PdfMarkupKind.underline:
+              editor.addUnderline(
+                page,
+                quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author);
-          case PdfMarkupKind.strikeOut:
-            editor.addStrikeOut(page, quads,
+                author: author,
+              );
+            case PdfMarkupKind.strikeOut:
+              editor.addStrikeOut(
+                page,
+                quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author);
-          case PdfMarkupKind.squiggly:
-            editor.addSquiggly(page, quads,
+                author: author,
+              );
+            case PdfMarkupKind.squiggly:
+              editor.addSquiggly(
+                page,
+                quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author);
-        }
-      });
-    }, pages: quadsByPage.keys, contentPages: const <int>[]);
+                author: author,
+              );
+          }
+        });
+      },
+    );
   }
 
   void addRectangle(int pageIndex, PdfRect rect) => apply(
-      (e) => e.addSquare(pageIndex, rect,
+        (e) => e.addSquare(
+          pageIndex,
+          rect,
           strokeColor: _colorValue,
           strokeWidth: preferences.strokeWidth,
           fillColor: _rgbOf(preferences.shapeFillColor),
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
-          author: author),
-      pages: [pageIndex],
-      contentPages: const <int>[]);
+          author: author,
+        ),
+      );
 
   // ---------------------------------------------------------------------
   // redaction
@@ -1544,20 +1618,24 @@ class PdfEditingController extends ChangeNotifier {
   /// Marks a single rectangular region for redaction (a /Redact
   /// annotation, fill black). This is the MARK phase - nothing is removed
   /// until [applyRedactions]. Undoable like any other edit until burned.
-  void addRedaction(int pageIndex, PdfRect rect) =>
-      apply((e) => e.addRedaction(pageIndex, [rect], author: author),
-          pages: [pageIndex], contentPages: const <int>[]);
+  void addRedaction(int pageIndex, PdfRect rect) => apply(
+        (e) => e.addRedaction(pageIndex, [rect], author: author),
+      );
 
   /// Marks the text runs in [quadsByPage] for redaction (one /Redact
   /// annotation per page, fill black), e.g. from a text selection. Mirrors
   /// [addMarkup].
   void addRedactionQuads(Map<int, List<PdfRect>> quadsByPage) {
     if (quadsByPage.values.every((quads) => quads.isEmpty)) return;
-    apply((editor) {
-      quadsByPage.forEach((page, quads) {
-        if (quads.isNotEmpty) editor.addRedaction(page, quads, author: author);
-      });
-    }, pages: quadsByPage.keys, contentPages: const <int>[]);
+    apply(
+      (editor) {
+        quadsByPage.forEach((page, quads) {
+          if (quads.isNotEmpty) {
+            editor.addRedaction(page, quads, author: author);
+          }
+        });
+      },
+    );
   }
 
   /// Whether any page carries a marked (unburned) /Redact annotation.
@@ -1580,106 +1658,112 @@ class PdfEditingController extends ChangeNotifier {
     if (!hasRedactionMarks) return false;
     final editor = PdfEditor(_document);
     final burned = editor.applyRedactions();
-    _resetTo(burned);
+    _resetTo(burned, impact: editor.impact);
     return true;
   }
 
   /// Replaces the byte buffer with [bytes] as a fresh single revision,
   /// discarding undo history. Used by [applyRedactions] (the burned file
   /// is not a prefix of the prior buffer).
-  void _resetTo(Uint8List bytes) {
+  void _resetTo(Uint8List bytes, {required PdfEditImpact impact}) {
     _bytes = bytes;
     _revisions
       ..clear()
       ..add(bytes.length);
-    _revisionPages
+    _revisionImpacts
       ..clear()
-      ..add(null);
-    _revisionContentPages
-      ..clear()
-      ..add(null);
+      ..add(PdfEditImpact.none);
     _cursor = 0;
     _hardModified = true;
     _selected.clear();
-    _bumpRenderStamps(null); // every page may have changed
-    _bumpContentRenderStamps(null);
+    _bumpRenderStamps(impact.visualPages);
+    _bumpContentRenderStamps(impact.contentPages);
     // a burn removes content irreversibly - mark it destructive so the
     // viewer blanks each page's raster instead of holding the (now
     // un-redacted) one up while the fresh render lands
-    _destructiveStampEpoch++;
+    if (impact.destructive) _destructiveStampEpoch++;
     _document = PdfDocument.open(bytes, password: _password);
     _invalidateElements();
     notifyListeners();
   }
 
   void addEllipse(int pageIndex, PdfRect rect) => apply(
-      (e) => e.addCircle(pageIndex, rect,
+        (e) => e.addCircle(
+          pageIndex,
+          rect,
           strokeColor: _colorValue,
           strokeWidth: preferences.strokeWidth,
           fillColor: _rgbOf(preferences.shapeFillColor),
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
-          author: author),
-      pages: [pageIndex],
-      contentPages: const <int>[]);
+          author: author,
+        ),
+      );
 
   /// Adds a line from [start] to [end]. With [arrow] the end carries a
   /// closed arrowhead (the dedicated arrow tool); otherwise the start and
   /// end endings come from the persisted [PdfEditingPreferences]
   /// ([lineStartEnding] / [lineEndEnding]).
-  void addLine(int pageIndex, (double, double) start, (double, double) end,
-          {bool arrow = false}) =>
+  void addLine(
+    int pageIndex,
+    (double, double) start,
+    (double, double) end, {
+    bool arrow = false,
+  }) =>
       apply(
-          (e) => e.addLine(pageIndex, start, end,
-              strokeColor: _colorValue,
-              strokeWidth: preferences.strokeWidth,
-              opacity: preferences.opacity,
-              dashPattern: _lineDashPattern,
-              startEnding:
-                  arrow ? PdfLineEnding.none : preferences.lineStartEnding,
-              endEnding:
-                  arrow ? PdfLineEnding.closedArrow : preferences.lineEndEnding,
-              author: author),
-          pages: [pageIndex],
-          contentPages: const <int>[]);
+        (e) => e.addLine(
+          pageIndex,
+          start,
+          end,
+          strokeColor: _colorValue,
+          strokeWidth: preferences.strokeWidth,
+          opacity: preferences.opacity,
+          dashPattern: _lineDashPattern,
+          startEnding: arrow ? PdfLineEnding.none : preferences.lineStartEnding,
+          endEnding:
+              arrow ? PdfLineEnding.closedArrow : preferences.lineEndEnding,
+          author: author,
+        ),
+      );
 
   void addPolyLine(int pageIndex, List<(double, double)> points) => apply(
-      (e) => e.addPolyLine(pageIndex, points,
+        (e) => e.addPolyLine(
+          pageIndex,
+          points,
           strokeColor: _colorValue,
           strokeWidth: preferences.strokeWidth,
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
           startEnding: preferences.lineStartEnding,
           endEnding: preferences.lineEndEnding,
-          author: author),
-      pages: [pageIndex],
-      contentPages: const <int>[]);
+          author: author,
+        ),
+      );
 
   void addPolygon(int pageIndex, List<(double, double)> points) => apply(
-      (e) => e.addPolygon(pageIndex, points,
+        (e) => e.addPolygon(
+          pageIndex,
+          points,
           strokeColor: _colorValue,
           strokeWidth: preferences.strokeWidth,
           fillColor: _rgbOf(preferences.shapeFillColor),
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
-          author: author),
-      pages: [pageIndex],
-      contentPages: const <int>[]);
-
-  /// Drag out a rectangular cloudy /Polygon from an axis-aligned [rect].
-  void addCloudPolygon(int pageIndex, PdfRect rect) => addCloudPolygonPoints(
-        pageIndex,
-        [
-          (rect.left, rect.bottom),
-          (rect.right, rect.bottom),
-          (rect.right, rect.top),
-          (rect.left, rect.top),
-        ],
+          author: author,
+        ),
       );
 
+  /// Drag out a rectangular cloudy /Polygon from an axis-aligned [rect].
+  void addCloudPolygon(int pageIndex, PdfRect rect) =>
+      addCloudPolygonPoints(pageIndex, [
+        (rect.left, rect.bottom),
+        (rect.right, rect.bottom),
+        (rect.right, rect.top),
+        (rect.left, rect.top),
+      ]);
+
   /// Click out a cloudy /Polygon from an arbitrary vertex list (3+ points).
-  void addCloudPolygonPoints(
-          int pageIndex, List<(double, double)> points) =>
+  void addCloudPolygonPoints(int pageIndex, List<(double, double)> points) =>
       apply(
         (e) => e.addPolygon(
           pageIndex,
@@ -1692,8 +1776,6 @@ class PdfEditingController extends ChangeNotifier {
           cloudy: true,
           author: author,
         ),
-        pages: [pageIndex],
-        contentPages: const <int>[],
       );
 
   // ---------------------------------------------------------------------
@@ -1772,8 +1854,10 @@ class PdfEditingController extends ChangeNotifier {
 
   /// The live net-area readout (outer shoelace minus [holes]) for a
   /// page-space polygon, or null without a scale or fewer than three points.
-  String? measuredNetArea(List<(double, double)> points,
-      [List<List<(double, double)>> holes = const []]) {
+  String? measuredNetArea(
+    List<(double, double)> points, [
+    List<List<(double, double)>> holes = const [],
+  ]) {
     final scale = measurementScale;
     if (scale == null || points.length < 3) return null;
     return scale.toMeasure().formatArea(pdfNetPolygonArea(points, holes));
@@ -1830,32 +1914,39 @@ class PdfEditingController extends ChangeNotifier {
     final scale = measurementScale;
     if (scale == null && kind != PdfMeasurementKind.count) return;
     apply(
-      (e) => e.addMeasurement(pageIndex, kind, points,
-          measure: scale?.toMeasure(),
-          depth: depth,
-          holes: holes,
-          label: label,
-          strokeColor: _colorValue,
-          strokeWidth: preferences.strokeWidth,
-          fillColor: _rgbOf(preferences.shapeFillColor),
-          opacity: preferences.opacity,
-          dashPattern: _lineDashPattern,
-          // the caption is base-14 text; an embedded selection falls back
-          // to the active standard family
-          captionFont: preferences.fontFamily,
-          captionSize: preferences.fontSize,
-          startEnding: preferences.lineStartEnding,
-          endEnding: preferences.lineEndEnding,
-          author: author),
-      pages: [pageIndex],
-      contentPages: const <int>[],
+      (e) => e.addMeasurement(
+        pageIndex,
+        kind,
+        points,
+        measure: scale?.toMeasure(),
+        depth: depth,
+        holes: holes,
+        label: label,
+        strokeColor: _colorValue,
+        strokeWidth: preferences.strokeWidth,
+        fillColor: _rgbOf(preferences.shapeFillColor),
+        opacity: preferences.opacity,
+        dashPattern: _lineDashPattern,
+        // the caption is base-14 text; an embedded selection falls back
+        // to the active standard family
+        captionFont: preferences.fontFamily,
+        captionSize: preferences.fontSize,
+        startEnding: preferences.lineStartEnding,
+        endEnding: preferences.lineEndEnding,
+        author: author,
+      ),
     );
   }
 
   /// Drops a single count marker at the page-space [point], tagged [label]
   /// so the running total tallies it with its siblings.
   void addCountMark(int pageIndex, (double, double) point, {String? label}) =>
-      addMeasurement(pageIndex, PdfMeasurementKind.count, [point],
+      addMeasurement(
+          pageIndex,
+          PdfMeasurementKind.count,
+          [
+            point,
+          ],
           label: label);
 
   /// The per-tool running totals over the live document - the takeoff
@@ -1875,11 +1966,13 @@ class PdfEditingController extends ChangeNotifier {
     final pages = pageIndex != null
         ? [pageIndex]
         : List<int>.generate(_document.pageCount, (i) => i);
-    apply((e) {
-      for (final p in pages) {
-        e.setPageMeasurementScale(p, measure);
-      }
-    }, pages: pages, contentPages: const <int>[]);
+    apply(
+      (e) {
+        for (final p in pages) {
+          e.setPageMeasurementScale(p, measure);
+        }
+      },
+    );
   }
 
   /// Adopts the drawing scale the document already carries (a page /VP
@@ -1914,7 +2007,9 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   ({double width, double height}) _visualSizeOfPageRect(
-      int pageIndex, PdfRect rect) {
+    int pageIndex,
+    PdfRect rect,
+  ) {
     return _pageIsSideways(pageIndex)
         ? (width: rect.height, height: rect.width)
         : (width: rect.width, height: rect.height);
@@ -1934,11 +2029,18 @@ class PdfEditingController extends ChangeNotifier {
     final cx = x.clamp(box.left + pageW / 2, box.right - pageW / 2);
     final cy = y.clamp(box.bottom + pageH / 2, box.top - pageH / 2);
     return PdfRect(
-        cx - pageW / 2, cy - pageH / 2, cx + pageW / 2, cy + pageH / 2);
+      cx - pageW / 2,
+      cy - pageH / 2,
+      cx + pageW / 2,
+      cy + pageH / 2,
+    );
   }
 
   void addFreeText(int pageIndex, PdfRect rect, String text) => apply(
-      (e) => e.addFreeText(pageIndex, rect, text,
+        (e) => e.addFreeText(
+          pageIndex,
+          rect,
+          text,
           fontSize: preferences.fontSize,
           font: _activeFont ?? preferences.fontFamily,
           align: preferences.textAlign,
@@ -1947,51 +2049,70 @@ class PdfEditingController extends ChangeNotifier {
           borderColor: _rgbOf(preferences.textBorderColor),
           borderWidth: preferences.strokeWidth,
           pageRotation: _page(pageIndex).rotation,
-          author: author),
-      pages: [pageIndex],
-      contentPages: const <int>[]);
+          author: author,
+        ),
+      );
 
   /// Places a callout: a [text] box at [rect] with a leader line pointing at
   /// [target] on the page (both in page space). Mirrors [addFreeText] for the
   /// box styling and points the arrow with the tool's stroke color/width.
   void addCallout(
-          int pageIndex, PdfRect rect, String text, (double, double) target) =>
+    int pageIndex,
+    PdfRect rect,
+    String text,
+    (double, double) target,
+  ) =>
       apply(
-          (e) => e.addCallout(pageIndex, rect, text, target,
-              fontSize: preferences.fontSize,
-              font: _activeFont ?? preferences.fontFamily,
-              align: preferences.textAlign,
-              color: _colorValue,
-              fillColor: _rgbOf(preferences.textFillColor),
-              // the box outline and leader share one stroke; fall back to the
-              // text color so the arrow always has a definite color/width
-              strokeColor: _rgbOf(preferences.textBorderColor) ?? _colorValue,
-              strokeWidth: preferences.strokeWidth,
-              pageRotation: _page(pageIndex).rotation,
-              author: author),
-          pages: [pageIndex],
-          contentPages: const <int>[]);
+        (e) => e.addCallout(
+          pageIndex,
+          rect,
+          text,
+          target,
+          fontSize: preferences.fontSize,
+          font: _activeFont ?? preferences.fontFamily,
+          align: preferences.textAlign,
+          color: _colorValue,
+          fillColor: _rgbOf(preferences.textFillColor),
+          // the box outline and leader share one stroke; fall back to the
+          // text color so the arrow always has a definite color/width
+          strokeColor: _rgbOf(preferences.textBorderColor) ?? _colorValue,
+          strokeWidth: preferences.strokeWidth,
+          pageRotation: _page(pageIndex).rotation,
+          author: author,
+        ),
+      );
 
   void addFreeTextRich(
-          int pageIndex, PdfRect rect, List<PdfFreeTextRun> runs) =>
+    int pageIndex,
+    PdfRect rect,
+    List<PdfFreeTextRun> runs,
+  ) =>
       apply(
-          (e) => e.addFreeTextRich(pageIndex, rect, runs,
-              align: preferences.textAlign,
-              fillColor: _rgbOf(preferences.textFillColor),
-              borderColor: _rgbOf(preferences.textBorderColor),
-              borderWidth: preferences.strokeWidth,
-              pageRotation: _page(pageIndex).rotation,
-              author: author),
-          pages: [pageIndex],
-          contentPages: const <int>[]);
+        (e) => e.addFreeTextRich(
+          pageIndex,
+          rect,
+          runs,
+          align: preferences.textAlign,
+          fillColor: _rgbOf(preferences.textFillColor),
+          borderColor: _rgbOf(preferences.textBorderColor),
+          borderWidth: preferences.strokeWidth,
+          pageRotation: _page(pageIndex).rotation,
+          author: author,
+        ),
+      );
 
   /// Places [text] as a default-sized FreeText annotation centered on
   /// ([x], [y]) in page space. This is used by keyboard paste from the
   /// system text clipboard, so the text lands under the cursor like
   /// annotation paste. The box is clamped into the page's crop box and
   /// the new annotation is selected.
-  bool placeFreeText(int pageIndex, double x, double y, String text,
-      {double width = 220}) {
+  bool placeFreeText(
+    int pageIndex,
+    double x,
+    double y,
+    String text, {
+    double width = 220,
+  }) {
     final value = text.trimRight();
     if (value.trim().isEmpty) return false;
     if (pageIndex < 0 || pageIndex >= _document.pageCount) return false;
@@ -1999,22 +2120,27 @@ class PdfEditingController extends ChangeNotifier {
     final lineHeight = fontSize * 1.2;
     final lines = value.split('\n').length.clamp(1, 12);
     final w = width.clamp(48.0, _visualPageWidth(pageIndex) * 0.9);
-    final h = (lineHeight * lines + fontSize)
-        .clamp(24.0, _visualPageHeight(pageIndex) * 0.9);
+    final h = (lineHeight * lines + fontSize).clamp(
+      24.0,
+      _visualPageHeight(pageIndex) * 0.9,
+    );
     final rect = _pageRectForVisualSize(pageIndex, x, y, width: w, height: h);
     final pasted = apply(
-        (e) => e.addFreeText(pageIndex, rect, value,
-            fontSize: fontSize,
-            font: _activeFont ?? preferences.fontFamily,
-            align: preferences.textAlign,
-            color: _colorValue,
-            fillColor: _rgbOf(preferences.textFillColor),
-            borderColor: _rgbOf(preferences.textBorderColor),
-            borderWidth: preferences.strokeWidth,
-            pageRotation: _page(pageIndex).rotation,
-            author: author),
-        pages: [pageIndex],
-        contentPages: const <int>[]);
+      (e) => e.addFreeText(
+        pageIndex,
+        rect,
+        value,
+        fontSize: fontSize,
+        font: _activeFont ?? preferences.fontFamily,
+        align: preferences.textAlign,
+        color: _colorValue,
+        fillColor: _rgbOf(preferences.textFillColor),
+        borderColor: _rgbOf(preferences.textBorderColor),
+        borderWidth: preferences.strokeWidth,
+        pageRotation: _page(pageIndex).rotation,
+        author: author,
+      ),
+    );
     if (!pasted) return false;
     tool = PdfEditTool.select;
     final total = _page(pageIndex).annotations.length;
@@ -2027,29 +2153,40 @@ class PdfEditingController extends ChangeNotifier {
 
   void addStamp(int pageIndex, PdfRect rect, String text, {int? color}) =>
       apply(
-          (e) => e.addStamp(pageIndex, rect, text,
-              color: color ?? _colorValue,
-              opacity: preferences.opacity,
-              pageRotation: _page(pageIndex).rotation,
-              author: author),
-          pages: [pageIndex],
-          contentPages: const <int>[]);
+        (e) => e.addStamp(
+          pageIndex,
+          rect,
+          text,
+          color: color ?? _colorValue,
+          opacity: preferences.opacity,
+          pageRotation: _page(pageIndex).rotation,
+          author: author,
+        ),
+      );
 
   void addCustomStamp(int pageIndex, PdfRect rect, PdfCustomStamp stamp) =>
-      apply((e) {
-        final templateValues = _resolvedStampTemplateValues();
-        final text = pdfResolveStampTemplateText(stamp.text, templateValues);
-        final template = stamp.template;
-        if (template == null) {
-          e.addStamp(pageIndex, rect, text,
+      apply(
+        (e) {
+          final templateValues = _resolvedStampTemplateValues();
+          final text = pdfResolveStampTemplateText(stamp.text, templateValues);
+          final template = stamp.template;
+          if (template == null) {
+            e.addStamp(
+              pageIndex,
+              rect,
+              text,
               color: stamp.color,
               opacity: preferences.opacity,
               pageRotation: _page(pageIndex).rotation,
               author: author,
               stampType: stamp.type,
-              stampTags: stamp.tags);
-        } else {
-          e.addTemplateStamp(pageIndex, rect, template,
+              stampTags: stamp.tags,
+            );
+          } else {
+            e.addTemplateStamp(
+              pageIndex,
+              rect,
+              template,
               contents: text,
               color: stamp.color,
               opacity: preferences.opacity,
@@ -2057,16 +2194,23 @@ class PdfEditingController extends ChangeNotifier {
               author: author,
               stampType: stamp.type,
               stampTags: stamp.tags,
-              templateValues: templateValues);
-        }
-      }, pages: [pageIndex], contentPages: const <int>[]);
+              templateValues: templateValues,
+            );
+          }
+        },
+      );
 
   /// Places [imageBytes] (PNG or JPEG) centered on ([x], [y]) in page
   /// space, [maxSize] points on its longest side, preserving the image's
   /// aspect ratio and clamped so the whole image stays on the page.
   /// Returns false when the bytes aren't a decodable PNG or JPEG.
-  bool placeImage(int pageIndex, double x, double y, Uint8List imageBytes,
-      {double maxSize = 200}) {
+  bool placeImage(
+    int pageIndex,
+    double x,
+    double y,
+    Uint8List imageBytes, {
+    double maxSize = 200,
+  }) {
     final PdfEmbeddableImage image;
     try {
       image = PdfEmbeddableImage.decode(imageBytes);
@@ -2079,8 +2223,12 @@ class PdfEditingController extends ChangeNotifier {
   /// Async counterpart to [placeImage]. PNG preparation can be CPU-heavy for
   /// large images, so the built-in UI uses this worker-backed path.
   Future<bool> placeImageAsync(
-      int pageIndex, double x, double y, Uint8List imageBytes,
-      {double maxSize = 200}) async {
+    int pageIndex,
+    double x,
+    double y,
+    Uint8List imageBytes, {
+    double maxSize = 200,
+  }) async {
     final image = await _decodeEmbeddableImageAsync(imageBytes);
     if (image == null) return false;
     return _placeDecodedImage(pageIndex, x, y, image, maxSize: maxSize);
@@ -2103,7 +2251,10 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Async counterpart to [addImageInRect]. See [placeImageAsync].
   Future<bool> addImageInRectAsync(
-      int pageIndex, PdfRect box, Uint8List imageBytes) async {
+    int pageIndex,
+    PdfRect box,
+    Uint8List imageBytes,
+  ) async {
     if (box.width <= 0 || box.height <= 0) return false;
     final image = await _decodeEmbeddableImageAsync(imageBytes);
     if (image == null) return false;
@@ -2111,18 +2262,26 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   Future<PdfEmbeddableImage?> _decodeEmbeddableImageAsync(
-      Uint8List imageBytes) async {
+    Uint8List imageBytes,
+  ) async {
     try {
-      return await compute(_decodeEmbeddableImage, imageBytes,
-          debugLabel: 'pdf-image-embed');
+      return await compute(
+        _decodeEmbeddableImage,
+        imageBytes,
+        debugLabel: 'pdf-image-embed',
+      );
     } catch (_) {
       return null;
     }
   }
 
   bool _placeDecodedImage(
-      int pageIndex, double x, double y, PdfEmbeddableImage image,
-      {required double maxSize}) {
+    int pageIndex,
+    double x,
+    double y,
+    PdfEmbeddableImage image, {
+    required double maxSize,
+  }) {
     final aspect = image.height == 0 ? 1.0 : image.width / image.height;
     var w = aspect >= 1 ? maxSize : maxSize * aspect;
     var h = aspect >= 1 ? maxSize / aspect : maxSize;
@@ -2130,12 +2289,18 @@ class PdfEditingController extends ChangeNotifier {
     final maxH = _visualPageHeight(pageIndex) * 0.9;
     if (w > maxW) (w, h) = (maxW, h * maxW / w);
     if (h > maxH) (w, h) = (w * maxH / h, maxH);
-    return _addImageStamp(pageIndex,
-        _pageRectForVisualSize(pageIndex, x, y, width: w, height: h), image);
+    return _addImageStamp(
+      pageIndex,
+      _pageRectForVisualSize(pageIndex, x, y, width: w, height: h),
+      image,
+    );
   }
 
   bool _addDecodedImageInRect(
-      int pageIndex, PdfRect box, PdfEmbeddableImage image) {
+    int pageIndex,
+    PdfRect box,
+    PdfEmbeddableImage image,
+  ) {
     if (box.width <= 0 || box.height <= 0) return false;
     final aspect = image.height == 0 ? 1.0 : image.width / image.height;
     var (width: w, height: h) = _visualSizeOfPageRect(pageIndex, box);
@@ -2145,18 +2310,24 @@ class PdfEditingController extends ChangeNotifier {
       h = w / aspect;
     }
     final cx = (box.left + box.right) / 2, cy = (box.bottom + box.top) / 2;
-    return _addImageStamp(pageIndex,
-        _pageRectForVisualSize(pageIndex, cx, cy, width: w, height: h), image);
+    return _addImageStamp(
+      pageIndex,
+      _pageRectForVisualSize(pageIndex, cx, cy, width: w, height: h),
+      image,
+    );
   }
 
   bool _addImageStamp(int pageIndex, PdfRect rect, PdfEmbeddableImage image) {
     final added = apply(
-        (e) => e.addImageStamp(pageIndex, rect, image,
-            opacity: preferences.opacity,
-            pageRotation: _page(pageIndex).rotation,
-            author: author),
-        pages: [pageIndex],
-        contentPages: const <int>[]);
+      (e) => e.addImageStamp(
+        pageIndex,
+        rect,
+        image,
+        opacity: preferences.opacity,
+        pageRotation: _page(pageIndex).rotation,
+        author: author,
+      ),
+    );
     if (!added) return false;
     tool = PdfEditTool.select;
     final total = _page(pageIndex).annotations.length;
@@ -2169,12 +2340,16 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Adds a sticky note with its top-left corner at ([x], [y]).
   void addNote(int pageIndex, double x, double y, String text) => apply(
-      (e) => e.addNote(pageIndex, x, y, text,
+        (e) => e.addNote(
+          pageIndex,
+          x,
+          y,
+          text,
           color: _colorValue,
           pageRotation: _page(pageIndex).rotation,
-          author: author),
-      pages: [pageIndex],
-      contentPages: const <int>[]);
+          author: author,
+        ),
+      );
 
   // ---------------------------------------------------------------------
   // signature
@@ -2217,8 +2392,8 @@ class PdfEditingController extends ChangeNotifier {
         for (final stroke in signature.strokes)
           [
             // normalized pad space is y-down; page space is y-up
-            for (final (nx, ny) in stroke) (left + nx * w, top - ny * h)
-          ]
+            for (final (nx, ny) in stroke) (left + nx * w, top - ny * h),
+          ],
       ],
       pressures: signature.pressures,
       // follow the selected toolbar colour, like every other tool
@@ -2235,14 +2410,16 @@ class PdfEditingController extends ChangeNotifier {
     final placement = signaturePlacement(pageIndex, x, y, width: width);
     if (placement == null) return false;
     return apply(
-        (e) => e.addInk(pageIndex, placement.strokes,
-            color: placement.color,
-            strokeWidth: placement.strokeWidth,
-            opacity: 1,
-            pressures: placement.pressures,
-            author: author),
-        pages: [pageIndex],
-        contentPages: const <int>[]);
+      (e) => e.addInk(
+        pageIndex,
+        placement.strokes,
+        color: placement.color,
+        strokeWidth: placement.strokeWidth,
+        opacity: 1,
+        pressures: placement.pressures,
+        author: author,
+      ),
+    );
   }
 
   // ---------------------------------------------------------------------
@@ -2309,7 +2486,7 @@ class PdfEditingController extends ChangeNotifier {
   void removeCustomStamp(PdfCustomStamp stamp) {
     preferences.customStamps = [
       for (final saved in preferences.customStamps)
-        if (saved != stamp) saved
+        if (saved != stamp) saved,
     ];
     if (_activeStamp == stamp) {
       _activeStamp = null;
@@ -2376,12 +2553,21 @@ class PdfEditingController extends ChangeNotifier {
     if (stamp == null) return false;
     final template = stamp.template;
     if (template != null) {
-      final rect =
-          _stampTemplatePlacement(pageIndex, x, y, template, height: height);
+      final rect = _stampTemplatePlacement(
+        pageIndex,
+        x,
+        y,
+        template,
+        height: height,
+      );
       if (rect == null) return false;
-      return apply((e) {
-        final templateValues = _resolvedStampTemplateValues();
-        e.addTemplateStamp(pageIndex, rect, template,
+      return apply(
+        (e) {
+          final templateValues = _resolvedStampTemplateValues();
+          e.addTemplateStamp(
+            pageIndex,
+            rect,
+            template,
             contents: pdfResolveStampTemplateText(stamp.text, templateValues),
             color: stamp.color,
             opacity: preferences.opacity,
@@ -2389,14 +2575,21 @@ class PdfEditingController extends ChangeNotifier {
             author: author,
             stampType: stamp.type,
             stampTags: stamp.tags,
-            templateValues: templateValues);
-      }, pages: [pageIndex], contentPages: const <int>[]);
+            templateValues: templateValues,
+          );
+        },
+      );
     }
-    return placeTextStamp(pageIndex, x, y, _resolveStampText(stamp.text),
-        height: height ?? 40,
-        color: stamp.color,
-        stampType: stamp.type,
-        stampTags: stamp.tags);
+    return placeTextStamp(
+      pageIndex,
+      x,
+      y,
+      _resolveStampText(stamp.text),
+      height: height ?? 40,
+      color: stamp.color,
+      stampType: stamp.type,
+      stampTags: stamp.tags,
+    );
   }
 
   /// The page-space rect [placeStamp] would use for the current
@@ -2406,17 +2599,28 @@ class PdfEditingController extends ChangeNotifier {
     if (stamp == null) return null;
     final template = stamp.template;
     return template == null
-        ? textStampPlacement(pageIndex, x, y, _resolveStampText(stamp.text),
-            height: height ?? 40)
+        ? textStampPlacement(
+            pageIndex,
+            x,
+            y,
+            _resolveStampText(stamp.text),
+            height: height ?? 40,
+          )
         : _stampTemplatePlacement(pageIndex, x, y, template, height: height);
   }
 
   PdfRect? _stampTemplatePlacement(
-      int pageIndex, double x, double y, PdfStampTemplate template,
-      {double? height}) {
+    int pageIndex,
+    double x,
+    double y,
+    PdfStampTemplate template, {
+    double? height,
+  }) {
     if (!template.isValid) return null;
-    final h = (height ?? template.height)
-        .clamp(8.0, _visualPageHeight(pageIndex) * 0.9);
+    final h = (height ?? template.height).clamp(
+      8.0,
+      _visualPageHeight(pageIndex) * 0.9,
+    );
     final aspect = template.width / template.height;
     var w = h * aspect;
     final maxW = _visualPageWidth(pageIndex) * 0.9;
@@ -2438,33 +2642,48 @@ class PdfEditingController extends ChangeNotifier {
   /// with arbitrary text/colour). This is the stamp tool's tap-to-place:
   /// tapping without dragging out a box drops a stamp at a sensible size.
   /// [color] null uses the selected toolbar colour.
-  bool placeTextStamp(int pageIndex, double x, double y, String text,
-      {double height = 40,
-      int? color,
-      String? stampType,
-      Iterable<String> stampTags = const []}) {
+  bool placeTextStamp(
+    int pageIndex,
+    double x,
+    double y,
+    String text, {
+    double height = 40,
+    int? color,
+    String? stampType,
+    Iterable<String> stampTags = const [],
+  }) {
     final rect = textStampPlacement(pageIndex, x, y, text, height: height);
     return apply(
-        (e) => e.addStamp(pageIndex, rect, text,
-            color: color ?? _colorValue,
-            opacity: preferences.opacity,
-            pageRotation: _page(pageIndex).rotation,
-            author: author,
-            stampType: stampType,
-            stampTags: stampTags),
-        pages: [pageIndex],
-        contentPages: const <int>[]);
+      (e) => e.addStamp(
+        pageIndex,
+        rect,
+        text,
+        color: color ?? _colorValue,
+        opacity: preferences.opacity,
+        pageRotation: _page(pageIndex).rotation,
+        author: author,
+        stampType: stampType,
+        stampTags: stampTags,
+      ),
+    );
   }
 
   /// The page-space rect [placeTextStamp] would use.
-  PdfRect textStampPlacement(int pageIndex, double x, double y, String text,
-      {double height = 40}) {
+  PdfRect textStampPlacement(
+    int pageIndex,
+    double x,
+    double y,
+    String text, {
+    double height = 40,
+  }) {
     final h = height.clamp(8.0, _visualPageHeight(pageIndex) * 0.9);
     // mirror addStamp's appearance math (6pt padding, text 72% of the
     // height) so the caption fills the box without shrinking
     final fontSize = (h - 12) * 0.72;
-    final w = (measureHelvetica(text, fontSize, bold: true) + 24)
-        .clamp(h, _visualPageWidth(pageIndex) * 0.9);
+    final w = (measureHelvetica(text, fontSize, bold: true) + 24).clamp(
+      h,
+      _visualPageWidth(pageIndex) * 0.9,
+    );
     return _pageRectForVisualSize(pageIndex, x, y, width: w, height: h);
   }
 
@@ -2481,21 +2700,26 @@ class PdfEditingController extends ChangeNotifier {
   /// is a real /Stamp annotation, so it can be moved, resized, and deleted
   /// like any other. This is the count tool's tap-to-place - repeated taps
   /// build the tally exposed by [checkMarkCount], Bluebeam-style.
-  bool placeCheckMark(int pageIndex, double x, double y,
-      {double size = checkMarkSize}) {
+  bool placeCheckMark(
+    int pageIndex,
+    double x,
+    double y, {
+    double size = checkMarkSize,
+  }) {
     final box = _page(pageIndex).cropBox;
     final s = size.clamp(4.0, math.min(box.width, box.height) * 0.9);
     final cx = x.clamp(box.left + s / 2, box.right - s / 2);
     final cy = y.clamp(box.bottom + s / 2, box.top - s / 2);
     return apply(
-        (e) => e.addCheckMark(
-            pageIndex, PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
-            color: _colorValue,
-            opacity: preferences.opacity,
-            pageRotation: _page(pageIndex).rotation,
-            author: author),
-        pages: [pageIndex],
-        contentPages: const <int>[]);
+      (e) => e.addCheckMark(
+        pageIndex,
+        PdfRect(cx - s / 2, cy - s / 2, cx + s / 2, cy + s / 2),
+        color: _colorValue,
+        opacity: preferences.opacity,
+        pageRotation: _page(pageIndex).rotation,
+        author: author,
+      ),
+    );
   }
 
   int? _checkMarkCount;
@@ -2562,8 +2786,10 @@ class PdfEditingController extends ChangeNotifier {
     _pageSelectionAnchor = null;
     final insertAt = at ?? _document.pageCount;
     if (width == null && height == null && _document.pageCount > 0) {
-      final neighbour =
-          (insertAt > 0 ? insertAt - 1 : 0).clamp(0, _document.pageCount - 1);
+      final neighbour = (insertAt > 0 ? insertAt - 1 : 0).clamp(
+        0,
+        _document.pageCount - 1,
+      );
       final box = _document.page(neighbour).mediaBox;
       width = box.width;
       height = box.height;
@@ -2585,10 +2811,17 @@ class PdfEditingController extends ChangeNotifier {
   /// Inserts pages from the PDF in [bytes] (opened with [password] when
   /// encrypted) at [at]. Convenience over [insertPagesFrom] for a file a
   /// host just read off disk.
-  void insertPagesFromBytes(Uint8List bytes,
-      {String password = '', List<int>? indices, int? at}) {
-    insertPagesFrom(PdfDocument.open(bytes, password: password),
-        indices: indices, at: at);
+  void insertPagesFromBytes(
+    Uint8List bytes, {
+    String password = '',
+    List<int>? indices,
+    int? at,
+  }) {
+    insertPagesFrom(
+      PdfDocument.open(bytes, password: password),
+      indices: indices,
+      at: at,
+    );
   }
 
   /// Duplicates [indices] (deep-copying each page and everything it
@@ -2610,8 +2843,9 @@ class PdfEditingController extends ChangeNotifier {
     // current bytes gives a separate source, so a page can be copied back
     // into the file it came from.
     final source = PdfDocument.open(bytes, password: _password);
-    return apply((e) =>
-        e.appendPagesFrom(source, indices: targets, at: targets.last + 1));
+    return apply(
+      (e) => e.appendPagesFrom(source, indices: targets, at: targets.last + 1),
+    );
   }
 
   /// Exports [indices] (in that order) as a fresh standalone PDF, leaving
@@ -2747,7 +2981,7 @@ class PdfEditingController extends ChangeNotifier {
         .toList()
       ..sort();
     if (targets.isEmpty || degrees % 360 == 0) return false;
-    return apply((e) => e.rotatePages(targets, degrees), pages: targets);
+    return apply((e) => e.rotatePages(targets, degrees));
   }
 
   /// Rotates the selected pages clockwise by [degrees] (default: 90; pass
@@ -2777,9 +3011,12 @@ class PdfEditingController extends ChangeNotifier {
     if (targets.isEmpty || (!fill && !stroke)) return const [];
     final editor = PdfEditor(_document);
     return [
-      for (final color
-          in editor.contentColorsOnPages(targets, fill: fill, stroke: stroke))
-        Color(0xFF000000 | color.rgb)
+      for (final color in editor.contentColorsOnPages(
+        targets,
+        fill: fill,
+        stroke: stroke,
+      ))
+        Color(0xFF000000 | color.rgb),
     ];
   }
 
@@ -2808,8 +3045,11 @@ class PdfEditingController extends ChangeNotifier {
     final uses = <int, List<int>>{};
     for (var i = 0; i < targets.length; i++) {
       if (isCancelled?.call() ?? false) return const [];
-      final pageColors =
-          editor.contentColors(targets[i], fill: fill, stroke: stroke);
+      final pageColors = editor.contentColors(
+        targets[i],
+        fill: fill,
+        stroke: stroke,
+      );
       for (final color in pageColors) {
         final counts = uses.putIfAbsent(color.rgb, () => [0, 0]);
         counts[0] += color.fillUses;
@@ -2827,9 +3067,7 @@ class PdfEditingController extends ChangeNotifier {
         final byUses = bUses.compareTo(aUses);
         return byUses != 0 ? byUses : a.key.compareTo(b.key);
       });
-    return [
-      for (final entry in entries) Color(0xFF000000 | entry.key),
-    ];
+    return [for (final entry in entries) Color(0xFF000000 | entry.key)];
   }
 
   /// Replaces matching page-content colors across [pages], or the whole
@@ -2881,7 +3119,7 @@ class PdfEditingController extends ChangeNotifier {
         stroke: stroke,
         transparent: transparent,
       );
-    }, pages: targets);
+    });
     return changed ? count : 0;
   }
 
@@ -2945,7 +3183,23 @@ class PdfEditingController extends ChangeNotifier {
       return 0;
     }
 
-    _commitSavedRevision(saved, beforeLength: beforeLength, pages: targets);
+    List<int>? pagesFrom(String key) {
+      final value = result[key];
+      return value == null ? null : (value as List).cast<int>();
+    }
+
+    final impact = PdfEditImpact.reported(
+      visualPages: pagesFrom('visualPages'),
+      contentPages: pagesFrom('contentPages'),
+      annotationPages: pagesFrom('annotationPages'),
+      pageStructureChanged: result['pageStructureChanged'] as bool? ?? false,
+      destructive: result['destructive'] as bool? ?? false,
+    );
+    _commitSavedRevision(
+      saved,
+      beforeLength: beforeLength,
+      impact: impact,
+    );
     return count;
   }
 
@@ -3044,16 +3298,25 @@ class PdfEditingController extends ChangeNotifier {
   /// at 100% zoom). [pageColor] and [annotations] should match how the
   /// page is displayed, so the snapshot looks like what's on screen.
   /// Returns null for a degenerate (sub-pixel) region.
-  Future<Uint8List?> captureSnapshot(int pageIndex, Rect region,
-      {double pixelRatio = 2,
-      Color pageColor = const Color(0xFFFFFFFF),
-      bool annotations = true}) async {
+  Future<Uint8List?> captureSnapshot(
+    int pageIndex,
+    Rect region, {
+    double pixelRatio = 2,
+    Color pageColor = const Color(0xFFFFFFFF),
+    bool annotations = true,
+  }) async {
     if (region.width < 1 || region.height < 1) return null;
-    final picture = await PdfPageRenderer.renderPicture(pageAt(pageIndex),
-        pageColor: pageColor, annotations: annotations);
+    final picture = await PdfPageRenderer.renderPicture(
+      pageAt(pageIndex),
+      pageColor: pageColor,
+      annotations: annotations,
+    );
     try {
-      final image =
-          await PdfPageRenderer.rasterizeRegion(picture, region, pixelRatio);
+      final image = await PdfPageRenderer.rasterizeRegion(
+        picture,
+        region,
+        pixelRatio,
+      );
       try {
         final data = await image.toByteData(format: ui.ImageByteFormat.png);
         return data?.buffer.asUint8List();
@@ -3114,8 +3377,7 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Rotation rides the appearance stream's /Matrix, so it needs one.
   bool get canRotateSelected =>
-      _selected.length == 1 &&
-      selectedAnnotation?.behavior.rotatable == true;
+      _selected.length == 1 && selectedAnnotation?.behavior.rotatable == true;
 
   bool get canEditSelectedText =>
       _selected.length == 1 &&
@@ -3126,7 +3388,10 @@ class PdfEditingController extends ChangeNotifier {
   /// with its /Annots slot - the select tool's hit test (later entries
   /// draw on top, so they win).
   (int index, PdfAnnotation)? selectableAnnotationAt(
-      int pageIndex, double x, double y) {
+    int pageIndex,
+    double x,
+    double y,
+  ) {
     final annotations = _page(pageIndex).annotations;
     for (var i = annotations.length - 1; i >= 0; i--) {
       final annotation = annotations[i];
@@ -3147,7 +3412,10 @@ class PdfEditingController extends ChangeNotifier {
   /// read-only field (one whose *value* can't change) is still
   /// selectable for move/resize/rename. Null when nothing is hit.
   (int index, PdfAnnotation)? selectableWidgetAt(
-      int pageIndex, double x, double y) {
+    int pageIndex,
+    double x,
+    double y,
+  ) {
     final annotations = _page(pageIndex).annotations;
     for (var i = annotations.length - 1; i >= 0; i--) {
       final annotation = annotations[i];
@@ -3167,8 +3435,12 @@ class PdfEditingController extends ChangeNotifier {
   /// (shift/⌘-click) the hit is added to or removed from the selection
   /// and a miss leaves the selection alone. The form tool stays armed.
   /// Returns whether a widget was hit.
-  bool selectFormWidgetAt(int pageIndex, double x, double y,
-      {bool toggle = false}) {
+  bool selectFormWidgetAt(
+    int pageIndex,
+    double x,
+    double y, {
+    bool toggle = false,
+  }) {
     final hit = selectableWidgetAt(pageIndex, x, y);
     if (hit == null) {
       if (!toggle) clearAnnotationSelection();
@@ -3192,8 +3464,12 @@ class PdfEditingController extends ChangeNotifier {
   /// centerline (padded by half the pen width), not merely inside the
   /// bounding rect, so crossing strokes don't erase together. An Ink
   /// annotation without a usable /InkList falls back to its rect.
-  (int index, PdfAnnotation)? inkAnnotationAt(int pageIndex, double x, double y,
-      {double tolerance = 4}) {
+  (int index, PdfAnnotation)? inkAnnotationAt(
+    int pageIndex,
+    double x,
+    double y, {
+    double tolerance = 4,
+  }) {
     final annotations = _page(pageIndex).annotations;
     for (var i = annotations.length - 1; i >= 0; i--) {
       final annotation = annotations[i];
@@ -3238,7 +3514,11 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Squared distance from ([x], [y]) to the segment [a]–[b].
   static double _segmentDistanceSquared(
-      double x, double y, (double, double) a, (double, double) b) {
+    double x,
+    double y,
+    (double, double) a,
+    (double, double) b,
+  ) {
     final (ax, ay) = a;
     final (bx, by) = b;
     final dx = bx - ax, dy = by - ay;
@@ -3253,8 +3533,12 @@ class PdfEditingController extends ChangeNotifier {
   /// [toggle] (shift/⌘-click) the hit is added to or removed from the
   /// selection instead, and a miss leaves the selection alone. Returns
   /// whether an annotation was hit.
-  bool selectAnnotationAt(int pageIndex, double x, double y,
-      {bool toggle = false}) {
+  bool selectAnnotationAt(
+    int pageIndex,
+    double x,
+    double y, {
+    bool toggle = false,
+  }) {
     final hit = selectableAnnotationAt(pageIndex, x, y);
     if (hit == null) {
       if (!toggle) clearAnnotationSelection();
@@ -3298,7 +3582,7 @@ class PdfEditingController extends ChangeNotifier {
     final next = [
       if (add) ..._selected,
       for (final hit in hits)
-        if (!add || !_selected.contains(hit)) hit
+        if (!add || !_selected.contains(hit)) hit,
     ];
     if (!listEquals(next, _selected)) {
       _selected
@@ -3314,9 +3598,9 @@ class PdfEditingController extends ChangeNotifier {
   int selectAllAnnotationsOn(int pageIndex) {
     final box = _page(pageIndex).cropBox;
     return selectAnnotationsIn(
-        pageIndex,
-        PdfRect(
-            box.left - 1e6, box.bottom - 1e6, box.right + 1e6, box.top + 1e6));
+      pageIndex,
+      PdfRect(box.left - 1e6, box.bottom - 1e6, box.right + 1e6, box.top + 1e6),
+    );
   }
 
   /// Selects the annotation in slot [index] of [pageIndex]'s /Annots
@@ -3352,8 +3636,9 @@ class PdfEditingController extends ChangeNotifier {
       final (page, slot) = _selected[i];
       if (page == pageIndex && slot > index) _selected[i] = (page, slot - 1);
     }
-    apply((e) => e.removeAnnotation(pageIndex, annotation),
-        pages: [pageIndex], contentPages: const <int>[]);
+    apply(
+      (e) => e.removeAnnotation(pageIndex, annotation),
+    );
   }
 
   /// Removes several annotations - (pageIndex, /Annots slot) pairs - in
@@ -3365,22 +3650,22 @@ class PdfEditingController extends ChangeNotifier {
       for (final slot in slots)
         if (_annotationAt(slot) case final annotation?
             when isAnnotationEditable(annotation))
-          (slot.$1, annotation)
+          (slot.$1, annotation),
     ];
     if (targets.isEmpty) return;
     // surviving annotations may land in different slots
     _selected.clear();
-    apply((e) {
-      final byPage = <int, List<PdfAnnotation>>{};
-      for (final (page, annotation) in targets) {
-        (byPage[page] ??= []).add(annotation);
-      }
-      for (final entry in byPage.entries) {
-        e.removeAnnotations(entry.key, entry.value);
-      }
-    },
-        pages: [for (final (page, _) in targets) page],
-        contentPages: const <int>[]);
+    apply(
+      (e) {
+        final byPage = <int, List<PdfAnnotation>>{};
+        for (final (page, annotation) in targets) {
+          (byPage[page] ??= []).add(annotation);
+        }
+        for (final entry in byPage.entries) {
+          e.removeAnnotations(entry.key, entry.value);
+        }
+      },
+    );
   }
 
   // ---------------------------------------------------------------------
@@ -3396,26 +3681,30 @@ class PdfEditingController extends ChangeNotifier {
     // a thread edit changes no page graphics: const [] skips re-raster
     // while still diffing for the change feed (see apply's pages contract)
     return apply(
-        (e) => e.replyToAnnotation(pageIndex, target, contents, author: author),
-        pages: const []);
+      (e) => e.replyToAnnotation(pageIndex, target, contents, author: author),
+    );
   }
 
   /// Records review [state] on [target]'s thread (a state reply). One
   /// revision, emitted on [annotationChanges]. Returns whether it changed.
   bool setReviewState(
-          int pageIndex, PdfAnnotation target, PdfReviewState state) =>
-      apply((e) => e.setReviewState(pageIndex, target, state, author: author),
-          pages: const []);
+    int pageIndex,
+    PdfAnnotation target,
+    PdfReviewState state,
+  ) =>
+      apply(
+        (e) => e.setReviewState(pageIndex, target, state, author: author),
+      );
 
   /// Marks [target]'s thread resolved (review state `Completed`).
-  bool resolveThread(int pageIndex, PdfAnnotation target) =>
-      apply((e) => e.resolveThread(pageIndex, target, author: author),
-          pages: const []);
+  bool resolveThread(int pageIndex, PdfAnnotation target) => apply(
+        (e) => e.resolveThread(pageIndex, target, author: author),
+      );
 
   /// Reopens [target]'s thread (review state `None`).
-  bool reopenThread(int pageIndex, PdfAnnotation target) =>
-      apply((e) => e.reopenThread(pageIndex, target, author: author),
-          pages: const []);
+  bool reopenThread(int pageIndex, PdfAnnotation target) => apply(
+        (e) => e.reopenThread(pageIndex, target, author: author),
+      );
 
   /// The reply threads on [pageIndex] (read-only model), assembled from
   /// the current revision's annotations. Mirrors
@@ -3440,29 +3729,34 @@ class PdfEditingController extends ChangeNotifier {
         if (annotation.subtype == 'Ink' &&
             !annotation.isHidden &&
             isAnnotationEditable(annotation))
-          annotation
+          annotation,
     ];
     if (targets.isEmpty) return false;
-    return apply((editor) {
-      var changed = false;
-      for (final annotation in targets) {
-        if (annotation.inkList == null) {
-          // no centerline to slice - the rect is all we have
-          if (_pathTouchesRect(path, annotation.rect, radius)) {
-            editor.removeAnnotation(pageIndex, annotation);
+    return apply(
+      (editor) {
+        var changed = false;
+        for (final annotation in targets) {
+          if (annotation.inkList == null) {
+            // no centerline to slice - the rect is all we have
+            if (_pathTouchesRect(path, annotation.rect, radius)) {
+              editor.removeAnnotation(pageIndex, annotation);
+              changed = true;
+            }
+          } else if (editor.sliceInk(pageIndex, annotation, path, radius)) {
             changed = true;
           }
-        } else if (editor.sliceInk(pageIndex, annotation, path, radius)) {
-          changed = true;
         }
-      }
-      // slots may shift under the survivors
-      if (changed) _selected.clear();
-    }, pages: [pageIndex], contentPages: const <int>[]);
+        // slots may shift under the survivors
+        if (changed) _selected.clear();
+      },
+    );
   }
 
   static bool _pathTouchesRect(
-      List<(double, double)> path, PdfRect rect, double radius) {
+    List<(double, double)> path,
+    PdfRect rect,
+    double radius,
+  ) {
     for (final (x, y) in path) {
       if (x >= rect.left - radius &&
           x <= rect.right + radius &&
@@ -3504,11 +3798,11 @@ class PdfEditingController extends ChangeNotifier {
       final count = _page(page).annotations.length;
       final rest = [
         for (var i = 0; i < count; i++)
-          if (!moving.contains(i)) i
+          if (!moving.contains(i)) i,
       ];
       final block = [
         for (var i = 0; i < count; i++)
-          if (moving.contains(i)) i
+          if (moving.contains(i)) i,
       ];
       final order = toFront ? [...rest, ...block] : [...block, ...rest];
       for (var newSlot = 0; newSlot < order.length; newSlot++) {
@@ -3520,9 +3814,9 @@ class PdfEditingController extends ChangeNotifier {
 
   bool _reorderChangesSlots({required bool toFront}) {
     if (_selected.isEmpty) return false;
-    return _reorderRemap(toFront: toFront)
-        .entries
-        .any((entry) => entry.key != entry.value);
+    return _reorderRemap(
+      toFront: toFront,
+    ).entries.any((entry) => entry.key != entry.value);
   }
 
   void _reorderSelected({required bool toFront}) {
@@ -3541,13 +3835,15 @@ class PdfEditingController extends ChangeNotifier {
     for (var i = 0; i < _selected.length; i++) {
       _selected[i] = remap[_selected[i]] ?? _selected[i];
     }
-    apply((e) {
-      for (final MapEntry(key: page, value: annotations) in byPage.entries) {
-        toFront
-            ? e.bringAnnotationsToFront(page, annotations)
-            : e.sendAnnotationsToBack(page, annotations);
-      }
-    }, pages: byPage.keys, contentPages: const <int>[]);
+    apply(
+      (e) {
+        for (final MapEntry(key: page, value: annotations) in byPage.entries) {
+          toFront
+              ? e.bringAnnotationsToFront(page, annotations)
+              : e.sendAnnotationsToBack(page, annotations);
+        }
+      },
+    );
   }
 
   void clearAnnotationSelection() {
@@ -3639,11 +3935,13 @@ class PdfEditingController extends ChangeNotifier {
     dx += _clampShift(left + dx, right + dx, box.left, box.right);
     dy += _clampShift(bottom + dy, top + dy, box.bottom, box.top);
     final count = _clipboard.length;
-    final pasted = apply((e) {
-      for (final snapshot in _clipboard) {
-        e.pasteAnnotation(pageIndex, snapshot, dx: dx, dy: dy);
-      }
-    }, pages: [pageIndex], contentPages: const <int>[]);
+    final pasted = apply(
+      (e) {
+        for (final snapshot in _clipboard) {
+          e.pasteAnnotation(pageIndex, snapshot, dx: dx, dy: dy);
+        }
+      },
+    );
     if (!pasted) return false;
     _pasteCount++;
     // pasted entries appended to /Annots - select them, like any editor
@@ -3694,14 +3992,16 @@ class PdfEditingController extends ChangeNotifier {
     }
     if (count == 0) return 0;
 
-    final changed = apply((e) {
-      for (final page in targets) {
-        for (final item in snapshots) {
-          if (item.page == page) continue;
-          e.pasteAnnotation(page, item.snapshot);
+    final changed = apply(
+      (e) {
+        for (final page in targets) {
+          for (final item in snapshots) {
+            if (item.page == page) continue;
+            e.pasteAnnotation(page, item.snapshot);
+          }
         }
-      }
-    }, pages: touched, contentPages: const <int>[]);
+      },
+    );
     return changed ? count : 0;
   }
 
@@ -3776,10 +4076,17 @@ class PdfEditingController extends ChangeNotifier {
     bottom += _clampShift(bottom, bottom + h, box.bottom, box.top);
     final target = PdfRect(left, bottom, left + w, bottom + h);
     int? captured;
-    final pasted = apply((e) {
-      captured = e.pasteVectorSnapshot(pageIndex, target, snapshot,
-          author: author, sharedObject: _snapshotCapturedRef);
-    }, pages: [pageIndex], contentPages: const <int>[]);
+    final pasted = apply(
+      (e) {
+        captured = e.pasteVectorSnapshot(
+          pageIndex,
+          target,
+          snapshot,
+          author: author,
+          sharedObject: _snapshotCapturedRef,
+        );
+      },
+    );
     if (!pasted) return false;
     // remember the shared captured form so repeat pastes reuse it
     _snapshotCapturedRef = captured;
@@ -3868,12 +4175,13 @@ class PdfEditingController extends ChangeNotifier {
   /// interior or text-box background (`(null,)` clears it), and
   /// parameters a subtype doesn't have are ignored for it. Returns
   /// whether anything changed.
-  bool restyleSelected(
-      {Color? color,
-      (Color?,)? fill,
-      double? strokeWidth,
-      double? opacity,
-      PdfLineStyle? lineStyle}) {
+  bool restyleSelected({
+    Color? color,
+    (Color?,)? fill,
+    double? strokeWidth,
+    double? opacity,
+    PdfLineStyle? lineStyle,
+  }) {
     if (color == null &&
         fill == null &&
         strokeWidth == null &&
@@ -3884,25 +4192,28 @@ class PdfEditingController extends ChangeNotifier {
     if (!canRestyleSelected) return false;
     final targets = <(int, PdfAnnotation)>[
       for (final slot in _selected)
-        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation)
+        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation),
     ];
     if (targets.isEmpty) return false;
-    return apply((e) {
-      for (final (page, annotation) in targets) {
-        // the dash array scales to the (possibly just-changed) pen width
-        final width = strokeWidth ?? annotation.borderWidth ?? 1;
-        e.restyleAnnotation(page, annotation,
+    return apply(
+      (e) {
+        for (final (page, annotation) in targets) {
+          // the dash array scales to the (possibly just-changed) pen width
+          final width = strokeWidth ?? annotation.borderWidth ?? 1;
+          e.restyleAnnotation(
+            page,
+            annotation,
             color: _rgbOf(color),
             fillColor: fill == null ? null : (_rgbOf(fill.$1),),
             strokeWidth: strokeWidth,
             opacity: opacity,
             dashPattern:
                 lineStyle == null ? null : (lineStyle.dashArray(width),),
-            pageRotation: _page(page).rotation);
-      }
-    },
-        pages: [for (final (page, _) in targets) page],
-        contentPages: const <int>[]);
+            pageRotation: _page(page).rotation,
+          );
+        }
+      },
+    );
   }
 
   // ---------------------------------------------------------------------
@@ -3960,16 +4271,16 @@ class PdfEditingController extends ChangeNotifier {
   void moveSelected(double dx, double dy) {
     final targets = <(int, PdfAnnotation)>[
       for (final slot in _selected)
-        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation)
+        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation),
     ];
     if (targets.isEmpty) return;
-    apply((e) {
-      for (final (page, annotation) in targets) {
-        e.moveAnnotation(page, annotation, dx, dy);
-      }
-    },
-        pages: [for (final (page, _) in targets) page],
-        contentPages: const <int>[]);
+    apply(
+      (e) {
+        for (final (page, annotation) in targets) {
+          e.moveAnnotation(page, annotation, dx, dy);
+        }
+      },
+    );
   }
 
   /// The selected annotations that share the primary selection's page, in
@@ -4007,19 +4318,22 @@ class PdfEditingController extends ChangeNotifier {
     if (page == null) return;
     final targets = _alignmentTargets();
     if (targets.length < alignment.minimumCount) return;
-    final offsets =
-        alignmentOffsets([for (final a in targets) a.rect], alignment);
+    final offsets = alignmentOffsets([
+      for (final a in targets) a.rect,
+    ], alignment);
     final moves = <(PdfAnnotation, double, double)>[];
     for (var i = 0; i < targets.length; i++) {
       final (:dx, :dy) = offsets[i];
       if (dx != 0 || dy != 0) moves.add((targets[i], dx, dy));
     }
     if (moves.isEmpty) return;
-    apply((e) {
-      for (final (annotation, dx, dy) in moves) {
-        e.moveAnnotation(page, annotation, dx, dy);
-      }
-    }, pages: [page], contentPages: const <int>[]);
+    apply(
+      (e) {
+        for (final (annotation, dx, dy) in moves) {
+          e.moveAnnotation(page, annotation, dx, dy);
+        }
+      },
+    );
   }
 
   /// Re-homes the single selected annotation onto [targetPage], shifted
@@ -4040,14 +4354,19 @@ class PdfEditingController extends ChangeNotifier {
     }
     final annotation = _annotationAt(slot);
     if (annotation == null || !isAnnotationEditable(annotation)) return false;
-    final snapshot =
-        PdfAnnotationSnapshot.capture(_document, annotation, keepName: true);
+    final snapshot = PdfAnnotationSnapshot.capture(
+      _document,
+      annotation,
+      keepName: true,
+    );
     if (snapshot == null) return false; // links/widgets/popups don't move
     final source = slot.$1;
-    final moved = apply((e) {
-      e.removeAnnotation(source, annotation);
-      e.pasteAnnotation(targetPage, snapshot, dx: dx, dy: dy);
-    }, pages: [source, targetPage], contentPages: const <int>[]);
+    final moved = apply(
+      (e) {
+        e.removeAnnotation(source, annotation);
+        e.pasteAnnotation(targetPage, snapshot, dx: dx, dy: dy);
+      },
+    );
     if (!moved) return false;
     final total = _page(targetPage).annotations.length;
     _selected
@@ -4072,17 +4391,21 @@ class PdfEditingController extends ChangeNotifier {
     if (annotation.isCallout) {
       // a callout's resize handles size the text box; the terminus stays
       // put and the leader stretches (Bluebeam's model)
-      apply((e) => e.reshapeCallout(_selected.last.$1, annotation, box: to),
-          pages: [_selected.last.$1], contentPages: const <int>[]);
+      apply(
+        (e) => e.reshapeCallout(_selected.last.$1, annotation, box: to),
+      );
       return;
     }
     apply(
-        (e) => e.resizeAnnotation(_selected.last.$1, annotation, to,
-            flipX: flipX,
-            flipY: flipY,
-            pageRotation: _page(_selected.last.$1).rotation),
-        pages: [_selected.last.$1],
-        contentPages: const <int>[]);
+      (e) => e.resizeAnnotation(
+        _selected.last.$1,
+        annotation,
+        to,
+        flipX: flipX,
+        flipY: flipY,
+        pageRotation: _page(_selected.last.$1).rotation,
+      ),
+    );
   }
 
   /// Moves a selected callout's arrow terminus to [target] (page space),
@@ -4092,9 +4415,8 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     if (annotation == null || !annotation.isCallout) return;
     apply(
-        (e) => e.reshapeCallout(_selected.last.$1, annotation, target: target),
-        pages: [_selected.last.$1],
-        contentPages: const <int>[]);
+      (e) => e.reshapeCallout(_selected.last.$1, annotation, target: target),
+    );
   }
 
   /// Moves a selected callout's arrow base (where the leader meets the text
@@ -4104,9 +4426,8 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     if (annotation == null || !annotation.isCallout) return;
     apply(
-        (e) => e.reshapeCallout(_selected.last.$1, annotation, attach: attach),
-        pages: [_selected.last.$1],
-        contentPages: const <int>[]);
+      (e) => e.reshapeCallout(_selected.last.$1, annotation, attach: attach),
+    );
   }
 
   /// Resizes the selected form-field [widget] so its /Rect becomes [to],
@@ -4117,8 +4438,9 @@ class PdfEditingController extends ChangeNotifier {
     final field = _widgetFieldForSlot(slot);
     if (field == null) return;
     final (name, widgetIndex) = field;
-    apply((e) => e.resizeFormWidget(name, widgetIndex, to),
-        pages: [slot.$1], contentPages: const <int>[]);
+    apply(
+      (e) => e.resizeFormWidget(name, widgetIndex, to),
+    );
   }
 
   /// The (field name, widget index) for the Widget annotation in [slot],
@@ -4142,8 +4464,11 @@ class PdfEditingController extends ChangeNotifier {
   /// rotated selection without shearing it.
   ///
   /// [flipX]/[flipY] mirror the artwork along the local axes.
-  void resizeSelectedLocal(PdfRect localTo,
-      {bool flipX = false, bool flipY = false}) {
+  void resizeSelectedLocal(
+    PdfRect localTo, {
+    bool flipX = false,
+    bool flipY = false,
+  }) {
     final annotation = selectedAnnotation;
     if (annotation == null || !canResizeSelected) return;
     if (localTo.width < 1 || localTo.height < 1) return;
@@ -4154,18 +4479,20 @@ class PdfEditingController extends ChangeNotifier {
     }
     if (annotation.isCallout) {
       apply(
-          (e) => e.reshapeCallout(_selected.last.$1, annotation, box: localTo),
-          pages: [_selected.last.$1],
-          contentPages: const <int>[]);
+        (e) => e.reshapeCallout(_selected.last.$1, annotation, box: localTo),
+      );
       return;
     }
     apply(
-        (e) => e.resizeAnnotationLocal(_selected.last.$1, annotation, localTo,
-            flipX: flipX,
-            flipY: flipY,
-            pageRotation: _page(_selected.last.$1).rotation),
-        pages: [_selected.last.$1],
-        contentPages: const <int>[]);
+      (e) => e.resizeAnnotationLocal(
+        _selected.last.$1,
+        annotation,
+        localTo,
+        flipX: flipX,
+        flipY: flipY,
+        pageRotation: _page(_selected.last.$1).rotation,
+      ),
+    );
   }
 
   /// Replaces the defining vertices of the selected Line, PolyLine, or
@@ -4175,8 +4502,9 @@ class PdfEditingController extends ChangeNotifier {
     if (annotation == null || !annotation.behavior.lineFamily) {
       return;
     }
-    apply((e) => e.reshapeLineAnnotation(_selected.last.$1, annotation, points),
-        pages: [_selected.last.$1], contentPages: const <int>[]);
+    apply(
+      (e) => e.reshapeLineAnnotation(_selected.last.$1, annotation, points),
+    );
   }
 
   /// Whether the single selected annotation is a /Line or /PolyLine whose
@@ -4206,10 +4534,13 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     if (annotation == null || !canSetLineEndings) return;
     apply(
-        (e) => e.setLineEndings(_selected.last.$1, annotation,
-            startEnding: start, endEnding: end),
-        pages: [_selected.last.$1],
-        contentPages: const <int>[]);
+      (e) => e.setLineEndings(
+        _selected.last.$1,
+        annotation,
+        startEnding: start,
+        endEnding: end,
+      ),
+    );
   }
 
   /// Whether the single selected annotation is a measurement (a /Line,
@@ -4239,10 +4570,13 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRestyleMeasurementCaption) return;
     apply(
-        (e) => e.setMeasurementCaptionStyle(_selected.last.$1, annotation,
-            font: font, size: size),
-        pages: [_selected.last.$1],
-        contentPages: const <int>[]);
+      (e) => e.setMeasurementCaptionStyle(
+        _selected.last.$1,
+        annotation,
+        font: font,
+        size: size,
+      ),
+    );
   }
 
   /// Rotates the selected annotation by [degrees] counterclockwise (page
@@ -4251,8 +4585,9 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRotateSelected) return;
     if (degrees.abs() < 0.01) return;
-    apply((e) => e.rotateAnnotation(_selected.last.$1, annotation, degrees),
-        pages: [_selected.last.$1], contentPages: const <int>[]);
+    apply(
+      (e) => e.rotateAnnotation(_selected.last.$1, annotation, degrees),
+    );
   }
 
   /// Deletes whatever is selected: the content element when the content
@@ -4280,7 +4615,7 @@ class PdfEditingController extends ChangeNotifier {
             final field = e.acroForm?.fieldNamed(name);
             if (field != null) e.removeField(field);
           }
-        }, contentPages: const <int>[]);
+        });
         return;
       }
     }
@@ -4293,9 +4628,11 @@ class PdfEditingController extends ChangeNotifier {
   /// Parses a free-text annotation's /DA: the font it was written with
   /// and its size, falling back to the current preferences.
   ({PdfStandardFont font, double size}) _freeTextStyleOf(
-      PdfAnnotation annotation) {
-    final tf = RegExp(r'/(\S+)\s+(\d+(?:\.\d+)?)\s+Tf')
-        .firstMatch(annotation.defaultAppearance ?? '');
+    PdfAnnotation annotation,
+  ) {
+    final tf = RegExp(
+      r'/(\S+)\s+(\d+(?:\.\d+)?)\s+Tf',
+    ).firstMatch(annotation.defaultAppearance ?? '');
     return (
       font: tf == null
           ? preferences.fontFamily
@@ -4339,8 +4676,11 @@ class PdfEditingController extends ChangeNotifier {
     final rc = annotation.richContent;
     if (rc == null) return null;
     final style = _freeTextStyleOf(annotation);
-    final runs = PdfAnnotationEditing.parseFreeTextRichContent(rc,
-        fallbackFont: style.font, fallbackSize: style.size);
+    final runs = PdfAnnotationEditing.parseFreeTextRichContent(
+      rc,
+      fallbackFont: style.font,
+      fallbackSize: style.size,
+    );
     return runs.isEmpty ? null : runs;
   }
 
@@ -4351,8 +4691,12 @@ class PdfEditingController extends ChangeNotifier {
     return selectedAnnotation?.freeTextStyle?.alignment ?? PdfTextAlign.left;
   }
 
-  PdfRect _autosizeTextRect(PdfAnnotation annotation, String text,
-      {required PdfStandardFont font, required double size}) {
+  PdfRect _autosizeTextRect(
+    PdfAnnotation annotation,
+    String text, {
+    required PdfStandardFont font,
+    required double size,
+  }) {
     const pad = 3.0;
     final lines = text.split('\n');
     final maxLineWidth = lines.fold<double>(0, (max, line) {
@@ -4382,8 +4726,12 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRestyleSelectedText) return;
     final style = _freeTextStyleOf(annotation);
-    final rect = _autosizeTextRect(annotation, annotation.contents ?? '',
-        font: style.font, size: style.size);
+    final rect = _autosizeTextRect(
+      annotation,
+      annotation.contents ?? '',
+      font: style.font,
+      size: style.size,
+    );
     resizeSelected(rect);
   }
 
@@ -4397,26 +4745,30 @@ class PdfEditingController extends ChangeNotifier {
   /// which leaves the annotation's own style alone. A border set without
   /// [borderWidth] keeps the annotation's width (or 1pt when it had no
   /// border to keep).
-  void restyleSelectedText(
-      {PdfStandardFont? font,
-      double? size,
-      PdfTextAlign? align,
-      (int?,)? fill,
-      (int?,)? border,
-      double? borderWidth}) {
+  void restyleSelectedText({
+    PdfStandardFont? font,
+    double? size,
+    PdfTextAlign? align,
+    (int?,)? fill,
+    (int?,)? border,
+    double? borderWidth,
+  }) {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRestyleSelectedText) return;
     // Default to the box's own (possibly embedded) font, so changing only
     // the size never silently converts an embedded font to Helvetica; an
     // explicit [font] (the family picker) still wins.
     final style = _freeTextFontOf(annotation);
-    _rewriteSelected(annotation, annotation.contents ?? '',
-        font: font ?? style.font,
-        size: size ?? style.size,
-        align: align,
-        fill: fill,
-        border: border,
-        borderWidth: borderWidth);
+    _rewriteSelected(
+      annotation,
+      annotation.contents ?? '',
+      font: font ?? style.font,
+      size: size ?? style.size,
+      align: align,
+      fill: fill,
+      border: border,
+      borderWidth: borderWidth,
+    );
   }
 
   /// Sets the horizontal alignment of the selected free-text box (its /Q
@@ -4436,16 +4788,25 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRestyleSelectedText) return;
     final style = _freeTextFontOf(annotation);
-    _rewriteSelected(annotation, annotation.contents ?? '',
-        font: font, size: style.size);
+    _rewriteSelected(
+      annotation,
+      annotation.contents ?? '',
+      font: font,
+      size: style.size,
+    );
   }
 
   /// Applies font, size, and/or text color to a substring of the selected
   /// FreeText annotation, leaving the rest of the annotation in its current
   /// style. [start] and [end] are UTF-16 string offsets, matching Flutter's
   /// [TextSelection] offsets.
-  bool restyleSelectedTextRange(int start, int end,
-      {PdfTextFont? font, double? size, int? color}) {
+  bool restyleSelectedTextRange(
+    int start,
+    int end, {
+    PdfTextFont? font,
+    double? size,
+    int? color,
+  }) {
     final annotation = selectedAnnotation;
     if (annotation == null || !canRestyleSelectedText) return false;
     final text = annotation.contents ?? '';
@@ -4455,18 +4816,28 @@ class PdfEditingController extends ChangeNotifier {
     final base = _freeTextFontOf(annotation);
     final parsed = annotation.freeTextStyle;
     final baseColor = parsed?.color ?? annotation.color ?? _colorValue;
-    final target = PdfFreeTextRun(text.substring(from, to),
-        font: font ?? base.font,
-        fontSize: size ?? base.size,
-        color: color ?? baseColor);
+    final target = PdfFreeTextRun(
+      text.substring(from, to),
+      font: font ?? base.font,
+      fontSize: size ?? base.size,
+      color: color ?? baseColor,
+    );
     final runs = <PdfFreeTextRun>[
       if (from > 0)
-        PdfFreeTextRun(text.substring(0, from),
-            font: base.font, fontSize: base.size, color: baseColor),
+        PdfFreeTextRun(
+          text.substring(0, from),
+          font: base.font,
+          fontSize: base.size,
+          color: baseColor,
+        ),
       target,
       if (to < text.length)
-        PdfFreeTextRun(text.substring(to),
-            font: base.font, fontSize: base.size, color: baseColor),
+        PdfFreeTextRun(
+          text.substring(to),
+          font: base.font,
+          fontSize: base.size,
+          color: baseColor,
+        ),
     ];
     return _rewriteSelectedRich(annotation, runs);
   }
@@ -4502,8 +4873,9 @@ class PdfEditingController extends ChangeNotifier {
     }
     final page = _selected.last.$1;
     // a tooltip/comment edit changes no page's rendering
-    return apply((e) => e.setAnnotationContents(page, annotation, text),
-        pages: const <int>[]);
+    return apply(
+      (e) => e.setAnnotationContents(page, annotation, text),
+    );
   }
 
   /// Sets the author (/T) on every selected annotation - one revision,
@@ -4513,7 +4885,7 @@ class PdfEditingController extends ChangeNotifier {
     final value = (author != null && author.isEmpty) ? null : author;
     final targets = <(int, PdfAnnotation)>[
       for (final slot in _selected)
-        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation)
+        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation),
     ];
     if (targets.isEmpty) return false;
     if (targets.every((t) => t.$2.author == value)) return false;
@@ -4521,16 +4893,19 @@ class PdfEditingController extends ChangeNotifier {
       for (final (page, annotation) in targets) {
         e.setAnnotationAuthor(page, annotation, value);
       }
-    }, pages: const <int>[]);
+    });
   }
 
-  void _rewriteSelected(PdfAnnotation annotation, String text,
-      {PdfTextFont? font,
-      double? size,
-      PdfTextAlign? align,
-      (int?,)? fill,
-      (int?,)? border,
-      double? borderWidth}) {
+  void _rewriteSelected(
+    PdfAnnotation annotation,
+    String text, {
+    PdfTextFont? font,
+    double? size,
+    PdfTextAlign? align,
+    (int?,)? fill,
+    (int?,)? border,
+    double? borderWidth,
+  }) {
     if (_selected.isEmpty) return;
     final page = _selected.last.$1;
     // a rotated text box flattens to horizontal under plain remove +
@@ -4543,16 +4918,20 @@ class PdfEditingController extends ChangeNotifier {
     final by = annotation.author; // a text edit doesn't change ownership
     final nm = annotation.name; // ... nor identity (sync tracks /NM)
     _selected.clear();
-    apply((e) {
-      e.removeAnnotation(page, annotation);
-      switch (annotation.subtype) {
-        case 'FreeText':
-          final style = _freeTextFontOf(annotation);
-          // the parsed style carries what /C alone can't: the text color
-          // (from /DA) plus any background fill and border; a wrapped
-          // [fill]/[border] overrides it (see restyleSelectedText)
-          final parsed = annotation.freeTextStyle;
-          e.addFreeText(page, rect, text,
+    apply(
+      (e) {
+        e.removeAnnotation(page, annotation);
+        switch (annotation.subtype) {
+          case 'FreeText':
+            final style = _freeTextFontOf(annotation);
+            // the parsed style carries what /C alone can't: the text color
+            // (from /DA) plus any background fill and border; a wrapped
+            // [fill]/[border] overrides it (see restyleSelectedText)
+            final parsed = annotation.freeTextStyle;
+            e.addFreeText(
+              page,
+              rect,
+              text,
               fontSize: size ?? style.size,
               font: font ?? style.font,
               // keep the box's own alignment unless this edit changes it
@@ -4564,29 +4943,40 @@ class PdfEditingController extends ChangeNotifier {
                   ((parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1),
               pageRotation: _page(page).rotation,
               author: by,
-              name: nm);
-        case 'Stamp':
-          e.addStamp(page, rect, text,
+              name: nm,
+            );
+          case 'Stamp':
+            e.addStamp(
+              page,
+              rect,
+              text,
               color: color ?? 0xC03030,
               pageRotation: _page(page).rotation,
               author: by,
-              name: nm);
-        default: // 'Text'
-          e.addNote(page, rect.left, rect.top, text,
+              name: nm,
+            );
+          default: // 'Text'
+            e.addNote(
+              page,
+              rect.left,
+              rect.top,
+              text,
               color: color ?? 0xFFD100,
               pageRotation: _page(page).rotation,
               author: by,
-              name: nm);
-      }
-      // spin the freshly horizontal box back onto the resting rotation:
-      // the just-added annotation is the last /Annots entry
-      if (rotation != 0) {
-        final added = _document.page(page).annotations;
-        if (added.isNotEmpty) {
-          e.rotateAnnotation(page, added.last, rotation * 180 / math.pi);
+              name: nm,
+            );
         }
-      }
-    }, pages: [page], contentPages: const <int>[]);
+        // spin the freshly horizontal box back onto the resting rotation:
+        // the just-added annotation is the last /Annots entry
+        if (rotation != 0) {
+          final added = _document.page(page).annotations;
+          if (added.isNotEmpty) {
+            e.rotateAnnotation(page, added.last, rotation * 180 / math.pi);
+          }
+        }
+      },
+    );
     // the rewritten annotation lands in the last /Annots slot - keep it
     // selected so consecutive restyles (a settings popup) stay anchored
     final annotations = _page(page).annotations;
@@ -4599,7 +4989,9 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   bool _rewriteSelectedRich(
-      PdfAnnotation annotation, List<PdfFreeTextRun> runs) {
+    PdfAnnotation annotation,
+    List<PdfFreeTextRun> runs,
+  ) {
     if (_selected.isEmpty || annotation.subtype != 'FreeText') return false;
     final page = _selected.last.$1;
     final rotation = _appearanceRotationOf(annotation);
@@ -4608,23 +5000,29 @@ class PdfEditingController extends ChangeNotifier {
     final nm = annotation.name;
     final parsed = annotation.freeTextStyle;
     _selected.clear();
-    final changed = apply((e) {
-      e.removeAnnotation(page, annotation);
-      e.addFreeTextRich(page, rect, runs,
+    final changed = apply(
+      (e) {
+        e.removeAnnotation(page, annotation);
+        e.addFreeTextRich(
+          page,
+          rect,
+          runs,
           align: parsed?.alignment ?? PdfTextAlign.left,
           fillColor: parsed?.fillColor,
           borderColor: parsed?.borderColor,
           borderWidth: (parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1,
           pageRotation: _page(page).rotation,
           author: by,
-          name: nm);
-      if (rotation != 0) {
-        final added = _document.page(page).annotations;
-        if (added.isNotEmpty) {
-          e.rotateAnnotation(page, added.last, rotation * 180 / math.pi);
+          name: nm,
+        );
+        if (rotation != 0) {
+          final added = _document.page(page).annotations;
+          if (added.isNotEmpty) {
+            e.rotateAnnotation(page, added.last, rotation * 180 / math.pi);
+          }
         }
-      }
-    }, pages: [page], contentPages: const <int>[]);
+      },
+    );
     final annotations = _page(page).annotations;
     if (annotations.isNotEmpty) {
       _selected
@@ -4684,7 +5082,9 @@ class PdfEditingController extends ChangeNotifier {
 
   /// The content elements of [pageIndex] at the current revision.
   PdfPageElements elementsOn(int pageIndex) => _elements.putIfAbsent(
-      pageIndex, () => PdfPageElements.of(_document, pageIndex));
+        pageIndex,
+        () => PdfPageElements.of(_document, pageIndex),
+      );
 
   /// The selected content element, or null.
   PdfContentElement? get selectedElement {
@@ -4750,8 +5150,9 @@ class PdfEditingController extends ChangeNotifier {
     final selected = _selectedElement;
     final element = selectedElement;
     if (selected == null || element == null) return;
-    apply((e) => e.deleteElements(elementsOn(selected.$1), [element.id]),
-        pages: [selected.$1]);
+    apply(
+      (e) => e.deleteElements(elementsOn(selected.$1), [element.id]),
+    );
   }
 
   /// Rewrites the selected text element's characters to [text] and
@@ -4763,8 +5164,10 @@ class PdfEditingController extends ChangeNotifier {
   /// position. Composite (/Type0) text is handled; [fallbackFonts] (the
   /// bundled DejaVu trio, see `loadFallbackFonts`) draw any character the
   /// document's own font can't, so typing outside its subset still works.
-  int replaceSelectedElementText(String text,
-      {List<PdfEmbeddedFont> fallbackFonts = const []}) {
+  int replaceSelectedElementText(
+    String text, {
+    List<PdfEmbeddedFont> fallbackFonts = const [],
+  }) {
     final selected = _selectedElement;
     final element = selectedElement;
     if (selected == null || element == null || !canEditSelectedElementText) {
@@ -4772,9 +5175,13 @@ class PdfEditingController extends ChangeNotifier {
     }
     var count = 0;
     apply(
-        (e) => count = e.replaceText(selected.$1, element.text!, text,
-            fallbackFonts: fallbackFonts),
-        pages: [selected.$1]);
+      (e) => count = e.replaceText(
+        selected.$1,
+        element.text!,
+        text,
+        fallbackFonts: fallbackFonts,
+      ),
+    );
     return count;
   }
 
@@ -4784,8 +5191,11 @@ class PdfEditingController extends ChangeNotifier {
   /// Styling lands on simple-font runs; a composite (/Type0) element is still
   /// re-typed but keeps its original colour, size, and face. Returns how many
   /// runs changed.
-  int replaceStyledSelectedElementText(String text, PdfTextStyle style,
-      {List<PdfEmbeddedFont> fallbackFonts = const []}) {
+  int replaceStyledSelectedElementText(
+    String text,
+    PdfTextStyle style, {
+    List<PdfEmbeddedFont> fallbackFonts = const [],
+  }) {
     final selected = _selectedElement;
     final element = selectedElement;
     if (selected == null || element == null || !canEditSelectedElementText) {
@@ -4793,9 +5203,14 @@ class PdfEditingController extends ChangeNotifier {
     }
     var count = 0;
     apply(
-        (e) => count = e.replaceText(selected.$1, element.text!, text,
-            fallbackFonts: fallbackFonts, style: style),
-        pages: [selected.$1]);
+      (e) => count = e.replaceText(
+        selected.$1,
+        element.text!,
+        text,
+        fallbackFonts: fallbackFonts,
+        style: style,
+      ),
+    );
     return count;
   }
 
@@ -4857,8 +5272,12 @@ class PdfEditingController extends ChangeNotifier {
     return _replaceElementImage(selected, current, currentBounds, image);
   }
 
-  bool _replaceElementImage((int page, int id) selected,
-      PdfContentElement element, PdfRect bounds, PdfEmbeddableImage image) {
+  bool _replaceElementImage(
+    (int page, int id) selected,
+    PdfContentElement element,
+    PdfRect bounds,
+    PdfEmbeddableImage image,
+  ) {
     final aspect = image.height == 0 ? 1.0 : image.width / image.height;
     var (width: w, height: h) = _visualSizeOfPageRect(selected.$1, bounds);
     if (w / h > aspect) {
@@ -4870,16 +5289,17 @@ class PdfEditingController extends ChangeNotifier {
     final cy = (bounds.bottom + bounds.top) / 2;
     final elements = elementsOn(selected.$1);
     return apply(
-        (e) => e
-          ..deleteElements(elements, [element.id])
-          ..addImageStamp(
-              selected.$1,
-              _pageRectForVisualSize(selected.$1, cx, cy, width: w, height: h),
-              image,
-              opacity: preferences.opacity,
-              pageRotation: _page(selected.$1).rotation,
-              author: author),
-        pages: [selected.$1]);
+      (e) => e
+        ..deleteElements(elements, [element.id])
+        ..addImageStamp(
+          selected.$1,
+          _pageRectForVisualSize(selected.$1, cx, cy, width: w, height: h),
+          image,
+          opacity: preferences.opacity,
+          pageRotation: _page(selected.$1).rotation,
+          author: author,
+        ),
+    );
   }
 
   /// Renders the selected page-content image element to a standalone PNG.
@@ -4946,7 +5366,8 @@ class PdfEditingController extends ChangeNotifier {
         pageIndex: selected.$1,
         pageRect: bounds,
         pngBytes: Uint8List.fromList(
-            data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes)),
+          data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+        ),
       );
     } finally {
       image?.dispose();
@@ -4980,8 +5401,9 @@ class PdfEditingController extends ChangeNotifier {
       return false;
     }
     var reflowed = false;
-    apply((e) => reflowed = e.reflowText(selected.$1, element.text!, text),
-        pages: [selected.$1]);
+    apply(
+      (e) => reflowed = e.reflowText(selected.$1, element.text!, text),
+    );
     return reflowed;
   }
 
@@ -5008,7 +5430,10 @@ class PdfEditingController extends ChangeNotifier {
   /// radio group that index says which button was tapped
   /// ([PdfFormField.widgetOnState]). Null when nothing is hit.
   (PdfFormField field, int widgetIndex)? formFieldAt(
-      int pageIndex, double x, double y) {
+    int pageIndex,
+    double x,
+    double y,
+  ) {
     final form = acroForm;
     if (form == null) return null;
     final annotations = _page(pageIndex).annotations;
@@ -5060,36 +5485,26 @@ class PdfEditingController extends ChangeNotifier {
     return result;
   }
 
-  /// The pages a field's widgets are displayed on, or null when any
-  /// widget's page is unknown (then every page's render stamp bumps).
-  List<int>? _fieldPages(String name) {
-    final field = acroForm?.fieldNamed(name);
-    if (field == null) return null;
-    final pages = <int>{};
-    for (var i = 0; i < field.widgets.length; i++) {
-      final page = field.widgetPageIndex(i);
-      if (page < 0) return null;
-      pages.add(page);
-    }
-    return pages.toList();
-  }
-
   /// Shared fill plumbing: resolves the field by [name] (fields die with
   /// every revision, so names are the stable handle), guards type and
   /// read-only, and turns editor complaints into a false return - a UI
   /// tap must never crash on a quirky field.
-  bool _fillField(String name, Set<PdfFieldType> types,
-      void Function(PdfEditor e, PdfFormField f) fill) {
+  bool _fillField(
+    String name,
+    Set<PdfFieldType> types,
+    void Function(PdfEditor e, PdfFormField f) fill,
+  ) {
     final field = acroForm?.fieldNamed(name);
     if (field == null || field.isReadOnly || !types.contains(field.type)) {
       return false;
     }
-    final pages = _fieldPages(name);
     try {
-      return apply((e) {
-        final f = e.acroForm?.fieldNamed(name);
-        if (f != null) fill(e, f);
-      }, pages: pages, contentPages: const <int>[]);
+      return apply(
+        (e) {
+          final f = e.acroForm?.fieldNamed(name);
+          if (f != null) fill(e, f);
+        },
+      );
     } on ArgumentError {
       return false;
     } on StateError {
@@ -5103,13 +5518,19 @@ class PdfEditingController extends ChangeNotifier {
     final field = acroForm?.fieldNamed(name);
     if (field != null && (field.value ?? '') == value) return false;
     return _fillField(
-        name, const {PdfFieldType.text}, (e, f) => e.setTextValue(f, value));
+        name,
+        const {
+          PdfFieldType.text,
+        },
+        (e, f) => e.setTextValue(f, value));
   }
 
   /// Toggles the check box [name].
   bool toggleFormCheckBox(String name) => _fillField(
       name,
-      const {PdfFieldType.checkBox},
+      const {
+        PdfFieldType.checkBox,
+      },
       (e, f) => e.setCheckBoxValue(f, !f.isChecked));
 
   /// Selects [onState] in the radio group [name] (the tapped widget's
@@ -5117,7 +5538,11 @@ class PdfEditingController extends ChangeNotifier {
   bool setFormRadioValue(String name, String onState) {
     final field = acroForm?.fieldNamed(name);
     if (field != null && field.value == onState) return false;
-    return _fillField(name, const {PdfFieldType.radioGroup},
+    return _fillField(
+        name,
+        const {
+          PdfFieldType.radioGroup,
+        },
         (e, f) => e.setRadioValue(f, onState));
   }
 
@@ -5125,7 +5550,10 @@ class PdfEditingController extends ChangeNotifier {
   /// value, per [PdfEditor.setChoiceValue]).
   bool setFormChoiceValue(String name, String value) => _fillField(
       name,
-      const {PdfFieldType.comboBox, PdfFieldType.listBox},
+      const {
+        PdfFieldType.comboBox,
+        PdfFieldType.listBox,
+      },
       (e, f) => e.setChoiceValue(f, value));
 
   /// Fills the push button [name] with [imageBytes] (PNG or JPEG),
@@ -5137,16 +5565,26 @@ class PdfEditingController extends ChangeNotifier {
     } catch (_) {
       return false;
     }
-    return _fillField(name, const {PdfFieldType.pushButton},
+    return _fillField(
+        name,
+        const {
+          PdfFieldType.pushButton,
+        },
         (e, f) => e.setButtonImage(f, image));
   }
 
   /// Async counterpart to [setFormButtonImage]. See [placeImageAsync].
   Future<bool> setFormButtonImageAsync(
-      String name, Uint8List imageBytes) async {
+    String name,
+    Uint8List imageBytes,
+  ) async {
     final image = await _decodeEmbeddableImageAsync(imageBytes);
     if (image == null) return false;
-    return _fillField(name, const {PdfFieldType.pushButton},
+    return _fillField(
+        name,
+        const {
+          PdfFieldType.pushButton,
+        },
         (e, f) => e.setButtonImage(f, image));
   }
 
@@ -5172,16 +5610,18 @@ class PdfEditingController extends ChangeNotifier {
       i++;
     }
     final name = 'Field $i';
-    final added = apply((e) {
-      switch (kind) {
-        case PdfFormFieldKind.text:
-          e.addTextField(pageIndex, name, rect);
-        case PdfFormFieldKind.checkBox:
-          e.addCheckBoxField(pageIndex, name, rect);
-        case PdfFormFieldKind.pushButton:
-          e.addPushButtonField(pageIndex, name, rect);
-      }
-    }, pages: [pageIndex], contentPages: const <int>[]);
+    final added = apply(
+      (e) {
+        switch (kind) {
+          case PdfFormFieldKind.text:
+            e.addTextField(pageIndex, name, rect);
+          case PdfFormFieldKind.checkBox:
+            e.addCheckBoxField(pageIndex, name, rect);
+          case PdfFormFieldKind.pushButton:
+            e.addPushButtonField(pageIndex, name, rect);
+        }
+      },
+    );
     return added ? name : null;
   }
 
@@ -5195,7 +5635,7 @@ class PdfEditingController extends ChangeNotifier {
       return apply((e) {
         final f = e.acroForm?.fieldNamed(name);
         if (f != null) e.renameField(f, newName);
-      }, pages: const <int>[]);
+      });
     } on ArgumentError {
       return false;
     }
@@ -5204,11 +5644,12 @@ class PdfEditingController extends ChangeNotifier {
   /// Removes the field [name] and its widgets.
   bool removeFormField(String name) {
     if (acroForm?.fieldNamed(name) == null) return false;
-    final pages = _fieldPages(name);
-    return apply((e) {
-      final f = e.acroForm?.fieldNamed(name);
-      if (f != null) e.removeField(f);
-    }, pages: pages, contentPages: const <int>[]);
+    return apply(
+      (e) {
+        final f = e.acroForm?.fieldNamed(name);
+        if (f != null) e.removeField(f);
+      },
+    );
   }
 
   /// Rebuilds the field [name] as [kind] at its first widget's place,
@@ -5221,12 +5662,13 @@ class PdfEditingController extends ChangeNotifier {
       PdfFormFieldKind.checkBox => PdfFieldType.checkBox,
       PdfFormFieldKind.pushButton => PdfFieldType.pushButton,
     };
-    final pages = _fieldPages(name);
     try {
-      return apply((e) {
-        final f = e.acroForm?.fieldNamed(name);
-        if (f != null) e.changeFieldType(f, type);
-      }, pages: pages, contentPages: const <int>[]);
+      return apply(
+        (e) {
+          final f = e.acroForm?.fieldNamed(name);
+          if (f != null) e.changeFieldType(f, type);
+        },
+      );
     } on ArgumentError {
       return false;
     } on StateError {
@@ -5279,7 +5721,10 @@ class PdfEditingController extends ChangeNotifier {
     final rect = field.widgetRect(0);
     if (page < 0 || rect == null) return false;
     return selectFormWidgetAt(
-        page, (rect.left + rect.right) / 2, (rect.bottom + rect.top) / 2);
+      page,
+      (rect.left + rect.right) / 2,
+      (rect.bottom + rect.top) / 2,
+    );
   }
 
   /// The selected text field's current style, or null when no single text
@@ -5288,9 +5733,9 @@ class PdfEditingController extends ChangeNotifier {
     final sel = _selectedFormTextField;
     if (sel == null) return null;
     final field = sel.$2;
-    final name = RegExp(r'/(\S+)\s+[\d.]+\s+Tf')
-            .firstMatch(field.defaultAppearance ?? '')
-            ?.group(1) ??
+    final name = RegExp(
+          r'/(\S+)\s+[\d.]+\s+Tf',
+        ).firstMatch(field.defaultAppearance ?? '')?.group(1) ??
         'Helv';
     final size = field.appearanceFontSize;
     return PdfFormFieldStyle(
@@ -5298,8 +5743,10 @@ class PdfEditingController extends ChangeNotifier {
       size: size == 0 ? 12 : size,
       autoSize: size == 0,
       color: Color(0xFF000000 | (field.appearanceColor ?? 0)),
-      align: PdfTextAlign.values.firstWhere((a) => a.quadding == field.quadding,
-          orElse: () => PdfTextAlign.left),
+      align: PdfTextAlign.values.firstWhere(
+        (a) => a.quadding == field.quadding,
+        orElse: () => PdfTextAlign.left,
+      ),
       multiline: field.isMultiline,
     );
   }
@@ -5322,20 +5769,23 @@ class PdfEditingController extends ChangeNotifier {
     if (field == null || field.isReadOnly || field.type != PdfFieldType.text) {
       return false;
     }
-    final pages = _fieldPages(name);
     try {
-      return apply((e) {
-        final f = e.acroForm?.fieldNamed(name);
-        if (f != null) {
-          e.setTextFieldStyle(f,
+      return apply(
+        (e) {
+          final f = e.acroForm?.fieldNamed(name);
+          if (f != null) {
+            e.setTextFieldStyle(
+              f,
               font: font,
               fontSize: fontSize,
               autoSize: autoSize,
               color: color,
               align: align,
-              multiline: multiline);
-        }
-      }, pages: pages, contentPages: const <int>[]);
+              multiline: multiline,
+            );
+          }
+        },
+      );
     } on ArgumentError {
       return false;
     } on StateError {

--- a/packages/dart_pdf_editor/test/editing_panels_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panels_test.dart
@@ -64,7 +64,7 @@ void main() {
       expect(editing.pageRenderStamp(2), after[2]);
     });
 
-    test('structural and unattributed edits bump every page', () {
+    test('structural edits bump all; editor-attributed edits stay narrow', () {
       final editing = PdfEditingController(buildMultiPagePdf(3));
       addTearDown(editing.dispose);
       final before = [for (var i = 0; i < 3; i++) editing.pageRenderStamp(i)];
@@ -75,11 +75,12 @@ void main() {
         expect(moved[i], isNot(before[i]));
       }
 
-      // a host edit through the public apply, with no pages named
+      // A host edit through public apply gets its impact from PdfEditor;
+      // callers no longer need to name the affected page themselves.
       editing.apply((e) => e.rotatePage(0, 90));
-      for (var i = 0; i < 3; i++) {
-        expect(editing.pageRenderStamp(i), isNot(moved[i]));
-      }
+      expect(editing.pageRenderStamp(0), isNot(moved[0]));
+      expect(editing.pageRenderStamp(1), moved[1]);
+      expect(editing.pageRenderStamp(2), moved[2]);
     });
 
     test('pageAt caches within a revision', () {

--- a/packages/dart_pdf_editor/test/editing_transaction_test.dart
+++ b/packages/dart_pdf_editor/test/editing_transaction_test.dart
@@ -1,0 +1,111 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('document mutation drives narrow render and content stamps', () {
+    final editing = PdfEditingController(buildMultiPagePdf(3));
+    addTearDown(editing.dispose);
+    final render = [for (var i = 0; i < 3; i++) editing.pageRenderStamp(i)];
+    final content = [
+      for (var i = 0; i < 3; i++) editing.pageContentRenderStamp(i),
+    ];
+
+    expect(
+      editing.apply(
+        (editor) => editor.stampPage(
+          1,
+          (stamp) => stamp.text('impact', x: 10, y: 10),
+        ),
+      ),
+      isTrue,
+    );
+
+    expect(editing.pageRenderStamp(0), render[0]);
+    expect(editing.pageRenderStamp(1), greaterThan(render[1]));
+    expect(editing.pageRenderStamp(2), render[2]);
+    expect(editing.pageContentRenderStamp(0), content[0]);
+    expect(editing.pageContentRenderStamp(1), greaterThan(content[1]));
+    expect(editing.pageContentRenderStamp(2), content[2]);
+  });
+
+  test('annotation metadata emits sync without invalidating rendering',
+      () async {
+    final editing = PdfEditingController(buildClassicPdf())
+      ..addRectangle(0, const PdfRect(100, 600, 200, 700))
+      ..selectAnnotation(0, 0);
+    addTearDown(editing.dispose);
+    final render = editing.pageRenderStamp(0);
+    final content = editing.pageContentRenderStamp(0);
+    final batches = <List<PdfAnnotationChange>>[];
+    final subscription = editing.annotationChanges.listen(batches.add);
+    addTearDown(subscription.cancel);
+
+    expect(editing.setSelectedAuthor('Ben'), isTrue);
+    await pumpEventQueue();
+
+    expect(editing.pageRenderStamp(0), render);
+    expect(editing.pageContentRenderStamp(0), content);
+    expect(batches, hasLength(1));
+    expect(batches.single.single.kind, PdfAnnotationChangeKind.modified);
+  });
+
+  test('undo and redo replay the mutation-reported impact', () {
+    final editing = PdfEditingController(buildMultiPagePdf(3));
+    addTearDown(editing.dispose);
+
+    editing.addRectangle(1, const PdfRect(100, 600, 200, 700));
+    final afterEdit = [
+      for (var i = 0; i < 3; i++) editing.pageRenderStamp(i),
+    ];
+    editing.undo();
+    final afterUndo = [
+      for (var i = 0; i < 3; i++) editing.pageRenderStamp(i),
+    ];
+    editing.redo();
+    final afterRedo = [
+      for (var i = 0; i < 3; i++) editing.pageRenderStamp(i),
+    ];
+
+    expect(afterUndo[0], afterEdit[0]);
+    expect(afterUndo[1], greaterThan(afterEdit[1]));
+    expect(afterUndo[2], afterEdit[2]);
+    expect(afterRedo[0], afterUndo[0]);
+    expect(afterRedo[1], greaterThan(afterUndo[1]));
+    expect(afterRedo[2], afterUndo[2]);
+  });
+
+  test('structural mutation clears page and annotation selection', () {
+    final editing = PdfEditingController(buildMultiPagePdf(3))
+      ..addRectangle(0, const PdfRect(100, 600, 200, 700))
+      ..selectAnnotation(0, 0)
+      ..selectPage(0);
+    addTearDown(editing.dispose);
+
+    expect(editing.apply((editor) => editor.movePage(0, 2)), isTrue);
+
+    expect(editing.hasAnnotationSelection, isFalse);
+    expect(editing.selectedPages, isEmpty);
+  });
+
+  test('legacy impact hints remain compatible for custom mutations', () {
+    final editing = PdfEditingController(buildMultiPagePdf(2));
+    addTearDown(editing.dispose);
+    final before = editing.pageRenderStamp(1);
+
+    expect(
+      editing.apply(
+        (editor) => editor.setInfo(title: 'legacy'),
+        pages: const [1],
+        contentPages: const [],
+      ),
+      isTrue,
+    );
+
+    expect(editing.pageRenderStamp(1), greaterThan(before));
+  });
+}

--- a/packages/pdf_document/lib/src/annotation_clipboard.dart
+++ b/packages/pdf_document/lib/src/annotation_clipboard.dart
@@ -9,8 +9,12 @@ part of 'editor.dart';
 /// including across documents. Capture with [capture], paste with
 /// [PdfAnnotationClipboard.pasteAnnotation].
 class PdfAnnotationSnapshot {
-  PdfAnnotationSnapshot._(this._dict, this.subtype, this.rect,
-      {this.inReplyTo});
+  PdfAnnotationSnapshot._(
+    this._dict,
+    this.subtype,
+    this.rect, {
+    this.inReplyTo,
+  });
 
   /// Fully detached: no [CosReference]s, streams held inline. Pastes
   /// re-copy it ([_materialize]), so one snapshot can paste many times
@@ -53,8 +57,10 @@ class PdfAnnotationSnapshot {
   /// identity the snapshot travels under (see
   /// [PdfAnnotationSyncEditing.upsertAnnotation]).
   static PdfAnnotationSnapshot? capture(
-      PdfDocument document, PdfAnnotation annotation,
-      {bool keepName = false}) {
+    PdfDocument document,
+    PdfAnnotation annotation, {
+    bool keepName = false,
+  }) {
     if (const {'Popup', 'Widget', 'Link'}.contains(annotation.subtype)) {
       return null;
     }
@@ -69,8 +75,12 @@ class PdfAnnotationSnapshot {
       }
       out[key] = copier.copy(value);
     });
-    return PdfAnnotationSnapshot._(out, annotation.subtype, annotation.rect,
-        inReplyTo: keepName ? annotation.inReplyTo : null);
+    return PdfAnnotationSnapshot._(
+      out,
+      annotation.subtype,
+      annotation.rect,
+      inReplyTo: keepName ? annotation.inReplyTo : null,
+    );
   }
 
   /// The /NM identity captured with `keepName: true`, if any.
@@ -111,8 +121,12 @@ class PdfAnnotationSnapshot {
     return PdfAnnotationSnapshot._(
       dict,
       subtype,
-      PdfRect((rect[0] as num).toDouble(), (rect[1] as num).toDouble(),
-          (rect[2] as num).toDouble(), (rect[3] as num).toDouble()),
+      PdfRect(
+        (rect[0] as num).toDouble(),
+        (rect[1] as num).toDouble(),
+        (rect[2] as num).toDouble(),
+        (rect[3] as num).toDouble(),
+      ),
       inReplyTo: irt as String?,
     );
   }
@@ -136,7 +150,7 @@ Object? _encodeCos(CosObject value) {
       };
     case CosDictionary dict:
       return {
-        'd': {for (final e in dict.entries.entries) e.key: _encodeCos(e.value)}
+        'd': {for (final e in dict.entries.entries) e.key: _encodeCos(e.value)},
       };
     case CosArray array:
       return [for (final item in array.items) _encodeCos(item)];
@@ -170,8 +184,10 @@ CosObject _decodeCos(Object? value) {
     case Map map when map.containsKey('n'):
       return CosName(map['n'] as String);
     case Map map when map.containsKey('s'):
-      return CosString(base64Decode(map['s'] as String),
-          isHex: map['h'] == true);
+      return CosString(
+        base64Decode(map['s'] as String),
+        isHex: map['h'] == true,
+      );
     case Map map when map.containsKey('d'):
       final dict = CosDictionary();
       (map['d'] as Map).forEach((key, item) {
@@ -189,8 +205,10 @@ CosObject _decodeCos(Object? value) {
 CosObject _copyDetached(CosObject value) {
   switch (value) {
     case CosStream stream:
-      return CosStream(_copyDetached(stream.dictionary) as CosDictionary,
-          Uint8List.fromList(stream.rawBytes));
+      return CosStream(
+        _copyDetached(stream.dictionary) as CosDictionary,
+        Uint8List.fromList(stream.rawBytes),
+      );
     case CosDictionary dict:
       final out = CosDictionary();
       dict.entries.forEach((key, item) => out[key] = _copyDetached(item));
@@ -275,8 +293,12 @@ extension PdfAnnotationClipboard on PdfEditor {
   /// two annotations. Streams (the appearance) become fresh indirect
   /// objects per §7.3.8, and the annotation appends to the page's
   /// /Annots, so it paints on top (§12.5.2).
-  void pasteAnnotation(int pageIndex, PdfAnnotationSnapshot snapshot,
-      {double dx = 0, double dy = 0}) {
+  void pasteAnnotation(
+    int pageIndex,
+    PdfAnnotationSnapshot snapshot, {
+    double dx = 0,
+    double dy = 0,
+  }) {
     final dict = snapshot._materialize();
     // pasted copies are new annotations and get a fresh identity; a
     // sync snapshot captured with keepName pastes under its own /NM
@@ -284,12 +306,9 @@ extension PdfAnnotationClipboard on PdfEditor {
       dict['NM'] = CosString.fromText(_generateAnnotationName());
     }
     final rect = snapshot.rect;
-    dict['Rect'] = _rectArray(PdfRect(
-      rect.left + dx,
-      rect.bottom + dy,
-      rect.right + dx,
-      rect.top + dy,
-    ));
+    dict['Rect'] = _rectArray(
+      PdfRect(rect.left + dx, rect.bottom + dy, rect.right + dx, rect.top + dy),
+    );
     for (final key in const ['QuadPoints', 'L', 'Vertices', 'CL']) {
       final shifted = _shiftPoints(dict[key], dx, dy);
       if (shifted != null) dict[key] = shifted;
@@ -317,7 +336,11 @@ extension PdfAnnotationClipboard on PdfEditor {
     _hoistStreams(dict);
 
     final annotRef = _updater.addObject(dict);
-    _PdfPageAnnotationList(this, pageIndex).append(annotRef);
+    _linkAnnotation(
+      pageIndex,
+      annotRef,
+      visual: !const {'Popup'}.contains(snapshot.subtype),
+    );
   }
 
   /// Replaces every inline [CosStream] in the tree with a reference to a

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -16,7 +16,8 @@ double pdfInkStrokeWidth(double strokeWidth, double pressure) =>
 /// appearances and the live stroke previews so committed ink matches
 /// what was drawn.
 List<((double, double), (double, double))> pdfInkCurveControls(
-    List<(double, double)> points) {
+  List<(double, double)> points,
+) {
   return [
     for (var i = 0; i < points.length - 1; i++)
       () {
@@ -110,10 +111,8 @@ enum PdfLineEnding {
   final String pdfName;
 
   /// The matching ending for a /LE name, or [none] when unknown.
-  static PdfLineEnding fromName(String name) => values.firstWhere(
-        (ending) => ending.pdfName == name,
-        orElse: () => none,
-      );
+  static PdfLineEnding fromName(String name) =>
+      values.firstWhere((ending) => ending.pdfName == name, orElse: () => none);
 }
 
 /// The start/end line endings recorded on [annotation]'s /LE entry, or
@@ -186,11 +185,16 @@ enum PdfLineEnding {
     List<(double, double)?>? intervals;
     for (var i = 0; i + 1 < stroke.length; i++) {
       final interval = _capsuleInterval(
-          stroke[i], stroke[i + 1], from, to, radius,
-          boundsLeft: boundsLeft,
-          boundsRight: boundsRight,
-          boundsBottom: boundsBottom,
-          boundsTop: boundsTop);
+        stroke[i],
+        stroke[i + 1],
+        from,
+        to,
+        radius,
+        boundsLeft: boundsLeft,
+        boundsRight: boundsRight,
+        boundsBottom: boundsBottom,
+        boundsTop: boundsTop,
+      );
       if (interval == null) continue;
       (intervals ??= List.filled(stroke.length - 1, null))[i] = interval;
     }
@@ -281,7 +285,11 @@ enum PdfLineEnding {
     return null;
   }
   double f(double t) => _distanceToSegment(
-      a.$1 + (b.$1 - a.$1) * t, a.$2 + (b.$2 - a.$2) * t, c, d);
+        a.$1 + (b.$1 - a.$1) * t,
+        a.$2 + (b.$2 - a.$2) * t,
+        c,
+        d,
+      );
   final f0 = f(0), f1 = f(1);
   var lo = 0.0, hi = 1.0;
   for (var i = 0; i < 60; i++) {
@@ -315,7 +323,11 @@ enum PdfLineEnding {
 
 /// Distance from ([x], [y]) to the segment [a]–[b].
 double _distanceToSegment(
-    double x, double y, (double, double) a, (double, double) b) {
+  double x,
+  double y,
+  (double, double) a,
+  (double, double) b,
+) {
   final (ax, ay) = a;
   final (bx, by) = b;
   final dx = bx - ax, dy = by - ay;
@@ -359,8 +371,9 @@ String _generateAnnotationName() {
   }
   b[6] = (b[6] & 0x0F) | 0x40; // version 4
   b[8] = (b[8] & 0x3F) | 0x80; // RFC 4122 variant
-  final hex =
-      [for (final byte in b) byte.toRadixString(16).padLeft(2, '0')].join();
+  final hex = [
+    for (final byte in b) byte.toRadixString(16).padLeft(2, '0'),
+  ].join();
   return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
       '${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20)}';
 }
@@ -392,48 +405,90 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) =>
-      _addTextMarkup('Highlight', pageIndex, quads, color, opacity, contents,
-          author, name);
+      _addTextMarkup(
+        'Highlight',
+        pageIndex,
+        quads,
+        color,
+        opacity,
+        contents,
+        author,
+        name,
+      );
 
   /// Adds an underline beneath each quad in [quads].
-  void addUnderline(int pageIndex, List<PdfRect> quads,
-          {int color = 0x10A010,
-          double opacity = 1,
-          String? contents,
-          String? author,
-          String? name}) =>
-      _addTextMarkup('Underline', pageIndex, quads, color, opacity, contents,
-          author, name);
+  void addUnderline(
+    int pageIndex,
+    List<PdfRect> quads, {
+    int color = 0x10A010,
+    double opacity = 1,
+    String? contents,
+    String? author,
+    String? name,
+  }) =>
+      _addTextMarkup(
+        'Underline',
+        pageIndex,
+        quads,
+        color,
+        opacity,
+        contents,
+        author,
+        name,
+      );
 
   /// Adds a strike-out through each quad in [quads].
-  void addStrikeOut(int pageIndex, List<PdfRect> quads,
-          {int color = 0xD02020,
-          double opacity = 1,
-          String? contents,
-          String? author,
-          String? name}) =>
-      _addTextMarkup('StrikeOut', pageIndex, quads, color, opacity, contents,
-          author, name);
+  void addStrikeOut(
+    int pageIndex,
+    List<PdfRect> quads, {
+    int color = 0xD02020,
+    double opacity = 1,
+    String? contents,
+    String? author,
+    String? name,
+  }) =>
+      _addTextMarkup(
+        'StrikeOut',
+        pageIndex,
+        quads,
+        color,
+        opacity,
+        contents,
+        author,
+        name,
+      );
 
   /// Adds a squiggly (jagged) underline beneath each quad in [quads].
-  void addSquiggly(int pageIndex, List<PdfRect> quads,
-          {int color = 0xD02020,
-          double opacity = 1,
-          String? contents,
-          String? author,
-          String? name}) =>
+  void addSquiggly(
+    int pageIndex,
+    List<PdfRect> quads, {
+    int color = 0xD02020,
+    double opacity = 1,
+    String? contents,
+    String? author,
+    String? name,
+  }) =>
       _addTextMarkup(
-          'Squiggly', pageIndex, quads, color, opacity, contents, author, name);
+        'Squiggly',
+        pageIndex,
+        quads,
+        color,
+        opacity,
+        contents,
+        author,
+        name,
+      );
 
   void _addTextMarkup(
-      String subtype,
-      int pageIndex,
-      List<PdfRect> quads,
-      int color,
-      double opacity,
-      String? contents,
-      String? author,
-      String? name) {
+    String subtype,
+    int pageIndex,
+    List<PdfRect> quads,
+    int color,
+    double opacity,
+    String? contents,
+    String? author,
+    String? name,
+  ) {
     final rect = _boundsOf(quads);
     final (w, gs) = _markupContent(subtype, quads, color, opacity);
     _addAnnotation(
@@ -451,7 +506,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// [restyleAnnotation] so a restyled markup re-renders exactly like a
   /// fresh one.
   (ContentWriter, CosDictionary?) _markupContent(
-      String subtype, List<PdfRect> quads, int color, double opacity) {
+    String subtype,
+    List<PdfRect> quads,
+    int color,
+    double opacity,
+  ) {
     switch (subtype) {
       case 'Highlight':
         final w = ContentWriter()
@@ -540,10 +599,15 @@ extension PdfAnnotationEditing on PdfEditor {
       dict['OverlayText'] = CosString.fromText(overlayText);
       dict['Repeat'] = const CosBoolean(false);
       final rgb = ContentWriter.rgbComponents(overlayTextColor);
-      dict['DA'] = CosString(Uint8List.fromList(
-          latin1.encode('/Helv ${ContentWriter.fmt(overlayFontSize)} Tf '
-              '${ContentWriter.fmt(rgb[0])} ${ContentWriter.fmt(rgb[1])} '
-              '${ContentWriter.fmt(rgb[2])} rg')));
+      dict['DA'] = CosString(
+        Uint8List.fromList(
+          latin1.encode(
+            '/Helv ${ContentWriter.fmt(overlayFontSize)} Tf '
+            '${ContentWriter.fmt(rgb[0])} ${ContentWriter.fmt(rgb[1])} '
+            '${ContentWriter.fmt(rgb[2])} rg',
+          ),
+        ),
+      );
     }
     _addAnnotation(
       pageIndex,
@@ -583,13 +647,21 @@ extension PdfAnnotationEditing on PdfEditor {
               for (var i = 0; i < strokes.length; i++)
                 if (pressures[i] != null &&
                     pressures[i]!.length != strokes[i].length)
-                  i
+                  i,
             ].isNotEmpty)) {
       throw ArgumentError.value(
-          pressures, 'pressures', 'must parallel strokes point for point');
+        pressures,
+        'pressures',
+        'must parallel strokes point for point',
+      );
     }
-    final (rect, w, gs) =
-        _inkAppearance(strokes, pressures, color, strokeWidth, opacity);
+    final (rect, w, gs) = _inkAppearance(
+      strokes,
+      pressures,
+      color,
+      strokeWidth,
+      opacity,
+    );
 
     _addAnnotation(
       pageIndex,
@@ -629,8 +701,9 @@ extension PdfAnnotationEditing on PdfEditor {
     // a Bézier stays inside its control points' hull, so including the
     // controls makes the rect cover any spline overshoot past the samples
     for (var s = 0; s < strokes.length; s++) {
-      for (final (x, y)
-          in strokes[s].followedBy(controls[s].expand((c) => [c.$1, c.$2]))) {
+      for (final (x, y) in strokes[s].followedBy(
+        controls[s].expand((c) => [c.$1, c.$2]),
+      )) {
         if (x < minX) minX = x;
         if (x > maxX) maxX = x;
         if (y < minY) minY = y;
@@ -680,8 +753,9 @@ extension PdfAnnotationEditing on PdfEditor {
         final ((c1x, c1y), (c2x, c2y)) = controls[s][i];
         final (xb, yb) = stroke[i + 1];
         w
-          ..lineWidth(pdfInkStrokeWidth(
-              strokeWidth, (pressure[i] + pressure[i + 1]) / 2))
+          ..lineWidth(
+            pdfInkStrokeWidth(strokeWidth, (pressure[i] + pressure[i + 1]) / 2),
+          )
           ..moveTo(xa, ya)
           ..curveTo(c1x, c1y, c2x, c2y, xb, yb)
           ..stroke();
@@ -710,8 +784,12 @@ extension PdfAnnotationEditing on PdfEditor {
   /// Returns whether anything changed; false for non-Ink annotations
   /// and ones without a usable /InkList (those can only be deleted
   /// whole).
-  bool sliceInk(int pageIndex, PdfAnnotation annotation,
-      List<(double, double)> path, double radius) {
+  bool sliceInk(
+    int pageIndex,
+    PdfAnnotation annotation,
+    List<(double, double)> path,
+    double radius,
+  ) {
     if (annotation.subtype != 'Ink' || path.isEmpty || radius <= 0) {
       return false;
     }
@@ -740,18 +818,29 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     final opacity = form == null ? 1.0 : _appearanceOpacity(form);
     final color = annotation.color ?? 0x000000;
-    final (rect, w, gs) =
-        _inkAppearance(strokes, pressures, color, strokeWidth, opacity);
+    final (rect, w, gs) = _inkAppearance(
+      strokes,
+      pressures,
+      color,
+      strokeWidth,
+      opacity,
+    );
     final dict = annotation.dict;
     dict['Rect'] = _rectArray(rect);
     dict['InkList'] = _inkListArray(strokes);
     if (form != null) {
-      _replaceAppearance(dict, form, rect, w,
-          resources: _resources(extGState: gs));
+      _replaceAppearance(
+        dict,
+        form,
+        rect,
+        w,
+        resources: _resources(extGState: gs),
+      );
     } else {
       dict['AP'] = CosDictionary({
-        'N': _updater
-            .addObject(_form(rect, w, resources: _resources(extGState: gs))),
+        'N': _updater.addObject(
+          _form(rect, w, resources: _resources(extGState: gs)),
+        ),
       });
     }
     _markAnnotationChanged(pageIndex, dict);
@@ -764,8 +853,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// pressures, averaged back onto the points. Returns null - uniform
   /// width - whenever the stream doesn't match that exact shape
   /// (foreign appearances, plain uniform ink).
-  List<List<double>?>? _recoverInkPressures(CosStream form,
-      List<List<(double, double)>> strokes, double strokeWidth) {
+  List<List<double>?>? _recoverInkPressures(
+    CosStream form,
+    List<List<(double, double)>> strokes,
+    double strokeWidth,
+  ) {
     if (strokeWidth <= 0) return null;
     final List<ContentOperation> ops;
     try {
@@ -845,8 +937,19 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) =>
-      _addShape('Square', pageIndex, rect, strokeColor, strokeWidth, fillColor,
-          opacity, contents, author, name, dashPattern);
+      _addShape(
+        'Square',
+        pageIndex,
+        rect,
+        strokeColor,
+        strokeWidth,
+        fillColor,
+        opacity,
+        contents,
+        author,
+        name,
+        dashPattern,
+      );
 
   /// Adds an ellipse annotation inscribed in [rect]. At least one of
   /// [strokeColor] and [fillColor] must be given.
@@ -862,8 +965,19 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) =>
-      _addShape('Circle', pageIndex, rect, strokeColor, strokeWidth, fillColor,
-          opacity, contents, author, name, dashPattern);
+      _addShape(
+        'Circle',
+        pageIndex,
+        rect,
+        strokeColor,
+        strokeWidth,
+        fillColor,
+        opacity,
+        contents,
+        author,
+        name,
+        dashPattern,
+      );
 
   /// Adds a straight /Line annotation from [start] to [end]. Set
   /// [endEnding] to [PdfLineEnding.closedArrow] for a standard arrow.
@@ -890,18 +1004,22 @@ extension PdfAnnotationEditing on PdfEditor {
       ..._endingExtent(startEnding, start, end, strokeWidth),
       ..._endingExtent(endEnding, end, start, strokeWidth),
     ];
-    final rect = _pointBounds(
-        [...points, ...endingPoints], strokeWidth + (dashed ? strokeWidth : 0));
+    final rect = _pointBounds([
+      ...points,
+      ...endingPoints,
+    ], strokeWidth + (dashed ? strokeWidth : 0));
     final gs = _alphaState(opacity);
-    final w = _lineContent(points,
-        strokeColor: strokeColor,
-        strokeWidth: strokeWidth,
-        dashPattern: dashPattern,
-        closed: false,
-        fillColor: null,
-        startEnding: startEnding,
-        endEnding: endEnding,
-        hasAlpha: gs != null);
+    final w = _lineContent(
+      points,
+      strokeColor: strokeColor,
+      strokeWidth: strokeWidth,
+      dashPattern: dashPattern,
+      closed: false,
+      fillColor: null,
+      startEnding: startEnding,
+      endEnding: endEnding,
+      hasAlpha: gs != null,
+    );
     final dict = _markupDict('Line', rect, strokeColor, contents, author)
       ..['L'] = CosArray([
         CosReal(start.$1),
@@ -915,8 +1033,11 @@ extension PdfAnnotationEditing on PdfEditor {
       ])
       ..['BS'] = _borderStyle(strokeWidth, dashPattern: dashPattern);
     _addAnnotation(
-        pageIndex, dict, _form(rect, w, resources: _resources(extGState: gs)),
-        name: name);
+      pageIndex,
+      dict,
+      _form(rect, w, resources: _resources(extGState: gs)),
+      name: name,
+    );
   }
 
   /// Adds a /PolyLine annotation through [vertices]. Per §12.5.6.7 a
@@ -942,19 +1063,25 @@ extension PdfAnnotationEditing on PdfEditor {
     final endingPoints = <(double, double)>[
       ..._endingExtent(startEnding, vertices.first, vertices[1], strokeWidth),
       ..._endingExtent(
-          endEnding, vertices.last, vertices[vertices.length - 2], strokeWidth),
+        endEnding,
+        vertices.last,
+        vertices[vertices.length - 2],
+        strokeWidth,
+      ),
     ];
     final rect = _pointBounds([...vertices, ...endingPoints], strokeWidth);
     final gs = _alphaState(opacity);
-    final w = _lineContent(vertices,
-        strokeColor: strokeColor,
-        strokeWidth: strokeWidth,
-        dashPattern: dashPattern,
-        closed: false,
-        fillColor: null,
-        startEnding: startEnding,
-        endEnding: endEnding,
-        hasAlpha: gs != null);
+    final w = _lineContent(
+      vertices,
+      strokeColor: strokeColor,
+      strokeWidth: strokeWidth,
+      dashPattern: dashPattern,
+      closed: false,
+      fillColor: null,
+      startEnding: startEnding,
+      endEnding: endEnding,
+      hasAlpha: gs != null,
+    );
     final dict = _markupDict('PolyLine', rect, strokeColor, contents, author)
       ..['Vertices'] = _pointArray(vertices)
       ..['LE'] = CosArray([
@@ -963,8 +1090,11 @@ extension PdfAnnotationEditing on PdfEditor {
       ])
       ..['BS'] = _borderStyle(strokeWidth, dashPattern: dashPattern);
     _addAnnotation(
-        pageIndex, dict, _form(rect, w, resources: _resources(extGState: gs)),
-        name: name);
+      pageIndex,
+      dict,
+      _form(rect, w, resources: _resources(extGState: gs)),
+      name: name,
+    );
   }
 
   /// Adds a /Polygon annotation through [vertices].
@@ -984,23 +1114,29 @@ extension PdfAnnotationEditing on PdfEditor {
     if (vertices.length < 3) {
       throw ArgumentError.value(vertices, 'vertices', 'must have 3+ points');
     }
-    final rect = _pointBounds(vertices,
-        cloudy ? _cloudPadding(strokeWidth) : _linePadding(strokeWidth));
+    final rect = _pointBounds(
+      vertices,
+      cloudy ? _cloudPadding(strokeWidth) : _linePadding(strokeWidth),
+    );
     final gs = _alphaState(opacity);
     final w = cloudy
-        ? _cloudPolygonContent(vertices,
+        ? _cloudPolygonContent(
+            vertices,
             strokeColor: strokeColor,
             strokeWidth: strokeWidth,
             dashPattern: dashPattern,
             fillColor: fillColor,
-            hasAlpha: gs != null)
-        : _lineContent(vertices,
+            hasAlpha: gs != null,
+          )
+        : _lineContent(
+            vertices,
             strokeColor: strokeColor,
             strokeWidth: strokeWidth,
             dashPattern: dashPattern,
             closed: true,
             fillColor: fillColor,
-            hasAlpha: gs != null);
+            hasAlpha: gs != null,
+          );
     final dict = _markupDict('Polygon', rect, strokeColor, contents, author)
       ..['Vertices'] = _pointArray(vertices)
       ..['BS'] = _borderStyle(strokeWidth, dashPattern: dashPattern);
@@ -1012,8 +1148,11 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     if (fillColor != null) dict['IC'] = _colorComponents(fillColor);
     _addAnnotation(
-        pageIndex, dict, _form(rect, w, resources: _resources(extGState: gs)),
-        name: name);
+      pageIndex,
+      dict,
+      _form(rect, w, resources: _resources(extGState: gs)),
+      name: name,
+    );
   }
 
   /// The document-default measurement scale, or null until
@@ -1081,6 +1220,7 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     page.dict['VP'] = CosArray([viewport, ...kept]);
     _updater.markChanged(page.dict);
+    _markVisual([pageIndex]);
     _defaultMeasure = measure;
     return measure;
   }
@@ -1126,8 +1266,10 @@ extension PdfAnnotationEditing on PdfEditor {
   }) {
     final m = measure ?? _defaultMeasure;
     if (m == null && kind != PdfMeasurementKind.count) {
-      throw StateError('no measurement scale set - call setMeasurementScale '
-          'or pass a measure');
+      throw StateError(
+        'no measurement scale set - call setMeasurementScale '
+        'or pass a measure',
+      );
     }
     final minPoints = switch (kind) {
       PdfMeasurementKind.count => 1,
@@ -1143,7 +1285,10 @@ extension PdfAnnotationEditing on PdfEditor {
     };
     if (points.length < minPoints) {
       throw ArgumentError.value(
-          points, 'points', 'needs $minPoints+ points for ${kind.name}');
+        points,
+        'points',
+        'needs $minPoints+ points for ${kind.name}',
+      );
     }
 
     final isPolygon = kind == PdfMeasurementKind.area ||
@@ -1163,23 +1308,27 @@ extension PdfAnnotationEditing on PdfEditor {
 
     final ContentWriter content;
     if (isCount) {
-      content = _countMarker(points.first,
-          radius: markerR,
-          strokeColor: strokeColor,
-          strokeWidth: strokeWidth,
-          hasAlpha: gs != null);
+      content = _countMarker(
+        points.first,
+        radius: markerR,
+        strokeColor: strokeColor,
+        strokeWidth: strokeWidth,
+        hasAlpha: gs != null,
+      );
     } else {
       final drawPoints =
           kind == PdfMeasurementKind.arc ? _arcPolyline(points) : points;
-      content = _lineContent(drawPoints,
-          strokeColor: strokeColor,
-          strokeWidth: strokeWidth,
-          dashPattern: dashPattern,
-          closed: isPolygon,
-          fillColor: isPolygon ? fillColor : null,
-          startEnding: isPolygon ? PdfLineEnding.none : startEnding,
-          endEnding: isPolygon ? PdfLineEnding.none : endEnding,
-          hasAlpha: gs != null);
+      content = _lineContent(
+        drawPoints,
+        strokeColor: strokeColor,
+        strokeWidth: strokeWidth,
+        dashPattern: dashPattern,
+        closed: isPolygon,
+        fillColor: isPolygon ? fillColor : null,
+        startEnding: isPolygon ? PdfLineEnding.none : startEnding,
+        endEnding: isPolygon ? PdfLineEnding.none : endEnding,
+        hasAlpha: gs != null,
+      );
       // a net-area cutout draws each hole as an inner outline.
       for (final hole in holes) {
         if (hole.length < 3) continue;
@@ -1196,14 +1345,25 @@ extension PdfAnnotationEditing on PdfEditor {
       }
     }
 
-    final (caption, anchor) =
-        _takeoffCaption(kind, points, m, depth: depth, holes: holes);
+    final (caption, anchor) = _takeoffCaption(
+      kind,
+      points,
+      m,
+      depth: depth,
+      holes: holes,
+    );
     final PdfRect captionBox;
     if (caption.isEmpty) {
       captionBox = PdfRect(anchor.$1, anchor.$2, anchor.$1, anchor.$2);
     } else {
-      captionBox = _drawMeasurementCaption(content, caption, anchor,
-          font: captionFont, size: captionSize, color: labelColor);
+      captionBox = _drawMeasurementCaption(
+        content,
+        caption,
+        anchor,
+        font: captionFont,
+        size: captionSize,
+        color: labelColor,
+      );
     }
 
     // the rect covers geometry (+ holes / the marker) and the caption box.
@@ -1248,16 +1408,23 @@ extension PdfAnnotationEditing on PdfEditor {
       ..['BS'] = _borderStyle(strokeWidth, dashPattern: dashPattern)
       ..['IT'] = CosName(intent)
       // the caption's font/size/color, so a restyle can redraw it (§12.7.2)
-      ..['DA'] = CosString.fromText('${rgb(labelColor)} rg '
-          '/${captionFont.resourceName} ${ContentWriter.fmt(captionSize)} Tf');
+      ..['DA'] = CosString.fromText(
+        '${rgb(labelColor)} rg '
+        '/${captionFont.resourceName} ${ContentWriter.fmt(captionSize)} Tf',
+      );
     if (m != null) dict['Measure'] = m.toCosDictionary();
     if (!classic || label != null) {
-      dict['Takeoff'] =
-          PdfTakeoffData(kind: kind, depth: depth, holes: holes, label: label)
-              .toCosDictionary();
+      dict['Takeoff'] = PdfTakeoffData(
+        kind: kind,
+        depth: depth,
+        holes: holes,
+        label: label,
+      ).toCosDictionary();
     }
-    final leArray =
-        CosArray([CosName(startEnding.pdfName), CosName(endEnding.pdfName)]);
+    final leArray = CosArray([
+      CosName(startEnding.pdfName),
+      CosName(endEnding.pdfName),
+    ]);
     if (isLine) {
       dict['L'] = CosArray([
         CosReal(points.first.$1),
@@ -1277,9 +1444,11 @@ extension PdfAnnotationEditing on PdfEditor {
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, content,
-          resources:
-              _resources(extGState: gs, font: _standardFont(captionFont))),
+      _form(
+        rect,
+        content,
+        resources: _resources(extGState: gs, font: _standardFont(captionFont)),
+      ),
       name: name,
     );
   }
@@ -1378,23 +1547,23 @@ extension PdfAnnotationEditing on PdfEditor {
         final dx = b.$1 - a.$1, dy = b.$2 - a.$2;
         return (
           m!.formatDistance(math.sqrt(dx * dx + dy * dy)),
-          ((a.$1 + b.$1) / 2, (a.$2 + b.$2) / 2)
+          ((a.$1 + b.$1) / 2, (a.$2 + b.$2) / 2),
         );
       case PdfMeasurementKind.slope:
         final a = points.first, b = points.last;
         return (
           angle(pdfSlopeDegrees(a, b)),
-          ((a.$1 + b.$1) / 2, (a.$2 + b.$2) / 2)
+          ((a.$1 + b.$1) / 2, (a.$2 + b.$2) / 2),
         );
       case PdfMeasurementKind.perimeter:
         return (
           m!.formatDistance(pdfPolylineLength(points)),
-          _centroid(points)
+          _centroid(points),
         );
       case PdfMeasurementKind.angle:
         return (
           angle(pdfAngleDegrees(points[1], points[0], points[2])),
-          points[1]
+          points[1],
         );
       case PdfMeasurementKind.arc:
         final metrics = pdfArcMetrics(points[0], points[1], points[2]);
@@ -1405,12 +1574,12 @@ extension PdfAnnotationEditing on PdfEditor {
       case PdfMeasurementKind.areaCutout:
         return (
           m!.formatArea(pdfNetPolygonArea(points, holes)),
-          _centroid(points)
+          _centroid(points),
         );
       case PdfMeasurementKind.volume:
         return (
           m!.formatVolume(pdfShoelaceArea(points), depth ?? 0),
-          _centroid(points)
+          _centroid(points),
         );
     }
   }
@@ -1441,12 +1610,18 @@ extension PdfAnnotationEditing on PdfEditor {
       ..beginText()
       ..font(font.resourceName, size)
       ..fillColor(color)
-      ..textAt(anchor.$1 - textWidth / 2,
-          anchor.$2 - size * 0.36) // rough cap-height centering
+      ..textAt(
+        anchor.$1 - textWidth / 2,
+        anchor.$2 - size * 0.36,
+      ) // rough cap-height centering
       ..showText(caption)
       ..endText();
     return PdfRect(
-        boxLeft, boxBottom, boxLeft + boxWidth, boxBottom + boxHeight);
+      boxLeft,
+      boxBottom,
+      boxLeft + boxWidth,
+      boxBottom + boxHeight,
+    );
   }
 
   /// Recovers a measurement caption's font, size, and color from the
@@ -1454,7 +1629,8 @@ extension PdfAnnotationEditing on PdfEditor {
   /// Helvetica 10 pt in the stroke color for measurements authored before
   /// /DA was stored.
   (PdfStandardFont, double, int) _measurementCaptionStyle(
-      PdfAnnotation annotation) {
+    PdfAnnotation annotation,
+  ) {
     final fallbackColor = annotation.color ?? 0x000000;
     final da = annotation.defaultAppearance;
     if (da == null) return (PdfStandardFont.helvetica, 10, fallbackColor);
@@ -1464,9 +1640,9 @@ extension PdfAnnotationEditing on PdfEditor {
         ? PdfStandardFont.helvetica
         : (PdfStandardFont.tryFromName(tf.group(1)!) ??
             PdfStandardFont.helvetica);
-    final rg = RegExp(r'([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+rg\b')
-        .allMatches(da)
-        .lastOrNull;
+    final rg = RegExp(
+      r'([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+rg\b',
+    ).allMatches(da).lastOrNull;
     var color = fallbackColor;
     if (rg != null) {
       int byte(String s) =>
@@ -1484,8 +1660,12 @@ extension PdfAnnotationEditing on PdfEditor {
   /// font resource. For a non-measurement line it draws nothing and
   /// returns [rect] with no font. Shared by every appearance regeneration
   /// (restyle, resize, reshape, ending change) so the label is never lost.
-  (PdfRect, CosDictionary?) _appendMeasurementCaption(PdfAnnotation annotation,
-      PdfRect rect, List<(double, double)> points, ContentWriter w) {
+  (PdfRect, CosDictionary?) _appendMeasurementCaption(
+    PdfAnnotation annotation,
+    PdfRect rect,
+    List<(double, double)> points,
+    ContentWriter w,
+  ) {
     final kind = annotation.measurementKind;
     if (kind == null) return (rect, null);
     final measure = annotation.measure;
@@ -1493,12 +1673,23 @@ extension PdfAnnotationEditing on PdfEditor {
       return (rect, null);
     }
     final takeoff = annotation.takeoff;
-    final (caption, anchor) = _takeoffCaption(kind, points, measure,
-        depth: takeoff?.depth, holes: takeoff?.holes ?? const []);
+    final (caption, anchor) = _takeoffCaption(
+      kind,
+      points,
+      measure,
+      depth: takeoff?.depth,
+      holes: takeoff?.holes ?? const [],
+    );
     if (caption.isEmpty) return (rect, null); // count marker: no label
     final (font, size, color) = _measurementCaptionStyle(annotation);
-    final box = _drawMeasurementCaption(w, caption, anchor,
-        font: font, size: size, color: color);
+    final box = _drawMeasurementCaption(
+      w,
+      caption,
+      anchor,
+      font: font,
+      size: size,
+      color: color,
+    );
     final full = PdfRect(
       math.min(rect.left, box.left),
       math.min(rect.bottom, box.bottom),
@@ -1542,8 +1733,10 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
     // When the text contains non-Latin-1 characters and the font is a
     // standard base-14 face (which only supports WinAnsi encoding), wrap it
     // in a PdfUnicodeFont - a lightweight Type0 Identity-H font that encodes
@@ -1558,16 +1751,19 @@ extension PdfAnnotationEditing on PdfEditor {
     // The font accumulates which glyphs the appearance shows (so an
     // embedded font's /W and /ToUnicode cover exactly them); start fresh.
     if (font is PdfEmbeddedFont) font.resetUsage();
-    final w = _freeTextContent(rect, text,
-        fontSize: fontSize,
-        font: effectiveFont,
-        textDirection: textDirection,
-        align: align,
-        color: color,
-        fillColor: fillColor,
-        borderColor: borderColor,
-        borderWidth: borderWidth,
-        pageRotation: effectivePageRotation);
+    final w = _freeTextContent(
+      rect,
+      text,
+      fontSize: fontSize,
+      font: effectiveFont,
+      textDirection: textDirection,
+      align: align,
+      color: color,
+      fillColor: fillColor,
+      borderColor: borderColor,
+      borderWidth: borderWidth,
+      pageRotation: effectivePageRotation,
+    );
 
     String rgb(int c) =>
         ContentWriter.rgbComponents(c).map(ContentWriter.fmt).join(' ');
@@ -1576,8 +1772,10 @@ extension PdfAnnotationEditing on PdfEditor {
         '/${effectiveFont.resourceName} ${ContentWriter.fmt(fontSize)} Tf';
     final dict = _markupDict('FreeText', rect, fillColor ?? color, text, author)
       ..['DA'] = CosString.fromText(da)
-      ..['Q'] = CosInteger(align?.quadding ??
-          (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0));
+      ..['Q'] = CosInteger(
+        align?.quadding ??
+            (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0),
+      );
     if (borderColor != null && borderWidth > 0) {
       dict['BS'] = _borderStyle(borderWidth);
     }
@@ -1624,8 +1822,10 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
     // Match addFreeText's non-Latin-1 handling: wrap a base-14 face in a
     // Type0 Identity-H font so the appearance can encode any code point.
     PdfUnicodeFont? unicodeFont;
@@ -1641,8 +1841,12 @@ extension PdfAnnotationEditing on PdfEditor {
     // later reshape reproduces the same arrow instead of guessing.
     final callout = _calloutLine(boxRect, target);
     // /Rect and BBox must cover the box, the leader, and the arrowhead.
-    final endingPoints =
-        _endingExtent(ending, callout.first, callout[1], strokeWidth);
+    final endingPoints = _endingExtent(
+      ending,
+      callout.first,
+      callout[1],
+      strokeWidth,
+    );
     final rect = _pointBounds([
       (boxRect.left, boxRect.bottom),
       (boxRect.right, boxRect.top),
@@ -1650,19 +1854,23 @@ extension PdfAnnotationEditing on PdfEditor {
       ...endingPoints,
     ], strokeWidth);
 
-    final w = _calloutContent(boxRect, callout, text,
-        fontSize: fontSize,
-        font: effectiveFont,
-        textDirection: textDirection,
-        align: align,
-        color: color,
-        fillColor: fillColor,
-        borderColor: strokeColor,
-        borderWidth: strokeWidth,
-        lineColor: strokeColor,
-        lineWidth: strokeWidth,
-        ending: ending,
-        pageRotation: effectivePageRotation);
+    final w = _calloutContent(
+      boxRect,
+      callout,
+      text,
+      fontSize: fontSize,
+      font: effectiveFont,
+      textDirection: textDirection,
+      align: align,
+      color: color,
+      fillColor: fillColor,
+      borderColor: strokeColor,
+      borderWidth: strokeWidth,
+      lineColor: strokeColor,
+      lineWidth: strokeWidth,
+      ending: ending,
+      pageRotation: effectivePageRotation,
+    );
 
     String rgb(int c) =>
         ContentWriter.rgbComponents(c).map(ContentWriter.fmt).join(' ');
@@ -1675,8 +1883,10 @@ extension PdfAnnotationEditing on PdfEditor {
       ..['LE'] = CosName(ending.pdfName)
       ..['RD'] = _rdArray(rect, boxRect)
       ..['BS'] = _borderStyle(strokeWidth)
-      ..['Q'] = CosInteger(align?.quadding ??
-          (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0));
+      ..['Q'] = CosInteger(
+        align?.quadding ??
+            (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0),
+      );
     final CosDictionary fontResource;
     if (unicodeFont != null) {
       fontResource = unicodeFont.buildResource(_updater.addObject);
@@ -1699,8 +1909,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// edge nearest the target) and `knee` gives the leader a short stub out of
   /// that edge (Acrobat/Bluebeam house style). Collapses to `[target, attach]`
   /// when a knee would be degenerate.
-  List<(double, double)> _calloutLine(PdfRect box, (double, double) target,
-      {(double, double)? attach}) {
+  List<(double, double)> _calloutLine(
+    PdfRect box,
+    (double, double) target, {
+    (double, double)? attach,
+  }) {
     final a = attach != null
         ? _clampToBoxPerimeter(box, attach)
         : _calloutAttach(box, target);
@@ -1727,7 +1940,10 @@ extension PdfAnnotationEditing on PdfEditor {
   /// A short stub out of the edge [a] sits on, toward [target] - null when the
   /// target is on the box's side of that edge (a straight leader reads better).
   (double, double)? _calloutKnee(
-      PdfRect box, (double, double) a, (double, double) target) {
+    PdfRect box,
+    (double, double) a,
+    (double, double) target,
+  ) {
     const stub = 14.0;
     const eps = 0.5;
     final (ax, ay) = a;
@@ -1788,25 +2004,30 @@ extension PdfAnnotationEditing on PdfEditor {
     required PdfLineEnding ending,
     int pageRotation = 0,
   }) {
-    final leader = _lineContent(callout,
-        strokeColor: lineColor,
-        strokeWidth: lineWidth,
-        dashPattern: null,
-        closed: false,
-        fillColor: null,
-        startEnding: ending,
-        endEnding: PdfLineEnding.none,
-        hasAlpha: false);
-    final box = _freeTextContent(boxRect, text,
-        fontSize: fontSize,
-        font: font,
-        textDirection: textDirection,
-        align: align,
-        color: color,
-        fillColor: fillColor,
-        borderColor: borderColor,
-        borderWidth: borderWidth,
-        pageRotation: pageRotation);
+    final leader = _lineContent(
+      callout,
+      strokeColor: lineColor,
+      strokeWidth: lineWidth,
+      dashPattern: null,
+      closed: false,
+      fillColor: null,
+      startEnding: ending,
+      endEnding: PdfLineEnding.none,
+      hasAlpha: false,
+    );
+    final box = _freeTextContent(
+      boxRect,
+      text,
+      fontSize: fontSize,
+      font: font,
+      textDirection: textDirection,
+      align: align,
+      color: color,
+      fillColor: fillColor,
+      borderColor: borderColor,
+      borderWidth: borderWidth,
+      pageRotation: pageRotation,
+    );
     return ContentWriter()
       ..append(leader)
       ..append(box);
@@ -1815,7 +2036,8 @@ extension PdfAnnotationEditing on PdfEditor {
   /// Reads a callout's leader line (/CL) and arrow (/LE) when [a] is a
   /// /FreeTextCallout, else null.
   ({List<(double, double)> line, PdfLineEnding ending})? _calloutInfo(
-      PdfAnnotation a) {
+    PdfAnnotation a,
+  ) {
     final line = a.calloutLine;
     if (line == null || line.length < 2) return null;
     final le = document.cos.resolve(a.dict['LE']);
@@ -1837,8 +2059,12 @@ extension PdfAnnotationEditing on PdfEditor {
       return 0;
     }
 
-    return PdfRect(rect.left + d(0), rect.bottom + d(3), rect.right - d(2),
-        rect.top - d(1));
+    return PdfRect(
+      rect.left + d(0),
+      rect.bottom + d(3),
+      rect.right - d(2),
+      rect.top - d(1),
+    );
   }
 
   /// Rebuilds a callout from a new text [box] and/or arrow [target] (page
@@ -1847,8 +2073,13 @@ extension PdfAnnotationEditing on PdfEditor {
   /// Preserves the text, style, and arrow ending; regenerates /CL, /RD,
   /// /Rect, and the appearance. Returns false when [annotation] is not a
   /// callout this editor can reproduce.
-  bool reshapeCallout(int pageIndex, PdfAnnotation annotation,
-      {PdfRect? box, (double, double)? target, (double, double)? attach}) {
+  bool reshapeCallout(
+    int pageIndex,
+    PdfAnnotation annotation, {
+    PdfRect? box,
+    (double, double)? target,
+    (double, double)? attach,
+  }) {
     final info = _calloutInfo(annotation);
     if (info == null) return false;
     final style = annotation.freeTextStyle;
@@ -1886,8 +2117,12 @@ extension PdfAnnotationEditing on PdfEditor {
     final callout = _calloutLine(newBox, newTarget, attach: newAttach);
     final leaderColor = style.borderColor ?? style.color;
     final leaderWidth = style.borderWidth > 0 ? style.borderWidth : 1.0;
-    final endingPoints =
-        _endingExtent(info.ending, callout.first, callout[1], leaderWidth);
+    final endingPoints = _endingExtent(
+      info.ending,
+      callout.first,
+      callout[1],
+      leaderWidth,
+    );
     final rect = _pointBounds([
       (newBox.left, newBox.bottom),
       (newBox.right, newBox.top),
@@ -1896,19 +2131,23 @@ extension PdfAnnotationEditing on PdfEditor {
     ], math.max(style.borderWidth, leaderWidth));
 
     final pageRotation = _appearancePageRotation(pageIndex, null);
-    final w = _calloutContent(newBox, callout, text,
-        fontSize: style.fontSize,
-        font: effectiveFont,
-        textDirection: PdfTextDirection.auto,
-        align: style.alignment,
-        color: style.color,
-        fillColor: style.fillColor,
-        borderColor: style.borderColor,
-        borderWidth: style.borderWidth,
-        lineColor: leaderColor,
-        lineWidth: leaderWidth,
-        ending: info.ending,
-        pageRotation: pageRotation);
+    final w = _calloutContent(
+      newBox,
+      callout,
+      text,
+      fontSize: style.fontSize,
+      font: effectiveFont,
+      textDirection: PdfTextDirection.auto,
+      align: style.alignment,
+      color: style.color,
+      fillColor: style.fillColor,
+      borderColor: style.borderColor,
+      borderWidth: style.borderWidth,
+      lineColor: leaderColor,
+      lineWidth: leaderWidth,
+      ending: info.ending,
+      pageRotation: pageRotation,
+    );
 
     final dict = annotation.dict;
     dict['Rect'] = _rectArray(rect);
@@ -1919,12 +2158,18 @@ extension PdfAnnotationEditing on PdfEditor {
         : _standardFont(stdFont);
     final form = annotation.normalAppearance;
     if (form != null) {
-      _replaceAppearance(dict, form, rect, w,
-          resources: _resources(font: fontResource));
+      _replaceAppearance(
+        dict,
+        form,
+        rect,
+        w,
+        resources: _resources(font: fontResource),
+      );
     } else {
       dict['AP'] = CosDictionary({
-        'N': _updater
-            .addObject(_form(rect, w, resources: _resources(font: fontResource)))
+        'N': _updater.addObject(
+          _form(rect, w, resources: _resources(font: fontResource)),
+        ),
       });
     }
     _markAnnotationChanged(pageIndex, dict);
@@ -1951,11 +2196,13 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
     final nonEmpty = [
       for (final run in runs)
-        if (run.text.isNotEmpty) run
+        if (run.text.isNotEmpty) run,
     ];
     if (nonEmpty.isEmpty) return;
     final text = nonEmpty.map((run) => run.text).join();
@@ -1964,23 +2211,28 @@ extension PdfAnnotationEditing on PdfEditor {
       for (final run in nonEmpty)
         if (run.font is PdfStandardFont &&
             run.text.codeUnits.any((c) => c > 0xFF))
-          PdfFreeTextRun(run.text,
-              font: PdfUnicodeFont(run.font as PdfStandardFont)..resetUsage(),
-              fontSize: run.fontSize,
-              color: run.color)
+          PdfFreeTextRun(
+            run.text,
+            font: PdfUnicodeFont(run.font as PdfStandardFont)..resetUsage(),
+            fontSize: run.fontSize,
+            color: run.color,
+          )
         else
           run,
     ];
     for (final font in _richFonts(effective)) {
       if (font is PdfEmbeddedFont) font.resetUsage();
     }
-    final w = _freeTextRichContent(rect, effective,
-        textDirection: textDirection,
-        align: align,
-        fillColor: fillColor,
-        borderColor: borderColor,
-        borderWidth: borderWidth,
-        pageRotation: effectivePageRotation);
+    final w = _freeTextRichContent(
+      rect,
+      effective,
+      textDirection: textDirection,
+      align: align,
+      fillColor: fillColor,
+      borderColor: borderColor,
+      borderWidth: borderWidth,
+      pageRotation: effectivePageRotation,
+    );
 
     final first = effective.first;
     String rgb(int c) =>
@@ -1997,16 +2249,21 @@ extension PdfAnnotationEditing on PdfEditor {
           // from the unwrapped runs so base-14 family names survive.
           ..['RC'] = CosString.fromText(_richContentXhtml(nonEmpty))
           ..['DS'] = CosString.fromText(_richSpanStyle(nonEmpty.first))
-          ..['Q'] = CosInteger(align?.quadding ??
-              (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0));
+          ..['Q'] = CosInteger(
+            align?.quadding ??
+                (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0),
+          );
     if (borderColor != null && borderWidth > 0) {
       dict['BS'] = _borderStyle(borderWidth);
     }
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, w,
-          resources: _resources(font: _richFontResources(effective))),
+      _form(
+        rect,
+        w,
+        resources: _resources(font: _richFontResources(effective)),
+      ),
       name: name,
     );
   }
@@ -2018,7 +2275,8 @@ extension PdfAnnotationEditing on PdfEditor {
   /// [parseFreeTextRichContent].
   static String _richContentXhtml(List<PdfFreeTextRun> runs) {
     final b = StringBuffer(
-        '<?xml version="1.0"?><body xmlns="http://www.w3.org/1999/xhtml"><p>');
+      '<?xml version="1.0"?><body xmlns="http://www.w3.org/1999/xhtml"><p>',
+    );
     for (final run in runs) {
       b
         ..write('<span style="')
@@ -2064,28 +2322,31 @@ extension PdfAnnotationEditing on PdfEditor {
     int fallbackColor = 0x000000,
   }) {
     final runs = <PdfFreeTextRun>[];
-    for (final span in RegExp(r'<span\b([^>]*)>(.*?)</span>', dotAll: true)
-        .allMatches(rc)) {
+    for (final span in RegExp(
+      r'<span\b([^>]*)>(.*?)</span>',
+      dotAll: true,
+    ).allMatches(rc)) {
       final attrs = span.group(1) ?? '';
       final style =
           RegExp(r'style\s*=\s*"([^"]*)"').firstMatch(attrs)?.group(1) ?? '';
       final text = _xmlUnescape(span.group(2) ?? '');
       if (text.isEmpty) continue;
-      runs.add(PdfFreeTextRun(
-        text,
-        font: _richSpanFont(style, fallbackFont),
-        fontSize: _richSpanSize(style) ?? fallbackSize,
-        color: _richSpanColor(style) ?? fallbackColor,
-      ));
+      runs.add(
+        PdfFreeTextRun(
+          text,
+          font: _richSpanFont(style, fallbackFont),
+          fontSize: _richSpanSize(style) ?? fallbackSize,
+          color: _richSpanColor(style) ?? fallbackColor,
+        ),
+      );
     }
     return runs;
   }
 
   static PdfStandardFont _richSpanFont(String style, PdfStandardFont fallback) {
-    final family = RegExp(r'font-family\s*:\s*([^;]+)')
-        .firstMatch(style)
-        ?.group(1)
-        ?.trim();
+    final family = RegExp(
+      r'font-family\s*:\s*([^;]+)',
+    ).firstMatch(style)?.group(1)?.trim();
     var font = family == null ? null : PdfStandardFont.tryFromName(family);
     if (RegExp(r'font-weight\s*:\s*(bold|[6-9]00)').hasMatch(style)) {
       font = (font ?? fallback).withBold(true);
@@ -2153,8 +2414,12 @@ extension PdfAnnotationEditing on PdfEditor {
       w
         ..strokeColor(borderColor)
         ..lineWidth(borderWidth)
-        ..rect(vr.left + borderWidth / 2, vr.bottom + borderWidth / 2,
-            vr.width - borderWidth, vr.height - borderWidth)
+        ..rect(
+          vr.left + borderWidth / 2,
+          vr.bottom + borderWidth / 2,
+          vr.width - borderWidth,
+          vr.height - borderWidth,
+        )
         ..stroke();
     }
     w
@@ -2228,8 +2493,12 @@ extension PdfAnnotationEditing on PdfEditor {
       w
         ..strokeColor(borderColor)
         ..lineWidth(borderWidth)
-        ..rect(vr.left + borderWidth / 2, vr.bottom + borderWidth / 2,
-            vr.width - borderWidth, vr.height - borderWidth)
+        ..rect(
+          vr.left + borderWidth / 2,
+          vr.bottom + borderWidth / 2,
+          vr.width - borderWidth,
+          vr.height - borderWidth,
+        )
         ..stroke();
     }
     final plain = runs.map((run) => run.text).join();
@@ -2250,11 +2519,14 @@ extension PdfAnnotationEditing on PdfEditor {
         continue;
       }
       final ascent = line.runs.fold<double>(
-          0,
-          (max, run) =>
-              math.max(max, run.style.fontSize * run.style.font.ascent / 1000));
+        0,
+        (max, run) =>
+            math.max(max, run.style.fontSize * run.style.font.ascent / 1000),
+      );
       final lineHeight = line.runs.fold<double>(
-          0, (max, run) => math.max(max, run.style.fontSize * 1.2));
+        0,
+        (max, run) => math.max(max, run.style.fontSize * 1.2),
+      );
       var x = _lineX(effectiveAlign, vr, line.width, pad);
       final y = top - ascent;
       final drawRuns = resolvedDirection == PdfTextDirection.rtl
@@ -2301,7 +2573,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// inside the padded visual rect [vr]. Centering cancels the padding, so
   /// a centered line is centered within the full width.
   static double _lineX(
-          PdfTextAlign align, PdfRect vr, double width, double pad) =>
+    PdfTextAlign align,
+    PdfRect vr,
+    double width,
+    double pad,
+  ) =>
       switch (align) {
         PdfTextAlign.left => vr.left + pad,
         PdfTextAlign.center => vr.left + (vr.width - width) / 2,
@@ -2335,7 +2611,10 @@ extension PdfAnnotationEditing on PdfEditor {
   /// visual rect appears upright after the renderer applies the page's
   /// display rotation.
   static void _orientedCounterRotation(
-      ContentWriter w, PdfRect pageRect, int pageRotation) {
+    ContentWriter w,
+    PdfRect pageRect,
+    int pageRotation,
+  ) {
     final cx = (pageRect.left + pageRect.right) / 2;
     final cy = (pageRect.bottom + pageRect.top) / 2;
     switch (pageRotation) {
@@ -2385,8 +2664,10 @@ extension PdfAnnotationEditing on PdfEditor {
     void addText(PdfFreeTextRun style, String text) {
       if (text.isEmpty) return;
       if (current.isNotEmpty && current.last.sameStyle(style)) {
-        current[current.length - 1] =
-            _RichTextPiece(current.last.text + text, current.last.style);
+        current[current.length - 1] = _RichTextPiece(
+          current.last.text + text,
+          current.last.style,
+        );
       } else {
         current.add(_RichTextPiece(text, style));
       }
@@ -2421,8 +2702,10 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
     const size = 20.0;
     final rect = PdfRect(x, y - size, x + size, y);
     _addAnnotation(
@@ -2430,7 +2713,9 @@ extension PdfAnnotationEditing on PdfEditor {
       _markupDict('Text', rect, color, contents, author)
         ..['Name'] = const CosName('Comment'),
       _form(
-          rect, _noteContent(rect, color, pageRotation: effectivePageRotation)),
+        rect,
+        _noteContent(rect, color, pageRotation: effectivePageRotation),
+      ),
       name: name,
     );
   }
@@ -2481,18 +2766,30 @@ extension PdfAnnotationEditing on PdfEditor {
     String? stampType,
     Iterable<String> stampTags = const [],
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
-    final (w, gs) = _stampContent(rect, text, color, opacity,
-        pageRotation: effectivePageRotation);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
+    final (w, gs) = _stampContent(
+      rect,
+      text,
+      color,
+      opacity,
+      pageRotation: effectivePageRotation,
+    );
     final dict = _markupDict('Stamp', rect, color, text, author);
     _applyStampMetadata(dict, type: stampType, tags: stampTags);
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, w,
-          resources: _resources(
-              extGState: gs, font: _helvetica(bold: true, name: 'HelvB'))),
+      _form(
+        rect,
+        w,
+        resources: _resources(
+          extGState: gs,
+          font: _helvetica(bold: true, name: 'HelvB'),
+        ),
+      ),
       name: name,
     );
   }
@@ -2501,8 +2798,12 @@ extension PdfAnnotationEditing on PdfEditor {
   /// rounded border, sized to fit [rect]. Shared by [addStamp] and
   /// [restyleAnnotation].
   (ContentWriter, CosDictionary?) _stampContent(
-      PdfRect rect, String text, int color, double opacity,
-      {int pageRotation = 0}) {
+    PdfRect rect,
+    String text,
+    int color,
+    double opacity, {
+    int pageRotation = 0,
+  }) {
     const borderWidth = 2.0;
     const pad = 6.0;
     final vr = _orientedVisualRect(rect, pageRotation);
@@ -2524,14 +2825,21 @@ extension PdfAnnotationEditing on PdfEditor {
     w
       ..strokeColor(color)
       ..lineWidth(borderWidth)
-      ..roundedRect(vr.left + borderWidth / 2, vr.bottom + borderWidth / 2,
-          vr.width - borderWidth, vr.height - borderWidth, 4)
+      ..roundedRect(
+        vr.left + borderWidth / 2,
+        vr.bottom + borderWidth / 2,
+        vr.width - borderWidth,
+        vr.height - borderWidth,
+        4,
+      )
       ..stroke()
       ..beginText()
       ..font('HelvB', fontSize)
       ..fillColor(color)
-      ..textAt(vr.left + (vr.width - textWidth) / 2,
-          vr.bottom + (vr.height - fontSize * 0.718) / 2)
+      ..textAt(
+        vr.left + (vr.width - textWidth) / 2,
+        vr.bottom + (vr.height - fontSize * 0.718) / 2,
+      )
       ..showText(text)
       ..endText();
     if (pageRotation != 0) w.restore();
@@ -2559,33 +2867,48 @@ extension PdfAnnotationEditing on PdfEditor {
     Map<String, String> templateValues = const {},
   }) {
     if (!template.isValid) return;
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
-    final appearance = _stampTemplateContent(rect, template, opacity,
-        pageRotation: effectivePageRotation, templateValues: templateValues);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
+    final appearance = _stampTemplateContent(
+      rect,
+      template,
+      opacity,
+      pageRotation: effectivePageRotation,
+      templateValues: templateValues,
+    );
     final dict = _markupDict(
-        'Stamp',
-        rect,
-        color,
-        contents == null
-            ? null
-            : pdfResolveStampTemplateText(contents, templateValues),
-        author);
+      'Stamp',
+      rect,
+      color,
+      contents == null
+          ? null
+          : pdfResolveStampTemplateText(contents, templateValues),
+      author,
+    );
     _applyStampMetadata(dict, type: stampType, tags: stampTags);
     _addAnnotation(
       pageIndex,
       dict,
-      _form(rect, appearance.writer,
-          resources: _resources(
-              extGState: appearance.extGState,
-              font: appearance.font,
-              xObject: appearance.xObject)),
+      _form(
+        rect,
+        appearance.writer,
+        resources: _resources(
+          extGState: appearance.extGState,
+          font: appearance.font,
+          xObject: appearance.xObject,
+        ),
+      ),
       name: name,
     );
   }
 
-  void _applyStampMetadata(CosDictionary dict,
-      {String? type, Iterable<String> tags = const []}) {
+  void _applyStampMetadata(
+    CosDictionary dict, {
+    String? type,
+    Iterable<String> tags = const [],
+  }) {
     final normalizedType = type?.trim();
     if (normalizedType != null && normalizedType.isNotEmpty) {
       dict['DartPdfStampType'] = CosString.fromText(normalizedType);
@@ -2595,8 +2918,9 @@ extension PdfAnnotationEditing on PdfEditor {
         if (tag.trim().isNotEmpty) tag.trim(),
     ];
     if (normalizedTags.isNotEmpty) {
-      dict['DartPdfStampTags'] =
-          CosArray([for (final tag in normalizedTags) CosString.fromText(tag)]);
+      dict['DartPdfStampTags'] = CosArray([
+        for (final tag in normalizedTags) CosString.fromText(tag),
+      ]);
     }
   }
 
@@ -2606,8 +2930,12 @@ extension PdfAnnotationEditing on PdfEditor {
     CosDictionary? font,
     CosDictionary? xObject,
   }) _stampTemplateContent(
-      PdfRect rect, PdfStampTemplate template, double opacity,
-      {int pageRotation = 0, Map<String, String> templateValues = const {}}) {
+    PdfRect rect,
+    PdfStampTemplate template,
+    double opacity, {
+    int pageRotation = 0,
+    Map<String, String> templateValues = const {},
+  }) {
     final resolvedTemplate = template.resolveText(templateValues);
     final vr = _orientedVisualRect(rect, pageRotation);
     final sx = vr.width / resolvedTemplate.width;
@@ -2637,25 +2965,37 @@ extension PdfAnnotationEditing on PdfEditor {
       final bottom = top - height;
       switch (c.type) {
         case PdfStampTemplateComponentType.rectangle:
-          _stampTemplateShape(w, c,
-              left: left,
-              bottom: bottom,
-              width: width,
-              height: height,
-              scale: math.min(sx, sy),
-              ellipse: false);
+          _stampTemplateShape(
+            w,
+            c,
+            left: left,
+            bottom: bottom,
+            width: width,
+            height: height,
+            scale: math.min(sx, sy),
+            ellipse: false,
+          );
         case PdfStampTemplateComponentType.ellipse:
-          _stampTemplateShape(w, c,
-              left: left,
-              bottom: bottom,
-              width: width,
-              height: height,
-              scale: math.min(sx, sy),
-              ellipse: true);
+          _stampTemplateShape(
+            w,
+            c,
+            left: left,
+            bottom: bottom,
+            width: width,
+            height: height,
+            scale: math.min(sx, sy),
+            ellipse: true,
+          );
         case PdfStampTemplateComponentType.text:
           ensureFont(c.font);
-          _stampTemplateText(w, c,
-              left: left, bottom: bottom, width: width, height: height);
+          _stampTemplateText(
+            w,
+            c,
+            left: left,
+            bottom: bottom,
+            width: width,
+            height: height,
+          );
         case PdfStampTemplateComponentType.image:
           final imageBytes = c.imageBytes;
           if (imageBytes == null) continue;
@@ -2666,21 +3006,27 @@ extension PdfAnnotationEditing on PdfEditor {
             continue;
           }
           final name = 'Img${imageIndex++}';
-          xObjects[name] = _updater
-              .addObject(image.toXObject((smask) => _updater.addObject(smask)));
-          _stampTemplateImage(w,
-              name: name,
-              left: left,
-              bottom: bottom,
-              width: width,
-              height: height);
+          xObjects[name] = _updater.addObject(
+            image.toXObject((smask) => _updater.addObject(smask)),
+          );
+          _stampTemplateImage(
+            w,
+            name: name,
+            left: left,
+            bottom: bottom,
+            width: width,
+            height: height,
+          );
         case PdfStampTemplateComponentType.signature:
-          _stampTemplateSignature(w, c,
-              left: left,
-              bottom: bottom,
-              width: width,
-              height: height,
-              scale: math.min(sx, sy));
+          _stampTemplateSignature(
+            w,
+            c,
+            left: left,
+            bottom: bottom,
+            width: width,
+            height: height,
+            scale: math.min(sx, sy),
+          );
       }
     }
 
@@ -2716,8 +3062,12 @@ extension PdfAnnotationEditing on PdfEditor {
       ..strokeColor(c.color)
       ..lineWidth(strokeWidth);
     if (ellipse) {
-      w.ellipse(x + shapeWidth / 2, y + shapeHeight / 2, shapeWidth / 2,
-          shapeHeight / 2);
+      w.ellipse(
+        x + shapeWidth / 2,
+        y + shapeHeight / 2,
+        shapeWidth / 2,
+        shapeHeight / 2,
+      );
     } else {
       w.roundedRect(x, y, shapeWidth, shapeHeight, c.radius * scale);
     }
@@ -2751,8 +3101,10 @@ extension PdfAnnotationEditing on PdfEditor {
       ..beginText()
       ..font(c.font.resourceName, fontSize)
       ..fillColor(c.color)
-      ..textAt(left + (width - textWidth) / 2,
-          bottom + (height - fontSize * c.font.ascent / 1000) / 2)
+      ..textAt(
+        left + (width - textWidth) / 2,
+        bottom + (height - fontSize * c.font.ascent / 1000) / 2,
+      )
       ..showText(text)
       ..endText();
   }
@@ -2788,9 +3140,7 @@ extension PdfAnnotationEditing on PdfEditor {
     final strokes = [
       for (final stroke in c.strokes)
         if (stroke.isNotEmpty)
-          [
-            for (final (x, y) in stroke) (left + x * width, top - y * height),
-          ],
+          [for (final (x, y) in stroke) (left + x * width, top - y * height)],
     ];
     if (strokes.isEmpty) return;
     final List<List<double>?> pressures = c.pressures.length == c.strokes.length
@@ -2841,8 +3191,9 @@ extension PdfAnnotationEditing on PdfEditor {
         final ((c1x, c1y), (c2x, c2y)) = control[j];
         final (xb, yb) = stroke[j + 1];
         w
-          ..lineWidth(pdfInkStrokeWidth(
-              strokeWidth, (pressure[j] + pressure[j + 1]) / 2))
+          ..lineWidth(
+            pdfInkStrokeWidth(strokeWidth, (pressure[j] + pressure[j + 1]) / 2),
+          )
           ..moveTo(xa, ya)
           ..curveTo(c1x, c1y, c2x, c2y, xb, yb)
           ..stroke();
@@ -2864,10 +3215,16 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
-    final (w, gs) = _checkMarkContent(rect, color, opacity,
-        pageRotation: effectivePageRotation);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
+    final (w, gs) = _checkMarkContent(
+      rect,
+      color,
+      opacity,
+      pageRotation: effectivePageRotation,
+    );
     _addAnnotation(
       pageIndex,
       _markupDict('Stamp', rect, color, null, author)
@@ -2880,8 +3237,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// The check-mark appearance: a tick stroked inside [rect], centered in
   /// its largest square so it stays proportional whatever the rect aspect.
   (ContentWriter, CosDictionary?) _checkMarkContent(
-      PdfRect rect, int color, double opacity,
-      {int pageRotation = 0}) {
+    PdfRect rect,
+    int color,
+    double opacity, {
+    int pageRotation = 0,
+  }) {
     final gs = _alphaState(opacity);
     final w = ContentWriter();
     if (gs != null) w.extGState('GS0');
@@ -2924,10 +3284,13 @@ extension PdfAnnotationEditing on PdfEditor {
     String? author,
     String? name,
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
-    final imageRef = _updater
-        .addObject(image.toXObject((smask) => _updater.addObject(smask)));
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
+    final imageRef = _updater.addObject(
+      image.toXObject((smask) => _updater.addObject(smask)),
+    );
     final w = ContentWriter();
     final gs = _alphaState(opacity);
     if (gs != null) w.extGState('GS0');
@@ -2948,9 +3311,14 @@ extension PdfAnnotationEditing on PdfEditor {
     _addAnnotation(
       pageIndex,
       _markupDict('Stamp', rect, 0xC03030, null, author),
-      _form(rect, w,
-          resources: _resources(
-              extGState: gs, xObject: CosDictionary({'Img0': imageRef}))),
+      _form(
+        rect,
+        w,
+        resources: _resources(
+          extGState: gs,
+          xObject: CosDictionary({'Img0': imageRef}),
+        ),
+      ),
       name: name,
     );
   }
@@ -2975,29 +3343,41 @@ extension PdfAnnotationEditing on PdfEditor {
       if (popup is CosDictionary) targets.add(popup);
     }
     if (targets.isEmpty) return;
-    _PdfPageAnnotationList(this, pageIndex).removeWhere((_, resolved) =>
-        resolved is CosDictionary && targets.contains(resolved));
+    final changed = _PdfPageAnnotationList(this, pageIndex).removeWhere(
+      (_, resolved) => resolved is CosDictionary && targets.contains(resolved),
+    );
+    if (changed) _markAnnotations([pageIndex]);
   }
 
   /// Moves [annotations] to the end of the page's /Annots array,
   /// preserving their relative order. Later entries paint on top
   /// (§12.5.2's painter's model), so this brings them to the front.
   void bringAnnotationsToFront(
-          int pageIndex, Iterable<PdfAnnotation> annotations) =>
+    int pageIndex,
+    Iterable<PdfAnnotation> annotations,
+  ) =>
       _reorderAnnotations(pageIndex, annotations, toFront: true);
 
   /// Moves [annotations] to the start of the page's /Annots array,
   /// preserving their relative order - behind everything else.
   void sendAnnotationsToBack(
-          int pageIndex, Iterable<PdfAnnotation> annotations) =>
+    int pageIndex,
+    Iterable<PdfAnnotation> annotations,
+  ) =>
       _reorderAnnotations(pageIndex, annotations, toFront: false);
 
-  void _reorderAnnotations(int pageIndex, Iterable<PdfAnnotation> annotations,
-      {required bool toFront}) {
+  void _reorderAnnotations(
+    int pageIndex,
+    Iterable<PdfAnnotation> annotations, {
+    required bool toFront,
+  }) {
     final targets = Set<CosDictionary>.identity()
       ..addAll([for (final annotation in annotations) annotation.dict]);
-    _PdfPageAnnotationList(this, pageIndex)
-        .reorderResolvedDictionaries(targets, toFront: toFront);
+    final changed = _PdfPageAnnotationList(
+      this,
+      pageIndex,
+    ).reorderResolvedDictionaries(targets, toFront: toFront);
+    if (changed) _markAnnotations([pageIndex]);
   }
 
   /// Translates [annotation] by ([dx], [dy]) in page space.
@@ -3006,15 +3386,16 @@ extension PdfAnnotationEditing on PdfEditor {
   /// (/QuadPoints, /InkList, /L, /Vertices, /CL). The appearance stream
   /// needs no rewrite: viewers map its BBox onto the new /Rect (§12.5.5).
   void moveAnnotation(
-      int pageIndex, PdfAnnotation annotation, double dx, double dy) {
+    int pageIndex,
+    PdfAnnotation annotation,
+    double dx,
+    double dy,
+  ) {
     final dict = annotation.dict;
     final rect = annotation.rect;
-    dict['Rect'] = _rectArray(PdfRect(
-      rect.left + dx,
-      rect.bottom + dy,
-      rect.right + dx,
-      rect.top + dy,
-    ));
+    dict['Rect'] = _rectArray(
+      PdfRect(rect.left + dx, rect.bottom + dy, rect.right + dx, rect.top + dy),
+    );
     for (final key in const ['QuadPoints', 'L', 'Vertices', 'CL']) {
       final shifted = _shiftPoints(dict[key], dx, dy);
       if (shifted != null) dict[key] = shifted;
@@ -3032,7 +3413,10 @@ extension PdfAnnotationEditing on PdfEditor {
   /// and regenerates its appearance. Existing color, width, dash, fill,
   /// opacity, and line-ending style are preserved.
   void reshapeLineAnnotation(
-      int pageIndex, PdfAnnotation annotation, List<(double, double)> points) {
+    int pageIndex,
+    PdfAnnotation annotation,
+    List<(double, double)> points,
+  ) {
     final subtype = annotation.subtype;
     if (subtype == 'Line' && points.length != 2) {
       throw ArgumentError.value(points, 'points', 'Line needs 2 points');
@@ -3058,20 +3442,29 @@ extension PdfAnnotationEditing on PdfEditor {
         : <(double, double)>[
             ..._endingExtent(endings.$1, points.first, points[1], width),
             ..._endingExtent(
-                endings.$2, points.last, points[points.length - 2], width),
+              endings.$2,
+              points.last,
+              points[points.length - 2],
+              width,
+            ),
           ];
-    final rect = _pointBounds([...points, ...endingPoints],
-        cloudy ? _cloudPadding(width) : _linePadding(width, dashed: dashed));
+    final rect = _pointBounds([
+      ...points,
+      ...endingPoints,
+    ], cloudy ? _cloudPadding(width) : _linePadding(width, dashed: dashed));
     final form = annotation.normalAppearance;
     final gs = _alphaState(form == null ? 1 : _appearanceOpacity(form));
     final w = cloudy
-        ? _cloudPolygonContent(points,
+        ? _cloudPolygonContent(
+            points,
             strokeColor: stroke,
             strokeWidth: width,
             dashPattern: annotation.borderDash,
             fillColor: fill,
-            hasAlpha: gs != null)
-        : _lineContent(points,
+            hasAlpha: gs != null,
+          )
+        : _lineContent(
+            points,
             strokeColor: stroke,
             strokeWidth: width,
             dashPattern: annotation.borderDash,
@@ -3079,7 +3472,8 @@ extension PdfAnnotationEditing on PdfEditor {
             fillColor: fill,
             startEnding: endings.$1,
             endEnding: endings.$2,
-            hasAlpha: gs != null);
+            hasAlpha: gs != null,
+          );
     final dict = annotation.dict;
     dict['Rect'] = _rectArray(rect);
     if (subtype == 'Line') {
@@ -3095,12 +3489,22 @@ extension PdfAnnotationEditing on PdfEditor {
     // a measurement's caption rides along, expanding /Rect to fit it
     final (bbox, font) = _appendMeasurementCaption(annotation, rect, points, w);
     if (form != null) {
-      _replaceAppearance(dict, form, bbox, w,
-          resources: _resources(extGState: gs, font: font));
+      _replaceAppearance(
+        dict,
+        form,
+        bbox,
+        w,
+        resources: _resources(extGState: gs, font: font),
+      );
     } else {
       dict['AP'] = CosDictionary({
         'N': _updater.addObject(
-            _form(bbox, w, resources: _resources(extGState: gs, font: font))),
+          _form(
+            bbox,
+            w,
+            resources: _resources(extGState: gs, font: font),
+          ),
+        ),
       });
     }
     _markAnnotationChanged(pageIndex, dict);
@@ -3140,7 +3544,10 @@ extension PdfAnnotationEditing on PdfEditor {
     // re-wrap: the dict's /LE just changed under the caller's instance, and
     // reshape reads the endings back through a fresh parse
     reshapeLineAnnotation(
-        pageIndex, PdfAnnotation.fromDict(document, annotation.dict), points);
+      pageIndex,
+      PdfAnnotation.fromDict(document, annotation.dict),
+      points,
+    );
     return true;
   }
 
@@ -3176,14 +3583,20 @@ extension PdfAnnotationEditing on PdfEditor {
       if (vertices == null || vertices.length < 2) return false;
       points = vertices;
     }
-    final rgb =
-        ContentWriter.rgbComponents(color).map(ContentWriter.fmt).join(' ');
-    annotation.dict['DA'] = CosString.fromText('$rgb rg '
-        '/${newFont.resourceName} ${ContentWriter.fmt(newSize)} Tf');
+    final rgb = ContentWriter.rgbComponents(
+      color,
+    ).map(ContentWriter.fmt).join(' ');
+    annotation.dict['DA'] = CosString.fromText(
+      '$rgb rg '
+      '/${newFont.resourceName} ${ContentWriter.fmt(newSize)} Tf',
+    );
     // re-wrap: the dict's /DA just changed under the caller's instance, and
     // reshape recovers the caption style back through a fresh parse
     reshapeLineAnnotation(
-        pageIndex, PdfAnnotation.fromDict(document, annotation.dict), points);
+      pageIndex,
+      PdfAnnotation.fromDict(document, annotation.dict),
+      points,
+    );
     return true;
   }
 
@@ -3195,21 +3608,27 @@ extension PdfAnnotationEditing on PdfEditor {
   /// painted is the controller's text-edit path. An empty string removes
   /// the entry.
   void setAnnotationContents(
-      int pageIndex, PdfAnnotation annotation, String contents) {
+    int pageIndex,
+    PdfAnnotation annotation,
+    String contents,
+  ) {
     final dict = annotation.dict;
     if (contents.isEmpty) {
       dict.entries.remove('Contents');
     } else {
       dict['Contents'] = CosString.fromText(contents);
     }
-    _markAnnotationChanged(pageIndex, dict);
+    _markAnnotationChanged(pageIndex, dict, visual: false);
   }
 
   /// Sets [annotation]'s author (/T, §12.5.6.2) in place; null or empty
   /// removes it. Refused for form widgets, where /T is the field's
   /// partial name, not an author.
   void setAnnotationAuthor(
-      int pageIndex, PdfAnnotation annotation, String? author) {
+    int pageIndex,
+    PdfAnnotation annotation,
+    String? author,
+  ) {
     if (annotation.subtype == 'Widget') {
       throw ArgumentError('on widgets /T is the field name, not an author');
     }
@@ -3219,21 +3638,24 @@ extension PdfAnnotationEditing on PdfEditor {
     } else {
       dict['T'] = CosString.fromText(author);
     }
-    _markAnnotationChanged(pageIndex, dict);
+    _markAnnotationChanged(pageIndex, dict, visual: false);
   }
 
   /// Sets [annotation]'s /NM unique name in place; null or empty removes
   /// it. The name is sync identity ([PdfAnnotation.name]) - rewrites that
   /// remove + re-add an annotation use this to carry it across.
   void setAnnotationName(
-      int pageIndex, PdfAnnotation annotation, String? name) {
+    int pageIndex,
+    PdfAnnotation annotation,
+    String? name,
+  ) {
     final dict = annotation.dict;
     if (name == null || name.isEmpty) {
       dict.entries.remove('NM');
     } else {
       dict['NM'] = CosString.fromText(name);
     }
-    _markAnnotationChanged(pageIndex, dict);
+    _markAnnotationChanged(pageIndex, dict, visual: false);
   }
 
   /// Sets [annotation]'s /F flag word (§12.5.3) in place - the way to
@@ -3291,10 +3713,18 @@ extension PdfAnnotationEditing on PdfEditor {
   /// untouched) and the point arrays reflect about the /Rect center to
   /// match; regenerated appearances (shapes, free text, lines) ignore the
   /// flip - a mirrored rectangle or readable-text box looks the same.
-  void resizeAnnotation(int pageIndex, PdfAnnotation annotation, PdfRect to,
-      {bool flipX = false, bool flipY = false, int? pageRotation}) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
+  void resizeAnnotation(
+    int pageIndex,
+    PdfAnnotation annotation,
+    PdfRect to, {
+    bool flipX = false,
+    bool flipY = false,
+    int? pageRotation,
+  }) {
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
     final from = annotation.rect;
     if (from.width <= 0 ||
         from.height <= 0 ||
@@ -3302,8 +3732,11 @@ extension PdfAnnotationEditing on PdfEditor {
         to.height <= 0) {
       throw ArgumentError('resizeAnnotation needs non-degenerate rects');
     }
-    final regenerated = _regenerateResizedAppearance(annotation, to,
-        pageRotation: effectivePageRotation);
+    final regenerated = _regenerateResizedAppearance(
+      annotation,
+      to,
+      pageRotation: effectivePageRotation,
+    );
     if (!regenerated && (flipX || flipY)) {
       final form = annotation.normalAppearance;
       if (form != null) _flipFormArtwork(form, flipX: flipX, flipY: flipY);
@@ -3340,8 +3773,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// about the BBox center into its /Matrix. The reflection maps the BBox
   /// onto itself, so a conforming viewer's §12.5.5 BBox→/Rect fit lands
   /// exactly where it did - only the interior is flipped.
-  void _flipFormArtwork(CosStream form,
-      {required bool flipX, required bool flipY}) {
+  void _flipFormArtwork(
+    CosStream form, {
+    required bool flipX,
+    required bool flipY,
+  }) {
     final bbox = pdfRectFrom(document.cos, form.dictionary['BBox']);
     if (bbox == null) return;
     final cx = (bbox.left + bbox.right) / 2;
@@ -3372,7 +3808,10 @@ extension PdfAnnotationEditing on PdfEditor {
   /// the rect (/QuadPoints, /InkList, /L, /Vertices, /CL) rotate too, so
   /// viewers that regenerate appearances stay consistent.
   void rotateAnnotation(
-      int pageIndex, PdfAnnotation annotation, double degrees) {
+    int pageIndex,
+    PdfAnnotation annotation,
+    double degrees,
+  ) {
     final form = annotation.normalAppearance;
     if (form == null) {
       throw StateError('rotateAnnotation needs an appearance stream');
@@ -3448,15 +3887,28 @@ extension PdfAnnotationEditing on PdfEditor {
   /// path the mirror folds into the local scale (a negative factor), so
   /// the /Rect and point arrays stay consistent with the appearance.
   void resizeAnnotationLocal(
-      int pageIndex, PdfAnnotation annotation, PdfRect localTo,
-      {bool flipX = false, bool flipY = false, int? pageRotation}) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
+    int pageIndex,
+    PdfAnnotation annotation,
+    PdfRect localTo, {
+    bool flipX = false,
+    bool flipY = false,
+    int? pageRotation,
+  }) {
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
     final quad = annotation.appearanceQuad;
     final theta = quad == null ? 0.0 : _quadRotation(quad);
     if (theta == 0) {
-      resizeAnnotation(pageIndex, annotation, localTo,
-          flipX: flipX, flipY: flipY, pageRotation: effectivePageRotation);
+      resizeAnnotation(
+        pageIndex,
+        annotation,
+        localTo,
+        flipX: flipX,
+        flipY: flipY,
+        pageRotation: effectivePageRotation,
+      );
       return;
     }
     if (localTo.width <= 0 || localTo.height <= 0) {
@@ -3468,27 +3920,39 @@ extension PdfAnnotationEditing on PdfEditor {
     final (urx, ury) = quad[2];
     final (ulx, uly) = quad[3];
     final cx = (llx + urx) / 2, cy = (lly + ury) / 2;
-    final fromW =
-        math.sqrt((lrx - llx) * (lrx - llx) + (lry - lly) * (lry - lly));
-    final fromH =
-        math.sqrt((ulx - llx) * (ulx - llx) + (uly - lly) * (uly - lly));
+    final fromW = math.sqrt(
+      (lrx - llx) * (lrx - llx) + (lry - lly) * (lry - lly),
+    );
+    final fromH = math.sqrt(
+      (ulx - llx) * (ulx - llx) + (uly - lly) * (uly - lly),
+    );
     if (fromW < 1e-9 || fromH < 1e-9) {
-      resizeAnnotation(pageIndex, annotation, localTo,
-          flipX: flipX, flipY: flipY, pageRotation: effectivePageRotation);
+      resizeAnnotation(
+        pageIndex,
+        annotation,
+        localTo,
+        flipX: flipX,
+        flipY: flipY,
+        pageRotation: effectivePageRotation,
+      );
       return;
     }
 
-    if (_regenerateResizedAppearance(annotation, localTo,
-        pageRotation: effectivePageRotation)) {
+    if (_regenerateResizedAppearance(
+      annotation,
+      localTo,
+      pageRotation: effectivePageRotation,
+    )) {
       // a fresh, unrotated appearance at the local box - re-applying the
       // resting angle is then plain rotation (which also sets /Rect).
       // PdfAnnotation parses /Rect once, so rotate a re-wrapped view of
       // the dict instead of the stale [annotation]
       annotation.dict['Rect'] = _rectArray(localTo);
       rotateAnnotation(
-          pageIndex,
-          PdfAnnotation.fromDict(document, annotation.dict),
-          theta * 180 / math.pi);
+        pageIndex,
+        PdfAnnotation.fromDict(document, annotation.dict),
+        theta * 180 / math.pi,
+      );
       return;
     }
 
@@ -3497,8 +3961,14 @@ extension PdfAnnotationEditing on PdfEditor {
     if (form == null || baked == null) {
       // nothing can be rotated without a matrix-carrying appearance;
       // degrade to a page-space resize of the bounds
-      resizeAnnotation(pageIndex, annotation, localTo,
-          flipX: flipX, flipY: flipY, pageRotation: effectivePageRotation);
+      resizeAnnotation(
+        pageIndex,
+        annotation,
+        localTo,
+        flipX: flipX,
+        flipY: flipY,
+        pageRotation: effectivePageRotation,
+      );
       return;
     }
     final dict = annotation.dict;
@@ -3580,10 +4050,22 @@ extension PdfAnnotationEditing on PdfEditor {
         final stroke = width > 0 ? style.color : null;
         final fill = style.fillColor;
         final gs = _alphaState(opacity ?? _appearanceOpacity(form));
-        final w = _shapeContent(annotation.subtype, to, stroke, width, fill,
-            dashPattern: annotation.borderDash, hasAlpha: gs != null);
-        _replaceAppearance(dict, form, to, w,
-            resources: _resources(extGState: gs));
+        final w = _shapeContent(
+          annotation.subtype,
+          to,
+          stroke,
+          width,
+          fill,
+          dashPattern: annotation.borderDash,
+          hasAlpha: gs != null,
+        );
+        _replaceAppearance(
+          dict,
+          form,
+          to,
+          w,
+          resources: _resources(extGState: gs),
+        );
         return true;
       case 'FreeText':
         final style = behavior.style.freeText!;
@@ -3617,37 +4099,49 @@ extension PdfAnnotationEditing on PdfEditor {
             to.bottom + (oldBox.top - from.bottom) * sy,
           );
           dict['RD'] = _rdArray(to, box);
-          w = _calloutContent(box, line, text,
-              fontSize: style.fontSize,
-              font: effectiveFont,
-              textDirection: PdfTextDirection.auto,
-              align: style.alignment,
-              color: style.color,
-              fillColor: style.fillColor,
-              borderColor: style.borderColor,
-              borderWidth: style.borderWidth,
-              lineColor: style.borderColor ?? style.color,
-              lineWidth: style.borderWidth > 0 ? style.borderWidth : 1,
-              ending: callout.ending,
-              pageRotation: pageRotation);
+          w = _calloutContent(
+            box,
+            line,
+            text,
+            fontSize: style.fontSize,
+            font: effectiveFont,
+            textDirection: PdfTextDirection.auto,
+            align: style.alignment,
+            color: style.color,
+            fillColor: style.fillColor,
+            borderColor: style.borderColor,
+            borderWidth: style.borderWidth,
+            lineColor: style.borderColor ?? style.color,
+            lineWidth: style.borderWidth > 0 ? style.borderWidth : 1,
+            ending: callout.ending,
+            pageRotation: pageRotation,
+          );
         } else {
-          w = _freeTextContent(to, text,
-              fontSize: style.fontSize,
-              font: effectiveFont,
-              // direction follows the text; /Q carries the explicit alignment
-              textDirection: PdfTextDirection.auto,
-              align: style.alignment,
-              color: style.color,
-              fillColor: style.fillColor,
-              borderColor: style.borderColor,
-              borderWidth: style.borderWidth,
-              pageRotation: pageRotation);
+          w = _freeTextContent(
+            to,
+            text,
+            fontSize: style.fontSize,
+            font: effectiveFont,
+            // direction follows the text; /Q carries the explicit alignment
+            textDirection: PdfTextDirection.auto,
+            align: style.alignment,
+            color: style.color,
+            fillColor: style.fillColor,
+            borderColor: style.borderColor,
+            borderWidth: style.borderWidth,
+            pageRotation: pageRotation,
+          );
         }
         final CosDictionary fontResource = unicodeFont != null
             ? unicodeFont.buildResource(_updater.addObject)
             : _standardFont(stdFont);
-        _replaceAppearance(dict, form, to, w,
-            resources: _resources(font: fontResource));
+        _replaceAppearance(
+          dict,
+          form,
+          to,
+          w,
+          resources: _resources(font: fontResource),
+        );
         return true;
       case 'Line':
         final line = annotation.line;
@@ -3659,8 +4153,12 @@ extension PdfAnnotationEditing on PdfEditor {
               to.left + (p.$1 - from.left) * sx,
               to.bottom + (p.$2 - from.bottom) * sy,
             );
-        return _regenerateLineLikeAppearance(annotation, to,
-            points: [map(line.$1), map(line.$2)], opacity: opacity);
+        return _regenerateLineLikeAppearance(
+          annotation,
+          to,
+          points: [map(line.$1), map(line.$2)],
+          opacity: opacity,
+        );
       case 'PolyLine' || 'Polygon':
         final vertices = annotation.vertices;
         if (vertices == null || vertices.isEmpty) return false;
@@ -3669,17 +4167,28 @@ extension PdfAnnotationEditing on PdfEditor {
         final sy = to.height / from.height;
         final mapped = [
           for (final (x, y) in vertices)
-            (to.left + (x - from.left) * sx, to.bottom + (y - from.bottom) * sy)
+            (
+              to.left + (x - from.left) * sx,
+              to.bottom + (y - from.bottom) * sy,
+            ),
         ];
-        return _regenerateLineLikeAppearance(annotation, to,
-            points: mapped, opacity: opacity);
+        return _regenerateLineLikeAppearance(
+          annotation,
+          to,
+          points: mapped,
+          opacity: opacity,
+        );
       default:
         return false;
     }
   }
 
-  bool _regenerateLineLikeAppearance(PdfAnnotation annotation, PdfRect rect,
-      {required List<(double, double)> points, double? opacity}) {
+  bool _regenerateLineLikeAppearance(
+    PdfAnnotation annotation,
+    PdfRect rect, {
+    required List<(double, double)> points,
+    double? opacity,
+  }) {
     final form = annotation.normalAppearance;
     if (form == null) return false;
     final width = annotation.borderWidth ?? 1;
@@ -3690,13 +4199,16 @@ extension PdfAnnotationEditing on PdfEditor {
     final endings = _lineEndings(annotation);
     final gs = _alphaState(opacity ?? _appearanceOpacity(form));
     final w = annotation.subtype == 'Polygon' && annotation.hasCloudyBorder
-        ? _cloudPolygonContent(points,
+        ? _cloudPolygonContent(
+            points,
             strokeColor: stroke,
             strokeWidth: width,
             dashPattern: annotation.borderDash,
             fillColor: fill,
-            hasAlpha: gs != null)
-        : _lineContent(points,
+            hasAlpha: gs != null,
+          )
+        : _lineContent(
+            points,
             strokeColor: stroke,
             strokeWidth: width,
             dashPattern: annotation.borderDash,
@@ -3704,14 +4216,20 @@ extension PdfAnnotationEditing on PdfEditor {
             fillColor: fill,
             startEnding: endings.$1,
             endEnding: endings.$2,
-            hasAlpha: gs != null);
+            hasAlpha: gs != null,
+          );
     // A measurement carries a caption drawn over the line; regenerate it
     // too (recovering its font/size/color from /DA) so a width or style
     // change never drops the label, widening the BBox/Rect to keep it
     // unclipped.
     final (bbox, font) = _appendMeasurementCaption(annotation, rect, points, w);
-    _replaceAppearance(annotation.dict, form, bbox, w,
-        resources: _resources(extGState: gs, font: font));
+    _replaceAppearance(
+      annotation.dict,
+      form,
+      bbox,
+      w,
+      resources: _resources(extGState: gs, font: font),
+    );
     return true;
   }
 
@@ -3755,8 +4273,10 @@ extension PdfAnnotationEditing on PdfEditor {
     (List<double>?,)? dashPattern,
     int? pageRotation,
   }) {
-    final effectivePageRotation =
-        _appearancePageRotation(pageIndex, pageRotation);
+    final effectivePageRotation = _appearancePageRotation(
+      pageIndex,
+      pageRotation,
+    );
     if (color == null &&
         fillColor == null &&
         strokeWidth == null &&
@@ -3784,12 +4304,18 @@ extension PdfAnnotationEditing on PdfEditor {
         dict['C'] = _colorComponents(newColor);
         dict['BS'] = _borderStyle(newWidth);
         if (form != null) {
-          _replaceAppearance(dict, form, rect, w,
-              resources: _resources(extGState: gs));
+          _replaceAppearance(
+            dict,
+            form,
+            rect,
+            w,
+            resources: _resources(extGState: gs),
+          );
         } else {
           dict['AP'] = CosDictionary({
             'N': _updater.addObject(
-                _form(rect, w, resources: _resources(extGState: gs))),
+              _form(rect, w, resources: _resources(extGState: gs)),
+            ),
           });
         }
         _markAnnotationChanged(pageIndex, dict);
@@ -3800,17 +4326,27 @@ extension PdfAnnotationEditing on PdfEditor {
         final newColor = color ?? currentStyle.color ?? 0xFFD100;
         final newOpacity = opacity ?? currentStyle.opacity;
         final rect = _boundsOf(quads);
-        final (w, gs) =
-            _markupContent(annotation.subtype, quads, newColor, newOpacity);
+        final (w, gs) = _markupContent(
+          annotation.subtype,
+          quads,
+          newColor,
+          newOpacity,
+        );
         dict['C'] = _colorComponents(newColor);
         dict['Rect'] = _rectArray(rect);
         if (form != null) {
-          _replaceAppearance(dict, form, rect, w,
-              resources: _resources(extGState: gs));
+          _replaceAppearance(
+            dict,
+            form,
+            rect,
+            w,
+            resources: _resources(extGState: gs),
+          );
         } else {
           dict['AP'] = CosDictionary({
             'N': _updater.addObject(
-                _form(rect, w, resources: _resources(extGState: gs))),
+              _form(rect, w, resources: _resources(extGState: gs)),
+            ),
           });
         }
         _markAnnotationChanged(pageIndex, dict);
@@ -3858,14 +4394,19 @@ extension PdfAnnotationEditing on PdfEditor {
             : null;
         String rgb(int c) =>
             ContentWriter.rgbComponents(c).map(ContentWriter.fmt).join(' ');
-        dict['DA'] = CosString.fromText('${rgb(textColor)} rg '
-            '${border != null ? '${rgb(border)} RG ' : ''}'
-            '/${font.resourceName} ${ContentWriter.fmt(style.fontSize)} Tf');
+        dict['DA'] = CosString.fromText(
+          '${rgb(textColor)} rg '
+          '${border != null ? '${rgb(border)} RG ' : ''}'
+          '/${font.resourceName} ${ContentWriter.fmt(style.fontSize)} Tf',
+        );
         // /C is the background - or mirrors the text color when there is
         // none, the legacy form freeTextStyle reads back as "no fill"
         dict['C'] = _colorComponents(fill ?? textColor);
-        return _restyleRegenerate(pageIndex, dict,
-            pageRotation: effectivePageRotation);
+        return _restyleRegenerate(
+          pageIndex,
+          dict,
+          pageRotation: effectivePageRotation,
+        );
       case 'Text':
         dict['C'] = _colorComponents(color ?? currentStyle.color ?? 0xFFD100);
         return _restyleRegenerate(pageIndex, dict,
@@ -3883,16 +4424,24 @@ extension PdfAnnotationEditing on PdfEditor {
   /// unrotated annotations regenerate at their /Rect; rotated ones
   /// regenerate in their local frame and re-rotate (the
   /// [resizeAnnotationLocal] shape, at the same size).
-  bool _restyleRegenerate(int pageIndex, CosDictionary dict,
-      {double? opacity, int pageRotation = 0}) {
+  bool _restyleRegenerate(
+    int pageIndex,
+    CosDictionary dict, {
+    double? opacity,
+    int pageRotation = 0,
+  }) {
     // re-wrap: /Rect and style entries are parsed at construction or
     // lazily, and the dict just changed under the caller's instance
     final annotation = PdfAnnotation.fromDict(document, dict);
     final quad = annotation.appearanceQuad;
     final theta = quad == null ? 0.0 : _quadRotation(quad);
     if (theta == 0) {
-      if (!_regenerateStyledAppearance(annotation, annotation.rect,
-          opacity: opacity, pageRotation: pageRotation)) {
+      if (!_regenerateStyledAppearance(
+        annotation,
+        annotation.rect,
+        opacity: opacity,
+        pageRotation: pageRotation,
+      )) {
         return false;
       }
       _markAnnotationChanged(pageIndex, dict);
@@ -3907,21 +4456,32 @@ extension PdfAnnotationEditing on PdfEditor {
     final h = math.sqrt((ulx - llx) * (ulx - llx) + (uly - lly) * (uly - lly));
     if (w < 1e-9 || h < 1e-9) return false;
     final local = PdfRect(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2);
-    if (!_regenerateStyledAppearance(annotation, local,
-        opacity: opacity, pageRotation: pageRotation)) {
+    if (!_regenerateStyledAppearance(
+      annotation,
+      local,
+      opacity: opacity,
+      pageRotation: pageRotation,
+    )) {
       return false;
     }
     dict['Rect'] = _rectArray(local);
-    rotateAnnotation(pageIndex, PdfAnnotation.fromDict(document, dict),
-        theta * 180 / math.pi);
+    rotateAnnotation(
+      pageIndex,
+      PdfAnnotation.fromDict(document, dict),
+      theta * 180 / math.pi,
+    );
     return true;
   }
 
   /// [_regenerateResizedAppearance] widened to the restyle-only
   /// subtypes (stamps, notes), which regenerate at their current size
   /// but never resize this way.
-  bool _regenerateStyledAppearance(PdfAnnotation annotation, PdfRect to,
-      {double? opacity, int pageRotation = 0}) {
+  bool _regenerateStyledAppearance(
+    PdfAnnotation annotation,
+    PdfRect to, {
+    double? opacity,
+    int pageRotation = 0,
+  }) {
     switch (annotation.subtype) {
       case 'Square' ||
             'Circle' ||
@@ -3929,25 +4489,44 @@ extension PdfAnnotationEditing on PdfEditor {
             'Line' ||
             'PolyLine' ||
             'Polygon':
-        return _regenerateResizedAppearance(annotation, to,
-            opacity: opacity, pageRotation: pageRotation);
+        return _regenerateResizedAppearance(
+          annotation,
+          to,
+          opacity: opacity,
+          pageRotation: pageRotation,
+        );
       case 'Stamp':
         final form = annotation.normalAppearance;
         if (form == null) return false;
         final color = annotation.color ?? 0xC03030;
-        final (w, gs) = _stampContent(to, annotation.contents ?? '', color,
-            opacity ?? _appearanceOpacity(form),
-            pageRotation: pageRotation);
-        _replaceAppearance(annotation.dict, form, to, w,
-            resources: _resources(
-                extGState: gs, font: _helvetica(bold: true, name: 'HelvB')));
+        final (w, gs) = _stampContent(
+          to,
+          annotation.contents ?? '',
+          color,
+          opacity ?? _appearanceOpacity(form),
+          pageRotation: pageRotation,
+        );
+        _replaceAppearance(
+          annotation.dict,
+          form,
+          to,
+          w,
+          resources: _resources(
+            extGState: gs,
+            font: _helvetica(bold: true, name: 'HelvB'),
+          ),
+        );
         return true;
       case 'Text':
         final form = annotation.normalAppearance;
         if (form == null) return false;
         final color = annotation.color ?? 0xFFD100;
-        _replaceAppearance(annotation.dict, form, to,
-            _noteContent(to, color, pageRotation: pageRotation));
+        _replaceAppearance(
+          annotation.dict,
+          form,
+          to,
+          _noteContent(to, color, pageRotation: pageRotation),
+        );
         return true;
       default:
         return false;
@@ -3984,8 +4563,12 @@ extension PdfAnnotationEditing on PdfEditor {
   /// adopting the new object into the document cache so later edits in
   /// the same apply resolve it.
   void _replaceAppearance(
-      CosDictionary annot, CosStream oldForm, PdfRect bbox, ContentWriter w,
-      {CosDictionary? resources}) {
+    CosDictionary annot,
+    CosStream oldForm,
+    PdfRect bbox,
+    ContentWriter w, {
+    CosDictionary? resources,
+  }) {
     final form = _form(bbox, w, resources: resources);
     final cos = document.cos;
     final ref = cos.referenceTo(oldForm);
@@ -4016,7 +4599,7 @@ extension PdfAnnotationEditing on PdfEditor {
       0,
       sy,
       rect.left - bounds.left * sx,
-      rect.bottom - bounds.bottom * sy
+      rect.bottom - bounds.bottom * sy,
     ]);
   }
 
@@ -4058,14 +4641,19 @@ extension PdfAnnotationEditing on PdfEditor {
 
   /// An x y x y ... array with each coordinate mapped, or null if [raw]
   /// is not a numeric array.
-  CosArray? _mapPoints(CosObject? raw, double Function(double) mapX,
-          double Function(double) mapY) =>
+  CosArray? _mapPoints(
+    CosObject? raw,
+    double Function(double) mapX,
+    double Function(double) mapY,
+  ) =>
       _mapPointPairs(raw, (x, y) => (mapX(x), mapY(y)));
 
   /// An x y x y ... array with each point mapped jointly (rotation needs
   /// both coordinates), or null if [raw] is not a numeric array.
   CosArray? _mapPointPairs(
-      CosObject? raw, (double, double) Function(double x, double y) map) {
+    CosObject? raw,
+    (double, double) Function(double x, double y) map,
+  ) {
     final cos = document.cos;
     final array = cos.resolve(raw);
     if (array is! CosArray) return null;
@@ -4092,8 +4680,13 @@ extension PdfAnnotationEditing on PdfEditor {
 
   /// Stages whatever object owns [dict]'s bytes: the annotation itself
   /// when indirect, otherwise its containing /Annots array or page.
-  void _markAnnotationChanged(int pageIndex, CosDictionary dict) {
+  void _markAnnotationChanged(
+    int pageIndex,
+    CosDictionary dict, {
+    bool visual = true,
+  }) {
     _PdfPageAnnotationList(this, pageIndex).markOwnerChangedFor(dict);
+    _markAnnotations([pageIndex], visual: visual);
   }
 
   /// Bakes the page's annotation appearances into its content streams and
@@ -4107,7 +4700,11 @@ extension PdfAnnotationEditing on PdfEditor {
 
   /// [flattenAnnotations] restricted to annotations matching [select]
   /// (used by [PdfFormAdmin.flattenForm] to take widgets only).
-  void _flattenAnnotations(int pageIndex, bool Function(PdfAnnotation) select) {
+  void _flattenAnnotations(
+    int pageIndex,
+    bool Function(PdfAnnotation) select, {
+    bool syncAnnotations = true,
+  }) {
     final cos = document.cos;
     final page = document.page(pageIndex);
 
@@ -4171,12 +4768,23 @@ extension PdfAnnotationEditing on PdfEditor {
       w
         ..save()
         ..concatMatrix(
-            sx, 0, 0, sy, rect.left - minX * sx, rect.bottom - minY * sy)
+          sx,
+          0,
+          0,
+          sy,
+          rect.left - minX * sx,
+          rect.bottom - minY * sy,
+        )
         ..drawXObject(name)
         ..restore();
       flattened.add(annot.dict);
     }
     if (flattened.isEmpty) return;
+
+    _markContent([pageIndex]);
+    if (syncAnnotations) {
+      _markAnnotations([pageIndex], visual: false);
+    }
 
     resources['XObject'] = xObjects;
     page.dict['Resources'] = resources;
@@ -4189,19 +4797,25 @@ extension PdfAnnotationEditing on PdfEditor {
     if (resolvedContents is CosArray) {
       items.addAll(resolvedContents.items);
     } else if (resolvedContents is CosStream) {
-      items.add(rawContents is CosReference
-          ? rawContents
-          : _updater.addObject(resolvedContents));
+      items.add(
+        rawContents is CosReference
+            ? rawContents
+            : _updater.addObject(resolvedContents),
+      );
     }
     final suffix = w.takeBytes();
-    items.add(_updater.addObject(CosStream(
-        CosDictionary({'Length': CosInteger(suffix.length)}), suffix)));
+    items.add(
+      _updater.addObject(
+        CosStream(CosDictionary({'Length': CosInteger(suffix.length)}), suffix),
+      ),
+    );
     page.dict['Contents'] = CosArray(items);
 
     _PdfPageAnnotationList(this, pageIndex).removeWhere(
-        (_, resolved) =>
-            resolved is CosDictionary && flattened.contains(resolved),
-        removeIfEmpty: true);
+      (_, resolved) =>
+          resolved is CosDictionary && flattened.contains(resolved),
+      removeIfEmpty: true,
+    );
     _updater.markChanged(page.dict);
   }
 
@@ -4214,11 +4828,13 @@ extension PdfAnnotationEditing on PdfEditor {
       final values = <double>[];
       for (var i = 0; i < 6; i++) {
         final n = document.cos.resolve(raw[i]);
-        values.add(n is CosInteger
-            ? n.value.toDouble()
-            : n is CosReal
-                ? n.value
-                : (i == 0 || i == 3 ? 1.0 : 0.0));
+        values.add(
+          n is CosInteger
+              ? n.value.toDouble()
+              : n is CosReal
+                  ? n.value
+                  : (i == 0 || i == 3 ? 1.0 : 0.0),
+        );
       }
       return values;
     }
@@ -4228,7 +4844,9 @@ extension PdfAnnotationEditing on PdfEditor {
   CosStream _rawStream(String text) {
     final bytes = Uint8List.fromList(text.codeUnits);
     return CosStream(
-        CosDictionary({'Length': CosInteger(bytes.length)}), bytes);
+      CosDictionary({'Length': CosInteger(bytes.length)}),
+      bytes,
+    );
   }
 
   void _addShape(
@@ -4250,27 +4868,47 @@ extension PdfAnnotationEditing on PdfEditor {
     final stroking = strokeColor != null && strokeWidth > 0;
     final dash = stroking ? dashPattern : null;
     final gs = _alphaState(opacity);
-    final w = _shapeContent(subtype, rect, strokeColor, strokeWidth, fillColor,
-        dashPattern: dash, hasAlpha: gs != null);
+    final w = _shapeContent(
+      subtype,
+      rect,
+      strokeColor,
+      strokeWidth,
+      fillColor,
+      dashPattern: dash,
+      hasAlpha: gs != null,
+    );
 
     final dict = _markupDict(
-        subtype, rect, strokeColor ?? fillColor!, contents, author)
-      ..['BS'] = _borderStyle(stroking ? strokeWidth : 0, dashPattern: dash);
+      subtype,
+      rect,
+      strokeColor ?? fillColor!,
+      contents,
+      author,
+    )..['BS'] = _borderStyle(stroking ? strokeWidth : 0, dashPattern: dash);
     if (fillColor != null) {
       dict['IC'] = CosArray([
         for (final c in ContentWriter.rgbComponents(fillColor)) CosReal(c),
       ]);
     }
     _addAnnotation(
-        pageIndex, dict, _form(rect, w, resources: _resources(extGState: gs)),
-        name: name);
+      pageIndex,
+      dict,
+      _form(rect, w, resources: _resources(extGState: gs)),
+      name: name,
+    );
   }
 
   /// The shape appearance content: a rectangle or inscribed ellipse,
   /// stroked inside [rect] so the line never spills past the /Rect.
-  ContentWriter _shapeContent(String subtype, PdfRect rect, int? strokeColor,
-      double strokeWidth, int? fillColor,
-      {List<double>? dashPattern, required bool hasAlpha}) {
+  ContentWriter _shapeContent(
+    String subtype,
+    PdfRect rect,
+    int? strokeColor,
+    double strokeWidth,
+    int? fillColor, {
+    List<double>? dashPattern,
+    required bool hasAlpha,
+  }) {
     final stroking = strokeColor != null && strokeWidth > 0;
     final inset = stroking ? strokeWidth / 2 : 0.0;
     final w = ContentWriter();
@@ -4283,11 +4921,19 @@ extension PdfAnnotationEditing on PdfEditor {
       if (dashPattern != null && dashPattern.isNotEmpty) w.dash(dashPattern);
     }
     if (subtype == 'Square') {
-      w.rect(rect.left + inset, rect.bottom + inset, rect.width - 2 * inset,
-          rect.height - 2 * inset);
+      w.rect(
+        rect.left + inset,
+        rect.bottom + inset,
+        rect.width - 2 * inset,
+        rect.height - 2 * inset,
+      );
     } else {
-      w.ellipse((rect.left + rect.right) / 2, (rect.bottom + rect.top) / 2,
-          rect.width / 2 - inset, rect.height / 2 - inset);
+      w.ellipse(
+        (rect.left + rect.right) / 2,
+        (rect.bottom + rect.top) / 2,
+        rect.width / 2 - inset,
+        rect.height / 2 - inset,
+      );
     }
     if (fillColor != null && stroking) {
       w.fillAndStroke();
@@ -4333,9 +4979,21 @@ extension PdfAnnotationEditing on PdfEditor {
     if (dashed) w.dash(const []);
     if (points.length >= 2) {
       _drawEnding(
-          w, startEnding, points.first, points[1], strokeColor, strokeWidth);
-      _drawEnding(w, endEnding, points.last, points[points.length - 2],
-          strokeColor, strokeWidth);
+        w,
+        startEnding,
+        points.first,
+        points[1],
+        strokeColor,
+        strokeWidth,
+      );
+      _drawEnding(
+        w,
+        endEnding,
+        points.last,
+        points[points.length - 2],
+        strokeColor,
+        strokeWidth,
+      );
     }
     return w;
   }
@@ -4361,8 +5019,9 @@ extension PdfAnnotationEditing on PdfEditor {
   /// form BBox clips the outer half of every puff (the scallops render as
   /// flattened brackets at the edges).
   double _cloudPadding(double strokeWidth) => math.max(
-      _linePadding(strokeWidth),
-      2 * _cloudArcRadius(strokeWidth) * _cloudBulgeFactor + strokeWidth);
+        _linePadding(strokeWidth),
+        2 * _cloudArcRadius(strokeWidth) * _cloudBulgeFactor + strokeWidth,
+      );
 
   ContentWriter _cloudPolygonContent(
     List<(double, double)> points, {
@@ -4402,7 +5061,10 @@ extension PdfAnnotationEditing on PdfEditor {
   }
 
   void _appendCloudPath(
-      ContentWriter w, List<(double, double)> points, double strokeWidth) {
+    ContentWriter w,
+    List<(double, double)> points,
+    double strokeWidth,
+  ) {
     if (points.length < 3) return;
     final clockwise = _signedArea(points) < 0;
     final arc = _cloudArcRadius(strokeWidth);
@@ -4445,10 +5107,22 @@ extension PdfAnnotationEditing on PdfEditor {
         // Two quarter-arcs meeting at the apex: the feet leave the edge
         // perpendicular (giving each puff a distinct neck/cusp), the apex
         // runs parallel to the edge.
-        w.curveTo(sx + nx * cf, sy + ny * cf, apx - ux * ca, apy - uy * ca,
-            apx, apy);
-        w.curveTo(apx + ux * ca, apy + uy * ca, ex + nx * cf, ey + ny * cf,
-            ex, ey);
+        w.curveTo(
+          sx + nx * cf,
+          sy + ny * cf,
+          apx - ux * ca,
+          apy - uy * ca,
+          apx,
+          apy,
+        );
+        w.curveTo(
+          apx + ux * ca,
+          apy + uy * ca,
+          ex + nx * cf,
+          ey + ny * cf,
+          ex,
+          ey,
+        );
       }
     }
     w.closePath();
@@ -4481,8 +5155,12 @@ extension PdfAnnotationEditing on PdfEditor {
     bool isCircle,
     (double, double) center,
     double radius,
-  })? _endingPath(PdfLineEnding kind, (double, double) tip,
-      (double, double) from, double strokeWidth) {
+  })? _endingPath(
+    PdfLineEnding kind,
+    (double, double) tip,
+    (double, double) from,
+    double strokeWidth,
+  ) {
     if (kind == PdfLineEnding.none) return null;
     final dx = from.$1 - tip.$1;
     final dy = from.$2 - tip.$2;
@@ -4545,7 +5223,7 @@ extension PdfAnnotationEditing on PdfEditor {
             (tip.$1 + r, tip.$2),
             (tip.$1, tip.$2 + r),
             (tip.$1 - r, tip.$2),
-            (tip.$1, tip.$2 - r)
+            (tip.$1, tip.$2 - r),
           ],
           closed: true,
           filled: true,
@@ -4585,8 +5263,14 @@ extension PdfAnnotationEditing on PdfEditor {
     }
   }
 
-  void _drawEnding(ContentWriter w, PdfLineEnding kind, (double, double) tip,
-      (double, double) from, int color, double strokeWidth) {
+  void _drawEnding(
+    ContentWriter w,
+    PdfLineEnding kind,
+    (double, double) tip,
+    (double, double) from,
+    int color,
+    double strokeWidth,
+  ) {
     final shape = _endingPath(kind, tip, from, strokeWidth);
     if (shape == null) return;
     if (shape.isCircle) {
@@ -4630,8 +5314,12 @@ extension PdfAnnotationEditing on PdfEditor {
   /// The extreme points an ending [kind] reaches at [tip] (line arriving
   /// from [from]) - fed into [_pointBounds] so the appearance /Rect and
   /// BBox cover the ending, not just the line.
-  List<(double, double)> _endingExtent(PdfLineEnding kind, (double, double) tip,
-      (double, double) from, double strokeWidth) {
+  List<(double, double)> _endingExtent(
+    PdfLineEnding kind,
+    (double, double) tip,
+    (double, double) from,
+    double strokeWidth,
+  ) {
     final shape = _endingPath(kind, tip, from, strokeWidth);
     if (shape == null) return const [];
     return [tip, ...shape.vertices];
@@ -4657,8 +5345,13 @@ extension PdfAnnotationEditing on PdfEditor {
 
   /// The common annotation dictionary: /C carries [color], /F sets Print
   /// so the annotation survives printing and flattening.
-  CosDictionary _markupDict(String subtype, PdfRect rect, int color,
-      String? contents, String? author) {
+  CosDictionary _markupDict(
+    String subtype,
+    PdfRect rect,
+    int color,
+    String? contents,
+    String? author,
+  ) {
     final dict = CosDictionary({
       'Type': const CosName('Annot'),
       'Subtype': CosName(subtype),
@@ -4676,8 +5369,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// Wraps the annotation content in a Form XObject whose BBox is the
   /// annotation rect in page coordinates - the §12.5.5 algorithm then maps
   /// it onto /Rect as the identity.
-  CosStream _form(PdfRect bbox, ContentWriter content,
-      {CosDictionary? resources}) {
+  CosStream _form(
+    PdfRect bbox,
+    ContentWriter content, {
+    CosDictionary? resources,
+  }) {
     final bytes = content.takeBytes();
     final dict = CosDictionary({
       'Type': const CosName('XObject'),
@@ -4695,8 +5391,12 @@ extension PdfAnnotationEditing on PdfEditor {
   /// Every created annotation gets an /NM (§12.5.2): [name] when given,
   /// else a generated UUID - the durable identity that survives slot
   /// shifts and revisions (see [PdfAnnotation.name]).
-  void _addAnnotation(int pageIndex, CosDictionary annot, CosStream form,
-      {String? name}) {
+  void _addAnnotation(
+    int pageIndex,
+    CosDictionary annot,
+    CosStream form, {
+    String? name,
+  }) {
     if (!annot.entries.containsKey('NM')) {
       annot['NM'] = CosString.fromText(name ?? _generateAnnotationName());
     }
@@ -4708,8 +5408,13 @@ extension PdfAnnotationEditing on PdfEditor {
   /// when absent and staging whichever object now owns it. Shared by the
   /// appearance-bearing [_addAnnotation] and the appearance-less
   /// [_addThreadAnnotation].
-  void _linkAnnotation(int pageIndex, CosReference annotRef) {
+  void _linkAnnotation(
+    int pageIndex,
+    CosReference annotRef, {
+    bool visual = true,
+  }) {
     _PdfPageAnnotationList(this, pageIndex).append(annotRef);
+    _markAnnotations([pageIndex], visual: visual);
   }
 
   CosDictionary? _alphaState(double opacity, {bool multiply = false}) {
@@ -4723,8 +5428,11 @@ extension PdfAnnotationEditing on PdfEditor {
     return dict;
   }
 
-  CosDictionary? _resources(
-      {CosDictionary? extGState, CosDictionary? font, CosDictionary? xObject}) {
+  CosDictionary? _resources({
+    CosDictionary? extGState,
+    CosDictionary? font,
+    CosDictionary? xObject,
+  }) {
     if (extGState == null && font == null && xObject == null) return null;
     final dict = CosDictionary();
     if (extGState != null) {
@@ -4738,8 +5446,11 @@ extension PdfAnnotationEditing on PdfEditor {
   /// A non-embedded base-14 Helvetica font with explicit /Widths, so both
   /// this renderer's substitution and other viewers space text correctly.
   CosDictionary _helvetica({bool bold = false, String name = 'Helv'}) =>
-      _fontResource(name, bold ? 'Helvetica-Bold' : 'Helvetica',
-          bold ? helveticaBoldWidths : helveticaWidths);
+      _fontResource(
+        name,
+        bold ? 'Helvetica-Bold' : 'Helvetica',
+        bold ? helveticaBoldWidths : helveticaWidths,
+      );
 
   /// Same, for any of the standard text fonts.
   CosDictionary _standardFont(PdfStandardFont font) =>
@@ -4811,8 +5522,12 @@ extension PdfAnnotationEditing on PdfEditor {
 
   /// Greedy word wrap with [font]'s metrics; a single word longer than
   /// [maxWidth] overflows (and is clipped by the appearance).
-  List<String> _wrap(String text, double fontSize, double maxWidth,
-      {PdfTextFont font = PdfStandardFont.helvetica}) {
+  List<String> _wrap(
+    String text,
+    double fontSize,
+    double maxWidth, {
+    PdfTextFont font = PdfStandardFont.helvetica,
+  }) {
     final lines = <String>[];
     for (final paragraph in text.split('\n')) {
       var line = '';

--- a/packages/pdf_document/lib/src/color_processing.dart
+++ b/packages/pdf_document/lib/src/color_processing.dart
@@ -79,7 +79,7 @@ extension PdfColorProcessing on PdfEditor {
           rgb: entry.key,
           fillUses: entry.value.fillUses,
           strokeUses: entry.value.strokeUses,
-        )
+        ),
     ];
     colors.sort((a, b) {
       final byUses = b.uses.compareTo(a.uses);
@@ -133,7 +133,7 @@ extension PdfColorProcessing on PdfEditor {
     );
     final rewritten = processor.rewrite(operations);
     if (processor.count == 0) return 0;
-    _setContent(page, ContentStreamSerializer.serialize(rewritten));
+    _setContent(index, page, ContentStreamSerializer.serialize(rewritten));
     return processor.count;
   }
 
@@ -284,7 +284,10 @@ abstract class _ColorScannerBase {
   }
 
   void _setColor(
-      ContentOperation op, _PaintSide side, _DeviceColorSpace space) {
+    ContentOperation op,
+    _PaintSide side,
+    _DeviceColorSpace space,
+  ) {
     _setSpace(side, space);
     _onColor(op, side, space);
   }
@@ -323,8 +326,9 @@ abstract class _ColorScannerBase {
         return _DeviceColorSpace.cmyk;
     }
 
-    final colorSpaces =
-        editor.document.cos.resolve(page.resources['ColorSpace']);
+    final colorSpaces = editor.document.cos.resolve(
+      page.resources['ColorSpace'],
+    );
     if (colorSpaces is! CosDictionary) return _DeviceColorSpace.other;
     return _spaceFromObject(editor.document.cos.resolve(colorSpaces[name]));
   }
@@ -431,7 +435,7 @@ class _ColorCollector extends _ColorScannerBase {
           rgb: entry.key,
           fillUses: entry.value.fillUses,
           strokeUses: entry.value.strokeUses,
-        )
+        ),
     ];
     colors.sort((a, b) {
       final byUses = b.uses.compareTo(a.uses);
@@ -511,7 +515,10 @@ class _ColorProcessor extends _ColorScannerBase {
   }
 
   ContentOperation _deviceColor(
-      ContentOperation op, _PaintSide side, _DeviceColorSpace space) {
+    ContentOperation op,
+    _PaintSide side,
+    _DeviceColorSpace space,
+  ) {
     _setSpace(side, space);
     return _maybeReplace(op, side, space);
   }
@@ -526,7 +533,10 @@ class _ColorProcessor extends _ColorScannerBase {
   }
 
   ContentOperation _maybeReplace(
-      ContentOperation op, _PaintSide side, _DeviceColorSpace space) {
+    ContentOperation op,
+    _PaintSide side,
+    _DeviceColorSpace space,
+  ) {
     if (side == _PaintSide.fill && !fill) return op;
     if (side == _PaintSide.stroke && !stroke) return op;
     final rgb = _rgbFrom(op.operands, space);
@@ -623,11 +633,7 @@ class _ColorProcessor extends _ColorScannerBase {
     final dropFill = paintsFill && _state.transparentFill;
     final dropStroke = paintsStroke && _state.transparentStroke;
     if (!dropFill && !dropStroke) return [op];
-    final nextMode = _textModeWithout(
-      mode,
-      fill: dropFill,
-      stroke: dropStroke,
-    );
+    final nextMode = _textModeWithout(mode, fill: dropFill, stroke: dropStroke);
     if (nextMode == mode) return [op];
     count += (dropFill ? 1 : 0) + (dropStroke ? 1 : 0);
     return [

--- a/packages/pdf_document/lib/src/comment_editor.dart
+++ b/packages/pdf_document/lib/src/comment_editor.dart
@@ -37,8 +37,10 @@ extension PdfCommentEditing on PdfEditor {
   }) {
     final parentRef = document.cos.referenceTo(target.dict);
     if (parentRef == null) {
-      throw ArgumentError('target annotation is not an indirect object; '
-          'save and reopen the document before replying to a fresh one');
+      throw ArgumentError(
+        'target annotation is not an indirect object; '
+        'save and reopen the document before replying to a fresh one',
+      );
     }
     final nm = name ?? _generateAnnotationName();
     final when = createdAt ?? DateTime.now();
@@ -82,8 +84,10 @@ extension PdfCommentEditing on PdfEditor {
   }) {
     final parentRef = document.cos.referenceTo(target.dict);
     if (parentRef == null) {
-      throw ArgumentError('target annotation is not an indirect object; '
-          'save and reopen the document before setting its state');
+      throw ArgumentError(
+        'target annotation is not an indirect object; '
+        'save and reopen the document before setting its state',
+      );
     }
     final nm = name ?? _generateAnnotationName();
     final when = at ?? DateTime.now();
@@ -111,23 +115,45 @@ extension PdfCommentEditing on PdfEditor {
 
   /// Marks [target]'s thread resolved - review state `Completed`
   /// ([PdfCommentThread.isResolved]). A convenience over [setReviewState].
-  String resolveThread(int pageIndex, PdfAnnotation target,
-          {String? author, DateTime? at, String? name}) =>
-      setReviewState(pageIndex, target, PdfReviewState.completed,
-          author: author, at: at, name: name);
+  String resolveThread(
+    int pageIndex,
+    PdfAnnotation target, {
+    String? author,
+    DateTime? at,
+    String? name,
+  }) =>
+      setReviewState(
+        pageIndex,
+        target,
+        PdfReviewState.completed,
+        author: author,
+        at: at,
+        name: name,
+      );
 
   /// Reopens [target]'s thread - review state `None`, clearing a prior
   /// resolution. A convenience over [setReviewState].
-  String reopenThread(int pageIndex, PdfAnnotation target,
-          {String? author, DateTime? at, String? name}) =>
-      setReviewState(pageIndex, target, PdfReviewState.none,
-          author: author, at: at, name: name);
+  String reopenThread(
+    int pageIndex,
+    PdfAnnotation target, {
+    String? author,
+    DateTime? at,
+    String? name,
+  }) =>
+      setReviewState(
+        pageIndex,
+        target,
+        PdfReviewState.none,
+        author: author,
+        at: at,
+        name: name,
+      );
 
   /// Stages an appearance-less thread annotation (reply or state) and
   /// links it into the page's /Annots. Unlike [_addAnnotation] it writes
   /// no /AP: replies and state replies carry no page graphics. The caller
   /// is responsible for the /NM (both creators stamp one).
   void _addThreadAnnotation(int pageIndex, CosDictionary annot) {
-    _linkAnnotation(pageIndex, _updater.addObject(annot));
+    _linkAnnotation(pageIndex, _updater.addObject(annot), visual: false);
   }
 }

--- a/packages/pdf_document/lib/src/content_editor.dart
+++ b/packages/pdf_document/lib/src/content_editor.dart
@@ -9,13 +9,14 @@ part of 'editor.dart';
 /// simple-font (non-/Type0) text runs; composite runs are still replaced
 /// but keep their original colour, size, and face.
 class PdfTextStyle {
-  const PdfTextStyle(
-      {this.color,
-      this.fontSize,
-      this.family,
-      this.embeddedFont,
-      this.bold,
-      this.italic});
+  const PdfTextStyle({
+    this.color,
+    this.fontSize,
+    this.family,
+    this.embeddedFont,
+    this.bold,
+    this.italic,
+  });
 
   /// Nonstroking fill colour as `0xRRGGBB`, or null to keep the run's colour.
   final int? color;
@@ -67,8 +68,14 @@ class PdfTextStyle {
       other.italic == italic;
 
   @override
-  int get hashCode => Object.hash(color, fontSize, family,
-      identityHashCode(embeddedFont), bold, italic);
+  int get hashCode => Object.hash(
+        color,
+        fontSize,
+        family,
+        identityHashCode(embeddedFont),
+        bold,
+        italic,
+      );
 }
 
 /// Tracks an embedded font used by a styled replacement across the runs of
@@ -96,7 +103,7 @@ extension PdfContentEditing on PdfEditor {
       ..add(latin1.encode('q\n'))
       ..add(stamp.content.takeBytes())
       ..add(latin1.encode('Q\n'));
-    _appendContent(page, wrapped.takeBytes());
+    _appendContent(index, page, wrapped.takeBytes());
   }
 
   /// Tier 2 - element deletion. Removes the [ids] listed in [elements]
@@ -127,7 +134,10 @@ extension PdfContentEditing on PdfEditor {
     }
     if (drop.isEmpty) return;
     _setContent(
-        page, elements.serialize(drop: drop, replacements: replacements));
+      elements.pageIndex,
+      page,
+      elements.serialize(drop: drop, replacements: replacements),
+    );
   }
 
   /// Tier 3 - text editing. Replaces occurrences of [find] with [replace]
@@ -166,8 +176,13 @@ extension PdfContentEditing on PdfEditor {
   /// italic) to the replacement - see [replaceStyledText], which this
   /// forwards to. Styling only affects simple-font runs; a composite
   /// (/Type0) run is still corrected but keeps its original appearance.
-  int replaceText(int index, String find, String replace,
-      {List<PdfEmbeddedFont> fallbackFonts = const [], PdfTextStyle? style}) {
+  int replaceText(
+    int index,
+    String find,
+    String replace, {
+    List<PdfEmbeddedFont> fallbackFonts = const [],
+    PdfTextStyle? style,
+  }) {
     if (find.isEmpty) throw ArgumentError.value(find, 'find', 'is empty');
     // the simple-font path is byte-encoded; non-Latin-1 strings can only be
     // matched/drawn by the composite path, so leave these null there.
@@ -190,7 +205,9 @@ extension PdfContentEditing on PdfEditor {
     final type0Cache = <String, _Type0Editing?>{};
     _Type0Editing? type0For(String name, CosDictionary f) =>
         type0Cache.putIfAbsent(
-            name, () => _Type0Editing.tryCreate(this, page, name, f, fallbackFonts));
+          name,
+          () => _Type0Editing.tryCreate(this, page, name, f, fallbackFonts),
+        );
 
     final styled = style != null && !style.isEmpty;
     // an embedded-font restyle embeds the chosen face once, after the runs
@@ -246,15 +263,27 @@ extension PdfContentEditing on PdfEditor {
         final simpleRewrite = findBytes == null
             ? (run, 0)
             : (styled
-                ? _rewriteStyledTextRun(page, run, font, fontName, fontSize,
-                    findBytes, replaceBytes, replace, style, restoreColorOps,
-                    styledEmbed)
+                ? _rewriteStyledTextRun(
+                    page,
+                    run,
+                    font,
+                    fontName,
+                    fontSize,
+                    findBytes,
+                    replaceBytes,
+                    replace,
+                    style,
+                    restoreColorOps,
+                    styledEmbed,
+                  )
                 : (replaceBytes != null
                     ? _rewriteTextRun(run, font, findBytes, replaceBytes)
                     : (run, 0)));
         final (ops_, n) = _isType0(cos, font) && fontName != null
-            ? (type0For(fontName, font!)
-                    ?.rewriteRun(run, find, replace, fontSize) ??
+            ? (type0For(
+                  fontName,
+                  font!,
+                )?.rewriteRun(run, find, replace, fontSize) ??
                 (run, 0))
             : simpleRewrite;
         rewritten.addAll(ops_);
@@ -290,14 +319,17 @@ extension PdfContentEditing on PdfEditor {
       // embed the styled replacement's font as a page /Font resource once all
       // its glyphs have been recorded.
       if (styledEmbed != null && styledEmbed.name != null) {
-        final built =
-            styledEmbed.font.buildResource(_updater.addObject).entries.values.first;
+        final built = styledEmbed.font
+            .buildResource(_updater.addObject)
+            .entries
+            .values
+            .first;
         _ownFontResources(page)[styledEmbed.name!] = _updater.addObject(built);
       }
       ops
         ..clear()
         ..addAll(rewritten);
-      _setContent(page, elements.serialize());
+      _setContent(index, page, elements.serialize());
     }
     return count;
   }
@@ -314,11 +346,20 @@ extension PdfContentEditing on PdfEditor {
   /// Courier), so it works even against embedded fonts. Styling is applied to
   /// simple-font runs only; composite (/Type0) runs are corrected without
   /// restyling.
-  int replaceStyledText(int index, String find, String replace,
-          PdfTextStyle style,
-          {List<PdfEmbeddedFont> fallbackFonts = const []}) =>
-      replaceText(index, find, replace,
-          fallbackFonts: fallbackFonts, style: style);
+  int replaceStyledText(
+    int index,
+    String find,
+    String replace,
+    PdfTextStyle style, {
+    List<PdfEmbeddedFont> fallbackFonts = const [],
+  }) =>
+      replaceText(
+        index,
+        find,
+        replace,
+        fallbackFonts: fallbackFonts,
+        style: style,
+      );
 
   /// Rewrites one run of show operators like [_rewriteTextRun] but applies
   /// [style] to each replacement: the replaced bytes are drawn in their own
@@ -328,17 +369,18 @@ extension PdfContentEditing on PdfEditor {
   /// the styled font and size and a compensating `TJ` adjustment keeps the
   /// rest of the line in place.
   (List<ContentOperation>, int) _rewriteStyledTextRun(
-      PdfPage page,
-      List<ContentOperation> run,
-      CosDictionary? font,
-      String? fontName,
-      double fontSize,
-      List<int> findBytes,
-      List<int>? replaceBytes,
-      String replace,
-      PdfTextStyle style,
-      List<ContentOperation> restoreColorOps,
-      _StyledEmbed? embed) {
+    PdfPage page,
+    List<ContentOperation> run,
+    CosDictionary? font,
+    String? fontName,
+    double fontSize,
+    List<int> findBytes,
+    List<int>? replaceBytes,
+    String replace,
+    PdfTextStyle style,
+    List<ContentOperation> restoreColorOps,
+    _StyledEmbed? embed,
+  ) {
     if (_isType0(document.cos, font)) return (run, 0);
 
     final cells = _runCells(run);
@@ -369,7 +411,10 @@ extension PdfContentEditing on PdfEditor {
     final CosString replShow;
     if (useEmbed) {
       styledFontName = _embeddedFontResource(page, embed);
-      replShow = CosString(_hexBytes(embed.font.encodeHex(replace)), isHex: true);
+      replShow = CosString(
+        _hexBytes(embed.font.encodeHex(replace)),
+        isHex: true,
+      );
       var w = 0.0;
       for (final r in runes) {
         w += embed.font.advanceForGlyph(embed.font.glyphForRune(r));
@@ -419,8 +464,9 @@ extension PdfContentEditing on PdfEditor {
         final last = charCell[end - 1];
         var oldWidth = 0.0;
         for (var k = cell; k <= last; k++) {
-          oldWidth +=
-              cells[k].byte != null ? origWidthOf(cells[k].byte!) : -cells[k].kern!;
+          oldWidth += cells[k].byte != null
+              ? origWidthOf(cells[k].byte!)
+              : -cells[k].kern!;
         }
         flushPending();
         // open the style
@@ -441,9 +487,11 @@ extension PdfContentEditing on PdfEditor {
         if (end < totalChars && fontSize != 0) {
           final kern = newWidthEm * styledSize / fontSize - oldWidth;
           if (kern.abs() >= 0.001) {
-            out.add(ContentOperation('TJ', [
-              CosArray([_numberObject(kern)])
-            ]));
+            out.add(
+              ContentOperation('TJ', [
+                CosArray([_numberObject(kern)]),
+              ]),
+            );
           }
         }
         count++;
@@ -461,7 +509,8 @@ extension PdfContentEditing on PdfEditor {
   /// Coalesces flattened cells back into one show op (a `Tj` for a single
   /// plain string, else a `TJ` array with adjacent kerns merged).
   static List<ContentOperation> _emitSimpleCells(
-      List<({int? byte, double? kern})> cells) {
+    List<({int? byte, double? kern})> cells,
+  ) {
     final items = <CosObject>[];
     final buffer = <int>[];
     var kern = 0.0;
@@ -491,11 +540,11 @@ extension PdfContentEditing on PdfEditor {
     if (items.isEmpty) return const [];
     if (items.length == 1 && items[0] is CosString) {
       return [
-        ContentOperation('Tj', [items[0]])
+        ContentOperation('Tj', [items[0]]),
       ];
     }
     return [
-      ContentOperation('TJ', [CosArray(items)])
+      ContentOperation('TJ', [CosArray(items)]),
     ];
   }
 
@@ -530,8 +579,9 @@ extension PdfContentEditing on PdfEditor {
     if (existing is CosDictionary && res['Font'] is! CosReference) {
       return existing;
     }
-    final fonts =
-        CosDictionary({if (existing is CosDictionary) ...existing.entries});
+    final fonts = CosDictionary({
+      if (existing is CosDictionary) ...existing.entries,
+    });
     res['Font'] = fonts;
     return fonts;
   }
@@ -555,12 +605,14 @@ extension PdfContentEditing on PdfEditor {
       i++;
     }
     final name = 'StF$i';
-    fonts[name] = _updater.addObject(CosDictionary({
-      'Type': const CosName('Font'),
-      'Subtype': const CosName('Type1'),
-      'BaseFont': CosName(font.baseFont),
-      'Encoding': const CosName('WinAnsiEncoding'),
-    }));
+    fonts[name] = _updater.addObject(
+      CosDictionary({
+        'Type': const CosName('Font'),
+        'Subtype': const CosName('Type1'),
+        'BaseFont': CosName(font.baseFont),
+        'Encoding': const CosName('WinAnsiEncoding'),
+      }),
+    );
     return name;
   }
 
@@ -588,8 +640,9 @@ extension PdfContentEditing on PdfEditor {
     return out;
   }
 
-  static ContentOperation _colorOp(int rgb) => ContentOperation(
-      'rg', [for (final v in ContentWriter.rgbComponents(rgb)) _numberObject(v)]);
+  static ContentOperation _colorOp(int rgb) => ContentOperation('rg', [
+        for (final v in ContentWriter.rgbComponents(rgb)) _numberObject(v),
+      ]);
 
   static ContentOperation _tfOp(String name, double size) =>
       ContentOperation('Tf', [CosName(name), _numberObject(size)]);
@@ -616,7 +669,8 @@ extension PdfContentEditing on PdfEditor {
   /// One position in a flattened run: a shown byte, or a `TJ` kern number
   /// (advance of `-kern/1000` em). Exactly one field is set.
   static List<({int? byte, double? kern})> _runCells(
-      List<ContentOperation> run) {
+    List<ContentOperation> run,
+  ) {
     final cells = <({int? byte, double? kern})>[];
     for (final op in run) {
       if (op.operator == 'TJ' &&
@@ -649,8 +703,12 @@ extension PdfContentEditing on PdfEditor {
   /// [replaceBytes] across its strings. Returns the operations to emit in
   /// the run's place (the originals untouched when nothing matched) and the
   /// number of replacements.
-  (List<ContentOperation>, int) _rewriteTextRun(List<ContentOperation> run,
-      CosDictionary? font, List<int> findBytes, List<int> replaceBytes) {
+  (List<ContentOperation>, int) _rewriteTextRun(
+    List<ContentOperation> run,
+    CosDictionary? font,
+    List<int> findBytes,
+    List<int> replaceBytes,
+  ) {
     if (_isType0(document.cos, font)) return (run, 0);
 
     final cells = _runCells(run);
@@ -734,13 +792,18 @@ extension PdfContentEditing on PdfEditor {
         items.length == 1 &&
         items[0] is CosString) {
       final original = run[0].operands[0];
-      run[0].operands[0] = CosString((items[0] as CosString).bytes,
-          isHex: original is CosString && original.isHex);
+      run[0].operands[0] = CosString(
+        (items[0] as CosString).bytes,
+        isHex: original is CosString && original.isHex,
+      );
       return (run, count);
     }
-    return ([
-      ContentOperation('TJ', [CosArray(items)])
-    ], count);
+    return (
+      [
+        ContentOperation('TJ', [CosArray(items)]),
+      ],
+      count,
+    );
   }
 
   /// An advance-width lookup (thousandths of an em) for [font]: its own
@@ -766,7 +829,9 @@ extension PdfContentEditing on PdfEditor {
       final base = cos.resolve(font['BaseFont']);
       if (base is CosName) {
         final standard = PdfStandardFont.tryFromName(base.value);
-        if (standard != null) return (code) => standard.widthOf(code).toDouble();
+        if (standard != null) {
+          return (code) => standard.widthOf(code).toDouble();
+        }
       }
     }
     return (code) => PdfStandardFont.helvetica.widthOf(code).toDouble();
@@ -799,7 +864,10 @@ extension PdfContentEditing on PdfEditor {
   }
 
   static Uint8List? _replaceBytes(
-      Uint8List source, List<int> find, List<int> replace) {
+    Uint8List source,
+    List<int> find,
+    List<int> replace,
+  ) {
     final out = BytesBuilder();
     var copied = 0;
     var found = false;
@@ -853,7 +921,7 @@ extension PdfContentEditing on PdfEditor {
 
   /// Wraps the existing content in q/Q (once per editor session) and
   /// appends [bytes] as a fresh stream in the /Contents array.
-  void _appendContent(PdfPage page, Uint8List bytes) {
+  void _appendContent(int pageIndex, PdfPage page, Uint8List bytes) {
     final cos = document.cos;
     final dict = page.dict;
     if (!_wrappedPages.contains(dict)) {
@@ -871,23 +939,31 @@ extension PdfContentEditing on PdfEditor {
       ]);
     }
     final contents = cos.resolve(dict['Contents']) as CosArray;
-    contents.items.add(_updater.addObject(CosStream(
-        CosDictionary({'Length': CosInteger(bytes.length)}), bytes)));
+    contents.items.add(
+      _updater.addObject(
+        CosStream(CosDictionary({'Length': CosInteger(bytes.length)}), bytes),
+      ),
+    );
     _updater.markChanged(dict);
+    _markContent([pageIndex]);
   }
 
   /// Replaces the page's entire content with one new stream.
-  void _setContent(PdfPage page, Uint8List bytes) {
-    page.dict['Contents'] = _updater.addObject(CosStream(
-        CosDictionary({'Length': CosInteger(bytes.length)}), bytes));
+  void _setContent(int pageIndex, PdfPage page, Uint8List bytes) {
+    page.dict['Contents'] = _updater.addObject(
+      CosStream(CosDictionary({'Length': CosInteger(bytes.length)}), bytes),
+    );
     _updater.markChanged(page.dict);
     _wrappedPages.remove(page.dict);
+    _markContent([pageIndex]);
   }
 
   static CosStream _stream(String text) {
     final bytes = Uint8List.fromList(latin1.encode(text));
     return CosStream(
-        CosDictionary({'Length': CosInteger(bytes.length)}), bytes);
+      CosDictionary({'Length': CosInteger(bytes.length)}),
+      bytes,
+    );
   }
 }
 
@@ -923,7 +999,13 @@ class PdfStamp {
     if (angleDegrees != 0) {
       final r = angleDegrees * math.pi / 180;
       content.concatMatrix(
-          math.cos(r), math.sin(r), -math.sin(r), math.cos(r), x, y);
+        math.cos(r),
+        math.sin(r),
+        -math.sin(r),
+        math.cos(r),
+        x,
+        y,
+      );
       content.beginText();
       content.font(font, size);
       content.fillColor(color);
@@ -962,9 +1044,7 @@ class PdfStamp {
       content.lineWidth(lineWidth);
     }
     content.rect(x, y, width, height);
-    content.op(fillColor != null
-        ? (strokeColor != null ? 'B' : 'f')
-        : 'S');
+    content.op(fillColor != null ? (strokeColor != null ? 'B' : 'f') : 'S');
     content.restore();
   }
 
@@ -979,8 +1059,13 @@ class PdfStamp {
     double? width,
     double? height,
   }) =>
-      image(PdfEmbeddableImage.jpeg(jpeg),
-          x: x, y: y, width: width, height: height);
+      image(
+        PdfEmbeddableImage.jpeg(jpeg),
+        x: x,
+        y: y,
+        width: width,
+        height: height,
+      );
 
   /// Places a decoded [PdfEmbeddableImage] (JPEG or PNG - including PNG
   /// transparency) with its bottom-left corner at ([x], [y]). Sizing
@@ -1000,7 +1085,8 @@ class PdfStamp {
 
     final name = _freeName(_xobjects, 'Im');
     _xobjects[name] = _editor._updater.addObject(
-        img.toXObject((smask) => _editor._updater.addObject(smask)));
+      img.toXObject((smask) => _editor._updater.addObject(smask)),
+    );
 
     content.save();
     content.concatMatrix(w, 0, 0, h, x, y);
@@ -1016,8 +1102,9 @@ class PdfStamp {
     if (existing is CosDictionary && _resources[key] is! CosReference) {
       return existing;
     }
-    final copy = CosDictionary(
-        {if (existing is CosDictionary) ...existing.entries});
+    final copy = CosDictionary({
+      if (existing is CosDictionary) ...existing.entries,
+    });
     _resources[key] = copy;
     return copy;
   }
@@ -1035,12 +1122,14 @@ class PdfStamp {
       }
     }
     final name = _freeName(fonts, 'StF');
-    fonts[name] = _editor._updater.addObject(CosDictionary({
-      'Type': const CosName('Font'),
-      'Subtype': const CosName('Type1'),
-      'BaseFont': CosName(base),
-      'Encoding': const CosName('WinAnsiEncoding'),
-    }));
+    fonts[name] = _editor._updater.addObject(
+      CosDictionary({
+        'Type': const CosName('Font'),
+        'Subtype': const CosName('Type1'),
+        'BaseFont': CosName(base),
+        'Encoding': const CosName('WinAnsiEncoding'),
+      }),
+    );
     return name;
   }
 
@@ -1052,4 +1141,3 @@ class PdfStamp {
     return '$prefix$i';
   }
 }
-

--- a/packages/pdf_document/lib/src/content_reflow.dart
+++ b/packages/pdf_document/lib/src/content_reflow.dart
@@ -74,8 +74,12 @@ extension PdfParagraphReflow on PdfEditor {
       if (!joined.contains(find)) continue;
 
       final font = fontFor(group.first.fontName);
-      final reflowFont = _reflowFontFor(page, group.first.fontName, font,
-          group.first.fontSize);
+      final reflowFont = _reflowFontFor(
+        page,
+        group.first.fontName,
+        font,
+        group.first.fontSize,
+      );
       if (reflowFont == null) continue; // unsupported font for this group
 
       // available width: the widest line the author used (the column they
@@ -128,7 +132,7 @@ extension PdfParagraphReflow on PdfEditor {
 
       ops.replaceRange(firstShow, lastShow + 1, generated);
       reflowFont.commit();
-      _setContent(page, elements.serialize());
+      _setContent(index, page, elements.serialize());
       return true;
     }
     return false;
@@ -137,7 +141,11 @@ extension PdfParagraphReflow on PdfEditor {
   /// A measuring/encoding strategy for [font] at [size], or null when the
   /// font isn't one paragraph reflow can rewrite.
   _ReflowFont? _reflowFontFor(
-      PdfPage page, String? name, CosDictionary? font, double size) {
+    PdfPage page,
+    String? name,
+    CosDictionary? font,
+    double size,
+  ) {
     if (font == null) return null;
     if (PdfContentEditing._isType0(document.cos, font) && name != null) {
       final editing = _Type0Editing.tryCreate(this, page, name, font, const []);
@@ -150,7 +158,9 @@ extension PdfParagraphReflow on PdfEditor {
   /// [textByOp], tracking the text/line matrices so each line carries its
   /// origin, leading, font, and how it was reached.
   static List<_ReflowLine> _reflowLines(
-      List<ContentOperation> ops, Map<int, String> textByOp) {
+    List<ContentOperation> ops,
+    Map<int, String> textByOp,
+  ) {
     final lines = <_ReflowLine>[];
     var objId = -1;
     String? fontName;
@@ -173,28 +183,43 @@ extension PdfParagraphReflow on PdfEditor {
       switch (op.operator) {
         case 'BT':
           objId++;
-          a = 1; b = 0; c = 0; d = 1; e = 0; f = 0;
+          a = 1;
+          b = 0;
+          c = 0;
+          d = 1;
+          e = 0;
+          f = 0;
           pending = const _ReflowBreak('first', 0, 0);
         case 'Tf':
           if (operands.isNotEmpty && operands[0] is CosName) {
             fontName = (operands[0] as CosName).value;
           }
-          if (operands.length >= 2) fontSize = PdfContentEditing._num(operands[1]);
+          if (operands.length >= 2) {
+            fontSize = PdfContentEditing._num(operands[1]);
+          }
         case 'TL':
-          if (operands.isNotEmpty) leading = PdfContentEditing._num(operands[0]);
+          if (operands.isNotEmpty) {
+            leading = PdfContentEditing._num(operands[0]);
+          }
         case 'Tc':
-          if (operands.isNotEmpty) charSpace = PdfContentEditing._num(operands[0]);
+          if (operands.isNotEmpty) {
+            charSpace = PdfContentEditing._num(operands[0]);
+          }
         case 'Tw':
-          if (operands.isNotEmpty) wordSpace = PdfContentEditing._num(operands[0]);
+          if (operands.isNotEmpty) {
+            wordSpace = PdfContentEditing._num(operands[0]);
+          }
         case 'Td':
           if (operands.length >= 2) {
-            final tx = PdfContentEditing._num(operands[0]), ty = PdfContentEditing._num(operands[1]);
+            final tx = PdfContentEditing._num(operands[0]),
+                ty = PdfContentEditing._num(operands[1]);
             translate(tx, ty);
             pending = _ReflowBreak('Td', tx, ty);
           }
         case 'TD':
           if (operands.length >= 2) {
-            final tx = PdfContentEditing._num(operands[0]), ty = PdfContentEditing._num(operands[1]);
+            final tx = PdfContentEditing._num(operands[0]),
+                ty = PdfContentEditing._num(operands[1]);
             leading = -ty;
             translate(tx, ty);
             pending = _ReflowBreak('TD', tx, ty);
@@ -214,9 +239,25 @@ extension PdfParagraphReflow on PdfEditor {
           pending = _ReflowBreak('T*', 0, -leading);
         case "'":
           translate(0, -leading);
-          _addLine(lines, op, i, objId, fontName, fontSize, leading, charSpace,
-              wordSpace, a, b, c, d, e, f,
-              const _ReflowBreak("'", 0, 0), textByOp);
+          _addLine(
+            lines,
+            op,
+            i,
+            objId,
+            fontName,
+            fontSize,
+            leading,
+            charSpace,
+            wordSpace,
+            a,
+            b,
+            c,
+            d,
+            e,
+            f,
+            const _ReflowBreak("'", 0, 0),
+            textByOp,
+          );
           pending = null;
         case '"':
           if (operands.length >= 2) {
@@ -224,15 +265,47 @@ extension PdfParagraphReflow on PdfEditor {
             charSpace = PdfContentEditing._num(operands[1]);
           }
           translate(0, -leading);
-          _addLine(lines, op, i, objId, fontName, fontSize, leading, charSpace,
-              wordSpace, a, b, c, d, e, f,
-              const _ReflowBreak('"', 0, 0), textByOp);
+          _addLine(
+            lines,
+            op,
+            i,
+            objId,
+            fontName,
+            fontSize,
+            leading,
+            charSpace,
+            wordSpace,
+            a,
+            b,
+            c,
+            d,
+            e,
+            f,
+            const _ReflowBreak('"', 0, 0),
+            textByOp,
+          );
           pending = null;
         case 'Tj':
         case 'TJ':
-          _addLine(lines, op, i, objId, fontName, fontSize, leading, charSpace,
-              wordSpace, a, b, c, d, e, f,
-              pending ?? const _ReflowBreak('cont', 0, 0), textByOp);
+          _addLine(
+            lines,
+            op,
+            i,
+            objId,
+            fontName,
+            fontSize,
+            leading,
+            charSpace,
+            wordSpace,
+            a,
+            b,
+            c,
+            d,
+            e,
+            f,
+            pending ?? const _ReflowBreak('cont', 0, 0),
+            textByOp,
+          );
           pending = null;
       }
     }
@@ -240,41 +313,44 @@ extension PdfParagraphReflow on PdfEditor {
   }
 
   static void _addLine(
-      List<_ReflowLine> lines,
-      ContentOperation op,
-      int opIndex,
-      int objId,
-      String? fontName,
-      double fontSize,
-      double leading,
-      double charSpace,
-      double wordSpace,
-      double a,
-      double b,
-      double c,
-      double d,
-      double e,
-      double f,
-      _ReflowBreak brk,
-      Map<int, String> textByOp) {
-    lines.add(_ReflowLine(
-      opIndex: opIndex,
-      objId: objId,
-      operator: op.operator,
-      fontName: fontName,
-      fontSize: fontSize,
-      leading: leading,
-      charSpace: charSpace,
-      wordSpace: wordSpace,
-      a: a,
-      b: b,
-      c: c,
-      d: d,
-      originX: e,
-      baselineY: f,
-      brk: brk,
-      text: textByOp[opIndex] ?? '',
-    ));
+    List<_ReflowLine> lines,
+    ContentOperation op,
+    int opIndex,
+    int objId,
+    String? fontName,
+    double fontSize,
+    double leading,
+    double charSpace,
+    double wordSpace,
+    double a,
+    double b,
+    double c,
+    double d,
+    double e,
+    double f,
+    _ReflowBreak brk,
+    Map<int, String> textByOp,
+  ) {
+    lines.add(
+      _ReflowLine(
+        opIndex: opIndex,
+        objId: objId,
+        operator: op.operator,
+        fontName: fontName,
+        fontSize: fontSize,
+        leading: leading,
+        charSpace: charSpace,
+        wordSpace: wordSpace,
+        a: a,
+        b: b,
+        c: c,
+        d: d,
+        originX: e,
+        baselineY: f,
+        brk: brk,
+        text: textByOp[opIndex] ?? '',
+      ),
+    );
   }
 
   /// Groups the eligible lines into paragraph candidates: consecutive,
@@ -362,7 +438,9 @@ extension PdfParagraphReflow on PdfEditor {
   /// The line immediately following [group] in the same text object, or null
   /// when the paragraph is the last text in its object.
   static _ReflowLine? _followingLine(
-      List<_ReflowLine> group, List<_ReflowLine> lines) {
+    List<_ReflowLine> group,
+    List<_ReflowLine> lines,
+  ) {
     final last = group.last;
     for (final line in lines) {
       if (line.objId == last.objId && line.opIndex > last.opIndex) return line;
@@ -374,7 +452,9 @@ extension PdfParagraphReflow on PdfEditor {
   /// the paragraph's own inter-line break when it has one, else the break
   /// that connects a single-line paragraph to its following content.
   static String? _breakStyleFor(
-      List<_ReflowLine> group, List<_ReflowLine> lines) {
+    List<_ReflowLine> group,
+    List<_ReflowLine> lines,
+  ) {
     if (group.length >= 2) {
       final kind = group[1].brk.kind;
       return kind == 'T*' ? 'T*' : 'Td';
@@ -392,8 +472,10 @@ extension PdfParagraphReflow on PdfEditor {
       final leading = group.length >= 2
           ? group.first.baselineY - group[1].baselineY
           : group.first.leading;
-      return ContentOperation(
-          'Td', [PdfContentEditing._numberObject(0), PdfContentEditing._numberObject(-leading)]);
+      return ContentOperation('Td', [
+        PdfContentEditing._numberObject(0),
+        PdfContentEditing._numberObject(-leading),
+      ]);
     }
     return ContentOperation('T*', const []);
   }
@@ -541,8 +623,9 @@ class _SimpleReflowFont extends _ReflowFont {
     for (final unit in text.codeUnits) {
       if (unit > 0xFF) return null; // not representable in a simple font
     }
-    return ContentOperation(
-        'Tj', [CosString(Uint8List.fromList(text.codeUnits))]);
+    return ContentOperation('Tj', [
+      CosString(Uint8List.fromList(text.codeUnits)),
+    ]);
   }
 
   @override

--- a/packages/pdf_document/lib/src/editor.dart
+++ b/packages/pdf_document/lib/src/editor.dart
@@ -50,6 +50,143 @@ part 'signature_editor.dart';
 part 'struct_tree_editor.dart';
 part 'vector_snapshot.dart';
 
+/// The observable consequences of one [PdfEditor] mutation session.
+///
+/// A null page set means every page; an empty set means no pages. Keeping
+/// visual, base-content, and annotation-sync effects separate lets hosts
+/// invalidate exactly what changed without understanding the PDF operation
+/// that produced it.
+class PdfEditImpact {
+  const PdfEditImpact._({
+    required this.visualPages,
+    required this.contentPages,
+    required this.annotationPages,
+    required this.pageStructureChanged,
+    required this.destructive,
+  });
+
+  /// No observable document change.
+  static const none = PdfEditImpact._(
+    visualPages: <int>{},
+    contentPages: <int>{},
+    annotationPages: <int>{},
+    pageStructureChanged: false,
+    destructive: false,
+  );
+
+  /// Conservative fallback for a mutation that has not reported its impact.
+  static const unknown = PdfEditImpact._(
+    visualPages: null,
+    contentPages: null,
+    annotationPages: null,
+    pageStructureChanged: false,
+    destructive: false,
+  );
+
+  /// Creates the legacy impact shape used by older
+  /// `PdfEditingController.apply(pages:, contentPages:)` callers.
+  factory PdfEditImpact.legacy({
+    Iterable<int>? pages,
+    Iterable<int>? contentPages,
+  }) {
+    final visual = pages == null ? null : Set<int>.unmodifiable(pages);
+    final content =
+        contentPages == null ? visual : Set<int>.unmodifiable(contentPages);
+    // The old controller used an empty render set to mean "diff annotation
+    // metadata across the document". Preserve that behavior for legacy
+    // callers; editor-reported impact can name the exact annotation pages.
+    final annotations = visual != null && visual.isEmpty ? null : visual;
+    return PdfEditImpact._(
+      visualPages: visual,
+      contentPages: content,
+      annotationPages: annotations,
+      pageStructureChanged: false,
+      destructive: false,
+    );
+  }
+
+  /// Reconstructs a reported impact after an asynchronous editor mutation.
+  factory PdfEditImpact.reported({
+    required Iterable<int>? visualPages,
+    required Iterable<int>? contentPages,
+    required Iterable<int>? annotationPages,
+    bool pageStructureChanged = false,
+    bool destructive = false,
+  }) =>
+      PdfEditImpact._(
+        visualPages:
+            visualPages == null ? null : Set<int>.unmodifiable(visualPages),
+        contentPages:
+            contentPages == null ? null : Set<int>.unmodifiable(contentPages),
+        annotationPages: annotationPages == null
+            ? null
+            : Set<int>.unmodifiable(annotationPages),
+        pageStructureChanged: pageStructureChanged,
+        destructive: destructive,
+      );
+
+  /// Pages whose visible rendering changed; null means every page.
+  final Set<int>? visualPages;
+
+  /// Pages whose base page-content raster changed; null means every page.
+  final Set<int>? contentPages;
+
+  /// Pages whose syncable annotations changed; null means every page.
+  final Set<int>? annotationPages;
+
+  /// Whether page indices/geometry may have shifted across the document.
+  final bool pageStructureChanged;
+
+  /// Whether existing page content was irreversibly removed.
+  final bool destructive;
+}
+
+class _PdfEditImpactBuilder {
+  bool known = false;
+  Set<int>? visualPages = <int>{};
+  Set<int>? contentPages = <int>{};
+  Set<int>? annotationPages = <int>{};
+  bool pageStructureChanged = false;
+  bool destructive = false;
+
+  Set<int>? _merge(Set<int>? current, Iterable<int>? next) {
+    if (current == null || next == null) return null;
+    current.addAll(next);
+    return current;
+  }
+
+  void add({
+    Iterable<int>? visual = const <int>[],
+    Iterable<int>? content = const <int>[],
+    Iterable<int>? annotations = const <int>[],
+    bool structure = false,
+    bool removesContent = false,
+  }) {
+    known = true;
+    visualPages = _merge(visualPages, visual);
+    contentPages = _merge(contentPages, content);
+    annotationPages = _merge(annotationPages, annotations);
+    pageStructureChanged |= structure;
+    destructive |= removesContent;
+  }
+
+  PdfEditImpact build({required bool hasChanges}) {
+    if (!hasChanges) return PdfEditImpact.none;
+    if (!known) return PdfEditImpact.unknown;
+    return PdfEditImpact._(
+      visualPages:
+          visualPages == null ? null : Set<int>.unmodifiable(visualPages!),
+      contentPages:
+          contentPages == null ? null : Set<int>.unmodifiable(contentPages!),
+      annotationPages: annotationPages == null
+          ? null
+          : Set<int>.unmodifiable(annotationPages!),
+      pageStructureChanged: pageStructureChanged,
+      destructive: destructive,
+    );
+  }
+}
+
 /// High-level editing session over a [PdfDocument].
 ///
 /// Edits accumulate and [save] appends them as one incremental update, so
@@ -59,6 +196,7 @@ class PdfEditor {
 
   final PdfDocument document;
   final CosIncrementalUpdater _updater;
+  final _impact = _PdfEditImpactBuilder();
 
   /// Pages whose original content this session already wrapped in q/Q.
   final Set<CosDictionary> _wrappedPages = {};
@@ -75,6 +213,39 @@ class PdfEditor {
   PdfMeasure? _defaultMeasure;
 
   bool get hasChanges => _updater.hasChanges;
+
+  /// The rendering, sync, and structural consequences reported by the
+  /// mutations staged in this editor session.
+  ///
+  /// Uninstrumented mutations conservatively return [PdfEditImpact.unknown]
+  /// when they staged changes, preserving correctness while making missing
+  /// locality visible to tests and diagnostics.
+  PdfEditImpact get impact => _impact.build(hasChanges: hasChanges);
+
+  void _markMetadata({Iterable<int> annotationPages = const <int>[]}) =>
+      _impact.add(annotations: annotationPages);
+
+  void _markVisual(Iterable<int>? pages) => _impact.add(visual: pages);
+
+  void _markAnnotations(Iterable<int> pages, {bool visual = true}) =>
+      _impact.add(visual: visual ? pages : const <int>[], annotations: pages);
+
+  void _markContent(Iterable<int> pages) =>
+      _impact.add(visual: pages, content: pages);
+
+  void _markStructure() => _impact.add(
+        visual: null,
+        content: null,
+        annotations: null,
+        structure: true,
+      );
+
+  void _markDestructive([Iterable<int>? pages]) => _impact.add(
+        visual: pages,
+        content: pages,
+        annotations: pages,
+        removesContent: true,
+      );
 
   /// Updates document information entries. Null leaves an entry unchanged.
   void setInfo({
@@ -108,6 +279,7 @@ class PdfEditor {
     } else {
       _updater.setTrailerEntry('Info', _updater.addObject(dict));
     }
+    _markMetadata();
   }
 
   /// Adds [degrees] (a multiple of 90) to the page's display rotation.
@@ -119,6 +291,7 @@ class PdfEditor {
     final next = (page.rotation + degrees) % 360;
     page.dict['Rotate'] = CosInteger(next < 0 ? next + 360 : next);
     _updater.markChanged(page.dict);
+    _markContent([index]);
   }
 
   /// The full bytes of the edited file (original + incremental update).

--- a/packages/pdf_document/lib/src/form_admin.dart
+++ b/packages/pdf_document/lib/src/form_admin.dart
@@ -9,8 +9,12 @@ part of 'editor.dart';
 extension PdfFormAdmin on PdfEditor {
   /// Adds a single-widget text field named [name] on [pageIndex].
   /// The document gains an /AcroForm dictionary if it has none.
-  PdfFormField addTextField(int pageIndex, String name, PdfRect rect,
-      {bool multiline = false}) {
+  PdfFormField addTextField(
+    int pageIndex,
+    String name,
+    PdfRect rect, {
+    bool multiline = false,
+  }) {
     final dict = _newFieldDict('Tx', name, rect);
     if (multiline) dict['Ff'] = const CosInteger(PdfFormField.multilineFlag);
     return _installField(pageIndex, name, dict);
@@ -38,8 +42,10 @@ extension PdfFormAdmin on PdfEditor {
     // a blank normal appearance so viewers (and flattening) treat the
     // empty button as drawable rather than missing
     final rectangle = field.widgetRect(0)!;
-    _setNormalAppearance(field.dict,
-        _widgetForm(rectangle.width, rectangle.height, ContentWriter()));
+    _setNormalAppearance(
+      field.dict,
+      _widgetForm(rectangle.width, rectangle.height, ContentWriter()),
+    );
     _stageFormDict(field, field.dict);
     return field;
   }
@@ -65,11 +71,15 @@ extension PdfFormAdmin on PdfEditor {
     for (final other in field.form.fields) {
       if (!identical(other.dict, field.dict) && other.name == full) {
         throw ArgumentError.value(
-            newName, 'newName', 'another field is already named "$full"');
+          newName,
+          'newName',
+          'another field is already named "$full"',
+        );
       }
     }
     field.dict['T'] = CosString.fromText(newName);
     _stageFormDict(field, field.dict);
+    _markMetadata();
   }
 
   /// Removes [field] from the form and detaches its widgets from their
@@ -78,12 +88,23 @@ extension PdfFormAdmin on PdfEditor {
   void removeField(PdfFormField field) {
     final cos = document.cos;
     final widgets = field.widgets;
+    final pages = <int>{};
+    var unknownPage = false;
+    for (var i = 0; i < widgets.length; i++) {
+      final page = field.widgetPageIndex(i);
+      if (page < 0) {
+        unknownPage = true;
+      } else {
+        pages.add(page);
+      }
+    }
 
     // detach widgets from every page that lists them.
     for (var i = 0; i < document.pageCount; i++) {
       _PdfPageAnnotationList(this, i).removeWhere(
-          (_, resolved) => _isFieldWidget(resolved, field, widgets),
-          removeIfEmpty: true);
+        (_, resolved) => _isFieldWidget(resolved, field, widgets),
+        removeIfEmpty: true,
+      );
     }
 
     // pull the field node out of its parent /Kids or the form /Fields
@@ -109,10 +130,14 @@ extension PdfFormAdmin on PdfEditor {
         }
       }
     }
+    _markVisual(unknownPage ? null : pages);
   }
 
   static bool _isFieldWidget(
-      CosObject? annot, PdfFormField field, List<CosDictionary> widgets) {
+    CosObject? annot,
+    PdfFormField field,
+    List<CosDictionary> widgets,
+  ) {
     if (identical(annot, field.dict)) return true;
     for (final widget in widgets) {
       if (identical(widget, annot)) return true;
@@ -135,15 +160,20 @@ extension PdfFormAdmin on PdfEditor {
       PdfFieldType.pushButton,
     };
     if (!supported.contains(newType)) {
-      throw ArgumentError.value(newType, 'newType',
-          'only ${supported.map((t) => t.name).join('/')} are supported');
+      throw ArgumentError.value(
+        newType,
+        'newType',
+        'only ${supported.map((t) => t.name).join('/')} are supported',
+      );
     }
     if (field.type == newType) return field;
     final pageIndex = field.widgetPageIndex(0);
     final rect = field.widgetRect(0);
     if (pageIndex < 0 || rect == null) {
-      throw StateError('field "${field.name}" has no widget bound to a page - '
-          'cannot rebuild');
+      throw StateError(
+        'field "${field.name}" has no widget bound to a page - '
+        'cannot rebuild',
+      );
     }
     final name = field.name;
     removeField(field);
@@ -164,7 +194,11 @@ extension PdfFormAdmin on PdfEditor {
     if (form == null) return;
     for (var i = 0; i < document.pageCount; i++) {
       try {
-        _flattenAnnotations(i, (annot) => annot.subtype == 'Widget');
+        _flattenAnnotations(
+          i,
+          (annot) => annot.subtype == 'Widget',
+          syncAnnotations: false,
+        );
       } catch (_) {
         // a malformed page must not stop the rest of the form
       }
@@ -201,7 +235,10 @@ extension PdfFormAdmin on PdfEditor {
     final existing = acroForm?.fieldNamed(name);
     if (existing != null) {
       throw ArgumentError.value(
-          name, 'name', 'another field is already named "$name"');
+        name,
+        'name',
+        'another field is already named "$name"',
+      );
     }
     final page = document.page(pageIndex);
 
@@ -212,12 +249,14 @@ extension PdfFormAdmin on PdfEditor {
         'DA': CosString.fromText('/Helv 0 Tf 0 g'),
         'DR': CosDictionary({
           'Font': CosDictionary({
-            'Helv': _updater.addObject(CosDictionary({
-              'Type': const CosName('Font'),
-              'Subtype': const CosName('Type1'),
-              'BaseFont': const CosName('Helvetica'),
-              'Encoding': const CosName('WinAnsiEncoding'),
-            })),
+            'Helv': _updater.addObject(
+              CosDictionary({
+                'Type': const CosName('Font'),
+                'Subtype': const CosName('Type1'),
+                'BaseFont': const CosName('Helvetica'),
+                'Encoding': const CosName('WinAnsiEncoding'),
+              }),
+            ),
           }),
         }),
       });
@@ -228,8 +267,10 @@ extension PdfFormAdmin on PdfEditor {
     final ref = _updater.addObject(dict);
     // reassign rather than mutate, in case the arrays were indirect
     final fields = cos.resolve(formDict['Fields']);
-    formDict['Fields'] =
-        CosArray([if (fields is CosArray) ...fields.items, ref]);
+    formDict['Fields'] = CosArray([
+      if (fields is CosArray) ...fields.items,
+      ref,
+    ]);
 
     final pageRef = cos.referenceTo(page.dict);
     if (pageRef != null) dict['P'] = pageRef;
@@ -246,6 +287,7 @@ extension PdfFormAdmin on PdfEditor {
     if (field == null) {
       throw StateError('field "$name" failed to register');
     }
+    _markVisual([pageIndex]);
     return field;
   }
 }

--- a/packages/pdf_document/lib/src/form_editor.dart
+++ b/packages/pdf_document/lib/src/form_editor.dart
@@ -21,14 +21,19 @@ extension PdfFormFilling on PdfEditor {
   /// /V stores [value] verbatim (UTF-16BE when it leaves Latin-1); the
   /// generated appearance replaces characters the byte-encoded
   /// appearance fonts cannot show with spaces.
-  void setTextValue(PdfFormField field, String value,
-      {bool? multiline,
-      PdfTextDirection textDirection = PdfTextDirection.auto}) {
+  void setTextValue(
+    PdfFormField field,
+    String value, {
+    bool? multiline,
+    PdfTextDirection textDirection = PdfTextDirection.auto,
+  }) {
     _checkFillable(field, const {PdfFieldType.text});
     if (multiline != null && multiline != field.isMultiline) {
-      field.dict['Ff'] = CosInteger(multiline
-          ? field.flags | PdfFormField.multilineFlag
-          : field.flags & ~PdfFormField.multilineFlag);
+      field.dict['Ff'] = CosInteger(
+        multiline
+            ? field.flags | PdfFormField.multilineFlag
+            : field.flags & ~PdfFormField.multilineFlag,
+      );
     }
     field.dict['V'] = CosString.fromText(value);
     _regenerateVariableText(field, value, textDirection: textDirection);
@@ -41,8 +46,9 @@ extension PdfFormFilling on PdfEditor {
   /// widget's /MK background and border.
   void setButtonImage(PdfFormField field, PdfEmbeddableImage image) {
     _checkFillable(field, const {PdfFieldType.pushButton});
-    final imageRef = _updater
-        .addObject(image.toXObject((smask) => _updater.addObject(smask)));
+    final imageRef = _updater.addObject(
+      image.toXObject((smask) => _updater.addObject(smask)),
+    );
     for (final widget in field.widgets) {
       final rect = pdfRectFrom(document.cos, widget['Rect']);
       if (rect == null || rect.width <= 0 || rect.height <= 0) continue;
@@ -58,10 +64,14 @@ extension PdfFormFilling on PdfEditor {
         ..drawXObject('Img0')
         ..restore();
 
-      final form = _widgetForm(w, h, writer,
-          resources: CosDictionary({
-            'XObject': CosDictionary({'Img0': imageRef})
-          }));
+      final form = _widgetForm(
+        w,
+        h,
+        writer,
+        resources: CosDictionary({
+          'XObject': CosDictionary({'Img0': imageRef}),
+        }),
+      );
       _setNormalAppearance(widget, form);
       if (!identical(widget, field.dict)) _stageFormDict(field, widget);
     }
@@ -82,8 +92,11 @@ extension PdfFormFilling on PdfEditor {
   void setRadioValue(PdfFormField field, String onState) {
     _checkFillable(field, const {PdfFieldType.radioGroup});
     if (onState != 'Off' && !field.onStates.contains(onState)) {
-      throw ArgumentError.value(onState, 'onState',
-          'not an option of "${field.name}" (${field.onStates.join(', ')})');
+      throw ArgumentError.value(
+        onState,
+        'onState',
+        'not an option of "${field.name}" (${field.onStates.join(', ')})',
+      );
     }
     _selectButtonState(field, onState);
   }
@@ -107,10 +120,11 @@ extension PdfFormFilling on PdfEditor {
         field.flags & PdfFormField.editFlag != 0;
     if (index < 0 && options.isNotEmpty && !editable) {
       throw ArgumentError.value(
-          value,
-          'value',
-          'not an option of "${field.name}" '
-              '(${options.map((o) => o.$1).join(', ')})');
+        value,
+        'value',
+        'not an option of "${field.name}" '
+            '(${options.map((o) => o.$1).join(', ')})',
+      );
     }
     field.dict['V'] = CosString.fromText(export);
     if (field.type == PdfFieldType.listBox && index >= 0) {
@@ -276,12 +290,16 @@ extension PdfFormFilling on PdfEditor {
   /// emit '?'. /V keeps the original text.
   static String sanitizeFieldText(String text) {
     if (text.codeUnits.every((c) => c <= 0xFF)) return text;
-    return String.fromCharCodes(
-        [for (final c in text.codeUnits) c <= 0xFF ? c : 0x20]);
+    return String.fromCharCodes([
+      for (final c in text.codeUnits) c <= 0xFF ? c : 0x20,
+    ]);
   }
 
-  void _regenerateVariableText(PdfFormField field, String rawText,
-      {PdfTextDirection textDirection = PdfTextDirection.auto}) {
+  void _regenerateVariableText(
+    PdfFormField field,
+    String rawText, {
+    PdfTextDirection textDirection = PdfTextDirection.auto,
+  }) {
     final cos = document.cos;
     final da = _parseDefaultAppearance(field.defaultAppearance);
     final fontDict = _formFont(field.form, da.fontName);
@@ -394,7 +412,11 @@ extension PdfFormFilling on PdfEditor {
   /// Background and border from the widget's /MK appearance
   /// characteristics (§12.5.6.19), drawn in form space.
   void _paintWidgetDecorations(
-      ContentWriter writer, CosDictionary widget, double w, double h) {
+    ContentWriter writer,
+    CosDictionary widget,
+    double w,
+    double h,
+  ) {
     final cos = document.cos;
     final mk = cos.resolve(widget['MK']);
     if (mk is! CosDictionary) return;
@@ -457,8 +479,12 @@ extension PdfFormFilling on PdfEditor {
 
   /// A widget appearance form: BBox [0 0 w h], mapped onto /Rect by the
   /// §12.5.5 algorithm.
-  CosStream _widgetForm(double w, double h, ContentWriter content,
-      {CosDictionary? resources}) {
+  CosStream _widgetForm(
+    double w,
+    double h,
+    ContentWriter content, {
+    CosDictionary? resources,
+  }) {
     final bytes = content.takeBytes();
     final dict = CosDictionary({
       'Type': const CosName('XObject'),
@@ -493,7 +519,8 @@ extension PdfFormFilling on PdfEditor {
   /// Splits a /DA string into the font selection and the remaining
   /// (color) operators, replayed verbatim into the appearance.
   ({String fontName, double fontSize, String colorOps}) _parseDefaultAppearance(
-      String? da) {
+    String? da,
+  ) {
     final tokens =
         (da ?? '').split(RegExp(r'\s+')).where((t) => t.isNotEmpty).toList();
     var fontName = 'Helv';
@@ -530,7 +557,10 @@ extension PdfFormFilling on PdfEditor {
   /// is indirect, the dict itself when direct, or generated Helvetica as
   /// the lenient fallback for forms with broken /DR.
   CosDictionary _appearanceFontResource(
-      PdfAcroForm form, String name, CosDictionary? fontDict) {
+    PdfAcroForm form,
+    String name,
+    CosDictionary? fontDict,
+  ) {
     if (fontDict == null) return _helvetica(name: name);
     final ref = document.cos.referenceTo(fontDict);
     return CosDictionary({name: ref ?? fontDict});
@@ -567,8 +597,12 @@ extension PdfFormFilling on PdfEditor {
 
   /// Greedy word wrap using [measure]; a single overlong word overflows
   /// (and is clipped by the appearance).
-  List<String> _wrapWith(double Function(String, double) measure, String text,
-      double fontSize, double maxWidth) {
+  List<String> _wrapWith(
+    double Function(String, double) measure,
+    String text,
+    double fontSize,
+    double maxWidth,
+  ) {
     final lines = <String>[];
     for (final paragraph in text.split('\n')) {
       var line = '';
@@ -592,8 +626,9 @@ extension PdfFormFilling on PdfEditor {
   void _checkFillable(PdfFormField field, Set<PdfFieldType> expected) {
     if (!expected.contains(field.type)) {
       throw ArgumentError(
-          'field "${field.name}" is a ${field.type.name}, expected '
-          '${expected.map((t) => t.name).join(' or ')}');
+        'field "${field.name}" is a ${field.type.name}, expected '
+        '${expected.map((t) => t.name).join(' or ')}',
+      );
     }
     if (field.isReadOnly) {
       throw StateError('field "${field.name}" is read-only');
@@ -601,6 +636,16 @@ extension PdfFormFilling on PdfEditor {
   }
 
   void _finishFieldEdit(PdfFormField field) {
+    final pages = <int>{};
+    var unknownPage = false;
+    for (var i = 0; i < field.widgets.length; i++) {
+      final page = field.widgetPageIndex(i);
+      if (page < 0) {
+        unknownPage = true;
+      } else {
+        pages.add(page);
+      }
+    }
     // A reconciled field holds its canonical value on the /Fields dict we
     // just wrote; the adopted page widgets may still carry the producer's
     // stale /V, which would otherwise shadow it on read-back. Drop it so
@@ -617,6 +662,7 @@ extension PdfFormFilling on PdfEditor {
       form.dict['NeedAppearances'] = const CosBoolean(false);
       _stageFormDict(field, form.dict);
     }
+    _markVisual(unknownPage ? null : pages);
   }
 
   /// Stages the first indirect object whose serialization carries

--- a/packages/pdf_document/lib/src/ocr_editor.dart
+++ b/packages/pdf_document/lib/src/ocr_editor.dart
@@ -95,7 +95,7 @@ extension PdfOcrEditing on PdfEditor {
         ..endText();
     }
     writer.restore();
-    _appendContent(page, writer.takeBytes());
+    _appendContent(pageIndex, page, writer.takeBytes());
     return accepted.length;
   }
 
@@ -110,8 +110,9 @@ extension PdfOcrEditing on PdfEditor {
     if (existing is CosDictionary && resources['Font'] is! CosReference) {
       fonts = existing;
     } else {
-      fonts =
-          CosDictionary({if (existing is CosDictionary) ...existing.entries});
+      fonts = CosDictionary({
+        if (existing is CosDictionary) ...existing.entries,
+      });
       resources['Font'] = fonts;
     }
 

--- a/packages/pdf_document/lib/src/outline_editor.dart
+++ b/packages/pdf_document/lib/src/outline_editor.dart
@@ -47,7 +47,8 @@ extension PdfOutlineEditing on PdfEditor {
     _outlineOpenOverride[itemRef.objectNumber] = open;
 
     final siblings = _outlineChildren(parentRef);
-    final at = index == null ? siblings.length : index.clamp(0, siblings.length);
+    final at =
+        index == null ? siblings.length : index.clamp(0, siblings.length);
     siblings.insert(at, itemRef);
     _relinkOutlineChildren(parentRef, siblings);
     _recountOutline(rootRef);
@@ -60,8 +61,7 @@ extension PdfOutlineEditing on PdfEditor {
   void removeOutlineItem(CosReference item) {
     final dict = _outlineDict(item);
     final parentRef = _outlineParentRef(dict) ?? _ensureOutlineRoot();
-    final siblings = _outlineChildren(parentRef)
-      ..removeWhere((r) => r == item);
+    final siblings = _outlineChildren(parentRef)..removeWhere((r) => r == item);
     _relinkOutlineChildren(parentRef, siblings);
     _recountOutline(_ensureOutlineRoot());
   }
@@ -69,8 +69,7 @@ extension PdfOutlineEditing on PdfEditor {
   /// Moves [item] (and its subtree) under [parent] (null = top level) at
   /// [index] among the destination's children (null appends). Throws if
   /// [parent] is [item] itself or one of its descendants.
-  void moveOutlineItem(CosReference item,
-      {CosReference? parent, int? index}) {
+  void moveOutlineItem(CosReference item, {CosReference? parent, int? index}) {
     final rootRef = _ensureOutlineRoot();
     final dict = _outlineDict(item);
     final newParentRef = parent ?? rootRef;
@@ -82,14 +81,16 @@ extension PdfOutlineEditing on PdfEditor {
     if (oldParentRef == newParentRef) {
       final siblings = _outlineChildren(oldParentRef)
         ..removeWhere((r) => r == item);
-      final at = index == null ? siblings.length : index.clamp(0, siblings.length);
+      final at =
+          index == null ? siblings.length : index.clamp(0, siblings.length);
       siblings.insert(at, item);
       _relinkOutlineChildren(newParentRef, siblings);
     } else {
       final old = _outlineChildren(oldParentRef)..removeWhere((r) => r == item);
       _relinkOutlineChildren(oldParentRef, old);
       final siblings = _outlineChildren(newParentRef);
-      final at = index == null ? siblings.length : index.clamp(0, siblings.length);
+      final at =
+          index == null ? siblings.length : index.clamp(0, siblings.length);
       siblings.insert(at, item);
       _relinkOutlineChildren(newParentRef, siblings);
     }
@@ -105,7 +106,9 @@ extension PdfOutlineEditing on PdfEditor {
 
   /// Points [item] at [destination].
   void setOutlineDestination(
-      CosReference item, PdfExplicitDestination destination) {
+    CosReference item,
+    PdfExplicitDestination destination,
+  ) {
     final dict = _outlineDict(item);
     dict['Dest'] = _outlineDestArray(destination);
     dict.entries.remove('A'); // an explicit /Dest supersedes a /GoTo action
@@ -214,7 +217,9 @@ extension PdfOutlineEditing on PdfEditor {
   /// Rewrites a parent's First/Last and every child's Prev/Next/Parent from
   /// the ordered [children] list, staging all of them.
   void _relinkOutlineChildren(
-      CosReference parentRef, List<CosReference> children) {
+    CosReference parentRef,
+    List<CosReference> children,
+  ) {
     final parent = _outlineDict(parentRef);
     if (children.isEmpty) {
       parent.entries.remove('First');
@@ -280,8 +285,10 @@ extension PdfOutlineEditing on PdfEditor {
     return true;
   }
 
-  void _stageOutline(CosReference ref, CosDictionary dict) =>
-      _updater.replaceObject(ref.objectNumber, dict);
+  void _stageOutline(CosReference ref, CosDictionary dict) {
+    _updater.replaceObject(ref.objectNumber, dict);
+    _markMetadata();
+  }
 
   CosArray _outlineDestArray(PdfExplicitDestination dest) =>
       dest.toCosArray(_pageReference(dest.pageIndex));

--- a/packages/pdf_document/lib/src/page_editor.dart
+++ b/packages/pdf_document/lib/src/page_editor.dart
@@ -26,7 +26,10 @@ extension PdfPageOperations on PdfEditor {
         {...order}.length != count ||
         order.any((i) => i < 0 || i >= count)) {
       throw ArgumentError.value(
-          order, 'order', 'must be a permutation of 0..${count - 1}');
+        order,
+        'order',
+        'must be a permutation of 0..${count - 1}',
+      );
     }
     final leaves = _materializedLeaves();
     _rebuildPageTree([for (final i in order) leaves[i]]);
@@ -49,8 +52,10 @@ extension PdfPageOperations on PdfEditor {
       throw ArgumentError('cannot remove every page of a document');
     }
     final leaves = _materializedLeaves();
-    _rebuildPageTree(
-        [for (var i = 0; i < count; i++) if (!doomed.contains(i)) leaves[i]]);
+    _rebuildPageTree([
+      for (var i = 0; i < count; i++)
+        if (!doomed.contains(i)) leaves[i],
+    ]);
   }
 
   /// Rotates the pages at [indices] clockwise by [degrees] (a multiple of
@@ -60,8 +65,7 @@ extension PdfPageOperations on PdfEditor {
   /// page dictionary (so it overrides any value inherited from an ancestor).
   void rotatePages(Iterable<int> indices, int degrees) {
     if (degrees % 90 != 0) {
-      throw ArgumentError.value(
-          degrees, 'degrees', 'must be a multiple of 90');
+      throw ArgumentError.value(degrees, 'degrees', 'must be a multiple of 90');
     }
     final count = document.pageCount;
     final targets = {...indices};
@@ -78,6 +82,7 @@ extension PdfPageOperations on PdfEditor {
       _updater.markChanged(dict);
     }
     document.invalidatePageCache();
+    _markContent(targets);
   }
 
   /// Inserts a new blank page [at] the given index (default: appended at
@@ -101,7 +106,8 @@ extension PdfPageOperations on PdfEditor {
     });
     final ref = _updater.addObject(dict);
     _rebuildPageTree(
-        [...leaves]..insert(insertAt, _Leaf(ref, dict, isNew: true)));
+      [...leaves]..insert(insertAt, _Leaf(ref, dict, isNew: true)),
+    );
   }
 
   /// Copies pages from [source] into this document - all of them, or the
@@ -115,11 +121,12 @@ extension PdfPageOperations on PdfEditor {
   /// document along).
   void appendPagesFrom(PdfDocument source, {List<int>? indices, int? at}) {
     if (identical(source.cos, document.cos)) {
-      throw ArgumentError('source is this document; '
-          'use movePage/reorderPages to rearrange within a file');
+      throw ArgumentError(
+        'source is this document; '
+        'use movePage/reorderPages to rearrange within a file',
+      );
     }
-    final picks =
-        indices ?? [for (var i = 0; i < source.pageCount; i++) i];
+    final picks = indices ?? [for (var i = 0; i < source.pageCount; i++) i];
     for (final i in picks) {
       RangeError.checkValidIndex(i, null, 'indices', source.pageCount);
     }
@@ -137,9 +144,7 @@ extension PdfPageOperations on PdfEditor {
   /// about to cut those ancestors out of the tree.
   List<_Leaf> _materializedLeaves() {
     final count = document.pageCount;
-    return [
-      for (var i = 0; i < count; i++) _materialize(document.page(i)),
-    ];
+    return [for (var i = 0; i < count; i++) _materialize(document.page(i))];
   }
 
   _Leaf _materialize(PdfPage page) {
@@ -185,6 +190,7 @@ extension PdfPageOperations on PdfEditor {
     root['Count'] = CosInteger(leaves.length);
     _updater.markChanged(root);
     document.invalidatePageCache();
+    _markStructure();
   }
 
   CosReference _pagesRootRef() {
@@ -228,10 +234,9 @@ extension PdfPageExtraction on PdfDocument {
     }
     pagesDict['Kids'] = CosArray([for (final leaf in leaves) leaf.ref]);
     pagesDict['Count'] = CosInteger(leaves.length);
-    final catalogRef = builder.add(CosDictionary({
-      'Type': const CosName('Catalog'),
-      'Pages': pagesRef,
-    }));
+    final catalogRef = builder.add(
+      CosDictionary({'Type': const CosName('Catalog'), 'Pages': pagesRef}),
+    );
     CosReference? infoRef;
     final info = cos.resolve(cos.trailer['Info']);
     if (info is CosDictionary) {
@@ -241,9 +246,8 @@ extension PdfPageExtraction on PdfDocument {
     return builder.build(
       root: catalogRef,
       info: infoRef,
-      version: RegExp(r'^\d+\.\d+$').hasMatch(headerVersion)
-          ? headerVersion
-          : '1.7',
+      version:
+          RegExp(r'^\d+\.\d+$').hasMatch(headerVersion) ? headerVersion : '1.7',
     );
   }
 
@@ -345,8 +349,7 @@ class _PageImporter {
       case CosArray array:
         return CosArray([for (final item in array.items) copyValue(item)]);
       case CosString string:
-        return CosString(Uint8List.fromList(string.bytes),
-            isHex: string.isHex);
+        return CosString(Uint8List.fromList(string.bytes), isHex: string.isHex);
       default:
         return value; // names, numbers, booleans, null are immutable
     }
@@ -399,8 +402,7 @@ class _PageImporter {
     final filter = cos.resolve(stream.dictionary['Filter']);
     final first = switch (filter) {
       CosName(:final value) => value,
-      CosArray array when array.length > 0 =>
-        switch (cos.resolve(array[0])) {
+      CosArray array when array.length > 0 => switch (cos.resolve(array[0])) {
           CosName(:final value) => value,
           _ => null,
         },

--- a/packages/pdf_document/lib/src/redaction.dart
+++ b/packages/pdf_document/lib/src/redaction.dart
@@ -47,6 +47,7 @@ extension PdfRedactionApply on PdfEditor {
     }
     // No marks anywhere: keep any other staged edits as an incremental save.
     if (burned == 0) return save();
+    _markDestructive(pages);
     return _compactedSave();
   }
 
@@ -58,8 +59,9 @@ extension PdfRedactionApply on PdfEditor {
     final cos = document.cos;
     if (cos.encryption != null) {
       throw UnsupportedError(
-          'applyRedactions cannot compact an encrypted document; decrypt it '
-          'before redacting');
+        'applyRedactions cannot compact an encrypted document; decrypt it '
+        'before redacting',
+      );
     }
     final rootRef = cos.trailer['Root'];
     if (rootRef is! CosReference) {
@@ -128,8 +130,9 @@ extension PdfRedactionApply on PdfEditor {
 
     final builder = CosDocumentBuilder();
     for (final number in order) {
-      builder
-          .add(remap(cos.resolve(CosReference(number, generation[number]!))));
+      builder.add(
+        remap(cos.resolve(CosReference(number, generation[number]!))),
+      );
     }
     return builder.build(
       root: CosReference(newNumber[rootRef.objectNumber]!, 0),
@@ -171,18 +174,20 @@ extension PdfRedactionApply on PdfEditor {
       ..add(burned)
       ..add(latin1.encode('\nQ\n'))
       ..add(fill);
-    _setContent(page, rebuilt.takeBytes());
+    _setContent(pageIndex, page, rebuilt.takeBytes());
 
     // 3. Drop the /Redact annotations and scrub any annotation whose
     //    appearance is fully under a redaction region (it would leak the
     //    content the rect is meant to hide).
-    _PdfPageAnnotationList(this, pageIndex).removeWhere((_, resolved) {
+    final annotationsChanged =
+        _PdfPageAnnotationList(this, pageIndex).removeWhere((_, resolved) {
       if (resolved is! CosDictionary) return false;
       final subtype = cos.resolve(resolved['Subtype']);
       if (subtype is CosName && subtype.value == 'Redact') return true;
       final r = pdfRectFrom(cos, resolved['Rect']);
       return r != null && _rectFullyCovered(r, regions);
     });
+    if (annotationsChanged) _markAnnotations([pageIndex], visual: false);
     return true;
   }
 
@@ -202,21 +207,25 @@ extension PdfRedactionApply on PdfEditor {
       final v = <double>[];
       for (final n in quads.items) {
         final r = cos.resolve(n);
-        v.add(r is CosInteger
-            ? r.value.toDouble()
-            : r is CosReal
-                ? r.value
-                : 0);
+        v.add(
+          r is CosInteger
+              ? r.value.toDouble()
+              : r is CosReal
+                  ? r.value
+                  : 0,
+        );
       }
       for (var i = 0; i + 7 < v.length; i += 8) {
         final xs = [v[i], v[i + 2], v[i + 4], v[i + 6]];
         final ys = [v[i + 1], v[i + 3], v[i + 5], v[i + 7]];
-        rects.add(PdfRect(
-          xs.reduce(math.min),
-          ys.reduce(math.min),
-          xs.reduce(math.max),
-          ys.reduce(math.max),
-        ));
+        rects.add(
+          PdfRect(
+            xs.reduce(math.min),
+            ys.reduce(math.min),
+            xs.reduce(math.max),
+            ys.reduce(math.max),
+          ),
+        );
       }
     }
     if (rects.isEmpty) {
@@ -419,8 +428,9 @@ class _RedactionBurn {
     final operands = op.operands;
     switch (op.operator) {
       case 'q':
-        _gsStack.add(_RedGraphicsState(
-            _ctm, _tfs, _tc, _tw, _th, _tl, _trise, _fontName));
+        _gsStack.add(
+          _RedGraphicsState(_ctm, _tfs, _tc, _tw, _th, _tl, _trise, _fontName),
+        );
         _writeOp(op, out);
         return;
       case 'Q':
@@ -445,7 +455,7 @@ class _RedactionBurn {
             _n(operands[2]),
             _n(operands[3]),
             _n(operands[4]),
-            _n(operands[5])
+            _n(operands[5]),
           ), _ctm);
         }
         _writeOp(op, out);
@@ -532,9 +542,12 @@ class _RedactionBurn {
         }
         _tlm = _redMul((1, 0, 0, 1, 0, -_tl), _tlm);
         _tm = _tlm;
-        _showText(op, out,
-            prefix: '${ContentWriter.fmt(_tw)} Tw '
-                '${ContentWriter.fmt(_tc)} Tc T*\n');
+        _showText(
+          op,
+          out,
+          prefix: '${ContentWriter.fmt(_tw)} Tw '
+              '${ContentWriter.fmt(_tc)} Tc T*\n',
+        );
         return;
       case 'TJ':
         _showText(op, out);
@@ -813,8 +826,13 @@ class _RedactionBurn {
 
 /// The glyph metrics a redaction burn needs from one font.
 class _RedFont {
-  _RedFont._(this.isComposite, this._firstChar, this._widths, this._fallback,
-      this.defaultWidth);
+  _RedFont._(
+    this.isComposite,
+    this._firstChar,
+    this._widths,
+    this._fallback,
+    this.defaultWidth,
+  );
 
   final bool isComposite;
   final int _firstChar;
@@ -854,7 +872,7 @@ class _RedFont {
             CosInteger(:final value) => value.toDouble(),
             CosReal(:final value) => value,
             _ => 0.0,
-          }
+          },
       ];
     }
     return _RedFont._(false, firstChar, widths, fallback, 500);
@@ -883,8 +901,16 @@ class _RedFont {
 }
 
 class _RedGraphicsState {
-  _RedGraphicsState(this.ctm, this.tfs, this.tc, this.tw, this.th, this.tl,
-      this.trise, this.fontName);
+  _RedGraphicsState(
+    this.ctm,
+    this.tfs,
+    this.tc,
+    this.tw,
+    this.th,
+    this.tl,
+    this.trise,
+    this.fontName,
+  );
 
   final _RedMatrix ctm;
   final double tfs;

--- a/packages/pdf_document/test/edit_impact_test.dart
+++ b/packages/pdf_document/test/edit_impact_test.dart
@@ -1,0 +1,94 @@
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PdfEditImpact', () {
+    test('annotation creation reports visual and sync impact only', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(3)))
+        ..addSquare(1, const PdfRect(100, 100, 200, 200));
+
+      expect(editor.impact.visualPages, {1});
+      expect(editor.impact.contentPages, isEmpty);
+      expect(editor.impact.annotationPages, {1});
+      expect(editor.impact.pageStructureChanged, isFalse);
+      expect(editor.impact.destructive, isFalse);
+    });
+
+    test('annotation metadata reports sync impact without repainting', () {
+      final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
+        ..addSquare(0, const PdfRect(100, 100, 200, 200));
+      final document = PdfDocument.open(first.save());
+      final annotation = document.page(0).annotations.single;
+      final editor = PdfEditor(document)
+        ..setAnnotationAuthor(0, annotation, 'Ben');
+
+      expect(editor.impact.visualPages, isEmpty);
+      expect(editor.impact.contentPages, isEmpty);
+      expect(editor.impact.annotationPages, {0});
+    });
+
+    test('page content reports base raster impact without annotation diff', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(2)))
+        ..stampPage(1, (stamp) => stamp.text('impact', x: 10, y: 10));
+
+      expect(editor.impact.visualPages, {1});
+      expect(editor.impact.contentPages, {1});
+      expect(editor.impact.annotationPages, isEmpty);
+    });
+
+    test('multiple mutations merge their page sets', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(3)))
+        ..addSquare(0, const PdfRect(10, 10, 20, 20))
+        ..addCircle(2, const PdfRect(30, 30, 50, 50));
+
+      expect(editor.impact.visualPages, {0, 2});
+      expect(editor.impact.contentPages, isEmpty);
+      expect(editor.impact.annotationPages, {0, 2});
+    });
+
+    test('page-tree edits report document-wide structural impact', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(3)))
+        ..movePage(0, 2);
+
+      expect(editor.impact.visualPages, isNull);
+      expect(editor.impact.contentPages, isNull);
+      expect(editor.impact.annotationPages, isNull);
+      expect(editor.impact.pageStructureChanged, isTrue);
+    });
+
+    test('form filling reports widget repaint without content invalidation',
+        () {
+      final editor = PdfEditor(PdfDocument.open(buildAcroFormPdf()));
+      final field = editor.acroForm!.fieldNamed('name')!;
+      editor.setTextValue(field, 'Impact');
+
+      expect(editor.impact.visualPages, {0});
+      expect(editor.impact.contentPages, isEmpty);
+      expect(editor.impact.annotationPages, isEmpty);
+    });
+
+    test('outline edits report metadata-only impact', () {
+      final editor = PdfEditor(PdfDocument.open(buildClassicPdf()))
+        ..addOutlineItem('Start', pageIndex: 0);
+
+      expect(editor.impact.visualPages, isEmpty);
+      expect(editor.impact.contentPages, isEmpty);
+      expect(editor.impact.annotationPages, isEmpty);
+    });
+
+    test('redaction burn is destructive without claiming structure change', () {
+      final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
+        ..addRedaction(0, const [PdfRect(60, 715, 200, 748)]);
+      final editor = PdfEditor(PdfDocument.open(first.save()));
+
+      editor.applyRedactions();
+
+      expect(editor.impact.visualPages, {0});
+      expect(editor.impact.contentPages, {0});
+      expect(editor.impact.annotationPages, {0});
+      expect(editor.impact.destructive, isTrue);
+      expect(editor.impact.pageStructureChanged, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #252.

## What changed

- Adds `PdfEditImpact` as the single mutation report produced by `PdfEditor`.
- Moves visual/content/annotation/structure/destructive attribution into the document mutation layer.
- Makes `PdfEditingController` consume that report for page render stamps, content cache invalidation, annotation sync diffs, destructive epochs, selection validation, undo, and redo.
- Retains the old `pages` / `contentPages` hints as a source-compatible fallback for external callers.
- Adds focused transaction tests and impact attribution tests.

## Performance

No extra document parse/save pass is added. Annotation diffs still reopen the prior revision only when the change stream has a listener, and metadata-only mutations avoid page render invalidation.

Paired local microbenchmarks (median microseconds, baseline → branch):

| path | baseline | branch |
|---|---:|---:|
| annotation commit | 316 | 310 |
| metadata commit | 94 | 93 |
| undo/redo | 103 | 106 |
| structural edit | 58 | 62 |

Repeated runs stayed within normal process noise; no material regression was observed.

## Verification

- `fvm dart analyze` (only the 6 pre-existing style infos)
- `packages/pdf_document: fvm dart test` — 624 passed, 1 skipped
- `packages/dart_pdf_editor: fvm flutter test` — 1,377 passed, 31 skipped
- New edit-impact and controller transaction regression tests
