### PR TITLE
perf: revision-aware render worker — update in place instead of restarting the pool (#308)

### DIFF
--- a/doc/dev-log/2026-07-16-revision-aware-render-worker.md
+++ b/doc/dev-log/2026-07-16-revision-aware-render-worker.md
@@ -1,0 +1,114 @@
+# Revision-aware render worker: stop restarting the pool on every edit
+
+Issue #308 (perf). Follow-up to #306/#307. The render worker's interface used
+to be a fixed byte snapshot, so `PdfShellSessionLifecycle._syncWorker` disposed
+the whole pool and called `startPdfRenderWorker` again on *every* edit, undo,
+and redo: N private `PdfDocument` re-parses (xref + content) plus an empty
+decoded-image cache **and** transcript/record cache, all to reflect a change to
+one page. Yet revisions are append-only (one growing buffer, a stack of
+lengths), so an edit to page 5 leaves every other page's bytes identical.
+Identity-based restart was the coarsest possible invalidation.
+
+## What landed
+
+A deeper worker interface that absorbs a revision in place instead of being
+torn down:
+
+`PdfRenderWorker.updateRevision(int baseLength, Uint8List appendedBytes,
+int newLength, Set<int>? changedPages)` plus a `bool supportsRevisionUpdate`
+capability. The worker keeps its buffer's first `baseLength` bytes (the shared
+prefix), appends `appendedBytes` to reach a `newLength`-byte revision, feeds
+that into its already-open document, and evicts only `changedPages` from its
+per-page caches (null = every page).
+
+### Layering
+
+- **pdf_cos** `CosDocument.applyIncrementalUpdate(newBytes)`: `bytes`/`trailer`/
+  `startXref` became mutable. It parses only the xref sections newer than the
+  current `startXref` (walking `/Prev`+`/XRefStm` until it reaches the old
+  start offset), overrides the matching `_xref` entries (newest wins), merges
+  the trailer (keeping doc-level keys the incremental trailer omits, like
+  `/Root`), swaps in the new bytes, and drops cached state (`_cache`,
+  `_objectStreams`, `_streamOwners`) for the redefined objects only. Returns the
+  changed object numbers. Refuses recovered documents (`startXref <= 0`) and
+  non-append buffers. Safe because the prefix bytes are byte-identical, so cached
+  objects that hold views into the old buffer stay valid.
+- **pdf_document** `PdfDocument.applyIncrementalUpdate` = cos + `invalidatePageCache()`.
+- **budgeted_cache** `evictWhere(predicate)` — targeted per-key eviction. The
+  record/transcript caches already key on `(pageIndex, ...)`, so per-page
+  invalidation is a filtered eviction, not `clear()`.
+- **transcript cache** `evictPages(Set<int>?)`; isolate `_BinCommandCache.evictPages`.
+- **render_worker** wrappers: `PdfCachingRenderWorker.updateRevision` evicts the
+  record cache for the changed pages and forwards to the inner worker;
+  `PdfPooledRenderWorker` fans the update to every platform worker and rolls the
+  urgent-worker seed bytes (`_urgentBytes`) forward so a long-jump preview after
+  an edit opens the edited document.
+
+### The isolate backend
+
+`_IsolateRenderWorker.updateRevision` routes the update through the **same
+priority queue** as records (priority `-1000`), so it dispatches only when the
+worker is idle. That matters: the update mutates the worker's document in place,
+and the record/bin walks are async and yield — running them concurrently would
+let an interpret see a half-updated document. A queued update preempts a
+running record (which requeues via `requeueAfterPreemption` and then re-runs
+against the new revision) exactly like an urgent visible record preempts
+prefetch. In `_workerMain` the `'update'` message rebuilds the worker's byte
+buffer and tries `applyIncrementalUpdate`; if that throws (an undo shrinks to a
+shorter prefix, so it's not an append) it re-opens from the target prefix. On
+the in-place fast path only the changed pages' `_BinCommandCache` entries are
+evicted; a re-open makes a fresh document so **all** cached commands (which
+referenced the old one) are dropped.
+
+### The stale-inflight guard (subtle)
+
+The isolate processes messages serially, so an in-flight record for page P
+finishes against the *old* document before the `'update'` runs — its buffer is
+stale. `PdfCachingRenderWorker` therefore stamps a revision epoch: a decode
+captures `_epoch` at dispatch and stores its result only if its page was not
+invalidated since (`_invalidationEpochFor(page) <= dispatchEpoch`). Without this
+a decode dispatched just before an edit to its page would cache pre-edit content
+and a later request would hit it. Covered by the "in-flight decode ... is not
+cached (stale)" test.
+
+### Controller + shell
+
+`PdfEditingController.lastRevisionDelta` (a `PdfWorkerRevisionDelta` of
+`baseLength`/`newLength`/`changedPages`) is set at each transition:
+- forward edit / redo: `baseLength` = previous live length, append the tail,
+  `changedPages` = `impact.visualPages`;
+- undo: `baseLength == newLength` (keep the shorter prefix, append nothing);
+- **null** for the initial open, a `pageStructureChanged` edit, or a redaction
+  burn (`_resetTo` replaces the buffer with a non-prefix compaction) — the shell
+  falls back to a full worker restart there.
+
+`_syncWorker` now takes the incremental path when the worker
+`supportsRevisionUpdate`, the delta is non-null, and its `newLength` matches the
+live revision; otherwise it starts a new generation as before. It copies the
+appended slice (`Uint8List.fromList`) so transferring it to the isolate can't
+detach the controller's buffer.
+
+## Scope / what's deferred
+
+- The **native isolate** backend is fully wired (VM tests exercise it). The
+  **web** backend and its bundled prebuilt worker asset are *not* updated:
+  `supportsRevisionUpdate` stays false there, so web keeps restarting the worker
+  on an edit (no regression, no gain). Wiring the web-worker `'update'` message
+  and rebuilding `assets/web/pdf_render_worker.dart.js` is a clean follow-up.
+- Undo/redo take the isolate's re-open fallback (a prefix re-parse), not a true
+  incremental step, and clear that worker's bin cache wholesale — the record and
+  decoded-image caches still survive, so the headline "only the edited page
+  re-renders" holds. The forward-edit path (the measured case) is fully in place.
+
+## Measures / tests
+
+- `debugWorkerGenerations` stays flat across form-fill / edit / undo / redo and
+  bumps once on a redaction burn (`shell_session_test.dart`).
+- Edit page 5 → page 6's record survives, page 5's is dropped
+  (`render_worker_revision_test.dart`, both a fake-backend unit test and a real
+  isolate integration test that confirms the in-place document actually reflects
+  the edit).
+- `applyIncrementalUpdate` matches a full reopen; unedited pages stay
+  byte-identical; redefined objects resolve to the new value
+  (`pdf_document/test/incremental_update_test.dart`).
+- `evictWhere` / `evictPages` unit tests.

--- a/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
@@ -218,6 +218,17 @@ class PdfBudgetedCache<K, V> {
   /// Drops (and disposes) the retained value for [key]. A no-op on a miss.
   void evict(K key) => _removeEntry(key);
 
+  /// Drops (and disposes) every retained entry whose key satisfies [test].
+  /// Used for targeted, per-page invalidation - a render worker evicting just
+  /// the pages an incremental revision changed instead of clearing the whole
+  /// cache. Counters and every non-matching entry are untouched.
+  void evictWhere(bool Function(K key) test) {
+    final doomed = _entries.keys.where(test).toList();
+    for (final key in doomed) {
+      _removeEntry(key);
+    }
+  }
+
   /// Empties the cache, disposing every retained value. Counters survive - a
   /// clear is a cache operation, not a fresh measurement. Any clones already
   /// handed out are unaffected.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -257,6 +257,31 @@ class PdfFormFieldStyle {
   final bool multiline;
 }
 
+/// The byte-level shape of one editor revision transition (an edit, undo, or
+/// redo), consumed by the shell to feed the render worker's incremental
+/// in-place update instead of restarting it. See
+/// [PdfEditingController.lastRevisionDelta].
+class PdfWorkerRevisionDelta {
+  const PdfWorkerRevisionDelta({
+    required this.baseLength,
+    required this.newLength,
+    required this.changedPages,
+  });
+
+  /// Byte length of the prefix shared with the previous revision. Revisions are
+  /// prefixes of one growing buffer, so the worker keeps its buffer up to here
+  /// and appends the `newLength - baseLength` bytes that follow. A pure undo
+  /// (shrinking to an earlier prefix) has [baseLength] == [newLength].
+  final int baseLength;
+
+  /// Byte length of the revision after the transition.
+  final int newLength;
+
+  /// Pages whose rendering the transition changed, or null when every page may
+  /// have (the worker then clears its per-page caches).
+  final Set<int>? changedPages;
+}
+
 /// An editing session over a PDF document: applies edits through
 /// [PdfEditor], owns the resulting document revisions, and carries the
 /// UI state of the editing tools (active tool, color, pending ink
@@ -429,6 +454,16 @@ class PdfEditingController extends ChangeNotifier {
   /// edit, undo, and redo.
   PdfDocument get document => _document;
 
+  PdfWorkerRevisionDelta? _lastRevisionDelta;
+
+  /// The byte-level shape of the most recent revision transition (edit, undo,
+  /// redo) for the render worker's incremental update path, or null when the
+  /// last transition cannot be applied incrementally (the initial open, a page
+  /// structure change, or a redaction burn that replaced the buffer). Only
+  /// meaningful the moment [document]'s identity changes; the shell reads it
+  /// then and ignores it otherwise.
+  PdfWorkerRevisionDelta? get lastRevisionDelta => _lastRevisionDelta;
+
   /// The current revision's bytes - what "save to disk" should write.
   Uint8List get bytes => Uint8List.sublistView(_bytes, 0, _revisions[_cursor]);
 
@@ -451,6 +486,14 @@ class PdfEditingController extends ChangeNotifier {
     _bumpRenderStamps(impact.visualPages);
     _bumpContentRenderStamps(impact.contentPages);
     _cursor--;
+    // The worker keeps the shared prefix and re-reads it - no bytes to append.
+    _lastRevisionDelta = impact.pageStructureChanged
+        ? null
+        : PdfWorkerRevisionDelta(
+            baseLength: _revisions[_cursor],
+            newLength: _revisions[_cursor],
+            changedPages: impact.visualPages,
+          );
     _reopen();
     _emitAnnotationChanges(beforeLength, impact.annotationPages);
   }
@@ -462,6 +505,15 @@ class PdfEditingController extends ChangeNotifier {
     final impact = _revisionImpacts[_cursor];
     _bumpRenderStamps(impact.visualPages);
     _bumpContentRenderStamps(impact.contentPages);
+    // Re-extend to the redone revision - its bytes already sit in the buffer as
+    // a prefix, so the worker re-appends bytes it may already hold.
+    _lastRevisionDelta = impact.pageStructureChanged
+        ? null
+        : PdfWorkerRevisionDelta(
+            baseLength: beforeLength,
+            newLength: _revisions[_cursor],
+            changedPages: impact.visualPages,
+          );
     _reopen();
     _emitAnnotationChanges(beforeLength, impact.annotationPages);
   }
@@ -519,6 +571,17 @@ class PdfEditingController extends ChangeNotifier {
     _bumpContentRenderStamps(impact.contentPages);
     if (impact.destructive) _destructiveStampEpoch++;
     _cursor++;
+    // The incremental save appended to the previous revision, so its bytes are
+    // that revision's prefix plus the new tail: the worker keeps the first
+    // [beforeLength] bytes and appends the rest. A structural edit can shift
+    // page indices, so fall back to a full worker restart there.
+    _lastRevisionDelta = impact.pageStructureChanged
+        ? null
+        : PdfWorkerRevisionDelta(
+            baseLength: beforeLength,
+            newLength: saved.length,
+            changedPages: impact.visualPages,
+          );
     if (_committingRemoteRevision) _undoFloor = _cursor;
     final selected = List.of(_selected);
     _document = PdfDocument.open(bytes, password: _password);
@@ -1852,6 +1915,9 @@ class PdfEditingController extends ChangeNotifier {
     _cursor = 0;
     _undoFloor = 0;
     _hardModified = true;
+    // A burn recompacts the whole file: the new buffer is not a prefix-append
+    // of the prior one, so the worker cannot update in place and must restart.
+    _lastRevisionDelta = null;
     _selected.clear();
     _bumpRenderStamps(impact.visualPages);
     _bumpContentRenderStamps(impact.contentPages);

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -333,6 +333,40 @@ abstract class PdfRenderWorker {
   /// passes bins straight through).
   void cancelBinStrips(int pageIndex, {int priority = 0}) {}
 
+  /// Whether this backend can absorb an [updateRevision] in place instead of
+  /// being torn down and restarted on every edit. The native isolate backend
+  /// (and the wrappers around it) do; the null fallback and the web backend do
+  /// not yet, so their host restarts the worker on a revision change as before.
+  bool get supportsRevisionUpdate => false;
+
+  /// Feeds one append-only editor revision into the worker's already-open
+  /// document instead of disposing and restarting it, then invalidates the
+  /// worker's cached renders for the [changedPages] only.
+  ///
+  /// Revisions are byte prefixes of one growing buffer, so a page the edit did
+  /// not touch is byte-identical across the boundary: keeping the worker (and
+  /// its decoded-image, transcript, and record caches) alive turns "every
+  /// visible page re-warms from cold on every pen stroke" into "only the edited
+  /// page re-renders".
+  ///
+  /// The worker holds the bytes of the revision it currently reflects. To reach
+  /// the new revision it keeps that buffer's first [baseLength] bytes (the
+  /// shared prefix) and appends [appendedBytes], giving a buffer [newLength]
+  /// bytes long ([newLength] == [baseLength] + `appendedBytes.length`). A pure
+  /// undo therefore passes empty [appendedBytes] with [baseLength] ==
+  /// [newLength] (the worker just re-reads a shorter prefix it already holds).
+  ///
+  /// [changedPages] are the pages whose rendering the transition changed; null
+  /// means every page may have changed (the worker clears its per-page caches).
+  ///
+  /// The base implementation is a no-op (see [supportsRevisionUpdate]).
+  void updateRevision(
+    int baseLength,
+    Uint8List appendedBytes,
+    int newLength,
+    Set<int>? changedPages,
+  ) {}
+
   /// Whether this worker actually offloads. False for the null fallback, so
   /// callers can skip the round-trip and render locally without asking.
   bool get isActive;
@@ -406,7 +440,10 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
 
   static const int _urgentPriority = -2000;
 
-  final Uint8List? _urgentBytes;
+  // The bytes a lazily-created one-off urgent worker opens. Kept at the current
+  // revision by [updateRevision] so a long-jump preview after an edit opens the
+  // edited document, not the stale spawn snapshot. Null in the test seam.
+  Uint8List? _urgentBytes;
   final List<PdfRenderWorker> _workers;
   late final List<int> _loads;
   final _routes = <(int, int), _PoolRoute>{};
@@ -606,6 +643,36 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
       );
 
   @override
+  bool get supportsRevisionUpdate =>
+      _workers.every((worker) => worker.supportsRevisionUpdate);
+
+  @override
+  void updateRevision(
+    int baseLength,
+    Uint8List appendedBytes,
+    int newLength,
+    Set<int>? changedPages,
+  ) {
+    for (final worker in _workers) {
+      worker.updateRevision(baseLength, appendedBytes, newLength, changedPages);
+    }
+    // Roll the urgent-worker seed bytes forward to the new revision and drop
+    // any live one-off worker so the next long-jump preview reopens the edited
+    // document instead of the snapshot it was spawned on.
+    final urgentBytes = _urgentBytes;
+    if (urgentBytes != null &&
+        baseLength <= urgentBytes.length &&
+        newLength == baseLength + appendedBytes.length) {
+      final next = Uint8List(newLength);
+      next.setRange(0, baseLength, urgentBytes);
+      next.setRange(baseLength, newLength, appendedBytes);
+      _urgentBytes = next;
+    }
+    _urgentWorker?.dispose();
+    _urgentWorker = null;
+  }
+
+  @override
   void dispose() {
     _routes.clear();
     _pageWorkers.clear();
@@ -705,6 +772,45 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
   // Keys whose decode is running now, so concurrent requests share one decode.
   final _inflight = <_RecordCacheKey, Future<List<PdfRenderCommand>?>>{};
 
+  // Revision-invalidation epochs. A decode dispatched before an edit that
+  // touched its page must not store its now-stale result: the worker's document
+  // has moved on under it. Each [updateRevision] bumps [_epoch] and stamps the
+  // pages it invalidated (or [_globalInvalidatedAt] for an all-pages revision);
+  // a decode captures the epoch at dispatch and stores only if its page was not
+  // invalidated since.
+  int _epoch = 0;
+  int _globalInvalidatedAt = 0;
+  final Map<int, int> _pageInvalidatedAt = {};
+
+  int _invalidationEpochFor(int page) =>
+      math.max(_globalInvalidatedAt, _pageInvalidatedAt[page] ?? 0);
+
+  @override
+  bool get supportsRevisionUpdate => _inner.supportsRevisionUpdate;
+
+  @override
+  void updateRevision(
+    int baseLength,
+    Uint8List appendedBytes,
+    int newLength,
+    Set<int>? changedPages,
+  ) {
+    _epoch++;
+    if (changedPages == null) {
+      _globalInvalidatedAt = _epoch;
+      _pageInvalidatedAt.clear();
+      _cache.clear();
+      _inflight.clear();
+    } else {
+      for (final page in changedPages) {
+        _pageInvalidatedAt[page] = _epoch;
+      }
+      _cache.evictWhere((key) => changedPages.contains(key.$1));
+      _inflight.removeWhere((key, _) => changedPages.contains(key.$1));
+    }
+    _inner.updateRevision(baseLength, appendedBytes, newLength, changedPages);
+  }
+
   @override
   bool get isActive => _inner.isActive;
 
@@ -782,6 +888,7 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
       imagePixelRatio: imagePixelRatio,
       decodeImages: decodeImages,
       imageDecodeRegion: effectiveRegion,
+      dispatchEpoch: _epoch,
     );
     _inflight[key] = future;
     return future;
@@ -795,6 +902,7 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
     required double? imagePixelRatio,
     required bool decodeImages,
     required PdfRect? imageDecodeRegion,
+    required int dispatchEpoch,
   }) async {
     try {
       final timeout = pdfRenderWorkerRecordTimeout;
@@ -816,7 +924,11 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
           return null;
         },
       );
-      if (commands != null) {
+      // Skip storing a result whose page was invalidated by a revision update
+      // after this decode was dispatched: the worker's document has moved on,
+      // so the buffer is stale and must not be cached (a later request would
+      // hit it and paint pre-edit content).
+      if (commands != null && _invalidationEpochFor(pageIndex) <= dispatchEpoch) {
         final weight = _weigh(commands);
         final storeKey =
             key.$6 != null && weight == 0 ? _withoutRegion(key) : key;

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -891,6 +891,13 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
       dispatchEpoch: _epoch,
     );
     _inflight[key] = future;
+    // Clear the slot only if it still holds THIS future. An updateRevision may
+    // have dropped the entry mid-decode and a newer request re-populated it; a
+    // stale decode's completion must not evict the fresh in-flight future, or
+    // the dedup breaks and the page is decoded redundantly.
+    future.whenComplete(() {
+      if (identical(_inflight[key], future)) _inflight.remove(key);
+    });
     return future;
   }
 
@@ -904,40 +911,36 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
     required PdfRect? imageDecodeRegion,
     required int dispatchEpoch,
   }) async {
-    try {
-      final timeout = pdfRenderWorkerRecordTimeout;
-      final commands = await _inner
-          .record(
-        pageIndex,
-        annotations: annotations,
-        priority: priority,
-        imagePixelRatio: imagePixelRatio,
-        decodeImages: decodeImages,
-        commandLimit: key.$5,
-        imageDecodeRegion: imageDecodeRegion,
-      )
-          .timeout(
-        timeout,
-        onTimeout: () {
-          _inner.cancel(pageIndex, priority: priority);
-          _inner.dispose();
-          return null;
-        },
-      );
-      // Skip storing a result whose page was invalidated by a revision update
-      // after this decode was dispatched: the worker's document has moved on,
-      // so the buffer is stale and must not be cached (a later request would
-      // hit it and paint pre-edit content).
-      if (commands != null && _invalidationEpochFor(pageIndex) <= dispatchEpoch) {
-        final weight = _weigh(commands);
-        final storeKey =
-            key.$6 != null && weight == 0 ? _withoutRegion(key) : key;
-        _store(storeKey, commands, weight);
-      }
-      return commands;
-    } finally {
-      _inflight.remove(key);
+    final timeout = pdfRenderWorkerRecordTimeout;
+    final commands = await _inner
+        .record(
+      pageIndex,
+      annotations: annotations,
+      priority: priority,
+      imagePixelRatio: imagePixelRatio,
+      decodeImages: decodeImages,
+      commandLimit: key.$5,
+      imageDecodeRegion: imageDecodeRegion,
+    )
+        .timeout(
+      timeout,
+      onTimeout: () {
+        _inner.cancel(pageIndex, priority: priority);
+        _inner.dispose();
+        return null;
+      },
+    );
+    // Skip storing a result whose page was invalidated by a revision update
+    // after this decode was dispatched: the worker's document has moved on,
+    // so the buffer is stale and must not be cached (a later request would
+    // hit it and paint pre-edit content).
+    if (commands != null && _invalidationEpochFor(pageIndex) <= dispatchEpoch) {
+      final weight = _weigh(commands);
+      final storeKey =
+          key.$6 != null && weight == 0 ? _withoutRegion(key) : key;
+      _store(storeKey, commands, weight);
     }
+    return commands;
   }
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -64,6 +64,36 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   @override
   bool get isActive => !_disposed && !_spawnFailed;
 
+  @override
+  bool get supportsRevisionUpdate => true;
+
+  static const int _updatePriority = -1000;
+
+  @override
+  void updateRevision(
+    int baseLength,
+    Uint8List appendedBytes,
+    int newLength,
+    Set<int>? changedPages,
+  ) {
+    if (_disposed || _spawnFailed) return;
+    // Route the update through the ordinary priority queue so it runs only when
+    // the worker is idle: it mutates the worker's document in place, so it must
+    // not overlap an in-flight record/bin walk. Its high priority preempts a
+    // running record (which requeues and then re-runs against the new revision)
+    // and jumps ahead of queued prefetch.
+    final request = _PendingRequest.update(
+      _updatePriority,
+      _seq++,
+      baseLength,
+      appendedBytes,
+      newLength,
+      changedPages,
+    );
+    _queue.add(request);
+    _pump();
+  }
+
   Future<void> _spawn(Uint8List bytes) async {
     try {
       await _spawnInner(bytes);
@@ -289,7 +319,16 @@ class _IsolateRenderWorker extends PdfRenderWorker {
     }
     final request = _queue.removeAt(best)..id = _nextId++;
     _inFlight = request;
-    if (request.kind == _RequestKind.record) {
+    if (request.kind == _RequestKind.update) {
+      port.send([
+        'update',
+        request.id,
+        request.baseLength,
+        TransferableTypedData.fromList([request.appendedBytes!]),
+        request.newLength,
+        request.changedPages?.toList(),
+      ]);
+    } else if (request.kind == _RequestKind.record) {
       port.send([
         'record',
         request.id,
@@ -427,7 +466,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   }
 }
 
-enum _RequestKind { record, bin, detail }
+enum _RequestKind { record, bin, detail, update }
 
 /// One queued request (a page record or a strip bin) and its pending result.
 class _PendingRequest {
@@ -445,7 +484,11 @@ class _PendingRequest {
         deviceWidth = 0,
         deviceHeight = 0,
         binPixelRatio = 0,
-        slugGlyphs = false;
+        slugGlyphs = false,
+        baseLength = 0,
+        appendedBytes = null,
+        newLength = 0,
+        changedPages = null;
 
   _PendingRequest.bin(
       this.priority,
@@ -461,7 +504,11 @@ class _PendingRequest {
         imagePixelRatio = null,
         decodeImages = false,
         commandLimit = null,
-        imageDecodeRegion = null;
+        imageDecodeRegion = null,
+        baseLength = 0,
+        appendedBytes = null,
+        newLength = 0,
+        changedPages = null;
 
   _PendingRequest.detail(
       this.priority,
@@ -477,6 +524,30 @@ class _PendingRequest {
         imagePixelRatio = null,
         decodeImages = true,
         commandLimit = null,
+        slugGlyphs = false,
+        baseLength = 0,
+        appendedBytes = null,
+        newLength = 0,
+        changedPages = null;
+
+  _PendingRequest.update(
+      this.priority,
+      this.seq,
+      this.baseLength,
+      this.appendedBytes,
+      this.newLength,
+      this.changedPages)
+      : kind = _RequestKind.update,
+        pageIndex = -1,
+        annotations = false,
+        imagePixelRatio = null,
+        decodeImages = false,
+        commandLimit = null,
+        imageDecodeRegion = null,
+        pageToDevice = null,
+        deviceWidth = 0,
+        deviceHeight = 0,
+        binPixelRatio = 0,
         slugGlyphs = false;
 
   final _RequestKind kind;
@@ -497,6 +568,12 @@ class _PendingRequest {
   final int deviceHeight;
   final double binPixelRatio;
   final bool slugGlyphs;
+
+  // update-only
+  final int baseLength;
+  final Uint8List? appendedBytes;
+  final int newLength;
+  final Set<int>? changedPages;
 
   final completer = Completer<List<Uint8List>?>();
   bool requeueAfterPreemption = false;
@@ -521,9 +598,13 @@ void _workerMain(_WorkerInit init) {
   final cancelPort = ReceivePort();
   init.reply.send([requests.sendPort, cancelPort.sendPort]);
 
+  // The worker's own copy of the document image. It grows in place as
+  // append-only revisions arrive ('update' messages), so the buffer the open
+  // document parses from stays valid across edits.
+  var workerBytes = init.bytes.materialize().asUint8List();
   PdfDocument? document;
   try {
-    document = PdfDocument.open(init.bytes.materialize().asUint8List());
+    document = PdfDocument.open(workerBytes);
   } catch (_) {
     document = null; // a broken document fails every page → all local renders
   }
@@ -547,6 +628,46 @@ void _workerMain(_WorkerInit init) {
     final request = message as List<Object?>;
     final kind = request[0] as String;
     final id = request[1] as int;
+
+    if (kind == 'update') {
+      // The main side only dispatches an update when the worker is idle, so it
+      // never overlaps an in-flight record/bin walk that would see the document
+      // mutate mid-interpret.
+      final baseLength = request[2] as int;
+      final appended =
+          (request[3] as TransferableTypedData).materialize().asUint8List();
+      final newLength = request[4] as int;
+      final changed = (request[5] as List?)?.cast<int>().toSet();
+      workerBytes = Uint8List(baseLength + appended.length)
+        ..setRange(0, baseLength, workerBytes)
+        ..setRange(baseLength, baseLength + appended.length, appended);
+      final live = Uint8List.sublistView(workerBytes, 0, newLength);
+      var incremental = false;
+      final doc = document;
+      if (doc != null) {
+        try {
+          doc.applyIncrementalUpdate(live);
+          incremental = true;
+        } catch (_) {
+          // Not a forward append (an undo shrinks to a prefix) or an
+          // unsupported document: re-open from the target prefix instead.
+        }
+      }
+      if (!incremental) {
+        try {
+          document = PdfDocument.open(live);
+        } catch (_) {
+          document = null;
+        }
+      }
+      // On the in-place fast path only the changed pages' cached commands are
+      // stale; a re-open makes a fresh document, so every cached command (which
+      // referenced the old one) must go.
+      binCommands.evictPages(incremental ? changed : null);
+      init.reply.send([id, null]);
+      return;
+    }
+
     final pageIndex = request[2] as int;
     final annotations = request[3] as bool;
 
@@ -555,11 +676,15 @@ void _workerMain(_WorkerInit init) {
     activeRequestId = id;
     Uint8List? buffer;
     Uint8List? detailPlanBuffer;
+    // Snapshot the (reassignable) document so an 'update' arriving between
+    // yields of this walk can't null it out mid-flight - and so the compiler
+    // can type-promote it.
+    final doc = document;
     try {
-      if (document != null) {
+      if (doc != null) {
         if (kind == 'bin') {
           buffer = await _binStripsAsync(
-              document,
+              doc,
               binCommands,
               pageIndex,
               annotations,
@@ -571,7 +696,7 @@ void _workerMain(_WorkerInit init) {
               token);
         } else if (kind == 'detail') {
           final result = await _recordStripDetailAsync(
-            document,
+            doc,
             binCommands,
             pageIndex,
             annotations,
@@ -597,7 +722,7 @@ void _workerMain(_WorkerInit init) {
                   request[9] as double, request[10] as double)
               : null;
           buffer = await _recordPageAsync(
-              document,
+              doc,
               pageIndex,
               annotations,
               imagePixelRatio,
@@ -764,6 +889,16 @@ class _BinCommandCache {
         0,
         (total, entry) => total + entry.retainedCommandWeight,
       );
+
+  /// Drops the cached commands for [pages] (or every page when null) after a
+  /// revision update, so a later bin re-records them from the new document.
+  void evictPages(Set<int>? pages) {
+    if (pages == null) {
+      _entries.clear();
+    } else {
+      _entries.removeWhere((key, _) => pages.contains(key.$1));
+    }
+  }
 
   Future<List<PdfRenderCommand>?> commandsFor(PdfDocument document,
           int pageIndex, bool annotations, PdfCancellationToken token) async =>

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -632,38 +632,47 @@ void _workerMain(_WorkerInit init) {
     if (kind == 'update') {
       // The main side only dispatches an update when the worker is idle, so it
       // never overlaps an in-flight record/bin walk that would see the document
-      // mutate mid-interpret.
-      final baseLength = request[2] as int;
-      final appended =
-          (request[3] as TransferableTypedData).materialize().asUint8List();
-      final newLength = request[4] as int;
-      final changed = (request[5] as List?)?.cast<int>().toSet();
-      workerBytes = Uint8List(baseLength + appended.length)
-        ..setRange(0, baseLength, workerBytes)
-        ..setRange(baseLength, baseLength + appended.length, appended);
-      final live = Uint8List.sublistView(workerBytes, 0, newLength);
-      var incremental = false;
-      final doc = document;
-      if (doc != null) {
-        try {
-          doc.applyIncrementalUpdate(live);
-          incremental = true;
-        } catch (_) {
-          // Not a forward append (an undo shrinks to a prefix) or an
-          // unsupported document: re-open from the target prefix instead.
+      // mutate mid-interpret. The whole body is guarded so a malformed update
+      // (an inconsistent length triple) can never throw past the ack below and
+      // leave the main side's slot pinned - that would wedge the worker.
+      try {
+        final baseLength = request[2] as int;
+        final appended =
+            (request[3] as TransferableTypedData).materialize().asUint8List();
+        final newLength = request[4] as int;
+        final changed = (request[5] as List?)?.cast<int>().toSet();
+        final rebuilt = Uint8List(baseLength + appended.length)
+          ..setRange(0, baseLength, workerBytes)
+          ..setRange(baseLength, baseLength + appended.length, appended);
+        final live = Uint8List.sublistView(rebuilt, 0, newLength);
+        var incremental = false;
+        final doc = document;
+        if (doc != null) {
+          try {
+            doc.applyIncrementalUpdate(live);
+            incremental = true;
+          } catch (_) {
+            // Not a forward append (an undo shrinks to a prefix) or an
+            // unsupported document: re-open from the target prefix instead.
+          }
         }
-      }
-      if (!incremental) {
-        try {
-          document = PdfDocument.open(live);
-        } catch (_) {
-          document = null;
+        if (!incremental) {
+          try {
+            document = PdfDocument.open(live);
+          } catch (_) {
+            document = null;
+          }
         }
+        // Commit the grown buffer only once the document reflects it.
+        workerBytes = rebuilt;
+        // On the in-place fast path only the changed pages' cached commands are
+        // stale; a re-open makes a fresh document, so every cached command
+        // (which referenced the old one) must go.
+        binCommands.evictPages(incremental ? changed : null);
+      } catch (_) {
+        // Malformed update: leave the document and buffer as they were and just
+        // free the worker slot below so it keeps serving other pages.
       }
-      // On the in-place fast path only the changed pages' cached commands are
-      // stale; a re-open makes a fresh document, so every cached command (which
-      // referenced the old one) must go.
-      binCommands.evictPages(incremental ? changed : null);
       init.reply.send([id, null]);
       return;
     }

--- a/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_transcript_cache.dart
@@ -240,4 +240,16 @@ class PdfWorkerTranscriptCache {
   }
 
   void clear() => _entries.clear();
+
+  /// Evicts the transcripts for [pages] only, or every transcript when [pages]
+  /// is null (a structural / all-pages revision). A worker calls this when an
+  /// incremental revision changes those pages: their transcripts are stale, but
+  /// every other page's stays warm across the edit boundary.
+  void evictPages(Set<int>? pages) {
+    if (pages == null) {
+      _entries.clear();
+    } else {
+      _entries.evictWhere((key) => pages.contains(key.$1));
+    }
+  }
 }

--- a/packages/dart_pdf_editor/lib/src/shell_session.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_session.dart
@@ -131,6 +131,35 @@ class PdfShellSessionLifecycle {
 
   void _syncWorker() {
     if (identical(session.document, _workerDocument)) return;
+
+    // Revision-aware fast path: revisions are byte prefixes of one growing
+    // buffer, so an edit to one page leaves every other page byte-identical.
+    // Feed the incremental append into the live worker and evict only the
+    // changed pages' cached renders instead of tearing down the whole pool and
+    // re-parsing N private documents from cold. See issue #308.
+    final worker = _worker;
+    final delta = session.lastRevisionDelta;
+    if (worker != null &&
+        worker.supportsRevisionUpdate &&
+        delta != null &&
+        delta.newLength == session.bytes.length) {
+      final appended = delta.newLength > delta.baseLength
+          ? Uint8List.fromList(
+              Uint8List.sublistView(session.bytes, delta.baseLength))
+          : Uint8List(0);
+      worker.updateRevision(
+        delta.baseLength,
+        appended,
+        delta.newLength,
+        delta.changedPages,
+      );
+      _workerDocument = session.document;
+      return;
+    }
+
+    // Fresh open, a backend that can't update in place (web/null), or a
+    // non-incremental transition (a structural edit or a redaction burn that
+    // replaced the buffer): start a new worker generation.
     _worker?.dispose();
     final workerCount = performance.beginWorkerGeneration();
     _worker = startPdfRenderWorker(session.bytes,

--- a/packages/dart_pdf_editor/test/budgeted_cache_test.dart
+++ b/packages/dart_pdf_editor/test/budgeted_cache_test.dart
@@ -317,6 +317,23 @@ void main() {
       expect(registry.registrationCount, before);
     });
 
+    test('evictWhere drops only the matching keys and disposes them', () {
+      final dropped = <int>[];
+      final c = PdfBudgetedCache<int, _Res>(
+        maxEntries: 10,
+        disposer: (v) => dropped.add(v.id),
+      );
+      addTearDown(c.dispose);
+      for (var i = 0; i < 6; i++) {
+        c.put(i, _Res(i));
+      }
+      // Evict the even keys (mirrors a worker dropping a changed page set).
+      c.evictWhere((key) => key.isEven);
+      expect(c.length, 3);
+      expect(c.keys, [1, 3, 5]);
+      expect(dropped, [0, 2, 4]);
+    });
+
     test('a cache without clearsUnderMemoryPressure is not registered', () {
       final registry = PdfCacheRegistry.instance;
       final before = registry.registrationCount;

--- a/packages/dart_pdf_editor/test/render_worker_revision_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_revision_test.dart
@@ -145,6 +145,42 @@ void main() {
         reason: 'a decode dispatched before the edit must not cache its result');
   });
 
+  test('a stale in-flight completion does not evict a newer in-flight decode',
+      () async {
+    final backend = _FakeBackend();
+    final worker = PdfCachingRenderWorker(backend);
+
+    // F1 for page 8 is held in flight.
+    final gate1 = Completer<void>();
+    backend.gate = gate1;
+    final f1 = worker.record(8);
+    expect(backend.recordCounts[8], 1);
+
+    // Edit page 8: its in-flight entry is dropped from the dedup map.
+    worker.updateRevision(10, Uint8List.fromList([1]), 11, {8});
+
+    // A fresh request re-decodes against the new revision (F2) and becomes the
+    // in-flight decode for page 8.
+    final gate2 = Completer<void>();
+    backend.gate = gate2;
+    final f2 = worker.record(8);
+    expect(backend.recordCounts[8], 2);
+
+    // The stale F1 now completes. Its cleanup must NOT clear the slot F2 owns.
+    gate1.complete();
+    await f1;
+    await Future<void>.microtask(() {});
+
+    // A third request must share F2 (in-flight dedup), not start a third decode.
+    backend.gate = null;
+    final f3 = worker.record(8);
+    expect(backend.recordCounts[8], 2,
+        reason: 'the stale decode must not clear the fresh in-flight slot');
+
+    gate2.complete();
+    await Future.wait([f2, f3]);
+  });
+
   testWidgets(
       'the real isolate worker updates its document in place across an edit',
       (tester) async {

--- a/packages/dart_pdf_editor/test/render_worker_revision_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_revision_test.dart
@@ -179,6 +179,46 @@ void main() {
           reason: 'the edited page must reflect the new annotation');
       expect(after1!.length, before1!.length,
           reason: 'an unedited page must render identically after the edit');
+
+      // Undo: the live revision shrinks back to the original prefix (no bytes to
+      // append). The isolate can't apply that as a forward append, so it
+      // re-opens from the shorter prefix and page 0 renders as it did before.
+      worker.updateRevision(original.length, Uint8List(0), original.length, {0});
+      final undone0 = await worker.record(0);
+      expect(undone0, isNotNull);
+      expect(undone0!.length, before0.length,
+          reason: 'undo must restore the pre-edit rendering of page 0');
+    });
+  });
+
+  testWidgets('the pooled worker fans a revision update to every worker',
+      (tester) async {
+    await tester.runAsync(() async {
+      // 12 pages + a pool of 2 selects the PdfPooledRenderWorker backend.
+      final original = buildMultiPagePdf(12);
+      final worker =
+          startPdfRenderWorker(original, pageCount: 12, workerCount: 2);
+      addTearDown(worker.dispose);
+      expect(worker.supportsRevisionUpdate, isTrue);
+
+      final before3 = await worker.record(3);
+      final before9 = await worker.record(9);
+      expect(before3, isNotNull);
+      expect(before9, isNotNull);
+
+      final editor = PdfEditor(PdfDocument.open(original))
+        ..addSquare(3, const PdfRect(20, 20, 120, 120));
+      final updated = editor.save();
+      final appended =
+          Uint8List.fromList(Uint8List.sublistView(updated, original.length));
+      worker.updateRevision(original.length, appended, updated.length, {3});
+
+      // Whichever pooled worker serves each page has the update, so page 3
+      // reflects the edit and page 9 does not - no matter the routing.
+      final after3 = await worker.record(3);
+      final after9 = await worker.record(9);
+      expect(after3!.length, greaterThan(before3!.length));
+      expect(after9!.length, before9!.length);
     });
   });
 }

--- a/packages/dart_pdf_editor/test/render_worker_revision_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_revision_test.dart
@@ -1,0 +1,184 @@
+// The revision-aware render worker (issue #308): an editor revision feeds an
+// incremental append into the live worker instead of restarting it, and only
+// the changed pages' cached renders are dropped - every other page's warm
+// record survives the edit boundary.
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/render_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// A fake backend that counts records per page and records the revision updates
+/// it is handed. Its `record` returns an empty (weight-0) command list so the
+/// caching wrapper stores and later serves it from cache.
+class _FakeBackend extends PdfRenderWorker {
+  final recordCounts = <int, int>{};
+  final updates = <({int base, int appended, int newLength, Set<int>? pages})>[];
+  bool _active = true;
+
+  // Completer gate for the in-flight test; when set, `record` waits on it.
+  Completer<void>? gate;
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  bool get supportsRevisionUpdate => true;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+  }) async {
+    recordCounts[pageIndex] = (recordCounts[pageIndex] ?? 0) + 1;
+    if (gate != null) await gate!.future;
+    return const <PdfRenderCommand>[];
+  }
+
+  @override
+  void updateRevision(
+    int baseLength,
+    Uint8List appendedBytes,
+    int newLength,
+    Set<int>? changedPages,
+  ) {
+    updates.add((
+      base: baseLength,
+      appended: appendedBytes.length,
+      newLength: newLength,
+      pages: changedPages,
+    ));
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => _active = false;
+}
+
+void main() {
+  test('supportsRevisionUpdate propagates through the caching wrapper', () {
+    final backend = _FakeBackend();
+    expect(PdfCachingRenderWorker(backend).supportsRevisionUpdate, isTrue);
+  });
+
+  test('editing one page drops its cache and keeps every other page warm',
+      () async {
+    final backend = _FakeBackend();
+    final worker = PdfCachingRenderWorker(backend);
+
+    // Warm pages 5 and 6.
+    await worker.record(5);
+    await worker.record(6);
+    expect(backend.recordCounts[5], 1);
+    expect(backend.recordCounts[6], 1);
+
+    // Both served from cache now - no new backend records.
+    await worker.record(5);
+    await worker.record(6);
+    expect(backend.recordCounts[5], 1);
+    expect(backend.recordCounts[6], 1);
+
+    // Edit page 5: an incremental append that changes page 5 only.
+    worker.updateRevision(100, Uint8List.fromList([1, 2, 3]), 103, {5});
+
+    // The update was forwarded to the backend unchanged.
+    expect(backend.updates.single.base, 100);
+    expect(backend.updates.single.appended, 3);
+    expect(backend.updates.single.newLength, 103);
+    expect(backend.updates.single.pages, {5});
+
+    // Page 5's record was dropped (re-records); page 6's survived (still cached).
+    await worker.record(5);
+    await worker.record(6);
+    expect(backend.recordCounts[5], 2, reason: 'edited page 5 must re-render');
+    expect(backend.recordCounts[6], 1, reason: 'page 6 must survive the edit');
+  });
+
+  test('an all-pages revision (null changedPages) clears the whole cache',
+      () async {
+    final backend = _FakeBackend();
+    final worker = PdfCachingRenderWorker(backend);
+    await worker.record(1);
+    await worker.record(2);
+    expect(backend.recordCounts[1], 1);
+    expect(backend.recordCounts[2], 1);
+
+    worker.updateRevision(50, Uint8List.fromList([9]), 51, null);
+
+    await worker.record(1);
+    await worker.record(2);
+    expect(backend.recordCounts[1], 2);
+    expect(backend.recordCounts[2], 2);
+  });
+
+  test('an in-flight decode for a changed page is not cached (stale)', () async {
+    final backend = _FakeBackend();
+    final worker = PdfCachingRenderWorker(backend);
+
+    // Start a decode for page 7 and hold it in flight.
+    backend.gate = Completer<void>();
+    final pending = worker.record(7);
+    expect(backend.recordCounts[7], 1);
+
+    // Page 7 is edited while its decode is still running.
+    worker.updateRevision(10, Uint8List.fromList([1]), 11, {7});
+
+    // Let the stale decode finish.
+    backend.gate!.complete();
+    await pending;
+    backend.gate = null;
+
+    // Its result must not have been cached: a fresh request re-records.
+    await worker.record(7);
+    expect(backend.recordCounts[7], 2,
+        reason: 'a decode dispatched before the edit must not cache its result');
+  });
+
+  testWidgets(
+      'the real isolate worker updates its document in place across an edit',
+      (tester) async {
+    await tester.runAsync(() async {
+      final original = buildMultiPagePdf(3);
+
+      final worker =
+          startPdfRenderWorker(original, pageCount: 3, workerCount: 1);
+      addTearDown(worker.dispose);
+      expect(worker.supportsRevisionUpdate, isTrue);
+
+      final before0 = await worker.record(0);
+      final before1 = await worker.record(1);
+      expect(before0, isNotNull);
+      expect(before1, isNotNull);
+
+      // Draw a square on page 0 and feed the incremental append to the worker.
+      final editor = PdfEditor(PdfDocument.open(original))
+        ..addSquare(0, const PdfRect(20, 20, 120, 120));
+      final updated = editor.save();
+      final appended =
+          Uint8List.fromList(Uint8List.sublistView(updated, original.length));
+      worker.updateRevision(original.length, appended, updated.length, {0});
+
+      final after0 = await worker.record(0);
+      final after1 = await worker.record(1);
+      expect(after0, isNotNull);
+      expect(after1, isNotNull);
+
+      // Page 0 gained the square's appearance commands; page 1 is untouched.
+      expect(after0!.length, greaterThan(before0!.length),
+          reason: 'the edited page must reflect the new annotation');
+      expect(after1!.length, before1!.length,
+          reason: 'an unedited page must render identically after the edit');
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/render_worker_transcript_cache_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_transcript_cache_test.dart
@@ -190,4 +190,48 @@ void main() {
     expect(optimized!.retainedCommandWeight,
         lessThan(baseline.retainedCommandWeight));
   });
+
+  test('evictPages drops the named pages and keeps the rest warm', () async {
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final cache = PdfWorkerTranscriptCache(capacity: 4);
+    await cache.transcriptFor(document, 0, true, PdfCancellationToken());
+    await cache.transcriptFor(document, 1, true, PdfCancellationToken());
+    expect(cache.length, 2);
+
+    // Edit page 0: its transcript is stale, page 1's stays warm.
+    cache.evictPages({0});
+    expect(cache.length, 1);
+
+    final keptTimings = PdfWorkerPhaseTimings();
+    await cache.transcriptFor(
+      document,
+      1,
+      true,
+      PdfCancellationToken(),
+      timings: keptTimings,
+    );
+    expect(keptTimings.transcriptHit, isTrue,
+        reason: 'the unedited page survived');
+
+    final droppedTimings = PdfWorkerPhaseTimings();
+    await cache.transcriptFor(
+      document,
+      0,
+      true,
+      PdfCancellationToken(),
+      timings: droppedTimings,
+    );
+    expect(droppedTimings.transcriptHit, isFalse,
+        reason: 'the edited page was dropped');
+  });
+
+  test('evictPages(null) clears every transcript', () async {
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final cache = PdfWorkerTranscriptCache(capacity: 4);
+    await cache.transcriptFor(document, 0, true, PdfCancellationToken());
+    await cache.transcriptFor(document, 1, true, PdfCancellationToken());
+    expect(cache.length, 2);
+    cache.evictPages(null);
+    expect(cache.length, 0);
+  });
 }

--- a/packages/dart_pdf_editor/test/shell_session_test.dart
+++ b/packages/dart_pdf_editor/test/shell_session_test.dart
@@ -70,7 +70,8 @@ void main() {
     expect(lifecycle.debugWorkerGenerations, generations + 1);
   });
 
-  test('form fill or editor revision restarts the worker once', () {
+  test('form fill / edit / undo update the worker in place, no new generation',
+      () {
     final lifecycle = PdfShellSessionLifecycle(
       bytes: buildAcroFormPdf(),
       controller: null,
@@ -80,14 +81,44 @@ void main() {
       documentId: 'revision-test',
     );
     addTearDown(lifecycle.dispose);
+    // The native isolate backend absorbs an incremental revision in place, so
+    // the worker (and its warm caches) survives every edit - the whole point of
+    // issue #308.
+    expect(lifecycle.worker?.supportsRevisionUpdate, isTrue);
     final generations = lifecycle.debugWorkerGenerations;
 
     expect(lifecycle.session.setFormFieldText('name', 'Jane'), isTrue);
-    expect(lifecycle.debugWorkerGenerations, generations + 1);
+    expect(lifecycle.debugWorkerGenerations, generations);
     lifecycle.session.undo();
-    expect(lifecycle.debugWorkerGenerations, generations + 2);
+    expect(lifecycle.debugWorkerGenerations, generations);
+    lifecycle.session.redo();
+    expect(lifecycle.debugWorkerGenerations, generations);
     lifecycle.session.addRectangle(0, const PdfRect(10, 10, 40, 40));
-    expect(lifecycle.debugWorkerGenerations, generations + 3);
+    expect(lifecycle.debugWorkerGenerations, generations);
+  });
+
+  test('a redaction burn restarts the worker (buffer replaced, not appended)',
+      () {
+    final lifecycle = PdfShellSessionLifecycle(
+      bytes: buildMultiPagePdf(2),
+      controller: null,
+      preferences: null,
+      viewerController: null,
+      performance: null,
+      documentId: 'burn-test',
+    );
+    addTearDown(lifecycle.dispose);
+    final generations = lifecycle.debugWorkerGenerations;
+
+    // An ordinary edit updates in place.
+    lifecycle.session.addRectangle(0, const PdfRect(10, 10, 40, 40));
+    expect(lifecycle.debugWorkerGenerations, generations);
+
+    // A redaction burn replaces the whole buffer, which is not a prefix-append,
+    // so the worker must restart.
+    lifecycle.session.addRedaction(0, const PdfRect(0, 0, 100, 100));
+    expect(lifecycle.session.applyRedactions(), isTrue);
+    expect(lifecycle.debugWorkerGenerations, generations + 1);
   });
 
   test('external resources remain caller-owned', () {

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -15,18 +15,22 @@ class CosDocument {
   CosDocument._(
       this.bytes, this._offsetShift, this._xref, this.trailer, this.startXref);
 
-  final Uint8List bytes;
+  /// The document image the xref offsets refer to. Grows in place when an
+  /// append-only incremental revision is fed through [applyIncrementalUpdate];
+  /// the prefix is always byte-identical, so objects cached against the old
+  /// buffer stay valid.
+  Uint8List bytes;
 
   /// Offset of the `%PDF-` header. Some files carry junk before the header;
   /// xref offsets are then relative to the header, not the file start.
   final int _offsetShift;
 
   final Map<int, CosXrefEntry> _xref;
-  final CosDictionary trailer;
+  CosDictionary trailer;
 
   /// The newest cross-reference section's offset, as declared after the
   /// `startxref` keyword. An incremental update points /Prev here.
-  final int startXref;
+  int startXref;
 
   final Map<CosReference, CosObject> _cache = {};
   final Map<int, _ObjectStream> _objectStreams = {};
@@ -88,6 +92,75 @@ class CosDocument {
       // ditto: an xref offset pointing outside the file
     }
     return _recover(bytes, shift, password);
+  }
+
+  /// Feeds an append-only incremental revision into this already-parsed
+  /// document in place, so a caller holding an open document (a render worker)
+  /// need not re-open and re-parse the whole xref chain to see one page's edit.
+  ///
+  /// [newBytes] must begin with this document's current [bytes] (a strict
+  /// prefix) and carry one or more appended incremental-update sections. Only
+  /// the cross-reference sections newer than the current [startXref] are
+  /// parsed; their entries replace the matching ones (newest wins), the trailer
+  /// is refreshed (keeping keys the newest section omits, like /Root), and the
+  /// cached state of every object the update redefined is evicted so the next
+  /// resolve re-reads it from the appended bytes. Returns the set of redefined
+  /// object numbers.
+  ///
+  /// Throws when the update cannot be applied incrementally (this document was
+  /// opened through xref recovery, [newBytes] is not an append, or the appended
+  /// xref chain is malformed); the caller should re-open from scratch instead.
+  Set<int> applyIncrementalUpdate(Uint8List newBytes) {
+    if (startXref <= 0) {
+      // A recovered document has no trustworthy xref chain to hang a /Prev off.
+      throw CosParseException('cannot incrementally update a recovered document');
+    }
+    if (newBytes.length <= bytes.length) {
+      throw CosParseException('incremental update is not an append');
+    }
+    final newStartXref = _findStartXref(newBytes);
+    final oldStartOffset = startXref + _offsetShift;
+    final changed = <int>{};
+    CosDictionary? newestTrailer;
+    final pending = <int>[newStartXref + _offsetShift];
+    final visited = <int>{};
+    while (pending.isNotEmpty) {
+      final offset = pending.removeAt(0);
+      // Everything at or below the previous newest section is already loaded.
+      if (offset == oldStartOffset) continue;
+      if (!visited.add(offset)) continue;
+      final section = _parseXrefSection(newBytes, offset);
+      newestTrailer ??= section.trailer;
+      for (final entry in section.entries.entries) {
+        // First occurrence among the appended sections wins, and it overrides
+        // whatever the old chain held for that object.
+        if (changed.add(entry.key)) _xref[entry.key] = entry.value;
+      }
+      final hybrid = section.trailer['XRefStm'];
+      if (hybrid is CosInteger) pending.add(hybrid.value + _offsetShift);
+      final prev = section.trailer['Prev'];
+      if (prev is CosInteger) pending.add(prev.value + _offsetShift);
+    }
+
+    bytes = newBytes;
+    startXref = newStartXref;
+    if (newestTrailer != null) {
+      // The newest trailer wins, but an incremental trailer may omit doc-level
+      // keys (/Root, /Encrypt, /ID) that still carry over from the base.
+      final merged = CosDictionary();
+      trailer.entries.forEach((key, value) => merged.entries[key] = value);
+      newestTrailer.entries.forEach((key, value) => merged.entries[key] = value);
+      trailer = merged;
+    }
+
+    // Drop cached state for every redefined object so the next resolve re-reads
+    // it from the appended bytes; untouched objects keep their warm cache.
+    _cache.removeWhere((ref, _) => changed.contains(ref.objectNumber));
+    _objectStreams.removeWhere((number, _) => changed.contains(number));
+    _streamOwners
+        .removeWhere((stream, ref) => changed.contains(ref.objectNumber));
+    _scannedHeaders = null;
+    return changed;
   }
 
   static CosDocument _openFromXref(Uint8List bytes, int shift) {

--- a/packages/pdf_cos/test/incremental_update_test.dart
+++ b/packages/pdf_cos/test/incremental_update_test.dart
@@ -1,0 +1,89 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+// CosDocument.applyIncrementalUpdate feeds an append-only incremental revision
+// into an already-open document in place (a render worker reflecting one page's
+// edit without re-parsing the whole xref chain). CosIncrementalUpdater produces
+// exactly that shape - a prefix-append with a new xref section pointing /Prev at
+// the old one.
+void main() {
+  test('merges an appended revision in place, evicting the changed object', () {
+    final original = buildClassicPdf();
+    final updated = (CosIncrementalUpdater(CosDocument.open(original))
+          ..replaceObject(
+            5,
+            CosDictionary({
+              'Type': const CosName('Font'),
+              'Subtype': const CosName('Type1'),
+              'BaseFont': const CosName('Courier'),
+            }),
+          ))
+        .save();
+
+    final doc = CosDocument.open(original);
+    // Warm the cache for the object about to change, so the eviction path runs.
+    doc.getObject(5, 0);
+    doc.catalog;
+
+    final changed = doc.applyIncrementalUpdate(updated);
+
+    expect(changed, contains(5));
+    expect(doc.bytes.length, updated.length);
+    expect(doc.startXref, greaterThan(0));
+    // The redefined object resolves to the appended value (its cache entry was
+    // evicted), while untouched objects still load through the retained ones.
+    expect(
+      (doc.getObject(5, 0) as CosDictionary)['BaseFont'],
+      const CosName('Courier'),
+    );
+    expect((doc.getObject(3, 0) as CosDictionary).typeName, 'Page');
+    expect(doc.catalog.typeName, 'Catalog');
+    // The refreshed trailer chains /Prev back to the base revision and keeps the
+    // doc-level keys (/Root) the incremental trailer carries over.
+    expect(doc.trailer['Prev'], isA<CosInteger>());
+    expect(doc.trailer['Root'], isNotNull);
+  });
+
+  test('resolves objects the appended revision adds', () {
+    final original = buildClassicPdf();
+    final updater = CosIncrementalUpdater(CosDocument.open(original));
+    final ref =
+        updater.addObject(CosDictionary({'New': const CosBoolean(true)}));
+    final updated = updater.save();
+
+    final doc = CosDocument.open(original);
+    final changed = doc.applyIncrementalUpdate(updated);
+    expect(changed, contains(ref.objectNumber));
+    expect((doc.resolve(ref) as CosDictionary)['New'], const CosBoolean(true));
+  });
+
+  test('leaves the document equivalent to a fresh open of the new bytes', () {
+    final original = buildClassicPdf();
+    final updated = (CosIncrementalUpdater(CosDocument.open(original))
+          ..replaceObject(5, CosDictionary({'A': const CosInteger(7)})))
+        .save();
+
+    final incremental = CosDocument.open(original)
+      ..applyIncrementalUpdate(updated);
+    final fresh = CosDocument.open(updated);
+
+    expect(
+      (incremental.getObject(5, 0) as CosDictionary)['A'],
+      (fresh.getObject(5, 0) as CosDictionary)['A'],
+    );
+    expect(incremental.declaredSize, fresh.declaredSize);
+  });
+
+  test('rejects a buffer that is not an append', () {
+    final original = buildClassicPdf();
+    final doc = CosDocument.open(original);
+    final shorter = Uint8List.sublistView(original, 0, original.length - 1);
+    expect(
+      () => doc.applyIncrementalUpdate(shorter),
+      throwsA(isA<CosParseException>()),
+    );
+  });
+}

--- a/packages/pdf_document/lib/src/document.dart
+++ b/packages/pdf_document/lib/src/document.dart
@@ -85,6 +85,19 @@ class PdfDocument {
   /// changes (reorder, removal, insertion) so lookups re-walk the tree.
   void invalidatePageCache() => _leafCache = null;
 
+  /// Feeds an append-only incremental revision into this open document in
+  /// place (see [CosDocument.applyIncrementalUpdate]) and re-walks the page
+  /// tree, so a render worker can reflect one page's edit without re-parsing
+  /// the whole document. [newBytes] must begin with this document's current
+  /// bytes (`cos.bytes`).
+  /// Returns the set of redefined COS object numbers. Throws when the update
+  /// cannot be applied incrementally; the caller should re-open instead.
+  Set<int> applyIncrementalUpdate(Uint8List newBytes) {
+    final changed = cos.applyIncrementalUpdate(newBytes);
+    invalidatePageCache();
+    return changed;
+  }
+
   /// Zero-based index of a page dictionary, or -1 if it isn't a leaf of
   /// this document's page tree. Resolved objects are cached by reference,
   /// so identity comparison is sound. Used to resolve link destinations.

--- a/packages/pdf_document/test/incremental_update_test.dart
+++ b/packages/pdf_document/test/incremental_update_test.dart
@@ -1,0 +1,86 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // An incremental editor save appends a new xref section pointing /Prev at the
+  // old one, so the new bytes are a strict prefix-append of the old document.
+  Uint8List editThenSave(Uint8List bytes, void Function(PdfEditor) edit) {
+    final editor = PdfEditor(PdfDocument.open(bytes));
+    edit(editor);
+    final saved = editor.save();
+    // Sanity: the save is genuinely a prefix-append (the shape the worker's
+    // incremental update relies on).
+    expect(saved.length, greaterThan(bytes.length));
+    for (var i = 0; i < bytes.length; i++) {
+      expect(saved[i], bytes[i], reason: 'byte $i diverged from the prefix');
+    }
+    return saved;
+  }
+
+  test('applyIncrementalUpdate matches a full reopen of the new bytes', () {
+    final original = buildMultiPagePdf(4);
+    final updated = editThenSave(
+      original,
+      (e) => e.setInfo(title: 'Revised', author: 'Ben'),
+    );
+
+    final incremental = PdfDocument.open(original);
+    final changed = incremental.applyIncrementalUpdate(updated);
+    final full = PdfDocument.open(updated);
+
+    expect(changed, isNotEmpty);
+    expect(incremental.pageCount, full.pageCount);
+    expect(incremental.info['Title'], 'Revised');
+    expect(incremental.info['Author'], 'Ben');
+    // The buffer now points at the appended revision.
+    expect(incremental.cos.bytes.length, updated.length);
+  });
+
+  test('unedited pages keep byte-identical content across the update', () {
+    final original = buildMultiPagePdf(5);
+    // Draw a rectangle on page 2 only.
+    final updated = editThenSave(
+      original,
+      (e) => e.addSquare(2, const PdfRect(20, 20, 80, 80)),
+    );
+
+    final full = PdfDocument.open(updated);
+    final incremental = PdfDocument.open(original);
+    incremental.applyIncrementalUpdate(updated);
+
+    for (var page = 0; page < full.pageCount; page++) {
+      expect(
+        incremental.page(page).contentBytes(),
+        full.page(page).contentBytes(),
+        reason: 'page $page content differs from a full reopen',
+      );
+    }
+  });
+
+  test('a redefined object resolves to the new value after the update', () {
+    final original = buildMultiPagePdf(2);
+    final updated = editThenSave(
+      original,
+      (e) => e.setInfo(title: 'After'),
+    );
+
+    final incremental = PdfDocument.open(original);
+    expect(incremental.info['Title'], isNot('After'));
+    incremental.applyIncrementalUpdate(updated);
+    expect(incremental.info['Title'], 'After');
+  });
+
+  test('rejects a non-append buffer', () {
+    final original = buildMultiPagePdf(2);
+    final shorter = Uint8List.sublistView(original, 0, original.length - 1);
+    final doc = PdfDocument.open(original);
+    expect(
+      () => doc.applyIncrementalUpdate(shorter),
+      throwsA(isA<CosParseException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #308. The render worker's interface was a fixed byte snapshot, so `PdfShellSessionLifecycle._syncWorker` disposed the whole pool and re-ran `startPdfRenderWorker` on **every** edit, undo, and redo — N private `PdfDocument` re-parses (xref + content) plus an empty decoded-image **and** transcript/record cache, all to reflect a change to one page. Revisions are append-only (one growing buffer, a stack of lengths), so an edit to page 5 leaves every other page byte-identical; identity-based restart was the coarsest possible invalidation.

This deepens the worker interface so a revision is absorbed **in place** and only the changed pages are invalidated:

`PdfRenderWorker.updateRevision(int baseLength, Uint8List appendedBytes, int newLength, Set<int>? changedPages)` + a `supportsRevisionUpdate` capability. The worker keeps its buffer's first `baseLength` bytes (the shared prefix), appends `appendedBytes` to reach a `newLength`-byte revision, feeds that into its already-open document, and evicts only `changedPages` from its per-page caches (null = every page).

Result: `debugWorkerGenerations` stays flat across edits, the decoded-image/transcript/record working set survives the edit boundary, and "only the edited page re-renders" replaces "every visible page re-warms from cold".

### How it fits together

- **pdf_cos** `CosDocument.applyIncrementalUpdate(newBytes)`: parses only the xref sections newer than the current `startxref`, overrides the matching entries (newest wins), merges the trailer (keeping doc-level keys the incremental trailer omits), swaps in the new bytes, and evicts cached state for the redefined objects only. Refuses recovered documents and non-append buffers. Safe because the prefix bytes are byte-identical.
- **pdf_document** `PdfDocument.applyIncrementalUpdate` = cos + `invalidatePageCache()`.
- **budgeted_cache** `evictWhere` (targeted per-key eviction); transcript/bin caches gain `evictPages`.
- **Caching wrapper** evicts the record cache per changed page and stamps a **revision epoch** so an in-flight decode dispatched before an edit to its page can't cache stale content. **Pooled worker** fans the update to every platform worker and rolls the urgent-worker seed bytes forward.
- **Isolate backend** routes the update through the same priority queue as records so it never overlaps an in-flight walk (which would see a half-updated document); it applies the update in place, or re-opens from the target prefix on an undo.
- **Controller** exposes `lastRevisionDelta` (set on edit/undo/redo; null on the initial open, a structural edit, or a redaction burn that replaces the buffer). **Shell** `_syncWorker` takes the incremental path when supported and restarts otherwise.

## Affected packages

- [x] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Performance change
- [x] Editing behavior change (worker lifecycle across edits)
- [ ] Bug fix

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean)
- [x] `cd packages/pdf_cos && fvm dart test` (200 passed)
- [x] `cd packages/pdf_document && fvm dart test` (665 passed, incl. new `incremental_update_test`)
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (1555 passed, incl. new `render_worker_revision_test` + updated `shell_session_test`)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

pdf_graphics was untouched, so its suite was not re-run.

## Tests

- `debugWorkerGenerations` stays flat across form-fill / edit / undo / redo and bumps once on a redaction burn (`shell_session_test.dart`).
- Edit page 5 → page 6's record survives, page 5's is dropped — both a fake-backend unit test and a **real isolate integration test** confirming the in-place document actually reflects the edit (`render_worker_revision_test.dart`).
- `applyIncrementalUpdate` matches a full reopen; unedited pages stay byte-identical; redefined objects resolve to the new value (`incremental_update_test.dart`).
- `evictWhere` / `evictPages` unit tests.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required (the prefix is byte-identical, so cached lazy streams stay valid across the swap).
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The **native isolate** backend is fully wired (VM tests exercise it). The **web** backend and its prebuilt worker asset are intentionally left as-is: `supportsRevisionUpdate` stays false there, so web keeps restarting the worker on an edit (no regression, no gain). Wiring the web-worker `'update'` message and rebuilding `assets/web/pdf_render_worker.dart.js` is a clean follow-up.
- Undo/redo take the isolate's re-open fallback (a shorter-prefix re-parse) rather than a true incremental step, and clear that worker's bin cache wholesale; the record and decoded-image caches still survive, so the headline win holds on the measured forward-edit path.
- Design rationale and the stale-inflight epoch subtlety are written up in `doc/dev-log/2026-07-16-revision-aware-render-worker.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D76m9zF6AZBg4JXnzx7gec

---
_Generated by [Claude Code](https://claude.ai/code/session_01D76m9zF6AZBg4JXnzx7gec)_