### PR TITLE
perf(#314): batched tile pyramid on desktop, F12 devtools, coordinated cache ceiling

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'devtools.dart';
 import 'editor_screen.dart';
 import 'oidc_signin.dart';
 import 'platform_fonts.dart';
@@ -33,6 +34,8 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
   @override
   void initState() {
     super.initState();
+    // Log/frame-timing capture for the F12 developer tools (debug/profile).
+    if (!kReleaseMode) AppDevTools.instance.install();
     // A small pool gives heavy CAD/image pages real overlap without multiplying
     // document memory too far. Mobile-class targets get a lower default; the
     // perf harness is allowed to be more aggressive.
@@ -42,6 +45,19 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
       TargetPlatform.fuchsia =>
         2,
       _ => 3,
+    };
+    // Proactive process-level ceiling across the viewer's budgeted caches
+    // (decoded images 256 MB + render records + previews + thumbnails + tiles
+    // can sum past 600 MB, and desktop OSes deliver the memory-pressure signal
+    // that used to be the only trim too late, if at all - see the 2026-07-18
+    // memory audit). The split between the ceiling and the per-cache budgets
+    // is heuristic pending a re-run of benchmark_image_cache_budget_test.
+    PdfCacheRegistry.instance.maxTotalWeight = switch (defaultTargetPlatform) {
+      TargetPlatform.android ||
+      TargetPlatform.iOS ||
+      TargetPlatform.fuchsia =>
+        192 << 20,
+      _ => 384 << 20,
     };
     // Offer the host's installed fonts in the editor's font menu by default.
     // Fire-and-forget: the registry is read when a font menu opens, and an
@@ -53,8 +69,10 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
   Future<void> _loadPlatformFonts() async {
     try {
       pdfPlatformFonts = await loadPlatformFonts();
-    } catch (_) {
+    } catch (e) {
       // Font discovery is best-effort; the menu degrades to its other choices.
+      AppDevTools.instance
+          .addLog('platform font discovery failed: $e', level: DevLogLevel.error);
     }
   }
 
@@ -67,9 +85,12 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
-      listenable: _prefs,
+      listenable: Listenable.merge(
+          [_prefs, AppDevTools.instance.showPerformanceOverlay]),
       builder: (context, _) => MaterialApp(
         title: 'DartPDF',
+        showPerformanceOverlay:
+            AppDevTools.instance.showPerformanceOverlay.value,
         theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),
         darkTheme: ThemeData(
           colorSchemeSeed: Colors.indigo,

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -34,8 +34,8 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
   @override
   void initState() {
     super.initState();
-    // Log/frame-timing capture for the F12 developer tools (debug/profile).
-    if (!kReleaseMode) AppDevTools.instance.install();
+    // Log/frame-timing capture for the F12 developer tools.
+    if (kDevToolsEnabled) AppDevTools.instance.install();
     // A small pool gives heavy CAD/image pages real overlap without multiplying
     // document memory too far. Mobile-class targets get a lower default; the
     // perf harness is allowed to be more aggressive.
@@ -59,6 +59,9 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
         192 << 20,
       _ => 384 << 20,
     };
+    // Persisted devtools options (deep-zoom mode, overlays, worker count)
+    // override the defaults above once loaded.
+    if (kDevToolsEnabled) unawaited(AppDevTools.instance.restoreOptions());
     // Offer the host's installed fonts in the editor's font menu by default.
     // Fire-and-forget: the registry is read when a font menu opens, and an
     // empty result (web, or a locked-down platform) just leaves the base-14,

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -1,0 +1,194 @@
+/// The model half of the in-app developer tools: a process-wide singleton that
+/// captures logs ([debugPrint] + [FlutterError.onError]), samples frame
+/// timings, and exposes the toggles the panel flips (performance overlay).
+///
+/// [AppDevTools.install] is idempotent and cheap; the capture hooks chain to
+/// the previous handlers so nothing is swallowed. The panel UI lives in
+/// `devtools_panel.dart`.
+library;
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:ui' show FramePhase;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+
+import 'devtools_memory_stub.dart'
+    if (dart.library.io) 'devtools_memory_io.dart' as memory;
+
+/// One captured log line.
+class DevLogEntry {
+  DevLogEntry(this.time, this.level, this.message);
+
+  final DateTime time;
+  final DevLogLevel level;
+  final String message;
+}
+
+enum DevLogLevel { info, error }
+
+/// Rolling frame-timing aggregates over the sample window.
+class DevFrameStats {
+  const DevFrameStats({
+    required this.frames,
+    required this.fps,
+    required this.avgBuildMs,
+    required this.avgRasterMs,
+    required this.worstFrameMs,
+    required this.jankFrames,
+  });
+
+  static const empty = DevFrameStats(
+    frames: 0,
+    fps: 0,
+    avgBuildMs: 0,
+    avgRasterMs: 0,
+    worstFrameMs: 0,
+    jankFrames: 0,
+  );
+
+  /// Frames in the sample window (up to [AppDevTools.frameWindow]).
+  final int frames;
+
+  /// Frame rate over the window's wall-clock span (0 when idle - Flutter only
+  /// produces frames when something animates or repaints).
+  final double fps;
+
+  final double avgBuildMs;
+  final double avgRasterMs;
+  final double worstFrameMs;
+
+  /// Frames whose build+raster exceeded ~16.7 ms in the window.
+  final int jankFrames;
+}
+
+/// Process-wide devtools state. Install once from the app root.
+class AppDevTools extends ChangeNotifier {
+  AppDevTools._();
+
+  static final AppDevTools instance = AppDevTools._();
+
+  static const int maxLogEntries = 500;
+  static const int frameWindow = 120;
+
+  /// Mirrored into [MaterialApp.showPerformanceOverlay] by the app root.
+  final ValueNotifier<bool> showPerformanceOverlay = ValueNotifier(false);
+
+  final ListQueue<DevLogEntry> _log = ListQueue();
+  final ListQueue<FrameTiming> _timings = ListQueue();
+
+  bool _installed = false;
+  bool _capturing = false;
+  bool _notifyScheduled = false;
+  DateTime _lastNotify = DateTime.fromMillisecondsSinceEpoch(0);
+
+  /// Captured log, oldest first. A fixed-size ring of [maxLogEntries].
+  List<DevLogEntry> get log => List.unmodifiable(_log);
+
+  /// Hooks [debugPrint], [FlutterError.onError], and the frame-timings
+  /// callback. Idempotent; chains to the previous handlers. A no-op under
+  /// `flutter test`, whose binding asserts those globals stay untouched -
+  /// the panel still works there via [addLog].
+  void install() {
+    if (_installed || memory.inFlutterTest()) return;
+    _installed = true;
+
+    final previousPrint = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) {
+      _record(DevLogLevel.info, message ?? '');
+      previousPrint(message, wrapWidth: wrapWidth);
+    };
+
+    final previousOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      _record(DevLogLevel.error, details.exceptionAsString());
+      previousOnError?.call(details);
+    };
+
+    SchedulerBinding.instance.addTimingsCallback(_onTimings);
+  }
+
+  /// Adds an app-authored entry (the capture hooks use this too).
+  void addLog(String message, {DevLogLevel level = DevLogLevel.info}) =>
+      _record(level, message);
+
+  void clearLog() {
+    _log.clear();
+    notifyListeners();
+  }
+
+  void _record(DevLogLevel level, String message) {
+    // debugPrint re-entrance guard: recording must never print.
+    if (_capturing) return;
+    _capturing = true;
+    _log.addLast(DevLogEntry(DateTime.now(), level, message));
+    while (_log.length > maxLogEntries) {
+      _log.removeFirst();
+    }
+    _capturing = false;
+    _scheduleNotify();
+  }
+
+  void _onTimings(List<FrameTiming> timings) {
+    for (final timing in timings) {
+      _timings.addLast(timing);
+    }
+    while (_timings.length > frameWindow) {
+      _timings.removeFirst();
+    }
+    _scheduleNotify();
+  }
+
+  /// Aggregates over the retained frame window.
+  DevFrameStats frameStats() {
+    if (_timings.isEmpty) return DevFrameStats.empty;
+    var buildUs = 0, rasterUs = 0, worstUs = 0, jank = 0;
+    for (final t in _timings) {
+      final b = t.buildDuration.inMicroseconds;
+      final r = t.rasterDuration.inMicroseconds;
+      buildUs += b;
+      rasterUs += r;
+      if (b + r > worstUs) worstUs = b + r;
+      if (b + r > 16700) jank++;
+    }
+    final spanUs = _timings.last.timestampInMicroseconds(FramePhase.rasterFinish) -
+        _timings.first.timestampInMicroseconds(FramePhase.buildStart);
+    return DevFrameStats(
+      frames: _timings.length,
+      fps: spanUs <= 0 ? 0 : (_timings.length - 1) * 1e6 / spanUs,
+      avgBuildMs: buildUs / _timings.length / 1000,
+      avgRasterMs: rasterUs / _timings.length / 1000,
+      worstFrameMs: worstUs / 1000,
+      jankFrames: jank,
+    );
+  }
+
+  /// Resident set size, null on the web.
+  int? get currentRssBytes => memory.currentRssBytes();
+
+  /// RSS high-water mark, null on the web.
+  int? get maxRssBytes => memory.maxRssBytes();
+
+  /// Throttle bursts (a frame's timings, a multi-line print) to at most one
+  /// notification per quarter second, and always notify from a microtask:
+  /// records can arrive mid-build (a FlutterError reported during layout
+  /// lands here via the onError hook), where a synchronous notify makes any
+  /// listening panel widget a build-phase violation - which reports another
+  /// error, which records again, cascading. No trailing Timer (a pending
+  /// Timer on this process-wide singleton would leak across widget tests);
+  /// the panel's own 1 s poll picks up whatever the throttle dropped.
+  void _scheduleNotify() {
+    if (_notifyScheduled) return;
+    if (DateTime.now().difference(_lastNotify) <
+        const Duration(milliseconds: 250)) {
+      return;
+    }
+    _notifyScheduled = true;
+    scheduleMicrotask(() {
+      _notifyScheduled = false;
+      _lastNotify = DateTime.now();
+      notifyListeners();
+    });
+  }
+}

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -9,13 +9,26 @@ library;
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:convert';
 import 'dart:ui' show FramePhase;
 
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'devtools_memory_stub.dart'
     if (dart.library.io) 'devtools_memory_io.dart' as memory;
