### PR TITLE
Collapse PdfViewer's document + editing dual input (#319)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,9 +145,13 @@ free text/note/stamp; select + move + resize via
 arrays - appearances regenerate for shapes/free text, stretch per
 §12.5.5 otherwise; see the batch-3 session-1 block), binds undo/redo/delete/escape
 shortcuts, and preserves the viewport across same-geometry document
-swaps. `PdfEditingToolbar` is the stock chrome. The host must rebuild
-the viewer with `editing.document` whenever the controller notifies
-(asserted in debug builds); the example app shows the wiring.
+swaps. `PdfEditingToolbar` is the stock chrome. `PdfViewer(editing:)`
+(and `formController:`) reads the current revision from the controller
+and subscribes to it itself, so the host neither passes `document` nor
+rebuilds the viewer as revisions land - `document` is only the
+no-controller reader path (`_revisionController`/`_document`/
+`_onRevisionControllerChanged` in pdf_viewer.dart). The example app
+shows the wiring.
 On top of that: style controls (controller carries strokeWidth/opacity/
 fontSize; the toolbar's tune button opens a slider popup), an
 annotation sidebar (`PdfAnnotationSidebar` - lists by page, tap selects

--- a/doc/dev-log/2026-07-17-viewer-editing-single-input.md
+++ b/doc/dev-log/2026-07-17-viewer-editing-single-input.md
@@ -1,0 +1,63 @@
+# Collapse PdfViewer's document + editing dual input (issue #319)
+
+`PdfViewer` used to take `document` **and** `editing`/`formController`
+separately, tied by an unchecked invariant: `document` had to be
+`editing.document`, and the host had to rebuild the viewer with the
+current revision on every controller notification. That was interface
+knowledge pushed onto every host, asserted only in debug builds.
+
+## What changed
+
+The viewer now reads the displayed document from the controller and
+subscribes to it directly - the pair can no longer desync.
+
+`pdf_viewer.dart`, `_PdfViewerState`:
+
+- `_revisionController` - the controller that owns the revisions:
+  `widget.editing ?? (interactiveForms ? widget.formController : null)`.
+  This is the same resolution the annotation layer / page-image helpers
+  already used, lifted into one getter.
+- `_document` - `_revisionController?.document ?? widget.document!`. Every
+  internal read of the document (`_loadPages`, `_labels`, text extraction)
+  goes through this instead of `widget.document`.
+- `_loadedDocument` - what `_loadPages` last read; a swap is detected
+  against it.
+- `_onRevisionControllerChanged` - the subscription callback (added in
+  `initState`, moved in `didUpdateWidget` when the controller identity
+  changes, removed in `dispose`). If the controller advanced a revision it
+  runs `_swapDocument`; otherwise it `setState`s for the tool/selection/
+  eyedropper state the build reads. This is exactly what the host's
+  `ListenableBuilder` used to do.
+- `_swapDocument` - the document-swap reconciliation (same-geometry
+  rebind vs. full reset) extracted out of `didUpdateWidget` so both the
+  host-rebuild path and the controller-notification path share it.
+
+`PdfViewer.document` is now nullable; a constructor assert requires a
+document source (`document`, `editing`, or `formController`). The build
+assert enforcing `document == editing.document` is gone. Hosts that pass a
+controller may drop both `document:` and the wrapping `ListenableBuilder`
+around the viewer.
+
+## Why it still keeps the viewport across revisions
+
+The identity-swap optimization keys on document identity, which the
+controller already changes per revision - unchanged. `_sameGeometryAs`
+still decides rebind-vs-reset.
+
+## Backward compatibility
+
+Hosts that still wrap the viewer in a `ListenableBuilder` and pass
+`document: editing.document` keep working: the redundant host rebuild and
+the viewer's own subscription both fire, but the swap runs once (the
+controller has already advanced its `document` by the time either fires,
+so whichever runs first reconciles and the other sees
+`_loadedDocument == _document`). The reader keeps its `ListenableBuilder`
+because it also drives `PdfReflowView` and reacts to preferences, and its
+no-form path is the standalone-`document` reader path.
+
+## Tests
+
+`pdf_viewer_test.dart` - new `editing controller drives the document`
+group: the viewer follows revisions with no host `ListenableBuilder` and
+no `document` (both `editing` and `formController`), and a deliberately
+stale standalone `document` never desyncs it.

--- a/packages/dart_pdf_editor/README.md
+++ b/packages/dart_pdf_editor/README.md
@@ -181,23 +181,21 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 // Just the viewer
 PdfViewer(document: PdfDocument.open(bytes));
 
-// Your own editor layout
+// Your own editor layout. The controller owns the document revisions, and
+// the viewer reads the current one from it and follows its edits itself -
+// no need to pass `document` or rebuild the viewer as revisions land.
 final editing = PdfEditingController(bytes);
 final viewer = PdfViewerController();
 
-ListenableBuilder(
-  listenable: editing,
-  builder: (context, _) => Column(children: [
-    Expanded(
-      child: PdfViewer(
-        document: editing.document, // rebuild with each revision
-        controller: viewer,
-        editing: editing,
-      ),
+Column(children: [
+  Expanded(
+    child: PdfViewer(
+      controller: viewer,
+      editing: editing,
     ),
-    PdfEditingToolbar(controller: editing, viewerController: viewer),
-  ]),
-);
+  ),
+  PdfEditingToolbar(controller: editing, viewerController: viewer),
+]);
 
 // Saving
 final Uint8List saved = editing.bytes;

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -698,7 +698,7 @@ typedef PdfScrollIndicatorBuilder = Widget Function(
 class PdfViewer extends StatefulWidget {
   const PdfViewer({
     super.key,
-    required this.document,
+    this.document,
     this.controller,
     this.onAction,
     this.onAnnotationTap,
@@ -741,9 +741,19 @@ class PdfViewer extends StatefulWidget {
     this.textCache,
     this.documentId,
     this.active = true,
-  });
+  }) : assert(
+            document != null || editing != null || formController != null,
+            'PdfViewer needs a document: pass document for the read-only '
+            'reader path, or an editing/formController controller that owns '
+            'the document revisions.');
 
-  final PdfDocument document;
+  /// The document to display when no controller drives the viewer (the
+  /// read-only reader path). Ignored when [editing] or an active
+  /// [formController] is set - those own the document revisions and the
+  /// viewer reads the current revision from them directly, so a host that
+  /// passes a controller never has to keep this field in sync (and may
+  /// leave it null). See [editing].
+  final PdfDocument? document;
 
   /// Whether the viewer is the foreground view. Set false when another view
   /// fully overlays it (the editor's full-area page grid) so it stops
@@ -855,17 +865,20 @@ class PdfViewer extends StatefulWidget {
   /// each page grows an editing layer that captures the tool's gestures,
   /// and the viewer binds undo/redo/delete shortcuts.
   ///
-  /// The controller owns the document revisions, so [document] must be
-  /// `editing.document` - rebuild the viewer when the controller
-  /// notifies. Because edits are incremental updates, a swap to the next
-  /// revision keeps the scroll position and zoom.
+  /// The controller owns the document revisions, and the viewer reads the
+  /// current revision from it and subscribes to it directly: a new revision
+  /// swaps the displayed document without the host rebuilding, and the
+  /// standalone [document] is ignored (it may be left null). Because edits
+  /// are incremental updates, a swap to the next revision keeps the scroll
+  /// position and zoom.
   final PdfEditingController? editing;
 
   /// Enables interactive form filling without the full editing surface -
   /// for the read-only reader, which lets users fill fields but not move
   /// or delete annotations. The controller owns the document revisions
-  /// (filling produces one), so [document] must track its current
-  /// revision, the same as [editing]. Ignored when [editing] is set (that
+  /// (filling produces one); the viewer reads the current revision from it
+  /// and subscribes directly, the same as [editing], so the standalone
+  /// [document] need not track it. Ignored when [editing] is set (that
   /// controller drives both) or [interactiveForms] is false.
   final PdfEditingController? formController;
 
@@ -1136,6 +1149,26 @@ class _PdfViewerState extends State<PdfViewer>
   late List<PdfPage> _pages;
   late List<double> _aspects; // height / width, after /Rotate
 
+  /// The controller that owns the document revisions, if any: the editing
+  /// controller, or - when interactive forms are on - the form controller.
+  /// The viewer reads its current [PdfEditingController.document] and
+  /// subscribes to it (see [_onRevisionControllerChanged]), so the displayed
+  /// document can never desync from the controller and the host does not have
+  /// to keep [PdfViewer.document] in step or rebuild on every notification.
+  PdfEditingController? get _revisionController =>
+      widget.editing ??
+      (widget.interactiveForms ? widget.formController : null);
+
+  /// The document actually displayed: the revision controller's current
+  /// document when one drives the viewer, otherwise the standalone
+  /// [PdfViewer.document] (the read-only reader path).
+  PdfDocument get _document => _revisionController?.document ?? widget.document!;
+
+  /// The document [_loadPages] last read - what is currently on screen. A
+  /// swap (a host rebuild with a new [PdfViewer.document], or the revision
+  /// controller advancing to the next revision) is detected against this.
+  PdfDocument? _loadedDocument;
+
   /// Displayed width of each page in PDF points (after /Rotate + view
   /// rotation). Pages lay out at this width times [_fitScale] (and the
   /// layout zoom), so they keep their true sizes relative to one another
@@ -1351,6 +1384,11 @@ class _PdfViewerState extends State<PdfViewer>
     // the first frame so covered pages never interpret
     if (!widget.active) _renderScheduler.holding = true;
     _pendingViewport = widget.initialViewport;
+    // subscribe to the revision controller directly: it owns the document
+    // revisions, so the viewer reads the current one and rebuilds itself when
+    // it notifies, instead of leaning on the host to rebuild with a matching
+    // document (the old unchecked invariant).
+    _revisionController?.addListener(_onRevisionControllerChanged);
     _zoomAnimator = AnimationController(
         vsync: this, duration: const Duration(milliseconds: 200))
       ..addListener(() {
@@ -1911,61 +1949,21 @@ class _PdfViewerState extends State<PdfViewer>
         SchedulerBinding.instance.addTimingsCallback(_onPerformanceTimings);
       }
     }
-    if (!identical(oldWidget.document, widget.document)) {
-      // an edit-induced swap to a revision with the same page geometry
-      // keeps the reading position; a genuinely different document resets
-      final sameGeometry = _sameGeometryAs(widget.document);
-      _textCache.clear();
-      _annotCache.clear();
-      _visibleAnnotCache.clear();
-      _fieldRectCache.clear();
-      _controller.clearSearch();
-      _clearSelection();
-      _loadPages();
-      // an edit revision keeps its previews (rebound to the new page
-      // objects - edited pages refresh from their on-screen render); a
-      // different document starts clean
-      if (sameGeometry) {
-        // a page whose content stamp advanced changed materially (a
-        // redaction burn removes glyphs/images): drop its stale preview so
-        // a fast scroll can't flash the deleted content, instead of
-        // rebinding it. Untouched pages rebind in place as before.
-        _previews.rebind(_pages, changed: (i) {
-          final prev = _contentStamps[i];
-          return prev != null && prev != _contentStamp(i);
-        });
-      } else {
-        _previews.clear();
-        // the page list shifted under the lazy list's slot-keyed States;
-        // bump the epoch so each reused page drops the raster of the page
-        // that used to sit in its slot (otherwise a fast scroll right after
-        // an insert/remove/reorder paints the wrong, stale low-res page)
-        _pageEpoch++;
-      }
-      // the cached previews (rebound or cleared) now reflect this revision
-      _snapshotContentStamps();
-      // re-point (and, for a different file, re-prime) the persistent
-      // preview backing; an edit revision keeps its rebound previews so the
-      // prime is a no-op there
-      _bindRasterCache(prime: !sameGeometry);
-      _previewAttempts.clear();
-      _previewVectorAttempts.clear();
-      WidgetsBinding.instance.addPostFrameCallback((_) => _prerenderPreviews());
-      if (!sameGeometry) {
-        // didUpdateWidget runs mid-build, and jumpTo synchronously
-        // dispatches a ScrollNotification - ancestors listening through a
-        // ScrollNotificationObserver (a Material AppBar's scrolled-under
-        // state, for one) would setState during build. Reset after the frame.
-        SchedulerBinding.instance.addPostFrameCallback((_) {
-          if (mounted && _scroll.hasClients) _scroll.jumpTo(0);
-        });
-        _transform.value = Matrix4.identity();
-        // a different file deserves a fresh fit; an edit revision (same
-        // geometry) keeps the zoom the user chose
-        _appliedInitialFit = false;
-      }
-      setState(() {});
+    // the revision controller (editing, or an active formController) can be
+    // swapped in place - move the subscription before reading _document, which
+    // resolves through it
+    final oldRevisionController = oldWidget.editing ??
+        (oldWidget.interactiveForms ? oldWidget.formController : null);
+    final newRevisionController = _revisionController;
+    if (!identical(oldRevisionController, newRevisionController)) {
+      oldRevisionController?.removeListener(_onRevisionControllerChanged);
+      newRevisionController?.addListener(_onRevisionControllerChanged);
     }
+    // a document swap is a new document object under the viewer, whether the
+    // host rebuilt with a fresh document/controller or the controller advanced
+    // a revision (handled directly in _onRevisionControllerChanged)
+    final documentSwapped = !identical(_loadedDocument, _document);
+    if (documentSwapped) _swapDocument();
     final oldPageImagesShowAnnotations = oldWidget.showAnnotations &&
         _pageImagesShowAnnotationsFor(
           editing: oldWidget.editing,
@@ -1993,8 +1991,7 @@ class _PdfViewerState extends State<PdfViewer>
     // A document swap in the same rebuild already reset the fit and scroll
     // (above), so only re-anchor for a pure layout flip - otherwise the two
     // branches would schedule competing post-frame scrolls.
-    if (oldWidget.pageLayout != widget.pageLayout &&
-        identical(oldWidget.document, widget.document)) {
+    if (oldWidget.pageLayout != widget.pageLayout && !documentSwapped) {
       // the scroll axis flipped: the fit dimension and every scroll extent
       // change, so drop the zoom window, re-fit, and re-anchor on the page
       // the reader was on once the new layout's extents exist.
@@ -2021,6 +2018,83 @@ class _PdfViewerState extends State<PdfViewer>
     }
   }
 
+  /// The revision controller notified. It owns the document revisions, so a
+  /// new revision (an edit, a form fill, undo/redo) means a new
+  /// [_document] to reconcile; every notification also feeds the build (an
+  /// armed tool, a selection, the eyedropper), so rebuild regardless. This is
+  /// what the host's `ListenableBuilder` used to do - the viewer now does it
+  /// itself so the displayed document can't lag the controller.
+  void _onRevisionControllerChanged() {
+    if (!mounted) return;
+    if (!identical(_loadedDocument, _document)) {
+      _swapDocument();
+    } else {
+      setState(() {});
+    }
+  }
+
+  /// Reconciles cached state to a document swap - from [_loadedDocument] to
+  /// the current [_document]. An edit revision with the same page geometry
+  /// keeps the reading position; a genuinely different document resets. Runs
+  /// from [didUpdateWidget] (a host rebuild with a new document/controller)
+  /// and from [_onRevisionControllerChanged] (a new revision with no host
+  /// rebuild).
+  void _swapDocument() {
+    final document = _document;
+    final sameGeometry = _sameGeometryAs(document);
+    _textCache.clear();
+    _annotCache.clear();
+    _visibleAnnotCache.clear();
+    _fieldRectCache.clear();
+    _controller.clearSearch();
+    _clearSelection();
+    _loadPages();
+    // an edit revision keeps its previews (rebound to the new page
+    // objects - edited pages refresh from their on-screen render); a
+    // different document starts clean
+    if (sameGeometry) {
+      // a page whose content stamp advanced changed materially (a
+      // redaction burn removes glyphs/images): drop its stale preview so
+      // a fast scroll can't flash the deleted content, instead of
+      // rebinding it. Untouched pages rebind in place as before.
+      _previews.rebind(_pages, changed: (i) {
+        final prev = _contentStamps[i];
+        return prev != null && prev != _contentStamp(i);
+      });
+    } else {
+      _previews.clear();
+      // the page list shifted under the lazy list's slot-keyed States;
+      // bump the epoch so each reused page drops the raster of the page
+      // that used to sit in its slot (otherwise a fast scroll right after
+      // an insert/remove/reorder paints the wrong, stale low-res page)
+      _pageEpoch++;
+    }
+    // the cached previews (rebound or cleared) now reflect this revision
+    _snapshotContentStamps();
+    // re-point (and, for a different file, re-prime) the persistent
+    // preview backing; an edit revision keeps its rebound previews so the
+    // prime is a no-op there
+    _bindRasterCache(prime: !sameGeometry);
+    _previewAttempts.clear();
+    _previewVectorAttempts.clear();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _prerenderPreviews());
+    if (!sameGeometry) {
+      // didUpdateWidget/a controller notification can land mid-build, and
+      // jumpTo synchronously dispatches a ScrollNotification - ancestors
+      // listening through a ScrollNotificationObserver (a Material AppBar's
+      // scrolled-under state, for one) would setState during build. Reset
+      // after the frame.
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _scroll.hasClients) _scroll.jumpTo(0);
+      });
+      _transform.value = Matrix4.identity();
+      // a different file deserves a fresh fit; an edit revision (same
+      // geometry) keeps the zoom the user chose
+      _appliedInitialFit = false;
+    }
+    setState(() {});
+  }
+
   /// Whether [document] lays out exactly like the one on screen: same
   /// page count, same aspect ratio per page.
   bool _sameGeometryAs(PdfDocument document) {
@@ -2044,8 +2118,10 @@ class _PdfViewerState extends State<PdfViewer>
       ((_pages[index].rotation + _controller._viewRotation) % 360 + 360) % 360;
 
   void _loadPages() {
-    final count = widget.document.pageCount;
-    _pages = [for (var i = 0; i < count; i++) widget.document.page(i)];
+    final document = _document;
+    _loadedDocument = document;
+    final count = document.pageCount;
+    _pages = [for (var i = 0; i < count; i++) document.page(i)];
     _pageLabels = null; // recompute lazily for the (possibly new) document
     _recomputeAspects();
     _controller._setPageCount(count);
@@ -2055,7 +2131,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// document and reset on a document swap in [_loadPages].
   PdfPageLabels? _pageLabels;
   PdfPageLabels get _labels =>
-      _pageLabels ??= PdfPageLabels.of(widget.document);
+      _pageLabels ??= PdfPageLabels.of(_document);
 
   /// The logical label for page [index], or its 1-based number when the
   /// document carries no labels.
@@ -2191,6 +2267,7 @@ class _PdfViewerState extends State<PdfViewer>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _revisionController?.removeListener(_onRevisionControllerChanged);
     widget.performance?.removeListener(_onPerformanceChanged);
     if (widget.performance != null) {
       SchedulerBinding.instance.removeTimingsCallback(_onPerformanceTimings);
@@ -2700,11 +2777,11 @@ class _PdfViewerState extends State<PdfViewer>
     final key = widget.documentId;
     if (textCache != null && key != null && widget.editing == null) {
       final text = await textCache.get(
-          key, index, () => PdfTextExtractor.extract(widget.document, index));
+          key, index, () => PdfTextExtractor.extract(_document, index));
       return _textCache.putIfAbsent(index, () => text);
     }
     return _textCache.putIfAbsent(
-        index, () => PdfTextExtractor.extract(widget.document, index));
+        index, () => PdfTextExtractor.extract(_document, index));
   }
 
   Future<List<PdfSearchResult>> _searchAllPages(
@@ -2762,7 +2839,7 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   PdfPageText _pageText(int index) => _textCache.putIfAbsent(
-      index, () => PdfTextExtractor.extract(widget.document, index));
+      index, () => PdfTextExtractor.extract(_document, index));
 
   /// The visible part of page [index]'s laid-out area, as fractions of
   /// the page (0–1, y-down), or null while the page is off-screen.
@@ -4719,13 +4796,6 @@ class _PdfViewerState extends State<PdfViewer>
 
   @override
   Widget build(BuildContext context) {
-    assert(
-        widget.editing == null ||
-            identical(widget.editing!.document, widget.document),
-        'PdfViewer.editing is set but document is not editing.document. '
-        'The editing controller owns the document revisions: rebuild the '
-        'viewer with editing.document whenever the controller notifies '
-        '(e.g. wrap it in a ListenableBuilder on the controller).');
     final editing = widget.editing;
     final canvasColor = widget.backgroundColor ??
         PdfViewerTheme.of(context).canvasColor ??

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -742,10 +742,13 @@ class PdfViewer extends StatefulWidget {
     this.documentId,
     this.active = true,
   }) : assert(
-            document != null || editing != null || formController != null,
-            'PdfViewer needs a document: pass document for the read-only '
-            'reader path, or an editing/formController controller that owns '
-            'the document revisions.');
+            document != null ||
+                editing != null ||
+                (formController != null && interactiveForms),
+            'PdfViewer needs a document source: pass document for the '
+            'read-only reader path, or an editing / active formController '
+            'controller that owns the document revisions. (A formController '
+            'with interactiveForms: false is ignored, so it is not a source.)');
 
   /// The document to display when no controller drives the viewer (the
   /// read-only reader path). Ignored when [editing] or an active
@@ -1149,15 +1152,21 @@ class _PdfViewerState extends State<PdfViewer>
   late List<PdfPage> _pages;
   late List<double> _aspects; // height / width, after /Rotate
 
-  /// The controller that owns the document revisions, if any: the editing
-  /// controller, or - when interactive forms are on - the form controller.
-  /// The viewer reads its current [PdfEditingController.document] and
-  /// subscribes to it (see [_onRevisionControllerChanged]), so the displayed
-  /// document can never desync from the controller and the host does not have
-  /// to keep [PdfViewer.document] in step or rebuild on every notification.
-  PdfEditingController? get _revisionController =>
+  /// The controller that owns the document revisions for a given viewer
+  /// configuration, if any: the editing controller, or - when interactive
+  /// forms are on - the form controller. Kept as one function so the live
+  /// getter and the [didUpdateWidget] old-widget comparison can't drift.
+  static PdfEditingController? _revisionControllerFor(PdfViewer widget) =>
       widget.editing ??
       (widget.interactiveForms ? widget.formController : null);
+
+  /// This viewer's revision controller. The viewer reads its current
+  /// [PdfEditingController.document] and subscribes to it (see
+  /// [_onRevisionControllerChanged]), so the displayed document can never
+  /// desync from the controller and the host does not have to keep
+  /// [PdfViewer.document] in step or rebuild on every notification.
+  PdfEditingController? get _revisionController =>
+      _revisionControllerFor(widget);
 
   /// The document actually displayed: the revision controller's current
   /// document when one drives the viewer, otherwise the standalone
@@ -1952,8 +1961,7 @@ class _PdfViewerState extends State<PdfViewer>
     // the revision controller (editing, or an active formController) can be
     // swapped in place - move the subscription before reading _document, which
     // resolves through it
-    final oldRevisionController = oldWidget.editing ??
-        (oldWidget.interactiveForms ? oldWidget.formController : null);
+    final oldRevisionController = _revisionControllerFor(oldWidget);
     final newRevisionController = _revisionController;
     if (!identical(oldRevisionController, newRevisionController)) {
       oldRevisionController?.removeListener(_onRevisionControllerChanged);

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1342,4 +1342,87 @@ void main() {
     expect(controller.currentPage, 2,
         reason: 'jumpToPage must reach the replacement viewer');
   });
+
+  group('editing controller drives the document', () {
+    testWidgets(
+        'follows revisions with no host ListenableBuilder and no document',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      final controller = PdfViewerController();
+      // deliberately no ListenableBuilder wrapping the viewer and no
+      // `document:` - the viewer reads editing.document and subscribes to the
+      // controller itself, so the host no longer owns that invariant.
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            editing: editing,
+            controller: controller,
+          ),
+        ),
+      ));
+      await tester.pump();
+      expect(controller.pageCount, 3);
+
+      // a structural edit advances the revision; the viewer must pick it up
+      // on its own, without the host rebuilding it with a fresh document
+      editing.removePage(2);
+      await tester.pump();
+      expect(controller.pageCount, 2,
+          reason: 'the viewer tracks the controller revision by itself');
+    });
+
+    testWidgets('a stale standalone document never desyncs the viewer',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      // a document that does NOT match editing.document - the old debug
+      // invariant would have asserted; now the viewer ignores it and follows
+      // the controller instead.
+      final stale = PdfDocument.open(buildMultiPagePdf(5));
+      final controller = PdfViewerController();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: stale,
+            editing: editing,
+            controller: controller,
+          ),
+        ),
+      ));
+      await tester.pump();
+      expect(controller.pageCount, 3,
+          reason: 'editing.document wins over the standalone document');
+    });
+
+    testWidgets('a form fill revision reaches the viewer without a rebuild',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      addTearDown(editing.dispose);
+      final controller = PdfViewerController();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            formController: editing,
+            controller: controller,
+          ),
+        ),
+      ));
+      await tester.pump();
+      expect(controller.pageCount, 3);
+
+      // formController owns the revisions too: a page removal must land
+      // without the host wrapping the viewer in a ListenableBuilder.
+      editing.removePage(2);
+      await tester.pump();
+      expect(controller.pageCount, 2,
+          reason: 'the viewer subscribes to the form controller as well');
+    });
+  });
 }

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1399,6 +1399,21 @@ void main() {
           reason: 'editing.document wins over the standalone document');
     });
 
