### PR TITLE
Show the real embedded face in the toolbar font chip

### DIFF
--- a/doc/dev-log/2026-07-17-toolbar-font-chip-embedded-face.md
+++ b/doc/dev-log/2026-07-17-toolbar-font-chip-embedded-face.md
@@ -1,0 +1,47 @@
+# Toolbar font chip vs. tune popup: show the real face
+
+## Symptom
+
+For a free-text box drawn in an embedded font (a bundled/custom/platform
+face, e.g. "Arial"), the toolbar's font chip read "Sans" while the tune
+(style) popup's font button read the box's real family. The two disagreed
+on what was, in fact, the same font.
+
+## Cause
+
+The two widgets resolved "current font" differently.
+
+- The tune popup's `PdfFontMenuButton` (`editing_toolbar.dart`, the `fields.font`
+  block) passes `currentFont: controller.selectedTextFont ?? captionStyle?.font
+  ?? controller.activeFont ?? controller.fontFamily`. `selectedTextFont`
+  recovers the *actual* embedded face from the box's appearance (see its
+  doc-comment in `editing_controller.dart`), so it shows "Arial".
+- `_FontChip` used `controller.selectedTextStyle?.font ?? controller.fontFamily`.
+  `selectedTextStyle` only parses a base-14 `PdfStandardFont` out of the flat
+  /DA, so any embedded face collapsed to its nearest standard family label
+  ("Sans"/"Serif"/"Mono").
+
+## Fix
+
+`_FontChip` now resolves the same way the popup does:
+
+```dart
+final font = controller.selectedTextFont ??
+    controller.activeFont ??
+    style?.font ??
+    controller.fontFamily;
+```
+
+and `_familyLabel` was widened from `PdfStandardFont` to `PdfTextFont`: an
+embedded font reports `familyName`, a custom `PdfTextFont` reports
+`resourceName`, and a standard family keeps the existing " B"/" I"/" BI"
+suffix. `PdfEmbeddedFont` was added to the pdf_document import list.
+
+The chip's size still comes from `selectedTextStyle?.size ??
+preferences.fontSize` - only the family label needed the real-face fix.
+
+## Test
+
+`editing_text_edit_test.dart` › "the toolbar font chip shows the embedded
+face, not Sans": embeds DejaVu into a box, selects it, and asserts the chip
+carries the embedded family name and not "Sans".

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:pdf_document/pdf_document.dart'
     show
         PdfAlignment,
+        PdfEmbeddedFont,
         PdfFieldType,
         PdfFormField,
         PdfLineEnding,
@@ -3940,7 +3941,12 @@ class _FontChip extends StatelessWidget {
   final String tooltip;
   final VoidCallback onTap;
 
-  static String _familyLabel(PdfStandardFont font) {
+  static String _familyLabel(PdfTextFont font) {
+    // an embedded/bundled/custom face shows its own name, not the base-14
+    // family "Sans" - matching the style popup's font button
+    if (font is! PdfStandardFont) {
+      return font is PdfEmbeddedFont ? font.familyName : font.resourceName;
+    }
     final base = font.family.label;
     final suffix = switch ((font.isBold, font.isItalic)) {
       (true, true) => ' BI',
@@ -3955,7 +3961,13 @@ class _FontChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final style = controller.selectedTextStyle;
-    final font = style?.font ?? controller.fontFamily;
+    // reflect the box's real face (an embedded/bundled font shows its own
+    // name) the same way the style popup's font button does, so the chip
+    // and popup never disagree
+    final font = controller.selectedTextFont ??
+        controller.activeFont ??
+        style?.font ??
+        controller.fontFamily;
     final size = (style?.size ?? controller.preferences.fontSize).round();
     return Tooltip(
       message: tooltip,

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -1052,6 +1052,46 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('the toolbar font chip shows the embedded face, not Sans',
+        (tester) async {
+      // regression: the chip parsed only the base-14 family from /DA and
+      // collapsed an embedded box to "Sans", while the tune popup's font
+      // button reported the real face - so the two disagreed
+      SharedPreferences.setMockInitialValues({});
+      final fontBytes =
+          File('../pdf_document/test/fonts/DejaVuSans.ttf').readAsBytesSync();
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      expect(editing.setCustomFont(fontBytes), isTrue);
+      final embedded = editing.activeFont as PdfEmbeddedFont;
+      editing.addFreeText(0, const PdfRect(100, 600, 360, 660), 'Hello');
+      editing.selectAnnotation(0, 0);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+          ),
+        ),
+      ));
+
+      final chip = find.byTooltip('Stroke, opacity, font');
+      await tester.scrollUntilVisible(chip, 100,
+          scrollable: find.byType(Scrollable).first);
+      // the chip carries the embedded family name, not the base-14 "Sans"
+      expect(
+          find.descendant(
+              of: chip, matching: find.text(embedded.familyName)),
+          findsOneWidget);
+      expect(find.descendant(of: chip, matching: find.text('Sans')),
+          findsNothing);
+      editing.activeFont = null;
+    });
+
     testWidgets('resizing an embedded-font box reflows instead of stretching',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);


### PR DESCRIPTION
## Summary

The toolbar's font chip and the tune (style) popup's font button disagreed on the current font. For a free-text box drawn in an embedded font (bundled/custom/platform, e.g. "Arial"), the chip showed "Sans" while the popup correctly showed the box's real face.

The chip resolved the font as `controller.selectedTextStyle?.font ?? controller.fontFamily`; `selectedTextStyle` only parses a base-14 `PdfStandardFont` out of the flat /DA, so any embedded face collapsed to its nearest standard family label. The popup used `controller.selectedTextFont`, which recovers the actual embedded face from the box's appearance.

This makes `_FontChip` resolve the current font the same way the popup does (`selectedTextFont ?? activeFont ?? selectedTextStyle.font ?? fontFamily`) and widens `_familyLabel` from `PdfStandardFont` to `PdfTextFont` — an embedded font reports its `familyName`, a custom `PdfTextFont` its `resourceName`, and a standard family keeps the existing " B"/" I"/" BI" suffix. The chip's size is unchanged.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (on the touched file — no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran `editing_text_edit_test.dart` + `editing_fonts_test.dart`, all pass)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: change is isolated to the editor toolbar's font-label resolution; the two exercised Flutter test files cover the font chip and font controls.

## PDF fixtures and screenshots

No new fixtures. The regression is covered programmatically by embedding DejaVu into a free-text box in the new test.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

New regression test: `editing_text_edit_test.dart` › "the toolbar font chip shows the embedded face, not Sans" — embeds DejaVu into a box, selects it, and asserts the chip carries the embedded family name and not "Sans". Session notes in `doc/dev-log/2026-07-17-toolbar-font-chip-embedded-face.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfY9ekwNoMXhDUSuNC9FK7)_