### PR TITLE
Add page copy/cut/paste to the thumbnail view, shared across doc tabs

### DIFF
--- a/doc/dev-log/2026-07-16-page-clipboard.md
+++ b/doc/dev-log/2026-07-16-page-clipboard.md
@@ -1,0 +1,60 @@
+# Page copy/cut/paste in the thumbnail view (cross-tab)
+
+Added whole-page copy/cut/paste to the thumbnail strip and grid, with a
+clipboard shared across document tabs so pages copied in one open document
+paste into another.
+
+## The shared clipboard
+
+`PdfPageClipboard` (`editing_page_clipboard.dart`) is a `ChangeNotifier`
+holding the copied pages as a **self-contained PDF byte buffer** plus a page
+count. Bytes come from `exportPages` (pdf_cos's from-scratch writer via
+`extractPages`), so a paste deep-copies everything each page references and
+never depends on the source document - or the tab it came from - still being
+open.
+
+`PdfPageClipboard.instance` is a process-wide singleton; every
+`PdfEditingController` defaults to it (new `pageClipboard` constructor arg),
+so cross-tab paste works with **zero host wiring** - the example app's tabs
+each `PdfEditingController(bytes, ...)` and automatically share it. Pass a
+private clipboard to isolate a session (the tests do).
+
+The controller registers `notifyListeners` on the clipboard (mirroring how
+it listens to `preferences`), so every tab rebuilds its paste affordances
+the instant any tab fills or clears the clipboard. Removed in `dispose`
+(instance-method tear-offs compare equal, so `removeListener` matches).
+
+## Controller ops (`editing_controller.dart`)
+
+- `copyPages(indices)` / `copySelectedPages()` - fill the clipboard; no
+  document edit, no revision.
+- `cutPages(indices)` / `cutSelectedPages()` - copy **then** `removePages`
+  in one undoable edit. Refused (nothing copied) when it would empty the
+  document, matching `removeSelectedPages`. Clears the selection.
+- `pastePages({at})` - `insertPagesFromBytes` at `at` (default: append),
+  then selects the pasted run so the strip highlights what landed. One undo
+  removes the paste.
+- `hasPageClipboard` gates the paste affordances.
+
+## UI (`editing_thumbnails.dart`)
+
+Wired into every surface, both the docked strip and the full-area grid:
+
+- **Context menu** (`_showPageTileMenu`): Copy / Cut / Paste rows
+  (`pdf-thumbnail-menu-{copy,cut,paste}`). Cut dims when it would empty the
+  doc; Paste dims when the clipboard is empty and drops its pages after the
+  right-clicked page (jumping there).
+- **Bulk selection bar** (`_PageSelectionBar`): copy/cut icon buttons
+  (`pdf-thumbnail-{copy,cut}-selected`).
+- **Header page-actions menu** (`_PageActionsButton`): a Paste entry
+  (`pdf-thumbnail-paste-pages`) - the touch path, since long-press starts a
+  reorder drag rather than the context menu. The button now also renders
+  when the clipboard has pages even if no insert/export callback is wired,
+  gated on `allowPageEditing`.
+- **Keyboard**: ⌘/Ctrl+C/X/V in both strip and grid, acting on the page
+  selection (or the keyboard/current page when nothing is selected); paste
+  reveals the landing page. Gated on `allowPageEditing`.
+
+Tests in `editing_page_clipboard_test.dart` cover the clipboard, all three
+controller ops (incl. cut-empty refusal and undo), cross-tab paste through a
+shared clipboard, and each UI surface.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -24,6 +24,7 @@ export 'src/editing/editing_fonts.dart';
 export 'src/editing/editing_interaction.dart';
 export 'src/editing/editing_measure.dart';
 export 'src/editing/editing_menu.dart';
+export 'src/editing/editing_page_clipboard.dart';
 export 'src/editing/editing_panel.dart';
 export 'src/editing/editing_pencil.dart';
 export 'src/editing/editing_preferences.dart';

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -11,6 +11,7 @@ import '../page_geometry.dart';
 import '../renderer.dart';
 import 'digital_signature.dart';
 import 'editing_measure.dart';
+import 'editing_page_clipboard.dart';
 import 'editing_preferences.dart';
 import 'line_style.dart';
 import 'editing_signature.dart';
@@ -295,12 +296,17 @@ class PdfEditingController extends ChangeNotifier {
     Uint8List bytes, {
     String password = '',
     PdfEditingPreferences? preferences,
+    PdfPageClipboard? pageClipboard,
   })  : _bytes = bytes,
         _password = password,
         _revisions = [bytes.length],
         _document = PdfDocument.open(bytes, password: password),
