### PR TITLE
Re-wrap embedded-font text boxes in the resize drag preview

### DIFF
--- a/doc/dev-log/2026-07-17-textbox-resize-preview-embedded-wrap.md
+++ b/doc/dev-log/2026-07-17-textbox-resize-preview-embedded-wrap.md
@@ -1,0 +1,70 @@
+# Text-box resize preview: re-wrap embedded-font boxes too
+
+## Symptom
+
+Dragging a free-text (text box) resize handle **stretched the glyphs** in
+the live drag preview while the eventual commit re-wrapped the text at a
+constant font size. The preview disagreed with the result: the text
+appeared to scale, then snapped back to wrapped on release.
+
+## What was already there
+
+The overlay already previews the re-wrap for **base-14** free text:
+`_textResizeStyle` (editing_overlay.dart) suppresses the stretch ghost and
+floats a live Flutter `Text` widget (`_wrappedTextBox`) that wraps at the
+committed point size into the dragged rect, over a "lifted" clean page
+render (the page drawn without the box). The commit side already re-wraps
+both base-14 and embedded boxes: `PdfAnnotationBehavior.resizeBehavior`
+returns `reflowText` when the box has *either* a `standardTextFont` *or*
+`hasEmbeddedTextFont` (annotation_behavior.dart).
+
+The gap was preview-only: `_textResizeStyle` bailed to `null` (→ stretch
+ghost) whenever `standardTextFont == null`, i.e. for every embedded/bundled
+font box - the common case when the editor's active font is a loaded TTF.
+
+## Fix
+
+Reuse the inline editor's embedded-font preview machinery. That path
+(`_ensureEmbeddedFontPreview` / `_embeddedPreviewFamilies` /
+`_textEditUiFamily`) already registers an embedded font's outline bytes
+with the engine under a synthetic `pdfedit-<key>` family via
+`ui.loadFontFromList`, so Flutter can lay the real font out.
+
+- `_textResizeStyle` now falls back to the box's embedded face
+  (`standardTextFont ?? _resizeEmbeddedFontOf(annotation)`); its record's
+  `font` widened from `PdfStandardFont` to `PdfTextFont`. Same for
+  `_afterText` (the frozen post-commit afterimage) so an embedded resize
+  also freezes wrapped, not stretched.
+- `_wrappedTextBox` takes a `PdfTextFont`, kicks off
+  `_ensureEmbeddedFontPreview` for embedded faces, resolves its family
+  through `_textEditUiFamily` (embedded-aware) instead of the base-14-only
+  `_uiFamily` (removed - the inline editor's field now shares
+  `_textEditUiFamily` too), and gates bold/italic on `is PdfStandardFont`.
+- Until the async font load lands, `_textEditUiFamily` returns null and the
+  preview wraps in a fallback face - still wrapped, never stretched - then
+  rebuilds to the real face. Matches the inline editor's existing
+  fallback-face-while-loading behaviour.
+
+## Gotchas / why it's shaped this way
+
+- The embedded font program can't be recovered cheaply -
+  `PdfEmbeddedFont.fromFreeText` decodes the /FontFile program - and
+  `_textResizeStyle` is read every drag frame from `build`. So the parse is
+  cached in the overlay against the **annotation instance identity**
+  (`_resizeEmbeddedFontOf`), which is stable within a revision (page
+  `annotations` and `PdfAnnotation.behavior` are both cached), giving one
+  parse per selection rather than per frame.
+- The cache lives in the overlay, **not** on `PdfAnnotationBehavior`:
+  `annotation.dart` sits below `font_embedder.dart` in the layering
+  (font_embedder imports annotation, not vice-versa), so referencing
+  `PdfEmbeddedFont` from `annotation_behavior.dart` would introduce a
+  circular import. `hasEmbeddedTextFont` stays the cheap COS-only gate on
+  the behavior; the actual parse is the editor's job.
+
+## Test
+
+`editing_text_edit_test.dart` -> "resizing an embedded-font box previews
+the re-wrap too": loads DejaVuSans, adds a box, drags a handle, and asserts
+the `pdf-text-resize-preview` widget shows the real text at the committed
+size mid-drag (previously it found nothing and the stretch ghost took
+over). The existing base-14 preview and shape-stretch tests still pass.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -874,6 +874,13 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   ui.Picture? _resizeCleanPicture;
   Object? _resizeCleanFor;
 
+  // The embedded/bundled face a free-text resize preview re-wraps with,
+  // reparsed from the box's appearance program once per selection. Recovering
+  // the program isn't free, so it's cached against the annotation instance
+  // (stable within a revision) rather than decoded on every drag frame.
+  PdfEmbeddedFont? _resizeEmbeddedFont;
+  PdfAnnotation? _resizeEmbeddedFontFor;
+
   // Clean page for a selected annotation's original footprint. Move commits
   // clip this into the source rect so the annotation disappears without
   // covering underlying page content with a paper-colored box.
