### PR TITLE
Fix collaboration undo and permission handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ subsampling/PCRL-CPRL progressions.
   included, so a synced annotation renders identically on every device.
 - `annotationChanges` emits per-revision diffs (created/modified/removed,
   undo and redo included); `applyRemoteChange` replays remote edits
-  without echoing them back. Two controllers piped together converge.
+  without echoing them back. Each remote apply is an undo checkpoint: local
+  edits after it remain undoable, but undo cannot remove remote state or
+  cross into older local history. Two controllers piped together converge.
 - Permissions: the document's /F ReadOnly and Locked flags are honored,
   and a `canEditAnnotation` predicate covers policies like "users may
   only edit their own annotations". Gated annotations still render and

--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -161,7 +161,9 @@ are byte prefixes of one buffer.
   `canEditAnnotation` predicate implements policies like "users may
   only edit their own annotations" in one line.
 - Sync: an `annotationChanges` feed plus `applyRemoteChange` for wiring
-  annotations to a collaborative store (Firestore, websockets, etc.).
+  annotations to a collaborative store (Firestore, websockets, etc.). A
+  remote apply is a non-crossable undo checkpoint; later local edits remain
+  undoable without removing the remote state.
 
 ## Composing your own UI
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -339,6 +339,12 @@ class PdfEditingController extends ChangeNotifier {
   final List<int> _revisions;
   int _cursor = 0;
 
+  /// The oldest revision this session may reach with [undo]. A successful
+  /// remote replay advances the floor to its newly committed revision, so a
+  /// local undo can never remove collaboration state received from another
+  /// session. Local revisions committed after the floor remain undoable.
+  int _undoFloor = 0;
+
   /// Parallels [_revisions]: the consequences reported by the document
   /// mutation that produced each revision. Entry 0 is the original document
   /// and is never replayed.
@@ -421,7 +427,7 @@ class PdfEditingController extends ChangeNotifier {
   /// Whether the current revision differs from the originally opened one.
   bool get isModified => _cursor > 0 || _hardModified;
 
-  bool get canUndo => _cursor > 0;
+  bool get canUndo => _cursor > _undoFloor;
   bool get canRedo => _cursor < _revisions.length - 1;
 
   void undo() {
@@ -500,6 +506,7 @@ class PdfEditingController extends ChangeNotifier {
     _bumpContentRenderStamps(impact.contentPages);
     if (impact.destructive) _destructiveStampEpoch++;
     _cursor++;
+    if (_committingRemoteRevision) _undoFloor = _cursor;
     final selected = List.of(_selected);
     _document = PdfDocument.open(bytes, password: _password);
     // Existing controller mutations remap slots before committing when an
@@ -722,6 +729,7 @@ class PdfEditingController extends ChangeNotifier {
 
   StreamController<List<PdfAnnotationChange>>? _changeFeed;
   bool _applyingRemote = false;
+  bool _committingRemoteRevision = false;
 
   /// A live feed of annotation diffs: after every edit, undo, and redo,
   /// one batch of [PdfAnnotationChange]s describing what happened to the
@@ -734,11 +742,11 @@ class PdfEditingController extends ChangeNotifier {
   /// through [applyRemoteChange] - remote applies don't re-emit, so
   /// there is no echo to suppress.
   ///
-  /// Caveats: open pre-existing documents with [ensureAnnotationNames] +
-  /// [annotationBaseline] so every annotation has a durable identity
-  /// first, and remember that remote applies join the revision (undo)
-  /// stack - undoing past one reverts it locally and broadcasts the
-  /// revert as a local change.
+  /// Caveat: open pre-existing documents with [ensureAnnotationNames] +
+  /// [annotationBaseline] so every annotation has a durable identity first.
+  /// A successful remote apply becomes a non-crossable undo checkpoint:
+  /// local edits made afterward can still be undone, while older local
+  /// history remains in the document below that checkpoint.
   Stream<List<PdfAnnotationChange>> get annotationChanges =>
       (_changeFeed ??= StreamController.broadcast()).stream;
 
@@ -770,11 +778,14 @@ class PdfEditingController extends ChangeNotifier {
   /// snapshot of a created/modified change, removes by name for a
   /// removed one. Returns whether the document changed.
   ///
-  /// The edit is a normal revision (rendering, thumbnails, and undo all
-  /// see it) but is never re-emitted on [annotationChanges].
+  /// The edit is a normal rendering/thumbnail revision but is never
+  /// re-emitted on [annotationChanges] and cannot itself be undone locally.
+  /// It establishes a new undo checkpoint, sealing any earlier local history;
+  /// edits made after it remain undoable down to that checkpoint.
   bool applyRemoteChange(PdfAnnotationChange change) {
     final snapshot = change.snapshot;
     _applyingRemote = true;
+    _committingRemoteRevision = true;
     try {
       switch (change.kind) {
         case PdfAnnotationChangeKind.created:
@@ -806,6 +817,7 @@ class PdfEditingController extends ChangeNotifier {
           );
       }
     } finally {
+      _committingRemoteRevision = false;
       _applyingRemote = false;
     }
   }
@@ -1747,6 +1759,7 @@ class PdfEditingController extends ChangeNotifier {
       ..clear()
       ..add(PdfEditImpact.none);
     _cursor = 0;
+    _undoFloor = 0;
     _hardModified = true;
     _selected.clear();
     _bumpRenderStamps(impact.visualPages);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1278,7 +1278,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       final annotations = _controller.pageAt(widget.pageIndex).annotations;
       for (var slot = 0; slot < annotations.length; slot++) {
         final annotation = annotations[slot];
-        if (annotation.subtype != 'Ink' || annotation.isHidden) continue;
+        if (annotation.subtype != 'Ink' ||
+            annotation.isHidden ||
+            !_controller.isAnnotationEditable(annotation)) {
+          continue;
+        }
         final tracked = _eraseSliced[slot];
         final strokes = tracked?.strokes ?? annotation.inkList;
         if (strokes == null) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -279,7 +279,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   Widget _tile(BuildContext context, int pageIndex, int index,
       PdfAnnotation annotation) {
     final slot = (pageIndex, index);
-    final selectable = annotation.behavior.selectable;
+    final editable = annotation.behavior.selectable &&
+        widget.controller.isAnnotationEditable(annotation);
     final detail = _detail(pageIndex, annotation);
     final actionsVisible =
         !pdfPanelControlsRevealOnHover() || _hoveredSlot == slot;
@@ -291,7 +292,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
         leading: _selecting
             ? Checkbox(
                 value: _checked.contains(slot),
-                onChanged: selectable ? (_) => _toggle(slot) : null,
+                onChanged: editable ? (_) => _toggle(slot) : null,
               )
             : Icon(
                 annotation.isCallout
@@ -306,23 +307,23 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
         selected: !_selecting &&
             widget.controller.isAnnotationSelected(pageIndex, index),
         onTap: _selecting
-            ? (selectable ? () => _toggle(slot) : null)
+            ? (editable ? () => _toggle(slot) : null)
             : () {
                 unawaited(widget.viewerController
                     .showRect(pageIndex, annotation.rect));
-                if (selectable) {
+                if (editable) {
                   widget.controller.selectAnnotation(pageIndex, index);
                 }
                 // pulse it on the page so the eye lands right
                 widget.controller.flashAnnotation(pageIndex, index);
               },
-        onLongPress: selectable && !_selecting
+        onLongPress: editable && !_selecting
             ? () => setState(() {
                   _selecting = true;
                   _checked.add(slot);
                 })
             : null,
-        trailing: _selecting || !selectable
+        trailing: _selecting || !editable
             ? null
             : Visibility(
                 visible: actionsVisible,

--- a/packages/dart_pdf_editor/test/editing_eraser_test.dart
+++ b/packages/dart_pdf_editor/test/editing_eraser_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/editing/editing_overlay.dart';
+import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -293,6 +294,38 @@ void main() {
   });
 
   group('live preview', () {
+    testWidgets('locked ink is excluded from the live preview and commit',
+        (tester) async {
+      final (editing, _) = await pumpViewer(tester);
+      editing
+        ..addInkStroke(0, [(150, 500), (250, 500)])
+        ..finishInk();
+      final ink = editing.annotationAt(0, 0)!;
+      editing.apply(
+        (editor) => editor.setAnnotationFlags(0, ink, 128),
+      );
+      editing.tool = PdfEditTool.eraser;
+      await tester.pump();
+
+      final g = await tester.startGesture(view(200, 520),
+          kind: PointerDeviceKind.mouse);
+      for (var i = 0; i < 4; i++) {
+        await g.moveBy(Offset(0, 10 * scale));
+        await tester.pump();
+      }
+
+      final painter = overlayPainter(tester);
+      expect((painter.fadeInk as List), isEmpty);
+      expect((painter.extraInk as List), isEmpty);
+
+      await g.up();
+      await tester.pump();
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.isLocked, isTrue);
+      expect(annotation.inkList, hasLength(1));
+      expect(annotation.inkList!.single, [(150.0, 500.0), (250.0, 500.0)]);
+    });
+
     testWidgets('mid-swipe the original fades and the remainder paints',
         (tester) async {
       final (editing, _) = await pumpViewer(tester);

--- a/packages/dart_pdf_editor/test/editing_sidebar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_sidebar_test.dart
@@ -114,6 +114,65 @@ void main() {
     expect(editing.document.page(0).annotations, hasLength(2));
   });
 
+  testWidgets('locked rows still navigate and flash but expose no edit actions',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1))
+      ..addRectangle(0, const PdfRect(250, 350, 400, 450))
+      ..addEllipse(0, const PdfRect(100, 100, 200, 150));
+    final locked = editing.annotationAt(0, 0)!;
+    editing.apply(
+      (editor) => editor.setAnnotationFlags(0, locked, 128),
+    );
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await pumpSidebar(tester, editing, viewer);
+
+    expect(
+        find.byKey(const ValueKey('pdf-annotation-delete-0-0')), findsNothing);
+    expect(find.byKey(const ValueKey('pdf-annotation-delete-0-1')),
+        findsOneWidget);
+
+    await tester.tap(find.text('Square'));
+    await tester.pump();
+    expect(editing.hasAnnotationSelection, isFalse);
+    expect(editing.pendingFlash, isNotNull);
+    expect(editing.pendingFlash?.slot, 0);
+    await tester.pumpAndSettle();
+
+    await tester.longPress(find.text('Square'));
+    await tester.pump();
+    expect(find.text('1 selected'), findsNothing);
+
+    await tester.longPress(find.text('Circle'));
+    await tester.pump();
+    expect(find.text('1 selected'), findsOneWidget);
+
+    final squareTile = find.ancestor(
+      of: find.text('Square'),
+      matching: find.byType(ListTile),
+    );
+    final circleTile = find.ancestor(
+      of: find.text('Circle'),
+      matching: find.byType(ListTile),
+    );
+    final squareCheckbox = tester.widget<Checkbox>(find.descendant(
+      of: squareTile,
+      matching: find.byType(Checkbox),
+    ));
+    final circleCheckbox = tester.widget<Checkbox>(find.descendant(
+      of: circleTile,
+      matching: find.byType(Checkbox),
+    ));
+    expect(squareCheckbox.onChanged, isNull);
+    expect(circleCheckbox.onChanged, isNotNull);
+
+    await tester.tap(find.text('Square'));
+    await tester.pump();
+    expect(find.text('1 selected'), findsOneWidget);
+    await tester.pump(PdfEditingController.flashLifetime);
+  });
+
   testWidgets('tapping a tile zooms the viewer to the annotation',
       (tester) async {
     // mid-page, so framing it needs no clamping at the document edges

--- a/packages/dart_pdf_editor/test/editing_sync_test.dart
+++ b/packages/dart_pdf_editor/test/editing_sync_test.dart
@@ -29,6 +29,22 @@ void main() {
     return (batches, sub);
   }
 
+  PdfAnnotationChange remoteRectangle({bool locked = false}) {
+    final source = PdfEditingController(buildClassicPdf());
+    try {
+      source.addRectangle(0, const PdfRect(100, 600, 200, 700));
+      if (locked) {
+        final annotation = source.annotationAt(0, 0)!;
+        source.apply(
+          (editor) => editor.setAnnotationFlags(0, annotation, 128),
+        );
+      }
+      return source.annotationBaseline().single;
+    } finally {
+      source.dispose();
+    }
+  }
+
   group('change feed', () {
     test('create, modify, delete each emit one named change', () async {
       final editing = PdfEditingController(buildClassicPdf());
@@ -119,6 +135,64 @@ void main() {
   });
 
   group('remote replay', () {
+    test('a remote locked creation is a non-crossable undo checkpoint', () {
+      final editing = PdfEditingController(buildClassicPdf());
+      addTearDown(editing.dispose);
+      final change = remoteRectangle(locked: true);
+
+      expect(editing.applyRemoteChange(change), isTrue);
+      expect(editing.canUndo, isFalse);
+      final length = editing.bytes.length;
+
+      editing.undo();
+
+      expect(editing.bytes.length, length);
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.name, change.name);
+      expect(annotation.isLocked, isTrue);
+    });
+
+    test('a local edit after a remote change undoes to the checkpoint', () {
+      final editing = PdfEditingController(buildClassicPdf());
+      addTearDown(editing.dispose);
+      final remote = remoteRectangle(locked: true);
+      editing.applyRemoteChange(remote);
+
+      editing.addEllipse(0, const PdfRect(300, 600, 400, 700));
+      expect(editing.canUndo, isTrue);
+      expect(editing.document.page(0).annotations, hasLength(2));
+
+      editing.undo();
+      expect(editing.canUndo, isFalse);
+      expect(editing.canRedo, isTrue);
+      expect(editing.document.page(0).annotations.single.name, remote.name);
+
+      editing.redo();
+      expect(editing.document.page(0).annotations, hasLength(2));
+      expect(
+        editing.document.page(0).annotations.first.name,
+        remote.name,
+      );
+    });
+
+    test('a later remote change seals older local history in place', () {
+      final editing = PdfEditingController(buildClassicPdf());
+      addTearDown(editing.dispose);
+      editing.addEllipse(0, const PdfRect(300, 600, 400, 700));
+      final localName = editing.document.page(0).annotations.single.name;
+      final remote = remoteRectangle(locked: true);
+
+      expect(editing.applyRemoteChange(remote), isTrue);
+      expect(editing.canUndo, isFalse,
+          reason: 'history before a remote checkpoint is sealed');
+
+      editing.undo();
+      final annotations = editing.document.page(0).annotations;
+      expect(annotations, hasLength(2));
+      expect(annotations.map((annotation) => annotation.name),
+          containsAll([localName, remote.name]));
+    });
+
     test('applyRemoteChange lands the annotation and never echoes', () async {
       // device A authors; device B replays
       final a = PdfEditingController(buildClassicPdf());


### PR DESCRIPTION
## Summary

- make remotely applied annotation revisions non-crossable undo checkpoints
- keep local edits made after a remote revision undoable down to that checkpoint
- exclude locked annotations from the eraser's live preview
- hide and disable annotation-sidebar edit actions for locked annotations while preserving navigation and attention flashing
- document the collaboration undo semantics

## Root cause

Remote collaboration changes were stored as ordinary prefix revisions, so local undo could cross them even though the persistence layer correctly rejected the resulting unauthorized write. The eraser's committed slice respected annotation permissions, but its preview did not. The sidebar likewise checked only whether an annotation was selectable, rather than whether the controller allowed it to be edited.

## User impact

Remote and locked annotations now remain stable under local undo and editing gestures. Users can still undo their own edits made after the latest remote checkpoint, and locked sidebar rows remain available for navigation without exposing mutation controls.

## Validation

- `fvm flutter test test/editing_sync_test.dart test/editing_readonly_test.dart test/editing_eraser_test.dart test/editing_sidebar_test.dart` — 44 passed
- `fvm dart analyze` — no issues
- `git diff --check`