### PR TITLE
Preview a 'TEXT' placeholder when hovering the text-stamp tool

### DIFF
--- a/doc/dev-log/2026-07-16-text-stamp-hover-preview.md
+++ b/doc/dev-log/2026-07-16-text-stamp-hover-preview.md
@@ -1,0 +1,26 @@
+# Text stamp: hover preview shows a 'TEXT' placeholder
+
+The stamp tool already painted a live hover preview for an **active custom
+stamp** (`_activeStampAfterimageAt` → `stampPreview`), so you could see the
+auto-sized box a click would drop before committing. But the plain
+**text-stamp fallback** — the mode with no active custom stamp, where a click
+prompts for the caption — showed nothing on hover: `_onHover` returned `null`
+when `activeStamp == null`, so the click target was invisible.
+
+Fix (`editing_overlay.dart`): a small `_stampHoverAfterimageAt(position)`
+helper that returns the active-stamp afterimage when one is selected, and
+otherwise previews the text-stamp fallback via the existing
+`_textStampAfterimageAt` with a `'TEXT'` placeholder caption
+(`_textStampPreviewLabel`) in the toolbar `color`. Both `_onHover` and the
+`_EditingPreviewPainter.stampPreview` wiring now call the helper instead of
+`_activeStampAfterimageAt` directly.
+
+The placeholder is preview-only: a click still opens the text prompt and
+commits the entered caption (`placeTextStamp`), sized to the real text. The
+preview box is sized for `'TEXT'`, so the ghost is an approximate footprint,
+not the final width — good enough to show where the stamp lands.
+
+Test: `editing_stamps_test.dart` gains "stamp hover previews a TEXT
+placeholder without an active stamp" alongside the existing active-stamp
+hover test — hover paints a `stampPreview` with `text == 'TEXT'` centered on
+the pointer, nothing is committed, and moving off-page clears it.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1868,6 +1868,21 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     );
   }
 
