### PR TITLE
Bound the viewer's per-page object caches by entry count (#283)

### DIFF
--- a/doc/dev-log/2026-07-16-viewer-page-object-cache-cap.md
+++ b/doc/dev-log/2026-07-16-viewer-page-object-cache-cap.md
@@ -1,0 +1,71 @@
+# 2026-07-16 — Bound the viewer's per-page object caches (#283)
+
+Branch `claude/continue-283-286-axq6un`. Follow-up to #286, which capped the
+render worker's record cache by entry count and closed the unbounded-in-page-
+count *decoded/transcript* half of #283. #286's "notes for reviewers" flagged
+the remaining unbounded-in-page-count structure on the Dart side and this
+picks it up.
+
+## The structure
+
+`_PdfViewerState` keeps four maps keyed by page index in `pdf_viewer.dart`:
+
+- `_textCache` — a page's extracted `PdfPageText` (used by selection, search,
+  hit-testing text positions).
+- `_annotCache` — the page's interactive (action-bearing) annotations.
+- `_visibleAnnotCache` — the page's visible annotations, for host tap
+  callbacks.
+- `_fieldRectCache` — the page's form-field widget rects, for the field
+  highlight.
+
+Each was a plain `Map<int, …>` populated with `[index] ??= …` and cleared only
+on a document/revision swap (`didUpdateWidget`). So every page ever visited
+left one entry behind for the life of the viewer: retention keyed by the page
+index that only grows, the same shape #283 measured. The entries hold
+text/annotation *objects*, not decoded pixels, so the footprint is minor (as
+#286 noted), but on a long scroll it is still unbounded in the page count.
+
+## The fix
+
+New `PdfPageObjectCache<V>` (`page_object_cache.dart`) — a bounded, LRU,
+int-keyed cache. Insertion order is LRU order (a plain Dart map is
+insertion-ordered), so the first key is the least-recently used and a
+remove-then-reinsert on access moves an entry to the most-recently-used end —
+exactly the technique the render worker's record cache already uses. `[]`
+touches on read, `putIfAbsent` computes-once on a miss and evicts the LRU tail
+past the cap (never the entry just inserted). `clear()` for the swap path.
+
+The four maps become `PdfPageObjectCache` instances; the four `??=` sites
+become `putIfAbsent`, and the one plain read (`_extractText`) already used
+`[]`, which the class implements. The `.clear()` calls in `didUpdateWidget`
+are unchanged.
+
+Cap: `pdfViewerPageObjectCacheMaxEntries` (default 128), a runtime override
+mirroring `pdfRenderWorkerCacheMaxEntries` so a memory-constrained host can
+lower it once at startup. 128 sits far above the on-screen + preview-warm
+working set (a page's objects are derived only when it is near the viewport —
+hit-tested, selected, or searched; `previewWindow` ≤ 10 each side), so a page
+in view is never the LRU victim and ordinary back-and-forth revisits still hit.
+
+Full-document search (`_searchAllPages`) walks every page through
+`_extractText`, using each page's text once and immediately, with no cross-page
+reuse — so eviction behind the walk costs nothing, and a static document still
+has the persistent `PdfViewer.textCache` behind the in-memory cap.
+
+## Tests
+
+`page_object_cache_test.dart`: the count is bounded across a 100-page fill
+(cap 3, only the newest survive); the cap is never undershot while filling; a
+lookup marks its page MRU so the untouched LRU page is the eviction victim; a
+`putIfAbsent` hit returns the stored value without recomputing and refreshes
+recency; `clear` empties; the runtime-default / explicit-override plumbing; and
+the cap floors at 1. `dart analyze` is clean; `pdf_viewer_test.dart` and the
+text-cache suites still pass.
+
+## Left open / scope
+
+This is the last of the *Dart-side* unbounded-in-page-count retention #283
+named. The bulk of the memory the issue measured on a 62-page scroll remains
+CanvasKit's wasm heap, which never shrinks back after `ui.Image.dispose()` on
+web — an engine characteristic (already noted in `performance_policy.dart`),
+mitigated by the `imagePixelRatioCap` tiers, not fixable from Dart.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -44,6 +44,7 @@ export 'src/image_decoder.dart' show PdfImageCache;
 export 'src/ocr.dart';
 export 'src/page_export.dart';
 export 'src/page_geometry.dart';
+export 'src/page_object_cache.dart';
 export 'src/page_number_field.dart';
 export 'src/page_render_session.dart';
 export 'src/perf_log.dart';

--- a/packages/dart_pdf_editor/lib/src/page_object_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/page_object_cache.dart
@@ -1,0 +1,86 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+/// Default maximum number of per-page objects the viewer keeps in each of its
+/// page-keyed object caches (extracted text, annotation lists, form-field
+/// rects).
+const int defaultPdfViewerPageObjectCacheMaxEntries = 128;
+
+/// Maximum number of per-page objects the viewer retains in each page-keyed
+/// object cache, regardless of size. See [PdfPageObjectCache].
+///
+/// Left unbounded these caches grow one small entry for every page ever
+/// visited and are dropped only on a document/revision swap - retention keyed
+/// by the page index that only ever grows, the same shape issue #283 measured
+/// (the render worker's record cache had the identical problem, capped in
+/// #286). The entries hold text/annotation data, not decoded pixels, so the
+/// footprint is minor, but on a long scroll it is still unbounded in the page
+/// count. Capturing this cap when a viewer builds its caches bounds it. Lower
+/// it once at startup on a memory-constrained device.
+int pdfViewerPageObjectCacheMaxEntries =
+    defaultPdfViewerPageObjectCacheMaxEntries;
+
+/// A bounded, least-recently-used cache keyed by page index.
+///
+/// The viewer derives a few objects per page - extracted text, the interactive
+/// and visible annotation lists, the form-field rects - and keeps them so a
+/// re-visit (a scroll back, a hit-test, a search) does not recompute. The cap
+/// sits well above the on-screen plus preview-warm working set (a page's
+/// objects are derived only when it is near the viewport - hit-tested, selected
+/// or searched), so ordinary back-and-forth revisits still hit; it only stops
+/// the cold tail from growing without limit on a long document.
+///
+/// Insertion order is LRU order: a plain Dart map is insertion-ordered, so its
+/// first key is the least-recently used, and a remove-then-reinsert on access
+/// moves an entry to the most-recently-used end (the technique the render
+/// worker's record cache uses). A lookup or insert therefore marks its page
+/// most-recently used, so a page in view is never the eviction victim.
+///
+/// [V] is expected to be non-nullable - a stored null reads back as a miss.
+class PdfPageObjectCache<V> {
+  PdfPageObjectCache({int? maxEntries})
+      : _maxEntries =
+            math.max(1, maxEntries ?? pdfViewerPageObjectCacheMaxEntries);
+
+  /// The most entries this cache retains before evicting the least-recently
+  /// used. At least 1.
+  final int _maxEntries;
+
+  final Map<int, V> _entries = {};
+
+  /// The cached value for [page], or null on a miss. A hit is marked
+  /// most-recently used so a lookup protects the entry from eviction.
+  V? operator [](int page) {
+    final hit = _entries.remove(page);
+    if (hit == null) return null;
+    _entries[page] = hit;
+    return hit;
+  }
+
+  /// The cached value for [page], computing and storing it with [ifAbsent] on
+  /// a miss. The entry is marked most-recently used, then the least-recently
+  /// used entries past the cap are evicted (never the entry just inserted - it
+  /// is the most-recently used).
+  V putIfAbsent(int page, V Function() ifAbsent) {
+    final existing = this[page];
+    if (existing != null) return existing;
+    final value = ifAbsent();
+    _entries[page] = value;
+    while (_entries.length > _maxEntries) {
+      _entries.remove(_entries.keys.first);
+    }
+    return value;
+  }
+
+  /// Drops every entry - a document or revision swap invalidates them all.
+  void clear() => _entries.clear();
+
+  /// The number of retained entries. Bounded by the configured cap.
+  @visibleForTesting
+  int get length => _entries.length;
+
+  /// The retained pages, least-recently used first.
+  @visibleForTesting
+  Iterable<int> get pages => _entries.keys;
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -26,6 +26,7 @@ import 'editing/tool_shortcuts.dart';
 import 'exact_extent_list.dart';
 import 'image_decoder.dart';
 import 'page_geometry.dart';
+import 'page_object_cache.dart';
 import 'perf_log.dart';
 import 'performance_policy.dart';
 import 'pdf_page_view.dart';
@@ -929,10 +930,17 @@ class _PdfViewerState extends State<PdfViewer>
   /// layout zoom 1 this page exactly fills the viewport; narrower pages lay
   /// out proportionally narrower and centered.
   double _maxPointWidth = 0;
-  final Map<int, PdfPageText> _textCache = {};
-  final Map<int, List<PdfAnnotation>> _annotCache = {};
-  final Map<int, List<PdfAnnotation>> _visibleAnnotCache = {};
-  final Map<int, List<PdfRect>> _fieldRectCache = {};
+  // Per-page derived objects, bounded LRU so a long scroll cannot pin one
+  // entry per visited page for the life of the viewer (issue #283). They are
+  // warm only near the viewport (derived on hit-test/selection/search), so a
+  // cap well above the working set never evicts an on-screen page.
+  final PdfPageObjectCache<PdfPageText> _textCache = PdfPageObjectCache();
+  final PdfPageObjectCache<List<PdfAnnotation>> _annotCache =
+      PdfPageObjectCache();
+  final PdfPageObjectCache<List<PdfAnnotation>> _visibleAnnotCache =
+      PdfPageObjectCache();
+  final PdfPageObjectCache<List<PdfRect>> _fieldRectCache =
+      PdfPageObjectCache();
   double _viewWidth = 0;
   double _viewHeight = 0;
 
@@ -2313,10 +2321,10 @@ class _PdfViewerState extends State<PdfViewer>
     if (textCache != null && key != null && widget.editing == null) {
       final text = await textCache.get(
           key, index, () => PdfTextExtractor.extract(widget.document, index));
-      return _textCache[index] ??= text;
+      return _textCache.putIfAbsent(index, () => text);
     }
-    return _textCache[index] ??=
-        PdfTextExtractor.extract(widget.document, index);
+    return _textCache.putIfAbsent(
+        index, () => PdfTextExtractor.extract(widget.document, index));
   }
 
   Future<List<PdfSearchResult>> _searchAllPages(
@@ -2373,8 +2381,8 @@ class _PdfViewerState extends State<PdfViewer>
     );
   }
 
