### PR TITLE
pdf_cos: share file-tail framing between builder and updater (#318)

### DIFF
--- a/doc/dev-log/2026-07-17-shared-file-tail-framing.md
+++ b/doc/dev-log/2026-07-17-shared-file-tail-framing.md
@@ -1,0 +1,58 @@
+# 2026-07-17 — Share the file-tail framing between builder and updater (#318)
+
+Branch `claude/github-issue-318-wuprcy`. From the 2026-07-16 architecture
+review's "also noted" list. `CosSerializer` deepened object serialization but
+stopped at the object level; the *file-container* framing — the classic xref
+table, the trailer, and the `startxref`/`%%EOF` epilogue — was re-implemented
+in two places.
+
+## The duplication
+
+Both `CosDocumentBuilder.build` (`builder.dart`) and
+`CosIncrementalUpdater.save` (`updater.dart`) independently emitted:
+
+- the `NNNNNNNNNN GGGGG n ` in-use entry encoding (offset padded to ten,
+  generation to five);
+- the `0000000000 65535 f ` object-0 free-list head (builder only);
+- the `xref` header and consecutive-run subsections;
+- `trailer` + serialized dict;
+- `startxref\n<offset>\n%%EOF\n`.
+
+Each also carried its own `_writeText(BytesBuilder, String)`. The updater's
+`_runsOf` (consecutive-number run grouping) was sidestepped by the builder only
+because a from-scratch file always writes a single `0..N` run.
+
+## The fix
+
+New `CosXrefTableWriter` (`xref_writer.dart`), exported from `pdf_cos`, owns the
+framing:
+
+- `runsOf(sorted)` — the run grouping, now shared with `_writeXrefStream` too
+  (the stream's `/Index` needs the same runs), so `_runsOf` is deleted.
+- `writeTable(offsets, generationOf, {includeFreeHead})` — `xref` + one
+  subsection per run. `includeFreeHead` prepends object 0 as the free head; it
+  is the *only* structural difference between the from-scratch and incremental
+  tables. Modelling the builder as "the incremental case with an empty prefix"
+  (the issue's framing) is exactly this flag.
+- `writeTrailer(dict)` — `trailer` + dict + `\n`. Kept **separate** from
+  `writeTable` because the builder hashes the just-written table bytes into
+  `/ID` (§14.4) *before* it can compose the trailer.
+- `writeEpilogue(xrefOffset)` — `startxref`/`%%EOF`, shared by the table and
+  the xref-stream branch of `save`.
+
+Trailer *contents* stay per-writer (the builder computes an md5 `/ID`; the
+updater copies `Root/Info/Encrypt/ID`, sets `/Prev`, applies overrides) — the
+writer only frames a dict it is handed. Output is byte-identical to before: the
+builder's old sequence `trailer\n<dict>\nstartxref…` is just
+`writeTrailer` + `writeEpilogue` back to back.
+
+## Tests
+
+The framing is now asserted **once**, directly, in `xref_writer_test.dart`
+(free head, entry encoding, run splitting with a non-zero generation, trailer,
+epilogue, `runsOf`). `builder.dart` — which had **no test at all** — gets
+`builder_test.dart` for free: object numbering, a reopenable round-trip, the
+shared from-scratch framing, and caller-supplied `/Info`/version. Existing
+`updater_test.dart` and the pdf_document suites still pass unchanged.
+
+Related: #315 is the read side of the same concern.

--- a/packages/pdf_cos/lib/pdf_cos.dart
+++ b/packages/pdf_cos/lib/pdf_cos.dart
@@ -25,3 +25,4 @@ export 'src/serializer.dart';
 export 'src/token.dart';
 export 'src/updater.dart';
 export 'src/xref.dart';
+export 'src/xref_writer.dart';

--- a/packages/pdf_cos/lib/src/builder.dart
+++ b/packages/pdf_cos/lib/src/builder.dart
@@ -4,6 +4,7 @@ import 'package:crypto/crypto.dart' show md5;
 
 import 'objects.dart';
 import 'serializer.dart';
+import 'xref_writer.dart';
 
 /// Assembles a brand-new PDF file from scratch - the counterpart of
 /// [CosIncrementalUpdater] for output that does not extend an existing
@@ -42,12 +43,13 @@ class CosDocumentBuilder {
           .writeIndirectObject(CosIndirectObject(i + 1, 0, _objects[i]));
     }
 
+    final tail = CosXrefTableWriter(out);
     final xrefOffset = out.length;
-    _writeText(out, 'xref\n0 ${_objects.length + 1}\n');
-    _writeText(out, '0000000000 65535 f \n');
-    for (final offset in offsets) {
-      _writeText(out, '${offset.toString().padLeft(10, '0')} 00000 n \n');
-    }
+    tail.writeTable(
+      {for (var i = 0; i < offsets.length; i++) i + 1: offsets[i]},
+      (_) => 0,
+      includeFreeHead: true,
+    );
 
     // both /ID halves may be identical for a freshly created file (§14.4)
     final id = Uint8List.fromList(md5.convert(out.toBytes()).bytes);
@@ -60,9 +62,8 @@ class CosDocumentBuilder {
         CosString(id, isHex: true),
       ]),
     });
