### PR TITLE
Allow recolouring vector snapshots from the context menu

### DIFF
--- a/doc/dev-log/2026-07-16-vector-snapshot-recolour.md
+++ b/doc/dev-log/2026-07-16-vector-snapshot-recolour.md
@@ -1,0 +1,73 @@
+# Vector snapshot recolour on the context menu
+
+The Snapshot tool captures a page region as detached **vector** graphics and
+pastes it back as a `/Stamp` whose appearance draws a captured `/Cap` Form
+XObject (`vector_snapshot.dart`). Those pastes keep the source page's own
+colours, and the generic restyle path can't touch them: a content-less
+`/Stamp` has `canRestyle == false`, and the Stamp restyle branch would rebuild
+it as a *text* stamp, destroying the picture. So snapshots had no way to be
+recoloured. This adds one, from the annotation context menu.
+
+## What changed
+
+- **`pdf_document/lib/src/vector_snapshot.dart`**
+  - `pasteVectorSnapshot` now stamps the annotation with a
+    `/DartPdfVectorSnapshot true` marker (mirrors the `DartPdfStampType`
+    marker pattern) so a pasted snapshot is distinguishable from an ordinary
+    stamp.
+  - `isVectorSnapshotStamp(annotation)` - the gate.
+  - `recolorVectorSnapshot(pageIndex, annotation, rgb)` - retints the captured
+    graphics to a single ink (a monochrome silhouette, the Bluebeam-style
+    "recolor a snapshot"). It builds a recoloured **copy** of the `/Cap` form
+    and points *this* annotation's appearance at it, so other pastes that
+    share the original captured form are untouched. Idempotent - recolouring
+    again just retints. The geometry (the appearance's `cm`/`/Matrix`) is left
+    alone, so resize/rotate state survives; only the nested `/Cap` reference is
+    swapped and the appearance form re-serialized via `_updater.markChanged`.
+  - `_recoloredForm` recurses into nested Form XObjects the capture draws
+    (copying each once through a `done` map, cycle-guarded by `visiting`) so
+    forms that set their own colours recolour too.
+  - `_recolorContentBytes` rewrites the content stream: every fill colour op
+    (`g`/`rg`/`k`/`sc`/`scn`) → `rg` target, every stroke op
+    (`G`/`RG`/`K`/`SC`/`SCN`) → `RG` target, and `cs`/`CS` dropped (moot once
+    everything is DeviceRGB). It **prepends** a forced initial ink for both
+    paint sides so colour-less paths that rely on the default black recolour
+    too - without that, black line art would be a no-op. Reuses
+    `ContentStreamParser`/`ContentStreamSerializer` from pdf_cos.
+
+  Documented limitation: embedded raster images, inline images, and shadings
+  keep their own colours - they aren't vector fills. Patterns collapse to the
+  solid ink (a `scn`/`SCN` with a name operand is replaced too).
+
+- **`dart_pdf_editor` `editing_controller.dart`**: `canRecolorSnapshotSelected`
+  (every selected annotation is a vector snapshot) + `recolorSnapshotSelected`
+  (one revision, one undo, selection kept), following the `restyleSelected`
+  shape.
+
+- **`dart_pdf_editor` `editing_menu.dart`**: a stock **"Recolour…"** entry
+  (`pdf-annot-menu-recolor-snapshot`) shown only when
+  `canRecolorSnapshotSelected`. It opens `showPdfColorPicker` (persisting the
+  format via prefs, like the other pickers) and applies the pick.
+
+## Gotchas
+
+- Recolour deliberately does **not** go through `restyleAnnotation`: for a
+  Stamp that path regenerates a *text* appearance and would wipe the vectors.
+  The snapshot recolour is its own operator-rewrite over the captured form.
+- Copy, don't mutate: pastes of one snapshot share the `/Cap` object, so the
+  recolour has to fork a private copy or every sibling paste would change. The
+  appearance's own `/Resources /XObject` dict *is* per-paste, so swapping its
+  `Cap` entry and `markChanged`-ing the appearance form is enough to isolate.
+
+## Tests
+
+- `pdf_document/test/vector_snapshot_test.dart` (new `recolour` group): marker
+  set on paste; ordinary stamps rejected; forced-ink prepend recolours
+  default-black text; existing fill/stroke colours rewritten (via a small
+  inline colour PDF); recolour isolated from a shared paste; and the
+  cross-revision path (paste, save, reopen, recolour).
+- `dart_pdf_editor/test/editing_snapshot_test.dart`: controller
+  `recolorSnapshotSelected` retints; a non-snapshot selection is rejected.
+- `dart_pdf_editor/test/editing_menu_test.dart`: the "Recolour…" entry shows
+  only for a snapshot selection, and picking it opens the colour dialog and
+  lands a revision.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4358,6 +4358,44 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   // ---------------------------------------------------------------------
+  // vector snapshot recolour
+
+  /// Whether every selected annotation is a pasted vector snapshot, so
+  /// [recolorSnapshotSelected] can retint them as vectors. Vector snapshots
+  /// keep the captured page's own colours, which the generic restyle path
+  /// ([canRestyleSelected]) can't rewrite, so they get their own recolour.
+  bool get canRecolorSnapshotSelected {
+    if (_selected.isEmpty) return false;
+    final editor = PdfEditor(_document);
+    return _selected.every((slot) {
+      final annotation = _annotationAt(slot);
+      return annotation != null && editor.isVectorSnapshotStamp(annotation);
+    });
+  }
+
+  /// Recolours every selected vector snapshot to [color] in one revision
+  /// (one undo), keeping the selection. The captured graphics are rewritten
+  /// to a single ink - see [PdfVectorSnapshotEditing.recolorVectorSnapshot].
+  /// Returns whether anything changed.
+  bool recolorSnapshotSelected(Color color) {
+    if (!canRecolorSnapshotSelected) return false;
+    final rgb = _rgbOf(color);
+    if (rgb == null) return false;
+    final targets = <(int, PdfAnnotation)>[
+      for (final slot in _selected)
+        if (_annotationAt(slot) case final annotation?) (slot.$1, annotation),
+    ];
+    if (targets.isEmpty) return false;
+    return apply(
+      (e) {
+        for (final (page, annotation) in targets) {
+          e.recolorVectorSnapshot(page, annotation, rgb);
+        }
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------
   // attention flash
 
   ({PdfDocument document, int page, int slot})? _flash;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 
 import '../page_range_dialog.dart';
+import 'editing_color_picker.dart';
 import 'editing_controller.dart';
 import 'editing_form_style.dart';
 import 'text_prompt.dart';
@@ -163,6 +164,24 @@ Future<void> showPdfAnnotationMenu({
         enabled: controller.canSendSelectedToBack,
         onSelected: (request) => request.controller.sendSelectedToBack(),
       ),
+      if (controller.canRecolorSnapshotSelected)
+        PdfAnnotationMenuItem(
+          key: const ValueKey('pdf-annot-menu-recolor-snapshot'),
+          label: 'Recolour…',
+          icon: Icons.palette_outlined,
+          onSelected: (request) async {
+            final picked = await showPdfColorPicker(
+              context,
+              initial: request.controller.color,
+              initialFormat: request.controller.preferences.colorPickerFormat,
+              onFormatChanged: (format) =>
+                  request.controller.preferences.colorPickerFormat = format,
+            );
+            if (picked != null) {
+              request.controller.recolorSnapshotSelected(picked);
+            }
+          },
+        ),
       PdfAnnotationMenuItem(
         key: const ValueKey('pdf-annot-menu-delete'),
         label: 'Delete',

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -156,6 +156,45 @@ void main() {
       expect(editing.hasAnnotationSelection, isFalse);
     });
 
+    testWidgets('Recolour… shows only for a vector snapshot selection',
+        (tester) async {
+      final editing = await pumpViewer(tester);
+      // paste a vector snapshot; it lands selected, on top, below the rects
+      editing.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      expect(editing.pasteSnapshot(0, at: (110, 500)), isTrue);
+      await tester.pump();
+
+      await rightClick(tester, viewPoint(110, 500)); // the snapshot stamp
+      expect(find.byKey(const ValueKey('pdf-annot-menu-recolor-snapshot')),
+          findsOneWidget);
+      await tester.tapAt(const Offset(5, 5)); // dismiss
+      await tester.pumpAndSettle();
+
+      await rightClick(tester, viewPoint(110, 725)); // plain rectangle A
+      expect(find.byKey(const ValueKey('pdf-annot-menu-recolor-snapshot')),
+          findsNothing);
+    });
+
+    testWidgets('Recolour… opens the picker and retints the snapshot',
+        (tester) async {
+      final editing = await pumpViewer(tester);
+      editing.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      expect(editing.pasteSnapshot(0, at: (110, 500)), isTrue);
+      await tester.pump();
+      final before = editing.document;
+
+      await rightClick(tester, viewPoint(110, 500));
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-annot-menu-recolor-snapshot')));
+      await tester.pumpAndSettle();
+      // the colour dialog is up; accept the default ink
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      // a new revision landed - the snapshot was recoloured
+      expect(identical(editing.document, before), isFalse);
+    });
+
     testWidgets('right-click keeps an existing multi-selection',
         (tester) async {
       final editing = await pumpViewer(tester);

--- a/packages/dart_pdf_editor/test/editing_snapshot_test.dart
+++ b/packages/dart_pdf_editor/test/editing_snapshot_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -85,6 +86,39 @@ void main() {
       addTearDown(editing.dispose);
       expect(editing.pasteSnapshot(0), isFalse);
       expect(editing.isModified, isFalse);
+    });
+
+    test('recolorSnapshotSelected retints the pasted vector snapshot', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      expect(editing.pasteSnapshot(0, at: (100, 100)), isTrue);
+      // the paste leaves the new stamp selected, ready to recolour
+      expect(editing.canRecolorSnapshotSelected, isTrue);
+      expect(editing.recolorSnapshotSelected(const Color(0xFFFF0000)), isTrue);
+
+      final stamp = editing.document.page(0).annotations.single;
+      final cos = editing.document.cos;
+      final res =
+          cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
+              as CosDictionary;
+      final xobj = cos.resolve(res['XObject']) as CosDictionary;
+      final cap = cos.resolve(xobj['Cap']) as CosStream;
+      // the captured graphics now paint in the chosen ink
+      expect(latin1.decode(cos.decodeStreamData(cap)), contains('1 0 0 rg'));
+    });
+
+    test('a non-snapshot selection is not recolourable as a snapshot', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.addRectangle(0, const PdfRect(10, 10, 60, 60));
+      editing.selectAnnotationAt(0, 35, 35);
+      expect(editing.hasAnnotationSelection, isTrue);
+      expect(editing.canRecolorSnapshotSelected, isFalse);
+      expect(
+          editing.recolorSnapshotSelected(const Color(0xFF00FF00)), isFalse);
     });
 
     test('the snapshot clipboard clamps an oversized region into the page', () {

--- a/packages/pdf_document/lib/src/vector_snapshot.dart
+++ b/packages/pdf_document/lib/src/vector_snapshot.dart
@@ -163,7 +163,10 @@ extension PdfVectorSnapshotEditing on PdfEditor {
       ..restore();
     _addAnnotation(
       pageIndex,
-      _markupDict('Stamp', targetRect, 0x000000, null, author),
+      // mark the stamp so the editor can tell a pasted vector snapshot apart
+      // from an ordinary stamp - only these recolour as vectors
+      _markupDict('Stamp', targetRect, 0x000000, null, author)
+        ..[_vectorSnapshotMarker] = const CosBoolean(true),
       _form(targetRect, w,
           resources: _resources(
               extGState: gs, xObject: CosDictionary({'Cap': capRef}))),
@@ -171,7 +174,141 @@ extension PdfVectorSnapshotEditing on PdfEditor {
     );
     return capObject;
   }
+
+  /// Whether [annotation] is a vector snapshot this editor pasted - a /Stamp
+  /// carrying the [_vectorSnapshotMarker] whose appearance draws a captured
+  /// /Cap form. Only these can be recoloured in place by
+  /// [recolorVectorSnapshot].
+  bool isVectorSnapshotStamp(PdfAnnotation annotation) {
+    if (annotation.subtype != 'Stamp') return false;
+    final marker = document.cos.resolve(annotation.dict[_vectorSnapshotMarker]);
+    return marker is CosBoolean && marker.value;
+  }
+
+  /// Recolours a pasted vector snapshot to a single ink [color] (`0xRRGGBB`),
+  /// keeping it sharp vector graphics.
+  ///
+  /// Every fill/stroke colour the captured graphics set is rewritten to
+  /// [color] - the snapshot becomes a monochrome silhouette, the standard
+  /// "recolour a snapshot" behaviour - and colour-less (default-black) paths
+  /// are covered too. Embedded raster images, inline images, and shadings
+  /// keep their own colours (they are not vector fills). Nested Form XObjects
+  /// the capture draws are recoloured as well.
+  ///
+  /// The recolour is isolated to [annotation]: it gets its own recoloured
+  /// copy of the captured form, so other pastes of the same snapshot keep
+  /// their colours. Idempotent - recolouring again just retints. Returns
+  /// false when [annotation] is not a recolourable vector snapshot.
+  bool recolorVectorSnapshot(
+    int pageIndex,
+    PdfAnnotation annotation,
+    int color,
+  ) {
+    if (!isVectorSnapshotStamp(annotation)) return false;
+    final cos = document.cos;
+    final appearance = annotation.normalAppearance;
+    if (appearance == null) return false;
+    final resources = cos.resolve(appearance.dictionary['Resources']);
+    if (resources is! CosDictionary) return false;
+    final xObjects = cos.resolve(resources['XObject']);
+    if (xObjects is! CosDictionary) return false;
+    final captured = cos.resolve(xObjects['Cap']);
+    if (captured is! CosStream) return false;
+    final recolored = _recoloredForm(captured, color & 0xFFFFFF, {}, {});
+    // point THIS appearance at the recoloured copy; other pastes that share
+    // the original captured form are untouched
+    xObjects['Cap'] = _updater.addObject(recolored);
+    _updater.markChanged(appearance);
+    _markAnnotationChanged(pageIndex, annotation.dict);
+    return true;
+  }
+
+  /// A recoloured deep copy of a captured Form XObject: its content stream
+  /// with every colour operator forced to [rgb], recursing into the nested
+  /// Form XObjects it draws (copied once each through [done], guarded against
+  /// cyclic references by [visiting]).
+  CosStream _recoloredForm(
+    CosStream form,
+    int rgb,
+    Map<CosStream, CosReference> done,
+    Set<CosStream> visiting,
+  ) {
+    final cos = document.cos;
+    final recoloredContent =
+        _recolorContentBytes(cos.decodeStreamData(form), rgb);
+    final dict = CosDictionary({...form.dictionary.entries});
+    visiting.add(form);
+    final resources = cos.resolve(form.dictionary['Resources']);
+    if (resources is CosDictionary) {
+      final xObjects = cos.resolve(resources['XObject']);
+      if (xObjects is CosDictionary) {
+        CosDictionary? recoloredXObjects;
+        for (final entry in xObjects.entries.entries) {
+          final nested = cos.resolve(entry.value);
+          if (nested is! CosStream) continue;
+          final subtype = cos.resolve(nested.dictionary['Subtype']);
+          if (subtype is! CosName || subtype.value != 'Form') continue;
+          if (visiting.contains(nested)) continue; // guard cyclic forms
+          final ref = done[nested] ??=
+              _updater.addObject(_recoloredForm(nested, rgb, done, visiting));
+          (recoloredXObjects ??= CosDictionary({...xObjects.entries}))[
+              entry.key] = ref;
+        }
+        if (recoloredXObjects != null) {
+          dict['Resources'] = CosDictionary({...resources.entries})
+            ..['XObject'] = recoloredXObjects;
+        }
+      }
+    }
+    visiting.remove(form);
+    // the copy carries decoded (plaintext) content
+    dict.entries
+      ..remove('Filter')
+      ..remove('DecodeParms')
+      ..remove('DP');
+    dict['Length'] = CosInteger(recoloredContent.length);
+    return CosStream(dict, recoloredContent);
+  }
+
+  /// [content] with every fill/stroke colour operator rewritten to [rgb], so
+  /// the graphics paint in a single ink. An initial colour is forced up front
+  /// so paths that rely on the default black recolour too; colour-space
+  /// selectors (`cs`/`CS`) are dropped since every colour is DeviceRGB now.
+  /// Images, inline images, and shadings are left untouched.
+  Uint8List _recolorContentBytes(Uint8List content, int rgb) {
+    CosObject component(int value) => value <= 0
+        ? CosInteger(0)
+        : value >= 255
+            ? CosInteger(1)
+            : CosReal(value / 255);
+    final operands = [
+      component((rgb >> 16) & 0xFF),
+      component((rgb >> 8) & 0xFF),
+      component(rgb & 0xFF),
+    ];
+    ContentOperation fill() => ContentOperation('rg', operands);
+    ContentOperation stroke() => ContentOperation('RG', operands);
+    final out = <ContentOperation>[fill(), stroke()];
+    for (final op in ContentStreamParser.parse(content)) {
+      switch (op.operator) {
+        case 'g' || 'rg' || 'k' || 'sc' || 'scn':
+          out.add(fill());
+        case 'G' || 'RG' || 'K' || 'SC' || 'SCN':
+          out.add(stroke());
+        case 'cs' || 'CS':
+          break; // drop: colour space is moot once every colour is DeviceRGB
+        default:
+          out.add(op);
+      }
+    }
+    return ContentStreamSerializer.serialize(out);
+  }
 }
+
+/// The annotation-dictionary key [PdfVectorSnapshotEditing.pasteVectorSnapshot]
+/// stamps onto its /Stamp so a pasted vector snapshot is distinguishable from
+/// an ordinary stamp (see [PdfVectorSnapshotEditing.isVectorSnapshotStamp]).
+const _vectorSnapshotMarker = 'DartPdfVectorSnapshot';
 
 /// Formats a matrix component for a content stream - integers without a
 /// trailing `.0`.

--- a/packages/pdf_document/test/vector_snapshot_test.dart
+++ b/packages/pdf_document/test/vector_snapshot_test.dart
@@ -42,6 +42,40 @@ Uint8List _coloredPagePdf() {
   return Uint8List.fromList(latin1.encode(buffer.toString()));
 }
 
+/// A one-page PDF whose content draws a **nested** Form XObject (/Fm0) that
+/// sets its own blue fill - so a recolour has to recurse into the nested form,
+/// not just rewrite the top-level content.
+Uint8List _nestedFormPagePdf() {
+  const pageContent = '/Fm0 Do';
+  const formContent = '0 0 1 rg 0 0 50 50 re f';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] '
+        '/Contents 4 0 R /Resources << /XObject << /Fm0 5 0 R >> >> >>',
+    '<< /Length ${pageContent.length} >>\nstream\n$pageContent\nendstream',
+    '<< /Type /XObject /Subtype /Form /BBox [0 0 100 100] '
+        '/Length ${formContent.length} >>\nstream\n$formContent\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(latin1.encode(buffer.toString()));
+}
+
 String _capContent(PdfDocument out, PdfAnnotation stamp) {
   final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
       as CosDictionary;
@@ -318,6 +352,34 @@ void main() {
       final other = _capContent(out, outStamps[1]);
       expect(other, contains('1 0 0 rg'));
       expect(other, isNot(contains('0 0 1 rg')));
+    });
+
+    test('recolour recurses into nested Form XObjects', () {
+      final doc = PdfDocument.open(_nestedFormPagePdf());
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(0, 0, 200, 200));
+      editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 200, 200), snap);
+      final stamp = doc.page(0).annotations.single;
+      editor.recolorVectorSnapshot(0, stamp, 0xFF0000);
+
+      final out = PdfDocument.open(editor.save());
+      final s = out.page(0).annotations.single;
+      final res = out.cos.resolve(s.normalAppearance!.dictionary['Resources'])
+          as CosDictionary;
+      final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
+      final cap = out.cos.resolve(xobj['Cap']) as CosStream;
+      // the top capture still invokes the nested form
+      expect(latin1.decode(out.cos.decodeStreamData(cap)), contains('/Fm0 Do'));
+      // and the nested form's own blue fill is retinted red
+      final capRes =
+          out.cos.resolve(cap.dictionary['Resources']) as CosDictionary;
+      final capXobj = out.cos.resolve(capRes['XObject']) as CosDictionary;
+      final nested = out.cos.resolve(capXobj['Fm0']) as CosStream;
+      final nestedContent = latin1.decode(out.cos.decodeStreamData(nested));
+      expect(nestedContent, contains('1 0 0 rg'));
+      expect(nestedContent, isNot(contains('0 0 1 rg')));
+      expect(nestedContent, contains('re'));
     });
 
     test('recolour works on a snapshot loaded from a prior revision', () {

--- a/packages/pdf_document/test/vector_snapshot_test.dart
+++ b/packages/pdf_document/test/vector_snapshot_test.dart
@@ -2,6 +2,7 @@
 // detached vector graphics and pasting it back as a /Stamp annotation
 // whose appearance *draws* the captured content (so it stays vector).
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -9,6 +10,45 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:test/test.dart';
 
 String _name(CosObject? o) => (o as CosName).value;
+
+/// A one-page PDF whose content sets a red fill and a green stroke, then
+/// paints a filled+stroked rectangle - so a recolour has real colour
+/// operators to rewrite (the shared fixtures draw only default-black text).
+Uint8List _coloredPagePdf() {
+  const content = '1 0 0 rg 0 1 0 RG 10 10 100 100 re B';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] '
+        '/Contents 4 0 R /Resources << >> >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return Uint8List.fromList(latin1.encode(buffer.toString()));
+}
+
+String _capContent(PdfDocument out, PdfAnnotation stamp) {
+  final res = out.cos.resolve(stamp.normalAppearance!.dictionary['Resources'])
+      as CosDictionary;
+  final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
+  final cap = out.cos.resolve(xobj['Cap']) as CosStream;
+  return latin1.decode(out.cos.decodeStreamData(cap));
+}
 
 double _num(CosObject o) => switch (o) {
       CosInteger(:final value) => value.toDouble(),
@@ -194,6 +234,108 @@ void main() {
       final xobj = out.cos.resolve(res['XObject']) as CosDictionary;
       final cap = out.cos.resolve(xobj['Cap']) as CosStream;
       expect(latin1.decode(out.cos.decodeStreamData(cap)), contains('(Page 1) Tj'));
+    });
+  });
+
+  group('PdfVectorSnapshot recolour', () {
+    test('paste marks the stamp as a vector snapshot', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 160, 40), snap);
+      final stamp = doc.page(0).annotations.single;
+      expect(editor.isVectorSnapshotStamp(stamp), isTrue);
+    });
+
+    test('an ordinary stamp is not a recolourable vector snapshot', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc)
+        ..addStamp(0, const PdfRect(0, 0, 120, 40), 'APPROVED');
+      final stamp = doc.page(0).annotations.single;
+      expect(editor.isVectorSnapshotStamp(stamp), isFalse);
+      expect(editor.recolorVectorSnapshot(0, stamp, 0xFF0000), isFalse);
+    });
+
+    test('recolour forces a single ink up front so default-black recolours',
+        () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 160, 40), snap);
+      final stamp = doc.page(0).annotations.single;
+      expect(editor.recolorVectorSnapshot(0, stamp, 0xFF0000), isTrue);
+
+      final out = PdfDocument.open(editor.save());
+      final content = _capContent(out, out.page(0).annotations.single);
+      // the fixture text carries no colour operator, so a leading ink is
+      // forced for both paint sides - the text draws red now
+      expect(content, contains('1 0 0 rg'));
+      expect(content, contains('1 0 0 RG'));
+      // the captured vectors survive
+      expect(content, contains('(Page 1) Tj'));
+    });
+
+    test('recolour rewrites existing fill and stroke colours', () {
+      final doc = PdfDocument.open(_coloredPagePdf());
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(0, 0, 200, 200));
+      editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 200, 200), snap);
+      final stamp = doc.page(0).annotations.single;
+      editor.recolorVectorSnapshot(0, stamp, 0x0000FF);
+
+      final out = PdfDocument.open(editor.save());
+      final content = _capContent(out, out.page(0).annotations.single);
+      // the red fill and green stroke are gone, retinted blue; the path
+      // paint operator survives
+      expect(content, isNot(contains('1 0 0 rg')));
+      expect(content, isNot(contains('0 1 0 RG')));
+      expect(content, contains('0 0 1 rg'));
+      expect(content, contains('0 0 1 RG'));
+      expect(content, contains('re'));
+    });
+
+    test('recolour is isolated to the stamp - shared pastes keep their ink',
+        () {
+      final doc = PdfDocument.open(_coloredPagePdf());
+      final editor = PdfEditor(doc);
+      final snap =
+          editor.captureVectorSnapshot(0, const PdfRect(0, 0, 200, 200));
+      final ref1 =
+          editor.pasteVectorSnapshot(0, const PdfRect(0, 0, 100, 100), snap);
+      editor.pasteVectorSnapshot(0, const PdfRect(100, 100, 200, 200), snap,
+          sharedObject: ref1);
+      final stamps = doc.page(0).annotations;
+      // recolour only the first paste
+      editor.recolorVectorSnapshot(0, stamps[0], 0x0000FF);
+
+      final out = PdfDocument.open(editor.save());
+      final outStamps = out.page(0).annotations;
+      expect(_capContent(out, outStamps[0]), contains('0 0 1 rg'));
+      // the shared paste still references the original, un-recoloured form
+      final other = _capContent(out, outStamps[1]);
+      expect(other, contains('1 0 0 rg'));
+      expect(other, isNot(contains('0 0 1 rg')));
+    });
+
+    test('recolour works on a snapshot loaded from a prior revision', () {
+      final doc = PdfDocument.open(buildMultiPagePdf(1));
+      final first = PdfEditor(doc);
+      final snap =
+          first.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      first.pasteVectorSnapshot(0, const PdfRect(0, 0, 160, 40), snap);
+      final mid = PdfDocument.open(first.save());
+
+      final second = PdfEditor(mid);
+      final stamp = mid.page(0).annotations.single;
+      expect(second.recolorVectorSnapshot(0, stamp, 0x00FF00), isTrue);
+
+      final out = PdfDocument.open(second.save());
+      final content = _capContent(out, out.page(0).annotations.single);
+      expect(content, contains('0 1 0 rg'));
+      expect(content, contains('(Page 1) Tj'));
     });
   });
 }