-        preferences = preferences ?? PdfEditingPreferences() {
+        preferences = preferences ?? PdfEditingPreferences(),
+        pageClipboard = pageClipboard ?? PdfPageClipboard.instance {
     this.preferences.addListener(notifyListeners);
+    // rebuild paste affordances live as the shared page clipboard fills or
+    // clears - from this controller or from another document tab sharing it
+    this.pageClipboard.addListener(notifyListeners);
   }
 
   /// The persisted UI preferences backing [color], [strokeWidth],
@@ -309,6 +315,12 @@ class PdfEditingController extends ChangeNotifier {
   /// to share it with the host's chrome (the sidebar-visibility flags
   /// live there too).
   final PdfEditingPreferences preferences;
+
+  /// The clipboard whole copied/cut pages live in, shared across document
+  /// tabs so pages copied from one document paste into another. Defaults to
+  /// the process-wide [PdfPageClipboard.instance]; pass a private one to
+  /// isolate a session. See [copyPages], [cutPages], and [pastePages].
+  final PdfPageClipboard pageClipboard;
 
   /// The session's shared page-thumbnail cache (and its viewport-ordered
   /// render queue). Every thumbnail surface - the docked strip, the
@@ -326,6 +338,7 @@ class PdfEditingController extends ChangeNotifier {
     _changeFeed?.close();
     thumbnailCache.dispose();
     preferences.removeListener(notifyListeners);
+    pageClipboard.removeListener(notifyListeners);
     super.dispose();
   }
 
@@ -3109,6 +3122,76 @@ class PdfEditingController extends ChangeNotifier {
   /// leaving this document untouched. Null when nothing is selected.
   Uint8List? exportSelectedPages() =>
       _selectedPages.isEmpty ? null : exportPages(selectedPages);
+
+  // ---------------------------------------------------------------------
+  // page clipboard (copy / cut / paste, shared across document tabs)
+
+  /// Whether [pastePages] has pages waiting on the shared [pageClipboard].
+  bool get hasPageClipboard => pageClipboard.isNotEmpty;
+
+  /// Copies [indices] (de-duplicated, ascending) onto the shared
+  /// [pageClipboard] as a self-contained PDF, leaving this document
+  /// untouched. Because the clipboard is shared, the copy can then be
+  /// pasted into this document or a different open document tab. Returns
+  /// false (a no-op) when no valid page is given.
+  bool copyPages(Iterable<int> indices) {
+    final targets = indices
+        .where((i) => i >= 0 && i < _document.pageCount)
+        .toSet()
+        .toList()
+      ..sort();
+    if (targets.isEmpty) return false;
+    pageClipboard.setPages(exportPages(targets), targets.length);
+    return true;
+  }
+
+  /// Copies the strip's selected pages onto the shared [pageClipboard].
+  /// A no-op (returns false) when nothing is selected.
+  bool copySelectedPages() => copyPages(selectedPages);
+
+  /// Copies [indices] onto the shared [pageClipboard] and removes them in
+  /// one edit (one undo) - copy + delete. Refused (nothing copied, nothing
+  /// removed, returns false) when the pages would empty the document; at
+  /// least one page must remain. Clears the page selection, like
+  /// [removeSelectedPages].
+  bool cutPages(Iterable<int> indices) {
+    final targets = indices
+        .where((i) => i >= 0 && i < _document.pageCount)
+        .toSet()
+        .toList()
+      ..sort();
+    if (targets.isEmpty || targets.length >= _document.pageCount) return false;
+    pageClipboard.setPages(exportPages(targets), targets.length);
+    _selected.clear();
+    _selectedPages.clear();
+    _pageSelectionAnchor = null;
+    return apply((e) => e.removePages(targets));
+  }
+
+  /// Cuts the strip's selected pages onto the shared [pageClipboard].
+  /// A no-op (returns false) when nothing is selected or the cut would
+  /// empty the document.
+  bool cutSelectedPages() => cutPages(selectedPages);
+
+  /// Inserts the shared [pageClipboard]'s pages at [at] (default: appended
+  /// at the end) and selects the pasted block. Because the clipboard is
+  /// shared across tabs, this pastes pages copied from any document.
+  /// Returns false (a no-op) when the clipboard is empty. The paste is one
+  /// undoable edit.
+  bool pastePages({int? at}) {
+    final bytes = pageClipboard.bytes;
+    if (bytes == null) return false;
+    final count = pageClipboard.pageCount;
+    final insertAt = (at ?? _document.pageCount).clamp(0, _document.pageCount);
+    insertPagesFromBytes(bytes, at: insertAt);
+    // surface what landed: select the pasted run so the strip highlights it
+    _selectedPages
+      ..clear()
+      ..addAll([for (var i = insertAt; i < insertAt + count; i++) i]);
+    _pageSelectionAnchor = insertAt;
+    notifyListeners();
+    return true;
+  }
 
   /// Rotates [indices] clockwise by [degrees] (a multiple of 90; negative
   /// turns counterclockwise) in one edit (one undo). Rotation is a visual

--- a/packages/dart_pdf_editor/lib/src/editing/editing_page_clipboard.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_page_clipboard.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart';
+
+/// A clipboard for whole PDF pages, shared across documents: copy or cut
+/// pages in one [PdfEditingController]'s thumbnail view, then paste them
+/// into the same document - or into a different open document tab, since
+/// every controller shares the process-wide [instance] by default.
+///
+/// The copied pages are held as a self-contained PDF byte buffer (produced
+/// by [PdfEditingController.exportPages]), so a paste deep-copies everything
+/// each page references - content, resources, fonts, images, annotations -
+/// and never depends on the source document staying open (or even the tab
+/// it was copied from still existing).
+///
+/// A [ChangeNotifier] so paste affordances can enable and disable live as
+/// the clipboard fills and clears. Controllers default to the shared
+/// [instance] so a copy in one tab pastes into another with no wiring; pass
+/// a private clipboard to a controller to isolate it (tests do this).
+class PdfPageClipboard extends ChangeNotifier {
+  /// The process-wide clipboard every [PdfEditingController] shares by
+  /// default, so a copy in one document tab can be pasted into another.
+  static final PdfPageClipboard instance = PdfPageClipboard();
+
+  Uint8List? _bytes;
+  int _pageCount = 0;
+
+  /// The self-contained PDF holding the copied pages, or null when the
+  /// clipboard is empty.
+  Uint8List? get bytes => _bytes;
+
+  /// How many pages the clipboard currently holds (0 when empty).
+  int get pageCount => _pageCount;
+
+  /// Whether there are pages waiting to be pasted.
+  bool get isNotEmpty => _bytes != null;
+
+  /// Whether the clipboard is empty.
+  bool get isEmpty => _bytes == null;
+
+  /// Fills the clipboard with [pageCount] pages held as the self-contained
+  /// PDF [bytes], replacing any previous contents and notifying listeners.
+  void setPages(Uint8List bytes, int pageCount) {
+    _bytes = bytes;
+    _pageCount = pageCount;
+    notifyListeners();
+  }
+
+  /// Empties the clipboard (a no-op, no notification, when already empty).
+  void clear() {
+    if (_bytes == null) return;
+    _bytes = null;
+    _pageCount = 0;
+    notifyListeners();
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -26,10 +26,12 @@ import 'thumbnail_cache.dart';
 /// first so the list still scrolls), the per-tile button deletes a page
 /// (the last remaining page cannot be deleted), and the strip's footer
 /// appends a blank page. Right-clicking a tile (secondary tap) opens a
-/// page context menu - rotate, duplicate, insert a blank page before or
-/// after, export (when [onExportPages] is given), delete - that acts on
-/// the strip's selection when the tile belongs to it. All of this (export
-/// aside) needs [allowPageEditing].
+/// page context menu - rotate, duplicate, copy/cut/paste (a shared page
+/// clipboard, so pages copied here paste into a different document tab),
+/// insert a blank page before or after, export (when [onExportPages] is
+/// given), delete - that acts on the strip's selection when the tile
+/// belongs to it. Copy/cut/paste are also bound to ⌘/Ctrl+C/X/V. All of
+/// this (export aside) needs [allowPageEditing].
 ///
 /// Built to stay light on large documents: thumbnails are rasterized at
 /// tile resolution and cached, keyed by
@@ -242,6 +244,29 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     unawaited(widget.viewerController.jumpToPage(target));
   }
 
+  /// The pages a copy/cut shortcut acts on: the strip's selection, or the
+  /// keyboard/current page when nothing is selected.
+  List<int> _clipboardTargets() {
+    final selected = widget.controller.selectedPages;
+    if (selected.isNotEmpty) return selected;
+    if (widget.controller.document.pageCount == 0) return const [];
+    return [_keyboardBase()];
+  }
+
+  void _copyPages() => widget.controller.copyPages(_clipboardTargets());
+
+  void _cutPages() => widget.controller.cutPages(_clipboardTargets());
+
+  /// Pastes the shared clipboard's pages after the selection (or the
+  /// keyboard/current page) and reveals where they landed.
+  void _pastePages() {
+    final selected = widget.controller.selectedPages;
+    final at = (selected.isNotEmpty ? selected.last : _keyboardBase()) + 1;
+    if (!widget.controller.pastePages(at: at)) return;
+    _focusPage(at);
+    if (widget.followsViewer) _revealPage(at);
+  }
+
   Map<ShortcutActivator, VoidCallback> get _keyboardShortcuts => {
         const SingleActivator(LogicalKeyboardKey.arrowUp): () =>
             _moveKeyboardSelection(-1),
@@ -259,6 +284,18 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
             _moveKeyboardSelection(-1),
         const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true): () =>
             _moveKeyboardSelection(1),
+        if (widget.allowPageEditing) ...{
+          const SingleActivator(LogicalKeyboardKey.keyC, meta: true): _copyPages,
+          const SingleActivator(LogicalKeyboardKey.keyC, control: true):
+              _copyPages,
+          const SingleActivator(LogicalKeyboardKey.keyX, meta: true): _cutPages,
+          const SingleActivator(LogicalKeyboardKey.keyX, control: true):
+              _cutPages,
+          const SingleActivator(LogicalKeyboardKey.keyV, meta: true):
+              _pastePages,
+          const SingleActivator(LogicalKeyboardKey.keyV, control: true):
+              _pastePages,
+        },
       };
 
   double get _frameWidth =>
@@ -524,11 +561,15 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                                           ),
                                         ),
                                         if (widget.onPickPdfToInsert != null ||
-                                            widget.onExportPages != null)
+                                            widget.onExportPages != null ||
+                                            (widget.allowPageEditing &&
+                                                controller.hasPageClipboard))
                                           _PageActionsButton(
                                             controller: controller,
                                             viewerController:
                                                 widget.viewerController,
+                                            allowPageEditing:
+                                                widget.allowPageEditing,
                                             onPickPdfToInsert:
                                                 widget.onPickPdfToInsert,
                                             onExportPages: widget.onExportPages,
@@ -715,6 +756,20 @@ class _PageSelectionBar extends StatelessWidget {
           onPressed: () => controller.rotateSelectedPages(90),
         ),
       ],
