### PR TITLE
Font menu: pick document fonts, show recents, focus search

### DIFF
--- a/doc/dev-log/2026-07-17-embedded-font-menu-selection.md
+++ b/doc/dev-log/2026-07-17-embedded-font-menu-selection.md
@@ -1,0 +1,83 @@
+# Font menu: document fonts, recents, and search focus
+
+## Goal
+
+Three font-menu improvements:
+
+1. Let the user pick a font **already embedded in the open document**, not
+   just the base-14 families, the bundled trio, platform fonts, and a
+   custom file.
+2. Surface **recently-used fonts** (and the document's own fonts) so common
+   picks are one tap away.
+3. **Focus the search box** as soon as the menu opens, so the user can type
+   to filter immediately.
+
+## What landed
+
+### Enumerating a document's embedded fonts (`pdf_document`)
+
+`font_embedder.dart` gained two public statics on `PdfEmbeddedFont`:
+
+- `fromEmbeddedProgram(cos, fontDict)` - the general sibling of the existing
+  Type0-only `fromFontDict`. It finds the `/FontDescriptor` whether the dict
+  is a simple font (`/TrueType`/`/Type1`, descriptor inline) or a composite
+  `/Type0` (descriptor on the descendant CIDFont), pulls the `/FontFile2`
+  (TrueType) or `/FontFile3` (OpenType) program, and reparses it via
+  `PdfEmbeddedFont.parse`. Bare-CFF `/FontFile3`, Type1 `/FontFile`, and any
+  subset stripped of its `cmap` return null - which conveniently leaves only
+  the fonts whose glyphs newly-typed text can actually map onto.
+- `usedIn(document)` - walks every page's `/Font` resources **and** each
+  annotation's normal-appearance `/Resources` `/Font` (so authored
+  embedded-font free text counts), plus the AcroForm `/DR`, reparsing each
+  through `fromEmbeddedProgram`. Deduplicated by PostScript name; skips
+  anything with no reparsable sfnt program. Fonts nested inside Form
+  XObjects are not walked (out of scope).
+
+Why annotation appearances too: an embedded font authored via the editor
+lives in the free-text box's appearance stream resources, **not** the page
+content resources - so a page-only walk would miss exactly the fonts a user
+just added. `PdfStamp.text` only draws Helvetica, so there's no page-content
+embedding path to lean on for the common case.
+
+### Wiring into the menu (`dart_pdf_editor`)
+
+- `PdfEditingController.documentFonts` caches `PdfEmbeddedFont.usedIn` per
+  revision (keyed by `_document` identity; edits reopen the document so the
+  cache invalidates for free).
+- `showPdfFontMenu` gained a `_DocumentChoice` entry kind and an optional
+  `documentFonts` param (defaulting to `controller.documentFonts`). Document
+  fonts show under an "In this document" subtitle; picking one applies the
+  already-parsed `PdfEmbeddedFont` directly (no byte load).
+- **Recents**: `PdfEditingPreferences.recentFonts` / `noteRecentFont(key)`
+  mirror the existing `recentColors` pattern (persisted string list, cap 6,
+  dedup-to-front). Keys are stable identifiers (`std:sans`, `bundled:<label>`,
+  `platform:<label>`, `doc:<postScriptName>`), **not** font bytes - the menu
+  resolves each key back to a live catalogue entry on open, so a recent that
+  no longer exists (a document font from a since-closed file) just drops out.
+  Custom-loaded (`Load font…`) picks aren't tracked - they can't be
+  reconstructed from a key. Each entry carries a `recentKey`; recents render
+  as a "Recently used" group above the catalogue with their own distinct
+  `pdf-font-recent-N` keys (so a font can appear both in recents and its home
+  section without a duplicate-key clash). Recents show only while the search
+  box is empty; typing filters the whole catalogue instead.
+- The dialog now renders a flat row list where a `String` is a section header
+  ("Recently used" / "All fonts") and a `_FontEntry` is a tappable font.
+- `autofocus: true` on the search `TextField`.
+
+## Tests
+
+- `pdf_document/test/font_used_in_test.dart` - `usedIn` finds/dedups/ignores
+  the right fonts; `fromEmbeddedProgram` reparses vs returns null.
+- `dart_pdf_editor/test/editing_fonts_test.dart` - document fonts appear and
+  embed on pick; a pick reappears under "Recently used" next open and
+  re-applies; the search field is focused on open.
+
+## Gotchas
+
+- Re-embedding a document font only works when its program still carries a
+  usable `cmap` (many full embeds do; aggressive subsets may not) - that's
+  the same gate `parse` already enforces, so unusable fonts simply never
+  reach the menu.
+- Dedup is by name-table PostScript name (clean of the `ABCDEF+` subset tag,
+  which rides on `/BaseFont`, not the name table), so the same face subset
+  across pages collapses to one entry.

--- a/doc/dev-log/2026-07-17-embedded-font-menu-selection.md
+++ b/doc/dev-log/2026-07-17-embedded-font-menu-selection.md
@@ -72,6 +72,28 @@ embedding path to lean on for the common case.
   embed on pick; a pick reappears under "Recently used" next open and
   re-applies; the search field is focused on open.
 
+## Follow-up (same session)
+
+Three menu refinements after review:
+
+- **Document fonts get their own section.** `_FontEntry` gained a `section`
+  label; the dialog now groups the catalogue under headers ("Recently used",
+  then "In this document", then "All fonts") while the query is empty, and
+  flattens (no headers) while searching. Document entries are ordered first
+  so their section leads the catalogue.
+- **Rows preview in their own face.** `_ensureDocumentFontPreview` registers
+  each document font's `fontBytes` with the engine via `FontLoader` under a
+  stable private family (`pdf-doc-font::<postScriptName>`, cached so repeated
+  opens don't re-register), and the row's title renders in it. Best-effort:
+  a font the engine can't load just renders plain and still embeds on pick.
+  Preloaded before the dialog opens (with a `context.mounted` guard after the
+  await). Bundled/standard/platform rows already previewed via their declared
+  families.
+- **Clean names.** `PdfEmbeddedFont.displayName` strips the six-letter
+  `ABCDEF+` subset tag producers prepend (`XAAPZZ+HorbseTextured` ->
+  `HorbseTextured`). Used by the menu row label, the toolbar font chip
+  (`_familyLabel`), the button label (`_fontLabel`), and `activeFontLabel`.
+
 ## Gotchas
 
 - Re-embedding a document font only works when its program still carries a

--- a/doc/dev-log/2026-07-17-embedded-font-menu-selection.md
+++ b/doc/dev-log/2026-07-17-embedded-font-menu-selection.md
@@ -94,6 +94,36 @@ Three menu refinements after review:
   `HorbseTextured`). Used by the menu row label, the toolbar font chip
   (`_familyLabel`), the button label (`_fontLabel`), and `activeFontLabel`.
 
