### PR TITLE
perf(#283): reproduce the web tab-memory measurement and confirm it's bounded

### DIFF
--- a/app/tool/perf/README.md
+++ b/app/tool/perf/README.md
@@ -51,6 +51,20 @@ node report.mjs 20                # last 20 runs' trend
 | `PERF_VERBOSE` | `false` | echo every browser console line |
 | `PERF_PORT` / `PERF_CHROME` | `8099` / system Chrome | server port / Chrome path |
 
+### Tab-memory probe
+
+The summary's `tab memory` line comes from
+`performance.measureUserAgentSpecificMemory()`, which counts CanvasKit's WASM
+heap (issue #283). It needs cross-origin isolation (the server sends COOP/COEP)
+**and** the browser-process PerformanceManager, which the old headless shell
+does not run — so `PERF_CHROME` must point at a **full** Chrome/Chromium binary,
+not a `*_headless_shell` one, and the driver uses new headless. `build.sh`
+builds with `--no-web-resources-cdn` so CanvasKit is served locally (the CDN
+fetch has no network in CI and is blocked by the credentialless COEP anyway).
+
+No representative document handy? `packages/pdf_cos/tool/gen_image_pdf.dart`
+generates an image-heavy multi-page PDF with the same decoded-RGBA footprint.
+
 ## Verdict
 
 `✓ PASS` means no harness/page errors, frames captured, pages visited. `◐ PASS

--- a/app/tool/perf/build.sh
+++ b/app/tool/perf/build.sh
@@ -18,9 +18,14 @@ echo "==> Building the render worker (web)"
 $DART run dart_pdf_editor:build_web_worker
 
 echo "==> flutter build web $MODE (harness entrypoint, PDF_PERF_LOG=true)"
+# --no-web-resources-cdn bundles CanvasKit into build/web/canvaskit instead of
+# loading it from gstatic.com. The driver serves the bundle offline behind
+# COOP/COEP (cross-origin isolation, which the CDN fetch fails under
+# credentialless COEP anyway), so a headless/CI run has no network for the CDN.
 $FLUTTER build web $MODE \
   --target tool/perf/perf_harness.dart \
   --dart-define=PDF_PERF_LOG=true \
+  --no-web-resources-cdn \
   "$@"
 
 echo "==> Done. Harness bundle in app/build/web; worker beside index.html."

--- a/app/tool/perf/driver.mjs
+++ b/app/tool/perf/driver.mjs
@@ -236,7 +236,9 @@ const MEMORY_PROBE = `(async () => {
         .slice(0, 6);
     } catch (e) { out.measureError = String(e); }
   } else {
-    out.measureError = 'measureUserAgentSpecificMemory unavailable (not cross-origin isolated?)';
+    out.measureError = 'measureUserAgentSpecificMemory unavailable '
+      + '(not cross-origin isolated, or an old-headless / headless_shell binary '
+      + 'without the PerformanceManager - use a full-browser binary + new headless)';
   }
   return out;
 })()`;
@@ -273,9 +275,19 @@ async function main() {
 
   const browser = await puppeteer.launch({
     executablePath: CHROME,
-    headless: HEADLESS ? 'shell' : false,
+    // New headless, NOT the old `chrome --headless=old` / headless_shell:
+    // performance.measureUserAgentSpecificMemory() - the whole point of the
+    // memory probe below - is backed by the browser-process PerformanceManager,
+    // which the headless shell doesn't run, so there the call throws
+    // "not available" even when the page is cross-origin isolated. New headless
+    // (a full Chrome/Chromium binary) has it. Point PERF_CHROME at a full
+    // browser binary, not a *_headless_shell one, for the memory numbers.
+    headless: HEADLESS ? true : false,
     args: ['--no-sandbox', '--disable-dev-shm-usage', '--window-size=1400,1000',
-      '--js-flags=--expose-gc'],
+      '--js-flags=--expose-gc',
+      // A locale-less headless host makes Flutter's intl throw "Incorrect
+      // locale information provided" at startup; pin one so the app boots.
+      '--lang=en-US', '--accept-lang=en-US'],
     defaultViewport: { width: 1400, height: 1000 },
   });
 

--- a/app/tool/perf/driver.mjs
+++ b/app/tool/perf/driver.mjs
@@ -282,7 +282,7 @@ async function main() {
     // "not available" even when the page is cross-origin isolated. New headless
     // (a full Chrome/Chromium binary) has it. Point PERF_CHROME at a full
     // browser binary, not a *_headless_shell one, for the memory numbers.
-    headless: HEADLESS ? true : false,
+    headless: HEADLESS,
     args: ['--no-sandbox', '--disable-dev-shm-usage', '--window-size=1400,1000',
       '--js-flags=--expose-gc',
       // A locale-less headless host makes Flutter's intl throw "Incorrect

--- a/doc/dev-log/2026-07-17-web-memory-283-reproduction.md
+++ b/doc/dev-log/2026-07-17-web-memory-283-reproduction.md
@@ -1,0 +1,129 @@
+# 2026-07-17 — Reproducing the web tab-memory growth (#283)
+
+Issue #283 (split from #281) reported that a web tab grows ~20 MB per page
+scrolled and never releases it, running to ~2.3 GB over a 62-page image-heavy
+document — with the decoded-image cache flat at its budget the whole time, so
+the cache is not the source. It asked whether per-page retention (retained
+scenes / `ui.Picture`s, worker transcripts, anything keyed by page index)
+survives the page scrolling out of view and a GC.
+
+This session set out to **reproduce the measurement on the current codebase**
+(which already carries the #286 render-record cap and the #305 page-object
+caps) and characterise the growth, before proposing any further change.
+
+## What was already bounded (code audit)
+
+Every per-page structure the issue named is bounded, and page state is
+disposed when it scrolls out of the `ListView` build window:
+
+- `PdfPagePreviewCache` — 300 previews + a 32 MB full-raster pixel budget, LRU,
+  disposes evicted images (`preview_cache.dart`).
+- `PdfWorkerTranscriptCache` / the worker's `_BinCommandCache` — ≤4 / ≤2
+  entries plus a retained-command-weight cap, per worker
+  (`render_worker_transcript_cache.dart`, `render_worker_isolate.dart`).
+- `PdfCachingRenderWorker._cache` — 64 entries / 96 MB, byte- and count-bounded
+  (`render_worker.dart`).
+- `_textCache` / `_annotCache` / `_visibleAnnotCache` / `_fieldRectCache` —
+  `PdfPageObjectCache` (LRU, cap 128) since #305 (`pdf_viewer.dart`).
+- `PdfImageCache` — byte-budgeted, clone-on-take / dispose-on-evict.
+- `_PdfPageViewState.dispose()` disposes `_scene` (the retained scene **and its
+  decoded images**), `_image`, `_detailImage`, `_preview`, `_slugPicture`, and
+  cancels the page's queued worker / scheduler work (`pdf_page_view.dart`). The
+  viewer's `ListView` has **no** keep-alive requesters (nothing in
+  `lib/src/` uses `AutomaticKeepAliveClientMixin` / `wantKeepAlive` /
+  `KeepAliveNotification`), so a page past the 250 px cache extent is genuinely
+  unmounted and disposed — retained scenes/pictures *are* dropped when a page
+  leaves the viewport, including on web.
+
+So the retained scenes the issue asks about are released; the question is
+whether the *measured* growth is a Dart object leak or CanvasKit's WASM
+linear-memory high-water mark (which never returns freed pages to the OS on
+web — already noted in `performance_policy.dart`).
+
+## Reproduction harness
+
+The corpus is git-ignored and absent in a fresh checkout, so a self-contained
+generator now builds a representative image-heavy document:
+
+`packages/pdf_cos/tool/gen_image_pdf.dart` — writes an N-page PDF (via the
+from-scratch `CosDocumentBuilder`) where each page draws one full-page RGB
+image XObject, plus optional vector rectangles. The images differ per page
+(the decoded-image cache can't dedup them) but are highly compressible (small
+file, full decoded RGBA footprint), matching #283's doc shape (24 MB file,
+~436 MB decoded). Defaults: 62 pages, 1240×1650 (~8.2 MB RGBA/page, ~507 MB
+total).
+
+```sh
+# image-only pages
+fvm dart run packages/pdf_cos/tool/gen_image_pdf.dart perf_images.pdf 62
+# image + 4000 vector rects/page (print/CAD-like retained-scene weight)
+fvm dart run packages/pdf_cos/tool/gen_image_pdf.dart perf_rich.pdf 62 1240 1650 4000
+```
+
+### Making `app/tool/perf/driver.mjs` measure memory headless
+
+`performance.measureUserAgentSpecificMemory()` (the only probe that counts
+CanvasKit's WASM heap) needs cross-origin isolation *and* the browser-process
+PerformanceManager. Getting it to run headless on Linux CI took three fixes,
+now folded into the tooling:
+
+1. **New headless, not the shell.** `headless_shell` (old `--headless`) has no
+   PerformanceManager, so the call throws `SecurityError: … is not available`
+   even when `crossOriginIsolated === true`. `driver.mjs` now launches new
+   headless (`headless: true`) — point `PERF_CHROME` at a **full** browser
+   binary, not a `*_headless_shell` one.
+2. **Local CanvasKit.** `build.sh` now passes `--no-web-resources-cdn`, so
+   CanvasKit is bundled into `build/web/canvaskit` instead of fetched from
+   gstatic.com — which a headless/offline run can't reach, and which the
+   `credentialless` COEP the driver sends would block anyway.
+3. **Locale.** A locale-less headless host makes Flutter's intl throw
+   "Incorrect locale information provided" at boot; `driver.mjs` now passes
+   `--lang=en-US --accept-lang=en-US`.
+
+## Measured results (current code, 64 MB image-cache budget, fast pass off)
+
+Chromium 1194 (Playwright build), new headless, `--expose-gc` forced GC before
+each sample.
+
+Image-only doc (1 image op/page):
+
+| pages rendered | agent memory | image cache |
+|---|---|---|
+| 9  | 351 MB | 57 MB |
+| 20 | 358 MB | 57 MB |
+| 25 (of 62) | 371 MB | 59 MB |
+
+≈ **0.4 MB/page** — essentially flat.
+
+Image + 4000-vector-rects/page doc (print/CAD-like), all pages fully rendered:
+
+| pages rendered | agent memory | image cache |
+|---|---|---|
+| 10 | 420 MB | 58 MB |
+| 20 | 441 MB | 58 MB |
+| 62 | 569 MB | 57 MB |
+
+≈ **2.9 MB/page**; the image cache stays pinned at its budget throughout.
+
+For contrast, #283's pre-cap numbers were 1122 MB (10 pages) → 2286 MB
+(62 pages), ≈ **20 MB/page**.
+
+## Conclusion
+
+On the current codebase the unbounded-in-page-count Dart retention #283
+measured is gone — the #286 and #305 caps closed it. Tab memory now tracks
+per-page **content** weight, not page count: a trivial page costs ~0.4 MB of
+creep, a vector-rich page ~2.9 MB, and the image cache never exceeds its
+budget. That residual creep is CanvasKit's WASM high-water mark (peak
+simultaneous decode + `ui.Picture`/scene + raster allocation, plus allocator
+fragmentation that never shrinks back on web), scaling with render complexity —
+consistent with the code audit above, where every per-page cache is bounded and
+the page State + retained scene + rasters are disposed on scroll-out.
+
+A real document's pages are heavier than these synthetic ones, so it will creep
+more than 2.9 MB/page — but the growth is bounded per-page-content and no longer
+unbounded per-page-count. Lowering the plateau further is a peak-allocation /
+WASM-fragmentation problem (the lever the existing `imagePixelRatioCap` and
+preview-window tiers already pull), not an un-freed Dart object; it needs the
+real target document to tune against, which the harness above now makes
+reproducible in a headless/CI run.

--- a/packages/pdf_cos/tool/gen_image_pdf.dart
+++ b/packages/pdf_cos/tool/gen_image_pdf.dart
@@ -26,6 +26,9 @@ void main(List<String> args) {
 
   final builder = CosDocumentBuilder();
   final zlib = ZLibCodec(level: 6);
+  // Reused across pages: every page overwrites all imgW*imgH*3 bytes, so one
+  // buffer avoids reallocating ~imgW*imgH*3 bytes per page.
+  final rgb = Uint8List(imgW * imgH * 3);
 
   // Object numbers are assigned in registration order starting at 1:
   //   1 = catalog, 2 = pages tree, then per page i (0-based), three objects
@@ -91,7 +94,6 @@ void main(List<String> args) {
     // file stays small - the decode still expands to the full RGBA footprint.
     // This matches the real doc's shape (24 MB file, 436 MB decoded RGBA):
     // it's the decoded size, not the file size, that drives the tab memory.
-    final rgb = Uint8List(imgW * imgH * 3);
     final phase = i * 37;
     var p = 0;
     for (var y = 0; y < imgH; y++) {

--- a/packages/pdf_cos/tool/gen_image_pdf.dart
+++ b/packages/pdf_cos/tool/gen_image_pdf.dart
@@ -1,0 +1,145 @@
+// Generates a synthetic image-heavy multi-page PDF for the web memory perf
+// harness (issue #283). Each page draws one full-page RGB image XObject; the
+// images differ per page so the decoded-image cache can't dedup them, giving a
+// per-page decoded-RGBA footprint like a scanned/photo document.
+//
+//   fvm dart run packages/pdf_cos/tool/gen_image_pdf.dart <out.pdf> [pages] [w] [h]
+//
+// Defaults: 62 pages, 1240x1650 px images (~8.2 MB decoded RGBA each), so the
+// whole document decodes to ~500 MB of RGBA - the shape issue #283 measured.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+
+void main(List<String> args) {
+  final outPath = args.isNotEmpty ? args[0] : 'perf_images.pdf';
+  final pageCount = args.length > 1 ? int.parse(args[1]) : 62;
+  final imgW = args.length > 2 ? int.parse(args[2]) : 1240;
+  final imgH = args.length > 3 ? int.parse(args[3]) : 1650;
+  // Vector rectangles drawn per page on top of the image, so each page's
+  // retained scene / ui.Picture carries print/CAD-like weight.
+  final richOps = args.length > 4 ? int.parse(args[4]) : 4000;
+
+  const pageW = 612.0; // US Letter, points
+  const pageH = 792.0;
+
+  final builder = CosDocumentBuilder();
+  final zlib = ZLibCodec(level: 6);
+
+  // Object numbers are assigned in registration order starting at 1:
+  //   1 = catalog, 2 = pages tree, then per page i (0-based), three objects
+  //   in this add() order: content = 3+i*3, image = 3+i*3+1, page = 3+i*3+2.
+  const catalogNum = 1;
+  const treeNum = 2;
+  final treeRef = const CosReference(treeNum, 0);
+
+  final pageRefs = [
+    for (var i = 0; i < pageCount; i++) CosReference(3 + i * 3 + 2, 0),
+  ];
+
+  builder.add(CosDictionary({
+    'Type': const CosName('Catalog'),
+    'Pages': treeRef,
+  })); // obj 1
+  builder.add(CosDictionary({
+    'Type': const CosName('Pages'),
+    'Kids': CosArray(pageRefs),
+    'Count': CosInteger(pageCount),
+  })); // obj 2
+
+  for (var i = 0; i < pageCount; i++) {
+    final contentRef = CosReference(3 + i * 3, 0);
+    final imageRef = CosReference(3 + i * 3 + 1, 0);
+
+    // 1) content stream (obj 3+i*3): the full-page image plus a few thousand
+    // vector ops, so each page's retained scene / ui.Picture carries real
+    // weight (like a print/CAD page), not a single Do. A small LCG seeded by
+    // the page index places the shapes so every page differs.
+    final sb = StringBuffer('q\n$pageW 0 0 $pageH 0 0 cm\n/Im0 Do\nQ\n');
+    var seed = (i + 1) * 2654435761 & 0x7fffffff;
+    int next() {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed;
+    }
+
+    for (var k = 0; k < richOps; k++) {
+      final x = (next() % 1000000) / 1000000 * pageW;
+      final y = (next() % 1000000) / 1000000 * pageH;
+      final w = (next() % 40) + 4;
+      final h = (next() % 40) + 4;
+      final r = (next() % 256) / 255;
+      final g = (next() % 256) / 255;
+      final b = (next() % 256) / 255;
+      sb.write('${r.toStringAsFixed(3)} ${g.toStringAsFixed(3)} '
+          '${b.toStringAsFixed(3)} rg\n'
+          '${x.toStringAsFixed(2)} ${y.toStringAsFixed(2)} $w $h re\nf\n');
+    }
+    final contentRaw = Uint8List.fromList(sb.toString().codeUnits);
+    final contentBytes = Uint8List.fromList(zlib.encode(contentRaw));
+    builder.add(CosStream(
+      CosDictionary({
+        'Length': CosInteger(contentBytes.length),
+        'Filter': const CosName('FlateDecode'),
+      }),
+      contentBytes,
+    ));
+
+    // 2) image xobject (obj 3+i*3+1): distinct pixels per page so the
+    // decoded-image cache can't dedup, but HIGHLY compressible (coarse
+    // horizontal bands, constant within each band and across a row) so the
+    // file stays small - the decode still expands to the full RGBA footprint.
+    // This matches the real doc's shape (24 MB file, 436 MB decoded RGBA):
+    // it's the decoded size, not the file size, that drives the tab memory.
+    final rgb = Uint8List(imgW * imgH * 3);
+    final phase = i * 37;
+    var p = 0;
+    for (var y = 0; y < imgH; y++) {
+      final band = (y ~/ 24);
+      final r = (band + phase) & 0xFF;
+      final g = (band * 2 + phase * 2) & 0xFF;
+      final b = (band * 3 + phase * 3) & 0xFF;
+      for (var x = 0; x < imgW; x++) {
+        rgb[p++] = r;
+        rgb[p++] = g;
+        rgb[p++] = b;
+      }
+    }
+    final compressed = Uint8List.fromList(zlib.encode(rgb));
+    builder.add(CosStream(
+      CosDictionary({
+        'Type': const CosName('XObject'),
+        'Subtype': const CosName('Image'),
+        'Width': CosInteger(imgW),
+        'Height': CosInteger(imgH),
+        'ColorSpace': const CosName('DeviceRGB'),
+        'BitsPerComponent': CosInteger(8),
+        'Filter': const CosName('FlateDecode'),
+        'Length': CosInteger(compressed.length),
+      }),
+      compressed,
+    ));
+
+    // 3) page dict (obj 3+i*3+2)
+    builder.add(CosDictionary({
+      'Type': const CosName('Page'),
+      'Parent': treeRef,
+      'MediaBox': CosArray([
+        CosInteger(0),
+        CosInteger(0),
+        CosReal(pageW),
+        CosReal(pageH),
+      ]),
+      'Resources': CosDictionary({
+        'XObject': CosDictionary({'Im0': imageRef}),
+      }),
+      'Contents': contentRef,
+    }));
+  }
+
+  final bytes = builder.build(root: const CosReference(catalogNum, 0));
+  File(outPath).writeAsBytesSync(bytes);
+  stdout.writeln('wrote $outPath: ${bytes.length} bytes, $pageCount pages, '
+      'image ${imgW}x$imgH (~${(imgW * imgH * 4 / 1e6).toStringAsFixed(1)} MB '
+      'RGBA/page, ~${(imgW * imgH * 4 * pageCount / 1e6).toStringAsFixed(0)} MB total)');
+}


### PR DESCRIPTION
## Summary

Issue #283 reported a web tab growing ~20 MB per page scrolled and never
releasing it (~2.3 GB over 62 image-heavy pages), unbounded in page count. This
reproduces the measurement **on the current codebase** — which already carries
the #286 render-record cap and the #305 page-object caps — characterises the
growth, and lands the tooling to make the measurement repeatable headless.

Result: tab memory now tracks per-page **content** weight, not page count:
≈ 0.4 MB/page for trivial pages, ≈ 2.9 MB/page for vector-rich pages, with the
decoded-image cache pinned at its budget throughout — an order of magnitude
flatter than the pre-cap ≈ 20 MB/page. The unbounded-in-page-count Dart
retention #283 measured is gone (a code audit confirms every per-page cache is
bounded and page state + retained scenes + rasters are disposed on scroll-out,
with no keep-alive holding pages mounted). The residual creep is CanvasKit's
WASM high-water mark, which never returns freed pages to the OS on web.

Changes:
- `packages/pdf_cos/tool/gen_image_pdf.dart` — generates a representative
  image-heavy N-page PDF (via `CosDocumentBuilder`) with a real decoded-RGBA
  footprint but a small file, so the measurement reproduces without the
  git-ignored corpus.
- `app/tool/perf/build.sh` — build with `--no-web-resources-cdn` so CanvasKit is
  bundled locally (a headless/CI run has no network for gstatic, and the
  `credentialless` COEP the driver sends blocks the CDN fetch anyway).
- `app/tool/perf/driver.mjs` — launch **new** headless (not the headless shell,
  which lacks the PerformanceManager `measureUserAgentSpecificMemory()` needs —
  it threw "not available" even when cross-origin isolated) and pin a locale so
  Flutter's intl boots on a locale-less host.
- `doc/dev-log/2026-07-17-web-memory-283-reproduction.md`, `app/tool/perf/README.md`
  — the reproduction method, measured curves, and conclusion.

## Affected packages

- [x] `pdf_cos` (new `tool/` script only — no library change)
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (perf harness + dev-log)

## Change type

- [x] Performance change (investigation + reproduction tooling; no runtime code changed)
- [x] Documentation only (dev-log, README)

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean on the new tool)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [x] Real PDF corpus parse/render smoke test — the web perf harness itself
  (build + `driver.mjs`) was run end-to-end against the generated 62-page doc

No runtime library code changed (tooling + docs only), so the package unit
suites were not re-run; the change was validated by running the perf harness
build and the headless memory probe end-to-end.

## PDF fixtures and screenshots

Measured (current code, 64 MB image-cache budget, fast pass off, forced GC):

Image + 4000-vector-rects/page doc, all pages fully rendered:

| pages rendered | agent memory | image cache |
|---|---|---|
| 10 | 420 MB | 58 MB |
| 20 | 441 MB | 58 MB |
| 62 | 569 MB | 57 MB |

For contrast, #283's pre-cap numbers were 1122 MB (10) → 2286 MB (62), ≈ 20 MB/page.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory (the generator lives in `tool/`, not `lib/`).
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation (the generator uses `CosDocumentBuilder`).

## Notes for reviewers

- No runtime library code changed — this is investigation + reproduction tooling
  answering #283's open questions with measured evidence.
- The synthetic doc creeps less per page than a real print/CAD doc (its pages
  are lighter), but the shape is the point: growth is bounded per-page-**content**
  and no longer unbounded per-page-**count**, with the image cache flat at budget.
- Lowering the plateau further is a peak-allocation / WASM-fragmentation problem
  (the lever the existing `imagePixelRatioCap` / preview-window tiers already
  pull), not an un-freed Dart object; tuning it wants the real target document,
  which the harness now makes reproducible in a headless/CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VXXXF3TD3v9qwyYUBx24q

---
_Generated by [Claude Code](https://claude.ai/code/session_017VXXXF3TD3v9qwyYUBx24q)_