### PR TITLE
Fill cloudy polygons to the scalloped cloud edges

### DIFF
--- a/doc/dev-log/2026-07-16-cloud-polygon-fill-edges.md
+++ b/doc/dev-log/2026-07-16-cloud-polygon-fill-edges.md
@@ -1,0 +1,34 @@
+# Cloud polygon fill: paint to the scalloped edges
+
+## What changed
+
+A cloudy (`/BE` Cloudy) filled polygon painted its interior colour only up
+to the *straight* polygon footprint (the line through the /Vertices), while
+the scalloped border puffs bulge outward past those edges. The result was an
+unfilled crescent between each straight edge and its row of scallops - the
+fill visibly stopped short of the cloud outline.
+
+Now the interior is filled along the **scalloped cloud path** itself, so the
+colour reaches the puffed edges.
+
+## Where
+
+- `pdf_document` `annotation_editor.dart` `_cloudPolygonContent`: instead of
+  filling the straight vertex polygon (`f`) and then stroking the cloud path
+  (`S`) as two separate constructions, it now builds the cloud path once via
+  `_appendCloudPath` and fills+strokes it in one pass (`B`) - nonstroking
+  colour for the fill, stroking colour for the outline. All three cloud
+  callers (add, update, style-flatten) go through this function, so they all
+  get the fix.
+- `dart_pdf_editor` `editing_overlay.dart` `_paintCloudPolygon`: the live
+  preview mirrored the same "fill the straight polygon" shortcut; it now
+  fills the `_cloudPath` (already a closed path) so the preview matches the
+  committed appearance.
+
+## Tests
+
+- `annotation_editor_test.dart` "cloud polygon carries border effect …" now
+  asserts a combined `B` operator (fill+stroke of the cloud path) rather than
+  separate `f`/`S`.
+- The BBox-containment test is unchanged: the cloud path geometry didn't
+  move, only what gets filled.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -5920,19 +5920,16 @@ class _EditingPreviewPainter extends CustomPainter {
   void _paintCloudPolygon(Canvas canvas, List<Offset> points, Color color,
       Color? fillColor, double width, bool dashed) {
     if (points.length < 3) return;
-    final fillPath = Path()..moveTo(points.first.dx, points.first.dy);
-    for (final point in points.skip(1)) {
-      fillPath.lineTo(point.dx, point.dy);
-    }
-    fillPath.close();
+    final cloud = _cloudPath(points, width);
     if (fillColor != null) {
+      // Fill the scalloped outline itself so the interior colour reaches the
+      // puffed edges, matching the committed appearance stream.
       canvas.drawPath(
-          fillPath,
+          cloud,
           Paint()
             ..color = fillColor
             ..style = PaintingStyle.fill);
     }
-    final cloud = _cloudPath(points, width);
     canvas.drawPath(
         dashed ? _dashPath(cloud, width) : cloud,
         Paint()

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -5265,19 +5265,10 @@ extension PdfAnnotationEditing on PdfEditor {
     final w = ContentWriter();
     if (hasAlpha) w.extGState('GS0');
 
-    // Fill the actual polygon footprint first. The cloudy border then
-    // protrudes from it, matching the /Vertices geometry while still
-    // producing the expected cloud outline in viewers that honor /AP.
-    if (fillColor != null) {
-      w.fillColor(fillColor);
-      w.moveTo(points.first.$1, points.first.$2);
-      for (final (x, y) in points.skip(1)) {
-        w.lineTo(x, y);
-      }
-      w.closePath();
-      w.fill();
-    }
-
+    // Fill the actual scalloped cloud outline (not just the straight-edged
+    // polygon footprint) so the interior colour reaches the puffed edges.
+    // The same path is stroked, so fill and stroke share one construction.
+    if (fillColor != null) w.fillColor(fillColor);
     w
       ..strokeColor(strokeColor)
       ..lineWidth(strokeWidth)
@@ -5285,7 +5276,11 @@ extension PdfAnnotationEditing on PdfEditor {
       ..lineJoin(1);
     if (dashed) w.dash(dashPattern);
     _appendCloudPath(w, points, strokeWidth);
-    w.stroke();
+    if (fillColor != null) {
+      w.fillAndStroke();
+    } else {
+      w.stroke();
+    }
     if (dashed) w.dash(const []);
     return w;
   }

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -1103,8 +1103,10 @@ void main() {
     expect(annotation.rect.right, greaterThan(220));
     final content = appearanceText(doc, annotation);
     expect(content, contains(' c\n'));
-    expect(content, contains('f\n'));
-    expect(content, contains('S\n'));
+    // The scalloped cloud outline is filled and stroked in one pass (B), so
+    // the interior colour reaches the puffed edges rather than stopping at
+    // the straight polygon footprint.
+    expect(content, contains('B\n'));
   });
 
   test('cloud scallops stay inside the form BBox (no clipped puffs)', () {


### PR DESCRIPTION
## Summary

A cloudy (`/BE` Cloudy) filled polygon painted its interior colour only up to the *straight* polygon footprint (the line through the `/Vertices`), while the scalloped border puffs bulge outward past those edges. The result was an unfilled crescent between each straight edge and its row of scallops — the fill visibly stopped short of the cloud outline.

Now the interior is filled along the **scalloped cloud path** itself, so the colour reaches the puffed edges. `_cloudPolygonContent` builds the cloud path once and fills+strokes it in one pass (`B`) — nonstroking colour for the fill, stroking colour for the outline — instead of filling the straight vertex polygon (`f`) and then separately stroking the cloud (`S`). All three cloud callers (add, update, style-flatten) route through this function. The live editor preview (`_paintCloudPolygon`) mirrored the same shortcut and now fills the cloud path too.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [ ] `fvm flutter pub get`
- [x] `fvm dart analyze` (on the changed files)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test` (annotation_editor_test.dart)
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (editing_test.dart, editing_tool_shortcuts_test.dart)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: focused on the changed subsystem; ran analyze on the touched files and the annotation/editing test suites.

## PDF fixtures and screenshots

Covered by the programmatic `annotation_editor_test.dart` fixture — the cloud polygon appearance now emits a combined `B` (fill+stroke of the cloud path).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The cloud path geometry is unchanged — only *what gets filled* changed — so the existing BBox-containment test still passes. The "cloud polygon carries border effect …" test was updated to assert the combined `B` operator instead of separate `f`/`S`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLrXavJqih824WusZvaFr)_