### PR TITLE
Expose editing actions for selected PDF text

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Expose edit-and-style and markup actions when text is selected in an
+  editor-backed viewer, on both touch and desktop context menus.
+
 ## 1.4.5
 
 - Correct selection and copy ordering for multi-word Arabic and other

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -5223,6 +5223,56 @@ class PdfEditingController extends ChangeNotifier {
       selectedElement?.kind == PdfElementKind.text &&
       (selectedElement?.text?.isNotEmpty ?? false);
 
+  /// Resolves a viewer text selection to the one editable page-content text
+  /// element underneath all of its [rects]. Returns null for multi-run text,
+  /// text inside a Form XObject, or ambiguous overlapping text layers.
+  ///
+  /// Keeping this conservative lets the selection menu promise that an edit
+  /// changes exactly the occurrence the user selected. Broader paragraph and
+  /// Form-XObject edits continue to use their dedicated content workflows.
+  PdfContentElement? textElementForSelection(
+    int pageIndex,
+    List<PdfRect> rects,
+    String text,
+  ) {
+    if (text.isEmpty || rects.isEmpty || text.contains('\n')) return null;
+    final candidates = elementsOn(pageIndex).elements.where((element) {
+      final bounds = element.bounds;
+      final elementText = element.text;
+      if (element.kind != PdfElementKind.text ||
+          bounds == null ||
+          elementText == null) {
+        return false;
+      }
+      final occurrence = elementText.indexOf(text);
+      if (occurrence < 0 ||
+          elementText.indexOf(text, occurrence + text.length) >= 0) {
+        return false;
+      }
+      return rects.every((rect) {
+        final overlap = bounds.intersect(rect);
+        return overlap.width > 0 && overlap.height > 0;
+      });
+    }).toList(growable: false);
+    return candidates.length == 1 ? candidates.single : null;
+  }
+
+  /// Whether [element]'s current font can accept rich style overrides.
+  /// Composite Type0 text can be re-typed in supported encodings, but the
+  /// content editor deliberately preserves its appearance.
+  bool canStyleContentText(int pageIndex, PdfContentElement element) {
+    if (element.kind != PdfElementKind.text) return false;
+    final name = element.resourceName;
+    if (name == null) return true;
+    final cos = _document.cos;
+    final fonts = cos.resolve(pageAt(pageIndex).resources['Font']);
+    if (fonts is! CosDictionary) return true;
+    final font = cos.resolve(fonts[name]);
+    if (font is! CosDictionary) return true;
+    final subtype = cos.resolve(font['Subtype']);
+    return subtype is! CosName || subtype.value != 'Type0';
+  }
+
   /// Whether the selected element is an image-like content draw that can be
   /// removed from the page stream and replaced by an image stamp in the same
   /// bounds.
@@ -5325,6 +5375,37 @@ class PdfEditingController extends ChangeNotifier {
       (e) => count = e.replaceText(
         selected.$1,
         element.text!,
+        text,
+        fallbackFonts: fallbackFonts,
+        style: style,
+      ),
+    );
+    return count;
+  }
+
+  /// Rewrites [find] only inside [element], the occurrence resolved from a
+  /// viewer text selection. Returns zero if the selection became stale while
+  /// a prompt was open or if the PDF font cannot safely draw [text].
+  int replaceTextInElement(
+    int pageIndex,
+    PdfContentElement element,
+    String find,
+    String text,
+    PdfTextStyle style, {
+    List<PdfEmbeddedFont> fallbackFonts = const [],
+  }) {
+    final elements = elementsOn(pageIndex);
+    if (element.id < 0 ||
+        element.id >= elements.elements.length ||
+        !identical(elements.elements[element.id], element)) {
+      return 0;
+    }
+    var count = 0;
+    apply(
+      (editor) => count = editor.replaceElementText(
+        elements,
+        element,
+        find,
         text,
         fallbackFonts: fallbackFonts,
         style: style,

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -15,6 +15,7 @@ import 'editing/editing_stamps.dart';
 import 'editing/editing_thumbnails.dart';
 import 'editing/editing_toolbar.dart';
 import 'editing/text_prompt.dart';
+import 'editing/text_style_prompt.dart';
 import 'editing/tool_shortcuts.dart';
 import 'page_number_field.dart';
 import 'performance_policy.dart';
@@ -229,6 +230,7 @@ class PdfEditorView extends StatefulWidget {
     this.fontPicker,
     this.onSnapshot,
     this.textPrompt,
+    this.styledTextPrompt,
     this.palette = PdfEditingToolbar.defaultPalette,
     this.toolShortcuts = pdfEditToolShortcuts,
     this.toolbarLeading = const [],
@@ -368,6 +370,10 @@ class PdfEditorView extends StatefulWidget {
   /// How dialog-based tools ask for text. Defaults to
   /// [showPdfTextPrompt], a Material dialog.
   final PdfTextPrompt? textPrompt;
+
+  /// How selected page-content text is edited together with its rich style.
+  /// Defaults to [showPdfStyledTextPrompt].
+  final PdfStyledTextPrompt? styledTextPrompt;
 
   /// The toolbar's color palette.
   final List<Color> palette;
@@ -752,6 +758,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     viewerController: _viewer,
                     // save lives in the header now, not the dock
                     textPrompt: widget.textPrompt ?? showPdfTextPrompt,
+                    styledTextPrompt:
+                        widget.styledTextPrompt ?? showPdfStyledTextPrompt,
                     imagePicker: widget.imagePicker,
                     formImagePicker: widget.formImagePicker,
                     onExportSelectedContentImage:
@@ -960,6 +968,18 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                             widget.systemImagePasteProvider,
                         onSnapshot: widget.onSnapshot,
                         editingTextPrompt: widget.textPrompt,
+                        editingStyledTextPrompt: widget.styledTextPrompt,
+                        editingPalette: widget.palette,
+                        textSelectionEditing: (features.tools == null ||
+                                features.tools!
+                                    .contains(PdfEditTool.content)) &&
+                            (features.toolGroups == null ||
+                                features.toolGroups!
+                                    .contains(PdfEditToolGroup.edit)),
+                        textSelectionMarkup: features.markup &&
+                            (features.toolGroups == null ||
+                                features.toolGroups!
+                                    .contains(PdfEditToolGroup.markup)),
                         initialFit: widget.initialFit,
                         toolShortcuts: _toolShortcuts,
                         backgroundColor: widget.backgroundColor,
@@ -1009,8 +1029,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
       body = PdfViewerTheme(data: widget.viewerTheme!, child: body);
     }
     final bindings = <ShortcutActivator, VoidCallback>{
-      ..._shell.searchShortcuts(
-          enabled: features.headerBar && features.search),
+      ..._shell.searchShortcuts(enabled: features.headerBar && features.search),
       // ⌘S / Ctrl+S saves through the host's [onSave], the same path the
       // toolbar's save button takes. ⌘⇧S / Ctrl+Shift+S invokes the
       // host's Save As path when one is provided.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -15,11 +15,13 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'annotation_tap.dart';
 import 'editing/editing_controller.dart';
+import 'editing/editing_fonts.dart';
 import 'editing/editing_form_layer.dart';
 import 'editing/editing_interaction.dart';
 import 'editing/editing_menu.dart';
 import 'editing/editing_overlay.dart';
 import 'editing/text_prompt.dart';
+import 'editing/text_style_prompt.dart';
 import 'editing/tool_shortcuts.dart';
 import 'exact_extent_list.dart';
 import 'page_geometry.dart';
@@ -33,6 +35,7 @@ import 'render_worker.dart';
 import 'renderer.dart';
 import 'scrollbar.dart';
 import 'theme.dart';
+import 'toast.dart';
 import 'viewport.dart';
 
 export 'viewport.dart' show PdfViewport, pdfDocumentKey;
@@ -501,6 +504,10 @@ class PdfViewer extends StatefulWidget {
     this.interactionSession,
     this.formController,
     this.editingTextPrompt,
+    this.editingStyledTextPrompt,
+    this.editingPalette = defaultStyledTextPalette,
+    this.textSelectionEditing = true,
+    this.textSelectionMarkup = true,
     this.annotationMenuBuilder,
     this.formImagePicker,
     this.fontPicker,
@@ -648,6 +655,21 @@ class PdfViewer extends StatefulWidget {
   /// How the editing tools ask for annotation text (free text, notes,
   /// stamps). Defaults to [showPdfTextPrompt], a Material dialog.
   final PdfTextPrompt? editingTextPrompt;
+
+  /// How the text-selection menu asks for replacement text and rich style.
+  /// Defaults to [showPdfStyledTextPrompt].
+  final PdfStyledTextPrompt? editingStyledTextPrompt;
+
+  /// Quick-pick colors shown by [editingStyledTextPrompt].
+  final List<Color> editingPalette;
+
+  /// Whether an editor-backed text selection exposes the pencil action that
+  /// opens [editingStyledTextPrompt]. Has no effect without [editing].
+  final bool textSelectionEditing;
+
+  /// Whether an editor-backed text selection exposes highlight, underline,
+  /// strikeout, and squiggly actions. Has no effect without [editing].
+  final bool textSelectionMarkup;
 
   /// Adds the app's own entries to the annotation context menu (the
   /// right-click menu - z-order and delete come stock). Called when the
@@ -2657,9 +2679,9 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     await _showTextMenu(details.globalPosition, details.localPosition, page);
   }
 
-  /// The mouse right-click text menu: Copy the current selection and
-  /// Select all on the page. Mirrors the touch selection chip's actions
-  /// for desktop users, who otherwise have only ⌘C. A right-click that
+  /// The mouse right-click text menu: editing/markup actions when an editor
+  /// is attached, plus Copy and Select all. Mirrors the touch selection
+  /// chip for desktop users, who otherwise have only ⌘C. A right-click that
   /// lands outside the current selection first selects the word under
   /// the cursor, like a desktop reader, so Copy has something to act on;
   /// a click inside the selection keeps it. With no selectable word and
@@ -2673,6 +2695,11 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
     final hasSelection = _selRange != null;
     final hasText = _pageText(page).text.isNotEmpty;
     if (!hasSelection && !hasText) return;
+    final editing = widget.editing;
+    final canEdit =
+        editing != null && widget.textSelectionEditing && hasSelection;
+    final canMarkup =
+        editing != null && widget.textSelectionMarkup && hasSelection;
     final overlay =
         Overlay.of(context).context.findRenderObject()! as RenderBox;
     final picked = await showMenu<_TextMenuAction>(
@@ -2680,6 +2707,35 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       position: RelativeRect.fromRect(
           globalPosition & Size.zero, Offset.zero & overlay.size),
       items: [
+        if (canEdit)
+          PopupMenuItem<_TextMenuAction>(
+            key: const ValueKey('pdf-text-menu-edit'),
+            value: _TextMenuAction.edit,
+            child: _textMenuRow(Icons.edit, 'Edit text & style', true),
+          ),
+        if (canMarkup) ...[
+          PopupMenuItem<_TextMenuAction>(
+            key: const ValueKey('pdf-text-menu-highlight'),
+            value: _TextMenuAction.highlight,
+            child: _textMenuRow(Icons.border_color, 'Highlight', true),
+          ),
+          PopupMenuItem<_TextMenuAction>(
+            key: const ValueKey('pdf-text-menu-underline'),
+            value: _TextMenuAction.underline,
+            child: _textMenuRow(Icons.format_underlined, 'Underline', true),
+          ),
+          PopupMenuItem<_TextMenuAction>(
+            key: const ValueKey('pdf-text-menu-strikeout'),
+            value: _TextMenuAction.strikeOut,
+            child: _textMenuRow(Icons.format_strikethrough, 'Strike out', true),
+          ),
+          PopupMenuItem<_TextMenuAction>(
+            key: const ValueKey('pdf-text-menu-squiggly'),
+            value: _TextMenuAction.squiggly,
+            child: _textMenuRow(Icons.gesture, 'Squiggly', true),
+          ),
+        ],
+        if (canEdit || canMarkup) const PopupMenuDivider(),
         PopupMenuItem<_TextMenuAction>(
           key: const ValueKey('pdf-text-menu-copy'),
           value: _TextMenuAction.copy,
@@ -2695,6 +2751,16 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       ],
     );
     switch (picked) {
+      case _TextMenuAction.edit:
+        await _editTextSelection();
+      case _TextMenuAction.highlight:
+        _markupTextSelection(PdfMarkupKind.highlight);
+      case _TextMenuAction.underline:
+        _markupTextSelection(PdfMarkupKind.underline);
+      case _TextMenuAction.strikeOut:
+        _markupTextSelection(PdfMarkupKind.strikeOut);
+      case _TextMenuAction.squiggly:
+        _markupTextSelection(PdfMarkupKind.squiggly);
       case _TextMenuAction.copy:
         await _controller.copySelection();
       case _TextMenuAction.selectAll:
@@ -2702,6 +2768,98 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       case null:
         break;
     }
+  }
+
+  /// Opens the rich content-text editor for the exact text element under the
+  /// current viewer selection. Selection is kept on cancel/failure so the
+  /// user can copy or mark it up instead.
+  Future<void> _editTextSelection() async {
+    final editing = widget.editing;
+    final range = _selRange;
+    final selected = _controller.selectedText;
+    if (editing == null || range == null || selected.isEmpty) return;
+    if (range.$1.$1 != range.$2.$1) {
+      _textSelectionToast('Editing requires a selection on one page.');
+      return;
+    }
+    final page = range.$1.$1;
+    final rects = _selectionRectsOn(page);
+    final element = editing.textElementForSelection(page, rects, selected);
+    if (element == null) {
+      _textSelectionToast(
+          'This selection is not one editable page-content text run.');
+      return;
+    }
+    final result =
+        await (widget.editingStyledTextPrompt ?? showPdfStyledTextPrompt)(
+      context,
+      initial: selected,
+      palette: widget.editingPalette,
+      pickFont: (context) => _pickSelectionFont(context, editing),
+    );
+    if (result == null || !mounted) return;
+    if (result.text.isEmpty ||
+        (result.text == selected && result.style.isEmpty)) {
+      return;
+    }
+    if (!result.style.isEmpty && !editing.canStyleContentText(page, element)) {
+      _textSelectionToast(
+          'This PDF font can be re-typed, but its style cannot be changed.');
+      return;
+    }
+    final fallbacks = await loadFallbackFonts();
+    if (!mounted ||
+        _selRange != range ||
+        _controller.selectedText != selected) {
+      return;
+    }
+    final count = editing.replaceTextInElement(
+      page,
+      element,
+      selected,
+      result.text,
+      result.style,
+      fallbackFonts: fallbacks,
+    );
+    if (count == 0) {
+      _textSelectionToast('This PDF font or encoding cannot be edited safely.');
+      return;
+    }
+    _clearSelection();
+  }
+
+  Future<PdfTextFont?> _pickSelectionFont(
+      BuildContext context, PdfEditingController editing) async {
+    PdfTextFont? chosen;
+    await showPdfFontMenu(
+      context: context,
+      controller: editing,
+      fontPicker: widget.fontPicker,
+      onSelected: (font) => chosen = font,
+    );
+    return chosen;
+  }
+
+  void _markupTextSelection(PdfMarkupKind kind) {
+    final editing = widget.editing;
+    if (editing == null || _selRange == null) return;
+    final quadsByPage = {
+      for (final page in _controller.selectionPages)
+        page: _selectionRectsOn(page),
+    };
+    editing.useMarkupStyleScope();
+    editing.addMarkup(kind, quadsByPage);
+    _clearSelection();
+  }
+
+  void _textSelectionToast(String message) {
+    ScaffoldMessenger.maybeOf(context)
+      ?..clearSnackBars()
+      ..showSnackBar(SnackBar(
+        content: Text(message),
+        behavior: SnackBarBehavior.floating,
+        margin: pdfFloatingToastMargin(context),
+      ));
   }
 
   Widget _textMenuRow(IconData icon, String label, bool enabled) => Row(
@@ -3461,6 +3619,12 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
       onDragEnd: _onHandleDragEnd,
       onCopy: _copyAndDismiss,
       onSelectAll: () => _selectAllTextOn(index),
+      onEdit: widget.editing != null && widget.textSelectionEditing
+          ? _editTextSelection
+          : null,
+      onMarkup: widget.editing != null && widget.textSelectionMarkup
+          ? _markupTextSelection
+          : null,
     );
   }
 
@@ -5343,7 +5507,15 @@ class _FlingClock extends Simulation {
 enum _TrackpadIntent { undecided, scroll, zoom }
 
 /// The mouse right-click text menu's actions.
-enum _TextMenuAction { copy, selectAll }
+enum _TextMenuAction {
+  edit,
+  highlight,
+  underline,
+  strikeOut,
+  squiggly,
+  copy,
+  selectAll,
+}
 
 /// Claims every trackpad pan-zoom gesture, eagerly. The viewer drives
 /// scrolling, zoom-window panning, and pinch zoom itself: leaving these
@@ -5515,6 +5687,8 @@ class _PageTextSelection {
     required this.onDragEnd,
     required this.onCopy,
     required this.onSelectAll,
+    required this.onEdit,
+    required this.onMarkup,
   });
 
   /// The selection's first rect on this page (PDF coordinates) when the
@@ -5540,6 +5714,8 @@ class _PageTextSelection {
   final VoidCallback onDragEnd;
   final VoidCallback onCopy;
   final VoidCallback onSelectAll;
+  final Future<void> Function()? onEdit;
+  final void Function(PdfMarkupKind kind)? onMarkup;
 }
 
 /// The touch selection chrome on one page: iOS-style lollipop handles
@@ -5596,19 +5772,14 @@ class _TextSelectionChrome extends StatelessWidget {
     // clear of the end handle's ball below and the start handle's above
     final clearance = 28 * s;
     final above = anchor.top - clearance - 44 * s >= 0;
-    final width = geometry.viewSize.width;
-    final halfChip = 90.0 * s;
-    final position = Offset(
-      width <= 2 * halfChip
-          ? width / 2
-          : anchor.center.dx.clamp(halfChip, width - halfChip),
-      above ? anchor.top - clearance : anchor.bottom + clearance,
-    );
-    return Positioned(
-      left: position.dx,
-      top: position.dy,
-      child: FractionalTranslation(
-        translation: Offset(-0.5, above ? -1 : 0),
+    return Positioned.fill(
+      child: CustomSingleChildLayout(
+        delegate: _SelectionChipLayoutDelegate(
+          anchor: anchor,
+          clearance: clearance,
+          scale: s,
+          above: above,
+        ),
         child: Transform.scale(
           scale: s,
           alignment: above ? Alignment.bottomCenter : Alignment.topCenter,
@@ -5618,11 +5789,67 @@ class _TextSelectionChrome extends StatelessWidget {
             borderRadius: BorderRadius.circular(22),
             clipBehavior: Clip.antiAlias,
             child: Row(mainAxisSize: MainAxisSize.min, children: [
+              if (selection.onEdit != null) ...[
+                IconButton(
+                  key: const ValueKey('pdf-text-selection-chip-edit'),
+                  tooltip: 'Edit text & style',
+                  icon: const Icon(Icons.edit, size: 20),
+                  onPressed: selection.onEdit,
+                ),
+                const SizedBox(height: 24, child: VerticalDivider(width: 1)),
+              ],
               TextButton(
                 key: const ValueKey('pdf-text-selection-chip-copy'),
                 onPressed: selection.onCopy,
                 child: const Text('Copy'),
               ),
+              if (selection.onMarkup != null) ...[
+                const SizedBox(height: 24, child: VerticalDivider(width: 1)),
+                PopupMenuButton<PdfMarkupKind>(
+                  key: const ValueKey('pdf-text-selection-chip-markup'),
+                  tooltip: 'Markup',
+                  icon: const Icon(Icons.edit_note, size: 20),
+                  onSelected: selection.onMarkup,
+                  itemBuilder: (context) => const [
+                    PopupMenuItem(
+                      key: ValueKey('pdf-text-selection-highlight'),
+                      value: PdfMarkupKind.highlight,
+                      child: ListTile(
+                        dense: true,
+                        leading: Icon(Icons.border_color),
+                        title: Text('Highlight'),
+                      ),
+                    ),
+                    PopupMenuItem(
+                      key: ValueKey('pdf-text-selection-underline'),
+                      value: PdfMarkupKind.underline,
+                      child: ListTile(
+                        dense: true,
+                        leading: Icon(Icons.format_underlined),
+                        title: Text('Underline'),
+                      ),
+                    ),
+                    PopupMenuItem(
+                      key: ValueKey('pdf-text-selection-strikeout'),
+                      value: PdfMarkupKind.strikeOut,
+                      child: ListTile(
+                        dense: true,
+                        leading: Icon(Icons.format_strikethrough),
+                        title: Text('Strike out'),
+                      ),
+                    ),
+                    PopupMenuItem(
+                      key: ValueKey('pdf-text-selection-squiggly'),
+                      value: PdfMarkupKind.squiggly,
+                      child: ListTile(
+                        dense: true,
+                        leading: Icon(Icons.gesture),
+                        title: Text('Squiggly'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
               const SizedBox(height: 24, child: VerticalDivider(width: 1)),
               TextButton(
                 key: const ValueKey('pdf-text-selection-chip-select-all'),
@@ -5635,6 +5862,47 @@ class _TextSelectionChrome extends StatelessWidget {
       ),
     );
   }
+}
+
+class _SelectionChipLayoutDelegate extends SingleChildLayoutDelegate {
+  const _SelectionChipLayoutDelegate({
+    required this.anchor,
+    required this.clearance,
+    required this.scale,
+    required this.above,
+  });
+
+  final Rect anchor;
+  final double clearance;
+  final double scale;
+  final bool above;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) =>
+      constraints.loosen();
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final visualHalfWidth = childSize.width * scale / 2;
+    final centerX = size.width <= 2 * visualHalfWidth
+        ? size.width / 2
+        : anchor.center.dx
+            .clamp(visualHalfWidth, size.width - visualHalfWidth)
+            .toDouble();
+    return Offset(
+      centerX - childSize.width / 2,
+      above
+          ? anchor.top - clearance - childSize.height
+          : anchor.bottom + clearance,
+    );
+  }
+
+  @override
+  bool shouldRelayout(_SelectionChipLayoutDelegate oldDelegate) =>
+      anchor != oldDelegate.anchor ||
+      clearance != oldDelegate.clearance ||
+      scale != oldDelegate.scale ||
+      above != oldDelegate.above;
 }
 
 /// One lollipop: a ball above the selection start (or below the end)

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -240,6 +240,33 @@ void main() {
       return controller;
     }
 
+    Future<({PdfViewerController viewer, PdfEditingController editing})>
+        pumpEditor(
+      WidgetTester tester, {
+      PdfStyledTextPrompt? styledTextPrompt,
+    }) async {
+      final viewer = PdfViewerController();
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(viewer.dispose);
+      addTearDown(editing.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+              editingStyledTextPrompt: styledTextPrompt,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return (viewer: viewer, editing: editing);
+    }
+
     Future<void> rightClick(WidgetTester tester, Offset at) async {
       await tester.tapAt(at,
           kind: PointerDeviceKind.mouse, buttons: kSecondaryMouseButton);
@@ -255,6 +282,9 @@ void main() {
       expect(find.byKey(const ValueKey('pdf-text-menu-copy')), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-text-menu-select-all')),
           findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-text-menu-edit')), findsNothing);
+      expect(
+          find.byKey(const ValueKey('pdf-text-menu-highlight')), findsNothing);
       final copy = tester.widget<PopupMenuItem>(
           find.byKey(const ValueKey('pdf-text-menu-copy')));
       expect(copy.enabled, isTrue);
@@ -282,8 +312,7 @@ void main() {
       final controller = await pumpReader(tester);
 
       await rightClick(tester, viewPoint(100, 720));
-      await tester
-          .tap(find.byKey(const ValueKey('pdf-text-menu-select-all')));
+      await tester.tap(find.byKey(const ValueKey('pdf-text-menu-select-all')));
       await tester.pumpAndSettle();
       expect(controller.selectedText, 'Page 1');
     });
@@ -319,6 +348,35 @@ void main() {
       // back to a single word
       await rightClick(tester, viewPoint(110, 720));
       expect(controller.selectedText, 'Page');
+    });
+
+    testWidgets('the editor text menu exposes and applies Edit text & style',
+        (tester) async {
+      String? promptedWith;
+      final state = await pumpEditor(
+        tester,
+        styledTextPrompt: (context,
+            {required initial, palette = const <Color>[], pickFont}) async {
+          promptedWith = initial;
+          return const PdfStyledTextEdit('Document', PdfTextStyle());
+        },
+      );
+
+      await rightClick(tester, viewPoint(100, 720));
+      expect(find.byKey(const ValueKey('pdf-text-menu-edit')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-text-menu-highlight')),
+          findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('pdf-text-menu-edit')));
+      await tester.pumpAndSettle();
+
+      expect(promptedWith, 'Page');
+      final text = PdfPageElements.of(state.editing.document, 0)
+          .elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .map((element) => element.text)
+          .join();
+      expect(text, 'Document 1');
+      expect(state.viewer.hasSelection, isFalse);
     });
   });
 }

--- a/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_touch_selection_test.dart
@@ -39,6 +39,33 @@ void main() {
     return controller;
   }
 
+  Future<({PdfViewerController viewer, PdfEditingController editing})>
+      pumpEditor(
+    WidgetTester tester, {
+    PdfStyledTextPrompt? styledTextPrompt,
+  }) async {
+    final viewer = PdfViewerController();
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    addTearDown(viewer.dispose);
+    addTearDown(editing.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: editing.document,
+            controller: viewer,
+            editing: editing,
+            editingStyledTextPrompt: styledTextPrompt,
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return (viewer: viewer, editing: editing);
+  }
+
   /// Long-presses the word at [at] and lifts, leaving handles + chip.
   Future<void> longPressSelect(WidgetTester tester, Offset at) async {
     final gesture = await tester.startGesture(at);
@@ -151,6 +178,10 @@ void main() {
       expect(find.byKey(const ValueKey('pdf-text-handle-end')), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-text-selection-chip')),
           findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-text-selection-chip-edit')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('pdf-text-selection-chip-markup')),
+          findsNothing);
       await tester.pump(const Duration(milliseconds: 400));
     });
 
@@ -346,6 +377,66 @@ void main() {
       expect(controller.selectedText, 'Page 1');
       expect(find.byKey(const ValueKey('pdf-text-selection-chip')),
           findsOneWidget);
+    });
+  });
+
+  group('editor selection actions', () {
+    testWidgets('the editor chip exposes pencil and markup actions',
+        (tester) async {
+      await pumpEditor(tester);
+      await longPressSelect(tester, view(100, 720));
+
+      expect(find.byKey(const ValueKey('pdf-text-selection-chip-edit')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-text-selection-chip-markup')),
+          findsOneWidget);
+    });
+
+    testWidgets('the pencil edits only the selected text occurrence',
+        (tester) async {
+      String? promptedWith;
+      final state = await pumpEditor(
+        tester,
+        styledTextPrompt: (context,
+            {required initial, palette = const <Color>[], pickFont}) async {
+          promptedWith = initial;
+          return const PdfStyledTextEdit('Document', PdfTextStyle());
+        },
+      );
+      await longPressSelect(tester, view(100, 720));
+      expect(state.viewer.selectedText, 'Page');
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-text-selection-chip-edit')));
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      expect(promptedWith, 'Page');
+      final text = PdfPageElements.of(state.editing.document, 0)
+          .elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .map((element) => element.text)
+          .join();
+      expect(text, 'Document 1');
+      expect(state.viewer.hasSelection, isFalse);
+    });
+
+    testWidgets('the markup menu applies a highlight to the selection',
+        (tester) async {
+      final state = await pumpEditor(tester);
+      await longPressSelect(tester, view(100, 720));
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-text-selection-chip-markup')));
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-text-selection-highlight')));
+      await tester.pumpAndSettle();
+
+      expect(state.editing.document.page(0).annotations.single.subtype,
+          'Highlight');
+      expect(state.viewer.hasSelection, isFalse);
     });
   });
 }

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add operation-scoped page-content text replacement and expose the active
+  font resource on text element snapshots for selection-driven editing.
+
 ## 1.4.5
 
 - Version bump to keep the dart-pdf package suite aligned at 1.4.5. No

--- a/packages/pdf_document/lib/src/content_editor.dart
+++ b/packages/pdf_document/lib/src/content_editor.dart
@@ -182,6 +182,54 @@ extension PdfContentEditing on PdfEditor {
     String replace, {
     List<PdfEmbeddedFont> fallbackFonts = const [],
     PdfTextStyle? style,
+  }) =>
+      _replaceText(
+        index,
+        find,
+        replace,
+        fallbackFonts: fallbackFonts,
+        style: style,
+      );
+
+  /// Replaces [find] only inside one text [element], leaving identical text
+  /// in every other page-content operation untouched.
+  ///
+  /// [elements] and [element] must come from the same [PdfPageElements]
+  /// snapshot. Element handles die with every edit revision. This targeted
+  /// form backs selection-driven editing, where changing the occurrence the
+  /// user selected must not rewrite the same word elsewhere on the page.
+  int replaceElementText(
+    PdfPageElements elements,
+    PdfContentElement element,
+    String find,
+    String replace, {
+    List<PdfEmbeddedFont> fallbackFonts = const [],
+    PdfTextStyle? style,
+  }) {
+    if (element.kind != PdfElementKind.text ||
+        element.id < 0 ||
+        element.id >= elements.elements.length ||
+        !identical(elements.elements[element.id], element)) {
+      throw ArgumentError.value(
+          element, 'element', 'is not a text element in this snapshot');
+    }
+    return _replaceText(
+      elements.pageIndex,
+      find,
+      replace,
+      fallbackFonts: fallbackFonts,
+      style: style,
+      operationRange: (element.start, element.end),
+    );
+  }
+
+  int _replaceText(
+    int index,
+    String find,
+    String replace, {
+    required List<PdfEmbeddedFont> fallbackFonts,
+    required PdfTextStyle? style,
+    (int start, int end)? operationRange,
   }) {
     if (find.isEmpty) throw ArgumentError.value(find, 'find', 'is empty');
     // the simple-font path is byte-encoded; non-Latin-1 strings can only be
@@ -249,12 +297,22 @@ extension PdfContentEditing on PdfEditor {
         }
       }
       if (op.operator == 'Tj' || op.operator == 'TJ') {
+        // Targeted selection edits leave every show operation outside the
+        // selected element byte-for-byte alone. In particular, do not merge
+        // an adjacent unselected Tj/TJ into the selected run.
+        if (operationRange != null &&
+            (i < operationRange.$1 || i >= operationRange.$2)) {
+          rewritten.add(op);
+          i++;
+          continue;
+        }
         // a run is a maximal stretch of adjacent show operators: text
         // state (font, position) is constant across it, so the strings
         // read as one line and may be merged into a single TJ.
         final run = <ContentOperation>[];
         while (i < ops.length &&
-            (ops[i].operator == 'Tj' || ops[i].operator == 'TJ')) {
+            (ops[i].operator == 'Tj' || ops[i].operator == 'TJ') &&
+            (operationRange == null || i < operationRange.$2)) {
           run.add(ops[i]);
           i++;
         }
@@ -293,6 +351,8 @@ extension PdfContentEditing on PdfEditor {
       // ' and " carry a line break, so they stand alone; a single string
       // with nothing after it on its line needs no width compensation.
       if ((op.operator == "'" || op.operator == '"') &&
+          (operationRange == null ||
+              (i >= operationRange.$1 && i < operationRange.$2)) &&
           !_isType0(cos, font) &&
           findBytes != null &&
           replaceBytes != null) {

--- a/packages/pdf_document/lib/src/content_elements.dart
+++ b/packages/pdf_document/lib/src/content_elements.dart
@@ -57,7 +57,8 @@ class PdfContentElement {
   /// Multi-byte and symbolic encodings come out garbled but unique.
   final String? text;
 
-  /// The /XObject resource name for [PdfElementKind.image] and
+  /// The active /Font resource name for [PdfElementKind.text], or the
+  /// /XObject resource name for [PdfElementKind.image] and
   /// [PdfElementKind.form].
   final String? resourceName;
 
@@ -321,6 +322,7 @@ class PdfPageElements {
           final m = _multiply(text.matrix, ctm);
           addElement(PdfElementKind.text, i, i + 1,
               shown: string,
+              resource: text.fontName,
               bounds: _hull([
                 _apply(m, 0, -0.2 * text.size),
                 _apply(m, width, -0.2 * text.size),

--- a/packages/pdf_document/test/content_edit_test.dart
+++ b/packages/pdf_document/test/content_edit_test.dart
@@ -99,8 +99,8 @@ void main() {
     test('deleting one text run leaves its sibling in place', () {
       final doc = PdfDocument.open(buildContentPdf(richContent));
       final elements = PdfPageElements.of(doc, 0);
-      final second = elements.elements
-          .firstWhere((e) => e.text == 'second line');
+      final second =
+          elements.elements.firstWhere((e) => e.text == 'second line');
       final editor = PdfEditor(doc)..deleteElements(elements, [second.id]);
       final out = PdfDocument.open(editor.save());
       expect(pageText(out), contains('(first line) Tj'));
@@ -113,8 +113,7 @@ void main() {
       final doc = PdfDocument.open(buildContentPdf(
           "BT /F1 12 Tf 14 TL 72 700 Td (one) Tj (two) ' (three) ' ET"));
       final elements = PdfPageElements.of(doc, 0);
-      final two =
-          elements.elements.firstWhere((e) => e.text == 'two');
+      final two = elements.elements.firstWhere((e) => e.text == 'two');
       final editor = PdfEditor(doc)..deleteElements(elements, [two.id]);
       final out = PdfDocument.open(editor.save());
       final text = pageText(out);
@@ -122,14 +121,12 @@ void main() {
       expect(text, contains('T*'));
       // 'three' still lands two leadings below 700
       final reparsed = PdfPageElements.of(out, 0);
-      final three =
-          reparsed.elements.firstWhere((e) => e.text == 'three');
+      final three = reparsed.elements.firstWhere((e) => e.text == 'three');
       expect(three.bounds!.bottom, closeTo(700 - 28 - 2.4, 0.01));
     });
 
     test('inline images round-trip through a rewrite', () {
-      final doc = PdfDocument.open(buildContentPdf(
-          '100 100 10 10 re f\n'
+      final doc = PdfDocument.open(buildContentPdf('100 100 10 10 re f\n'
           'q 5 0 0 5 10 10 cm BI /W 2 /H 1 /CS /G /BPC 8 ID \xa0\xa1 EI Q\n'));
       final elements = PdfPageElements.of(doc, 0);
       expect(elements.elements[1].kind, PdfElementKind.inlineImage);
@@ -138,8 +135,7 @@ void main() {
       final out = PdfDocument.open(editor.save());
       final reparsed = PdfPageElements.of(out, 0);
       expect(reparsed.elements.single.kind, PdfElementKind.inlineImage);
-      final bi = reparsed.operations[
-          reparsed.elements.single.start];
+      final bi = reparsed.operations[reparsed.elements.single.start];
       expect((bi.operands[1] as CosString).bytes, [0xa0, 0xa1]);
     });
   });
@@ -155,6 +151,27 @@ void main() {
       expect(pageText(out, 1), contains('(Page 2) Tj'));
     });
 
+    test('replaceElementText changes only the selected operation', () {
+      final doc = PdfDocument.open(buildContentPdf(
+          'BT /F1 12 Tf 72 700 Td (Page 1) Tj 0 -20 Td (Page 2) Tj ET'));
+      final elements = PdfPageElements.of(doc, 0);
+      final texts = elements.elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .toList();
+      final editor = PdfEditor(doc);
+
+      expect(
+          editor.replaceElementText(elements, texts.first, 'Page', 'Sheet'), 1);
+
+      final reopened = PdfDocument.open(editor.save());
+      final text = PdfPageElements.of(reopened, 0)
+          .elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .map((element) => element.text)
+          .toList();
+      expect(text, ['Sheet 1', 'Page 2']);
+    });
+
     test('a miss returns zero and queues nothing', () {
       final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
       expect(editor.replaceText(0, 'absent text', 'x'), 0);
@@ -162,16 +179,16 @@ void main() {
     });
 
     test('replaces within a single TJ element', () {
-      final doc = PdfDocument.open(buildContentPdf(
-          'BT /F1 12 Tf 72 700 Td [(spli) -20 (t run)] TJ ET'));
+      final doc = PdfDocument.open(
+          buildContentPdf('BT /F1 12 Tf 72 700 Td [(spli) -20 (t run)] TJ ET'));
       final editor = PdfEditor(doc);
       expect(editor.replaceText(0, 't run', 't sprint'), 1);
       expect(pageText(PdfDocument.open(editor.save())), contains('(t sprint)'));
     });
 
     test('matches across TJ array elements and their kern', () {
-      final doc = PdfDocument.open(buildContentPdf(
-          'BT /F1 12 Tf 72 700 Td [(spli) -20 (t run)] TJ ET'));
+      final doc = PdfDocument.open(
+          buildContentPdf('BT /F1 12 Tf 72 700 Td [(spli) -20 (t run)] TJ ET'));
       final editor = PdfEditor(doc);
       // 'split' spans both strings and the -20 kern between them
       expect(editor.replaceText(0, 'split', 'joined'), 1);
@@ -182,8 +199,8 @@ void main() {
     });
 
     test('a width change inserts a compensating adjustment', () {
-      final doc = PdfDocument.open(buildContentPdf(
-          'BT /F1 12 Tf 72 700 Td [(AAA) (BBB)] TJ ET'));
+      final doc = PdfDocument.open(
+          buildContentPdf('BT /F1 12 Tf 72 700 Td [(AAA) (BBB)] TJ ET'));
       final editor = PdfEditor(doc);
       expect(editor.replaceText(0, 'AAA', 'AA'), 1);
       // Helvetica 'A' is 667/1000 em; dropping one shifts 'BBB' back by 667,
@@ -193,8 +210,8 @@ void main() {
     });
 
     test('a match can span consecutive show operators', () {
-      final doc = PdfDocument.open(buildContentPdf(
-          'BT /F1 12 Tf 72 700 Td (foo) Tj (bar) Tj ET'));
+      final doc = PdfDocument.open(
+          buildContentPdf('BT /F1 12 Tf 72 700 Td (foo) Tj (bar) Tj ET'));
       final editor = PdfEditor(doc);
       expect(editor.replaceText(0, 'ooba', 'X'), 1);
       final text = pageText(PdfDocument.open(editor.save()));
@@ -204,8 +221,7 @@ void main() {
     });
 
     test('composite Type0 runs are skipped', () {
-      final bytes = buildContentPdf(
-          'BT /F1 12 Tf 72 700 Td (find me) Tj ET');
+      final bytes = buildContentPdf('BT /F1 12 Tf 72 700 Td (find me) Tj ET');
       // rewrite the font to claim /Subtype /Type0
       final doc = PdfDocument.open(ascii(latin1
           .decode(bytes)
@@ -230,8 +246,8 @@ void main() {
       expect(text, contains('(APPROVED) Tj'));
       expect(text.indexOf('APPROVED'), greaterThan(text.indexOf('Hello')));
 
-      final fonts = out.cos.resolve(out.page(0).resources['Font'])
-          as CosDictionary;
+      final fonts =
+          out.cos.resolve(out.page(0).resources['Font']) as CosDictionary;
       final stampFont = out.cos.resolve(fonts['StF1']) as CosDictionary;
       expect(stampFont['BaseFont'], const CosName('Helvetica-Bold'));
       // the original font reference is untouched
@@ -254,14 +270,13 @@ void main() {
     test('rotated text writes a rotation matrix', () {
       final doc = PdfDocument.open(buildClassicPdf());
       final editor = PdfEditor(doc)
-        ..stampPage(0,
-            (s) => s.text('DRAFT', x: 100, y: 100, angleDegrees: 45));
+        ..stampPage(
+            0, (s) => s.text('DRAFT', x: 100, y: 100, angleDegrees: 45));
       final out = PdfDocument.open(editor.save());
       expect(pageText(out), contains('0.707'));
     });
 
-    test('stamping a page with inherited resources copies them privately',
-        () {
+    test('stamping a page with inherited resources copies them privately', () {
       final doc = PdfDocument.open(buildNestedPageTreePdf());
       final editor = PdfEditor(doc)
         ..stampPage(0, (s) => s.text('stamp', x: 5, y: 5));
@@ -289,11 +304,10 @@ void main() {
       ]);
       final doc = PdfDocument.open(buildClassicPdf());
       final editor = PdfEditor(doc)
-        ..stampPage(0,
-            (s) => s.jpegImage(jpeg, x: 100, y: 500, width: 200));
+        ..stampPage(0, (s) => s.jpegImage(jpeg, x: 100, y: 500, width: 200));
       final out = PdfDocument.open(editor.save());
-      final xobjects = out.cos.resolve(out.page(0).resources['XObject'])
-          as CosDictionary;
+      final xobjects =
+          out.cos.resolve(out.page(0).resources['XObject']) as CosDictionary;
       final image = out.cos.resolve(xobjects['Im1']) as CosStream;
       expect(image.dictionary['Width'], const CosInteger(4));
       expect(image.dictionary['Height'], const CosInteger(3));
@@ -316,8 +330,8 @@ void main() {
             (s) => s.image(PdfEmbeddableImage.decode(png),
                 x: 50, y: 60, height: 100));
       final out = PdfDocument.open(editor.save());
-      final xobjects = out.cos.resolve(out.page(0).resources['XObject'])
-          as CosDictionary;
+      final xobjects =
+          out.cos.resolve(out.page(0).resources['XObject']) as CosDictionary;
       final image = out.cos.resolve(xobjects['Im1']) as CosStream;
       expect(image.dictionary['Width'], const CosInteger(2));
       expect(image.dictionary['Height'], const CosInteger(2));
@@ -325,8 +339,7 @@ void main() {
       expect(image.dictionary['ColorSpace'], const CosName('DeviceRGB'));
       expect(out.cos.decodeStreamData(image),
           [255, 0, 0, 0, 255, 0, 0, 0, 255, 10, 20, 30]);
-      final smask =
-          out.cos.resolve(image.dictionary['SMask']) as CosStream;
+      final smask = out.cos.resolve(image.dictionary['SMask']) as CosStream;
       expect(smask.dictionary['ColorSpace'], const CosName('DeviceGray'));
       expect(out.cos.decodeStreamData(smask), [255, 128, 0, 77]);
       // square pixels, height 100 → width 100
@@ -348,20 +361,16 @@ void main() {
   });
 
   group('styled replacement', () {
-    PdfDocument styledEdit(String content, String find, String replace,
-        PdfTextStyle style) {
+    PdfDocument styledEdit(
+        String content, String find, String replace, PdfTextStyle style) {
       final doc = PdfDocument.open(buildContentPdf(content));
-      final editor = PdfEditor(doc)
-        ..replaceStyledText(0, find, replace, style);
+      final editor = PdfEditor(doc)..replaceStyledText(0, find, replace, style);
       return PdfDocument.open(editor.save());
     }
 
     test('recolours the replacement and restores the prior colour', () {
-      final out = styledEdit(
-          'BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
-          'Hello',
-          'Hi',
-          const PdfTextStyle(color: 0xFF0000));
+      final out = styledEdit('BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
+          'Hello', 'Hi', const PdfTextStyle(color: 0xFF0000));
       final text = pageText(out);
       // the replacement is drawn red, then black is restored for " World"
       expect(text, contains('1 0 0 rg'));
@@ -390,11 +399,8 @@ void main() {
     });
 
     test('changes font size with a Tf switch and restores it', () {
-      final out = styledEdit(
-          'BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
-          'Hello',
-          'Hi',
-          const PdfTextStyle(fontSize: 24));
+      final out = styledEdit('BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
+          'Hello', 'Hi', const PdfTextStyle(fontSize: 24));
       final text = pageText(out);
       expect(text, contains('/F1 24 Tf'));
       expect(text, contains('(Hi) Tj'));
@@ -404,11 +410,8 @@ void main() {
     });
 
     test('bold substitutes a base-14 variant font resource', () {
-      final out = styledEdit(
-          'BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
-          'Hello',
-          'Hi',
-          const PdfTextStyle(bold: true));
+      final out = styledEdit('BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
+          'Hello', 'Hi', const PdfTextStyle(bold: true));
       final fonts =
           out.cos.resolve(out.page(0).resources['Font']) as CosDictionary;
       final bold = fonts.entries.values
@@ -423,21 +426,15 @@ void main() {
     });
 
     test('keeps following text in place when the width changes', () {
-      final out = styledEdit(
-          'BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
-          'Hello',
-          'Hi',
-          const PdfTextStyle(fontSize: 24));
+      final out = styledEdit('BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
+          'Hello', 'Hi', const PdfTextStyle(fontSize: 24));
       // a compensating TJ adjustment follows the restored-size replacement
       expect(pageText(out), contains('] TJ'));
     });
 
     test('italic substitutes the oblique base-14 variant', () {
-      final out = styledEdit(
-          'BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
-          'Hello',
-          'Hi',
-          const PdfTextStyle(italic: true));
+      final out = styledEdit('BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
+          'Hello', 'Hi', const PdfTextStyle(italic: true));
       final fonts =
           out.cos.resolve(out.page(0).resources['Font']) as CosDictionary;
       final oblique = fonts.entries.values
@@ -544,11 +541,8 @@ void main() {
     });
 
     test('an empty style behaves like a plain replaceText', () {
-      final out = styledEdit(
-          'BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
-          'Hello',
-          'Hi',
-          const PdfTextStyle());
+      final out = styledEdit('BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
+          'Hello', 'Hi', const PdfTextStyle());
       final text = pageText(out);
       expect(text, contains('(Hi)'));
       expect(text, isNot(contains(' rg')));
@@ -560,15 +554,11 @@ void main() {
       expect(reader, contains('Hi World'));
     });
 
-    test('leaves composite runs unstyled but still replaced is skipped',
-        () {
+    test('leaves composite runs unstyled but still replaced is skipped', () {
       // simple-font restyle applies; nothing here to assert about Type0,
       // but a plain simple replacement must not emit stray style ops.
-      final out = styledEdit(
-          'BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
-          'World',
-          'Earth',
-          const PdfTextStyle(color: 0x00FF00));
+      final out = styledEdit('BT /F1 12 Tf 72 700 Td (Hello World) Tj ET',
+          'World', 'Earth', const PdfTextStyle(color: 0x00FF00));
       final text = pageText(out);
       expect(text, contains('0 1 0 rg'));
       expect(text, contains('(Earth) Tj'));


### PR DESCRIPTION
## Summary

- expose **Edit text & style** plus highlight, underline, strikeout, and squiggly actions from the touch selection chip and desktop text context menu whenever a `PdfEditingController` is attached
- target content edits at the selected PDF text-show operation so an identical word elsewhere on the page is left alone; ambiguous or unsupported selections stay selected and show useful feedback
- thread the styled-text prompt, palette, and editor feature gates through `PdfEditorView`, while leaving reader-only selection at Copy / Select all
- keep the wider touch action chip inside the visible page near either margin

## What was happening

The viewer's text-selection UI was still hard-coded as reader chrome. Even in an editor-backed viewer it only exposed Copy and Select all, so the existing content-editing and markup capabilities were effectively hidden after selecting text.

## Testing

- `fvm dart analyze`
- `cd packages/pdf_document && fvm dart test` (634 tests passed)
- `cd packages/dart_pdf_editor && fvm flutter test` (1,420 tests passed)
- focused touch, desktop-menu, exact replacement, and worker-cancellation regression tests

Closes #272