### PR TITLE
Add arrow-key nudging for selected annotations

### DIFF
--- a/doc/dev-log/2026-07-16-arrow-key-nudge.md
+++ b/doc/dev-log/2026-07-16-arrow-key-nudge.md
@@ -1,0 +1,47 @@
+# Arrow-key nudge for selected annotations
+
+Added keyboard nudging so a selected annotation can be moved a hair at a
+time without dragging.
+
+## What
+
+- Plain arrow → 1 pt, Shift+arrow → 10 pt (the coarse step). Constants
+  `_annotationNudgeStep` / `_annotationNudgeStepCoarse` in `pdf_viewer.dart`.
+- Bound in the same `CallbackShortcuts` map as undo/redo/delete
+  (`pdf_viewer.dart`, in the `editing != null` block). The arrow bindings
+  are wrapped in `if (editing.hasAnnotationSelection)` so a bare arrow with
+  nothing selected falls through to page scrolling instead of being
+  swallowed. The map is re-evaluated on every controller notify because the
+  host rebuilds the viewer (the existing editing-UI contract), and selection
+  changes call `notifyListeners`.
+- The whole map is already empty while an in-place text editor is open
+  (`editing.isEditingText`), so arrows reach the field's own caret movement.
+
+## Rotation
+
+`PdfEditingController.nudgeSelected(screenDx, screenDy)` takes a view-space
+delta (y **down**, as the reader sees the page) and translates it to page
+space through the primary selected page's `/Rotate`, mirroring
+`PdfPageGeometry.toPagePoint`:
+
+| rotation | (dx, dy) |
+| -------- | -------- |
+| 0        | (sx, -sy) |
+| 90       | (sy, sx)  |
+| 180      | (-sx, sy) |
+| 270      | (-sy, -sx) |
+
+so "right" always slides the annotation the way the key points on screen,
+whatever the page rotation. It then defers to the existing
+`moveSelected`, so a nudge is one revision and the selection survives. A
+multi-page selection uses the primary page's rotation for the whole move
+(same simplification `moveSelected` already makes by applying one page
+delta everywhere).
+
+## Tests
+
+`test/editing_arrow_nudge_test.dart` — direction/rotation mapping at the
+controller level (rotation 0 via `buildMultiPagePdf`, rotation 90 via
+`buildNestedPageTreePdf`'s inherited `/Rotate 90`), plus viewer widget
+tests that an arrow and Shift+arrow move the selection and that a bare
+arrow with nothing selected leaves annotations alone.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Nudge the selected annotation(s) with the arrow keys — 1 pt per press,
+  10 pt with Shift — translating the move through the page's /Rotate so a
+  key always slides the annotation the way it points on screen. A bare
+  arrow still scrolls the page when nothing is selected.
 - Free-text boxes: add line spacing, character spacing, font width
   (horizontal scaling), and underline controls (tune popup + properties
   panel), with an inline underline toggle and Cmd/Ctrl+U shortcut.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4424,6 +4424,27 @@ class PdfEditingController extends ChangeNotifier {
     );
   }
 
+  /// Nudges the selection by ([screenDx], [screenDy]) view-space units - the
+  /// way the arrow keys point on screen, with y running *down* as the reader
+  /// sees the page. The delta is translated through the primary selected
+  /// page's /Rotate so an annotation always slides the direction the key
+  /// points regardless of how the page is turned, then handed to
+  /// [moveSelected] (one revision; the selection survives). A no-op with
+  /// nothing selected.
+  void nudgeSelected(double screenDx, double screenDy) {
+    final page = selectedPage;
+    if (page == null) return;
+    // Mirror of PdfPageGeometry.toPagePoint: view y is down and /Rotate turns
+    // the page clockwise, so recover the page-space (y-up) delta per rotation.
+    final (dx, dy) = switch (_page(page).rotation % 360) {
+      90 => (screenDy, screenDx),
+      180 => (-screenDx, screenDy),
+      270 => (-screenDy, -screenDx),
+      _ => (screenDx, -screenDy),
+    };
+    moveSelected(dx, dy);
+  }
+
   /// The selected annotations that share the primary selection's page, in
   /// selection order - the candidates an alignment acts on. Aligning across
   /// pages has no geometric meaning, so the primary page wins and other

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -45,6 +45,11 @@ export 'annotation_tap.dart'
 
 const double _defaultMaxZoom = 24;
 
