### PR TITLE
Introduce PdfEditToolBehavior - one source of tool identity (#311)

### DIFF
--- a/doc/dev-log/2026-07-17-tool-behavior-interface.md
+++ b/doc/dev-log/2026-07-17-tool-behavior-interface.md
@@ -1,0 +1,77 @@
+# PdfEditToolBehavior - a single source of tool identity (#311)
+
+`PdfEditTool` is a 30-value enum whose behaviour used to be smeared across
+several `switch (tool)` blocks in separate places, so adding a tool meant
+editing every one:
+
+- the overlay's classification getters (`_inkTool`, `_drawTool`, `_polyTool`,
+  `_lineDragTool`, `_measureKind`, `_fixedPolyCount`) and its per-phase
+  commit switches (`_commitRect`, `_commitLineDrag`, `_finishPolyPath`);
+- the controller's persisted-style tables (`_styleScopeKey`,
+  `_styleScopeFields`, `_styleScopeDefaults`, `_buffersInk`);
+- the toolbar's per-tool tune-popup capability (`_StyleFields` +
+  `_groupStyleFields`).
+
+That was four to five independent copies of "what this tool is."
+
+## What landed
+
+`lib/src/editing/editing_tool_behavior.dart` - `PdfEditToolBehavior`, one
+authoritative descriptor per tool, mirroring `PdfAnnotationBehavior`
+(pdf_document) on the tool side. It owns:
+
+- **classification** the gesture phases dispatch on (`isInk`, `isDraw`,
+  `buffersInk`, `isPoly`, `closesPoly`, `isLineDrag`, `measureKind`,
+  `fixedPolyCount`);
+- the **persisted style scope** the controller remembers (`styleScopeKey`,
+  `styleScopeFields`, `styleScopeDefaults`, and `usesColor` derived from
+  them);
+- the **tune-popup controls** the toolbar shows (`styleFields`, a
+  `PdfToolStyleFields` value - the old `_StyleFields`, now shared);
+- **commit hooks** for the tools whose placement is a single document
+  mutation (`commitShapeRect`, `commitLineDrag`, `commitPoly`).
+
+One adapter per tool is registered in `_behaviors`; look one up with
+`PdfEditToolBehavior.of` / `.maybeOf`.
+
+The three consumers now read from it:
+
+- `editing_controller.dart`: the four static tables collapse to
+  `PdfEditToolBehavior.maybeOf(tool)?.…`.
+- `editing_overlay.dart`: the classification getters delegate to `_behavior`
+  (`PdfEditToolBehavior.maybeOf(_tool)`); `_commitRect` (shapes),
+  `_commitLineDrag`, and `_finishPolyPath` call the commit hooks.
+- `editing_toolbar.dart`: `_StyleFields` is now a typedef for
+  `PdfToolStyleFields`; `_groupStyleFields` returns
+  `behavior.styleFields` for the armed tool - the per-tool capability
+  booleans (which shapes carry endings/fill/corner-radius, which
+  measurements carry endings) are gone from the toolbar.
+
+## The test surface
+
+`test/editing_tool_behavior_test.dart` (24 tests) is the payoff the ticket
+called for: feed a behaviour a `PdfEditingController` (and page-space
+geometry for the commit hooks) and assert what it reports/emits - no pumped
+`PdfViewer`, no synthetic pointer streams.
+
+## Faithfulness gotchas
+
+- **The cloud tool is deliberately not an `isPoly` behaviour.** Its drag path
+  rubber-bands a rectangle; only its *click* path builds a free-form
+  footprint (via `addCloudPolygonPoints`). `_finishPolyPath` still
+  special-cases it before the `commitPoly` hook.
+- **The volume tool's `commitPoly` returns false** - it must prompt for a
+  depth first, so it declines the synchronous commit and the overlay runs
+  its async `_commitVolume`.
+- **Insert-strip tools share one tune popup.** The old `_groupStyleFields`
+  was group-keyed, so note/stamp/count/image/signature all showed
+  `opacity + font + boxColors`. Preserved exactly (each carries the same
+  `styleFields`) even though it's semantically loose - a behaviour change
+  there is out of scope.
+- The overlay classification getters were kept (delegating to `_behavior`)
+  rather than inlined, so their many call sites and doc comments stay put.
+
+Select-mode manipulation (move/resize/rotate/vertex/marquee), raw-pointer
+palm rejection, viewport pan, autoscroll, and the afterimage/preview
+bookkeeping stay in the overlay `State` - they are gesture infrastructure
+and render concerns, not per-tool identity.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -13,6 +13,7 @@ import 'digital_signature.dart';
 import 'editing_measure.dart';
 import 'editing_page_clipboard.dart';
 import 'editing_preferences.dart';
+import 'editing_tool_behavior.dart';
 import 'line_style.dart';
 import 'editing_signature.dart';
 import 'editing_stamps.dart';
@@ -1056,116 +1057,24 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   static bool _buffersInk(PdfEditTool? tool) =>
-      tool == PdfEditTool.ink || tool == PdfEditTool.highlight;
+      PdfEditToolBehavior.maybeOf(tool)?.buffersInk ?? false;
 
-  /// The persisted-style scope key for [tool] - its [PdfEditTool] name for
-  /// the tools that create styled annotations, null for the others (select,
-  /// content, form, redact, signature, eraser-when-radius-only handled by
-  /// its own slot). See [preferences].
-  static String? _styleScopeKey(PdfEditTool? tool) => switch (tool) {
-        PdfEditTool.ink => 'ink',
-        PdfEditTool.highlight => 'freehandHighlight',
-        PdfEditTool.eraser => 'eraser',
-        PdfEditTool.rectangle => 'rectangle',
-        PdfEditTool.ellipse => 'ellipse',
-        PdfEditTool.line => 'line',
-        PdfEditTool.arrow => 'arrow',
-        PdfEditTool.polyline => 'polyline',
-        PdfEditTool.polygon => 'polygon',
-        PdfEditTool.cloudPolygon => 'cloudPolygon',
-        PdfEditTool.measureDistance => 'measureDistance',
-        PdfEditTool.measurePerimeter => 'measurePerimeter',
-        PdfEditTool.measureArea => 'measureArea',
-        PdfEditTool.measureSlope => 'measureSlope',
-        PdfEditTool.measureAngle => 'measureAngle',
-        PdfEditTool.measureArc => 'measureArc',
-        PdfEditTool.measureVolume => 'measureVolume',
-        PdfEditTool.freeText => 'freeText',
-        PdfEditTool.callout => 'callout',
-        PdfEditTool.note => 'note',
-        PdfEditTool.stamp => 'stamp',
-        PdfEditTool.count => 'count',
-        _ => null,
-      };
+  /// The persisted-style scope key for [tool] - a stable slot name for the
+  /// tools that create styled annotations, null for the others (select,
+  /// content, form, redact, signature, image, snapshot, calibrate). Owned by
+  /// [PdfEditToolBehavior]. See [preferences].
+  static String? _styleScopeKey(PdfEditTool? tool) =>
+      PdfEditToolBehavior.maybeOf(tool)?.styleScopeKey;
 
   /// The style fields [tool] remembers - mirrors the controls its toolbar
   /// strip exposes, so a rectangle keeps its fill but not a font, ink keeps