@@ -930,7 +937,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   ({
     Rect rect,
     String text,
-    PdfStandardFont font,
+    PdfTextFont font,
     double size,
     Color color,
     Color? fill,
@@ -1886,13 +1893,28 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     );
   }
 
+  /// The embedded (Type0-with-program) face a free-text [annotation] names in
+  /// its /DA, reparsed from its appearance program so a resize preview can
+  /// re-wrap in the real font. Cached against the annotation instance (stable
+  /// within a revision) because decoding the program isn't cheap. Null when
+  /// the box has no embedded program or it can't be recovered.
+  PdfEmbeddedFont? _resizeEmbeddedFontOf(PdfAnnotation annotation) {
+    if (!identical(annotation, _resizeEmbeddedFontFor)) {
+      _resizeEmbeddedFontFor = annotation;
+      _resizeEmbeddedFont = annotation.behavior.hasEmbeddedTextFont
+          ? PdfEmbeddedFont.fromFreeText(annotation)
+          : null;
+    }
+    return _resizeEmbeddedFont;
+  }
+
   /// The selection's text style when a resize commit will RE-WRAP it at
   /// a constant font size - the editor's FreeText regenerate path:
-  /// an /AP to replace and a /DA naming a standard font. Null means the
+  /// an /AP to replace and a /DA naming the box's font. Null means the
   /// commit stretches the appearance and the ghost previews faithfully.
   ({
     String text,
-    PdfStandardFont font,
+    PdfTextFont font,
     double size,
     Color color,
     Color? fill,
@@ -1906,10 +1928,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             PdfAnnotationResizeBehavior.reflowText) {
       return null;
     }
-    // an embedded-font box reflows too, but the lightweight preview can only
-    // draw base-14 faces - fall back to the stretch ghost during the drag
-    // (the commit still re-wraps correctly)
-    final font = annotation.behavior.standardTextFont;
+    // Base-14 boxes preview in the matching platform face; an embedded/bundled
+    // box previews in its own outline bytes, registered with the engine under
+    // a synthetic family ([_wrappedTextBox] kicks that off) exactly like the
+    // inline editor - so the drag wraps in the real font instead of stretching
+    // baked glyphs. Only when neither is recoverable does the stretch ghost
+    // still stand in (the commit re-wraps correctly regardless).
+    final PdfTextFont? font = annotation.behavior.standardTextFont ??
+        _resizeEmbeddedFontOf(annotation);
     if (font == null) return null;
     final parsed = annotation.behavior.style.freeText!;
     return (
@@ -4690,7 +4716,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     Key? key,
     required Rect rect,
     required String text,
-    required PdfStandardFont font,
+    required PdfTextFont font,
     required double size,
     required Color color,
     required Color? background,
@@ -4699,6 +4725,13 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     bool underline = false,
     double lineSpacing = kPdfFreeTextDefaultLineSpacing,
   }) {
+    // An embedded/bundled face has no platform family - register its outline
+    // bytes so Flutter wraps this preview in the real font (until the async
+    // load lands, [_textEditUiFamily] returns null and the fallback face wraps
+    // it, still without stretching). Bold/italic are base-14-only variants.
+    if (font is PdfEmbeddedFont) _ensureEmbeddedFontPreview(font);
+    final isBold = font is PdfStandardFont && font.isBold;
+    final isItalic = font is PdfStandardFont && font.isItalic;
     final direction = _flutterTextDirection(text);
     final columnAlign = switch (align) {
       null => AlignmentDirectional.topStart.resolve(direction),
@@ -4724,9 +4757,9 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             color: color,
             fontSize: size * _geometry.scale,
             height: lineSpacing,
-            fontFamily: _uiFamily(font),
-            fontWeight: font.isBold ? FontWeight.bold : FontWeight.normal,
-            fontStyle: font.isItalic ? FontStyle.italic : FontStyle.normal,
+            fontFamily: _textEditUiFamily(font),
+            fontWeight: isBold ? FontWeight.bold : FontWeight.normal,
+            fontStyle: isItalic ? FontStyle.italic : FontStyle.normal,
             decoration: underline ? TextDecoration.underline : null,
             decorationColor: underline ? color : null,
           ),
@@ -4741,14 +4774,6 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       ),
     );
   }
-
-  /// The Flutter font family that visually matches [font] - the same
-  /// substitution the renderer uses for non-embedded base-14 fonts.
-  static String _uiFamily(PdfStandardFont font) => switch (font.family) {
-        PdfStandardFontFamily.sans => 'Helvetica',
-        PdfStandardFontFamily.serif => 'Times New Roman',
-        PdfStandardFontFamily.mono => 'Courier',
-      };
 
   @override
   Widget build(BuildContext context) {
@@ -5321,7 +5346,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                   height: _textEditLineSpacing,
                                   letterSpacing:
                                       _textEditCharSpacing * _geometry.scale,
-                                  fontFamily: _uiFamily(_textEditFont),
+                                  fontFamily: _textEditUiFamily(_textEditFont),
                                   fontWeight: _textEditFont.isBold
                                       ? FontWeight.bold
                                       : FontWeight.normal,

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -1420,6 +1420,43 @@ void main() {
       await settle(tester);
     });
 
