### PR TITLE
Size the decoded-image cache budget per platform, and honour memory pressure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,15 @@ wired into sc/scn and image decoding). RSASSA-PSS verification is in
 recovery, KAT vs OpenSSL; PSS-params parsing and dispatch in cms.dart's
 `cmsVerify` and `X509Certificate.isSignedBy`). Remaining gaps:
 JPX subsampling + PCRL/CPRL, rendering intents/BPC in ICC.
+The decoded-image cache budget (`PdfImageCache.maxBytes`, settable) is
+platform-aware: `pdfDefaultImageCacheBytes()` in performance_policy.dart -
+desktop 256 MB, mobile/web 128 MB, 64 MB on a <=2 GB browser device
+(`navigator.deviceMemory`, web-only and secure-context-only, via the
+performance_memory.dart conditional export). The numbers are measured, not
+guessed - see doc/dev-log/2026-07-16-image-cache-budget.md and
+`test/benchmark_image_cache_budget_test.dart`; re-run it before changing
+them. `didHaveMemoryPressure` on the viewer clears the image + preview
+caches.
 The editing UI is in (dart_pdf_editor `src/editing/`): `PdfEditingController`
 owns the edit session - every edit is an incremental save, so revisions
 are byte prefixes of one buffer and undo/redo is a stack of lengths;

