### PR TITLE
Annotation list: thread more-menu on hover + ctrl/shift multi-select

### DIFF
--- a/doc/dev-log/2026-07-17-annotation-list-more-menu-and-modifier-select.md
+++ b/doc/dev-log/2026-07-17-annotation-list-more-menu-and-modifier-select.md
@@ -1,0 +1,57 @@
+# Annotation sidebar: thread "more" menu + ⌘/Ctrl/Shift multi-select
+
+Two annotation-list interaction changes in
+`packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart`.
+
+## Reply / Resolve moved into a per-row "more" (⋮) menu
+
+The thread controls used to be an always-visible Reply / Resolve
+`TextButton` row rendered inline under every markup row by
+`_threadSection`. They now live in a `PopupMenuButton<_ThreadAction>`
+(`_threadMenu`) in the row's trailing area, revealed on hover next to the
+delete button (`_rowActions` builds the trailing `Row`, wrapped in the
+existing hover `Visibility`). `_threadSection` keeps only the review-state
+chip, the reply tree, and - when open - the inline reply field.
+
+- Menu-item keys `pdf-reply-button` / `pdf-resolve-button` are kept (now
+  on the `PopupMenuItem`s), so the actions still fire the same controller
+  calls; the trigger has its own key `pdf-annotation-more-<page>-<slot>`.
+- The menu shows for any thread-hosting (`behavior.selectable`) row, even a
+  locked one - reply/resolve add *new* annotations rather than editing the
+  locked one, matching the old inline behavior (which never gated on
+  `isAnnotationEditable`). Delete stays gated on editability.
+- Reply is disabled when the root has no `/NM` (a reply is matched to its
+  root by name, so there'd be no field to open).
+- Removed the now-unused `_threadActionStyle`.
+
+Gotcha for tests: the trailing hover `Visibility` uses
+`maintainState`/`maintainSize` but not `maintainInteractivity`, so while
+invisible the button is wrapped in `IgnorePointer` and can't be tapped.
+Widget tests must hover the row first (a mouse `TestGesture.moveTo` the
+row centre) before tapping the ⋮ - see `openMore` in
+`editing_thread_test.dart`. Because the open menu is an overlay route it
+survives the pointer leaving; `openMore` removes its pointer at the end so
+a second call (resolve → reopen) can add its own without tripping the
+mouse-tracker add/remove assertion.
+
+## ⌘/Ctrl-click and Shift-click multi-select
+
+The list already had a touch-friendly long-press → checkbox mode; desktop
+now also gets modifier selection, mirroring the viewer.
+
+- `_onTileTap` reads `HardwareKeyboard.instance`: Ctrl/⌘ toggles the row in
+  the selection (`controller.toggleAnnotationSelection`), Shift selects the
+  range from `_anchor` to the row (`controller.selectAnnotationSlots`), and
+  a plain click keeps the old navigate + select + flash. Modifier gestures
+  leave the viewport put (no `showRect`/flash).
+- The range runs along `ordered`, a per-build list of every displayed,
+  selectable+editable slot in display order, captured by each row's tap
+  handler (it's complete by tap time). `_anchor` is set on plain and
+  Ctrl/⌘ clicks and cleared on every revision (slots shift under edits).
+- New controller methods (`editing_controller.dart`):
+  `toggleAnnotationSelection(page, index)` and
+  `selectAnnotationSlots(slots)` - both arm the select tool and drop
+  invalid/unselectable/locked slots, matching `selectAnnotation`'s gate.
+
+Tests: `editing_thread_test.dart` (menu open flow), `editing_sidebar_test.dart`
+(ctrl-toggle, shift-range).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -3764,6 +3764,57 @@ class PdfEditingController extends ChangeNotifier {
     return true;
   }
 
+  /// Adds or removes the annotation in slot [index] of [pageIndex]'s
+  /// /Annots from the selection - the annotation sidebar's ⌘/Ctrl-click.
+  /// Arms the select tool and keeps any other selected annotations. An
+  /// already-selected slot is deselected; a slot that can't be selected
+  /// (invalid, unselectable subtype, or locked) is ignored when it isn't
+  /// already in the selection. Returns whether the annotation is selected
+  /// afterwards.
+  bool toggleAnnotationSelection(int pageIndex, int index) {
+    final slot = (pageIndex, index);
+    if (_selected.contains(slot)) {
+      _selected.remove(slot);
+      notifyListeners();
+      return false;
+    }
+    final annotation = _annotationAt(slot);
+    if (annotation == null ||
+        !annotation.behavior.selectable ||
+        !isAnnotationEditable(annotation)) {
+      return false;
+    }
+    tool = PdfEditTool.select;
+    _selected.add(slot);
+    notifyListeners();
+    return true;
+  }
+
+  /// Replaces the annotation selection with [slots] (in the given order,
+  /// dropping duplicates and any that are invalid, unselectable, or
+  /// locked) and arms the select tool - the annotation sidebar's
+  /// shift-click range select. Returns how many are selected afterwards.
+  int selectAnnotationSlots(Iterable<(int page, int index)> slots) {
+    final next = <(int, int)>[];
+    for (final slot in slots) {
+      if (next.contains(slot)) continue;
+      final annotation = _annotationAt(slot);
+      if (annotation != null &&
+          annotation.behavior.selectable &&
+          isAnnotationEditable(annotation)) {
+        next.add(slot);
+      }
+    }
+    tool = PdfEditTool.select;
+    if (!listEquals(next, _selected)) {
+      _selected
+        ..clear()
+        ..addAll(next);
+      notifyListeners();
+    }
+    return next.length;
+  }
+
   /// Removes the annotation in slot [index] of [pageIndex]'s /Annots
   /// without going through the selection.
   void deleteAnnotation(int pageIndex, int index) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show HardwareKeyboard;
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
@@ -18,11 +19,17 @@ import 'editing_preferences.dart';
 ///
 /// Tapping a tile zooms the viewer to the annotation, selects it
 /// (arming the select tool), and pulses an attention flash around it on
-/// the page; the trailing button deletes it. A long press starts
-/// multi-select: checkboxes replace the icons, tapping toggles, and the
-/// header's delete removes everything checked as one undo step. The
-/// list rebuilds on every revision, so it always reflects the current
-/// state - including undo and redo.
+/// the page. On mouse hover a row reveals its trailing actions: a "more"
+/// (⋮) menu carrying Reply / Resolve for a markup annotation's comment
+/// thread, and a delete button.
+///
+/// Rows are multi-selectable: ⌘/Ctrl-click toggles a row in or out of
+/// the selection and shift-click extends a range from the last click,
+/// mirroring the viewer's own selection. A long press starts a
+/// touch-friendly checkbox multi-select: checkboxes replace the icons,
+/// tapping toggles, and the header's delete removes everything checked as
+/// one undo step. The list rebuilds on every revision, so it always
+/// reflects the current state - including undo and redo.
 ///
 /// The inner edge is draggable ([resizable]); the chosen width persists
 /// via [PdfEditingPreferences.annotationSidebarWidth].
@@ -97,6 +104,11 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   final Set<(int, int)> _checked = {};
   (int, int)? _hoveredSlot;
   bool _selecting = false;
+
+  /// The slot a shift-click range extends from - set on a plain or
+  /// ⌘/Ctrl-click. Cleared with the selection on every revision (slots
+  /// shift under edits).
+  (int, int)? _anchor;
 
   final ScrollController _scroll = ScrollController();
 
@@ -277,10 +289,15 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   }
 
   Widget _tile(BuildContext context, int pageIndex, int index,
-      PdfAnnotation annotation) {
+      PdfAnnotation annotation, PdfCommentThread? thread,
+      List<(int, int)> ordered) {
     final slot = (pageIndex, index);
     final editable = annotation.behavior.selectable &&
         widget.controller.isAnnotationEditable(annotation);
+    // a markup annotation hosts a comment thread; reply / resolve act on
+    // it even when the annotation itself is locked (they add new
+    // annotations rather than editing the locked one)
+    final hostsThread = annotation.behavior.selectable;
     final detail = _detail(pageIndex, annotation);
     final actionsVisible =
         !pdfPanelControlsRevealOnHover() || _hoveredSlot == slot;
@@ -308,38 +325,132 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
             widget.controller.isAnnotationSelected(pageIndex, index),
         onTap: _selecting
             ? (editable ? () => _toggle(slot) : null)
-            : () {
-                unawaited(widget.viewerController
-                    .showRect(pageIndex, annotation.rect));
-                if (editable) {
-                  widget.controller.selectAnnotation(pageIndex, index);
-                }
-                // pulse it on the page so the eye lands right
-                widget.controller.flashAnnotation(pageIndex, index);
-              },
+            : () => _onTileTap(pageIndex, index, annotation, editable, ordered),
         onLongPress: editable && !_selecting
             ? () => setState(() {
                   _selecting = true;
                   _checked.add(slot);
                 })
             : null,
-        trailing: _selecting || !editable
+        trailing: _selecting
             ? null
-            : Visibility(
-                visible: actionsVisible,
-                maintainSize: true,
-                maintainAnimation: true,
-                maintainState: true,
-                child: IconButton(
-                  key: ValueKey('pdf-annotation-delete-$pageIndex-$index'),
-                  icon: const Icon(Icons.delete_outline, size: 20),
-                  tooltip: 'Delete',
-                  onPressed: () =>
-                      widget.controller.deleteAnnotation(pageIndex, index),
-                ),
-              ),
+            : _rowActions(context, pageIndex, index, annotation, thread,
+                editable, hostsThread, actionsVisible),
       ),
     );
