### PR TITLE
Allow rounding corners of rectangle shapes

### DIFF
--- a/doc/dev-log/2026-07-16-rectangle-corner-radius-restyle.md
+++ b/doc/dev-log/2026-07-16-rectangle-corner-radius-restyle.md
@@ -1,0 +1,52 @@
+# Corner radius as a restyle property for selected rectangles
+
+Follow-up to `2026-07-16-rectangle-corner-radius.md`, which added corner
+rounding only as a *creation* default (the tune slider set
+`PdfEditingController.cornerRadius`, and restyling an already-placed
+rectangle was called out as out of scope). This adds it as an editable
+property of a selected /Square.
+
+## Core (`pdf_document`)
+
+- `PdfEditor.restyleAnnotation` gains a `double? cornerRadius` parameter,
+  folded into the "nothing to change" early-return guard. In the
+  `Square || Circle` case it rewrites the `/Border` array
+  (`[hCornerRadius vCornerRadius width]`, §12.5.4; the width mirrors the
+  current stroke) and lets the existing `_restyleRegenerate` →
+  `_regenerateResizedAppearance` path rebake the rounded `/AP` — that path
+  already reads the radius back from `annotation.cornerRadius`, so no new
+  geometry code. Radius `0` drops `/Border` and restores square corners.
+- Rounding is rectangle-only. A `cornerRadius`-only call on a /Circle now
+  returns false instead of staging a pointless regeneration (a circle has
+  no corners), guarded before the shared Square/Circle body so a
+  colour/width/opacity change on a circle still works.
+
+## Editor UI (`dart_pdf_editor`)
+
+- `PdfEditingController.restyleSelected` gains `cornerRadius`, threaded to
+  every selected annotation (subtypes that don't round ignore it, so a
+  mixed selection is safe). New `canRoundSelectedCorners` (every selected
+  annotation is a restylable /Square) gates the control, and
+  `selectedCornerRadius` exposes the primary rectangle's current radius for
+  display.
+- `_selectionStyleFields()` sets `cornerRadius: canRoundSelectedCorners` on
+  the Square/Circle/Polygon branch, so the selection strip's tune popup
+  shows the slider for a selected rectangle (and only a rectangle).
+- The existing "Corner radius" slider is now restyle-aware, mirroring the
+  stroke slider: a `_draggingCornerRadius` live readout, value from
+  `selectedCornerRadius ?? cornerRadius`, and `onChangeEnd` calls
+  `restyleSelected(cornerRadius:)` when a selection is being restyled
+  (else it just updates the creation default).
+
+## Tests
+
+- `annotation_restyle_test.dart`: rounding a placed square rebakes Bézier
+  corners + records `/Border` and keeps the same appearance object number;
+  dialing back to 0 re-squares and drops `/Border`; a radius-only call on a
+  circle is a no-op.
+- `editing_shape_styles_test.dart`: `restyleSelected(cornerRadius:)` rounds
+  and re-squares a selected rectangle (selection survives, control
+  reflects it); the controls are off / no-op for a selected ellipse.
+- `editing_test.dart`: a widget test opens the selection-strip tune popup
+  on a selected rectangle and drags the `pdf-corner-radius` slider,
+  asserting the annotation (not just the creation default) rounds.

