### PR TITLE
Fix Arabic search and tashkil extraction

### DIFF
--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -43,6 +43,10 @@ class CanvasPdfDevice implements PdfDevice {
   @visibleForTesting
   static int get debugTextLayoutCacheLength => _textCache.length;
 
+  /// Ordered fallbacks used for normal substituted text — test hook.
+  @visibleForTesting
+  static List<String> get debugDefaultFontFallbacks => _defaultFontFallbacks;
+
   /// Diagnostic kill switches for the command replay benchmark.
   @visibleForTesting
   static bool debugReuseSolidPaints = true;
@@ -743,6 +747,21 @@ class CanvasPdfDevice implements PdfDevice {
   ];
 
   static const _defaultFontFallbacks = [
+    // Shipped with dart_pdf_editor, so Arabic (including presentation forms
+    // copied from shaped PDFs), Hebrew, Greek and Cyrillic render consistently
+    // even when the host's Helvetica substitute has no suitable fallback.
+    'packages/dart_pdf_editor/DejaVu Sans',
+    // The unprefixed family is used when this package itself is the Flutter
+    // application under test, and by hosts that register DejaVu system-wide.
+    'DejaVu Sans',
+    // Platform Arabic faces. These also cover the Arabic Presentation Forms
+    // commonly exposed by PDFs that store already-shaped text.
+    'Geeza Pro',
+    '.SF Arabic',
+    'Noto Naskh Arabic',
+    'Noto Sans Arabic',
+    'Segoe UI',
+    'Arial Unicode MS',
     'Hiragino Sans',
     'PingFang SC',
     'Noto Sans CJK SC',

--- a/packages/dart_pdf_editor/test/render_smoke_test.dart
+++ b/packages/dart_pdf_editor/test/render_smoke_test.dart
@@ -29,6 +29,7 @@ Future<void> loadSystemFonts() async {
       '/System/Library/Fonts/Supplemental/Times New Roman.ttf'
     ],
     'Courier': ['/System/Library/Fonts/Supplemental/Courier New.ttf'],
+    'Geeza Pro': ['/System/Library/Fonts/GeezaPro.ttc'],
     'Apple Symbols': ['/System/Library/Fonts/Apple Symbols.ttf'],
     'Symbol': ['/System/Library/Fonts/Symbol.ttf'],
     'Zapf Dingbats': ['/System/Library/Fonts/ZapfDingbats.ttf'],

--- a/packages/dart_pdf_editor/test/text_cache_test.dart
+++ b/packages/dart_pdf_editor/test/text_cache_test.dart
@@ -5,13 +5,90 @@
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/painting.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 Future<Uint8List> _raster(PdfPage page) async {
   final image = await PdfPageRenderer.renderImage(page, pixelRatio: 2);
+  try {
+    final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+    return Uint8List.fromList(data!.buffer.asUint8List());
+  } finally {
+    image.dispose();
+  }
+}
+
+const _copiedArabicLine =
+    '\u2067اﻟﺣﻣد لله رب اﻟﻌﺎﻟﻣﯾن) 2 (اﻟرﺣﻣن اﻟرﺣﯾم) 3 (ﻣﺎﻟك ﯾوم\u2069';
+
+bool _dejavuLoaded = false;
+
+Future<void> _loadBundledDejavu() async {
+  if (_dejavuLoaded) return;
+  _dejavuLoaded = true;
+  final data = await rootBundle
+      .load('packages/dart_pdf_editor/assets/fonts/DejaVuSans.ttf');
+  final loader = FontLoader('packages/dart_pdf_editor/DejaVu Sans')
+    ..addFont(Future.value(data));
+  await loader.load();
+}
+
+Future<Uint8List> _rasterSubstitutedArabic({
+  required bool throughDevice,
+  List<String>? fallbacks,
+  String fontFamily = 'Helvetica',
+}) async {
+  const renderSize = 100.0;
+  const runWidth = _copiedArabicLine.length * 0.5;
+  const transform = PdfMatrix(20, 0, 0, 20, 20, 80);
+  final style = TextStyle(
+    color: const Color(0xFFFF0000),
+    fontSize: renderSize,
+    fontFamily: fontFamily,
+    fontFamilyFallback: fallbacks ?? CanvasPdfDevice.debugDefaultFontFallbacks,
+    letterSpacing: 0,
+    height: 1,
+  );
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder)
+    ..drawColor(const Color(0xFFFFFFFF), BlendMode.src);
+
+  if (throughDevice) {
+    CanvasPdfDevice(canvas).drawText(const PdfTextRun(
+      text: _copiedArabicLine,
+      transform: transform,
+      color: PdfColor(1, 0, 0),
+      width: runWidth,
+      fontName: 'Helvetica',
+      fontSize: 20,
+    ));
+  } else {
+    final painter = TextPainter(
+      text: TextSpan(text: _copiedArabicLine, style: style),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    final baseline =
+        painter.computeDistanceToActualBaseline(TextBaseline.alphabetic);
+    final scaleX = runWidth * renderSize / painter.width;
+    canvas
+      ..save()
+      ..transform(Float64List.fromList(const [
+        20, 0, 0, 0, //
+        0, 20, 0, 0, //
+        0, 0, 1, 0, //
+        20, 80, 0, 1,
+      ]))
+      ..scale(scaleX / renderSize, -1 / renderSize);
+    painter.paint(canvas, Offset(0, -baseline));
+    canvas.restore();
+  }
+
+  final image = await recorder.endRecording().toImage(1400, 160);
   try {
     final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
     return Uint8List.fromList(data!.buffer.asUint8List());
@@ -70,6 +147,31 @@ void main() {
       final cold = await _raster(page);
       final warm = await _raster(page);
       expect(warm, equals(cold));
+    });
+  });
+
+  testWidgets(
+      'substituted text renders copied Arabic presentation forms through the bundled fallback',
+      (tester) async {
+    await tester.runAsync(() async {
+      await _loadBundledDejavu();
+      CanvasPdfDevice.clearTextLayoutCache();
+
+      expect(
+        CanvasPdfDevice.debugDefaultFontFallbacks,
+        contains('packages/dart_pdf_editor/DejaVu Sans'),
+      );
+      final expected = await _rasterSubstitutedArabic(throughDevice: false);
+      final missing = await _rasterSubstitutedArabic(
+        throughDevice: false,
+        fallbacks: const ['Ahem'],
+        fontFamily: 'Ahem',
+      );
+      final actual = await _rasterSubstitutedArabic(throughDevice: true);
+
+      expect(expected, isNot(equals(missing)),
+          reason: 'the bundled font must replace missing-glyph boxes');
+      expect(actual, equals(expected));
     });
   });
 }

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -11,6 +11,9 @@ import 'mesh.dart';
 import 'path.dart';
 import 'shading.dart';
 
