### PR TITLE
test(#360): cover devtools/tile diagnostics surfaces left untested by the merge

### DIFF
--- a/packages/dart_pdf_editor/test/budgeted_cache_test.dart
+++ b/packages/dart_pdf_editor/test/budgeted_cache_test.dart
@@ -417,4 +417,51 @@ void main() {
       expect(cache.weight, 300, reason: 'only the per-cache budget applies');
     });
   });
+
+  group('PdfCacheRegistry.snapshot', () {
+    test('reports each registered cache label, count, weight, and budget', () {
+      final registry = PdfCacheRegistry.instance;
+      final images = PdfBudgetedCache<int, _Res>(
+        weigher: (r) => r.weight,
+        maxWeight: 500,
+        clearsUnderMemoryPressure: true,
+        debugLabel: 'images',
+      );
+      final records = PdfBudgetedCache<int, _Res>(
+        maxEntries: 4,
+        clearsUnderMemoryPressure: true,
+        debugLabel: 'records',
+      );
+      addTearDown(() {
+        images.dispose();
+        records.dispose();
+      });
+      images.put(0, _Res(0, weight: 40));
+      images.put(1, _Res(1, weight: 60));
+      records.put(0, _Res(0));
+
+      final rows = {for (final row in registry.snapshot()) row.label: row};
+      expect(rows['images']!.length, 2);
+      expect(rows['images']!.weight, 100);
+      expect(rows['images']!.maxWeight, 500);
+      // An entry-bounded cache has no weight budget: maxWeight is 0.
+      expect(rows['records']!.length, 1);
+      expect(rows['records']!.weight, 0);
+      expect(rows['records']!.maxWeight, 0);
+    });
+
+    test('a disposed cache drops out of the snapshot', () {
+      final registry = PdfCacheRegistry.instance;
+      final cache = PdfBudgetedCache<int, _Res>(
+        weigher: (r) => r.weight,
+        maxWeight: 100,
+        clearsUnderMemoryPressure: true,
+        debugLabel: 'ephemeral',
+      );
+      cache.put(0, _Res(0, weight: 10));
+      expect(registry.snapshot().any((r) => r.label == 'ephemeral'), isTrue);
+      cache.dispose();
+      expect(registry.snapshot().any((r) => r.label == 'ephemeral'), isFalse);
+    });
+  });
 }

