### PR TITLE
Bound the render worker record cache by entry count (#283)

### DIFF
--- a/doc/dev-log/2026-07-16-render-cache-entry-cap.md
+++ b/doc/dev-log/2026-07-16-render-cache-entry-cap.md
@@ -1,0 +1,74 @@
+# 2026-07-16 — Bound the render worker record cache by entry count (#283)
+
+Branch `claude/text-box-features-fixes-3ad025`. Issue #283: on web, tab memory
+grows ~20 MB per page scrolled and is never released, even after the page
+leaves the viewport and a forced GC. The growth appears unbounded in the page
+count, which is the real worry — a long document (or a mobile browser with a
+lower ceiling) plausibly hits the wall.
+
+## What was ruled out
+
+The per-page widget lifecycle is clean. The list is a plain lazy
+`ExactExtentListView` with no `AutomaticKeepAlive`, so a page's
+`_PdfPageViewState` is disposed once it scrolls past the 250 px cache extent,
+and `dispose()` releases everything it holds: `_picture`/`_slugPicture`
+(`_dropPicture`), the retained `_scene` (`_setScene(null)` →
+`PdfRetainedScene.dispose`, which disposes its decoded `ui.Image`s), and
+`_image`/`_detailImage`/`_preview`. `PdfPageRenderSession` holds no pixels.
+
+The two named caches are already bounded: `PdfPagePreviewCache` (300 previews
+at ~125 KB + a 32 MB full-raster budget) and the per-worker
+`PdfWorkerTranscriptCache` (LRU cap 4). `PdfImageCache` is a byte-bounded LRU
+(64–128 MB on web).
+
+## The unbounded structure
+
+`PdfCachingRenderWorker._cache` (`render_worker.dart`) is one map on the main
+isolate wrapping the whole worker pool. It is keyed by
+`(pageIndex, annotations, decodeImages, ratioBucket, commandLimit, region)`
+and is *designed* to outlive the disposed page widget so a recycled/rebuilt
+page is served without a re-decode. It was bounded only by decoded-image bytes
+(`pdfRenderWorkerCacheBudgetBytes`, 96 MB), and eviction (`_oldestHeavyKey`)
+**only ever removed entries with `weight > 0`.**
+
+`_weigh` counts decoded RGBA only. So every image-free page and every
+vector-first prefetch pass (`decodeImages: false`) produces a **weight-0**
+record that the byte budget cannot see and the eviction loop never touches —
+and there was no cap on the entry *count*. On a long scroll those pile up one
+(or more, across ratio/region key variants) per page for the whole life of the
+worker: retention keyed by page index that only grows. That is the piece that
+makes the growth unbounded in the page count.
+
+## The fix
+
+Add a second bound to `_store`: after the byte-budget loop, evict the
+least-recently-used records — weight-0 or not — until the map is back under a
+maximum entry count (`pdfRenderWorkerCacheMaxEntries`, default 64), never
+evicting the entry just inserted. The byte-budget semantics are unchanged (it
+still bounds decoded pixels and still prefers to keep the cheap weight-0
+buffers *within* the count budget); the count cap only stops the weightless
+tail from growing without limit. 64 sits well above the on-screen + preview
+warm working set (`previewWindow` ≤ 10 each side), so ordinary back-and-forth
+revisits still hit. On-screen and recently-touched pages are the most-recently
+used, so they are never the LRU victim.
+
+Tests in `render_worker_test.dart`: the count is bounded across a 10-page
+weight-0 scroll (cap 3); count eviction is LRU (a touched page survives, the
+untouched LRU page is dropped); evicting a heavy LRU record decrements the byte
+total; and the runtime default / explicit-override plumbing.
+
+## Left open / scope
+
+- This bounds the unbounded *Dart-side* main-isolate retention. The bulk of the
+  ~1.9 GB the issue measured on a 62-page scroll is CanvasKit's wasm heap,
+  which (as `performance_policy.dart` already notes) never shrinks back after
+  `ui.Image.dispose()` on web — an engine characteristic, mitigated by the
+  existing `imagePixelRatioCap` tiers, not fixable from Dart. For the reported
+  62-page document the entry cap is a modest saving; its real value is the long
+  document / high-page-count case the issue is most worried about, where the
+  old behaviour was unbounded.
+- The viewer's per-page maps (`_textCache` / `_annotCache` /
+  `_visibleAnnotCache` / `_fieldRectCache` in `pdf_viewer.dart`) also grow one
+  small entry per page visited and are cleared only on a document/revision
+  swap. They hold text/annotation objects, not pixels, so the footprint is
+  minor; bounding them is a possible follow-up.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Bound the render worker's page-record cache by entry count, not only by
+  decoded-image bytes: image-free and vector-first records weigh zero, so on a
+  long scroll they used to accumulate one (or more) per page for the life of
+  the worker with no limit (issue #283). The cache now caps retained records
+  (`pdfRenderWorkerCacheMaxEntries`, default 64), so a long document's memory
+  no longer grows unbounded in the page count.
 - Free-text boxes: add line spacing, character spacing, font width
   (horizontal scaling), and underline controls (tune popup + properties
   panel), with an inline underline toggle and Cmd/Ctrl+U shortcut.

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -62,6 +62,21 @@ const int defaultPdfRenderWorkerCacheBudgetBytes = 96 << 20;
 /// constrained devices can lower it once at startup before opening viewers.
 int pdfRenderWorkerCacheBudgetBytes = defaultPdfRenderWorkerCacheBudgetBytes;
 
+/// Default maximum number of records the caching worker retains.
+const int defaultPdfRenderWorkerCacheMaxEntries = 64;
+
+/// Maximum number of records the caching worker retains, regardless of weight.
+///
+/// The byte budget ([pdfRenderWorkerCacheBudgetBytes]) only bounds decoded image
+/// pixels, so image-free and vector-first records weigh zero and never trip it.
+/// Without a second bound they accumulate one (or more) per page for the whole
+/// life of the worker - unbounded in the page count, which is exactly the tab
+/// growth issue #283 measured on a long scroll. This caps the retained record
+/// count so a thousand-page scroll cannot pin a thousand transcripts; the window
+/// stays well above the on-screen plus preview-warm working set, so ordinary
+/// revisits still hit. Lower it once at startup on memory-constrained devices.
+int pdfRenderWorkerCacheMaxEntries = defaultPdfRenderWorkerCacheMaxEntries;
+
 /// Whether newly-created web render workers reuse one image-free page
 /// transcript across progressive record, image, detail, and strip phases.
 ///
@@ -632,11 +647,18 @@ typedef _RecordCacheKey = (int, bool, bool, int, int?, _RegionBucket?);
 /// those repeats into one decode per page. A scrolled-away page is cancelled
 /// for every sharer at once, which is correct - none of them want it any more.
 class PdfCachingRenderWorker extends PdfRenderWorker {
-  PdfCachingRenderWorker(this._inner, {int? budgetBytes})
-      : _budgetBytes = budgetBytes ?? pdfRenderWorkerCacheBudgetBytes;
+  PdfCachingRenderWorker(this._inner, {int? budgetBytes, int? maxEntries})
+      : _budgetBytes = budgetBytes ?? pdfRenderWorkerCacheBudgetBytes,
+        _maxEntries =
+            math.max(1, maxEntries ?? pdfRenderWorkerCacheMaxEntries);
 
   final PdfRenderWorker _inner;
   final int _budgetBytes;
+
+  /// Hard cap on retained records, bounding the weight-0 (image-free /
+  /// vector-first) records the byte budget cannot see. See
+  /// [pdfRenderWorkerCacheMaxEntries].
+  final int _maxEntries;
 
   // LinkedHashMap iteration order doubles as LRU order: a hit re-inserts to
   // the end, eviction takes the oldest (first) key.
@@ -657,6 +679,12 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
 
   /// Maximum decoded image bytes this cache tries to retain.
   int get cacheBudgetBytes => _budgetBytes;
+
+  /// Records currently retained (both weight-bearing and weight-0).
+  int get cachedEntryCount => _cache.length;
+
+  /// Maximum records this cache retains regardless of weight.
+  int get cacheMaxEntries => _maxEntries;
 
   /// Fraction of [cacheBudgetBytes] currently occupied by decoded image data.
   double get cachePressure {
@@ -865,6 +893,16 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
       final victim = _oldestHeavyKey(except: key);
       if (victim == null) break; // nothing left worth evicting
       _bytes -= _cache.remove(victim)!.weight;
+    }
+    // Second bound: total record count. The byte budget above cannot see the
+    // weight-0 records (image-free pages, vector-first passes), so on a long
+    // scroll they would otherwise pile up one-per-page without limit (issue
+    // #283). Evict the least-recently-used records - weight-0 or not - until
+    // back under the cap, never the entry we just inserted.
+    while (_cache.length > _maxEntries) {
+      final oldest = _cache.keys.first;
+      if (oldest == key) break;
+      _bytes -= _cache.remove(oldest)!.weight;
     }
   }
 

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -776,6 +776,84 @@ void main() {
       expect(inner.calls.length, 2, reason: 'a declined page must re-ask');
     });
 
