### PR TITLE
perf(image): resolve the DeviceN tint transform per sample, not per pixel

### DIFF
--- a/doc/dev-log/2026-07-16-devicen-tint-memo.md
+++ b/doc/dev-log/2026-07-16-devicen-tint-memo.md
@@ -1,0 +1,161 @@
+# 2026-07-16 — The DeviceN tint transform ran per pixel, not per distinct sample
+
+Branch `perf/devicen-tint-memo`. A reader on r/FlutterDev reported the web
+demo going unresponsive and then crashing on a ~60-page PDF, and guessed it
+was "image heavy". The file (a 24 MB, 62-page InDesign print export) does
+carry 247 image XObjects / 282 MB of decoded RGBA, but that guess was wrong
+and cost some time — worth recording how the measurements actually fell.
+
+## Repro, and what it wasn't
+
+Rendering every page through `PdfPageRenderer.renderImage` at ratio 2:
+
+```
+62 pages in 106392 ms, mean 1716 ms, worst page 2 at 32633 ms
+```
+
+but the shape was bimodal, not heavy-everywhere: pages 2/21/22/30 took
+16–32 **seconds** each and every other page took ~180 ms. So it was never
+about the document's total image weight.
+
+Two false leads, both cheap to kill with the existing tools:
+
+- Interpret is innocent. `tool/interp_timing.dart`-style walk to a
+  `NullDevice` is 6.0 ms/page mean, 369 ms for the whole document. Page 2
+  interprets in 38 ms and rasterizes in 32633 ms.
+- Not image count or size. Page 30 has **one** 127×127 icon and took
+  16 s. Page 2's own `/Resources /XObject` is empty — its images are nested
+  inside Form XObjects, which is why a naive resource-dict probe reported
+  "no images" on the slowest page in the file. Walk with
+  `scanImagesOnly: true` instead; it sees through forms, Type3 glyphs, and
+  tiling patterns.
+
+Phase-timing `renderPictureWithPlan` on page 2 put it beyond argument:
+
+```
+parse ops      : 5 ms (334 ops)
+collect walk   : 34 ms (8 images)
+decode images  : 32927 ms      <-- here
+interpret null : 44 ms
+```
+
+## The bug
+
+`_alternateToRgba` (image_pixels.dart) is the Separation/DeviceN path. It
+called `alternate.colorFor(values)` **once per pixel**, allocating a samples
+list and a values list each time. The colour space here is:
+
+```
+/DeviceN [/Black] /DeviceCMYK <FunctionType 4 ...>
+```
+
+One colorant, 8 bits — **256 possible inputs** — and a type 4 PostScript
+calculator tint transform, whose `evaluateAt` re-interprets the token
+program on a fresh `List<Object>` stack per call. At 1691×1293 that is
+2.19M interpreted program runs (~10 µs each) to produce 256 distinct
+answers: 23.7 s for one image.
+
+Fix: resolve each distinct sample *tuple* once, keyed by the packed 8-bit
+samples, and index the answer per pixel — the same shape as
+`_indexedToRgba` resolving its palette up front. Bounds that matter:
+
+- key packing needs `components <= 8` to fit an int (`_tintMemoMaxComponents`);
+- `_tintMemoMaxEntries` (1<<16) caps the table so a wide DeviceN whose tuples
+  never repeat can't grow it with the pixel count — past the cap it just
+  evaluates directly, which is the old behaviour;
+- alpha stays per-pixel. The colour is shared, the colour-key `/Mask` test is
+  **not** — it reads the raw sample, so two pixels sharing a colour can still
+  differ in alpha;
+- the memo keys on **raw** samples, before the `/Decode` LUT. Safe because the
+  LUT is fixed per image, so raw sample → same value every time.
+
+## The second bug, found by the first
+
+`decodePdfImagePixels` did:
+
+```dart
+final base = decodePdfImageBase(cos, stream);   // full DeviceN conversion
+...
+if (_softMaskIsDct(cos, dict)) return null;     // ...thrown away
+```
+
+and `_decodeOne` (dart_pdf_editor/image_decoder.dart) then called
+`decodePdfImageBase` **again** for its platform-JPEG-mask path. Any
+non-JPEG base under a DCTDecode `/SMask` — exactly this file's images —
+decoded twice. `_softMaskIsDct` is pure dict lookups, so it now runs before
+the base decode. Same output, half the work (131 → 98 ms/image here). Mind
+the ordering: a stencil `/ImageMask` ignores the soft mask, so it must not
+take the early bail.
+
+## Why the corpora never caught it
+
+Worth knowing, because it's a real coverage gap rather than bad luck:
+
+- the unit fixtures are 1–2 px — correct, and the cost is invisible;
+- Ghent *has* DeviceN cases, but `ghent_render_test.dart` skips them as
+  "known baseline deviation — colour handling is not pixel-exact" and only
+  asserts non-blank, and its DeviceN content is vector, where the transform
+  runs per fill, not per pixel;
+- across all 275 files in ghent + pdfjs + the local corpus, only **7**
+  images reach this path and the largest is 0.26 MP.
+
+The trigger needs a large *raster* image in a Separation/DeviceN space with
+a calculator transform: a print-production signature (NChannel spot inks).
+CAD sheets are vector CMYK; the pdf.js/PDFium benchmark corpora are screen
+PDFs. The combination simply wasn't represented.
+
+## Verification
+
+The Ghent baselines can't police this path (see above), so equivalence was
+proved directly with `tool/hash_image_decodes.dart`: hash the decoded RGBA
+of every Separation/DeviceN image instance across the reader's file plus
+all 275 files in ghent + pdfjs + the local corpus, at HEAD and with the
+fix, and require the line sets to be identical. 217 instance lines (the
+reader's file contributes 206; 12 corpus files are legitimately unreadable
+— encrypted or fuzzed pdf.js fixtures). The unfixed side is slow enough
+that it needs page-range sharding across cores to finish — which is itself
+the point.
+
+Three traps the sweep itself stepped in, all now guarded in the tool,
+recorded because each one *silently shrank coverage while still reporting
+success*:
+
+- hash **both** entry points. `decodePdfImagePixels` returns null for
+  exactly these images (DCT `/SMask`), so hashing only it covered 7 images
+  instead of 206 and would have "passed" while checking nothing;
+- pass the file list NUL-delimited (`tr '\n' '\0' | xargs -0`). An unquoted
+  `$(cat files.txt)` word-split every filename containing a space into
+  fragments that each failed to open — as OPEN-FAILED lines, not errors;
+- one fuzzed pdf.js file threw from `pageCount` and killed the whole sweep
+  mid-output. The tool now guards it per file (and grew
+  `PDF_HASH_PAGE_MIN`/`MAX` env knobs so a killed multi-hour sweep can
+  resume by page range).
+
+## Numbers (the reader's file, ratio 2)
+
+| | before | after |
+|---|---|---|
+| worst page | 32633 ms | 695 ms |
+| whole document | 106392 ms | 14100 ms |
+| the 1691×1293 DeviceN image | 23656 ms | 98 ms |
+
+## Left open
+
+Everything above was measured on the VM and through Flutter's rasterizer.
+The fix lands in the pure-Dart decode that *every* path shares — UI thread,
+native isolate worker, and the web worker — so the win is not
+platform-specific, but the reported symptom was never reproduced in a
+browser (none was in the loop here).
+
+Worth not guessing about: on web these images do **not** block the main
+thread. `_decodeBrowserImage` (render_worker_web_entry.dart:688) explicitly
+handles "pure base + DCT /SMask" by calling `decodePdfImageBase` on the
+worker and lifting only the mask through the browser codec — which is
+exactly this file's shape. So the 23 s/image was burning on the Web Worker,
+and what the reader saw (unresponsive, then a crash) is unexplained in its
+specifics. Load the file into the demo and watch it before claiming the
+crash is fixed.
+
+Related but separate: `PdfImageCache.instance` is a flat 256 MB on every
+platform including web, and this file pegs it at 268 MB for two thirds of
+the document — issue #281.

