### PR TITLE
Add desktop tab grid dialog

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -1594,88 +1594,128 @@ class _EditorScreenState extends State<EditorScreen>
       showDragHandle: true,
       builder: (sheetContext) => StatefulBuilder(
         builder: (sheetContext, setSheetState) {
-          final scheme = Theme.of(sheetContext).colorScheme;
           return SafeArea(
             top: false,
             child: SizedBox(
               height: MediaQuery.sizeOf(sheetContext).height * 0.72,
-              child: Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 0, 12, 8),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            'Tabs',
-                            style: Theme.of(sheetContext).textTheme.titleMedium,
-                          ),
-                        ),
-                        IconButton(
-                          key: const ValueKey('mobile-tabs-open'),
-                          icon: const Icon(Icons.add),
-                          tooltip: 'Open PDF in a new tab',
-                          onPressed: () {
-                            Navigator.of(sheetContext).pop();
-                            unawaited(_pickAndOpen());
-                          },
-                        ),
-                      ],
-                    ),
-                  ),
-                  const Divider(height: 1),
-                  Expanded(
-                    child: GridView.builder(
-                      key: const ValueKey('mobile-tabs-grid'),
-                      padding: const EdgeInsets.all(12),
-                      gridDelegate:
-                          const SliverGridDelegateWithMaxCrossAxisExtent(
-                        maxCrossAxisExtent: 220,
-                        mainAxisSpacing: 12,
-                        crossAxisSpacing: 12,
-                        childAspectRatio: 0.78,
-                      ),
-                      itemCount: _tabs.length,
-                      itemBuilder: (context, index) {
-                        final tab = _tabs[index];
-                        final selected = index == _activeIndex;
-                        return _MobileTabTile(
-                          key: ValueKey('mobile-tab-${tab.hashCode}'),
-                          tab: tab,
-                          selected: selected,
-                          onTap: () {
-                            setState(() => _activeIndex = index);
-                            Navigator.of(sheetContext).pop();
-                          },
-                          onClose: () async {
-                            await _closeTabs([tab]);
-                            if (!mounted || !sheetContext.mounted) return;
-                            if (_tabs.isEmpty) {
-                              Navigator.of(sheetContext).pop();
-                            } else {
-                              setSheetState(() {});
-                            }
-                          },
-                        );
-                      },
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-                    child: Text(
-                      '${_tabs.length} open',
-                      style: Theme.of(sheetContext)
-                          .textTheme
-                          .labelMedium
-                          ?.copyWith(color: scheme.onSurfaceVariant),
-                    ),
-                  ),
-                ],
+              child: _buildTabsGrid(
+                sheetContext,
+                setOverlayState: setSheetState,
+                keyPrefix: 'mobile',
+                headerTopPadding: 0,
               ),
             ),
           );
         },
       ),