+final _bidiFormattingControls =
+    RegExp(r'[\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]');
+
 /// One positioned run of text on a page, in page space.
 class PdfExtractedRun {
   const PdfExtractedRun({
@@ -124,6 +127,8 @@ class PdfPageText {
   /// throwing); matching is synchronous with no timeout, so a pathological
   /// (catastrophically backtracking) pattern over a large page can block
   /// the caller. [caseSensitive] applies to both literal and regex search.
+  /// Literal queries ignore Unicode BiDi formatting controls so text copied
+  /// with direction metadata can be pasted back into search.
   List<PdfTextMatch> findAll(
     String query, {
     bool caseSensitive = false,
@@ -146,6 +151,8 @@ class PdfPageText {
       }
       return matches;
     }
+    query = query.replaceAll(_bidiFormattingControls, '');
+    if (query.isEmpty) return const [];
     final haystack = caseSensitive ? text : text.toLowerCase();
     final needle = caseSensitive ? query : query.toLowerCase();
     var from = 0;
@@ -568,42 +575,46 @@ class PdfTextExtractor {
       flush();
     }
 
-    final visualLine = _visualSourceOrder(line);
+    final visualLine = _visualSourceClusters(line);
     PdfTextRun? visualPrevious;
-    for (final item in visualLine) {
+    for (final cluster in visualLine) {
       add(
         visualPrevious == null
             ? ''
-            : _separatorWithinVisualLine(visualPrevious, item.run),
+            : _separatorWithinVisualLine(visualPrevious, cluster.anchor),
         null,
       );
-      final glyphs = item.run.glyphs;
-      final hasGlyphText = glyphs != null &&
-          glyphs.every((glyph) => glyph.text != null) &&
-          glyphs.map((glyph) => glyph.text!).join() == item.run.text;
-      if (!hasGlyphText) {
-        add(item.run.text, item.run);
-        visualPrevious = item.run;
-        continue;
+      if (_isZeroAdvanceMark(cluster.sources.first.run)) {
+        previousKind = _firstStrongKind(cluster.anchor.text) ?? previousKind;
       }
-      var sourceOffset = 0;
-      for (var i = 0; i < glyphs.length; i++) {
-        final glyph = glyphs[i];
-        final text = glyph.text!;
-        final end = i + 1 < glyphs.length
-            ? math.max(glyph.offset, glyphs[i + 1].offset)
-            : item.run.width;
-        add(
-          text,
-          item.run,
-          sourceOffset: sourceOffset,
-          preserveText: true,
-          sourceX0: glyph.offset,
-          sourceX1: end,
-        );
-        sourceOffset += text.length;
+      for (final item in cluster.sources) {
+        final glyphs = item.run.glyphs;
+        final hasGlyphText = glyphs != null &&
+            glyphs.every((glyph) => glyph.text != null) &&
+            glyphs.map((glyph) => glyph.text!).join() == item.run.text;
+        if (!hasGlyphText) {
+          add(item.run.text, item.run);
+          continue;
+        }
+        var sourceOffset = 0;
+        for (var i = 0; i < glyphs.length; i++) {
+          final glyph = glyphs[i];
+          final text = glyph.text!;
+          final end = i + 1 < glyphs.length
+              ? math.max(glyph.offset, glyphs[i + 1].offset)
+              : item.run.width;
+          add(
+            text,
+            item.run,
+            sourceOffset: sourceOffset,
+            preserveText: true,
+            sourceX0: glyph.offset,
+            sourceX1: end,
+          );
+          sourceOffset += text.length;
+        }
       }
-      visualPrevious = item.run;
+      visualPrevious = cluster.anchor;
     }
     if (!hasRtl || hasUnpositionedRtl) return null;
 
@@ -654,30 +665,72 @@ class PdfTextExtractor {
     ));
   }
 
-  /// Orders separately positioned text-showing runs by their location along
-  /// the line's visual baseline. RTL layout engines commonly emit words in
-  /// logical order while placing each successive word farther left; using the
-  /// content-stream order in that case reverses the words a second time.
-  static List<_SourceRun> _visualSourceOrder(List<_SourceRun> line) {
-    if (line.length < 2) return line;
+  /// Groups zero-advance marks with their following base run, then orders the
+  /// clusters by their location along the line's visual baseline.
+  ///
+  /// Skia emits Arabic marks as separate text-showing operators immediately
+  /// before their base glyph. Sorting those marks independently moves them
+  /// across the base and makes the gap heuristic insert spaces inside words.
+  /// Keeping the source-order cluster intact lets the RTL reversal restore
+  /// base-then-mark logical order while separately positioned words can still
+  /// move into visual order before the reversal.
+  static List<_SourceCluster> _visualSourceClusters(List<_SourceRun> line) {
+    final clusters = <_SourceCluster>[];
+    final pendingMarks = <_SourceRun>[];
+    for (final source in line) {
+      if (_isZeroAdvanceMark(source.run)) {
+        pendingMarks.add(source);
+        continue;
+      }
+      clusters.add(_SourceCluster(
+        [...pendingMarks, source],
+        source.run,
+      ));
+      pendingMarks.clear();
+    }
+    if (pendingMarks.isNotEmpty) {
+      if (clusters.isEmpty) {
+        clusters.add(_SourceCluster([...pendingMarks], pendingMarks.last.run));
+      } else {
+        final last = clusters.removeLast();
+        clusters.add(_SourceCluster(
+          [...last.sources, ...pendingMarks],
+          last.anchor,
+        ));
+      }
+    }
+    if (clusters.length < 2) return clusters;
+
     final baseline = line.first.run.transform;
     final length = math.sqrt(baseline.a * baseline.a + baseline.b * baseline.b);
-    if (length <= 1e-9) return line;
+    if (length <= 1e-9) return clusters;
     final ux = baseline.a / length;
     final uy = baseline.b / length;
-    final positioned = <({int index, double offset, _SourceRun source})>[
-      for (var i = 0; i < line.length; i++)
+    final positioned = <({int index, double offset, _SourceCluster cluster})>[
+      for (var i = 0; i < clusters.length; i++)
         (
           index: i,
-          offset: line[i].run.transform.e * ux + line[i].run.transform.f * uy,
-          source: line[i],
+          offset: clusters[i].anchor.transform.e * ux +
+              clusters[i].anchor.transform.f * uy,
+          cluster: clusters[i],
         ),
     ];
     positioned.sort((a, b) {
       final order = a.offset.compareTo(b.offset);
       return order != 0 ? order : a.index.compareTo(b.index);
     });
-    return [for (final item in positioned) item.source];
+    return [for (final item in positioned) item.cluster];
+  }
+
+  static bool _isZeroAdvanceMark(PdfTextRun run) =>
+      run.width.abs() <= 1e-9 && run.text.trim().isNotEmpty;
+
+  static _BidiKind? _firstStrongKind(String text) {
+    for (final rune in text.runes) {
+      final kind = _strongBidiKind(rune);
+      if (kind != null) return kind;
+    }
+    return null;
   }
 
   /// Reconstructs an inferred separator after source runs have been reordered
@@ -685,6 +738,7 @@ class PdfTextExtractor {
   /// same logic works for rotated text.
   static String _separatorWithinVisualLine(
       PdfTextRun previous, PdfTextRun next) {
+    if (previous.text.trim().isEmpty || next.text.trim().isEmpty) return '';
     final em = previous.transform.scaleFactor;
     final axisLength = math.sqrt(previous.transform.a * previous.transform.a +
         previous.transform.b * previous.transform.b);
@@ -1101,6 +1155,13 @@ class _SourceRun {
 
   final String separator;
   final PdfTextRun run;
+}
+
+class _SourceCluster {
+  const _SourceCluster(this.sources, this.anchor);
+
+  final List<_SourceRun> sources;
+  final PdfTextRun anchor;
 }
 
 enum _BidiKind { ltr, rtl, neutral }

--- a/packages/pdf_graphics/test/text_extraction_test.dart
+++ b/packages/pdf_graphics/test/text_extraction_test.dart
@@ -176,6 +176,17 @@ void main() {
         firstWord.rects.first.left, greaterThan(secondWord.rects.first.left));
   });
 
+  test('positioned tashkil stays clustered with its Arabic base glyph', () {
+    const logical = 'ٱﻟْﺣَﻣْدُ ل';
+    final page = PdfTextExtractor.extract(
+      PdfDocument.open(buildPositionedTashkilPdf()),
+      0,
+    );
+
+    expect(page.text, logical);
+    expect(page.findAll(logical, caseSensitive: true), hasLength(1));
+  });
+
   test('Arabic logical-order substitute text is not double-reversed', () {
     const logical = 'مرحبا 123';
     final page = PdfTextExtractor.extract(
@@ -241,6 +252,15 @@ void main() {
     expect(first.quads.first.isRightToLeft, isTrue);
     expect(page.positionNear(359, 720), 0);
     expect(page.positionNear(313, 720), 4);
+  });
+
+  test('literal search ignores clipboard bidi formatting controls', () {
+    const text = '(اﻟرﺣﻣن';
+    const page = PdfPageText(pageIndex: 0, text: text, runs: []);
+
+    final match = page.findAll('\u2067$text\u2069', caseSensitive: true).single;
+    expect((match.start, match.end), (0, text.length));
+    expect(page.findAll('\u2067\u2069'), isEmpty);
   });
 
   test('copy text uses paragraph-scoped Unicode bidi isolates', () {

--- a/packages/pdf_test_fixtures/lib/src/rtl_text.dart
+++ b/packages/pdf_test_fixtures/lib/src/rtl_text.dart
@@ -90,6 +90,78 @@ Uint8List buildRtlTextPdf({
   ]);
 }
 
+/// Builds a one-page Type3-font PDF matching Skia's positioned Arabic
+/// tashkil output: every zero-advance mark is a separate text-showing run
+/// immediately before its base glyph and is shifted over that glyph.
+///
+/// The logical text is `ٱﻟْﺣَﻣْدُ ل`; the content stream paints visual clusters
+/// left-to-right as `ُد`, `ْﻣ`, `َﺣ`, `ْﻟ`, `ٱ`, a space, then `ل`.
+Uint8List buildPositionedTashkilPdf() {
+  const glyphs = <({String text, int width, double x, double y})>[
+    (text: 'ُ', width: 0, x: 202, y: 724),
+    (text: 'د', width: 500, x: 200, y: 720),
+    (text: 'ْ', width: 0, x: 214, y: 724),
+    (text: 'ﻣ', width: 500, x: 212, y: 720),
+    (text: 'َ', width: 0, x: 226, y: 724),
+    (text: 'ﺣ', width: 500, x: 224, y: 720),
+    (text: 'ْ', width: 0, x: 238, y: 724),
+    (text: 'ﻟ', width: 500, x: 236, y: 720),
+    (text: 'ٱ', width: 500, x: 248, y: 720),
+    (text: ' ', width: 250, x: 188, y: 720),
+    (text: 'ل', width: 500, x: 176, y: 720),
+  ];
+  final operations = <String>['BT /F1 24 Tf'];
+  final cmapEntries = <String>[];
+  final widths = <String>[];
+  final names = <String>[];
+  for (var i = 0; i < glyphs.length; i++) {
+    final code = i + 1;
+    final glyph = glyphs[i];
+    final codeHex = code.toRadixString(16).padLeft(2, '0');
+    final unicode = glyph.text.codeUnits
+        .map((unit) => unit.toRadixString(16).padLeft(4, '0'))
+        .join();
+    operations.add(
+      '1 0 0 1 ${_number(glyph.x)} ${_number(glyph.y)} Tm '
+      '<$codeHex> Tj',
+    );
+    cmapEntries.add('<$codeHex> <$unicode>');
+    widths.add('${glyph.width}');
+    names.add('/g$code');
+  }
+  operations.add('ET');
+  final content = operations.join('\n');
+  final cmap = [
+    '/CIDInit /ProcSet findresource begin',
+    '12 dict begin begincmap',
+    '1 begincodespacerange <00> <FF> endcodespacerange',
+    '${cmapEntries.length} beginbfchar',
+    ...cmapEntries,
+    'endbfchar endcmap CMapName currentdict /CMap defineresource pop',
+    'end end',
+  ].join('\n');
+  final font = '<< /Type /Font /Subtype /Type3 '
+      '/FontBBox [0 -200 1000 800] /FontMatrix [0.001 0 0 0.001 0 0] '
+      '/FirstChar 1 /LastChar ${glyphs.length} '
+      '/Widths [${widths.join(' ')}] '
+      '/Encoding << /Type /Encoding /Differences [1 ${names.join(' ')}] >> '
+      '/ToUnicode 6 0 R '
+      '/CharProcs << ${[
+    for (final name in names) '$name 7 0 R'
+  ].join(' ')} >> /Resources << >> >>';
+  const charProc = '500 0 d0 0 0 450 700 re f';
+  return _assemblePdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    font,
+    '<< /Length ${cmap.length} >>\nstream\n$cmap\nendstream',
+    '<< /Length ${charProc.length} >>\nstream\n$charProc\nendstream',
+  ]);
+}
+
 bool _isCombiningMark(int rune) => rune >= 0x064b && rune <= 0x065f;
 
 String _number(double value) {


### PR DESCRIPTION
## Summary

- ignore Unicode BiDi formatting controls in literal search queries, so Arabic text copied with RLI/PDI metadata can be searched directly
- cluster separately positioned zero-advance Arabic marks with their base glyph before visual run ordering, preventing spaces between tashkil and letters
- treat explicit whitespace runs as authoritative when reconstructing RTL separators
- render substituted Unicode text through the bundled DejaVu Sans face, followed by native Arabic families, so pasted Arabic presentation forms do not become missing-glyph boxes
- add programmatic regressions for Skia-style positioned tashkil, copied search text, and the reported pasted Arabic line

Fixes #273.

## Validation

- `fvm dart analyze`
- `cd packages/pdf_graphics && fvm dart test` (800 tests)
- `cd packages/dart_pdf_editor && fvm flutter test` (1,417 tests)
- generated web-worker freshness check matches the checked-in asset
- verified extraction and exact copied-query search against the sample PDF attached to #273
- visually verified the reported copied line renders fully after committing a FreeText annotation