### PR TITLE
perf(#359): open local files through the ranged byte source — first paint without reading the whole file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,14 @@
             "deviceId": "chrome"
         },
         {
+            "name": "DartPDF app (release)",
+            "type": "dart",
+            "request": "launch",
+            "cwd": "app",
+            "program": "lib/main.dart",
+            "flutterMode": "release"
+        },
+        {
             "name": "Example app",
             "type": "dart",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,14 +17,6 @@
             "deviceId": "chrome"
         },
         {
-            "name": "DartPDF app (release)",
-            "type": "dart",
-            "request": "launch",
-            "cwd": "app",
-            "program": "lib/main.dart",
-            "flutterMode": "release"
-        },
-        {
             "name": "Example app",
             "type": "dart",
             "request": "launch",

--- a/README.md
+++ b/README.md
@@ -113,9 +113,29 @@ final source = PdfHttpByteSource(
 final document = await PdfDocument.openSource(source);
 ```
 
+For an even faster first paint on a big, image-heavy document (a scan, a CAD
+sheet), pass `firstPaintPages` so the loader fetches only the first page's
+bytes, paints it, and lets you stream the rest in behind it:
+
+```dart
+final preview = await PdfDocument.openSource(
+  source,
+  options: PdfSourceLoadOptions(
+    firstPaintPages: 1,
+    onProgress: (received, total) => report(received, total),
+  ),
+);
+// `preview` renders the first page immediately, but its buffer is deliberately
+// incomplete - render-only, never edit or sign from it. Read the whole source
+// in the background and reopen for the full document when you need every page.
+```
+
 `PdfByteSource` is network-agnostic (`length` + `readRange`), so any random-
-access transport works; `PdfDocument.open(Uint8List)` and the byte-based widgets
-are unchanged. See [`doc/dev-log`](doc/dev-log) for the loader design.
+access transport works - including a local file. `PdfDocument.open(Uint8List)`
+and the byte-based widgets are unchanged. See
+[`doc/progressive-loading.md`](doc/progressive-loading.md) for the full guide
+(local files, the fast-first-paint pattern, Flutter viewer wiring) and
+[`doc/dev-log`](doc/dev-log) for the loader design.
 
 For OCR, add one engine package and call `PdfEditor.applyOcr` before opening
 or replacing the document in your viewer:

--- a/app/lib/document_tab.dart
+++ b/app/lib/document_tab.dart
@@ -60,6 +60,27 @@ class DocumentTab {
         isLoading = false,
         deferredBytes = bytes;
 
+  /// A file-backed document known only by its path (session restore), with no
+  /// bytes read yet: reading and rendering are postponed until the tab is first
+  /// shown, when it opens *progressively* (see [EditorScreen] materialization).
+  /// This keeps launch cheap even when the last session held several big
+  /// cloud-synced files - only the active tab pulls any bytes, and it first-
+  /// paints from ranges rather than waiting on a whole-file read.
+  DocumentTab.deferredPath({
+    required this.title,
+    this.originPath,
+    this.originBookmark,
+    this.cachePath,
+  })  : session = null,
+        viewer = null,
+        savedLength = 0,
+        error = null,
+        compareBefore = null,
+        compareAfter = null,
+        isLoading = false {
+    _deferredPath = true;
+  }
+
   /// A read-only first paint from a progressive open: the ranged loader has
   /// assembled just enough of the file to render (a sparse buffer - live
   /// objects present, free space still zero), so the viewer paints in ~1-2 s
@@ -127,6 +148,12 @@ class DocumentTab {
 
   /// True while this tab holds bytes it has not yet parsed into a session.
   bool get isDeferred => deferredBytes != null;
+
+  bool _deferredPath = false;
+
+  /// True while this tab knows only its path and has read no bytes yet - it
+  /// opens progressively the first time it is shown (see [DocumentTab.deferredPath]).
+  bool get isDeferredPath => _deferredPath;
 
   /// The read-only document rendered during a progressive first paint (see
   /// [DocumentTab.preview]); null on every other kind.

--- a/app/lib/document_tab.dart
+++ b/app/lib/document_tab.dart
@@ -1,11 +1,14 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
+import 'package:pdf_document/pdf_document.dart';
 
 /// One open document. Holds its own edit session and viewer controller so
 /// switching tabs preserves edits, undo history, and scroll position.
 ///
-/// A tab is one of four kinds: a normal editable [document], a [loading]
-/// placeholder, an [error] placeholder, or a two-file [comparison].
+/// A tab is one of five kinds: a normal editable [document], a [loading]
+/// placeholder, a read-only [preview] painting from a progressive first paint
+/// while the full bytes stream in, an [error] placeholder, or a two-file
+/// [comparison].
 class DocumentTab {
   DocumentTab.loading(
       {required this.title,
@@ -57,6 +60,34 @@ class DocumentTab {
         isLoading = false,
         deferredBytes = bytes;
 
+  /// A read-only first paint from a progressive open: the ranged loader has
+  /// assembled just enough of the file to render (a sparse buffer - live
+  /// objects present, free space still zero), so the viewer paints in ~1-2 s
+  /// even from a slow cloud-synced file while the complete bytes stream in
+  /// behind it. [progress] tracks that background full read (0-1); [cancel]
+  /// aborts both the read and any in-flight ranged fetch when the tab closes.
+  /// When the full bytes land the app swaps this for a real
+  /// [DocumentTab.document] (see EditorScreen), so edit affordances (Save,
+  /// Digitally sign) light up only once the whole file is in hand.
+  DocumentTab.preview({
+    required this.title,
+    required PdfDocument document,
+    required Uint8List previewBytes,
+    required this.progress,
+    required this.cancel,
+    this.originPath,
+    this.originBookmark,
+    this.cachePath,
+  })  : session = null,
+        viewer = PdfViewerController(),
+        previewDocument = document,
+        _previewBytes = previewBytes,
+        savedLength = 0,
+        error = null,
+        compareBefore = null,
+        compareAfter = null,
+        isLoading = false;
+
   DocumentTab.error({required this.title, required this.error})
       : session = null,
         viewer = null,
@@ -96,6 +127,27 @@ class DocumentTab {
 
   /// True while this tab holds bytes it has not yet parsed into a session.
   bool get isDeferred => deferredBytes != null;
+
+  /// The read-only document rendered during a progressive first paint (see
+  /// [DocumentTab.preview]); null on every other kind.
+  PdfDocument? previewDocument;
+
+  /// The sparse buffer the [previewDocument] renders from.
+  Uint8List? _previewBytes;
+
+  /// The sparse bytes a [preview] tab paints from until the full read lands.
+  Uint8List? get previewBytes => _previewBytes;
+
+  /// Progress (0-1) of the background full read behind a [preview] first paint.
+  ValueNotifier<double>? progress;
+
+  /// Cancels the progressive load (ranged fetch + background full read) when a
+  /// [preview] tab is closed before its full bytes arrive.
+  PdfCancelToken? cancel;
+
+  /// True while this tab is a read-only progressive first paint awaiting its
+  /// complete bytes.
+  bool get isPreview => previewDocument != null;
 
   /// Guards against kicking off materialization more than once while the
   /// placeholder frame is still on screen (build can run several times).
@@ -151,6 +203,10 @@ class DocumentTab {
   String get documentId => title;
 
   void dispose() {
+    // Closing a still-loading preview cancels its ranged fetch and background
+    // full read so a closed tab stops pulling bytes.
+    cancel?.cancel();
+    progress?.dispose();
     session?.dispose();
     viewer?.dispose();
   }

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -157,6 +157,11 @@ class _EditorScreenState extends State<EditorScreen>
   /// before [_restoreSession] has had a chance to re-open it.
   bool _sessionLoaded = false;
 
+  /// True while [_restoreSession] is re-adding the last session's tabs, so a
+  /// restored path-only tab that is briefly active mid-restore does not start
+  /// opening. Only the tab active when restore finishes materializes.
+  bool _restoringSession = false;
+
   /// The update checker, owned here unless the host injected one.
   late final UpdateService _updates =
       widget.updateService ?? UpdateService(currentVersion: AppInfo.version);
@@ -322,16 +327,27 @@ class _EditorScreenState extends State<EditorScreen>
   Future<void> _restoreSession() async {
     final documents = await _session.load();
     if (mounted && !_hasExplicitLaunchTarget) {
-      for (final doc in documents) {
-        // Skip anything already open (e.g. an OS file-open that arrived first).
-        final key = doc.readPath;
-        if (key != null &&
-            _tabs.any((t) => t.originPath == key || t.cachePath == key)) {
-          continue;
+      // Suppress lazy materialization while restoring: each tab is briefly the
+      // active one as it is added, and we don't want every restored file to
+      // start opening. Only the tab left active when restore finishes should
+      // materialize (see _buildBody / _materializeDeferredPath).
+      _restoringSession = true;
+      try {
+        for (final doc in documents) {
+          // Skip anything already open (e.g. an OS file-open that arrived first).
+          final key = doc.readPath;
+          if (key != null &&
+              _tabs.any((t) => t.originPath == key || t.cachePath == key)) {
+            continue;
+          }
+          await _reopenSessionDocument(doc);
+          if (!mounted) return;
         }
-        await _reopenSessionDocument(doc);
-        if (!mounted) return;
+      } finally {
+        _restoringSession = false;
       }
+      // Let the tab left active materialize now that restore is done.
+      if (mounted) setState(() {});
     }
     _sessionLoaded = true;
     unawaited(_persistSession());
@@ -343,6 +359,42 @@ class _EditorScreenState extends State<EditorScreen>
     // Desktop restores by its writable origin; a mobile pick has none and
     // restores from its private snapshot instead.
     final originPath = doc.path.isNotEmpty ? doc.path : null;
+
+    // Desktop origin: restore lazily and progressively. Probe the file length
+    // first - cheap metadata, no content read or cloud hydration - so a moved
+    // or deleted file is still dropped silently, then add a path-only tab that
+    // reads nothing until it is shown, when it opens progressively. This keeps
+    // launch cheap even when the last session held several big files: only the
+    // active tab pulls bytes, and it first-paints from ranges.
+    if (progressiveOpenSupported(originPath)) {
+      final source =
+          pdfByteSourceForPath(originPath!, bookmark: doc.bookmark);
+      int? length;
+      try {
+        length = await source.length;
+      } catch (_) {
+        length = null;
+      } finally {
+        await source.close();
+      }
+      if (!mounted) return;
+      if (length == null || length <= 0) return; // gone: drop silently
+      _addTab(DocumentTab.deferredPath(
+        title: doc.title,
+        originPath: originPath,
+        originBookmark: doc.bookmark,
+        cachePath: doc.cachePath,
+      ));
+      _recents.add(
+          title: doc.title,
+          path: originPath,
+          cachePath: doc.cachePath,
+          bookmark: doc.bookmark);
+      return;
+    }
+
+    // Snapshot-only restore (mobile private cache, or a platform without
+    // progressive open): read the bytes and defer only the parse.
     final loading = _openLoading(
       doc.title,
       originPath: originPath,
@@ -580,6 +632,27 @@ class _EditorScreenState extends State<EditorScreen>
     });
   }
 
+  /// Opens a [DocumentTab.deferredPath] (a session-restored file known only by
+  /// its path) the first time it is shown, progressively and in place. The read
+  /// starts after the placeholder paints, so landing on a restored tab feels
+  /// like a fresh progressive open - and restored tabs the user never visits
+  /// never read a byte.
+  void _materializeDeferredPath(DocumentTab tab) {
+    if (tab.materializing) return;
+    tab.materializing = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted || !_tabs.contains(tab) || tab.originPath == null) return;
+      await _openProgressive(
+        title: tab.title,
+        path: tab.originPath!,
+        bookmark: tab.originBookmark,
+        cachePath: tab.cachePath,
+        into: tab,
+      );
+    });
+  }
+
   /// Opens a file-backed document progressively: the ranged loader assembles
   /// just the header/xref/live-object bytes needed to render, so the viewer
   /// paints read-only in ~1-2 s even from a slow cloud-synced file, then the
@@ -592,19 +665,25 @@ class _EditorScreenState extends State<EditorScreen>
   /// of the app uses if the progressive first paint can't be assembled, so
   /// nothing a normal open handles regresses. Desktop only (see
   /// [progressiveOpenSupported]); [onOpenFailed] lets recents drop a stale entry.
+  ///
+  /// Pass [into] to reuse an existing placeholder tab (a lazily-materialized
+  /// [DocumentTab.deferredPath] from session restore) instead of adding a fresh
+  /// loading tab.
   Future<void> _openProgressive({
     required String title,
     required String path,
     String? bookmark,
     String? cachePath,
     void Function(Object error)? onOpenFailed,
+    DocumentTab? into,
   }) async {
-    final loading = _openLoading(
-      title,
-      originPath: path,
-      originBookmark: bookmark,
-      cachePath: cachePath,
-    );
+    final loading = into ??
+        _openLoading(
+          title,
+          originPath: path,
+          originBookmark: bookmark,
+          cachePath: cachePath,
+        );
     final cancel = PdfCancelToken();
     final progress = ValueNotifier<double>(0);
     final source = pdfByteSourceForPath(path, bookmark: bookmark, cancelToken: cancel);
@@ -2007,6 +2086,13 @@ class _EditorScreenState extends State<EditorScreen>
         onOpen: _pickAndOpen,
         onOpenRecent: _openRecent,
       );
+    }
+    if (tab.isDeferredPath) {
+      // First time we show a restored path-only tab: open it progressively
+      // (after this frame), showing the placeholder meanwhile. Held off while
+      // the session is still restoring, so only the finally-active tab opens.
+      if (!_restoringSession) _materializeDeferredPath(tab);
+      return _OpeningDocument(title: tab.title);
     }
     if (tab.isDeferred) {
       // First time we show a deferred tab: parse it (after this frame) and

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -580,6 +580,208 @@ class _EditorScreenState extends State<EditorScreen>
     });
   }
 
+  /// Opens a file-backed document progressively: the ranged loader assembles
+  /// just the header/xref/live-object bytes needed to render, so the viewer
+  /// paints read-only in ~1-2 s even from a slow cloud-synced file, then the
+  /// complete bytes stream in behind that first paint and the tab swaps to a
+  /// full edit session. Save / Digitally sign light up only after the swap
+  /// (a preview tab has no session, so those actions stay disabled meanwhile).
+  ///
+  /// Returns once the first paint (or a fallback full read) is on screen; the
+  /// background read finishes later. Falls back to the plain full read the rest
+  /// of the app uses if the progressive first paint can't be assembled, so
+  /// nothing a normal open handles regresses. Desktop only (see
+  /// [progressiveOpenSupported]); [onOpenFailed] lets recents drop a stale entry.
+  Future<void> _openProgressive({
+    required String title,
+    required String path,
+    String? bookmark,
+    String? cachePath,
+    void Function(Object error)? onOpenFailed,
+  }) async {
+    final loading = _openLoading(
+      title,
+      originPath: path,
+      originBookmark: bookmark,
+      cachePath: cachePath,
+    );
+    final cancel = PdfCancelToken();
+    final progress = ValueNotifier<double>(0);
+    final source = pdfByteSourceForPath(path, bookmark: bookmark, cancelToken: cancel);
+
+    PdfDocument doc;
+    try {
+      doc = await PdfDocument.openSource(source);
+    } on PdfHttpCancelledException {
+      progress.dispose();
+      await source.close();
+      return;
+    } catch (error) {
+      // The progressive first paint could not be assembled (IO error, or a
+      // shape the ranged loader gives up on). Fall back to the plain read the
+      // rest of the app uses, reusing the same loading placeholder.
+      progress.dispose();
+      await source.close();
+      if (!mounted) return;
+      await _fallbackFullOpen(loading,
+          title: title,
+          path: path,
+          bookmark: bookmark,
+          cachePath: cachePath,
+          onOpenFailed: onOpenFailed);
+      return;
+    }
+
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) {
+      progress.dispose();
+      cancel.cancel();
+      await source.close();
+      return;
+    }
+
+    final preview = DocumentTab.preview(
+      title: title,
+      document: doc,
+      previewBytes: doc.cos.bytes,
+      progress: progress,
+      cancel: cancel,
+      originPath: path,
+      originBookmark: bookmark,
+      cachePath: cachePath,
+    );
+    if (!_replaceLoadingTab(loading, preview)) {
+      // The loading tab was closed while opening; preview.dispose() cancels the
+      // load and frees the progress notifier.
+      await source.close();
+      return;
+    }
+    // Record the recent on first paint, so a briefly-opened document still
+    // lands in the list even if it's closed before the full read completes.
+    _recents.add(title: title, path: path, cachePath: cachePath, bookmark: bookmark);
+    AppDevTools.instance.addLog(
+        'progressive open: "$title" first paint — ${doc.pageCount} pages; '
+        'reading full file…');
+
+    // Stream the rest in behind the first paint, then swap to a full session.
+    unawaited(_finishProgressive(preview, source));
+  }
+
+  /// The background half of [_openProgressive]: reads the whole file (reporting
+  /// progress on the preview's [DocumentTab.progress]) and swaps the read-only
+  /// [preview] for a full edit session once the complete bytes land.
+  Future<void> _finishProgressive(
+      DocumentTab preview, PdfByteSource source) async {
+    final progress = preview.progress!;
+    final cancel = preview.cancel!;
+    try {
+      final full = await readSourceFully(
+        source,
+        cancelToken: cancel,
+        onProgress: (received, total) {
+          if (total != null && total > 0) {
+            progress.value = (received / total).clamp(0.0, 1.0);
+          }
+        },
+      );
+      await source.close();
+      if (!mounted) return;
+      if (_swapPreviewToDocument(preview, full)) {
+        AppDevTools.instance.addLog(
+            'progressive open: "${preview.title}" full read complete — '
+            '${full.length} bytes');
+      }
+    } on PdfHttpCancelledException {
+      // The tab was closed mid-read (its dispose fired the token); the preview
+      // is already gone, so there is nothing to swap.
+      await source.close();
+    } catch (error) {
+      await source.close();
+      if (!mounted || !_tabs.contains(preview)) return;
+      // First paint worked but the full read failed. Try the plain read so the
+      // user still gets a fully-editable document where possible; otherwise
+      // surface the error in place of the preview.
+      try {
+        final full = await readPdfAtPath(preview.originPath!,
+            bookmark: preview.originBookmark);
+        if (!mounted) return;
+        _swapPreviewToDocument(preview, full);
+      } catch (error2) {
+        if (!mounted) return;
+        final index = _tabs.indexOf(preview);
+        if (index == -1) return;
+        setState(() => _tabs[index] = DocumentTab.error(
+              title: preview.title,
+              error: 'Could not open ${preview.title}\n$error2',
+            ));
+        preview.dispose();
+      }
+    }
+  }
+
+  /// Replaces the read-only [preview] with a full [DocumentTab.document] built
+  /// from the complete [bytes], in place (keeping the tab's position and, if it
+  /// is active, focus). Returns false if the tab was closed meanwhile.
+  bool _swapPreviewToDocument(DocumentTab preview, Uint8List bytes) {
+    final index = _tabs.indexOf(preview);
+    if (index == -1) return false;
+    setState(() {
+      _tabs[index] = DocumentTab.document(
+        title: preview.title,
+        bytes: bytes,
+        preferences: _prefs,
+        originPath: preview.originPath,
+        originBookmark: preview.originBookmark,
+        cachePath: preview.cachePath,
+      );
+    });
+    preview.dispose();
+    unawaited(_persistSession());
+    return true;
+  }
+
+  /// Reads [path] whole (the app's normal open path) into the [loading] tab -
+  /// the fallback when a progressive first paint can't be assembled.
+  Future<void> _fallbackFullOpen(
+    DocumentTab loading, {
+    required String title,
+    required String path,
+    String? bookmark,
+    String? cachePath,
+    void Function(Object error)? onOpenFailed,
+  }) async {
+    try {
+      final bytes = await readPdfAtPath(path, bookmark: bookmark);
+      await WidgetsBinding.instance.endOfFrame;
+      if (!mounted) return;
+      final opened = _replaceLoadingTab(
+        loading,
+        DocumentTab.document(
+          title: title,
+          bytes: bytes,
+          preferences: _prefs,
+          originPath: path,
+          originBookmark: bookmark,
+          cachePath: cachePath,
+        ),
+      );
+      if (opened) {
+        _recents.add(
+            title: title, path: path, cachePath: cachePath, bookmark: bookmark);
+      }
+    } catch (error) {
+      onOpenFailed?.call(error);
+      if (!mounted) return;
+      _replaceLoadingTab(
+        loading,
+        DocumentTab.error(
+          title: title,
+          error: 'Could not open $title\n$error',
+        ),
+      );
+    }
+  }
+
   Future<void> _pickAndOpen() async {
     try {
       final files = await pickPdfFiles();
@@ -591,13 +793,21 @@ class _EditorScreenState extends State<EditorScreen>
         if (!mounted) return;
         final path = originPathForPickedFile(file);
         final bookmark = await securityBookmarkForPath(path);
-        await _openLoadedBytes(
-          file.readAsBytes(),
-          title: file.name,
-          originPath: path,
-          originBookmark: bookmark,
-          defer: defer,
-        );
+        // A single desktop pick opens progressively (first paint from ranged
+        // reads, full bytes behind it). A batch keeps the deferred whole-file
+        // path so the picker doesn't fan out many concurrent streams.
+        if (!defer && progressiveOpenSupported(path)) {
+          await _openProgressive(
+              title: file.name, path: path!, bookmark: bookmark);
+        } else {
+          await _openLoadedBytes(
+            file.readAsBytes(),
+            title: file.name,
+            originPath: path,
+            originBookmark: bookmark,
+            defer: defer,
+          );
+        }
       }
     } catch (e) {
       _openError('Open failed', 'Could not open the selected file\n$e');
@@ -645,6 +855,13 @@ class _EditorScreenState extends State<EditorScreen>
         return;
       }
     }
+    // An OS-handed file with a real path opens progressively; one delivered as
+    // raw bytes (Android content://, web handle) is already fully in memory.
+    if (file.bytes == null && progressiveOpenSupported(file.path)) {
+      await _openProgressive(
+          title: file.name, path: file.path!, bookmark: file.bookmark);
+      return;
+    }
     await _openLoadedBytes(
       file.bytes == null
           ? readPdfAtPath(file.path!, bookmark: file.bookmark)
@@ -690,13 +907,18 @@ class _EditorScreenState extends State<EditorScreen>
       // we don't treat as a writable origin.
       final path = (!kIsWeb && item.path.isNotEmpty) ? item.path : null;
       final bookmark = await securityBookmarkForPath(path);
-      await _openLoadedBytes(
-        item.readAsBytes(),
-        title: item.name,
-        originPath: path,
-        originBookmark: bookmark,
-        defer: defer,
-      );
+      if (!defer && progressiveOpenSupported(path)) {
+        await _openProgressive(
+            title: item.name, path: path!, bookmark: bookmark);
+      } else {
+        await _openLoadedBytes(
+          item.readAsBytes(),
+          title: item.name,
+          originPath: path,
+          originBookmark: bookmark,
+          defer: defer,
+        );
+      }
     }
   }
 
@@ -774,6 +996,22 @@ class _EditorScreenState extends State<EditorScreen>
     // Desktop reopens by its writable origin; a mobile entry reads back its
     // private snapshot but has no origin, so saves there still go save-as.
     final originPath = entry.path;
+    // A desktop origin reopens progressively - the whole point of #359 is the
+    // big cloud-synced file that took tens of seconds to reopen whole.
+    if (progressiveOpenSupported(originPath)) {
+      await _openProgressive(
+        title: entry.title,
+        path: originPath!,
+        bookmark: entry.bookmark,
+        cachePath: entry.cachePath,
+        onOpenFailed: (_) {
+          unawaited(_recents.remove(entry.id));
+          _pruneRecentCache();
+          _toast('Could not reopen ${entry.title}');
+        },
+      );
+      return;
+    }
     final loading = _openLoading(
       entry.title,
       originPath: originPath,
@@ -1789,6 +2027,16 @@ class _EditorScreenState extends State<EditorScreen>
         after: tab.compareAfter!,
       );
     }
+    if (tab.isPreview) {
+      // A progressive first paint: render the read-only sparse document while
+      // the complete bytes stream in, with a slim progress bar for that read.
+      return _ProgressivePreview(
+        key: ValueKey(tab),
+        tab: tab,
+        preferences: _prefs,
+        onAction: _onAction,
+      );
+    }
     if (_readOnly) {
       return PdfReader(
         key: ValueKey(tab),
@@ -2271,6 +2519,63 @@ class _OpeningDocument extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// The read-only first paint of a progressive open: a [PdfReader] over the
+/// sparse document the ranged loader assembled, with a slim top progress bar
+/// tracking the background full read. When that read lands the host swaps this
+/// for a full [PdfEditorView] (see [EditorScreen._swapPreviewToDocument]), so
+/// Save / Digitally sign appear only once the whole file is in hand.
+class _ProgressivePreview extends StatelessWidget {
+  const _ProgressivePreview({
+    super.key,
+    required this.tab,
+    required this.preferences,
+    required this.onAction,
+  });
+
+  final DocumentTab tab;
+  final PdfEditingPreferences preferences;
+  final PdfActionHandler onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: PdfReader(
+            bytes: tab.previewBytes!,
+            documentId: tab.documentId,
+            controller: tab.viewer,
+            preferences: preferences,
+            onAction: onAction,
+          ),
+        ),
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          child: ValueListenableBuilder<double>(
+            valueListenable: tab.progress!,
+            builder: (context, value, _) {
+              // Hide the bar once the full read is essentially done - the swap
+              // to the edit session is imminent.
+              if (value >= 0.999) return const SizedBox.shrink();
+              return Semantics(
+                label: 'Loading full document',
+                value: '${(value * 100).round()}%',
+                liveRegion: true,
+                child: LinearProgressIndicator(
+                  value: value == 0 ? null : value,
+                  minHeight: 3,
+                ),
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 }

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -690,7 +690,13 @@ class _EditorScreenState extends State<EditorScreen>
 
     PdfDocument doc;
     try {
-      doc = await PdfDocument.openSource(source);
+      // Fetch just the first page's worth of bytes for the read-only first
+      // paint - for an image-heavy scan/CAD file the live objects are the page
+      // images, so fetching every object would be the whole file (tens of
+      // seconds). The background read behind the preview then completes the
+      // buffer for the full edit session.
+      doc = await PdfDocument.openSource(source,
+          options: const PdfSourceLoadOptions(firstPaintPages: 1));
     } on PdfHttpCancelledException {
       progress.dispose();
       await source.close();
@@ -814,7 +820,10 @@ class _EditorScreenState extends State<EditorScreen>
         cachePath: preview.cachePath,
       );
     });
-    preview.dispose();
+    // Dispose the preview's live viewer only after this frame swaps the
+    // read-only PdfReader out of the tree - disposing its controller while the
+    // widget is still mounted would fault its in-flight render.
+    WidgetsBinding.instance.addPostFrameCallback((_) => preview.dispose());
     unawaited(_persistSession());
     return true;
   }

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -291,8 +291,12 @@ Future<Uint8List> readSourceFully(
       final end = pos + chunk < len ? pos + chunk : len;
       final data = await source.readRange(pos, end);
       if (data.isEmpty) break;
-      out.setRange(pos, pos + data.length, data);
-      pos += data.length;
+      // Never trust a source to honour the requested length: a misbehaving one
+      // can answer with more bytes than asked for (a 200-style full body).
+      // Clamp so setRange can't run past the buffer.
+      final count = data.length < len - pos ? data.length : len - pos;
+      out.setRange(pos, pos + count, data);
+      pos += count;
       onProgress?.call(pos, len);
     }
     return pos == len ? out : Uint8List.sublistView(out, 0, pos);

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:file_selector/file_selector.dart';
@@ -7,6 +8,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+import 'pdf_bookmark_source.dart';
+import 'pdf_file_source.dart';
 
 const _macosFileAccessChannel =
     MethodChannel('dev.milanko.dartpdf/file_access');
@@ -231,6 +235,81 @@ Future<Uint8List> readPdfAtPath(String path, {String? bookmark}) async {
     }
   }
   return XFile(path).readAsBytes();
+}
+
+/// Whether opening [path] progressively (first paint from ranged reads, full
+/// bytes streamed in behind it) is worthwhile on this platform. Desktop only:
+/// the big cloud-synced documents this pays off for live behind a real file
+/// path, and web/mobile picks hand back bytes (or a throwaway sandbox copy)
+/// that are already fully in memory.
+bool progressiveOpenSupported(String? path) =>
+    supportsInPlaceSave && path != null && path.isNotEmpty;
+
+/// A ranged [PdfByteSource] for a local file, so the app can open it
+/// progressively via [PdfDocument.openSource] and stream the rest in behind the
+/// first paint. On sandboxed macOS a bookmarked reopen must reactivate its
+/// security scope, so it reads through the native runner
+/// ([PdfBookmarkFileByteSource]); every other desktop path reads directly with
+/// a `RandomAccessFile` ([PdfFileByteSource]).
+PdfByteSource pdfByteSourceForPath(
+  String path, {
+  String? bookmark,
+  PdfCancelToken? cancelToken,
+  void Function(int received, int? total)? onProgress,
+}) {
+  if (_isMacOSDesktop && bookmark != null && bookmark.isNotEmpty) {
+    return PdfBookmarkFileByteSource(
+      bookmark: bookmark,
+      cancelToken: cancelToken,
+      onProgress: onProgress,
+    );
+  }
+  return PdfFileByteSource(
+    path,
+    cancelToken: cancelToken,
+    onProgress: onProgress,
+  );
+}
+
+/// Reads a whole [source] into one contiguous buffer, reporting progress as it
+/// goes. Unlike the sparse buffer [PdfDocument.openSource] assembles (zeros in
+/// the free space the parser never reads), this is the complete file - what the
+/// edit session, signing, and the render workers need. Used for the background
+/// full read behind a progressive first paint.
+Future<Uint8List> readSourceFully(
+  PdfByteSource source, {
+  void Function(int received, int? total)? onProgress,
+  int chunk = 8 << 20,
+  PdfCancelToken? cancelToken,
+}) async {
+  final len = await source.length;
+  if (len != null && len >= 0) {
+    final out = Uint8List(len);
+    var pos = 0;
+    while (pos < len) {
+      cancelToken?.throwIfCancelled();
+      final end = pos + chunk < len ? pos + chunk : len;
+      final data = await source.readRange(pos, end);
+      if (data.isEmpty) break;
+      out.setRange(pos, pos + data.length, data);
+      pos += data.length;
+      onProgress?.call(pos, len);
+    }
+    return pos == len ? out : Uint8List.sublistView(out, 0, pos);
+  }
+  // Unknown length: chunk until a short read signals EOF.
+  final builder = BytesBuilder(copy: false);
+  var pos = 0;
+  while (true) {
+    cancelToken?.throwIfCancelled();
+    final data = await source.readRange(pos, pos + chunk);
+    if (data.isEmpty) break;
+    builder.add(data);
+    pos += data.length;
+    onProgress?.call(pos, null);
+    if (data.length < chunk) break;
+  }
+  return builder.toBytes();
 }
 
 /// Whether the current platform can open a local file's containing folder in

--- a/app/lib/pdf_bookmark_source.dart
+++ b/app/lib/pdf_bookmark_source.dart
@@ -1,0 +1,77 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// The method channel the macOS runner exposes for security-scoped file
+/// access (bookmark create / whole-file read+write, and the ranged reads this
+/// source uses). Shared verbatim with `file_io.dart`.
+const _fileAccessChannel = MethodChannel('dev.milanko.dartpdf/file_access');
+
+/// A [PdfByteSource] over a sandboxed macOS file addressed by a security-scoped
+/// bookmark, reading ranges through the native runner (`readFileRange`).
+///
+/// Sandboxed macOS reopens (OneDrive/iCloud/Dropbox folders reached across app
+/// launches) can only be read after reactivating their security scope from a
+/// bookmark - something a raw `RandomAccessFile` cannot do. This source is the
+/// bookmark-aware sibling of [PdfFileByteSource]: each [readRange] re-resolves
+/// the bookmark natively, so the progressive loader (and the background full
+/// read) fetch only the bytes they need from a cloud-synced file instead of
+/// hydrating and slurping the whole thing.
+///
+/// Ranged native calls carry a per-request copy across the channel, so callers
+/// should read in reasonably large chunks (the loader coalesces object ranges;
+/// the background full read uses multi-MB chunks). Pass a [PdfCancelToken] to
+/// abort, and [onProgress] to observe the running byte total.
+class PdfBookmarkFileByteSource implements PdfByteSource {
+  PdfBookmarkFileByteSource({
+    required this.bookmark,
+    this.cancelToken,
+    this.onProgress,
+    @visibleForTesting MethodChannel? channel,
+  }) : _channel = channel ?? _fileAccessChannel;
+
+  /// Base64 security-scoped bookmark for the file (see `securityBookmarkForPath`).
+  final String bookmark;
+
+  /// Optional cooperative cancellation. A fired token makes pending and later
+  /// reads throw [PdfHttpCancelledException].
+  final PdfCancelToken? cancelToken;
+
+  /// Called after each read with the running total of bytes pulled and the
+  /// file length once known.
+  final void Function(int received, int? total)? onProgress;
+
+  final MethodChannel _channel;
+  int? _length;
+  int _received = 0;
+
+  @override
+  Future<int?> get length async {
+    cancelToken?.throwIfCancelled();
+    if (_length != null) return _length;
+    final len = await _channel.invokeMethod<int>('fileLength', {
+      'bookmark': bookmark,
+    });
+    return _length = len;
+  }
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    cancelToken?.throwIfCancelled();
+    final s = start < 0 ? 0 : start;
+    if (endExclusive <= s) return Uint8List(0);
+    final data = await _channel.invokeMethod<Uint8List>('readFileRange', {
+      'bookmark': bookmark,
+      'offset': s,
+      'length': endExclusive - s,
+    });
+    cancelToken?.throwIfCancelled();
+    final bytes = data ?? Uint8List(0);
+    _received += bytes.length;
+    onProgress?.call(_received, _length);
+    return bytes;
+  }
+
+  @override
+  Future<void> close() async {}
+}

--- a/app/lib/pdf_file_source.dart
+++ b/app/lib/pdf_file_source.dart
@@ -1,0 +1,7 @@
+// The local-file [PdfByteSource] (`PdfFileByteSource`), backed by a real
+// `RandomAccessFile` on native targets and a throwing stub on the web (no
+// `dart:io` there). A conditional import keeps `file_io.dart` and the app open
+// path compiling for every platform while only native builds pull in the real
+// filesystem implementation. See `pdf_file_source_io.dart` for the contract.
+export 'pdf_file_source_stub.dart'
+    if (dart.library.io) 'pdf_file_source_io.dart';

--- a/app/lib/pdf_file_source_io.dart
+++ b/app/lib/pdf_file_source_io.dart
@@ -97,11 +97,13 @@ class PdfFileByteSource implements PdfByteSource {
 
   @override
   Future<void> close() async {
+    // Drain the queue first so a read in flight finishes on the current handle;
+    // clearing [_file] before draining would make a queued read reopen a fresh
+    // handle that then leaks.
+    await _synchronized(() async {});
     final file = _file;
     _file = null;
     if (file != null) {
-      // Drain the queue so a read in flight finishes before the handle closes.
-      await _synchronized(() async {});
       try {
         await file.close();
       } catch (_) {

--- a/app/lib/pdf_file_source_io.dart
+++ b/app/lib/pdf_file_source_io.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+/// A [PdfByteSource] that reads a local file on demand through a single
+/// [RandomAccessFile], so the progressive loader can open a document by
+/// fetching only the header, cross-reference chain, and live-object ranges it
+/// needs - the local-file counterpart of [PdfHttpByteSource].
+///
+/// This is the "missing half" of the byte-source API for the app's own open
+/// path: cloud-synced folders (OneDrive/Dropbox/iCloud) are the normal home of
+/// this app's big scanned documents, where reading the whole file up front is
+/// tens of seconds of pure byte transport. Ranged reads let the viewer paint
+/// from a few MB while the rest streams in behind it.
+///
+/// Reads are serialized on the one handle (a [RandomAccessFile] is stateful -
+/// its position is shared - so concurrent `setPosition`+`read` pairs would
+/// interleave), which still satisfies the concurrency-safety contract of
+/// [PdfByteSource.readRange]. Pass a [PdfCancelToken] to abort an in-flight or
+/// later read, and [onProgress] to observe the running byte total (mirrors
+/// [PdfHttpByteSource]).
+///
+/// On sandboxed macOS a file reopened across launches needs its security scope
+/// reactivated from a bookmark, which a raw [RandomAccessFile] cannot do - use
+/// the native-channel `PdfBookmarkFileByteSource` there instead (see
+/// `file_io.dart`'s `pdfByteSourceForPath`). This source covers fresh picks
+/// (whose scope is live for the session) and every non-sandboxed platform.
+class PdfFileByteSource implements PdfByteSource {
+  PdfFileByteSource(
+    this.path, {
+    this.cancelToken,
+    this.onProgress,
+  });
+
+  /// The on-disk path to read.
+  final String path;
+
+  /// Optional cooperative cancellation. A fired token makes pending and later
+  /// reads throw [PdfHttpCancelledException].
+  final PdfCancelToken? cancelToken;
+
+  /// Called after each read with the running total of bytes pulled and the
+  /// file length once known.
+  final void Function(int received, int? total)? onProgress;
+
+  RandomAccessFile? _file;
+  int? _length;
+  int _received = 0;
+
+  /// Serializes access to the shared [RandomAccessFile] position.
+  Future<void> _lock = Future.value();
+
+  Future<T> _synchronized<T>(Future<T> Function() action) {
+    final completer = Completer<T>();
+    _lock = _lock.then((_) async {
+      try {
+        completer.complete(await action());
+      } catch (error, stack) {
+        completer.completeError(error, stack);
+      }
+    });
+    return completer.future;
+  }
+
+  Future<RandomAccessFile> _open() async {
+    return _file ??= await File(path).open();
+  }
+
+  @override
+  Future<int?> get length async {
+    cancelToken?.throwIfCancelled();
+    return _length ??= await File(path).length();
+  }
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    cancelToken?.throwIfCancelled();
+    final s = start < 0 ? 0 : start;
+    if (endExclusive <= s) return Uint8List(0);
+    return _synchronized(() async {
+      cancelToken?.throwIfCancelled();
+      final file = await _open();
+      final total = _length ??= await file.length();
+      if (s >= total) return Uint8List(0);
+      final end = math.min(endExclusive, total);
+      await file.setPosition(s);
+      final data = await file.read(end - s);
+      cancelToken?.throwIfCancelled();
+      _received += data.length;
+      onProgress?.call(_received, total);
+      return data;
+    });
+  }
+
+  @override
+  Future<void> close() async {
+    final file = _file;
+    _file = null;
+    if (file != null) {
+      // Drain the queue so a read in flight finishes before the handle closes.
+      await _synchronized(() async {});
+      try {
+        await file.close();
+      } catch (_) {
+        // Already closed / gone - nothing to release.
+      }
+    }
+  }
+}

--- a/app/lib/pdf_file_source_stub.dart
+++ b/app/lib/pdf_file_source_stub.dart
@@ -1,0 +1,32 @@
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+/// Web stub for [PdfFileByteSource]: the browser has no `dart:io` filesystem,
+/// so progressive open-by-path never runs there (web picks hand back bytes, not
+/// a path). Present only so `pdf_file_source.dart` compiles for web; every
+/// method throws [UnsupportedError] if something constructs and uses it anyway.
+class PdfFileByteSource implements PdfByteSource {
+  PdfFileByteSource(
+    this.path, {
+    this.cancelToken,
+    this.onProgress,
+  });
+
+  final String path;
+  final PdfCancelToken? cancelToken;
+  final void Function(int received, int? total)? onProgress;
+
+  Never _unsupported() =>
+      throw UnsupportedError('PdfFileByteSource is not available on the web');
+
+  @override
+  Future<int?> get length async => _unsupported();
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async =>
+      _unsupported();
+
+  @override
+  Future<void> close() async {}
+}

--- a/app/macos/Runner/MainFlutterWindow.swift
+++ b/app/macos/Runner/MainFlutterWindow.swift
@@ -63,6 +63,29 @@ class MainFlutterWindow: NSWindow {
           return
         }
         self.writeFile(bookmark: bookmark, bytes: typed.data, result: result)
+      case "fileLength":
+        guard let args = call.arguments as? [String: Any],
+              let bookmark = args["bookmark"] as? String else {
+          result(FlutterError(
+            code: "bad_args",
+            message: "fileLength expects a bookmark",
+            details: nil))
+          return
+        }
+        self.fileLength(bookmark: bookmark, result: result)
+      case "readFileRange":
+        guard let args = call.arguments as? [String: Any],
+              let bookmark = args["bookmark"] as? String,
+              let offset = args["offset"] as? Int,
+              let length = args["length"] as? Int else {
+          result(FlutterError(
+            code: "bad_args",
+            message: "readFileRange expects a bookmark, offset and length",
+            details: nil))
+          return
+        }
+        self.readFileRange(
+          bookmark: bookmark, offset: offset, length: length, result: result)
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -195,6 +218,48 @@ class MainFlutterWindow: NSWindow {
       let scoped = url.startAccessingSecurityScopedResource()
       defer { if scoped { url.stopAccessingSecurityScopedResource() } }
       let data = try Data(contentsOf: url)
+      result(FlutterStandardTypedData(bytes: data))
+    } catch {
+      result(FlutterError(
+        code: "read_failed",
+        message: error.localizedDescription,
+        details: nil))
+    }
+  }
+
+  /// The byte length of a bookmarked file, for the progressive/ranged loader.
+  private func fileLength(bookmark: String, result: FlutterResult) {
+    do {
+      let url = try resolveBookmarkedURL(bookmark)
+      let scoped = url.startAccessingSecurityScopedResource()
+      defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+      let values = try url.resourceValues(forKeys: [.fileSizeKey])
+      result(values.fileSize ?? 0)
+    } catch {
+      result(FlutterError(
+        code: "length_failed",
+        message: error.localizedDescription,
+        details: nil))
+    }
+  }
+
+  /// Reads `length` bytes starting at `offset` from a bookmarked file. Lets the
+  /// progressive loader (and the background full read) pull only the ranges it
+  /// needs from a sandboxed / cloud-synced file without slurping the whole
+  /// thing - the security scope is reactivated per call and released right
+  /// after, so no handle or scope leaks between reads. A short read near EOF
+  /// returns fewer bytes; an offset past EOF returns an empty list.
+  private func readFileRange(
+    bookmark: String, offset: Int, length: Int, result: FlutterResult
+  ) {
+    do {
+      let url = try resolveBookmarkedURL(bookmark)
+      let scoped = url.startAccessingSecurityScopedResource()
+      defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+      let handle = try FileHandle(forReadingFrom: url)
+      defer { handle.closeFile() }
+      handle.seek(toFileOffset: UInt64(max(0, offset)))
+      let data = handle.readData(ofLength: max(0, length))
       result(FlutterStandardTypedData(bytes: data))
     } catch {
       result(FlutterError(

--- a/app/test/pdf_file_source_test.dart
+++ b/app/test/pdf_file_source_test.dart
@@ -1,0 +1,129 @@
+// PdfFileByteSource reads a local file on demand for the progressive loader:
+// ranged reads, clamped/short past EOF, progress, cancellation - and it opens
+// a real document through PdfDocument.openSource. readSourceFully reassembles
+// the complete contiguous buffer (with progress) for the background full read.
+@TestOn('vm')
+library;
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_app/file_io.dart';
+import 'package:dart_pdf_editor_app/pdf_file_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tmp;
+  late File pdfFile;
+  late Uint8List pdfBytes;
+
+  setUp(() async {
+    tmp = await Directory.systemTemp.createTemp('pdf_file_source_test');
+    pdfBytes = PdfBlankDocument.create();
+    pdfFile = File('${tmp.path}/blank.pdf');
+    await pdfFile.writeAsBytes(pdfBytes, flush: true);
+  });
+
+  tearDown(() async {
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  test('length reports the file size', () async {
+    final source = PdfFileByteSource(pdfFile.path);
+    expect(await source.length, pdfBytes.length);
+    await source.close();
+  });
+
+  test('readRange returns the requested slice', () async {
+    final source = PdfFileByteSource(pdfFile.path);
+    final head = await source.readRange(0, 5);
+    expect(head, pdfBytes.sublist(0, 5));
+    final mid = await source.readRange(10, 20);
+    expect(mid, pdfBytes.sublist(10, 20));
+    await source.close();
+  });
+
+  test('readRange clamps past the end and empties beyond it', () async {
+    final source = PdfFileByteSource(pdfFile.path);
+    final len = pdfBytes.length;
+    // A window straddling EOF returns only the real bytes (a short read).
+    final tail = await source.readRange(len - 4, len + 100);
+    expect(tail, pdfBytes.sublist(len - 4));
+    // Wholly past the end is empty; so is a degenerate range.
+    expect(await source.readRange(len + 10, len + 20), isEmpty);
+    expect(await source.readRange(30, 30), isEmpty);
+    // A negative start is clamped to 0.
+    expect(await source.readRange(-5, 3), pdfBytes.sublist(0, 3));
+    await source.close();
+  });
+
+  test('reports cumulative progress across reads', () async {
+    final seen = <int>[];
+    final source = PdfFileByteSource(
+      pdfFile.path,
+      onProgress: (received, total) {
+        expect(total, pdfBytes.length);
+        seen.add(received);
+      },
+    );
+    await source.readRange(0, 10);
+    await source.readRange(10, 25);
+    expect(seen, [10, 25]);
+    await source.close();
+  });
+
+  test('a fired cancel token aborts reads', () async {
+    final token = PdfCancelToken();
+    final source = PdfFileByteSource(pdfFile.path, cancelToken: token);
+    token.cancel();
+    expect(source.readRange(0, 10), throwsA(isA<PdfHttpCancelledException>()));
+    expect(source.length, throwsA(isA<PdfHttpCancelledException>()));
+    await source.close();
+  });
+
+  test('concurrent reads on one handle stay consistent', () async {
+    final source = PdfFileByteSource(pdfFile.path);
+    final futures = [
+      for (var i = 0; i < pdfBytes.length; i += 7)
+        source.readRange(i, i + 7),
+    ];
+    final chunks = await Future.wait(futures);
+    final rebuilt = BytesBuilder(copy: false);
+    for (final c in chunks) {
+      rebuilt.add(c);
+    }
+    expect(rebuilt.toBytes(), pdfBytes);
+    await source.close();
+  });
+
+  test('readSourceFully reassembles the exact file with progress', () async {
+    final source = PdfFileByteSource(pdfFile.path);
+    var lastReceived = 0;
+    int? lastTotal;
+    final full = await readSourceFully(
+      source,
+      chunk: 16, // force many chunks over the small fixture
+      onProgress: (received, total) {
+        lastReceived = received;
+        lastTotal = total;
+      },
+    );
+    expect(full, pdfBytes);
+    expect(lastReceived, pdfBytes.length);
+    expect(lastTotal, pdfBytes.length);
+    await source.close();
+  });
+
+  test('PdfDocument.openSource opens the file through the source', () async {
+    final source = PdfFileByteSource(pdfFile.path);
+    final doc = await PdfDocument.openSource(source);
+    expect(doc.pageCount, 1);
+    // The progressive loader assembles a full-length (sparse) buffer.
+    expect(doc.cos.bytes.length, pdfBytes.length);
+    await source.close();
+  });
+}

--- a/app/test/progressive_open_test.dart
+++ b/app/test/progressive_open_test.dart
@@ -2,6 +2,7 @@
 // first paint renders the sparse document, then the complete bytes stream in
 // behind it and the tab swaps to a full edit session. Driven on Linux so the
 // source is a plain RandomAccessFile (no macOS security-scoped channel).
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -88,6 +89,55 @@ void main() {
       expect(log, contains('full read complete'));
       // ...and ended on a real edit session, not a read-only preview.
       expect(find.byType(PdfEditorView), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('restores a desktop session tab lazily, opening it progressively',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      final path = seedFile('restored.pdf');
+      SharedPreferences.setMockInitialValues({
+        'dart_pdf_editor_app.session': jsonEncode([
+          {'t': 'restored.pdf', 'p': path}
+        ]),
+      });
+
+      await pump(tester, () async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      });
+
+      // The restored tab opened via the progressive path and became a full
+      // edit session - it read no bytes until it was the active tab.
+      expect(tabTitle('restored.pdf'), findsOneWidget);
+      final log = AppDevTools.instance.log.map((e) => e.message).join('\n');
+      expect(log, contains('progressive open: "restored.pdf" first paint'));
+      expect(find.byType(PdfEditorView), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets('drops a restored desktop file that has gone missing',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      SharedPreferences.setMockInitialValues({
+        'dart_pdf_editor_app.session': jsonEncode([
+          {'t': 'gone.pdf', 'p': '${tempDir.path}/gone.pdf'}
+        ]),
+      });
+
+      await pump(tester, () async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      });
+
+      // The length probe fails for a missing file, so it is dropped silently -
+      // no tab, no error placeholder.
+      expect(tabTitle('gone.pdf'), findsNothing);
+      expect(find.byType(PdfEditorView), findsNothing);
     } finally {
       debugDefaultTargetPlatformOverride = null;
     }

--- a/app/test/progressive_open_test.dart
+++ b/app/test/progressive_open_test.dart
@@ -1,0 +1,95 @@
+// A single desktop path-open goes through the progressive loader: a read-only
+// first paint renders the sparse document, then the complete bytes stream in
+// behind it and the tab swaps to a full edit session. Driven on Linux so the
+// source is a plain RandomAccessFile (no macOS security-scoped channel).
+import 'dart:io';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/devtools.dart';
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/incoming_file.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+  late Directory tempDir;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+    tempDir = Directory.systemTemp.createTempSync('dartpdf_progressive_test');
+    AppDevTools.instance.clearLog();
+  });
+
+  tearDown(() {
+    prefs.dispose();
+    tempDir.deleteSync(recursive: true);
+  });
+
+  String seedFile(String name) {
+    final path = '${tempDir.path}/$name';
+    File(path).writeAsBytesSync(Uint8List.fromList(buildClassicPdf()));
+    return path;
+  }
+
+  Finder tabTitle(String name) => find.descendant(
+        of: find.byKey(const ValueKey('tab-strip')),
+        matching: find.text(name),
+      );
+
+  Future<void> pump(WidgetTester tester, Future<void> Function() action) async {
+    await tester.runAsync(() async {
+      await action();
+      for (var i = 0; i < 24; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    await tester.pump();
+  }
+
+  // Hands the editor a file-with-path the way the OS does (no bytes), which the
+  // open path treats as a progressive open on desktop.
+  Future<void> openIncoming(WidgetTester tester, String path, String name) {
+    const codec = StandardMethodCodec();
+    final message = codec.encodeMethodCall(MethodCall('openFile', {
+      'name': name,
+      'path': path,
+    }));
+    return tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+      IncomingFileService.channelName,
+      message,
+      (_) {},
+    );
+  }
+
+  testWidgets('opens progressively and swaps to a full edit session',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    try {
+      final path = seedFile('big.pdf');
+
+      await pump(tester, () async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      });
+      await pump(tester, () => openIncoming(tester, path, 'big.pdf'));
+
+      // The tab opened...
+      expect(tabTitle('big.pdf'), findsOneWidget);
+      // ...through the progressive path (first paint, then the full read)...
+      final log = AppDevTools.instance.log.map((e) => e.message).join('\n');
+      expect(log, contains('progressive open: "big.pdf" first paint'));
+      expect(log, contains('full read complete'));
+      // ...and ended on a real edit session, not a read-only preview.
+      expect(find.byType(PdfEditorView), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/doc/dev-log/2026-07-18-progressive-file-open.md
+++ b/doc/dev-log/2026-07-18-progressive-file-open.md
@@ -29,8 +29,20 @@ rules), so the sources live in the app:
 Factory + helpers in `file_io.dart`:
 - `pdfByteSourceForPath(path, {bookmark})` picks the bookmark source on
   sandboxed macOS, else the RAF source.
-- `progressiveOpenSupported(path)` gates it to desktop with a real path (web
-  and mobile picks are already fully in memory / have no durable path).
+- `progressiveOpenSupported(path)` gates it to desktop with a real path. Web
+  has no filesystem. **Mobile is a real gap, not "already in memory":** you can
+  pick a OneDrive/iCloud file on a phone, but `file_selector` hands us a *copy*
+  — `file_selector_android`'s `getPathFromCopyOfFileFromUri` streams the whole
+  content URI into `{cacheDir}/{uuid}/` at pick time, and `file_selector_ios`
+  uses `UIDocumentPickerViewController(in: .import)`, which copies too. So the
+  full cloud transport is paid inside the OS picker, before the app sees a byte
+  or a path; app-level ranged open can't intercept it. Making mobile progressive
+  needs a custom picker (Android `ACTION_OPEN_DOCUMENT` keeping the content Uri;
+  iOS `.open` + a security-scoped URL) plus native ranged reads
+  (`ContentResolver.openFileDescriptor` — often non-seekable for cloud
+  providers; iOS `NSFileCoordinator` + `FileHandle`) — a separate,
+  provider-dependent effort. Mobile *reopens* already read the local snapshot
+  (`cacheOpenedPdf`), so only the first pick pays cloud transport.
 - `readSourceFully(source, {onProgress})` reassembles the **complete**
   contiguous buffer with progress — unlike the sparse buffer `openSource`
   assembles (zeros in the free space the parser never reads), this is what the

--- a/doc/dev-log/2026-07-18-progressive-file-open.md
+++ b/doc/dev-log/2026-07-18-progressive-file-open.md
@@ -104,6 +104,40 @@ Milestones are logged to the **F12 devtools** log
 (`AppDevTools.instance.addLog`), and the whole ranged fetch is already timed by
 `PdfPerfPhase.sourceFetch` — enable the panel's perf-log toggle to see it.
 
+## 2c. Lazy page-scoped first paint (the actual win)
+
+The first cut fetched the whole *object graph* for the first paint
+(`openCosDocumentFromSource` fetches every live object). The 2026-07-18 perf
+export showed why that's not enough: for an image-heavy scan/CAD file the live
+objects **are** the page images, so `sourceFetch` was **36 s / 211 MB** at
+~5.8 MB/s (the OneDrive rate) - the whole file, before first paint. Parse itself
+is trivial (`docOpen` 9 ms). So the "first paint" was really a 36 s spinner.
+
+`PdfSourceLoadOptions.firstPaintPages` (pdf_cos `byte_source.dart`) makes the
+loader fetch only what the first N pages need: it builds an object-number →
+`CosXrefEntry` map with `CosXrefReader`, walks the page tree fetching every node
+and leaf dict (small - so page count and navigation still work), and then, for
+the first N leaves only, fetches the transitive closure of their `/Contents` and
+`/Resources` (fonts, image XObjects), following `/Parent` for inherited
+resources but **never** `/Kids` (so it can't pull other pages' content). Object
+streams are decoded on the way (`_DecodedObjStm`). Any surprise falls back to
+fetching every object, so a first-paint open never fails where a whole-object
+one would. The app passes `firstPaintPages: 1`; the background `readSourceFully`
+then completes the buffer for the full session. Result: first paint is ~1 page
+(~1 MB, ~1 s) instead of the whole file.
+
+**Tolerating the partial buffer.** The read-only preview renders the sparse
+buffer in the real viewer, which eagerly resolves objects beyond page 1 - an
+AcroForm's field widgets, say, living in a not-yet-fetched object stream. The
+in-use object path already returns a dangling `CosNull` for a missing object
+(real files have dangling refs, so forms/annotations tolerate it), but the
+**compressed** path *threw* `CosParseException: object stream N is not a stream`
+→ a red error widget. `CosDocument.getObject` now returns `CosNull` for a
+compressed object whose object stream can't be loaded, mirroring the in-use
+path - lenient on input, and correct for genuinely broken files too. The swap
+also defers `preview.dispose()` to a post-frame callback so the read-only
+viewer's controller isn't torn down mid-render.
+
 ## 3. Fewer worker byte copies
 
 `PdfPooledRenderWorker` made one defensive `Uint8List.fromList` snapshot of the

--- a/doc/dev-log/2026-07-18-progressive-file-open.md
+++ b/doc/dev-log/2026-07-18-progressive-file-open.md
@@ -72,10 +72,21 @@ notifier and a `PdfCancelToken`. `EditorScreen`:
 Wired into the single-file desktop paths: `_pickAndOpen` (1 file),
 `_openIncoming` (path), `_openDropped` (1 file), `_openRecent` (desktop
 origin). Batch opens keep the deferred whole-file path so the picker doesn't
-fan out many concurrent streams. Session restore stays on its existing deferred
-path for now (making it progressive means first-painting every restored tab at
-launch; a "deferred progressive" that only first-paints the active tab is the
-follow-up).
+fan out many concurrent streams.
+
+**Session restore is lazy *and* progressive.** A new `DocumentTab.deferredPath`
+holds only a path - no bytes read at launch. Restore probes each desktop file's
+length (cheap metadata, no content read / cloud hydration) so a moved/deleted
+file is still dropped silently, then adds a path-only tab. When a
+`deferredPath` tab is first shown it opens progressively in place
+(`_materializeDeferredPath` → `_openProgressive(into:)`). A `_restoringSession`
+flag suppresses materialization while the tabs are being re-added (each is
+briefly the active one mid-loop), so only the tab left active when restore
+finishes opens - the rest read nothing until visited. This kills the old
+"every restored tab reads its whole file at launch" cost (`_reopenSessionDocument`
+used to `await readPdfAtPath` the full bytes for each). Mobile/snapshot restore
+keeps the existing read-bytes-then-defer-parse path (`progressiveOpenSupported`
+is false there).
 
 Milestones are logged to the **F12 devtools** log
 (`AppDevTools.instance.addLog`), and the whole ranged fetch is already timed by

--- a/doc/dev-log/2026-07-18-progressive-file-open.md
+++ b/doc/dev-log/2026-07-18-progressive-file-open.md
@@ -41,8 +41,8 @@ Factory + helpers in `file_io.dart`:
   iOS `.open` + a security-scoped URL) plus native ranged reads
   (`ContentResolver.openFileDescriptor` — often non-seekable for cloud
   providers; iOS `NSFileCoordinator` + `FileHandle`) — a separate,
-  provider-dependent effort. Mobile *reopens* already read the local snapshot
-  (`cacheOpenedPdf`), so only the first pick pays cloud transport.
+  provider-dependent effort, tracked in #364. Mobile *reopens* already read the
+  local snapshot (`cacheOpenedPdf`), so only the first pick pays cloud transport.
 - `readSourceFully(source, {onProgress})` reassembles the **complete**
   contiguous buffer with progress — unlike the sparse buffer `openSource`
   assembles (zeros in the free space the parser never reads), this is what the

--- a/doc/dev-log/2026-07-18-progressive-file-open.md
+++ b/doc/dev-log/2026-07-18-progressive-file-open.md
@@ -1,0 +1,122 @@
+# Progressive local-file open (#359)
+
+Opens the app's own file path through the ranged byte-source API (#325/#328)
+so a big cloud-synced document paints in ~1-2 s instead of stalling on tens of
+seconds of pure byte transport. Three parts.
+
+## 1. `PdfFileByteSource` — the missing local half
+
+`PdfByteSource`/`CosDocument.openSource`/`PdfHttpByteSource` (PR #328) gave the
+parser a random-access, ranged source, but the only concrete source was HTTP.
+The app's open path still `readAsBytes`'d the whole file first. #359 adds the
+local-file source.
+
+`dart:io`'s `RandomAccessFile` can't live in any package `lib/` (web + layering
+rules), so the sources live in the app:
+
+- `app/lib/pdf_file_source_io.dart` — `PdfFileByteSource` over one
+  `RandomAccessFile`. Reads are serialized on the shared handle (a RAF has one
+  cursor) via a `Future`-chain mutex, which still satisfies the concurrency
+  contract. `PdfCancelToken` + `onProgress` mirror `PdfHttpByteSource`.
+- `app/lib/pdf_file_source_stub.dart` + `pdf_file_source.dart` — web stub +
+  conditional-export facade (throws if ever used; web opens never take a path).
+- `app/lib/pdf_bookmark_source.dart` — `PdfBookmarkFileByteSource` for sandboxed
+  macOS. The app is sandboxed (`com.apple.security.app-sandbox`); a file
+  reopened across launches (OneDrive/iCloud) needs its security scope
+  reactivated from a bookmark, which a raw RAF can't do. This source reads
+  ranges through a new native `readFileRange` method (see below).
+
+Factory + helpers in `file_io.dart`:
+- `pdfByteSourceForPath(path, {bookmark})` picks the bookmark source on
+  sandboxed macOS, else the RAF source.
+- `progressiveOpenSupported(path)` gates it to desktop with a real path (web
+  and mobile picks are already fully in memory / have no durable path).
+- `readSourceFully(source, {onProgress})` reassembles the **complete**
+  contiguous buffer with progress — unlike the sparse buffer `openSource`
+  assembles (zeros in the free space the parser never reads), this is what the
+  edit session, signing, and the render workers need.
+
+Native (macOS runner, `MainFlutterWindow.swift`): `fileLength` and
+`readFileRange(bookmark, offset, length)` reactivate the security scope per
+call (no leaked handle/scope), so the loader pulls only the ranges it needs
+from a cloud-synced file. Deployment target is 10.15, so it uses the classic
+`FileHandle` seek/readData API (no `read(upToCount:)` availability guard).
+
+## 2. First paint from ranges, full bytes behind it
+
+The whole editing model needs the complete contiguous buffer synchronously
+(`PdfEditingController(bytes)` → `PdfDocument.open`; grow-only buffer; signing
+over full ranges). So progressive open can't hand the sparse buffer to the edit
+session — it renders it **read-only** for the first paint, then swaps to a real
+session once the full read lands.
+
+New tab kind `DocumentTab.preview` (`document_tab.dart`): a read-only
+`PdfDocument` from `PdfDocument.openSource`, its sparse bytes, a `progress`
+notifier and a `PdfCancelToken`. `EditorScreen`:
+
+- `_openProgressive` opens the source, `await`s the ranged first paint, shows a
+  `_ProgressivePreview` (a `PdfReader` over the sparse bytes + a slim
+  `LinearProgressIndicator` for the background read), records the recent, then
+  `unawaited`s `_finishProgressive`.
+- `_finishProgressive` runs `readSourceFully` (feeding `progress`), then
+  `_swapPreviewToDocument` replaces the preview with a full
+  `DocumentTab.document` **in place** (same `documentId` → viewport/search
+  memory carries across the swap, like the deferred→document swap already does).
+- Failure of the first paint falls back to the plain `readPdfAtPath` full read
+  (`_fallbackFullOpen`), so nothing a normal open handles regresses; a failed
+  background read falls back too, else surfaces an error tab.
+- Save / Digitally sign are gated on `tab.session != null` throughout, so they
+  stay disabled during the read-only preview and light up only after the swap —
+  exactly the issue's "queue until full bytes" requirement, for free.
+
+Wired into the single-file desktop paths: `_pickAndOpen` (1 file),
+`_openIncoming` (path), `_openDropped` (1 file), `_openRecent` (desktop
+origin). Batch opens keep the deferred whole-file path so the picker doesn't
+fan out many concurrent streams. Session restore stays on its existing deferred
+path for now (making it progressive means first-painting every restored tab at
+launch; a "deferred progressive" that only first-paints the active tab is the
+follow-up).
+
+Milestones are logged to the **F12 devtools** log
+(`AppDevTools.instance.addLog`), and the whole ranged fetch is already timed by
+`PdfPerfPhase.sourceFetch` — enable the panel's perf-log toggle to see it.
+
+## 3. Fewer worker byte copies
+
+`PdfPooledRenderWorker` made one defensive `Uint8List.fromList` snapshot of the
+document and seeded every worker from it; each isolate then materializes its own
+copy (unavoidable). On a 179 MB doc across a pool that snapshot is another full
+copy per worker generation. Added `copySource` (default true, public contract
+unchanged); `startPdfRenderWorker` and `PdfRenderWorker.start`/`_backend` pass
+`false` because their bytes never change under the worker (the edit session's
+grow-only buffer is replaced, not mutated in place; the reader/preview bytes are
+read-only). The pool then adds **zero** source-byte copies of its own beyond
+each isolate's unavoidable materialization. The bigger win — a shared-source
+model where isolates read ranges instead of holding the whole buffer — is left
+as a follow-up.
+
+Snapshot-behind-first-paint (the issue's third note) needs no change: the
+`cacheOpenedPdf` snapshot is mobile-only and progressive open is desktop-only,
+so they don't intersect; the mobile snapshot already runs `unawaited` off the
+open hot path.
+
+## Tests
+
+- `app/test/pdf_file_source_test.dart` — ranged reads, past-EOF clamp/short
+  read, progress, cancellation, concurrent reads, `readSourceFully` exactness,
+  and an end-to-end `PdfDocument.openSource` over a real temp file.
+- `app/test/progressive_open_test.dart` — a desktop path-open (platform forced
+  to Linux → RAF source) first-paints and swaps to a `PdfEditorView`, with the
+  devtools milestones logged.
+- `render_worker_test.dart` — `copySource: false` seeds workers directly from
+  the caller buffer (no snapshot).
+
+## Gotchas
+
+- `debugDefaultTargetPlatformOverride` must be reset **inside** the test body
+  (try/finally), not in tearDown — the foundation-var invariant check runs
+  before tearDown.
+- The progressive first paint renders `doc.cos.bytes` (the sparse buffer). It's
+  a full-length `Uint8List` with zeros in free space; the renderer only touches
+  live objects, so it paints correctly, but it must never reach the edit session
+  or signing — hence the separate `readSourceFully` complete read.

--- a/doc/progressive-loading.md
+++ b/doc/progressive-loading.md
@@ -1,0 +1,144 @@
+# Progressive / optimised loading
+
+Open a large PDF without reading the whole file up front. The parser is
+network-agnostic: it asks a `PdfByteSource` for the byte ranges it needs
+(header, cross-reference chain, the objects a page references) rather than
+requiring the complete buffer. This is how you keep a viewer responsive on a
+198-page scan sitting in a slow cloud-synced folder, or a multi-hundred-MB CAD
+sheet served over HTTP.
+
+This guide is for **consumers of the `dart_pdf_editor` / `pdf_document`
+packages**. If you just have bytes, keep using `PdfDocument.open(Uint8List)` /
+`PdfViewer(bytes:)` / `PdfReader(bytes:)` - none of that changes.
+
+## The API
+
+- `PdfByteSource` (from `pdf_cos`, re-exported by `dart_pdf_editor`): the
+  contract - `Future<int?> get length` and
+  `Future<Uint8List> readRange(int start, int endExclusive)`, plus an optional
+  `close()`. Implementations must be safe to call `readRange` on concurrently.
+- `PdfDocument.openSource(source, {password, options})`: opens a document from a
+  source, fetching only the bytes it needs and falling back to a plain download
+  when the source can't serve useful ranges.
+- `PdfSourceLoadOptions`: tuning - `onProgress`, window sizes, and
+  `firstPaintPages` (below).
+- `PdfHttpByteSource` (from `dart_pdf_editor`): a ready-made HTTP(S) source using
+  Range requests, with auth headers, `PdfCancelToken`, and progress.
+
+## Remote files (HTTP)
+
+```dart
+final source = PdfHttpByteSource(
+  Uri.parse('https://host/big.pdf'),
+  headers: {'Authorization': 'Bearer $token'},
+  cancelToken: cancelToken,
+  onProgress: (received, total) => setState(() => _progress = received / total!),
+);
+final document = await PdfDocument.openSource(source);
+// ...show it, then:
+await source.close();
+```
+
+On the web, cross-origin Range loading needs the server to expose
+`Accept-Ranges`/`Content-Range` via `Access-Control-Expose-Headers`; without
+that the browser hides them and the source transparently falls back to a single
+full download.
+
+## Local files (native, off the web)
+
+`dart:io` can't live in the packages (they compile for the web too), so there's
+no bundled file source - implement the two-method contract over a
+`RandomAccessFile`. Reads share one handle's cursor, so serialise them:
+
+```dart
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:pdf_cos/pdf_cos.dart';
+
+class FileByteSource implements PdfByteSource {
+  FileByteSource(this.path);
+  final String path;
+  RandomAccessFile? _file;
+  int? _length;
+  Future<void> _lock = Future.value();
+
+  Future<T> _sync<T>(Future<T> Function() action) {
+    final done = Completer<T>();
+    _lock = _lock.then((_) async {
+      try { done.complete(await action()); }
+      catch (e, s) { done.completeError(e, s); }
+    });
+    return done.future;
+  }
+
+  @override
+  Future<int?> get length async => _length ??= await File(path).length();
+
+  @override
+  Future<Uint8List> readRange(int start, int end) => _sync(() async {
+        final f = _file ??= await File(path).open();
+        final total = _length ??= await f.length();
+        final s = start < 0 ? 0 : start;
+        if (s >= total || end <= s) return Uint8List(0);
+        await f.setPosition(s);
+        return f.read((end > total ? total : end) - s);
+      });
+
+  @override
+  Future<void> close() =>
+      _sync(() async => _file?.close()).whenComplete(() => _file = null);
+}
+```
+
+The example app (`app/lib/pdf_file_source_io.dart`) ships a fuller version with
+progress and cancellation, plus a variant that reads a sandboxed macOS file
+through a security-scoped bookmark over a platform channel - reach for that
+shape if your app is sandboxed and reopens files across launches.
+
+## Fast first paint (`firstPaintPages`)
+
+`PdfDocument.openSource` fetches every live object before it returns. For a
+lightly-packed PDF that's a few MB; for a **scan or CAD sheet the live objects
+are the page images**, so it's essentially the whole file - and "first paint"
+becomes a long wait on a slow source.
+
+`firstPaintPages` fetches only what the first N pages need (the whole page tree,
+so page count and navigation still work, plus those pages' content, resources,
+fonts and image XObjects) and leaves the rest of the buffer unfetched:
+
+```dart
+final preview = await PdfDocument.openSource(
+  source,
+  options: PdfSourceLoadOptions(
+    firstPaintPages: 1,
+    onProgress: (received, total) => report(received, total),
+  ),
+);
+```
+
+**The buffer is deliberately incomplete.** The covered pages render; the rest
+render blank until you complete it. So:
+
+- Render-only. Do **not** edit or sign a `firstPaintPages` document - those need
+  every byte (edits append to one buffer; signing hashes byte ranges).
+- Complete the buffer in the background - read the whole `source` sequentially -
+  then reopen for the full document once every page is available.
+
+A typical Flutter flow: show `PdfReader`/`PdfViewer` over the first-paint
+document for an instant page 1, read the whole source behind it (report
+`onProgress` on a bar), then swap to a full `PdfDocument.open(completeBytes)` /
+editing session when the read lands. The example app wires exactly this
+(`EditorScreen._openProgressive`).
+
+## Notes
+
+- `PdfDocument.open(Uint8List)` and the byte-based widgets are unaffected;
+  `openSource` is purely additive.
+- Progress + cancellation live on the source (`PdfHttpByteSource`) and the
+  loader (`PdfSourceLoadOptions.onProgress`), not on `PdfByteSource` itself.
+- `PdfPerfPhase.sourceFetch` (via `package:pdf_cos/perf.dart`) times the fetch if
+  you want to measure it.
+
+See [`doc/dev-log`](dev-log) for the loader internals (the ranged xref walk, the
+page-scoped closure, and the sparse-buffer parser contract).

--- a/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
@@ -97,8 +97,8 @@ for(s=a.length;b>0;b=r){r=b-1
 if(!(r<s))return A.a(a,r)
 q=a.charCodeAt(r)
 if(q!==32&&q!==13&&!J.pQ(q))break}return b},
-di(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.dA.prototype
-return J.eB.prototype}if(typeof a=="string")return J.cS.prototype
+dj(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.dA.prototype
+return J.eB.prototype}if(typeof a=="string")return J.cT.prototype
 if(a==null)return J.eA.prototype
 if(typeof a=="boolean")return J.hD.prototype
 if(Array.isArray(a))return J.n.prototype
@@ -107,7 +107,7 @@ if(typeof a=="symbol")return J.dE.prototype
 if(typeof a=="bigint")return J.dD.prototype
 return a}if(a instanceof A.K)return a
 return J.nF(a)},
-a9(a){if(typeof a=="string")return J.cS.prototype
+a9(a){if(typeof a=="string")return J.cT.prototype
 if(a==null)return a
 if(Array.isArray(a))return J.n.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.bJ.prototype
@@ -130,7 +130,7 @@ rC(a){if(typeof a=="number")return J.dB.prototype
 if(a==null)return a
 if(!(a instanceof A.K))return J.cC.prototype
 return a},
-y1(a){if(typeof a=="string")return J.cS.prototype
+y1(a){if(typeof a=="string")return J.cT.prototype
 if(a==null)return a
 if(!(a instanceof A.K))return J.cC.prototype
 return a},
@@ -142,18 +142,18 @@ return a}if(a instanceof A.K)return a
 return J.nF(a)},
 V(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
-return J.di(a).I(a,b)},
+return J.dj(a).I(a,b)},
 tF(a){if(typeof a=="number")return-a
 return J.rB(a).ec(a)},
 a4(a,b){if(typeof b==="number")if(Array.isArray(a)||typeof a=="string"||A.y9(a,a[v.dispatchPropertyName]))if(b>>>0===b&&b<a.length)return a[b]
 return J.a9(a).h(a,b)},
-dn(a,b,c){return J.e7(a).k(a,b,c)},
+dp(a,b,c){return J.e7(a).k(a,b,c)},
 o8(a){if(typeof a==="number")return Math.abs(a)
 return J.rB(a).fw(a)},
-dp(a,b){return J.e7(a).i(a,b)},
+dq(a,b){return J.e7(a).i(a,b)},
 pl(a,b){return J.y1(a).bB(a,b)},
 o9(a){return J.bV(a).fA(a)},
-I(a,b,c){return J.bV(a).cH(a,b,c)},
+J(a,b,c){return J.bV(a).cH(a,b,c)},
 pm(a,b,c){return J.bV(a).fB(a,b,c)},
 tG(a,b,c){return J.bV(a).dO(a,b,c)},
 tH(a,b,c){return J.bV(a).fC(a,b,c)},
@@ -164,17 +164,17 @@ tK(a){return J.bV(a).fG(a)},
 aC(a,b,c){return J.bV(a).cI(a,b,c)},
 po(a,b){return J.e7(a).aC(a,b)},
 tL(a){return J.bV(a).gt(a)},
-Z(a){return J.di(a).gD(a)},
+Z(a){return J.dj(a).gD(a)},
 pp(a){return J.a9(a).gap(a)},
 bh(a){return J.e7(a).gV(a)},
 tM(a){return J.e7(a).gaq(a)},
 a6(a){return J.a9(a).gp(a)},
-tN(a){return J.di(a).gag(a)},
+tN(a){return J.dj(a).gag(a)},
 tO(a){return J.rC(a).cj(a)},
 tP(a,b){return J.e7(a).aJ(a,b)},
 tQ(a,b){return J.e7(a).cT(a,b)},
 eb(a){return J.rC(a).K(a)},
-cO(a){return J.di(a).m(a)},
+cO(a){return J.dj(a).m(a)},
 hB:function hB(){},
 hD:function hD(){},
 eA:function eA(){},
@@ -197,7 +197,7 @@ _.$ti=c},
 dB:function dB(){},
 dA:function dA(){},
 eB:function eB(){},
-cS:function cS(){}},A={om:function om(){},
+cT:function cT(){}},A={om:function om(){},
 uK(a){return new A.cn("Field '"+a+"' has been assigned during initialization.")},
 uM(a){return new A.cn("Field '"+a+"' has not been initialized.")},
 uL(a){return new A.cn("Field '"+a+"' has already been initialized.")},
@@ -216,9 +216,9 @@ f5(a,b,c,d){A.eZ(b,"start")
 if(c!=null){A.eZ(c,"end")
 if(b>c)A.Q(A.aA(b,0,c,"start",null))}return new A.f4(a,b,c,d.l("f4<0>"))},
 os(a,b,c,d){if(t.gt.b(a))return new A.eh(a,b,c.l("@<0>").am(d).l("eh<1,2>"))
-return new A.cV(a,b,c.l("@<0>").am(d).l("cV<1,2>"))},
-bn(){return new A.d7("No element")},
-pN(){return new A.d7("Too many elements")},
+return new A.cW(a,b,c.l("@<0>").am(d).l("cW<1,2>"))},
+bn(){return new A.d8("No element")},
+pN(){return new A.d8("Too many elements")},
 b_:function b_(a){this.a=0
 this.b=a},
 dT:function dT(a){this.a=0
@@ -239,7 +239,7 @@ _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-cV:function cV(a,b,c){this.a=a
+cW:function cW(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 eh:function eh(a,b,c){this.a=a
@@ -266,7 +266,7 @@ this.$ti=b},
 fe:function fe(a,b){this.a=a
 this.$ti=b},
 aP:function aP(){},
-d8:function d8(){},
+d9:function d9(){},
 dR:function dR(){},
 f_:function f_(a,b){this.a=a
 this.$ti=b},
@@ -307,7 +307,7 @@ if(r==="NaN"||r==="+NaN"||r==="-NaN")return s
 return null}return s},
 i7(a){var s,r,q,p
 if(a instanceof A.K)return A.aV(A.bW(a),null)
-s=J.di(a)
+s=J.dj(a)
 if(s===B.ds||s===B.du||t.cx.b(a)){r=B.aC(a)
 if(r!=="Object"&&r!=="")return r
 q=a.constructor
@@ -425,7 +425,7 @@ try{$expr$.$method$($argumentsExpr$)}catch(s){return s.message}}(a)},
 qx(a){return function($expr$){try{$expr$.$method$}catch(s){return s.message}}(a)},
 oo(a,b){var s=b==null,r=s?null:b.method
 return new A.hH(a,r,s?null:b.receiver)},
-J(a){var s
+I(a){var s
 if(a==null)return new A.hR(a)
 if(a instanceof A.ek){s=a.a
 return A.cN(a,s==null?A.e0(s):s)}if(typeof a!=="object")return a
@@ -504,7 +504,7 @@ default:s=null}if(s!=null)return s.bind(a)
 return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.x4)},
 u7(a2){var s,r,q,p,o,n,m,l,k,j,i=a2.co,h=a2.iS,g=a2.iI,f=a2.nDA,e=a2.aI,d=a2.fs,c=a2.cs,b=d[0],a=c[0],a0=i[b],a1=a2.fT
 a1.toString
-s=h?Object.create(new A.ik().constructor.prototype):Object.create(new A.dq(null,null).constructor.prototype)
+s=h?Object.create(new A.ik().constructor.prototype):Object.create(new A.dr(null,null).constructor.prototype)
 s.$initialize=s.constructor
 r=h?function static_tear_off(){this.$initialize()}:function tear_off(a3,a4){this.$initialize(a3,a4)}
 s.constructor=r
@@ -560,7 +560,7 @@ p_(a){return A.u7(a)},
 tU(a,b){return A.fK(v.typeUniverse,A.bW(a.a),b)},
 pz(a){return a.a},
 tV(a){return a.b},
-pw(a){var s,r,q,p=new A.dq("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
+pw(a){var s,r,q,p=new A.dr("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
 o.$flags=1
 s=o
 for(o=s.length,r=0;r<o;++r){q=s[r]
@@ -679,7 +679,7 @@ this.c=c},
 A:function A(a){this.a=a},
 fD:function fD(a){this.a=a},
 fE:function fE(a){this.a=a},
-dt:function dt(){},
+du:function du(){},
 aY:function aY(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
@@ -720,7 +720,7 @@ h9:function h9(){},
 ha:function ha(){},
 iq:function iq(){},
 ik:function ik(){},
-dq:function dq(a,b){this.a=a
+dr:function dr(a,b){this.a=a
 this.b=b},
 ic:function ic(a){this.a=a},
 bK:function bK(a){var _=this
@@ -742,7 +742,7 @@ _.d=null
 _.$ti=d},
 eG:function eG(a,b){this.a=a
 this.$ti=b},
-cU:function cU(a,b,c,d){var _=this
+cV:function cV(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -750,7 +750,7 @@ _.d=null
 _.$ti=d},
 c2:function c2(a,b){this.a=a
 this.$ti=b},
-cT:function cT(a,b,c,d){var _=this
+cU:function cU(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -771,7 +771,7 @@ nH:function nH(a){this.a=a},
 nI:function nI(a){this.a=a},
 aT:function aT(){},
 dX:function dX(){},
-df:function df(){},
+dg:function dg(){},
 cF:function cF(){},
 dC:function dC(a,b){var _=this
 _.a=a
@@ -798,7 +798,7 @@ _.c=c
 _.d=null},
 yp(a){throw A.ao(A.uK(a),new Error())},
 k(){throw A.ao(A.uM(""),new Error())},
-dl(){throw A.ao(A.uL(""),new Error())},
+dm(){throw A.ao(A.uL(""),new Error())},
 w8(){var s=new A.m6()
 return s.b=s},
 m6:function m6(){this.b=null},
@@ -860,8 +860,8 @@ eK:function eK(){},
 eL:function eL(){},
 eN:function eN(){},
 eO:function eO(){},
-cW:function cW(){},
 cX:function cX(){},
+cY:function cY(){},
 fu:function fu(){},
 fv:function fv(){},
 fw:function fw(){},
@@ -960,7 +960,7 @@ if(A.qk(b))if(a instanceof A.aN){s=A.nv(a)
 if(s!=null)return s}return A.bW(a)},
 bW(a){if(a instanceof A.K)return A.G(a)
 if(Array.isArray(a))return A.ar(a)
-return A.oR(J.di(a))},
+return A.oR(J.dj(a))},
 ar(a){var s=a[v.arrayRti],r=t.dG
 if(s==null)return r
 if(s.constructor!==r.constructor)return r
@@ -1001,7 +1001,7 @@ s.b=A.xD(s)
 return s.b(a)},
 xD(a){var s,r,q,p,o
 if(a===t.K)return A.xa
-if(A.dk(a))return A.xe
+if(A.dl(a))return A.xe
 s=a.w
 if(s===6)return A.wV
 if(s===1)return A.r9
@@ -1009,7 +1009,7 @@ if(s===7)return A.x5
 r=A.xB(a)
 if(r!=null)return r
 if(s===8){q=a.x
-if(a.y.every(A.dk)){a.f="$i"+q
+if(a.y.every(A.dl)){a.f="$i"+q
 if(q==="i")return A.x8
 if(a===t.m)return A.x7
 return A.xd}}else if(s===10){p=A.xY(a.x,a.y)
@@ -1020,14 +1020,14 @@ if(a===t.i||a===t.r)return A.x9
 if(a===t.N)return A.xc
 if(a===t.y)return A.bq}return null},
 wZ(a){var s=this,r=A.wS
-if(A.dk(s))r=A.wH
+if(A.dl(s))r=A.wH
 else if(s===t.K)r=A.e0
 else if(A.e8(s)){r=A.wU
 if(s===t.aV)r=A.wG
 else if(s===t.jv)r=A.oM
 else if(s===t.o9)r=A.fN
 else if(s===t.jh)r=A.qW
-else if(s===t.jX)r=A.dg
+else if(s===t.jX)r=A.dh
 else if(s===t.mU)r=A.oL}else if(s===t.S)r=A.B
 else if(s===t.N)r=A.a8
 else if(s===t.y)r=A.bf
@@ -1045,14 +1045,14 @@ xd(a){var s,r=this
 if(a==null)return A.e8(r)
 s=r.f
 if(a instanceof A.K)return!!a[s]
-return!!J.di(a)[s]},
+return!!J.dj(a)[s]},
 x8(a){var s,r=this
 if(a==null)return A.e8(r)
 if(typeof a!="object")return!1
 if(Array.isArray(a))return!0
 s=r.f
 if(a instanceof A.K)return!!a[s]
-return!!J.di(a)[s]},
+return!!J.dj(a)[s]},
 x7(a){var s=this
 if(a==null)return!1
 if(typeof a=="object"){if(a instanceof A.K)return!!a[s.f]
@@ -1091,7 +1091,7 @@ if(a==null)return a
 throw A.ao(A.bp(a,"bool?"),new Error())},
 D(a){if(typeof a=="number")return a
 throw A.ao(A.bp(a,"double"),new Error())},
-dg(a){if(typeof a=="number")return a
+dh(a){if(typeof a=="number")return a
 if(a==null)return a
 throw A.ao(A.bp(a,"double?"),new Error())},
 ng(a){return typeof a=="number"&&Math.floor(a)===a},
@@ -1235,7 +1235,7 @@ return s},
 wv(a,b,c,d){var s,r,q
 if(d){s=b.w
 r=!0
-if(!A.dk(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.e8(b.x)
+if(!A.dl(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.e8(b.x)
 if(r)return b
 else if(s===1)return t.P}q=new A.bz(null,null)
 q.w=6
@@ -1249,7 +1249,7 @@ a.eC.set(r,s)
 return s},
 wt(a,b,c,d){var s,r
 if(d){s=b.w
-if(A.dk(b)||b===t.K)return b
+if(A.dl(b)||b===t.K)return b
 else if(s===1)return A.fI(a,"bH",[b])
 else if(b===t.P||b===t.T)return t.gK}r=new A.bz(null,null)
 r.w=7
@@ -1352,7 +1352,7 @@ case 58:k.push(!1)
 break
 case 33:k.push(!0)
 break
-case 59:k.push(A.de(a.u,a.e,k.pop()))
+case 59:k.push(A.df(a.u,a.e,k.pop()))
 break
 case 94:k.push(A.ww(a.u,k.pop()))
 break
@@ -1370,10 +1370,10 @@ break
 case 38:A.wh(a,k)
 break
 case 63:p=a.u
-k.push(A.qQ(p,A.de(p,a.e,k.pop()),a.n))
+k.push(A.qQ(p,A.df(p,a.e,k.pop()),a.n))
 break
 case 47:p=a.u
-k.push(A.qP(p,A.de(p,a.e,k.pop()),a.n))
+k.push(A.qP(p,A.df(p,a.e,k.pop()),a.n))
 break
 case 40:k.push(-3)
 k.push(a.p)
@@ -1407,7 +1407,7 @@ a.p=k.length
 r=n+1
 break
 default:throw"Bad character "+q}}}m=k.pop()
-return A.de(a.u,a.e,m)},
+return A.df(a.u,a.e,m)},
 wg(a,b,c,d){var s,r,q=b-48
 for(s=c.length;a<s;++a){r=c.charCodeAt(a)
 if(!(r>=48&&r<=57))break
@@ -1428,7 +1428,7 @@ d.push(A.fK(s,o,n))}else d.push(p)
 return m},
 wi(a,b){var s,r=a.u,q=A.qF(a,b),p=b.pop()
 if(typeof p=="string")b.push(A.fI(r,p,q))
-else{s=A.de(r,a.e,p)
+else{s=A.df(r,a.e,p)
 switch(s.w){case 11:b.push(A.oK(r,s,q,a.n))
 break
 default:b.push(A.oJ(r,s,q))
@@ -1445,7 +1445,7 @@ o=b.pop()
 switch(o){case-3:o=b.pop()
 if(n==null)n=p.sEA
 if(m==null)m=p.sEA
-r=A.de(p,a.e,o)
+r=A.df(p,a.e,o)
 q=new A.iQ()
 q.a=s
 q.b=n
@@ -1463,13 +1463,13 @@ qF(a,b){var s=b.splice(a.p)
 A.qJ(a.u,a.e,s)
 a.p=b.pop()
 return s},
-de(a,b,c){if(typeof c=="string")return A.fI(a,c,a.sEA)
+df(a,b,c){if(typeof c=="string")return A.fI(a,c,a.sEA)
 else if(typeof c=="number"){b.toString
 return A.wj(a,b,c)}else return c},
 qJ(a,b,c){var s,r=c.length
-for(s=0;s<r;++s)c[s]=A.de(a,b,c[s])},
+for(s=0;s<r;++s)c[s]=A.df(a,b,c[s])},
 wk(a,b,c){var s,r=c.length
-for(s=2;s<r;s+=3)c[s]=A.de(a,b,c[s])},
+for(s=2;s<r;s+=3)c[s]=A.df(a,b,c[s])},
 wj(a,b,c){var s,r,q=b.w
 if(q===9){if(c===0)return b.x
 s=b.y
@@ -1489,10 +1489,10 @@ if(s==null){s=A.au(a,b,null,c,null)
 r.set(c,s)}return s},
 au(a,b,c,d,e){var s,r,q,p,o,n,m,l,k,j,i
 if(b===d)return!0
-if(A.dk(d))return!0
+if(A.dl(d))return!0
 s=b.w
 if(s===4)return!0
-if(A.dk(b))return!1
+if(A.dl(b))return!1
 if(b.w===1)return!0
 r=s===13
 if(r)if(A.au(a,c[b.x],c,d,e))return!0
@@ -1578,9 +1578,9 @@ if(b.x!==d.x)return!1
 for(s=0;s<p;++s)if(!A.au(a,r[s],c,q[s],e))return!1
 return!0},
 e8(a){var s=a.w,r=!0
-if(!(a===t.P||a===t.T))if(!A.dk(a))if(s!==6)r=s===7&&A.e8(a.x)
+if(!(a===t.P||a===t.T))if(!A.dl(a))if(s!==6)r=s===7&&A.e8(a.x)
 return r},
-dk(a){var s=a.w
+dl(a){var s=a.w
 return s===2||s===3||s===4||s===5||a===t.iD},
 qU(a,b){var s,r,q=Object.keys(b),p=q.length
 for(s=0;s<p;++s){r=q[s]
@@ -1618,7 +1618,7 @@ b.b=!0
 return b.a},
 an(a,b){A.wI(a,b)},
 b1(a,b){b.dT(a)},
-b0(a,b){b.dU(A.J(a),A.cM(a))},
+b0(a,b){b.dU(A.I(a),A.cM(a))},
 wI(a,b){var s,r,q=new A.n3(b),p=new A.n4(b)
 if(a instanceof A.aq)a.fp(q,p,t.z)
 else{s=t.z
@@ -1663,10 +1663,10 @@ else n=!1
 else n=!0
 if(n){p=b.c5()
 b.cp(o.a)
-A.dc(b,p)
+A.dd(b,p)
 return}b.a^=2
 A.jn(null,null,b.b,t.M.a(new A.mn(o,b)))},
-dc(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
+dd(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
 for(s=t.v,r=t.d;;){q={}
 p=c.a
 o=(p&16)===0
@@ -1675,7 +1675,7 @@ if(b==null){if(n&&(p&1)===0){m=s.a(c.c)
 A.oV(m.a,m.b)}return}q.a=b
 l=b.a
 for(c=b;l!=null;c=l,l=k){c.a=null
-A.dc(d.a,c)
+A.dd(d.a,c)
 q.a=l
 k=l.a}p=d.a
 j=p.c
@@ -1802,7 +1802,7 @@ this.c=c},
 iI:function iI(){},
 ff:function ff(a,b){this.a=a
 this.$ti=b},
-db:function db(a,b,c,d,e){var _=this
+dc:function dc(a,b,c,d,e){var _=this
 _.a=null
 _.b=a
 _.c=b
@@ -1845,7 +1845,7 @@ nj:function nj(a,b){this.a=a
 this.b=b},
 hM(a,b,c){return b.l("@<0>").am(c).l("kp<1,2>").a(A.rz(a,new A.bK(b.l("@<0>").am(c).l("bK<1,2>"))))},
 x(a,b){return new A.bK(a.l("@<0>").am(b).l("bK<1,2>"))},
-aK(a){return new A.dd(a.l("dd<0>"))},
+aK(a){return new A.de(a.l("de<0>"))},
 oH(){var s=Object.create(null)
 s["<non-identifier-key>"]=s
 delete s["<non-identifier-key>"]
@@ -1861,7 +1861,7 @@ a.al(0,new A.kt(r,s))
 s.a+="}"}finally{if(0>=$.bg.length)return A.a($.bg,-1)
 $.bg.pop()}r=s.a
 return r.charCodeAt(0)==0?r:r},
-dd:function dd(a){var _=this
+de:function de(a){var _=this
 _.a=0
 _.f=_.e=_.d=_.c=_.b=null
 _.r=0
@@ -1882,7 +1882,7 @@ N:function N(){},
 aL:function aL(){},
 kt:function kt(a,b){this.a=a
 this.b=b},
-d6:function d6(){},
+d7:function d7(){},
 fF:function fF(){},
 wC(a,b,c){var s,r,q,p,o=c-b
 if(o<=4096)s=$.tr()
@@ -1990,8 +1990,8 @@ jf:function jf(){},
 h0:function h0(){},
 m1:function m1(){this.a=0},
 h3:function h3(){},
-d9:function d9(a){this.a=a},
-ds:function ds(){},
+da:function da(a){this.a=a},
+dt:function dt(){},
 af:function af(){},
 hi:function hi(){},
 eF:function eF(a,b){this.a=a
@@ -2017,7 +2017,7 @@ this.b=16
 this.c=0},
 pI(a,b){return new A.ho(new WeakMap(),a,b.l("ho<0>"))},
 ut(a){},
-dj(a,b){var s=A.qf(a,b)
+dk(a,b){var s=A.qf(a,b)
 if(s!=null)return s
 throw A.d(A.bm(a,null,null))},
 ur(a,b){a=A.ao(a,new Error())
@@ -2088,7 +2088,7 @@ return a},
 oi(a,b,c,d){return new A.hx(b,!0,a,d,"Index out of range")},
 bR(a){return new A.f9(a)},
 qz(a){return new A.is(a)},
-aS(a){return new A.d7(a)},
+aS(a){return new A.d8(a)},
 aX(a){return new A.hc(a)},
 bm(a,b,c){return new A.C(a,b,c)},
 uB(a,b,c){var s,r
@@ -2140,34 +2140,34 @@ B.a.i(b,r)},
 c4(a,b,c,d,e,f,g){var s
 if(B.h===c){s=J.Z(a)
 b=J.Z(b)
-return A.dQ(A.a5(A.a5($.dm(),s),b))}if(B.h===d){s=J.Z(a)
+return A.dQ(A.a5(A.a5($.dn(),s),b))}if(B.h===d){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
-return A.dQ(A.a5(A.a5(A.a5($.dm(),s),b),c))}if(B.h===e){s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5($.dn(),s),b),c))}if(B.h===e){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
-return A.dQ(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d))}if(B.h===f){s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d))}if(B.h===f){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
 e=J.Z(e)
-return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d),e))}if(B.h===g){s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d),e))}if(B.h===g){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
 e=J.Z(e)
 f=J.Z(f)
-return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d),e),f))}s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d),e),f))}s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
 e=J.Z(e)
 f=J.Z(f)
 g=J.Z(g)
-g=A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d),e),f),g))
+g=A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d),e),f),g))
 return g},
-S(a){var s,r,q=$.dm()
+S(a){var s,r,q=$.dn()
 for(s=a.length,r=0;r<a.length;a.length===s||(0,A.l)(a),++r)q=A.a5(q,J.Z(a[r]))
 return A.dQ(q)},
 wL(a,b){return 65536+((a&1023)<<10)+(b&1023)},
@@ -2196,7 +2196,7 @@ _.c=d
 _.d=e},
 f9:function f9(a){this.a=a},
 is:function is(a){this.a=a},
-d7:function d7(a){this.a=a},
+d8:function d8(a){this.a=a},
 hc:function hc(a){this.a=a},
 hS:function hS(){},
 f2:function f2(){},
@@ -2243,15 +2243,15 @@ nU:function nU(a,b){this.a=a
 this.b=b},
 nV:function nV(a){this.a=a},
 vV(a){throw A.d(A.bR("Uint64List not supported on the web."))},
-tW(a){return J.I(a,0,null)},
+tW(a){return J.J(a,0,null)},
 aD(a){var s=a.BYTES_PER_ELEMENT,r=A.bc(0,null,B.b.S(a.byteLength,s))
-return J.I(B.d.gt(a),a.byteOffset+0*s,r*s)},
+return J.J(B.d.gt(a),a.byteOffset+0*s,r*s)},
 Y(a,b,c){var s=a.BYTES_PER_ELEMENT
 c=A.bc(b,c,B.b.S(a.byteLength,s))
 return J.aC(J.tL(a),a.byteOffset+b*s,(c-b)*s)},
 k2(a,b,c){var s=a.BYTES_PER_ELEMENT,r=(A.bc(b,c,B.b.S(a.byteLength,s))-b)*s
 if(B.b.ah(r,4)!==0)throw A.d(A.bj(u.a,null))
-return J.pm(B.t.gt(a),a.byteOffset+b*s,B.b.W(r,4))},
+return J.pm(B.u.gt(a),a.byteOffset+b*s,B.b.W(r,4))},
 uv(a){return a.dO(0,0,null)},
 k3(a,b,c){var s=a.BYTES_PER_ELEMENT,r=(A.bc(b,c,B.b.S(a.byteLength,s))-b)*s
 if(B.b.ah(r,8)!==0)throw A.d(A.bj("The number of bytes to view must be a multiple of 8",null))
@@ -2385,7 +2385,7 @@ p.a=0
 s=new A.nx(p,b)
 try{r=s.$1(a)
 p=p.a===b.length?r:null
-return p}catch(q){if(A.J(q) instanceof A.d7)return null
+return p}catch(q){if(A.I(q) instanceof A.d8)return null
 else throw q}},
 cz:function cz(a,b,c){this.a=a
 this.b=b
@@ -2416,7 +2416,7 @@ r.buffer=s
 a.postMessage(r,A.b([s],t.f))},
 qX(a,b,c){var s
 if(b==null||c==null)return
-s=$.d3
+s=$.d4
 if(s){a.cosStats=B.cv.kE(A.vp().h8(),null)
 A.vo()}a.workerUs=c
 a.parseUs=0
@@ -2579,7 +2579,7 @@ for(;;)switch(s){case 0:b=A.b([],t.lO)
 p=J.bh(a0),o=!1
 case 3:if(!p.u()){s=4
 break}n=p.gF()
-if(a1.a)throw A.d(new A.cZ())
+if(a1.a)throw A.d(new A.d_())
 m=n instanceof A.bo
 l=m?n.a:null
 s=m?6:7
@@ -2631,7 +2631,7 @@ if(!("Blob" in g&&"createImageBitmap" in g&&"OffscreenCanvas" in g)){q=null
 s=1
 break}p=b.a
 g=p.a
-if(a.j(g.h(0,"ImageMask")).I(0,B.q)){q=null
+if(a.j(g.h(0,"ImageMask")).I(0,B.r)){q=null
 s=1
 break}o=A.e9(a,p)
 if(B.a.a_(o,"DCTDecode"))n="DCTDecode"
@@ -2695,7 +2695,7 @@ break A}n=o>0
 m=n?A.nS(a,b,o):null
 l=n?A.nR(a,b,o):null
 if(m!=null||l!=null)A.yf(k.a,o,m,l)
-q=new A.d0(k.a,k.b,k.c,l==null)
+q=new A.d1(k.a,k.b,k.c,l==null)
 s=1
 break
 case 1:return A.b1(q,r)}})
@@ -2717,7 +2717,7 @@ s=1
 break A}i=l[i]
 if(!(j<n)){q=A.a(m,j)
 s=1
-break A}m[j]=i}q=new A.d1(m,p,o)
+break A}m[j]=i}q=new A.d2(m,p,o)
 s=1
 break
 case 1:return A.b1(q,r)}})
@@ -2821,7 +2821,7 @@ this.b=b},
 f(a,b,c){return new A.hn(a,b)},
 hn:function hn(a,b){this.a=a
 this.b=b},
-cR:function cR(a){this.a=a},
+cS:function cS(a){this.a=a},
 dx:function dx(a,b){this.a=a
 this.b=b},
 uz(a,b){var s,r=J.dz(b,t.ba)
@@ -2857,7 +2857,7 @@ hb:function hb(a,b,c){this.e=a
 this.f=b
 this.r=c},
 ck:function ck(){},
-cQ:function cQ(a){this.a=a},
+cR:function cR(a){this.a=a},
 em:function em(a){this.a=a},
 kl:function kl(){this.d=null},
 cm:function cm(a,b,c,d){var _=this
@@ -2927,9 +2927,9 @@ case 3:return new A.L(t.p.a(b.c),!0)
 case 4:return new A.u(A.a8(b.c))
 case 5:return A.ug(a)
 case 7:return A.ue(a)
-case 9:switch(A.a8(b.c)){case"true":return B.q
+case 9:switch(A.a8(b.c)){case"true":return B.r
 case"false":return B.ab
-case"null":return B.u}throw A.d(A.z('unexpected keyword "'+b.gh6()+'"',b.b))
+case"null":return B.n}throw A.d(A.z('unexpected keyword "'+b.gh6()+'"',b.b))
 case 10:throw A.d(A.z("unexpected end of input",b.b))
 case 6:case 8:throw A.d(A.z("unexpected token "+b.m(0),b.b))}},
 ug(a){var s,r,q,p=A.b([],t.q)
@@ -2959,7 +2959,7 @@ uf(a){var s,r,q,p,o,n,m,l,k=A.aJ(null),j=k.a
 for(;;){if(!!0){s=null
 break}r=a.L()
 q=r.a
-if(q===B.n&&r.c==="ID"){s=r
+if(q===B.o&&r.c==="ID"){s=r
 break}if(q===B.C)throw A.d(A.z("unterminated inline image",r.b))
 if(q!==B.O)throw A.d(A.z("expected name in inline image dictionary, found "+r.m(0),r.b))
 j.k(0,A.a8(r.c),A.hd(a,a.L()))}p=a.a
@@ -3228,9 +3228,9 @@ else for(r=n.length,o=t.t,q=19;q>=0;--q){l=A.b([],o)
 for(k=0;k<r;++k)l.push((n[k]^q)>>>0)
 m=A.fU(l,new Uint8Array(A.H(m)))}j=A.qr(new Uint8Array(A.H(m)),b,d,e,f,g,h)
 if(A.qq(j,c,e,g))return j
-throw A.d(new A.cP())},
+throw A.d(new A.cQ())},
 vB(a,b,c,d,e,f){var s,r,q,p,o,n,m=new A.ln(f,a)
-if(c.length<48||d.length<48)throw A.d(new A.cP())
+if(c.length<48||d.length<48)throw A.d(new A.cQ())
 s=B.a8.aa(b)
 if(s.length>127)s=B.d.a1(s,0,127)
 r=new A.lo(e)
@@ -3241,7 +3241,7 @@ return m.dS(new Uint8Array(16),B.d.a1(p,0,32))}}o=B.d.a1(d,0,48)
 if(A.lp(r.$3(s,B.d.a1(c,32,40),o),B.d.a1(c,0,32))){q=r.$3(s,B.d.a1(c,40,48),o)
 n=m.$1("OE")
 if(n.length>=32){m=A.oa(q)
-return m.dS(new Uint8Array(16),B.d.a1(n,0,32))}}throw A.d(new A.cP())},
+return m.dS(new Uint8Array(16),B.d.a1(n,0,32))}}throw A.d(new A.cQ())},
 vD(a,b,c){var s,r,q,p,o,n,m,l,k,j,i,h="Hash.add() called after close().",g=t.S,f=A.al(a,g)
 B.a.T(f,b)
 B.a.T(f,c)
@@ -3321,8 +3321,8 @@ try{r=A.uj(a,s)
 r.eP(b)
 q=r.j(r.d.a.h(0,"Root"))
 if(!(q instanceof A.p)){n=A.z("trailer /Root does not resolve",null)
-throw A.d(n)}return r}catch(m){n=A.J(m)
-if(n instanceof A.cP)throw m
+throw A.d(n)}return r}catch(m){n=A.I(m)
+if(n instanceof A.cQ)throw m
 else if(n instanceof A.f8)throw m
 else if(!t.I.b(n))if(!t.b0.b(n))throw m}n=A.uk(a,s,b)
 return n}finally{A.cy(B.bK,l)}},
@@ -3349,7 +3349,7 @@ if(a3<0)break
 try{a3=r
 if(typeof a3!=="number")return a3.R()
 q=new A.c_(new A.bG(b6,a3+7),b1,A.b([],a2)).bn()
-if(q instanceof A.p)q.a.al(0,new A.jN(s))}catch(a4){if(!a1.b(A.J(a4)))throw a4}a3=r
+if(q instanceof A.p)q.a.al(0,new A.jN(s))}catch(a4){if(!a1.b(A.I(a4)))throw a4}a3=r
 if(typeof a3!=="number")return a3.R()
 r=a3+7}p=A.pF(b6,b7,b5,s,0)
 a2=b5
@@ -3364,7 +3364,7 @@ m=n.a.a.h(0,b2)
 if(!(m instanceof A.u)||m.a!=="XRef")continue
 for(a7=0;a7<4;++a7){l=B.e_[a7]
 k=n.a.a.h(0,A.a8(l))
-if(k!=null)s.a.k(0,l,k)}}catch(a4){if(a1.b(A.J(a4)))continue
+if(k!=null)s.a.k(0,l,k)}}catch(a4){if(a1.b(A.I(a4)))continue
 else throw a4}}p.f.A(0)
 p.r.A(0)
 p.eP(b8)
@@ -3395,7 +3395,7 @@ d=B.a.h(b0,e).a
 b5.ad(d,new A.jO(j,e))
 a9=e
 if(typeof a9!=="number")return a9.R()
-e=a9+1}}catch(a4){if(!a1.b(A.J(a4)))throw a4}}if(!(p.j(s.a.h(0,b3)) instanceof A.p)){s.a.b1(0,b3)
+e=a9+1}}catch(a4){if(!a1.b(A.I(a4)))throw a4}}if(!(p.j(s.a.h(0,b3)) instanceof A.p)){s.a.b1(0,b3)
 a2=b5
 a2=A.al(new A.ah(a2,A.G(a2).l("ah<1>")),a3)
 a3=a2.length
@@ -3407,7 +3407,7 @@ b=a5
 a=p.bq(c,b.c)
 if(a instanceof A.p){a0=p.j(a.a.h(0,b2))
 if(a0 instanceof A.u&&a0.a==="Catalog"){s.a.k(0,b3,new A.av(c,b.c))
-break}}}catch(a4){if(a1.b(A.J(a4)))continue
+break}}}catch(a4){if(a1.b(A.I(a4)))continue
 else throw a4}}}b4.a=0
 for(a1=b5,a1=new A.az(a1,a1.r,a1.e,A.G(a1).l("az<1>"));a1.u();){a2=a1.d
 if(a2>b4.a)b4.a=a2}s.a.ad("Size",new A.jP(b4))
@@ -3485,12 +3485,12 @@ this.b=b},
 dW:function dW(a,b,c){this.a=a
 this.b=b
 this.c=c},
-z(a,b){return new A.du(a,b)},
+z(a,b){return new A.cP(a,b)},
 oC(a){return new A.f8(a)},
-du:function du(a,b){this.a=a
+cP:function cP(a,b){this.a=a
 this.b=b},
 iu:function iu(a){this.a=a},
-cP:function cP(){},
+cQ:function cQ(){},
 f8:function f8(a){this.a=a},
 fY:function fY(){},
 fX:function fX(){},
@@ -3500,9 +3500,9 @@ p=q.length
 if(p!==2)continue
 if(0>=p)return A.a(q,0)
 o=q[0]
-n=A.dj(o,2)
+n=A.dk(o,2)
 if(1>=p)return A.a(q,1)
-l.k(0,(o.length<<16|n)>>>0,A.dj(q[1],null))}return l},
+l.k(0,(o.length<<16|n)>>>0,A.dk(q[1],null))}return l},
 h8:function h8(){},
 jA:function jA(a){this.a=a},
 jz:function jz(a){this.a=a},
@@ -3533,7 +3533,7 @@ n=B.ek.h(0,i)
 if(n==null){if(!(o<g.length))return A.a(g,o)
 throw A.d(new A.iu(g[o]))}m=A.cx()
 p=n.bE(p,o<q.length?q[o]:null)
-k=$.d3
+k=$.d4
 if(k){if(!(o<g.length))return A.a(g,o)
 A.xq(g[o],m,p.length)}}if(k!==0)A.by(B.bF,1)
 return p},
@@ -3596,7 +3596,7 @@ j=m*l+B.c.q(j,3)
 l=J.a4(p,j)
 m=n
 if(typeof m!=="number")return m.e9()
-J.dn(p,j,l&~(128>>>(m&7)))}m=n
+J.dp(p,j,l&~(128>>>(m&7)))}m=n
 if(typeof m!=="number")return m.R()
 n=m+1}m=o
 if(typeof m!=="number")return m.R()
@@ -3804,9 +3804,9 @@ m===$&&A.k()
 p.$7(b,d,o,n,m,1,1)
 l=new Float32Array(h)
 for(k=0;k<g;){d=k*h
-B.t.au(l,0,h,e,d)
+B.u.au(l,0,h,e,d)
 A.rg(l,a7,a6);++k
-B.t.C(e,d,k*h,l)}j=new Float32Array(g)
+B.u.C(e,d,k*h,l)}j=new Float32Array(g)
 for(i=0;i<h;++i){for(k=0;k<g;++k){d=k*h+i
 if(!(d>=0&&d<f))return A.a(e,d)
 d=e[d]
@@ -3850,7 +3850,7 @@ s.$2(0.443506852043971,!0)
 s.$2(0.882911075530934,!1)
 s.$2(-0.052980118572961,!0)
 s.$2(-1.586134342059924,!1)
-B.t.C(q,0,k,l.a)}B.t.C(a,0,k,q)},
+B.u.C(q,0,k,l.a)}B.u.C(a,0,k,q)},
 ko:function ko(a,b,c,d){var _=this
 _.a=a
 _.b=b
@@ -4043,10 +4043,10 @@ this.c=c},
 c_:function c_(a,b,c){this.a=a
 this.b=b
 this.c=c},
-cx(){var s=$.d3
+cx(){var s=$.d4
 if(!s)return 0
 return $.ov.gac()},
-cy(a,b){var s,r=$.d3
+cy(a,b){var s,r=$.d4
 if(!r)return
 r=$.i2
 s=a.a
@@ -4055,13 +4055,13 @@ B.a.k(r,s,r[s]+($.ov.gac()-b))
 b=$.l5
 if(!(s<b.length))return A.a(b,s)
 B.a.k(b,s,b[s]+1)},
-by(a,b){var s,r=$.d3
+by(a,b){var s,r=$.d4
 if(!r)return
 r=$.l3
 s=a.a
 if(!(s<r.length))return A.a(r,s)
 B.a.k(r,s,r[s]+b)},
-qb(a,b){var s,r=$.d3
+qb(a,b){var s,r=$.d4
 if(!r)return
 r=$.l4
 s=a.a
@@ -4123,7 +4123,7 @@ if(p.a!==B.w)A.Q(A.z(f+p.m(0),p.b))
 k=A.B(p.c)
 j=q.length!==0?B.a.ae(q,0):r.L()
 i=o+m
-h=j.a===B.n
+h=j.a===B.o
 if(h&&j.c==="n")s.ad(i,new A.jZ(l,k))
 else if(h&&j.c==="f")s.ad(i,new A.k_())
 else throw A.d(A.z("invalid xref entry type",j.b))}}a.cP("trailer")
@@ -4470,10 +4470,10 @@ this.a=c},
 jr(a,b){var s,r=b==null?J.a6(a):b,q=new A.nw(a)
 A:{if(1===r){s=q.$1(0)
 s=new A.M(s,s,s)
-break A}if(4===r){s=A.d_(q.$1(0),q.$1(1),q.$1(2),q.$1(3))
+break A}if(4===r){s=A.d0(q.$1(0),q.$1(1),q.$1(2),q.$1(3))
 break A}s=new A.M(q.$1(0),q.$1(1),q.$1(2))
 break A}return s},
-d_(a,b,c,d){var s=B.c.n(a,0,1),r=B.c.n(b,0,1),q=B.c.n(c,0,1),p=B.c.n(d,0,1)
+d0(a,b,c,d){var s=B.c.n(a,0,1),r=B.c.n(b,0,1),q=B.c.n(c,0,1),p=B.c.n(d,0,1)
 return new A.M(B.c.n((255+s*(-4.387332384609988*s+54.48615194189176*r+18.82290502165302*q+212.25662451639585*p+-285.2331026137004)+r*(1.7149763477362134*r+-5.6096736904047315*q+-17.873870861415444*p+-5.497006427196366)+q*(-2.5217340131683033*q+-21.248923337353073*p+17.5119270841813)+p*(-21.86122147463605*p+-189.48180835922747))/255,0,1),B.c.n((255+s*(8.841041422036149*s+60.118027045597366*r+6.871425592049007*q+31.159100130055922*p+-79.2970844816548)+r*(-15.310361306967817*r+17.575251261109482*q+131.35250912493976*p+-190.9453302588951)+q*(4.444339102852739*q+9.8632861493405*p+-24.86741582555878)+p*(-20.737325471181034*p+-187.80453709719578))/255,0,1),B.c.n((255+s*(0.8842522430003296*s+8.078677503112928*r+30.89978309703729*q+-0.23883238689178934*p+-14.183576799673286)+r*(10.49593273432072*r+63.02378494754052*q+50.606957656360734*p+-112.23884253719248)+q*(0.03296041114873217*q+115.60384449646641*p+-193.58209356861505)+p*(-22.33816807309886*p+-180.12613974708367))/255,0,1))},
 nw:function nw(a){this.a=a},
 M:function M(a,b,c){this.a=a
@@ -4505,7 +4505,7 @@ p=r instanceof A.m?r.a:3
 o=c!=null?c.ad(s,new A.kB(a,s)):A.pZ(a,s)}}return new A.fn(o,p)},
 pZ(a,b){var s,r
 try{s=A.uy(a.a3(b))
-return s}catch(r){if(t.I.b(A.J(r)))return null
+return s}catch(r){if(t.I.b(A.I(r)))return null
 else throw r}},
 pY(a){var s
 A:{if("DeviceGray"===a||"G"===a){s=B.R
@@ -4527,7 +4527,7 @@ if(3>=k.length)return A.a(k,3)
 s=a.j(k[3])
 r=null
 if(s instanceof A.L)r=s.a
-else if(s instanceof A.y)try{r=a.a3(s)}catch(m){if(t.I.b(A.J(m)))return l
+else if(s instanceof A.y)try{r=a.a3(s)}catch(m){if(t.I.b(A.I(m)))return l
 else throw m}else return l
 return new A.fo(q,n,r)},
 wp(a,b,c,d,e){var s,r=b.a
@@ -4638,7 +4638,7 @@ a6=c8.j(b8.h(0,b7))
 if(a6 instanceof A.p){e=A.q4(c8,a6)
 d=e==null?A.q3(c8,a6):b5
 b=A.q2(c8,a6)}r=c8.j(b8.h(0,"CIDToGIDMap"))
-if(r instanceof A.y)try{s=c8.a3(r)}catch(a7){if(t.I.b(A.J(a7)))s=null
+if(r instanceof A.y)try{s=c8.a3(r)}catch(a7){if(t.I.b(A.I(a7)))s=null
 else throw a7}}else a5=B.ad
 a8=e==null&&d==null&&g.gap(g)?c4?A.u2(a.a):b5:b5
 a9=B.Q}else{a9=A.vh(c8,b8.h(0,b6),c2)
@@ -4715,12 +4715,12 @@ for(q=t.I,p=b.a,o=0;o<2;++o){s=a.j(p.h(0,B.dP[o]))
 if(!(s instanceof A.y))continue
 try{r=A.vL(a.a3(s))
 if(r!=null){n=r
-return n}}catch(m){if(q.b(A.J(m)))A.by(B.a_,1)
+return n}}catch(m){if(q.b(A.I(m)))A.by(B.a_,1)
 else throw m}}return null},
 va(a,b){var s,r,q=a.j(b.a.h(0,"FontFile"))
 if(!(q instanceof A.y))return null
 try{s=A.vU(a.a3(q))
-return s}catch(r){if(t.I.b(A.J(r))){A.by(B.a_,1)
+return s}catch(r){if(t.I.b(A.I(r))){A.by(B.a_,1)
 return null}else throw r}},
 q2(a,b){var s=a.j(b.a.h(0,"Flags"))
 return s instanceof A.m&&(s.a&4)!==0},
@@ -4729,7 +4729,7 @@ for(q=t.I,p=b.a,o=0;o<2;++o){s=a.j(p.h(0,B.dQ[o]))
 if(!(s instanceof A.y))continue
 try{r=A.u1(a.a3(s))
 if(r!=null){n=r
-return n}}catch(m){if(q.b(A.J(m)))A.by(B.a_,1)
+return n}}catch(m){if(q.b(A.I(m)))A.by(B.a_,1)
 else throw m}}return null},
 v7(a){var s,r
 if(a==null)return!1
@@ -4792,7 +4792,7 @@ if(n<s&&a[n]===32)r=n}else B.a.i(m,q)}return m},
 vg(a,b){var s,r,q,p,o,n,m,l=a.j(b)
 if(!(l instanceof A.y))return B.Q
 s=null
-try{s=a.a3(l)}catch(o){if(t.I.b(A.J(o)))return B.Q
+try{s=a.a3(l)}catch(o){if(t.I.b(A.I(o)))return B.Q
 else throw o}r=A.x(t.S,t.N)
 q=new A.c_(new A.bG(s,0),null,A.b([],t.O))
 try{for(;;){n=q
@@ -4800,19 +4800,19 @@ m=n.c
 p=m.length!==0?B.a.ae(m,0):n.a.L()
 if(p.a===B.C)break
 n=p
-if(n.a===B.n&&n.c==="beginbfchar")A.vc(q,r)
+if(n.a===B.o&&n.c==="beginbfchar")A.vc(q,r)
 else{n=p
-if(n.a===B.n&&n.c==="beginbfrange")A.vd(q,r)}}}catch(o){if(!(A.J(o) instanceof A.du))throw o}return r},
+if(n.a===B.o&&n.c==="beginbfrange")A.vd(q,r)}}}catch(o){if(!(A.I(o) instanceof A.cP))throw o}return r},
 vc(a,b){var s,r,q,p,o,n
 for(s=a.a,r=a.c,q=t.p;;){p=r.length!==0?B.a.ae(r,0):s.L()
 o=p.a
-if(o===B.n&&p.c==="endbfchar"||o===B.C)return
+if(o===B.o&&p.c==="endbfchar"||o===B.C)return
 n=r.length!==0?B.a.ae(r,0):s.L()
 if(o===B.H&&n.a===B.H)b.k(0,A.kH(q.a(p.c)),A.ou(q.a(n.c)))}},
 vd(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d
 for(s=t.p,r=a.a,q=a.c,p=t.Y;;){o=q.length!==0?B.a.ae(q,0):r.L()
 n=o.a
-if(n===B.n&&o.c==="endbfrange"||n===B.C)return
+if(n===B.o&&o.c==="endbfrange"||n===B.C)return
 m=q.length!==0?B.a.ae(q,0):r.L()
 if(n!==B.H||m.a!==B.H)return
 l=A.kH(s.a(o.c))
@@ -4910,10 +4910,10 @@ return A.Y(a,l,l+((m<<24|n<<16|o<<8|a[p])>>>0))}}return k},
 tX(b3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0=null,b1={},b2=new A.ch(b3)
 b2.b=2
 b2.b=b2.P()
-A.dr(b2)
-s=A.dr(b2)
-r=A.dr(b2)
-q=A.dr(b2)
+A.ds(b2)
+s=A.ds(b2)
+r=A.ds(b2)
+q=A.ds(b2)
 p=s.length
 if(p===0)return b0
 if(0>=p)return A.a(s,0)
@@ -4922,7 +4922,7 @@ n=A.ee(o.h(0,17))
 if(n==null)return b0
 p=new A.ch(b3)
 p.b=n
-m=A.dr(p)
+m=A.ds(p)
 if(m.length===0)return b0
 l=o.ak(3079)
 p=t.n
@@ -4936,7 +4936,7 @@ g=A.b([],t.mL)
 f=A.b([],t.iP)
 e=o.ak(3102)
 if(e){d=A.ee(o.h(0,3108))
-if(d!=null)for(j=new A.ch(b3),j.b=d,j=A.dr(j),i=j.length,h=0;h<j.length;j.length===i||(0,A.l)(j),++h){c=A.oe(b3,j[h])
+if(d!=null)for(j=new A.ch(b3),j.b=d,j=A.ds(j),i=j.length,h=0;h<j.length;j.length===i||(0,A.l)(j),++h){c=A.oe(b3,j[h])
 B.a.i(g,A.qK(b3,c.h(0,18)))
 b=c.h(0,3079)
 if(b==null||b.length<6)a=b0
@@ -4957,7 +4957,7 @@ if(a7==null)a7=0
 if(a7>1)A.tZ(b3,a7,a5,a6)
 else for(a8=32;a8<=126;++a8){a9=a6.h(0,a8-31)
 if(a9!=null)a5.k(0,a8,a9)}}return new A.jB(b3,m,q,g,a3,b1.a,a5,k,f,l,a4,r,A.x(p,t.ak),A.x(p,t.i))},
-dr(a){var s,r,q,p,o,n,m,l=a.H()
+ds(a){var s,r,q,p,o,n,m,l=a.H()
 if(l===0)return B.ag
 s=new A.jG(a.P(),a)
 r=A.b([],t.t)
@@ -5094,7 +5094,7 @@ p=A.oe(a,new A.j(q,q+r))
 o=A.ee(p.h(0,19))
 if(o!=null){s=new A.ch(a)
 s.b=q+o
-n=A.dr(s)}else n=B.ag
+n=A.ds(s)}else n=B.ag
 s=p.h(0,20)
 if(s==null)s=l
 else s=s.length===0?l:B.a.gaY(s)
@@ -5259,7 +5259,7 @@ lH:function lH(a){this.a=a},
 bA:function bA(a,b,c){this.a=a
 this.b=b
 this.c=c},
-da:function da(a,b,c,d){var _=this
+db:function db(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -5298,7 +5298,7 @@ else{h=e.b
 if(1>=h.length)return A.a(h,1)
 h=h[1]
 h.toString
-d=A.dj(h,b)}k=d
+d=A.dk(h,b)}k=d
 j=A.vR(n,k)
 i=A.vO(n,k)
 if(i.a===0)return b
@@ -5381,7 +5381,7 @@ n=(o==null?p.a(o):o).b
 if(1>=n.length)return A.a(n,1)
 m=n[1]
 m.toString
-m=A.dj(m,null)
+m=A.dk(m,null)
 if(2>=n.length)return A.a(n,2)
 n=n[2]
 n.toString
@@ -5398,7 +5398,7 @@ else{s=p.b
 if(1>=s.length)return A.a(s,1)
 s=s[1]
 s.toString
-o=A.dj(s,null)}s=o<=0?0:o
+o=A.dk(s,null)}s=o<=0?0:o
 n=A.W(s,null,!1,t.X)
 for(m=f;;m=g){l=A.f6(a,new A.br("dup "),m)
 if(l<0)break
@@ -5432,7 +5432,7 @@ for(;;){if(o<q){if(!(o>=0))return A.a(a,o)
 p=a[o]
 p=p>=48&&p<=57}else p=!1
 if(!p)break;++o}if(o===r){r=o
-continue}m=A.dj(A.a0(a,r,o),null)
+continue}m=A.dk(A.a0(a,r,o),null)
 r=o
 for(;;){if(r<q){if(!(r>=0))return A.a(a,r)
 p=a[r]
@@ -5454,7 +5454,7 @@ for(;;){if(r<n){if(!(r>=0))return A.a(a,r)
 s=a[r]
 s=s>=48&&s<=57}else s=!1
 if(!s)break;++r}if(r===b)return o
-q=A.dj(A.a0(a,b,r),o)
+q=A.dk(A.a0(a,b,r),o)
 b=r
 for(;;){if(b<n){if(!(b>=0))return A.a(a,b)
 s=a[b]
@@ -5464,7 +5464,7 @@ for(;;){if(r<n){if(!(r>=0))return A.a(a,r)
 s=a[r]
 s=s>=48&&s<=57}else s=!1
 if(!s)break;++r}if(r===b)return o
-p=A.dj(A.a0(a,b,r),o)
+p=A.dk(A.a0(a,b,r),o)
 b=r
 for(;;){if(b<n){if(!(b>=0))return A.a(a,b)
 s=a[b]
@@ -5540,7 +5540,7 @@ a=A.c8(a7,p.h(0,"Range"))
 a0=B.c.K(A.q5(a7,p.h(0,"BitsPerSample"),8))
 if(b.length===0||a.length===0)return a5
 s=null
-try{s=a7.a3(a6)}catch(a1){if(t.I.b(A.J(a1)))return a5
+try{s=a7.a3(a6)}catch(a1){if(t.I.b(A.I(a1)))return a5
 else throw a1}a2=A.c8(a7,p.h(0,"Encode"))
 a3=A.c8(a7,p.h(0,"Decode"))
 p=s
@@ -5553,7 +5553,7 @@ case 4:if(!(a6 instanceof A.y))return a5
 a=A.c8(a7,p.h(0,"Range"))
 if(a.length<2)return a5
 r=null
-try{r=a7.a3(a6)}catch(a1){if(t.I.b(A.J(a1)))return a5
+try{r=a7.a3(a6)}catch(a1){if(t.I.b(A.I(a1)))return a5
 else throw a1}a4=A.wm(A.a0(r,0,a5))
 if(a4==null)return a5
 return new A.j_(a4,a,k.length>=2?k:A.b([j,i],t.n))
@@ -5990,7 +5990,7 @@ mE:function mE(a,b,c){this.a=a
 this.b=b
 this.c=c},
 v2(a,b,c){return new A.aH(a,b,c)},
-p0(a2,a3){var s,r,q,p,o,n,m,l,k,j,i,h,g=null,f="DCTDecode",e="JPXDecode",d="JBIG2Decode",c=a3.a,b=A.e9(a2,c),a=c.a,a0=a2.j(a.h(0,"ImageMask")).I(0,B.q),a1=a2.j(a.h(0,"Mask")) instanceof A.o
+p0(a2,a3){var s,r,q,p,o,n,m,l,k,j,i,h,g=null,f="DCTDecode",e="JPXDecode",d="JBIG2Decode",c=a3.a,b=A.e9(a2,c),a=c.a,a0=a2.j(a.h(0,"ImageMask")).I(0,B.r),a1=a2.j(a.h(0,"Mask")) instanceof A.o
 if(B.a.a_(b,f))s=f
 else s=B.a.a_(b,"DCT")?"DCT":g
 r=!a0
@@ -6003,11 +6003,11 @@ r=p.b
 o=p.c
 n=A.rh(a2,c,a,r,o,8,A.r2(a2,c))
 if(n==null)return g
-return new A.d0(n,r,o,!a1)}if(B.a.a_(b,e)){m=A.uJ(a2.bm(a3,e))
+return new A.d1(n,r,o,!a1)}if(B.a.a_(b,e)){m=A.uJ(a2.bm(a3,e))
 if(m==null)return g
 n=A.xh(m)
 if(n==null)return g
-return new A.d0(n,m.a,m.b,!0)}o=a2.j(a.h(0,"Width"))
+return new A.d1(n,m.a,m.b,!0)}o=a2.j(a.h(0,"Width"))
 l=o instanceof A.m?o.a:0
 o=a2.j(a.h(0,"Height"))
 k=o instanceof A.m?o.a:0
@@ -6019,8 +6019,8 @@ if(i==null)return g
 h=i}else h=a2.a3(a3)
 n=a0?A.xF(a2,c,h,l,k):A.rh(a2,c,h,l,k,j,A.r2(a2,c))
 if(n==null)return g
-return new A.d0(n,l,k,r&&!a1)},
-p1(a,b){var s,r,q,p,o,n,m=b.a,l=a.j(m.a.h(0,"ImageMask")).I(0,B.q)
+return new A.d1(n,l,k,r&&!a1)},
+p1(a,b){var s,r,q,p,o,n,m=b.a,l=a.j(m.a.h(0,"ImageMask")).I(0,B.r)
 if(!l&&A.xC(a,m))return null
 s=A.p0(a,b)
 if(s==null)return null
@@ -6076,7 +6076,7 @@ l=A.e9(a0,d)
 if(l.length!==1)return e
 k=B.a.gbS(l)
 if(!(k==="FlateDecode"||k==="Fl"||k==="CCITTFaxDecode"||k==="CCF"))return e
-j=a0.j(c.h(0,"ImageMask")).I(0,B.q)
+j=a0.j(c.h(0,"ImageMask")).I(0,B.r)
 i=a0.j(c.h(0,"Mask"))
 if(!j&&c.ak("SMask"))return e
 h=a0.a3(a1)
@@ -6529,7 +6529,7 @@ if(!(m<s))return A.a(f,m)
 l=f[m]
 k=q+3
 if(!(k<s))return A.a(f,k)
-j=A.d_(p/255,n/255,l/255,f[k]/255)
+j=A.d0(p/255,n/255,l/255,f[k]/255)
 l=B.c.v(j.a*255)
 if(!(q<h))return A.a(g,q)
 g[q]=l
@@ -6548,7 +6548,7 @@ if(q instanceof A.p&&q.a.ak(o)){k=q.a.h(0,o)
 break}}s=a.j(k)
 if(!(s instanceof A.y))return null
 try{n=a.a3(s)
-return n}catch(p){if(t.I.b(A.J(p)))return null
+return n}catch(p){if(t.I.b(A.I(p)))return null
 else throw p}},
 xC(a,b){var s=a.j(b.a.h(0,"SMask"))
 if(!(s instanceof A.y))return!1
@@ -6557,7 +6557,7 @@ yg(a,b){var s,r,q="DCTDecode",p=a.j(b.a.h(0,"SMask"))
 if(!(p instanceof A.y))return null
 if(!B.a.a_(A.e9(a,p.a),q))return null
 try{s=a.bm(p,q)
-return s}catch(r){if(t.I.b(A.J(r)))return null
+return s}catch(r){if(t.I.b(A.I(r)))return null
 else throw r}},
 rM(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=null,d=a.j(b.a.h(0,"SMask"))
 if(!(d instanceof A.y))return e
@@ -6582,7 +6582,7 @@ if(typeof i!=="number")return i.a5()
 if(typeof h!=="number")return A.r(h)
 h=j>=i*h
 j=h}else j=!1
-if(j)return new A.d1(p,s,r)
+if(j)return new A.d2(p,s,r)
 if(J.V(q,1)){j=s
 if(typeof j!=="number")return j.R()
 o=B.c.W(j+7,8)
@@ -6626,12 +6626,12 @@ if(typeof h!=="number")return A.r(h)
 j=l
 if(typeof j!=="number")return A.r(j)
 g=J.V(k,1)?255:0
-J.dn(n,i*h+j,g)
+J.dp(n,i*h+j,g)
 j=l
 if(typeof j!=="number")return j.R()
 l=j+1}j=m
 if(typeof j!=="number")return j.R()
-m=j+1}return new A.d1(n,s,r)}return e}catch(f){if(t.I.b(A.J(f)))return e
+m=j+1}return new A.d2(n,s,r)}return e}catch(f){if(t.I.b(A.I(f)))return e
 else throw f}},
 rN(a1,a2){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=null,a0=a1.j(a2.a.h(0,"Mask"))
 if(!(a0 instanceof A.y))return a
@@ -6699,12 +6699,12 @@ if(typeof e!=="number")return A.r(e)
 d=j
 if(typeof d!=="number")return A.r(d)
 c=h?0:255
-J.dn(l,g*e+d,c)
+J.dp(l,g*e+d,c)
 g=j
 if(typeof g!=="number")return g.R()
 j=g+1}g=k
 if(typeof g!=="number")return g.R()
-k=g+1}return new A.d1(l,s,r)}catch(b){if(t.I.b(A.J(b)))return a
+k=g+1}return new A.d2(l,s,r)}catch(b){if(t.I.b(A.I(b)))return a
 else throw b}},
 nS(a,b,c){var s,r,q,p,o,n,m,l,k=a.j(b.a.h(0,"Decode"))
 if(!(k instanceof A.o)||k.a.length<c*2)return null
@@ -6917,9 +6917,9 @@ if(!(l<c8))return A.a(c9,l)
 c9[l]=s
 s=c+3
 if(!(s<c8))return A.a(c9,s)
-c9[s]=255}return c9}b=A.dh(r,0)
-a=A.dh(r,1)
-a0=A.dh(r,2)
+c9[s]=255}return c9}b=A.di(r,0)
+a=A.di(r,1)
+a0=A.di(r,2)
 for(l=q!=null,k=b.length,i=a.length,f=a0.length,s=!s,a1=t.n,a2=t.H,g=0;g<c7;++g){d=g*3
 c=g*4
 if(!(d<d2))return A.a(d6,d)
@@ -6971,7 +6971,7 @@ a7=a6>=a7.a&&a6<=a7.b}}}a7=a7?0:255
 if(!(a4<c8))return A.a(c9,a4)
 c9[a4]=a7}return c9
 case"DeviceGray":if(d6.length<c7)return c6
-b0=A.dh(r,0)
+b0=A.di(r,0)
 b1=e0!=null&&e0.a===1?e0:c6
 d2=b1==null
 if(d2&&r==null&&q==null){for(g=0;g<c7;++g){c=g*4
@@ -7019,10 +7019,10 @@ if(!(k<c8))return A.a(c9,k)
 c9[k]=i}return c9
 case"DeviceCMYK":d2=d6.length
 if(d2<c8)return c6
-b=A.dh(r,0)
-a=A.dh(r,1)
-a0=A.dh(r,2)
-b5=A.dh(r,3)
+b=A.di(r,0)
+a=A.di(r,1)
+a0=A.di(r,2)
+b5=A.di(r,3)
 b6=e0!=null&&e0.a===4?e0:c6
 for(s=q!=null,l=b.length,k=a.length,i=a0.length,f=b5.length,a1=b6!=null,a2=t.n,a4=t.H,g=0;g<c7;++g){b7=g*4
 if(!(b7<d2))return A.a(d6,b7)
@@ -7051,7 +7051,7 @@ c3=a[b9]
 if(!(c0<i))return A.a(a0,c0)
 c4=a0[c0]
 if(!(c1<f))return A.a(b5,c1)
-c5=A.d_(c2/255,c3/255,c4/255,b5[c1]/255)}c2=B.c.v(c5.a*255)
+c5=A.d0(c2/255,c3/255,c4/255,b5[c1]/255)}c2=B.c.v(c5.a*255)
 if(!(b7<c8))return A.a(c9,b7)
 c9[b7]=c2
 c2=B.c.v(c5.b*255)
@@ -7125,7 +7125,7 @@ if(e<h.a||e>h.b)break;++q}}r+=3
 p=f?0:255
 if(!(r<j))return A.a(a2,r)
 a2[r]=p}return a2},
-dh(a,b){var s
+di(a,b){var s
 if(a==null)s=$.pj()
 else{if(!(b<a.length))return A.a(a,b)
 s=A.oP(a[b])}return s},
@@ -7244,7 +7244,7 @@ if(!(a<s))return A.a(k,a)
 a=k[a]
 a0=f+3
 if(!(a0<s))return A.a(k,a0)
-b=A.d_(e/255,c/255,a/255,k[a0]/255)
+b=A.d0(e/255,c/255,a/255,k[a0]/255)
 a0=g*3
 a=B.c.v(b.a*255)
 if(!(a0<q))return A.a(i,a0)
@@ -7300,10 +7300,10 @@ return 0},
 aH:function aH(a,b,c){this.a=a
 this.b=b
 this.c=c},
-d1:function d1(a,b,c){this.a=a
+d2:function d2(a,b,c){this.a=a
 this.b=b
 this.c=c},
-d0:function d0(a,b,c,d){var _=this
+d1:function d1(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -7337,7 +7337,7 @@ r=a[1]
 if(2>=p)return A.a(a,2)
 q=a[2]
 if(3>=p)return A.a(a,3)
-return A.d_(s,r,q,a[3])}return b},
+return A.d0(s,r,q,a[3])}return b},
 q6(a,b,c){var s=t.h,r=t.g
 return new A.hZ(b,c,a,A.iR(),A.b([],t.eK),A.x(s,t.D),A.x(s,t.fW),A.b([],t.c),A.b([],t.hM),new A.fs(t.dI),A.b([],r),B.y,B.y,A.b([],r),new A.bQ(""))},
 vk(a,b){var s,r=$.t8(),q=r.b1(0,b)
@@ -7396,7 +7396,7 @@ c=j.d
 b=j.e
 a=j.f
 g=new A.ab(q*f+p*e+o,n*f+m*e+l,q*d+p*c+o,n*d+m*c+l,q*b+p*a+o,n*b+m*a+l)
-break A}if(j instanceof A.ba){g=B.o
+break A}if(j instanceof A.ba){g=B.p
 break A}g=null}B.a.i(a0,g)}},
 ai(a){if(a instanceof A.m)return a.a
 if(a instanceof A.R)return a.a
@@ -7439,7 +7439,7 @@ _.f=f
 _.r=g
 _.w=!1},
 hV:function hV(){this.a=!1},
-cZ:function cZ(){},
+d_:function d_(){},
 hZ:function hZ(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o){var _=this
 _.a=a
 _.b=b
@@ -7518,7 +7518,7 @@ break A}if(1===a){s=3*b*r*r
 break A}if(2===a){s=3*b*b*r
 break A}s=b*b*b
 break A}return s},
-d2:function d2(a,b,c){this.a=a
+d3:function d3(a,b,c){this.a=a
 this.b=b
 this.c=c},
 eU:function eU(a,b){this.a=a
@@ -7930,7 +7930,7 @@ try{r=A.ye(a)
 q=A.xS(r,8)
 if(J.a6(r)===0||q.w)s=$.pd()
 else{p=A.y_(r,q)
-s=A.qm(p,J.a6(p)/4|0,q.a,q.b,q.c,q.d,q.e,!1)}}catch(m){if(A.J(m) instanceof A.bi)s=$.pd()
+s=A.qm(p,J.a6(p)/4|0,q.a,q.b,q.c,q.d,q.e,!1)}}catch(m){if(A.I(m) instanceof A.bi)s=$.pd()
 else throw m}$.qo=$.qo+n.gac()
 $.qp=$.qp+1
 $.pc().k(0,a,s)
@@ -8245,7 +8245,7 @@ c.a7(r.length)
 for(q=r.length,p=0;p<r.length;r.length===q||(0,A.l)(r),++p){o=r[p]
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,o,!1)
@@ -8254,28 +8254,28 @@ c.a7(r.length)
 for(q=r.length,p=0;p<r.length;r.length===q||(0,A.l)(r),++p){l=r[p]
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.a,!1)
 c.c+=4
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.f,!1)
 c.c+=4
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.d,!1)
 c.c+=4
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.e,!1)
@@ -8285,7 +8285,7 @@ m=l.b
 k=m.length
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 j=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(j,k,!1)
@@ -8294,19 +8294,19 @@ for(k=m.length,i=0;i<m.length;m.length===k||(0,A.l)(m),++i){h=m[i]
 j=h.b
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 g=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(g,j.length/8|0,!1)
 c.c+=4
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 g=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(g,h.a,!1)
 c.c+=4
-g=B.t.gt(j)
+g=B.u.gt(j)
 f=j.byteOffset
 j=j.byteLength
 c.a2(j)
@@ -8315,7 +8315,7 @@ d=c.c
 B.d.C(e,d,d+j,J.aC(g,f,j))
 c.c+=j
 j=h.c
-f=B.t.gt(j)
+f=B.u.gt(j)
 g=j.byteOffset
 j=j.byteLength
 c.a2(j)
@@ -8345,35 +8345,35 @@ c.a7(r.length)
 for(q=r.length,p=0;p<r.length;r.length===q||(0,A.l)(r),++p){l=r[p]
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.a,!1)
 c.c+=4
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.f,!1)
 c.c+=4
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.d,!1)
 c.c+=4
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(m,l.e,!1)
 c.c+=4
 c.a2(8)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 m=c.c
 n.$flags&2&&A.e(n,13)
 n.setFloat64(m,l.r,!1)
@@ -8383,7 +8383,7 @@ m=l.b
 k=m.length
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 j=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(j,k,!1)
@@ -8392,12 +8392,12 @@ for(k=m.length,i=0;i<m.length;m.length===k||(0,A.l)(m),++i){h=m[i]
 j=h.a
 c.a2(4)
 n=c.b
-if(n===$)n=c.b=J.I(B.d.gt(c.a),0,null)
+if(n===$)n=c.b=J.J(B.d.gt(c.a),0,null)
 g=c.c
 n.$flags&2&&A.e(n,11)
 n.setUint32(g,j.length/8|0,!1)
 c.c+=4
-g=B.t.gt(j)
+g=B.u.gt(j)
 f=j.byteOffset
 j=j.byteLength
 c.a2(j)
@@ -8406,7 +8406,7 @@ d=c.c
 B.d.C(e,d,d+j,J.aC(g,f,j))
 c.c+=j
 j=h.b
-f=B.t.gt(j)
+f=B.u.gt(j)
 g=j.byteOffset
 j=j.byteLength
 c.a2(j)
@@ -8596,8 +8596,8 @@ this.b=b
 this.c=$},
 rQ(b7,b8,b9,c0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5=null,b6=b9==null?J.a6(b7):b9
 for(s=J.a9(b7),r=b8.Q,q=t.oh,p=t.M,o=t.l5,n=b8.as,m=t.ob,l=t.jL,k=c0;k<b6;++k){j=s.h(b7,k)
-if(j instanceof A.d5){B.a.i(n,!1)
-continue}if(j instanceof A.d4){i=n.length
+if(j instanceof A.d6){B.a.i(n,!1)
+continue}if(j instanceof A.d5){i=n.length
 if(i!==0){if(0>=i)return A.a(n,-1)
 i=n.pop()}else i=!1
 if(i)b8.aZ()
@@ -8664,7 +8664,7 @@ if(i){b8.cN(a6)
 continue}i=j instanceof A.bO
 a7=i?j.a:b5
 if(i){b8.z=o.a(a7)
-continue}a2=j instanceof A.cY
+continue}a2=j instanceof A.cZ
 if(a2){a=j.a
 a8=j.b
 e=a}else{a8=b5
@@ -8717,8 +8717,8 @@ break
 case 4:return A.b1(null,r)}})
 return A.b2($async$jt,r)},
 a7:function a7(){},
+d6:function d6(){},
 d5:function d5(){},
-d4:function d4(){},
 bw:function bw(a,b,c,d){var _=this
 _.a=a
 _.b=b
@@ -8741,7 +8741,7 @@ this.b=b},
 cu:function cu(a){this.a=a},
 bo:function bo(a){this.a=a},
 bO:function bO(a){this.a=a},
-cY:function cY(a,b){this.a=a
+cZ:function cZ(a,b){this.a=a
 this.b=b},
 dL:function dL(){},
 dJ:function dJ(){},
@@ -8763,7 +8763,7 @@ if(r){if(f!=null&&f.c-f.a>0&&f.d-f.b>0&&h>0){q=B.c.v((f.c-f.a)*(f.d-f.b)*h*h)
 p=q>0&&q<16777216?B.b.n(B.b.v(q),1,m):m}else p=m
 s=A.wX(k,d,h,p,f)}try{r=s
 o=g&&!e
-A.ri(j,k,d,r,null,e,f,o,h)}catch(n){if(A.J(n) instanceof A.fL)return null
+A.ri(j,k,d,r,null,e,f,o,h)}catch(n){if(A.I(n) instanceof A.fL)return null
 else throw n}r=j
 return new Uint8Array(A.H(A.Y(r.a,0,r.c)))},
 qZ(a,b){var s,r,q,p,o,n,m,l,k,j,i,h=J.a9(a),g=b==null?h.gp(a):Math.min(h.gp(a),Math.max(0,b)),f=new Uint8Array(g)
@@ -8771,11 +8771,11 @@ B.d.ao(f,0,g,1)
 s=A.b([],t.t)
 r=A.b([],t.c)
 for(h=J.a9(a),q=0,p=0;p<g;++p){o=h.h(a,p)
-if(o instanceof A.d5){B.a.i(s,p)
+if(o instanceof A.d6){B.a.i(s,p)
 B.a.i(r,!1)
 continue}if(o instanceof A.b9){n=r.length
 if(n!==0)B.a.k(r,n-1,!0)
-continue}if(o instanceof A.d4){n=s.length
+continue}if(o instanceof A.d5){n=s.length
 if(n===0)continue
 if(0>=n)return A.a(s,-1)
 m=s.pop()
@@ -8783,7 +8783,7 @@ if(0>=r.length)return A.a(r,-1)
 if(!r.pop()){if(!(m<g))return A.a(f,m)
 f[m]=0
 f[p]=0
-q+=2}continue}continue}l=A.W(g-q,B.p,!1,t.e)
+q+=2}continue}continue}l=A.W(g-q,B.q,!1,t.e)
 for(k=0,p=0;p<g;++p){if(f[p]===0)continue
 j=h.h(a,p)
 i=k+1
@@ -8817,12 +8817,12 @@ return r},
 ri(a,b,c,d,e,f,g,h,i){var s,r=J.a9(b),q=e==null?r.gp(b):Math.min(r.gp(b),Math.max(0,e))
 a.a7(q)
 for(r=J.a9(b),s=0;s<q;++s)A.xM(a,r.h(b,s),c,d,f,g,h,i)},
-rb(a){var s,r=a.X(),q=A.W(r,B.p,!0,t.e)
+rb(a){var s,r=a.X(),q=A.W(r,B.q,!0,t.e)
 for(s=0;s<r;++s)B.a.k(q,s,A.xn(a))
 return q},
 xM(b3,b4,b5,b6,b7,b8,b9,c0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2=null
-A:{if(b4 instanceof A.d5){b3.B(0)
-break A}if(b4 instanceof A.d4){b3.B(1)
+A:{if(b4 instanceof A.d6){b3.B(0)
+break A}if(b4 instanceof A.d5){b3.B(1)
 break A}o=b4 instanceof A.bw
 n=b2
 m=b2
@@ -8918,7 +8918,7 @@ A.rk(b3,b,a2,a3==null?b2:a3.b)}break A}b=b4 instanceof A.bO
 a4=b?b4.a:b2
 if(b){b3.B(9)
 b3.B(a4.a)
-break A}e=b4 instanceof A.cY
+break A}e=b4 instanceof A.cZ
 if(e){h=b4.a
 a5=b4.b
 l=h}else{a5=b2
@@ -9056,7 +9056,7 @@ if(s){a.a7(d.b)
 a.a7(d.c)
 a.dQ(d.a)}},
 xn(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d=a.P()
-switch(d){case 0:return B.p
+switch(d){case 0:return B.q
 case 1:return B.v
 case 2:s=A.jm(a)
 r=a.J()
@@ -9090,7 +9090,7 @@ return new A.bo(new A.ca(l,i,!0,n,m,r===1,new A.M(q,p,o)))
 case 9:r=a.P()
 if(!(r>=0&&r<16))return A.a(B.b7,r)
 return new A.bO(B.b7[r])
-case 10:return new A.cY(a.J(),a.P()===1)
+case 10:return new A.cZ(a.J(),a.P()===1)
 case 11:return B.aG
 case 12:return B.aF
 case 13:r=a.P()
@@ -9116,7 +9116,7 @@ if(p){a.B(0)
 A.D(l)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,l,!1)
@@ -9124,7 +9124,7 @@ a.c+=4
 A.D(o)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,o,!1)
@@ -9139,7 +9139,7 @@ if(p){a.B(1)
 A.D(l)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,l,!1)
@@ -9147,7 +9147,7 @@ a.c+=4
 A.D(o)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,o,!1)
@@ -9168,7 +9168,7 @@ if(j){a.B(2)
 A.D(d)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,d,!1)
@@ -9176,7 +9176,7 @@ a.c+=4
 A.D(i)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,i,!1)
@@ -9184,7 +9184,7 @@ a.c+=4
 A.D(h)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,h,!1)
@@ -9192,7 +9192,7 @@ a.c+=4
 A.D(g)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,g,!1)
@@ -9200,7 +9200,7 @@ a.c+=4
 A.D(f)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,f,!1)
@@ -9208,13 +9208,13 @@ a.c+=4
 A.D(e)
 a.Z(4)
 k=a.b
-if(k===$)k=a.b=J.I(B.d.gt(a.a),0,null)
+if(k===$)k=a.b=J.J(B.d.gt(a.a),0,null)
 j=a.c
 k.$flags&2&&A.e(k,12)
 k.setFloat32(j,e,!1)
 a.c+=4
 continue}if(q instanceof A.ba)a.B(3)}},
-jm(a){var s,r,q,p,o,n,m,l,k,j,i=a.X(),h=A.W(i,B.o,!0,t.bM)
+jm(a){var s,r,q,p,o,n,m,l,k,j,i=a.X(),h=A.W(i,B.p,!0,t.bM)
 for(s=a.b,r=0;r<i;++r){q=s.getUint8(a.c++)
 A:{if(0===q){p=s.getFloat32(a.c,!1)
 o=s.getFloat32(a.c+=4,!1)
@@ -9232,7 +9232,7 @@ k=s.getFloat32(a.c+=4,!1)
 j=s.getFloat32(a.c+=4,!1)
 a.c+=4
 n=new A.ab(p,o,m,l,k,j)
-break A}if(3===q){n=B.o
+break A}if(3===q){n=B.p
 break A}n=A.Q(A.bm("unknown path segment tag",null,null))}B.a.k(h,r,n)}return new A.ak(h)},
 jo(a,b){a.N(b.a)
 a.N(b.b)
@@ -9252,21 +9252,21 @@ a.a7(s.length)
 for(r=s.length,q=0;q<s.length;s.length===r||(0,A.l)(s),++q){p=s[q]
 a.Z(8)
 o=a.b
-if(o===$)o=a.b=J.I(B.d.gt(a.a),0,null)
+if(o===$)o=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 o.$flags&2&&A.e(o,13)
 o.setFloat64(n,p.a,!1)
 a.c+=8
 a.Z(8)
 o=a.b
-if(o===$)o=a.b=J.I(B.d.gt(a.a),0,null)
+if(o===$)o=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 o.$flags&2&&A.e(o,13)
 o.setFloat64(n,p.b,!1)
 a.c+=8
 a.Z(8)
 o=a.b
-if(o===$)o=a.b=J.I(B.d.gt(a.a),0,null)
+if(o===$)o=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 o.$flags&2&&A.e(o,13)
 o.setFloat64(n,p.c,!1)
@@ -9285,14 +9285,14 @@ a.a7(m.length)
 for(s=m.length,r=0;r<m.length;m.length===s||(0,A.l)(m),++r){q=m[r]
 a.Z(8)
 p=a.b
-if(p===$)p=a.b=J.I(B.d.gt(a.a),0,null)
+if(p===$)p=a.b=J.J(B.d.gt(a.a),0,null)
 o=a.c
 p.$flags&2&&A.e(p,13)
 p.setFloat64(o,q.a,!1)
 a.c+=8
 a.Z(8)
 p=a.b
-if(p===$)p=a.b=J.I(B.d.gt(a.a),0,null)
+if(p===$)p=a.b=J.J(B.d.gt(a.a),0,null)
 o=a.c
 p.$flags&2&&A.e(p,13)
 p.setFloat64(o,q.b,!1)
@@ -9300,21 +9300,21 @@ a.c+=8
 o=q.c
 a.Z(8)
 p=a.b
-if(p===$)p=a.b=J.I(B.d.gt(a.a),0,null)
+if(p===$)p=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 p.$flags&2&&A.e(p,13)
 p.setFloat64(n,o.a,!1)
 a.c+=8
 a.Z(8)
 p=a.b
-if(p===$)p=a.b=J.I(B.d.gt(a.a),0,null)
+if(p===$)p=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 p.$flags&2&&A.e(p,13)
 p.setFloat64(n,o.b,!1)
 a.c+=8
 a.Z(8)
 p=a.b
-if(p===$)p=a.b=J.I(B.d.gt(a.a),0,null)
+if(p===$)p=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 p.$flags&2&&A.e(p,13)
 p.setFloat64(n,o.c,!1)
@@ -9326,7 +9326,7 @@ o=s.getFloat64(a.c+=8,!1)
 n=s.getFloat64(a.c+=8,!1)
 m=s.getFloat64(a.c+=8,!1)
 a.c+=8
-k.push(new A.d2(q,p,new A.M(o,n,m)))}return new A.eU(k,a.kR())},
+k.push(new A.d3(q,p,new A.M(o,n,m)))}return new A.eU(k,a.kR())},
 xO(a,b){var s,r,q,p,o,n
 a.bV(b.f)
 A.oY(a,b.r)
@@ -9344,14 +9344,14 @@ a.a7(r.length)
 for(s=r.length,q=0;q<r.length;r.length===s||(0,A.l)(r),++q){p=r[q]
 a.Z(8)
 o=a.b
-if(o===$)o=a.b=J.I(B.d.gt(a.a),0,null)
+if(o===$)o=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 o.$flags&2&&A.e(o,13)
 o.setFloat64(n,p.a,!1)
 a.c+=8
 a.Z(8)
 o=a.b
-if(o===$)o=a.b=J.I(B.d.gt(a.a),0,null)
+if(o===$)o=a.b=J.J(B.d.gt(a.a),0,null)
 n=a.c
 o.$flags&2&&A.e(o,13)
 o.setFloat64(n,p.b,!1)
@@ -9382,7 +9382,7 @@ m=a0.P()
 k=a0.P()===1?new A.M(a0.J(),a0.J(),a0.J()):j
 return new A.eV(m===1,k,a0.J(),q===1,i,h,new A.M(g,f,e),c,d,b,a,r)},
 nb(a,b,c){var s,r,q,p,o,n,m,l
-if(c>64)return B.u
+if(c>64)return B.n
 s=a.j(b)
 if(s instanceof A.y){r=A.x(t.N,t.l)
 q=s.a
@@ -9450,7 +9450,7 @@ a.a7(i.a)
 i.al(0,new A.nr(a))
 break A}if(b instanceof A.av)a.B(0)}},
 ni(a){var s,r,q,p,o
-switch(a.P()){case 0:return B.u
+switch(a.P()){case 0:return B.n
 case 1:return new A.bY(a.P()===1)
 case 2:s=a.b.getFloat64(a.c,!1)
 a.c+=8
@@ -9515,9 +9515,9 @@ j=m.gbK()
 i=o.length>=2?o:B.dy
 h=n instanceof A.o
 if(h){g=n.a
-g=g.length>0&&g[0].I(0,B.q)}else g=!1
+g=g.length>0&&g[0].I(0,B.r)}else g=!1
 if(h){h=n.a
-h=h.length>1&&h[1].I(0,B.q)}else h=!1
+h=h.length>1&&h[1].I(0,B.r)}else h=!1
 return new A.l6(l,p,r,k,j,i,g,h,a,d?e:f,s)},
 l7(a,b){var s,r,q,p,o,n,m,l=a.j(b)
 if(!(l instanceof A.o))return B.B
@@ -10148,7 +10148,7 @@ $ic:1}
 J.eB.prototype={
 gag(a){return A.cj(t.i)},
 $iX:1}
-J.cS.prototype={
+J.cT.prototype={
 bB(a,b){return new A.jb(b,a,0)},
 fQ(a,b){var s=b.length,r=a.length
 if(s>r)return!1
@@ -10340,7 +10340,7 @@ if(s>=o){r.d=null
 return!1}r.d=p.aC(q,s);++r.c
 return!0},
 $ia3:1}
-A.cV.prototype={
+A.cW.prototype={
 gV(a){return new A.eH(J.bh(this.a),this.b,A.G(this).l("eH<1,2>"))},
 gp(a){return J.a6(this.a)}}
 A.eh.prototype={$iE:1}
@@ -10379,8 +10379,8 @@ return!1},
 gF(){return this.$ti.c.a(this.a.gF())},
 $ia3:1}
 A.aP.prototype={}
-A.d8.prototype={
-k(a,b,c){A.G(this).l("d8.E").a(c)
+A.d9.prototype={
+k(a,b,c){A.G(this).l("d9.E").a(c)
 throw A.d(A.bR("Cannot modify an unmodifiable list"))}}
 A.dR.prototype={}
 A.f_.prototype={
@@ -10393,7 +10393,7 @@ A.fC.prototype={$r:"+color,fontName,size(1,2,3)",$s:4}
 A.A.prototype={$r:"+(1,2,3,4)",$s:5}
 A.fD.prototype={$r:"+(1,2,3,4,5)",$s:6}
 A.fE.prototype={$r:"+(1,2,3,4,5,6,7)",$s:7}
-A.dt.prototype={
+A.du.prototype={
 gap(a){return this.gp(this)===0},
 m(a){return A.or(this)},
 $ibL:1}
@@ -10502,10 +10502,10 @@ A.ik.prototype={
 m(a){var s=this.$static_name
 if(s==null)return"Closure of unknown static method"
 return"Closure '"+A.rT(s)+"'"}}
-A.dq.prototype={
+A.dr.prototype={
 I(a,b){if(b==null)return!1
 if(this===b)return!0
-if(!(b instanceof A.dq))return!1
+if(!(b instanceof A.dr))return!1
 return this.$_target===b.$_target&&this.a===b.a},
 gD(a){return(A.fT(this.a)^A.eX(this.$_target))>>>0},
 m(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.i7(this.a)+"'")}}
@@ -10644,8 +10644,8 @@ $ia3:1}
 A.eG.prototype={
 gp(a){return this.a.a},
 gV(a){var s=this.a
-return new A.cU(s,s.r,s.e,this.$ti.l("cU<1>"))}}
-A.cU.prototype={
+return new A.cV(s,s.r,s.e,this.$ti.l("cV<1>"))}}
+A.cV.prototype={
 gF(){return this.d},
 u(){var s,r=this,q=r.a
 if(r.b!==q.r)throw A.d(A.aX(q))
@@ -10658,8 +10658,8 @@ $ia3:1}
 A.c2.prototype={
 gp(a){return this.a.a},
 gV(a){var s=this.a
-return new A.cT(s,s.r,s.e,this.$ti.l("cT<1,2>"))}}
-A.cT.prototype={
+return new A.cU(s,s.r,s.e,this.$ti.l("cU<1,2>"))}}
+A.cU.prototype={
 gF(){var s=this.d
 s.toString
 return s},
@@ -10720,11 +10720,11 @@ cv(){return[this.a,this.b]},
 I(a,b){if(b==null)return!1
 return b instanceof A.dX&&this.$s===b.$s&&J.V(this.a,b.a)&&J.V(this.b,b.b)},
 gD(a){return A.c4(this.$s,this.a,this.b,B.h,B.h,B.h,B.h)}}
-A.df.prototype={
+A.dg.prototype={
 cv(){return[this.a,this.b,this.c]},
 I(a,b){var s=this
 if(b==null)return!1
-return b instanceof A.df&&s.$s===b.$s&&J.V(s.a,b.a)&&J.V(s.b,b.b)&&J.V(s.c,b.c)},
+return b instanceof A.dg&&s.$s===b.$s&&J.V(s.a,b.a)&&J.V(s.b,b.b)&&J.V(s.c,b.c)},
 gD(a){var s=this
 return A.c4(s.$s,s.a,s.b,s.c,B.h,B.h,B.h)}}
 A.cF.prototype={
@@ -10956,14 +10956,14 @@ h(a,b){A.ci(b,a,a.length)
 return a[b]},
 $iX:1,
 $ioB:1}
-A.cW.prototype={
+A.cX.prototype={
 gag(a){return B.h4},
 gp(a){return a.length},
 h(a,b){A.ci(b,a,a.length)
 return a[b]},
 $iX:1,
-$icW:1}
-A.cX.prototype={
+$icX:1}
+A.cY.prototype={
 gag(a){return B.h5},
 gp(a){return a.length},
 h(a,b){A.ci(b,a,a.length)
@@ -10971,7 +10971,7 @@ return a[b]},
 a1(a,b,c){return new Uint8Array(a.subarray(b,A.jj(b,c,a.length)))},
 bW(a,b){return this.a1(a,b,null)},
 $iX:1,
-$icX:1,
+$icY:1,
 $iaI:1}
 A.fu.prototype={}
 A.fv.prototype={}
@@ -11096,14 +11096,14 @@ r.l("1/?").a(a)
 s=this.a
 if((s.a&30)!==0)throw A.d(A.aS("Future already completed"))
 s.eo(r.l("1/").a(a))}}
-A.db.prototype={
+A.dc.prototype={
 l0(a){if((this.c&15)!==6)return!0
 return this.b.b.e2(t.iW.a(this.d),a.a,t.y,t.K)},
 kP(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
 if(t.ng.b(q))p=l.ll(q,m,a.b,o,n,t.k)
 else p=l.e2(t.mq.a(q),m,o,n)
 try{o=r.$ti.l("2/").a(p)
-return o}catch(s){if(t.do.b(A.J(s))){if((r.c&1)!==0)throw A.d(A.bj("The error handler of Future.then must return a value of the returned future's type","onError"))
+return o}catch(s){if(t.do.b(A.I(s))){if((r.c&1)!==0)throw A.d(A.bj("The error handler of Future.then must return a value of the returned future's type","onError"))
 throw A.d(A.bj("The error handler of Future.catchError must return a value of the future's type","onError"))}else throw s}}}
 A.aq.prototype={
 h7(a,b,c){var s,r,q=this.$ti
@@ -11111,12 +11111,12 @@ q.am(c).l("1/(2)").a(a)
 s=$.ad
 if(s===B.z){if(!t.ng.b(b)&&!t.mq.b(b))throw A.d(A.fW(b,"onError",u.c))}else{c.l("@<0/>").am(q.c).l("1(2)").a(a)
 b=A.xs(b,s)}r=new A.aq(s,c.l("aq<0>"))
-this.d1(new A.db(r,3,a,b,q.l("@<1>").am(c).l("db<1,2>")))
+this.d1(new A.dc(r,3,a,b,q.l("@<1>").am(c).l("dc<1,2>")))
 return r},
 fp(a,b,c){var s,r=this.$ti
 r.am(c).l("1/(2)").a(a)
 s=new A.aq($.ad,c.l("aq<0>"))
-this.d1(new A.db(s,19,a,b,r.l("@<1>").am(c).l("db<1,2>")))
+this.d1(new A.dc(s,19,a,b,r.l("@<1>").am(c).l("dc<1,2>")))
 return s},
 jX(a){this.a=this.a&1|16
 this.c=a},
@@ -11152,23 +11152,23 @@ else{s=r.c5()
 q.c.a(a)
 r.a=8
 r.c=a
-A.dc(r,s)}},
+A.dd(r,s)}},
 ey(a){var s,r=this
 r.$ti.c.a(a)
 s=r.c5()
 r.a=8
 r.c=a
-A.dc(r,s)},
+A.dd(r,s)},
 hX(a){var s,r,q=this
 if((a.a&16)!==0){s=q.b===a.b
 s=!(s||s)}else s=!1
 if(s)return
 r=q.c5()
 q.cp(a)
-A.dc(q,r)},
+A.dd(q,r)},
 d7(a){var s=this.c5()
 this.jX(a)
-A.dc(this,s)},
+A.dd(this,s)},
 eo(a){var s=this.$ti
 s.l("1/").a(a)
 if(s.l("bH<1>").b(a)){this.es(a)
@@ -11183,10 +11183,10 @@ d2(a){this.a^=2
 A.jn(null,null,this.b,t.M.a(new A.mk(this,a)))},
 $ibH:1}
 A.mj.prototype={
-$0(){A.dc(this.a,this.b)},
+$0(){A.dd(this.a,this.b)},
 $S:0}
 A.mo.prototype={
-$0(){A.dc(this.b,this.a.a)},
+$0(){A.dd(this.b,this.a.a)},
 $S:0}
 A.mn.prototype={
 $0(){A.mm(this.a.a,this.b,!0)},
@@ -11200,7 +11200,7 @@ $S:0}
 A.mr.prototype={
 $0(){var s,r,q,p,o,n,m,l,k=this,j=null
 try{q=k.a.a
-j=q.b.b.lk(t.mY.a(q.d),t.z)}catch(p){s=A.J(p)
+j=q.b.b.lk(t.mY.a(q.d),t.z)}catch(p){s=A.I(p)
 r=A.cM(p)
 if(k.c&&t.v.a(k.b.a.c).a===s){q=k.a
 q.c=t.v.a(k.b.a.c)}else{q=s
@@ -11233,7 +11233,7 @@ p=q.a
 o=p.$ti
 n=o.c
 m=n.a(this.b)
-q.c=p.b.b.e2(o.l("2/(1)").a(p.d),m,o.l("2/"),n)}catch(l){s=A.J(l)
+q.c=p.b.b.e2(o.l("2/(1)").a(p.d),m,o.l("2/"),n)}catch(l){s=A.I(l)
 r=A.cM(l)
 q=s
 p=r
@@ -11247,7 +11247,7 @@ $0(){var s,r,q,p,o,n,m,l=this
 try{s=t.v.a(l.a.a.c)
 p=l.b
 if(p.a.l0(s)&&p.a.e!=null){p.c=p.a.kP(s)
-p.b=!1}}catch(o){r=A.J(o)
+p.b=!1}}catch(o){r=A.I(o)
 q=A.cM(o)
 p=t.v.a(l.a.a.c)
 if(p.a===r){n=l.b
@@ -11266,7 +11266,7 @@ A.j1.prototype={
 lm(a){var s,r,q
 t.M.a(a)
 try{if(B.z===$.ad){a.$0()
-return}A.rd(null,null,this,a,t.o)}catch(q){s=A.J(q)
+return}A.rd(null,null,this,a,t.o)}catch(q){s=A.I(q)
 r=A.cM(q)
 A.oV(A.e0(s),t.k.a(r))}},
 fH(a){return new A.mT(this,t.M.a(a))},
@@ -11289,7 +11289,7 @@ $S:0}
 A.nj.prototype={
 $0(){A.us(this.a,this.b)},
 $S:0}
-A.dd.prototype={
+A.de.prototype={
 gV(a){var s=this,r=new A.fr(s,s.r,A.G(s).l("fr<1>"))
 r.c=s.e
 return r},
@@ -11428,7 +11428,7 @@ r.a=(r.a+=s)+": "
 s=A.v(b)
 r.a+=s},
 $S:26}
-A.d6.prototype={
+A.d7.prototype={
 T(a,b){var s,r,q
 A.G(this).l("q<1>").a(b)
 for(s=b.$ti,r=new A.bB(b.a(),s.l("bB<1>")),s=s.c;r.u();){q=r.b
@@ -11474,8 +11474,8 @@ s=A.w1(a,b,c,q)
 r.a=A.w3(a,b,c,s,0,r.a)
 return s}}
 A.h3.prototype={$ibd:1}
-A.d9.prototype={}
-A.ds.prototype={}
+A.da.prototype={}
+A.dt.prototype={}
 A.af.prototype={
 aS(a){A.G(this).l("bd<af.T>").a(a)
 throw A.d(A.bR("This converter does not support chunked conversions: "+this.m(0)))}}
@@ -11561,7 +11561,7 @@ try{s=o.b.$1(a)
 if(!o.hb(s)){q=A.pU(a,null,o.gf5())
 throw A.d(q)}q=o.a
 if(0>=q.length)return A.a(q,-1)
-q.pop()}catch(p){r=A.J(p)
+q.pop()}catch(p){r=A.I(p)
 q=A.pU(a,r,o.gf5())
 throw A.d(q)}},
 hb(a){var s,r,q=this
@@ -11813,7 +11813,7 @@ A.f9.prototype={
 m(a){return"Unsupported operation: "+this.a}}
 A.is.prototype={
 m(a){return"UnimplementedError: "+this.a}}
-A.d7.prototype={
+A.d8.prototype={
 m(a){return"Bad state: "+this.a}}
 A.hc.prototype={
 m(a){var s=this.a
@@ -12292,7 +12292,7 @@ s[0]=1732584193
 s[1]=4023233417
 s[2]=2562383102
 s[3]=271733878
-return new A.d9(new A.iZ(s,a,B.T,r,q,8))}}
+return new A.da(new A.iZ(s,a,B.T,r,q,8))}}
 A.iZ.prototype={
 e8(a){var s,r,q,p,o,n={}
 if(15>=a.length)return A.a(a,15)
@@ -12344,7 +12344,7 @@ t.Z.a(a)
 s=new Uint32Array(A.H(A.b([1779033703,3144134277,1013904242,2773480762,1359893119,2600822924,528734635,1541459225],t.t)))
 r=new Uint32Array(64)
 q=new Uint8Array(64)
-return new A.d9(new A.j4(s,r,a,B.N,q,new Uint32Array(16),8))}}
+return new A.da(new A.j4(s,r,a,B.N,q,new Uint32Array(16),8))}}
 A.j5.prototype={
 e8(a0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a
 for(s=this.z,r=a0.length,q=s.$flags|0,p=0;p<16;++p){if(!(p<r))return A.a(a0,p)
@@ -12393,7 +12393,7 @@ s=new Uint32Array(A.H(A.b([3418070365,3238371032,1654270250,914150663,2438529370
 r=new Uint32Array(160)
 q=new Uint32Array(38)
 p=new Uint8Array(128)
-return new A.d9(new A.ie(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
+return new A.da(new A.ie(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
 A.j7.prototype={
 aS(a){var s,r,q,p
 t.Z.a(a)
@@ -12401,7 +12401,7 @@ s=new Uint32Array(A.H(A.b([1779033703,4089235720,3144134277,2227873595,101390424
 r=new Uint32Array(160)
 q=new Uint32Array(38)
 p=new Uint8Array(128)
-return new A.d9(new A.ig(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
+return new A.da(new A.ig(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
 A.j8.prototype={
 gcM(){return J.pn(B.k.gt(this.y),0,this.gfO())},
 aF(a,b,c,d,e){var s,r,q,p
@@ -12765,7 +12765,7 @@ n=t.S
 $.i2=A.W(22,0,!1,n)
 $.l5=A.W(22,0,!1,n)
 $.l3=A.W(21,0,!1,n)
-$.l4=A.W(3,0,!1,n)}$.d3=l
+$.l4=A.W(3,0,!1,n)}$.d4=l
 if(m.c){k=new A.ax()
 $.aB()
 k.ai()
@@ -12781,7 +12781,7 @@ g.kind="ready"
 g.shared=s
 if(r!=null)g.openUs=r.gac()
 b1.b.postMessage(g)
-return}if(o==="cancel"){n=A.dg(b3.id)
+return}if(o==="cancel"){n=A.dh(b3.id)
 f=n==null?b2:A.B(n)
 n=f!=null
 if(n&&f===b1.a.d){n=b1.a.e
@@ -12809,19 +12809,19 @@ return}if(o!=="record")return
 f=A.B(A.D(b3.id))
 d=A.B(A.D(b3.page))
 c=A.bf(b3.annotations)
-a4=A.dg(b3.imageRatio)
+a4=A.dh(b3.imageRatio)
 if(a4==null)a4=b2
 n=A.fN(b3.decodeImages)
 if(n==null)n=b2
-m=A.dg(b3.commandLimit)
+m=A.dh(b3.commandLimit)
 a5=m==null?b2:A.B(m)
-a6=A.dg(b3.regionLeft)
+a6=A.dh(b3.regionLeft)
 if(a6==null)a6=b2
-a7=A.dg(b3.regionBottom)
+a7=A.dh(b3.regionBottom)
 if(a7==null)a7=b2
-a8=A.dg(b3.regionRight)
+a8=A.dh(b3.regionRight)
 if(a8==null)a8=b2
-a9=A.dg(b3.regionTop)
+a9=A.dh(b3.regionTop)
 if(a9==null)a9=b2
 b0=a6!=null&&a7!=null&&a8!=null&&a9!=null?new A.aR(a6,a7,a8,a9):b2
 a2=new A.hV()
@@ -12875,8 +12875,8 @@ s=5
 break
 case 3:q=2
 b0=p.pop()
-a8=A.J(b0)
-if(a8 instanceof A.cZ)n=null
+a8=A.I(b0)
+if(a8 instanceof A.d_)n=null
 else{h=a8
 g=A.cM(b0)
 n=null
@@ -12932,8 +12932,8 @@ s=5
 break
 case 3:q=2
 c=p.pop()
-e=A.J(c)
-if(e instanceof A.cZ)n=null
+e=A.I(c)
+if(e instanceof A.d_)n=null
 else{k=e
 j=A.cM(c)
 n=null
@@ -12965,7 +12965,7 @@ for(l=k.a,l=new A.az(l,l.r,l.e,A.G(l).l("az<1>"));l.u();){j=l.d
 i=k.h(0,j)
 m=i==null?m+("\t"+e.cl(j)+"\n"):m+("\t"+e.cl(j)+": "+i.m(0)+"\n")}for(l=k.b.a,j=new A.az(l,l.r,l.e,A.G(l).l("az<1>"));j.u();){h=j.d
 m+=h+"\n"
-if(!l.ak(h))l.k(0,h,new A.dx(A.x(q,p),new A.cR(A.x(o,n))))
+if(!l.ak(h))l.k(0,h,new A.dx(A.x(q,p),new A.cS(A.x(o,n))))
 g=l.h(0,h)
 for(h=g.a,h=new A.az(h,h.r,h.e,A.G(h).l("az<1>"));h.u();){f=h.d
 i=g.h(0,f)
@@ -12998,7 +12998,7 @@ if(typeof b1!=="number")return A.r(b1)
 b1=b0+b1
 b8.d=b1
 if(a5-b1<2)break
-p=new A.dx(A.x(a6,a7),new A.cR(A.x(a8,a9)))
+p=new A.dx(A.x(a6,a7),new A.cS(A.x(a8,a9)))
 o=b8.az()
 b0=o
 if(typeof b0!=="number")return b0.a5()
@@ -13013,7 +13013,7 @@ b1=n
 if(typeof b0!=="number")return b0.a4()
 if(typeof b1!=="number")return A.r(b1)
 if(!(b0<b1))break
-J.dn(m,l,this.fb(b8,s))
+J.dp(m,l,this.fb(b8,s))
 b0=l
 if(typeof b0!=="number")return b0.R()
 l=b0+1}k=m
@@ -13021,13 +13021,13 @@ for(b0=k,b1=b0.length,b2=0;b2<b0.length;b0.length===b1||(0,A.l)(b0),++b2){j=b0[b
 if(j.b!=null){b3=j.a
 b4=j.b
 b4.toString
-J.dn(p,b3,b4)}}a3.k(0,"ifd"+A.v(q),p)
+J.dp(p,b3,b4)}}a3.k(0,"ifd"+A.v(q),p)
 b0=q
 if(typeof b0!=="number")return b0.R()
 q=b0+1
 i=b8.ar()
 if(J.V(i,r))break
-else r=i}catch(b5){break}}for(a3=new A.cU(a3,a3.r,a3.e,A.G(a3).l("cU<2>"));a3.u();){h=a3.d
+else r=i}catch(b5){break}}for(a3=new A.cV(a3,a3.r,a3.e,A.G(a3).l("cV<2>"));a3.u();){h=a3.d
 for(a5=B.bg.gbJ(),a5=a5.gV(a5);a5.u();){g=a5.gF()
 b0=A.B(g)
 if(h.a.ak(b0))try{f=J.a4(h,g).K(0)
@@ -13036,7 +13036,7 @@ b1=f
 if(typeof b0!=="number")return b0.R()
 if(typeof b1!=="number")return A.r(b1)
 b8.d=b0+b1
-e=new A.dx(A.x(a6,a7),new A.cR(A.x(a8,a9)))
+e=new A.dx(A.x(a6,a7),new A.cS(A.x(a8,a9)))
 d=b8.az()
 c=d
 b1=c
@@ -13048,7 +13048,7 @@ b1=c
 if(typeof b0!=="number")return b0.a4()
 if(typeof b1!=="number")return A.r(b1)
 if(!(b0<b1))break
-J.dn(b,a,this.fb(b8,s))
+J.dp(b,a,this.fb(b8,s))
 b0=a
 if(typeof b0!=="number")return b0.R()
 a=b0+1}a0=b
@@ -13056,7 +13056,7 @@ for(b0=a0,b1=b0.length,b2=0;b2<b0.length;b0.length===b1||(0,A.l)(b0),++b2){a1=b0
 if(a1.b!=null){b3=a1.a
 b4=a1.b
 b4.toString
-J.dn(e,b3,b4)}}b0=h.b
+J.dp(e,b3,b4)}}b0=h.b
 b1=B.bg.h(0,g)
 b1.toString
 b0.a.k(0,b1,a9.a(e))}catch(b5){continue}}}b8.e=b7
@@ -13117,7 +13117,7 @@ i.b=o}break}a.d=q+4
 return i}}
 A.iO.prototype={}
 A.hn.prototype={}
-A.cR.prototype={}
+A.cS.prototype={}
 A.dx.prototype={
 h(a,b){var s=this.a.h(0,b)
 return s},
@@ -13204,7 +13204,7 @@ if(r===1){if(0>=r)return A.a(s,0)
 s=""+s[0]}else s=A.v(s)
 return s}}
 A.es.prototype={
-gaB(){return B.r},
+gaB(){return B.t},
 gp(a){return this.a.length},
 K(a){var s=this.a
 if(0>=s.length)return A.a(s,0)
@@ -13377,7 +13377,7 @@ K(a){return this.a},
 m(a){return"Ifd@"+this.a}}
 A.hb.prototype={}
 A.ck.prototype={}
-A.cQ.prototype={}
+A.cR.prototype={}
 A.em.prototype={}
 A.kl.prototype={}
 A.cm.prototype={}
@@ -13691,11 +13691,11 @@ B.a.i(k,r)
 for(;k.length<=o;r=l){m=A.W(2,null,!1,s)
 l=new A.dV(m)
 B.a.i(k,l)
-B.a.k(r.a,r.b,new A.cQ(m))}++p}++o
+B.a.k(r.a,r.b,new A.cR(m))}++p}++o
 if(o<j){m=A.W(2,null,!1,s)
 l=new A.dV(m)
 B.a.i(k,l)
-B.a.k(r.a,r.b,new A.cQ(m))
+B.a.k(r.a,r.b,new A.cR(m))
 r=l}}if(0>=k.length)return A.a(k,0)
 return k[0].a},
 hM(a0,a1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=a1.e
@@ -13817,8 +13817,8 @@ r.ay=s
 if(s===255)if(q.aw()!==0)return null
 r.ch=7
 return r.ay>>>7&1},
-c0(a){var s,r,q=new A.cQ(t.hQ.a(a))
-while(s=this.bg(),s!=null){if(q instanceof A.cQ){r=q.a
+c0(a){var s,r,q=new A.cR(t.hQ.a(a))
+while(s=this.bg(),s!=null){if(q instanceof A.cR){r=q.a
 if(s>>>0!==s||s>=2)return A.a(r,s)
 q=r[s]}if(q instanceof A.em)return q.a}return null},
 dC(a){var s,r
@@ -14064,7 +14064,7 @@ return s},
 $S:23}
 A.jJ.prototype={
 fg(){var s,r=this
-if(!r.r){s=$.d3
+if(!r.r){s=$.d4
 s=!s}else s=!0
 if(s)return
 r.r=!0
@@ -14086,11 +14086,11 @@ break
 case 1:B.a.i(l.d,new A.R(A.D(r.c)))
 break
 case 9:n=A.a8(r.c)
-switch(n){case"true":B.a.i(l.d,B.q)
+switch(n){case"true":B.a.i(l.d,B.r)
 continue A
 case"false":B.a.i(l.d,B.ab)
 continue A
-case"null":B.a.i(l.d,B.u)
+case"null":B.a.i(l.d,B.n)
 continue A
 case"BI":m=A.uf(s)
 l.d=A.b([],t.q)
@@ -14218,7 +14218,7 @@ if(n instanceof A.o&&p instanceof A.o){s=p.a
 q=n.a
 m=0
 for(;;){l=s.length
-if(!(m<l&&m<q.length)){n=B.u
+if(!(m<l&&m<q.length)){n=B.n
 break}if(!(m<l))return A.a(s,m)
 k=b.$1(s[m])
 if(k instanceof A.u&&k.a==="Crypt"){if(!(m<q.length))return A.a(q,m)
@@ -14311,31 +14311,35 @@ return s},
 h3(a){var s,r
 for(s=this.f,s=new A.c2(s,A.G(s).l("c2<1,2>")).gV(0);s.u();){r=s.d
 if(r.b===a)return r.a}return null},
-bq(a,b){var s,r,q,p,o,n,m=this,l=new A.av(a,b),k=m.f,j=k.h(0,l)
-if(j!=null)return j
-s=m.c.h(0,a)
-if(s==null)return B.u
-p=m.y
-if(!p.i(0,a))return B.u
+bq(a,b){var s,r,q,p,o,n,m,l,k=this,j=new A.av(a,b),i=k.f,h=i.h(0,j)
+if(h!=null)return h
+s=k.c.h(0,a)
+if(s==null)return B.n
+o=k.y
+if(!o.i(0,a))return B.n
 A.by(B.bD,1)
 r=null
-try{switch(s.a.a){case 0:r=B.u
+try{switch(s.a.a){case 0:r=B.n
 break
-case 1:o=m.f4(s.b,a)
-q=o==null?m.jk(a):o
-if(q==null)r=B.u
+case 1:n=k.f4(s.b,a)
+q=n==null?k.jk(a):n
+if(q==null)r=B.n
 else{r=q.c
-n=m.w
-if(n!=null&&a!==m.x)n.cL(r,a,q.b)}break
-case 2:r=m.f_(s.d).l2(a,s.e)
-break}}finally{p.b1(0,a)}if(r instanceof A.y)r.c=l
-k.k(0,l,r)
+m=k.w
+if(m!=null&&a!==k.x)m.cL(r,a,q.b)}break
+case 2:p=null
+try{p=k.f_(s.d).l2(a,s.e)}catch(l){m=A.I(l)
+if(m instanceof A.cP)p=B.n
+else if(t.b0.b(m))p=B.n
+else throw l}r=p
+break}}finally{o.b1(0,a)}if(r instanceof A.y)r.c=j
+i.k(0,j,r)
 return r},
 f4(a,b){var s,r,q,p
 try{s=new A.c_(new A.bG(this.a,a+this.b),this.gfh(),A.b([],t.O))
 r=s.h1()
 q=r.a===b?r:null
-return q}catch(p){q=A.J(p)
+return q}catch(p){q=A.I(p)
 if(t.I.b(q))return null
 else if(t.b0.b(q))return null
 else throw p}},
@@ -14347,7 +14351,7 @@ if(r==null||r.a!==B.P)return null
 q=p.f4(r.b,a)
 if(q!=null)A.by(B.bz,1)
 return q},
-j(a){var s,r,q=a==null?B.u:a
+j(a){var s,r,q=a==null?B.n:a
 for(s=0;q instanceof A.av;s=r){r=s+1
 if(s>1000)throw A.d(A.z("reference cycle",null))
 q=this.bq(q.a,q.b)}return q},
@@ -14400,7 +14404,7 @@ p=k
 n=p.c
 o=n.length!==0?B.a.ae(n,0):p.a.L()
 if(o.a!==B.w)A.Q(A.z(l+o.m(0),o.b))
-B.a.i(s,new A.j(q,A.B(o.c)))}catch(m){if(A.J(m) instanceof A.du)break
+B.a.i(s,new A.j(q,A.B(o.c)))}catch(m){if(A.I(m) instanceof A.cP)break
 else throw m}},
 l2(a,b){var s,r,q,p,o=this,n=o.c
 n=b<n.length&&n[b].a===a
@@ -14411,14 +14415,14 @@ if(s==null)for(n=o.c,r=n.length,q=0;q<r;++q){p=n[q]
 if(p.a===a){s=p
 break}}if(s==null)throw A.d(A.z("object "+a+" not found in its object stream",null))
 return new A.c_(new A.bG(o.a,o.b+s.b),null,A.b([],t.O)).bn()}}
-A.du.prototype={
+A.cP.prototype={
 m(a){var s=this.b,r=this.a
 return s==null?"CosParseException: "+r:"CosParseException at byte "+A.v(s)+": "+r},
 $iaa:1}
 A.iu.prototype={
 m(a){return"UnsupportedFilterException: "+this.a},
 $iaa:1}
-A.cP.prototype={
+A.cQ.prototype={
 m(a){return"CosPasswordException: password required or incorrect"},
 $iaa:1}
 A.f8.prototype={
@@ -14462,7 +14466,7 @@ return r instanceof A.m?r.a:b},
 $S:18}
 A.jz.prototype={
 $1(a){var s=this.a
-return J.V(s==null?null:s.a.h(0,a),B.q)},
+return J.V(s==null?null:s.a.h(0,a),B.r)},
 $S:75}
 A.h7.prototype={
 bD(){var s,r,q,p,o,n,m,l,k,j,i,h,g=this,f=g.b,e=B.b.q(f+7,3),d=new A.b_($.aW()),c=A.b([f,f],t.t),b=t.S,a=g.f,a0=g.a,a1=a0===0
@@ -14483,7 +14487,7 @@ k=l==null
 if(!k)a.aJ(0,1)
 if(k)break
 s=l===0}r=null
-try{r=s?g.im(c):g.ij()}catch(j){if(A.J(j) instanceof A.fj)break
+try{r=s?g.im(c):g.ij()}catch(j){if(A.I(j) instanceof A.fj)break
 else throw j}if(r==null)break
 d.i(0,g.jM(r,e));++m
 k=A.al(r,b)
@@ -14615,7 +14619,7 @@ s.b=s.b+B.b.q(r,3)
 s.c=r&7}}
 A.bF.prototype={}
 A.nA.prototype={
-$1(a){var s=a==null?B.u:a,r=this.a,q=r!=null
+$1(a){var s=a==null?B.n:a,r=this.a,q=r!=null
 for(;;){if(!(s instanceof A.av&&q))break
 s=r.$1(s)}return s},
 $S:20}
@@ -15372,7 +15376,7 @@ l=b3.e
 b1=(j-r)*(q-l)+(m-l)
 for(b2=0;b2<a2;++b2){r=b1+b2*(b3.c-b3.e)
 if(!(e<s.length))return A.a(s,e)
-B.t.au(b0,r,r+a1,s[e],b2*a1)}}},
+B.u.au(b0,r,r+a1,s[e],b2*a1)}}},
 ik(a,b){var s,r,q,p,o,n,m,l,k,j,i,h
 t.iZ.a(b)
 s=this.Q
@@ -15506,34 +15510,34 @@ A.iA.prototype={
 hN(a8,a9,b0,b1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=this,a5=a4.a,a6=a5.a,a7=a6===0
 if(a7){s=a5.b
 s===$&&A.k()
-a4.f!==$&&A.dl()
+a4.f!==$&&A.dm()
 a4.f=s
 s=a5.c
 s===$&&A.k()
-a4.r!==$&&A.dl()
+a4.r!==$&&A.dm()
 a4.r=s
 s=a5.d
 s===$&&A.k()
-a4.w!==$&&A.dl()
+a4.w!==$&&A.dm()
 a4.w=s
 s=a5.e
 s===$&&A.k()
-a4.x!==$&&A.dl()
+a4.x!==$&&A.dm()
 a4.x=s}else{r=B.b.M(1,b1+1)
 q=B.b.M(1,b1)
 s=q*a9
 p=B.c.E((a8.a-s)/r)
-a4.f!==$&&A.dl()
+a4.f!==$&&A.dm()
 a4.f=p
 p=q*b0
 o=B.c.E((a8.b-p)/r)
-a4.r!==$&&A.dl()
+a4.r!==$&&A.dm()
 a4.r=o
 s=B.c.E((a8.c-s)/r)
-a4.w!==$&&A.dl()
+a4.w!==$&&A.dm()
 a4.w=s
 p=B.c.E((a8.d-p)/r)
-a4.x!==$&&A.dl()
+a4.x!==$&&A.dm()
 a4.x=p
 s=p}p=a8.e
 o=p.z
@@ -16275,9 +16279,9 @@ case 40:return n.j0(s)
 case 41:throw A.d(A.z('unexpected ")"',s))
 case 47:return n.j3(s)
 case 123:n.b=s+1
-return new A.aw(B.n,s,"{")
+return new A.aw(B.o,s,"{")
 case 125:n.b=s+1
-return new A.aw(B.n,s,"}")
+return new A.aw(B.o,s,"}")
 default:r=!0
 if(p!==43)if(p!==45)if(p!==46)r=p>=48&&p<=57
 if(r)return n.j5(s)
@@ -16411,7 +16415,7 @@ s=p[n]
 s=!(s===0||s===9||s===10||s===12||s===13||s===32)&&!A.hf(s)}else s=!1
 if(!s)break;++n}if(n===a){if(!(q>=0&&q<o))return A.a(p,q)
 throw A.d(A.z("unexpected byte 0x"+B.b.e6(p[q],16),a))}r.b=n
-return new A.aw(B.n,a,r.iY(a,n))},
+return new A.aw(B.o,a,r.iY(a,n))},
 iY(a,b){var s,r,q,p,o,n,m=b-a
 if(m>3)return A.a0(this.a,a,b)
 s=this.a
@@ -16520,14 +16524,14 @@ bc(){return this.e1(0)},
 L(){var s=this.c
 return s.length!==0?B.a.ae(s,0):this.a.L()},
 cP(a){var s=this.L()
-if(!(s.a===B.n&&s.c===a))throw A.d(A.z('expected "'+a+'", found '+s.m(0),s.b))
+if(!(s.a===B.o&&s.c===a))throw A.d(A.z('expected "'+a+'", found '+s.m(0),s.b))
 return s},
 dX(){var s=this.L()
 if(s.a!==B.w)throw A.d(A.z("expected integer, found "+s.m(0),s.b))
 return A.B(s.c)},
 bn(){var s,r,q,p=this,o=p.bc()
 switch(o.a.a){case 0:if(p.e1(1).a===B.w){s=p.e1(2)
-s=s.a===B.n&&s.c==="R"}else s=!1
+s=s.a===B.o&&s.c==="R"}else s=!1
 if(s){r=A.B(p.L().c)
 q=A.B(p.L().c)
 p.L()
@@ -16544,16 +16548,16 @@ return new A.u(A.a8(o.c))
 case 5:return p.ja()
 case 7:return p.jc()
 case 9:p.L()
-switch(A.a8(o.c)){case"true":return B.q
+switch(A.a8(o.c)){case"true":return B.r
 case"false":return B.ab
-case"null":return B.u}throw A.d(A.z('unexpected keyword "'+o.gh6()+'"',o.b))
+case"null":return B.n}throw A.d(A.z('unexpected keyword "'+o.gh6()+'"',o.b))
 case 10:throw A.d(A.z("unexpected end of input",o.b))
 case 6:case 8:throw A.d(A.z("unexpected token "+o.m(0),o.b))}},
 h1(){var s,r,q=this,p=q.dX(),o=q.dX()
 q.cP("obj")
 s=q.bn()
 r=q.bc()
-if(r.a===B.n&&r.c==="endobj")q.L()
+if(r.a===B.o&&r.c==="endobj")q.L()
 return new A.jQ(p,o,s)},
 ja(){var s,r,q,p=this
 p.L()
@@ -16577,7 +16581,7 @@ if(n!==B.O)throw A.d(A.z("expected name as dictionary key, found "+o.m(0),o.b))
 if(p.length!==0)B.a.ae(p,0)
 else q.L()
 r.k(0,A.a8(o.c),f.bn())}n=f.bc()
-if(n.a===B.n&&n.c==="stream"){m=f.L()
+if(n.a===B.o&&n.c==="stream"){m=f.L()
 B.a.A(p)
 n=q.b=m.b+6
 l=q.a
@@ -16672,7 +16676,7 @@ lp(a){var s,r,q,p,o,n,m=t.S,l=A.x(m,t.w),k=A.aJ(null),j=this.b,i=A.b([a+j],t.t),
 for(s=!1;i.length!==0;){r=B.a.ae(i,0)
 if(!h.i(0,r))continue
 q=this.l6(r)
-for(m=q.a,m=new A.cT(m,m.r,m.e,A.G(m).l("cT<1,2>"));m.u();){p=m.d
+for(m=q.a,m=new A.cU(m,m.r,m.e,A.G(m).l("cU<1,2>"));m.u();){p=m.d
 l.ad(p.a,new A.k0(p))}if(!s){k=q.b
 s=!0}m=q.b.a
 o=m.h(0,"XRefStm")
@@ -16683,7 +16687,7 @@ l6(a){var s,r
 if(a<0||a>=this.a.length)throw A.d(A.z("cross-reference offset out of range",a))
 s=new A.c_(new A.bG(this.a,a),null,A.b([],t.O))
 r=s.bc()
-if(r.a===B.n&&r.c==="xref")return A.uq(s)
+if(r.a===B.o&&r.c==="xref")return A.uq(s)
 return A.up(s)}}
 A.k0.prototype={
 $0(){return this.a.b},
@@ -16906,7 +16910,7 @@ if(j instanceof A.o)for(q=j.a,p=q.length,o=0;o<q.length;q.length===p||(0,A.l)(q)
 if(n instanceof A.y)B.a.i(i,n)}m=new A.b_($.aW())
 for(q=i.length,p=t.I,o=0;o<i.length;i.length===q||(0,A.l)(i),++o){s=i[o]
 r=null
-try{r=k.a3(s)}catch(l){if(p.b(A.J(l)))continue
+try{r=k.a3(s)}catch(l){if(p.b(A.I(l)))continue
 else throw l}if(m.gcf(0))m.ab(10)
 m.i(0,r)}return m.aG()},
 k8(a){var s,r,q,p,o,n,m
@@ -17560,7 +17564,7 @@ if(2>=r)return A.a(q,2)
 n=B.c.v(q[2])
 if(3>=r)return A.a(q,3)
 b0.y.$4(p,o,n,B.c.v(q[3]))
-B.a.A(q)}if(b0.ch){B.a.i(l,B.o)
+B.a.A(q)}if(b0.ch){B.a.i(l,B.p)
 b0.ch=!1}return}if(12===g){if(!(s<o))return A.a(p,s)
 c=s+1
 b0.hT(p[s])
@@ -17650,7 +17654,7 @@ eq(a,b,c,d,e,f){var s=this
 B.a.i(s.z,new A.ab(s.bY(a,b),s.bZ(a,b),s.bY(c,d),s.bZ(c,d),s.bY(e,f),s.bZ(e,f)))
 s.as=e
 s.at=f},
-hS(){if(this.ch){B.a.i(this.z,B.o)
+hS(){if(this.ch){B.a.i(this.z,B.p)
 this.ch=!1}},
 fz(a,b,c){var s,r,q,p,o=this,n=o.bY(b,c),m=o.bZ(b,c)
 for(s=a.a,r=s.length,q=o.z,p=0;p<s.length;s.length===r||(0,A.l)(s),++p)B.a.i(q,o.k9(s[p],n,m))},
@@ -17777,7 +17781,7 @@ a=r
 if(typeof b!=="number")return b.a4()
 if(typeof a!=="number")return A.r(a)
 if(!(b<a))break
-J.dp(q,s.H())
+J.dq(q,s.H())
 b=p
 if(typeof b!=="number")return b.R()
 p=b+1}o=q
@@ -17809,10 +17813,10 @@ q=s
 b=q.a
 q=q.b++
 if(!(q>=0&&q<b.length))return A.a(b,q)
-J.dp(k,b[q])
+J.dq(k,b[q])
 q=j
 if(typeof q!=="number")return q.R()
-j=q+1}J.dp(n,A.a0(k,0,null))}i=A.x(t.N,t.S)
+j=q+1}J.dq(n,A.a0(k,0,null))}i=A.x(t.N,t.S)
 h=0
 for(;;){q=h
 k=r
@@ -17944,7 +17948,7 @@ j=k?l:new A.bA((n.a+l.a)/2,(n.b+l.b)/2,!0)
 A.qv(c,o,n,j,b)
 n=k?null:l
 o=j}}if(n!=null)A.qv(c,o,n,q,b)
-B.a.i(c,B.o)},
+B.a.i(c,B.p)},
 bw(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this,e=f.w
 if(e!=null)return e
 s=A.b([],t.br)
@@ -17966,7 +17970,7 @@ l=q.X()
 i=r.a
 h=l
 if(typeof h!=="number")return A.r(h)
-J.dp(s,new A.da(k,i+h,n,m))
+J.dq(s,new A.db(k,i+h,n,m))
 i=o
 if(typeof i!=="number")return i.R()
 o=i+1}}catch(g){}return f.w=s}}
@@ -17993,7 +17997,7 @@ $1(a){var s=this.a,r=J.a9(s)
 return r.h(s,B.b.ah(a,r.gp(s)))},
 $S:58}
 A.bA.prototype={}
-A.da.prototype={
+A.db.prototype={
 cS(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
 try{j=new A.cg(this.a)
 j.b=this.b
@@ -18189,7 +18193,7 @@ d.dz(l,k,j,h,g,5<m?b[5]:0)
 B.a.A(b)
 p=o
 break
-case 9:if(d.as){B.a.i(q,B.o)
+case 9:if(d.as){B.a.i(q,B.p)
 d.as=!1}B.a.A(b)
 p=o
 break
@@ -18371,7 +18375,7 @@ d0(a,b,c,d,e,f){var s=this
 B.a.i(s.d,new A.ab(s.c8(a,b),s.c9(a,b),s.c8(c,d),s.c9(c,d),s.c8(e,f),s.c9(e,f)))
 s.x=e
 s.y=f},
-cq(){if(this.as){B.a.i(this.d,B.o)
+cq(){if(this.as){B.a.i(this.d,B.p)
 this.as=!1}},
 aK(a){var s=this.e
 return a<s.length?s[a]:0},
@@ -18491,7 +18495,7 @@ n=p
 if(typeof n!=="number")return n.a5()
 n*=2
 if(n>>>0!==n||n>=o.length)return A.a(o,n)
-J.dp(q,o[n])
+J.dq(q,o[n])
 n=p
 if(typeof n!=="number")return n.R()
 p=n+1}return q}d=A.b([],t.n)
@@ -18712,8 +18716,8 @@ else f=g==="para"?12+4*B.a.h(B.dX,Math.min(m.getUint16(p+8,!1),4)):12
 p+=(f+3&4294967292)>>>0}return q},
 $S:67}
 A.aH.prototype={}
+A.d2.prototype={}
 A.d1.prototype={}
-A.d0.prototype={}
 A.kM.prototype={}
 A.mh.prototype={}
 A.nT.prototype={
@@ -18725,7 +18729,7 @@ sfM(a){this.a=t.ge.a(a)},
 skO(a){this.y=t.H.a(a)}}
 A.lS.prototype={}
 A.hV.prototype={}
-A.cZ.prototype={$iaa:1}
+A.d_.prototype={$iaa:1}
 A.hZ.prototype={
 cd(a,b,c,d){return this.kD(a,b,c,d)},
 kC(a,b,c){return this.cd(a,b,null,c)},
@@ -18737,7 +18741,7 @@ B.a.A(n.x)
 B.a.A(n.y)
 n.ay=a.gfX()
 l=n.b
-B.a.i(l.gG(),B.p)
+B.a.i(l.gG(),B.q)
 q=2
 k=A.pD(b,c)
 j=a.c
@@ -18801,7 +18805,7 @@ n=j-n
 d=j-h
 l=i-l
 c=i-g
-q=new A.ak(A.b([new A.a1(m,i),new A.ab(m,p,f,e,j,e),new A.ab(n,e,d,p,d,i),new A.ab(d,l,n,c,j,c),new A.ab(f,c,m,l,m,i),B.o],t.g))
+q=new A.ak(A.b([new A.a1(m,i),new A.ab(m,p,f,e,j,e),new A.ab(n,e,d,p,d,i),new A.ab(d,l,n,c,j,c),new A.ab(f,c,m,l,m,i),B.p],t.g))
 m=a.b.a
 o=a.b2(m.h(0,"IC"))
 p=o==null
@@ -18898,7 +18902,7 @@ if((l.d-l.b-j)/2<2)l=2
 else{l=s
 l=(l.d-l.b-j)/2}n=l+s.b
 l=this.b
-B.a.i(l.gG(),B.p)
+B.a.i(l.gG(),B.q)
 try{k=this.dD(new A.aR(s.a+1,s.b+1,s.c-1,s.d-1))
 B.a.i(l.gG(),new A.b9(k,B.l))
 k=s.a
@@ -18979,7 +18983,7 @@ break A}s=null
 break A}return s},
 bi(a){return new A.M((a>>>16&255)/255,(a>>>8&255)/255,(a&255)/255)},
 dD(a){var s=a.a,r=a.b,q=a.c,p=a.d
-return new A.ak(A.b([new A.a1(s,r),new A.O(q,r),new A.O(q,p),new A.O(s,p),B.o],t.g))},
+return new A.ak(A.b([new A.a1(s,r),new A.O(q,r),new A.O(q,p),new A.O(s,p),B.p],t.g))},
 eR(a,b){var s=a.c,r=a.a,q=Math.min(b,(s-r)/2),p=a.d,o=a.b,n=Math.min(b,(p-o)/2)
 return new A.aR(r+q,o+n,s-q,p-n)},
 jq(a){var s,r,q,p,o,n,m,l,k,j,i=this.a,h=i.j(a.b.a.h(0,"QuadPoints"))
@@ -18999,7 +19003,7 @@ for(r=a.c,q=-o,s=!0;m<r;){m=Math.min(r,m+n)
 B.a.i(l,new A.O(m,p+(s?o:q)))
 s=!s}return new A.ak(l)},
 is(b3,b4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1=this,b2=null
-try{b2=b1.a.a3(b3)}catch(k){if(t.I.b(A.J(k)))return
+try{b2=b1.a.a3(b3)}catch(k){if(t.I.b(A.I(k)))return
 else throw k}s=b3.a
 j=b1.a
 i=j.j(s.a.h(0,"Matrix"))
@@ -19024,7 +19028,7 @@ o=g.length
 f=b1.x
 n=f.length
 e=b1.b
-B.a.i(e.gG(),B.p)
+B.a.i(e.gG(),B.q)
 try{d=A.iR()
 d.sfM(q)
 b1.e=d
@@ -19134,7 +19138,7 @@ this.eI(q,b,c)}},
 eI(a4,a5,a6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=this,a2=null,a3=a4.b
 A:{s=a4.a
 if("q"===s){B.a.i(a1.f,A.oF(a1.e))
-B.a.i(a1.b.gG(),B.p)
+B.a.i(a1.b.gG(),B.q)
 break A}if("Q"===s){r=a1.f
 q=r.length
 if(q!==0){if(0>=q)return A.a(r,-1)
@@ -19209,9 +19213,9 @@ r.c=new A.M(q,q,q)
 break A}if("rg"===s){a1.e.b=new A.M(A.w(a3,0),A.w(a3,1),A.w(a3,2))
 a1.e.x=null
 break A}if("RG"===s){a1.e.c=new A.M(A.w(a3,0),A.w(a3,1),A.w(a3,2))
-break A}if("k"===s){a1.e.b=A.d_(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
+break A}if("k"===s){a1.e.b=A.d0(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
 a1.e.x=null
-break A}if("K"===s){a1.e.c=A.d_(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
+break A}if("K"===s){a1.e.c=A.d0(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
 break A}if("cs"===s){r=a1.e
 q=r.x=null
 n=a3.length
@@ -19452,7 +19456,7 @@ B.a.i(s.ch,new A.ab(r.aH(a,b),r.aI(a,b),r.aH(c,d),r.aI(c,d),r.aH(e,f),r.aI(e,f))
 s.CW=e
 s.cx=f},
 c_(){var s=this
-B.a.i(s.ch,B.o)
+B.a.i(s.ch,B.p)
 s.CW=s.cy
 s.cx=s.db},
 bh(a,b){var s,r,q,p,o,n,m,l,k=this,j=k.ch,i=new A.ak(j)
@@ -19578,12 +19582,12 @@ B.a.i(s.gG(),new A.aQ(a.c,r,p,a.d,a.e,a.f))},
 jT(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c=this
 if(c.at>=16)return
 s=null
-try{s=c.a.a3(a.a)}catch(j){if(t.I.b(A.J(j)))return
+try{s=c.a.a3(a.a)}catch(j){if(t.I.b(A.I(j)))return
 else throw j}r=c.e
 i=c.f
 q=i.length
 h=c.b
-B.a.i(h.gG(),B.p)
+B.a.i(h.gG(),B.q)
 try{g=A.iR()
 g.a=a.b
 c.e=g
@@ -19600,7 +19604,7 @@ if(!(e<4))break
 e=A.B(m)
 d=o.a
 if(!(e>=0&&e<d.length))return A.a(d,e)
-J.dp(n,A.ai(g.j(d[e])))
+J.dq(n,A.ai(g.j(d[e])))
 e=m
 if(typeof e!=="number")return e.R()
 m=e+1}c.co(n)}l=g.j(f.h(0,"Resources"))
@@ -19718,7 +19722,7 @@ s=s==null?o:s.gcJ()}return s},
 fq(a){var s,r,q,p,o,n,m,l,k,j=this,i=null,h=j.a.j(a.a.a.h(0,"PaintType"))
 if(h instanceof A.m&&h.a===2){r=j.e.y
 return r.length!==0?A.jr(r,i):i}s=null
-try{s=j.r.ad(a,new A.kY(j,a))}catch(q){if(t.I.b(A.J(q)))return i
+try{s=j.r.ad(a,new A.kY(j,a))}catch(q){if(t.I.b(A.I(q)))return i
 else throw q}for(r=J.bh(s),p=i;r.u();){o=r.gF()
 n=o.b
 switch(o.a){case"g":o=0<n.length?A.ai(n[0]):0
@@ -19733,7 +19737,7 @@ case"k":o=n.length
 m=0<o?A.ai(n[0]):0
 l=1<o?A.ai(n[1]):0
 k=2<o?A.ai(n[2]):0
-p=A.d_(m,l,k,3<o?A.ai(n[3]):0)
+p=A.d0(m,l,k,3<o?A.ai(n[3]):0)
 break}}return p},
 iV(a){var s,r,q,p=this.dv(a)
 if(p==null)return null
@@ -19768,7 +19772,7 @@ B.a.i(l.b.gG(),new A.cw(a,b,n,s))
 return}m=s?null:o.e5(l.c2(k))
 if(m==null)m=s?null:o.e4(l.c2(k))
 if(m!=null){s=l.b
-B.a.i(s.gG(),B.p)
+B.a.i(s.gG(),B.q)
 B.a.i(s.gG(),new A.b9(a,b))
 r=l.e.d
 B.a.i(s.gG(),new A.cv(m,r))
@@ -19836,7 +19840,7 @@ if(typeof a5!=="number")return a5.ee()
 if(typeof a6!=="number")return A.r(a6)
 if((a0-a1+1)*(a5-a6+1)>4096)return
 a0=c5.b
-B.a.i(a0.gG(),B.p)
+B.a.i(a0.gG(),B.q)
 B.a.i(a0.gG(),new A.b9(c8,c9))
 c2=c5.e
 i=c2
@@ -19871,7 +19875,7 @@ c5.e=a5
 if(g!=null){a5.b=g
 a5.c=g}c4=a0.c
 if(c4===$){a0.c=c3
-c4=c3}B.a.i(c4,B.p)
+c4=c3}B.a.i(c4,B.q)
 try{c5.co(q)
 c5.c6(r,n,c5.at+1)}finally{d=c5.e.z
 if(d!=null)c5.b9(d)
@@ -19908,7 +19912,7 @@ s=n.a
 r=n.b
 m=n.c
 l=n.d
-l=A.b([new A.a1(s,r),new A.O(m,r),new A.O(m,l),new A.O(s,l),B.o],t.g)
+l=A.b([new A.a1(s,r),new A.O(m,r),new A.O(m,l),new A.O(s,l),B.p],t.g)
 s=k.e.d
 B.a.i(k.b.gG(),new A.cw(new A.ak(l),B.l,p,s))},
 eY(a){var s,r,q,p,o=this.a,n=o.j(a)
@@ -19943,12 +19947,12 @@ if(!(s instanceof A.y))return
 g=s.a.a.h(0,"Subtype")
 f=g instanceof A.u?g.a:""
 if(f==="Image"){n=a5.e
-a5.b.cN(new A.ca(s,null,!1,n.a,n.d,i.j(s.a.a.h(0,"ImageMask")).I(0,B.q),a5.e.b))
+a5.b.cN(new A.ca(s,null,!1,n.a,n.d,i.j(s.a.a.h(0,"ImageMask")).I(0,B.r),a5.e.b))
 return}if(f!=="Form"||a8>=16)return
 e=a5.e.d
 d=i.j(s.a.a.h(0,"Group"))
 c=d instanceof A.p
-b=c&&i.j(d.a.h(0,"K")).I(0,B.q)
+b=c&&i.j(d.a.h(0,"K")).I(0,B.r)
 if(c)a=e<1||b
 else a=!1
 r=a
@@ -19957,8 +19961,8 @@ q=a0.z
 a1=a5.f
 B.a.i(a1,A.oF(a0))
 a0=a5.b
-B.a.i(a0.gG(),B.p)
-if(r){B.a.i(a0.gG(),new A.cY(e,b))
+B.a.i(a0.gG(),B.q)
+if(r){B.a.i(a0.gG(),new A.cZ(e,b))
 a2=a5.e
 a2.e=a2.d=1}try{p=i.j(s.a.a.h(0,"Matrix"))
 if(p instanceof A.o&&p.a.length>=6)a5.e.a=A.eS(p.a).a6(a5.e.a)
@@ -19971,12 +19975,12 @@ if(!(a2<4))break
 a2=A.B(m)
 a3=o.a
 if(!(a2>=0&&a2<a3.length))return A.a(a3,a2)
-J.dp(n,A.ai(i.j(a3[a2])))
+J.dq(n,A.ai(i.j(a3[a2])))
 a2=m
 if(typeof a2!=="number")return a2.R()
 m=a2+1}a5.co(n)}l=i.j(s.a.a.h(0,"Resources"))
 k=null
-try{k=i.a3(s)}catch(a4){if(t.I.b(A.J(a4)))return
+try{k=i.a3(s)}catch(a4){if(t.I.b(A.I(a4)))return
 else throw a4}n=A.ef(k)
 i=l instanceof A.p?l:a6
 a5.c6(n,i,a8+1)}finally{j=a5.e.z
@@ -20005,7 +20009,7 @@ i=i.b
 i=new A.a1(q*h+p*i+o,m*h+l*i+k)}else{i=n[j]
 h=i.a
 i=i.b
-i=new A.O(q*h+p*i+o,m*h+l*i+k)}r.push(i)}r.push(B.o)
+i=new A.O(q*h+p*i+o,m*h+l*i+k)}r.push(i)}r.push(B.p)
 B.a.i(this.b.gG(),new A.b9(new A.ak(r),B.l))},
 iy(a){var s,r,q,p
 t.Q.a(a)
@@ -20021,7 +20025,7 @@ q.a.al(0,new A.kO(p))
 if(1>=a.length)return A.a(a,1)
 s=t.V.a(a[1])
 r=this.e
-this.b.cN(new A.ca(new A.y(p,s.a),null,!0,r.a,r.d,J.V(p.a.h(0,"ImageMask"),B.q),this.e.b))}}
+this.b.cN(new A.ca(new A.y(p,s.a),null,!0,r.a,r.d,J.V(p.a.h(0,"ImageMask"),B.r),this.e.b))}}
 A.kN.prototype={
 $1(a){return A.bf(a)},
 $S:7}
@@ -20044,7 +20048,7 @@ A.kQ.prototype={
 $1(a){var s,r
 try{s=this.a
 s=s.r.ad(a,new A.kP(s,a))
-return s}catch(r){if(t.I.b(A.J(r)))return B.b8
+return s}catch(r){if(t.I.b(A.I(r)))return B.b8
 else throw r}},
 $S:70}
 A.kP.prototype={
@@ -20069,7 +20073,7 @@ i=k.k2
 h=A.al(i,t.bM)
 m=h
 l=k.b
-B.a.i(l.gG(),B.p)
+B.a.i(l.gG(),B.q)
 try{g=A.oF(r)
 g.sfM(s)
 g.as=null
@@ -20094,7 +20098,7 @@ $S:11}
 A.kS.prototype={
 $0(){var s,r
 try{s=A.ef(this.a.a.a3(this.b))
-return s}catch(r){if(t.I.b(A.J(r)))return B.b8
+return s}catch(r){if(t.I.b(A.I(r)))return B.b8
 else throw r}},
 $S:11}
 A.kO.prototype={
@@ -20105,7 +20109,7 @@ s=B.em.h(0,a)
 if(s==null)s=a
 this.a.k(0,s,b)},
 $S:8}
-A.d2.prototype={}
+A.d3.prototype={}
 A.eU.prototype={
 gcJ(){var s,r,q,p,o,n,m
 for(s=this.a,r=s.length,q=0,p=0,o=0,n=0;n<r;++n){m=s[n].c
@@ -20122,7 +20126,7 @@ case 5:q.jg()
 break
 case 6:case 7:q.jh(s===7)
 break
-default:return null}}catch(r){if(!(A.J(r) instanceof A.fy))throw r}s=q.as
+default:return null}}catch(r){if(!(A.I(r) instanceof A.fy))throw r}s=q.as
 if(s.length===0)return null
 return new A.eU(q.Q,s)},
 da(a,b,c){var s,r=b>=32?4294967295:B.b.M(1,b)-1,q=c*2,p=this.e,o=p.length,n=q<o?p[q]:0;++q
@@ -20136,7 +20140,7 @@ for(;;){if(!(l<(m?1:o)))break
 r.push(s.da(q.aP(p),p,2+l));++l}if(m){if(0>=r.length)return A.a(r,0)
 return s.x.$1(n.aO(r[0]))}return s.x.$1(r)},
 c3(){var s=this.bA()
-return new A.d2(s.a,s.b,this.fa())},
+return new A.d3(s.a,s.b,this.fa())},
 je(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
 for(s=e.z,r=e.d,q=s.a.length,p=e.as,o=t.t,n=e.Q,m=null,l=null,k=null;(q-s.b)*8-s.c>=r;){j=s.aP(r)
 if(j===0){B.a.i(n,e.c3())
@@ -20253,7 +20257,7 @@ a1=f+(e.b-f)*n
 g=g.c
 c=c.c
 a2=g+(e.c-g)*n
-B.a.i(s,new A.d2(m,l,new A.M(a+(b+(d.a-b)*n-a)*p,a1+(a0+(d.b-a0)*n-a1)*p,a2+(c+(d.c-c)*n-a2)*p)))}}for(s=this.as,g=t.t,q=0;q<8;++q)for(f=r+q*9,o=0;o<8;++o){a3=f+o
+B.a.i(s,new A.d3(m,l,new A.M(a+(b+(d.a-b)*n-a)*p,a1+(a0+(d.b-a0)*n-a1)*p,a2+(c+(d.c-c)*n-a2)*p)))}}for(s=this.as,g=t.t,q=0;q<8;++q)for(f=r+q*9,o=0;o<8;++o){a3=f+o
 a4=a3+1
 a5=a3+9
 B.a.T(s,A.b([a3,a4,a5],g))
@@ -20394,7 +20398,7 @@ if(q<=o)return
 s=o*2
 while(s<q)s*=2
 q=new Float32Array(s)
-B.t.C(q,0,r,p)
+B.u.C(q,0,r,p)
 this.a=q},
 cG(a,b,c,d){var s,r,q,p,o=this
 o.dk(4)
@@ -20709,7 +20713,7 @@ q.r=s
 r=q.w
 s=4*s
 if(r.length<s)q.w=new Float32Array(s)
-else B.t.ao(r,0,s,0)
+else B.u.ao(r,0,s,0)
 s=q.x
 r=q.f
 if(s.length<r){s=q.x=new Int32Array(r)
@@ -21332,7 +21336,7 @@ if(s)c.f8(j,f,k,e,d)
 else c.f8(j,e,d,f,k)}},
 f8(a,b,c,d,e){var s,r,q,p,o,n,m=this,l=m.ay,k=4*l,j=m.at,i=j.length
 if(k+4>i){i=new Float32Array(i*2)
-B.t.C(i,0,k,j)
+B.u.C(i,0,k,j)
 m.at=i
 i=m.ax
 j=new Int32Array(i.length*2)
@@ -21712,7 +21716,7 @@ B.a.i(s.cx,q)
 s.db=s.db+q.f}}
 A.mK.prototype={
 gfm(){var s=this.b
-return s===$?this.b=J.I(B.d.gt(this.a),0,null):s},
+return s===$?this.b=J.J(B.d.gt(this.a),0,null):s},
 a2(a){var s,r,q=this,p=q.c,o=p+a,n=q.a,m=n.length
 if(o<=m)return
 s=m*2
@@ -21720,7 +21724,7 @@ while(s<o)s*=2
 r=new Uint8Array(s)
 B.d.C(r,0,p,n)
 q.a=r
-q.b=J.I(B.d.gt(r),0,null)},
+q.b=J.J(B.d.gt(r),0,null)},
 B(a){var s,r
 this.a2(1)
 s=this.a
@@ -21861,8 +21865,8 @@ cN(a){B.a.i(this.b,a)
 B.a.i(this.gG(),new A.bo(a))},
 $ikD:1}
 A.a7.prototype={}
+A.d6.prototype={}
 A.d5.prototype={}
-A.d4.prototype={}
 A.bw.prototype={}
 A.cw.prototype={}
 A.cv.prototype={}
@@ -21871,7 +21875,7 @@ A.b9.prototype={}
 A.cu.prototype={}
 A.bo.prototype={}
 A.bO.prototype={}
-A.cY.prototype={}
+A.cZ.prototype={}
 A.dL.prototype={}
 A.dJ.prototype={}
 A.aQ.prototype={}
@@ -21915,7 +21919,7 @@ A.nq(s,b)},
 $S:8}
 A.n1.prototype={
 gdM(){var s=this.b
-return s===$?this.b=J.I(B.d.gt(this.a),0,null):s},
+return s===$?this.b=J.J(B.d.gt(this.a),0,null):s},
 Z(a){var s,r,q=this,p=q.c,o=p+a,n=q.a,m=n.length
 if(o<=m)return
 s=m*2
@@ -21923,7 +21927,7 @@ while(s<o)s*=2
 r=new Uint8Array(s)
 B.d.C(r,0,p,n)
 q.a=r
-q.b=J.I(B.d.gt(r),0,null)},
+q.b=J.J(B.d.gt(r),0,null)},
 B(a){var s,r
 this.Z(1)
 s=this.a
@@ -21968,7 +21972,7 @@ n.a7(a.length)
 n.Z(a.length*8)
 for(s=a.length,r=0;r<a.length;a.length===s||(0,A.l)(a),++r){q=a[r]
 p=n.b
-if(p===$)p=n.b=J.I(B.d.gt(n.a),0,null)
+if(p===$)p=n.b=J.J(B.d.gt(n.a),0,null)
 o=n.c
 p.$flags&2&&A.e(p,13)
 p.setFloat64(o,q,!1)
@@ -21979,7 +21983,7 @@ n.a7(a.length)
 n.Z(a.length*4)
 for(s=a.length,r=0;r<a.length;a.length===s||(0,A.l)(a),++r){q=a[r]
 p=n.b
-if(p===$)p=n.b=J.I(B.d.gt(n.a),0,null)
+if(p===$)p=n.b=J.J(B.d.gt(n.a),0,null)
 o=n.c
 p.$flags&2&&A.e(p,8)
 p.setInt32(o,q,!1)
@@ -22022,7 +22026,7 @@ else r=!0
 if(r)return null
 r=new A.l9(n,l)
 s=null
-try{s=n.a3(m)}catch(q){if(t.I.b(A.J(q)))return null
+try{s=n.a3(m)}catch(q){if(t.I.b(A.I(q)))return null
 else throw q}p=s
 return new A.l_(k,r.$2("BitsPerCoordinate",16),r.$2("BitsPerComponent",8),r.$2("BitsPerFlag",8),A.l7(n,l.a.h(0,"Decode")),o.d,r.$2("VerticesPerRow",0),o.c,o.e,a,new A.m4(p),A.b([],t.ai),A.b([],t.t)).l5()},
 e4(a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=this,a5=a4.c,a6=!0
@@ -22044,7 +22048,7 @@ if(0>=b)return A.a(s,0)
 a=s[0]
 if(1>=b)return A.a(s,1)
 a0=a+(s[1]-a)*c/24
-B.a.i(p,new A.d2(m*a0+f+k,j*a0+e+h,n.$1(a5.bF(A.b([a0,d],a6)))))}}for(g=0;g<24;++g)for(a6=g*25,c=0;c<24;++c){a1=a6+c
+B.a.i(p,new A.d3(m*a0+f+k,j*a0+e+h,n.$1(a5.bF(A.b([a0,d],a6)))))}}for(g=0;g<24;++g)for(a6=g*25,c=0;c<24;++c){a1=a6+c
 a2=a1+1
 a3=a1+24+1
 B.a.i(o,a1)
@@ -22100,30 +22104,30 @@ p(A.hZ.prototype,"geH","dg",23)
 o(A,"rH",2,null,["$1$2","$2"],["rJ",function(a,b){return A.rJ(a,b,t.r)}],27,0)
 o(A,"rG",2,null,["$1$2","$2"],["rI",function(a,b){return A.rI(a,b,t.r)}],27,0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
 r(A.K,null)
-q(A.K,[A.om,J.hB,A.f0,J.ed,A.b_,A.dT,A.a2,A.N,A.le,A.q,A.b7,A.eH,A.fc,A.ej,A.fe,A.aP,A.d8,A.aT,A.dt,A.fq,A.aN,A.lO,A.hR,A.ek,A.fG,A.aL,A.kq,A.az,A.cU,A.cT,A.dC,A.ft,A.dS,A.il,A.jc,A.m6,A.jg,A.bz,A.iQ,A.je,A.mU,A.iy,A.bB,A.bk,A.iI,A.db,A.aq,A.iz,A.ja,A.fM,A.d6,A.iW,A.fr,A.af,A.m1,A.h3,A.ds,A.mC,A.n_,A.jh,A.hh,A.mi,A.hS,A.f2,A.iN,A.C,A.bv,A.ap,A.jd,A.ax,A.ia,A.bQ,A.ho,A.hQ,A.hj,A.k6,A.lR,A.kd,A.hz,A.hT,A.aO,A.c0,A.hu,A.hU,A.fl,A.i3,A.cz,A.la,A.iD,A.cR,A.iO,A.hn,A.dx,A.ay,A.hb,A.ck,A.kl,A.cm,A.km,A.dV,A.hF,A.kn,A.hG,A.hw,A.ke,A.dP,A.aZ,A.jJ,A.fV,A.lj,A.he,A.dW,A.du,A.iu,A.cP,A.f8,A.bF,A.h7,A.fj,A.iC,A.ki,A.iB,A.mv,A.t,A.iS,A.mu,A.bS,A.ko,A.iJ,A.fk,A.fB,A.mx,A.cH,A.j0,A.iA,A.bT,A.mH,A.bC,A.m2,A.bM,A.ku,A.bG,A.a_,A.T,A.jQ,A.c_,A.i1,A.aw,A.bs,A.hg,A.jT,A.jU,A.c5,A.cr,A.kC,A.kE,A.iK,A.iU,A.l1,A.aR,A.dK,A.M,A.c6,A.c9,A.eV,A.ca,A.hW,A.jB,A.fA,A.m7,A.ch,A.bX,A.lG,A.bA,A.da,A.cg,A.lL,A.mW,A.c7,A.cl,A.bU,A.iX,A.aH,A.d1,A.d0,A.kM,A.mh,A.fm,A.lS,A.hV,A.cZ,A.hZ,A.d2,A.eU,A.l_,A.fy,A.m4,A.bN,A.ak,A.dO,A.eY,A.hs,A.bl,A.hq,A.dv,A.k1,A.el,A.f1,A.ij,A.ii,A.lg,A.io,A.im,A.f3,A.lx,A.ly,A.h5,A.k5,A.h6,A.lf,A.lE,A.mK,A.lF,A.i8,A.a7,A.fL,A.dU,A.iT,A.n1,A.mR,A.hY,A.l6])
-q(J.hB,[J.hD,J.eA,J.eC,J.dD,J.dE,J.dB,J.cS])
+q(A.K,[A.om,J.hB,A.f0,J.ed,A.b_,A.dT,A.a2,A.N,A.le,A.q,A.b7,A.eH,A.fc,A.ej,A.fe,A.aP,A.d9,A.aT,A.du,A.fq,A.aN,A.lO,A.hR,A.ek,A.fG,A.aL,A.kq,A.az,A.cV,A.cU,A.dC,A.ft,A.dS,A.il,A.jc,A.m6,A.jg,A.bz,A.iQ,A.je,A.mU,A.iy,A.bB,A.bk,A.iI,A.dc,A.aq,A.iz,A.ja,A.fM,A.d7,A.iW,A.fr,A.af,A.m1,A.h3,A.dt,A.mC,A.n_,A.jh,A.hh,A.mi,A.hS,A.f2,A.iN,A.C,A.bv,A.ap,A.jd,A.ax,A.ia,A.bQ,A.ho,A.hQ,A.hj,A.k6,A.lR,A.kd,A.hz,A.hT,A.aO,A.c0,A.hu,A.hU,A.fl,A.i3,A.cz,A.la,A.iD,A.cS,A.iO,A.hn,A.dx,A.ay,A.hb,A.ck,A.kl,A.cm,A.km,A.dV,A.hF,A.kn,A.hG,A.hw,A.ke,A.dP,A.aZ,A.jJ,A.fV,A.lj,A.he,A.dW,A.cP,A.iu,A.cQ,A.f8,A.bF,A.h7,A.fj,A.iC,A.ki,A.iB,A.mv,A.t,A.iS,A.mu,A.bS,A.ko,A.iJ,A.fk,A.fB,A.mx,A.cH,A.j0,A.iA,A.bT,A.mH,A.bC,A.m2,A.bM,A.ku,A.bG,A.a_,A.T,A.jQ,A.c_,A.i1,A.aw,A.bs,A.hg,A.jT,A.jU,A.c5,A.cr,A.kC,A.kE,A.iK,A.iU,A.l1,A.aR,A.dK,A.M,A.c6,A.c9,A.eV,A.ca,A.hW,A.jB,A.fA,A.m7,A.ch,A.bX,A.lG,A.bA,A.db,A.cg,A.lL,A.mW,A.c7,A.cl,A.bU,A.iX,A.aH,A.d2,A.d1,A.kM,A.mh,A.fm,A.lS,A.hV,A.d_,A.hZ,A.d3,A.eU,A.l_,A.fy,A.m4,A.bN,A.ak,A.dO,A.eY,A.hs,A.bl,A.hq,A.dv,A.k1,A.el,A.f1,A.ij,A.ii,A.lg,A.io,A.im,A.f3,A.lx,A.ly,A.h5,A.k5,A.h6,A.lf,A.lE,A.mK,A.lF,A.i8,A.a7,A.fL,A.dU,A.iT,A.n1,A.mR,A.hY,A.l6])
+q(J.hB,[J.hD,J.eA,J.eC,J.dD,J.dE,J.dB,J.cT])
 q(J.eC,[J.co,J.n,A.cp,A.eM])
 q(J.co,[J.i6,J.cC,J.bJ])
 r(J.hC,A.f0)
 r(J.kh,J.n)
 q(J.dB,[J.dA,J.eB])
-q(A.a2,[A.cn,A.cd,A.hH,A.it,A.ic,A.iM,A.eF,A.fZ,A.bi,A.f9,A.is,A.d7,A.hc])
+q(A.a2,[A.cn,A.cd,A.hH,A.it,A.ic,A.iM,A.eF,A.fZ,A.bi,A.f9,A.is,A.d8,A.hc])
 r(A.dR,A.N)
 r(A.br,A.dR)
-q(A.q,[A.E,A.cV,A.fb,A.fd,A.fp,A.ix,A.jb,A.cG,A.ib])
+q(A.q,[A.E,A.cW,A.fb,A.fd,A.fp,A.ix,A.jb,A.cG,A.ib])
 q(A.E,[A.as,A.ei,A.ah,A.eG,A.c2])
 q(A.as,[A.f4,A.c3,A.f_])
-r(A.eh,A.cV)
-q(A.aT,[A.dX,A.df,A.cF])
+r(A.eh,A.cW)
+q(A.aT,[A.dX,A.dg,A.cF])
 r(A.j,A.dX)
-q(A.df,[A.am,A.fC])
+q(A.dg,[A.am,A.fC])
 q(A.cF,[A.A,A.fD,A.fE])
-q(A.dt,[A.aY,A.bt])
+q(A.du,[A.aY,A.bt])
 q(A.aN,[A.hA,A.h9,A.ha,A.iq,A.nG,A.nI,A.lU,A.lT,A.n3,A.ms,A.nU,A.nV,A.mG,A.nx,A.lb,A.nZ,A.jK,A.lk,A.ll,A.ln,A.lo,A.lq,A.jz,A.nA,A.mA,A.lZ,A.lY,A.m_,A.m0,A.mI,A.mJ,A.nf,A.nl,A.nn,A.nm,A.kr,A.jL,A.kA,A.kz,A.m5,A.nw,A.jH,A.lJ,A.lH,A.lM,A.mP,A.kb,A.k8,A.k9,A.ka,A.k7,A.m8,A.m9,A.ma,A.mg,A.mb,A.mc,A.md,A.me,A.mf,A.nT,A.kN,A.kU,A.kV,A.kW,A.kX,A.kQ,A.kR,A.l0,A.nQ,A.nL,A.nM,A.nO,A.nP,A.nD,A.nz,A.li,A.o0,A.lD,A.lA,A.o4,A.o1,A.o2,A.o3,A.na])
 r(A.bI,A.hA)
 q(A.h9,[A.lc,A.lV,A.lW,A.mV,A.k4,A.mj,A.mo,A.mn,A.ml,A.mk,A.mr,A.mq,A.mp,A.mT,A.nj,A.mZ,A.mY,A.nX,A.nY,A.jx,A.jO,A.jP,A.jM,A.jy,A.ks,A.kv,A.k0,A.jZ,A.k_,A.jW,A.jX,A.jY,A.kF,A.l2,A.kB,A.kL,A.kK,A.jC,A.jI,A.jG,A.lK,A.lI,A.lN,A.mQ,A.mO,A.mM,A.mL,A.mN,A.mF,A.kT,A.kP,A.kY,A.kS,A.nN,A.nE,A.lh,A.lv,A.lw,A.lu,A.lt,A.ls,A.lr,A.lB,A.nW])
 r(A.eP,A.cd)
-q(A.iq,[A.ik,A.dq])
+q(A.iq,[A.ik,A.dr])
 r(A.bK,A.aL)
 q(A.bK,[A.eE,A.eD])
 q(A.ha,[A.nH,A.n4,A.np,A.mt,A.kt,A.mD,A.lm,A.jN,A.jA,A.kk,A.my,A.mz,A.m3,A.no,A.jV,A.kJ,A.kI,A.kG,A.jE,A.jF,A.jD,A.mE,A.kO,A.ns,A.nt,A.ny,A.lC,A.lz,A.nc,A.nd,A.nr,A.l9])
@@ -22135,16 +22139,16 @@ r(A.cq,A.fv)
 r(A.fx,A.fw)
 r(A.b8,A.fx)
 q(A.cq,[A.eI,A.eJ])
-q(A.b8,[A.hP,A.eK,A.eL,A.eN,A.eO,A.cW,A.cX])
+q(A.b8,[A.hP,A.eK,A.eL,A.eN,A.eO,A.cX,A.cY])
 r(A.dZ,A.iM)
 r(A.ff,A.iI)
 r(A.j1,A.fM)
-r(A.fF,A.d6)
-r(A.dd,A.fF)
-r(A.fs,A.dd)
+r(A.fF,A.d7)
+r(A.de,A.fF)
+r(A.fs,A.de)
 q(A.af,[A.jf,A.h0,A.hK,A.iw,A.fa,A.ht])
-r(A.d9,A.h3)
-q(A.ds,[A.hi,A.hI])
+r(A.da,A.h3)
+q(A.dt,[A.hi,A.hI])
 r(A.hJ,A.eF)
 r(A.mB,A.mC)
 r(A.hL,A.jf)
@@ -22158,9 +22162,9 @@ q(A.ht,[A.iY,A.j3,A.j6,A.j7])
 q(A.hu,[A.iZ,A.j5,A.j8])
 r(A.j4,A.j5)
 q(A.j8,[A.ie,A.ig])
-r(A.hm,A.cR)
+r(A.hm,A.cS)
 q(A.ay,[A.en,A.eo,A.ex,A.er,A.es,A.et,A.ew,A.eu,A.ev,A.ey,A.ep,A.ez,A.eq])
-q(A.ck,[A.cQ,A.em])
+q(A.ck,[A.cR,A.em])
 q(A.bF,[A.fY,A.fX,A.h8,A.hp,A.hN,A.i9])
 q(A.T,[A.bZ,A.bY,A.m,A.R,A.L,A.u,A.o,A.p,A.y,A.av])
 q(A.c5,[A.i_,A.eW])
@@ -22171,32 +22175,32 @@ q(A.bX,[A.ih,A.hl,A.hr,A.h1,A.ir,A.f7])
 q(A.c7,[A.iH,A.iP,A.j9,A.j2,A.j_])
 q(A.bN,[A.a1,A.O,A.ab,A.ba])
 r(A.ip,A.f3)
-q(A.a7,[A.d5,A.d4,A.bw,A.cw,A.cv,A.bb,A.b9,A.cu,A.bo,A.bO,A.cY,A.dL,A.dJ,A.aQ])
-s(A.dR,A.d8)
+q(A.a7,[A.d6,A.d5,A.bw,A.cw,A.cv,A.bb,A.b9,A.cu,A.bo,A.bO,A.cZ,A.dL,A.dJ,A.aQ])
+s(A.dR,A.d9)
 s(A.fu,A.N)
 s(A.fv,A.aP)
 s(A.fw,A.N)
 s(A.fx,A.aP)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{c:"int",h:"double",bD:"num",F:"String",U:"bool",ap:"Null",i:"List",K:"Object",bL:"Map",ag:"JSObject"},mangledNames:{},types:["~()","h(h)","c()","M(i<h>)","bs()","h(c)","~(cm,i<c>)","U(U)","~(F,T)","c(c,c)","c(bT)","i<aZ>()","ak?()","~(c,c)","~(c,F)","~(~())","U(h)","~(h,h,h,h)","c(F,c)","~(@)","T(T?)","aI(F)","~(h,h)","U(T?)","bH<ap>()","@()","~(K?,K?)","0^(0^,0^)<bD>","h()","c(h)","ap()","ap(@)","@(@)","~(c,c,c)","c(c,cH)","T(av)","~(c,c,c,c)","+(bC,bC)(c)","U(bT)","~(c,@)","ap(K,cB)","~(dw,c,c,c,c,c,c)","~(c)","~(h,U)","c?()","aI(c)","F(bv<F,T>)","aI()","@(F)","i<p>()","i<c5>()","cl?()","@(@,F)","cs(F)","aI(i<c>,i<c>,i<c>)","U(T)","ap(~())","U(da)","bA(c)","h?(cc)","F(cc)","i<K>?()","i<a7>(i<a7>)","U()","K()","+(c,c)?(F)","c(cz)","i<i<h>>?(c,c)","U(+(h,h))","ap(ag)","i<aZ>(y)","m()","~(i<aZ>,p,a_)","+(h,h)(i<+(+(h,h),h)>)","dW()","U(F)","h(h,h)","~(bl)","c(+(c,c),+(c,c))","~(h)","~(h,h,h,h,h,h)","~(h,h,h,h,h,h,h,h,h,h)","~(i<a7>)","ap(@,cB)","~(h,h,c,c)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.j&&a.b(c.a)&&b.b(c.b),"3;":(a,b,c)=>d=>d instanceof A.am&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"3;color,fontName,size":(a,b,c)=>d=>d instanceof A.fC&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;":a=>b=>b instanceof A.A&&A.p7(a,b.a),"5;":a=>b=>b instanceof A.fD&&A.p7(a,b.a),"7;":a=>b=>b instanceof A.fE&&A.p7(a,b.a)}}
-A.wy(v.typeUniverse,JSON.parse('{"bJ":"co","i6":"co","cC":"co","yL":"cp","hD":{"U":[],"X":[]},"eA":{"ap":[],"X":[]},"eC":{"ag":[]},"co":{"ag":[]},"n":{"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"hC":{"f0":[]},"kh":{"n":["1"],"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"ed":{"a3":["1"]},"dB":{"h":[],"bD":[]},"dA":{"h":[],"c":[],"bD":[],"X":[]},"eB":{"h":[],"bD":[],"X":[]},"cS":{"F":[],"ky":[],"aF":["@"],"X":[]},"b_":{"od":[]},"dT":{"od":[]},"cn":{"a2":[]},"br":{"N":["c"],"d8":["c"],"i":["c"],"E":["c"],"q":["c"],"N.E":"c","d8.E":"c"},"E":{"q":["1"]},"as":{"E":["1"],"q":["1"]},"f4":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"b7":{"a3":["1"]},"cV":{"q":["2"],"q.E":"2"},"eh":{"cV":["1","2"],"E":["2"],"q":["2"],"q.E":"2"},"eH":{"a3":["2"]},"c3":{"as":["2"],"E":["2"],"q":["2"],"q.E":"2","as.E":"2"},"fb":{"q":["1"],"q.E":"1"},"fc":{"a3":["1"]},"ei":{"E":["1"],"q":["1"],"q.E":"1"},"ej":{"a3":["1"]},"fd":{"q":["1"],"q.E":"1"},"fe":{"a3":["1"]},"dR":{"N":["1"],"d8":["1"],"i":["1"],"E":["1"],"q":["1"]},"f_":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"j":{"dX":[],"aT":[]},"am":{"df":[],"aT":[]},"fC":{"df":[],"aT":[]},"A":{"cF":[],"aT":[]},"fD":{"cF":[],"aT":[]},"fE":{"cF":[],"aT":[]},"dt":{"bL":["1","2"]},"aY":{"dt":["1","2"],"bL":["1","2"]},"fp":{"q":["1"],"q.E":"1"},"fq":{"a3":["1"]},"bt":{"dt":["1","2"],"bL":["1","2"]},"hA":{"aN":[],"c1":[]},"bI":{"aN":[],"c1":[]},"eP":{"cd":[],"a2":[]},"hH":{"a2":[]},"it":{"a2":[]},"hR":{"aa":[]},"fG":{"cB":[]},"aN":{"c1":[]},"h9":{"aN":[],"c1":[]},"ha":{"aN":[],"c1":[]},"iq":{"aN":[],"c1":[]},"ik":{"aN":[],"c1":[]},"dq":{"aN":[],"c1":[]},"ic":{"a2":[]},"bK":{"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"ah":{"E":["1"],"q":["1"],"q.E":"1"},"az":{"a3":["1"]},"eG":{"E":["1"],"q":["1"],"q.E":"1"},"cU":{"a3":["1"]},"c2":{"E":["bv<1,2>"],"q":["bv<1,2>"],"q.E":"bv<1,2>"},"cT":{"a3":["bv<1,2>"]},"eE":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"eD":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"dX":{"aT":[]},"df":{"aT":[]},"cF":{"aT":[]},"dC":{"vx":[],"ky":[]},"ft":{"cc":[],"dF":[]},"ix":{"q":["cc"],"q.E":"cc"},"dS":{"a3":["cc"]},"il":{"dF":[]},"jb":{"q":["dF"],"q.E":"dF"},"jc":{"a3":["dF"]},"cW":{"b8":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cX":{"b8":[],"aI":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cp":{"ag":[],"h2":[],"X":[]},"dH":{"cp":[],"ag":[],"h2":[],"X":[]},"eM":{"ag":[]},"jg":{"h2":[]},"hO":{"pA":[],"ag":[],"X":[]},"aG":{"b6":["1"],"ag":[],"aF":["1"]},"cq":{"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"]},"b8":{"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"]},"eI":{"cq":[],"dw":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"eJ":{"cq":[],"og":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"hP":{"b8":[],"kf":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eK":{"b8":[],"dy":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eL":{"b8":[],"ok":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eN":{"b8":[],"lQ":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eO":{"b8":[],"oB":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"iM":{"a2":[]},"dZ":{"cd":[],"a2":[]},"bB":{"a3":["1"]},"cG":{"q":["1"],"q.E":"1"},"bk":{"a2":[]},"ff":{"iI":["1"]},"aq":{"bH":["1"]},"fM":{"qA":[]},"j1":{"fM":[],"qA":[]},"dd":{"d6":["1"],"id":["1"],"E":["1"],"q":["1"]},"fs":{"dd":["1"],"d6":["1"],"id":["1"],"E":["1"],"q":["1"]},"fr":{"a3":["1"]},"N":{"i":["1"],"E":["1"],"q":["1"]},"aL":{"bL":["1","2"]},"d6":{"id":["1"],"E":["1"],"q":["1"]},"fF":{"d6":["1"],"id":["1"],"E":["1"],"q":["1"]},"jf":{"af":["F","i<c>"]},"h0":{"af":["F","i<c>"],"af.T":"i<c>"},"h3":{"bd":["i<c>"]},"d9":{"bd":["i<c>"]},"hi":{"ds":["F","i<c>"]},"eF":{"a2":[]},"hJ":{"a2":[]},"hI":{"ds":["K?","F"]},"hK":{"af":["K?","F"],"af.T":"F"},"hL":{"af":["F","i<c>"],"af.T":"i<c>"},"iv":{"ds":["F","i<c>"]},"iw":{"af":["F","i<c>"],"af.T":"i<c>"},"fa":{"af":["i<c>","F"],"af.T":"F"},"h":{"bD":[]},"c":{"bD":[]},"i":{"E":["1"],"q":["1"]},"cc":{"dF":[]},"F":{"ky":[]},"fZ":{"a2":[]},"cd":{"a2":[]},"bi":{"a2":[]},"cb":{"a2":[]},"hx":{"cb":[],"a2":[]},"f9":{"a2":[]},"is":{"a2":[]},"d7":{"a2":[]},"hc":{"a2":[]},"hS":{"a2":[]},"f2":{"a2":[]},"iN":{"aa":[]},"C":{"aa":[]},"jd":{"cB":[]},"ib":{"q":["c"],"q.E":"c"},"ia":{"a3":["c"]},"bQ":{"vE":[]},"hQ":{"aa":[]},"ok":{"i":["c"],"E":["c"],"q":["c"]},"aI":{"i":["c"],"E":["c"],"q":["c"]},"vW":{"i":["c"],"E":["c"],"q":["c"]},"kf":{"i":["c"],"E":["c"],"q":["c"]},"lQ":{"i":["c"],"E":["c"],"q":["c"]},"dy":{"i":["c"],"E":["c"],"q":["c"]},"oB":{"i":["c"],"E":["c"],"q":["c"]},"dw":{"i":["h"],"E":["h"],"q":["h"]},"og":{"i":["h"],"E":["h"],"q":["h"]},"hy":{"hz":[]},"eQ":{"hT":[]},"c0":{"bd":["aO"]},"ht":{"af":["i<c>","aO"]},"hu":{"bd":["i<c>"]},"iY":{"af":["i<c>","aO"],"af.T":"aO"},"iZ":{"bd":["i<c>"]},"j3":{"af":["i<c>","aO"],"af.T":"aO"},"j5":{"bd":["i<c>"]},"j4":{"bd":["i<c>"]},"j6":{"af":["i<c>","aO"],"af.T":"aO"},"j7":{"af":["i<c>","aO"],"af.T":"aO"},"j8":{"bd":["i<c>"]},"ie":{"bd":["i<c>"]},"ig":{"bd":["i<c>"]},"hm":{"cR":[]},"en":{"ay":[]},"eo":{"ay":[]},"ex":{"ay":[]},"er":{"ay":[]},"es":{"ay":[]},"et":{"ay":[]},"ew":{"ay":[]},"eu":{"ay":[]},"ev":{"ay":[]},"ey":{"ay":[]},"ep":{"ay":[]},"ez":{"ay":[]},"eq":{"ay":[]},"cQ":{"ck":[]},"em":{"ck":[]},"hw":{"aa":[]},"du":{"aa":[]},"iu":{"aa":[]},"cP":{"aa":[]},"f8":{"aa":[]},"fY":{"bF":[]},"fX":{"bF":[]},"h8":{"bF":[]},"fj":{"aa":[]},"hp":{"bF":[]},"hN":{"bF":[]},"i9":{"bF":[]},"m":{"T":[]},"p":{"T":[]},"y":{"T":[]},"av":{"T":[]},"bZ":{"T":[]},"bY":{"T":[]},"R":{"T":[]},"L":{"T":[]},"u":{"T":[]},"o":{"T":[]},"i_":{"c5":[]},"eW":{"c5":[]},"i5":{"cr":[]},"hX":{"cr":[]},"i0":{"cr":[]},"eT":{"cr":[]},"i4":{"cr":[]},"iE":{"dK":[]},"iF":{"dK":[]},"iV":{"dK":[]},"cE":{"c6":[]},"fz":{"c6":[]},"fi":{"c6":[]},"fn":{"c6":[]},"fo":{"c6":[]},"dY":{"c6":[]},"ih":{"bX":[]},"hl":{"bX":[]},"hr":{"bX":[]},"h1":{"bX":[]},"ir":{"bX":[]},"f7":{"bX":[]},"iH":{"c7":[]},"iP":{"c7":[]},"j9":{"c7":[]},"j2":{"c7":[]},"j_":{"c7":[]},"cZ":{"aa":[]},"fy":{"aa":[]},"a1":{"bN":[]},"O":{"bN":[]},"ab":{"bN":[]},"ba":{"bN":[]},"f3":{"kD":[]},"ip":{"kD":[]},"i8":{"kD":[]},"d5":{"a7":[]},"d4":{"a7":[]},"bw":{"a7":[]},"cw":{"a7":[]},"cv":{"a7":[]},"bb":{"a7":[]},"b9":{"a7":[]},"cu":{"a7":[]},"bo":{"a7":[]},"bO":{"a7":[]},"cY":{"a7":[]},"dL":{"a7":[]},"dJ":{"a7":[]},"aQ":{"a7":[]},"fL":{"aa":[]}}'))
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{c:"int",h:"double",bD:"num",F:"String",U:"bool",ap:"Null",i:"List",K:"Object",bL:"Map",ag:"JSObject"},mangledNames:{},types:["~()","h(h)","c()","M(i<h>)","bs()","h(c)","~(cm,i<c>)","U(U)","~(F,T)","c(c,c)","c(bT)","i<aZ>()","ak?()","~(c,c)","~(c,F)","~(~())","U(h)","~(h,h,h,h)","c(F,c)","~(@)","T(T?)","aI(F)","~(h,h)","U(T?)","bH<ap>()","@()","~(K?,K?)","0^(0^,0^)<bD>","h()","c(h)","ap()","ap(@)","@(@)","~(c,c,c)","c(c,cH)","T(av)","~(c,c,c,c)","+(bC,bC)(c)","U(bT)","~(c,@)","ap(K,cB)","~(dw,c,c,c,c,c,c)","~(c)","~(h,U)","c?()","aI(c)","F(bv<F,T>)","aI()","@(F)","i<p>()","i<c5>()","cl?()","@(@,F)","cs(F)","aI(i<c>,i<c>,i<c>)","U(T)","ap(~())","U(db)","bA(c)","h?(cc)","F(cc)","i<K>?()","i<a7>(i<a7>)","U()","K()","+(c,c)?(F)","c(cz)","i<i<h>>?(c,c)","U(+(h,h))","ap(ag)","i<aZ>(y)","m()","~(i<aZ>,p,a_)","+(h,h)(i<+(+(h,h),h)>)","dW()","U(F)","h(h,h)","~(bl)","c(+(c,c),+(c,c))","~(h)","~(h,h,h,h,h,h)","~(h,h,h,h,h,h,h,h,h,h)","~(i<a7>)","ap(@,cB)","~(h,h,c,c)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.j&&a.b(c.a)&&b.b(c.b),"3;":(a,b,c)=>d=>d instanceof A.am&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"3;color,fontName,size":(a,b,c)=>d=>d instanceof A.fC&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;":a=>b=>b instanceof A.A&&A.p7(a,b.a),"5;":a=>b=>b instanceof A.fD&&A.p7(a,b.a),"7;":a=>b=>b instanceof A.fE&&A.p7(a,b.a)}}
+A.wy(v.typeUniverse,JSON.parse('{"bJ":"co","i6":"co","cC":"co","yL":"cp","hD":{"U":[],"X":[]},"eA":{"ap":[],"X":[]},"eC":{"ag":[]},"co":{"ag":[]},"n":{"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"hC":{"f0":[]},"kh":{"n":["1"],"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"ed":{"a3":["1"]},"dB":{"h":[],"bD":[]},"dA":{"h":[],"c":[],"bD":[],"X":[]},"eB":{"h":[],"bD":[],"X":[]},"cT":{"F":[],"ky":[],"aF":["@"],"X":[]},"b_":{"od":[]},"dT":{"od":[]},"cn":{"a2":[]},"br":{"N":["c"],"d9":["c"],"i":["c"],"E":["c"],"q":["c"],"N.E":"c","d9.E":"c"},"E":{"q":["1"]},"as":{"E":["1"],"q":["1"]},"f4":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"b7":{"a3":["1"]},"cW":{"q":["2"],"q.E":"2"},"eh":{"cW":["1","2"],"E":["2"],"q":["2"],"q.E":"2"},"eH":{"a3":["2"]},"c3":{"as":["2"],"E":["2"],"q":["2"],"q.E":"2","as.E":"2"},"fb":{"q":["1"],"q.E":"1"},"fc":{"a3":["1"]},"ei":{"E":["1"],"q":["1"],"q.E":"1"},"ej":{"a3":["1"]},"fd":{"q":["1"],"q.E":"1"},"fe":{"a3":["1"]},"dR":{"N":["1"],"d9":["1"],"i":["1"],"E":["1"],"q":["1"]},"f_":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"j":{"dX":[],"aT":[]},"am":{"dg":[],"aT":[]},"fC":{"dg":[],"aT":[]},"A":{"cF":[],"aT":[]},"fD":{"cF":[],"aT":[]},"fE":{"cF":[],"aT":[]},"du":{"bL":["1","2"]},"aY":{"du":["1","2"],"bL":["1","2"]},"fp":{"q":["1"],"q.E":"1"},"fq":{"a3":["1"]},"bt":{"du":["1","2"],"bL":["1","2"]},"hA":{"aN":[],"c1":[]},"bI":{"aN":[],"c1":[]},"eP":{"cd":[],"a2":[]},"hH":{"a2":[]},"it":{"a2":[]},"hR":{"aa":[]},"fG":{"cB":[]},"aN":{"c1":[]},"h9":{"aN":[],"c1":[]},"ha":{"aN":[],"c1":[]},"iq":{"aN":[],"c1":[]},"ik":{"aN":[],"c1":[]},"dr":{"aN":[],"c1":[]},"ic":{"a2":[]},"bK":{"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"ah":{"E":["1"],"q":["1"],"q.E":"1"},"az":{"a3":["1"]},"eG":{"E":["1"],"q":["1"],"q.E":"1"},"cV":{"a3":["1"]},"c2":{"E":["bv<1,2>"],"q":["bv<1,2>"],"q.E":"bv<1,2>"},"cU":{"a3":["bv<1,2>"]},"eE":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"eD":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"dX":{"aT":[]},"dg":{"aT":[]},"cF":{"aT":[]},"dC":{"vx":[],"ky":[]},"ft":{"cc":[],"dF":[]},"ix":{"q":["cc"],"q.E":"cc"},"dS":{"a3":["cc"]},"il":{"dF":[]},"jb":{"q":["dF"],"q.E":"dF"},"jc":{"a3":["dF"]},"cX":{"b8":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cY":{"b8":[],"aI":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cp":{"ag":[],"h2":[],"X":[]},"dH":{"cp":[],"ag":[],"h2":[],"X":[]},"eM":{"ag":[]},"jg":{"h2":[]},"hO":{"pA":[],"ag":[],"X":[]},"aG":{"b6":["1"],"ag":[],"aF":["1"]},"cq":{"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"]},"b8":{"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"]},"eI":{"cq":[],"dw":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"eJ":{"cq":[],"og":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"hP":{"b8":[],"kf":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eK":{"b8":[],"dy":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eL":{"b8":[],"ok":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eN":{"b8":[],"lQ":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eO":{"b8":[],"oB":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"iM":{"a2":[]},"dZ":{"cd":[],"a2":[]},"bB":{"a3":["1"]},"cG":{"q":["1"],"q.E":"1"},"bk":{"a2":[]},"ff":{"iI":["1"]},"aq":{"bH":["1"]},"fM":{"qA":[]},"j1":{"fM":[],"qA":[]},"de":{"d7":["1"],"id":["1"],"E":["1"],"q":["1"]},"fs":{"de":["1"],"d7":["1"],"id":["1"],"E":["1"],"q":["1"]},"fr":{"a3":["1"]},"N":{"i":["1"],"E":["1"],"q":["1"]},"aL":{"bL":["1","2"]},"d7":{"id":["1"],"E":["1"],"q":["1"]},"fF":{"d7":["1"],"id":["1"],"E":["1"],"q":["1"]},"jf":{"af":["F","i<c>"]},"h0":{"af":["F","i<c>"],"af.T":"i<c>"},"h3":{"bd":["i<c>"]},"da":{"bd":["i<c>"]},"hi":{"dt":["F","i<c>"]},"eF":{"a2":[]},"hJ":{"a2":[]},"hI":{"dt":["K?","F"]},"hK":{"af":["K?","F"],"af.T":"F"},"hL":{"af":["F","i<c>"],"af.T":"i<c>"},"iv":{"dt":["F","i<c>"]},"iw":{"af":["F","i<c>"],"af.T":"i<c>"},"fa":{"af":["i<c>","F"],"af.T":"F"},"h":{"bD":[]},"c":{"bD":[]},"i":{"E":["1"],"q":["1"]},"cc":{"dF":[]},"F":{"ky":[]},"fZ":{"a2":[]},"cd":{"a2":[]},"bi":{"a2":[]},"cb":{"a2":[]},"hx":{"cb":[],"a2":[]},"f9":{"a2":[]},"is":{"a2":[]},"d8":{"a2":[]},"hc":{"a2":[]},"hS":{"a2":[]},"f2":{"a2":[]},"iN":{"aa":[]},"C":{"aa":[]},"jd":{"cB":[]},"ib":{"q":["c"],"q.E":"c"},"ia":{"a3":["c"]},"bQ":{"vE":[]},"hQ":{"aa":[]},"ok":{"i":["c"],"E":["c"],"q":["c"]},"aI":{"i":["c"],"E":["c"],"q":["c"]},"vW":{"i":["c"],"E":["c"],"q":["c"]},"kf":{"i":["c"],"E":["c"],"q":["c"]},"lQ":{"i":["c"],"E":["c"],"q":["c"]},"dy":{"i":["c"],"E":["c"],"q":["c"]},"oB":{"i":["c"],"E":["c"],"q":["c"]},"dw":{"i":["h"],"E":["h"],"q":["h"]},"og":{"i":["h"],"E":["h"],"q":["h"]},"hy":{"hz":[]},"eQ":{"hT":[]},"c0":{"bd":["aO"]},"ht":{"af":["i<c>","aO"]},"hu":{"bd":["i<c>"]},"iY":{"af":["i<c>","aO"],"af.T":"aO"},"iZ":{"bd":["i<c>"]},"j3":{"af":["i<c>","aO"],"af.T":"aO"},"j5":{"bd":["i<c>"]},"j4":{"bd":["i<c>"]},"j6":{"af":["i<c>","aO"],"af.T":"aO"},"j7":{"af":["i<c>","aO"],"af.T":"aO"},"j8":{"bd":["i<c>"]},"ie":{"bd":["i<c>"]},"ig":{"bd":["i<c>"]},"hm":{"cS":[]},"en":{"ay":[]},"eo":{"ay":[]},"ex":{"ay":[]},"er":{"ay":[]},"es":{"ay":[]},"et":{"ay":[]},"ew":{"ay":[]},"eu":{"ay":[]},"ev":{"ay":[]},"ey":{"ay":[]},"ep":{"ay":[]},"ez":{"ay":[]},"eq":{"ay":[]},"cR":{"ck":[]},"em":{"ck":[]},"hw":{"aa":[]},"cP":{"aa":[]},"iu":{"aa":[]},"cQ":{"aa":[]},"f8":{"aa":[]},"fY":{"bF":[]},"fX":{"bF":[]},"h8":{"bF":[]},"fj":{"aa":[]},"hp":{"bF":[]},"hN":{"bF":[]},"i9":{"bF":[]},"m":{"T":[]},"p":{"T":[]},"y":{"T":[]},"av":{"T":[]},"bZ":{"T":[]},"bY":{"T":[]},"R":{"T":[]},"L":{"T":[]},"u":{"T":[]},"o":{"T":[]},"i_":{"c5":[]},"eW":{"c5":[]},"i5":{"cr":[]},"hX":{"cr":[]},"i0":{"cr":[]},"eT":{"cr":[]},"i4":{"cr":[]},"iE":{"dK":[]},"iF":{"dK":[]},"iV":{"dK":[]},"cE":{"c6":[]},"fz":{"c6":[]},"fi":{"c6":[]},"fn":{"c6":[]},"fo":{"c6":[]},"dY":{"c6":[]},"ih":{"bX":[]},"hl":{"bX":[]},"hr":{"bX":[]},"h1":{"bX":[]},"ir":{"bX":[]},"f7":{"bX":[]},"iH":{"c7":[]},"iP":{"c7":[]},"j9":{"c7":[]},"j2":{"c7":[]},"j_":{"c7":[]},"d_":{"aa":[]},"fy":{"aa":[]},"a1":{"bN":[]},"O":{"bN":[]},"ab":{"bN":[]},"ba":{"bN":[]},"f3":{"kD":[]},"ip":{"kD":[]},"i8":{"kD":[]},"d6":{"a7":[]},"d5":{"a7":[]},"bw":{"a7":[]},"cw":{"a7":[]},"cv":{"a7":[]},"bb":{"a7":[]},"b9":{"a7":[]},"cu":{"a7":[]},"bo":{"a7":[]},"bO":{"a7":[]},"cZ":{"a7":[]},"dL":{"a7":[]},"dJ":{"a7":[]},"aQ":{"a7":[]},"fL":{"aa":[]}}'))
 A.wx(v.typeUniverse,JSON.parse('{"E":1,"dR":1,"aG":1,"fF":1}'))
 var u={c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type",a:"The number of bytes to view must be a multiple of 4"}
 var t=(function rtii(){var s=A.ae
-return{v:s("bk"),eL:s("h6"),gS:s("br"),cq:s("aY<F,c>"),Y:s("o"),C:s("p"),G:s("u"),l:s("T"),kI:s("T(T?)"),md:s("av"),h:s("y"),V:s("L"),w:s("bs"),mG:s("bl"),gt:s("E<@>"),W:s("a2"),I:s("aa"),x:s("c1"),A:s("bt<c,F>"),B:s("bt<c,c>"),eD:s("dx"),lD:s("ay"),id:s("bI<h>"),n6:s("bI<c>"),bW:s("dy"),kk:s("q<h>"),fg:s("q<@>"),fm:s("q<c>"),an:s("n<hb>"),no:s("n<aZ>"),cN:s("n<p>"),q:s("n<T>"),mD:s("n<y>"),O:s("n<aw>"),gM:s("n<dv>"),mr:s("n<dw>"),aQ:s("n<dy>"),ns:s("n<cm>"),eH:s("n<i<+(h,h)>>"),e7:s("n<i<bA>>"),iA:s("n<i<h>>"),f:s("n<K>"),co:s("n<c5>"),b:s("n<M>"),lv:s("n<c7>"),bw:s("n<c9>"),bY:s("n<ca>"),ai:s("n<d2>"),g:s("n<bN>"),eF:s("n<aR>"),lO:s("n<a7>"),dL:s("n<eY>"),fV:s("n<+(+(h,h),h)>"),pe:s("n<+(bT,c)>"),fU:s("n<+(h,h)>"),u:s("n<+(c,c)>"),gN:s("n<ii>"),dP:s("n<ij>"),mW:s("n<f1>"),s:s("n<F>"),oq:s("n<im>"),fv:s("n<io>"),kN:s("n<lQ>"),a:s("n<aI>"),bl:s("n<iA>"),j:s("n<bS>"),br:s("n<da>"),hp:s("n<bT>"),nH:s("n<iJ>"),n0:s("n<iO>"),eK:s("n<fm>"),jf:s("n<iS>"),E:s("n<t>"),kv:s("n<dV>"),mZ:s("n<bA>"),mL:s("n<fA>"),aT:s("n<j0>"),eJ:s("n<cH>"),c:s("n<U>"),n:s("n<h>"),dG:s("n<@>"),t:s("n<c>"),le:s("n<p?>"),gU:s("n<hF?>"),iP:s("n<i<h>?>"),nn:s("n<h?>"),hM:s("n<c?>"),g2:s("n<bD>"),iy:s("aF<@>"),T:s("eA"),m:s("ag"),dY:s("bJ"),dX:s("b6<@>"),fh:s("cm"),D:s("i<aZ>"),oc:s("i<aZ>(y)"),lr:s("i<p>"),Q:s("i<T>"),iu:s("i<dw>"),kn:s("i<dy>"),n5:s("i<i<dy>>"),aZ:s("i<i<+(h,h)>>"),ez:s("i<K>"),ot:s("i<M>"),aY:s("i<c9>"),oQ:s("i<bN>"),J:s("i<a7>"),cn:s("i<+(+(h,h),h)>"),aE:s("i<aI>"),cP:s("i<bS>"),eP:s("i<bA>"),iZ:s("i<cH>"),H:s("i<h>"),gs:s("i<@>"),L:s("i<c>"),hQ:s("i<ck?>"),oT:s("i<bD>"),dj:s("bv<F,T>"),dV:s("bL<F,c>"),av:s("bL<@,@>"),eb:s("dH"),dQ:s("cq"),aj:s("b8"),mR:s("cW"),hD:s("cX"),P:s("ap"),K:s("K"),l5:s("at"),dF:s("hU<+(c,U),cz>"),hv:s("M"),jL:s("dM"),eB:s("c9"),ge:s("a_"),ob:s("ak"),bM:s("bN"),oh:s("aR"),e:s("a7"),b0:s("cb"),ba:s("dP"),lZ:s("yO"),aK:s("+()"),gB:s("+(bC,bC)"),aL:s("+(h,h)"),lG:s("+(c,U)"),R:s("+(c,c)"),i0:s("+(ak,c,c)"),F:s("cc"),on:s("f_<h>"),bB:s("id<p>"),Z:s("bd<aO>"),k:s("cB"),N:s("F"),aJ:s("X"),do:s("cd"),p:s("aI"),cx:s("cC"),iQ:s("fd<h>"),mj:s("bS"),aG:s("da"),U:s("bT"),jE:s("fk"),is:s("fl<cz>"),_:s("aq<@>"),dI:s("fs<y>"),c4:s("dW"),kb:s("fB"),lp:s("cG<av>"),l_:s("cG<+(h,h)>"),bp:s("cH"),y:s("U"),iW:s("U(K)"),i:s("h"),z:s("@"),mY:s("@()"),mq:s("@(K)"),ng:s("@(K,cB)"),S:s("c"),ir:s("T?"),gK:s("bH<ap>?"),er:s("ck?"),fW:s("cl?"),jH:s("kf?"),mU:s("ag?"),gv:s("bJ?"),nE:s("i<h>?"),iM:s("i<ck?>?"),iD:s("K?"),ex:s("aH?"),eM:s("d0?"),bd:s("d1?"),ak:s("ak?"),gE:s("cz?"),as:s("+(aI,aI)?"),jv:s("F?"),X:s("aI?"),bA:s("bS?"),lX:s("iD?"),d:s("db<@,@>?"),nF:s("iW?"),o9:s("U?"),jX:s("h?"),aV:s("c?"),jh:s("bD?"),r:s("bD"),o:s("~"),M:s("~()"),mX:s("~(cm,i<c>)"),gf:s("~(i<aZ>,p,a_)")}})();(function constants(){var s=hunkHelpers.makeConstList
+return{v:s("bk"),eL:s("h6"),gS:s("br"),cq:s("aY<F,c>"),Y:s("o"),C:s("p"),G:s("u"),l:s("T"),kI:s("T(T?)"),md:s("av"),h:s("y"),V:s("L"),w:s("bs"),mG:s("bl"),gt:s("E<@>"),W:s("a2"),I:s("aa"),x:s("c1"),A:s("bt<c,F>"),B:s("bt<c,c>"),eD:s("dx"),lD:s("ay"),id:s("bI<h>"),n6:s("bI<c>"),bW:s("dy"),kk:s("q<h>"),fg:s("q<@>"),fm:s("q<c>"),an:s("n<hb>"),no:s("n<aZ>"),cN:s("n<p>"),q:s("n<T>"),mD:s("n<y>"),O:s("n<aw>"),gM:s("n<dv>"),mr:s("n<dw>"),aQ:s("n<dy>"),ns:s("n<cm>"),eH:s("n<i<+(h,h)>>"),e7:s("n<i<bA>>"),iA:s("n<i<h>>"),f:s("n<K>"),co:s("n<c5>"),b:s("n<M>"),lv:s("n<c7>"),bw:s("n<c9>"),bY:s("n<ca>"),ai:s("n<d3>"),g:s("n<bN>"),eF:s("n<aR>"),lO:s("n<a7>"),dL:s("n<eY>"),fV:s("n<+(+(h,h),h)>"),pe:s("n<+(bT,c)>"),fU:s("n<+(h,h)>"),u:s("n<+(c,c)>"),gN:s("n<ii>"),dP:s("n<ij>"),mW:s("n<f1>"),s:s("n<F>"),oq:s("n<im>"),fv:s("n<io>"),kN:s("n<lQ>"),a:s("n<aI>"),bl:s("n<iA>"),j:s("n<bS>"),br:s("n<db>"),hp:s("n<bT>"),nH:s("n<iJ>"),n0:s("n<iO>"),eK:s("n<fm>"),jf:s("n<iS>"),E:s("n<t>"),kv:s("n<dV>"),mZ:s("n<bA>"),mL:s("n<fA>"),aT:s("n<j0>"),eJ:s("n<cH>"),c:s("n<U>"),n:s("n<h>"),dG:s("n<@>"),t:s("n<c>"),le:s("n<p?>"),gU:s("n<hF?>"),iP:s("n<i<h>?>"),nn:s("n<h?>"),hM:s("n<c?>"),g2:s("n<bD>"),iy:s("aF<@>"),T:s("eA"),m:s("ag"),dY:s("bJ"),dX:s("b6<@>"),fh:s("cm"),D:s("i<aZ>"),oc:s("i<aZ>(y)"),lr:s("i<p>"),Q:s("i<T>"),iu:s("i<dw>"),kn:s("i<dy>"),n5:s("i<i<dy>>"),aZ:s("i<i<+(h,h)>>"),ez:s("i<K>"),ot:s("i<M>"),aY:s("i<c9>"),oQ:s("i<bN>"),J:s("i<a7>"),cn:s("i<+(+(h,h),h)>"),aE:s("i<aI>"),cP:s("i<bS>"),eP:s("i<bA>"),iZ:s("i<cH>"),H:s("i<h>"),gs:s("i<@>"),L:s("i<c>"),hQ:s("i<ck?>"),oT:s("i<bD>"),dj:s("bv<F,T>"),dV:s("bL<F,c>"),av:s("bL<@,@>"),eb:s("dH"),dQ:s("cq"),aj:s("b8"),mR:s("cX"),hD:s("cY"),P:s("ap"),K:s("K"),l5:s("at"),dF:s("hU<+(c,U),cz>"),hv:s("M"),jL:s("dM"),eB:s("c9"),ge:s("a_"),ob:s("ak"),bM:s("bN"),oh:s("aR"),e:s("a7"),b0:s("cb"),ba:s("dP"),lZ:s("yO"),aK:s("+()"),gB:s("+(bC,bC)"),aL:s("+(h,h)"),lG:s("+(c,U)"),R:s("+(c,c)"),i0:s("+(ak,c,c)"),F:s("cc"),on:s("f_<h>"),bB:s("id<p>"),Z:s("bd<aO>"),k:s("cB"),N:s("F"),aJ:s("X"),do:s("cd"),p:s("aI"),cx:s("cC"),iQ:s("fd<h>"),mj:s("bS"),aG:s("db"),U:s("bT"),jE:s("fk"),is:s("fl<cz>"),_:s("aq<@>"),dI:s("fs<y>"),c4:s("dW"),kb:s("fB"),lp:s("cG<av>"),l_:s("cG<+(h,h)>"),bp:s("cH"),y:s("U"),iW:s("U(K)"),i:s("h"),z:s("@"),mY:s("@()"),mq:s("@(K)"),ng:s("@(K,cB)"),S:s("c"),ir:s("T?"),gK:s("bH<ap>?"),er:s("ck?"),fW:s("cl?"),jH:s("kf?"),mU:s("ag?"),gv:s("bJ?"),nE:s("i<h>?"),iM:s("i<ck?>?"),iD:s("K?"),ex:s("aH?"),eM:s("d1?"),bd:s("d2?"),ak:s("ak?"),gE:s("cz?"),as:s("+(aI,aI)?"),jv:s("F?"),X:s("aI?"),bA:s("bS?"),lX:s("iD?"),d:s("dc<@,@>?"),nF:s("iW?"),o9:s("U?"),jX:s("h?"),aV:s("c?"),jh:s("bD?"),r:s("bD"),o:s("~"),M:s("~()"),mX:s("~(cm,i<c>)"),gf:s("~(i<aZ>,p,a_)")}})();(function constants(){var s=hunkHelpers.makeConstList
 B.ds=J.hB.prototype
 B.a=J.n.prototype
 B.b=J.dA.prototype
 B.c=J.dB.prototype
-B.f=J.cS.prototype
+B.f=J.cT.prototype
 B.dt=J.bJ.prototype
 B.du=J.eC.prototype
-B.t=A.eI.prototype
+B.u=A.eI.prototype
 B.ah=A.eJ.prototype
 B.D=A.eK.prototype
 B.eo=A.eL.prototype
 B.Y=A.eN.prototype
 B.k=A.eO.prototype
-B.d=A.cX.prototype
+B.d=A.cY.prototype
 B.bY=J.i6.prototype
 B.as=J.cC.prototype
 B.ck=new A.h4(0,"littleEndian")
@@ -22207,7 +22211,7 @@ B.aw=new A.bI(A.rH(),t.id)
 B.S=new A.bI(A.rH(),t.n6)
 B.M=new A.h0()
 B.cl=new A.h1()
-B.u=new A.bZ()
+B.n=new A.bZ()
 B.a7=new A.hh()
 B.cm=new A.ej(A.ae("ej<0&>"))
 B.N=new A.hj()
@@ -22343,11 +22347,11 @@ B.cv=new A.hI()
 B.cw=new A.hL()
 B.cx=new A.hS()
 B.aF=new A.dJ()
-B.A=new A.cZ()
-B.o=new A.ba()
+B.A=new A.d_()
+B.p=new A.ba()
 B.aG=new A.dL()
-B.v=new A.d4()
-B.p=new A.d5()
+B.v=new A.d5()
+B.q=new A.d6()
 B.h=new A.le()
 B.cy=new A.ih()
 B.cz=new A.ir()
@@ -22365,7 +22369,7 @@ B.V=new A.jd()
 B.aJ=new A.fL()
 B.cD=new A.n2()
 B.ab=new A.bY(!1)
-B.q=new A.bY(!0)
+B.r=new A.bY(!0)
 B.cE=new A.u("Font")
 B.cF=new A.u("Helvetica")
 B.cG=new A.u("Type1")
@@ -22379,7 +22383,7 @@ B.aL=new A.b5(5,"arrayOpen")
 B.aM=new A.b5(6,"arrayClose")
 B.cI=new A.b5(7,"dictOpen")
 B.ac=new A.b5(8,"dictClose")
-B.n=new A.b5(9,"keyword")
+B.o=new A.b5(9,"keyword")
 B.P=new A.eg(1,"inUse")
 B.aN=new A.eg(2,"compressed")
 B.cJ=new A.eg(0,"free")
@@ -22441,7 +22445,7 @@ B.aX=new A.aE(13,"ifd")
 B.j=new A.aE(2,"ascii")
 B.i=new A.aE(3,"short")
 B.m=new A.aE(4,"long")
-B.r=new A.aE(5,"rational")
+B.t=new A.aE(5,"rational")
 B.aY=new A.aE(6,"sByte")
 B.I=new A.aE(7,"undefined")
 B.aZ=new A.aE(8,"sShort")
@@ -22557,7 +22561,7 @@ B.l=new A.dM(0,"nonzero")
 B.E=new A.dM(1,"evenOdd")
 B.J=s([B.l,B.E],A.ae("n<dM>"))
 B.b4=s([0.8951,0.2664,-0.1614,-0.7502,1.7135,0.0367,0.0389,-0.0685,1.0296],t.n)
-B.dZ=s([B.e,B.aT,B.j,B.i,B.m,B.r,B.aY,B.I,B.aZ,B.b_,B.aU,B.aV,B.aW,B.aX],A.ae("n<aE>"))
+B.dZ=s([B.e,B.aT,B.j,B.i,B.m,B.t,B.aY,B.I,B.aZ,B.b_,B.aU,B.aV,B.aW,B.aX],A.ae("n<aE>"))
 B.b5=s([0.9869929,-0.1470543,0.1599627,0.4323053,0.5183603,0.0492912,-0.0085287,0.0400428,0.9684867],t.n)
 B.e_=s(["Root","Info","Encrypt","ID"],t.s)
 B.hL=new A.t(6,32,75)
@@ -22822,7 +22826,7 @@ $.oS=!1
 $.ad=B.z
 $.oN=null
 $.of=A.x(t.S,t.N)
-$.d3=!1
+$.d4=!1
 $.ov=null
 $.i2=null
 $.l5=null
@@ -22860,7 +22864,7 @@ s($,"zb","tp",()=>new A.mZ().$0())
 s($,"zc","tq",()=>new A.mY().$0())
 s($,"z7","tm",()=>A.uT(A.b([-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-1,-2,-2,-2,-2,-2,62,-2,62,-2,63,52,53,54,55,56,57,58,59,60,61,-2,-2,-2,-1,-2,-2,-2,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-2,-2,-2,-2,63,-2,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,-2,-2,-2,-2,-2],t.t)))
 s($,"z6","tl",()=>A.kw(0))
-s($,"zl","dm",()=>A.fT(B.h1))
+s($,"zl","dn",()=>A.fT(B.h1))
 s($,"yT","aB",()=>{A.vt()
 return $.ld})
 s($,"yF","t2",()=>A.tW(B.Y.gt(A.uW(A.b([1],t.t)))).getInt8(0)===1?B.T:B.N)
@@ -22868,7 +22872,7 @@ s($,"yJ","t6",()=>A.hv(B.ee))
 s($,"yI","t5",()=>A.hv(B.dK))
 s($,"zw","tB",()=>A.uY(A.b([1116352408,3609767458,1899447441,602891725,3049323471,3964484399,3921009573,2173295548,961987163,4081628472,1508970993,3053834265,2453635748,2937671579,2870763221,3664609560,3624381080,2734883394,310598401,1164996542,607225278,1323610764,1426881987,3590304994,1925078388,4068182383,2162078206,991336113,2614888103,633803317,3248222580,3479774868,3835390401,2666613458,4022224774,944711139,264347078,2341262773,604807628,2007800933,770255983,1495990901,1249150122,1856431235,1555081692,3175218132,1996064986,2198950837,2554220882,3999719339,2821834349,766784016,2952996808,2566594879,3210313671,3203337956,3336571891,1034457026,3584528711,2466948901,113926993,3758326383,338241895,168717936,666307205,1188179964,773529912,1546045734,1294757372,1522805485,1396182291,2643833823,1695183700,2343527390,1986661051,1014477480,2177026350,1206759142,2456956037,344077627,2730485921,1290863460,2820302411,3158454273,3259730800,3505952657,3345764771,106217008,3516065817,3606008344,3600352804,1432725776,4094571909,1467031594,275423344,851169720,430227734,3100823752,506948616,1363258195,659060556,3750685593,883997877,3785050280,958139571,3318307427,1322822218,3812723403,1537002063,2003034995,1747873779,3602036899,1955562222,1575990012,2024104815,1125592928,2227730452,2716904306,2361852424,442776044,2428436474,593698344,2756734187,3733110249,3204031479,2999351573,3329325298,3815920427,3391569614,3928383900,3515267271,566280711,3940187606,3454069534,4118630271,4000239992,116418474,1914138554,174292421,2731055270,289380356,3203993006,460393269,320620315,685471733,587496836,852142971,1086792851,1017036298,365543100,1126000580,2618297676,1288033470,3409855158,1501505948,4234509866,1607167915,987167468,1816402316,1246189591],t.t)))
 s($,"zA","tE",()=>{var r=null,q="ISOSpeed"
-return A.hM([11,A.f("ProcessingSoftware",B.j,r),254,A.f("SubfileType",B.m,1),255,A.f("OldSubfileType",B.m,1),256,A.f("ImageWidth",B.m,1),257,A.f("ImageLength",B.m,1),258,A.f("BitsPerSample",B.i,1),259,A.f("Compression",B.i,1),262,A.f("PhotometricInterpretation",B.i,1),263,A.f("Thresholding",B.i,1),264,A.f("CellWidth",B.i,1),265,A.f("CellLength",B.i,1),266,A.f("FillOrder",B.i,1),269,A.f("DocumentName",B.j,r),270,A.f("ImageDescription",B.j,r),271,A.f("Make",B.j,r),272,A.f("Model",B.j,r),273,A.f("StripOffsets",B.m,r),274,A.f("Orientation",B.i,1),277,A.f("SamplesPerPixel",B.i,1),278,A.f("RowsPerStrip",B.m,1),279,A.f("StripByteCounts",B.m,1),280,A.f("MinSampleValue",B.i,1),281,A.f("MaxSampleValue",B.i,1),282,A.f("XResolution",B.r,1),283,A.f("YResolution",B.r,1),284,A.f("PlanarConfiguration",B.i,1),285,A.f("PageName",B.j,r),286,A.f("XPosition",B.r,1),287,A.f("YPosition",B.r,1),290,A.f("GrayResponseUnit",B.i,1),291,A.f("GrayResponseCurve",B.e,r),292,A.f("T4Options",B.e,r),293,A.f("T6Options",B.e,r),296,A.f("ResolutionUnit",B.i,1),297,A.f("PageNumber",B.i,2),300,A.f("ColorResponseUnit",B.e,r),301,A.f("TransferFunction",B.i,768),305,A.f("Software",B.j,r),306,A.f("DateTime",B.j,r),315,A.f("Artist",B.j,r),316,A.f("HostComputer",B.j,r),317,A.f("Predictor",B.i,1),318,A.f("WhitePoint",B.r,2),319,A.f("PrimaryChromaticities",B.r,6),320,A.f("ColorMap",B.i,r),321,A.f("HalftoneHints",B.i,2),322,A.f("TileWidth",B.m,1),323,A.f("TileLength",B.m,1),324,A.f("TileOffsets",B.m,r),325,A.f("TileByteCounts",B.e,r),326,A.f("BadFaxLines",B.e,r),327,A.f("CleanFaxData",B.e,r),328,A.f("ConsecutiveBadFaxLines",B.e,r),332,A.f("InkSet",B.e,r),333,A.f("InkNames",B.e,r),334,A.f("NumberofInks",B.e,r),336,A.f("DotRange",B.e,r),337,A.f("TargetPrinter",B.j,r),338,A.f("ExtraSamples",B.e,r),339,A.f("SampleFormat",B.i,1),340,A.f("SMinSampleValue",B.e,r),341,A.f("SMaxSampleValue",B.e,r),342,A.f("TransferRange",B.e,r),343,A.f("ClipPath",B.e,r),512,A.f("JPEGProc",B.e,r),513,A.f("JPEGInterchangeFormat",B.e,r),514,A.f("JPEGInterchangeFormatLength",B.e,r),529,A.f("YCbCrCoefficients",B.r,3),530,A.f("YCbCrSubSampling",B.i,1),531,A.f("YCbCrPositioning",B.i,1),532,A.f("ReferenceBlackWhite",B.r,6),700,A.f("ApplicationNotes",B.i,1),18246,A.f("Rating",B.i,1),33421,A.f("CFARepeatPatternDim",B.e,r),33422,A.f("CFAPattern",B.e,r),33423,A.f("BatteryLevel",B.e,r),33432,A.f("Copyright",B.j,r),33434,A.f("ExposureTime",B.r,1),33437,A.f("FNumber",B.r,r),33723,A.f("IPTC-NAA",B.m,1),34665,A.f("ExifOffset",B.e,r),34675,A.f("InterColorProfile",B.e,r),34850,A.f("ExposureProgram",B.i,1),34852,A.f("SpectralSensitivity",B.j,r),34853,A.f("GPSOffset",B.e,r),34855,A.f(q,B.m,1),34856,A.f("OECF",B.e,r),34864,A.f("SensitivityType",B.i,1),34866,A.f("RecommendedExposureIndex",B.m,1),34867,A.f(q,B.m,1),36864,A.f("ExifVersion",B.I,r),36867,A.f("DateTimeOriginal",B.j,r),36868,A.f("DateTimeDigitized",B.j,r),36880,A.f("OffsetTime",B.j,r),36881,A.f("OffsetTimeOriginal",B.j,r),36882,A.f("OffsetTimeDigitized",B.j,r),37121,A.f("ComponentsConfiguration",B.I,r),37122,A.f("CompressedBitsPerPixel",B.e,r),37377,A.f("ShutterSpeedValue",B.e,r),37378,A.f("ApertureValue",B.e,r),37379,A.f("BrightnessValue",B.e,r),37380,A.f("ExposureBiasValue",B.e,r),37381,A.f("MaxApertureValue",B.e,r),37382,A.f("SubjectDistance",B.e,r),37383,A.f("MeteringMode",B.e,r),37384,A.f("LightSource",B.e,r),37385,A.f("Flash",B.e,r),37386,A.f("FocalLength",B.e,r),37396,A.f("SubjectArea",B.e,r),37500,A.f("MakerNote",B.I,r),37510,A.f("UserComment",B.I,r),37520,A.f("SubSecTime",B.e,r),37521,A.f("SubSecTimeOriginal",B.e,r),37522,A.f("SubSecTimeDigitized",B.e,r),40091,A.f("XPTitle",B.e,r),40092,A.f("XPComment",B.e,r),40093,A.f("XPAuthor",B.e,r),40094,A.f("XPKeywords",B.e,r),40095,A.f("XPSubject",B.e,r),40960,A.f("FlashPixVersion",B.e,r),40961,A.f("ColorSpace",B.i,1),40962,A.f("ExifImageWidth",B.i,1),40963,A.f("ExifImageLength",B.i,1),40964,A.f("RelatedSoundFile",B.e,r),40965,A.f("InteroperabilityOffset",B.e,r),41483,A.f("FlashEnergy",B.e,r),41484,A.f("SpatialFrequencyResponse",B.e,r),41486,A.f("FocalPlaneXResolution",B.e,r),41487,A.f("FocalPlaneYResolution",B.e,r),41488,A.f("FocalPlaneResolutionUnit",B.e,r),41492,A.f("SubjectLocation",B.e,r),41493,A.f("ExposureIndex",B.e,r),41495,A.f("SensingMethod",B.e,r),41728,A.f("FileSource",B.e,r),41729,A.f("SceneType",B.e,r),41730,A.f("CVAPattern",B.e,r),41985,A.f("CustomRendered",B.e,r),41986,A.f("ExposureMode",B.e,r),41987,A.f("WhiteBalance",B.e,r),41988,A.f("DigitalZoomRatio",B.e,r),41989,A.f("FocalLengthIn35mmFilm",B.e,r),41990,A.f("SceneCaptureType",B.e,r),41991,A.f("GainControl",B.e,r),41992,A.f("Contrast",B.e,r),41993,A.f("Saturation",B.e,r),41994,A.f("Sharpness",B.e,r),41995,A.f("DeviceSettingDescription",B.e,r),41996,A.f("SubjectDistanceRange",B.e,r),42016,A.f("ImageUniqueID",B.e,r),42032,A.f("CameraOwnerName",B.j,r),42033,A.f("BodySerialNumber",B.j,r),42034,A.f("LensSpecification",B.e,r),42035,A.f("LensMake",B.j,r),42036,A.f("LensModel",B.j,r),42037,A.f("LensSerialNumber",B.j,r),42240,A.f("Gamma",B.r,1),50341,A.f("PrintIM",B.e,r),59932,A.f("Padding",B.e,r),59933,A.f("OffsetSchema",B.e,r),65e3,A.f("OwnerName",B.j,r),65001,A.f("SerialNumber",B.j,r)],t.S,A.ae("hn"))})
+return A.hM([11,A.f("ProcessingSoftware",B.j,r),254,A.f("SubfileType",B.m,1),255,A.f("OldSubfileType",B.m,1),256,A.f("ImageWidth",B.m,1),257,A.f("ImageLength",B.m,1),258,A.f("BitsPerSample",B.i,1),259,A.f("Compression",B.i,1),262,A.f("PhotometricInterpretation",B.i,1),263,A.f("Thresholding",B.i,1),264,A.f("CellWidth",B.i,1),265,A.f("CellLength",B.i,1),266,A.f("FillOrder",B.i,1),269,A.f("DocumentName",B.j,r),270,A.f("ImageDescription",B.j,r),271,A.f("Make",B.j,r),272,A.f("Model",B.j,r),273,A.f("StripOffsets",B.m,r),274,A.f("Orientation",B.i,1),277,A.f("SamplesPerPixel",B.i,1),278,A.f("RowsPerStrip",B.m,1),279,A.f("StripByteCounts",B.m,1),280,A.f("MinSampleValue",B.i,1),281,A.f("MaxSampleValue",B.i,1),282,A.f("XResolution",B.t,1),283,A.f("YResolution",B.t,1),284,A.f("PlanarConfiguration",B.i,1),285,A.f("PageName",B.j,r),286,A.f("XPosition",B.t,1),287,A.f("YPosition",B.t,1),290,A.f("GrayResponseUnit",B.i,1),291,A.f("GrayResponseCurve",B.e,r),292,A.f("T4Options",B.e,r),293,A.f("T6Options",B.e,r),296,A.f("ResolutionUnit",B.i,1),297,A.f("PageNumber",B.i,2),300,A.f("ColorResponseUnit",B.e,r),301,A.f("TransferFunction",B.i,768),305,A.f("Software",B.j,r),306,A.f("DateTime",B.j,r),315,A.f("Artist",B.j,r),316,A.f("HostComputer",B.j,r),317,A.f("Predictor",B.i,1),318,A.f("WhitePoint",B.t,2),319,A.f("PrimaryChromaticities",B.t,6),320,A.f("ColorMap",B.i,r),321,A.f("HalftoneHints",B.i,2),322,A.f("TileWidth",B.m,1),323,A.f("TileLength",B.m,1),324,A.f("TileOffsets",B.m,r),325,A.f("TileByteCounts",B.e,r),326,A.f("BadFaxLines",B.e,r),327,A.f("CleanFaxData",B.e,r),328,A.f("ConsecutiveBadFaxLines",B.e,r),332,A.f("InkSet",B.e,r),333,A.f("InkNames",B.e,r),334,A.f("NumberofInks",B.e,r),336,A.f("DotRange",B.e,r),337,A.f("TargetPrinter",B.j,r),338,A.f("ExtraSamples",B.e,r),339,A.f("SampleFormat",B.i,1),340,A.f("SMinSampleValue",B.e,r),341,A.f("SMaxSampleValue",B.e,r),342,A.f("TransferRange",B.e,r),343,A.f("ClipPath",B.e,r),512,A.f("JPEGProc",B.e,r),513,A.f("JPEGInterchangeFormat",B.e,r),514,A.f("JPEGInterchangeFormatLength",B.e,r),529,A.f("YCbCrCoefficients",B.t,3),530,A.f("YCbCrSubSampling",B.i,1),531,A.f("YCbCrPositioning",B.i,1),532,A.f("ReferenceBlackWhite",B.t,6),700,A.f("ApplicationNotes",B.i,1),18246,A.f("Rating",B.i,1),33421,A.f("CFARepeatPatternDim",B.e,r),33422,A.f("CFAPattern",B.e,r),33423,A.f("BatteryLevel",B.e,r),33432,A.f("Copyright",B.j,r),33434,A.f("ExposureTime",B.t,1),33437,A.f("FNumber",B.t,r),33723,A.f("IPTC-NAA",B.m,1),34665,A.f("ExifOffset",B.e,r),34675,A.f("InterColorProfile",B.e,r),34850,A.f("ExposureProgram",B.i,1),34852,A.f("SpectralSensitivity",B.j,r),34853,A.f("GPSOffset",B.e,r),34855,A.f(q,B.m,1),34856,A.f("OECF",B.e,r),34864,A.f("SensitivityType",B.i,1),34866,A.f("RecommendedExposureIndex",B.m,1),34867,A.f(q,B.m,1),36864,A.f("ExifVersion",B.I,r),36867,A.f("DateTimeOriginal",B.j,r),36868,A.f("DateTimeDigitized",B.j,r),36880,A.f("OffsetTime",B.j,r),36881,A.f("OffsetTimeOriginal",B.j,r),36882,A.f("OffsetTimeDigitized",B.j,r),37121,A.f("ComponentsConfiguration",B.I,r),37122,A.f("CompressedBitsPerPixel",B.e,r),37377,A.f("ShutterSpeedValue",B.e,r),37378,A.f("ApertureValue",B.e,r),37379,A.f("BrightnessValue",B.e,r),37380,A.f("ExposureBiasValue",B.e,r),37381,A.f("MaxApertureValue",B.e,r),37382,A.f("SubjectDistance",B.e,r),37383,A.f("MeteringMode",B.e,r),37384,A.f("LightSource",B.e,r),37385,A.f("Flash",B.e,r),37386,A.f("FocalLength",B.e,r),37396,A.f("SubjectArea",B.e,r),37500,A.f("MakerNote",B.I,r),37510,A.f("UserComment",B.I,r),37520,A.f("SubSecTime",B.e,r),37521,A.f("SubSecTimeOriginal",B.e,r),37522,A.f("SubSecTimeDigitized",B.e,r),40091,A.f("XPTitle",B.e,r),40092,A.f("XPComment",B.e,r),40093,A.f("XPAuthor",B.e,r),40094,A.f("XPKeywords",B.e,r),40095,A.f("XPSubject",B.e,r),40960,A.f("FlashPixVersion",B.e,r),40961,A.f("ColorSpace",B.i,1),40962,A.f("ExifImageWidth",B.i,1),40963,A.f("ExifImageLength",B.i,1),40964,A.f("RelatedSoundFile",B.e,r),40965,A.f("InteroperabilityOffset",B.e,r),41483,A.f("FlashEnergy",B.e,r),41484,A.f("SpatialFrequencyResponse",B.e,r),41486,A.f("FocalPlaneXResolution",B.e,r),41487,A.f("FocalPlaneYResolution",B.e,r),41488,A.f("FocalPlaneResolutionUnit",B.e,r),41492,A.f("SubjectLocation",B.e,r),41493,A.f("ExposureIndex",B.e,r),41495,A.f("SensingMethod",B.e,r),41728,A.f("FileSource",B.e,r),41729,A.f("SceneType",B.e,r),41730,A.f("CVAPattern",B.e,r),41985,A.f("CustomRendered",B.e,r),41986,A.f("ExposureMode",B.e,r),41987,A.f("WhiteBalance",B.e,r),41988,A.f("DigitalZoomRatio",B.e,r),41989,A.f("FocalLengthIn35mmFilm",B.e,r),41990,A.f("SceneCaptureType",B.e,r),41991,A.f("GainControl",B.e,r),41992,A.f("Contrast",B.e,r),41993,A.f("Saturation",B.e,r),41994,A.f("Sharpness",B.e,r),41995,A.f("DeviceSettingDescription",B.e,r),41996,A.f("SubjectDistanceRange",B.e,r),42016,A.f("ImageUniqueID",B.e,r),42032,A.f("CameraOwnerName",B.j,r),42033,A.f("BodySerialNumber",B.j,r),42034,A.f("LensSpecification",B.e,r),42035,A.f("LensMake",B.j,r),42036,A.f("LensModel",B.j,r),42037,A.f("LensSerialNumber",B.j,r),42240,A.f("Gamma",B.t,1),50341,A.f("PrintIM",B.e,r),59932,A.f("Padding",B.e,r),59933,A.f("OffsetSchema",B.e,r),65e3,A.f("OwnerName",B.j,r),65001,A.f("SerialNumber",B.j,r)],t.S,A.ae("hn"))})
 s($,"yK","jw",()=>A.kx(A.b([0,1,8,16,9,2,3,10,17,24,32,25,18,11,4,5,12,19,26,33,40,48,41,34,27,20,13,6,7,14,21,28,35,42,49,56,57,50,43,36,29,22,15,23,30,37,44,51,58,59,52,45,38,31,39,46,53,60,61,54,47,55,62,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],t.t)))
 s($,"ze","pf",()=>A.uV(1))
 s($,"zf","ts",()=>J.tH(B.Y.gt($.pf()),0,null))
@@ -22932,7 +22936,7 @@ for(var o=0;;o++){var n=s(p+"_"+o+"_")
 if(!(n in q)){q[n]=1
 v.isolateTag=n
 break}}v.dispatchPropertyName=v.getIsolateTag("dispatch_record")}()
-hunkHelpers.setOrUpdateInterceptorsByTag({SharedArrayBuffer:A.cp,ArrayBuffer:A.dH,ArrayBufferView:A.eM,DataView:A.hO,Float32Array:A.eI,Float64Array:A.eJ,Int16Array:A.hP,Int32Array:A.eK,Int8Array:A.eL,Uint16Array:A.eN,Uint32Array:A.eO,Uint8ClampedArray:A.cW,CanvasPixelArray:A.cW,Uint8Array:A.cX})
+hunkHelpers.setOrUpdateInterceptorsByTag({SharedArrayBuffer:A.cp,ArrayBuffer:A.dH,ArrayBufferView:A.eM,DataView:A.hO,Float32Array:A.eI,Float64Array:A.eJ,Int16Array:A.hP,Int32Array:A.eK,Int8Array:A.eL,Uint16Array:A.eN,Uint32Array:A.eO,Uint8ClampedArray:A.cX,CanvasPixelArray:A.cX,Uint8Array:A.cY})
 hunkHelpers.setOrUpdateLeafTags({SharedArrayBuffer:true,ArrayBuffer:true,ArrayBufferView:false,DataView:true,Float32Array:true,Float64Array:true,Int16Array:true,Int32Array:true,Int8Array:true,Uint16Array:true,Uint32Array:true,Uint8ClampedArray:true,CanvasPixelArray:true,Uint8Array:false})
 A.aG.$nativeSuperclassTag="ArrayBufferView"
 A.fu.$nativeSuperclassTag="ArrayBufferView"

--- a/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
@@ -97,8 +97,8 @@ for(s=a.length;b>0;b=r){r=b-1
 if(!(r<s))return A.a(a,r)
 q=a.charCodeAt(r)
 if(q!==32&&q!==13&&!J.pQ(q))break}return b},
-dj(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.dA.prototype
-return J.eB.prototype}if(typeof a=="string")return J.cT.prototype
+di(a){if(typeof a=="number"){if(Math.floor(a)==a)return J.dA.prototype
+return J.eB.prototype}if(typeof a=="string")return J.cS.prototype
 if(a==null)return J.eA.prototype
 if(typeof a=="boolean")return J.hD.prototype
 if(Array.isArray(a))return J.n.prototype
@@ -107,7 +107,7 @@ if(typeof a=="symbol")return J.dE.prototype
 if(typeof a=="bigint")return J.dD.prototype
 return a}if(a instanceof A.K)return a
 return J.nF(a)},
-a9(a){if(typeof a=="string")return J.cT.prototype
+a9(a){if(typeof a=="string")return J.cS.prototype
 if(a==null)return a
 if(Array.isArray(a))return J.n.prototype
 if(typeof a!="object"){if(typeof a=="function")return J.bJ.prototype
@@ -130,7 +130,7 @@ rC(a){if(typeof a=="number")return J.dB.prototype
 if(a==null)return a
 if(!(a instanceof A.K))return J.cC.prototype
 return a},
-y1(a){if(typeof a=="string")return J.cT.prototype
+y1(a){if(typeof a=="string")return J.cS.prototype
 if(a==null)return a
 if(!(a instanceof A.K))return J.cC.prototype
 return a},
@@ -142,15 +142,15 @@ return a}if(a instanceof A.K)return a
 return J.nF(a)},
 V(a,b){if(a==null)return b==null
 if(typeof a!="object")return b!=null&&a===b
-return J.dj(a).I(a,b)},
+return J.di(a).I(a,b)},
 tF(a){if(typeof a=="number")return-a
 return J.rB(a).ec(a)},
 a4(a,b){if(typeof b==="number")if(Array.isArray(a)||typeof a=="string"||A.y9(a,a[v.dispatchPropertyName]))if(b>>>0===b&&b<a.length)return a[b]
 return J.a9(a).h(a,b)},
-dp(a,b,c){return J.e7(a).k(a,b,c)},
+dn(a,b,c){return J.e7(a).k(a,b,c)},
 o8(a){if(typeof a==="number")return Math.abs(a)
 return J.rB(a).fw(a)},
-dq(a,b){return J.e7(a).i(a,b)},
+dp(a,b){return J.e7(a).i(a,b)},
 pl(a,b){return J.y1(a).bB(a,b)},
 o9(a){return J.bV(a).fA(a)},
 J(a,b,c){return J.bV(a).cH(a,b,c)},
@@ -164,17 +164,17 @@ tK(a){return J.bV(a).fG(a)},
 aC(a,b,c){return J.bV(a).cI(a,b,c)},
 po(a,b){return J.e7(a).aC(a,b)},
 tL(a){return J.bV(a).gt(a)},
-Z(a){return J.dj(a).gD(a)},
+Z(a){return J.di(a).gD(a)},
 pp(a){return J.a9(a).gap(a)},
 bh(a){return J.e7(a).gV(a)},
 tM(a){return J.e7(a).gaq(a)},
 a6(a){return J.a9(a).gp(a)},
-tN(a){return J.dj(a).gag(a)},
+tN(a){return J.di(a).gag(a)},
 tO(a){return J.rC(a).cj(a)},
 tP(a,b){return J.e7(a).aJ(a,b)},
 tQ(a,b){return J.e7(a).cT(a,b)},
 eb(a){return J.rC(a).K(a)},
-cO(a){return J.dj(a).m(a)},
+cO(a){return J.di(a).m(a)},
 hB:function hB(){},
 hD:function hD(){},
 eA:function eA(){},
@@ -197,7 +197,7 @@ _.$ti=c},
 dB:function dB(){},
 dA:function dA(){},
 eB:function eB(){},
-cT:function cT(){}},A={om:function om(){},
+cS:function cS(){}},A={om:function om(){},
 uK(a){return new A.cn("Field '"+a+"' has been assigned during initialization.")},
 uM(a){return new A.cn("Field '"+a+"' has not been initialized.")},
 uL(a){return new A.cn("Field '"+a+"' has already been initialized.")},
@@ -216,9 +216,9 @@ f5(a,b,c,d){A.eZ(b,"start")
 if(c!=null){A.eZ(c,"end")
 if(b>c)A.Q(A.aA(b,0,c,"start",null))}return new A.f4(a,b,c,d.l("f4<0>"))},
 os(a,b,c,d){if(t.gt.b(a))return new A.eh(a,b,c.l("@<0>").am(d).l("eh<1,2>"))
-return new A.cW(a,b,c.l("@<0>").am(d).l("cW<1,2>"))},
-bn(){return new A.d8("No element")},
-pN(){return new A.d8("Too many elements")},
+return new A.cV(a,b,c.l("@<0>").am(d).l("cV<1,2>"))},
+bn(){return new A.d7("No element")},
+pN(){return new A.d7("Too many elements")},
 b_:function b_(a){this.a=0
 this.b=a},
 dT:function dT(a){this.a=0
@@ -239,7 +239,7 @@ _.b=b
 _.c=0
 _.d=null
 _.$ti=c},
-cW:function cW(a,b,c){this.a=a
+cV:function cV(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 eh:function eh(a,b,c){this.a=a
@@ -266,7 +266,7 @@ this.$ti=b},
 fe:function fe(a,b){this.a=a
 this.$ti=b},
 aP:function aP(){},
-d9:function d9(){},
+d8:function d8(){},
 dR:function dR(){},
 f_:function f_(a,b){this.a=a
 this.$ti=b},
@@ -307,7 +307,7 @@ if(r==="NaN"||r==="+NaN"||r==="-NaN")return s
 return null}return s},
 i7(a){var s,r,q,p
 if(a instanceof A.K)return A.aV(A.bW(a),null)
-s=J.dj(a)
+s=J.di(a)
 if(s===B.ds||s===B.du||t.cx.b(a)){r=B.aC(a)
 if(r!=="Object"&&r!=="")return r
 q=a.constructor
@@ -478,7 +478,7 @@ rz(a,b){var s,r,q,p=a.length
 for(s=0;s<p;s=q){r=s+1
 q=r+1
 b.k(0,a[s],a[r])}return b},
-x4(a,b,c,d,e,f){t.x.a(a)
+x4(a,b,c,d,e,f){t.A.a(a)
 switch(A.B(b)){case 0:return a.$0()
 case 1:return a.$1(c)
 case 2:return a.$2(c,d)
@@ -504,7 +504,7 @@ default:s=null}if(s!=null)return s.bind(a)
 return function(c,d,e){return function(f,g,h,i){return e(c,d,f,g,h,i)}}(a,b,A.x4)},
 u7(a2){var s,r,q,p,o,n,m,l,k,j,i=a2.co,h=a2.iS,g=a2.iI,f=a2.nDA,e=a2.aI,d=a2.fs,c=a2.cs,b=d[0],a=c[0],a0=i[b],a1=a2.fT
 a1.toString
-s=h?Object.create(new A.ik().constructor.prototype):Object.create(new A.dr(null,null).constructor.prototype)
+s=h?Object.create(new A.ik().constructor.prototype):Object.create(new A.dq(null,null).constructor.prototype)
 s.$initialize=s.constructor
 r=h?function static_tear_off(){this.$initialize()}:function tear_off(a3,a4){this.$initialize(a3,a4)}
 s.constructor=r
@@ -560,7 +560,7 @@ p_(a){return A.u7(a)},
 tU(a,b){return A.fK(v.typeUniverse,A.bW(a.a),b)},
 pz(a){return a.a},
 tV(a){return a.b},
-pw(a){var s,r,q,p=new A.dr("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
+pw(a){var s,r,q,p=new A.dq("receiver","interceptor"),o=Object.getOwnPropertyNames(p)
 o.$flags=1
 s=o
 for(o=s.length,r=0;r<o;++r){q=s[r]
@@ -679,7 +679,7 @@ this.c=c},
 A:function A(a){this.a=a},
 fD:function fD(a){this.a=a},
 fE:function fE(a){this.a=a},
-du:function du(){},
+dt:function dt(){},
 aY:function aY(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
@@ -720,7 +720,7 @@ h9:function h9(){},
 ha:function ha(){},
 iq:function iq(){},
 ik:function ik(){},
-dr:function dr(a,b){this.a=a
+dq:function dq(a,b){this.a=a
 this.b=b},
 ic:function ic(a){this.a=a},
 bK:function bK(a){var _=this
@@ -742,7 +742,7 @@ _.d=null
 _.$ti=d},
 eG:function eG(a,b){this.a=a
 this.$ti=b},
-cV:function cV(a,b,c,d){var _=this
+cU:function cU(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -750,7 +750,7 @@ _.d=null
 _.$ti=d},
 c2:function c2(a,b){this.a=a
 this.$ti=b},
-cU:function cU(a,b,c,d){var _=this
+cT:function cT(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -771,7 +771,7 @@ nH:function nH(a){this.a=a},
 nI:function nI(a){this.a=a},
 aT:function aT(){},
 dX:function dX(){},
-dg:function dg(){},
+df:function df(){},
 cF:function cF(){},
 dC:function dC(a,b){var _=this
 _.a=a
@@ -798,7 +798,7 @@ _.c=c
 _.d=null},
 yp(a){throw A.ao(A.uK(a),new Error())},
 k(){throw A.ao(A.uM(""),new Error())},
-dm(){throw A.ao(A.uL(""),new Error())},
+dl(){throw A.ao(A.uL(""),new Error())},
 w8(){var s=new A.m6()
 return s.b=s},
 m6:function m6(){this.b=null},
@@ -860,8 +860,8 @@ eK:function eK(){},
 eL:function eL(){},
 eN:function eN(){},
 eO:function eO(){},
+cW:function cW(){},
 cX:function cX(){},
-cY:function cY(){},
 fu:function fu(){},
 fv:function fv(){},
 fw:function fw(){},
@@ -960,7 +960,7 @@ if(A.qk(b))if(a instanceof A.aN){s=A.nv(a)
 if(s!=null)return s}return A.bW(a)},
 bW(a){if(a instanceof A.K)return A.G(a)
 if(Array.isArray(a))return A.ar(a)
-return A.oR(J.dj(a))},
+return A.oR(J.di(a))},
 ar(a){var s=a[v.arrayRti],r=t.dG
 if(s==null)return r
 if(s.constructor!==r.constructor)return r
@@ -1001,7 +1001,7 @@ s.b=A.xD(s)
 return s.b(a)},
 xD(a){var s,r,q,p,o
 if(a===t.K)return A.xa
-if(A.dl(a))return A.xe
+if(A.dk(a))return A.xe
 s=a.w
 if(s===6)return A.wV
 if(s===1)return A.r9
@@ -1009,29 +1009,29 @@ if(s===7)return A.x5
 r=A.xB(a)
 if(r!=null)return r
 if(s===8){q=a.x
-if(a.y.every(A.dl)){a.f="$i"+q
+if(a.y.every(A.dk)){a.f="$i"+q
 if(q==="i")return A.x8
 if(a===t.m)return A.x7
 return A.xd}}else if(s===10){p=A.xY(a.x,a.y)
 o=p==null?A.r9:p
 return o==null?A.e0(o):o}return A.wT},
 xB(a){if(a.w===8){if(a===t.S)return A.ng
-if(a===t.i||a===t.r)return A.x9
+if(a===t.i||a===t.v)return A.x9
 if(a===t.N)return A.xc
 if(a===t.y)return A.bq}return null},
 wZ(a){var s=this,r=A.wS
-if(A.dl(s))r=A.wH
+if(A.dk(s))r=A.wH
 else if(s===t.K)r=A.e0
 else if(A.e8(s)){r=A.wU
 if(s===t.aV)r=A.wG
 else if(s===t.jv)r=A.oM
 else if(s===t.o9)r=A.fN
 else if(s===t.jh)r=A.qW
-else if(s===t.jX)r=A.dh
+else if(s===t.jX)r=A.dg
 else if(s===t.mU)r=A.oL}else if(s===t.S)r=A.B
 else if(s===t.N)r=A.a8
 else if(s===t.y)r=A.bf
-else if(s===t.r)r=A.cJ
+else if(s===t.v)r=A.cJ
 else if(s===t.i)r=A.D
 else if(s===t.m)r=A.e_
 s.a=r
@@ -1045,14 +1045,14 @@ xd(a){var s,r=this
 if(a==null)return A.e8(r)
 s=r.f
 if(a instanceof A.K)return!!a[s]
-return!!J.dj(a)[s]},
+return!!J.di(a)[s]},
 x8(a){var s,r=this
 if(a==null)return A.e8(r)
 if(typeof a!="object")return!1
 if(Array.isArray(a))return!0
 s=r.f
 if(a instanceof A.K)return!!a[s]
-return!!J.dj(a)[s]},
+return!!J.di(a)[s]},
 x7(a){var s=this
 if(a==null)return!1
 if(typeof a=="object"){if(a instanceof A.K)return!!a[s.f]
@@ -1091,7 +1091,7 @@ if(a==null)return a
 throw A.ao(A.bp(a,"bool?"),new Error())},
 D(a){if(typeof a=="number")return a
 throw A.ao(A.bp(a,"double"),new Error())},
-dh(a){if(typeof a=="number")return a
+dg(a){if(typeof a=="number")return a
 if(a==null)return a
 throw A.ao(A.bp(a,"double?"),new Error())},
 ng(a){return typeof a=="number"&&Math.floor(a)===a},
@@ -1135,7 +1135,7 @@ if(a4==null)a4=A.b([],t.s)
 else a2=a4.length
 r=a4.length
 for(q=s;q>0;--q)B.a.i(a4,"T"+(r+q))
-for(p=t.iD,o="<",n="",q=0;q<s;++q,n=a1){m=a4.length
+for(p=t.X,o="<",n="",q=0;q<s;++q,n=a1){m=a4.length
 l=m-1-q
 if(!(l>=0))return A.a(a4,l)
 o=o+n+a4[l]
@@ -1235,7 +1235,7 @@ return s},
 wv(a,b,c,d){var s,r,q
 if(d){s=b.w
 r=!0
-if(!A.dl(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.e8(b.x)
+if(!A.dk(b))if(!(b===t.P||b===t.T))if(s!==6)r=s===7&&A.e8(b.x)
 if(r)return b
 else if(s===1)return t.P}q=new A.bz(null,null)
 q.w=6
@@ -1249,7 +1249,7 @@ a.eC.set(r,s)
 return s},
 wt(a,b,c,d){var s,r
 if(d){s=b.w
-if(A.dl(b)||b===t.K)return b
+if(A.dk(b)||b===t.K)return b
 else if(s===1)return A.fI(a,"bH",[b])
 else if(b===t.P||b===t.T)return t.gK}r=new A.bz(null,null)
 r.w=7
@@ -1352,7 +1352,7 @@ case 58:k.push(!1)
 break
 case 33:k.push(!0)
 break
-case 59:k.push(A.df(a.u,a.e,k.pop()))
+case 59:k.push(A.de(a.u,a.e,k.pop()))
 break
 case 94:k.push(A.ww(a.u,k.pop()))
 break
@@ -1370,10 +1370,10 @@ break
 case 38:A.wh(a,k)
 break
 case 63:p=a.u
-k.push(A.qQ(p,A.df(p,a.e,k.pop()),a.n))
+k.push(A.qQ(p,A.de(p,a.e,k.pop()),a.n))
 break
 case 47:p=a.u
-k.push(A.qP(p,A.df(p,a.e,k.pop()),a.n))
+k.push(A.qP(p,A.de(p,a.e,k.pop()),a.n))
 break
 case 40:k.push(-3)
 k.push(a.p)
@@ -1407,7 +1407,7 @@ a.p=k.length
 r=n+1
 break
 default:throw"Bad character "+q}}}m=k.pop()
-return A.df(a.u,a.e,m)},
+return A.de(a.u,a.e,m)},
 wg(a,b,c,d){var s,r,q=b-48
 for(s=c.length;a<s;++a){r=c.charCodeAt(a)
 if(!(r>=48&&r<=57))break
@@ -1428,7 +1428,7 @@ d.push(A.fK(s,o,n))}else d.push(p)
 return m},
 wi(a,b){var s,r=a.u,q=A.qF(a,b),p=b.pop()
 if(typeof p=="string")b.push(A.fI(r,p,q))
-else{s=A.df(r,a.e,p)
+else{s=A.de(r,a.e,p)
 switch(s.w){case 11:b.push(A.oK(r,s,q,a.n))
 break
 default:b.push(A.oJ(r,s,q))
@@ -1445,7 +1445,7 @@ o=b.pop()
 switch(o){case-3:o=b.pop()
 if(n==null)n=p.sEA
 if(m==null)m=p.sEA
-r=A.df(p,a.e,o)
+r=A.de(p,a.e,o)
 q=new A.iQ()
 q.a=s
 q.b=n
@@ -1463,13 +1463,13 @@ qF(a,b){var s=b.splice(a.p)
 A.qJ(a.u,a.e,s)
 a.p=b.pop()
 return s},
-df(a,b,c){if(typeof c=="string")return A.fI(a,c,a.sEA)
+de(a,b,c){if(typeof c=="string")return A.fI(a,c,a.sEA)
 else if(typeof c=="number"){b.toString
 return A.wj(a,b,c)}else return c},
 qJ(a,b,c){var s,r=c.length
-for(s=0;s<r;++s)c[s]=A.df(a,b,c[s])},
+for(s=0;s<r;++s)c[s]=A.de(a,b,c[s])},
 wk(a,b,c){var s,r=c.length
-for(s=2;s<r;s+=3)c[s]=A.df(a,b,c[s])},
+for(s=2;s<r;s+=3)c[s]=A.de(a,b,c[s])},
 wj(a,b,c){var s,r,q=b.w
 if(q===9){if(c===0)return b.x
 s=b.y
@@ -1489,10 +1489,10 @@ if(s==null){s=A.au(a,b,null,c,null)
 r.set(c,s)}return s},
 au(a,b,c,d,e){var s,r,q,p,o,n,m,l,k,j,i
 if(b===d)return!0
-if(A.dl(d))return!0
+if(A.dk(d))return!0
 s=b.w
 if(s===4)return!0
-if(A.dl(b))return!1
+if(A.dk(b))return!1
 if(b.w===1)return!0
 r=s===13
 if(r)if(A.au(a,c[b.x],c,d,e))return!0
@@ -1506,7 +1506,7 @@ if(q===7){if(A.au(a,b,c,d.x,e))return!0
 return A.au(a,b,c,A.ox(a,d),e)}if(q===6)return A.au(a,b,c,p,e)||A.au(a,b,c,d.x,e)
 if(r)return!1
 p=s!==11
-if((!p||s===12)&&d===t.x)return!0
+if((!p||s===12)&&d===t.A)return!0
 o=s===10
 if(o&&d===t.lZ)return!0
 if(q===12){if(b===t.dY)return!0
@@ -1578,10 +1578,10 @@ if(b.x!==d.x)return!1
 for(s=0;s<p;++s)if(!A.au(a,r[s],c,q[s],e))return!1
 return!0},
 e8(a){var s=a.w,r=!0
-if(!(a===t.P||a===t.T))if(!A.dl(a))if(s!==6)r=s===7&&A.e8(a.x)
+if(!(a===t.P||a===t.T))if(!A.dk(a))if(s!==6)r=s===7&&A.e8(a.x)
 return r},
-dl(a){var s=a.w
-return s===2||s===3||s===4||s===5||a===t.iD},
+dk(a){var s=a.w
+return s===2||s===3||s===4||s===5||a===t.X},
 qU(a,b){var s,r,q=Object.keys(b),p=q.length
 for(s=0;s<p;++s){r=q[s]
 a[r]=b[r]}},
@@ -1630,7 +1630,7 @@ r.fp(q,p,s)}}},
 b4(a){var s=function(b,c){return function(d,e){while(true){try{b(d,e)
 break}catch(r){e=r
 d=c}}}}(a,1)
-return $.ad.h4(new A.np(s),t.o,t.S,t.z)},
+return $.ad.h4(new A.np(s),t.q,t.S,t.z)},
 qL(a,b,c){return 0},
 oc(a){var s
 if(t.W.b(a)){s=a.gbT()
@@ -1663,11 +1663,11 @@ else n=!1
 else n=!0
 if(n){p=b.c5()
 b.cp(o.a)
-A.dd(b,p)
+A.dc(b,p)
 return}b.a^=2
 A.jn(null,null,b.b,t.M.a(new A.mn(o,b)))},
-dd(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
-for(s=t.v,r=t.d;;){q={}
+dc(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d={},c=d.a=a
+for(s=t.w,r=t.d;;){q={}
 p=c.a
 o=(p&16)===0
 n=!o
@@ -1675,7 +1675,7 @@ if(b==null){if(n&&(p&1)===0){m=s.a(c.c)
 A.oV(m.a,m.b)}return}q.a=b
 l=b.a
 for(c=b;l!=null;c=l,l=k){c.a=null
-A.dd(d.a,c)
+A.dc(d.a,c)
 q.a=l
 k=l.a}p=d.a
 j=p.c
@@ -1802,7 +1802,7 @@ this.c=c},
 iI:function iI(){},
 ff:function ff(a,b){this.a=a
 this.$ti=b},
-dc:function dc(a,b,c,d,e){var _=this
+db:function db(a,b,c,d,e){var _=this
 _.a=null
 _.b=a
 _.c=b
@@ -1845,7 +1845,7 @@ nj:function nj(a,b){this.a=a
 this.b=b},
 hM(a,b,c){return b.l("@<0>").am(c).l("kp<1,2>").a(A.rz(a,new A.bK(b.l("@<0>").am(c).l("bK<1,2>"))))},
 x(a,b){return new A.bK(a.l("@<0>").am(b).l("bK<1,2>"))},
-aK(a){return new A.de(a.l("de<0>"))},
+aK(a){return new A.dd(a.l("dd<0>"))},
 oH(){var s=Object.create(null)
 s["<non-identifier-key>"]=s
 delete s["<non-identifier-key>"]
@@ -1861,7 +1861,7 @@ a.al(0,new A.kt(r,s))
 s.a+="}"}finally{if(0>=$.bg.length)return A.a($.bg,-1)
 $.bg.pop()}r=s.a
 return r.charCodeAt(0)==0?r:r},
-de:function de(a){var _=this
+dd:function dd(a){var _=this
 _.a=0
 _.f=_.e=_.d=_.c=_.b=null
 _.r=0
@@ -1882,7 +1882,7 @@ N:function N(){},
 aL:function aL(){},
 kt:function kt(a,b){this.a=a
 this.b=b},
-d7:function d7(){},
+d6:function d6(){},
 fF:function fF(){},
 wC(a,b,c){var s,r,q,p,o=c-b
 if(o<=4096)s=$.tr()
@@ -1990,8 +1990,8 @@ jf:function jf(){},
 h0:function h0(){},
 m1:function m1(){this.a=0},
 h3:function h3(){},
-da:function da(a){this.a=a},
-dt:function dt(){},
+d9:function d9(a){this.a=a},
+ds:function ds(){},
 af:function af(){},
 hi:function hi(){},
 eF:function eF(a,b){this.a=a
@@ -2017,7 +2017,7 @@ this.b=16
 this.c=0},
 pI(a,b){return new A.ho(new WeakMap(),a,b.l("ho<0>"))},
 ut(a){},
-dk(a,b){var s=A.qf(a,b)
+dj(a,b){var s=A.qf(a,b)
 if(s!=null)return s
 throw A.d(A.bm(a,null,null))},
 ur(a,b){a=A.ao(a,new Error())
@@ -2088,7 +2088,7 @@ return a},
 oi(a,b,c,d){return new A.hx(b,!0,a,d,"Index out of range")},
 bR(a){return new A.f9(a)},
 qz(a){return new A.is(a)},
-aS(a){return new A.d8(a)},
+aS(a){return new A.d7(a)},
 aX(a){return new A.hc(a)},
 bm(a,b,c){return new A.C(a,b,c)},
 uB(a,b,c){var s,r
@@ -2140,34 +2140,34 @@ B.a.i(b,r)},
 c4(a,b,c,d,e,f,g){var s
 if(B.h===c){s=J.Z(a)
 b=J.Z(b)
-return A.dQ(A.a5(A.a5($.dn(),s),b))}if(B.h===d){s=J.Z(a)
+return A.dQ(A.a5(A.a5($.dm(),s),b))}if(B.h===d){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
-return A.dQ(A.a5(A.a5(A.a5($.dn(),s),b),c))}if(B.h===e){s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5($.dm(),s),b),c))}if(B.h===e){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
-return A.dQ(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d))}if(B.h===f){s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d))}if(B.h===f){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
 e=J.Z(e)
-return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d),e))}if(B.h===g){s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d),e))}if(B.h===g){s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
 e=J.Z(e)
 f=J.Z(f)
-return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d),e),f))}s=J.Z(a)
+return A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d),e),f))}s=J.Z(a)
 b=J.Z(b)
 c=J.Z(c)
 d=J.Z(d)
 e=J.Z(e)
 f=J.Z(f)
 g=J.Z(g)
-g=A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dn(),s),b),c),d),e),f),g))
+g=A.dQ(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5(A.a5($.dm(),s),b),c),d),e),f),g))
 return g},
-S(a){var s,r,q=$.dn()
+S(a){var s,r,q=$.dm()
 for(s=a.length,r=0;r<a.length;a.length===s||(0,A.l)(a),++r)q=A.a5(q,J.Z(a[r]))
 return A.dQ(q)},
 wL(a,b){return 65536+((a&1023)<<10)+(b&1023)},
@@ -2196,7 +2196,7 @@ _.c=d
 _.d=e},
 f9:function f9(a){this.a=a},
 is:function is(a){this.a=a},
-d8:function d8(a){this.a=a},
+d7:function d7(a){this.a=a},
 hc:function hc(a){this.a=a},
 hS:function hS(){},
 f2:function f2(){},
@@ -2222,7 +2222,7 @@ ho:function ho(a,b,c){this.a=a
 this.b=b
 this.$ti=c},
 hQ:function hQ(a){this.a=a},
-wJ(a,b,c){t.x.a(a)
+wJ(a,b,c){t.A.a(a)
 if(A.B(c)>=1)return a.$1(b)
 return a.$0()},
 xT(a,b,c){var s,r
@@ -2385,7 +2385,7 @@ p.a=0
 s=new A.nx(p,b)
 try{r=s.$1(a)
 p=p.a===b.length?r:null
-return p}catch(q){if(A.I(q) instanceof A.d8)return null
+return p}catch(q){if(A.I(q) instanceof A.d7)return null
 else throw q}},
 cz:function cz(a,b,c){this.a=a
 this.b=b
@@ -2416,7 +2416,7 @@ r.buffer=s
 a.postMessage(r,A.b([s],t.f))},
 qX(a,b,c){var s
 if(b==null||c==null)return
-s=$.d4
+s=$.d3
 if(s){a.cosStats=B.cv.kE(A.vp().h8(),null)
 A.vo()}a.workerUs=c
 a.parseUs=0
@@ -2426,7 +2426,7 @@ a.serializeUs=b.f
 a.decodeUs=b.e
 a.binUs=b.r
 a.transcriptHit=b.x},
-fR(a,b,c,d,a0,a1,a2,a3,a4,a5,a6){var s=0,r=A.b3(t.X),q,p,o,n,m,l,k,j,i,h,g,f,e
+fR(a,b,c,d,a0,a1,a2,a3,a4,a5,a6){var s=0,r=A.b3(t.J),q,p,o,n,m,l,k,j,i,h,g,f,e
 var $async$fR=A.b4(function(a7,a8){if(a7===1)return A.b0(a8,r)
 for(;;)switch(s){case 0:if(d<0||d>=J.a6(a.gdm())){q=null
 s=1
@@ -2478,7 +2478,7 @@ s=1
 break
 case 1:return A.b1(q,r)}})
 return A.b2($async$fR,r)},
-ji(a,b,c,d,e,f,g,a0,a1,a2,a3){var s=0,r=A.b3(t.X),q,p,o,n,m,l,k,j,i,h
+ji(a,b,c,d,e,f,g,a0,a1,a2,a3){var s=0,r=A.b3(t.J),q,p,o,n,m,l,k,j,i,h
 var $async$ji=A.b4(function(a4,a5){if(a4===1)return A.b0(a5,r)
 for(;;)switch(s){case 0:s=3
 return A.an(b.bO(a,c,d,a2,a3,4096),$async$ji)
@@ -2508,7 +2508,7 @@ if(a3==null)i=null
 else{i=new A.ax()
 $.aB()
 i.ai()}s=4
-return A.an(A.jt(t.J.a(h.b),j,a2),$async$ji)
+return A.an(A.jt(t.I.a(h.b),j,a2),$async$ji)
 case 4:if(i!=null){if(i.b==null)i.b=$.aM.$0()
 a3.r=a3.r+i.gac()}q=A.rx(j.fS())
 s=1
@@ -2566,20 +2566,20 @@ if(o)c=null
 else{c=new A.ax()
 $.aB()
 c.ai()}s=5
-return A.an(A.jt(t.J.a(j),d,a8),$async$fS)
+return A.an(A.jt(t.I.a(j),d,a8),$async$fS)
 case 5:if(c!=null){if(c.b==null)c.b=$.aM.$0()
 a9.r=a9.r+c.gac()}q=new A.j(k,A.rx(d.fS()))
 s=1
 break
 case 1:return A.b1(q,r)}})
 return A.b2($async$fS,r)},
-e4(a,a0,a1){var s=0,r=A.b3(t.J),q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b
+e4(a,a0,a1){var s=0,r=A.b3(t.I),q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b
 var $async$e4=A.b4(function(a2,a3){if(a2===1)return A.b0(a3,r)
 for(;;)switch(s){case 0:b=A.b([],t.lO)
 p=J.bh(a0),o=!1
 case 3:if(!p.u()){s=4
 break}n=p.gF()
-if(a1.a)throw A.d(new A.d_())
+if(a1.a)throw A.d(new A.cZ())
 m=n instanceof A.bo
 l=m?n.a:null
 s=m?6:7
@@ -2695,7 +2695,7 @@ break A}n=o>0
 m=n?A.nS(a,b,o):null
 l=n?A.nR(a,b,o):null
 if(m!=null||l!=null)A.yf(k.a,o,m,l)
-q=new A.d1(k.a,k.b,k.c,l==null)
+q=new A.d0(k.a,k.b,k.c,l==null)
 s=1
 break
 case 1:return A.b1(q,r)}})
@@ -2717,7 +2717,7 @@ s=1
 break A}i=l[i]
 if(!(j<n)){q=A.a(m,j)
 s=1
-break A}m[j]=i}q=new A.d2(m,p,o)
+break A}m[j]=i}q=new A.d1(m,p,o)
 s=1
 break
 case 1:return A.b1(q,r)}})
@@ -2821,7 +2821,7 @@ this.b=b},
 f(a,b,c){return new A.hn(a,b)},
 hn:function hn(a,b){this.a=a
 this.b=b},
-cS:function cS(a){this.a=a},
+cR:function cR(a){this.a=a},
 dx:function dx(a,b){this.a=a
 this.b=b},
 uz(a,b){var s,r=J.dz(b,t.ba)
@@ -2857,7 +2857,7 @@ hb:function hb(a,b,c){this.e=a
 this.f=b
 this.r=c},
 ck:function ck(){},
-cR:function cR(a){this.a=a},
+cQ:function cQ(a){this.a=a},
 em:function em(a){this.a=a},
 kl:function kl(){this.d=null},
 cm:function cm(a,b,c,d){var _=this
@@ -2932,7 +2932,7 @@ case"false":return B.ab
 case"null":return B.n}throw A.d(A.z('unexpected keyword "'+b.gh6()+'"',b.b))
 case 10:throw A.d(A.z("unexpected end of input",b.b))
 case 6:case 8:throw A.d(A.z("unexpected token "+b.m(0),b.b))}},
-ug(a){var s,r,q,p=A.b([],t.q)
+ug(a){var s,r,q,p=A.b([],t.r)
 for(;;){s=a.L()
 switch(s.a.a){case 6:return new A.o(p)
 case 10:return new A.o(p)
@@ -2973,7 +2973,7 @@ q=p[q]
 q=q===0||q===9||q===10||q===12||q===13||q===32}else q=!1
 if(!q)break;--m}l=A.Y(p,o,m)
 a.b=n+2
-return new A.aZ("BI",A.b([k,new A.L(l,!1)],t.q))},
+return new A.aZ("BI",A.b([k,new A.L(l,!1)],t.r))},
 ua(a,b,c){var s,r,q,p
 if(A.u9(c)){s=A.uc(a,b)
 if(s!=null){r=A.ud(a,s)
@@ -3018,7 +3018,7 @@ r=A.jS(a[s])}else r=!0
 if(p<o){if(!(p>=0&&p<o))return A.a(a,p)
 q=A.jS(a[p])}else q=!0
 return r&&q?c:null},
-pD(a,b){var s=A.b([],t.q),r=b!=null&&b<=0
+pD(a,b){var s=A.b([],t.r),r=b!=null&&b<=0
 return new A.jJ(b,new A.bG(a,0),a.length,s,r)},
 aZ:function aZ(a,b){this.a=a
 this.b=b},
@@ -3228,9 +3228,9 @@ else for(r=n.length,o=t.t,q=19;q>=0;--q){l=A.b([],o)
 for(k=0;k<r;++k)l.push((n[k]^q)>>>0)
 m=A.fU(l,new Uint8Array(A.H(m)))}j=A.qr(new Uint8Array(A.H(m)),b,d,e,f,g,h)
 if(A.qq(j,c,e,g))return j
-throw A.d(new A.cQ())},
+throw A.d(new A.cP())},
 vB(a,b,c,d,e,f){var s,r,q,p,o,n,m=new A.ln(f,a)
-if(c.length<48||d.length<48)throw A.d(new A.cQ())
+if(c.length<48||d.length<48)throw A.d(new A.cP())
 s=B.a8.aa(b)
 if(s.length>127)s=B.d.a1(s,0,127)
 r=new A.lo(e)
@@ -3241,7 +3241,7 @@ return m.dS(new Uint8Array(16),B.d.a1(p,0,32))}}o=B.d.a1(d,0,48)
 if(A.lp(r.$3(s,B.d.a1(c,32,40),o),B.d.a1(c,0,32))){q=r.$3(s,B.d.a1(c,40,48),o)
 n=m.$1("OE")
 if(n.length>=32){m=A.oa(q)
-return m.dS(new Uint8Array(16),B.d.a1(n,0,32))}}throw A.d(new A.cQ())},
+return m.dS(new Uint8Array(16),B.d.a1(n,0,32))}}throw A.d(new A.cP())},
 vD(a,b,c){var s,r,q,p,o,n,m,l,k,j,i,h="Hash.add() called after close().",g=t.S,f=A.al(a,g)
 B.a.T(f,b)
 B.a.T(f,c)
@@ -3322,9 +3322,9 @@ r.eP(b)
 q=r.j(r.d.a.h(0,"Root"))
 if(!(q instanceof A.p)){n=A.z("trailer /Root does not resolve",null)
 throw A.d(n)}return r}catch(m){n=A.I(m)
-if(n instanceof A.cQ)throw m
+if(n instanceof A.cP)throw m
 else if(n instanceof A.f8)throw m
-else if(!t.I.b(n))if(!t.b0.b(n))throw m}n=A.uk(a,s,b)
+else if(!t.H.b(n))if(!t.b0.b(n))throw m}n=A.uk(a,s,b)
 return n}finally{A.cy(B.bK,l)}},
 uj(a,b){var s,r,q,p=A.cx()
 try{r=a.length
@@ -3342,7 +3342,7 @@ ul(b6,b7,b8){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a
 if(b5.a===0)throw A.d(A.z("cross-reference recovery found no objects in the file",b1))
 s=A.aJ(b1)
 r=b7
-for(a1=t.I,a2=t.O;;){r=A.r4(b6,"trailer",r,b1)
+for(a1=t.H,a2=t.O;;){r=A.r4(b6,"trailer",r,b1)
 a3=r
 if(typeof a3!=="number")return a3.a4()
 if(a3<0)break
@@ -3412,7 +3412,7 @@ else throw a4}}}b4.a=0
 for(a1=b5,a1=new A.az(a1,a1.r,a1.e,A.G(a1).l("az<1>"));a1.u();){a2=a1.d
 if(a2>b4.a)b4.a=a2}s.a.ad("Size",new A.jP(b4))
 return p},
-pG(a,b){var s,r,q,p,o,n,m,l=A.x(t.S,t.w)
+pG(a,b){var s,r,q,p,o,n,m,l=A.x(t.S,t.x)
 for(s=a.length,r=b;q=r+3,q<=s;++r){if(!(r>=0&&r<s))return A.a(a,r)
 p=!0
 if(a[r]===111){o=r+1
@@ -3485,12 +3485,12 @@ this.b=b},
 dW:function dW(a,b,c){this.a=a
 this.b=b
 this.c=c},
-z(a,b){return new A.cP(a,b)},
+z(a,b){return new A.du(a,b)},
 oC(a){return new A.f8(a)},
-cP:function cP(a,b){this.a=a
+du:function du(a,b){this.a=a
 this.b=b},
 iu:function iu(a){this.a=a},
-cQ:function cQ(){},
+cP:function cP(){},
 f8:function f8(a){this.a=a},
 fY:function fY(){},
 fX:function fX(){},
@@ -3500,9 +3500,9 @@ p=q.length
 if(p!==2)continue
 if(0>=p)return A.a(q,0)
 o=q[0]
-n=A.dk(o,2)
+n=A.dj(o,2)
 if(1>=p)return A.a(q,1)
-l.k(0,(o.length<<16|n)>>>0,A.dk(q[1],null))}return l},
+l.k(0,(o.length<<16|n)>>>0,A.dj(q[1],null))}return l},
 h8:function h8(){},
 jA:function jA(a){this.a=a},
 jz:function jz(a){this.a=a},
@@ -3533,7 +3533,7 @@ n=B.ek.h(0,i)
 if(n==null){if(!(o<g.length))return A.a(g,o)
 throw A.d(new A.iu(g[o]))}m=A.cx()
 p=n.bE(p,o<q.length?q[o]:null)
-k=$.d4
+k=$.d3
 if(k){if(!(o<g.length))return A.a(g,o)
 A.xq(g[o],m,p.length)}}if(k!==0)A.by(B.bF,1)
 return p},
@@ -3596,7 +3596,7 @@ j=m*l+B.c.q(j,3)
 l=J.a4(p,j)
 m=n
 if(typeof m!=="number")return m.e9()
-J.dp(p,j,l&~(128>>>(m&7)))}m=n
+J.dn(p,j,l&~(128>>>(m&7)))}m=n
 if(typeof m!=="number")return m.R()
 n=m+1}m=o
 if(typeof m!=="number")return m.R()
@@ -4043,10 +4043,10 @@ this.c=c},
 c_:function c_(a,b,c){this.a=a
 this.b=b
 this.c=c},
-cx(){var s=$.d4
+cx(){var s=$.d3
 if(!s)return 0
 return $.ov.gac()},
-cy(a,b){var s,r=$.d4
+cy(a,b){var s,r=$.d3
 if(!r)return
 r=$.i2
 s=a.a
@@ -4055,13 +4055,13 @@ B.a.k(r,s,r[s]+($.ov.gac()-b))
 b=$.l5
 if(!(s<b.length))return A.a(b,s)
 B.a.k(b,s,b[s]+1)},
-by(a,b){var s,r=$.d4
+by(a,b){var s,r=$.d3
 if(!r)return
 r=$.l3
 s=a.a
 if(!(s<r.length))return A.a(r,s)
 B.a.k(r,s,r[s]+b)},
-qb(a,b){var s,r=$.d4
+qb(a,b){var s,r=$.d3
 if(!r)return
 r=$.l4
 s=a.a
@@ -4108,7 +4108,7 @@ this.b=b
 this.c=c},
 uq(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f="expected integer, found "
 a.cP("xref")
-s=A.x(t.S,t.w)
+s=A.x(t.S,t.x)
 for(r=a.a,q=a.c;a.bc().a===B.w;){p=q.length!==0?B.a.ae(q,0):r.L()
 if(p.a!==B.w)A.Q(A.z(f+p.m(0),p.b))
 o=A.B(p.c)
@@ -4146,7 +4146,7 @@ if(h instanceof A.o){q=A.b([],n)
 for(l=h.a,k=l.length,j=0;j<l.length;l.length===k||(0,A.l)(l),++j){g=l[j]
 q.push(g instanceof A.m?g.a:A.Q(A.z("invalid /Index entry",a9)))}f=q}else f=A.b([0,o.a],n)
 q=t.S
-e=A.x(q,t.w)
+e=A.x(q,t.x)
 d=B.a.cQ(m,0,new A.jV(),q)
 for(q=r.length,c=0,b=0;l=b+1,k=f.length,l<k;b+=2){if(!(b<k))return A.a(f,b)
 a=f[b]
@@ -4470,10 +4470,10 @@ this.a=c},
 jr(a,b){var s,r=b==null?J.a6(a):b,q=new A.nw(a)
 A:{if(1===r){s=q.$1(0)
 s=new A.M(s,s,s)
-break A}if(4===r){s=A.d0(q.$1(0),q.$1(1),q.$1(2),q.$1(3))
+break A}if(4===r){s=A.d_(q.$1(0),q.$1(1),q.$1(2),q.$1(3))
 break A}s=new A.M(q.$1(0),q.$1(1),q.$1(2))
 break A}return s},
-d0(a,b,c,d){var s=B.c.n(a,0,1),r=B.c.n(b,0,1),q=B.c.n(c,0,1),p=B.c.n(d,0,1)
+d_(a,b,c,d){var s=B.c.n(a,0,1),r=B.c.n(b,0,1),q=B.c.n(c,0,1),p=B.c.n(d,0,1)
 return new A.M(B.c.n((255+s*(-4.387332384609988*s+54.48615194189176*r+18.82290502165302*q+212.25662451639585*p+-285.2331026137004)+r*(1.7149763477362134*r+-5.6096736904047315*q+-17.873870861415444*p+-5.497006427196366)+q*(-2.5217340131683033*q+-21.248923337353073*p+17.5119270841813)+p*(-21.86122147463605*p+-189.48180835922747))/255,0,1),B.c.n((255+s*(8.841041422036149*s+60.118027045597366*r+6.871425592049007*q+31.159100130055922*p+-79.2970844816548)+r*(-15.310361306967817*r+17.575251261109482*q+131.35250912493976*p+-190.9453302588951)+q*(4.444339102852739*q+9.8632861493405*p+-24.86741582555878)+p*(-20.737325471181034*p+-187.80453709719578))/255,0,1),B.c.n((255+s*(0.8842522430003296*s+8.078677503112928*r+30.89978309703729*q+-0.23883238689178934*p+-14.183576799673286)+r*(10.49593273432072*r+63.02378494754052*q+50.606957656360734*p+-112.23884253719248)+q*(0.03296041114873217*q+115.60384449646641*p+-193.58209356861505)+p*(-22.33816807309886*p+-180.12613974708367))/255,0,1))},
 nw:function nw(a){this.a=a},
 M:function M(a,b,c){this.a=a
@@ -4505,7 +4505,7 @@ p=r instanceof A.m?r.a:3
 o=c!=null?c.ad(s,new A.kB(a,s)):A.pZ(a,s)}}return new A.fn(o,p)},
 pZ(a,b){var s,r
 try{s=A.uy(a.a3(b))
-return s}catch(r){if(t.I.b(A.I(r)))return null
+return s}catch(r){if(t.H.b(A.I(r)))return null
 else throw r}},
 pY(a){var s
 A:{if("DeviceGray"===a||"G"===a){s=B.R
@@ -4527,7 +4527,7 @@ if(3>=k.length)return A.a(k,3)
 s=a.j(k[3])
 r=null
 if(s instanceof A.L)r=s.a
-else if(s instanceof A.y)try{r=a.a3(s)}catch(m){if(t.I.b(A.I(m)))return l
+else if(s instanceof A.y)try{r=a.a3(s)}catch(m){if(t.H.b(A.I(m)))return l
 else throw m}else return l
 return new A.fo(q,n,r)},
 wp(a,b,c,d,e){var s,r=b.a
@@ -4592,7 +4592,7 @@ vj(a,b){var s,r=A.cx()
 try{s=A.v9(a,b)
 A.by(B.bC,1)
 return s}finally{A.cy(B.bQ,r)}},
-v9(c8,c9){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5=null,b6="Encoding",b7="FontDescriptor",b8=c9.a,b9=b8.h(0,"Subtype"),c0=b9 instanceof A.u?b9.a:"",c1=c8.j(b8.h(0,"BaseFont")),c2=c1 instanceof A.u?c1.a:b5,c3=c0==="Type0",c4=t.S,c5=A.x(c4,t.H),c6=c0==="Type3",c7=0.001
+v9(c8,c9){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5=null,b6="Encoding",b7="FontDescriptor",b8=c9.a,b9=b8.h(0,"Subtype"),c0=b9 instanceof A.u?b9.a:"",c1=c8.j(b8.h(0,"BaseFont")),c2=c1 instanceof A.u?c1.a:b5,c3=c0==="Type0",c4=t.S,c5=A.x(c4,t.o),c6=c0==="Type3",c7=0.001
 if(c6){q=c8.j(b8.h(0,"FontMatrix"))
 if(q instanceof A.o&&q.a.length>=6){p=A.b([],t.n)
 for(o=q.a,n=0;n<6;++n){if(!(n<o.length))return A.a(o,n)
@@ -4638,7 +4638,7 @@ a6=c8.j(b8.h(0,b7))
 if(a6 instanceof A.p){e=A.q4(c8,a6)
 d=e==null?A.q3(c8,a6):b5
 b=A.q2(c8,a6)}r=c8.j(b8.h(0,"CIDToGIDMap"))
-if(r instanceof A.y)try{s=c8.a3(r)}catch(a7){if(t.I.b(A.I(a7)))s=null
+if(r instanceof A.y)try{s=c8.a3(r)}catch(a7){if(t.H.b(A.I(a7)))s=null
 else throw a7}}else a5=B.ad
 a8=e==null&&d==null&&g.gap(g)?c4?A.u2(a.a):b5:b5
 a9=B.Q}else{a9=A.vh(c8,b8.h(0,b6),c2)
@@ -4711,7 +4711,7 @@ o=c.cW(p)
 if(o!==0)r.k(0,q,o)}A.ot(a,m.h(0,n)).al(0,new A.kG(c,r))
 return r.a===0?null:r},
 q4(a,b){var s,r,q,p,o,n,m
-for(q=t.I,p=b.a,o=0;o<2;++o){s=a.j(p.h(0,B.dP[o]))
+for(q=t.H,p=b.a,o=0;o<2;++o){s=a.j(p.h(0,B.dP[o]))
 if(!(s instanceof A.y))continue
 try{r=A.vL(a.a3(s))
 if(r!=null){n=r
@@ -4720,12 +4720,12 @@ else throw m}}return null},
 va(a,b){var s,r,q=a.j(b.a.h(0,"FontFile"))
 if(!(q instanceof A.y))return null
 try{s=A.vU(a.a3(q))
-return s}catch(r){if(t.I.b(A.I(r))){A.by(B.a_,1)
+return s}catch(r){if(t.H.b(A.I(r))){A.by(B.a_,1)
 return null}else throw r}},
 q2(a,b){var s=a.j(b.a.h(0,"Flags"))
 return s instanceof A.m&&(s.a&4)!==0},
 q3(a,b){var s,r,q,p,o,n,m
-for(q=t.I,p=b.a,o=0;o<2;++o){s=a.j(p.h(0,B.dQ[o]))
+for(q=t.H,p=b.a,o=0;o<2;++o){s=a.j(p.h(0,B.dQ[o]))
 if(!(s instanceof A.y))continue
 try{r=A.u1(a.a3(s))
 if(r!=null){n=r
@@ -4792,7 +4792,7 @@ if(n<s&&a[n]===32)r=n}else B.a.i(m,q)}return m},
 vg(a,b){var s,r,q,p,o,n,m,l=a.j(b)
 if(!(l instanceof A.y))return B.Q
 s=null
-try{s=a.a3(l)}catch(o){if(t.I.b(A.I(o)))return B.Q
+try{s=a.a3(l)}catch(o){if(t.H.b(A.I(o)))return B.Q
 else throw o}r=A.x(t.S,t.N)
 q=new A.c_(new A.bG(s,0),null,A.b([],t.O))
 try{for(;;){n=q
@@ -4802,7 +4802,7 @@ if(p.a===B.C)break
 n=p
 if(n.a===B.o&&n.c==="beginbfchar")A.vc(q,r)
 else{n=p
-if(n.a===B.o&&n.c==="beginbfrange")A.vd(q,r)}}}catch(o){if(!(A.I(o) instanceof A.cP))throw o}return r},
+if(n.a===B.o&&n.c==="beginbfrange")A.vd(q,r)}}}catch(o){if(!(A.I(o) instanceof A.du))throw o}return r},
 vc(a,b){var s,r,q,p,o,n
 for(s=a.a,r=a.c,q=t.p;;){p=r.length!==0?B.a.ae(r,0):s.L()
 o=p.a
@@ -4910,10 +4910,10 @@ return A.Y(a,l,l+((m<<24|n<<16|o<<8|a[p])>>>0))}}return k},
 tX(b3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0=null,b1={},b2=new A.ch(b3)
 b2.b=2
 b2.b=b2.P()
-A.ds(b2)
-s=A.ds(b2)
-r=A.ds(b2)
-q=A.ds(b2)
+A.dr(b2)
+s=A.dr(b2)
+r=A.dr(b2)
+q=A.dr(b2)
 p=s.length
 if(p===0)return b0
 if(0>=p)return A.a(s,0)
@@ -4922,7 +4922,7 @@ n=A.ee(o.h(0,17))
 if(n==null)return b0
 p=new A.ch(b3)
 p.b=n
-m=A.ds(p)
+m=A.dr(p)
 if(m.length===0)return b0
 l=o.ak(3079)
 p=t.n
@@ -4936,7 +4936,7 @@ g=A.b([],t.mL)
 f=A.b([],t.iP)
 e=o.ak(3102)
 if(e){d=A.ee(o.h(0,3108))
-if(d!=null)for(j=new A.ch(b3),j.b=d,j=A.ds(j),i=j.length,h=0;h<j.length;j.length===i||(0,A.l)(j),++h){c=A.oe(b3,j[h])
+if(d!=null)for(j=new A.ch(b3),j.b=d,j=A.dr(j),i=j.length,h=0;h<j.length;j.length===i||(0,A.l)(j),++h){c=A.oe(b3,j[h])
 B.a.i(g,A.qK(b3,c.h(0,18)))
 b=c.h(0,3079)
 if(b==null||b.length<6)a=b0
@@ -4957,7 +4957,7 @@ if(a7==null)a7=0
 if(a7>1)A.tZ(b3,a7,a5,a6)
 else for(a8=32;a8<=126;++a8){a9=a6.h(0,a8-31)
 if(a9!=null)a5.k(0,a8,a9)}}return new A.jB(b3,m,q,g,a3,b1.a,a5,k,f,l,a4,r,A.x(p,t.ak),A.x(p,t.i))},
-ds(a){var s,r,q,p,o,n,m,l=a.H()
+dr(a){var s,r,q,p,o,n,m,l=a.H()
 if(l===0)return B.ag
 s=new A.jG(a.P(),a)
 r=A.b([],t.t)
@@ -4972,7 +4972,7 @@ o.push(new A.j(p+m,p+r[q]))}if(!(l<r.length))return A.a(r,l)
 a.b=p+r[l]
 return o},
 oe(a0,a1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c=A.x(t.S,t.oT),b=A.b([],t.g2),a=a1.a
-for(s=a1.b,r=a0.length,q=t.r;a<s;){if(!(a>=0&&a<r))return A.a(a0,a)
+for(s=a1.b,r=a0.length,q=t.v;a<s;){if(!(a>=0&&a<r))return A.a(a0,a)
 p=a0[a]
 if(p<=21){++a
 if(p===12){if(!(a<r))return A.a(a0,a)
@@ -5094,7 +5094,7 @@ p=A.oe(a,new A.j(q,q+r))
 o=A.ee(p.h(0,19))
 if(o!=null){s=new A.ch(a)
 s.b=q+o
-n=A.ds(s)}else n=B.ag
+n=A.dr(s)}else n=B.ag
 s=p.h(0,20)
 if(s==null)s=l
 else s=s.length===0?l:B.a.gaY(s)
@@ -5259,7 +5259,7 @@ lH:function lH(a){this.a=a},
 bA:function bA(a,b,c){this.a=a
 this.b=b
 this.c=c},
-db:function db(a,b,c,d){var _=this
+da:function da(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -5298,7 +5298,7 @@ else{h=e.b
 if(1>=h.length)return A.a(h,1)
 h=h[1]
 h.toString
-d=A.dk(h,b)}k=d
+d=A.dj(h,b)}k=d
 j=A.vR(n,k)
 i=A.vO(n,k)
 if(i.a===0)return b
@@ -5381,7 +5381,7 @@ n=(o==null?p.a(o):o).b
 if(1>=n.length)return A.a(n,1)
 m=n[1]
 m.toString
-m=A.dk(m,null)
+m=A.dj(m,null)
 if(2>=n.length)return A.a(n,2)
 n=n[2]
 n.toString
@@ -5398,8 +5398,8 @@ else{s=p.b
 if(1>=s.length)return A.a(s,1)
 s=s[1]
 s.toString
-o=A.dk(s,null)}s=o<=0?0:o
-n=A.W(s,null,!1,t.X)
+o=A.dj(s,null)}s=o<=0?0:o
+n=A.W(s,null,!1,t.J)
 for(m=f;;m=g){l=A.f6(a,new A.br("dup "),m)
 if(l<0)break
 k=A.f6(a,new A.br("/CharStrings"),f)
@@ -5432,7 +5432,7 @@ for(;;){if(o<q){if(!(o>=0))return A.a(a,o)
 p=a[o]
 p=p>=48&&p<=57}else p=!1
 if(!p)break;++o}if(o===r){r=o
-continue}m=A.dk(A.a0(a,r,o),null)
+continue}m=A.dj(A.a0(a,r,o),null)
 r=o
 for(;;){if(r<q){if(!(r>=0))return A.a(a,r)
 p=a[r]
@@ -5454,7 +5454,7 @@ for(;;){if(r<n){if(!(r>=0))return A.a(a,r)
 s=a[r]
 s=s>=48&&s<=57}else s=!1
 if(!s)break;++r}if(r===b)return o
-q=A.dk(A.a0(a,b,r),o)
+q=A.dj(A.a0(a,b,r),o)
 b=r
 for(;;){if(b<n){if(!(b>=0))return A.a(a,b)
 s=a[b]
@@ -5464,7 +5464,7 @@ for(;;){if(r<n){if(!(r>=0))return A.a(a,r)
 s=a[r]
 s=s>=48&&s<=57}else s=!1
 if(!s)break;++r}if(r===b)return o
-p=A.dk(A.a0(a,b,r),o)
+p=A.dj(A.a0(a,b,r),o)
 b=r
 for(;;){if(b<n){if(!(b>=0))return A.a(a,b)
 s=a[b]
@@ -5540,7 +5540,7 @@ a=A.c8(a7,p.h(0,"Range"))
 a0=B.c.K(A.q5(a7,p.h(0,"BitsPerSample"),8))
 if(b.length===0||a.length===0)return a5
 s=null
-try{s=a7.a3(a6)}catch(a1){if(t.I.b(A.I(a1)))return a5
+try{s=a7.a3(a6)}catch(a1){if(t.H.b(A.I(a1)))return a5
 else throw a1}a2=A.c8(a7,p.h(0,"Encode"))
 a3=A.c8(a7,p.h(0,"Decode"))
 p=s
@@ -5553,7 +5553,7 @@ case 4:if(!(a6 instanceof A.y))return a5
 a=A.c8(a7,p.h(0,"Range"))
 if(a.length<2)return a5
 r=null
-try{r=a7.a3(a6)}catch(a1){if(t.I.b(A.I(a1)))return a5
+try{r=a7.a3(a6)}catch(a1){if(t.H.b(A.I(a1)))return a5
 else throw a1}a4=A.wm(A.a0(r,0,a5))
 if(a4==null)return a5
 return new A.j_(a4,a,k.length>=2?k:A.b([j,i],t.n))
@@ -6003,11 +6003,11 @@ r=p.b
 o=p.c
 n=A.rh(a2,c,a,r,o,8,A.r2(a2,c))
 if(n==null)return g
-return new A.d1(n,r,o,!a1)}if(B.a.a_(b,e)){m=A.uJ(a2.bm(a3,e))
+return new A.d0(n,r,o,!a1)}if(B.a.a_(b,e)){m=A.uJ(a2.bm(a3,e))
 if(m==null)return g
 n=A.xh(m)
 if(n==null)return g
-return new A.d1(n,m.a,m.b,!0)}o=a2.j(a.h(0,"Width"))
+return new A.d0(n,m.a,m.b,!0)}o=a2.j(a.h(0,"Width"))
 l=o instanceof A.m?o.a:0
 o=a2.j(a.h(0,"Height"))
 k=o instanceof A.m?o.a:0
@@ -6019,7 +6019,7 @@ if(i==null)return g
 h=i}else h=a2.a3(a3)
 n=a0?A.xF(a2,c,h,l,k):A.rh(a2,c,h,l,k,j,A.r2(a2,c))
 if(n==null)return g
-return new A.d1(n,l,k,r&&!a1)},
+return new A.d0(n,l,k,r&&!a1)},
 p1(a,b){var s,r,q,p,o,n,m=b.a,l=a.j(m.a.h(0,"ImageMask")).I(0,B.r)
 if(!l&&A.xC(a,m))return null
 s=A.p0(a,b)
@@ -6529,7 +6529,7 @@ if(!(m<s))return A.a(f,m)
 l=f[m]
 k=q+3
 if(!(k<s))return A.a(f,k)
-j=A.d0(p/255,n/255,l/255,f[k]/255)
+j=A.d_(p/255,n/255,l/255,f[k]/255)
 l=B.c.v(j.a*255)
 if(!(q<h))return A.a(g,q)
 g[q]=l
@@ -6548,7 +6548,7 @@ if(q instanceof A.p&&q.a.ak(o)){k=q.a.h(0,o)
 break}}s=a.j(k)
 if(!(s instanceof A.y))return null
 try{n=a.a3(s)
-return n}catch(p){if(t.I.b(A.I(p)))return null
+return n}catch(p){if(t.H.b(A.I(p)))return null
 else throw p}},
 xC(a,b){var s=a.j(b.a.h(0,"SMask"))
 if(!(s instanceof A.y))return!1
@@ -6557,7 +6557,7 @@ yg(a,b){var s,r,q="DCTDecode",p=a.j(b.a.h(0,"SMask"))
 if(!(p instanceof A.y))return null
 if(!B.a.a_(A.e9(a,p.a),q))return null
 try{s=a.bm(p,q)
-return s}catch(r){if(t.I.b(A.I(r)))return null
+return s}catch(r){if(t.H.b(A.I(r)))return null
 else throw r}},
 rM(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=null,d=a.j(b.a.h(0,"SMask"))
 if(!(d instanceof A.y))return e
@@ -6582,7 +6582,7 @@ if(typeof i!=="number")return i.a5()
 if(typeof h!=="number")return A.r(h)
 h=j>=i*h
 j=h}else j=!1
-if(j)return new A.d2(p,s,r)
+if(j)return new A.d1(p,s,r)
 if(J.V(q,1)){j=s
 if(typeof j!=="number")return j.R()
 o=B.c.W(j+7,8)
@@ -6626,12 +6626,12 @@ if(typeof h!=="number")return A.r(h)
 j=l
 if(typeof j!=="number")return A.r(j)
 g=J.V(k,1)?255:0
-J.dp(n,i*h+j,g)
+J.dn(n,i*h+j,g)
 j=l
 if(typeof j!=="number")return j.R()
 l=j+1}j=m
 if(typeof j!=="number")return j.R()
-m=j+1}return new A.d2(n,s,r)}return e}catch(f){if(t.I.b(A.I(f)))return e
+m=j+1}return new A.d1(n,s,r)}return e}catch(f){if(t.H.b(A.I(f)))return e
 else throw f}},
 rN(a1,a2){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=null,a0=a1.j(a2.a.h(0,"Mask"))
 if(!(a0 instanceof A.y))return a
@@ -6699,12 +6699,12 @@ if(typeof e!=="number")return A.r(e)
 d=j
 if(typeof d!=="number")return A.r(d)
 c=h?0:255
-J.dp(l,g*e+d,c)
+J.dn(l,g*e+d,c)
 g=j
 if(typeof g!=="number")return g.R()
 j=g+1}g=k
 if(typeof g!=="number")return g.R()
-k=g+1}return new A.d2(l,s,r)}catch(b){if(t.I.b(A.I(b)))return a
+k=g+1}return new A.d1(l,s,r)}catch(b){if(t.H.b(A.I(b)))return a
 else throw b}},
 nS(a,b,c){var s,r,q,p,o,n,m,l,k=a.j(b.a.h(0,"Decode"))
 if(!(k instanceof A.o)||k.a.length<c*2)return null
@@ -6917,10 +6917,10 @@ if(!(l<c8))return A.a(c9,l)
 c9[l]=s
 s=c+3
 if(!(s<c8))return A.a(c9,s)
-c9[s]=255}return c9}b=A.di(r,0)
-a=A.di(r,1)
-a0=A.di(r,2)
-for(l=q!=null,k=b.length,i=a.length,f=a0.length,s=!s,a1=t.n,a2=t.H,g=0;g<c7;++g){d=g*3
+c9[s]=255}return c9}b=A.dh(r,0)
+a=A.dh(r,1)
+a0=A.dh(r,2)
+for(l=q!=null,k=b.length,i=a.length,f=a0.length,s=!s,a1=t.n,a2=t.o,g=0;g<c7;++g){d=g*3
 c=g*4
 if(!(d<d2))return A.a(d6,d)
 a3=d6[d]
@@ -6971,7 +6971,7 @@ a7=a6>=a7.a&&a6<=a7.b}}}a7=a7?0:255
 if(!(a4<c8))return A.a(c9,a4)
 c9[a4]=a7}return c9
 case"DeviceGray":if(d6.length<c7)return c6
-b0=A.di(r,0)
+b0=A.dh(r,0)
 b1=e0!=null&&e0.a===1?e0:c6
 d2=b1==null
 if(d2&&r==null&&q==null){for(g=0;g<c7;++g){c=g*4
@@ -6988,7 +6988,7 @@ d2=c+3
 if(!(d2<c8))return A.a(c9,d2)
 c9[d2]=255}return c9}if(d2)b3=c6
 else{d2=A.b([],t.b)
-for(s=b0.length,l=t.n,k=t.H,i=b1.b,b2=0;b2<256;++b2){if(!(b2<s))return A.a(b0,b2)
+for(s=b0.length,l=t.n,k=t.o,i=b1.b,b2=0;b2<256;++b2){if(!(b2<s))return A.a(b0,b2)
 d2.push(i.$1(k.a(A.b([b0[b2]/255],l))))}b3=d2}for(d2=q!=null,s=b0.length,l=b3!=null,g=0;g<c7;++g){c=g*4
 d=d6[g]
 k=c+1
@@ -7019,12 +7019,12 @@ if(!(k<c8))return A.a(c9,k)
 c9[k]=i}return c9
 case"DeviceCMYK":d2=d6.length
 if(d2<c8)return c6
-b=A.di(r,0)
-a=A.di(r,1)
-a0=A.di(r,2)
-b5=A.di(r,3)
+b=A.dh(r,0)
+a=A.dh(r,1)
+a0=A.dh(r,2)
+b5=A.dh(r,3)
 b6=e0!=null&&e0.a===4?e0:c6
-for(s=q!=null,l=b.length,k=a.length,i=a0.length,f=b5.length,a1=b6!=null,a2=t.n,a4=t.H,g=0;g<c7;++g){b7=g*4
+for(s=q!=null,l=b.length,k=a.length,i=a0.length,f=b5.length,a1=b6!=null,a2=t.n,a4=t.o,g=0;g<c7;++g){b7=g*4
 if(!(b7<d2))return A.a(d6,b7)
 b8=d6[b7]
 a7=b7+1
@@ -7051,7 +7051,7 @@ c3=a[b9]
 if(!(c0<i))return A.a(a0,c0)
 c4=a0[c0]
 if(!(c1<f))return A.a(b5,c1)
-c5=A.d0(c2/255,c3/255,c4/255,b5[c1]/255)}c2=B.c.v(c5.a*255)
+c5=A.d_(c2/255,c3/255,c4/255,b5[c1]/255)}c2=B.c.v(c5.a*255)
 if(!(b7<c8))return A.a(c9,b7)
 c9[b7]=c2
 c2=B.c.v(c5.b*255)
@@ -7125,7 +7125,7 @@ if(e<h.a||e>h.b)break;++q}}r+=3
 p=f?0:255
 if(!(r<j))return A.a(a2,r)
 a2[r]=p}return a2},
-di(a,b){var s
+dh(a,b){var s
 if(a==null)s=$.pj()
 else{if(!(b<a.length))return A.a(a,b)
 s=A.oP(a[b])}return s},
@@ -7244,7 +7244,7 @@ if(!(a<s))return A.a(k,a)
 a=k[a]
 a0=f+3
 if(!(a0<s))return A.a(k,a0)
-b=A.d0(e/255,c/255,a/255,k[a0]/255)
+b=A.d_(e/255,c/255,a/255,k[a0]/255)
 a0=g*3
 a=B.c.v(b.a*255)
 if(!(a0<q))return A.a(i,a0)
@@ -7300,10 +7300,10 @@ return 0},
 aH:function aH(a,b,c){this.a=a
 this.b=b
 this.c=c},
-d2:function d2(a,b,c){this.a=a
+d1:function d1(a,b,c){this.a=a
 this.b=b
 this.c=c},
-d1:function d1(a,b,c,d){var _=this
+d0:function d0(a,b,c,d){var _=this
 _.a=a
 _.b=b
 _.c=c
@@ -7337,7 +7337,7 @@ r=a[1]
 if(2>=p)return A.a(a,2)
 q=a[2]
 if(3>=p)return A.a(a,3)
-return A.d0(s,r,q,a[3])}return b},
+return A.d_(s,r,q,a[3])}return b},
 q6(a,b,c){var s=t.h,r=t.g
 return new A.hZ(b,c,a,A.iR(),A.b([],t.eK),A.x(s,t.D),A.x(s,t.fW),A.b([],t.c),A.b([],t.hM),new A.fs(t.dI),A.b([],r),B.y,B.y,A.b([],r),new A.bQ(""))},
 vk(a,b){var s,r=$.t8(),q=r.b1(0,b)
@@ -7439,7 +7439,7 @@ _.f=f
 _.r=g
 _.w=!1},
 hV:function hV(){this.a=!1},
-d_:function d_(){},
+cZ:function cZ(){},
 hZ:function hZ(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o){var _=this
 _.a=a
 _.b=b
@@ -7518,7 +7518,7 @@ break A}if(1===a){s=3*b*r*r
 break A}if(2===a){s=3*b*b*r
 break A}s=b*b*b
 break A}return s},
-d3:function d3(a,b,c){this.a=a
+d2:function d2(a,b,c){this.a=a
 this.b=b
 this.c=c},
 eU:function eU(a,b){this.a=a
@@ -8596,8 +8596,8 @@ this.b=b
 this.c=$},
 rQ(b7,b8,b9,c0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5=null,b6=b9==null?J.a6(b7):b9
 for(s=J.a9(b7),r=b8.Q,q=t.oh,p=t.M,o=t.l5,n=b8.as,m=t.ob,l=t.jL,k=c0;k<b6;++k){j=s.h(b7,k)
-if(j instanceof A.d6){B.a.i(n,!1)
-continue}if(j instanceof A.d5){i=n.length
+if(j instanceof A.d5){B.a.i(n,!1)
+continue}if(j instanceof A.d4){i=n.length
 if(i!==0){if(0>=i)return A.a(n,-1)
 i=n.pop()}else i=!1
 if(i)b8.aZ()
@@ -8664,7 +8664,7 @@ if(i){b8.cN(a6)
 continue}i=j instanceof A.bO
 a7=i?j.a:b5
 if(i){b8.z=o.a(a7)
-continue}a2=j instanceof A.cZ
+continue}a2=j instanceof A.cY
 if(a2){a=j.a
 a8=j.b
 e=a}else{a8=b5
@@ -8701,9 +8701,9 @@ a9=r.length
 if(a9!==0){if(0>=a9)return A.a(r,-1)
 r.pop()}i.$0()
 b8.aZ()}}},
-jt(a,b,c){var s=0,r=A.b3(t.o),q,p,o,n
+jt(a,b,c){var s=0,r=A.b3(t.q),q,p,o,n
 var $async$jt=A.b4(function(d,e){if(d===1)return A.b0(e,r)
-for(;;)switch(s){case 0:q=t.o,p=0
+for(;;)switch(s){case 0:q=t.q,p=0
 case 2:if(!(p<a.length)){s=4
 break}s=5
 return A.an(A.pJ(B.a7,q),$async$jt)
@@ -8717,8 +8717,8 @@ break
 case 4:return A.b1(null,r)}})
 return A.b2($async$jt,r)},
 a7:function a7(){},
-d6:function d6(){},
 d5:function d5(){},
+d4:function d4(){},
 bw:function bw(a,b,c,d){var _=this
 _.a=a
 _.b=b
@@ -8741,7 +8741,7 @@ this.b=b},
 cu:function cu(a){this.a=a},
 bo:function bo(a){this.a=a},
 bO:function bO(a){this.a=a},
-cZ:function cZ(a,b){this.a=a
+cY:function cY(a,b){this.a=a
 this.b=b},
 dL:function dL(){},
 dJ:function dJ(){},
@@ -8771,11 +8771,11 @@ B.d.ao(f,0,g,1)
 s=A.b([],t.t)
 r=A.b([],t.c)
 for(h=J.a9(a),q=0,p=0;p<g;++p){o=h.h(a,p)
-if(o instanceof A.d6){B.a.i(s,p)
+if(o instanceof A.d5){B.a.i(s,p)
 B.a.i(r,!1)
 continue}if(o instanceof A.b9){n=r.length
 if(n!==0)B.a.k(r,n-1,!0)
-continue}if(o instanceof A.d5){n=s.length
+continue}if(o instanceof A.d4){n=s.length
 if(n===0)continue
 if(0>=n)return A.a(s,-1)
 m=s.pop()
@@ -8821,8 +8821,8 @@ rb(a){var s,r=a.X(),q=A.W(r,B.q,!0,t.e)
 for(s=0;s<r;++s)B.a.k(q,s,A.xn(a))
 return q},
 xM(b3,b4,b5,b6,b7,b8,b9,c0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2=null
-A:{if(b4 instanceof A.d6){b3.B(0)
-break A}if(b4 instanceof A.d5){b3.B(1)
+A:{if(b4 instanceof A.d5){b3.B(0)
+break A}if(b4 instanceof A.d4){b3.B(1)
 break A}o=b4 instanceof A.bw
 n=b2
 m=b2
@@ -8918,7 +8918,7 @@ A.rk(b3,b,a2,a3==null?b2:a3.b)}break A}b=b4 instanceof A.bO
 a4=b?b4.a:b2
 if(b){b3.B(9)
 b3.B(a4.a)
-break A}e=b4 instanceof A.cZ
+break A}e=b4 instanceof A.cY
 if(e){h=b4.a
 a5=b4.b
 l=h}else{a5=b2
@@ -9090,7 +9090,7 @@ return new A.bo(new A.ca(l,i,!0,n,m,r===1,new A.M(q,p,o)))
 case 9:r=a.P()
 if(!(r>=0&&r<16))return A.a(B.b7,r)
 return new A.bO(B.b7[r])
-case 10:return new A.cZ(a.J(),a.P()===1)
+case 10:return new A.cY(a.J(),a.P()===1)
 case 11:return B.aG
 case 12:return B.aF
 case 13:r=a.P()
@@ -9326,7 +9326,7 @@ o=s.getFloat64(a.c+=8,!1)
 n=s.getFloat64(a.c+=8,!1)
 m=s.getFloat64(a.c+=8,!1)
 a.c+=8
-k.push(new A.d3(q,p,new A.M(o,n,m)))}return new A.eU(k,a.kR())},
+k.push(new A.d2(q,p,new A.M(o,n,m)))}return new A.eU(k,a.kR())},
 xO(a,b){var s,r,q,p,o,n
 a.bV(b.f)
 A.oY(a,b.r)
@@ -9391,7 +9391,7 @@ p=a.bm(s,A.wR(a,q))
 r.k(0,"Length",new A.m(p.length))
 return new A.y(A.aJ(r),p)}if(s instanceof A.p){r=A.x(t.N,t.l)
 s.a.al(0,new A.nd(r,a,c))
-return A.aJ(r)}if(s instanceof A.o){q=A.b([],t.q)
+return A.aJ(r)}if(s instanceof A.o){q=A.b([],t.r)
 for(o=s.a,n=o.length,m=c+1,l=0;l<o.length;o.length===n||(0,A.l)(o),++l)q.push(A.nb(a,o[l],m))
 return new A.o(q)}return s},
 wR(a,b){var s,r,q,p,o=a.j(b.a.h(0,"Filter"))
@@ -9459,7 +9459,7 @@ case 3:return new A.R(a.J())
 case 4:return new A.L(a.km(),a.P()===1)
 case 5:return new A.u(a.bU())
 case 6:r=a.X()
-q=A.b([],t.q)
+q=A.b([],t.r)
 for(p=0;p<r;++p)q.push(A.ni(a))
 return new A.o(q)
 case 8:return new A.y(t.C.a(A.ni(a)),a.dR(!0))
@@ -9551,9 +9551,9 @@ _.y=j
 _.z=k},
 l9:function l9(a,b){this.a=a
 this.b=b},
-rJ(a,b,c){A.ro(c,t.r,"T","min")
+rJ(a,b,c){A.ro(c,t.v,"T","min")
 return Math.min(c.a(a),c.a(b))},
-rI(a,b,c){A.ro(c,t.r,"T","max")
+rI(a,b,c){A.ro(c,t.v,"T","max")
 return Math.max(c.a(a),c.a(b))},
 yi(a,b){return Math.pow(a,b)},
 yk(b3,b4,b5,b6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2
@@ -10136,7 +10136,7 @@ s=a>>s>>>0}return s},
 a8(a,b){if(0>b)throw A.d(A.cL(b))
 return this.an(a,b)},
 an(a,b){return b>31?0:a>>>b},
-gag(a){return A.cj(t.r)},
+gag(a){return A.cj(t.v)},
 $ih:1,
 $ibD:1}
 J.dA.prototype={
@@ -10148,7 +10148,7 @@ $ic:1}
 J.eB.prototype={
 gag(a){return A.cj(t.i)},
 $iX:1}
-J.cT.prototype={
+J.cS.prototype={
 bB(a,b){return new A.jb(b,a,0)},
 fQ(a,b){var s=b.length,r=a.length
 if(s>r)return!1
@@ -10340,7 +10340,7 @@ if(s>=o){r.d=null
 return!1}r.d=p.aC(q,s);++r.c
 return!0},
 $ia3:1}
-A.cW.prototype={
+A.cV.prototype={
 gV(a){return new A.eH(J.bh(this.a),this.b,A.G(this).l("eH<1,2>"))},
 gp(a){return J.a6(this.a)}}
 A.eh.prototype={$iE:1}
@@ -10379,8 +10379,8 @@ return!1},
 gF(){return this.$ti.c.a(this.a.gF())},
 $ia3:1}
 A.aP.prototype={}
-A.d9.prototype={
-k(a,b,c){A.G(this).l("d9.E").a(c)
+A.d8.prototype={
+k(a,b,c){A.G(this).l("d8.E").a(c)
 throw A.d(A.bR("Cannot modify an unmodifiable list"))}}
 A.dR.prototype={}
 A.f_.prototype={
@@ -10393,7 +10393,7 @@ A.fC.prototype={$r:"+color,fontName,size(1,2,3)",$s:4}
 A.A.prototype={$r:"+(1,2,3,4)",$s:5}
 A.fD.prototype={$r:"+(1,2,3,4,5)",$s:6}
 A.fE.prototype={$r:"+(1,2,3,4,5,6,7)",$s:7}
-A.du.prototype={
+A.dt.prototype={
 gap(a){return this.gp(this)===0},
 m(a){return A.or(this)},
 $ibL:1}
@@ -10502,10 +10502,10 @@ A.ik.prototype={
 m(a){var s=this.$static_name
 if(s==null)return"Closure of unknown static method"
 return"Closure '"+A.rT(s)+"'"}}
-A.dr.prototype={
+A.dq.prototype={
 I(a,b){if(b==null)return!1
 if(this===b)return!0
-if(!(b instanceof A.dr))return!1
+if(!(b instanceof A.dq))return!1
 return this.$_target===b.$_target&&this.a===b.a},
 gD(a){return(A.fT(this.a)^A.eX(this.$_target))>>>0},
 m(a){return"Closure '"+this.$_name+"' of "+("Instance of '"+A.i7(this.a)+"'")}}
@@ -10644,8 +10644,8 @@ $ia3:1}
 A.eG.prototype={
 gp(a){return this.a.a},
 gV(a){var s=this.a
-return new A.cV(s,s.r,s.e,this.$ti.l("cV<1>"))}}
-A.cV.prototype={
+return new A.cU(s,s.r,s.e,this.$ti.l("cU<1>"))}}
+A.cU.prototype={
 gF(){return this.d},
 u(){var s,r=this,q=r.a
 if(r.b!==q.r)throw A.d(A.aX(q))
@@ -10658,8 +10658,8 @@ $ia3:1}
 A.c2.prototype={
 gp(a){return this.a.a},
 gV(a){var s=this.a
-return new A.cU(s,s.r,s.e,this.$ti.l("cU<1,2>"))}}
-A.cU.prototype={
+return new A.cT(s,s.r,s.e,this.$ti.l("cT<1,2>"))}}
+A.cT.prototype={
 gF(){var s=this.d
 s.toString
 return s},
@@ -10720,11 +10720,11 @@ cv(){return[this.a,this.b]},
 I(a,b){if(b==null)return!1
 return b instanceof A.dX&&this.$s===b.$s&&J.V(this.a,b.a)&&J.V(this.b,b.b)},
 gD(a){return A.c4(this.$s,this.a,this.b,B.h,B.h,B.h,B.h)}}
-A.dg.prototype={
+A.df.prototype={
 cv(){return[this.a,this.b,this.c]},
 I(a,b){var s=this
 if(b==null)return!1
-return b instanceof A.dg&&s.$s===b.$s&&J.V(s.a,b.a)&&J.V(s.b,b.b)&&J.V(s.c,b.c)},
+return b instanceof A.df&&s.$s===b.$s&&J.V(s.a,b.a)&&J.V(s.b,b.b)&&J.V(s.c,b.c)},
 gD(a){var s=this
 return A.c4(s.$s,s.a,s.b,s.c,B.h,B.h,B.h)}}
 A.cF.prototype={
@@ -10956,14 +10956,14 @@ h(a,b){A.ci(b,a,a.length)
 return a[b]},
 $iX:1,
 $ioB:1}
-A.cX.prototype={
+A.cW.prototype={
 gag(a){return B.h4},
 gp(a){return a.length},
 h(a,b){A.ci(b,a,a.length)
 return a[b]},
 $iX:1,
-$icX:1}
-A.cY.prototype={
+$icW:1}
+A.cX.prototype={
 gag(a){return B.h5},
 gp(a){return a.length},
 h(a,b){A.ci(b,a,a.length)
@@ -10971,7 +10971,7 @@ return a[b]},
 a1(a,b,c){return new Uint8Array(a.subarray(b,A.jj(b,c,a.length)))},
 bW(a,b){return this.a1(a,b,null)},
 $iX:1,
-$icY:1,
+$icX:1,
 $iaI:1}
 A.fu.prototype={}
 A.fv.prototype={}
@@ -11096,7 +11096,7 @@ r.l("1/?").a(a)
 s=this.a
 if((s.a&30)!==0)throw A.d(A.aS("Future already completed"))
 s.eo(r.l("1/").a(a))}}
-A.dc.prototype={
+A.db.prototype={
 l0(a){if((this.c&15)!==6)return!0
 return this.b.b.e2(t.iW.a(this.d),a.a,t.y,t.K)},
 kP(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
@@ -11111,12 +11111,12 @@ q.am(c).l("1/(2)").a(a)
 s=$.ad
 if(s===B.z){if(!t.ng.b(b)&&!t.mq.b(b))throw A.d(A.fW(b,"onError",u.c))}else{c.l("@<0/>").am(q.c).l("1(2)").a(a)
 b=A.xs(b,s)}r=new A.aq(s,c.l("aq<0>"))
-this.d1(new A.dc(r,3,a,b,q.l("@<1>").am(c).l("dc<1,2>")))
+this.d1(new A.db(r,3,a,b,q.l("@<1>").am(c).l("db<1,2>")))
 return r},
 fp(a,b,c){var s,r=this.$ti
 r.am(c).l("1/(2)").a(a)
 s=new A.aq($.ad,c.l("aq<0>"))
-this.d1(new A.dc(s,19,a,b,r.l("@<1>").am(c).l("dc<1,2>")))
+this.d1(new A.db(s,19,a,b,r.l("@<1>").am(c).l("db<1,2>")))
 return s},
 jX(a){this.a=this.a&1|16
 this.c=a},
@@ -11152,23 +11152,23 @@ else{s=r.c5()
 q.c.a(a)
 r.a=8
 r.c=a
-A.dd(r,s)}},
+A.dc(r,s)}},
 ey(a){var s,r=this
 r.$ti.c.a(a)
 s=r.c5()
 r.a=8
 r.c=a
-A.dd(r,s)},
+A.dc(r,s)},
 hX(a){var s,r,q=this
 if((a.a&16)!==0){s=q.b===a.b
 s=!(s||s)}else s=!1
 if(s)return
 r=q.c5()
 q.cp(a)
-A.dd(q,r)},
+A.dc(q,r)},
 d7(a){var s=this.c5()
 this.jX(a)
-A.dd(this,s)},
+A.dc(this,s)},
 eo(a){var s=this.$ti
 s.l("1/").a(a)
 if(s.l("bH<1>").b(a)){this.es(a)
@@ -11183,10 +11183,10 @@ d2(a){this.a^=2
 A.jn(null,null,this.b,t.M.a(new A.mk(this,a)))},
 $ibH:1}
 A.mj.prototype={
-$0(){A.dd(this.a,this.b)},
+$0(){A.dc(this.a,this.b)},
 $S:0}
 A.mo.prototype={
-$0(){A.dd(this.b,this.a.a)},
+$0(){A.dc(this.b,this.a.a)},
 $S:0}
 A.mn.prototype={
 $0(){A.mm(this.a.a,this.b,!0)},
@@ -11202,18 +11202,18 @@ $0(){var s,r,q,p,o,n,m,l,k=this,j=null
 try{q=k.a.a
 j=q.b.b.lk(t.mY.a(q.d),t.z)}catch(p){s=A.I(p)
 r=A.cM(p)
-if(k.c&&t.v.a(k.b.a.c).a===s){q=k.a
-q.c=t.v.a(k.b.a.c)}else{q=s
+if(k.c&&t.w.a(k.b.a.c).a===s){q=k.a
+q.c=t.w.a(k.b.a.c)}else{q=s
 o=r
 if(o==null)o=A.oc(q)
 n=k.a
 n.c=new A.bk(q,o)
 q=n}q.b=!0
 return}if(j instanceof A.aq&&(j.a&24)!==0){if((j.a&16)!==0){q=k.a
-q.c=t.v.a(j.c)
+q.c=t.w.a(j.c)
 q.b=!0}return}if(j instanceof A.aq){m=k.b.a
 l=new A.aq(m.b,m.$ti)
-j.h7(new A.ms(l,m),new A.mt(l),t.o)
+j.h7(new A.ms(l,m),new A.mt(l),t.q)
 q=k.a
 q.c=l
 q.b=!1}},
@@ -11244,12 +11244,12 @@ o.b=!0}},
 $S:0}
 A.mp.prototype={
 $0(){var s,r,q,p,o,n,m,l=this
-try{s=t.v.a(l.a.a.c)
+try{s=t.w.a(l.a.a.c)
 p=l.b
 if(p.a.l0(s)&&p.a.e!=null){p.c=p.a.kP(s)
 p.b=!1}}catch(o){r=A.I(o)
 q=A.cM(o)
-p=t.v.a(l.a.a.c)
+p=t.w.a(l.a.a.c)
 if(p.a===r){n=l.b
 n.c=p
 p=n}else{p=r
@@ -11266,7 +11266,7 @@ A.j1.prototype={
 lm(a){var s,r,q
 t.M.a(a)
 try{if(B.z===$.ad){a.$0()
-return}A.rd(null,null,this,a,t.o)}catch(q){s=A.I(q)
+return}A.rd(null,null,this,a,t.q)}catch(q){s=A.I(q)
 r=A.cM(q)
 A.oV(A.e0(s),t.k.a(r))}},
 fH(a){return new A.mT(this,t.M.a(a))},
@@ -11289,7 +11289,7 @@ $S:0}
 A.nj.prototype={
 $0(){A.us(this.a,this.b)},
 $S:0}
-A.de.prototype={
+A.dd.prototype={
 gV(a){var s=this,r=new A.fr(s,s.r,A.G(s).l("fr<1>"))
 r.c=s.e
 return r},
@@ -11428,7 +11428,7 @@ r.a=(r.a+=s)+": "
 s=A.v(b)
 r.a+=s},
 $S:26}
-A.d7.prototype={
+A.d6.prototype={
 T(a,b){var s,r,q
 A.G(this).l("q<1>").a(b)
 for(s=b.$ti,r=new A.bB(b.a(),s.l("bB<1>")),s=s.c;r.u();){q=r.b
@@ -11474,8 +11474,8 @@ s=A.w1(a,b,c,q)
 r.a=A.w3(a,b,c,s,0,r.a)
 return s}}
 A.h3.prototype={$ibd:1}
-A.da.prototype={}
-A.dt.prototype={}
+A.d9.prototype={}
+A.ds.prototype={}
 A.af.prototype={
 aS(a){A.G(this).l("bd<af.T>").a(a)
 throw A.d(A.bR("This converter does not support chunked conversions: "+this.m(0)))}}
@@ -11594,7 +11594,7 @@ this.cV(s.h(a,r))}}q.a+="]"},
 lr(a){var s,r,q,p,o,n,m=this,l={}
 if(a.gap(a)){m.c.a+="{}"
 return!0}s=a.gp(a)*2
-r=A.W(s,null,!1,t.iD)
+r=A.W(s,null,!1,t.X)
 q=l.a=0
 l.b=!0
 a.al(0,new A.mD(l,r))
@@ -11813,7 +11813,7 @@ A.f9.prototype={
 m(a){return"Unsupported operation: "+this.a}}
 A.is.prototype={
 m(a){return"UnimplementedError: "+this.a}}
-A.d8.prototype={
+A.d7.prototype={
 m(a){return"Bad state: "+this.a}}
 A.hc.prototype={
 m(a){var s=this.a
@@ -12292,7 +12292,7 @@ s[0]=1732584193
 s[1]=4023233417
 s[2]=2562383102
 s[3]=271733878
-return new A.da(new A.iZ(s,a,B.T,r,q,8))}}
+return new A.d9(new A.iZ(s,a,B.T,r,q,8))}}
 A.iZ.prototype={
 e8(a){var s,r,q,p,o,n={}
 if(15>=a.length)return A.a(a,15)
@@ -12344,7 +12344,7 @@ t.Z.a(a)
 s=new Uint32Array(A.H(A.b([1779033703,3144134277,1013904242,2773480762,1359893119,2600822924,528734635,1541459225],t.t)))
 r=new Uint32Array(64)
 q=new Uint8Array(64)
-return new A.da(new A.j4(s,r,a,B.N,q,new Uint32Array(16),8))}}
+return new A.d9(new A.j4(s,r,a,B.N,q,new Uint32Array(16),8))}}
 A.j5.prototype={
 e8(a0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a
 for(s=this.z,r=a0.length,q=s.$flags|0,p=0;p<16;++p){if(!(p<r))return A.a(a0,p)
@@ -12393,7 +12393,7 @@ s=new Uint32Array(A.H(A.b([3418070365,3238371032,1654270250,914150663,2438529370
 r=new Uint32Array(160)
 q=new Uint32Array(38)
 p=new Uint8Array(128)
-return new A.da(new A.ie(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
+return new A.d9(new A.ie(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
 A.j7.prototype={
 aS(a){var s,r,q,p
 t.Z.a(a)
@@ -12401,7 +12401,7 @@ s=new Uint32Array(A.H(A.b([1779033703,4089235720,3144134277,2227873595,101390424
 r=new Uint32Array(160)
 q=new Uint32Array(38)
 p=new Uint8Array(128)
-return new A.da(new A.ig(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
+return new A.d9(new A.ig(s,r,q,a,B.N,p,new Uint32Array(32),16))}}
 A.j8.prototype={
 gcM(){return J.pn(B.k.gt(this.y),0,this.gfO())},
 aF(a,b,c,d,e){var s,r,q,p
@@ -12668,7 +12668,7 @@ return"PdfRenderTrace("+("page="+-1+" "+n+" total="+(m+"ms")+" transcript="+s)+"
 A.cz.prototype={}
 A.nx.prototype={
 $1(a){var s,r,q,p,o,n,m,l,k,j,i,h
-t.J.a(a)
+t.I.a(a)
 for(s=J.a9(a),r=this.b,q=this.a,p=t.e,o=null,n=0;n<s.gp(a);++n){m=s.h(a,n)
 if(m instanceof A.bo){l=q.a
 if(l>=r.length)throw A.d(A.aS("wire transcript has more images than its source"))
@@ -12765,7 +12765,7 @@ n=t.S
 $.i2=A.W(22,0,!1,n)
 $.l5=A.W(22,0,!1,n)
 $.l3=A.W(21,0,!1,n)
-$.l4=A.W(3,0,!1,n)}$.d4=l
+$.l4=A.W(3,0,!1,n)}$.d3=l
 if(m.c){k=new A.ax()
 $.aB()
 k.ai()
@@ -12781,7 +12781,7 @@ g.kind="ready"
 g.shared=s
 if(r!=null)g.openUs=r.gac()
 b1.b.postMessage(g)
-return}if(o==="cancel"){n=A.dh(b3.id)
+return}if(o==="cancel"){n=A.dg(b3.id)
 f=n==null?b2:A.B(n)
 n=f!=null
 if(n&&f===b1.a.d){n=b1.a.e
@@ -12809,19 +12809,19 @@ return}if(o!=="record")return
 f=A.B(A.D(b3.id))
 d=A.B(A.D(b3.page))
 c=A.bf(b3.annotations)
-a4=A.dh(b3.imageRatio)
+a4=A.dg(b3.imageRatio)
 if(a4==null)a4=b2
 n=A.fN(b3.decodeImages)
 if(n==null)n=b2
-m=A.dh(b3.commandLimit)
+m=A.dg(b3.commandLimit)
 a5=m==null?b2:A.B(m)
-a6=A.dh(b3.regionLeft)
+a6=A.dg(b3.regionLeft)
 if(a6==null)a6=b2
-a7=A.dh(b3.regionBottom)
+a7=A.dg(b3.regionBottom)
 if(a7==null)a7=b2
-a8=A.dh(b3.regionRight)
+a8=A.dg(b3.regionRight)
 if(a8==null)a8=b2
-a9=A.dh(b3.regionTop)
+a9=A.dg(b3.regionTop)
 if(a9==null)a9=b2
 b0=a6!=null&&a7!=null&&a8!=null&&a9!=null?new A.aR(a6,a7,a8,a9):b2
 a2=new A.hV()
@@ -12876,7 +12876,7 @@ break
 case 3:q=2
 b0=p.pop()
 a8=A.I(b0)
-if(a8 instanceof A.d_)n=null
+if(a8 instanceof A.cZ)n=null
 else{h=a8
 g=A.cM(b0)
 n=null
@@ -12933,7 +12933,7 @@ break
 case 3:q=2
 c=p.pop()
 e=A.I(c)
-if(e instanceof A.d_)n=null
+if(e instanceof A.cZ)n=null
 else{k=e
 j=A.cM(c)
 n=null
@@ -12965,7 +12965,7 @@ for(l=k.a,l=new A.az(l,l.r,l.e,A.G(l).l("az<1>"));l.u();){j=l.d
 i=k.h(0,j)
 m=i==null?m+("\t"+e.cl(j)+"\n"):m+("\t"+e.cl(j)+": "+i.m(0)+"\n")}for(l=k.b.a,j=new A.az(l,l.r,l.e,A.G(l).l("az<1>"));j.u();){h=j.d
 m+=h+"\n"
-if(!l.ak(h))l.k(0,h,new A.dx(A.x(q,p),new A.cS(A.x(o,n))))
+if(!l.ak(h))l.k(0,h,new A.dx(A.x(q,p),new A.cR(A.x(o,n))))
 g=l.h(0,h)
 for(h=g.a,h=new A.az(h,h.r,h.e,A.G(h).l("az<1>"));h.u();){f=h.d
 i=g.h(0,f)
@@ -12998,7 +12998,7 @@ if(typeof b1!=="number")return A.r(b1)
 b1=b0+b1
 b8.d=b1
 if(a5-b1<2)break
-p=new A.dx(A.x(a6,a7),new A.cS(A.x(a8,a9)))
+p=new A.dx(A.x(a6,a7),new A.cR(A.x(a8,a9)))
 o=b8.az()
 b0=o
 if(typeof b0!=="number")return b0.a5()
@@ -13013,7 +13013,7 @@ b1=n
 if(typeof b0!=="number")return b0.a4()
 if(typeof b1!=="number")return A.r(b1)
 if(!(b0<b1))break
-J.dp(m,l,this.fb(b8,s))
+J.dn(m,l,this.fb(b8,s))
 b0=l
 if(typeof b0!=="number")return b0.R()
 l=b0+1}k=m
@@ -13021,13 +13021,13 @@ for(b0=k,b1=b0.length,b2=0;b2<b0.length;b0.length===b1||(0,A.l)(b0),++b2){j=b0[b
 if(j.b!=null){b3=j.a
 b4=j.b
 b4.toString
-J.dp(p,b3,b4)}}a3.k(0,"ifd"+A.v(q),p)
+J.dn(p,b3,b4)}}a3.k(0,"ifd"+A.v(q),p)
 b0=q
 if(typeof b0!=="number")return b0.R()
 q=b0+1
 i=b8.ar()
 if(J.V(i,r))break
-else r=i}catch(b5){break}}for(a3=new A.cV(a3,a3.r,a3.e,A.G(a3).l("cV<2>"));a3.u();){h=a3.d
+else r=i}catch(b5){break}}for(a3=new A.cU(a3,a3.r,a3.e,A.G(a3).l("cU<2>"));a3.u();){h=a3.d
 for(a5=B.bg.gbJ(),a5=a5.gV(a5);a5.u();){g=a5.gF()
 b0=A.B(g)
 if(h.a.ak(b0))try{f=J.a4(h,g).K(0)
@@ -13036,7 +13036,7 @@ b1=f
 if(typeof b0!=="number")return b0.R()
 if(typeof b1!=="number")return A.r(b1)
 b8.d=b0+b1
-e=new A.dx(A.x(a6,a7),new A.cS(A.x(a8,a9)))
+e=new A.dx(A.x(a6,a7),new A.cR(A.x(a8,a9)))
 d=b8.az()
 c=d
 b1=c
@@ -13048,7 +13048,7 @@ b1=c
 if(typeof b0!=="number")return b0.a4()
 if(typeof b1!=="number")return A.r(b1)
 if(!(b0<b1))break
-J.dp(b,a,this.fb(b8,s))
+J.dn(b,a,this.fb(b8,s))
 b0=a
 if(typeof b0!=="number")return b0.R()
 a=b0+1}a0=b
@@ -13056,7 +13056,7 @@ for(b0=a0,b1=b0.length,b2=0;b2<b0.length;b0.length===b1||(0,A.l)(b0),++b2){a1=b0
 if(a1.b!=null){b3=a1.a
 b4=a1.b
 b4.toString
-J.dp(e,b3,b4)}}b0=h.b
+J.dn(e,b3,b4)}}b0=h.b
 b1=B.bg.h(0,g)
 b1.toString
 b0.a.k(0,b1,a9.a(e))}catch(b5){continue}}}b8.e=b7
@@ -13117,7 +13117,7 @@ i.b=o}break}a.d=q+4
 return i}}
 A.iO.prototype={}
 A.hn.prototype={}
-A.cS.prototype={}
+A.cR.prototype={}
 A.dx.prototype={
 h(a,b){var s=this.a.h(0,b)
 return s},
@@ -13377,7 +13377,7 @@ K(a){return this.a},
 m(a){return"Ifd@"+this.a}}
 A.hb.prototype={}
 A.ck.prototype={}
-A.cR.prototype={}
+A.cQ.prototype={}
 A.em.prototype={}
 A.kl.prototype={}
 A.cm.prototype={}
@@ -13691,11 +13691,11 @@ B.a.i(k,r)
 for(;k.length<=o;r=l){m=A.W(2,null,!1,s)
 l=new A.dV(m)
 B.a.i(k,l)
-B.a.k(r.a,r.b,new A.cR(m))}++p}++o
+B.a.k(r.a,r.b,new A.cQ(m))}++p}++o
 if(o<j){m=A.W(2,null,!1,s)
 l=new A.dV(m)
 B.a.i(k,l)
-B.a.k(r.a,r.b,new A.cR(m))
+B.a.k(r.a,r.b,new A.cQ(m))
 r=l}}if(0>=k.length)return A.a(k,0)
 return k[0].a},
 hM(a0,a1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=a1.e
@@ -13706,7 +13706,7 @@ r=a<<3>>>0
 q=new Int32Array(64)
 p=new Uint8Array(64)
 o=s*8
-n=A.W(o,null,!1,t.X)
+n=A.W(o,null,!1,t.J)
 for(m=a1.c,l=a1.d,k=0,j=0;j<s;++j){i=j<<3>>>0
 for(h=0;h<8;++h,k=g){g=k+1
 B.a.k(n,k,new Uint8Array(r))}for(f=0;f<a;++f){if(!(l<4))return A.a(m,l)
@@ -13817,8 +13817,8 @@ r.ay=s
 if(s===255)if(q.aw()!==0)return null
 r.ch=7
 return r.ay>>>7&1},
-c0(a){var s,r,q=new A.cR(t.hQ.a(a))
-while(s=this.bg(),s!=null){if(q instanceof A.cR){r=q.a
+c0(a){var s,r,q=new A.cQ(t.hQ.a(a))
+while(s=this.bg(),s!=null){if(q instanceof A.cQ){r=q.a
 if(s>>>0!==s||s>=2)return A.a(r,s)
 q=r[s]}if(q instanceof A.em)return q.a}return null},
 dC(a){var s,r
@@ -14064,7 +14064,7 @@ return s},
 $S:23}
 A.jJ.prototype={
 fg(){var s,r=this
-if(!r.r){s=$.d4
+if(!r.r){s=$.d3
 s=!s}else s=!0
 if(s)return
 r.r=!0
@@ -14093,10 +14093,10 @@ continue A
 case"null":B.a.i(l.d,B.n)
 continue A
 case"BI":m=A.uf(s)
-l.d=A.b([],t.q)
+l.d=A.b([],t.r)
 return l.eA(m)
 default:s=l.d
-l.d=A.b([],t.q)
+l.d=A.b([],t.r)
 return l.eA(new A.aZ(n,s))}default:B.a.i(l.d,A.hd(s,r))}}},
 eA(a){var s=this,r=++s.e,q=s.a
 if(q!=null&&r>=q){s.f=!0
@@ -14329,7 +14329,7 @@ m=k.w
 if(m!=null&&a!==k.x)m.cL(r,a,q.b)}break
 case 2:p=null
 try{p=k.f_(s.d).l2(a,s.e)}catch(l){m=A.I(l)
-if(m instanceof A.cP)p=B.n
+if(t.H.b(m))p=B.n
 else if(t.b0.b(m))p=B.n
 else throw l}r=p
 break}}finally{o.b1(0,a)}if(r instanceof A.y)r.c=j
@@ -14340,7 +14340,7 @@ try{s=new A.c_(new A.bG(this.a,a+this.b),this.gfh(),A.b([],t.O))
 r=s.h1()
 q=r.a===b?r:null
 return q}catch(p){q=A.I(p)
-if(t.I.b(q))return null
+if(t.H.b(q))return null
 else if(t.b0.b(q))return null
 else throw p}},
 jk(a){var s,r,q,p=this
@@ -14404,7 +14404,7 @@ p=k
 n=p.c
 o=n.length!==0?B.a.ae(n,0):p.a.L()
 if(o.a!==B.w)A.Q(A.z(l+o.m(0),o.b))
-B.a.i(s,new A.j(q,A.B(o.c)))}catch(m){if(A.I(m) instanceof A.cP)break
+B.a.i(s,new A.j(q,A.B(o.c)))}catch(m){if(A.I(m) instanceof A.du)break
 else throw m}},
 l2(a,b){var s,r,q,p,o=this,n=o.c
 n=b<n.length&&n[b].a===a
@@ -14415,14 +14415,14 @@ if(s==null)for(n=o.c,r=n.length,q=0;q<r;++q){p=n[q]
 if(p.a===a){s=p
 break}}if(s==null)throw A.d(A.z("object "+a+" not found in its object stream",null))
 return new A.c_(new A.bG(o.a,o.b+s.b),null,A.b([],t.O)).bn()}}
-A.cP.prototype={
+A.du.prototype={
 m(a){var s=this.b,r=this.a
 return s==null?"CosParseException: "+r:"CosParseException at byte "+A.v(s)+": "+r},
 $iaa:1}
 A.iu.prototype={
 m(a){return"UnsupportedFilterException: "+this.a},
 $iaa:1}
-A.cQ.prototype={
+A.cP.prototype={
 m(a){return"CosPasswordException: password required or incorrect"},
 $iaa:1}
 A.f8.prototype={
@@ -15510,34 +15510,34 @@ A.iA.prototype={
 hN(a8,a9,b0,b1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=this,a5=a4.a,a6=a5.a,a7=a6===0
 if(a7){s=a5.b
 s===$&&A.k()
-a4.f!==$&&A.dm()
+a4.f!==$&&A.dl()
 a4.f=s
 s=a5.c
 s===$&&A.k()
-a4.r!==$&&A.dm()
+a4.r!==$&&A.dl()
 a4.r=s
 s=a5.d
 s===$&&A.k()
-a4.w!==$&&A.dm()
+a4.w!==$&&A.dl()
 a4.w=s
 s=a5.e
 s===$&&A.k()
-a4.x!==$&&A.dm()
+a4.x!==$&&A.dl()
 a4.x=s}else{r=B.b.M(1,b1+1)
 q=B.b.M(1,b1)
 s=q*a9
 p=B.c.E((a8.a-s)/r)
-a4.f!==$&&A.dm()
+a4.f!==$&&A.dl()
 a4.f=p
 p=q*b0
 o=B.c.E((a8.b-p)/r)
-a4.r!==$&&A.dm()
+a4.r!==$&&A.dl()
 a4.r=o
 s=B.c.E((a8.c-s)/r)
-a4.w!==$&&A.dm()
+a4.w!==$&&A.dl()
 a4.w=s
 p=B.c.E((a8.d-p)/r)
-a4.x!==$&&A.dm()
+a4.x!==$&&A.dl()
 a4.x=p
 s=p}p=a8.e
 o=p.z
@@ -16561,7 +16561,7 @@ if(r.a===B.o&&r.c==="endobj")q.L()
 return new A.jQ(p,o,s)},
 ja(){var s,r,q,p=this
 p.L()
-s=A.b([],t.q)
+s=A.b([],t.r)
 for(;;){r=p.bc()
 q=r.a
 if(q===B.aM){q=p.c
@@ -16672,11 +16672,11 @@ A.bs.prototype={}
 A.hg.prototype={}
 A.jT.prototype={}
 A.jU.prototype={
-lp(a){var s,r,q,p,o,n,m=t.S,l=A.x(m,t.w),k=A.aJ(null),j=this.b,i=A.b([a+j],t.t),h=A.aK(m)
+lp(a){var s,r,q,p,o,n,m=t.S,l=A.x(m,t.x),k=A.aJ(null),j=this.b,i=A.b([a+j],t.t),h=A.aK(m)
 for(s=!1;i.length!==0;){r=B.a.ae(i,0)
 if(!h.i(0,r))continue
 q=this.l6(r)
-for(m=q.a,m=new A.cU(m,m.r,m.e,A.G(m).l("cU<1,2>"));m.u();){p=m.d
+for(m=q.a,m=new A.cT(m,m.r,m.e,A.G(m).l("cT<1,2>"));m.u();){p=m.d
 l.ad(p.a,new A.k0(p))}if(!s){k=q.b
 s=!0}m=q.b.a
 o=m.h(0,"XRefStm")
@@ -16908,7 +16908,7 @@ fL(){var s,r,q,p,o,n,m,l,k=this.a.a,j=k.j(this.b.a.h(0,"Contents")),i=A.b([],t.m
 if(j instanceof A.y)B.a.i(i,j)
 if(j instanceof A.o)for(q=j.a,p=q.length,o=0;o<q.length;q.length===p||(0,A.l)(q),++o){n=k.j(q[o])
 if(n instanceof A.y)B.a.i(i,n)}m=new A.b_($.aW())
-for(q=i.length,p=t.I,o=0;o<i.length;i.length===q||(0,A.l)(i),++o){s=i[o]
+for(q=i.length,p=t.H,o=0;o<i.length;i.length===q||(0,A.l)(i),++o){s=i[o]
 r=null
 try{r=k.a3(s)}catch(l){if(p.b(A.I(l)))continue
 else throw l}if(m.gcf(0))m.ab(10)
@@ -16952,7 +16952,7 @@ for(r=a.length,q=0;q<a.length;a.length===r||(0,A.l)(a),++q)s.push(a[q]/255)
 return this.a9(s)}}
 A.iE.prototype={
 a9(a){var s,r
-t.H.a(a)
+t.o.a(a)
 s=J.a9(a)
 r=s.gap(a)?0:B.c.n(s.h(a,0),0,1)
 s=this.b
@@ -16961,7 +16961,7 @@ s=B.c.n(Math.max(295.8*Math.pow(s[1]*Math.pow(r,this.c),0.3333333333333333)-40.8
 return new A.M(s,s,s)}}
 A.iF.prototype={
 a9(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b=this
-t.H.a(a)
+t.o.a(a)
 s=A.oD(a,0)
 r=A.oD(a,1)
 q=A.oD(a,2)
@@ -16996,7 +16996,7 @@ $1(a){return A.D(a)<0},
 $S:16}
 A.iV.prototype={
 a9(a){var s,r,q,p,o,n,m,l,k,j,i
-t.H.a(a)
+t.o.a(a)
 s=J.a9(a)
 r=B.c.n(s.gcf(a)?s.h(a,0):0,0,100)
 q=s.gp(a)>1?s.h(a,1):0
@@ -17061,20 +17061,20 @@ A.kB.prototype={
 $0(){return A.pZ(this.a,this.b)},
 $S:51}
 A.cE.prototype={
-a9(a){return A.jr(t.H.a(a),this.b)},
+a9(a){return A.jr(t.o.a(a),this.b)},
 gaN(){return this.b}}
 A.fz.prototype={
 gaN(){return 0},
-a9(a){t.H.a(a)
+a9(a){t.o.a(a)
 return B.F}}
 A.fi.prototype={
 gaN(){return this.b.a},
-a9(a){return this.b.a9(t.H.a(a))},
+a9(a){return this.b.a9(t.o.a(a))},
 bL(a){return this.b.bL(t.L.a(a))}}
 A.fn.prototype={
 gfT(){return this.a},
 a9(a){var s
-t.H.a(a)
+t.o.a(a)
 s=this.a
 if(s!=null&&J.a6(a)===s.a)return s.b.$1(a)
 return A.jr(a,this.b)},
@@ -17082,7 +17082,7 @@ gaN(){return this.b}}
 A.fo.prototype={
 gaN(){return 1},
 a9(a){var s,r,q,p,o,n,m,l,k,j,i=this
-t.H.a(a)
+t.o.a(a)
 s=J.a9(a)
 r=B.c.v(s.gap(a)?0:s.h(a,0))
 if(r<0)r=0
@@ -17097,7 +17097,7 @@ for(m=i.c,l=m.length,k=0;k<p;++k){j=o+k
 if(!(j>=0&&j<l))return A.a(m,j)
 n.push(m[j])}return s.bL(n)}}
 A.dY.prototype={
-a9(a){return this.d.a9(this.c.bF(t.H.a(a)))},
+a9(a){return this.d.a9(this.c.bF(t.o.a(a)))},
 gaN(){return this.b}}
 A.at.prototype={
 aL(){return"PdfBlendMode."+this.b}}
@@ -17781,7 +17781,7 @@ a=r
 if(typeof b!=="number")return b.a4()
 if(typeof a!=="number")return A.r(a)
 if(!(b<a))break
-J.dq(q,s.H())
+J.dp(q,s.H())
 b=p
 if(typeof b!=="number")return b.R()
 p=b+1}o=q
@@ -17813,10 +17813,10 @@ q=s
 b=q.a
 q=q.b++
 if(!(q>=0&&q<b.length))return A.a(b,q)
-J.dq(k,b[q])
+J.dp(k,b[q])
 q=j
 if(typeof q!=="number")return q.R()
-j=q+1}J.dq(n,A.a0(k,0,null))}i=A.x(t.N,t.S)
+j=q+1}J.dp(n,A.a0(k,0,null))}i=A.x(t.N,t.S)
 h=0
 for(;;){q=h
 k=r
@@ -17970,7 +17970,7 @@ l=q.X()
 i=r.a
 h=l
 if(typeof h!=="number")return A.r(h)
-J.dq(s,new A.db(k,i+h,n,m))
+J.dp(s,new A.da(k,i+h,n,m))
 i=o
 if(typeof i!=="number")return i.R()
 o=i+1}}catch(g){}return f.w=s}}
@@ -17997,7 +17997,7 @@ $1(a){var s=this.a,r=J.a9(s)
 return r.h(s,B.b.ah(a,r.gp(s)))},
 $S:58}
 A.bA.prototype={}
-A.db.prototype={
+A.da.prototype={
 cS(a){var s,r,q,p,o,n,m,l,k,j,i,h,g
 try{j=new A.cg(this.a)
 j.b=this.b
@@ -18395,7 +18395,7 @@ if(5>=p)return A.a(q,5)
 return a*s+b*r+q[5]}}
 A.c7.prototype={
 bF(a){var s
-t.H.a(a)
+t.o.a(a)
 s=J.a9(a)
 return this.aO(s.gap(a)?0:s.h(a,0))}}
 A.iH.prototype={
@@ -18403,7 +18403,7 @@ aO(a){var s,r,q,p=A.b([],t.n)
 for(s=this.a,r=s.length,q=0;q<s.length;s.length===r||(0,A.l)(s),++q)B.a.T(p,s[q].aO(a))
 return p},
 bF(a){var s,r,q,p
-t.H.a(a)
+t.o.a(a)
 s=A.b([],t.n)
 for(r=this.a,q=r.length,p=0;p<r.length;r.length===q||(0,A.l)(r),++p)B.a.T(s,r[p].bF(a))
 return s}}
@@ -18470,7 +18470,7 @@ q=(q<<1|B.b.a8(s[n],7-(o&7))&1)>>>0}return q}}
 A.j_.prototype={
 aO(a){return this.bF(A.b([a],t.n))},
 bF(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b
-t.H.a(a)
+t.o.a(a)
 o=this.d
 s=o.length/2|0
 n=A.b([],t.f)
@@ -18495,7 +18495,7 @@ n=p
 if(typeof n!=="number")return n.a5()
 n*=2
 if(n>>>0!==n||n>=o.length)return A.a(o,n)
-J.dq(q,o[n])
+J.dp(q,o[n])
 n=p
 if(typeof n!=="number")return n.R()
 p=n+1}return q}d=A.b([],t.n)
@@ -18573,7 +18573,7 @@ A.kb.prototype={
 $1(a){return this.a.h(0,a)},
 $S:65}
 A.k8.prototype={
-$1(a){var s,r,q,p,o=this.a.ki(t.H.a(a))
+$1(a){var s,r,q,p,o=this.a.ki(t.o.a(a))
 if(this.b==="Lab "){s=o.length
 if(0>=s)return A.a(o,0)
 r=o[0]
@@ -18590,12 +18590,12 @@ if(2>=s)return A.a(p,2)
 return A.pL(r,q,p[2])},
 $S:3}
 A.k9.prototype={
-$1(a){var s=A.kc(this.a.a.$1(B.c.n(J.a4(t.H.a(a),0),0,1)))
+$1(a){var s=A.kc(this.a.a.$1(B.c.n(J.a4(t.o.a(a),0),0,1)))
 return new A.M(s,s,s)},
 $S:3}
 A.ka.prototype={
 $1(a){var s,r,q,p,o,n,m=this
-t.H.a(a)
+t.o.a(a)
 s=J.a9(a)
 r=m.a.a.$1(B.c.n(s.h(a,0),0,1))
 q=m.b.a.$1(B.c.n(s.h(a,1),0,1))
@@ -18651,7 +18651,7 @@ return a>=s.a?Math.pow(s.b*a+s.c,s.d)+s.e:s.f*a+s.r},
 $S:1}
 A.iX.prototype={
 ki(a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3=this
-t.H.a(a4)
+t.o.a(a4)
 s=t.n
 r=A.b([],s)
 for(q=a3.a,p=a3.c,o=J.a9(a4),n=0;n<q;++n){if(!(n<p.length))return A.a(p,n)
@@ -18701,7 +18701,7 @@ return s},
 $S:28}
 A.mE.prototype={
 $2(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f
-if(a===0){s=J.dz(b,t.H)
+if(a===0){s=J.dz(b,t.o)
 for(r=0;r<b;++r)s[r]=$.to()
 return s}q=A.b([],t.iA)
 p=this.a+a
@@ -18716,8 +18716,8 @@ else f=g==="para"?12+4*B.a.h(B.dX,Math.min(m.getUint16(p+8,!1),4)):12
 p+=(f+3&4294967292)>>>0}return q},
 $S:67}
 A.aH.prototype={}
-A.d2.prototype={}
 A.d1.prototype={}
+A.d0.prototype={}
 A.kM.prototype={}
 A.mh.prototype={}
 A.nT.prototype={
@@ -18726,14 +18726,14 @@ return a.a===0&&a.b===1},
 $S:68}
 A.fm.prototype={
 sfM(a){this.a=t.ge.a(a)},
-skO(a){this.y=t.H.a(a)}}
+skO(a){this.y=t.o.a(a)}}
 A.lS.prototype={}
 A.hV.prototype={}
-A.d_.prototype={$iaa:1}
+A.cZ.prototype={$iaa:1}
 A.hZ.prototype={
 cd(a,b,c,d){return this.kD(a,b,c,d)},
 kC(a,b,c){return this.cd(a,b,null,c)},
-kD(a,b,c,d){var s=0,r=A.b3(t.o),q=1,p=[],o=[],n=this,m,l,k,j
+kD(a,b,c,d){var s=0,r=A.b3(t.q),q=1,p=[],o=[],n=this,m,l,k,j
 var $async$cd=A.b4(function(e,f){if(e===1){p.push(f)
 s=q}for(;;)switch(s){case 0:if(d<=0)throw A.d(A.fW(d,"yieldInterval","must be > 0"))
 n.e=A.iR()
@@ -19003,7 +19003,7 @@ for(r=a.c,q=-o,s=!0;m<r;){m=Math.min(r,m+n)
 B.a.i(l,new A.O(m,p+(s?o:q)))
 s=!s}return new A.ak(l)},
 is(b3,b4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1=this,b2=null
-try{b2=b1.a.a3(b3)}catch(k){if(t.I.b(A.I(k)))return
+try{b2=b1.a.a3(b3)}catch(k){if(t.H.b(A.I(k)))return
 else throw k}s=b3.a
 j=b1.a
 i=j.j(s.a.h(0,"Matrix"))
@@ -19075,7 +19075,7 @@ if(!(p>o))break
 if(0>=p)return A.a(q,-1)
 q.pop()}n.at=s}},
 cD(a,b,c,d){return this.jR(a,b,c,d)},
-jR(a,b,c,d){var s=0,r=A.b3(t.o),q,p=2,o=[],n=[],m=this,l,k,j,i,h
+jR(a,b,c,d){var s=0,r=A.b3(t.q),q,p=2,o=[],n=[],m=this,l,k,j,i,h
 var $async$cD=A.b4(function(e,f){if(e===1){o.push(f)
 s=p}for(;;)A:switch(s){case 0:j=m.at
 i=m.x
@@ -19110,10 +19110,10 @@ break
 case 5:case 1:return A.b1(q,r)
 case 2:return A.b0(o.at(-1),r)}})
 return A.b2($async$cD,r)},
-cE(a,b,c,d){var s=0,r=A.b3(t.o),q,p=this,o,n,m,l,k
+cE(a,b,c,d){var s=0,r=A.b3(t.q),q,p=this,o,n,m,l,k
 var $async$cE=A.b4(function(e,f){if(e===1)return A.b0(f,r)
 for(;;)switch(s){case 0:k=p.c
-o=t.o,n=0
+o=t.q,n=0
 case 3:m=a.fY()
 if(m==null){s=1
 break}++n
@@ -19213,9 +19213,9 @@ r.c=new A.M(q,q,q)
 break A}if("rg"===s){a1.e.b=new A.M(A.w(a3,0),A.w(a3,1),A.w(a3,2))
 a1.e.x=null
 break A}if("RG"===s){a1.e.c=new A.M(A.w(a3,0),A.w(a3,1),A.w(a3,2))
-break A}if("k"===s){a1.e.b=A.d0(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
+break A}if("k"===s){a1.e.b=A.d_(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
 a1.e.x=null
-break A}if("K"===s){a1.e.c=A.d0(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
+break A}if("K"===s){a1.e.c=A.d_(A.w(a3,0),A.w(a3,1),A.w(a3,2),A.w(a3,3))
 break A}if("cs"===s){r=a1.e
 q=r.x=null
 n=a3.length
@@ -19574,7 +19574,7 @@ if(r==null)r=B.bX
 q=t.M.a(new A.kT(this,a))
 p=A.b([],t.lO)
 o=s.gG()
-n=t.J
+n=t.I
 s.c=n.a(p)
 q.$0()
 s.c=n.a(o)
@@ -19582,7 +19582,7 @@ B.a.i(s.gG(),new A.aQ(a.c,r,p,a.d,a.e,a.f))},
 jT(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c=this
 if(c.at>=16)return
 s=null
-try{s=c.a.a3(a.a)}catch(j){if(t.I.b(A.I(j)))return
+try{s=c.a.a3(a.a)}catch(j){if(t.H.b(A.I(j)))return
 else throw j}r=c.e
 i=c.f
 q=i.length
@@ -19604,7 +19604,7 @@ if(!(e<4))break
 e=A.B(m)
 d=o.a
 if(!(e>=0&&e<d.length))return A.a(d,e)
-J.dq(n,A.ai(g.j(d[e])))
+J.dp(n,A.ai(g.j(d[e])))
 e=m
 if(typeof e!=="number")return e.R()
 m=e+1}c.co(n)}l=g.j(f.h(0,"Resources"))
@@ -19722,7 +19722,7 @@ s=s==null?o:s.gcJ()}return s},
 fq(a){var s,r,q,p,o,n,m,l,k,j=this,i=null,h=j.a.j(a.a.a.h(0,"PaintType"))
 if(h instanceof A.m&&h.a===2){r=j.e.y
 return r.length!==0?A.jr(r,i):i}s=null
-try{s=j.r.ad(a,new A.kY(j,a))}catch(q){if(t.I.b(A.I(q)))return i
+try{s=j.r.ad(a,new A.kY(j,a))}catch(q){if(t.H.b(A.I(q)))return i
 else throw q}for(r=J.bh(s),p=i;r.u();){o=r.gF()
 n=o.b
 switch(o.a){case"g":o=0<n.length?A.ai(n[0]):0
@@ -19737,7 +19737,7 @@ case"k":o=n.length
 m=0<o?A.ai(n[0]):0
 l=1<o?A.ai(n[1]):0
 k=2<o?A.ai(n[2]):0
-p=A.d0(m,l,k,3<o?A.ai(n[3]):0)
+p=A.d_(m,l,k,3<o?A.ai(n[3]):0)
 break}}return p},
 iV(a){var s,r,q,p=this.dv(a)
 if(p==null)return null
@@ -19962,7 +19962,7 @@ a1=a5.f
 B.a.i(a1,A.oF(a0))
 a0=a5.b
 B.a.i(a0.gG(),B.q)
-if(r){B.a.i(a0.gG(),new A.cZ(e,b))
+if(r){B.a.i(a0.gG(),new A.cY(e,b))
 a2=a5.e
 a2.e=a2.d=1}try{p=i.j(s.a.a.h(0,"Matrix"))
 if(p instanceof A.o&&p.a.length>=6)a5.e.a=A.eS(p.a).a6(a5.e.a)
@@ -19975,12 +19975,12 @@ if(!(a2<4))break
 a2=A.B(m)
 a3=o.a
 if(!(a2>=0&&a2<a3.length))return A.a(a3,a2)
-J.dq(n,A.ai(i.j(a3[a2])))
+J.dp(n,A.ai(i.j(a3[a2])))
 a2=m
 if(typeof a2!=="number")return a2.R()
 m=a2+1}a5.co(n)}l=i.j(s.a.a.h(0,"Resources"))
 k=null
-try{k=i.a3(s)}catch(a4){if(t.I.b(A.I(a4)))return
+try{k=i.a3(s)}catch(a4){if(t.H.b(A.I(a4)))return
 else throw a4}n=A.ef(k)
 i=l instanceof A.p?l:a6
 a5.c6(n,i,a8+1)}finally{j=a5.e.z
@@ -19990,7 +19990,7 @@ if(0>=a1.length)return A.a(a1,-1)
 a5.e=a1.pop()
 B.a.i(a0.gG(),B.v)}},
 co(a){var s,r,q,p,o,n,m,l,k,j,i,h
-t.H.a(a)
+t.o.a(a)
 s=this.e.a
 r=a.length
 if(0>=r)return A.a(a,0)
@@ -20048,7 +20048,7 @@ A.kQ.prototype={
 $1(a){var s,r
 try{s=this.a
 s=s.r.ad(a,new A.kP(s,a))
-return s}catch(r){if(t.I.b(A.I(r)))return B.b8
+return s}catch(r){if(t.H.b(A.I(r)))return B.b8
 else throw r}},
 $S:70}
 A.kP.prototype={
@@ -20098,7 +20098,7 @@ $S:11}
 A.kS.prototype={
 $0(){var s,r
 try{s=A.ef(this.a.a.a3(this.b))
-return s}catch(r){if(t.I.b(A.I(r)))return B.b8
+return s}catch(r){if(t.H.b(A.I(r)))return B.b8
 else throw r}},
 $S:11}
 A.kO.prototype={
@@ -20109,7 +20109,7 @@ s=B.em.h(0,a)
 if(s==null)s=a
 this.a.k(0,s,b)},
 $S:8}
-A.d3.prototype={}
+A.d2.prototype={}
 A.eU.prototype={
 gcJ(){var s,r,q,p,o,n,m
 for(s=this.a,r=s.length,q=0,p=0,o=0,n=0;n<r;++n){m=s[n].c
@@ -20140,7 +20140,7 @@ for(;;){if(!(l<(m?1:o)))break
 r.push(s.da(q.aP(p),p,2+l));++l}if(m){if(0>=r.length)return A.a(r,0)
 return s.x.$1(n.aO(r[0]))}return s.x.$1(r)},
 c3(){var s=this.bA()
-return new A.d3(s.a,s.b,this.fa())},
+return new A.d2(s.a,s.b,this.fa())},
 je(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
 for(s=e.z,r=e.d,q=s.a.length,p=e.as,o=t.t,n=e.Q,m=null,l=null,k=null;(q-s.b)*8-s.c>=r;){j=s.aP(r)
 if(j===0){B.a.i(n,e.c3())
@@ -20257,7 +20257,7 @@ a1=f+(e.b-f)*n
 g=g.c
 c=c.c
 a2=g+(e.c-g)*n
-B.a.i(s,new A.d3(m,l,new A.M(a+(b+(d.a-b)*n-a)*p,a1+(a0+(d.b-a0)*n-a1)*p,a2+(c+(d.c-c)*n-a2)*p)))}}for(s=this.as,g=t.t,q=0;q<8;++q)for(f=r+q*9,o=0;o<8;++o){a3=f+o
+B.a.i(s,new A.d2(m,l,new A.M(a+(b+(d.a-b)*n-a)*p,a1+(a0+(d.b-a0)*n-a1)*p,a2+(c+(d.c-c)*n-a2)*p)))}}for(s=this.as,g=t.t,q=0;q<8;++q)for(f=r+q*9,o=0;o<8;++o){a3=f+o
 a4=a3+1
 a5=a3+9
 B.a.T(s,A.b([a3,a4,a5],g))
@@ -21865,8 +21865,8 @@ cN(a){B.a.i(this.b,a)
 B.a.i(this.gG(),new A.bo(a))},
 $ikD:1}
 A.a7.prototype={}
-A.d6.prototype={}
 A.d5.prototype={}
+A.d4.prototype={}
 A.bw.prototype={}
 A.cw.prototype={}
 A.cv.prototype={}
@@ -21875,7 +21875,7 @@ A.b9.prototype={}
 A.cu.prototype={}
 A.bo.prototype={}
 A.bO.prototype={}
-A.cZ.prototype={}
+A.cY.prototype={}
 A.dL.prototype={}
 A.dJ.prototype={}
 A.aQ.prototype={}
@@ -21885,7 +21885,7 @@ $S:0}
 A.fL.prototype={$iaa:1}
 A.na.prototype={
 $1(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
-for(s=J.bh(t.J.a(a)),r=e.d,q=e.a,p=e.c,o=e.b,n=o==null;s.u();){m=s.gF()
+for(s=J.bh(t.I.a(a)),r=e.d,q=e.a,p=e.c,o=e.b,n=o==null;s.u();){m=s.gF()
 if(m instanceof A.bo){l=n?null:A.r3(p,m.a,o,r,1)
 if(l!=null)q.a=q.a+l.f*l.r
 else{m=m.a
@@ -21967,7 +21967,7 @@ hh(a){if(a==null)this.B(0)
 else{this.B(1)
 this.bV(a)}},
 dZ(a){var s,r,q,p,o,n=this
-t.H.a(a)
+t.o.a(a)
 n.a7(a.length)
 n.Z(a.length*8)
 for(s=a.length,r=0;r<a.length;a.length===s||(0,A.l)(a),++r){q=a[r]
@@ -22026,7 +22026,7 @@ else r=!0
 if(r)return null
 r=new A.l9(n,l)
 s=null
-try{s=n.a3(m)}catch(q){if(t.I.b(A.I(q)))return null
+try{s=n.a3(m)}catch(q){if(t.H.b(A.I(q)))return null
 else throw q}p=s
 return new A.l_(k,r.$2("BitsPerCoordinate",16),r.$2("BitsPerComponent",8),r.$2("BitsPerFlag",8),A.l7(n,l.a.h(0,"Decode")),o.d,r.$2("VerticesPerRow",0),o.c,o.e,a,new A.m4(p),A.b([],t.ai),A.b([],t.t)).l5()},
 e4(a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=this,a5=a4.c,a6=!0
@@ -22048,7 +22048,7 @@ if(0>=b)return A.a(s,0)
 a=s[0]
 if(1>=b)return A.a(s,1)
 a0=a+(s[1]-a)*c/24
-B.a.i(p,new A.d3(m*a0+f+k,j*a0+e+h,n.$1(a5.bF(A.b([a0,d],a6)))))}}for(g=0;g<24;++g)for(a6=g*25,c=0;c<24;++c){a1=a6+c
+B.a.i(p,new A.d2(m*a0+f+k,j*a0+e+h,n.$1(a5.bF(A.b([a0,d],a6)))))}}for(g=0;g<24;++g)for(a6=g*25,c=0;c<24;++c){a1=a6+c
 a2=a1+1
 a3=a1+24+1
 B.a.i(o,a1)
@@ -22101,33 +22101,33 @@ p(A.fn.prototype,"gbK","a9",3)
 p(A.fo.prototype,"gbK","a9",3)
 p(A.dY.prototype,"gbK","a9",3)
 p(A.hZ.prototype,"geH","dg",23)
-o(A,"rH",2,null,["$1$2","$2"],["rJ",function(a,b){return A.rJ(a,b,t.r)}],27,0)
-o(A,"rG",2,null,["$1$2","$2"],["rI",function(a,b){return A.rI(a,b,t.r)}],27,0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
+o(A,"rH",2,null,["$1$2","$2"],["rJ",function(a,b){return A.rJ(a,b,t.v)}],27,0)
+o(A,"rG",2,null,["$1$2","$2"],["rI",function(a,b){return A.rI(a,b,t.v)}],27,0)})();(function inheritance(){var s=hunkHelpers.mixin,r=hunkHelpers.inherit,q=hunkHelpers.inheritMany
 r(A.K,null)
-q(A.K,[A.om,J.hB,A.f0,J.ed,A.b_,A.dT,A.a2,A.N,A.le,A.q,A.b7,A.eH,A.fc,A.ej,A.fe,A.aP,A.d9,A.aT,A.du,A.fq,A.aN,A.lO,A.hR,A.ek,A.fG,A.aL,A.kq,A.az,A.cV,A.cU,A.dC,A.ft,A.dS,A.il,A.jc,A.m6,A.jg,A.bz,A.iQ,A.je,A.mU,A.iy,A.bB,A.bk,A.iI,A.dc,A.aq,A.iz,A.ja,A.fM,A.d7,A.iW,A.fr,A.af,A.m1,A.h3,A.dt,A.mC,A.n_,A.jh,A.hh,A.mi,A.hS,A.f2,A.iN,A.C,A.bv,A.ap,A.jd,A.ax,A.ia,A.bQ,A.ho,A.hQ,A.hj,A.k6,A.lR,A.kd,A.hz,A.hT,A.aO,A.c0,A.hu,A.hU,A.fl,A.i3,A.cz,A.la,A.iD,A.cS,A.iO,A.hn,A.dx,A.ay,A.hb,A.ck,A.kl,A.cm,A.km,A.dV,A.hF,A.kn,A.hG,A.hw,A.ke,A.dP,A.aZ,A.jJ,A.fV,A.lj,A.he,A.dW,A.cP,A.iu,A.cQ,A.f8,A.bF,A.h7,A.fj,A.iC,A.ki,A.iB,A.mv,A.t,A.iS,A.mu,A.bS,A.ko,A.iJ,A.fk,A.fB,A.mx,A.cH,A.j0,A.iA,A.bT,A.mH,A.bC,A.m2,A.bM,A.ku,A.bG,A.a_,A.T,A.jQ,A.c_,A.i1,A.aw,A.bs,A.hg,A.jT,A.jU,A.c5,A.cr,A.kC,A.kE,A.iK,A.iU,A.l1,A.aR,A.dK,A.M,A.c6,A.c9,A.eV,A.ca,A.hW,A.jB,A.fA,A.m7,A.ch,A.bX,A.lG,A.bA,A.db,A.cg,A.lL,A.mW,A.c7,A.cl,A.bU,A.iX,A.aH,A.d2,A.d1,A.kM,A.mh,A.fm,A.lS,A.hV,A.d_,A.hZ,A.d3,A.eU,A.l_,A.fy,A.m4,A.bN,A.ak,A.dO,A.eY,A.hs,A.bl,A.hq,A.dv,A.k1,A.el,A.f1,A.ij,A.ii,A.lg,A.io,A.im,A.f3,A.lx,A.ly,A.h5,A.k5,A.h6,A.lf,A.lE,A.mK,A.lF,A.i8,A.a7,A.fL,A.dU,A.iT,A.n1,A.mR,A.hY,A.l6])
-q(J.hB,[J.hD,J.eA,J.eC,J.dD,J.dE,J.dB,J.cT])
+q(A.K,[A.om,J.hB,A.f0,J.ed,A.b_,A.dT,A.a2,A.N,A.le,A.q,A.b7,A.eH,A.fc,A.ej,A.fe,A.aP,A.d8,A.aT,A.dt,A.fq,A.aN,A.lO,A.hR,A.ek,A.fG,A.aL,A.kq,A.az,A.cU,A.cT,A.dC,A.ft,A.dS,A.il,A.jc,A.m6,A.jg,A.bz,A.iQ,A.je,A.mU,A.iy,A.bB,A.bk,A.iI,A.db,A.aq,A.iz,A.ja,A.fM,A.d6,A.iW,A.fr,A.af,A.m1,A.h3,A.ds,A.mC,A.n_,A.jh,A.hh,A.mi,A.hS,A.f2,A.iN,A.C,A.bv,A.ap,A.jd,A.ax,A.ia,A.bQ,A.ho,A.hQ,A.hj,A.k6,A.lR,A.kd,A.hz,A.hT,A.aO,A.c0,A.hu,A.hU,A.fl,A.i3,A.cz,A.la,A.iD,A.cR,A.iO,A.hn,A.dx,A.ay,A.hb,A.ck,A.kl,A.cm,A.km,A.dV,A.hF,A.kn,A.hG,A.hw,A.ke,A.dP,A.aZ,A.jJ,A.fV,A.lj,A.he,A.dW,A.du,A.iu,A.cP,A.f8,A.bF,A.h7,A.fj,A.iC,A.ki,A.iB,A.mv,A.t,A.iS,A.mu,A.bS,A.ko,A.iJ,A.fk,A.fB,A.mx,A.cH,A.j0,A.iA,A.bT,A.mH,A.bC,A.m2,A.bM,A.ku,A.bG,A.a_,A.T,A.jQ,A.c_,A.i1,A.aw,A.bs,A.hg,A.jT,A.jU,A.c5,A.cr,A.kC,A.kE,A.iK,A.iU,A.l1,A.aR,A.dK,A.M,A.c6,A.c9,A.eV,A.ca,A.hW,A.jB,A.fA,A.m7,A.ch,A.bX,A.lG,A.bA,A.da,A.cg,A.lL,A.mW,A.c7,A.cl,A.bU,A.iX,A.aH,A.d1,A.d0,A.kM,A.mh,A.fm,A.lS,A.hV,A.cZ,A.hZ,A.d2,A.eU,A.l_,A.fy,A.m4,A.bN,A.ak,A.dO,A.eY,A.hs,A.bl,A.hq,A.dv,A.k1,A.el,A.f1,A.ij,A.ii,A.lg,A.io,A.im,A.f3,A.lx,A.ly,A.h5,A.k5,A.h6,A.lf,A.lE,A.mK,A.lF,A.i8,A.a7,A.fL,A.dU,A.iT,A.n1,A.mR,A.hY,A.l6])
+q(J.hB,[J.hD,J.eA,J.eC,J.dD,J.dE,J.dB,J.cS])
 q(J.eC,[J.co,J.n,A.cp,A.eM])
 q(J.co,[J.i6,J.cC,J.bJ])
 r(J.hC,A.f0)
 r(J.kh,J.n)
 q(J.dB,[J.dA,J.eB])
-q(A.a2,[A.cn,A.cd,A.hH,A.it,A.ic,A.iM,A.eF,A.fZ,A.bi,A.f9,A.is,A.d8,A.hc])
+q(A.a2,[A.cn,A.cd,A.hH,A.it,A.ic,A.iM,A.eF,A.fZ,A.bi,A.f9,A.is,A.d7,A.hc])
 r(A.dR,A.N)
 r(A.br,A.dR)
-q(A.q,[A.E,A.cW,A.fb,A.fd,A.fp,A.ix,A.jb,A.cG,A.ib])
+q(A.q,[A.E,A.cV,A.fb,A.fd,A.fp,A.ix,A.jb,A.cG,A.ib])
 q(A.E,[A.as,A.ei,A.ah,A.eG,A.c2])
 q(A.as,[A.f4,A.c3,A.f_])
-r(A.eh,A.cW)
-q(A.aT,[A.dX,A.dg,A.cF])
+r(A.eh,A.cV)
+q(A.aT,[A.dX,A.df,A.cF])
 r(A.j,A.dX)
-q(A.dg,[A.am,A.fC])
+q(A.df,[A.am,A.fC])
 q(A.cF,[A.A,A.fD,A.fE])
-q(A.du,[A.aY,A.bt])
+q(A.dt,[A.aY,A.bt])
 q(A.aN,[A.hA,A.h9,A.ha,A.iq,A.nG,A.nI,A.lU,A.lT,A.n3,A.ms,A.nU,A.nV,A.mG,A.nx,A.lb,A.nZ,A.jK,A.lk,A.ll,A.ln,A.lo,A.lq,A.jz,A.nA,A.mA,A.lZ,A.lY,A.m_,A.m0,A.mI,A.mJ,A.nf,A.nl,A.nn,A.nm,A.kr,A.jL,A.kA,A.kz,A.m5,A.nw,A.jH,A.lJ,A.lH,A.lM,A.mP,A.kb,A.k8,A.k9,A.ka,A.k7,A.m8,A.m9,A.ma,A.mg,A.mb,A.mc,A.md,A.me,A.mf,A.nT,A.kN,A.kU,A.kV,A.kW,A.kX,A.kQ,A.kR,A.l0,A.nQ,A.nL,A.nM,A.nO,A.nP,A.nD,A.nz,A.li,A.o0,A.lD,A.lA,A.o4,A.o1,A.o2,A.o3,A.na])
 r(A.bI,A.hA)
 q(A.h9,[A.lc,A.lV,A.lW,A.mV,A.k4,A.mj,A.mo,A.mn,A.ml,A.mk,A.mr,A.mq,A.mp,A.mT,A.nj,A.mZ,A.mY,A.nX,A.nY,A.jx,A.jO,A.jP,A.jM,A.jy,A.ks,A.kv,A.k0,A.jZ,A.k_,A.jW,A.jX,A.jY,A.kF,A.l2,A.kB,A.kL,A.kK,A.jC,A.jI,A.jG,A.lK,A.lI,A.lN,A.mQ,A.mO,A.mM,A.mL,A.mN,A.mF,A.kT,A.kP,A.kY,A.kS,A.nN,A.nE,A.lh,A.lv,A.lw,A.lu,A.lt,A.ls,A.lr,A.lB,A.nW])
 r(A.eP,A.cd)
-q(A.iq,[A.ik,A.dr])
+q(A.iq,[A.ik,A.dq])
 r(A.bK,A.aL)
 q(A.bK,[A.eE,A.eD])
 q(A.ha,[A.nH,A.n4,A.np,A.mt,A.kt,A.mD,A.lm,A.jN,A.jA,A.kk,A.my,A.mz,A.m3,A.no,A.jV,A.kJ,A.kI,A.kG,A.jE,A.jF,A.jD,A.mE,A.kO,A.ns,A.nt,A.ny,A.lC,A.lz,A.nc,A.nd,A.nr,A.l9])
@@ -22139,16 +22139,16 @@ r(A.cq,A.fv)
 r(A.fx,A.fw)
 r(A.b8,A.fx)
 q(A.cq,[A.eI,A.eJ])
-q(A.b8,[A.hP,A.eK,A.eL,A.eN,A.eO,A.cX,A.cY])
+q(A.b8,[A.hP,A.eK,A.eL,A.eN,A.eO,A.cW,A.cX])
 r(A.dZ,A.iM)
 r(A.ff,A.iI)
 r(A.j1,A.fM)
-r(A.fF,A.d7)
-r(A.de,A.fF)
-r(A.fs,A.de)
+r(A.fF,A.d6)
+r(A.dd,A.fF)
+r(A.fs,A.dd)
 q(A.af,[A.jf,A.h0,A.hK,A.iw,A.fa,A.ht])
-r(A.da,A.h3)
-q(A.dt,[A.hi,A.hI])
+r(A.d9,A.h3)
+q(A.ds,[A.hi,A.hI])
 r(A.hJ,A.eF)
 r(A.mB,A.mC)
 r(A.hL,A.jf)
@@ -22162,9 +22162,9 @@ q(A.ht,[A.iY,A.j3,A.j6,A.j7])
 q(A.hu,[A.iZ,A.j5,A.j8])
 r(A.j4,A.j5)
 q(A.j8,[A.ie,A.ig])
-r(A.hm,A.cS)
+r(A.hm,A.cR)
 q(A.ay,[A.en,A.eo,A.ex,A.er,A.es,A.et,A.ew,A.eu,A.ev,A.ey,A.ep,A.ez,A.eq])
-q(A.ck,[A.cR,A.em])
+q(A.ck,[A.cQ,A.em])
 q(A.bF,[A.fY,A.fX,A.h8,A.hp,A.hN,A.i9])
 q(A.T,[A.bZ,A.bY,A.m,A.R,A.L,A.u,A.o,A.p,A.y,A.av])
 q(A.c5,[A.i_,A.eW])
@@ -22175,23 +22175,23 @@ q(A.bX,[A.ih,A.hl,A.hr,A.h1,A.ir,A.f7])
 q(A.c7,[A.iH,A.iP,A.j9,A.j2,A.j_])
 q(A.bN,[A.a1,A.O,A.ab,A.ba])
 r(A.ip,A.f3)
-q(A.a7,[A.d6,A.d5,A.bw,A.cw,A.cv,A.bb,A.b9,A.cu,A.bo,A.bO,A.cZ,A.dL,A.dJ,A.aQ])
-s(A.dR,A.d9)
+q(A.a7,[A.d5,A.d4,A.bw,A.cw,A.cv,A.bb,A.b9,A.cu,A.bo,A.bO,A.cY,A.dL,A.dJ,A.aQ])
+s(A.dR,A.d8)
 s(A.fu,A.N)
 s(A.fv,A.aP)
 s(A.fw,A.N)
 s(A.fx,A.aP)})()
-var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{c:"int",h:"double",bD:"num",F:"String",U:"bool",ap:"Null",i:"List",K:"Object",bL:"Map",ag:"JSObject"},mangledNames:{},types:["~()","h(h)","c()","M(i<h>)","bs()","h(c)","~(cm,i<c>)","U(U)","~(F,T)","c(c,c)","c(bT)","i<aZ>()","ak?()","~(c,c)","~(c,F)","~(~())","U(h)","~(h,h,h,h)","c(F,c)","~(@)","T(T?)","aI(F)","~(h,h)","U(T?)","bH<ap>()","@()","~(K?,K?)","0^(0^,0^)<bD>","h()","c(h)","ap()","ap(@)","@(@)","~(c,c,c)","c(c,cH)","T(av)","~(c,c,c,c)","+(bC,bC)(c)","U(bT)","~(c,@)","ap(K,cB)","~(dw,c,c,c,c,c,c)","~(c)","~(h,U)","c?()","aI(c)","F(bv<F,T>)","aI()","@(F)","i<p>()","i<c5>()","cl?()","@(@,F)","cs(F)","aI(i<c>,i<c>,i<c>)","U(T)","ap(~())","U(db)","bA(c)","h?(cc)","F(cc)","i<K>?()","i<a7>(i<a7>)","U()","K()","+(c,c)?(F)","c(cz)","i<i<h>>?(c,c)","U(+(h,h))","ap(ag)","i<aZ>(y)","m()","~(i<aZ>,p,a_)","+(h,h)(i<+(+(h,h),h)>)","dW()","U(F)","h(h,h)","~(bl)","c(+(c,c),+(c,c))","~(h)","~(h,h,h,h,h,h)","~(h,h,h,h,h,h,h,h,h,h)","~(i<a7>)","ap(@,cB)","~(h,h,c,c)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.j&&a.b(c.a)&&b.b(c.b),"3;":(a,b,c)=>d=>d instanceof A.am&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"3;color,fontName,size":(a,b,c)=>d=>d instanceof A.fC&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;":a=>b=>b instanceof A.A&&A.p7(a,b.a),"5;":a=>b=>b instanceof A.fD&&A.p7(a,b.a),"7;":a=>b=>b instanceof A.fE&&A.p7(a,b.a)}}
-A.wy(v.typeUniverse,JSON.parse('{"bJ":"co","i6":"co","cC":"co","yL":"cp","hD":{"U":[],"X":[]},"eA":{"ap":[],"X":[]},"eC":{"ag":[]},"co":{"ag":[]},"n":{"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"hC":{"f0":[]},"kh":{"n":["1"],"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"ed":{"a3":["1"]},"dB":{"h":[],"bD":[]},"dA":{"h":[],"c":[],"bD":[],"X":[]},"eB":{"h":[],"bD":[],"X":[]},"cT":{"F":[],"ky":[],"aF":["@"],"X":[]},"b_":{"od":[]},"dT":{"od":[]},"cn":{"a2":[]},"br":{"N":["c"],"d9":["c"],"i":["c"],"E":["c"],"q":["c"],"N.E":"c","d9.E":"c"},"E":{"q":["1"]},"as":{"E":["1"],"q":["1"]},"f4":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"b7":{"a3":["1"]},"cW":{"q":["2"],"q.E":"2"},"eh":{"cW":["1","2"],"E":["2"],"q":["2"],"q.E":"2"},"eH":{"a3":["2"]},"c3":{"as":["2"],"E":["2"],"q":["2"],"q.E":"2","as.E":"2"},"fb":{"q":["1"],"q.E":"1"},"fc":{"a3":["1"]},"ei":{"E":["1"],"q":["1"],"q.E":"1"},"ej":{"a3":["1"]},"fd":{"q":["1"],"q.E":"1"},"fe":{"a3":["1"]},"dR":{"N":["1"],"d9":["1"],"i":["1"],"E":["1"],"q":["1"]},"f_":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"j":{"dX":[],"aT":[]},"am":{"dg":[],"aT":[]},"fC":{"dg":[],"aT":[]},"A":{"cF":[],"aT":[]},"fD":{"cF":[],"aT":[]},"fE":{"cF":[],"aT":[]},"du":{"bL":["1","2"]},"aY":{"du":["1","2"],"bL":["1","2"]},"fp":{"q":["1"],"q.E":"1"},"fq":{"a3":["1"]},"bt":{"du":["1","2"],"bL":["1","2"]},"hA":{"aN":[],"c1":[]},"bI":{"aN":[],"c1":[]},"eP":{"cd":[],"a2":[]},"hH":{"a2":[]},"it":{"a2":[]},"hR":{"aa":[]},"fG":{"cB":[]},"aN":{"c1":[]},"h9":{"aN":[],"c1":[]},"ha":{"aN":[],"c1":[]},"iq":{"aN":[],"c1":[]},"ik":{"aN":[],"c1":[]},"dr":{"aN":[],"c1":[]},"ic":{"a2":[]},"bK":{"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"ah":{"E":["1"],"q":["1"],"q.E":"1"},"az":{"a3":["1"]},"eG":{"E":["1"],"q":["1"],"q.E":"1"},"cV":{"a3":["1"]},"c2":{"E":["bv<1,2>"],"q":["bv<1,2>"],"q.E":"bv<1,2>"},"cU":{"a3":["bv<1,2>"]},"eE":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"eD":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"dX":{"aT":[]},"dg":{"aT":[]},"cF":{"aT":[]},"dC":{"vx":[],"ky":[]},"ft":{"cc":[],"dF":[]},"ix":{"q":["cc"],"q.E":"cc"},"dS":{"a3":["cc"]},"il":{"dF":[]},"jb":{"q":["dF"],"q.E":"dF"},"jc":{"a3":["dF"]},"cX":{"b8":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cY":{"b8":[],"aI":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cp":{"ag":[],"h2":[],"X":[]},"dH":{"cp":[],"ag":[],"h2":[],"X":[]},"eM":{"ag":[]},"jg":{"h2":[]},"hO":{"pA":[],"ag":[],"X":[]},"aG":{"b6":["1"],"ag":[],"aF":["1"]},"cq":{"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"]},"b8":{"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"]},"eI":{"cq":[],"dw":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"eJ":{"cq":[],"og":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"hP":{"b8":[],"kf":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eK":{"b8":[],"dy":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eL":{"b8":[],"ok":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eN":{"b8":[],"lQ":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eO":{"b8":[],"oB":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"iM":{"a2":[]},"dZ":{"cd":[],"a2":[]},"bB":{"a3":["1"]},"cG":{"q":["1"],"q.E":"1"},"bk":{"a2":[]},"ff":{"iI":["1"]},"aq":{"bH":["1"]},"fM":{"qA":[]},"j1":{"fM":[],"qA":[]},"de":{"d7":["1"],"id":["1"],"E":["1"],"q":["1"]},"fs":{"de":["1"],"d7":["1"],"id":["1"],"E":["1"],"q":["1"]},"fr":{"a3":["1"]},"N":{"i":["1"],"E":["1"],"q":["1"]},"aL":{"bL":["1","2"]},"d7":{"id":["1"],"E":["1"],"q":["1"]},"fF":{"d7":["1"],"id":["1"],"E":["1"],"q":["1"]},"jf":{"af":["F","i<c>"]},"h0":{"af":["F","i<c>"],"af.T":"i<c>"},"h3":{"bd":["i<c>"]},"da":{"bd":["i<c>"]},"hi":{"dt":["F","i<c>"]},"eF":{"a2":[]},"hJ":{"a2":[]},"hI":{"dt":["K?","F"]},"hK":{"af":["K?","F"],"af.T":"F"},"hL":{"af":["F","i<c>"],"af.T":"i<c>"},"iv":{"dt":["F","i<c>"]},"iw":{"af":["F","i<c>"],"af.T":"i<c>"},"fa":{"af":["i<c>","F"],"af.T":"F"},"h":{"bD":[]},"c":{"bD":[]},"i":{"E":["1"],"q":["1"]},"cc":{"dF":[]},"F":{"ky":[]},"fZ":{"a2":[]},"cd":{"a2":[]},"bi":{"a2":[]},"cb":{"a2":[]},"hx":{"cb":[],"a2":[]},"f9":{"a2":[]},"is":{"a2":[]},"d8":{"a2":[]},"hc":{"a2":[]},"hS":{"a2":[]},"f2":{"a2":[]},"iN":{"aa":[]},"C":{"aa":[]},"jd":{"cB":[]},"ib":{"q":["c"],"q.E":"c"},"ia":{"a3":["c"]},"bQ":{"vE":[]},"hQ":{"aa":[]},"ok":{"i":["c"],"E":["c"],"q":["c"]},"aI":{"i":["c"],"E":["c"],"q":["c"]},"vW":{"i":["c"],"E":["c"],"q":["c"]},"kf":{"i":["c"],"E":["c"],"q":["c"]},"lQ":{"i":["c"],"E":["c"],"q":["c"]},"dy":{"i":["c"],"E":["c"],"q":["c"]},"oB":{"i":["c"],"E":["c"],"q":["c"]},"dw":{"i":["h"],"E":["h"],"q":["h"]},"og":{"i":["h"],"E":["h"],"q":["h"]},"hy":{"hz":[]},"eQ":{"hT":[]},"c0":{"bd":["aO"]},"ht":{"af":["i<c>","aO"]},"hu":{"bd":["i<c>"]},"iY":{"af":["i<c>","aO"],"af.T":"aO"},"iZ":{"bd":["i<c>"]},"j3":{"af":["i<c>","aO"],"af.T":"aO"},"j5":{"bd":["i<c>"]},"j4":{"bd":["i<c>"]},"j6":{"af":["i<c>","aO"],"af.T":"aO"},"j7":{"af":["i<c>","aO"],"af.T":"aO"},"j8":{"bd":["i<c>"]},"ie":{"bd":["i<c>"]},"ig":{"bd":["i<c>"]},"hm":{"cS":[]},"en":{"ay":[]},"eo":{"ay":[]},"ex":{"ay":[]},"er":{"ay":[]},"es":{"ay":[]},"et":{"ay":[]},"ew":{"ay":[]},"eu":{"ay":[]},"ev":{"ay":[]},"ey":{"ay":[]},"ep":{"ay":[]},"ez":{"ay":[]},"eq":{"ay":[]},"cR":{"ck":[]},"em":{"ck":[]},"hw":{"aa":[]},"cP":{"aa":[]},"iu":{"aa":[]},"cQ":{"aa":[]},"f8":{"aa":[]},"fY":{"bF":[]},"fX":{"bF":[]},"h8":{"bF":[]},"fj":{"aa":[]},"hp":{"bF":[]},"hN":{"bF":[]},"i9":{"bF":[]},"m":{"T":[]},"p":{"T":[]},"y":{"T":[]},"av":{"T":[]},"bZ":{"T":[]},"bY":{"T":[]},"R":{"T":[]},"L":{"T":[]},"u":{"T":[]},"o":{"T":[]},"i_":{"c5":[]},"eW":{"c5":[]},"i5":{"cr":[]},"hX":{"cr":[]},"i0":{"cr":[]},"eT":{"cr":[]},"i4":{"cr":[]},"iE":{"dK":[]},"iF":{"dK":[]},"iV":{"dK":[]},"cE":{"c6":[]},"fz":{"c6":[]},"fi":{"c6":[]},"fn":{"c6":[]},"fo":{"c6":[]},"dY":{"c6":[]},"ih":{"bX":[]},"hl":{"bX":[]},"hr":{"bX":[]},"h1":{"bX":[]},"ir":{"bX":[]},"f7":{"bX":[]},"iH":{"c7":[]},"iP":{"c7":[]},"j9":{"c7":[]},"j2":{"c7":[]},"j_":{"c7":[]},"d_":{"aa":[]},"fy":{"aa":[]},"a1":{"bN":[]},"O":{"bN":[]},"ab":{"bN":[]},"ba":{"bN":[]},"f3":{"kD":[]},"ip":{"kD":[]},"i8":{"kD":[]},"d6":{"a7":[]},"d5":{"a7":[]},"bw":{"a7":[]},"cw":{"a7":[]},"cv":{"a7":[]},"bb":{"a7":[]},"b9":{"a7":[]},"cu":{"a7":[]},"bo":{"a7":[]},"bO":{"a7":[]},"cZ":{"a7":[]},"dL":{"a7":[]},"dJ":{"a7":[]},"aQ":{"a7":[]},"fL":{"aa":[]}}'))
+var v={G:typeof self!="undefined"?self:globalThis,typeUniverse:{eC:new Map(),tR:{},eT:{},tPV:{},sEA:[]},mangledGlobalNames:{c:"int",h:"double",bD:"num",F:"String",U:"bool",ap:"Null",i:"List",K:"Object",bL:"Map",ag:"JSObject"},mangledNames:{},types:["~()","h(h)","c()","M(i<h>)","bs()","h(c)","~(cm,i<c>)","U(U)","~(F,T)","c(c,c)","c(bT)","i<aZ>()","ak?()","~(c,c)","~(c,F)","~(~())","U(h)","~(h,h,h,h)","c(F,c)","~(@)","T(T?)","aI(F)","~(h,h)","U(T?)","bH<ap>()","@()","~(K?,K?)","0^(0^,0^)<bD>","h()","c(h)","ap()","ap(@)","@(@)","~(c,c,c)","c(c,cH)","T(av)","~(c,c,c,c)","+(bC,bC)(c)","U(bT)","~(c,@)","ap(K,cB)","~(dw,c,c,c,c,c,c)","~(c)","~(h,U)","c?()","aI(c)","F(bv<F,T>)","aI()","@(F)","i<p>()","i<c5>()","cl?()","@(@,F)","cs(F)","aI(i<c>,i<c>,i<c>)","U(T)","ap(~())","U(da)","bA(c)","h?(cc)","F(cc)","i<K>?()","i<a7>(i<a7>)","U()","K()","+(c,c)?(F)","c(cz)","i<i<h>>?(c,c)","U(+(h,h))","ap(ag)","i<aZ>(y)","m()","~(i<aZ>,p,a_)","+(h,h)(i<+(+(h,h),h)>)","dW()","U(F)","h(h,h)","~(bl)","c(+(c,c),+(c,c))","~(h)","~(h,h,h,h,h,h)","~(h,h,h,h,h,h,h,h,h,h)","~(i<a7>)","ap(@,cB)","~(h,h,c,c)"],interceptorsByTag:null,leafTags:null,arrayRti:Symbol("$ti"),rttc:{"2;":(a,b)=>c=>c instanceof A.j&&a.b(c.a)&&b.b(c.b),"3;":(a,b,c)=>d=>d instanceof A.am&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"3;color,fontName,size":(a,b,c)=>d=>d instanceof A.fC&&a.b(d.a)&&b.b(d.b)&&c.b(d.c),"4;":a=>b=>b instanceof A.A&&A.p7(a,b.a),"5;":a=>b=>b instanceof A.fD&&A.p7(a,b.a),"7;":a=>b=>b instanceof A.fE&&A.p7(a,b.a)}}
+A.wy(v.typeUniverse,JSON.parse('{"bJ":"co","i6":"co","cC":"co","yL":"cp","hD":{"U":[],"X":[]},"eA":{"ap":[],"X":[]},"eC":{"ag":[]},"co":{"ag":[]},"n":{"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"hC":{"f0":[]},"kh":{"n":["1"],"i":["1"],"E":["1"],"ag":[],"q":["1"],"aF":["1"]},"ed":{"a3":["1"]},"dB":{"h":[],"bD":[]},"dA":{"h":[],"c":[],"bD":[],"X":[]},"eB":{"h":[],"bD":[],"X":[]},"cS":{"F":[],"ky":[],"aF":["@"],"X":[]},"b_":{"od":[]},"dT":{"od":[]},"cn":{"a2":[]},"br":{"N":["c"],"d8":["c"],"i":["c"],"E":["c"],"q":["c"],"N.E":"c","d8.E":"c"},"E":{"q":["1"]},"as":{"E":["1"],"q":["1"]},"f4":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"b7":{"a3":["1"]},"cV":{"q":["2"],"q.E":"2"},"eh":{"cV":["1","2"],"E":["2"],"q":["2"],"q.E":"2"},"eH":{"a3":["2"]},"c3":{"as":["2"],"E":["2"],"q":["2"],"q.E":"2","as.E":"2"},"fb":{"q":["1"],"q.E":"1"},"fc":{"a3":["1"]},"ei":{"E":["1"],"q":["1"],"q.E":"1"},"ej":{"a3":["1"]},"fd":{"q":["1"],"q.E":"1"},"fe":{"a3":["1"]},"dR":{"N":["1"],"d8":["1"],"i":["1"],"E":["1"],"q":["1"]},"f_":{"as":["1"],"E":["1"],"q":["1"],"q.E":"1","as.E":"1"},"j":{"dX":[],"aT":[]},"am":{"df":[],"aT":[]},"fC":{"df":[],"aT":[]},"A":{"cF":[],"aT":[]},"fD":{"cF":[],"aT":[]},"fE":{"cF":[],"aT":[]},"dt":{"bL":["1","2"]},"aY":{"dt":["1","2"],"bL":["1","2"]},"fp":{"q":["1"],"q.E":"1"},"fq":{"a3":["1"]},"bt":{"dt":["1","2"],"bL":["1","2"]},"hA":{"aN":[],"c1":[]},"bI":{"aN":[],"c1":[]},"eP":{"cd":[],"a2":[]},"hH":{"a2":[]},"it":{"a2":[]},"hR":{"aa":[]},"fG":{"cB":[]},"aN":{"c1":[]},"h9":{"aN":[],"c1":[]},"ha":{"aN":[],"c1":[]},"iq":{"aN":[],"c1":[]},"ik":{"aN":[],"c1":[]},"dq":{"aN":[],"c1":[]},"ic":{"a2":[]},"bK":{"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"ah":{"E":["1"],"q":["1"],"q.E":"1"},"az":{"a3":["1"]},"eG":{"E":["1"],"q":["1"],"q.E":"1"},"cU":{"a3":["1"]},"c2":{"E":["bv<1,2>"],"q":["bv<1,2>"],"q.E":"bv<1,2>"},"cT":{"a3":["bv<1,2>"]},"eE":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"eD":{"bK":["1","2"],"aL":["1","2"],"kp":["1","2"],"bL":["1","2"],"aL.K":"1","aL.V":"2"},"dX":{"aT":[]},"df":{"aT":[]},"cF":{"aT":[]},"dC":{"vx":[],"ky":[]},"ft":{"cc":[],"dF":[]},"ix":{"q":["cc"],"q.E":"cc"},"dS":{"a3":["cc"]},"il":{"dF":[]},"jb":{"q":["dF"],"q.E":"dF"},"jc":{"a3":["dF"]},"cW":{"b8":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cX":{"b8":[],"aI":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"cp":{"ag":[],"h2":[],"X":[]},"dH":{"cp":[],"ag":[],"h2":[],"X":[]},"eM":{"ag":[]},"jg":{"h2":[]},"hO":{"pA":[],"ag":[],"X":[]},"aG":{"b6":["1"],"ag":[],"aF":["1"]},"cq":{"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"]},"b8":{"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"]},"eI":{"cq":[],"dw":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"eJ":{"cq":[],"og":[],"N":["h"],"aG":["h"],"i":["h"],"b6":["h"],"E":["h"],"ag":[],"aF":["h"],"q":["h"],"aP":["h"],"X":[],"N.E":"h"},"hP":{"b8":[],"kf":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eK":{"b8":[],"dy":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eL":{"b8":[],"ok":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eN":{"b8":[],"lQ":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"eO":{"b8":[],"oB":[],"N":["c"],"aG":["c"],"i":["c"],"b6":["c"],"E":["c"],"ag":[],"aF":["c"],"q":["c"],"aP":["c"],"X":[],"N.E":"c"},"iM":{"a2":[]},"dZ":{"cd":[],"a2":[]},"bB":{"a3":["1"]},"cG":{"q":["1"],"q.E":"1"},"bk":{"a2":[]},"ff":{"iI":["1"]},"aq":{"bH":["1"]},"fM":{"qA":[]},"j1":{"fM":[],"qA":[]},"dd":{"d6":["1"],"id":["1"],"E":["1"],"q":["1"]},"fs":{"dd":["1"],"d6":["1"],"id":["1"],"E":["1"],"q":["1"]},"fr":{"a3":["1"]},"N":{"i":["1"],"E":["1"],"q":["1"]},"aL":{"bL":["1","2"]},"d6":{"id":["1"],"E":["1"],"q":["1"]},"fF":{"d6":["1"],"id":["1"],"E":["1"],"q":["1"]},"jf":{"af":["F","i<c>"]},"h0":{"af":["F","i<c>"],"af.T":"i<c>"},"h3":{"bd":["i<c>"]},"d9":{"bd":["i<c>"]},"hi":{"ds":["F","i<c>"]},"eF":{"a2":[]},"hJ":{"a2":[]},"hI":{"ds":["K?","F"]},"hK":{"af":["K?","F"],"af.T":"F"},"hL":{"af":["F","i<c>"],"af.T":"i<c>"},"iv":{"ds":["F","i<c>"]},"iw":{"af":["F","i<c>"],"af.T":"i<c>"},"fa":{"af":["i<c>","F"],"af.T":"F"},"h":{"bD":[]},"c":{"bD":[]},"i":{"E":["1"],"q":["1"]},"cc":{"dF":[]},"F":{"ky":[]},"fZ":{"a2":[]},"cd":{"a2":[]},"bi":{"a2":[]},"cb":{"a2":[]},"hx":{"cb":[],"a2":[]},"f9":{"a2":[]},"is":{"a2":[]},"d7":{"a2":[]},"hc":{"a2":[]},"hS":{"a2":[]},"f2":{"a2":[]},"iN":{"aa":[]},"C":{"aa":[]},"jd":{"cB":[]},"ib":{"q":["c"],"q.E":"c"},"ia":{"a3":["c"]},"bQ":{"vE":[]},"hQ":{"aa":[]},"ok":{"i":["c"],"E":["c"],"q":["c"]},"aI":{"i":["c"],"E":["c"],"q":["c"]},"vW":{"i":["c"],"E":["c"],"q":["c"]},"kf":{"i":["c"],"E":["c"],"q":["c"]},"lQ":{"i":["c"],"E":["c"],"q":["c"]},"dy":{"i":["c"],"E":["c"],"q":["c"]},"oB":{"i":["c"],"E":["c"],"q":["c"]},"dw":{"i":["h"],"E":["h"],"q":["h"]},"og":{"i":["h"],"E":["h"],"q":["h"]},"hy":{"hz":[]},"eQ":{"hT":[]},"c0":{"bd":["aO"]},"ht":{"af":["i<c>","aO"]},"hu":{"bd":["i<c>"]},"iY":{"af":["i<c>","aO"],"af.T":"aO"},"iZ":{"bd":["i<c>"]},"j3":{"af":["i<c>","aO"],"af.T":"aO"},"j5":{"bd":["i<c>"]},"j4":{"bd":["i<c>"]},"j6":{"af":["i<c>","aO"],"af.T":"aO"},"j7":{"af":["i<c>","aO"],"af.T":"aO"},"j8":{"bd":["i<c>"]},"ie":{"bd":["i<c>"]},"ig":{"bd":["i<c>"]},"hm":{"cR":[]},"en":{"ay":[]},"eo":{"ay":[]},"ex":{"ay":[]},"er":{"ay":[]},"es":{"ay":[]},"et":{"ay":[]},"ew":{"ay":[]},"eu":{"ay":[]},"ev":{"ay":[]},"ey":{"ay":[]},"ep":{"ay":[]},"ez":{"ay":[]},"eq":{"ay":[]},"cQ":{"ck":[]},"em":{"ck":[]},"hw":{"aa":[]},"du":{"aa":[]},"iu":{"aa":[]},"cP":{"aa":[]},"f8":{"aa":[]},"fY":{"bF":[]},"fX":{"bF":[]},"h8":{"bF":[]},"fj":{"aa":[]},"hp":{"bF":[]},"hN":{"bF":[]},"i9":{"bF":[]},"m":{"T":[]},"p":{"T":[]},"y":{"T":[]},"av":{"T":[]},"bZ":{"T":[]},"bY":{"T":[]},"R":{"T":[]},"L":{"T":[]},"u":{"T":[]},"o":{"T":[]},"i_":{"c5":[]},"eW":{"c5":[]},"i5":{"cr":[]},"hX":{"cr":[]},"i0":{"cr":[]},"eT":{"cr":[]},"i4":{"cr":[]},"iE":{"dK":[]},"iF":{"dK":[]},"iV":{"dK":[]},"cE":{"c6":[]},"fz":{"c6":[]},"fi":{"c6":[]},"fn":{"c6":[]},"fo":{"c6":[]},"dY":{"c6":[]},"ih":{"bX":[]},"hl":{"bX":[]},"hr":{"bX":[]},"h1":{"bX":[]},"ir":{"bX":[]},"f7":{"bX":[]},"iH":{"c7":[]},"iP":{"c7":[]},"j9":{"c7":[]},"j2":{"c7":[]},"j_":{"c7":[]},"cZ":{"aa":[]},"fy":{"aa":[]},"a1":{"bN":[]},"O":{"bN":[]},"ab":{"bN":[]},"ba":{"bN":[]},"f3":{"kD":[]},"ip":{"kD":[]},"i8":{"kD":[]},"d5":{"a7":[]},"d4":{"a7":[]},"bw":{"a7":[]},"cw":{"a7":[]},"cv":{"a7":[]},"bb":{"a7":[]},"b9":{"a7":[]},"cu":{"a7":[]},"bo":{"a7":[]},"bO":{"a7":[]},"cY":{"a7":[]},"dL":{"a7":[]},"dJ":{"a7":[]},"aQ":{"a7":[]},"fL":{"aa":[]}}'))
 A.wx(v.typeUniverse,JSON.parse('{"E":1,"dR":1,"aG":1,"fF":1}'))
 var u={c:"Error handler must accept one Object or one Object and a StackTrace as arguments, and return a value of the returned future's type",a:"The number of bytes to view must be a multiple of 4"}
 var t=(function rtii(){var s=A.ae
-return{v:s("bk"),eL:s("h6"),gS:s("br"),cq:s("aY<F,c>"),Y:s("o"),C:s("p"),G:s("u"),l:s("T"),kI:s("T(T?)"),md:s("av"),h:s("y"),V:s("L"),w:s("bs"),mG:s("bl"),gt:s("E<@>"),W:s("a2"),I:s("aa"),x:s("c1"),A:s("bt<c,F>"),B:s("bt<c,c>"),eD:s("dx"),lD:s("ay"),id:s("bI<h>"),n6:s("bI<c>"),bW:s("dy"),kk:s("q<h>"),fg:s("q<@>"),fm:s("q<c>"),an:s("n<hb>"),no:s("n<aZ>"),cN:s("n<p>"),q:s("n<T>"),mD:s("n<y>"),O:s("n<aw>"),gM:s("n<dv>"),mr:s("n<dw>"),aQ:s("n<dy>"),ns:s("n<cm>"),eH:s("n<i<+(h,h)>>"),e7:s("n<i<bA>>"),iA:s("n<i<h>>"),f:s("n<K>"),co:s("n<c5>"),b:s("n<M>"),lv:s("n<c7>"),bw:s("n<c9>"),bY:s("n<ca>"),ai:s("n<d3>"),g:s("n<bN>"),eF:s("n<aR>"),lO:s("n<a7>"),dL:s("n<eY>"),fV:s("n<+(+(h,h),h)>"),pe:s("n<+(bT,c)>"),fU:s("n<+(h,h)>"),u:s("n<+(c,c)>"),gN:s("n<ii>"),dP:s("n<ij>"),mW:s("n<f1>"),s:s("n<F>"),oq:s("n<im>"),fv:s("n<io>"),kN:s("n<lQ>"),a:s("n<aI>"),bl:s("n<iA>"),j:s("n<bS>"),br:s("n<db>"),hp:s("n<bT>"),nH:s("n<iJ>"),n0:s("n<iO>"),eK:s("n<fm>"),jf:s("n<iS>"),E:s("n<t>"),kv:s("n<dV>"),mZ:s("n<bA>"),mL:s("n<fA>"),aT:s("n<j0>"),eJ:s("n<cH>"),c:s("n<U>"),n:s("n<h>"),dG:s("n<@>"),t:s("n<c>"),le:s("n<p?>"),gU:s("n<hF?>"),iP:s("n<i<h>?>"),nn:s("n<h?>"),hM:s("n<c?>"),g2:s("n<bD>"),iy:s("aF<@>"),T:s("eA"),m:s("ag"),dY:s("bJ"),dX:s("b6<@>"),fh:s("cm"),D:s("i<aZ>"),oc:s("i<aZ>(y)"),lr:s("i<p>"),Q:s("i<T>"),iu:s("i<dw>"),kn:s("i<dy>"),n5:s("i<i<dy>>"),aZ:s("i<i<+(h,h)>>"),ez:s("i<K>"),ot:s("i<M>"),aY:s("i<c9>"),oQ:s("i<bN>"),J:s("i<a7>"),cn:s("i<+(+(h,h),h)>"),aE:s("i<aI>"),cP:s("i<bS>"),eP:s("i<bA>"),iZ:s("i<cH>"),H:s("i<h>"),gs:s("i<@>"),L:s("i<c>"),hQ:s("i<ck?>"),oT:s("i<bD>"),dj:s("bv<F,T>"),dV:s("bL<F,c>"),av:s("bL<@,@>"),eb:s("dH"),dQ:s("cq"),aj:s("b8"),mR:s("cX"),hD:s("cY"),P:s("ap"),K:s("K"),l5:s("at"),dF:s("hU<+(c,U),cz>"),hv:s("M"),jL:s("dM"),eB:s("c9"),ge:s("a_"),ob:s("ak"),bM:s("bN"),oh:s("aR"),e:s("a7"),b0:s("cb"),ba:s("dP"),lZ:s("yO"),aK:s("+()"),gB:s("+(bC,bC)"),aL:s("+(h,h)"),lG:s("+(c,U)"),R:s("+(c,c)"),i0:s("+(ak,c,c)"),F:s("cc"),on:s("f_<h>"),bB:s("id<p>"),Z:s("bd<aO>"),k:s("cB"),N:s("F"),aJ:s("X"),do:s("cd"),p:s("aI"),cx:s("cC"),iQ:s("fd<h>"),mj:s("bS"),aG:s("db"),U:s("bT"),jE:s("fk"),is:s("fl<cz>"),_:s("aq<@>"),dI:s("fs<y>"),c4:s("dW"),kb:s("fB"),lp:s("cG<av>"),l_:s("cG<+(h,h)>"),bp:s("cH"),y:s("U"),iW:s("U(K)"),i:s("h"),z:s("@"),mY:s("@()"),mq:s("@(K)"),ng:s("@(K,cB)"),S:s("c"),ir:s("T?"),gK:s("bH<ap>?"),er:s("ck?"),fW:s("cl?"),jH:s("kf?"),mU:s("ag?"),gv:s("bJ?"),nE:s("i<h>?"),iM:s("i<ck?>?"),iD:s("K?"),ex:s("aH?"),eM:s("d1?"),bd:s("d2?"),ak:s("ak?"),gE:s("cz?"),as:s("+(aI,aI)?"),jv:s("F?"),X:s("aI?"),bA:s("bS?"),lX:s("iD?"),d:s("dc<@,@>?"),nF:s("iW?"),o9:s("U?"),jX:s("h?"),aV:s("c?"),jh:s("bD?"),r:s("bD"),o:s("~"),M:s("~()"),mX:s("~(cm,i<c>)"),gf:s("~(i<aZ>,p,a_)")}})();(function constants(){var s=hunkHelpers.makeConstList
+return{w:s("bk"),eL:s("h6"),gS:s("br"),cq:s("aY<F,c>"),Y:s("o"),C:s("p"),G:s("u"),l:s("T"),kI:s("T(T?)"),md:s("av"),h:s("y"),V:s("L"),x:s("bs"),mG:s("bl"),gt:s("E<@>"),W:s("a2"),H:s("aa"),A:s("c1"),B:s("bt<c,F>"),iG:s("bt<c,c>"),eD:s("dx"),lD:s("ay"),id:s("bI<h>"),n6:s("bI<c>"),bW:s("dy"),kk:s("q<h>"),fg:s("q<@>"),fm:s("q<c>"),an:s("n<hb>"),no:s("n<aZ>"),cN:s("n<p>"),r:s("n<T>"),mD:s("n<y>"),O:s("n<aw>"),gM:s("n<dv>"),mr:s("n<dw>"),aQ:s("n<dy>"),ns:s("n<cm>"),eH:s("n<i<+(h,h)>>"),e7:s("n<i<bA>>"),iA:s("n<i<h>>"),f:s("n<K>"),co:s("n<c5>"),b:s("n<M>"),lv:s("n<c7>"),bw:s("n<c9>"),bY:s("n<ca>"),ai:s("n<d2>"),g:s("n<bN>"),eF:s("n<aR>"),lO:s("n<a7>"),dL:s("n<eY>"),fV:s("n<+(+(h,h),h)>"),pe:s("n<+(bT,c)>"),fU:s("n<+(h,h)>"),u:s("n<+(c,c)>"),gN:s("n<ii>"),dP:s("n<ij>"),mW:s("n<f1>"),s:s("n<F>"),oq:s("n<im>"),fv:s("n<io>"),kN:s("n<lQ>"),a:s("n<aI>"),bl:s("n<iA>"),j:s("n<bS>"),br:s("n<da>"),hp:s("n<bT>"),nH:s("n<iJ>"),n0:s("n<iO>"),eK:s("n<fm>"),jf:s("n<iS>"),E:s("n<t>"),kv:s("n<dV>"),mZ:s("n<bA>"),mL:s("n<fA>"),aT:s("n<j0>"),eJ:s("n<cH>"),c:s("n<U>"),n:s("n<h>"),dG:s("n<@>"),t:s("n<c>"),le:s("n<p?>"),gU:s("n<hF?>"),iP:s("n<i<h>?>"),nn:s("n<h?>"),hM:s("n<c?>"),g2:s("n<bD>"),iy:s("aF<@>"),T:s("eA"),m:s("ag"),dY:s("bJ"),dX:s("b6<@>"),fh:s("cm"),D:s("i<aZ>"),oc:s("i<aZ>(y)"),lr:s("i<p>"),Q:s("i<T>"),iu:s("i<dw>"),kn:s("i<dy>"),n5:s("i<i<dy>>"),aZ:s("i<i<+(h,h)>>"),ez:s("i<K>"),ot:s("i<M>"),aY:s("i<c9>"),oQ:s("i<bN>"),I:s("i<a7>"),cn:s("i<+(+(h,h),h)>"),aE:s("i<aI>"),cP:s("i<bS>"),eP:s("i<bA>"),iZ:s("i<cH>"),o:s("i<h>"),gs:s("i<@>"),L:s("i<c>"),hQ:s("i<ck?>"),oT:s("i<bD>"),dj:s("bv<F,T>"),dV:s("bL<F,c>"),av:s("bL<@,@>"),eb:s("dH"),dQ:s("cq"),aj:s("b8"),mR:s("cW"),hD:s("cX"),P:s("ap"),K:s("K"),l5:s("at"),dF:s("hU<+(c,U),cz>"),hv:s("M"),jL:s("dM"),eB:s("c9"),ge:s("a_"),ob:s("ak"),bM:s("bN"),oh:s("aR"),e:s("a7"),b0:s("cb"),ba:s("dP"),lZ:s("yO"),aK:s("+()"),gB:s("+(bC,bC)"),aL:s("+(h,h)"),lG:s("+(c,U)"),R:s("+(c,c)"),i0:s("+(ak,c,c)"),F:s("cc"),on:s("f_<h>"),bB:s("id<p>"),Z:s("bd<aO>"),k:s("cB"),N:s("F"),aJ:s("X"),do:s("cd"),p:s("aI"),cx:s("cC"),iQ:s("fd<h>"),mj:s("bS"),aG:s("da"),U:s("bT"),jE:s("fk"),is:s("fl<cz>"),_:s("aq<@>"),dI:s("fs<y>"),c4:s("dW"),kb:s("fB"),lp:s("cG<av>"),l_:s("cG<+(h,h)>"),bp:s("cH"),y:s("U"),iW:s("U(K)"),i:s("h"),z:s("@"),mY:s("@()"),mq:s("@(K)"),ng:s("@(K,cB)"),S:s("c"),ir:s("T?"),gK:s("bH<ap>?"),er:s("ck?"),fW:s("cl?"),jH:s("kf?"),mU:s("ag?"),gv:s("bJ?"),nE:s("i<h>?"),iM:s("i<ck?>?"),X:s("K?"),ex:s("aH?"),eM:s("d0?"),bd:s("d1?"),ak:s("ak?"),gE:s("cz?"),as:s("+(aI,aI)?"),jv:s("F?"),J:s("aI?"),bA:s("bS?"),lX:s("iD?"),d:s("db<@,@>?"),nF:s("iW?"),o9:s("U?"),jX:s("h?"),aV:s("c?"),jh:s("bD?"),v:s("bD"),q:s("~"),M:s("~()"),mX:s("~(cm,i<c>)"),gf:s("~(i<aZ>,p,a_)")}})();(function constants(){var s=hunkHelpers.makeConstList
 B.ds=J.hB.prototype
 B.a=J.n.prototype
 B.b=J.dA.prototype
 B.c=J.dB.prototype
-B.f=J.cT.prototype
+B.f=J.cS.prototype
 B.dt=J.bJ.prototype
 B.du=J.eC.prototype
 B.u=A.eI.prototype
@@ -22200,7 +22200,7 @@ B.D=A.eK.prototype
 B.eo=A.eL.prototype
 B.Y=A.eN.prototype
 B.k=A.eO.prototype
-B.d=A.cY.prototype
+B.d=A.cX.prototype
 B.bY=J.i6.prototype
 B.as=J.cC.prototype
 B.ck=new A.h4(0,"littleEndian")
@@ -22347,11 +22347,11 @@ B.cv=new A.hI()
 B.cw=new A.hL()
 B.cx=new A.hS()
 B.aF=new A.dJ()
-B.A=new A.d_()
+B.A=new A.cZ()
 B.p=new A.ba()
 B.aG=new A.dL()
-B.v=new A.d5()
-B.q=new A.d6()
+B.v=new A.d4()
+B.q=new A.d5()
 B.h=new A.le()
 B.cy=new A.ih()
 B.cz=new A.ir()
@@ -22749,8 +22749,8 @@ B.hi=new A.t(3,32,65808)
 B.ef=s([B.hb,B.hg,B.hh,B.a6,B.hi],t.E)
 B.eg=s([0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,0,0],t.t)
 B.eh=s([".notdef",".null","nonmarkingreturn","space","exclam","quotedbl","numbersign","dollar","percent","ampersand","quotesingle","parenleft","parenright","asterisk","plus","comma","hyphen","period","slash","zero","one","two","three","four","five","six","seven","eight","nine","colon","semicolon","less","equal","greater","question","at","A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z","bracketleft","backslash","bracketright","asciicircum","underscore","grave","a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z","braceleft","bar","braceright","asciitilde","Adieresis","Aring","Ccedilla","Eacute","Ntilde","Odieresis","Udieresis","aacute","agrave","acircumflex","adieresis","atilde","aring","ccedilla","eacute","egrave","ecircumflex","edieresis","iacute","igrave","icircumflex","idieresis","ntilde","oacute","ograve","ocircumflex","odieresis","otilde","uacute","ugrave","ucircumflex","udieresis","dagger","degree","cent","sterling","section","bullet","paragraph","germandbls","registered","copyright","trademark","acute","dieresis","notequal","AE","Oslash","infinity","plusminus","lessequal","greaterequal","yen","mu","partialdiff","summation","product","pi","integral","ordfeminine","ordmasculine","Omega","ae","oslash","questiondown","exclamdown","logicalnot","radical","florin","approxequal","Delta","guillemotleft","guillemotright","ellipsis","nonbreakingspace","Agrave","Atilde","Otilde","OE","oe","endash","emdash","quotedblleft","quotedblright","quoteleft","quoteright","divide","lozenge","ydieresis","Ydieresis","fraction","currency","guilsinglleft","guilsinglright","fi","fl","daggerdbl","periodcentered","quotesinglbase","quotedblbase","perthousand","Acircumflex","Ecircumflex","Aacute","Edieresis","Egrave","Iacute","Icircumflex","Idieresis","Igrave","Oacute","Ocircumflex","apple","Ograve","Uacute","Ucircumflex","Ugrave","dotlessi","circumflex","tilde","macron","breve","dotaccent","ring","cedilla","hungarumlaut","ogonek","caron","Lslash","lslash","Scaron","scaron","Zcaron","zcaron","brokenbar","Eth","eth","Yacute","yacute","Thorn","thorn","minus","multiply","onesuperior","twosuperior","threesuperior","onehalf","onequarter","threequarters","franc","Gbreve","gbreve","Idotaccent","Scedilla","scedilla","Cacute","cacute","Ccaron","ccaron","dcroat"],t.s)
-B.ei=new A.bt([128,"Euro",130,"quotesinglbase",131,"florin",132,"quotedblbase",133,"ellipsis",134,"dagger",135,"daggerdbl",136,"circumflex",137,"perthousand",138,"Scaron",139,"guilsinglleft",140,"OE",142,"Zcaron",145,"quoteleft",146,"quoteright",147,"quotedblleft",148,"quotedblright",149,"bullet",150,"endash",151,"emdash",152,"tilde",153,"trademark",154,"scaron",155,"guilsinglright",156,"oe",158,"zcaron",159,"Ydieresis",160,"space",161,"exclamdown",162,"cent",163,"sterling",164,"currency",165,"yen",166,"brokenbar",167,"section",168,"dieresis",169,"copyright",170,"ordfeminine",171,"guillemotleft",172,"logicalnot",173,"hyphen",174,"registered",175,"macron",176,"degree",177,"plusminus",178,"twosuperior",179,"threesuperior",180,"acute",181,"mu",182,"paragraph",183,"periodcentered",184,"cedilla",185,"onesuperior",186,"ordmasculine",187,"guillemotright",188,"onequarter",189,"onehalf",190,"threequarters",191,"questiondown",192,"Agrave",193,"Aacute",194,"Acircumflex",195,"Atilde",196,"Adieresis",197,"Aring",198,"AE",199,"Ccedilla",200,"Egrave",201,"Eacute",202,"Ecircumflex",203,"Edieresis",204,"Igrave",205,"Iacute",206,"Icircumflex",207,"Idieresis",208,"Eth",209,"Ntilde",210,"Ograve",211,"Oacute",212,"Ocircumflex",213,"Otilde",214,"Odieresis",215,"multiply",216,"Oslash",217,"Ugrave",218,"Uacute",219,"Ucircumflex",220,"Udieresis",221,"Yacute",222,"Thorn",223,"germandbls",224,"agrave",225,"aacute",226,"acircumflex",227,"atilde",228,"adieresis",229,"aring",230,"ae",231,"ccedilla",232,"egrave",233,"eacute",234,"ecircumflex",235,"edieresis",236,"igrave",237,"iacute",238,"icircumflex",239,"idieresis",240,"eth",241,"ntilde",242,"ograve",243,"oacute",244,"ocircumflex",245,"otilde",246,"odieresis",247,"divide",248,"oslash",249,"ugrave",250,"uacute",251,"ucircumflex",252,"udieresis",253,"yacute",254,"thorn",255,"ydieresis"],t.A)
-B.ej=new A.bt([41377,12288,41389,8230,41896,65288,41897,65289,41900,65292,41905,65297,41906,65298,41907,65299,41909,65301,41910,65302,41912,65304,41913,65305,45259,20843,45484,29190,45536,32534,45759,37096,45818,20135,46038,25345,46532,30340,46544,25932,46552,22320,46784,29420,46792,24230,46799,26029,46804,23545,46846,20108,47010,21457,47037,26041,47040,38450,47300,25913,47351,21508,47576,20851,47610,22269,47823,21512,47852,32418,47859,21518,48119,20987,48304,21450,48353,22362,48379,35265,48595,25509,48610,35299,48615,30028,48837,20061,48892,20891,49066,24320,49332,26469,49570,31435,49578,32852,49847,36335,49852,24405,49876,30053,50367,30446,50383,21335,50410,24180,50640,21028,50911,19971,50928,36215,51106,27965,51115,35878,51177,24773,51192,21306,51371,20840,51406,20219,51413,26085,51453,19977,51645,23665,51886,21313,51889,26102,51893,23454,51904,19990,51910,21183,51917,37322,51952,32626,52164,22235,52396,24577,52408,35848,52450,39064,52652,21516,52938,38382,52958,26080,52977,21153,52983,35199,53454,24418,53456,34892,53687,36874,53930,35201,53947,19968,53986,24847,54182,24212,54222,28216,54224,26377,54234,20110,54251,19982,54445,21407,54466,26376,54490,22312,54514,21017,54713,23637,54717,25112,54751,32773,54763,38024,54777,20105,54992,20013,55031,20027,55252,33258,55287,20316],t.B)
+B.ei=new A.bt([128,"Euro",130,"quotesinglbase",131,"florin",132,"quotedblbase",133,"ellipsis",134,"dagger",135,"daggerdbl",136,"circumflex",137,"perthousand",138,"Scaron",139,"guilsinglleft",140,"OE",142,"Zcaron",145,"quoteleft",146,"quoteright",147,"quotedblleft",148,"quotedblright",149,"bullet",150,"endash",151,"emdash",152,"tilde",153,"trademark",154,"scaron",155,"guilsinglright",156,"oe",158,"zcaron",159,"Ydieresis",160,"space",161,"exclamdown",162,"cent",163,"sterling",164,"currency",165,"yen",166,"brokenbar",167,"section",168,"dieresis",169,"copyright",170,"ordfeminine",171,"guillemotleft",172,"logicalnot",173,"hyphen",174,"registered",175,"macron",176,"degree",177,"plusminus",178,"twosuperior",179,"threesuperior",180,"acute",181,"mu",182,"paragraph",183,"periodcentered",184,"cedilla",185,"onesuperior",186,"ordmasculine",187,"guillemotright",188,"onequarter",189,"onehalf",190,"threequarters",191,"questiondown",192,"Agrave",193,"Aacute",194,"Acircumflex",195,"Atilde",196,"Adieresis",197,"Aring",198,"AE",199,"Ccedilla",200,"Egrave",201,"Eacute",202,"Ecircumflex",203,"Edieresis",204,"Igrave",205,"Iacute",206,"Icircumflex",207,"Idieresis",208,"Eth",209,"Ntilde",210,"Ograve",211,"Oacute",212,"Ocircumflex",213,"Otilde",214,"Odieresis",215,"multiply",216,"Oslash",217,"Ugrave",218,"Uacute",219,"Ucircumflex",220,"Udieresis",221,"Yacute",222,"Thorn",223,"germandbls",224,"agrave",225,"aacute",226,"acircumflex",227,"atilde",228,"adieresis",229,"aring",230,"ae",231,"ccedilla",232,"egrave",233,"eacute",234,"ecircumflex",235,"edieresis",236,"igrave",237,"iacute",238,"icircumflex",239,"idieresis",240,"eth",241,"ntilde",242,"ograve",243,"oacute",244,"ocircumflex",245,"otilde",246,"odieresis",247,"divide",248,"oslash",249,"ugrave",250,"uacute",251,"ucircumflex",252,"udieresis",253,"yacute",254,"thorn",255,"ydieresis"],t.B)
+B.ej=new A.bt([41377,12288,41389,8230,41896,65288,41897,65289,41900,65292,41905,65297,41906,65298,41907,65299,41909,65301,41910,65302,41912,65304,41913,65305,45259,20843,45484,29190,45536,32534,45759,37096,45818,20135,46038,25345,46532,30340,46544,25932,46552,22320,46784,29420,46792,24230,46799,26029,46804,23545,46846,20108,47010,21457,47037,26041,47040,38450,47300,25913,47351,21508,47576,20851,47610,22269,47823,21512,47852,32418,47859,21518,48119,20987,48304,21450,48353,22362,48379,35265,48595,25509,48610,35299,48615,30028,48837,20061,48892,20891,49066,24320,49332,26469,49570,31435,49578,32852,49847,36335,49852,24405,49876,30053,50367,30446,50383,21335,50410,24180,50640,21028,50911,19971,50928,36215,51106,27965,51115,35878,51177,24773,51192,21306,51371,20840,51406,20219,51413,26085,51453,19977,51645,23665,51886,21313,51889,26102,51893,23454,51904,19990,51910,21183,51917,37322,51952,32626,52164,22235,52396,24577,52408,35848,52450,39064,52652,21516,52938,38382,52958,26080,52977,21153,52983,35199,53454,24418,53456,34892,53687,36874,53930,35201,53947,19968,53986,24847,54182,24212,54222,28216,54224,26377,54234,20110,54251,19982,54445,21407,54466,26376,54490,22312,54514,21017,54713,23637,54717,25112,54751,32773,54763,38024,54777,20105,54992,20013,55031,20027,55252,33258,55287,20316],t.iG)
 B.ep={FlateDecode:0,Fl:1,ASCIIHexDecode:2,AHx:3,ASCII85Decode:4,A85:5,LZWDecode:6,LZW:7,RunLengthDecode:8,RL:9,CCITTFaxDecode:10,CCF:11}
 B.aB=new A.hp()
 B.az=new A.fY()
@@ -22759,18 +22759,18 @@ B.aE=new A.hN()
 B.aH=new A.i9()
 B.aA=new A.h8()
 B.ek=new A.aY(B.ep,[B.aB,B.aB,B.az,B.az,B.ay,B.ay,B.aE,B.aE,B.aH,B.aH,B.aA,B.aA],A.ae("aY<F,bF>"))
-B.bg=new A.bt([34665,"exif",40965,"interop",34853,"gps"],t.A)
+B.bg=new A.bt([34665,"exif",40965,"interop",34853,"gps"],t.B)
 B.er={space:0,quotedbl:1,quotesingle:2,grave:3,circumflex:4,tilde:5,breve:6,dotaccent:7,ring:8,caron:9,hungarumlaut:10,ogonek:11,exclamdown:12,cent:13,sterling:14,currency:15,yen:16,brokenbar:17,section:18,dieresis:19,copyright:20,ordfeminine:21,guillemotleft:22,logicalnot:23,registered:24,macron:25,degree:26,plusminus:27,twosuperior:28,threesuperior:29,acute:30,mu:31,paragraph:32,periodcentered:33,cedilla:34,onesuperior:35,ordmasculine:36,guillemotright:37,onequarter:38,onehalf:39,threequarters:40,questiondown:41,Agrave:42,Aacute:43,Acircumflex:44,Atilde:45,Adieresis:46,Aring:47,AE:48,Ccedilla:49,Egrave:50,Eacute:51,Ecircumflex:52,Edieresis:53,Igrave:54,Iacute:55,Icircumflex:56,Idieresis:57,Eth:58,Ntilde:59,Ograve:60,Oacute:61,Ocircumflex:62,Otilde:63,Odieresis:64,multiply:65,Oslash:66,Ugrave:67,Uacute:68,Ucircumflex:69,Udieresis:70,Yacute:71,Thorn:72,germandbls:73,agrave:74,aacute:75,acircumflex:76,atilde:77,adieresis:78,aring:79,ae:80,ccedilla:81,egrave:82,eacute:83,ecircumflex:84,edieresis:85,igrave:86,iacute:87,icircumflex:88,idieresis:89,eth:90,ntilde:91,ograve:92,oacute:93,ocircumflex:94,otilde:95,odieresis:96,divide:97,oslash:98,ugrave:99,uacute:100,ucircumflex:101,udieresis:102,yacute:103,thorn:104,ydieresis:105,bullet:106,dagger:107,daggerdbl:108,ellipsis:109,emdash:110,endash:111,florin:112,fraction:113,guilsinglleft:114,guilsinglright:115,minus:116,perthousand:117,quotedblbase:118,quotedblleft:119,quotedblright:120,quoteleft:121,quoteright:122,quotesinglbase:123,trademark:124,fi:125,fl:126,Lslash:127,OE:128,Scaron:129,Ydieresis:130,Zcaron:131,dotlessi:132,lslash:133,oe:134,scaron:135,zcaron:136,Euro:137}
 B.bh=new A.aY(B.er,[32,34,39,96,710,732,728,729,730,711,733,731,161,162,163,164,165,166,167,168,169,170,171,172,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251,252,253,254,255,8226,8224,8225,8230,8212,8211,402,8260,8249,8250,8722,8240,8222,8220,8221,8216,8217,8218,8482,64257,64258,321,338,352,376,381,305,322,339,353,382,8364],t.cq)
 B.ai={}
 B.W=new A.aY(B.ai,[],t.cq)
 B.bi=new A.aY(B.ai,[],A.ae("aY<c,y>"))
 B.Q=new A.aY(B.ai,[],A.ae("aY<c,F>"))
-B.el=new A.bt([33,9985,34,9986,35,9987,36,9988,37,9742,38,9990,39,9991,40,9992,41,9993,42,9755,43,9758,44,9996,45,9997,46,9998,47,9999,48,1e4,49,10001,50,10002,51,10003,52,10004,53,10005,54,10006,55,10007,56,10008,57,10009,58,10010,59,10011,60,10012,61,10013,62,10014,63,10015,64,10016,65,10017,66,10018,67,10019,68,10020,69,10021,70,10022,71,10023,72,9733,73,10025,74,10026,75,10027,76,10028,77,10029,78,10030,79,10031,80,10032,81,10033,82,10034,83,10035,84,10036,85,10037,86,10038,87,10039,88,10040,89,10041,90,10042,91,10043,92,10044,93,10045,94,10046,95,10047,96,10048,97,10049,98,10050,99,10051,100,10052,101,10053,102,10054,103,10055,104,10056,105,10057,106,10058,107,10059,108,9679,109,10061,110,9632,111,10063,112,10064,113,10065,114,10066,115,9650,116,9660,117,9670,118,10070,119,9687,120,10072,121,10073,122,10074,123,10075,124,10076,125,10077,126,10078,161,10081,162,10082,163,10083,164,10084,165,10085,166,10086,167,10087,168,9827,169,9830,170,9829,171,9824,172,9312,173,9313,174,9314,175,9315,176,9316,177,9317,178,9318,179,9319,180,9320,181,9321,182,10102,183,10103,184,10104,185,10105,186,10106,187,10107,188,10108,189,10109,190,10110,191,10111,192,10112,193,10113,194,10114,195,10115,196,10116,197,10117,198,10118,199,10119,200,10120,201,10121,202,10122,203,10123,204,10124,205,10125,206,10126,207,10127,208,10128,209,10129,210,10130,211,10131,212,10132,213,8594,214,8596,215,8597,216,10136,217,10137,218,10138,219,10139,220,10140,221,10141,222,10142,223,10143,224,10144,225,10145,226,10146,227,10147,228,10148,229,10149,230,10150,231,10151,232,10152,233,10153,234,10154,235,10155,236,10156,237,10157,238,10158,239,10159,241,10161,242,10162,243,10163,244,10164,245,10165,246,10166,247,10167,248,10168,249,10169,250,10170,251,10171,252,10172,253,10173,254,10174],t.B)
-B.X=new A.bt([161,"exclamdown",162,"cent",163,"sterling",164,"fraction",165,"yen",166,"florin",167,"section",168,"currency",169,"quotesingle",170,"quotedblleft",171,"guillemotleft",172,"guilsinglleft",173,"guilsinglright",174,"fi",175,"fl",177,"endash",178,"dagger",179,"daggerdbl",180,"periodcentered",182,"paragraph",183,"bullet",184,"quotesinglbase",185,"quotedblbase",186,"quotedblright",187,"guillemotright",188,"ellipsis",189,"perthousand",191,"questiondown",193,"grave",194,"acute",195,"circumflex",196,"tilde",197,"macron",198,"breve",199,"dotaccent",200,"dieresis",202,"ring",203,"cedilla",205,"hungarumlaut",206,"ogonek",207,"caron",208,"emdash",225,"AE",227,"ordfeminine",232,"Lslash",233,"Oslash",234,"OE",235,"ordmasculine",241,"ae",245,"dotlessi",248,"lslash",249,"oslash",250,"oe",251,"germandbls"],t.A)
+B.el=new A.bt([33,9985,34,9986,35,9987,36,9988,37,9742,38,9990,39,9991,40,9992,41,9993,42,9755,43,9758,44,9996,45,9997,46,9998,47,9999,48,1e4,49,10001,50,10002,51,10003,52,10004,53,10005,54,10006,55,10007,56,10008,57,10009,58,10010,59,10011,60,10012,61,10013,62,10014,63,10015,64,10016,65,10017,66,10018,67,10019,68,10020,69,10021,70,10022,71,10023,72,9733,73,10025,74,10026,75,10027,76,10028,77,10029,78,10030,79,10031,80,10032,81,10033,82,10034,83,10035,84,10036,85,10037,86,10038,87,10039,88,10040,89,10041,90,10042,91,10043,92,10044,93,10045,94,10046,95,10047,96,10048,97,10049,98,10050,99,10051,100,10052,101,10053,102,10054,103,10055,104,10056,105,10057,106,10058,107,10059,108,9679,109,10061,110,9632,111,10063,112,10064,113,10065,114,10066,115,9650,116,9660,117,9670,118,10070,119,9687,120,10072,121,10073,122,10074,123,10075,124,10076,125,10077,126,10078,161,10081,162,10082,163,10083,164,10084,165,10085,166,10086,167,10087,168,9827,169,9830,170,9829,171,9824,172,9312,173,9313,174,9314,175,9315,176,9316,177,9317,178,9318,179,9319,180,9320,181,9321,182,10102,183,10103,184,10104,185,10105,186,10106,187,10107,188,10108,189,10109,190,10110,191,10111,192,10112,193,10113,194,10114,195,10115,196,10116,197,10117,198,10118,199,10119,200,10120,201,10121,202,10122,203,10123,204,10124,205,10125,206,10126,207,10127,208,10128,209,10129,210,10130,211,10131,212,10132,213,8594,214,8596,215,8597,216,10136,217,10137,218,10138,219,10139,220,10140,221,10141,222,10142,223,10143,224,10144,225,10145,226,10146,227,10147,228,10148,229,10149,230,10150,231,10151,232,10152,233,10153,234,10154,235,10155,236,10156,237,10157,238,10158,239,10159,241,10161,242,10162,243,10163,244,10164,245,10165,246,10166,247,10167,248,10168,249,10169,250,10170,251,10171,252,10172,253,10173,254,10174],t.iG)
+B.X=new A.bt([161,"exclamdown",162,"cent",163,"sterling",164,"fraction",165,"yen",166,"florin",167,"section",168,"currency",169,"quotesingle",170,"quotedblleft",171,"guillemotleft",172,"guilsinglleft",173,"guilsinglright",174,"fi",175,"fl",177,"endash",178,"dagger",179,"daggerdbl",180,"periodcentered",182,"paragraph",183,"bullet",184,"quotesinglbase",185,"quotedblbase",186,"quotedblright",187,"guillemotright",188,"ellipsis",189,"perthousand",191,"questiondown",193,"grave",194,"acute",195,"circumflex",196,"tilde",197,"macron",198,"breve",199,"dotaccent",200,"dieresis",202,"ring",203,"cedilla",205,"hungarumlaut",206,"ogonek",207,"caron",208,"emdash",225,"AE",227,"ordfeminine",232,"Lslash",233,"Oslash",234,"OE",235,"ordmasculine",241,"ae",245,"dotlessi",248,"lslash",249,"oslash",250,"oe",251,"germandbls"],t.B)
 B.eq={W:0,H:1,BPC:2,CS:3,F:4,D:5,DP:6,IM:7,I:8}
 B.em=new A.aY(B.eq,["Width","Height","BitsPerComponent","ColorSpace","Filter","Decode","DecodeParms","ImageMask","Interpolate"],A.ae("aY<F,F>"))
-B.en=new A.bt([24,728,25,711,26,710,27,729,28,733,29,731,30,730,31,732,128,8226,129,8224,130,8225,131,8230,132,8212,133,8211,134,402,135,8260,136,8249,137,8250,138,8722,139,8240,140,8222,141,8220,142,8221,143,8216,144,8217,145,8218,146,8482,147,64257,148,64258,149,321,150,338,151,352,152,376,153,381,154,305,155,322,156,339,157,353,158,382,160,8364],t.B)
+B.en=new A.bt([24,728,25,711,26,710,27,729,28,733,29,731,30,730,31,732,128,8226,129,8224,130,8225,131,8230,132,8212,133,8211,134,402,135,8260,136,8249,137,8250,138,8722,139,8240,140,8222,141,8220,142,8221,143,8216,144,8217,145,8218,146,8482,147,64257,148,64258,149,321,150,338,151,352,152,376,153,381,154,305,155,322,156,339,157,353,158,382,160,8364],t.iG)
 B.bx=new A.cs(0,"none")
 B.ak=new A.cs(1,"rc4")
 B.es=new A.cs(2,"aes128")
@@ -22826,7 +22826,7 @@ $.oS=!1
 $.ad=B.z
 $.oN=null
 $.of=A.x(t.S,t.N)
-$.d4=!1
+$.d3=!1
 $.ov=null
 $.i2=null
 $.l5=null
@@ -22864,7 +22864,7 @@ s($,"zb","tp",()=>new A.mZ().$0())
 s($,"zc","tq",()=>new A.mY().$0())
 s($,"z7","tm",()=>A.uT(A.b([-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-2,-1,-2,-2,-2,-2,-2,62,-2,62,-2,63,52,53,54,55,56,57,58,59,60,61,-2,-2,-2,-1,-2,-2,-2,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-2,-2,-2,-2,63,-2,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,-2,-2,-2,-2,-2],t.t)))
 s($,"z6","tl",()=>A.kw(0))
-s($,"zl","dn",()=>A.fT(B.h1))
+s($,"zl","dm",()=>A.fT(B.h1))
 s($,"yT","aB",()=>{A.vt()
 return $.ld})
 s($,"yF","t2",()=>A.tW(B.Y.gt(A.uW(A.b([1],t.t)))).getInt8(0)===1?B.T:B.N)
@@ -22936,7 +22936,7 @@ for(var o=0;;o++){var n=s(p+"_"+o+"_")
 if(!(n in q)){q[n]=1
 v.isolateTag=n
 break}}v.dispatchPropertyName=v.getIsolateTag("dispatch_record")}()
-hunkHelpers.setOrUpdateInterceptorsByTag({SharedArrayBuffer:A.cp,ArrayBuffer:A.dH,ArrayBufferView:A.eM,DataView:A.hO,Float32Array:A.eI,Float64Array:A.eJ,Int16Array:A.hP,Int32Array:A.eK,Int8Array:A.eL,Uint16Array:A.eN,Uint32Array:A.eO,Uint8ClampedArray:A.cX,CanvasPixelArray:A.cX,Uint8Array:A.cY})
+hunkHelpers.setOrUpdateInterceptorsByTag({SharedArrayBuffer:A.cp,ArrayBuffer:A.dH,ArrayBufferView:A.eM,DataView:A.hO,Float32Array:A.eI,Float64Array:A.eJ,Int16Array:A.hP,Int32Array:A.eK,Int8Array:A.eL,Uint16Array:A.eN,Uint32Array:A.eO,Uint8ClampedArray:A.cW,CanvasPixelArray:A.cW,Uint8Array:A.cX})
 hunkHelpers.setOrUpdateLeafTags({SharedArrayBuffer:true,ArrayBuffer:true,ArrayBufferView:false,DataView:true,Float32Array:true,Float64Array:true,Int16Array:true,Int32Array:true,Int8Array:true,Uint16Array:true,Uint32Array:true,Uint8ClampedArray:true,CanvasPixelArray:true,Uint8Array:false})
 A.aG.$nativeSuperclassTag="ArrayBufferView"
 A.fu.$nativeSuperclassTag="ArrayBufferView"

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -120,14 +120,21 @@ const int pdfRenderWorkerPoolMinPages = 12;
 /// backend when the document is long enough and [workerCount] (or the global
 /// [pdfRenderWorkerPoolSize] fallback) asks for parallelism, otherwise a single
 /// platform worker.
+/// [copySource] is forwarded to [PdfPooledRenderWorker]; it defaults to false
+/// here because every caller of this entry point starts the worker over a
+/// document image whose bytes don't change under it (the read-only reader, or
+/// the edit session's grow-only buffer, which is replaced rather than mutated).
+/// Skipping the pool's defensive snapshot saves a full-document allocation per
+/// worker generation - the single-worker branch never copied either.
 PdfRenderWorker startPdfRenderWorker(
   Uint8List bytes, {
   required int pageCount,
   int? workerCount,
+  bool copySource = false,
 }) {
   final count = math.max(1, workerCount ?? pdfRenderWorkerPoolSize);
   final backend = count > 1 && pageCount >= pdfRenderWorkerPoolMinPages
-      ? PdfPooledRenderWorker(bytes, count)
+      ? PdfPooledRenderWorker(bytes, count, copySource: copySource)
       : startRenderWorker(bytes);
   return PdfCachingRenderWorker(backend);
 }
@@ -176,9 +183,16 @@ abstract class PdfRenderWorker {
 
   /// Builds the uncached backend: a single platform worker, or - when
   /// [pdfRenderWorkerPoolSize] asks for more than one - a pool of them.
+  ///
+  /// Seeds without the pool's defensive copy ([copySource] false): [start]'s
+  /// document image is read-only by contract (the reader, or a progressive
+  /// first paint's sparse buffer - both immutable under the worker), so a
+  /// full-document snapshot here is pure waste on the big files #359 makes
+  /// common.
   static PdfRenderWorker _backend(Uint8List bytes) =>
       pdfRenderWorkerPoolSize > 1
-          ? PdfPooledRenderWorker(bytes, pdfRenderWorkerPoolSize)
+          ? PdfPooledRenderWorker(bytes, pdfRenderWorkerPoolSize,
+              copySource: false)
           : startRenderWorker(bytes);
 
   /// The raw platform worker, NOT wrapped in [PdfCachingRenderWorker]. Test-
@@ -411,7 +425,11 @@ abstract class PdfRenderWorker {
 /// snapshot is safe. That drops the pool's own source-byte footprint from N+1
 /// copies (a private per-worker copy plus the urgent copy) to exactly one; each
 /// worker's materialized copy inside its own isolate is unavoidable and
-/// unchanged. Size the pool to the platform via [pdfRenderWorkerPoolSize].
+/// unchanged. A caller whose buffer contents never change under the worker can
+/// drop even that one copy with `copySource: false` (see the factory), which
+/// [startPdfRenderWorker] does - so the pool then adds zero source-byte copies
+/// of its own beyond what each isolate must materialize. Size the pool to the
+/// platform via [pdfRenderWorkerPoolSize].
 ///
 /// Normally wrapped in a [PdfCachingRenderWorker] (see [PdfRenderWorker.start]),
 /// which dedups concurrent requests for one page - so the cache, not the pool,
@@ -427,9 +445,19 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
   /// keeps just this single source-byte copy instead of one per worker). [size]
   /// is clamped to at least 1; a pool of 1 is just a single worker with this
   /// routing wrapper.
-  factory PdfPooledRenderWorker(Uint8List bytes, int size) =>
+  ///
+  /// [copySource] defaults to true: the pool takes its own `Uint8List.fromList`
+  /// snapshot so it is decoupled from a caller that may mutate its buffer. Pass
+  /// false when the caller guarantees the buffer's *contents* never change under
+  /// the worker (the edit session's grow-only buffer is only ever replaced, not
+  /// mutated in place - see [startPdfRenderWorker]); the pool then seeds directly
+  /// from [bytes], saving a full-document-sized allocation on every (re)start -
+  /// worth ~one document copy per worker generation on the big files #359 makes
+  /// common.
+  factory PdfPooledRenderWorker(Uint8List bytes, int size,
+          {bool copySource = true}) =>
       PdfPooledRenderWorker._shared(
-        Uint8List.fromList(bytes),
+        copySource ? Uint8List.fromList(bytes) : bytes,
         size,
         startRenderWorker,
       );
@@ -442,9 +470,11 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
   factory PdfPooledRenderWorker.withSpawner(
     Uint8List bytes,
     int size,
-    PdfRenderWorker Function(Uint8List) spawn,
-  ) =>
-      PdfPooledRenderWorker._shared(Uint8List.fromList(bytes), size, spawn);
+    PdfRenderWorker Function(Uint8List) spawn, {
+    bool copySource = true,
+  }) =>
+      PdfPooledRenderWorker._shared(
+          copySource ? Uint8List.fromList(bytes) : bytes, size, spawn);
 
   /// Seeds every worker and the urgent lane from the already-owned [shared]
   /// snapshot (the factories above copy the caller's bytes once into it).

--- a/packages/dart_pdf_editor/lib/src/shell_session.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_session.dart
@@ -162,8 +162,13 @@ class PdfShellSessionLifecycle {
     // replaced the buffer): start a new worker generation.
     _worker?.dispose();
     final workerCount = performance.beginWorkerGeneration();
+    // The session's grow-only buffer is replaced on edit, never mutated in
+    // place, so the pool can seed from it directly - no defensive copy of a
+    // possibly-huge document (#359).
     _worker = startPdfRenderWorker(session.bytes,
-        pageCount: session.document.pageCount, workerCount: workerCount);
+        pageCount: session.document.pageCount,
+        workerCount: workerCount,
+        copySource: false);
     _workerDocument = session.document;
     _workerGenerations++;
     PdfPerfLog.log(performance.diagnostics.toString());

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -1010,6 +1010,24 @@ void main() {
       expect(seeds, hasLength(3), reason: 'the urgent worker was spawned');
       expect(identical(seeds.last, workerSeed), isTrue);
     });
+
+    test('copySource: false seeds directly from the caller buffer, no copy',
+        () {
+      final source = Uint8List.fromList(List.generate(64, (i) => i & 0xff));
+      final seeds = <Uint8List>[];
+      final pool = PdfPooledRenderWorker.withSpawner(source, 3, (bytes) {
+        seeds.add(bytes);
+        return _SeedWorker(bytes);
+      }, copySource: false);
+      addTearDown(pool.dispose);
+
+      // Every worker is seeded from the caller's very buffer - no per-pool
+      // snapshot allocation (#359: skip a full-document copy on stable bytes).
+      expect(seeds, hasLength(3));
+      expect(identical(seeds[0], source), isTrue);
+      expect(identical(seeds[1], source), isTrue);
+      expect(identical(seeds[2], source), isTrue);
+    });
   });
 }
 

--- a/packages/pdf_cos/lib/src/byte_source.dart
+++ b/packages/pdf_cos/lib/src/byte_source.dart
@@ -8,6 +8,7 @@ import 'objects.dart';
 import 'parser.dart';
 import 'perf/perf.dart';
 import 'token.dart';
+import 'xref.dart';
 
 /// A random-access, possibly asynchronous source of PDF bytes.
 ///
@@ -75,12 +76,14 @@ class PdfSourceLoadOptions {
     this.xrefWindow = 65536,
     this.coalesceGap = 65536,
     this.downloadChunk = 1 << 20,
+    this.firstPaintPages,
     this.onProgress,
   })  : assert(headWindow > 0),
         assert(tailWindow > 0),
         assert(xrefWindow > 0),
         assert(coalesceGap >= 0),
-        assert(downloadChunk > 0);
+        assert(downloadChunk > 0),
+        assert(firstPaintPages == null || firstPaintPages > 0);
 
   /// Bytes fetched from the start of the file to locate the `%PDF-` header.
   final int headWindow;
@@ -100,6 +103,21 @@ class PdfSourceLoadOptions {
   /// Chunk size used by the sequential-download fallback (unknown length or
   /// a source that cannot serve useful ranges).
   final int downloadChunk;
+
+  /// When set, fetch only the bytes needed to render the first [firstPaintPages]
+  /// page(s) - the whole page tree (so page navigation and count work) plus
+  /// those pages' content streams, resources, fonts and image XObjects - instead
+  /// of every live object. For an image-heavy document (a scan, a CAD sheet) the
+  /// live objects *are* the page images, so the default whole-object fetch is
+  /// essentially the whole file; this makes first paint a few pages' worth of
+  /// bytes. The returned buffer is deliberately incomplete (later pages' bytes
+  /// are still zero), so it is only good for rendering the covered pages - do
+  /// NOT edit or sign from it; complete the buffer first (e.g. a background
+  /// sequential read). Null keeps the original fetch-every-object behaviour.
+  ///
+  /// Falls back to fetching every object if the page tree can't be walked from
+  /// ranged reads, so a first-paint open never fails where a full one would.
+  final int? firstPaintPages;
 
   /// Optional progress callback, invoked after each fetch.
   final PdfSourceProgress? onProgress;
@@ -212,6 +230,15 @@ class _ProgressiveLoader {
 
     final offsets = await _walkXref(startXref + shift, shift);
     if (offsets.isEmpty) throw const _FallbackToFullDownload();
+
+    // Page-scoped first paint: fetch just the page tree + the first few pages'
+    // render closure. Falls through to fetching every object when the page tree
+    // can't be walked from ranged reads - so a first-paint open never fails
+    // where a whole-object open would.
+    if (options.firstPaintPages != null &&
+        await _fetchFirstPaintClosure(startXref, shift, offsets)) {
+      return _buffer;
+    }
 
     await _fetchObjects(offsets);
     return _buffer;
@@ -478,6 +505,249 @@ class _ProgressiveLoader {
     _present
       ..clear()
       ..addAll(merged);
+  }
+
+  // --- page-scoped first paint --------------------------------------------
+
+  /// Object-number → cross-reference entry, built (via [CosXrefReader]) once the
+  /// xref sections are fetched. Drives the targeted object fetches below.
+  Map<int, CosXrefEntry> _entries = const {};
+
+  /// Absolute (post-shift) offsets of every in-use object, sorted - the upper
+  /// bound for a single object's byte range is the next one.
+  List<int> _sortedInUseOffsets = const [];
+
+  /// Objects parsed during the closure walk, so a shared font/resource is
+  /// fetched and parsed once.
+  final Map<int, CosObject> _loaded = {};
+
+  /// Decoded object streams, so a /ObjStm holding several page dicts is fetched
+  /// and inflated once.
+  final Map<int, _DecodedObjStm> _objStmCache = {};
+
+  /// Fetches only the bytes needed to render the first [PdfSourceLoadOptions.
+  /// firstPaintPages] pages: the whole page tree (so navigation and page count
+  /// work) plus those pages' content, resources, fonts and image XObjects.
+  /// Returns true on success, false to fall back to fetching every object.
+  Future<bool> _fetchFirstPaintClosure(
+      int rawStartXref, int shift, List<int> sortedOffsets) async {
+    try {
+      _sortedInUseOffsets = sortedOffsets;
+      final chain = CosXrefReader(_buffer, shift: shift).walkFrom(rawStartXref);
+      _entries = chain.entries;
+
+      // CosDocument.open validates /Root (and /Encrypt) resolve, so fetch them
+      // up front or the open would trip the whole-file recovery scan.
+      final rootRef = chain.trailer['Root'];
+      if (rootRef is! CosReference) return false;
+      final catalog = await _loadObject(rootRef.objectNumber, shift);
+      if (catalog is! CosDictionary) return false;
+      final encrypt = chain.trailer['Encrypt'];
+      if (encrypt is CosReference) {
+        await _loadObject(encrypt.objectNumber, shift);
+      }
+
+      final pagesRef = catalog['Pages'];
+      if (pagesRef is! CosReference) return false;
+      final leaves = <CosDictionary>[];
+      if (!await _walkPageTree(pagesRef.objectNumber, shift, leaves, <int>{})) {
+        return false;
+      }
+      if (leaves.isEmpty) return false;
+
+      final wanted = options.firstPaintPages!;
+      final visited = <int>{};
+      for (var i = 0; i < leaves.length && i < wanted; i++) {
+        await _fetchLeafRenderClosure(leaves[i], shift, visited);
+      }
+      return true;
+    } on _FallbackToFullDownload {
+      return false;
+    } on Object {
+      // Any surprise (odd tree, malformed object, filter error on a partial
+      // stream) just means we fetch everything instead - still correct.
+      return false;
+    }
+  }
+
+  /// Walks the page tree depth-first in reading order, fetching every node and
+  /// leaf dictionary (small) and collecting the page leaves into [leaves].
+  /// Returns false on a shape it can't follow, so the caller falls back.
+  Future<bool> _walkPageTree(int nodeNumber, int shift,
+      List<CosDictionary> leaves, Set<int> visited) async {
+    if (!visited.add(nodeNumber)) return true;
+    if (visited.length > 1000000) return false;
+    final node = await _loadObject(nodeNumber, shift);
+    if (node is! CosDictionary) return false;
+    final kids = node['Kids'];
+    if (node.typeName == 'Page' || kids is! CosArray) {
+      leaves.add(node);
+      return true;
+    }
+    for (final kid in kids.items) {
+      if (kid is! CosReference) return false; // inline kid: bail to fetch-all
+      if (!await _walkPageTree(kid.objectNumber, shift, leaves, visited)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Fetches a page leaf's render dependencies: its content stream(s), its own
+  /// /Resources graph (fonts, image XObjects, and everything they reference),
+  /// and the /Resources inherited from ancestor page-tree nodes (followed via
+  /// /Parent, never /Kids - so it never pulls other pages' content).
+  Future<void> _fetchLeafRenderClosure(
+      CosDictionary leaf, int shift, Set<int> visited) async {
+    await _fetchGraph(leaf['Contents'], shift, visited);
+    var node = leaf;
+    final seenNodes = <int>{};
+    while (true) {
+      await _fetchGraph(node['Resources'], shift, visited);
+      final parent = node['Parent'];
+      if (parent is! CosReference || !seenNodes.add(parent.objectNumber)) break;
+      final p = await _loadObject(parent.objectNumber, shift);
+      if (p is! CosDictionary) break;
+      node = p;
+    }
+  }
+
+  /// Fetches the transitive closure of indirect objects reachable from [root]
+  /// (a resources dict, a /Contents ref/array, ...). Bounded: a page's resource
+  /// graph never reaches other pages.
+  Future<void> _fetchGraph(
+      CosObject? root, int shift, Set<int> visited) async {
+    if (root == null) return;
+    final queue = <CosReference>[..._enumerateRefs(root)];
+    while (queue.isNotEmpty) {
+      final ref = queue.removeLast();
+      if (!visited.add(ref.objectNumber)) continue;
+      final obj = await _loadObject(ref.objectNumber, shift);
+      if (obj != null) queue.addAll(_enumerateRefs(obj));
+    }
+  }
+
+  /// Every indirect reference contained (recursively) in [object].
+  Iterable<CosReference> _enumerateRefs(CosObject object) sync* {
+    if (object is CosReference) {
+      yield object;
+    } else if (object is CosArray) {
+      for (final item in object.items) {
+        yield* _enumerateRefs(item);
+      }
+    } else if (object is CosDictionary) {
+      for (final value in object.entries.values) {
+        yield* _enumerateRefs(value);
+      }
+    } else if (object is CosStream) {
+      yield* _enumerateRefs(object.dictionary);
+    }
+  }
+
+  /// Fetches and parses the object numbered [objectNumber] (following an
+  /// /ObjStm for a compressed object), memoized in [_loaded]. Returns null when
+  /// the object is free, missing, or can't be parsed from the fetched bytes.
+  Future<CosObject?> _loadObject(int objectNumber, int shift) async {
+    final cached = _loaded[objectNumber];
+    if (cached != null) return cached;
+    final entry = _entries[objectNumber];
+    if (entry == null) return null;
+    CosObject? result;
+    switch (entry.type) {
+      case CosXrefEntryType.inUse:
+        final start = entry.offset + shift;
+        if (start < 0 || start >= _length) return null;
+        await _fetch(start, _boundedEnd(start));
+        try {
+          final indirect = CosParser(_buffer, offset: start).parseIndirectObject();
+          if (indirect.objectNumber == objectNumber) result = indirect.object;
+        } on Object {
+          result = null;
+        }
+      case CosXrefEntryType.compressed:
+        final stream = await _loadObjStm(entry.streamObjectNumber, shift);
+        result = stream?.object(objectNumber);
+      case CosXrefEntryType.free:
+        result = null;
+    }
+    if (result != null) _loaded[objectNumber] = result;
+    return result;
+  }
+
+  /// Fetches, parses and inflates the object stream numbered [streamNumber],
+  /// memoized in [_objStmCache].
+  Future<_DecodedObjStm?> _loadObjStm(int streamNumber, int shift) async {
+    final cached = _objStmCache[streamNumber];
+    if (cached != null) return cached;
+    final entry = _entries[streamNumber];
+    if (entry == null || entry.type != CosXrefEntryType.inUse) return null;
+    final start = entry.offset + shift;
+    if (start < 0 || start >= _length) return null;
+    await _fetch(start, _boundedEnd(start));
+    try {
+      final indirect = CosParser(_buffer, offset: start).parseIndirectObject();
+      final object = indirect.object;
+      if (object is! CosStream) return null;
+      final data = decodeStream(object);
+      final n = object.dictionary['N'];
+      final first = object.dictionary['First'];
+      if (n is! CosInteger || first is! CosInteger) return null;
+      final decoded = _DecodedObjStm(data, n.value, first.value);
+      _objStmCache[streamNumber] = decoded;
+      return decoded;
+    } on Object {
+      return null;
+    }
+  }
+
+  /// The end of the object at absolute offset [start]: the next in-use object,
+  /// the next xref section, or end of file - a safe upper bound to fetch, since
+  /// the exact end is unknown until the bytes (with `endstream`/`endobj`) are
+  /// present. Mirrors [_objectEnd] but keyed by offset (binary search).
+  int _boundedEnd(int start) {
+    var end = _length;
+    final offsets = _sortedInUseOffsets;
+    var lo = 0, hi = offsets.length;
+    while (lo < hi) {
+      final mid = (lo + hi) >> 1;
+      if (offsets[mid] <= start) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    if (lo < offsets.length) end = offsets[lo];
+    for (final xref in _xrefOffsets) {
+      if (xref > start && xref < end) end = xref;
+    }
+    return end;
+  }
+}
+
+/// A decoded /ObjStm: the inflated body plus the object-number → in-body offset
+/// index, so a compressed object can be parsed on demand.
+class _DecodedObjStm {
+  _DecodedObjStm(this._data, int count, this._first) {
+    final parser = CosParser(_data);
+    for (var i = 0; i < count; i++) {
+      final number = parser.expectInteger();
+      final offset = parser.expectInteger();
+      _index[number] = offset;
+    }
+  }
+
+  final Uint8List _data;
+  final int _first;
+  final Map<int, int> _index = {};
+
+  CosObject? object(int objectNumber) {
+    final offset = _index[objectNumber];
+    if (offset == null) return null;
+    try {
+      return CosParser(_data, offset: _first + offset).parseObject();
+    } on Object {
+      return null;
+    }
   }
 }
 

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -468,9 +468,22 @@ class CosDocument {
           }
         case CosXrefEntryType.compressed:
           // objects inside an object stream were decrypted wholesale with
-          // the stream itself - never again individually (§7.6.3)
-          result = _objectStream(entry.streamObjectNumber)
-              .objectByNumber(objectNumber, entry.indexInStream);
+          // the stream itself - never again individually (§7.6.3). An object
+          // stream that can't be loaded - a broken file, or a range not yet
+          // fetched in a progressive/page-scoped open - leaves the object
+          // dangling (CosNull) rather than throwing, mirroring the in-use path
+          // above so callers that already tolerate dangling references (forms,
+          // annotations) don't fault on a partial buffer.
+          CosObject compressed;
+          try {
+            compressed = _objectStream(entry.streamObjectNumber)
+                .objectByNumber(objectNumber, entry.indexInStream);
+          } on CosParseException {
+            compressed = CosNull.instance;
+          } on RangeError {
+            compressed = CosNull.instance;
+          }
+          result = compressed;
       }
     } finally {
       _loadingObjects.remove(objectNumber);

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -478,7 +478,11 @@ class CosDocument {
           try {
             compressed = _objectStream(entry.streamObjectNumber)
                 .objectByNumber(objectNumber, entry.indexInStream);
-          } on CosParseException {
+          } on Exception {
+            // A malformed or not-yet-fetched object stream throws various
+            // exception types - CosParseException, a filter's FormatException /
+            // UnsupportedFilterException, etc. Treat them all as a dangling
+            // reference, like the in-use path's parse fallback above.
             compressed = CosNull.instance;
           } on RangeError {
             compressed = CosNull.instance;

--- a/packages/pdf_cos/test/byte_source_test.dart
+++ b/packages/pdf_cos/test/byte_source_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
@@ -353,6 +354,109 @@ void main() {
       final doc =
           await CosDocument.openSource(PdfBytesByteSource(buildClassicPdf()));
       expect(doc.catalog.typeName, 'Catalog');
+    });
+  });
+
+  group('page-scoped first paint', () {
+    // Small windows so the head/tail/xref fetches don't blanket these tiny
+    // fixtures - then a deferred page's bytes are genuinely never requested.
+
+    // Byte offset of the first occurrence of [needle] in [bytes] (the fixtures
+    // are ASCII, so a latin1 char index is the byte offset).
+    int offsetOf(Uint8List bytes, String needle) {
+      final at = latin1.decode(bytes, allowInvalid: true).indexOf(needle);
+      expect(at, greaterThanOrEqualTo(0), reason: 'missing "$needle"');
+      return at;
+    }
+
+    test('fetches only the first page, not later pages', () async {
+      final bytes = buildMultiPagePdf(8);
+      final source = RecordingSource(bytes);
+      final doc = await CosDocument.openSource(source,
+          options: const PdfSourceLoadOptions(
+              firstPaintPages: 1,
+              headWindow: 64,
+              tailWindow: 200,
+              xrefWindow: 4096));
+
+      // Page 1's content is fetched and the document opens...
+      expect(doc.catalog.typeName, 'Catalog');
+      expect(source.covers(offsetOf(bytes, '(Page 1)')), isTrue);
+      // ...but the later pages' content streams are left unfetched.
+      expect(source.covers(offsetOf(bytes, '(Page 2)')), isFalse);
+      expect(source.covers(offsetOf(bytes, '(Page 8)')), isFalse);
+
+      // The whole page tree is still fetched, so navigation and page count work
+      // (every /Type /Page dictionary is present) - the pages just render blank
+      // until their content arrives.
+      var from = 0;
+      final text = latin1.decode(bytes, allowInvalid: true);
+      while (true) {
+        final at = text.indexOf('/Type /Page /Parent', from);
+        if (at < 0) break;
+        expect(source.covers(at), isTrue, reason: 'page dict at $at unfetched');
+        from = at + 1;
+      }
+
+      // And it read far less than fetching every object.
+      final full = RecordingSource(bytes);
+      await CosDocument.openSource(full,
+          options: const PdfSourceLoadOptions(
+              headWindow: 64,
+              tailWindow: 200,
+              xrefWindow: 4096));
+      expect(source.bytesFetched, lessThan(full.bytesFetched));
+    });
+
+    test('firstPaintPages: 3 covers the first three pages only', () async {
+      final bytes = buildMultiPagePdf(8);
+      final source = RecordingSource(bytes);
+      await CosDocument.openSource(source,
+          options: const PdfSourceLoadOptions(
+              firstPaintPages: 3,
+              headWindow: 64,
+              tailWindow: 200,
+              xrefWindow: 4096));
+      expect(source.covers(offsetOf(bytes, '(Page 3)')), isTrue);
+      expect(source.covers(offsetOf(bytes, '(Page 4)')), isFalse);
+    });
+
+    test('page 1 is fully resolvable from the partial buffer', () async {
+      final bytes = buildMultiPagePdf(5);
+      final doc = await CosDocument.openSource(RecordingSource(bytes),
+          options: const PdfSourceLoadOptions(
+              firstPaintPages: 1,
+              headWindow: 64,
+              tailWindow: 200,
+              xrefWindow: 4096));
+      // catalog → pages → first kid → its content stream decodes to page 1.
+      final pages = doc.resolve(doc.catalog['Pages']) as CosDictionary;
+      final firstKid =
+          doc.resolve((pages['Kids'] as CosArray).items.first) as CosDictionary;
+      final content = doc.resolve(firstKid['Contents']) as CosStream;
+      expect(latin1.decode(doc.decodeStreamData(content)), contains('(Page 1)'));
+    });
+
+    test('handles a compressed (object-stream) page dictionary', () async {
+      // The single page's dict lives inside an /ObjStm, exercising the
+      // compressed-object fetch/decode path of the page walk.
+      final doc = await CosDocument.openSource(
+          RecordingSource(buildXrefStreamPdf()),
+          options: const PdfSourceLoadOptions(firstPaintPages: 1));
+      final pages = doc.resolve(doc.catalog['Pages']) as CosDictionary;
+      expect(pages.typeName, 'Pages');
+      final firstKid =
+          doc.resolve((pages['Kids'] as CosArray).items.first) as CosDictionary;
+      expect(firstKid.typeName, 'Page');
+    });
+
+    test('falls back to fetching everything when firstPaintPages is null',
+        () async {
+      final bytes = buildMultiPagePdf(4);
+      final source = RecordingSource(bytes);
+      await CosDocument.openSource(source);
+      // The default path still fetches every page's content.
+      expect(source.covers(offsetOf(bytes, '(Page 4)')), isTrue);
     });
   });
 }

--- a/packages/pdf_cos/test/document_test.dart
+++ b/packages/pdf_cos/test/document_test.dart
@@ -79,6 +79,16 @@ void main() {
       // /Extra is marked compressed in an object stream that does not exist.
       expect(doc.resolve(doc.catalog['Extra']), isA<CosNull>());
     });
+
+    test('a compressed object in an undecodable object stream resolves to null',
+        () {
+      // The object stream exists but its /FlateDecode body is garbage, so the
+      // decoder throws a FormatException (not a CosParseException) - which must
+      // still resolve to a dangling null rather than crashing the caller.
+      final doc = CosDocument.open(_corruptObjStmPdf());
+      expect(doc.catalog.typeName, 'Catalog');
+      expect(doc.resolve(doc.catalog['Extra']), isA<CosNull>());
+    });
   });
 
   test('junk before the header shifts offsets', () {
@@ -290,6 +300,51 @@ Uint8List _danglingCompressedPdf() {
       ..addAll([(row[2] >> 8) & 0xFF, row[2] & 0xFF]);
   }
   out.write('3 0 obj\n<< /Type /XRef /Size 5 /W [1 4 2] /Root 1 0 R '
+      '/Length ${xrefData.length} >>\nstream\n');
+
+  return (BytesBuilder()
+        ..add(ascii(out.toString()))
+        ..add(xrefData)
+        ..add(ascii('\nendstream\nendobj\nstartxref\n$xrefOffset\n%%EOF\n')))
+      .takeBytes();
+}
+
+/// Like [_danglingCompressedPdf], but object 4 lives in a real object stream
+/// (object 5) whose /FlateDecode body is garbage - so decoding it throws a
+/// FormatException, exercising the non-CosParseException leniency path.
+Uint8List _corruptObjStmPdf() {
+  final out = StringBuffer('%PDF-1.5\n');
+  final offset1 = out.length;
+  out.write('1 0 obj\n<< /Type /Catalog /Pages 2 0 R /Extra 4 0 R >>\nendobj\n');
+  final offset2 = out.length;
+  out.write('2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n');
+  final offset5 = out.length;
+  const garbage = 'not valid deflate data';
+  out.write('5 0 obj\n<< /Type /ObjStm /N 1 /First 6 /Filter /FlateDecode '
+      '/Length ${garbage.length} >>\nstream\n$garbage\nendstream\nendobj\n');
+
+  final xrefOffset = out.length;
+  final rows = <List<int>>[
+    [0, 0, 0xFFFF], // 0: free-list head
+    [1, offset1, 0], // 1: catalog
+    [1, offset2, 0], // 2: pages
+    [1, xrefOffset, 0], // 3: this xref stream
+    [2, 5, 0], // 4: compressed in object stream 5, index 0
+    [1, offset5, 0], // 5: the (corrupt) object stream
+  ];
+  final xrefData = <int>[];
+  for (final row in rows) {
+    xrefData
+      ..add(row[0])
+      ..addAll([
+        (row[1] >> 24) & 0xFF,
+        (row[1] >> 16) & 0xFF,
+        (row[1] >> 8) & 0xFF,
+        row[1] & 0xFF,
+      ])
+      ..addAll([(row[2] >> 8) & 0xFF, row[2] & 0xFF]);
+  }
+  out.write('3 0 obj\n<< /Type /XRef /Size 6 /W [1 4 2] /Root 1 0 R '
       '/Length ${xrefData.length} >>\nstream\n');
 
   return (BytesBuilder()

--- a/packages/pdf_cos/test/document_test.dart
+++ b/packages/pdf_cos/test/document_test.dart
@@ -66,6 +66,19 @@ void main() {
       expect(page.typeName, 'Page');
       expect((doc.resolve(page['MediaBox']) as CosArray).length, 4);
     });
+
+    test('a compressed object in a missing object stream resolves to null',
+        () {
+      // A page-scoped / progressive open leaves some object streams unfetched
+      // (zeros). Objects the xref marks as living inside one must resolve to a
+      // dangling null - like an in-use object at a junk offset - not throw, so
+      // callers that already tolerate dangling references (forms, annotations)
+      // don't fault on a partial buffer.
+      final doc = CosDocument.open(_danglingCompressedPdf());
+      expect(doc.catalog.typeName, 'Catalog'); // /Root is reachable
+      // /Extra is marked compressed in an object stream that does not exist.
+      expect(doc.resolve(doc.catalog['Extra']), isA<CosNull>());
+    });
   });
 
   test('junk before the header shifts offsets', () {
@@ -243,4 +256,45 @@ void main() {
       expect(doc.catalog.typeName, 'Catalog');
     });
   });
+}
+
+/// A cross-reference-stream PDF whose object 4 (/Extra on the catalog) is marked
+/// as compressed inside object stream 99 - which does not exist. The catalog
+/// (/Root) and pages node stay uncompressed so the document opens; resolving
+/// /Extra must yield a dangling null rather than throwing.
+Uint8List _danglingCompressedPdf() {
+  final out = StringBuffer('%PDF-1.5\n');
+  final offset1 = out.length;
+  out.write('1 0 obj\n<< /Type /Catalog /Pages 2 0 R /Extra 4 0 R >>\nendobj\n');
+  final offset2 = out.length;
+  out.write('2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n');
+
+  final xrefOffset = out.length;
+  final rows = <List<int>>[
+    [0, 0, 0xFFFF], // 0: free-list head
+    [1, offset1, 0], // 1: catalog
+    [1, offset2, 0], // 2: pages
+    [1, xrefOffset, 0], // 3: this xref stream
+    [2, 99, 0], // 4: "compressed" in the non-existent stream 99
+  ];
+  final xrefData = <int>[];
+  for (final row in rows) {
+    xrefData
+      ..add(row[0])
+      ..addAll([
+        (row[1] >> 24) & 0xFF,
+        (row[1] >> 16) & 0xFF,
+        (row[1] >> 8) & 0xFF,
+        row[1] & 0xFF,
+      ])
+      ..addAll([(row[2] >> 8) & 0xFF, row[2] & 0xFF]);
+  }
+  out.write('3 0 obj\n<< /Type /XRef /Size 5 /W [1 4 2] /Root 1 0 R '
+      '/Length ${xrefData.length} >>\nstream\n');
+
+  return (BytesBuilder()
+        ..add(ascii(out.toString()))
+        ..add(xrefData)
+        ..add(ascii('\nendstream\nendobj\nstartxref\n$xrefOffset\n%%EOF\n')))
+      .takeBytes();
 }


### PR DESCRIPTION
Closes #359.

The app's own open path never used the ranged byte-source API from #325/#328 — every open (File menu, drag-drop, recents, OS "open with", session restore) slurped the complete file with `readAsBytes` before `PdfDocument.open` saw a byte. On a big cloud-synced document (the measured case: a 198-page 179 MB scanned book in OneDrive Files-On-Demand) that's ~36 s of pure byte transport on *every* open. This wires the desktop open paths through the progressive loader so the viewer paints from a few MB of ranges in ~1–2 s, then streams the rest in behind the first paint.

## What changed

**1. The local-file byte source (the missing half of #328)**
- `PdfFileByteSource` (`app/lib/pdf_file_source_io.dart`) — a `PdfByteSource` over one `RandomAccessFile`, reads serialized on the shared handle, with `PdfCancelToken` + progress mirroring `PdfHttpByteSource`. Web stub + conditional-export facade (`dart:io` can't live in any package `lib/`).
- `PdfBookmarkFileByteSource` (`app/lib/pdf_bookmark_source.dart`) — for sandboxed macOS, reads ranges through a new native `readFileRange`/`fileLength` (`MainFlutterWindow.swift`), reactivating the security scope per call. A file reopened across launches can't be read by a raw RAF.
- `file_io.dart` gains `pdfByteSourceForPath` (picks the right source), `progressiveOpenSupported` (desktop + real path), and `readSourceFully` (reassembles the **complete** contiguous buffer with progress — the sparse buffer `openSource` builds is renderable but unsafe for the edit session / signing).

**2. First paint from ranges, full bytes behind it**
- New `DocumentTab.preview` renders the sparse progressive document **read-only** for the first paint. `EditorScreen._openProgressive` shows a `_ProgressivePreview` (a `PdfReader` + slim progress bar), then `_swapPreviewToDocument` replaces it with a full edit session once `readSourceFully` lands — same `documentId`, so viewport/search memory carries across the swap. Save / Digitally sign are gated on `session != null`, so they stay disabled during the preview and light up after the swap.
- Wired into single-file desktop opens: pick, recents, OS-open, drag-drop. Batch opens keep the deferred whole-file path. Any progressive-open failure falls back to the plain full read, so nothing regresses.
- Milestones are logged to the **F12 devtools** panel; `PdfPerfPhase.sourceFetch` already times the fetch.
- **Lazy page-scoped first paint.** The progressive loader (`PdfSourceLoadOptions.firstPaintPages`, pdf_cos) fetches only what the first page needs — the whole page tree (so count/navigation work) plus page 1's `/Contents`+`/Resources` closure — not every live object. This matters because for a scanned/CAD file the live objects *are* the page images, so the naïve fetch was the whole file (the perf export showed `sourceFetch` = 36 s / 211 MB before first paint); page-scoped drops that to ~1 page (~1 MB). `CosDocument.getObject` now returns a dangling `CosNull` for a compressed object in a not-yet-fetched object stream (mirroring the in-use path), so the preview tolerates the partial buffer instead of red-screening on eagerly-resolved AcroForm fields.

**2b. Lazy + progressive session restore**
- A new `DocumentTab.deferredPath` holds only a path — no bytes read at launch. Restore probes each desktop file's length (cheap metadata, no content read / cloud hydration) so a moved/deleted file is still dropped silently, then adds a path-only tab that opens progressively when first shown. A `_restoringSession` flag suppresses materialization while tabs are re-added, so only the tab left active when restore finishes opens; the rest read nothing until visited. This removes the old cost where restore `await readPdfAtPath`'d the whole bytes of *every* restored file at launch.

**3. Fewer render-worker byte copies**
- `PdfPooledRenderWorker` gains `copySource` (default true, public contract unchanged). `startPdfRenderWorker` and `PdfRenderWorker.start`/`_backend` pass `false` — their bytes never change under the worker (the edit session's grow-only buffer is *replaced*, not mutated in place; reader/preview bytes are read-only), so the pool skips its defensive full-document snapshot copy. The bigger shared-source model is left as a follow-up.
- Snapshot-behind-first-paint needs no change: `cacheOpenedPdf` is mobile-only and progressive open is desktop-only, so they don't intersect; the mobile snapshot already runs off the hot path.

## Platform coverage
- **Windows / Linux**: the plain `RandomAccessFile` path (no bookmark/native code). OneDrive Files-On-Demand on Windows gets the same partial-hydration benefit.
- **macOS**: the native bookmark ranged read (sandboxed).
- **web**: no filesystem; the source stub throws if ever constructed.
- **mobile (not covered — a real follow-up, not "already in memory")**: you *can* pick a OneDrive/iCloud file on a phone, and it *does* pay full cloud transport — but that happens **inside the OS document picker's copy**, before the app sees a byte or a path (`file_selector_android` streams the content URI into `{cacheDir}/{uuid}/`; `file_selector_ios` uses `UIDocumentPickerViewController(in: .import)`, which copies). So app-level ranged open can't intercept the current pick flow. Making mobile progressive needs a custom picker (Android `ACTION_OPEN_DOCUMENT` keeping the content Uri; iOS `.open` + security-scoped URL) plus native ranged reads (`ContentResolver.openFileDescriptor`, often non-seekable for cloud providers; iOS `NSFileCoordinator`+`FileHandle`) — a separate, provider-dependent effort, tracked in #364. Note mobile *reopens* already read a local snapshot, so only the first pick pays transport.

## Testing
- `app/test/pdf_file_source_test.dart` — ranged reads, past-EOF clamp/short read, progress, cancellation, concurrent reads, `readSourceFully` exactness, end-to-end `PdfDocument.openSource`.
- `app/test/progressive_open_test.dart` — a desktop path-open (platform → Linux, i.e. the RAF branch shared with Windows) first-paints and swaps to a `PdfEditorView`; lazy-progressive session restore; silent drop of a gone restored file.
- `render_worker_test.dart` — `copySource: false` seeds workers directly from the caller buffer.
- Full app suite (221 tests) + worker suites green; `dart analyze` clean.
- **Verified live on macOS**: opened a 58 MB CAD file through the native bookmark ranged path — renders as a full editable session; F12 devtools panel functional. (Windows rests on the shared RAF code path + `dart analyze`; not run on a live Windows build here.)

Dev-log: `doc/dev-log/2026-07-18-progressive-file-open.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