+/// Page-space distance an arrow-key press slides the selected annotation(s),
+/// and the coarser step Shift+arrow uses. Points, matching the drag move.
+const double _annotationNudgeStep = 1;
+const double _annotationNudgeStepCoarse = 10;
+
 /// One search hit with the text around it, ready for a results list
 /// like [PdfSearchResultsPanel].
 class PdfSearchResult {
@@ -4476,6 +4481,36 @@ class _PdfViewerState extends State<PdfViewer>
                       editing.deleteSelected,
                   const SingleActivator(LogicalKeyboardKey.backspace):
                       editing.deleteSelected,
+                  // arrow keys nudge the selected annotation(s) - 1 pt per
+                  // press, 10 pt with Shift for a coarse move. Only bound
+                  // while something is selected so a bare arrow still scrolls
+                  // the page when it isn't.
+                  if (editing.hasAnnotationSelection) ...{
+                    const SingleActivator(LogicalKeyboardKey.arrowLeft):
+                        () => editing.nudgeSelected(-_annotationNudgeStep, 0),
+                    const SingleActivator(LogicalKeyboardKey.arrowRight):
+                        () => editing.nudgeSelected(_annotationNudgeStep, 0),
+                    const SingleActivator(LogicalKeyboardKey.arrowUp):
+                        () => editing.nudgeSelected(0, -_annotationNudgeStep),
+                    const SingleActivator(LogicalKeyboardKey.arrowDown):
+                        () => editing.nudgeSelected(0, _annotationNudgeStep),
+                    const SingleActivator(LogicalKeyboardKey.arrowLeft,
+                            shift: true):
+                        () => editing.nudgeSelected(
+                            -_annotationNudgeStepCoarse, 0),
+                    const SingleActivator(LogicalKeyboardKey.arrowRight,
+                            shift: true):
+                        () => editing.nudgeSelected(
+                            _annotationNudgeStepCoarse, 0),
+                    const SingleActivator(LogicalKeyboardKey.arrowUp,
+                            shift: true):
+                        () => editing.nudgeSelected(
+                            0, -_annotationNudgeStepCoarse),
+                    const SingleActivator(LogicalKeyboardKey.arrowDown,
+                            shift: true):
+                        () => editing.nudgeSelected(
+                            0, _annotationNudgeStepCoarse),
+                  },
                   // unmodified single-key tool shortcuts (V select, P pen,
                   // R rectangle, …) - safe because an open in-place text
                   // editor disables every binding above

--- a/packages/dart_pdf_editor/test/editing_arrow_nudge_test.dart
+++ b/packages/dart_pdf_editor/test/editing_arrow_nudge_test.dart
@@ -108,30 +108,46 @@ void main() {
       await tester.pump();
     }
 
-    testWidgets('an arrow nudges the selection by a point', (tester) async {
+    Future<void> arrow(WidgetTester tester, LogicalKeyboardKey key,
+        {bool shift = false}) async {
+      if (shift) await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(key);
+      if (shift) await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pump();
+    }
+
+    testWidgets('each arrow nudges the selection by a point', (tester) async {
       final editing = await pumpEditor(tester);
       await focusViewer(tester);
       editing.selectAnnotationAt(0, 140, 675);
       await tester.pump();
+      PdfRect rect() => editing.document.page(0).annotations.single.rect;
 
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-      await tester.pump();
-      expect(editing.document.page(0).annotations.single.rect.top,
-          closeTo(701, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowUp);
+      expect(rect().top, closeTo(701, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowDown);
+      expect(rect().top, closeTo(700, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowRight);
+      expect(rect().left, closeTo(101, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowLeft);
+      expect(rect().left, closeTo(100, 0.01));
     });
 
-    testWidgets('Shift+arrow nudges by the coarse step', (tester) async {
+    testWidgets('each Shift+arrow nudges by the coarse step', (tester) async {
       final editing = await pumpEditor(tester);
       await focusViewer(tester);
       editing.selectAnnotationAt(0, 140, 675);
       await tester.pump();
+      PdfRect rect() => editing.document.page(0).annotations.single.rect;
 
-      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
-      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
-      await tester.pump();
-      expect(editing.document.page(0).annotations.single.rect.left,
-          closeTo(110, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowRight, shift: true);
+      expect(rect().left, closeTo(110, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowLeft, shift: true);
+      expect(rect().left, closeTo(100, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowUp, shift: true);
+      expect(rect().top, closeTo(710, 0.01));
+      await arrow(tester, LogicalKeyboardKey.arrowDown, shift: true);
+      expect(rect().top, closeTo(700, 0.01));
     });
 
     testWidgets('with nothing selected the arrow keys leave annotations alone',

--- a/packages/dart_pdf_editor/test/editing_arrow_nudge_test.dart
+++ b/packages/dart_pdf_editor/test/editing_arrow_nudge_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  group('PdfEditingController.nudgeSelected', () {
+    PdfEditingController oneRect() => PdfEditingController(buildMultiPagePdf(2))
+      ..addRectangle(0, const PdfRect(100, 650, 180, 700));
+
+    test('nothing selected is a no-op (no revision)', () {
+      final editing = oneRect();
+      addTearDown(editing.dispose);
+      final revisions = editing.bytes.length;
+      editing.nudgeSelected(0, -1);
+      expect(editing.bytes.length, revisions);
+    });
+
+    test('arrow directions map to page space with y up (rotation 0)', () {
+      final editing = oneRect();
+      addTearDown(editing.dispose);
+      editing.selectAnnotationAt(0, 140, 675);
+
+      // up on screen raises the annotation in page space
+      editing.nudgeSelected(0, -1);
+      var rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.top, closeTo(701, 0.01));
+      expect(rect.left, closeTo(100, 0.01));
+
+      // right on screen increases x
+      editing.nudgeSelected(1, 0);
+      rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.left, closeTo(101, 0.01));
+      expect(rect.top, closeTo(701, 0.01));
+
+      // down and left walk it back
+      editing.nudgeSelected(0, 1);
+      editing.nudgeSelected(-1, 0);
+      rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.left, closeTo(100, 0.01));
+      expect(rect.top, closeTo(700, 0.01));
+
+      // the selection survives the nudges
+      expect(editing.selectedAnnotationSlots, [(0, 0)]);
+
+      // each nudge is its own revision - a single undo reverts just the last
+      editing.undo();
+      rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.left, closeTo(101, 0.01));
+      expect(rect.top, closeTo(700, 0.01));
+    });
+
+    test('the delta is translated through the page /Rotate (90°)', () {
+      // page 0 of the nested tree inherits /Rotate 90
+      final editing = PdfEditingController(buildNestedPageTreePdf())
+        ..addRectangle(0, const PdfRect(100, 150, 180, 200));
+      addTearDown(editing.dispose);
+      expect(editing.document.page(0).rotation, 90);
+      editing.selectAnnotationAt(0, 140, 175);
+
+      // on a page turned 90° clockwise, pressing right on screen slides the
+      // annotation along +y in page space (and up slides it along -x)
+      editing.nudgeSelected(1, 0);
+      var rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.left, closeTo(100, 0.01));
+      expect(rect.bottom, closeTo(151, 0.01));
+
+      editing.nudgeSelected(0, -1);
+      rect = editing.document.page(0).annotations.single.rect;
+      expect(rect.left, closeTo(99, 0.01));
+      expect(rect.bottom, closeTo(151, 0.01));
+    });
+  });
+
+  group('arrow keys in the viewer', () {
+    const scale = 800 / 612;
+    // an empty patch mid-page to focus the viewer without selecting anything
+    final empty = const Offset(450 * scale, (792 - 400) * scale);
+
+    Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(2))
+        ..addRectangle(0, const PdfRect(100, 650, 180, 700));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    Future<void> focusViewer(WidgetTester tester) async {
+      await tester.tapAt(empty, kind: PointerDeviceKind.mouse);
+      await tester.pump();
+    }
+
+    testWidgets('an arrow nudges the selection by a point', (tester) async {
+      final editing = await pumpEditor(tester);
+      await focusViewer(tester);
+      editing.selectAnnotationAt(0, 140, 675);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(editing.document.page(0).annotations.single.rect.top,
+          closeTo(701, 0.01));
+    });
+
+    testWidgets('Shift+arrow nudges by the coarse step', (tester) async {
+      final editing = await pumpEditor(tester);
+      await focusViewer(tester);
+      editing.selectAnnotationAt(0, 140, 675);
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pump();
+      expect(editing.document.page(0).annotations.single.rect.left,
+          closeTo(110, 0.01));
+    });
+
+    testWidgets('with nothing selected the arrow keys leave annotations alone',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      await focusViewer(tester);
+      final revisions = editing.bytes.length;
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(editing.bytes.length, revisions);
+      expect(editing.document.page(0).annotations.single.rect.top,
+          closeTo(700, 0.01));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Arrow keys now move the selected annotation(s) so they can be positioned
precisely without a drag: a plain arrow nudges by 1 pt, Shift+arrow by
10 pt. The view-space delta is translated through the primary selected
page's `/Rotate` (new `PdfEditingController.nudgeSelected`) so a key always
slides the annotation the way it points on screen, then handed to the
existing `moveSelected` — one revision, and the selection survives.

The bindings live in the viewer's editing shortcut map (alongside
undo/redo/delete) and are gated on there being an annotation selection, so
a bare arrow still scrolls the page when nothing is selected. While an
in-place text editor is open the whole map is already empty, so arrows
keep reaching the field's own caret movement.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to
`dart_pdf_editor` editing input handling with no effect on the COS,
document, or graphics layers, so those packages' suites and the render
corpora were not exercised. Ran `dart analyze` (clean) and the editor's
Flutter tests, including the new suite plus the multi-select and tool
shortcut suites.

## PDF fixtures and screenshots

No new fixtures — tests reuse the programmatic `buildMultiPagePdf` and the
`buildNestedPageTreePdf` (its pages inherit `/Rotate 90`) builders to cover
both unrotated and rotated pages.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `nudgeSelected` takes a view-space delta (y **down**, as the reader sees
  the page) and maps it to page space per the page rotation, mirroring
  `PdfPageGeometry.toPagePoint` (0 → `(sx, -sy)`, 90 → `(sy, sx)`,
  180 → `(-sx, sy)`, 270 → `(-sy, -sx)`).
- A multi-page selection uses the primary page's rotation for the whole
  move — the same simplification `moveSelected` already makes by applying
  one page delta to every selected annotation.
- Design notes in `doc/dev-log/2026-07-16-arrow-key-nudge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLn7LjYk4uvK1faxfPrN6Q)_