### PR TITLE
Centralize annotation behavior and capability policy

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/annotation_presentation.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/annotation_presentation.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Flutter-only presentation for PDF annotation subtypes.
+///
+/// Semantic editing policy lives in `PdfAnnotation.behavior` in
+/// pdf_document; Material names and icons stay above the Flutter boundary.
+String pdfAnnotationLabel(String subtype) => switch (subtype) {
+      'StrikeOut' => 'Strike-out',
+      'FreeText' => 'Text box',
+      'Text' => 'Note',
+      'Widget' => 'Form field',
+      _ => subtype,
+    };
+
+IconData pdfAnnotationIcon(String subtype) => switch (subtype) {
+      'Highlight' => Icons.border_color,
+      'Underline' => Icons.format_underlined,
+      'StrikeOut' => Icons.format_strikethrough,
+      'Squiggly' => Icons.gesture,
+      'Ink' => Icons.draw,
+      'Square' => Icons.rectangle_outlined,
+      'Circle' => Icons.circle_outlined,
+      'FreeText' => Icons.text_fields,
+      'Text' => Icons.sticky_note_2_outlined,
+      'Stamp' => Icons.approval,
+      'Link' => Icons.link,
+      'Widget' => Icons.input,
+      'FileAttachment' => Icons.attach_file,
+      _ => Icons.bookmark_border,
+    };

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2976,27 +2976,6 @@ class PdfEditingController extends ChangeNotifier {
   // ---------------------------------------------------------------------
   // selection
 
-  /// Annotation subtypes the select tool ignores: popups belong to their
-  /// parent, links and widgets are interactive objects with their own
-  /// semantics (widgets are form fields - moving one breaks its field).
-  static const _unselectable = {'Popup', 'Link', 'Widget'};
-
-  /// Subtypes whose geometry is defined by /Rect (plus point arrays the
-  /// editor rescales), so resizing keeps them consistent everywhere.
-  static const _resizable = {
-    'Square',
-    'Circle',
-    'FreeText',
-    'Stamp',
-    'Ink',
-    'Line',
-    'PolyLine',
-    'Polygon',
-  };
-
-  /// Subtypes whose text the controller can rewrite in place.
-  static const _textEditable = {'FreeText', 'Stamp', 'Text'};
-
   PdfAnnotationEditPredicate? _canEditAnnotation;
 
   /// Host veto over which annotations the editing UI may change.
@@ -3129,19 +3108,18 @@ class PdfEditingController extends ChangeNotifier {
   /// editor regenerates their appearance at the new size).
   bool get canResizeSelected =>
       _selected.length == 1 &&
-      (_resizable.contains(selectedAnnotation?.subtype) ||
+      (selectedAnnotation?.behavior.resizable == true ||
           (tool == PdfEditTool.form &&
               selectedAnnotation?.subtype == 'Widget'));
 
   /// Rotation rides the appearance stream's /Matrix, so it needs one.
   bool get canRotateSelected =>
       _selected.length == 1 &&
-      _resizable.contains(selectedAnnotation?.subtype) &&
-      selectedAnnotation?.normalAppearance != null;
+      selectedAnnotation?.behavior.rotatable == true;
 
   bool get canEditSelectedText =>
       _selected.length == 1 &&
-      _textEditable.contains(selectedAnnotation?.subtype) &&
+      selectedAnnotation?.behavior.textEditable == true &&
       selectedAnnotation?.isLockedContents != true;
 
   /// The topmost selectable annotation under ([x], [y]) on [pageIndex],
@@ -3153,7 +3131,7 @@ class PdfEditingController extends ChangeNotifier {
     for (var i = annotations.length - 1; i >= 0; i--) {
       final annotation = annotations[i];
       if (annotation.isHidden ||
-          _unselectable.contains(annotation.subtype) ||
+          !annotation.behavior.selectable ||
           !isAnnotationEditable(annotation)) {
         continue;
       }
@@ -3305,7 +3283,7 @@ class PdfEditingController extends ChangeNotifier {
     for (var i = 0; i < annotations.length; i++) {
       final annotation = annotations[i];
       if (annotation.isHidden ||
-          _unselectable.contains(annotation.subtype) ||
+          !annotation.behavior.selectable ||
           !isAnnotationEditable(annotation)) {
         continue;
       }
@@ -3349,7 +3327,7 @@ class PdfEditingController extends ChangeNotifier {
   bool selectAnnotation(int pageIndex, int index) {
     final annotation = _annotationAt((pageIndex, index));
     if (annotation == null ||
-        _unselectable.contains(annotation.subtype) ||
+        !annotation.behavior.selectable ||
         !isAnnotationEditable(annotation)) {
       return false;
     }
@@ -3832,7 +3810,7 @@ class PdfEditingController extends ChangeNotifier {
       _selected.isNotEmpty &&
       _selected.every((slot) {
         final annotation = _annotationAt(slot);
-        return annotation != null && pdfCanRestyleAnnotation(annotation);
+        return annotation?.behavior.canRestyle == true;
       });
 
   /// The primary selected annotation's current style, for style controls
@@ -3843,32 +3821,26 @@ class PdfEditingController extends ChangeNotifier {
       get selectedAnnotationStyle {
     final annotation = selectedAnnotation;
     if (annotation == null) return null;
-    final rgb = annotation.subtype == 'FreeText'
-        ? annotation.freeTextStyle?.color ?? annotation.color
-        : annotation.color;
+    final style = annotation.behavior.style;
     return (
-      color: Color(0xFF000000 | (rgb ?? 0)),
-      strokeWidth: annotation.borderWidth,
-      opacity: annotation.appearanceOpacity,
+      color: Color(0xFF000000 | (style.color ?? 0)),
+      strokeWidth: style.strokeWidth,
+      opacity: style.opacity,
     );
   }
 
-  /// Whether every selected annotation is a fillable shape (Square,
-  /// Circle, or Polygon) - i.e. [restyleSelected]'s `fill` parameter
-  /// applies to the whole selection.
+  /// Whether [restyleSelected]'s `fill` parameter applies to every selected
+  /// annotation (shapes and FreeText boxes).
   bool get canFillSelected =>
       canRestyleSelected &&
       _selected.every((slot) {
-        final subtype = _annotationAt(slot)?.subtype;
-        return subtype == 'Square' ||
-            subtype == 'Circle' ||
-            subtype == 'Polygon';
+        return _annotationAt(slot)?.behavior.supportsFill == true;
       });
 
-  /// The primary selected shape's interior fill, or null when it has none
-  /// (or the selection isn't a shape). For the fill control to display.
+  /// The primary selected annotation's interior/background fill, or null
+  /// when it has none. For the fill control to display.
   Color? get selectedShapeFill {
-    final rgb = selectedAnnotation?.interiorColor;
+    final rgb = selectedAnnotation?.behavior.style.fillColor;
     return rgb == null ? null : Color(0xFF000000 | rgb);
   }
 
@@ -3877,12 +3849,7 @@ class PdfEditingController extends ChangeNotifier {
   bool get canSetLineStyleSelected =>
       canRestyleSelected &&
       _selected.every((slot) {
-        final subtype = _annotationAt(slot)?.subtype;
-        return subtype == 'Square' ||
-            subtype == 'Circle' ||
-            subtype == 'Line' ||
-            subtype == 'PolyLine' ||
-            subtype == 'Polygon';
+        return _annotationAt(slot)?.behavior.supportsLineStyle == true;
       });
 
   /// The primary selected annotation's border line style (for the line-type
@@ -3890,8 +3857,7 @@ class PdfEditingController extends ChangeNotifier {
   PdfLineStyle? get selectedLineStyle {
     final annotation = selectedAnnotation;
     if (annotation == null) return null;
-    const styled = {'Square', 'Circle', 'Line', 'PolyLine', 'Polygon'};
-    if (!styled.contains(annotation.subtype)) return null;
+    if (!annotation.behavior.supportsLineStyle) return null;
     return PdfLineStyle.ofDashArray(annotation.borderDash);
   }
 
@@ -4206,10 +4172,7 @@ class PdfEditingController extends ChangeNotifier {
   /// Polygon annotation. The selection keeps its /Annots slot.
   void reshapeSelectedLine(List<(double, double)> points) {
     final annotation = selectedAnnotation;
-    if (annotation == null ||
-        annotation.subtype != 'Line' &&
-            annotation.subtype != 'PolyLine' &&
-            annotation.subtype != 'Polygon') {
+    if (annotation == null || !annotation.behavior.lineFamily) {
       return;
     }
     apply((e) => e.reshapeLineAnnotation(_selected.last.$1, annotation, points),
@@ -4222,7 +4185,7 @@ class PdfEditingController extends ChangeNotifier {
     final annotation = selectedAnnotation;
     return _selected.length == 1 &&
         annotation != null &&
-        (annotation.subtype == 'Line' || annotation.subtype == 'PolyLine') &&
+        annotation.behavior.supportsLineEndings &&
         annotation.normalAppearance != null;
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -566,6 +566,7 @@ typedef _ShapeResize = ({
   Color? stroke,
   double strokeWidth,
   Color? fill,
+  List<double>? dashPattern,
   double rotation,
   double opacity,
 });
@@ -1357,8 +1358,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   bool get _selectedLineFamily {
-    final subtype = _controller.selectedAnnotation?.subtype;
-    return subtype == 'Line' || subtype == 'PolyLine' || subtype == 'Polygon';
+    return _controller.selectedAnnotation?.behavior.lineFamily == true;
   }
 
   PdfEditTool? get _selectedLineTool {
@@ -1728,14 +1728,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       get _textResizeStyle {
     final annotation = _controller.selectedAnnotation;
     if (annotation == null ||
-        annotation.subtype != 'FreeText' ||
-        annotation.normalAppearance == null) {
+        annotation.behavior.resizeBehavior !=
+            PdfAnnotationResizeBehavior.reflowText) {
       return null;
     }
-    final parsed = annotation.freeTextStyle;
-    final font =
-        parsed == null ? null : PdfStandardFont.tryFromName(parsed.fontName);
-    if (parsed == null || font == null) return null;
+    final parsed = annotation.behavior.style.freeText!;
+    final font = annotation.behavior.standardTextFont!;
     return (
       text: annotation.contents ?? '',
       font: font,
@@ -1750,7 +1748,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// The selected annotation's style when a resize commit will
   /// REGENERATE it (Square/Circle) at a constant stroke width - the
   /// editor's shape regenerate path: an /AP to replace, no cloudy /BE,
-  /// no dashed border, and a stroke or fill to draw. [strokeWidth] is in
+  /// and a stroke or fill to draw. Dashed borders carry their exact /BS /D
+  /// pattern into the preview. [strokeWidth] is in
   /// view pixels (the page-space border width scaled), so the preview
   /// reads at the same weight the commit will, instead of the ghost's
   /// stretched line. Null leaves the drag on the stretch ghost.
@@ -1760,26 +1759,28 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   _ShapeResize? _shapeResizeStyle(Rect rect, double rotation) {
     final annotation = _controller.selectedAnnotation;
     if (annotation == null ||
-        (annotation.subtype != 'Square' && annotation.subtype != 'Circle') ||
-        annotation.normalAppearance == null) {
+        annotation.behavior.resizeBehavior !=
+            PdfAnnotationResizeBehavior.regenerateShape) {
       return null;
     }
-    // cloudy and dashed borders fall back to the stretch path in the editor
-    if (annotation.dict['BE'] != null || annotation.borderDash != null) {
-      return null;
-    }
-    final width = annotation.borderWidth ?? 1;
-    final stroke = width > 0 ? annotation.color : null;
-    final fill = annotation.interiorColor;
-    if (stroke == null && fill == null) return null;
+    final style = annotation.behavior.style;
+    final width = style.strokeWidth ?? 1;
+    final stroke = width > 0 ? style.color : null;
+    final fill = style.fillColor;
     return (
       rect: rect,
       ellipse: annotation.subtype == 'Circle',
       stroke: stroke == null ? null : Color(0xFF000000 | stroke),
       strokeWidth: width * _geometry.scale,
       fill: fill == null ? null : Color(0xFF000000 | fill),
+      dashPattern: annotation.borderDash == null
+          ? null
+          : [
+              for (final length in annotation.borderDash!)
+                length * _geometry.scale,
+            ],
       rotation: rotation,
-      opacity: annotation.appearanceOpacity,
+      opacity: style.opacity,
     );
   }
 
@@ -2282,8 +2283,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final style = existing ? _controller.selectedTextStyle : null;
     // /DA carries the text color; /C is the box background for free text
     final annotation = existing ? _controller.selectedAnnotation : null;
-    final parsed = annotation?.freeTextStyle;
-    final annotationColor = parsed?.color ?? annotation?.color;
+    final parsed = annotation?.behavior.style.freeText;
+    final annotationColor = annotation?.behavior.style.color;
     // an already-rotated box edits in its rotated frame: take the chrome's
     // un-rotated box + resting angle so the editor (and the committed
     // afterimage) ride the artwork, not its axis-aligned bounds
@@ -3316,9 +3317,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       points: points,
       tool: tool,
       color: style?.color.withValues(alpha: opacity) ?? _controller.color,
-      fillColor: annotation?.interiorColor == null
+      fillColor: annotation?.behavior.style.fillColor == null
           ? null
-          : Color(0xFF000000 | annotation!.interiorColor!)
+          : Color(0xFF000000 | annotation!.behavior.style.fillColor!)
               .withValues(alpha: opacity),
       strokeWidth:
           (style?.strokeWidth ?? _controller.strokeWidth) * _geometry.scale,
@@ -3344,9 +3345,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       points: points,
       tool: tool,
       color: style.color.withValues(alpha: opacity),
-      fillColor: annotation.interiorColor == null
+      fillColor: annotation.behavior.style.fillColor == null
           ? null
-          : Color(0xFF000000 | annotation.interiorColor!)
+          : Color(0xFF000000 | annotation.behavior.style.fillColor!)
               .withValues(alpha: opacity),
       strokeWidth:
           (style.strokeWidth ?? _controller.strokeWidth) * _geometry.scale,
@@ -5847,7 +5848,13 @@ class _EditingPreviewPainter extends CustomPainter {
         ..color = s.stroke!
         ..style = PaintingStyle.stroke
         ..strokeWidth = s.strokeWidth;
-      s.ellipse ? canvas.drawOval(box, paint) : canvas.drawRect(box, paint);
+      if (s.dashPattern == null) {
+        s.ellipse ? canvas.drawOval(box, paint) : canvas.drawRect(box, paint);
+      } else {
+        final path = Path();
+        s.ellipse ? path.addOval(box) : path.addRect(box);
+        canvas.drawPath(_dashPath(path, s.strokeWidth, s.dashPattern), paint);
+      }
     }
     if (layered) canvas.restore();
     canvas.restore();
@@ -5931,9 +5938,13 @@ class _EditingPreviewPainter extends CustomPainter {
         false);
   }
 
-  Path _dashPath(Path path, double width) {
+  Path _dashPath(Path path, double width, [List<double>? dashPattern]) {
     final out = Path();
-    final pattern = [math.max(2.0, width * 3), math.max(2.0, width * 2)];
+    final pattern = dashPattern == null ||
+            dashPattern.isEmpty ||
+            !dashPattern.any((length) => length > 0)
+        ? [math.max(2.0, width * 3), math.max(2.0, width * 2)]
+        : [for (final length in dashPattern) math.max(0.01, length)];
     for (final metric in path.computeMetrics()) {
       var distance = 0.0;
       var draw = true;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 
 import '../scrollbar.dart';
+import 'annotation_presentation.dart';
 import 'editing_color_picker.dart';
 import 'editing_controller.dart';
 import 'editing_font_controls.dart';
@@ -167,28 +168,6 @@ class _PdfAnnotationPropertiesPanelState
     _preferences.propertiesPanelWidth = _dragWidth;
     setState(() => _dragWidth = null);
   }
-
-  static String _label(String subtype) => switch (subtype) {
-        'StrikeOut' => 'Strike-out',
-        'FreeText' => 'Text box',
-        'Text' => 'Note',
-        'Widget' => 'Form field',
-        _ => subtype,
-      };
-
-  static IconData _icon(String subtype) => switch (subtype) {
-        'Highlight' => Icons.border_color,
-        'Underline' => Icons.format_underlined,
-        'StrikeOut' => Icons.format_strikethrough,
-        'Squiggly' => Icons.gesture,
-        'Ink' => Icons.draw,
-        'Square' => Icons.rectangle_outlined,
-        'Circle' => Icons.circle_outlined,
-        'FreeText' => Icons.text_fields,
-        'Text' => Icons.sticky_note_2_outlined,
-        'Stamp' => Icons.approval,
-        _ => Icons.bookmark_border,
-      };
 
   static String _endingLabel(PdfLineEnding ending) => switch (ending) {
         PdfLineEnding.none => 'None',
@@ -460,28 +439,19 @@ class _PdfAnnotationPropertiesPanelState
     );
   }
 
-  /// Whether every selected annotation has [subtype] in [subtypes].
-  bool _allSelected(Set<String> subtypes) {
+  /// Whether every selected annotation satisfies a shared semantic
+  /// capability. The subtype matrix lives in pdf_document.
+  bool _allSelected(bool Function(PdfAnnotationBehavior) test) {
     final slots = _controller.selectedAnnotationSlots;
     if (slots.isEmpty) return false;
     for (final (page, index) in slots) {
       final annotation = _controller.annotationAt(page, index);
-      if (annotation == null || !subtypes.contains(annotation.subtype)) {
+      if (annotation == null || !test(annotation.behavior)) {
         return false;
       }
     }
     return true;
   }
-
-  static const _fillable = {'Square', 'Circle', 'Polygon', 'FreeText'};
-  static const _stroked = {'Square', 'Circle', 'Polygon', 'Ink'};
-  static const _lineStyled = {
-    'Square', 'Circle', 'Line', 'PolyLine', 'Polygon', //
-  };
-  static const _translucent = {
-    'Square', 'Circle', 'Polygon', 'Ink', 'Highlight', 'Underline',
-    'StrikeOut', 'Squiggly', 'Stamp', //
-  };
 
   List<Widget> _styleControls(PdfAnnotation annotation) {
     final children = <Widget>[];
@@ -491,17 +461,15 @@ class _PdfAnnotationPropertiesPanelState
     children.add(_section('Appearance'));
     children.add(_swatchRow('Color', style.color,
         key: const ValueKey('pdf-prop-color'), onTap: _pickColor));
-    if (_allSelected(_fillable)) {
-      final fill = annotation.subtype == 'FreeText'
-          ? annotation.freeTextStyle?.fillColor
-          : annotation.interiorColor;
+    if (_allSelected((behavior) => behavior.supportsFill)) {
+      final fill = annotation.behavior.style.fillColor;
       final fillColor = fill == null ? null : Color(0xFF000000 | fill);
       children.add(_swatchRow('Fill', fillColor,
           key: const ValueKey('pdf-prop-fill'),
           onTap: () => _pickFill(fillColor),
           onClear: () => _controller.restyleSelected(fill: (null,))));
     }
-    if (_allSelected(_stroked)) {
+    if (_allSelected((behavior) => behavior.supportsStrokeWidth)) {
       children.add(_sliderRow(
         'Stroke',
         _draggingStroke ?? style.strokeWidth ?? _controller.strokeWidth,
@@ -515,7 +483,8 @@ class _PdfAnnotationPropertiesPanelState
         },
       ));
     }
-    if (_allSelected(_lineStyled) && _controller.canSetLineStyleSelected) {
+    if (_allSelected((behavior) => behavior.supportsLineStyle) &&
+        _controller.canSetLineStyleSelected) {
       children.add(Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         child: Row(children: [
@@ -556,7 +525,7 @@ class _PdfAnnotationPropertiesPanelState
               _controller.setSelectedLineEndings(end: ending),
         ));
     }
-    if (_allSelected(_translucent)) {
+    if (_allSelected((behavior) => behavior.supportsOpacity)) {
       children.add(_sliderRow(
         'Opacity',
         _draggingOpacity ?? style.opacity,
@@ -582,9 +551,7 @@ class _PdfAnnotationPropertiesPanelState
     if (!_controller.canRestyleSelectedText) return const [];
     final style = _controller.selectedTextStyle;
     if (style == null) return const [];
-    final border = annotation.subtype == 'FreeText'
-        ? annotation.freeTextStyle?.borderColor
-        : null;
+    final border = annotation.behavior.style.borderColor;
     final borderColor = border == null ? null : Color(0xFF000000 | border);
     return [
       _section('Text'),
@@ -740,9 +707,11 @@ class _PdfAnnotationPropertiesPanelState
       ListTile(
         leading: Icon(annotation.isCallout
             ? Icons.chat_bubble_outline
-            : _icon(annotation.subtype)),
+            : pdfAnnotationIcon(annotation.subtype)),
         title: Text(
-            annotation.isCallout ? 'Callout' : _label(annotation.subtype)),
+            annotation.isCallout
+                ? 'Callout'
+                : pdfAnnotationLabel(annotation.subtype)),
         subtitle: Text('Page ${slot.$1 + 1}'),
       ),
       ..._styleControls(annotation),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -6,6 +6,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 
 import '../pdf_viewer.dart';
 import '../scrollbar.dart';
+import 'annotation_presentation.dart';
 import 'editing_controller.dart';
 import 'editing_panel.dart';
 import 'editing_preferences.dart';
@@ -92,7 +93,6 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   /// tool refuses them too); popups belong to their parent annotation
   /// and are not listed at all.
   static const _unlisted = {'Popup'};
-  static const _unselectable = {'Link', 'Widget'};
 
   /// Checked tiles in multi-select mode, as (page, /Annots slot).
   final Set<(int, int)> _checked = {};
@@ -180,31 +180,6 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
     setState(() => _dragWidth = null);
   }
 
-  static IconData _icon(String subtype) => switch (subtype) {
-        'Highlight' => Icons.border_color,
-        'Underline' => Icons.format_underlined,
-        'StrikeOut' => Icons.format_strikethrough,
-        'Squiggly' => Icons.gesture,
-        'Ink' => Icons.draw,
-        'Square' => Icons.rectangle_outlined,
-        'Circle' => Icons.circle_outlined,
-        'FreeText' => Icons.text_fields,
-        'Text' => Icons.sticky_note_2_outlined,
-        'Stamp' => Icons.approval,
-        'Link' => Icons.link,
-        'Widget' => Icons.input,
-        'FileAttachment' => Icons.attach_file,
-        _ => Icons.bookmark_border,
-      };
-
-  static String _label(String subtype) => switch (subtype) {
-        'StrikeOut' => 'Strike-out',
-        'FreeText' => 'Text box',
-        'Text' => 'Note',
-        'Widget' => 'Form field',
-        _ => subtype,
-      };
-
   /// A finer title for form fields, from the inherited /FT.
   static String _fieldLabel(String? fieldType) => switch (fieldType) {
         'Tx' => 'Text field',
@@ -273,7 +248,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
       ? _fieldLabel(annotation.fieldType)
       : annotation.isCallout
           ? 'Callout'
-          : _label(annotation.subtype);
+          : pdfAnnotationLabel(annotation.subtype);
 
   bool _matches(String query, int pageIndex, PdfAnnotation annotation) {
     if (query.isEmpty) return true;
@@ -321,7 +296,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   Widget _tile(BuildContext context, int pageIndex, int index,
       PdfAnnotation annotation) {
     final slot = (pageIndex, index);
-    final selectable = !_unselectable.contains(annotation.subtype);
+    final selectable = annotation.behavior.selectable;
     final detail = _detail(pageIndex, annotation);
     final actionsVisible =
         !pdfPanelControlsRevealOnHover() || _hoveredSlot == slot;
@@ -338,7 +313,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
             : Icon(
                 annotation.isCallout
                     ? Icons.chat_bubble_outline
-                    : _icon(annotation.subtype),
+                    : pdfAnnotationIcon(annotation.subtype),
                 size: 20),
         title: Text(_title(annotation)),
         subtitle: detail.isEmpty
@@ -647,7 +622,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
               if (!_matches(query, page, annotation)) continue;
               tiles.add(_tile(context, page, i, annotation));
               // a markup annotation hosts a comment thread
-              if (!_unselectable.contains(annotation.subtype)) {
+              if (annotation.behavior.selectable) {
                 tiles.addAll(_threadSection(
                     context, page, annotation, threadByDict[annotation.dict]));
               }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1704,6 +1704,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   _StyleFields _selectionStyleFields() {
     final annotation = controller.selectedAnnotation;
     if (annotation == null) return const _StyleFields();
+    final behavior = annotation.behavior;
     final canStroke = controller.canRestyleSelected;
     switch (annotation.subtype) {
       case 'Widget':
@@ -1711,13 +1712,16 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         return _StyleFields(formField: controller.canStyleSelectedFormField);
       case 'FreeText':
         final text = controller.canRestyleSelectedText;
-        return _StyleFields(opacity: true, font: text, boxColors: text);
+        return _StyleFields(
+            opacity: behavior.supportsOpacity,
+            font: text,
+            boxColors: text);
       case 'Square':
       case 'Circle':
       case 'Polygon':
         return _StyleFields(
-            stroke: canStroke,
-            opacity: true,
+            stroke: canStroke && behavior.supportsStrokeWidth,
+            opacity: behavior.supportsOpacity,
             // a /Polygon area measurement carries a caption font
             font: controller.canRestyleMeasurementCaption,
             lineType: controller.canSetLineStyleSelected,
@@ -1725,17 +1729,19 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       case 'Line':
       case 'PolyLine':
         return _StyleFields(
-            stroke: canStroke,
-            opacity: true,
+            stroke: canStroke && behavior.supportsStrokeWidth,
+            opacity: behavior.supportsOpacity,
             // a measurement (/Line distance, /PolyLine perimeter) carries one
             font: controller.canRestyleMeasurementCaption,
             lineType: controller.canSetLineStyleSelected,
             lineEndings: controller.canSetLineEndings);
       case 'Ink':
-        return _StyleFields(stroke: canStroke, opacity: true);
+        return _StyleFields(
+            stroke: canStroke && behavior.supportsStrokeWidth,
+            opacity: behavior.supportsOpacity);
       default:
-        // markup, stamps, notes: opacity is the only shared restyle
-        return const _StyleFields(opacity: true);
+        // Markup and stamps expose opacity; notes and foreign subtypes do not.
+        return _StyleFields(opacity: behavior.supportsOpacity);
     }
   }
 
@@ -3589,4 +3595,3 @@ class _LineEndingPainter extends CustomPainter {
   bool shouldRepaint(_LineEndingPainter old) =>
       old.ending != ending || old.atEnd != atEnd || old.color != color;
 }
-

--- a/packages/dart_pdf_editor/test/editing_shape_resize_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_resize_test.dart
@@ -24,10 +24,11 @@ void main() {
 
   // A bare overlay over a 306×396 view of the 612×792 page: 0.5 px/pt.
   Future<PdfEditingController> pumpOverlay(WidgetTester tester,
-      {required String shape}) async {
+      {required String shape, bool dashed = false}) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
       ..color = const Color(0xFFFF0000)
-      ..strokeWidth = 4;
+      ..strokeWidth = 4
+      ..dashedStroke = dashed;
     if (shape == 'Circle') {
       editing.addEllipse(0, const PdfRect(100, 550, 300, 650));
     } else {
@@ -108,6 +109,28 @@ void main() {
 
     await gesture.up();
     await tester.pump(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('a dashed shape uses the committed dash in its resize preview',
+      (tester) async {
+    final editing =
+        await pumpOverlay(tester, shape: 'Square', dashed: true);
+    final origin = tester.getTopLeft(find.byType(EditingPageOverlay));
+    final corner = origin + const Offset(150, 121);
+
+    final gesture =
+        await tester.startGesture(corner, kind: PointerDeviceKind.mouse);
+    await gesture.moveTo(origin + const Offset(280, 250));
+    await tester.pump();
+
+    final shapeResize = overlayPainter(tester).shapeResize;
+    expect(shapeResize, isNotNull);
+    // 4pt pen => [12, 8]pt /BS /D; the 0.5 px/pt view scales it once.
+    expect(shapeResize.dashPattern, [6.0, 4.0]);
+
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(editing.document.page(0).annotations.single.borderDash, [12.0, 8.0]);
   });
 
   testWidgets(

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:pdf_cos/pdf_cos.dart';
 
@@ -7,6 +8,8 @@ import 'document.dart';
 import 'measure.dart';
 import 'rect.dart';
 import 'takeoff.dart';
+
+part 'annotation_behavior.dart';
 
 /// An entry in a page's /Annots array (§12.5).
 ///
@@ -67,6 +70,15 @@ class PdfAnnotation {
 
   /// The /F flag word (§12.5.3).
   final int flags;
+
+  /// PDF-semantic editing capabilities and authoritative style for this
+  /// annotation.
+  ///
+  /// The descriptor is lazy and cached for the lifetime of this parsed
+  /// annotation. A saved editor revision produces new [PdfAnnotation]
+  /// instances, so hot UI paths can reuse the derived facts without stale
+  /// cross-revision state or repeated appearance-stream parsing.
+  late final PdfAnnotationBehavior behavior = PdfAnnotationBehavior._(this);
 
   bool get isHidden => flags & 2 != 0;
   bool get isNoView => flags & 32 != 0;

--- a/packages/pdf_document/lib/src/annotation_behavior.dart
+++ b/packages/pdf_document/lib/src/annotation_behavior.dart
@@ -1,0 +1,281 @@
+part of 'annotation.dart';
+
+/// How resizing an annotation updates its appearance.
+enum PdfAnnotationResizeBehavior {
+  /// The subtype is not supported by the editor's resize operation.
+  none,
+
+  /// Scale the existing appearance and coordinate arrays.
+  stretch,
+
+  /// Rebuild a shape at the new bounds, preserving stroke width and fill.
+  regenerateShape,
+
+  /// Re-wrap free text at the new width, preserving its font size.
+  reflowText,
+
+  /// Rebuild line-family geometry and its optional measurement caption.
+  regenerateLine,
+}
+
+/// The annotation style values that editing controls should display.
+///
+/// Values are resolved once by [PdfAnnotationBehavior]. In particular,
+/// [opacity] may require decoding the normal appearance stream, and free-text
+/// colors come from /DA rather than the annotation's generic /C entry.
+class PdfAnnotationStyle {
+  const PdfAnnotationStyle({
+    required this.color,
+    required this.fillColor,
+    required this.borderColor,
+    required this.strokeWidth,
+    required this.opacity,
+    required this.freeText,
+  });
+
+  /// Primary tint: text color for FreeText, stroke/tint for other subtypes.
+  final int? color;
+
+  /// Interior/background color, or null when absent or unsupported.
+  final int? fillColor;
+
+  /// FreeText border color. Other subtypes use [color] for their stroke.
+  final int? borderColor;
+
+  /// /BS /W when present.
+  final double? strokeWidth;
+
+  /// Alpha baked into the normal appearance, defaulting to 1.
+  final double opacity;
+
+  /// Parsed FreeText /DA and box style, when usable.
+  final PdfFreeTextStyle? freeText;
+}
+
+/// One authoritative view of PDF-semantic annotation behavior.
+///
+/// Material labels, icons, and tool presentation deliberately stay in the
+/// Flutter package. This descriptor owns only facts derived from the PDF
+/// subtype and dictionary: editing gates, style sources, and whether a resize
+/// can regenerate an equivalent appearance.
+class PdfAnnotationBehavior {
+  PdfAnnotationBehavior._(this.annotation);
+
+  final PdfAnnotation annotation;
+
+  String get subtype => annotation.subtype;
+
+  /// Whether the general annotation selection tool may select this subtype.
+  /// Links and widgets have their own interaction paths; popups belong to
+  /// their parent annotation.
+  bool get selectable => switch (subtype) {
+        'Popup' || 'Link' || 'Widget' => false,
+        _ => true,
+      };
+
+  /// Whether the editor knows how to keep this subtype's geometry coherent
+  /// when /Rect changes.
+  bool get resizable => switch (subtype) {
+        'Square' ||
+        'Circle' ||
+        'FreeText' ||
+        'Stamp' ||
+        'Ink' ||
+        'Line' ||
+        'PolyLine' ||
+        'Polygon' =>
+          true,
+        _ => false,
+      };
+
+  /// Whether rotation can ride this annotation's normal appearance matrix.
+  late final bool rotatable = resizable && annotation.normalAppearance != null;
+
+  /// Whether the editing controller can rewrite the annotation's text.
+  bool get textEditable => switch (subtype) {
+        'FreeText' || 'Stamp' || 'Text' => true,
+        _ => false,
+      };
+
+  /// A line, polyline, or polygon whose defining points are independently
+  /// editable by the overlay.
+  bool get lineFamily => switch (subtype) {
+        'Line' || 'PolyLine' || 'Polygon' => true,
+        _ => false,
+      };
+
+  /// Whether the restyle API's fill argument applies to this subtype.
+  bool get supportsFill => switch (subtype) {
+        'Square' || 'Circle' || 'Polygon' || 'FreeText' => true,
+        _ => false,
+      };
+
+  /// Whether a stroke-width control applies to this subtype.
+  bool get supportsStrokeWidth => switch (subtype) {
+        'Square' ||
+        'Circle' ||
+        'Line' ||
+        'PolyLine' ||
+        'Polygon' ||
+        'Ink' =>
+          true,
+        _ => false,
+      };
+
+  /// Whether /BS /D is an editable line style for this subtype.
+  bool get supportsLineStyle => switch (subtype) {
+        'Square' || 'Circle' || 'Line' || 'PolyLine' || 'Polygon' => true,
+        _ => false,
+      };
+
+  /// Whether line-ending controls apply to this subtype.
+  bool get supportsLineEndings => subtype == 'Line' || subtype == 'PolyLine';
+
+  /// Whether the editor can faithfully rebuild this subtype with a new alpha.
+  bool get supportsOpacity => switch (subtype) {
+        'Square' ||
+        'Circle' ||
+        'Line' ||
+        'PolyLine' ||
+        'Polygon' ||
+        'Ink' ||
+        'Highlight' ||
+        'Underline' ||
+        'StrikeOut' ||
+        'Squiggly' ||
+        'Stamp' =>
+          true,
+        _ => false,
+      };
+
+  late final PdfFreeTextStyle? _freeTextStyle =
+      subtype == 'FreeText' ? annotation.freeTextStyle : null;
+
+  late final PdfStandardFont? standardTextFont = _freeTextStyle == null
+      ? null
+      : PdfStandardFont.tryFromName(_freeTextStyle.fontName);
+
+  late final List<PdfRect>? markupQuads = _readAxisAlignedQuads();
+
+  /// Whether the editor has enough well-formed source data to regenerate an
+  /// equivalent appearance for an in-place restyle.
+  late final bool canRestyle = switch (subtype) {
+    'Square' ||
+    'Circle' =>
+      annotation.normalAppearance != null && annotation.dict['BE'] == null,
+    'Line' => annotation.normalAppearance != null && annotation.line != null,
+    'PolyLine' => annotation.normalAppearance != null &&
+        (annotation.vertices?.length ?? 0) >= 2,
+    'Polygon' => annotation.normalAppearance != null &&
+        (annotation.vertices?.length ?? 0) >= 3,
+    'FreeText' =>
+      annotation.normalAppearance != null && standardTextFont != null,
+    'Ink' => annotation.inkList?.isNotEmpty ?? false,
+    'Highlight' ||
+    'Underline' ||
+    'StrikeOut' ||
+    'Squiggly' =>
+      markupQuads != null,
+    'Text' => annotation.normalAppearance != null,
+    'Stamp' => annotation.normalAppearance != null &&
+        (annotation.contents?.isNotEmpty ?? false),
+    _ => false,
+  };
+
+  /// Appearance strategy used by both the document editor and live preview.
+  late final PdfAnnotationResizeBehavior resizeBehavior = _resizeBehavior();
+
+  /// Authoritative style values for UI controls and mutation defaults.
+  late final PdfAnnotationStyle style = PdfAnnotationStyle(
+    color: subtype == 'FreeText'
+        ? _freeTextStyle?.color ?? annotation.color
+        : annotation.color,
+    fillColor: subtype == 'FreeText'
+        ? _freeTextStyle?.fillColor
+        : supportsFill
+            ? annotation.interiorColor
+            : null,
+    borderColor: _freeTextStyle?.borderColor,
+    strokeWidth: annotation.borderWidth,
+    opacity: annotation.appearanceOpacity,
+    freeText: _freeTextStyle,
+  );
+
+  PdfAnnotationResizeBehavior _resizeBehavior() {
+    if (!resizable) return PdfAnnotationResizeBehavior.none;
+    final form = annotation.normalAppearance;
+    if (form == null) return PdfAnnotationResizeBehavior.stretch;
+    switch (subtype) {
+      case 'Square' || 'Circle':
+        if (annotation.dict['BE'] != null) {
+          return PdfAnnotationResizeBehavior.stretch;
+        }
+        final width = annotation.borderWidth ?? 1;
+        final stroke = width > 0 ? annotation.color : null;
+        if (stroke == null && annotation.interiorColor == null) {
+          return PdfAnnotationResizeBehavior.stretch;
+        }
+        return PdfAnnotationResizeBehavior.regenerateShape;
+      case 'FreeText':
+        return standardTextFont == null
+            ? PdfAnnotationResizeBehavior.stretch
+            : PdfAnnotationResizeBehavior.reflowText;
+      case 'Line':
+        return annotation.line == null
+            ? PdfAnnotationResizeBehavior.stretch
+            : PdfAnnotationResizeBehavior.regenerateLine;
+      case 'PolyLine' || 'Polygon':
+        return (annotation.vertices?.isEmpty ?? true)
+            ? PdfAnnotationResizeBehavior.stretch
+            : PdfAnnotationResizeBehavior.regenerateLine;
+      default:
+        return PdfAnnotationResizeBehavior.stretch;
+    }
+  }
+
+  List<PdfRect>? _readAxisAlignedQuads() {
+    if (subtype != 'Highlight' &&
+        subtype != 'Underline' &&
+        subtype != 'StrikeOut' &&
+        subtype != 'Squiggly') {
+      return null;
+    }
+    final cos = annotation.document.cos;
+    final raw = cos.resolve(annotation.dict['QuadPoints']);
+    if (raw is! CosArray || raw.length == 0 || raw.length % 8 != 0) {
+      return null;
+    }
+    final values = <double>[];
+    for (var i = 0; i < raw.length; i++) {
+      final n = cos.resolve(raw[i]);
+      if (n is CosInteger) {
+        values.add(n.value.toDouble());
+      } else if (n is CosReal) {
+        values.add(n.value);
+      } else {
+        return null;
+      }
+    }
+    final quads = <PdfRect>[];
+    for (var i = 0; i < values.length; i += 8) {
+      final xs = [values[i], values[i + 2], values[i + 4], values[i + 6]];
+      final ys = [values[i + 1], values[i + 3], values[i + 5], values[i + 7]];
+      final left = xs.reduce(math.min);
+      final right = xs.reduce(math.max);
+      final bottom = ys.reduce(math.min);
+      final top = ys.reduce(math.max);
+      // Preserve the editor's historical tolerance for real-world PDF
+      // coordinate noise while rejecting genuinely rotated quads.
+      const epsilon = 0.01;
+      for (var p = 0; p < 4; p++) {
+        final x = xs[p], y = ys[p];
+        if (!((x - left).abs() <= epsilon || (x - right).abs() <= epsilon) ||
+            !((y - bottom).abs() <= epsilon || (y - top).abs() <= epsilon)) {
+          return null;
+        }
+      }
+      quads.add(PdfRect(left, bottom, right, top));
+    }
+    return List.unmodifiable(quads);
+  }
+}

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -340,75 +340,8 @@ double _distanceToSegment(
 /// (/BE) or dashed (/BS /D), lines need /L or /Vertices, free text needs a standard-font /DA, ink
 /// needs a usable /InkList, markups need axis-aligned /QuadPoints,
 /// stamps need their caption in /Contents.
-bool pdfCanRestyleAnnotation(PdfAnnotation annotation) {
-  switch (annotation.subtype) {
-    case 'Square' || 'Circle':
-      if (annotation.normalAppearance == null) return false;
-      // cloudy borders (/BE) still can't regenerate; dashed ones now do
-      return annotation.dict['BE'] == null;
-    case 'Line':
-      return annotation.normalAppearance != null && annotation.line != null;
-    case 'PolyLine':
-      return annotation.normalAppearance != null &&
-          (annotation.vertices?.length ?? 0) >= 2;
-    case 'Polygon':
-      return annotation.normalAppearance != null &&
-          (annotation.vertices?.length ?? 0) >= 3;
-    case 'FreeText':
-      if (annotation.normalAppearance == null) return false;
-      final style = annotation.freeTextStyle;
-      return style != null &&
-          PdfStandardFont.tryFromName(style.fontName) != null;
-    case 'Ink':
-      return annotation.inkList?.isNotEmpty ?? false;
-    case 'Highlight' || 'Underline' || 'StrikeOut' || 'Squiggly':
-      return _axisAlignedQuads(annotation) != null;
-    case 'Text':
-      return annotation.normalAppearance != null;
-    case 'Stamp':
-      return annotation.normalAppearance != null &&
-          (annotation.contents?.isNotEmpty ?? false);
-    default:
-      return false;
-  }
-}
-
-/// The /QuadPoints as one axis-aligned rect per quad, or null when they
-/// are absent, malformed, or rotated (every corner must sit on the
-/// quad's own bounds) - regenerating a markup repaints axis-aligned
-/// rects, so rotated quads can't restyle faithfully.
-List<PdfRect>? _axisAlignedQuads(PdfAnnotation annotation) {
-  final cos = annotation.document.cos;
-  final raw = cos.resolve(annotation.dict['QuadPoints']);
-  if (raw is! CosArray || raw.length == 0 || raw.length % 8 != 0) return null;
-  final values = <double>[];
-  for (var i = 0; i < raw.length; i++) {
-    final n = cos.resolve(raw[i]);
-    if (n is CosInteger) {
-      values.add(n.value.toDouble());
-    } else if (n is CosReal) {
-      values.add(n.value);
-    } else {
-      return null;
-    }
-  }
-  const eps = 0.01;
-  final quads = <PdfRect>[];
-  for (var q = 0; q + 7 < values.length; q += 8) {
-    final xs = [values[q], values[q + 2], values[q + 4], values[q + 6]];
-    final ys = [values[q + 1], values[q + 3], values[q + 5], values[q + 7]];
-    final minX = xs.reduce(math.min), maxX = xs.reduce(math.max);
-    final minY = ys.reduce(math.min), maxY = ys.reduce(math.max);
-    for (final x in xs) {
-      if ((x - minX).abs() > eps && (x - maxX).abs() > eps) return null;
-    }
-    for (final y in ys) {
-      if ((y - minY).abs() > eps && (y - maxY).abs() > eps) return null;
-    }
-    quads.add(PdfRect(minX, minY, maxX, maxY));
-  }
-  return quads;
-}
+bool pdfCanRestyleAnnotation(PdfAnnotation annotation) =>
+    annotation.behavior.canRestyle;
 
 /// A random version-4 UUID for an annotation's /NM. Random.secure() where
 /// the platform provides it, falling back to a time-seeded generator
@@ -3632,16 +3565,20 @@ extension PdfAnnotationEditing on PdfEditor {
   /// carried - [restyleAnnotation]'s opacity path.
   bool _regenerateResizedAppearance(PdfAnnotation annotation, PdfRect to,
       {double? opacity, int pageRotation = 0}) {
+    final behavior = annotation.behavior;
+    if (behavior.resizeBehavior == PdfAnnotationResizeBehavior.none ||
+        behavior.resizeBehavior == PdfAnnotationResizeBehavior.stretch) {
+      return false;
+    }
     final form = annotation.normalAppearance;
     if (form == null) return false;
     final dict = annotation.dict;
     switch (annotation.subtype) {
       case 'Square' || 'Circle':
-        if (dict['BE'] != null) return false; // cloudy borders still stretch
-        final width = annotation.borderWidth ?? 1;
-        final stroke = width > 0 ? annotation.color : null;
-        final fill = annotation.interiorColor;
-        if (stroke == null && fill == null) return false;
+        final style = behavior.style;
+        final width = style.strokeWidth ?? 1;
+        final stroke = width > 0 ? style.color : null;
+        final fill = style.fillColor;
         final gs = _alphaState(opacity ?? _appearanceOpacity(form));
         final w = _shapeContent(annotation.subtype, to, stroke, width, fill,
             dashPattern: annotation.borderDash, hasAlpha: gs != null);
@@ -3649,10 +3586,8 @@ extension PdfAnnotationEditing on PdfEditor {
             resources: _resources(extGState: gs));
         return true;
       case 'FreeText':
-        final style = annotation.freeTextStyle;
-        if (style == null) return false;
-        final stdFont = PdfStandardFont.tryFromName(style.fontName);
-        if (stdFont == null) return false;
+        final style = behavior.style.freeText!;
+        final stdFont = behavior.standardTextFont!;
         final text = annotation.contents ?? '';
         PdfUnicodeFont? unicodeFont;
         if (text.codeUnits.any((c) => c > 0xFF)) {
@@ -3800,7 +3735,7 @@ extension PdfAnnotationEditing on PdfEditor {
   ///   free text (/C); the single-field record distinguishes "set to
   ///   this" - including `(null,)`, clearing the fill - from an omitted
   ///   parameter. Ignored elsewhere.
-  /// * [strokeWidth] - shapes and ink. Ignored elsewhere (markup line
+  /// * [strokeWidth] - shapes, the line family, and ink. Ignored elsewhere (markup line
   ///   weights derive from the text size; free-text borders restyle
   ///   through the text-style path).
   /// * [opacity] - shapes, ink, markups, stamps. Free text and notes
@@ -3829,19 +3764,20 @@ extension PdfAnnotationEditing on PdfEditor {
         dashPattern == null) {
       return false;
     }
-    if (!pdfCanRestyleAnnotation(annotation)) return false;
+    final behavior = annotation.behavior;
+    if (!behavior.canRestyle) return false;
+    final currentStyle = behavior.style;
     final dict = annotation.dict;
     switch (annotation.subtype) {
       case 'Ink':
         final form = annotation.normalAppearance;
         final strokes = annotation.inkList!;
-        final oldWidth = annotation.borderWidth ?? 1;
+        final oldWidth = currentStyle.strokeWidth ?? 1;
         final pressures =
             form == null ? null : _recoverInkPressures(form, strokes, oldWidth);
-        final newColor = color ?? annotation.color ?? 0x000000;
+        final newColor = color ?? currentStyle.color ?? 0x000000;
         final newWidth = strokeWidth ?? oldWidth;
-        final newOpacity =
-            opacity ?? (form == null ? 1.0 : _appearanceOpacity(form));
+        final newOpacity = opacity ?? currentStyle.opacity;
         final (rect, w, gs) =
             _inkAppearance(strokes, pressures, newColor, newWidth, newOpacity);
         dict['Rect'] = _rectArray(rect);
@@ -3859,11 +3795,10 @@ extension PdfAnnotationEditing on PdfEditor {
         _markAnnotationChanged(pageIndex, dict);
         return true;
       case 'Highlight' || 'Underline' || 'StrikeOut' || 'Squiggly':
-        final quads = _axisAlignedQuads(annotation)!;
+        final quads = behavior.markupQuads!;
         final form = annotation.normalAppearance;
-        final newColor = color ?? annotation.color ?? 0xFFD100;
-        final newOpacity =
-            opacity ?? (form == null ? 1.0 : _appearanceOpacity(form));
+        final newColor = color ?? currentStyle.color ?? 0xFFD100;
+        final newOpacity = opacity ?? currentStyle.opacity;
         final rect = _boundsOf(quads);
         final (w, gs) =
             _markupContent(annotation.subtype, quads, newColor, newOpacity);
@@ -3881,10 +3816,9 @@ extension PdfAnnotationEditing on PdfEditor {
         _markAnnotationChanged(pageIndex, dict);
         return true;
       case 'Square' || 'Circle':
-        final width = strokeWidth ?? annotation.borderWidth ?? 1;
-        final stroke = color ?? annotation.color;
-        final fill =
-            fillColor != null ? fillColor.$1 : annotation.interiorColor;
+        final width = strokeWidth ?? currentStyle.strokeWidth ?? 1;
+        final stroke = color ?? currentStyle.color;
+        final fill = fillColor != null ? fillColor.$1 : currentStyle.fillColor;
         if ((stroke == null || width <= 0) && fill == null) return false;
         if (stroke != null) dict['C'] = _colorComponents(stroke);
         final dash =
@@ -3897,8 +3831,8 @@ extension PdfAnnotationEditing on PdfEditor {
         }
         return _restyleRegenerate(pageIndex, dict, opacity: opacity);
       case 'Line' || 'PolyLine' || 'Polygon':
-        final width = strokeWidth ?? annotation.borderWidth ?? 1;
-        final stroke = color ?? annotation.color;
+        final width = strokeWidth ?? currentStyle.strokeWidth ?? 1;
+        final stroke = color ?? currentStyle.color;
         if (stroke == null || width <= 0) return false;
         final dash =
             dashPattern != null ? dashPattern.$1 : annotation.borderDash;
@@ -3906,7 +3840,7 @@ extension PdfAnnotationEditing on PdfEditor {
         dict['BS'] = _borderStyle(width, dashPattern: dash);
         if (annotation.subtype == 'Polygon') {
           final fill =
-              fillColor != null ? fillColor.$1 : annotation.interiorColor;
+              fillColor != null ? fillColor.$1 : currentStyle.fillColor;
           if (fill != null) {
             dict['IC'] = _colorComponents(fill);
           } else {
@@ -3915,8 +3849,8 @@ extension PdfAnnotationEditing on PdfEditor {
         }
         return _restyleRegenerate(pageIndex, dict, opacity: opacity);
       case 'FreeText':
-        final style = annotation.freeTextStyle!;
-        final font = PdfStandardFont.tryFromName(style.fontName)!;
+        final style = currentStyle.freeText!;
+        final font = behavior.standardTextFont!;
         final textColor = color ?? style.color;
         final fill = fillColor != null ? fillColor.$1 : style.fillColor;
         final border = style.borderColor != null && style.borderWidth > 0
@@ -3933,11 +3867,11 @@ extension PdfAnnotationEditing on PdfEditor {
         return _restyleRegenerate(pageIndex, dict,
             pageRotation: effectivePageRotation);
       case 'Text':
-        dict['C'] = _colorComponents(color ?? annotation.color ?? 0xFFD100);
+        dict['C'] = _colorComponents(color ?? currentStyle.color ?? 0xFFD100);
         return _restyleRegenerate(pageIndex, dict,
             pageRotation: effectivePageRotation);
       case 'Stamp':
-        dict['C'] = _colorComponents(color ?? annotation.color ?? 0xC03030);
+        dict['C'] = _colorComponents(color ?? currentStyle.color ?? 0xC03030);
         return _restyleRegenerate(pageIndex, dict,
             opacity: opacity, pageRotation: effectivePageRotation);
     }

--- a/packages/pdf_document/test/annotation_behavior_test.dart
+++ b/packages/pdf_document/test/annotation_behavior_test.dart
@@ -1,0 +1,149 @@
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+PdfDocument _edited(void Function(PdfEditor) edit) {
+  final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+  edit(editor);
+  return PdfDocument.open(editor.save());
+}
+
+void main() {
+  test('capability matrix is shared and cached per parsed annotation', () {
+    final doc = _edited((editor) {
+      editor
+        ..addSquare(0, const PdfRect(10, 10, 80, 60),
+            strokeColor: 0x112233, strokeWidth: 3, fillColor: 0x445566)
+        ..addLine(0, (100, 20), (180, 50), strokeWidth: 2)
+        ..addInk(0, [
+          [(200, 20), (240, 50)],
+        ])
+        ..addNote(0, 280, 60, 'note');
+    });
+    final [square, line, ink, note] = doc.page(0).annotations;
+
+    expect(identical(square.behavior, square.behavior), isTrue);
+    expect(identical(square.behavior.style, square.behavior.style), isTrue);
+    expect(square.behavior.selectable, isTrue);
+    expect(square.behavior.resizable, isTrue);
+    expect(square.behavior.rotatable, isTrue);
+    expect(square.behavior.canRestyle, isTrue);
+    expect(square.behavior.supportsFill, isTrue);
+    expect(square.behavior.supportsStrokeWidth, isTrue);
+    expect(square.behavior.supportsLineStyle, isTrue);
+    expect(square.behavior.supportsOpacity, isTrue);
+    expect(square.behavior.resizeBehavior,
+        PdfAnnotationResizeBehavior.regenerateShape);
+    expect(square.behavior.style.color, 0x112233);
+    expect(square.behavior.style.fillColor, 0x445566);
+    expect(square.behavior.style.strokeWidth, 3);
+
+    expect(line.behavior.lineFamily, isTrue);
+    expect(line.behavior.supportsLineEndings, isTrue);
+    expect(line.behavior.supportsStrokeWidth, isTrue);
+    expect(line.behavior.supportsOpacity, isTrue);
+    expect(line.behavior.resizeBehavior,
+        PdfAnnotationResizeBehavior.regenerateLine);
+
+    expect(ink.behavior.resizable, isTrue);
+    expect(ink.behavior.supportsLineStyle, isFalse);
+    expect(ink.behavior.canRestyle, isTrue);
+
+    expect(note.behavior.textEditable, isTrue);
+    expect(note.behavior.resizable, isFalse);
+    expect(note.behavior.supportsOpacity, isFalse);
+  });
+
+  test('free-text style comes from /DA and drives resize strategy', () {
+    final doc = _edited((editor) => editor.addFreeText(
+          0,
+          const PdfRect(20, 100, 220, 160),
+          'Styled',
+          font: PdfStandardFont.times,
+          fontSize: 14,
+          color: 0x102030,
+          fillColor: 0x405060,
+          borderColor: 0x708090,
+          borderWidth: 2,
+        ));
+    final annotation = doc.page(0).annotations.single;
+    final behavior = annotation.behavior;
+
+    expect(behavior.textEditable, isTrue);
+    expect(behavior.canRestyle, isTrue);
+    expect(behavior.supportsFill, isTrue);
+    expect(behavior.supportsOpacity, isFalse);
+    expect(behavior.resizeBehavior, PdfAnnotationResizeBehavior.reflowText);
+    expect(behavior.standardTextFont, PdfStandardFont.times);
+    expect(behavior.style.color, 0x102030);
+    expect(behavior.style.fillColor, 0x405060);
+    expect(behavior.style.borderColor, 0x708090);
+    expect(behavior.style.freeText?.fontSize, 14);
+  });
+
+  test('interactive and structural subtypes are not generally selectable', () {
+    final doc = PdfDocument.open(buildMultiPagePdf(1));
+    PdfAnnotation annotation(String subtype) => PdfAnnotation.fromDict(
+          doc,
+          CosDictionary({
+            'Subtype': CosName(subtype),
+            'Rect': CosArray(const [
+              CosInteger(0),
+              CosInteger(0),
+              CosInteger(10),
+              CosInteger(10),
+            ]),
+          }),
+        );
+
+    expect(annotation('Popup').behavior.selectable, isFalse);
+    expect(annotation('Link').behavior.selectable, isFalse);
+    expect(annotation('Widget').behavior.selectable, isFalse);
+    expect(annotation('ForeignSubtype').behavior.selectable, isTrue);
+    expect(annotation('ForeignSubtype').behavior.canRestyle, isFalse);
+    expect(annotation('ForeignSubtype').behavior.resizeBehavior,
+        PdfAnnotationResizeBehavior.none);
+  });
+
+  test('malformed and foreign appearance data falls back without rebuilding',
+      () {
+    final doc = _edited((editor) {
+      editor
+        ..addFreeText(0, const PdfRect(20, 100, 220, 160), 'Text')
+        ..addHighlight(0, const [PdfRect(20, 200, 120, 214)]);
+    });
+    final freeText = doc.page(0).annotations[0];
+    freeText.dict['DA'] = CosString.fromText('/Embedded 12 Tf 0 g');
+    final foreignText = PdfAnnotation.fromDict(doc, freeText.dict);
+    expect(foreignText.behavior.canRestyle, isFalse);
+    expect(foreignText.behavior.standardTextFont, isNull);
+    expect(foreignText.behavior.resizeBehavior,
+        PdfAnnotationResizeBehavior.stretch);
+
+    final highlight = doc.page(0).annotations[1];
+    highlight.dict['QuadPoints'] = CosArray(const [
+      CosInteger(20),
+      CosInteger(200),
+      CosInteger(120),
+      CosInteger(204),
+      CosInteger(116),
+      CosInteger(214),
+      CosInteger(24),
+      CosInteger(210),
+    ]);
+    final rotatedMarkup = PdfAnnotation.fromDict(doc, highlight.dict);
+    expect(rotatedMarkup.behavior.markupQuads, isNull);
+    expect(rotatedMarkup.behavior.canRestyle, isFalse);
+  });
+
+  test('legacy restyle gate delegates to the shared descriptor', () {
+    final doc = _edited((editor) => editor.addCircle(
+          0,
+          const PdfRect(20, 20, 80, 80),
+          strokeColor: 0x123456,
+        ));
+    final annotation = doc.page(0).annotations.single;
+    expect(pdfCanRestyleAnnotation(annotation), annotation.behavior.canRestyle);
+  });
+}


### PR DESCRIPTION
Closes #253.

## What changed

- Adds a lazy, per-`PdfAnnotation` `PdfAnnotationBehavior` descriptor in `pdf_document`.
- Centralizes selection, resize, rotation, text-edit, fill, stroke, line-style, opacity, restyle, style-source, and resize-strategy rules.
- Caches derived style and appearance facts for each parsed annotation/revision.
- Makes the editor, controller, overlay, toolbar, sidebar, and properties panel consume the shared semantic descriptor.
- Keeps Material labels and icons in one Flutter-only presentation helper.
- Preserves the public `pdfCanRestyleAnnotation` gate as a compatibility delegate.
- Carries exact stored dash patterns into shape-resize previews, fixing a preview/commit mismatch.
- Adds malformed/foreign annotation fallback coverage and shared-policy contract tests.

## Performance

The behavior object is lazy. Selection hit testing only reads cheap subtype policy; style and appearance-stream data are computed only when requested, then cached for that parsed annotation. Saved revisions create fresh annotations, so there is no stale cross-revision cache.

Sequential hot-path benchmarks (median microseconds, main → branch):

| batch | main | branch |
|---|---:|---:|
| 200 selection misses across 200 annotations | 567–585 | 334–342 |
| 1,000 capability/style reads | 1,089–1,092 | 292–306 |
| properties-panel rebuild | 16,022–16,916 | 16,140–16,678 |

Selection and capability paths improved materially; panel rebuild time remained flat. After first access there are no new per-pointer policy allocations.

## Verification

- `fvm dart analyze` — no issues
- `packages/pdf_document: fvm dart test` — 621 passed, 1 skipped
- `packages/dart_pdf_editor: fvm flutter test` — 1,375 passed, 31 skipped
- New annotation behavior contract tests
- New dashed resize-preview regression
