### PR TITLE
fix(#360): devtools tile counters read the effective store, not just the override

### DIFF
--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -137,7 +137,9 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
   Future<void> _exportSnapshot() async {
     final frames = _tools.frameStats();
     final session = widget.session;
-    final store = PdfPageView.debugTileStoreOverride;
+    final store = PdfPageView.tileStoreDetail
+        ? (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+        : PdfPageView.debugTileStoreOverride;
     final snapshot = <String, Object?>{
       'tool': 'dartpdf-devtools',
       'exportedAt': DateTime.now().toIso8601String(),
@@ -522,7 +524,9 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
   void _persist() => unawaited(_tools.persistOptions());
 
   Widget _deepZoomSection(ThemeData theme) {
-    final store = PdfPageView.debugTileStoreOverride;
+    final store = PdfPageView.tileStoreDetail
+        ? (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+        : PdfPageView.debugTileStoreOverride;
     return _section(theme, 'Deep-zoom detail (#314)', [
       RadioGroup<String>(
         groupValue: _deepZoomMode,


### PR DESCRIPTION
## Problem

The F12 devtools snapshot (both the JSON export and the live "Deep-zoom detail (#314)" panel) read the tile store from `PdfPageView.debugTileStoreOverride`, which is **only non-null when someone manually flips the deep-zoom mode in devtools** (that path spawns a fresh override `PdfTileStore`).

On the **default desktop path**, tiles are served from `PdfTileStore.instance` and the override is `null` — so the entire `tileStore` counter block (`scheduled` / `landed` / `discarded` / `batches`) was **omitted from the snapshot on the exact platform where the #314 tile pyramid ships on-by-default.**

This is a diagnostics blind spot: while investigating tile eviction-thrash / green-grid flicker on macOS release (198-page CAD book, tiles cache pegged at its 100 MB budget, every frame janking), the on-device traces couldn't show the real tile-store churn counters, because the panel was reading the wrong (null) store. The tiles *cache* row survived only because it comes from a separate cache registry.

## Fix

Read the *effective* store — mirroring the render path (`debugTileStoreOverride ?? PdfTileStore.instance`) — but only when the tile path is actually enabled:

```dart
final store = PdfPageView.tileStoreDetail
    ? (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
    : PdfPageView.debugTileStoreOverride;
```

In `patch` mode (`tileStoreDetail == false`) the ternary yields `null`, so the existing `if (store != null)` guard still omits the block — no misleading empty block, and no needless lazy instantiation of the singleton. Applied in both `_exportSnapshot` and `_deepZoomSection`.

Diagnostics-only change; no behavior change to the tile pyramid itself.

## Verification

- `fvm dart analyze` (root): **No issues found**
- `app/test/devtools_panel_test.dart` + `devtools_options_test.dart`: **7/7 pass**

## Context

This unblocks confirming/quantifying the tile eviction-thrash on the default desktop path (issues #314 / #360). Root-cause fix for the thrash itself (a `viewFor` budget-vs-demand guard + intra-frame eviction pin) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)