+
+/// Whether the developer tools (F12 panel, capture hooks, option restore)
+/// are enabled in this build. On by default in EVERY mode, release included -
+/// the tools are the user's own metrics and logs, and release is where real
+/// performance questions live. A store/CI build that wants them gone passes
+/// `--dart-define=DEVTOOLS=false`, which also lets the tree-shaker drop the
+/// panel. Debug-engine-only toggles (repaint rainbow) and profile-only ones
+/// (performance overlay) stay additionally gated inside the panel.
+const bool kDevToolsEnabled =
+    bool.fromEnvironment('DEVTOOLS', defaultValue: true);
 
 /// One captured log line.
 class DevLogEntry {
@@ -169,6 +182,98 @@ class AppDevTools extends ChangeNotifier {
 
   /// RSS high-water mark, null on the web.
   int? get maxRssBytes => memory.maxRssBytes();
+
+  // --- deep-zoom detail mode (shared by the panel and option restore) -------
+
+  static const modePatch = 'patch';
+  static const modeTiles = 'tiles (per-tile)';
+  static const modeBatched = 'tiles (batched)';
+
+  /// The active deep-zoom detail mechanism (#314 experiment switch).
+  String get deepZoomMode {
+    if (!PdfPageView.tileStoreDetail) return modePatch;
+    final store = PdfPageView.debugTileStoreOverride;
+    return (store?.batchRasters ?? true) ? modeBatched : modeTiles;
+  }
+
+  /// Applies [mode], swapping the tile store via the debug override seam.
+  /// Takes effect from the next zoom or pan settle.
+  void setDeepZoomMode(String mode) {
+    if (mode == deepZoomMode) return;
+    final old = PdfPageView.debugTileStoreOverride;
+    switch (mode) {
+      case modePatch:
+        PdfPageView.tileStoreDetail = false;
+        PdfPageView.debugTileStoreOverride = null;
+      case modeTiles:
+        PdfPageView.tileStoreDetail = true;
+        PdfPageView.debugTileStoreOverride = PdfTileStore(batchRasters: false);
+      case modeBatched:
+        PdfPageView.tileStoreDetail = true;
+        PdfPageView.debugTileStoreOverride = PdfTileStore();
+      default:
+        return;
+    }
+    // Free the previous pyramid's tiles but keep its notifier alive: a
+    // mounted PdfTileLayer may still listen until the next rebuild.
+    old?.invalidate();
+    addLog('devtools: deep-zoom detail → $mode');
+  }
+
+  // --- option persistence ---------------------------------------------------
+
+  static const _optionsKey = 'devtools.options';
+
+  /// Restores persisted devtools options. Call once at app start, after the
+  /// platform defaults are set (the persisted values override them). A pool
+  /// spawned before this async load completes just uses the default size
+  /// until its next respawn.
+  Future<void> restoreOptions() async {
+    try {
+      final raw = (await SharedPreferences.getInstance()).getString(_optionsKey);
+      if (raw == null) return;
+      final map = jsonDecode(raw);
+      if (map is! Map) return;
+      if (map['deepZoomMode'] case final String mode) {
+        setDeepZoomMode(mode);
+      }
+      if (map['tileBorders'] case final bool v) {
+        pdfDebugPaintDetailBounds.value = v;
+      }
+      if (map['renderWindow'] case final bool v) {
+        pdfDebugShowRenderWindow.value = v;
+      }
+      if (map['perfOverlay'] case final bool v) {
+        showPerformanceOverlay.value = v;
+      }
+      if (map['perfLog'] case final bool v) PdfPerfLog.enabled = v;
+      if (map['workers'] case final int v) {
+        pdfRenderWorkerPoolSize = v.clamp(1, 8);
+      }
+      _scheduleNotify();
+    } catch (e) {
+      addLog('devtools options restore failed: $e', level: DevLogLevel.error);
+    }
+  }
+
+  /// Persists the current option set. The panel calls this after each change.
+  Future<void> persistOptions() async {
+    try {
+      await (await SharedPreferences.getInstance()).setString(
+        _optionsKey,
+        jsonEncode({
+          'deepZoomMode': deepZoomMode,
+          'tileBorders': pdfDebugPaintDetailBounds.value,
+          'renderWindow': pdfDebugShowRenderWindow.value,
+          'perfOverlay': showPerformanceOverlay.value,
+          'perfLog': PdfPerfLog.enabled,
+          'workers': pdfRenderWorkerPoolSize,
+        }),
+      );
+    } catch (e) {
+      addLog('devtools options persist failed: $e', level: DevLogLevel.error);
+    }
+  }
 
   /// Throttle bursts (a frame's timings, a multi-line print) to at most one
   /// notification per quarter second, and always notify from a microtask:

--- a/app/lib/devtools_memory_io.dart
+++ b/app/lib/devtools_memory_io.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+
+/// Resident set size of the process right now.
+int? currentRssBytes() => ProcessInfo.currentRss;
+
+/// High-water mark of the resident set size.
+int? maxRssBytes() => ProcessInfo.maxRss;
+
+/// True under `flutter test`, whose binding asserts that foundation globals
+/// like [debugPrint] are never replaced.
+bool inFlutterTest() => Platform.environment.containsKey('FLUTTER_TEST');

--- a/app/lib/devtools_memory_stub.dart
+++ b/app/lib/devtools_memory_stub.dart
@@ -1,0 +1,8 @@
+/// Web build: process RSS is not observable from a browser tab.
+int? currentRssBytes() => null;
+
+/// Web build: no high-water mark either.
+int? maxRssBytes() => null;
+
+/// Web build: flutter_test implies the VM, so never.
+bool inFlutterTest() => false;

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -1,0 +1,780 @@
+/// The in-app developer tools panel (F12, or Settings → Developer tools).
+///
+/// A docked side panel over the editor: frame timings, process/cache memory,
+/// the experimental deep-zoom detail mode switch (#314 tile pyramid vs the
+/// shipping patch), PdfPerf phase/counter accumulators, session diagnostics,
+/// and the captured log. Model state lives in `devtools.dart`; this file is
+/// pure presentation. The whole panel is compiled into debug/profile builds
+/// only (the editor gates its creation on `!kReleaseMode`).
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show debugRepaintRainbowEnabled;
+import 'package:flutter/services.dart';
+// ignore: implementation_imports - the perf facade is deliberately unexported.
+import 'package:pdf_cos/perf.dart';
+
+import 'devtools.dart';
+import 'file_io.dart';
+
+/// Docked developer tools panel. Create it only off-release.
+class DevToolsPanel extends StatefulWidget {
+  const DevToolsPanel({super.key, required this.onClose, this.session});
+
+  final VoidCallback onClose;
+
+  /// The active tab's edit session, when one is open.
+  final PdfEditingController? session;
+
+  @override
+  State<DevToolsPanel> createState() => _DevToolsPanelState();
+}
+
+class _DevToolsPanelState extends State<DevToolsPanel> {
+  final _tools = AppDevTools.instance;
+  Timer? _refresh;
+  String _logFilter = '';
+
+  @override
+  void initState() {
+    super.initState();
+    // Caches, RSS, and PdfPerf have no change notifications; poll while open.
+    _refresh = Timer.periodic(
+        const Duration(seconds: 1), (_) => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _refresh?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // The same docked chrome the editor's own sidebars (Annotations, Pages)
+    // use: shared frame, resize grip, surface color, compact close button.
+    // The width is session-local (no persistence preference).
+    return PdfSidebarPanelFrame(
+      width: 360,
+      minWidth: 300,
+      maxWidth: 560,
+      side: PdfSidebarSide.right,
+      resizable: true,
+      bottomSheet: false,
+      gripKey: const ValueKey('devtools-resize-grip'),
+      onClose: widget.onClose,
+      builder: (context, geometry) => Material(
+        key: const ValueKey('devtools-panel'),
+        color: theme.colorScheme.surfaceContainerLow,
+        child: Column(
+          children: [
+            _header(theme, geometry),
+            Expanded(
+              child: ListenableBuilder(
+                listenable: _tools,
+                // Eager column, not a lazy list: every section stays live so
+                // its metrics keep updating (and are findable) off-screen.
+                builder: (context, _) => SingleChildScrollView(
+                  padding: EdgeInsets.only(
+                      bottom: 16, left: geometry.contentStartInset),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _framesSection(theme),
+                      _memorySection(theme),
+                      _workersSection(theme),
+                      _deepZoomSection(theme),
+                      _perfSection(theme),
+                      if (widget.session != null) _sessionSection(theme),
+                      _logSection(theme),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _header(ThemeData theme, PdfSidebarPanelGeometry geometry) {
+    final closeButton =
+        geometry.closeButton(key: const ValueKey('devtools-close'));
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+          12 + geometry.contentStartInset, 8, closeButton != null ? 4 : 12, 4),
+      child: Row(
+        children: [
+          Icon(Icons.build_outlined,
+              size: 18, color: theme.colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text('Developer tools', style: theme.textTheme.titleMedium),
+          ),
+          IconButton(
+            key: const ValueKey('devtools-export'),
+            icon: const Icon(Icons.download_outlined, size: 18),
+            visualDensity: VisualDensity.compact,
+            tooltip: 'Export snapshot as JSON',
+            onPressed: () => unawaited(_exportSnapshot()),
+          ),
+          if (closeButton != null) closeButton,
+        ],
+      ),
+    );
+  }
+
+  /// One JSON document with everything the panel shows, for offline analysis
+  /// (spreadsheets, diffing two sessions, attaching to an issue).
+  Future<void> _exportSnapshot() async {
+    final frames = _tools.frameStats();
+    final session = widget.session;
+    final store = PdfPageView.debugTileStoreOverride;
+    final snapshot = <String, Object?>{
+      'tool': 'dartpdf-devtools',
+      'exportedAt': DateTime.now().toIso8601String(),
+      'platform': kIsWeb ? 'web' : defaultTargetPlatform.name,
+      'buildMode': kDebugMode ? 'debug' : 'profile',
+      'frames': {
+        'window': frames.frames,
+        'fps': frames.fps,
+        'avgBuildMs': frames.avgBuildMs,
+        'avgRasterMs': frames.avgRasterMs,
+        'worstFrameMs': frames.worstFrameMs,
+        'jankFrames': frames.jankFrames,
+      },
+      'memory': {
+        'rssBytes': _tools.currentRssBytes,
+        'rssHighWaterBytes': _tools.maxRssBytes,
+        'cacheTotalBytes': PdfCacheRegistry.instance.totalWeight,
+        'cacheCeilingBytes': PdfCacheRegistry.instance.maxTotalWeight,
+        'caches': [
+          for (final cache in PdfCacheRegistry.instance.snapshot())
+            {
+              'label': cache.label,
+              'entries': cache.length,
+              'bytes': cache.weight,
+              'budgetBytes': cache.maxWeight,
+            },
+        ],
+      },
+      'renderWorkers': pdfRenderWorkerPoolSize,
+      'deepZoomMode': _deepZoomMode,
+      if (store != null)
+        'tileStore': {
+          'tiles': store.tileCount,
+          'retainedBytes': store.retainedBytes,
+          'inFlight': store.inFlightCount,
+          'scheduled': store.debugTilesScheduled,
+          'landed': store.debugTilesLanded,
+          'discarded': store.debugTilesDiscarded,
+          'batches': store.debugBatchesDispatched,
+        },
+      'pdfPerf': PdfPerf.snapshot().toJson(),
+      if (session != null)
+        'session': {
+          'pages': session.document.pageCount,
+          'currentRevisionBytes': session.bytes.length,
+          'sessionBufferBytes': session.sessionBufferBytes,
+          'revisions': session.revisionCount,
+        },
+      'log': [
+        for (final entry in _tools.log)
+          {
+            'time': entry.time.toIso8601String(),
+            'level': entry.level.name,
+            'message': entry.message,
+          },
+      ],
+    };
+    final stamp = DateTime.now()
+        .toIso8601String()
+        .replaceAll(':', '')
+        .split('.')
+        .first;
+    final result = await saveJsonAs(
+      context,
+      const JsonEncoder.withIndent('  ').convert(snapshot),
+      'dartpdf-devtools-$stamp.json',
+    );
+    _tools.addLog('devtools: snapshot export ${result.runtimeType}');
+  }
+
+  // --- render workers -------------------------------------------------------
+
+  static const _workersHelp =
+      'Background isolates that interpret pages and decode images off the UI '
+      'thread. More workers overlap heavy pages but each holds its own parsed '
+      'copy of the document. Changes apply to the NEXT spawned pool - reopen '
+      'the document or switch tabs to respawn.';
+
+  Widget _workersSection(ThemeData theme) => _section(theme, 'Render workers', [
+        Row(
+          children: [
+            Expanded(
+              child: Tooltip(
+                message: _workersHelp,
+                waitDuration: const Duration(milliseconds: 600),
+                child: InkWell(
+                  onTap: () => _explain('Render worker pool', _workersHelp),
+                  child: Text('Pool size', style: theme.textTheme.bodySmall),
+                ),
+              ),
+            ),
+            IconButton(
+              key: const ValueKey('devtools-workers-down'),
+              icon: const Icon(Icons.remove, size: 16),
+              visualDensity: VisualDensity.compact,
+              onPressed: pdfRenderWorkerPoolSize > 1
+                  ? () => setState(() => pdfRenderWorkerPoolSize--)
+                  : null,
+            ),
+            Text('$pdfRenderWorkerPoolSize',
+                style: theme.textTheme.bodyMedium),
+            IconButton(
+              key: const ValueKey('devtools-workers-up'),
+              icon: const Icon(Icons.add, size: 16),
+              visualDensity: VisualDensity.compact,
+              onPressed: pdfRenderWorkerPoolSize < 8
+                  ? () => setState(() => pdfRenderWorkerPoolSize++)
+                  : null,
+            ),
+          ],
+        ),
+        Text(
+          'Applies to the next worker pool: reopen the document or switch '
+          'tabs to respawn.',
+          style: theme.textTheme.bodySmall!
+              .copyWith(color: theme.colorScheme.outline),
+        ),
+      ]);
+
+  Widget _section(ThemeData theme, String title, List<Widget> children,
+          {Widget? trailing}) =>
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(title, style: theme.textTheme.titleSmall),
+                ),
+                if (trailing != null) trailing,
+              ],
+            ),
+            const SizedBox(height: 4),
+            ...children,
+            const Divider(height: 20),
+          ],
+        ),
+      );
+
+  /// One metric row. With [help], the row explains itself twice over: the
+  /// text as a hover tooltip, and a tap opens the same explanation as a
+  /// dialog (for touch, and for reading at leisure).
+  Widget _kv(ThemeData theme, String key, String value, {String? help}) {
+    final row = Padding(
+      padding: const EdgeInsets.symmetric(vertical: 1),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(key, style: theme.textTheme.bodySmall),
+          ),
+          Text(value,
+              style: theme.textTheme.bodySmall!
+                  .copyWith(fontFeatures: const [FontFeature.tabularFigures()])),
+        ],
+      ),
+    );
+    if (help == null) return row;
+    return Tooltip(
+      message: help,
+      waitDuration: const Duration(milliseconds: 600),
+      child: InkWell(
+        onTap: () => _explain(key.trim(), help),
+        child: row,
+      ),
+    );
+  }
+
+  void _explain(String title, String text) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(title),
+        content: SizedBox(width: 420, child: Text(text)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// A switch row with the same tooltip + tap-dialog explanation as [_kv]:
+  /// the tooltip covers the whole tile, and an info affordance opens the
+  /// dialog (the tile's own tap has to stay the toggle).
+  Widget _helpSwitch(
+    ThemeData theme, {
+    required Key? key,
+    required String title,
+    required String help,
+    Widget? subtitle,
+    required bool value,
+    required ValueChanged<bool>? onChanged,
+  }) =>
+      Tooltip(
+        message: help,
+        waitDuration: const Duration(milliseconds: 600),
+        child: SwitchListTile(
+          key: key,
+          dense: true,
+          contentPadding: EdgeInsets.zero,
+          secondary: IconButton(
+            icon: const Icon(Icons.info_outline, size: 16),
+            visualDensity: VisualDensity.compact,
+            tooltip: 'What is this?',
+            onPressed: () => _explain(title, help),
+          ),
+          title: Text(title),
+          subtitle: subtitle,
+          value: value,
+          onChanged: onChanged,
+        ),
+      );
+
+  static String _mb(num bytes) => '${(bytes / (1 << 20)).toStringAsFixed(1)} MB';
+
+  // --- frames ---------------------------------------------------------------
+
+  Widget _framesSection(ThemeData theme) {
+    final stats = _tools.frameStats();
+    return _section(theme, 'Frames', [
+      _kv(theme, 'FPS (last ${stats.frames} frames)',
+          stats.frames == 0 ? 'idle' : stats.fps.toStringAsFixed(1),
+          help: 'Frame rate over the sampled window (up to 120 frames). '
+              'Flutter only produces frames when something animates or '
+              'repaints, so "idle" while nothing moves is normal and good.'),
+      _kv(
+          theme,
+          'Avg build / raster',
+          '${stats.avgBuildMs.toStringAsFixed(1)} / '
+              '${stats.avgRasterMs.toStringAsFixed(1)} ms',
+          help: 'Average per-frame time on the UI thread (widget build/layout) '
+              'and the raster thread (painting the frame on the GPU). Either '
+              'one exceeding ~16.7 ms means dropped frames at 60 Hz.'),
+      _kv(theme, 'Worst frame', '${stats.worstFrameMs.toStringAsFixed(1)} ms',
+          help: 'The slowest single frame in the window, build + raster '
+              'combined. One bad frame is a visible hitch even when the '
+              'averages look fine.'),
+      _kv(theme, 'Jank frames (>16.7 ms)', '${stats.jankFrames}',
+          help: 'Frames in the window whose build + raster exceeded 16.7 ms - '
+              'each one missed a 60 Hz deadline and was visible as jank.'),
+      _helpSwitch(
+        theme,
+        key: null,
+        title: 'Performance overlay',
+        help: "Flutter's built-in overlay graphing UI-thread and raster-"
+            'thread frame times on top of the app. Available in debug and '
+            'profile builds; profile numbers are the meaningful ones.',
+        value: _tools.showPerformanceOverlay.value,
+        onChanged: (v) =>
+            setState(() => _tools.showPerformanceOverlay.value = v),
+      ),
+      if (kDebugMode)
+        _helpSwitch(
+          theme,
+          key: null,
+          title: 'Repaint rainbow',
+          help: 'Debug-only: every repainted region cycles through colors on '
+              'each repaint, showing what actually repaints. If the whole '
+              'page flashes on scroll, something is forcing full-screen '
+              'repaints.',
+          value: debugRepaintRainbowEnabled,
+          onChanged: (v) => setState(() => debugRepaintRainbowEnabled = v),
+        ),
+    ]);
+  }
+
+  // --- memory ---------------------------------------------------------------
+
+  Widget _memorySection(ThemeData theme) {
+    final rss = _tools.currentRssBytes;
+    final peak = _tools.maxRssBytes;
+    final caches = PdfCacheRegistry.instance.snapshot();
+    return _section(
+      theme,
+      'Memory',
+      [
+        _kv(theme, 'Process RSS', rss == null ? 'n/a on web' : _mb(rss),
+            help: 'Resident set size of the whole process: Dart heaps for '
+                'every isolate, the engine, GPU-backed images, and native '
+                'allocations. This is the number the OS acts on (macOS '
+                'pauses the app over it). Not observable from a web tab.'),
+        if (peak != null)
+          _kv(theme, 'RSS high-water', _mb(peak),
+              help: 'The highest resident set size the process has reached '
+                  'since launch. Memory freed later does not lower it.'),
+        _kv(theme, 'Budgeted caches (this isolate)',
+            _mb(PdfCacheRegistry.instance.totalWeight),
+            help: 'Sum of every budgeted LRU cache registered in the main '
+                'isolate: decoded images, render records, previews, '
+                'thumbnails, and deep-zoom tiles when active.'),
+        _kv(
+            theme,
+            'Coordinated ceiling',
+            PdfCacheRegistry.instance.maxTotalWeight == 0
+                ? 'off'
+                : _mb(PdfCacheRegistry.instance.maxTotalWeight),
+            help: 'Process-level cap across all registered caches, enforced '
+                'proactively as caches grow rather than waiting for the '
+                "platform's memory-pressure signal (which desktop OSes "
+                'deliver too late, if at all). Over the ceiling, every cache '
+                'is trimmed proportionally, least-recently-used first.'),
+        for (final cache in caches)
+          _kv(
+              theme,
+              '  ${cache.label} (${cache.length})',
+              cache.maxWeight > 0
+                  ? '${_mb(cache.weight)} / ${_mb(cache.maxWeight)}'
+                  : _mb(cache.weight),
+              help: _cacheExplanation(cache.label)),
+        Text(
+          'Worker isolates hold parsed documents and command transcripts, '
+          'not decoded pixels; their memory is not itemized here.',
+          style: theme.textTheme.bodySmall!
+              .copyWith(color: theme.colorScheme.outline),
+        ),
+      ],
+      trailing: TextButton(
+        key: const ValueKey('devtools-clear-caches'),
+        onPressed: () {
+          final freed = PdfCacheRegistry.instance.handleMemoryPressure();
+          _tools.addLog('devtools: cleared caches, freed ${_mb(freed)}');
+          setState(() {});
+        },
+        child: const Text('Clear'),
+      ),
+    );
+  }
+
+  /// Per-cache explanations keyed by [PdfBudgetedCache.debugLabel], with a
+  /// generic fallback for labels this map has not caught up with.
+  static const _cacheHelp = <String, String>{
+    'decoded-image': 'Decoded raster images (RGBA, GPU-backed) shared by every '
+        'render path in the main isolate. Weighed by pixel bytes; the budget '
+        'is platform-tiered (256 MB desktop).',
+    'render-record': 'Interpreted page command records returned by the render '
+        'workers, weighed by their decoded image bytes, so a revisited page '
+        'replays instead of re-interpreting.',
+    'tiles': 'The deep-zoom tile pyramid (#314): fixed-size GPU-resident '
+        'tiles per zoom bucket, weighed by pixel bytes. Only populated when '
+        'a tile mode is active.',
+  };
+
+  String _cacheExplanation(String label) =>
+      _cacheHelp[label] ??
+      'A budgeted least-recently-used cache registered for coordinated '
+          'trimming and memory pressure. The parenthesized number is its '
+          'entry count; the value is retained bytes (and budget).';
+
+  // --- deep-zoom detail mode ------------------------------------------------
+
+  static const _modePatch = 'patch';
+  static const _modeTiles = 'tiles (per-tile)';
+  static const _modeBatched = 'tiles (batched)';
+
+  String get _deepZoomMode {
+    if (!PdfPageView.tileStoreDetail) return _modePatch;
+    final store = PdfPageView.debugTileStoreOverride;
+    return (store?.batchRasters ?? true) ? _modeBatched : _modeTiles;
+  }
+
+  void _setDeepZoomMode(String mode) {
+    if (mode == _deepZoomMode) return;
+    final old = PdfPageView.debugTileStoreOverride;
+    switch (mode) {
+      case _modePatch:
+        PdfPageView.tileStoreDetail = false;
+        PdfPageView.debugTileStoreOverride = null;
+      case _modeTiles:
+        PdfPageView.tileStoreDetail = true;
+        PdfPageView.debugTileStoreOverride = PdfTileStore(batchRasters: false);
+      case _modeBatched:
+        PdfPageView.tileStoreDetail = true;
+        PdfPageView.debugTileStoreOverride = PdfTileStore();
+    }
+    // Free the previous pyramid's tiles but keep its notifier alive: a mounted
+    // PdfTileLayer may still listen until the next rebuild replaces it.
+    old?.invalidate();
+    _tools.addLog('devtools: deep-zoom detail → $mode');
+    setState(() {});
+  }
+
+  Widget _deepZoomSection(ThemeData theme) {
+    final store = PdfPageView.debugTileStoreOverride;
+    return _section(theme, 'Deep-zoom detail (#314)', [
+      RadioGroup<String>(
+        groupValue: _deepZoomMode,
+        onChanged: (v) => v == null ? null : _setDeepZoomMode(v),
+        child: Column(
+          children: [
+            for (final (mode, subtitle) in const [
+              (_modePatch, 'Shipping path: one detail patch per settle'),
+              (_modeTiles, 'Tile pyramid, one readback per 512² tile'),
+              (
+                _modeBatched,
+                'Tile pyramid, one slab readback per settle, GPU-sliced'
+              ),
+            ])
+              RadioListTile<String>(
+                key: ValueKey('devtools-mode-$mode'),
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                value: mode,
+                title: Text(mode),
+                subtitle: Text(subtitle),
+              ),
+          ],
+        ),
+      ),
+      Text('A mode change applies from the next zoom or pan settle.',
+          style: theme.textTheme.bodySmall!
+              .copyWith(color: theme.colorScheme.outline)),
+      _helpSwitch(
+        theme,
+        key: const ValueKey('devtools-tile-borders'),
+        title: 'Tile / patch borders',
+        help: 'Outlines what sharpens the visible slice: green borders are '
+            'exact-bucket tiles, orange are upscaled coarser-bucket '
+            'fallbacks, purple is the legacy single detail patch. Nothing '
+            'outlined at deep zoom means the tile path is not engaging for '
+            'this page (e.g. it is on the vector-first progressive path).',
+        value: pdfDebugPaintDetailBounds.value,
+        onChanged: (v) => setState(() => pdfDebugPaintDetailBounds.value = v),
+      ),
+      _helpSwitch(
+        theme,
+        key: const ValueKey('devtools-render-window'),
+        title: 'Render window in thumbnails',
+        help: 'Outlines (teal) in the Pages sidebar the pages whose '
+            'page-view state is currently live - the lazy list\'s render '
+            'window. Each live page can retain a full-page raster, a detail '
+            'patch, and a scene with decoded images, so this window is '
+            'where per-page memory goes.',
+        value: pdfDebugShowRenderWindow.value,
+        onChanged: (v) => setState(() => pdfDebugShowRenderWindow.value = v),
+      ),
+      if (store != null) ...[
+        const SizedBox(height: 4),
+        _kv(theme, 'Tiles retained',
+            '${store.tileCount} (${_mb(store.retainedBytes)})',
+            help: 'GPU-resident tiles currently cached across all zoom '
+                'buckets, and their pixel bytes. Bounded by the tile budget '
+                '(96 MB default), evicting least-recently-used.'),
+        _kv(theme, 'In flight', '${store.inFlightCount}',
+            help: 'Tiles whose raster has been scheduled but has not landed '
+                'yet. A settle over an untiled area spikes this, then it '
+                'drains to zero.'),
+        _kv(
+            theme,
+            'Scheduled / landed / discarded',
+            '${store.debugTilesScheduled} / ${store.debugTilesLanded} / '
+                '${store.debugTilesDiscarded}',
+            help: 'Lifetime counters: rasters requested, tiles that entered '
+                'the cache, and completions thrown away because the page was '
+                'edited or invalidated while they were in flight.'),
+        _kv(theme, 'Batches dispatched', '${store.debugBatchesDispatched}',
+            help: 'Slab readbacks issued in batched mode: missing tiles of '
+                'one settle are rastered as one region readback and sliced '
+                'GPU-side, instead of one readback per tile.'),
+      ],
+    ]);
+  }
+
+  // --- PdfPerf --------------------------------------------------------------
+
+  Widget _perfSection(ThemeData theme) {
+    final stats = PdfPerf.snapshot();
+    return _section(
+      theme,
+      'PdfPerf (main isolate)',
+      [
+        _helpSwitch(
+          theme,
+          key: null,
+          title: 'Collect phase timings',
+          help: "PdfPerf: the PDF stack's zero-overhead instrumentation "
+              '(enum-indexed phase timers and counters across parsing, '
+              'filters, fonts, saving). Off, each site costs one branch; on, '
+              'accumulators fill and show below. Main isolate only - worker '
+              'time is not included.',
+          subtitle: kPdfPerfCompiledIn
+              ? null
+              : const Text('compiled out (PDF_PERF=false)'),
+          value: PdfPerf.enabled,
+          onChanged: kPdfPerfCompiledIn
+              ? (v) => setState(() => PdfPerf.enabled = v)
+              : null,
+        ),
+        if (stats.isEmpty)
+          Text('No samples yet - open or edit a document.',
+              style: theme.textTheme.bodySmall!
+                  .copyWith(color: theme.colorScheme.outline))
+        else ...[
+          for (final phase in PdfPerfPhase.values)
+            if (stats.phaseCallCount(phase) > 0)
+              _kv(
+                  theme,
+                  phase.name,
+                  '${(stats.phaseTotalUs(phase) / 1000).toStringAsFixed(1)} ms '
+                      '(${stats.phaseCallCount(phase)}×)',
+                  help: 'Accumulated wall time and begin/end pair count for '
+                      'the "${phase.name}" instrumented phase since enable '
+                      'or reset. Phases nest, so totals can overlap.'),
+          for (final count in PdfPerfCount.values)
+            if (stats.count(count) > 0)
+              _kv(theme, count.name, '${stats.count(count)}',
+                  help: 'Monotonic counter "${count.name}" - a structural '
+                      'fact or byte volume bumped on the hot path, not a '
+                      'timing. Resets with the Reset button.'),
+        ],
+      ],
+      trailing: TextButton(
+        onPressed: () => setState(PdfPerf.reset),
+        child: const Text('Reset'),
+      ),
+    );
+  }
+
+  // --- session --------------------------------------------------------------
+
+  Widget _sessionSection(ThemeData theme) {
+    final session = widget.session!;
+    return _section(theme, 'Session', [
+      _kv(theme, 'Pages', '${session.document.pageCount}',
+          help: 'Page count of the active document.'),
+      _kv(theme, 'Current revision', _mb(session.bytes.length),
+          help: 'Byte size of the document as it stands now - what Save '
+              'writes. Every edit appends an incremental revision, so this '
+              'grows with edits.'),
+      _kv(
+          theme,
+          'Session buffer (grow-only)',
+          '${_mb(session.sessionBufferBytes)} over '
+              '${session.revisionCount} revision(s)',
+          help: 'Total bytes retained by the edit session: every revision is '
+              'a byte prefix of one grow-only buffer (that is what makes '
+              'undo/redo cheap). It only grows within a session - watch it '
+              'when chasing memory growth during heavy editing; image stamps '
+              'embed their full bytes.'),
+      _kv(theme, 'Undo / redo',
+          '${session.canUndo ? 'yes' : 'no'} / ${session.canRedo ? 'yes' : 'no'}',
+          help: 'Whether an undo or redo step is available. Undo rewinds the '
+              'revision cursor; redo replays forward until a new edit forks '
+              'history.'),
+    ]);
+  }
+
+  // --- log ------------------------------------------------------------------
+
+  Widget _logSection(ThemeData theme) {
+    final entries = _tools.log
+        .where((e) =>
+            _logFilter.isEmpty ||
+            e.message.toLowerCase().contains(_logFilter.toLowerCase()))
+        .toList()
+        .reversed
+        .toList();
+    return _section(
+      theme,
+      'Log (${entries.length})',
+      [
+        _helpSwitch(
+          theme,
+          key: const ValueKey('devtools-perf-log'),
+          title: 'Verbose render log (PdfPerfLog)',
+          help: 'Streams the render stack\'s diagnostic log lines '
+              '(vector-first routing, worker requests, detail settles, '
+              'jank markers) through debugPrint into this log. Also lights '
+              'up the PdfPerf accumulators. Chatty - enable to diagnose, '
+              'then turn it off.',
+          value: PdfPerfLog.enabled,
+          onChanged: (v) => setState(() => PdfPerfLog.enabled = v),
+        ),
+        TextField(
+          key: const ValueKey('devtools-log-filter'),
+          decoration: const InputDecoration(
+            isDense: true,
+            prefixIcon: Icon(Icons.filter_alt_outlined, size: 16),
+            hintText: 'Filter',
+          ),
+          onChanged: (v) => setState(() => _logFilter = v),
+        ),
+        const SizedBox(height: 6),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 240),
+          child: entries.isEmpty
+              ? Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Text('No log entries.',
+                      style: theme.textTheme.bodySmall!
+                          .copyWith(color: theme.colorScheme.outline)),
+                )
+              : ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    final entry = entries[index];
+                    final time =
+                        entry.time.toIso8601String().substring(11, 19);
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 1),
+                      child: Text(
+                        '$time  ${entry.message}',
+                        style: theme.textTheme.bodySmall!.copyWith(
+                          fontFamily: 'monospace',
+                          fontSize: 11,
+                          color: entry.level == DevLogLevel.error
+                              ? theme.colorScheme.error
+                              : null,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+        ),
+      ],
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextButton(
+            onPressed: () {
+              final text = _tools.log
+                  .map((e) => '${e.time.toIso8601String()} '
+                      '[${e.level.name}] ${e.message}')
+                  .join('\n');
+              Clipboard.setData(ClipboardData(text: text));
+            },
+            child: const Text('Copy'),
+          ),
+          TextButton(
+            onPressed: _tools.clearLog,
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -4,8 +4,9 @@
 /// the experimental deep-zoom detail mode switch (#314 tile pyramid vs the
 /// shipping patch), PdfPerf phase/counter accumulators, session diagnostics,
 /// and the captured log. Model state lives in `devtools.dart`; this file is
-/// pure presentation. The whole panel is compiled into debug/profile builds
-/// only (the editor gates its creation on `!kReleaseMode`).
+/// pure presentation. Available in every build mode (release included) unless
+/// stripped with `--dart-define=DEVTOOLS=false` ([kDevToolsEnabled]); the
+/// debug-engine-only toggles gate themselves inside the panel.
 library;
 
 import 'dart:async';
@@ -141,7 +142,11 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
       'tool': 'dartpdf-devtools',
       'exportedAt': DateTime.now().toIso8601String(),
       'platform': kIsWeb ? 'web' : defaultTargetPlatform.name,
-      'buildMode': kDebugMode ? 'debug' : 'profile',
+      'buildMode': kDebugMode
+          ? 'debug'
+          : kReleaseMode
+              ? 'release'
+              : 'profile',
       'frames': {
         'window': frames.frames,
         'fps': frames.fps,
@@ -233,7 +238,10 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               icon: const Icon(Icons.remove, size: 16),
               visualDensity: VisualDensity.compact,
               onPressed: pdfRenderWorkerPoolSize > 1
-                  ? () => setState(() => pdfRenderWorkerPoolSize--)
+                  ? () => setState(() {
+                        pdfRenderWorkerPoolSize--;
+                        _persist();
+                      })
                   : null,
             ),
             Text('$pdfRenderWorkerPoolSize',
@@ -243,7 +251,10 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               icon: const Icon(Icons.add, size: 16),
               visualDensity: VisualDensity.compact,
               onPressed: pdfRenderWorkerPoolSize < 8
-                  ? () => setState(() => pdfRenderWorkerPoolSize++)
+                  ? () => setState(() {
+                        pdfRenderWorkerPoolSize++;
+                        _persist();
+                      })
                   : null,
             ),
           ],
@@ -381,16 +392,19 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
       _kv(theme, 'Jank frames (>16.7 ms)', '${stats.jankFrames}',
           help: 'Frames in the window whose build + raster exceeded 16.7 ms - '
               'each one missed a 60 Hz deadline and was visible as jank.'),
-      _helpSwitch(
-        theme,
-        key: null,
-        title: 'Performance overlay',
+      if (!kReleaseMode)
+        _helpSwitch(
+          theme,
+          key: null,
+          title: 'Performance overlay',
         help: "Flutter's built-in overlay graphing UI-thread and raster-"
             'thread frame times on top of the app. Available in debug and '
             'profile builds; profile numbers are the meaningful ones.',
         value: _tools.showPerformanceOverlay.value,
-        onChanged: (v) =>
-            setState(() => _tools.showPerformanceOverlay.value = v),
+        onChanged: (v) => setState(() {
+          _tools.showPerformanceOverlay.value = v;
+          _persist();
+        }),
       ),
       if (kDebugMode)
         _helpSwitch(
@@ -491,36 +505,21 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
 
   // --- deep-zoom detail mode ------------------------------------------------
 
-  static const _modePatch = 'patch';
-  static const _modeTiles = 'tiles (per-tile)';
-  static const _modeBatched = 'tiles (batched)';
+  static const _modePatch = AppDevTools.modePatch;
+  static const _modeTiles = AppDevTools.modeTiles;
+  static const _modeBatched = AppDevTools.modeBatched;
 
-  String get _deepZoomMode {
-    if (!PdfPageView.tileStoreDetail) return _modePatch;
-    final store = PdfPageView.debugTileStoreOverride;
-    return (store?.batchRasters ?? true) ? _modeBatched : _modeTiles;
-  }
+  String get _deepZoomMode => _tools.deepZoomMode;
 
   void _setDeepZoomMode(String mode) {
-    if (mode == _deepZoomMode) return;
-    final old = PdfPageView.debugTileStoreOverride;
-    switch (mode) {
-      case _modePatch:
-        PdfPageView.tileStoreDetail = false;
-        PdfPageView.debugTileStoreOverride = null;
-      case _modeTiles:
-        PdfPageView.tileStoreDetail = true;
-        PdfPageView.debugTileStoreOverride = PdfTileStore(batchRasters: false);
-      case _modeBatched:
-        PdfPageView.tileStoreDetail = true;
-        PdfPageView.debugTileStoreOverride = PdfTileStore();
-    }
-    // Free the previous pyramid's tiles but keep its notifier alive: a mounted
-    // PdfTileLayer may still listen until the next rebuild replaces it.
-    old?.invalidate();
-    _tools.addLog('devtools: deep-zoom detail → $mode');
+    _tools.setDeepZoomMode(mode);
+    _persist();
     setState(() {});
   }
+
+  /// Every option change writes the whole set - devtools options survive an
+  /// app restart.
+  void _persist() => unawaited(_tools.persistOptions());
 
   Widget _deepZoomSection(ThemeData theme) {
     final store = PdfPageView.debugTileStoreOverride;
@@ -558,11 +557,16 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
         title: 'Tile / patch borders',
         help: 'Outlines what sharpens the visible slice: green borders are '
             'exact-bucket tiles, orange are upscaled coarser-bucket '
-            'fallbacks, purple is the legacy single detail patch. Nothing '
-            'outlined at deep zoom means the tile path is not engaging for '
-            'this page (e.g. it is on the vector-first progressive path).',
+            'fallbacks, purple is the legacy single detail patch. The Pages '
+            'sidebar mirrors it per thumbnail (cached tiles green - dimmer '
+            'for coarser buckets - patch purple), so you can see the whole '
+            "pyramid's coverage at a glance. Nothing outlined at deep zoom "
+            'means the tile path is not engaging for this page.',
         value: pdfDebugPaintDetailBounds.value,
-        onChanged: (v) => setState(() => pdfDebugPaintDetailBounds.value = v),
+        onChanged: (v) => setState(() {
+          pdfDebugPaintDetailBounds.value = v;
+          _persist();
+        }),
       ),
       _helpSwitch(
         theme,
@@ -574,7 +578,10 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
             'patch, and a scene with decoded images, so this window is '
             'where per-page memory goes.',
         value: pdfDebugShowRenderWindow.value,
-        onChanged: (v) => setState(() => pdfDebugShowRenderWindow.value = v),
+        onChanged: (v) => setState(() {
+          pdfDebugShowRenderWindow.value = v;
+          _persist();
+        }),
       ),
       if (store != null) ...[
         const SizedBox(height: 4),
@@ -711,7 +718,10 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               'up the PdfPerf accumulators. Chatty - enable to diagnose, '
               'then turn it off.',
           value: PdfPerfLog.enabled,
-          onChanged: (v) => setState(() => PdfPerfLog.enabled = v),
+          onChanged: (v) => setState(() {
+            PdfPerfLog.enabled = v;
+            _persist();
+          }),
         ),
         TextField(
           key: const ValueKey('devtools-log-filter'),

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -186,7 +186,7 @@ class _EditorScreenState extends State<EditorScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    if (!kReleaseMode) {
+    if (kDevToolsEnabled) {
       HardwareKeyboard.instance.addHandler(_onGlobalKeyEvent);
     }
     _recents.load().then((_) {
@@ -276,7 +276,7 @@ class _EditorScreenState extends State<EditorScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    if (!kReleaseMode) {
+    if (kDevToolsEnabled) {
       HardwareKeyboard.instance.removeHandler(_onGlobalKeyEvent);
     }
     _incomingSub?.cancel();
@@ -1658,7 +1658,7 @@ class _EditorScreenState extends State<EditorScreen>
             prefs: _prefs,
             recents: _recents,
             updates: _updates,
-            onOpenDevTools: kReleaseMode ? null : _toggleDevTools,
+            onOpenDevTools: kDevToolsEnabled ? _toggleDevTools : null,
           ),
           child: _appMenuTile(
             icon: Icons.settings_outlined,
@@ -1667,9 +1667,10 @@ class _EditorScreenState extends State<EditorScreen>
         ),
       ];
 
-  /// Shows/hides the developer tools panel (F12, debug/profile builds only).
+  /// Shows/hides the developer tools panel (F12; every build mode unless
+  /// stripped with --dart-define=DEVTOOLS=false).
   void _toggleDevTools() {
-    if (kReleaseMode) return;
+    if (!kDevToolsEnabled) return;
     setState(() => _devToolsOpen = !_devToolsOpen);
   }
 
@@ -1678,7 +1679,7 @@ class _EditorScreenState extends State<EditorScreen>
   /// whenever the focused node leaves its subtree (e.g. after the panel
   /// itself opens).
   bool _onGlobalKeyEvent(KeyEvent event) {
-    if (!kReleaseMode &&
+    if (kDevToolsEnabled &&
         event is KeyDownEvent &&
         event.logicalKey == LogicalKeyboardKey.f12) {
       _toggleDevTools();
@@ -1739,7 +1740,7 @@ class _EditorScreenState extends State<EditorScreen>
                 child: Row(
                   children: [
                     Expanded(child: _buildBody(tab)),
-                    if (_devToolsOpen && !kReleaseMode)
+                    if (_devToolsOpen && kDevToolsEnabled)
                       DevToolsPanel(
                         onClose: _toggleDevTools,
                         session: tab?.session,

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -12,6 +12,8 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'app_info.dart';
+import 'devtools.dart';
+import 'devtools_panel.dart';
 import 'digital_signature.dart';
 import 'document_tab.dart';
 import 'file_io.dart';
@@ -170,6 +172,9 @@ class _EditorScreenState extends State<EditorScreen>
   final List<DocumentTab> _tabs = [];
   int _activeIndex = 0;
 
+  /// Whether the developer tools panel is docked over the editor (F12).
+  bool _devToolsOpen = false;
+
   DocumentTab? get _active =>
       _tabs.isEmpty ? null : _tabs[_activeIndex.clamp(0, _tabs.length - 1)];
 
@@ -181,6 +186,9 @@ class _EditorScreenState extends State<EditorScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    if (!kReleaseMode) {
+      HardwareKeyboard.instance.addHandler(_onGlobalKeyEvent);
+    }
     _recents.load().then((_) {
       if (mounted) _pruneRecentCache();
     });
@@ -268,6 +276,9 @@ class _EditorScreenState extends State<EditorScreen>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    if (!kReleaseMode) {
+      HardwareKeyboard.instance.removeHandler(_onGlobalKeyEvent);
+    }
     _incomingSub?.cancel();
     _incoming.dispose();
     _ocr.dispose();
@@ -363,8 +374,10 @@ class _EditorScreenState extends State<EditorScreen>
             cachePath: doc.cachePath,
             bookmark: doc.bookmark);
       }
-    } catch (_) {
+    } catch (e) {
       // The file is gone (moved/deleted): drop the placeholder quietly.
+      AppDevTools.instance.addLog('deferred open failed (file moved?): $e',
+          level: DevLogLevel.error);
       if (mounted) await _closeTabs([loading]);
     }
   }
@@ -420,6 +433,8 @@ class _EditorScreenState extends State<EditorScreen>
   }
 
   void _openError(String title, String error) {
+    AppDevTools.instance
+        .addLog('open error: $title - $error', level: DevLogLevel.error);
     _addTab(DocumentTab.error(title: title, error: error));
   }
 
@@ -697,7 +712,9 @@ class _EditorScreenState extends State<EditorScreen>
         final bytes = await item.readAsBytes();
         session.insertPagesFromBytes(bytes);
         inserted++;
-      } catch (_) {
+      } catch (e) {
+        AppDevTools.instance
+            .addLog('insert failed: ${item.name} - $e', level: DevLogLevel.error);
         failed.add(item.name);
       }
     }
@@ -1378,6 +1395,9 @@ class _EditorScreenState extends State<EditorScreen>
   }
 
   void _toast(String message) {
+    // Toasts are transient; mirroring them into the devtools log keeps a
+    // history (and puts them in the exported snapshot).
+    AppDevTools.instance.addLog('toast: $message');
     ScaffoldMessenger.of(context)
       ..clearSnackBars()
       ..showSnackBar(SnackBar(
@@ -1638,6 +1658,7 @@ class _EditorScreenState extends State<EditorScreen>
             prefs: _prefs,
             recents: _recents,
             updates: _updates,
+            onOpenDevTools: kReleaseMode ? null : _toggleDevTools,
           ),
           child: _appMenuTile(
             icon: Icons.settings_outlined,
@@ -1645,6 +1666,26 @@ class _EditorScreenState extends State<EditorScreen>
           ),
         ),
       ];
+
+  /// Shows/hides the developer tools panel (F12, debug/profile builds only).
+  void _toggleDevTools() {
+    if (kReleaseMode) return;
+    setState(() => _devToolsOpen = !_devToolsOpen);
+  }
+
+  /// Global F12 hook (registered in initState): a devtools toggle must work
+  /// regardless of where focus sits - a CallbackShortcuts binding goes deaf
+  /// whenever the focused node leaves its subtree (e.g. after the panel
+  /// itself opens).
+  bool _onGlobalKeyEvent(KeyEvent event) {
+    if (!kReleaseMode &&
+        event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.f12) {
+      _toggleDevTools();
+      return true;
+    }
+    return false;
+  }
 
   // --- build ---------------------------------------------------------------
 
@@ -1691,7 +1732,21 @@ class _EditorScreenState extends State<EditorScreen>
           },
           child: Stack(
             children: [
-              Positioned.fill(child: _buildBody(tab)),
+              // The devtools panel docks beside the body (like the editor's
+              // own sidebars), so the viewer relays out narrower instead of
+              // being overlaid - zoom and scroll gestures keep their space.
+              Positioned.fill(
+                child: Row(
+                  children: [
+                    Expanded(child: _buildBody(tab)),
+                    if (_devToolsOpen && !kReleaseMode)
+                      DevToolsPanel(
+                        onClose: _toggleDevTools,
+                        session: tab?.session,
+                      ),
+                  ],
+                ),
+              ),
               if (_dragging)
                 Positioned.fill(
                   child: _DropOverlay(

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -369,10 +369,18 @@ Future<SaveResult> saveBytesAs(
 Future<SaveResult> exportCustomStampsAs(
   BuildContext context,
   List<PdfCustomStamp> stamps,
+) =>
+    saveJsonAs(context, encodeCustomStampBundle(stamps), 'dartpdf-stamps.json');
+
+/// Save-as for a JSON document, with the same platform behaviour as
+/// [saveBytesAs]: a save dialog on desktop, a browser download on the web,
+/// the share sheet on phones. [name] should carry `.json`.
+Future<SaveResult> saveJsonAs(
+  BuildContext context,
+  String json,
+  String name,
 ) async {
-  final name = 'dartpdf-stamps.json';
-  final bytes =
-      Uint8List.fromList(utf8.encode(encodeCustomStampBundle(stamps)));
+  final bytes = Uint8List.fromList(utf8.encode(json));
   final file = XFile.fromData(
     bytes,
     mimeType: 'application/json',

--- a/app/lib/keyless_identity_cache.dart
+++ b/app/lib/keyless_identity_cache.dart
@@ -2,6 +2,8 @@ import 'package:flutter/widgets.dart';
 import 'package:pdf_cos/pdf_cos.dart' show X509Certificate;
 import 'package:pdf_document/pdf_document.dart' show PdfSigningIdentity;
 
+import 'devtools.dart';
+
 /// Mints a keyless (Sigstore/Fulcio) identity - an OIDC sign-in followed by a
 /// Fulcio certificate. Returns null when it can't: a silent attempt with no
 /// reusable login, or a cancelled interactive sign-in.
@@ -48,7 +50,9 @@ class KeylessIdentityCache {
     try {
       final notAfter = X509Certificate.parse(identity.certificate).notAfter;
       return notAfter.toUtc().isAfter(_now().toUtc().add(margin));
-    } catch (_) {
+    } catch (e) {
+      AppDevTools.instance
+          .addLog('keyless identity certificate unreadable: $e');
       return false;
     }
   }

--- a/app/lib/oidc_token_cache.dart
+++ b/app/lib/oidc_token_cache.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'devtools.dart';
+
 /// Reads the `exp` (expiry) claim of a JWT as a UTC [DateTime], or null when
 /// the token is malformed or carries no numeric `exp`. This only decodes the
 /// unsigned payload - it is not verification - and is used solely to decide
@@ -16,7 +18,8 @@ DateTime? oidcTokenExpiry(String token) {
     if (exp is! num) return null;
     return DateTime.fromMillisecondsSinceEpoch(exp.toInt() * 1000,
         isUtc: true);
-  } catch (_) {
+  } catch (e) {
+    AppDevTools.instance.addLog('cached OIDC token unreadable: $e');
     return null;
   }
 }

--- a/app/lib/recents.dart
+++ b/app/lib/recents.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'devtools.dart';
+
 /// One entry in the "recent documents" list shown on the welcome screen.
 @immutable
 class RecentFile {
@@ -98,8 +100,10 @@ class RecentsStore extends ChangeNotifier {
             .map((m) => RecentFile.fromJson(m.cast<String, dynamic>())));
       _sort();
       notifyListeners();
-    } catch (_) {
+    } catch (e) {
       // No storage (tests) - keep the in-memory list.
+      AppDevTools.instance
+          .addLog('recents load failed: $e', level: DevLogLevel.error);
     }
   }
 
@@ -142,8 +146,10 @@ class RecentsStore extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(
           _key, jsonEncode(_items.map((e) => e.toJson()).toList()));
-    } catch (_) {
+    } catch (e) {
       // No storage - nothing to persist.
+      AppDevTools.instance
+          .addLog('recents persist failed: $e', level: DevLogLevel.error);
     }
   }
 }

--- a/app/lib/session_store.dart
+++ b/app/lib/session_store.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'devtools.dart';
+
 /// One file-backed document that was open in the previous session, captured so
 /// the editor can re-open it on the next launch.
 @immutable
@@ -82,8 +84,10 @@ class SessionStore {
           .map((m) => SessionDocument.fromJson(m.cast<String, dynamic>()))
           .where((d) => d.readPath != null)
           .toList();
-    } catch (_) {
+    } catch (e) {
       // No storage (tests) - keep whatever is already in memory.
+      AppDevTools.instance
+          .addLog('session restore failed: $e', level: DevLogLevel.error);
     }
     return _documents;
   }
@@ -95,8 +99,10 @@ class SessionStore {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(
           _key, jsonEncode(_documents.map((d) => d.toJson()).toList()));
-    } catch (_) {
+    } catch (e) {
       // No storage - nothing to persist.
+      AppDevTools.instance
+          .addLog('session persist failed: $e', level: DevLogLevel.error);
     }
   }
 }

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -88,11 +88,16 @@ Future<void> showAppSettings(
   required PdfEditingPreferences prefs,
   required RecentsStore recents,
   UpdateService? updates,
+  VoidCallback? onOpenDevTools,
 }) {
   return showDialog<void>(
     context: context,
-    builder: (context) =>
-        _SettingsDialog(prefs: prefs, recents: recents, updates: updates),
+    builder: (context) => _SettingsDialog(
+      prefs: prefs,
+      recents: recents,
+      updates: updates,
+      onOpenDevTools: onOpenDevTools,
+    ),
   );
 }
 
@@ -101,11 +106,16 @@ class _SettingsDialog extends StatefulWidget {
     required this.prefs,
     required this.recents,
     this.updates,
+    this.onOpenDevTools,
   });
 
   final PdfEditingPreferences prefs;
   final RecentsStore recents;
   final UpdateService? updates;
+
+  /// Non-null in debug/profile builds: closes the dialog and opens the
+  /// developer tools panel (same as F12).
+  final VoidCallback? onOpenDevTools;
 
   @override
   State<_SettingsDialog> createState() => _SettingsDialogState();
@@ -178,6 +188,19 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () => _showDefaultAppSetup(context),
                 ),