-    _writeText(out, 'trailer\n');
-    serializer.writeObject(trailer);
-    _writeText(out, '\nstartxref\n$xrefOffset\n%%EOF\n');
+    tail.writeTrailer(trailer);
+    tail.writeEpilogue(xrefOffset);
     return out.takeBytes();
   }
 

--- a/packages/pdf_cos/lib/src/updater.dart
+++ b/packages/pdf_cos/lib/src/updater.dart
@@ -5,6 +5,7 @@ import 'document.dart';
 import 'objects.dart';
 import 'serializer.dart';
 import 'xref.dart';
+import 'xref_writer.dart';
 
 /// Writes changes to a document as an incremental update: the original bytes
 /// are preserved verbatim and changed objects plus a new cross-reference
@@ -94,12 +95,15 @@ class CosIncrementalUpdater {
     // a file whose newest xref is a stream must be updated with a stream;
     // a classic-table file is updated with a classic table (§7.5.8.4)
     final xrefOffset = out.length - shift;
+    final tail = CosXrefTableWriter(out);
     if (document.trailer.typeName == 'XRef') {
       _writeXrefStream(serializer, offsets, xrefOffset);
     } else {
-      _writeXrefTable(out, offsets);
+      tail
+        ..writeTable(offsets, _generationOf)
+        ..writeTrailer(_buildTrailer());
     }
-    _writeText(out, 'startxref\n$xrefOffset\n%%EOF\n');
+    tail.writeEpilogue(xrefOffset);
     return out.takeBytes();
   }
 
@@ -163,34 +167,6 @@ class CosIncrementalUpdater {
     return trailer;
   }
 
