### PR TITLE
refactor(ui): deepen the shared sidebar panel frame

### DIFF
--- a/doc/benchmarks/issue-257-panel-frame.md
+++ b/doc/benchmarks/issue-257-panel-frame.md
@@ -1,0 +1,39 @@
+# Issue 257 sidebar-frame benchmark
+
+`PdfSidebarPanelFrame` owns width/clamping/persistence, dock and sheet
+geometry, grip and close policy, and scrollbar placement/clearance. Annotation,
+bookmark, search, properties, and thumbnail content/controllers remain separate.
+
+## Build and resize timing
+
+Run from `packages/dart_pdf_editor`:
+
+```sh
+PDF_BENCHMARK_PANEL_FRAME=1 \
+  fvm flutter test test/benchmark_panel_frame_test.dart --reporter expanded
+```
+
+Detached `23381f4` baseline versus this branch, nine trials after warmup:
+
+| revision | dock/sheet build | resize frame |
+| --- | ---: | ---: |
+| baseline | 2,702.24 us/update | 1,089.97 us/frame |
+| shared frame | 2,497.44 us/update | 767.92 us/frame |
+
+The shared frame was 7.6% faster for repeated dock/side/sheet builds and 29.5%
+faster during the synthetic resize drag. This is consistent with moving resize
+state below the content panel state rather than rebuilding the panel owner.
+
+## Behavioral performance guards
+
+- width persistence is called exactly once at drag end (frame test)
+- scroll controllers remain owned by panel content; the frame does not listen
+  to scroll ticks
+- the existing thumbnail test still asserts that an edit re-rasterizes only
+  the page it touched
+- existing shell tests cover toggling docked panels and switching to/from
+  bottom-sheet layouts
+- existing long sidebar/search/bookmark list tests keep row and scrollbar
+  behavior at the panel-specific seams
+
+The complete package test suite remains the final regression gate.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
@@ -45,7 +45,6 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
   final ScrollController _scroll = ScrollController();
   final Map<String, bool> _expanded = {};
   String? _hoveredPath;
-  double? _dragWidth;
 
   PdfEditingController get controller => widget.controller;
 
@@ -54,9 +53,6 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
     _scroll.dispose();
     super.dispose();
   }
-
-  double get _width =>
-      _dragWidth ?? controller.preferences.bookmarkSidebarWidth ?? widget.width;
 
   String _keyFor(List<int> path) => path.join('.');
 
@@ -133,12 +129,17 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
     widget.viewerController.showDestination(destination);
   }
 
-  Widget _header(BuildContext context, {required bool barInset}) {
-    final closeable = !widget.bottomSheet && widget.onClose != null;
+  Widget _header(
+    BuildContext context, {
+    required PdfSidebarPanelGeometry geometry,
+  }) {
+    final closeButton = geometry.closeButton(
+      key: const ValueKey('pdf-bookmark-panel-close'),
+    );
     final showTitle = !widget.bottomSheet;
     return Padding(
-      padding: EdgeInsets.fromLTRB(showTitle ? 16 : 8, 4,
-          barInset ? PdfSidebarResizeGrip.width + 4 : 4, 0),
+      padding: EdgeInsets.fromLTRB(
+          showTitle ? 16 : 8, 4, geometry.contentEndInset + 4, 0),
       child: Row(children: [
         if (showTitle)
           Expanded(
@@ -156,11 +157,7 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
             icon: const Icon(Icons.add),
             onPressed: () => _addBookmark(context),
           ),
-        if (closeable)
-          PdfSidebarCloseButton(
-            key: const ValueKey('pdf-bookmark-panel-close'),
-            onPressed: widget.onClose!,
-          ),
+        if (closeButton != null) closeButton,
       ]),
     );
   }
@@ -308,7 +305,10 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
     );
   }
 