--- a/app/tool/perf/driver.mjs
+++ b/app/tool/perf/driver.mjs
@@ -209,6 +209,40 @@ function parse(lines, frames) {
 
 function fmt(n, d = 1) { return Number(n).toFixed(d); }
 
+// What the tab actually holds. performance.memory only sees the JS heap, and
+// decoded PDF images live in CanvasKit's wasm heap - so the number that matters
+// comes from measureUserAgentSpecificMemory(), which counts WASM and is why the
+// server sends COOP/COEP (it needs cross-origin isolation). Returns the agent
+// total plus the ceilings a tab is judged against.
+const MEMORY_PROBE = `(async () => {
+  const out = { deviceMemoryGb: navigator.deviceMemory ?? null };
+  // Chrome is launched with --expose-gc so the numbers below are retained
+  // memory, not whatever V8 had not got round to collecting.
+  if (window.gc) { window.gc(); await new Promise((r) => setTimeout(r, 500)); window.gc(); out.gc = true; }
+  const m = performance.memory;
+  if (m) {
+    out.jsHeapUsed = m.usedJSHeapSize;
+    out.jsHeapLimit = m.jsHeapSizeLimit;
+  }
+  if (window.__perfImageCacheBytes) out.imageCacheBytes = window.__perfImageCacheBytes();
+  if (performance.measureUserAgentSpecificMemory) {
+    try {
+      const r = await performance.measureUserAgentSpecificMemory();
+      out.agentBytes = r.bytes;
+      out.breakdown = r.breakdown
+        .filter((b) => b.bytes > 0)
+        .map((b) => ({ bytes: b.bytes, types: b.types }))
+        .sort((a, b) => b.bytes - a.bytes)
+        .slice(0, 6);
+    } catch (e) { out.measureError = String(e); }
+  } else {
+    out.measureError = 'measureUserAgentSpecificMemory unavailable (not cross-origin isolated?)';
+  }
+  return out;
+})()`;
+
+function mb(bytes) { return bytes == null ? '?' : `${(bytes / 1048576).toFixed(0)}MB`; }
+
 async function main() {
   if (!existsSync(WEB_DIR) || !existsSync(join(WEB_DIR, 'index.html'))) {
     console.error(`✗ no harness build at ${WEB_DIR} - run tool/perf/build.sh first`);
@@ -232,6 +266,7 @@ async function main() {
   if (process.env.PERF_PASSES) qp.set('passes', process.env.PERF_PASSES);
   if (process.env.PERF_FAST_PASS) qp.set('fast', process.env.PERF_FAST_PASS);
   if (process.env.PERF_TARGET_PAGE) qp.set('targetPage', process.env.PERF_TARGET_PAGE);
+  if (process.env.PERF_IMAGE_CACHE_MB) qp.set('imageCacheMb', process.env.PERF_IMAGE_CACHE_MB);
   const qs = qp.toString();
   const url = `http://127.0.0.1:${PORT}/${qs ? '?' + qs : ''}`;
   console.log(`▶ serving ${WEB_DIR} + /perf.pdf at ${url} (headless=${HEADLESS}, isolated=${ISOLATED})`);
@@ -239,7 +274,8 @@ async function main() {
   const browser = await puppeteer.launch({
     executablePath: CHROME,
     headless: HEADLESS ? 'shell' : false,
-    args: ['--no-sandbox', '--disable-dev-shm-usage', '--window-size=1400,1000'],
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--window-size=1400,1000',
+      '--js-flags=--expose-gc'],
     defaultViewport: { width: 1400, height: 1000 },
   });
 
@@ -275,6 +311,10 @@ async function main() {
     if (!done && !fatal) fatal = `timeout after ${TIMEOUT_S}s waiting for __perfDone`;
     if (pageErrors.length) (result ??= {}).pageErrors = pageErrors;
 
+    // Sample memory before scraping the trace, while the run's peak is still
+    // resident (the wasm heap never shrinks, so this is a high-water mark).
+    const memory = await page.evaluate(MEMORY_PROBE).catch((e) => ({ measureError: String(e) }));
+
     const harnessError = await page.evaluate('window.__perfError ?? null').catch(() => null);
     const dump = await page.evaluate('window.__perfDump ? window.__perfDump() : ""').catch(() => '');
     const framesJson = await page.evaluate('window.__perfFrames ? window.__perfFrames() : "[]"').catch(() => '[]');
@@ -283,7 +323,7 @@ async function main() {
     let frames = [];
     try { frames = JSON.parse(framesJson); } catch { /* ignore */ }
 
-    result = { ...(result ?? {}), harnessError, lines: lines.length, ...parse(lines, frames) };
+    result = { ...(result ?? {}), harnessError, memory, lines: lines.length, ...parse(lines, frames) };
     result.rawLineSample = lines.filter((l) => /interpret|webworker|vector-first|preview-paint|HARNESS|JANK|error/i.test(l)).slice(0, 60);
   } catch (e) {
     fatal = String(e?.stack ?? e);
@@ -317,6 +357,15 @@ async function main() {
     console.log(`  prerender warms    vector=${result.prerender.vector} full=${result.prerender.full}`);
     if (result.target?.firstContentMs != null) {
       console.log(`  target first paint page=${result.target.page} ${fmt(result.target.firstContentMs)}ms via ${result.target.kind}`);
+    }
+    const mem = result.memory;
+    if (mem && !mem.measureError) {
+      console.log(`  tab memory         agent=${mb(mem.agentBytes)} imageCache=${mb(mem.imageCacheBytes)} jsHeap=${mb(mem.jsHeapUsed)}/${mb(mem.jsHeapLimit)} deviceMemory=${mem.deviceMemoryGb ?? '?'}GB`);
+      for (const b of mem.breakdown ?? []) {
+        console.log(`      ${mb(b.bytes).padStart(7)}  ${b.types.join(', ')}`);
+      }
+    } else if (mem?.measureError) {
+      console.log(`  tab memory         unavailable: ${mem.measureError}`);
     }
     console.log(`  frames             ${f.count}  buildP50=${fmt(f.buildP50)}ms p95=${fmt(f.buildP95)}ms max=${fmt(f.buildMax)}ms`);
     console.log(`  build over budget  >16ms=${f.buildOver16}  >32ms=${f.buildOver32}  >50ms=${f.buildOver50}   (PdfPerfLog JANK lines=${result.jankCount})`);

--- a/app/tool/perf/perf_harness.dart
+++ b/app/tool/perf/perf_harness.dart
@@ -60,6 +60,10 @@ final bool _fastPass = _qBool(
     'fast', const bool.fromEnvironment('PERF_FAST_PASS', defaultValue: true));
 final int _targetPage = _qInt('targetPage', -1);
 
+/// Decoded-image cache budget, MB. 0 leaves the platform default in place; the
+/// driver sweeps it to measure what each budget costs a real tab (issue #281).
+final int _imageCacheMb = _qInt('imageCacheMb', 0);
+
 // ---------------------------------------------------------------------------
 // Capture: every debugPrint line + every frame's timing.
 // ---------------------------------------------------------------------------
@@ -123,6 +127,15 @@ void main() {
   final isolated =
       (globalContext['crossOriginIsolated'] as JSBoolean?)?.toDart ?? false;
   _record('[perf] HARNESS crossOriginIsolated=$isolated');
+  if (_imageCacheMb > 0) {
+    PdfImageCache.instance.maxBytes = _imageCacheMb * 1024 * 1024;
+  }
+  _record('[perf] HARNESS imageCacheBudget='
+      '${PdfImageCache.instance.maxBytes ~/ (1024 * 1024)}MB');
+  // The driver samples this alongside the tab's memory, so a run can show the
+  // cache's own occupancy against the agent total it drives.
+  _setGlobal(
+      '__perfImageCacheBytes', (() => PdfImageCache.instance.bytes).toJS);
 
   // Expose the driver's read surface up front (so a poll never races startup).
   _setGlobal('__perfDone', false.toJS);

--- a/doc/dev-log/2026-07-16-image-cache-budget.md
+++ b/doc/dev-log/2026-07-16-image-cache-budget.md
@@ -1,0 +1,167 @@
+# Tuning the decoded-image cache budget (issue #281)
+
+`PdfImageCache.instance` was a flat `256 * 1024 * 1024` on every platform, a
+number nobody had ever measured. This session measured it on native and web,
+then replaced the constant with a platform-aware default and wired the
+memory-pressure signal the class doc had been claiming for months.
+
+## The mental model the numbers argue for
+
+**The budget is a ceiling, not a reservation.** A document whose images decode
+to 40 MB costs 40 MB under any budget. Raising the budget only changes
+behaviour for documents that *exceed* it - and for those, the cache only pays
+off when it can hold the *whole* working set. LRU under a linear scan is the
+pathological case: each pass evicts exactly what the next pass wants. So a
+budget that lands *between* "fits the document" and "small" is the worst place
+to be - it costs RSS proportional to itself and buys almost nothing.
+
+That reframes the whole question. Don't ask "how much memory can we afford?";
+ask "how big is a document we want to hold outright?"
+
+## What was measured
+
+Harness: `packages/dart_pdf_editor/test/benchmark_image_cache_budget_test.dart`
+(two tests, both skipped unless their env var is set - not CI).
+
+### Corpus footprint - the number that picks the budget
+
+`PDF_FOOTPRINT_DIR=../../corpus`, 49 real-world PDFs, decoded footprint of the
+first 40 pages of each:
+
+| budget | documents held whole |
+|--------|----------------------|
+| 16 MB  | 33/49 (67%) |
+| 32 MB  | 37/49 (76%) |
+| 64 MB  | 43/49 (88%) |
+| 128 MB | 46/49 (94%) |
+| 256 MB | 47/49 (96%) |
+| 512 MB | 47/49 (96%) |
+
+The curve is flat past 128 MB: 256 MB buys exactly one more document, and past
+that the only documents left are `Combined Design Pack.pdf` (1881 MB of RGBA)
+and `ly9-far-cad.pdf` (1183 MB), which no sane budget holds.
+
+### Budget sweep on the ticket's document
+
+The reader-reported file (`8100_Time_Without_Tide_Quickstart.pdf`, 62 pages,
+24 MB, **436 MB** of decoded RGBA across 314 unique images) - so every budget
+below is pegged and evicting. `PDF_BENCHMARK_PDF=...`, rendered at 1x:
+
+Reading straight through (one pass):
+
+| budget | hit rate | decodes | render | RSS after |
+|--------|----------|---------|--------|-----------|
+| 16 MB  | 0.0%  | 742 | 249 ms/pg | 493 MB |
+| 64 MB  | 34.1% | 489 | 180 ms/pg | 512 MB |
+| 128 MB | 51.6% | 359 | 147 ms/pg | 581 MB |
+| 256 MB | 57.4% | 316 | 145 ms/pg | 679 MB |
+| 512 MB | 57.7% | 314 | 156 ms/pg | 658 MB |
+
+**128 → 256 MB buys 2 ms/page and costs ~100 MB of RSS.** (The ticket's
+"282 MB / 247 images" differs from 436 MB / 314 because that figure came from
+the app, where the worker caps images to display resolution; this sweep decodes
+at full resolution.)
+
+Re-reading (3 passes - where a fitting cache should pay):
+
+| budget | hit rate | decodes | render | RSS after |
+|--------|----------|---------|--------|-----------|
+| 64 MB  | 34.5% | 1459 | 205 ms/pg | 500 MB |
+| 128 MB | 52.2% | 1065 | 164 ms/pg | 490 MB |
+| 256 MB | 58.8% | 916  | 149 ms/pg | 654 MB |
+| 512 MB | 85.9% | 314  | 113 ms/pg | 891 MB |
+
+512 MB holds the document whole: **314 decodes across 3 passes - zero
+re-decodes**. That is the cliff. 256 MB, stuck mid-cliff, gets a fifth of the
+benefit for a quarter of the memory.
+
+### Web: the ticket's hypothesis was wrong
+
+The ticket suspected the budget was sharper on web ("a tab OOM under this
+budget is plausible but unmeasured"). Measured, it is not the cache.
+
+Driver: `app/tool/perf/driver.mjs` now probes
+`performance.measureUserAgentSpecificMemory()` (the only API that counts
+CanvasKit's wasm heap, not just the JS heap - it needs cross-origin isolation,
+which the server already sends) and Chrome runs with `--expose-gc` so the
+figures are retained memory, not uncollected garbage. `PERF_IMAGE_CACHE_MB`
+sweeps the budget via a URL param.
+
+62-page scroll of the same document, tab memory by budget:
+
+| budget | agent memory | image cache |
+|--------|--------------|-------------|
+| 32 MB  | 2136 MB | 25 MB |
+| 64 MB  | 2136 MB | 62 MB |
+| 128 MB | 2138 MB | 122 MB |
+| 256 MB | 2328 MB | 191 MB |
+| 512 MB | 2238 MB | 184 MB |
+
+The budget barely moves the total. What does move it is **pages scrolled** -
+at a fixed 64 MB budget: 10 pages → 1122 MB, 20 → 1465 MB, 40 → 1972 MB,
+62 → 2286 MB, while the cache stays pinned at ~60 MB. Controls: a 1-page
+render of the same document is 370 MB, and a tiny PDF is 128 MB, so the probe
+does respond.
+
+So a tab does approach its ceiling (2.3 GB against a ~4.2 GB
+`jsHeapSizeLimit`), but the image cache is ~3% of it. **Filed as #283** -
+~20 MB/page of per-page retention on web. The budget is not the lever there.
+
+## What shipped
+
+`pdfDefaultImageCacheBytes()` in `performance_policy.dart` (next to the
+platform detection that was already there; `PdfPerformanceEnvironment.detect`
+now shares the new `detectedPdfPerformancePlatform` instead of a second copy of
+the same switch):
+
+- **desktop 256 MB** - unchanged, but now defended: holds 96% of the corpus
+  whole, and ~700 MB RSS is affordable where a machine has tens of GB.
+- **mobile 128 MB** - still holds 94% outright; on documents it cannot hold,
+  the ~100 MB it returns matters under an iOS jetsam limit far more than
+  2 ms/page does.
+- **web 128 MB**, dropping to **64 MB** when `navigator.deviceMemory` <= 2 GB.
+- **other 128 MB**.
+
+`maxBytes` is now settable (trims immediately) so a host that has profiled its
+own documents can override at startup; `bytes` is public occupancy (it pairs
+with the public budget, and the perf harness needs it from another package).
+
+### Two `navigator.deviceMemory` traps, both verified in Chrome 141
+
+Read defensively in `performance_memory_web.dart`:
+
+- It only exists in a **secure context**, and only in Chromium - Firefox and
+  Safari have never shipped it. `package:web` types it as a non-nullable
+  `double`, so reading it blind on a plain-http page hands back a bogus value
+  instead of null. The code probes for the property first.
+- **The widely-cited "clamped to 8" is out of date**: a 16 GB host reports
+  `16`. Don't read 8 as the maximum.
+
+There is no total-RAM API on the VM side (`dart:io` gives you your own RSS,
+not the machine's), so native falls back to the platform tier - which is the
+distinction that matters anyway.
+
+### Memory pressure
+
+`_PdfViewerState` is now a `WidgetsBindingObserver` and implements
+`didHaveMemoryPressure` (iOS/Android only; the web never sends it): it clears
+`PdfImageCache.instance` and its own `_previews`. Every cache here hands out
+clones, so dropping masters cannot pull pixels from a painting picture, and
+on-screen pages keep their retained scenes. Several viewers mounted at once
+each clear the process-wide cache - the second call is a no-op. The observer is
+removed in `dispose`, and there is a test for exactly that (an unmounted viewer
+that still answered pressure would be a leak).
+
+Left alone deliberately: `PdfThumbnailCache` (256 entries, no byte budget) -
+its tiles are on screen, so clearing them under pressure is churn, not relief.
+
+## Gotchas for next time
+
+- `ui.decodeImageFromPixels` never completes inside `testWidgets`' fake-async
+  zone. Any cache test that builds a real `ui.Image` under `testWidgets` must
+  wrap it in `tester.runAsync` or the test hangs with no output at all.
+- Under `flutter_test` the platform reports as **mobile** (android), so the
+  default budget in tests is 128 MB, not the desktop 256 MB.
+- The budget benchmark warms every lazy structure with an unbounded pass before
+  measuring, so the sweeps differ only in their budget - without it the first
+  budget measured wears the font/xref warm-up cost.

--- a/packages/dart_pdf_editor/lib/src/image_decoder.dart
+++ b/packages/dart_pdf_editor/lib/src/image_decoder.dart
@@ -7,6 +7,8 @@ import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
+import 'performance_policy.dart';
+
 /// Map key for a decoded image. Image XObjects key by stream identity -
 /// the xref cache hands back the same [CosStream] on every interpretation
 /// pass. Inline images are re-synthesized each pass, so they key by value
@@ -96,27 +98,50 @@ class PdfInlineImageKey {
 /// is by total decoded bytes ([maxBytes]), oldest-touched first, not by a
 /// flat entry count.
 class PdfImageCache {
-  PdfImageCache({this.maxBytes = 256 * 1024 * 1024});
+  /// A cache holding at most [maxBytes] of decoded pixels, defaulting to the
+  /// budget this platform can afford ([pdfDefaultImageCacheBytes]).
+  PdfImageCache({int? maxBytes})
+      : _maxBytes = maxBytes ?? pdfDefaultImageCacheBytes();
 
   /// The shared cache every render path consults by default.
+  ///
+  /// A host that knows better than the platform default - it has profiled its
+  /// own documents, or it is sharing a process with something hungrier - can
+  /// say so at startup:
+  ///
+  /// ```dart
+  /// PdfImageCache.instance.maxBytes = 64 * 1024 * 1024;
+  /// ```
   static final PdfImageCache instance = PdfImageCache();
 
   /// Eviction budget: the cache holds at most this many bytes of decoded
   /// pixels (estimated as width × height × 4), evicting the least-recently
-  /// used master first.
-  final int maxBytes;
+  /// used master first. Lowering it trims to the new budget at once.
+  int get maxBytes => _maxBytes;
+  set maxBytes(int value) {
+    _maxBytes = value;
+    _trim();
+  }
+
+  int _maxBytes;
 
   // LinkedHashMap insertion order is the LRU order: a hit re-inserts to the
   // back, eviction takes the front.
   final _entries = <Object, _CachedImage>{};
   int _bytes = 0;
   bool _disposed = false;
+  int _hits = 0;
+  int _misses = 0;
 
   /// A clone of the cached image for [key] (the caller owns and disposes
   /// it), or null on a miss. Counts as a use for LRU ordering.
   ui.Image? take(Object key) {
     final entry = _entries.remove(key);
-    if (entry == null) return null;
+    if (entry == null) {
+      _misses++;
+      return null;
+    }
+    _hits++;
     _entries[key] = entry; // touch
     return entry.image.clone();
   }
@@ -130,13 +155,17 @@ class PdfImageCache {
     final entry = _CachedImage(master);
     _entries[key] = entry;
     _bytes += entry.bytes;
-    // Keep at least the just-added entry even if it alone exceeds the
-    // budget - it is still useful for this render's clones; it ages out on
-    // the next insert.
-    while (_bytes > maxBytes && _entries.length > 1) {
+    _trim();
+    return master.clone();
+  }
+
+  // Keep at least the most-recently-used entry even if it alone exceeds the
+  // budget - it is still useful for this render's clones; it ages out on the
+  // next insert.
+  void _trim() {
+    while (_bytes > _maxBytes && _entries.length > 1) {
       _entries.remove(_entries.keys.first)!.dispose(this);
     }
-    return master.clone();
   }
 
   /// Drops the cached master for [key] (e.g. an image whose stream changed).
@@ -157,13 +186,31 @@ class PdfImageCache {
     clear();
   }
 
+  /// Estimated bytes of decoded pixels held right now, against [maxBytes].
+  ///
+  /// Occupancy, not a reservation: a document whose images fit well under the
+  /// budget only ever costs what it uses.
+  int get bytes => _bytes;
+
   /// Number of cached masters - for tests.
   @visibleForTesting
   int get debugLength => _entries.length;
 
-  /// Estimated cached bytes - for tests.
+  /// Lookups served from cached pixels - for tests and the budget benchmark.
   @visibleForTesting
-  int get debugBytes => _bytes;
+  int get debugHits => _hits;
+
+  /// Lookups that had to decode - for tests and the budget benchmark.
+  @visibleForTesting
+  int get debugMisses => _misses;
+
+  /// Zeroes the hit/miss counters (they survive [clear], which is a cache
+  /// operation, not a new measurement).
+  @visibleForTesting
+  void debugResetCounters() {
+    _hits = 0;
+    _misses = 0;
+  }
 }
 
 class _CachedImage {

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -24,6 +24,7 @@ import 'editing/text_prompt.dart';
 import 'editing/text_style_prompt.dart';
 import 'editing/tool_shortcuts.dart';
 import 'exact_extent_list.dart';
+import 'image_decoder.dart';
 import 'page_geometry.dart';
 import 'perf_log.dart';
 import 'performance_policy.dart';
@@ -825,7 +826,8 @@ class PdfViewer extends StatefulWidget {
   State<PdfViewer> createState() => _PdfViewerState();
 }
 
-class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
+class _PdfViewerState extends State<PdfViewer>
+    with TickerProviderStateMixin, WidgetsBindingObserver {
   static const int _jumpPreviewOperationLimit = 2000;
 
   late PdfViewerController _controller;
@@ -1139,9 +1141,29 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
         setState(() => _zoomModifierDown = false);
       }
     });
+    WidgetsBinding.instance.addObserver(this); // for didHaveMemoryPressure
     // background preview prerender starts once the first frame (and the
     // scroll metrics the priority order needs) exists
     WidgetsBinding.instance.addPostFrameCallback((_) => _prerenderPreviews());
+  }
+
+  /// The platform is short of memory (iOS/Android send this; the web never
+  /// does). Drop the decoded pixels we are holding purely to make a later
+  /// render fast - they are all reconstructible, and being killed is slower
+  /// than any re-decode.
+  ///
+  /// Every cache here hands out clones, so dropping the masters cannot pull
+  /// pixels out from under a picture that is still painting; the on-screen
+  /// pages keep their own retained scenes and are unaffected. Several viewers
+  /// mounted at once each clear the process-wide image cache - the second call
+  /// is a no-op.
+  @override
+  void didHaveMemoryPressure() {
+    PdfPerfLog.log(
+        'memory-pressure clearing imageCache='
+        '${PdfImageCache.instance.bytes >> 20}MB');
+    PdfImageCache.instance.clear();
+    _previews.clear();
   }
 
   void _onPerformanceChanged() {
@@ -1901,6 +1923,7 @@ class _PdfViewerState extends State<PdfViewer> with TickerProviderStateMixin {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     widget.performance?.removeListener(_onPerformanceChanged);
     if (widget.performance != null) {
       SchedulerBinding.instance.removeTimingsCallback(_onPerformanceTimings);

--- a/packages/dart_pdf_editor/lib/src/performance_memory.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_memory.dart
@@ -1,0 +1,3 @@
+export 'performance_memory_stub.dart'
+    if (dart.library.io) 'performance_memory_io.dart'
+    if (dart.library.js_interop) 'performance_memory_web.dart';

--- a/packages/dart_pdf_editor/lib/src/performance_memory_io.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_memory_io.dart
@@ -1,0 +1,9 @@
+/// Device RAM in GB - unavailable on the Dart VM.
+///
+/// `dart:io` exposes the process's own footprint ([ProcessInfo.currentRss],
+/// [ProcessInfo.maxRss]) but no total-physical-memory API, and reading one out
+/// of `sysctl`/`/proc` would mean spawning a process during cache setup on
+/// platforms that each spell it differently. Native callers fall back to the
+/// platform tier instead (a phone and a desktop want different budgets far
+/// more than two desktops do).
+double? get detectedPdfDeviceMemoryGb => null;

--- a/packages/dart_pdf_editor/lib/src/performance_memory_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_memory_stub.dart
@@ -1,0 +1,3 @@
+/// Device RAM in GB, when the platform reports it. Null everywhere but the
+/// web - see performance_memory_io.dart for why.
+double? get detectedPdfDeviceMemoryGb => null;

--- a/packages/dart_pdf_editor/lib/src/performance_memory_web.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_memory_web.dart
@@ -1,0 +1,26 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:web/web.dart' as web;
+
+/// Device RAM in GB from `navigator.deviceMemory`, or null where the browser
+/// will not say.
+///
+/// Two traps this reads defensively around, both verified in Chrome 141:
+///
+/// - The property only exists in a **secure context** (and only in Chromium -
+///   Firefox and Safari have not shipped the Device Memory API at all), so a
+///   page served over plain http sees `undefined`. `package:web` types it as a
+///   non-nullable `double`, which would hand back a bogus value rather than
+///   null, so this probes for the property before reading it.
+/// - The spec says the value is clamped to a power of two in [0.25, 8], but
+///   Chrome now reports the real figure - a 16 GB host measures 16. Callers
+///   must not read 8 as "the maximum".
+double? get detectedPdfDeviceMemoryGb {
+  final navigator = web.window.navigator as JSObject;
+  if (!navigator.has('deviceMemory')) return null;
+  final value = navigator.getProperty<JSAny?>('deviceMemory'.toJS);
+  if (value == null || !value.isA<JSNumber>()) return null;
+  final gb = (value as JSNumber).toDartDouble;
+  return gb.isFinite && gb > 0 ? gb : null;
+}

--- a/packages/dart_pdf_editor/lib/src/performance_policy.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_policy.dart
@@ -2,10 +2,86 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 
+import 'performance_memory.dart';
 import 'performance_processors.dart';
 
 /// Coarse runtime family used by the adaptive render policy.
 enum PdfPerformancePlatform { mobile, desktop, web, other }
+
+/// The current runtime family, however the platform will admit to it.
+PdfPerformancePlatform get detectedPdfPerformancePlatform => kIsWeb
+    ? PdfPerformancePlatform.web
+    : switch (defaultTargetPlatform) {
+        TargetPlatform.android ||
+        TargetPlatform.iOS ||
+        TargetPlatform.fuchsia =>
+          PdfPerformancePlatform.mobile,
+        TargetPlatform.linux ||
+        TargetPlatform.macOS ||
+        TargetPlatform.windows =>
+          PdfPerformancePlatform.desktop,
+      };
+
+/// The default byte budget for the process-wide decoded-image cache
+/// ([PdfImageCache]) on this platform.
+///
+/// ## What the budget actually buys
+///
+/// The budget is a ceiling, not a reservation: a document whose images decode
+/// to 40 MB costs 40 MB under any budget. Raising it only changes behaviour for
+/// documents that *exceed* it - and for those, measurements (issue #281) say a
+/// budget short of the whole working set buys very little, because the cache
+/// only pays off when it can hold everything a reader revisits:
+///
+/// - Decoded footprint of a 49-document real-world corpus: 88% fit in 64 MB,
+///   94% in 128 MB, 96% in 256 MB. Beyond that the curve is flat - the only
+///   documents left are a 1.2 GB and a 1.9 GB CAD drawing, which no sane budget
+///   holds.
+/// - On a 62-page print PDF whose images decode to 436 MB (so every budget
+///   below is pegged and evicting), reading straight through: 64 MB → 180
+///   ms/page, 128 MB → 147, 256 MB → 145. The last doubling buys 2 ms/page and
+///   costs ~100 MB of RSS. Re-reading the same pages, where a fitting cache
+///   would pay off, 256 MB → 149 ms/page against 128 MB's 164 - real, but only
+///   a fifth of what actually holding the document (512 MB → 113 ms/page)
+///   would give.
+///
+/// So the budget is sized to hold the *common* document outright, and is only
+/// raised past that where the memory is genuinely free.
+///
+/// ## Why the platforms differ
+///
+/// - **Desktop** keeps 256 MB: it covers 96% of the corpus whole, and ~700 MB
+///   of RSS on a pathological document is affordable where a machine has tens
+///   of GB.
+/// - **Mobile** takes 128 MB: it still covers 94% of documents outright, and on
+///   the documents it cannot hold, the ~100 MB it gives back matters under an
+///   iOS jetsam limit far more than 2 ms/page does.
+/// - **Web** takes 128 MB, less on a small device. A tab is the tightest target
+///   (Chrome caps the JS heap near 4 GB) and CanvasKit's wasm heap, where
+///   decoded pixels live, never shrinks back. Notably this budget is *not* what
+///   pressures a tab: measured over a 62-page scroll, tab memory ran to ~2.3 GB
+///   whatever the budget, of which the image cache was ~60-200 MB - the rest is
+///   per-page retention (issue #283). 128 MB is cheap insurance under a
+///   ceiling that other retention is already spending, not a fix for it.
+int pdfDefaultImageCacheBytes({
+  PdfPerformancePlatform? platform,
+  double? deviceMemoryGb,
+}) {
+  const mb = 1024 * 1024;
+  final family = platform ?? detectedPdfPerformancePlatform;
+  final ram = deviceMemoryGb ?? detectedPdfDeviceMemoryGb;
+  return switch (family) {
+    PdfPerformancePlatform.desktop => 256 * mb,
+    PdfPerformancePlatform.mobile => 128 * mb,
+    // Only Chromium reports deviceMemory, and only over a secure context, so
+    // the constant is the common case rather than the fallback. A device that
+    // admits to 2 GB or less is a phone browser, where the tab's ceiling is
+    // lower than the desktop's by more than this budget is wide.
+    PdfPerformancePlatform.web =>
+      ram != null && ram <= 2 ? 64 * mb : 128 * mb,
+    PdfPerformancePlatform.other => 128 * mb,
+  };
+}
 
 /// The current auto-policy posture. Exposed in diagnostics and tests.
 enum PdfPerformanceTier { conservative, balanced, throughput }
@@ -61,20 +137,8 @@ class PdfPerformanceEnvironment {
     required int pageCount,
     required int documentBytes,
   }) {
-    final platform = kIsWeb
-        ? PdfPerformancePlatform.web
-        : switch (defaultTargetPlatform) {
-            TargetPlatform.android ||
-            TargetPlatform.iOS ||
-            TargetPlatform.fuchsia =>
-              PdfPerformancePlatform.mobile,
-            TargetPlatform.linux ||
-            TargetPlatform.macOS ||
-            TargetPlatform.windows =>
-              PdfPerformancePlatform.desktop,
-          };
     return PdfPerformanceEnvironment(
-      platform: platform,
+      platform: detectedPdfPerformancePlatform,
       logicalProcessors: detectedPdfLogicalProcessors,
       pageCount: pageCount,
       documentBytes: documentBytes,

--- a/packages/dart_pdf_editor/test/benchmark_image_cache_budget_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_image_cache_budget_test.dart
@@ -1,0 +1,197 @@
+// Characterises the decoded-image cache budget (PdfImageCache.maxBytes) on a
+// real document: for each candidate budget, renders every page in reading
+// order (the scroll a reader actually performs) and reports the cache's hit
+// rate, the re-decode work the budget costs, and the process RSS it buys.
+//
+// The point is to put a number on the trade the budget makes - a bigger cache
+// only pays for itself when the document's working set fits it, and RSS is the
+// price. Not a CI test: skipped unless PDF_BENCHMARK_PDF is set.
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_PDF=/path/to/doc.pdf fvm flutter test \
+//     test/benchmark_image_cache_budget_test.dart
+//
+//   PDF_BENCHMARK_BUDGETS=32,64,128,256,512   # MB, in sweep order
+//   PDF_BENCHMARK_SCALE=1                     # raster pixel ratio
+//   PDF_BENCHMARK_PASSES=1                    # sweeps of the document
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+void main() {
+  _footprintTest();
+
+  final path = Platform.environment['PDF_BENCHMARK_PDF'];
+  final scale =
+      double.tryParse(Platform.environment['PDF_BENCHMARK_SCALE'] ?? '') ?? 1.0;
+  final passes =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_PASSES'] ?? '') ?? 1;
+  final budgetsMb = (Platform.environment['PDF_BENCHMARK_BUDGETS'] ??
+          '16,32,64,128,256,512')
+      .split(',')
+      .map((s) => int.parse(s.trim()))
+      .toList();
+
+  testWidgets('image cache budget sweep', (tester) async {
+    if (path == null) {
+      markTestSkipped('set PDF_BENCHMARK_PDF');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final bytes = File(path).readAsBytesSync();
+      final doc = PdfDocument.open(bytes);
+      final cache = PdfImageCache.instance;
+
+      // The unique decoded footprint of the document: every image, decoded
+      // once, with eviction effectively off. Also warms every lazy structure
+      // (fonts, xref, glyph atlases) so the measured sweeps below differ only
+      // in their cache budget.
+      cache
+        ..clear()
+        ..maxBytes = 1 << 62;
+      var uniqueImages = 0, uniqueBytes = 0;
+      for (var i = 0; i < doc.pageCount; i++) {
+        await _renderPage(doc.page(i), scale);
+        uniqueImages = cache.debugLength;
+        uniqueBytes = cache.bytes;
+      }
+      final baselineRss = ProcessInfo.currentRss;
+
+      _line('');
+      _line('=== image cache budget sweep ===');
+      _line('  document:   ${path.split('/').last}');
+      _line('  pages:      ${doc.pageCount}  (${_mb(bytes.length)} on disk, '
+          'rendered at ${scale}x, $passes pass(es))');
+      _line('  unique decoded images: $uniqueImages  '
+          '(${_mb(uniqueBytes)} of RGBA)');
+      _line('  RSS after an unbounded sweep: ${_mb(baselineRss)} '
+          '(peak ${_mb(ProcessInfo.maxRss)})');
+      _line('');
+      _line('  budget    hit rate    decodes    render    RSS after    '
+          'peak cache');
+      _line('  ${'-' * 62}');
+
+      for (final mb in budgetsMb) {
+        cache
+          ..clear()
+          ..maxBytes = mb * 1024 * 1024
+          ..debugResetCounters();
+        var peakCache = 0;
+        final sw = Stopwatch()..start();
+        for (var pass = 0; pass < passes; pass++) {
+          for (var i = 0; i < doc.pageCount; i++) {
+            await _renderPage(doc.page(i), scale);
+            if (cache.bytes > peakCache) peakCache = cache.bytes;
+          }
+        }
+        final elapsed = sw.elapsedMilliseconds;
+        final lookups = cache.debugHits + cache.debugMisses;
+        final hitRate = lookups == 0 ? 0.0 : cache.debugHits / lookups * 100;
+        _line('  ${_pad('${mb}M', 8)}'
+            '${_pad('${hitRate.toStringAsFixed(1)}%', 12)}'
+            '${_pad('${cache.debugMisses}', 11)}'
+            '${_pad('${(elapsed / (doc.pageCount * passes)).toStringAsFixed(1)}'
+                ' ms/pg', 10)}'
+            '${_pad(_mb(ProcessInfo.currentRss), 13)}'
+            '${_mb(peakCache)}');
+      }
+      cache.clear();
+      _line('');
+    });
+  }, timeout: const Timeout(Duration(minutes: 90)));
+}
+
+/// What the budget has to hold: the decoded footprint of every document in a
+/// corpus. A budget only earns its RSS on documents whose whole working set
+/// fits under it (see the sweep above - a budget that lands short of the
+/// footprint pays for evictions and buys little), so the distribution of real
+/// documents' footprints is what picks the number.
+///
+///   PDF_FOOTPRINT_DIR=../../corpus fvm flutter test \
+///     test/benchmark_image_cache_budget_test.dart
+void _footprintTest() {
+  final dir = Platform.environment['PDF_FOOTPRINT_DIR'];
+  final maxPages =
+      int.tryParse(Platform.environment['PDF_FOOTPRINT_MAX_PAGES'] ?? '') ?? 40;
+
+  testWidgets('decoded image footprint across a corpus', (tester) async {
+    if (dir == null) {
+      markTestSkipped('set PDF_FOOTPRINT_DIR');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final files = Directory(dir)
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+      final cache = PdfImageCache.instance;
+      final footprints = <String, int>{};
+      for (final file in files) {
+        PdfDocument doc;
+        try {
+          doc = PdfDocument.open(file.readAsBytesSync());
+        } catch (_) {
+          continue;
+        }
+        cache
+          ..clear()
+          ..maxBytes = 1 << 62;
+        final limit =
+            maxPages <= 0 ? doc.pageCount : math.min(doc.pageCount, maxPages);
+        for (var i = 0; i < limit; i++) {
+          try {
+            // renderPicture runs the decodes; rasterizing adds nothing to the
+            // footprint and would dominate the run.
+            (await PdfPageRenderer.renderPicture(doc.page(i))).dispose();
+          } catch (_) {}
+        }
+        footprints[file.uri.pathSegments.last] = cache.bytes;
+      }
+      cache
+        ..clear()
+        ..maxBytes = pdfDefaultImageCacheBytes();
+
+      final sorted = footprints.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value));
+      _line('');
+      _line('=== decoded image footprint (${sorted.length} documents, '
+          'first $maxPages pages each) ===');
+      for (final e in sorted.take(12)) {
+        _line('  ${_pad(_mb(e.value), 10)}${e.key}');
+      }
+      _line('  ...');
+      _line('');
+      _line('  documents fitting a budget of:');
+      for (final mb in const [16, 32, 64, 128, 256, 512]) {
+        final fit =
+            sorted.where((e) => e.value <= mb * 1024 * 1024).length;
+        _line('    ${_pad('${mb}M', 8)}$fit/${sorted.length}  '
+            '(${(fit / sorted.length * 100).toStringAsFixed(0)}%)');
+      }
+      _line('');
+    });
+  }, timeout: const Timeout(Duration(minutes: 90)));
+}
+
+Future<void> _renderPage(PdfPage page, double scale) async {
+  final picture = await PdfPageRenderer.renderPicture(page);
+  final image = await PdfPageRenderer.rasterize(
+      picture, PdfPageRenderer.pageSize(page), scale);
+  image.dispose();
+  picture.dispose();
+}
+
+String _mb(int bytes) => '${(bytes / 1024 / 1024).toStringAsFixed(0)} MB';
+String _pad(String s, int width) => s.padRight(width);
+// ignore: avoid_print
+void _line(String s) => print(s);

--- a/packages/dart_pdf_editor/test/image_cache_budget_test.dart
+++ b/packages/dart_pdf_editor/test/image_cache_budget_test.dart
@@ -1,0 +1,165 @@
+// The decoded-image cache budget: the platform-aware default
+// (pdfDefaultImageCacheBytes), the live maxBytes knob a host can set, and the
+// memory-pressure signal that drops the cache. See issue #281 - the numbers
+// below are the measured policy, so a change here should come with a re-run of
+// benchmark_image_cache_budget_test.dart, not just a new expectation.
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+const int _mb = 1024 * 1024;
+
+/// A 100x100 RGBA master, as the cache counts it (width * height * 4).
+const int _imageBytes = 100 * 100 * 4;
+
+Future<ui.Image> _solid() {
+  final px = Uint8List(_imageBytes);
+  for (var i = 3; i < px.length; i += 4) {
+    px[i] = 255;
+  }
+  final c = Completer<ui.Image>();
+  ui.decodeImageFromPixels(px, 100, 100, ui.PixelFormat.rgba8888, c.complete);
+  return c.future;
+}
+
+/// Decoding runs on the engine, which the fake-async zone inside [testWidgets]
+/// never pumps - the completer would hang forever without [WidgetTester.runAsync].
+Future<void> _putProbe(WidgetTester tester, PdfImageCache cache, Object key) =>
+    tester.runAsync(() async => cache.put(key, await _solid()));
+
+void main() {
+  group('platform default', () {
+    test('desktop keeps the 256 MB budget - RSS is cheap there', () {
+      expect(
+          pdfDefaultImageCacheBytes(
+              platform: PdfPerformancePlatform.desktop, deviceMemoryGb: 16),
+          256 * _mb);
+    });
+
+    test('mobile halves it, where an iOS jetsam limit makes RSS expensive', () {
+      expect(pdfDefaultImageCacheBytes(platform: PdfPerformancePlatform.mobile),
+          128 * _mb);
+    });
+
+    test('web takes the mobile budget under a tab ceiling', () {
+      expect(
+          pdfDefaultImageCacheBytes(
+              platform: PdfPerformancePlatform.web, deviceMemoryGb: 16),
+          128 * _mb);
+    });
+
+    test('a small-memory device browser drops to 64 MB', () {
+      expect(
+          pdfDefaultImageCacheBytes(
+              platform: PdfPerformancePlatform.web, deviceMemoryGb: 2),
+          64 * _mb);
+    });
+
+    test('web without a deviceMemory reading falls back to the constant', () {
+      // Firefox, Safari, and any insecure context report nothing at all.
+      expect(pdfDefaultImageCacheBytes(platform: PdfPerformancePlatform.web),
+          128 * _mb);
+    });
+
+    test('an unknown platform gets the conservative middle', () {
+      expect(pdfDefaultImageCacheBytes(platform: PdfPerformancePlatform.other),
+          128 * _mb);
+    });
+
+    test('every platform lands in a sane range', () {
+      for (final platform in PdfPerformancePlatform.values) {
+        final budget = pdfDefaultImageCacheBytes(platform: platform);
+        expect(budget, greaterThanOrEqualTo(64 * _mb), reason: '$platform');
+        expect(budget, lessThanOrEqualTo(256 * _mb), reason: '$platform');
+      }
+    });
+
+    test('a default-constructed cache adopts the platform budget', () {
+      expect(PdfImageCache().maxBytes, pdfDefaultImageCacheBytes());
+    });
+  });
+
+  group('maxBytes', () {
+    test('lowering it evicts down to the new budget at once', () async {
+      final cache = PdfImageCache(maxBytes: 5 * _imageBytes);
+      for (var i = 0; i < 4; i++) {
+        cache.put('k$i', await _solid());
+      }
+      expect(cache.debugLength, 4);
+      expect(cache.bytes, 4 * _imageBytes);
+
+      cache.maxBytes = 2 * _imageBytes;
+
+      expect(cache.maxBytes, 2 * _imageBytes);
+      expect(cache.bytes, 2 * _imageBytes);
+      expect(cache.debugLength, 2, reason: 'the oldest two evicted');
+      expect(cache.take('k0'), isNull);
+      expect(cache.take('k3'), isNotNull, reason: 'the newest survives');
+    });
+
+    test('raising it evicts nothing', () async {
+      final cache = PdfImageCache(maxBytes: _imageBytes);
+      cache.put('a', await _solid());
+      cache.maxBytes = 256 * _mb;
+      expect(cache.debugLength, 1);
+      expect(cache.bytes, _imageBytes);
+    });
+  });
+
+  testWidgets('memory pressure drops the decoded images', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(document: PdfDocument.open(buildMultiPagePdf(1))),
+      ),
+    ));
+    await tester.pump();
+
+    final cache = PdfImageCache.instance;
+    addTearDown(cache.clear);
+    await _putProbe(tester, cache, 'pressure-probe');
+    expect(cache.bytes, greaterThan(0));
+
+    await _sendMemoryPressure(tester);
+
+    expect(cache.debugLength, 0);
+    expect(cache.bytes, 0);
+  });
+
+  testWidgets('an unmounted viewer stops answering memory pressure',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(document: PdfDocument.open(buildMultiPagePdf(1))),
+      ),
+    ));
+    await tester.pump();
+    await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+    await tester.pump();
+
+    final cache = PdfImageCache.instance;
+    addTearDown(cache.clear);
+    await _putProbe(tester, cache, 'pressure-probe');
+
+    await _sendMemoryPressure(tester);
+
+    expect(cache.debugLength, 1,
+        reason: 'the disposed viewer must have removed its observer');
+  });
+}
+
+/// The platform's low-memory warning, as the engine delivers it.
+Future<void> _sendMemoryPressure(WidgetTester tester) async {
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    SystemChannels.system.name,
+    const JSONMessageCodec()
+        .encodeMessage(<String, dynamic>{'type': 'memoryPressure'}),
+    (_) {},
+  );
+  await tester.pump();
+}