--- a/doc/dev-log/2026-07-16-rectangle-corner-radius.md
+++ b/doc/dev-log/2026-07-16-rectangle-corner-radius.md
@@ -1,0 +1,41 @@
+# Rounded corners for rectangle shapes
+
+Rectangle (/Square) annotations can now be drawn with rounded corners.
+
+## Core (`pdf_document`)
+
+- `PdfEditor.addSquare` gains a `cornerRadius` parameter (page points, 0 =
+  square). Threaded through the private `_addShape` into `_shapeContent`,
+  which now emits `ContentWriter.roundedRect` instead of a single `re` when
+  the radius is positive. The radius is pulled in by the stroke half-width
+  along with the rest of the box so the rounded outer edge stays inside
+  `/Rect`; `roundedRect` clamps it to half the smaller side. `Circle` and
+  every other subtype ignore the radius.
+- The radius is recorded in the annotation's `/Border` array
+  (`[hCornerRadius vCornerRadius width]`, §12.5.4). `/BS` still governs the
+  actual border render (and hides `/Border` from conforming viewers), but
+  the baked `/AP` appearance is authoritative so the rounding shows in every
+  viewer regardless. We read the radius back from `/Border` in the resize
+  path so a rounded rectangle keeps its corners when resized
+  (`_regenerateResizedAppearance`, `Square` case).
+- New `PdfAnnotation.cornerRadius` getter parses `/Border[0]`. The
+  interpreter already reads `/Border[2]` as the synthesized-border width, so
+  writing the width there stays consistent (that fallback only fires for
+  annotations with no `/AP`, which ours always have).
+
+## Editor UI (`dart_pdf_editor`)
+
+- `PdfEditingPreferences.cornerRadius` — a persisted, style-scoped double
+  mirroring `strokeWidth` (load, restore, snapshot, `_recordScoped`). Added
+  to the rectangle tool's style scope (`_styleScopeFields`), which was split
+  out of the shared rectangle/ellipse/polygon case so only the rectangle
+  remembers a radius.
+- `PdfEditingController.cornerRadius` getter/setter; `addRectangle` passes
+  `preferences.cornerRadius` to `addSquare`.
+- `_StyleFields.cornerRadius` gates a new "Corner radius" slider (0–40 pt) in
+  the tune popup, shown only for the rectangle tool (`_groupStyleFields`
+  `shapes` case). The `editing_test` style-menu test now expects three shape
+  sliders (stroke, corner radius, opacity).
+
+Not done: restyling the corner radius of an already-selected rectangle (the
+slider only sets the creation default); ellipse/polygon rounding.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4336,12 +4336,14 @@ class PdfEditingController extends ChangeNotifier {
     double? strokeWidth,
     double? opacity,
     PdfLineStyle? lineStyle,
+    double? cornerRadius,
   }) {
     if (color == null &&
         fill == null &&
         strokeWidth == null &&
         opacity == null &&
-        lineStyle == null) {
+        lineStyle == null &&
+        cornerRadius == null) {
       return false;
     }
     if (!canRestyleSelected) return false;
@@ -4364,11 +4366,30 @@ class PdfEditingController extends ChangeNotifier {
             opacity: opacity,
             dashPattern:
                 lineStyle == null ? null : (lineStyle.dashArray(width),),
+            // rounding only lands on /Square rectangles; other subtypes
+            // ignore it, so a mixed selection is safe to pass through
+            cornerRadius: cornerRadius,
             pageRotation: _page(page).rotation,
           );
         }
       },
     );
+  }
+
+  /// Whether [restyleSelected]'s `cornerRadius` applies - every selected
+  /// annotation is a restylable /Square rectangle (the only subtype that
+  /// rounds its corners). Gates the selection corner-radius control.
+  bool get canRoundSelectedCorners =>
+      canRestyleSelected &&
+      _selected.every((slot) => _annotationAt(slot)?.subtype == 'Square');
+
+  /// The primary selected rectangle's current corner radius (page points),
+  /// or null when the selection isn't a roundable /Square - for the corner
+  /// radius control to display.
+  double? get selectedCornerRadius {
+    final annotation = selectedAnnotation;
+    if (annotation == null || annotation.subtype != 'Square') return null;
+    return annotation.cornerRadius;
   }
 
   // ---------------------------------------------------------------------

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1022,7 +1022,14 @@ class PdfEditingController extends ChangeNotifier {
             'opacity'
           },
         PdfEditTool.eraser => const {'eraserRadius'},
-        PdfEditTool.rectangle ||
+        PdfEditTool.rectangle => const {
+            'color',
+            'strokeWidth',
+            'opacity',
+            'lineStyle',
+            'shapeFillColor',
+            'cornerRadius',
+          },
         PdfEditTool.ellipse ||
         PdfEditTool.polygon ||
         PdfEditTool.cloudPolygon =>