### PR DESCRIPTION
## Summary

Vector snapshots (the Snapshot tool's "paste as vector") paste back as `/Stamp` annotations whose appearance draws a captured Form XObject, so they keep the source page's own colours. The generic restyle path can't touch them — a content-less stamp reports `canRestyle == false`, and the stamp restyle branch would rebuild a *text* stamp and destroy the picture — so snapshots had no way to be recoloured.

This adds a dedicated recolour that retints the captured vectors to a single ink (a monochrome silhouette, the Bluebeam-style "recolor a snapshot"), reachable from the annotation context menu:

- **`pdf_document`** — `PdfVectorSnapshotEditing` gains `isVectorSnapshotStamp` and `recolorVectorSnapshot`. `pasteVectorSnapshot` now stamps a `DartPdfVectorSnapshot` marker so a pasted snapshot is distinguishable from an ordinary stamp. Recolour rewrites the captured form's content stream — every fill/stroke colour operator forced to the target, an initial ink prepended so default-black paths recolour too, recursing into nested Form XObjects. It forks a **private copy** of the `/Cap` form (so other pastes of the same snapshot keep their colours) and leaves the appearance geometry untouched, so resize/rotate state survives.
- **`dart_pdf_editor`** — `PdfEditingController` gains `canRecolorSnapshotSelected` / `recolorSnapshotSelected` (one revision, one undo, selection kept), and the annotation context menu shows a **"Recolour…"** entry for snapshot selections that opens the colour picker.

Documented limitation: embedded raster images, inline images, and shadings keep their own colours (they aren't vector fills); patterns collapse to the solid ink.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (pdf_document + dart_pdf_editor — clean)
- [x] `cd packages/pdf_document && fvm dart test` (644 passing)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (snapshot + menu + clipboard/longpress/ipad suites)

Ran the analyzer and the affected package suites. Did not run the Ghent/corpus render sweeps — this change is editing-only and adds no rendering path (the recolour is a content-stream rewrite exercised by unit tests).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Recolour deliberately does **not** go through `restyleAnnotation`: for a `/Stamp` that path regenerates a *text* appearance and would wipe the vectors. The snapshot recolour is its own operator-rewrite over the captured form.
- Pastes of one snapshot share the `/Cap` object, so the recolour forks a private copy — otherwise every sibling paste would change. The appearance's own `/Resources /XObject` dict is per-paste, so swapping its `Cap` entry and `markChanged`-ing the appearance form isolates the change.
- Design rationale and file pointers in `doc/dev-log/2026-07-16-vector-snapshot-recolour.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GD9HP6USSrGrzKxWFCN4Jn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GD9HP6USSrGrzKxWFCN4Jn)_