--- a/packages/dart_pdf_editor/test/image_cache_test.dart
+++ b/packages/dart_pdf_editor/test/image_cache_test.dart
@@ -54,7 +54,7 @@ void main() {
     cache.put(a, await _solid(100, 100, 10)).dispose();
     cache.put(b, await _solid(100, 100, 20)).dispose();
     expect(cache.debugLength, 2);
-    expect(cache.debugBytes, 80000);
+    expect(cache.bytes, 80000);
 
     // Touch a so b is now the least-recently-used.
     cache.take(a)!.dispose();
@@ -85,7 +85,7 @@ void main() {
     expect(cache.debugLength, 2);
     cache.clear();
     expect(cache.debugLength, 0);
-    expect(cache.debugBytes, 0);
+    expect(cache.bytes, 0);
     cache.dispose();
   });
 


### PR DESCRIPTION
Closes #281.

`PdfImageCache.instance` was a flat 256 MB on every platform — a phone, a desktop, and a browser tab all got the same number, and, as the ticket says, it had never been measured against a real ceiling. So: measure first, then set it from the data.

## The reframe the data forces

**The budget is a ceiling, not a reservation.** A document whose images decode to 40 MB costs 40 MB under any budget. Raising it only changes behaviour for documents that *exceed* it — and for those, LRU under a linear read is the pathological case (each pass evicts exactly what the next wants). The cache only pays off once it holds the whole working set, so a budget stuck *between* "holds the document" and "small" is the worst place to be: RSS proportional to itself, almost nothing bought.