-  /// its stroke but not line endings, and so on.
-  static Set<String> _styleScopeFields(PdfEditTool? tool) => switch (tool) {
-        PdfEditTool.ink || PdfEditTool.highlight => const {
-            'color',
-            'strokeWidth',
-            'opacity'
-          },
-        PdfEditTool.eraser => const {'eraserRadius'},
-        PdfEditTool.rectangle => const {
-            'color',
-            'strokeWidth',
-            'opacity',
-            'lineStyle',
-            'shapeFillColor',
-            'cornerRadius',
-          },
-        PdfEditTool.ellipse ||
-        PdfEditTool.polygon ||
-        PdfEditTool.cloudPolygon =>
-          const {
-            'color',
-            'strokeWidth',
-            'opacity',
-            'lineStyle',
-            'lineScale',
-            'shapeFillColor',
-          },
-        PdfEditTool.line || PdfEditTool.polyline => const {
-            'color',
-            'strokeWidth',
-            'opacity',
-            'lineStyle',
-            'lineScale',
-            'lineStartEnding',
-            'lineEndEnding',
-          },
-        PdfEditTool.arrow => const {
-            'color',
-            'strokeWidth',
-            'opacity',
-            'lineStyle',
-            'lineScale',
-          },
-        PdfEditTool.measureDistance ||
-        PdfEditTool.measurePerimeter ||
-        PdfEditTool.measureArea ||
-        PdfEditTool.measureSlope ||
-        PdfEditTool.measureAngle ||
-        PdfEditTool.measureArc ||
-        PdfEditTool.measureVolume =>
-          const {'color', 'strokeWidth', 'opacity'},
-        PdfEditTool.freeText || PdfEditTool.callout => const {
-            'color',
-            'fontSize',
-            'fontFamily',
-            'textAlign',
-            'opacity',
-            'textFillColor',
-            'textBorderColor',
-            'strokeWidth',
-          },
-        PdfEditTool.note => const {'color'},
-        PdfEditTool.stamp => const {'color', 'opacity'},
-        PdfEditTool.count => const {'color', 'opacity'},
-        _ => const {},
-      };
+  /// its stroke but not line endings, and so on. Owned by
+  /// [PdfEditToolBehavior].
+  static Set<String> _styleScopeFields(PdfEditTool? tool) =>
+      PdfEditToolBehavior.maybeOf(tool)?.styleScopeFields ?? const {};
 
   static Map<String, Object?> _styleScopeDefaults(PdfEditTool? tool) =>
-      switch (tool) {
-        PdfEditTool.highlight => const {
-            'color': 0xFFFFD100,
-            'strokeWidth': 12.0,
-            'opacity': 0.45,
-          },
-        _ => const {},
-      };
+      PdfEditToolBehavior.maybeOf(tool)?.styleScopeDefaults ?? const {};
 
   /// Activates the text-markup style scope (highlight / underline / strike
   /// out / squiggly) - they act on the text selection rather than arming a

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -18,6 +18,7 @@ import 'editing_controller.dart';
 import 'editing_fonts.dart';
 import 'editing_interaction.dart';
 import 'editing_measure.dart';
+import 'editing_tool_behavior.dart';
 import 'stroke_prediction.dart';
 import 'text_prompt.dart';
 
@@ -1069,9 +1070,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
               .clamp(0.0, 1.0)
           : null;
 
-  bool get _inkTool =>
-      _tool == PdfEditTool.ink || _tool == PdfEditTool.highlight;
-  bool get _drawTool => _inkTool || _tool == PdfEditTool.eraser;
+  /// The armed tool's behaviour - the single source of tool identity the
+  /// gesture phases dispatch on - or null when nothing is armed.
+  PdfEditToolBehavior? get _behavior => PdfEditToolBehavior.maybeOf(_tool);
+
+  bool get _inkTool => _behavior?.isInk ?? false;
+  bool get _drawTool => _behavior?.isDraw ?? false;
 
   /// A finger should pan the viewer (not draw): the draw tool is armed
   /// but finger-drawing is off, so touch is reserved for scrolling.
@@ -1079,14 +1083,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _drawTool &&
       !_controller.fingerDrawsInk &&
       _host.panViewport != null;
-  bool get _polyTool =>
-      _tool == PdfEditTool.polyline ||
-      _tool == PdfEditTool.polygon ||
-      _tool == PdfEditTool.measurePerimeter ||
-      _tool == PdfEditTool.measureArea ||
-      _tool == PdfEditTool.measureAngle ||
-      _tool == PdfEditTool.measureArc ||
-      _tool == PdfEditTool.measureVolume;
+  bool get _polyTool => _behavior?.isPoly ?? false;
 
   /// The cloud tool is a hybrid: a drag rubber-bands a rectangle, but a
   /// tap starts (and each further tap extends) a free-form vertex list -
@@ -1098,32 +1095,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// The number of clicks a fixed-arity poly tool takes before it
   /// auto-finishes - three for the angle and arc takeoffs - or null for an
   /// open-ended poly tool (finished by a double-tap).
-  int? get _fixedPolyCount => switch (_tool) {
-        PdfEditTool.measureAngle || PdfEditTool.measureArc => 3,
-        _ => null,
-      };
+  int? get _fixedPolyCount => _behavior?.fixedPolyCount;
 
   /// A tool placed by dragging a single straight segment (a /Line or a
   /// distance/slope measurement).
-  bool get _lineDragTool =>
-      _tool == PdfEditTool.line ||
-      _tool == PdfEditTool.arrow ||
-      _tool == PdfEditTool.measureDistance ||
-      _tool == PdfEditTool.measureSlope ||
-      _tool == PdfEditTool.calibrate;
+  bool get _lineDragTool => _behavior?.isLineDrag ?? false;
 
   /// The measurement kind the armed tool creates, or null for a
   /// non-measurement tool.
-  PdfMeasurementKind? get _measureKind => switch (_tool) {
-        PdfEditTool.measureDistance => PdfMeasurementKind.distance,
-        PdfEditTool.measurePerimeter => PdfMeasurementKind.perimeter,
-        PdfEditTool.measureArea => PdfMeasurementKind.area,
-        PdfEditTool.measureSlope => PdfMeasurementKind.slope,
-        PdfEditTool.measureAngle => PdfMeasurementKind.angle,
-        PdfEditTool.measureArc => PdfMeasurementKind.arc,
-        PdfEditTool.measureVolume => PdfMeasurementKind.volume,
-        _ => null,
-      };
+  PdfMeasurementKind? get _measureKind => _behavior?.measureKind;
 
   /// Whether a pointer of [kind] draws (or erases) through the raw
   /// event stream instead of the gesture arena. Pan recognizers only
@@ -3549,15 +3529,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return;
     }
     final before = _controller.document;