+## Follow-up 2: subset fonts (preview + typing honesty)
+
+Real documents embed **subset** fonts: the producer keeps the full `cmap`
+but strips the `glyf` outline of every glyph the file never draws. So a
+recovered document font maps a character to a glyph that renders blank -
+previewing its own name drops letters (`Montern` -> "ontern", `HomemadeApple`
+-> "omemadeApple"), and, more importantly, **typing** new text in it drops
+any character the subset lacks. The outlines aren't in the file; nothing can
+recover them.
+
+- `PdfEmbeddedFont.glyphHasOutline(gid)` reads the TrueType `loca`/`glyf`
+  tables and reports whether a glyph's entry is non-empty (empty entry =
+  stripped glyph). `canRender(text)` = every non-space rune maps to a glyph
+  with an outline. Both are conservative: CFF/OpenType and unreadable tables
+  return "has outline", so we only ever suppress a preview we can *prove* is
+  blank. (`cmap` presence alone is not enough - hence `glyphForRune > 0` is
+  insufficient; the outline must exist.)
+- **Preview gate**: a document row previews in its own face only when
+  `canRender(displayName)`; otherwise it renders in the legible UI font. No
+  more half-blank names.
+- **Typing honesty** (user asked): a document subset that can't cover the
+  basic alphabet (`_typeableProbe` = A–Z a–z 0–9) is flagged **"Limited
+  characters"** with a warning icon + tooltip, because typing in it would drop
+  glyphs. It stays selectable (useful for re-typing text the file already
+  contains). Decision was "mark them", not hide/substitute.
+- Detection was validated against the user's real 235-page PDF: 10/12 fonts
+  correctly flagged limited, matching the blanks seen in the screenshot
+  (`Montern` blank="M", `HomemadeApple` blank="H", etc.); `NoyhABistro-Rough`
+  and `FranklinGothic-Demi` cover their names and preview cleanly.
+
 ## Gotchas
 
 - Re-embedding a document font only works when its program still carries a

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1190,7 +1190,7 @@ class PdfEditingController extends ChangeNotifier {
   /// be written in (the embedded font's family, or the standard family).
   String get activeFontLabel =>
       selectedMeasurementCaptionStyle?.font.family.label ??
-      _activeFont?.familyName ??
+      _activeFont?.displayName ??
       preferences.fontFamily.family.label;
 
   /// Parses [bytes] as a TrueType (.ttf) or OpenType (.otf) font and

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1205,6 +1205,22 @@ class PdfEditingController extends ChangeNotifier {
     }
   }
 
+  PdfDocument? _documentFontsFor;
+  List<PdfEmbeddedFont>? _documentFontsCache;
+
+  /// The embeddable fonts the current document already uses (see
+  /// [PdfEmbeddedFont.usedIn]) - offered in the font menu so new free text
+  /// can reuse a face the file already carries. Parsed once per revision
+  /// and cached; the list is empty when nothing embeddable is found.
+  List<PdfEmbeddedFont> get documentFonts {
+    if (!identical(_documentFontsFor, _document) ||
+        _documentFontsCache == null) {
+      _documentFontsFor = _document;
+      _documentFontsCache = PdfEmbeddedFont.usedIn(_document);
+    }
+    return _documentFontsCache!;
+  }
+
   /// Whether new annotations are non-solid - the legacy boolean view of
   /// [preferences.lineStyle] (kept for the drag previews that only show
   /// dashed/solid).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter/services.dart' show FontLoader, rootBundle;
 import 'package:pdf_document/pdf_document.dart';
 
 import 'editing_controller.dart';
