### PR TITLE
Add asynchronous byte-source API for progressive remote PDF loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ PdfEditorView(
 PdfReader(bytes: pdfBytes)
 ```
 
+To open a large PDF hosted remotely without downloading the whole file first,
+use the asynchronous byte-source API. `PdfHttpByteSource` fetches over HTTP
+Range requests (forwarding auth headers, with cancellation and progress), and
+falls back to a plain download when the server does not support ranges:
+
+```dart
+final source = PdfHttpByteSource(
+  Uri.parse('https://host/big.pdf'),
+  headers: {'Authorization': 'Bearer $token'},
+  cancelToken: cancelToken,
+  onProgress: (received, total) => report(received, total),
+);
+final document = await PdfDocument.openSource(source);
+```
+
+`PdfByteSource` is network-agnostic (`length` + `readRange`), so any random-
+access transport works; `PdfDocument.open(Uint8List)` and the byte-based widgets
+are unchanged. See [`doc/dev-log`](doc/dev-log) for the loader design.
+
 For OCR, add one engine package and call `PdfEditor.applyOcr` before opening
 or replacing the document in your viewer:
 

--- a/doc/dev-log/2026-07-16-async-byte-source-remote-pdf.md
+++ b/doc/dev-log/2026-07-16-async-byte-source-remote-pdf.md
@@ -103,6 +103,21 @@ created itself.
 
 `dart analyze` clean; full `pdf_cos` (217) and `pdf_document` (665) suites pass.
 
+## Example wiring
+
+The example app now has an **Open from a URL…** menu action
+(`_openFromUrl` in `example/lib/main.dart`) so the API is visible in the live
+demo. It builds a `PdfHttpByteSource` and calls `PdfDocument.openSource` with a
+`PdfSourceLoadOptions.onProgress` that drives a determinate download-percent
+ring in the loading tab (`_OpeningDocument` gained an optional
+`ValueListenable<double>`), then hands `doc.cos.bytes` to the normal viewer
+tab. The field prefills with a CORS-enabled, Range-capable pdf.js sample; the
+error tab spells out the web CORS requirement. A `remoteByteSourceFactory` test
+seam swaps in a `PdfBytesByteSource` so `test/remote_open_test.dart` covers the
+flow with no network. `dart_pdf_editor` now re-exports `PdfByteSource`,
+`PdfBytesByteSource`, `PdfSourceLoadOptions`, and `PdfSourceProgress`, so a
+viewer host gets the whole remote-loading vocabulary from the one package.
+
 ## Left open / scope
 
 Because the sync core needs all referenced bytes present before it runs, the

--- a/doc/dev-log/2026-07-16-async-byte-source-remote-pdf.md
+++ b/doc/dev-log/2026-07-16-async-byte-source-remote-pdf.md
@@ -1,0 +1,116 @@
+# 2026-07-16 — Asynchronous byte-source API for progressive remote loading (#325)
+
+Branch `claude/async-byte-source-remote-pdf-b97wkm`. #325 asks for a random-
+access, possibly-async PDF byte source so a host need not download a whole
+remote file before the parser can begin — plus an HTTP adapter that uses Range
+requests, forwards auth, supports cancellation/progress, and degrades to a full
+download when ranges are unavailable. The public `open(Uint8List)` path and the
+byte-based widgets stay untouched; this is purely additive.
+
+## Constraint that shaped the design
+
+The COS parser is **synchronous** end to end: `CosDocument`, `getObject`,
+`resolve`, `decodeStreamData`, and every `pdf_document`/`pdf_graphics` caller
+read `bytes[i]` off an in-memory `Uint8List`. Making resolution lazily async
+would cascade an `await` through hundreds of call sites — out of scope and
+risky. So rather than parse *from* the source, the loader **prefetches exactly
+the byte ranges the synchronous parser will need** into a sparse buffer and
+hands that to the existing `CosDocument.open`. Every byte the sync path reads is
+already present; unfetched regions (free space, dead revisions, post-EOF junk)
+stay zero-filled and are never touched.
+
+## Core (`pdf_cos/src/byte_source.dart`)
+
+- `PdfByteSource` — `Future<int?> get length` + `Future<Uint8List>
+  readRange(start, endExclusive)` + optional `close()`. Network-agnostic.
+- `PdfBytesByteSource` — an in-memory implementation (tests, and adapting
+  already-downloaded bytes).
+- `openCosDocumentFromSource(...)` / `CosDocument.openSource(...)` /
+  `PdfDocument.openSource(...)` — the entry points, with a
+  `PdfSourceLoadOptions` (head/tail/xref window sizes, coalescing gap, download
+  chunk, `onProgress`).
+
+The `_ProgressiveLoader`:
+
+1. Fetches a small **header probe** (settles the `%PDF-` offset shift) and a
+   **tail window** (`startxref` + newest xref section).
+2. **Walks the xref chain** newest-to-oldest with ranged reads, following
+   `/Prev` and `/XRefStm`, parsing tables and cross-reference streams to
+   collect the absolute offsets of every in-use object. Compressed objects need
+   no offset — their container `ObjStm` is itself an in-use object in the chain.
+3. **Fetches the live objects' byte ranges**, each bounded by the next object
+   offset *and* the surrounding xref sections (object bodies never cross an
+   xref section), coalescing ranges within `coalesceGap` into one request.
+4. Opens the populated buffer with the ordinary `CosDocument.open` — so
+   encryption, object streams, recovery, `/Prev`, and everything else work
+   unchanged.
+
+### Why truncated reads can't corrupt silently
+
+An xref section parse only *succeeds* when its terminator (`trailer` for a
+table; `endstream`/`endobj` for a stream) is reached over real bytes. Beyond the
+fetched window the buffer is zero-filled, and `0x00` is PDF whitespace, so the
+lexer skips it and hits EOF — every truncation **throws** rather than returning
+a plausible-but-wrong offset. The loader therefore just widens the window
+geometrically and retries on any failure, giving up to the full-download
+fallback only once the whole remaining file has been fetched. A successful parse
+is authoritative, which also guarantees the loader's xref view matches what the
+final `CosDocument.open` re-derives from the same bytes.
+
+### Fallbacks
+
+Unknown length, a broken cross-reference chain, or a ranged read that fails all
+unwind (`_FallbackToFullDownload`) to a plain sequential download — chunked
+until a short read signals EOF when the length is unknown — then the normal
+`open` (with its own scan-recovery) takes over. A non-range-capable server thus
+still works, just without the bandwidth savings.
+
+## HTTP adapter (`dart_pdf_editor/src/http_byte_source.dart`)
+
+`PdfHttpByteSource` (new `http: ^1.2.0` dep — cross-platform, VM + web fetch, no
+`dart:io` in our code). One one-byte ranged GET (`Range: bytes=0-0`) probes both
+length (from `Content-Range`) and range support:
+
+- **206** → ranges work; reads issue `Range` GETs.
+- **200** → server ignored Range (or a web CORS response hid the headers); the
+  full body is kept and every later range is served from memory.
+- **416** → empty/past-end.
+- other status / transport failure → `PdfHttpException`.
+
+`headers` carry auth (`Authorization`, cookies via a caller-supplied
+`BrowserClient()..withCredentials`), a `PdfCancelToken` aborts in-flight and
+future reads with `PdfHttpCancelledException`, and `onProgress` reports bytes
+received. CORS is documented: cross-origin progressive loading needs the server
+to expose `Content-Range`/`Accept-Ranges` via `Access-Control-Expose-Headers`,
+else it falls back to a full download. `close()` only closes a client the source
+created itself.
+
+## Tests
+
+- `pdf_cos/test/byte_source_test.dart` (17): classic table, xref-stream +
+  object-stream, multi-page, header/tail as separate ranges (not one blob),
+  `/Prev` chain from an incremental update, tiny-window growth, progress
+  monotonicity, unknown-length + chunked fallback, broken-`startxref` recovery,
+  cancellation, non-PDF, corrupted body, encrypted (owner password + wrong
+  password), and `PdfBytesByteSource` clamping.
+- `dart_pdf_editor/test/http_byte_source_test.dart` (13): probe shape, mid-range
+  reads, `openSource` integration, multi-revision doc, auth-header forwarding,
+  progress, range-less full-download fallback + memory-served slices, error
+  status, wrapped transport failure, cancel-before and cancel-mid-load, and
+  client-ownership on `close()`, all via `http`'s `MockClient` — no real network.
+- `pdf_document/test/open_source_test.dart` (4): page-tree/attributes, page
+  count, content bytes, unknown-length fallback.
+
+`dart analyze` clean; full `pdf_cos` (217) and `pdf_document` (665) suites pass.
+
+## Left open / scope
+
+Because the sync core needs all referenced bytes present before it runs, the
+loader still fetches *all* live objects (skipping only free space, superseded
+revisions, and the trailing junk past the last xref). True first-page-only
+rendering for linearized PDFs — fetch the linearization dict + first-page
+objects, render, then stream the rest — needs an **async** resolve path in the
+core and is the natural follow-up now that `PdfByteSource` exists to build on.
+No new viewer widget was added; a host wires remote loading with
+`PdfDocument.openSource(PdfHttpByteSource(uri))` and rebuilds the viewer with
+the resulting document.

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -25,6 +25,20 @@ final _githubUrl = Uri.parse('https://github.com/ben-milanko/dart-pdf');
 /// The published Flutter package the example is built on.
 final _pubDevUrl = Uri.parse('https://pub.dev/packages/dart_pdf_editor');
 
+/// A CORS-enabled, Range-capable sample used to prefill the "Open from a URL"
+/// field - the classic pdf.js test document, served by raw.githubusercontent
+/// with `Access-Control-Allow-Origin: *`.
+const _sampleRemotePdfUrl =
+    'https://raw.githubusercontent.com/mozilla/pdf.js/master/web/'
+    'compressed.tracemonkey-pldi-09.pdf';
+
+/// Test seam: builds the byte source a remote open reads from. Defaults to a
+/// real [PdfHttpByteSource]; tests swap in an in-memory source so no network
+/// is touched. See `test/remote_open_test.dart`.
+@visibleForTesting
+PdfByteSource Function(Uri uri) remoteByteSourceFactory =
+    (uri) => PdfHttpByteSource(uri);
+
 /// One filter, every platform: desktop and web match on the extension,
 /// Android on the MIME type, iOS/macOS on the uniform type identifier -
 /// a type group missing the field a platform filters by throws there.
@@ -375,6 +389,13 @@ class _ViewerScreenState extends State<ViewerScreen> {
             icon: Icons.folder_open,
             title: 'Open a PDF…',
             shortcut: _menuShortcut('O'),
+          ),
+        ),
+        PopupMenuItem(
+          value: () => unawaited(_openFromUrl()),
+          child: _appMenuTile(
+            icon: Icons.cloud_download_outlined,
+            title: 'Open from a URL…',
           ),
         ),
         PopupMenuItem(
@@ -761,6 +782,71 @@ class _ViewerScreenState extends State<ViewerScreen> {
       );
     }
   }
+
+  /// Opens a PDF hosted at a URL without downloading it whole up front, using
+  /// the asynchronous byte-source API: [PdfHttpByteSource] streams the ranges
+  /// the parser needs (Range requests, falling back to a full download), and
+  /// [PdfDocument.openSource] assembles the document. A live download percent
+  /// is shown while it loads.
+  Future<void> _openFromUrl() async {
+    final input = await _promptForUrl();
+    if (input == null) return;
+    final uri = Uri.tryParse(input.trim());
+    if (uri == null || !uri.hasScheme || uri.host.isEmpty) {
+      _openError(input, 'Not a valid URL:\n$input');
+      return;
+    }
+    final name =
+        uri.pathSegments.isNotEmpty && uri.pathSegments.last.isNotEmpty
+            ? uri.pathSegments.last
+            : uri.host;
+
+    final progress = ValueNotifier<double>(0);
+    final loading = _DocumentTab.loading(title: name, loadingProgress: progress);
+    _addTab(loading);
+
+    final source = remoteByteSourceFactory(uri);
+    try {
+      final doc = await PdfDocument.openSource(
+        source,
+        options: PdfSourceLoadOptions(onProgress: (received, total) {
+          if (total != null && total > 0) progress.value = received / total;
+        }),
+      );
+      await source.close();
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
+      final bytes = doc.cos.bytes;
+      _replaceLoadingTab(
+        loading,
+        _DocumentTab.document(
+            title: name, bytes: bytes, preferences: _prefs),
+      );
+      unawaited(_recents.record(name, bytes));
+    } catch (e, s) {
+      AppLog.instance.error('Could not open $uri', error: e, stackTrace: s);
+      await source.close();
+      if (!mounted) return;
+      _replaceLoadingTab(
+        loading,
+        _DocumentTab.error(
+          title: name,
+          error: 'Could not open $uri\n$e\n\n'
+              'On the web this is often a CORS restriction: the server must '
+              'send Access-Control-Allow-Origin and expose the Range headers.',
+        ),
+      );
+    } finally {
+      progress.dispose();
+    }
+  }
+
+  /// Prompts for a URL to open, prefilled with a known CORS-enabled sample.
+  /// Returns null when cancelled.
+  Future<String?> _promptForUrl() => showDialog<String>(
+        context: context,
+        builder: (context) => const _OpenUrlDialog(initial: _sampleRemotePdfUrl),
+      );
 
   /// Picks a PDF and returns its bytes (null when cancelled) - the source
   /// for the editor's "Insert PDF…" action.
@@ -1256,7 +1342,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
                 ),
               )
             : tab.isLoading
-                ? _OpeningDocument(title: tab.title)
+                ? _OpeningDocument(
+                    title: tab.title, progress: tab.loadingProgress)
                 : tab.error != null
                     ? Center(
                         child: Text(tab.error!, textAlign: TextAlign.center))
@@ -1450,12 +1537,18 @@ const double _appMenuIconSize = 24;
 const int _maxRecentMenuItems = 8;
 
 class _OpeningDocument extends StatelessWidget {
-  const _OpeningDocument({required this.title});
+  const _OpeningDocument({required this.title, this.progress});
 
   final String title;
 
+  /// Determinate download progress (0..1) for a remote load, or null for the
+  /// indeterminate spinner used by local opens.
+  final ValueListenable<double>? progress;
+
   @override
   Widget build(BuildContext context) {
+    final label = title.isEmpty ? 'Opening PDF…' : 'Opening $title…';
+    final tracker = progress;
     return Center(
       child: Semantics(
         label: 'Opening document',
@@ -1463,12 +1556,33 @@ class _OpeningDocument extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const CircularProgressIndicator(),
+            if (tracker == null)
+              const CircularProgressIndicator()
+            else
+              ValueListenableBuilder<double>(
+                valueListenable: tracker,
+                builder: (context, value, _) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(
+                      width: 48,
+                      height: 48,
+                      child: CircularProgressIndicator(
+                        // Indeterminate until the first byte lands, then a
+                        // determinate ring driven by PdfHttpByteSource's
+                        // onProgress.
+                        value: value > 0 ? value.clamp(0.0, 1.0) : null,
+                      ),
+                    ),
+                    if (value > 0) ...[
+                      const SizedBox(height: 8),
+                      Text('${(value.clamp(0.0, 1.0) * 100).round()}%'),
+                    ],
+                  ],
+                ),
+              ),
             const SizedBox(height: 16),
-            Text(
-              title.isEmpty ? 'Opening PDF…' : 'Opening $title…',
-              textAlign: TextAlign.center,
-            ),
+            Text(label, textAlign: TextAlign.center),
           ],
         ),
       ),
@@ -1480,7 +1594,7 @@ class _OpeningDocument extends StatelessWidget {
 /// so switching tabs preserves edits, undo history, scroll position,
 /// and any demo-specific overlay state.
 class _DocumentTab {
-  _DocumentTab.loading({required this.title})
+  _DocumentTab.loading({required this.title, this.loadingProgress})
       : session = null,
         viewer = null,
         isDemo = false,
@@ -1499,6 +1613,7 @@ class _DocumentTab {
         error = null,
         compareBefore = null,
         compareAfter = null,
+        loadingProgress = null,
         isLoading = false;
 
   _DocumentTab.error({required this.title, required this.error})
@@ -1507,6 +1622,7 @@ class _DocumentTab {
         isDemo = false,
         compareBefore = null,
         compareAfter = null,
+        loadingProgress = null,
         isLoading = false;
 
   /// A document-comparison tab: hosts a [PdfComparisonView] over two
@@ -1521,12 +1637,18 @@ class _DocumentTab {
         error = null,
         compareBefore = before,
         compareAfter = after,
+        loadingProgress = null,
         isLoading = false;
 
   final String title;
   final String? error;
   final bool isDemo;
   final bool isLoading;
+
+  /// Download progress (0..1) for a remote-load ([_openFromUrl]) loading tab,
+  /// or null for an indeterminate spinner. The notifier is owned by the code
+  /// that started the load, not the tab.
+  final ValueListenable<double>? loadingProgress;
 
   /// The two documents a comparison tab diffs; null on every other tab.
   final Uint8List? compareBefore;
@@ -1548,6 +1670,71 @@ class _DocumentTab {
     session?.dispose();
     viewer?.dispose();
     noteField.dispose();
+  }
+}
+
+/// Collects a URL to open a remote PDF from. Returns the entered string on
+/// "Open", or null on cancel. Submitting the text field also confirms.
+class _OpenUrlDialog extends StatefulWidget {
+  const _OpenUrlDialog({required this.initial});
+
+  final String initial;
+
+  @override
+  State<_OpenUrlDialog> createState() => _OpenUrlDialogState();
+}
+
+class _OpenUrlDialogState extends State<_OpenUrlDialog> {
+  late final TextEditingController _url =
+      TextEditingController(text: widget.initial);
+
+  @override
+  void dispose() {
+    _url.dispose();
+    super.dispose();
+  }
+
+  void _submit() => Navigator.of(context).pop(_url.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Open from a URL'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Streams the PDF over HTTP Range requests via PdfHttpByteSource, '
+            'fetching only what the parser needs and falling back to a full '
+            'download when the server has no range support.',
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            key: const ValueKey('open-url-field'),
+            controller: _url,
+            autofocus: true,
+            keyboardType: TextInputType.url,
+            decoration: const InputDecoration(
+              labelText: 'PDF URL',
+              hintText: 'https://example.com/document.pdf',
+            ),
+            onSubmitted: (_) => _submit(),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          key: const ValueKey('open-url-confirm'),
+          onPressed: _submit,
+          child: const Text('Open'),
+        ),
+      ],
+    );
   }
 }
 

--- a/packages/dart_pdf_editor/example/test/remote_open_test.dart
+++ b/packages/dart_pdf_editor/example/test/remote_open_test.dart
@@ -1,0 +1,73 @@
+// The "Open from a URL…" flow: it drives PdfDocument.openSource over a
+// PdfByteSource, so the example exercises the async byte-source API. The
+// remoteByteSourceFactory seam swaps the real HTTP source for an in-memory
+// one, so the test touches no network.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_viewer_example/demo_document.dart';
+import 'package:pdf_viewer_example/main.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  tearDown(() {
+    // Restore the production factory so one test can't leak into another.
+    remoteByteSourceFactory = (uri) => PdfHttpByteSource(uri);
+  });
+
+  testWidgets('opens a document from a URL via the byte-source API',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final demo = buildDemoPdf();
+    Uri? requested;
+    remoteByteSourceFactory = (uri) {
+      requested = uri;
+      return PdfBytesByteSource(demo);
+    };
+
+    await tester.pumpWidget(const ViewerApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('dartpdf-app-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open from a URL…').last);
+    await tester.pumpAndSettle();
+
+    // The dialog is prefilled with the sample URL; confirm it.
+    expect(find.byKey(const ValueKey('open-url-field')), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('open-url-confirm')));
+    await tester.pumpAndSettle();
+
+    // The source was built from the entered URL and a viewer is now showing.
+    expect(requested, isNotNull);
+    expect(requested!.host, 'raw.githubusercontent.com');
+    expect(find.byType(PdfViewer), findsOneWidget);
+  });
+
+  testWidgets('a malformed URL surfaces an error tab, no network call',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    var built = false;
+    remoteByteSourceFactory = (uri) {
+      built = true;
+      return PdfBytesByteSource(buildDemoPdf());
+    };
+
+    await tester.pumpWidget(const ViewerApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('dartpdf-app-menu')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open from a URL…').last);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.byKey(const ValueKey('open-url-field')), 'not a url');
+    await tester.tap(find.byKey(const ValueKey('open-url-confirm')));
+    await tester.pumpAndSettle();
+
+    expect(built, isFalse); // never reached the source factory
+    expect(find.textContaining('Not a valid URL'), findsOneWidget);
+  });
+}

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -41,6 +41,11 @@ export 'src/editing/stroke_prediction.dart';
 export 'src/editing/text_prompt.dart';
 export 'src/editing/text_style_prompt.dart';
 export 'src/editing/tool_shortcuts.dart';
+// The network-agnostic byte-source API the HTTP adapter and progressive
+// loader build on, surfaced so viewer hosts get the whole remote-loading
+// vocabulary from this one package.
+export 'package:pdf_cos/pdf_cos.dart'
+    show PdfByteSource, PdfBytesByteSource, PdfSourceLoadOptions, PdfSourceProgress;
 export 'src/http_byte_source.dart';
 export 'src/image_decoder.dart' show PdfImageCache;
 export 'src/ocr.dart';

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -41,6 +41,7 @@ export 'src/editing/stroke_prediction.dart';
 export 'src/editing/text_prompt.dart';
 export 'src/editing/text_style_prompt.dart';
 export 'src/editing/tool_shortcuts.dart';
+export 'src/http_byte_source.dart';
 export 'src/image_decoder.dart' show PdfImageCache;
 export 'src/ocr.dart';
 export 'src/page_export.dart';

--- a/packages/dart_pdf_editor/lib/src/http_byte_source.dart
+++ b/packages/dart_pdf_editor/lib/src/http_byte_source.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'package:pdf_cos/pdf_cos.dart';
+
+/// Cooperative cancellation for a [PdfHttpByteSource]. Call [cancel] to stop
+/// an in-progress or subsequent load; pending and future reads then throw a
+/// [PdfHttpCancelledException]. A token is single-use.
+class PdfCancelToken {
+  bool _cancelled = false;
+
+  /// Whether [cancel] has been called.
+  bool get isCancelled => _cancelled;
+
+  /// Requests cancellation. Idempotent.
+  void cancel() => _cancelled = true;
+
+  void throwIfCancelled() {
+    if (_cancelled) throw const PdfHttpCancelledException();
+  }
+}
+
+/// Thrown from a [PdfHttpByteSource] read after its [PdfCancelToken] fired.
+class PdfHttpCancelledException implements Exception {
+  const PdfHttpCancelledException();
+
+  @override
+  String toString() => 'PdfHttpCancelledException: load cancelled';
+}
+
+/// Thrown when the server responds in a way the source cannot use (an error
+/// status, or a body that does not match the requested range).
+class PdfHttpException implements Exception {
+  PdfHttpException(this.message, {this.statusCode});
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => statusCode == null
+      ? 'PdfHttpException: $message'
+      : 'PdfHttpException ($statusCode): $message';
+}
+
+/// A [PdfByteSource] that reads a remote PDF over HTTP(S), using Range
+/// requests when the server supports them and transparently falling back to a
+/// single full download when it does not.
+///
+/// Pass [headers] for authentication (e.g. `Authorization`) or content
+/// negotiation. On the web, cross-origin loads are subject to CORS: the
+/// server must send `Access-Control-Allow-Origin` and, for Range-based
+/// progressive loading, expose `Accept-Ranges`/`Content-Range` via
+/// `Access-Control-Expose-Headers`; otherwise the browser hides them and this
+/// source falls back to a full download. To send cookies cross-origin, supply
+/// a `BrowserClient()..withCredentials = true` as [client].
+///
+/// Use with [PdfDocument.openSource] / [CosDocument.openSource]:
+///
+/// ```dart
+/// final source = PdfHttpByteSource(Uri.parse('https://host/big.pdf'),
+///     headers: {'Authorization': 'Bearer $token'}, cancelToken: token);
+/// final document = await PdfDocument.openSource(source);
+/// ```
+class PdfHttpByteSource implements PdfByteSource {
+  PdfHttpByteSource(
+    this.uri, {
+    Map<String, String>? headers,
+    http.Client? client,
+    this.cancelToken,
+    this.onProgress,
+  })  : _headers = headers,
+        _client = client ?? http.Client(),
+        _ownsClient = client == null;
+
+  /// The document URL.
+  final Uri uri;
+
+  final Map<String, String>? _headers;
+  final http.Client _client;
+  final bool _ownsClient;
+
+  /// Optional cancellation handle.
+  final PdfCancelToken? cancelToken;
+
+  /// Called after each network read with the running total of bytes received
+  /// and the document length once known.
+  final void Function(int received, int? total)? onProgress;
+
+  bool _probed = false;
+  bool _supportsRange = false;
+  int? _length;
+
+  /// Whether the server answered the probe with a 206 (Range supported). Only
+  /// meaningful after the first read; false when the source fell back to a
+  /// full download. Useful for diagnostics and tests.
+  bool get supportsRange => _supportsRange;
+
+  /// Populated when the server ignores Range (or has no length): the whole
+  /// body, downloaded once and served from memory thereafter.
+  Uint8List? _fullBuffer;
+
+  int _received = 0;
+
+  @override
+  Future<int?> get length async {
+    await _probe();
+    return _length;
+  }
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    cancelToken?.throwIfCancelled();
+    await _probe();
+
+    final buffer = _fullBuffer;
+    if (buffer != null) return _slice(buffer, start, endExclusive);
+
+    final s = start < 0 ? 0 : start;
+    if (endExclusive <= s) return Uint8List(0);
+
+    final response = await _get(rangeStart: s, rangeEndInclusive: endExclusive - 1);
+    cancelToken?.throwIfCancelled();
+    switch (response.statusCode) {
+      case 206:
+        return _report(response.bodyBytes);
+      case 200:
+        // The server ignored the Range header and sent the whole file; keep
+        // it and serve this and every later range from memory.
+        _adoptFullBody(response.bodyBytes);
+        return _slice(_fullBuffer!, start, endExclusive);
+      case 416:
+        return Uint8List(0); // requested wholly past the end
+      default:
+        throw PdfHttpException('unexpected status reading range $s-${endExclusive - 1}',
+            statusCode: response.statusCode);
+    }
+  }
+
+  /// Probes range support and length with a single one-byte ranged GET.
+  Future<void> _probe() async {
+    if (_probed) return;
+    _probed = true;
+    cancelToken?.throwIfCancelled();
+    final response = await _get(rangeStart: 0, rangeEndInclusive: 0);
+    cancelToken?.throwIfCancelled();
+    switch (response.statusCode) {
+      case 206:
+        _supportsRange = true;
+        _length = _totalFromContentRange(response.headers['content-range']);
+        _report(response.bodyBytes);
+      case 200:
+        _supportsRange = false;
+        _adoptFullBody(response.bodyBytes);
+      case 416:
+        _length = 0;
+        _adoptFullBody(Uint8List(0));
+      default:
+        throw PdfHttpException('unexpected status ${response.statusCode} for $uri',
+            statusCode: response.statusCode);
+    }
+  }
+
+  Future<http.Response> _get({
+    required int rangeStart,
+    required int rangeEndInclusive,
+  }) async {
+    final extra = _headers;
+    final headers = <String, String>{
+      if (extra != null) ...extra,
+      'Range': 'bytes=$rangeStart-$rangeEndInclusive',
+    };
+    try {
+      return await _client.get(uri, headers: headers);
+    } on PdfHttpCancelledException {
+      rethrow;
+    } on Object catch (error) {
+      throw PdfHttpException('request failed for $uri: $error');
+    }
+  }
+
+  void _adoptFullBody(Uint8List body) {
+    _fullBuffer = body;
+    _length = body.length;
+    _report(body, cumulativeOverride: body.length);
+  }
+
+  Uint8List _report(Uint8List data, {int? cumulativeOverride}) {
+    _received = cumulativeOverride ?? _received + data.length;
+    onProgress?.call(_received, _length);
+    return data;
+  }
+
+  static Uint8List _slice(Uint8List buffer, int start, int endExclusive) {
+    final s = start < 0 ? 0 : (start > buffer.length ? buffer.length : start);
+    final e = endExclusive < s
+        ? s
+        : (endExclusive > buffer.length ? buffer.length : endExclusive);
+    return Uint8List.sublistView(buffer, s, e);
+  }
+
+  /// Parses the total length from a `Content-Range: bytes 0-0/12345` header;
+  /// returns null for `.../*` or a missing/malformed header.
+  static int? _totalFromContentRange(String? header) {
+    if (header == null) return null;
+    final slash = header.lastIndexOf('/');
+    if (slash < 0) return null;
+    final total = header.substring(slash + 1).trim();
+    if (total == '*') return null;
+    return int.tryParse(total);
+  }
+
+  @override
+  Future<void> close() async {
+    if (_ownsClient) _client.close();
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/http_byte_source.dart
+++ b/packages/dart_pdf_editor/lib/src/http_byte_source.dart
@@ -140,7 +140,6 @@ class PdfHttpByteSource implements PdfByteSource {
   /// Probes range support and length with a single one-byte ranged GET.
   Future<void> _probe() async {
     if (_probed) return;
-    _probed = true;
     cancelToken?.throwIfCancelled();
     final response = await _get(rangeStart: 0, rangeEndInclusive: 0);
     cancelToken?.throwIfCancelled();
@@ -159,6 +158,9 @@ class PdfHttpByteSource implements PdfByteSource {
         throw PdfHttpException('unexpected status ${response.statusCode} for $uri',
             statusCode: response.statusCode);
     }
+    // Mark probed only after a usable response: a failed or cancelled probe
+    // must not permanently skip range/length detection on a retry.
+    _probed = true;
   }
 
   Future<http.Response> _get({

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -20,6 +20,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  # Cross-platform HTTP client (VM + web via fetch) for the progressive remote
+  # PDF byte source (PdfHttpByteSource); uses Range requests, no dart:io in our
+  # code. See src/http_byte_source.dart.
+  http: ^1.2.0
   image: ^4.9.1
   pdf_cos: ^1.4.7
   pdf_document: ^1.4.7

--- a/packages/dart_pdf_editor/test/http_byte_source_test.dart
+++ b/packages/dart_pdf_editor/test/http_byte_source_test.dart
@@ -149,6 +149,82 @@ void main() {
     });
   });
 
+  group('range support changing or edge statuses mid-read', () {
+    // A server that answers the 0-0 probe with 206 but a later ranged read
+    // with something else, exercising readRange's non-206 branches.
+    MockClient probe206Then(http.Response Function(int start, int end) onRange) {
+      return MockClient((request) async {
+        final m =
+            RegExp(r'bytes=(\d+)-(\d+)').firstMatch(request.headers['Range']!)!;
+        final start = int.parse(m.group(1)!);
+        final end = int.parse(m.group(2)!);
+        if (start == 0 && end == 0) {
+          return http.Response.bytes(const [0], 206,
+              headers: {'content-range': 'bytes 0-0/1000'});
+        }
+        return onRange(start, end);
+      });
+    }
+
+    test('a later 200 adopts the full body and serves from memory', () async {
+      final data = Uint8List.fromList(List.generate(1000, (i) => i % 256));
+      final source = PdfHttpByteSource(uri,
+          client: probe206Then((_, __) => http.Response.bytes(data, 200)));
+      expect(await source.length, 1000);
+      expect(source.supportsRange, isTrue); // probe saw 206
+      final chunk = await source.readRange(100, 130);
+      expect(chunk, data.sublist(100, 130));
+    });
+
+    test('a 416 on a past-end read yields empty', () async {
+      final source = PdfHttpByteSource(uri,
+          client: probe206Then((_, __) => http.Response.bytes(const [], 416)));
+      await source.length;
+      expect(await source.readRange(5000, 5100), isEmpty);
+    });
+
+    test('an unexpected status on a read throws', () async {
+      final source = PdfHttpByteSource(uri,
+          client: probe206Then((_, __) => http.Response('boom', 500)));
+      await source.length;
+      await expectLater(
+          source.readRange(10, 20), throwsA(isA<PdfHttpException>()));
+    });
+
+    test('an empty file (416 probe) reports length zero', () async {
+      final source = PdfHttpByteSource(uri,
+          client: MockClient((_) async => http.Response.bytes(const [], 416)));
+      expect(await source.length, 0);
+      expect(await source.readRange(0, 10), isEmpty);
+    });
+
+    test('reads without an explicit range are a no-op past the end', () async {
+      final source = PdfHttpByteSource(uri, client: rangeServer(buildClassicPdf()));
+      await source.length;
+      expect(await source.readRange(10, 10), isEmpty);
+    });
+  });
+
+  group('owned client and diagnostics', () {
+    test('a default client is created and closed by close()', () async {
+      // No client injected: the source owns one. Exercises the owning path;
+      // close() must complete without error.
+      final source = PdfHttpByteSource(uri);
+      await source.close();
+    });
+
+    test('cancel token and exception strings are exposed', () {
+      final token = PdfCancelToken();
+      expect(token.isCancelled, isFalse);
+      token.cancel();
+      expect(token.isCancelled, isTrue);
+      expect(const PdfHttpCancelledException().toString(), contains('cancelled'));
+      expect(PdfHttpException('bad', statusCode: 404).toString(),
+          contains('404'));
+      expect(PdfHttpException('bad').toString(), contains('bad'));
+    });
+  });
+
   group('errors and cancellation', () {
     test('an error status throws PdfHttpException', () async {
       final source = PdfHttpByteSource(uri,

--- a/packages/dart_pdf_editor/test/http_byte_source_test.dart
+++ b/packages/dart_pdf_editor/test/http_byte_source_test.dart
@@ -1,0 +1,206 @@
+// PdfHttpByteSource: Range-request progressive loading, full-download
+// fallback for servers that ignore Range, header/auth forwarding,
+// cancellation, and error handling. Uses http's MockClient - no real network.
+
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// A MockClient serving [data]. When [supportRange] is false it answers every
+/// request with a full 200 body, modelling a server (or a web CORS response
+/// with hidden headers) that does not expose ranges. Records requests.
+MockClient rangeServer(
+  Uint8List data, {
+  bool supportRange = true,
+  List<http.Request>? log,
+}) {
+  return MockClient((request) async {
+    log?.add(request);
+    final range = request.headers['Range'];
+    if (supportRange && range != null) {
+      final match = RegExp(r'bytes=(\d+)-(\d+)').firstMatch(range);
+      if (match != null) {
+        final start = int.parse(match.group(1)!);
+        var end = int.parse(match.group(2)!);
+        if (start >= data.length) {
+          return http.Response.bytes(const [], 416);
+        }
+        if (end >= data.length) end = data.length - 1;
+        return http.Response.bytes(
+          data.sublist(start, end + 1),
+          206,
+          headers: {'content-range': 'bytes $start-$end/${data.length}'},
+        );
+      }
+    }
+    return http.Response.bytes(data, 200);
+  });
+}
+
+void main() {
+  final uri = Uri.parse('https://example.test/doc.pdf');
+
+  group('range-capable server', () {
+    test('probes length and range support with one small request', () async {
+      final data = buildMultiPagePdf(4);
+      final requests = <http.Request>[];
+      final source = PdfHttpByteSource(uri,
+          client: rangeServer(data, log: requests));
+
+      expect(await source.length, data.length);
+      expect(source.supportsRange, isTrue);
+      // The probe is a single one-byte range, not a full download.
+      expect(requests.single.headers['Range'], 'bytes=0-0');
+    });
+
+    test('reads a middle range', () async {
+      final data = Uint8List.fromList(List.generate(1000, (i) => i % 256));
+      final source = PdfHttpByteSource(uri, client: rangeServer(data));
+      final chunk = await source.readRange(100, 150);
+      expect(chunk, data.sublist(100, 150));
+    });
+
+    test('opens a document through PdfDocument.openSource', () async {
+      final source =
+          PdfHttpByteSource(uri, client: rangeServer(buildClassicPdf()));
+      final doc = await PdfDocument.openSource(source);
+      expect(doc.catalog.typeName, 'Catalog');
+      expect(doc.pageCount, 1);
+    });
+
+    test('opens a linearized-style multi-revision document', () async {
+      final base = CosDocument.open(buildClassicPdf());
+      final updated = (CosIncrementalUpdater(base)
+            ..replaceObject(5, CosDictionary({'Rewritten': const CosBoolean(true)})))
+          .save();
+      final source = PdfHttpByteSource(uri, client: rangeServer(updated));
+      final doc = await CosDocument.openSource(source);
+      expect(doc.catalog.typeName, 'Catalog');
+    });
+
+    test('forwards authentication headers on every request', () async {
+      final data = buildClassicPdf();
+      final requests = <http.Request>[];
+      final source = PdfHttpByteSource(
+        uri,
+        headers: {'Authorization': 'Bearer secret-token'},
+        client: rangeServer(data, log: requests),
+      );
+      await CosDocument.openSource(source);
+      expect(requests, isNotEmpty);
+      expect(
+        requests.every((r) => r.headers['Authorization'] == 'Bearer secret-token'),
+        isTrue,
+      );
+    });
+
+    test('reports progress with the known total', () async {
+      final data = buildMultiPagePdf(4);
+      final events = <({int received, int? total})>[];
+      final source = PdfHttpByteSource(
+        uri,
+        client: rangeServer(data),
+        onProgress: (received, total) =>
+            events.add((received: received, total: total)),
+      );
+      await CosDocument.openSource(source);
+      expect(events, isNotEmpty);
+      expect(events.last.total, data.length);
+      for (var i = 1; i < events.length; i++) {
+        expect(events[i].received, greaterThanOrEqualTo(events[i - 1].received));
+      }
+    });
+  });
+
+  group('server without range support', () {
+    test('falls back to a full download and still opens', () async {
+      final data = buildClassicPdf();
+      final requests = <http.Request>[];
+      final source = PdfHttpByteSource(uri,
+          client: rangeServer(data, supportRange: false, log: requests));
+
+      final doc = await CosDocument.openSource(source);
+      expect(doc.catalog.typeName, 'Catalog');
+      expect(source.supportsRange, isFalse);
+      // Length is learned from the 200 body, and later reads are served from
+      // memory - only the first request actually hit the network.
+      expect(await source.length, data.length);
+    });
+
+    test('serves subsequent ranges from the cached body', () async {
+      final data = Uint8List.fromList(List.generate(500, (i) => i % 251));
+      var hits = 0;
+      final client = MockClient((request) async {
+        hits++;
+        return http.Response.bytes(data, 200); // ignores Range
+      });
+      final source = PdfHttpByteSource(uri, client: client);
+      final a = await source.readRange(10, 20);
+      final b = await source.readRange(400, 450);
+      expect(a, data.sublist(10, 20));
+      expect(b, data.sublist(400, 450));
+      expect(hits, 1); // one download, both slices from memory
+    });
+  });
+
+  group('errors and cancellation', () {
+    test('an error status throws PdfHttpException', () async {
+      final source = PdfHttpByteSource(uri,
+          client: MockClient((_) async => http.Response('nope', 404)));
+      await expectLater(source.length, throwsA(isA<PdfHttpException>()));
+    });
+
+    test('a transport failure is wrapped', () async {
+      final source = PdfHttpByteSource(uri,
+          client: MockClient((_) async => throw http.ClientException('boom')));
+      await expectLater(
+          source.readRange(0, 10), throwsA(isA<PdfHttpException>()));
+    });
+
+    test('cancellation before reading throws', () async {
+      final token = PdfCancelToken()..cancel();
+      final source = PdfHttpByteSource(uri,
+          client: rangeServer(buildClassicPdf()), cancelToken: token);
+      await expectLater(
+          source.readRange(0, 10), throwsA(isA<PdfHttpCancelledException>()));
+    });
+
+    test('cancellation mid-load aborts openSource', () async {
+      final token = PdfCancelToken();
+      var served = 0;
+      final data = buildMultiPagePdf(6);
+      final client = MockClient((request) async {
+        served++;
+        if (served >= 2) token.cancel(); // cancel after the probe
+        final range = request.headers['Range']!;
+        final m = RegExp(r'bytes=(\d+)-(\d+)').firstMatch(range)!;
+        final s = int.parse(m.group(1)!);
+        var e = int.parse(m.group(2)!);
+        if (e >= data.length) e = data.length - 1;
+        return http.Response.bytes(data.sublist(s, e + 1), 206,
+            headers: {'content-range': 'bytes $s-$e/${data.length}'});
+      });
+      final source =
+          PdfHttpByteSource(uri, client: client, cancelToken: token);
+      await expectLater(CosDocument.openSource(source),
+          throwsA(isA<PdfHttpCancelledException>()));
+    });
+  });
+
+  test('close() leaves a caller-supplied client open', () async {
+    // The source only owns (and closes) a client it created itself; an
+    // injected client is the caller's to manage.
+    final client = rangeServer(buildClassicPdf());
+    final source = PdfHttpByteSource(uri, client: client);
+    await source.close();
+    // The injected client is still usable after close().
+    final response = await client.get(uri, headers: {'Range': 'bytes=0-0'});
+    expect(response.statusCode, 206);
+  });
+}

--- a/packages/pdf_cos/lib/pdf_cos.dart
+++ b/packages/pdf_cos/lib/pdf_cos.dart
@@ -3,6 +3,7 @@
 library;
 
 export 'src/builder.dart';
+export 'src/byte_source.dart';
 export 'src/content_parser.dart';
 export 'src/crypto/aes.dart';
 export 'src/crypto/asn1.dart';

--- a/packages/pdf_cos/lib/src/byte_source.dart
+++ b/packages/pdf_cos/lib/src/byte_source.dart
@@ -59,18 +59,6 @@ class PdfBytesByteSource implements PdfByteSource {
   Future<void> close() async {}
 }
 
-/// Thrown when a byte source cannot satisfy a request the loader needs. The
-/// progressive loader catches its own recoverable failures and falls back to
-/// a full download; this surfaces only genuinely unrecoverable conditions.
-class PdfByteSourceException implements Exception {
-  PdfByteSourceException(this.message);
-
-  final String message;
-
-  @override
-  String toString() => 'PdfByteSourceException: $message';
-}
-
 /// Reports progressive-load progress. [fetched] is the running total of bytes
 /// pulled from the source; [total] is the document length when known.
 typedef PdfSourceProgress = void Function(int fetched, int? total);
@@ -437,9 +425,15 @@ class _ProgressiveLoader {
     for (final gap in _missing(start, end)) {
       final data = await source.readRange(gap.start, gap.end);
       if (data.isEmpty) continue;
-      _buffer.setRange(gap.start, gap.start + data.length, data);
-      _addPresent(gap.start, gap.start + data.length);
-      _fetched += data.length;
+      // Never trust a source to honour the requested length: a misbehaving
+      // server can answer a ranged read with more bytes than asked for
+      // (a 206 carrying the whole file, a padding CDN). Clamp so setRange
+      // can't run past the gap - and the buffer's end - which would abort
+      // the whole open instead of letting it fall back.
+      final count = math.min(data.length, gap.end - gap.start);
+      _buffer.setRange(gap.start, gap.start + count, data);
+      _addPresent(gap.start, gap.start + count);
+      _fetched += count;
       options.onProgress?.call(_fetched, _length);
     }
   }

--- a/packages/pdf_cos/lib/src/byte_source.dart
+++ b/packages/pdf_cos/lib/src/byte_source.dart
@@ -1,0 +1,525 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'document.dart';
+import 'exceptions.dart';
+import 'filters/filters.dart';
+import 'objects.dart';
+import 'parser.dart';
+import 'token.dart';
+
+/// A random-access, possibly asynchronous source of PDF bytes.
+///
+/// The core parser is network-agnostic: it asks a source for the byte ranges
+/// it needs rather than requiring the whole file in one buffer. An HTTP
+/// implementation (Range requests, headers, auth, cancellation, progress)
+/// lives outside the core - see `PdfHttpByteSource` in `dart_pdf_editor`.
+///
+/// Implementations must be safe to call [readRange] on concurrently.
+abstract interface class PdfByteSource {
+  /// The total number of bytes, or null when the length is not known ahead
+  /// of time (e.g. a server that answers neither HEAD nor a ranged GET with
+  /// a total). A null length makes progressive loading fall back to a plain
+  /// sequential download.
+  Future<int?> get length;
+
+  /// Returns the bytes in `[start, endExclusive)`. Implementations clamp the
+  /// range to the available data: a request past the end returns fewer bytes
+  /// (a short read), and a request wholly past the end returns an empty list.
+  /// `start` is clamped to be non-negative; `endExclusive <= start` yields an
+  /// empty list.
+  Future<Uint8List> readRange(int start, int endExclusive);
+
+  /// Releases any resources (open connections, buffers). Optional; the
+  /// default does nothing. Sources are single-use unless documented
+  /// otherwise.
+  Future<void> close() async {}
+}
+
+/// A [PdfByteSource] backed by a complete in-memory buffer. Handy for tests
+/// and for adapting already-downloaded bytes to the source-based API.
+class PdfBytesByteSource implements PdfByteSource {
+  PdfBytesByteSource(this._bytes);
+
+  final Uint8List _bytes;
+
+  @override
+  Future<int?> get length async => _bytes.length;
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    final s = start < 0 ? 0 : (start > _bytes.length ? _bytes.length : start);
+    final e = endExclusive < s
+        ? s
+        : (endExclusive > _bytes.length ? _bytes.length : endExclusive);
+    return Uint8List.sublistView(_bytes, s, e);
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
+/// Thrown when a byte source cannot satisfy a request the loader needs. The
+/// progressive loader catches its own recoverable failures and falls back to
+/// a full download; this surfaces only genuinely unrecoverable conditions.
+class PdfByteSourceException implements Exception {
+  PdfByteSourceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'PdfByteSourceException: $message';
+}
+
+/// Reports progressive-load progress. [fetched] is the running total of bytes
+/// pulled from the source; [total] is the document length when known.
+typedef PdfSourceProgress = void Function(int fetched, int? total);
+
+/// Tuning knobs for [openCosDocumentFromSource]. The defaults suit HTTP Range
+/// loading: a few KB probes for the header, ~64 KB windows for the tail and
+/// each xref section, and coalescing of nearby object ranges so densely
+/// packed bodies fetch in one request instead of thousands.
+class PdfSourceLoadOptions {
+  const PdfSourceLoadOptions({
+    this.headWindow = 4096,
+    this.tailWindow = 65536,
+    this.xrefWindow = 65536,
+    this.coalesceGap = 65536,
+    this.downloadChunk = 1 << 20,
+    this.onProgress,
+  })  : assert(headWindow > 0),
+        assert(tailWindow > 0),
+        assert(xrefWindow > 0),
+        assert(coalesceGap >= 0),
+        assert(downloadChunk > 0);
+
+  /// Bytes fetched from the start of the file to locate the `%PDF-` header.
+  final int headWindow;
+
+  /// Bytes fetched from the end of the file to locate `startxref` and the
+  /// newest cross-reference section.
+  final int tailWindow;
+
+  /// Initial window fetched for each cross-reference section; grown
+  /// geometrically when a section (a large xref table or stream) overruns it.
+  final int xrefWindow;
+
+  /// Object byte ranges separated by at most this many bytes are fetched in a
+  /// single request. Larger values mean fewer, bigger requests.
+  final int coalesceGap;
+
+  /// Chunk size used by the sequential-download fallback (unknown length or
+  /// a source that cannot serve useful ranges).
+  final int downloadChunk;
+
+  /// Optional progress callback, invoked after each fetch.
+  final PdfSourceProgress? onProgress;
+}
+
+/// Opens a [CosDocument] from an asynchronous [source], fetching only the
+/// bytes it needs.
+///
+/// The loader reads the header probe, walks the cross-reference chain with
+/// ranged reads, and then fetches the byte ranges of the live objects
+/// (skipping free space and superseded incremental-update revisions) into a
+/// sparse buffer that the ordinary synchronous [CosDocument.open] consumes.
+///
+/// When the length is unknown, the cross-reference machinery is broken, or a
+/// ranged read fails, it falls back to a plain sequential download and opens
+/// that - so a non-range-capable server still works, just without the
+/// bandwidth savings. [password] is forwarded to [CosDocument.open].
+Future<CosDocument> openCosDocumentFromSource(
+  PdfByteSource source, {
+  String password = '',
+  PdfSourceLoadOptions options = const PdfSourceLoadOptions(),
+}) async {
+  Uint8List buffer;
+  try {
+    buffer = await _ProgressiveLoader(source, options).load();
+  } on _FallbackToFullDownload {
+    buffer = await _downloadFully(source, options);
+  }
+  return CosDocument.open(buffer, password: password);
+}
+
+/// Sentinel that unwinds the progressive path to the full-download fallback.
+class _FallbackToFullDownload implements Exception {
+  const _FallbackToFullDownload();
+}
+
+/// A half-open byte interval `[start, end)`.
+class _Range {
+  _Range(this.start, this.end);
+  int start;
+  int end;
+}
+
+/// Fetches the whole document sequentially. Used when ranged loading is not
+/// viable. Reads one range for a known length, otherwise chunks until a short
+/// read signals EOF.
+Future<Uint8List> _downloadFully(
+    PdfByteSource source, PdfSourceLoadOptions options) async {
+  final len = await source.length;
+  if (len != null && len >= 0) {
+    final data = await source.readRange(0, len);
+    options.onProgress?.call(data.length, len);
+    return data;
+  }
+  final builder = BytesBuilder(copy: false);
+  var pos = 0;
+  while (true) {
+    final chunk = await source.readRange(pos, pos + options.downloadChunk);
+    if (chunk.isEmpty) break;
+    builder.add(chunk);
+    pos += chunk.length;
+    options.onProgress?.call(pos, null);
+    if (chunk.length < options.downloadChunk) break;
+  }
+  return builder.toBytes();
+}
+
+/// Drives a [PdfByteSource] to assemble a sparse buffer good enough for the
+/// synchronous parser: header, cross-reference sections, and the live
+/// objects' byte ranges are populated; free space and dead revisions are
+/// left as zeros the parser never reads.
+class _ProgressiveLoader {
+  _ProgressiveLoader(this.source, this.options);
+
+  final PdfByteSource source;
+  final PdfSourceLoadOptions options;
+
+  late final int _length;
+  late final Uint8List _buffer;
+
+  /// Fetched (merged, sorted) byte ranges, so overlapping windows are not
+  /// pulled twice.
+  final List<_Range> _present = [];
+  int _fetched = 0;
+
+  Future<Uint8List> load() async {
+    final len = await source.length;
+    if (len == null || len <= 0) throw const _FallbackToFullDownload();
+    _length = len;
+    _buffer = Uint8List(len);
+
+    // Header probe: also settles the offset shift for junk-before-header.
+    await _fetch(0, math.min(len, options.headWindow));
+    final shift = _indexOf(_buffer, _pdfHeader, 0, math.min(len, 1024));
+    if (shift < 0) throw const _FallbackToFullDownload();
+
+    // Tail: startxref + the newest cross-reference section usually live here.
+    await _fetch(math.max(0, len - options.tailWindow), len);
+
+    final startXref = _findStartXref(shift);
+    if (startXref == null) throw const _FallbackToFullDownload();
+
+    final offsets = await _walkXref(startXref + shift, shift);
+    if (offsets.isEmpty) throw const _FallbackToFullDownload();
+
+    await _fetchObjects(offsets);
+    return _buffer;
+  }
+
+  /// Absolute offsets of the cross-reference sections visited by [_walkXref].
+  /// Object bodies never cross into an xref section, so these bound how far an
+  /// object range may extend.
+  final List<int> _xrefOffsets = [];
+
+  /// Walks the cross-reference chain newest-to-oldest, collecting the absolute
+  /// file offsets of every in-use object. Compressed objects need no offset -
+  /// their container object stream is itself an in-use object in the chain.
+  Future<List<int>> _walkXref(int firstOffset, int shift) async {
+    final offsets = <int>{};
+    final pending = <int>[firstOffset];
+    final visited = <int>{};
+    var sections = 0;
+    while (pending.isNotEmpty) {
+      final offset = pending.removeAt(0);
+      if (!visited.add(offset)) continue;
+      if (++sections > 4096) throw const _FallbackToFullDownload();
+      _xrefOffsets.add(offset);
+      final section = await _readXrefSection(offset);
+      for (final raw in section.inUseOffsets) {
+        offsets.add(raw + shift);
+      }
+      final xrefStm = section.trailer['XRefStm'];
+      if (xrefStm is CosInteger) pending.add(xrefStm.value + shift);
+      final prev = section.trailer['Prev'];
+      if (prev is CosInteger) pending.add(prev.value + shift);
+    }
+    _xrefOffsets.sort();
+    return offsets.toList()..sort();
+  }
+
+  /// The smallest boundary strictly greater than [start] - the next object
+  /// offset, the next xref section, or end of file - which is where the object
+  /// at [start] can safely be assumed to end.
+  int _objectEnd(List<int> sortedOffsets, int index) {
+    final start = sortedOffsets[index];
+    var end = index + 1 < sortedOffsets.length
+        ? sortedOffsets[index + 1]
+        : _length;
+    for (final xref in _xrefOffsets) {
+      if (xref > start && xref < end) end = xref;
+    }
+    return end;
+  }
+
+  /// Reads and parses the cross-reference section at [offset], growing the
+  /// fetched window geometrically until the section fits.
+  ///
+  /// A section parse only succeeds when its terminator (`trailer` for a
+  /// table, `endstream`/`endobj` for a stream) is reached over real bytes:
+  /// beyond the fetched window the buffer is zero-filled, which the lexer
+  /// treats as whitespace and runs into an EOF, so truncation always throws
+  /// rather than yielding a short read. That makes any successful parse
+  /// authoritative, so we simply widen the window and retry on failure,
+  /// giving up (to the full-download fallback) only once the whole remaining
+  /// file has been fetched.
+  Future<_XrefSection> _readXrefSection(int offset) async {
+    if (offset < 0 || offset >= _length) {
+      throw const _FallbackToFullDownload();
+    }
+    var window = options.xrefWindow;
+    while (true) {
+      final end = math.min(_length, offset + window);
+      await _fetch(offset, end);
+      try {
+        return _parseXrefSection(offset, end);
+      } on _FallbackToFullDownload {
+        rethrow;
+      } on Exception {
+        // Truncated window (_NeedMoreBytes), malformed syntax, or a filter
+        // error on a partial stream - widen and retry.
+        _growOrFail(end);
+        window *= 2;
+      } on RangeError {
+        _growOrFail(end);
+        window *= 2;
+      }
+    }
+  }
+
+  void _growOrFail(int end) {
+    if (end >= _length) throw const _FallbackToFullDownload();
+  }
+
+  _XrefSection _parseXrefSection(int offset, int limit) {
+    final parser = CosParser(_buffer, offset: offset);
+    if (parser.peekToken().isKeyword('xref')) {
+      return _parseXrefTable(parser, limit);
+    }
+    return _parseXrefStream(parser, limit);
+  }
+
+  _XrefSection _parseXrefTable(CosParser parser, int limit) {
+    parser.expectKeyword('xref');
+    final inUse = <int>[];
+    while (parser.peekToken().type == CosTokenType.integer) {
+      parser.expectInteger(); // subsection start object number
+      final count = parser.expectInteger();
+      for (var i = 0; i < count; i++) {
+        final offset = parser.expectInteger();
+        parser.expectInteger(); // generation
+        final kind = parser.nextToken();
+        if (kind.offset >= limit) throw const _NeedMoreBytes();
+        if (kind.isKeyword('n')) {
+          inUse.add(offset);
+        } else if (!kind.isKeyword('f')) {
+          throw CosParseException('invalid xref entry type', kind.offset);
+        }
+        // free entries carry no live object
+      }
+    }
+    final trailerToken = parser.expectKeyword('trailer');
+    if (trailerToken.offset >= limit) throw const _NeedMoreBytes();
+    final trailer = parser.parseObject();
+    if (trailer is! CosDictionary) {
+      throw CosParseException('trailer is not a dictionary');
+    }
+    return _XrefSection(inUse, trailer);
+  }
+
+  _XrefSection _parseXrefStream(CosParser parser, int limit) {
+    final indirect = parser.parseIndirectObject();
+    final object = indirect.object;
+    if (object is! CosStream) {
+      throw CosParseException('expected a cross-reference stream');
+    }
+    final dict = object.dictionary;
+    // The stream body slices the shared buffer; its absolute end must fall
+    // within the fetched window, otherwise part of it is still zero-filled.
+    final bodyEnd = object.rawBytes.offsetInBytes + object.rawBytes.length;
+    if (bodyEnd > limit) throw const _NeedMoreBytes();
+    final data = decodeStream(object);
+
+    final w = dict['W'];
+    final size = dict['Size'];
+    if (w is! CosArray || w.length < 3 || size is! CosInteger) {
+      throw CosParseException('invalid /W or /Size in cross-reference stream');
+    }
+    final widths = [
+      for (final field in w.items)
+        field is CosInteger
+            ? field.value
+            : throw CosParseException('invalid /W entry'),
+    ];
+    final index = dict['Index'];
+    final ranges = index is CosArray
+        ? [
+            for (final v in index.items)
+              v is CosInteger
+                  ? v.value
+                  : throw CosParseException('invalid /Index entry'),
+          ]
+        : [0, size.value];
+
+    final inUse = <int>[];
+    final rowLength = widths.fold(0, (a, b) => a + b);
+    var pos = 0;
+    for (var r = 0; r + 1 < ranges.length; r += 2) {
+      final count = ranges[r + 1];
+      for (var i = 0; i < count && pos + rowLength <= data.length; i++) {
+        final fields = <int>[];
+        for (final width in widths) {
+          var value = 0;
+          for (var k = 0; k < width; k++) {
+            value = (value << 8) | data[pos++];
+          }
+          fields.add(value);
+        }
+        final type = widths[0] == 0 ? 1 : fields[0];
+        if (type == 1) inUse.add(fields[1]);
+      }
+    }
+    return _XrefSection(inUse, dict);
+  }
+
+  /// Fetches the byte ranges of the live objects. Each object spans from its
+  /// offset up to the next object's offset (a safe upper bound); the highest
+  /// object runs to end of file. Nearby ranges coalesce into one request.
+  Future<void> _fetchObjects(List<int> offsets) async {
+    if (offsets.isEmpty) return;
+    _Range? pending;
+    for (var i = 0; i < offsets.length; i++) {
+      final start = offsets[i];
+      final end = _objectEnd(offsets, i);
+      if (start < 0 || end > _length || start >= end) continue;
+      if (pending == null) {
+        pending = _Range(start, end);
+      } else if (start - pending.end <= options.coalesceGap) {
+        pending.end = end;
+      } else {
+        await _fetch(pending.start, pending.end);
+        pending = _Range(start, end);
+      }
+    }
+    if (pending != null) await _fetch(pending.start, pending.end);
+  }
+
+  int? _findStartXref(int shift) {
+    final from = _length > 2048 ? _length - 2048 : shift;
+    final at = _lastIndexOf(_buffer, _startXref, from);
+    if (at < 0) return null;
+    try {
+      return CosParser(_buffer, offset: at + _startXref.length).expectInteger();
+    } on CosParseException {
+      return null;
+    } on RangeError {
+      return null;
+    }
+  }
+
+  /// Reads `[start, end)` from the source into the buffer, skipping any bytes
+  /// already present. Reports progress for the bytes actually pulled.
+  Future<void> _fetch(int start, int end) async {
+    if (end <= start) return;
+    for (final gap in _missing(start, end)) {
+      final data = await source.readRange(gap.start, gap.end);
+      if (data.isEmpty) continue;
+      _buffer.setRange(gap.start, gap.start + data.length, data);
+      _addPresent(gap.start, gap.start + data.length);
+      _fetched += data.length;
+      options.onProgress?.call(_fetched, _length);
+    }
+  }
+
+  /// The sub-ranges of `[start, end)` not yet fetched.
+  List<_Range> _missing(int start, int end) {
+    final gaps = <_Range>[];
+    var cursor = start;
+    for (final r in _present) {
+      if (r.end <= cursor) continue;
+      if (r.start >= end) break;
+      if (r.start > cursor) gaps.add(_Range(cursor, math.min(r.start, end)));
+      cursor = math.max(cursor, r.end);
+      if (cursor >= end) break;
+    }
+    if (cursor < end) gaps.add(_Range(cursor, end));
+    return gaps;
+  }
+
+  void _addPresent(int start, int end) {
+    _present.add(_Range(start, end));
+    _present.sort((a, b) => a.start.compareTo(b.start));
+    final merged = <_Range>[];
+    for (final r in _present) {
+      if (merged.isNotEmpty && r.start <= merged.last.end) {
+        if (r.end > merged.last.end) merged.last.end = r.end;
+      } else {
+        merged.add(_Range(r.start, r.end));
+      }
+    }
+    _present
+      ..clear()
+      ..addAll(merged);
+  }
+}
+
+/// Parsed cross-reference section: the raw (pre-shift) file offsets of its
+/// in-use objects and its trailer/xref-stream dictionary (for /Prev chasing).
+class _XrefSection {
+  _XrefSection(this.inUseOffsets, this.trailer);
+  final List<int> inUseOffsets;
+  final CosDictionary trailer;
+}
+
+/// Raised inside section parsing when the fetched window is too small; the
+/// caller widens the window and retries.
+class _NeedMoreBytes implements Exception {
+  const _NeedMoreBytes();
+}
+
+final Uint8List _pdfHeader = _ascii('%PDF-');
+final Uint8List _startXref = _ascii('startxref');
+
+Uint8List _ascii(String s) => Uint8List.fromList(s.codeUnits);
+
+int _indexOf(Uint8List bytes, Uint8List pattern, int from, int limit) {
+  final end = limit - pattern.length;
+  for (var p = from; p <= end; p++) {
+    var match = true;
+    for (var i = 0; i < pattern.length; i++) {
+      if (bytes[p + i] != pattern[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) return p;
+  }
+  return -1;
+}
+
+int _lastIndexOf(Uint8List bytes, Uint8List pattern, int from) {
+  for (var p = bytes.length - pattern.length; p >= from; p--) {
+    var match = true;
+    for (var i = 0; i < pattern.length; i++) {
+      if (bytes[p + i] != pattern[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) return p;
+  }
+  return -1;
+}

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'byte_source.dart';
 import 'crypto/standard_security_handler.dart';
 import 'exceptions.dart';
 import 'filters/filters.dart';
@@ -89,6 +90,19 @@ class CosDocument {
     }
     return _recover(bytes, shift, password);
   }
+
+  /// Opens a document from an asynchronous, random-access [source], fetching
+  /// only the byte ranges it needs (header, cross-reference chain, and the
+  /// live objects) instead of requiring the whole file up front. Falls back
+  /// to a full sequential download when the source cannot serve useful
+  /// ranges or the cross-reference machinery is broken. See [PdfByteSource]
+  /// and [openCosDocumentFromSource].
+  static Future<CosDocument> openSource(
+    PdfByteSource source, {
+    String password = '',
+    PdfSourceLoadOptions options = const PdfSourceLoadOptions(),
+  }) =>
+      openCosDocumentFromSource(source, password: password, options: options);
 
   static CosDocument _openFromXref(Uint8List bytes, int shift) {
     final startXref = _findStartXref(bytes);

--- a/packages/pdf_cos/test/byte_source_test.dart
+++ b/packages/pdf_cos/test/byte_source_test.dart
@@ -1,0 +1,297 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+/// A [PdfByteSource] over an in-memory buffer that records every range it is
+/// asked for, and can simulate the real-world quirks the loader must survive:
+/// an unknown length (a server that answers no Range and no Content-Length),
+/// per-read failure (cancellation, a dropped connection), and corrupted bytes
+/// (a malformed response body).
+class RecordingSource implements PdfByteSource {
+  RecordingSource(
+    this._bytes, {
+    this.knownLength = true,
+    this.failAtRead,
+    this.corrupt = const {},
+  });
+
+  final Uint8List _bytes;
+  final bool knownLength;
+
+  /// Throw a [StateError] when this many reads have been served (1-based),
+  /// standing in for a cancelled or dropped transfer.
+  final int? failAtRead;
+
+  /// Byte offsets whose value the source flips, corrupting the response.
+  final Set<int> corrupt;
+
+  final List<({int start, int end})> reads = [];
+  int closes = 0;
+
+  int get bytesFetched =>
+      reads.fold(0, (sum, r) => sum + (r.end - r.start));
+
+  bool covers(int offset) => reads.any((r) => offset >= r.start && offset < r.end);
+
+  @override
+  Future<int?> get length async => knownLength ? _bytes.length : null;
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    reads.add((start: start, end: endExclusive));
+    if (failAtRead != null && reads.length >= failAtRead!) {
+      throw StateError('transfer cancelled');
+    }
+    final s = start < 0 ? 0 : (start > _bytes.length ? _bytes.length : start);
+    final e = endExclusive < s
+        ? s
+        : (endExclusive > _bytes.length ? _bytes.length : endExclusive);
+    final view = Uint8List.fromList(_bytes.sublist(s, e));
+    for (final at in corrupt) {
+      if (at >= s && at < e) view[at - s] ^= 0xFF;
+    }
+    return view;
+  }
+
+  @override
+  Future<void> close() async => closes++;
+}
+
+void main() {
+  group('progressive load over a range-capable source', () {
+    test('opens a classic xref-table document', () async {
+      final source = RecordingSource(buildClassicPdf());
+      final doc = await CosDocument.openSource(source);
+
+      expect(doc.catalog.typeName, 'Catalog');
+      final page = doc.getObject(3, 0) as CosDictionary;
+      expect(page.typeName, 'Page');
+      final content = doc.getObject(4, 0) as CosStream;
+      expect(String.fromCharCodes(doc.decodeStreamData(content)),
+          contains('Hello, world!'));
+    });
+
+    test('opens an xref-stream + object-stream document', () async {
+      final source = RecordingSource(buildXrefStreamPdf());
+      final doc = await CosDocument.openSource(source);
+
+      expect(doc.version, '1.5');
+      final pages = doc.resolve(doc.catalog['Pages']) as CosDictionary;
+      expect(pages.typeName, 'Pages');
+      final page = doc.resolve((pages['Kids'] as CosArray)[0]) as CosDictionary;
+      expect(page.typeName, 'Page');
+    });
+
+    test('opens a larger multi-page document', () async {
+      final source = RecordingSource(buildMultiPagePdf(8));
+      final doc = await CosDocument.openSource(source);
+      final pages = doc.resolve(doc.catalog['Pages']) as CosDictionary;
+      expect((pages['Kids'] as CosArray).length, 8);
+    });
+
+    test('fetches the header and tail as separate ranges, not one blob',
+        () async {
+      final bytes = buildMultiPagePdf(6);
+      final source = RecordingSource(bytes);
+      // Small probes so the body is fetched separately from the header/tail,
+      // making the ranged (non-blob) behaviour observable on a small file.
+      await CosDocument.openSource(source,
+          options: const PdfSourceLoadOptions(headWindow: 128, tailWindow: 128));
+
+      // Progressive: more than one request, none of them the whole file.
+      expect(source.reads.length, greaterThan(1));
+      expect(source.reads.any((r) => r.start == 0 && r.end >= bytes.length),
+          isFalse);
+      // The header probe starts at 0; the tail window reaches the last byte.
+      expect(source.reads.any((r) => r.start == 0), isTrue);
+      expect(source.covers(bytes.length - 1), isTrue);
+    });
+
+    test('walks a /Prev chain from an incremental update', () async {
+      final base = CosDocument.open(buildClassicPdf());
+      final updated = (CosIncrementalUpdater(base)
+            ..replaceObject(
+                5,
+                CosDictionary({
+                  'Type': const CosName('Font'),
+                  'Subtype': const CosName('Type1'),
+                  'BaseFont': const CosName('Courier'),
+                })))
+          .save();
+
+      final doc = await CosDocument.openSource(RecordingSource(updated));
+      // Newest revision wins, older objects still resolve through /Prev.
+      expect((doc.getObject(5, 0) as CosDictionary)['BaseFont'],
+          const CosName('Courier'));
+      expect((doc.getObject(3, 0) as CosDictionary).typeName, 'Page');
+      expect(doc.catalog.typeName, 'Catalog');
+    });
+
+    test('opens correctly with tiny head and tail windows', () async {
+      // Small windows force the loader to grow xref windows and issue many
+      // small ranged reads; the result must still be correct.
+      final bytes = buildMultiPagePdf(12);
+      final source = RecordingSource(bytes);
+      final doc = await CosDocument.openSource(source,
+          options: const PdfSourceLoadOptions(
+              tailWindow: 128, headWindow: 128, xrefWindow: 128));
+      expect(doc.catalog.typeName, 'Catalog');
+      expect((doc.resolve(doc.catalog['Pages']) as CosDictionary)['Kids'],
+          isA<CosArray>());
+    });
+
+    test('reports progress with a monotonic count and the real total',
+        () async {
+      final bytes = buildMultiPagePdf(4);
+      final seen = <int>[];
+      int? total;
+      await CosDocument.openSource(
+        RecordingSource(bytes),
+        options: PdfSourceLoadOptions(onProgress: (fetched, t) {
+          seen.add(fetched);
+          total = t;
+        }),
+      );
+      expect(seen, isNotEmpty);
+      expect(total, bytes.length);
+      for (var i = 1; i < seen.length; i++) {
+        expect(seen[i], greaterThanOrEqualTo(seen[i - 1]));
+      }
+    });
+  });
+
+  group('fallback to a full download', () {
+    test('unknown length downloads sequentially and still opens', () async {
+      final bytes = buildClassicPdf();
+      final source = RecordingSource(bytes, knownLength: false);
+      final doc = await CosDocument.openSource(source);
+
+      expect(doc.catalog.typeName, 'Catalog');
+      // No ranged probing: the first read starts at 0.
+      expect(source.reads.first.start, 0);
+    });
+
+    test('unknown length chunks until a short read signals EOF', () async {
+      final bytes = buildMultiPagePdf(4);
+      final source = RecordingSource(bytes, knownLength: false);
+      final doc = await CosDocument.openSource(
+        source,
+        options: const PdfSourceLoadOptions(downloadChunk: 512),
+      );
+      expect(doc.catalog.typeName, 'Catalog');
+      // Reads advance by the chunk size from zero.
+      expect(source.reads.first, (start: 0, end: 512));
+      expect(source.bytesFetched, greaterThanOrEqualTo(bytes.length));
+    });
+
+    test('a broken startxref falls back and recovers via a full scan',
+        () async {
+      final bytes = Uint8List.fromList(buildClassicPdf());
+      // Corrupt the startxref offset digits near the tail so the ranged xref
+      // walk fails; recovery in CosDocument.open then rebuilds by scanning.
+      final marker = 'startxref'.codeUnits;
+      var at = -1;
+      for (var p = bytes.length - marker.length; p >= 0; p--) {
+        var match = true;
+        for (var i = 0; i < marker.length; i++) {
+          if (bytes[p + i] != marker[i]) {
+            match = false;
+            break;
+          }
+        }
+        if (match) {
+          at = p;
+          break;
+        }
+      }
+      expect(at, greaterThan(0));
+      // Overwrite the offset that follows with an absurd value.
+      for (var i = at + marker.length + 1; i < bytes.length - 6; i++) {
+        if (bytes[i] >= 0x30 && bytes[i] <= 0x39) bytes[i] = 0x39; // 9
+      }
+      final doc = await CosDocument.openSource(RecordingSource(bytes));
+      expect(doc.catalog.typeName, 'Catalog');
+    });
+  });
+
+  group('errors and cancellation', () {
+    test('a cancelled transfer surfaces the error', () async {
+      final source = RecordingSource(buildMultiPagePdf(4), failAtRead: 1);
+      await expectLater(
+        CosDocument.openSource(source),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('non-PDF data throws a parse exception', () async {
+      final source = RecordingSource(
+          Uint8List.fromList('this is definitely not a pdf'.codeUnits));
+      await expectLater(
+        CosDocument.openSource(source),
+        throwsA(isA<CosParseException>()),
+      );
+    });
+
+    test('a corrupted object body is reported, not silently accepted',
+        () async {
+      // Corrupting a byte inside the object region makes the eventual parse
+      // of that object fail; opening the catalog surfaces it rather than
+      // returning wrong data.
+      final bytes = buildClassicPdf();
+      // Corrupt a spread of interior bytes (object region), leaving the
+      // header and tail intact so the xref still parses.
+      final corrupt = <int>{
+        for (var i = 20; i < bytes.length - 80; i += 7) i,
+      };
+      final source = RecordingSource(bytes, corrupt: corrupt);
+      // Either it throws, or the catalog is unreachable - never a bogus
+      // "valid" catalog silently built from garbage.
+      try {
+        final doc = await CosDocument.openSource(source);
+        // If it opened, the recovery path must still find a real catalog.
+        expect(doc.catalog.typeName, 'Catalog');
+      } on Object {
+        // Acceptable: corruption detected.
+      }
+    });
+  });
+
+  group('encrypted documents', () {
+    test('decrypts through the source path with the owner password',
+        () async {
+      final source = RecordingSource(buildEncryptedPdf());
+      final doc = await CosDocument.openSource(source, password: 'owner');
+      expect(doc.isEncrypted, isTrue);
+      final info = doc.resolve(doc.trailer['Info']) as CosDictionary;
+      expect((info['Title'] as CosString).text, 'Secret Title');
+    });
+
+    test('a wrong password throws, not a corrupt document', () async {
+      final source = RecordingSource(buildEncryptedPdf(userPassword: 'secret'));
+      await expectLater(
+        CosDocument.openSource(source, password: 'wrong'),
+        throwsA(isA<CosPasswordException>()),
+      );
+    });
+  });
+
+  group('PdfBytesByteSource', () {
+    test('serves clamped ranges', () async {
+      final source = PdfBytesByteSource(Uint8List.fromList([1, 2, 3, 4, 5]));
+      expect(await source.length, 5);
+      expect(await source.readRange(1, 3), [2, 3]);
+      expect(await source.readRange(3, 100), [4, 5]);
+      expect(await source.readRange(10, 20), isEmpty);
+      expect(await source.readRange(-5, 2), [1, 2]);
+    });
+
+    test('opens a document through the in-memory source', () async {
+      final doc =
+          await CosDocument.openSource(PdfBytesByteSource(buildClassicPdf()));
+      expect(doc.catalog.typeName, 'Catalog');
+    });
+  });
+}

--- a/packages/pdf_cos/test/byte_source_test.dart
+++ b/packages/pdf_cos/test/byte_source_test.dart
@@ -60,6 +60,26 @@ class RecordingSource implements PdfByteSource {
   Future<void> close() async => closes++;
 }
 
+/// A source that ignores the requested end and always returns bytes through
+/// end-of-file - i.e. it hands back more than asked for. Models a server that
+/// answers a Range request with a 200-style full body.
+class _OverReadSource implements PdfByteSource {
+  _OverReadSource(this._bytes);
+  final Uint8List _bytes;
+
+  @override
+  Future<int?> get length async => _bytes.length;
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    final s = start < 0 ? 0 : (start > _bytes.length ? _bytes.length : start);
+    return Uint8List.sublistView(_bytes, s); // to EOF, ignoring endExclusive
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
 void main() {
   group('progressive load over a range-capable source', () {
     test('opens a classic xref-table document', () async {
@@ -83,6 +103,36 @@ void main() {
       expect(pages.typeName, 'Pages');
       final page = doc.resolve((pages['Kids'] as CosArray)[0]) as CosDictionary;
       expect(page.typeName, 'Page');
+    });
+
+    test('walks a cross-reference-stream /Prev chain with an /Index', () async {
+      // An incremental update of an xref-stream file appends a second xref
+      // stream that carries an /Index for just the changed object and a /Prev
+      // back to the original - exercising the stream path twice, the /Index
+      // branch, and /Prev following through streams.
+      final base = CosDocument.open(buildXrefStreamPdf());
+      final updated = (CosIncrementalUpdater(base)
+            ..replaceObject(1,
+                CosDictionary({'Type': const CosName('Catalog'), 'Pages': const CosReference(2, 0)})))
+          .save();
+      final doc = await CosDocument.openSource(RecordingSource(updated));
+      expect(doc.catalog.typeName, 'Catalog');
+      final pages = doc.resolve(doc.catalog['Pages']) as CosDictionary;
+      expect(pages.typeName, 'Pages');
+    });
+
+    test('grows the window to fit a cross-reference stream body', () async {
+      // A tiny xref window forces the loader to widen it until the xref
+      // stream (and its /Prev chain) fits, covering the retry path.
+      final base = CosDocument.open(buildXrefStreamPdf());
+      final updated = (CosIncrementalUpdater(base)
+            ..replaceObject(1,
+                CosDictionary({'Type': const CosName('Catalog'), 'Pages': const CosReference(2, 0)})))
+          .save();
+      final doc = await CosDocument.openSource(RecordingSource(updated),
+          options: const PdfSourceLoadOptions(
+              headWindow: 32, tailWindow: 32, xrefWindow: 16));
+      expect(doc.catalog.typeName, 'Catalog');
     });
 
     test('opens a larger multi-page document', () async {
@@ -259,6 +309,16 @@ void main() {
     });
   });
 
+  group('misbehaving sources', () {
+    test('a source that over-returns bytes does not crash the load', () async {
+      // Some servers answer a ranged read with more bytes than requested
+      // (a 206 carrying the whole file). The loader must clamp, not throw a
+      // RangeError past the buffer end.
+      final doc = await CosDocument.openSource(_OverReadSource(buildClassicPdf()));
+      expect(doc.catalog.typeName, 'Catalog');
+    });
+  });
+
   group('encrypted documents', () {
     test('decrypts through the source path with the owner password',
         () async {
@@ -286,6 +346,7 @@ void main() {
       expect(await source.readRange(3, 100), [4, 5]);
       expect(await source.readRange(10, 20), isEmpty);
       expect(await source.readRange(-5, 2), [1, 2]);
+      await source.close(); // no-op, must not throw
     });
 
     test('opens a document through the in-memory source', () async {

--- a/packages/pdf_document/lib/src/document.dart
+++ b/packages/pdf_document/lib/src/document.dart
@@ -18,6 +18,23 @@ class PdfDocument {
   static PdfDocument open(Uint8List bytes, {String password = ''}) =>
       PdfDocument._(CosDocument.open(bytes, password: password));
 
+  /// Opens a document from an asynchronous, random-access [source] - a remote
+  /// file over HTTP Range requests, a local file read on demand, or any other
+  /// [PdfByteSource]. Only the bytes the parser needs (header, cross-reference
+  /// chain, and the live objects) are fetched, falling back to a full download
+  /// when the source cannot serve useful ranges or the file is malformed.
+  ///
+  /// [PdfDocument.open] and the byte-based widgets are unaffected; this is an
+  /// additive entry point for progressive/remote loading. See [PdfByteSource]
+  /// and, for the HTTP adapter, `PdfHttpByteSource` in `dart_pdf_editor`.
+  static Future<PdfDocument> openSource(
+    PdfByteSource source, {
+    String password = '',
+    PdfSourceLoadOptions options = const PdfSourceLoadOptions(),
+  }) async =>
+      PdfDocument._(await CosDocument.openSource(source,
+          password: password, options: options));
+
   String get version => cos.version;
 
   CosDictionary get catalog => cos.catalog;

--- a/packages/pdf_document/test/open_source_test.dart
+++ b/packages/pdf_document/test/open_source_test.dart
@@ -1,0 +1,60 @@
+// PdfDocument.openSource: opening documents from an asynchronous byte source
+// with page-level semantics intact.
+
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('opens a one-page document and reads its page tree', () async {
+    final doc =
+        await PdfDocument.openSource(PdfBytesByteSource(buildClassicPdf()));
+    expect(doc.pageCount, 1);
+    final page = doc.page(0);
+    expect(page.mediaBox, const PdfRect(0, 0, 612, 792));
+    expect(page.resources.containsKey('Font'), isTrue);
+  });
+
+  test('opens a multi-page document with the right page count', () async {
+    final doc =
+        await PdfDocument.openSource(PdfBytesByteSource(buildMultiPagePdf(7)));
+    expect(doc.pageCount, 7);
+  });
+
+  test('reads page content through the source', () async {
+    final doc =
+        await PdfDocument.openSource(PdfBytesByteSource(buildClassicPdf()));
+    final content = String.fromCharCodes(doc.page(0).contentBytes());
+    expect(content, contains('Hello, world!'));
+  });
+
+  test('falls back cleanly for an unknown-length source', () async {
+    final doc = await PdfDocument.openSource(_UnknownLengthSource(
+        buildMultiPagePdf(3)));
+    expect(doc.pageCount, 3);
+  });
+}
+
+/// A source that reports no length, forcing the sequential-download fallback.
+class _UnknownLengthSource implements PdfByteSource {
+  _UnknownLengthSource(this._bytes);
+  final Uint8List _bytes;
+
+  @override
+  Future<int?> get length async => null;
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    final s = start < 0 ? 0 : (start > _bytes.length ? _bytes.length : start);
+    final e = endExclusive < s
+        ? s
+        : (endExclusive > _bytes.length ? _bytes.length : endExclusive);
+    return Uint8List.sublistView(_bytes, s, e);
+  }
+
+  @override
+  Future<void> close() async {}
+}


### PR DESCRIPTION
## Summary

Adds an optional asynchronous, random-access PDF byte-source abstraction so a
host can open a large remote PDF without downloading the whole file before the
parser begins (#325). The synchronous COS parser is preserved: a progressive
loader fetches only the byte ranges it needs — a header probe, the
cross-reference chain (following `/Prev` and `/XRefStm`), and the live objects'
byte ranges (skipping free space, superseded revisions, and trailing junk) —
into a sparse buffer, then hands that to the existing `CosDocument.open`. It
falls back to a plain sequential download when the length is unknown, the xref
chain is broken, or a ranged read fails, so non-range-capable servers still work.

New API (names/placement per the issue's "flexible" note):

- **`pdf_cos`** — `PdfByteSource` (`Future<int?> length`, `Future<Uint8List>
  readRange(start, endExclusive)`, `close()`), `PdfBytesByteSource` (in-memory),
  `PdfSourceLoadOptions`, and `CosDocument.openSource(...)`.
- **`pdf_document`** — `PdfDocument.openSource(source)` entry point.
- **`dart_pdf_editor`** — `PdfHttpByteSource`: HTTP Range loading with request
  headers/auth, cancellation (`PdfCancelToken`), progress, and a transparent
  full-download fallback for servers (or web CORS responses) that don't expose
  ranges. Adds `http: ^1.2.0` (cross-platform, no `dart:io` in our code).

`PdfDocument.open(Uint8List)` and the byte-based widgets are unchanged — this is
purely additive.

### Why a prefetch loader rather than an async parser

The COS parser (`getObject`/`resolve`/`decodeStreamData` and all
`pdf_document`/`pdf_graphics` callers) is synchronous over an in-memory buffer.
Threading `await` through every call site was out of scope and risky, so the
loader instead guarantees every byte the sync path will read is present before
`open` runs. Truncated windows can't corrupt silently: a section parse only
succeeds when its terminator is reached over real bytes (zero-fill past the
window is PDF whitespace → EOF → a throw), so the loader just widens the window
and retries, and a successful parse is authoritative. See
`doc/dev-log/2026-07-16-async-byte-source-remote-pdf.md` for the full design.

## Affected packages

- [x] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean)
- [x] `cd packages/pdf_cos && fvm dart test` (217 pass, incl. new `byte_source_test.dart`)
- [x] `cd packages/pdf_document && fvm dart test` (665 pass, incl. new `open_source_test.dart`)
- [ ] `cd packages/pdf_graphics && fvm dart test` (not touched)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran the new `http_byte_source_test.dart` — 13 pass)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Corpus/render suites were not run: this change adds a loading path and does not
alter parsing output or rendering.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory (`PdfHttpByteSource` uses `package:http`, which is web-safe; no `dart:io` in our code).
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Test coverage spans the issue's asks: range-capable and non-range-capable
  servers, multi-revision (`/Prev`) documents, cancellation, malformed and
  non-PDF input, encrypted documents (owner + wrong password), progress, and web
  CORS behaviour (modelled as a 200 with hidden Range headers → full-download
  fallback). HTTP tests use `http`'s `MockClient` — no real network.
- **Follow-up / out of scope:** because the sync core needs all referenced bytes
  present, the loader still fetches every live object. True first-page-only
  rendering for linearized PDFs (fetch linearization dict + first-page objects,
  render, stream the rest) needs an async resolve path in the core, which
  `PdfByteSource` now exists to build on. No new viewer widget was added; a host
  wires remote loading with `PdfDocument.openSource(PdfHttpByteSource(uri))`.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Acmq4yTFPpQna82F9rwkB

---
_Generated by [Claude Code](https://claude.ai/code/session_012Acmq4yTFPpQna82F9rwkB)_