The question is therefore "how big is a document we want to hold outright?", not "how much memory can we afford?".

## What was measured

New harness: `packages/dart_pdf_editor/test/benchmark_image_cache_budget_test.dart` (two tests, skipped unless their env var is set — not CI).

**Corpus footprint** (49 real-world PDFs) — the number that picks the budget:

| budget | documents held whole |
|---|---|
| 64 MB | 43/49 (88%) |
| 128 MB | 46/49 (94%) |
| 256 MB | 47/49 (96%) |
| 512 MB | 47/49 (96%) |

Flat past 128 MB. 256 MB buys exactly one more document; beyond it the only ones left are a 1.2 GB and a 1.9 GB CAD drawing that no budget holds.

**The ticket's document** (62 pages, 24 MB, 436 MB of decoded RGBA — so every budget is pegged and evicting), read straight through:

| budget | hit rate | render | RSS after |
|---|---|---|---|
| 64 MB | 34.1% | 180 ms/pg | 512 MB |
| 128 MB | 51.6% | 147 ms/pg | 581 MB |
| 256 MB | 57.4% | 145 ms/pg | 679 MB |

**128 → 256 MB buys 2 ms/page and costs ~100 MB of RSS.** (Re-reading the document 3x, 256 MB does earn 15 ms/page over 128 MB — but that is a fifth of what actually *holding* the document at 512 MB gives, at a quarter of the memory. Mid-cliff is a bad place to be.)

