### PR TITLE
Expose a customizable viewer scroll indicator / page-scrubber API (#326)

### DIFF
--- a/doc/dev-log/2026-07-16-scroll-indicator-api.md
+++ b/doc/dev-log/2026-07-16-scroll-indicator-api.md
@@ -65,3 +65,31 @@ Tests: `test/scroll_indicator_test.dart` (metrics equality, snapshot
 before/after layout, position tracking, no-overflow, `jumpToNormalized`
 top/bottom/mid/clamp, `animateToPage`, builder replacing the stock bar +
 receiving live metrics + not building on no-overflow + a scrubber drag).
+
+## Example app demo
+
+`example/lib/scroll_indicator_demo.dart` (`ScrollIndicatorDemoScreen`) is a
+self-contained screen that exercises the whole API for people to see, opened
+from the DartPDF menu ("Scroll indicator API demo") as a full-screen route
+over the demo PDF. It replaces the stock bar with a draggable page scrubber
+(`scrollIndicatorBuilder` → a `_PageScrubber` sized by `extent`, positioned
+by `position`, driven with `jumpToNormalized`), pops a page bubble while
+dragging, animates page taps in the app bar via `animateToPage`, and shows a
+live corner readout of the raw `PdfScrollMetrics`.
+
+Gotchas that shaped it:
+
+- **The readout is fed from the builder, not `viewportChanges`.** The corner
+  readout renders from the last metrics the viewer handed `scrollIndicatorBuilder`
+  (stashed via a post-frame `setState`, only when changed), so it is populated
+  the moment the viewer lays out. Listening to `viewportChanges` alone leaves
+  it in the "not laid out" state until the first scroll/zoom, because that
+  `Listenable` doesn't fire on the initial layout.
+- **The drag target must be the strip, not the fill.** The builder's return
+  fills the viewer's `Positioned.fill` slot, so the scrubber `Align`s its 48px
+  strip to the right edge; the test-facing key sits on the strip's
+  `GestureDetector` (not the outer widget, whose box is full-screen) so a
+  `tester.drag` lands on the opaque strip rather than the page underneath.
+
+Test: `example/test/scroll_indicator_demo_test.dart` (scrubber replaces the
+stock thumb, readout populates after layout, a strip drag scrolls the list).

--- a/doc/dev-log/2026-07-16-scroll-indicator-api.md
+++ b/doc/dev-log/2026-07-16-scroll-indicator-api.md
@@ -1,0 +1,67 @@
+# Viewer scroll-indicator / page-scrubber API (issue #326)
+
+Exposed a supported customization point for the viewer's scroll indicator
+so a host can build a compact page number, a draggable page scrubber, or a
+platform-styled scrollbar without reaching into the viewer's private
+`ScrollController`. Both halves the issue asked for: a read-only scroll-state
+snapshot + page-aware commands on `PdfViewerController`, and a builder on
+`PdfViewer`.
+
+All in `pdf_viewer.dart` (whole file is re-exported, so the new public types
+ship automatically).
+
+## What landed
+
+- **`PdfScrollMetrics`** - immutable snapshot: `pageCount`, `currentPage`,
+  normalized `position` (0 top … 1 bottom) and `extent` (visible fraction),
+  the list-space pixel triple (`pixels`/`maxPixels`/`viewportPixels`),
+  `zoom` (px/pt, same as `PdfViewerController.zoom`), and `hasOverflow`.
+- **`PdfViewerController.scrollMetrics`** - reads the snapshot, null before
+  layout. Listen to the existing `viewportChanges` `Listenable` to know when
+  to re-read (it already fires on scroll and zoom; the controller itself
+  stays quiet during scrolling and only notifies on a `currentPage` flip).
+- **`PdfViewerController.jumpToNormalized(double)`** - immediate, zoom-aware
+  scroll to a normalized position; what a scrubber-thumb drag maps to.
+- **`PdfViewerController.animateToPage(int, {duration, curve})`** - the
+  animated sibling of the existing `jumpToPage`.
+- **`PdfViewer.scrollIndicatorBuilder`** (`PdfScrollIndicatorBuilder`) -
+  replaces the built-in **vertical** scrollbar with a host widget, stacked
+  over the right edge outside the zoom transform. The horizontal
+  (zoom-window) bar is untouched.
+
+## Design notes / gotchas
+
+- **Reuse over reinvention.** The metrics mirror `PdfScrollbar`'s own
+  measurement (`_verticalScrollExtents`): `total = maxScrollExtent +
+  viewportDimension`, `visible = viewportDimension / scale`, and the
+  viewport's leading edge unprojects through the transform as
+  `-t_y/s + pixels` (the same formula `_visibleFractionOf` /
+  `_captureViewport` use). So a custom thumb of height `extent` at
+  `position` lines up pixel-for-pixel with the stock bar at any zoom and
+  with mixed page sizes.
+- **`jumpToNormalized` routes through `_scrollbarScrollBy`** (the scrollbar's
+  own list-space motion), so it spills into the zoom window at the extents
+  exactly like a bar drag - no separate zoom bookkeeping.
+- **`hasOverflow` is threshold-based, not `maxPixels > 0`.** The list pads
+  its bottom by `pageSpacing`, so a fully visible document still carries
+  ~12px of nominal slack. The stock bar hides for it via
+  `PdfScrollbar.minOverflow`; `hasOverflow` matches (`range > pageSpacing`),
+  and the viewer skips the builder entirely while it is false, so a host
+  never has to guard the "document fits" case. `extent` there is ~0.98 (the
+  trailing margin), not 1.
+- **`animateToPage` keeps `jumpToPage`'s far-jump snap.** Beyond
+  `max(viewHeight*2, 2400)` px it snaps (warming the destination preview)
+  rather than animating every intervening page into view; within range it
+  animates for the given duration/curve. Both share the refactored
+  `_jumpToPage(index, {duration, curve})`.
+- **Full-fill builder + gesture arena.** The indicator is `Positioned.fill`
+  so a host can float a page label anywhere or run a full-height scrubber.
+  Interactive regions must set an opaque hit behavior (like the stock bar's
+  strip) to win the vertical-drag arena over the scroll view underneath;
+  non-interactive areas pass through to the viewer. The test's scrubber uses
+  `HitTestBehavior.opaque` for this reason.
+
+Tests: `test/scroll_indicator_test.dart` (metrics equality, snapshot
+before/after layout, position tracking, no-overflow, `jumpToNormalized`
+top/bottom/mid/clamp, `animateToPage`, builder replacing the stock bar +
+receiving live metrics + not building on no-overflow + a scrubber drag).

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Expose a customizable viewer scroll indicator / page-scrubber API: a
+  read-only `PdfScrollMetrics` snapshot (page count, current page,
+  normalized position/extent, pixel offsets, zoom) via
+  `PdfViewerController.scrollMetrics`, page-aware commands
+  `jumpToNormalized` and `animateToPage` alongside the existing
+  `jumpToPage`, and a `PdfViewer.scrollIndicatorBuilder` that replaces the
+  built-in vertical scrollbar with a host widget (#326).
+
 ## 1.4.7
 
 - Print through each platform's native print system: the Dart engine

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -18,6 +18,7 @@ import 'feedback.dart';
 import 'persistent_cache.dart';
 import 'platform_fonts.dart';
 import 'recent_files.dart';
+import 'scroll_indicator_demo.dart';
 
 /// The project's source repository, opened from the AppBar links menu.
 final _githubUrl = Uri.parse('https://github.com/ben-milanko/dart-pdf');
@@ -382,6 +383,18 @@ class _ViewerScreenState extends State<ViewerScreen> {
           child: _appMenuTile(
             icon: Icons.auto_awesome,
             title: 'Open the interactive demo',
+          ),
+        ),
+        PopupMenuItem(
+          value: () => unawaited(Navigator.of(menuContext).push(
+            MaterialPageRoute<void>(
+              builder: (_) =>
+                  ScrollIndicatorDemoScreen(bytes: buildDemoPdf()),
+            ),
+          )),
+          child: _appMenuTile(
+            icon: Icons.straighten,
+            title: 'Scroll indicator API demo',
           ),
         ),
         ..._recentMenuItems(menuContext),

--- a/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
+++ b/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
@@ -1,0 +1,297 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+/// A self-contained showcase of the viewer's public scroll-indicator API
+/// (issue #326): [PdfViewer.scrollIndicatorBuilder] fed by a live
+/// [PdfScrollMetrics], driven back with
+/// [PdfViewerController.jumpToNormalized] and
+/// [PdfViewerController.animateToPage].
+///
+/// The built-in scrollbar is replaced with a draggable page scrubber that
+/// pops a page bubble while dragging, and a corner readout mirrors the raw
+/// metrics so the numbers are visible as you scroll and zoom. The app opens
+/// it as a full-screen route from the DartPDF menu.
+class ScrollIndicatorDemoScreen extends StatefulWidget {
+  const ScrollIndicatorDemoScreen({super.key, required this.bytes});
+
+  /// The document to show - the app passes the feature-showcase demo PDF.
+  final Uint8List bytes;
+
+  @override
+  State<ScrollIndicatorDemoScreen> createState() =>
+      _ScrollIndicatorDemoScreenState();
+}
+
+class _ScrollIndicatorDemoScreenState extends State<ScrollIndicatorDemoScreen> {
+  final _controller = PdfViewerController();
+  late final PdfDocument _document = PdfDocument.open(widget.bytes);
+
+  /// The latest metrics the viewer handed to [scrollIndicatorBuilder]. The
+  /// corner readout renders from this so it is populated the moment the
+  /// viewer lays out and tracks every scroll/zoom, without depending on when
+  /// [PdfViewerController.viewportChanges] first fires.
+  PdfScrollMetrics? _latest;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Called from the indicator builder (during layout). We cannot call
+  /// [setState] mid-build, so stash the value after the frame - and only
+  /// when it actually changed, to avoid a rebuild per identical frame.
+  void _onMetrics(PdfScrollMetrics metrics) {
+    if (metrics == _latest) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _latest = metrics);
+    });
+  }
+
+  void _step(int delta) {
+    final metrics = _controller.scrollMetrics;
+    if (metrics == null) return;
+    final target =
+        (metrics.currentPage + delta).clamp(0, metrics.pageCount - 1);
+    // animateToPage: the smooth sibling of jumpToPage
+    _controller.animateToPage(target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Scroll indicator API'),
+        actions: [
+          IconButton(
+            tooltip: 'Previous page',
+            icon: const Icon(Icons.keyboard_arrow_up),
+            onPressed: () => _step(-1),
+          ),
+          IconButton(
+            tooltip: 'Next page',
+            icon: const Icon(Icons.keyboard_arrow_down),
+            onPressed: () => _step(1),
+          ),
+          const SizedBox(width: 4),
+        ],
+      ),
+      body: Stack(
+        children: [
+          PdfViewer(
+            document: _document,
+            controller: _controller,
+            // width fit guarantees vertical overflow so the scrubber shows
+            initialFit: PdfViewerFit.width,
+            // the whole point of the demo: swap the stock bar for our own
+            scrollIndicatorBuilder: (context, controller, metrics) {
+              _onMetrics(metrics);
+              return _PageScrubber(
+                // a stable key keeps the scrubber's drag state across the
+                // metric-driven rebuilds
+                key: const ValueKey('demo-scrubber-state'),
+                controller: controller,
+                metrics: metrics,
+              );
+            },
+          ),
+          Positioned(
+            left: 12,
+            bottom: 12,
+            child: _MetricsReadout(metrics: _latest),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A draggable page scrubber that mirrors the stock scrollbar's geometry
+/// from [PdfScrollMetrics] (thumb of height `extent` at `position`) and
+/// drives the view with [PdfViewerController.jumpToNormalized].
+class _PageScrubber extends StatefulWidget {
+  const _PageScrubber({
+    super.key,
+    required this.controller,
+    required this.metrics,
+  });
+
+  final PdfViewerController controller;
+  final PdfScrollMetrics metrics;
+
+  @override
+  State<_PageScrubber> createState() => _PageScrubberState();
+}
+
+class _PageScrubberState extends State<_PageScrubber> {
+  static const _trackWidth = 48.0;
+  static const _minThumb = 44.0;
+
+  bool _dragging = false;
+
+  void _scrubTo(double localY, double trackHeight, double thumbHeight) {
+    final span = trackHeight - thumbHeight;
+    // map the pointer to the thumb's *centre*, so grabbing anywhere on the
+    // thumb feels natural, then hand the fraction to the controller
+    final fraction =
+        span <= 0 ? 0.0 : ((localY - thumbHeight / 2) / span).clamp(0.0, 1.0);
+    widget.controller.jumpToNormalized(fraction);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final metrics = widget.metrics;
+    final scheme = Theme.of(context).colorScheme;
+    return Align(
+      alignment: Alignment.centerRight,
+      child: SizedBox(
+        width: _trackWidth,
+        child: LayoutBuilder(builder: (context, constraints) {
+          final trackHeight = constraints.maxHeight;
+          final thumbHeight =
+              (metrics.extent * trackHeight).clamp(_minThumb, trackHeight);
+          final thumbTop = metrics.position * (trackHeight - thumbHeight);
+          return GestureDetector(
+            // the drag target - a 48px strip down the right edge
+            key: const ValueKey('demo-page-scrubber'),
+            // opaque so the scrubber wins the vertical-drag gesture arena
+            // over the scroll view underneath (as the stock bar's strip does)
+            behavior: HitTestBehavior.opaque,
+            onVerticalDragStart: (d) {
+              setState(() => _dragging = true);
+              _scrubTo(d.localPosition.dy, trackHeight, thumbHeight);
+            },
+            onVerticalDragUpdate: (d) =>
+                _scrubTo(d.localPosition.dy, trackHeight, thumbHeight),
+            onVerticalDragEnd: (_) => setState(() => _dragging = false),
+            onVerticalDragCancel: () => setState(() => _dragging = false),
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                // a faint track scrim down the right edge
+                Positioned(
+                  top: 0,
+                  bottom: 0,
+                  right: 8,
+                  width: 6,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: scheme.onSurface.withValues(alpha: 0.08),
+                      borderRadius: BorderRadius.circular(3),
+                    ),
+                  ),
+                ),
+                // the thumb - height is metrics.extent, offset is position
+                Positioned(
+                  top: thumbTop,
+                  right: 4,
+                  width: _trackWidth - 8,
+                  height: thumbHeight,
+                  child: Center(
+                    child: Container(
+                      width: _dragging ? 16 : 12,
+                      height: thumbHeight,
+                      decoration: BoxDecoration(
+                        color: _dragging
+                            ? scheme.primary
+                            : scheme.primary.withValues(alpha: 0.75),
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(
+                            color: scheme.onSurface.withValues(alpha: 0.25)),
+                      ),
+                    ),
+                  ),
+                ),
+                // a page bubble that follows the thumb while dragging
+                if (_dragging)
+                  Positioned(
+                    right: _trackWidth,
+                    top: (thumbTop + thumbHeight / 2 - 18)
+                        .clamp(0.0, trackHeight - 36),
+                    child: _Bubble(
+                      'Page ${metrics.currentPage + 1} / ${metrics.pageCount}',
+                    ),
+                  ),
+              ],
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _Bubble extends StatelessWidget {
+  const _Bubble(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.inverseSurface,
+      elevation: 3,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Text(
+          text,
+          style: TextStyle(
+              color: scheme.onInverseSurface, fontWeight: FontWeight.w600),
+        ),
+      ),
+    );
+  }
+}
+
+/// A live readout of the raw [PdfScrollMetrics] the viewer last reported, so
+/// the numbers behind the scrubber are visible as you scroll and zoom.
+class _MetricsReadout extends StatelessWidget {
+  const _MetricsReadout({required this.metrics});
+
+  final PdfScrollMetrics? metrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final m = metrics;
+    final lines = m == null
+        ? const ['scrollMetrics: null (not laid out)']
+        : [
+            'page:      ${m.currentPage + 1} / ${m.pageCount}',
+            'position:  ${m.position.toStringAsFixed(3)}',
+            'extent:    ${m.extent.toStringAsFixed(3)}',
+            'zoom:      ${m.zoom.toStringAsFixed(2)}x',
+            'overflow:  ${m.hasOverflow}',
+          ];
+    return IgnorePointer(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: scheme.inverseSurface.withValues(alpha: 0.9),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final line in lines)
+              Text(
+                line,
+                style: TextStyle(
+                  color: scheme.onInverseSurface,
+                  fontFeatures: const [FontFeature.tabularFigures()],
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/dart_pdf_editor/example/test/scroll_indicator_demo_test.dart
+++ b/packages/dart_pdf_editor/example/test/scroll_indicator_demo_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_viewer_example/scroll_indicator_demo.dart';
+import 'package:pdf_viewer_example/demo_document.dart';
+
+void main() {
+  testWidgets('demo replaces the stock bar with a working page scrubber',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: ScrollIndicatorDemoScreen(bytes: buildDemoPdf()),
+    ));
+    await tester.pump();
+
+    // the custom scrubber is up and the stock scrollbar thumb is gone
+    expect(find.byKey(const ValueKey('demo-page-scrubber')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-scrollbar-thumb')), findsNothing);
+
+    // the live-metrics readout populates once layout settles (the builder
+    // stashes metrics via a post-frame setState, so pump to flush it)
+    await tester.pump();
+    expect(find.textContaining('page:'), findsOneWidget);
+
+    // dragging the scrubber scrolls the document (verified on the underlying
+    // scroll position, which the scrubber drives via jumpToNormalized)
+    final scroll =
+        tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+    expect(scroll.pixels, moreOrLessEquals(0, epsilon: 0.5));
+    await tester.drag(find.byKey(const ValueKey('demo-page-scrubber')),
+        const Offset(0, 400));
+    await tester.pump();
+    expect(scroll.pixels, greaterThan(0));
+
+    // the readout catches up on the next frame (post-frame setState)
+    await tester.pump();
+    expect(find.textContaining('position:  0.000'), findsNothing);
+
+    // drain the viewer's settle/motion-hold timers before teardown
+    await tester.pumpAndSettle();
+  });
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -141,6 +141,95 @@ class PdfViewSync {
   final Matrix4 transform;
 }
 
+/// A read-only snapshot of a [PdfViewer]'s vertical scroll state, enough to
+/// drive a custom scroll indicator or page scrubber without reaching into
+/// the viewer's private scroll controller. Read it from
+/// [PdfViewerController.scrollMetrics] (or the [PdfScrollIndicatorBuilder]),
+/// and listen to [PdfViewerController.viewportChanges] to know when to
+/// re-read it.
+///
+/// The normalized [position] and [extent] behave the same as the built-in
+/// scrollbar's thumb (they account for zoom and mixed page sizes): a thumb
+/// of height `extent` sitting at `position` along the track mirrors the
+/// stock bar. The pixel fields are in the viewer's internal list space
+/// (logical pixels at the current layout zoom, before the zoom-window
+/// transform) - useful for precise math, but most indicators only need the
+/// normalized pair.
+class PdfScrollMetrics {
+  const PdfScrollMetrics({
+    required this.pageCount,
+    required this.currentPage,
+    required this.position,
+    required this.extent,
+    required this.pixels,
+    required this.maxPixels,
+    required this.viewportPixels,
+    required this.zoom,
+    required this.hasOverflow,
+  });
+
+  /// Number of pages in the document.
+  final int pageCount;
+
+  /// Zero-based index of the page nearest the viewport center - the same
+  /// value as [PdfViewerController.currentPage].
+  final int currentPage;
+
+  /// Normalized scroll position along the vertical axis: 0 at the top, 1
+  /// fully scrolled to the bottom. 0 when the whole document fits and there
+  /// is nothing to scroll ([hasOverflow] is false).
+  final double position;
+
+  /// The visible fraction of the scrollable content (0–1) - a page scrubber
+  /// sizes its thumb by this. 1 when the whole document fits.
+  final double extent;
+
+  /// Leading (top) edge of the viewport in list-space pixels: the scroll
+  /// offset plus any zoom-window pan.
+  final double pixels;
+
+  /// The largest reachable [pixels] value (content extent minus the visible
+  /// extent); 0 when nothing overflows.
+  final double maxPixels;
+
+  /// The visible vertical extent in list-space pixels.
+  final double viewportPixels;
+
+  /// Effective zoom in logical pixels per PDF point (1 = actual size) - the
+  /// same value [PdfViewerController.zoom] reports.
+  final double zoom;
+
+  /// Whether the document overflows the viewport vertically enough to
+  /// scroll - true exactly when the built-in scrollbar would show. A page
+  /// that fits within a hair of the viewport (only the trailing page margin
+  /// overflows) reports false, so an indicator can hide itself the same way
+  /// the stock bar does. The viewer skips
+  /// [PdfViewer.scrollIndicatorBuilder] entirely while this is false.
+  final bool hasOverflow;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfScrollMetrics &&
+      other.pageCount == pageCount &&
+      other.currentPage == currentPage &&
+      other.position == position &&
+      other.extent == extent &&
+      other.pixels == pixels &&
+      other.maxPixels == maxPixels &&
+      other.viewportPixels == viewportPixels &&
+      other.zoom == zoom &&
+      other.hasOverflow == hasOverflow;
+
+  @override
+  int get hashCode => Object.hash(pageCount, currentPage, position, extent,
+      pixels, maxPixels, viewportPixels, zoom, hasOverflow);
+
+  @override
+  String toString() => 'PdfScrollMetrics(page ${currentPage + 1}/$pageCount, '
+      'position: ${position.toStringAsFixed(3)}, '
+      'extent: ${extent.toStringAsFixed(3)}, zoom: ${zoom.toStringAsFixed(2)})';
+}
+
 /// Drives a [PdfViewer] and reports its state: current page, zoom, and
 /// search results. Listeners fire on any change.
 class PdfViewerController extends ChangeNotifier {
@@ -274,6 +363,35 @@ class PdfViewerController extends ChangeNotifier {
   int get currentMatch => _currentMatch;
 
   Future<void> jumpToPage(int index) async => _state?._jumpToPage(index);
+
+  /// Scrolls to [index] with a smooth animation. Unlike [jumpToPage] (which
+  /// snaps when the target is far away, to avoid animating every intervening
+  /// page into view), this always animates for the given [duration] and
+  /// [curve] once the distance is within range - a very long jump still
+  /// snaps. A no-op while no viewer is attached.
+  Future<void> animateToPage(
+    int index, {
+    Duration duration = const Duration(milliseconds: 250),
+    Curve curve = Curves.easeInOut,
+  }) async =>
+      _state?._jumpToPage(index, duration: duration, curve: curve);
+
+  /// A read-only snapshot of the viewer's vertical scroll state - page,
+  /// normalized position/extent, pixel offsets, and zoom - for building a
+  /// custom scroll indicator or page scrubber (see [PdfScrollMetrics] and
+  /// [PdfViewer.scrollIndicatorBuilder]). Null while no viewer is attached
+  /// or it has not laid out yet. Listen to [viewportChanges] to know when
+  /// to re-read it, and drive the view with [jumpToNormalized],
+  /// [jumpToPage], or [animateToPage].
+  PdfScrollMetrics? get scrollMetrics => _state?._scrollMetrics();
+
+  /// Scrolls so the vertical scroll position lands at [position], a fraction
+  /// clamped to 0 (top) … 1 (bottom) - what a page-scrubber thumb drag maps
+  /// to. Immediate (no animation), so it follows a drag frame by frame, and
+  /// zoom-aware: while zoomed in it spills into the zoom window exactly like
+  /// dragging the built-in scrollbar. A no-op while no viewer is attached.
+  void jumpToNormalized(double position) =>
+      _state?._scrollToNormalized(position);
 
   /// Scrolls to a PDF destination, using the same `/Fit`, `/FitH`, and
   /// `/XYZ` handling as in-document GoTo links.
@@ -493,6 +611,25 @@ typedef PdfUrlLauncher = Future<bool> Function(Uri uri);
 typedef PdfPageOverlayBuilder = List<Widget> Function(
     BuildContext context, int pageIndex, PdfPageGeometry geometry);
 
+/// Signature for [PdfViewer.scrollIndicatorBuilder]: builds a custom
+/// vertical scroll indicator (a compact page number, a draggable page
+/// scrubber, a platform-styled bar) in place of the viewer's built-in
+/// scrollbar. It is stacked over the viewer's right edge and rebuilt
+/// whenever the scroll position, zoom, or current page changes.
+///
+/// Use [metrics] for the page count and the normalized position/extent, and
+/// drive the view through [controller] - [PdfViewerController.jumpToNormalized]
+/// for a scrubber-thumb drag, [PdfViewerController.jumpToPage] or
+/// [PdfViewerController.animateToPage] for page taps. Return an empty widget
+/// (e.g. `SizedBox.shrink()`) to show nothing; the indicator is not built at
+/// all before the viewer has laid out or when the document does not overflow
+/// ([PdfScrollMetrics.hasOverflow] is false), so a builder never has to guard
+/// those cases.
+typedef PdfScrollIndicatorBuilder = Widget Function(
+    BuildContext context,
+    PdfViewerController controller,
+    PdfScrollMetrics metrics);
+
 /// A scrolling, zoomable PDF viewer.
 ///
 /// Supports pinch zoom, double-tap zoom toggle, page tracking, and document
@@ -507,6 +644,7 @@ class PdfViewer extends StatefulWidget {
     this.onAnnotationTap,
     this.onLaunchUrl,
     this.pageOverlayBuilder,
+    this.scrollIndicatorBuilder,
     this.editing,
     this.interactionSession,
     this.formController,
@@ -636,6 +774,17 @@ class PdfViewer extends StatefulWidget {
   /// so they scroll and zoom with the page; they receive pointer events
   /// before the viewer's own selection and link handling.
   final PdfPageOverlayBuilder? pageOverlayBuilder;
+
+  /// Replaces the viewer's built-in vertical scrollbar with a custom scroll
+  /// indicator - a compact page number, a draggable page scrubber, a
+  /// platform-styled bar. See [PdfScrollIndicatorBuilder]; it receives the
+  /// live [PdfScrollMetrics] and the controller for page-aware navigation.
+  ///
+  /// Null keeps the stock scrollbar. The horizontal (zoom-window) scrollbar
+  /// is unaffected - it still appears when zoomed in. The indicator is
+  /// stacked over the viewer's right edge outside the zoom transform, so it
+  /// holds its place and size at any zoom.
+  final PdfScrollIndicatorBuilder? scrollIndicatorBuilder;
 
   /// Stable transition/effect surface for editing gestures. The viewer uses
   /// it for every page overlay; pointer samples do not notify listeners.
@@ -2139,7 +2288,11 @@ class _PdfViewerState extends State<PdfViewer>
     return m.storage[13] / m.getMaxScaleOnAxis();
   }
 
-  Future<void> _jumpToPage(int index) async {
+  Future<void> _jumpToPage(
+    int index, {
+    Duration duration = const Duration(milliseconds: 250),
+    Curve curve = Curves.easeInOut,
+  }) async {
     if (!_scroll.hasClients) return;
     final targetIndex = index.clamp(0, _pages.length - 1);
     _jumpFocusPage = targetIndex;
@@ -2152,11 +2305,61 @@ class _PdfViewerState extends State<PdfViewer>
       _scroll.jumpTo(clamped);
       return;
     }
-    await _scroll.animateTo(
-      clamped,
-      duration: const Duration(milliseconds: 250),
-      curve: Curves.easeInOut,
+    await _scroll.animateTo(clamped, duration: duration, curve: curve);
+  }
+
+  /// The viewport's leading (top) edge and the scrollable range along the
+  /// vertical axis, both in list-space pixels: `(offset, total, visible)`.
+  /// Mirrors the built-in scrollbar's own measurement (see
+  /// [PdfScrollbar] / [_visibleFractionOf]) so a custom indicator lines up
+  /// with the stock bar. Null until the viewer has laid out.
+  (double offset, double total, double visible)? _verticalScrollExtents() {
+    if (_viewWidth <= 0 || !_scroll.hasClients) return null;
+    final position = _scroll.position;
+    if (!position.hasContentDimensions) return null;
+    final scale = _transform.value.getMaxScaleOnAxis();
+    final total = position.maxScrollExtent + position.viewportDimension;
+    final visible = position.viewportDimension / scale;
+    // the viewport unprojects to list space as (p - t) / s, riding the
+    // scroll offset (see _visibleFractionOf)
+    final offset = -_transform.value.storage[13] / scale + position.pixels;
+    return (offset, total, visible);
+  }
+
+  /// The public scroll snapshot behind [PdfViewerController.scrollMetrics]
+  /// and [PdfViewer.scrollIndicatorBuilder].
+  PdfScrollMetrics? _scrollMetrics() {
+    final extents = _verticalScrollExtents();
+    if (extents == null) return null;
+    final (offset, total, visible) = extents;
+    final range = total - visible;
+    return PdfScrollMetrics(
+      pageCount: _pages.length,
+      currentPage: _controller.currentPage,
+      position: range <= 0 ? 0 : (offset / range).clamp(0.0, 1.0),
+      extent: total <= 0 ? 1 : (visible / total).clamp(0.0, 1.0),
+      pixels: offset,
+      maxPixels: range <= 0 ? 0 : range,
+      viewportPixels: visible,
+      zoom: _displayScale,
+      // the list pads its bottom by pageSpacing, so a fully visible document
+      // still carries that much nominal slack - the stock bar hides for it
+      // (see PdfScrollbar.minOverflow), and so does this
+      hasOverflow: range > widget.pageSpacing + 0.5,
     );
+  }
+
+  /// Scrolls so the normalized vertical position lands at [fraction]
+  /// (0 = top, 1 = bottom). Reuses the scrollbar's own list-space motion so
+  /// it spills into the zoom window at the extents just like a bar drag.
+  void _scrollToNormalized(double fraction) {
+    final extents = _verticalScrollExtents();
+    if (extents == null) return;
+    final (offset, total, visible) = extents;
+    final range = total - visible;
+    if (range <= 0) return;
+    final target = fraction.clamp(0.0, 1.0) * range;
+    _scrollbarScrollBy(target - offset);
   }
 
   /// A resolution-independent snapshot of where the viewport sits: the
@@ -4293,6 +4496,25 @@ class _PdfViewerState extends State<PdfViewer>
     }
   }
 
+  /// Hosts [PdfViewer.scrollIndicatorBuilder]. Rebuilds on scroll, zoom, and
+  /// current-page changes (the three inputs to [PdfScrollMetrics]); the
+  /// controller notifies for the page flip, and _scroll/_transform for the
+  /// rest. Skips the builder entirely before the first layout or when the
+  /// document does not overflow, so the host never has to guard those.
+  Widget _buildScrollIndicator() {
+    final builder = widget.scrollIndicatorBuilder!;
+    return AnimatedBuilder(
+      animation: Listenable.merge([_scroll, _transform, _controller]),
+      builder: (context, _) {
+        final metrics = _scrollMetrics();
+        if (metrics == null || !metrics.hasOverflow) {
+          return const SizedBox.shrink();
+        }
+        return builder(context, _controller, metrics);
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     assert(
@@ -4774,19 +4996,22 @@ class _PdfViewerState extends State<PdfViewer>
                 ),
                 // outside the zoom transform, so they keep their place
                 // and size at any zoom
-                Positioned(
-                  top: 0,
-                  bottom: 0,
-                  right: 0,
-                  child: PdfScrollbar(
-                    axis: Axis.vertical,
-                    scroll: _scroll,
-                    transform: _transform,
-                    minOverflow: widget.pageSpacing,
-                    onScrollBy: _scrollbarScrollBy,
-                    thumbKey: const ValueKey('pdf-scrollbar-thumb'),
-                  ),
-                ),
+                if (widget.scrollIndicatorBuilder == null)
+                  Positioned(
+                    top: 0,
+                    bottom: 0,
+                    right: 0,
+                    child: PdfScrollbar(
+                      axis: Axis.vertical,
+                      scroll: _scroll,
+                      transform: _transform,
+                      minOverflow: widget.pageSpacing,
+                      onScrollBy: _scrollbarScrollBy,
+                      thumbKey: const ValueKey('pdf-scrollbar-thumb'),
+                    ),
+                  )
+                else
+                  Positioned.fill(child: _buildScrollIndicator()),
                 // appears only while zoomed in (the only sideways
                 // overflow); inset so the corner stays the vertical bar's
                 Positioned(

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -151,7 +151,10 @@ class PdfViewSync {
 /// The normalized [position] and [extent] behave the same as the built-in
 /// scrollbar's thumb (they account for zoom and mixed page sizes): a thumb
 /// of height `extent` sitting at `position` along the track mirrors the
-/// stock bar. The pixel fields are in the viewer's internal list space
+/// stock bar. (The stock bar additionally floors its thumb at a minimum
+/// pixel height for grabbability, so on a very long document a thumb sized
+/// strictly by `extent` can come out shorter than the stock one.) The pixel
+/// fields are in the viewer's internal list space
 /// (logical pixels at the current layout zoom, before the zoom-window
 /// transform) - useful for precise math, but most indicators only need the
 /// normalized pair.
@@ -176,12 +179,16 @@ class PdfScrollMetrics {
   final int currentPage;
 
   /// Normalized scroll position along the vertical axis: 0 at the top, 1
-  /// fully scrolled to the bottom. 0 when the whole document fits and there
-  /// is nothing to scroll ([hasOverflow] is false).
+  /// fully scrolled to the bottom. 0 when there is no scrollable range at all
+  /// (the content is not taller than the viewport). When only the trailing
+  /// page margin overflows ([hasOverflow] is false) the range is tiny but
+  /// still nonzero, so scrolling into that margin can move this off 0.
   final double position;
 
   /// The visible fraction of the scrollable content (0–1) - a page scrubber
-  /// sizes its thumb by this. 1 when the whole document fits.
+  /// sizes its thumb by this. Approaches 1 when the whole document fits,
+  /// staying a hair below it because the list pads its bottom by the page
+  /// spacing (the same trailing margin that keeps [hasOverflow] false there).
   final double extent;
 
   /// Leading (top) edge of the viewport in list-space pixels: the scroll

--- a/packages/dart_pdf_editor/test/scroll_indicator_test.dart
+++ b/packages/dart_pdf_editor/test/scroll_indicator_test.dart
@@ -1,0 +1,249 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+// The public scroll-indicator API (issue #326): PdfScrollMetrics, the
+// controller's scrollMetrics/jumpToNormalized/animateToPage commands, and
+// PdfViewer.scrollIndicatorBuilder.
+void main() {
+  const stockThumb = ValueKey('pdf-scrollbar-thumb');
+
+  Future<PdfViewerController> pumpViewer(
+    WidgetTester tester, {
+    int pages = 5,
+    PdfViewerFit fit = PdfViewerFit.width,
+    PdfScrollIndicatorBuilder? indicator,
+    PdfViewerController? controller,
+  }) async {
+    final c = controller ?? PdfViewerController();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          initialFit: fit,
+          document: PdfDocument.open(buildMultiPagePdf(pages)),
+          controller: c,
+          scrollIndicatorBuilder: indicator,
+        ),
+      ),
+    ));
+    await tester.pump();
+    return c;
+  }
+
+  ScrollPosition scrollPosition(WidgetTester tester) =>
+      tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+
+  group('PdfScrollMetrics', () {
+    test('value equality', () {
+      const a = PdfScrollMetrics(
+        pageCount: 5,
+        currentPage: 1,
+        position: 0.5,
+        extent: 0.2,
+        pixels: 100,
+        maxPixels: 200,
+        viewportPixels: 60,
+        zoom: 1,
+        hasOverflow: true,
+      );
+      const b = PdfScrollMetrics(
+        pageCount: 5,
+        currentPage: 1,
+        position: 0.5,
+        extent: 0.2,
+        pixels: 100,
+        maxPixels: 200,
+        viewportPixels: 60,
+        zoom: 1,
+        hasOverflow: true,
+      );
+      const c = PdfScrollMetrics(
+        pageCount: 5,
+        currentPage: 2, // differs
+        position: 0.5,
+        extent: 0.2,
+        pixels: 100,
+        maxPixels: 200,
+        viewportPixels: 60,
+        zoom: 1,
+        hasOverflow: true,
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.hasOverflow, isTrue);
+    });
+  });
+
+  group('controller.scrollMetrics', () {
+    testWidgets('is null before layout, populated after', (tester) async {
+      final controller = PdfViewerController();
+      expect(controller.scrollMetrics, isNull);
+      await pumpViewer(tester, controller: controller);
+
+      final metrics = controller.scrollMetrics;
+      expect(metrics, isNotNull);
+      expect(metrics!.pageCount, 5);
+      expect(metrics.currentPage, 0);
+      expect(metrics.position, moreOrLessEquals(0, epsilon: 0.001));
+      expect(metrics.hasOverflow, isTrue);
+      // extent is the visible fraction, matching the stock thumb sizing
+      final position = scrollPosition(tester);
+      final total = position.maxScrollExtent + position.viewportDimension;
+      expect(metrics.extent,
+          moreOrLessEquals(position.viewportDimension / total, epsilon: 0.001));
+      expect(metrics.zoom, moreOrLessEquals(controller.zoom, epsilon: 0.001));
+    });
+
+    testWidgets('position tracks scrolling', (tester) async {
+      final controller = await pumpViewer(tester);
+      expect(controller.scrollMetrics!.position, moreOrLessEquals(0, epsilon: 0.001));
+
+      scrollPosition(tester).jumpTo(scrollPosition(tester).maxScrollExtent);
+      await tester.pump();
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(1, epsilon: 0.001));
+      expect(controller.scrollMetrics!.currentPage, 4);
+    });
+
+    testWidgets('reports no overflow when the whole document fits',
+        (tester) async {
+      final controller =
+          await pumpViewer(tester, pages: 1, fit: PdfViewerFit.page);
+      final metrics = controller.scrollMetrics;
+      expect(metrics, isNotNull);
+      expect(metrics!.hasOverflow, isFalse);
+      expect(metrics.position, 0);
+      // nearly the whole content is visible (only the trailing page margin
+      // sits below the fold)
+      expect(metrics.extent, greaterThan(0.95));
+    });
+  });
+
+  group('controller.jumpToNormalized', () {
+    testWidgets('scrolls to the top and bottom', (tester) async {
+      final controller = await pumpViewer(tester);
+      final position = scrollPosition(tester);
+
+      controller.jumpToNormalized(1);
+      await tester.pump();
+      expect(position.pixels, moreOrLessEquals(position.maxScrollExtent, epsilon: 0.5));
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(1, epsilon: 0.001));
+
+      controller.jumpToNormalized(0);
+      await tester.pump();
+      expect(position.pixels, moreOrLessEquals(0, epsilon: 0.5));
+    });
+
+    testWidgets('maps a mid-range fraction proportionally', (tester) async {
+      final controller = await pumpViewer(tester);
+      final position = scrollPosition(tester);
+
+      controller.jumpToNormalized(0.5);
+      await tester.pump();
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(0.5, epsilon: 0.01));
+      expect(position.pixels,
+          moreOrLessEquals(position.maxScrollExtent / 2, epsilon: 1));
+    });
+
+    testWidgets('clamps out-of-range fractions', (tester) async {
+      final controller = await pumpViewer(tester);
+      final position = scrollPosition(tester);
+
+      controller.jumpToNormalized(5);
+      await tester.pump();
+      expect(position.pixels, moreOrLessEquals(position.maxScrollExtent, epsilon: 0.5));
+
+      controller.jumpToNormalized(-5);
+      await tester.pump();
+      expect(position.pixels, moreOrLessEquals(0, epsilon: 0.5));
+    });
+  });
+
+  group('controller.animateToPage', () {
+    testWidgets('animates to a page', (tester) async {
+      final controller = await pumpViewer(tester, pages: 8);
+      unawaited(controller.animateToPage(3));
+      await tester.pumpAndSettle();
+      expect(controller.currentPage, 3);
+    });
+  });
+
+  group('PdfViewer.scrollIndicatorBuilder', () {
+    testWidgets('replaces the stock scrollbar and receives live metrics',
+        (tester) async {
+      PdfScrollMetrics? seen;
+      final controller = await pumpViewer(
+        tester,
+        indicator: (context, controller, metrics) {
+          seen = metrics;
+          return const SizedBox.shrink(key: ValueKey('custom-indicator'));
+        },
+      );
+
+      // the built-in scrollbar thumb is gone, the custom indicator is up
+      expect(find.byKey(stockThumb), findsNothing);
+      expect(find.byKey(const ValueKey('custom-indicator')), findsOneWidget);
+      expect(seen, isNotNull);
+      expect(seen!.pageCount, 5);
+      expect(seen!.position, moreOrLessEquals(0, epsilon: 0.001));
+
+      // scrolling rebuilds the indicator with fresh metrics
+      scrollPosition(tester).jumpTo(scrollPosition(tester).maxScrollExtent);
+      await tester.pump();
+      expect(seen!.position, moreOrLessEquals(1, epsilon: 0.001));
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(1, epsilon: 0.001));
+    });
+
+    testWidgets('is not built while the document fits (no overflow)',
+        (tester) async {
+      var built = 0;
+      await pumpViewer(
+        tester,
+        pages: 1,
+        fit: PdfViewerFit.page,
+        indicator: (context, controller, metrics) {
+          built++;
+          return const SizedBox.shrink(key: ValueKey('custom-indicator'));
+        },
+      );
+      expect(find.byKey(const ValueKey('custom-indicator')), findsNothing);
+      expect(built, 0);
+    });
+
+    testWidgets('a scrubber drag through the controller scrolls', (tester) async {
+      final controller = await pumpViewer(
+        tester,
+        pages: 8,
+        indicator: (context, controller, metrics) => GestureDetector(
+          key: const ValueKey('scrubber'),
+          // opaque so the scrubber wins the gesture arena over the scroll
+          // view underneath, the way the stock scrollbar's strip does
+          behavior: HitTestBehavior.opaque,
+          onVerticalDragUpdate: (d) {
+            final box = context.findRenderObject() as RenderBox;
+            controller.jumpToNormalized(d.localPosition.dy / box.size.height);
+          },
+          child: const SizedBox.expand(),
+        ),
+      );
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(0, epsilon: 0.001));
+
+      // drag to roughly the middle of the track
+      await tester.drag(
+          find.byKey(const ValueKey('scrubber')), const Offset(0, 300));
+      await tester.pump();
+      expect(controller.scrollMetrics!.position, greaterThan(0.2));
+      // drain the viewer's settle/motion-hold timers before teardown
+      await tester.pumpAndSettle();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #326. Adds a supported customization point for the `PdfViewer` scroll indicator so an app can build a compact page number, a draggable page scrubber, or a platform-styled scrollbar without reaching into the viewer's private `ScrollController`. Delivers both halves the issue proposed — a read-only scroll-state API + page-aware commands on `PdfViewerController`, and a builder on `PdfViewer`. The default scrollbar is unchanged when the new hooks aren't used.

New public surface (all in `pdf_viewer.dart`, which is re-exported wholesale):

- **`PdfScrollMetrics`** — immutable snapshot: `pageCount`, `currentPage`, normalized `position` (0 top … 1 bottom) and `extent` (visible fraction), the list-space pixel triple (`pixels`/`maxPixels`/`viewportPixels`), `zoom` (px/pt, matching `PdfViewerController.zoom`), and `hasOverflow`. It mirrors the built-in scrollbar's own measurement, so a custom thumb of height `extent` at `position` lines up pixel-for-pixel with the stock bar at any zoom and with mixed page sizes.
- **`PdfViewerController.scrollMetrics`** — reads the snapshot (null before layout). The existing `viewportChanges` `Listenable` already fires on scroll/zoom, so it's the signal for when to re-read.
- **`PdfViewerController.jumpToNormalized(double)`** — immediate, zoom-aware scroll to a normalized position; what a scrubber-thumb drag maps to. It routes through the scrollbar's own list-space motion, so it spills into the zoom window at the extents exactly like a bar drag.
- **`PdfViewerController.animateToPage(int, {duration, curve})`** — the animated sibling of the existing `jumpToPage`, sharing a refactored `_jumpToPage`.
- **`PdfViewer.scrollIndicatorBuilder`** (`PdfScrollIndicatorBuilder`) — replaces the built-in **vertical** scrollbar with a host widget stacked over the right edge outside the zoom transform. The horizontal (zoom-window) bar is untouched. The builder is skipped before layout and when the document doesn't overflow, so the host never guards those cases.

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean over `dart_pdf_editor`)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (new `scroll_indicator_test.dart` + `pdf_scrollbar_test`, `viewport_test`, `wheel_scroll_test`, `pdf_viewer_test`, `editing_autoscroll_test` all green)

New tests in `test/scroll_indicator_test.dart` cover: metrics equality, the snapshot before/after layout, position tracking on scroll, the no-overflow case, `jumpToNormalized` (top/bottom/mid/clamp), `animateToPage`, and the builder replacing the stock bar + receiving live metrics + not building on no-overflow + a scrubber drag driving the controller.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `hasOverflow` is threshold-based (`range > pageSpacing`), not `maxPixels > 0`: the list pads its bottom by `pageSpacing`, so a fully-visible document carries ~12px of nominal slack that the stock bar already hides via `PdfScrollbar.minOverflow`. This keeps the indicator's show/hide identical to the built-in bar; `extent` in that case is ~0.98 (the trailing margin), not 1.
- The indicator is `Positioned.fill` so a host can float a page label anywhere or run a full-height scrubber. Interactive regions should set an opaque hit behavior (like the stock bar's strip) to win the vertical-drag arena over the scroll view; non-interactive areas pass through to the viewer.
- `animateToPage` keeps `jumpToPage`'s far-jump snap (beyond `max(viewHeight*2, 2400)` px it snaps, warming the destination preview, rather than animating every intervening page into view).
- Design rationale is recorded in `doc/dev-log/2026-07-16-scroll-indicator-api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Snmsob4w3nCqukkLyuJUun

---
_Generated by [Claude Code](https://claude.ai/code/session_01Snmsob4w3nCqukkLyuJUun)_