+  }
+
+  /// The trailing hover actions for a row: a "more" (⋮) menu with the
+  /// thread's Reply / Resolve for a markup annotation, then delete for an
+  /// editable one. Null when the row exposes neither.
+  Widget? _rowActions(
+    BuildContext context,
+    int pageIndex,
+    int index,
+    PdfAnnotation annotation,
+    PdfCommentThread? thread,
+    bool editable,
+    bool hostsThread,
+    bool actionsVisible,
+  ) {
+    final actions = <Widget>[
+      if (hostsThread)
+        _threadMenu(context, pageIndex, index, annotation, thread),
+      if (editable)
+        IconButton(
+          key: ValueKey('pdf-annotation-delete-$pageIndex-$index'),
+          icon: const Icon(Icons.delete_outline, size: 20),
+          tooltip: 'Delete',
+          onPressed: () =>
+              widget.controller.deleteAnnotation(pageIndex, index),
+        ),
+    ];
+    if (actions.isEmpty) return null;
+    return Visibility(
+      visible: actionsVisible,
+      maintainSize: true,
+      maintainAnimation: true,
+      maintainState: true,
+      child: Row(mainAxisSize: MainAxisSize.min, children: actions),
+    );
+  }
+
+  /// The per-row "more" menu holding a markup annotation's thread actions:
+  /// Reply (opens the inline reply field) and Resolve / Reopen.
+  Widget _threadMenu(BuildContext context, int pageIndex, int index,
+      PdfAnnotation annotation, PdfCommentThread? thread) {
+    final nm = annotation.name;
+    final resolved = thread?.isResolved ?? false;
+    return PopupMenuButton<_ThreadAction>(
+      key: ValueKey('pdf-annotation-more-$pageIndex-$index'),
+      icon: const Icon(Icons.more_vert, size: 20),
+      tooltip: 'More',
+      onSelected: (action) {
+        switch (action) {
+          case _ThreadAction.reply:
+            setState(() {
+              _replyingTo = nm;
+              _reply.text = '';
+            });
+          case _ThreadAction.resolve:
+            resolved
+                ? widget.controller.reopenThread(pageIndex, annotation)
+                : widget.controller.resolveThread(pageIndex, annotation);
+        }
+      },
+      itemBuilder: (context) => [
+        PopupMenuItem(
+          key: const ValueKey('pdf-reply-button'),
+          value: _ThreadAction.reply,
+          // a reply is matched to its root by /NM; without one there's
+          // no field to open
+          enabled: nm != null,
+          child: const Text('Reply'),
+        ),
+        PopupMenuItem(
+          key: const ValueKey('pdf-resolve-button'),
+          value: _ThreadAction.resolve,
+          child: Text(resolved ? 'Reopen' : 'Resolve'),
+        ),
+      ],
+    );
+  }
+
+  /// A plain / ⌘-Ctrl / shift click on a row (outside checkbox mode).
+  /// Plain click navigates the viewer to the annotation, selects it, and
+  /// flashes it. ⌘/Ctrl-click toggles it in the selection; shift-click
+  /// selects the range from the [_anchor] to it. Both modifier gestures
+  /// leave the viewport put.
+  void _onTileTap(int pageIndex, int index, PdfAnnotation annotation,
+      bool editable, List<(int, int)> ordered) {
+    final slot = (pageIndex, index);
+    final keys = HardwareKeyboard.instance;
+    final toggle = keys.isControlPressed || keys.isMetaPressed;
+    final range = keys.isShiftPressed;
+
+    if (editable && range && _anchor != null) {
+      final from = ordered.indexOf(_anchor!);
+      final to = ordered.indexOf(slot);
+      if (from != -1 && to != -1) {
+        final lo = from < to ? from : to;
+        final hi = from < to ? to : from;
+        widget.controller.selectAnnotationSlots(ordered.sublist(lo, hi + 1));
+        return;
+      }
+    }
+    if (editable && toggle) {
+      widget.controller.toggleAnnotationSelection(pageIndex, index);
+      _anchor = slot;
+      return;
+    }
+    // plain click: frame it, select it, and pulse it on the page so the
+    // eye lands right
+    unawaited(widget.viewerController.showRect(pageIndex, annotation.rect));
+    if (editable) {
+      widget.controller.selectAnnotation(pageIndex, index);
+      _anchor = slot;
+    }
+    widget.controller.flashAnnotation(pageIndex, index);
   }
 
   /// A short local-time stamp for a comment, or '' when undated.