+                if (widget.onOpenDevTools != null)
+                  ListTile(
+                    key: const ValueKey('settings-devtools'),
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.build_outlined),
+                    title: const Text('Developer tools'),
+                    subtitle: const Text('Metrics, logs, render modes (F12)'),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      widget.onOpenDevTools!();
+                    },
+                  ),
                 if (widget.updates != null && UpdateService.supported) ...[
                   const Divider(height: 32),
                   _UpdateSection(updates: widget.updates!),

--- a/app/lib/signature_appearance_store.dart
+++ b/app/lib/signature_appearance_store.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'devtools.dart';
+
 /// The reusable parts of a visible signature - the hand-drawn mark and the
 /// logo backdrop - remembered on the device so the next signature can reuse
 /// them without redrawing or re-picking.
@@ -39,7 +41,10 @@ class PrefsSignatureAppearanceStore implements SignatureAppearanceStore {
       if (value == null) return null;
       try {
         return base64Decode(value);
-      } catch (_) {
+      } catch (e) {
+        AppDevTools.instance.addLog(
+            'signature appearance cache corrupt ($key): $e',
+            level: DevLogLevel.error);
         return null;
       }
     }

--- a/app/lib/update.dart
+++ b/app/lib/update.dart
@@ -5,6 +5,8 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'devtools.dart';
+
 /// A parsed semantic version (`major.minor.patch`), tolerant of the leading
 /// `app-v` / `v` that the release tags carry, an optional `+build` metadata
 /// suffix (ignored for ordering, per semver), and an optional `-prerelease`
@@ -288,6 +290,8 @@ class UpdateService extends ChangeNotifier {
         _status = UpdateStatus.upToDate;
       }
     } catch (e) {
+      AppDevTools.instance
+          .addLog('update check failed: $e', level: DevLogLevel.error);
       _error = e;
       _status = UpdateStatus.failed;
     }

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -1,0 +1,66 @@
+// Devtools options persist across app restarts: every panel change writes
+// the whole option set to SharedPreferences, and restoreOptions applies it
+// over the platform defaults at startup.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/devtools.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    // Reset the globals the options touch so tests stay independent.
+    AppDevTools.instance.setDeepZoomMode(AppDevTools.modePatch);
+    pdfDebugPaintDetailBounds.value = false;
+    pdfDebugShowRenderWindow.value = false;
+    AppDevTools.instance.showPerformanceOverlay.value = false;
+    PdfPerfLog.enabled = false;
+    pdfRenderWorkerPoolSize = defaultPdfRenderWorkerPoolSize;
+  });
+
+  test('options round-trip through SharedPreferences', () async {
+    SharedPreferences.setMockInitialValues({});
+    final tools = AppDevTools.instance;
+
+    tools.setDeepZoomMode(AppDevTools.modeBatched);
+    pdfDebugPaintDetailBounds.value = true;
+    pdfDebugShowRenderWindow.value = true;
+    pdfRenderWorkerPoolSize = 5;
+    await tools.persistOptions();
+
+    // "Restart": globals back to defaults, then restore.
+    tools.setDeepZoomMode(AppDevTools.modePatch);
+    pdfDebugPaintDetailBounds.value = false;
+    pdfDebugShowRenderWindow.value = false;
+    pdfRenderWorkerPoolSize = 3;
+    await tools.restoreOptions();
+
+    expect(tools.deepZoomMode, AppDevTools.modeBatched);
+    expect(PdfPageView.tileStoreDetail, isTrue);
+    expect(PdfPageView.debugTileStoreOverride!.batchRasters, isTrue);
+    expect(pdfDebugPaintDetailBounds.value, isTrue);
+    expect(pdfDebugShowRenderWindow.value, isTrue);
+    expect(pdfRenderWorkerPoolSize, 5);
+  });
+
+  test('restore with nothing persisted leaves the defaults alone', () async {
+    SharedPreferences.setMockInitialValues({});
+    pdfRenderWorkerPoolSize = 3;
+    await AppDevTools.instance.restoreOptions();
+    expect(AppDevTools.instance.deepZoomMode, AppDevTools.modePatch);
+    expect(pdfRenderWorkerPoolSize, 3);
+  });
+
+  test('a corrupt payload is logged, not thrown', () async {
+    SharedPreferences.setMockInitialValues(
+        {'flutter.devtools.options': '{not json'});
+    await AppDevTools.instance.restoreOptions();
+    expect(
+      AppDevTools.instance.log.any(
+          (e) => e.message.contains('devtools options restore failed')),
+      isTrue,
+    );
+  });
+}

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -1,0 +1,126 @@
+// The F12 developer tools panel: opens via F12, shows the metric sections,
+// hosts the deep-zoom detail mode switch (#314), and captures logs. The panel
+// exists in debug/profile builds only; tests run in debug, so it's available.
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_app/devtools.dart';
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+  tearDown(() {
+    prefs.dispose();
+    // Reset the statics the mode switch flips so tests stay independent.
+    PdfPageView.tileStoreDetail = false;
+    PdfPageView.debugTileStoreOverride = null;
+  });
+
+  Future<void> pumpWithDoc(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        initialDocument: (bytes: buildClassicPdf(), title: 'Report.pdf'),
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  testWidgets('F12 toggles the panel; sections and session info render',
+      (tester) async {
+    await pumpWithDoc(tester);
+    expect(find.byKey(const ValueKey('devtools-panel')), findsNothing);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.f12);
+    await tester.pump();
+    expect(find.byKey(const ValueKey('devtools-panel')), findsOneWidget);
+    expect(find.text('Frames'), findsOneWidget);
+    expect(find.text('Memory'), findsOneWidget);
+    expect(find.text('Deep-zoom detail (#314)'), findsOneWidget);
+    expect(find.text('Session'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.f12);
+    await tester.pump();
+    expect(find.byKey(const ValueKey('devtools-panel')), findsNothing);
+  });
+
+  testWidgets('the deep-zoom mode switch flips the tile path statics',
+      (tester) async {
+    await pumpWithDoc(tester);
+    await tester.sendKeyEvent(LogicalKeyboardKey.f12);
+    await tester.pump();
+
+    expect(PdfPageView.tileStoreDetail, isFalse);
+
+    Future<void> tapMode(String mode) async {
+      final finder = find.byKey(ValueKey('devtools-mode-$mode'));
+      await tester.ensureVisible(finder);
+      await tester.pump();
+      await tester.tap(finder);
+      await tester.pump();
+    }
+
+    await tapMode('tiles (batched)');
+    expect(PdfPageView.tileStoreDetail, isTrue);
+    expect(PdfPageView.debugTileStoreOverride, isNotNull);
+    expect(PdfPageView.debugTileStoreOverride!.batchRasters, isTrue);
+
+    await tapMode('tiles (per-tile)');
+    expect(PdfPageView.debugTileStoreOverride!.batchRasters, isFalse);
+
+    await tapMode('patch');
+    expect(PdfPageView.tileStoreDetail, isFalse);
+    expect(PdfPageView.debugTileStoreOverride, isNull);
+  });
+
+  testWidgets('captured logs appear and the filter narrows them',
+      (tester) async {
+    AppDevTools.instance.addLog('devtools-test: alpha entry');
+    AppDevTools.instance.addLog('devtools-test: beta entry');
+    await pumpWithDoc(tester);
+    await tester.sendKeyEvent(LogicalKeyboardKey.f12);
+    await tester.pump();
+
+    await tester.ensureVisible(
+        find.byKey(const ValueKey('devtools-log-filter')));
+    await tester.pump();
+    expect(find.textContaining('alpha entry'), findsOneWidget);
+    expect(find.textContaining('beta entry'), findsOneWidget);
+
+    await tester.enterText(
+        find.byKey(const ValueKey('devtools-log-filter')), 'alpha');
+    await tester.pump();
+    expect(find.textContaining('alpha entry'), findsOneWidget);
+    expect(find.textContaining('beta entry'), findsNothing);
+  });
+
+  testWidgets('Settings offers Developer tools and it opens the panel',
+      (tester) async {
+    await pumpWithDoc(tester);
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+    // With a document open the menu is taller than the test surface.
+    await tester.ensureVisible(find.text('Settings'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+
+    final tile = find.byKey(const ValueKey('settings-devtools'));
+    await tester.ensureVisible(tile);
+    await tester.pumpAndSettle();
+    await tester.tap(tile);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('devtools-panel')), findsOneWidget);
+  });
+}

