### PR TITLE
Free text: spacing/underline/width controls and editing fixes

### DIFF
--- a/doc/dev-log/2026-07-16-text-box-features-fixes.md
+++ b/doc/dev-log/2026-07-16-text-box-features-fixes.md
@@ -1,0 +1,114 @@
+# 2026-07-16 — Free-text box: styling features and editing fixes
+
+Branch `claude/text-box-features-fixes-3ad025`. A batch of free-text
+(FreeText annotation) reports from using the editor: four bugs and four
+new box styling controls. They share plumbing, so they landed together.
+
+## The appearance layer (pdf_document)
+
+`PdfFreeTextRun` grew a per-run `underline`. `_freeTextContent` and
+`_freeTextRichContent` (annotation_editor.dart) now take box-level
+`lineSpacing` (a leading multiplier), `charSpacing` (Tc, points) and
+`horizontalScale` (Tz, per cent), plus underline (per-box for the flat
+path, per-run for rich). New `ContentWriter.charSpacing`/`horizontalScale`
+emit `Tc`/`Tz`.
+
+Key detail: **advance width has to account for Tc and Tz** or wrapping and
+right/centre alignment drift. `_advanceWidth(font, text, size, charSpacing,
+horizontalScale)` returns `(natural + Tc*count) * hScale/100` and every
+wrap/align site goes through it (`_wrap`, `_wrapRich`, the per-line width).
+Td translations are *not* scaled by Tz (only the glyph-drawing matrix is),
+so the line-x math stays in unscaled text space and the advance already
+carries the Tz factor — consistent.
+
+Underline is a **filled rectangle drawn after `ET`** (path artwork can't sit
+inside a text object), collected during the line loop into `_UnderlineRun`s
+and flushed by `_drawUnderlines`, still inside the box clip.
+
+Persistence: these four have no standard PDF representation, so they ride
+vendor dictionary keys (`kPdfFreeText*Key` in annotation.dart —
+`LineSpacing`/`CharSpacing`/`HScale`/`TextUnderline`), written only when
+non-default (a plain box's dict is unchanged) and read back by
+`freeTextStyle`. Rich underline additionally rides `/RC`'s
+`text-decoration:underline` span style so per-run underline round-trips.
+
+## Bug 1 — backspace ate bold from the line below
+
+The inline editor's `_RichTextEditingController._ranges` were absolute
+UTF-16 offsets that never moved when text changed, so after a backspace a
+bold run kept its old numbers and appeared to slide one char per keystroke.
+Fix: override `set value`, diff old→new by common prefix/suffix, and remap
+every range (`_shiftRanges`). `seedRuns` sets `_remapRanges=false` while it
+assigns text+ranges together (they're already correct). Text inserted
+*inside* a run extends it; text in a replaced span collapses to the span
+start.
+
+## Bug 2 — resize stretched embedded-font (and rich) boxes
+
+`_resizeBehavior` only allowed `reflowText` when `standardTextFont != null`,
+so any box switched to a bundled/custom font fell to the §12.5.5 stretch.
+Added a cheap COS probe `hasEmbeddedTextFont` (Type0 + FontFile in the AP
+resources — no font-program parse) to the gate, and the regenerator now
+recovers the real face with `PdfEmbeddedFont.fromFreeText` and re-wraps in
+it. It also **preserves rich runs on resize** (`preserveRich`, true for
+resize, false for a colour restyle which still flattens) by regenerating
+through `_freeTextRichContent`.
+
+The live drag preview (`_textResizeStyle` → `_wrappedTextBox`) can only draw
+base-14 faces, so embedded boxes fall back to the stretch ghost *during the
+drag* — the commit still re-wraps correctly.
+
+## Bug 5 — alignment "reset to left" after a resize
+
+The committed appearance always kept `/Q` (the regenerator reads it), but
+the resize preview and post-commit afterimage (`_wrappedTextBox`, used for
+both) were hard-coded `TextAlign.start` / `topStart`, so a centred/right box
+visibly snapped left during the drag and only settled back once the raster
+caught up. Threaded the box alignment (and underline + line spacing) through
+`_textResizeStyle`, the `_afterText` record and `_wrappedTextBox`.
+`_textEditAlign` is nullable — null means "follow the text direction", which
+maps to `TextAlign.start` so RTL boxes still hug the right edge.
+
+## Bug 4 — font picker stuck on "Sans" after a font change
+
+The chip read `selectedTextStyle.font`, which only parses a base-14 face
+from `/DA`, so an embedded box read back Helvetica → "Sans". New
+`selectedTextFont` returns `_freeTextFontOf().font` (the recovered embedded
+face, else the standard one); the tune popup and properties panel use it.
+
+## Bug 8 — line spacing wrong in the popup until it closed
+
+The inline `TextField` took its line height from each run's own font, so
+changing a run's family nudged the lines until the font-independent PDF
+leading re-laid on commit. Pinned the preview with a `StrutStyle`
+(`forceStrutHeight: true`, size = the box's max run size, height =
+`lineSpacing`), matching the committed leading. The base style also carries
+`height`/`letterSpacing` now, and `buildTextSpan` threads
+`previewLineHeight`/`previewLetterSpacing` into each run.
+
+## New controls (features 3/6/7)
+
+Box-level line spacing, character spacing and font width sliders plus an
+underline toggle live in the tune popup and the properties panel. They set
+creation defaults (`controller.lineSpacing/charSpacing/fontWidth/
+textUnderline`, session-only — the font program-adjacent spacing isn't worth
+persisting) and, on a selected box, `setSelectedTextBoxStyle` regenerates it
+(preserving rich runs; whole-box underline maps onto every run). It **skips
+the rewrite while the inline editor is open** (would swap the document under
+the editor) — the change rides the creation defaults and lands at commit;
+`_onControllerChanged` mirrors the defaults into the live preview for a
+new box.
+
+Underline is a per-character format like bold: the inline style chip's
+underline button and Cmd/Ctrl+U toggle it on the selection (or the whole box
+when nothing is selected), so an underlined box commits as rich `/RC`.
+
+## Left open
+
+- Horizontal scaling (Tz) has no Flutter `TextField` equivalent, so it isn't
+  previewed live in the inline editor — it shows once the raster lands.
+- Mixed per-*line* font sizes over-space slightly in the strut-pinned
+  preview (single strut height); the committed rich appearance is exact.
+- Embedded-font resize previews use the stretch ghost during the drag (only
+  the commit re-wraps); a real embedded preview would need the registered
+  synthetic family the inline editor already loads.

--- a/doc/dev-log/2026-07-16-text-box-features-fixes.md
+++ b/doc/dev-log/2026-07-16-text-box-features-fixes.md
@@ -103,6 +103,27 @@ Underline is a per-character format like bold: the inline style chip's
 underline button and Cmd/Ctrl+U toggle it on the selection (or the whole box
 when nothing is selected), so an underlined box commits as rich `/RC`.
 
+## Follow-up — the chip deselected the box on mobile
+
+A tap on the inline style chip (underline, size, …) on touch devices blurred
+the `TextField`, and `_onTextEditFocus` treats any focus loss as a commit —
+so the box committed and deselected out from under the tap. Desktop was fine
+because the chip's `Focus(canRequestFocus:false, descendantsAreFocusable:
+false)` keeps the field focused; a mobile tap drops it anyway.
+
+Fix: wrap the chip in a `Listener` that begins the controller's
+`beginEditingTextFocusHold()` on pointer-down (the same hold the tune popup
+already uses, which `_onTextEditFocus` honours) and releases it on pointer-up.
+The release is deferred to a post-frame callback — pointer-up fires *before*
+the button's `onPressed`, so re-focusing synchronously there collapsed the
+selection before the style could apply. It's also cleared in `dispose` so the
+hold counter can't leak.
+
+Note this is not reproducible in `flutter_test`: a synthetic tap never blurs a
+non-focusable button, so the harness can't exercise the focus drop. The chip
+underline button's *action* is tested by invoking its handler directly (the
+scaled/translated chrome also makes a synthetic tap's hit-test unreliable).
+
 ## Left open
 
 - Horizontal scaling (Tz) has no Flutter `TextField` equivalent, so it isn't

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+- Free-text boxes: add line spacing, character spacing, font width
+  (horizontal scaling), and underline controls (tune popup + properties
+  panel), with an inline underline toggle and Cmd/Ctrl+U shortcut.
+- Fix backspacing in an inline free-text editor sliding a bold (or otherwise
+  styled) run onto the following characters — style runs now follow their
+  own text across edits.
+- Resize an embedded/bundled-font free-text box by re-wrapping it (as with
+  base-14 boxes) instead of stretching the glyphs, and keep rich per-run
+  styling across the resize.
+- Keep a free-text box's alignment in the resize preview and post-commit
+  afterimage so it no longer appears to snap to the left while dragging.
+- Show a free-text box's actual (embedded/bundled) font name in the font
+  picker instead of collapsing it to "Sans".
+- Stop the inline editor's line spacing shifting when a run's font changes
+  in the tune popup (font-independent leading, matching the appearance).
+
 ## 1.4.6
 
 - Expose edit-and-style and markup actions when text is selected in an

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -17,6 +17,8 @@
   picker instead of collapsing it to "Sans".
 - Stop the inline editor's line spacing shifting when a run's font changes
   in the tune popup (font-independent leading, matching the appearance).
+- Fix tapping a free-text style-chip button (underline, size, …) on touch
+  devices committing and deselecting the box out from under the tap.
 
 ## 1.4.6
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1146,6 +1146,51 @@ class PdfEditingController extends ChangeNotifier {
 
   set textAlign(PdfTextAlign? value) => preferences.textAlign = value;
 
+  double _lineSpacing = kPdfFreeTextDefaultLineSpacing;
+  double _charSpacing = 0;
+  double _fontWidth = kPdfFreeTextDefaultHorizontalScale;
+  bool _textUnderline = false;
+
+  /// The line-height multiplier new free-text boxes are created with
+  /// (baseline-to-baseline distance is `fontSize * lineSpacing`). Session
+  /// state (not persisted).
+  double get lineSpacing => _lineSpacing;
+
+  set lineSpacing(double value) {
+    if (value == _lineSpacing) return;
+    _lineSpacing = value;
+    notifyListeners();
+  }
+
+  /// The character spacing (extra points after each glyph) new free-text
+  /// boxes are created with. Session state (not persisted).
+  double get charSpacing => _charSpacing;
+
+  set charSpacing(double value) {
+    if (value == _charSpacing) return;
+    _charSpacing = value;
+    notifyListeners();
+  }
+
+  /// The horizontal glyph scaling (per cent, 100 = natural width) new
+  /// free-text boxes are created with. Session state (not persisted).
+  double get fontWidth => _fontWidth;
+
+  set fontWidth(double value) {
+    if (value == _fontWidth) return;
+    _fontWidth = value;
+    notifyListeners();
+  }
+
+  /// Whether new free-text boxes are created underlined. Session state.
+  bool get textUnderline => _textUnderline;
+
+  set textUnderline(bool value) {
+    if (value == _textUnderline) return;
+    _textUnderline = value;
+    notifyListeners();
+  }
+
   PdfEmbeddedFont? _activeFont;
 
   /// An embedded TrueType/OpenType font selected for new free text, taking
@@ -1334,7 +1379,8 @@ class PdfEditingController extends ChangeNotifier {
   bool _editingText = false;
   TextSelection? _editingTextSelection;
   int _editingTextStyleRevision = 0;
-  ({PdfTextFont? font, double? size, int? color})? _editingTextStyleRequest;
+  ({PdfTextFont? font, double? size, int? color, bool? underline})?
+      _editingTextStyleRequest;
   int _editSelectedTextRevision = 0;
   int _editingTextFocusHoldCount = 0;
   int _editingTextFocusHoldRevision = 0;
@@ -1352,7 +1398,7 @@ class PdfEditingController extends ChangeNotifier {
 
   int get editingTextStyleRevision => _editingTextStyleRevision;
 
-  ({PdfTextFont? font, double? size, int? color})?
+  ({PdfTextFont? font, double? size, int? color, bool? underline})?
       get editingTextStyleRequest => _editingTextStyleRequest;
 
   int get editSelectedTextRevision => _editSelectedTextRevision;
@@ -1385,9 +1431,11 @@ class PdfEditingController extends ChangeNotifier {
     PdfTextFont? font,
     double? size,
     int? color,
+    bool? underline,
   }) {
     if (!hasEditingTextSelection) return false;
-    _editingTextStyleRequest = (font: font, size: size, color: color);
+    _editingTextStyleRequest =
+        (font: font, size: size, color: color, underline: underline);
     _editingTextStyleRevision++;
     notifyListeners();
     return true;
@@ -2134,6 +2182,10 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.textFillColor),
           borderColor: _rgbOf(preferences.textBorderColor),
           borderWidth: preferences.strokeWidth,
+          lineSpacing: _lineSpacing,
+          charSpacing: _charSpacing,
+          horizontalScale: _fontWidth,
+          underline: _textUnderline,
           pageRotation: _page(pageIndex).rotation,
           author: author,
         ),
@@ -2182,6 +2234,9 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.textFillColor),
           borderColor: _rgbOf(preferences.textBorderColor),
           borderWidth: preferences.strokeWidth,
+          lineSpacing: _lineSpacing,
+          charSpacing: _charSpacing,
+          horizontalScale: _fontWidth,
           pageRotation: _page(pageIndex).rotation,
           author: author,
         ),
@@ -4783,6 +4838,72 @@ class PdfEditingController extends ChangeNotifier {
     return selectedAnnotation?.freeTextStyle?.alignment ?? PdfTextAlign.left;
   }
 
+  /// The actual font of the selected free-text box - its embedded font
+  /// recovered from the appearance when present, else the base-14 face from
+  /// /DA. Unlike [selectedTextStyle] (which only parses a standard family)
+  /// this reports the real face, so the font picker shows a bundled/custom
+  /// font's own name instead of collapsing to "Sans".
+  PdfTextFont? get selectedTextFont {
+    final annotation = selectedAnnotation;
+    if (annotation == null || annotation.subtype != 'FreeText') return null;
+    return _freeTextFontOf(annotation).font;
+  }
+
+  /// The selected free-text box's full parsed style (spacing, underline,
+  /// alignment, colours), or null when the selection isn't a free-text box.
+  PdfFreeTextStyle? get selectedFreeTextStyle {
+    final annotation = selectedAnnotation;
+    if (annotation == null || annotation.subtype != 'FreeText') return null;
+    return annotation.freeTextStyle;
+  }
+
+  /// Sets box-level free-text styling (line spacing, character spacing,
+  /// horizontal glyph width, whole-box underline) on the selected box,
+  /// regenerating its appearance and preserving any per-run styling. Each
+  /// value also becomes the creation default. Omitted values are left as-is.
+  /// A no-op when the selection isn't a single free-text box.
+  void setSelectedTextBoxStyle({
+    double? lineSpacing,
+    double? charSpacing,
+    double? fontWidth,
+    bool? underline,
+  }) {
+    if (lineSpacing != null) this.lineSpacing = lineSpacing;
+    if (charSpacing != null) this.charSpacing = charSpacing;
+    if (fontWidth != null) this.fontWidth = fontWidth;
+    if (underline != null) textUnderline = underline;
+    // while the inline editor owns the box, rewriting the annotation would
+    // swap the document under it - the change rides the creation defaults
+    // and lands when the edit commits instead
+    if (isEditingText) return;
+    final annotation = selectedAnnotation;
+    if (annotation == null || !canRestyleSelectedText) return;
+    final richRuns = selectedRichRuns;
+    if (richRuns != null && richRuns.isNotEmpty) {
+      final runs = underline == null
+          ? richRuns
+          : [
+              for (final r in richRuns)
+                PdfFreeTextRun(r.text,
+                    font: r.font,
+                    fontSize: r.fontSize,
+                    color: r.color,
+                    underline: underline)
+            ];
+      _rewriteSelectedRich(annotation, runs,
+          lineSpacing: lineSpacing, charSpacing: charSpacing, fontWidth: fontWidth);
+    } else {
+      _rewriteSelected(
+        annotation,
+        annotation.contents ?? '',
+        lineSpacing: lineSpacing,
+        charSpacing: charSpacing,
+        fontWidth: fontWidth,
+        underline: underline,
+      );
+    }
+  }
+
   PdfRect _autosizeTextRect(
     PdfAnnotation annotation,
     String text, {
@@ -5037,6 +5158,10 @@ class PdfEditingController extends ChangeNotifier {
     (int?,)? fill,
     (int?,)? border,
     double? borderWidth,
+    double? lineSpacing,
+    double? charSpacing,
+    double? fontWidth,
+    bool? underline,
   }) {
     if (_selected.isEmpty) return;
     final page = _selected.last.$1;
@@ -5073,6 +5198,15 @@ class PdfEditingController extends ChangeNotifier {
               borderColor: border != null ? border.$1 : parsed?.borderColor,
               borderWidth: borderWidth ??
                   ((parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1),
+              // keep the box's own spacing/decoration unless changed
+              lineSpacing: lineSpacing ??
+                  parsed?.lineSpacing ??
+                  kPdfFreeTextDefaultLineSpacing,
+              charSpacing: charSpacing ?? parsed?.charSpacing ?? 0,
+              horizontalScale: fontWidth ??
+                  parsed?.horizontalScale ??
+                  kPdfFreeTextDefaultHorizontalScale,
+              underline: underline ?? parsed?.underline ?? false,
               pageRotation: _page(page).rotation,
               author: by,
               name: nm,
@@ -5122,8 +5256,12 @@ class PdfEditingController extends ChangeNotifier {
 
   bool _rewriteSelectedRich(
     PdfAnnotation annotation,
-    List<PdfFreeTextRun> runs,
-  ) {
+    List<PdfFreeTextRun> runs, {
+    double? lineSpacing,
+    double? charSpacing,
+    double? fontWidth,
+    PdfTextAlign? align,
+  }) {
     if (_selected.isEmpty || annotation.subtype != 'FreeText') return false;
     final page = _selected.last.$1;
     final rotation = _appearanceRotationOf(annotation);
@@ -5139,10 +5277,17 @@ class PdfEditingController extends ChangeNotifier {
           page,
           rect,
           runs,
-          align: parsed?.alignment ?? PdfTextAlign.left,
+          align: align ?? parsed?.alignment ?? PdfTextAlign.left,
           fillColor: parsed?.fillColor,
           borderColor: parsed?.borderColor,
           borderWidth: (parsed?.borderWidth ?? 0) > 0 ? parsed!.borderWidth : 1,
+          lineSpacing: lineSpacing ??
+              parsed?.lineSpacing ??
+              kPdfFreeTextDefaultLineSpacing,
+          charSpacing: charSpacing ?? parsed?.charSpacing ?? 0,
+          horizontalScale: fontWidth ??
+              parsed?.horizontalScale ??
+              kPdfFreeTextDefaultHorizontalScale,
           pageRotation: _page(page).rotation,
           author: by,
           name: nm,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -24,6 +24,12 @@ import 'text_prompt.dart';
 TextDirection _flutterTextDirection(String text) =>
     pdfTextLooksRtl(text) ? TextDirection.rtl : TextDirection.ltr;
 
+TextAlign _flutterTextAlign(PdfTextAlign align) => switch (align) {
+      PdfTextAlign.left => TextAlign.left,
+      PdfTextAlign.center => TextAlign.center,
+      PdfTextAlign.right => TextAlign.right,
+    };
+
 String? _textEditUiFamily(PdfTextFont font) {
   if (font is PdfStandardFont) {
     return switch (font.family) {
@@ -66,30 +72,43 @@ FontStyle _textEditSlant(PdfTextFont font) =>
 
 class _TextEditStyle {
   const _TextEditStyle(
-      {required this.font, required this.size, required this.color});
+      {required this.font,
+      required this.size,
+      required this.color,
+      this.underline = false});
 
   final PdfTextFont font;
   final double size;
   final Color color;
+  final bool underline;
 
-  _TextEditStyle merge({PdfTextFont? font, double? size, int? color}) =>
+  _TextEditStyle merge(
+          {PdfTextFont? font, double? size, int? color, bool? underline}) =>
       _TextEditStyle(
         font: font ?? this.font,
         size: size ?? this.size,
         color: color == null ? this.color : Color(0xFF000000 | color),
+        underline: underline ?? this.underline,
       );
 
-  TextStyle toTextStyle(double scale) => TextStyle(
+  TextStyle toTextStyle(double scale, {double height = 1.2, double? letterSpacing}) =>
+      TextStyle(
         color: color,
         fontSize: size * scale,
-        height: 1.2,
+        height: height,
+        letterSpacing: letterSpacing,
         fontFamily: _textEditUiFamily(font),
         fontWeight: _textEditWeight(font),
         fontStyle: _textEditSlant(font),
+        decoration: underline ? TextDecoration.underline : null,
+        decorationColor: underline ? color : null,
       );
 
   PdfFreeTextRun toRun(String text) => PdfFreeTextRun(text,
-      font: font, fontSize: size, color: color.toARGB32() & 0xFFFFFF);
+      font: font,
+      fontSize: size,
+      color: color.toARGB32() & 0xFFFFFF,
+      underline: underline);
 }
 
 class _TextEditStyleRange {
@@ -106,7 +125,70 @@ class _RichTextEditingController extends TextEditingController {
   _TextEditStyle defaultStyle = const _TextEditStyle(
       font: PdfStandardFont.helvetica, size: 14, color: Color(0xFF000000));
   double scale = 1;
+
+  /// The box-level line-height multiplier and character spacing (already in
+  /// view pixels) the styled span previews, so the live text matches the
+  /// committed appearance's leading and Tc.
+  double previewLineHeight = 1.2;
+  double previewLetterSpacing = 0;
   final List<_TextEditStyleRange> _ranges = [];
+
+  /// The text the style ranges are indexed against. Every edit (typing,
+  /// backspace, paste) shifts the ranges so a run keeps following its own
+  /// characters instead of the absolute offsets sliding under it.
+  String _rangeText = '';
+
+  /// Suppresses range remapping while [seedRuns] assigns text and ranges
+  /// together (the ranges are already correct for the new text).
+  bool _remapRanges = true;
+
+  @override
+  set value(TextEditingValue newValue) {
+    if (_remapRanges && _ranges.isNotEmpty && newValue.text != _rangeText) {
+      _shiftRanges(_rangeText, newValue.text);
+    }
+    _rangeText = newValue.text;
+    super.value = newValue;
+  }
+
+  /// Re-maps every style range across the edit that turned [before] into
+  /// [after], so a run stays glued to its characters. The changed span is
+  /// the region between the common prefix and common suffix; text before it
+  /// is untouched, text after it shifts by the length delta, and text
+  /// inserted inside a run extends that run.
+  void _shiftRanges(String before, String after) {
+    var prefix = 0;
+    final minLen = math.min(before.length, after.length);
+    while (prefix < minLen && before[prefix] == after[prefix]) {
+      prefix++;
+    }
+    var suffix = 0;
+    while (suffix < minLen - prefix &&
+        before[before.length - 1 - suffix] ==
+            after[after.length - 1 - suffix]) {
+      suffix++;
+    }
+    final changeStart = prefix;
+    final oldChangeEnd = before.length - suffix;
+    final delta = after.length - before.length;
+    int mapOffset(int o) {
+      if (o <= changeStart) return o;
+      if (o >= oldChangeEnd) return o + delta;
+      return changeStart; // inside a replaced span - collapse to its start
+    }
+
+    final next = <_TextEditStyleRange>[];
+    for (final range in _ranges) {
+      final start = mapOffset(range.start);
+      final end = mapOffset(range.end);
+      if (start < end) {
+        next.add(_TextEditStyleRange(start, end, range.style));
+      }
+    }
+    _ranges
+      ..clear()
+      ..addAll(_mergeRanges(next));
+  }
 
   void resetStyles(_TextEditStyle style) {
     defaultStyle = style;
@@ -134,19 +216,35 @@ class _RichTextEditingController extends TextEditingController {
           _TextEditStyle(
               font: run.font,
               size: run.fontSize,
-              color: Color(0xFF000000 | (run.color & 0xFFFFFF)))));
+              color: Color(0xFF000000 | (run.color & 0xFFFFFF)),
+              underline: run.underline)));
     }
     _ranges
       ..clear()
       ..addAll(_mergeRanges(ranges));
-    // assigning text notifies listeners and rebuilds the styled span
+    // assigning text notifies listeners and rebuilds the styled span; the
+    // ranges are already correct for the new text, so skip the edit remap
+    _remapRanges = false;
     text = buffer.toString();
+    _remapRanges = true;
   }
 
   bool get hasRichStyles => _ranges.isNotEmpty;
 
+  /// The largest font size across the default style and every run - the
+  /// strut size the inline editor pins line height to, so line spacing
+  /// stays font-independent (matching the committed appearance's leading)
+  /// instead of jumping when a run's font changes.
+  double get maxStyleSize {
+    var largest = defaultStyle.size;
+    for (final range in _ranges) {
+      if (range.style.size > largest) largest = range.style.size;
+    }
+    return largest;
+  }
+
   void applyStyle(TextSelection selection,
-      {PdfTextFont? font, double? size, int? color}) {
+      {PdfTextFont? font, double? size, int? color, bool? underline}) {
     if (!selection.isValid || selection.isCollapsed) return;
     final start = math.max(0, math.min(selection.start, selection.end));
     final end = math.min(text.length, math.max(selection.start, selection.end));
@@ -164,13 +262,30 @@ class _RichTextEditingController extends TextEditingController {
         next.add(_TextEditStyleRange(end, range.end, range.style));
       }
     }
-    next.add(_TextEditStyleRange(start, end,
-        _styleAt(start).merge(font: font, size: size, color: color)));
+    // split the selection into runs of already-uniform style so underlining
+    // (or any per-char toggle) keeps each character's own font/size/colour
+    var cursor = start;
+    while (cursor < end) {
+      final runStyle = _styleAt(cursor);
+      var runEnd = cursor + 1;
+      while (runEnd < end && _sameStyle(_styleAt(runEnd), runStyle)) {
+        runEnd++;
+      }
+      next.add(_TextEditStyleRange(cursor, runEnd,
+          runStyle.merge(font: font, size: size, color: color, underline: underline)));
+      cursor = runEnd;
+    }
     _ranges
       ..clear()
       ..addAll(_mergeRanges(next));
     notifyListeners();
   }
+
+  static bool _sameStyle(_TextEditStyle a, _TextEditStyle b) =>
+      identical(a.font, b.font) &&
+      a.size == b.size &&
+      a.color == b.color &&
+      a.underline == b.underline;
 
   List<PdfFreeTextRun> toPdfRuns() {
     final value = text;
@@ -213,7 +328,8 @@ class _RichTextEditingController extends TextEditingController {
           out.last.end == range.start &&
           identical(out.last.style.font, range.style.font) &&
           out.last.style.size == range.style.size &&
-          out.last.style.color == range.style.color) {
+          out.last.style.color == range.style.color &&
+          out.last.style.underline == range.style.underline) {
         final last = out.removeLast();
         out.add(_TextEditStyleRange(last.start, range.end, last.style));
       } else {
@@ -243,7 +359,9 @@ class _RichTextEditingController extends TextEditingController {
       }
       children.add(TextSpan(
           text: value.substring(start, end),
-          style: range.style.toTextStyle(scale)));
+          style: range.style.toTextStyle(scale,
+              height: previewLineHeight,
+              letterSpacing: previewLetterSpacing)));
       offset = end;
     }
     if (offset < value.length) {
@@ -685,6 +803,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   double _textEditSize = 14; // pt
   Color _textEditColor = const Color(0xFF000000);
   Color? _textEditFill; // the box background the commit will paint
+  // box-level layout the inline editor previews so the live text matches
+  // what commits: alignment (/Q), line height, character spacing, and
+  // horizontal glyph scaling
+  // null means "follow the text direction" (left for LTR, right for RTL) -
+  // a box with no explicit /Q, matching TextField's TextAlign.start
+  PdfTextAlign? _textEditAlign;
+  double _textEditLineSpacing = kPdfFreeTextDefaultLineSpacing;
+  double _textEditCharSpacing = 0;
   bool _textEditStyleMenuOpen = false;
   // resting view-space rotation of the box being edited (radians,
   // clockwise positive): nonzero only when editing already-rotated text,
@@ -805,6 +931,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     Color? fill,
     bool washed,
     double rotation,
+    PdfTextAlign? align,
+    bool underline,
+    double lineSpacing,
   })? _afterText;
   // the lifted clean page (the page rendered without the resized text box)
   // kept alive past the drag so a transparent box's commit afterimage shows
@@ -1762,16 +1891,28 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// a constant font size - the editor's FreeText regenerate path:
   /// an /AP to replace and a /DA naming a standard font. Null means the
   /// commit stretches the appearance and the ghost previews faithfully.
-  ({String text, PdfStandardFont font, double size, Color color, Color? fill})?
-      get _textResizeStyle {
+  ({
+    String text,
+    PdfStandardFont font,
+    double size,
+    Color color,
+    Color? fill,
+    PdfTextAlign align,
+    bool underline,
+    double lineSpacing,
+  })? get _textResizeStyle {
     final annotation = _controller.selectedAnnotation;
     if (annotation == null ||
         annotation.behavior.resizeBehavior !=
             PdfAnnotationResizeBehavior.reflowText) {
       return null;
     }
+    // an embedded-font box reflows too, but the lightweight preview can only
+    // draw base-14 faces - fall back to the stretch ghost during the drag
+    // (the commit still re-wraps correctly)
+    final font = annotation.behavior.standardTextFont;
+    if (font == null) return null;
     final parsed = annotation.behavior.style.freeText!;
-    final font = annotation.behavior.standardTextFont!;
     return (
       text: annotation.contents ?? '',
       font: font,
@@ -1780,6 +1921,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       fill: parsed.fillColor != null
           ? Color(0xFF000000 | parsed.fillColor!)
           : null,
+      align: parsed.alignment,
+      underline: parsed.underline,
+      lineSpacing: parsed.lineSpacing,
     );
   }
 
@@ -2086,6 +2230,29 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       }
     }
     if (_textEditRect == null) return;
+    // a new box in flight follows the tune popup's box-level defaults live
+    // (alignment, spacing, underline) instead of only picking them up on open
+    if (!_textEditExisting && _textEditFieldName == null) {
+      final align = _controller.textAlign;
+      final ls = _controller.lineSpacing;
+      final cs = _controller.charSpacing;
+      final ul = _controller.textUnderline;
+      final defaultUnderline = _textEditText.defaultStyle.underline;
+      if (align != _textEditAlign ||
+          ls != _textEditLineSpacing ||
+          cs != _textEditCharSpacing ||
+          (ul != defaultUnderline && !_textEditText.hasRichStyles)) {
+        setState(() {
+          _textEditAlign = align;
+          _textEditLineSpacing = ls;
+          _textEditCharSpacing = cs;
+          if (ul != defaultUnderline && !_textEditText.hasRichStyles) {
+            _textEditText.resetStyles(
+                _textEditText.defaultStyle.merge(underline: ul));
+          }
+        });
+      }
+    }
     final revision = _controller.editingTextStyleRevision;
     if (revision == _textEditStyleRevision) return;
     _textEditStyleRevision = revision;
@@ -2098,7 +2265,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _ensureEmbeddedFontPreview(request.font as PdfEmbeddedFont);
     }
     _textEditText.applyStyle(_textEditText.selection,
-        font: request.font, size: request.size, color: request.color);
+        font: request.font,
+        size: request.size,
+        color: request.color,
+        underline: request.underline);
   }
 
   Offset _handleCenter(Rect rect, _Handle handle) => Offset(
@@ -2347,8 +2517,13 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final defaultColor = annotationColor != null
         ? Color(0xFF000000 | annotationColor)
         : _controller.color;
+    final defaultUnderline =
+        existing ? (parsed?.underline ?? false) : _controller.textUnderline;
     final fallbackStyle = _TextEditStyle(
-        font: defaultFont, size: defaultSize, color: defaultColor);
+        font: defaultFont,
+        size: defaultSize,
+        color: defaultColor,
+        underline: defaultUnderline);
     // a box saved with mixed styling carries /RC: reseed its per-run fonts
     // so reopening shows the bold/italic/colour, not a flattened style
     final richRuns = existing ? _controller.selectedRichRuns : null;
@@ -2368,6 +2543,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           defaultFont is PdfStandardFont ? defaultFont : _controller.fontFamily;
       _textEditSize = defaultSize;
       _textEditColor = defaultColor;
+      _textEditAlign = existing ? parsed?.alignment : _controller.textAlign;
+      _textEditLineSpacing = existing
+          ? (parsed?.lineSpacing ?? kPdfFreeTextDefaultLineSpacing)
+          : _controller.lineSpacing;
+      _textEditCharSpacing =
+          existing ? (parsed?.charSpacing ?? 0) : _controller.charSpacing;
       _textEditFill = existing
           ? (parsed?.fillColor != null
               ? Color(0xFF000000 | parsed!.fillColor!)
@@ -2520,6 +2701,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         fill: null,
         washed: true, // cover the old value until the raster lands
         rotation: 0,
+        align: PdfTextAlign.left,
+        underline: false,
+        lineSpacing: kPdfFreeTextDefaultLineSpacing,
       );
       _afterDocument = _controller.document;
       return;
@@ -2567,6 +2751,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       fill: fill,
       washed: existing,
       rotation: rotation,
+      align: _textEditAlign,
+      underline: _textEditText.defaultStyle.underline,
+      lineSpacing: _textEditLineSpacing,
     );
     _afterDocument = _controller.document;
   }
@@ -3204,6 +3391,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             // lift does it fall back to the opaque-paper wash
             washed: liftClean == null,
             rotation: resizeAngle,
+            align: wrapStyle.align,
+            underline: wrapStyle.underline,
+            lineSpacing: wrapStyle.lineSpacing,
           );
           _afterTextClean = liftClean;
           _afterTextHideRect = liftHideRect;
@@ -4116,7 +4306,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     return _textEditText._styleAt(offset.clamp(0, _textEditText.text.length));
   }
 
-  void _applyInlineTextStyle({PdfTextFont? font, double? size, Color? color}) {
+  void _applyInlineTextStyle(
+      {PdfTextFont? font, double? size, Color? color, bool? underline}) {
     if (!_canStyleInlineTextSelection) return;
     final rgb = color == null ? null : color.toARGB32() & 0xFFFFFF;
     if (font is PdfStandardFont) {
@@ -4126,8 +4317,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     }
     if (size != null) _controller.fontSize = size;
     if (color != null) _controller.color = Color(0xFF000000 | rgb!);
+    if (underline != null) _controller.textUnderline = underline;
     _controller.setEditingTextSelection(_textEditText.selection);
-    _controller.restyleEditingTextSelection(font: font, size: size, color: rgb);
+    _controller.restyleEditingTextSelection(
+        font: font, size: size, color: rgb, underline: underline);
   }
 
   /// Registers an embedded font's outline bytes with the engine under a
@@ -4191,6 +4384,33 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _textEditText.selection =
         TextSelection(baseOffset: 0, extentOffset: length);
     _applyInlineTextStyle(font: next);
+  }
+
+  /// Toggles underline on the inline text editor - the desktop Cmd/Ctrl+U
+  /// shortcut and the style-chip button. Underline is a per-character format
+  /// (like bold), so with a selection it restyles that run; with none it
+  /// underlines the whole box (or just sets the default when the box is
+  /// still empty).
+  void _toggleInlineUnderline() {
+    if (_textEditRect == null || _textEditFieldName != null) return;
+    final on = !_currentInlineTextStyle().underline;
+    if (_canStyleInlineTextSelection) {
+      _applyInlineTextStyle(underline: on);
+      return;
+    }
+    final length = _textEditText.text.length;
+    if (length == 0) {
+      _controller.textUnderline = on;
+      setState(() => _textEditText.resetStyles(_TextEditStyle(
+          font: _textEditFont,
+          size: _textEditSize,
+          color: _textEditColor,
+          underline: on)));
+      return;
+    }
+    _textEditText.selection =
+        TextSelection(baseOffset: 0, extentOffset: length);
+    _applyInlineTextStyle(underline: on);
   }
 
   Future<void> _showInlineTextFontMenu(BuildContext context) async {
@@ -4276,6 +4496,16 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   onPressed: enabled
                       ? () => _applyInlineTextStyle(
                           size: (current.size + 1).clamp(8, 48).toDouble())
+                      : null,
+                ),
+                IconButton(
+                  key: const ValueKey('pdf-inline-text-underline'),
+                  icon: const Icon(Icons.format_underlined),
+                  tooltip: 'Underline',
+                  isSelected: current.underline,
+                  // underline works with or without a selection (whole box)
+                  onPressed: _textEditFieldName == null
+                      ? _toggleInlineUnderline
                       : null,
                 ),
                 Builder(builder: (buttonContext) {
@@ -4455,28 +4685,40 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     required Color color,
     required Color? background,
     required double rotation,
+    PdfTextAlign? align,
+    bool underline = false,
+    double lineSpacing = kPdfFreeTextDefaultLineSpacing,
   }) {
     final direction = _flutterTextDirection(text);
+    final columnAlign = switch (align) {
+      null => AlignmentDirectional.topStart.resolve(direction),
+      PdfTextAlign.left => Alignment.topLeft,
+      PdfTextAlign.center => Alignment.topCenter,
+      PdfTextAlign.right => Alignment.topRight,
+    };
     final box = Container(
       key: key,
       color: background,
       padding: EdgeInsets.all(3 * _geometry.scale),
-      alignment: AlignmentDirectional.topStart.resolve(direction),
+      alignment: columnAlign,
       child: Directionality(
         textDirection: direction,
         child: Text(
           text,
-          textAlign: TextAlign.start,
+          textAlign:
+              align == null ? TextAlign.start : _flutterTextAlign(align),
           textHeightBehavior: const TextHeightBehavior(
             applyHeightToFirstAscent: false,
           ),
           style: TextStyle(
             color: color,
             fontSize: size * _geometry.scale,
-            height: 1.2,
+            height: lineSpacing,
             fontFamily: _uiFamily(font),
             fontWeight: font.isBold ? FontWeight.bold : FontWeight.normal,
             fontStyle: font.isItalic ? FontStyle.italic : FontStyle.normal,
+            decoration: underline ? TextDecoration.underline : null,
+            decorationColor: underline ? color : null,
           ),
         ),
       ),
@@ -4502,6 +4744,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   Widget build(BuildContext context) {
     _scheduleRasterReady();
     _textEditText.scale = _geometry.scale;
+    _textEditText.previewLineHeight = _textEditLineSpacing;
+    _textEditText.previewLetterSpacing = _textEditCharSpacing * _geometry.scale;
     _ensureGhost();
     _ensureSourceClean();
     // the afterimage has served once the committed revision's raster is
@@ -4905,6 +5149,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   color: wrapResize.color,
                   background: wrapResize.fill,
                   rotation: _resizeAngle,
+                  align: wrapResize.align,
+                  underline: wrapResize.underline,
+                  lineSpacing: wrapResize.lineSpacing,
                 ),
               // a just-committed text edit, frozen until the page raster
               // catches up (same wash the inline editor painted over old
@@ -4921,6 +5168,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                           ? widget.pageColor.withValues(alpha: 0.92)
                           : null),
                   rotation: after.rotation,
+                  align: after.align,
+                  underline: after.underline,
+                  lineSpacing: after.lineSpacing,
                 ),
               if (preview != null)
                 Positioned(
@@ -4961,6 +5211,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                             () => _toggleInlineTextStyle(
                                   italic: true,
                                 ),
+                        const SingleActivator(LogicalKeyboardKey.keyU, meta: true):
+                            _toggleInlineUnderline,
+                        const SingleActivator(LogicalKeyboardKey.keyU, control: true):
+                            _toggleInlineUnderline,
                       },
                       child: Container(
                         // the chrome border lives in the inflate(2) gutter
@@ -5007,11 +5261,30 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                     _textEditMultiline,
                                 onSubmitted: (_) => _commitTextEdit(),
                                 textDirection: direction,
-                                textAlign: TextAlign.start,
+                                // free text follows the box's /Q alignment so
+                                // the live text sits where it commits; a box
+                                // with no explicit /Q (and form fields) stays
+                                // direction-aware start-aligned
+                                textAlign: _textEditFieldName == null &&
+                                        _textEditAlign != null
+                                    ? _flutterTextAlign(_textEditAlign!)
+                                    : TextAlign.start,
                                 textAlignVertical: _textEditFieldName == null ||
                                         _textEditMultiline
                                     ? TextAlignVertical.top
                                     : TextAlignVertical.center,
+                                // pin line height to the box's leading so the
+                                // preview spacing is font-independent, matching
+                                // the committed appearance - changing a run's
+                                // font no longer nudges the lines until commit
+                                strutStyle: _textEditFieldName == null
+                                    ? StrutStyle(
+                                        fontSize: _textEditText.maxStyleSize *
+                                            _geometry.scale,
+                                        height: _textEditLineSpacing,
+                                        forceStrutHeight: true,
+                                      )
+                                    : null,
                                 cursorColor: _textEditColor,
                                 cursorWidth: 2 * _chromeScale,
                                 selectionControls: _ScaledTextSelectionControls(
@@ -5030,12 +5303,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                   );
                                 },
                                 // mirrors the committed appearance: same size
-                                // in view pixels, same 1.2 leading, matching
-                                // family and color
+                                // in view pixels, same leading/spacing,
+                                // matching family, color and underline
                                 style: TextStyle(
                                   color: _textEditColor,
                                   fontSize: _textEditSize * _geometry.scale,
-                                  height: 1.2,
+                                  height: _textEditLineSpacing,
+                                  letterSpacing:
+                                      _textEditCharSpacing * _geometry.scale,
                                   fontFamily: _uiFamily(_textEditFont),
                                   fontWeight: _textEditFont.isBold
                                       ? FontWeight.bold
@@ -5043,6 +5318,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                   fontStyle: _textEditFont.isItalic
                                       ? FontStyle.italic
                                       : FontStyle.normal,
+                                  decoration:
+                                      _textEditText.defaultStyle.underline
+                                          ? TextDecoration.underline
+                                          : null,
                                 ),
                                 decoration: InputDecoration(
                                   isCollapsed: true,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -812,6 +812,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   double _textEditLineSpacing = kPdfFreeTextDefaultLineSpacing;
   double _textEditCharSpacing = 0;
   bool _textEditStyleMenuOpen = false;
+  // holds the editor's keyboard focus while a pointer is down on the inline
+  // style chip, so tapping a chip button (underline, size, …) on mobile
+  // doesn't blur the field and commit/deselect the box under it
+  bool _chipFocusHeld = false;
   // resting view-space rotation of the box being edited (radians,
   // clockwise positive): nonzero only when editing already-rotated text,
   // so the inline editor and afterimage sit on the artwork instead of
@@ -2182,6 +2186,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // pixels. Guarded by _moveStart so disposing some other (off-screen)
     // page's overlay never clears a preview the dragging page still owns.
     if (_moveStart != null) _host.moveDragPreview?.call(null);
+    if (_chipFocusHeld) {
+      _chipFocusHeld = false;
+      _controller.endEditingTextFocusHold();
+    }
     _textEditFocus
       ..removeListener(_onTextEditFocus)
       ..dispose();
@@ -2843,6 +2851,31 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         !_controller.isEditingTextFocusCommitHeld) {
       _commitTextEdit();
     }
+  }
+
+  /// Holds the inline editor's focus while a pointer is down on the style
+  /// chip, so a chip tap on mobile (which blurs the field) can't trip the
+  /// focus-loss commit and deselect the box before the button runs.
+  void _holdChipFocus() {
+    if (_chipFocusHeld || _textEditRect == null) return;
+    _chipFocusHeld = true;
+    _controller.beginEditingTextFocusHold();
+  }
+
+  void _releaseChipFocus() {
+    if (!_chipFocusHeld) return;
+    // pointer-up fires before the button's onPressed, so defer to the next
+    // frame: by then the button's style change has run against the live
+    // selection. Restore the keyboard to the field (unless a colour/font
+    // menu now owns it) and drop the hold so a later real blur commits.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_chipFocusHeld) return;
+      _chipFocusHeld = false;
+      if (mounted && _textEditRect != null && !_textEditStyleMenuOpen) {
+        _textEditFocus.requestFocus();
+      }
+      _controller.endEditingTextFocusHold();
+    });
   }
 
   void _panStart(DragStartDetails details) {
@@ -4461,7 +4494,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         child: Transform.scale(
           scale: s,
           alignment: above ? Alignment.bottomCenter : Alignment.topCenter,
-          child: Focus(
+          // pin the editor's focus while a chip button is pressed - on mobile
+          // the tap otherwise blurs the field and the focus-loss listener
+          // commits/deselects the box before the button's action runs
+          child: Listener(
+            behavior: HitTestBehavior.deferToChild,
+            onPointerDown: (_) => _holdChipFocus(),
+            onPointerUp: (_) => _releaseChipFocus(),
+            onPointerCancel: (_) => _releaseChipFocus(),
+            child: Focus(
             canRequestFocus: false,
             descendantsAreFocusable: false,
             child: Material(
@@ -4523,6 +4564,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                 }),
               ]),
             ),
+          ),
           ),
         ),
       ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -120,6 +120,9 @@ class _PdfAnnotationPropertiesPanelState
   double? _draggingStroke;
   double? _draggingOpacity;
   double? _draggingFontSize;
+  double? _draggingLineSpacing;
+  double? _draggingCharSpacing;
+  double? _draggingFontWidth;
 
   PdfEditingController get _controller => widget.controller;
 
@@ -661,7 +664,8 @@ class _PdfAnnotationPropertiesPanelState
             buttonKey: const ValueKey('pdf-prop-font'),
             controller: _controller,
             fontPicker: widget.fontPicker,
-            currentFont: style.font,
+            // the box's real face (embedded/bundled shows its own name)
+            currentFont: _controller.selectedTextFont ?? style.font,
           ),
         ]),
       ),
@@ -699,12 +703,73 @@ class _PdfAnnotationPropertiesPanelState
           setState(() => _draggingFontSize = null);
         },
       ),
-      if (annotation.subtype == 'FreeText')
+      if (annotation.subtype == 'FreeText') ...[
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          child: Row(children: [
+            const Expanded(child: Text('Underline')),
+            IconButton(
+              key: const ValueKey('pdf-prop-text-underline'),
+              icon: const Icon(Icons.format_underlined, size: 18),
+              tooltip: 'Underline',
+              isSelected: _controller.selectedFreeTextStyle?.underline ?? false,
+              onPressed: () => _controller.setSelectedTextBoxStyle(
+                  underline:
+                      !(_controller.selectedFreeTextStyle?.underline ?? false)),
+            ),
+          ]),
+        ),
+        _sliderRow(
+          'Line spacing',
+          _draggingLineSpacing ??
+              _controller.selectedFreeTextStyle?.lineSpacing ??
+              kPdfFreeTextDefaultLineSpacing,
+          key: const ValueKey('pdf-prop-line-spacing'),
+          min: 0.8,
+          max: 3,
+          display: (v) => '${v.toStringAsFixed(1)}×',
+          onChanged: (v) => setState(() => _draggingLineSpacing = v),
+          onChangeEnd: (v) {
+            _controller.setSelectedTextBoxStyle(lineSpacing: v);
+            setState(() => _draggingLineSpacing = null);
+          },
+        ),
+        _sliderRow(
+          'Char spacing',
+          _draggingCharSpacing ??
+              _controller.selectedFreeTextStyle?.charSpacing ??
+              0,
+          key: const ValueKey('pdf-prop-char-spacing'),
+          min: -2,
+          max: 10,
+          display: (v) => '${v.toStringAsFixed(1)} pt',
+          onChanged: (v) => setState(() => _draggingCharSpacing = v),
+          onChangeEnd: (v) {
+            _controller.setSelectedTextBoxStyle(charSpacing: v);
+            setState(() => _draggingCharSpacing = null);
+          },
+        ),
+        _sliderRow(
+          'Font width',
+          _draggingFontWidth ??
+              _controller.selectedFreeTextStyle?.horizontalScale ??
+              kPdfFreeTextDefaultHorizontalScale,
+          key: const ValueKey('pdf-prop-font-width'),
+          min: 50,
+          max: 200,
+          display: (v) => '${v.round()}%',
+          onChanged: (v) => setState(() => _draggingFontWidth = v),
+          onChangeEnd: (v) {
+            _controller.setSelectedTextBoxStyle(fontWidth: v);
+            setState(() => _draggingFontWidth = null);
+          },
+        ),
         _swatchRow('Outline', borderColor,
             key: const ValueKey('pdf-prop-text-border'),
             onTap: () => _pickTextBorder(borderColor),
             onClear: () => _controller.restyleSelectedText(border: (null,)),
             clearTooltip: 'No outline'),
+      ],
     ];
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -3243,6 +3243,9 @@ class _StyleMenuState extends State<_StyleMenu> {
   /// selected annotation.
   double? _draggingStroke;
   double? _draggingOpacity;
+  double? _draggingLineSpacing;
+  double? _draggingCharSpacing;
+  double? _draggingFontWidth;
   bool _holdingTextEditFocus = false;
 
   @override
@@ -3646,7 +3649,9 @@ class _StyleMenuState extends State<_StyleMenu> {
                             child: PdfFontMenuButton(
                               controller: controller,
                               fontPicker: widget.fontPicker,
-                              currentFont: selectedStyle?.font ??
+                              // the box's real face (embedded/bundled shows its
+                              // own name, not "Sans")
+                              currentFont: controller.selectedTextFont ??
                                   captionStyle?.font ??
                                   controller.activeFont ??
                                   controller.fontFamily,
@@ -3677,8 +3682,76 @@ class _StyleMenuState extends State<_StyleMenu> {
                               PdfTextAlign.left,
                           onChanged: _setTextAlign,
                         ),
+                        const Spacer(),
+                        // whole-box underline (a per-run underline is set from
+                        // the inline editor's style chip)
+                        IconButton(
+                          key: const ValueKey('pdf-text-underline'),
+                          icon: const Icon(Icons.format_underlined, size: 18),
+                          tooltip: 'Underline',
+                          isSelected: controller.selectedFreeTextStyle
+                                  ?.underline ??
+                              controller.textUnderline,
+                          onPressed: () => controller.setSelectedTextBoxStyle(
+                              underline: !(controller.selectedFreeTextStyle
+                                      ?.underline ??
+                                  controller.textUnderline)),
+                        ),
                       ]),
                     ),
+                    if (captionStyle == null) ...[
+                      _slider(
+                        key: const ValueKey('pdf-text-line-spacing'),
+                        label: 'Line spacing',
+                        value: _draggingLineSpacing ??
+                            controller.selectedFreeTextStyle?.lineSpacing ??
+                            controller.lineSpacing,
+                        min: 0.8,
+                        max: 3,
+                        display: (v) => '${v.toStringAsFixed(1)}×',
+                        onChanged: (v) =>
+                            setState(() => _draggingLineSpacing = v),
+                        onChangeEnd: (v) {
+                          controller.setSelectedTextBoxStyle(lineSpacing: v);
+                          setState(() => _draggingLineSpacing = null);
+                        },
+                      ),
+                      _slider(
+                        key: const ValueKey('pdf-text-char-spacing'),
+                        label: 'Char spacing',
+                        value: _draggingCharSpacing ??
+                            controller.selectedFreeTextStyle?.charSpacing ??
+                            controller.charSpacing,
+                        min: -2,
+                        max: 10,
+                        display: (v) => '${v.toStringAsFixed(1)} pt',
+                        parse: _parsePoints,
+                        onChanged: (v) =>
+                            setState(() => _draggingCharSpacing = v),
+                        onChangeEnd: (v) {
+                          controller.setSelectedTextBoxStyle(charSpacing: v);
+                          setState(() => _draggingCharSpacing = null);
+                        },
+                      ),
+                      _slider(
+                        key: const ValueKey('pdf-text-font-width'),
+                        label: 'Font width',
+                        value: _draggingFontWidth ??
+                            controller
+                                .selectedFreeTextStyle?.horizontalScale ??
+                            controller.fontWidth,
+                        min: 50,
+                        max: 200,
+                        display: (v) => '${v.round()}%',
+                        parse: _parsePoints,
+                        onChanged: (v) =>
+                            setState(() => _draggingFontWidth = v),
+                        onChangeEnd: (v) {
+                          controller.setSelectedTextBoxStyle(fontWidth: v);
+                          setState(() => _draggingFontWidth = null);
+                        },
+                      ),
+                    ],
                   ],
                   if (fields.boxColors && widget.showColor) ...[
                     _boxColorRow(

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -842,6 +842,53 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('the inline chip underline button keeps the box in edit mode',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing.addFreeText(0, const PdfRect(100, 600, 360, 660), 'Hello world');
+      await tester.pump();
+      editing.tool = PdfEditTool.select;
+      await tester.pump();
+
+      // enter edit mode with a bare caret (no range selection, so no text
+      // selection toolbar floats over the chip): the underline button then
+      // styles the whole box and the box must stay in edit mode - tapping a
+      // chip button must never commit/deselect it (the mobile report)
+      await tap(tester, view(200, 630));
+      await tap(tester, view(200, 630));
+      expect(find.byKey(editorKey), findsOneWidget);
+
+      final underline =
+          find.byKey(const ValueKey('pdf-inline-text-underline'));
+      expect(underline, findsOneWidget);
+      // invoke the button's handler directly: the chip sits inside scaled,
+      // translated chrome that makes a synthetic tap's hit-test unreliable,
+      // and the mobile focus-drop it guards against isn't reproducible in a
+      // widget test (a tap never blurs a non-focusable button here)
+      tester.widget<IconButton>(underline).onPressed!.call();
+      await tester.pump();
+
+      // still editing (not committed/deselected) and the box is now underlined
+      expect(find.byKey(editorKey), findsOneWidget);
+      expect(editing.isEditingText, isTrue);
+      final field = tester.widget<TextField>(find.byKey(editorKey));
+      expect(field.controller!.text, 'Hello world');
+      final span = field.controller!.buildTextSpan(
+        context: tester.element(find.byKey(editorKey)),
+        style: const TextStyle(),
+        withComposing: false,
+      );
+      final underlined = span.children!
+          .whereType<TextSpan>()
+          .where((c) => c.style?.decoration == TextDecoration.underline)
+          .map((c) => c.text)
+          .join();
+      expect(underlined, contains('Hello world'));
+
+      editing.textUnderline = false;
+      await settle(tester);
+    });
+
     testWidgets('Ctrl+B and Ctrl+I toggle bold/italic on the selection',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -895,6 +895,133 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('backspace before a bold run keeps the run bold',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing.addFreeText(0, const PdfRect(100, 600, 360, 660), 'Hello world');
+      await tester.pump();
+      editing.tool = PdfEditTool.select;
+      await tester.pump();
+
+      await tap(tester, view(200, 630));
+      await tap(tester, view(200, 630));
+      final field = tester.widget<TextField>(find.byKey(editorKey));
+      // bold exactly "world" (offsets 6..11)
+      field.controller!.value = const TextEditingValue(
+        text: 'Hello world',
+        selection: TextSelection(baseOffset: 6, extentOffset: 11),
+      );
+      await tester.pump();
+      expect(
+          editing.restyleEditingTextSelection(
+              font: PdfStandardFont.helveticaBold),
+          isTrue);
+      await tester.pump();
+
+      // delete the 'o' in "Hello" - the bold run must follow its own
+      // characters, not slide down by one (the reported regression)
+      field.controller!.value = const TextEditingValue(
+        text: 'Hell world',
+        selection: TextSelection.collapsed(offset: 4),
+      );
+      await tester.pump();
+
+      final span = field.controller!.buildTextSpan(
+        context: tester.element(find.byKey(editorKey)),
+        style: const TextStyle(),
+        withComposing: false,
+      );
+      final bold = span.children!
+          .whereType<TextSpan>()
+          .where((c) => c.style?.fontWeight == FontWeight.bold)
+          .map((c) => c.text)
+          .join();
+      expect(bold, 'world');
+
+      editing.fontFamily = PdfStandardFont.helvetica;
+      await settle(tester);
+    });
+
+    testWidgets('Ctrl+U underlines the selection and persists to /RC',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      editing.addFreeText(0, const PdfRect(100, 600, 360, 660), 'Hello world');
+      await tester.pump();
+      editing.tool = PdfEditTool.select;
+      await tester.pump();
+
+      await tap(tester, view(200, 630));
+      await tap(tester, view(200, 630));
+      final field = tester.widget<TextField>(find.byKey(editorKey));
+      field.controller!.value = const TextEditingValue(
+        text: 'Hello world',
+        selection: TextSelection(baseOffset: 6, extentOffset: 11),
+      );
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyU);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      final span = field.controller!.buildTextSpan(
+        context: tester.element(find.byKey(editorKey)),
+        style: const TextStyle(),
+        withComposing: false,
+      );
+      final styled = span.children!
+          .whereType<TextSpan>()
+          .singleWhere((c) => c.text == 'world');
+      expect(styled.style?.decoration, TextDecoration.underline);
+
+      await tap(tester, view(450, 400)); // commit
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.richContent, contains('text-decoration:underline'));
+      final content = latin1.decode(
+          editing.document.cos.decodeStreamData(annotation.normalAppearance!));
+      // an underline rule (a filled rectangle) is drawn after the text object
+      expect(content.lastIndexOf(' re'), greaterThan(content.lastIndexOf('ET')));
+      editing.textUnderline = false;
+      await settle(tester);
+    });
+
+    testWidgets('the font picker reports an embedded box font, not Sans',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      final fontBytes =
+          File('../pdf_document/test/fonts/DejaVuSans.ttf').readAsBytesSync();
+      expect(editing.setCustomFont(fontBytes), isTrue);
+      final embedded = editing.activeFont as PdfEmbeddedFont;
+
+      editing.addFreeText(0, const PdfRect(100, 600, 360, 660), 'Hello');
+      await tester.pump();
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+
+      final font = editing.selectedTextFont;
+      expect(font, isA<PdfEmbeddedFont>());
+      expect((font as PdfEmbeddedFont).familyName, embedded.familyName);
+      editing.activeFont = null;
+      await settle(tester);
+    });
+
+    testWidgets('resizing an embedded-font box reflows instead of stretching',
+        (tester) async {
+      final (editing, _) = await pumpEditor(tester);
+      final fontBytes =
+          File('../pdf_document/test/fonts/DejaVuSans.ttf').readAsBytesSync();
+      expect(editing.setCustomFont(fontBytes), isTrue);
+      editing.addFreeText(
+          0, const PdfRect(100, 600, 400, 640), 'reflow me please');
+      await tester.pump();
+      final box = editing.document.page(0).annotations.single;
+      // embedded-font free text now re-wraps on resize (no stretched glyphs)
+      expect(box.behavior.resizeBehavior,
+          PdfAnnotationResizeBehavior.reflowText);
+      editing.activeFont = null;
+      await settle(tester);
+    });
+
     testWidgets('reopening a mixed-format box restores its per-run styling',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);

--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Free-text appearances support line spacing, character spacing (Tc),
+  horizontal glyph scaling (Tz), and underline (per box and per rich run),
+  round-tripping through the annotation dictionary and `/RC`.
+- Regenerate embedded-font and rich free-text boxes on resize (re-wrapping
+  in the recovered face and preserving per-run styling) instead of falling
+  back to the appearance stretch.
+
 ## 1.4.6
 
 - Add operation-scoped page-content text replacement and expose the active

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -580,6 +580,15 @@ class PdfAnnotation {
     final background = color;
     final width = borderWidth ?? 0;
     final q = document.cos.resolve(dict['Q']);
+    final cos = document.cos;
+    double? number(String key) {
+      final v = cos.resolve(dict[key]);
+      if (v is CosInteger) return v.value.toDouble();
+      if (v is CosReal) return v.value;
+      return null;
+    }
+
+    final underlineFlag = cos.resolve(dict[kPdfFreeTextUnderlineKey]);
     return PdfFreeTextStyle(
       fontName: tf.group(1)!,
       fontSize: size,
@@ -588,6 +597,12 @@ class PdfAnnotation {
       borderColor: lastColor('RG') ?? (width > 0 ? text : null),
       borderWidth: width,
       alignment: PdfTextAlign.fromQuadding(q is CosInteger ? q.value : null),
+      lineSpacing:
+          number(kPdfFreeTextLineSpacingKey) ?? kPdfFreeTextDefaultLineSpacing,
+      charSpacing: number(kPdfFreeTextCharSpacingKey) ?? 0,
+      horizontalScale: number(kPdfFreeTextHScaleKey) ??
+          kPdfFreeTextDefaultHorizontalScale,
+      underline: underlineFlag is CosBoolean && underlineFlag.value,
     );
   }
 
@@ -756,6 +771,22 @@ String pdfFormatDate(DateTime time) {
       "${two(t.hour)}${two(t.minute)}${two(t.second)}Z00'00'";
 }
 
+/// Dictionary keys where free-text styling that /DA and /Q cannot express
+/// is persisted (line height, character spacing, horizontal glyph scaling,
+/// whole-box underline). Non-standard PDF keys, written and read back only
+/// by this package so a resize/edit can regenerate the same appearance.
+const String kPdfFreeTextLineSpacingKey = 'LineSpacing';
+const String kPdfFreeTextCharSpacingKey = 'CharSpacing';
+const String kPdfFreeTextHScaleKey = 'HScale';
+const String kPdfFreeTextUnderlineKey = 'TextUnderline';
+
+/// The default free-text line-height multiplier (baseline-to-baseline
+/// distance is `fontSize * lineSpacing`).
+const double kPdfFreeTextDefaultLineSpacing = 1.2;
+
+/// The default free-text horizontal glyph scaling, as a percentage.
+const double kPdfFreeTextDefaultHorizontalScale = 100.0;
+
 /// A free-text annotation's text and box styling, as recoverable from
 /// its dictionary (see [PdfAnnotation.freeTextStyle]). Colors are
 /// 0xRRGGBB.
@@ -768,6 +799,10 @@ class PdfFreeTextStyle {
     this.borderColor,
     this.borderWidth = 0,
     this.alignment = PdfTextAlign.left,
+    this.lineSpacing = kPdfFreeTextDefaultLineSpacing,
+    this.charSpacing = 0,
+    this.horizontalScale = kPdfFreeTextDefaultHorizontalScale,
+    this.underline = false,
   });
 
   /// The /DA font resource name (e.g. `Helv`), unresolved.
@@ -787,6 +822,20 @@ class PdfFreeTextStyle {
   /// How the lines are aligned inside the box (the /Q quadding). Defaults
   /// to [PdfTextAlign.left] when the annotation carries no /Q.
   final PdfTextAlign alignment;
+
+  /// The line-height multiplier (baseline-to-baseline distance is
+  /// `fontSize * lineSpacing`). Defaults to [kPdfFreeTextDefaultLineSpacing].
+  final double lineSpacing;
+
+  /// Extra spacing added after each glyph, in points (the Tc value).
+  final double charSpacing;
+
+  /// Horizontal glyph scaling as a percentage - 100 is the font's natural
+  /// width (the Tz value).
+  final double horizontalScale;
+
+  /// Whether the whole box is drawn underlined.
+  final bool underline;
 }
 
 /// A /Link annotation: a clickable region with an action (§12.5.6.5).

--- a/packages/pdf_document/lib/src/annotation_behavior.dart
+++ b/packages/pdf_document/lib/src/annotation_behavior.dart
@@ -155,6 +155,39 @@ class PdfAnnotationBehavior {
       ? null
       : PdfStandardFont.tryFromName(_freeTextStyle.fontName);
 
+  /// Whether the box's /DA font resolves to an embedded (Type0-with-program)
+  /// face in its appearance resources. Cheap COS inspection - enough to know
+  /// a resize can re-wrap the box without parsing the whole font program
+  /// (the editor recovers the actual font for that). Lets embedded/bundled
+  /// free-text boxes reflow on resize instead of stretching their glyphs.
+  late final bool hasEmbeddedTextFont = _hasEmbeddedTextFont();
+
+  bool _hasEmbeddedTextFont() {
+    if (subtype != 'FreeText') return false;
+    final cos = annotation.document.cos;
+    final form = annotation.normalAppearance;
+    if (form == null) return false;
+    final res = cos.resolve(form.dictionary['Resources']);
+    if (res is! CosDictionary) return false;
+    final fonts = cos.resolve(res['Font']);
+    if (fonts is! CosDictionary) return false;
+    final name = RegExp(r'/(\S+)\s+[\d.]+\s+Tf')
+        .firstMatch(annotation.defaultAppearance ?? '')
+        ?.group(1);
+    final dict = name != null ? cos.resolve(fonts[name]) : null;
+    if (dict is! CosDictionary) return false;
+    final sub = cos.resolve(dict['Subtype']);
+    if (sub is! CosName || sub.value != 'Type0') return false;
+    final desc = cos.resolve(dict['DescendantFonts']);
+    if (desc is! CosArray || desc.items.isEmpty) return false;
+    final cid = cos.resolve(desc.items.first);
+    if (cid is! CosDictionary) return false;
+    final fd = cos.resolve(cid['FontDescriptor']);
+    if (fd is! CosDictionary) return false;
+    return cos.resolve(fd['FontFile2']) is CosStream ||
+        cos.resolve(fd['FontFile3']) is CosStream;
+  }
+
   late final List<PdfRect>? markupQuads = _readAxisAlignedQuads();
 
   /// Whether the editor has enough well-formed source data to regenerate an
@@ -217,7 +250,7 @@ class PdfAnnotationBehavior {
         }
         return PdfAnnotationResizeBehavior.regenerateShape;
       case 'FreeText':
-        return standardTextFont == null
+        return standardTextFont == null && !hasEmbeddedTextFont
             ? PdfAnnotationResizeBehavior.stretch
             : PdfAnnotationResizeBehavior.reflowText;
       case 'Line':

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -47,6 +47,27 @@ List<((double, double), (double, double))> pdfInkCurveControls(
 /// orders of magnitude above the rounding noise.
 const double _wrapTolerance = 1e-6;
 
+/// The default line-height multiplier for free-text appearances: the
+/// baseline-to-baseline distance is `fontSize * lineSpacing`.
+const double _defaultLineSpacing = kPdfFreeTextDefaultLineSpacing;
+
+/// The default horizontal text scaling (per cent) for free-text: 100 is the
+/// font's natural glyph width.
+const double _defaultHorizontalScale = kPdfFreeTextDefaultHorizontalScale;
+
+/// One underline segment recorded while a free-text line is laid out, drawn
+/// as a filled rectangle after the enclosing text object closes.
+class _UnderlineRun {
+  const _UnderlineRun(this.x, this.baseline, this.width, this.fontSize,
+      this.color);
+
+  final double x;
+  final double baseline;
+  final double width;
+  final double fontSize;
+  final int color;
+}
+
 /// One styled run inside a rich free-text annotation.
 ///
 /// A normal FreeText annotation has one `/DA` default appearance. Runs let
@@ -59,12 +80,16 @@ class PdfFreeTextRun {
     this.font = PdfStandardFont.helvetica,
     this.fontSize = 12,
     this.color = 0x000000,
+    this.underline = false,
   });
 
   final String text;
   final PdfTextFont font;
   final double fontSize;
   final int color;
+
+  /// Whether this run is drawn with an underline.
+  final bool underline;
 }
 
 class _RichTextPiece {
@@ -76,7 +101,8 @@ class _RichTextPiece {
   bool sameStyle(PdfFreeTextRun other) =>
       style.font.resourceName == other.font.resourceName &&
       style.fontSize == other.fontSize &&
-      style.color == other.color;
+      style.color == other.color &&
+      style.underline == other.underline;
 }
 
 class _RichTextLine {
@@ -1729,6 +1755,10 @@ extension PdfAnnotationEditing on PdfEditor {
     int? fillColor,
     int? borderColor,
     double borderWidth = 1,
+    double lineSpacing = _defaultLineSpacing,
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
+    bool underline = false,
     int? pageRotation,
     String? author,
     String? name,
@@ -1762,6 +1792,10 @@ extension PdfAnnotationEditing on PdfEditor {
       fillColor: fillColor,
       borderColor: borderColor,
       borderWidth: borderWidth,
+      lineSpacing: lineSpacing,
+      charSpacing: charSpacing,
+      horizontalScale: horizontalScale,
+      underline: underline,
       pageRotation: effectivePageRotation,
     );
 
@@ -1776,6 +1810,11 @@ extension PdfAnnotationEditing on PdfEditor {
         align?.quadding ??
             (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0),
       );
+    _writeFreeTextSpacing(dict,
+        lineSpacing: lineSpacing,
+        charSpacing: charSpacing,
+        horizontalScale: horizontalScale,
+        underline: underline);
     if (borderColor != null && borderWidth > 0) {
       dict['BS'] = _borderStyle(borderWidth);
     }
@@ -1976,6 +2015,40 @@ extension PdfAnnotationEditing on PdfEditor {
     return (px.clamp(box.left, box.right).toDouble(), box.top);
   }
 
+  /// Persists the free-text spacing/decoration that /DA and /Q cannot carry
+  /// (line height, character spacing, horizontal scaling, whole-box
+  /// underline) onto [dict], as the vendor keys [PdfFreeTextStyle] reads
+  /// back. Default values are omitted so a plain box's dictionary is
+  /// unchanged.
+  static void _writeFreeTextSpacing(
+    CosDictionary dict, {
+    required double lineSpacing,
+    required double charSpacing,
+    required double horizontalScale,
+    required bool underline,
+  }) {
+    if (lineSpacing != _defaultLineSpacing) {
+      dict[kPdfFreeTextLineSpacingKey] = CosReal(lineSpacing);
+    } else {
+      dict.entries.remove(kPdfFreeTextLineSpacingKey);
+    }
+    if (charSpacing != 0) {
+      dict[kPdfFreeTextCharSpacingKey] = CosReal(charSpacing);
+    } else {
+      dict.entries.remove(kPdfFreeTextCharSpacingKey);
+    }
+    if (horizontalScale != _defaultHorizontalScale) {
+      dict[kPdfFreeTextHScaleKey] = CosReal(horizontalScale);
+    } else {
+      dict.entries.remove(kPdfFreeTextHScaleKey);
+    }
+    if (underline) {
+      dict[kPdfFreeTextUnderlineKey] = const CosBoolean(true);
+    } else {
+      dict.entries.remove(kPdfFreeTextUnderlineKey);
+    }
+  }
+
   /// The /RD (rectangle differences, §12.5.6.19) insets - left, top, right,
   /// bottom - from the annotation [rect] to the text [box] within it.
   CosArray _rdArray(PdfRect rect, PdfRect box) => CosArray([
@@ -2002,6 +2075,10 @@ extension PdfAnnotationEditing on PdfEditor {
     required int lineColor,
     required double lineWidth,
     required PdfLineEnding ending,
+    double lineSpacing = _defaultLineSpacing,
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
+    bool underline = false,
     int pageRotation = 0,
   }) {
     final leader = _lineContent(
@@ -2026,6 +2103,10 @@ extension PdfAnnotationEditing on PdfEditor {
       fillColor: fillColor,
       borderColor: borderColor,
       borderWidth: borderWidth,
+      lineSpacing: lineSpacing,
+      charSpacing: charSpacing,
+      horizontalScale: horizontalScale,
+      underline: underline,
       pageRotation: pageRotation,
     );
     return ContentWriter()
@@ -2192,6 +2273,9 @@ extension PdfAnnotationEditing on PdfEditor {
     int? fillColor,
     int? borderColor,
     double borderWidth = 1,
+    double lineSpacing = _defaultLineSpacing,
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
     int? pageRotation,
     String? author,
     String? name,
@@ -2216,6 +2300,7 @@ extension PdfAnnotationEditing on PdfEditor {
             font: PdfUnicodeFont(run.font as PdfStandardFont)..resetUsage(),
             fontSize: run.fontSize,
             color: run.color,
+            underline: run.underline,
           )
         else
           run,
@@ -2231,6 +2316,9 @@ extension PdfAnnotationEditing on PdfEditor {
       fillColor: fillColor,
       borderColor: borderColor,
       borderWidth: borderWidth,
+      lineSpacing: lineSpacing,
+      charSpacing: charSpacing,
+      horizontalScale: horizontalScale,
       pageRotation: effectivePageRotation,
     );
 
@@ -2253,6 +2341,13 @@ extension PdfAnnotationEditing on PdfEditor {
             align?.quadding ??
                 (textDirection.resolve(text) == PdfTextDirection.rtl ? 2 : 0),
           );
+    // a whole-box underline (every run underlined) is also mirrored in the
+    // box-level flag so a flat re-read still shows it
+    _writeFreeTextSpacing(dict,
+        lineSpacing: lineSpacing,
+        charSpacing: charSpacing,
+        horizontalScale: horizontalScale,
+        underline: nonEmpty.every((run) => run.underline));
     if (borderColor != null && borderWidth > 0) {
       dict['BS'] = _borderStyle(borderWidth);
     }
@@ -2305,6 +2400,7 @@ extension PdfAnnotationEditing on PdfEditor {
       if (font.isBold) parts.add('font-weight:bold');
       if (font.isItalic) parts.add('font-style:italic');
     }
+    if (run.underline) parts.add('text-decoration:underline');
     return parts.join(';');
   }
 
@@ -2337,6 +2433,8 @@ extension PdfAnnotationEditing on PdfEditor {
           font: _richSpanFont(style, fallbackFont),
           fontSize: _richSpanSize(style) ?? fallbackSize,
           color: _richSpanColor(style) ?? fallbackColor,
+          underline: RegExp(r'text-decoration\s*:\s*[^;]*underline')
+              .hasMatch(style),
         ),
       );
     }
@@ -2395,6 +2493,10 @@ extension PdfAnnotationEditing on PdfEditor {
     required int? fillColor,
     required int? borderColor,
     required double borderWidth,
+    double lineSpacing = _defaultLineSpacing,
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
+    bool underline = false,
     int pageRotation = 0,
   }) {
     const pad = 3.0;
@@ -2422,26 +2524,34 @@ extension PdfAnnotationEditing on PdfEditor {
         )
         ..stroke();
     }
+    final lineHeight = fontSize * lineSpacing;
     w
       ..save()
       ..rect(vr.left, vr.bottom, vr.width, vr.height)
       ..clip()
       ..beginText()
       ..font(font.resourceName, fontSize)
-      ..leading(fontSize * 1.2)
+      ..leading(lineHeight)
       ..fillColor(color);
+    if (charSpacing != 0) w.charSpacing(charSpacing);
+    if (horizontalScale != _defaultHorizontalScale) {
+      w.horizontalScale(horizontalScale);
+    }
     // first baseline sits one ascent below the top padding
     final firstY = vr.top - pad - fontSize * font.ascent / 1000;
-    final lines = _wrap(text, fontSize, vr.width - 2 * pad, font: font);
+    final lines = _wrap(text, fontSize, vr.width - 2 * pad,
+        font: font, charSpacing: charSpacing, horizontalScale: horizontalScale);
     final resolvedDirection = textDirection.resolve(text);
     final effectiveAlign = align ?? _alignForDirection(resolvedDirection);
+    final underlines = <_UnderlineRun>[];
     var prevX = 0.0;
     var prevY = 0.0;
     for (var i = 0; i < lines.length; i++) {
       final line = lines[i];
-      final width = font.measure(line, fontSize);
+      final width = _advanceWidth(font, line, fontSize,
+          charSpacing: charSpacing, horizontalScale: horizontalScale);
       final x = _lineX(effectiveAlign, vr, width, pad);
-      final y = firstY - i * fontSize * 1.2;
+      final y = firstY - i * lineHeight;
       w.textAt(x - prevX, y - prevY);
       if (font is PdfUnicodeFont) {
         // Logical order: our renderer's TextPainter applies BiDi and shaping
@@ -2456,14 +2566,31 @@ extension PdfAnnotationEditing on PdfEditor {
           w.showText(visual);
         }
       }
+      if (underline && line.isNotEmpty) {
+        underlines.add(_UnderlineRun(x, y, width, fontSize, color));
+      }
       prevX = x;
       prevY = y;
     }
-    w
-      ..endText()
-      ..restore();
+    w.endText();
+    _drawUnderlines(w, underlines);
+    w.restore();
     if (pageRotation != 0) w.restore();
     return w;
+  }
+
+  /// Draws the collected [runs] as filled underline rectangles - path
+  /// artwork must sit outside the enclosing BT/ET, so the caller records
+  /// each run during the text loop and flushes it here.
+  static void _drawUnderlines(ContentWriter w, List<_UnderlineRun> runs) {
+    for (final run in runs) {
+      final thickness = math.max(0.5, run.fontSize * 0.06);
+      final y = run.baseline - run.fontSize * 0.12;
+      w
+        ..fillColor(run.color)
+        ..rect(run.x, y, run.width, thickness)
+        ..fill();
+    }
   }
 
   ContentWriter _freeTextRichContent(
@@ -2474,6 +2601,9 @@ extension PdfAnnotationEditing on PdfEditor {
     required int? fillColor,
     required int? borderColor,
     required double borderWidth,
+    double lineSpacing = _defaultLineSpacing,
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
     int pageRotation = 0,
   }) {
     const pad = 3.0;
@@ -2504,18 +2634,24 @@ extension PdfAnnotationEditing on PdfEditor {
     final plain = runs.map((run) => run.text).join();
     final resolvedDirection = textDirection.resolve(plain);
     final effectiveAlign = align ?? _alignForDirection(resolvedDirection);
-    final lines = _wrapRich(runs, vr.width - 2 * pad);
+    final lines = _wrapRich(runs, vr.width - 2 * pad,
+        charSpacing: charSpacing, horizontalScale: horizontalScale);
     var top = vr.top - pad;
     var prevX = 0.0;
     var prevY = 0.0;
+    final underlines = <_UnderlineRun>[];
     w
       ..save()
       ..rect(vr.left, vr.bottom, vr.width, vr.height)
       ..clip()
       ..beginText();
+    if (charSpacing != 0) w.charSpacing(charSpacing);
+    if (horizontalScale != _defaultHorizontalScale) {
+      w.horizontalScale(horizontalScale);
+    }
     for (final line in lines) {
       if (line.runs.isEmpty) {
-        top -= 12 * 1.2;
+        top -= 12 * lineSpacing;
         continue;
       }
       final ascent = line.runs.fold<double>(
@@ -2525,7 +2661,7 @@ extension PdfAnnotationEditing on PdfEditor {
       );
       final lineHeight = line.runs.fold<double>(
         0,
-        (max, run) => math.max(max, run.style.fontSize * 1.2),
+        (max, run) => math.max(max, run.style.fontSize * lineSpacing),
       );
       var x = _lineX(effectiveAlign, vr, line.width, pad);
       final y = top - ascent;
@@ -2537,7 +2673,8 @@ extension PdfAnnotationEditing on PdfEditor {
         final isUnicode = style.font is PdfUnicodeFont;
         final visual =
             isUnicode ? run.text : pdfVisualText(run.text, resolvedDirection);
-        final width = style.font.measure(visual, style.fontSize);
+        final width = _advanceWidth(style.font, visual, style.fontSize,
+            charSpacing: charSpacing, horizontalScale: horizontalScale);
         w
           ..font(style.font.resourceName, style.fontSize)
           ..fillColor(style.color)
@@ -2549,15 +2686,19 @@ extension PdfAnnotationEditing on PdfEditor {
         } else {
           w.showText(visual);
         }
+        if (style.underline && run.text.isNotEmpty) {
+          underlines
+              .add(_UnderlineRun(x, y, width, style.fontSize, style.color));
+        }
         prevX = x;
         prevY = y;
         x += width;
       }
       top -= lineHeight;
     }
-    w
-      ..endText()
-      ..restore();
+    w.endText();
+    _drawUnderlines(w, underlines);
+    w.restore();
     if (pageRotation != 0) w.restore();
     return w;
   }
@@ -2627,6 +2768,25 @@ extension PdfAnnotationEditing on PdfEditor {
     }
   }
 
+  /// Rebuilds [runs] so any base-14 run carrying non-Latin-1 text is wrapped
+  /// in a fresh [PdfUnicodeFont] (Identity-H) - the standard faces only speak
+  /// WinAnsi. Preserves each run's size, colour, and underline. Shared by
+  /// [addFreeTextRich] and the resize regenerator.
+  List<PdfFreeTextRun> _wrapNonLatinRuns(List<PdfFreeTextRun> runs) => [
+        for (final run in runs)
+          if (run.font is PdfStandardFont &&
+              run.text.codeUnits.any((c) => c > 0xFF))
+            PdfFreeTextRun(
+              run.text,
+              font: PdfUnicodeFont(run.font as PdfStandardFont)..resetUsage(),
+              fontSize: run.fontSize,
+              color: run.color,
+              underline: run.underline,
+            )
+          else
+            run,
+      ];
+
   Iterable<PdfTextFont> _richFonts(List<PdfFreeTextRun> runs) sync* {
     final seen = <String>{};
     for (final run in runs) {
@@ -2650,7 +2810,12 @@ extension PdfAnnotationEditing on PdfEditor {
     return dict;
   }
 
-  List<_RichTextLine> _wrapRich(List<PdfFreeTextRun> runs, double maxWidth) {
+  List<_RichTextLine> _wrapRich(
+    List<PdfFreeTextRun> runs,
+    double maxWidth, {
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
+  }) {
     final lines = <_RichTextLine>[];
     var current = <_RichTextPiece>[];
     var width = 0.0;
@@ -2671,7 +2836,8 @@ extension PdfAnnotationEditing on PdfEditor {
       } else {
         current.add(_RichTextPiece(text, style));
       }
-      width += style.font.measure(text, style.fontSize);
+      width += _advanceWidth(style.font, text, style.fontSize,
+          charSpacing: charSpacing, horizontalScale: horizontalScale);
     }
 
     for (final run in runs) {
@@ -2681,7 +2847,8 @@ extension PdfAnnotationEditing on PdfEditor {
           continue;
         }
         final text = String.fromCharCode(rune);
-        final w = run.font.measure(text, run.fontSize);
+        final w = _advanceWidth(run.font, text, run.fontSize,
+            charSpacing: charSpacing, horizontalScale: horizontalScale);
         if (width > 0 && width + w > maxWidth + _wrapTolerance) flushLine();
         addText(run, text);
       }
@@ -4034,7 +4201,7 @@ extension PdfAnnotationEditing on PdfEditor {
   /// [opacity], when given, replaces the alpha the old appearance
   /// carried - [restyleAnnotation]'s opacity path.
   bool _regenerateResizedAppearance(PdfAnnotation annotation, PdfRect to,
-      {double? opacity, int pageRotation = 0}) {
+      {double? opacity, int pageRotation = 0, bool preserveRich = true}) {
     final behavior = annotation.behavior;
     if (behavior.resizeBehavior == PdfAnnotationResizeBehavior.none ||
         behavior.resizeBehavior == PdfAnnotationResizeBehavior.stretch) {
@@ -4069,72 +4236,134 @@ extension PdfAnnotationEditing on PdfEditor {
         return true;
       case 'FreeText':
         final style = behavior.style.freeText!;
-        final stdFont = behavior.standardTextFont!;
+        final stdFont = behavior.standardTextFont;
+        // an embedded/bundled-font box re-wraps in its own recovered face
+        // rather than reverting to Helvetica or stretching its glyphs
+        final embedded = stdFont == null
+            ? PdfEmbeddedFont.fromFreeText(annotation)
+            : null;
+        if (stdFont == null && embedded == null) return false;
         final text = annotation.contents ?? '';
-        PdfUnicodeFont? unicodeFont;
-        if (text.codeUnits.any((c) => c > 0xFF)) {
-          unicodeFont = PdfUnicodeFont(stdFont);
-          unicodeFont.resetUsage();
-        }
-        final PdfTextFont effectiveFont = unicodeFont ?? stdFont;
-        // A callout draws its leader line and box together, and its text box
-        // is a sub-rect of /Rect, so map both through the resize and keep /RD
-        // and /CL in step rather than filling the whole rect with text.
         final callout = _calloutInfo(annotation);
-        final ContentWriter w;
-        if (callout != null) {
-          final from = annotation.rect;
-          final sx = from.width == 0 ? 1.0 : to.width / from.width;
-          final sy = from.height == 0 ? 1.0 : to.height / from.height;
-          (double, double) map((double, double) p) => (
-                to.left + (p.$1 - from.left) * sx,
-                to.bottom + (p.$2 - from.bottom) * sy,
+        // a rich (/RC) box keeps its per-run styling across a resize; a
+        // restyle (colour/opacity) deliberately flattens to the new uniform
+        // /DA instead, so [preserveRich] is false there
+        final rc = preserveRich ? annotation.richContent : null;
+        final richRuns = (rc == null || callout != null)
+            ? null
+            : parseFreeTextRichContent(
+                rc,
+                fallbackFont: stdFont ?? PdfStandardFont.helvetica,
+                fallbackSize: style.fontSize,
+                fallbackColor: style.color,
               );
-          final line = [for (final p in callout.line) map(p)];
-          final oldBox = _boxFromRd(annotation, from);
-          final box = PdfRect(
-            to.left + (oldBox.left - from.left) * sx,
-            to.bottom + (oldBox.bottom - from.bottom) * sy,
-            to.left + (oldBox.right - from.left) * sx,
-            to.bottom + (oldBox.top - from.bottom) * sy,
-          );
-          dict['RD'] = _rdArray(to, box);
-          w = _calloutContent(
-            box,
-            line,
-            text,
-            fontSize: style.fontSize,
-            font: effectiveFont,
-            textDirection: PdfTextDirection.auto,
-            align: style.alignment,
-            color: style.color,
-            fillColor: style.fillColor,
-            borderColor: style.borderColor,
-            borderWidth: style.borderWidth,
-            lineColor: style.borderColor ?? style.color,
-            lineWidth: style.borderWidth > 0 ? style.borderWidth : 1,
-            ending: callout.ending,
-            pageRotation: pageRotation,
-          );
-        } else {
-          w = _freeTextContent(
+        final ContentWriter w;
+        final CosDictionary fontResource;
+        if (richRuns != null && richRuns.isNotEmpty) {
+          final runs = style.underline
+              ? [
+                  for (final r in richRuns)
+                    PdfFreeTextRun(r.text,
+                        font: r.font,
+                        fontSize: r.fontSize,
+                        color: r.color,
+                        underline: true)
+                ]
+              : richRuns;
+          final effective = _wrapNonLatinRuns(runs);
+          for (final font in _richFonts(effective)) {
+            if (font is PdfEmbeddedFont) font.resetUsage();
+          }
+          w = _freeTextRichContent(
             to,
-            text,
-            fontSize: style.fontSize,
-            font: effectiveFont,
-            // direction follows the text; /Q carries the explicit alignment
+            effective,
             textDirection: PdfTextDirection.auto,
             align: style.alignment,
-            color: style.color,
             fillColor: style.fillColor,
             borderColor: style.borderColor,
             borderWidth: style.borderWidth,
+            lineSpacing: style.lineSpacing,
+            charSpacing: style.charSpacing,
+            horizontalScale: style.horizontalScale,
             pageRotation: pageRotation,
           );
+          fontResource = _richFontResources(effective);
+        } else {
+          final PdfTextFont baseFont = embedded ?? stdFont!;
+          PdfUnicodeFont? unicodeFont;
+          if (baseFont is PdfStandardFont &&
+              text.codeUnits.any((c) => c > 0xFF)) {
+            unicodeFont = PdfUnicodeFont(baseFont)..resetUsage();
+          }
+          if (baseFont is PdfEmbeddedFont) baseFont.resetUsage();
+          final PdfTextFont effectiveFont = unicodeFont ?? baseFont;
+          if (callout != null) {
+            // A callout draws its leader line and box together, and its text
+            // box is a sub-rect of /Rect, so map both through the resize and
+            // keep /RD and /CL in step rather than filling the whole rect.
+            final from = annotation.rect;
+            final sx = from.width == 0 ? 1.0 : to.width / from.width;
+            final sy = from.height == 0 ? 1.0 : to.height / from.height;
+            (double, double) map((double, double) p) => (
+                  to.left + (p.$1 - from.left) * sx,
+                  to.bottom + (p.$2 - from.bottom) * sy,
+                );
+            final line = [for (final p in callout.line) map(p)];
+            final oldBox = _boxFromRd(annotation, from);
+            final box = PdfRect(
+              to.left + (oldBox.left - from.left) * sx,
+              to.bottom + (oldBox.bottom - from.bottom) * sy,
+              to.left + (oldBox.right - from.left) * sx,
+              to.bottom + (oldBox.top - from.bottom) * sy,
+            );
+            dict['RD'] = _rdArray(to, box);
+            w = _calloutContent(
+              box,
+              line,
+              text,
+              fontSize: style.fontSize,
+              font: effectiveFont,
+              textDirection: PdfTextDirection.auto,
+              align: style.alignment,
+              color: style.color,
+              fillColor: style.fillColor,
+              borderColor: style.borderColor,
+              borderWidth: style.borderWidth,
+              lineColor: style.borderColor ?? style.color,
+              lineWidth: style.borderWidth > 0 ? style.borderWidth : 1,
+              ending: callout.ending,
+              lineSpacing: style.lineSpacing,
+              charSpacing: style.charSpacing,
+              horizontalScale: style.horizontalScale,
+              underline: style.underline,
+              pageRotation: pageRotation,
+            );
+          } else {
+            w = _freeTextContent(
+              to,
+              text,
+              fontSize: style.fontSize,
+              font: effectiveFont,
+              // direction follows the text; /Q carries the explicit alignment
+              textDirection: PdfTextDirection.auto,
+              align: style.alignment,
+              color: style.color,
+              fillColor: style.fillColor,
+              borderColor: style.borderColor,
+              borderWidth: style.borderWidth,
+              lineSpacing: style.lineSpacing,
+              charSpacing: style.charSpacing,
+              horizontalScale: style.horizontalScale,
+              underline: style.underline,
+              pageRotation: pageRotation,
+            );
+          }
+          fontResource = unicodeFont != null
+              ? unicodeFont.buildResource(_updater.addObject)
+              : baseFont is PdfEmbeddedFont
+                  ? baseFont.buildResource(_updater.addObject)
+                  : _standardFont(baseFont as PdfStandardFont);
         }
-        final CosDictionary fontResource = unicodeFont != null
-            ? unicodeFont.buildResource(_updater.addObject)
-            : _standardFont(stdFont);
         _replaceAppearance(
           dict,
           form,
@@ -4494,6 +4723,7 @@ extension PdfAnnotationEditing on PdfEditor {
           to,
           opacity: opacity,
           pageRotation: pageRotation,
+          preserveRich: false,
         );
       case 'Stamp':
         final form = annotation.normalAppearance;
@@ -5527,6 +5757,8 @@ extension PdfAnnotationEditing on PdfEditor {
     double fontSize,
     double maxWidth, {
     PdfTextFont font = PdfStandardFont.helvetica,
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
   }) {
     final lines = <String>[];
     for (final paragraph in text.split('\n')) {
@@ -5534,7 +5766,10 @@ extension PdfAnnotationEditing on PdfEditor {
       for (final word in paragraph.split(' ')) {
         final candidate = line.isEmpty ? word : '$line $word';
         if (line.isNotEmpty &&
-            font.measure(candidate, fontSize) > maxWidth + _wrapTolerance) {
+            _advanceWidth(font, candidate, fontSize,
+                    charSpacing: charSpacing,
+                    horizontalScale: horizontalScale) >
+                maxWidth + _wrapTolerance) {
           lines.add(line);
           line = word;
         } else {
@@ -5544,5 +5779,20 @@ extension PdfAnnotationEditing on PdfEditor {
       lines.add(line);
     }
     return lines;
+  }
+
+  /// The horizontal advance of [text] at [fontSize] in [font], including the
+  /// per-glyph [charSpacing] (Tc) and the [horizontalScale] per cent (Tz) -
+  /// so wrapping and alignment measure the same width the appearance draws.
+  static double _advanceWidth(
+    PdfTextFont font,
+    String text,
+    double fontSize, {
+    double charSpacing = 0,
+    double horizontalScale = _defaultHorizontalScale,
+  }) {
+    final natural = font.measure(text, fontSize);
+    final count = text.runes.length;
+    return (natural + charSpacing * count) * (horizontalScale / 100);
   }
 }

--- a/packages/pdf_document/lib/src/content_writer.dart
+++ b/packages/pdf_document/lib/src/content_writer.dart
@@ -255,6 +255,14 @@ class ContentWriter {
   void leading(double value) => op('TL', [value]);
   void textAt(double x, double y) => op('Td', [x, y]);
 
+  /// Sets the character spacing (`Tc`, §9.3.2): extra space added after each
+  /// glyph, in unscaled text-space units (points at the nominal size).
+  void charSpacing(double value) => op('Tc', [value]);
+
+  /// Sets the horizontal text scaling (`Tz`, §9.3.4) as a percentage - 100
+  /// is the font's natural width, 150 stretches glyphs to 1.5×.
+  void horizontalScale(double percent) => op('Tz', [percent]);
+
   void showText(String text) {
     _buffer.write('(');
     for (final code in text.codeUnits) {

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -1399,6 +1399,91 @@ void main() {
     expect(double.parse(m!.group(1)!), greaterThan(150));
   });
 
+  test('free text line/character spacing and width round-trip and emit', () {
+    final doc = roundTrip((e) => e.addFreeText(
+          0,
+          const PdfRect(100, 600, 400, 660),
+          'Spaced out text',
+          lineSpacing: 2.0,
+          charSpacing: 3,
+          horizontalScale: 150,
+        ));
+    final box = doc.page(0).annotations.single;
+    final style = box.freeTextStyle!;
+    expect(style.lineSpacing, closeTo(2.0, 1e-9));
+    expect(style.charSpacing, closeTo(3, 1e-9));
+    expect(style.horizontalScale, closeTo(150, 1e-9));
+
+    final content = appearanceText(doc, box);
+    expect(content, contains('3 Tc'));
+    expect(content, contains('150 Tz'));
+    // leading is fontSize (12) * lineSpacing (2) = 24
+    expect(content, contains('24 TL'));
+
+    // the values survive a resize (which regenerates the appearance)
+    final editor = PdfEditor(doc)
+      ..resizeAnnotation(0, box, const PdfRect(100, 600, 520, 660));
+    final reopened = PdfDocument.open(editor.save());
+    final resized = reopened.page(0).annotations.single.freeTextStyle!;
+    expect(resized.lineSpacing, closeTo(2.0, 1e-9));
+    expect(resized.charSpacing, closeTo(3, 1e-9));
+    expect(resized.horizontalScale, closeTo(150, 1e-9));
+    expect(appearanceText(reopened, reopened.page(0).annotations.single),
+        contains('150 Tz'));
+  });
+
+  test('a plain free text box writes no spacing keys', () {
+    final doc = roundTrip(
+        (e) => e.addFreeText(0, const PdfRect(100, 600, 400, 640), 'Plain'));
+    final dict = doc.page(0).annotations.single.dict;
+    expect(dict[kPdfFreeTextLineSpacingKey], isNull);
+    expect(dict[kPdfFreeTextCharSpacingKey], isNull);
+    expect(dict[kPdfFreeTextHScaleKey], isNull);
+    expect(dict[kPdfFreeTextUnderlineKey], isNull);
+  });
+
+  test('underlined free text draws a rule and round-trips the flag', () {
+    final doc = roundTrip((e) => e.addFreeText(
+          0,
+          const PdfRect(100, 600, 400, 640),
+          'Underlined',
+          underline: true,
+        ));
+    final box = doc.page(0).annotations.single;
+    expect(box.freeTextStyle!.underline, isTrue);
+    // the underline is a filled rectangle drawn after the text object
+    final content = appearanceText(doc, box);
+    expect(content, contains('ET'));
+    expect(content.lastIndexOf(' re'), greaterThan(content.lastIndexOf('ET')));
+
+    // it survives a resize
+    final editor = PdfEditor(doc)
+      ..resizeAnnotation(0, box, const PdfRect(100, 600, 500, 640));
+    final reopened = PdfDocument.open(editor.save());
+    expect(reopened.page(0).annotations.single.freeTextStyle!.underline,
+        isTrue);
+  });
+
+  test('rich free text carries per-run underline through /RC', () {
+    final doc = roundTrip((e) => e.addFreeTextRich(
+          0,
+          const PdfRect(100, 600, 400, 640),
+          const [
+            PdfFreeTextRun('plain '),
+            PdfFreeTextRun('under', underline: true),
+          ],
+        ));
+    final box = doc.page(0).annotations.single;
+    final rc = box.richContent!;
+    expect(rc, contains('text-decoration:underline'));
+    final runs = PdfAnnotationEditing.parseFreeTextRichContent(rc);
+    expect(runs.where((r) => r.underline).map((r) => r.text).join(),
+        contains('under'));
+    // the appearance draws one underline rule (a re after the text object)
+    final content = appearanceText(doc, box);
+    expect(content.lastIndexOf('ET'), lessThan(content.lastIndexOf(' re')));
+  });
+
   test('resizeAnnotation rejects degenerate rects', () {
     final first = PdfEditor(PdfDocument.open(buildClassicPdf()))
       ..addSquare(0, const PdfRect(100, 100, 200, 150));


### PR DESCRIPTION
## Summary

A batch of free-text (FreeText annotation) reports from using the editor —
four bug fixes and four new box-styling controls. They share plumbing, so
they land together.

**New controls** (tune popup + properties panel):
- **Line spacing** (leading multiplier), **character spacing** (Tc),
  **font width** (horizontal glyph scaling, Tz), and **underline**.
- Underline is a per-character format like bold: an inline style-chip button
  and Cmd/Ctrl+U toggle it on the selection (or the whole box when nothing is
  selected). The other three are box-level.

**Fixes:**
- **Backspace ate bold from the line below.** The inline editor's style runs
  were absolute offsets that never moved on an edit, so a run slid one char
  per keystroke. Runs now re-map across every insert/delete.
- **Resize stretched the text.** Embedded/bundled-font boxes fell to the
  §12.5.5 stretch; they now re-wrap in the recovered face like base-14 boxes,
  and rich per-run styling survives the resize.
- **Alignment reset to left on resize.** The committed appearance always kept
  `/Q`, but the resize preview/afterimage were hard-coded start-aligned so a
  centred/right box appeared to snap left mid-drag. Alignment (and underline
  + line spacing) now ride the preview.
- **Font picker showed "Sans" after a font change.** It read a base-14 face
  from `/DA`; it now reports the box's real embedded font name.
- **Tune-popup line spacing was wrong until the popup closed.** The inline
  preview took its line height from each run's font; it's now pinned to the
  box's font-independent leading (a forced strut), matching the appearance.

Appearance details, persistence choices, and known limitations are in
`doc/dev-log/2026-07-16-text-box-features-fixes.md`.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Feature
- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/pdf_document && fvm dart test` (638 pass)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (1430 pass)

Not run: `pdf_cos`/`pdf_graphics` tests (untouched), Ghent/corpus/example
smoke tests — this change is annotation-editing only and is covered by the
programmatic annotation and inline-editor widget tests.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The new spacing/underline have no standard PDF representation, so they ride
  vendor dictionary keys (`LineSpacing`/`CharSpacing`/`HScale`/`TextUnderline`,
  written only when non-default) and `/RC`'s `text-decoration:underline` for
  per-run underline.
- Creation defaults for spacing/underline are session-only (not persisted) —
  consistent with `activeFont`.
- Horizontal scaling (Tz) has no Flutter `TextField` equivalent, so it isn't
  previewed live in the inline editor (it shows once the raster lands);
  embedded-font resize previews use the stretch ghost during the drag (only
  the commit re-wraps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0151Z6sSJuDyd6ZAAtBLhR6a)_