+    testWidgets('resizing an embedded-font box previews the re-wrap too',
+        (tester) async {
+      const previewKey = ValueKey('pdf-text-resize-preview');
+      final (editing, _) = await pumpEditor(tester);
+      final fontBytes =
+          File('../pdf_document/test/fonts/DejaVuSans.ttf').readAsBytesSync();
+      expect(editing.setCustomFont(fontBytes), isTrue);
+      editing
+        ..preferences.fontSize = 16
+        ..addFreeText(0, const PdfRect(100, 600, 300, 650), 'Wrap me please')
+        ..tool = PdfEditTool.select;
+      expect(editing.selectAnnotation(0, 0), isTrue);
+      await tester.pump();
+      // genuinely the embedded path, not a base-14 fallback
+      expect(editing.selectedTextFont, isA<PdfEmbeddedFont>());
+
+      // grab the bottom-right handle and pull it inward
+      final gesture = await tester.startGesture(view(300, 600));
+      await gesture.moveTo(view(260, 580));
+      await gesture.moveTo(view(220, 560));
+      await tester.pump();
+
+      // an embedded/bundled box re-wraps live just like a base-14 box - the
+      // wrapped-text preview rides the dragged box at the committed size,
+      // rather than falling back to stretched glyphs
+      expect(find.byKey(previewKey), findsOneWidget);
+      final text = tester.widget<Text>(find.descendant(
+          of: find.byKey(previewKey), matching: find.byType(Text)));
+      expect(text.data, 'Wrap me please');
+      expect(text.style!.fontSize, closeTo(16 * scale, 0.01));
+
+      await gesture.up();
+      await tester.pump();
+      editing.activeFont = null;
+      await settle(tester);
+    });
+
     testWidgets('the resize preview lifts the box, transparent over the page',
         (tester) async {
       final (editing, _) = await pumpEditor(tester);


### PR DESCRIPTION
## Summary

Resizing a free-text (text box) annotation stretched the text in the live drag preview whenever the box used an **embedded/bundled font**, then snapped to correctly-wrapped text on release. The commit path already re-wrapped both base-14 and embedded boxes (`behavior.resizeBehavior == reflowText`); only the *preview* lagged, because `_textResizeStyle` bailed out to `null` (falling back to the stretch ghost) whenever `standardTextFont` was null — i.e. for every embedded box.

This makes the drag preview re-wrap embedded boxes too, so what you see while dragging matches what commits.

**How:** reuse the inline editor's existing embedded-font preview machinery (`_ensureEmbeddedFontPreview`, which registers the font's outline bytes with the engine under a synthetic family). `_textResizeStyle` now falls back to the box's recovered `PdfEmbeddedFont`; its record and `_afterText` widen from `PdfStandardFont` to `PdfTextFont`; `_wrappedTextBox` registers embedded faces on demand and resolves the family through the embedded-aware `_textEditUiFamily` (retiring the base-14-only `_uiFamily`), gating bold/italic on `PdfStandardFont`. Until the async font load lands the preview wraps in a fallback face — still wrapped, never stretched — then rebuilds to the real font, exactly as the inline editor already behaves. The recovered font program is cached against the annotation instance so it isn't re-decoded every drag frame.

The cache lives in the overlay (not on `PdfAnnotationBehavior`) because `annotation.dart` sits below `font_embedder.dart` in the layering, and referencing `PdfEmbeddedFont` there would introduce a circular import. `hasEmbeddedTextFont` stays the cheap COS-only gate on the behavior.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] Documentation / CI / repository metadata only (dev-log note added)

## Change type

- [x] Bug fix
- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze` (`--fatal-infos`, clean for `dart_pdf_editor`)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — `test/editing_text_edit_test.dart` (49 tests, incl. the new embedded-font preview test) passes; full-package suite run kicked off after push and CI covers it.

## PDF fixtures and screenshots

New widget test drags an embedded-font (DejaVuSans) box's resize handle and asserts the `pdf-text-resize-preview` widget rides the dragged box showing the real text at the committed font size mid-drag — previously it found nothing and the stretch ghost took over. Existing base-14 preview and shape-stretch-ghost tests still pass.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory (the test's `File` read is test-only, matching the sibling embedded-font tests).
- [x] Layering is preserved: the embedded-font parse is kept in the editor overlay rather than pushed down into `annotation.dart`, which would create a circular import with `font_embedder.dart`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required (font program decoded only when a resize preview needs it, then cached).
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Preview fidelity depends on the engine having the embedded font registered. On the very first resize of a freshly-loaded font there can be a frame or two where the wrap uses a fallback face before `ui.loadFontFromList` resolves; it is never stretched, and it rebuilds to the real face — the same tradeoff the inline text editor already makes.
- CFF/non-Identity embedded shapes that the commit path itself can't reflow are unaffected (they still resolve to `stretch` and preview with the ghost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bkn8HjPPctP87vzuPUvdcK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bkn8HjPPctP87vzuPUvdcK)_