@@ -1113,6 +1120,12 @@ class PdfEditingController extends ChangeNotifier {
   double get strokeWidth => preferences.strokeWidth;
 
   set strokeWidth(double value) => preferences.strokeWidth = value;
+
+  /// Corner radius for new rectangle shapes, in PDF points; 0 gives square
+  /// corners. Persisted (remembered per the rectangle tool's style scope).
+  double get cornerRadius => preferences.cornerRadius;
+
+  set cornerRadius(double value) => preferences.cornerRadius = value;
 
   /// The circle eraser's radius, in PDF points - the eraser removes
   /// every part of an ink stroke within this distance of its swept
@@ -1741,6 +1754,7 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.shapeFillColor),
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
+          cornerRadius: preferences.cornerRadius,
           author: author,
         ),
       );

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -51,6 +51,7 @@ class PdfEditingPreferences extends ChangeNotifier {
 
   Color _color = const Color(0xFFE53935);
   double _strokeWidth = 2;
+  double _cornerRadius = 0;
   double _eraserRadius = 8;
   double _fontSize = 14;
   PdfStandardFont _fontFamily = PdfStandardFont.helvetica;
@@ -134,6 +135,8 @@ class PdfEditingPreferences extends ChangeNotifier {
       final color = store.getInt('${_prefix}color');
       if (color != null) _color = Color(color);
       _strokeWidth = store.getDouble('${_prefix}strokeWidth') ?? _strokeWidth;
+      _cornerRadius =
+          store.getDouble('${_prefix}cornerRadius') ?? _cornerRadius;
       _eraserRadius =
           store.getDouble('${_prefix}eraserRadius') ?? _eraserRadius;
       _fontSize = store.getDouble('${_prefix}fontSize') ?? _fontSize;
@@ -412,6 +415,7 @@ class PdfEditingPreferences extends ChangeNotifier {
         if (slot['color'] case final int v) color = Color(v);
       }
       if (slot['strokeWidth'] case final num v) strokeWidth = v.toDouble();
+      if (slot['cornerRadius'] case final num v) cornerRadius = v.toDouble();
       if (slot['eraserRadius'] case final num v) eraserRadius = v.toDouble();
       if (slot['opacity'] case final num v) opacity = v.toDouble();
       if (slot['fontSize'] case final num v) fontSize = v.toDouble();
@@ -474,6 +478,7 @@ class PdfEditingPreferences extends ChangeNotifier {
 
     put('color', _color.toARGB32());
     put('strokeWidth', _strokeWidth);
+    put('cornerRadius', _cornerRadius);
     put('eraserRadius', _eraserRadius);
     put('opacity', _opacity);
     put('fontSize', _fontSize);
@@ -519,6 +524,18 @@ class PdfEditingPreferences extends ChangeNotifier {
     _strokeWidth = value;
     _write((s) => s.setDouble('${_prefix}strokeWidth', value));
     _recordScoped('strokeWidth', value);
+    notifyListeners();
+  }
+
+  /// Corner radius for new rectangle shapes, in PDF points; 0 (the default)
+  /// gives square corners.
+  double get cornerRadius => _cornerRadius;
+
+  set cornerRadius(double value) {
+    if (value == _cornerRadius) return;
+    _cornerRadius = value;
+    _write((s) => s.setDouble('${_prefix}cornerRadius', value));
+    _recordScoped('cornerRadius', value);
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -2043,6 +2043,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         return _StyleFields(
             stroke: canStroke && behavior.supportsStrokeWidth,
             opacity: behavior.supportsOpacity,
+            // only a rectangle rounds its corners
+            cornerRadius: controller.canRoundSelectedCorners,
             // a /Polygon area measurement carries a caption font
             font: controller.canRestyleMeasurementCaption,
             lineType: controller.canSetLineStyleSelected,
@@ -3248,6 +3250,7 @@ class _StyleMenuState extends State<_StyleMenu> {
   /// Same, for the stroke-width and opacity sliders restyling a
   /// selected annotation.
   double? _draggingStroke;
+  double? _draggingCornerRadius;
   double? _draggingOpacity;
   double? _draggingLineSpacing;
   double? _draggingCharSpacing;
@@ -3520,13 +3523,31 @@ class _StyleMenuState extends State<_StyleMenu> {
                     _slider(
                       key: const ValueKey('pdf-corner-radius'),
                       label: 'Corner radius',
-                      value: controller.cornerRadius,
+                      // a selected rectangle shows its own radius; otherwise
+                      // the creation default while the rectangle tool is armed
+                      value: _draggingCornerRadius ??
+                          (restylingAnnotation
+                              ? controller.selectedCornerRadius
+                              : null) ??
+                          controller.cornerRadius,
                       min: 0,
                       max: 40,
                       display: (v) => '${v.round()} pt',
                       parse: _parsePoints,
-                      onChanged: (v) =>
-                          controller.cornerRadius = v.roundToDouble(),
+                      onChanged: (v) {
+                        setState(() => _draggingCornerRadius = v);
+                        if (!restylingAnnotation) {
+                          controller.cornerRadius = v.roundToDouble();
+                        }
+                      },
+                      onChangeEnd: (v) {
+                        controller.cornerRadius = v.roundToDouble();
+                        if (restylingAnnotation) {
+                          controller.restyleSelected(
+                              cornerRadius: v.roundToDouble());
+                        }
+                        setState(() => _draggingCornerRadius = null);
+                      },
                     ),
                   if (fields.opacity)
                     _slider(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1998,6 +1998,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
               tool == PdfEditTool.ellipse ||
               tool == PdfEditTool.polygon ||
               tool == PdfEditTool.cloudPolygon,
+          cornerRadius: tool == PdfEditTool.rectangle,
         );
       case 'insert':
         return const _StyleFields(opacity: true, font: true, boxColors: true);
@@ -3151,12 +3152,16 @@ class _StyleFields {
     this.font = false,
     this.boxColors = false,
     this.shapeFill = false,
+    this.cornerRadius = false,
     this.eraser = false,
     this.formField = false,
   });
 
   final bool stroke;
   final bool opacity;
+
+  /// The rectangle corner-radius slider (rectangle shape only).
+  final bool cornerRadius;
 
   /// The line-type dropdown (solid / dashed / dotted / dash-dot) - shapes
   /// and the line family.
@@ -3187,6 +3192,7 @@ class _StyleFields {
       !font &&
       !boxColors &&
       !shapeFill &&
+      !cornerRadius &&
       !eraser &&
       !formField;
 }
@@ -3509,6 +3515,18 @@ class _StyleMenuState extends State<_StyleMenu> {
                         }
                         setState(() => _draggingStroke = null);
                       },
+                    ),
+                  if (fields.cornerRadius)
+                    _slider(
+                      key: const ValueKey('pdf-corner-radius'),
+                      label: 'Corner radius',
+                      value: controller.cornerRadius,
+                      min: 0,
+                      max: 40,
+                      display: (v) => '${v.round()} pt',
+                      parse: _parsePoints,
+                      onChanged: (v) =>
+                          controller.cornerRadius = v.roundToDouble(),
                     ),
                   if (fields.opacity)
                     _slider(

--- a/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
@@ -53,6 +53,24 @@ void main() {
     });
   });
 
+  group('rectangle corner radius on the controller', () {
+    test('the corner radius preference rounds new rectangles', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..cornerRadius = 10;
+      addTearDown(editing.dispose);
+      editing.addRectangle(0, const PdfRect(100, 100, 300, 200));
+      expect(
+          editing.document.page(0).annotations.single.cornerRadius, 10);
+    });
+
+    test('a zero radius leaves the rectangle square', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.addRectangle(0, const PdfRect(100, 100, 300, 200));
+      expect(editing.document.page(0).annotations.single.cornerRadius, 0);
+    });
+  });
+
   group('polygon fill', () {
     test('a polygon drawn with a shape fill colour stores /IC', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))

--- a/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
@@ -69,6 +69,37 @@ void main() {
       editing.addRectangle(0, const PdfRect(100, 100, 300, 200));
       expect(editing.document.page(0).annotations.single.cornerRadius, 0);
     });
