### PR TITLE
Add visible signature box for signing and PAdES

### DIFF
--- a/doc/dev-log/2026-07-16-signature-appearance-box.md
+++ b/doc/dev-log/2026-07-16-signature-appearance-box.md
@@ -1,0 +1,70 @@
+# Visible signature box for signing / PAdES
+
+Signatures were always invisible: `_attachSignatureField` created a widget
+with `/Rect [0 0 0 0]` and no `/AP`, so Acrobat/Bluebeam showed nothing
+where the signature was. Added an Acrobat/Bluebeam-style **visible
+signature box** the signer can place and that fills an existing field's
+rectangle.
+
+## API
+
+`PdfSignatureAppearance` (in `signature_editor.dart`, exported via
+`editor.dart`) describes the box:
+
+- `page` + `rect` — where to put a box on a **freshly created** field.
+- `graphic` — an optional `PdfEmbeddableImage` (handwritten signature /
+  logo) drawn in the left panel instead of the large name.
+- `showName` / `showDate` / `showReason` / `showLocation` — which detail
+  lines appear on the right.
+- `backgroundColor` / `borderColor` / `textColor`.
+
+Threaded as an optional `appearance:` argument through both
+`PdfSigning.saveSigned` and `PdfPadesSigning.saveSignedPades` →
+`_emitSignatureRevision` → `_attachSignatureField`.
+
+## Behavior
+
+- **Existing field with a visible `/Rect`** (a producer-placed signature
+  field): the box is drawn into it even without an explicit
+  `appearance` — defaults are used. This is the "sign the field the author
+  placed" case, matching Acrobat/Bluebeam.
+- **New field**: invisible `[0 0 0 0]` as before unless
+  `appearance.rect` is given, then the widget is placed at that rect on
+  `appearance.page` and rendered.
+- **DocTimeStamp** (`docTimeStamp: true`): never gets an appearance
+  (`_emitSignatureRevision` passes `appearance: null` on that path).
+
+Backward compatible: with no `appearance` and no visible field, output is
+byte-identical to before (the `[0 0 0 0]`, no-`/AP` widget).
+
+## Rendering
+
+`_installSignatureAppearance` builds a `/AP /N` form XObject (reusing
+form_editor's `_widgetForm` / `_setNormalAppearance` — cross-extension
+private calls resolve fine since everything is `part of editor.dart`):
+
+- optional background fill, a 1pt border, a 0.5pt column divider at 42%
+  width (only when both panels carry content);
+- left panel: the signer name in Helvetica-Bold auto-sized down from 22pt
+  and vertically centered, or the `graphic` image scaled to fit;
+- right panel: `Digitally signed by <name>` / `Date: …` / `Reason: …` /
+  `Location: …`, Helvetica auto-sized from 9pt, top-anchored, word-wrapped
+  and clipped to the panel.
+
+`_drawSignatureText` does the fit-shrink-wrap-clip; fonts are inline
+base-14 Type1 dicts with `/Widths` (`_signatureFont`) so other viewers
+space text the same way. Date is Acrobat-style `2026.07.16 09:30:00
++00'00'` (signing time is normalized to UTC first). Text past Latin-1
+degrades to spaces via `ContentWriter.showText`, same limitation as the
+other appearance generators.
+
+`tool/emit_signature_box.dart` emits a sample signed PDF for eyeballing in
+a real viewer.
+
+## Tests
+
+`signature_test.dart` — placed box (rect, BBox, shown text), placement on
+a later page, filling an existing visible field, `show*` toggles, and the
+unchanged invisible default. `pades_test.dart` — a B-LTA signature with a
+box stays valid + LTV. Shown-text assertions join `(...) Tj` operands with
+spaces so word-wrapping reads back as the original strings.