+    );
+  }
+
+  Future<void> _showTabsDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (dialogContext, setDialogState) {
+          final viewport = MediaQuery.sizeOf(dialogContext);
+          final width = viewport.width > 888 ? 840.0 : viewport.width - 48;
+          final height = viewport.height > 688 ? 640.0 : viewport.height - 48;
+          return Dialog(
+            key: const ValueKey('desktop-tabs-dialog'),
+            clipBehavior: Clip.antiAlias,
+            child: SizedBox(
+              width: width,
+              height: height,
+              child: _buildTabsGrid(
+                dialogContext,
+                setOverlayState: setDialogState,
+                keyPrefix: 'desktop',
+                headerTopPadding: 12,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildTabsGrid(
+    BuildContext overlayContext, {
+    required StateSetter setOverlayState,
+    required String keyPrefix,
+    required double headerTopPadding,
+  }) {
+    final scheme = Theme.of(overlayContext).colorScheme;
+    return Column(
+      children: [
+        Padding(
+          padding: EdgeInsets.fromLTRB(20, headerTopPadding, 12, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Tabs',
+                  style: Theme.of(overlayContext).textTheme.titleMedium,
+                ),
+              ),
+              IconButton(
+                key: ValueKey('$keyPrefix-tabs-open'),
+                icon: const Icon(Icons.add),
+                tooltip: 'Open PDF in a new tab',
+                onPressed: () {
+                  Navigator.of(overlayContext).pop();
+                  unawaited(_pickAndOpen());
+                },
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: GridView.builder(
+            key: ValueKey('$keyPrefix-tabs-grid'),
+            padding: const EdgeInsets.all(12),
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 220,
+              mainAxisSpacing: 12,
+              crossAxisSpacing: 12,
+              childAspectRatio: 0.78,
+            ),
+            itemCount: _tabs.length,
+            itemBuilder: (context, index) {
+              final tab = _tabs[index];
+              final selected = index == _activeIndex;
+              return _MobileTabTile(
+                key: ValueKey('$keyPrefix-tab-${tab.hashCode}'),
+                tab: tab,
+                selected: selected,
+                onTap: () {
+                  setState(() => _activeIndex = index);
+                  Navigator.of(overlayContext).pop();
+                },
+                onClose: () async {
+                  await _closeTabs([tab]);
+                  if (!mounted || !overlayContext.mounted) return;
+                  if (_tabs.isEmpty) {
+                    Navigator.of(overlayContext).pop();
+                  } else {
+                    setOverlayState(() {});
+                  }
+                },
+              );
+            },
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          child: Text(
+            '${_tabs.length} open',
+            style: Theme.of(overlayContext)
+                .textTheme
+                .labelMedium
+                ?.copyWith(color: scheme.onSurfaceVariant),
+          ),
+        ),
+      ],
     );
   }
 
@@ -1698,7 +1738,8 @@ class _EditorScreenState extends State<EditorScreen>
       child: LayoutBuilder(
         builder: (context, constraints) {
           const buttonWidth = 40.0;
-          final maxTabsWidth = (constraints.maxWidth - buttonWidth)
+          const controlsWidth = buttonWidth * 2;
+          final maxTabsWidth = (constraints.maxWidth - controlsWidth)
               .clamp(0.0, double.infinity)
               .toDouble();
           final desiredTabsWidth = _estimatedTabStripWidth(context);
@@ -1733,6 +1774,20 @@ class _EditorScreenState extends State<EditorScreen>
                   icon: const Icon(Icons.add),
                   tooltip: 'Open PDF in a new tab',
                   onPressed: _pickAndOpen,
+                ),
+              ),
+              SizedBox(
+                width: buttonWidth,
+                height: _tabStripHeight,
+                child: IconButton(
+                  key: const ValueKey('desktop-tabs-button'),
+                  visualDensity: VisualDensity.compact,
+                  padding: EdgeInsets.zero,
+                  constraints:
+                      const BoxConstraints.tightFor(width: buttonWidth),
+                  icon: const Icon(Icons.grid_view),
+                  tooltip: 'View all tabs',
+                  onPressed: _showTabsDialog,
                 ),
               ),
             ],

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -1767,6 +1767,7 @@ class _EditorScreenState extends State<EditorScreen>
                 width: buttonWidth,
                 height: _tabStripHeight,
                 child: IconButton(
+                  key: const ValueKey('desktop-tab-add-button'),
                   visualDensity: VisualDensity.compact,
                   padding: EdgeInsets.zero,
                   constraints:
@@ -1776,6 +1777,7 @@ class _EditorScreenState extends State<EditorScreen>
                   onPressed: _pickAndOpen,
                 ),
               ),
+              const Spacer(key: ValueKey('desktop-tabs-spacer')),
               SizedBox(
                 width: buttonWidth,
                 height: _tabStripHeight,
@@ -2158,11 +2160,27 @@ class _MobileTabPreview extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final session = tab.session;
     if (session != null) {
-      return _MobileTabDocumentPreview(
+      final preview = _MobileTabDocumentPreview(
         controller: session,
         stamp: session.pageRenderStamp(0),
         pageColor: session.preferences.pageColor,
         showAnnotations: session.preferences.showAnnotations,
+      );
+      double? aspectRatio;
+      try {
+        final size = PdfPageRenderer.pageSize(session.pageAt(0));
+        if (size.width > 0 && size.height > 0) {
+          aspectRatio = size.width / size.height;
+        }
+      } catch (_) {
+        // Broken zero-page documents keep the old fill-the-tile placeholder.
+      }
+      if (aspectRatio == null) return preview;
+      return Center(
+        child: AspectRatio(
+          aspectRatio: aspectRatio,
+          child: preview,
+        ),
       );
     }
     final (icon, label) = tab.isLoading

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -144,6 +144,51 @@ void main() {
     expect(find.byKey(const ValueKey('mobile-tabs-open')), findsOneWidget);
   });
 
+  testWidgets('desktop tab strip opens the preview grid in a dialog',
+      (tester) async {
+    await openTabs(tester);
+
+    final button = find.byKey(const ValueKey('desktop-tabs-button'));
+    expect(button, findsOneWidget);
+    expect(
+      tester.getCenter(button).dx,
+      greaterThan(
+        tester.getTopRight(find.byKey(const ValueKey('tab-strip'))).dx,
+      ),
+    );
+
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+
+    final grid = find.byKey(const ValueKey('desktop-tabs-grid'));
+    expect(find.byKey(const ValueKey('desktop-tabs-dialog')), findsOneWidget);
+    expect(grid, findsOneWidget);
+    expect(
+      find.descendant(
+        of: grid,
+        matching: find.byKey(const ValueKey('mobile-tab-tile')),
+      ),
+      findsNWidgets(3),
+    );
+    expect(
+      find.descendant(
+        of: grid,
+        matching: find.byKey(const ValueKey('mobile-tab-preview')),
+      ),
+      findsNWidgets(3),
+    );
+    expect(find.byKey(const ValueKey('desktop-tabs-open')), findsOneWidget);
+
+    await tester.tap(
+      find.descendant(of: grid, matching: find.text('alpha.pdf')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('desktop-tabs-dialog')), findsNothing);
+    expect(tester.widget<Text>(tabTitle('alpha.pdf')).style?.fontWeight,
+        FontWeight.w600);
+  });
+
   testWidgets('right-click opens the tab context menu', (tester) async {
     await openTabs(tester);
 

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -30,12 +30,17 @@ void main() {
 
   // Delivers a PDF to the running app the way the OS would (a warm-start
   // "open with"), opening it in a new tab.
-  Future<void> openTab(WidgetTester tester, String name, {String? path}) async {
+  Future<void> openTab(
+    WidgetTester tester,
+    String name, {
+    String? path,
+    List<int>? bytes,
+  }) async {
     const codec = StandardMethodCodec();
     final message = codec.encodeMethodCall(
       MethodCall('openFile', {
         'name': name,
-        'bytes': buildClassicPdf(),
+        'bytes': bytes ?? buildClassicPdf(),
         if (path != null) 'path': path,
       }),
     );
@@ -149,13 +154,18 @@ void main() {
     await openTabs(tester);
 
     final button = find.byKey(const ValueKey('desktop-tabs-button'));
+    final addButton = find.byKey(const ValueKey('desktop-tab-add-button'));
     expect(button, findsOneWidget);
+    expect(addButton, findsOneWidget);
+    expect(find.byKey(const ValueKey('desktop-tabs-spacer')), findsOneWidget);
     expect(
       tester.getCenter(button).dx,
       greaterThan(
         tester.getTopRight(find.byKey(const ValueKey('tab-strip'))).dx,
       ),
     );
+    expect(tester.getCenter(button).dx - tester.getCenter(addButton).dx,
+        greaterThan(40));
 
     await tester.tap(button);
     await tester.pumpAndSettle();
@@ -187,6 +197,43 @@ void main() {
     expect(find.byKey(const ValueKey('desktop-tabs-dialog')), findsNothing);
     expect(tester.widget<Text>(tabTitle('alpha.pdf')).style?.fontWeight,
         FontWeight.w600);
+  });
+
+  testWidgets('tab thumbnails preserve each first page aspect ratio',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+
+    await openTab(tester, 'portrait.pdf');
+    // The replacement is byte-for-byte the same length, so the fixture's xref
+    // offsets stay valid while its first page becomes landscape.
+    final landscape = ascii(
+      String.fromCharCodes(buildClassicPdf()).replaceFirst(
+        '/MediaBox [0 0 612 792]',
+        '/MediaBox [0 0 792 612]',
+      ),
+    );
+    await openTab(tester, 'landscape.pdf', bytes: landscape);
+
+    await tester.tap(find.byKey(const ValueKey('desktop-tabs-button')));
+    await tester.pumpAndSettle();
+
+    final grid = find.byKey(const ValueKey('desktop-tabs-grid'));
+    Finder previewFor(String title) {
+      final tile = find.ancestor(
+        of: find.descendant(of: grid, matching: find.text(title)),
+        matching: find.byKey(const ValueKey('mobile-tab-tile')),
+      );
+      return find.descendant(
+        of: tile,
+        matching: find.byKey(const ValueKey('mobile-tab-preview')),
+      );
+    }
+
+    expect(tester.getSize(previewFor('portrait.pdf')).aspectRatio,
+        closeTo(612 / 792, 0.001));
+    expect(tester.getSize(previewFor('landscape.pdf')).aspectRatio,
+        closeTo(792 / 612, 0.001));
   });
 
   testWidgets('right-click opens the tab context menu', (tester) async {


### PR DESCRIPTION
## Summary

- add a grid-view button to the right side of the desktop tab strip
- show the existing mobile-style tab preview grid in a responsive desktop dialog
- share tab selection, closing, opening, preview rendering, and active-state behavior between the mobile sheet and desktop dialog
- preserve the existing compact mobile bottom-sheet experience

## Why

Desktop users could only navigate the horizontal tab strip, while the mobile viewer already provided a visual overview of every open document. This gives desktop users the same preview-based navigation without replacing the desktop tab bar.

## Validation

- `fvm dart analyze app/lib/editor_screen.dart app/test/tabs_menu_test.dart`
- `cd app && fvm flutter test test/tabs_menu_test.dart`
- `cd app && fvm flutter test test/tabs_reorder_test.dart`