--- a/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
@@ -5815,21 +5815,21 @@ h=i}else h=a2.a0(a3)
 n=a0?A.x_(a2,c,h,l,k):A.qQ(a2,c,h,l,k,j,A.qB(a2,c))
 if(n==null)return g
 return new A.cT(n,l,k,r&&!a1)},
-qZ(a,b){var s,r,q,p,o,n,m=A.oD(a,b)
-if(m==null)return null
-s=b.a
-if(a.j(s.a.h(0,"ImageMask")).I(0,B.q)){r=m.a
-q=m.b
-p=m.c
+qZ(a,b){var s,r,q,p,o,n,m=b.a,l=a.j(m.a.h(0,"ImageMask")).I(0,B.q)
+if(!l&&A.wX(a,m))return null
+s=A.oD(a,b)
+if(s==null)return null
+if(l){r=s.a
+q=s.b
+p=s.c
 A.j8(r)
-return new A.aD(r,q,p)}if(A.wX(a,s))return null
-o=A.rk(a,s)
-if(o==null)o=A.rl(a,s)
-if(o==null){r=m.a
-q=m.b
-p=m.c
-if(!m.d)A.j8(r)
-return new A.aD(r,q,p)}n=A.rj(m.a,m.b,m.c,o)
+return new A.aD(r,q,p)}o=A.rk(a,m)
+if(o==null)o=A.rl(a,m)
+if(o==null){r=s.a
+q=s.b
+p=s.c
+if(!s.d)A.j8(r)
+return new A.aD(r,q,p)}n=A.rj(s.a,s.b,s.c,o)
 r=n.a
 A.j8(r)
 return new A.aD(r,n.b,n.c)},
@@ -6850,52 +6850,60 @@ a7=q[3]
 a7=c1>=a7.a&&c1<=a7.b}}}}a7=a7?0:255
 if(!(a9<c8))return A.a(c9,a9)
 c9[a9]=a7}return c9}return c6},
