### PR TITLE
Loosen typed value range for style slider readouts

### DIFF
--- a/doc/dev-log/2026-07-16-slider-typed-value-range.md
+++ b/doc/dev-log/2026-07-16-slider-typed-value-range.md
@@ -1,0 +1,35 @@
+# Looser typed range for slider readouts
+
+The editing UI's style sliders (stroke width, font size, opacity, eraser
+size, line/char spacing, font width) each pair a `Slider` scaled to a
+compact `min`..`max` with an editable numeric readout
+(`PdfSliderValueField`). The readout used to clamp a *typed* value to the
+same `min`..`max` as the slider, so e.g. a 12 pt max stroke could never be
+set to 20 pt by typing - the scale that keeps the slider usable also
+capped what you could enter.
+
+Now the field's clamp is decoupled from the slider's scale.
+`PdfSliderValueField` gained `fieldMin`/`fieldMax` (default to `min`/`max`,
+so unchanged callers keep the old behaviour); the `_slider`
+(`editing_toolbar.dart`) and `_sliderRow` (`editing_properties.dart`)
+helpers thread them through. The slider thumb still moves only within
+`min`..`max`; typing accepts the wider `fieldMin`..`fieldMax`.
+
+Widened bounds (chosen "within reason / to not crash"):
+
+- Open-ended point/size values - stroke width, eraser size, font size,
+  font width, char spacing - clamp the typed field to `kPdfTypedSizeMax`
+  (= 1000, in `editing_value_field.dart`). Far past any slider max but
+  bounded so an accidental huge value can't blow up appearance generation
+  or rendering. Stroke allows 0; char spacing allows the negative side too.
+- Line spacing: 0.1..100×.
+- Opacity: kept a true ratio - the field reaches 0% (fully transparent,
+  below the slider's 0.05/0.1 floor) but never past 100%.
+
+Note: the shared `_parsePoints` still strips non-`[0-9.]`, so a *typed*
+char-spacing value can't currently go negative regardless of `fieldMin`;
+that's pre-existing and only the positive side is widened in practice.
+
+Test: `editing_properties_test.dart` "typing an exact value into a slider
+readout" now asserts 80 pt is accepted (past the 16 pt slider max), 999999
+clamps to 1000, and opacity 150 clamps to 100%.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_style.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_style.dart
@@ -223,6 +223,8 @@ class _PdfFormFieldStyleControlsState extends State<PdfFormFieldStyleControls> {
                   value: _draggingSize ?? style.size,
                   min: 6,
                   max: 72,
+                  fieldMin: 1,
+                  fieldMax: kPdfTypedSizeMax,
                   width: 40,
                   display: (v) => '${v.round()}',
                   onSubmit: (v) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -403,6 +403,8 @@ class _PdfAnnotationPropertiesPanelState
       required ValueChanged<double> onChangeEnd,
       String Function(double)? display,
       double? Function(String)? parse,
+      double? fieldMin,
+      double? fieldMax,
       bool varies = false}) {
     final base = key is ValueKey ? '${key.value}' : '$key';
     return Padding(
@@ -421,12 +423,15 @@ class _PdfAnnotationPropertiesPanelState
         ),
         // the value also reads back as an editable number, so it can be set
         // exactly without nudging the slider (general rule: any slider's
-        // value is directly typeable)
+        // value is directly typeable). A typed value may exceed the slider's
+        // scale within reason (fieldMin/fieldMax).
         PdfSliderValueField(
           key: ValueKey('$base-input'),
           value: value,
           min: min,
           max: max,
+          fieldMin: fieldMin,
+          fieldMax: fieldMax,
           display: display ?? _fmt,
           parse: parse,
           varies: varies,
@@ -562,6 +567,8 @@ class _PdfAnnotationPropertiesPanelState
         key: const ValueKey('pdf-prop-stroke'),
         min: 0.5,
         max: 16,
+        fieldMin: 0,
+        fieldMax: kPdfTypedSizeMax,
         varies: _draggingStroke == null && widths.varies,
         onChanged: (v) => setState(() => _draggingStroke = v),
         onChangeEnd: (v) {
@@ -632,6 +639,9 @@ class _PdfAnnotationPropertiesPanelState
         key: const ValueKey('pdf-prop-opacity'),
         min: 0.05,
         max: 1,
+        // a true ratio: typeable down to 0%, never past 100%
+        fieldMin: 0,
+        fieldMax: 1,
         varies: _draggingOpacity == null && opacities.varies,
         display: (v) => '${(v * 100).round()}%',
         parse: (s) {
@@ -697,6 +707,8 @@ class _PdfAnnotationPropertiesPanelState
         key: const ValueKey('pdf-prop-font-size'),
         min: 6,
         max: 72,
+        fieldMin: 1,
+        fieldMax: kPdfTypedSizeMax,
         onChanged: (v) => setState(() => _draggingFontSize = v),
         onChangeEnd: (v) {
           _controller.restyleSelectedText(size: v.roundToDouble());
@@ -727,6 +739,8 @@ class _PdfAnnotationPropertiesPanelState
           key: const ValueKey('pdf-prop-line-spacing'),
           min: 0.8,
           max: 3,
+          fieldMin: 0.1,
+          fieldMax: 100,
           display: (v) => '${v.toStringAsFixed(1)}×',
           onChanged: (v) => setState(() => _draggingLineSpacing = v),
           onChangeEnd: (v) {
@@ -742,6 +756,8 @@ class _PdfAnnotationPropertiesPanelState
           key: const ValueKey('pdf-prop-char-spacing'),
           min: -2,
           max: 10,
+          fieldMin: -kPdfTypedSizeMax,
+          fieldMax: kPdfTypedSizeMax,
           display: (v) => '${v.toStringAsFixed(1)} pt',
           onChanged: (v) => setState(() => _draggingCharSpacing = v),
           onChangeEnd: (v) {
@@ -757,6 +773,8 @@ class _PdfAnnotationPropertiesPanelState
           key: const ValueKey('pdf-prop-font-width'),
           min: 50,
           max: 200,
+          fieldMin: 1,
+          fieldMax: kPdfTypedSizeMax,
           display: (v) => '${v.round()}%',
           onChanged: (v) => setState(() => _draggingFontWidth = v),
           onChangeEnd: (v) {
@@ -834,6 +852,8 @@ class _PdfAnnotationPropertiesPanelState
           key: const ValueKey('pdf-prop-form-size'),
           min: 6,
           max: 72,
+          fieldMin: 1,
+          fieldMax: kPdfTypedSizeMax,
           onChanged: (v) => setState(() => _draggingFontSize = v),
           onChangeEnd: (v) {
             _controller.setFormFieldStyle(name, fontSize: v.roundToDouble());

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1911,6 +1911,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         value: value,
         min: 0.1,
         max: 1,
+        // a true ratio: typeable down to 0%, never past 100%
+        fieldMin: 0,
+        fieldMax: 1,
         width: 40,
         display: (v) => '${(v * 100).round()}%',
         parse: _parsePercent,
@@ -3512,6 +3515,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                       value: controller.eraserRadius,
                       min: 2,
                       max: 40,
+                      fieldMin: 1,
+                      fieldMax: kPdfTypedSizeMax,
                       display: (v) => '${v.round()} pt',
                       parse: _parsePoints,
                       onChanged: (v) =>
@@ -3523,6 +3528,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                       value: strokeValue,
                       min: 0.5,
                       max: 12,
+                      fieldMin: 0,
+                      fieldMax: kPdfTypedSizeMax,
                       display: (v) => '${v.toStringAsFixed(1)} pt',
                       parse: _parsePoints,
                       onChanged: (v) {
@@ -3543,6 +3550,10 @@ class _StyleMenuState extends State<_StyleMenu> {
                       value: opacityValue,
                       min: 0.1,
                       max: 1,
+                      // opacity is a true ratio: let the field reach 0% but
+                      // never past 100%
+                      fieldMin: 0,
+                      fieldMax: 1,
                       display: (v) => '${(v * 100).round()}%',
                       parse: _parsePercent,
                       onChanged: (v) {
@@ -3645,6 +3656,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                           controller.fontSize,
                       min: 8,
                       max: 48,
+                      fieldMin: 1,
+                      fieldMax: kPdfTypedSizeMax,
                       display: (v) => '${v.round()} pt',
                       parse: _parsePoints,
                       onChanged: (v) {
@@ -3744,6 +3757,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                             controller.lineSpacing,
                         min: 0.8,
                         max: 3,
+                        fieldMin: 0.1,
+                        fieldMax: 100,
                         display: (v) => '${v.toStringAsFixed(1)}×',
                         onChanged: (v) =>
                             setState(() => _draggingLineSpacing = v),
@@ -3760,6 +3775,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                             controller.charSpacing,
                         min: -2,
                         max: 10,
+                        fieldMin: -kPdfTypedSizeMax,
+                        fieldMax: kPdfTypedSizeMax,
                         display: (v) => '${v.toStringAsFixed(1)} pt',
                         parse: _parsePoints,
                         onChanged: (v) =>
@@ -3778,6 +3795,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                             controller.fontWidth,
                         min: 50,
                         max: 200,
+                        fieldMin: 1,
+                        fieldMax: kPdfTypedSizeMax,
                         display: (v) => '${v.round()}%',
                         parse: _parsePoints,
                         onChanged: (v) =>
@@ -3872,6 +3891,8 @@ class _StyleMenuState extends State<_StyleMenu> {
     double? Function(String)? parse,
     required ValueChanged<double> onChanged,
     ValueChanged<double>? onChangeEnd,
+    double? fieldMin,
+    double? fieldMax,
   }) {
     return Row(key: key, children: [
       SizedBox(width: 86, child: Text(label)),
@@ -3886,12 +3907,15 @@ class _StyleMenuState extends State<_StyleMenu> {
       ),
       // the readout is editable: type an exact value (general rule across
       // the editing UI) - committing routes through the change-end callback,
-      // or onChanged for sliders that have none (live-only)
+      // or onChanged for sliders that have none (live-only). The typed value
+      // may run past the slider's scale (fieldMin/fieldMax) within reason.
       PdfSliderValueField(
         key: key is ValueKey ? ValueKey('${key.value}-input') : null,
         value: value,
         min: min,
         max: max,
+        fieldMin: fieldMin,
+        fieldMax: fieldMax,
         width: 56,
         display: display,
         parse: parse,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_value_field.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_value_field.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
 
+/// A generous ceiling for the typed readout of an open-ended point/size
+/// slider (stroke width, font size, eraser radius, char spacing, font
+/// width…). The slider's own scale stays fixed; typing an exact value can
+/// go past it, but is capped here so an accidental huge number can't blow
+/// up appearance generation or rendering. It is deliberately far larger
+/// than any slider max yet small enough to stay safe.
+const double kPdfTypedSizeMax = 1000;
+
 /// The numeric readout beside a slider, editable in place: the user can type
 /// an exact value instead of nudging the slider (a general rule across the
 /// editing UI - any slider's value is directly typeable).
 ///
 /// Tracks the slider's [value] while not focused (so a drag updates the
-/// text), and on Enter or focus loss parses, clamps to [min]..[max], and
-/// commits through [onSubmit] - the same callback the slider fires on
+/// text), and on Enter or focus loss parses, clamps to [fieldMin]..[fieldMax],
+/// and commits through [onSubmit] - the same callback the slider fires on
 /// change-end. Invalid text reverts to the current value.
+///
+/// The slider that owns this readout is scaled to [min]..[max], but typing
+/// is allowed a wider range: [fieldMin]/[fieldMax] default to [min]/[max]
+/// (so the readout matches the slider unless a caller opts in), and callers
+/// pass a looser pair to let an exact value exceed the slider's scale - the
+/// scale stays put while the field accepts more, within reason.
 ///
 /// [display] formats the value for show (e.g. `42` or `40%`); [parse] inverts
 /// it back to the underlying value (defaults to [double.tryParse], so pass a
@@ -21,13 +35,26 @@ class PdfSliderValueField extends StatefulWidget {
     required this.display,
     required this.onSubmit,
     double? Function(String)? parse,
+    double? fieldMin,
+    double? fieldMax,
     this.width = 52,
     this.varies = false,
-  }) : parse = parse ?? double.tryParse;
+  })  : parse = parse ?? double.tryParse,
+        fieldMin = fieldMin ?? min,
+        fieldMax = fieldMax ?? max;
 
   final double value;
+
+  /// The lower/upper bound of the slider's scale - the thumb never moves
+  /// outside these.
   final double min;
   final double max;
+
+  /// The clamp applied to a *typed* value. Defaults to [min]/[max]; pass a
+  /// wider range to let the field accept values the slider can't reach.
+  final double fieldMin;
+  final double fieldMax;
+
   final String Function(double) display;
   final double? Function(String) parse;
   final ValueChanged<double> onSubmit;
@@ -74,7 +101,7 @@ class _PdfSliderValueFieldState extends State<PdfSliderValueField> {
       _controller.text = widget.varies ? '' : widget.display(widget.value);
       return;
     }
-    final clamped = parsed.clamp(widget.min, widget.max).toDouble();
+    final clamped = parsed.clamp(widget.fieldMin, widget.fieldMax).toDouble();
     _controller.text = widget.display(clamped);
     widget.onSubmit(clamped);
   }

--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -275,11 +275,19 @@ void main() {
       await tester.pump();
       expect(editing.selectedAnnotation!.borderWidth, 9);
 
-      // out-of-range input clamps to the slider's max (16)
-      await tester.enterText(field, '500');
+      // the typed field is looser than the slider's scale: a value past the
+      // slider max (16) is accepted, up to the safety cap
+      await tester.enterText(field, '80');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
-      expect(editing.selectedAnnotation!.borderWidth, 16);
+      expect(editing.selectedAnnotation!.borderWidth, 80);
+
+      // absurd input still clamps to the safety cap (kPdfTypedSizeMax = 1000)
+      // so nothing blows up
+      await tester.enterText(field, '999999');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(editing.selectedAnnotation!.borderWidth, 1000);
 
       // opacity reads back as a percentage and round-trips through it
       final opacity = find.byKey(const ValueKey('pdf-prop-opacity-input'));
@@ -288,6 +296,13 @@ void main() {
       await tester.pump();
       expect(
           editing.selectedAnnotation!.appearanceOpacity, closeTo(0.4, 0.001));
+
+      // opacity is a true ratio: an over-100% entry still clamps to 100%
+      await tester.enterText(opacity, '150');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(
+          editing.selectedAnnotation!.appearanceOpacity, closeTo(1, 0.001));
     });
 
     testWidgets('the fill clear button removes a shape fill', (tester) async {


### PR DESCRIPTION
## Summary

The editing UI's style sliders (stroke width, font size, opacity, eraser size, line/char spacing, font width) each pair a `Slider` scaled to a compact `min`..`max` with an editable numeric readout (`PdfSliderValueField`). Previously the readout clamped a *typed* value to the same `min`..`max` as the slider, so a value the slider couldn't reach (e.g. a 20 pt stroke past the 12 pt slider max) also couldn't be typed.

This decouples the field's clamp from the slider's scale. `PdfSliderValueField` gains `fieldMin`/`fieldMax` (defaulting to `min`/`max`, so untouched callers keep the old behavior); the `_slider` and `_sliderRow` helpers thread them through. The slider thumb still moves only within `min`..`max`; typing now accepts the wider `fieldMin`..`fieldMax`.

Widened bounds, chosen "within reason / to not crash the app":

- Open-ended point/size values — stroke width, eraser size, font size, font width, char spacing — clamp the typed field to `kPdfTypedSizeMax` (= 1000). Far past any slider max, but bounded so an accidental huge value can't blow up appearance generation or rendering. Stroke allows 0; char spacing allows the negative side too.
- Line spacing: `0.1`..`100×`.
- Opacity: kept a true ratio — the field reaches 0% (below the slider's floor) but never past 100%.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (edited files — clean)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (editing_properties, editing_shape_styles, editing_form_style, editing_text_edit, editing_shape_resize — all pass)

Ran the editing test suites touching the changed widgets rather than the whole repo; the change is scoped to `dart_pdf_editor` UI clamping.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

`fieldMin`/`fieldMax` default to `min`/`max`, so any `PdfSliderValueField` / `_slider` / `_sliderRow` caller that doesn't opt in is unchanged. One pre-existing quirk left as-is: the shared `_parsePoints` strips non-`[0-9.]`, so a *typed* char-spacing value still can't go negative regardless of `fieldMin` — only the positive side is widened in practice. Dev-log note added at `doc/dev-log/2026-07-16-slider-typed-value-range.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lgs7fQNKaKqhVbLGJZcuPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgs7fQNKaKqhVbLGJZcuPu)_