-  /// Groups sorted object numbers into runs of consecutive numbers.
-  static List<List<int>> _runsOf(List<int> sorted) {
-    final runs = <List<int>>[];
-    for (final number in sorted) {
-      if (runs.isEmpty || runs.last.last != number - 1) {
-        runs.add([number]);
-      } else {
-        runs.last.add(number);
-      }
-    }
-    return runs;
-  }
-
-  void _writeXrefTable(BytesBuilder out, Map<int, int> offsets) {
-    _writeText(out, 'xref\n');
-    for (final run in _runsOf(offsets.keys.toList()..sort())) {
-      _writeText(out, '${run.first} ${run.length}\n');
-      for (final number in run) {
-        final offset = offsets[number]!.toString().padLeft(10, '0');
-        final generation = _generationOf(number).toString().padLeft(5, '0');
-        _writeText(out, '$offset $generation n \n');
-      }
-    }
-    _writeText(out, 'trailer\n');
-    CosSerializer(out).writeObject(_buildTrailer());
-    _writeText(out, '\n');
-  }
-
   void _writeXrefStream(
       CosSerializer serializer, Map<int, int> offsets, int xrefOffset) {
     // the cross-reference stream is itself an object and lists itself
@@ -198,7 +174,7 @@ class CosIncrementalUpdater {
     offsets[streamNumber] = xrefOffset;
 
     final sorted = offsets.keys.toList()..sort();
-    final runs = _runsOf(sorted);
+    final runs = CosXrefTableWriter.runsOf(sorted);
     final data = BytesBuilder();
     for (final number in sorted) {
       final offset = offsets[number]!;
@@ -228,7 +204,4 @@ class CosIncrementalUpdater {
     serializer.writeIndirectObject(
         CosIndirectObject(streamNumber, 0, CosStream(dict, payload)));
   }
-
-  static void _writeText(BytesBuilder out, String text) =>
-      out.add(text.codeUnits);
 }

--- a/packages/pdf_cos/lib/src/xref_writer.dart
+++ b/packages/pdf_cos/lib/src/xref_writer.dart
@@ -1,0 +1,77 @@
+import 'dart:typed_data';
+
+import 'objects.dart';
+import 'serializer.dart';
+
+/// Writes the file-tail framing shared by the from-scratch [CosDocumentBuilder]
+/// and the incremental [CosIncrementalUpdater]: the classic cross-reference
+/// table (entry encoding plus consecutive-run subsections), the `trailer`
+/// dictionary, and the `startxref`/`%%EOF` epilogue.
+///
+/// From-scratch output is just the incremental case with an empty prefix, a
+/// free-list head, and no `/Prev` - so both writers emit the same bytes here.
+class CosXrefTableWriter {
+  CosXrefTableWriter(this._out) : _serializer = CosSerializer(_out);
+
+  final BytesBuilder _out;
+  final CosSerializer _serializer;
+
+  /// Groups sorted object numbers into runs of consecutive numbers, one
+  /// cross-reference subsection each. Shared with the xref-stream writer.
+  static List<List<int>> runsOf(List<int> sorted) {
+    final runs = <List<int>>[];
+    for (final number in sorted) {
+      if (runs.isEmpty || runs.last.last != number - 1) {
+        runs.add([number]);
+      } else {
+        runs.last.add(number);
+      }
+    }
+    return runs;
+  }
+
+  /// Writes `xref` and one subsection per consecutive run of [offsets]. Each
+  /// in-use entry is encoded as `NNNNNNNNNN GGGGG n ` (byte offset padded to
+  /// ten digits, generation from [generationOf] padded to five). When
+  /// [includeFreeHead] is set the object-0 free-list head
+  /// (`0000000000 65535 f `) leads the table - required for a from-scratch
+  /// file, omitted for an incremental update whose object 0 is already on file.
+  void writeTable(
+    Map<int, int> offsets,
+    int Function(int) generationOf, {
+    bool includeFreeHead = false,
+  }) {
+    final numbers = offsets.keys.toList()..sort();
+    if (includeFreeHead) numbers.insert(0, 0);
+    _writeText('xref\n');
+    for (final run in runsOf(numbers)) {
+      _writeText('${run.first} ${run.length}\n');
+      for (final number in run) {
+        if (includeFreeHead && number == 0) {
+          _writeText('0000000000 65535 f \n');
+        } else {
+          final offset = offsets[number]!.toString().padLeft(10, '0');
+          final generation = generationOf(number).toString().padLeft(5, '0');
+          _writeText('$offset $generation n \n');
+        }
+      }
+    }
+  }
+
+  /// Writes `trailer` followed by the [trailer] dictionary and a newline. Kept
+  /// separate from [writeTable] so the builder can hash the emitted table bytes
+  /// into `/ID` before the trailer is composed.
+  void writeTrailer(CosDictionary trailer) {
+    _writeText('trailer\n');
+    _serializer.writeObject(trailer);
+    _writeText('\n');
+  }
+
+  /// Writes the `startxref`/`%%EOF` epilogue pointing at [xrefOffset] (the
+  /// cross-reference offset relative to the `%PDF-` header).
+  void writeEpilogue(int xrefOffset) {
+    _writeText('startxref\n$xrefOffset\n%%EOF\n');
+  }
+
+  void _writeText(String text) => _out.add(text.codeUnits);
+}

--- a/packages/pdf_cos/test/builder_test.dart
+++ b/packages/pdf_cos/test/builder_test.dart
@@ -1,0 +1,76 @@
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CosDocumentBuilder', () {
+    test('assigns object numbers in registration order from 1', () {
+      final builder = CosDocumentBuilder();
+      final a = builder.add(CosDictionary({'Type': const CosName('Pages')}));
+      final b = builder.add(CosDictionary({'Type': const CosName('Catalog')}));
+      expect(a, const CosReference(1, 0));
+      expect(b, const CosReference(2, 0));
+    });
+
+    test('builds a reopenable file with a shared xref table and trailer', () {
+      final builder = CosDocumentBuilder();
+      final pages = CosDictionary({'Type': const CosName('Pages')});
+      final pagesRef = builder.add(pages);
+      final page = builder.add(CosDictionary({
+        'Type': const CosName('Page'),
+        'Parent': pagesRef,
+        'MediaBox': CosArray([
+          const CosInteger(0),
+          const CosInteger(0),
+          const CosInteger(200),
+          const CosInteger(300),
+        ]),
+      }));
+      pages['Kids'] = CosArray([page]);
+      pages['Count'] = const CosInteger(1);
+      final catalog = builder.add(CosDictionary({
+        'Type': const CosName('Catalog'),
+        'Pages': pagesRef,
+      }));
+
+      final bytes = builder.build(root: catalog);
+
+      final reopened = CosDocument.open(bytes);
+      expect(reopened.catalog.typeName, 'Catalog');
+      expect((reopened.getObject(2, 0) as CosDictionary).typeName, 'Page');
+      // four objects registered plus the object-0 free head
+      expect(reopened.declaredSize, 4);
+      expect(reopened.trailer['Prev'], isNull);
+    });
+
+    test('emits the from-scratch framing produced by CosXrefTableWriter', () {
+      final builder = CosDocumentBuilder();
+      final catalog = builder.add(CosDictionary({
+        'Type': const CosName('Catalog'),
+        'Pages': const CosReference(1, 0),
+      }));
+      final text = String.fromCharCodes(builder.build(root: catalog));
+
+      expect(text, startsWith('%PDF-1.7\n'));
+      // the free-list head and the shared entry encoding
+      expect(text, contains('xref\n0 2\n0000000000 65535 f \n'));
+      expect(text, matches(RegExp(r'\n\d{10} 00000 n \n')));
+      expect(text, contains('trailer\n'));
+      expect(text, endsWith('%%EOF\n'));
+    });
+
+    test('honours a caller-supplied /Info reference and version', () {
+      final builder = CosDocumentBuilder();
+      final info =
+          builder.add(CosDictionary({'Title': CosString.fromText('Doc')}));
+      final catalog = builder.add(CosDictionary({
+        'Type': const CosName('Catalog'),
+      }));
+      final bytes = builder.build(root: catalog, info: info, version: '1.5');
+
+      expect(String.fromCharCodes(bytes), startsWith('%PDF-1.5\n'));
+      final reopened = CosDocument.open(bytes);
+      final infoDict = reopened.resolve(reopened.trailer['Info']);
+      expect((infoDict as CosDictionary)['Title'], CosString.fromText('Doc'));
+    });
+  });
+}

