### PR TITLE
refactor(dart_pdf_editor): delete the pure style forwarders on PdfEditingController (#317)

### DIFF
--- a/doc/dev-log/2026-07-17-controller-style-forwarders.md
+++ b/doc/dev-log/2026-07-17-controller-style-forwarders.md
@@ -1,0 +1,61 @@
+# 2026-07-17 — delete the pure style forwarders on `PdfEditingController`
+
+Issue #317 (from the 2026-07-16 architecture review). `PdfEditingController`
+carried ~40 members that were pure forwarders to `preferences`
+(`double get strokeWidth => preferences.strokeWidth;` and its setter, etc.).
+Style state lived in three places — `PdfEditingPreferences` (the real store),
+the controller mirror, and the toolbar's field cache — and because a couple of
+setters *do* add behaviour, callers couldn't tell the load-bearing ones from
+the noise.
+
+## What changed
+
+Deleted the pure get/set forwarder pairs for these 19 preference-backed
+properties (38 members):
+
+`strokeWidth`, `cornerRadius`, `eraserRadius`, `fontSize`, `textAlign`,
+`opacity`, `lineStyle`, `lineScale`, `lineStartEnding`, `lineEndEnding`,
+`textFillColor`, `textBorderColor`, `shapeFillColor`, `author`,
+`stampDateFormat`, `stampTimeFormat`, `fingerDrawsInk`, `measurementScale`,
+`signature`.
+
+Callers now read/write `controller.preferences.strokeWidth` directly (the
+toolbar already did in places). Internally the controller reaches through
+`preferences.` too — `author: author` in the `apply` calls became
+`author: preferences.author`, the stamp-template resolver reads
+`preferences.stampDateFormat`/`stampTimeFormat`, and `calibrateScale` /
+`measuredDistance` / the takeoff readouts go through
+`preferences.measurementScale`.
+
+### Kept (load-bearing — clearly the point of the exercise)
+
+- `color` — the setter honours the `colorLocked` guard and recolours the
+  active stamp under the stamp tool. Doc now spells out why it stays.
+- `fontFamily` — the setter clears any embedded `activeFont` (back to base-14)
+  before writing through.
+- `dashedStroke` — a computed boolean view of `preferences.lineStyle` (kept for
+  the drag previews that only distinguish dashed/solid), not a forwarder.
+- `hasMeasurementScale` — derived predicate, not a forwarder.
+- The signature/measurement *behaviour* (`signaturePlacement`, `placeSignature`,
+  `calibrateScale`, `measuredDistance`/`Perimeter`/`Area`, `writeMeasurementScale`)
+  stays on the controller; only the value forwarders went.
+
+## Blast radius / gotchas
+
+- Consumers updated: `editing_overlay.dart`, `editing_toolbar.dart`,
+  `editing_properties.dart`, `editing_stamps.dart`, `editing_takeoff.dart`,
+  `pdf_editor_view.dart`, `pdf_viewer.dart`, plus ~20 test files. All the
+  controller variables were a single consistent identifier per file
+  (`_controller`, `controller`, `session`, `editing`), so the rewrites were a
+  mechanical `X.member` → `X.preferences.member`.
+- `editing_signature.dart` was imported by the controller only for the
+  `PdfInkSignature` return type on the deleted `signature` forwarder — dropped
+  the now-unused import.
+- `editing_preferences_test.dart` deliberately asserted the forwarders; those
+  assertions now read `editing.preferences.strokeWidth`, which is the point of
+  the issue ("style/preference behaviour testable against
+  `PdfEditingPreferences` alone").
+
+The controller's public surface now narrows toward what it actually owns —
+revisions, apply, selection, page ops. A fuller split into
+`revisions`/`selection`/`pageOps` sub-objects is a separate, larger change.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Breaking:** remove the pure style forwarders from `PdfEditingController`.
+  The ~19 tool-style properties that only mirrored `preferences`
+  (`strokeWidth`, `cornerRadius`, `eraserRadius`, `fontSize`, `textAlign`,
+  `opacity`, `lineStyle`, `lineScale`, `lineStartEnding`, `lineEndEnding`,
+  `textFillColor`, `textBorderColor`, `shapeFillColor`, `author`,
+  `stampDateFormat`, `stampTimeFormat`, `fingerDrawsInk`, `measurementScale`,
+  `signature`) are gone; read and write them through
+  `controller.preferences.<name>` instead. The setters that carried editing
+  side effects stay on the controller (`color` still recolours the active
+  stamp and honours the colour lock; `fontFamily` still clears the embedded
+  `activeFont`), as do the computed helpers (`dashedStroke`,
+  `hasMeasurementScale`) and every signature/measurement behaviour method
+  (`placeSignature`, `calibrateScale`, `measuredDistance`, …) (#317).
 - Expose a customizable viewer scroll indicator / page-scrubber API: a
   read-only `PdfScrollMetrics` snapshot (page count, current page,
   normalized position/extent, pixel offsets, zoom) via

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -14,7 +14,6 @@ import 'editing_measure.dart';
 import 'editing_page_clipboard.dart';
 import 'editing_preferences.dart';
 import 'line_style.dart';
-import 'editing_signature.dart';
 import 'editing_stamps.dart';
 import 'text_prompt.dart';
 import 'thumbnail_cache.dart';
@@ -172,7 +171,7 @@ enum PdfEditTool {
   count,
 
   /// Tap to place the saved hand-drawn signature
-  /// ([PdfEditingController.signature]) as an Ink annotation.
+  /// ([PdfEditingPreferences.signature]) as an Ink annotation.
   signature,
 
   /// Insert a raster image (PNG or JPEG). Tapping places it at a default
@@ -334,11 +333,13 @@ class PdfEditingController extends ChangeNotifier {
     this.pageClipboard.addListener(notifyListeners);
   }
 
-  /// The persisted UI preferences backing [color], [strokeWidth],
-  /// [fontSize], [opacity], and [fingerDrawsInk] - every change is saved
-  /// to the local device and restored on the next session. Pass one in
-  /// to share it with the host's chrome (the sidebar-visibility flags
-  /// live there too).
+  /// The persisted UI preferences that own the tool styles (stroke width,
+  /// font size, opacity, colour, the stylus [PdfEditingPreferences.fingerDrawsInk]
+  /// mode, and so on). Read and write them directly - `controller.preferences.
+  /// strokeWidth` - since the controller no longer mirrors them. Every change
+  /// is saved to the local device and restored on the next session. Pass one
+  /// in to share it with the host's chrome (the sidebar-visibility flags live
+  /// there too).
   final PdfEditingPreferences preferences;
 
   /// The clipboard whole copied/cut pages live in, shared across document
@@ -606,7 +607,7 @@ class PdfEditingController extends ChangeNotifier {
   /// Adds a certificate-backed PAdES B-B digital signature as a new editor
   /// revision.
   ///
-  /// This is distinct from the hand-drawn [signature] annotation tool. The
+  /// This is distinct from the hand-drawn [preferences.signature] annotation tool. The
   /// returned revision cryptographically covers every byte in the current
   /// document and embeds [identity]'s X.509 chain. It is validated before it
   /// joins the undo stack; malformed, non-matching, or non-covering output is
@@ -1186,37 +1187,18 @@ class PdfEditingController extends ChangeNotifier {
   /// redact, signature), so the colour swatches aren't shown beside them.
   bool get toolUsesColor => _styleScopeFields(tool).contains('color');
 
-  /// The color new annotations are created with. Persisted (these four
-  /// style properties live in [preferences]).
+  /// The color new annotations are created with. Persisted in [preferences].
+  ///
+  /// Kept on the controller (unlike the other style properties, which are
+  /// read straight off [preferences]) because the setter has editing-side
+  /// effects: it honours the [colorLocked] guard and recolours the active
+  /// stamp under the stamp tool.
   Color get color => preferences.color;
 
   set color(Color value) {
     preferences.setColor(value, recordStyleScope: !_colorLocked);
     if (_tool == PdfEditTool.stamp) _recolorActiveStamp(value);
   }
-
-  /// Stroke width for ink and shape annotations, in PDF points. Persisted.
-  double get strokeWidth => preferences.strokeWidth;
-
-  set strokeWidth(double value) => preferences.strokeWidth = value;
-
-  /// Corner radius for new rectangle shapes, in PDF points; 0 gives square
-  /// corners. Persisted (remembered per the rectangle tool's style scope).
-  double get cornerRadius => preferences.cornerRadius;
-
-  set cornerRadius(double value) => preferences.cornerRadius = value;
-
-  /// The circle eraser's radius, in PDF points - the eraser removes
-  /// every part of an ink stroke within this distance of its swept
-  /// path, PSPDFKit-style. Persisted.
-  double get eraserRadius => preferences.eraserRadius;
-
-  set eraserRadius(double value) => preferences.eraserRadius = value;
-
-  /// Font size for free-text annotations, in PDF points. Persisted.
-  double get fontSize => preferences.fontSize;
-
-  set fontSize(double value) => preferences.fontSize = value;
 
   /// Font family for free-text annotations - one of the standard PDF
   /// text fonts (sans-serif, serif, monospace). Persisted. Selecting a
@@ -1230,13 +1212,6 @@ class PdfEditingController extends ChangeNotifier {
     }
     preferences.fontFamily = value;
   }
-
-  /// Horizontal alignment (left/center/right) new free-text boxes are
-  /// created with, or null (the default) to follow the text direction -
-  /// left for LTR, right for RTL. Persisted.
-  PdfTextAlign? get textAlign => preferences.textAlign;
-
-  set textAlign(PdfTextAlign? value) => preferences.textAlign = value;
 
   double _lineSpacing = kPdfFreeTextDefaultLineSpacing;
   double _charSpacing = 0;
@@ -1321,81 +1296,24 @@ class PdfEditingController extends ChangeNotifier {
     }
   }
 
-  /// Opacity (0–1] new ink, shape, markup, and stamp annotations are
-  /// created with. Free text and notes are always opaque. Persisted.
-  double get opacity => preferences.opacity;
-
-  set opacity(double value) => preferences.opacity = value;
-
-  /// The border line style (solid / dashed / dotted / dash-dot) new shape
-  /// and line annotations are created with. Persisted.
-  PdfLineStyle get lineStyle => preferences.lineStyle;
-
-  set lineStyle(PdfLineStyle value) => preferences.lineStyle = value;
-
   /// Whether new annotations are non-solid - the legacy boolean view of
-  /// [lineStyle] (kept for the drag previews that only show dashed/solid).
+  /// [preferences.lineStyle] (kept for the drag previews that only show
+  /// dashed/solid).
   bool get dashedStroke => preferences.lineStyle != PdfLineStyle.solid;
 
   set dashedStroke(bool value) =>
       preferences.lineStyle = value ? PdfLineStyle.dashed : PdfLineStyle.solid;
 
-  /// The pattern scale new shape and line annotations are created with - a
-  /// multiplier (1 = default) sizing the dash pattern and cloudy scallops
-  /// *independently* of [strokeWidth], so the line thickness and the
-  /// pattern size are set separately. Persisted.
-  double get lineScale => preferences.lineScale;
-
-  set lineScale(double value) => preferences.lineScale = value;
-
   /// The `/BS /D` dash array new annotations get, for the current
-  /// [lineStyle] at the current [strokeWidth], sized by [lineScale] - null
-  /// for a solid border.
+  /// [preferences.lineStyle] at the current [preferences.strokeWidth], sized
+  /// by [preferences.lineScale] - null for a solid border.
   List<double>? get _lineDashPattern => preferences.lineStyle
       .dashArray(preferences.strokeWidth, scale: preferences.lineScale);
-
-  /// The line ending new /Line and /PolyLine annotations carry at their
-  /// start vertex (§12.5.6.7). Persisted.
-  PdfLineEnding get lineStartEnding => preferences.lineStartEnding;
-
-  set lineStartEnding(PdfLineEnding value) =>
-      preferences.lineStartEnding = value;
-
-  /// The line ending new /Line and /PolyLine annotations carry at their
-  /// end vertex (§12.5.6.7). Persisted.
-  PdfLineEnding get lineEndEnding => preferences.lineEndEnding;
-
-  set lineEndEnding(PdfLineEnding value) => preferences.lineEndEnding = value;
-
-  /// The background fill new text boxes get, or null for none (the
-  /// default - a bare text box, like before). Persisted.
-  Color? get textFillColor => preferences.textFillColor;
-
-  set textFillColor(Color? value) => preferences.textFillColor = value;
-
-  /// The border color new text boxes get, or null for none (the
-  /// default). The border is [strokeWidth] points wide. Persisted.
-  Color? get textBorderColor => preferences.textBorderColor;
-
-  set textBorderColor(Color? value) => preferences.textBorderColor = value;
-
-  /// The interior fill new shapes (rectangle/ellipse) get, or null for an
-  /// unfilled outline (the default). Persisted.
-  Color? get shapeFillColor => preferences.shapeFillColor;
-
-  set shapeFillColor(Color? value) => preferences.shapeFillColor = value;
 
   int get _colorValue => preferences.color.toARGB32() & 0xFFFFFF;
 
   static int? _rgbOf(Color? color) =>
       color == null ? null : color.toARGB32() & 0xFFFFFF;
-
-  /// The author name new annotations carry (/T - shown in
-  /// [PdfAnnotationSidebar] and other viewers' comment lists). Null
-  /// (the default) leaves them unsigned. Persisted.
-  String? get author => preferences.author;
-
-  set author(String? value) => preferences.author = value;
 
   Map<String, String> _stampTemplateValues = const {};
 
@@ -1405,7 +1323,8 @@ class PdfEditingController extends ChangeNotifier {
   /// than the saved stamp design.
   ///
   /// Built-ins are added at placement time: `date`, `time`, `datetime`, and
-  /// `username` (which defaults to [author]). Entries here override those
+  /// `username` (which defaults to [preferences.author]). Entries here override
+  /// those
   /// built-ins, so a host can provide its own date formatting or user label.
   Map<String, String> get stampTemplateValues => _stampTemplateValues;
 
@@ -1419,18 +1338,6 @@ class PdfEditingController extends ChangeNotifier {
   /// Clock used for the built-in `date`, `time`, and `datetime` stamp
   /// placeholders. Override in tests or when a host app needs a fixed clock.
   DateTime Function() stampTemplateClock = DateTime.now;
-
-  /// Format used for the built-in `{{date}}` stamp field. Persisted.
-  PdfStampDateFormat get stampDateFormat => preferences.stampDateFormat;
-
-  set stampDateFormat(PdfStampDateFormat value) =>
-      preferences.stampDateFormat = value;
-
-  /// Format used for the built-in `{{time}}` stamp field. Persisted.
-  PdfStampTimeFormat get stampTimeFormat => preferences.stampTimeFormat;
-
-  set stampTimeFormat(PdfStampTimeFormat value) =>
-      preferences.stampTimeFormat = value;
 
   /// Field names the stamp editor should offer for insertion.
   ///
@@ -1460,13 +1367,13 @@ class PdfEditingController extends ChangeNotifier {
 
   Map<String, String> _resolvedStampTemplateValues() {
     final now = stampTemplateClock();
-    final date = stampDateFormat.format(now);
-    final time = stampTimeFormat.format(now);
+    final date = preferences.stampDateFormat.format(now);
+    final time = preferences.stampTimeFormat.format(now);
     return {
       'date': date,
       'time': time,
       'datetime': '$date $time',
-      'username': author ?? '',
+      'username': preferences.author ?? '',
       ..._stampTemplateValues,
     };
   }
@@ -1593,7 +1500,7 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   /// Disarms the eyedropper and adopts [picked] (forced opaque - alpha is
-  /// [opacity]'s job) as the annotation [color].
+  /// [preferences.opacity]'s job) as the annotation [color].
   void finishColorPick(Color picked) {
     _pickingColor = false;
     color = Color(0xFF000000 | (picked.toARGB32() & 0xFFFFFF));
@@ -1670,15 +1577,6 @@ class PdfEditingController extends ChangeNotifier {
       strokeWidth: committed.strokeWidth,
     );
   }
-
-  /// Whether touch pointers draw with the ink tool. When false they
-  /// scroll and zoom as usual and only stylus (and mouse) input draws -
-  /// palm rejection. The viewer turns this off automatically the first
-  /// time a stylus (Apple Pencil) touches a page with the ink tool armed,
-  /// and the choice is persisted with the other [preferences].
-  bool get fingerDrawsInk => preferences.fingerDrawsInk;
-
-  set fingerDrawsInk(bool value) => preferences.fingerDrawsInk = value;
 
   /// Whether touch input is in play this session: always true on
   /// touch-first platforms (iOS/Android/Fuchsia), and flipped on by the
@@ -1758,7 +1656,7 @@ class PdfEditingController extends ChangeNotifier {
               strokeWidth: preferences.strokeWidth,
               opacity: preferences.opacity,
               pressures: pressures[page],
-              author: author,
+              author: preferences.author,
             );
           }
         });
@@ -1805,7 +1703,7 @@ class PdfEditingController extends ChangeNotifier {
                 quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author,
+                author: preferences.author,
               );
             case PdfMarkupKind.underline:
               editor.addUnderline(
@@ -1813,7 +1711,7 @@ class PdfEditingController extends ChangeNotifier {
                 quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author,
+                author: preferences.author,
               );
             case PdfMarkupKind.strikeOut:
               editor.addStrikeOut(
@@ -1821,7 +1719,7 @@ class PdfEditingController extends ChangeNotifier {
                 quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author,
+                author: preferences.author,
               );
             case PdfMarkupKind.squiggly:
               editor.addSquiggly(
@@ -1829,7 +1727,7 @@ class PdfEditingController extends ChangeNotifier {
                 quads,
                 color: _colorValue,
                 opacity: preferences.opacity,
-                author: author,
+                author: preferences.author,
               );
           }
         });
@@ -1847,7 +1745,7 @@ class PdfEditingController extends ChangeNotifier {
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
           cornerRadius: preferences.cornerRadius,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -1858,7 +1756,7 @@ class PdfEditingController extends ChangeNotifier {
   /// annotation, fill black). This is the MARK phase - nothing is removed
   /// until [applyRedactions]. Undoable like any other edit until burned.
   void addRedaction(int pageIndex, PdfRect rect) => apply(
-        (e) => e.addRedaction(pageIndex, [rect], author: author),
+        (e) => e.addRedaction(pageIndex, [rect], author: preferences.author),
       );
 
   /// Marks the text runs in [quadsByPage] for redaction (one /Redact
@@ -1870,7 +1768,7 @@ class PdfEditingController extends ChangeNotifier {
       (editor) {
         quadsByPage.forEach((page, quads) {
           if (quads.isNotEmpty) {
-            editor.addRedaction(page, quads, author: author);
+            editor.addRedaction(page, quads, author: preferences.author);
           }
         });
       },
@@ -1939,14 +1837,14 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.shapeFillColor),
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
-          author: author,
+          author: preferences.author,
         ),
       );
 
   /// Adds a line from [start] to [end]. With [arrow] the end carries a
   /// closed arrowhead (the dedicated arrow tool); otherwise the start and
   /// end endings come from the persisted [PdfEditingPreferences]
-  /// ([lineStartEnding] / [lineEndEnding]).
+  /// ([preferences.lineStartEnding] / [preferences.lineEndEnding]).
   void addLine(
     int pageIndex,
     (double, double) start,
@@ -1965,7 +1863,7 @@ class PdfEditingController extends ChangeNotifier {
           startEnding: arrow ? PdfLineEnding.none : preferences.lineStartEnding,
           endEnding:
               arrow ? PdfLineEnding.closedArrow : preferences.lineEndEnding,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -1979,7 +1877,7 @@ class PdfEditingController extends ChangeNotifier {
           dashPattern: _lineDashPattern,
           startEnding: preferences.lineStartEnding,
           endEnding: preferences.lineEndEnding,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -1992,7 +1890,7 @@ class PdfEditingController extends ChangeNotifier {
           fillColor: _rgbOf(preferences.shapeFillColor),
           opacity: preferences.opacity,
           dashPattern: _lineDashPattern,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -2018,27 +1916,18 @@ class PdfEditingController extends ChangeNotifier {
           dashPattern: _lineDashPattern,
           cloudy: true,
           cloudScale: preferences.lineScale,
-          author: author,
+          author: preferences.author,
         ),
       );
 
   // ---------------------------------------------------------------------
   // measurements (§12.9)
 
-  /// The active measurement calibration the measure tools stamp onto new
-  /// annotations, or null until [calibrateScale] (or setting
-  /// [measurementScale]) provides one. Persisted with the other
-  /// [preferences].
-  PdfMeasurementScale? get measurementScale => preferences.measurementScale;
-
-  set measurementScale(PdfMeasurementScale? value) =>
-      preferences.measurementScale = value;
-
   /// Whether a measurement tool can place an annotation right now - i.e. a
   /// scale has been calibrated.
   bool get hasMeasurementScale => preferences.measurementScale != null;
 
-  /// Calibrates [measurementScale] from a reference segment between
+  /// Calibrates [preferences.measurementScale] from a reference segment between
   /// [start] and [end] (page-space points) that represents [realLength]
   /// [unitLabel]s. The classic "two-point calibration" flow.
   void calibrateScale(
@@ -2054,7 +1943,7 @@ class PdfEditingController extends ChangeNotifier {
     final dy = end.$2 - start.$2;
     final length = math.sqrt(dx * dx + dy * dy);
     if (length <= 0 || realLength <= 0) return;
-    measurementScale = PdfMeasurementScale.fromReference(
+    preferences.measurementScale = PdfMeasurementScale.fromReference(
       pointLength: length,
       realLength: realLength,
       unitLabel: unitLabel,
@@ -2067,7 +1956,7 @@ class PdfEditingController extends ChangeNotifier {
   /// The live distance readout for a segment from [start] to [end]
   /// (page-space points), or null without a scale.
   String? measuredDistance((double, double) start, (double, double) end) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null) return null;
     final dx = end.$1 - start.$1;
     final dy = end.$2 - start.$2;
@@ -2077,7 +1966,7 @@ class PdfEditingController extends ChangeNotifier {
   /// The live perimeter readout (sum of segment lengths) for a page-space
   /// polyline through [points], or null without a scale.
   String? measuredPerimeter(List<(double, double)> points) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null || points.length < 2) return null;
     var total = 0.0;
     for (var i = 0; i + 1 < points.length; i++) {
@@ -2091,7 +1980,7 @@ class PdfEditingController extends ChangeNotifier {
   /// The live area readout (shoelace) for a page-space polygon through
   /// [points], or null without a scale or fewer than three points.
   String? measuredArea(List<(double, double)> points) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null || points.length < 3) return null;
     return scale.toMeasure().formatArea(pdfShoelaceArea(points));
   }
@@ -2102,7 +1991,7 @@ class PdfEditingController extends ChangeNotifier {
     List<(double, double)> points, [
     List<List<(double, double)>> holes = const [],
   ]) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null || points.length < 3) return null;
     return scale.toMeasure().formatArea(pdfNetPolygonArea(points, holes));
   }
@@ -2110,7 +1999,7 @@ class PdfEditingController extends ChangeNotifier {
   /// The live volume readout (area × [depth], depth in the scale's unit)
   /// for a page-space polygon, or null without a scale.
   String? measuredVolume(List<(double, double)> points, double depth) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null || points.length < 3) return null;
     return scale.toMeasure().formatVolume(pdfShoelaceArea(points), depth);
   }
@@ -2120,7 +2009,7 @@ class PdfEditingController extends ChangeNotifier {
   /// an angle is unit-free.
   String? measuredAngle(List<(double, double)> points) {
     if (points.length < 3) return null;
-    return (measurementScale?.toMeasure() ??
+    return (preferences.measurementScale?.toMeasure() ??
             PdfMeasure.scale(unitsPerPoint: 1, unitLabel: ''))
         .formatAngle(pdfMeasurementAngle(points));
   }
@@ -2128,7 +2017,7 @@ class PdfEditingController extends ChangeNotifier {
   /// The live slope readout (inclination above horizontal, degrees) for a
   /// segment from [start] to [end]. Needs no scale.
   String? measuredSlope((double, double) start, (double, double) end) {
-    return (measurementScale?.toMeasure() ??
+    return (preferences.measurementScale?.toMeasure() ??
             PdfMeasure.scale(unitsPerPoint: 1, unitLabel: ''))
         .formatAngle(pdfSlopeDegrees(start, end));
   }
@@ -2136,7 +2025,7 @@ class PdfEditingController extends ChangeNotifier {
   /// The live arc-length readout for the three page-space [points] (start,
   /// mid, end on the arc), or null without a scale or fewer than three.
   String? measuredArc(List<(double, double)> points) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null || points.length < 3) return null;
     final metrics = pdfArcMetrics(points[0], points[1], points[2]);
     final len = metrics?.length ?? pdfPolylineLength(points);
@@ -2144,7 +2033,7 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   /// Adds a measurement annotation of [kind] through [points] using the
-  /// active [measurementScale] (count needs none). [depth] feeds a volume,
+  /// active [preferences.measurementScale] (count needs none). [depth] feeds a volume,
   /// [holes] cut a net-area polygon, [label] buckets the running total.
   /// A no-op for a scaled kind without a scale.
   void addMeasurement(
@@ -2155,7 +2044,7 @@ class PdfEditingController extends ChangeNotifier {
     List<List<(double, double)>> holes = const [],
     String? label,
   }) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null && kind != PdfMeasurementKind.count) return;
     apply(
       (e) => e.addMeasurement(
@@ -2177,7 +2066,7 @@ class PdfEditingController extends ChangeNotifier {
         captionSize: preferences.fontSize,
         startEnding: preferences.lineStartEnding,
         endEnding: preferences.lineEndEnding,
-        author: author,
+        author: preferences.author,
       ),
     );
   }
@@ -2198,13 +2087,13 @@ class PdfEditingController extends ChangeNotifier {
   /// walk), so callers refresh it whenever the controller notifies.
   PdfTakeoffSummary get takeoffSummary => PdfTakeoffSummary.of(_document);
 
-  /// Writes the active [measurementScale] into the document itself (a /VP
+  /// Writes the active [preferences.measurementScale] into the document itself (a /VP
   /// viewport /Measure on [pageIndex], or every page when null) so the
   /// drawing scale travels with the file - surviving a reopen and portable
   /// across devices - not just in this device's preferences. A no-op
   /// without a scale.
   void persistScaleToDocument({int? pageIndex}) {
-    final scale = measurementScale;
+    final scale = preferences.measurementScale;
     if (scale == null) return;
     final measure = scale.toMeasure();
     final pages = pageIndex != null
@@ -2224,11 +2113,11 @@ class PdfEditingController extends ChangeNotifier {
   /// measures correctly without re-calibration. Returns true when a scale
   /// was adopted. Call after binding a new document.
   bool adoptDocumentScale() {
-    if (measurementScale != null) return false;
+    if (preferences.measurementScale != null) return false;
     for (var i = 0; i < _document.pageCount; i++) {
       final m = _document.page(i).measure;
       if (m != null) {
-        measurementScale = PdfMeasurementScale.fromMeasure(m);
+        preferences.measurementScale = PdfMeasurementScale.fromMeasure(m);
         return true;
       }
     }
@@ -2297,7 +2186,7 @@ class PdfEditingController extends ChangeNotifier {
           horizontalScale: _fontWidth,
           underline: _textUnderline,
           pageRotation: _page(pageIndex).rotation,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -2326,7 +2215,7 @@ class PdfEditingController extends ChangeNotifier {
           strokeColor: _rgbOf(preferences.textBorderColor) ?? _colorValue,
           strokeWidth: preferences.strokeWidth,
           pageRotation: _page(pageIndex).rotation,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -2348,7 +2237,7 @@ class PdfEditingController extends ChangeNotifier {
           charSpacing: _charSpacing,
           horizontalScale: _fontWidth,
           pageRotation: _page(pageIndex).rotation,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -2389,7 +2278,7 @@ class PdfEditingController extends ChangeNotifier {
         borderColor: _rgbOf(preferences.textBorderColor),
         borderWidth: preferences.strokeWidth,
         pageRotation: _page(pageIndex).rotation,
-        author: author,
+        author: preferences.author,
       ),
     );
     if (!pasted) return false;
@@ -2411,7 +2300,7 @@ class PdfEditingController extends ChangeNotifier {
           color: color ?? _colorValue,
           opacity: preferences.opacity,
           pageRotation: _page(pageIndex).rotation,
-          author: author,
+          author: preferences.author,
         ),
       );
 
@@ -2429,7 +2318,7 @@ class PdfEditingController extends ChangeNotifier {
               color: stamp.color,
               opacity: preferences.opacity,
               pageRotation: _page(pageIndex).rotation,
-              author: author,
+              author: preferences.author,
               stampType: stamp.type,
               stampTags: stamp.tags,
             );
@@ -2442,7 +2331,7 @@ class PdfEditingController extends ChangeNotifier {
               color: stamp.color,
               opacity: preferences.opacity,
               pageRotation: _page(pageIndex).rotation,
-              author: author,
+              author: preferences.author,
               stampType: stamp.type,
               stampTags: stamp.tags,
               templateValues: templateValues,
@@ -2576,7 +2465,7 @@ class PdfEditingController extends ChangeNotifier {
         image,
         opacity: preferences.opacity,
         pageRotation: _page(pageIndex).rotation,
-        author: author,
+        author: preferences.author,
       ),
     );
     if (!added) return false;
@@ -2598,19 +2487,12 @@ class PdfEditingController extends ChangeNotifier {
           text,
           color: _colorValue,
           pageRotation: _page(pageIndex).rotation,
-          author: author,
+          author: preferences.author,
         ),
       );
 
   // ---------------------------------------------------------------------
   // signature
-
-  /// The saved hand-drawn signature the signature tool stamps. Persisted
-  /// with the other [preferences], so it survives app restarts. Drawn in
-  /// [showPdfSignatureDialog].
-  PdfInkSignature? get signature => preferences.signature;
-
-  set signature(PdfInkSignature? value) => preferences.signature = value;
 
   /// The layout [placeSignature] would commit for a tap at ([x], [y]):
   /// the page-space strokes, pressures, ink color, and stroke width -
@@ -2653,7 +2535,7 @@ class PdfEditingController extends ChangeNotifier {
     );
   }
 
-  /// Stamps [signature] as an Ink annotation centered on ([x], [y]) in
+  /// Stamps [preferences.signature] as an Ink annotation centered on ([x], [y]) in
   /// page space, [width] points wide (clamped, with the center, so the
   /// whole signature stays on the page). Keeps the signature's own ink
   /// color and pen pressures. Returns false when none is saved.
@@ -2668,7 +2550,7 @@ class PdfEditingController extends ChangeNotifier {
         strokeWidth: placement.strokeWidth,
         opacity: 1,
         pressures: placement.pressures,
-        author: author,
+        author: preferences.author,
       ),
     );
   }
@@ -2823,7 +2705,7 @@ class PdfEditingController extends ChangeNotifier {
             color: stamp.color,
             opacity: preferences.opacity,
             pageRotation: _page(pageIndex).rotation,
-            author: author,
+            author: preferences.author,
             stampType: stamp.type,
             stampTags: stamp.tags,
             templateValues: templateValues,
@@ -2912,7 +2794,7 @@ class PdfEditingController extends ChangeNotifier {
         color: color ?? _colorValue,
         opacity: preferences.opacity,
         pageRotation: _page(pageIndex).rotation,
-        author: author,
+        author: preferences.author,
         stampType: stampType,
         stampTags: stampTags,
       ),
@@ -2947,7 +2829,7 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Drops a check-mark centered on ([x], [y]) in page space, [size] points
   /// per side (clamped, with the centre, so the whole mark stays on the
-  /// page). The mark follows the selected toolbar [color] and [opacity] and
+  /// page). The mark follows the selected toolbar [color] and [preferences.opacity] and
   /// is a real /Stamp annotation, so it can be moved, resized, and deleted
   /// like any other. This is the count tool's tap-to-place - repeated taps
   /// build the tally exposed by [checkMarkCount], Bluebeam-style.
@@ -2968,7 +2850,7 @@ class PdfEditingController extends ChangeNotifier {
         color: _colorValue,
         opacity: preferences.opacity,
         pageRotation: _page(pageIndex).rotation,
-        author: author,
+        author: preferences.author,
       ),
     );
   }
@@ -4020,7 +3902,8 @@ class PdfEditingController extends ChangeNotifier {
   // comment threads (§12.5.6.x)
 
   /// Replies to [target] on [pageIndex] with [contents], stamping the
-  /// controller's [author]. The reply is appearance-less thread content
+  /// controller's [preferences.author]. The reply is appearance-less thread
+  /// content
   /// (it does not repaint the page); one revision, emitted on
   /// [annotationChanges] so it syncs. Returns whether it was added (a
   /// blank [contents] adds nothing).
@@ -4029,7 +3912,7 @@ class PdfEditingController extends ChangeNotifier {
     // a thread edit changes no page graphics: const [] skips re-raster
     // while still diffing for the change feed (see apply's pages contract)
     return apply(
-      (e) => e.replyToAnnotation(pageIndex, target, contents, author: author),
+      (e) => e.replyToAnnotation(pageIndex, target, contents, author: preferences.author),
     );
   }
 
@@ -4041,17 +3924,17 @@ class PdfEditingController extends ChangeNotifier {
     PdfReviewState state,
   ) =>
       apply(
-        (e) => e.setReviewState(pageIndex, target, state, author: author),
+        (e) => e.setReviewState(pageIndex, target, state, author: preferences.author),
       );
 
   /// Marks [target]'s thread resolved (review state `Completed`).
   bool resolveThread(int pageIndex, PdfAnnotation target) => apply(
-        (e) => e.resolveThread(pageIndex, target, author: author),
+        (e) => e.resolveThread(pageIndex, target, author: preferences.author),
       );
 
   /// Reopens [target]'s thread (review state `None`).
   bool reopenThread(int pageIndex, PdfAnnotation target) => apply(
-        (e) => e.reopenThread(pageIndex, target, author: author),
+        (e) => e.reopenThread(pageIndex, target, author: preferences.author),
       );
 
   /// The reply threads on [pageIndex] (read-only model), assembled from
@@ -4062,14 +3945,14 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Erases along [path] (page space) with the circle eraser: every
   /// ink annotation on [pageIndex] is sliced where the swept circle of
-  /// [eraserRadius] crosses its strokes - strokes split, the rest
+  /// [preferences.eraserRadius] crosses its strokes - strokes split, the rest
   /// survives - in one revision, so a single undo restores the whole
   /// swipe. Ink annotations without a usable /InkList can't be sliced
   /// and are deleted whole when the path reaches their rect. Returns
   /// whether anything changed.
   bool sliceErase(int pageIndex, List<(double, double)> path) {
     if (path.isEmpty) return false;
-    final radius = eraserRadius;
+    final radius = preferences.eraserRadius;
     // resolve every target up front: removals shift /Annots slots, but
     // the editor works by dictionary identity
     final targets = [
@@ -4430,7 +4313,7 @@ class PdfEditingController extends ChangeNotifier {
           pageIndex,
           target,
           snapshot,
-          author: author,
+          author: preferences.author,
           sharedObject: _snapshotCapturedRef,
         );
       },
@@ -4520,7 +4403,7 @@ class PdfEditingController extends ChangeNotifier {
   /// for the pattern-scale control to display, or null when the selection
   /// isn't a cloud - other shapes bake their pattern scale into the stored
   /// dash array rather than a readable field, so the control falls back to
-  /// the creation default [lineScale] for them.
+  /// the creation default [preferences.lineScale] for them.
   double? get selectedLineScale {
     final annotation = selectedAnnotation;
     if (annotation == null) return null;
@@ -4577,7 +4460,7 @@ class PdfEditingController extends ChangeNotifier {
             strokeWidth: strokeWidth,
             opacity: opacity,
             dashPattern: recomputeDash
-                ? (style.dashArray(width, scale: scale ?? lineScale),)
+                ? (style.dashArray(width, scale: scale ?? preferences.lineScale),)
                 : null,
             cloudScale: scale,
             // rounding only lands on /Square rectangles; other subtypes
@@ -5411,7 +5294,7 @@ class PdfEditingController extends ChangeNotifier {
   /// quadding), regenerating its appearance, and makes it the default for
   /// new boxes. A no-op when the selection isn't a single free-text box.
   void setSelectedTextAlign(PdfTextAlign align) {
-    textAlign = align; // the new default either way
+    preferences.textAlign = align; // the new default either way
     if (canRestyleSelectedText) restyleSelectedText(align: align);
   }
 
@@ -6078,7 +5961,7 @@ class PdfEditingController extends ChangeNotifier {
           image,
           opacity: preferences.opacity,
           pageRotation: _page(selected.$1).rotation,
-          author: author,
+          author: preferences.author,
         ),
     );
   }
@@ -6559,7 +6442,7 @@ class PdfEditingController extends ChangeNotifier {
 
   /// Restyles the text field [name] ([PdfEditor.setTextFieldStyle]): each
   /// non-null argument is applied. [font] may be a base-14 [PdfStandardFont]
-  /// or an embedded [PdfEmbeddedFont]; [autoSize] true (or [fontSize] 0)
+  /// or an embedded [PdfEmbeddedFont]; [autoSize] true (or [preferences.fontSize] 0)
   /// fits the text to the box; [color] is 0xRRGGBB. Returns false for a
   /// missing, read-only, or non-text field.
   bool setFormFieldStyle(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1077,7 +1077,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// but finger-drawing is off, so touch is reserved for scrolling.
   bool get _fingerPansViewport =>
       _drawTool &&
-      !_controller.fingerDrawsInk &&
+      !_controller.preferences.fingerDrawsInk &&
       _host.panViewport != null;
   bool get _polyTool =>
       _tool == PdfEditTool.polyline ||
@@ -1136,7 +1136,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (!_drawTool) return false;
     return switch (kind) {
       PointerDeviceKind.stylus || PointerDeviceKind.invertedStylus => true,
-      PointerDeviceKind.touch => _controller.fingerDrawsInk,
+      PointerDeviceKind.touch => _controller.preferences.fingerDrawsInk,
       _ => false,
     };
   }
@@ -1209,12 +1209,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return;
     }
     if (_drawTool &&
-        _controller.fingerDrawsInk &&
+        _controller.preferences.fingerDrawsInk &&
         (event.kind == PointerDeviceKind.stylus ||
             event.kind == PointerDeviceKind.invertedStylus)) {
       // an Apple Pencil (or other stylus) is in play: from now on the
       // pen draws and fingers scroll, until the user toggles it back
-      _controller.fingerDrawsInk = false;
+      _controller.preferences.fingerDrawsInk = false;
     }
     if (_pointers.rawPointer == null && _rawDrives(event.kind)) {
       _pointers.rawPointer = event.pointer;
@@ -1403,7 +1403,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// deletes them.
   void _eraseAt(Offset position) {
     final point = _geometry.toPagePoint(position);
-    final radius = _controller.eraserRadius;
+    final radius = _controller.preferences.eraserRadius;
     final from = _erasePath.isEmpty ? point : _erasePath.last;
     setState(() {
       _eraserCursor = position;
@@ -1784,7 +1784,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         template: null,
         check: check,
         color: color,
-        opacity: _controller.opacity.clamp(0.0, 1.0).toDouble(),
+        opacity: _controller.preferences.opacity.clamp(0.0, 1.0).toDouble(),
       ),
       document: _controller.document,
     );
@@ -1839,7 +1839,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         template: template,
         check: check,
         color: color,
-        opacity: _controller.opacity.clamp(0.0, 1.0).toDouble(),
+        opacity: _controller.preferences.opacity.clamp(0.0, 1.0).toDouble(),
       );
 
   _StampAfterimage? _activeStampAfterimageAt(Offset position) {
@@ -1902,7 +1902,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       template: null,
       check: true,
       color: _controller.color,
-      opacity: _controller.opacity.clamp(0.0, 1.0).toDouble(),
+      opacity: _controller.preferences.opacity.clamp(0.0, 1.0).toDouble(),
     );
   }
 
@@ -2256,7 +2256,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // a new box in flight follows the tune popup's box-level defaults live
     // (alignment, spacing, underline) instead of only picking them up on open
     if (!_textEditExisting && _textEditFieldName == null) {
-      final align = _controller.textAlign;
+      final align = _controller.preferences.textAlign;
       final ls = _controller.lineSpacing;
       final cs = _controller.charSpacing;
       final ul = _controller.textUnderline;
@@ -2504,7 +2504,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   Rect _defaultPlacementRect(Offset tap) {
     final scale = _geometry.scale;
     final w = 200.0 * scale;
-    final h = (_controller.fontSize * 1.6 + 8) * scale;
+    final h = (_controller.preferences.fontSize * 1.6 + 8) * scale;
     final size = _geometry.viewSize;
     final left = tap.dx.clamp(0.0, math.max(0.0, size.width - w)).toDouble();
     final top = tap.dy.clamp(0.0, math.max(0.0, size.height - h)).toDouble();
@@ -2536,7 +2536,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     final defaultFont = existing
         ? (style?.font ?? _controller.fontFamily)
         : (_controller.activeFont ?? _controller.fontFamily);
-    final defaultSize = style?.size ?? _controller.fontSize;
+    final defaultSize = style?.size ?? _controller.preferences.fontSize;
     final defaultColor = annotationColor != null
         ? Color(0xFF000000 | annotationColor)
         : _controller.color;
@@ -2566,7 +2566,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           defaultFont is PdfStandardFont ? defaultFont : _controller.fontFamily;
       _textEditSize = defaultSize;
       _textEditColor = defaultColor;
-      _textEditAlign = existing ? parsed?.alignment : _controller.textAlign;
+      _textEditAlign = existing ? parsed?.alignment : _controller.preferences.textAlign;
       _textEditLineSpacing = existing
           ? (parsed?.lineSpacing ?? kPdfFreeTextDefaultLineSpacing)
           : _controller.lineSpacing;
@@ -2576,7 +2576,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           ? (parsed?.fillColor != null
               ? Color(0xFF000000 | parsed!.fillColor!)
               : null)
-          : _controller.textFillColor;
+          : _controller.preferences.textFillColor;
     });
     _beginInteraction(PdfEditingInteractionIntent.text, _lastPointerKind);
     _controller.setEditingText(true);
@@ -2645,8 +2645,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return (
         terminus,
         _nearestBoxEdge(_textEditRect!, terminus),
-        _controller.textBorderColor ?? _controller.color,
-        _controller.strokeWidth * _geometry.scale,
+        _controller.preferences.textBorderColor ?? _controller.color,
+        _controller.preferences.strokeWidth * _geometry.scale,
       );
     }
     return null;
@@ -2995,7 +2995,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       case PdfEditTool.signature:
         // press-drag-release placement: the preview rides the pointer
         // (touch has no hover), release commits where it landed
-        if (_controller.signature != null) {
+        if (_controller.preferences.signature != null) {
           _beginInteraction(
               PdfEditingInteractionIntent.signature, details.kind);
           setState(() {
@@ -3564,9 +3564,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       points: [start, end],
       tool: _tool!,
       color: _controller.color
-          .withValues(alpha: _controller.opacity.clamp(0.0, 1.0)),
+          .withValues(alpha: _controller.preferences.opacity.clamp(0.0, 1.0)),
       fillColor: null,
-      strokeWidth: _controller.strokeWidth * _geometry.scale,
+      strokeWidth: _controller.preferences.strokeWidth * _geometry.scale,
       dashed: _controller.dashedStroke,
     );
     _afterDocument = _controller.document;
@@ -3576,7 +3576,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// the real world, then derives [PdfEditingController.measurementScale]
   /// from it and disarms the tool. Nothing is stamped on the page.
   Future<void> _commitCalibration(Offset start, Offset end) async {
-    final existing = _controller.measurementScale;
+    final existing = _controller.preferences.measurementScale;
     final result = await showPdfCalibrationLengthDialog(
       context,
       initialUnit: existing?.unitLabel,
@@ -3599,7 +3599,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   Future<void> _commitVolume(List<(double, double)> pagePoints) async {
     final depth = await showPdfDepthDialog(
       context,
-      unitLabel: _controller.measurementScale?.unitLabel,
+      unitLabel: _controller.preferences.measurementScale?.unitLabel,
     );
     if (!mounted || depth == null) return;
     _controller.addMeasurement(
@@ -3639,7 +3639,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           : Color(0xFF000000 | annotation!.behavior.style.fillColor!)
               .withValues(alpha: opacity),
       strokeWidth:
-          (style?.strokeWidth ?? _controller.strokeWidth) * _geometry.scale,
+          (style?.strokeWidth ?? _controller.preferences.strokeWidth) * _geometry.scale,
       dashed: annotation?.borderDash != null,
     );
     _afterDocument = _controller.document;
@@ -3667,7 +3667,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           : Color(0xFF000000 | annotation.behavior.style.fillColor!)
               .withValues(alpha: opacity),
       strokeWidth:
-          (style.strokeWidth ?? _controller.strokeWidth) * _geometry.scale,
+          (style.strokeWidth ?? _controller.preferences.strokeWidth) * _geometry.scale,
       dashed: annotation.borderDash != null,
     );
   }
@@ -3749,8 +3749,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _polyPoints = null;
       _polyHover = null;
     });
-    final opacity = _controller.opacity.clamp(0.0, 1.0);
-    final fill = _controller.shapeFillColor;
+    final opacity = _controller.preferences.opacity.clamp(0.0, 1.0);
+    final fill = _controller.preferences.shapeFillColor;
     _afterPath = (
       points: simplified,
       tool: _tool!,
@@ -3763,7 +3763,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
               fill != null
           ? fill.withValues(alpha: opacity)
           : null,
-      strokeWidth: _controller.strokeWidth * _geometry.scale,
+      strokeWidth: _controller.preferences.strokeWidth * _geometry.scale,
       dashed: _controller.dashedStroke,
     );
     _afterDocument = _controller.document;
@@ -3791,8 +3791,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           rect: viewRect,
           tool: tool,
           color: _controller.color
-              .withValues(alpha: _controller.opacity.clamp(0.0, 1.0)),
-          strokeWidth: _controller.strokeWidth * _geometry.scale,
+              .withValues(alpha: _controller.preferences.opacity.clamp(0.0, 1.0)),
+          strokeWidth: _controller.preferences.strokeWidth * _geometry.scale,
         );
         _afterDocument = _controller.document;
       case PdfEditTool.stamp:
@@ -4218,7 +4218,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       cursor = SystemMouseCursors.precise;
     } else if (_tool == PdfEditTool.signature) {
       // the live preview rides the mouse; a click commits it
-      if (_controller.signature != null &&
+      if (_controller.preferences.signature != null &&
           event.localPosition != _signaturePreview) {
         setState(() => _signaturePreview = event.localPosition);
       }
@@ -4362,7 +4362,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     } else if (font is PdfEmbeddedFont) {
       _controller.activeFont = font;
     }
-    if (size != null) _controller.fontSize = size;
+    if (size != null) _controller.preferences.fontSize = size;
     if (color != null) _controller.color = Color(0xFF000000 | rgb!);
     if (underline != null) _controller.textUnderline = underline;
     _controller.setEditingTextSelection(_textEditText.selection);
@@ -4670,8 +4670,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       } else {
         return null;
       }
-      width = _controller.strokeWidth;
-      opacity = _controller.opacity;
+      width = _controller.preferences.strokeWidth;
+      opacity = _controller.preferences.opacity;
     } else {
       return null;
     }
@@ -4987,7 +4987,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         behavior: HitTestBehavior.opaque,
         // with finger drawing off, touch falls through to the scroll
         // view and only pen-like devices reach the ink recognizers
-        supportedDevices: _drawTool && !_controller.fingerDrawsInk
+        supportedDevices: _drawTool && !_controller.preferences.fingerDrawsInk
             ? const {
                 PointerDeviceKind.stylus,
                 PointerDeviceKind.invertedStylus,
@@ -5060,7 +5060,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     chromeScale: _chromeScale,
                     tool: _tool,
                     color: _controller.color,
-                    strokeWidth: _controller.strokeWidth * _geometry.scale,
+                    strokeWidth: _controller.preferences.strokeWidth * _geometry.scale,
                     geometry: _geometry,
                     // the in-progress stroke is NOT here - it rides its own
                     // RepaintBoundary layer below so each appended point is a
@@ -5079,9 +5079,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     dragPath: polyPreview,
                     dragPathFill: (_tool == PdfEditTool.polygon ||
                                 _tool == PdfEditTool.cloudPolygon) &&
-                            _controller.shapeFillColor != null
-                        ? _controller.shapeFillColor!.withValues(
-                            alpha: _controller.opacity.clamp(0.0, 1.0))
+                            _controller.preferences.shapeFillColor != null
+                        ? _controller.preferences.shapeFillColor!.withValues(
+                            alpha: _controller.preferences.opacity.clamp(0.0, 1.0))
                         : null,
                     dashed: _controller.dashedStroke,
                     livePath: vertexPreview,
@@ -5138,12 +5138,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                         _tool == PdfEditTool.eraser || _pointers.rawErasing
                             ? _eraserCursor
                             : null,
-                    eraserRadius: _controller.eraserRadius * _geometry.scale,
+                    eraserRadius: _controller.preferences.eraserRadius * _geometry.scale,
                     // the pen-preview dot (ink tool) and the rotation glyph
                     // (rotate knob): painted in place of the system cursor
                     penCursor:
                         _inkTool && _activeStroke == null ? _penCursor : null,
-                    penOpacity: _controller.opacity,
+                    penOpacity: _controller.preferences.opacity,
                     countPreview:
                         _tool == PdfEditTool.count && _countCursor != null
                             ? _countPreviewAt(_countCursor!)
@@ -5598,17 +5598,17 @@ class _ActiveStrokePainter extends CustomPainter {
       [display],
       [pressures],
       _state._controller.color,
-      _state._controller.strokeWidth * geometry.scale,
+      _state._controller.preferences.strokeWidth * geometry.scale,
     );
     final cursor = _state._penCursor;
     if (cursor != null && _state._inkTool) {
       _paintPenCursor(
         canvas,
         cursor,
-        strokeWidth: _state._controller.strokeWidth * geometry.scale,
+        strokeWidth: _state._controller.preferences.strokeWidth * geometry.scale,
         chromeScale: _state._chromeScale,
         color: _state._controller.color,
-        opacity: _state._controller.opacity,
+        opacity: _state._controller.preferences.opacity,
       );
     }
   }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -332,7 +332,7 @@ class _PdfAnnotationPropertiesPanelState
         initial: current ?? const Color(0xFF000000));
     if (picked != null) {
       _controller.restyleSelectedText(
-          border: (_rgb(picked),), borderWidth: _controller.strokeWidth);
+          border: (_rgb(picked),), borderWidth: _controller.preferences.strokeWidth);
     }
   }
 
@@ -558,7 +558,7 @@ class _PdfAnnotationPropertiesPanelState
       ]);
       children.add(_sliderRow(
         'Stroke',
-        _draggingStroke ?? widths.value ?? _controller.strokeWidth,
+        _draggingStroke ?? widths.value ?? _controller.preferences.strokeWidth,
         key: const ValueKey('pdf-prop-stroke'),
         min: 0.5,
         max: 16,
@@ -604,14 +604,14 @@ class _PdfAnnotationPropertiesPanelState
         'Scale',
         _draggingScale ??
             _controller.selectedLineScale ??
-            _controller.lineScale,
+            _controller.preferences.lineScale,
         key: const ValueKey('pdf-prop-line-scale'),
         min: 0.5,
         max: 4,
         display: (v) => '${v.toStringAsFixed(1)}×',
         onChanged: (v) => setState(() => _draggingScale = v),
         onChangeEnd: (v) {
-          _controller.lineScale = v;
+          _controller.preferences.lineScale = v;
           _controller.restyleSelected(scale: v);
           setState(() => _draggingScale = null);
         },

--- a/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
@@ -366,10 +366,10 @@ class _StampDateTimeFormatControls extends StatelessWidget {
       children: [
         KeyedSubtree(
           key: ValueKey(
-              'pdf-stamp-date-format-field-${controller.stampDateFormat.name}'),
+              'pdf-stamp-date-format-field-${controller.preferences.stampDateFormat.name}'),
           child: DropdownButtonFormField<PdfStampDateFormat>(
             key: const ValueKey('pdf-stamp-date-format'),
-            initialValue: controller.stampDateFormat,
+            initialValue: controller.preferences.stampDateFormat,
             decoration: const InputDecoration(labelText: 'Date format'),
             items: [
               for (final format in PdfStampDateFormat.values)
@@ -380,17 +380,17 @@ class _StampDateTimeFormatControls extends StatelessWidget {
                 ),
             ],
             onChanged: (value) {
-              if (value != null) controller.stampDateFormat = value;
+              if (value != null) controller.preferences.stampDateFormat = value;
             },
           ),
         ),
         const SizedBox(height: 8),
         KeyedSubtree(
           key: ValueKey(
-              'pdf-stamp-time-format-field-${controller.stampTimeFormat.name}'),
+              'pdf-stamp-time-format-field-${controller.preferences.stampTimeFormat.name}'),
           child: DropdownButtonFormField<PdfStampTimeFormat>(
             key: const ValueKey('pdf-stamp-time-format'),
-            initialValue: controller.stampTimeFormat,
+            initialValue: controller.preferences.stampTimeFormat,
             decoration: const InputDecoration(labelText: 'Time format'),
             items: [
               for (final format in PdfStampTimeFormat.values)
@@ -401,7 +401,7 @@ class _StampDateTimeFormatControls extends StatelessWidget {
                 ),
             ],
             onChanged: (value) {
-              if (value != null) controller.stampTimeFormat = value;
+              if (value != null) controller.preferences.stampTimeFormat = value;
             },
           ),
         ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_takeoff.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_takeoff.dart
@@ -32,7 +32,7 @@ class PdfTakeoffPanel extends StatelessWidget {
         final groups = summary.groups;
         // format running totals through the active scale so they match the
         // on-page captions (200 ft² not 200.00 ft²).
-        final measure = controller.measurementScale?.toMeasure();
+        final measure = controller.preferences.measurementScale?.toMeasure();
         final theme = Theme.of(context);
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -538,7 +538,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     final messenger = ScaffoldMessenger.maybeOf(context);
     final scale = await showPdfScaleDialog(
       context,
-      initial: controller.measurementScale,
+      initial: controller.preferences.measurementScale,
       onCalibrate: () {
         controller.tool = PdfEditTool.calibrate;
         messenger?.showSnackBar(const SnackBar(
@@ -546,7 +546,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         ));
       },
     );
-    if (scale != null) controller.measurementScale = scale;
+    if (scale != null) controller.preferences.measurementScale = scale;
   }
 
   Future<void> _armMeasureTool(BuildContext context, PdfEditTool tool) async {
@@ -566,7 +566,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       controller.tool = PdfEditTool.select;
       return;
     }
-    if (controller.signature == null && !await _drawSignature(context)) {
+    if (controller.preferences.signature == null && !await _drawSignature(context)) {
       return;
     }
     _toggleTool(PdfEditTool.signature);
@@ -575,7 +575,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   Future<bool> _drawSignature(BuildContext context) async {
     final signature = await showPdfSignatureDialog(context);
     if (signature == null) return false;
-    controller.signature = signature;
+    controller.preferences.signature = signature;
     // the signature follows the selected colour, so seed it with the ink
     // the user just drew in - they can recolour it from the toolbar after
     controller.color = Color(0xFF000000 | signature.color);
@@ -1453,12 +1453,12 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           controller.hasTouchInput)
         IconButton(
           icon: const Icon(Icons.touch_app),
-          tooltip: controller.fingerDrawsInk
+          tooltip: controller.preferences.fingerDrawsInk
               ? 'Finger draws - tap so it scrolls instead'
               : 'Finger scrolls (pen draws) - tap so it draws',
-          isSelected: controller.fingerDrawsInk,
+          isSelected: controller.preferences.fingerDrawsInk,
           onPressed: () =>
-              controller.fingerDrawsInk = !controller.fingerDrawsInk,
+              controller.preferences.fingerDrawsInk = !controller.preferences.fingerDrawsInk,
         ),
       if (controller.hasPendingInk && !controller.inkAutoCommits) ...[
         IconButton(
@@ -1827,10 +1827,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     final restyling = controller.canRestyleSelected;
     final current = restyling
         ? (controller.selectedAnnotationStyle?.strokeWidth ??
-            controller.strokeWidth)
-        : controller.strokeWidth;
+            controller.preferences.strokeWidth)
+        : controller.preferences.strokeWidth;
     void set(double w) {
-      controller.strokeWidth = w;
+      controller.preferences.strokeWidth = w;
       if (restyling) controller.restyleSelected(strokeWidth: w);
     }
 
@@ -1875,7 +1875,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     final restyling = controller.canRestyleSelected;
     final value = _dragOpacity ??
         (restyling ? controller.selectedAnnotationStyle?.opacity : null) ??
-        controller.opacity;
+        controller.preferences.opacity;
     return Row(mainAxisSize: MainAxisSize.min, children: [
       const Padding(
         padding: EdgeInsets.only(right: 2),
@@ -1894,10 +1894,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             max: 1,
             onChanged: (v) {
               setState(() => _dragOpacity = v);
-              if (!restyling) controller.opacity = v;
+              if (!restyling) controller.preferences.opacity = v;
             },
             onChangeEnd: (v) {
-              controller.opacity = v;
+              controller.preferences.opacity = v;
               if (restyling) controller.restyleSelected(opacity: v);
               setState(() => _dragOpacity = null);
             },
@@ -1915,7 +1915,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         display: (v) => '${(v * 100).round()}%',
         parse: _parsePercent,
         onSubmit: (v) {
-          controller.opacity = v;
+          controller.preferences.opacity = v;
           if (restyling) controller.restyleSelected(opacity: v);
           setState(() => _dragOpacity = null);
         },
@@ -1929,7 +1929,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     return _SettingChip(
       key: const ValueKey('pdf-measure-scale'),
       leading: 'Scale',
-      value: controller.measurementScale?.ratioLabel ?? 'Set…',
+      value: controller.preferences.measurementScale?.ratioLabel ?? 'Set…',
       onTap: () => _setScale(context),
     );
   }
@@ -3314,7 +3314,7 @@ class _StyleMenuState extends State<_StyleMenu> {
       color == null ? null : color.toARGB32() & 0xFFFFFF;
 
   void _setTextFill(Color? color) {
-    controller.textFillColor = color; // the new default either way
+    controller.preferences.textFillColor = color; // the new default either way
     if (controller.canRestyleSelectedText) {
       controller.restyleSelectedText(fill: (_rgb(color),));
     }
@@ -3330,7 +3330,7 @@ class _StyleMenuState extends State<_StyleMenu> {
   }
 
   void _setShapeFill(Color? color) {
-    controller.shapeFillColor = color; // the new default either way
+    controller.preferences.shapeFillColor = color; // the new default either way
     if (controller.canFillSelected) {
       controller.restyleSelected(fill: (color,));
     }
@@ -3347,13 +3347,13 @@ class _StyleMenuState extends State<_StyleMenu> {
   }
 
   void _setTextBorder(Color? color) {
-    controller.textBorderColor = color;
+    controller.preferences.textBorderColor = color;
     if (controller.canRestyleSelectedText) {
       controller.restyleSelectedText(
           border: (_rgb(color),),
           // setting a border gives it the current stroke width; clearing
           // one leaves the width field alone
-          borderWidth: color == null ? null : controller.strokeWidth);
+          borderWidth: color == null ? null : controller.preferences.strokeWidth);
     }
   }
 
@@ -3472,10 +3472,10 @@ class _StyleMenuState extends State<_StyleMenu> {
                 restylingAnnotation ? controller.selectedAnnotationStyle : null;
             final strokeValue = _draggingStroke ??
                 annotationStyle?.strokeWidth ??
-                controller.strokeWidth;
+                controller.preferences.strokeWidth;
             final opacityValue = _draggingOpacity ??
                 annotationStyle?.opacity ??
-                controller.opacity;
+                controller.preferences.opacity;
             // with a free text selected the rows show its own box style;
             // otherwise the creation defaults
             // line endings: edit a selected /Line or /PolyLine in place,
@@ -3483,7 +3483,7 @@ class _StyleMenuState extends State<_StyleMenu> {
             final lineEndingTarget = controller.canSetLineEndings;
             final lineEndings = lineEndingTarget
                 ? controller.selectedLineEndings!
-                : (controller.lineStartEnding, controller.lineEndEnding);
+                : (controller.preferences.lineStartEnding, controller.preferences.lineEndEnding);
             final restyling = controller.canRestyleSelectedText;
             final boxStyle =
                 restyling ? controller.selectedAnnotation?.freeTextStyle : null;
@@ -3497,18 +3497,18 @@ class _StyleMenuState extends State<_StyleMenu> {
                 ? (boxStyle?.fillColor != null
                     ? Color(0xFF000000 | boxStyle!.fillColor!)
                     : null)
-                : controller.textFillColor;
+                : controller.preferences.textFillColor;
             final borderValue = restyling
                 ? (boxStyle?.borderColor != null &&
                         (boxStyle?.borderWidth ?? 0) > 0
                     ? Color(0xFF000000 | boxStyle!.borderColor!)
                     : null)
-                : controller.textBorderColor;
+                : controller.preferences.textBorderColor;
             // shape interior fill: a selected shape shows its own /IC,
             // else the creation default
             final shapeFillValue = controller.canFillSelected
                 ? controller.selectedShapeFill
-                : controller.shapeFillColor;
+                : controller.preferences.shapeFillColor;
             // shape/cloud/line outline: a selected shape shows its own /C,
             // else the creation default
             final strokeColorValue = restylingAnnotation
@@ -3530,7 +3530,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                     _slider(
                       key: const ValueKey('pdf-eraser-size'),
                       label: 'Eraser size',
-                      value: controller.eraserRadius,
+                      value: controller.preferences.eraserRadius,
                       min: 2,
                       max: 40,
                       fieldMin: 1,
@@ -3538,7 +3538,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                       display: (v) => '${v.round()} pt',
                       parse: _parsePoints,
                       onChanged: (v) =>
-                          controller.eraserRadius = v.roundToDouble(),
+                          controller.preferences.eraserRadius = v.roundToDouble(),
                     ),
                   if (fields.stroke)
                     _slider(
@@ -3552,10 +3552,10 @@ class _StyleMenuState extends State<_StyleMenu> {
                       parse: _parsePoints,
                       onChanged: (v) {
                         setState(() => _draggingStroke = v);
-                        if (!restylingAnnotation) controller.strokeWidth = v;
+                        if (!restylingAnnotation) controller.preferences.strokeWidth = v;
                       },
                       onChangeEnd: (v) {
-                        controller.strokeWidth = v;
+                        controller.preferences.strokeWidth = v;
                         if (restylingAnnotation) {
                           controller.restyleSelected(strokeWidth: v);
                         }
@@ -3572,7 +3572,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                           (restylingAnnotation
                               ? controller.selectedCornerRadius
                               : null) ??
-                          controller.cornerRadius,
+                          controller.preferences.cornerRadius,
                       min: 0,
                       max: 40,
                       display: (v) => '${v.round()} pt',
@@ -3580,11 +3580,11 @@ class _StyleMenuState extends State<_StyleMenu> {
                       onChanged: (v) {
                         setState(() => _draggingCornerRadius = v);
                         if (!restylingAnnotation) {
-                          controller.cornerRadius = v.roundToDouble();
+                          controller.preferences.cornerRadius = v.roundToDouble();
                         }
                       },
                       onChangeEnd: (v) {
-                        controller.cornerRadius = v.roundToDouble();
+                        controller.preferences.cornerRadius = v.roundToDouble();
                         if (restylingAnnotation) {
                           controller.restyleSelected(
                               cornerRadius: v.roundToDouble());
@@ -3606,10 +3606,10 @@ class _StyleMenuState extends State<_StyleMenu> {
                       parse: _parsePercent,
                       onChanged: (v) {
                         setState(() => _draggingOpacity = v);
-                        if (!restylingAnnotation) controller.opacity = v;
+                        if (!restylingAnnotation) controller.preferences.opacity = v;
                       },
                       onChangeEnd: (v) {
-                        controller.opacity = v;
+                        controller.preferences.opacity = v;
                         if (restylingAnnotation) {
                           controller.restyleSelected(opacity: v);
                         }
@@ -3627,8 +3627,8 @@ class _StyleMenuState extends State<_StyleMenu> {
                             isDense: true,
                             value: restylingAnnotation
                                 ? (controller.selectedLineStyle ??
-                                    controller.lineStyle)
-                                : controller.lineStyle,
+                                    controller.preferences.lineStyle)
+                                : controller.preferences.lineStyle,
                             underline: const SizedBox.shrink(),
                             items: [
                               for (final style in PdfLineStyle.values)
@@ -3640,7 +3640,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                             ],
                             onChanged: (value) {
                               if (value == null) return;
-                              controller.lineStyle = value;
+                              controller.preferences.lineStyle = value;
                               if (restylingAnnotation &&
                                   controller.canSetLineStyleSelected) {
                                 controller.restyleSelected(lineStyle: value);
@@ -3657,17 +3657,17 @@ class _StyleMenuState extends State<_StyleMenu> {
                       value: _draggingScale ??
                           (restylingAnnotation
                               ? (controller.selectedLineScale ??
-                                  controller.lineScale)
-                              : controller.lineScale),
+                                  controller.preferences.lineScale)
+                              : controller.preferences.lineScale),
                       min: 0.5,
                       max: 4,
                       display: (v) => '${v.toStringAsFixed(1)}×',
                       onChanged: (v) {
                         setState(() => _draggingScale = v);
-                        if (!restylingAnnotation) controller.lineScale = v;
+                        if (!restylingAnnotation) controller.preferences.lineScale = v;
                       },
                       onChangeEnd: (v) {
-                        controller.lineScale = v;
+                        controller.preferences.lineScale = v;
                         if (restylingAnnotation &&
                             controller.canSetLineStyleSelected) {
                           controller.restyleSelected(scale: v);
@@ -3683,7 +3683,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                       atEnd: false,
                       value: lineEndings.$1,
                       onChanged: (ending) {
-                        controller.lineStartEnding = ending;
+                        controller.preferences.lineStartEnding = ending;
                         if (controller.canSetLineEndings) {
                           controller.setSelectedLineEndings(start: ending);
                         }
@@ -3696,7 +3696,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                       atEnd: true,
                       value: lineEndings.$2,
                       onChanged: (ending) {
-                        controller.lineEndEnding = ending;
+                        controller.preferences.lineEndEnding = ending;
                         if (controller.canSetLineEndings) {
                           controller.setSelectedLineEndings(end: ending);
                         }
@@ -3726,7 +3726,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                       value: _draggingFontSize ??
                           selectedStyle?.size ??
                           captionStyle?.size ??
-                          controller.fontSize,
+                          controller.preferences.fontSize,
                       min: 8,
                       max: 48,
                       fieldMin: 1,
@@ -3736,26 +3736,26 @@ class _StyleMenuState extends State<_StyleMenu> {
                       onChanged: (v) {
                         setState(() => _draggingFontSize = v.roundToDouble());
                         if (selectedStyle == null && captionStyle == null) {
-                          controller.fontSize = v.roundToDouble();
+                          controller.preferences.fontSize = v.roundToDouble();
                         }
                       },
                       onChangeEnd: (v) {
                         final size = v.roundToDouble();
                         if (controller.restyleEditingTextSelection(
                             size: size)) {
-                          controller.fontSize = size;
+                          controller.preferences.fontSize = size;
                           setState(() => _draggingFontSize = null);
                           return;
                         }
                         if (controller.canRestyleSelectedText) {
-                          controller.fontSize = size;
+                          controller.preferences.fontSize = size;
                           controller.restyleSelectedText(size: size);
                         } else if (controller.canRestyleMeasurementCaption) {
                           // a selected measurement keeps its own caption size;
                           // don't disturb the creation default
                           controller.setSelectedMeasurementCaption(size: size);
                         } else {
-                          controller.fontSize = size;
+                          controller.preferences.fontSize = size;
                         }
                         setState(() => _draggingFontSize = null);
                       },
@@ -3800,7 +3800,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                         const SizedBox(width: 86, child: Text('Align')),
                         TextAlignToggles(
                           align: controller.selectedTextAlign ??
-                              controller.textAlign ??
+                              controller.preferences.textAlign ??
                               PdfTextAlign.left,
                           onChanged: _setTextAlign,
                         ),
@@ -4027,7 +4027,7 @@ class _FontChip extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final style = controller.selectedTextStyle;
     final font = style?.font ?? controller.fontFamily;
-    final size = (style?.size ?? controller.fontSize).round();
+    final size = (style?.size ?? controller.preferences.fontSize).round();
     return Tooltip(
       message: tooltip,
       child: Material(

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -561,9 +561,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   Future<void> _promptAuthor() async {
     final session = _session;
     final name = await showPdfTextPrompt(context,
-        title: 'Author name', initial: session.author ?? '');
+        title: 'Author name', initial: session.preferences.author ?? '');
     if (name == null) return;
-    session.author = name.trim().isEmpty ? null : name.trim();
+    session.preferences.author = name.trim().isEmpty ? null : name.trim();
   }
 
   @override
@@ -806,7 +806,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 pageGrid: features.thumbnails,
                 pageColor: features.pageColorEditable,
                 author: features.author,
-                authorName: session.author,
+                authorName: session.preferences.author,
                 onAuthorPressed: _promptAuthor,
                 toolShortcuts: _toolShortcuts,
                 onToolShortcutsChanged: (value) =>
@@ -906,7 +906,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         pageGrid: features.thumbnails,
                         pageColor: features.pageColorEditable,
                         author: features.author,
-                        authorName: session.author,
+                        authorName: session.preferences.author,
                         onAuthorPressed: _promptAuthor,
                         toolShortcuts: _toolShortcuts,
                         onToolShortcutsChanged: (value) =>

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3734,7 +3734,7 @@ class _PdfViewerState extends State<PdfViewer>
     }
     return switch (kind) {
       PointerDeviceKind.stylus || PointerDeviceKind.invertedStylus => true,
-      PointerDeviceKind.touch => editing.fingerDrawsInk,
+      PointerDeviceKind.touch => editing.preferences.fingerDrawsInk,
       _ => false,
     };
   }

--- a/packages/dart_pdf_editor/test/editing_callout_test.dart
+++ b/packages/dart_pdf_editor/test/editing_callout_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('callout through the controller', () {
     test('addCallout builds a FreeText callout pointing at the target', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..author = 'Ben'
+        ..preferences.author = 'Ben'
         ..addCallout(
             0, const PdfRect(300, 600, 460, 660), 'Look here', (120, 500));
 
@@ -50,7 +50,7 @@ void main() {
 
     test('autosize fits the box and leaves the arrow tip alone', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..fontSize = 14
+        ..preferences.fontSize = 14
         ..addCallout(0, const PdfRect(300, 600, 700, 700), 'Hi', (120, 500));
       expect(editing.selectAnnotation(0, 0), isTrue);
       final tip0 =

--- a/packages/dart_pdf_editor/test/editing_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_clipboard_test.dart
@@ -196,8 +196,8 @@ void main() {
     test('selectedAnnotationStyle reads the current style', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..color = const Color(0xFFE53935)
-        ..strokeWidth = 4
-        ..opacity = 0.5
+        ..preferences.strokeWidth = 4
+        ..preferences.opacity = 0.5
         ..addRectangle(0, const PdfRect(100, 650, 250, 750));
       addTearDown(editing.dispose);
       expect(editing.selectedAnnotationStyle, isNull);
@@ -523,7 +523,7 @@ void main() {
         (tester) async {
       final (editing, _) = await pumpEditor(tester, toolbar: true);
       editing
-        ..strokeWidth = 2
+        ..preferences.strokeWidth = 2
         ..addRectangle(0, const PdfRect(100, 650, 250, 750))
         ..selectAnnotation(0, 0);
       await tester.pump();

--- a/packages/dart_pdf_editor/test/editing_drag_preview_test.dart
+++ b/packages/dart_pdf_editor/test/editing_drag_preview_test.dart
@@ -351,7 +351,7 @@ void main() {
       // a red rectangle near the bottom of page 1 (page y 30..70)
       editing
         ..color = const Color(0xFFFF0000)
-        ..strokeWidth = 3
+        ..preferences.strokeWidth = 3
         ..addRectangle(0, const PdfRect(250, 30, 400, 70))
         ..tool = PdfEditTool.select;
       await tester.pump();

--- a/packages/dart_pdf_editor/test/editing_eraser_test.dart
+++ b/packages/dart_pdf_editor/test/editing_eraser_test.dart
@@ -62,7 +62,7 @@ void main() {
         ..finishInk()
         ..addInkStroke(0, [(150, 450), (250, 450)])
         ..finishInk();
-      editing.eraserRadius = 30;
+      editing.preferences.eraserRadius = 30;
 
       expect(
         editing.sliceErase(0, const [(200, 550), (200, 420)]),
@@ -112,7 +112,7 @@ void main() {
         ..finishInk();
       editing
         ..tool = PdfEditTool.eraser
-        ..eraserRadius = 30;
+        ..preferences.eraserRadius = 30;
       await tester.pump();
 
       final g = await tester.startGesture(view(200, 550),
@@ -141,7 +141,7 @@ void main() {
         ..finishInk();
       editing
         ..tool = PdfEditTool.eraser
-        ..eraserRadius = 30;
+        ..preferences.eraserRadius = 30;
       await tester.pump();
 
       final g = await tester.startGesture(view(200, 550),
@@ -170,7 +170,7 @@ void main() {
         ..finishInk();
       editing
         ..tool = PdfEditTool.eraser
-        ..eraserRadius = 30;
+        ..preferences.eraserRadius = 30;
       await tester.pump();
 
       const pointer = 17;
@@ -214,7 +214,7 @@ void main() {
         ..finishInk();
       editing
         ..tool = PdfEditTool.eraser
-        ..eraserRadius = 30;
+        ..preferences.eraserRadius = 30;
       await tester.pump();
 
       const pointer = 18;
@@ -256,7 +256,7 @@ void main() {
         ..addInkStroke(0, [(195, 500), (205, 500)])
         ..finishInk();
       editing.tool = PdfEditTool.eraser;
-      editing.eraserRadius = 30;
+      editing.preferences.eraserRadius = 30;
       await tester.pump();
 
       await tester.tapAt(view(200, 500), kind: PointerDeviceKind.mouse);
@@ -273,7 +273,7 @@ void main() {
         ..addInkStroke(0, [(150, 400), (250, 400)])
         ..finishInk();
       editing.tool = PdfEditTool.eraser;
-      editing.eraserRadius = 30;
+      editing.preferences.eraserRadius = 30;
       await tester.pump();
 
       // sweep along the whole upper stroke
@@ -352,7 +352,7 @@ void main() {
       expect((extraInk.single.strokes as List), hasLength(2));
       // the ring cursor rides the pointer at the page-space radius
       expect(painter.eraserCursor, isNotNull);
-      expect(painter.eraserRadius, closeTo(editing.eraserRadius * scale, 1e-6));
+      expect(painter.eraserRadius, closeTo(editing.preferences.eraserRadius * scale, 1e-6));
 
       await g.up();
       await tester.pump();
@@ -433,7 +433,7 @@ void main() {
               matching: find.byType(Slider)),
           const Offset(200, 0));
       await tester.pump();
-      expect(editing.eraserRadius, greaterThan(8));
+      expect(editing.preferences.eraserRadius, greaterThan(8));
       await tester.pumpAndSettle();
     });
 

--- a/packages/dart_pdf_editor/test/editing_ipad_test.dart
+++ b/packages/dart_pdf_editor/test/editing_ipad_test.dart
@@ -270,7 +270,7 @@ void main() {
     testWidgets('a finger draws raw when finger drawing is on', (tester) async {
       final (editing, _) = await pumpViewer(tester);
       editing.tool = PdfEditTool.ink;
-      expect(editing.fingerDrawsInk, isTrue);
+      expect(editing.preferences.fingerDrawsInk, isTrue);
       await tester.pump();
 
       final g = await tester.startGesture(view(200, 500));
@@ -378,7 +378,7 @@ void main() {
       editing.tool = PdfEditTool.ink;
       // the state the first Apple Pencil touch leaves behind: pen draws,
       // fingers scroll
-      editing.fingerDrawsInk = false;
+      editing.preferences.fingerDrawsInk = false;
       await tester.pump();
 
       final (g, stamp) = await swipeUp(tester);
@@ -395,7 +395,7 @@ void main() {
         (tester) async {
       final (editing, _) = await pumpViewer(tester, pages: 4);
       editing.tool = PdfEditTool.ink;
-      expect(editing.fingerDrawsInk, isTrue);
+      expect(editing.preferences.fingerDrawsInk, isTrue);
       await tester.pump();
 
       final (g, stamp) = await swipeUp(tester);
@@ -412,7 +412,7 @@ void main() {
         (tester) async {
       final (editing, _) = await pumpViewer(tester, pages: 4);
       editing.tool = PdfEditTool.ink;
-      editing.fingerDrawsInk = false;
+      editing.preferences.fingerDrawsInk = false;
       await tester.pump();
 
       final pen = await tester.startGesture(view(200, 500),

--- a/packages/dart_pdf_editor/test/editing_line_endings_test.dart
+++ b/packages/dart_pdf_editor/test/editing_line_endings_test.dart
@@ -14,8 +14,8 @@ void main() {
   group('controller line endings', () {
     test('new lines and polylines use the persisted endings', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..lineStartEnding = PdfLineEnding.circle
-        ..lineEndEnding = PdfLineEnding.closedArrow;
+        ..preferences.lineStartEnding = PdfLineEnding.circle
+        ..preferences.lineEndEnding = PdfLineEnding.closedArrow;
       addTearDown(editing.dispose);
 
       editing.addLine(0, (100, 100), (220, 160));
@@ -31,8 +31,8 @@ void main() {
 
     test('the arrow tool still forces a closed arrow at the end', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..lineStartEnding = PdfLineEnding.diamond
-        ..lineEndEnding = PdfLineEnding.none;
+        ..preferences.lineStartEnding = PdfLineEnding.diamond
+        ..preferences.lineEndEnding = PdfLineEnding.none;
       addTearDown(editing.dispose);
 
       editing.addLine(0, (100, 100), (220, 160), arrow: true);
@@ -127,7 +127,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text('Closed arrow').last);
       await tester.pumpAndSettle();
-      expect(editing.lineEndEnding, PdfLineEnding.closedArrow);
+      expect(editing.preferences.lineEndEnding, PdfLineEnding.closedArrow);
     });
 
     testWidgets('the picker restyles a selected line in place', (tester) async {

--- a/packages/dart_pdf_editor/test/editing_measure_test.dart
+++ b/packages/dart_pdf_editor/test/editing_measure_test.dart
@@ -22,7 +22,7 @@ void main() {
       editing.calibrateScale((100, 100), (316, 100), 60, 'ft');
 
       expect(editing.hasMeasurementScale, isTrue);
-      final scale = editing.measurementScale!;
+      final scale = editing.preferences.measurementScale!;
       expect(scale.unitLabel, 'ft');
       expect(scale.unitsPerPoint, closeTo(60 / 216, 1e-9));
       // 1 in = 72 pt → 72 × (60/216) = 20 ft
@@ -32,7 +32,7 @@ void main() {
     test('live readouts compute distance, perimeter, and area', () {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
-      editing.measurementScale =
+      editing.preferences.measurementScale =
           PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
 
       expect(editing.measuredDistance((100, 100), (316, 100)), '60 ft');
@@ -49,7 +49,7 @@ void main() {
         () {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
-      editing.measurementScale =
+      editing.preferences.measurementScale =
           PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
 
       editing.addMeasurement(
@@ -65,12 +65,12 @@ void main() {
         () {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
-      editing.measurementScale =
+      editing.preferences.measurementScale =
           PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
       editing.fontFamily = PdfStandardFont.times;
-      editing.fontSize = 14;
-      editing.lineStartEnding = PdfLineEnding.openArrow;
-      editing.lineEndEnding = PdfLineEnding.closedArrow;
+      editing.preferences.fontSize = 14;
+      editing.preferences.lineStartEnding = PdfLineEnding.openArrow;
+      editing.preferences.lineEndEnding = PdfLineEnding.closedArrow;
 
       editing.addMeasurement(
           0, PdfMeasurementKind.distance, const [(100, 100), (316, 100)]);
@@ -86,7 +86,7 @@ void main() {
     test('changing a selected measurement keeps its caption visible', () {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
-      editing.measurementScale =
+      editing.preferences.measurementScale =
           PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
       editing.addMeasurement(
           0, PdfMeasurementKind.distance, const [(100, 100), (316, 100)]);
@@ -106,7 +106,7 @@ void main() {
     test('the panel can restyle a selected measurement caption font', () {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
-      editing.measurementScale =
+      editing.preferences.measurementScale =
           PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
       editing.addMeasurement(
           0, PdfMeasurementKind.distance, const [(100, 100), (316, 100)]);
@@ -378,7 +378,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(editing.hasMeasurementScale, isTrue);
-      final result = editing.measurementScale!;
+      final result = editing.preferences.measurementScale!;
       expect(result.unitLabel, 'ft');
       // 50 ft over 200 page points
       expect(result.unitsPerPoint, closeTo(50 / 200, 1e-6));
@@ -435,7 +435,7 @@ void main() {
         WidgetTester tester) async {
       SharedPreferences.setMockInitialValues({});
       final editing = PdfEditingController(buildMultiPagePdf(2))
-        ..measurementScale =
+        ..preferences.measurementScale =
             PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);

--- a/packages/dart_pdf_editor/test/editing_polish_test.dart
+++ b/packages/dart_pdf_editor/test/editing_polish_test.dart
@@ -391,7 +391,7 @@ void main() {
     testWidgets('signature hover previews without committing, click places',
         (tester) async {
       final (editing, boundary) = await pumpViewer(tester);
-      editing.signature = PdfInkSignature(
+      editing.preferences.signature = PdfInkSignature(
         strokes: [
           [(0, 0.5), (0.5, 0.5), (1, 0.5)]
         ],
@@ -431,7 +431,7 @@ void main() {
     testWidgets('touch press-drag-release places at the release point',
         (tester) async {
       final (editing, _) = await pumpViewer(tester);
-      editing.signature = PdfInkSignature(
+      editing.preferences.signature = PdfInkSignature(
         strokes: [
           [(0, 0.5), (1, 0.5)]
         ],

--- a/packages/dart_pdf_editor/test/editing_prediction_test.dart
+++ b/packages/dart_pdf_editor/test/editing_prediction_test.dart
@@ -19,7 +19,7 @@ void main() {
       {required bool predict}) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
       ..color = const Color(0xFFFF0000)
-      ..strokeWidth = 8;
+      ..preferences.strokeWidth = 8;
     addTearDown(editing.dispose);
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -152,10 +152,10 @@ void main() {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       await editing.preferences.ready;
       expect(editing.color, const Color(0xFF00A040));
-      expect(editing.strokeWidth, 6);
-      expect(editing.fontSize, 22);
-      expect(editing.opacity, 0.4);
-      expect(editing.fingerDrawsInk, isFalse);
+      expect(editing.preferences.strokeWidth, 6);
+      expect(editing.preferences.fontSize, 22);
+      expect(editing.preferences.opacity, 0.4);
+      expect(editing.preferences.fingerDrawsInk, isFalse);
     });
 
     test('controller setters write through to storage', () async {
@@ -164,16 +164,16 @@ void main() {
       await first.preferences.ready;
       first
         ..color = const Color(0xFF0000FF)
-        ..strokeWidth = 7
-        ..opacity = 0.8;
+        ..preferences.strokeWidth = 7
+        ..preferences.opacity = 0.8;
       await pumpEventQueue();
 
       // a later session: new controller, its own preferences instance
       final second = PdfEditingController(buildMultiPagePdf(1));
       await second.preferences.ready;
       expect(second.color, const Color(0xFF0000FF));
-      expect(second.strokeWidth, 7);
-      expect(second.opacity, 0.8);
+      expect(second.preferences.strokeWidth, 7);
+      expect(second.preferences.opacity, 0.8);
     });
 
     test('preference changes notify controller listeners', () async {
@@ -196,22 +196,22 @@ void main() {
 
       editing.tool = PdfEditTool.ink;
       editing.color = const Color(0xFFFF0000);
-      editing.strokeWidth = 6;
+      editing.preferences.strokeWidth = 6;
 
       editing.tool = PdfEditTool.rectangle;
       editing.color = const Color(0xFF0000FF);
-      editing.strokeWidth = 2;
-      editing.shapeFillColor = const Color(0xFF00FF00);
+      editing.preferences.strokeWidth = 2;
+      editing.preferences.shapeFillColor = const Color(0xFF00FF00);
 
       // arming the rectangle didn't disturb ink's remembered style
       editing.tool = PdfEditTool.ink;
       expect(editing.color, const Color(0xFFFF0000));
-      expect(editing.strokeWidth, 6);
+      expect(editing.preferences.strokeWidth, 6);
 
       editing.tool = PdfEditTool.rectangle;
       expect(editing.color, const Color(0xFF0000FF));
-      expect(editing.strokeWidth, 2);
-      expect(editing.shapeFillColor, const Color(0xFF00FF00));
+      expect(editing.preferences.strokeWidth, 2);
+      expect(editing.preferences.shapeFillColor, const Color(0xFF00FF00));
     });
 
     test('the markup scope keeps the highlighter its own colour', () async {
@@ -242,8 +242,8 @@ void main() {
         ..tool = PdfEditTool.highlight;
 
       expect(editing.color, const Color(0xFF123456));
-      expect(editing.strokeWidth, 12);
-      expect(editing.opacity, 0.45);
+      expect(editing.preferences.strokeWidth, 12);
+      expect(editing.preferences.opacity, 0.45);
 
       editing.colorLocked = false;
       expect(editing.color, const Color(0xFFFFD100));

--- a/packages/dart_pdf_editor/test/editing_readonly_test.dart
+++ b/packages/dart_pdf_editor/test/editing_readonly_test.dart
@@ -92,9 +92,9 @@ void main() {
     test('gates selection by author', () {
       final editing = PdfEditingController(buildClassicPdf());
       addTearDown(editing.dispose);
-      editing.author = 'Alice';
+      editing.preferences.author = 'Alice';
       editing.addRectangle(0, const PdfRect(100, 600, 200, 700));
-      editing.author = 'Bob';
+      editing.preferences.author = 'Bob';
       editing.addEllipse(0, const PdfRect(300, 600, 400, 700));
 
       editing.canEditAnnotation = (a) => a.author == 'Bob';
@@ -112,9 +112,9 @@ void main() {
     test('setting the predicate drops newly ineligible selections', () {
       final editing = PdfEditingController(buildClassicPdf());
       addTearDown(editing.dispose);
-      editing.author = 'Alice';
+      editing.preferences.author = 'Alice';
       editing.addRectangle(0, const PdfRect(100, 600, 200, 700));
-      editing.author = 'Bob';
+      editing.preferences.author = 'Bob';
       editing.addEllipse(0, const PdfRect(300, 600, 400, 700));
       expect(editing.selectAllAnnotationsOn(0), 2);
 
@@ -132,7 +132,7 @@ void main() {
     test('remote applies bypass the gate - sync is not user editing', () {
       final editing = PdfEditingController(buildClassicPdf());
       addTearDown(editing.dispose);
-      editing.author = 'Alice';
+      editing.preferences.author = 'Alice';
       editing.addRectangle(0, const PdfRect(100, 600, 200, 700));
       editing.canEditAnnotation = (_) => false;
 

--- a/packages/dart_pdf_editor/test/editing_rotate_test.dart
+++ b/packages/dart_pdf_editor/test/editing_rotate_test.dart
@@ -132,7 +132,7 @@ void main() {
 
   test('editing a rotated free text keeps it rotated', () {
     final editing = PdfEditingController(buildMultiPagePdf(1))
-      ..fontSize = 18
+      ..preferences.fontSize = 18
       ..addFreeText(0, const PdfRect(100, 650, 300, 700), 'before')
       ..selectAnnotation(0, 0)
       ..rotateSelected(30);
@@ -244,7 +244,7 @@ void main() {
 
       editing
         ..color = const Color(0xFFFF0000)
-        ..strokeWidth = 4
+        ..preferences.strokeWidth = 4
         ..addRectangle(0, const PdfRect(100, 650, 250, 750))
         ..tool = PdfEditTool.select
         ..selectAnnotation(0, 0)

--- a/packages/dart_pdf_editor/test/editing_shape_resize_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_resize_test.dart
@@ -27,7 +27,7 @@ void main() {
       {required String shape, bool dashed = false}) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
       ..color = const Color(0xFFFF0000)
-      ..strokeWidth = 4
+      ..preferences.strokeWidth = 4
       ..dashedStroke = dashed;
     if (shape == 'Circle') {
       editing.addEllipse(0, const PdfRect(100, 550, 300, 650));

--- a/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
+++ b/packages/dart_pdf_editor/test/editing_shape_styles_test.dart
@@ -15,7 +15,7 @@ void main() {
   group('line style (dash) on the controller', () {
     test('a non-solid line style stores a /BS /D dash array on new shapes', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..lineStyle = PdfLineStyle.dashed;
+        ..preferences.lineStyle = PdfLineStyle.dashed;
       addTearDown(editing.dispose);
       editing.addRectangle(0, const PdfRect(100, 100, 200, 200));
       final square = editing.document.page(0).annotations.single;
@@ -65,16 +65,16 @@ void main() {
     test('the pattern scale drives new shapes and is independent of stroke',
         () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..lineStyle = PdfLineStyle.dashed
-        ..strokeWidth = 1
-        ..lineScale = 1;
+        ..preferences.lineStyle = PdfLineStyle.dashed
+        ..preferences.strokeWidth = 1
+        ..preferences.lineScale = 1;
       addTearDown(editing.dispose);
       editing.addRectangle(0, const PdfRect(100, 100, 300, 200));
       final narrow =
           editing.document.page(0).annotations.single.borderDash!.first;
 
       editing
-        ..lineScale = 3
+        ..preferences.lineScale = 3
         ..addRectangle(0, const PdfRect(100, 300, 300, 400));
       final wide = editing.document.page(0).annotations.last.borderDash!.first;
       expect(wide, greaterThan(narrow));
@@ -84,7 +84,7 @@ void main() {
   group('pattern scale on clouds', () {
     test('a cloud drawn at a bigger scale stores it on /BE /I', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..lineScale = 2.5;
+        ..preferences.lineScale = 2.5;
       addTearDown(editing.dispose);
       editing.addCloudPolygon(0, const PdfRect(100, 100, 300, 200));
       final cloud = editing.document.page(0).annotations.single;
@@ -109,7 +109,7 @@ void main() {
   group('rectangle corner radius on the controller', () {
     test('the corner radius preference rounds new rectangles', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..cornerRadius = 10;
+        ..preferences.cornerRadius = 10;
       addTearDown(editing.dispose);
       editing.addRectangle(0, const PdfRect(100, 100, 300, 200));
       expect(
@@ -158,7 +158,7 @@ void main() {
   group('polygon fill', () {
     test('a polygon drawn with a shape fill colour stores /IC', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..shapeFillColor = const Color(0xFF80C0FF);
+        ..preferences.shapeFillColor = const Color(0xFF80C0FF);
       addTearDown(editing.dispose);
       editing.addPolygon(0, const [(100, 100), (200, 180), (160, 100)]);
       expect(
@@ -311,8 +311,8 @@ void main() {
       await tester.pump();
       editing
         ..tool = PdfEditTool.rectangle
-        ..strokeWidth = 4
-        ..opacity = 0.5;
+        ..preferences.strokeWidth = 4
+        ..preferences.opacity = 0.5;
       await tester.pump();
 
       final gesture = await tester.startGesture(view(150, 600));
@@ -349,8 +349,8 @@ void main() {
       await tester.pump();
       editing
         ..tool = PdfEditTool.rectangle
-        ..strokeWidth = 4
-        ..opacity = 0.5;
+        ..preferences.strokeWidth = 4
+        ..preferences.opacity = 0.5;
       await tester.pump();
 
       Future<Rect> dragAndRead(Offset start, Offset end) async {

--- a/packages/dart_pdf_editor/test/editing_sidebar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_sidebar_test.dart
@@ -67,7 +67,7 @@ void main() {
   testWidgets('annotations carry the author and the sidebar shows it',
       (tester) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
-      ..author = 'Ben'
+      ..preferences.author = 'Ben'
       ..addNote(0, 100, 700, 'first note');
     final viewer = PdfViewerController();
     addTearDown(editing.dispose);
@@ -267,7 +267,7 @@ void main() {
   group('search', () {
     testWidgets('filters by type, contents, and author', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(2))
-        ..author = 'Ben'
+        ..preferences.author = 'Ben'
         ..addNote(0, 100, 700, 'review this paragraph')
         ..addRectangle(0, const PdfRect(100, 100, 200, 150))
         ..addStamp(1, const PdfRect(100, 600, 240, 650), 'DRAFT');

--- a/packages/dart_pdf_editor/test/editing_signature_test.dart
+++ b/packages/dart_pdf_editor/test/editing_signature_test.dart
@@ -78,7 +78,7 @@ void main() {
     test('stamps a centered, y-flipped Ink annotation', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..color = const Color(0xFF1A3E8C)
-        ..signature = signature();
+        ..preferences.signature = signature();
       expect(editing.placeSignature(0, 300, 400, width: 100), isTrue);
 
       final ink = editing.document.page(0).annotations.single;
@@ -96,7 +96,7 @@ void main() {
 
     test('clamps so the whole signature stays on the page', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..signature = signature();
+        ..preferences.signature = signature();
       final box = editing.document.page(0).cropBox;
       expect(editing.placeSignature(0, box.right, box.bottom), isTrue);
 
@@ -110,7 +110,7 @@ void main() {
     test('the placed signature follows the selected colour, not the drawn one',
         () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..signature = signature() // drawn in 0x1A3E8C
+        ..preferences.signature = signature() // drawn in 0x1A3E8C
         ..color = const Color(0xFF00AA00);
       expect(editing.placeSignature(0, 300, 400, width: 100), isTrue);
       expect(editing.document.page(0).annotations.single.color, 0x00AA00);
@@ -189,7 +189,7 @@ void main() {
       await tester.tap(find.widgetWithText(FilledButton, 'Done'));
       await tester.pumpAndSettle();
 
-      expect(editing.signature, isNotNull);
+      expect(editing.preferences.signature, isNotNull);
       expect(editing.tool, PdfEditTool.signature);
 
       // tap the page; the double-tap recognizer holds taps ~300ms

--- a/packages/dart_pdf_editor/test/editing_stamps_test.dart
+++ b/packages/dart_pdf_editor/test/editing_stamps_test.dart
@@ -427,7 +427,7 @@ void main() {
         ],
       );
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..author = 'Comment Author'
+        ..preferences.author = 'Comment Author'
         ..stampTemplateClock = (() => DateTime(2026, 7, 4, 9, 5))
         ..stampTemplateValues = {
           'username': 'Ben',
@@ -466,8 +466,8 @@ void main() {
       );
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..stampTemplateClock = (() => DateTime(2026, 7, 4, 9, 5, 6))
-        ..stampDateFormat = PdfStampDateFormat.monthNameDayYear
-        ..stampTimeFormat = PdfStampTimeFormat.twelveHourSeconds
+        ..preferences.stampDateFormat = PdfStampDateFormat.monthNameDayYear
+        ..preferences.stampTimeFormat = PdfStampTimeFormat.twelveHourSeconds
         ..activeStamp = PdfCustomStamp(
           text: '{{datetime}}',
           color: 0x1A3E8C,
@@ -975,7 +975,7 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..color = const Color(0xFFE53935)
-        ..strokeWidth = 12
+        ..preferences.strokeWidth = 12
         ..addRectangle(0, const PdfRect(120, 650, 180, 720));
       addTearDown(editing.dispose);
       const boundaryKey = ValueKey('annotation-layer-capture');
@@ -1667,13 +1667,13 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text('06/07/2026').last);
       await tester.pumpAndSettle();
-      expect(editing.stampDateFormat, PdfStampDateFormat.dayMonthYear);
+      expect(editing.preferences.stampDateFormat, PdfStampDateFormat.dayMonthYear);
 
       await tester.tap(find.byKey(const ValueKey('pdf-stamp-time-format')));
       await tester.pumpAndSettle();
       await tester.tap(find.text('17:05:06 (24 hr)').last);
       await tester.pumpAndSettle();
-      expect(editing.stampTimeFormat, PdfStampTimeFormat.twentyFourHourSeconds);
+      expect(editing.preferences.stampTimeFormat, PdfStampTimeFormat.twentyFourHourSeconds);
     });
 
     testWidgets('the picker lists app-supplied stamps without delete controls',

--- a/packages/dart_pdf_editor/test/editing_takeoff_test.dart
+++ b/packages/dart_pdf_editor/test/editing_takeoff_test.dart
@@ -10,7 +10,7 @@ void main() {
 
   PdfEditingController scaled() {
     final c = PdfEditingController(buildMultiPagePdf(1));
-    c.measurementScale = PdfMeasurementScale(
+    c.preferences.measurementScale = PdfMeasurementScale(
         unitsPerPoint: 20 / 72, unitLabel: 'ft', precision: 1);
     return c;
   }
@@ -100,7 +100,7 @@ void main() {
       addTearDown(reopened.dispose);
       expect(reopened.hasMeasurementScale, isFalse);
       expect(reopened.adoptDocumentScale(), isTrue);
-      expect(reopened.measurementScale!.unitLabel, 'ft');
+      expect(reopened.preferences.measurementScale!.unitLabel, 'ft');
       expect(reopened.measuredDistance((100, 100), (316, 100)), '60 ft');
     });
   });

--- a/packages/dart_pdf_editor/test/editing_takeoff_tools_test.dart
+++ b/packages/dart_pdf_editor/test/editing_takeoff_tools_test.dart
@@ -14,7 +14,7 @@ void main() {
   Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
     SharedPreferences.setMockInitialValues({});
     final editing = PdfEditingController(buildMultiPagePdf(1))
-      ..measurementScale = PdfMeasurementScale(
+      ..preferences.measurementScale = PdfMeasurementScale(
           unitsPerPoint: 20 / 72, unitLabel: 'ft', precision: 1);
     final viewer = PdfViewerController();
     addTearDown(editing.dispose);
@@ -86,7 +86,7 @@ void main() {
   testWidgets('arc tool measures the swept length after three clicks',
       (tester) async {
     final editing = await pumpEditor(tester);
-    editing.measurementScale = PdfMeasurementScale(
+    editing.preferences.measurementScale = PdfMeasurementScale(
         unitsPerPoint: 1 / 72, unitLabel: 'ft', precision: 100);
     editing.tool = PdfEditTool.measureArc;
     await tester.pump();

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -117,7 +117,7 @@ void main() {
 
     test('ink pressures are buffered and committed with the annotation', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..strokeWidth = 4
+        ..preferences.strokeWidth = 4
         ..addInkStroke(0, [(100, 100), (150, 130), (200, 100)],
             pressures: [0.0, 0.5, 1.0])
         ..addInkStroke(0, [(120, 90), (140, 95)]);
@@ -278,7 +278,7 @@ void main() {
 
     test('opacity is baked into new annotation appearances', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..opacity = 0.5
+        ..preferences.opacity = 0.5
         ..addRectangle(0, const PdfRect(100, 100, 200, 150));
       final written = String.fromCharCodes(editing.bytes);
       expect(written, contains('/ExtGState'));
@@ -793,7 +793,7 @@ void main() {
       final (editing, _) = await pumpEditor(tester);
       editing.tool = PdfEditTool.ink;
       await tester.pump();
-      expect(editing.fingerDrawsInk, isTrue);
+      expect(editing.preferences.fingerDrawsInk, isTrue);
 
       // TestGesture can't carry pressure, so dispatch the Apple Pencil
       // contact as raw events: pressure rising over the stroke
@@ -812,7 +812,7 @@ void main() {
       ));
       await tester.pump();
       // the first stylus contact turns palm rejection on
-      expect(editing.fingerDrawsInk, isFalse);
+      expect(editing.preferences.fingerDrawsInk, isFalse);
       binding.handlePointerEvent(PointerMoveEvent(
         pointer: pointer,
         kind: PointerDeviceKind.stylus,
@@ -1154,22 +1154,22 @@ void main() {
       expect(editing.tool, PdfEditTool.highlight);
       expect(viewer.hasSelection, isFalse);
       expect(editing.color, const Color(0xFFFFD100));
-      expect(editing.strokeWidth, 12);
-      expect(editing.opacity, 0.45);
+      expect(editing.preferences.strokeWidth, 12);
+      expect(editing.preferences.opacity, 0.45);
 
       await tester.tap(find.widgetWithIcon(IconButton, Icons.draw));
       await tester.pump();
       expect(editing.tool, PdfEditTool.ink);
       expect(editing.color, const Color(0xFFE53935));
-      expect(editing.strokeWidth, 2);
-      expect(editing.opacity, 1);
+      expect(editing.preferences.strokeWidth, 2);
+      expect(editing.preferences.opacity, 1);
 
       await tester.tap(find.byTooltip('Highlight - draw freehand'));
       await tester.pump();
       expect(editing.tool, PdfEditTool.highlight);
       expect(editing.color, const Color(0xFFFFD100));
-      expect(editing.strokeWidth, 12);
-      expect(editing.opacity, 0.45);
+      expect(editing.preferences.strokeWidth, 12);
+      expect(editing.preferences.opacity, 0.45);
 
       final gesture = await tester.startGesture(view(80, 720),
           kind: PointerDeviceKind.mouse);
@@ -1342,22 +1342,22 @@ void main() {
       // pattern scale
       await tester.drag(menuSliders.at(0), const Offset(200, 0));
       await tester.pump();
-      expect(editing.strokeWidth, greaterThan(2));
+      expect(editing.preferences.strokeWidth, greaterThan(2));
 
       await tester.drag(menuSliders.at(1), const Offset(200, 0));
       await tester.pump();
-      expect(editing.cornerRadius, greaterThan(0));
+      expect(editing.preferences.cornerRadius, greaterThan(0));
 
       await tester.drag(menuSliders.at(2), const Offset(-200, 0));
       await tester.pump();
-      expect(editing.opacity, lessThan(1));
+      expect(editing.preferences.opacity, lessThan(1));
 
       // the pattern scale is independent of the pen width
-      final beforeStroke = editing.strokeWidth;
+      final beforeStroke = editing.preferences.strokeWidth;
       await tester.drag(menuSliders.at(3), const Offset(200, 0));
       await tester.pump();
-      expect(editing.lineScale, greaterThan(1));
-      expect(editing.strokeWidth, beforeStroke);
+      expect(editing.preferences.lineScale, greaterThan(1));
+      expect(editing.preferences.strokeWidth, beforeStroke);
       await tester.pumpAndSettle();
     });
 

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -29,7 +29,7 @@ void main() {
     test('restyleSelectedText changes font and size, keeps text and author',
         () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..author = 'Ben'
+        ..preferences.author = 'Ben'
         ..addFreeText(0, const PdfRect(100, 600, 300, 650), 'Styled');
       expect(editing.selectAnnotation(0, 0), isTrue);
       expect(editing.canRestyleSelectedText, isTrue);
@@ -52,7 +52,7 @@ void main() {
     test('setSelectedText preserves the font family and size', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..fontFamily = PdfStandardFont.courier
-        ..fontSize = 18
+        ..preferences.fontSize = 18
         ..addFreeText(0, const PdfRect(100, 600, 300, 650), 'Original');
       expect(editing.selectAnnotation(0, 0), isTrue);
 
@@ -66,7 +66,7 @@ void main() {
     test('autosizeSelectedTextBox fits the selected box to its contents', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..fontFamily = PdfStandardFont.courier
-        ..fontSize = 18
+        ..preferences.fontSize = 18
         ..addFreeText(0, const PdfRect(100, 600, 500, 720), 'Wide line\nshort');
       expect(editing.selectAnnotation(0, 0), isTrue);
 
@@ -85,7 +85,7 @@ void main() {
 
     test('textAlign preference flows into new free text', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..textAlign = PdfTextAlign.center
+        ..preferences.textAlign = PdfTextAlign.center
         ..addFreeText(0, const PdfRect(100, 600, 360, 650), 'Centered');
 
       final style = editing.document.page(0).annotations.single.freeTextStyle!;
@@ -106,12 +106,12 @@ void main() {
       // the selection survives the rewrite
       expect(editing.selectedTextAlign, PdfTextAlign.right);
       // and right becomes the default for new boxes
-      expect(editing.textAlign, PdfTextAlign.right);
+      expect(editing.preferences.textAlign, PdfTextAlign.right);
     });
 
     test('restyleSelectedText preserves alignment across a size change', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..textAlign = PdfTextAlign.center
+        ..preferences.textAlign = PdfTextAlign.center
         ..addFreeText(0, const PdfRect(100, 600, 360, 650), 'Centered');
       expect(editing.selectAnnotation(0, 0), isTrue);
       expect(editing.selectedTextAlign, PdfTextAlign.center);
@@ -125,7 +125,7 @@ void main() {
 
     test('addFreeTextRich applies the alignment default', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..textAlign = PdfTextAlign.right;
+        ..preferences.textAlign = PdfTextAlign.right;
       editing.addFreeTextRich(
           0, const PdfRect(100, 600, 360, 650), [const PdfFreeTextRun('Rich')]);
 
@@ -135,9 +135,9 @@ void main() {
 
     test('text fill and border preferences flow into new free text', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..strokeWidth = 3
-        ..textFillColor = const Color(0xFFFFF59D)
-        ..textBorderColor = const Color(0xFF1E88E5)
+        ..preferences.strokeWidth = 3
+        ..preferences.textFillColor = const Color(0xFFFFF59D)
+        ..preferences.textBorderColor = const Color(0xFF1E88E5)
         ..addFreeText(0, const PdfRect(100, 600, 300, 660), 'Boxed');
 
       final style = editing.document.page(0).annotations.single.freeTextStyle!;
@@ -308,7 +308,7 @@ void main() {
       final (editing, _) = await pumpEditor(tester);
       editing
         ..fontFamily = PdfStandardFont.courier
-        ..fontSize = 18
+        ..preferences.fontSize = 18
         ..addFreeText(0, const PdfRect(100, 600, 500, 720), 'Wide line')
         ..selectAnnotation(0, 0);
       await tester.pump();
@@ -1204,14 +1204,14 @@ void main() {
       await tester.pumpAndSettle();
 
       // no selection: the buttons set the creation default
-      expect(editing.textAlign, isNull);
+      expect(editing.preferences.textAlign, isNull);
       await tester.tap(find.byKey(const ValueKey('pdf-text-align-center')));
       await tester.pump();
-      expect(editing.textAlign, PdfTextAlign.center);
+      expect(editing.preferences.textAlign, PdfTextAlign.center);
 
       await tester.tap(find.byKey(const ValueKey('pdf-text-align-right')));
       await tester.pump();
-      expect(editing.textAlign, PdfTextAlign.right);
+      expect(editing.preferences.textAlign, PdfTextAlign.right);
     });
 
     testWidgets('the style menu sets text colour, fill, and border defaults',
@@ -1249,22 +1249,22 @@ void main() {
 
       await tester.tap(find.byKey(const ValueKey('pdf-text-fill-1')));
       await tester.pump();
-      expect(editing.textFillColor, PdfEditingToolbar.defaultPalette[1]);
+      expect(editing.preferences.textFillColor, PdfEditingToolbar.defaultPalette[1]);
 
       await tester.tap(find.byKey(const ValueKey('pdf-text-border-3')));
       await tester.pump();
-      expect(editing.textBorderColor, PdfEditingToolbar.defaultPalette[3]);
+      expect(editing.preferences.textBorderColor, PdfEditingToolbar.defaultPalette[3]);
 
       await tester.tap(find.byKey(const ValueKey('pdf-text-fill-none')));
       await tester.pump();
-      expect(editing.textFillColor, isNull);
-      expect(editing.textBorderColor, PdfEditingToolbar.defaultPalette[3]);
+      expect(editing.preferences.textFillColor, isNull);
+      expect(editing.preferences.textBorderColor, PdfEditingToolbar.defaultPalette[3]);
     });
 
     testWidgets('the style menu restyles the selected text box',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1))
-        ..strokeWidth = 2.5
+        ..preferences.strokeWidth = 2.5
         ..addFreeText(0, const PdfRect(100, 600, 300, 660), 'Boxed');
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);
@@ -1308,7 +1308,7 @@ void main() {
         (tester) async {
       final (editing, _) = await pumpEditor(tester);
       editing
-        ..textFillColor = const Color(0xFFFFF59D)
+        ..preferences.textFillColor = const Color(0xFFFFF59D)
         ..tool = PdfEditTool.freeText;
       await tester.pump();
 
@@ -1378,7 +1378,7 @@ void main() {
       const previewKey = ValueKey('pdf-text-resize-preview');
       final (editing, _) = await pumpEditor(tester);
       editing
-        ..fontSize = 16
+        ..preferences.fontSize = 16
         ..addFreeText(0, const PdfRect(100, 600, 300, 650), 'Wrap me please')
         ..tool = PdfEditTool.select;
       expect(editing.selectAnnotation(0, 0), isTrue);
@@ -1424,8 +1424,8 @@ void main() {
         (tester) async {
       final (editing, _) = await pumpEditor(tester);
       editing
-        ..fontSize = 16
-        ..textFillColor = const Color(0xFFFFEB3B) // a yellow filled box
+        ..preferences.fontSize = 16
+        ..preferences.textFillColor = const Color(0xFFFFEB3B) // a yellow filled box
         ..addFreeText(0, const PdfRect(100, 600, 300, 650), 'Filled box')
         ..tool = PdfEditTool.select;
       expect(editing.selectAnnotation(0, 0), isTrue);
@@ -1459,10 +1459,10 @@ void main() {
         (tester) async {
       final (editing, _) = await pumpEditor(tester);
       editing
-        ..fontSize = 16
+        ..preferences.fontSize = 16
         // a transparent box (no fill): the one that used to flash opaque
         // white over the page on release
-        ..textFillColor = null
+        ..preferences.textFillColor = null
         ..addFreeText(0, const PdfRect(100, 600, 300, 650), 'Clear box')
         ..tool = PdfEditTool.select;
       expect(editing.selectAnnotation(0, 0), isTrue);

--- a/packages/dart_pdf_editor/test/editing_thread_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thread_test.dart
@@ -34,7 +34,7 @@ void main() {
 
   testWidgets('reply through the sidebar adds a thread reply', (tester) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
-      ..author = 'Ann'
+      ..preferences.author = 'Ann'
       ..addNote(0, 100, 700, 'Please check');
     final viewer = PdfViewerController();
     addTearDown(editing.dispose);
@@ -68,7 +68,7 @@ void main() {
 
   testWidgets('resolve then reopen toggles the state chip', (tester) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
-      ..author = 'Ann'
+      ..preferences.author = 'Ann'
       ..addRectangle(0, const PdfRect(100, 100, 200, 150));
     final viewer = PdfViewerController();
     addTearDown(editing.dispose);
@@ -127,7 +127,7 @@ void main() {
   testWidgets('controller.setReviewState records a review verdict',
       (tester) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
-      ..author = 'Ann'
+      ..preferences.author = 'Ann'
       ..addRectangle(0, const PdfRect(100, 100, 200, 150));
     addTearDown(editing.dispose);
 

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -796,8 +796,8 @@ void main() {
       await tester.pump();
       expect(editing.tool, PdfEditTool.highlight);
       expect(editing.color, const Color(0xFF123456));
-      expect(editing.strokeWidth, 12);
-      expect(editing.opacity, 0.45);
+      expect(editing.preferences.strokeWidth, 12);
+      expect(editing.preferences.opacity, 0.45);
     });
 
     testWidgets('color controls are present by default', (tester) async {
@@ -1149,7 +1149,7 @@ void main() {
       final editing =
           PdfEditingController(buildMultiPagePdf(1), preferences: prefs);
       addTearDown(editing.dispose);
-      editing.author = 'A. Reviewer';
+      editing.preferences.author = 'A. Reviewer';
 
       await pump(
         tester,


### PR DESCRIPTION
## Summary

Closes #317.

`PdfEditingController` carried ~40 members that were pure forwarders to `preferences` (`double get strokeWidth => preferences.strokeWidth;` and its setter, etc.), mirroring style state that already lives in `PdfEditingPreferences` (the deep module). The forwarders widened the controller's interface to nearly the size of its implementation without adding behaviour, and — because a few setters *do* add behaviour — hid the load-bearing ones from callers.

This deletes the pure get/set pairs for **19 preference-backed properties (38 members)**:

`strokeWidth`, `cornerRadius`, `eraserRadius`, `fontSize`, `textAlign`, `opacity`, `lineStyle`, `lineScale`, `lineStartEnding`, `lineEndEnding`, `textFillColor`, `textBorderColor`, `shapeFillColor`, `author`, `stampDateFormat`, `stampTimeFormat`, `fingerDrawsInk`, `measurementScale`, `signature`.

Callers now read/write `controller.preferences.<name>` directly (some already did, e.g. the toolbar); the controller reaches through `preferences.` internally too (`author: preferences.author` in the `apply` calls, the stamp-template resolver, `calibrateScale`/`measured*` readouts).

**Kept — the setters with editing-side effects, now clearly documented:**
- `color` — honours the `colorLocked` guard and recolours the active stamp under the stamp tool.
- `fontFamily` — clears any embedded `activeFont` (back to base-14) before writing through.

Also kept the computed helpers (`dashedStroke`, `hasMeasurementScale`) and all signature/measurement *behaviour* methods (`signaturePlacement`, `placeSignature`, `calibrateScale`, `measuredDistance`/`Perimeter`/`Area`, `writeMeasurementScale`); only the value forwarders went. Dropped the now-unused `editing_signature.dart` import. No behaviour change.

Net: the controller file shrinks and its public surface narrows toward what it actually owns — revisions, apply, selection, page ops. A fuller split into `revisions`/`selection`/`pageOps` sub-objects remains a separate, larger change.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Refactor / cleanup

## Validation

- [x] `fvm dart analyze` (dart_pdf_editor: **No issues found!**)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (**all 1604 tests pass**)

Consumers updated: `editing_overlay.dart`, `editing_toolbar.dart`, `editing_properties.dart`, `editing_stamps.dart`, `editing_takeoff.dart`, `pdf_editor_view.dart`, `pdf_viewer.dart`, plus ~20 test files. `editing_preferences_test.dart`'s forwarder assertions now read `editing.preferences.strokeWidth`, which is the point of the issue (style/preference behaviour testable against `PdfEditingPreferences` alone).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Purely mechanical relocation — the deletion test the issue mentions holds: removing the forwarders relocates zero complexity because callers were already one hop from `preferences`. Style state now has one home. Dev-log note added at `doc/dev-log/2026-07-17-controller-style-forwarders.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MNvbZYQhPr6ZFdZxhtYTu

---
_Generated by [Claude Code](https://claude.ai/code/session_016MNvbZYQhPr6ZFdZxhtYTu)_