### PR TITLE
Separate line thickness from pattern scale for dashes and clouds

### DIFF
--- a/doc/dev-log/2026-07-16-line-thickness-scale-separation.md
+++ b/doc/dev-log/2026-07-16-line-thickness-scale-separation.md
@@ -1,0 +1,56 @@
+# Separating line thickness from pattern scale
+
+## Problem
+
+The size of a shape's dash pattern and a cloudy /Polygon's scallops were
+both derived from the pen width (`strokeWidth`): `PdfLineStyle.dashArray`
+multiplied its dash units by the stroke, and `_cloudArcRadius` was
+`max(12, strokeWidth * 4)`. So you couldn't have a thin outline with big
+puffs, or a heavy line with tight dashes - thickness and pattern moved
+together.
+
+## Change
+
+A separate **pattern scale** (a multiplier, `1` = the historical look)
+now drives dash and cloud sizing, decoupled from the pen.
+
+- `PdfLineStyle.dashArray(strokeWidth, {scale})` (dart_pdf_editor
+  `line_style.dart`): the dash unit is `max(strokeWidth, max(2, 2*scale*m))`.
+  The scale drives the nominal size; `strokeWidth` only floors each segment
+  so the gaps stay visible under a heavy pen. At `scale: 1` + the default
+  2pt pen the arrays are byte-identical to before.
+- `_cloudArcRadius(strokeWidth, scale)` (pdf_document
+  `annotation_editor.dart`): `max(strokeWidth*4, 12*scale)`. The
+  `strokeWidth*4` term stays only as a crowd-avoidance floor. Threaded
+  through `_cloudPadding`, `_cloudPolygonContent`, `_appendCloudPath`.
+
+## Persistence
+
+Dashes already round-trip: the scaled lengths live in the stored
+`/BS /D` array, so restyle keeps them. Clouds had nowhere to keep the
+scallop size (it was recomputed from the pen on every regenerate), so the
+scale is stored on **`/BE /I`** - the border-effect intensity, which in
+Acrobat already tracks scallop size, so the overload is semantically
+aligned and round-trips. `PdfAnnotation.cloudBorderScale` reads it back
+(default 1). `addPolygon(cloudScale:)` writes it; `reshapeLineAnnotation`
+and `_regenerateLineLikeAppearance` read it; `restyleAnnotation(cloudScale:)`
+updates `/BE /I` before regenerating so the regenerate picks it up.
+
+Latent fix along the way: the line-like restyle regenerate never re-derived
+a cloud's `/Rect` from the padded footprint, so a scallop that grew (a
+bigger pen *or* scale) was clipped by the unchanged form BBox.
+`_regenerateLineLikeAppearance` now recomputes the cloud bounds from the
+points + `_cloudPadding` and rewrites `/Rect` (unrotated path; the rotated
+path re-derives its own local rect as before).
+
+## UI
+
+- `PdfEditingPreferences.lineScale` (persisted, in the tool-style scope
+  memory next to `lineStyle`).
+- `PdfEditingController.lineScale`, `selectedLineScale` (a cloud's
+  `/BE /I`, else null), and `restyleSelected(scale:)` - which recomputes
+  the dash array from the scale (a pen-width change alone no longer
+  resizes the dashes) and updates the cloud `/BE /I`.
+- A **"Pattern scale"** slider (0.5×–4×) in the toolbar style popup and
+  the properties panel, shown wherever the line-type control is
+  (`_StyleFields.lineScale`).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1031,6 +1031,7 @@ class PdfEditingController extends ChangeNotifier {
             'strokeWidth',
             'opacity',
             'lineStyle',
+            'lineScale',
             'shapeFillColor',
           },
         PdfEditTool.line || PdfEditTool.polyline => const {
@@ -1038,6 +1039,7 @@ class PdfEditingController extends ChangeNotifier {
             'strokeWidth',
             'opacity',
             'lineStyle',
+            'lineScale',
             'lineStartEnding',
             'lineEndEnding',
           },
@@ -1045,7 +1047,8 @@ class PdfEditingController extends ChangeNotifier {
             'color',
             'strokeWidth',
             'opacity',
-            'lineStyle'
+            'lineStyle',
+            'lineScale',
           },
         PdfEditTool.measureDistance ||
         PdfEditTool.measurePerimeter ||
@@ -1248,10 +1251,19 @@ class PdfEditingController extends ChangeNotifier {
   set dashedStroke(bool value) =>
       preferences.lineStyle = value ? PdfLineStyle.dashed : PdfLineStyle.solid;
 
+  /// The pattern scale new shape and line annotations are created with - a
+  /// multiplier (1 = default) sizing the dash pattern and cloudy scallops
+  /// *independently* of [strokeWidth], so the line thickness and the
+  /// pattern size are set separately. Persisted.
+  double get lineScale => preferences.lineScale;
+
+  set lineScale(double value) => preferences.lineScale = value;
+
   /// The `/BS /D` dash array new annotations get, for the current
-  /// [lineStyle] at the current [strokeWidth] - null for a solid border.
-  List<double>? get _lineDashPattern =>
-      preferences.lineStyle.dashArray(preferences.strokeWidth);
+  /// [lineStyle] at the current [strokeWidth], sized by [lineScale] - null
+  /// for a solid border.
+  List<double>? get _lineDashPattern => preferences.lineStyle
+      .dashArray(preferences.strokeWidth, scale: preferences.lineScale);
 
   /// The line ending new /Line and /PolyLine annotations carry at their
   /// start vertex (§12.5.6.7). Persisted.
@@ -1379,8 +1391,12 @@ class PdfEditingController extends ChangeNotifier {
   bool _editingText = false;
   TextSelection? _editingTextSelection;
   int _editingTextStyleRevision = 0;
-  ({PdfTextFont? font, double? size, int? color, bool? underline})?
-      _editingTextStyleRequest;
+  ({
+    PdfTextFont? font,
+    double? size,
+    int? color,
+    bool? underline
+  })? _editingTextStyleRequest;
   int _editSelectedTextRevision = 0;
   int _editingTextFocusHoldCount = 0;
   int _editingTextFocusHoldRevision = 0;
@@ -1908,6 +1924,7 @@ class PdfEditingController extends ChangeNotifier {
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
           cloudy: true,
+          cloudScale: preferences.lineScale,
           author: author,
         ),
       );
@@ -4309,6 +4326,17 @@ class PdfEditingController extends ChangeNotifier {
     return PdfLineStyle.ofDashArray(annotation.borderDash);
   }
 
+  /// The primary selected cloudy /Polygon's scallop scale (its `/BE /I`),
+  /// for the pattern-scale control to display, or null when the selection
+  /// isn't a cloud - other shapes bake their pattern scale into the stored
+  /// dash array rather than a readable field, so the control falls back to
+  /// the creation default [lineScale] for them.
+  double? get selectedLineScale {
+    final annotation = selectedAnnotation;
+    if (annotation == null) return null;
+    return annotation.hasCloudyBorder ? annotation.cloudBorderScale : null;
+  }
+
   /// Restyles every selected annotation in place - one revision, one
   /// undo, and the selection survives (annotations keep their /Annots
   /// slots). Parameters follow [PdfEditor.restyleAnnotation]: [color]
@@ -4322,12 +4350,14 @@ class PdfEditingController extends ChangeNotifier {
     double? strokeWidth,
     double? opacity,
     PdfLineStyle? lineStyle,
+    double? scale,
   }) {
     if (color == null &&
         fill == null &&
         strokeWidth == null &&
         opacity == null &&
-        lineStyle == null) {
+        lineStyle == null &&
+        scale == null) {
       return false;
     }
     if (!canRestyleSelected) return false;
@@ -4339,8 +4369,14 @@ class PdfEditingController extends ChangeNotifier {
     return apply(
       (e) {
         for (final (page, annotation) in targets) {
-          // the dash array scales to the (possibly just-changed) pen width
           final width = strokeWidth ?? annotation.borderWidth ?? 1;
+          // Recompute the dash array when the line style *or* the pattern
+          // scale changes - both size it, and the scale is otherwise baked
+          // into the stored array with no readable field. A pen-width change
+          // alone no longer resizes it: thickness and pattern are separate.
+          final style =
+              lineStyle ?? PdfLineStyle.ofDashArray(annotation.borderDash);
+          final recomputeDash = lineStyle != null || scale != null;
           e.restyleAnnotation(
             page,
             annotation,
@@ -4348,8 +4384,10 @@ class PdfEditingController extends ChangeNotifier {
             fillColor: fill == null ? null : (_rgbOf(fill.$1),),
             strokeWidth: strokeWidth,
             opacity: opacity,
-            dashPattern:
-                lineStyle == null ? null : (lineStyle.dashArray(width),),
+            dashPattern: recomputeDash
+                ? (style.dashArray(width, scale: scale ?? lineScale),)
+                : null,
+            cloudScale: scale,
             pageRotation: _page(page).rotation,
           );
         }
@@ -4891,7 +4929,9 @@ class PdfEditingController extends ChangeNotifier {
                     underline: underline)
             ];
       _rewriteSelectedRich(annotation, runs,
-          lineSpacing: lineSpacing, charSpacing: charSpacing, fontWidth: fontWidth);
+          lineSpacing: lineSpacing,
+          charSpacing: charSpacing,
+          fontWidth: fontWidth);
     } else {
       _rewriteSelected(
         annotation,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -57,6 +57,7 @@ class PdfEditingPreferences extends ChangeNotifier {
   PdfTextAlign? _textAlign;
   double _opacity = 1;
   PdfLineStyle _lineStyle = PdfLineStyle.solid;
+  double _lineScale = 1;
   PdfLineEnding _lineStartEnding = PdfLineEnding.none;
   PdfLineEnding _lineEndEnding = PdfLineEnding.none;
   bool _fingerDrawsInk = true;
@@ -147,6 +148,7 @@ class PdfEditingPreferences extends ChangeNotifier {
         _textAlign = PdfTextAlign.values.asNameMap()[textAlign] ?? _textAlign;
       }
       _opacity = store.getDouble('${_prefix}opacity') ?? _opacity;
+      _lineScale = store.getDouble('${_prefix}lineScale') ?? _lineScale;
       final lineStyle = store.getString('${_prefix}lineStyle');
       if (lineStyle != null) {
         _lineStyle = PdfLineStyle.values.asNameMap()[lineStyle] ?? _lineStyle;
@@ -427,6 +429,7 @@ class PdfEditingPreferences extends ChangeNotifier {
         final style = PdfLineStyle.values.asNameMap()[v];
         if (style != null) lineStyle = style;
       }
+      if (slot['lineScale'] case final num v) lineScale = v.toDouble();
       if (slot['lineStartEnding'] case final String v) {
         final ending = PdfLineEnding.values.asNameMap()[v];
         if (ending != null) lineStartEnding = ending;
@@ -480,6 +483,7 @@ class PdfEditingPreferences extends ChangeNotifier {
     put('fontFamily', _fontFamily.name);
     put('textAlign', _textAlign?.name);
     put('lineStyle', _lineStyle.name);
+    put('lineScale', _lineScale);
     put('lineStartEnding', _lineStartEnding.name);
     put('lineEndEnding', _lineEndEnding.name);
     put('textFillColor', _textFillColor?.toARGB32());
@@ -593,6 +597,20 @@ class PdfEditingPreferences extends ChangeNotifier {
     _lineStyle = value;
     _write((s) => s.setString('${_prefix}lineStyle', value.name));
     _recordScoped('lineStyle', value.name);
+    notifyListeners();
+  }
+
+  /// The pattern scale new shape and line annotations are created with - a
+  /// multiplier (1 = default) driving the size of dash patterns and cloudy
+  /// scallops *independently* of [strokeWidth], so the line thickness and
+  /// the pattern size change separately. Persisted.
+  double get lineScale => _lineScale;
+
+  set lineScale(double value) {
+    if (value == _lineScale) return;
+    _lineScale = value;
+    _write((s) => s.setDouble('${_prefix}lineScale', value));
+    _recordScoped('lineScale', value);
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -118,6 +118,7 @@ class _PdfAnnotationPropertiesPanelState
   /// revision, so it lands on release, and the thumb shows the dragged
   /// value meanwhile.
   double? _draggingStroke;
+  double? _draggingScale;
   double? _draggingOpacity;
   double? _draggingFontSize;
   double? _draggingLineSpacing;
@@ -597,6 +598,22 @@ class _PdfAnnotationPropertiesPanelState
             },
           ),
         ]),
+      ));
+      children.add(_sliderRow(
+        'Scale',
+        _draggingScale ??
+            _controller.selectedLineScale ??
+            _controller.lineScale,
+        key: const ValueKey('pdf-prop-line-scale'),
+        min: 0.5,
+        max: 4,
+        display: (v) => '${v.toStringAsFixed(1)}×',
+        onChanged: (v) => setState(() => _draggingScale = v),
+        onChangeEnd: (v) {
+          _controller.lineScale = v;
+          _controller.restyleSelected(scale: v);
+          setState(() => _draggingScale = null);
+        },
       ));
     }
     if (_controller.canSetLineEndings) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1993,6 +1993,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           stroke: true,
           opacity: true,
           lineType: true,
+          lineScale: true,
           lineEndings: tool == PdfEditTool.line || tool == PdfEditTool.polyline,
           shapeFill: tool == PdfEditTool.rectangle ||
               tool == PdfEditTool.ellipse ||
@@ -2045,6 +2046,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             // a /Polygon area measurement carries a caption font
             font: controller.canRestyleMeasurementCaption,
             lineType: controller.canSetLineStyleSelected,
+            lineScale: controller.canSetLineStyleSelected,
             shapeFill: controller.canFillSelected);
       case 'Line':
       case 'PolyLine':
@@ -2054,6 +2056,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             // a measurement (/Line distance, /PolyLine perimeter) carries one
             font: controller.canRestyleMeasurementCaption,
             lineType: controller.canSetLineStyleSelected,
+            lineScale: controller.canSetLineStyleSelected,
             lineEndings: controller.canSetLineEndings);
       case 'Ink':
         return _StyleFields(
@@ -3147,6 +3150,7 @@ class _StyleFields {
     this.stroke = false,
     this.opacity = false,
     this.lineType = false,
+    this.lineScale = false,
     this.lineEndings = false,
     this.font = false,
     this.boxColors = false,
@@ -3161,6 +3165,10 @@ class _StyleFields {
   /// The line-type dropdown (solid / dashed / dotted / dash-dot) - shapes
   /// and the line family.
   final bool lineType;
+
+  /// The pattern-scale slider - sizes dash patterns and cloudy scallops
+  /// apart from the pen width. Shown alongside [lineType].
+  final bool lineScale;
   final bool lineEndings;
 
   /// Font size + family (free text).
@@ -3183,6 +3191,7 @@ class _StyleFields {
       !stroke &&
       !opacity &&
       !lineType &&
+      !lineScale &&
       !lineEndings &&
       !font &&
       !boxColors &&
@@ -3242,6 +3251,7 @@ class _StyleMenuState extends State<_StyleMenu> {
   /// Same, for the stroke-width and opacity sliders restyling a
   /// selected annotation.
   double? _draggingStroke;
+  double? _draggingScale;
   double? _draggingOpacity;
   double? _draggingLineSpacing;
   double? _draggingCharSpacing;
@@ -3564,6 +3574,31 @@ class _StyleMenuState extends State<_StyleMenu> {
                         ],
                       ),
                     ),
+                  if (fields.lineScale)
+                    _slider(
+                      key: const ValueKey('pdf-line-scale'),
+                      label: 'Pattern scale',
+                      value: _draggingScale ??
+                          (restylingAnnotation
+                              ? (controller.selectedLineScale ??
+                                  controller.lineScale)
+                              : controller.lineScale),
+                      min: 0.5,
+                      max: 4,
+                      display: (v) => '${v.toStringAsFixed(1)}×',
+                      onChanged: (v) {
+                        setState(() => _draggingScale = v);
+                        if (!restylingAnnotation) controller.lineScale = v;
+                      },
+                      onChangeEnd: (v) {
+                        controller.lineScale = v;
+                        if (restylingAnnotation &&
+                            controller.canSetLineStyleSelected) {
+                          controller.restyleSelected(scale: v);
+                        }
+                        setState(() => _draggingScale = null);
+                      },
+                    ),
                   if (fields.lineEndings) ...[
                     _lineEndingRow(
                       context: context,
@@ -3689,12 +3724,12 @@ class _StyleMenuState extends State<_StyleMenu> {
                           key: const ValueKey('pdf-text-underline'),
                           icon: const Icon(Icons.format_underlined, size: 18),
                           tooltip: 'Underline',
-                          isSelected: controller.selectedFreeTextStyle
-                                  ?.underline ??
-                              controller.textUnderline,
+                          isSelected:
+                              controller.selectedFreeTextStyle?.underline ??
+                                  controller.textUnderline,
                           onPressed: () => controller.setSelectedTextBoxStyle(
-                              underline: !(controller.selectedFreeTextStyle
-                                      ?.underline ??
+                              underline: !(controller
+                                      .selectedFreeTextStyle?.underline ??
                                   controller.textUnderline)),
                         ),
                       ]),
@@ -3737,8 +3772,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                         key: const ValueKey('pdf-text-font-width'),
                         label: 'Font width',
                         value: _draggingFontWidth ??
-                            controller
-                                .selectedFreeTextStyle?.horizontalScale ??
+                            controller.selectedFreeTextStyle?.horizontalScale ??
                             controller.fontWidth,
                         min: 50,
                         max: 200,

--- a/packages/dart_pdf_editor/lib/src/editing/line_style.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/line_style.dart
@@ -17,11 +17,17 @@ enum PdfLineStyle {
         PdfLineStyle.dashDot => 'Dash-dot',
       };
 
-  /// The `/BS /D` dash array for this style at [strokeWidth], or null for
-  /// [solid]. Lengths scale with the pen width, with a 2pt floor so thin
-  /// lines still read as dashed.
-  List<double>? dashArray(double strokeWidth) {
-    double u(double m) => math.max(2, strokeWidth * m);
+  /// The `/BS /D` dash array for this style, or null for [solid].
+  ///
+  /// The pattern size is driven by [scale] (a multiplier, 1 = the default
+  /// look) *independently* of the pen [strokeWidth] - so a thin line can
+  /// carry big dashes, or a heavy line tight ones. [strokeWidth] still sets
+  /// a floor on each segment so the gaps stay visible under a heavy pen
+  /// (round/projecting caps would otherwise swallow them). At `scale: 1`
+  /// and the default 2pt pen the arrays match the historical
+  /// width-proportional values.
+  List<double>? dashArray(double strokeWidth, {double scale = 1}) {
+    double u(double m) => math.max(strokeWidth, math.max(2, 2 * scale * m));
     return switch (this) {
       PdfLineStyle.solid => null,
       PdfLineStyle.dashed => [u(3), u(2)],

--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -258,6 +258,26 @@ void main() {
       expect(editing.selectedAnnotation!.borderWidth, width);
     });
 
+    testWidgets('the pattern-scale slider rescales a selected cloud',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addCloudPolygon(0, const PdfRect(100, 500, 300, 620));
+      addTearDown(editing.dispose);
+      await pumpPanel(tester, editing);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      // the scale row shows the cloud's current /BE /I (1×) and drives it
+      final scale = find.byKey(const ValueKey('pdf-prop-line-scale'));
+      expect(scale, findsOneWidget);
+      expect(editing.selectedLineScale, closeTo(1, 1e-9));
+
+      await tester.drag(scale, const Offset(60, 0));
+      await tester.pump();
+      expect(editing.selectedLineScale, greaterThan(1));
+      expect(editing.selectedAnnotation!.hasCloudyBorder, isTrue);
+    });
+
     testWidgets('typing an exact value into a slider readout commits it',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1))

--- a/packages/dart_pdf_editor/test/editing_shape_resize_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_resize_test.dart
@@ -113,8 +113,7 @@ void main() {
 
   testWidgets('a dashed shape uses the committed dash in its resize preview',
       (tester) async {
-    final editing =
-        await pumpOverlay(tester, shape: 'Square', dashed: true);
+    final editing = await pumpOverlay(tester, shape: 'Square', dashed: true);
     final origin = tester.getTopLeft(find.byType(EditingPageOverlay));
     final corner = origin + const Offset(150, 121);
 
@@ -125,12 +124,13 @@ void main() {
 
     final shapeResize = overlayPainter(tester).shapeResize;
     expect(shapeResize, isNotNull);
-    // 4pt pen => [12, 8]pt /BS /D; the 0.5 px/pt view scales it once.
-    expect(shapeResize.dashPattern, [6.0, 4.0]);
+    // the dash size is driven by the pattern scale (1×), not the pen: a
+    // dashed shape => [6, 4]pt /BS /D; the 0.5 px/pt view scales it once.
+    expect(shapeResize.dashPattern, [3.0, 2.0]);
 
     await gesture.up();
     await tester.pump(const Duration(milliseconds: 400));
-    expect(editing.document.page(0).annotations.single.borderDash, [12.0, 8.0]);
+    expect(editing.document.page(0).annotations.single.borderDash, [6.0, 4.0]);
   });
 
   testWidgets(

--- a/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
@@ -13,8 +13,7 @@ void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
   group('line style (dash) on the controller', () {
-    test('a non-solid line style stores a /BS /D dash array on new shapes',
-        () {
+    test('a non-solid line style stores a /BS /D dash array on new shapes', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..lineStyle = PdfLineStyle.dashed;
       addTearDown(editing.dispose);
@@ -51,6 +50,60 @@ void main() {
         expect(PdfLineStyle.ofDashArray(style.dashArray(3)), style);
       }
     });
+
+    test('the pattern scale sizes the dash array apart from the pen width', () {
+      // Same style, same pen width: a bigger scale means bigger dashes.
+      final small = PdfLineStyle.dashed.dashArray(1, scale: 1)!;
+      final big = PdfLineStyle.dashed.dashArray(1, scale: 2)!;
+      expect(big.first, greaterThan(small.first));
+      // Changing only the pen width leaves the pattern alone.
+      final thin = PdfLineStyle.dashed.dashArray(1, scale: 1.5)!;
+      final thick = PdfLineStyle.dashed.dashArray(1, scale: 1.5)!;
+      expect(thick, thin);
+    });
+
+    test('the pattern scale drives new shapes and is independent of stroke',
+        () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..lineStyle = PdfLineStyle.dashed
+        ..strokeWidth = 1
+        ..lineScale = 1;
+      addTearDown(editing.dispose);
+      editing.addRectangle(0, const PdfRect(100, 100, 300, 200));
+      final narrow =
+          editing.document.page(0).annotations.single.borderDash!.first;
+
+      editing
+        ..lineScale = 3
+        ..addRectangle(0, const PdfRect(100, 300, 300, 400));
+      final wide = editing.document.page(0).annotations.last.borderDash!.first;
+      expect(wide, greaterThan(narrow));
+    });
+  });
+
+  group('pattern scale on clouds', () {
+    test('a cloud drawn at a bigger scale stores it on /BE /I', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..lineScale = 2.5;
+      addTearDown(editing.dispose);
+      editing.addCloudPolygon(0, const PdfRect(100, 100, 300, 200));
+      final cloud = editing.document.page(0).annotations.single;
+      expect(cloud.hasCloudyBorder, isTrue);
+      expect(cloud.cloudBorderScale, closeTo(2.5, 1e-9));
+    });
+
+    test('restyleSelected(scale:) rescales a selected cloud', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing
+        ..addCloudPolygon(0, const PdfRect(100, 100, 300, 200))
+        ..selectAnnotation(0, 0);
+      expect(editing.selectedLineScale, closeTo(1, 1e-9));
+      expect(editing.restyleSelected(scale: 3), isTrue);
+      expect(editing.document.page(0).annotations.single.cloudBorderScale,
+          closeTo(3, 1e-9));
+      expect(editing.selectedLineScale, closeTo(3, 1e-9));
+    });
   });
 
   group('polygon fill', () {
@@ -59,8 +112,8 @@ void main() {
         ..shapeFillColor = const Color(0xFF80C0FF);
       addTearDown(editing.dispose);
       editing.addPolygon(0, const [(100, 100), (200, 180), (160, 100)]);
-      expect(editing.document.page(0).annotations.single.interiorColor,
-          0x80C0FF);
+      expect(
+          editing.document.page(0).annotations.single.interiorColor, 0x80C0FF);
     });
 
     test('canFillSelected and restyleSelected fill cover polygons', () {
@@ -70,16 +123,14 @@ void main() {
         ..addPolygon(0, const [(100, 100), (200, 180), (160, 100)])
         ..selectAnnotation(0, 0);
       expect(editing.canFillSelected, isTrue);
+      expect(editing.restyleSelected(fill: (const Color(0xFF112233),)), isTrue);
       expect(
-          editing.restyleSelected(fill: (const Color(0xFF112233),)), isTrue);
-      expect(editing.document.page(0).annotations.single.interiorColor,
-          0x112233);
+          editing.document.page(0).annotations.single.interiorColor, 0x112233);
     });
   });
 
   group('cross-page annotation move', () {
-    test('moveSelectedToPage re-homes the annotation onto the target page',
-        () {
+    test('moveSelectedToPage re-homes the annotation onto the target page', () {
       final editing = PdfEditingController(buildMultiPagePdf(2));
       addTearDown(editing.dispose);
       editing

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -1298,11 +1298,11 @@ void main() {
       // scope to the popup's sliders - the strip also has an inline opacity
       final menuSliders = find.descendant(
           of: find.byType(MenuAnchor), matching: find.byType(Slider));
-      // the shapes popup carries stroke width + opacity (font is irrelevant
-      // to a rectangle, so it's no longer shown)
-      expect(menuSliders, findsNWidgets(2));
+      // the shapes popup carries stroke width, opacity, and the pattern
+      // scale (font is irrelevant to a rectangle, so it's not shown)
+      expect(menuSliders, findsNWidgets(3));
 
-      // sliders are laid out stroke width, opacity
+      // sliders are laid out stroke width, opacity, pattern scale
       await tester.drag(menuSliders.at(0), const Offset(200, 0));
       await tester.pump();
       expect(editing.strokeWidth, greaterThan(2));
@@ -1310,6 +1310,13 @@ void main() {
       await tester.drag(menuSliders.at(1), const Offset(-200, 0));
       await tester.pump();
       expect(editing.opacity, lessThan(1));
+
+      // the pattern scale is independent of the pen width
+      final beforeStroke = editing.strokeWidth;
+      await tester.drag(menuSliders.at(2), const Offset(200, 0));
+      await tester.pump();
+      expect(editing.lineScale, greaterThan(1));
+      expect(editing.strokeWidth, beforeStroke);
       await tester.pumpAndSettle();
     });
 

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -279,6 +279,17 @@ class PdfAnnotation {
     return style is CosName && style.value == 'Cloudy';
   }
 
+  /// The cloud scallop scale carried on `/BE /I` (§12.5.4) - the border
+  /// effect intensity, which the editor also uses as a puff-size multiplier
+  /// so a cloud's scallop size survives a restyle or reshape independently
+  /// of its stroke width. Defaults to 1 when absent or not cloudy.
+  double get cloudBorderScale {
+    final be = document.cos.resolve(dict['BE']);
+    if (be is! CosDictionary) return 1;
+    final intensity = _number(document.cos.resolve(be['I']));
+    return intensity == null || intensity <= 0 ? 1 : intensity;
+  }
+
   /// The endpoints of a /Line annotation, page space.
   ((double, double), (double, double))? get line {
     if (subtype != 'Line') return null;
@@ -600,8 +611,8 @@ class PdfAnnotation {
       lineSpacing:
           number(kPdfFreeTextLineSpacingKey) ?? kPdfFreeTextDefaultLineSpacing,
       charSpacing: number(kPdfFreeTextCharSpacingKey) ?? 0,
-      horizontalScale: number(kPdfFreeTextHScaleKey) ??
-          kPdfFreeTextDefaultHorizontalScale,
+      horizontalScale:
+          number(kPdfFreeTextHScaleKey) ?? kPdfFreeTextDefaultHorizontalScale,
       underline: underlineFlag is CosBoolean && underlineFlag.value,
     );
   }

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -58,8 +58,8 @@ const double _defaultHorizontalScale = kPdfFreeTextDefaultHorizontalScale;
 /// One underline segment recorded while a free-text line is laid out, drawn
 /// as a filled rectangle after the enclosing text object closes.
 class _UnderlineRun {
-  const _UnderlineRun(this.x, this.baseline, this.width, this.fontSize,
-      this.color);
+  const _UnderlineRun(
+      this.x, this.baseline, this.width, this.fontSize, this.color);
 
   final double x;
   final double baseline;
@@ -1133,6 +1133,7 @@ extension PdfAnnotationEditing on PdfEditor {
     double opacity = 1,
     List<double>? dashPattern,
     bool cloudy = false,
+    double cloudScale = 1,
     String? contents,
     String? author,
     String? name,
@@ -1142,7 +1143,9 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     final rect = _pointBounds(
       vertices,
-      cloudy ? _cloudPadding(strokeWidth) : _linePadding(strokeWidth),
+      cloudy
+          ? _cloudPadding(strokeWidth, cloudScale)
+          : _linePadding(strokeWidth),
     );
     final gs = _alphaState(opacity);
     final w = cloudy
@@ -1150,6 +1153,7 @@ extension PdfAnnotationEditing on PdfEditor {
             vertices,
             strokeColor: strokeColor,
             strokeWidth: strokeWidth,
+            cloudScale: cloudScale,
             dashPattern: dashPattern,
             fillColor: fillColor,
             hasAlpha: gs != null,
@@ -1169,7 +1173,7 @@ extension PdfAnnotationEditing on PdfEditor {
     if (cloudy) {
       dict['BE'] = CosDictionary({
         'S': const CosName('Cloudy'),
-        'I': const CosReal(1),
+        'I': CosReal(cloudScale),
       });
     }
     if (fillColor != null) dict['IC'] = _colorComponents(fillColor);
@@ -2433,8 +2437,8 @@ extension PdfAnnotationEditing on PdfEditor {
           font: _richSpanFont(style, fallbackFont),
           fontSize: _richSpanSize(style) ?? fallbackSize,
           color: _richSpanColor(style) ?? fallbackColor,
-          underline: RegExp(r'text-decoration\s*:\s*[^;]*underline')
-              .hasMatch(style),
+          underline:
+              RegExp(r'text-decoration\s*:\s*[^;]*underline').hasMatch(style),
         ),
       );
     }
@@ -3602,6 +3606,7 @@ extension PdfAnnotationEditing on PdfEditor {
     if (stroke == null || width <= 0) return;
     final dashed = annotation.borderDash != null;
     final cloudy = subtype == 'Polygon' && annotation.hasCloudyBorder;
+    final cloudScale = annotation.cloudBorderScale;
     final fill = subtype == 'Polygon' ? annotation.interiorColor : null;
     final endings = _lineEndings(annotation);
     final endingPoints = subtype == 'Polygon'
@@ -3615,10 +3620,14 @@ extension PdfAnnotationEditing on PdfEditor {
               width,
             ),
           ];
-    final rect = _pointBounds([
-      ...points,
-      ...endingPoints,
-    ], cloudy ? _cloudPadding(width) : _linePadding(width, dashed: dashed));
+    final rect = _pointBounds(
+        [
+          ...points,
+          ...endingPoints,
+        ],
+        cloudy
+            ? _cloudPadding(width, cloudScale)
+            : _linePadding(width, dashed: dashed));
     final form = annotation.normalAppearance;
     final gs = _alphaState(form == null ? 1 : _appearanceOpacity(form));
     final w = cloudy
@@ -3626,6 +3635,7 @@ extension PdfAnnotationEditing on PdfEditor {
             points,
             strokeColor: stroke,
             strokeWidth: width,
+            cloudScale: cloudScale,
             dashPattern: annotation.borderDash,
             fillColor: fill,
             hasAlpha: gs != null,
@@ -4239,9 +4249,8 @@ extension PdfAnnotationEditing on PdfEditor {
         final stdFont = behavior.standardTextFont;
         // an embedded/bundled-font box re-wraps in its own recovered face
         // rather than reverting to Helvetica or stretching its glyphs
-        final embedded = stdFont == null
-            ? PdfEmbeddedFont.fromFreeText(annotation)
-            : null;
+        final embedded =
+            stdFont == null ? PdfEmbeddedFont.fromFreeText(annotation) : null;
         if (stdFont == null && embedded == null) return false;
         final text = annotation.contents ?? '';
         final callout = _calloutInfo(annotation);
@@ -4427,11 +4436,15 @@ extension PdfAnnotationEditing on PdfEditor {
         annotation.subtype == 'Polygon' ? annotation.interiorColor : null;
     final endings = _lineEndings(annotation);
     final gs = _alphaState(opacity ?? _appearanceOpacity(form));
-    final w = annotation.subtype == 'Polygon' && annotation.hasCloudyBorder
+    final cloudy =
+        annotation.subtype == 'Polygon' && annotation.hasCloudyBorder;
+    final cloudScale = annotation.cloudBorderScale;
+    final w = cloudy
         ? _cloudPolygonContent(
             points,
             strokeColor: stroke,
             strokeWidth: width,
+            cloudScale: cloudScale,
             dashPattern: annotation.borderDash,
             fillColor: fill,
             hasAlpha: gs != null,
@@ -4447,11 +4460,18 @@ extension PdfAnnotationEditing on PdfEditor {
             endEnding: endings.$2,
             hasAlpha: gs != null,
           );
+    // The scallops' size (pen width and cloud scale both drive it) can widen
+    // past the stored /Rect, so re-derive the cloud's bounds from the padded
+    // footprint - otherwise the form BBox clips the outer half of each puff
+    // after a restyle.
+    final base =
+        cloudy ? _pointBounds(points, _cloudPadding(width, cloudScale)) : rect;
+    if (cloudy) annotation.dict['Rect'] = _rectArray(base);
     // A measurement carries a caption drawn over the line; regenerate it
     // too (recovering its font/size/color from /DA) so a width or style
     // change never drops the label, widening the BBox/Rect to keep it
     // unclipped.
-    final (bbox, font) = _appendMeasurementCaption(annotation, rect, points, w);
+    final (bbox, font) = _appendMeasurementCaption(annotation, base, points, w);
     _replaceAppearance(
       annotation.dict,
       form,
@@ -4500,6 +4520,7 @@ extension PdfAnnotationEditing on PdfEditor {
     double? strokeWidth,
     double? opacity,
     (List<double>?,)? dashPattern,
+    double? cloudScale,
     int? pageRotation,
   }) {
     final effectivePageRotation = _appearancePageRotation(
@@ -4510,7 +4531,8 @@ extension PdfAnnotationEditing on PdfEditor {
         fillColor == null &&
         strokeWidth == null &&
         opacity == null &&
-        dashPattern == null) {
+        dashPattern == null &&
+        cloudScale == null) {
       return false;
     }
     final behavior = annotation.behavior;
@@ -4610,6 +4632,12 @@ extension PdfAnnotationEditing on PdfEditor {
             dict['IC'] = _colorComponents(fill);
           } else {
             dict.entries.remove('IC');
+          }
+          // a new cloud scale rides on /BE /I; the regenerate below reads it
+          // back through PdfAnnotation.cloudBorderScale
+          if (cloudScale != null && annotation.hasCloudyBorder) {
+            final be = document.cos.resolve(dict['BE']);
+            if (be is CosDictionary) be['I'] = CosReal(cloudScale);
           }
         }
         return _restyleRegenerate(pageIndex, dict, opacity: opacity);
@@ -5235,11 +5263,14 @@ extension PdfAnnotationEditing on PdfEditor {
   /// puffs (with cusps between them) instead of flat half-circles.
   static const double _cloudBulgeFactor = 1.15;
 
-  /// Target radius of one cloud scallop, in page points. Independent of the
-  /// (usually hairline) stroke so the puffs stay fluffy; grows only when the
-  /// stroke itself is heavy enough to crowd them.
-  double _cloudArcRadius(double strokeWidth) =>
-      math.max(12.0, strokeWidth * 4.0);
+  /// Target radius of one cloud scallop, in page points. Its size is driven
+  /// by [scale] (a multiplier, 1 = the default puff) *independently* of the
+  /// pen so the line thickness and the scallop size change separately; a
+  /// heavy stroke still raises a floor so the puffs never crowd narrower
+  /// than the pen can draw them. At `scale: 1` and the default 2pt pen this
+  /// matches the historical `max(12, strokeWidth * 4)`.
+  double _cloudArcRadius(double strokeWidth, double scale) =>
+      math.max(strokeWidth * 4.0, 12.0 * scale);
 
   /// Padding for the cloud's `/Rect` and form BBox. A scallop's apex sits
   /// `_cloudArcRadius * _cloudBulgeFactor` past the polygon edge (plus half
@@ -5248,15 +5279,17 @@ extension PdfAnnotationEditing on PdfEditor {
   /// by only `pad / 2 + 1`, so the padding is doubled here; otherwise the
   /// form BBox clips the outer half of every puff (the scallops render as
   /// flattened brackets at the edges).
-  double _cloudPadding(double strokeWidth) => math.max(
+  double _cloudPadding(double strokeWidth, double scale) => math.max(
         _linePadding(strokeWidth),
-        2 * _cloudArcRadius(strokeWidth) * _cloudBulgeFactor + strokeWidth,
+        2 * _cloudArcRadius(strokeWidth, scale) * _cloudBulgeFactor +
+            strokeWidth,
       );
 
   ContentWriter _cloudPolygonContent(
     List<(double, double)> points, {
     required int strokeColor,
     required double strokeWidth,
+    required double cloudScale,
     required List<double>? dashPattern,
     required int? fillColor,
     required bool hasAlpha,
@@ -5275,7 +5308,7 @@ extension PdfAnnotationEditing on PdfEditor {
       ..lineCap(1)
       ..lineJoin(1);
     if (dashed) w.dash(dashPattern);
-    _appendCloudPath(w, points, strokeWidth);
+    _appendCloudPath(w, points, strokeWidth, cloudScale);
     if (fillColor != null) {
       w.fillAndStroke();
     } else {
@@ -5289,10 +5322,11 @@ extension PdfAnnotationEditing on PdfEditor {
     ContentWriter w,
     List<(double, double)> points,
     double strokeWidth,
+    double cloudScale,
   ) {
     if (points.length < 3) return;
     final clockwise = _signedArea(points) < 0;
-    final arc = _cloudArcRadius(strokeWidth);
+    final arc = _cloudArcRadius(strokeWidth, cloudScale);
     const k = 0.5522847498307936;
     var first = true;
     for (var i = 0; i < points.length; i++) {

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -1132,6 +1132,7 @@ void main() {
         _ => throw StateError('not a number: $r'),
       };
     }
+
     final bx0 = num(bbox[0]);
     final by0 = num(bbox[1]);
     final bx1 = num(bbox[2]);
@@ -1182,6 +1183,76 @@ void main() {
     // and the puffs really do bulge out past the polygon vertices
     expect(maxY, greaterThan(640));
     expect(minY, lessThan(500));
+  });
+
+  test('a cloud scale rides on /BE /I and bulges bigger scallops', () {
+    // The scallop size is driven by cloudScale, independent of the pen.
+    Iterable<double> puffExtent(double scale) {
+      final doc = roundTrip((e) {
+        e.addPolygon(
+          0,
+          [(120, 500), (420, 500), (420, 640), (120, 640)],
+          strokeWidth: 2,
+          cloudy: true,
+          cloudScale: scale,
+        );
+      });
+      final annotation = doc.page(0).annotations.single;
+      expect(annotation.cloudBorderScale, closeTo(scale, 1e-9));
+      final be = doc.cos.resolve(annotation.dict['BE']) as CosDictionary;
+      expect((doc.cos.resolve(be['I']) as CosReal).value, closeTo(scale, 1e-9));
+      // how far the /Rect balloons past the polygon footprint - a proxy for
+      // the scallop bulge
+      return [
+        120 - annotation.rect.left,
+        annotation.rect.right - 420,
+        annotation.rect.top - 640,
+      ];
+    }
+
+    final small = puffExtent(1).toList();
+    final big = puffExtent(2.5).toList();
+    for (var i = 0; i < small.length; i++) {
+      expect(big[i], greaterThan(small[i]));
+    }
+  });
+
+  test('restyling a cloud preserves its scale across a colour change', () {
+    final doc = roundTrip((e) {
+      e.addPolygon(
+        0,
+        [(120, 500), (420, 500), (420, 640), (120, 640)],
+        strokeWidth: 2,
+        cloudy: true,
+        cloudScale: 2.5,
+      );
+    });
+    final editor = PdfEditor(doc)
+      ..restyleAnnotation(0, doc.page(0).annotations.single, color: 0x123456);
+    final reopened = PdfDocument.open(editor.save());
+    final annotation = reopened.page(0).annotations.single;
+    expect(annotation.hasCloudyBorder, isTrue);
+    expect(annotation.cloudBorderScale, closeTo(2.5, 1e-9));
+    // and the puffs are still the wider ones the scale asked for
+    expect(annotation.rect.top - 640, greaterThan(20));
+  });
+
+  test('restyleAnnotation cloudScale resizes the scallops', () {
+    final doc = roundTrip((e) {
+      e.addPolygon(
+        0,
+        [(120, 500), (420, 500), (420, 640), (120, 640)],
+        strokeWidth: 2,
+        cloudy: true,
+      );
+    });
+    final before = doc.page(0).annotations.single.rect.top - 640;
+    final editor = PdfEditor(doc)
+      ..restyleAnnotation(0, doc.page(0).annotations.single, cloudScale: 3);
+    final reopened = PdfDocument.open(editor.save());
+    final annotation = reopened.page(0).annotations.single;
+    expect(annotation.cloudBorderScale, closeTo(3, 1e-9));
+    expect(annotation.rect.top - 640, greaterThan(before));
   });
 
   test('resizing a dashed arrow regenerates with scaled endpoints', () {
@@ -1462,8 +1533,8 @@ void main() {
     final editor = PdfEditor(doc)
       ..resizeAnnotation(0, box, const PdfRect(100, 600, 500, 640));
     final reopened = PdfDocument.open(editor.save());
-    expect(reopened.page(0).annotations.single.freeTextStyle!.underline,
-        isTrue);
+    expect(
+        reopened.page(0).annotations.single.freeTextStyle!.underline, isTrue);
   });
 
   test('rich free text carries per-run underline through /RC', () {


### PR DESCRIPTION
## Summary

Line thickness and pattern size are now set separately. Previously the size of a shape's dash pattern and a cloudy `/Polygon`'s scallops were both derived from the pen width, so you couldn't have a thin outline with big puffs, or a heavy line with tight dashes — thickness and pattern moved together.

A new **pattern scale** multiplier (1× = the historical look) drives dash and cloud sizing independently of the stroke width:

- **`line_style.dart`**: `dashArray(strokeWidth, {scale})` sizes the dash unit from the scale, flooring each segment at the pen width so gaps stay visible under a heavy pen. At `scale: 1` and the default 2pt pen the arrays are byte-identical to before.
- **`annotation_editor.dart`**: `_cloudArcRadius(strokeWidth, scale) = max(strokeWidth*4, 12*scale)` (the `*4` term stays only as a crowd-avoidance floor), threaded through cloud padding/content/path. The scale persists on `/BE /I` (`PdfAnnotation.cloudBorderScale`) so a restyle or reshape reproduces it; `restyleAnnotation` gains a `cloudScale` param. Along the way, the line-like restyle regenerate now re-derives a cloud's `/Rect` from the padded footprint — fixing a latent clip when scallops grow (a bigger pen *or* scale).
- **Preferences / controller**: persisted `lineScale`, `selectedLineScale` (a cloud's `/BE /I`, else null), and `restyleSelected(scale:)`. A pen-width change alone no longer resizes the dashes.
- **UI**: a "Pattern scale" slider (0.5×–4×) in the toolbar style popup and the properties panel, shown wherever the line-type control is.

See `doc/dev-log/2026-07-16-line-thickness-scale-separation.md` for the design rationale.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Editing behavior change

Note: at the default pen this is behavior-preserving; the change is that dash/cloud pattern size no longer scales with pen width unless the new scale is changed.

## Validation

- [x] `fvm dart analyze` (clean across the workspace)
- [x] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Not run: Ghent/corpus and example-app smoke tests — this change only affects annotation-authoring appearance generation, covered by the new and existing programmatic tests.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Parsers remain lenient on input and writers strict on output (`cloudBorderScale` defaults to 1 when `/BE /I` is absent or non-positive).
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

- The cloud scale is stored on `/BE /I` (border-effect intensity), which in Acrobat already tracks scallop size — so the overload is semantically aligned and round-trips through our own renderer, degrading gracefully in others.
- Dash patterns need no new field: their scaled lengths already live in the stored `/BS /D` array, so a restyle preserves them.
- The rotated-cloud restyle path re-derives its own local rect as before; only the common unrotated path gains the `/Rect` re-derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfAnMChPgPb8qTaSy5AtbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfAnMChPgPb8qTaSy5AtbG)_