**Web — the ticket's sharper question, answered: it is not the cache.** `driver.mjs` now probes `performance.measureUserAgentSpecificMemory()` (the only API that counts CanvasKit's wasm heap; it needs the cross-origin isolation the harness already sends), with Chrome on `--expose-gc` so the numbers are retained bytes. Over a 62-page scroll:

| budget | agent memory | image cache |
|---|---|---|
| 32 MB | 2136 MB | 25 MB |
| 128 MB | 2138 MB | 122 MB |
| 512 MB | 2238 MB | 184 MB |

The budget barely moves the total; **pages scrolled** does (10 → 1122 MB, 40 → 1972 MB, 62 → 2286 MB, cache flat at its budget throughout). A tab does approach its ~4.2 GB ceiling, but the image cache is ~3% of it. Filed separately as #283.

## What this changes

`pdfDefaultImageCacheBytes()` in `performance_policy.dart`, next to the platform detection already there:

- **desktop 256 MB** — unchanged, but defended now: holds 96% of the corpus whole, and RSS is cheap there.
- **mobile 128 MB** — still holds 94% outright; the ~100 MB returned matters under an iOS jetsam limit far more than 2 ms/page does.
- **web 128 MB**, → **64 MB** when `navigator.deviceMemory` <= 2 GB.
- **other 128 MB**.