-w3(a3,a4,a5,a6,a7,a8,a9){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0=a4*a5,a1=a7.a,a2=a3.length
-if(a2<a0*a1)return null
+w3(a5,a6,a7,a8,a9,b0,b1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=null,a2=a6*a7,a3=a9.a,a4=a5.length
+if(a4<a2*a3)return a1
 s=A.b([],t.a)
-for(r=a8==null,q=0;q<a1;++q){if(r)p=$.oU()
-else{if(!(q<a8.length))return A.a(a8,q)
-p=A.or(a8[q])}s.push(p)}for(r=t.o,p=a7.c,o=a7.d,n=t.n,m=t.t,l=a7.b,k=0;k<a0;++k){j=A.b([],m)
-for(i=k*a1,q=0;q<a1;++q){h=i+q
-if(!(h<a2))return A.a(a3,h)
-j.push(a3[h])}i=A.b([],n)
-for(q=0;q<a1;++q){if(!(q<s.length))return A.a(s,q)
-h=s[q]
-if(!(q<j.length))return A.a(j,q)
-g=j[q]
-if(!(g<h.length))return A.a(h,g)
-i.push(h[g]/255)}f=p.bk(r.a(i))
-e=o==null?null:o.b3(f)
-if(e==null)e=A.da(f,l)
-i=k*4
-h=B.b.n(B.c.v(e.a*255),0,255)
-a6.$flags&2&&A.e(a6)
-g=a6.length
-if(!(i<g))return A.a(a6,i)
-a6[i]=h
+for(r=b0==null,q=0;q<a3;++q){if(r)p=$.oU()
+else{if(!(q<b0.length))return A.a(b0,q)
+p=A.or(b0[q])}s.push(p)}if(a3<=8){r=t.S
+o=A.y(r,r)}else o=a1
+n=new Float64Array(a3)
+for(r=t.o,p=a9.c,m=a9.d,l=a9.b,k=0;k<a2;++k){j=k*a3
+i=o==null
+h=!i
+g=0
+if(h)for(q=0;q<a3;++q){f=j+q
+if(!(f<a4))return A.a(a5,f)
+g=(g<<8|a5[f])>>>0}e=i?a1:o.h(0,g)
+if(e==null)e=-1
+if(e<0){for(i=s.length,q=0;q<a3;++q){if(!(q<i))return A.a(s,q)
+f=s[q]
+d=j+q
+if(!(d<a4))return A.a(a5,d)
+d=a5[d]
+if(!(d<f.length))return A.a(f,d)
+d=f[d]
+if(!(q<a3))return A.a(n,q)
+n[q]=d/255}c=p.bk(r.a(n))
+b=m==null?a1:m.b3(c)
+if(b==null)b=A.da(c,l)
+e=(B.b.n(B.c.v(b.a*255),0,255)<<16|B.b.n(B.c.v(b.b*255),0,255)<<8|B.b.n(B.c.v(b.c*255),0,255))>>>0
+if(h&&o.a<65536)o.k(0,g,e)}i=k*4
+h=B.b.q(e,16)
+a8.$flags&2&&A.e(a8)
+f=a8.length
+if(!(i<f))return A.a(a8,i)
+a8[i]=h&255
 h=i+1
-d=B.b.n(B.c.v(e.b*255),0,255)
-a6.$flags&2&&A.e(a6)
-if(!(h<g))return A.a(a6,h)
-a6[h]=d
+d=B.b.q(e,8)
+if(!(h<f))return A.a(a8,h)
+a8[h]=d&255
 d=i+2
-h=B.b.n(B.c.v(e.c*255),0,255)
-a6.$flags&2&&A.e(a6)
-if(!(d<g))return A.a(a6,d)
-a6[d]=h
-c=!1
-if(a9!=null){h=j.length
-d=a9.length
+if(!(d<f))return A.a(a8,d)
+a8[d]=e&255
+a=!1
+if(b1!=null){h=b1.length
 q=0
-for(;;){if(!(q<a1)){c=!0
-break}if(!(q<h))return A.a(j,q)
-b=j[q]
-if(!(q<d))return A.a(a9,q)
-a=a9[q]
-if(b<a.a||b>a.b)break;++q}}j=i+3
-i=c?0:255
-if(!(j<g))return A.a(a6,j)
-a6[j]=i}return a6},
+for(;;){if(!(q<a3)){a=!0
+break}d=j+q
+if(!(d<a4))return A.a(a5,d)
+a0=a5[d]
+if(!(q<h))return A.a(b1,q)
+d=b1[q]
+if(a0<d.a||a0>d.b)break;++q}}i+=3
+h=a?0:255
+if(!(i<f))return A.a(a8,i)
+a8[i]=h}return a8},
 d9(a,b){var s
 if(a==null)s=$.oU()
 else{if(!(b<a.length))return A.a(a,b)

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -148,15 +148,22 @@ PdfImageBase? decodePdfImageBase(CosDocument cos, CosStream stream) {
 /// encoded /SMask - or the image can't be decoded. On null the caller falls
 /// back to the `dart:ui` decode path ([decodePdfImageBase] + the codec).
 PdfDecodedPixels? decodePdfImagePixels(CosDocument cos, CosStream stream) {
+  final dict = stream.dictionary;
+  final isStencil = cos.resolve(dict['ImageMask']) == const CosBoolean(true);
+
+  // Bail before decoding the base, not after: a DCTDecode /SMask sends the
+  // image to the `dart:ui` path whatever the base holds, and that path decodes
+  // the base itself ([decodePdfImageBase]), so a base decoded here is thrown
+  // away and paid for twice. A stencil ignores the soft mask, so it stays.
+  if (!isStencil && _softMaskIsDct(cos, dict)) return null;
+
   final base = decodePdfImageBase(cos, stream);
   if (base == null) return null;
 
-  final dict = stream.dictionary;
-  if (cos.resolve(dict['ImageMask']) == const CosBoolean(true)) {
+  if (isStencil) {
     // A stencil's alpha is already in base.rgba; no soft mask applies.
     return _finish(base.rgba, base.width, base.height, hasAlpha: true);
   }
-  if (_softMaskIsDct(cos, dict)) return null; // mask needs the platform codec
   final mask = pdfImageSoftMask(cos, dict) ?? pdfImageStencilMask(cos, dict);
   if (mask == null) {
     return _finish(base.rgba, base.width, base.height, hasAlpha: !base.opaque);
@@ -1294,6 +1301,20 @@ Uint8List? _toRgba(CosDocument cos, CosDictionary dict, Uint8List data,
   return null;
 }
 
+/// A packed sample tuple must fit an int key; wider spaces skip the table.
+const int _tintMemoMaxComponents = 8;
+
+/// Ceiling on distinct tuples remembered, so a wide space whose tuples never
+/// repeat cannot grow the table with the pixel count.
+const int _tintMemoMaxEntries = 1 << 16;
+
+/// Separation and DeviceN samples reach the alternate space through a tint
+/// transform, which - a type 4 calculator especially - costs orders of
+/// magnitude more per pixel than the device spaces' copy. Samples are 8 bits,
+/// so one colorant has at most 256 distinct inputs and two at most 65536,
+/// against the millions of pixels in a scan: evaluate each distinct tuple
+/// once and index the answer afterwards, the way [_indexedToRgba] resolves
+/// its palette up front.
 Uint8List? _alternateToRgba(
   Uint8List data,
   int width,
@@ -1307,22 +1328,39 @@ Uint8List? _alternateToRgba(
   final components = alternate.components;
   if (data.length < count * components) return null;
   final luts = [for (var c = 0; c < components; c++) _lutFor(ranges, c)];
+  final memo = components <= _tintMemoMaxComponents ? <int, int>{} : null;
+  // Reused across pixels: evaluateAt reads its input and keeps no reference.
+  final values = Float64List(components);
+
   for (var i = 0; i < count; i++) {
-    final samples = [
-      for (var c = 0; c < components; c++) data[i * components + c]
-    ];
-    final values = [
-      for (var c = 0; c < components; c++) luts[c][samples[c]] / 255
-    ];
-    final color = alternate.colorFor(values);
-    out[i * 4] = (color.red * 255).round().clamp(0, 255);
-    out[i * 4 + 1] = (color.green * 255).round().clamp(0, 255);
-    out[i * 4 + 2] = (color.blue * 255).round().clamp(0, 255);
+    final base = i * components;
+    var key = 0;
+    if (memo != null) {
+      for (var c = 0; c < components; c++) {
+        key = (key << 8) | data[base + c];
+      }
+    }
+    // Packed RGB is never negative, so -1 stands in for "not remembered".
+    var rgb = memo?[key] ?? -1;
+    if (rgb < 0) {
+      for (var c = 0; c < components; c++) {
+        values[c] = luts[c][data[base + c]] / 255;
+      }
+      final color = alternate.colorFor(values);
+      rgb = ((color.red * 255).round().clamp(0, 255) << 16) |
+          ((color.green * 255).round().clamp(0, 255) << 8) |
+          ((color.blue * 255).round().clamp(0, 255));
+      if (memo != null && memo.length < _tintMemoMaxEntries) memo[key] = rgb;
+    }
+    out[i * 4] = (rgb >> 16) & 0xff;
+    out[i * 4 + 1] = (rgb >> 8) & 0xff;
+    out[i * 4 + 2] = rgb & 0xff;
     var masked = false;
     if (colorKey != null) {
       masked = true;
       for (var c = 0; c < components; c++) {
-        if (samples[c] < colorKey[c].$1 || samples[c] > colorKey[c].$2) {
+        final sample = data[base + c];
+        if (sample < colorKey[c].$1 || sample > colorKey[c].$2) {
           masked = false;
           break;
         }

--- a/packages/pdf_graphics/test/image_pixels_test.dart
+++ b/packages/pdf_graphics/test/image_pixels_test.dart
@@ -508,4 +508,146 @@ void main() {
     expect(base.opaque, isTrue);
     expect(base.rgba, [10, 20, 30, 255]);
   });
+
+  // Separation and DeviceN samples reach RGB through a tint transform, which
+  // the decoder resolves once per distinct sample tuple rather than once per
+  // pixel. These pin that the shared answers stay per-pixel correct.
+  group('tint transform', () {
+    /// `{ dup 0.5 mul exch 0.25 mul 0.0 0.0 }`: one ink in, CMYK out, with
+    /// different factors per output so a mixed-up tuple cannot pass by luck.
+    CosStream separation(List<int> samples, {Map<String, CosObject> extra = const {}}) =>
+        image({
+          'Width': CosInteger(samples.length),
+          'Height': const CosInteger(1),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': CosArray([
+            const CosName('Separation'),
+            const CosName('Spot'),
+            const CosName('DeviceCMYK'),
+            CosStream(
+                CosDictionary({
+                  'FunctionType': const CosInteger(4),
+                  'Domain': CosArray([const CosReal(0), const CosReal(1)]),
+                  'Range': CosArray([
+                    for (var i = 0; i < 4; i++) ...[
+                      const CosReal(0),
+                      const CosReal(1)
+                    ]
+                  ]),
+                }),
+                Uint8List.fromList(
+                    '{ dup 0.5 mul exch 0.25 mul 0.0 0.0 }'.codeUnits)),
+          ]),
+          ...extra,
+        }, samples);
+
+    test('repeated samples decode the same as their first occurrence', () {
+      // 0 and 255 repeat out of order, so a stale or mis-keyed answer shows up
+      // as one pixel disagreeing with its twin.
+      const samples = [0, 128, 255, 128, 0, 255, 64];
+      final pixels = decodePdfImagePixels(cos, separation(samples))!;
+      expect(pixels.width, samples.length);
+
+      List<int> pixelAt(int i) => pixels.rgba.sublist(i * 4, i * 4 + 4);
+      for (var i = 0; i < samples.length; i++) {
+        final first = samples.indexOf(samples[i]);
+        expect(pixelAt(i), pixelAt(first),
+            reason: 'sample ${samples[i]} at $i differs from its first '
+                'occurrence at $first');
+      }
+      // Distinct inks must not collapse onto one another.
+      expect(pixelAt(0), isNot(pixelAt(1)));
+      expect(pixelAt(1), isNot(pixelAt(2)));
+    });
+
+    test('every distinct sample maps through the tint transform', () {
+      // All 256 inputs, each appearing twice: the answers must match the
+      // transform evaluated directly, so sharing cannot drift from the maths.
+      final samples = [for (var i = 0; i < 256; i++) i, for (var i = 0; i < 256; i++) i];
+      final pixels = decodePdfImagePixels(cos, separation(samples))!;
+
+      for (var i = 0; i < samples.length; i++) {
+        final tint = samples[i] / 255;
+        // The tint transform's CMYK, converted the way the decoder does.
+        final expected = colorFromComponents(
+            [tint * 0.5, tint * 0.25, 0.0, 0.0], 4);
+        expect(pixels.rgba[i * 4], (expected.red * 255).round().clamp(0, 255),
+            reason: 'red for sample ${samples[i]}');
+        expect(pixels.rgba[i * 4 + 1],
+            (expected.green * 255).round().clamp(0, 255),
+            reason: 'green for sample ${samples[i]}');
+        expect(pixels.rgba[i * 4 + 2],
+            (expected.blue * 255).round().clamp(0, 255),
+            reason: 'blue for sample ${samples[i]}');
+        expect(pixels.rgba[i * 4 + 3], 255);
+      }
+    });
+
+    test('color-key /Mask stays per-pixel when samples repeat', () {
+      // Alpha depends on the raw sample, not the shared colour: the two 128s
+      // must both key out while their neighbours stay opaque.
+      final pixels = decodePdfImagePixels(
+          cos,
+          separation([0, 128, 255, 128], extra: {
+            'Mask': CosArray([const CosInteger(128), const CosInteger(128)]),
+          }))!;
+      expect([for (var i = 0; i < 4; i++) pixels.rgba[i * 4 + 3]],
+          [255, 0, 255, 0]);
+    });
+
+    test('/Decode inverts the ink before the tint transform', () {
+      // /Decode [1 0] maps sample 0 to full ink: pixel 0 must equal what
+      // sample 255 gives without /Decode.
+      final plain = decodePdfImagePixels(cos, separation([0, 255]))!;
+      final inverted = decodePdfImagePixels(
+          cos,
+          separation([0, 255], extra: {
+            'Decode': CosArray([const CosReal(1), const CosReal(0)]),
+          }))!;
+      expect(inverted.rgba.sublist(0, 4), plain.rgba.sublist(4, 8));
+      expect(inverted.rgba.sublist(4, 8), plain.rgba.sublist(0, 4));
+    });
+
+    test('DeviceN keys each colorant separately', () {
+      // `{ pop dup 0.0 0.0 }` drops InkB and paints with InkA alone, so a key
+      // that ignored InkA would make (0,255) and (255,0) agree, while one that
+      // ignored InkB would (correctly) keep (0,255) and (0,0) together.
+      final stream = image({
+        'Width': const CosInteger(3),
+        'Height': const CosInteger(1),
+        'BitsPerComponent': const CosInteger(8),
+        'ColorSpace': CosArray([
+          const CosName('DeviceN'),
+          CosArray([const CosName('InkA'), const CosName('InkB')]),
+          const CosName('DeviceCMYK'),
+          CosStream(
+              CosDictionary({
+                'FunctionType': const CosInteger(4),
+                'Domain': CosArray([
+                  const CosReal(0),
+                  const CosReal(1),
+                  const CosReal(0),
+                  const CosReal(1)
+                ]),
+                'Range': CosArray([
+                  for (var i = 0; i < 4; i++) ...[
+                    const CosReal(0),
+                    const CosReal(1)
+                  ]
+                ]),
+              }),
+              Uint8List.fromList('{ pop dup 0.0 0.0 }'.codeUnits)),
+        ]),
+      }, [
+        0, 255, //
+        0, 0, //
+        255, 0,
+      ]);
+
+      final pixels = decodePdfImagePixels(cos, stream)!;
+      List<int> pixelAt(int i) => pixels.rgba.sublist(i * 4, i * 4 + 4);
+      expect(pixelAt(0), pixelAt(1)); // InkB is dropped by the transform
+      expect(pixelAt(0), isNot(pixelAt(2))); // InkA drives the colour
+    });
+  });
 }

--- a/packages/pdf_graphics/tool/hash_image_decodes.dart
+++ b/packages/pdf_graphics/tool/hash_image_decodes.dart
@@ -1,0 +1,116 @@
+// Hashes the decoded pixels of every image XObject across a set of PDFs, so a
+// change to the decode path can be proved byte-identical:
+//
+//   fvm dart run tool/hash_image_decodes.dart ../../test_corpora/*/*.pdf > after.txt
+//   # ...check out the old code in a worktree, run it there...
+//   diff <(sort before.txt) <(sort after.txt)
+//
+// Pass --alternate-only to restrict the sweep to Separation/DeviceN images
+// (the tint-transform path). Unfixed decode paths can be slow enough that the
+// sweep needs sharding across cores to finish; split the file list and diff the
+// concatenation.
+//
+// Both entry points are hashed on purpose. decodePdfImagePixels returns null
+// for a base paired with a DCTDecode /SMask, and the dart:ui layer then decodes
+// the base itself - so hashing only the first silently skips those images.
+import 'dart:io';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+/// FNV-1a over the decoded pixels - no dependency, and collisions do not
+/// matter for an equal/not-equal check against the same data.
+String _fnv(List<int> bytes) {
+  var h = 0xcbf29ce484222325;
+  for (final b in bytes) {
+    h = (h ^ b) * 0x100000001b3;
+    h &= 0xFFFFFFFFFFFFFFFF;
+  }
+  return h.toRadixString(16);
+}
+
+/// Whether this image decodes through the Separation/DeviceN tint transform.
+bool _isAlternate(CosDocument cos, CosDictionary dict) {
+  final cs = cos.resolve(dict['ColorSpace']);
+  if (cs is! CosArray || cs.length == 0) return false;
+  final family = cos.resolve(cs[0]);
+  return family is CosName &&
+      (family.value == 'DeviceN' || family.value == 'Separation');
+}
+
+class _Collect implements PdfDevice {
+  final streams = <PdfImageRequest>[];
+
+  @override
+  void drawImage(PdfImageRequest r) => streams.add(r);
+
+  @override
+  dynamic noSuchMethod(Invocation i) => null;
+}
+
+void main(List<String> args) {
+  final alternateOnly = args.contains('--alternate-only');
+  final paths = args.where((a) => !a.startsWith('--'));
+
+  // Resume aids for long sweeps (the unfixed side of a comparison can be
+  // slow enough to shard by page range): hash only pages in [min, max].
+  final pageMin = int.tryParse(
+          Platform.environment['PDF_HASH_PAGE_MIN'] ?? '') ??
+      0;
+  final pageMax =
+      int.tryParse(Platform.environment['PDF_HASH_PAGE_MAX'] ?? '') ?? 1 << 30;
+
+  for (final path in paths) {
+    final name = path.split('/').last;
+    final PdfDocument doc;
+    final int pages;
+    try {
+      doc = PdfDocument.open(File(path).readAsBytesSync());
+      // Corrupt files (the pdf.js suite includes fuzzed PDFs) can open and
+      // then throw here; without the guard one such file kills the sweep and
+      // silently truncates the output.
+      pages = doc.pageCount;
+    } catch (e) {
+      stdout.writeln('$name OPEN-FAILED ${e.runtimeType}');
+      continue;
+    }
+    for (var p = pageMin; p < pages && p <= pageMax; p++) {
+      final collector = _Collect();
+      try {
+        // scanImagesOnly walks forms, Type3 glyphs, and tiling patterns, so it
+        // sees images a page's own /Resources /XObject never lists.
+        PdfInterpreter(cos: doc.cos, device: collector, scanImagesOnly: true)
+            .drawPageOperations(doc.page(p),
+                ContentStreamParser.parse(doc.page(p).contentBytes()));
+      } catch (e) {
+        stdout.writeln('$name p$p WALK-FAILED ${e.runtimeType}');
+        continue;
+      }
+      for (var i = 0; i < collector.streams.length; i++) {
+        final stream = collector.streams[i].stream;
+        if (alternateOnly && !_isAlternate(doc.cos, stream.dictionary)) continue;
+
+        String digest;
+        try {
+          final pixels = decodePdfImagePixels(doc.cos, stream);
+          digest = pixels == null
+              ? 'pixels:null'
+              : 'pixels:${pixels.width}x${pixels.height}:${_fnv(pixels.rgba)}';
+        } catch (e) {
+          digest = 'pixels:THREW ${e.runtimeType}';
+        }
+        try {
+          final base = decodePdfImageBase(doc.cos, stream);
+          digest += base == null
+              ? ' base:null'
+              : ' base:${base.width}x${base.height}:'
+                  '${base.opaque ? 'opaque' : 'alpha'}:${_fnv(base.rgba)}';
+        } catch (e) {
+          digest += ' base:THREW ${e.runtimeType}';
+        }
+        stdout.writeln('$name p$p i$i $digest');
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

A reader on r/FlutterDev reported the web demo going unresponsive and crashing on a 62-page print PDF. Two independent bugs in the pure-Dart image decode, both in `image_pixels.dart`:

1. **The Separation/DeviceN tint transform ran once per pixel.** The transform is often a type 4 PostScript calculator whose `evaluateAt` re-interprets the token program on a fresh boxed stack per call. The reported file carries `/DeviceN [/Black] /DeviceCMYK` images at 1691×1293: 2.19M interpreted program runs to produce **256 distinct answers** (one 8-bit colorant), 23.7 s for a single image. Fixed by resolving each distinct sample tuple once (packed-samples key, capped table) and indexing the answer per pixel — the same shape `_indexedToRgba` already uses for its palette. Alpha stays per-pixel: a colour-key `/Mask` reads the raw sample, so pixels sharing a colour can still differ in alpha.

2. **The base decoded twice under a DCT `/SMask`.** `decodePdfImagePixels` decoded the base, then discarded it when the soft mask turned out to be DCTDecode-encoded — and `_decodeOne` immediately decoded the same base again for the platform-codec path. `_softMaskIsDct` is pure dictionary lookups, so it now runs before the base decode (stencils still ignore the soft mask).

## Numbers (the reported file, pixelRatio 2)

| | before | after |
|---|---|---|
| worst page | 32,633 ms | 695 ms |
| whole document | 106,392 ms | 14,100 ms |
| the 1691×1293 DeviceN image | 23,656 ms | 98 ms |

## Why the corpora never caught it

Not a regression — the loop is unchanged since Separation/DeviceN support landed (`52baa7d`). The Ghent suite skips DeviceN as a known non-pixel-exact deviation (asserts non-blank only), and across ghent + pdfjs + the local corpus only a handful of *raster* images reach this path, the largest 0.26 MP. The trigger — a large raster image in a spot-ink space with a calculator transform — is a print-production signature none of the corpora represent.

## Verification

- Equivalence proved directly with the new `tool/hash_image_decodes.dart`: the decoded RGBA of every Separation/DeviceN image instance across the reported file + all 275 corpus files, hashed at HEAD and with the fix, compared both directions: **217/217 lines identical**. The tool hashes both decode entry points on purpose — `decodePdfImagePixels` returns null for exactly these images, so hashing only it covers 7 instances instead of 206 and passes while checking nothing.
- Five new regression tests pin the memo behaviour: repeated samples, all 256 inputs vs the transform evaluated directly, per-pixel colour-key alpha under shared colours, `/Decode` inversion, and per-colorant key packing.
- Full suites green: pdf_cos 200, pdf_document 634, pdf_graphics 806, dart_pdf_editor 1432, Ghent render baselines, PDF.js render, image_decoder.

## Left open

The reader saw a *crash*, not just a hang, and on web this decode runs on the worker, so the crash mechanism is unconfirmed — worth loading the file into the demo after this lands. The related-but-separate cache-budget question is #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018grS21dxf5DeaEYUrc722x