@@ -364,36 +475,6 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
         PdfReviewState.none => null,
       };
 
-  /// Thread actions should read like secondary links, not two primary
-  /// buttons repeated under every annotation. Desktop keeps the visual row
-  /// tight; touch-first platforms retain a comfortable 44px hit target.
-  ButtonStyle _threadActionStyle(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final compact = pdfPanelControlsRevealOnHover();
-    return TextButton.styleFrom(
-      minimumSize: Size(0, compact ? 24 : 44),
-      padding: const EdgeInsets.symmetric(horizontal: 7),
-      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      visualDensity: VisualDensity.compact,
-      textStyle: Theme.of(context)
-          .textTheme
-          .labelSmall
-          ?.copyWith(fontWeight: FontWeight.w500),
-    ).copyWith(
-      foregroundColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.disabled)) {
-          return cs.onSurface.withValues(alpha: 0.38);
-        }
-        if (states.contains(WidgetState.hovered) ||
-            states.contains(WidgetState.focused) ||
-            states.contains(WidgetState.pressed)) {
-          return cs.primary;
-        }
-        return cs.onSurfaceVariant;
-      }),
-    );
-  }
-
   /// Each comment in [root]'s reply tree with its depth (root = 0), in
   /// document/pre-order.
   static List<(PdfComment, int)> _flattenWithDepth(PdfComment root) {
@@ -410,7 +491,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   }
 
   /// The inline thread under a root markup tile: a review-state chip, the