--- a/doc/dev-log/2026-07-18-devtools-and-cache-ceiling.md
+++ b/doc/dev-log/2026-07-18-devtools-and-cache-ceiling.md
@@ -1,0 +1,123 @@
+# In-app devtools panel + proactive coordinated cache ceiling
+
+Two app-facing pieces from the 8 GB macOS debug investigation (same day as
+the tile-batch session, separate workstream).
+
+## The memory audit, corrected
+
+A retention sweep across the viewer/editor/app found **no single leak** - the
+#283-era caches are genuinely budgeted. The 8 GB debug RSS is a *sum*:
+the main-isolate budgeted caches (decoded-image 256 MB + render-record 96 MB +
+previews + thumbnails + tiles-when-active can pass 600 MB), the per-live-page
+retained rasters (`_image` ≤64 MB + `_detailImage` ≤64 MB + the unbudgeted
+`PdfRetainedScene` decoded images, × the build window), the grow-only edit
+session buffer (`_bytes`, plus the worker's parallel copy - the one truly
+unbounded path), and per-open-tab baselines. Crucially, on desktop the only
+trim trigger was the platform memory-pressure callback, which macOS delivers
+too late (or never) before pausing the process.
+
+**Correction:** the audit's claim that each render-worker isolate carries its
+own 256 MB `PdfImageCache` is wrong - worker isolates never materialize
+`ui.Image`s; the decoded-byte record cache (96 MB, budgeted) lives on the
+main isolate in `PdfCachingRenderWorker`, and per-worker transcript caches are
+command-slot-weighted and small. So there was no "divide the worker budget by
+pool size" fix to make; the real fix is the ceiling below.
+
+## Proactive coordinated cache ceiling
+
+`PdfCacheRegistry.maxTotalWeight` (budgeted_cache.dart): a process-level
+ceiling across every registered cache, enforced **as caches grow** - each
+weight-bearing `put` on a registered cache calls `enforceBudget()` - instead
+of only on `didHaveMemoryPressure`. Enforcement trims每 cache
+**proportionally** (`trimToWeight(weight * ceiling ~/ total)`, a new public
+LRU-trim that protects the MRU entry and skips weight-0 entries), so a hot
+big cache isn't wiped to protect idle small ones and no cross-cache LRU clock
+is needed. Residue above the ceiling is bounded by one MRU entry per cache.
+Default **0 = disabled** - no SDK behavior change; the app opts in
+(`app.dart`: 384 MB desktop / 192 MB mobile - heuristic split pending a
+re-run of `benchmark_image_cache_budget_test.dart`). Tests in
+`budgeted_cache_test.dart` ('coordinated ceiling' group).
+
+## Devtools panel (F12 / Settings → Developer tools)
+
+`app/lib/devtools.dart` (model) + `devtools_panel.dart` (UI), debug/profile
+only (`!kReleaseMode` gates the F12 handler, the Settings tile, and
+`AppDevTools.install()`). The panel uses the editor's own sidebar chrome
+(`PdfSidebarPanelFrame`, docked right, resizable, session-local width) so it
+looks like Annotations/Pages - just with no toolbar button - and it docks
+**beside** the body in a Row (the viewer relays out narrower), never overlaying
+the page, so zoom/scroll gestures keep their space. F12 is a
+`HardwareKeyboard.instance.addHandler` global hook, not a CallbackShortcuts
+binding: a shortcuts binding goes deaf whenever focus leaves its subtree,
+e.g. right after the panel itself opens. Every metric row carries a hover
+tooltip and a tap-to-open dialog with the same explanation (`_kv(help:)` /
+`_helpSwitch`).
+
+Sections: frame stats (fps/build/raster/jank over a 120-frame window, plus
+performance-overlay switch and debug-only repaint rainbow), memory (process
+RSS via conditional `dart:io`, per-cache table from the new
+`PdfCacheRegistry.snapshot()`, the ceiling, clear-all), render-worker pool
+stepper (`pdfRenderWorkerPoolSize`, applies to the next spawned pool),
+deep-zoom detail mode switch (#314: patch / tiles per-tile / tiles batched,
+via `PdfPageView.debugTileStoreOverride` + live tile counters), PdfPerf
+(enable toggle, nonzero phases/counters, reset - main isolate only), session
+diagnostics (`revisionCount` / `sessionBufferBytes`, new on
+`PdfEditingController`), and a captured log (debugPrint + FlutterError,
+filterable, copy/clear). A header button exports the whole snapshot -
+frames, memory, caches, tile counters, PdfPerf, session, log - as one JSON
+document (`saveJsonAs`, generalized from the stamps exporter) for offline
+analysis. Neither the performance overlay nor repaint rainbow exists in
+release: the panel is compiled out, rainbow is debug-engine-only, and the
+overlay is meaningful in profile.
+
+## Debug overlays + why a CAD page shows 0 tiles
+
+Testing the tile modes on `OGW-30-06_Diagram.pdf` (31k-command 3370×2384 pt
+CAD sheet) showed **0 tiles scheduled at 590% zoom**. Diagnosis: the page
+never reaches a tile-eligible scene. `_useTilePath` (pdf_page_view.dart)
+requires a retained, region-cullable, NON-vector-only scene - and a dense
+vector page at deep zoom takes the **vector-first progressive path**, which
+adopts a `vectorOnly` placeholder scene (image pixels deliberately absent)
+and sharpens via the legacy patch. All three OGW pages are region-cullable
+(probed headless), but they do carry image draws, so the "vector-only is
+complete when the page has no images" relaxation does not apply. Whether the
+full record ever replaces the vector-only scene during a deep-zoom dwell (it
+appeared not to within ~90 s) is the open question - the new PdfPerfLog
+devtools switch exists to answer exactly that from a live session. Fixing
+tiles-under-vector-first is follow-up work (options: let the full record land
+under tile mode, or raster tiles from the vector-only scene and stamp them
+image-invalid).
+
+New SDK debug flags (`src/debug_overlays.dart`, exported): 
+- `pdfDebugPaintDetailBounds` - `PdfTileLayer` strokes every placement
+  (green exact, orange upscaled fallback via the new
+  `PdfTilePlacement.isFallback`) and the legacy detail patch draws a purple
+  border. ValueNotifier, merged into the painter's `repaint`, so toggling
+  repaints without rebuilding pages.
+- `PdfLivePageRegistry` + `pdfDebugShowRenderWindow` - page views register
+  their `previewIndex` on init/dispose/slot-reuse; the thumbnail tile
+  (shared by strip + grid) outlines live pages in teal: the lazy-list
+  render window where per-page memory lives.
+
+Devtools panel additions: switches for both overlays, a PdfPerfLog
+verbose-log toggle (its debugPrint lines land in the captured log), and
+app-level catches now emit to the devtools log - `_toast`/`_openError` are
+mirrored (history + export), and the silent best-effort catches (platform
+fonts, session store, recents, update check, signature-appearance/OIDC/
+keyless caches, deferred opens, page inserts) log errors instead of
+vanishing.
+
+## Gotchas
+
+- `debugPrint` must NOT be wrapped under `flutter test` - the binding asserts
+  foundation globals are untouched after every test. `install()` is a no-op
+  when `FLUTTER_TEST` is set (conditional-import probe; web stub says false).
+- No pending `Timer`s on a process-wide singleton: flutter_test fails any test
+  that ends with one. The log/frame notifier throttles by timestamp
+  (leading-edge) instead of a trailing timer; the panel's own 1 s poll picks
+  up dropped trailing updates.
+- The panel body is an eager Column in a `SingleChildScrollView`, not a lazy
+  list - sections must stay live (and findable in tests) while scrolled out.
+- Switching tile stores at runtime: `invalidate()` the old store but do not
+  `dispose()` it - a mounted `PdfTileLayer` may still be listening until the
+  next rebuild.

