### PR TITLE
Fix RTL multi-word copy and selection

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -235,7 +235,8 @@ class PdfViewerController extends ChangeNotifier {
   /// Cmd/Ctrl+C while the viewer has focus.
   Future<void> copySelection() async {
     if (_selectedText.isEmpty) return;
-    await Clipboard.setData(ClipboardData(text: _selectedText));
+    await Clipboard.setData(
+        ClipboardData(text: pdfBidiIsolateForCopy(_selectedText)));
   }
 
   void clearSelection() => _state?._clearSelection();
@@ -3445,11 +3446,15 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     // mid-long-press the live selection wash is the only feedback;
     // handles and chip appear when the finger lifts
     if (_touchSelecting) return null;
-    final rects = _selectionRectsOn(index);
-    if (rects.isEmpty) return null;
+    final quads = _selectionQuadsOn(index);
+    if (quads.isEmpty) return null;
+    final first = quads.first;
+    final last = quads.last;
     return _PageTextSelection(
-      startRect: isStart ? rects.first : null,
-      endRect: isEnd ? rects.last : null,
+      startRect: isStart ? first.bounds : null,
+      startRightToLeft: isStart && first.isRightToLeft,
+      endRect: isEnd ? last.bounds : null,
+      endRightToLeft: isEnd && last.isRightToLeft,
       chip: isEnd && !_handleDragging,
       onDragStart: _onHandleDragStart,
       onDragUpdate: _onHandleDragUpdate,
@@ -5501,7 +5506,9 @@ class _EagerPanRecognizer extends PanGestureRecognizer {
 class _PageTextSelection {
   const _PageTextSelection({
     required this.startRect,
+    required this.startRightToLeft,
     required this.endRect,
+    required this.endRightToLeft,
     required this.chip,
     required this.onDragStart,
     required this.onDragUpdate,
@@ -5514,8 +5521,14 @@ class _PageTextSelection {
   /// selection starts here, else null. Anchors the start handle.
   final PdfRect? startRect;
 
+  /// Whether the logical start is the rectangle's right edge.
+  final bool startRightToLeft;
+
   /// The selection's last rect when the selection ends here.
   final PdfRect? endRect;
+
+  /// Whether the logical end is the rectangle's left edge.
+  final bool endRightToLeft;
 
   /// Whether the Copy/Select-All chip shows on this page.
   final bool chip;
@@ -5556,6 +5569,7 @@ class _TextSelectionChrome extends StatelessWidget {
         _SelectionHandle(
           rect: geometry.toViewRect(startRect),
           isStart: true,
+          rightToLeft: selection.startRightToLeft,
           chromeScale: s,
           color: color,
           onDragStart: selection.onDragStart,
@@ -5566,6 +5580,7 @@ class _TextSelectionChrome extends StatelessWidget {
         _SelectionHandle(
           rect: geometry.toViewRect(endRect),
           isStart: false,
+          rightToLeft: selection.endRightToLeft,
           chromeScale: s,
           color: color,
           onDragStart: selection.onDragStart,
@@ -5630,6 +5645,7 @@ class _SelectionHandle extends StatelessWidget {
   const _SelectionHandle({
     required this.rect,
     required this.isStart,
+    required this.rightToLeft,
     required this.chromeScale,
     required this.color,
     required this.onDragStart,
@@ -5640,6 +5656,7 @@ class _SelectionHandle extends StatelessWidget {
   /// The boundary selection rect, view coordinates.
   final Rect rect;
   final bool isStart;
+  final bool rightToLeft;
   final double chromeScale;
   final Color color;
   final void Function(
@@ -5653,7 +5670,7 @@ class _SelectionHandle extends StatelessWidget {
     final s = chromeScale;
     final ballSpace = 16 * s; // ball diameter + gap, above or below
     final hitWidth = 36 * s;
-    final x = isStart ? rect.left : rect.right;
+    final x = isStart == rightToLeft ? rect.right : rect.left;
     final textEndpoint = Offset(
         hitWidth / 2, isStart ? ballSpace + rect.height / 2 : rect.height / 2);
     return Positioned(

--- a/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
@@ -23,14 +23,14 @@ void main() {
   Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);
 
   Future<PdfViewerController> pumpViewer(WidgetTester tester,
-      {int pages = 3}) async {
+      {int pages = 3, Uint8List? bytes}) async {
     final controller = PdfViewerController();
     addTearDown(controller.dispose);
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: PdfViewer(
           initialFit: PdfViewerFit.width,
-          document: PdfDocument.open(buildMultiPagePdf(pages)),
+          document: PdfDocument.open(bytes ?? buildMultiPagePdf(pages)),
           controller: controller,
         ),
       ),
@@ -95,6 +95,50 @@ void main() {
   });
 
   group('long-press selection', () {
+    testWidgets('RTL selection starts on the right edge', (tester) async {
+      final controller = await pumpViewer(tester, bytes: buildRtlTextPdf());
+      await longPressSelect(tester, view(336, 720));
+
+      expect(controller.selectedText, 'اهلا');
+      final start =
+          tester.getCenter(find.byKey(const ValueKey('pdf-text-handle-start')));
+      final end =
+          tester.getCenter(find.byKey(const ValueKey('pdf-text-handle-end')));
+      expect(start.dx, closeTo(view(360, 720).dx, 1));
+      expect(end.dx, closeTo(view(312, 720).dx, 1));
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('RTL long-press selection keeps word order across lines',
+        (tester) async {
+      final controller = await pumpViewer(tester, bytes: buildRtlTextPdf());
+      final gesture = await tester.startGesture(view(336, 720));
+      await tester.pump(const Duration(milliseconds: 600));
+      await gesture.moveTo(view(276, 680));
+      await tester.pump();
+
+      expect(controller.selectedText, 'اهلا وسهلا\nكيف حالك');
+      await gesture.up();
+      await tester.pump();
+
+      final copied = <String?>[];
+      tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied.add((call.arguments as Map)['text'] as String?);
+        }
+        return null;
+      });
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-text-selection-chip-copy')));
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump();
+      expect(copied, [
+        '\u2067اهلا وسهلا\u2069\n'
+            '\u2067كيف حالك\u2069'
+      ]);
+    });
+
     testWidgets(
         'long press selects the word under the finger and shows '
         'handles and the chip', (tester) async {

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -57,11 +57,15 @@ class PdfExtractedRun {
 /// painted as a quad rotates with the text instead of ballooning out to
 /// an axis-aligned bounding box.
 class PdfTextQuad {
-  const PdfTextQuad(this.corners);
+  const PdfTextQuad(this.corners, {this.isRightToLeft = false});
 
   /// The four `(x, y)` page-space points in perimeter order (ll, lr, ur,
   /// ul). Always length 4.
   final List<(double x, double y)> corners;
+
+  /// Whether logical text advances from the quad's right edge toward its
+  /// left edge. Selection chrome uses this to anchor its logical endpoints.
+  final bool isRightToLeft;
 
   /// The axis-aligned page-space bounding box of the four corners.
   PdfRect get bounds {
@@ -205,7 +209,12 @@ class PdfPageText {
       final logicalEnd = (overlapEnd - run.startIndex) / run.text.length;
       final f0 = run.isRightToLeft ? 1 - logicalEnd : logicalStart;
       final f1 = run.isRightToLeft ? 1 - logicalStart : logicalEnd;
-      quads.add(_quadOf(run.transform, run.width * f0, run.width * f1));
+      quads.add(_quadOf(
+        run.transform,
+        run.width * f0,
+        run.width * f1,
+        isRightToLeft: run.isRightToLeft,
+      ));
     }
     return quads;
   }
@@ -266,6 +275,49 @@ class PdfPageText {
     final logicalFraction = best.isRightToLeft ? 1 - fraction : fraction;
     return best.startIndex + (logicalFraction * best.text.length).round();
   }
+}
+
+/// Adds Unicode direction metadata suitable for putting extracted [text] on
+/// a plain-text clipboard.
+///
+/// Searchable PDF text remains in clean logical order. Each paragraph that
+/// contains strong RTL text is instead wrapped at copy time in the isolate
+/// matching its first strong character (`RLI` or `LRI`), followed by `PDI`.
+/// Isolates are paragraph-scoped, so line endings are preserved outside the
+/// controls. A paragraph already wrapped in `LRI`/`RLI`/`FSI` and `PDI` is
+/// left alone.
+///
+/// This follows the W3C guidance for carrying bidirectional metadata in
+/// plain text when markup is unavailable:
+/// https://www.w3.org/International/questions/qa-bidi-unicode-controls.en.html
+String pdfBidiIsolateForCopy(String text) {
+  if (text.isEmpty) return text;
+  return text.splitMapJoin(
+    RegExp(r'\r\n|[\r\n]'),
+    onMatch: (match) => match.group(0)!,
+    onNonMatch: _isolateBidiParagraph,
+  );
+}
+
+String _isolateBidiParagraph(String text) {
+  if (text.isEmpty || _hasOuterBidiIsolate(text)) return text;
+  _BidiKind? firstStrong;
+  var hasRightToLeft = false;
+  for (final rune in text.runes) {
+    final direction = _strongBidiKind(rune);
+    if (direction == null) continue;
+    firstStrong ??= direction;
+    if (direction == _BidiKind.rtl) hasRightToLeft = true;
+  }
+  if (!hasRightToLeft) return text;
+  final opener = firstStrong == _BidiKind.rtl ? '\u2067' : '\u2066';
+  return '$opener$text\u2069';
+}
+
+bool _hasOuterBidiIsolate(String text) {
+  final first = text.codeUnitAt(0);
+  return (first == 0x2066 || first == 0x2067 || first == 0x2068) &&
+      text.codeUnitAt(text.length - 1) == 0x2069;
 }
 
 /// A line of text inferred from positioned page text.
@@ -516,14 +568,22 @@ class PdfTextExtractor {
       flush();
     }
 
-    for (final item in line) {
-      add(item.separator, null);
+    final visualLine = _visualSourceOrder(line);
+    PdfTextRun? visualPrevious;
+    for (final item in visualLine) {
+      add(
+        visualPrevious == null
+            ? ''
+            : _separatorWithinVisualLine(visualPrevious, item.run),
+        null,
+      );
       final glyphs = item.run.glyphs;
       final hasGlyphText = glyphs != null &&
           glyphs.every((glyph) => glyph.text != null) &&
           glyphs.map((glyph) => glyph.text!).join() == item.run.text;
       if (!hasGlyphText) {
         add(item.run.text, item.run);
+        visualPrevious = item.run;
         continue;
       }
       var sourceOffset = 0;
@@ -543,6 +603,7 @@ class PdfTextExtractor {
         );
         sourceOffset += text.length;
       }
+      visualPrevious = item.run;
     }
     if (!hasRtl || hasUnpositionedRtl) return null;
 
@@ -591,6 +652,53 @@ class PdfTextExtractor {
       isRightToLeft: rightToLeft,
       mcid: source.mcid,
     ));
+  }
+
+  /// Orders separately positioned text-showing runs by their location along
+  /// the line's visual baseline. RTL layout engines commonly emit words in
+  /// logical order while placing each successive word farther left; using the
+  /// content-stream order in that case reverses the words a second time.
+  static List<_SourceRun> _visualSourceOrder(List<_SourceRun> line) {
+    if (line.length < 2) return line;
+    final baseline = line.first.run.transform;
+    final length = math.sqrt(baseline.a * baseline.a + baseline.b * baseline.b);
+    if (length <= 1e-9) return line;
+    final ux = baseline.a / length;
+    final uy = baseline.b / length;
+    final positioned = <({int index, double offset, _SourceRun source})>[
+      for (var i = 0; i < line.length; i++)
+        (
+          index: i,
+          offset: line[i].run.transform.e * ux + line[i].run.transform.f * uy,
+          source: line[i],
+        ),
+    ];
+    positioned.sort((a, b) {
+      final order = a.offset.compareTo(b.offset);
+      return order != 0 ? order : a.index.compareTo(b.index);
+    });
+    return [for (final item in positioned) item.source];
+  }
+
+  /// Reconstructs an inferred separator after source runs have been reordered
+  /// visually. The gap is measured along the preceding run's baseline so the
+  /// same logic works for rotated text.
+  static String _separatorWithinVisualLine(
+      PdfTextRun previous, PdfTextRun next) {
+    final em = previous.transform.scaleFactor;
+    final axisLength = math.sqrt(previous.transform.a * previous.transform.a +
+        previous.transform.b * previous.transform.b);
+    if (em <= 0 || axisLength <= 1e-9) return ' ';
+    final endX = previous.transform.transformX(previous.width, 0);
+    final endY = previous.transform.transformY(previous.width, 0);
+    final dx = next.transform.e - endX;
+    final dy = next.transform.f - endY;
+    final ux = previous.transform.a / axisLength;
+    final uy = previous.transform.b / axisLength;
+    final along = dx * ux + dy * uy;
+    final across = (dx * -uy + dy * ux).abs();
+    if (across > 0.5 * em || along > 0.15 * em) return ' ';
+    return '';
   }
 
   /// Extracts every page and infers paragraph blocks in reading order.
@@ -1063,6 +1171,20 @@ _BidiKind _bidiKind(int rune, _BidiKind? previous) {
   };
 }
 
+/// Strong direction only, for choosing a plain-text paragraph isolate.
+/// Numbers and neutral/formatting characters deliberately return null.
+_BidiKind? _strongBidiKind(int rune) {
+  if ((rune >= 0x10800 && rune <= 0x10FFF) ||
+      (rune >= 0x1E800 && rune <= 0x1EDFF)) {
+    return _BidiKind.rtl;
+  }
+  return switch (bidi.getCharacterType(rune)) {
+    bidi.CharacterType.rtl || bidi.CharacterType.al => _BidiKind.rtl,
+    bidi.CharacterType.ltr => _BidiKind.ltr,
+    _ => null,
+  };
+}
+
 String _reverseRunes(String text) =>
     String.fromCharCodes(text.runes.toList().reversed);
 
@@ -1083,18 +1205,26 @@ class _Column {
 /// Quad of the em-space span [x0]..[x1] (with conventional 0.25 em descent
 /// and 0.75 em ascent) mapped through [transform], in perimeter order
 /// (ll, lr, ur, ul). Rotated text yields a rotated parallelogram.
-PdfTextQuad _quadOf(PdfMatrix transform, double x0, double x1) {
+PdfTextQuad _quadOf(
+  PdfMatrix transform,
+  double x0,
+  double x1, {
+  bool isRightToLeft = false,
+}) {
   const descent = -0.25;
   const ascent = 0.75;
-  return PdfTextQuad([
-    for (final (x, y) in [
-      (x0, descent),
-      (x1, descent),
-      (x1, ascent),
-      (x0, ascent),
-    ])
-      (transform.transformX(x, y), transform.transformY(x, y)),
-  ]);
+  return PdfTextQuad(
+    [
+      for (final (x, y) in [
+        (x0, descent),
+        (x1, descent),
+        (x1, ascent),
+        (x0, ascent),
+      ])
+        (transform.transformX(x, y), transform.transformY(x, y)),
+    ],
+    isRightToLeft: isRightToLeft,
+  );
 }
 
 /// Axis-aligned bounding box of the em-space span [x0]..[x1] mapped

--- a/packages/pdf_graphics/test/text_extraction_test.dart
+++ b/packages/pdf_graphics/test/text_extraction_test.dart
@@ -221,6 +221,48 @@ void main() {
     expect(page.findAll('الله', caseSensitive: true), hasLength(1));
   });
 
+  test('positioned RTL word runs keep logical word and line order', () {
+    const logical = 'اهلا وسهلا\nكيف حالك\nخوش آمدید';
+    final document = PdfDocument.open(buildRtlTextPdf(lines: const [
+      'اهلا وسهلا',
+      'كيف حالك',
+      'خوش آمدید',
+    ]));
+    final page = PdfTextExtractor.extract(document, 0);
+
+    expect(page.text, logical);
+    expect(page.findAll('اهلا وسهلا', caseSensitive: true), hasLength(1));
+    expect(page.findAll('خوش آمدید', caseSensitive: true), hasLength(1));
+    expect(page.textIn(const PdfRect(200, 590, 380, 750)), logical);
+
+    final first = page.findAll('اهلا', caseSensitive: true).single;
+    final second = page.findAll('وسهلا', caseSensitive: true).single;
+    expect(first.rects.first.left, greaterThan(second.rects.first.left));
+    expect(first.quads.first.isRightToLeft, isTrue);
+    expect(page.positionNear(359, 720), 0);
+    expect(page.positionNear(313, 720), 4);
+  });
+
+  test('copy text uses paragraph-scoped Unicode bidi isolates', () {
+    expect(pdfBidiIsolateForCopy('Hello, world!'), 'Hello, world!');
+    expect(
+      pdfBidiIsolateForCopy('اهلا وسهلا'),
+      '\u2067اهلا وسهلا\u2069',
+    );
+    expect(
+      pdfBidiIsolateForCopy('Invoice: اهلا'),
+      '\u2066Invoice: اهلا\u2069',
+    );
+    expect(
+      pdfBidiIsolateForCopy('اهلا\nکیف حالک'),
+      '\u2067اهلا\u2069\n\u2067کیف حالک\u2069',
+    );
+    expect(
+      pdfBidiIsolateForCopy('\u2067اهلا\u2069'),
+      '\u2067اهلا\u2069',
+    );
+  });
+
   test('reflow reads visual columns before stream order', () {
     final doc = PdfDocument.open(_buildTextPdf([
       _textAt(320, 720, 'Right top'),

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 export 'src/encrypted.dart';
 export 'src/icc_profiles.dart';
 export 'src/pkix_ltv.dart';
+export 'src/rtl_text.dart';
 export 'src/signer_identity.dart';
 export 'src/test_tsa.dart';
 

--- a/packages/pdf_test_fixtures/lib/src/rtl_text.dart
+++ b/packages/pdf_test_fixtures/lib/src/rtl_text.dart
@@ -1,0 +1,118 @@
+import 'dart:typed_data';
+
+/// Builds a one-page Type3-font PDF whose RTL words are painted by separate
+/// text-showing operators.
+///
+/// Operators remain in logical word order while their origins move from right
+/// to left. Each word's glyph codes are in visual order, matching PDFs emitted
+/// by layout engines that position Arabic or Urdu one word at a time.
+Uint8List buildRtlTextPdf({
+  List<String> lines = const ['اهلا وسهلا', 'كيف حالك'],
+}) {
+  const fontSize = 24.0;
+  const rightEdge = 360.0;
+  const wordGap = 24.0;
+  const firstBaseline = 720.0;
+  const lineGap = 40.0;
+  final glyphs = <(int code, String text, int width)>[];
+  final operations = <String>['BT /F1 24 Tf'];
+  var nextCode = 1;
+
+  for (var lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    var right = rightEdge;
+    final words =
+        lines[lineIndex].split(RegExp(r'\s+')).where((word) => word.isNotEmpty);
+    for (final word in words) {
+      final visual = word.runes.toList().reversed;
+      final codes = StringBuffer();
+      var width = 0;
+      for (final rune in visual) {
+        if (nextCode > 0xff) {
+          throw ArgumentError.value(
+              lines, 'lines', 'fixture exceeds 255 glyphs');
+        }
+        final glyphWidth = _isCombiningMark(rune) ? 0 : 500;
+        glyphs.add((nextCode, String.fromCharCode(rune), glyphWidth));
+        codes.write(nextCode.toRadixString(16).padLeft(2, '0'));
+        width += glyphWidth;
+        nextCode++;
+      }
+      final widthPoints = width * fontSize / 1000;
+      final x = right - widthPoints;
+      final y = firstBaseline - lineIndex * lineGap;
+      operations.add('1 0 0 1 ${_number(x)} ${_number(y)} Tm <$codes> Tj');
+      right = x - wordGap;
+    }
+  }
+  operations.add('ET');
+  final content = operations.join('\n');
+
+  final cmapEntries = <String>[];
+  final widths = <String>[];
+  final names = <String>[];
+  for (final (code, text, width) in glyphs) {
+    final codeHex = code.toRadixString(16).padLeft(2, '0');
+    final unicode = text.codeUnits
+        .map((unit) => unit.toRadixString(16).padLeft(4, '0'))
+        .join();
+    cmapEntries.add('<$codeHex> <$unicode>');
+    widths.add('$width');
+    names.add('/g$code');
+  }
+  final cmap = [
+    '/CIDInit /ProcSet findresource begin',
+    '12 dict begin begincmap',
+    '1 begincodespacerange <00> <FF> endcodespacerange',
+    '${cmapEntries.length} beginbfchar',
+    ...cmapEntries,
+    'endbfchar endcmap CMapName currentdict /CMap defineresource pop',
+    'end end',
+  ].join('\n');
+  final font = '<< /Type /Font /Subtype /Type3 '
+      '/FontBBox [0 -200 1000 800] /FontMatrix [0.001 0 0 0.001 0 0] '
+      '/FirstChar 1 /LastChar ${glyphs.length} '
+      '/Widths [${widths.join(' ')}] '
+      '/Encoding << /Type /Encoding /Differences [1 ${names.join(' ')}] >> '
+      '/ToUnicode 6 0 R '
+      '/CharProcs << ${[
+    for (final name in names) '$name 7 0 R'
+  ].join(' ')} >> /Resources << >> >>';
+  const charProc = '500 0 d0 0 0 450 700 re f';
+  return _assemblePdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    font,
+    '<< /Length ${cmap.length} >>\nstream\n$cmap\nendstream',
+    '<< /Length ${charProc.length} >>\nstream\n$charProc\nendstream',
+  ]);
+}
+
+bool _isCombiningMark(int rune) => rune >= 0x064b && rune <= 0x065f;
+
+String _number(double value) {
+  final fixed = value.toStringAsFixed(3);
+  return fixed.replaceFirst(RegExp(r'\.?0+$'), '');
+}
+
+Uint8List _assemblePdf(List<String> objects) {
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}


### PR DESCRIPTION
## Summary

Fix multi-word RTL text extraction and selection for Arabic and Urdu PDFs.

Some PDFs emit RTL words as separate `Tj` operators in logical word order while positioning them progressively to the left. The previous line-wide reversal then reversed the word groups a second time, so copied or searched text such as `اهلا وسهلا` became `وسهلا اهلا`.

This change:

- normalizes separately positioned text runs into visual baseline order before converting the line to logical BiDi order
- carries RTL direction through text quads so selection starts and ends on the correct visual sides
- wraps clipboard paragraphs containing RTL text in W3C-recommended RLI/LRI and PDI controls, without adding controls to search or selected-text APIs
- adds programmatic Arabic and Urdu fixtures covering multi-word and multi-line extraction, copying, searching, and touch selection

## Impact

- Multi-word Arabic and Urdu search and copy preserve logical word order.
- RTL selection handles use the logical start on the right and logical end on the left.
- Clipboard text remains stable when embedded in surrounding LTR content.

## Verification

- `fvm dart analyze`
- `cd packages/pdf_graphics && fvm dart test` — 798 tests passed
- `cd packages/dart_pdf_editor && fvm flutter test` — 1416 tests passed
- Web worker compilation matches the checked-in asset
