### PR TITLE
Add grid colour selector with recents and document colours

### DIFF
--- a/doc/dev-log/2026-07-16-grid-colour-selector.md
+++ b/doc/dev-log/2026-07-16-grid-colour-selector.md
@@ -1,0 +1,65 @@
+# Grid colour selector: palette + recents + document colours
+
+Added a swatch **grid** to the annotation colour picker, plus two
+context-aware quick-pick rows: the colours the user recently chose, and
+the colours already used in the open document.
+
+## What changed
+
+- `PdfColorPicker` (`editing_color_picker.dart`) now renders labelled
+  swatch grids under the value-entry row:
+  - **Palette** - a fixed general-purpose set (`PdfColorPicker.defaultSwatches`:
+    a grayscale ramp plus a spread of hues). Always shown; pass
+    `swatches: const []` to hide it.
+  - **Recent** - from the new `recentColors` param (empty ⇒ hidden).
+  - **In document** - from the new `documentColors` param (empty ⇒ hidden).
+  Each grid deduplicates by RGB (alpha ignored - the picker deals in opaque
+  colours), wraps to the picker's 260px width, and rings the swatch that
+  matches the current colour. Tapping a swatch adopts it into the model and
+  refreshes the SV area, hue slider, and value fields. Swatch keys are
+  `pdf-color-swatch-<grid>-<HEX>`; grid containers are `pdf-color-grid-<grid>`.
+  `showPdfColorPicker` gained matching `recentColors`/`documentColors`
+  params and now wraps its content in a `SingleChildScrollView` so the taller
+  dialog never overflows on short screens.
+
+- **Recents persistence** (`editing_preferences.dart`): `recentColors`
+  getter + `noteRecentColor(Color)`. Move-to-front, deduped by RGB, capped
+  at 18, stored as a `StringList` of RGB ints under
+  `dart_pdf_editor.editing.recentColors`. Re-noting the current newest colour
+  is a no-op (no write, no notify).
+
+- **Document colours** (`editing_controller.dart`):
+  `documentAnnotationColors({limit = 24})` gathers each annotation's `/C`
+  stroke and `/IC` interior colours across all pages, most-frequent first,
+  deduped by RGB. Cheap and synchronous (a dict read per annotation) - unlike
+  the existing `documentContentColors`, which scans page content streams and
+  is async for large docs. The picker's "In document" grid is annotation
+  colours; the colour-processing dialog keeps its own page-content list.
+
+- **Wiring**: new helper `pickEditingColor(context, controller, initial:)`
+  (`editing_color_pick.dart`) opens the picker with the preferences' format +
+  recents and the controller's annotation colours, and records the committed
+  colour as a recent. Routed through the annotation-styling entry points:
+  the properties panel (`editing_properties.dart`), the toolbar "More
+  colours" button and the text-box fill/border rows (`editing_toolbar.dart`,
+  via a new optional `pickColor` callback on `PdfColorSwatchRow`), the inline
+  free-text colour (`editing_overlay.dart`), and form-field colour
+  (`editing_form_style.dart`). The colour-processing dialog and the page-
+  colour picker pass `recentColors` (+ `noteRecentColor`) but not a document
+  grid. The stamp-template editor and the standalone styled-text prompt keep
+  the plain picker (no controller in scope) - they still get the palette grid.
+
+## Gotchas
+
+- `PdfColorSwatchRow.pickColor` is optional and defaults to a plain
+  `showPdfColorPicker`, so callers without a controller (the styled-text
+  prompt) still work and stay decoupled from the editing layer.
+- Removing the now-unused `editing_color_picker.dart` import from
+  `editing_toolbar.dart`/`editing_properties.dart`/`editing_overlay.dart`/
+  `editing_form_style.dart` after swapping to the helper is easy to miss -
+  the analyzer flags it as `unused_import`.
+
+Tests: swatch-grid rendering/selection/dedup in `editing_test.dart`
+(`PdfColorPicker` group), recents move-to-front/dedup/cap/persist in
+`editing_preferences_test.dart`, and `documentAnnotationColors`
+frequency-ordering + limit in `editing_test.dart`.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_color_pick.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_color_pick.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+import 'editing_color_picker.dart';
+import 'editing_controller.dart';
+
+/// Opens the full colour picker for an editing session, wiring its
+/// quick-pick grids from [controller]: the "Recent" grid from
+/// `PdfEditingPreferences.recentColors` and the "In document" grid from
+/// [PdfEditingController.documentAnnotationColors]. The value-entry format
+/// is restored from and persisted back to the preferences, and a committed
+/// colour is recorded as a recent.
+///
+/// Returns the chosen colour, or null when the dialog is dismissed. This is
+/// the entry point the editing chrome should use instead of
+/// [showPdfColorPicker] directly, so recents and document colours show up
+/// everywhere a colour is chosen.
+Future<Color?> pickEditingColor(
+  BuildContext context,
+  PdfEditingController controller, {
+  required Color initial,
+}) async {
+  final preferences = controller.preferences;
+  final picked = await showPdfColorPicker(
+    context,
+    initial: initial,
+    initialFormat: preferences.colorPickerFormat,
+    onFormatChanged: (format) => preferences.colorPickerFormat = format,
+    recentColors: preferences.recentColors,
+    documentColors: controller.documentAnnotationColors(),
+  );
+  if (picked != null) preferences.noteRecentColor(picked);
+  return picked;
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_color_picker.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_color_picker.dart
@@ -20,9 +20,11 @@ enum PdfColorFormat {
 }
 
 /// A compact full-spectrum color picker: a saturation/value area, a hue
-/// slider, and a value row - hex, RGB, HSL, or CMYK, switchable - kept
-/// in sync. Annotation opacity is a separate controller property, so
-/// the picker deals in opaque colors.
+/// slider, a value row - hex, RGB, HSL, or CMYK, switchable - kept in
+/// sync, and a grid of quick-pick swatches (a fixed palette plus, when
+/// supplied, the colours recently chosen and the colours already used in
+/// the document). Annotation opacity is a separate controller property,
+/// so the picker deals in opaque colors.
 ///
 /// Used by [showPdfColorPicker]; embed it directly for custom chrome.
 class PdfColorPicker extends StatefulWidget {
@@ -32,6 +34,9 @@ class PdfColorPicker extends StatefulWidget {
     required this.onChanged,
     this.initialFormat = PdfColorFormat.hex,
     this.onFormatChanged,
+    this.swatches = defaultSwatches,
+    this.recentColors = const [],
+    this.documentColors = const [],
   });
 
   final Color color;
@@ -43,6 +48,41 @@ class PdfColorPicker extends StatefulWidget {
   /// Reports format switches so the host can persist the choice (see
   /// [showPdfColorPicker]).
   final ValueChanged<PdfColorFormat>? onFormatChanged;
+
+  /// The fixed palette shown in the "Palette" swatch grid. Defaults to
+  /// [defaultSwatches]; pass an empty list to hide the row.
+  final List<Color> swatches;
+
+  /// Colours the user picked recently, most-recent first - shown in a
+  /// "Recent" grid when non-empty. See `PdfEditingPreferences.recentColors`.
+  final List<Color> recentColors;
+
+  /// Colours already used in the open document (annotation strokes and
+  /// fills) - shown in an "In document" grid when non-empty.
+  final List<Color> documentColors;
+
+  /// A general-purpose palette: a grayscale ramp plus a spread of hues.
+  /// Alpha is ignored - the picker deals in opaque colours.
+  static const defaultSwatches = [
+    Color(0xFF000000),
+    Color(0xFF5F6368),
+    Color(0xFF9AA0A6),
+    Color(0xFFDADCE0),
+    Color(0xFFFFFFFF),
+    Color(0xFFD32F2F),
+    Color(0xFFE53935),
+    Color(0xFFF4511E),
+    Color(0xFFFB8C00),
+    Color(0xFFFDD835),
+    Color(0xFFC0CA33),
+    Color(0xFF43A047),
+    Color(0xFF00897B),
+    Color(0xFF1E88E5),
+    Color(0xFF3949AB),
+    Color(0xFF8E24AA),
+    Color(0xFFD81B60),
+    Color(0xFF6D4C41),
+  ];
 
   @override
   State<PdfColorPicker> createState() => _PdfColorPickerState();
@@ -162,6 +202,14 @@ class _PdfColorPickerState extends State<PdfColorPicker> {
     final value = int.tryParse(text, radix: 16);
     if (value == null) return;
     setState(() => _hsv = HSVColor.fromColor(Color(0xFF000000 | value)));
+    widget.onChanged(_color);
+  }
+
+  /// From a swatch tap: adopt the swatch's (opaque) colour into the model
+  /// and refresh the SV area, hue slider, and value fields.
+  void _selectSwatch(Color color) {
+    setState(() => _hsv = HSVColor.fromColor(color.withValues(alpha: 1)));
+    _syncFields();
     widget.onChanged(_color);
   }
 
@@ -287,8 +335,97 @@ class _PdfColorPickerState extends State<PdfColorPicker> {
               ),
             ),
           ]),