--- a/packages/pdf_document/lib/src/pades_editor.dart
+++ b/packages/pdf_document/lib/src/pades_editor.dart
@@ -22,7 +22,9 @@ extension PdfPadesSigning on PdfEditor {
   /// author signature with a /DocMDP transform at [docMdpPermissions]
   /// (1 = no changes, 2 = form-fill + signing, 3 = + annotations).
   ///
-  /// After this call the editor is spent.
+  /// Pass an [appearance] to draw a visible signature box (the Acrobat/
+  /// Bluebeam two-column layout); the same rules as [PdfSigning.saveSigned]
+  /// apply. After this call the editor is spent.
   Future<Uint8List> saveSignedPades({
     required RsaPrivateKey privateKey,
     required List<Uint8List> certificates,
@@ -37,6 +39,7 @@ extension PdfPadesSigning on PdfEditor {
     DateTime? signingTime,
     bool certify = false,
     int docMdpPermissions = 2,
+    PdfSignatureAppearance? appearance,
   }) async {
     if (certificates.isEmpty) {
       throw ArgumentError('the signer certificate is required');
@@ -61,6 +64,7 @@ extension PdfPadesSigning on PdfEditor {
       contactInfo: contactInfo,
       defaultSignerCert: certificates.first,
       docMdpPermissions: certify ? docMdpPermissions : null,
+      appearance: appearance,
     );
     final signedAttrs = cmsSignedAttributes(
       contentDigest: crypto.sha256.convert(revision.signedData).bytes,

--- a/packages/pdf_document/lib/src/signature_editor.dart
+++ b/packages/pdf_document/lib/src/signature_editor.dart
@@ -1,5 +1,77 @@
 part of 'editor.dart';
 
+/// The visible signature box drawn into a signature field's widget when
+/// signing - the two-column layout Acrobat and Bluebeam render once a
+/// field is signed: the signer's name (or a handwritten-signature image)
+/// set large in the left panel, and the signing details ("Digitally signed
+/// by …", date, reason, location) listed on the right.
+///
+/// Pass one to [PdfSigning.saveSigned] or [PdfPadesSigning.saveSignedPades]
+/// to place and render the box. When signing into a form field that already
+/// carries a visible /Rect, the box is drawn into that rectangle even
+/// without an explicit appearance (the defaults are used); [page] and
+/// [rect] only place a box on a freshly created field.
+class PdfSignatureAppearance {
+  const PdfSignatureAppearance({
+    this.page = 0,
+    this.rect,
+    this.graphic,
+    this.showName = true,
+    this.showDate = true,
+    this.showReason = true,
+    this.showLocation = true,
+    this.backgroundColor,
+    this.borderColor = 0x2E5E86,
+    this.textColor = 0x1A1A1A,
+  });
+
+  /// The 0-based page a newly created signature widget is placed on.
+  /// Ignored when signing into a field that already exists - that field
+  /// keeps the page its widget already sits on.
+  final int page;
+
+  /// The widget rectangle, in PDF user space, for a newly created field.
+  /// Required to put a visible box on a fresh field; ignored when signing
+  /// an existing field (which keeps its own /Rect).
+  final PdfRect? rect;
+
+  /// An optional handwritten-signature or logo image drawn in the left
+  /// panel in place of the large name text.
+  final PdfEmbeddableImage? graphic;
+
+  /// Draws the large signer name in the left panel and the
+  /// "Digitally signed by …" line on the right.
+  final bool showName;
+
+  /// Draws the signing date/time on the right.
+  final bool showDate;
+
+  /// Draws the /Reason on the right, when the signature carries one.
+  final bool showReason;
+
+  /// Draws the /Location on the right, when the signature carries one.
+  final bool showLocation;
+
+  /// Panel background fill (0xRRGGBB), or null for a transparent box.
+  final int? backgroundColor;
+
+  /// The border and column-divider color (0xRRGGBB).
+  final int borderColor;
+
+  /// The text color (0xRRGGBB).
+  final int textColor;
+}
+
+/// The signer details rendered into a visible signature box.
+class _SignatureText {
+  const _SignatureText({this.name, this.time, this.reason, this.location});
+
+  final String? name;
+  final DateTime? time;
+  final String? reason;
+  final String? location;
+}
+
 /// Signing: writes the pending edits plus a new signature as one
 /// incremental update, then fills in the byte range and CMS container.
 extension PdfSigning on PdfEditor {
@@ -11,8 +83,14 @@ extension PdfSigning on PdfEditor {
   /// subject becomes the visible signer unless [signerName] overrides it.
   /// An existing empty signature field called [fieldName] is used when
   /// present, otherwise an invisible signature field is created on the
-  /// first page. After this call the editor is spent - saving again
-  /// would invalidate the signature it just produced.
+  /// first page.
+  ///
+  /// Pass an [appearance] to draw a visible signature box (the Acrobat/
+  /// Bluebeam two-column layout). When signing into a field that already
+  /// has a visible /Rect the box is rendered into it even without an
+  /// [appearance]; [PdfSignatureAppearance.rect] places a box on a fresh
+  /// field. After this call the editor is spent - saving again would
+  /// invalidate the signature it just produced.
   Uint8List saveSigned({
     required RsaPrivateKey privateKey,
     required List<Uint8List> certificates,
@@ -22,6 +100,7 @@ extension PdfSigning on PdfEditor {
     String? location,
     String? contactInfo,
     DateTime? signingTime,
+    PdfSignatureAppearance? appearance,
   }) {
     if (certificates.isEmpty) {
       throw ArgumentError('the signer certificate is required');
@@ -37,6 +116,7 @@ extension PdfSigning on PdfEditor {
       location: location,
       contactInfo: contactInfo,
       defaultSignerCert: certificates.first,
+      appearance: appearance,
     );
     final cms = cmsSignDetached(
       contentDigest: crypto.sha256.convert(revision.signedData).bytes,
@@ -76,6 +156,7 @@ extension PdfSigning on PdfEditor {
     Uint8List? defaultSignerCert,
     bool docTimeStamp = false,
     int? docMdpPermissions,
+    PdfSignatureAppearance? appearance,
   }) {
     if (document.cos.isEncrypted) {
       // the signature /Contents and /ByteRange must stay unencrypted and
@@ -128,8 +209,18 @@ extension PdfSigning on PdfEditor {
     if (docMdpPermissions != null) {
       _applyDocMdp(sigRef);
     }
-    _attachSignatureField(sigRef, fieldName,
-        certify: docMdpPermissions != null);
+    _attachSignatureField(
+      sigRef,
+      fieldName,
+      certify: docMdpPermissions != null,
+      appearance: docTimeStamp ? null : appearance,
+      text: _SignatureText(
+        name: name,
+        time: signingTime,
+        reason: reason,
+        location: location,
+      ),
+    );
 
     final saved = _updater.save();
 
@@ -224,11 +315,19 @@ extension PdfSigning on PdfEditor {
     return -1;
   }
 
-  /// Points an existing empty signature field at [sigRef], or creates an
-  /// invisible one on the first page. [certify] marks an author signature
-  /// (the DocMDP /Perms wiring is applied separately by the caller).
-  void _attachSignatureField(CosReference sigRef, String? fieldName,
-      {bool certify = false}) {
+  /// Points an existing empty signature field at [sigRef], or creates a
+  /// field on the requested page. [certify] marks an author signature
+  /// (the DocMDP /Perms wiring is applied separately by the caller). When
+  /// the target widget has a visible /Rect a signature box is rendered
+  /// into it from [appearance] and [text]; a fresh field is invisible
+  /// unless [appearance] supplies a [PdfSignatureAppearance.rect].
+  void _attachSignatureField(
+    CosReference sigRef,
+    String? fieldName, {
+    bool certify = false,
+    PdfSignatureAppearance? appearance,
+    _SignatureText? text,
+  }) {
     final cos = document.cos;
     final form = PdfAcroForm.of(document);
 
@@ -242,32 +341,59 @@ extension PdfSigning on PdfEditor {
           throw StateError('field "$fieldName" is already signed');
         }
         existing.dict['V'] = sigRef;
+        // Fill the field's box with a signature appearance when it is
+        // visible, matching how Acrobat/Bluebeam render a signed field.
+        final widget = existing.widgets.first;
+        final rect = pdfRectFrom(cos, widget['Rect']);
+        if (rect != null && rect.width > 1 && rect.height > 1) {
+          _installSignatureAppearance(widget, rect,
+              appearance ?? const PdfSignatureAppearance(), text);
+          if (!identical(widget, existing.dict) &&
+              cos.referenceTo(widget) != null) {
+            _updater.markChanged(widget);
+          }
+        }
         _updater.markChanged(existing.dict);
         _ensureSigFlags();
         return;
       }
     }
 
-    final page = document.page(0);
+    final visible = appearance?.rect;
+    final pageIndex = visible != null
+        ? appearance!.page.clamp(0, document.pageCount - 1)
+        : 0;
+    final page = document.page(pageIndex);
     final pageRef = cos.referenceTo(page.dict);
     final name = fieldName ?? _freshFieldName(form);
+    final rect = visible == null
+        ? CosArray([
+            const CosInteger(0), const CosInteger(0), //
+            const CosInteger(0), const CosInteger(0),
+          ])
+        : CosArray([
+            CosReal(visible.left),
+            CosReal(visible.bottom),
+            CosReal(visible.right),
+            CosReal(visible.top),
+          ]);
     final fieldDict = CosDictionary({
       'FT': const CosName('Sig'),
       'T': CosString.fromText(name),
       'V': sigRef,
       'Type': const CosName('Annot'),
       'Subtype': const CosName('Widget'),
-      'Rect': CosArray([
-        const CosInteger(0), const CosInteger(0), //
-        const CosInteger(0), const CosInteger(0),
-      ]),
+      'Rect': rect,
       'F': const CosInteger(132), // print + locked
       if (pageRef != null) 'P': pageRef,
     });
+    if (visible != null) {
+      _installSignatureAppearance(fieldDict, visible, appearance!, text);
+    }
     final fieldRef = _updater.addObject(fieldDict);
 
     // page /Annots
-    _PdfPageAnnotationList(this, 0).append(fieldRef);
+    _PdfPageAnnotationList(this, pageIndex).append(fieldRef);
 
     // AcroForm /Fields
     final acroForm = cos.resolve(document.catalog['AcroForm']);
@@ -321,6 +447,233 @@ extension PdfSigning on PdfEditor {
       i++;
     }
     return 'Signature$i';
+  }
+
+  // ---------------------------------------------------------------------
+  // visible signature box (§12.7.4.5)
+
+  /// Renders the signature box into [widget]'s /AP /N: an optional
+  /// background and border, a left panel holding the signer's name (or a
+  /// handwritten-signature image), and a right panel listing the signing
+  /// details. Mirrors the two-column layout Acrobat and Bluebeam draw.
+  void _installSignatureAppearance(CosDictionary widget, PdfRect rect,
+      PdfSignatureAppearance config, _SignatureText? text) {
+    final w = rect.width, h = rect.height;
+    final info = text ?? const _SignatureText();
+    final writer = ContentWriter();
+    final fonts = CosDictionary({});
+    final xObjects = CosDictionary({});
+    const pad = 4.0;
+
+    if (config.backgroundColor != null) {
+      writer
+        ..fillColor(config.backgroundColor!)
+        ..rect(0, 0, w, h)
+        ..fill();
+    }
+    writer
+      ..strokeColor(config.borderColor)
+      ..lineWidth(1)
+      ..rect(0.5, 0.5, w - 1, h - 1)
+      ..stroke();
+
+    final name = info.name;
+    final showName = config.showName && name != null && name.isNotEmpty;
+    final hasGraphic = config.graphic != null;
+    final hasLeft = hasGraphic || showName;
+
+    final details = <String>[
+      if (config.showName && name != null && name.isNotEmpty)
+        'Digitally signed by $name',
+      if (config.showDate && info.time != null)
+        'Date: ${_displaySignDate(info.time!)}',
+      if (config.showReason &&
+          info.reason != null &&
+          info.reason!.isNotEmpty)
+        'Reason: ${info.reason}',
+      if (config.showLocation &&
+          info.location != null &&
+          info.location!.isNotEmpty)
+        'Location: ${info.location}',
+    ];
+
+    // Column split: a divider only when both panels carry content.
+    double divider;
+    if (hasLeft && details.isNotEmpty) {
+      divider = w * 0.42;
+      writer
+        ..strokeColor(config.borderColor)
+        ..lineWidth(0.5)
+        ..moveTo(divider, pad)
+        ..lineTo(divider, h - pad)
+        ..stroke();
+    } else if (hasLeft) {
+      divider = w; // left content only
+    } else {
+      divider = 0; // details only
+    }
+
+    if (hasGraphic) {
+      final image = config.graphic!;
+      final imageRef =
+          _updater.addObject(image.toXObject((s) => _updater.addObject(s)));
+      final panelW = divider - 2 * pad, panelH = h - 2 * pad;
+      if (panelW > 0 && panelH > 0 && image.width > 0 && image.height > 0) {
+        final scale = math.min(
+            panelW / image.width, panelH / image.height);
+        final dw = image.width * scale, dh = image.height * scale;
+        writer
+          ..save()
+          ..concatMatrix(dw, 0, 0, dh, pad + (panelW - dw) / 2,
+              pad + (panelH - dh) / 2)
+          ..drawXObject('SigImg')
+          ..restore();
+        xObjects['SigImg'] = imageRef;
+      }
+    } else if (showName) {
+      const boldFont = PdfStandardFont.helveticaBold;
+      fonts[boldFont.resourceName] = _signatureFont(boldFont);
+      _drawSignatureText(
+        writer,
+        [name],
+        boldFont,
+        config.textColor,
+        pad,
+        pad,
+        divider - pad,
+        h - pad,
+        maxSize: 22,
+        align: PdfTextAlign.center,
+        centerVertical: true,
+      );
+    }
+
+    if (details.isNotEmpty) {
+      const detailFont = PdfStandardFont.helvetica;
+      fonts[detailFont.resourceName] = _signatureFont(detailFont);
+      final left = divider > 0 ? divider + pad : pad;
+      _drawSignatureText(
+        writer,
+        details,
+        detailFont,
+        config.textColor,
+        left,
+        pad,
+        w - pad,
+        h - pad,
+        maxSize: 9,
+      );
+    }
+
+    final resources = CosDictionary({
+      if (fonts.entries.isNotEmpty) 'Font': fonts,
+      if (xObjects.entries.isNotEmpty) 'XObject': xObjects,
+    });
+    final form = _widgetForm(w, h, writer, resources: resources);
+    _setNormalAppearance(widget, form);
+  }
+
+  /// A base-14 font dict (with /Widths) for the appearance's /Font resource.
+  CosDictionary _signatureFont(PdfStandardFont font) => CosDictionary({
+        'Type': const CosName('Font'),
+        'Subtype': const CosName('Type1'),
+        'BaseFont': CosName(font.baseFont),
+        'Encoding': const CosName('WinAnsiEncoding'),
+        'FirstChar': const CosInteger(32),
+        'LastChar': const CosInteger(126),
+        'Widths': CosArray([for (final width in font.widths) CosInteger(width)]),
+      });
+
+  /// Lays [lines] out in the box `[left, bottom, right, top]`, shrinking the
+  /// font (from [maxSize]) and wrapping until the block fits, clipped to the
+  /// box. Top-anchored unless [centerVertical]; aligned per [align].
+  void _drawSignatureText(
+    ContentWriter writer,
+    List<String> lines,
+    PdfStandardFont font,
+    int color,
+    double left,
+    double bottom,
+    double right,
+    double top, {
+    required double maxSize,
+    PdfTextAlign align = PdfTextAlign.left,
+    bool centerVertical = false,
+  }) {
+    final boxW = right - left, boxH = top - bottom;
+    if (boxW <= 0 || boxH <= 0) return;
+
+    var size = maxSize;
+    List<String> wrapped;
+    while (true) {
+      wrapped = [
+        for (final line in lines) ..._wrapSignatureLine(line, font, size, boxW),
+      ];
+      if (wrapped.length * size * 1.3 <= boxH || size <= 4) break;
+      size -= 0.5;
+    }
+    if (wrapped.isEmpty) return;
+
+    final lineHeight = size * 1.3;
+    final ascent = size * font.ascent / 1000;
+    final blockHeight = wrapped.length * lineHeight;
+    final blockTop =
+        centerVertical ? bottom + (boxH + blockHeight) / 2 : top;
+
+    writer
+      ..save()
+      ..rect(left, bottom, boxW, boxH)
+      ..clip()
+      ..beginText()
+      ..fillColor(color)
+      ..font(font.resourceName, size);
+    var prevX = 0.0, prevY = 0.0;
+    for (var i = 0; i < wrapped.length; i++) {
+      final lineWidth = font.measure(wrapped[i], size);
+      final x = switch (align) {
+        PdfTextAlign.center => left + (boxW - lineWidth) / 2,
+        PdfTextAlign.right => right - lineWidth,
+        PdfTextAlign.left => left,
+      };
+      final y = blockTop - i * lineHeight - ascent;
+      writer
+        ..textAt(x - prevX, y - prevY)
+        ..showText(wrapped[i]);
+      prevX = x;
+      prevY = y;
+    }
+    writer
+      ..endText()
+      ..restore();
+  }
+
+  /// Greedy word-wrap of [text] to [maxWidth]; a single overlong word
+  /// overflows (and is clipped by the box).
+  List<String> _wrapSignatureLine(
+      String text, PdfStandardFont font, double size, double maxWidth) {
+    if (font.measure(text, size) <= maxWidth) return [text];
+    final out = <String>[];
+    var line = '';
+    for (final word in text.split(' ')) {
+      final candidate = line.isEmpty ? word : '$line $word';
+      if (line.isNotEmpty && font.measure(candidate, size) > maxWidth) {
+        out.add(line);
+        line = word;
+      } else {
+        line = candidate;
+      }
+    }
+    if (line.isNotEmpty) out.add(line);
+    return out.isEmpty ? [text] : out;
+  }
+
+  /// Acrobat-style display date: `2026.06.10 12:00:00 +00'00'`. Signing
+  /// times are normalized to UTC before display.
+  static String _displaySignDate(DateTime time) {
+    final utc = time.toUtc();
+    String two(int v) => v.toString().padLeft(2, '0');
+    return '${utc.year}.${two(utc.month)}.${two(utc.day)} '
+        "${two(utc.hour)}:${two(utc.minute)}:${two(utc.second)} +00'00'";
   }
 }
 

--- a/packages/pdf_document/test/pades_test.dart
+++ b/packages/pdf_document/test/pades_test.dart
@@ -39,6 +39,39 @@ void main() {
     });
   });
 
+  group('visible signature box', () {
+    test('renders a box while staying a valid B-LTA signature', () async {
+      final bytes = await freshEditor().saveSignedPades(
+        privateKey: signerKey,
+        certificates: [signerCert],
+        level: PdfPadesLevel.bLTA,
+        timestampClient: testTsa(),
+        signingTime: signedAt,
+        reason: 'Approval',
+        appearance: const PdfSignatureAppearance(
+          rect: PdfRect(72, 640, 340, 720),
+        ),
+      );
+      final doc = PdfDocument.open(bytes);
+      final signature = PdfSignature.of(doc)
+          .firstWhere((s) => !s.isDocumentTimeStamp);
+      final result = signature.validate();
+      expect(result.intact, isTrue);
+      expect(result.padesLevel, PdfPadesLevel.bLTA);
+
+      final widget = signature.field.widgets.first;
+      final ap = doc.cos.resolve(widget['AP']) as CosDictionary;
+      final form = doc.cos.resolve(ap['N']) as CosStream;
+      final content = String.fromCharCodes(doc.cos.decodeStreamData(form));
+      final shown = RegExp(r'\(([^)]*)\) Tj')
+          .allMatches(content)
+          .map((m) => m.group(1))
+          .join(' ');
+      expect(shown, contains('Digitally signed by Dart PDF Test Signer'));
+      expect(shown, contains('Reason: Approval'));
+    });
+  });
+
   group('PAdES B-T', () {
     test('embeds a verifiable signature timestamp', () async {
       final bytes = await freshEditor().saveSignedPades(

--- a/packages/pdf_document/test/signature_test.dart
+++ b/packages/pdf_document/test/signature_test.dart
@@ -54,7 +54,131 @@ Uint8List buildEmptySigFieldPdf() {
   return ascii(buffer.toString());
 }
 
+/// The decoded content of a field's /AP /N appearance form, or null.
+String? appearanceContent(PdfDocument doc, PdfFormField field) {
+  final widget = field.widgets.first;
+  final ap = doc.cos.resolve(widget['AP']);
+  if (ap is! CosDictionary) return null;
+  final n = doc.cos.resolve(ap['N']);
+  if (n is! CosStream) return null;
+  return String.fromCharCodes(doc.cos.decodeStreamData(n));
+}
+
+/// All the text shown by an appearance's `(...) Tj` operators, joined with
+/// spaces so word-wrapped lines read back as the original strings.
+String shownText(String content) => RegExp(r'\(([^)]*)\) Tj')
+    .allMatches(content)
+    .map((m) => m.group(1))
+    .join(' ');
+
 void main() {
+  group('visible signature box', () {
+    test('a placed appearance draws the Acrobat-style box', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+      final signed = editor.saveSigned(
+        privateKey: key,
+        certificates: [cert],
+        reason: 'Approval',
+        location: 'Melbourne',
+        signingTime: signedAt,
+        appearance: const PdfSignatureAppearance(
+          rect: PdfRect(72, 600, 320, 700),
+        ),
+      );
+      final doc = PdfDocument.open(signed);
+      final signature = PdfSignature.of(doc).single;
+      expect(signature.validate().intact, isTrue);
+
+      // the widget is visible at the requested rectangle
+      final widget = signature.field.widgets.first;
+      final rect = doc.cos.resolve(widget['Rect']) as CosArray;
+      expect((doc.cos.resolve(rect[0]) as CosReal).value, 72);
+      expect((doc.cos.resolve(rect[3]) as CosReal).value, 700);
+
+      // the appearance form has a BBox matching the box size and shows the
+      // signer name, date, reason and location
+      final ap = doc.cos.resolve(widget['AP']) as CosDictionary;
+      final form = doc.cos.resolve(ap['N']) as CosStream;
+      final bbox = doc.cos.resolve(form.dictionary['BBox']) as CosArray;
+      expect((doc.cos.resolve(bbox[2]) as CosReal).value, 248); // 320-72
+      expect((doc.cos.resolve(bbox[3]) as CosReal).value, 100); // 700-600
+
+      final shown = shownText(appearanceContent(doc, signature.field)!);
+      expect(shown, contains('Digitally signed by Dart PDF Test Signer'));
+      expect(shown, contains('Date: 2026.06.10 12:00:00'));
+      expect(shown, contains('Reason: Approval'));
+      expect(shown, contains('Location: Melbourne'));
+    });
+
+    test('placing on a later page attaches the widget to that page', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(3)));
+      final signed = editor.saveSigned(
+        privateKey: key,
+        certificates: [cert],
+        signingTime: signedAt,
+        appearance: const PdfSignatureAppearance(
+          page: 2,
+          rect: PdfRect(100, 100, 300, 160),
+        ),
+      );
+      final doc = PdfDocument.open(signed);
+      final annots0 = doc.cos.resolve(doc.page(0).dict['Annots']);
+      expect(annots0 is CosArray ? annots0.length : 0, 0);
+      final annots2 = doc.cos.resolve(doc.page(2).dict['Annots']) as CosArray;
+      expect(annots2.length, 1);
+      expect(PdfSignature.of(doc).single.validate().intact, isTrue);
+    });
+
+    test('signing an existing visible field fills its box', () {
+      final editor = PdfEditor(PdfDocument.open(buildEmptySigFieldPdf()));
+      final signed = editor.saveSigned(
+        privateKey: key,
+        certificates: [cert],
+        fieldName: 'ApproverSig',
+        reason: 'Reviewed',
+        signingTime: signedAt,
+      );
+      final doc = PdfDocument.open(signed);
+      final signature = PdfSignature.of(doc).single;
+      expect(signature.validate().intact, isTrue);
+      final content = appearanceContent(doc, signature.field);
+      expect(content, isNotNull);
+      expect(content, contains('Digitally signed by'));
+      expect(content, contains('Reason: Reviewed'));
+    });
+
+    test('showing fewer fields omits them from the box', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+      final signed = editor.saveSigned(
+        privateKey: key,
+        certificates: [cert],
+        reason: 'Approval',
+        location: 'Melbourne',
+        signingTime: signedAt,
+        appearance: const PdfSignatureAppearance(
+          rect: PdfRect(72, 600, 320, 700),
+          showReason: false,
+          showLocation: false,
+        ),
+      );
+      final doc = PdfDocument.open(signed);
+      final shown =
+          shownText(appearanceContent(doc, PdfSignature.of(doc).single.field)!);
+      expect(shown, contains('Digitally signed by'));
+      expect(shown, isNot(contains('Reason:')));
+      expect(shown, isNot(contains('Location:')));
+    });
+
+    test('no appearance keeps an invisible field (backward compatible)', () {
+      final doc = PdfDocument.open(signedFixture());
+      final signature = PdfSignature.of(doc).single;
+      expect(appearanceContent(doc, signature.field), isNull);
+      final widget = signature.field.widgets.first;
+      final rect = doc.cos.resolve(widget['Rect']) as CosArray;
+      expect((doc.cos.resolve(rect[2]) as CosInteger).value, 0);
+    });
+  });
+
   group('signing', () {
     test('a signed document validates as intact and whole', () {
       final doc = PdfDocument.open(signedFixture());

--- a/packages/pdf_document/test/signature_test.dart
+++ b/packages/pdf_document/test/signature_test.dart
@@ -1,9 +1,15 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:test/test.dart';
+
+// 2x2 RGBA PNG (from png_test.dart), used as a handwritten-signature graphic.
+final _png = base64.decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAGUlEQVR4nGP4z8DwHwgb'
+    'WBgZ/jNyicr7AgA3BAUOTnqjAAAAAABJRU5ErkJggg==');
 
 final key = RsaPrivateKey.fromPem(testSignerKeyPem);
 final cert = pemBytes(testSignerCertPem);
@@ -167,6 +173,59 @@ void main() {
       expect(shown, contains('Digitally signed by'));
       expect(shown, isNot(contains('Reason:')));
       expect(shown, isNot(contains('Location:')));
+    });
+
+    test('a graphic renders in the left panel as an image XObject', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+      final signed = editor.saveSigned(
+        privateKey: key,
+        certificates: [cert],
+        signingTime: signedAt,
+        appearance: PdfSignatureAppearance(
+          rect: const PdfRect(72, 600, 320, 700),
+          graphic: PdfEmbeddableImage.png(_png),
+        ),
+      );
+      final doc = PdfDocument.open(signed);
+      final signature = PdfSignature.of(doc).single;
+      expect(signature.validate().intact, isTrue);
+
+      final widget = signature.field.widgets.first;
+      final ap = doc.cos.resolve(widget['AP']) as CosDictionary;
+      final form = doc.cos.resolve(ap['N']) as CosStream;
+      final resources =
+          doc.cos.resolve(form.dictionary['Resources']) as CosDictionary;
+      final xobjects = doc.cos.resolve(resources['XObject']) as CosDictionary;
+      expect(xobjects.entries.keys, contains('SigImg'));
+
+      final content = String.fromCharCodes(doc.cos.decodeStreamData(form));
+      expect(content, contains('/SigImg Do'));
+      // the big name text is replaced by the graphic in the left panel
+      expect(shownText(content), isNot(contains('Dart PDF Test Signer Dart')));
+    });
+
+    test('a details-only box (no name/graphic) omits the left panel', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+      final signed = editor.saveSigned(
+        privateKey: key,
+        certificates: [cert],
+        reason: 'Approval',
+        signingTime: signedAt,
+        appearance: const PdfSignatureAppearance(
+          rect: PdfRect(72, 600, 320, 700),
+          backgroundColor: 0xEEF3F8,
+          showName: false,
+        ),
+      );
+      final doc = PdfDocument.open(signed);
+      final signature = PdfSignature.of(doc).single;
+      expect(signature.validate().intact, isTrue);
+      final content = appearanceContent(doc, signature.field)!;
+      // background fill rectangle emitted before the border
+      expect(content, contains('0 0 248 100 re'));
+      final shown = shownText(content);
+      expect(shown, isNot(contains('Digitally signed by')));
+      expect(shown, contains('Reason: Approval'));
     });
 
     test('no appearance keeps an invisible field (backward compatible)', () {

--- a/packages/pdf_document/tool/emit_signature_box.dart
+++ b/packages/pdf_document/tool/emit_signature_box.dart
@@ -1,0 +1,24 @@
+// Emits a sample signed PDF with a visible signature box so the Acrobat/
+// Bluebeam-style appearance can be inspected in a real viewer.
+import 'dart:io';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+  final signed = editor.saveSigned(
+    privateKey: RsaPrivateKey.fromPem(testSignerKeyPem),
+    certificates: [pemBytes(testSignerCertPem)],
+    reason: 'I approve this document',
+    location: 'Melbourne, AU',
+    signingTime: DateTime.utc(2026, 7, 16, 9, 30, 0),
+    appearance: const PdfSignatureAppearance(
+      rect: PdfRect(72, 640, 372, 720),
+      backgroundColor: 0xF3F7FB,
+    ),
+  );
+  File('signature_box_sample.pdf').writeAsBytesSync(signed);
+  stdout.writeln('wrote signature_box_sample.pdf (${signed.length} bytes)');
+}


### PR DESCRIPTION
## Summary

Signatures were always invisible: `_attachSignatureField` created a widget with `/Rect [0 0 0 0]` and no `/AP`, so Acrobat/Bluebeam showed nothing where a signature was placed. This adds an **Acrobat/Bluebeam-style visible signature box** the signer can place, and that automatically fills a form field the author already placed.

- New `PdfSignatureAppearance` (exported via `editor.dart`) describes the box: `page` + `rect` for a fresh field, an optional handwritten-signature/logo `graphic`, `showName`/`showDate`/`showReason`/`showLocation` toggles, and `backgroundColor`/`borderColor`/`textColor`.
- Threaded as an optional `appearance:` argument through `PdfSigning.saveSigned` and `PdfPadesSigning.saveSignedPades` → `_emitSignatureRevision` → `_attachSignatureField`.
- `_installSignatureAppearance` renders the `/AP /N` form XObject: optional background fill, 1pt border, a 0.5pt column divider, the signer name (Helvetica-Bold, auto-sized, centered) or the graphic in the left panel, and `Digitally signed by … / Date: … / Reason: … / Location: …` (Helvetica, auto-sized, word-wrapped, clipped) on the right. Date is Acrobat-style `2026.07.16 09:30:00 +00'00'`.

**Behavior:** an existing field with a visible `/Rect` is filled even without an explicit `appearance` (defaults used); a freshly created field stays invisible unless `appearance.rect` is given; document timestamps never get an appearance. Output is byte-identical to before when no box is requested (backward compatible).

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (workspace clean)
- [x] `cd packages/pdf_document && fvm dart test` (signature/pades/form suites — 64 pass)

## PDF fixtures and screenshots

`tool/emit_signature_box.dart` emits a sample signed PDF with a visible box for inspection in a real viewer. Tests build the input programmatically and assert on the decoded `/AP /N` content stream (BBox, `/Rect`, and the shown `(...) Tj` text).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory (the sample emitter lives in `tool/`, not `lib/`).
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The appearance generator reuses form_editor's `_widgetForm` / `_setNormalAppearance` and the same `ContentWriter` operators as the proven form/annotation appearance code. Text past Latin-1 degrades to spaces (`ContentWriter.showText`), the same limitation as the other appearance generators. Dev-log: `doc/dev-log/2026-07-16-signature-appearance-box.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8QH1oUstLo5qLz1NNwi35

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8QH1oUstLo5qLz1NNwi35)_