### PR TITLE
Fix Ctrl/⌘+S no-op on a brand-new untitled document

### DIFF
--- a/app/lib/document_tab.dart
+++ b/app/lib/document_tab.dart
@@ -98,6 +98,12 @@ class DocumentTab {
   /// True when the document has edits not yet written to disk.
   bool get isDirty => session != null && session!.bytes.length != savedLength;
 
+  /// True until this document has been saved at least once. A brand-new
+  /// document (created via New, [initiallyDirty]) has no saved baseline, so
+  /// it is savable even before the first edit; [markSaved] establishes the
+  /// baseline and clears this.
+  bool get isUnsaved => session != null && savedLength < 0;
+
   /// Marks the current revision as the saved baseline (call after a save).
   void markSaved() {
     if (session != null) savedLength = session!.bytes.length;

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -1509,6 +1509,10 @@ class _EditorScreenState extends State<EditorScreen>
       onSave: (_) => unawaited(_save(tab)),
       onSaveAs: (_) => unawaited(_save(tab, saveAs: true)),
       showSaveButton: !compact,
+      // A brand-new untitled document has no on-disk origin yet, so keep
+      // Save (button + Ctrl/⌘+S) live even before the first edit - the first
+      // save writes the file via the Save As flow.
+      alwaysAllowSave: tab.isUnsaved,
       onPickPdfToInsert: pickPdfBytes,
       onExportPages: (bytes) =>
           unawaited(saveBytesAs(context, bytes, tab.title)),

--- a/app/test/save_shortcuts_test.dart
+++ b/app/test/save_shortcuts_test.dart
@@ -70,6 +70,47 @@ void main() {
     }
   });
 
