### PR TITLE
Make the stamp template composer use overlay-style touch handles

### DIFF
--- a/doc/dev-log/2026-07-16-stamp-canvas-touch-handles.md
+++ b/doc/dev-log/2026-07-16-stamp-canvas-touch-handles.md
@@ -1,0 +1,55 @@
+# Stamp template canvas: overlay-style touch handles
+
+## Problem
+
+The custom-stamp editor's in-dialog composer (`_StampTemplateCanvas` in
+`editing_stamps.dart`) was finicky on touch, "especially the scale box":
+
+- It listened to **raw pointer events** (`Listener`, `onPointerDown/Move/Up`)
+  with no gesture recognizer, so no touch slop - the faintest jitter during a
+  tap-to-select dragged the component - and no gesture-arena participation.
+- It exposed **one tiny resize handle at the bottom-right corner only**
+  (`12 / scale` template units, drawn at `10 / scale`). A finger had to land
+  almost exactly on that corner or the press read as a *move* instead.
+
+On-page placed stamps never had this problem: a placed stamp is an ordinary
+`subtype == 'Stamp'` annotation and already flows through the shared
+`EditingPageOverlay` (8 handles, `_handleHitRadius` = 12 logical px, rotate
+knob). Only the template composer rolled its own controls.
+
+## Change
+
+Ported the overlay's interaction model into `_StampTemplateCanvas` (keeping the
+two coordinate systems decoupled - the composer works in template space before
+any PDF exists, so it can't literally reuse the overlay, which is bound to a
+live `PdfDocument`):
+
+- **`GestureDetector` with `dragStartBehavior: DragStartBehavior.down`**
+  (`onPanStart/Update/End` + `onTapUp`), mirroring the overlay's own wiring.
+  `DragStartBehavior.down` anchors the drag at the press point, so the handle
+  grab and the move both start where the finger actually landed. The
+  recognizer also gives real touch slop, so tap-to-select no longer nudges the
+  component. Inside the dialog's `SingleChildScrollView` the inner pan wins the
+  arena over the scrollable (and mouse drags, used by the widget tests, don't
+  contend since `Scrollable`'s default drag devices exclude the mouse).
+- **Eight handles** (`_stampHandles`, corners + edge midpoints) with the same
+  `(dx, dy)` edge convention as the overlay's `_Handle`, hit-tested in **logical
+  pixels** against `_stampHandleHitRadius` = 14 so the target is the same size
+  at any template zoom. `_resizeSelected` now takes the grabbed handle and moves
+  only the edge(s) it owns, clamped to a minimum size and the template bounds
+  (previously it only grew width/height from a fixed top-left anchor).
+
+## Gotchas / pointers
+
+- The resize callback signature changed: `onResizeSelected` is now
+  `void Function(_StampHandle handle, Offset delta)`; the frame-coalescing in
+  `_queueDelta`/`_flushPendingDelta` carries the handle alongside the delta.
+- `DragStartBehavior` lives in `package:flutter/gestures.dart` - added that
+  import (material alone doesn't re-export it).
+- Handle centers are computed once by the top-level `_stampHandleCenter` and
+  shared by both the painter (draws in template space, scaled by the canvas) and
+  the state's hit-test (converts to logical px via the canvas scale).
+- Tests: `editing_stamps_test.dart` keeps the existing move/resize case (still
+  drives the bottom-right corner) and adds one that grabs the **top-left**
+  corner a few px off-center - impossible with the old single handle - to guard
+  the new multi-handle path and the forgiving radius.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -614,20 +615,38 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
     _replaceSelected(component.copyWith(x: x, y: y));
   }
 
-  void _resizeSelected(Offset delta) {
+  void _resizeSelected(_StampHandle handle, Offset delta) {
     final component = _selectedComponent;
     if (component == null) return;
     final minWidth =
         component.type == PdfStampTemplateComponentType.text ? 28.0 : 16.0;
     final minHeight =
         component.type == PdfStampTemplateComponentType.text ? 14.0 : 16.0;
-    final width = (component.width + delta.dx)
-        .clamp(minWidth, _templateWidth - component.x)
-        .toDouble();
-    final height = (component.height + delta.dy)
-        .clamp(minHeight, _templateHeight - component.y)
-        .toDouble();
-    _replaceSelected(component.copyWith(width: width, height: height));
+    var left = component.x;
+    var top = component.y;
+    var right = component.x + component.width;
+    var bottom = component.y + component.height;
+    // Each handle moves only the edge(s) it owns; the opposite edge stays put,
+    // clamped so the box keeps a minimum size and never leaves the template.
+    if (handle.dx < 0) {
+      left = (left + delta.dx).clamp(0.0, right - minWidth).toDouble();
+    } else if (handle.dx > 0) {
+      right =
+          (right + delta.dx).clamp(left + minWidth, _templateWidth).toDouble();
+    }
+    if (handle.dy < 0) {
+      top = (top + delta.dy).clamp(0.0, bottom - minHeight).toDouble();
+    } else if (handle.dy > 0) {
+      bottom = (bottom + delta.dy)
+          .clamp(top + minHeight, _templateHeight)
+          .toDouble();
+    }
+    _replaceSelected(component.copyWith(
+      x: left,
+      y: top,
+      width: right - left,
+      height: bottom - top,
+    ));
   }
 
   void _setSelectedFont(PdfStandardFont font) {
@@ -1059,18 +1078,51 @@ class _StampTemplateCanvas extends StatefulWidget {
   final int? selectedIndex;
   final ValueChanged<int?> onSelect;
   final ValueChanged<Offset> onMoveSelected;
-  final ValueChanged<Offset> onResizeSelected;
+  final void Function(_StampHandle handle, Offset delta) onResizeSelected;
 
   @override
   State<_StampTemplateCanvas> createState() => _StampTemplateCanvasState();
 }
 
-enum _StampDragMode { move, resize }
+/// Which sides of the selection a resize handle moves: -1 the left/top edge,
+/// +1 the right/bottom edge, 0 leaves that axis anchored. (Template space, y
+/// down.) Mirrors the on-page editing overlay's `_Handle` convention.
+typedef _StampHandle = ({int dx, int dy});
+
+/// The eight resize handles (four corners + four edge midpoints) that ring a
+/// selected component, in the same order as the on-page overlay.
+const List<_StampHandle> _stampHandles = [
+  (dx: -1, dy: -1),
+  (dx: 0, dy: -1),
+  (dx: 1, dy: -1),
+  (dx: -1, dy: 0),
+  (dx: 1, dy: 0),
+  (dx: -1, dy: 1),
+  (dx: 0, dy: 1),
+  (dx: 1, dy: 1),
+];
+
+/// Side length of a handle square as drawn on the component, in logical pixels.
+const double _stampHandleSize = 9;
+
+/// How close (logical pixels) a press must land to a handle to grab it. Matches
+/// the overlay's forgiving target so scaling isn't finicky on touch.
+const double _stampHandleHitRadius = 14;
+
+/// The center of [handle] on [rect], in template space.
+Offset _stampHandleCenter(Rect rect, _StampHandle handle) => Offset(
+      rect.center.dx + handle.dx * rect.width / 2,
+      rect.center.dy + handle.dy * rect.height / 2,
+    );
+
+enum _StampDragKind { move, resize }
 
 class _StampTemplateCanvasState extends State<_StampTemplateCanvas> {
-  _StampDragMode? _dragMode;
+  _StampDragKind? _dragKind;
+  _StampHandle? _dragHandle;
   Offset? _lastTemplatePoint;
-  _StampDragMode? _pendingMode;
+  _StampDragKind? _pendingKind;
+  _StampHandle? _pendingHandle;
   Offset _pendingDelta = Offset.zero;
   bool _pendingFrame = false;
 
@@ -1084,19 +1136,27 @@ class _StampTemplateCanvasState extends State<_StampTemplateCanvas> {
   Rect _componentRect(PdfStampTemplateComponent c) =>
       Rect.fromLTWH(c.x, c.y, c.width, c.height);
 
-  Rect _handleRect(PdfStampTemplateComponent c, double scale) {
-    final size = 12 / scale;
-    return Rect.fromCenter(
-      center: _componentRect(c).bottomRight,
-      width: size,
-      height: size,
-    );
+  /// The resize handle whose forgiving hit target [local] (in logical pixels)
+  /// falls within, or null. Handles ride the selected component only, and the
+  /// test runs in logical pixels so the target stays the same size at any
+  /// template zoom.
+  _StampHandle? _handleAt(Offset local, Size size) {
+    final selected = widget.selectedIndex;
+    if (selected == null || selected >= widget.components.length) return null;
+    final scale = _scale(size);
+    final rect = _componentRect(widget.components[selected]);
+    for (final handle in _stampHandles) {
+      final center = _stampHandleCenter(rect, handle) * scale;
+      if ((local - center).distance <= _stampHandleHitRadius) return handle;
+    }
+    return null;
   }
 
-  int? _hitComponent(Offset templatePoint) {
+  int? _hitComponent(Offset templatePoint, double scale) {
+    final pad = 6 / scale;
     for (var i = widget.components.length - 1; i >= 0; i--) {
       if (_componentRect(widget.components[i])
-          .inflate(4)
+          .inflate(pad)
           .contains(templatePoint)) {
         return i;
       }
@@ -1104,34 +1164,38 @@ class _StampTemplateCanvasState extends State<_StampTemplateCanvas> {
     return null;
   }
 
-  void _start(Offset localPosition, Size size) {
-    final point = _toTemplate(localPosition, size);
-    _lastTemplatePoint = point;
-    final selected = widget.selectedIndex;
-    if (selected != null) {
-      final selectedComponent = widget.components[selected];
-      if (_handleRect(selectedComponent, _scale(size)).contains(point)) {
-        _dragMode = _StampDragMode.resize;
-        return;
-      }
+  void _panStart(DragStartDetails details, Size size) {
+    final local = details.localPosition;
+    _lastTemplatePoint = _toTemplate(local, size);
+    final handle = _handleAt(local, size);
+    if (handle != null) {
+      _dragKind = _StampDragKind.resize;
+      _dragHandle = handle;
+      return;
     }
-    final hit = _hitComponent(point);
+    final hit = _hitComponent(_lastTemplatePoint!, _scale(size));
     widget.onSelect(hit);
-    _dragMode = hit == null ? null : _StampDragMode.move;
+    _dragKind = hit == null ? null : _StampDragKind.move;
+    _dragHandle = null;
   }
 
-  void _update(Offset localPosition, Size size) {
-    final point = _toTemplate(localPosition, size);
+  void _panUpdate(DragUpdateDetails details, Size size) {
+    final point = _toTemplate(details.localPosition, size);
     final last = _lastTemplatePoint;
     _lastTemplatePoint = point;
     if (last == null) return;
-    final delta = point - last;
-    _queueDelta(delta);
+    _queueDelta(point - last);
+  }
+
+  void _tapUp(TapUpDetails details, Size size) {
+    widget.onSelect(_hitComponent(_toTemplate(details.localPosition, size),
+        _scale(size)));
   }
 
   void _queueDelta(Offset delta) {
-    if (_dragMode == null || delta == Offset.zero) return;
-    _pendingMode ??= _dragMode;
+    if (_dragKind == null || delta == Offset.zero) return;
+    _pendingKind ??= _dragKind;
+    _pendingHandle ??= _dragHandle;
     _pendingDelta += delta;
     if (_pendingFrame) return;
     _pendingFrame = true;
@@ -1143,22 +1207,25 @@ class _StampTemplateCanvasState extends State<_StampTemplateCanvas> {
   }
 
   void _flushPendingDelta() {
-    final mode = _pendingMode;
+    final kind = _pendingKind;
+    final handle = _pendingHandle;
     final delta = _pendingDelta;
-    _pendingMode = null;
+    _pendingKind = null;
+    _pendingHandle = null;
     _pendingDelta = Offset.zero;
-    if (!mounted || mode == null || delta == Offset.zero) return;
-    switch (mode) {
-      case _StampDragMode.move:
+    if (!mounted || kind == null || delta == Offset.zero) return;
+    switch (kind) {
+      case _StampDragKind.move:
         widget.onMoveSelected(delta);
-      case _StampDragMode.resize:
-        widget.onResizeSelected(delta);
+      case _StampDragKind.resize:
+        widget.onResizeSelected(handle ?? const (dx: 1, dy: 1), delta);
     }
   }
 
-  void _end() {
+  void _panEnd() {
     _flushPendingDelta();
-    _dragMode = null;
+    _dragKind = null;
+    _dragHandle = null;
     _lastTemplatePoint = null;
   }
 
@@ -1177,12 +1244,18 @@ class _StampTemplateCanvasState extends State<_StampTemplateCanvas> {
       child: SizedBox(
         width: size.width,
         height: size.height,
-        child: Listener(
+        child: GestureDetector(
           behavior: HitTestBehavior.opaque,
-          onPointerDown: (event) => _start(event.localPosition, size),
-          onPointerMove: (event) => _update(event.localPosition, size),
-          onPointerUp: (_) => _end(),
-          onPointerCancel: (_) => _end(),
+          // Anchor the drag at the press point (like the on-page editing
+          // overlay) so a handle grab and a move both start where the finger
+          // actually landed, not where the recognizer won the gesture arena.
+          // Using the recognizer also gives touch slop, so a tap-to-select no
+          // longer jitters the component.
+          dragStartBehavior: DragStartBehavior.down,
+          onTapUp: (details) => _tapUp(details, size),
+          onPanStart: (details) => _panStart(details, size),
+          onPanUpdate: (details) => _panUpdate(details, size),
+          onPanEnd: (_) => _panEnd(),
           child: _StampTemplateSurface(
             templateSize: widget.templateSize,
             components: widget.components,
@@ -1332,13 +1405,17 @@ class _StampTemplatePainter extends CustomPainter {
         ..style = PaintingStyle.stroke
         ..strokeWidth = 1.5 / scale;
       canvas.drawRect(rect.inflate(2 / scale), stroke);
-      final handle = Rect.fromCenter(
-        center: rect.bottomRight,
-        width: 10 / scale,
-        height: 10 / scale,
-      );
-      canvas.drawRect(handle, Paint()..color = scheme.surface);
-      canvas.drawRect(handle, stroke);
+      final handleSize = _stampHandleSize / scale;
+      final fill = Paint()..color = scheme.surface;
+      for (final handle in _stampHandles) {
+        final box = Rect.fromCenter(
+          center: _stampHandleCenter(rect, handle),
+          width: handleSize,
+          height: handleSize,
+        );
+        canvas.drawRect(box, fill);
+        canvas.drawRect(box, stroke);
+      }
     }
     canvas.restore();
   }

--- a/packages/dart_pdf_editor/test/editing_stamps_test.dart
+++ b/packages/dart_pdf_editor/test/editing_stamps_test.dart
@@ -1335,6 +1335,52 @@ void main() {
       expect(text.height, greaterThan(36));
     });
 
+    testWidgets('stamp editor resizes from any corner with a forgiving target',
+        (tester) async {
+      PdfCustomStamp? saved;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (context) => Center(
+            child: FilledButton(
+              onPressed: () async {
+                saved = await showPdfStampEditor(context);
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final canvas = find.byKey(const ValueKey('pdf-stamp-template-canvas'));
+      final rect = tester.getRect(canvas);
+      final scale = rect.width / 240;
+      final origin = rect.topLeft;
+      // The default text component's top-left corner is at (20, 30). Grab it a
+      // few logical pixels off-center - the old single bottom-right handle
+      // could not do this, and the generous hit radius forgives the miss - then
+      // drag up and left so that corner (and only that corner) follows.
+      final resize = await tester.startGesture(
+          origin + Offset(20 * scale + 5, 30 * scale + 5),
+          kind: PointerDeviceKind.mouse);
+      await resize.moveBy(const Offset(-16, -10));
+      await resize.up();
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      final text = saved!.template!.components
+          .firstWhere((c) => c.type == PdfStampTemplateComponentType.text);
+      // Top-left corner moved out, so the origin shrank and the box grew.
+      expect(text.x, lessThan(20));
+      expect(text.y, lessThan(30));
+      expect(text.width, greaterThan(200));
+      expect(text.height, greaterThan(36));
+    });
+
     testWidgets('the picker lists and deletes saved stamps', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);

--- a/packages/dart_pdf_editor/test/editing_stamps_test.dart
+++ b/packages/dart_pdf_editor/test/editing_stamps_test.dart
@@ -1381,6 +1381,60 @@ void main() {
       expect(text.height, greaterThan(36));
     });
 
+    testWidgets('stamp editor taps to reselect the component being sized',
+        (tester) async {
+      PdfCustomStamp? saved;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (context) => Center(
+            child: FilledButton(
+              onPressed: () async {
+                saved = await showPdfStampEditor(context);
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final canvas = find.byKey(const ValueKey('pdf-stamp-template-canvas'));
+      final rect = tester.getRect(canvas);
+      final scale = rect.width / 240;
+      final origin = rect.topLeft;
+      // Tap the empty strip above the components to clear the initial text
+      // selection, then press-drag there: with nothing selected the canvas has
+      // no handles, so the gesture is a no-op instead of resizing.
+      await tester.tapAt(origin + Offset(2 * scale, 2 * scale));
+      await tester.pump();
+      final empty = await tester.startGesture(origin + Offset(2 * scale, 2 * scale),
+          kind: PointerDeviceKind.mouse);
+      await empty.moveBy(const Offset(6, 6));
+      await empty.up();
+      await tester.pump();
+
+      // Tap the border rectangle - below the caption - to select it, then drag
+      // its bottom-right corner outward to grow it.
+      await tester.tapAt(origin + Offset(120 * scale, 22 * scale));
+      await tester.pump();
+      final resize = await tester.startGesture(
+          origin + Offset(234 * scale, 80 * scale),
+          kind: PointerDeviceKind.mouse);
+      await resize.moveBy(const Offset(8, 6));
+      await resize.up();
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      final border = saved!.template!.components
+          .firstWhere((c) => c.type == PdfStampTemplateComponentType.rectangle);
+      expect(border.width, greaterThan(228));
+      expect(border.height, greaterThan(64));
+    });
+
     testWidgets('the picker lists and deletes saved stamps', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);


### PR DESCRIPTION
## Summary

The custom-stamp editor's in-dialog composer (`_StampTemplateCanvas` in `editing_stamps.dart`) was finicky on touch — "especially the scale box." It listened to raw pointer events (no touch slop, so tap-to-select jittered the component) and exposed a **single tiny resize handle at the bottom-right corner only**, so a slightly-off press read as a *move* instead of a resize.

On-page placed stamps never had this problem: a placed stamp is an ordinary `subtype == 'Stamp'` annotation that already flows through the shared `EditingPageOverlay` (eight handles, 12px hit radius, rotate knob). Only the template composer rolled its own controls.

This ports the overlay's interaction model into the composer. The two coordinate systems stay decoupled — the composer works in template space before any PDF exists, so it can't literally reuse the overlay (which is bound to a live `PdfDocument`) — but the *interaction feel* now matches:

- **`GestureDetector` with `dragStartBehavior: DragStartBehavior.down`** (`onPanStart`/`onPanUpdate`/`onPanEnd` + `onTapUp`), mirroring the overlay's own wiring. This gives real touch slop (tap-to-select no longer nudges the component) and anchors the drag at the press point. Inside the dialog's `SingleChildScrollView` the inner pan wins the arena over the scrollable.
- **Eight handles** (corners + edge midpoints) using the overlay's `(dx, dy)` edge convention, hit-tested in **logical pixels** against a 14px radius so the target is forgiving and zoom-independent. `_resizeSelected` now takes the grabbed handle and moves only the edge(s) it owns, clamped to a minimum size and the template bounds (previously it only grew width/height from a fixed top-left anchor).

No public API change — `_StampTemplateCanvas` and its callbacks are private to the editor.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Ran `dart analyze` on the package (clean) and the affected editor test files (`editing_stamps_test.dart` — 41 pass, `editing_snapshot_test.dart`, `editing_test.dart` — all pass). The stamp widget tests drive real pointer gestures through the new recognizer and assert the resulting template geometry, so the gesture path is exercised end-to-end.

## PDF fixtures and screenshots

No fixtures needed; the change is interaction-only. The existing move/resize test still drives the bottom-right corner, and a new test grabs the **top-left** corner a few pixels off-center — impossible with the old single handle — to guard the multi-handle path and the forgiving hit radius.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Only the stamp *design dialog* changed; placed on-page stamps were already using the shared overlay controls and are untouched. Session notes: `doc/dev-log/2026-07-16-stamp-canvas-touch-handles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XL4myX8bdYeo22JVmXBSs

---
_Generated by [Claude Code](https://claude.ai/code/session_013XL4myX8bdYeo22JVmXBSs)_