+          ..._gridSections(context),
         ],
       ),
+    );
+  }
+
+  /// The swatch grids shown below the value row: the fixed palette, then
+  /// (when supplied) recents and the document's own colours. Each is a
+  /// labelled [_SwatchGrid]; empty inputs drop out entirely.
+  List<Widget> _gridSections(BuildContext context) {
+    final currentRgb = _color.toARGB32() & 0xFFFFFF;
+    final sections = <(String, String, List<Color>)>[
+      ('Palette', 'palette', widget.swatches),
+      ('Recent', 'recent', widget.recentColors),
+      ('In document', 'document', widget.documentColors),
+    ];
+    final grids = <Widget>[];
+    for (final (label, keyPart, colors) in sections) {
+      if (colors.isEmpty) continue;
+      grids
+        ..add(const SizedBox(height: 12))
+        ..add(_SwatchGrid(
+          key: ValueKey('pdf-color-grid-$keyPart'),
+          label: label,
+          keyPart: keyPart,
+          colors: colors,
+          selectedRgb: currentRgb,
+          onSelected: _selectSwatch,
+        ));
+    }
+    return grids;
+  }
+}
+
+/// A labelled row of quick-pick colour swatches that wraps to fit the
+/// picker's width. Deduplicates by RGB (alpha is ignored) so a colour
+/// never appears twice in one grid, and rings the swatch matching the
+/// picker's current colour.
+class _SwatchGrid extends StatelessWidget {
+  const _SwatchGrid({
+    super.key,
+    required this.label,
+    required this.keyPart,
+    required this.colors,
+    required this.selectedRgb,
+    required this.onSelected,
+  });
+
+  final String label;
+  final String keyPart;
+  final List<Color> colors;
+  final int selectedRgb;
+  final ValueChanged<Color> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final seen = <int>{};
+    final swatches = <Widget>[];
+    for (final color in colors) {
+      final rgb = color.toARGB32() & 0xFFFFFF;
+      if (!seen.add(rgb)) continue;
+      final hex = rgb.toRadixString(16).toUpperCase().padLeft(6, '0');
+      swatches.add(Tooltip(
+        message: '#$hex',
+        child: InkWell(
+          key: ValueKey('pdf-color-swatch-$keyPart-$hex'),
+          onTap: () => onSelected(Color(0xFF000000 | rgb)),
+          customBorder: const CircleBorder(),
+          child: Container(
+            width: 24,
+            height: 24,
+            decoration: BoxDecoration(
+              color: Color(0xFF000000 | rgb),
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: rgb == selectedRgb ? scheme.primary : scheme.outline,
+                width: rgb == selectedRgb ? 3 : 1,
+              ),
+            ),
+          ),
+        ),
+      ));
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: Theme.of(context).textTheme.labelSmall),
+        const SizedBox(height: 6),
+        Wrap(spacing: 6, runSpacing: 6, children: swatches),
+      ],
     );
   }
 }
