### PR TITLE
perf: PdfTileStore — budgeted zoom-bucket tile pyramid for deep-zoom detail (#314)

### DIFF
--- a/doc/dev-log/2026-07-17-gpu-tile-store.md
+++ b/doc/dev-log/2026-07-17-gpu-tile-store.md
@@ -1,0 +1,113 @@
+# PdfTileStore: a budgeted zoom-bucket tile pyramid for deep-zoom detail
+
+Issue #314 (perf). The structural gap against native viewers (Bluebeam-class):
+they composite GPU-resident tiles and never re-rasterize on pan; the page view
+re-reads pixels back from the GPU on every settle. Today three raster
+mechanisms coexist per `_PdfPageViewState`, each with its own staleness rule -
+the full-page `_image` (capped by `_maxPixels`/`_maxDimension`, so page size
+bounds fidelity), **exactly one** unbudgeted detail patch (`_detailImage`, which
+dies on every settle/scene change/edit, so a pan past it blurs until a fresh
+whole-region `toImage` lands), and the `_preview` upscale. This lands the module
+the issue proposed, plus a flag-gated integration, without touching the shipping
+default path.
+
+## What landed
+
+**`lib/src/tile_store.dart` - `PdfTileStore`** (a `ChangeNotifier`), a quantized
+zoom-bucket pyramid of fixed-size (512² physical px ≈ 1 MB RGBA) GPU-resident
+tiles. The interface the issue specified, small and synchronous:
+
+- **`PdfTileView viewFor({id, pageSize, desiredRatio, visiblePageRect,
+  rasterize})`** - returns the best-available tiles *now*. It snaps
+  `desiredRatio` to a bucket, walks the visible tile range **center-out**, and
+  for each tile: composites the exact-bucket tile if cached (touched to
+  most-recently-used), else schedules its raster and falls back **per-tile to
+  the nearest coarser cached bucket, upscaled** (clipped to the overlap; any
+  still-uncovered gap leaves the base raster showing through, which is why the
+  layer is purely additive). It also schedules a one-tile **prefetch ring** so a
+  pan reveals ready tiles. Every placed tile is promoted to MRU, so a concurrent
+  completion's eviction can only drop tiles outside the current view (the byte
+  budget floor keeps a viewport's worth well above the eviction line).
+- **`invalidate({Set<int>? pages})`** - `null` clears all; a page set evicts via
+  `PdfBudgetedCache.evictWhere` and stamps a per-page epoch so an in-flight
+  raster dispatched before the edit is discarded on completion (the exact model
+  `PdfCachingRenderWorker.updateRevision`'s `changedPages` uses, #308).
+- **Listenable** - ticks (coalesced to one `notifyListeners` per microtask) as
+  sharper tiles land.
+
+Storage is one `PdfBudgetedCache<PdfTileKey, PdfTile>` (#307) weighed by tile
+bytes, default 96 MB, `disposer` disposing the `ui.Image`, registered with
+`PdfCacheRegistry` so memory pressure clears it. The tile key -
+`(PdfTilePageIdentity{pageIndex, pageEpoch, contentStamp, destructiveStamp,
+plan}, rung, tx, ty)` - is built entirely from identities already on
+`PdfPageRenderIntent`/`PdfPageRenderPlan`, so a content edit, rotation, or
+paper-color change is a distinct key and stale pixels can never surface even
+before `invalidate` frees them. The `PdfTileZoomLadder` snaps a desired ratio to
+a ×√2 rung (rung 0 = ratio 1), clamped, so a small pan/pinch keeps hitting the
+same rung's tiles.
+
+The raster primitive is the existing `PdfRetainedScene.rasterizeRegion` - a tile
+is just a region raster of the tile bounds at the bucket ratio. Added
+`PdfRetainedScene.supportsRegionRaster` (a non-debug alias over the region
+index's `supported` flag) so the caller can leave soft-mask/group pages, whose
+regions can't be culled, on the legacy path.
+
+**`lib/src/tile_layer.dart` - `PdfTileLayer`**, the presentation seam: a
+`CustomPaint` whose painter (`super(repaint: store)`) calls `viewFor` each paint
+and issues `canvas.drawImageRect` per placement, repainting when the store
+ticks. Kept in its own file so `tile_store.dart` stays a pure model (no widget
+import).
+
+**Integration behind `PdfPageView.tileStoreDetail` (default false).** When on
+and the page retains a region-cullable scene, `_updateDetail` short-circuits:
+instead of producing the single `_detailImage`, `_refreshTileGeometry` stores
+the visible fraction + desired ratio (computed post-render, never during
+layout - `_detailGeometryAt` reads the render tree), and `build` slots a
+`Positioned.fill(PdfTileLayer(...))` **above** the base `_image`, replacing the
+detail-patch branch. `_dropDetail` also calls the store's per-page `invalidate`.
+Soft-mask/group pages and the vector-first progressive scene keep the legacy
+patch - the fallback adapter the issue calls for.
+
+## Why flag-gated + additive, not the wholesale replacement
+
+The issue's "what it deletes" list (`_detailImage`/`_detailGeometryAt`, the
+`_rasteredRatio` staleness gate, the `_maxPixels`/`_maxDimension` caps, the
+preview cache's full-raster tier) touches load-bearing machinery interwoven with
+the Slug web layer, the strip router, speculative worker binning, and the
+vector-first progressive scene. Ripping those out in one PR would be reckless.
+The tile layer sits *above* the untouched base raster, so with the flag off the
+default path is byte-identical, and with it on a not-yet-tiled gap simply shows
+the (capped) base image - no regression surface. The deletions and making it
+default are deferred follow-ups, pending the #306 render-trace measurements the
+issue sequences this after (settle-to-sharp latency, per-readback main-thread
+stall on web, retained MB on the #283 62-page scroll).
+
+## Tests
+
+- `tile_store_test.dart` (13): ladder snapping/round-trip; center-out
+  scheduling at the bucket ratio; prefetch ring; coarser-bucket upscaled
+  fallback (and no-cache → empty base-only view); per-page `invalidate` +
+  in-flight discard; `null` clears all; byte-budget bound; coalesced tick;
+  memory pressure; dispose inert + late-tile drop.
+- `tile_layer_test.dart` (2): the layer schedules on first paint then
+  composites + repaints as tiles land; an empty store paints nothing.
+- `tile_store_page_view_test.dart` (2): with the flag on, a deep-zoom classic
+  page composites real tiles from its retained scene (`pdf-page-tile-layer`
+  present, `pdf-page-detail-image` gone, base RawImage intact); a classic scene
+  reports region-cullable.
+
+## Gotchas
+
+- **Never call `findRenderObject` during layout.** The first cut computed the
+  visible fraction inside the `LayoutBuilder` builder; that runs during the
+  layout phase where reading `RenderBox.size`/`localToGlobal` asserts. Moved to
+  a post-render `_refreshTileGeometry` that stores the fraction for `build`.
+- **MRU protection is budget-relative.** `viewFor` promotes placed tiles, but a
+  batch of completions larger than `budget − viewport` could still age a view
+  tile past the eviction line. The 96 MB default (8 MB floor) sits far above a
+  deep-zoom viewport (a dozen tiles ≈ 12 MB) plus a completion batch, so in
+  practice eviction only ever targets off-view/prefetch tiles.
+- **Tick coalescing is per-microtask, not per-batch-across-turns.** The
+  test's `flush` completes every rasterizer synchronously in one burst so the
+  N completions drain in a single microtask and coalesce to one tick; spread
+  across event-loop turns they'd tick per turn (still correct, just chattier).

--- a/doc/dev-log/2026-07-17-gpu-tile-store.md
+++ b/doc/dev-log/2026-07-17-gpu-tile-store.md
@@ -96,6 +96,40 @@ stall on web, retained MB on the #283 62-page scroll).
   present, `pdf-page-detail-image` gone, base RawImage intact); a classic scene
   reports region-cullable.
 
+## Benchmarks (`test/benchmark_tile_store_test.dart`)
+
+A skip-unless-`PDF_BENCHMARK_DIR` harness drives the two raster strategies -
+the shipping single detail patch (`rasterizeRegion` of the whole visible region
+per settle) vs. the tile store - through the same pinch-in, deep-zoom pan, and
+revisit sequences over each page's retained scene, sharing one up-front
+`record` so only the *re-raster* is measured. Run on `test_corpora/pdfjs`
+(14 pages, ratio 8, best-of-2, headless VM software raster):
+
+| scenario | legacy patch | tile store | verdict |
+|---|---|---|---|
+| **revisit** (drag back over just-seen area) | 196 Mpx / 216 ms | **0 Mpx / 0 ms** | **100% reuse** - the headline win, "pan = zero re-raster" |
+| **pan** (cold monotonic drag) | 218 Mpx / 235 ms | 112 Mpx / 1924 ms | tiles raster **1.9× fewer pixels** but are **~8× slower wall-time** |
+| **pinch-in** (zoom through buckets) | 91 Mpx | 206 Mpx | tiles do **2.3× more** cold work |
+
+The reuse win is decisive and real: any revisited area (back-and-forth pan,
+jitter, a settle at a scale already tiled) costs the tile store nothing, where
+the patch always re-rasters. But the cold-path numbers **confirm the issue's own
+risk** ("per-`toImage` overhead on web may favour batching several tiles per
+readback - measure via #306 before committing to tile size"): 91 Mpx split into
+~350 512²-tile `toImage` calls loses badly to one big-region `toImage`, because
+the fixed per-readback overhead dominates. So a naive 1-`toImage`-per-512²-tile
+at these sizes is throughput-negative on a cold sweep; the wins are reuse,
+cancellability, and uncapped fidelity, not raw cold throughput.
+
+**This is exactly the measurement that must gate flipping the flag to default**,
+and it says the next step before that is bigger tiles and/or batching several
+tiles per readback (the issue's #306 direction) - not turning `tileStoreDetail`
+on as-is. Caveat: headless software raster with a synchronous `toImage`
+overweights per-call overhead vs. an on-device GPU with an async, cancellable
+readback (the web case the pyramid most helps), and pdfjs pages are small enough
+that the patch's `_maxPixels`/`_maxDimension` caps - which tiles escape - never
+bind; a dense large-format sheet would shift pan/pinch further toward tiles.
+
 ## Gotchas
 
 - **Never call `findRenderObject` during layout.** The first cut computed the

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -73,4 +73,6 @@ export 'src/retained_scene.dart';
 export 'src/search_panel.dart';
 export 'src/scrollbar.dart';
 export 'src/theme.dart';
+export 'src/tile_layer.dart';
+export 'src/tile_store.dart';
 export 'src/toast.dart';

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -22,6 +22,8 @@ import 'render_worker.dart';
 import 'renderer.dart';
 import 'retained_scene.dart';
 import 'strips/strip_device.dart';
+import 'tile_layer.dart';
+import 'tile_store.dart';
 
 /// Displays a single PDF page, rendered natively in Dart.
 ///
@@ -299,6 +301,24 @@ class PdfPageView extends StatefulWidget {
   /// thread turns the returned detail commands into the sharp on-screen patch.
   static bool deferFullRenderUntilDetailPaint = true;
 
+  /// Opt-in: composite deep-zoom detail from the [PdfTileStore] zoom-bucket
+  /// pyramid instead of the single unbudgeted detail patch. When true (and the
+  /// page retains a region-cullable scene), the visible slice is tiled: panning
+  /// at deep zoom draws cached tiles with zero re-raster and a settle only
+  /// rasterizes the missing tiles, all under one shared byte budget that evicts
+  /// by least-recently used and drops under memory pressure.
+  ///
+  /// Additive to the existing pipeline: the tile layer sits ABOVE the base
+  /// raster, so a gap not yet tiled shows the (capped) base image through it,
+  /// and pages the region index cannot cull (soft-mask/group spans) keep the
+  /// legacy single-patch path. Default false while the pyramid is measured
+  /// against the shipping detail patch (issue #314).
+  static bool tileStoreDetail = false;
+
+  /// Test seam: the store the tile layer draws from. Null uses the shared
+  /// [PdfTileStore.instance].
+  static PdfTileStore? debugTileStoreOverride;
+
   /// Test hook for [webSlugGlyphLayer]. Null uses [kIsWeb].
   static bool? debugWebSlugGlyphLayerBackendOverride;
 
@@ -369,6 +389,14 @@ class _PdfPageViewState extends State<PdfPageView> {
   ui.Image? _detailImage;
   Rect? _detailFraction; // patch placement as fractions of the page
   Future<bool>? _progressiveDetailFuture;
+
+  /// Visible slice (fraction of the page) and desired ratio for the
+  /// [PdfPageView.tileStoreDetail] tile layer, recomputed on each settle in
+  /// [_refreshTileGeometry] - post-render, never during layout - so `build`
+  /// reads a stored value instead of probing the render tree. Null when the
+  /// tile path is inactive.
+  Rect? _tileFraction;
+  double? _tileDesiredRatio;
 
   /// Clone of this page's cached low-res preview; painted while no full
   /// raster exists, dropped (to free the buffer) the moment one lands.
@@ -670,7 +698,18 @@ class _PdfPageViewState extends State<PdfPageView> {
   /// page's command list on every pan.
   bool _sceneHasImageDraws = false;
 
+  /// Drops this page's retained tiles when its content is replaced (edit,
+  /// redaction, display change), the tile analogue of [_dropDetail]. Content
+  /// stamps already key stale tiles out; this frees them eagerly and discards
+  /// any in-flight raster from the superseded scene (issue #308's model).
+  void _invalidateTiles() {
+    if (!PdfPageView.tileStoreDetail) return;
+    (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+        .invalidate(pages: {widget.previewIndex});
+  }
+
   void _dropDetail() {
+    _invalidateTiles();
     _renderSession.invalidateDetail();
     if (_detailImage != null) {
       _detailImage?.dispose();
@@ -1411,6 +1450,13 @@ class _PdfPageViewState extends State<PdfPageView> {
     final generation = _renderSession.beginDetail();
     if (_renderPaused) return false;
 
+    // The tile pyramid supplies deep-zoom detail instead of the single patch:
+    // just refresh the visible slice and let the tile layer schedule/composite.
+    if (_useTilePath) {
+      _refreshTileGeometry();
+      return true;
+    }
+
     // A Slug page picture is already transform-sharp for text and vector
     // content. Image-free pages therefore gain nothing from a deep-zoom
     // raster patch: it only re-records the whole page in the worker, performs
@@ -1750,6 +1796,69 @@ class _PdfPageViewState extends State<PdfPageView> {
       _maxDimension / math.max(region.width, region.height),
     );
     return _DetailGeometry(fraction, region, ratio);
+  }
+
+  /// Whether the [PdfPageView.tileStoreDetail] tile path drives deep-zoom
+  /// detail for this page: the flag is on and the retained scene is
+  /// region-cullable (soft-mask/group spans and the vector-first progressive
+  /// scene keep the legacy single-patch path).
+  bool get _useTilePath {
+    if (!PdfPageView.tileStoreDetail) return false;
+    final scene = PdfPageView.retainedZoomReplay ? _scene : null;
+    return scene != null && !_sceneIsVectorOnly && scene.supportsRegionRaster;
+  }
+
+  /// Recomputes the tile layer's visible slice + desired ratio on a settle.
+  /// Runs post-render (never during layout), so reading the render tree in
+  /// [_detailGeometryAt] is safe; `build` reads the stored fields.
+  void _refreshTileGeometry() {
+    if (!mounted) return;
+    Rect? fraction;
+    double? desired;
+    if (_useTilePath) {
+      // _detailGeometryAt returns null when the base raster is already sharp
+      // enough (desired <= effective) - exactly when tiles add nothing.
+      fraction = _detailGeometryAt(widget.scale)?.fraction;
+      if (fraction != null) desired = _desiredRatioAt(widget.scale);
+    }
+    if (fraction != _tileFraction || desired != _tileDesiredRatio) {
+      setState(() {
+        _tileFraction = fraction;
+        _tileDesiredRatio = desired;
+      });
+    }
+  }
+
+  /// The [PdfTileStore] deep-zoom composite for this page, or null when the
+  /// tile path is inactive or the page is not zoomed past the base raster.
+  ///
+  /// [size] is the page-point size (the tile grid space). Placed above the base
+  /// raster so uncovered gaps show it through; it replaces the single detail
+  /// patch when active.
+  Widget? _tileLayerWidget(Size size) {
+    if (!_useTilePath) return null;
+    final scene = _scene;
+    final fraction = _tileFraction;
+    final desired = _tileDesiredRatio;
+    if (scene == null || fraction == null || desired == null) return null;
+    final store = PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance;
+    return Positioned.fill(
+      child: PdfTileLayer(
+        store: store,
+        identity: PdfTilePageIdentity(
+          pageIndex: widget.previewIndex,
+          pageEpoch: widget.pageEpoch,
+          contentStamp: widget.contentStamp,
+          destructiveStamp: widget.destructiveStamp,
+          plan: _renderPlan,
+        ),
+        pageSize: size,
+        desiredRatio: desired,
+        visibleFraction: fraction,
+        rasterize: (region, ratio) =>
+            scene.rasterizeRegion(region, pixelRatio: ratio),
+      ),
+    );
   }
 
   /// Whether worker strip binning may be asked for at all - shared by
@@ -2120,6 +2229,7 @@ class _PdfPageViewState extends State<PdfPageView> {
               final detail = _detailImage;
               final fraction = _detailFraction;
               final slugPicture = _slugPicture;
+              final tileLayer = _tileLayerWidget(size);
               return Stack(
                 alignment: Alignment.topLeft,
                 fit: StackFit.expand,
@@ -2153,7 +2263,9 @@ class _PdfPageViewState extends State<PdfPageView> {
                       fit: BoxFit.contain,
                       filterQuality: FilterQuality.medium,
                     ),
-                  if (detail != null && fraction != null && w.isFinite)
+                  if (tileLayer != null)
+                    tileLayer
+                  else if (detail != null && fraction != null && w.isFinite)
                     Positioned(
                       left: fraction.left * w,
                       top: fraction.top * h,

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -71,6 +71,13 @@ class PdfRetainedScene {
   bool debugLastRegionReplayWasSelective = false;
   int debugLastRegionReplayCommandCount = 0;
 
+  /// Whether region rasters ([rasterizeRegion]) can be spatially culled to the
+  /// requested bounds rather than replaying the whole transcript. False when a
+  /// transparency group or soft mask spans the page (splitting one would change
+  /// its isolated compositing) - the [PdfTileStore] tile path leaves such pages
+  /// on the legacy full-page raster to avoid per-tile full-transcript replays.
+  bool get supportsRegionRaster => _ensureRegionIndex().supported;
+
   int get debugRegionReplayUnitCount => _ensureRegionIndex().units.length;
   int get debugRegionReplayEstimatedBytes =>
       _ensureRegionIndex().estimatedBytes;

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -1,0 +1,127 @@
+/// The presentation half of [PdfTileStore]: a [CustomPaint] that composites the
+/// store's best-available tiles for a page's visible region via
+/// `canvas.drawImageRect`, repainting as sharper tiles land.
+///
+/// Kept separate from `tile_store.dart` so the store stays a pure model (no
+/// widget dependency); this file is the only tile code that imports Flutter's
+/// widget layer.
+library;
+
+import 'package:flutter/widgets.dart';
+
+import 'tile_store.dart';
+
+/// Draws a page's tile pyramid over its visible region.
+///
+/// Place it in a [Stack] above the base page raster (e.g. via [Positioned.fill]):
+/// the tiles sharpen the visible slice while the base image shows through any
+/// gap not yet covered by a tile or an upscaled coarser fallback. The layer
+/// asks [store] for the best-available composite every paint and repaints
+/// whenever the store ticks (a sharper tile landed).
+class PdfTileLayer extends StatelessWidget {
+  const PdfTileLayer({
+    super.key,
+    required this.store,
+    required this.identity,
+    required this.pageSize,
+    required this.desiredRatio,
+    required this.visibleFraction,
+    required this.rasterize,
+    this.filterQuality = FilterQuality.medium,
+  });
+
+  /// The pyramid to composite from.
+  final PdfTileStore store;
+
+  /// The page's current visual identity (slot, stamps, plan).
+  final PdfTilePageIdentity identity;
+
+  /// The page size in points (after the plan's rotation) - the tile grid space.
+  final Size pageSize;
+
+  /// The uncapped resolution the current zoom wants; snapped to a bucket.
+  final double desiredRatio;
+
+  /// The on-screen visible slice as fractions (0..1) of the page.
+  final Rect visibleFraction;
+
+  /// Rasterizes one tile from the page's retained scene.
+  final PdfTileRasterizer rasterize;
+
+  final FilterQuality filterQuality;
+
+  @override
+  Widget build(BuildContext context) => CustomPaint(
+        key: const ValueKey('pdf-page-tile-layer'),
+        painter: _TilePagePainter(
+          store: store,
+          identity: identity,
+          pageSize: pageSize,
+          desiredRatio: desiredRatio,
+          visibleFraction: visibleFraction,
+          rasterize: rasterize,
+          filterQuality: filterQuality,
+        ),
+      );
+}
+
+class _TilePagePainter extends CustomPainter {
+  _TilePagePainter({
+    required this.store,
+    required this.identity,
+    required this.pageSize,
+    required this.desiredRatio,
+    required this.visibleFraction,
+    required this.rasterize,
+    required this.filterQuality,
+  }) : super(repaint: store); // tick as sharper tiles land
+
+  final PdfTileStore store;
+  final PdfTilePageIdentity identity;
+  final Size pageSize;
+  final double desiredRatio;
+  final Rect visibleFraction;
+  final PdfTileRasterizer rasterize;
+  final FilterQuality filterQuality;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (size.isEmpty || pageSize.isEmpty) return;
+    final visiblePageRect = Rect.fromLTRB(
+      visibleFraction.left * pageSize.width,
+      visibleFraction.top * pageSize.height,
+      visibleFraction.right * pageSize.width,
+      visibleFraction.bottom * pageSize.height,
+    );
+    // Synchronous: returns cached tiles now and schedules the missing ones
+    // (their arrival ticks the store, which repaints this painter).
+    final view = store.viewFor(
+      id: identity,
+      pageSize: pageSize,
+      desiredRatio: desiredRatio,
+      visiblePageRect: visiblePageRect,
+      rasterize: rasterize,
+    );
+    if (view.isEmpty) return;
+    final paint = Paint()..filterQuality = filterQuality;
+    for (final placement in view.placements) {
+      final dest = Rect.fromLTRB(
+        placement.destFraction.left * size.width,
+        placement.destFraction.top * size.height,
+        placement.destFraction.right * size.width,
+        placement.destFraction.bottom * size.height,
+      );
+      canvas.drawImageRect(placement.image, placement.src, dest, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _TilePagePainter old) =>
+      !identical(old.store, store) ||
+      old.identity != identity ||
+      old.pageSize != pageSize ||
+      old.desiredRatio != desiredRatio ||
+      old.visibleFraction != visibleFraction ||
+      !identical(old.rasterize, rasterize) ||
+      old.filterQuality != filterQuality;
+}

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -1,0 +1,497 @@
+/// A quantized zoom-bucket pyramid of fixed-size, GPU-resident page tiles.
+///
+/// The classic deep-zoom path ([PdfRetainedScene.rasterizeRegion], driven by
+/// `_PdfPageViewState._updateDetail`) keeps exactly one detail patch per page:
+/// it is unbudgeted and dies on every settle, scene change, and edit, so a pan
+/// past its bounds shows the capped base raster until a fresh whole-region
+/// `toImage` lands. [PdfTileStore] instead retains many small tiles across a
+/// pyramid of zoom buckets under one shared budget, so panning at deep zoom
+/// composites cached tiles with zero re-raster and a settle only rasterizes the
+/// handful of visible tiles that are missing.
+///
+/// A tile is a region raster (see [PdfRetainedScene.rasterizeRegion]) of fixed
+/// physical size ([PdfTileStore.tilePixels]² ≈ 1 MB RGBA), keyed by
+/// `(page identity, plan, zoom bucket, column, row)` - every identity already
+/// carried by [PdfPageRenderIntent] and [PdfPageRenderPlan]. Storage is one
+/// [PdfBudgetedCache] weighed by tile bytes, evicting by least-recently used
+/// and registered with the coordinated memory-pressure path.
+///
+/// The presentation contract is small and synchronous: [viewFor] returns the
+/// best-available tiles *now* - exact-bucket tiles where cached, else the
+/// nearest coarser bucket upscaled - and schedules the missing ones; the store
+/// is a [Listenable] that ticks as sharper tiles land so the page view repaints
+/// them via `canvas.drawImageRect`.
+library;
+
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+
+import 'budgeted_cache.dart';
+import 'renderer.dart';
+
+/// Rasterizes one tile: [region] is the tile's bounds in page points (the
+/// y-down raster space [PdfRetainedScene.rasterizeRegion] takes), [pixelRatio]
+/// the bucket ratio. The returned image is owned by the store.
+typedef PdfTileRasterizer = Future<ui.Image> Function(
+    Rect region, double pixelRatio);
+
+/// The discrete ×√2 (or ×2) pixel-ratio ladder tiles are rastered on.
+///
+/// A continuous zoom would raster every tile at a slightly different ratio and
+/// never reuse one; snapping the desired ratio to a rung means a small pan or
+/// pinch keeps hitting the same rung's tiles. Rung 0 is ratio 1.0; each rung is
+/// [stepsPerOctave]-th of a doubling, so the default of 2 gives a ×√2 ladder.
+@immutable
+class PdfTileZoomLadder {
+  const PdfTileZoomLadder({
+    this.stepsPerOctave = 2,
+    this.minRung = -8,
+    this.maxRung = 16,
+  })  : assert(stepsPerOctave >= 1),
+        assert(minRung <= 0 && maxRung >= 0);
+
+  /// Rungs per factor-of-two of pixel ratio. 1 is a ×2 ladder, 2 is ×√2.
+  final int stepsPerOctave;
+
+  /// Clamp bounds so a degenerate desired ratio can't select an absurd bucket
+  /// (ratio floor 0.05 / a huge accidental zoom). minRung ratio ≈ 2^(min/steps).
+  final int minRung;
+  final int maxRung;
+
+  /// The rung whose ratio is nearest [ratio] (in log space), clamped.
+  int rungFor(double ratio) {
+    final safe = ratio <= 0 ? 0.05 : ratio;
+    final raw = (math.log(safe) / math.ln2) * stepsPerOctave;
+    return raw.round().clamp(minRung, maxRung);
+  }
+
+  /// The exact pixel ratio a [rung]'s tiles are rastered at.
+  double ratioFor(int rung) => math.pow(2, rung / stepsPerOctave).toDouble();
+}
+
+/// Everything about a page's visual state that changes what a tile should
+/// contain: the page slot and its epoch/content/destructive stamps (from
+/// [PdfPageRenderIntent]) plus the display [plan] (paper color, annotations,
+/// rotation, from [PdfPageRenderPlan]). Two identities that compare equal may
+/// share tiles; any difference is a distinct key so stale pixels never surface.
+@immutable
+class PdfTilePageIdentity {
+  const PdfTilePageIdentity({
+    required this.pageIndex,
+    required this.pageEpoch,
+    required this.contentStamp,
+    required this.destructiveStamp,
+    required this.plan,
+  });
+
+  final int pageIndex;
+  final int pageEpoch;
+  final int contentStamp;
+  final int destructiveStamp;
+  final PdfPageRenderPlan plan;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfTilePageIdentity &&
+      pageIndex == other.pageIndex &&
+      pageEpoch == other.pageEpoch &&
+      contentStamp == other.contentStamp &&
+      destructiveStamp == other.destructiveStamp &&
+      plan == other.plan;
+
+  @override
+  int get hashCode => Object.hash(
+      pageIndex, pageEpoch, contentStamp, destructiveStamp, plan);
+}
+
+/// The full cache key of a single tile.
+@immutable
+class PdfTileKey {
+  const PdfTileKey(this.id, this.rung, this.tx, this.ty);
+
+  final PdfTilePageIdentity id;
+  final int rung;
+  final int tx;
+  final int ty;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfTileKey &&
+      rung == other.rung &&
+      tx == other.tx &&
+      ty == other.ty &&
+      id == other.id;
+
+  @override
+  int get hashCode => Object.hash(id, rung, tx, ty);
+}
+
+/// A retained tile image plus the page-point region it covers and the bucket it
+/// belongs to. Owned by the store's cache; disposed on eviction.
+class PdfTile {
+  PdfTile(this.image, this.region, this.rung);
+
+  final ui.Image image;
+
+  /// The tile's bounds in page points (clamped to the page at the edges).
+  final Rect region;
+  final int rung;
+
+  int get bytes => image.width * image.height * 4;
+}
+
+/// One `drawImageRect` a [PdfTileView] asks the painter to issue: [src] pixels
+/// of [image] scaled into [destFraction] (0..1 of the page rect).
+@immutable
+class PdfTilePlacement {
+  const PdfTilePlacement({
+    required this.image,
+    required this.src,
+    required this.destFraction,
+  });
+
+  final ui.Image image;
+  final Rect src;
+  final Rect destFraction;
+}
+
+/// The synchronous result of [PdfTileStore.viewFor]: the tiles to composite for
+/// the requested viewport right now, plus whether every visible tile was
+/// available at the exact bucket ([complete] = no upscaled fallback in play).
+@immutable
+class PdfTileView {
+  const PdfTileView({
+    required this.rung,
+    required this.placements,
+    required this.complete,
+  });
+
+  static const empty =
+      PdfTileView(rung: 0, placements: <PdfTilePlacement>[], complete: true);
+
+  /// The zoom bucket this view targeted.
+  final int rung;
+
+  /// Composited bottom-to-top (fallbacks and exact tiles never overlap, so the
+  /// order only matters for determinism).
+  final List<PdfTilePlacement> placements;
+
+  /// True when no coarser-bucket fallback was needed - the view is fully sharp.
+  final bool complete;
+
+  bool get isEmpty => placements.isEmpty;
+}
+
+/// The tile pyramid. Instantiable (tests, an isolated page) with a shared
+/// process-wide default ([instance]) so one budget spans every page, replacing
+/// the unbudgeted per-page detail patch and image retention.
+class PdfTileStore extends ChangeNotifier {
+  PdfTileStore({
+    this.tilePixels = 512,
+    this.ladder = const PdfTileZoomLadder(),
+    int maxBytes = _defaultMaxBytes,
+    this.prefetchRing = 1,
+    this.maxFallbackDepth = 4,
+    bool registerForMemoryPressure = true,
+  }) : _cache = PdfBudgetedCache<PdfTileKey, PdfTile>(
+          weigher: (tile) => tile.bytes,
+          maxWeight: math.max(maxBytes, _minBytes),
+          disposer: (tile) => tile.image.dispose(),
+          clearsUnderMemoryPressure: registerForMemoryPressure,
+          debugLabel: 'tiles',
+        );
+
+  /// ~96 MB: enough for a deep-zoom viewport plus a prefetch ring across a
+  /// couple of buckets, well under the decoded-image budget it sits beside.
+  static const _defaultMaxBytes = 96 << 20;
+
+  /// A floor so a viewport's worth of tiles is never evicted out from under the
+  /// view that just asked for them (see [viewFor]'s MRU-protection contract).
+  static const _minBytes = 8 << 20;
+
+  static PdfTileStore? _instance;
+
+  /// The shared store the viewer uses. Lazily created so nothing is allocated
+  /// (or registered for memory pressure) unless the tile path is exercised.
+  static PdfTileStore get instance => _instance ??= PdfTileStore();
+
+  /// Physical pixels per tile side. A tile at bucket ratio r covers
+  /// `tilePixels / r` page points per side.
+  final int tilePixels;
+  final PdfTileZoomLadder ladder;
+
+  /// How many tiles beyond the visible range to pre-raster on each side, so a
+  /// pan reveals ready tiles instead of blanks.
+  final int prefetchRing;
+
+  /// How many buckets coarser [viewFor] will search for an upscaled fallback
+  /// before leaving the base raster to show through.
+  final int maxFallbackDepth;
+
+  final PdfBudgetedCache<PdfTileKey, PdfTile> _cache;
+  final Set<PdfTileKey> _inFlight = {};
+
+  /// Invalidation epochs: a tile whose page was invalidated after its raster
+  /// was dispatched is discarded on completion (mirrors the render worker's
+  /// stale-inflight guard). [_globalEpoch] rises on every invalidation;
+  /// [_pageEpoch] records the epoch at which each page was last invalidated.
+  int _globalEpoch = 0;
+  final Map<int, int> _pageEpoch = {};
+
+  bool _tickScheduled = false;
+  bool _disposed = false;
+
+  // Diagnostics (asserted in tests).
+  int debugTilesScheduled = 0;
+  int debugTilesLanded = 0;
+  int debugTilesDiscarded = 0;
+  int debugTicks = 0;
+
+  /// Total bytes of retained tiles.
+  int get retainedBytes => _cache.weight;
+
+  /// Number of retained tiles.
+  int get tileCount => _cache.length;
+
+  /// Tiles whose raster is currently in flight.
+  int get inFlightCount => _inFlight.length;
+
+  /// The weight budget, live-adjustable (a device-memory tier could lower it).
+  int get maxBytes => _cache.maxWeight;
+  set maxBytes(int value) => _cache.maxWeight = math.max(value, _minBytes);
+
+  /// Whether a tile for [key] is retained (test/diagnostic; no LRU touch).
+  bool containsTile(PdfTileKey key) => _cache.containsKey(key);
+
+  /// The best-available composite for [id] over [visiblePageRect] (page points)
+  /// at [desiredRatio], scheduling the missing exact-bucket tiles (center-out)
+  /// plus a one-tile prefetch ring. Missing tiles fall back per-tile to the
+  /// nearest coarser cached bucket, upscaled; anything still uncovered leaves
+  /// the base raster showing through.
+  ///
+  /// Synchronous and side-effecting: every tile it *places* is touched to
+  /// most-recently-used, so a concurrent completion's eviction can only drop
+  /// tiles outside the current view (the budget floor keeps a viewport's worth
+  /// safely above the eviction line). The returned images are the cache masters
+  /// - valid until the next completion for that key - which is exactly the
+  /// window `drawImageRect` needs within one frame.
+  PdfTileView viewFor({
+    required PdfTilePageIdentity id,
+    required Size pageSize,
+    required double desiredRatio,
+    required Rect visiblePageRect,
+    required PdfTileRasterizer rasterize,
+  }) {
+    if (_disposed ||
+        pageSize.width <= 0 ||
+        pageSize.height <= 0 ||
+        visiblePageRect.isEmpty) {
+      return PdfTileView.empty;
+    }
+
+    final rung = ladder.rungFor(desiredRatio);
+    final ratio = ladder.ratioFor(rung);
+    final span = tilePixels / ratio; // page points per tile side
+    if (!span.isFinite || span <= 0) return PdfTileView.empty;
+
+    final nx = math.max(1, (pageSize.width / span).ceil());
+    final ny = math.max(1, (pageSize.height / span).ceil());
+
+    final visible = visiblePageRect.intersect(Offset.zero & pageSize);
+    if (visible.isEmpty) return PdfTileView.empty;
+
+    final tx0 = (visible.left / span).floor().clamp(0, nx - 1);
+    final ty0 = (visible.top / span).floor().clamp(0, ny - 1);
+    final tx1 = ((visible.right / span).ceil() - 1).clamp(0, nx - 1);
+    final ty1 = ((visible.bottom / span).ceil() - 1).clamp(0, ny - 1);
+
+    // Center-out ordering: the tile under the viewport center sharpens first.
+    final cx = (visible.center.dx / span);
+    final cy = (visible.center.dy / span);
+    final coords = <(int, int)>[];
+    for (var ty = ty0; ty <= ty1; ty++) {
+      for (var tx = tx0; tx <= tx1; tx++) {
+        coords.add((tx, ty));
+      }
+    }
+    coords.sort((a, b) {
+      final da = (a.$1 + 0.5 - cx) * (a.$1 + 0.5 - cx) +
+          (a.$2 + 0.5 - cy) * (a.$2 + 0.5 - cy);
+      final db = (b.$1 + 0.5 - cx) * (b.$1 + 0.5 - cx) +
+          (b.$2 + 0.5 - cy) * (b.$2 + 0.5 - cy);
+      return da.compareTo(db);
+    });
+
+    final placements = <PdfTilePlacement>[];
+    var complete = true;
+    for (final (tx, ty) in coords) {
+      final key = PdfTileKey(id, rung, tx, ty);
+      final tile = _cache.take(key); // hit → promote to MRU
+      if (tile != null) {
+        placements.add(PdfTilePlacement(
+          image: tile.image,
+          src: Rect.fromLTWH(
+              0, 0, tile.image.width.toDouble(), tile.image.height.toDouble()),
+          destFraction: _fractionOf(tile.region, pageSize),
+        ));
+      } else {
+        complete = false;
+        _schedule(key, id, pageSize, span, ratio, rasterize);
+        final fallback = _coarserFallback(id, rung, tx, ty, span, pageSize);
+        if (fallback != null) placements.add(fallback);
+      }
+    }
+
+    // Prefetch ring: pre-raster the border just outside the visible range so a
+    // pan reveals ready tiles. Scheduled after the visible tiles (which matter
+    // now); dedup keeps a hovering viewport from re-queueing.
+    if (prefetchRing > 0) {
+      final rx0 = math.max(0, tx0 - prefetchRing);
+      final ry0 = math.max(0, ty0 - prefetchRing);
+      final rx1 = math.min(nx - 1, tx1 + prefetchRing);
+      final ry1 = math.min(ny - 1, ty1 + prefetchRing);
+      for (var ty = ry0; ty <= ry1; ty++) {
+        for (var tx = rx0; tx <= rx1; tx++) {
+          if (tx >= tx0 && tx <= tx1 && ty >= ty0 && ty <= ty1) continue;
+          _schedule(PdfTileKey(id, rung, tx, ty), id, pageSize, span, ratio,
+              rasterize);
+        }
+      }
+    }
+
+    return PdfTileView(rung: rung, placements: placements, complete: complete);
+  }
+
+  /// The coarsest-searched cached tile covering the missing fine tile's center,
+  /// as an upscaled placement clipped to the overlap. Nearest coarser bucket
+  /// first (sharpest available); null when nothing coarser is cached.
+  PdfTilePlacement? _coarserFallback(
+    PdfTilePageIdentity id,
+    int rung,
+    int tx,
+    int ty,
+    double span,
+    Size pageSize,
+  ) {
+    final fine = _clampToPage(Rect.fromLTWH(tx * span, ty * span, span, span),
+        pageSize);
+    if (fine.isEmpty) return null;
+    final center = fine.center;
+    for (var d = 1; d <= maxFallbackDepth; d++) {
+      final cr = rung - d;
+      if (cr < ladder.minRung) break;
+      final cratio = ladder.ratioFor(cr);
+      final cspan = tilePixels / cratio;
+      final ctx = (center.dx / cspan).floor();
+      final cty = (center.dy / cspan).floor();
+      final key = PdfTileKey(id, cr, ctx, cty);
+      final tile = _cache.take(key); // promote the fallback too
+      if (tile == null) continue;
+      final overlap = fine.intersect(tile.region);
+      if (overlap.isEmpty) continue;
+      final src = Rect.fromLTRB(
+        (overlap.left - tile.region.left) * cratio,
+        (overlap.top - tile.region.top) * cratio,
+        (overlap.right - tile.region.left) * cratio,
+        (overlap.bottom - tile.region.top) * cratio,
+      );
+      return PdfTilePlacement(
+        image: tile.image,
+        src: Rect.fromLTRB(
+          src.left.clamp(0, tile.image.width.toDouble()),
+          src.top.clamp(0, tile.image.height.toDouble()),
+          src.right.clamp(0, tile.image.width.toDouble()),
+          src.bottom.clamp(0, tile.image.height.toDouble()),
+        ),
+        destFraction: _fractionOf(overlap, pageSize),
+      );
+    }
+    return null;
+  }
+
+  void _schedule(
+    PdfTileKey key,
+    PdfTilePageIdentity id,
+    Size pageSize,
+    double span,
+    double ratio,
+    PdfTileRasterizer rasterize,
+  ) {
+    if (_disposed || _cache.containsKey(key) || _inFlight.contains(key)) return;
+    final region = _clampToPage(
+        Rect.fromLTWH(key.tx * span, key.ty * span, span, span), pageSize);
+    if (region.width <= 0 || region.height <= 0) return;
+
+    _inFlight.add(key);
+    debugTilesScheduled++;
+    final dispatchEpoch = _globalEpoch;
+    rasterize(region, ratio).then((image) {
+      _inFlight.remove(key);
+      if (_disposed || _isStale(id.pageIndex, dispatchEpoch)) {
+        image.dispose();
+        debugTilesDiscarded++;
+        return;
+      }
+      _cache.put(key, PdfTile(image, region, key.rung));
+      debugTilesLanded++;
+      _scheduleTick();
+    }, onError: (Object _, StackTrace __) {
+      _inFlight.remove(key);
+      debugTilesDiscarded++;
+    });
+  }
+
+  bool _isStale(int pageIndex, int dispatchEpoch) =>
+      _globalEpoch > dispatchEpoch ||
+      (_pageEpoch[pageIndex] ?? -1) > dispatchEpoch;
+
+  /// Drops retained (and in-flight) tiles. With [pages] null every tile is
+  /// dropped; otherwise only tiles for those page slots - the model
+  /// [PdfCachingRenderWorker.updateRevision]'s `changedPages` feeds. In-flight
+  /// rasters for the affected pages are discarded on completion.
+  void invalidate({Set<int>? pages}) {
+    if (_disposed) return;
+    _globalEpoch++;
+    if (pages == null) {
+      _cache.clear();
+    } else {
+      for (final page in pages) {
+        _pageEpoch[page] = _globalEpoch;
+      }
+      _cache.evictWhere((key) => pages.contains(key.id.pageIndex));
+    }
+  }
+
+  void _scheduleTick() {
+    if (_tickScheduled || _disposed) return;
+    _tickScheduled = true;
+    scheduleMicrotask(() {
+      _tickScheduled = false;
+      if (_disposed) return;
+      debugTicks++;
+      notifyListeners();
+    });
+  }
+
+  Rect _clampToPage(Rect r, Size pageSize) =>
+      r.intersect(Offset.zero & pageSize);
+
+  Rect _fractionOf(Rect region, Size pageSize) => Rect.fromLTRB(
+        region.left / pageSize.width,
+        region.top / pageSize.height,
+        region.right / pageSize.width,
+        region.bottom / pageSize.height,
+      );
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _cache.dispose();
+    _inFlight.clear();
+    super.dispose();
+  }
+}

--- a/packages/dart_pdf_editor/test/benchmark_tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_tile_store_test.dart
@@ -1,0 +1,373 @@
+// Before/after benchmark for the PdfTileStore deep-zoom path (issue #314):
+// the shipping single detail patch re-rasterizes the whole visible region on
+// every settle, while the tile pyramid rasterizes only the missing tiles and
+// reuses the rest. This harness drives the two raster strategies through the
+// same pinch-in and deep-zoom pan sequences over a page's retained scene and
+// reports the raster work each pays (calls, megapixels, wall time) plus the
+// tile reuse ratio and retained bytes.
+//
+// Both strategies share one up-front PdfRetainedScene.record (interpret +
+// decode) - the cost the zoom must never re-pay - so the numbers isolate the
+// re-raster the issue targets, not the one-time record.
+//
+// Skips unless PDF_BENCHMARK_DIR is set:
+//
+//   cd packages/dart_pdf_editor
+//   PDF_BENCHMARK_DIR=../../test_corpora/pdfjs \
+//   PDF_BENCHMARK_TILE_RATIO=8 PDF_BENCHMARK_PAN_STEPS=10 \
+//   PDF_BENCHMARK_MAX_FILES=8 \
+//   PDF_BENCHMARK_OUT=../../benchmark/out/tile-store.json \
+//     fvm flutter test test/benchmark_tile_store_test.dart
+//
+// Env knobs: PDF_BENCHMARK_VIEWPORT ("1280x1600"), PDF_BENCHMARK_TILE_RATIO
+// (deep-zoom pixel ratio, 8), PDF_BENCHMARK_PAN_STEPS (10), PDF_BENCHMARK_TILE_PX
+// (512), PDF_BENCHMARK_MAX_FILES (8), PDF_BENCHMARK_REPEAT (best-of-N, 1),
+// PDF_BENCHMARK_OUT (JSON path; prints when unset).
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'render_smoke_test.dart' show loadSystemFonts;
+
+/// Accumulates the region rasters a strategy issues over a settle sequence.
+class _RasterMeter {
+  int calls = 0;
+  int pixels = 0;
+  int micros = 0;
+
+  /// Instruments one region raster from the retained scene.
+  Future<ui.Image> raster(PdfRetainedScene scene, Rect region, double ratio) async {
+    final sw = Stopwatch()..start();
+    final image = await scene.rasterizeRegion(region, pixelRatio: ratio);
+    micros += sw.elapsedMicroseconds;
+    calls++;
+    pixels += image.width * image.height;
+    return image;
+  }
+
+  Map<String, Object?> summary(int settles) => {
+        'settles': settles,
+        'rasterCalls': calls,
+        'rasterMegapixels': double.parse((pixels / 1e6).toStringAsFixed(2)),
+        'rasterMs': double.parse((micros / 1000).toStringAsFixed(2)),
+      };
+}
+
+Size _parseViewport(String? raw) {
+  final parts = (raw ?? '1280x1600').split('x');
+  final w = double.tryParse(parts.first) ?? 1280.0;
+  final h = parts.length > 1 ? double.tryParse(parts[1]) ?? 1600.0 : 1600.0;
+  return Size(w, h);
+}
+
+/// The visible page-point rect for a [viewport] (device px) at [ratio], its
+/// top-left at ([ox],[oy]) page points, clamped to the page.
+Rect _visibleRegion(
+    Size pageSize, Size viewport, double ratio, double ox, double oy) {
+  final w = math.min(viewport.width / ratio, pageSize.width);
+  final h = math.min(viewport.height / ratio, pageSize.height);
+  final left = ox.clamp(0.0, math.max(0.0, pageSize.width - w)).toDouble();
+  final top = oy.clamp(0.0, math.max(0.0, pageSize.height - h)).toDouble();
+  return Rect.fromLTWH(left, top, w, h);
+}
+
+void main() {
+  final dir = Platform.environment['PDF_BENCHMARK_DIR'];
+  final viewport = _parseViewport(Platform.environment['PDF_BENCHMARK_VIEWPORT']);
+  final tileRatio =
+      double.tryParse(Platform.environment['PDF_BENCHMARK_TILE_RATIO'] ?? '') ??
+          8.0;
+  final panSteps =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_PAN_STEPS'] ?? '') ?? 10;
+  final panFraction =
+      double.tryParse(Platform.environment['PDF_BENCHMARK_PAN_FRACTION'] ?? '') ??
+          0.35;
+  final tilePx =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_TILE_PX'] ?? '') ?? 512;
+  final maxFiles =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_MAX_FILES'] ?? '') ?? 8;
+  final repeat =
+      int.tryParse(Platform.environment['PDF_BENCHMARK_REPEAT'] ?? '') ?? 1;
+  final outPath = Platform.environment['PDF_BENCHMARK_OUT'];
+
+  testWidgets('benchmarks tile-store vs single-patch deep-zoom detail',
+      (tester) async {
+    if (dir == null) {
+      markTestSkipped('set PDF_BENCHMARK_DIR to run the tile-store benchmark');
+      return;
+    }
+    await tester.runAsync(() async {
+      await loadSystemFonts();
+      final corpus = Directory(dir);
+      final root = corpus.path.endsWith('/') ? corpus.path : '${corpus.path}/';
+      final files = corpus
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((f) => f.path.toLowerCase().endsWith('.pdf'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+      final selected =
+          maxFiles <= 0 ? files : files.take(maxFiles).toList();
+
+      final results = <Map<String, Object?>>[];
+      for (final file in selected) {
+        final name = file.path.startsWith(root)
+            ? file.path.substring(root.length)
+            : file.uri.pathSegments.last;
+        Map<String, Object?>? best;
+        for (var r = 0; r < repeat; r++) {
+          final res = await _benchFile(file, name, viewport, tileRatio,
+              panSteps, panFraction, tilePx, tester);
+          if (res['error'] != null) {
+            best ??= res;
+            continue;
+          }
+          // Best-of-N: keep the run whose tile pan raster was fastest.
+          if (best == null ||
+              best['error'] != null ||
+              ((res['tilePan'] as Map)['rasterMs'] as double) <
+                  ((best['tilePan'] as Map)['rasterMs'] as double)) {
+            best = res;
+          }
+        }
+        results.add(best ?? {'file': name, 'error': 'not run'});
+      }
+
+      // Aggregate the raster work each strategy paid across every page.
+      var patchPanMp = 0.0, tilePanMp = 0.0, patchPanMs = 0.0, tilePanMs = 0.0;
+      var patchPinchMp = 0.0, tilePinchMp = 0.0;
+      var patchRevMp = 0.0, tileRevMp = 0.0, patchRevMs = 0.0, tileRevMs = 0.0;
+      for (final res in results) {
+        if (res['error'] != null) continue;
+        patchPanMp += (res['patchPan'] as Map)['rasterMegapixels'] as double;
+        tilePanMp += (res['tilePan'] as Map)['rasterMegapixels'] as double;
+        patchPanMs += (res['patchPan'] as Map)['rasterMs'] as double;
+        tilePanMs += (res['tilePan'] as Map)['rasterMs'] as double;
+        patchPinchMp += (res['patchPinch'] as Map)['rasterMegapixels'] as double;
+        tilePinchMp += (res['tilePinch'] as Map)['rasterMegapixels'] as double;
+        patchRevMp += (res['patchRevisit'] as Map)['rasterMegapixels'] as double;
+        tileRevMp += (res['tileRevisit'] as Map)['rasterMegapixels'] as double;
+        patchRevMs += (res['patchRevisit'] as Map)['rasterMs'] as double;
+        tileRevMs += (res['tileRevisit'] as Map)['rasterMs'] as double;
+      }
+      double ratio(double a, double b) =>
+          b == 0 ? 0 : double.parse((a / b).toStringAsFixed(2));
+      final aggregate = {
+        'pagesBenched': results.where((r) => r['error'] == null).length,
+        'pan': {
+          'patchMegapixels': double.parse(patchPanMp.toStringAsFixed(1)),
+          'tileMegapixels': double.parse(tilePanMp.toStringAsFixed(1)),
+          'patchMs': double.parse(patchPanMs.toStringAsFixed(1)),
+          'tileMs': double.parse(tilePanMs.toStringAsFixed(1)),
+          'megapixelSpeedup': ratio(patchPanMp, tilePanMp),
+          'msSpeedup': ratio(patchPanMs, tilePanMs),
+        },
+        'revisit': {
+          'patchMegapixels': double.parse(patchRevMp.toStringAsFixed(1)),
+          'tileMegapixels': double.parse(tileRevMp.toStringAsFixed(1)),
+          'patchMs': double.parse(patchRevMs.toStringAsFixed(1)),
+          'tileMs': double.parse(tileRevMs.toStringAsFixed(1)),
+          // How much of the legacy re-raster the tile cache avoided on revisit.
+          'tileReusePct': patchRevMp == 0
+              ? null
+              : double.parse(
+                  (100 * (1 - tileRevMp / patchRevMp)).toStringAsFixed(1)),
+        },
+        'pinch': {
+          'patchMegapixels': double.parse(patchPinchMp.toStringAsFixed(1)),
+          'tileMegapixels': double.parse(tilePinchMp.toStringAsFixed(1)),
+          'megapixelSpeedup': ratio(patchPinchMp, tilePinchMp),
+        },
+      };
+      // ignore: avoid_print
+      print('  tile-store aggregate: ${const JsonEncoder().convert(aggregate)}');
+
+      final payload = {
+        'tool': 'dart-pdf-tile-store',
+        'viewport': '${viewport.width.toInt()}x${viewport.height.toInt()}',
+        'tileRatio': tileRatio,
+        'panSteps': panSteps,
+        'tilePx': tilePx,
+        'aggregate': aggregate,
+        'results': results,
+      };
+      final text = const JsonEncoder.withIndent('  ').convert(payload);
+      if (outPath != null) {
+        File(outPath)
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(text);
+        // ignore: avoid_print
+        print('wrote $outPath');
+      } else {
+        // ignore: avoid_print
+        print(text);
+      }
+    });
+  }, timeout: const Timeout(Duration(minutes: 60)));
+}
+
+Future<Map<String, Object?>> _benchFile(
+  File file,
+  String name,
+  Size viewport,
+  double tileRatio,
+  int panSteps,
+  double panFraction,
+  int tilePx,
+  WidgetTester tester,
+) async {
+  PdfRetainedScene scene;
+  try {
+    final doc = PdfDocument.open(file.readAsBytesSync());
+    scene = await PdfRetainedScene.record(doc.page(0));
+  } catch (e) {
+    return {'file': name, 'error': e.toString()};
+  }
+  try {
+    final pageSize = scene.pageSize;
+    if (pageSize.width <= 0 || pageSize.height <= 0) {
+      return {'file': name, 'error': 'empty page'};
+    }
+    final identity = PdfTilePageIdentity(
+      pageIndex: 0,
+      pageEpoch: 0,
+      contentStamp: 0,
+      destructiveStamp: 0,
+      plan: scene.plan,
+    );
+
+    // --- Pinch-in: settle at each zoom bucket, center-anchored. ---
+    final pinchRatios = <double>[1.0, 1.5, 2.0, 3.0, 4.0, tileRatio]
+        .where((r) => r <= tileRatio)
+        .toList();
+    final patchPinch = _RasterMeter();
+    for (final ratio in pinchRatios) {
+      final region = _visibleRegion(
+        pageSize,
+        viewport,
+        ratio,
+        (pageSize.width - viewport.width / ratio) / 2,
+        (pageSize.height - viewport.height / ratio) / 2,
+      );
+      (await patchPinch.raster(scene, region, ratio)).dispose();
+    }
+
+    final tilePinch = _RasterMeter();
+    final pinchStore = PdfTileStore(
+      tilePixels: tilePx,
+      registerForMemoryPressure: false,
+    );
+    for (final ratio in pinchRatios) {
+      final region = _visibleRegion(
+        pageSize,
+        viewport,
+        ratio,
+        (pageSize.width - viewport.width / ratio) / 2,
+        (pageSize.height - viewport.height / ratio) / 2,
+      );
+      pinchStore.viewFor(
+        id: identity,
+        pageSize: pageSize,
+        desiredRatio: ratio,
+        visiblePageRect: region,
+        rasterize: (r, pr) => tilePinch.raster(scene, r, pr),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 1));
+      await Future<void>.delayed(Duration.zero);
+    }
+    final pinchRetained = pinchStore.retainedBytes;
+    final pinchTiles = pinchStore.tileCount;
+    pinchStore.dispose();
+
+    // --- Pan: fixed deep zoom, incremental drag (overlapping viewports, the
+    // case tile reuse targets - each step reveals a leading strip and keeps
+    // the rest). stepDx = a fraction of the visible width. ---
+    final visW = math.min(viewport.width / tileRatio, pageSize.width);
+    final stepDx = visW * panFraction;
+
+    final patchPan = _RasterMeter();
+    for (var i = 0; i < panSteps; i++) {
+      final region =
+          _visibleRegion(pageSize, viewport, tileRatio, i * stepDx, 0);
+      (await patchPan.raster(scene, region, tileRatio)).dispose();
+    }
+
+    final tilePan = _RasterMeter();
+    final panStore = PdfTileStore(
+      tilePixels: tilePx,
+      registerForMemoryPressure: false,
+    );
+    Future<void> tileSettleAt(double ox, _RasterMeter meter) async {
+      final region = _visibleRegion(pageSize, viewport, tileRatio, ox, 0);
+      panStore.viewFor(
+        id: identity,
+        pageSize: pageSize,
+        desiredRatio: tileRatio,
+        visiblePageRect: region,
+        rasterize: (r, pr) => meter.raster(scene, r, pr),
+      );
+      await tester.pumpAndSettle(const Duration(milliseconds: 1));
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    for (var i = 0; i < panSteps; i++) {
+      await tileSettleAt(i * stepDx, tilePan);
+    }
+    final panRetained = panStore.retainedBytes;
+    final panTiles = panStore.tileCount;
+
+    // Revisit: drag back over the just-tiled area. Legacy re-rasters the full
+    // region every step; the tile store reuses cached tiles (the "pan = zero
+    // re-raster" claim), so its revisit raster work should be near zero.
+    final patchRevisit = _RasterMeter();
+    for (var i = panSteps - 2; i >= 0; i--) {
+      final region =
+          _visibleRegion(pageSize, viewport, tileRatio, i * stepDx, 0);
+      (await patchRevisit.raster(scene, region, tileRatio)).dispose();
+    }
+    final tileRevisit = _RasterMeter();
+    for (var i = panSteps - 2; i >= 0; i--) {
+      await tileSettleAt(i * stepDx, tileRevisit);
+    }
+    panStore.dispose();
+
+    double speedup(double a, double b) =>
+        b == 0 ? 0 : double.parse((a / b).toStringAsFixed(2));
+
+    return {
+      'file': name,
+      'error': null,
+      'pageSize': '${pageSize.width.toInt()}x${pageSize.height.toInt()}',
+      'commands': scene.commands.length,
+      'regionCullable': scene.supportsRegionRaster,
+      'patchPinch': patchPinch.summary(pinchRatios.length),
+      'tilePinch': {
+        ...tilePinch.summary(pinchRatios.length),
+        'retainedKB': pinchRetained ~/ 1024,
+        'tiles': pinchTiles,
+      },
+      'patchPan': patchPan.summary(panSteps),
+      'tilePan': {
+        ...tilePan.summary(panSteps),
+        'retainedKB': panRetained ~/ 1024,
+        'tiles': panTiles,
+      },
+      'patchRevisit': patchRevisit.summary(panSteps - 1),
+      'tileRevisit': tileRevisit.summary(panSteps - 1),
+      'tileRevisitSpeedup':
+          speedup(patchRevisit.pixels.toDouble(), tileRevisit.pixels.toDouble()),
+      'tilePanSpeedup':
+          speedup(patchPan.pixels.toDouble(), tilePan.pixels.toDouble()),
+      'tilePinchSpeedup':
+          speedup(patchPinch.pixels.toDouble(), tilePinch.pixels.toDouble()),
+    };
+  } finally {
+    scene.dispose();
+  }
+}

--- a/packages/dart_pdf_editor/test/tile_layer_test.dart
+++ b/packages/dart_pdf_editor/test/tile_layer_test.dart
@@ -1,0 +1,130 @@
+// PdfTileLayer: the presentation seam must drive the store from paint (schedule
+// missing tiles), then repaint and composite them once they land.
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<ui.Image> _solidImage(int w, int h) {
+  final recorder = ui.PictureRecorder();
+  Canvas(recorder).drawRect(Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+      Paint()..color = const Color(0xFF2277EE));
+  final picture = recorder.endRecording();
+  final image = picture.toImage(w, h);
+  picture.dispose();
+  return image;
+}
+
+class _Rasterizer {
+  _Rasterizer({this.tileSize = 32});
+  final int tileSize;
+  var calls = 0;
+  final _pending = <Completer<ui.Image>>[];
+
+  Future<ui.Image> call(Rect region, double ratio) {
+    calls++;
+    final completer = Completer<ui.Image>();
+    _pending.add(completer);
+    return completer.future;
+  }
+
+  Future<void> flush() async {
+    final pending = _pending.where((c) => !c.isCompleted).toList();
+    final images = <ui.Image>[
+      for (var i = 0; i < pending.length; i++)
+        await _solidImage(tileSize, tileSize),
+    ];
+    for (var i = 0; i < pending.length; i++) {
+      pending[i].complete(images[i]);
+    }
+    await pumpEventQueue();
+  }
+}
+
+PdfTilePageIdentity _id(int page) => PdfTilePageIdentity(
+      pageIndex: page,
+      pageEpoch: 0,
+      contentStamp: 0,
+      destructiveStamp: 0,
+      plan: const PdfPageRenderPlan(),
+    );
+
+void main() {
+  testWidgets('schedules on first paint, then composites tiles as they land',
+      (tester) async {
+    await tester.runAsync(() async {
+      final store = PdfTileStore(
+        tilePixels: 32,
+        prefetchRing: 0,
+        registerForMemoryPressure: false,
+      );
+      final raster = _Rasterizer(tileSize: 32);
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 128,
+              height: 128,
+              child: PdfTileLayer(
+                store: store,
+                identity: _id(0),
+                pageSize: const Size(128, 128),
+                desiredRatio: 2.0,
+                visibleFraction: const Rect.fromLTRB(0, 0, 1, 1),
+                rasterize: raster.call,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // The first paint asked the store for a view, which scheduled the
+      // missing tiles.
+      expect(raster.calls, greaterThan(0));
+      expect(store.inFlightCount, greaterThan(0));
+      final ticksBefore = store.debugTicks;
+
+      await raster.flush();
+      await tester.pump(); // the store's tick repaints the layer
+
+      expect(store.tileCount, greaterThan(0));
+      expect(store.debugTilesLanded, greaterThan(0));
+      expect(store.debugTicks, greaterThan(ticksBefore));
+
+      store.dispose();
+    });
+  });
+
+  testWidgets('an empty store paints nothing and does not throw',
+      (tester) async {
+    await tester.runAsync(() async {
+      final store = PdfTileStore(registerForMemoryPressure: false);
+      // A rasterizer that never completes: the view stays empty (base-only).
+      Future<ui.Image> never(Rect region, double ratio) =>
+          Completer<ui.Image>().future;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(
+            width: 64,
+            height: 64,
+            child: PdfTileLayer(
+              store: store,
+              identity: _id(0),
+              pageSize: const Size(64, 64),
+              desiredRatio: 1.0,
+              visibleFraction: const Rect.fromLTRB(0, 0, 1, 1),
+              rasterize: never,
+            ),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      store.dispose();
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -1,0 +1,64 @@
+// With PdfPageView.tileStoreDetail on, a deep-zoom page must composite tiles
+// from the store instead of the single detail patch, while the base raster
+// keeps showing through. Kept in its own file so the global flag mutation can't
+// leak into other page-view tests.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main() {
+  testWidgets('tile path composites deep-zoom tiles instead of the patch',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    // Laid out 10x wider than its point size: only a slice fits, so the tile
+    // layer covers the visible fraction and the base raster shows underneath.
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(width: 6120, child: PdfPageView(page: doc.page(0))),
+        ),
+      ),
+    );
+    // Let the base render, the tile-geometry refresh, and the tile rasters land.
+    for (var i = 0; i < 4; i++) {
+      await tester
+          .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 60)));
+      await tester.pump();
+    }
+
+    // The tile layer replaced the single detail patch.
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsNothing);
+    // The base raster is still the only RawImage (tiles paint via CustomPaint).
+    expect(find.byType(RawImage), findsOneWidget);
+    // Real tiles rastered from the page's retained scene.
+    expect(store.tileCount, greaterThan(0));
+  });
+
+  testWidgets('a soft-mask-free scene reports region-cullable', (tester) async {
+    // Guards the fallback-adapter gate: classic pages are cullable, so they
+    // take the tile path; a soft-mask page would keep the legacy patch.
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(buildClassicPdf());
+      final scene = await PdfRetainedScene.record(doc.page(0));
+      expect(scene.supportsRegionRaster, isTrue);
+      scene.dispose();
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -1,0 +1,431 @@
+// PdfTileStore: the zoom-bucket tile pyramid must snap ratios to a stable
+// ladder, cover a viewport center-out, fall back per-tile to the nearest
+// coarser cached bucket, invalidate per page (discarding stale in-flight
+// rasters), and stay under its byte budget - all the behaviour the deep-zoom
+// composite depends on.
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<ui.Image> _solidImage(int w, int h,
+    [Color color = const Color(0xFF102030)]) {
+  final recorder = ui.PictureRecorder();
+  final canvas = Canvas(recorder);
+  canvas.drawRect(Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+      Paint()..color = color);
+  final picture = recorder.endRecording();
+  final image = picture.toImage(w, h);
+  picture.dispose();
+  return image;
+}
+
+/// A rasterizer that holds every request pending until [flush], so a test can
+/// inspect the in-flight state before the tiles land.
+class _Rasterizer {
+  _Rasterizer({this.tileSize = 16});
+
+  final int tileSize;
+  final calls = <({Rect region, double ratio})>[];
+  final _pending = <Completer<ui.Image>>[];
+
+  Future<ui.Image> call(Rect region, double ratio) {
+    calls.add((region: region, ratio: ratio));
+    final completer = Completer<ui.Image>();
+    _pending.add(completer);
+    return completer.future;
+  }
+
+  int get pendingCount => _pending.where((c) => !c.isCompleted).length;
+
+  /// Completes every outstanding raster with a solid tile-sized image, then
+  /// drains the store's completion + tick microtasks.
+  Future<void> flush() async {
+    final pending = _pending.where((c) => !c.isCompleted).toList();
+    // Build every image first, then complete them all in one synchronous burst
+    // so the store's completions land in a single microtask drain (the case
+    // its tick-coalescing targets).
+    final images = <ui.Image>[
+      for (var i = 0; i < pending.length; i++)
+        await _solidImage(tileSize, tileSize),
+    ];
+    for (var i = 0; i < pending.length; i++) {
+      pending[i].complete(images[i]);
+    }
+    await pumpEventQueue();
+  }
+}
+
+const _plan = PdfPageRenderPlan();
+
+PdfTilePageIdentity _id(int page, {int epoch = 0, int content = 0}) =>
+    PdfTilePageIdentity(
+      pageIndex: page,
+      pageEpoch: epoch,
+      contentStamp: content,
+      destructiveStamp: 0,
+      plan: _plan,
+    );
+
+void main() {
+  group('PdfTileZoomLadder', () {
+    test('rung 0 is ratio 1 and the ×√2 ladder round-trips', () {
+      const ladder = PdfTileZoomLadder(); // stepsPerOctave: 2
+      expect(ladder.ratioFor(0), 1.0);
+      expect(ladder.ratioFor(2), closeTo(2.0, 1e-9));
+      expect(ladder.ratioFor(-2), closeTo(0.5, 1e-9));
+      expect(ladder.ratioFor(1), closeTo(1.4142135, 1e-6));
+      for (final rung in [-4, -1, 0, 3, 7]) {
+        expect(ladder.rungFor(ladder.ratioFor(rung)), rung);
+      }
+    });
+
+    test('snaps a desired ratio to the nearest rung and clamps', () {
+      const ladder = PdfTileZoomLadder(stepsPerOctave: 1, minRung: -2, maxRung: 4);
+      expect(ladder.rungFor(1.1), 0); // nearest rung 0 (ratio 1)
+      expect(ladder.rungFor(1.9), 1); // nearest rung 1 (ratio 2)
+      expect(ladder.rungFor(1000), 4); // clamped to maxRung
+      expect(ladder.rungFor(0.001), -2); // clamped to minRung
+      expect(ladder.rungFor(0), -2); // degenerate ratio → safe 0.05, clamped
+    });
+  });
+
+  group('PdfTileStore.viewFor', () {
+    testWidgets('schedules the visible tiles center-out at the bucket ratio',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        const pageSize = Size(64, 64); // 4×4 grid at rung 0 (span 16)
+
+        final view = store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+        );
+
+        expect(view.rung, 0);
+        expect(view.complete, isFalse); // nothing cached yet
+        expect(view.isEmpty, isTrue); // no fallback available
+        expect(store.inFlightCount, 16);
+        expect(raster.calls.length, 16);
+        expect(raster.calls.every((c) => c.ratio == 1.0), isTrue);
+
+        // The first scheduled tile is one of the four central tiles (col/row
+        // 1 or 2), not a corner.
+        final first = raster.calls.first.region;
+        expect(first.left, anyOf(16.0, 32.0));
+        expect(first.top, anyOf(16.0, 32.0));
+
+        await raster.flush();
+        expect(store.tileCount, 16);
+        expect(store.debugTilesLanded, 16);
+
+        // A second identical request now composites exact tiles - no reschedule.
+        final calls = raster.calls.length;
+        final view2 = store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+        );
+        expect(view2.complete, isTrue);
+        expect(view2.placements.length, 16);
+        expect(raster.calls.length, calls); // fully cached, nothing scheduled
+        store.dispose();
+      });
+    });
+
+    testWidgets('prefetch ring schedules the border outside the viewport',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 1,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        // Visible = the single centre tile (2,2) of a 5×5 grid; ring adds the
+        // 8 surrounding tiles.
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(80, 80),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(32, 32, 16, 16),
+          rasterize: raster.call,
+        );
+        expect(store.inFlightCount, 9); // 1 visible + 8 ring
+        store.dispose();
+      });
+    });
+
+    testWidgets('falls back to the nearest coarser cached bucket, upscaled',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 32,
+          prefetchRing: 0,
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(tileSize: 32);
+        const pageSize = Size(256, 256);
+        const visible = Rect.fromLTWH(0, 0, 128, 128);
+
+        // Warm a coarse bucket (ratio 1, rung 0).
+        store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: visible,
+          rasterize: raster.call,
+        );
+        await raster.flush();
+        final coarseTiles = store.tileCount;
+        expect(coarseTiles, greaterThan(0));
+
+        // Request a sharper bucket over the same area: exact tiles are missing,
+        // but the coarse bucket covers it, so the view is non-empty yet not
+        // complete (upscaled fallback in play).
+        final view = store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 4.0, // rung 4 on the ×√2 ladder
+          visiblePageRect: visible,
+          rasterize: raster.call,
+        );
+        expect(view.rung, greaterThan(0));
+        expect(view.complete, isFalse);
+        expect(view.placements, isNotEmpty,
+            reason: 'coarser bucket should supply a fallback');
+        // Every fallback placement draws from a coarse-bucket image (32² here).
+        expect(view.placements.every((p) => p.image.width == 32), isTrue);
+        store.dispose();
+      });
+    });
+
+    testWidgets('no fallback and no cache yields an empty (base-only) view',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 32,
+          prefetchRing: 0,
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(tileSize: 32);
+        final view = store.viewFor(
+          id: _id(0),
+          pageSize: const Size(128, 128),
+          desiredRatio: 4.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 128, 128),
+          rasterize: raster.call,
+        );
+        expect(view.isEmpty, isTrue);
+        expect(view.complete, isFalse);
+        store.dispose();
+      });
+    });
+  });
+
+  group('PdfTileStore.invalidate', () {
+    testWidgets('drops only the named pages; others survive', (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        for (final page in [0, 1]) {
+          store.viewFor(
+            id: _id(page),
+            pageSize: const Size(32, 32),
+            desiredRatio: 1.0,
+            visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+            rasterize: raster.call,
+          );
+        }
+        await raster.flush();
+        final before = store.tileCount;
+        expect(before, 8); // 4 tiles each
+
+        store.invalidate(pages: {0});
+        expect(store.tileCount, 4);
+        expect(store.containsTile(PdfTileKey(_id(0), 0, 0, 0)), isFalse);
+        expect(store.containsTile(PdfTileKey(_id(1), 0, 0, 0)), isTrue);
+        store.dispose();
+      });
+    });
+
+    testWidgets('discards in-flight rasters for an invalidated page',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        expect(store.inFlightCount, 4);
+
+        // Invalidate before the rasters land: their results must be dropped.
+        store.invalidate(pages: {0});
+        await raster.flush();
+        expect(store.tileCount, 0);
+        expect(store.debugTilesDiscarded, 4);
+        expect(store.debugTilesLanded, 0);
+        store.dispose();
+      });
+    });
+
+    testWidgets('null clears every page', (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        await raster.flush();
+        expect(store.tileCount, greaterThan(0));
+        store.invalidate();
+        expect(store.tileCount, 0);
+        store.dispose();
+      });
+    });
+  });
+
+  group('PdfTileStore budget & lifecycle', () {
+    testWidgets('stays under the byte budget as tiles land', (tester) async {
+      await tester.runAsync(() async {
+        // 8 MB budget (the floor), 4 MB tiles → at most 2 retained.
+        final store = PdfTileStore(
+          tilePixels: 1024,
+          prefetchRing: 0,
+          maxBytes: 8 << 20,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(tileSize: 1024); // 1024² × 4 = 4 MB
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(64, 64), // 4×4 tiles at span 16
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+        );
+        await raster.flush();
+        expect(store.retainedBytes, lessThanOrEqualTo(8 << 20));
+        expect(store.tileCount, lessThanOrEqualTo(2));
+        expect(store.tileCount, greaterThan(0)); // the MRU tile survives
+        store.dispose();
+      });
+    });
+
+    testWidgets('ticks once (coalesced) as a batch of tiles lands',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        var ticks = 0;
+        store.addListener(() => ticks++);
+        final raster = _Rasterizer();
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        await raster.flush(); // 4 tiles land in one microtask batch
+        expect(store.debugTilesLanded, 4);
+        expect(ticks, 1, reason: 'notifications coalesce to one tick');
+        store.dispose();
+      });
+    });
+
+    testWidgets('memory pressure clears every tile', (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+        );
+        final raster = _Rasterizer();
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        await raster.flush();
+        expect(store.tileCount, greaterThan(0));
+        PdfCacheRegistry.instance.handleMemoryPressure();
+        expect(store.tileCount, 0);
+        store.dispose();
+      });
+    });
+
+    testWidgets('after dispose viewFor is inert and late tiles are dropped',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        store.dispose();
+        final view = store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        expect(view.isEmpty, isTrue);
+        await raster.flush(); // completions after dispose just free the images
+        expect(store.tileCount, 0);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the `PdfTileStore` proposed in #314: a GPU-resident, budgeted
zoom-bucket tile pyramid so panning at deep zoom composites cached tiles with
**zero re-raster**, and a settle only rasterizes the missing visible tiles —
instead of reading the whole page back off the GPU on every settle and holding
a single unbudgeted detail patch that dies on every settle/scene change/edit.

New module (`tile_store.dart` — `PdfTileStore`, a `ChangeNotifier`):

- **`viewFor({id, pageSize, desiredRatio, visiblePageRect, rasterize})`** —
  synchronous. Snaps `desiredRatio` to a ×√2 bucket, walks the visible tile
  range **center-out**, composites exact-bucket tiles where cached, and falls
  back **per-tile to the nearest coarser cached bucket, upscaled**; schedules
  the missing tiles plus a one-tile **prefetch ring**. Placed tiles are touched
  to most-recently-used so eviction only ever drops off-view tiles.
- **`invalidate({Set<int>? pages})`** — evicts per page via `evictWhere` and
  discards stale in-flight rasters (the `changedPages` model from #308).
- **Listenable** — coalesced tick as sharper tiles land; the page view repaints
  via `canvas.drawImageRect`.

Storage is one shared `PdfBudgetedCache` (#307) weighed by tile bytes
(default 96 MB), LRU + memory-pressure aware. The tile key is built entirely
from identities already on `PdfPageRenderIntent`/`PdfPageRenderPlan`, so a
content edit, rotation, or paper-color change is a distinct key and stale pixels
never surface. Tiles rasterize through the existing
`PdfRetainedScene.rasterizeRegion`; a new `supportsRegionRaster` leaves
soft-mask/group pages (which the region index can't cull) on the legacy path —
the fallback adapter the issue calls for.

Presentation (`tile_layer.dart` — `PdfTileLayer`) is a `CustomPaint` that
composites the store's tiles and repaints on each tick. It is wired into
`_PdfPageViewState` behind **`PdfPageView.tileStoreDetail` (default false)**,
sitting **above** the untouched base raster: with the flag off the default path
is byte-identical, and with it on any not-yet-tiled gap shows the base image
through — additive, no regression surface.

Deliberately **not** in this PR: the issue's "what it deletes" list
(`_detailImage`/`_detailGeometryAt`, the `_rasteredRatio` gate, the
`_maxPixels`/`_maxDimension` caps, the preview cache's full-raster tier). Those
are interwoven with the Slug web layer, the strip router, and speculative worker
binning; deleting them and making tiles default are deferred follow-ups pending
the #306 render-trace measurements this is sequenced after. See
`doc/dev-log/2026-07-17-gpu-tile-store.md`.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Performance change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean across the repo)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (1621 pass / 35 pre-existing skips)

New tests: `tile_store_test.dart` (ladder snapping, `viewFor`
coverage/center-out/prefetch, coarser-bucket fallback, per-page `invalidate` +
in-flight discard, byte budget, coalesced tick, memory pressure, dispose),
`tile_layer_test.dart` (schedule-on-paint then composite/repaint; empty store is
inert), and `tile_store_page_view_test.dart` (flag-on deep-zoom page composites
real tiles from its retained scene, base raster intact).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The feature is **off by default** (`PdfPageView.tileStoreDetail`); this is the
  measure-and-explore landing the issue sequences, not the default flip.
- **MRU protection is budget-relative**: a completion batch larger than
  `budget − viewport` could theoretically age a view tile past the eviction
  line, but the 96 MB default (8 MB floor) sits far above a deep-zoom viewport
  (≈12 MB) plus a batch, so eviction only targets off-view/prefetch tiles.
- Gotcha captured in the dev-log: the visible fraction is computed post-render
  in `_refreshTileGeometry`, never inside the `LayoutBuilder` builder, because
  reading the render tree during layout asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqYcgXd2NUYv6SP5k4AqGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqYcgXd2NUYv6SP5k4AqGs)_