### PR TITLE
perf: share one source-byte snapshot across the render worker pool (#309)

### DIFF
--- a/doc/dev-log/2026-07-17-pool-shared-bytes.md
+++ b/doc/dev-log/2026-07-17-pool-shared-bytes.md
@@ -1,0 +1,54 @@
+# Render worker pool: share one source-byte snapshot across workers (#309)
+
+`PdfPooledRenderWorker` (`dart_pdf_editor/lib/src/render_worker.dart`) used to
+make a private `Uint8List.fromList(bytes)` copy for **every** worker plus one
+more for the urgent one-off lane - `N+1` copies of the source bytes on the main
+isolate before any decode working set. For a pool of 3 over a 24 MB file that
+is ~96 MB of source bytes just sitting there (the class doc acknowledged it).
+
+The per-worker copy was defensive: the doc claimed "a platform worker may
+transfer (and so detach) the buffer it is handed", so sharing one buffer would
+leave later workers with an empty document. That is **not true of either
+backend** as written:
+
+- Native (`render_worker_isolate.dart`): the isolate is seeded with
+  `TransferableTypedData.fromList([bytes])`. `fromList` copies the bytes into an
+  external buffer at construction and does **not** neuter/detach its input - the
+  same `Uint8List` can be wrapped by `fromList` any number of times and each
+  materializes to the full data. (Verified empirically; the zero-copy transfer
+  is the later `materialize()`, which each isolate does on its own copy.)
+- Web (`render_worker_web.dart`): the worker either copies into a
+  `SharedArrayBuffer` (`setAll`, a read) or does `Uint8List.fromList(bytes)`
+  before transferring the copy's `ArrayBuffer`. The input `bytes` is never
+  transferred/detached directly.
+
+So both backends already copy internally, and the pool's own copy just
+duplicated that. The fix: the pool makes **one** read-only snapshot and seeds
+every worker - and the lazy urgent worker - from that single instance. Pool
+source-byte footprint drops from `N+1` copies to exactly one; each isolate's
+materialized copy inside its own isolate is unavoidable and unchanged.
+
+## Shape of the change
+
+- `PdfPooledRenderWorker(bytes, size)` is now a `factory` that snapshots the
+  caller's bytes once and redirects to a private `_shared(snapshot, size,
+  spawn)` generative ctor, which seeds all workers from `snapshot` and stores it
+  as `_urgentBytes`.
+- New `_spawnWorker` field (the worker factory, `startRenderWorker` in
+  production) is reused by `_urgentWorkerFor`, which no longer re-copies with
+  `Uint8List.fromList` - it hands the shared snapshot straight to the backend.
+- Test seam `PdfPooledRenderWorker.withSpawner(bytes, size, spawn)` injects a
+  fake spawner so a test can capture the byte view each worker (and the urgent
+  lane) is handed and assert they are the **same instance**
+  (`render_worker_test.dart`, two new cases in the `PdfPooledRenderWorker`
+  group). The existing real-isolate `PdfRenderWorker.start` tests already cover
+  the pooled path over live isolates and still replay pixel-identically.
+
+## Deferred: the transfer half
+
+The issue's second half - passing command graphs by `SendPort`/`Isolate.exit`
+transfer on native instead of the `serializeCommands`/`deserializeCommands`
+round-trip - is intentionally **not** done here. It is speculative (the codec
+also normalizes geometry to float32 that the UI consumes, so a raw transfer is
+not a pure win) and riskier; the shared-byte-view half is the safe first step
+the issue called out. Left for a follow-up.

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -401,12 +401,17 @@ abstract class PdfRenderWorker {
 /// the same pair reuse its worker; [cancel] routes through that lease table so
 /// it still reaches the worker holding the queued request.
 ///
-/// Each worker opens its own copy of the document. The bytes are copied per
-/// worker ([Uint8List.fromList]) because a platform worker may transfer (and so
-/// detach) the buffer it is handed - sharing one buffer would leave later
-/// workers with an empty document. The cost is N copies of the bytes plus N
-/// decode working sets; size the pool to the platform via
-/// [pdfRenderWorkerPoolSize].
+/// Each worker opens its own copy of the document, but the pool does NOT hand
+/// each one a private snapshot: it makes ONE read-only copy of the source bytes
+/// and seeds every worker (and the lazy urgent one-off lane) from that single
+/// instance. Both platform backends copy the buffer internally before handing
+/// it to their isolate/worker - native `TransferableTypedData.fromList` copies into
+/// external memory, web copies into a `SharedArrayBuffer` or a transferred
+/// `ArrayBuffer` - and neither detaches the view it was given, so one shared
+/// snapshot is safe. That drops the pool's own source-byte footprint from N+1
+/// copies (a private per-worker copy plus the urgent copy) to exactly one; each
+/// worker's materialized copy inside its own isolate is unavoidable and
+/// unchanged. Size the pool to the platform via [pdfRenderWorkerPoolSize].
 ///
 /// Normally wrapped in a [PdfCachingRenderWorker] (see [PdfRenderWorker.start]),
 /// which dedups concurrent requests for one page - so the cache, not the pool,
@@ -417,13 +422,41 @@ abstract class PdfRenderWorker {
 /// jump should not wait behind several already-started background records that
 /// cannot receive cancellation until their synchronous parse step yields.
 class PdfPooledRenderWorker extends PdfRenderWorker {
-  /// Starts [size] platform workers over copies of [bytes]. [size] is clamped to
-  /// at least 1; a pool of 1 is just a single worker with this routing wrapper.
-  PdfPooledRenderWorker(Uint8List bytes, int size)
-      : _urgentBytes = Uint8List.fromList(bytes),
+  /// Starts [size] platform workers, all seeded from ONE read-only snapshot of
+  /// [bytes] (see the class doc - the backends copy internally, so the pool
+  /// keeps just this single source-byte copy instead of one per worker). [size]
+  /// is clamped to at least 1; a pool of 1 is just a single worker with this
+  /// routing wrapper.
+  factory PdfPooledRenderWorker(Uint8List bytes, int size) =>
+      PdfPooledRenderWorker._shared(
+        Uint8List.fromList(bytes),
+        size,
+        startRenderWorker,
+      );
+
+  /// Test seam: a pool that spawns its workers through [spawn] instead of the
+  /// platform [startRenderWorker], so the byte-sharing contract - every worker
+  /// (and the urgent lane) seeded from the SAME snapshot instance, no private
+  /// per-worker copy - can be asserted with fakes that capture the bytes they
+  /// are handed.
+  factory PdfPooledRenderWorker.withSpawner(
+    Uint8List bytes,
+    int size,
+    PdfRenderWorker Function(Uint8List) spawn,
+  ) =>
+      PdfPooledRenderWorker._shared(Uint8List.fromList(bytes), size, spawn);
+
+  /// Seeds every worker and the urgent lane from the already-owned [shared]
+  /// snapshot (the factories above copy the caller's bytes once into it).
+  PdfPooledRenderWorker._shared(
+    Uint8List shared,
+    int size,
+    PdfRenderWorker Function(Uint8List) spawn,
+  )   : _spawnWorker = spawn,
+        _urgentBytes = shared,
         _workers = List.generate(
           size < 1 ? 1 : size,
-          (_) => startRenderWorker(Uint8List.fromList(bytes)),
+          (_) => spawn(shared),
           growable: false,
         ) {
     _loads = List.filled(_workers.length, 0);
@@ -433,6 +466,7 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
   /// teardown can be exercised with fakes instead of real platform workers.
   PdfPooledRenderWorker.fromWorkers(List<PdfRenderWorker> workers)
       : assert(workers.isNotEmpty),
+        _spawnWorker = startRenderWorker,
         _urgentBytes = null,
         _workers = List.of(workers, growable: false) {
     _loads = List.filled(_workers.length, 0);
@@ -440,9 +474,15 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
 
   static const int _urgentPriority = -2000;
 
-  // The bytes a lazily-created one-off urgent worker opens. Kept at the current
-  // revision by [updateRevision] so a long-jump preview after an edit opens the
-  // edited document, not the stale spawn snapshot. Null in the test seam.
+  // Spawns one platform worker over a byte view. The real [startRenderWorker]
+  // in production; a fake in [PdfPooledRenderWorker.withSpawner] tests. Used for
+  // the lazy urgent lane too, so it also shares the pool's one snapshot.
+  final PdfRenderWorker Function(Uint8List) _spawnWorker;
+
+  // The bytes a lazily-created one-off urgent worker opens - the same snapshot
+  // instance the pool workers were seeded from. Kept at the current revision by
+  // [updateRevision] so a long-jump preview after an edit opens the edited
+  // document, not the stale spawn snapshot. Null in the test seam.
   Uint8List? _urgentBytes;
   final List<PdfRenderWorker> _workers;
   late final List<int> _loads;
@@ -696,7 +736,10 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
     }
     final bytes = _urgentBytes;
     if (!start || bytes == null) return null;
-    return _urgentWorker = startRenderWorker(Uint8List.fromList(bytes));
+    // No defensive copy: the backend copies internally, and _urgentBytes is only
+    // ever replaced (never mutated in place), so the urgent worker can share the
+    // pool's snapshot like the ordinary workers do.
+    return _urgentWorker = _spawnWorker(bytes);
   }
 }
 

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -973,7 +973,73 @@ void main() {
       expect(only.calls.single.$1, 5);
       expect(only.cancels.single, (5, 0));
     });
+
+    test('every worker is seeded from one shared byte snapshot, not a '
+        'per-worker copy', () {
+      final source = Uint8List.fromList(List.generate(64, (i) => i & 0xff));
+      final seeds = <Uint8List>[];
+      final pool = PdfPooledRenderWorker.withSpawner(source, 3, (bytes) {
+        seeds.add(bytes);
+        return _SeedWorker(bytes);
+      });
+      addTearDown(pool.dispose);
+
+      expect(seeds, hasLength(3), reason: 'three workers were spawned');
+      // All three got the very same instance - no private per-worker copy.
+      expect(identical(seeds[0], seeds[1]), isTrue);
+      expect(identical(seeds[1], seeds[2]), isTrue);
+      // And it is the pool's own snapshot, decoupled from the caller's bytes.
+      expect(identical(seeds[0], source), isFalse);
+      expect(seeds[0], equals(source));
+    });
+
+    test('the urgent one-off lane shares the same snapshot as the workers',
+        () async {
+      final source = Uint8List.fromList(List.generate(64, (i) => i & 0xff));
+      final seeds = <Uint8List>[];
+      final pool = PdfPooledRenderWorker.withSpawner(source, 2, (bytes) {
+        seeds.add(bytes);
+        return _SeedWorker(bytes);
+      });
+      addTearDown(pool.dispose);
+
+      final workerSeed = seeds.first;
+      // Priority -2000 routes past the pool into the lazily-spawned urgent
+      // worker, which must reuse the snapshot rather than copy again.
+      await pool.record(0, priority: -2000);
+      expect(seeds, hasLength(3), reason: 'the urgent worker was spawned');
+      expect(identical(seeds.last, workerSeed), isTrue);
+    });
   });
+}
+
+/// A [PdfRenderWorker] that records the byte view it was constructed with, for
+/// asserting the pool seeds every worker from one shared snapshot. Declines
+/// every record (null → local), which is all the sharing tests need.
+class _SeedWorker extends PdfRenderWorker {
+  _SeedWorker(this.seed);
+
+  final Uint8List seed;
+  bool disposed = false;
+
+  @override
+  bool get isActive => !disposed;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio,
+          bool decodeImages = true,
+          int? commandLimit,
+          PdfRect? imageDecodeRegion}) async =>
+      null;
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => disposed = true;
 }
 
 /// A [PdfRenderWorker] that records each [record] call and returns a synthetic


### PR DESCRIPTION
## Summary

`PdfPooledRenderWorker` made a private `Uint8List.fromList(bytes)` copy for **every** worker plus one more for the urgent one-off lane — `N+1` copies of the source bytes on the main isolate before any decode working set (~96 MB for a pool of 3 over a 24 MB file, as the issue and the class doc noted).

The per-worker copy was defensive against a backend "transferring (and so detaching) the buffer it is handed." Neither backend actually does that:

- **Native** (`render_worker_isolate.dart`): seeds the isolate with `TransferableTypedData.fromList([bytes])`, which copies into an external buffer at construction and does **not** detach its input (verified empirically — the same `Uint8List` can be wrapped repeatedly and each materializes to full data; the zero-copy step is each isolate's own `materialize()`).
- **Web** (`render_worker_web.dart`): copies into a `SharedArrayBuffer` (`setAll`, a read) or does `Uint8List.fromList(bytes)` before transferring the copy's `ArrayBuffer`. The input is never transferred/detached directly.

Both already copy internally, so the pool's copy was pure duplication. The pool now snapshots the caller's bytes **once** and seeds every worker — and the lazily-spawned urgent worker — from that single instance, dropping its source-byte footprint from `N+1` copies to one. Each isolate's own materialized copy is unavoidable and unchanged.

The main constructor becomes a `factory` redirecting to a private `_shared` ctor; the urgent lane reuses the stored spawner instead of re-copying with `Uint8List.fromList`.

The issue's speculative second half (native `SendPort`/`Isolate.exit` command-graph transfer instead of the codec round-trip) is intentionally left for a follow-up — it is not a pure win because the codec also normalizes geometry to float32 the UI consumes, and the shared-byte-view half is the safe first step the issue called out.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Performance change
- [x] Refactor / cleanup
- [x] Tests / fixtures only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (render_worker, render_worker_revision, render_worker_strips, render_worker_transcript_cache suites)

Ran the render-worker test suites relevant to this change rather than the whole cross-package matrix, since the change is confined to `dart_pdf_editor`'s pool wrapper. The existing real-isolate `PdfRenderWorker.start` cases already exercise the pooled path over live isolates and still replay pixel-identically.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- New `PdfPooledRenderWorker.withSpawner(bytes, size, spawn)` test seam injects a fake spawner so the two new cases in the `PdfPooledRenderWorker` group can assert the sharing contract directly (`identical` byte view across all workers and the urgent lane, decoupled from the caller's buffer).
- `updateRevision` still rolls `_urgentBytes` forward by allocating a fresh buffer and reassigning (never mutating in place), so sharing the snapshot with the urgent worker stays correct across edits.
- Follow-up: the native command-graph transfer half of #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjX5TncmxGGvetYhJbc6An

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjX5TncmxGGvetYhJbc6An)_