--- a/packages/dart_pdf_editor/test/debug_overlays_test.dart
+++ b/packages/dart_pdf_editor/test/debug_overlays_test.dart
@@ -1,0 +1,162 @@
+// The devtools debug-overlay registries. Both are process singletons fed from
+// page-view initState/dispose - which run mid-build, where a synchronous
+// notifyListeners is a build-phase violation for a listening overlay (the
+// crash that motivated the microtask coalescing). These tests pin the
+// mutation logic AND that a burst of mutations coalesces to exactly one
+// deferred notification.
+import 'dart:ui' show Rect;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PdfLivePageRegistry', () {
+    final registry = PdfLivePageRegistry.instance;
+
+    // A singleton: leave it as we found it so tests stay order-independent.
+    tearDown(() {
+      for (final page in registry.pages.toList()) {
+        registry.remove(page);
+      }
+    });
+
+    test('add/remove/contains/length track the live set', () async {
+      expect(registry.contains(3), isFalse);
+      registry.add(3);
+      registry.add(7);
+      expect(registry.contains(3), isTrue);
+      expect(registry.contains(7), isTrue);
+      expect(registry.length, 2);
+      expect(registry.pages, {3, 7});
+
+      registry.remove(3);
+      expect(registry.contains(3), isFalse);
+      expect(registry.length, 1);
+    });
+
+    test('pages is an unmodifiable snapshot', () {
+      registry.add(1);
+      final view = registry.pages;
+      expect(() => view.add(2), throwsUnsupportedError);
+    });
+
+    test('move relabels a slot without changing the count', () {
+      registry.add(4);
+      registry.add(5);
+      registry.move(4, 9);
+      expect(registry.contains(4), isFalse);
+      expect(registry.contains(9), isTrue);
+      expect(registry.contains(5), isTrue);
+      expect(registry.length, 2);
+    });
+
+    test('a burst of mutations coalesces to one deferred notification',
+        () async {
+      var ticks = 0;
+      void listener() => ticks++;
+      registry.addListener(listener);
+      addTearDown(() => registry.removeListener(listener));
+
+      // Synchronous burst (a lazy list inflating a screenful of pages).
+      registry.add(10);
+      registry.add(11);
+      registry.add(12);
+      registry.move(12, 13);
+      // Nothing has fired yet: the notify is deferred past the current stack.
+      expect(ticks, 0, reason: 'notify must not run synchronously (mid-build)');
+
+      await pumpEventQueue();
+      expect(ticks, 1, reason: 'the whole burst coalesces to one tick');
+    });
+
+    test('a no-op mutation schedules no notification', () async {
+      registry.add(20);
+      await pumpEventQueue();
+
+      var ticks = 0;
+      void listener() => ticks++;
+      registry.addListener(listener);
+      addTearDown(() => registry.removeListener(listener));
+
+      registry.add(20); // already present
+      registry.remove(21); // absent
+      registry.move(22, 22); // same slot
+      await pumpEventQueue();
+      expect(ticks, 0);
+    });
+  });
+
+  group('PdfDebugDetailRegions', () {
+    final regions = PdfDebugDetailRegions.instance;
+
+    tearDown(() {
+      for (final page in [0, 1, 2, 3]) {
+        regions.report(page, null);
+      }
+    });
+
+    test('report records and patchFractionOf reads back', () {
+      const rect = Rect.fromLTRB(0.1, 0.2, 0.5, 0.6);
+      expect(regions.patchFractionOf(0), isNull);
+      regions.report(0, rect);
+      expect(regions.patchFractionOf(0), rect);
+    });
+
+    test('reporting null clears the page', () {
+      regions.report(1, const Rect.fromLTRB(0, 0, 1, 1));
+      expect(regions.patchFractionOf(1), isNotNull);
+      regions.report(1, null);
+      expect(regions.patchFractionOf(1), isNull);
+    });
+
+    test('an unchanged report schedules no notification', () async {
+      const rect = Rect.fromLTRB(0, 0, 0.5, 0.5);
+      regions.report(2, rect);
+      await pumpEventQueue();
+
+      var ticks = 0;
+      void listener() => ticks++;
+      regions.addListener(listener);
+      addTearDown(() => regions.removeListener(listener));
+
+      regions.report(2, rect); // identical bounds
+      regions.report(3, null); // clear an already-absent page
+      await pumpEventQueue();
+      expect(ticks, 0);
+    });
+
+    test('a burst of reports coalesces to one deferred notification', () async {
+      var ticks = 0;
+      void listener() => ticks++;
+      regions.addListener(listener);
+      addTearDown(() => regions.removeListener(listener));
+
+      regions.report(0, const Rect.fromLTRB(0, 0, 0.2, 0.2));
+      regions.report(1, const Rect.fromLTRB(0, 0, 0.3, 0.3));
+      regions.report(2, const Rect.fromLTRB(0, 0, 0.4, 0.4));
+      expect(ticks, 0, reason: 'notify must not run synchronously (mid-build)');
+
+      await pumpEventQueue();
+      expect(ticks, 1);
+    });
+  });
+
+  group('pdfDebug flags', () {
+    test('default off', () {
+      expect(pdfDebugPaintDetailBounds.value, isFalse);
+      expect(pdfDebugShowRenderWindow.value, isFalse);
+    });
+
+    test('are ValueNotifiers that notify on change', () {
+      var ticks = 0;
+      void listener() => ticks++;
+      pdfDebugPaintDetailBounds.addListener(listener);
+      addTearDown(() {
+        pdfDebugPaintDetailBounds.removeListener(listener);
+        pdfDebugPaintDetailBounds.value = false;
+      });
+      pdfDebugPaintDetailBounds.value = true;
+      expect(ticks, 1);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_diagnostics_test.dart
+++ b/packages/dart_pdf_editor/test/editing_diagnostics_test.dart
@@ -1,0 +1,65 @@
+// The session diagnostics getters the devtools Session panel reads:
+// revisionCount (undo/redo history length) and sessionBufferBytes (the
+// grow-only buffer that only ever grows within a session - the memory-audit
+// signal). Every edit is an incremental save appended to one buffer, so an
+// edit both grows the buffer and adds a revision; undo/redo moves the cursor
+// without shrinking either.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('PdfEditingController session diagnostics', () {
+    test('a fresh session is one revision sized to the opened bytes', () {
+      SharedPreferences.setMockInitialValues({});
+      final source = buildMultiPagePdf(1);
+      final editing = PdfEditingController(source);
+      addTearDown(editing.dispose);
+
+      expect(editing.revisionCount, 1);
+      expect(editing.sessionBufferBytes, source.length);
+      expect(editing.canUndo, isFalse);
+    });
+
+    test('each edit adds a revision and grows the buffer', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      final buffer0 = editing.sessionBufferBytes;
+
+      editing.placeCheckMark(0, 100, 100);
+      expect(editing.revisionCount, 2);
+      expect(editing.sessionBufferBytes, greaterThan(buffer0),
+          reason: 'the incremental revision appended to the buffer');
+      final buffer1 = editing.sessionBufferBytes;
+
+      editing.placeCheckMark(0, 200, 200);
+      expect(editing.revisionCount, 3);
+      expect(editing.sessionBufferBytes, greaterThan(buffer1));
+
+      // The current revision view is a prefix of the whole grow-only buffer.
+      expect(editing.bytes.length, lessThanOrEqualTo(editing.sessionBufferBytes));
+    });
+
+    test('undo keeps the buffer and revision history intact', () {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+
+      editing.placeCheckMark(0, 100, 100);
+      final revisionsAfterEdit = editing.revisionCount;
+      final bufferAfterEdit = editing.sessionBufferBytes;
+      final currentBytes = editing.bytes.length;
+
+      editing.undo();
+      // Undo rewinds the cursor - so "save to disk" shrinks back...
+      expect(editing.bytes.length, lessThan(currentBytes));
+      // ...but the history and grow-only buffer are unchanged (redo works).
+      expect(editing.revisionCount, revisionsAfterEdit);
+      expect(editing.sessionBufferBytes, bufferAfterEdit);
+      expect(editing.canRedo, isTrue);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/performance_policy_test.dart
+++ b/packages/dart_pdf_editor/test/performance_policy_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
@@ -146,5 +147,31 @@ void main() {
     expect(controller.tuning.previewWindow, 2);
     expect(controller.tuning.vectorFirstPreviews, isTrue);
     expect(controller.beginWorkerGeneration(), 1);
+  });
+
+  group('pdfDefaultTileStoreDetail (issue #314 rollout)', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test('on for desktop platforms', () {
+      for (final platform in [
+        TargetPlatform.macOS,
+        TargetPlatform.windows,
+        TargetPlatform.linux,
+      ]) {
+        debugDefaultTargetPlatformOverride = platform;
+        expect(pdfDefaultTileStoreDetail(), isTrue, reason: '$platform');
+      }
+    });
+
+    test('off for mobile platforms pending their own validation', () {
+      for (final platform in [
+        TargetPlatform.iOS,
+        TargetPlatform.android,
+        TargetPlatform.fuchsia,
+      ]) {
+        debugDefaultTargetPlatformOverride = platform;
+        expect(pdfDefaultTileStoreDetail(), isFalse, reason: '$platform');
+      }
+    });
   });
 }

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -158,6 +158,8 @@ void main() {
         );
         expect(view2.complete, isTrue);
         expect(view2.placements.length, 16);
+        // Exact-bucket placements are never flagged as fallbacks.
+        expect(view2.placements.any((p) => p.isFallback), isFalse);
         expect(raster.calls.length, calls); // fully cached, nothing scheduled
         store.dispose();
       });