`maxBytes` is settable (trims immediately) for hosts that have profiled their own documents; `bytes` exposes occupancy.

Two `navigator.deviceMemory` traps, verified in Chrome 141 and read defensively in `performance_memory_web.dart`: it exists **only in a secure context and only in Chromium** (`package:web` types it non-nullable, so a blind read hands back a bogus value instead of null), and **the widely-cited "clamped to 8" is out of date** — a 16 GB host reports `16`.

There is no total-RAM API on the VM side, so native falls back to the platform tier — the distinction that actually matters.

## Memory pressure

`_PdfViewerState` is now a `WidgetsBindingObserver` and implements `didHaveMemoryPressure` (iOS/Android; the web never sends it), clearing the image cache and its previews — the signal `PdfImageCache.clear()`'s own doc comment has cited for months with nothing calling it. Every cache hands out clones, so dropping masters can't pull pixels from a painting picture. The observer is removed on dispose, with a test for exactly that.

Left alone deliberately: `PdfThumbnailCache` — its tiles are on screen, so clearing them under pressure is churn, not relief.

## Verification

- `dart analyze` clean across the workspace.
- Full `dart_pdf_editor` suite: **1444 passing**, no regressions.
- New `test/image_cache_budget_test.dart` covers the policy per platform, the `maxBytes` trim, and pressure both mounted (clears) and unmounted (doesn't — the leak guard).
- Web path recompiled via `dart compile js` (app + worker), the build that VM tests can't catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018grS21dxf5DeaEYUrc722x