--- a/doc/dev-log/2026-07-18-tile-batch-slicing.md
+++ b/doc/dev-log/2026-07-18-tile-batch-slicing.md
@@ -1,0 +1,84 @@
+# Tile store: batched slab rasters + GPU-side slicing (issue #314 follow-up)
+
+The #342 benchmark said a naive 1-`toImage`-per-512²-tile cold sweep loses
+badly to the legacy single-patch path and named the fix: batch several tiles
+per readback. This session lands that batching, plus a measurement correction
+that changes the original benchmark's story.
+
+## What landed
+
+**`PdfTileStore.batchRasters` (default true).** One `viewFor` pass already
+knows every missing tile before it returns, so that is the batching point:
+`_schedule` defers keys into the pass's pending list and the pass dispatches
+raster *batches* instead of per-tile rasters.
+
+- **Grouping (`_groupBatches`):** the whole missing set rasters as one slab
+  when it fills ≥50% of its tile bounding box (the cold-settle shape) and fits
+  `maxBatchTilesPerAxis` (8 → a 4096² slab at 512² tiles, under the 2^14
+  texture limit); a sparse set (revisit holes) falls back to contiguous
+  per-row runs so cached tiles between holes are never re-rastered
+  (asserted in `tile_store_test.dart`).
+- **Slicing (`_sliceTile`):** the slab lands as one `rasterizeRegion` readback
+  (the exact shape that makes the legacy patch fast); each tile is then cut
+  out with a 1:1 `drawImageRect` blit converted by `toImageSync` — GPU-resident
+  output, no scene replay, no extra pixel readback. Slices are exact because
+  the whole batch shares one raster at the bucket ratio (a quadrant-color KAT
+  in the tests pins the pixel offsets).
+- Staleness, invalidation epochs, MRU, budget: unchanged — a batch checks one
+  epoch for its page and discards the whole slab if stale. Per-tile mode
+  (`batchRasters: false`) is intact and still covered by the original tests
+  (the center-out scheduling test pins it explicitly).
+
+**Benchmark now drives three strategies** (`benchmark_tile_store_test.dart`):
+legacy patch, per-tile store, batched store — and adds `settleMs`, a
+settle-to-sharp wall clock that *drains in-flight rasters inside the timing
+window* (`while (store.inFlightCount > 0)`).
+
+## The measurement correction
+
+The original harness's `rasterMs` sums per-raster stopwatches, and per-tile
+mode runs dozens of rasters concurrently — each stopwatch spans awaits that
+include the *other* rasters' work, so the sum overcounts wall time severely.
+The dev-log's "tiles ~8× slower wall-time" (1924 ms vs 235 ms pan) was this
+artifact. The drained settle clock is the honest number.
+
+## Results (7 pdfjs pages, ratio 8, best-of-2, headless software raster)
+
+Pan (cold) per strategy — readbacks / raster-meter ms / settle-to-sharp ms:
+
+| strategy | readbacks | rasterMs | settleMs |
+|---|---|---|---|
+| patch | 70 | 80 | ≈80 |
+| per-tile 512² | 224 | 542 (overcounted) | **79** |
+| batched 512² | **35** | 75 | 331 |
+| batched 1024² | **16** | 55 | 278 |
+
+Revisit stays 100% reuse for both tile modes (settle ≈7–30 ms vs patch
+≈100 ms). Pinch: per-tile settle 125 ms, batch 511 ms, patch 44 ms.
+
+Reading it honestly:
+
+- **Batching does what it promised on readbacks**: 35 (or 16 at 1024²) slab
+  readbacks vs 224 per-tile — and at 1024² the batch *raster* cost beats even
+  the patch (55 vs 97 ms) while touching 1.6× fewer pixels.
+- **This harness cannot pick the winner.** The software renderer makes
+  `toImage` per-call overhead tiny (so per-tile looks fine at wall clock —
+  which the GPU/web case, one full GPU sync + readback per call, will not
+  reproduce) and makes `toImageSync` slicing a real CPU raster pass
+  (~0.5 ms/slice, dominating batch settleMs — which on GPU is a near-free
+  blit). It under-costs exactly what batching saves and over-costs exactly
+  what batching adds.
+- So the flag-flip decision still needs the #306 on-device/web render-trace
+  numbers; what's no longer in question is the batch path's correctness and
+  that it removes the readback-count explosion (the web killer: each readback
+  is an uncancellable main-thread stall).
+
+## Gotchas
+
+- Never compare summed per-operation stopwatches across strategies with
+  different concurrency — drain to a quiescent state inside the clock window.
+- `_sliceTile` must skip `drawImageRect` when the clamped src is empty (an
+  edge tile of a clamped slab), else the engine asserts.
+- Fake rasterizers feeding a batching store must size images from the
+  requested region (`_Rasterizer(sizeFromRegion: true)`), or slices read
+  blank pixels.

--- a/doc/dev-log/2026-07-18-tile-batch-slicing.md
+++ b/doc/dev-log/2026-07-18-tile-batch-slicing.md
@@ -73,6 +73,20 @@ Reading it honestly:
   that it removes the readback-count explosion (the web killer: each readback
   is an uncancellable main-thread stall).
 