-  PdfPageText _pageText(int index) =>
-      _textCache[index] ??= PdfTextExtractor.extract(widget.document, index);
+  PdfPageText _pageText(int index) => _textCache.putIfAbsent(
+      index, () => PdfTextExtractor.extract(widget.document, index));
 
   /// The visible part of page [index]'s laid-out area, as fractions of
   /// the page (0–1, y-down), or null while the page is off-screen.
@@ -2551,26 +2559,28 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   /// Visible annotations with an action on a page, cached.
-  List<PdfAnnotation> _interactiveAnnots(int index) => _annotCache[index] ??= [
-        for (final a in _pages[index].annotations)
-          if (!a.isHidden && !a.isNoView && a.action != null) a,
-      ];
+  List<PdfAnnotation> _interactiveAnnots(int index) =>
+      _annotCache.putIfAbsent(index, () => [
+            for (final a in _pages[index].annotations)
+              if (!a.isHidden && !a.isNoView && a.action != null) a,
+          ]);
 
   /// All visible annotations on a page, cached for hit-testing host tap
   /// callbacks.
   List<PdfAnnotation> _visibleAnnots(int index) =>
-      _visibleAnnotCache[index] ??= [
-        for (final a in _pages[index].annotations)
-          if (!a.isHidden && !a.isNoView) a,
-      ];
+      _visibleAnnotCache.putIfAbsent(index, () => [
+            for (final a in _pages[index].annotations)
+              if (!a.isHidden && !a.isNoView) a,
+          ]);
 
   /// Visible form-field widget rects on a page, for the field highlight.
   /// Cached beside the annotation caches (same lifecycle: pages are reloaded
   /// on every document swap).