--- a/packages/pdf_cos/test/builder_test.dart
+++ b/packages/pdf_cos/test/builder_test.dart
@@ -37,7 +37,7 @@ void main() {
       final reopened = CosDocument.open(bytes);
       expect(reopened.catalog.typeName, 'Catalog');
       expect((reopened.getObject(2, 0) as CosDictionary).typeName, 'Page');
-      // four objects registered plus the object-0 free head
+      // three objects registered plus the object-0 free head
       expect(reopened.declaredSize, 4);
       expect(reopened.trailer['Prev'], isNull);
     });

--- a/packages/pdf_cos/test/xref_writer_test.dart
+++ b/packages/pdf_cos/test/xref_writer_test.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:test/test.dart';
+
+/// Renders a writer callback to a string so the exact xref/trailer byte format
+/// can be asserted verbatim - the whole point of sharing the framing.
+String render(void Function(CosXrefTableWriter) body) {
+  final out = BytesBuilder(copy: false);
+  body(CosXrefTableWriter(out));
+  return String.fromCharCodes(out.takeBytes());
+}
+
+void main() {
+  group('runsOf', () {
+    test('groups consecutive numbers into runs', () {
+      expect(CosXrefTableWriter.runsOf([1, 2, 3]), [
+        [1, 2, 3]
+      ]);
+      expect(CosXrefTableWriter.runsOf([1, 2, 4, 5, 9]), [
+        [1, 2],
+        [4, 5],
+        [9]
+      ]);
+      expect(CosXrefTableWriter.runsOf([]), isEmpty);
+    });
+  });
+
+  group('writeTable', () {
+    test('from-scratch table leads with the object-0 free head', () {
+      final table = render((w) => w.writeTable(
+            {1: 15, 2: 74, 3: 132},
+            (_) => 0,
+            includeFreeHead: true,
+          ));
+      expect(
+          table,
+          'xref\n'
+          '0 4\n'
+          '0000000000 65535 f \n'
+          '0000000015 00000 n \n'
+          '0000000074 00000 n \n'
+          '0000000132 00000 n \n');
+    });
+
+    test('incremental table omits the free head and splits runs', () {
+      final table = render((w) => w.writeTable(
+            {5: 900, 6: 950, 9: 1200},
+            (n) => n == 6 ? 2 : 0,
+          ));
+      expect(
+          table,
+          'xref\n'
+          '5 2\n'
+          '0000000900 00000 n \n'
+          '0000000950 00002 n \n'
+          '9 1\n'
+          '0000001200 00000 n \n');
+    });
+  });
+
+  test('writeTrailer frames the dictionary with a trailing newline', () {
+    final trailer = render((w) => w.writeTrailer(CosDictionary({
+          'Size': const CosInteger(4),
+          'Root': const CosReference(1, 0),
+        })));
+    expect(trailer, 'trailer\n<< /Size 4 /Root 1 0 R >>\n');
+  });
+
+  test('writeEpilogue points startxref at the offset', () {
+    expect(render((w) => w.writeEpilogue(2048)),
+        'startxref\n2048\n%%EOF\n');
+  });
+}


