### PR TITLE
feat(viewer): configurable horizontal and facing-ready page layouts

### DIFF
--- a/doc/dev-log/2026-07-16-viewer-horizontal-layout.md
+++ b/doc/dev-log/2026-07-16-viewer-horizontal-layout.md
@@ -78,7 +78,17 @@ which.
 
 `didUpdateWidget` on a `pageLayout` change drops the zoom window, re-fits,
 and re-anchors on `currentPage` in a post-frame callback (the new extents
-only exist after the relayout).
+only exist after the relayout). It skips the re-anchor when the `document`
+also changed in the same rebuild - that branch already resets fit + scroll,
+so running both would schedule competing post-frame scrolls.
+
+## Example app
+
+The demo app (`example/lib/main.dart`) exercises the API: a "Horizontal
+page layout" / "Vertical page layout" toggle in the app menu flips
+`_pageLayout` (a `PdfPageLayout`), passed to both the `PdfReader` and
+`PdfEditorView` shells - so both the read-only and editing modes can be
+seen in either layout.
 
 ## Tests
 

--- a/doc/dev-log/2026-07-16-viewer-horizontal-layout.md
+++ b/doc/dev-log/2026-07-16-viewer-horizontal-layout.md
@@ -1,0 +1,97 @@
+# Configurable page layouts (horizontal continuous) in PdfViewer
+
+Issue #324: `PdfViewer` only stacked pages vertically. Added a public,
+extensible `PdfPageLayout` and a working horizontal-continuous layout that
+reuses the whole viewer (virtualization, zoom/pan, selection, search,
+overlays, links, forms) rather than reimplementing it.
+
+## Public API
+
+- `PdfPageLayout` (in `pdf_viewer.dart`, exported via the existing
+  `export 'src/pdf_viewer.dart'`): a value type with named const
+  constructors `verticalContinuous()` / `horizontalContinuous()` and a
+  `scrollAxis` getter. Deliberately **not** a bare enum, so a
+  facing/two-page mode can be added later as a new constructor without
+  touching `PdfViewer`'s signature (the issue's explicit forward-compat
+  ask).
+- `PdfViewer.pageLayout` (defaults to `verticalContinuous()`), forwarded by
+  `PdfReader` and `PdfEditorView`.
+
+## How it works: the main/cross axis abstraction
+
+The viewer's zoom model is unchanged and was already axis-friendly: at/below
+fit the zoom lives in `_layoutZoom` (pages relayout smaller); above fit it
+rides the `InteractiveViewer` transform (a scale+translate window). The list
+is an `ExactExtentListView` (now given `scrollDirection`).
+
+Everything was written against "vertical list, horizontal cross-axis in the
+transform". Rather than fork every path, the state now speaks **main** (the
+scroll axis) and **cross** (the fixed fit/centre axis). Vertical is the
+identity case (main = Y, cross = X); horizontal swaps them. The primitives
+(all in `_PdfViewerState`):
+
+- `_horizontal`, `_mainTranslate`/`_crossTranslate` (Matrix4 storage index
+  12/13 by axis), `_mainView`/`_crossView` (viewport extents),
+  `_mainOf`/`_crossOf(Offset)` and `_axisOffset(main, cross)`.
+- Geometry: `_crossPointOf`/`_mainPointOf` (page size in points per axis,
+  from `_pointWidths`/`_aspects`), `_maxCrossPoint` (fit reference -
+  `_maxPointWidth` or the new `_maxPointHeight`), `_fitScale`,
+  `_pageCross`/`_pageMain`, `_crossInsetOf`, `_mainOffsetOf` (cumulative
+  scroll offset), `_pageContentX/Y`/`_pageContentRect`, `_crossFactor`.
+- `_pageWidth`/`_pageHeight` now mean literal on-screen w/h (they pick
+  main/cross by axis) so `PdfPageGeometry` and `toViewRect` are untouched.
+
+Every offset↔page mapping was rewritten in these terms: `_captureViewport`,
+`_placeViewport`, `_showRect`, `_visibleFractionOf`, `_pagePointAt`,
+`_pageContainsListPoint`, `_toPageView`, `_updateCurrentPage`, `_jumpToPage`,
+`_scrollToDestination`, `_showMatch`, `_setLayoutZoom` (focal is now
+`focalMain`), `_crossPageGhostFor`, and the initial-fit + reading-anchor
+logic in `build`.
+
+Gestures: the transform-translation cluster that was hard-wired to
+"horizontal = free/rubber-band, vertical = scroll-bound" became main/cross.
+`_clampedTransformVerticalOnly` → `_clampedTransformMainOnly`,
+`_springBackHorizontal` → `_springBackCross`, `_horizontalOverscroll` →
+`_crossOverscroll`, `_onHorizontalBounceTick` → `_onCrossBounceTick`;
+`_rubberBandClamp`, `_onPanFlingTick`, `_scrollbarScrollBy`/`_scrollbarPanBy`,
+`_grabPanBy`/`_touchGrabPanBy`, the trackpad pan/fling, and `_onPointerSignal`
+(wheel) all route through the axis accessors. `_clampedTransform` already
+clamped both axes symmetrically - no change.
+
+`PdfDestination`/`_showMatch`: a `/FitH top` drives a vertical layout's
+scroll; a horizontal layout scrolls to the destination/match's **left**
+(the main axis) instead, leaving the fully-in-view cross axis to the zoom
+window.
+
+## Scrollbars
+
+`PdfScrollbar` keyed "scroll-driven vs transform-only" off `axis ==
+vertical`. Decoupled: it's now `_scrollDriven = scroll != null`, and the
+transform storage index is `axis == vertical ? 13 : 12` (by the bar's own
+orientation). So the same widget serves a horizontal *main* (scroll-driven)
+bar and a vertical *cross* (transform-only) bar. The viewer positions each
+bar by its orientation (vertical → right, horizontal → bottom, inset for the
+corner) via `_positionedScrollbar`, so they never collide whichever axis is
+which.
+
+## Runtime switching
+
+`didUpdateWidget` on a `pageLayout` change drops the zoom window, re-fits,
+and re-anchors on `currentPage` in a post-frame callback (the new extents
+only exist after the relayout).
+
+## Tests
+
+`test/pdf_horizontal_layout_test.dart` - 12 tests: value semantics, the
+horizontal `Scrollable`, drag/jump current-page tracking, `visiblePageRegion`,
+capture/restore round-trip, overlay geometry at the fit-height scale, search
+nav, `Fit.page`, runtime layout switching, and mixed-size centring. All the
+existing viewer/scrollbar/viewport/selection/comparison suites still pass
+(vertical is the byte-for-byte identity case).
+
+## Not done (future)
+
+Facing/two-page and single-page paging - the API admits them; only the two
+continuous layouts are implemented. `_showMatch`/`_scrollToDestination`
+intra-page offsets ignore page `/Rotate` on the horizontal axis, same
+simplification the vertical path already made.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.8
+## Unreleased
 
 - Add configurable page layouts to `PdfViewer`: the new `pageLayout`
   parameter takes a `PdfPageLayout` - `verticalContinuous()` (the default,

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.4.8
+
+- Add configurable page layouts to `PdfViewer`: the new `pageLayout`
+  parameter takes a `PdfPageLayout` - `verticalContinuous()` (the default,
+  top-to-bottom) or `horizontalContinuous()` (left-to-right, book-like
+  reading and wide documents). The horizontal layout keeps every viewer
+  behaviour along the new axis - virtualization, zoom/pan, current-page
+  tracking, search and destination navigation, text selection, overlays,
+  links, forms/annotation hit-testing, keyboard navigation, and mixed page
+  sizes (pages fit the viewport height and centre on the cross axis).
+  `PdfPageLayout` is a value type with named constructors so further layouts
+  (facing/two-page) can be added without changing the viewer's API.
+  `PdfReader` and `PdfEditorView` forward the option (#324).
+
 ## 1.4.7
 
 - Print through each platform's native print system: the Dart engine

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -211,6 +211,15 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// [PdfEditorView] for the view-only [PdfReader]. App-wide.
   bool _readOnly = false;
 
+  /// Demo of [PdfViewer.pageLayout]: the toggle flips the viewer between the
+  /// default vertical continuous layout and horizontal continuous
+  /// (left-to-right, book-like). App-wide.
+  bool _horizontalLayout = false;
+
+  PdfPageLayout get _pageLayout => _horizontalLayout
+      ? const PdfPageLayout.horizontalContinuous()
+      : const PdfPageLayout.verticalContinuous();
+
   final PdfPerformanceController _performance = PdfPerformanceController();
   int _workerConfigEpoch = 0;
 
@@ -408,6 +417,19 @@ class _ViewerScreenState extends State<ViewerScreen> {
           child: _appMenuTile(
             icon: _readOnly ? Icons.edit : Icons.edit_off,
             title: _readOnly ? 'Switch to edit mode' : 'Switch to read-only',
+          ),
+        ),
+        PopupMenuItem(
+          value: () =>
+              setState(() => _horizontalLayout = !_horizontalLayout),
+          enabled: tab?.session != null,
+          child: _appMenuTile(
+            icon: _horizontalLayout
+                ? Icons.swap_vert
+                : Icons.swap_horiz,
+            title: _horizontalLayout
+                ? 'Vertical page layout'
+                : 'Horizontal page layout',
           ),
         ),
         PopupMenuItem(
@@ -1281,6 +1303,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 performance: _performance,
                                 rasterCache: _rasterCache,
                                 textCache: _textCache,
+                                pageLayout: _pageLayout,
                                 onAction: _onAction,
                                 pageOverlayBuilder:
                                     tab.isDemo ? _demoOverlays : null,
@@ -1293,6 +1316,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 performance: _performance,
                                 rasterCache: _rasterCache,
                                 textCache: _textCache,
+                                pageLayout: _pageLayout,
                                 onSave: (saved) => unawaited(_saveAs(saved)),
                                 onPickPdfToInsert: _pickPdfBytes,
                                 onExportPages: (bytes) =>

--- a/packages/dart_pdf_editor/lib/src/exact_extent_list.dart
+++ b/packages/dart_pdf_editor/lib/src/exact_extent_list.dart
@@ -16,6 +16,7 @@ import 'package:flutter/widgets.dart';
 class ExactExtentListView extends ListView {
   ExactExtentListView.builder({
     super.key,
+    super.scrollDirection,
     super.controller,
     super.physics,
     super.padding,

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -237,6 +237,7 @@ class PdfEditorView extends StatefulWidget {
     this.toolbarLeading = const [],
     this.toolbarTrailing = const [],
     this.toolbarBuilder,
+    this.pageLayout = const PdfPageLayout.verticalContinuous(),
     this.initialFit = PdfViewerFit.page,
     this.backgroundColor,
     this.pageColor,
@@ -414,6 +415,9 @@ class PdfEditorView extends StatefulWidget {
   /// [PdfEditorFeatures.toolbar] still gates this builder. Set that feature to
   /// false to disable all toolbar chrome regardless of this value.
   final PdfEditorToolbarBuilder? toolbarBuilder;
+
+  /// See [PdfViewer.pageLayout].
+  final PdfPageLayout pageLayout;
 
   /// See [PdfViewer.initialFit].
   final PdfViewerFit initialFit;
@@ -990,6 +994,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                             (features.toolGroups == null ||
                                 features.toolGroups!
                                     .contains(PdfEditToolGroup.markup)),
+                        pageLayout: widget.pageLayout,
                         initialFit: widget.initialFit,
                         toolShortcuts: _toolShortcuts,
                         backgroundColor: widget.backgroundColor,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -113,6 +113,7 @@ class PdfReader extends StatefulWidget {
     this.onAnnotationTap,
     this.onLaunchUrl,
     this.pageOverlayBuilder,
+    this.pageLayout = const PdfPageLayout.verticalContinuous(),
     this.initialFit = PdfViewerFit.page,
     this.backgroundColor,
     this.pageColor,
@@ -167,6 +168,9 @@ class PdfReader extends StatefulWidget {
 
   /// See [PdfViewer.pageOverlayBuilder].
   final PdfPageOverlayBuilder? pageOverlayBuilder;
+
+  /// See [PdfViewer.pageLayout].
+  final PdfPageLayout pageLayout;
 
   /// See [PdfViewer.initialFit].
   final PdfViewerFit initialFit;
@@ -406,6 +410,7 @@ class _PdfReaderState extends State<PdfReader> {
                           onAnnotationTap: widget.onAnnotationTap,
                           onLaunchUrl: widget.onLaunchUrl,
                           pageOverlayBuilder: widget.pageOverlayBuilder,
+                          pageLayout: widget.pageLayout,
                           initialFit: widget.initialFit,
                           backgroundColor: widget.backgroundColor,
                           pageColor: pageColor,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1834,7 +1834,11 @@ class _PdfViewerState extends State<PdfViewer>
       // index-keyed disk backing, leaving it must restore (and re-prime) it
       _bindRasterCache();
     }
-    if (oldWidget.pageLayout != widget.pageLayout) {
+    // A document swap in the same rebuild already reset the fit and scroll
+    // (above), so only re-anchor for a pure layout flip - otherwise the two
+    // branches would schedule competing post-frame scrolls.
+    if (oldWidget.pageLayout != widget.pageLayout &&
+        identical(oldWidget.document, widget.document)) {
       // the scroll axis flipped: the fit dimension and every scroll extent
       // change, so drop the zoom window, re-fit, and re-anchor on the page
       // the reader was on once the new layout's extents exist.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -475,6 +475,59 @@ enum PdfViewerFit {
   page,
 }
 
+/// How [PdfViewer] arranges the document's pages.
+///
+/// Passed to [PdfViewer.pageLayout]. The default,
+/// [PdfPageLayout.verticalContinuous], stacks pages top-to-bottom and
+/// scrolls vertically - the classic reading layout.
+/// [PdfPageLayout.horizontalContinuous] lays them left-to-right and scrolls
+/// horizontally, for book-like reading, wide documents, and apps that offer
+/// a horizontal reading mode.
+///
+/// Both continuous modes keep every viewer behaviour - virtualization,
+/// zoom/pan, current-page tracking, search and destination navigation, text
+/// selection, page overlays, links, form and annotation hit-testing, and
+/// mixed page sizes - along the chosen axis. Pages keep their true relative
+/// sizes and are centred on the cross axis.
+///
+/// The type is a value object rather than a bare enum so that further
+/// layouts (a facing/two-page mode, single-page paging) can be added as new
+/// constructors without changing [PdfViewer]'s constructor signature.
+@immutable
+class PdfPageLayout {
+  /// Pages stacked top-to-bottom, scrolling vertically (the default, and
+  /// what every earlier version of the viewer did).
+  const PdfPageLayout.verticalContinuous()
+      : _kind = _PdfPageLayoutKind.verticalContinuous;
+
+  /// Pages laid left-to-right, scrolling horizontally. The first page fills
+  /// the viewport height (rather than its width); narrower/shorter pages lay
+  /// out proportionally and are centred vertically.
+  const PdfPageLayout.horizontalContinuous()
+      : _kind = _PdfPageLayoutKind.horizontalContinuous;
+
+  final _PdfPageLayoutKind _kind;
+
+  /// The axis pages scroll along: [Axis.vertical] for
+  /// [PdfPageLayout.verticalContinuous], [Axis.horizontal] for
+  /// [PdfPageLayout.horizontalContinuous].
+  Axis get scrollAxis => _kind == _PdfPageLayoutKind.horizontalContinuous
+      ? Axis.horizontal
+      : Axis.vertical;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfPageLayout && other._kind == _kind;
+
+  @override
+  int get hashCode => _kind.hashCode;
+
+  @override
+  String toString() => 'PdfPageLayout.${_kind.name}';
+}
+
+enum _PdfPageLayoutKind { verticalContinuous, horizontalContinuous }
+
 /// Signature for [PdfViewer.onAction]: the user activated [annotation]
 /// (tapped a link or form button) and the viewer doesn't handle its
 /// [action] itself.
@@ -522,6 +575,7 @@ class PdfViewer extends StatefulWidget {
     this.systemImagePasteProvider,
     this.onSnapshot,
     this.pageSpacing = 12,
+    this.pageLayout = const PdfPageLayout.verticalContinuous(),
     this.initialFit = PdfViewerFit.page,
     this.initialViewport,
     this.minZoom = 0.25,
@@ -714,6 +768,12 @@ class PdfViewer extends StatefulWidget {
   final PdfSnapshotHandler? onSnapshot;
 
   final double pageSpacing;
+
+  /// How the pages are arranged: vertical continuous (the default,
+  /// top-to-bottom) or horizontal continuous (left-to-right). See
+  /// [PdfPageLayout]. Switching it at runtime keeps the current page in
+  /// view and re-applies [initialFit] against the new axis.
+  final PdfPageLayout pageLayout;
 
   /// The zoom the document opens at: the whole first page visible
   /// (default, like desktop browser viewers) or filling the viewport
@@ -921,7 +981,7 @@ class _PdfViewerState extends State<PdfViewer>
   late List<double> _aspects; // height / width, after /Rotate
 
   /// Displayed width of each page in PDF points (after /Rotate + view
-  /// rotation). Pages lay out at this width times [_fitWidthScale] (and the
+  /// rotation). Pages lay out at this width times [_fitScale] (and the
   /// layout zoom), so they keep their true sizes relative to one another
   /// instead of every page filling the viewport.
   late List<double> _pointWidths;
@@ -930,6 +990,11 @@ class _PdfViewerState extends State<PdfViewer>
   /// layout zoom 1 this page exactly fills the viewport; narrower pages lay
   /// out proportionally narrower and centered.
   double _maxPointWidth = 0;
+
+  /// The tallest page's displayed point height - the fit-height reference
+  /// used by [PdfPageLayout.horizontalContinuous], the horizontal analogue
+  /// of [_maxPointWidth].
+  double _maxPointHeight = 0;
   // Per-page derived objects, bounded LRU so a long scroll cannot pin one
   // entry per visited page for the life of the viewer (issue #283). They are
   // warm only near the viewport (derived on hit-test/selection/search), so a
@@ -1041,7 +1106,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// gesture overshoots the content edge (rubber-band release).
   late final AnimationController _hBounceController =
       AnimationController.unbounded(vsync: this)
-        ..addListener(_onHorizontalBounceTick);
+        ..addListener(_onCrossBounceTick);
 
   /// True while a touch-originated gesture is driving horizontal pan
   /// (overlay viewport pan, touch fling, pinch). Enables rubber-band
@@ -1300,7 +1365,10 @@ class _PdfViewerState extends State<PdfViewer>
         dx = dy;
         dy = 0;
       }
-      if (zoomed) matrix.storage[12] -= dx;
+      // the primary wheel (dy) scrolls the list along its own axis - down
+      // the page vertically, across it horizontally; the secondary (dx)
+      // pans the zoom window on the cross axis
+      if (zoomed) matrix.storage[_crossTranslate] -= dx;
       if (_scroll.hasClients && dy != 0) {
         final position = _scroll.position;
         // deltas are screen pixels; the list lives under the zoom transform
@@ -1308,7 +1376,9 @@ class _PdfViewerState extends State<PdfViewer>
         final clamped =
             target.clamp(position.minScrollExtent, position.maxScrollExtent);
         if (clamped != position.pixels) position.jumpTo(clamped);
-        if (zoomed) matrix.storage[13] -= (target - clamped) * scale;
+        if (zoomed) {
+          matrix.storage[_mainTranslate] -= (target - clamped) * scale;
+        }
       }
       if (zoomed) _transform.value = _clampedTransform(matrix);
     });
@@ -1329,7 +1399,7 @@ class _PdfViewerState extends State<PdfViewer>
   void _setZoomFromController(double scale) {
     // the public zoom is logical px per point (1 = actual size); the
     // internal layout/transform machinery works in fit-width multiples
-    final target = _fitWidthScale <= 0 ? scale : scale / _fitWidthScale;
+    final target = _fitScale <= 0 ? scale : scale / _fitScale;
     _zoomTo(target, Offset(_viewWidth / 2, _viewHeight / 2));
   }
 
@@ -1339,9 +1409,9 @@ class _PdfViewerState extends State<PdfViewer>
       if (_transform.value.getMaxScaleOnAxis() > 1) {
         _transform.value = Matrix4.identity();
       }
-      _setLayoutZoom(zoom, focalY: focal.dy);
+      _setLayoutZoom(zoom, focalMain: _mainOf(focal));
     } else {
-      if (_layoutZoom < 1) _setLayoutZoom(1, focalY: focal.dy);
+      if (_layoutZoom < 1) _setLayoutZoom(1, focalMain: _mainOf(focal));
       final matrix = _transform.value.clone();
       final factor = zoom / matrix.getMaxScaleOnAxis();
       matrix
@@ -1349,18 +1419,18 @@ class _PdfViewerState extends State<PdfViewer>
         ..scaleByDouble(factor, factor, factor, 1)
         ..translateByDouble(-focal.dx, -focal.dy, 0, 1);
       _transform.value = _touchPanning
-          ? _clampedTransformVerticalOnly(matrix)
+          ? _clampedTransformMainOnly(matrix)
           : _clampedTransform(matrix);
     }
   }
 
-  /// Lays the pages out at [zoom] × fit-width (≤ 1), keeping the content
-  /// at [focalY] (viewport coordinates) as stationary as the new scroll
-  /// extents allow.
-  void _setLayoutZoom(double zoom, {double? focalY}) {
+  /// Lays the pages out at [zoom] × fit (≤ 1), keeping the content at
+  /// [focalMain] (viewport coordinates along the scroll axis) as stationary
+  /// as the new scroll extents allow.
+  void _setLayoutZoom(double zoom, {double? focalMain}) {
     final z = zoom.clamp(widget.minZoom, 1.0);
     if (z == _layoutZoom) return;
-    final anchor = focalY ?? _viewHeight / 2;
+    final anchor = focalMain ?? _mainView / 2;
     final pixels = _scroll.hasClients ? _scroll.position.pixels : 0.0;
     final target = (pixels + anchor) * (z / _layoutZoom) - anchor;
     setState(() => _layoutZoom = z);
@@ -1764,6 +1834,20 @@ class _PdfViewerState extends State<PdfViewer>
       // index-keyed disk backing, leaving it must restore (and re-prime) it
       _bindRasterCache();
     }
+    if (oldWidget.pageLayout != widget.pageLayout) {
+      // the scroll axis flipped: the fit dimension and every scroll extent
+      // change, so drop the zoom window, re-fit, and re-anchor on the page
+      // the reader was on once the new layout's extents exist.
+      final anchor = _controller.currentPage;
+      _transform.value = Matrix4.identity();
+      _layoutZoom = 1;
+      _appliedInitialFit = false;
+      _zoomed = false;
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _scroll.hasClients) _jumpToPage(anchor);
+      });
+      setState(() {});
+    }
     // the viewer was paused (e.g. the full-area page grid overlaid it) and is
     // foreground again - release the render hold and resume the prerender
     if (oldWidget.active != widget.active) {
@@ -1879,6 +1963,12 @@ class _PdfViewerState extends State<PdfViewer>
             : math.max(1e-6, _pages[i].cropBox.width),
     ];
     _maxPointWidth = _pointWidths.isEmpty ? 0 : _pointWidths.reduce(math.max);
+    _maxPointHeight = _pages.isEmpty
+        ? 0
+        : [
+            for (var i = 0; i < _pages.length; i++)
+              _aspects[i] * _pointWidths[i]
+          ].reduce(math.max);
   }
 
   void _onViewRotationChanged() {
@@ -1972,62 +2062,126 @@ class _PdfViewerState extends State<PdfViewer>
     super.dispose();
   }
 
-  /// Logical pixels per PDF point at the fit-width baseline ([_layoutZoom]
-  /// == 1, transform identity): the widest page exactly fills the viewport.
-  /// The public zoom is expressed against actual size (1 px/pt), so it is
-  /// this scale times the fit-width multiplier ([_currentZoom]).
-  double get _fitWidthScale => (_maxPointWidth <= 0 || _viewWidth <= 0)
-      ? 1
-      : _viewWidth / _maxPointWidth;
+  // --- layout axis ---
+  //
+  // The viewer supports two continuous layouts (see [PdfPageLayout]). Rather
+  // than duplicate every geometry/gesture path, the code is written in terms
+  // of a "main" axis (the scroll direction) and a "cross" axis (the fixed
+  // one the pages fit to and are centred on). Vertical layout is the identity
+  // case: main = Y, cross = X. Horizontal layout swaps them: main = X,
+  // cross = Y. The transform's translation storage index and the viewport
+  // extent follow the axis the same way.
 
-  /// Gesture/controller zoom clamps are expressed as fit-width multiples.
-  /// On phone-width viewports fit-width is less than actual size, so the
-  /// stock 24x fit-width cap used to top out below 2400% actual size. Keep
-  /// the default generous there without changing explicit host caps.
+  bool get _horizontal => widget.pageLayout.scrollAxis == Axis.horizontal;
+
+  /// Matrix4 translation storage index for the main (scroll) axis, and for
+  /// the cross (free-pan) axis. Column-major: index 12 is x, 13 is y.
+  int get _mainTranslate => _horizontal ? 12 : 13;
+  int get _crossTranslate => _horizontal ? 13 : 12;
+
+  /// Viewport extent along the main (scroll) and cross axes.
+  double get _mainView => _horizontal ? _viewWidth : _viewHeight;
+  double get _crossView => _horizontal ? _viewHeight : _viewWidth;
+
+  /// The main/cross components of a screen-space offset.
+  double _mainOf(Offset o) => _horizontal ? o.dx : o.dy;
+  double _crossOf(Offset o) => _horizontal ? o.dy : o.dx;
+
+  /// Builds a screen-space offset from main + cross components.
+  Offset _axisOffset(double main, double cross) =>
+      _horizontal ? Offset(main, cross) : Offset(cross, main);
+
+  /// A page's displayed size in PDF points along the cross (fit) axis and
+  /// the main (scroll) axis, after /Rotate and view rotation. Vertical:
+  /// cross = width, main = height. Horizontal swaps them.
+  double _crossPointOf(int index) =>
+      _horizontal ? _aspects[index] * _pointWidths[index] : _pointWidths[index];
+  double _mainPointOf(int index) =>
+      _horizontal ? _pointWidths[index] : _aspects[index] * _pointWidths[index];
+
+  /// The largest cross-axis point size - the fit reference (widest page for
+  /// vertical, tallest for horizontal).
+  double get _maxCrossPoint => _horizontal ? _maxPointHeight : _maxPointWidth;
+
+  /// Logical pixels per PDF point at the fit baseline ([_layoutZoom] == 1,
+  /// transform identity): the reference page exactly fills the viewport's
+  /// cross axis (its width for vertical, its height for horizontal). The
+  /// public zoom is expressed against actual size (1 px/pt), so it is this
+  /// scale times the fit multiplier ([_currentZoom]).
+  double get _fitScale => (_maxCrossPoint <= 0 || _crossView <= 0)
+      ? 1
+      : _crossView / _maxCrossPoint;
+
+  /// Gesture/controller zoom clamps are expressed as fit multiples. On small
+  /// viewports the fit scale is less than actual size, so the stock 24x cap
+  /// used to top out below 2400% actual size. Keep the default generous
+  /// there without changing explicit host caps.
   double get _effectiveMaxZoom {
     if (widget.maxZoom != _defaultMaxZoom) return widget.maxZoom;
-    final fitWidth = _fitWidthScale;
-    if (!fitWidth.isFinite || fitWidth <= 0 || fitWidth >= 1) {
+    final fit = _fitScale;
+    if (!fit.isFinite || fit <= 0 || fit >= 1) {
       return widget.maxZoom;
     }
-    return math.max(widget.maxZoom, _defaultMaxZoom / fitWidth);
+    return math.max(widget.maxZoom, _defaultMaxZoom / fit);
   }
 
   /// The on-screen scale the user sees, in logical pixels per PDF point,
   /// where 1.0 is actual size (100%) - independent of the viewport. This is
   /// what [PdfViewerController.zoom] reports.
-  double get _displayScale => _currentZoom * _fitWidthScale;
+  double get _displayScale => _currentZoom * _fitScale;
 
-  /// The on-screen width of page [index] in the scroll list (logical
-  /// pixels), sized by its real point width so pages keep their true sizes
-  /// relative to one another rather than all stretching to the viewport.
-  double _pageWidth(int index) =>
-      _pointWidths[index] * _fitWidthScale * _layoutZoom;
+  /// A page's on-screen size (logical pixels) along the cross (fit) and main
+  /// (scroll) axes. Pages keep their true sizes relative to one another
+  /// rather than all stretching to the viewport.
+  double _pageCross(int index) =>
+      _crossPointOf(index) * _fitScale * _layoutZoom;
+  double _pageMain(int index) => _mainPointOf(index) * _fitScale * _layoutZoom;
 
-  /// Page rows fill the viewport width and center the page; this is the
-  /// page's left inset inside its row (0 for the widest page at fit-width).
-  double _pageLeft(int index) => (_viewWidth - _pageWidth(index)) / 2;
+  /// The page's inset along the cross axis: pages are centred on it (0 for
+  /// the reference page at fit).
+  double _crossInsetOf(int index) => (_crossView - _pageCross(index)) / 2;
 
-  /// The fraction of the viewport width page [index] occupies at the
-  /// current layout zoom - its real width relative to the widest page.
-  double _widthFactor(int index) =>
-      (_maxPointWidth <= 0 ? 1.0 : _pointWidths[index] / _maxPointWidth) *
-      _layoutZoom;
-
-  double _pageHeight(int index) => _aspects[index] * _pageWidth(index);
-
-  double _pageOffset(int index) {
+  /// The cumulative main-axis (scroll) offset at which page [index] begins.
+  double _mainOffsetOf(int index) {
     var offset = 0.0;
     for (var i = 0; i < index; i++) {
-      offset += _pageHeight(i) + widget.pageSpacing;
+      offset += _pageMain(i) + widget.pageSpacing;
     }
     return offset;
   }
 
+  /// The on-screen width of page [index] (logical pixels). Horizontal =
+  /// main size, vertical = cross size.
+  double _pageWidth(int index) =>
+      _horizontal ? _pageMain(index) : _pageCross(index);
+
+  /// The on-screen height of page [index] (logical pixels). Horizontal =
+  /// cross size, vertical = main size.
+  double _pageHeight(int index) =>
+      _horizontal ? _pageCross(index) : _pageMain(index);
+
+  /// The page's top-left corner in list (pre-transform) space: the cross
+  /// centring inset on one axis, the cumulative scroll offset on the other.
+  double _pageContentX(int index) =>
+      _horizontal ? _mainOffsetOf(index) : _crossInsetOf(index);
+  double _pageContentY(int index) =>
+      _horizontal ? _crossInsetOf(index) : _mainOffsetOf(index);
+
+  /// The list-space rect page [index] occupies.
+  Rect _pageContentRect(int index) => Rect.fromLTWH(_pageContentX(index),
+      _pageContentY(index), _pageWidth(index), _pageHeight(index));
+
+  /// The cross-axis size fraction page [index] fills at the current layout
+  /// zoom (its real cross size relative to the reference page) - the factor
+  /// for the [FractionallySizedBox] that centres it.
+  double _crossFactor(int index) =>
+      (_maxCrossPoint <= 0 ? 1.0 : _crossPointOf(index) / _maxCrossPoint) *
+      _layoutZoom;
+
   /// A page's slot extent in the scroll list, mirroring [itemExtentBuilder]:
   /// the leading [PdfViewer.pageSpacing] belongs to every page but the first.
   double _scrollExtentOf(int index) =>
-      _pageHeight(index) + (index == 0 ? 0 : widget.pageSpacing);
+      _pageMain(index) + (index == 0 ? 0 : widget.pageSpacing);
 
   /// The list-space offset at which page [index]'s slot begins.
   double _slotStart(int index) {
@@ -2108,15 +2262,15 @@ class _PdfViewerState extends State<PdfViewer>
     }
     final matrix = _transform.value;
     final scale = matrix.getMaxScaleOnAxis();
-    // Unproject the screen centre through the zoom window. The old
-    // scroll+viewport/2 calculation was only valid while the transform's
-    // vertical translation sat at its focal-centred default.
+    // Unproject the screen centre (along the scroll axis) through the zoom
+    // window. The old scroll+viewport/2 calculation was only valid while the
+    // transform's main-axis translation sat at its focal-centred default.
     final center = _scroll.offset +
-        (_viewHeight / 2 - matrix.storage[13]) /
+        (_mainView / 2 - matrix.storage[_mainTranslate]) /
             (scale.isFinite && scale > 0 ? scale : 1.0);
     var offset = 0.0;
     for (var i = 0; i < _pages.length; i++) {
-      offset += _pageHeight(i) + widget.pageSpacing;
+      offset += _pageMain(i) + widget.pageSpacing;
       if (center < offset) {
         _controller._setCurrentPage(i);
         return;
@@ -2132,11 +2286,11 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   /// While zoomed in, the screen viewport sees list space starting at
-  /// (pixels − t_y)/s (see _visibleFractionOf) - scroll targets must
-  /// shift by t_y/s, or every jump lands above where the user looks.
-  double get _zoomWindowDy {
+  /// (pixels − t_main)/s (see _visibleFractionOf) - scroll targets must
+  /// shift by t_main/s, or every jump lands off where the user looks.
+  double get _zoomWindowMain {
     final m = _transform.value;
-    return m.storage[13] / m.getMaxScaleOnAxis();
+    return m.storage[_mainTranslate] / m.getMaxScaleOnAxis();
   }
 
   Future<void> _jumpToPage(int index) async {
@@ -2144,10 +2298,10 @@ class _PdfViewerState extends State<PdfViewer>
     final targetIndex = index.clamp(0, _pages.length - 1);
     _jumpFocusPage = targetIndex;
     _renderScheduler.focus = targetIndex;
-    final target = _pageOffset(targetIndex) + _zoomWindowDy;
+    final target = _mainOffsetOf(targetIndex) + _zoomWindowMain;
     final clamped = target.clamp(0.0, _scroll.position.maxScrollExtent);
     final distance = (clamped - _scroll.position.pixels).abs();
-    if (distance > math.max(_viewHeight * 2, 2400.0)) {
+    if (distance > math.max(_mainView * 2, 2400.0)) {
       _warmJumpTargetPreview(targetIndex);
       _scroll.jumpTo(clamped);
       return;
@@ -2165,28 +2319,31 @@ class _PdfViewerState extends State<PdfViewer>
   PdfViewport? _captureViewport() {
     if (_viewWidth <= 0 || !_scroll.hasClients || _pages.isEmpty) return null;
     // the InteractiveViewer transform is scale + translation only, so the
-    // viewport's top-left unprojects to list space as (p - t) / s (see
-    // _visibleFractionOf)
+    // viewport's leading corner unprojects to list space as (p - t) / s (see
+    // _visibleFractionOf). PdfViewport.top holds the fraction along the
+    // scroll (main) axis, .left the fraction along the cross axis.
     final m = _transform.value;
     final scale = m.getMaxScaleOnAxis();
-    final viewTop = -m.storage[13] / scale + _scroll.position.pixels;
-    final viewLeft = -m.storage[12] / scale;
-    var top = 0.0;
+    final viewMain =
+        -m.storage[_mainTranslate] / scale + _scroll.position.pixels;
+    final viewCross = -m.storage[_crossTranslate] / scale;
+    var mainStart = 0.0;
     for (var i = 0; i < _pages.length; i++) {
-      final height = _pageHeight(i);
-      if (viewTop < top + height + widget.pageSpacing ||
+      final pageMain = _pageMain(i);
+      if (viewMain < mainStart + pageMain + widget.pageSpacing ||
           i == _pages.length - 1) {
-        final pageWidth = _pageWidth(i);
+        final pageCross = _pageCross(i);
         // fractions are layout-zoom independent: numerator and page size
         // scale together
         return PdfViewport(
           page: i,
-          top: height <= 0 ? 0 : (viewTop - top) / height,
-          left: pageWidth <= 0 ? 0 : (viewLeft - _pageLeft(i)) / pageWidth,
+          top: pageMain <= 0 ? 0 : (viewMain - mainStart) / pageMain,
+          left:
+              pageCross <= 0 ? 0 : (viewCross - _crossInsetOf(i)) / pageCross,
           zoom: _currentZoom,
         );
       }
-      top += height + widget.pageSpacing;
+      mainStart += pageMain + widget.pageSpacing;
     }
     return null;
   }
@@ -2226,26 +2383,28 @@ class _PdfViewerState extends State<PdfViewer>
   /// extents.
   void _placeViewport(PdfViewport viewport, int page) {
     if (_viewWidth <= 0 || _pages.isEmpty) return;
-    final listTop = _pageOffset(page) + viewport.top * _pageHeight(page);
+    final listMain = _mainOffsetOf(page) + viewport.top * _pageMain(page);
     final maxScroll = _scroll.position.maxScrollExtent;
     if (viewport.zoom <= 1) {
       _transform.value = Matrix4.identity();
-      _scroll.jumpTo(listTop.clamp(0.0, maxScroll));
+      _scroll.jumpTo(listMain.clamp(0.0, maxScroll));
     } else {
-      // zoom above fit-width rides the transform over fit-width pages, so
-      // the page is the full viewport width here (see _zoomTo)
+      // zoom above fit rides the transform over fit-laid-out pages (see
+      // _zoomTo). Solve (p - t) / s = target for each translation, matching
+      // the unprojection in _captureViewport / _visibleFractionOf; the page
+      // is centred on the cross axis, so its leading cross edge sits at
+      // _crossInsetOf and the stored fraction is into the page's own size.
       final scale = viewport.zoom.clamp(1.0, _effectiveMaxZoom);
-      final scroll = listTop.clamp(0.0, maxScroll);
-      // solve (p - t) / s = target for the translation, matching the
-      // unprojection in _captureViewport / _visibleFractionOf; the page is
-      // centered in the viewport-wide list, so its left edge sits at
-      // _pageLeft and the stored fraction is into the page's own width
-      final pageView = _pageLeft(page) + viewport.left * _pageWidth(page);
-      final tx = (-scale * pageView).clamp(_viewWidth * (1 - scale), 0.0);
-      final ty =
-          (scale * (scroll - listTop)).clamp(_viewHeight * (1 - scale), 0.0);
+      final scroll = listMain.clamp(0.0, maxScroll);
+      final crossView = _crossInsetOf(page) + viewport.left * _pageCross(page);
+      final tCross =
+          (-scale * crossView).clamp(_crossView * (1 - scale), 0.0);
+      final tMain =
+          (scale * (scroll - listMain)).clamp(_mainView * (1 - scale), 0.0);
+      final translate =
+          _axisOffset(tMain, tCross); // (main,cross) -> (x,y) storage
       _transform.value = Matrix4.identity()
-        ..translateByDouble(tx, ty, 0, 1)
+        ..translateByDouble(translate.dx, translate.dy, 0, 1)
         ..scaleByDouble(scale, scale, scale, 1);
       _scroll.jumpTo(scroll);
       setState(() => _zoomed = scale > 1.01);
@@ -2277,13 +2436,15 @@ class _PdfViewerState extends State<PdfViewer>
       viewSize: Size(pageWidth, _pageHeight(index)),
     );
     final target = geometry.toViewRect(rect);
-    // list space: pages are centered horizontally and stacked vertically
-    final center = target.center + Offset(_pageLeft(index), _pageOffset(index));
+    // list space: pages are centred on the cross axis and laid out along the
+    // main (scroll) axis
+    final center = target.center +
+        Offset(_pageContentX(index), _pageContentY(index));
     final fit = 0.4 *
         math.min(_viewWidth / math.max(target.width, 8),
             _viewHeight / math.max(target.height, 8));
     final scale = fit.clamp(1.0, _effectiveMaxZoom);
-    final scroll = (center.dy - _viewHeight / 2)
+    final scroll = (_mainOf(center) - _mainView / 2)
         .clamp(0.0, _scroll.position.maxScrollExtent);
     final Matrix4 end;
     if (scale <= 1.01) {
@@ -2292,12 +2453,13 @@ class _PdfViewerState extends State<PdfViewer>
       // the viewport unprojects to list space as (p - t) / s (see
       // _visibleFractionOf); solve its center = `center` for t, with the
       // scroll offset the list actually reaches
-      final tx = (_viewWidth / 2 - scale * center.dx)
-          .clamp(_viewWidth * (1 - scale), 0.0);
-      final ty = (scale * (scroll - center.dy) + _viewHeight / 2)
-          .clamp(_viewHeight * (1 - scale), 0.0);
+      final tCross = (_crossView / 2 - scale * _crossOf(center))
+          .clamp(_crossView * (1 - scale), 0.0);
+      final tMain = (scale * (scroll - _mainOf(center)) + _mainView / 2)
+          .clamp(_mainView * (1 - scale), 0.0);
+      final translate = _axisOffset(tMain, tCross);
       end = Matrix4.identity()
-        ..translateByDouble(tx, ty, 0, 1)
+        ..translateByDouble(translate.dx, translate.dy, 0, 1)
         ..scaleByDouble(scale, scale, scale, 1);
     }
     _zoomAnimation = Matrix4Tween(begin: _transform.value, end: end).animate(
@@ -2395,17 +2557,18 @@ class _PdfViewerState extends State<PdfViewer>
       return null;
     }
     // the InteractiveViewer transform is scale + translation only, so the
-    // viewport unprojects to list space as (p - t) / s
+    // viewport unprojects to list space as (p - t) / s; the scroll offset
+    // adds along the main (scroll) axis only
     final m = _transform.value;
     final scale = m.getMaxScaleOnAxis();
+    final base = _scroll.position.pixels;
     final view = Rect.fromLTWH(
-      -m.storage[12] / scale,
-      -m.storage[13] / scale + _scroll.position.pixels,
+      -m.storage[12] / scale + (_horizontal ? base : 0),
+      -m.storage[13] / scale + (_horizontal ? 0 : base),
       _viewWidth / scale,
       _viewHeight / scale,
     );
-    final pageRect = Rect.fromLTWH(_pageLeft(index), _pageOffset(index),
-        _pageWidth(index), _pageHeight(index));
+    final pageRect = _pageContentRect(index);
     if (pageRect.isEmpty) return null;
     final overlap = view.intersect(pageRect);
     if (overlap.width <= 0 || overlap.height <= 0) return null;
@@ -2422,24 +2585,25 @@ class _PdfViewerState extends State<PdfViewer>
   /// user space.
   (int, double, double)? _pagePointAt(Offset local) {
     if (_viewWidth <= 0 || !_scroll.hasClients || _pages.isEmpty) return null;
-    final contentY = _scroll.offset + local.dy;
-    var top = 0.0;
+    // list space: the scroll offset is only along the main axis
+    final contentMain = _scroll.offset + _mainOf(local);
+    final point = _axisOffset(contentMain, _crossOf(local));
+    var mainStart = 0.0;
     for (var i = 0; i < _pages.length; i++) {
-      final height = _pageHeight(i);
-      if (contentY <= top + height || i == _pages.length - 1) {
+      final pageMain = _pageMain(i);
+      if (contentMain <= mainStart + pageMain || i == _pages.length - 1) {
         final box = _pages[i].cropBox;
         if (box.width <= 0 || box.height <= 0) return null;
-        final pageWidth = _pageWidth(i);
         final geometry = PdfPageGeometry(
           cropBox: box,
           rotation: _pages[i].rotation,
-          viewSize: Size(pageWidth, height),
+          viewSize: Size(_pageWidth(i), _pageHeight(i)),
         );
-        final (x, y) = geometry
-            .toPagePoint(Offset(local.dx - _pageLeft(i), contentY - top));
+        final (x, y) = geometry.toPagePoint(
+            point - Offset(_pageContentX(i), _pageContentY(i)));
         return (i, x, y);
       }
-      top += height + widget.pageSpacing;
+      mainStart += pageMain + widget.pageSpacing;
     }
     return null;
   }
@@ -2453,16 +2617,18 @@ class _PdfViewerState extends State<PdfViewer>
   /// claim those canvas drags while leaving page gestures to the editor.
   bool _pageContainsListPoint(Offset local) {
     if (_viewWidth <= 0 || !_scroll.hasClients || _pages.isEmpty) return false;
-    final contentY = _scroll.offset + local.dy;
-    var top = 0.0;
+    final contentMain = _scroll.offset + _mainOf(local);
+    final contentCross = _crossOf(local);
+    var mainStart = 0.0;
     for (var i = 0; i < _pages.length; i++) {
-      final height = _pageHeight(i);
-      if (contentY < top) return false; // the spacing before this page
-      if (contentY <= top + height) {
-        final left = _pageLeft(i);
-        return local.dx >= left && local.dx <= left + _pageWidth(i);
+      final pageMain = _pageMain(i);
+      if (contentMain < mainStart) return false; // the spacing before it
+      if (contentMain <= mainStart + pageMain) {
+        final crossStart = _crossInsetOf(i);
+        return contentCross >= crossStart &&
+            contentCross <= crossStart + _pageCross(i);
       }
-      top += height + widget.pageSpacing;
+      mainStart += pageMain + widget.pageSpacing;
     }
     return false;
   }
@@ -2503,11 +2669,12 @@ class _PdfViewerState extends State<PdfViewer>
     // [from] is the picture's source anchor and must stay in source view
     // space (paintAnnotationDragPreview places the picture relative to it);
     // only [to] moves into this page's view space. Pages of different sizes
-    // sit at different left insets in the centered row, so shift x as well
-    // as y when mapping between their view spaces.
-    final dy = _pageTop(preview.pageIndex) - _pageTop(index);
-    final dx = _pageLeft(preview.pageIndex) - _pageLeft(index);
-    final to = preview.to.shift(Offset(dx, dy));
+    // sit at different insets in the centred row/column, so shift by the
+    // difference of their content-space top-left corners.
+    final to = preview.to.shift(Offset(
+      _pageContentX(preview.pageIndex) - _pageContentX(index),
+      _pageContentY(preview.pageIndex) - _pageContentY(index),
+    ));
     final pageBox = Offset.zero & Size(_pageWidth(index), _pageHeight(index));
     if (!to.overlaps(pageBox)) return null;
     return PdfMoveDragPreview(
@@ -2517,15 +2684,6 @@ class _PdfViewerState extends State<PdfViewer>
       to: to,
       scale: preview.scale,
     );
-  }
-
-  /// The cumulative top offset (list coordinates) of page [index].
-  double _pageTop(int index) {
-    var top = 0.0;
-    for (var i = 0; i < index; i++) {
-      top += _pageHeight(i) + widget.pageSpacing;
-    }
-    return top;
   }
 
   /// The laid-out geometry of page [index], or null when it isn't
@@ -2546,10 +2704,9 @@ class _PdfViewerState extends State<PdfViewer>
   /// marquee dragged past the page edge still maps to sensible (possibly
   /// out-of-page) user-space coordinates.
   Offset _toPageView(int index, Offset local) {
-    return Offset(
-      local.dx - _pageLeft(index),
-      _scroll.offset + local.dy - _pageTop(index),
-    );
+    final content =
+        _axisOffset(_scroll.offset + _mainOf(local), _crossOf(local));
+    return content - Offset(_pageContentX(index), _pageContentY(index));
   }
 
   /// Maps a pointer position to a text position. [tolerance] is in page
@@ -3029,12 +3186,24 @@ class _PdfViewerState extends State<PdfViewer>
   void _scrollToDestination(PdfDestination destination) {
     if (!_scroll.hasClients) return;
     final index = destination.pageIndex.clamp(0, _pages.length - 1);
-    var target = _pageOffset(index) + _zoomWindowDy;
+    var target = _mainOffsetOf(index) + _zoomWindowMain;
     final box = _pages[index].cropBox;
-    final top = destination.top;
-    if (top != null && box.height > 0) {
-      final fractionDown = ((box.top - top) / box.height).clamp(0.0, 1.0);
-      target += fractionDown * _pageHeight(index);
+    // The destination's main-axis offset into the page: a /FitH-style top
+    // (vertical) drives a vertical layout's scroll; a horizontal layout
+    // scrolls to the destination's left (horizontal) instead. The other
+    // axis is fully in view at fit, so it is left to the zoom window.
+    if (_horizontal) {
+      final left = destination.left;
+      if (left != null && box.width > 0) {
+        final fraction = ((left - box.left) / box.width).clamp(0.0, 1.0);
+        target += fraction * _pageMain(index);
+      }
+    } else {
+      final top = destination.top;
+      if (top != null && box.height > 0) {
+        final fraction = ((box.top - top) / box.height).clamp(0.0, 1.0);
+        target += fraction * _pageMain(index);
+      }
     }
     _scroll.animateTo(
       target.clamp(0.0, _scroll.position.maxScrollExtent),
@@ -3675,18 +3844,18 @@ class _PdfViewerState extends State<PdfViewer>
   /// transform); the scroll extents absorb what they can and the rest
   /// pans the zoom window, like the scrollbars.
   void _grabPanBy(Offset delta) {
-    _scrollbarScrollBy(-delta.dy);
-    _scrollbarPanBy(-delta.dx);
+    _scrollbarScrollBy(-_mainOf(delta));
+    _scrollbarPanBy(-_crossOf(delta));
   }
 
   /// Grab panning from a touch gesture - allows rubber-band over-scroll
-  /// on the horizontal axis so the edge doesn't snap.
+  /// on the cross axis so the edge doesn't snap.
   void _touchGrabPanBy(Offset delta) {
     _touchPanning = true;
     _beginMotionRenderHold();
     _hBounceController.stop();
-    _scrollbarScrollBy(-delta.dy);
-    _scrollbarPanBy(-delta.dx);
+    _scrollbarScrollBy(-_mainOf(delta));
+    _scrollbarPanBy(-_crossOf(delta));
   }
 
   /// How thick the viewport's auto-scroll edge band is (logical px) and how
@@ -3744,7 +3913,7 @@ class _PdfViewerState extends State<PdfViewer>
     _hBounceController.stop();
     final v = velocity.pixelsPerSecond;
     if (v.distance < kMinFlingVelocity) {
-      _springBackHorizontal();
+      _springBackCross();
       return;
     }
     _flingSimX =
@@ -3782,7 +3951,7 @@ class _PdfViewerState extends State<PdfViewer>
   void _onTouchFlingStatus(AnimationStatus status) {
     if (status == AnimationStatus.completed ||
         status == AnimationStatus.dismissed) {
-      _springBackHorizontal();
+      _springBackCross();
     }
   }
 
@@ -3843,13 +4012,21 @@ class _PdfViewerState extends State<PdfViewer>
     if (!_scroll.hasClients || _viewWidth <= 0) return;
     final page = _pages[match.pageIndex];
     final box = page.cropBox;
-    var target = _pageOffset(match.pageIndex) + _zoomWindowDy;
-    if (match.rects.isNotEmpty && box.height > 0) {
-      // place the match a third of the way down the screen viewport -
-      // which, zoomed in, covers 1/s of the list's space
+    var target = _mainOffsetOf(match.pageIndex) + _zoomWindowMain;
+    if (match.rects.isNotEmpty) {
+      // place the match a third of the way into the screen viewport along
+      // the scroll axis - which, zoomed in, covers 1/s of the list's space
       final scale = _transform.value.getMaxScaleOnAxis();
-      final fractionDown = (box.top - match.rects.first.top) / box.height;
-      target += fractionDown * _pageHeight(match.pageIndex) -
+      final rect = match.rects.first;
+      // fraction along the main (scroll) axis: down the page for a vertical
+      // layout, across it for a horizontal one
+      final double fraction;
+      if (_horizontal) {
+        fraction = box.width > 0 ? (rect.left - box.left) / box.width : 0;
+      } else {
+        fraction = box.height > 0 ? (box.top - rect.top) / box.height : 0;
+      }
+      target += fraction * _pageMain(match.pageIndex) -
           _scroll.position.viewportDimension / (3 * scale);
     }
     _scroll.animateTo(
@@ -3912,7 +4089,7 @@ class _PdfViewerState extends State<PdfViewer>
     if ((current - 1).abs() > 0.01) {
       // from any zoom - in or out - back to 100%
       if (_layoutZoom < 1) {
-        _setLayoutZoom(1, focalY: details.localPosition.dy);
+        _setLayoutZoom(1, focalMain: _mainOf(details.localPosition));
       }
       end = Matrix4.identity();
       zoomedAfter = false;
@@ -3968,7 +4145,7 @@ class _PdfViewerState extends State<PdfViewer>
 
   void _onPinchEnd(ScaleEndDetails details) {
     _settleZoomGesture();
-    _springBackHorizontal();
+    _springBackCross();
   }
 
   /// A one-finger touch pan after zoom must drive both the list scroll extent
@@ -3992,7 +4169,7 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   void _onZoomedTouchPanCancel() {
-    _springBackHorizontal();
+    _springBackCross();
   }
 
   bool _zoomedTouchPanEnabledAt(Offset localPosition) {
@@ -4016,9 +4193,9 @@ class _PdfViewerState extends State<PdfViewer>
   /// Settles a finished zoom gesture into the layout/transform regime
   /// split: total zoom at or below 1 lives in the page layout, above 1
   /// in the InteractiveViewer transform. Shared by touch pinches and
-  /// InteractiveViewer's own gesture end. Vertical translation is always
-  /// hard-clamped; horizontal is left untouched so [_springBackHorizontal]
-  /// can animate it back smoothly.
+  /// InteractiveViewer's own gesture end. The main (scroll) translation is
+  /// always hard-clamped; the cross axis is left untouched so
+  /// [_springBackCross] can animate it back smoothly.
   void _settleZoomGesture() {
     final total = _transform.value.getMaxScaleOnAxis() * _layoutZoom;
     if (total <= 1) {
@@ -4032,10 +4209,10 @@ class _PdfViewerState extends State<PdfViewer>
         ..translateByDouble(_viewWidth / 2, _viewHeight / 2, 0, 1)
         ..scaleByDouble(fold, fold, fold, 1)
         ..translateByDouble(-_viewWidth / 2, -_viewHeight / 2, 0, 1);
-      _transform.value = _clampedTransformVerticalOnly(matrix);
+      _transform.value = _clampedTransformMainOnly(matrix);
     } else {
       _transform.value =
-          _clampedTransformVerticalOnly(_transform.value.clone());
+          _clampedTransformMainOnly(_transform.value.clone());
     }
     final zoomed = _transform.value.getMaxScaleOnAxis() > 1.01;
     if (zoomed != _zoomed) setState(() => _zoomed = zoomed);
@@ -4044,11 +4221,11 @@ class _PdfViewerState extends State<PdfViewer>
   // --- trackpad gestures ---
   //
   // A dedicated recognizer owns every trackpad pan-zoom gesture (see
-  // _TrackpadPanRecognizer): vertical deltas scroll the list 1:1 with the
+  // _TrackpadPanRecognizer): main-axis deltas scroll the list 1:1 with the
   // fingers on screen (spilling into the zoom window's translation at the
   // scroll extents, so the document's ends stay reachable while zoomed),
-  // horizontal deltas pan the zoom window, and pinch zooms around the
-  // gesture's focal point. Lifting off feeds vertical velocity back through
+  // cross-axis deltas pan the zoom window, and pinch zooms around the
+  // gesture's focal point. Lifting off feeds main-axis velocity back through
   // the same direct pan path as live scrolling; the list's ScrollPhysics may
   // be disabled while editing, but trackpad momentum should still continue.
 
@@ -4104,19 +4281,21 @@ class _PdfViewerState extends State<PdfViewer>
 
     final matrix = _transform.value.clone();
     final scale = matrix.getMaxScaleOnAxis();
-    matrix.storage[12] += delta.dx;
+    // cross axis: pan the zoom window directly
+    matrix.storage[_crossTranslate] += _crossOf(delta);
 
-    // vertical: scroll the list (deltas are screen pixels; the list lives
+    // main axis: scroll the list (deltas are screen pixels; the list lives
     // under the zoom transform). Whatever the extents can't absorb pans
-    // the zoom window instead, so the very top and bottom of the document
-    // are reachable at any zoom.
-    if (_scroll.hasClients && delta.dy != 0) {
+    // the zoom window instead, so the very ends of the document are
+    // reachable at any zoom.
+    final mainDelta = _mainOf(delta);
+    if (_scroll.hasClients && mainDelta != 0) {
       final position = _scroll.position;
-      final target = position.pixels - delta.dy / scale;
+      final target = position.pixels - mainDelta / scale;
       final clamped =
           target.clamp(position.minScrollExtent, position.maxScrollExtent);
       if (clamped != position.pixels) position.jumpTo(clamped);
-      matrix.storage[13] += (clamped - target) * scale;
+      matrix.storage[_mainTranslate] += (clamped - target) * scale;
     }
     _transform.value = _clampedTransform(matrix);
   }
@@ -4134,25 +4313,28 @@ class _PdfViewerState extends State<PdfViewer>
       _scheduleMotionRenderHoldRelease();
       return;
     }
-    // Continue vertical momentum through the same direct path used during
+    // Continue main-axis momentum through the same direct path used during
     // the gesture. `goBallistic` is tempting here, but it goes through the
     // list's ScrollPhysics; with an edit tool armed those physics are
     // deliberately NeverScrollable, so a real trackpad fling stops as if it
     // had hit an edge.
-    if (_scroll.hasClients && velocity.dy.abs() > kMinFlingVelocity) {
-      _flingViewport(Velocity(pixelsPerSecond: Offset(0, velocity.dy / scale)));
+    final mainVel = _mainOf(velocity);
+    final crossVel = _crossOf(velocity);
+    if (_scroll.hasClients && mainVel.abs() > kMinFlingVelocity) {
+      _flingViewport(
+          Velocity(pixelsPerSecond: _axisOffset(mainVel / scale, 0)));
     }
-    // horizontal momentum continues in the zoom window's translation,
-    // with the same friction InteractiveViewer uses for its flings
-    if (zoomed && velocity.dx.abs() > kMinFlingVelocity) {
+    // cross-axis momentum continues in the zoom window's translation, with
+    // the same friction InteractiveViewer uses for its flings
+    if (zoomed && crossVel.abs() > kMinFlingVelocity) {
       _panFlinger.animateWith(FrictionSimulation(
-          0.0000135, _transform.value.storage[12], velocity.dx));
+          0.0000135, _transform.value.storage[_crossTranslate], crossVel));
     }
     _scheduleMotionRenderHoldRelease();
   }
 
-  /// One frame of the horizontal fling: moves the zoom window's
-  /// x-translation along the friction simulation, stopping at the edges.
+  /// One frame of the cross-axis fling: moves the zoom window's free
+  /// translation along the friction simulation, stopping at the edges.
   void _onPanFlingTick() {
     final matrix = _transform.value.clone();
     final scale = matrix.getMaxScaleOnAxis();
@@ -4160,9 +4342,9 @@ class _PdfViewerState extends State<PdfViewer>
       _panFlinger.stop();
       return;
     }
-    final min = _viewWidth * (1 - scale);
+    final min = _crossView * (1 - scale);
     final value = _panFlinger.value;
-    matrix.storage[12] = value.clamp(min, 0.0);
+    matrix.storage[_crossTranslate] = value.clamp(min, 0.0);
     _transform.value = matrix;
     if (value <= min || value >= 0) _panFlinger.stop();
   }
@@ -4179,50 +4361,51 @@ class _PdfViewerState extends State<PdfViewer>
     return matrix;
   }
 
-  /// Like [_clampedTransform] but only clamps the vertical axis, leaving
-  /// the horizontal translation untouched (for rubber-band over-scroll).
-  Matrix4 _clampedTransformVerticalOnly(Matrix4 matrix) {
+  /// Like [_clampedTransform] but only clamps the main (scroll) axis,
+  /// leaving the cross translation untouched (for rubber-band over-scroll).
+  Matrix4 _clampedTransformMainOnly(Matrix4 matrix) {
     final scale = matrix.getMaxScaleOnAxis();
     if (scale <= 1.01) return Matrix4.identity();
     final s = matrix.storage;
-    s[13] = s[13].clamp(_viewHeight * (1 - scale), 0.0);
+    s[_mainTranslate] =
+        s[_mainTranslate].clamp(_mainView * (1 - scale), 0.0);
     return matrix;
   }
 
-  /// Rubber-band damping for the horizontal translation: within bounds
-  /// returns [tx] unchanged; past the edge, excess motion is dampened
+  /// Rubber-band damping for the cross-axis translation: within bounds
+  /// returns [t] unchanged; past the edge, excess motion is dampened
   /// logarithmically (the further past the edge, the harder it resists).
   /// Matches the iOS UIScrollView rubber-band feel.
-  double _rubberBandClamp(double tx, double scale) {
-    final min = _viewWidth * (1 - scale);
-    if (tx >= min && tx <= 0) return tx;
-    final limit = _viewWidth * 0.5;
-    if (tx > 0) {
-      return limit * (1 - math.exp(-tx / limit));
+  double _rubberBandClamp(double t, double scale) {
+    final min = _crossView * (1 - scale);
+    if (t >= min && t <= 0) return t;
+    final limit = _crossView * 0.5;
+    if (t > 0) {
+      return limit * (1 - math.exp(-t / limit));
     } else {
-      final overshoot = min - tx;
+      final overshoot = min - t;
       return min - limit * (1 - math.exp(-overshoot / limit));
     }
   }
 
-  /// How far the horizontal translation is past the content bounds (> 0
+  /// How far the cross-axis translation is past the content bounds (> 0
   /// means overshot), or 0 when within bounds.
-  double _horizontalOverscroll() {
+  double _crossOverscroll() {
     final matrix = _transform.value;
     final scale = matrix.getMaxScaleOnAxis();
     if (scale <= 1.01) return 0;
-    final tx = matrix.storage[12];
-    final min = _viewWidth * (1 - scale);
-    if (tx > 0) return tx;
-    if (tx < min) return tx - min;
+    final t = matrix.storage[_crossTranslate];
+    final min = _crossView * (1 - scale);
+    if (t > 0) return t;
+    if (t < min) return t - min;
     return 0;
   }
 
-  /// If the horizontal translation is past the content edge, animates it
+  /// If the cross-axis translation is past the content edge, animates it
   /// back with a spring. Called when a touch gesture ends.
-  void _springBackHorizontal() {
+  void _springBackCross() {
     _touchPanning = false;
-    final overscroll = _horizontalOverscroll();
+    final overscroll = _crossOverscroll();
     if (overscroll.abs() < 0.5) {
       // close enough - just clamp
       if (overscroll != 0) {
@@ -4231,27 +4414,27 @@ class _PdfViewerState extends State<PdfViewer>
       _scheduleMotionRenderHoldRelease();
       return;
     }
-    final tx = _transform.value.storage[12];
+    final t = _transform.value.storage[_crossTranslate];
     final scale = _transform.value.getMaxScaleOnAxis();
-    final min = _viewWidth * (1 - scale);
-    final target = tx > 0 ? 0.0 : min;
+    final min = _crossView * (1 - scale);
+    final target = t > 0 ? 0.0 : min;
     _hBounceController
-        .animateWith(SpringSimulation(_hBounceSpring, tx, target, 0));
+        .animateWith(SpringSimulation(_hBounceSpring, t, target, 0));
     _scheduleMotionRenderHoldRelease();
   }
 
   static const SpringDescription _hBounceSpring =
       SpringDescription(mass: 1, stiffness: 400, damping: 30);
 
-  void _onHorizontalBounceTick() {
+  void _onCrossBounceTick() {
     final matrix = _transform.value.clone();
     final scale = matrix.getMaxScaleOnAxis();
     if (scale <= 1.01) {
       _hBounceController.stop();
       return;
     }
-    matrix.storage[12] = _hBounceController.value;
-    _transform.value = _clampedTransformVerticalOnly(matrix);
+    matrix.storage[_crossTranslate] = _hBounceController.value;
+    _transform.value = _clampedTransformMainOnly(matrix);
   }
 
   /// Scrollbar motion, in list-space pixels: the scroll extents absorb
@@ -4268,30 +4451,38 @@ class _PdfViewerState extends State<PdfViewer>
     final matrix = _transform.value.clone();
     final scale = matrix.getMaxScaleOnAxis();
     if (scale > 1.01) {
-      matrix.storage[13] += (clamped - target) * scale;
+      matrix.storage[_mainTranslate] += (clamped - target) * scale;
       _transform.value = _touchPanning
-          ? _clampedTransformVerticalOnly(matrix)
+          ? _clampedTransformMainOnly(matrix)
           : _clampedTransform(matrix);
     }
   }
 
-  /// Horizontal scrollbar motion, in list-space pixels. Sideways overflow
-  /// exists only inside the zoom window, so this pans the transform.
-  /// During a touch gesture ([_touchPanning]) the clamp is replaced by
-  /// rubber-band resistance so the edge doesn't snap.
+  /// Cross-axis (zoom-window) pan, in list-space pixels. Cross-axis overflow
+  /// exists only inside the zoom window, so this pans the transform. During
+  /// a touch gesture ([_touchPanning]) the clamp is replaced by rubber-band
+  /// resistance so the edge doesn't snap.
   void _scrollbarPanBy(double delta) {
     final matrix = _transform.value.clone();
     final scale = matrix.getMaxScaleOnAxis();
     if (scale <= 1.01) return;
-    final tx = matrix.storage[12] - delta * scale;
+    final t = matrix.storage[_crossTranslate] - delta * scale;
     if (_touchPanning) {
-      matrix.storage[12] = _rubberBandClamp(tx, scale);
-      _transform.value = _clampedTransformVerticalOnly(matrix);
+      matrix.storage[_crossTranslate] = _rubberBandClamp(t, scale);
+      _transform.value = _clampedTransformMainOnly(matrix);
     } else {
-      matrix.storage[12] = tx;
+      matrix.storage[_crossTranslate] = t;
       _transform.value = _clampedTransform(matrix);
     }
   }
+
+  /// Anchors a [PdfScrollbar] to the viewer edge for its orientation: a
+  /// vertical bar to the right (full height), a horizontal bar to the bottom
+  /// (inset so the bottom-right corner belongs to the vertical bar).
+  Widget _positionedScrollbar(PdfScrollbar bar) => bar.axis == Axis.vertical
+      ? Positioned(top: 0, bottom: 0, right: 0, child: bar)
+      : Positioned(
+          left: 0, right: PdfScrollbar.hitExtent, bottom: 0, child: bar);
 
   @override
   Widget build(BuildContext context) {
@@ -4312,11 +4503,16 @@ class _PdfViewerState extends State<PdfViewer>
     final marqueeColor = PdfViewerTheme.of(context).annotationChromeColor ??
         const Color(0xFF1E88E5);
     return LayoutBuilder(builder: (context, constraints) {
-      // _viewWidth still holds the previous layout's width here; a change
-      // rescales every page, so pin the reading position before adopting it
-      // (skips the very first layout, where there is nothing to preserve).
+      // _viewWidth/_viewHeight still hold the previous layout's size here; a
+      // change to the cross (fit) dimension rescales every page, so pin the
+      // reading position before adopting it (skips the very first layout,
+      // where there is nothing to preserve).
+      final newCross =
+          _horizontal ? constraints.maxHeight : constraints.maxWidth;
+      final oldCross = _horizontal ? _viewHeight : _viewWidth;
       if (_viewWidth > 0 &&
-          constraints.maxWidth != _viewWidth &&
+          _viewHeight > 0 &&
+          newCross != oldCross &&
           _scroll.hasClients &&
           _pages.isNotEmpty) {
         _preserveReadingAnchor();
@@ -4340,17 +4536,17 @@ class _PdfViewerState extends State<PdfViewer>
           });
         } else if (!_appliedInitialFit) {
           _appliedInitialFit = true;
-          // PdfViewerFit.width fills the viewport with the widest page
-          // (layout zoom 1); PdfViewerFit.page shrinks until the whole
-          // first page fits in height as well. Either way pages keep their
-          // real relative sizes - a narrower page lays out narrower.
-          final firstHeightAtFullWidth = _aspects.isNotEmpty
-              ? _aspects.first * _pointWidths.first * _fitWidthScale
-              : 0.0;
+          // PdfViewerFit.width fills the viewport's cross axis with the
+          // reference page (layout zoom 1); PdfViewerFit.page shrinks until
+          // the whole first page fits along the main axis too. Either way
+          // pages keep their real relative sizes - a narrower page lays out
+          // narrower. (For a horizontal layout "width"/"page" read as the
+          // cross/both axes respectively.)
+          final firstMainAtFit =
+              _pages.isNotEmpty ? _mainPointOf(0) * _fitScale : 0.0;
           _layoutZoom = widget.initialFit == PdfViewerFit.page &&
-                  firstHeightAtFullWidth > 0
-              ? (_viewHeight / firstHeightAtFullWidth)
-                  .clamp(widget.minZoom, 1.0)
+                  firstMainAtFit > 0
+              ? (_mainView / firstMainAtFit).clamp(widget.minZoom, 1.0)
               : 1.0;
         }
       }
@@ -4360,6 +4556,7 @@ class _PdfViewerState extends State<PdfViewer>
       // transform instead (_PdfScrollbar below).
       final list = ExactExtentListView.builder(
         controller: _scroll,
+        scrollDirection: widget.pageLayout.scrollAxis,
         // with a tool armed, touch drags belong to the editing overlay -
         // the list's drag recognizer would win vertical-ish strokes in
         // the arena otherwise. Desktop trackpad gestures are unaffected
@@ -4379,17 +4576,22 @@ class _PdfViewerState extends State<PdfViewer>
         // jump (AMT-SP-101: 93k↔162k px between frames).
         itemExtentBuilder: (index, dimensions) => index >= _pages.length
             ? null
-            : _pageHeight(index) + (index == 0 ? 0 : widget.pageSpacing),
+            : _pageMain(index) + (index == 0 ? 0 : widget.pageSpacing),
         itemCount: _pages.length,
-        padding: EdgeInsets.only(bottom: widget.pageSpacing),
+        padding: _horizontal
+            ? EdgeInsets.only(right: widget.pageSpacing)
+            : EdgeInsets.only(bottom: widget.pageSpacing),
         itemBuilder: (context, index) => Padding(
-          padding: EdgeInsets.only(top: index == 0 ? 0 : widget.pageSpacing),
-          // each page lays out at its real width relative to the widest
-          // page (times the layout zoom), centered - so pages keep their
-          // true sizes instead of all stretching to the viewport width
+          padding: _horizontal
+              ? EdgeInsets.only(left: index == 0 ? 0 : widget.pageSpacing)
+              : EdgeInsets.only(top: index == 0 ? 0 : widget.pageSpacing),
+          // each page lays out at its real size relative to the reference
+          // page (times the layout zoom), centred on the cross axis - so
+          // pages keep their true sizes instead of stretching to the viewport
           child: Center(
             child: FractionallySizedBox(
-              widthFactor: _widthFactor(index),
+              widthFactor: _horizontal ? null : _crossFactor(index),
+              heightFactor: _horizontal ? _crossFactor(index) : null,
               child: _PdfViewerPage(
                 page: _pages[index],
                 effectiveRotation: _effectiveRotation(index),
@@ -4589,7 +4791,7 @@ class _PdfViewerState extends State<PdfViewer>
                   // the eager pinch recognizer's
                   onInteractionEnd: (_) {
                     _settleZoomGesture();
-                    _springBackHorizontal();
+                    _springBackCross();
                   },
                   // all trackpad pan-zoom gestures are handled here, never by
                   // the list's drag recognizer (whose iOS-style velocity
@@ -4772,35 +4974,29 @@ class _PdfViewerState extends State<PdfViewer>
                     ),
                   ),
                 ),
-                // outside the zoom transform, so they keep their place
-                // and size at any zoom
-                Positioned(
-                  top: 0,
-                  bottom: 0,
-                  right: 0,
-                  child: PdfScrollbar(
-                    axis: Axis.vertical,
-                    scroll: _scroll,
-                    transform: _transform,
-                    minOverflow: widget.pageSpacing,
-                    onScrollBy: _scrollbarScrollBy,
-                    thumbKey: const ValueKey('pdf-scrollbar-thumb'),
-                  ),
-                ),
-                // appears only while zoomed in (the only sideways
-                // overflow); inset so the corner stays the vertical bar's
-                Positioned(
-                  left: 0,
-                  right: PdfScrollbar.hitExtent,
-                  bottom: 0,
-                  child: PdfScrollbar(
-                    axis: Axis.horizontal,
-                    transform: _transform,
-                    viewExtent: _viewWidth,
-                    onScrollBy: _scrollbarPanBy,
-                    thumbKey: const ValueKey('pdf-hscrollbar-thumb'),
-                  ),
-                ),
+                // outside the zoom transform, so they keep their place and
+                // size at any zoom. The main bar rides the scroll axis (the
+                // layout axis); the cross bar appears only while zoomed in
+                // (the only overflow across the fit axis). A bar is placed by
+                // its own orientation - a vertical bar hugs the right edge, a
+                // horizontal one the bottom (inset so the corner is the
+                // vertical bar's) - so the two never collide whichever axis
+                // is which.
+                _positionedScrollbar(PdfScrollbar(
+                  axis: widget.pageLayout.scrollAxis,
+                  scroll: _scroll,
+                  transform: _transform,
+                  minOverflow: widget.pageSpacing,
+                  onScrollBy: _scrollbarScrollBy,
+                  thumbKey: const ValueKey('pdf-scrollbar-thumb'),
+                )),
+                _positionedScrollbar(PdfScrollbar(
+                  axis: _horizontal ? Axis.vertical : Axis.horizontal,
+                  transform: _transform,
+                  viewExtent: _crossView,
+                  onScrollBy: _scrollbarPanBy,
+                  thumbKey: const ValueKey('pdf-hscrollbar-thumb'),
+                )),
               ]),
             ),
           ),

--- a/packages/dart_pdf_editor/lib/src/scrollbar.dart
+++ b/packages/dart_pdf_editor/lib/src/scrollbar.dart
@@ -32,9 +32,11 @@ class PdfScrollbar extends StatefulWidget {
     this.viewExtent,
     this.onScrollBy,
     this.thumbKey,
-  })  : assert(axis == Axis.vertical ? scroll != null : viewExtent != null),
-        assert(axis == Axis.vertical || transform != null,
-            'a horizontal bar measures overflow from the transform'),
+  })  : assert(scroll != null || viewExtent != null,
+            'a scroll-driven bar needs a controller; a transform-only bar '
+            'needs the cross-axis view extent'),
+        assert(scroll != null || transform != null,
+            'a transform-only bar measures overflow from the transform'),
         assert(onScrollBy != null || scroll != null);
 
   /// How much room bars reserve: the viewer's horizontal bar is inset
@@ -85,12 +87,22 @@ class _PdfScrollbarState extends State<PdfScrollbar> {
 
   bool get _vertical => widget.axis == Axis.vertical;
 
+  /// Whether this bar tracks a real [ScrollController] (the layout's main
+  /// axis) rather than measuring overflow purely from the zoom transform
+  /// (the cross axis, which overflows only while zoomed in). Independent of
+  /// orientation: a horizontal continuous layout has a scroll-driven
+  /// *horizontal* main bar and a transform-only *vertical* cross bar.
+  bool get _scrollDriven => widget.scroll != null;
+
+  /// This bar's translation index into the zoom transform, by orientation.
+  int get _translateIndex => _vertical ? 13 : 12;
+
   double get _scale => widget.transform?.value.getMaxScaleOnAxis() ?? 1;
 
   /// (laid-out extent, visible extent) along the axis, in list-space
   /// pixels, or null while there are no metrics yet.
   (double, double)? _extents() {
-    if (_vertical) {
+    if (_scrollDriven) {
       final scroll = widget.scroll!;
       // exactly one: a host swapping its list's slot in the tree leaves
       // both the old and new positions attached for one frame
@@ -100,21 +112,22 @@ class _PdfScrollbarState extends State<PdfScrollbar> {
       final total = position.maxScrollExtent + position.viewportDimension;
       return (total, position.viewportDimension / _scale);
     }
-    // horizontally the pages always lay out at the viewer width;
+    // the cross axis always lays out at the viewer's cross extent;
     // overflow exists only inside the zoom window
     final total = widget.viewExtent!;
     return (total, total / _scale);
   }
 
   /// The visible window's leading edge in list space: the viewport
-  /// unprojects through the transform as (p - t) / s, riding on the
-  /// scroll offset vertically (see _visibleFractionOf).
+  /// unprojects through the transform as (p - t) / s, riding on the scroll
+  /// offset along the scroll-driven (main) axis (see _visibleFractionOf).
   double _offset() {
     final m = widget.transform?.value;
-    if (m == null) return widget.scroll!.position.pixels;
-    return _vertical
-        ? -m.storage[13] / _scale + widget.scroll!.position.pixels
-        : -m.storage[12] / _scale;
+    if (!_scrollDriven) {
+      return m == null ? 0 : -m.storage[_translateIndex] / _scale;
+    }
+    final base = widget.scroll!.position.pixels;
+    return m == null ? base : -m.storage[_translateIndex] / _scale + base;
   }
 
   void _scrollBy(double delta) {

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_pdf_editor
 description: >-
   Flutter PDF viewer and editor for Dart: native rendering, text selection,
   search, annotations, forms, signatures, page editing, and document comparison.
-version: 1.4.7
+version: 1.4.8
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_editor
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:

--- a/packages/dart_pdf_editor/pubspec.yaml
+++ b/packages/dart_pdf_editor/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_pdf_editor
 description: >-
   Flutter PDF viewer and editor for Dart: native rendering, text selection,
   search, annotations, forms, signatures, page editing, and document comparison.
-version: 1.4.8
+version: 1.4.7
 repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_editor
 issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
 topics:

--- a/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
@@ -262,6 +263,14 @@ void main() {
     // more pages fit across the viewport once shrunk
     expect(controller.visiblePageRegion(0), isNotNull);
     expect(controller.visiblePageRegion(2), isNotNull);
+
+    // framing a rect from the zoomed-out layout re-fits to layout zoom 1
+    // first (with no focal point), then zooms in on the rect. Fire-and-pump
+    // (not awaited): showRect awaits endOfFrame internally, so awaiting it
+    // here would deadlock the pump loop.
+    unawaited(controller.showRect(1, const PdfRect(72, 692, 172, 742)));
+    await tester.pumpAndSettle(const Duration(milliseconds: 400));
+    expect(controller.zoom, greaterThanOrEqualTo(1.0));
   });
 
   testWidgets('touch cross-axis pan rubber-bands and springs back',
@@ -303,7 +312,7 @@ void main() {
     final gesture = await tester.startGesture(const Offset(400, 300),
         kind: PointerDeviceKind.touch);
     var stamp = Duration.zero;
-    for (var i = 0; i < 12; i++) {
+    for (var i = 0; i < 15; i++) {
       stamp += const Duration(milliseconds: 16);
       await gesture.moveBy(const Offset(0, 60), timeStamp: stamp);
       await tester.pump(const Duration(milliseconds: 16));
@@ -312,10 +321,19 @@ void main() {
     expect(regionMidDrag.top, lessThan(regionBefore.top),
         reason: 'the content should have shifted down');
 
+    // hold still so lift-off carries ~no velocity, then release
+    for (var i = 0; i < 6; i++) {
+      stamp += const Duration(milliseconds: 16);
+      await gesture.moveBy(Offset.zero, timeStamp: stamp);
+      await tester.pump(const Duration(milliseconds: 16));
+    }
     await gesture.up(timeStamp: stamp + const Duration(milliseconds: 16));
-    await tester.pump();
-    // the spring-back animation brings the page back to the edge
-    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    // advance the spring-back with bounded pumps (pumpAndSettle would wait on
+    // the double-tap timer)
+    for (var i = 0; i < 40; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    // the cross-axis over-scroll relaxes back to the page edge
     final regionAfter = controller.visiblePageRegion(0)!;
     expect(regionAfter.top, moreOrLessEquals(0, epsilon: 0.02));
 

--- a/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
@@ -1,0 +1,235 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  // The default test surface is 800×600. Pages are 612×792, so a horizontal
+  // continuous layout fits each page's height to the 600px viewport: the
+  // on-screen scale is 600/792 and each page is 612×(600/792) wide.
+  const fitScale = 600 / 792;
+
+  Future<PdfViewerController> pumpHorizontal(
+    WidgetTester tester, {
+    int pages = 5,
+    Uint8List? bytes,
+    PdfViewerFit fit = PdfViewerFit.width,
+    PdfPageOverlayBuilder? overlayBuilder,
+  }) async {
+    final controller = PdfViewerController();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          document: PdfDocument.open(bytes ?? buildMultiPagePdf(pages)),
+          controller: controller,
+          pageLayout: const PdfPageLayout.horizontalContinuous(),
+          initialFit: fit,
+          pageOverlayBuilder: overlayBuilder,
+        ),
+      ),
+    ));
+    await tester.pump();
+    return controller;
+  }
+
+  group('PdfPageLayout', () {
+    test('exposes the scroll axis', () {
+      expect(const PdfPageLayout.verticalContinuous().scrollAxis,
+          Axis.vertical);
+      expect(const PdfPageLayout.horizontalContinuous().scrollAxis,
+          Axis.horizontal);
+    });
+
+    test('has value equality', () {
+      expect(const PdfPageLayout.horizontalContinuous(),
+          const PdfPageLayout.horizontalContinuous());
+      expect(const PdfPageLayout.verticalContinuous(),
+          isNot(const PdfPageLayout.horizontalContinuous()));
+      expect(const PdfPageLayout.horizontalContinuous().hashCode,
+          const PdfPageLayout.horizontalContinuous().hashCode);
+    });
+  });
+
+  testWidgets('lays pages out along a horizontal scrollable', (tester) async {
+    final controller = await pumpHorizontal(tester);
+    expect(controller.pageCount, 5);
+    expect(controller.currentPage, 0);
+    expect(find.byType(PdfPageView), findsWidgets);
+
+    // the list scrolls horizontally
+    final scrollable = tester.widget<Scrollable>(find
+        .descendant(
+            of: find.byType(PdfViewer), matching: find.byType(Scrollable))
+        .first);
+    expect(scrollable.axisDirection, AxisDirection.right);
+  });
+
+  testWidgets('horizontal drag advances the current page', (tester) async {
+    final controller = await pumpHorizontal(tester);
+    // a leftward drag pulls later pages into view
+    await tester.drag(find.byType(PdfViewer), const Offset(-2500, 0));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+    expect(controller.currentPage, greaterThan(0));
+  });
+
+  testWidgets('jumpToPage scrolls horizontally to the page', (tester) async {
+    final controller = await pumpHorizontal(tester);
+    controller.jumpToPage(4);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(controller.currentPage, 4);
+    // page 4 sits at the viewport's left edge
+    final region = controller.visiblePageRegion(4);
+    expect(region, isNotNull);
+    expect(region!.left, moreOrLessEquals(0, epsilon: 0.02));
+  });
+
+  testWidgets('visiblePageRegion tracks a horizontal scroll', (tester) async {
+    final controller = await pumpHorizontal(tester);
+    // page 0 fully spans the height, at the left edge
+    final page0 = controller.visiblePageRegion(0)!;
+    expect(page0.left, moreOrLessEquals(0, epsilon: 0.001));
+    expect(page0.top, moreOrLessEquals(0, epsilon: 0.001));
+    expect(page0.bottom, moreOrLessEquals(1, epsilon: 0.001));
+
+    controller.jumpToPage(2);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(controller.visiblePageRegion(0), isNull,
+        reason: 'page 0 has scrolled off the left');
+    expect(controller.visiblePageRegion(2), isNotNull);
+  });
+
+  testWidgets('captures and restores a horizontal viewport', (tester) async {
+    final controller = await pumpHorizontal(tester);
+    controller.jumpToPage(3);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    // nudge a little into the page along the scroll axis
+    await tester.drag(find.byType(PdfViewer), const Offset(-80, 0));
+    await tester.pumpAndSettle(const Duration(milliseconds: 100));
+
+    final snapshot = controller.captureViewport();
+    expect(snapshot, isNotNull);
+    expect(snapshot!.page, 3);
+    expect(snapshot.top, greaterThan(0));
+
+    // scroll away, then restore
+    controller.jumpToPage(0);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    controller.restoreViewport(snapshot);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+
+    final restored = controller.captureViewport()!;
+    expect(restored.page, 3);
+    expect(restored.top, moreOrLessEquals(snapshot.top, epsilon: 0.02));
+  });
+
+  testWidgets('page overlays sit at PDF coordinates in a horizontal layout',
+      (tester) async {
+    var taps = 0;
+    final controller = await pumpHorizontal(
+      tester,
+      pages: 2,
+      overlayBuilder: (context, pageIndex, geometry) => [
+        if (pageIndex == 0)
+          Positioned.fromRect(
+            rect: geometry.toViewRect(const PdfRect(72, 692, 172, 742)),
+            child: TextButton(
+              key: const Key('overlay'),
+              onPressed: () => taps++,
+              child: const Text('go'),
+            ),
+          ),
+      ],
+    );
+    expect(controller.currentPage, 0);
+
+    // page 0 starts at scroll 0 and fills the viewport height, so view space
+    // == page view space at the fit-height scale
+    final rect = tester.getRect(find.byKey(const Key('overlay')));
+    expect(rect.left, moreOrLessEquals(72 * fitScale, epsilon: 0.2));
+    expect(rect.top, moreOrLessEquals((792 - 742) * fitScale, epsilon: 0.2));
+    expect(rect.width, moreOrLessEquals(100 * fitScale, epsilon: 0.2));
+    expect(rect.height, moreOrLessEquals(50 * fitScale, epsilon: 0.2));
+
+    // the overlay stays interactive
+    await tester.tap(find.byKey(const Key('overlay')));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(taps, 1);
+    expect(find.byType(TextButton), findsOneWidget);
+  });
+
+  testWidgets('search navigates to a match in a horizontal layout',
+      (tester) async {
+    final controller = await pumpHorizontal(tester, pages: 6);
+    await tester.runAsync(() => controller.search('Page 5'));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(controller.matchCount, greaterThan(0));
+    expect(controller.currentPage, 4, reason: 'page index for "Page 5"');
+    expect(controller.visiblePageRegion(4), isNotNull);
+  });
+
+  testWidgets('opens fitted to the whole first page (Fit.page)',
+      (tester) async {
+    // Fit.page shrinks until the first page fits along the main (horizontal)
+    // axis too: at fit-height the page is 612*(600/792) ≈ 464 wide, which is
+    // already narrower than the 800px viewport, so no extra shrink is needed
+    // and the whole page is visible.
+    final controller =
+        await pumpHorizontal(tester, pages: 3, fit: PdfViewerFit.page);
+    final region = controller.visiblePageRegion(0)!;
+    expect(region.left, moreOrLessEquals(0, epsilon: 0.001));
+    expect(region.right, moreOrLessEquals(1, epsilon: 0.02),
+        reason: 'the whole first page is visible along the scroll axis');
+  });
+
+  testWidgets('switching layout at runtime keeps the current page',
+      (tester) async {
+    final controller = PdfViewerController();
+    final document = PdfDocument.open(buildMultiPagePdf(6));
+    Widget build(PdfPageLayout layout) => MaterialApp(
+          home: Scaffold(
+            body: PdfViewer(
+              key: const ValueKey('viewer'),
+              document: document,
+              controller: controller,
+              pageLayout: layout,
+              initialFit: PdfViewerFit.width,
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(build(const PdfPageLayout.verticalContinuous()));
+    await tester.pump();
+    controller.jumpToPage(3);
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(controller.currentPage, 3);
+
+    // flip to horizontal - the reader stays on page 3
+    await tester
+        .pumpWidget(build(const PdfPageLayout.horizontalContinuous()));
+    await tester.pump(); // adopt the new layout
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(controller.currentPage, 3);
+
+    final scrollable = tester.widget<Scrollable>(find
+        .descendant(
+            of: find.byType(PdfViewer), matching: find.byType(Scrollable))
+        .first);
+    expect(scrollable.axisDirection, AxisDirection.right);
+  });
+
+  testWidgets('mixed page sizes keep their aspect ratios centred',
+      (tester) async {
+    // buildVariedHeightPdf cycles page heights (792/396/1008, all 612 wide),
+    // so in a horizontal layout the cross (height) fit differs per page and
+    // shorter pages are centred vertically.
+    final controller =
+        await pumpHorizontal(tester, bytes: buildVariedHeightPdf(4));
+    // the tallest page (1008pt) is the fit reference and fills the height
+    final tall = controller.visiblePageRegion(2)!; // index 2 -> 1008pt
+    expect(tall.top, moreOrLessEquals(0, epsilon: 0.02));
+    expect(tall.bottom, moreOrLessEquals(1, epsilon: 0.02));
+  });
+}

--- a/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -50,6 +51,16 @@ void main() {
           isNot(const PdfPageLayout.horizontalContinuous()));
       expect(const PdfPageLayout.horizontalContinuous().hashCode,
           const PdfPageLayout.horizontalContinuous().hashCode);
+    });
+
+    test('constructs at runtime and describes itself', () {
+      // non-const invocations exercise the constructors at runtime
+      final horizontal = PdfPageLayout.horizontalContinuous();
+      final vertical = PdfPageLayout.verticalContinuous();
+      expect(horizontal.scrollAxis, Axis.horizontal);
+      expect(vertical.scrollAxis, Axis.vertical);
+      expect(horizontal.toString(), 'PdfPageLayout.horizontalContinuous');
+      expect(vertical.toString(), 'PdfPageLayout.verticalContinuous');
     });
   });
 
@@ -218,6 +229,97 @@ void main() {
             of: find.byType(PdfViewer), matching: find.byType(Scrollable))
         .first);
     expect(scrollable.axisDirection, AxisDirection.right);
+  });
+
+  testWidgets('showDestination scrolls to a page position horizontally',
+      (tester) async {
+    // 8 pages so page 3 sits well clear of the max scroll extent (no clamp)
+    final controller = await pumpHorizontal(tester, pages: 8);
+    // an /XYZ destination carries a left (horizontal) coordinate; a
+    // horizontal layout scrolls the main axis to it (page 612pt wide)
+    controller.showDestination(const PdfDestination(
+      pageIndex: 3,
+      fit: 'XYZ',
+      params: [306, 700, null],
+    ));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    // the destination scrolled page 3 so that 306/612 = 0.5 of the way
+    // across it sits at the viewport's left edge (currentPage tracks the
+    // viewport centre, which by then is the following page)
+    final region = controller.visiblePageRegion(3);
+    expect(region, isNotNull);
+    expect(region!.left, moreOrLessEquals(0.5, epsilon: 0.05));
+  });
+
+  testWidgets('zooming out below fit relays the pages out horizontally',
+      (tester) async {
+    final controller = await pumpHorizontal(tester, pages: 5);
+    // fit-height rests at 600/792 px/pt; zoom out below it to relayout the
+    // pages smaller (exercises the layout-zoom path on the main axis)
+    controller.setZoom(0.5);
+    await tester.pumpAndSettle(const Duration(milliseconds: 200));
+    expect(controller.zoom, moreOrLessEquals(0.5, epsilon: 0.01));
+    // more pages fit across the viewport once shrunk
+    expect(controller.visiblePageRegion(0), isNotNull);
+    expect(controller.visiblePageRegion(2), isNotNull);
+  });
+
+  testWidgets('touch cross-axis pan rubber-bands and springs back',
+      (tester) async {
+    // In a horizontal layout the cross (rubber-band) axis is vertical, so a
+    // vertical touch drag past the page edge over-scrolls and springs back.
+    final editing = PdfEditingController(buildMultiPagePdf(3));
+    addTearDown(editing.dispose);
+    final controller = PdfViewerController();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            document: editing.document,
+            editing: editing,
+            controller: controller,
+            pageLayout: const PdfPageLayout.horizontalContinuous(),
+            initialFit: PdfViewerFit.width,
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    editing.tool = PdfEditTool.select;
+    await tester.pump();
+
+    // zoom in with a touch double-tap (2.5×)
+    await tester.tapAt(const Offset(400, 300));
+    await tester.pump(const Duration(milliseconds: 80));
+    await tester.tapAt(const Offset(400, 300));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(controller.zoom, greaterThan(1));
+
+    final regionBefore = controller.visiblePageRegion(0)!;
+
+    // vertical touch drag downward → content slides down, visible region
+    // pushes past the top edge (top < 0 in rubber-band)
+    final gesture = await tester.startGesture(const Offset(400, 300),
+        kind: PointerDeviceKind.touch);
+    var stamp = Duration.zero;
+    for (var i = 0; i < 12; i++) {
+      stamp += const Duration(milliseconds: 16);
+      await gesture.moveBy(const Offset(0, 60), timeStamp: stamp);
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    final regionMidDrag = controller.visiblePageRegion(0)!;
+    expect(regionMidDrag.top, lessThan(regionBefore.top),
+        reason: 'the content should have shifted down');
+
+    await gesture.up(timeStamp: stamp + const Duration(milliseconds: 16));
+    await tester.pump();
+    // the spring-back animation brings the page back to the edge
+    await tester.pumpAndSettle(const Duration(milliseconds: 500));
+    final regionAfter = controller.visiblePageRegion(0)!;
+    expect(regionAfter.top, moreOrLessEquals(0, epsilon: 0.02));
+
+    await tester.pump(const Duration(milliseconds: 400));
   });
 
   testWidgets('mixed page sizes keep their aspect ratios centred',


### PR DESCRIPTION
## Summary

Adds an optional public page-layout strategy to `PdfViewer` (issue #324), keeping the current vertical continuous layout as the default and adding a fully-working **horizontal continuous** layout for book-like reading, wide documents, and apps that offer a horizontal reading mode.

```dart
PdfViewer(
  document: document,
  controller: controller,
  pageLayout: const PdfPageLayout.horizontalContinuous(),
)
```

`PdfPageLayout` is a value type with named `const` constructors (`verticalContinuous()` / `horizontalContinuous()`) and a `scrollAxis` getter — deliberately **not** a bare enum, so a facing/two-page mode can be added later as a new constructor **without changing `PdfViewer`'s API again** (the issue's explicit forward-compat ask).

Rather than build a separate horizontal viewer, the existing viewer is generalized over a **main** (scroll) axis and a **cross** (fit/centre) axis. Vertical is the byte-for-byte identity case; horizontal swaps the two. Every viewer behaviour keeps working along the chosen axis:

- Virtualization (`ExactExtentListView` with `scrollDirection`), mixed page sizes (pages fit the viewport's cross axis, keep true relative sizes, and centre on the cross axis)
- Zoom/pan (the `InteractiveViewer` transform, rubber-band, spring-back, trackpad/touch flings, wheel), current-page tracking, `jumpToPage`
- Search-result and `/GoTo` destination navigation, `captureViewport`/`restoreViewport`, `visiblePageRegion`
- Text selection, page overlays, links, form/annotation hit-testing, keyboard navigation
- Scrollbars: `PdfScrollbar`'s scroll-driven vs transform-only behaviour is decoupled from orientation, so it serves a horizontal main bar and a vertical cross (zoom-overflow) bar

`pageLayout` can be switched at runtime (the reader stays on the current page) and is forwarded by `PdfReader` and `PdfEditorView`.

Design notes are in `doc/dev-log/2026-07-16-viewer-horizontal-layout.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (dev-log, CHANGELOG)

## Change type

- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (no issues)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (full non-benchmark suite: **+1490 passed, 0 failed**, incl. 12 new horizontal-layout tests; skips are corpus/benchmark harnesses needing external data)

New tests: `packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart` — value semantics, the horizontal `Scrollable`, drag/jump current-page tracking, `visiblePageRegion`, capture/restore round-trip, overlay geometry at the fit-height scale, search navigation, `Fit.page`, runtime layout switching, and mixed-size centring.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output. (No parser/writer changes.)
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required. (No stream changes.)
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Vertical is the exact identity path — all pre-existing viewer/scrollbar/viewport/selection/comparison tests pass unchanged.
- Only the two continuous layouts are implemented; the API admits facing/two-page and single-page paging as future constructors.
- `_showMatch` / `_scrollToDestination` intra-page offsets ignore page `/Rotate` on the horizontal axis — the same simplification the vertical path already made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSf8XU1F4ng8fhzq14ALwk)_