### PR TITLE
refactor(render): concentrate page lifecycle behind one session

### DIFF
--- a/doc/benchmarks/issue-256-render-session.md
+++ b/doc/benchmarks/issue-256-render-session.md
@@ -1,0 +1,58 @@
+# Issue 256 render-session benchmark
+
+This change moves only the page-render control plane: visual identity,
+invalidation outcomes, full/detail generations, stale-result acceptance, and
+hold/scheduler routing. Local rendering, native/web worker protocols, command
+replay, retained scenes, strip plans, image decoding, transfer buffers, and
+raster caches are unchanged.
+
+## Control-plane updates
+
+Run from `packages/dart_pdf_editor`:
+
+```sh
+PDF_BENCHMARK_SESSION=1 \
+  fvm flutter test test/benchmark_render_session_test.dart --reporter expanded
+```
+
+Detached `c821f29` baseline versus this branch, 9 trials of 300 settled-view
+updates after 30 warmups:
+
+| revision | median | per update |
+| --- | ---: | ---: |
+| baseline | 238,452 us | 794.84 us |
+| render session | 235,619 us | 785.40 us |
+
+The 1.2% difference is below run-to-run noise and favors the branch.
+
+## Representative cold/warm rendering
+
+A four-file directory was assembled from the local corpus with one lightweight
+vector page, one dense CAD page, one image-bearing page, and one scanned page.
+Run from `packages/dart_pdf_editor`:
+
+```sh
+PDF_BENCHMARK_DIR=/path/to/four-file-matrix \
+PDF_BENCHMARK_SCALE=1 PDF_BENCHMARK_MAX_PAGES=1 \
+  fvm flutter test test/benchmark_warmcache_test.dart --reporter expanded
+```
+
+| revision | cold | warm |
+| --- | ---: | ---: |
+| baseline | 66.5 ms/page | 54.2 ms/page |
+| render session | 67.6 ms/page | 52.9 ms/page |
+
+Cold moved +1.7% and warm moved -2.4%, within single-run raster variance. The
+measured rendering code is byte-for-byte unchanged by this patch.
+
+## Adapter and output parity
+
+The focused adapter suite covers local and isolate recording, scheduler hold,
+preview progression, retained-scene replay, worker strip plans, speculative
+zoom/pan detail, and web Slug fallback. Corpus/pixel suites and the complete
+Flutter package suite remain the final gates.
+
+Live browser transfer-volume, browser memory/allocation, and platform frame-jank
+traces require the existing device/browser harnesses and are intentionally a
+ready-for-review gate rather than inferred from VM widget timing. The draft PR
+must not be marked ready if those downstream measurements expose a regression.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -43,6 +43,7 @@ export 'src/ocr.dart';
 export 'src/page_export.dart';
 export 'src/page_geometry.dart';
 export 'src/page_number_field.dart';
+export 'src/page_render_session.dart';
 export 'src/perf_log.dart';
 export 'src/page_range_dialog.dart';
 export 'src/pdf_editor_view.dart';

