### PR TITLE
fix(#314/#360): budget-vs-demand guard for the tile pyramid — kill the deep-zoom eviction thrash

### DIFF
--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -137,7 +137,9 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
   Future<void> _exportSnapshot() async {
     final frames = _tools.frameStats();
     final session = widget.session;
-    final store = PdfPageView.debugTileStoreOverride;
+    final store = PdfPageView.tileStoreDetail
+        ? (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+        : PdfPageView.debugTileStoreOverride;
     final snapshot = <String, Object?>{
       'tool': 'dartpdf-devtools',
       'exportedAt': DateTime.now().toIso8601String(),
@@ -522,7 +524,9 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
   void _persist() => unawaited(_tools.persistOptions());
 
   Widget _deepZoomSection(ThemeData theme) {
-    final store = PdfPageView.debugTileStoreOverride;
+    final store = PdfPageView.tileStoreDetail
+        ? (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance)
+        : PdfPageView.debugTileStoreOverride;
     return _section(theme, 'Deep-zoom detail (#314)', [
       RadioGroup<String>(
         groupValue: _deepZoomMode,


### PR DESCRIPTION
## Symptom

The deep-zoom tile grid flickered **"everywhere, even when the viewport wasn't moving"** on web release and — more importantly — **macOS release, the default-on platform**. The green `pdfDebugPaintDetailBounds` overlay churned across the page. On-device devtools traces:

- **web:** `scheduled 3897 / landed 3897 / discarded 0`, only **96 tiles retained** (cache pegged at the 96 MB budget), `batches` still climbing on a *static* view.
- **macOS:** tiles cache pegged at 100/100 MB on a 198-page CAD book, `jankFrames 120/120`.

`discarded 0` with a huge scheduled/retained gap is **pure LRU eviction thrash**, not invalidation.

## Root cause (confirmed in code)

`PdfBudgetedCache` protects only the **single** most-recently-used entry (`_protectedKey = _entries.keys.last`), so `viewFor`'s "MRU-protection contract" collapses the moment one view's working set exceeds the 96-tile budget: last frame's `take`-promoted tiles drift back toward LRU as new slab `put`s arrive and get evicted, then the `repaint: Listenable.merge([store])` → `viewFor` loop re-requests them → re-raster → evict others → never settles.

Two compounding reasons the working set overran the budget, both off the validated desktop-single-page path:

1. **The tile slice inherited the patch's 50%-per-side inflation** (`_detailGeometryAt` default `inflation: 0.5`), quadrupling the requested tile area for pan-ahead the prefetch ring already provides. On a 1440×900 HiDPI viewport at deep zoom that's ~77 visible tiles, +ring ~117 > 96 → thrash.
2. **No budget-vs-demand guard** — the code *assumed* "a viewport's worth stays above the eviction line" but never enforced it.

(#314's "validated on 198-page scan books, pyramid pinned at its 96 MB budget with healthy RSS" read the *saturation* signature as healthy utilization.)

## Fix (default stays ON, fixed in place)

**`PdfTileStore`:**
- `budgetTileCapacity` = `maxBytes ~/ (tilePixels²·4)`.
- `viewFitsBudget(...)` — true only when the visible exact-bucket tile count ≤ **75%** of capacity (headroom for coarser-fallback tiles + eviction margin). Shares a new `_tileGrid` helper with `viewFor` so the fit test and the scheduler count identical tiles.
- `viewFor` caps the **prefetch ring to the budget headroom** left after the visible set — never schedules more than the LRU can hold.

**`PdfPageView`:**
- Tile slice uses `_tileInflation = 0.0` (rely on the ring, not the patch's guard band) — the primary thrash cut, ~4× smaller working set, keeps tiles enabled on normal displays.
- `_refreshTileGeometry()` now returns whether it tiled; over budget it leaves `_tileFraction` null and `_updateDetail` **falls through to the single detail patch** (pre-#314, well tested), which covers an arbitrarily large region in one raster without evicting the pyramid. The `build` composition already prefers the patch when `tileLayer == null`.

Tiers: **fits** → tile with ring; **visible fills budget** → tile, ring dropped; **visible > 75% of capacity** → patch fallback.

## Also folds in #365 (diagnostics)

The devtools tile counters read the *effective* store (`debugTileStoreOverride ?? PdfTileStore.instance`) instead of only the override, so the `tileStore` block (`scheduled`/`landed`/`discarded`/`batches`) is populated on the default desktop path — previously blank on the exact platform where tiles ship on-by-default. **This supersedes #365, which can be closed.** With both changes, a stationary macOS deep-zoom re-capture should show `scheduled`/`batches` flat and `discarded 0` instead of climbing.

## Tests

- `tile_store_test.dart` — `budgetTileCapacity`; `viewFitsBudget` accept/reject; `viewFor` drops the ring under pressure; **a budget-tight static view converges** (repeated identical passes schedule nothing further, `discarded 0` — the flicker regression guard).
- `tile_store_page_view_test.dart` — an over-budget deep-zoom view renders the single patch (`pdf-page-detail-image`), no tile layer, `tileCount == 0`.
- `app/test/devtools_*` (folded #365): 7/7 pass.
- Root `dart analyze`: clean.

See `doc/dev-log/2026-07-18-tile-budget-thrash.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)