+
+    test('restyleSelected rounds and re-squares a selected rectangle', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing
+        ..addRectangle(0, const PdfRect(100, 100, 300, 200))
+        ..selectAnnotation(0, 0);
+      expect(editing.canRoundSelectedCorners, isTrue);
+      expect(editing.selectedCornerRadius, 0);
+
+      expect(editing.restyleSelected(cornerRadius: 12), isTrue);
+      expect(editing.document.page(0).annotations.single.cornerRadius, 12);
+      // the selection survives, so the control reflects the new radius
+      expect(editing.selectedCornerRadius, 12);
+
+      expect(editing.restyleSelected(cornerRadius: 0), isTrue);
+      expect(editing.document.page(0).annotations.single.cornerRadius, 0);
+      expect(editing.selectedCornerRadius, 0);
+    });
+
+    test('corner radius controls are off for non-rectangle selections', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing
+        ..addEllipse(0, const PdfRect(100, 100, 300, 200))
+        ..selectAnnotation(0, 0);
+      expect(editing.canRoundSelectedCorners, isFalse);
+      expect(editing.selectedCornerRadius, isNull);
+      // a circle has no corners, so the radius restyle is a no-op
+      expect(editing.restyleSelected(cornerRadius: 12), isFalse);
+    });
   });
 
   group('polygon fill', () {

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -1318,6 +1318,43 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets('the style menu rounds a selected rectangle in place',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      editing
+        ..addRectangle(0, const PdfRect(100, 100, 300, 200))
+        ..selectAnnotation(0, 0);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+          ),
+        ),
+      ));
+
+      // the selection strip carries the tune button for the selected shape
+      await tester.tap(find.byTooltip('Stroke, opacity, font'));
+      await tester.pumpAndSettle();
+
+      final radius = find.byKey(const ValueKey('pdf-corner-radius'));
+      expect(radius, findsOneWidget);
+      await tester.drag(
+          find.descendant(of: radius, matching: find.byType(Slider)),
+          const Offset(200, 0));
+      await tester.pump();
+
+      // dragging restyled the selection, not just the creation default
+      expect(editing.document.page(0).annotations.single.cornerRadius,
+          greaterThan(0));
+      expect(editing.selectedCornerRadius, greaterThan(0));
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('the thumbnail sidebar jumps, reorders, and deletes pages',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(3));

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -1298,16 +1298,21 @@ void main() {
       // scope to the popup's sliders - the strip also has an inline opacity
       final menuSliders = find.descendant(
           of: find.byType(MenuAnchor), matching: find.byType(Slider));
-      // the shapes popup carries stroke width + opacity (font is irrelevant
-      // to a rectangle, so it's no longer shown)
-      expect(menuSliders, findsNWidgets(2));
+      // the shapes popup carries stroke width + corner radius + opacity
+      // (font is irrelevant to a rectangle, so it's not shown; corner radius
+      // is rectangle-only)
+      expect(menuSliders, findsNWidgets(3));
 
-      // sliders are laid out stroke width, opacity
+      // sliders are laid out stroke width, corner radius, opacity
       await tester.drag(menuSliders.at(0), const Offset(200, 0));
       await tester.pump();
       expect(editing.strokeWidth, greaterThan(2));
 
-      await tester.drag(menuSliders.at(1), const Offset(-200, 0));
+      await tester.drag(menuSliders.at(1), const Offset(200, 0));
+      await tester.pump();
+      expect(editing.cornerRadius, greaterThan(0));
+
+      await tester.drag(menuSliders.at(2), const Offset(-200, 0));
       await tester.pump();
       expect(editing.opacity, lessThan(1));
       await tester.pumpAndSettle();

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -270,6 +270,17 @@ class PdfAnnotation {
     return values.any((value) => value > 0) ? values : null;
   }
 
+  /// The corner radius (page points) of a /Square annotation's rounded
+  /// rectangle, from the /Border array's first entry (§12.5.4
+  /// `[hCornerRadius vCornerRadius width]`); 0 for square corners or when
+  /// /Border is absent or malformed.
+  double get cornerRadius {
+    final border = document.cos.resolve(dict['Border']);
+    if (border is! CosArray || border.length < 3) return 0;
+    final r = _number(document.cos.resolve(border[0]));
+    return r != null && r > 0 ? r : 0;
+  }
+
   /// Whether the annotation asks conforming viewers to render its border as
   /// a cloudy border effect (`/BE << /S /Cloudy ... >>`).
   bool get hasCloudyBorder {

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -950,7 +950,9 @@ extension PdfAnnotationEditing on PdfEditor {
   }
 
   /// Adds a rectangle annotation. At least one of [strokeColor] and
-  /// [fillColor] must be given.
+  /// [fillColor] must be given. [cornerRadius] (page points, 0 for a plain
+  /// rectangle) rounds the corners - it is baked into the appearance and
+  /// recorded in the annotation's /Border array so it survives a resize.
   void addSquare(
     int pageIndex,
     PdfRect rect, {
@@ -959,6 +961,7 @@ extension PdfAnnotationEditing on PdfEditor {
     int? fillColor,
     double opacity = 1,
     List<double>? dashPattern,
+    double cornerRadius = 0,
     String? contents,
     String? author,
     String? name,
@@ -975,6 +978,7 @@ extension PdfAnnotationEditing on PdfEditor {
         author,
         name,
         dashPattern,
+        cornerRadius: cornerRadius,
       );
 
   /// Adds an ellipse annotation inscribed in [rect]. At least one of
@@ -4224,6 +4228,7 @@ extension PdfAnnotationEditing on PdfEditor {
           width,
           fill,
           dashPattern: annotation.borderDash,
+          cornerRadius: annotation.cornerRadius,
           hasAlpha: gs != null,
         );
         _replaceAppearance(
@@ -5090,13 +5095,15 @@ extension PdfAnnotationEditing on PdfEditor {
     String? contents,
     String? author,
     String? name,
-    List<double>? dashPattern,
-  ) {
+    List<double>? dashPattern, {
+    double cornerRadius = 0,
+  }) {
     if (strokeColor == null && fillColor == null) {
       throw ArgumentError('strokeColor and fillColor are both null');
     }
     final stroking = strokeColor != null && strokeWidth > 0;
     final dash = stroking ? dashPattern : null;
+    final radius = subtype == 'Square' ? math.max(0.0, cornerRadius) : 0.0;
     final gs = _alphaState(opacity);
     final w = _shapeContent(
       subtype,
@@ -5105,6 +5112,7 @@ extension PdfAnnotationEditing on PdfEditor {
       strokeWidth,
       fillColor,
       dashPattern: dash,
+      cornerRadius: radius,
       hasAlpha: gs != null,
     );
 
@@ -5115,6 +5123,16 @@ extension PdfAnnotationEditing on PdfEditor {
       contents,
       author,
     )..['BS'] = _borderStyle(stroking ? strokeWidth : 0, dashPattern: dash);
+    if (radius > 0) {
+      // §12.5.4 /Border = [hCornerRadius vCornerRadius width]. /BS above
+      // governs the actual border render (and hides /Border from conforming
+      // viewers), but our own resize path reads the radius back from here.
+      dict['Border'] = CosArray([
+        CosReal(radius),
+        CosReal(radius),
+        CosReal(stroking ? strokeWidth : 0),
+      ]);
+    }
     if (fillColor != null) {
       dict['IC'] = CosArray([
         for (final c in ContentWriter.rgbComponents(fillColor)) CosReal(c),
@@ -5137,6 +5155,7 @@ extension PdfAnnotationEditing on PdfEditor {
     double strokeWidth,
     int? fillColor, {
     List<double>? dashPattern,
+    double cornerRadius = 0,
     required bool hasAlpha,
   }) {
     final stroking = strokeColor != null && strokeWidth > 0;
@@ -5151,12 +5170,18 @@ extension PdfAnnotationEditing on PdfEditor {
       if (dashPattern != null && dashPattern.isNotEmpty) w.dash(dashPattern);
     }
     if (subtype == 'Square') {
-      w.rect(
-        rect.left + inset,
-        rect.bottom + inset,
-        rect.width - 2 * inset,
-        rect.height - 2 * inset,
-      );
+      final x = rect.left + inset;
+      final y = rect.bottom + inset;
+      final width = rect.width - 2 * inset;
+      final height = rect.height - 2 * inset;
+      if (cornerRadius > 0) {
+        // Pull the radius in with the stroke so the rounded outer edge stays
+        // inside /Rect; roundedRect clamps it to half the smaller side.
+        w.roundedRect(x, y, width, height,
+            math.max(0.0, cornerRadius - inset));
+      } else {
+        w.rect(x, y, width, height);
+      }
     } else {
       w.ellipse(
         (rect.left + rect.right) / 2,

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -4492,6 +4492,10 @@ extension PdfAnnotationEditing on PdfEditor {
   ///   through the text-style path).
   /// * [opacity] - shapes, ink, markups, stamps. Free text and notes
   ///   stay opaque, as authored.
+  /// * [cornerRadius] - the rounded-corner radius (page points) of a
+  ///   /Square rectangle, rewritten into /Border and baked into the
+  ///   appearance; `0` restores square corners. Ignored by every other
+  ///   subtype (Circle and the rest have no corners to round).
   ///
   /// Rotation survives: a rotated appearance regenerates in its local
   /// frame and re-rotates, exactly like [resizeAnnotationLocal].
@@ -4505,6 +4509,7 @@ extension PdfAnnotationEditing on PdfEditor {
     double? strokeWidth,
     double? opacity,
     (List<double>?,)? dashPattern,
+    double? cornerRadius,
     int? pageRotation,
   }) {
     final effectivePageRotation = _appearancePageRotation(
@@ -4515,7 +4520,8 @@ extension PdfAnnotationEditing on PdfEditor {
         fillColor == null &&
         strokeWidth == null &&
         opacity == null &&
-        dashPattern == null) {
+        dashPattern == null &&
+        cornerRadius == null) {
       return false;
     }
     final behavior = annotation.behavior;
@@ -4586,6 +4592,17 @@ extension PdfAnnotationEditing on PdfEditor {
         _markAnnotationChanged(pageIndex, dict);
         return true;
       case 'Square' || 'Circle':
+        // cornerRadius is the only rectangle-specific knob; a circle has no
+        // corners, so a radius-only call there changes nothing (don't stage a
+        // pointless regeneration)
+        if (annotation.subtype == 'Circle' &&
+            color == null &&
+            fillColor == null &&
+            strokeWidth == null &&
+            opacity == null &&
+            dashPattern == null) {
+          return false;
+        }
         final width = strokeWidth ?? currentStyle.strokeWidth ?? 1;
         final stroke = color ?? currentStyle.color;
         final fill = fillColor != null ? fillColor.$1 : currentStyle.fillColor;
@@ -4593,11 +4610,27 @@ extension PdfAnnotationEditing on PdfEditor {
         if (stroke != null) dict['C'] = _colorComponents(stroke);
         final dash =
             dashPattern != null ? dashPattern.$1 : annotation.borderDash;
+        final stroking = stroke != null && width > 0;
         dict['BS'] = _borderStyle(width, dashPattern: dash);
         if (fill != null) {
           dict['IC'] = _colorComponents(fill);
         } else {
           dict.entries.remove('IC');
+        }
+        // Rounding only applies to rectangles; the regeneration below reads
+        // the radius back from /Border (§12.5.4 [hCornerRadius vCornerRadius
+        // width]) so writing it here rebakes the rounded /AP.
+        if (cornerRadius != null && annotation.subtype == 'Square') {
+          final radius = math.max(0.0, cornerRadius);
+          if (radius > 0) {
+            dict['Border'] = CosArray([
+              CosReal(radius),
+              CosReal(radius),
+              CosReal(stroking ? width : 0),
+            ]);
+          } else {
+            dict.entries.remove('Border');
+          }
         }
         return _restyleRegenerate(pageIndex, dict, opacity: opacity);
       case 'Line' || 'PolyLine' || 'Polygon':

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -226,6 +226,60 @@ void main() {
     expect(circle, contains('S'));
   });
 
+  test('rounded rectangle curves its corners and records /Border', () {
+    final doc = roundTrip((e) => e.addSquare(
+          0,
+          const PdfRect(100, 100, 300, 200),
+          strokeWidth: 2,
+          cornerRadius: 12,
+        ));
+    final square = doc.page(0).annotations.single;
+    expect(square.subtype, 'Square');
+    expect(square.cornerRadius, 12);
+
+    final content = appearanceText(doc, square);
+    // roundedRect draws corners as Bézier curves rather than a single `re`.
+    expect(content, contains('c'));
+    expect(content, isNot(contains(' re')));
+
+    // §12.5.4 /Border = [hCornerRadius vCornerRadius width].
+    final border = doc.cos.resolve(square.dict['Border']) as CosArray;
+    expect(border.length, 3);
+    expect((doc.cos.resolve(border[0]) as CosReal).value, 12);
+    expect((doc.cos.resolve(border[1]) as CosReal).value, 12);
+  });
+
+  test('a plain rectangle keeps square corners and no /Border radius', () {
+    final doc = roundTrip((e) => e.addSquare(
+          0,
+          const PdfRect(100, 100, 300, 200),
+          strokeWidth: 2,
+        ));
+    final square = doc.page(0).annotations.single;
+    expect(square.cornerRadius, 0);
+    expect(appearanceText(doc, square), contains(' re'));
+  });
+
+  test('resizing a rounded rectangle keeps its corner radius', () {
+    final editor = PdfEditor(PdfDocument.open(buildClassicPdf()));
+    editor.addSquare(
+      0,
+      const PdfRect(100, 100, 300, 200),
+      strokeWidth: 2,
+      cornerRadius: 12,
+    );
+    final doc = PdfDocument.open(editor.save());
+    final editor2 = PdfEditor(doc);
+    final square = doc.page(0).annotations.single;
+    editor2.resizeAnnotation(0, square, const PdfRect(100, 100, 500, 400));
+    final resized = PdfDocument.open(editor2.save());
+    final annot = resized.page(0).annotations.single;
+    expect(annot.cornerRadius, 12);
+    final content = appearanceText(resized, annot);
+    expect(content, contains('c'));
+    expect(content, isNot(contains(' re')));
+  });
+
   test('free text wraps to the rect and records /DA', () {
     final doc = roundTrip((e) => e.addFreeText(
           0,

--- a/packages/pdf_document/test/annotation_restyle_test.dart
+++ b/packages/pdf_document/test/annotation_restyle_test.dart
@@ -245,4 +245,57 @@ void main() {
         }));
     expect(pdfCanRestyleAnnotation(link), isFalse);
   });
+
+  test('square: corner radius restyles in place, rebaking rounded corners',
+      () {
+    final doc = edited(
+        PdfDocument.open(buildMultiPagePdf(1)),
+        (e) => e.addSquare(0, const PdfRect(100, 600, 200, 660),
+            strokeColor: 0xE53935, strokeWidth: 2));
+    final before = doc.page(0).annotations.single;
+    expect(before.cornerRadius, 0);
+    expect(content(doc, before), contains(' re'));
+    final formRef = doc.cos.referenceTo(before.normalAppearance!)!;
+
+    // round the corners of the already-placed rectangle
+    final out = edited(
+        doc, (e) => e.restyleAnnotation(0, before, cornerRadius: 10));
+    final after = out.page(0).annotations.single;
+    expect(after.cornerRadius, 10);
+    // §12.5.4 /Border = [hCornerRadius vCornerRadius width]; width mirrors /BS
+    final border = out.cos.resolve(after.dict['Border']) as CosArray;
+    expect(border.length, 3);
+    expect((out.cos.resolve(border[0]) as CosReal).value, 10);
+    expect((out.cos.resolve(border[1]) as CosReal).value, 10);
+    expect((out.cos.resolve(border[2]) as CosReal).value, 2);
+    // the appearance now curves its corners rather than a single `re`
+    final stream = content(out, after);
+    expect(stream, contains('c'));
+    expect(stream, isNot(contains(' re')));
+    // identity and geometry survive; the appearance was replaced, not re-added
+    expect(after.rect, const PdfRect(100, 600, 200, 660));
+    expect(out.cos.referenceTo(after.normalAppearance!)!.objectNumber,
+        formRef.objectNumber);
+
+    // dialing it back to 0 restores square corners and drops /Border
+    final squared = edited(
+        out, (e) => e.restyleAnnotation(0, after, cornerRadius: 0));
+    final plain = squared.page(0).annotations.single;
+    expect(plain.cornerRadius, 0);
+    expect(plain.dict['Border'], isNull);
+    expect(content(squared, plain), contains(' re'));
+  });
+
+  test('corner radius is a no-op on circles (nothing to round)', () {
+    final doc = edited(
+        PdfDocument.open(buildMultiPagePdf(1)),
+        (e) => e.addCircle(0, const PdfRect(100, 600, 200, 660),
+            strokeColor: 0xE53935, strokeWidth: 2));
+    final circle = doc.page(0).annotations.single;
+    final editor = PdfEditor(doc);
+    // only /Square rounds; a lone cornerRadius on a circle changes nothing
+    expect(editor.restyleAnnotation(0, circle, cornerRadius: 10), isFalse);
+    expect(editor.hasChanges, isFalse);
+    expect(circle.dict['Border'], isNull);
+  });
 }


### PR DESCRIPTION
## Summary

Rectangle (`/Square`) annotations can now be drawn **and restyled** with rounded corners.

- `PdfEditor.addSquare` gains a `cornerRadius` parameter (page points, `0` =
  square corners). It's baked into the `/AP` appearance via
  `ContentWriter.roundedRect` (already present) instead of a single `re`, and
  the radius is pulled in with the stroke half-width so the rounded outer edge
  stays inside `/Rect`. `Circle` and other subtypes ignore it.
- The radius is persisted in the annotation's `/Border` array
  (`[hCornerRadius vCornerRadius width]`, §12.5.4) and read back on resize, so
  a rounded rectangle keeps its corners when resized. A new
  `PdfAnnotation.cornerRadius` getter exposes it.
- `PdfEditor.restyleAnnotation` gains a `cornerRadius` parameter: it rewrites
  `/Border` and lets the existing regeneration path rebake the rounded `/AP`,
  so an **already-placed rectangle** can be rounded or re-squared in place
  (same object numbers, selection/identity preserved). A radius-only call on a
  `/Circle` is a no-op.
- Editor UI: a persisted, style-scoped `cornerRadius` preference (mirroring
  `strokeWidth`), a `PdfEditingController.cornerRadius` getter/setter wired
  into `addRectangle`, and a rectangle-only **Corner radius** slider (0–40 pt)
  in the tune popup. The slider is restyle-aware — with a rectangle selected it
  edits the selection in place (`restyleSelected(cornerRadius:)`), gated by
  `canRoundSelectedCorners`/`selectedCornerRadius`; otherwise it sets the
  creation default.

The baked appearance is authoritative, so the rounding renders in every
viewer regardless of how `/BS` vs `/Border` are interpreted.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (clean at workspace root)
- [x] `cd packages/pdf_document && fvm dart test` (643 pass — annotation_editor + annotation_restyle corner-radius cases)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (1453 pass — editing_shape_styles, editing_test style-menu, and the rest)

Did not run the corpus/Ghent sweeps or example-app smoke test: this change
adds a new opt-in authoring/restyle parameter and UI control with a zero
default, so existing rendering baselines are unaffected.

## PDF fixtures and screenshots

New coverage uses the existing programmatic `buildClassicPdf`/`buildMultiPagePdf`
fixtures — no binary PDFs added. Tests assert the appearance draws Bézier
corners (no `re`), the `/Border` radius round-trips, the radius survives a
resize, and an in-place restyle rounds then re-squares a placed rectangle.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The radius is stored in `/Border` while `/BS` still drives the border render;
per §12.5.4 conforming viewers ignore `/Border` when `/BS` is present, but the
baked appearance makes that moot. Out of scope: rounding ellipses/polygons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UD4Ya2o17u2HN4Rg83jhr

---
_Generated by [Claude Code](https://claude.ai/code/session_011UD4Ya2o17u2HN4Rg83jhr)_