-  /// reply tree (indented), and the reply / resolve controls.
+  /// reply tree (indented), and - when open - the reply field. Reply and
+  /// Resolve are triggered from the row's "more" menu ([_threadMenu]).
   List<Widget> _threadSection(BuildContext context, int page,
       PdfAnnotation root, PdfCommentThread? thread) {
     if (_selecting) return const []; // chrome stays clear during multi-select
@@ -450,7 +532,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
       }
     }
 
-    // controls: an open reply field, or the Reply / Resolve buttons
+    // the open reply field, when the row's "more" > Reply was chosen
     final nm = root.name;
     final replying = nm != null && _replyingTo == nm;
     if (replying) {
@@ -482,32 +564,6 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
               child: const Text('Reply'),
             ),
           ]),
-        ]),
-      ));
-    } else {
-      final resolved = thread?.isResolved ?? false;
-      widgets.add(Padding(
-        padding: const EdgeInsets.fromLTRB(56, 0, 12, 4),
-        child: Wrap(alignment: WrapAlignment.end, spacing: 2, children: [
-          TextButton(
-            key: const ValueKey('pdf-reply-button'),
-            style: _threadActionStyle(context),
-            onPressed: nm == null
-                ? null
-                : () => setState(() {
-                      _replyingTo = nm;
-                      _reply.text = '';
-                    }),
-            child: const Text('Reply'),
-          ),
-          TextButton(
-            key: const ValueKey('pdf-resolve-button'),
-            style: _threadActionStyle(context),
-            onPressed: () => resolved
-                ? widget.controller.reopenThread(page, root)
-                : widget.controller.resolveThread(page, root),
-            child: Text(resolved ? 'Reopen' : 'Resolve'),
-          ),
         ]),
       ));
     }