+## Default rollout (same day, after interactive validation)
+
+`PdfPageView.tileStoreDetail` now defaults per platform
+(`pdfDefaultTileStoreDetail()`): **on for desktop**, off for web/mobile.
+Desktop evidence: interactive testing on dense CAD sheets (with the
+vector-only per-tile veto) and a 198-page scan book - 4,490 tiles over 862
+slab readbacks, zero discards, pyramid pinned at its 96 MB budget, RSS
+healthy under the coordinated ceiling, and the scan handoff
+(vector-only → full record → tiles) confirmed working. Web stays off until
+its own pass (Slug-layer coexistence, CanvasKit `toImageSync`, readback
+stalls - the wins are biggest there, so measure, don't assume); mobile is
+untested and jetsam-tight. Widget tests run as TargetPlatform.android, so
+the existing detail-patch tests keep pinning the patch path unchanged.
+
 ## Gotchas
 
 - Never compare summed per-operation stopwatches across strategies with

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -12,6 +12,7 @@ export 'package:pdf_document/pdf_document.dart'
 
 export 'src/annotation_tap.dart';
 export 'src/budgeted_cache.dart';
+export 'src/debug_overlays.dart';
 export 'src/canvas_device.dart';
 export 'src/comparison/comparison_view.dart';
 export 'src/comparison/document_comparison.dart';

--- a/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
@@ -100,6 +100,25 @@ class PdfBudgetedCache<K, V> {
   /// The count cap, or null when the cache is unbounded by entry count.
   int? get maxEntries => _maxEntries;
 
+  /// Evicts least-recently-used weight-bearing entries until retained weight
+  /// is at or under [target] (floored at 0). Like the budget eviction in
+  /// [_trim], the most-recently-used entry is protected and weight-0 entries
+  /// are skipped (evicting them frees nothing). A no-op without a [weigher].
+  ///
+  /// This is the [PdfCacheRegistry.maxTotalWeight] rebalance hook: the
+  /// coordinated ceiling shrinks caches *below* their individual budgets, so
+  /// it needs a target other than [maxWeight].
+  void trimToWeight(int target) {
+    if (_disposed || _weigher == null) return;
+    final floor = math.max(0, target);
+    while (_weight > floor) {
+      final victim = _oldestEvictable(requireWeight: true);
+      if (victim == null) break;
+      _removeEntry(victim);
+      _evictions++;
+    }
+  }
+
   /// Total weight currently retained (occupancy, not a reservation).
   int get weight => _weight;
 
@@ -166,6 +185,9 @@ class PdfBudgetedCache<K, V> {
     _entries[key] = _Entry(value, weight);
     _weight += weight;
     _trim();
+    if (_clearsUnderMemoryPressure && weight > 0) {
+      PdfCacheRegistry.instance.enforceBudget();
+    }
     return value;
   }
 
@@ -212,6 +234,9 @@ class PdfBudgetedCache<K, V> {
     _entries[key] = _Entry(value, weight);
     _weight += weight;
     _trim();
+    if (_clearsUnderMemoryPressure && weight > 0) {
+      PdfCacheRegistry.instance.enforceBudget();
+    }
     return value;
   }
 
@@ -373,6 +398,62 @@ class PdfCacheRegistry {
   int get registrationCount {
     _pruneDead();
     return _caches.length;
+  }
+
+  /// Diagnostic snapshot of every live registered cache: its [PdfBudgetedCache
+  /// .debugLabel], entry count, retained weight, and weight budget (0 when the
+  /// cache is bounded by entries only). For devtools-style displays.
+  List<({String label, int length, int weight, int maxWeight})> snapshot() {
+    _pruneDead();
+    return [
+      for (final ref in _caches)
+        if (ref.target case final cache?)
+          (
+            label: cache.debugLabel,
+            length: cache.length,
+            weight: cache.weight,
+            maxWeight: cache.maxWeight,
+          ),
+    ];
+  }
+
+  int _maxTotalWeight = 0;
+  bool _enforcing = false;
+
+  /// A process-level ceiling across every registered cache, enforced
+  /// **proactively** as caches grow (from [PdfBudgetedCache.put]) instead of
+  /// only on the platform memory-pressure callback - which desktop OSes
+  /// deliver too late, if at all, letting the *sum* of individually-budgeted
+  /// caches sit at a multi-hundred-MB sticky baseline (the 2026-07-18 memory
+  /// audit). 0 (the default) disables the ceiling; setting a value enforces it
+  /// immediately.
+  int get maxTotalWeight => _maxTotalWeight;
+  set maxTotalWeight(int value) {
+    _maxTotalWeight = math.max(0, value);
+    enforceBudget();
+  }
+
+  /// Trims registered caches until [totalWeight] is at or under
+  /// [maxTotalWeight] (no-op when disabled or already under). Each cache is
+  /// trimmed **proportionally** - it keeps the same fraction of its weight -
+  /// so one hot large cache is not wiped to protect idle small ones, and no
+  /// cross-cache LRU clock is needed. Because each cache protects its
+  /// most-recently-used entry, the result can land slightly above the ceiling;
+  /// that residue is bounded by one entry per cache.
+  void enforceBudget() {
+    if (_maxTotalWeight <= 0 || _enforcing) return;
+    final total = totalWeight;
+    if (total <= _maxTotalWeight) return;
+    _enforcing = true;
+    try {
+      for (final ref in _caches.toList()) {
+        final cache = ref.target;
+        if (cache == null || cache.weight == 0) continue;
+        cache.trimToWeight(cache.weight * _maxTotalWeight ~/ total);
+      }
+    } finally {
+      _enforcing = false;
+    }
   }
 
   /// Clears every live registered cache. Wired to the platform

--- a/packages/dart_pdf_editor/lib/src/debug_overlays.dart
+++ b/packages/dart_pdf_editor/lib/src/debug_overlays.dart
@@ -5,6 +5,7 @@
 library;
 
 import 'dart:async';
+import 'dart:ui' show Rect;
 
 import 'package:flutter/foundation.dart';
 
@@ -62,6 +63,44 @@ class PdfLivePageRegistry extends ChangeNotifier {
   /// a synchronous [notifyListeners] is a build-phase violation for any
   /// listening overlay. Defer to a microtask (coalescing a burst of page
   /// lifecycles into one tick), which runs after the frame's synchronous work.
+  void _scheduleNotify() {
+    if (_notifyScheduled) return;
+    _notifyScheduled = true;
+    scheduleMicrotask(() {
+      _notifyScheduled = false;
+      notifyListeners();
+    });
+  }
+}
+
+/// Debug registry of each page's current legacy detail-patch bounds, as
+/// fractions (0..1) of the page. Page views report on build (only while
+/// [pdfDebugPaintDetailBounds] is on); the thumbnail overlay draws them so
+/// the strip shows where each page's patch sits. Same microtask coalescing
+/// as [PdfLivePageRegistry] - reports arrive mid-build.
+class PdfDebugDetailRegions extends ChangeNotifier {
+  PdfDebugDetailRegions._();
+
+  static final PdfDebugDetailRegions instance = PdfDebugDetailRegions._();
+
+  final Map<int, Rect> _patchFraction = {};
+
+  /// The page's current detail-patch bounds (page fractions), or null.
+  Rect? patchFractionOf(int pageIndex) => _patchFraction[pageIndex];
+
+  /// Records (or clears, with null) a page's patch bounds.
+  void report(int pageIndex, Rect? fraction) {
+    if (_patchFraction[pageIndex] == fraction) return;
+    if (fraction == null) {
+      _patchFraction.remove(pageIndex);
+    } else {
+      _patchFraction[pageIndex] = fraction;
+    }
+    _scheduleNotify();
+  }
+
+  bool _notifyScheduled = false;
+
   void _scheduleNotify() {
     if (_notifyScheduled) return;
     _notifyScheduled = true;

--- a/packages/dart_pdf_editor/lib/src/debug_overlays.dart
+++ b/packages/dart_pdf_editor/lib/src/debug_overlays.dart
@@ -1,0 +1,73 @@
+/// Viewer debug-overlay flags and registries, driven by a host app's
+/// developer tools. All default off and cost nothing until flipped; they are
+/// [ValueNotifier]s so overlay painters can repaint on toggle without the
+/// host rebuilding the page tree.
+library;
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Paints diagnostic borders on the deep-zoom detail surfaces: every tile
+/// placement in a [PdfTileLayer] (green for exact-bucket tiles, orange for
+/// upscaled coarser fallbacks) and the legacy single detail patch (purple).
+/// Shows what sharpens the visible slice, and from which source.
+final ValueNotifier<bool> pdfDebugPaintDetailBounds = ValueNotifier(false);
+
+/// Outlines, in the thumbnail strip/grid, the pages that currently hold a
+/// live page-view state ([PdfLivePageRegistry]) - the lazy-list "render
+/// window" whose retained scenes and rasters dominate per-page memory.
+final ValueNotifier<bool> pdfDebugShowRenderWindow = ValueNotifier(false);
+
+/// Debug registry of the page indices with a live page-view state (created
+/// in `initState`, removed on `dispose`). Only the active document's viewer
+/// builds page views, so indices are unambiguous. Feeds
+/// [pdfDebugShowRenderWindow]; maintained always (a set add/remove per page
+/// lifecycle is noise) so the overlay is truthful the moment it is enabled.
+class PdfLivePageRegistry extends ChangeNotifier {
+  PdfLivePageRegistry._();
+
+  static final PdfLivePageRegistry instance = PdfLivePageRegistry._();
+
+  final Set<int> _pages = <int>{};
+
+  /// Whether [pageIndex] currently has a live page-view state.
+  bool contains(int pageIndex) => _pages.contains(pageIndex);
+
+  /// Number of live page-view states.
+  int get length => _pages.length;
+
+  /// The live page indices (unmodifiable snapshot).
+  Set<int> get pages => Set.unmodifiable(_pages);
+
+  void add(int pageIndex) {
+    if (_pages.add(pageIndex)) _scheduleNotify();
+  }
+
+  void remove(int pageIndex) {
+    if (_pages.remove(pageIndex)) _scheduleNotify();
+  }
+
+  void move(int from, int to) {
+    if (from == to) return;
+    _pages.remove(from);
+    _pages.add(to);
+    _scheduleNotify();
+  }
+
+  bool _notifyScheduled = false;
+
+  /// Mutations arrive from page-view `initState`/`dispose`, which run
+  /// mid-build (a lazy list inflates children inside a layout callback), where
+  /// a synchronous [notifyListeners] is a build-phase violation for any
+  /// listening overlay. Defer to a microtask (coalescing a burst of page
+  /// lifecycles into one tick), which runs after the frame's synchronous work.
+  void _scheduleNotify() {
+    if (_notifyScheduled) return;
+    _notifyScheduled = true;
+    scheduleMicrotask(() {
+      _notifyScheduled = false;
+      notifyListeners();
+    });
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -489,6 +489,17 @@ class PdfEditingController extends ChangeNotifier {
   bool get canUndo => _cursor > _undoFloor;
   bool get canRedo => _cursor < _revisions.length - 1;
 
+  /// Diagnostics: how many revisions the session buffer retains (every one is
+  /// a byte prefix of the same grow-only buffer, so this is the undo/redo
+  /// history length, not extra copies).
+  int get revisionCount => _revisions.length;
+
+  /// Diagnostics: total bytes retained by the session's grow-only buffer -
+  /// the whole edit history, of which [bytes] is the current revision's
+  /// prefix view. This only ever grows within a session (see the memory
+  /// audit notes); watch it when chasing memory growth during editing.
+  int get sessionBufferBytes => _bytes.length;
+
   void undo() {
     if (!canUndo) return;
     final beforeLength = _revisions[_cursor];

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
+import '../debug_overlays.dart';
 import '../page_range_dialog.dart';
 import '../pdf_viewer.dart';
 import '../perf_log.dart';
@@ -1915,6 +1916,36 @@ class _PageTileState extends State<_PageTile> {
                           painter: _ViewportPainter(viewport, indicator),
                         ),
                       ),
+                    // Devtools overlay: mark the pages whose page-view state
+                    // is live (the lazy list's render window) - the pages
+                    // whose retained scenes/rasters hold real memory.
+                    Positioned.fill(
+                      child: ValueListenableBuilder<bool>(
+                        valueListenable: pdfDebugShowRenderWindow,
+                        builder: (context, on, _) => !on
+                            ? const SizedBox.shrink()
+                            : ListenableBuilder(
+                                listenable: PdfLivePageRegistry.instance,
+                                builder: (context, _) => !PdfLivePageRegistry
+                                        .instance
+                                        .contains(pageIndex)
+                                    ? const SizedBox.shrink()
+                                    : IgnorePointer(
+                                        child: DecoratedBox(
+                                          key: ValueKey(
+                                              'pdf-thumbnail-live-$pageIndex'),
+                                          decoration: BoxDecoration(
+                                            border: Border.all(
+                                              // teal: live render window
+                                              color: const Color(0xCC009688),
+                                              width: 2,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                              ),
+                      ),
+                    ),
                   ]),
                 );
               },

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -10,7 +10,9 @@ import 'package:flutter/services.dart';
 
 import '../debug_overlays.dart';
 import '../page_range_dialog.dart';
+import '../pdf_page_view.dart';
 import '../pdf_viewer.dart';
+import '../tile_store.dart';
 import '../perf_log.dart';
 import '../raster_cache.dart';
 import '../render_worker.dart';
@@ -1916,6 +1918,34 @@ class _PageTileState extends State<_PageTile> {
                           painter: _ViewportPainter(viewport, indicator),
                         ),
                       ),
+                    // Devtools overlay: each page's cached tiles (green) and
+                    // legacy detail patch (purple), scaled into the thumbnail.
+                    Positioned.fill(
+                      child: ValueListenableBuilder<bool>(
+                        valueListenable: pdfDebugPaintDetailBounds,
+                        builder: (context, on, _) {
+                          if (!on) return const SizedBox.shrink();
+                          final store = PdfPageView.debugTileStoreOverride ??
+                              PdfTileStore.instanceOrNull;
+                          return ListenableBuilder(
+                            listenable: Listenable.merge([
+                              PdfDebugDetailRegions.instance,
+                              if (store != null) store,
+                            ]),
+                            builder: (context, _) => IgnorePointer(
+                              child: CustomPaint(
+                                painter: _DetailBoundsPainter(
+                                  store?.debugTileFractionsForPage(pageIndex) ??
+                                      const [],
+                                  PdfDebugDetailRegions.instance
+                                      .patchFractionOf(pageIndex),
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
                     // Devtools overlay: mark the pages whose page-view state
                     // is live (the lazy list's render window) - the pages
                     // whose retained scenes/rasters hold real memory.
@@ -2531,6 +2561,46 @@ String _traceMs(double v) => '${v.toStringAsFixed(1)}ms';
 
 /// Marks the viewer's viewport on a thumbnail: [region] is the visible
 /// part of the page as fractions of its area.
+/// Devtools: strokes a page's cached tile grid (green, dimmer the coarser
+/// the rung relative to the sharpest present) and its legacy detail patch
+/// (purple) into the thumbnail. Rects arrive as page fractions.
+class _DetailBoundsPainter extends CustomPainter {
+  const _DetailBoundsPainter(this.tiles, this.patch);
+
+  final List<({Rect fraction, int rung})> tiles;
+  final Rect? patch;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    Rect scale(Rect f) => Rect.fromLTRB(f.left * size.width,
+        f.top * size.height, f.right * size.width, f.bottom * size.height);
+    if (tiles.isNotEmpty) {
+      final sharpest =
+          tiles.map((t) => t.rung).reduce((a, b) => a > b ? a : b);
+      for (final tile in tiles) {
+        final paint = Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1
+          ..color = const Color(0xFF00C853)
+              .withValues(alpha: tile.rung == sharpest ? 0.9 : 0.35);
+        canvas.drawRect(scale(tile.fraction), paint);
+      }
+    }
+    if (patch != null) {
+      canvas.drawRect(
+        scale(patch!),
+        Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1.5
+          ..color = const Color(0xCCAA00FF),
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _DetailBoundsPainter old) => true;
+}
+
 class _ViewportPainter extends CustomPainter {
   const _ViewportPainter(this.region, this.color);
 

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -302,19 +302,21 @@ class PdfPageView extends StatefulWidget {
   /// thread turns the returned detail commands into the sharp on-screen patch.
   static bool deferFullRenderUntilDetailPaint = true;
 
-  /// Opt-in: composite deep-zoom detail from the [PdfTileStore] zoom-bucket
-  /// pyramid instead of the single unbudgeted detail patch. When true (and the
-  /// page retains a region-cullable scene), the visible slice is tiled: panning
-  /// at deep zoom draws cached tiles with zero re-raster and a settle only
-  /// rasterizes the missing tiles, all under one shared byte budget that evicts
-  /// by least-recently used and drops under memory pressure.
+  /// Composite deep-zoom detail from the [PdfTileStore] zoom-bucket pyramid
+  /// instead of the single unbudgeted detail patch. When true (and the page
+  /// retains a region-cullable scene), the visible slice is tiled: panning at
+  /// deep zoom draws cached tiles with zero re-raster and a settle only
+  /// rasterizes the missing tiles (batched into slab readbacks), all under one
+  /// shared byte budget that evicts by least-recently used and drops under
+  /// memory pressure.
   ///
   /// Additive to the existing pipeline: the tile layer sits ABOVE the base
   /// raster, so a gap not yet tiled shows the (capped) base image through it,
   /// and pages the region index cannot cull (soft-mask/group spans) keep the
-  /// legacy single-patch path. Default false while the pyramid is measured
-  /// against the shipping detail patch (issue #314).
-  static bool tileStoreDetail = false;
+  /// legacy single-patch path. Defaults per platform
+  /// ([pdfDefaultTileStoreDetail], issue #314): on for desktop, off for
+  /// web/mobile pending their own validation passes.
+  static bool tileStoreDetail = pdfDefaultTileStoreDetail();
 
   /// Test seam: the store the tile layer draws from. Null uses the shared
   /// [PdfTileStore.instance].

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -13,6 +13,7 @@ import 'package:pdf_graphics/pdf_graphics.dart'
         PdfMatrix,
         PdfRenderCommand;
 
+import 'debug_overlays.dart';
 import 'perf_log.dart';
 import 'page_render_session.dart';
 import 'performance_policy.dart';
@@ -438,6 +439,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   @override
   void initState() {
     super.initState();
+    PdfLivePageRegistry.instance.add(widget.previewIndex);
     _renderSession = PdfPageRenderSession(_renderIntent(widget));
     widget.renderHold?.addListener(_onRenderHoldChanged);
     widget.previewCache?.addListener(_onPreviewCacheChanged);
@@ -552,6 +554,8 @@ class _PdfPageViewState extends State<PdfPageView> {
       liveTransform?.addListener(_onLiveTransformChanged);
     }
     if (oldWidget.previewIndex != widget.previewIndex) {
+      PdfLivePageRegistry.instance
+          .move(oldWidget.previewIndex, widget.previewIndex);
       // The lazy list reused this State for a different page (it scrolled into
       // this slot): cancel the old page's queued worker request - the user
       // scrolled past it, so decoding it now would only delay the page now on
@@ -616,6 +620,7 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   @override
   void dispose() {
+    PdfLivePageRegistry.instance.remove(widget.previewIndex);
     widget.renderHold?.removeListener(_onRenderHoldChanged);
     _liveTransformFor(widget)?.removeListener(_onLiveTransformChanged);
     _speculateTimer?.cancel();
@@ -2271,11 +2276,27 @@ class _PdfPageViewState extends State<PdfPageView> {
                       top: fraction.top * h,
                       width: fraction.width * w,
                       height: fraction.height * h,
-                      child: RawImage(
-                        key: const ValueKey('pdf-page-detail-image'),
-                        image: detail,
-                        fit: BoxFit.fill,
-                        filterQuality: FilterQuality.medium,
+                      // The debug border repaints on toggle without a page
+                      // rebuild (the flag is a ValueNotifier).
+                      child: ValueListenableBuilder<bool>(
+                        valueListenable: pdfDebugPaintDetailBounds,
+                        child: RawImage(
+                          key: const ValueKey('pdf-page-detail-image'),
+                          image: detail,
+                          fit: BoxFit.fill,
+                          filterQuality: FilterQuality.medium,
+                        ),
+                        builder: (context, debugBounds, child) => !debugBounds
+                            ? child!
+                            : DecoratedBox(
+                                position: DecorationPosition.foreground,
+                                decoration: BoxDecoration(
+                                  // purple: the legacy single detail patch
+                                  border: Border.all(
+                                      color: const Color(0xAAAA00FF)),
+                                ),
+                                child: child,
+                              ),
                       ),
                     ),
                 ],

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -556,6 +556,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (oldWidget.previewIndex != widget.previewIndex) {
       PdfLivePageRegistry.instance
           .move(oldWidget.previewIndex, widget.previewIndex);
+      PdfDebugDetailRegions.instance.report(oldWidget.previewIndex, null);
       // The lazy list reused this State for a different page (it scrolled into
       // this slot): cancel the old page's queued worker request - the user
       // scrolled past it, so decoding it now would only delay the page now on
@@ -621,6 +622,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   @override
   void dispose() {
     PdfLivePageRegistry.instance.remove(widget.previewIndex);
+    PdfDebugDetailRegions.instance.report(widget.previewIndex, null);
     widget.renderHold?.removeListener(_onRenderHoldChanged);
     _liveTransformFor(widget)?.removeListener(_onLiveTransformChanged);
     _speculateTimer?.cancel();
@@ -680,6 +682,11 @@ class _PdfPageViewState extends State<PdfPageView> {
         scene != null && PdfPageRenderer.hasImageDraws(scene.commands);
     _sceneFromWorker = scene != null && fromWorker;
     _sceneIsVectorOnly = scene != null && vectorOnly;
+    // A vector-only scene may feed the tile path everywhere its absent image
+    // pixels can't corrupt a tile; a full scene has no veto.
+    _tileCanRasterize = scene != null && vectorOnly && _sceneHasImageDraws
+        ? (region) => !_imagesIntersectRegion(scene.commands, region)
+        : null;
     _slugPictureRejected = false;
     // a speculative bin's geometry was computed against the previous scene;
     // with the scene identity changed it is meaningless, so drop it (the
@@ -1805,13 +1812,27 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   /// Whether the [PdfPageView.tileStoreDetail] tile path drives deep-zoom
   /// detail for this page: the flag is on and the retained scene is
-  /// region-cullable (soft-mask/group spans and the vector-first progressive
-  /// scene keep the legacy single-patch path).
+  /// region-cullable (soft-mask/group spans keep the legacy single-patch
+  /// path).
+  ///
+  /// A vector-only progressive scene is eligible too - on the dense CAD pages
+  /// the pyramid targets, the full image-bearing record may never land during
+  /// a deep-zoom dwell, so excluding vector-only scenes meant 0 tiles exactly
+  /// where tiles matter most. Its absent image pixels are handled per tile:
+  /// [_tileCanRasterize] vetoes the regions an image draw intersects, which
+  /// keep the fallback/base raster and heal automatically if the full record
+  /// later replaces the scene.
   bool get _useTilePath {
     if (!PdfPageView.tileStoreDetail) return false;
     final scene = PdfPageView.retainedZoomReplay ? _scene : null;
-    return scene != null && !_sceneIsVectorOnly && scene.supportsRegionRaster;
+    return scene != null && scene.supportsRegionRaster;
   }
+
+  /// Per-tile veto for the tile store while the scene is vector-only: a tile
+  /// region an image draw intersects would bake the placeholder's missing
+  /// pixels into a cached tile. Bound to the scene at adoption ([_setScene])
+  /// so the painter's identity check doesn't see a fresh closure every build.
+  bool Function(Rect region)? _tileCanRasterize;
 
   /// Recomputes the tile layer's visible slice + desired ratio on a settle.
   /// Runs post-render (never during layout), so reading the render tree in
@@ -1862,6 +1883,7 @@ class _PdfPageViewState extends State<PdfPageView> {
         visibleFraction: fraction,
         rasterize: (region, ratio) =>
             scene.rasterizeRegion(region, pixelRatio: ratio),
+        canRasterize: _tileCanRasterize,
       ),
     );
   }
@@ -2235,6 +2257,12 @@ class _PdfPageViewState extends State<PdfPageView> {
               final fraction = _detailFraction;
               final slugPicture = _slugPicture;
               final tileLayer = _tileLayerWidget(size);
+              // Publish this page's patch bounds for the thumbnail debug
+              // overlay (report coalesces its notify past this build).
+              if (pdfDebugPaintDetailBounds.value) {
+                PdfDebugDetailRegions.instance.report(widget.previewIndex,
+                    tileLayer == null && detail != null ? fraction : null);
+              }
               return Stack(
                 alignment: Alignment.topLeft,
                 fit: StackFit.expand,

--- a/packages/dart_pdf_editor/lib/src/performance_policy.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_policy.dart
@@ -22,6 +22,22 @@ PdfPerformancePlatform get detectedPdfPerformancePlatform => kIsWeb
           PdfPerformancePlatform.desktop,
       };
 
+/// Whether the deep-zoom tile pyramid ([PdfPageView.tileStoreDetail], issue
+/// #314) is on by default for this platform.
+///
+/// - **Desktop**: on. Validated interactively on dense CAD sheets and 198-page
+///   scan books (2026-07-18 dev-log: batched slab rasters, per-tile veto for
+///   vector-only scenes, the pyramid pinned at its 96 MB budget with healthy
+///   RSS), where panning at deep zoom reuses cached tiles instead of
+///   re-rastering.
+/// - **Web**: off pending its own validation pass - the tile layer must
+///   coexist with the Slug vector layer, `toImageSync` behaves differently on
+///   CanvasKit, and web-only breakage has slipped through CI before.
+/// - **Mobile**: off - untested there, and the 96 MB pyramid budget is a
+///   meaningful slice of a jetsam-limited process.
+bool pdfDefaultTileStoreDetail() =>
+    detectedPdfPerformancePlatform == PdfPerformancePlatform.desktop;
+
 /// The default byte budget for the process-wide decoded-image cache
 /// ([PdfImageCache]) on this platform.
 ///

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -9,6 +9,7 @@ library;
 
 import 'package:flutter/widgets.dart';
 
+import 'debug_overlays.dart';
 import 'tile_store.dart';
 
 /// Draws a page's tile pyramid over its visible region.
@@ -74,7 +75,9 @@ class _TilePagePainter extends CustomPainter {
     required this.visibleFraction,
     required this.rasterize,
     required this.filterQuality,
-  }) : super(repaint: store); // tick as sharper tiles land
+  }) : super(
+            // tick as sharper tiles land, and repaint on debug-border toggles
+            repaint: Listenable.merge([store, pdfDebugPaintDetailBounds]));
 
   final PdfTileStore store;
   final PdfTilePageIdentity identity;
@@ -104,6 +107,19 @@ class _TilePagePainter extends CustomPainter {
     );
     if (view.isEmpty) return;
     final paint = Paint()..filterQuality = filterQuality;
+    final debugBounds = pdfDebugPaintDetailBounds.value;
+    final exactBorder = debugBounds
+        ? (Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1
+          ..color = const Color(0xAA00C853)) // green: exact-bucket tile
+        : null;
+    final fallbackBorder = debugBounds
+        ? (Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 1
+          ..color = const Color(0xAAFF6D00)) // orange: upscaled fallback
+        : null;
     for (final placement in view.placements) {
       final dest = Rect.fromLTRB(
         placement.destFraction.left * size.width,
@@ -112,6 +128,10 @@ class _TilePagePainter extends CustomPainter {
         placement.destFraction.bottom * size.height,
       );
       canvas.drawImageRect(placement.image, placement.src, dest, paint);
+      if (debugBounds) {
+        canvas.drawRect(
+            dest, placement.isFallback ? fallbackBorder! : exactBorder!);
+      }
     }
   }
 

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -28,6 +28,7 @@ class PdfTileLayer extends StatelessWidget {
     required this.desiredRatio,
     required this.visibleFraction,
     required this.rasterize,
+    this.canRasterize,
     this.filterQuality = FilterQuality.medium,
   });
 
@@ -49,6 +50,10 @@ class PdfTileLayer extends StatelessWidget {
   /// Rasterizes one tile from the page's retained scene.
   final PdfTileRasterizer rasterize;
 
+  /// Optional per-tile veto (see [PdfTileStore.viewFor]): a region this
+  /// returns false for is left to the fallback/base raster.
+  final bool Function(Rect region)? canRasterize;
+
   final FilterQuality filterQuality;
 
   @override
@@ -61,6 +66,7 @@ class PdfTileLayer extends StatelessWidget {
           desiredRatio: desiredRatio,
           visibleFraction: visibleFraction,
           rasterize: rasterize,
+          canRasterize: canRasterize,
           filterQuality: filterQuality,
         ),
       );
@@ -74,6 +80,7 @@ class _TilePagePainter extends CustomPainter {
     required this.desiredRatio,
     required this.visibleFraction,
     required this.rasterize,
+    required this.canRasterize,
     required this.filterQuality,
   }) : super(
             // tick as sharper tiles land, and repaint on debug-border toggles
@@ -85,6 +92,7 @@ class _TilePagePainter extends CustomPainter {
   final double desiredRatio;
   final Rect visibleFraction;
   final PdfTileRasterizer rasterize;
+  final bool Function(Rect region)? canRasterize;
   final FilterQuality filterQuality;
 
   @override
@@ -104,6 +112,7 @@ class _TilePagePainter extends CustomPainter {
       desiredRatio: desiredRatio,
       visiblePageRect: visiblePageRect,
       rasterize: rasterize,
+      canRasterize: canRasterize,
     );
     if (view.isEmpty) return;
     final paint = Paint()..filterQuality = filterQuality;
@@ -143,5 +152,6 @@ class _TilePagePainter extends CustomPainter {
       old.desiredRatio != desiredRatio ||
       old.visibleFraction != visibleFraction ||
       !identical(old.rasterize, rasterize) ||
+      !identical(old.canRasterize, canRasterize) ||
       old.filterQuality != filterQuality;
 }

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -133,13 +133,18 @@ class PdfTileKey {
 /// A retained tile image plus the page-point region it covers and the bucket it
 /// belongs to. Owned by the store's cache; disposed on eviction.
 class PdfTile {
-  PdfTile(this.image, this.region, this.rung);
+  PdfTile(this.image, this.region, this.rung, this.pageFraction);
 
   final ui.Image image;
 
   /// The tile's bounds in page points (clamped to the page at the edges).
   final Rect region;
   final int rung;
+
+  /// [region] as fractions (0..1) of the page - recorded at raster time so
+  /// diagnostics (the thumbnail debug overlay) can place the tile without
+  /// knowing the page size.
+  final Rect pageFraction;
 
   int get bytes => image.width * image.height * 4;
 }
@@ -229,6 +234,10 @@ class PdfTileStore extends ChangeNotifier {
   /// (or registered for memory pressure) unless the tile path is exercised.
   static PdfTileStore get instance => _instance ??= PdfTileStore();
 
+  /// The shared store if one was ever created, without creating it -
+  /// diagnostics must not allocate a pyramid just by looking.
+  static PdfTileStore? get instanceOrNull => _instance;
+
   /// Physical pixels per tile side. A tile at bucket ratio r covers
   /// `tilePixels / r` page points per side.
   final int tilePixels;
@@ -301,11 +310,28 @@ class PdfTileStore extends ChangeNotifier {
   /// Whether a tile for [key] is retained (test/diagnostic; no LRU touch).
   bool containsTile(PdfTileKey key) => _cache.containsKey(key);
 
+  /// Diagnostic snapshot of the retained tiles for [pageIndex] (any identity
+  /// generation), as page fractions + rung. Pure peek - no LRU touches. The
+  /// thumbnail debug overlay draws these.
+  List<({Rect fraction, int rung})> debugTileFractionsForPage(int pageIndex) =>
+      [
+        for (final key in _cache.keys.toList())
+          if (key.id.pageIndex == pageIndex)
+            if (_cache.peek(key) case final tile?)
+              (fraction: tile.pageFraction, rung: tile.rung),
+      ];
+
   /// The best-available composite for [id] over [visiblePageRect] (page points)
   /// at [desiredRatio], scheduling the missing exact-bucket tiles (center-out)
   /// plus a one-tile prefetch ring. Missing tiles fall back per-tile to the
   /// nearest coarser cached bucket, upscaled; anything still uncovered leaves
   /// the base raster showing through.
+  ///
+  /// [canRasterize], when given, vetoes scheduling per tile region: a vetoed
+  /// tile is never rastered or cached (its area keeps the fallback/base),
+  /// and is re-consulted on every pass so it heals once the veto lifts. The
+  /// page view uses this to tile a vector-only progressive scene everywhere
+  /// except the regions its absent image pixels would corrupt.
   ///
   /// Synchronous and side-effecting: every tile it *places* is touched to
   /// most-recently-used, so a concurrent completion's eviction can only drop
@@ -319,6 +345,7 @@ class PdfTileStore extends ChangeNotifier {
     required double desiredRatio,
     required Rect visiblePageRect,
     required PdfTileRasterizer rasterize,
+    bool Function(Rect region)? canRasterize,
   }) {
     if (_disposed ||
         pageSize.width <= 0 ||
@@ -375,7 +402,8 @@ class PdfTileStore extends ChangeNotifier {
         ));
       } else {
         complete = false;
-        _schedule(key, id, pageSize, span, ratio, rasterize, pending);
+        _schedule(key, id, pageSize, span, ratio, rasterize, pending,
+            canRasterize);
         final fallback = _coarserFallback(id, rung, tx, ty, span, pageSize);
         if (fallback != null) placements.add(fallback);
       }
@@ -393,7 +421,7 @@ class PdfTileStore extends ChangeNotifier {
         for (var tx = rx0; tx <= rx1; tx++) {
           if (tx >= tx0 && tx <= tx1 && ty >= ty0 && ty <= ty1) continue;
           _schedule(PdfTileKey(id, rung, tx, ty), id, pageSize, span, ratio,
-              rasterize, pending);
+              rasterize, pending, canRasterize);
         }
       }
     }
@@ -466,11 +494,15 @@ class PdfTileStore extends ChangeNotifier {
     double ratio,
     PdfTileRasterizer rasterize,
     List<PdfTileKey>? pending,
+    bool Function(Rect region)? canRasterize,
   ) {
     if (_disposed || _cache.containsKey(key) || _inFlight.contains(key)) return;
     final region = _clampToPage(
         Rect.fromLTWH(key.tx * span, key.ty * span, span, span), pageSize);
     if (region.width <= 0 || region.height <= 0) return;
+    // Vetoed tiles are neither in-flight nor cached, so every pass re-asks -
+    // the veto lifting (a scene upgrade) heals them without invalidation.
+    if (canRasterize != null && !canRasterize(region)) return;
 
     _inFlight.add(key);
     debugTilesScheduled++;
@@ -486,7 +518,8 @@ class PdfTileStore extends ChangeNotifier {
         debugTilesDiscarded++;
         return;
       }
-      _cache.put(key, PdfTile(image, region, key.rung));
+      _cache.put(
+          key, PdfTile(image, region, key.rung, _fractionOf(region, pageSize)));
       debugTilesLanded++;
       _scheduleTick();
     }, onError: (Object _, StackTrace __) {
@@ -579,7 +612,7 @@ class PdfTileStore extends ChangeNotifier {
           _cache.put(
               key,
               PdfTile(_sliceTile(slab, batchRegion, region, ratio), region,
-                  key.rung));
+                  key.rung, _fractionOf(region, pageSize)));
           debugTilesLanded++;
         }
       } finally {

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -152,11 +152,17 @@ class PdfTilePlacement {
     required this.image,
     required this.src,
     required this.destFraction,
+    this.isFallback = false,
   });
 
   final ui.Image image;
   final Rect src;
   final Rect destFraction;
+
+  /// True when this placement upscales a coarser-bucket tile standing in for
+  /// a missing exact tile (diagnostic - drawn differently by the debug
+  /// border overlay).
+  final bool isFallback;
 }
 
 /// The synchronous result of [PdfTileStore.viewFor]: the tiles to composite for
@@ -196,8 +202,12 @@ class PdfTileStore extends ChangeNotifier {
     int maxBytes = _defaultMaxBytes,
     this.prefetchRing = 1,
     this.maxFallbackDepth = 4,
+    this.batchRasters = true,
+    this.maxBatchTilesPerAxis = 8,
     bool registerForMemoryPressure = true,
-  }) : _cache = PdfBudgetedCache<PdfTileKey, PdfTile>(
+  })  : assert(tilePixels * maxBatchTilesPerAxis <= 1 << 14,
+            'a batch slab must fit the engine texture limit'),
+        _cache = PdfBudgetedCache<PdfTileKey, PdfTile>(
           weigher: (tile) => tile.bytes,
           maxWeight: math.max(maxBytes, _minBytes),
           disposer: (tile) => tile.image.dispose(),
@@ -232,6 +242,29 @@ class PdfTileStore extends ChangeNotifier {
   /// before leaving the base raster to show through.
   final int maxFallbackDepth;
 
+  /// Coalesce the missing tiles of one [viewFor] pass into as few region
+  /// rasters as possible, then slice each returned slab into tiles GPU-side
+  /// (`drawImageRect` + `toImageSync` - a blit, no scene replay and no extra
+  /// readback). The per-`toImage` fixed overhead is what makes one raster per
+  /// 512² tile lose to the legacy single-patch path on a cold sweep (see
+  /// benchmark_tile_store_test.dart), so batching restores the patch's
+  /// one-readback-per-settle cost while keeping the pyramid's reuse.
+  ///
+  /// A dense missing set (at least half of its bounding box, the cold-settle
+  /// shape) rasters as one slab; a sparse one (revisit holes) falls back to
+  /// per-row runs so cached tiles are never re-rastered. False restores one
+  /// raster call per tile.
+  final bool batchRasters;
+
+  /// Cap on a batch's tile extent per axis, bounding the slab under the
+  /// engine's 2^14 px texture limit (8 × 512 = 4096) and bounding the latency
+  /// of any single readback.
+  final int maxBatchTilesPerAxis;
+
+  /// A missing set sparser than this fraction of its bounding box splits into
+  /// per-row runs instead of one slab, bounding wasted raster area to <2×.
+  static const _batchFillThreshold = 0.5;
+
   final PdfBudgetedCache<PdfTileKey, PdfTile> _cache;
   final Set<PdfTileKey> _inFlight = {};
 
@@ -250,6 +283,7 @@ class PdfTileStore extends ChangeNotifier {
   int debugTilesLanded = 0;
   int debugTilesDiscarded = 0;
   int debugTicks = 0;
+  int debugBatchesDispatched = 0;
 
   /// Total bytes of retained tiles.
   int get retainedBytes => _cache.weight;
@@ -327,6 +361,7 @@ class PdfTileStore extends ChangeNotifier {
     });
 
     final placements = <PdfTilePlacement>[];
+    final pending = batchRasters ? <PdfTileKey>[] : null;
     var complete = true;
     for (final (tx, ty) in coords) {
       final key = PdfTileKey(id, rung, tx, ty);
@@ -340,7 +375,7 @@ class PdfTileStore extends ChangeNotifier {
         ));
       } else {
         complete = false;
-        _schedule(key, id, pageSize, span, ratio, rasterize);
+        _schedule(key, id, pageSize, span, ratio, rasterize, pending);
         final fallback = _coarserFallback(id, rung, tx, ty, span, pageSize);
         if (fallback != null) placements.add(fallback);
       }
@@ -358,8 +393,14 @@ class PdfTileStore extends ChangeNotifier {
         for (var tx = rx0; tx <= rx1; tx++) {
           if (tx >= tx0 && tx <= tx1 && ty >= ty0 && ty <= ty1) continue;
           _schedule(PdfTileKey(id, rung, tx, ty), id, pageSize, span, ratio,
-              rasterize);
+              rasterize, pending);
         }
+      }
+    }
+
+    if (pending != null && pending.isNotEmpty) {
+      for (final group in _groupBatches(pending)) {
+        _dispatchBatch(group, id, pageSize, span, ratio, rasterize);
       }
     }
 
@@ -408,11 +449,15 @@ class PdfTileStore extends ChangeNotifier {
           src.bottom.clamp(0, tile.image.height.toDouble()),
         ),
         destFraction: _fractionOf(overlap, pageSize),
+        isFallback: true,
       );
     }
     return null;
   }
 
+  /// Marks [key] in-flight and either dispatches its raster now or, when
+  /// [pending] is non-null (one [viewFor] pass in [batchRasters] mode), defers
+  /// it into the pass's batch.
   void _schedule(
     PdfTileKey key,
     PdfTilePageIdentity id,
@@ -420,6 +465,7 @@ class PdfTileStore extends ChangeNotifier {
     double span,
     double ratio,
     PdfTileRasterizer rasterize,
+    List<PdfTileKey>? pending,
   ) {
     if (_disposed || _cache.containsKey(key) || _inFlight.contains(key)) return;
     final region = _clampToPage(
@@ -428,6 +474,10 @@ class PdfTileStore extends ChangeNotifier {
 
     _inFlight.add(key);
     debugTilesScheduled++;
+    if (pending != null) {
+      pending.add(key);
+      return;
+    }
     final dispatchEpoch = _globalEpoch;
     rasterize(region, ratio).then((image) {
       _inFlight.remove(key);
@@ -443,6 +493,137 @@ class PdfTileStore extends ChangeNotifier {
       _inFlight.remove(key);
       debugTilesDiscarded++;
     });
+  }
+
+  /// Splits one pass's missing tiles into raster batches: the whole set as a
+  /// single slab when it fills at least [_batchFillThreshold] of its bounding
+  /// box (and fits [maxBatchTilesPerAxis]), else contiguous per-row runs so a
+  /// sparse set never re-rasters the cached tiles between its holes.
+  List<List<PdfTileKey>> _groupBatches(List<PdfTileKey> keys) {
+    var txMin = keys.first.tx, txMax = keys.first.tx;
+    var tyMin = keys.first.ty, tyMax = keys.first.ty;
+    for (final k in keys) {
+      txMin = math.min(txMin, k.tx);
+      txMax = math.max(txMax, k.tx);
+      tyMin = math.min(tyMin, k.ty);
+      tyMax = math.max(tyMax, k.ty);
+    }
+    final w = txMax - txMin + 1;
+    final h = tyMax - tyMin + 1;
+    if (w <= maxBatchTilesPerAxis &&
+        h <= maxBatchTilesPerAxis &&
+        keys.length >= _batchFillThreshold * w * h) {
+      return [keys];
+    }
+    final byRow = <int, List<PdfTileKey>>{};
+    for (final k in keys) {
+      (byRow[k.ty] ??= []).add(k);
+    }
+    final groups = <List<PdfTileKey>>[];
+    for (final row in byRow.values) {
+      row.sort((a, b) => a.tx.compareTo(b.tx));
+      var run = <PdfTileKey>[row.first];
+      for (final k in row.skip(1)) {
+        if (k.tx == run.last.tx + 1 && run.length < maxBatchTilesPerAxis) {
+          run.add(k);
+        } else {
+          groups.add(run);
+          run = [k];
+        }
+      }
+      groups.add(run);
+    }
+    return groups;
+  }
+
+  /// Rasters one batch as a single slab readback and slices it into tiles.
+  /// Every key in [batch] is already in [_inFlight].
+  void _dispatchBatch(
+    List<PdfTileKey> batch,
+    PdfTilePageIdentity id,
+    Size pageSize,
+    double span,
+    double ratio,
+    PdfTileRasterizer rasterize,
+  ) {
+    Rect tileRegion(PdfTileKey key) => _clampToPage(
+        Rect.fromLTWH(key.tx * span, key.ty * span, span, span), pageSize);
+
+    var txMin = batch.first.tx, txMax = batch.first.tx;
+    var tyMin = batch.first.ty, tyMax = batch.first.ty;
+    for (final k in batch) {
+      txMin = math.min(txMin, k.tx);
+      txMax = math.max(txMax, k.tx);
+      tyMin = math.min(tyMin, k.ty);
+      tyMax = math.max(tyMax, k.ty);
+    }
+    final batchRegion = _clampToPage(
+        Rect.fromLTWH(txMin * span, tyMin * span, (txMax - txMin + 1) * span,
+            (tyMax - tyMin + 1) * span),
+        pageSize);
+
+    final dispatchEpoch = _globalEpoch;
+    debugBatchesDispatched++;
+    rasterize(batchRegion, ratio).then((slab) {
+      for (final key in batch) {
+        _inFlight.remove(key);
+      }
+      if (_disposed || _isStale(id.pageIndex, dispatchEpoch)) {
+        slab.dispose();
+        debugTilesDiscarded += batch.length;
+        return;
+      }
+      try {
+        for (final key in batch) {
+          final region = tileRegion(key);
+          _cache.put(
+              key,
+              PdfTile(_sliceTile(slab, batchRegion, region, ratio), region,
+                  key.rung));
+          debugTilesLanded++;
+        }
+      } finally {
+        slab.dispose();
+      }
+      _scheduleTick();
+    }, onError: (Object _, StackTrace __) {
+      for (final key in batch) {
+        _inFlight.remove(key);
+      }
+      debugTilesDiscarded += batch.length;
+    });
+  }
+
+  /// Cuts one tile out of a batch slab: a 1:1 `drawImageRect` blit converted
+  /// with `toImageSync`, so the tile becomes its own GPU-resident texture
+  /// without a scene replay or a pixel readback.
+  ui.Image _sliceTile(
+      ui.Image slab, Rect batchRegion, Rect tileRegion, double ratio) {
+    final w = (tileRegion.width * ratio).ceil().clamp(1, 1 << 14);
+    final h = (tileRegion.height * ratio).ceil().clamp(1, 1 << 14);
+    final src = Rect.fromLTWH(
+      (tileRegion.left - batchRegion.left) * ratio,
+      (tileRegion.top - batchRegion.top) * ratio,
+      w.toDouble(),
+      h.toDouble(),
+    ).intersect(
+        Rect.fromLTWH(0, 0, slab.width.toDouble(), slab.height.toDouble()));
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    if (!src.isEmpty) {
+      canvas.drawImageRect(
+        slab,
+        src,
+        Rect.fromLTWH(0, 0, src.width, src.height),
+        Paint()..filterQuality = FilterQuality.none,
+      );
+    }
+    final picture = recorder.endRecording();
+    try {
+      return picture.toImageSync(w, h);
+    } finally {
+      picture.dispose();
+    }
   }
 
   bool _isStale(int pageIndex, int dispatchEpoch) =>

--- a/packages/dart_pdf_editor/test/benchmark_tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_tile_store_test.dart
@@ -1,10 +1,13 @@
 // Before/after benchmark for the PdfTileStore deep-zoom path (issue #314):
 // the shipping single detail patch re-rasterizes the whole visible region on
 // every settle, while the tile pyramid rasterizes only the missing tiles and
-// reuses the rest. This harness drives the two raster strategies through the
-// same pinch-in and deep-zoom pan sequences over a page's retained scene and
-// reports the raster work each pays (calls, megapixels, wall time) plus the
-// tile reuse ratio and retained bytes.
+// reuses the rest. This harness drives three raster strategies - the legacy
+// patch, the per-tile store (batchRasters: false), and the batched store
+// (one slab readback per settle, sliced GPU-side) - through the same pinch-in
+// and deep-zoom pan sequences over a page's retained scene and reports the
+// raster work each pays (calls, megapixels, wall time), the settle-loop wall
+// clock (which for the batched store includes slab slicing), the tile reuse
+// ratio, and retained bytes.
 //
 // Both strategies share one up-front PdfRetainedScene.record (interpret +
 // decode) - the cost the zoom must never re-pay - so the numbers isolate the
@@ -140,50 +143,54 @@ void main() {
       }
 
       // Aggregate the raster work each strategy paid across every page.
-      var patchPanMp = 0.0, tilePanMp = 0.0, patchPanMs = 0.0, tilePanMs = 0.0;
-      var patchPinchMp = 0.0, tilePinchMp = 0.0;
-      var patchRevMp = 0.0, tileRevMp = 0.0, patchRevMs = 0.0, tileRevMs = 0.0;
-      for (final res in results) {
-        if (res['error'] != null) continue;
-        patchPanMp += (res['patchPan'] as Map)['rasterMegapixels'] as double;
-        tilePanMp += (res['tilePan'] as Map)['rasterMegapixels'] as double;
-        patchPanMs += (res['patchPan'] as Map)['rasterMs'] as double;
-        tilePanMs += (res['tilePan'] as Map)['rasterMs'] as double;
-        patchPinchMp += (res['patchPinch'] as Map)['rasterMegapixels'] as double;
-        tilePinchMp += (res['tilePinch'] as Map)['rasterMegapixels'] as double;
-        patchRevMp += (res['patchRevisit'] as Map)['rasterMegapixels'] as double;
-        tileRevMp += (res['tileRevisit'] as Map)['rasterMegapixels'] as double;
-        patchRevMs += (res['patchRevisit'] as Map)['rasterMs'] as double;
-        tileRevMs += (res['tileRevisit'] as Map)['rasterMs'] as double;
-      }
+      final ok = results.where((r) => r['error'] == null).toList();
+      double sumOf(String key, String field) => ok.fold(
+          0.0,
+          (t, r) =>
+              t + (((r[key] as Map)[field] ?? 0) as num).toDouble());
+      double round1(double v) => double.parse(v.toStringAsFixed(1));
       double ratio(double a, double b) =>
           b == 0 ? 0 : double.parse((a / b).toStringAsFixed(2));
+
+      // One phase ('Pan'/'Revisit'/'Pinch') across the three strategies.
+      Map<String, Object?> phaseAgg(String phase) => {
+            for (final strat in ['patch', 'tile', 'batch']) ...{
+              '${strat}Megapixels':
+                  round1(sumOf('$strat$phase', 'rasterMegapixels')),
+              '${strat}Ms': round1(sumOf('$strat$phase', 'rasterMs')),
+              '${strat}Calls': sumOf('$strat$phase', 'rasterCalls').round(),
+            },
+            'tileSettleMs': round1(sumOf('tile$phase', 'settleMs')),
+            'batchSettleMs': round1(sumOf('batch$phase', 'settleMs')),
+            'tileMegapixelSpeedup': ratio(
+                sumOf('patch$phase', 'rasterMegapixels'),
+                sumOf('tile$phase', 'rasterMegapixels')),
+            'batchMegapixelSpeedup': ratio(
+                sumOf('patch$phase', 'rasterMegapixels'),
+                sumOf('batch$phase', 'rasterMegapixels')),
+            'tileMsSpeedup': ratio(sumOf('patch$phase', 'rasterMs'),
+                sumOf('tile$phase', 'rasterMs')),
+            'batchMsSpeedup': ratio(sumOf('patch$phase', 'rasterMs'),
+                sumOf('batch$phase', 'rasterMs')),
+          };
+
+      final patchRevMp = sumOf('patchRevisit', 'rasterMegapixels');
       final aggregate = {
-        'pagesBenched': results.where((r) => r['error'] == null).length,
-        'pan': {
-          'patchMegapixels': double.parse(patchPanMp.toStringAsFixed(1)),
-          'tileMegapixels': double.parse(tilePanMp.toStringAsFixed(1)),
-          'patchMs': double.parse(patchPanMs.toStringAsFixed(1)),
-          'tileMs': double.parse(tilePanMs.toStringAsFixed(1)),
-          'megapixelSpeedup': ratio(patchPanMp, tilePanMp),
-          'msSpeedup': ratio(patchPanMs, tilePanMs),
-        },
+        'pagesBenched': ok.length,
+        'pan': phaseAgg('Pan'),
         'revisit': {
-          'patchMegapixels': double.parse(patchRevMp.toStringAsFixed(1)),
-          'tileMegapixels': double.parse(tileRevMp.toStringAsFixed(1)),
-          'patchMs': double.parse(patchRevMs.toStringAsFixed(1)),
-          'tileMs': double.parse(tileRevMs.toStringAsFixed(1)),
+          ...phaseAgg('Revisit'),
           // How much of the legacy re-raster the tile cache avoided on revisit.
           'tileReusePct': patchRevMp == 0
               ? null
-              : double.parse(
-                  (100 * (1 - tileRevMp / patchRevMp)).toStringAsFixed(1)),
+              : round1(100 *
+                  (1 - sumOf('tileRevisit', 'rasterMegapixels') / patchRevMp)),
+          'batchReusePct': patchRevMp == 0
+              ? null
+              : round1(100 *
+                  (1 - sumOf('batchRevisit', 'rasterMegapixels') / patchRevMp)),
         },
-        'pinch': {
-          'patchMegapixels': double.parse(patchPinchMp.toStringAsFixed(1)),
-          'tileMegapixels': double.parse(tilePinchMp.toStringAsFixed(1)),
-          'megapixelSpeedup': ratio(patchPinchMp, tilePinchMp),
-        },
+        'pinch': phaseAgg('Pinch'),
       };
       // ignore: avoid_print
       print('  tile-store aggregate: ${const JsonEncoder().convert(aggregate)}');
@@ -258,36 +265,9 @@ Future<Map<String, Object?>> _benchFile(
       (await patchPinch.raster(scene, region, ratio)).dispose();
     }
 
-    final tilePinch = _RasterMeter();
-    final pinchStore = PdfTileStore(
-      tilePixels: tilePx,
-      registerForMemoryPressure: false,
-    );
-    for (final ratio in pinchRatios) {
-      final region = _visibleRegion(
-        pageSize,
-        viewport,
-        ratio,
-        (pageSize.width - viewport.width / ratio) / 2,
-        (pageSize.height - viewport.height / ratio) / 2,
-      );
-      pinchStore.viewFor(
-        id: identity,
-        pageSize: pageSize,
-        desiredRatio: ratio,
-        visiblePageRect: region,
-        rasterize: (r, pr) => tilePinch.raster(scene, r, pr),
-      );
-      await tester.pumpAndSettle(const Duration(milliseconds: 1));
-      await Future<void>.delayed(Duration.zero);
-    }
-    final pinchRetained = pinchStore.retainedBytes;
-    final pinchTiles = pinchStore.tileCount;
-    pinchStore.dispose();
-
-    // --- Pan: fixed deep zoom, incremental drag (overlapping viewports, the
-    // case tile reuse targets - each step reveals a leading strip and keeps
-    // the rest). stepDx = a fraction of the visible width. ---
+    // --- Pan geometry: fixed deep zoom, incremental drag (overlapping
+    // viewports, the case tile reuse targets - each step reveals a leading
+    // strip and keeps the rest). stepDx = a fraction of the visible width. ---
     final visW = math.min(viewport.width / tileRatio, pageSize.width);
     final stepDx = visW * panFraction;
 
@@ -298,32 +278,8 @@ Future<Map<String, Object?>> _benchFile(
       (await patchPan.raster(scene, region, tileRatio)).dispose();
     }
 
-    final tilePan = _RasterMeter();
-    final panStore = PdfTileStore(
-      tilePixels: tilePx,
-      registerForMemoryPressure: false,
-    );
-    Future<void> tileSettleAt(double ox, _RasterMeter meter) async {
-      final region = _visibleRegion(pageSize, viewport, tileRatio, ox, 0);
-      panStore.viewFor(
-        id: identity,
-        pageSize: pageSize,
-        desiredRatio: tileRatio,
-        visiblePageRect: region,
-        rasterize: (r, pr) => meter.raster(scene, r, pr),
-      );
-      await tester.pumpAndSettle(const Duration(milliseconds: 1));
-      await Future<void>.delayed(Duration.zero);
-    }
-
-    for (var i = 0; i < panSteps; i++) {
-      await tileSettleAt(i * stepDx, tilePan);
-    }
-    final panRetained = panStore.retainedBytes;
-    final panTiles = panStore.tileCount;
-
-    // Revisit: drag back over the just-tiled area. Legacy re-rasters the full
-    // region every step; the tile store reuses cached tiles (the "pan = zero
+    // Revisit: drag back over the just-seen area. Legacy re-rasters the full
+    // region every step; a tile store reuses cached tiles (the "pan = zero
     // re-raster" claim), so its revisit raster work should be near zero.
     final patchRevisit = _RasterMeter();
     for (var i = panSteps - 2; i >= 0; i--) {
@@ -331,12 +287,112 @@ Future<Map<String, Object?>> _benchFile(
           _visibleRegion(pageSize, viewport, tileRatio, i * stepDx, 0);
       (await patchRevisit.raster(scene, region, tileRatio)).dispose();
     }
-    final tileRevisit = _RasterMeter();
-    for (var i = panSteps - 2; i >= 0; i--) {
-      await tileSettleAt(i * stepDx, tileRevisit);
-    }
-    panStore.dispose();
 
+    // One tile strategy (per-tile or batched slab), through the same pinch /
+    // pan / revisit settles. settleMs is the loop's wall clock - for the
+    // batched store that includes the GPU-side slab slicing the raster meter
+    // can't see (both tile strategies share the same pump overhead, so they
+    // compare apples-to-apples).
+    Future<Map<String, Object?>> runTileStrategy({required bool batch}) async {
+      final pinch = _RasterMeter();
+      final pinchStore = PdfTileStore(
+        tilePixels: tilePx,
+        batchRasters: batch,
+        registerForMemoryPressure: false,
+      );
+      final pinchClock = Stopwatch()..start();
+      for (final ratio in pinchRatios) {
+        final region = _visibleRegion(
+          pageSize,
+          viewport,
+          ratio,
+          (pageSize.width - viewport.width / ratio) / 2,
+          (pageSize.height - viewport.height / ratio) / 2,
+        );
+        pinchStore.viewFor(
+          id: identity,
+          pageSize: pageSize,
+          desiredRatio: ratio,
+          visiblePageRect: region,
+          rasterize: (r, pr) => pinch.raster(scene, r, pr),
+        );
+        await tester.pumpAndSettle(const Duration(milliseconds: 1));
+        // Settle-to-sharp: the settle isn't over until every scheduled tile
+        // has landed (or been sliced), so drain in-flight rasters inside the
+        // clock window.
+        while (pinchStore.inFlightCount > 0) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+      pinchClock.stop();
+      final pinchRetained = pinchStore.retainedBytes;
+      final pinchTiles = pinchStore.tileCount;
+      pinchStore.dispose();
+
+      final panStore = PdfTileStore(
+        tilePixels: tilePx,
+        batchRasters: batch,
+        registerForMemoryPressure: false,
+      );
+      Future<void> settleAt(double ox, _RasterMeter meter) async {
+        final region = _visibleRegion(pageSize, viewport, tileRatio, ox, 0);
+        panStore.viewFor(
+          id: identity,
+          pageSize: pageSize,
+          desiredRatio: tileRatio,
+          visiblePageRect: region,
+          rasterize: (r, pr) => meter.raster(scene, r, pr),
+        );
+        await tester.pumpAndSettle(const Duration(milliseconds: 1));
+        // Settle-to-sharp: drain in-flight rasters inside the clock window.
+        while (panStore.inFlightCount > 0) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }
+
+      final pan = _RasterMeter();
+      final panClock = Stopwatch()..start();
+      for (var i = 0; i < panSteps; i++) {
+        await settleAt(i * stepDx, pan);
+      }
+      panClock.stop();
+      final panRetained = panStore.retainedBytes;
+      final panTiles = panStore.tileCount;
+
+      final revisit = _RasterMeter();
+      final revisitClock = Stopwatch()..start();
+      for (var i = panSteps - 2; i >= 0; i--) {
+        await settleAt(i * stepDx, revisit);
+      }
+      revisitClock.stop();
+      panStore.dispose();
+
+      double ms(Stopwatch sw) =>
+          double.parse((sw.elapsedMicroseconds / 1000).toStringAsFixed(2));
+      return {
+        'pinch': {
+          ...pinch.summary(pinchRatios.length),
+          'settleMs': ms(pinchClock),
+          'retainedKB': pinchRetained ~/ 1024,
+          'tiles': pinchTiles,
+        },
+        'pan': {
+          ...pan.summary(panSteps),
+          'settleMs': ms(panClock),
+          'retainedKB': panRetained ~/ 1024,
+          'tiles': panTiles,
+        },
+        'revisit': {
+          ...revisit.summary(panSteps - 1),
+          'settleMs': ms(revisitClock),
+        },
+      };
+    }
+
+    final tiles = await runTileStrategy(batch: false);
+    final batched = await runTileStrategy(batch: true);
+
+    double mp(Map<String, Object?> s) => (s['rasterMegapixels'] as num).toDouble();
     double speedup(double a, double b) =>
         b == 0 ? 0 : double.parse((a / b).toStringAsFixed(2));
 
@@ -347,25 +403,24 @@ Future<Map<String, Object?>> _benchFile(
       'commands': scene.commands.length,
       'regionCullable': scene.supportsRegionRaster,
       'patchPinch': patchPinch.summary(pinchRatios.length),
-      'tilePinch': {
-        ...tilePinch.summary(pinchRatios.length),
-        'retainedKB': pinchRetained ~/ 1024,
-        'tiles': pinchTiles,
-      },
+      'tilePinch': tiles['pinch'],
+      'batchPinch': batched['pinch'],
       'patchPan': patchPan.summary(panSteps),
-      'tilePan': {
-        ...tilePan.summary(panSteps),
-        'retainedKB': panRetained ~/ 1024,
-        'tiles': panTiles,
-      },
+      'tilePan': tiles['pan'],
+      'batchPan': batched['pan'],
       'patchRevisit': patchRevisit.summary(panSteps - 1),
-      'tileRevisit': tileRevisit.summary(panSteps - 1),
-      'tileRevisitSpeedup':
-          speedup(patchRevisit.pixels.toDouble(), tileRevisit.pixels.toDouble()),
-      'tilePanSpeedup':
-          speedup(patchPan.pixels.toDouble(), tilePan.pixels.toDouble()),
-      'tilePinchSpeedup':
-          speedup(patchPinch.pixels.toDouble(), tilePinch.pixels.toDouble()),
+      'tileRevisit': tiles['revisit'],
+      'batchRevisit': batched['revisit'],
+      'tileRevisitSpeedup': speedup(patchRevisit.pixels / 1e6,
+          mp(tiles['revisit'] as Map<String, Object?>)),
+      'tilePanSpeedup': speedup(
+          patchPan.pixels / 1e6, mp(tiles['pan'] as Map<String, Object?>)),
+      'tilePinchSpeedup': speedup(
+          patchPinch.pixels / 1e6, mp(tiles['pinch'] as Map<String, Object?>)),
+      'batchPanSpeedup': speedup(
+          patchPan.pixels / 1e6, mp(batched['pan'] as Map<String, Object?>)),
+      'batchPinchSpeedup': speedup(patchPinch.pixels / 1e6,
+          mp(batched['pinch'] as Map<String, Object?>)),
     };
   } finally {
     scene.dispose();

--- a/packages/dart_pdf_editor/test/budgeted_cache_test.dart
+++ b/packages/dart_pdf_editor/test/budgeted_cache_test.dart
@@ -345,4 +345,76 @@ void main() {
       expect(c.length, 1, reason: 'pressure does not touch an unregistered cache');
     });
   });
+
+  group('coordinated ceiling (maxTotalWeight)', () {
+    tearDown(() => PdfCacheRegistry.instance.maxTotalWeight = 0);
+
+    PdfBudgetedCache<int, _Res> registered({List<int>? dropped}) {
+      final cache = PdfBudgetedCache<int, _Res>(
+        weigher: (r) => r.weight,
+        maxWeight: 1000,
+        clearsUnderMemoryPressure: true,
+        disposer: dropped == null ? null : (r) => dropped.add(r.id),
+      );
+      addTearDown(cache.dispose);
+      return cache;
+    }
+
+    test('trimToWeight evicts LRU-first and protects the MRU entry', () {
+      final dropped = <int>[];
+      final cache = registered(dropped: dropped);
+      for (var i = 0; i < 5; i++) {
+        cache.put(i, _Res(i, weight: 10));
+      }
+      cache.trimToWeight(25);
+      expect(cache.weight, 20);
+      expect(dropped, [0, 1, 2]);
+
+      cache.trimToWeight(0);
+      expect(cache.length, 1, reason: 'the MRU entry is never evicted');
+      expect(cache.containsKey(4), isTrue);
+    });
+
+    test('setting the ceiling trims registered caches proportionally', () {
+      final registry = PdfCacheRegistry.instance;
+      final a = registered();
+      final b = registered();
+      for (var i = 0; i < 30; i++) {
+        a.put(i, _Res(i, weight: 10)); // 300
+      }
+      for (var i = 0; i < 10; i++) {
+        b.put(i, _Res(i, weight: 10)); // 100
+      }
+      expect(registry.totalWeight, 400,
+          reason: 'no other weight-bearing cache should be live in this test');
+
+      registry.maxTotalWeight = 200;
+      expect(registry.totalWeight, lessThanOrEqualTo(200));
+      // Proportional: both keep ~half, so the hot cache is not wiped to
+      // protect the small one.
+      expect(a.weight, 150);
+      expect(b.weight, 50);
+    });
+
+    test('a put on a registered cache enforces the ceiling proactively', () {
+      final registry = PdfCacheRegistry.instance;
+      final cache = registered();
+      registry.maxTotalWeight = registry.totalWeight + 100;
+
+      for (var i = 0; i < 30; i++) {
+        cache.put(i, _Res(i, weight: 10)); // would retain 300 unchecked
+      }
+      expect(cache.weight, lessThanOrEqualTo(100),
+          reason: 'growth is trimmed as it happens, not on a later signal');
+    });
+
+    test('ceiling 0 (the default) never trims', () {
+      final cache = registered();
+      expect(PdfCacheRegistry.instance.maxTotalWeight, 0);
+      for (var i = 0; i < 30; i++) {
+        cache.put(i, _Res(i, weight: 10));
+      }
+      expect(cache.weight, 300, reason: 'only the per-cache budget applies');
+    });
+  });
 }

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -558,6 +558,50 @@ void main() {
       });
     });
 
+    testWidgets('canRasterize vetoes tiles per region and heals when lifted',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(sizeFromRegion: true);
+        const pageSize = Size(64, 64); // 4×4 grid
+
+        // Veto the left half of the page (a vector-only scene's image area).
+        store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+          canRasterize: (region) => region.left >= 32,
+        );
+        // Only the right half scheduled - and as one batch of that half.
+        expect(store.inFlightCount, 8);
+        expect(raster.calls.length, 1);
+        expect(raster.calls.single.region, const Rect.fromLTWH(32, 0, 32, 64));
+        await raster.flush();
+        expect(store.tileCount, 8);
+
+        // The veto lifting (scene upgraded to the full record) heals the rest
+        // on the next pass without any invalidation.
+        store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+        );
+        expect(store.inFlightCount, 8);
+        await raster.flush();
+        expect(store.tileCount, 16);
+        store.dispose();
+      });
+    });
+
     testWidgets('a sparse missing set never re-rasters the cached area between',
         (tester) async {
       await tester.runAsync(() async {

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -25,9 +25,15 @@ Future<ui.Image> _solidImage(int w, int h,
 /// A rasterizer that holds every request pending until [flush], so a test can
 /// inspect the in-flight state before the tiles land.
 class _Rasterizer {
-  _Rasterizer({this.tileSize = 16});
+  _Rasterizer({this.tileSize = 16, this.sizeFromRegion = false});
 
   final int tileSize;
+
+  /// Size each completed image from its requested region × ratio (what a real
+  /// scene raster returns) instead of a fixed [tileSize] - required by batched
+  /// stores, whose slab slicing reads exact pixel offsets.
+  final bool sizeFromRegion;
+
   final calls = <({Rect region, double ratio})>[];
   final _pending = <Completer<ui.Image>>[];
 
@@ -40,19 +46,29 @@ class _Rasterizer {
 
   int get pendingCount => _pending.where((c) => !c.isCompleted).length;
 
-  /// Completes every outstanding raster with a solid tile-sized image, then
-  /// drains the store's completion + tick microtasks.
+  /// Completes every outstanding raster with a solid image, then drains the
+  /// store's completion + tick microtasks.
   Future<void> flush() async {
-    final pending = _pending.where((c) => !c.isCompleted).toList();
+    final pending = <int>[
+      for (var i = 0; i < _pending.length; i++)
+        if (!_pending[i].isCompleted) i,
+    ];
     // Build every image first, then complete them all in one synchronous burst
     // so the store's completions land in a single microtask drain (the case
     // its tick-coalescing targets).
     final images = <ui.Image>[
-      for (var i = 0; i < pending.length; i++)
-        await _solidImage(tileSize, tileSize),
+      for (final i in pending)
+        await _solidImage(
+          sizeFromRegion
+              ? (calls[i].region.width * calls[i].ratio).ceil()
+              : tileSize,
+          sizeFromRegion
+              ? (calls[i].region.height * calls[i].ratio).ceil()
+              : tileSize,
+        ),
     ];
     for (var i = 0; i < pending.length; i++) {
-      pending[i].complete(images[i]);
+      _pending[pending[i]].complete(images[i]);
     }
     await pumpEventQueue();
   }
@@ -100,6 +116,7 @@ void main() {
           tilePixels: 16,
           prefetchRing: 0,
           ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          batchRasters: false, // this test pins the per-tile scheduling order
           registerForMemoryPressure: false,
         );
         final raster = _Rasterizer();
@@ -425,6 +442,164 @@ void main() {
         expect(view.isEmpty, isTrue);
         await raster.flush(); // completions after dispose just free the images
         expect(store.tileCount, 0);
+      });
+    });
+  });
+
+  group('PdfTileStore batched rasters', () {
+    testWidgets('a cold settle coalesces into one slab readback and slices it',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 1,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(sizeFromRegion: true);
+        const pageSize = Size(64, 64); // 4×4 grid, fully visible (no ring)
+
+        store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+        );
+        // All 16 tiles in flight, but a single readback for the whole region.
+        expect(store.inFlightCount, 16);
+        expect(raster.calls.length, 1);
+        expect(raster.calls.single.region, const Rect.fromLTWH(0, 0, 64, 64));
+        expect(store.debugBatchesDispatched, 1);
+
+        await raster.flush();
+        expect(store.tileCount, 16);
+        expect(store.debugTilesLanded, 16);
+
+        final view = store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+        );
+        expect(view.complete, isTrue);
+        expect(view.placements.length, 16);
+        // Every slice is a real tile-sized image of its own.
+        expect(view.placements.every((p) => p.image.width == 16), isTrue);
+        expect(raster.calls.length, 1); // fully cached, nothing new
+        store.dispose();
+      });
+    });
+
+    testWidgets('slab slices land each tile\'s own pixels', (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        const colors = [
+          Color(0xFFFF0000), // tile (0,0)
+          Color(0xFF00FF00), // tile (1,0)
+          Color(0xFF0000FF), // tile (0,1)
+          Color(0xFFFFFF00), // tile (1,1)
+        ];
+        // Paints the requested region as a 2×2 quadrant grid in slab pixels.
+        Future<ui.Image> quadrants(Rect region, double ratio) async {
+          final recorder = ui.PictureRecorder();
+          final canvas = Canvas(recorder);
+          for (var i = 0; i < 4; i++) {
+            canvas.drawRect(
+              Rect.fromLTWH((i % 2) * 16.0, (i ~/ 2) * 16.0, 16, 16),
+              Paint()..color = colors[i],
+            );
+          }
+          final picture = recorder.endRecording();
+          final image = await picture.toImage(
+            (region.width * ratio).ceil(),
+            (region.height * ratio).ceil(),
+          );
+          picture.dispose();
+          return image;
+        }
+
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: quadrants,
+        );
+        expect(store.debugBatchesDispatched, 1);
+        await pumpEventQueue();
+        expect(store.tileCount, 4);
+
+        final view = store.viewFor(
+          id: _id(0),
+          pageSize: const Size(32, 32),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: quadrants,
+        );
+        expect(view.placements.length, 4);
+        for (final placement in view.placements) {
+          final tx = placement.destFraction.left >= 0.5 ? 1 : 0;
+          final ty = placement.destFraction.top >= 0.5 ? 1 : 0;
+          final data = (await placement.image.toByteData())!;
+          final o = ((8 * placement.image.width) + 8) * 4; // center pixel
+          final pixel = Color.fromARGB(data.getUint8(o + 3), data.getUint8(o),
+              data.getUint8(o + 1), data.getUint8(o + 2));
+          expect(pixel, colors[ty * 2 + tx],
+              reason: 'tile ($tx,$ty) sliced from the wrong slab offset');
+        }
+        store.dispose();
+      });
+    });
+
+    testWidgets('a sparse missing set never re-rasters the cached area between',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(sizeFromRegion: true);
+        const pageSize = Size(160, 16); // 10×1 grid
+
+        // Warm the middle run (tiles 1..8) as one slab.
+        store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(16, 0, 128, 16),
+          rasterize: raster.call,
+        );
+        expect(raster.calls.length, 1);
+        await raster.flush();
+        expect(store.tileCount, 8);
+
+        // Full row: only the far ends (tiles 0 and 9) are missing. A bounding
+        // box would re-raster the 8 cached tiles between them; the sparse path
+        // must issue two tile-sized rasters instead.
+        store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 160, 16),
+          rasterize: raster.call,
+        );
+        final sparse = raster.calls.skip(1).toList();
+        expect(sparse.length, 2);
+        expect(sparse.every((c) => c.region.width == 16), isTrue);
+        expect({sparse[0].region.left, sparse[1].region.left}, {0.0, 144.0});
+
+        await raster.flush();
+        expect(store.tileCount, 10);
+        store.dispose();
       });
     });
   });


