### PR TITLE
Draggable, dockable panels: any edge, side-by-side or tab groups, saved layout

### DIFF
--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -65,7 +65,7 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
       width: 360,
       minWidth: 300,
       maxWidth: 560,
-      side: PdfSidebarSide.right,
+      dock: PdfPanelDock.right,
       resizable: true,
       bottomSheet: false,
       gripKey: const ValueKey('devtools-resize-grip'),

--- a/doc/dev-log/2026-07-18-draggable-dockable-panels.md
+++ b/doc/dev-log/2026-07-18-draggable-dockable-panels.md
@@ -1,0 +1,78 @@
+# Draggable, dockable side panels (left/right/top/bottom) with saved layout
+
+The editor's side panels (Pages/thumbnails, Search results, Bookmarks,
+Annotations, Properties) could only sit left or right, and only implicitly -
+placement was decided by which hard-coded list (`leadingPanels` /
+`trailingPanels`) `pdf_editor_view.dart` dropped each panel into. This session
+made the panels **draggable to any of the four edges** and **persists the
+layout** per panel.
+
+## Model
+
+- `PdfPanelDock { left, right, top, bottom }` (`editing/editing_panel.dart`) is
+  the new placement concept, with `isHorizontal` (left/right = fixed-width
+  columns; top/bottom = fixed-height strips) and `gripSide` (maps a horizontal
+  dock to the existing `PdfSidebarSide` the resize grip speaks). `PdfSidebarSide
+  { left, right }` stays - it's still the grip's / comparison navigator's
+  horizontal-only orientation.
+- `PdfDockablePanel { thumbnails, search, bookmarks, annotations, properties }`
+  is both the drag payload and the identity a shell maps to a persisted dock.
+  Each value carries a `label` + `icon` for the drag feedback chip.
+
+## The shared frame did the heavy lifting
+
+All five panels already funnel through one `PdfSidebarPanelFrame`
+(`editing/editing_panel.dart`), so most of the work landed there:
+
+- Its `side` param became `dock`. Horizontal docks render as before
+  (fixed-width column + `PdfSidebarResizeGrip` on the inner edge). Vertical
+  docks render as a fixed-height strip with a new internal
+  `_PdfSidebarVerticalResizeGrip` on the inner edge. **`width/minWidth/maxWidth`
+  now mean the cross-axis extent** - the column width for left/right, the strip
+  height for top/bottom - and the existing per-panel `...Width` prefs are reused
+  as that extent (a left panel dragged to top carries its width over as height).
+- `PdfSidebarPanelGeometry.moveHandle()` is the new counterpart to
+  `closeButton()`: a `PdfSidebarMoveHandle` (a `Draggable<PdfDockablePanel>`)
+  that each panel renders next to its close button. It renders **nothing** when
+  no `PdfPanelDragScope` is in scope, so the same panels stay non-draggable in
+  contexts that don't wire redocking (standalone use, the reader shell).
+
+## Shell wiring
+
+- `PdfShellPanelLayout` (`shell_chrome.dart`) is now stateful and gained
+  `topPanels` / `bottomPanels` (full-width strips above/below the viewer row)
+  and an `onPanelDock` callback. When `onPanelDock` is wired it provides a
+  `PdfPanelDragScope` around the tree and, **only while a drag is underway**,
+  overlays four edge `DragTarget` drop zones (`_PanelDropZones` /`_DropTarget`,
+  keys `pdf-shell-dropzone-{left,right,top,bottom}`). Top/bottom bands are inset
+  horizontally so they never overlap the left/right bands at the corners.
+- `pdf_editor_view.dart` reads each panel's persisted dock, pairs every visible
+  docked panel with its dock, and `dockedPanels(dock)` filters them into the
+  four groups (canonical order = thumbnails, search, bookmarks, annotations,
+  properties, so the default left/right layout is byte-identical to before).
+  `_setPanelDock` writes the pref on drop; the pref notifies and the panel
+  re-routes to its new edge on the next build.
+
+## Persistence
+
+Five `PdfPanelDock` prefs in `editing_preferences.dart`
+(`thumbnailSidebarDock`, `searchPanelDock`, `bookmarkSidebarDock`,
+`annotationSidebarDock`, `propertiesPanelDock`), persisted by enum `.name`
+(`_readDock`/`_setDock`), defaults reproducing the built-in layout
+(thumbnails/search/bookmarks left, annotations/properties right).
+
+## Notes / gotchas
+
+- ValueKey-ed panels moving between the leading/trailing/top/bottom lists
+  **remount** (ValueKeys only match within one parent), which is the safe path -
+  the same reason the docked/sheet variants already carry distinct keys (the
+  thumbnail tiles' Tooltip `OverlayPortal` must not reactivate mid-layout).
+- The reader shell (`pdf_reader.dart`) is left as-is: it passes no
+  `onPanelDock`, so its thumbnail/bookmark panels keep their default docks and
+  show no move handle. Wiring it would be a small follow-up.
+- Tests: `test/panel_dock_test.dart` covers dock defaults + persistence,
+  `PdfPanelDock.isHorizontal`, the vertical-strip frame layout, and an
+  end-to-end drag of the annotation panel's handle onto the top drop zone
+  (asserting the pref flips to `top`). Existing `editing_panel_frame_test.dart`
+  / `editing_panels_test.dart` / `benchmark_panel_frame_test.dart` were updated
+  for the `side` -> `dock` rename.

--- a/doc/dev-log/2026-07-18-draggable-dockable-panels.md
+++ b/doc/dev-log/2026-07-18-draggable-dockable-panels.md
@@ -76,3 +76,38 @@ Five `PdfPanelDock` prefs in `editing_preferences.dart`
   (asserting the pref flips to `top`). Existing `editing_panel_frame_test.dart`
   / `editing_panels_test.dart` / `benchmark_panel_frame_test.dart` were updated
   for the `side` -> `dock` rename.
+
+## Tab groups (IDE-style)
+
+Follow-up: panels sharing an edge can be **side-by-side** (the default) or
+combined into a **tab group** (one visible at a time, tabs to switch),
+VS Code / JetBrains style.
+
+- Model: each panel carries a persisted **tab-group id** (`panelGroup`,
+  `editing_preferences.dart`, default = its own enum index → all standalone).
+  Panels sharing both a dock *and* a group id render as one tabbed panel; a
+  panel alone in its group is standalone. Grouping key = (dock, group id).
+- Interaction (reuses the drag infra): dropping a panel's handle/tab onto an
+  **edge zone** docks it standalone there (and resets its group id → splits it
+  out); dropping it onto **another panel's body** joins that panel's group
+  (tabs them). `PdfPanelTabDropRegion` (`shell_chrome.dart`) wraps every dock
+  child as the "drop onto me to tab" target; it rejects a drag of one of its
+  own members (no self-join). Edge bands were shrunk (≈10%, capped 56–96 px)
+  so an already-docked panel keeps a reachable inner tab-target past the band.
+- `PdfPanelTabGroup` (`shell_chrome.dart`) hosts the tabbed panels: one shared
+  `PdfSidebarPanelFrame` (extent + grip, persisted per dock via
+  `panelGroupWidth`) + a scrollable tab strip (`_PanelTab` — each an
+  independently draggable `Draggable<PdfDockablePanel>` with a close ×) over an
+  `IndexedStack` (all bodies stay mounted, so tab state survives switching).
+  Tab bodies are the panels built in **bottom-sheet content mode**
+  (`bottomSheet: true`) — that already renders them chromeless (no frame, no
+  per-panel close/move), which is exactly a bare tab body; the group supplies
+  the frame + close/move affordances.
+- `pdf_editor_view.dart`'s `dockedPanels(dock)` now partitions the dock's
+  visible panels by group id (preserving first-appearance order) and emits a
+  standalone panel or a `PdfPanelTabGroup`, each wrapped in a
+  `PdfPanelTabDropRegion`. `_joinPanel` sets dock+group on a drop-to-tab;
+  `_setPanelDock` (edge drop) sets dock and resets the group to standalone.
+- Tests in `panel_dock_test.dart`: group defaults/persistence, drag-panel-onto-
+  panel → tabbed, drag-tab-to-edge → split, and tab selection. The tab strip is
+  a horizontal scroller, so tests `ensureVisible` a tab before hitting it.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
@@ -17,7 +17,7 @@ class PdfBookmarkSidebar extends StatefulWidget {
     required this.controller,
     required this.viewerController,
     this.editable = true,
-    this.side = PdfSidebarSide.left,
+    this.dock = PdfPanelDock.left,
     this.bottomSheet = false,
     this.width = 260,
     this.minWidth = 200,
@@ -29,7 +29,7 @@ class PdfBookmarkSidebar extends StatefulWidget {
   final PdfEditingController controller;
   final PdfViewerController viewerController;
   final bool editable;
-  final PdfSidebarSide side;
+  final PdfPanelDock dock;
   final bool bottomSheet;
   final double width;
   final double minWidth;
@@ -136,6 +136,9 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
     final closeButton = geometry.closeButton(
       key: const ValueKey('pdf-bookmark-panel-close'),
     );
+    final moveHandle = geometry.moveHandle(
+      key: const ValueKey('pdf-bookmark-panel-move'),
+    );
     final showTitle = !widget.bottomSheet;
     return Padding(
       padding: EdgeInsets.fromLTRB(
@@ -157,6 +160,7 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
             icon: const Icon(Icons.add),
             onPressed: () => _addBookmark(context),
           ),
+        if (moveHandle != null) moveHandle,
         if (closeButton != null) closeButton,
       ]),
     );
@@ -349,7 +353,8 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
       persistedWidth: controller.preferences.bookmarkSidebarWidth,
       onPersistWidth: (width) =>
           controller.preferences.bookmarkSidebarWidth = width,
-      side: widget.side,
+      dock: widget.dock,
+      panel: PdfDockablePanel.bookmarks,
       resizable: widget.resizable,
       bottomSheet: widget.bottomSheet,
       gripKey: const ValueKey('pdf-bookmark-resize-grip'),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
@@ -147,7 +147,7 @@ class PdfSidebarMoveHandle extends StatelessWidget {
       onDragStarted: scope.onDragStarted,
       onDragEnd: (_) => scope.onDragEnded(),
       onDraggableCanceled: (_, __) => scope.onDragEnded(),
-      feedback: _MoveFeedback(panel: panel),
+      feedback: PdfPanelDragFeedback(panel: panel),
       // keep the handle in place under the moving feedback chip
       childWhenDragging: Opacity(opacity: 0.3, child: handle),
       child: handle,
@@ -155,9 +155,10 @@ class PdfSidebarMoveHandle extends StatelessWidget {
   }
 }
 
-/// The chip that follows the pointer while a panel is being redocked.
-class _MoveFeedback extends StatelessWidget {
-  const _MoveFeedback({required this.panel});
+/// The chip that follows the pointer while a panel is being redocked or
+/// dragged onto another panel to form a tab group.
+class PdfPanelDragFeedback extends StatelessWidget {
+  const PdfPanelDragFeedback({super.key, required this.panel});
 
   final PdfDockablePanel panel;
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
@@ -4,9 +4,53 @@ import 'package:flutter/material.dart';
 
 import '../scrollbar.dart';
 
-/// Which side of the viewer a sidebar panel is docked on. Its resize
-/// grip rides the opposite (inner) edge - the one facing the viewer.
+/// Which side of the viewer a sidebar panel's resize grip belongs to. Its
+/// grip rides the opposite (inner) edge - the one facing the viewer. Kept
+/// as the horizontal-only orientation the grip and the comparison navigator
+/// still speak; new placement code uses [PdfPanelDock].
 enum PdfSidebarSide { left, right }
+
+/// Which edge of the content area a dockable panel is attached to.
+///
+/// Left/right docks lay the panel out as a fixed-width column beside the
+/// viewer; top/bottom docks lay it out as a fixed-height strip spanning the
+/// content width, above or below the viewer. The user drags a panel's move
+/// handle onto another edge to redock it, and the shell persists the choice.
+enum PdfPanelDock {
+  left,
+  right,
+  top,
+  bottom;
+
+  /// Left/right docks are vertical columns sized by their width; top/bottom
+  /// docks are horizontal strips sized by their height.
+  bool get isHorizontal =>
+      this == PdfPanelDock.left || this == PdfPanelDock.right;
+
+  /// The horizontal orientation the resize grip speaks, for the left/right
+  /// docks. Meaningless for the vertical docks (which use a vertical grip).
+  PdfSidebarSide get gripSide =>
+      this == PdfPanelDock.left ? PdfSidebarSide.left : PdfSidebarSide.right;
+}
+
+/// The panels a shell can rearrange between docks. Doubles as the payload
+/// dragged from a move handle onto a drop zone and the identity a shell maps
+/// to the panel's persisted [PdfPanelDock].
+enum PdfDockablePanel {
+  thumbnails('Pages', Icons.grid_view),
+  search('Search results', Icons.manage_search),
+  bookmarks('Bookmarks', Icons.bookmarks_outlined),
+  annotations('Annotations', Icons.list_alt),
+  properties('Properties', Icons.tune);
+
+  const PdfDockablePanel(this.label, this.icon);
+
+  /// A human-readable name shown on the drag feedback chip.
+  final String label;
+
+  /// The panel's glyph, shown on the drag feedback chip.
+  final IconData icon;
+}
 
 /// Whether panel row controls should be revealed by mouse hover.
 ///
@@ -22,6 +66,32 @@ bool pdfPanelControlsRevealOnHover() => switch (defaultTargetPlatform) {
       TargetPlatform.iOS =>
         false,
     };
+
+/// Ambient wiring that lets a docked panel's move handle drive the shell's
+/// drag-to-redock affordance. [PdfShellPanelLayout] provides it around the
+/// panels; a panel's [PdfSidebarPanelGeometry.moveHandle] reads it. Absent
+/// when a shell wires no redocking - then panels render no move handle.
+class PdfPanelDragScope extends InheritedWidget {
+  const PdfPanelDragScope({
+    super.key,
+    required this.onDragStarted,
+    required this.onDragEnded,
+    required super.child,
+  });
+
+  /// A panel's move handle picked up a drag - the shell reveals its drop
+  /// zones.
+  final VoidCallback onDragStarted;
+
+  /// The drag ended (dropped or cancelled) - the shell hides its drop zones.
+  final VoidCallback onDragEnded;
+
+  static PdfPanelDragScope? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<PdfPanelDragScope>();
+
+  @override
+  bool updateShouldNotify(PdfPanelDragScope oldWidget) => false;
+}
 
 /// A compact close (×) button for a docked sidebar panel's header - the
 /// desktop counterpart of the bottom sheet's close button (which the
@@ -46,10 +116,87 @@ class PdfSidebarCloseButton extends StatelessWidget {
       );
 }
 
+/// The grab handle a docked panel shows in its header: drag it onto another
+/// edge's drop zone to redock the panel. Renders nothing when no
+/// [PdfPanelDragScope] is in scope (the shell wires no redocking).
+class PdfSidebarMoveHandle extends StatelessWidget {
+  const PdfSidebarMoveHandle({
+    super.key,
+    required this.panel,
+  });
+
+  /// The panel this handle moves - the drag payload a drop zone receives.
+  final PdfDockablePanel panel;
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = PdfPanelDragScope.maybeOf(context);
+    if (scope == null) return const SizedBox.shrink();
+    final scheme = Theme.of(context).colorScheme;
+    final handle = MouseRegion(
+      cursor: SystemMouseCursors.move,
+      child: Tooltip(
+        message: 'Drag to move panel',
+        child: Icon(Icons.drag_indicator,
+            size: 18, color: scheme.onSurfaceVariant),
+      ),
+    );
+    return Draggable<PdfDockablePanel>(
+      data: panel,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      onDragStarted: scope.onDragStarted,
+      onDragEnd: (_) => scope.onDragEnded(),
+      onDraggableCanceled: (_, __) => scope.onDragEnded(),
+      feedback: _MoveFeedback(panel: panel),
+      // keep the handle in place under the moving feedback chip
+      childWhenDragging: Opacity(opacity: 0.3, child: handle),
+      child: handle,
+    );
+  }
+}
+
+/// The chip that follows the pointer while a panel is being redocked.
+class _MoveFeedback extends StatelessWidget {
+  const _MoveFeedback({required this.panel});
+
+  final PdfDockablePanel panel;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: scheme.primaryContainer,
+          borderRadius: BorderRadius.circular(8),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.2),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(mainAxisSize: MainAxisSize.min, children: [
+          Icon(panel.icon, size: 18, color: scheme.onPrimaryContainer),
+          const SizedBox(width: 8),
+          Text(panel.label,
+              style: TextStyle(
+                  color: scheme.onPrimaryContainer,
+                  fontWeight: FontWeight.w500)),
+        ]),
+      ),
+    );
+  }
+}
+
 /// The draggable divider on a sidebar's inner edge: an invisible 8px
 /// hit strip with a hairline down the middle that thickens and tints on
 /// hover and while dragging. Reports width deltas already signed toward