+    test('a formController ignored by interactiveForms: false is not a source',
+        () {
+      // formController is ignored when interactiveForms is false, so it can't
+      // stand in for the document - the assert must reject this rather than
+      // let _document dereference a null document later.
+      final editing = PdfEditingController(buildMultiPagePdf(2));
+      addTearDown(editing.dispose);
+      expect(
+        () => PdfViewer(formController: editing, interactiveForms: false),
+        throwsAssertionError,
+      );
+      // with interactiveForms on (the default) it IS a source
+      expect(PdfViewer(formController: editing), isNotNull);
+    });
+
     testWidgets('a form fill revision reaches the viewer without a rebuild',
         (tester) async {
       SharedPreferences.setMockInitialValues({});


### PR DESCRIPTION
## Summary

Closes #319.

`PdfViewer` took `document` **and** `editing`/`formController` separately, tied by an unchecked invariant: `document` had to equal the controller's current revision, and the host had to rebuild the viewer on every controller notification (asserted only in debug builds). That was interface knowledge pushed onto every host, plus a second copy of the same rule for `formController`.

Now the viewer reads the displayed document from the revision controller and subscribes to it directly, so the pair can't desync:

- `_revisionController` — the controller that owns the revisions (`editing`, or an active `formController`), lifted into one getter.
- `_document` — `_revisionController?.document ?? widget.document!`. Every internal document read (`_loadPages`, page labels, text extraction) goes through this.
- `_loadedDocument` — what `_loadPages` last read; a swap is detected against it.
- `_onRevisionControllerChanged` — the subscription callback (added in `initState`, moved when the controller identity changes in `didUpdateWidget`, removed in `dispose`). A new revision runs the swap; otherwise it `setState`s for the tool/selection/eyedropper state the build reads. This is exactly what the host's `ListenableBuilder` used to do.
- `_swapDocument` — the same-geometry-rebind-vs-reset reconciliation, extracted out of `didUpdateWidget` so the host-rebuild path and the notification path share it.

`PdfViewer.document` is now optional (a constructor assert requires a document source: `document`, `editing`, or `formController`); the build-time desync assert is gone. Hosts passing a controller may drop both `document:` and the wrapping `ListenableBuilder` — the viewer's editing contract is one input instead of an invariant. The viewport-preserving identity-swap still keys on document identity, which the controller already changes per revision.

Backward compatible: hosts that still wrap the viewer in a `ListenableBuilder` and pass `document: editing.document` keep working — the swap just runs once (the controller has already advanced its `document` by the time either path fires, so whichever runs first reconciles and the other sees `_loadedDocument == _document`). `PdfReader` keeps its `ListenableBuilder` because it also drives `PdfReflowView` and reacts to preferences, and its no-form path is the standalone-`document` reader path.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Refactor / cleanup
- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Full `dart_pdf_editor` suite: +1607, 0 failures. New `editing controller drives the document` group in `pdf_viewer_test.dart` proves the viewer follows revisions with no host `ListenableBuilder` and no `document` (for both `editing` and `formController`), and that a deliberately stale standalone `document` never desyncs it. Analyzer clean.

## PDF fixtures and screenshots

None — behavior is covered by widget tests using programmatic fixtures.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The README and `CLAUDE.md` snippets are updated to the collapsed contract (drop `document:`/`ListenableBuilder` when a controller is present).
- Dev-log note added: `doc/dev-log/2026-07-17-viewer-editing-single-input.md`.
- `formController` is only treated as a revision source when `interactiveForms` is true, matching the pre-existing annotation-layer/page-image resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TorY3JaTGzGfR8rEpi48vU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TorY3JaTGzGfR8rEpi48vU)_