+      if (allowPageEditing) ...[
+        _action(
+          key: 'pdf-thumbnail-copy-selected',
+          icon: Icons.copy_outlined,
+          tooltip: 'Copy selected pages',
+          onPressed: () => controller.copySelectedPages(),
+        ),
+        _action(
+          key: 'pdf-thumbnail-cut-selected',
+          icon: Icons.content_cut,
+          tooltip: 'Cut selected pages',
+          onPressed: () => controller.cutSelectedPages(),
+        ),
+      ],
       if (onExportPages != null)
         _action(
           key: 'pdf-thumbnail-export-selected',
@@ -770,7 +825,7 @@ class _PageSelectionBar extends StatelessWidget {
   }
 }
 
-enum _PageAction { insert, export }
+enum _PageAction { paste, insert, export }
 
 const _densePopupMenuHeight = 34.0;
 
@@ -789,14 +844,28 @@ class _PageActionsButton extends StatelessWidget {
   const _PageActionsButton({
     required this.controller,
     required this.viewerController,
+    required this.allowPageEditing,
     this.onPickPdfToInsert,
     this.onExportPages,
   });
 
   final PdfEditingController controller;
   final PdfViewerController viewerController;
+
+  /// Whether structural page edits (paste, insert) are offered - a
+  /// read-only strip drops them and keeps only Export.
+  final bool allowPageEditing;
   final Future<Uint8List?> Function()? onPickPdfToInsert;
   final void Function(Uint8List bytes)? onExportPages;
+
+  void _paste() {
+    // paste the shared clipboard's pages after the current page, then
+    // scroll there so the reader sees what landed
+    final pastedAt = viewerController.currentPage + 1;
+    if (controller.pastePages(at: pastedAt)) {
+      unawaited(_jumpToInsertedPage(viewerController, pastedAt));
+    }
+  }
 
   Future<void> _insert(BuildContext context) async {
     final pick = onPickPdfToInsert;
@@ -835,6 +904,7 @@ class _PageActionsButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final canPaste = allowPageEditing && controller.hasPageClipboard;
     final canInsert = onPickPdfToInsert != null;
     final canExport = onExportPages != null;
     return PopupMenuButton<_PageAction>(
@@ -844,6 +914,8 @@ class _PageActionsButton extends StatelessWidget {
       style: const ButtonStyle(visualDensity: VisualDensity.compact),
       onSelected: (action) {
         switch (action) {
+          case _PageAction.paste:
+            _paste();
           case _PageAction.insert:
             _insert(context);
           case _PageAction.export:
@@ -851,6 +923,18 @@ class _PageActionsButton extends StatelessWidget {
         }
       },
       itemBuilder: (context) => [
+        if (canPaste)
+          PopupMenuItem(
+            key: const ValueKey('pdf-thumbnail-paste-pages'),
+            value: _PageAction.paste,
+            height: _densePopupMenuHeight,
+            child: Text(
+              controller.pageClipboard.pageCount == 1
+                  ? 'Paste page'
+                  : 'Paste ${controller.pageClipboard.pageCount} pages',
+              style: _densePopupTextStyle(context),
+            ),
+          ),
         if (canInsert)
           PopupMenuItem(
             key: const ValueKey('pdf-thumbnail-insert-pdf'),
@@ -1079,6 +1163,29 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
     _revealPage(target);
   }
 
+  /// The pages a copy/cut shortcut acts on: the grid's selection, or the
+  /// keyboard/current page when nothing is selected.
+  List<int> _clipboardTargets() {
+    final selected = widget.controller.selectedPages;
+    if (selected.isNotEmpty) return selected;
+    if (widget.controller.document.pageCount == 0) return const [];
+    return [_keyboardBase()];
+  }
+
+  void _copyPages() => widget.controller.copyPages(_clipboardTargets());
+
+  void _cutPages() => widget.controller.cutPages(_clipboardTargets());
+
+  /// Pastes the shared clipboard's pages after the selection (or the
+  /// keyboard/current page) and reveals where they landed.
+  void _pastePages() {
+    final selected = widget.controller.selectedPages;
+    final at = (selected.isNotEmpty ? selected.last : _keyboardBase()) + 1;
+    if (!widget.controller.pastePages(at: at)) return;
+    _focusPage(at);
+    _revealPage(at);
+  }
+
   Map<ShortcutActivator, VoidCallback> _keyboardShortcuts(int columns) => {
         const SingleActivator(LogicalKeyboardKey.arrowLeft): () =>
             _moveKeyboardSelection(-1),
@@ -1096,6 +1203,18 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
             _moveKeyboardSelection(-columns),
         SingleActivator(LogicalKeyboardKey.arrowDown, shift: true): () =>
             _moveKeyboardSelection(columns),
+        if (widget.allowPageEditing) ...{
+          const SingleActivator(LogicalKeyboardKey.keyC, meta: true): _copyPages,
+          const SingleActivator(LogicalKeyboardKey.keyC, control: true):
+              _copyPages,
+          const SingleActivator(LogicalKeyboardKey.keyX, meta: true): _cutPages,
+          const SingleActivator(LogicalKeyboardKey.keyX, control: true):
+              _cutPages,
+          const SingleActivator(LogicalKeyboardKey.keyV, meta: true):
+              _pastePages,
+          const SingleActivator(LogicalKeyboardKey.keyV, control: true):
+              _pastePages,
+        },
       };
 
   void _revealPage(int index) {
@@ -1215,10 +1334,13 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
                                 _preferences.thumbnailViewTileWidth = value,
                           ),
                           if (widget.onPickPdfToInsert != null ||
-                              widget.onExportPages != null)
+                              widget.onExportPages != null ||
+                              (widget.allowPageEditing &&
+                                  controller.hasPageClipboard))
                             _PageActionsButton(
                               controller: controller,
                               viewerController: widget.viewerController,
+                              allowPageEditing: widget.allowPageEditing,
                               onPickPdfToInsert: widget.onPickPdfToInsert,
                               onExportPages: widget.onExportPages,
                             ),
@@ -1878,6 +2000,9 @@ enum _PageTileAction {
   rotateRight,
   rotate180,
   duplicate,
+  copy,
+  cut,
+  paste,
   insertBefore,
   insertAfter,
   export,
@@ -1937,6 +2062,25 @@ Future<void> _showPageTileMenu({
           tileKey: 'pdf-thumbnail-menu-duplicate',
           icon: Icons.copy_all_outlined,
           label: forPages('Duplicate')),
+      // copy/cut fill the shared page clipboard (cross-tab); paste drops
+      // its pages after the right-clicked page. Cut can't empty the
+      // document, so it dims when it would take every page.
+      _pageMenuRow(context, _PageTileAction.copy,
+          tileKey: 'pdf-thumbnail-menu-copy',
+          icon: Icons.copy_outlined,
+          label: forPages('Copy')),
+      _pageMenuRow(context, _PageTileAction.cut,
+          tileKey: 'pdf-thumbnail-menu-cut',
+          icon: Icons.content_cut,
+          label: forPages('Cut'),
+          enabled: multi ? targets.length < pageCount : pageCount > 1),
+      _pageMenuRow(context, _PageTileAction.paste,
+          tileKey: 'pdf-thumbnail-menu-paste',
+          icon: Icons.content_paste,
+          label: controller.pageClipboard.pageCount == 1
+              ? 'Paste page'
+              : 'Paste ${controller.pageClipboard.pageCount} pages',
+          enabled: controller.hasPageClipboard),
       // insert is relative to the right-clicked page - a single insertion
       // point - so it stays singular even under a multi-selection
       _pageMenuRow(context, _PageTileAction.insertBefore,
@@ -1981,6 +2125,15 @@ Future<void> _showPageTileMenu({
       controller.rotatePages(targets, 180);
     case _PageTileAction.duplicate:
       controller.duplicatePages(targets);
+    case _PageTileAction.copy:
+      controller.copyPages(targets);
+    case _PageTileAction.cut:
+      controller.cutPages(targets);
+    case _PageTileAction.paste:
+      final pastedAt = pageIndex + 1;
+      if (controller.pastePages(at: pastedAt)) {
+        unawaited(_jumpToInsertedPage(viewerController, pastedAt));
+      }
     case _PageTileAction.insertBefore:
       controller.addBlankPage(at: pageIndex);
     case _PageTileAction.insertAfter:

--- a/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
@@ -1,0 +1,365 @@
+// Copy/cut/paste of whole pages: the shared [PdfPageClipboard], the
+// controller operations that fill and consume it, cross-document-tab
+// pasting, and the thumbnail-view UI (selection-bar buttons, the context
+// menu, the ⌘/Ctrl+C/X/V shortcuts, and the header paste entry).
+
+import 'package:flutter/gestures.dart' show kSecondaryButton;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The "Page N" label a page draws, or '' for a blank page.
+String labelOf(PdfDocument doc, int index) {
+  final content = String.fromCharCodes(doc.page(index).contentBytes());
+  return RegExp(r'\((Page \d+)\)').firstMatch(content)?.group(1) ?? '';
+}
+
+List<String> labelsOf(PdfDocument doc) =>
+    [for (var i = 0; i < doc.pageCount; i++) labelOf(doc, i)];
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('PdfPageClipboard', () {
+    test('starts empty and fills / clears with notification', () {
+      final clip = PdfPageClipboard();
+      var notified = 0;
+      clip.addListener(() => notified++);
+      expect(clip.isEmpty, isTrue);
+      expect(clip.isNotEmpty, isFalse);
+      expect(clip.pageCount, 0);
+      expect(clip.bytes, isNull);
+
+      clip.setPages(buildMultiPagePdf(2), 2);
+      expect(clip.isNotEmpty, isTrue);
+      expect(clip.pageCount, 2);
+      expect(clip.bytes, isNotNull);
+      expect(notified, 1);
+
+      clip.clear();
+      expect(clip.isEmpty, isTrue);
+      expect(notified, 2);
+      // clearing an already-empty clipboard doesn't notify again
+      clip.clear();
+      expect(notified, 2);
+    });
+
+    test('a controller defaults to the shared process-wide instance', () {
+      addTearDown(PdfPageClipboard.instance.clear);
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      expect(identical(editing.pageClipboard, PdfPageClipboard.instance),
+          isTrue);
+    });
+  });
+
+  group('controller copy / paste', () {
+    test('copy fills the clipboard without touching the document', () {
+      final clip = PdfPageClipboard();
+      final editing =
+          PdfEditingController(buildMultiPagePdf(3), pageClipboard: clip);
+      addTearDown(editing.dispose);
+      final before = editing.document;
+
+      expect(editing.hasPageClipboard, isFalse);
+      expect(editing.copyPages([0, 2]), isTrue);
+      expect(editing.hasPageClipboard, isTrue);
+      expect(clip.pageCount, 2);
+      // copying is not an edit: no new revision, the document is unchanged
+      expect(identical(editing.document, before), isTrue);
+      expect(editing.document.pageCount, 3);
+    });
+
+    test('copy of nothing valid is a no-op', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2),
+          pageClipboard: PdfPageClipboard());
+      addTearDown(editing.dispose);
+      expect(editing.copyPages(const []), isFalse);
+      expect(editing.copyPages([5, 9]), isFalse);
+      expect(editing.hasPageClipboard, isFalse);
+    });
+
+    test('paste drops the copied pages and selects them; one undo', () {
+      final editing = PdfEditingController(buildMultiPagePdf(3),
+          pageClipboard: PdfPageClipboard());
+      addTearDown(editing.dispose);
+      editing.copyPages([0]); // "Page 1"
+
+      expect(editing.pastePages(at: 2), isTrue);
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 1', 'Page 3']);
+      // the pasted run is selected so the strip highlights what landed
+      expect(editing.selectedPages, [2]);
+
+      // one revision: a single undo removes the paste
+      editing.undo();
+      expect(labelsOf(editing.document), ['Page 1', 'Page 2', 'Page 3']);
+    });
+
+    test('paste with no target appends at the end', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2),
+          pageClipboard: PdfPageClipboard());
+      addTearDown(editing.dispose);
+      editing.copyPages([1]); // "Page 2"
+      expect(editing.pastePages(), isTrue);
+      expect(labelsOf(editing.document), ['Page 1', 'Page 2', 'Page 2']);
+      expect(editing.selectedPages, [2]);
+    });
+
+    test('paste with an empty clipboard is a no-op', () {
+      final editing = PdfEditingController(buildMultiPagePdf(2),
+          pageClipboard: PdfPageClipboard());
+      addTearDown(editing.dispose);
+      expect(editing.pastePages(), isFalse);
+      expect(editing.document.pageCount, 2);
+    });
+
+    test('copySelectedPages copies the strip selection', () {
+      final clip = PdfPageClipboard();
+      final editing =
+          PdfEditingController(buildMultiPagePdf(4), pageClipboard: clip);
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      editing.selectPageRange(2); // pages 1..2
+      expect(editing.copySelectedPages(), isTrue);
+      expect(clip.pageCount, 2);
+    });
+  });
+
+  group('controller cut', () {
+    test('cut copies then removes, one undo restores both', () {
+      final clip = PdfPageClipboard();
+      final editing =
+          PdfEditingController(buildMultiPagePdf(3), pageClipboard: clip);
+      addTearDown(editing.dispose);
+
+      expect(editing.cutPages([1]), isTrue);
+      expect(clip.pageCount, 1);
+      expect(labelsOf(editing.document), ['Page 1', 'Page 3']);
+      expect(editing.hasPageSelection, isFalse);
+
+      editing.undo();
+      expect(labelsOf(editing.document), ['Page 1', 'Page 2', 'Page 3']);
+    });
+
+    test('cut that would empty the document is refused, clipboard untouched',
+        () {
+      final clip = PdfPageClipboard();
+      final editing =
+          PdfEditingController(buildMultiPagePdf(2), pageClipboard: clip);
+      addTearDown(editing.dispose);
+      expect(editing.cutPages([0, 1]), isFalse);
+      expect(clip.isEmpty, isTrue);
+      expect(editing.document.pageCount, 2);
+    });
+
+    test('cut then paste moves a page', () {
+      final editing = PdfEditingController(buildMultiPagePdf(3),
+          pageClipboard: PdfPageClipboard());
+      addTearDown(editing.dispose);
+      editing.cutPages([0]); // remove "Page 1"
+      expect(labelsOf(editing.document), ['Page 2', 'Page 3']);
+      editing.pastePages(); // append it at the end
+      expect(labelsOf(editing.document), ['Page 2', 'Page 3', 'Page 1']);
+    });
+  });
+
+  group('cross-document-tab paste', () {
+    test('pages copied in one controller paste into another sharing the clip',
+        () {
+      final clip = PdfPageClipboard();
+      final tabA = PdfEditingController(buildMultiPagePdf(3), pageClipboard: clip)
+        ..addBlankPage(); // keep this session distinct
+      addTearDown(tabA.dispose);
+      final tabB = PdfEditingController(buildMultiPagePdf(2), pageClipboard: clip);
+      addTearDown(tabB.dispose);
+
+      expect(tabA.copyPages([0, 2]), isTrue); // "Page 1", "Page 3"
+      // the other tab sees the shared clipboard right away
+      expect(tabB.hasPageClipboard, isTrue);
+
+      expect(tabB.pastePages(at: 1), isTrue);
+      expect(labelsOf(tabB.document), ['Page 1', 'Page 1', 'Page 3', 'Page 2']);
+      // pasting into B left A untouched
+      expect(tabA.document.pageCount, 4);
+    });
+
+    test('the shared clipboard notifies every controller bound to it', () {
+      final clip = PdfPageClipboard();
+      final tabA =
+          PdfEditingController(buildMultiPagePdf(1), pageClipboard: clip);
+      addTearDown(tabA.dispose);
+      final tabB =
+          PdfEditingController(buildMultiPagePdf(1), pageClipboard: clip);
+      addTearDown(tabB.dispose);
+      var notifiedB = 0;
+      tabB.addListener(() => notifiedB++);
+
+      tabA.copyPages([0]);
+      // B rebuilds so its paste affordances can enable
+      expect(notifiedB, greaterThan(0));
+      expect(tabB.hasPageClipboard, isTrue);
+    });
+  });
+
+  group('PdfThumbnailView UI', () {
+    void wideScreen(WidgetTester tester) {
+      tester.view.physicalSize = const Size(1000, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+    }
+
+    Future<({PdfEditingController editing, PdfViewerController viewer})> pumpGrid(
+      WidgetTester tester, {
+      int pages = 4,
+      PdfEditingController? controller,
+    }) async {
+      final editing = controller ??
+          PdfEditingController(buildMultiPagePdf(pages),
+              pageClipboard: PdfPageClipboard());
+      final viewer = PdfViewerController();
+      if (controller == null) addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfThumbnailView(
+            controller: editing,
+            viewerController: viewer,
+          ),
+        ),
+      ));
+      await tester.pump();
+      return (editing: editing, viewer: viewer);
+    }
+
+    Future<void> drain(WidgetTester tester) =>
+        tester.pump(const Duration(seconds: 2));
+
+    testWidgets('the selection bar copies pages', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 4);
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 2'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(refs.editing.selectedPages, [0, 1]);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-copy-selected')));
+      await tester.pump();
+      expect(refs.editing.pageClipboard.pageCount, 2);
+      expect(refs.editing.document.pageCount, 4); // copy is not an edit
+      await drain(tester);
+    });
+
+    testWidgets('the selection bar cuts pages', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 4);
+      // the bar only appears for a multi-selection
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 2'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(refs.editing.selectedPages, [0, 1]);
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-cut-selected')));
+      await tester.pump();
+      expect(labelsOf(refs.editing.document), ['Page 3', 'Page 4']);
+      expect(refs.editing.pageClipboard.pageCount, 2);
+      expect(refs.editing.hasPageSelection, isFalse);
+      await drain(tester);
+    });
+
+    testWidgets('⌘C copies the selection and ⌘V pastes it', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 3);
+      await tester.tap(find.text('Page 1'));
+      await tester.pump();
+      expect(refs.editing.selectedPages, [0]);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+      expect(refs.editing.pageClipboard.pageCount, 1);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyV);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+      // pasted right after the selected page 1
+      expect(labelsOf(refs.editing.document),
+          ['Page 1', 'Page 1', 'Page 2', 'Page 3']);
+      await drain(tester);
+    });
+
+    testWidgets('⌘X cuts the selection', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 3);
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyX);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+      expect(labelsOf(refs.editing.document), ['Page 1', 'Page 3']);
+      expect(refs.editing.pageClipboard.pageCount, 1);
+      await drain(tester);
+    });
+
+    testWidgets('the header page-actions menu pastes', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 2);
+      // nothing copied yet - no page actions button (no insert/export wired)
+      expect(find.byKey(const ValueKey('pdf-thumbnail-page-actions')),
+          findsNothing);
+
+      refs.editing.copyPages([0]);
+      await tester.pump();
+      // the button appears once there's something to paste
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-page-actions')));
+      await tester.pumpAndSettle();
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-thumbnail-paste-pages')));
+      await tester.pumpAndSettle();
+      // the header paste lands after the current page (index 0)
+      expect(labelsOf(refs.editing.document), ['Page 1', 'Page 1', 'Page 2']);
+      await drain(tester);
+    });
+
+    testWidgets('right-clicking a tile copies then pastes via the menu',
+        (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 3);
+
+      // right-click page 1 -> Copy page
+      await tester.tapAt(tester.getCenter(find.text('Page 1')),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-menu-copy')));
+      await tester.pumpAndSettle();
+      expect(refs.editing.pageClipboard.pageCount, 1);
+
+      // right-click page 3 -> Paste page (lands after it)
+      await tester.tapAt(tester.getCenter(find.text('Page 3')),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-menu-paste')));
+      await tester.pumpAndSettle();
+      expect(labelsOf(refs.editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 1']);
+      await drain(tester);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds whole-page **copy / cut / paste** to the thumbnail strip and grid, with a clipboard shared across document tabs so pages copied in one open document can be pasted into another.

- **`PdfPageClipboard`** (new `editing_page_clipboard.dart`) — a `ChangeNotifier` holding the copied pages as a *self-contained PDF byte buffer* (from `exportPages`) plus a page count. Because the bytes are a standalone PDF, a paste deep-copies everything each page references and never depends on the source document (or its tab) staying open.
- Every `PdfEditingController` defaults to the process-wide `PdfPageClipboard.instance`, so **cross-tab paste works with zero host wiring** — the example app's per-tab controllers already share it. A private clipboard can be injected to isolate a session.
- Controller ops: `copyPages`/`copySelectedPages` (no document edit), `cutPages`/`cutSelectedPages` (copy + remove in one undo, refused when it would empty the document), and `pastePages({at})` (inserts the clipboard and selects the pasted run; one undo removes it). `hasPageClipboard` gates the paste affordances, and the controller rebuilds live as the shared clipboard fills/clears.
- UI wired into both the docked strip and the full-area grid:
  - Right-click **context menu**: Copy / Cut / Paste (`pdf-thumbnail-menu-{copy,cut,paste}`) — Cut dims when it would empty the doc, Paste dims when the clipboard is empty and drops pages after the right-clicked page.
  - **Bulk selection bar**: copy/cut icon buttons.
  - **Header page-actions menu**: a Paste entry (the touch path, since long-press starts a reorder drag); the button now also appears when the clipboard has pages even with no insert/export callback wired.
  - **Keyboard**: ⌘/Ctrl+C/X/V in strip and grid.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Only `dart_pdf_editor` (and its example) is touched, so the pdf_cos/pdf_document/pdf_graphics Dart-VM suites and the corpus sweeps weren't relevant. Full editor suite (1467 tests) plus the example's tab/editing tests pass; analyze is clean. New coverage in `editing_page_clipboard_test.dart` exercises the clipboard, all three controller ops (incl. cut-empty refusal and undo), cross-tab paste through a shared clipboard, and each UI surface.

## PDF fixtures and screenshots

None — tests use the programmatic `buildMultiPagePdf` fixture.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The clipboard is process-global by default (`PdfPageClipboard.instance`); the controller listens with a `notifyListeners` tear-off and removes it in `dispose` (instance-method tear-offs compare equal, matching the existing `preferences` pattern).
- Cut mirrors `removeSelectedPages`' guard: it's refused (and copies nothing) when it would remove every page.
- Dev notes: `doc/dev-log/2026-07-16-page-clipboard.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhjydNrfkXJzMLELw4LLU2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhjydNrfkXJzMLELw4LLU2)_