### PR TITLE
Add/remove polyline & polygon nodes from the context menu

### DIFF
--- a/doc/dev-log/2026-07-16-polyline-node-context-menu.md
+++ b/doc/dev-log/2026-07-16-polyline-node-context-menu.md
@@ -1,0 +1,49 @@
+# Add/remove polyline & polygon nodes from the context menu
+
+## What
+
+Right-clicking (or touch long-pressing) a selected /PolyLine or /Polygon
+now offers **Add node** and **Remove node** in the annotation context
+menu, so a vertex can be spliced in or dropped without re-drawing the
+whole shape. Dragging vertex handles already existed
+(`_commitVertexDrag` → `reshapeSelectedLine`); this fills the gap for
+changing the vertex *count*.
+
+## Where
+
+- `editing_controller.dart` — new API around the existing
+  `reshapeLineAnnotation` editor call:
+  - `canAddSelectedVertex` / `canRemoveSelectedVertex` gate the menu
+    entries. Remove is disabled at the subtype floor (a /PolyLine keeps
+    2+ vertices, a /Polygon 3+) so the reshape never throws.
+  - `addSelectedVertexAt((x, y))` splices the page point into the edge
+    nearest it (`_nearestEdgeInsertIndex`, using point-to-segment
+    distance; a polygon also weighs the closing last→first edge).
+  - `removeSelectedVertexNear((x, y))` drops the vertex closest to the
+    point (`_nearestVertexIndex`).
+  - `_editableVertexAnnotation` is the shared guard: exactly one selected
+    /PolyLine or /Polygon with real /Vertices. A plain /Line is excluded
+    (it is fixed at two points) as are non-line subtypes.
+- `editing_menu.dart` — two entries (`pdf-annot-menu-add-node`,
+  `pdf-annot-menu-remove-node`) between "Send to back" and "Delete".
+  They only appear when the menu was opened with a `pagePoint` (the
+  right-click / long-press paths both pass one); the selection-chip
+  "More" button has no point, so it hides them.
+
+## Notes / gotchas
+
+- Geometry is all page-space and scale-independent — the menu layer has
+  no view transform, so "nearest vertex/edge" is computed on the raw
+  /Vertices. Predictable: whatever the click is closest to is what gets
+  added-beside or removed.
+- The reshape goes through `reshapeLineAnnotation`, so the appearance
+  stream, /Rect, BBox, endings, and any measurement caption all
+  regenerate for free, and each edit is one undo step.
+
+## Tests
+
+`editing_menu_test.dart` — a `polyline/polygon nodes` controller group
+(splice into the nearest edge, polygon closing-edge splice, remove the
+closest node, floor enforcement, unavailable for /Line and /Square) plus
+two widget tests (a polygon right-click shows and applies Add node; a
+rectangle right-click shows neither entry).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4648,6 +4648,119 @@ class PdfEditingController extends ChangeNotifier {
     );
   }
 
