### PR TITLE
refactor(shell): share reader and editor session lifecycle

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -1,5 +1,4 @@
-import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, listEquals, mapEquals;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, mapEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -18,14 +17,13 @@ import 'editing/editing_toolbar.dart';
 import 'editing/text_prompt.dart';
 import 'editing/tool_shortcuts.dart';
 import 'page_number_field.dart';
-import 'perf_log.dart';
 import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
 import 'raster_cache.dart';
-import 'render_worker.dart';
 import 'search_panel.dart';
 import 'shell_chrome.dart';
+import 'shell_session.dart';
 import 'theme.dart';
 
 /// Builds the editing toolbar for [PdfEditorView].
@@ -422,29 +420,13 @@ class PdfEditorView extends StatefulWidget {
 }
 
 class _PdfEditorViewState extends State<PdfEditorView> {
-  PdfEditingController? _ownedSession;
-  PdfEditingPreferences? _ownedPrefs;
-  PdfViewerController? _ownedViewer;
-  PdfViewportMemory? _viewportMemory;
-  PdfPerformanceController? _ownedPerformance;
+  late PdfShellSessionLifecycle _shell;
 
   // Routes the Apple Pencil's native double-tap to the session's eraser
   // toggle. Created only on iOS (the only platform with the gesture) so the
   // method-channel handler isn't claimed needlessly elsewhere.
   PdfPencilInteraction? _pencil;
 
-  // Offloads page interpretation to a background isolate (native; a no-op
-  // fallback on web), keyed to the session's current document. Pure scrolling
-  // spawns one worker; every edit revision produces a new document, so the
-  // stale worker is dropped (pages render locally = correct) and a fresh one
-  // is started over the new bytes. Edits commit at most about once a second
-  // (stroke auto-commit, blur, fill), so respawning per revision is cheap
-  // enough without debouncing.
-  PdfRenderWorker? _worker;
-  PdfDocument? _workerDoc;
-
-  final _searchField = TextEditingController();
-  final _searchFocus = FocusNode();
   late Map<PdfEditTool, LogicalKeyboardKey> _toolShortcuts;
 
   /// The revision length last reported through onDocumentChanged -
@@ -452,69 +434,41 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   /// the same revision.
   late int _reportedLength;
 
-  PdfEditingController get _session => widget.controller ?? _ownedSession!;
-
-  PdfViewerController get _viewer =>
-      widget.viewerController ?? (_ownedViewer ??= PdfViewerController());
-
-  PdfEditingPreferences get _prefs => _session.preferences;
-
-  PdfPerformanceController get _performance =>
-      widget.performance ?? (_ownedPerformance ??= PdfPerformanceController());
+  PdfEditingController get _session => _shell.session;
+  PdfViewerController get _viewer => _shell.viewer;
+  PdfEditingPreferences get _prefs => _shell.preferences;
+  PdfPerformanceController get _performance => _shell.performance;
+  TextEditingController get _searchField => _shell.searchController;
+  FocusNode get _searchFocus => _shell.searchFocus;
 
   /// A stable key for the open document, or null when there is nothing to
   /// key a remembered position on - an external controller with no
   /// [documentId]. With [bytes] one is derived from the content.
-  String? get _documentKey {
-    if (widget.documentId != null) return widget.documentId;
-    final bytes = widget.bytes;
-    return bytes == null ? null : pdfDocumentKey(bytes);
-  }
+  String? get _documentKey => _shell.documentKey;
 
   @override
   void initState() {
     super.initState();
     _toolShortcuts =
         Map<PdfEditTool, LogicalKeyboardKey>.of(widget.toolShortcuts);
-    _openSession();
-    // remember and restore where the user left this document
-    final key = _documentKey;
-    if (key != null) {
-      _viewportMemory = PdfViewportMemory(
-        viewer: _viewer,
-        preferences: _prefs,
-        documentKey: key,
-      );
-    }
-  }
-
-  void _openSession() {
-    if (widget.bytes != null) {
-      final prefs =
-          widget.preferences ?? (_ownedPrefs ??= PdfEditingPreferences());
-      _ownedSession = PdfEditingController(widget.bytes!, preferences: prefs);
-    }
-    _session.providedCustomStamps = widget.customStamps;
-    _performance.configureDocument(
-      pageCount: _session.document.pageCount,
-      documentBytes: _session.bytes.length,
+    _shell = PdfShellSessionLifecycle(
+      bytes: widget.bytes,
+      controller: widget.controller,
+      preferences: widget.preferences,
+      viewerController: widget.viewerController,
+      performance: widget.performance,
+      documentId: widget.documentId,
+      prepareSession: _prepareSession,
+      onSessionChanged: _onSessionChanged,
     );
-    _syncFeatureLocks();
     _reportedLength = _session.bytes.length;
-    _session.addListener(_onSessionChanged);
     _attachPencil();
-    _syncWorker();
   }
 
-  void _closeSession() {
-    _pencil?.dispose();
-    _pencil = null;
-    _worker?.dispose();
-    _worker = null;
-    _workerDoc = null;
-    _session.removeListener(_onSessionChanged);
-    _ownedSession?.dispose();
-    _ownedSession = null;
+  void _prepareSession(PdfEditingController session) {
+    session
+      ..providedCustomStamps = widget.customStamps
+      ..colorLocked = !widget.features.colorControls;
   }
 
   /// Binds the Apple Pencil double-tap to the session's eraser toggle on
@@ -527,84 +481,49 @@ class _PdfEditorViewState extends State<PdfEditorView> {
     (_pencil ??= PdfPencilInteraction()).attach(_session);
   }
 
-  /// Keeps [_worker] tied to the session's current document - see the field
-  /// doc. A revision (edit, undo, redo) changes the document identity, so
-  /// the old worker is disposed and a new one started over the current bytes;
-  /// disposing first means the just-edited page renders locally (correctly)
-  /// until the new worker is ready.
-  void _syncWorker() {
-    if (identical(_session.document, _workerDoc)) return;
-    _worker?.dispose();
-    final workerCount = _performance.beginWorkerGeneration();
-    _worker = startPdfRenderWorker(_session.bytes,
-        pageCount: _session.document.pageCount, workerCount: workerCount);
-    _workerDoc = _session.document;
-    PdfPerfLog.log(_performance.diagnostics.toString());
-  }
-
-  void _syncFeatureLocks() {
-    _session.colorLocked = !widget.features.colorControls;
-  }
-
-  void _onSessionChanged() {
-    // the merged ListenableBuilder rebuilds the viewer on this same notify,
-    // so swapping the worker here is enough - no setState needed
-    _syncWorker();
-    final length = _session.bytes.length;
+  void _onSessionChanged(PdfEditingController session) {
+    final length = session.bytes.length;
     if (length == _reportedLength) return;
     _reportedLength = length;
-    widget.onDocumentChanged?.call(_session.bytes);
+    widget.onDocumentChanged?.call(session.bytes);
   }
 
   @override
   void didUpdateWidget(PdfEditorView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.performance, widget.performance)) {
-      if (oldWidget.performance == null) {
-        _ownedPerformance?.dispose();
-        _ownedPerformance = null;
-      }
-      _performance.configureDocument(
-        pageCount: _session.document.pageCount,
-        documentBytes: _session.bytes.length,
-      );
-    }
     if (!mapEquals(widget.toolShortcuts, oldWidget.toolShortcuts)) {
       _toolShortcuts =
           Map<PdfEditTool, LogicalKeyboardKey>.of(widget.toolShortcuts);
     }
-    if (widget.controller != oldWidget.controller ||
+    final sourceChanging = widget.controller != oldWidget.controller ||
         !identical(widget.bytes, oldWidget.bytes) ||
-        widget.documentId != oldWidget.documentId) {
-      _closeSession();
-      _searchField.clear();
-      _openSession();
-      final key = _documentKey;
-      if (key != null) _viewportMemory?.rekey(key);
-    } else if (!listEquals(widget.customStamps, oldWidget.customStamps)) {
-      _session.providedCustomStamps = widget.customStamps;
+        (widget.controller == null &&
+            !identical(widget.preferences, oldWidget.preferences));
+    if (sourceChanging) {
+      _pencil?.dispose();
+      _pencil = null;
     }
-    if (widget.features.colorControls != oldWidget.features.colorControls) {
-      _syncFeatureLocks();
+    final update = _shell.update(
+      bytes: widget.bytes,
+      controller: widget.controller,
+      preferences: widget.preferences,
+      viewerController: widget.viewerController,
+      performanceController: widget.performance,
+      documentId: widget.documentId,
+      prepareSession: _prepareSession,
+      onSessionChanged: _onSessionChanged,
+    );
+    if (update.sessionChanged) {
+      _reportedLength = _session.bytes.length;
+      _attachPencil();
     }
   }
 
   @override
   void dispose() {
-    _viewportMemory?.dispose();
-    _closeSession();
-    _ownedPrefs?.dispose();
-    _ownedViewer?.dispose();
-    _ownedPerformance?.dispose();
-    _searchField.dispose();
-    _searchFocus.dispose();
+    _pencil?.dispose();
+    _shell.dispose();
     super.dispose();
-  }
-
-  void _focusSearch() {
-    _searchFocus.requestFocus();
-    _searchField.selection =
-        TextSelection(baseOffset: 0, extentOffset: _searchField.text.length);
   }
 
   /// Whether there's anything to save: false while the document still
@@ -677,7 +596,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 onPickPdfToInsert:
                     features.pageEditing ? widget.onPickPdfToInsert : null,
                 onExportPages: widget.onExportPages,
-                renderWorker: _worker,
+                renderWorker: _shell.worker,
                 rasterCache: thumbnailDisk,
               );
           PdfSearchResultsPanel searchResults({required bool bottomSheet}) =>
@@ -741,7 +660,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     features.pageEditing ? widget.onPickPdfToInsert : null,
                 onExportPages: widget.onExportPages,
                 onOpenPage: (_) => prefs.showThumbnailView = false,
-                renderWorker: _worker,
+                renderWorker: _shell.worker,
                 rasterCache: thumbnailDisk,
               );
 
@@ -1046,7 +965,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         pageColor: pageColor,
                         showAnnotations: prefs.showAnnotations,
                         highlightFormFields: prefs.highlightFormFields,
-                        renderWorker: _worker,
+                        renderWorker: _shell.worker,
                         performance: _performance,
                         rasterCache: widget.rasterCache,
                         textCache: widget.textCache,
@@ -1089,12 +1008,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
       body = PdfViewerTheme(data: widget.viewerTheme!, child: body);
     }
     final bindings = <ShortcutActivator, VoidCallback>{
-      if (features.headerBar && features.search) ...{
-        const SingleActivator(LogicalKeyboardKey.keyF, meta: true):
-            _focusSearch,
-        const SingleActivator(LogicalKeyboardKey.keyF, control: true):
-            _focusSearch,
-      },
+      ..._shell.searchShortcuts(
+          enabled: features.headerBar && features.search),
       // ⌘S / Ctrl+S saves through the host's [onSave], the same path the
       // toolbar's save button takes. ⌘⇧S / Ctrl+Shift+S invokes the
       // host's Save As path when one is provided.

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -1,5 +1,6 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
@@ -8,14 +9,13 @@ import 'editing/editing_controller.dart';
 import 'editing/editing_preferences.dart';
 import 'editing/editing_thumbnails.dart';
 import 'page_number_field.dart';
-import 'perf_log.dart';
 import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
 import 'raster_cache.dart';
-import 'render_worker.dart';
 import 'search_panel.dart';
 import 'shell_chrome.dart';
+import 'shell_session.dart';
 import 'theme.dart';
 
 /// Which pieces of chrome a [PdfReader] shows. Everything defaults on;
@@ -187,117 +187,46 @@ class PdfReader extends StatefulWidget {
 }
 
 class _PdfReaderState extends State<PdfReader> {
-  // the session wraps the bytes for the viewer and the thumbnail
-  // strip's caches; the reader makes no structural edits, so the
-  // document stays byte-identical to the input - except form fills
-  // (PdfReaderFeatures.fillForms), the one mutation a reader allows
-  late PdfEditingController _session;
-  PdfEditingPreferences? _ownedPrefs;
-  PdfViewerController? _ownedViewer;
-  PdfViewportMemory? _viewportMemory;
-  PdfPerformanceController? _ownedPerformance;
+  late PdfShellSessionLifecycle _shell;
 
-  // Offloads page interpretation to a background isolate (native; a no-op
-  // fallback on web). Keyed to the session's current document: pure reading
-  // spawns one worker for the life of the document, and the rare form-fill
-  // revision respawns it over the new bytes so it never serves a stale page.
-  PdfRenderWorker? _worker;
-  PdfDocument? _workerDoc;
-
-  final _searchField = TextEditingController();
-  final _searchFocus = FocusNode();
-
-  PdfViewerController get _viewer =>
-      widget.controller ?? (_ownedViewer ??= PdfViewerController());
-
-  PdfEditingPreferences get _prefs => _session.preferences;
-  PdfPerformanceController get _performance =>
-      widget.performance ?? (_ownedPerformance ??= PdfPerformanceController());
-
-  String get _documentKey => widget.documentId ?? pdfDocumentKey(widget.bytes);
+  PdfEditingController get _session => _shell.session;
+  PdfViewerController get _viewer => _shell.viewer;
+  PdfEditingPreferences get _prefs => _shell.preferences;
+  PdfPerformanceController get _performance => _shell.performance;
+  String get _documentKey => _shell.documentKey!;
+  TextEditingController get _searchField => _shell.searchController;
+  FocusNode get _searchFocus => _shell.searchFocus;
 
   @override
   void initState() {
     super.initState();
-    _openSession();
-    // remember and restore where the user left this document
-    _viewportMemory = PdfViewportMemory(
-      viewer: _viewer,
-      preferences: _prefs,
-      documentKey: _documentKey,
+    _shell = PdfShellSessionLifecycle(
+      bytes: widget.bytes,
+      controller: null,
+      preferences: widget.preferences,
+      viewerController: widget.controller,
+      performance: widget.performance,
+      documentId: widget.documentId,
     );
-  }
-
-  void _openSession() {
-    final prefs =
-        widget.preferences ?? (_ownedPrefs ??= PdfEditingPreferences());
-    _session = PdfEditingController(widget.bytes, preferences: prefs);
-    _performance.configureDocument(
-      pageCount: _session.document.pageCount,
-      documentBytes: widget.bytes.length,
-    );
-    _session.addListener(_syncWorker);
-    _syncWorker();
-  }
-
-  /// Keeps [_worker] tied to the session's current document. Reading never
-  /// changes it (one spawn for the document's life); a form fill produces a
-  /// new revision, so the old worker - which holds the pre-fill bytes - is
-  /// disposed and a fresh one started over the new bytes. Disposing first
-  /// means pages render locally (correctly) during the brief respawn rather
-  /// than from a stale isolate.
-  void _syncWorker() {
-    if (identical(_session.document, _workerDoc)) return;
-    _worker?.dispose();
-    final workerCount = _performance.beginWorkerGeneration();
-    _worker = startPdfRenderWorker(_session.bytes,
-        pageCount: _session.document.pageCount, workerCount: workerCount);
-    _workerDoc = _session.document;
-    PdfPerfLog.log(_performance.diagnostics.toString());
   }
 
   @override
   void didUpdateWidget(PdfReader oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.performance, widget.performance)) {
-      if (oldWidget.performance == null) {
-        _ownedPerformance?.dispose();
-        _ownedPerformance = null;
-      }
-      _performance.configureDocument(
-        pageCount: _session.document.pageCount,
-        documentBytes: widget.bytes.length,
-      );
-    }
-    if (!identical(widget.bytes, oldWidget.bytes) ||
-        widget.documentId != oldWidget.documentId) {
-      final previous = _session;
-      previous.removeListener(_syncWorker);
-      _searchField.clear();
-      _openSession();
-      _viewportMemory?.rekey(_documentKey);
-      previous.dispose();
-    }
+    _shell.update(
+      bytes: widget.bytes,
+      controller: null,
+      preferences: widget.preferences,
+      viewerController: widget.controller,
+      performanceController: widget.performance,
+      documentId: widget.documentId,
+    );
   }
 
   @override
   void dispose() {
-    _viewportMemory?.dispose();
-    _worker?.dispose();
-    _session.removeListener(_syncWorker);
-    _session.dispose();
-    _ownedPrefs?.dispose();
-    _ownedViewer?.dispose();
-    _ownedPerformance?.dispose();
-    _searchField.dispose();
-    _searchFocus.dispose();
+    _shell.dispose();
     super.dispose();
-  }
-
-  void _focusSearch() {
-    _searchFocus.requestFocus();
-    _searchField.selection =
-        TextSelection(baseOffset: 0, extentOffset: _searchField.text.length);
   }
 
   @override
@@ -338,7 +267,7 @@ class _PdfReaderState extends State<PdfReader> {
                 onClose: bottomSheet
                     ? null
                     : () => prefs.showThumbnailSidebar = false,
-                renderWorker: _worker,
+                renderWorker: _shell.worker,
               );
           PdfBookmarkSidebar bookmarks({required bool bottomSheet}) =>
               PdfBookmarkSidebar(
@@ -482,7 +411,7 @@ class _PdfReaderState extends State<PdfReader> {
                           pageColor: pageColor,
                           showAnnotations: prefs.showAnnotations,
                           highlightFormFields: prefs.highlightFormFields,
-                          renderWorker: _worker,
+                          renderWorker: _shell.worker,
                           performance: _performance,
                           rasterCache: widget.rasterCache,
                           textCache: widget.textCache,
@@ -520,12 +449,7 @@ class _PdfReaderState extends State<PdfReader> {
     }
     if (features.headerBar && features.search) {
       body = CallbackShortcuts(
-        bindings: {
-          const SingleActivator(LogicalKeyboardKey.keyF, meta: true):
-              _focusSearch,
-          const SingleActivator(LogicalKeyboardKey.keyF, control: true):
-              _focusSearch,
-        },
+        bindings: _shell.searchShortcuts(enabled: true),
         child: body,
       );
     }

--- a/packages/dart_pdf_editor/lib/src/shell_session.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_session.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'editing/editing_controller.dart';
+import 'editing/editing_preferences.dart';
+import 'perf_log.dart';
+import 'performance_policy.dart';
+import 'pdf_viewer.dart';
+import 'render_worker.dart';
+import 'shell_chrome.dart';
+
+typedef PdfShellPrepareSession = void Function(PdfEditingController session);
+typedef PdfShellSessionChanged = void Function(PdfEditingController session);
+
+class PdfShellSessionUpdate {
+  const PdfShellSessionUpdate({
+    required this.sessionChanged,
+    required this.viewerChanged,
+    required this.documentKeyChanged,
+  });
+
+  final bool sessionChanged;
+  final bool viewerChanged;
+  final bool documentKeyChanged;
+}
+
+/// Shared resource lifecycle behind PdfReader and PdfEditorView.
+///
+/// Public shell policy stays in those widgets. This object owns only the
+/// ordering-sensitive protocol: borrowed/owned resources, document sessions,
+/// worker generations, viewport memory, search focus, and common shortcuts.
+class PdfShellSessionLifecycle {
+  PdfShellSessionLifecycle({
+    required Uint8List? bytes,
+    required PdfEditingController? controller,
+    required PdfEditingPreferences? preferences,
+    required PdfViewerController? viewerController,
+    required PdfPerformanceController? performance,
+    required String? documentId,
+    PdfShellPrepareSession? prepareSession,
+    PdfShellSessionChanged? onSessionChanged,
+  })  : _bytes = bytes,
+        _externalController = controller,
+        _externalPreferences = preferences,
+        _externalViewer = viewerController,
+        _externalPerformance = performance,
+        _documentId = documentId,
+        _prepareSession = prepareSession,
+        _onSessionChanged = onSessionChanged {
+    _openSession();
+    _bindViewportMemory(recreate: true);
+  }
+
+  Uint8List? _bytes;
+  PdfEditingController? _externalController;
+  PdfEditingPreferences? _externalPreferences;
+  PdfViewerController? _externalViewer;
+  PdfPerformanceController? _externalPerformance;
+  String? _documentId;
+  PdfShellPrepareSession? _prepareSession;
+  PdfShellSessionChanged? _onSessionChanged;
+
+  PdfEditingController? _ownedSession;
+  PdfEditingPreferences? _ownedPreferences;
+  PdfViewerController? _ownedViewer;
+  PdfPerformanceController? _ownedPerformance;
+  PdfViewportMemory? _viewportMemory;
+  PdfRenderWorker? _worker;
+  Object? _workerDocument;
+  int _workerGenerations = 0;
+
+  final TextEditingController searchController = TextEditingController();
+  final FocusNode searchFocus = FocusNode();
+
+  PdfEditingController get session => _externalController ?? _ownedSession!;
+
+  PdfEditingPreferences get preferences => session.preferences;
+
+  PdfViewerController get viewer =>
+      _externalViewer ?? (_ownedViewer ??= PdfViewerController());
+
+  PdfPerformanceController get performance =>
+      _externalPerformance ??
+      (_ownedPerformance ??= PdfPerformanceController());
+
+  PdfRenderWorker? get worker => _worker;
+
+  String? get documentKey =>
+      _documentId ?? (_bytes == null ? null : pdfDocumentKey(_bytes!));
+
+  /// Number of actual worker generations started by this lifecycle.
+  int get debugWorkerGenerations => _workerGenerations;
+  bool get debugOwnsSession => _ownedSession != null;
+  bool get debugOwnsPreferences => _ownedPreferences != null;
+  bool get debugOwnsViewer => _ownedViewer != null;
+  bool get debugOwnsPerformance => _ownedPerformance != null;
+
+  void _openSession() {
+    if (_externalController == null) {
+      final bytes = _bytes;
+      if (bytes == null) {
+        throw ArgumentError(
+            'bytes are required without an external controller');
+      }
+      final prefs = _externalPreferences ??
+          (_ownedPreferences ??= PdfEditingPreferences());
+      _ownedSession = PdfEditingController(bytes, preferences: prefs);
+    }
+    _prepareSession?.call(session);
+    performance.configureDocument(
+      pageCount: session.document.pageCount,
+      documentBytes: session.bytes.length,
+    );
+    session.addListener(_handleSessionChanged);
+    _syncWorker();
+  }
+
+  void _closeSession() {
+    session.removeListener(_handleSessionChanged);
+    _worker?.dispose();
+    _worker = null;
+    _workerDocument = null;
+    _ownedSession?.dispose();
+    _ownedSession = null;
+  }
+
+  void _handleSessionChanged() {
+    _syncWorker();
+    _onSessionChanged?.call(session);
+  }
+
+  void _syncWorker() {
+    if (identical(session.document, _workerDocument)) return;
+    _worker?.dispose();
+    final workerCount = performance.beginWorkerGeneration();
+    _worker = startPdfRenderWorker(session.bytes,
+        pageCount: session.document.pageCount, workerCount: workerCount);
+    _workerDocument = session.document;
+    _workerGenerations++;
+    PdfPerfLog.log(performance.diagnostics.toString());
+  }
+
+  void _bindViewportMemory({required bool recreate}) {
+    final key = documentKey;
+    if (recreate) {
+      _viewportMemory?.dispose();
+      _viewportMemory = null;
+    }
+    if (key == null) {
+      _viewportMemory?.dispose();
+      _viewportMemory = null;
+    } else if (_viewportMemory == null) {
+      _viewportMemory = PdfViewportMemory(
+        viewer: viewer,
+        preferences: preferences,
+        documentKey: key,
+      );
+    } else {
+      _viewportMemory!.rekey(key);
+    }
+  }
+
+  /// Applies a rebuilt shell's resource inputs while preserving ownership.
+  ///
+  /// A document/session change restarts the worker once. A document-id-only
+  /// change merely rekeys viewport memory; a performance object swap
+  /// reconfigures the current document and takes effect on the next required
+  /// worker generation, matching the previous shell behavior.
+  PdfShellSessionUpdate update({
+    required Uint8List? bytes,
+    required PdfEditingController? controller,
+    required PdfEditingPreferences? preferences,
+    required PdfViewerController? viewerController,
+    required PdfPerformanceController? performanceController,
+    required String? documentId,
+    PdfShellPrepareSession? prepareSession,
+    PdfShellSessionChanged? onSessionChanged,
+  }) {
+    final oldKey = documentKey;
+    final oldViewer = viewer;
+    final oldPreferences = this.preferences;
+    final preferencesInputChanged =
+        !identical(preferences, _externalPreferences);
+    final sessionChanged = !identical(controller, _externalController) ||
+        !identical(bytes, _bytes) ||
+        (controller == null && preferencesInputChanged);
+    final viewerChanged = !identical(viewerController, _externalViewer);
+    final performanceChanged =
+        !identical(performanceController, _externalPerformance);
+
+    if (sessionChanged) _closeSession();
+    if (sessionChanged &&
+        _externalController == null &&
+        (controller != null || preferencesInputChanged)) {
+      _viewportMemory?.dispose();
+      _viewportMemory = null;
+      _ownedPreferences?.dispose();
+      _ownedPreferences = null;
+    }
+    if (viewerChanged && _externalViewer == null) {
+      _viewportMemory?.dispose();
+      _viewportMemory = null;
+      _ownedViewer?.dispose();
+      _ownedViewer = null;
+    }
+    if (performanceChanged && _externalPerformance == null) {
+      _ownedPerformance?.dispose();
+      _ownedPerformance = null;
+    }
+
+    _bytes = bytes;
+    _externalController = controller;
+    _externalPreferences = preferences;
+    _externalViewer = viewerController;
+    _externalPerformance = performanceController;
+    _documentId = documentId;
+    _prepareSession = prepareSession;
+    _onSessionChanged = onSessionChanged;
+
+    if (sessionChanged) {
+      searchController.clear();
+      _openSession();
+    } else {
+      _prepareSession?.call(session);
+      if (performanceChanged) {
+        performance.configureDocument(
+          pageCount: session.document.pageCount,
+          documentBytes: session.bytes.length,
+        );
+      }
+    }
+
+    final keyChanged = oldKey != documentKey;
+    final effectiveViewerChanged = !identical(oldViewer, viewer);
+    final effectivePreferencesChanged =
+        !identical(oldPreferences, this.preferences);
+    if (sessionChanged ||
+        effectiveViewerChanged ||
+        effectivePreferencesChanged) {
+      _bindViewportMemory(
+          recreate: effectiveViewerChanged || effectivePreferencesChanged);
+    } else if (keyChanged) {
+      _bindViewportMemory(recreate: false);
+    }
+    return PdfShellSessionUpdate(
+      sessionChanged: sessionChanged,
+      viewerChanged: viewerChanged,
+      documentKeyChanged: keyChanged,
+    );
+  }
+
+  void focusSearch() {
+    searchFocus.requestFocus();
+    searchController.selection = TextSelection(
+        baseOffset: 0, extentOffset: searchController.text.length);
+  }
+
+  Map<ShortcutActivator, VoidCallback> searchShortcuts({
+    required bool enabled,
+  }) =>
+      enabled
+          ? {
+              const SingleActivator(LogicalKeyboardKey.keyF, meta: true):
+                  focusSearch,
+              const SingleActivator(LogicalKeyboardKey.keyF, control: true):
+                  focusSearch,
+            }
+          : const <ShortcutActivator, VoidCallback>{};
+
+  void dispose() {
+    _viewportMemory?.dispose();
+    _closeSession();
+    _ownedPreferences?.dispose();
+    _ownedViewer?.dispose();
+    _ownedPerformance?.dispose();
+    searchController.dispose();
+    searchFocus.dispose();
+  }
+}

--- a/packages/dart_pdf_editor/test/shell_session_test.dart
+++ b/packages/dart_pdf_editor/test/shell_session_test.dart
@@ -1,0 +1,147 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/shell_session.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('document key rekeys viewport memory without restarting the worker', () {
+    final bytes = buildMultiPagePdf(1);
+    final lifecycle = PdfShellSessionLifecycle(
+      bytes: bytes,
+      controller: null,
+      preferences: null,
+      viewerController: null,
+      performance: null,
+      documentId: 'document-a',
+    );
+    addTearDown(lifecycle.dispose);
+    final session = lifecycle.session;
+    final generations = lifecycle.debugWorkerGenerations;
+
+    final update = lifecycle.update(
+      bytes: bytes,
+      controller: null,
+      preferences: null,
+      viewerController: null,
+      performanceController: null,
+      documentId: 'document-b',
+    );
+
+    expect(update.sessionChanged, isFalse);
+    expect(update.documentKeyChanged, isTrue);
+    expect(identical(lifecycle.session, session), isTrue);
+    expect(lifecycle.documentKey, 'document-b');
+    expect(lifecycle.debugWorkerGenerations, generations);
+  });
+
+  test('byte swap opens once and starts exactly one worker generation', () {
+    final first = buildMultiPagePdf(1);
+    final second = buildMultiPagePdf(2);
+    final lifecycle = PdfShellSessionLifecycle(
+      bytes: first,
+      controller: null,
+      preferences: null,
+      viewerController: null,
+      performance: null,
+      documentId: null,
+    );
+    addTearDown(lifecycle.dispose);
+    final oldSession = lifecycle.session;
+    final generations = lifecycle.debugWorkerGenerations;
+
+    final update = lifecycle.update(
+      bytes: second,
+      controller: null,
+      preferences: null,
+      viewerController: null,
+      performanceController: null,
+      documentId: null,
+    );
+
+    expect(update.sessionChanged, isTrue);
+    expect(identical(lifecycle.session, oldSession), isFalse);
+    expect(lifecycle.session.document.pageCount, 2);
+    expect(lifecycle.debugWorkerGenerations, generations + 1);
+  });
+
+  test('form fill or editor revision restarts the worker once', () {
+    final lifecycle = PdfShellSessionLifecycle(
+      bytes: buildAcroFormPdf(),
+      controller: null,
+      preferences: null,
+      viewerController: null,
+      performance: null,
+      documentId: 'revision-test',
+    );
+    addTearDown(lifecycle.dispose);
+    final generations = lifecycle.debugWorkerGenerations;
+
+    expect(lifecycle.session.setFormFieldText('name', 'Jane'), isTrue);
+    expect(lifecycle.debugWorkerGenerations, generations + 1);
+    lifecycle.session.undo();
+    expect(lifecycle.debugWorkerGenerations, generations + 2);
+    lifecycle.session.addRectangle(0, const PdfRect(10, 10, 40, 40));
+    expect(lifecycle.debugWorkerGenerations, generations + 3);
+  });
+
+  test('external resources remain caller-owned', () {
+    final controller = PdfEditingController(buildMultiPagePdf(1));
+    final viewer = PdfViewerController();
+    final performance = PdfPerformanceController();
+    final preferences = controller.preferences;
+    final lifecycle = PdfShellSessionLifecycle(
+      bytes: null,
+      controller: controller,
+      preferences: null,
+      viewerController: viewer,
+      performance: performance,
+      documentId: 'external',
+    );
+
+    expect(lifecycle.debugOwnsSession, isFalse);
+    expect(lifecycle.debugOwnsPreferences, isFalse);
+    expect(lifecycle.debugOwnsViewer, isFalse);
+    expect(lifecycle.debugOwnsPerformance, isFalse);
+    lifecycle.dispose();
+
+    expect(() => controller.addRectangle(0, const PdfRect(10, 10, 40, 40)),
+        returnsNormally);
+    expect(
+        () => preferences.pageColor = const Color(0xFFEEEEEE), returnsNormally);
+    expect(() => viewer.addListener(() {}), returnsNormally);
+    expect(
+        () => performance.configureDocument(
+            pageCount: 1, documentBytes: controller.bytes.length),
+        returnsNormally);
+
+    controller.dispose();
+    viewer.dispose();
+    performance.dispose();
+  });
+
+  test('owned resource policy is explicit', () async {
+    final lifecycle = PdfShellSessionLifecycle(
+      bytes: buildMultiPagePdf(1),
+      controller: null,
+      preferences: null,
+      viewerController: null,
+      performance: null,
+      documentId: null,
+    );
+    expect(lifecycle.debugOwnsSession, isTrue);
+    expect(lifecycle.debugOwnsPreferences, isTrue);
+    // Lazy owned resources become owned on first access.
+    lifecycle.viewer;
+    lifecycle.performance;
+    expect(lifecycle.debugOwnsViewer, isTrue);
+    expect(lifecycle.debugOwnsPerformance, isTrue);
+    await lifecycle.preferences.ready;
+    lifecycle.dispose();
+  });
+}


### PR DESCRIPTION
Closes #255.

## What changed

- introduce one internal `PdfShellSessionLifecycle` shared by `PdfReader` and `PdfEditorView`
- centralize owned vs borrowed controller, preferences, viewer, and performance resources
- centralize render-worker generations, viewport-memory binding/rekeying, and search focus/shortcuts
- keep editor-only policy (Pencil, tool shortcuts, save/document callbacks) in `PdfEditorView`
- avoid reopening the document or restarting the worker for a document-id-only rekey
- add lifecycle tests for byte swaps, form fills, edits, undo, viewport rekeys, and resource ownership

## Performance

Repeated baseline/branch widget microbenchmarks showed no material regression:

- reader cold open: +1.6% median
- editor cold open: +3.9% median
- reader byte swap: 1.1% faster
- compact and wide responsive relayout: branch faster
- crisp-render timings overlap baseline ranges and remain dominated by worker/preference startup variance

Worker-generation tests also pin exactly one generation per real document revision and zero generations for an ID-only rekey.

## Verification

- `fvm dart analyze`
- focused lifecycle + shell suite: 75 passed
- complete `dart_pdf_editor` suite: 1,380 passed, 31 skipped
- `git diff --check`