@@ -236,8 +236,31 @@ class _LoadChoice extends _FontChoice {
 String? _fontLabel(PdfTextFont? font) {
   if (font == null) return null;
   if (font is PdfStandardFont) return font.family.label;
-  if (font is PdfEmbeddedFont) return font.familyName;
+  if (font is PdfEmbeddedFont) return font.displayName;
   return font.resourceName;
+}
+
+/// Family names of document fonts already registered with the engine for
+/// menu previews (see [_ensureDocumentFontPreview]), so each embeds once.
+final Set<String> _documentPreviewFamilies = <String>{};
+
+/// Registers [font]'s program bytes with the engine under a private family
+/// name so a menu entry can preview it in its own face, and returns that
+/// name (null when the engine can't load it, e.g. in a headless test). The
+/// name is stable per PostScript name and cached, so repeated menu opens
+/// don't re-register the same face.
+Future<String?> _ensureDocumentFontPreview(PdfEmbeddedFont font) async {
+  final family = 'pdf-doc-font::${font.postScriptName}';
+  if (_documentPreviewFamilies.contains(family)) return family;
+  try {
+    await (FontLoader(family)
+          ..addFont(Future.value(ByteData.sublistView(font.fontBytes))))
+        .load();
+    _documentPreviewFamilies.add(family);
+    return family;
+  } catch (_) {
+    return null; // preview only - the font still embeds fine on pick
+  }
 }
 
 class _FontEntry {
@@ -250,6 +273,7 @@ class _FontEntry {
     this.fontFamily,
     this.package,
     this.recentKey,
+    this.section,
   });
 
   final Key key;
@@ -264,6 +288,10 @@ class _FontEntry {
   /// group (see [PdfEditingPreferences.recentFonts]); null for entries that
   /// aren't tracked as recents (the "Load font…" action).
   final String? recentKey;
+
+  /// The section header this entry is grouped under in the menu ("In this
+  /// document", "All fonts"); null groups it with the preceding entry.
+  final String? section;
 }
 
 class _PdfFontPickerDialog extends StatefulWidget {
@@ -295,16 +323,23 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
   Widget build(BuildContext context) {
     final query = _search.text.trim().toLowerCase();
     // A flat list of rows: a String is a section header, a _FontEntry a
-    // tappable font. Recents (and their headers) show only for an empty
-    // query - searching filters the whole catalogue instead.
+    // tappable font. While the query is empty the list is grouped under
+    // section headers ("Recently used", then each entry's own section);
+    // searching flattens it, filtering the whole catalogue with no headers.
     final rows = <Object>[];
     if (query.isEmpty) {
       if (widget.recent.isNotEmpty) {
         rows.add('Recently used');
         rows.addAll(widget.recent);
-        rows.add('All fonts');
       }
-      rows.addAll(widget.entries);
+      String? lastSection;
+      for (final entry in widget.entries) {
+        if (entry.section != null && entry.section != lastSection) {
+          rows.add(entry.section!);
+          lastSection = entry.section;
+        }
+        rows.add(entry);
+      }
     } else {
       rows.addAll(
           widget.entries.where((entry) => entry.searchText.contains(query)));
@@ -414,7 +449,36 @@ Future<void> showPdfFontMenu({
 }) async {
   final platform = platformFonts ?? pdfPlatformFonts;
   final inDocument = documentFonts ?? controller.documentFonts;
+
+  // Register each document font's outlines with the engine (best-effort) so
+  // its menu row can preview in its own face. A font that fails to register
+  // just renders in the default face; it still embeds fine on pick.
+  final previewFamilies = <int, String>{};
+  await Future.wait([
+    for (var i = 0; i < inDocument.length; i++)
+      _ensureDocumentFontPreview(inDocument[i]).then((family) {
+        if (family != null) previewFamilies[i] = family;
+      }),
+  ]);
+  if (!context.mounted) return;
+
   final entries = <_FontEntry>[
+    // Document fonts head the catalogue in their own "In this document"
+    // section, previewed in their own face and shown by their real family
+    // name (subset tag stripped).
+    for (var i = 0; i < inDocument.length; i++)
+      _FontEntry(
+        key: ValueKey('pdf-font-document-$i'),
+        label: inDocument[i].displayName,
+        searchText: '${inDocument[i].displayName} '
+                '${inDocument[i].familyName} ${inDocument[i].postScriptName} '
+                'document embedded font'
+            .toLowerCase(),
+        choice: _DocumentChoice(inDocument[i]),
+        fontFamily: previewFamilies[i],
+        recentKey: 'doc:${inDocument[i].postScriptName}',
+        section: 'In this document',
+      ),
     const _FontEntry(
       key: ValueKey('pdf-font-std-sans'),
       label: 'Sans (Helvetica)',
@@ -423,6 +487,7 @@ Future<void> showPdfFontMenu({
       choice: _StandardChoice(PdfStandardFontFamily.sans),
       fontFamily: 'Helvetica',
       recentKey: 'std:sans',
+      section: 'All fonts',
     ),
     const _FontEntry(
       key: ValueKey('pdf-font-std-serif'),
@@ -432,6 +497,7 @@ Future<void> showPdfFontMenu({
       choice: _StandardChoice(PdfStandardFontFamily.serif),
       fontFamily: 'Times New Roman',
       recentKey: 'std:serif',
+      section: 'All fonts',
     ),
     const _FontEntry(
       key: ValueKey('pdf-font-std-mono'),
@@ -441,18 +507,8 @@ Future<void> showPdfFontMenu({
       choice: _StandardChoice(PdfStandardFontFamily.mono),
       fontFamily: 'Courier',
       recentKey: 'std:mono',
+      section: 'All fonts',
     ),
-    for (var i = 0; i < inDocument.length; i++)
-      _FontEntry(
-        key: ValueKey('pdf-font-document-$i'),
-        label: inDocument[i].familyName,
-        subtitle: 'In this document',
-        searchText: '${inDocument[i].familyName} '
-                '${inDocument[i].postScriptName} document embedded font'
-            .toLowerCase(),
-        choice: _DocumentChoice(inDocument[i]),
-        recentKey: 'doc:${inDocument[i].postScriptName}',
-      ),
     for (var i = 0; i < bundled.length; i++)
       _FontEntry(
         key: ValueKey('pdf-font-bundled-$i'),
@@ -463,6 +519,7 @@ Future<void> showPdfFontMenu({
         fontFamily: bundled[i].label,
         package: 'dart_pdf_editor',
         recentKey: 'bundled:${bundled[i].label}',
+        section: 'All fonts',
       ),
     for (var i = 0; i < platform.length; i++)
       _FontEntry(
@@ -475,6 +532,7 @@ Future<void> showPdfFontMenu({
         choice: _PlatformChoice(platform[i]),
         fontFamily: platform[i].family,
         recentKey: 'platform:${platform[i].label}',
+        section: 'All fonts',
       ),
     if (fontPicker != null)
       const _FontEntry(
@@ -483,6 +541,7 @@ Future<void> showPdfFontMenu({
         subtitle: 'TTF or OTF file',
         searchText: 'load custom font ttf otf file upload',
         choice: _LoadChoice(),
+        section: 'All fonts',
       ),
   ];
 
@@ -506,6 +565,7 @@ Future<void> showPdfFontMenu({
       fontFamily: match.fontFamily,
       package: match.package,
       recentKey: match.recentKey,
+      section: match.section,
     ));
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
@@ -221,6 +221,14 @@ class _PlatformChoice extends _FontChoice {
   final PdfPlatformFont font;
 }
 
+class _DocumentChoice extends _FontChoice {
+  const _DocumentChoice(this.font);
+
+  /// A font already embedded in the open document, reparsed into a
+  /// re-embeddable [PdfEmbeddedFont] - picking it needs no byte loading.
+  final PdfEmbeddedFont font;
+}
+
 class _LoadChoice extends _FontChoice {
   const _LoadChoice();
 }
@@ -241,6 +249,7 @@ class _FontEntry {
     this.subtitle,
     this.fontFamily,
     this.package,
+    this.recentKey,
   });
 
   final Key key;
@@ -250,12 +259,23 @@ class _FontEntry {
   final _FontChoice choice;
   final String? fontFamily;
   final String? package;
+
+  /// The opaque key this entry is remembered under in the "Recently used"
+  /// group (see [PdfEditingPreferences.recentFonts]); null for entries that
+  /// aren't tracked as recents (the "Load font…" action).
+  final String? recentKey;
 }
 
 class _PdfFontPickerDialog extends StatefulWidget {
-  const _PdfFontPickerDialog({required this.entries});
+  const _PdfFontPickerDialog({required this.entries, this.recent = const []});
 
+  /// The full font catalogue (standard, document, bundled, platform, load).
   final List<_FontEntry> entries;
+
+  /// The "Recently used" group, newest first, shown above the catalogue
+  /// while the search box is empty. Distinct keys from their catalogue
+  /// twins so both can appear at once.
+  final List<_FontEntry> recent;
 
   @override
   State<_PdfFontPickerDialog> createState() => _PdfFontPickerDialogState();
@@ -274,11 +294,22 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
   @override
   Widget build(BuildContext context) {
     final query = _search.text.trim().toLowerCase();
-    final entries = query.isEmpty
-        ? widget.entries
-        : widget.entries
-            .where((entry) => entry.searchText.contains(query))
-            .toList();
+    // A flat list of rows: a String is a section header, a _FontEntry a
+    // tappable font. Recents (and their headers) show only for an empty
+    // query - searching filters the whole catalogue instead.
+    final rows = <Object>[];
+    if (query.isEmpty) {
+      if (widget.recent.isNotEmpty) {
+        rows.add('Recently used');
+        rows.addAll(widget.recent);
+        rows.add('All fonts');
+      }
+      rows.addAll(widget.entries);
+    } else {
+      rows.addAll(
+          widget.entries.where((entry) => entry.searchText.contains(query)));
+    }
+    final hasEntries = rows.any((row) => row is _FontEntry);
     return Dialog(
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 380, maxHeight: 500),
@@ -293,6 +324,7 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
               TextField(
                 key: const ValueKey('pdf-font-search'),
                 controller: _search,
+                autofocus: true,
                 decoration: const InputDecoration(
                   isDense: true,
                   prefixIcon: Icon(Icons.search),
@@ -302,7 +334,7 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
               ),
               const SizedBox(height: 8),
               Flexible(
-                child: entries.isEmpty
+                child: !hasEntries
                     ? const Center(
                         child: Padding(
                           padding: EdgeInsets.all(24),
@@ -312,9 +344,11 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
                       )
                     : ListView.builder(
                         shrinkWrap: true,
-                        itemCount: entries.length,
+                        itemCount: rows.length,
                         itemBuilder: (context, index) {
-                          final entry = entries[index];
+                          final row = rows[index];
+                          if (row is String) return _sectionHeader(context, row);
+                          final entry = row as _FontEntry;
                           return ListTile(
                             key: entry.key,
                             dense: true,
@@ -342,24 +376,44 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
       ),
     );
   }
+
+  Widget _sectionHeader(BuildContext context, String label) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 12, 4, 4),
+      child: Text(
+        label.toUpperCase(),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.primary,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
 }
 
 /// Pops a font menu anchored at [context]'s widget and applies the pick:
-/// the standard families, the [bundled] fonts, the platform fonts
-/// ([platformFonts], defaulting to the host-populated [pdfPlatformFonts]
-/// registry), then "Load font…" (when a [fontPicker] is given). The menu
-/// is searchable. Bundled, platform and custom fonts embed into the
-/// document so the text renders everywhere.
+/// the standard families, the fonts already embedded in the open document
+/// ([documentFonts], defaulting to [PdfEditingController.documentFonts]),
+/// the [bundled] fonts, the platform fonts ([platformFonts], defaulting to
+/// the host-populated [pdfPlatformFonts] registry), then "Load font…" (when
+/// a [fontPicker] is given). Recently-picked fonts head the list in a
+/// "Recently used" group. The search field is focused on open and the menu
+/// is searchable. Bundled, platform, document and custom fonts embed into
+/// the document so the text renders everywhere.
 Future<void> showPdfFontMenu({
   required BuildContext context,
   required PdfEditingController controller,
   PdfFontPicker? fontPicker,
   List<PdfBundledFont> bundled = pdfBundledFonts,
   List<PdfPlatformFont>? platformFonts,
+  List<PdfEmbeddedFont>? documentFonts,
   PdfTextFont? currentFont,
   void Function(PdfTextFont font)? onSelected,
 }) async {
   final platform = platformFonts ?? pdfPlatformFonts;
+  final inDocument = documentFonts ?? controller.documentFonts;
   final entries = <_FontEntry>[
     const _FontEntry(
       key: ValueKey('pdf-font-std-sans'),
@@ -368,6 +422,7 @@ Future<void> showPdfFontMenu({
       searchText: 'sans helvetica standard pdf font',
       choice: _StandardChoice(PdfStandardFontFamily.sans),
       fontFamily: 'Helvetica',
+      recentKey: 'std:sans',
     ),
     const _FontEntry(
       key: ValueKey('pdf-font-std-serif'),
@@ -376,6 +431,7 @@ Future<void> showPdfFontMenu({
       searchText: 'serif times times-roman standard pdf font',
       choice: _StandardChoice(PdfStandardFontFamily.serif),
       fontFamily: 'Times New Roman',
+      recentKey: 'std:serif',
     ),
     const _FontEntry(
       key: ValueKey('pdf-font-std-mono'),
@@ -384,7 +440,19 @@ Future<void> showPdfFontMenu({
       searchText: 'mono monospace courier standard pdf font',
       choice: _StandardChoice(PdfStandardFontFamily.mono),
       fontFamily: 'Courier',
+      recentKey: 'std:mono',
     ),
+    for (var i = 0; i < inDocument.length; i++)
+      _FontEntry(
+        key: ValueKey('pdf-font-document-$i'),
+        label: inDocument[i].familyName,
+        subtitle: 'In this document',
+        searchText: '${inDocument[i].familyName} '
+                '${inDocument[i].postScriptName} document embedded font'
+            .toLowerCase(),
+        choice: _DocumentChoice(inDocument[i]),
+        recentKey: 'doc:${inDocument[i].postScriptName}',
+      ),
     for (var i = 0; i < bundled.length; i++)
       _FontEntry(
         key: ValueKey('pdf-font-bundled-$i'),
@@ -394,6 +462,7 @@ Future<void> showPdfFontMenu({
         choice: _BundledChoice(bundled[i]),
         fontFamily: bundled[i].label,
         package: 'dart_pdf_editor',
+        recentKey: 'bundled:${bundled[i].label}',
       ),
     for (var i = 0; i < platform.length; i++)
       _FontEntry(
@@ -405,6 +474,7 @@ Future<void> showPdfFontMenu({
             .toLowerCase(),
         choice: _PlatformChoice(platform[i]),
         fontFamily: platform[i].family,
+        recentKey: 'platform:${platform[i].label}',
       ),
     if (fontPicker != null)
       const _FontEntry(
@@ -416,9 +486,32 @@ Future<void> showPdfFontMenu({
       ),
   ];
 
+  // Resolve the persisted recent keys back to live catalogue entries, newest
+  // first, giving each a distinct key so it can sit above its twin. Keys with
+  // no current match (e.g. a document font from a since-closed file) drop out.
+  final byRecentKey = <String, _FontEntry>{};
+  for (final entry in entries) {
+    if (entry.recentKey case final key?) byRecentKey.putIfAbsent(key, () => entry);
+  }
+  final recent = <_FontEntry>[];
+  for (final key in controller.preferences.recentFonts) {
+    final match = byRecentKey[key];
+    if (match == null) continue;
+    recent.add(_FontEntry(
+      key: ValueKey('pdf-font-recent-${recent.length}'),
+      label: match.label,
+      subtitle: match.subtitle,
+      searchText: match.searchText,
+      choice: match.choice,
+      fontFamily: match.fontFamily,
+      package: match.package,
+      recentKey: match.recentKey,
+    ));
+  }
+
   final choice = await showDialog<_FontChoice>(
     context: context,
-    builder: (_) => _PdfFontPickerDialog(entries: entries),
+    builder: (_) => _PdfFontPickerDialog(entries: entries, recent: recent),
   );
   if (choice == null) return;
 
@@ -430,6 +523,11 @@ Future<void> showPdfFontMenu({
     }
   }
 
+  // Records the pick as the newest recent, so the next open floats it up.
+  void noteRecent(String? key) {
+    if (key != null) controller.preferences.noteRecentFont(key);
+  }
+
   switch (choice) {
     case _StandardChoice(:final family):
       final current = currentFont ??
@@ -439,10 +537,15 @@ Future<void> showPdfFontMenu({
       apply(PdfStandardFont.styled(family,
           bold: current is PdfStandardFont && current.isBold,
           italic: current is PdfStandardFont && current.isItalic));
+      noteRecent('std:${family.name}');
+    case _DocumentChoice(:final font):
+      apply(font);
+      noteRecent('doc:${font.postScriptName}');
     case _BundledChoice(:final font):
       try {
         final bytes = await loadBundledFont(font);
         apply(PdfEmbeddedFont.parse(bytes));
+        noteRecent('bundled:${font.label}');
       } catch (_) {
         // A missing/corrupt bundled asset just leaves the font unchanged.
       }
@@ -451,6 +554,7 @@ Future<void> showPdfFontMenu({
         final bytes = await font.loadBytes();
         if (bytes != null) {
           apply(PdfEmbeddedFont.parse(bytes));
+          noteRecent('platform:${font.label}');
         }
       } catch (_) {
         // An unreadable/unsupported platform font (e.g. .ttc, WOFF, or one

--- a/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
@@ -244,6 +244,14 @@ String? _fontLabel(PdfTextFont? font) {
 /// menu previews (see [_ensureDocumentFontPreview]), so each embeds once.
 final Set<String> _documentPreviewFamilies = <String>{};
 
+/// The basic Latin alphabet and digits a font must fully cover to be typed
+/// freely. A document font is usually a subset carrying only the glyphs the
+/// file already draws (see [PdfEmbeddedFont.canRender]); one that can't draw
+/// all of these is flagged "limited" in the menu, because new text typed in
+/// it would drop the characters the subset lacks.
+const String _typeableProbe = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    'abcdefghijklmnopqrstuvwxyz0123456789';
+
 /// Registers [font]'s program bytes with the engine under a private family
 /// name so a menu entry can preview it in its own face, and returns that
 /// name (null when the engine can't load it, e.g. in a headless test). The
@@ -274,6 +282,7 @@ class _FontEntry {
     this.package,
     this.recentKey,
     this.section,
+    this.limited = false,
   });
 
   final Key key;
@@ -283,6 +292,11 @@ class _FontEntry {
   final _FontChoice choice;
   final String? fontFamily;
   final String? package;
+
+  /// Whether this is a document subset font that can't cover the basic Latin
+  /// alphabet, so typing new text in it would drop unavailable characters -
+  /// the menu flags it with a caption and a warning icon.
+  final bool limited;
 
   /// The opaque key this entry is remembered under in the "Recently used"
   /// group (see [PdfEditingPreferences.recentFonts]); null for entries that
@@ -399,6 +413,20 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
                                 ? null
                                 : Text(entry.subtitle!,
                                     overflow: TextOverflow.ellipsis),
+                            trailing: entry.limited
+                                ? Tooltip(
+                                    message: 'This font is subset - only the '
+                                        'characters already used in the '
+                                        'document can be typed.',
+                                    child: Icon(
+                                      Icons.warning_amber_rounded,
+                                      size: 18,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .outline,
+                                    ),
+                                  )
+                                : null,
                             onTap: () =>
                                 Navigator.of(context).pop(entry.choice),
                           );
@@ -451,14 +479,21 @@ Future<void> showPdfFontMenu({
   final inDocument = documentFonts ?? controller.documentFonts;
 
   // Register each document font's outlines with the engine (best-effort) so
-  // its menu row can preview in its own face. A font that fails to register
-  // just renders in the default face; it still embeds fine on pick.
+  // its menu row can preview in its own face. Only fonts that can actually
+  // draw their whole name get a preview: document fonts are usually subsets
+  // whose unused glyphs were stripped (the cmap survives but the outline is
+  // empty), so previewing their name would drop letters - those render in the
+  // legible UI face instead. A font that fails to register also falls back.
+  // A document subset that can't cover the basic alphabet can only type the
+  // characters the file already used, so flag it "limited".
+  final limited = [for (final f in inDocument) !f.canRender(_typeableProbe)];
   final previewFamilies = <int, String>{};
   await Future.wait([
     for (var i = 0; i < inDocument.length; i++)
-      _ensureDocumentFontPreview(inDocument[i]).then((family) {
-        if (family != null) previewFamilies[i] = family;
-      }),
+      if (inDocument[i].canRender(inDocument[i].displayName))
+        _ensureDocumentFontPreview(inDocument[i]).then((family) {
+          if (family != null) previewFamilies[i] = family;
+        }),
   ]);
   if (!context.mounted) return;
 
@@ -470,6 +505,7 @@ Future<void> showPdfFontMenu({
       _FontEntry(
         key: ValueKey('pdf-font-document-$i'),
         label: inDocument[i].displayName,
+        subtitle: limited[i] ? 'Limited characters' : null,
         searchText: '${inDocument[i].displayName} '
                 '${inDocument[i].familyName} ${inDocument[i].postScriptName} '
                 'document embedded font'
@@ -478,6 +514,7 @@ Future<void> showPdfFontMenu({
         fontFamily: previewFamilies[i],
         recentKey: 'doc:${inDocument[i].postScriptName}',
         section: 'In this document',
+        limited: limited[i],
       ),
     const _FontEntry(
       key: ValueKey('pdf-font-std-sans'),
@@ -566,6 +603,7 @@ Future<void> showPdfFontMenu({
       package: match.package,
       recentKey: match.recentKey,
       section: match.section,
+      limited: match.limited,
     ));
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -74,6 +74,7 @@ class PdfEditingPreferences extends ChangeNotifier {
   ThemeMode _themeMode = ThemeMode.system;
   PdfColorFormat _colorPickerFormat = PdfColorFormat.hex;
   List<Color> _recentColors = const [];
+  List<String> _recentFonts = const [];
   Color _pageColor = const Color(0xFFFFFFFF);
   bool _showAnnotations = true;
   bool _highlightFormFields = true;
@@ -203,6 +204,10 @@ class PdfEditingPreferences extends ChangeNotifier {
           for (final entry in recentColors)
             if (int.tryParse(entry) case final rgb?) Color(0xFF000000 | rgb),
         ]);
+      }
+      final recentFonts = store.getStringList('${_prefix}recentFonts');
+      if (recentFonts != null) {
+        _recentFonts = List.unmodifiable(recentFonts);
       }
       final pageColor = store.getInt('${_prefix}pageColor');
       if (pageColor != null) _pageColor = Color(pageColor);
@@ -803,6 +808,36 @@ class PdfEditingPreferences extends ChangeNotifier {
     _recentColors = List.unmodifiable(next);
     _write((s) => s.setStringList('${_prefix}recentColors',
         [for (final c in _recentColors) '${c.toARGB32() & 0xFFFFFF}']));
+    notifyListeners();
+  }
+
+  /// How many recently-picked fonts to remember (see [recentFonts]).
+  static const _maxRecentFonts = 6;
+
+  /// Opaque keys of the fonts most recently chosen in the font menu, newest
+  /// first - the menu's "Recently used" group. Each key identifies a menu
+  /// entry (a standard family, a bundled/platform font, or a document font)
+  /// rather than carrying font bytes, so the menu resolves it back to a live
+  /// choice; keys no longer present (e.g. a document font from a closed file)
+  /// are simply skipped. Persisted on the device.
+  List<String> get recentFonts => _recentFonts;
+
+  /// Records [key] as the most-recently-used font, moving it to the front
+  /// (deduplicated) and dropping the oldest past [_maxRecentFonts]. A no-op
+  /// when [key] is empty or already the newest entry.
+  void noteRecentFont(String key) {
+    if (key.isEmpty) return;
+    if (_recentFonts.isNotEmpty && _recentFonts.first == key) return;
+    final next = [
+      key,
+      for (final existing in _recentFonts)
+        if (existing != key) existing,
+    ];
+    if (next.length > _maxRecentFonts) {
+      next.removeRange(_maxRecentFonts, next.length);
+    }
+    _recentFonts = List.unmodifiable(next);
+    _write((s) => s.setStringList('${_prefix}recentFonts', _recentFonts));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -3945,7 +3945,7 @@ class _FontChip extends StatelessWidget {
     // an embedded/bundled/custom face shows its own name, not the base-14
     // family "Sans" - matching the style popup's font button
     if (font is! PdfStandardFont) {
-      return font is PdfEmbeddedFont ? font.familyName : font.resourceName;
+      return font is PdfEmbeddedFont ? font.displayName : font.resourceName;
     }
     final base = font.family.label;
     final suffix = switch ((font.isBold, font.isItalic)) {

--- a/packages/dart_pdf_editor/test/editing_fonts_test.dart
+++ b/packages/dart_pdf_editor/test/editing_fonts_test.dart
@@ -280,6 +280,14 @@ void main() {
       // It sits under its own "In this document" section header.
       expect(find.text('IN THIS DOCUMENT'), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-font-document-0')), findsOneWidget);
+      // DejaVu is a full font (covers the basic alphabet), so it is not
+      // flagged "limited".
+      expect(
+          find.descendant(
+            of: find.byKey(const ValueKey('pdf-font-document-0')),
+            matching: find.text('Limited characters'),
+          ),
+          findsNothing);
 
       await tester.tap(find.byKey(const ValueKey('pdf-font-document-0')));
       await tester.pumpAndSettle();

--- a/packages/dart_pdf_editor/test/editing_fonts_test.dart
+++ b/packages/dart_pdf_editor/test/editing_fonts_test.dart
@@ -248,5 +248,69 @@ void main() {
       await tester.pumpAndSettle();
       expect(c.activeFont, isNull);
     });
+
+    testWidgets('the search field is focused when the menu opens',
+        (tester) async {
+      final c = PdfEditingController(buildMultiPagePdf(1));
+      await pumpButton(tester, c);
+      await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
+      await tester.pumpAndSettle();
+      final editable = tester.widget<EditableText>(find.descendant(
+        of: find.byKey(const ValueKey('pdf-font-search')),
+        matching: find.byType(EditableText),
+      ));
+      expect(editable.focusNode.hasFocus, isTrue);
+    });
+
+    testWidgets('fonts embedded in the document are offered and embed on pick',
+        (tester) async {
+      // Author some free text in an embedded font so the document carries it,
+      // then reopen: the font now appears under "In this document".
+      final c = PdfEditingController(buildMultiPagePdf(1))
+        ..setCustomFont(_fontBytes);
+      c.addFreeText(0, const PdfRect(72, 600, 300, 660), 'Embedded');
+      // Back to a standard family - the embedded face is only in the document.
+      c.fontFamily = PdfStandardFont.helvetica;
+      expect(c.activeFont, isNull);
+      expect(c.documentFonts, isNotEmpty);
+
+      await pumpButton(tester, c);
+      await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-font-search')), 'dejavu');
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-font-document-0')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-font-document-0')));
+      await tester.pumpAndSettle();
+      expect(c.activeFont, isNotNull);
+      expect(c.activeFontLabel, contains('DejaVu'));
+    });
+
+    testWidgets('a picked font shows up under "Recently used" next time',
+        (tester) async {
+      final c = PdfEditingController(buildMultiPagePdf(1));
+      await c.preferences.ready;
+      await pumpButton(tester, c);
+
+      // No recents yet on first open.
+      await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
+      await tester.pumpAndSettle();
+      expect(find.text('RECENTLY USED'), findsNothing);
+      await tester.tap(find.byKey(const ValueKey('pdf-font-std-serif')));
+      await tester.pumpAndSettle();
+      expect(c.preferences.recentFonts, contains('std:serif'));
+
+      // Reopen: Serif now heads the list in the recents group.
+      await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
+      await tester.pumpAndSettle();
+      expect(find.text('RECENTLY USED'), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-font-recent-0')), findsOneWidget);
+      // Picking the recent entry applies the same choice.
+      await tester.tap(find.byKey(const ValueKey('pdf-font-recent-0')));
+      await tester.pumpAndSettle();
+      expect(c.fontFamily.family, PdfStandardFontFamily.serif);
+    });
   });
 }

--- a/packages/dart_pdf_editor/test/editing_fonts_test.dart
+++ b/packages/dart_pdf_editor/test/editing_fonts_test.dart
@@ -277,15 +277,32 @@ void main() {
       await pumpButton(tester, c);
       await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
       await tester.pumpAndSettle();
-      await tester.enterText(
-          find.byKey(const ValueKey('pdf-font-search')), 'dejavu');
-      await tester.pump();
+      // It sits under its own "In this document" section header.
+      expect(find.text('IN THIS DOCUMENT'), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-font-document-0')), findsOneWidget);
 
       await tester.tap(find.byKey(const ValueKey('pdf-font-document-0')));
       await tester.pumpAndSettle();
       expect(c.activeFont, isNotNull);
       expect(c.activeFontLabel, contains('DejaVu'));
+    });
+
+    testWidgets('a document font row previews in its own registered face',
+        (tester) async {
+      final c = PdfEditingController(buildMultiPagePdf(1))
+        ..setCustomFont(_fontBytes);
+      c.addFreeText(0, const PdfRect(72, 600, 300, 660), 'Embedded');
+      c.fontFamily = PdfStandardFont.helvetica;
+
+      await pumpButton(tester, c);
+      await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
+      await tester.pumpAndSettle();
+      final title = tester.widget<Text>(find.descendant(
+        of: find.byKey(const ValueKey('pdf-font-document-0')),
+        matching: find.byType(Text),
+      ));
+      // The row renders in the font's own registered preview family.
+      expect(title.style?.fontFamily, startsWith('pdf-doc-font::'));
     });
 
     testWidgets('a picked font shows up under "Recently used" next time',

--- a/packages/pdf_document/lib/src/font_embedder.dart
+++ b/packages/pdf_document/lib/src/font_embedder.dart
@@ -372,6 +372,64 @@ class PdfEmbeddedFont implements PdfTextFont {
   /// The glyph id for [rune], or 0 (.notdef) when the font lacks it.
   int glyphForRune(int rune) => _cmap.gidFor(rune);
 
+  /// Whether [gid]'s TrueType outline actually has contours - i.e. its `glyf`
+  /// entry is non-empty.
+  ///
+  /// Subsetters keep a font's full `cmap` but empty the `glyf` of every glyph
+  /// the document never draws, so [glyphForRune] can map a character to a
+  /// glyph that renders blank. This distinguishes a real glyph from a
+  /// stripped one. Returns true for CFF/OpenType outlines (not checkable this
+  /// cheaply) and whenever the tables can't be read, so callers only ever
+  /// *suppress* a preview they can prove is blank, never a real one.
+  bool glyphHasOutline(int gid) {
+    if (_isCff || gid < 0) return true;
+    try {
+      final data = ByteData.sublistView(_bytes);
+      final numTables = data.getUint16(4);
+      int? headOffset, locaOffset, locaLength, glyfOffset;
+      for (var i = 0; i < numTables; i++) {
+        final rec = 12 + i * 16;
+        final tag = String.fromCharCodes(_bytes, rec, rec + 4);
+        final offset = data.getUint32(rec + 8);
+        switch (tag) {
+          case 'head':
+            headOffset = offset;
+          case 'loca':
+            locaOffset = offset;
+            locaLength = data.getUint32(rec + 12);
+          case 'glyf':
+            glyfOffset = offset;
+        }
+      }
+      if (headOffset == null || locaOffset == null || glyfOffset == null) {
+        return true; // no glyf-based outlines to check
+      }
+      // indexToLocFormat (head + 50): 0 = short (2-byte, *2), 1 = long (4-byte)
+      final longLoca = data.getInt16(headOffset + 50) != 0;
+      final entries = longLoca ? locaLength! ~/ 4 : locaLength! ~/ 2;
+      if (gid + 1 >= entries) return true; // out of range - don't second-guess
+      int locaAt(int g) => longLoca
+          ? data.getUint32(locaOffset! + g * 4)
+          : data.getUint16(locaOffset! + g * 2) * 2;
+      // An empty glyf entry has zero length (start == end offset).
+      return locaAt(gid + 1) > locaAt(gid);
+    } catch (_) {
+      return true;
+    }
+  }
+
+  /// Whether this font can draw every non-space character of [text] with a
+  /// real (non-empty) glyph - so [text] can be previewed in this face without
+  /// missing letters. Spaces are ignored (their empty glyf is expected).
+  bool canRender(String text) {
+    for (final rune in text.runes) {
+      if (rune == 0x20) continue;
+      final gid = glyphForRune(rune);
+      if (gid == 0 || !glyphHasOutline(gid)) return false;
+    }
+    return true;
+  }
+
   /// Advance width of [gid] in thousandths of an em.
   int advanceForGlyph(int gid) {
     if (_numHMetrics == 0) return 0;

--- a/packages/pdf_document/lib/src/font_embedder.dart
+++ b/packages/pdf_document/lib/src/font_embedder.dart
@@ -60,6 +60,15 @@ class PdfEmbeddedFont implements PdfTextFont {
   /// A human-friendly family name (name table id 1), for font menus.
   final String familyName;
 
+  /// [familyName] with the six-letter subset tag PDF producers prepend to a
+  /// subsetted font stripped (e.g. `XAAPZZ+HorbseTextured` ->
+  /// `HorbseTextured`) - what a font menu should show for a font recovered
+  /// from a document.
+  String get displayName {
+    final match = RegExp(r'^[A-Z]{6}\+').firstMatch(familyName);
+    return match == null ? familyName : familyName.substring(match.end);
+  }
+
   /// The raw font program (the TrueType/OpenType bytes this was parsed
   /// from). Exposed so a host can register the same outline data with a
   /// UI toolkit's font system - e.g. to preview the font while editing -

--- a/packages/pdf_document/lib/src/font_embedder.dart
+++ b/packages/pdf_document/lib/src/font_embedder.dart
@@ -6,6 +6,7 @@ import 'package:pdf_cos/pdf_cos.dart';
 
 import 'annotation.dart';
 import 'content_writer.dart';
+import 'document.dart';
 
 /// A TrueType/OpenType font program, parsed and ready to embed in a PDF as
 /// a full-Unicode composite (Type0) font.
@@ -266,6 +267,97 @@ class PdfEmbeddedFont implements PdfTextFont {
     } catch (_) {
       return null;
     }
+  }
+
+  /// Reparses the embedded program of any [fontDict] already in a document -
+  /// a simple font (/TrueType or /Type1 carrying a /FontDescriptor with a
+  /// /FontFile2 or /FontFile3 program) or a composite /Type0 font (whose
+  /// descriptor lives on its descendant CIDFont) - into a re-embeddable
+  /// [PdfEmbeddedFont]. Unlike [fromFontDict] it isn't limited to /Type0.
+  ///
+  /// Returns null when the dict carries no reparsable sfnt (TrueType /
+  /// OpenType) program: a bare-CFF /FontFile3, a Type1 /FontFile, or a
+  /// subset stripped of its cmap all disqualify it - which conveniently
+  /// leaves only fonts whose glyphs new text can actually be mapped onto.
+  static PdfEmbeddedFont? fromEmbeddedProgram(
+      CosDocument cos, CosDictionary fontDict,
+      {String resourceName = 'F0'}) {
+    try {
+      var descriptorHost = fontDict;
+      final sub = cos.resolve(fontDict['Subtype']);
+      if (sub is CosName && sub.value == 'Type0') {
+        final desc = cos.resolve(fontDict['DescendantFonts']);
+        if (desc is! CosArray || desc.items.isEmpty) return null;
+        final cid = cos.resolve(desc.items.first);
+        if (cid is! CosDictionary) return null;
+        descriptorHost = cid;
+      }
+      final fd = cos.resolve(descriptorHost['FontDescriptor']);
+      if (fd is! CosDictionary) return null;
+      var file = cos.resolve(fd['FontFile2']);
+      if (file is! CosStream) file = cos.resolve(fd['FontFile3']);
+      if (file is! CosStream) return null;
+      final bytes = cos.decodeStreamData(file);
+      return PdfEmbeddedFont.parse(Uint8List.fromList(bytes),
+          resourceName: resourceName);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The distinct embeddable fonts [document] already uses - the faces its
+  /// page /Font resources (and the AcroForm's /DR) reference, each reparsed
+  /// via [fromEmbeddedProgram] into a re-embeddable [PdfEmbeddedFont] so
+  /// authored text can reuse a font the file already carries without
+  /// bundling a new one.
+  ///
+  /// Deduplicated by PostScript name (so the same face subset onto several
+  /// pages appears once); fonts with no reparsable sfnt program are skipped.
+  /// Order is first appearance walking the pages (their content fonts, then
+  /// their annotations' appearance fonts) then the AcroForm. Reads page,
+  /// annotation-appearance and form resources, not fonts nested deeper
+  /// inside Form XObjects.
+  static List<PdfEmbeddedFont> usedIn(PdfDocument document) {
+    final cos = document.cos;
+    final dicts = <CosDictionary>[];
+    void collect(CosObject? fontsRef) {
+      final fonts = cos.resolve(fontsRef);
+      if (fonts is! CosDictionary) return;
+      for (final value in fonts.entries.values) {
+        final dict = cos.resolve(value);
+        if (dict is CosDictionary && !dicts.any((d) => identical(d, dict))) {
+          dicts.add(dict);
+        }
+      }
+    }
+
+    void collectResources(CosObject? resourcesRef) {
+      final res = cos.resolve(resourcesRef);
+      if (res is CosDictionary) collect(res['Font']);
+    }
+
+    for (var i = 0; i < document.pageCount; i++) {
+      final page = document.page(i);
+      collect(page.resources['Font']);
+      for (final annotation in page.annotations) {
+        collectResources(annotation.normalAppearance?.dictionary['Resources']);
+      }
+    }
+    final acroForm = cos.resolve(document.catalog['AcroForm']);
+    if (acroForm is CosDictionary) {
+      final dr = cos.resolve(acroForm['DR']);
+      if (dr is CosDictionary) collect(dr['Font']);
+    }
+
+    final result = <PdfEmbeddedFont>[];
+    final seen = <String>{};
+    for (final dict in dicts) {
+      final font = fromEmbeddedProgram(cos, dict);
+      if (font == null) continue;
+      if (!seen.add(font.postScriptName)) continue;
+      result.add(font);
+    }
+    return result;
   }
 
   /// The glyph id for [rune], or 0 (.notdef) when the font lacks it.

--- a/packages/pdf_document/test/font_used_in_test.dart
+++ b/packages/pdf_document/test/font_used_in_test.dart
@@ -79,6 +79,21 @@ void main() {
       expect(font!.familyName, contains('DejaVu'));
     });
 
+    test('canRender / glyphHasOutline gate a legible preview', () {
+      final font = PdfEmbeddedFont.parse(_fontBytes);
+      // A real letter has contours, so the font can preview its own name.
+      expect(font.glyphHasOutline(font.glyphForRune('A'.codeUnitAt(0))), isTrue);
+      expect(font.canRender('DejaVu Sans'), isTrue);
+      // A character the font lacks entirely (unmapped) can't be rendered - the
+      // same gate that, for a subset font, rejects a name whose glyphs were
+      // stripped (verified against real subset PDFs). U+10FFFF is unassigned,
+      // so no cmap maps it.
+      expect(font.glyphForRune(0x10FFFF), 0);
+      expect(font.canRender('\u{10FFFF}'), isFalse);
+      // Out-of-range gids are given the benefit of the doubt, never suppressed.
+      expect(font.glyphHasOutline(1 << 20), isTrue);
+    });
+
     test('displayName leaves an untagged name untouched', () {
       // Guards against the subset-tag stripper mangling a normal family name;
       // DejaVu carries no `ABCDEF+` tag.

--- a/packages/pdf_document/test/font_used_in_test.dart
+++ b/packages/pdf_document/test/font_used_in_test.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+final _fontBytes = File('test/fonts/DejaVuSans.ttf').readAsBytesSync();
+
+PdfDocument _edited(void Function(PdfEditor) edit) {
+  final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+  edit(editor);
+  return PdfDocument.open(editor.save());
+}
+
+/// The first font dict in [annotation]'s normal-appearance /Resources.
+CosDictionary _appearanceFontDict(PdfDocument doc, PdfAnnotation annotation) {
+  final cos = doc.cos;
+  final res =
+      cos.resolve(annotation.normalAppearance!.dictionary['Resources'])
+          as CosDictionary;
+  final fonts = cos.resolve(res['Font']) as CosDictionary;
+  return cos.resolve(fonts.entries.values.first) as CosDictionary;
+}
+
+void main() {
+  group('PdfEmbeddedFont.usedIn', () {
+    test('finds an embedded font in a free-text annotation appearance', () {
+      final doc = _edited((e) => e.addFreeText(
+            0,
+            const PdfRect(72, 600, 300, 660),
+            'Hello',
+            font: PdfEmbeddedFont.parse(_fontBytes),
+          ));
+      final fonts = PdfEmbeddedFont.usedIn(doc);
+      expect(fonts, hasLength(1));
+      expect(fonts.single.familyName, contains('DejaVu'));
+      // The reparsed program can map and measure real text.
+      expect(fonts.single.glyphForRune('A'.codeUnitAt(0)), greaterThan(0));
+    });
+
+    test('a base-14-only document yields no embedded fonts', () {
+      final doc = _edited((e) => e.addFreeText(
+            0,
+            const PdfRect(72, 600, 300, 660),
+            'Plain',
+            font: PdfStandardFont.helvetica,
+          ));
+      expect(PdfEmbeddedFont.usedIn(doc), isEmpty);
+    });
+
+    test('deduplicates the same face used on several pages', () {
+      final font = PdfEmbeddedFont.parse(_fontBytes);
+      final doc = _edited((e) {
+        e.addFreeText(0, const PdfRect(72, 600, 300, 660), 'One', font: font);
+        e.addFreeText(0, const PdfRect(72, 500, 300, 560), 'Two', font: font);
+      });
+      expect(PdfEmbeddedFont.usedIn(doc), hasLength(1));
+    });
+
+    test('an empty document yields no embedded fonts', () {
+      expect(PdfEmbeddedFont.usedIn(PdfDocument.open(buildMultiPagePdf(1))),
+          isEmpty);
+    });
+  });
+
+  group('PdfEmbeddedFont.fromEmbeddedProgram', () {
+    test('reparses a font already embedded in the document', () {
+      final doc = _edited((e) => e.addFreeText(
+            0,
+            const PdfRect(72, 600, 300, 660),
+            'Hi',
+            font: PdfEmbeddedFont.parse(_fontBytes),
+          ));
+      final annotation = doc.page(0).annotations.single;
+      final font = PdfEmbeddedFont.fromEmbeddedProgram(
+          doc.cos, _appearanceFontDict(doc, annotation));
+      expect(font, isNotNull);
+      expect(font!.familyName, contains('DejaVu'));
+    });
+
+    test('returns null for a dict with no embedded program', () {
+      final doc = _edited((e) => e.addFreeText(
+            0,
+            const PdfRect(72, 600, 300, 660),
+            'Plain',
+            font: PdfStandardFont.helvetica,
+          ));
+      final annotation = doc.page(0).annotations.single;
+      expect(
+          PdfEmbeddedFont.fromEmbeddedProgram(
+              doc.cos, _appearanceFontDict(doc, annotation)),
+          isNull);
+    });
+  });
+}

--- a/packages/pdf_document/test/font_used_in_test.dart
+++ b/packages/pdf_document/test/font_used_in_test.dart
@@ -79,6 +79,14 @@ void main() {
       expect(font!.familyName, contains('DejaVu'));
     });
 
+    test('displayName leaves an untagged name untouched', () {
+      // Guards against the subset-tag stripper mangling a normal family name;
+      // DejaVu carries no `ABCDEF+` tag.
+      final font = PdfEmbeddedFont.parse(_fontBytes);
+      expect(font.familyName, contains('DejaVu'));
+      expect(font.displayName, font.familyName);
+    });
+
     test('returns null for a dict with no embedded program', () {
       final doc = _edited((e) => e.addFreeText(
             0,


### PR DESCRIPTION
## Summary

Extends the editor's font menu (`showPdfFontMenu`) with three requested improvements:

- **Select a font already embedded in the open document.** New `PdfEmbeddedFont.usedIn(document)` walks each page's `/Font` resources, its annotations' appearance `/Resources`, and the AcroForm `/DR`, reparsing every embedded program into a re-embeddable `PdfEmbeddedFont` (via the new general `fromEmbeddedProgram`, the non-Type0-only sibling of `fromFontDict`). The controller caches these per revision (`documentFonts`) and the menu lists them under an "In this document" section; picking one applies the already-parsed font directly.
- **A "Recently used" group heads the menu.** `PdfEditingPreferences` gains `recentFonts` / `noteRecentFont`, mirroring the existing `recentColors` pattern. It persists stable per-entry keys (`std:sans`, `bundled:<label>`, `platform:<label>`, `doc:<postScriptName>`) rather than font bytes, so recents resolve back to live menu choices on open and silently drop out when no longer available (e.g. a document font from a since-closed file). Custom-loaded picks aren't tracked (not reconstructable from a key).
- **The search field autofocuses when the menu opens**, so the user can type to filter immediately.

Why annotation-appearance resources are walked too: an embedded font authored via the editor lives in the free-text box's appearance stream resources, not the page content stream, so a page-only walk would miss exactly the fonts a user just added.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze` (both changed packages — clean)
- [x] `cd packages/pdf_document && fvm dart test` (`font_used_in_test.dart`, `font_embed_test.dart`, `type0_font_test.dart`)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (`editing_fonts_test.dart`, `editing_text_edit_test.dart`)

Full-suite/corpus/example-app runs were not performed; changes are additive and covered by targeted unit + widget tests.

## PDF fixtures and screenshots

New tests build embedded-font documents programmatically (author free text in a bundled DejaVu face, save, reopen); no external fixtures added.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Re-embedding a document font only works when its program still carries a usable `cmap`, which is the same gate `PdfEmbeddedFont.parse` already enforces — so subsets stripped of their cmap simply never reach the menu (they'd draw `.notdef` for newly typed glyphs otherwise).
- Dedup is by name-table PostScript name (clean of the `ABCDEF+` subset tag, which rides on `/BaseFont`), so the same face subset across pages collapses to one entry.
- `usedIn` does not descend into fonts nested inside Form XObjects (out of scope).
- See `doc/dev-log/2026-07-17-embedded-font-menu-selection.md` for the full design write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015fLp9oXG7dZLvY1gYFSdFZ)_