### PR DESCRIPTION
Three intertwined workstreams from the 2026-07-18 sessions, validated end-to-end on real documents (dense CAD sheets, a 198-page scan book).

## 1. Tile pyramid: batched slab rasters, vector-first support, desktop default-on (#314)

- **`PdfTileStore.batchRasters`**: one settle's missing tiles dispatch as few slab readbacks as possible (≥50%-fill bounding box → one slab, capped 8 tiles/axis; sparse sets → per-row runs so cached tiles never re-raster), sliced into GPU-resident tiles via `drawImageRect` + `toImageSync` — no scene replay, no extra readback. Cold-pan readbacks drop 224 → 35 (512²) or 16 (1024²) on the benchmark corpus.
- **Measurement correction**: the original "tiles ~8× slower" number was concurrency overcounting of summed per-raster stopwatches; the benchmark now drives three strategies with a drained settle-to-sharp wall clock.
- **Vector-first pages tile now**: `viewFor(canRasterize:)` per-tile veto lets vector-only progressive scenes (dense CAD at deep zoom, where the full record may never land mid-dwell) tile everywhere their absent image pixels can't corrupt — 98%+ of a typical sheet; vetoed tiles heal automatically when the full record lands.
- **Default**: `pdfDefaultTileStoreDetail()` — on for desktop (validated interactively: 4,490 tiles / 862 batches / 0 discards on the scan book, pyramid pinned at its 96 MB budget), off for web and mobile pending their own validation passes.

