### PR TITLE
Shapes/clouds: add an Outline colour row to the tune popup

### DIFF
--- a/doc/dev-log/2026-07-16-cloud-outline-colour-tune.md
+++ b/doc/dev-log/2026-07-16-cloud-outline-colour-tune.md
@@ -1,0 +1,47 @@
+# Outline colour in the tune menu (clouds and other shapes)
+
+## What changed
+
+The tune popup (`_StyleMenu`, the `Icons.tune` gear) already carried a "Fill"
+colour row for shapes but no stroke/outline colour — that was only reachable
+from the toolbar's colour swatches. For a revision cloud that's backwards: a
+cloud usually has no fill, so its outline is the colour you actually want to
+change, yet the tune menu only offered "Fill".
+
+Added an **"Outline"** colour row to the tune popup, rendered just above
+"Fill". It sets the creation default (`controller.color`) and, with a
+restylable shape selected, restyles it in place via
+`controller.restyleSelected(color:)` — the same path the toolbar swatches use.
+No "none" swatch (a shape/cloud/line always strokes), matching the text-colour
+row.
+
+## Where
+
+- `dart_pdf_editor` `editing_toolbar.dart`:
+  - `_StyleFields` gains a `strokeColor` flag (folded into `isEmpty`).
+  - `_groupStyleFields` sets it on the whole **shapes** group; `_selectionStyleFields`
+    sets it on the Square/Circle/Polygon, Line/PolyLine, and Ink cases —
+    wherever a stroke width already applies (`canStroke && supportsStrokeWidth`).
+  - `_StyleMenuState._setStrokeColor` is the setter; the build method computes
+    `strokeColorValue` (selected shape's `/C` when restyling, else the creation
+    default) and renders the `pdf-shape-outline` `PdfColorSwatchRow`
+    (`allowNone: false`) before the existing `pdf-shape-fill` row.
+
+## Gotchas
+
+- Revision clouds are cloudy `/Polygon`s (`canRestyle` is true for Polygon
+  regardless of `/BE`, unlike Square/Circle which bail on a cloudy border), so
+  `restyleAnnotation`'s Polygon branch already rewrites `/C` and regenerates
+  the appearance keeping the cloud puffs (`_restyleRegenerate` reads
+  `hasCloudyBorder`). The new UI just surfaces that existing capability in the
+  tune menu.
+- On desktop this is partly redundant with the toolbar colour swatches, but
+  it puts the outline colour beside the fill colour where users look for it and
+  matches the request ("from the tune menu").
+
+## Test
+
+`editing_shape_styles_test.dart` — "cloud outline colour from the tune menu":
+selects a cloud, opens the tune popup, taps the blue outline swatch, and
+asserts the annotation's `/C` became blue, no "none" swatch is offered, and the
+cloudy border survives the restyle.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Shapes and revision clouds: add an "Outline" colour row to the tune popup,
+  next to "Fill", so a cloud's stroke colour can be picked from the tune menu
+  (not just the toolbar swatches) — armed or with the shape selected.
 - Free-text boxes: add line spacing, character spacing, font width
   (horizontal scaling), and underline controls (tune popup + properties
   panel), with an inline underline toggle and Cmd/Ctrl+U shortcut.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1991,6 +1991,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       case 'shapes':
         return _StyleFields(
           stroke: true,
+          strokeColor: true,
           opacity: true,
           lineType: true,
           lineEndings: tool == PdfEditTool.line || tool == PdfEditTool.polyline,
@@ -2041,6 +2042,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       case 'Polygon':
         return _StyleFields(
             stroke: canStroke && behavior.supportsStrokeWidth,
+            // the outline colour of shapes and revision clouds
+            strokeColor: canStroke && behavior.supportsStrokeWidth,
             opacity: behavior.supportsOpacity,
             // a /Polygon area measurement carries a caption font
             font: controller.canRestyleMeasurementCaption,
@@ -2050,6 +2053,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       case 'PolyLine':
         return _StyleFields(
             stroke: canStroke && behavior.supportsStrokeWidth,
+            strokeColor: canStroke && behavior.supportsStrokeWidth,
             opacity: behavior.supportsOpacity,
             // a measurement (/Line distance, /PolyLine perimeter) carries one
             font: controller.canRestyleMeasurementCaption,
@@ -2058,6 +2062,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       case 'Ink':
         return _StyleFields(
             stroke: canStroke && behavior.supportsStrokeWidth,
+            strokeColor: canStroke && behavior.supportsStrokeWidth,
             opacity: behavior.supportsOpacity);
       default:
         // Markup and stamps expose opacity; notes and foreign subtypes do not.
@@ -3145,6 +3150,7 @@ double? _parsePercent(String s) {
 class _StyleFields {
   const _StyleFields({
     this.stroke = false,
+    this.strokeColor = false,
     this.opacity = false,
     this.lineType = false,
     this.lineEndings = false,
@@ -3156,6 +3162,11 @@ class _StyleFields {
   });
 
   final bool stroke;
+
+  /// The stroke/outline colour row - shapes (including revision clouds) and
+  /// the line family. Distinct from [shapeFill], the interior fill.
+  final bool strokeColor;
+
   final bool opacity;
 
   /// The line-type dropdown (solid / dashed / dotted / dash-dot) - shapes
@@ -3181,6 +3192,7 @@ class _StyleFields {
 
   bool get isEmpty =>
       !stroke &&
+      !strokeColor &&
       !opacity &&
       !lineType &&
       !lineEndings &&
@@ -3302,6 +3314,16 @@ class _StyleMenuState extends State<_StyleMenu> {
     controller.shapeFillColor = color; // the new default either way
     if (controller.canFillSelected) {
       controller.restyleSelected(fill: (color,));
+    }
+  }
+
+  /// The shape/cloud/line outline colour. Sets the creation default and
+  /// restyles the selected shapes in place, mirroring the toolbar swatches.
+  void _setStrokeColor(Color? color) {
+    if (color == null) return;
+    controller.color = color; // the new default either way
+    if (controller.canRestyleSelected) {
+      controller.restyleSelected(color: color);
     }
   }
 
@@ -3466,6 +3488,11 @@ class _StyleMenuState extends State<_StyleMenu> {
             final shapeFillValue = controller.canFillSelected
                 ? controller.selectedShapeFill
                 : controller.shapeFillColor;
+            // shape/cloud/line outline: a selected shape shows its own /C,
+            // else the creation default
+            final strokeColorValue = restylingAnnotation
+                ? (annotationStyle?.color ?? controller.color)
+                : controller.color;
             return Container(
               width: 300,
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
@@ -3592,6 +3619,15 @@ class _StyleMenuState extends State<_StyleMenu> {
                       },
                     ),
                   ],
+                  if (fields.strokeColor && widget.showColor)
+                    _boxColorRow(
+                      context: context,
+                      label: 'Outline',
+                      keyPrefix: 'pdf-shape-outline',
+                      value: strokeColorValue,
+                      onChanged: _setStrokeColor,
+                      allowNone: false,
+                    ),
                   if (fields.shapeFill && widget.showColor)
                     _boxColorRow(
                       context: context,

--- a/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
@@ -77,6 +77,51 @@ void main() {
     });
   });
 
+  group('cloud outline colour from the tune menu', () {
+    testWidgets('the tune menu changes a selected cloud\'s outline colour',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      editing
+        ..addCloudPolygon(0, const PdfRect(100, 500, 300, 640))
+        ..selectAnnotation(0, 0);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+          ),
+        ),
+      ));
+
+      // the cloud is a restylable /Polygon with a cloudy border
+      final before = editing.document.page(0).annotations.single;
+      expect(before.subtype, 'Polygon');
+      expect(before.hasCloudyBorder, isTrue);
+
+      // open the tune popup from the selection strip
+      await tester.scrollUntilVisible(
+          find.byTooltip('Stroke, opacity, font'), 100,
+          scrollable: find.byType(Scrollable).first);
+      await tester.tap(find.byTooltip('Stroke, opacity, font'));
+      await tester.pumpAndSettle();
+
+      // blue is palette slot 3; picking it restyles the cloud outline
+      await tester.tap(find.byKey(const ValueKey('pdf-shape-outline-3')));
+      await tester.pumpAndSettle();
+
+      final after = editing.document.page(0).annotations.single;
+      expect(after.color, 0x1E88E5);
+      // the outline row offers no "none" - a cloud always has a stroke
+      expect(find.byKey(const ValueKey('pdf-shape-outline-none')), findsNothing);
+      // and the restyle keeps the revision-cloud border
+      expect(after.hasCloudyBorder, isTrue);
+    });
+  });
+
   group('cross-page annotation move', () {
     test('moveSelectedToPage re-homes the annotation onto the target page',
         () {


### PR DESCRIPTION
## Summary

The tune popup (the `Icons.tune` gear / `_StyleMenu`) already carried a **Fill**
colour row for shapes but no stroke/outline colour — that was only reachable
from the toolbar's colour swatches. For a revision cloud that's backwards: a
cloud usually has no fill, so its outline is the colour you actually want to
change, yet the tune menu only offered "Fill".

This adds an **"Outline"** colour row to the tune popup, rendered just above
"Fill". It sets the creation default (`controller.color`) and, with a
restylable shape selected, restyles it in place via
`controller.restyleSelected(color:)` — the same path the toolbar swatches use.
There's no "none" swatch (a shape/cloud/line always strokes), matching the
text-colour row. Revision clouds are cloudy `/Polygon`s whose restyle already
rewrites `/C` and regenerates the appearance keeping the cloud puffs, so this is
UI wiring only.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran the touched suites:
  `editing_shape_styles_test.dart`, `editing_text_edit_test.dart`,
  `editing_test.dart`)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Change is confined to the editor toolbar UI; ran `dart analyze` on the package
and the relevant editing widget suites. Rendering/corpus suites are unaffected.

## PDF fixtures and screenshots

New widget test `cloud outline colour from the tune menu` builds its cloud
programmatically — selects a cloud, opens the tune popup, taps the blue outline
swatch, and asserts the annotation's `/C` became blue, no "none" swatch is
offered, and the cloudy border survives the restyle.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

On desktop the new row is partly redundant with the toolbar colour swatches,
but it puts the outline colour beside the fill colour in the tune menu where
users look for it (and matches the request, "from the tune menu"). The
`strokeColor` field is applied wherever a stroke width already applies
(`canStroke && supportsStrokeWidth`): the shapes group plus the
Square/Circle/Polygon, Line/PolyLine, and Ink selection cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHfBfRL6bWVoerBoqCH7ak)_