-  List<PdfRect> _formFieldRects(int index) => _fieldRectCache[index] ??= [
-        for (final a in _pages[index].annotations)
-          if (a is PdfWidgetAnnotation && !a.isHidden && !a.isNoView) a.rect,
-      ];
+  List<PdfRect> _formFieldRects(int index) =>
+      _fieldRectCache.putIfAbsent(index, () => [
+            for (final a in _pages[index].annotations)
+              if (a is PdfWidgetAnnotation && !a.isHidden && !a.isNoView) a.rect,
+          ]);
 
   ({
     int pageIndex,

--- a/packages/dart_pdf_editor/test/page_object_cache_test.dart
+++ b/packages/dart_pdf_editor/test/page_object_cache_test.dart
@@ -1,0 +1,106 @@
+// The viewer's per-page object caches (extracted text, annotation lists,
+// form-field rects) are bounded LRU maps so a long scroll cannot pin one entry
+// per visited page for the life of the viewer (issue #283 / follow-up to #286).
+// These cases pin the count bound, the LRU order under both reads and inserts,
+// the compute-once semantics, and the runtime-default / explicit-override
+// plumbing.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PdfPageObjectCache', () {
+    test('bounds the entry count so a long scroll cannot grow unbounded', () {
+      final cache = PdfPageObjectCache<int>(maxEntries: 3);
+      for (var page = 0; page < 100; page++) {
+        cache.putIfAbsent(page, () => page);
+      }
+      expect(cache.length, 3);
+      // The most-recently inserted survive; the cold tail is gone.
+      expect(cache.pages.toList(), [97, 98, 99]);
+    });
+
+    test('never drops below the cap while filling', () {
+      final cache = PdfPageObjectCache<int>(maxEntries: 5);
+      for (var page = 0; page < 5; page++) {
+        cache.putIfAbsent(page, () => page);
+      }
+      expect(cache.length, 5);
+      cache.putIfAbsent(5, () => 5);
+      expect(cache.length, 5, reason: 'inserting a sixth evicts, not grows');
+      expect(cache[0], isNull, reason: 'the LRU entry (page 0) was evicted');
+    });
+
+    test('a lookup marks its page most-recently used', () {
+      final cache = PdfPageObjectCache<int>(maxEntries: 3);
+      cache.putIfAbsent(0, () => 0);
+      cache.putIfAbsent(1, () => 1);
+      cache.putIfAbsent(2, () => 2);
+      // Touch page 0 so it is no longer the LRU victim.
+      expect(cache[0], 0);
+      // Inserting page 3 must now evict page 1 (the untouched LRU), not 0.
+      cache.putIfAbsent(3, () => 3);
+      expect(cache[0], 0, reason: 'the touched page survived eviction');
+      expect(cache[1], isNull, reason: 'the untouched LRU page was evicted');
+      expect(cache[2], 2);
+      expect(cache[3], 3);
+    });
+
+    test('an insert of an existing page refreshes its recency without recompute',
+        () {
+      final cache = PdfPageObjectCache<int>(maxEntries: 3);
+      cache.putIfAbsent(0, () => 0);
+      cache.putIfAbsent(1, () => 1);
+      cache.putIfAbsent(2, () => 2);
+      var recomputed = false;
+      // A hit returns the stored value and does not run the compute closure.
+      expect(cache.putIfAbsent(0, () {
+        recomputed = true;
+        return -1;
+      }), 0);
+      expect(recomputed, isFalse);
+      // ...and page 0 is now the most-recently used, so page 1 is the victim.
+      cache.putIfAbsent(3, () => 3);
+      expect(cache[0], 0);
+      expect(cache[1], isNull);
+    });
+
+    test('clear drops every entry', () {
+      final cache = PdfPageObjectCache<int>(maxEntries: 3);
+      cache.putIfAbsent(0, () => 0);
+      cache.putIfAbsent(1, () => 1);
+      cache.clear();
+      expect(cache.length, 0);
+      expect(cache[0], isNull);
+    });
+
+    test('a null maxEntries takes the runtime default', () {
+      final previous = pdfViewerPageObjectCacheMaxEntries;
+      addTearDown(() => pdfViewerPageObjectCacheMaxEntries = previous);
+      pdfViewerPageObjectCacheMaxEntries = 2;
+      final cache = PdfPageObjectCache<int>();
+      for (var page = 0; page < 10; page++) {
+        cache.putIfAbsent(page, () => page);
+      }
+      expect(cache.length, 2);
+    });
+
+    test('an explicit maxEntries overrides the runtime default', () {
+      final previous = pdfViewerPageObjectCacheMaxEntries;
+      addTearDown(() => pdfViewerPageObjectCacheMaxEntries = previous);
+      pdfViewerPageObjectCacheMaxEntries = 2;
+      final cache = PdfPageObjectCache<int>(maxEntries: 4);
+      for (var page = 0; page < 10; page++) {
+        cache.putIfAbsent(page, () => page);
+      }
+      expect(cache.length, 4);
+    });
+
+    test('the cap is floored at 1', () {
+      final cache = PdfPageObjectCache<int>(maxEntries: 0);
+      cache.putIfAbsent(0, () => 0);
+      cache.putIfAbsent(1, () => 1);
+      expect(cache.length, 1);
+      expect(cache.pages.toList(), [1]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #286, which capped the render worker's record cache by entry count and closed the unbounded-in-page-count *decoded/transcript* half of #283. #286's "notes for reviewers" flagged the remaining unbounded-in-page-count structure on the Dart side; this picks it up.

`_PdfViewerState` (`pdf_viewer.dart`) keeps four maps keyed by page index — `_textCache` (extracted `PdfPageText`), `_annotCache` (interactive annotations), `_visibleAnnotCache` (visible annotations), and `_fieldRectCache` (form-field widget rects). Each was a plain `Map<int, …>` populated with `[index] ??= …` and cleared only on a document/revision swap, so every page ever visited left one entry behind for the life of the viewer: retention keyed by the page index that only grows — the same shape #283 measured. The entries hold text/annotation *objects*, not decoded pixels, so the footprint is minor (as #286 noted), but on a long scroll it is still unbounded in the page count.

The fix adds `PdfPageObjectCache<V>` (`page_object_cache.dart`): a bounded, LRU, int-keyed cache using the same insertion-order-is-LRU technique as the render worker's record cache — `[]` touches on read, `putIfAbsent` computes-once on a miss and evicts the LRU tail past the cap (never the entry just inserted), `clear()` for the swap path. The four maps become `PdfPageObjectCache` instances; the `??=` sites become `putIfAbsent`; the existing `.clear()` calls are unchanged.

The cap `pdfViewerPageObjectCacheMaxEntries` (default 128) mirrors `pdfRenderWorkerCacheMaxEntries` — a runtime override a memory-constrained host can lower once at startup. 128 sits far above the on-screen + preview-warm working set (a page's objects are derived only when it is near the viewport — hit-tested, selected, or searched; `previewWindow` ≤ 10 each side), so a page in view is never the LRU victim and ordinary back-and-forth revisits still hit. Full-document search walks every page through `_extractText`, using each page's text once with no cross-page reuse, so eviction behind the walk costs nothing; a static document still has the persistent `PdfViewer.textCache` behind the in-memory cap.

**Scope / left open:** this is the last of the *Dart-side* unbounded-in-page-count retention #283 named. The bulk of the memory the issue measured on a 62-page scroll remains CanvasKit's wasm heap, which never shrinks back after `ui.Image.dispose()` on web — an engine characteristic (noted in `performance_policy.dart`), mitigated by the `imagePixelRatioCap` tiers, not fixable from Dart. See `doc/dev-log/2026-07-16-viewer-page-object-cache-cap.md`.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Performance change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

`dart analyze` is clean across the package; `page_object_cache_test.dart` (8 new cases), `pdf_viewer_test.dart`, and the text-cache suites pass.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- New `page_object_cache_test.dart` covers the count bound (100-page fill, cap 3), LRU order under both reads and inserts (a touched page survives, the untouched LRU is the victim), the compute-once `putIfAbsent` hit, `clear`, the default/override plumbing, and the cap floor at 1.
- Default cap is 128, overridable per-cache (`maxEntries:`) and globally (`pdfViewerPageObjectCacheMaxEntries`), mirroring `pdfRenderWorkerCacheMaxEntries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wxwuoY43cNUfEKqPHfmK2

---
_Generated by [Claude Code](https://claude.ai/code/session_017wxwuoY43cNUfEKqPHfmK2)_