+  testWidgets('Ctrl+S saves a brand-new untitled document before any edit',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      var saveAsCalls = 0;
+      await tester.pumpWidget(MaterialApp(
+        home: EditorScreen(
+          prefs: prefs,
+          saveDocumentAs: (context, bytes, suggestedName) async {
+            saveAsCalls++;
+            expect(suggestedName, 'Untitled.pdf');
+            return SaveResult.cancelled;
+          },
+        ),
+      ));
+      await tester.pump();
+
+      // Create a new, unedited document from the app menu.
+      await tester.tap(find.byTooltip('DartPDF menu'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('menu-new-document')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('new-document-create')));
+      await tester.pumpAndSettle();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Plain Ctrl+S with no edits yet must still reach the Save flow: a
+      // never-saved document has no on-disk origin to overwrite.
+      await tester.tap(find.byType(PdfViewer), kind: PointerDeviceKind.mouse);
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyS);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(saveAsCalls, 1);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
   testWidgets('Save As continues the current tab at the new path',
       (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.linux;

--- a/doc/dev-log/2026-07-16-new-doc-save-shortcut.md
+++ b/doc/dev-log/2026-07-16-new-doc-save-shortcut.md
@@ -1,0 +1,44 @@
+# Ctrl/⌘+S on a brand-new untitled document
+
+## Symptom
+
+Creating a new document (app menu → *New document…*) and immediately
+pressing **Ctrl+S** / **⌘S** did nothing - the file could not be saved
+until an edit was made first. The stock Save button was likewise greyed
+out on the fresh document.
+
+## Cause
+
+`PdfEditorView._save()` (and the Save button's `onPressed`) gate on
+`_canSave`, which was `_session.isModified`. A freshly-created blank
+document has made no edits yet, so `PdfEditingController.isModified`
+(`_cursor > 0 || _hardModified`) is `false` and the shortcut early-returned.
+The SDK has no concept of a document's on-disk origin, so it treated a
+never-saved new file the same as an unchanged opened file.
+
+The app already tracks this state: a `New` tab is created with
+`initiallyDirty: true`, which sets `DocumentTab.savedLength = -1` (no saved
+baseline). But that flag never reached the SDK's save gate.
+
+## Fix
+
+- `PdfEditorView` gains `alwaysAllowSave` (default `false`). When `true`,
+  `_canSave => _session.isModified || alwaysAllowSave`, so Save stays live
+  even with no unsaved edits. Save As (`onSaveAs`) was already ungated.
+- `DocumentTab.isUnsaved` (`session != null && savedLength < 0`) marks a
+  document that has never been written to disk. `markSaved()` sets a
+  real baseline, clearing it.
+- `EditorScreen._buildBody` passes `alwaysAllowSave: tab.isUnsaved`. The
+  first Ctrl+S on a new tab has no origin, so `_save(tab)` routes through
+  the Save As flow (save dialog / download / share sheet).
+
+Opened-from-disk documents are unaffected: they have a saved baseline, so
+`isUnsaved` is `false` and Save stays gated on real edits.
+
+## Tests
+
+`app/test/save_shortcuts_test.dart`: *Ctrl+S saves a brand-new untitled
+document before any edit* creates a document via the menu and asserts the
+injected `saveDocumentAs` seam fires on a plain Ctrl+S with no edits.
+The SDK's existing *save button is disabled until there are changes*
+(`pdf_shell_test.dart`) still passes, pinning the default-`false` behaviour.

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -213,6 +213,7 @@ class PdfEditorView extends StatefulWidget {
     this.onSave,
     this.onSaveAs,
     this.showSaveButton = true,
+    this.alwaysAllowSave = false,
     this.onDocumentChanged,
     this.onPickPdfToInsert,
     this.onExportPages,
@@ -305,6 +306,13 @@ class PdfEditorView extends StatefulWidget {
   /// save affordance while still keeping [onSave] and the keyboard
   /// shortcut active.
   final bool showSaveButton;
+
+  /// Keeps Save (the button and ⌘S / Ctrl+S) enabled even when the
+  /// document has no unsaved edits. Hosts set this for a document that has
+  /// never been written to disk - a new untitled file - so the first Save
+  /// can create the file before any edit is made. Defaults to false, where
+  /// Save is gated on [PdfEditingController.isModified] as usual.
+  final bool alwaysAllowSave;
 
   /// Called after every revision - edits, undo, redo - with the new
   /// current bytes. For autosaving hosts.
@@ -534,8 +542,10 @@ class _PdfEditorViewState extends State<PdfEditorView> {
 
   /// Whether there's anything to save: false while the document still
   /// matches what was opened, which disables the Save button (and makes
-  /// the ⌘S / Ctrl+S shortcut a no-op).
-  bool get _canSave => _session.isModified;
+  /// the ⌘S / Ctrl+S shortcut a no-op). A host that flags the document as
+  /// never-saved ([PdfEditorView.alwaysAllowSave]) keeps Save enabled so a
+  /// brand-new file can be written before its first edit.
+  bool get _canSave => _session.isModified || widget.alwaysAllowSave;
 
   void _save() {
     if (!_canSave) return;


### PR DESCRIPTION
## Summary

Pressing **Ctrl+S** / **⌘S** on a brand-new *Untitled* document (created via the app menu → *New document…*) did nothing until an edit was made first; the stock Save button was likewise greyed out on the fresh file.

The SDK gates Save on `PdfEditorView._canSave` = `_session.isModified`. A freshly-created blank document has made no edits, so `PdfEditingController.isModified` is `false` and the shortcut early-returned. The SDK has no notion of a document's on-disk origin, so it treated a never-saved new file the same as an unchanged opened file.

Fix:
- `PdfEditorView` gains `alwaysAllowSave` (default `false`). When `true`, `_canSave => _session.isModified || alwaysAllowSave`, so Save (button + Ctrl/⌘+S) stays live even with no unsaved edits. Save As was already ungated.
- `DocumentTab.isUnsaved` (`session != null && savedLength < 0`) flags a document that has never been written to disk; `markSaved()` clears it.
- `EditorScreen._buildBody` passes `alwaysAllowSave: tab.isUnsaved`, so the first Ctrl+S on a new tab (which has no origin) routes through the Save As flow.

Documents opened from disk already have a saved baseline, so `isUnsaved` is `false` and their Save stays gated on real edits — unchanged behavior.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only

_(`app/` host app + a new dev-log note.)_

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (save/shell group)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Analyze is clean. Ran the affected app tests (`save_shortcuts_test.dart`, `new_document_test.dart`) and the SDK's `pdf_shell_test.dart` save group — all pass. Corpus/render suites not run: this change touches only the app's save wiring and an SDK save-gate flag, with no parser or rendering surface.

## PDF fixtures and screenshots

None — reproduced and pinned with a widget test that creates a document via the menu and asserts the injected `saveDocumentAs` seam fires on a plain Ctrl+S with no edits.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

`alwaysAllowSave` is a small additive flag with a `false` default, so existing `PdfEditorView` hosts are unaffected. The SDK's *save button is disabled until there are changes* test still passes, pinning the default behavior. New dev-log note: `doc/dev-log/2026-07-16-new-doc-save-shortcut.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Df91CXB1MrqJRxV3Qp8o7z)_