+  /// The single selected /PolyLine or /Polygon whose vertices can be edited
+  /// by adding or removing nodes. A /Line is fixed at two points, so it is
+  /// excluded. Null unless exactly one such annotation is selected.
+  PdfAnnotation? get _editableVertexAnnotation {
+    if (_selected.length != 1) return null;
+    final annotation = selectedAnnotation;
+    if (annotation == null) return null;
+    final subtype = annotation.subtype;
+    if (subtype != 'PolyLine' && subtype != 'Polygon') return null;
+    return annotation.vertices == null ? null : annotation;
+  }
+
+  /// Whether a node can be added to the selected /PolyLine or /Polygon.
+  bool get canAddSelectedVertex => _editableVertexAnnotation != null;
+
+  /// Whether a node can be removed from the selected /PolyLine or /Polygon -
+  /// true only when removing one still leaves a valid shape (2+ vertices for
+  /// a polyline, 3+ for a polygon).
+  bool get canRemoveSelectedVertex {
+    final annotation = _editableVertexAnnotation;
+    final vertices = annotation?.vertices;
+    if (annotation == null || vertices == null) return false;
+    final min = annotation.subtype == 'Polygon' ? 3 : 2;
+    return vertices.length > min;
+  }
+
+  /// Adds a node to the selected /PolyLine or /Polygon at [at] (page space),
+  /// splicing it into the edge nearest the point so the shape grows a vertex
+  /// there. No-op unless a single editable poly is selected.
+  void addSelectedVertexAt((double, double) at) {
+    final annotation = _editableVertexAnnotation;
+    final vertices = annotation?.vertices;
+    if (annotation == null || vertices == null || vertices.length < 2) return;
+    final insertAt = _nearestEdgeInsertIndex(
+      vertices,
+      at,
+      closed: annotation.subtype == 'Polygon',
+    );
+    final points = List<(double, double)>.of(vertices)..insert(insertAt, at);
+    apply(
+      (e) => e.reshapeLineAnnotation(_selected.last.$1, annotation, points),
+    );
+  }
+
+  /// Removes the node of the selected /PolyLine or /Polygon nearest [near]
+  /// (page space). No-op when removing would drop below the subtype minimum
+  /// (see [canRemoveSelectedVertex]) or nothing editable is selected.
+  void removeSelectedVertexNear((double, double) near) {
+    if (!canRemoveSelectedVertex) return;
+    final annotation = _editableVertexAnnotation!;
+    final vertices = annotation.vertices!;
+    final index = _nearestVertexIndex(vertices, near);
+    final points = List<(double, double)>.of(vertices)..removeAt(index);
+    apply(
+      (e) => e.reshapeLineAnnotation(_selected.last.$1, annotation, points),
+    );
+  }
+
+  /// Index of the vertex in [pts] closest to [p] (page space).
+  static int _nearestVertexIndex(
+      List<(double, double)> pts, (double, double) p) {
+    var best = 0;
+    var bestDist = double.infinity;
+    for (var i = 0; i < pts.length; i++) {
+      final dx = pts[i].$1 - p.$1, dy = pts[i].$2 - p.$2;
+      final dist = dx * dx + dy * dy;
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = i;
+      }
+    }
+    return best;
+  }
+
+  /// The list index at which inserting [p] lands it on the edge of [pts]
+  /// nearest the point. A [closed] polygon also weighs the wrap-around edge
+  /// (last→first), for which the insertion index is the list end.
+  static int _nearestEdgeInsertIndex(
+    List<(double, double)> pts,
+    (double, double) p, {
+    required bool closed,
+  }) {
+    var best = pts.length; // append if nothing beats it
+    var bestDist = double.infinity;
+    final segments = closed ? pts.length : pts.length - 1;
+    for (var i = 0; i < segments; i++) {
+      final a = pts[i];
+      final b = pts[(i + 1) % pts.length];
+      final dist = _segmentDistanceSq(p, a, b);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = i + 1;
+      }
+    }
+    return best;
+  }
+
+  /// Squared distance from point [p] to the segment [a]–[b] (page space).
+  static double _segmentDistanceSq(
+    (double, double) p,
+    (double, double) a,
+    (double, double) b,
+  ) {
+    final abx = b.$1 - a.$1, aby = b.$2 - a.$2;
+    final apx = p.$1 - a.$1, apy = p.$2 - a.$2;
+    final len2 = abx * abx + aby * aby;
+    var t = len2 == 0 ? 0.0 : (apx * abx + apy * aby) / len2;
+    t = t.clamp(0.0, 1.0);
+    final cx = a.$1 + t * abx, cy = a.$2 + t * aby;
+    final dx = p.$1 - cx, dy = p.$2 - cy;
+    return dx * dx + dy * dy;
+  }
+
   /// Whether every selected annotation is a /Line or /PolyLine whose endings
   /// can be set together ([setSelectedLineEndings]).
   bool get canSetLineEndings {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
@@ -78,8 +78,10 @@ typedef PdfAnnotationMenuBuilder = List<PdfAnnotationMenuItem> Function(
 
 /// Shows the annotation context menu at [position] (global coordinates)
 /// for [controller]'s current selection: copy/cut/apply-to-pages/paste,
-/// bring to front, send to back, delete, then whatever [customActions] adds.
-/// Resolves when the menu closes, after the picked action ran.
+/// bring to front, send to back, add/remove node (a single /PolyLine or
+/// /Polygon, when [pagePoint] is known), delete, then whatever
+/// [customActions] adds. Resolves when the menu closes, after the picked
+/// action ran.
 ///
 /// [pagePoint] is where on the page the menu was opened (page space) -
 /// Paste centers the clipboard there; without it the paste falls back
@@ -163,6 +165,26 @@ Future<void> showPdfAnnotationMenu({
         enabled: controller.canSendSelectedToBack,
         onSelected: (request) => request.controller.sendSelectedToBack(),
       ),
+      // A right-click on a /PolyLine or /Polygon can grow or drop a vertex
+      // at the click point. Needs the page point the menu opened on; the
+      // selection-chip "More" path (no point) hides these.
+      if (pagePoint != null && controller.canAddSelectedVertex) ...[
+        PdfAnnotationMenuItem(
+          key: const ValueKey('pdf-annot-menu-add-node'),
+          label: 'Add node',
+          icon: Icons.add_location_alt_outlined,
+          onSelected: (request) =>
+              request.controller.addSelectedVertexAt(pagePoint),
+        ),
+        PdfAnnotationMenuItem(
+          key: const ValueKey('pdf-annot-menu-remove-node'),
+          label: 'Remove node',
+          icon: Icons.wrong_location_outlined,
+          enabled: controller.canRemoveSelectedVertex,
+          onSelected: (request) =>
+              request.controller.removeSelectedVertexNear(pagePoint),
+        ),
+      ],
       PdfAnnotationMenuItem(
         key: const ValueKey('pdf-annot-menu-delete'),
         label: 'Delete',

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -283,6 +283,24 @@ void main() {
           editing.document.page(0).annotations.last.vertices, hasLength(5));
     });
 
+    testWidgets('Remove node from the menu drops the nearest vertex',
+        (tester) async {
+      final editing = await pumpViewer(tester);
+      editing.addPolygon(
+          0, const [(400, 600), (500, 600), (500, 700), (400, 700)]);
+      await tester.pump();
+
+      await rightClick(tester, viewPoint(405, 605)); // near vertex (400, 600)
+      expect(editing.selectedAnnotation?.subtype, 'Polygon');
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-annot-menu-remove-node')));
+      await tester.pumpAndSettle();
+
+      final vertices = editing.document.page(0).annotations.last.vertices;
+      expect(vertices, hasLength(3));
+      expect(vertices, isNot(contains((400.0, 600.0))));
+    });
+
     testWidgets('a rectangle right-click has no node entries', (tester) async {
       await pumpViewer(tester);
 

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -78,6 +78,85 @@ void main() {
     });
   });
 
+  group('polyline/polygon nodes', () {
+    test('addSelectedVertexAt splices a node into the nearest edge', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addPolyLine(0, const [(100, 100), (200, 100), (200, 200)])
+        ..tool = PdfEditTool.select
+        ..selectAnnotation(0, 0);
+      addTearDown(editing.dispose);
+      expect(editing.canAddSelectedVertex, isTrue);
+
+      // a point beside the first edge lands between vertices 0 and 1
+      editing.addSelectedVertexAt((150, 90));
+      final vertices = editing.document.page(0).annotations.single.vertices;
+      expect(vertices, hasLength(4));
+      expect(vertices![1], (150, 90));
+      expect(vertices, const [(100, 100), (150, 90), (200, 100), (200, 200)]);
+    });
+
+    test('addSelectedVertexAt on a polygon can splice the closing edge', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addPolygon(0, const [(100, 100), (200, 100), (150, 200)])
+        ..tool = PdfEditTool.select
+        ..selectAnnotation(0, 0);
+      addTearDown(editing.dispose);
+
+      // nearest the last→first edge: appended at the end
+      editing.addSelectedVertexAt((120, 150));
+      final vertices = editing.document.page(0).annotations.single.vertices;
+      expect(vertices, hasLength(4));
+      expect(vertices!.last, (120, 150));
+    });
+
+    test('removeSelectedVertexNear drops the closest node', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addPolyLine(0, const [(100, 100), (200, 100), (200, 200)])
+        ..tool = PdfEditTool.select
+        ..selectAnnotation(0, 0);
+      addTearDown(editing.dispose);
+      expect(editing.canRemoveSelectedVertex, isTrue);
+
+      editing.removeSelectedVertexNear((205, 105)); // nearest (200, 100)
+      final vertices = editing.document.page(0).annotations.single.vertices;
+      expect(vertices, const [(100, 100), (200, 200)]);
+    });
+
+    test('removal stops at the subtype minimum', () {
+      final line = PdfEditingController(buildMultiPagePdf(1))
+        ..addPolyLine(0, const [(100, 100), (200, 100)])
+        ..tool = PdfEditTool.select
+        ..selectAnnotation(0, 0);
+      addTearDown(line.dispose);
+      expect(line.canRemoveSelectedVertex, isFalse);
+      final before = line.document;
+      line.removeSelectedVertexNear((100, 100));
+      expect(identical(line.document, before), isTrue);
+
+      final polygon = PdfEditingController(buildMultiPagePdf(1))
+        ..addPolygon(0, const [(100, 100), (200, 100), (150, 200)])
+        ..tool = PdfEditTool.select
+        ..selectAnnotation(0, 0);
+      addTearDown(polygon.dispose);
+      expect(polygon.canRemoveSelectedVertex, isFalse); // 3 is the floor
+    });
+
+    test('node editing is unavailable for a plain /Line or /Square', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addLine(0, const (100, 100), const (200, 200))
+        ..addRectangle(0, const PdfRect(60, 700, 160, 750))
+        ..tool = PdfEditTool.select;
+      addTearDown(editing.dispose);
+
+      editing.selectAnnotation(0, 0); // the /Line
+      expect(editing.canAddSelectedVertex, isFalse);
+      expect(editing.canRemoveSelectedVertex, isFalse);
+
+      editing.selectAnnotation(0, 1); // the /Square
+      expect(editing.canAddSelectedVertex, isFalse);
+    });
+  });
+
   group('context menu', () {
     Future<PdfEditingController> pumpViewer(WidgetTester tester,
         {PdfAnnotationMenuBuilder? menuBuilder}) async {
@@ -181,6 +260,37 @@ void main() {
         PdfRect(200, 700, 300, 750),
       ]);
       expect(editing.selectedAnnotationSlots, [(0, 1), (0, 2)]);
+    });
+
+    testWidgets('a polygon right-click offers add/remove node, and adds one',
+        (tester) async {
+      final editing = await pumpViewer(tester);
+      editing.addPolygon(
+          0, const [(400, 600), (500, 600), (500, 700), (400, 700)]);
+      await tester.pump();
+
+      await rightClick(tester, viewPoint(450, 650)); // inside the polygon
+      expect(editing.selectedAnnotation?.subtype, 'Polygon');
+      expect(find.byKey(const ValueKey('pdf-annot-menu-add-node')),
+          findsOneWidget);
+      final remove = tester.widget<PopupMenuItem>(
+          find.byKey(const ValueKey('pdf-annot-menu-remove-node')));
+      expect(remove.enabled, isTrue);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-annot-menu-add-node')));
+      await tester.pumpAndSettle();
+      expect(
+          editing.document.page(0).annotations.last.vertices, hasLength(5));
+    });
+
+    testWidgets('a rectangle right-click has no node entries', (tester) async {
+      await pumpViewer(tester);
+
+      await rightClick(tester, viewPoint(110, 725)); // rectangle A
+      expect(find.byKey(const ValueKey('pdf-annot-menu-add-node')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('pdf-annot-menu-remove-node')),
+          findsNothing);
     });
 
     testWidgets('host actions ride below a divider and get the request',


### PR DESCRIPTION
## Summary

Right-clicking (or touch long-pressing) a selected /PolyLine or /Polygon now offers **Add node** and **Remove node** in the annotation context menu. Add node splices a vertex into the edge nearest the click; Remove node drops the vertex closest to it. Dragging existing vertex handles already reshaped these annotations — this fills the gap for changing the vertex *count* without redrawing the whole shape.

New controller API, all routed through the existing `reshapeLineAnnotation` so the appearance stream, `/Rect`, BBox, line endings, and measurement captions regenerate as a single undo step:

- `canAddSelectedVertex` / `canRemoveSelectedVertex` gate the entries. Remove is disabled at the subtype floor (a /PolyLine keeps 2+ vertices, a /Polygon 3+), so the reshape never throws.
- `addSelectedVertexAt((x, y))` — point-to-segment nearest edge (a polygon also weighs the closing last→first edge).
- `removeSelectedVertexNear((x, y))` — nearest vertex.
- A plain /Line is excluded (fixed at two points), as are non-line subtypes.

The menu entries only appear when the menu was opened with a page point (the right-click and long-press paths both pass one); the selection-chip "More" button has no point and hides them.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

`editing_menu_test.dart` gains a `polyline/polygon nodes` controller group (edge splice, polygon closing-edge splice, nearest-vertex removal, floor enforcement, unavailable for /Line and /Square) plus two widget tests (polygon right-click shows and applies Add node; rectangle right-click shows neither). Full package analyze is clean.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Geometry is all page-space and scale-independent — the menu layer has no view transform, so "nearest vertex/edge" is computed on the raw `/Vertices`. Within-shape only; adding a node between the arrowhead endings on a /PolyLine keeps the endings on the (unchanged) first/last vertices. See `doc/dev-log/2026-07-16-polyline-node-context-menu.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgY8MAoTmK7ZQNJPkMr7TZ)_