### PR DESCRIPTION
## Summary

Closes #318.

`CosSerializer` deepened object serialization but stopped at the object level; the *file-container* framing — the classic cross-reference table, the trailer, and the `startxref`/`%%EOF` epilogue — was re-implemented independently by the from-scratch `CosDocumentBuilder.build` and the incremental `CosIncrementalUpdater.save`. Both emitted the same `NNNNNNNNNN GGGGG n ` entry encoding, the `xref`/`trailer` framing, and the epilogue, each carrying its own `_writeText`.

This extracts a shared `CosXrefTableWriter` (`pdf_cos/lib/src/xref_writer.dart`, exported) that owns the framing:

- **`runsOf(sorted)`** — consecutive-number run grouping, now shared with the xref-stream writer too (its `/Index` needs the same runs), so `updater._runsOf` is deleted.
- **`writeTable(offsets, generationOf, {includeFreeHead})`** — `xref` plus one subsection per run. `includeFreeHead` prepends the object-0 free-list head; it is the *only* structural difference between the from-scratch and incremental tables, so the builder is literally "the incremental case with an empty prefix and no `/Prev`" (the issue's framing).
- **`writeTrailer(dict)`** — kept separate from `writeTable` because the builder hashes the just-written table bytes into `/ID` (§14.4) before it can compose the trailer.
- **`writeEpilogue(xrefOffset)`** — `startxref`/`%%EOF`, shared by both the classic-table and xref-stream branches of `save`.

Trailer *contents* stay per-writer (builder computes an md5 `/ID`; updater copies `Root/Info/Encrypt/ID`, sets `/Prev`, applies overrides). **Output is byte-identical** to before.

## Affected packages

- [x] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Refactor / cleanup

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test`

The whole `pdf_cos` and `pdf_document` suites pass unchanged; workspace `dart analyze` is clean.

## PDF fixtures and screenshots

Tests are programmatic (`CosDocumentBuilder` / direct `CosXrefTableWriter` byte assertions) — no fixture files.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The exact byte format is now asserted **once**, directly, in `xref_writer_test.dart` (free head, entry encoding, run splitting with a non-zero generation, trailer, epilogue, `runsOf`).
- `builder.dart` previously had **no test at all**; `builder_test.dart` now covers object numbering, a reopenable round-trip, the shared from-scratch framing, and caller-supplied `/Info`/version.
- Related: #315 is the read side of the same concern (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6eWtnRLwAfVy1zYGkrXP3)_