### PR TITLE
perf(#309): measure and reject the render-worker command-graph transfer half

### DIFF
--- a/doc/dev-log/2026-07-17-seam-transfer-measurement.md
+++ b/doc/dev-log/2026-07-17-seam-transfer-measurement.md
@@ -1,0 +1,91 @@
+# Render-worker seam: measuring (and rejecting) the command-graph transfer half of #309
+
+Issue [#309](https://github.com/ben-milanko/dart-pdf/issues/309) ("stop paying
+for copies at the pool/isolate seam") had two halves:
+
+1. **Shared source bytes** across the pool workers - a safe memory win. Landed
+   in #333 (see [2026-07-17-pool-shared-bytes.md](2026-07-17-pool-shared-bytes.md)).
+2. **Transfer command graphs** by `SendPort`/`Isolate.exit` on native instead
+   of the `serializeCommands`/`deserializeCommands` codec round-trip - flagged
+   in the issue itself as *speculative* ("not pure win"). This session is that
+   half's follow-up.
+
+The remaining work was to actually **measure** the transfer half (the issue's
+own "Measure" section) and decide. The measurement says: **don't do it.**
+
+## The current native seam
+
+`_IsolateRenderWorker` (`render_worker_isolate.dart`) records a page in a
+background isolate, then:
+
+- the worker calls `serializeCommands` -> one compact `Uint8List` (path
+  coordinates packed at float32; image XObjects inline-resolved and their
+  pixels decoded off-thread into the same buffer),
+- wraps it in `TransferableTypedData.fromList([buffer])` and `port.send`s it -
+  a **zero-copy** transfer of the byte buffer,
+- the main isolate `materialize()`s it (zero-copy) and calls
+  `deserializeCommands` to rebuild the `List<PdfRenderCommand>` it replays.
+
+So of the whole round-trip, only `deserializeCommands` runs on the UI thread;
+serialize is off-thread and the buffer crosses without a copy.
+
+The codec is *required* on web (a Web Worker's `postMessage` only accepts
+structured-cloneable data, not live Dart objects). #309 asked whether native
+should instead hand the `List<PdfRenderCommand>` straight over the port -
+"native transfer, web codec" as two adapters behind a real transport seam.
+
+## Measurement
+
+`packages/pdf_graphics/tool/bench_render_seam.dart` (re-runnable:
+`cd packages/pdf_graphics && fvm dart run tool/bench_render_seam.dart`) builds a
+synthetic image-free page - the dense fills/strokes shape #309 targets ("a
+dense CAD page (~100k commands)") - and compares, over real isolates:
+
+- the codec's `serialize` (worker) and `deserialize` (UI) legs, versus
+- a real `port.send(commands)` round-trip of the raw object graph (which the VM
+  services with a general deep copy of the graph, borne on the *receiving*
+  isolate).
+
+Representative run (Dart VM, `flutter 3.44.4`; absolute numbers vary by machine,
+the ratio does not):
+
+| workload            | codec deserialize (UI) | raw object graph, one crossing |
+| ------------------- | ---------------------- | ------------------------------ |
+| 10 000 commands     | ~8 ms                  | ~22 ms                         |
+| 100 000 commands    | ~112 ms                | ~422 ms                        |
+
+The raw object-graph transfer is **~2.6x–3.8x slower**, scales worse with
+command count, and lands its whole cost on the UI isolate - the exact thread
+the offload exists to protect. The VM's general graph copy (every `PdfPath`,
+`PdfPathSegment`, `PdfColor`, nested `List`, …) is simply far more expensive
+than walking a flat, cache-friendly byte buffer, and the codec's compact buffer
+already crosses the isolate boundary zero-copy via `TransferableTypedData`.
+
+## Why `Isolate.exit` doesn't rescue it
+
+`Isolate.exit(port, message)` *is* a zero-copy heap hand-off - but it kills the
+sending isolate. Our native backend is a **long-lived pooled worker**: it opens
+the document once, keeps decoded-image / strip-command caches warm, and absorbs
+edits in place via `updateRevision` (#308). Exiting per page would re-spawn the
+isolate and re-open + re-warm the document for every single page - catastrophic,
+and incompatible with the whole pooled/revision-aware design. So `Isolate.exit`
+is not an option here either.
+
+## Decision
+
+The transfer half is **not implemented**. The codec + zero-copy
+`TransferableTypedData` is already close to optimal for the native seam, and the
+speculative alternative is a measured regression on its own target workload. The
+issue author's caveat ("the transfer half is not pure win") is confirmed with
+numbers.
+
+What did land this session:
+
+- `tool/bench_render_seam.dart` - the durable, re-runnable benchmark, so the
+  next person who wonders "why not just `port.send` the commands on native?"
+  gets the answer by running it instead of re-litigating it.
+- A pointer comment at the serialize/deserialize seam in
+  `render_worker_isolate.dart` referencing this note.
+
+The safe half (shared bytes, #333) delivered #309's real win; the speculative
+half is now closed out with evidence rather than left as an open TODO.

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -40,6 +40,17 @@ int debugPdfRenderWorkerIgnoredStaleCancels = 0;
 /// just carry a different payload (device geometry in, an encoded [StripPlan]
 /// out) and are cancelled through [PdfRenderWorker.cancelBinStrips] so a
 /// record and a bin for the same page never cancel each other.
+///
+/// The command buffer crosses the seam as a serialized [Uint8List] wrapped in
+/// [TransferableTypedData] (zero-copy transfer), and is rebuilt with
+/// [deserializeCommands] on the main isolate. Passing the live
+/// `List<PdfRenderCommand>` graph over the port instead (issue #309's
+/// "transfer half") was measured and rejected: the VM's general object-graph
+/// copy is ~3–4x slower than the compact byte codec on a dense page and lands
+/// on the receiving UI isolate, and `Isolate.exit`'s zero-copy hand-off would
+/// kill this long-lived pooled worker. See
+/// `packages/pdf_graphics/tool/bench_render_seam.dart` and
+/// `doc/dev-log/2026-07-17-seam-transfer-measurement.md`.
 PdfRenderWorker startRenderWorker(Uint8List bytes) =>
     _IsolateRenderWorker(bytes);
 

--- a/packages/pdf_graphics/tool/bench_render_seam.dart
+++ b/packages/pdf_graphics/tool/bench_render_seam.dart
@@ -1,0 +1,131 @@
+// Benchmark for issue #309's "transfer half": is passing an image-free render
+// command graph directly across a native isolate `SendPort` cheaper than the
+// `serializeCommands`/`deserializeCommands` codec round-trip the native render
+// worker pays today?
+//
+// The codec exists because a Web Worker can only receive structured-cloneable
+// data over `postMessage`; the question #309 raised is whether the *native*
+// isolate adapter should skip it and hand the `List<PdfRenderCommand>` straight
+// over the port instead ("native transfer, web codec" as two adapters).
+//
+// Run:
+//   cd packages/pdf_graphics
+//   fvm dart run tool/bench_render_seam.dart
+//
+// Finding (see doc/dev-log/2026-07-17-seam-transfer-measurement.md): the raw
+// object-graph copy the VM performs for `port.send(commands)` is several times
+// SLOWER than the compact byte codec + zero-copy `TransferableTypedData`, and
+// the cost lands on the *receiving* (UI) isolate. The transfer half is a
+// regression on the dense-page workload it targeted; it is not implemented.
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+/// A synthetic image-free page of [count] fills/strokes, each a small cubic
+/// path - the "dense CAD page (~100k commands)" shape #309 calls out.
+List<PdfRenderCommand> buildDenseVectorPage(int count) {
+  final commands = <PdfRenderCommand>[];
+  var x = 0.0, y = 0.0;
+  for (var i = 0; i < count; i++) {
+    x = (x + 3.14159) % 800;
+    y = (y + 2.71828) % 600;
+    final path = PdfPath([
+      PdfMoveTo(x, y),
+      PdfLineTo(x + 12.5, y + 4.25),
+      PdfCubicTo(x + 1, y + 2, x + 3, y + 4, x + 20.75, y + 9.5),
+      PdfLineTo(x + 2.5, y + 30.125),
+      const PdfClosePath(),
+    ]);
+    commands.add(i.isEven
+        ? PdfFillPathCommand(
+            path, const PdfColor(0.1, 0.2, 0.3), PdfFillRule.nonzero, 1)
+        : PdfStrokePathCommand(
+            path, const PdfColor(0, 0, 0), const PdfStroke(width: 0.75), 0.9));
+  }
+  return commands;
+}
+
+/// An isolate that bounces whatever it receives straight back, so a round-trip
+/// pays the VM's object-graph copy once in each direction.
+Future<void> _echoIsolate(SendPort reply) async {
+  final port = ReceivePort();
+  reply.send(port.sendPort);
+  await for (final message in port) {
+    final m = message as List<Object?>;
+    (m[0] as SendPort).send(m[1]);
+  }
+}
+
+String _ms(int micros, int iters) => (micros / iters / 1000).toStringAsFixed(2);
+
+Future<void> _measure(int cmdCount) async {
+  final commands = buildDenseVectorPage(cmdCount);
+
+  // Correctness + warm-up for the codec path.
+  final wire = serializeCommands(commands, compactStateScopes: true);
+  if (wire == null) {
+    print('serialize returned null (unexpected for an image-free buffer)');
+    return;
+  }
+  final back = deserializeCommands(wire);
+  assert(back.length == commands.length);
+
+  const iters = 15;
+  var serUs = 0, deserUs = 0;
+  for (var i = 0; i < iters; i++) {
+    final sw = Stopwatch()..start();
+    final buf = serializeCommands(commands, compactStateScopes: true)!;
+    serUs += sw.elapsedMicroseconds;
+    sw
+      ..reset()
+      ..start();
+    deserializeCommands(buf);
+    deserUs += sw.elapsedMicroseconds;
+  }
+
+  final fromEcho = ReceivePort();
+  final isolate = await Isolate.spawn(_echoIsolate, fromEcho.sendPort);
+  final broadcast = fromEcho.asBroadcastStream();
+  final echoPort = await broadcast.first as SendPort;
+
+  Future<Object?> bounce(Object? payload) {
+    final rp = ReceivePort();
+    final done = rp.first;
+    echoPort.send([rp.sendPort, payload]);
+    return done;
+  }
+
+  // Sendability + warm-up for the raw-object path.
+  final bounced = await bounce(commands) as List;
+  assert(bounced.length == commands.length);
+
+  const rawIters = 8; // this path is slow; fewer iterations keep it bearable
+  var rawUs = 0;
+  for (var i = 0; i < rawIters; i++) {
+    final sw = Stopwatch()..start();
+    await bounce(commands);
+    rawUs += sw.elapsedMicroseconds;
+  }
+
+  isolate.kill(priority: Isolate.immediate);
+  fromEcho.close();
+
+  print('\n=== $cmdCount image-free commands '
+      '(${(wire.length / 1e6).toStringAsFixed(1)} MB wire) ===');
+  print('  codec serialize   (worker, off UI) : ${_ms(serUs, iters)} ms');
+  print('  codec deserialize (UI thread)       : ${_ms(deserUs, iters)} ms');
+  print('  raw object graph  round-trip        : ${_ms(rawUs, rawIters)} ms '
+      '(~${_ms(rawUs ~/ 2, rawIters)} ms one crossing, on the receiver)');
+}
+
+void main() async {
+  print('render-worker seam: codec byte round-trip vs raw isolate transfer');
+  for (final count in [10000, 100000]) {
+    await _measure(count);
+  }
+  print('\nThe native record path pays serialize off-thread + a zero-copy '
+      'TransferableTypedData transfer; only deserialize lands on the UI '
+      'thread. Replacing that with port.send(commands) moves a much larger '
+      'object-graph copy onto the receiving isolate. Transfer half rejected.');
+}


### PR DESCRIPTION
## Summary

Closes out the second, speculative half of #309. The issue had two parts:

1. **Shared source bytes** across the render-worker pool — a safe memory win. Already landed in #333.
2. **Transfer command graphs** across the native isolate seam directly (`SendPort`/`Isolate.exit`) instead of the `serializeCommands`/`deserializeCommands` codec round-trip — flagged *speculative* / "not pure win" in the issue itself, and left for a follow-up.

This PR does the follow-up the way the issue's own **Measure** section asked: it measures the transfer half and rejects it with evidence.

**Finding.** On #309's own target workload (a dense image-free page, ~100k commands), the VM's general object-graph copy for `port.send(commands)` is **~3–4× slower** than the compact byte codec + zero-copy `TransferableTypedData`, and its cost lands on the *receiving* UI isolate — the exact thread the offload exists to protect:

| workload | codec deserialize (UI) | raw object graph, one crossing |
| --- | --- | --- |
| 10 000 commands | ~8 ms | ~22 ms |
| 100 000 commands | ~112 ms | ~422 ms |

`Isolate.exit`'s zero-copy hand-off is also out: it kills the isolate, and our native backend is a long-lived pooled worker that opens the document once and keeps decoded-image / strip-command caches warm and absorbs edits in place (#308). Exiting per page would re-spawn + re-open + re-warm every page. So the codec (compact bytes + zero-copy transfer) is already close to optimal for the native seam.

No behavioral or API change. What lands:
- `packages/pdf_graphics/tool/bench_render_seam.dart` — a re-runnable benchmark backing the finding (codec byte round-trip vs raw isolate transfer, over real isolates, two page sizes).
- `doc/dev-log/2026-07-17-seam-transfer-measurement.md` — the write-up + numbers + the `Isolate.exit` reasoning.
- A pointer comment at the serialize/deserialize seam in `render_worker_isolate.dart` so the next reader gets the answer instead of re-litigating it.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [x] `pdf_graphics` (benchmark tool only)
- [x] `dart_pdf_editor` (doc comment only)
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Performance change (measurement + decision; no runtime behavior change)
- [x] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (changed files clean)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (`test/render_worker_test.dart`, 49 passing)
- [x] `fvm dart run tool/bench_render_seam.dart` (numbers above, reproduced across two page sizes)

The only production-source change is a documentation comment, so behavior is unchanged; the render-worker suite passing confirms no regression.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`. (The benchmark tool is pure Dart under `pdf_graphics`.)
- [x] No `dart:io` imports in any `lib/` directory. (Tool lives in `tool/`, not `lib/`.)
- [x] Layering is preserved: `pdf_cos` ← `pdf_document` ← `pdf_graphics` ← `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The shared-bytes half (#333) delivered #309's real win; this closes the speculative transfer half with a measured regression rather than leaving it as an open TODO. If you'd rather keep #309 open as a tracking item, the benchmark and dev-log stand on their own regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MYR6XtXGa8KpbncMEPzho

---
_Generated by [Claude Code](https://claude.ai/code/session_012MYR6XtXGa8KpbncMEPzho)_