@@ -605,6 +661,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
               _checked.clear();
               _hoveredSlot = null;
               _selecting = false;
+              _anchor = null;
               _pageTexts.clear();
               // a revision closes any open reply field (the sent reply
               // is what produced the new revision)
@@ -612,6 +669,10 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
             }
             final query = _search.text.trim().toLowerCase();
             final children = <Widget>[];
+            // every displayed, selectable slot in display order - the axis
+            // a shift-click range runs along. Filled as tiles are built and
+            // captured by each row's tap handler (complete by tap time).
+            final ordered = <(int, int)>[];
             var listed = 0;
             for (var page = 0; page < document.pageCount; page++) {
               final annotations = widget.controller.pageAt(page).annotations;
@@ -633,11 +694,15 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                 }
                 listed++;
                 if (!_matches(query, page, annotation)) continue;
-                tiles.add(_tile(context, page, i, annotation));
+                final thread = threadByDict[annotation.dict];
+                if (annotation.behavior.selectable &&
+                    widget.controller.isAnnotationEditable(annotation)) {
+                  ordered.add((page, i));
+                }
+                tiles.add(_tile(context, page, i, annotation, thread, ordered));
                 // a markup annotation hosts a comment thread
                 if (annotation.behavior.selectable) {
-                  tiles.addAll(_threadSection(context, page, annotation,
-                      threadByDict[annotation.dict]));
+                  tiles.addAll(_threadSection(context, page, annotation, thread));
                 }
               }
               if (tiles.isNotEmpty) {
@@ -693,6 +758,9 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
     );
   }
 }
