### PR TITLE
Avoid fragmented strip replay on clip-heavy pages

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Prevent dense pages from rendering as solid magenta on iPad by routing iOS
   deep-zoom replay through the stable canvas path instead of shader-backed
   sparse strips.
+- Keep clip-heavy Visio and CAD pages responsive by detecting fragmented
+  sparse-strip plans before worker binning and using cached canvas replay.
 
 ## 1.4.1
 

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -220,9 +220,20 @@ class PdfPageView extends StatefulWidget {
   /// retained replay costs about one frame.
   static int retainedZoomReplayMaxCommands = 20000;
 
-  /// Strip routing for pages ABOVE [retainedZoomReplayMaxCommands]: they DO
-  /// retain their scene, and zoom-driven re-rasters (full page and deep-zoom
-  /// detail patch) replay it through the sparse-strip shader device
+  /// Maximum estimated atlas batches allowed on the dense-page strip route.
+  ///
+  /// Command count alone does not predict strip performance. Some Visio/CAD
+  /// exports wrap nearly every small shape in its own clip, forcing thousands
+  /// of tiny painter-order batches. Every batch needs a separate alpha-atlas
+  /// upload; at that topology the cached canvas picture is dramatically
+  /// faster even though the page is dense. [StripReplayProfile] identifies
+  /// the fragmentation without flattening paths or generating coverage.
+  static int stripZoomReplayMaxEstimatedBatches = 256;
+
+  /// Strip routing for pages ABOVE [retainedZoomReplayMaxCommands] whose
+  /// topology stays under [stripZoomReplayMaxEstimatedBatches]: they retain
+  /// their scene, and zoom-driven re-rasters (full page and deep-zoom detail
+  /// patch) replay it through the sparse-strip shader device
   /// ([PdfRetainedScene.rasterizeStrips]) at the new ratio instead of
   /// re-rasterizing the cached nested picture. Pages under the ceiling keep
   /// the flat canvas replay - strips lose on office pages (fixed
@@ -854,10 +865,10 @@ class _PdfPageViewState extends State<PdfPageView> {
     // instead of being discarded after the 1:1 replay below.
     final scene = await PdfRetainedScene.record(widget.page, plan: _renderPlan);
     _lastInterpretResultBytes = _logImageStats(pageIndex, scene.commands);
-    if (!_retainScene(scene.commands.length)) {
-      // Too dense to replay per zoom settle: take the 1:1 picture (it holds
-      // its own image refs) and drop the scene - the classic cached-picture
-      // path serves this page's zooms.
+    if (!_retainScene(scene.commands)) {
+      // Too dense or too fragmented to replay per zoom settle: take the 1:1
+      // picture (it holds its own image refs) and drop the scene - the classic
+      // cached-picture path serves this page's zooms.
       final picture = scene.replay(pixelRatio: 1);
       scene.dispose();
       return (picture, null, false);
@@ -865,15 +876,21 @@ class _PdfPageViewState extends State<PdfPageView> {
     return (scene.replay(pixelRatio: 1), scene, false);
   }
 
-  /// Whether a page recorded as [commandCount] top-level commands should
-  /// retain its scene - the [PdfPageView.retainedZoomReplay] switch plus the
+  /// Whether a page's recorded commands should retain their scene - the
+  /// [PdfPageView.retainedZoomReplay] switch plus the
   /// [PdfPageView.retainedZoomReplayMaxCommands] density ceiling. With
-  /// [PdfPageView.stripZoomReplay] on, over-ceiling pages retain too: their
-  /// zooms re-bin through the strip device instead of the flat replay.
-  static bool _retainScene(int commandCount) =>
+  /// [PdfPageView.stripZoomReplay] on, eligible over-ceiling pages retain too:
+  /// their zooms re-bin through the strip device instead of the flat replay.
+  static bool _retainScene(List<PdfRenderCommand> commands) =>
       PdfPageView.retainedZoomReplay &&
-      (commandCount <= PdfPageView.retainedZoomReplayMaxCommands ||
-          (PdfPageView.stripZoomReplay && _stripBackendSupported));
+      (commands.length <= PdfPageView.retainedZoomReplayMaxCommands ||
+          _stripReplayCommands(commands));
+
+  static bool _stripReplayCommands(List<PdfRenderCommand> commands) =>
+      PdfPageView.stripZoomReplay &&
+      _stripBackendSupported &&
+      StripReplayProfile.of(commands).estimatedBatchCount <=
+          PdfPageView.stripZoomReplayMaxEstimatedBatches;
 
   /// Whether the runtime backend supports the strip route: web (validated
   /// through the worker/device probe), or a non-iOS native Impeller backend
@@ -895,7 +912,9 @@ class _PdfPageViewState extends State<PdfPageView> {
   static bool _stripReplayScene(PdfRetainedScene scene) =>
       PdfPageView.stripZoomReplay &&
       _stripBackendSupported &&
-      scene.commands.length > PdfPageView.retainedZoomReplayMaxCommands;
+      scene.commands.length > PdfPageView.retainedZoomReplayMaxCommands &&
+      scene.stripReplayEstimatedBatchCount <=
+          PdfPageView.stripZoomReplayMaxEstimatedBatches;
 
   bool _slugPictureScene(PdfRetainedScene? scene) =>
       scene != null &&
@@ -912,7 +931,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   Future<(ui.Picture, PdfRetainedScene?)> _replayableFromCommands(
     List<PdfRenderCommand> commands,
   ) async {
-    if (!_retainScene(commands.length)) {
+    if (!_retainScene(commands)) {
       return (
         await PdfPageRenderer.pictureFromCommandsWithPlan(
           widget.page,
@@ -961,13 +980,14 @@ class _PdfPageViewState extends State<PdfPageView> {
       return;
     }
 
+    final retainScene = _retainScene(commands);
     if (!PdfPageRenderer.hasImageDraws(commands)) {
       // Image-free page: this fast buffer already is the complete page. Cache
       // it (and its retained scene) so the full pass reuses it instead of
       // recording a second time; the normal raster path below paints it.
       _lastInterpretPath = 'worker';
       _lastInterpretResultBytes = 0;
-      if (_retainScene(commands.length)) {
+      if (retainScene) {
         // No images to decode, so this completes synchronously in practice.
         final scene = await PdfRetainedScene.fromCommands(
           widget.page,
@@ -1003,10 +1023,10 @@ class _PdfPageViewState extends State<PdfPageView> {
     PdfPerfLog.log(
       'vector-first detail page=$pageIndex '
       'scale=${widget.scale.toStringAsFixed(2)} eligible=$needsDetail '
-      'retained=${_retainScene(commands.length)} '
+      'retained=$retainScene '
       'commands=${commands.length}',
     );
-    if (needsDetail && _retainScene(commands.length)) {
+    if (needsDetail && retainScene) {
       final scene = await PdfRetainedScene.fromCommands(
         widget.page,
         commands,

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -51,6 +51,12 @@ class PdfRetainedScene {
   /// The interpreter's transcript of the page, in paint order.
   final List<PdfRenderCommand> commands;
 
+  /// Painter-order fragmentation of [commands] under the strip router.
+  /// Computed lazily because ordinary pages below the dense-command ceiling
+  /// never need it.
+  late final int stripReplayEstimatedBatchCount =
+      StripReplayProfile.of(commands).estimatedBatchCount;
+
   /// Enables the bounded selective path for ordinary retained region replay.
   /// Unsupported command groups conservatively use the full transcript.
   static bool spatialRegionReplay = true;

--- a/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
+++ b/packages/dart_pdf_editor/lib/src/strips/strip_device.dart
@@ -39,6 +39,7 @@ export 'package:pdf_graphics/raster.dart'
         StripPlan,
         StripPlanBinner,
         StripPlanMismatchError,
+        StripReplayProfile,
         decodeStripPlan,
         encodeStripPlan,
         stripFlattenTolerance;

--- a/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
+++ b/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
@@ -1,8 +1,9 @@
 // The dense-page strip zoom router (PdfPageView.stripZoomReplay):
 //
-//  - flag ON + page above retainedZoomReplayMaxCommands -> the scene IS
-//    retained and zoom re-rasters re-bin through StripPdfDevice
-//    (observable via the device's batching telemetry);
+//  - flag ON + page above retainedZoomReplayMaxCommands and below the
+//    fragmentation guard -> the scene IS retained and zoom re-rasters re-bin
+//    through StripPdfDevice (observable via the device's batching telemetry);
+//  - fragmented dense pages keep the cached-picture path;
 //  - flag OFF -> exactly the #208 behavior: over-ceiling pages retain no
 //    scene and zoom via the classic cached-picture re-raster (no strip
 //    device activity at all);
@@ -28,10 +29,7 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 /// A one-page classic-xref PDF with solid vector content (fills + a
 /// stroke), so the strip device has geometry to bin (text through a
 /// non-embedded Type1 font would delegate to the canvas fallback).
-Uint8List buildVectorPdf() {
-  const content = '1 0 0 rg 72 600 200 100 re f '
-      '0 0 1 rg 300 300 150 220 re f '
-      '0 0.6 0 RG 6 w 72 100 m 500 250 l S';
+Uint8List _buildContentPdf(String content) {
   final objects = <String>[
     '<< /Type /Catalog /Pages 2 0 R >>',
     '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
@@ -57,6 +55,17 @@ Uint8List buildVectorPdf() {
     ..write('startxref\n$xrefOffset\n%%EOF\n');
   return ascii(buffer.toString());
 }
+
+Uint8List buildVectorPdf() => _buildContentPdf(
+      '1 0 0 rg 72 600 200 100 re f '
+      '0 0 1 rg 300 300 150 220 re f '
+      '0 0.6 0 RG 6 w 72 100 m 500 250 l S',
+    );
+
+Uint8List buildFragmentedVectorPdf() => _buildContentPdf(
+      'q 0 0 306 792 re W n 1 0 0 rg 72 600 200 100 re f Q '
+      'q 306 0 306 792 re W n 0 0 1 rg 340 300 150 220 re f Q',
+    );
 
 Future<Uint8List> _rgba(ui.Image image) async =>
     (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!
@@ -202,6 +211,37 @@ void main() {
     expect(zoomed.width, 612 * 3);
     expect(StripPdfDevice.totalFlushes, 0,
         reason: 'flag off must never touch the strip device');
+  });
+
+  testWidgets(
+      'fragmented dense pages keep the cached-picture path, '
+      'no strip activity', (tester) async {
+    PdfPageView.retainedZoomReplayMaxCommands = 0;
+    PdfPageView.stripZoomReplayMaxEstimatedBatches = 1;
+    PdfPageView.stripZoomReplay = true;
+    PdfPageView.debugStripZoomReplayBackendOverride = true;
+    addTearDown(() {
+      PdfPageView.retainedZoomReplayMaxCommands = 20000;
+      PdfPageView.stripZoomReplayMaxEstimatedBatches = 256;
+      PdfPageView.stripZoomReplay = true;
+      PdfPageView.debugStripZoomReplayBackendOverride = null;
+    });
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final doc = PdfDocument.open(buildFragmentedVectorPdf());
+    final page = doc.page(0);
+    Widget at(double scale) => Center(
+        child:
+            SizedBox(width: 612, child: PdfPageView(page: page, scale: scale)));
+
+    StripPdfDevice.resetStats();
+    await tester.pumpWidget(at(1));
+    await settleRaster(tester, 612);
+    await tester.pumpWidget(at(3));
+    final zoomed = await settleRaster(tester, 612 * 3);
+    expect(zoomed.width, 612 * 3);
+    expect(StripPdfDevice.totalFlushes, 0,
+        reason: 'clip-per-shape pages must bypass fragmented atlas replay');
   });
 
   testWidgets('backend gate off: the flag is inert on non-Impeller backends',

--- a/packages/pdf_graphics/CHANGELOG.md
+++ b/packages/pdf_graphics/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.4.2
 
-- Version bump to keep the dart-pdf package suite aligned at 1.4.2. No
-  graphics API changes since 1.4.1.
+- Add geometry-free sparse-strip replay profiling so renderers can detect
+  painter-order fragmentation before path flattening and atlas generation.
 
 ## 1.4.1
 

--- a/packages/pdf_graphics/lib/raster.dart
+++ b/packages/pdf_graphics/lib/raster.dart
@@ -16,3 +16,4 @@ export 'src/raster/strip_batch_data.dart';
 export 'src/raster/strip_binning_device.dart';
 export 'src/raster/strip_generator.dart';
 export 'src/raster/strip_plan.dart';
+export 'src/raster/strip_replay_profile.dart';

--- a/packages/pdf_graphics/lib/src/raster/strip_replay_profile.dart
+++ b/packages/pdf_graphics/lib/src/raster/strip_replay_profile.dart
@@ -1,0 +1,157 @@
+import 'package:pdf_document/pdf_document.dart';
+
+import '../color.dart';
+import '../device.dart';
+import '../matrix.dart';
+import '../mesh.dart';
+import '../path.dart';
+import '../render_command.dart';
+import '../shading.dart';
+import 'strip_binning_device.dart';
+import 'strip_batch_data.dart';
+
+/// Cheap, geometry-free estimate of how a command transcript fragments when
+/// replayed through the sparse-strip device.
+///
+/// Every non-empty strip batch needs its own alpha-atlas upload. PDFs that
+/// wrap each tiny shape in a clip can therefore be much slower through strips
+/// than through the ordinary canvas even when their total command count is
+/// high. This profile follows the strip device's exact painter-order routing
+/// and flush state without flattening paths, generating coverage, or touching
+/// a platform image codec.
+class StripReplayProfile {
+  const StripReplayProfile({
+    required this.estimatedBatchCount,
+    required this.flushPointCount,
+    required this.delegatedPaintCount,
+    required this.routedPaintCount,
+  });
+
+  factory StripReplayProfile.of(List<PdfRenderCommand> commands) {
+    final profiler = _StripReplayProfiler();
+    replayCommands(commands, profiler);
+    return profiler.finish();
+  }
+
+  /// Flush intervals containing at least one strip-routed paint command.
+  ///
+  /// This can conservatively exceed a real plan's batch count when a path is
+  /// empty or wholly outside the device viewport. It never performs geometry
+  /// work merely to refine the estimate.
+  final int estimatedBatchCount;
+
+  /// Every painter-order flush point, including empty ones.
+  final int flushPointCount;
+
+  /// Paint commands that must use the ordinary device fallback.
+  final int delegatedPaintCount;
+
+  /// Fill, stroke, and outline-text commands eligible for strip routing.
+  final int routedPaintCount;
+}
+
+class _StripReplayProfiler extends StripBinningDevice {
+  _StripReplayProfiler()
+      : super(
+          pageToDevice: PdfMatrix.identity,
+          deviceWidth: 1,
+          deviceHeight: 1,
+          pixelRatio: 1,
+          binningEnabled: false,
+        );
+
+  var _pendingRoutedPaint = false;
+  var _estimatedBatchCount = 0;
+  var _routedPaintCount = 0;
+  var _finished = false;
+
+  void _markRoutedPaint() {
+    _pendingRoutedPaint = true;
+    _routedPaintCount++;
+  }
+
+  @override
+  void fillPath(PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {
+    if (stripsActive && !delegateFills) _markRoutedPaint();
+    super.fillPath(path, color, rule, alpha);
+  }
+
+  @override
+  void strokePath(
+      PdfPath path, PdfColor color, PdfStroke stroke, double alpha) {
+    if (stripsActive && !delegateStrokes) _markRoutedPaint();
+    super.strokePath(path, color, stroke, alpha);
+  }
+
+  @override
+  void drawText(PdfTextRun run) {
+    if (!run.invisible &&
+        stripsActive &&
+        !delegateText &&
+        run.hasOutlines &&
+        run.fill &&
+        run.strokeColor == null &&
+        run.gradient == null) {
+      _markRoutedPaint();
+    }
+    super.drawText(run);
+  }
+
+  @override
+  void emitBatch(int ordinal, StripBatchData? data) {
+    if (_pendingRoutedPaint) _estimatedBatchCount++;
+    _pendingRoutedPaint = false;
+  }
+
+  StripReplayProfile finish() {
+    assert(!_finished, 'StripReplayProfile.finish() called twice');
+    _finished = true;
+    flushPending();
+    return StripReplayProfile(
+      estimatedBatchCount: _estimatedBatchCount,
+      flushPointCount: flushPointCount,
+      delegatedPaintCount: delegatedPaintCount,
+      routedPaintCount: _routedPaintCount,
+    );
+  }
+
+  @override
+  void delegateSave() {}
+  @override
+  void delegateRestore() {}
+  @override
+  void delegateClipPath(PdfPath path, PdfFillRule rule) {}
+  @override
+  void delegateSetBlendMode(PdfBlendMode mode) {}
+  @override
+  void delegateBeginGroup(double alpha, {required bool knockout}) {}
+  @override
+  void delegateEndGroup() {}
+  @override
+  void delegateBeginSoftMasked() {}
+  @override
+  void delegateBeginSoftMaskComposite({
+    required bool luminosity,
+    required PdfRect backdrop,
+    required double backdropLuminance,
+    required double transferScale,
+    required double transferOffset,
+  }) {}
+  @override
+  void delegateFinishSoftMaskComposite() {}
+  @override
+  void delegateFillPath(
+      PdfPath path, PdfColor color, PdfFillRule rule, double alpha) {}
+  @override
+  void delegateStrokePath(
+      PdfPath path, PdfColor color, PdfStroke stroke, double alpha) {}
+  @override
+  void delegateFillPathGradient(
+      PdfPath path, PdfFillRule rule, PdfGradient gradient, double alpha) {}
+  @override
+  void delegateFillMesh(PdfMesh mesh, double alpha) {}
+  @override
+  void delegateDrawText(PdfTextRun run) {}
+  @override
+  void delegateDrawImage(PdfImageRequest request) {}
+}

--- a/packages/pdf_graphics/test/raster/strip_replay_profile_test.dart
+++ b/packages/pdf_graphics/test/raster/strip_replay_profile_test.dart
@@ -1,0 +1,91 @@
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_graphics/raster.dart';
+import 'package:test/test.dart';
+
+const _path = PdfPath([
+  PdfMoveTo(0, 0),
+  PdfLineTo(10, 0),
+  PdfLineTo(10, 10),
+  PdfClosePath(),
+]);
+
+const _fill = PdfFillPathCommand(
+  _path,
+  PdfColor(1, 0, 0),
+  PdfFillRule.nonzero,
+  1,
+);
+
+void main() {
+  test('consecutive strip paints share one estimated batch', () {
+    final profile = StripReplayProfile.of(const [
+      _fill,
+      PdfStrokePathCommand(
+        _path,
+        PdfColor.black,
+        PdfStroke(),
+        1,
+      ),
+    ]);
+
+    expect(profile.estimatedBatchCount, 1);
+    expect(profile.routedPaintCount, 2);
+    expect(profile.delegatedPaintCount, 0);
+    expect(profile.flushPointCount, 1);
+  });
+
+  test('clip-per-shape topology estimates one batch per shape', () {
+    final profile = StripReplayProfile.of(const [
+      PdfSaveCommand(),
+      PdfClipPathCommand(_path, PdfFillRule.nonzero),
+      _fill,
+      PdfRestoreCommand(),
+      PdfSaveCommand(),
+      PdfClipPathCommand(_path, PdfFillRule.nonzero),
+      PdfStrokePathCommand(
+        _path,
+        PdfColor.black,
+        PdfStroke(),
+        1,
+      ),
+      PdfRestoreCommand(),
+    ]);
+
+    expect(profile.estimatedBatchCount, 2);
+    expect(profile.routedPaintCount, 2);
+    expect(profile.delegatedPaintCount, 0);
+    expect(profile.flushPointCount, greaterThan(2));
+  });
+
+  test('delegated paints split surrounding strip batches', () {
+    final profile = StripReplayProfile.of(const [
+      _fill,
+      PdfDrawTextCommand(PdfTextRun(
+        text: 'substituted',
+        transform: PdfMatrix.identity,
+        color: PdfColor.black,
+        width: 1,
+      )),
+      _fill,
+    ]);
+
+    expect(profile.estimatedBatchCount, 2);
+    expect(profile.routedPaintCount, 2);
+    expect(profile.delegatedPaintCount, 1);
+  });
+
+  test('delegated-only transcripts estimate no strip batches', () {
+    final profile = StripReplayProfile.of(const [
+      PdfDrawTextCommand(PdfTextRun(
+        text: 'substituted',
+        transform: PdfMatrix.identity,
+        color: PdfColor.black,
+        width: 1,
+      )),
+    ]);
+
+    expect(profile.estimatedBatchCount, 0);
+    expect(profile.routedPaintCount, 0);
+    expect(profile.delegatedPaintCount, 1);
+  });
+}


### PR DESCRIPTION
## Summary

- profile retained display-list routing before sending dense pages through sparse-strip replay
- keep highly fragmented clip-heavy pages on the cached canvas replay path
- add pure-Dart profiling tests and a viewer routing regression
- document the behavior change in `pdf_graphics` and `dart_pdf_editor`

## Root cause

`OGW-30-06_Diagram.pdf` records 30,889 commands, which put it above the command-count threshold and into sparse-strip replay. Its Visio-style clip-per-shape topology produces an estimated 6,809 strip batches and 11,226 flush points. That made worker strip planning take about 39.1 seconds, despite direct canvas command replay taking roughly 33–42 ms.

The router now estimates the real strip batch topology before retaining an over-threshold scene. Pages above 256 estimated batches use the existing cached-picture path. Productive dense CAD pages remain strip-routed; the local corpus controls produced only 1–3 batches.

## Impact

Clip-heavy Visio/CAD drawings avoid the pathological worker-planning and atlas-upload route, keeping scrolling and zooming responsive without changing rendered output.

## Validation

- `fvm dart analyze`
- `cd packages/pdf_graphics && fvm dart test` — 791 passed
- focused strip/viewer tests — 46 passed
- `cd packages/dart_pdf_editor && fvm flutter test` — 1,408 passed, 33 environment-dependent benchmarks skipped
- reported PDF render smoke test passed at 2×