-  Widget _content(BuildContext context, {required bool barInset}) {
+  Widget _content(
+    BuildContext context, {
+    required PdfSidebarPanelGeometry geometry,
+  }) {
     return ListenableBuilder(
       listenable: controller,
       builder: (context, _) {
@@ -316,7 +316,7 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
         final showHeader =
             widget.editable || (!widget.bottomSheet && widget.onClose != null);
         return Column(children: [
-          if (showHeader) _header(context, barInset: barInset),
+          if (showHeader) _header(context, geometry: geometry),
           Expanded(
             child: rows.isEmpty
                 ? _empty(context)
@@ -327,7 +327,9 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
                         bottom: 12,
                         right: widget.bottomSheet
                             ? 0
-                            : PdfSidebarResizeGrip.width),
+                            : geometry.showGrip
+                                ? PdfSidebarResizeGrip.width
+                                : 0),
                     itemCount: rows.length,
                     itemBuilder: (context, index) =>
                         _tile(context, rows[index]),
@@ -340,46 +342,22 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
 
   @override
   Widget build(BuildContext context) {
-    final showGrip = widget.resizable && !widget.bottomSheet;
-    final onLeftEdge =
-        !widget.bottomSheet && widget.side == PdfSidebarSide.left;
-    final barInset = showGrip && onLeftEdge;
-    final content = Material(
-      color: Theme.of(context).colorScheme.surfaceContainerLow,
-      child: _content(context, barInset: barInset),
-    );
-    if (widget.bottomSheet) return content;
-
-    final width = _width.clamp(widget.minWidth, widget.maxWidth).toDouble();
-    return SizedBox(
-      width: width,
-      child: Stack(children: [
-        Positioned.fill(child: content),
-        if (showGrip)
-          Positioned(
-            top: 0,
-            bottom: 0,
-            left: widget.side == PdfSidebarSide.right ? 0 : null,
-            right: widget.side == PdfSidebarSide.left ? 0 : null,
-            child: PdfSidebarResizeGrip(
-              key: const ValueKey('pdf-bookmark-resize-grip'),
-              side: widget.side,
-              onWidthDelta: (delta) {
-                setState(() {
-                  _dragWidth = (_width + delta)
-                      .clamp(widget.minWidth, widget.maxWidth)
-                      .toDouble();
-                });
-              },
-              onResizeEnd: () {
-                if (_dragWidth != null) {
-                  controller.preferences.bookmarkSidebarWidth = _dragWidth;
-                }
-                setState(() => _dragWidth = null);
-              },
-            ),
-          ),
-      ]),
+    return PdfSidebarPanelFrame(
+      width: widget.width,
+      minWidth: widget.minWidth,
+      maxWidth: widget.maxWidth,
+      persistedWidth: controller.preferences.bookmarkSidebarWidth,
+      onPersistWidth: (width) =>
+          controller.preferences.bookmarkSidebarWidth = width,
+      side: widget.side,
+      resizable: widget.resizable,
+      bottomSheet: widget.bottomSheet,
+      gripKey: const ValueKey('pdf-bookmark-resize-grip'),
+      onClose: widget.onClose,
+      builder: (context, geometry) => Material(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        child: _content(context, geometry: geometry),
+      ),
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
@@ -2,6 +2,8 @@ import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform;
 import 'package:flutter/material.dart';
 
+import '../scrollbar.dart';
+
 /// Which side of the viewer a sidebar panel is docked on. Its resize
 /// grip rides the opposite (inner) edge - the one facing the viewer.
 enum PdfSidebarSide { left, right }
@@ -112,6 +114,162 @@ class _PdfSidebarResizeGripState extends State<PdfSidebarResizeGrip> {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Geometry and shared chrome supplied to a sidebar panel's content builder.
+class PdfSidebarPanelGeometry {
+  const PdfSidebarPanelGeometry._({
+    required this.width,
+    required this.bottomSheet,
+    required this.showGrip,
+    required this.gripOnLeft,
+    required this.onClose,
+  });
+
+  final double width;
+  final bool bottomSheet;
+  final bool showGrip;
+  final bool gripOnLeft;
+  final VoidCallback? onClose;
+
+  bool get gripOnRight => showGrip && !gripOnLeft;
+  bool get scrollbarSharesGripEdge => gripOnRight;
+  double get scrollbarInset =>
+      scrollbarSharesGripEdge ? PdfSidebarResizeGrip.width : 0;
+  double get scrollbarClearance => PdfScrollbar.hitExtent + scrollbarInset;
+  double get contentStartInset => gripOnLeft ? PdfSidebarResizeGrip.width : 0;
+  double get contentEndInset => gripOnRight ? PdfSidebarResizeGrip.width : 0;
+
+  /// The docked close button; bottom sheets supply their own sheet chrome.
+  Widget? closeButton({Key? key}) => bottomSheet || onClose == null
+      ? null
+      : PdfSidebarCloseButton(key: key, onPressed: onClose!);
+
+  /// Places the package scrollbar at the shared dock-aware inset.
+  Widget withScrollbar({
+    required Widget child,
+    required ScrollController scroll,
+    required Key thumbKey,
+  }) =>
+      Stack(children: [
+        child,
+        Positioned(
+          top: 0,
+          bottom: 0,
+          right: scrollbarInset,
+          child: PdfScrollbar(scroll: scroll, thumbKey: thumbKey),
+        ),
+      ]);
+}
+
+typedef PdfSidebarPanelContentBuilder = Widget Function(
+  BuildContext context,
+  PdfSidebarPanelGeometry geometry,
+);
+
+/// Shared docked/bottom-sheet frame for sidebar panels.
+///
+/// Owns drag width, clamping, one-shot persistence, grip placement, dock
+/// insets, close policy, and scrollbar geometry. Panel-specific data, lists,
+/// and controllers remain inside [builder].
+class PdfSidebarPanelFrame extends StatefulWidget {
+  const PdfSidebarPanelFrame({
+    super.key,
+    required this.builder,
+    required this.width,
+    required this.minWidth,
+    required this.maxWidth,
+    required this.side,
+    required this.resizable,
+    required this.bottomSheet,
+    required this.gripKey,
+    this.persistedWidth,
+    this.onPersistWidth,
+    this.onClose,
+  });
+
+  final PdfSidebarPanelContentBuilder builder;
+  final double width;
+  final double minWidth;
+  final double maxWidth;
+  final double? persistedWidth;
+  final ValueChanged<double>? onPersistWidth;
+  final PdfSidebarSide side;
+  final bool resizable;
+  final bool bottomSheet;
+  final Key gripKey;
+  final VoidCallback? onClose;
+
+  @override
+  State<PdfSidebarPanelFrame> createState() => _PdfSidebarPanelFrameState();
+}
+
+class _PdfSidebarPanelFrameState extends State<PdfSidebarPanelFrame> {
+  double? _dragWidth;
+  double? _settledWidth;
+
+  double get _width =>
+      (_dragWidth ?? _settledWidth ?? widget.persistedWidth ?? widget.width)
+          .clamp(widget.minWidth, widget.maxWidth)
+          .toDouble();
+
+  @override
+  void didUpdateWidget(PdfSidebarPanelFrame oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.persistedWidth != widget.persistedWidth) {
+      _settledWidth = null;
+    }
+  }
+
+  void _resize(double delta) => setState(() {
+        _dragWidth =
+            (_width + delta).clamp(widget.minWidth, widget.maxWidth).toDouble();
+      });
+
+  void _endResize() {
+    final width = _dragWidth;
+    if (width == null) return;
+    final persist = widget.onPersistWidth;
+    if (persist == null) return; // the search panel keeps an unpersisted drag
+    persist(width); // exactly one preference write per completed drag
+    setState(() {
+      _settledWidth = width;
+      _dragWidth = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final showGrip = widget.resizable && !widget.bottomSheet;
+    final geometry = PdfSidebarPanelGeometry._(
+      width: _width,
+      bottomSheet: widget.bottomSheet,
+      showGrip: showGrip,
+      gripOnLeft: showGrip && widget.side == PdfSidebarSide.right,
+      onClose: widget.onClose,
+    );
+    final content = widget.builder(context, geometry);
+    if (widget.bottomSheet) return content;
+    return SizedBox(
+      width: geometry.width,
+      child: Stack(children: [
+        Positioned.fill(child: content),
+        if (showGrip)
+          Positioned(
+            top: 0,
+            bottom: 0,
+            left: geometry.gripOnLeft ? 0 : null,
+            right: geometry.gripOnRight ? 0 : null,
+            child: PdfSidebarResizeGrip(
+              key: widget.gripKey,
+              side: widget.side,
+              onWidthDelta: _resize,
+              onResizeEnd: _endResize,
+            ),
+          ),
+      ]),
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 
-import '../scrollbar.dart';
 import 'annotation_presentation.dart';
 import 'editing_color_picker.dart';
 import 'editing_controller.dart';
@@ -115,16 +114,9 @@ class _PdfAnnotationPropertiesPanelState
   double? _draggingOpacity;
   double? _draggingFontSize;
 
-  /// The panel width while a resize drag is in flight.
-  double? _dragWidth;
-
   PdfEditingController get _controller => widget.controller;
 
   PdfEditingPreferences get _preferences => _controller.preferences;
-
-  double get _width =>
-      (_dragWidth ?? _preferences.propertiesPanelWidth ?? widget.width)
-          .clamp(widget.minWidth, widget.maxWidth);
 
   @override
   void initState() {
@@ -157,16 +149,6 @@ class _PdfAnnotationPropertiesPanelState
 
   void _onPreferences() {
     if (mounted) setState(() {});
-  }
-
-  void _onResizeDelta(double delta) => setState(() {
-        _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
-      });
-
-  void _onResizeEnd() {
-    if (_dragWidth == null) return;
-    _preferences.propertiesPanelWidth = _dragWidth;
-    setState(() => _dragWidth = null);
   }
 
   static String _endingLabel(PdfLineEnding ending) => switch (ending) {
@@ -708,10 +690,9 @@ class _PdfAnnotationPropertiesPanelState
         leading: Icon(annotation.isCallout
             ? Icons.chat_bubble_outline
             : pdfAnnotationIcon(annotation.subtype)),
-        title: Text(
-            annotation.isCallout
-                ? 'Callout'
-                : pdfAnnotationLabel(annotation.subtype)),
+        title: Text(annotation.isCallout
+            ? 'Callout'
+            : pdfAnnotationLabel(annotation.subtype)),
         subtitle: Text('Page ${slot.$1 + 1}'),
       ),
       ..._styleControls(annotation),
@@ -780,94 +761,71 @@ class _PdfAnnotationPropertiesPanelState
 
   @override
   Widget build(BuildContext context) {
-    final showGrip = widget.resizable && !widget.bottomSheet;
-    final onLeftEdge =
-        !widget.bottomSheet && widget.side == PdfSidebarSide.left;
-    // the docked panel's close button rides a slim header; a bottom sheet
-    // supplies its own in its sheet chrome
-    final closeable = !widget.bottomSheet && widget.onClose != null;
-    final content = Material(
-      color: Theme.of(context).colorScheme.surfaceContainerLow,
-      child: Column(children: [
-        if (closeable)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 4, 4, 0),
-            child: Row(children: [
-              Expanded(
-                child: Text('Properties',
-                    style: Theme.of(context).textTheme.titleSmall),
-              ),
-              PdfSidebarCloseButton(
-                key: const ValueKey('pdf-properties-panel-close'),
-                onPressed: widget.onClose!,
-              ),
-            ]),
-          ),
-        Expanded(
-          child: ListenableBuilder(
-            listenable: _controller,
-            builder: (context, _) {
-              final annotation = _controller.selectedAnnotation;
-              _syncFields(annotation);
-              if (annotation == null) {
-                return const Center(
-                  child: Padding(
-                    padding: EdgeInsets.all(24),
-                    child: Text('Select an annotation to see its properties',
-                        textAlign: TextAlign.center),
+    return PdfSidebarPanelFrame(
+      width: widget.width,
+      minWidth: widget.minWidth,
+      maxWidth: widget.maxWidth,
+      persistedWidth: _preferences.propertiesPanelWidth,
+      onPersistWidth: (width) => _preferences.propertiesPanelWidth = width,
+      side: widget.side,
+      resizable: widget.resizable,
+      bottomSheet: widget.bottomSheet,
+      gripKey: const ValueKey('pdf-properties-resize-grip'),
+      onClose: widget.onClose,
+      builder: (context, geometry) => Material(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        child: Column(children: [
+          if (geometry.closeButton(
+            key: const ValueKey('pdf-properties-panel-close'),
+          )
+              case final closeButton?)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 4, 0),
+              child: Row(children: [
+                Expanded(
+                  child: Text('Properties',
+                      style: Theme.of(context).textTheme.titleSmall),
+                ),
+                closeButton,
+              ]),
+            ),
+          Expanded(
+            child: ListenableBuilder(
+              listenable: _controller,
+              builder: (context, _) {
+                final annotation = _controller.selectedAnnotation;
+                _syncFields(annotation);
+                if (annotation == null) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(24),
+                      child: Text('Select an annotation to see its properties',
+                          textAlign: TextAlign.center),
+                    ),
+                  );
+                }
+                final count = _controller.selectedAnnotationSlots.length;
+                final children = count == 1
+                    ? _buildSingle(annotation)
+                    : _buildMulti(annotation, count);
+                return geometry.withScrollbar(
+                  scroll: _scroll,
+                  thumbKey: const ValueKey('pdf-properties-scrollbar-thumb'),
+                  child: ScrollConfiguration(
+                    behavior: ScrollConfiguration.of(context)
+                        .copyWith(scrollbars: false),
+                    child: ListView(
+                        controller: _scroll,
+                        padding:
+                            EdgeInsets.only(right: geometry.scrollbarClearance),
+                        children: children),
                   ),
                 );
-              }
-              final count = _controller.selectedAnnotationSlots.length;
-              final children = count == 1
-                  ? _buildSingle(annotation)
-                  : _buildMulti(annotation, count);
-              final barClearance = PdfScrollbar.hitExtent +
-                  (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
-              return Stack(children: [
-                ScrollConfiguration(
-                  behavior: ScrollConfiguration.of(context)
-                      .copyWith(scrollbars: false),
-                  child: ListView(
-                      controller: _scroll,
-                      padding: EdgeInsets.only(right: barClearance),
-                      children: children),
-                ),
-                Positioned(
-                  top: 0,
-                  bottom: 0,
-                  right:
-                      showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
-                  child: PdfScrollbar(
-                    scroll: _scroll,
-                    thumbKey: const ValueKey('pdf-properties-scrollbar-thumb'),
-                  ),
-                ),
-              ]);
-            },
-          ),
-        ),
-      ]),
-    );
-    if (widget.bottomSheet) return content;
-    return SizedBox(
-      width: _width,
-      child: Stack(children: [
-        Positioned.fill(child: content),
-        if (showGrip)
-          Positioned(
-            top: 0,
-            bottom: 0,
-            left: widget.side == PdfSidebarSide.right ? 0 : null,
-            right: widget.side == PdfSidebarSide.left ? 0 : null,
-            child: PdfSidebarResizeGrip(
-              key: const ValueKey('pdf-properties-resize-grip'),
-              side: widget.side,
-              onWidthDelta: _onResizeDelta,
-              onResizeEnd: _onResizeEnd,
+              },
             ),
           ),
-      ]),
+        ]),
+      ),
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -5,7 +5,6 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 import '../pdf_viewer.dart';
-import '../scrollbar.dart';
 import 'annotation_presentation.dart';
 import 'editing_controller.dart';
 import 'editing_panel.dart';
@@ -125,15 +124,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   /// text-free extractions.
   final Map<int, PdfPageText?> _pageTexts = {};
 
-  /// The panel width while a resize drag is in flight, overriding the
-  /// preference until the drag ends and persists it.
-  double? _dragWidth;
-
   PdfEditingPreferences get _preferences => widget.controller.preferences;
-
-  double get _width =>
-      (_dragWidth ?? _preferences.annotationSidebarWidth ?? widget.width)
-          .clamp(widget.minWidth, widget.maxWidth);
 
   @override
   void initState() {
@@ -168,16 +159,6 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
     final next = hovering ? slot : (_hoveredSlot == slot ? null : _hoveredSlot);
     if (next == _hoveredSlot) return;
     setState(() => _hoveredSlot = next);
-  }
-
-  void _onResizeDelta(double delta) => setState(() {
-        _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
-      });
-
-  void _onResizeEnd() {
-    if (_dragWidth == null) return;
-    _preferences.annotationSidebarWidth = _dragWidth;
-    setState(() => _dragWidth = null);
   }
 
   /// A finer title for form fields, from the inherited /FT.
@@ -256,10 +237,15 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
         _detail(pageIndex, annotation).toLowerCase().contains(query);
   }
 
-  Widget _searchField(BuildContext context) {
+  Widget _searchField(
+    BuildContext context,
+    PdfSidebarPanelGeometry geometry,
+  ) {
     // the docked panel's close button rides the right of the filter row;
     // a bottom sheet supplies its own in its sheet chrome
-    final closeable = !widget.bottomSheet && widget.onClose != null;
+    final closeButton = geometry.closeButton(
+      key: const ValueKey('pdf-annotation-panel-close'),
+    );
     final field = TextField(
       key: const ValueKey('pdf-annotation-search'),
       controller: _search,
@@ -280,14 +266,11 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
       ),
     );
     return Padding(
-      padding: EdgeInsets.fromLTRB(12, 8, closeable ? 4 : 12, 4),
-      child: closeable
+      padding: EdgeInsets.fromLTRB(12, 8, closeButton != null ? 4 : 12, 4),
+      child: closeButton != null
           ? Row(children: [
               Expanded(child: field),
-              PdfSidebarCloseButton(
-                key: const ValueKey('pdf-annotation-panel-close'),
-                onPressed: widget.onClose!,
-              ),
+              closeButton,
             ])
           : field,
     );
@@ -575,137 +558,114 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
 
   @override
   Widget build(BuildContext context) {
-    // a bottom sheet supplies its own width and resize affordance, so the
-    // panel drops the side resize grip and fills its parent
-    final showGrip = widget.resizable && !widget.bottomSheet;
-    final onLeftEdge =
-        !widget.bottomSheet && widget.side == PdfSidebarSide.left;
-    final content = Material(
-      color: Theme.of(context).colorScheme.surfaceContainerLow,
-      child: ListenableBuilder(
-        listenable: widget.controller,
-        builder: (context, _) {
-          final document = widget.controller.document;
-          if (!identical(document, _builtFor)) {
-            // already rebuilding - adjust the state in place
-            _builtFor = document;
-            _checked.clear();
-            _hoveredSlot = null;
-            _selecting = false;
-            _pageTexts.clear();
-            // a revision closes any open reply field (the sent reply
-            // is what produced the new revision)
-            _replyingTo = null;
-          }
-          final query = _search.text.trim().toLowerCase();
-          final children = <Widget>[];
-          var listed = 0;
-          for (var page = 0; page < document.pageCount; page++) {
-            final annotations = widget.controller.pageAt(page).annotations;
-            // map each thread to its root's dictionary so a tile can
-            // render its replies and state inline
-            final threadByDict = {
-              for (final thread in widget.controller.commentThreads(page))
-                thread.root.annotation.dict: thread,
-            };
-            final tiles = <Widget>[];
-            for (var i = 0; i < annotations.length; i++) {
-              final annotation = annotations[i];
-              if (_unlisted.contains(annotation.subtype)) continue;
-              // replies and review-state annotations are thread
-              // content - shown nested under their root, not as their
-              // own top-level rows
-              if (annotation.isReply || annotation.isStateAnnotation) {
-                continue;
+    return PdfSidebarPanelFrame(
+      width: widget.width,
+      minWidth: widget.minWidth,
+      maxWidth: widget.maxWidth,
+      persistedWidth: _preferences.annotationSidebarWidth,
+      onPersistWidth: (width) => _preferences.annotationSidebarWidth = width,
+      side: widget.side,
+      resizable: widget.resizable,
+      bottomSheet: widget.bottomSheet,
+      gripKey: const ValueKey('pdf-annotation-resize-grip'),
+      onClose: widget.onClose,
+      builder: (context, geometry) => Material(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        child: ListenableBuilder(
+          listenable: widget.controller,
+          builder: (context, _) {
+            final document = widget.controller.document;
+            if (!identical(document, _builtFor)) {
+              // already rebuilding - adjust the state in place
+              _builtFor = document;
+              _checked.clear();
+              _hoveredSlot = null;
+              _selecting = false;
+              _pageTexts.clear();
+              // a revision closes any open reply field (the sent reply
+              // is what produced the new revision)
+              _replyingTo = null;
+            }
+            final query = _search.text.trim().toLowerCase();
+            final children = <Widget>[];
+            var listed = 0;
+            for (var page = 0; page < document.pageCount; page++) {
+              final annotations = widget.controller.pageAt(page).annotations;
+              // map each thread to its root's dictionary so a tile can
+              // render its replies and state inline
+              final threadByDict = {
+                for (final thread in widget.controller.commentThreads(page))
+                  thread.root.annotation.dict: thread,
+              };
+              final tiles = <Widget>[];
+              for (var i = 0; i < annotations.length; i++) {
+                final annotation = annotations[i];
+                if (_unlisted.contains(annotation.subtype)) continue;
+                // replies and review-state annotations are thread
+                // content - shown nested under their root, not as their
+                // own top-level rows
+                if (annotation.isReply || annotation.isStateAnnotation) {
+                  continue;
+                }
+                listed++;
+                if (!_matches(query, page, annotation)) continue;
+                tiles.add(_tile(context, page, i, annotation));
+                // a markup annotation hosts a comment thread
+                if (annotation.behavior.selectable) {
+                  tiles.addAll(_threadSection(context, page, annotation,
+                      threadByDict[annotation.dict]));
+                }
               }
-              listed++;
-              if (!_matches(query, page, annotation)) continue;
-              tiles.add(_tile(context, page, i, annotation));
-              // a markup annotation hosts a comment thread
-              if (annotation.behavior.selectable) {
-                tiles.addAll(_threadSection(
-                    context, page, annotation, threadByDict[annotation.dict]));
+              if (tiles.isNotEmpty) {
+                children
+                  ..add(Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                    child: Text('Page ${page + 1}',
+                        style: Theme.of(context).textTheme.labelLarge),
+                  ))
+                  ..addAll(tiles);
               }
             }
-            if (tiles.isNotEmpty) {
-              children
-                ..add(Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-                  child: Text('Page ${page + 1}',
-                      style: Theme.of(context).textTheme.labelLarge),
-                ))
-                ..addAll(tiles);
-            }
-          }
-          // the viewer-style scrollbar replaces the implicit
-          // desktop bar; it wraps only the list, so the
-          // multi-select header above stays clear of it. Stepped
-          // off the resize grip when the grip rides the same
-          // (right) edge.
-          // keep the list clear of the overlay scrollbar's zone so
-          // the bar never covers a tile's trailing button
-          final barClearance = PdfScrollbar.hitExtent +
-              (showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0);
-          final list = children.isEmpty
-              ? Center(
-                  child: Text(listed > 0 && query.isNotEmpty
-                      ? 'No matching annotations'
-                      : 'No annotations'))
-              : Stack(children: [
-                  ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(context)
-                        .copyWith(scrollbars: false),
-                    child: ListView(
-                        controller: _scroll,
-                        padding: EdgeInsets.only(right: barClearance),
-                        children: children),
-                  ),
-                  Positioned(
-                    top: 0,
-                    bottom: 0,
-                    right:
-                        showGrip && onLeftEdge ? PdfSidebarResizeGrip.width : 0,
-                    child: PdfScrollbar(
-                      scroll: _scroll,
-                      thumbKey:
-                          const ValueKey('pdf-annotation-scrollbar-thumb'),
+            // the viewer-style scrollbar replaces the implicit
+            // desktop bar; it wraps only the list, so the
+            // multi-select header above stays clear of it. Stepped
+            // off the resize grip when the grip rides the same
+            // (right) edge.
+            // keep the list clear of the overlay scrollbar's zone so
+            // the bar never covers a tile's trailing button
+            final list = children.isEmpty
+                ? Center(
+                    child: Text(listed > 0 && query.isNotEmpty
+                        ? 'No matching annotations'
+                        : 'No annotations'))
+                : geometry.withScrollbar(
+                    scroll: _scroll,
+                    thumbKey: const ValueKey('pdf-annotation-scrollbar-thumb'),
+                    child: ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(context)
+                          .copyWith(scrollbars: false),
+                      child: ListView(
+                          controller: _scroll,
+                          padding: EdgeInsets.only(
+                              right: geometry.scrollbarClearance),
+                          children: children),
                     ),
-                  ),
-                ]);
-          // one shape for both modes, with the list keyed: the
-          // header appearing must not move the list to a new
-          // element (the controller would sit attached to two
-          // scroll views for a frame)
-          return Column(children: [
-            _searchField(context),
-            if (_selecting) _selectionHeader(context),
-            Expanded(
-              key: const ValueKey('pdf-annotation-list'),
-              child: list,
-            ),
-          ]);
-        },
+                  );
+            // one shape for both modes, with the list keyed: the
+            // header appearing must not move the list to a new
+            // element (the controller would sit attached to two
+            // scroll views for a frame)
+            return Column(children: [
+              _searchField(context, geometry),
+              if (_selecting) _selectionHeader(context),
+              Expanded(
+                key: const ValueKey('pdf-annotation-list'),
+                child: list,
+              ),
+            ]);
+          },
+        ),
       ),
-    );
-    if (widget.bottomSheet) return content;
-    return SizedBox(
-      width: _width,
-      child: Stack(children: [
-        Positioned.fill(child: content),
-        if (showGrip)
-          Positioned(
-            top: 0,
-            bottom: 0,
-            left: widget.side == PdfSidebarSide.right ? 0 : null,
-            right: widget.side == PdfSidebarSide.left ? 0 : null,
-            child: PdfSidebarResizeGrip(
-              key: const ValueKey('pdf-annotation-resize-grip'),
-              side: widget.side,
-              onWidthDelta: _onResizeDelta,
-              onResizeEnd: _onResizeEnd,
-            ),
-          ),
-      ]),
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -167,9 +167,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   /// built tile.
   final Map<int, GlobalKey> _tileKeys = {};
 
-  /// The panel width while a resize drag is in flight, overriding the
-  /// preference until the drag ends and persists it.
-  double? _dragWidth;
+  PdfSidebarPanelGeometry? _frameGeometry;
 
   int _lastCurrent = 0;
 
@@ -262,27 +260,30 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
             _moveKeyboardSelection(1),
       };
 
-  double get _width =>
-      (_dragWidth ?? _preferences.thumbnailSidebarWidth ?? widget.width)
-          .clamp(widget.minWidth, widget.maxWidth);
+  double get _frameWidth =>
+      _frameGeometry?.width ??
+      (_preferences.thumbnailSidebarWidth ?? widget.width)
+          .clamp(widget.minWidth, widget.maxWidth)
+          .toDouble();
 
   /// The scrollbar (and, when it rides the same right edge, the resize
   /// grip) overlay the list - the list keeps clear of that zone so the
   /// bar never covers a tile. Tiles already pad 12px on their own.
   double get _barClearance =>
+      _frameGeometry?.scrollbarClearance ??
       PdfScrollbar.hitExtent +
-      (widget.resizable &&
-              !widget.bottomSheet &&
-              widget.side == PdfSidebarSide.left
-          ? PdfSidebarResizeGrip.width
-          : 0);
+          (widget.resizable &&
+                  !widget.bottomSheet &&
+                  widget.side == PdfSidebarSide.left
+              ? PdfSidebarResizeGrip.width
+              : 0);
 
   double get _extraRightPadding => math.max(0, _barClearance - 12);
 
   /// The width a tile's thumbnail actually lays out at: panel width less
   /// the tile's 12px side paddings, the 1px borders, and the scrollbar
   /// clearance.
-  double get _tileWidth => _width - 26 - _extraRightPadding;
+  double get _tileWidth => _frameWidth - 26 - _extraRightPadding;
 
   @override
   void initState() {
@@ -423,19 +424,29 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     return offset;
   }
 
-  void _onResizeDelta(double delta) => setState(() {
-        _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
-      });
-
-  void _onResizeEnd() {
-    if (_dragWidth == null) return;
-    _preferences.thumbnailSidebarWidth = _dragWidth;
-    setState(() => _dragWidth = null);
-  }
-
   @override
   Widget build(BuildContext context) {
-    final width = _width;
+    return PdfSidebarPanelFrame(
+      width: widget.width,
+      minWidth: widget.minWidth,
+      maxWidth: widget.maxWidth,
+      persistedWidth: _preferences.thumbnailSidebarWidth,
+      onPersistWidth: (width) => _preferences.thumbnailSidebarWidth = width,
+      side: widget.side,
+      resizable: widget.resizable,
+      bottomSheet: widget.bottomSheet,
+      gripKey: const ValueKey('pdf-thumbnail-resize-grip'),
+      onClose: widget.onClose,
+      builder: _buildFrame,
+    );
+  }
+
+  Widget _buildFrame(
+    BuildContext context,
+    PdfSidebarPanelGeometry geometry,
+  ) {
+    _frameGeometry = geometry;
+    final width = geometry.width;
     final controller = widget.controller;
     // persist thumbnails to disk (bound to this document) so a later session
     // opens onto already-rendered pages instead of re-interpreting them
@@ -458,7 +469,6 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // a bottom sheet supplies its own width and resize affordance, so the
     // strip drops the side resize grip; the tile column keeps its preferred
     // width, centered in the wider sheet rather than stretched
-    final showGrip = widget.resizable && !widget.bottomSheet;
     // [inset] centers the tile column inside a full-width parent: in a
     // bottom sheet the list fills the whole sheet (so a drag anywhere in
     // it scrolls - not just over the narrow tile column) and the inset is
@@ -527,12 +537,11 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                             ),
                             // the docked strip's close button; a bottom sheet
                             // supplies its own in its sheet chrome
-                            if (!widget.bottomSheet && widget.onClose != null)
-                              PdfSidebarCloseButton(
-                                key:
-                                    const ValueKey('pdf-thumbnail-panel-close'),
-                                onPressed: widget.onClose!,
-                              ),
+                            if (geometry.closeButton(
+                              key: const ValueKey('pdf-thumbnail-panel-close'),
+                            )
+                                case final closeButton?)
+                              closeButton,
                           ],
                         ),
                       ),
@@ -624,35 +633,17 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       });
     }
 
-    return SizedBox(
-      width: width,
-      child: Stack(children: [
-        Positioned.fill(child: buildList(0)),
-        // stepped off the resize grip when the grip rides the same
-        // (right) edge
-        Positioned(
-          top: 0,
-          bottom: 0,
-          right: showGrip && widget.side == PdfSidebarSide.left
-              ? PdfSidebarResizeGrip.width
-              : 0,
-          child: scrollbar,
-        ),
-        if (showGrip)
-          Positioned(
-            top: 0,
-            bottom: 0,
-            left: widget.side == PdfSidebarSide.right ? 0 : null,
-            right: widget.side == PdfSidebarSide.left ? 0 : null,
-            child: PdfSidebarResizeGrip(
-              key: const ValueKey('pdf-thumbnail-resize-grip'),
-              side: widget.side,
-              onWidthDelta: _onResizeDelta,
-              onResizeEnd: _onResizeEnd,
-            ),
-          ),
-      ]),
-    );
+    return Stack(children: [
+      Positioned.fill(child: buildList(0)),
+      // stepped off the resize grip when the grip rides the same
+      // (right) edge
+      Positioned(
+        top: 0,
+        bottom: 0,
+        right: geometry.scrollbarInset,
+        child: scrollbar,
+      ),
+    ]);
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/search_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/search_panel.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'editing/editing_panel.dart';
 import 'editing/editing_preferences.dart';
 import 'pdf_viewer.dart';
-import 'scrollbar.dart';
 import 'theme.dart';
 
 /// A compact document-search field: a slim text box with the match
@@ -260,11 +259,6 @@ class PdfSearchResultsPanel extends StatefulWidget {
 
 class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
   final ScrollController _scroll = ScrollController();
-  double? _dragWidth;
-
-  double get _width =>
-      (_dragWidth ?? widget.preferences?.searchPanelWidth ?? widget.width)
-          .clamp(widget.minWidth, widget.maxWidth);
 
   @override
   void initState() {
@@ -290,18 +284,6 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
 
   void _onPreferences() {
     if (mounted) setState(() {});
-  }
-
-  void _onResizeDelta(double delta) => setState(() {
-        _dragWidth = (_width + delta).clamp(widget.minWidth, widget.maxWidth);
-      });
-
-  void _onResizeEnd() {
-    final preferences = widget.preferences;
-    if (preferences == null || _dragWidth == null) return;
-    // without preferences the dragged width simply stays in _dragWidth
-    preferences.searchPanelWidth = _dragWidth;
-    setState(() => _dragWidth = null);
   }
 
   Widget _hint(String message) => Center(
@@ -342,7 +324,10 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
 
   /// The state-dependent body below the options bar: a hint, the spinner,
   /// the "no matches" line, or the grouped results list with its scrollbar.
-  Widget _body(BuildContext context, {required bool barInset}) {
+  Widget _body(
+    BuildContext context, {
+    required PdfSidebarPanelGeometry geometry,
+  }) {
     final controller = widget.controller;
     if (controller.query.isEmpty) {
       return _hint('Search the document to list every match here');
@@ -363,11 +348,11 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
       }
       entries.add((header: null, result: i));
     }
-    final barClearance =
-        PdfScrollbar.hitExtent + (barInset ? PdfSidebarResizeGrip.width : 0);
     final textTheme = Theme.of(context).textTheme;
-    return Stack(children: [
-      Column(children: [
+    return geometry.withScrollbar(
+      scroll: _scroll,
+      thumbKey: const ValueKey('pdf-search-scrollbar-thumb'),
+      child: Column(children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
           child: Row(children: [
@@ -386,7 +371,8 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
             child: ListView.builder(
               key: const ValueKey('pdf-search-results-list'),
               controller: _scroll,
-              padding: EdgeInsets.only(right: barClearance, bottom: 8),
+              padding: EdgeInsets.only(
+                  right: geometry.scrollbarClearance, bottom: 8),
               itemCount: entries.length,
               itemBuilder: (context, index) {
                 final entry = entries[index];
@@ -405,89 +391,67 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
           ),
         ),
       ]),
-      Positioned(
-        top: 0,
-        bottom: 0,
-        right: barInset ? PdfSidebarResizeGrip.width : 0,
-        child: PdfScrollbar(
-          scroll: _scroll,
-          thumbKey: const ValueKey('pdf-search-scrollbar-thumb'),
-        ),
-      ),
-    ]);
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final controller = widget.controller;
-    final showGrip = widget.resizable && !widget.bottomSheet;
-    final onLeftEdge =
-        !widget.bottomSheet && widget.side == PdfSidebarSide.left;
-    final barInset = showGrip && onLeftEdge;
-    final dividerStartIndent =
-        showGrip && !onLeftEdge ? PdfSidebarResizeGrip.width : 0.0;
-    final dividerEndIndent = barInset ? PdfSidebarResizeGrip.width : 0.0;
-    final content = Material(
-      color: Theme.of(context).colorScheme.surfaceContainerLow,
-      child: ListenableBuilder(
-        listenable: controller,
-        builder: (context, _) => Column(children: [
-          // the docked panel's close button; a bottom sheet supplies
-          // its own in its sheet chrome
-          if (!widget.bottomSheet && widget.onClose != null)
-            Padding(
-              // clear the right-edge resize grip when it rides this side
-              padding: EdgeInsets.fromLTRB(
-                  16, 4, barInset ? PdfSidebarResizeGrip.width + 4 : 4, 0),
-              child: Row(children: [
-                Expanded(
-                  child: Text('Search results',
-                      style: Theme.of(context).textTheme.titleSmall),
-                ),
-                PdfSidebarCloseButton(
-                  key: const ValueKey('pdf-search-panel-close'),
-                  onPressed: widget.onClose!,
-                ),
-              ]),
-            ),
-          if (widget.showOptions) ...[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: _SearchOptionsBar(
-                    controller: controller, preferences: widget.preferences),
+    return PdfSidebarPanelFrame(
+      width: widget.width,
+      minWidth: widget.minWidth,
+      maxWidth: widget.maxWidth,
+      persistedWidth: widget.preferences?.searchPanelWidth,
+      onPersistWidth: widget.preferences == null
+          ? null
+          : (width) => widget.preferences!.searchPanelWidth = width,
+      side: widget.side,
+      resizable: widget.resizable,
+      bottomSheet: widget.bottomSheet,
+      gripKey: const ValueKey('pdf-search-resize-grip'),
+      onClose: widget.onClose,
+      builder: (context, geometry) => Material(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        child: ListenableBuilder(
+          listenable: controller,
+          builder: (context, _) => Column(children: [
+            // the docked panel's close button; a bottom sheet supplies
+            // its own in its sheet chrome
+            if (geometry.closeButton(
+              key: const ValueKey('pdf-search-panel-close'),
+            )
+                case final closeButton?)
+              Padding(
+                // clear the right-edge resize grip when it rides this side
+                padding:
+                    EdgeInsets.fromLTRB(16, 4, geometry.contentEndInset + 4, 0),
+                child: Row(children: [
+                  Expanded(
+                    child: Text('Search results',
+                        style: Theme.of(context).textTheme.titleSmall),
+                  ),
+                  closeButton,
+                ]),
               ),
-            ),
-            Divider(
-              height: 1,
-              indent: dividerStartIndent,
-              endIndent: dividerEndIndent,
-            ),
-          ],
-          Expanded(child: _body(context, barInset: barInset)),
-        ]),
+            if (widget.showOptions) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: _SearchOptionsBar(
+                      controller: controller, preferences: widget.preferences),
+                ),
+              ),
+              Divider(
+                height: 1,
+                indent: geometry.contentStartInset,
+                endIndent: geometry.contentEndInset,
+              ),
+            ],
+            Expanded(child: _body(context, geometry: geometry)),
+          ]),
+        ),
       ),
-    );
-    if (widget.bottomSheet) return content;
-    return SizedBox(
-      width: _width,
-      child: Stack(children: [
-        Positioned.fill(child: content),
-        if (showGrip)
-          Positioned(
-            top: 0,
-            bottom: 0,
-            left: widget.side == PdfSidebarSide.right ? 0 : null,
-            right: widget.side == PdfSidebarSide.left ? 0 : null,
-            child: PdfSidebarResizeGrip(
-              key: const ValueKey('pdf-search-resize-grip'),
-              side: widget.side,
-              onWidthDelta: _onResizeDelta,
-              onResizeEnd: _onResizeEnd,
-            ),
-          ),
-      ]),
     );
   }
 }

--- a/packages/dart_pdf_editor/test/benchmark_panel_frame_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_panel_frame_test.dart
@@ -1,0 +1,79 @@
+// Reproducible build/resize benchmark for PdfSidebarPanelFrame.
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_PANEL_FRAME=1 \
+//     fvm flutter test test/benchmark_panel_frame_test.dart --reporter expanded
+import 'dart:io';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('panel layout and resize control plane', (tester) async {
+    if (Platform.environment['PDF_BENCHMARK_PANEL_FRAME'] != '1') {
+      markTestSkipped('set PDF_BENCHMARK_PANEL_FRAME=1');
+      return;
+    }
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+
+    Widget panel(int generation) => MaterialApp(
+          home: SizedBox(
+            width: 800,
+            height: 600,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: PdfSearchResultsPanel(
+                controller: controller,
+                side: generation.isEven
+                    ? PdfSidebarSide.left
+                    : PdfSidebarSide.right,
+                bottomSheet: generation % 3 == 0,
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(panel(0));
+    for (var i = 1; i <= 30; i++) {
+      await tester.pumpWidget(panel(i));
+    }
+    const trials = 9;
+    const updates = 250;
+    final buildSamples = <int>[];
+    var generation = 31;
+    for (var trial = 0; trial < trials; trial++) {
+      final sw = Stopwatch()..start();
+      for (var i = 0; i < updates; i++) {
+        await tester.pumpWidget(panel(generation++));
+      }
+      buildSamples.add(sw.elapsedMicroseconds);
+    }
+    buildSamples.sort();
+
+    final resizeSamples = <int>[];
+    for (var trial = 0; trial < trials; trial++) {
+      await tester.pumpWidget(panel(1));
+      final grip = find.byKey(const ValueKey('pdf-search-resize-grip'));
+      final gesture = await tester.startGesture(tester.getCenter(grip));
+      final sw = Stopwatch()..start();
+      for (var i = 0; i < 80; i++) {
+        await gesture.moveBy(const Offset(-0.5, 0));
+        await tester.pump();
+      }
+      resizeSamples.add(sw.elapsedMicroseconds);
+      await gesture.up();
+      await tester.pump();
+    }
+    resizeSamples.sort();
+
+    final buildMedian = buildSamples[trials ~/ 2];
+    final resizeMedian = resizeSamples[trials ~/ 2];
+    // ignore: avoid_print
+    print('PANEL_FRAME_BENCH build_median_us=$buildMedian '
+        'build_us_per_update=${(buildMedian / updates).toStringAsFixed(2)} '
+        'resize_median_us=$resizeMedian '
+        'resize_us_per_frame=${(resizeMedian / 80).toStringAsFixed(2)}');
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_panel_frame_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panel_frame_test.dart
@@ -1,0 +1,132 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget host({
+    required PdfSidebarSide side,
+    bool bottomSheet = false,
+    ValueChanged<double>? onPersistWidth,
+    VoidCallback? onClose,
+    PdfSidebarPanelContentBuilder? builder,
+  }) =>
+      MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 400,
+            height: 500,
+            child: Align(
+              alignment: Alignment.topLeft,
+              child: PdfSidebarPanelFrame(
+                width: 240,
+                minWidth: 180,
+                maxWidth: 320,
+                persistedWidth: null,
+                onPersistWidth: onPersistWidth,
+                side: side,
+                resizable: true,
+                bottomSheet: bottomSheet,
+                gripKey: const ValueKey('frame-grip'),
+                onClose: onClose,
+                builder: builder ??
+                    (context, geometry) => ColoredBox(
+                          key: const ValueKey('frame-content'),
+                          color: Colors.white,
+                          child: geometry.closeButton(
+                                key: const ValueKey('frame-close'),
+                              ) ??
+                              const SizedBox.expand(),
+                        ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('dock geometry covers both sides and scrollbar clearance',
+      (tester) async {
+    late PdfSidebarPanelGeometry geometry;
+    final scroll = ScrollController();
+    addTearDown(scroll.dispose);
+
+    await tester.pumpWidget(host(
+      side: PdfSidebarSide.left,
+      builder: (context, value) {
+        geometry = value;
+        return value.withScrollbar(
+          scroll: scroll,
+          thumbKey: const ValueKey('frame-scrollbar'),
+          child: const SizedBox.expand(),
+        );
+      },
+    ));
+    expect(geometry.gripOnRight, isTrue);
+    expect(geometry.scrollbarInset, PdfSidebarResizeGrip.width);
+    expect(geometry.scrollbarClearance,
+        PdfScrollbar.hitExtent + PdfSidebarResizeGrip.width);
+    expect(find.byType(PdfScrollbar), findsOneWidget);
+    final leftGrip = tester.getCenter(find.byKey(const ValueKey('frame-grip')));
+    expect(leftGrip.dx, closeTo(236, 0.1));
+
+    await tester.pumpWidget(host(
+      side: PdfSidebarSide.right,
+      builder: (context, value) {
+        geometry = value;
+        return const SizedBox.expand();
+      },
+    ));
+    expect(geometry.gripOnLeft, isTrue);
+    expect(geometry.scrollbarInset, 0);
+    final rightGrip =
+        tester.getCenter(find.byKey(const ValueKey('frame-grip')));
+    expect(rightGrip.dx, closeTo(4, 0.1));
+  });
+
+  testWidgets('grip clamps width and persists once at drag end',
+      (tester) async {
+    var writes = 0;
+    double? persisted;
+    await tester.pumpWidget(host(
+      side: PdfSidebarSide.left,
+      onPersistWidth: (value) {
+        writes++;
+        persisted = value;
+      },
+    ));
+
+    final grip = find.byKey(const ValueKey('frame-grip'));
+    final gesture = await tester.startGesture(tester.getCenter(grip));
+    await gesture.moveBy(const Offset(60, 0));
+    await tester.pump();
+    expect(writes, 0);
+    await gesture.up();
+    await tester.pump();
+
+    expect(writes, 1);
+    expect(persisted, closeTo(300, 1));
+    expect(tester.getSize(find.byType(PdfSidebarPanelFrame)).width,
+        closeTo(300, 1));
+  });
+
+  testWidgets('close is docked-only and bottom sheet bypasses fixed width',
+      (tester) async {
+    var closes = 0;
+    await tester.pumpWidget(host(
+      side: PdfSidebarSide.left,
+      onClose: () => closes++,
+    ));
+    await tester.tap(find.byKey(const ValueKey('frame-close')));
+    expect(closes, 1);
+    expect(find.byKey(const ValueKey('frame-grip')), findsOneWidget);
+
+    await tester.pumpWidget(host(
+      side: PdfSidebarSide.left,
+      bottomSheet: true,
+      onClose: () => closes++,
+    ));
+    expect(find.byKey(const ValueKey('frame-close')), findsNothing);
+    expect(find.byKey(const ValueKey('frame-grip')), findsNothing);
+    expect(
+        tester.getSize(find.byKey(const ValueKey('frame-content'))).width, 400);
+  });
+}


### PR DESCRIPTION
Closes #257.

## What changed

- deepen `editing_panel.dart` with one stateful `PdfSidebarPanelFrame`
- centralize width selection, clamping, drag state, and one-shot persistence
- centralize left/right dock geometry, grip placement, close-button policy, bottom-sheet bypass, and scrollbar inset/clearance
- migrate annotation, bookmark, properties, search-results, and thumbnail panels
- preserve panel-specific content, controllers, list builders, and scroll ownership
- preserve existing preference keys, widget keys, semantics, and hit targets
- add one frame-level test matrix covering both dock sides, persistence, close behavior, sheet mode, and scrollbar clearance
- add a reproducible panel build/resize benchmark and report

## Performance

Baseline vs branch, nine trials after warmup:

- repeated dock/side/sheet builds: 2,702.24 → 2,497.44 µs/update (7.6% faster)
- synthetic resize frames: 1,089.97 → 767.92 µs/frame (29.5% faster)

Additional guards:

- exactly one preference write per completed drag
- frame does not listen to scroll ticks
- existing thumbnail test still pins rerasterization to the touched page only
- existing shell tests cover docked-panel toggles and bottom-sheet transitions

Details and command: `doc/benchmarks/issue-257-panel-frame.md`.

## Verification

- rebased onto `main` after #263 merged
- `fvm dart analyze`
- focused panel/shell/theme/search/sidebar/properties suites: 142 passed
- frame-level matrix: 3 passed
- complete combined `dart_pdf_editor` suite: 1,393 passed, 33 skipped
- `git diff --check`
