### PR TITLE
Release 1.4.1

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.4.1
 
 - Windows: Snapshots now copy to the system clipboard instead of failing with
   "Could not copy snapshot to clipboard". The desktop clipboard channel had no
@@ -9,6 +9,17 @@
   Opened PDFs are snapshotted into the app's private store, so tapping a Recent
   entry (or relaunching) reopens the document directly instead of showing "Pick
   again to reopen".
+- Add callout annotations and rich-text styling for in-place document text
+  edits.
+- Capture a local diagnostic log and attach it to feedback, making rendering
+  and workflow issues easier to investigate without collecting user data.
+- Greatly improve large CAD and illustration documents with adaptive retained
+  rendering, visible-region prioritization, exact raster reuse, and off-thread
+  strip planning on native and web.
+- Keep page edges reachable after pinch gestures on Android and improve glyph
+  and image sharpness while zooming and panning.
+- Improve macOS document opening, branded PDF file icons, store/web marketing
+  assets, and production web startup reliability.
 
 ## 1.4.0
 

--- a/app/lib/app_info.dart
+++ b/app/lib/app_info.dart
@@ -11,7 +11,7 @@ class AppInfo {
   static const tagline = 'A fully native Flutter PDF editor';
   static const sourceUrl = 'https://github.com/ben-milanko/dart-pdf';
 
-  static String version = '1.4.0';
+  static String version = '1.4.1';
 
   /// Populates [version] from the platform package metadata. Best-effort: any
   /// failure leaves the fallback in place.

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -5,7 +5,7 @@ resolution: workspace
 
 # version is the single source of truth for every platform build; CI passes
 # --build-name / --build-number derived from it (see app/RELEASING.md).
-version: 1.4.0+11
+version: 1.4.1+12
 
 environment:
   sdk: ^3.5.0
@@ -17,12 +17,12 @@ dependencies:
   cupertino_icons: ^1.0.8
 
   # The PDF engine and editing UI live in the workspace packages.
-  dart_pdf_editor: ^1.4.0
-  pdf_document: ^1.4.0
+  dart_pdf_editor: ^1.4.1
+  pdf_document: ^1.4.1
 
   # On-device, downloadable OCR - adds a selectable text layer over scans
   # without leaving the device (native platforms only).
-  pdf_ocr_ondevice: ^1.4.0
+  pdf_ocr_ondevice: ^1.4.1
 
   # Cross-platform file I/O and OS integration.
   file_selector: ^1.0.3
@@ -59,11 +59,11 @@ dev_dependencies:
     path: ../packages/dart_pdf_editor/example
 
   # Programmatically-built PDFs for widget tests.
-  pdf_test_fixtures: ^1.4.0
+  pdf_test_fixtures: ^1.4.1
 
   # Text extraction, used by the on-device OCR integration test to assert
   # the recognized layer is selectable (pdf_ocr_ondevice is a runtime dep).
-  pdf_graphics: ^1.4.0
+  pdf_graphics: ^1.4.1
   file_selector_platform_interface: ^2.7.0
 
 flutter:

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.4.1
+
+- Add callout annotations and rich-text styling for in-place document text
+  edits, including the editor controls and annotation presentation support.
+- Make dense CAD and illustration pages substantially more responsive with
+  retained-scene replay, adaptive render policy, sparse strip rendering,
+  speculative visible-region detail, and exact raster reuse on revisits.
+- Run strip planning and dense recording off the UI thread on native and web;
+  reuse compact Web Worker transcripts and prioritize visible detail to reduce
+  cold-start, zoom, and pan latency.
+- Bundle the default web render worker as a package asset and repair production
+  web loading, while retaining the public override for custom worker hosting.
+- Keep page edges reachable after Android pinch gestures and keep Slug glyphs
+  and image content sharp while zooming and panning.
+- Consolidate annotation policy, editing interactions, shell lifecycle, page
+  rendering, sidebar framing, and edit transactions without removing exported
+  APIs.
+
 ## 1.4.0
 
 - Color processing: add a Bluebeam-style tool that can list document colors,

--- a/packages/dart_pdf_editor/example/lib/demo_document.dart
+++ b/packages/dart_pdf_editor/example/lib/demo_document.dart
@@ -398,6 +398,13 @@ Uint8List buildDemoPdf() {
       _stream('/Type /XObject /Subtype /Form /BBox [0 0 18 18]', radioBase));
   final radioOn = add(_stream('/Type /XObject /Subtype /Form /BBox [0 0 18 18]',
       '$radioBase q 0.1 0.15 0.4 rg ${_circle(9, 9, 3.6)}f Q'));
+  final jsButtonAppearance = add(_stream(
+      '/Type /XObject /Subtype /Form '
+          '/BBox [0 0 ${_n(_jsButton.width)} ${_n(_jsButton.height)}] '
+          '/Resources << /Font << /F1 $f1 0 R >> >>',
+      'q 0.92 0.94 1 rg 0 0 ${_n(_jsButton.width)} ${_n(_jsButton.height)} re f '
+          '0.25 0.35 0.85 RG 1 w 0 0 ${_n(_jsButton.width)} ${_n(_jsButton.height)} re S Q\n'
+          'BT /F1 12 Tf 12 14 Td (Run JavaScript) Tj ET\n'));
 
   // form fields: text / checkbox / radio group / combo
   const mk = '/MK << /BC [0.35 0.4 0.6] /BG [0.96 0.97 1] >>';
@@ -451,6 +458,7 @@ Uint8List buildDemoPdf() {
       '${_link(_goToLink, '<< /S /GoTo /D [@PG2@ 0 R /XYZ null null null] >>')} '
       '${_link(_nextPageLink, '<< /S /Named /N /NextPage >>')} '
       '<< /Type /Annot /Subtype /Widget /FT /Btn /T (demoJs) '
+      '/AP << /N $jsButtonAppearance 0 R >> '
       '/Rect ${_rect(_jsButton)} /A << /S /JavaScript '
       r'/JS (app.alert\(Hello from PDF JavaScript\)) >> >> '
       '${tocLinks.join(' ')} ]';

--- a/packages/dart_pdf_editor/example/lib/error_log.dart
+++ b/packages/dart_pdf_editor/example/lib/error_log.dart
@@ -5,7 +5,7 @@ import 'package:flutter/foundation.dart';
 /// The app version reported in diagnostics. Keep in sync with the `version`
 /// field in `pubspec.yaml`; it is surfaced to feedback reviewers so a report
 /// can be matched to a build.
-const String kAppVersion = '1.4.0';
+const String kAppVersion = '1.4.1';
 
 /// Severity of a captured [AppLogEntry].
 enum AppLogLevel {

--- a/packages/dart_pdf_editor/example/pubspec.yaml
+++ b/packages/dart_pdf_editor/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_viewer_example
 description: Example PDF viewer built on dart_pdf_editor.
-version: 1.4.0
+version: 1.4.1
 publish_to: none
 resolution: workspace
 
@@ -12,10 +12,10 @@ dependencies:
   file_selector: ^1.0.3
   flutter:
     sdk: flutter
-  pdf_document: ^1.4.0
-  pdf_graphics: ^1.4.0
-  dart_pdf_editor: ^1.4.0
-  pdf_ocr_vlm: ^1.4.0
+  pdf_document: ^1.4.1
+  pdf_graphics: ^1.4.1
+  dart_pdf_editor: ^1.4.1
+  pdf_ocr_vlm: ^1.4.1
   share_plus: ^13.2.0
   url_launcher: ^6.3.0
   web: ^1.1.0

--- a/packages/dart_pdf_editor/example/test/demo_test.dart
+++ b/packages/dart_pdf_editor/example/test/demo_test.dart
@@ -77,7 +77,10 @@ void main() {
     // the counter control edits the same state the page-1 link increments
     // (.first: the page overlay's button - the AppBar tab strip's new-tab
     // '+' is also an Icons.add, and Scaffold mounts the body before the bar)
-    await tester.tap(find.byIcon(Icons.add).first);
+    await tester.tap(find.descendant(
+      of: find.byType(PdfViewer),
+      matching: find.byIcon(Icons.add),
+    ));
     await tester.pump(const Duration(milliseconds: 400));
     expect(plainText('1'), findsWidgets);
 

--- a/packages/dart_pdf_editor/example/test/editing_test.dart
+++ b/packages/dart_pdf_editor/example/test/editing_test.dart
@@ -8,6 +8,12 @@ void main() {
   Future<void> openDemo(WidgetTester tester) async {
     // the mock store is process-global: start every test from defaults
     SharedPreferences.setMockInitialValues({});
+    // These exercise the desktop dock. At the default 800px test width the
+    // open thumbnail panel intentionally collapses it to the mobile tool sheet.
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
     await tester.pumpWidget(const ViewerApp());
     await tester.pump();
   }
@@ -29,15 +35,31 @@ void main() {
     return page.topLeft + Offset(page.width * fx, page.height * fy);
   }
 
-  /// Taps a toolbar button, scrolling the toolbar's own row to it first -
-  /// the full button set overflows an 800px test window, and with the
-  /// viewer in the tree there are two Scrollables to choose from.
+  /// Opens the grouped desktop dock when necessary, then taps its tool.
   Future<void> tapToolbar(WidgetTester tester, String tooltip) async {
-    final button = find.byTooltip(tooltip);
-    await tester.scrollUntilVisible(button, 100,
-        scrollable: find.descendant(
-            of: find.byType(PdfEditingToolbar),
-            matching: find.byType(Scrollable)));
+    Finder buttonFor(String label) => find.byWidgetPredicate(
+          (widget) =>
+              widget is Tooltip &&
+              (widget.message == label ||
+                  (widget.message?.startsWith('$label (') ?? false)),
+        );
+
+    final group = switch (tooltip) {
+      'Select' => 'select',
+      'Draw' => 'draw',
+      'Rectangle' => 'shapes',
+      'Note' => 'insert',
+      _ => null,
+    };
+    if (group != null) {
+      await tester.tap(find.byKey(ValueKey('pdf-group-$group')));
+      await tester.pump();
+      // A group chip arms its default tool itself. Tapping the same tool in
+      // the strip would immediately toggle it back to Select.
+      if (const {'Select', 'Draw', 'Rectangle'}.contains(tooltip)) return;
+    }
+    final button = buttonFor(tooltip);
+    await tester.ensureVisible(button);
     await tester.tap(button);
     await tester.pump();
   }

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_pdf_editor
 description: >-
   Flutter PDF viewer and editor for Dart: native rendering, text selection,
   search, annotations, forms, signatures, page editing, and document comparison.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_editor
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -21,9 +21,9 @@ dependencies:
   flutter:
     sdk: flutter
   image: ^4.9.1
-  pdf_cos: ^1.4.0
-  pdf_document: ^1.4.0
-  pdf_graphics: ^1.4.0
+  pdf_cos: ^1.4.1
+  pdf_document: ^1.4.1
+  pdf_graphics: ^1.4.1
   shared_preferences: ^2.3.0
   # Opens hyperlink (/URI) actions the viewer follows itself; see
   # PdfViewer.onLaunchUrl. Web-safe, no dart:io.

--- a/packages/pdf_cos/CHANGELOG.md
+++ b/packages/pdf_cos/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.1
+
+- Speed up dense content parsing with byte-level real-number parsing, operator
+  interning, and streaming content-token handling.
+- Keep the low-level parser and writer compatible with the rendering and
+  editing improvements in the 1.4.1 package suite.
+
 ## 1.4.0
 
 - Version bump to keep the dart-pdf package suite aligned at 1.4.0. Low-level

--- a/packages/pdf_cos/pubspec.yaml
+++ b/packages/pdf_cos/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_cos
 description: >-
   COS object layer for PDF: tokenizer, parser, filters (incl. CCITT, JBIG2,
   JPEG 2000), xref machinery, encryption, and serializer. Pure Dart, web-ready.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_cos
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.4.1
+
+- Add callout annotation authoring and editing, and correct cloudy polygon
+  geometry and appearance generation.
+- Add rich-text styling for in-place content text edits while preserving the
+  surrounding PDF content structure.
+- Centralize annotation capability policy and mutation impact tracking so
+  editing operations invalidate only the document surfaces they change.
+- Improve annotation, form, outline, page, redaction, reflow, and content
+  editing robustness through the shared transaction path.
+
 ## 1.4.0
 
 - Add document color-processing APIs that discover paint colors, replace

--- a/packages/pdf_document/pubspec.yaml
+++ b/packages/pdf_document/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_document
 description: >-
   Document-level PDF semantics: page tree, annotations, AcroForm filling,
   digital signatures, and an incremental-save editor. Pure Dart, web-ready.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_document
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -18,7 +18,7 @@ environment:
 dependencies:
   archive: ^4.0.0
   crypto: ^3.0.0
-  pdf_cos: ^1.4.0
+  pdf_cos: ^1.4.1
 
 dev_dependencies:
   pdf_test_fixtures: ^1.4.0

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.4.1
+
+- Add retained raster scenes and sparse strip plans for fast deep-zoom replay
+  of dense vector, text, and image pages.
+- Re-sharpen all image types under deep zoom and stream dense content through
+  recording paths to reduce latency and memory pressure.
+- Add reusable raster geometry, strip binning, curve flattening, and stroke
+  contour primitives used by native-isolate and Web Worker rendering.
+
 ## 1.4.0
 
 - Version bump to keep the dart-pdf package suite aligned at 1.4.0. Rendering

--- a/packages/pdf_graphics/pubspec.yaml
+++ b/packages/pdf_graphics/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_graphics
 description: >-
   PDF content interpreter, device interface, font engine, shadings, ICC color,
   and text extraction - render pages to any device. Pure Dart, web-ready.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_graphics
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -16,8 +16,8 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  pdf_cos: ^1.4.0
-  pdf_document: ^1.4.0
+  pdf_cos: ^1.4.1
+  pdf_document: ^1.4.1
   image: ^4.9.1
 
 dev_dependencies:

--- a/packages/pdf_ocr_ondevice/CHANGELOG.md
+++ b/packages/pdf_ocr_ondevice/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.4.1
 
 - Run downloaded ONNX OCR models on a long-lived worker isolate by default.
   Page RGBA buffers transfer without a structured-message copy, and model

--- a/packages/pdf_ocr_ondevice/pubspec.yaml
+++ b/packages/pdf_ocr_ondevice/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_ocr_ondevice
 description: >-
   On-device OCR engine for dart_pdf_editor that adds a selectable, searchable
   text layer to scanned PDFs with a downloadable PP-OCR ONNX model.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_ocr_ondevice
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -20,8 +20,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_pdf_editor: ^1.4.0
-  pdf_document: ^1.4.0
+  dart_pdf_editor: ^1.4.1
+  pdf_document: ^1.4.1
   http: ^1.2.0
   crypto: ^3.0.0
   path_provider: ^2.1.6

--- a/packages/pdf_ocr_vlm/CHANGELOG.md
+++ b/packages/pdf_ocr_vlm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.1
+
+- Version bump to align with `dart_pdf_editor` 1.4.1. No public VLM OCR API
+  changes since 1.4.0.
+
 ## 1.4.0
 
 - Version bump to align with `dart_pdf_editor` 1.4.0. No public OCR API

--- a/packages/pdf_ocr_vlm/pubspec.yaml
+++ b/packages/pdf_ocr_vlm/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_ocr_vlm
 description: >-
   HTTP OCR engine for dart_pdf_editor that adds a selectable, searchable text
   layer to scanned PDFs using a self-hosted VLM or any JSON OCR service.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_ocr_vlm
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -19,8 +19,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  dart_pdf_editor: ^1.4.0
-  pdf_document: ^1.4.0
+  dart_pdf_editor: ^1.4.1
+  pdf_document: ^1.4.1
   http: ^1.2.0
 
 dev_dependencies:

--- a/packages/pdf_test_fixtures/CHANGELOG.md
+++ b/packages/pdf_test_fixtures/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.1
+
+- Add fixtures for callout annotations, rich content editing, retained page
+  rendering, and the expanded viewer/editor regression suite.
+
 ## 1.4.0
 
 - Version bump to keep the dart-pdf package suite aligned at 1.4.0. Fixture

--- a/packages/pdf_test_fixtures/pubspec.yaml
+++ b/packages/pdf_test_fixtures/pubspec.yaml
@@ -2,7 +2,7 @@ name: pdf_test_fixtures
 description: >-
   Programmatically-built PDF files for testing PDF tooling. Builders compute
   every offset, so fixtures are always structurally correct.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/pdf_test_fixtures
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:
@@ -20,7 +20,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.0
-  pdf_cos: ^1.4.0
+  pdf_cos: ^1.4.1
 
 dev_dependencies:
   lints: ^6.1.0


### PR DESCRIPTION
## Summary

- release all seven pub.dev packages at 1.4.1 in lockstep
- release the DartPDF app at 1.4.1+12
- document the rendering, editing, OCR, and platform fixes since 1.4.0
- restore a valid appearance for the showcase JavaScript form button and update the example integration tests for the grouped toolbar

## Compatibility

Public API comparison against 1.4.0 found additive APIs and internal refactors, with no removed or newly-required exported API. This is therefore a patch release under the requested version policy.

## Validation

- lockstep constraint check
- `fvm dart analyze --fatal-infos`
- pdf_cos: 200 tests
- pdf_document: 629 passed, 1 skipped
- pdf_graphics: 787 tests
- dart_pdf_editor: 1,404 passed, 27 skipped
- pdf_ocr_vlm: 5 tests
- pdf_ocr_ondevice: 36 tests
- standalone app: 140 tests
- example app: 50 tests
- pub.dev dry-run validation for all seven package archives