@@ -225,8 +227,10 @@ void main() {
         expect(view.complete, isFalse);
         expect(view.placements, isNotEmpty,
             reason: 'coarser bucket should supply a fallback');
-        // Every fallback placement draws from a coarse-bucket image (32² here).
+        // Every fallback placement draws from a coarse-bucket image (32² here)
+        // and is flagged as a fallback (what the debug overlay colors orange).
         expect(view.placements.every((p) => p.image.width == 32), isTrue);
+        expect(view.placements.every((p) => p.isFallback), isTrue);
         store.dispose();
       });
     });
@@ -645,6 +649,66 @@ void main() {
         expect(store.tileCount, 10);
         store.dispose();
       });
+    });
+  });
+
+  group('PdfTileStore diagnostics', () {
+    testWidgets('debugTileFractionsForPage reports cached tiles as fractions',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        const pageSize = Size(32, 32); // 2×2 grid at span 16
+
+        expect(store.debugTileFractionsForPage(0), isEmpty);
+        store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        await raster.flush();
+
+        final fractions = store.debugTileFractionsForPage(0);
+        expect(fractions.length, 4);
+        // The 4 tiles tile the unit square in quarters (span 16 of 32).
+        expect(
+          fractions.map((f) => f.fraction).toSet(),
+          {
+            const Rect.fromLTRB(0, 0, 0.5, 0.5),
+            const Rect.fromLTRB(0.5, 0, 1, 0.5),
+            const Rect.fromLTRB(0, 0.5, 0.5, 1),
+            const Rect.fromLTRB(0.5, 0.5, 1, 1),
+          },
+        );
+        expect(fractions.every((f) => f.rung == 0), isTrue);
+
+        // Scoped by page, and a pure peek (no LRU touch → no reschedule).
+        expect(store.debugTileFractionsForPage(1), isEmpty);
+        final view = store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+          rasterize: raster.call,
+        );
+        expect(view.complete, isTrue, reason: 'peek did not evict any tile');
+        store.dispose();
+      });
+    });
+
+    test('instanceOrNull is null until instance is first touched', () {
+      // Guarded by whether another test already created the shared store; if
+      // so, instanceOrNull just mirrors instance. Assert the invariant that
+      // holds either way: once instance exists, instanceOrNull returns it.
+      final shared = PdfTileStore.instance;
+      expect(PdfTileStore.instanceOrNull, same(shared));
     });
   });
 }