## 2. Proactive coordinated cache ceiling

From the 8 GB macOS debug investigation: desktop delivers the memory-pressure signal too late (or never), so the budgeted caches' sum sat at a multi-hundred-MB sticky baseline. `PdfCacheRegistry.maxTotalWeight` enforces a process-level ceiling **as caches grow**, trimming proportionally via the new `trimToWeight` (LRU-first, MRU-protected). SDK default off; the app opts in at 384 MB desktop / 192 MB mobile.

## 3. F12 developer tools panel + debug overlays

Docked panel (editor sidebar chrome, never overlaying the viewer; F12 or Settings → Developer tools; every build mode, strippable with `--dart-define=DEVTOOLS=false`): frame stats, memory (RSS + per-cache table + ceiling + clear), render-worker stepper, the deep-zoom mode switch with live tile counters, PdfPerf phases/counters + PdfPerfLog toggle, session diagnostics (grow-only buffer size), and a captured log (debugPrint/FlutterError + app catches that previously vanished). Every row has a hover tooltip and tap-for-details dialog; a header button exports the whole snapshot as JSON; options persist across restarts. SDK debug overlays: tile/patch borders on the page (green exact / orange fallback / purple patch) and per-thumbnail pyramid coverage + live render-window outlines.

## Verification

- All suites green throughout (app 210, editor full pass — only the known pre-existing GWG030 Ghent baseline, unrelated); new tests for batching (incl. pixel-exact slice offsets), the veto, the ceiling, the panel, and options persistence.
- Interactive validation via the panel itself on the documents above; benchmark JSON envelopes in the session dev-logs (`doc/dev-log/2026-07-18-*.md`).
- Widget tests run as `TargetPlatform.android`, so the desktop default flip leaves the existing detail-patch tests pinning the patch path.

Follow-ups tracked: #359 (ranged local open — a 179 MB cloud-synced book measures 36 s of pure file-provider read before parse), web/mobile tile validation passes, and the #306 on-device render trace remains the gate for those platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DV1tAxRLbUgSVWaMh7BvG9