+
+/// The actions a markup row's "more" menu offers on its comment thread.
+enum _ThreadAction { reply, resolve }
 
 /// A small rounded status chip used for a thread's review state.
 class _Pill extends StatelessWidget {

--- a/packages/dart_pdf_editor/test/editing_sidebar_test.dart
+++ b/packages/dart_pdf_editor/test/editing_sidebar_test.dart
@@ -1,6 +1,5 @@
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -112,6 +111,61 @@ void main() {
     editing.undo();
     await tester.pump();
     expect(editing.document.page(0).annotations, hasLength(2));
+  });
+
+  testWidgets('ctrl-click toggles rows in and out of the selection',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1))
+      ..addRectangle(0, const PdfRect(100, 100, 200, 150))
+      ..addEllipse(0, const PdfRect(250, 100, 350, 150))
+      ..addNote(0, 100, 700, 'note');
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await pumpSidebar(tester, editing, viewer);
+
+    // ctrl-click selects without navigating (and sets the range anchor)
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.tap(find.text('Square'));
+    await tester.pump();
+    expect(editing.selectedAnnotationSlots, [(0, 0)]);
+
+    // a second ctrl-click adds to the selection
+    await tester.tap(find.text('Circle'));
+    await tester.pump();
+    expect(editing.selectedAnnotationSlots.toSet(), {(0, 0), (0, 1)});
+
+    // ctrl-clicking a selected row removes it again
+    await tester.tap(find.text('Circle'));
+    await tester.pump();
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    expect(editing.selectedAnnotationSlots, [(0, 0)]);
+    // no checkbox mode - this is the desktop modifier path
+    expect(find.byType(Checkbox), findsNothing);
+  });
+
+  testWidgets('shift-click selects the range from the anchor', (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1))
+      ..addRectangle(0, const PdfRect(100, 100, 200, 150))
+      ..addEllipse(0, const PdfRect(250, 100, 350, 150))
+      ..addNote(0, 100, 700, 'note');
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await pumpSidebar(tester, editing, viewer);
+
+    // anchor on the first row
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.tap(find.text('Square'));
+    await tester.pump();
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+    // shift-click the last row selects everything between
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.tap(find.text('Note'));
+    await tester.pump();
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    expect(editing.selectedAnnotationSlots.toSet(), {(0, 0), (0, 1), (0, 2)});
   });
 
   testWidgets('locked rows still navigate and flash but expose no edit actions',

--- a/packages/dart_pdf_editor/test/editing_thread_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thread_test.dart
@@ -2,6 +2,7 @@
 // review-state chip, resolve and reopen - driving the controller's thread
 // methods (which round-trip through pdf_document's reply model).
 
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -32,6 +33,24 @@ void main() {
     await tester.pump();
   }
 
+  // the row's trailing actions reveal on hover (desktop); hover the row,
+  // then open its "more" menu.
+  Future<void> openMore(WidgetTester tester, int page, int index) async {
+    final moreKey = ValueKey('pdf-annotation-more-$page-$index');
+    final tile = find.ancestor(
+        of: find.byKey(moreKey), matching: find.byType(ListTile));
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    await gesture.moveTo(tester.getCenter(tile));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(moreKey));
+    await tester.pumpAndSettle();
+    // the open menu is an overlay route, so it survives the pointer
+    // leaving; remove it so a later openMore can add its own cleanly
+    await gesture.removePointer();
+    await tester.pumpAndSettle();
+  }
+
   testWidgets('reply through the sidebar adds a thread reply', (tester) async {
     final editing = PdfEditingController(buildMultiPagePdf(1))
       ..preferences.author = 'Ann'
@@ -41,7 +60,8 @@ void main() {
     addTearDown(viewer.dispose);
     await pumpSidebar(tester, editing, viewer);
 
-    // open the reply field
+    // open the row's "more" menu, then choose Reply to open the field
+    await openMore(tester, 0, 0);
     await tester.tap(find.byKey(const ValueKey('pdf-reply-button')));
     await tester.pump();
     expect(find.byKey(const ValueKey('pdf-reply-field')), findsOneWidget);
@@ -77,6 +97,8 @@ void main() {
 
     expect(find.text('Resolved'), findsNothing);
 
+    // more > Resolve
+    await openMore(tester, 0, 0);
     await tester.tap(find.byKey(const ValueKey('pdf-resolve-button')));
     await tester.pumpAndSettle(const Duration(milliseconds: 300));
 
@@ -84,7 +106,8 @@ void main() {
         isTrue);
     expect(find.text('Resolved'), findsOneWidget);
 
-    // the button now reopens
+    // the menu item now reopens
+    await openMore(tester, 0, 0);
     await tester.tap(find.byKey(const ValueKey('pdf-resolve-button')));
     await tester.pumpAndSettle(const Duration(milliseconds: 300));
     expect(PdfCommentThread.forPage(editing.document, 0).single.isResolved,
@@ -93,7 +116,7 @@ void main() {
   });
 
   testWidgets(
-    'thread actions are compact muted text links on desktop',
+    'thread actions live in the row\'s "more" menu, not inline',
     (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addNote(0, 100, 700, 'Please check');
@@ -102,24 +125,18 @@ void main() {
       addTearDown(viewer.dispose);
       await pumpSidebar(tester, editing, viewer);
 
-      final replyFinder = find.byKey(const ValueKey('pdf-reply-button'));
-      final resolveFinder = find.byKey(const ValueKey('pdf-resolve-button'));
-      final reply = tester.widget<TextButton>(replyFinder);
-      final scheme = Theme.of(tester.element(replyFinder)).colorScheme;
+      // no inline reply/resolve buttons - only the "more" trigger
+      expect(find.byKey(const ValueKey('pdf-reply-button')), findsNothing);
+      expect(find.byKey(const ValueKey('pdf-resolve-button')), findsNothing);
+      final more = find.byKey(const ValueKey('pdf-annotation-more-0-0'));
+      expect(more, findsOneWidget);
 
-      expect(reply.style?.minimumSize?.resolve({})?.height, 24);
-      expect(
-          reply.style?.foregroundColor?.resolve({}), scheme.onSurfaceVariant);
-      expect(reply.style?.foregroundColor?.resolve({WidgetState.hovered}),
-          scheme.primary);
-      expect(
-        find.descendant(of: replyFinder, matching: find.byType(Icon)),
-        findsNothing,
-      );
-      expect(
-        find.descendant(of: resolveFinder, matching: find.byType(Icon)),
-        findsNothing,
-      );
+      // opening it surfaces both actions
+      await openMore(tester, 0, 0);
+      expect(find.byKey(const ValueKey('pdf-reply-button')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-resolve-button')), findsOneWidget);
+      expect(find.text('Reply'), findsOneWidget);
+      expect(find.text('Resolve'), findsOneWidget);
     },
     variant: TargetPlatformVariant.only(TargetPlatform.macOS),
   );
@@ -153,6 +170,7 @@ void main() {
     addTearDown(viewer.dispose);
     await pumpSidebar(tester, editing, viewer);
 
+    await openMore(tester, 0, 0);
     await tester.tap(find.byKey(const ValueKey('pdf-reply-button')));
     await tester.pump();
     // send without typing anything


### PR DESCRIPTION
## Summary

Two interaction changes to the annotation sidebar (`PdfAnnotationSidebar`):

**Reply / Resolve moved into a hover "more" menu.** They used to be an
always-visible inline Reply / Resolve button row under every markup row.
They now live in a per-row `PopupMenuButton` (⋮) revealed on mouse hover
beside the delete button. The thread section keeps only the review-state
chip, the reply tree, and — when open — the inline reply field. The menu
shows for any thread-hosting (`selectable`) row, including a locked one
(reply/resolve add *new* annotations rather than editing the locked one),
matching the previous behavior; delete stays gated on editability.

**⌘/Ctrl + Shift multi-select.** Alongside the existing touch-friendly
long-press → checkbox mode, desktop now gets modifier selection mirroring
the viewer: ⌘/Ctrl-click toggles a row in/out of the selection, and
shift-click extends a range from the last click. Plain click keeps the
navigate + select + flash behavior. Backed by two new
`PdfEditingController` methods — `toggleAnnotationSelection` and
`selectAnnotationSlots` — that arm the select tool and drop
invalid/unselectable/locked slots (same gate as `selectAnnotation`).

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only (dev-log note)

## Change type

- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Full `dart_pdf_editor` suite passes (1653 tests). Added coverage:
`editing_thread_test.dart` (opening the more menu, reply/resolve/reopen
through it) and `editing_sidebar_test.dart` (ctrl-toggle, shift-range).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

The trailing hover `Visibility` uses `maintainState`/`maintainSize` but
not `maintainInteractivity`, so while invisible the ⋮ button is inside an
`IgnorePointer`. Widget tests must hover the row before tapping it — see
the `openMore` helper in `editing_thread_test.dart`. Design rationale and
gotchas are in `doc/dev-log/2026-07-17-annotation-list-more-menu-and-modifier-select.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2xigG4D9VUGqQrXiF9dgK)_