### PR DESCRIPTION
Follow-up to #360, which merged the batched tile pyramid, F12 devtools, and the coordinated cache ceiling. That PR's tests covered the core mechanics (batching, the veto, the ceiling, the panel, options persistence) but left several new public/diagnostic surfaces untested — including the registries whose microtask coalescing fixed a build-phase crash. This adds that coverage. Test-only; no `lib/` changes.

## What's now covered

- **`debug_overlays_test.dart`** (new) — `PdfLivePageRegistry` and `PdfDebugDetailRegions`: add/remove/move, `contains`/`length`/unmodifiable `pages`, `report`/`patchFractionOf` + null-clear, no-op-no-notify, and the **microtask coalescing** — a synchronous burst of mutations (a lazy list inflating a screenful of pages mid-build) defers to exactly one notification, which is the fix for the `setState() called during build` cascade. Plus the `pdfDebug*` flags default-off and notify-on-change.
- **`tile_store_test.dart`** — `debugTileFractionsForPage` (page-scoped, correct unit-square fractions, pure peek that doesn't evict), `instanceOrNull`, and `PdfTilePlacement.isFallback` asserted on both the coarser-bucket fallback path and the exact-bucket path (the flag that colors the debug overlay's borders green vs orange).
- **`performance_policy_test.dart`** — `pdfDefaultTileStoreDetail()` returns true only for desktop (macOS/Windows/Linux), false for mobile, via `debugDefaultTargetPlatformOverride`. Pins the rollout decision from #360.
- **`budgeted_cache_test.dart`** — `PdfCacheRegistry.snapshot()` rows (label/entries/weight/budget; an entry-bounded cache reports 0 budget) and that a disposed cache drops out.
- **`editing_diagnostics_test.dart`** (new) — the Session-panel getters `revisionCount` and `sessionBufferBytes`: a fresh session is one revision sized to the opened bytes; each edit adds a revision and grows the buffer; undo rewinds the current-bytes view without shrinking the grow-only buffer or history.

## Verification

All 72 tests across the touched files pass; `dart analyze` clean.

Not added (deliberately): an end-to-end page-view test of the vector-only tiling path — forcing vector-first scene adoption needs a live worker + deep-zoom conditions, making it brittle; the veto's actual logic is covered at the store level (`canRasterize vetoes tiles per region and heals when lifted`) and the classic-page tile path is covered by `tile_store_page_view_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DV1tAxRLbUgSVWaMh7BvG9