+    test('the record count is bounded so weight-0 pages cannot grow unbounded',
+        () async {
+      // Every record weighs 0 (image-free), so the byte budget never trips.
+      // Without the entry cap these would pile up one-per-page for the whole
+      // life of the worker - the unbounded growth issue #283 measured.
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner, maxEntries: 3);
+      addTearDown(worker.dispose);
+      for (var page = 0; page < 10; page++) {
+        await worker.record(page, decodeImages: false);
+      }
+      expect(worker.cachedEntryCount, 3,
+          reason: 'the cache is capped, not one entry per page scrolled');
+      expect(inner.calls.length, 10);
+      // The oldest pages were evicted, so page 0 must re-record.
+      await worker.record(0, decodeImages: false);
+      expect(inner.calls.length, 11, reason: 'the evicted page 0 re-records');
+      // The most-recent survivors still hit.
+      await worker.record(9, decodeImages: false);
+      await worker.record(8, decodeImages: false);
+      expect(inner.calls.length, 11, reason: 'recent pages stayed cached');
+    });
+
+    test('count eviction removes the least-recently-used record', () async {
+      final inner = _CountingWorker();
+      final worker = PdfCachingRenderWorker(inner, maxEntries: 3);
+      addTearDown(worker.dispose);
+      await worker.record(0, decodeImages: false); // {0}
+      await worker.record(1, decodeImages: false); // {0,1}
+      await worker.record(2, decodeImages: false); // {0,1,2}
+      await worker.record(0, decodeImages: false); // hit: 0 now MRU -> {1,2,0}
+      expect(inner.calls.length, 3);
+      await worker.record(3, decodeImages: false); // count 4>3: evict LRU (1)
+      expect(inner.calls.length, 4);
+      expect(worker.cachedEntryCount, 3);
+      await worker.record(0, decodeImages: false); // still cached
+      await worker.record(2, decodeImages: false); // still cached
+      expect(inner.calls.length, 4, reason: 'touched pages survived');
+      await worker.record(1, decodeImages: false); // 1 was the LRU eviction
+      expect(inner.calls.length, 5, reason: 'the least-recently-used page went');
+    });
+
+    test('count eviction of a heavy record frees its decoded bytes', () async {
+      final inner = _CountingWorker(decodedPixels: 64); // 256 bytes each
+      // A byte budget wide enough to never trip, so only the count cap evicts.
+      final worker =
+          PdfCachingRenderWorker(inner, budgetBytes: 1 << 20, maxEntries: 2);
+      addTearDown(worker.dispose);
+      await worker.record(0, imagePixelRatio: 2.0); // {0} bytes=256
+      await worker.record(1, imagePixelRatio: 2.0); // {0,1} bytes=512
+      await worker.record(2, imagePixelRatio: 2.0); // evict LRU 0, bytes=512
+      expect(worker.cachedEntryCount, 2);
+      expect(worker.cachedBytes, 256 * 2,
+          reason: 'evicting the LRU heavy record decremented the byte total');
+    });
+
+    test('uses the runtime default cache max entries when not overridden', () {
+      final previous = pdfRenderWorkerCacheMaxEntries;
+      addTearDown(() => pdfRenderWorkerCacheMaxEntries = previous);
+
+      pdfRenderWorkerCacheMaxEntries = 7;
+      final worker = PdfCachingRenderWorker(_CountingWorker());
+      addTearDown(worker.dispose);
+
+      expect(worker.cacheMaxEntries, 7);
+    });
+
+    test('explicit max entries overrides the runtime default', () {
+      final previous = pdfRenderWorkerCacheMaxEntries;
+      addTearDown(() => pdfRenderWorkerCacheMaxEntries = previous);
+
+      pdfRenderWorkerCacheMaxEntries = 7;
+      final worker = PdfCachingRenderWorker(_CountingWorker(), maxEntries: 9);
+      addTearDown(worker.dispose);
+
+      expect(worker.cacheMaxEntries, 9);
+    });
+
     test('record bypasses the cache while the inner worker is inactive',
         () async {
       final inner = _CountingWorker()..active = false;


### PR DESCRIPTION
## Summary

Fixes the unbounded-in-page-count half of #283 (web tab memory grows per page scrolled and is never released).

The main-isolate `PdfCachingRenderWorker._cache` (`render_worker.dart`) is one map wrapping the whole worker pool, keyed by `(pageIndex, annotations, decodeImages, ratioBucket, commandLimit, region)`. It is *designed* to outlive the disposed page widget so a recycled/rebuilt page is served without a re-decode. It was bounded **only** by decoded-image bytes (`pdfRenderWorkerCacheBudgetBytes`, 96 MB), and its eviction (`_oldestHeavyKey`) only ever removed entries with `weight > 0`. `_weigh` counts decoded RGBA only, so **every image-free page and every vector-first prefetch pass (`decodeImages: false`) produces a weight-0 record the byte budget can't see** — and there was no cap on the entry *count*. On a long scroll those pile up one (or more, across ratio/region key variants) per page for the life of the worker: retention keyed by page index that grows without limit. That is the piece that makes the growth unbounded in the page count.

The fix adds a second bound to `_store`: after the byte-budget loop, evict the least-recently-used records — weight-0 or not — until the map is back under a maximum entry count (`pdfRenderWorkerCacheMaxEntries`, default 64), never evicting the entry just inserted. The byte-budget semantics are unchanged (it still bounds decoded pixels and still prefers keeping the cheap weight-0 buffers *within* the count budget); the count cap only stops the weightless tail from growing without limit. The cap sits well above the on-screen + preview-warm working set (`previewWindow` ≤ 10 each side), so ordinary revisits still hit, and on-screen/recently-touched pages are the most-recently used so they are never the LRU victim.

**Investigation notes** (what was ruled out): the per-page widget lifecycle is clean — the lazy `ExactExtentListView` has no keep-alive, so `_PdfPageViewState.dispose()` releases its picture, retained scene (+ decoded images), and rasters on scroll-out; `PdfPagePreviewCache`, `PdfWorkerTranscriptCache`, and `PdfImageCache` are all already bounded. See `doc/dev-log/2026-07-16-render-cache-entry-cap.md`.

**Scope / left open:** this bounds the unbounded *Dart-side* main-isolate retention. The bulk of the ~1.9 GB the issue measured on a 62-page scroll is CanvasKit's wasm heap, which never shrinks back after `ui.Image.dispose()` on web (already noted in `performance_policy.dart`) — an engine characteristic mitigated by the existing `imagePixelRatioCap` tiers, not fixable from Dart. For the reported 62-page document the cap is a modest saving; its real value is the long-document / high-page-count case the issue is most worried about, where the old behaviour was unbounded.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Performance change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

`dart analyze` is clean across the package; the full `dart_pdf_editor` suite passes (1448 passed, 35 pre-existing skips), including 5 new `render_worker_test.dart` cases: the record count is bounded across a weight-0 scroll, count eviction is LRU (a touched page survives, the untouched LRU page is dropped), evicting a heavy LRU record decrements the byte total, and the runtime-default / explicit-override plumbing.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Default cap is 64 and is overridable per-worker (`maxEntries:`) and globally (`pdfRenderWorkerCacheMaxEntries`), mirroring `pdfRenderWorkerCacheBudgetBytes`. On a memory-constrained device a host can lower it once at startup.
- A possible follow-up (not in this PR): the viewer's per-page maps (`_textCache` / `_annotCache` / `_visibleAnnotCache` / `_fieldRectCache`) also grow one small entry per page visited and are cleared only on a document/revision swap. They hold text/annotation objects, not pixels, so the footprint is minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151Z6sSJuDyd6ZAAtBLhR6a

---
_Generated by [Claude Code](https://claude.ai/code/session_0151Z6sSJuDyd6ZAAtBLhR6a)_