-/// growth, whichever side the panel is docked on.
+/// growth, whichever side the panel is docked on. Used by the left/right
+/// docks and by the comparison navigator.
 class PdfSidebarResizeGrip extends StatefulWidget {
   const PdfSidebarResizeGrip({
     super.key,
@@ -69,7 +216,7 @@ class PdfSidebarResizeGrip extends StatefulWidget {
   /// The drag ended - time to persist the new width.
   final VoidCallback onResizeEnd;
 
-  /// The grip's hit-test width.
+  /// The grip's hit-test thickness.
   static const double width = 8;
 
   @override
@@ -118,34 +265,118 @@ class _PdfSidebarResizeGripState extends State<PdfSidebarResizeGrip> {
   }
 }
 
+/// The vertical counterpart of [PdfSidebarResizeGrip], for the top/bottom
+/// docks: an 8px horizontal hit strip whose hairline thickens on hover and
+/// drag. Reports height deltas already signed toward growth.
+class _PdfSidebarVerticalResizeGrip extends StatefulWidget {
+  const _PdfSidebarVerticalResizeGrip({
+    super.key,
+    required this.top,
+    required this.onHeightDelta,
+    required this.onResizeEnd,
+  });
+
+  /// Whether the panel is docked at the top (grip rides its bottom edge and
+  /// dragging down grows it) rather than the bottom.
+  final bool top;
+
+  final ValueChanged<double> onHeightDelta;
+  final VoidCallback onResizeEnd;
+
+  @override
+  State<_PdfSidebarVerticalResizeGrip> createState() =>
+      _PdfSidebarVerticalResizeGripState();
+}
+
+class _PdfSidebarVerticalResizeGripState
+    extends State<_PdfSidebarVerticalResizeGrip> {
+  bool _hovered = false;
+  bool _dragging = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final active = _hovered || _dragging;
+    return MouseRegion(
+      cursor: SystemMouseCursors.resizeRow,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onVerticalDragStart: (_) => setState(() => _dragging = true),
+        onVerticalDragUpdate: (details) => widget
+            .onHeightDelta(widget.top ? details.delta.dy : -details.delta.dy),
+        onVerticalDragEnd: (_) {
+          setState(() => _dragging = false);
+          widget.onResizeEnd();
+        },
+        onVerticalDragCancel: () {
+          setState(() => _dragging = false);
+          widget.onResizeEnd();
+        },
+        child: SizedBox(
+          height: PdfSidebarResizeGrip.width,
+          child: Center(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 120),
+              height: active ? 3 : 1,
+              color: active ? scheme.primary : scheme.outlineVariant,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Geometry and shared chrome supplied to a sidebar panel's content builder.
 class PdfSidebarPanelGeometry {
   const PdfSidebarPanelGeometry._({
     required this.width,
+    required this.dock,
     required this.bottomSheet,
     required this.showGrip,
     required this.gripOnLeft,
     required this.onClose,
+    required this.panel,
   });
 
+  /// The panel's fixed extent along its dock's cross axis - the column
+  /// width for left/right docks, the strip height for top/bottom docks.
   final double width;
+
+  /// Which edge the panel is docked on.
+  final PdfPanelDock dock;
+
   final bool bottomSheet;
   final bool showGrip;
   final bool gripOnLeft;
   final VoidCallback? onClose;
 
-  bool get gripOnRight => showGrip && !gripOnLeft;
+  /// The panel's identity, for the move handle's drag payload. Null when
+  /// the panel is not registered as dockable.
+  final PdfDockablePanel? panel;
+
+  bool get gripOnRight => showGrip && !gripOnLeft && dock.isHorizontal;
   bool get scrollbarSharesGripEdge => gripOnRight;
   double get scrollbarInset =>
       scrollbarSharesGripEdge ? PdfSidebarResizeGrip.width : 0;
   double get scrollbarClearance => PdfScrollbar.hitExtent + scrollbarInset;
-  double get contentStartInset => gripOnLeft ? PdfSidebarResizeGrip.width : 0;
+  double get contentStartInset =>
+      gripOnLeft && dock.isHorizontal ? PdfSidebarResizeGrip.width : 0;
   double get contentEndInset => gripOnRight ? PdfSidebarResizeGrip.width : 0;
 
   /// The docked close button; bottom sheets supply their own sheet chrome.
   Widget? closeButton({Key? key}) => bottomSheet || onClose == null
       ? null
       : PdfSidebarCloseButton(key: key, onPressed: onClose!);
+
+  /// The move (drag-to-redock) handle; null unless the panel is dockable
+  /// and docked (bottom sheets carry no handle). Renders nothing further
+  /// when no [PdfPanelDragScope] is in scope.
+  Widget? moveHandle({Key? key}) => bottomSheet || panel == null
+      ? null
+      : PdfSidebarMoveHandle(key: key, panel: panel!);
 
   /// Places the package scrollbar at the shared dock-aware inset.
   Widget withScrollbar({
@@ -171,9 +402,13 @@ typedef PdfSidebarPanelContentBuilder = Widget Function(
 
 /// Shared docked/bottom-sheet frame for sidebar panels.
 ///
-/// Owns drag width, clamping, one-shot persistence, grip placement, dock
+/// Owns drag extent, clamping, one-shot persistence, grip placement, dock
 /// insets, close policy, and scrollbar geometry. Panel-specific data, lists,
 /// and controllers remain inside [builder].
+///
+/// [width]/[minWidth]/[maxWidth] size the panel along its dock's cross axis:
+/// the column width for the left/right docks, the strip height for the
+/// top/bottom docks.
 class PdfSidebarPanelFrame extends StatefulWidget {
   const PdfSidebarPanelFrame({
     super.key,
@@ -181,10 +416,11 @@ class PdfSidebarPanelFrame extends StatefulWidget {
     required this.width,
     required this.minWidth,
     required this.maxWidth,
-    required this.side,
+    required this.dock,
     required this.resizable,
     required this.bottomSheet,
     required this.gripKey,
+    this.panel,
     this.persistedWidth,
     this.onPersistWidth,
     this.onClose,
@@ -196,7 +432,15 @@ class PdfSidebarPanelFrame extends StatefulWidget {
   final double maxWidth;
   final double? persistedWidth;
   final ValueChanged<double>? onPersistWidth;
-  final PdfSidebarSide side;
+
+  /// Which edge the panel docks on - decides column-vs-strip layout and the
+  /// grip orientation.
+  final PdfPanelDock dock;
+
+  /// The panel's identity, enabling the move (drag-to-redock) handle when a
+  /// [PdfPanelDragScope] is in scope. Null keeps the panel non-draggable.
+  final PdfDockablePanel? panel;
+
   final bool resizable;
   final bool bottomSheet;
   final Key gripKey;
@@ -243,29 +487,55 @@ class _PdfSidebarPanelFrameState extends State<PdfSidebarPanelFrame> {
   @override
   Widget build(BuildContext context) {
     final showGrip = widget.resizable && !widget.bottomSheet;
+    final horizontal = widget.dock.isHorizontal;
     final geometry = PdfSidebarPanelGeometry._(
       width: _width,
+      dock: widget.dock,
       bottomSheet: widget.bottomSheet,
       showGrip: showGrip,
-      gripOnLeft: showGrip && widget.side == PdfSidebarSide.right,
+      gripOnLeft: showGrip && widget.dock == PdfPanelDock.right,
       onClose: widget.onClose,
+      panel: widget.panel,
     );
     final content = widget.builder(context, geometry);
     if (widget.bottomSheet) return content;
+    if (horizontal) {
+      return SizedBox(
+        width: geometry.width,
+        child: Stack(children: [
+          Positioned.fill(child: content),
+          if (showGrip)
+            Positioned(
+              top: 0,
+              bottom: 0,
+              left: geometry.gripOnLeft ? 0 : null,
+              right: geometry.gripOnRight ? 0 : null,
+              child: PdfSidebarResizeGrip(
+                key: widget.gripKey,
+                side: widget.dock.gripSide,
+                onWidthDelta: _resize,
+                onResizeEnd: _endResize,
+              ),
+            ),
+        ]),
+      );
+    }
+    // top/bottom dock: a fixed-height strip; the grip rides the inner edge.
+    final atTop = widget.dock == PdfPanelDock.top;
     return SizedBox(
-      width: geometry.width,
+      height: geometry.width,
       child: Stack(children: [
         Positioned.fill(child: content),
         if (showGrip)
           Positioned(
-            top: 0,
-            bottom: 0,
-            left: geometry.gripOnLeft ? 0 : null,
-            right: geometry.gripOnRight ? 0 : null,
-            child: PdfSidebarResizeGrip(
+            left: 0,
+            right: 0,
+            top: atTop ? null : 0,
+            bottom: atTop ? 0 : null,
+            child: _PdfSidebarVerticalResizeGrip(
               key: widget.gripKey,
-              side: widget.side,
-              onWidthDelta: _resize,
+              top: atTop,
+              onHeightDelta: _resize,
               onResizeEnd: _endResize,
             ),
           ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -10,6 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../viewport.dart';
 import 'editing_color_picker.dart' show PdfColorFormat;
+import 'editing_panel.dart' show PdfPanelDock;
 import 'line_style.dart';
 import 'editing_measure.dart';
 import 'editing_signature.dart';
@@ -91,6 +92,14 @@ class PdfEditingPreferences extends ChangeNotifier {
   double? _annotationSidebarWidth;
   double? _propertiesPanelWidth;
   double? _searchPanelWidth;
+  // Which edge each dockable panel is attached to. Defaults reproduce the
+  // built-in layout (thumbnails/search/bookmarks left, annotations/
+  // properties right); the user drags a panel's move handle to redock it.
+  PdfPanelDock _thumbnailSidebarDock = PdfPanelDock.left;
+  PdfPanelDock _searchPanelDock = PdfPanelDock.left;
+  PdfPanelDock _bookmarkSidebarDock = PdfPanelDock.left;
+  PdfPanelDock _annotationSidebarDock = PdfPanelDock.right;
+  PdfPanelDock _propertiesPanelDock = PdfPanelDock.right;
   Color? _textFillColor;
   Color? _textBorderColor;
   Color? _shapeFillColor;
@@ -246,6 +255,15 @@ class PdfEditingPreferences extends ChangeNotifier {
               _propertiesPanelWidth;
       _searchPanelWidth =
           store.getDouble('${_prefix}searchPanelWidth') ?? _searchPanelWidth;
+      _thumbnailSidebarDock =
+          _readDock(store, 'thumbnailSidebarDock', _thumbnailSidebarDock);
+      _searchPanelDock = _readDock(store, 'searchPanelDock', _searchPanelDock);
+      _bookmarkSidebarDock =
+          _readDock(store, 'bookmarkSidebarDock', _bookmarkSidebarDock);
+      _annotationSidebarDock =
+          _readDock(store, 'annotationSidebarDock', _annotationSidebarDock);
+      _propertiesPanelDock =
+          _readDock(store, 'propertiesPanelDock', _propertiesPanelDock);
       final textFill = store.getInt('${_prefix}textFillColor');
       if (textFill != null) _textFillColor = Color(textFill);
       final textBorder = store.getInt('${_prefix}textBorderColor');
@@ -1072,6 +1090,62 @@ class PdfEditingPreferences extends ChangeNotifier {
         ? s.remove('${_prefix}searchPanelWidth')
         : s.setDouble('${_prefix}searchPanelWidth', value));
     notifyListeners();
+  }
+
+  PdfPanelDock _readDock(
+          SharedPreferences store, String key, PdfPanelDock fallback) =>
+      PdfPanelDock.values.asNameMap()[store.getString('$_prefix$key')] ??
+      fallback;
+
+  void _setDock(String key, PdfPanelDock value) {
+    _write((s) => s.setString('$_prefix$key', value.name));
+    notifyListeners();
+  }
+
+  /// Which edge the page-thumbnail panel is docked on. Persisted so a
+  /// dragged layout survives reopening the app.
+  PdfPanelDock get thumbnailSidebarDock => _thumbnailSidebarDock;
+
+  set thumbnailSidebarDock(PdfPanelDock value) {
+    if (value == _thumbnailSidebarDock) return;
+    _thumbnailSidebarDock = value;
+    _setDock('thumbnailSidebarDock', value);
+  }
+
+  /// Which edge the search-results panel is docked on. Persisted.
+  PdfPanelDock get searchPanelDock => _searchPanelDock;
+
+  set searchPanelDock(PdfPanelDock value) {
+    if (value == _searchPanelDock) return;
+    _searchPanelDock = value;
+    _setDock('searchPanelDock', value);
+  }
+
+  /// Which edge the bookmarks/outline panel is docked on. Persisted.
+  PdfPanelDock get bookmarkSidebarDock => _bookmarkSidebarDock;
+
+  set bookmarkSidebarDock(PdfPanelDock value) {
+    if (value == _bookmarkSidebarDock) return;
+    _bookmarkSidebarDock = value;
+    _setDock('bookmarkSidebarDock', value);
+  }
+
+  /// Which edge the annotation-list panel is docked on. Persisted.
+  PdfPanelDock get annotationSidebarDock => _annotationSidebarDock;
+
+  set annotationSidebarDock(PdfPanelDock value) {
+    if (value == _annotationSidebarDock) return;
+    _annotationSidebarDock = value;
+    _setDock('annotationSidebarDock', value);
+  }
+
+  /// Which edge the annotation-properties panel is docked on. Persisted.
+  PdfPanelDock get propertiesPanelDock => _propertiesPanelDock;
+
+  set propertiesPanelDock(PdfPanelDock value) {
+    if (value == _propertiesPanelDock) return;
+    _propertiesPanelDock = value;
+    _setDock('propertiesPanelDock', value);
   }
 
   /// Whether document search matches case (see `PdfSearchOptions.matchCase`).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -10,7 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../viewport.dart';
 import 'editing_color_picker.dart' show PdfColorFormat;
-import 'editing_panel.dart' show PdfPanelDock;
+import 'editing_panel.dart' show PdfDockablePanel, PdfPanelDock;
 import 'line_style.dart';
 import 'editing_measure.dart';
 import 'editing_signature.dart';
@@ -100,6 +100,16 @@ class PdfEditingPreferences extends ChangeNotifier {
   PdfPanelDock _bookmarkSidebarDock = PdfPanelDock.left;
   PdfPanelDock _annotationSidebarDock = PdfPanelDock.right;
   PdfPanelDock _propertiesPanelDock = PdfPanelDock.right;
+  // Tab-group membership: panels sharing the same dock AND the same group id
+  // render as one tabbed panel; a panel alone in its group is a standalone
+  // side-by-side panel. The default id is each panel's own enum index, so
+  // every panel starts standalone (the built-in side-by-side layout).
+  final Map<PdfDockablePanel, int> _panelGroups = {
+    for (final p in PdfDockablePanel.values) p: p.index,
+  };
+  // The dragged extent of a dock's tab group (its width for left/right, its
+  // height for top/bottom), null until the group is first resized.
+  final Map<PdfPanelDock, double> _panelGroupWidths = {};
   Color? _textFillColor;
   Color? _textBorderColor;
   Color? _shapeFillColor;
@@ -264,6 +274,14 @@ class PdfEditingPreferences extends ChangeNotifier {
           _readDock(store, 'annotationSidebarDock', _annotationSidebarDock);
       _propertiesPanelDock =
           _readDock(store, 'propertiesPanelDock', _propertiesPanelDock);
+      for (final p in PdfDockablePanel.values) {
+        _panelGroups[p] =
+            store.getInt('${_prefix}panelGroup.${p.name}') ?? _panelGroups[p]!;
+      }
+      for (final d in PdfPanelDock.values) {
+        final w = store.getDouble('${_prefix}panelGroupWidth.${d.name}');
+        if (w != null) _panelGroupWidths[d] = w;
+      }
       final textFill = store.getInt('${_prefix}textFillColor');
       if (textFill != null) _textFillColor = Color(textFill);
       final textBorder = store.getInt('${_prefix}textBorderColor');
@@ -1146,6 +1164,63 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _propertiesPanelDock) return;
     _propertiesPanelDock = value;
     _setDock('propertiesPanelDock', value);
+  }
+
+  /// The dock a specific [panel] is attached to, keyed by identity - the
+  /// generic form of the per-panel dock getters above.
+  PdfPanelDock panelDock(PdfDockablePanel panel) => switch (panel) {
+        PdfDockablePanel.thumbnails => _thumbnailSidebarDock,
+        PdfDockablePanel.search => _searchPanelDock,
+        PdfDockablePanel.bookmarks => _bookmarkSidebarDock,
+        PdfDockablePanel.annotations => _annotationSidebarDock,
+        PdfDockablePanel.properties => _propertiesPanelDock,
+      };
+
+  /// Sets [panel]'s dock, keyed by identity.
+  void setPanelDock(PdfDockablePanel panel, PdfPanelDock dock) {
+    switch (panel) {
+      case PdfDockablePanel.thumbnails:
+        thumbnailSidebarDock = dock;
+      case PdfDockablePanel.search:
+        searchPanelDock = dock;
+      case PdfDockablePanel.bookmarks:
+        bookmarkSidebarDock = dock;
+      case PdfDockablePanel.annotations:
+        annotationSidebarDock = dock;
+      case PdfDockablePanel.properties:
+        propertiesPanelDock = dock;
+    }
+  }
+
+  /// The tab-group id [panel] belongs to. Panels that share both a dock and
+  /// a group id render as one tabbed panel; a panel alone in its group is a
+  /// standalone side-by-side panel. Defaults to the panel's own enum index
+  /// (every panel standalone).
+  int panelGroup(PdfDockablePanel panel) => _panelGroups[panel]!;
+
+  /// Its own enum index - the value [panelGroup] returns when the panel is
+  /// standalone (in no shared tab group).
+  int standalonePanelGroup(PdfDockablePanel panel) => panel.index;
+
+  /// Sets [panel]'s tab-group id. Pass [standalonePanelGroup] to split it out
+  /// of any tab group.
+  void setPanelGroup(PdfDockablePanel panel, int group) {
+    if (_panelGroups[panel] == group) return;
+    _panelGroups[panel] = group;
+    _write((s) => s.setInt('${_prefix}panelGroup.${panel.name}', group));
+    notifyListeners();
+  }
+
+  /// The dragged extent of the tab group docked on [dock] (its width for
+  /// left/right, its height for top/bottom), or null before it is resized.
+  double? panelGroupWidth(PdfPanelDock dock) => _panelGroupWidths[dock];
+
+  /// Persists the dragged extent of the tab group docked on [dock].
+  void setPanelGroupWidth(PdfPanelDock dock, double width) {
+    if (_panelGroupWidths[dock] == width) return;
+    _panelGroupWidths[dock] = width;
+    _write((s) => s.setDouble('${_prefix}panelGroupWidth.${dock.name}', width));
+    notifyListeners();
   }
 
   /// Whether document search matches case (see `PdfSearchOptions.matchCase`).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -41,7 +41,7 @@ class PdfAnnotationPropertiesPanel extends StatefulWidget {
     super.key,
     required this.controller,
     this.width = 260,
-    this.side = PdfSidebarSide.right,
+    this.dock = PdfPanelDock.right,
     this.resizable = true,
     this.minWidth = 200,
     this.maxWidth = 420,
@@ -61,9 +61,9 @@ class PdfAnnotationPropertiesPanel extends StatefulWidget {
   /// [PdfEditingPreferences.propertiesPanelWidth], wins over it.
   final double width;
 
-  /// Which side of the viewer the panel sits on; the resize grip rides
+  /// Which edge of the viewer the panel docks on; the resize grip rides
   /// the opposite (inner) edge.
-  final PdfSidebarSide side;
+  final PdfPanelDock dock;
 
   /// Whether the inner edge can be dragged to resize the panel.
   final bool resizable;
@@ -332,7 +332,8 @@ class _PdfAnnotationPropertiesPanelState
         initial: current ?? const Color(0xFF000000));
     if (picked != null) {
       _controller.restyleSelectedText(
-          border: (_rgb(picked),), borderWidth: _controller.preferences.strokeWidth);
+          border: (_rgb(picked),),
+          borderWidth: _controller.preferences.strokeWidth);
     }
   }
 
@@ -1027,64 +1028,73 @@ class _PdfAnnotationPropertiesPanelState
       maxWidth: widget.maxWidth,
       persistedWidth: _preferences.propertiesPanelWidth,
       onPersistWidth: (width) => _preferences.propertiesPanelWidth = width,
-      side: widget.side,
+      dock: widget.dock,
+      panel: PdfDockablePanel.properties,
       resizable: widget.resizable,
       bottomSheet: widget.bottomSheet,
       gripKey: const ValueKey('pdf-properties-resize-grip'),
       onClose: widget.onClose,
-      builder: (context, geometry) => Material(
-        color: Theme.of(context).colorScheme.surfaceContainerLow,
-        child: Column(children: [
-          if (geometry.closeButton(
-            key: const ValueKey('pdf-properties-panel-close'),
-          )
-              case final closeButton?)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 4, 0),
-              child: Row(children: [
-                Expanded(
-                  child: Text('Properties',
-                      style: Theme.of(context).textTheme.titleSmall),
-                ),
-                closeButton,
-              ]),
-            ),
-          Expanded(
-            child: ListenableBuilder(
-              listenable: _controller,
-              builder: (context, _) {
-                final annotation = _controller.selectedAnnotation;
-                _syncFields(annotation);
-                if (annotation == null) {
-                  return const Center(
-                    child: Padding(
-                      padding: EdgeInsets.all(24),
-                      child: Text('Select an annotation to see its properties',
-                          textAlign: TextAlign.center),
+      builder: (context, geometry) {
+        final moveHandle = geometry.moveHandle(
+          key: const ValueKey('pdf-properties-panel-move'),
+        );
+        final closeButton = geometry.closeButton(
+          key: const ValueKey('pdf-properties-panel-close'),
+        );
+        return Material(
+          color: Theme.of(context).colorScheme.surfaceContainerLow,
+          child: Column(children: [
+            if (moveHandle != null || closeButton != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 4, 4, 0),
+                child: Row(children: [
+                  Expanded(
+                    child: Text('Properties',
+                        style: Theme.of(context).textTheme.titleSmall),
+                  ),
+                  if (moveHandle != null) moveHandle,
+                  if (closeButton != null) closeButton,
+                ]),
+              ),
+            Expanded(
+              child: ListenableBuilder(
+                listenable: _controller,
+                builder: (context, _) {
+                  final annotation = _controller.selectedAnnotation;
+                  _syncFields(annotation);
+                  if (annotation == null) {
+                    return const Center(
+                      child: Padding(
+                        padding: EdgeInsets.all(24),
+                        child: Text(
+                            'Select an annotation to see its properties',
+                            textAlign: TextAlign.center),
+                      ),
+                    );
+                  }
+                  final count = _controller.selectedAnnotationSlots.length;
+                  final children = count == 1
+                      ? _buildSingle(annotation)
+                      : _buildMulti(count);
+                  return geometry.withScrollbar(
+                    scroll: _scroll,
+                    thumbKey: const ValueKey('pdf-properties-scrollbar-thumb'),
+                    child: ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(context)
+                          .copyWith(scrollbars: false),
+                      child: ListView(
+                          controller: _scroll,
+                          padding: EdgeInsets.only(
+                              right: geometry.scrollbarClearance),
+                          children: children),
                     ),
                   );
-                }
-                final count = _controller.selectedAnnotationSlots.length;
-                final children =
-                    count == 1 ? _buildSingle(annotation) : _buildMulti(count);
-                return geometry.withScrollbar(
-                  scroll: _scroll,
-                  thumbKey: const ValueKey('pdf-properties-scrollbar-thumb'),
-                  child: ScrollConfiguration(
-                    behavior: ScrollConfiguration.of(context)
-                        .copyWith(scrollbars: false),
-                    child: ListView(
-                        controller: _scroll,
-                        padding:
-                            EdgeInsets.only(right: geometry.scrollbarClearance),
-                        children: children),
-                  ),
-                );
-              },
+                },
+              ),
             ),
-          ),
-        ]),
-      ),
+          ]),
+        );
+      },
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -51,7 +51,7 @@ class PdfAnnotationSidebar extends StatefulWidget {
     required this.controller,
     required this.viewerController,
     this.width = 280,
-    this.side = PdfSidebarSide.right,
+    this.dock = PdfPanelDock.right,
     this.resizable = true,
     this.minWidth = 200,
     this.maxWidth = 480,
@@ -68,9 +68,9 @@ class PdfAnnotationSidebar extends StatefulWidget {
   /// [PdfEditingPreferences.annotationSidebarWidth], wins over it.
   final double width;
 
-  /// Which side of the viewer the panel sits on; the resize grip rides
+  /// Which edge of the viewer the panel docks on; the resize grip rides
   /// the opposite (inner) edge.
-  final PdfSidebarSide side;
+  final PdfPanelDock dock;
 
   /// Whether the inner edge can be dragged to resize the panel.
   final bool resizable;
@@ -258,6 +258,13 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
     final closeButton = geometry.closeButton(
       key: const ValueKey('pdf-annotation-panel-close'),
     );
+    final moveHandle = geometry.moveHandle(
+      key: const ValueKey('pdf-annotation-panel-move'),
+    );
+    final trailing = <Widget>[
+      if (moveHandle != null) moveHandle,
+      if (closeButton != null) closeButton,
+    ];
     final field = TextField(
       key: const ValueKey('pdf-annotation-search'),
       controller: _search,
@@ -278,18 +285,22 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
       ),
     );
     return Padding(
-      padding: EdgeInsets.fromLTRB(12, 8, closeButton != null ? 4 : 12, 4),
-      child: closeButton != null
+      padding: EdgeInsets.fromLTRB(12, 8, trailing.isNotEmpty ? 4 : 12, 4),
+      child: trailing.isNotEmpty
           ? Row(children: [
               Expanded(child: field),
-              closeButton,
+              ...trailing,
             ])
           : field,
     );
   }
 
-  Widget _tile(BuildContext context, int pageIndex, int index,
-      PdfAnnotation annotation, PdfCommentThread? thread,
+  Widget _tile(
+      BuildContext context,
+      int pageIndex,
+      int index,
+      PdfAnnotation annotation,
+      PdfCommentThread? thread,
       List<(int, int)> ordered) {
     final slot = (pageIndex, index);
     final editable = annotation.behavior.selectable &&
@@ -372,8 +383,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
           key: ValueKey('pdf-annotation-delete-$pageIndex-$index'),
           icon: const Icon(Icons.delete_outline, size: 20),
           tooltip: 'Delete',
-          onPressed: () =>
-              widget.controller.deleteAnnotation(pageIndex, index),
+          onPressed: () => widget.controller.deleteAnnotation(pageIndex, index),
         ),
     ];
     if (actions.isEmpty) return null;
@@ -696,7 +706,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
       maxWidth: widget.maxWidth,
       persistedWidth: _preferences.annotationSidebarWidth,
       onPersistWidth: (width) => _preferences.annotationSidebarWidth = width,
-      side: widget.side,
+      dock: widget.dock,
+      panel: PdfDockablePanel.annotations,
       resizable: widget.resizable,
       bottomSheet: widget.bottomSheet,
       gripKey: const ValueKey('pdf-annotation-resize-grip'),
@@ -754,7 +765,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
                 tiles.add(_tile(context, page, i, annotation, thread, ordered));
                 // a markup annotation hosts a comment thread
                 if (annotation.behavior.selectable) {
-                  tiles.addAll(_threadSection(context, page, annotation, thread));
+                  tiles.addAll(
+                      _threadSection(context, page, annotation, thread));
                 }
               }
               if (tiles.isNotEmpty) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -67,7 +67,7 @@ class PdfThumbnailSidebar extends StatefulWidget {
     this.width = 160,
     this.pageColor = const Color(0xFFFFFFFF),
     this.showAnnotations = true,
-    this.side = PdfSidebarSide.left,
+    this.dock = PdfPanelDock.left,
     this.resizable = true,
     this.minWidth = 100,
     this.maxWidth = 400,
@@ -109,9 +109,9 @@ class PdfThumbnailSidebar extends StatefulWidget {
   /// [PdfViewer.showAnnotations] so they match the pages.
   final bool showAnnotations;
 
-  /// Which side of the viewer the panel sits on; the resize grip rides
+  /// Which edge of the viewer the panel docks on; the resize grip rides
   /// the opposite (inner) edge.
-  final PdfSidebarSide side;
+  final PdfPanelDock dock;
 
   /// Whether the inner edge can be dragged to resize the panel.
   final bool resizable;
@@ -288,7 +288,8 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
         const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true): () =>
             _moveKeyboardSelection(1),
         if (widget.allowPageEditing) ...{
-          const SingleActivator(LogicalKeyboardKey.keyC, meta: true): _copyPages,
+          const SingleActivator(LogicalKeyboardKey.keyC, meta: true):
+              _copyPages,
           const SingleActivator(LogicalKeyboardKey.keyC, control: true):
               _copyPages,
           const SingleActivator(LogicalKeyboardKey.keyX, meta: true): _cutPages,
@@ -315,7 +316,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       PdfScrollbar.hitExtent +
           (widget.resizable &&
                   !widget.bottomSheet &&
-                  widget.side == PdfSidebarSide.left
+                  widget.dock == PdfPanelDock.left
               ? PdfSidebarResizeGrip.width
               : 0);
 
@@ -473,7 +474,8 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       maxWidth: widget.maxWidth,
       persistedWidth: _preferences.thumbnailSidebarWidth,
       onPersistWidth: (width) => _preferences.thumbnailSidebarWidth = width,
-      side: widget.side,
+      dock: widget.dock,
+      panel: PdfDockablePanel.thumbnails,
       resizable: widget.resizable,
       bottomSheet: widget.bottomSheet,
       gripKey: const ValueKey('pdf-thumbnail-resize-grip'),
@@ -580,8 +582,14 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                                       ],
                                     ),
                             ),
-                            // the docked strip's close button; a bottom sheet
-                            // supplies its own in its sheet chrome
+                            // the drag-to-redock handle and the docked
+                            // strip's close button; a bottom sheet supplies
+                            // its own close in its sheet chrome
+                            if (geometry.moveHandle(
+                              key: const ValueKey('pdf-thumbnail-panel-move'),
+                            )
+                                case final moveHandle?)
+                              moveHandle,
                             if (geometry.closeButton(
                               key: const ValueKey('pdf-thumbnail-panel-close'),
                             )
@@ -1207,7 +1215,8 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
         SingleActivator(LogicalKeyboardKey.arrowDown, shift: true): () =>
             _moveKeyboardSelection(columns),
         if (widget.allowPageEditing) ...{
-          const SingleActivator(LogicalKeyboardKey.keyC, meta: true): _copyPages,
+          const SingleActivator(LogicalKeyboardKey.keyC, meta: true):
+              _copyPages,
           const SingleActivator(LogicalKeyboardKey.keyC, control: true):
               _copyPages,
           const SingleActivator(LogicalKeyboardKey.keyX, meta: true): _cutPages,
@@ -2575,8 +2584,7 @@ class _DetailBoundsPainter extends CustomPainter {
     Rect scale(Rect f) => Rect.fromLTRB(f.left * size.width,
         f.top * size.height, f.right * size.width, f.bottom * size.height);
     if (tiles.isNotEmpty) {
-      final sharpest =
-          tiles.map((t) => t.rung).reduce((a, b) => a > b ? a : b);
+      final sharpest = tiles.map((t) => t.rung).reduce((a, b) => a > b ? a : b);
       for (final tile in tiles) {
         final paint = Paint()
           ..style = PaintingStyle.stroke

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -571,22 +571,21 @@ class _PdfEditorViewState extends State<PdfEditorView> {
     session.preferences.author = name.trim().isEmpty ? null : name.trim();
   }
 
-  /// Redocks [panel] onto [dock] by writing its persisted dock preference;
-  /// the pref change notifies and rebuilds, re-routing the panel to its new
-  /// edge. Wired to [PdfShellPanelLayout.onPanelDock].
+  /// Redocks [panel] standalone onto [dock] (an edge drop zone): writes its
+  /// dock and splits it out of any tab group. The pref change notifies and
+  /// rebuilds, re-routing the panel. Wired to
+  /// [PdfShellPanelLayout.onPanelDock].
   void _setPanelDock(PdfDockablePanel panel, PdfPanelDock dock) {
-    switch (panel) {
-      case PdfDockablePanel.thumbnails:
-        _prefs.thumbnailSidebarDock = dock;
-      case PdfDockablePanel.search:
-        _prefs.searchPanelDock = dock;
-      case PdfDockablePanel.bookmarks:
-        _prefs.bookmarkSidebarDock = dock;
-      case PdfDockablePanel.annotations:
-        _prefs.annotationSidebarDock = dock;
-      case PdfDockablePanel.properties:
-        _prefs.propertiesPanelDock = dock;
-    }
+    _prefs.setPanelDock(panel, dock);
+    _prefs.setPanelGroup(panel, _prefs.standalonePanelGroup(panel));
+  }
+
+  /// Tabs [panel] into the group at [dock]/[group] (a drop onto another
+  /// panel): matches its dock and group id so the two render as one tabbed
+  /// panel. Wired to [PdfPanelTabDropRegion.onJoin].
+  void _joinPanel(PdfDockablePanel panel, PdfPanelDock dock, int group) {
+    _prefs.setPanelDock(panel, dock);
+    _prefs.setPanelGroup(panel, group);
   }
 
   @override
@@ -735,26 +734,101 @@ class _PdfEditorViewState extends State<PdfEditorView> {
           final showPropertiesPanel =
               features.propertiesPanel && prefs.showPropertiesPanel && !altView;
 
-          // The visible docked panels paired with the edge each is docked
-          // on (persisted per panel). [dockedPanels] filters them into the
-          // shell's four dock groups; a panel's move handle can drag it
-          // between edges, which rewrites the pref and re-routes it here.
-          final docked = <(PdfPanelDock, Widget)>[
-            if (showThumbnailsPanel && !useSheets)
-              (prefs.thumbnailSidebarDock, thumbnails(bottomSheet: false)),
-            if (showSearchPanel && !useSheets)
-              (prefs.searchPanelDock, searchResults(bottomSheet: false)),
-            if (showBookmarksPanel && !useSheets)
-              (prefs.bookmarkSidebarDock, bookmarks(bottomSheet: false)),
+          // The visible docked panels, in canonical order. Each is placed on
+          // its persisted edge ([PdfEditingPreferences.panelDock]) and, within
+          // that edge, its persisted tab group ([panelGroup]): panels sharing
+          // an edge and a group id render as one tabbed panel, otherwise as
+          // side-by-side panels. Dragging a panel's handle onto an edge zone
+          // redocks it standalone; dragging it onto another panel tabs them.
+          final visiblePanels = <PdfDockablePanel>[
+            if (showThumbnailsPanel && !useSheets) PdfDockablePanel.thumbnails,
+            if (showSearchPanel && !useSheets) PdfDockablePanel.search,
+            if (showBookmarksPanel && !useSheets) PdfDockablePanel.bookmarks,
             if (showAnnotationsPanel && !useSheets)
-              (prefs.annotationSidebarDock, annotations(bottomSheet: false)),
-            if (showPropertiesPanel && !useSheets)
-              (prefs.propertiesPanelDock, properties(bottomSheet: false)),
+              PdfDockablePanel.annotations,
+            if (showPropertiesPanel && !useSheets) PdfDockablePanel.properties,
           ];
-          List<Widget> dockedPanels(PdfPanelDock dock) => [
-                for (final (d, w) in docked)
-                  if (d == dock) w
-              ];
+          Widget standalonePanel(PdfDockablePanel p) => switch (p) {
+                PdfDockablePanel.thumbnails => thumbnails(bottomSheet: false),
+                PdfDockablePanel.search => searchResults(bottomSheet: false),
+                PdfDockablePanel.bookmarks => bookmarks(bottomSheet: false),
+                PdfDockablePanel.annotations => annotations(bottomSheet: false),
+                PdfDockablePanel.properties => properties(bottomSheet: false),
+              };
+          // a chromeless body for use inside a tab group (the group supplies
+          // the frame, tab strip, and close buttons); reuses the panels'
+          // bottom-sheet content mode
+          Widget tabBody(PdfDockablePanel p) => switch (p) {
+                PdfDockablePanel.thumbnails => thumbnails(bottomSheet: true),
+                PdfDockablePanel.search => searchResults(bottomSheet: true),
+                PdfDockablePanel.bookmarks => bookmarks(bottomSheet: true),
+                PdfDockablePanel.annotations => annotations(bottomSheet: true),
+                PdfDockablePanel.properties => properties(bottomSheet: true),
+              };
+          VoidCallback closePanel(PdfDockablePanel p) => switch (p) {
+                PdfDockablePanel.thumbnails => () =>
+                    prefs.showThumbnailSidebar = false,
+                PdfDockablePanel.search => () =>
+                    prefs.showSearchResultsPanel = false,
+                PdfDockablePanel.bookmarks => () =>
+                    prefs.showBookmarkSidebar = false,
+                PdfDockablePanel.annotations => () =>
+                    prefs.showAnnotationSidebar = false,
+                PdfDockablePanel.properties => () =>
+                    prefs.showPropertiesPanel = false,
+              };
+          List<Widget> dockedPanels(PdfPanelDock dock) {
+            final onDock = [
+              for (final p in visiblePanels)
+                if (prefs.panelDock(p) == dock) p
+            ];
+            // partition into tab groups by group id, preserving the order in
+            // which each group first appears
+            final order = <int>[];
+            final byGroup = <int, List<PdfDockablePanel>>{};
+            for (final p in onDock) {
+              final g = prefs.panelGroup(p);
+              if (!byGroup.containsKey(g)) {
+                byGroup[g] = [];
+                order.add(g);
+              }
+              byGroup[g]!.add(p);
+            }
+            final children = <Widget>[];
+            for (final g in order) {
+              final members = byGroup[g]!;
+              final Widget child;
+              if (members.length == 1) {
+                child = standalonePanel(members.first);
+              } else {
+                child = PdfPanelTabGroup(
+                  key: ValueKey('pdf-panel-tabgroup-${dock.name}-$g'),
+                  dock: dock,
+                  width: 300,
+                  minWidth: 200,
+                  maxWidth: 560,
+                  persistedWidth: prefs.panelGroupWidth(dock),
+                  onPersistWidth: (w) => prefs.setPanelGroupWidth(dock, w),
+                  gripKey: ValueKey('pdf-panel-tabgroup-grip-${dock.name}-$g'),
+                  entries: [
+                    for (final m in members)
+                      PdfPanelTabEntry(
+                        panel: m,
+                        body: tabBody(m),
+                        onClose: closePanel(m),
+                      ),
+                  ],
+                );
+              }
+              // dropping another panel onto this one tabs it into this group
+              children.add(PdfPanelTabDropRegion(
+                members: members.toSet(),
+                onJoin: (dragged) => _joinPanel(dragged, dock, g),
+                child: child,
+              ));
+            }
+            return children;
+          }
 
           final sheets = !useSheets
               ? const <Widget>[]

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -7,6 +7,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'editing/editing_bookmarks.dart';
 import 'editing/editing_controller.dart';
 import 'editing/editing_menu.dart';
+import 'editing/editing_panel.dart';
 import 'editing/editing_pencil.dart';
 import 'editing/editing_preferences.dart';
 import 'editing/editing_properties.dart';
@@ -570,6 +571,24 @@ class _PdfEditorViewState extends State<PdfEditorView> {
     session.preferences.author = name.trim().isEmpty ? null : name.trim();
   }
 
+  /// Redocks [panel] onto [dock] by writing its persisted dock preference;
+  /// the pref change notifies and rebuilds, re-routing the panel to its new
+  /// edge. Wired to [PdfShellPanelLayout.onPanelDock].
+  void _setPanelDock(PdfDockablePanel panel, PdfPanelDock dock) {
+    switch (panel) {
+      case PdfDockablePanel.thumbnails:
+        _prefs.thumbnailSidebarDock = dock;
+      case PdfDockablePanel.search:
+        _prefs.searchPanelDock = dock;
+      case PdfDockablePanel.bookmarks:
+        _prefs.bookmarkSidebarDock = dock;
+      case PdfDockablePanel.annotations:
+        _prefs.annotationSidebarDock = dock;
+      case PdfDockablePanel.properties:
+        _prefs.propertiesPanelDock = dock;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final features = widget.features;
@@ -610,6 +629,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 pageColor: pageColor,
                 showAnnotations: prefs.showAnnotations,
                 allowPageEditing: features.pageEditing,
+                dock: prefs.thumbnailSidebarDock,
                 bottomSheet: bottomSheet,
                 // the sheet chrome carries its own close button
                 onClose: bottomSheet
@@ -629,6 +649,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     'pdf-shell-search-panel-${bottomSheet ? 'sheet' : 'docked'}'),
                 controller: _viewer,
                 preferences: prefs,
+                dock: prefs.searchPanelDock,
                 bottomSheet: bottomSheet,
                 onClose: bottomSheet
                     ? null
@@ -641,6 +662,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 controller: session,
                 viewerController: _viewer,
                 editable: true,
+                dock: prefs.bookmarkSidebarDock,
                 bottomSheet: bottomSheet,
                 onClose: bottomSheet
                     ? null
@@ -652,6 +674,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     'pdf-shell-annotations-${bottomSheet ? 'sheet' : 'docked'}'),
                 controller: session,
                 viewerController: _viewer,
+                dock: prefs.annotationSidebarDock,
                 bottomSheet: bottomSheet,
                 onClose: bottomSheet
                     ? null
@@ -664,6 +687,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                     'pdf-shell-properties-${bottomSheet ? 'sheet' : 'docked'}'),
                 controller: session,
                 showAuthor: features.authorEditable,
+                dock: prefs.propertiesPanelDock,
                 bottomSheet: bottomSheet,
                 onClose: bottomSheet
                     ? null
@@ -710,6 +734,27 @@ class _PdfEditorViewState extends State<PdfEditorView> {
               !altView;
           final showPropertiesPanel =
               features.propertiesPanel && prefs.showPropertiesPanel && !altView;
+
+          // The visible docked panels paired with the edge each is docked
+          // on (persisted per panel). [dockedPanels] filters them into the
+          // shell's four dock groups; a panel's move handle can drag it
+          // between edges, which rewrites the pref and re-routes it here.
+          final docked = <(PdfPanelDock, Widget)>[
+            if (showThumbnailsPanel && !useSheets)
+              (prefs.thumbnailSidebarDock, thumbnails(bottomSheet: false)),
+            if (showSearchPanel && !useSheets)
+              (prefs.searchPanelDock, searchResults(bottomSheet: false)),
+            if (showBookmarksPanel && !useSheets)
+              (prefs.bookmarkSidebarDock, bookmarks(bottomSheet: false)),
+            if (showAnnotationsPanel && !useSheets)
+              (prefs.annotationSidebarDock, annotations(bottomSheet: false)),
+            if (showPropertiesPanel && !useSheets)
+              (prefs.propertiesPanelDock, properties(bottomSheet: false)),
+          ];
+          List<Widget> dockedPanels(PdfPanelDock dock) => [
+                for (final (d, w) in docked)
+                  if (d == dock) w
+              ];
 
           final sheets = !useSheets
               ? const <Widget>[]
@@ -959,14 +1004,10 @@ class _PdfEditorViewState extends State<PdfEditorView> {
               ),
             Expanded(
               child: PdfShellPanelLayout(
-                leadingPanels: [
-                  if (showThumbnailsPanel && !useSheets)
-                    thumbnails(bottomSheet: false),
-                  if (showSearchPanel && !useSheets)
-                    searchResults(bottomSheet: false),
-                  if (showBookmarksPanel && !useSheets)
-                    bookmarks(bottomSheet: false),
-                ],
+                leadingPanels: dockedPanels(PdfPanelDock.left),
+                topPanels: dockedPanels(PdfPanelDock.top),
+                bottomPanels: dockedPanels(PdfPanelDock.bottom),
+                onPanelDock: _setPanelDock,
                 viewer: reflowActive
                     ? PdfReflowView(
                         document: session.document,
@@ -1019,12 +1060,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         // page still scrolls it before the grid closes.
                         active: !gridActive,
                       ),
-                trailingPanels: [
-                  if (showAnnotationsPanel && !useSheets)
-                    annotations(bottomSheet: false),
-                  if (showPropertiesPanel && !useSheets)
-                    properties(bottomSheet: false),
-                ],
+                trailingPanels: dockedPanels(PdfPanelDock.right),
                 bottomSheets: sheets,
                 overlays: [
                   // the page grid covers the (still-mounted) viewer: a tap can

--- a/packages/dart_pdf_editor/lib/src/search_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/search_panel.dart
@@ -210,7 +210,7 @@ class PdfSearchResultsPanel extends StatefulWidget {
     required this.controller,
     this.preferences,
     this.width = 280,
-    this.side = PdfSidebarSide.left,
+    this.dock = PdfPanelDock.left,
     this.resizable = true,
     this.minWidth = 200,
     this.maxWidth = 480,
@@ -231,9 +231,9 @@ class PdfSearchResultsPanel extends StatefulWidget {
   /// The default width - a persisted user-dragged width wins over it.
   final double width;
 
-  /// Which side of the viewer the panel sits on; the resize grip rides
+  /// Which edge of the viewer the panel docks on; the resize grip rides
   /// the opposite (inner) edge.
-  final PdfSidebarSide side;
+  final PdfPanelDock dock;
 
   /// Whether the inner edge can be dragged to resize the panel.
   final bool resizable;
@@ -405,53 +405,61 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
       onPersistWidth: widget.preferences == null
           ? null
           : (width) => widget.preferences!.searchPanelWidth = width,
-      side: widget.side,
+      dock: widget.dock,
+      panel: PdfDockablePanel.search,
       resizable: widget.resizable,
       bottomSheet: widget.bottomSheet,
       gripKey: const ValueKey('pdf-search-resize-grip'),
       onClose: widget.onClose,
-      builder: (context, geometry) => Material(
-        color: Theme.of(context).colorScheme.surfaceContainerLow,
-        child: ListenableBuilder(
-          listenable: controller,
-          builder: (context, _) => Column(children: [
-            // the docked panel's close button; a bottom sheet supplies
-            // its own in its sheet chrome
-            if (geometry.closeButton(
-              key: const ValueKey('pdf-search-panel-close'),
-            )
-                case final closeButton?)
-              Padding(
-                // clear the right-edge resize grip when it rides this side
-                padding:
-                    EdgeInsets.fromLTRB(16, 4, geometry.contentEndInset + 4, 0),
-                child: Row(children: [
-                  Expanded(
-                    child: Text('Search results',
-                        style: Theme.of(context).textTheme.titleSmall),
-                  ),
-                  closeButton,
-                ]),
-              ),
-            if (widget.showOptions) ...[
-              Padding(
-                padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: _SearchOptionsBar(
-                      controller: controller, preferences: widget.preferences),
+      builder: (context, geometry) {
+        final moveHandle = geometry.moveHandle(
+          key: const ValueKey('pdf-search-panel-move'),
+        );
+        final closeButton = geometry.closeButton(
+          key: const ValueKey('pdf-search-panel-close'),
+        );
+        return Material(
+          color: Theme.of(context).colorScheme.surfaceContainerLow,
+          child: ListenableBuilder(
+            listenable: controller,
+            builder: (context, _) => Column(children: [
+              // the drag-to-redock handle and the docked panel's close
+              // button; a bottom sheet supplies its own in its sheet chrome
+              if (moveHandle != null || closeButton != null)
+                Padding(
+                  // clear the right-edge resize grip when it rides this side
+                  padding: EdgeInsets.fromLTRB(
+                      16, 4, geometry.contentEndInset + 4, 0),
+                  child: Row(children: [
+                    Expanded(
+                      child: Text('Search results',
+                          style: Theme.of(context).textTheme.titleSmall),
+                    ),
+                    if (moveHandle != null) moveHandle,
+                    if (closeButton != null) closeButton,
+                  ]),
                 ),
-              ),
-              Divider(
-                height: 1,
-                indent: geometry.contentStartInset,
-                endIndent: geometry.contentEndInset,
-              ),
-            ],
-            Expanded(child: _body(context, geometry: geometry)),
-          ]),
-        ),
-      ),
+              if (widget.showOptions) ...[
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: _SearchOptionsBar(
+                        controller: controller,
+                        preferences: widget.preferences),
+                  ),
+                ),
+                Divider(
+                  height: 1,
+                  indent: geometry.contentStartInset,
+                  endIndent: geometry.contentEndInset,
+                ),
+              ],
+              Expanded(child: _body(context, geometry: geometry)),
+            ]),
+          ),
+        );
+      },
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -170,11 +170,12 @@ class _PanelDropZones extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      // edge bands sized to a fraction of the area, capped so they stay
-      // legible targets without swallowing the whole viewer
-      final bandW = (constraints.maxWidth * 0.18).clamp(72.0, 200.0).toDouble();
-      final bandH =
-          (constraints.maxHeight * 0.18).clamp(56.0, 160.0).toDouble();
+      // Thin edge bands hug the very edge: docking a panel to an edge is
+      // dropping in its band, while dropping on a panel's body (inward of
+      // the band) tabs the two together. Kept narrow so an already-docked
+      // panel stays a reachable tab target.
+      final bandW = (constraints.maxWidth * 0.1).clamp(56.0, 96.0).toDouble();
+      final bandH = (constraints.maxHeight * 0.1).clamp(48.0, 84.0).toDouble();
       return Stack(children: [
         Positioned(
           left: 0,
@@ -257,6 +258,258 @@ class _DropTarget extends StatelessWidget {
                 size: active ? 32 : 26),
           ),
         );
+      },
+    );
+  }
+}
+
+/// One panel in a [PdfPanelTabGroup].
+class PdfPanelTabEntry {
+  const PdfPanelTabEntry({
+    required this.panel,
+    required this.body,
+    this.onClose,
+  });
+
+  /// The panel's identity (its label + icon name the tab).
+  final PdfDockablePanel panel;
+
+  /// The panel's content, built chromeless (it fills the tab body).
+  final Widget body;
+
+  /// Hides this panel - the shell turns its visibility preference off.
+  final VoidCallback? onClose;
+}
+
+/// Several panels docked on the same edge and grouped into one tabbed panel:
+/// a tab strip selects which body shows, and the rest stay mounted (their
+/// state survives tab switches). Each tab is draggable - onto an edge zone to
+/// split it back out, or onto another panel to move it - and closable. Shares
+/// the docked-panel frame (fixed extent + resize grip) with standalone panels.
+class PdfPanelTabGroup extends StatefulWidget {
+  const PdfPanelTabGroup({
+    super.key,
+    required this.dock,
+    required this.entries,
+    required this.width,
+    required this.minWidth,
+    required this.maxWidth,
+    required this.gripKey,
+    this.persistedWidth,
+    this.onPersistWidth,
+  });
+
+  final PdfPanelDock dock;
+  final List<PdfPanelTabEntry> entries;
+  final double width;
+  final double minWidth;
+  final double maxWidth;
+  final double? persistedWidth;
+  final ValueChanged<double>? onPersistWidth;
+  final Key gripKey;
+
+  @override
+  State<PdfPanelTabGroup> createState() => _PdfPanelTabGroupState();
+}
+
+class _PdfPanelTabGroupState extends State<PdfPanelTabGroup> {
+  int _selected = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = widget.entries;
+    final selected = _selected.clamp(0, entries.length - 1);
+    return PdfSidebarPanelFrame(
+      width: widget.width,
+      minWidth: widget.minWidth,
+      maxWidth: widget.maxWidth,
+      persistedWidth: widget.persistedWidth,
+      onPersistWidth: widget.onPersistWidth,
+      dock: widget.dock,
+      // no single move handle: each tab is dragged individually
+      resizable: true,
+      bottomSheet: false,
+      gripKey: widget.gripKey,
+      builder: (context, geometry) => Material(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        child: Column(children: [
+          _tabStrip(context, geometry, entries, selected),
+          const Divider(height: 1),
+          Expanded(
+            child: IndexedStack(
+              index: selected,
+              sizing: StackFit.expand,
+              children: [for (final e in entries) e.body],
+            ),
+          ),
+        ]),
+      ),
+    );
+  }
+
+  Widget _tabStrip(
+    BuildContext context,
+    PdfSidebarPanelGeometry geometry,
+    List<PdfPanelTabEntry> entries,
+    int selected,
+  ) {
+    return Padding(
+      // keep the strip clear of the inner resize grip
+      padding: EdgeInsets.only(
+        left: geometry.contentStartInset,
+        right: geometry.contentEndInset,
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            for (var i = 0; i < entries.length; i++)
+              _PanelTab(
+                entry: entries[i],
+                selected: i == selected,
+                onSelect: () => setState(() => _selected = i),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single tab chip: selects its panel on tap, drags to redock/split, and
+/// carries a close button.
+class _PanelTab extends StatelessWidget {
+  const _PanelTab({
+    required this.entry,
+    required this.selected,
+    required this.onSelect,
+  });
+
+  final PdfPanelTabEntry entry;
+  final bool selected;
+  final VoidCallback onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final panel = entry.panel;
+    final chip = InkWell(
+      key: ValueKey('pdf-panel-tab-${panel.name}'),
+      onTap: onSelect,
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(10, 8, 6, 8),
+        decoration: BoxDecoration(
+          color: selected ? scheme.surfaceContainerHighest : null,
+          border: Border(
+            bottom: BorderSide(
+              color: selected ? scheme.primary : Colors.transparent,
+              width: 2,
+            ),
+          ),
+        ),
+        child: Row(mainAxisSize: MainAxisSize.min, children: [
+          Icon(panel.icon,
+              size: 16,
+              color: selected ? scheme.primary : scheme.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Text(panel.label,
+              style: TextStyle(
+                color: selected ? scheme.onSurface : scheme.onSurfaceVariant,
+                fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+                fontSize: 13,
+              )),
+          if (entry.onClose != null) ...[
+            const SizedBox(width: 4),
+            InkWell(
+              key: ValueKey('pdf-panel-tab-close-${panel.name}'),
+              onTap: entry.onClose,
+              customBorder: const CircleBorder(),
+              child: Padding(
+                padding: const EdgeInsets.all(2),
+                child:
+                    Icon(Icons.close, size: 14, color: scheme.onSurfaceVariant),
+              ),
+            ),
+          ],
+        ]),
+      ),
+    );
+    final scope = PdfPanelDragScope.maybeOf(context);
+    if (scope == null) return chip;
+    return Draggable<PdfDockablePanel>(
+      data: panel,
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      onDragStarted: scope.onDragStarted,
+      onDragEnd: (_) => scope.onDragEnded(),
+      onDraggableCanceled: (_, __) => scope.onDragEnded(),
+      feedback: PdfPanelDragFeedback(panel: panel),
+      child: MouseRegion(cursor: SystemMouseCursors.move, child: chip),
+    );
+  }
+}
+
+/// Wraps a docked panel (standalone or a tab group) so that dragging another
+/// panel onto it joins that panel into this one's tab group. Passive - and
+/// pointer-transparent - until a droppable panel that is not already a
+/// [members] of this group hovers it.
+class PdfPanelTabDropRegion extends StatelessWidget {
+  const PdfPanelTabDropRegion({
+    super.key,
+    required this.members,
+    required this.onJoin,
+    required this.child,
+  });
+
+  /// The panels already in this target group - a drag of one of them is
+  /// rejected (dropping onto its own group is a no-op).
+  final Set<PdfDockablePanel> members;
+
+  /// Joins the dragged panel into this group.
+  final ValueChanged<PdfDockablePanel> onJoin;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return DragTarget<PdfDockablePanel>(
+      onWillAcceptWithDetails: (details) => !members.contains(details.data),
+      onAcceptWithDetails: (details) => onJoin(details.data),
+      builder: (context, candidate, rejected) {
+        final active = candidate.isNotEmpty;
+        return Stack(children: [
+          child,
+          if (active)
+            Positioned.fill(
+              child: IgnorePointer(
+                child: Container(
+                  margin: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: scheme.primary.withValues(alpha: 0.14),
+                    borderRadius: BorderRadius.circular(10),
+                    border: Border.all(color: scheme.primary, width: 2),
+                  ),
+                  child: Center(
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 6),
+                      decoration: BoxDecoration(
+                        color: scheme.primaryContainer,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(mainAxisSize: MainAxisSize.min, children: [
+                        Icon(Icons.tab,
+                            size: 18, color: scheme.onPrimaryContainer),
+                        const SizedBox(width: 6),
+                        Text('Tab here',
+                            style: TextStyle(color: scheme.onPrimaryContainer)),
+                      ]),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ]);
       },
     );
   }

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 
 import 'editing/editing_color_picker.dart';
 import 'editing/editing_controller.dart';
+import 'editing/editing_panel.dart';
 import 'editing/editing_preferences.dart';
 import 'editing/tool_shortcuts.dart';
 import 'pdf_viewer.dart';
@@ -39,28 +40,44 @@ const double _pdfShellSheetMaxFactor = 0.9;
 Widget pdfShellBottomSheets(List<Widget> sheets) =>
     _PdfShellBottomSheetArea(sheets: sheets);
 
-/// Shared shell topology: side panels dock around a stable viewer element on
-/// wide layouts, while compact layouts pass panel widgets as [bottomSheets].
-class PdfShellPanelLayout extends StatelessWidget {
+/// Shared shell topology: panels dock around a stable viewer element on wide
+/// layouts - a column of [topPanels], a row of [leadingPanels] · viewer ·
+/// [trailingPanels], then a column of [bottomPanels] - while compact layouts
+/// pass panel widgets as [bottomSheets].
+///
+/// When [onPanelDock] is wired, a panel's move handle can be dragged onto one
+/// of four edge drop zones to redock it; the shell reports the new dock
+/// through the callback and reveals the zones only while a drag is underway.
+class PdfShellPanelLayout extends StatefulWidget {
   const PdfShellPanelLayout({
     super.key,
     required this.viewer,
     this.leadingPanels = const [],
     this.trailingPanels = const [],
+    this.topPanels = const [],
+    this.bottomPanels = const [],
     this.bottomSheets = const [],
     this.overlays = const [],
     this.floatingToolbar,
     this.dockedToolbar,
+    this.onPanelDock,
   });
 
   /// The page viewer, reflow view, or other primary document surface.
   final Widget viewer;
 
-  /// Docked panels before the viewer in the horizontal row.
+  /// Docked panels before the viewer in the horizontal row (left edge).
   final List<Widget> leadingPanels;
 
-  /// Docked panels after the viewer in the horizontal row.
+  /// Docked panels after the viewer in the horizontal row (right edge).
   final List<Widget> trailingPanels;
+
+  /// Docked panels stacked above the viewer row, spanning the width (top edge).
+  final List<Widget> topPanels;
+
+  /// Docked panels stacked below the viewer row, spanning the width
+  /// (bottom edge).
+  final List<Widget> bottomPanels;
 
   /// Compact panels presented through [pdfShellBottomSheets].
   final List<Widget> bottomSheets;
@@ -74,34 +91,174 @@ class PdfShellPanelLayout extends StatelessWidget {
   /// A toolbar that consumes layout space below the content area.
   final Widget? dockedToolbar;
 
+  /// Redocks the given panel to the dropped-on edge. Null disables the
+  /// drag-to-redock affordance (panels then show no move handle).
+  final void Function(PdfDockablePanel panel, PdfPanelDock dock)? onPanelDock;
+
+  @override
+  State<PdfShellPanelLayout> createState() => _PdfShellPanelLayoutState();
+}
+
+class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
+  bool _dragging = false;
+
+  void _setDragging(bool value) {
+    if (_dragging == value) return;
+    setState(() => _dragging = value);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final content = Stack(children: [
-      Positioned.fill(
-        child: Row(children: [
-          ...leadingPanels,
-          Expanded(
-            key: const ValueKey('pdf-shell-viewer'),
-            child: viewer,
-          ),
-          ...trailingPanels,
-        ]),
+    final row = Row(children: [
+      ...widget.leadingPanels,
+      Expanded(
+        key: const ValueKey('pdf-shell-viewer'),
+        child: widget.viewer,
       ),
-      ...overlays,
-      if (floatingToolbar != null)
+      ...widget.trailingPanels,
+    ]);
+    final stacked = Column(children: [
+      ...widget.topPanels,
+      Expanded(child: row),
+      ...widget.bottomPanels,
+    ]);
+    final content = Stack(children: [
+      Positioned.fill(child: stacked),
+      ...widget.overlays,
+      if (widget.floatingToolbar != null)
         Positioned(
           left: 0,
           right: 0,
           bottom: 0,
-          child: floatingToolbar!,
+          child: widget.floatingToolbar!,
         ),
-      if (bottomSheets.isNotEmpty) pdfShellBottomSheets(bottomSheets),
+      if (widget.bottomSheets.isNotEmpty)
+        pdfShellBottomSheets(widget.bottomSheets),
+      // the redock drop zones sit above everything while a panel is being
+      // dragged, so a panel can be dropped onto any edge - even over the
+      // toolbar or another panel
+      if (widget.onPanelDock != null && _dragging)
+        Positioned.fill(
+          child: _PanelDropZones(onPanelDock: widget.onPanelDock!),
+        ),
     ]);
 
-    return Column(children: [
+    Widget result = Column(children: [
       Expanded(child: content),
-      if (dockedToolbar != null) dockedToolbar!,
+      if (widget.dockedToolbar != null) widget.dockedToolbar!,
     ]);
+    if (widget.onPanelDock != null) {
+      // the panels below read this to drive the drag: their move handles
+      // toggle the drop zones on and off.
+      result = PdfPanelDragScope(
+        onDragStarted: () => _setDragging(true),
+        onDragEnded: () => _setDragging(false),
+        child: result,
+      );
+    }
+    return result;
+  }
+}
+
+/// The four edge drop targets shown while a panel is being dragged. Dropping
+/// the panel onto one redocks it to that edge.
+class _PanelDropZones extends StatelessWidget {
+  const _PanelDropZones({required this.onPanelDock});
+
+  final void Function(PdfDockablePanel panel, PdfPanelDock dock) onPanelDock;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      // edge bands sized to a fraction of the area, capped so they stay
+      // legible targets without swallowing the whole viewer
+      final bandW = (constraints.maxWidth * 0.18).clamp(72.0, 200.0).toDouble();
+      final bandH =
+          (constraints.maxHeight * 0.18).clamp(56.0, 160.0).toDouble();
+      return Stack(children: [
+        Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: bandW,
+          child: _DropTarget(dock: PdfPanelDock.left, onPanelDock: onPanelDock),
+        ),
+        Positioned(
+          right: 0,
+          top: 0,
+          bottom: 0,
+          width: bandW,
+          child:
+              _DropTarget(dock: PdfPanelDock.right, onPanelDock: onPanelDock),
+        ),
+        // top/bottom bands inset horizontally so they never overlap the
+        // left/right bands at the corners
+        Positioned(
+          left: bandW,
+          right: bandW,
+          top: 0,
+          height: bandH,
+          child: _DropTarget(dock: PdfPanelDock.top, onPanelDock: onPanelDock),
+        ),
+        Positioned(
+          left: bandW,
+          right: bandW,
+          bottom: 0,
+          height: bandH,
+          child:
+              _DropTarget(dock: PdfPanelDock.bottom, onPanelDock: onPanelDock),
+        ),
+      ]);
+    });
+  }
+}
+
+class _DropTarget extends StatelessWidget {
+  const _DropTarget({required this.dock, required this.onPanelDock});
+
+  final PdfPanelDock dock;
+  final void Function(PdfDockablePanel panel, PdfPanelDock dock) onPanelDock;
+
+  IconData get _icon => switch (dock) {
+        PdfPanelDock.left => Icons.west,
+        PdfPanelDock.right => Icons.east,
+        PdfPanelDock.top => Icons.north,
+        PdfPanelDock.bottom => Icons.south,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return DragTarget<PdfDockablePanel>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (details) => onPanelDock(details.data, dock),
+      builder: (context, candidate, rejected) {
+        final active = candidate.isNotEmpty;
+        return AnimatedContainer(
+          key: ValueKey('pdf-shell-dropzone-${dock.name}'),
+          duration: const Duration(milliseconds: 120),
+          margin: const EdgeInsets.all(6),
+          decoration: BoxDecoration(
+            color: (active ? scheme.primary : scheme.primaryContainer)
+                .withValues(alpha: active ? 0.35 : 0.18),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: active
+                  ? scheme.primary
+                  : scheme.primary.withValues(
+                      alpha: 0.4,
+                    ),
+              width: active ? 2 : 1,
+            ),
+          ),
+          child: Center(
+            child: Icon(_icon,
+                color: active ? scheme.primary : scheme.onPrimaryContainer,
+                size: active ? 32 : 26),
+          ),
+        );
+      },
+    );
   }
 }
 
@@ -549,8 +706,7 @@ class PdfShellBar extends StatelessWidget {
                 child: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   child: ConstrainedBox(
-                    constraints:
-                        BoxConstraints(minWidth: constraints.maxWidth),
+                    constraints: BoxConstraints(minWidth: constraints.maxWidth),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [

--- a/packages/dart_pdf_editor/test/benchmark_panel_frame_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_panel_frame_test.dart
@@ -26,9 +26,9 @@ void main() {
               alignment: Alignment.topLeft,
               child: PdfSearchResultsPanel(
                 controller: controller,
-                side: generation.isEven
-                    ? PdfSidebarSide.left
-                    : PdfSidebarSide.right,
+                dock: generation.isEven
+                    ? PdfPanelDock.left
+                    : PdfPanelDock.right,
                 bottomSheet: generation % 3 == 0,
               ),
             ),

--- a/packages/dart_pdf_editor/test/editing_panel_frame_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panel_frame_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   Widget host({
-    required PdfSidebarSide side,
+    required PdfPanelDock dock,
     bool bottomSheet = false,
     ValueChanged<double>? onPersistWidth,
     VoidCallback? onClose,
@@ -23,7 +23,7 @@ void main() {
                 maxWidth: 320,
                 persistedWidth: null,
                 onPersistWidth: onPersistWidth,
-                side: side,
+                dock: dock,
                 resizable: true,
                 bottomSheet: bottomSheet,
                 gripKey: const ValueKey('frame-grip'),
@@ -50,7 +50,7 @@ void main() {
     addTearDown(scroll.dispose);
 
     await tester.pumpWidget(host(
-      side: PdfSidebarSide.left,
+      dock: PdfPanelDock.left,
       builder: (context, value) {
         geometry = value;
         return value.withScrollbar(
@@ -69,7 +69,7 @@ void main() {
     expect(leftGrip.dx, closeTo(236, 0.1));
 
     await tester.pumpWidget(host(
-      side: PdfSidebarSide.right,
+      dock: PdfPanelDock.right,
       builder: (context, value) {
         geometry = value;
         return const SizedBox.expand();
@@ -87,7 +87,7 @@ void main() {
     var writes = 0;
     double? persisted;
     await tester.pumpWidget(host(
-      side: PdfSidebarSide.left,
+      dock: PdfPanelDock.left,
       onPersistWidth: (value) {
         writes++;
         persisted = value;
@@ -112,7 +112,7 @@ void main() {
       (tester) async {
     var closes = 0;
     await tester.pumpWidget(host(
-      side: PdfSidebarSide.left,
+      dock: PdfPanelDock.left,
       onClose: () => closes++,
     ));
     await tester.tap(find.byKey(const ValueKey('frame-close')));
@@ -120,7 +120,7 @@ void main() {
     expect(find.byKey(const ValueKey('frame-grip')), findsOneWidget);
 
     await tester.pumpWidget(host(
-      side: PdfSidebarSide.left,
+      dock: PdfPanelDock.left,
       bottomSheet: true,
       onClose: () => closes++,
     ));

--- a/packages/dart_pdf_editor/test/editing_panels_test.dart
+++ b/packages/dart_pdf_editor/test/editing_panels_test.dart
@@ -537,7 +537,7 @@ void main() {
             PdfAnnotationSidebar(
               controller: editing,
               viewerController: viewer,
-              side: PdfSidebarSide.left,
+              dock: PdfPanelDock.left,
             ),
             const Expanded(child: SizedBox()),
           ]),

--- a/packages/dart_pdf_editor/test/panel_dock_test.dart
+++ b/packages/dart_pdf_editor/test/panel_dock_test.dart
@@ -1,0 +1,186 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Draggable/dockable panels: each panel remembers which edge it is docked
+// on (left/right/top/bottom), the choice persists, and a panel's move handle
+// can be dragged onto another edge to redock it live.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> pump(WidgetTester tester, Widget body) async {
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: body)));
+    await tester.pump();
+  }
+
+  group('dock preferences', () {
+    test('default docks reproduce the built-in layout', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      await prefs.ready;
+      expect(prefs.thumbnailSidebarDock, PdfPanelDock.left);
+      expect(prefs.searchPanelDock, PdfPanelDock.left);
+      expect(prefs.bookmarkSidebarDock, PdfPanelDock.left);
+      expect(prefs.annotationSidebarDock, PdfPanelDock.right);
+      expect(prefs.propertiesPanelDock, PdfPanelDock.right);
+    });
+
+    test('a redocked layout persists and a fresh instance restores it',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final a = PdfEditingPreferences();
+      addTearDown(a.dispose);
+      await a.ready;
+      a.thumbnailSidebarDock = PdfPanelDock.top;
+      a.searchPanelDock = PdfPanelDock.bottom;
+      a.annotationSidebarDock = PdfPanelDock.left;
+      a.propertiesPanelDock = PdfPanelDock.top;
+      await pumpEventQueue(); // let the unawaited writes land
+
+      final b = PdfEditingPreferences();
+      addTearDown(b.dispose);
+      await b.ready;
+      expect(b.thumbnailSidebarDock, PdfPanelDock.top);
+      expect(b.searchPanelDock, PdfPanelDock.bottom);
+      expect(b.annotationSidebarDock, PdfPanelDock.left);
+      expect(b.propertiesPanelDock, PdfPanelDock.top);
+      // untouched panels keep their defaults
+      expect(b.bookmarkSidebarDock, PdfPanelDock.left);
+    });
+
+    test('setting a dock to its current value writes nothing new', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = PdfEditingPreferences();
+      addTearDown(prefs.dispose);
+      await prefs.ready;
+      var notifications = 0;
+      prefs.addListener(() => notifications++);
+      prefs.annotationSidebarDock = PdfPanelDock.right; // already the default
+      expect(notifications, 0);
+      prefs.annotationSidebarDock = PdfPanelDock.top;
+      expect(notifications, 1);
+    });
+  });
+
+  group('PdfPanelDock', () {
+    test('left/right are horizontal, top/bottom are not', () {
+      expect(PdfPanelDock.left.isHorizontal, isTrue);
+      expect(PdfPanelDock.right.isHorizontal, isTrue);
+      expect(PdfPanelDock.top.isHorizontal, isFalse);
+      expect(PdfPanelDock.bottom.isHorizontal, isFalse);
+    });
+  });
+
+  group('vertical dock frame', () {
+    testWidgets('a top dock lays out as a fixed-height strip', (tester) async {
+      await pump(
+        tester,
+        SizedBox(
+          width: 500,
+          height: 400,
+          child: Column(children: [
+            PdfSidebarPanelFrame(
+              width: 180,
+              minWidth: 120,
+              maxWidth: 260,
+              dock: PdfPanelDock.top,
+              resizable: true,
+              bottomSheet: false,
+              gripKey: const ValueKey('v-grip'),
+              builder: (context, geometry) => const ColoredBox(
+                key: ValueKey('v-content'),
+                color: Colors.white,
+              ),
+            ),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      );
+      // the strip spans the full width and is bounded to its extent in height
+      final size = tester.getSize(find.byType(PdfSidebarPanelFrame));
+      expect(size.height, 180);
+      expect(size.width, 500);
+      // its grip is the horizontal (row-resize) variant, not the column one
+      expect(find.byKey(const ValueKey('v-grip')), findsOneWidget);
+    });
+  });
+
+  group('drag to redock', () {
+    testWidgets('dragging a panel handle onto the top zone redocks it',
+        (tester) async {
+      final prefs = PdfEditingPreferences()..showAnnotationSidebar = true;
+      addTearDown(prefs.dispose);
+      await prefs.ready;
+      await pump(
+        tester,
+        PdfEditorView(bytes: buildMultiPagePdf(2), preferences: prefs),
+      );
+      await tester.pump();
+
+      // the annotation panel starts docked on the right (the default)
+      expect(prefs.annotationSidebarDock, PdfPanelDock.right);
+      final handle = find.byKey(const ValueKey('pdf-annotation-panel-move'));
+      expect(handle, findsOneWidget);
+      // no drop zones until a drag is underway
+      expect(
+          find.byKey(const ValueKey('pdf-shell-dropzone-top')), findsNothing);
+
+      final gesture = await tester.startGesture(tester.getCenter(handle));
+      // move past the touch slop to start the Draggable's drag
+      await gesture.moveBy(const Offset(0, -24));
+      await tester.pump(const Duration(milliseconds: 40));
+
+      // the four edge drop zones appear while dragging
+      final topZone = find.byKey(const ValueKey('pdf-shell-dropzone-top'));
+      expect(topZone, findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-dropzone-left')),
+          findsOneWidget);
+
+      await gesture.moveTo(tester.getCenter(topZone));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      // the panel is now docked on the top edge, and the choice is persisted
+      expect(prefs.annotationSidebarDock, PdfPanelDock.top);
+      // dropping ends the drag, so the zones are gone again
+      expect(
+          find.byKey(const ValueKey('pdf-shell-dropzone-top')), findsNothing);
+      // the panel is still present (its search field survives the move)
+      expect(
+          find.byKey(const ValueKey('pdf-annotation-search')), findsOneWidget);
+      await tester.pump(const Duration(seconds: 1));
+    });
+
+    testWidgets('a panel outside a drag scope shows no move handle',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await pump(
+        tester,
+        Row(children: [
+          PdfAnnotationSidebar(
+            controller: editing,
+            viewerController: viewer,
+            onClose: () {},
+          ),
+          const Expanded(child: SizedBox()),
+        ]),
+      );
+      await tester.pump();
+      // the close button renders, but the move handle stays inert with no
+      // shell drag scope around it
+      expect(find.byKey(const ValueKey('pdf-annotation-panel-close')),
+          findsOneWidget);
+      final handle = find.byKey(const ValueKey('pdf-annotation-panel-move'));
+      expect(handle, findsOneWidget);
+      expect(find.descendant(of: handle, matching: find.byType(Draggable)),
+          findsNothing);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/panel_dock_test.dart
+++ b/packages/dart_pdf_editor/test/panel_dock_test.dart
@@ -1,4 +1,7 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+// PdfShellPanelLayout / PdfPanelTabGroup are shell-internal (not exported);
+// reach them directly for these composition tests.
+import 'package:dart_pdf_editor/src/shell_chrome.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
@@ -181,6 +184,131 @@ void main() {
       expect(handle, findsOneWidget);
       expect(find.descendant(of: handle, matching: find.byType(Draggable)),
           findsNothing);
+    });
+  });
+
+  group('tab groups', () {
+    test('group ids default to standalone and persist', () async {
+      SharedPreferences.setMockInitialValues({});
+      final a = PdfEditingPreferences();
+      addTearDown(a.dispose);
+      await a.ready;
+      // every panel starts in its own group (all side-by-side)
+      final groups = {
+        for (final p in PdfDockablePanel.values) a.panelGroup(p),
+      };
+      expect(groups.length, PdfDockablePanel.values.length);
+
+      // tab properties into annotations' group
+      a.setPanelGroup(PdfDockablePanel.properties,
+          a.panelGroup(PdfDockablePanel.annotations));
+      await pumpEventQueue();
+
+      final b = PdfEditingPreferences();
+      addTearDown(b.dispose);
+      await b.ready;
+      expect(b.panelGroup(PdfDockablePanel.properties),
+          b.panelGroup(PdfDockablePanel.annotations));
+    });
+
+    testWidgets(
+        'dropping a panel onto another tabs them, dragging a tab out '
+        'to an edge splits it back', (tester) async {
+      final prefs = PdfEditingPreferences()
+        ..showAnnotationSidebar = true
+        ..showPropertiesPanel = true;
+      addTearDown(prefs.dispose);
+      await prefs.ready;
+      await pump(
+        tester,
+        PdfEditorView(bytes: buildMultiPagePdf(2), preferences: prefs),
+      );
+      await tester.pump();
+
+      // annotations + properties start side-by-side on the right (two frames,
+      // no tab group yet)
+      expect(find.byType(PdfPanelTabGroup), findsNothing);
+      final propsHandle =
+          find.byKey(const ValueKey('pdf-properties-panel-move'));
+      final annotationsPanel =
+          find.byKey(const ValueKey('pdf-shell-annotations-docked'));
+      expect(propsHandle, findsOneWidget);
+      expect(annotationsPanel, findsOneWidget);
+
+      // drag the properties handle onto the annotations panel body -> tab them
+      var gesture = await tester.startGesture(tester.getCenter(propsHandle));
+      await gesture.moveBy(const Offset(-24, 0));
+      await tester.pump(const Duration(milliseconds: 40));
+      await gesture.moveTo(tester.getCenter(annotationsPanel));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      // they now share a group and render as one tabbed panel
+      expect(prefs.panelGroup(PdfDockablePanel.properties),
+          prefs.panelGroup(PdfDockablePanel.annotations));
+      expect(prefs.propertiesPanelDock, PdfPanelDock.right);
+      expect(find.byType(PdfPanelTabGroup), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-panel-tab-annotations')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-panel-tab-properties')),
+          findsOneWidget);
+
+      // now drag the properties tab onto the left edge zone -> split it out
+      final tab = find.byKey(const ValueKey('pdf-panel-tab-properties'));
+      await tester.ensureVisible(tab); // the tab strip scrolls; reveal it
+      await tester.pump();
+      gesture = await tester.startGesture(tester.getCenter(tab));
+      await gesture.moveBy(const Offset(-24, 0));
+      await tester.pump(const Duration(milliseconds: 40));
+      final leftZone = find.byKey(const ValueKey('pdf-shell-dropzone-left'));
+      expect(leftZone, findsOneWidget);
+      await gesture.moveTo(tester.getCenter(leftZone));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      // properties moved to the left, standalone (its own group again), so the
+      // tab group is gone
+      expect(prefs.propertiesPanelDock, PdfPanelDock.left);
+      expect(prefs.panelGroup(PdfDockablePanel.properties),
+          prefs.standalonePanelGroup(PdfDockablePanel.properties));
+      expect(find.byType(PdfPanelTabGroup), findsNothing);
+      await tester.pump(const Duration(seconds: 1));
+    });
+
+    testWidgets('tapping a tab switches the visible panel', (tester) async {
+      final prefs = PdfEditingPreferences()
+        ..showAnnotationSidebar = true
+        ..showPropertiesPanel = true;
+      addTearDown(prefs.dispose);
+      await prefs.ready;
+      // pre-tab annotations + properties into one group on the right
+      prefs.setPanelGroup(PdfDockablePanel.properties,
+          prefs.panelGroup(PdfDockablePanel.annotations));
+      await pump(
+        tester,
+        PdfEditorView(bytes: buildMultiPagePdf(2), preferences: prefs),
+      );
+      await tester.pump();
+
+      expect(find.byType(PdfPanelTabGroup), findsOneWidget);
+      // the first tab (annotations) is selected: its search field shows
+      expect(
+          find.byKey(const ValueKey('pdf-annotation-search')), findsOneWidget);
+
+      final propsTab = find.byKey(const ValueKey('pdf-panel-tab-properties'));
+      await tester.ensureVisible(propsTab); // the tab strip scrolls; reveal it
+      await tester.pump();
+      await tester.tap(propsTab);
+      await tester.pump();
+      // properties tab body is now shown (its "select an annotation" empty
+      // state), and the tabs are still both present
+      expect(find.byKey(const ValueKey('pdf-panel-tab-annotations')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-panel-tab-properties')),
+          findsOneWidget);
+      await tester.pump(const Duration(seconds: 1));
     });
   });
 }


### PR DESCRIPTION
## Summary

The editor's side panels (Pages/thumbnails, Search results, Bookmarks, Annotations, Properties) could only sit left or right, and only implicitly — placement was decided by the hard-coded `leadingPanels`/`trailingPanels` lists in the shell. This PR makes the panel layout fully user-arrangeable by drag, and **persists it**:

1. **Dock to any edge** — drag a panel's handle onto a left/right/top/bottom drop zone.
2. **Side-by-side or tab groups** — drop one panel onto another (IDE-style) to combine them into a tab group; drag a tab back out to an edge to split it into its own side-by-side panel.

Each docked panel shows a drag handle (⣿) next to its close button. Grabbing a handle (or a tab) reveals four translucent edge drop zones; the panel's body also becomes a "Tab here" drop target. All placement is saved per panel via `PdfEditingPreferences`, so the layout is restored on reopen.

### Docking (edges)
- **`PdfPanelDock { left, right, top, bottom }`** is the placement concept. `isHorizontal` distinguishes fixed-width columns (left/right) from fixed-height strips (top/bottom); `gripSide` maps a horizontal dock to the resize grip's existing `PdfSidebarSide`. **`PdfDockablePanel`** identifies each panel and is the drag payload.
- **`PdfSidebarPanelFrame`** takes a `dock` instead of a `side`: horizontal docks render as before; vertical docks render as a fixed-height strip with a new vertical resize grip. Its geometry gains `moveHandle()` — a `Draggable` that stays inert unless a `PdfPanelDragScope` is in scope.
- **`PdfShellPanelLayout`** gains `topPanels`/`bottomPanels` and an `onPanelDock` callback; while a drag is underway it overlays four edge drop zones.

### Tab groups
- Each panel carries a persisted **tab-group id** (default = its own index → every panel standalone). Panels sharing both a dock and a group id render as one tabbed panel; a panel alone in its group is standalone.
- **`PdfPanelTabGroup`** hosts a tab group in one shared frame (extent + grip, persisted per dock) with a scrollable strip of draggable, closable tabs over an `IndexedStack` (bodies stay mounted, so tab state survives switching). Tab bodies reuse the panels' chromeless bottom-sheet content mode.
- **`PdfPanelTabDropRegion`** wraps each dock child so dropping another panel onto it joins that panel's group; edge bands were narrowed (~10%, 56–96 px) so an already-docked panel keeps a reachable inner tab target.
- **`pdf_editor_view.dart`** partitions each dock's visible panels by group id into standalone panels or tab groups, and writes dock/group on drop; the pref change re-routes panels on the next build.

Existing per-panel drag-to-resize widths are reused as the cross-axis extent.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze --fatal-infos` (clean across the whole workspace, incl. `app/`)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (panel/shell/preferences suites + new `panel_dock_test.dart`)

New `test/panel_dock_test.dart` covers: dock defaults + persistence round-trip, `PdfPanelDock.isHorizontal`, the vertical-strip frame, an end-to-end drag of a panel handle onto the top drop zone, tab-group defaults + persistence, drag-panel-onto-panel → tabbed, drag-tab-to-edge → split, and tab selection. Existing `editing_panel_frame_test.dart` / `editing_panels_test.dart` / `benchmark_panel_frame_test.dart` were updated for the `side` → `dock` rename and pass. The root app's DevTools panel was updated for the same rename.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` ← `pdf_document` ← `pdf_graphics` ← `dart_pdf_editor`.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

- `PdfSidebarSide { left, right }` is kept — it remains the resize grip's and the comparison navigator's horizontal-only orientation. The frame's `width/minWidth/maxWidth` now mean the panel's cross-axis extent (column width for left/right, strip height for top/bottom).
- Drop-target disambiguation is geometric: the thin edge bands (painted on top) win at the extreme edges → dock standalone; a panel's inner body (past the band) wins → tab. The two highlights are mutually exclusive by position.
- Panels moving between docks/groups **remount** (ValueKeys only match within one parent) — the same safe path the docked/sheet variants already rely on to avoid mid-layout `OverlayPortal`/Tooltip reactivation in the thumbnail tiles.
- **Follow-up:** the view-only reader shell (`pdf_reader.dart`) is intentionally unchanged — it passes no `onPanelDock`, so its panels keep their default docks and show no move handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CztjhbNX1mcrfa4puvohmo