@@ -433,23 +570,31 @@ class _HuePainter extends CustomPainter {
 /// Pass [initialFormat]/[onFormatChanged] to keep the value row's format
 /// across openings - the stock chrome wires them to
 /// `PdfEditingPreferences.colorPickerFormat` so the choice persists on
-/// the device.
+/// the device. [recentColors] and [documentColors] feed the picker's
+/// quick-pick grids (see [PdfColorPicker]); `pickEditingColor` wires
+/// them from the controller and preferences.
 Future<Color?> showPdfColorPicker(
   BuildContext context, {
   required Color initial,
   PdfColorFormat initialFormat = PdfColorFormat.hex,
   ValueChanged<PdfColorFormat>? onFormatChanged,
+  List<Color> recentColors = const [],
+  List<Color> documentColors = const [],
 }) {
   var current = initial;
   return showDialog<Color>(
     context: context,
     builder: (context) => AlertDialog(
       title: const Text('Color'),
-      content: PdfColorPicker(
-        color: initial,
-        onChanged: (color) => current = color,
-        initialFormat: initialFormat,
-        onFormatChanged: onFormatChanged,
+      content: SingleChildScrollView(
+        child: PdfColorPicker(
+          color: initial,
+          onChanged: (color) => current = color,
+          initialFormat: initialFormat,
+          onFormatChanged: onFormatChanged,
+          recentColors: recentColors,
+          documentColors: documentColors,
+        ),
       ),
       actions: [
         TextButton(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_color_processing.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_color_processing.dart
@@ -74,14 +74,18 @@ class _ColorProcessingDialogState extends State<_ColorProcessingDialog> {
       _pickColor(_replace, (value) => _replace = value);
 
   Future<void> _pickColor(Color initial, ValueChanged<Color> setColor) async {
+    // The dialog already lists the document's page-content colours, so the
+    // picker only adds the "Recent" grid here (no document grid).
     final color = await showPdfColorPicker(
       context,
       initial: initial,
       initialFormat: widget.preferences.colorPickerFormat,
       onFormatChanged: (format) =>
           widget.preferences.colorPickerFormat = format,
+      recentColors: widget.preferences.recentColors,
     );
     if (color == null || !mounted) return;
+    widget.preferences.noteRecentColor(color);
     setState(() => setColor(color));
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -3211,6 +3211,33 @@ class PdfEditingController extends ChangeNotifier {
     return [for (final entry in entries) Color(0xFF000000 | entry.key)];
   }
 
+  /// The colours already used by the document's annotations - each
+  /// annotation's /C stroke colour and /IC interior fill - as opaque
+  /// Flutter colours, most-frequent first and deduplicated by RGB.
+  ///
+  /// Cheap and synchronous (a dictionary read per annotation, no content
+  /// stream scan), so it is the "In document" quick-pick grid the colour
+  /// picker shows while styling annotations. Capped at [limit] entries.
+  List<Color> documentAnnotationColors({int limit = 24}) {
+    final counts = <int, int>{};
+    for (var pageIndex = 0; pageIndex < _document.pageCount; pageIndex++) {
+      for (final annotation in _page(pageIndex).annotations) {
+        for (final rgb in [annotation.color, annotation.interiorColor]) {
+          if (rgb == null) continue;
+          counts.update(rgb & 0xFFFFFF, (n) => n + 1, ifAbsent: () => 1);
+        }
+      }
+    }
+    final entries = counts.entries.toList()
+      ..sort((a, b) {
+        final byUses = b.value.compareTo(a.value);
+        return byUses != 0 ? byUses : a.key.compareTo(b.key);
+      });
+    return [
+      for (final entry in entries.take(limit)) Color(0xFF000000 | entry.key),
+    ];
+  }
+
   /// Replaces matching page-content colors across [pages], or the whole
   /// document when [pages] is null. Returns the number of color-setting
   /// operators rewritten, or the number of paint sides suppressed when

--- a/packages/dart_pdf_editor/lib/src/editing/editing_font_controls.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_font_controls.dart
@@ -188,6 +188,7 @@ class PdfColorSwatchRow extends StatelessWidget {
     required this.onChanged,
     this.labelWidth = 86,
     this.allowNone = true,
+    this.pickColor,
   });
 
   /// The row label (e.g. "Text fill").
@@ -211,6 +212,12 @@ class PdfColorSwatchRow extends StatelessWidget {
   /// Whether to include the leading "none" swatch. Background and border
   /// rows allow no colour; foreground text always needs one.
   final bool allowNone;
+
+  /// Opens the full colour picker for the "More colours…" button, given
+  /// the current colour, and returns the chosen colour (or null when
+  /// dismissed). Defaults to a plain [showPdfColorPicker]; pass
+  /// `pickEditingColor` to add the recents and document-colour grids.
+  final Future<Color?> Function(BuildContext context, Color initial)? pickColor;
 
   @override
   Widget build(BuildContext context) {
@@ -271,8 +278,10 @@ class PdfColorSwatchRow extends StatelessWidget {
           tooltip: 'More colors…',
           visualDensity: VisualDensity.compact,
           onPressed: () async {
-            final picked = await showPdfColorPicker(context,
-                initial: value ?? const Color(0xFFFFFFFF));
+            final initial = value ?? const Color(0xFFFFFFFF);
+            final picked = pickColor != null
+                ? await pickColor!(context, initial)
+                : await showPdfColorPicker(context, initial: initial);
             if (picked != null) onChanged(picked);
           },
         ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_style.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_style.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 
-import 'editing_color_picker.dart';
+import 'editing_color_pick.dart';
 import 'editing_controller.dart';
 import 'editing_font_controls.dart';
 import 'editing_fonts.dart';
@@ -140,11 +140,8 @@ class _PdfFormFieldStyleControlsState extends State<PdfFormFieldStyleControls> {
   PdfEditingController get _controller => widget.controller;
 
   Future<void> _pickColor(String name, Color current) async {
-    final prefs = _controller.preferences;
-    final picked = await showPdfColorPicker(context,
-        initial: current,
-        initialFormat: prefs.colorPickerFormat,
-        onFormatChanged: (format) => prefs.colorPickerFormat = format);
+    final picked =
+        await pickEditingColor(context, _controller, initial: current);
     if (picked != null) {
       _controller.setFormFieldStyle(name, color: picked.toARGB32() & 0xFFFFFF);
     }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -13,7 +13,7 @@ import 'package:pdf_document/pdf_document.dart';
 import '../page_geometry.dart';
 import '../renderer.dart';
 import '../theme.dart';
-import 'editing_color_picker.dart';
+import 'editing_color_pick.dart';
 import 'editing_controller.dart';
 import 'editing_fonts.dart';
 import 'editing_interaction.dart';
@@ -4466,7 +4466,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (!_canStyleInlineTextSelection) return;
     _textEditStyleMenuOpen = true;
     _textEditFocus.requestFocus();
-    final picked = await showPdfColorPicker(context, initial: initial);
+    final picked =
+        await pickEditingColor(context, _controller, initial: initial);
     _textEditStyleMenuOpen = false;
     if (mounted && _textEditRect != null) _textEditFocus.requestFocus();
     if (picked != null && mounted) _applyInlineTextStyle(color: picked);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -71,6 +71,7 @@ class PdfEditingPreferences extends ChangeNotifier {
   PdfStampTimeFormat _stampTimeFormat = PdfStampTimeFormat.twentyFourHour;
   ThemeMode _themeMode = ThemeMode.system;
   PdfColorFormat _colorPickerFormat = PdfColorFormat.hex;
+  List<Color> _recentColors = const [];
   Color _pageColor = const Color(0xFFFFFFFF);
   bool _showAnnotations = true;
   bool _highlightFormFields = true;
@@ -190,6 +191,13 @@ class PdfEditingPreferences extends ChangeNotifier {
         _colorPickerFormat =
             PdfColorFormat.values.asNameMap()[colorPickerFormat] ??
                 _colorPickerFormat;
+      }
+      final recentColors = store.getStringList('${_prefix}recentColors');
+      if (recentColors != null) {
+        _recentColors = List.unmodifiable([
+          for (final entry in recentColors)
+            if (int.tryParse(entry) case final rgb?) Color(0xFF000000 | rgb),
+        ]);
       }
       final pageColor = store.getInt('${_prefix}pageColor');
       if (pageColor != null) _pageColor = Color(pageColor);
@@ -727,6 +735,39 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _colorPickerFormat) return;
     _colorPickerFormat = value;
     _write((s) => s.setString('${_prefix}colorPickerFormat', value.name));
+    notifyListeners();
+  }
+
+  /// How many recently-picked colours to remember (see [recentColors]).
+  static const _maxRecentColors = 18;
+
+  /// The colours most recently chosen in the full colour picker, newest
+  /// first - the picker's "Recent" quick-pick grid. Opaque (alpha
+  /// dropped); deduplicated by RGB. Persisted on the device.
+  List<Color> get recentColors => _recentColors;
+
+  /// Records [color] as the most-recently-used colour, moving it to the
+  /// front (deduplicated by RGB) and dropping the oldest past
+  /// [_maxRecentColors]. Alpha is ignored - the picker deals in opaque
+  /// colours. A no-op when [color] is already the newest entry.
+  void noteRecentColor(Color color) {
+    final rgb = color.toARGB32() & 0xFFFFFF;
+    final opaque = Color(0xFF000000 | rgb);
+    if (_recentColors.isNotEmpty &&
+        (_recentColors.first.toARGB32() & 0xFFFFFF) == rgb) {
+      return;
+    }
+    final next = [
+      opaque,
+      for (final existing in _recentColors)
+        if ((existing.toARGB32() & 0xFFFFFF) != rgb) existing,
+    ];
+    if (next.length > _maxRecentColors) {
+      next.removeRange(_maxRecentColors, next.length);
+    }
+    _recentColors = List.unmodifiable(next);
+    _write((s) => s.setStringList('${_prefix}recentColors',
+        [for (final c in _recentColors) '${c.toARGB32() & 0xFFFFFF}']));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -3,7 +3,7 @@ import 'package:flutter/foundation.dart' show listEquals;
 import 'package:pdf_document/pdf_document.dart';
 
 import 'annotation_presentation.dart';
-import 'editing_color_picker.dart';
+import 'editing_color_pick.dart';
 import 'editing_controller.dart';
 import 'editing_font_controls.dart';
 import 'editing_fonts.dart';
@@ -312,18 +312,14 @@ class _PdfAnnotationPropertiesPanelState
   Future<void> _pickColor() async {
     final initial =
         _controller.selectedAnnotationStyle?.color ?? _controller.color;
-    final picked = await showPdfColorPicker(context,
-        initial: initial,
-        initialFormat: _preferences.colorPickerFormat,
-        onFormatChanged: (format) => _preferences.colorPickerFormat = format);
+    final picked =
+        await pickEditingColor(context, _controller, initial: initial);
     if (picked != null) _controller.restyleSelected(color: picked);
   }
 
   Future<void> _pickFill(Color? current) async {
-    final picked = await showPdfColorPicker(context,
-        initial: current ?? const Color(0xFFFFF59D),
-        initialFormat: _preferences.colorPickerFormat,
-        onFormatChanged: (format) => _preferences.colorPickerFormat = format);
+    final picked = await pickEditingColor(context, _controller,
+        initial: current ?? const Color(0xFFFFF59D));
     if (picked != null) _controller.restyleSelected(fill: (picked,));
   }
 
@@ -331,10 +327,8 @@ class _PdfAnnotationPropertiesPanelState
       color == null ? null : color.toARGB32() & 0xFFFFFF;
 
   Future<void> _pickTextBorder(Color? current) async {
-    final picked = await showPdfColorPicker(context,
-        initial: current ?? const Color(0xFF000000),
-        initialFormat: _preferences.colorPickerFormat,
-        onFormatChanged: (format) => _preferences.colorPickerFormat = format);
+    final picked = await pickEditingColor(context, _controller,
+        initial: current ?? const Color(0xFF000000));
     if (picked != null) {
       _controller.restyleSelectedText(
           border: (_rgb(picked),), borderWidth: _controller.strokeWidth);
@@ -855,10 +849,8 @@ class _PdfAnnotationPropertiesPanelState
   }
 
   Future<void> _pickFormColor(String name, Color current) async {
-    final picked = await showPdfColorPicker(context,
-        initial: current,
-        initialFormat: _preferences.colorPickerFormat,
-        onFormatChanged: (format) => _preferences.colorPickerFormat = format);
+    final picked =
+        await pickEditingColor(context, _controller, initial: current);
     if (picked != null) {
       _controller.setFormFieldStyle(name, color: picked.toARGB32() & 0xFFFFFF);
     }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -15,7 +15,7 @@ import 'package:pdf_document/pdf_document.dart'
 
 import '../pdf_viewer.dart';
 import '../toast.dart';
-import 'editing_color_picker.dart';
+import 'editing_color_pick.dart';
 import 'editing_color_processing.dart';
 import 'editing_controller.dart';
 import 'editing_font_controls.dart';
@@ -1792,11 +1792,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             child: InkWell(
               customBorder: const CircleBorder(),
               onTap: () async {
-                final picked = await showPdfColorPicker(context,
-                    initial: controller.color,
-                    initialFormat: controller.preferences.colorPickerFormat,
-                    onFormatChanged: (format) =>
-                        controller.preferences.colorPickerFormat = format);
+                final picked = await pickEditingColor(context, controller,
+                    initial: controller.color);
                 if (picked != null) _applyColor(picked);
               },
               child: SizedBox(
@@ -3334,6 +3331,8 @@ class _StyleMenuState extends State<_StyleMenu> {
         palette: widget.palette,
         onChanged: onChanged,
         allowNone: allowNone,
+        pickColor: (context, initial) =>
+            pickEditingColor(context, controller, initial: initial),
       );
 
   /// A short human label for a line ending in the picker.

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -787,8 +787,12 @@ Future<void> _selectViewOption(
         initial: preferences.pageColor,
         initialFormat: preferences.colorPickerFormat,
         onFormatChanged: (format) => preferences.colorPickerFormat = format,
+        recentColors: preferences.recentColors,
       );
-      if (color != null) preferences.pageColor = color;
+      if (color != null) {
+        preferences.noteRecentColor(color);
+        preferences.pageColor = color;
+      }
     case _ViewOption.author:
       onAuthorPressed?.call();
     case _ViewOption.shortcuts:

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -56,6 +56,43 @@ void main() {
       expect(b.stampTimeFormat, PdfStampTimeFormat.twelveHourSeconds);
     });
 
+    test('noteRecentColor moves to front, dedupes, caps, and persists',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final a = PdfEditingPreferences();
+      await a.ready;
+      expect(a.recentColors, isEmpty);
+
+      // alpha is dropped and RGB deduplicated; newest goes first
+      a.noteRecentColor(const Color(0xFFE53935));
+      a.noteRecentColor(const Color(0x8043A047));
+      a.noteRecentColor(const Color(0xFFE53935)); // re-pick moves it to front
+      expect(a.recentColors,
+          const [Color(0xFF43A047), Color(0xFFE53935)].reversed.toList());
+      expect(a.recentColors.first, const Color(0xFFE53935));
+      expect(a.recentColors.length, 2);
+
+      // re-noting the newest colour (any alpha) is a no-op: no duplicate,
+      // no reorder, no listener churn
+      var notified = 0;
+      a.addListener(() => notified++);
+      a.noteRecentColor(const Color(0x00E53935)); // same RGB, alpha ignored
+      a.noteRecentColor(const Color(0xFFE53935));
+      expect(notified, 0);
+
+      // the cap holds: pushing 20 distinct colours keeps only the newest 18
+      for (var i = 0; i < 20; i++) {
+        a.noteRecentColor(Color(0xFF000000 | i));
+      }
+      expect(a.recentColors.length, 18);
+      expect(a.recentColors.first, const Color(0xFF000013)); // 19th push (i=19)
+      await pumpEventQueue();
+
+      final b = PdfEditingPreferences();
+      await b.ready;
+      expect(b.recentColors, a.recentColors);
+    });
+
     test('empty storage leaves the defaults', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = PdfEditingPreferences();

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -497,6 +497,41 @@ void main() {
           reason: 'the last page cannot be removed');
       expect(editing.document.page(0).annotations.single.subtype, 'Square');
     });
+
+    test('documentAnnotationColors collects annotation stroke/fill colours',
+        () {
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      expect(editing.documentAnnotationColors(), isEmpty);
+
+      editing
+        ..color = const Color(0xFF1E88E5)
+        ..addInkStroke(0, [(100, 100), (150, 130)])
+        ..finishInk();
+      editing
+        ..color = const Color(0xFFE53935)
+        ..addInkStroke(1, [(100, 100), (150, 130)])
+        ..finishInk();
+      // a second blue stroke makes blue the most-frequent colour
+      editing
+        ..color = const Color(0xFF1E88E5)
+        ..addInkStroke(0, [(120, 90), (140, 95)])
+        ..finishInk();
+
+      final colors = editing.documentAnnotationColors();
+      expect(colors, [const Color(0xFF1E88E5), const Color(0xFFE53935)],
+          reason: 'most-frequent first, deduplicated by RGB');
+    });
+
+    test('documentAnnotationColors respects the limit', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      for (var i = 0; i < 5; i++) {
+        editing
+          ..color = Color(0xFF000000 | (i * 0x102030))
+          ..addInkStroke(0, [(100.0 + i, 100), (150, 130)])
+          ..finishInk();
+      }
+      expect(editing.documentAnnotationColors(limit: 3), hasLength(3));
+    });
   });
 
   group('editing in the viewer', () {
@@ -1537,6 +1572,85 @@ void main() {
       expect(calls.changed, isEmpty);
       await enterChannel(tester, 0, '12');
       expect(calls.changed.last, const Color(0xFF0C3935));
+    });
+
+    testWidgets('the palette grid shows and a swatch tap drives onChanged',
+        (tester) async {
+      Color? last;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PdfColorPicker(
+              color: const Color(0xFFE53935),
+              onChanged: (color) => last = color,
+            ),
+          ),
+        ),
+      ));
+
+      // the fixed palette always shows; recents/document grids do not
+      // unless supplied
+      expect(find.byKey(const ValueKey('pdf-color-grid-palette')), findsOne);
+      expect(find.byKey(const ValueKey('pdf-color-grid-recent')), findsNothing);
+      expect(
+          find.byKey(const ValueKey('pdf-color-grid-document')), findsNothing);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-color-swatch-palette-1E88E5')));
+      expect(last, const Color(0xFF1E88E5));
+    });
+
+    testWidgets('recent and document grids show their swatches and select',
+        (tester) async {
+      Color? last;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PdfColorPicker(
+              color: const Color(0xFFE53935),
+              onChanged: (color) => last = color,
+              recentColors: const [Color(0xFF112233)],
+              documentColors: const [Color(0xFF445566), Color(0xFF778899)],
+            ),
+          ),
+        ),
+      ));
+
+      expect(find.byKey(const ValueKey('pdf-color-grid-recent')), findsOne);
+      expect(find.byKey(const ValueKey('pdf-color-grid-document')), findsOne);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-color-swatch-recent-112233')));
+      expect(last, const Color(0xFF112233));
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-color-swatch-document-778899')));
+      expect(last, const Color(0xFF778899));
+    });
+
+    testWidgets('a grid deduplicates repeated colours by RGB', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PdfColorPicker(
+              color: const Color(0xFFE53935),
+              onChanged: (_) {},
+              swatches: const [],
+              recentColors: const [
+                Color(0xFF112233),
+                Color(0xFF112233),
+                Color(0xFFABCDEF),
+              ],
+            ),
+          ),
+        ),
+      ));
+
+      // the duplicate collapses to a single swatch under one key
+      expect(find.byKey(const ValueKey('pdf-color-swatch-recent-112233')),
+          findsOne);
+      expect(find.byKey(const ValueKey('pdf-color-swatch-recent-ABCDEF')),
+          findsOne);
     });
   });
 }


