### PR TITLE
test(viewer): cover the cross-axis spring-back tick in a horizontal layout

### DIFF
--- a/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_horizontal_layout_test.dart
@@ -277,26 +277,10 @@ void main() {
       (tester) async {
     // In a horizontal layout the cross (rubber-band) axis is vertical, so a
     // vertical touch drag past the page edge over-scrolls and springs back.
-    final editing = PdfEditingController(buildMultiPagePdf(3));
-    addTearDown(editing.dispose);
-    final controller = PdfViewerController();
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: ListenableBuilder(
-          listenable: editing,
-          builder: (context, _) => PdfViewer(
-            document: editing.document,
-            editing: editing,
-            controller: controller,
-            pageLayout: const PdfPageLayout.horizontalContinuous(),
-            initialFit: PdfViewerFit.width,
-          ),
-        ),
-      ),
-    ));
-    await tester.pump();
-    editing.tool = PdfEditTool.select;
-    await tester.pump();
+    // No editing tool: a zoomed one-finger touch pan is owned by the viewer's
+    // own recognizer, which rubber-bands the transform and, on lift-off,
+    // animates the cross axis back to the edge (_onCrossBounceTick).
+    final controller = await pumpHorizontal(tester, pages: 3);
 
     // zoom in with a touch double-tap (2.5×)
     await tester.tapAt(const Offset(400, 300));
@@ -308,20 +292,21 @@ void main() {
     final regionBefore = controller.visiblePageRegion(0)!;
 
     // vertical touch drag downward → content slides down, visible region
-    // pushes past the top edge (top < 0 in rubber-band)
+    // pushes past the top edge, well into the rubber-band zone
     final gesture = await tester.startGesture(const Offset(400, 300),
         kind: PointerDeviceKind.touch);
     var stamp = Duration.zero;
-    for (var i = 0; i < 15; i++) {
+    for (var i = 0; i < 20; i++) {
       stamp += const Duration(milliseconds: 16);
       await gesture.moveBy(const Offset(0, 60), timeStamp: stamp);
       await tester.pump(const Duration(milliseconds: 16));
     }
     final regionMidDrag = controller.visiblePageRegion(0)!;
     expect(regionMidDrag.top, lessThan(regionBefore.top),
-        reason: 'the content should have shifted down');
+        reason: 'the content should have shifted down past the edge');
 
-    // hold still so lift-off carries ~no velocity, then release
+    // hold still so lift-off carries ~no velocity: the release springs back
+    // directly (no fling), animating the over-scroll to the edge
     for (var i = 0; i < 6; i++) {
       stamp += const Duration(milliseconds: 16);
       await gesture.moveBy(Offset.zero, timeStamp: stamp);
@@ -330,7 +315,7 @@ void main() {
     await gesture.up(timeStamp: stamp + const Duration(milliseconds: 16));
     // advance the spring-back with bounded pumps (pumpAndSettle would wait on
     // the double-tap timer)
-    for (var i = 0; i < 40; i++) {
+    for (var i = 0; i < 60; i++) {
       await tester.pump(const Duration(milliseconds: 16));
     }
     // the cross-axis over-scroll relaxes back to the page edge


### PR DESCRIPTION
## Summary

Follow-up to #330 (configurable page layouts). That PR merged with one line left uncovered by the codecov patch gate: `_onCrossBounceTick`'s transform write in `pdf_viewer.dart` — the point where the cross-axis over-scroll animates back to the page edge. It's only reached when the over-scroll actually *animates* (over-scroll ≥ 0.5 at lift-off), which the original test didn't reliably trigger.

The earlier "touch cross-axis pan rubber-bands and springs back" test armed the select tool, so the touch drag was consumed by the editing overlay (marquee/selection) instead of over-scrolling the zoom transform, and the spring-back never animated.

This drops the editing controller from that test: with no tool armed, a zoomed one-finger touch pan is owned by the viewer's own `_ZoomedTouchPanRecognizer`, which rubber-bands the transform directly. A brief still-hold before release zeroes the lift-off velocity so the gesture springs back **directly** (no fling first), driving the bounce animation. Verified locally that the previously-uncovered line is now hit (3×), and the assertion (over-scroll relaxes back to the page edge) still holds.

## Affected packages

- [x] `dart_pdf_editor` (test only)

## Change type

- [x] Tests / fixtures only

## Validation

- [x] `fvm dart analyze --fatal-infos` (clean)
- [x] `cd packages/dart_pdf_editor && fvm flutter test test/pdf_horizontal_layout_test.dart` (16 passing)
- [x] Coverage check: `_onCrossBounceTick`'s transform write now covered

## Compatibility checklist

- [x] No `dart:ui`/Flutter imports outside `dart_pdf_editor`; no `dart:io` in `lib/`.
- [x] Layering preserved (test-only change).
- [x] Test fixtures use programmatic builders.

## Notes for reviewers

Pure test change — no production code touched. It only strengthens the existing horizontal spring-back test so the cross-axis bounce animation is actually driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSf8XU1F4ng8fhzq14ALwk)_