--- a/packages/dart_pdf_editor/lib/src/page_render_session.dart
+++ b/packages/dart_pdf_editor/lib/src/page_render_session.dart
@@ -1,0 +1,185 @@
+import 'dart:ui' show Color;
+
+import 'package:flutter/foundation.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'render_scheduler.dart';
+
+/// The page and viewport state that determines what pixels a page view needs.
+///
+/// Adapter choices (local rendering, a worker, caches, and retained scenes)
+/// deliberately do not participate in this identity. They may change how a
+/// request is fulfilled, but not which result is current.
+@immutable
+class PdfPageRenderIntent {
+  const PdfPageRenderIntent({
+    required this.page,
+    required this.pageIndex,
+    required this.pageEpoch,
+    required this.contentStamp,
+    required this.destructiveStamp,
+    required this.trustContentStamp,
+    required this.rotation,
+    required this.pageColor,
+    required this.showAnnotations,
+    required this.scale,
+    required this.settleGeneration,
+  });
+
+  final PdfPage page;
+  final int pageIndex;
+  final int pageEpoch;
+  final int contentStamp;
+  final int destructiveStamp;
+  final bool trustContentStamp;
+  final int? rotation;
+  final Color pageColor;
+  final bool showAnnotations;
+  final double scale;
+  final int settleGeneration;
+}
+
+/// Actions required when a page render session receives a new intent.
+@immutable
+class PdfPageRenderTransition {
+  const PdfPageRenderTransition({
+    required this.dropBaseRaster,
+    required this.dropPreview,
+    required this.dropPicture,
+    required this.dropDetail,
+    required this.scheduleRender,
+  });
+
+  static const none = PdfPageRenderTransition(
+    dropBaseRaster: false,
+    dropPreview: false,
+    dropPicture: false,
+    dropDetail: false,
+    scheduleRender: false,
+  );
+
+  final bool dropBaseRaster;
+  final bool dropPreview;
+  final bool dropPicture;
+  final bool dropDetail;
+  final bool scheduleRender;
+}
+
+/// Owns page-render identity, invalidation, scheduling, and result freshness.
+///
+/// The rendering implementations remain separate adapters. This session is
+/// intentionally a small synchronous control plane around them, so it adds no
+/// work inside command replay, rasterization, or pixel transfer loops.
+class PdfPageRenderSession {
+  PdfPageRenderSession(PdfPageRenderIntent intent) : _intent = intent;
+
+  PdfPageRenderIntent _intent;
+  int _fullGeneration = 0;
+  int _detailGeneration = 0;
+  bool _holdPending = false;
+  bool _disposed = false;
+
+  PdfPageRenderIntent get intent => _intent;
+
+  /// Computes the invalidation outcome and rejects all older async results
+  /// before the adapters are asked to produce replacement pixels.
+  PdfPageRenderTransition update(PdfPageRenderIntent next) {
+    final old = _intent;
+    _intent = next;
+
+    final blanked = old.pageEpoch != next.pageEpoch ||
+        old.destructiveStamp != next.destructiveStamp;
+    final contentChanged = old.contentStamp != next.contentStamp;
+    final pageIdentityChanged = !identical(old.page, next.page);
+    final nonContentVisualChanged =
+        (pageIdentityChanged && !next.trustContentStamp) ||
+            old.trustContentStamp != next.trustContentStamp ||
+            old.rotation != next.rotation ||
+            old.pageColor != next.pageColor ||
+            old.showAnnotations != next.showAnnotations;
+    final visualChanged = contentChanged || nonContentVisualChanged;
+    final viewportChanged = old.scale != next.scale ||
+        old.settleGeneration != next.settleGeneration;
+    final pageSlotChanged = old.pageIndex != next.pageIndex;
+    final schedule = blanked || visualChanged || viewportChanged;
+
+    // A slot change alone is not a render trigger: structural edits carry a
+    // page epoch, while reorder reconciliation may merely move the same
+    // already-current page state. It does invalidate in-flight results so a
+    // worker response cannot be accepted into the recycled slot.
+    if (schedule || pageSlotChanged) {
+      invalidateFull();
+      invalidateDetail();
+    }
+    if (!schedule) return PdfPageRenderTransition.none;
+
+    return PdfPageRenderTransition(
+      dropBaseRaster: blanked,
+      dropPreview: blanked,
+      dropPicture: blanked || visualChanged,
+      // Additive annotation edits keep the existing sharp detail until the
+      // fresh patch arrives; destructive/display changes cannot safely do so.
+      dropDetail: blanked || nonContentVisualChanged,
+      scheduleRender: true,
+    );
+  }
+
+  int beginFull() => ++_fullGeneration;
+  void invalidateFull() => _fullGeneration++;
+
+  int beginDetail() => ++_detailGeneration;
+  void invalidateDetail() => _detailGeneration++;
+
+  bool acceptsFull(int generation, int pageIndex) =>
+      !_disposed &&
+      generation == _fullGeneration &&
+      pageIndex == _intent.pageIndex;
+
+  bool acceptsDetail(int generation) =>
+      !_disposed && generation == _detailGeneration;
+
+  bool matchesPage(int pageIndex) =>
+      !_disposed && pageIndex == _intent.pageIndex;
+
+  bool get hasPendingHold => _holdPending;
+
+  bool releaseHold() {
+    if (!_holdPending) return false;
+    _holdPending = false;
+    return true;
+  }
+
+  bool paused({
+    required PdfPageRenderScheduler? scheduler,
+    required ValueListenable<bool>? hold,
+  }) =>
+      scheduler?.holding ?? (hold?.value ?? false);
+
+  /// Routes a render through the shared scheduler, or through the standalone
+  /// widget's hold fallback when no scheduler adapter is supplied.
+  Future<void> request({
+    required Object owner,
+    required bool hasPicture,
+    required PdfPageRenderScheduler? scheduler,
+    required ValueListenable<bool>? hold,
+    required Future<void> Function() render,
+  }) async {
+    if (_disposed) return;
+    if (scheduler != null) {
+      scheduler.request(owner, _intent.pageIndex, render);
+      return;
+    }
+    if (!hasPicture && (hold?.value ?? false)) {
+      _holdPending = true;
+      return;
+    }
+    await render();
+  }
+
+  void dispose() {
+    _disposed = true;
+    _holdPending = false;
+    invalidateFull();
+    invalidateDetail();
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -14,6 +14,7 @@ import 'package:pdf_graphics/pdf_graphics.dart'
         PdfRenderCommand;
 
 import 'perf_log.dart';
+import 'page_render_session.dart';
 import 'performance_policy.dart';
 import 'preview_cache.dart';
 import 'render_scheduler.dart';
@@ -321,6 +322,7 @@ class PdfPageView extends StatefulWidget {
 }
 
 class _PdfPageViewState extends State<PdfPageView> {
+  late final PdfPageRenderSession _renderSession;
   Future<ui.Picture>? _picture;
 
   /// Web-only retained strip picture whose outline-text draws use the Slug
@@ -337,7 +339,6 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// is off. Lives and dies with [_picture] (see [_dropPicture]).
   PdfRetainedScene? _scene;
   ui.Image? _image;
-  int _renderGeneration = 0;
   double? _pixelRatio;
   double? _layoutWidth;
 
@@ -350,16 +351,11 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   ui.Image? _detailImage;
   Rect? _detailFraction; // patch placement as fractions of the page
-  int _detailGeneration = 0;
   Future<bool>? _progressiveDetailFuture;
 
   /// Clone of this page's cached low-res preview; painted while no full
   /// raster exists, dropped (to free the buffer) the moment one lands.
   ui.Image? _preview;
-
-  /// A render that arrived while [PdfPageView.renderHold] was up - it
-  /// fires the moment the hold releases.
-  bool _holdPending = false;
 
   // Full-page rasters stay within GPU texture limits and sane memory:
   // at most ~16.7M px (64 MB RGBA) and 8192 px per side. Past these caps
@@ -380,9 +376,24 @@ class _PdfPageViewState extends State<PdfPageView> {
         rotation: widget.rotation,
       );
 
+  PdfPageRenderIntent _renderIntent(PdfPageView source) => PdfPageRenderIntent(
+        page: source.page,
+        pageIndex: source.previewIndex,
+        pageEpoch: source.pageEpoch,
+        contentStamp: source.contentStamp,
+        destructiveStamp: source.destructiveStamp,
+        trustContentStamp: source.trustContentStamp,
+        rotation: source.rotation,
+        pageColor: source.pageColor,
+        showAnnotations: source.showAnnotations,
+        scale: source.scale,
+        settleGeneration: source.settleGeneration,
+      );
+
   @override
   void initState() {
     super.initState();
+    _renderSession = PdfPageRenderSession(_renderIntent(widget));
     widget.renderHold?.addListener(_onRenderHoldChanged);
     widget.previewCache?.addListener(_onPreviewCacheChanged);
     _liveTransformFor(widget)?.addListener(_onLiveTransformChanged);
@@ -423,8 +434,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   }
 
   void _onRenderHoldChanged() {
-    if (widget.renderHold?.value == false && _holdPending) {
-      _holdPending = false;
+    if (widget.renderHold?.value == false && _renderSession.releaseHold()) {
       if (mounted) _render();
     }
   }
@@ -480,6 +490,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   @override
   void didUpdateWidget(PdfPageView oldWidget) {
     super.didUpdateWidget(oldWidget);
+    final transition = _renderSession.update(_renderIntent(widget));
     if (!identical(oldWidget.renderHold, widget.renderHold)) {
       oldWidget.renderHold?.removeListener(_onRenderHoldChanged);
       widget.renderHold?.addListener(_onRenderHoldChanged);
@@ -517,9 +528,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       _preview = null;
       _refreshPreview();
     }
-    final blanked = oldWidget.pageEpoch != widget.pageEpoch ||
-        oldWidget.destructiveStamp != widget.destructiveStamp;
-    if (blanked) {
+    if (transition.dropBaseRaster) {
       // Either a structural document change reused this State for a different
       // page at the same slot (pageEpoch; previewIndex unchanged, so the
       // branches above don't fire), or content was removed from this page in
@@ -536,22 +545,13 @@ class _PdfPageViewState extends State<PdfPageView> {
       _preview?.dispose();
       _preview = null;
     }
-    final contentChanged = oldWidget.contentStamp != widget.contentStamp;
-    final pageIdentityChanged = !identical(oldWidget.page, widget.page);
-    final nonContentVisualChanged =
-        (pageIdentityChanged && !widget.trustContentStamp) ||
-            oldWidget.trustContentStamp != widget.trustContentStamp ||
-            oldWidget.rotation != widget.rotation ||
-            oldWidget.pageColor != widget.pageColor ||
-            oldWidget.showAnnotations != widget.showAnnotations;
-    final visualChanged = contentChanged || nonContentVisualChanged;
-    if (blanked || visualChanged) {
+    if (transition.dropPicture) {
       // Re-interpret at the new content/page. Unless we blanked above, the
       // old base raster stays up until the new render replaces it -
       // _dropPicture nulls _rasteredRatio so _renderNow still re-rasters -
       // so an additive edit on a heavy page never flashes blank.
       _dropPicture();
-      if (blanked || nonContentVisualChanged) {
+      if (transition.dropDetail) {
         // The deep-zoom detail patch is a sharper raster layered above the
         // base. For additive annotation edits, keep the stale patch for
         // sharpness and let the editing overlay's commit afterimage cover the
@@ -559,9 +559,8 @@ class _PdfPageViewState extends State<PdfPageView> {
         // and display-setting changes there is no safe afterimage, so drop it.
         _dropDetail();
       }
-      _render();
-    } else if (oldWidget.scale != widget.scale ||
-        oldWidget.settleGeneration != widget.settleGeneration) {
+    }
+    if (transition.scheduleRender) {
       // scale change re-rasters the page; a settle that only moved the
       // viewport refreshes the detail patch. Both route through _render so
       // they pace and coalesce through the scheduler (_renderNow skips the
@@ -593,6 +592,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       priority: widget.renderPriority,
     );
     widget.previewCache?.removeListener(_onPreviewCacheChanged);
+    _renderSession.dispose();
     _dropPicture();
     _image?.dispose();
     _detailImage?.dispose();
@@ -654,7 +654,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   bool _sceneHasImageDraws = false;
 
   void _dropDetail() {
-    _detailGeneration++;
+    _renderSession.invalidateDetail();
     if (_detailImage != null) {
       _detailImage?.dispose();
       _detailImage = null;
@@ -739,15 +739,17 @@ class _PdfPageViewState extends State<PdfPageView> {
     );
     if (image == null) return false;
     widget.renderScheduler?.cancel(this);
-    _renderGeneration++;
+    _renderSession.invalidateFull();
     setState(() {
       _image = image;
       _rasteredRatio = effective;
       _preview?.dispose();
       _preview = null;
     });
-    PdfPerfLog.log('full-raster cache hit page=${widget.previewIndex} '
-        '${image.width}x${image.height}');
+    PdfPerfLog.log(
+      'full-raster cache hit page=${widget.previewIndex} '
+      '${image.width}x${image.height}',
+    );
     widget.onRasterReady?.call();
     return true;
   }
@@ -767,31 +769,19 @@ class _PdfPageViewState extends State<PdfPageView> {
         (_effectiveRatio() - rastered).abs() <= rastered * 0.01) {
       return;
     }
-    final scheduler = widget.renderScheduler;
-    if (scheduler != null) {
-      // Route the first interpret AND every re-raster (zoom settle,
-      // detail-patch follow) through the scheduler: it dedupes per page
-      // (token), paces one render per frame, and defers while a scroll or
-      // zoom is in flight. The first interpret walks the content stream
-      // twice on the UI thread - what stalls fast scrolling on heavy
-      // pages. Re-rasters are a `toImage`, cheap on a raster thread but a
-      // single-threaded GPU readback on web: rapid zoom in/out used to
-      // fire one uncancellable readback per settle and they piled up,
-      // freezing the UI. Coalescing collapses them to the latest.
-      scheduler.request(this, widget.previewIndex, _renderNow);
-      return;
-    }
-    // The bare PdfPageView (no scheduler) defers only the first interpret
-    // behind renderHold; cached re-rasters run directly.
-    if (_picture == null && (widget.renderHold?.value ?? false)) {
-      _holdPending = true;
-      return;
-    }
-    await _renderNow();
+    await _renderSession.request(
+      owner: this,
+      hasPicture: _picture != null,
+      scheduler: widget.renderScheduler,
+      hold: widget.renderHold,
+      render: _renderNow,
+    );
   }
 
-  bool get _renderPaused =>
-      widget.renderScheduler?.holding ?? (widget.renderHold?.value ?? false);
+  bool get _renderPaused => _renderSession.paused(
+        scheduler: widget.renderScheduler,
+        hold: widget.renderHold,
+      );
 
   /// Interprets the page into a picture, off the UI thread when a worker is
   /// available and the page is serializable, else locally. The worker path
@@ -1095,12 +1085,12 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// production stops here (no wasted local interpret); painting is gated
   /// separately by [_superseded], which also rejects a stale generation.
   bool _abandoned(int pageIndex) =>
-      !mounted || widget.previewIndex != pageIndex;
+      !mounted || !_renderSession.matchesPage(pageIndex);
 
   /// Whether a render started at ([generation], [pageIndex]) must not paint -
   /// [_abandoned], or a newer render bumped the generation past this one.
   bool _superseded(int generation, int pageIndex) =>
-      _abandoned(pageIndex) || generation != _renderGeneration;
+      !mounted || !_renderSession.acceptsFull(generation, pageIndex);
 
   /// A zero-op picture for an abandoned render. Never painted (the caller's
   /// [_superseded] guards discard it); it only satisfies the return type.
@@ -1118,7 +1108,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// The actual interpret + rasterize, run once the first render is no
   /// longer gated (or directly for re-rasters of a cached picture).
   Future<void> _renderNow() async {
-    final generation = ++_renderGeneration;
+    final generation = _renderSession.beginFull();
     final pageIndex = widget.previewIndex;
     final firstInterpret = _picture == null;
     if (firstInterpret) _lastInterpretResultBytes = null;
@@ -1388,7 +1378,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     _DetailGeometry? detailGeometry,
     VoidCallback? onPaint,
   }) async {
-    final generation = ++_detailGeneration;
+    final generation = _renderSession.beginDetail();
     if (_renderPaused) return false;
 
     // A Slug page picture is already transform-sharp for text and vector
@@ -1460,7 +1450,9 @@ class _PdfPageViewState extends State<PdfPageView> {
         region,
         pixelRatio: ratio,
       );
-      if (mounted && generation == _detailGeneration && !_renderPaused) {
+      if (mounted &&
+          _renderSession.acceptsDetail(generation) &&
+          !_renderPaused) {
         setState(() {
           _detailImage?.dispose();
           _detailImage = vectorImage;
@@ -1485,7 +1477,9 @@ class _PdfPageViewState extends State<PdfPageView> {
       'elapsed=${detailClock.elapsedMilliseconds}ms '
       'stripImage=${workerStripImage != null} picture=${workerPicture != null}',
     );
-    if (!mounted || generation != _detailGeneration || _renderPaused) {
+    if (!mounted ||
+        !_renderSession.acceptsDetail(generation) ||
+        _renderPaused) {
       workerStripImage?.dispose();
       workerPicture?.dispose();
       return false;
@@ -1511,7 +1505,9 @@ class _PdfPageViewState extends State<PdfPageView> {
         ratio,
       );
       workerPicture.dispose();
-      if (!mounted || generation != _detailGeneration || _renderPaused) {
+      if (!mounted ||
+          !_renderSession.acceptsDetail(generation) ||
+          _renderPaused) {
         image.dispose();
         return false;
       }
@@ -1549,7 +1545,9 @@ class _PdfPageViewState extends State<PdfPageView> {
       widget.page,
       _renderPlan,
     ));
-    if (!mounted || generation != _detailGeneration || _renderPaused) {
+    if (!mounted ||
+        !_renderSession.acceptsDetail(generation) ||
+        _renderPaused) {
       return false;
     }
     // Same replay-over-nested-raster swap as the full-page path: the deep-
@@ -1566,7 +1564,9 @@ class _PdfPageViewState extends State<PdfPageView> {
         pixelRatio: ratio,
         region: region,
       );
-      if (!mounted || generation != _detailGeneration || _renderPaused) {
+      if (!mounted ||
+          !_renderSession.acceptsDetail(generation) ||
+          _renderPaused) {
         return false;
       }
       image = await scene.rasterizeRegionStrips(
@@ -1579,7 +1579,9 @@ class _PdfPageViewState extends State<PdfPageView> {
     } else {
       image = await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
     }
-    if (!mounted || generation != _detailGeneration || _renderPaused) {
+    if (!mounted ||
+        !_renderSession.acceptsDetail(generation) ||
+        _renderPaused) {
       image.dispose();
       return false;
     }
@@ -1600,7 +1602,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   }) {
     if (!PdfPerfLog.enabled) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || generation != _detailGeneration) return;
+      if (!mounted || !_renderSession.acceptsDetail(generation)) return;
       PdfPerfLog.log(
         'detail paint page=${widget.previewIndex} source=$source '
         'elapsed=${clock.elapsedMicroseconds / 1000.0}ms',
@@ -2000,7 +2002,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       );
     }
     if (_abandoned(pageIndex) ||
-        generation != _detailGeneration ||
+        !_renderSession.acceptsDetail(generation) ||
         _renderPaused ||
         detail == null) {
       return null;
@@ -2012,7 +2014,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       plan: _renderPlan,
     );
     if (_abandoned(pageIndex) ||
-        generation != _detailGeneration ||
+        !_renderSession.acceptsDetail(generation) ||
         _renderPaused) {
       scene.dispose();
       return null;

--- a/packages/dart_pdf_editor/test/benchmark_render_session_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_render_session_test.dart
@@ -1,0 +1,59 @@
+// Reproducible control-plane benchmark for PdfPageRenderSession.
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_SESSION=1 \
+//     fvm flutter test test/benchmark_render_session_test.dart --reporter expanded
+import 'dart:io';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  testWidgets('page render control-plane updates', (tester) async {
+    if (Platform.environment['PDF_BENCHMARK_SESSION'] != '1') {
+      markTestSkipped('set PDF_BENCHMARK_SESSION=1');
+      return;
+    }
+    final page = PdfDocument.open(buildMultiPagePdf(1)).page(0);
+    final hold = ValueNotifier<bool>(true);
+    addTearDown(hold.dispose);
+
+    Widget view(int generation) => MaterialApp(
+          home: SizedBox(
+            width: 612,
+            child: PdfPageView(
+              page: page,
+              scale: generation.isEven ? 1.0 : 1.01,
+              settleGeneration: generation,
+              renderHold: hold,
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(view(0));
+    for (var i = 1; i <= 30; i++) {
+      await tester.pumpWidget(view(i));
+    }
+
+    const trials = 9;
+    const updates = 300;
+    final samples = <int>[];
+    var generation = 31;
+    for (var trial = 0; trial < trials; trial++) {
+      final sw = Stopwatch()..start();
+      for (var i = 0; i < updates; i++) {
+        await tester.pumpWidget(view(generation++));
+      }
+      samples.add(sw.elapsedMicroseconds);
+    }
+    samples.sort();
+    final median = samples[samples.length ~/ 2];
+    // ignore: avoid_print
+    print('RENDER_SESSION_BENCH median_us=$median updates=$updates '
+        'us_per_update=${(median / updates).toStringAsFixed(2)} '
+        'samples=$samples');
+  });
+}

--- a/packages/dart_pdf_editor/test/page_render_session_test.dart
+++ b/packages/dart_pdf_editor/test/page_render_session_test.dart
@@ -1,0 +1,152 @@
+import 'dart:ui' show Color;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  late PdfPage page;
+
+  setUp(() {
+    page = PdfDocument.open(buildMultiPagePdf(1)).page(0);
+  });
+
+  PdfPageRenderIntent intent({
+    PdfPage? source,
+    int pageIndex = 0,
+    int pageEpoch = 0,
+    int contentStamp = 0,
+    int destructiveStamp = 0,
+    bool trustContentStamp = false,
+    int? rotation,
+    Color pageColor = const Color(0xFFFFFFFF),
+    bool showAnnotations = true,
+    double scale = 1,
+    int settleGeneration = 0,
+  }) =>
+      PdfPageRenderIntent(
+        page: source ?? page,
+        pageIndex: pageIndex,
+        pageEpoch: pageEpoch,
+        contentStamp: contentStamp,
+        destructiveStamp: destructiveStamp,
+        trustContentStamp: trustContentStamp,
+        rotation: rotation,
+        pageColor: pageColor,
+        showAnnotations: showAnnotations,
+        scale: scale,
+        settleGeneration: settleGeneration,
+      );
+
+  test('viewport changes request a reraster without dropping caches', () {
+    final session = PdfPageRenderSession(intent());
+
+    final transition = session.update(intent(scale: 2));
+
+    expect(transition.scheduleRender, isTrue);
+    expect(transition.dropPicture, isFalse);
+    expect(transition.dropBaseRaster, isFalse);
+    expect(transition.dropPreview, isFalse);
+    expect(transition.dropDetail, isFalse);
+  });
+
+  test(
+    'additive content keeps the old base and detail while replacing data',
+    () {
+      final session = PdfPageRenderSession(intent());
+
+      final transition = session.update(intent(contentStamp: 1));
+
+      expect(transition.scheduleRender, isTrue);
+      expect(transition.dropPicture, isTrue);
+      expect(transition.dropBaseRaster, isFalse);
+      expect(transition.dropPreview, isFalse);
+      expect(transition.dropDetail, isFalse);
+    },
+  );
+
+  test('destructive content invalidates every visible cache layer', () {
+    final session = PdfPageRenderSession(intent());
+
+    final transition = session.update(intent(destructiveStamp: 1));
+
+    expect(transition.scheduleRender, isTrue);
+    expect(transition.dropPicture, isTrue);
+    expect(transition.dropBaseRaster, isTrue);
+    expect(transition.dropPreview, isTrue);
+    expect(transition.dropDetail, isTrue);
+  });
+
+  test('new intent rejects stale full and detail results immediately', () {
+    final session = PdfPageRenderSession(intent());
+    final full = session.beginFull();
+    final detail = session.beginDetail();
+    expect(session.acceptsFull(full, 0), isTrue);
+    expect(session.acceptsDetail(detail), isTrue);
+
+    session.update(intent(pageColor: const Color(0xFFEEEEEE)));
+
+    expect(session.acceptsFull(full, 0), isFalse);
+    expect(session.acceptsDetail(detail), isFalse);
+  });
+
+  test('standalone hold defers exactly until release', () async {
+    final session = PdfPageRenderSession(intent());
+    final hold = ValueNotifier<bool>(true);
+    var renders = 0;
+    addTearDown(() {
+      session.dispose();
+      hold.dispose();
+    });
+
+    await session.request(
+      owner: Object(),
+      hasPicture: false,
+      scheduler: null,
+      hold: hold,
+      render: () async => renders++,
+    );
+    expect(renders, 0);
+    expect(session.hasPendingHold, isTrue);
+
+    hold.value = false;
+    expect(session.releaseHold(), isTrue);
+    await session.request(
+      owner: Object(),
+      hasPicture: false,
+      scheduler: null,
+      hold: hold,
+      render: () async => renders++,
+    );
+    expect(renders, 1);
+    expect(session.releaseHold(), isFalse);
+  });
+
+  testWidgets('scheduler adapter owns pacing without changing the outcome',
+      (tester) async {
+    final session = PdfPageRenderSession(intent());
+    final scheduler = PdfPageRenderScheduler()..holding = true;
+    var renders = 0;
+    addTearDown(() {
+      session.dispose();
+      scheduler.dispose();
+    });
+
+    await session.request(
+      owner: session,
+      hasPicture: false,
+      scheduler: scheduler,
+      hold: null,
+      render: () async => renders++,
+    );
+    expect(scheduler.hasPending, isTrue);
+    expect(renders, 0);
+
+    scheduler.holding = false;
+    await tester.pump();
+    expect(renders, 1);
+    expect(scheduler.hasPending, isFalse);
+  });
+}


### PR DESCRIPTION
Closes #256.

## What changed

- add `PdfPageRenderSession` as the control plane for page/viewport render intent
- centralize visual identity transitions and cache invalidation outcomes
- centralize full/detail generations and stale-result acceptance
- centralize standalone hold and shared scheduler routing
- leave local rendering, native/web workers, transferable buffers, previews, retained scenes, strip plans, Slug routing, and raster caches unchanged
- add outcome tests for viewport, additive, destructive, stale-result, hold, and scheduler transitions
- add a reproducible control-plane benchmark and benchmark report

This also rejects stale full/detail results immediately when a new intent is installed, rather than waiting for the next scheduled render to advance a scattered generation counter.

## Performance

The checked-in report is at `doc/benchmarks/issue-256-render-session.md`.

Baseline vs branch:

- control-plane median: 794.84 vs 785.40 µs/update (branch 1.2% faster; noisy tails overlap)
- representative cold render: 66.5 vs 67.6 ms/page (+1.7%)
- representative warm render: 54.2 vs 52.9 ms/page (-2.4%)

The renderer/raster loops are unchanged. Live browser transfer-volume, browser memory/allocation, and platform frame-jank traces remain a ready-for-review gate and are called out in the report; this PR stays draft until those device/browser measurements are satisfactory.

## Verification

- `fvm dart analyze`
- complete `dart_pdf_editor` suite: 1,385 passed, 32 skipped
- worker/preview/scheduler/retained-scene/strip/Slug parity suites
- isolated worker cancellation test on baseline and branch
- Ghent + PDF.js pure-Dart corpus suites
- Ghent baseline + PDF.js render suites
- `git diff --check`