### PR DESCRIPTION
## Summary

The annotation colour picker now shows a **swatch grid** below the value-entry row, with two context-aware quick-pick rows: the colours the user recently chose, and the colours already used in the open document.

- **`PdfColorPicker` / `showPdfColorPicker`** gain `swatches` (a fixed `defaultSwatches` palette — grayscale ramp + hue spread), `recentColors`, and `documentColors` params. Each renders a labelled grid that deduplicates by RGB (alpha ignored), wraps to the picker width, and rings the swatch matching the current colour; tapping a swatch drives `onChanged`. Empty lists drop out, so the recents/document rows only appear when supplied. The dialog now wraps its content in a `SingleChildScrollView` so the taller picker never overflows on short screens.
- **`PdfEditingPreferences`** persists `recentColors` (move-to-front, deduped by RGB, capped at 18) via the new `noteRecentColor`.
- **`PdfEditingController.documentAnnotationColors`** collects each annotation's `/C` stroke and `/IC` interior colours across all pages, most-frequent first — a cheap synchronous read (distinct from the async page-content `documentContentColors`) that feeds the "In document" grid.
- New **`pickEditingColor(context, controller, initial:)`** helper opens the picker with the preferences' format + recents and the controller's annotation colours, and records the committed colour as a recent. Routed through the annotation-styling entry points: properties panel, toolbar "More colours" + text-box fill/border rows (via a new optional `pickColor` callback on `PdfColorSwatchRow`), inline free text, and form-field colour. The colour-processing dialog and page-colour picker pass `recentColors` (they already have, or don't need, a document grid).

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (1449 pass, 35 pre-existing skips)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Only `dart_pdf_editor` is touched, so the other package suites and the corpus/render sweeps were not run — no parser or rendering behaviour changed.

## PDF fixtures and screenshots

No fixtures needed — new tests use the programmatic `buildMultiPagePdf` builder and widget pumps. Coverage added: swatch-grid render/selection/dedup (`editing_test.dart` `PdfColorPicker` group), recents move-to-front/dedup/cap/persist (`editing_preferences_test.dart`), and `documentAnnotationColors` frequency-ordering + limit (`editing_test.dart`).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `PdfColorSwatchRow.pickColor` is optional and defaults to a plain `showPdfColorPicker`, so callers without a controller in scope (the standalone styled-text prompt, the stamp-template editor) keep working and still get the fixed palette grid — they just don't get recents/document colours.
- `documentAnnotationColors` is annotation colours (`/C`, `/IC`) only; the colour-processing dialog keeps its own page-content colour list, so those two "document colours" surfaces are complementary, not duplicates.
- Session notes in `doc/dev-log/2026-07-16-grid-colour-selector.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LUKSn73S73p97K4AumzhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015LUKSn73S73p97K4AumzhJ)_