-    final lineKind = _measureKind; // distance or slope for a measure tool
-    if (lineKind != null) {
-      _controller.addMeasurement(widget.pageIndex, lineKind,
-          [_geometry.toPagePoint(start), _geometry.toPagePoint(end)]);
-    } else {
-      _controller.addLine(widget.pageIndex, _geometry.toPagePoint(start),
-          _geometry.toPagePoint(end),
-          arrow: _tool == PdfEditTool.arrow);
-    }
+    _behavior!.commitLineDrag(_controller, widget.pageIndex,
+        _geometry.toPagePoint(start), _geometry.toPagePoint(end));
     if (identical(before, _controller.document)) return;
     _clearAfterimage();
     _afterPath = (
@@ -3710,38 +3683,24 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (simplified.length < minPoints) return;
     final pagePoints = [for (final p in simplified) _geometry.toPagePoint(p)];
     final before = _controller.document;
-    switch (_measureKind) {
-      case PdfMeasurementKind.perimeter:
-        _controller.addMeasurement(
-            widget.pageIndex, PdfMeasurementKind.perimeter, pagePoints);
-      case PdfMeasurementKind.area:
-        _controller.addMeasurement(
-            widget.pageIndex, PdfMeasurementKind.area, pagePoints);
-      case PdfMeasurementKind.angle:
-        _controller.addMeasurement(
-            widget.pageIndex, PdfMeasurementKind.angle, pagePoints);
-      case PdfMeasurementKind.arc:
-        _controller.addMeasurement(
-            widget.pageIndex, PdfMeasurementKind.arc, pagePoints);
-      case PdfMeasurementKind.volume:
-        // volume needs a depth: prompt for it, then commit asynchronously.
-        unawaited(_commitVolume(pagePoints));
-        _clearAfterimage();
-        setState(() {
-          _polyPoints = null;
-          _polyHover = null;
-        });
-        return;
-      default:
-        // distance/slope are drag tools (handled elsewhere); a poly gesture
-        // with no measure kind active is a plain poly annotation.
-        if (_tool == PdfEditTool.cloudPolygon) {
-          _controller.addCloudPolygonPoints(widget.pageIndex, pagePoints);
-        } else if (_tool == PdfEditTool.polygon) {
-          _controller.addPolygon(widget.pageIndex, pagePoints);
-        } else {
-          _controller.addPolyLine(widget.pageIndex, pagePoints);
-        }
+    // Volume needs a depth: its behaviour declines the synchronous commit,
+    // so prompt for the depth and commit asynchronously here.
+    if (_measureKind == PdfMeasurementKind.volume) {
+      unawaited(_commitVolume(pagePoints));
+      _clearAfterimage();
+      setState(() {
+        _polyPoints = null;
+        _polyHover = null;
+      });
+      return;
+    }
+    // The cloud tool's click path builds a free-form footprint (its drag
+    // path rubber-bands a rectangle instead), so it isn't a poly behaviour;
+    // every other poly/measure-poly tool commits through its behaviour.
+    if (_tool == PdfEditTool.cloudPolygon) {
+      _controller.addCloudPolygonPoints(widget.pageIndex, pagePoints);
+    } else {
+      _behavior!.commitPoly(_controller, widget.pageIndex, pagePoints);
     }
     if (identical(before, _controller.document)) return;
     _clearAfterimage();
@@ -3777,13 +3736,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             PdfEditTool.cloudPolygon:
         final tool = _tool!;
         final before = _controller.document;
-        if (tool == PdfEditTool.rectangle) {
-          _controller.addRectangle(widget.pageIndex, rect);
-        } else if (tool == PdfEditTool.cloudPolygon) {
-          _controller.addCloudPolygon(widget.pageIndex, rect);
-        } else {
-          _controller.addEllipse(widget.pageIndex, rect);
-        }
+        _behavior!.commitShapeRect(_controller, widget.pageIndex, rect);
         if (identical(before, _controller.document)) return;
         // the drag preview, frozen until the new revision renders
         _clearAfterimage();

--- a/packages/dart_pdf_editor/lib/src/editing/editing_tool_behavior.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_tool_behavior.dart
@@ -124,10 +124,6 @@ abstract class PdfEditToolBehavior {
   /// rectangle by default.
   bool get isPoly => false;
 
-  /// A closed poly tool (its last vertex joins the first): polygon and the
-  /// area / volume measurements.
-  bool get closesPoly => false;
-
   /// Placed by dragging a single straight segment (a /Line, an arrow, a
   /// distance/slope measurement, or the scale-calibration drag).
   bool get isLineDrag => false;
@@ -322,7 +318,6 @@ class _PolyTool extends PdfEditToolBehavior {
   const _PolyTool(this.tool,
       {required this.styleScopeKey,
       required this.styleScopeFields,
-      required this.closesPoly,
       required this.styleFields});
 
   @override
@@ -331,8 +326,6 @@ class _PolyTool extends PdfEditToolBehavior {
   final String? styleScopeKey;
   @override
   final Set<String> styleScopeFields;
-  @override
-  final bool closesPoly;
   @override
   final PdfToolStyleFields styleFields;
   @override
@@ -387,7 +380,7 @@ class _MeasureLineTool extends PdfEditToolBehavior {
 /// readout is its perimeter, area, interior angle, arc length, or volume.
 class _MeasurePolyTool extends PdfEditToolBehavior {
   const _MeasurePolyTool(this.tool, this.measureKind,
-      {this.fixedPolyCount, required this.closesPoly, required this.hasEndings});
+      {this.fixedPolyCount, required this.hasEndings});
 
   @override
   final PdfEditTool tool;
@@ -395,8 +388,6 @@ class _MeasurePolyTool extends PdfEditToolBehavior {
   final PdfMeasurementKind measureKind;
   @override
   final int? fixedPolyCount;
-  @override
-  final bool closesPoly;
 
   /// Whether the running readout draws an open segment (so it carries
   /// endings): perimeter / angle / arc, but not the closed area / volume.
@@ -535,7 +526,6 @@ final Map<PdfEditTool, PdfEditToolBehavior> _behaviors = {
     const _PolyTool(PdfEditTool.polyline,
         styleScopeKey: 'polyline',
         styleScopeFields: _lineFields,
-        closesPoly: false,
         styleFields: PdfToolStyleFields(
           stroke: true,
           strokeColor: true,
@@ -547,7 +537,6 @@ final Map<PdfEditTool, PdfEditToolBehavior> _behaviors = {
     const _PolyTool(PdfEditTool.polygon,
         styleScopeKey: 'polygon',
         styleScopeFields: _shapeFields,
-        closesPoly: true,
         styleFields: PdfToolStyleFields(
           stroke: true,
           strokeColor: true,
@@ -560,15 +549,15 @@ final Map<PdfEditTool, PdfEditToolBehavior> _behaviors = {
     const _MeasureLineTool(PdfEditTool.measureSlope, PdfMeasurementKind.slope),
     const _MeasurePolyTool(
         PdfEditTool.measurePerimeter, PdfMeasurementKind.perimeter,
-        closesPoly: false, hasEndings: true),
+        hasEndings: true),
     const _MeasurePolyTool(PdfEditTool.measureArea, PdfMeasurementKind.area,
-        closesPoly: true, hasEndings: false),
+        hasEndings: false),
     const _MeasurePolyTool(PdfEditTool.measureAngle, PdfMeasurementKind.angle,
-        fixedPolyCount: 3, closesPoly: false, hasEndings: true),
+        fixedPolyCount: 3, hasEndings: true),
     const _MeasurePolyTool(PdfEditTool.measureArc, PdfMeasurementKind.arc,
-        fixedPolyCount: 3, closesPoly: false, hasEndings: true),
+        fixedPolyCount: 3, hasEndings: true),
     const _MeasurePolyTool(PdfEditTool.measureVolume, PdfMeasurementKind.volume,
-        closesPoly: true, hasEndings: false),
+        hasEndings: false),
     const _SimpleTool(PdfEditTool.calibrate, isLineDrag: true),
     const _SimpleTool(PdfEditTool.freeText,
         styleScopeKey: 'freeText',

--- a/packages/dart_pdf_editor/lib/src/editing/editing_tool_behavior.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_tool_behavior.dart
@@ -1,0 +1,613 @@
+import 'package:pdf_document/pdf_document.dart'
+    show PdfMeasurementKind, PdfRect;
+
+import 'editing_controller.dart';
+
+/// Which controls the style popup should show for a tool (or an annotation
+/// selection) - each context only carries the settings it can actually use,
+/// so the tune popup never shows (say) a font picker while a rectangle is
+/// armed, or line endings while ink is armed.
+///
+/// This mirrors, on the tool side, what [PdfEditToolBehavior.styleFields]
+/// exposes; the toolbar also builds one directly from a selected
+/// annotation's subtype. See [PdfEditToolBehavior].
+class PdfToolStyleFields {
+  const PdfToolStyleFields({
+    this.stroke = false,
+    this.strokeColor = false,
+    this.opacity = false,
+    this.lineType = false,
+    this.lineScale = false,
+    this.lineEndings = false,
+    this.font = false,
+    this.boxColors = false,
+    this.shapeFill = false,
+    this.cornerRadius = false,
+    this.eraser = false,
+    this.formField = false,
+  });
+
+  final bool stroke;
+
+  /// The stroke/outline colour row - shapes (including revision clouds) and
+  /// the line family. Distinct from [shapeFill], the interior fill.
+  final bool strokeColor;
+
+  final bool opacity;
+
+  /// The rectangle corner-radius slider (rectangle shape only).
+  final bool cornerRadius;
+
+  /// The line-type dropdown (solid / dashed / dotted / dash-dot) - shapes
+  /// and the line family.
+  final bool lineType;
+
+  /// The pattern-scale slider - sizes dash patterns and cloudy scallops
+  /// apart from the pen width. Shown alongside [lineType].
+  final bool lineScale;
+  final bool lineEndings;
+
+  /// Font size + family (free text).
+  final bool font;
+
+  /// The text-box fill + border colour rows (free text).
+  final bool boxColors;
+
+  /// The shape interior-fill colour row (rectangle / ellipse).
+  final bool shapeFill;
+
+  /// Eraser radius - replaces every other control while the eraser is armed.
+  final bool eraser;
+
+  /// The form text field style block (font, alignment, auto-size, size,
+  /// multiline, colour) - a single text-field widget is selected. Only ever
+  /// set from an annotation selection, never a tool.
+  final bool formField;
+
+  bool get isEmpty =>
+      !stroke &&
+      !strokeColor &&
+      !opacity &&
+      !lineType &&
+      !lineScale &&
+      !lineEndings &&
+      !font &&
+      !boxColors &&
+      !shapeFill &&
+      !cornerRadius &&
+      !eraser &&
+      !formField;
+}
+
+/// One authoritative view of an editing tool's behaviour.
+///
+/// [PdfEditTool] is a wide enum, and its behaviour used to be smeared across
+/// several `switch (tool)` blocks in separate gesture phases (the overlay's
+/// pointer handlers), the controller's persisted-style scopes, and the
+/// toolbar's per-tool capability booleans. This descriptor owns that
+/// per-tool identity in one place: the classification the overlay dispatches
+/// on, the style scope the controller persists, the controls the toolbar's
+/// tune popup offers, and - for the tools whose commit is a single document
+/// mutation - the commit itself, so it can be unit-tested against a
+/// [PdfEditingController] without pumping a widget.
+///
+/// This mirrors [PdfAnnotationBehavior] (pdf_document) on the tool side.
+/// Material labels, icons, and dock grouping deliberately stay in the
+/// toolbar; this descriptor owns only tool semantics.
+///
+/// One adapter per tool is registered in [_behaviors]; look one up with
+/// [PdfEditToolBehavior.of] or [PdfEditToolBehavior.maybeOf].
+abstract class PdfEditToolBehavior {
+  const PdfEditToolBehavior();
+
+  /// The enum value this behaviour implements.
+  PdfEditTool get tool;
+
+  // ---------------------------------------------------------------------
+  // Classification - the predicates the overlay's gesture phases route on.
+  // ---------------------------------------------------------------------
+
+  /// Freehand ink family (pen or freehand highlighter): strokes accumulate
+  /// in the controller until finished as one Ink annotation.
+  bool get isInk => false;
+
+  /// A "draw" tool driven through the raw pointer stream rather than the
+  /// gesture arena (ink, freehand highlight, and the eraser).
+  bool get isDraw => false;
+
+  /// A tool whose strokes buffer under a held auto-commit (ink / highlight).
+  bool get buffersInk => false;
+
+  /// Placed by clicking a running vertex list, finished by a double-tap
+  /// (polyline / polygon and the poly-shaped measurements). The cloud tool
+  /// is a hybrid and is deliberately *not* included - it rubber-bands a
+  /// rectangle by default.
+  bool get isPoly => false;
+
+  /// A closed poly tool (its last vertex joins the first): polygon and the
+  /// area / volume measurements.
+  bool get closesPoly => false;
+
+  /// Placed by dragging a single straight segment (a /Line, an arrow, a
+  /// distance/slope measurement, or the scale-calibration drag).
+  bool get isLineDrag => false;
+
+  /// The measurement kind this tool stamps, or null for a non-measurement
+  /// tool.
+  PdfMeasurementKind? get measureKind => null;
+
+  /// The number of clicks a fixed-arity poly tool takes before it
+  /// auto-finishes - three for the angle and arc takeoffs - or null for an
+  /// open-ended poly tool (finished by a double-tap).
+  int? get fixedPolyCount => null;
+
+  // ---------------------------------------------------------------------
+  // Persisted style scope - what the controller remembers per tool.
+  // ---------------------------------------------------------------------
+
+  /// The persisted-style scope key - a stable slot name for the tool's
+  /// remembered style, or null for the tools that create nothing styled
+  /// (select, content, form, redact, signature, image, snapshot,
+  /// calibrate). See [PdfEditingController.preferences].
+  String? get styleScopeKey => null;
+
+  /// The style fields this tool remembers - mirrors the controls its toolbar
+  /// strip exposes, so a rectangle keeps its fill but not a font, ink keeps
+  /// its stroke but not line endings, and so on.
+  Set<String> get styleScopeFields => const {};
+
+  /// Initial values seeded into the tool's style scope the first time it is
+  /// armed (the freehand highlighter's broad translucent yellow).
+  Map<String, Object?> get styleScopeDefaults => const {};
+
+  /// Whether the tool creates annotations that carry a colour the toolbar
+  /// can offer - i.e. its scope remembers `color`.
+  bool get usesColor => styleScopeFields.contains('color');
+
+  // ---------------------------------------------------------------------
+  // Toolbar tune popup.
+  // ---------------------------------------------------------------------
+
+  /// Which controls the tune popup shows while this tool is armed.
+  PdfToolStyleFields get styleFields => const PdfToolStyleFields();
+
+  // ---------------------------------------------------------------------
+  // Commit - a single document mutation, factored out so it can be driven
+  // from a unit test (feed a controller + page-space geometry, assert the
+  // emitted annotation) rather than a pumped widget. The overlay maps the
+  // gesture to page space, calls the matching hook, and keeps the
+  // render-side afterimage bookkeeping. Tools whose placement needs a
+  // prompt/picker (stamp text, note text, image bytes, calibration length,
+  // volume depth) keep that flow in the overlay.
+  // ---------------------------------------------------------------------
+
+  /// Commits a rubber-banded box for the shape family (rectangle, ellipse,
+  /// cloud). Returns true if it consumed the gesture.
+  bool commitShapeRect(PdfEditingController controller, int page, PdfRect rect) =>
+      false;
+
+  /// Commits a single straight-segment drag from [start] to [end] (both in
+  /// page space) for the line family and the line-shaped measurements.
+  /// Returns true if it consumed the gesture.
+  bool commitLineDrag(PdfEditingController controller, int page,
+          (double, double) start, (double, double) end) =>
+      false;
+
+  /// Commits a finished vertex list ([points] in page space) for the poly
+  /// family and the poly-shaped measurements. Returns true if it consumed
+  /// the gesture; false leaves it to the overlay (the volume tool, which
+  /// must prompt for a depth first).
+  bool commitPoly(
+          PdfEditingController controller, int page, List<(double, double)> points) =>
+      false;
+
+  /// The behaviour for [tool].
+  static PdfEditToolBehavior of(PdfEditTool tool) => _behaviors[tool]!;
+
+  /// The behaviour for [tool], or null when no tool is armed.
+  static PdfEditToolBehavior? maybeOf(PdfEditTool? tool) =>
+      tool == null ? null : _behaviors[tool];
+}
+
+// ---------------------------------------------------------------------------
+// Adapters. Grouped by shape of behaviour; metadata-only tools share
+// [_SimpleTool] so each still gets one authoritative row.
+// ---------------------------------------------------------------------------
+
+/// A tool whose behaviour is pure metadata (no drag/tap commit lives here -
+/// its placement stays in the overlay because it needs a prompt, a picker,
+/// or the select/erase interaction).
+class _SimpleTool extends PdfEditToolBehavior {
+  const _SimpleTool(
+    this.tool, {
+    this.styleScopeKey,
+    this.styleScopeFields = const {},
+    this.styleScopeDefaults = const {},
+    this.styleFields = const PdfToolStyleFields(),
+    this.isInk = false,
+    this.isDraw = false,
+    this.buffersInk = false,
+    this.isLineDrag = false,
+  });
+
+  @override
+  final PdfEditTool tool;
+  @override
+  final String? styleScopeKey;
+  @override
+  final Set<String> styleScopeFields;
+  @override
+  final Map<String, Object?> styleScopeDefaults;
+  @override
+  final PdfToolStyleFields styleFields;
+  @override
+  final bool isInk;
+  @override
+  final bool isDraw;
+  @override
+  final bool buffersInk;
+  @override
+  final bool isLineDrag;
+}
+
+/// Rectangle / ellipse / cloud: a drag rubber-bands a box that becomes a
+/// /Square, /Circle, or cloudy /Polygon.
+class _ShapeTool extends PdfEditToolBehavior {
+  const _ShapeTool(this.tool,
+      {required this.styleScopeKey,
+      required this.styleScopeFields,
+      required this.styleFields});
+
+  @override
+  final PdfEditTool tool;
+  @override
+  final String? styleScopeKey;
+  @override
+  final Set<String> styleScopeFields;
+  @override
+  final PdfToolStyleFields styleFields;
+
+  @override
+  bool commitShapeRect(
+      PdfEditingController controller, int page, PdfRect rect) {
+    switch (tool) {
+      case PdfEditTool.rectangle:
+        controller.addRectangle(page, rect);
+      case PdfEditTool.ellipse:
+        controller.addEllipse(page, rect);
+      case PdfEditTool.cloudPolygon:
+        controller.addCloudPolygon(page, rect);
+      default:
+        return false;
+    }
+    return true;
+  }
+}
+
+/// Line / arrow: a drag lays down a straight /Line annotation.
+class _LineTool extends PdfEditToolBehavior {
+  const _LineTool(this.tool,
+      {required this.styleScopeKey, required this.styleScopeFields});
+
+  @override
+  final PdfEditTool tool;
+  @override
+  final String? styleScopeKey;
+  @override
+  final Set<String> styleScopeFields;
+  @override
+  bool get isLineDrag => true;
+
+  @override
+  PdfToolStyleFields get styleFields => PdfToolStyleFields(
+        stroke: true,
+        strokeColor: true,
+        opacity: true,
+        lineType: true,
+        lineScale: true,
+        lineEndings: tool == PdfEditTool.line,
+      );
+
+  @override
+  bool commitLineDrag(PdfEditingController controller, int page,
+      (double, double) start, (double, double) end) {
+    controller.addLine(page, start, end, arrow: tool == PdfEditTool.arrow);
+    return true;
+  }
+}
+
+/// Polyline / polygon: a running vertex list becomes an open /PolyLine or a
+/// closed /Polygon.
+class _PolyTool extends PdfEditToolBehavior {
+  const _PolyTool(this.tool,
+      {required this.styleScopeKey,
+      required this.styleScopeFields,
+      required this.closesPoly,
+      required this.styleFields});
+
+  @override
+  final PdfEditTool tool;
+  @override
+  final String? styleScopeKey;
+  @override
+  final Set<String> styleScopeFields;
+  @override
+  final bool closesPoly;
+  @override
+  final PdfToolStyleFields styleFields;
+  @override
+  bool get isPoly => true;
+
+  @override
+  bool commitPoly(PdfEditingController controller, int page,
+      List<(double, double)> points) {
+    if (tool == PdfEditTool.polygon) {
+      controller.addPolygon(page, points);
+    } else {
+      controller.addPolyLine(page, points);
+    }
+    return true;
+  }
+}
+
+/// A line-shaped measurement (distance / slope): a drag stamps a /Line
+/// takeoff whose real-world length or inclination is shown live.
+class _MeasureLineTool extends PdfEditToolBehavior {
+  const _MeasureLineTool(this.tool, this.measureKind);
+
+  @override
+  final PdfEditTool tool;
+  @override
+  final PdfMeasurementKind measureKind;
+  @override
+  bool get isLineDrag => true;
+  @override
+  String get styleScopeKey => tool.name;
+  @override
+  Set<String> get styleScopeFields => const {'color', 'strokeWidth', 'opacity'};
+  @override
+  PdfToolStyleFields get styleFields => PdfToolStyleFields(
+        stroke: true,
+        opacity: true,
+        font: true,
+        // distance/slope draw an open segment, so it carries endings
+        lineEndings: true,
+      );
+
+  @override
+  bool commitLineDrag(PdfEditingController controller, int page,
+      (double, double) start, (double, double) end) {
+    controller.addMeasurement(page, measureKind, [start, end]);
+    return true;
+  }
+}
+
+/// A poly-shaped measurement (perimeter / area / angle / arc / volume): a
+/// running vertex list stamps a /PolyLine or /Polygon takeoff whose live
+/// readout is its perimeter, area, interior angle, arc length, or volume.
+class _MeasurePolyTool extends PdfEditToolBehavior {
+  const _MeasurePolyTool(this.tool, this.measureKind,
+      {this.fixedPolyCount, required this.closesPoly, required this.hasEndings});
+
+  @override
+  final PdfEditTool tool;
+  @override
+  final PdfMeasurementKind measureKind;
+  @override
+  final int? fixedPolyCount;
+  @override
+  final bool closesPoly;
+
+  /// Whether the running readout draws an open segment (so it carries
+  /// endings): perimeter / angle / arc, but not the closed area / volume.
+  final bool hasEndings;
+
+  @override
+  bool get isPoly => true;
+  @override
+  String get styleScopeKey => tool.name;
+  @override
+  Set<String> get styleScopeFields => const {'color', 'strokeWidth', 'opacity'};
+  @override
+  PdfToolStyleFields get styleFields =>
+      PdfToolStyleFields(stroke: true, opacity: true, font: true, lineEndings: hasEndings);
+
+  @override
+  bool commitPoly(PdfEditingController controller, int page,
+      List<(double, double)> points) {
+    // The volume tool needs a depth prompt first, so it defers to the
+    // overlay rather than committing here.
+    if (measureKind == PdfMeasurementKind.volume) return false;
+    controller.addMeasurement(page, measureKind, points);
+    return true;
+  }
+}
+
+const _shapeFields = {
+  'color',
+  'strokeWidth',
+  'opacity',
+  'lineStyle',
+  'lineScale',
+  'shapeFillColor',
+};
+
+const _lineFields = {
+  'color',
+  'strokeWidth',
+  'opacity',
+  'lineStyle',
+  'lineScale',
+  'lineStartEnding',
+  'lineEndEnding',
+};
+
+const _textFields = {
+  'color',
+  'fontSize',
+  'fontFamily',
+  'textAlign',
+  'opacity',
+  'textFillColor',
+  'textBorderColor',
+  'strokeWidth',
+};
+
+const _inkFields = {'color', 'strokeWidth', 'opacity'};
+
+final Map<PdfEditTool, PdfEditToolBehavior> _behaviors = {
+  for (final b in <PdfEditToolBehavior>[
+    const _SimpleTool(PdfEditTool.select),
+    const _SimpleTool(PdfEditTool.ink,
+        styleScopeKey: 'ink',
+        styleScopeFields: _inkFields,
+        isInk: true,
+        isDraw: true,
+        buffersInk: true,
+        styleFields: PdfToolStyleFields(stroke: true, opacity: true)),
+    const _SimpleTool(PdfEditTool.highlight,
+        styleScopeKey: 'freehandHighlight',
+        styleScopeFields: _inkFields,
+        styleScopeDefaults: {
+          'color': 0xFFFFD100,
+          'strokeWidth': 12.0,
+          'opacity': 0.45,
+        },
+        isInk: true,
+        isDraw: true,
+        buffersInk: true,
+        styleFields: PdfToolStyleFields(stroke: true, opacity: true)),
+    const _SimpleTool(PdfEditTool.eraser,
+        styleScopeKey: 'eraser',
+        styleScopeFields: {'eraserRadius'},
+        isDraw: true,
+        styleFields: PdfToolStyleFields(eraser: true)),
+    const _ShapeTool(PdfEditTool.rectangle,
+        styleScopeKey: 'rectangle',
+        styleScopeFields: {
+          'color',
+          'strokeWidth',
+          'opacity',
+          'lineStyle',
+          'shapeFillColor',
+          'cornerRadius',
+        },
+        styleFields: PdfToolStyleFields(
+          stroke: true,
+          strokeColor: true,
+          opacity: true,
+          lineType: true,
+          lineScale: true,
+          shapeFill: true,
+          cornerRadius: true,
+        )),
+    const _ShapeTool(PdfEditTool.ellipse,
+        styleScopeKey: 'ellipse',
+        styleScopeFields: _shapeFields,
+        styleFields: PdfToolStyleFields(
+          stroke: true,
+          strokeColor: true,
+          opacity: true,
+          lineType: true,
+          lineScale: true,
+          shapeFill: true,
+        )),
+    const _ShapeTool(PdfEditTool.cloudPolygon,
+        styleScopeKey: 'cloudPolygon',
+        styleScopeFields: _shapeFields,
+        styleFields: PdfToolStyleFields(
+          stroke: true,
+          strokeColor: true,
+          opacity: true,
+          lineType: true,
+          lineScale: true,
+          shapeFill: true,
+        )),
+    const _LineTool(PdfEditTool.line,
+        styleScopeKey: 'line', styleScopeFields: _lineFields),
+    const _LineTool(PdfEditTool.arrow, styleScopeKey: 'arrow', styleScopeFields: {
+      'color',
+      'strokeWidth',
+      'opacity',
+      'lineStyle',
+      'lineScale',
+    }),
+    const _PolyTool(PdfEditTool.polyline,
+        styleScopeKey: 'polyline',
+        styleScopeFields: _lineFields,
+        closesPoly: false,
+        styleFields: PdfToolStyleFields(
+          stroke: true,
+          strokeColor: true,
+          opacity: true,
+          lineType: true,
+          lineScale: true,
+          lineEndings: true,
+        )),
+    const _PolyTool(PdfEditTool.polygon,
+        styleScopeKey: 'polygon',
+        styleScopeFields: _shapeFields,
+        closesPoly: true,
+        styleFields: PdfToolStyleFields(
+          stroke: true,
+          strokeColor: true,
+          opacity: true,
+          lineType: true,
+          lineScale: true,
+          shapeFill: true,
+        )),
+    const _MeasureLineTool(PdfEditTool.measureDistance, PdfMeasurementKind.distance),
+    const _MeasureLineTool(PdfEditTool.measureSlope, PdfMeasurementKind.slope),
+    const _MeasurePolyTool(
+        PdfEditTool.measurePerimeter, PdfMeasurementKind.perimeter,
+        closesPoly: false, hasEndings: true),
+    const _MeasurePolyTool(PdfEditTool.measureArea, PdfMeasurementKind.area,
+        closesPoly: true, hasEndings: false),
+    const _MeasurePolyTool(PdfEditTool.measureAngle, PdfMeasurementKind.angle,
+        fixedPolyCount: 3, closesPoly: false, hasEndings: true),
+    const _MeasurePolyTool(PdfEditTool.measureArc, PdfMeasurementKind.arc,
+        fixedPolyCount: 3, closesPoly: false, hasEndings: true),
+    const _MeasurePolyTool(PdfEditTool.measureVolume, PdfMeasurementKind.volume,
+        closesPoly: true, hasEndings: false),
+    const _SimpleTool(PdfEditTool.calibrate, isLineDrag: true),
+    const _SimpleTool(PdfEditTool.freeText,
+        styleScopeKey: 'freeText',
+        styleScopeFields: _textFields,
+        styleFields:
+            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    const _SimpleTool(PdfEditTool.callout,
+        styleScopeKey: 'callout',
+        styleScopeFields: _textFields,
+        styleFields:
+            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    // The Insert strip offers one shared tune popup (opacity + font + text-box
+    // colours) to every tool it hosts, so each carries the same styleFields
+    // even though its persisted scope differs.
+    const _SimpleTool(PdfEditTool.note,
+        styleScopeKey: 'note',
+        styleScopeFields: {'color'},
+        styleFields:
+            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    const _SimpleTool(PdfEditTool.stamp,
+        styleScopeKey: 'stamp',
+        styleScopeFields: {'color', 'opacity'},
+        styleFields:
+            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    const _SimpleTool(PdfEditTool.count,
+        styleScopeKey: 'count',
+        styleScopeFields: {'color', 'opacity'},
+        styleFields:
+            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    const _SimpleTool(PdfEditTool.signature,
+        styleFields:
+            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    const _SimpleTool(PdfEditTool.image,
+        styleFields:
+            PdfToolStyleFields(opacity: true, font: true, boxColors: true)),
+    const _SimpleTool(PdfEditTool.content),
+    const _SimpleTool(PdfEditTool.form),
+    const _SimpleTool(PdfEditTool.redact),
+    const _SimpleTool(PdfEditTool.snapshot),
+  ])
+    b.tool: b,
+};

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -27,6 +27,7 @@ import 'editing_takeoff.dart';
 import 'line_style.dart';
 import 'editing_signature.dart';
 import 'editing_stamps.dart';
+import 'editing_tool_behavior.dart';
 import 'text_prompt.dart';
 import 'text_style_prompt.dart';
 import 'tool_shortcuts.dart';
@@ -1981,42 +1982,32 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// font picker, ink never offers line endings, and so on.
   _StyleFields _groupStyleFields(_ToolGroup group) {
     final tool = controller.tool;
+    // An armed tool owns exactly which controls it exposes - the per-tool
+    // capability booleans that used to live here now live in the tool's
+    // [PdfEditToolBehavior].
+    if (tool != null && _groupForTool(tool)?.id == group.id) {
+      return PdfEditToolBehavior.of(tool).styleFields;
+    }
+    // No in-group armed tool: the strip is open on its own (Select or Markup,
+    // a Draw strip over a selection, or a group opened before its default
+    // tool armed). Fall back to the group's resting controls.
     switch (group.id) {
       case 'draw':
-        if (tool == null && viewerController.hasSelection) {
-          return const _StyleFields(opacity: true);
-        }
-        if (tool == PdfEditTool.eraser) return const _StyleFields(eraser: true);
-        return const _StyleFields(stroke: true, opacity: true);
+        return viewerController.hasSelection
+            ? const _StyleFields(opacity: true)
+            : const _StyleFields(stroke: true, opacity: true);
       case 'shapes':
-        return _StyleFields(
+        return const _StyleFields(
           stroke: true,
           strokeColor: true,
           opacity: true,
           lineType: true,
           lineScale: true,
-          lineEndings: tool == PdfEditTool.line || tool == PdfEditTool.polyline,
-          shapeFill: tool == PdfEditTool.rectangle ||
-              tool == PdfEditTool.ellipse ||
-              tool == PdfEditTool.polygon ||
-              tool == PdfEditTool.cloudPolygon,
-          cornerRadius: tool == PdfEditTool.rectangle,
         );
       case 'insert':
         return const _StyleFields(opacity: true, font: true, boxColors: true);
       case 'measure':
-        return _StyleFields(
-          stroke: true,
-          opacity: true,
-          font: true,
-          // open measurements (distance/slope lines, perimeter/angle/arc
-          // polylines) carry endings; closed area/volume polygons don't
-          lineEndings: tool == PdfEditTool.measureDistance ||
-              tool == PdfEditTool.measureSlope ||
-              tool == PdfEditTool.measurePerimeter ||
-              tool == PdfEditTool.measureAngle ||
-              tool == PdfEditTool.measureArc,
-        );
+        return const _StyleFields(stroke: true, opacity: true, font: true);
       case 'markup':
         return const _StyleFields(opacity: true);
       default:
@@ -3153,72 +3144,10 @@ double? _parsePercent(String s) {
   return n == null ? null : n / 100;
 }
 
-class _StyleFields {
-  const _StyleFields({
-    this.stroke = false,
-    this.strokeColor = false,
-    this.opacity = false,
-    this.lineType = false,
-    this.lineScale = false,
-    this.lineEndings = false,
-    this.font = false,
-    this.boxColors = false,
-    this.shapeFill = false,
-    this.cornerRadius = false,
-    this.eraser = false,
-    this.formField = false,
-  });
-
-  final bool stroke;
-
-  /// The stroke/outline colour row - shapes (including revision clouds) and
-  /// the line family. Distinct from [shapeFill], the interior fill.
-  final bool strokeColor;
-
-  final bool opacity;
-
-  /// The rectangle corner-radius slider (rectangle shape only).
-  final bool cornerRadius;
-
-  /// The line-type dropdown (solid / dashed / dotted / dash-dot) - shapes
-  /// and the line family.
-  final bool lineType;
-
-  /// The pattern-scale slider - sizes dash patterns and cloudy scallops
-  /// apart from the pen width. Shown alongside [lineType].
-  final bool lineScale;
-  final bool lineEndings;
-
-  /// Font size + family (free text).
-  final bool font;
-
-  /// The text-box fill + border colour rows (free text).
-  final bool boxColors;
-
-  /// The shape interior-fill colour row (rectangle / ellipse).
-  final bool shapeFill;
-
-  /// Eraser radius - replaces every other control while the eraser is armed.
-  final bool eraser;
-
-  /// The form text field style block (font, alignment, auto-size, size,
-  /// multiline, colour) - a single text-field widget is selected.
-  final bool formField;
-
-  bool get isEmpty =>
-      !stroke &&
-      !strokeColor &&
-      !opacity &&
-      !lineType &&
-      !lineScale &&
-      !lineEndings &&
-      !font &&
-      !boxColors &&
-      !shapeFill &&
-      !cornerRadius &&
-      !eraser &&
-      !formField;
-}
+/// The tune popup's control set. The tool-armed case is owned by
+/// [PdfEditToolBehavior.styleFields]; the toolbar still builds one directly
+/// from a selected annotation's subtype (see [_selectionStyleFields]).
+typedef _StyleFields = PdfToolStyleFields;
 
 /// The style popup: sliders for stroke width, opacity, and font size,
 /// the font family for free text, and the text box's fill and border

--- a/packages/dart_pdf_editor/test/editing_tool_behavior_test.dart
+++ b/packages/dart_pdf_editor/test/editing_tool_behavior_test.dart
@@ -1,0 +1,272 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/editing/editing_tool_behavior.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// The `PdfEditToolBehavior` interface is the tool-logic test surface: rather
+/// than pumping a `PdfViewer` and simulating raw pointer streams, these feed a
+/// behaviour a `PdfEditingController` (and, for the commit hooks, page-space
+/// geometry) and assert what it reports and emits.
+void main() {
+  group('registry', () {
+    test('every PdfEditTool has exactly one behaviour, keyed by itself', () {
+      for (final tool in PdfEditTool.values) {
+        final behavior = PdfEditToolBehavior.of(tool);
+        expect(behavior.tool, tool, reason: '$tool maps to a mismatched row');
+      }
+    });
+
+    test('maybeOf is null for no armed tool', () {
+      expect(PdfEditToolBehavior.maybeOf(null), isNull);
+      expect(PdfEditToolBehavior.maybeOf(PdfEditTool.ink), isNotNull);
+    });
+  });
+
+  group('classification', () {
+    Set<PdfEditTool> toolsWhere(bool Function(PdfEditToolBehavior) test) => {
+          for (final tool in PdfEditTool.values)
+            if (test(PdfEditToolBehavior.of(tool))) tool,
+        };
+
+    test('ink family (was _inkTool)', () {
+      expect(toolsWhere((b) => b.isInk),
+          {PdfEditTool.ink, PdfEditTool.highlight});
+    });
+
+    test('draw tools drive the raw pointer (was _drawTool)', () {
+      expect(toolsWhere((b) => b.isDraw),
+          {PdfEditTool.ink, PdfEditTool.highlight, PdfEditTool.eraser});
+    });
+
+    test('ink buffering (was _buffersInk)', () {
+      expect(toolsWhere((b) => b.buffersInk),
+          {PdfEditTool.ink, PdfEditTool.highlight});
+    });
+
+    test('poly tools (was _polyTool - the cloud is deliberately excluded)', () {
+      expect(toolsWhere((b) => b.isPoly), {
+        PdfEditTool.polyline,
+        PdfEditTool.polygon,
+        PdfEditTool.measurePerimeter,
+        PdfEditTool.measureArea,
+        PdfEditTool.measureAngle,
+        PdfEditTool.measureArc,
+        PdfEditTool.measureVolume,
+      });
+    });
+
+    test('line-drag tools (was _lineDragTool)', () {
+      expect(toolsWhere((b) => b.isLineDrag), {
+        PdfEditTool.line,
+        PdfEditTool.arrow,
+        PdfEditTool.measureDistance,
+        PdfEditTool.measureSlope,
+        PdfEditTool.calibrate,
+      });
+    });
+
+    test('measurement kinds (was _measureKind)', () {
+      expect(PdfEditToolBehavior.of(PdfEditTool.measureDistance).measureKind,
+          PdfMeasurementKind.distance);
+      expect(PdfEditToolBehavior.of(PdfEditTool.measureVolume).measureKind,
+          PdfMeasurementKind.volume);
+      expect(PdfEditToolBehavior.of(PdfEditTool.rectangle).measureKind, isNull);
+      expect(PdfEditToolBehavior.of(PdfEditTool.polygon).measureKind, isNull);
+    });
+
+    test('fixed poly arity - only angle and arc auto-finish (was '
+        '_fixedPolyCount)', () {
+      expect(toolsWhere((b) => b.fixedPolyCount != null),
+          {PdfEditTool.measureAngle, PdfEditTool.measureArc});
+      expect(PdfEditToolBehavior.of(PdfEditTool.measureAngle).fixedPolyCount, 3);
+    });
+  });
+
+  group('persisted style scope (was the controller tables)', () {
+    test('scope keys - styled tools name a slot, the rest are null', () {
+      expect(PdfEditToolBehavior.of(PdfEditTool.ink).styleScopeKey, 'ink');
+      expect(PdfEditToolBehavior.of(PdfEditTool.highlight).styleScopeKey,
+          'freehandHighlight');
+      expect(PdfEditToolBehavior.of(PdfEditTool.rectangle).styleScopeKey,
+          'rectangle');
+      expect(
+          PdfEditToolBehavior.of(PdfEditTool.measureArc).styleScopeKey,
+          'measureArc');
+      for (final tool in [
+        PdfEditTool.select,
+        PdfEditTool.content,
+        PdfEditTool.form,
+        PdfEditTool.redact,
+        PdfEditTool.signature,
+        PdfEditTool.image,
+        PdfEditTool.snapshot,
+        PdfEditTool.calibrate,
+      ]) {
+        expect(PdfEditToolBehavior.of(tool).styleScopeKey, isNull,
+            reason: '$tool creates nothing styled');
+      }
+    });
+
+    test('scope fields drive toolUsesColor', () {
+      expect(PdfEditToolBehavior.of(PdfEditTool.rectangle).usesColor, isTrue);
+      expect(PdfEditToolBehavior.of(PdfEditTool.eraser).usesColor, isFalse);
+      expect(PdfEditToolBehavior.of(PdfEditTool.rectangle).styleScopeFields,
+          contains('cornerRadius'));
+      expect(PdfEditToolBehavior.of(PdfEditTool.ellipse).styleScopeFields,
+          isNot(contains('cornerRadius')));
+    });
+
+    test('the freehand highlighter seeds its broad translucent yellow', () {
+      expect(PdfEditToolBehavior.of(PdfEditTool.highlight).styleScopeDefaults, {
+        'color': 0xFFFFD100,
+        'strokeWidth': 12.0,
+        'opacity': 0.45,
+      });
+      expect(PdfEditToolBehavior.of(PdfEditTool.ink).styleScopeDefaults, isEmpty);
+    });
+
+    test('the controller reads the behaviour for toolUsesColor', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      editing.tool = PdfEditTool.rectangle;
+      expect(editing.toolUsesColor, isTrue);
+      editing.tool = PdfEditTool.eraser;
+      expect(editing.toolUsesColor, isFalse);
+    });
+  });
+
+  group('tune-popup style fields (was the toolbar mirror)', () {
+    test('a rectangle offers a corner-radius slider, not a font', () {
+      final fields = PdfEditToolBehavior.of(PdfEditTool.rectangle).styleFields;
+      expect(fields.cornerRadius, isTrue);
+      expect(fields.shapeFill, isTrue);
+      expect(fields.font, isFalse);
+    });
+
+    test('only the line and polyline shapes carry endings', () {
+      expect(PdfEditToolBehavior.of(PdfEditTool.line).styleFields.lineEndings,
+          isTrue);
+      expect(
+          PdfEditToolBehavior.of(PdfEditTool.polyline).styleFields.lineEndings,
+          isTrue);
+      expect(PdfEditToolBehavior.of(PdfEditTool.arrow).styleFields.lineEndings,
+          isFalse);
+      expect(PdfEditToolBehavior.of(PdfEditTool.polygon).styleFields.lineEndings,
+          isFalse);
+    });
+
+    test('the eraser popup replaces everything with its radius', () {
+      final fields = PdfEditToolBehavior.of(PdfEditTool.eraser).styleFields;
+      expect(fields.eraser, isTrue);
+      expect(fields.stroke, isFalse);
+      expect(fields.opacity, isFalse);
+    });
+
+    test('select and the edit tools expose no tune popup', () {
+      for (final tool in [
+        PdfEditTool.select,
+        PdfEditTool.content,
+        PdfEditTool.form,
+        PdfEditTool.redact,
+        PdfEditTool.snapshot,
+      ]) {
+        expect(PdfEditToolBehavior.of(tool).styleFields.isEmpty, isTrue,
+            reason: '$tool should carry no tune controls');
+      }
+    });
+  });
+
+  group('commit hooks emit annotations', () {
+    PdfEditingController controller() {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      return editing;
+    }
+
+    test('the shape family stamps a Square / Circle / Polygon', () {
+      for (final (tool, subtype) in [
+        (PdfEditTool.rectangle, 'Square'),
+        (PdfEditTool.ellipse, 'Circle'),
+        (PdfEditTool.cloudPolygon, 'Polygon'),
+      ]) {
+        final editing = controller();
+        final consumed = PdfEditToolBehavior.of(tool).commitShapeRect(
+            editing, 0, PdfRect(100, 100, 300, 260));
+        expect(consumed, isTrue, reason: '$tool should consume the drag');
+        expect(editing.document.page(0).annotations.single.subtype, subtype);
+      }
+    });
+
+    test('the line family stamps a /Line, arrowed only for the arrow tool', () {
+      final line = controller();
+      PdfEditToolBehavior.of(PdfEditTool.line)
+          .commitLineDrag(line, 0, (100, 100), (300, 100));
+      final lineAnnot = line.document.page(0).annotations.single;
+      expect(lineAnnot.subtype, 'Line');
+      expect(pdfLineEndings(lineAnnot)?.$2, isNot(PdfLineEnding.closedArrow));
+
+      final arrow = controller();
+      PdfEditToolBehavior.of(PdfEditTool.arrow)
+          .commitLineDrag(arrow, 0, (100, 100), (300, 100));
+      final arrowAnnot = arrow.document.page(0).annotations.single;
+      expect(arrowAnnot.subtype, 'Line');
+      expect(pdfLineEndings(arrowAnnot)?.$2, PdfLineEnding.closedArrow);
+    });
+
+    test('the poly family stamps a /PolyLine or /Polygon', () {
+      final poly = controller();
+      PdfEditToolBehavior.of(PdfEditTool.polyline)
+          .commitPoly(poly, 0, const [(100, 100), (200, 140), (300, 100)]);
+      expect(poly.document.page(0).annotations.single.subtype, 'PolyLine');
+
+      final closed = controller();
+      PdfEditToolBehavior.of(PdfEditTool.polygon)
+          .commitPoly(closed, 0, const [(100, 100), (200, 140), (300, 100)]);
+      expect(closed.document.page(0).annotations.single.subtype, 'Polygon');
+    });
+
+    test('a line-shaped measurement needs a scale and stamps a /Line', () {
+      final editing = controller();
+      editing.measurementScale =
+          PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
+      final consumed = PdfEditToolBehavior.of(PdfEditTool.measureDistance)
+          .commitLineDrag(editing, 0, (100, 100), (316, 100));
+      expect(consumed, isTrue);
+      final annot = editing.document.page(0).annotations.single;
+      expect(annot.subtype, 'Line');
+      expect(annot.measurementText, '60 ft');
+    });
+
+    test('a poly-shaped measurement stamps a takeoff', () {
+      final editing = controller();
+      editing.measurementScale =
+          PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
+      PdfEditToolBehavior.of(PdfEditTool.measurePerimeter)
+          .commitPoly(editing, 0, const [(100, 100), (300, 100), (300, 260)]);
+      final annot = editing.document.page(0).annotations.single;
+      expect(annot.subtype, 'PolyLine');
+      expect(annot.measure, isNotNull);
+    });
+
+    test('the volume tool declines the synchronous commit (it needs a depth)',
+        () {
+      final editing = controller();
+      editing.measurementScale =
+          PdfMeasurementScale(unitsPerPoint: 20 / 72, unitLabel: 'ft');
+      final consumed = PdfEditToolBehavior.of(PdfEditTool.measureVolume)
+          .commitPoly(editing, 0, const [(100, 100), (300, 100), (300, 260)]);
+      expect(consumed, isFalse);
+      expect(editing.document.page(0).annotations, isEmpty);
+    });
+
+    test('metadata-only tools do not commit through the hooks', () {
+      final editing = controller();
+      final note = PdfEditToolBehavior.of(PdfEditTool.note);
+      expect(note.commitShapeRect(editing, 0, PdfRect(0, 0, 10, 10)), isFalse);
+      expect(note.commitLineDrag(editing, 0, (0, 0), (1, 1)), isFalse);
+      expect(note.commitPoly(editing, 0, const [(0, 0), (1, 1)]), isFalse);
+      expect(editing.document.page(0).annotations, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Closes #311.

## Summary

`PdfEditTool` is a 30-value enum whose behaviour was smeared across four to five independent `switch (tool)` copies — adding a tool meant editing every one:

- the overlay's classification getters (`_inkTool`, `_drawTool`, `_polyTool`, `_lineDragTool`, `_measureKind`, `_fixedPolyCount`) and its per-phase commit switches (`_commitRect`, `_commitLineDrag`, `_finishPolyPath`);
- the controller's persisted-style tables (`_styleScopeKey`, `_styleScopeFields`, `_styleScopeDefaults`, `_buffersInk`);
- the toolbar's per-tool tune-popup capability (`_StyleFields` + the per-tool booleans in `_groupStyleFields`).

This adds **`PdfEditToolBehavior`** (`editing_tool_behavior.dart`) — one authoritative descriptor per tool, mirroring `PdfAnnotationBehavior` (pdf_document) on the tool side. It owns:

- **classification** the gesture phases dispatch on (`isInk`, `isDraw`, `buffersInk`, `isPoly`, `closesPoly`, `isLineDrag`, `measureKind`, `fixedPolyCount`);
- the **persisted style scope** the controller remembers (`styleScopeKey`, `styleScopeFields`, `styleScopeDefaults`, `usesColor`);
- the **tune-popup controls** the toolbar shows (`styleFields`, a shared `PdfToolStyleFields` value — the old `_StyleFields`);
- **commit hooks** for tools whose placement is a single document mutation (`commitShapeRect`, `commitLineDrag`, `commitPoly`).

One adapter per tool is registered in `_behaviors`; look one up with `PdfEditToolBehavior.of` / `.maybeOf`. The three consumers (controller, overlay, toolbar) now read from it, and the duplicated tables/booleans are deleted (net −274 lines of the old copies).

**The interface is the test surface**: `editing_tool_behavior_test.dart` (24 tests) feeds a behaviour a `PdfEditingController` (and page-space geometry for the commit hooks) and asserts what it reports/emits — no pumped `PdfViewer`, no synthetic pointer streams.

### Scope notes

Select-mode manipulation (move/resize/rotate/vertex/marquee), raw-pointer palm rejection, viewport pan, autoscroll, and the afterimage/preview bookkeeping stay in the overlay `State` — they are gesture infrastructure and render concerns, not per-tool identity. The cloud tool is intentionally *not* an `isPoly` behaviour (its drag rubber-bands a rectangle; only its click path builds a footprint), and the volume tool's `commitPoly` declines the synchronous commit because it must prompt for a depth first — both preserved. Insert-strip tools keep their shared tune popup exactly as before. See `doc/dev-log/2026-07-17-tool-behavior-interface.md`.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Refactor / cleanup

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (no issues)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (1628 passed, 0 failed; new behavior suite 24/24)

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Behaviour is intended to be identical — this is a pure consolidation. The one place to double-check is `_groupStyleFields`: the armed-tool case now returns `behavior.styleFields`, while the no-armed-tool fallbacks (Select/Markup strips, a Draw strip over a selection, a group opened before its default tool arms) keep the group's resting controls inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qAfoV1dmnTHsGeNQUyrDr

---
_Generated by [Claude Code](https://claude.ai/code/session_019qAfoV1dmnTHsGeNQUyrDr)_