+  /// Placeholder caption previewed while hovering the text-stamp tool before
+  /// a click prompts for the real text.
+  static const String _textStampPreviewLabel = 'TEXT';
+
+  /// The stamp tool's hover preview: an active custom stamp when one is
+  /// selected, otherwise the plain text-stamp fallback shown as a
+  /// [_textStampPreviewLabel] placeholder so the click target is visible.
+  _StampAfterimage? _stampHoverAfterimageAt(Offset position) {
+    if (_controller.activeStamp != null) {
+      return _activeStampAfterimageAt(position);
+    }
+    return _textStampAfterimageAt(
+        position, _textStampPreviewLabel, _controller.color);
+  }
+
   _StampAfterimage _countPreviewAt(Offset position) {
     final (x, y) = _geometry.toPagePoint(position);
     final box = _controller.pageAt(widget.pageIndex).cropBox;
@@ -4190,12 +4205,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       }
       cursor = SystemMouseCursors.none;
     } else if (_tool == PdfEditTool.stamp) {
-      // active custom stamps can be placed by a plain click. Show the
-      // exact auto-sized placement before committing it; when the tool is
-      // in its prompt-for-text fallback there is no text to preview yet.
-      final preview = _controller.activeStamp == null
-          ? null
-          : _activeStampAfterimageAt(event.localPosition);
+      // active custom stamps can be placed by a plain click - show the exact
+      // auto-sized placement before committing it. The prompt-for-text
+      // fallback has no caption yet, so it previews a 'TEXT' placeholder to
+      // make the click target visible.
+      final preview = _stampHoverAfterimageAt(event.localPosition);
       if (preview == null) {
         if (_stampPreview != null) setState(() => _stampPreview = null);
       } else if (_stampPreview != event.localPosition) {
@@ -5136,7 +5150,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     stampPreview: _tool == PdfEditTool.stamp &&
                             _dragStart == null &&
                             _stampPreview != null
-                        ? _activeStampAfterimageAt(_stampPreview!)
+                        ? _stampHoverAfterimageAt(_stampPreview!)
                         : null,
                     rotateCursor: _rotateCursor,
                     afterGhost: afterGhost,

--- a/packages/dart_pdf_editor/test/editing_stamps_test.dart
+++ b/packages/dart_pdf_editor/test/editing_stamps_test.dart
@@ -915,6 +915,61 @@ void main() {
       expect(overlayPainter(tester).stampPreview, isNull);
     });
 
+    testWidgets('stamp hover previews a TEXT placeholder without an active stamp',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..tool = PdfEditTool.stamp;
+      addTearDown(editing.dispose);
+      expect(editing.activeStamp, isNull);
+
+      final page = editing.document.page(0);
+      final geometry = PdfPageGeometry(
+        cropBox: page.cropBox,
+        rotation: 0,
+        viewSize: const Size(306, 396),
+      );
+      Offset local(double x, double y) => Offset(x * 0.5, (792 - y) * 0.5);
+      await tester.pumpWidget(MaterialApp(
+        home: Material(
+          child: Center(
+            child: SizedBox(
+              width: geometry.viewSize.width,
+              height: geometry.viewSize.height,
+              child: EditingPageOverlay(
+                controller: editing,
+                pageIndex: 0,
+                geometry: geometry,
+                textPrompt: showPdfTextPrompt,
+                rasterCurrent: false,
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      final origin = tester.getTopLeft(find.byType(EditingPageOverlay));
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: origin + local(250, 430));
+      addTearDown(mouse.removePointer);
+      await mouse.moveTo(origin + local(300, 400));
+      await tester.pump();
+
+      // hovering shows the placeholder; nothing is committed until a click
+      // prompts for the real caption.
+      expect(editing.document.page(0).annotations, isEmpty);
+      final preview = overlayPainter(tester).stampPreview;
+      expect(preview, isNotNull);
+      expect(preview.text, 'TEXT');
+      expect(preview.rect.center.dx, moreOrLessEquals(local(300, 400).dx));
+      expect(preview.rect.center.dy, moreOrLessEquals(local(300, 400).dy));
+
+      await mouse.moveTo(origin + const Offset(-20, -20));
+      await tester.pump();
+      expect(overlayPainter(tester).stampPreview, isNull);
+    });
+
     testWidgets('adding a stamp keeps existing annotations painted',
         (tester) async {
       SharedPreferences.setMockInitialValues({});


### PR DESCRIPTION
## Summary

The stamp tool painted a live hover preview only for an **active custom stamp** — you could see the auto-sized box a click would drop before committing. The plain **text-stamp fallback** (the mode with no active custom stamp, where a click prompts for the caption) showed nothing on hover, leaving the click target invisible.

This adds a hover preview for that fallback: while hovering, the tool now paints a `'TEXT'` placeholder ghost at the pointer so you can see where the stamp will land. The placeholder is preview-only — a click still opens the text prompt and commits the entered caption (`placeTextStamp`), sized to the real text.

Implementation (`editing_overlay.dart`): a small `_stampHoverAfterimageAt(position)` helper returns the active-stamp afterimage when one is selected, and otherwise previews the text-stamp fallback via the existing `_textStampAfterimageAt` with a `'TEXT'` placeholder caption in the toolbar color. Both `_onHover` and the `_EditingPreviewPainter.stampPreview` wiring now go through the helper instead of calling `_activeStampAfterimageAt` directly.

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Ran `dart analyze` on the edited file (no issues) and the full `editing_stamps_test.dart` suite (41 tests pass, including the new placeholder test). Other package suites and the corpus sweeps were not run — the change is confined to the editor's stamp-tool hover preview.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The preview box is sized for the literal `'TEXT'` string, so the ghost is an approximate footprint rather than the final committed width (which depends on the entered caption). New test: "stamp hover previews a TEXT placeholder without an active stamp" in `editing_stamps_test.dart`, mirroring the existing active-stamp hover test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nSxwALbtEsXPR6X3jTYdx

---
_Generated by [Claude Code](https://claude.ai/code/session_012nSxwALbtEsXPR6X3jTYdx)_