### PR TITLE
perf(#364): progressive open for mobile cloud picks — reference picker + native ranged reads

### DIFF
--- a/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
@@ -1,5 +1,6 @@
 package dev.milanko.dart_pdf_editor_app
 
+import android.app.Activity
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -14,11 +15,17 @@ import android.print.PrintDocumentAdapter
 import android.print.PrintDocumentInfo
 import android.print.PrintManager
 import android.provider.OpenableColumns
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.util.concurrent.Executors
 
 /// Forwards PDFs the OS opens in the app - a Files "open", a download tap, or a
 /// share - to the Dart `IncomingFileService` over a single method channel.
@@ -26,10 +33,20 @@ class MainActivity : FlutterActivity() {
     private val channelName = "dev.milanko.dartpdf/incoming"
     private val imageClipboardChannelName = "dev.milanko.dartpdf/image_clipboard"
     private val nativePrintChannelName = "dev.milanko.dartpdf/native_print"
+    private val mobileFileChannelName = "dev.milanko.dartpdf/mobile_file"
     private var channel: MethodChannel? = null
 
     /// The file the activity was launched with, drained by `getInitialFile`.
     private var pending: Map<String, Any>? = null
+
+    /// Serializes the (potentially large) ranged FD reads off the platform
+    /// thread so a multi-MB read can't ANR the UI.
+    private val fileIoExecutor = Executors.newSingleThreadExecutor()
+
+    /// The in-flight `pickDocuments` reply, held while the system document
+    /// picker is up (its result arrives asynchronously in `onActivityResult`).
+    private var pendingPick: MethodChannel.Result? = null
+    private val openDocumentRequestCode = 0x0D_0C
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -79,8 +96,204 @@ class MainActivity : FlutterActivity() {
                 }
             }
 
+        // Reference-based open (#364): a custom picker that keeps the original
+        // content Uri instead of copying the whole file into the sandbox, plus
+        // ranged reads over that Uri so a cloud pick can first-paint from a few
+        // MB. See MobileFileByteSource on the Dart side.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, mobileFileChannelName)
+            .setMethodCallHandler { call, result -> handleMobileFile(call, result) }
+
         channel = ch
         handleIntent(intent, initial = true)
+    }
+
+    private fun handleMobileFile(
+        call: MethodCall,
+        result: MethodChannel.Result
+    ) {
+        when (call.method) {
+            "pickDocuments" -> launchOpenDocument(result)
+            "probeSeekable" -> {
+                val token = call.argument<String>("token")
+                if (token == null) {
+                    result.error("bad_args", "probeSeekable expects a token", null)
+                    return
+                }
+                fileIoExecutor.execute {
+                    val seekable = probeSeekable(Uri.parse(token))
+                    runOnUiThread { result.success(seekable) }
+                }
+            }
+            "fileLength" -> {
+                val token = call.argument<String>("token")
+                if (token == null) {
+                    result.error("bad_args", "fileLength expects a token", null)
+                    return
+                }
+                fileIoExecutor.execute {
+                    val len = fileLength(Uri.parse(token))
+                    runOnUiThread { result.success(len) }
+                }
+            }
+            "readRange" -> {
+                val token = call.argument<String>("token")
+                val offset = (call.argument<Number>("offset"))?.toLong()
+                val length = call.argument<Int>("length")
+                if (token == null || offset == null || length == null) {
+                    result.error("bad_args", "readRange expects token/offset/length", null)
+                    return
+                }
+                fileIoExecutor.execute {
+                    try {
+                        val bytes = readRange(Uri.parse(token), offset, length)
+                        runOnUiThread { result.success(bytes) }
+                    } catch (e: Exception) {
+                        runOnUiThread {
+                            result.error("read_failed", e.message, null)
+                        }
+                    }
+                }
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    /// Launches ACTION_OPEN_DOCUMENT so the returned Uri is a durable reference
+    /// to the original file (persistable read permission) rather than a copy.
+    private fun launchOpenDocument(result: MethodChannel.Result) {
+        // Only one picker at a time; reject a second request rather than losing
+        // the first reply.
+        if (pendingPick != null) {
+            result.error("busy", "A document picker is already open", null)
+            return
+        }
+        val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "application/pdf"
+            putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+            // Keep cloud providers (OneDrive/Drive/iCloud) in the list - the
+            // whole point of #364 - so don't set EXTRA_LOCAL_ONLY.
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        pendingPick = result
+        try {
+            startActivityForResult(intent, openDocumentRequestCode)
+        } catch (e: Exception) {
+            pendingPick = null
+            result.error("no_picker", e.message, null)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode != openDocumentRequestCode) return
+        val reply = pendingPick ?: return
+        pendingPick = null
+        if (resultCode != Activity.RESULT_OK || data == null) {
+            // Cancelled: an empty list means "user backed out", distinct from an
+            // error.
+            reply.success(emptyList<Map<String, Any?>>())
+            return
+        }
+        val uris = ArrayList<Uri>()
+        val clip = data.clipData
+        if (clip != null) {
+            for (i in 0 until clip.itemCount) clip.getItemAt(i).uri?.let { uris.add(it) }
+        } else {
+            data.data?.let { uris.add(it) }
+        }
+        fileIoExecutor.execute {
+            val entries = uris.mapNotNull { describeOpenedDocument(it, data.flags) }
+            runOnUiThread { reply.success(entries) }
+        }
+    }
+
+    /// Persists read access to [uri], then builds the Dart-side descriptor
+    /// (token/name/length/seekable). Returns null if access can't be persisted.
+    private fun describeOpenedDocument(uri: Uri, intentFlags: Int): Map<String, Any?>? {
+        return try {
+            val persistable = intentFlags and Intent.FLAG_GRANT_READ_URI_PERMISSION
+            if (persistable != 0) {
+                try {
+                    contentResolver.takePersistableUriPermission(
+                        uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                } catch (_: SecurityException) {
+                    // Provider doesn't grant persistable permission - the Uri is
+                    // still usable for this session, which is all the first pick
+                    // needs.
+                }
+            }
+            mapOf(
+                "token" to uri.toString(),
+                "name" to (displayName(uri) ?: "document.pdf"),
+                "length" to fileLength(uri),
+                "seekable" to probeSeekable(uri),
+            )
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /// True only when [uri] backs a real seekable file. Many cloud providers
+    /// serve SAF a non-seekable pipe (statSize -1, lseek throws ESPIPE), where
+    /// random access is impossible and the caller must stream whole instead.
+    private fun probeSeekable(uri: Uri): Boolean {
+        return try {
+            contentResolver.openFileDescriptor(uri, "r")?.use { pfd ->
+                if (pfd.statSize < 0) return false
+                val fd = pfd.fileDescriptor
+                // Confirm random access end-to-end: seek forward and back.
+                val probe = if (pfd.statSize > 1) 1L else 0L
+                Os.lseek(fd, probe, OsConstants.SEEK_SET)
+                Os.lseek(fd, 0, OsConstants.SEEK_SET)
+                true
+            } ?: false
+        } catch (e: ErrnoException) {
+            false
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /// The file's length, or -1 when the provider doesn't report one (the Dart
+    /// side treats -1 as "unknown" and falls back to a sequential read).
+    private fun fileLength(uri: Uri): Long {
+        try {
+            contentResolver.openFileDescriptor(uri, "r")?.use { pfd ->
+                if (pfd.statSize >= 0) return pfd.statSize
+            }
+        } catch (_: Exception) {
+        }
+        return try {
+            contentResolver.query(
+                uri, arrayOf(OpenableColumns.SIZE), null, null, null
+            )?.use { cursor ->
+                if (cursor.moveToFirst() && !cursor.isNull(0)) cursor.getLong(0) else -1L
+            } ?: -1L
+        } catch (_: Exception) {
+            -1L
+        }
+    }
+
+    /// Reads `[offset, offset+length)` from [uri] through a seekable FD. Only
+    /// called after [probeSeekable] passed, so the FD supports lseek.
+    private fun readRange(uri: Uri, offset: Long, length: Int): ByteArray {
+        contentResolver.openFileDescriptor(uri, "r")?.use { pfd ->
+            val fd = pfd.fileDescriptor
+            Os.lseek(fd, offset, OsConstants.SEEK_SET)
+            // Do not close this stream - it wraps the pfd's fd, which `use`
+            // closes; closing here would double-close the descriptor.
+            val input = FileInputStream(fd)
+            val buffer = ByteArray(length)
+            var read = 0
+            while (read < length) {
+                val n = input.read(buffer, read, length - read)
+                if (n < 0) break // short read at EOF
+                read += n
+            }
+            return if (read == length) buffer else buffer.copyOf(read)
+        }
+        return ByteArray(0)
     }
 
     /// Hands the whole PDF to Android's print framework, which renders it.

--- a/app/ios/Runner/SceneDelegate.swift
+++ b/app/ios/Runner/SceneDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import UniformTypeIdentifiers
 
 /// Receives PDFs opened in the app - "Open in…", the share sheet, the Files
 /// browser - and forwards them to the Dart `IncomingFileService`. The iOS
@@ -15,6 +16,14 @@ class SceneDelegate: FlutterSceneDelegate {
   private var pencilChannel: FlutterMethodChannel?
   private var pencilInteraction: AnyObject?
   private var imageClipboardChannel: FlutterMethodChannel?
+  private var mobileFileChannel: FlutterMethodChannel?
+
+  /// The in-flight `pickDocuments` reply, held while the document picker is up
+  /// (its result arrives asynchronously via the picker delegate).
+  private var pendingPick: FlutterResult?
+
+  /// Serializes the (potentially large) ranged reads off the platform thread.
+  private let fileIoQueue = DispatchQueue(label: "dev.milanko.dartpdf.mobilefile")
 
   override func scene(
     _ scene: UIScene,
@@ -24,6 +33,7 @@ class SceneDelegate: FlutterSceneDelegate {
     super.scene(scene, willConnectTo: session, options: connectionOptions)
     setupChannel()
     setupImageClipboardChannel()
+    setupMobileFileChannel()
     setupPencilInteraction()
     handle(connectionOptions.urlContexts)
   }
@@ -79,6 +89,180 @@ class SceneDelegate: FlutterSceneDelegate {
     imageClipboardChannel = ch
   }
 
+  /// Reference-based open (#364): a custom picker in `.open` mode that keeps a
+  /// security-scoped URL to the *original* file instead of importing a copy,
+  /// plus coordinated ranged reads over that URL so a large iCloud/OneDrive PDF
+  /// can first-paint before the whole file downloads. iOS File Provider serves
+  /// the requested byte ranges on demand.
+  private func setupMobileFileChannel() {
+    guard mobileFileChannel == nil,
+      let controller = window?.rootViewController as? FlutterViewController
+    else { return }
+    let ch = FlutterMethodChannel(
+      name: "dev.milanko.dartpdf/mobile_file",
+      binaryMessenger: controller.binaryMessenger)
+    ch.setMethodCallHandler { [weak self] (call, result) in
+      self?.handleMobileFile(call, result)
+    }
+    mobileFileChannel = ch
+  }
+
+  private func handleMobileFile(
+    _ call: FlutterMethodCall, _ result: @escaping FlutterResult
+  ) {
+    switch call.method {
+    case "pickDocuments":
+      presentOpenPicker(result)
+    case "probeSeekable":
+      guard let token = (call.arguments as? [String: Any])?["token"] as? String
+      else {
+        result(FlutterError(code: "bad_args", message: "probeSeekable expects a token", details: nil))
+        return
+      }
+      fileIoQueue.async { [weak self] in
+        let seekable = self?.probeSeekable(token) ?? false
+        DispatchQueue.main.async { result(seekable) }
+      }
+    case "fileLength":
+      guard let token = (call.arguments as? [String: Any])?["token"] as? String
+      else {
+        result(FlutterError(code: "bad_args", message: "fileLength expects a token", details: nil))
+        return
+      }
+      fileIoQueue.async { [weak self] in
+        let len = self?.fileLength(token) ?? -1
+        DispatchQueue.main.async { result(len) }
+      }
+    case "readRange":
+      guard let args = call.arguments as? [String: Any],
+        let token = args["token"] as? String,
+        let offset = (args["offset"] as? NSNumber)?.int64Value,
+        let length = (args["length"] as? NSNumber)?.intValue
+      else {
+        result(FlutterError(code: "bad_args", message: "readRange expects token/offset/length", details: nil))
+        return
+      }
+      fileIoQueue.async { [weak self] in
+        let data = self?.readRange(token, offset: offset, length: length)
+        DispatchQueue.main.async {
+          if let data = data {
+            result(FlutterStandardTypedData(bytes: data))
+          } else {
+            result(FlutterError(code: "read_failed", message: "range read failed", details: nil))
+          }
+        }
+      }
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  /// Presents the document picker in `.open` mode so the returned URL is a
+  /// security-scoped reference to the original file, not an imported copy.
+  private func presentOpenPicker(_ result: @escaping FlutterResult) {
+    guard pendingPick == nil else {
+      result(FlutterError(code: "busy", message: "A document picker is already open", details: nil))
+      return
+    }
+    guard let root = window?.rootViewController else {
+      result(FlutterError(code: "no_window", message: "No root view controller", details: nil))
+      return
+    }
+    let picker: UIDocumentPickerViewController
+    if #available(iOS 14.0, *) {
+      picker = UIDocumentPickerViewController(forOpeningContentTypes: [.pdf])
+    } else {
+      picker = UIDocumentPickerViewController(documentTypes: ["com.adobe.pdf"], in: .open)
+    }
+    picker.allowsMultipleSelection = true
+    picker.delegate = self
+    pendingPick = result
+    root.present(picker, animated: true)
+  }
+
+  /// Builds the Dart-side descriptor for a picked URL: a base64 security-scoped
+  /// bookmark [token], display name, length, and a seekability probe. Returns
+  /// nil when a bookmark can't be minted (the URL is then unusable by range).
+  fileprivate func describePickedURL(_ url: URL) -> [String: Any]? {
+    let scoped = url.startAccessingSecurityScopedResource()
+    defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+    guard let bookmark = try? url.bookmarkData() else { return nil }
+    let token = bookmark.base64EncodedString()
+    let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
+    return [
+      "token": token,
+      "name": url.lastPathComponent,
+      "length": size,
+      // iOS File Provider serves coordinated ranged reads on demand, so a
+      // resolvable URL is seekable; confirm by opening a handle.
+      "seekable": probeSeekableURL(url),
+    ]
+  }
+
+  /// Resolves a base64 bookmark [token] back to its security-scoped URL.
+  private func resolveToken(_ token: String) -> URL? {
+    guard let data = Data(base64Encoded: token) else { return nil }
+    var stale = false
+    return try? URL(
+      resolvingBookmarkData: data, options: [], relativeTo: nil,
+      bookmarkDataIsStale: &stale)
+  }
+
+  private func probeSeekable(_ token: String) -> Bool {
+    guard let url = resolveToken(token) else { return false }
+    return probeSeekableURL(url)
+  }
+
+  private func probeSeekableURL(_ url: URL) -> Bool {
+    let scoped = url.startAccessingSecurityScopedResource()
+    defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+    var ok = false
+    var coordError: NSError?
+    NSFileCoordinator().coordinate(
+      readingItemAt: url, options: [], error: &coordError
+    ) { readURL in
+      guard let handle = try? FileHandle(forReadingFrom: readURL) else { return }
+      defer { try? handle.close() }
+      // A resolvable, openable file is seekable; a genuinely non-seekable
+      // source can't be opened by FileHandle at all.
+      ok = true
+    }
+    return ok
+  }
+
+  private func fileLength(_ token: String) -> Int {
+    guard let url = resolveToken(token) else { return -1 }
+    let scoped = url.startAccessingSecurityScopedResource()
+    defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+    var size = -1
+    var coordError: NSError?
+    NSFileCoordinator().coordinate(
+      readingItemAt: url, options: [], error: &coordError
+    ) { readURL in
+      size = (try? readURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
+    }
+    return size
+  }
+
+  /// Reads `[offset, offset+length)` from the token's file through a coordinated
+  /// read + `FileHandle` seek, letting the File Provider fetch just that range.
+  private func readRange(_ token: String, offset: Int64, length: Int) -> Data? {
+    guard let url = resolveToken(token) else { return nil }
+    let scoped = url.startAccessingSecurityScopedResource()
+    defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+    var result: Data?
+    var coordError: NSError?
+    NSFileCoordinator().coordinate(
+      readingItemAt: url, options: [], error: &coordError
+    ) { readURL in
+      guard let handle = try? FileHandle(forReadingFrom: readURL) else { return }
+      defer { try? handle.close() }
+      handle.seek(toFileOffset: UInt64(offset))
+      result = handle.readData(ofLength: length)
+    }
+    return result
+  }
+
   /// Wires the Apple Pencil's hardware double-tap to the Dart side. Flutter
   /// exposes no event for it, so we register a `UIPencilInteraction` on the
   /// Flutter view and forward each gesture over the shared method channel;
@@ -122,6 +306,27 @@ class SceneDelegate: FlutterSceneDelegate {
       "name": url.lastPathComponent,
       "bytes": FlutterStandardTypedData(bytes: data),
     ]
+  }
+}
+
+extension SceneDelegate: UIDocumentPickerDelegate {
+  func documentPicker(
+    _ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]
+  ) {
+    let reply = pendingPick
+    pendingPick = nil
+    guard let reply = reply else { return }
+    fileIoQueue.async { [weak self] in
+      let entries = urls.compactMap { self?.describePickedURL($0) }
+      DispatchQueue.main.async { reply(entries) }
+    }
+  }
+
+  func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+    let reply = pendingPick
+    pendingPick = nil
+    // An empty list means the user backed out, distinct from an error.
+    reply?([])
   }
 }
 

--- a/app/lib/document_tab.dart
+++ b/app/lib/document_tab.dart
@@ -14,6 +14,7 @@ class DocumentTab {
       {required this.title,
       this.originPath,
       this.originBookmark,
+      this.originToken,
       this.cachePath})
       : session = null,
         viewer = null,
@@ -29,6 +30,7 @@ class DocumentTab {
     required PdfEditingPreferences preferences,
     this.originPath,
     this.originBookmark,
+    this.originToken,
     this.cachePath,
     bool initiallyDirty = false,
   })  : session = PdfEditingController(bytes, preferences: preferences),
@@ -98,6 +100,7 @@ class DocumentTab {
     required this.cancel,
     this.originPath,
     this.originBookmark,
+    this.originToken,
     this.cachePath,
   })  : session = null,
         viewer = PdfViewerController(),
@@ -187,6 +190,14 @@ class DocumentTab {
 
   /// macOS security-scoped bookmark for [originPath], when available.
   String? originBookmark;
+
+  /// Opaque native reference to a mobile pick's *original* file (Android
+  /// persisted `content://` Uri; iOS security-scoped bookmark), when the tab
+  /// was opened progressively through the mobile reference picker (#364). Used
+  /// to build the ranged byte source and the full-read fallback while the
+  /// progressive first paint is on screen; null on desktop/web and after the
+  /// tab swaps to its complete, snapshotted bytes.
+  String? originToken;
 
   /// The app-private byte snapshot backing a mobile pick (see pdf_cache.dart),
   /// or null when the document has a real [originPath] (desktop) or can't be

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -499,11 +499,15 @@ class _EditorScreenState extends State<EditorScreen>
   }
 
   DocumentTab _openLoading(String title,
-      {String? originPath, String? originBookmark, String? cachePath}) {
+      {String? originPath,
+      String? originBookmark,
+      String? originToken,
+      String? cachePath}) {
     final tab = DocumentTab.loading(
         title: title,
         originPath: originPath,
         originBookmark: originBookmark,
+        originToken: originToken,
         cachePath: cachePath);
     _addTab(tab);
     return tab;
@@ -653,6 +657,43 @@ class _EditorScreenState extends State<EditorScreen>
     });
   }
 
+  /// Builds the ranged byte source for a progressive open from whichever origin
+  /// the tab has: a desktop file [path] (optionally security-scoped by
+  /// [bookmark]) or a mobile reference [token] (#364).
+  PdfByteSource _progressiveSource({
+    String? path,
+    String? bookmark,
+    String? token,
+    PdfCancelToken? cancel,
+    void Function(int received, int? total)? onProgress,
+  }) {
+    if (token != null && token.isNotEmpty) {
+      return pdfByteSourceForMobileToken(token,
+          cancelToken: cancel, onProgress: onProgress);
+    }
+    return pdfByteSourceForPath(path!,
+        bookmark: bookmark, cancelToken: cancel, onProgress: onProgress);
+  }
+
+  /// Reads an origin whole (the fallback behind a progressive open): a desktop
+  /// [path] through the normal path read, or a mobile [token] by draining its
+  /// ranged source. Both yield the complete bytes the edit session needs.
+  Future<Uint8List> _readOriginFully({
+    String? path,
+    String? bookmark,
+    String? token,
+  }) async {
+    if (token != null && token.isNotEmpty) {
+      final source = pdfByteSourceForMobileToken(token);
+      try {
+        return await readSourceFully(source);
+      } finally {
+        await source.close();
+      }
+    }
+    return readPdfAtPath(path!, bookmark: bookmark);
+  }
+
   /// Opens a file-backed document progressively: the ranged loader assembles
   /// just the header/xref/live-object bytes needed to render, so the viewer
   /// paints read-only in ~1-2 s even from a slow cloud-synced file, then the
@@ -663,30 +704,37 @@ class _EditorScreenState extends State<EditorScreen>
   /// Returns once the first paint (or a fallback full read) is on screen; the
   /// background read finishes later. Falls back to the plain full read the rest
   /// of the app uses if the progressive first paint can't be assembled, so
-  /// nothing a normal open handles regresses. Desktop only (see
-  /// [progressiveOpenSupported]); [onOpenFailed] lets recents drop a stale entry.
+  /// nothing a normal open handles regresses. Opened from a desktop file [path]
+  /// (see [progressiveOpenSupported]) or a mobile reference [token] (#364, see
+  /// [supportsMobileProgressiveOpen]); [onOpenFailed] lets recents drop a stale
+  /// entry.
   ///
   /// Pass [into] to reuse an existing placeholder tab (a lazily-materialized
   /// [DocumentTab.deferredPath] from session restore) instead of adding a fresh
   /// loading tab.
   Future<void> _openProgressive({
     required String title,
-    required String path,
+    String? path,
     String? bookmark,
+    String? token,
     String? cachePath,
     void Function(Object error)? onOpenFailed,
     DocumentTab? into,
   }) async {
+    assert((path != null) != (token != null),
+        'a progressive open needs exactly one of path/token');
     final loading = into ??
         _openLoading(
           title,
           originPath: path,
           originBookmark: bookmark,
+          originToken: token,
           cachePath: cachePath,
         );
     final cancel = PdfCancelToken();
     final progress = ValueNotifier<double>(0);
-    final source = pdfByteSourceForPath(path, bookmark: bookmark, cancelToken: cancel);
+    final source = _progressiveSource(
+        path: path, bookmark: bookmark, token: token, cancel: cancel);
 
     PdfDocument doc;
     try {
@@ -712,6 +760,7 @@ class _EditorScreenState extends State<EditorScreen>
           title: title,
           path: path,
           bookmark: bookmark,
+          token: token,
           cachePath: cachePath,
           onOpenFailed: onOpenFailed);
       return;
@@ -733,6 +782,7 @@ class _EditorScreenState extends State<EditorScreen>
       cancel: cancel,
       originPath: path,
       originBookmark: bookmark,
+      originToken: token,
       cachePath: cachePath,
     );
     if (!_replaceLoadingTab(loading, preview)) {
@@ -743,7 +793,13 @@ class _EditorScreenState extends State<EditorScreen>
     }
     // Record the recent on first paint, so a briefly-opened document still
     // lands in the list even if it's closed before the full read completes.
-    _recents.add(title: title, path: path, cachePath: cachePath, bookmark: bookmark);
+    // A mobile pick has no reopenable origin yet (path/cachePath both null - it
+    // snapshots on the full-read swap); skip it here so it doesn't briefly show
+    // a non-reopenable recent, and let the swap add it once the snapshot lands.
+    if (path != null || cachePath != null) {
+      _recents.add(
+          title: title, path: path, cachePath: cachePath, bookmark: bookmark);
+    }
     AppDevTools.instance.addLog(
         'progressive open: "$title" first paint — ${doc.pageCount} pages; '
         'reading full file…');
@@ -787,8 +843,11 @@ class _EditorScreenState extends State<EditorScreen>
       // user still gets a fully-editable document where possible; otherwise
       // surface the error in place of the preview.
       try {
-        final full = await readPdfAtPath(preview.originPath!,
-            bookmark: preview.originBookmark);
+        final full = await _readOriginFully(
+          path: preview.originPath,
+          bookmark: preview.originBookmark,
+          token: preview.originToken,
+        );
         if (!mounted) return;
         _swapPreviewToDocument(preview, full);
       } catch (error2) {
@@ -810,16 +869,26 @@ class _EditorScreenState extends State<EditorScreen>
   bool _swapPreviewToDocument(DocumentTab preview, Uint8List bytes) {
     final index = _tabs.indexOf(preview);
     if (index == -1) return false;
-    setState(() {
-      _tabs[index] = DocumentTab.document(
-        title: preview.title,
-        bytes: bytes,
-        preferences: _prefs,
-        originPath: preview.originPath,
-        originBookmark: preview.originBookmark,
-        cachePath: preview.cachePath,
-      );
-    });
+    final built = DocumentTab.document(
+      title: preview.title,
+      bytes: bytes,
+      preferences: _prefs,
+      originPath: preview.originPath,
+      originBookmark: preview.originBookmark,
+      cachePath: preview.cachePath,
+    );
+    setState(() => _tabs[index] = built);
+    // A mobile progressive open (#364) has no reopenable origin - the reference
+    // token dies with the pick - so snapshot the now-complete bytes into the
+    // app's private store, behind the first paint, so Recent/restore reopen
+    // from the local copy instead of re-picking. Desktop keeps its path/bookmark
+    // origin and needs no snapshot.
+    if (preview.originToken != null &&
+        preview.originPath == null &&
+        preview.cachePath == null &&
+        canCacheRecentPdfs) {
+      unawaited(_snapshotOpenedDocument(built, bytes));
+    }
     // Dispose the preview's live viewer only after this frame swaps the
     // read-only PdfReader out of the tree - disposing its controller while the
     // widget is still mounted would fault its in-flight render.
@@ -828,34 +897,45 @@ class _EditorScreenState extends State<EditorScreen>
     return true;
   }
 
-  /// Reads [path] whole (the app's normal open path) into the [loading] tab -
-  /// the fallback when a progressive first paint can't be assembled.
+  /// Reads the origin whole (the app's normal open path) into the [loading]
+  /// tab - the fallback when a progressive first paint can't be assembled.
+  /// Reads from a desktop [path] or a mobile reference [token] (#364).
   Future<void> _fallbackFullOpen(
     DocumentTab loading, {
     required String title,
-    required String path,
+    String? path,
     String? bookmark,
+    String? token,
     String? cachePath,
     void Function(Object error)? onOpenFailed,
   }) async {
     try {
-      final bytes = await readPdfAtPath(path, bookmark: bookmark);
+      final bytes =
+          await _readOriginFully(path: path, bookmark: bookmark, token: token);
       await WidgetsBinding.instance.endOfFrame;
       if (!mounted) return;
-      final opened = _replaceLoadingTab(
-        loading,
-        DocumentTab.document(
-          title: title,
-          bytes: bytes,
-          preferences: _prefs,
-          originPath: path,
-          originBookmark: bookmark,
-          cachePath: cachePath,
-        ),
+      final built = DocumentTab.document(
+        title: title,
+        bytes: bytes,
+        preferences: _prefs,
+        originPath: path,
+        originBookmark: bookmark,
+        cachePath: cachePath,
       );
+      final opened = _replaceLoadingTab(loading, built);
       if (opened) {
-        _recents.add(
-            title: title, path: path, cachePath: cachePath, bookmark: bookmark);
+        // With a reusable file origin (desktop) record the recent directly;
+        // a mobile pick (no path) snapshots the bytes so Recent/restore reopen
+        // from the local copy - the same reopen path a plain mobile open takes.
+        if (path != null || !canCacheRecentPdfs) {
+          _recents.add(
+              title: title,
+              path: path,
+              cachePath: cachePath,
+              bookmark: bookmark);
+        } else {
+          unawaited(_snapshotOpenedDocument(built, bytes));
+        }
       }
     } catch (error) {
       onOpenFailed?.call(error);
@@ -871,6 +951,24 @@ class _EditorScreenState extends State<EditorScreen>
   }
 
   Future<void> _pickAndOpen() async {
+    // On phones/tablets the OS picker copies the whole file into the sandbox
+    // before the app sees a byte, paying the full cloud transport up front
+    // (#364). Prefer the reference picker there: it keeps the original file so
+    // a cloud pick can first-paint from ranged reads. Falls back to the plain
+    // copy-based picker on a runner without the channel, or a non-seekable
+    // provider.
+    if (supportsMobileProgressiveOpen) {
+      try {
+        await _pickAndOpenMobile();
+        return;
+      } on MissingPluginException {
+        // Older runner without the mobile_file channel - fall through to the
+        // copy-based picker below.
+      } catch (e) {
+        _openError('Open failed', 'Could not open the selected file\n$e');
+        return;
+      }
+    }
     try {
       final files = await pickPdfFiles();
       if (files.isEmpty) return;
@@ -899,6 +997,36 @@ class _EditorScreenState extends State<EditorScreen>
       }
     } catch (e) {
       _openError('Open failed', 'Could not open the selected file\n$e');
+    }
+  }
+
+  /// Opens phone/tablet picks through the reference picker (#364): the runner
+  /// hands back a token to the *original* file (not a sandbox copy) plus a
+  /// seekability probe. A single seekable pick opens progressively (first paint
+  /// from native ranged reads, full bytes streamed in behind it, then a private
+  /// snapshot for reopen). A non-seekable provider - many cloud providers hand
+  /// SAF a pipe - streams the reference whole instead, the same cost as the old
+  /// picker copy. A batch defers parsing every tab but the active one, as the
+  /// desktop path does. Throws [MissingPluginException] up to [_pickAndOpen] on
+  /// a runner without the channel.
+  Future<void> _pickAndOpenMobile() async {
+    final picks = await pickPdfMobileReferences();
+    if (picks.isEmpty) return;
+    final defer = picks.length > 1;
+    for (final pick in picks) {
+      if (!mounted) return;
+      if (!defer && pick.seekable) {
+        await _openProgressive(title: pick.name, token: pick.token);
+      } else {
+        // Non-seekable, or a batch we won't fan out into concurrent streams:
+        // drain the reference whole (still one read of the original, no OS
+        // copy) and open it like any other loaded document.
+        await _openLoadedBytes(
+          _readOriginFully(token: pick.token),
+          title: pick.name,
+          defer: defer,
+        );
+      }
     }
   }
 

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -11,6 +11,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'pdf_bookmark_source.dart';
 import 'pdf_file_source.dart';
+import 'pdf_mobile_source.dart';
 
 const _macosFileAccessChannel =
     MethodChannel('dev.milanko.dartpdf/file_access');
@@ -58,6 +59,79 @@ class PickedPdf {
   /// recents/session entries so sandboxed folders can be reopened later.
   final String? bookmark;
 }
+
+/// A file the mobile reference picker handed back: a native [token] pointing at
+/// the *original* file (not a sandbox copy), its display [name], the [length]
+/// when the provider reports it, and whether the runner's up-front probe found
+/// the reference [seekable] (so ranged reads are worth attempting - see #364).
+class MobilePickedPdf {
+  const MobilePickedPdf({
+    required this.token,
+    required this.name,
+    this.length,
+    required this.seekable,
+  });
+
+  /// Opaque native reference (Android persisted `content://` Uri; iOS
+  /// security-scoped bookmark). Passed back to [pdfByteSourceForMobileToken].
+  final String token;
+  final String name;
+  final int? length;
+
+  /// Whether native ranged reads over [token] are random-access. False for a
+  /// non-seekable pipe (many cloud providers), where the caller streams whole
+  /// instead of opening progressively.
+  final bool seekable;
+}
+
+/// Whether this platform can pick a mobile file *by reference* (Android/iOS,
+/// off-web) and read ranges from it natively - the mobile counterpart of
+/// [progressiveOpenSupported]. The OS pickers otherwise copy the whole file
+/// into the sandbox before the app sees a byte, paying the full cloud transport
+/// up front (#364); the reference picker keeps the original so ranged reads can
+/// first-paint from a few MB. Whether ranged reads actually help depends on the
+/// provider (a non-seekable SAF pipe streams whole) - probed per pick.
+bool get supportsMobileProgressiveOpen =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS);
+
+/// Opens the reference-based mobile document picker and returns one entry per
+/// chosen PDF (empty when cancelled). Each entry carries a native [token] to
+/// the original file plus a seekability probe result. Throws
+/// [MissingPluginException] on a runner without the channel, so callers can
+/// fall back to the copy-based [pickPdfFiles].
+Future<List<MobilePickedPdf>> pickPdfMobileReferences() async {
+  final picked = await mobileFileChannel
+      .invokeListMethod<Map<Object?, Object?>>('pickDocuments');
+  if (picked == null) return const [];
+  final out = <MobilePickedPdf>[];
+  for (final entry in picked) {
+    final token = entry['token'] as String?;
+    if (token == null || token.isEmpty) continue;
+    out.add(MobilePickedPdf(
+      token: token,
+      name: (entry['name'] as String?) ?? 'document.pdf',
+      length: (entry['length'] as num?)?.toInt(),
+      seekable: entry['seekable'] == true,
+    ));
+  }
+  return out;
+}
+
+/// A ranged [PdfByteSource] over a mobile pick's native [token], so the app can
+/// open it progressively via [PdfDocument.openSource] and stream the rest in
+/// behind the first paint - the mobile counterpart of [pdfByteSourceForPath].
+PdfByteSource pdfByteSourceForMobileToken(
+  String token, {
+  PdfCancelToken? cancelToken,
+  void Function(int received, int? total)? onProgress,
+}) =>
+    PdfMobileByteSource(
+      token,
+      cancelToken: cancelToken,
+      onProgress: onProgress,
+    );
 
 /// Opens the system file picker for a PDF. Returns null when the user cancels.
 Future<XFile?> pickPdfFile() =>

--- a/app/lib/pdf_mobile_source.dart
+++ b/app/lib/pdf_mobile_source.dart
@@ -1,0 +1,93 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// The method channel the Android/iOS runners expose for reference-based mobile
+/// file access: a custom document picker that hands back a *reference* to the
+/// user's file (a persisted `content://` URI on Android, a security-scoped
+/// bookmark on iOS) rather than a whole-file copy, plus ranged reads over that
+/// reference. Shared verbatim with `file_io.dart`.
+const mobileFileChannel = MethodChannel('dev.milanko.dartpdf/mobile_file');
+
+/// A [PdfByteSource] over a phone/tablet file addressed by an opaque native
+/// [token], reading ranges through the runner (`readRange`).
+///
+/// The OS document pickers (`file_selector` under the hood) copy the *entire*
+/// picked file into an app-sandbox temp location before the app sees a byte -
+/// so for a OneDrive/iCloud/Drive file the whole cloud transport is paid inside
+/// the picker, before app-level ranged open can intercept it (#364). This
+/// source is the mobile counterpart of `PdfBookmarkFileByteSource`: the runner
+/// keeps a reference to the *original* file (Android `ACTION_OPEN_DOCUMENT`
+/// `content://` Uri with persisted read permission; iOS
+/// `UIDocumentPickerViewController` in `.open` mode's security-scoped URL) and
+/// serves byte ranges from it on demand, so the progressive loader (and the
+/// background full read) fetch only the bytes they need instead of hydrating
+/// and slurping the whole thing up front.
+///
+/// A per-provider caveat drives the design: many cloud providers hand SAF a
+/// *non-seekable* `ParcelFileDescriptor` (a pipe), so random access is
+/// impossible for exactly the providers this targets. The runner probes
+/// seekability up front (`probeSeekable`); the app only opens progressively
+/// through this source when the probe passes, and otherwise streams the
+/// reference whole - the same cost as the old picker copy, never worse. See
+/// `file_io.dart`'s `pickPdfMobileReferences`.
+///
+/// Ranged native calls carry a per-request copy across the channel, so callers
+/// should read in reasonably large chunks (the loader coalesces object ranges;
+/// the background full read uses multi-MB chunks). Pass a [PdfCancelToken] to
+/// abort, and [onProgress] to observe the running byte total.
+class PdfMobileByteSource implements PdfByteSource {
+  PdfMobileByteSource(
+    this.token, {
+    this.cancelToken,
+    this.onProgress,
+    @visibleForTesting MethodChannel? channel,
+  }) : _channel = channel ?? mobileFileChannel;
+
+  /// Opaque native reference to the picked file (see [pickPdfMobileReferences]).
+  final String token;
+
+  /// Optional cooperative cancellation. A fired token makes pending and later
+  /// reads throw [PdfHttpCancelledException].
+  final PdfCancelToken? cancelToken;
+
+  /// Called after each read with the running total of bytes pulled and the
+  /// file length once known.
+  final void Function(int received, int? total)? onProgress;
+
+  final MethodChannel _channel;
+  int? _length;
+  int _received = 0;
+
+  @override
+  Future<int?> get length async {
+    cancelToken?.throwIfCancelled();
+    if (_length != null) return _length;
+    final len = await _channel.invokeMethod<int>('fileLength', {
+      'token': token,
+    });
+    // A negative length means "unknown" on the native side; normalize to null
+    // so the loader falls back to a plain sequential read.
+    return _length = (len != null && len >= 0) ? len : null;
+  }
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    cancelToken?.throwIfCancelled();
+    final s = start < 0 ? 0 : start;
+    if (endExclusive <= s) return Uint8List(0);
+    final data = await _channel.invokeMethod<Uint8List>('readRange', {
+      'token': token,
+      'offset': s,
+      'length': endExclusive - s,
+    });
+    cancelToken?.throwIfCancelled();
+    final bytes = data ?? Uint8List(0);
+    _received += bytes.length;
+    onProgress?.call(_received, _length);
+    return bytes;
+  }
+
+  @override
+  Future<void> close() async {}
+}

--- a/app/test/mobile_progressive_open_test.dart
+++ b/app/test/mobile_progressive_open_test.dart
@@ -1,0 +1,103 @@
+// A phone/tablet pick of a *seekable* cloud file goes through the reference
+// picker + native ranged reads (#364): the runner hands back a token instead of
+// a whole-file copy, the loader first-paints from ranges, then the complete
+// bytes stream in behind it and the tab swaps to a full edit session (and
+// snapshots for reopen). Driven on Android with the native `mobile_file`
+// channel mocked to serve a real PDF by range; the native handlers themselves
+// need on-device verification.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/devtools.dart';
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/pdf_mobile_source.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+  late Uint8List pdfBytes;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+    pdfBytes = Uint8List.fromList(buildClassicPdf());
+    AppDevTools.instance.clearLog();
+  });
+
+  tearDown(() {
+    prefs.dispose();
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(mobileFileChannel, null);
+  });
+
+  Future<void> pump(WidgetTester tester, Future<void> Function() action) async {
+    await tester.runAsync(() async {
+      await action();
+      for (var i = 0; i < 24; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+    await tester.pump();
+  }
+
+  // Mocks the native reference picker: one seekable PDF served by range.
+  void mockSeekablePick() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(mobileFileChannel, (call) async {
+      switch (call.method) {
+        case 'pickDocuments':
+          return <Map<Object?, Object?>>[
+            {
+              'token': 'cloud-token',
+              'name': 'cloud.pdf',
+              'length': pdfBytes.length,
+              'seekable': true,
+            }
+          ];
+        case 'fileLength':
+          return pdfBytes.length;
+        case 'readRange':
+          final offset = call.arguments['offset'] as int;
+          final len = call.arguments['length'] as int;
+          final start = offset.clamp(0, pdfBytes.length);
+          final end = (offset + len).clamp(0, pdfBytes.length);
+          return Uint8List.sublistView(pdfBytes, start, end);
+        default:
+          return null;
+      }
+    });
+  }
+
+  testWidgets(
+      'opens a seekable mobile pick progressively and swaps to an edit session',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      mockSeekablePick();
+
+      await pump(tester, () async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      });
+
+      // Tap the welcome screen's Open button, which drives the mobile
+      // reference pick path.
+      await pump(tester, () async {
+        await tester.tap(find.text('Open a PDF'));
+      });
+
+      // The tab opened through the progressive path (first paint, then the full
+      // read) and ended on a real edit session, not a read-only preview.
+      final log = AppDevTools.instance.log.map((e) => e.message).join('\n');
+      expect(log, contains('progressive open: "cloud.pdf" first paint'));
+      expect(log, contains('full read complete'));
+      expect(find.byType(PdfEditorView), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/app/test/mobile_progressive_open_test.dart
+++ b/app/test/mobile_progressive_open_test.dart
@@ -45,8 +45,9 @@ void main() {
     await tester.pump();
   }
 
-  // Mocks the native reference picker: one seekable PDF served by range.
-  void mockSeekablePick() {
+  // Mocks the native reference picker: one PDF served by range, marked
+  // [seekable] or not.
+  void mockPick({required bool seekable}) {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(mobileFileChannel, (call) async {
       switch (call.method) {
@@ -56,7 +57,7 @@ void main() {
               'token': 'cloud-token',
               'name': 'cloud.pdf',
               'length': pdfBytes.length,
-              'seekable': true,
+              'seekable': seekable,
             }
           ];
         case 'fileLength':
@@ -78,7 +79,7 @@ void main() {
       (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
     try {
-      mockSeekablePick();
+      mockPick(seekable: true);
 
       await pump(tester, () async {
         await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
@@ -95,6 +96,33 @@ void main() {
       final log = AppDevTools.instance.log.map((e) => e.message).join('\n');
       expect(log, contains('progressive open: "cloud.pdf" first paint'));
       expect(log, contains('full read complete'));
+      expect(find.byType(PdfEditorView), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets(
+      'streams a non-seekable mobile pick whole into a full edit session',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      // A non-seekable provider (a SAF pipe) can't be read by range, so the
+      // pick is drained whole over the reference - one read of the original,
+      // no OS copy - and opened like any loaded document, not progressively.
+      mockPick(seekable: false);
+
+      await pump(tester, () async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+      });
+      await pump(tester, () async {
+        await tester.tap(find.text('Open a PDF'));
+      });
+
+      // It opened as a full edit session, without going through the progressive
+      // first-paint path.
+      final log = AppDevTools.instance.log.map((e) => e.message).join('\n');
+      expect(log, isNot(contains('progressive open')));
       expect(find.byType(PdfEditorView), findsOneWidget);
     } finally {
       debugDefaultTargetPlatformOverride = null;

--- a/app/test/pdf_mobile_source_test.dart
+++ b/app/test/pdf_mobile_source_test.dart
@@ -1,0 +1,177 @@
+// PdfMobileByteSource reads a phone/tablet pick by reference over the native
+// `mobile_file` method channel: ranged reads, progress, cancellation, an
+// unknown (negative) length normalized to null - and it opens a real document
+// through PdfDocument.openSource. pickPdfMobileReferences maps the picker's
+// native result into typed descriptors. The native handlers themselves
+// (Android openFileDescriptor / iOS NSFileCoordinator) need on-device
+// verification and can't run here; these cover the Dart contract.
+@TestOn('vm')
+library;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_app/file_io.dart';
+import 'package:dart_pdf_editor_app/pdf_mobile_source.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  late Uint8List pdfBytes;
+
+  /// Installs a fake native handler on [channel] that serves [bytes] as a
+  /// seekable file. [length] overrides the reported size (-1 = unknown).
+  void mockFile(MethodChannel channel, Uint8List bytes, {int? length}) {
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      switch (call.method) {
+        case 'fileLength':
+          return length ?? bytes.length;
+        case 'readRange':
+          final offset = call.arguments['offset'] as int;
+          final len = call.arguments['length'] as int;
+          final end = (offset + len).clamp(0, bytes.length);
+          final start = offset.clamp(0, bytes.length);
+          return Uint8List.sublistView(bytes, start, end);
+        default:
+          return null;
+      }
+    });
+  }
+
+  setUp(() {
+    pdfBytes = PdfBlankDocument.create();
+  });
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(mobileFileChannel, null);
+  });
+
+  test('length reports the native file size', () async {
+    const channel = MethodChannel('test/mobile_file_len');
+    mockFile(channel, pdfBytes);
+    final source = PdfMobileByteSource('tok', channel: channel);
+    expect(await source.length, pdfBytes.length);
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('a negative native length normalizes to unknown (null)', () async {
+    const channel = MethodChannel('test/mobile_file_unknown');
+    mockFile(channel, pdfBytes, length: -1);
+    final source = PdfMobileByteSource('tok', channel: channel);
+    expect(await source.length, isNull);
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('readRange returns the requested slice and empties past the end',
+      () async {
+    const channel = MethodChannel('test/mobile_file_range');
+    mockFile(channel, pdfBytes);
+    final source = PdfMobileByteSource('tok', channel: channel);
+    expect(await source.readRange(0, 5), pdfBytes.sublist(0, 5));
+    expect(await source.readRange(10, 20), pdfBytes.sublist(10, 20));
+    // A negative start clamps to 0; a degenerate range is empty.
+    expect(await source.readRange(-5, 3), pdfBytes.sublist(0, 3));
+    expect(await source.readRange(30, 30), isEmpty);
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('reports cumulative progress across reads', () async {
+    const channel = MethodChannel('test/mobile_file_progress');
+    mockFile(channel, pdfBytes);
+    final seen = <int>[];
+    final source = PdfMobileByteSource(
+      'tok',
+      channel: channel,
+      onProgress: (received, total) => seen.add(received),
+    );
+    await source.readRange(0, 10);
+    await source.readRange(10, 25);
+    // Progress is the running total of bytes pulled: 10, then 10 + 15.
+    expect(seen, [10, 25]);
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('a fired cancel token aborts reads without touching the channel',
+      () async {
+    const channel = MethodChannel('test/mobile_file_cancel');
+    mockFile(channel, pdfBytes);
+    final token = PdfCancelToken();
+    final source =
+        PdfMobileByteSource('tok', channel: channel, cancelToken: token);
+    token.cancel();
+    expect(source.readRange(0, 10), throwsA(isA<PdfHttpCancelledException>()));
+    expect(source.length, throwsA(isA<PdfHttpCancelledException>()));
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('readSourceFully reassembles the exact file over ranged reads',
+      () async {
+    const channel = MethodChannel('test/mobile_file_full');
+    mockFile(channel, pdfBytes);
+    final source = PdfMobileByteSource('tok', channel: channel);
+    final full = await readSourceFully(source, chunk: 16);
+    expect(full, pdfBytes);
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('PdfDocument.openSource opens the file through the mobile source',
+      () async {
+    const channel = MethodChannel('test/mobile_file_open');
+    mockFile(channel, pdfBytes);
+    final source = PdfMobileByteSource('tok', channel: channel);
+    final doc = await PdfDocument.openSource(source);
+    expect(doc.pageCount, 1);
+    expect(doc.cos.bytes.length, pdfBytes.length);
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  group('pickPdfMobileReferences', () {
+    test('maps the native picker result into typed descriptors', () async {
+      messenger.setMockMethodCallHandler(mobileFileChannel, (call) async {
+        expect(call.method, 'pickDocuments');
+        return <Map<Object?, Object?>>[
+          {'token': 't1', 'name': 'a.pdf', 'length': 1234, 'seekable': true},
+          // Seekability defaults to false when the runner omits it.
+          {'token': 't2', 'name': 'b.pdf'},
+          // An entry without a token is dropped.
+          {'name': 'no-token.pdf'},
+        ];
+      });
+      final picks = await pickPdfMobileReferences();
+      expect(picks.length, 2);
+      expect(picks[0].token, 't1');
+      expect(picks[0].name, 'a.pdf');
+      expect(picks[0].length, 1234);
+      expect(picks[0].seekable, isTrue);
+      expect(picks[1].token, 't2');
+      expect(picks[1].seekable, isFalse);
+      expect(picks[1].length, isNull);
+    });
+
+    test('a cancelled pick (null result) yields an empty list', () async {
+      messenger.setMockMethodCallHandler(
+          mobileFileChannel, (call) async => null);
+      expect(await pickPdfMobileReferences(), isEmpty);
+    });
+  });
+
+  group('supportsMobileProgressiveOpen', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test('is true on Android and iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(supportsMobileProgressiveOpen, isTrue);
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(supportsMobileProgressiveOpen, isTrue);
+    });
+
+    test('is false on desktop', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      expect(supportsMobileProgressiveOpen, isFalse);
+    });
+  });
+}

--- a/app/test/pdf_mobile_source_test.dart
+++ b/app/test/pdf_mobile_source_test.dart
@@ -79,6 +79,14 @@ void main() {
     messenger.setMockMethodCallHandler(channel, null);
   });
 
+  test('a null native response reads as empty', () async {
+    const channel = MethodChannel('test/mobile_file_null');
+    messenger.setMockMethodCallHandler(channel, (call) async => null);
+    final source = PdfMobileByteSource('tok', channel: channel);
+    expect(await source.readRange(0, 10), isEmpty);
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
   test('reports cumulative progress across reads', () async {
     const channel = MethodChannel('test/mobile_file_progress');
     mockFile(channel, pdfBytes);

--- a/doc/dev-log/2026-07-18-mobile-progressive-open.md
+++ b/doc/dev-log/2026-07-18-mobile-progressive-open.md
@@ -1,0 +1,137 @@
+# Mobile cloud progressive open (#364)
+
+Follow-up to #359 / #363. #363 made the *desktop* open path progressive (first
+paint from ranged reads, full bytes streamed in behind it). Mobile was gated
+off because the win it targets — a big OneDrive/iCloud/Drive file — pays its
+whole cloud transport **inside the OS document picker's copy**, before the app
+sees a byte or a path, so app-level ranged open can't intercept it:
+
+- **Android** — `file_selector_android` does `contentResolver.openInputStream`
+  → `copy(...)` of the entire content URI into `{cacheDir}/{uuid}/{name}`, then
+  hands back that local path.
+- **iOS** — `file_selector_ios` uses `UIDocumentPickerViewController(... in:
+  .import)`, which copies the file into a temp location.
+
+The fix is a *reference* picker + a mobile ranged `PdfByteSource`, wired into
+the same `_openProgressive` swap machinery #363 built. Desktop is untouched.
+
+## Design — reuse everything from #363
+
+The whole progressive pipeline (`PdfByteSource` → `PdfDocument.openSource` with
+`firstPaintPages: 1` → read-only `DocumentTab.preview` → background
+`readSourceFully` → swap to a full `DocumentTab.document`) is origin-agnostic.
+The only desktop-specific bits were "build a source from a path" and "read the
+whole thing from a path". Those became two seams:
+
+- `_progressiveSource({path, bookmark, token})` and
+  `_readOriginFully({path, bookmark, token})` in `editor_screen.dart` pick the
+  desktop path source or the new mobile token source.
+- `DocumentTab` gained `originToken`, carried through `loading`/`preview`/
+  `document` the same way `originBookmark` is, so the preview→document swap and
+  the full-read fallback know how to re-read a mobile origin.
+
+`_openProgressive` now takes `path` **or** `token` (asserted exactly one). Every
+existing desktop call site is unchanged.
+
+## New pieces
+
+### `PdfMobileByteSource` (`app/lib/pdf_mobile_source.dart`)
+
+The mobile sibling of `PdfBookmarkFileByteSource`: a `PdfByteSource` over an
+opaque native **token**, reading ranges through the
+`dev.milanko.dartpdf/mobile_file` method channel (`fileLength` / `readRange`).
+`PdfCancelToken` + `onProgress` mirror the other sources. A negative native
+length is normalized to `null` ("unknown"), so the loader falls back to a
+sequential read. No `dart:io`, no conditional import — the channel is only ever
+invoked behind a platform guard, so the class compiles everywhere.
+
+### `file_io.dart`
+
+- `MobilePickedPdf { token, name, length, seekable }` — the reference picker's
+  result per file.
+- `supportsMobileProgressiveOpen` — true on Android/iOS off-web (the mobile
+  counterpart of `progressiveOpenSupported`, which stays desktop-only).
+- `pickPdfMobileReferences()` — invokes `pickDocuments`; maps the native list to
+  descriptors; throws `MissingPluginException` on a runner without the channel
+  so the caller falls back to the copy-based `pickPdfFiles`.
+- `pdfByteSourceForMobileToken(token)` — the token → source factory.
+
+### Wiring (`_pickAndOpenMobile`)
+
+`_pickAndOpen` branches to `_pickAndOpenMobile` on
+`supportsMobileProgressiveOpen`. There, a **single seekable** pick opens
+progressively (`_openProgressive(token:)`); a **non-seekable** pick or a
+**batch** streams the reference whole via `_readOriginFully(token:)` —
+still one read of the original, no OS copy, i.e. never worse than the old path.
+On `MissingPluginException` it falls through to the copy-based picker.
+
+### Reopen snapshot
+
+A mobile pick has no reopenable path and the token dies with the pick, so on the
+full-read swap (`_swapPreviewToDocument`) — and in the non-seekable/batch and
+fallback paths — the now-complete bytes are snapshotted via
+`_snapshotOpenedDocument` / the existing `cacheOpenedPdf` store. Recents/session
+restore then reopen from the local snapshot (fast, no transport), exactly as a
+plain mobile open already did. The first-paint recent add is skipped for a
+mobile pick (no reopenable origin yet) and added when the snapshot lands.
+
+## Native handlers
+
+### Android (`MainActivity.kt`)
+
+`dev.milanko.dartpdf/mobile_file`:
+
+- `pickDocuments` → `ACTION_OPEN_DOCUMENT` (`CATEGORY_OPENABLE`, `application/
+  pdf`, `EXTRA_ALLOW_MULTIPLE`, **no** `EXTRA_LOCAL_ONLY` so cloud providers
+  stay in the list). The async result lands in `onActivityResult`, which
+  `takePersistableUriPermission`s each URI and returns
+  `{token: uri, name, length, seekable}`. The token is the `content://` URI.
+- `probeSeekable` / `fileLength` / `readRange` via
+  `contentResolver.openFileDescriptor(uri, "r")` + `Os.lseek`. Reads run on a
+  single-thread executor (a multi-MB read must not ANR the platform thread).
+
+**The Android risk, called out in #364:** many cloud providers (incl. OneDrive)
+hand SAF a **non-seekable** `ParcelFileDescriptor` (a pipe) — `statSize == -1`,
+`lseek` throws `ESPIPE`. `probeSeekable` detects exactly that (statSize check +
+a forward/back `lseek`) and returns false, so the app streams the reference
+whole instead of attempting random access. **Whether progressive actually wins
+on Android depends entirely on the provider and is unverified** — see below.
+
+### iOS (`SceneDelegate.swift`)
+
+`dev.milanko.dartpdf/mobile_file`:
+
+- `pickDocuments` → `UIDocumentPickerViewController` in **`.open`** mode
+  (`forOpeningContentTypes: [.pdf]` on iOS 14+, `documentTypes:in:.open` on 13),
+  `allowsMultipleSelection`. Each picked URL becomes a base64 **security-scoped
+  bookmark** token (`url.bookmarkData()` under
+  `startAccessingSecurityScopedResource`).
+- `probeSeekable` / `fileLength` / `readRange` resolve the bookmark and do an
+  `NSFileCoordinator` coordinated read + `FileHandle` `seek`/`read`, so the File
+  Provider serves just the requested range. Reads run off the platform thread on
+  a serial queue. iOS coordinated ranged reads are more likely to work than
+  Android SAF (the issue's assessment), but this is still on-device territory.
+
+## Verification
+
+- **CI (done):** `pdf_mobile_source_test.dart` covers the source (length,
+  ranged slice, progress, cancel, unknown-length, `openSource`) and
+  `pickPdfMobileReferences` / `supportsMobileProgressiveOpen` against a mocked
+  channel. `mobile_progressive_open_test.dart` drives the whole pick → first
+  paint → full-read swap end-to-end on an Android platform override with the
+  native channel mocked to serve a real PDF by range. Full app suite green.
+- **On-device (pending — cannot be done from CI/desktop):** the native handlers
+  are unexercised. Per #364's acceptance criteria, still required:
+  1. **Android spike:** confirm `openFileDescriptor` yields a **seekable** FD for
+     a real OneDrive/Drive file on a device. If cloud providers return pipes
+     (likely for some), `probeSeekable` returns false and those picks stream
+     whole — correct, but no progressive win. If *no* mainstream provider is
+     seekable, Android progressive is not viable via SAF and should be scoped to
+     iOS only (the plumbing already degrades to the stream path automatically).
+  2. **iOS:** verify a coordinated ranged read paints a large iCloud/OneDrive
+     PDF before the whole file downloads.
+
+The design is fail-safe by construction: a missing channel, a cancelled pick, a
+non-seekable provider, or any first-paint failure all fall back to a whole read
+(or the copy-based picker), so nothing a plain mobile open handled can regress —
+the only variable is whether the first-paint speedup materializes per provider.

--- a/doc/dev-log/2026-07-18-mobile-progressive-open.md
+++ b/doc/dev-log/2026-07-18-mobile-progressive-open.md
@@ -94,8 +94,10 @@ mobile pick (no reopenable origin yet) and added when the snapshot lands.
 hand SAF a **non-seekable** `ParcelFileDescriptor` (a pipe) — `statSize == -1`,
 `lseek` throws `ESPIPE`. `probeSeekable` detects exactly that (statSize check +
 a forward/back `lseek`) and returns false, so the app streams the reference
-whole instead of attempting random access. **Whether progressive actually wins
-on Android depends entirely on the provider and is unverified** — see below.
+whole instead of attempting random access. **Whether progressive wins on Android
+is provider-dependent** — OneDrive was confirmed seekable on-device (see
+Verification); other providers remain to be checked and a pipe-returning one
+degrades safely to whole-stream.
 
 ### iOS (`SceneDelegate.swift`)
 
@@ -120,16 +122,29 @@ on Android depends entirely on the provider and is unverified** — see below.
   channel. `mobile_progressive_open_test.dart` drives the whole pick → first
   paint → full-read swap end-to-end on an Android platform override with the
   native channel mocked to serve a real PDF by range. Full app suite green.
-- **On-device (pending — cannot be done from CI/desktop):** the native handlers
-  are unexercised. Per #364's acceptance criteria, still required:
-  1. **Android spike:** confirm `openFileDescriptor` yields a **seekable** FD for
-     a real OneDrive/Drive file on a device. If cloud providers return pipes
-     (likely for some), `probeSeekable` returns false and those picks stream
-     whole — correct, but no progressive win. If *no* mainstream provider is
-     seekable, Android progressive is not viable via SAF and should be scoped to
-     iOS only (the plumbing already degrades to the stream path automatically).
-  2. **iOS:** verify a coordinated ranged read paints a large iCloud/OneDrive
-     PDF before the whole file downloads.
+- **On-device (native handlers can't run in CI/desktop):** per #364's
+  acceptance criteria —
+  1. **Android + OneDrive — CONFIRMED (2026-07-19, release build, devtools
+     traces).** The de-risking gamble — does SAF's `openFileDescriptor` hand
+     back a **seekable** FD for a mainstream cloud provider? — is met for
+     OneDrive. Evidence, not inference: `rangeRequests` / `rangeBytesFetched`
+     are emitted only by the ranged source (0 on the old copy path), and were
+     non-zero on `platform: android`, so `PdfMobileByteSource` is the code path.
+     `rangeBytesFetched: 444 KB` across three OneDrive files of 58 / 21 / 36 MB
+     (`rangeRequests: 122`) — ~1% of a single 36 MB file, i.e. the sparse
+     seekable `_fetch` path; a non-seekable pipe would have streamed ~115 MB via
+     `_downloadFully`. Progressive swap confirmed per document (e.g. 107-page
+     first paint, then `full read complete — 36,383,879 bytes` ~636 ms later),
+     and `objectRescueScanBuilt: 1` shows xref recovery still works over the
+     ranged source. So Android progressive is viable — **not** iOS-only.
+  2. **iOS — pending:** verify a coordinated ranged read paints a large
+     iCloud/OneDrive PDF before the whole file downloads (not yet exercised).
+  3. **Other providers — pending:** only OneDrive confirmed; Google Drive /
+     iCloud outstanding. A pipe-returning provider degrades to whole-stream
+     (correct, no win) via `probeSeekable`.
+  4. **Speedup magnitude — pending:** the traces prove progressive *works* and
+     fetches ~1% for first paint, but not (no A/B yet) that first paint is
+     *faster* than the old copy path.
 
 The design is fail-safe by construction: a missing channel, a cancelled pick, a
 non-seekable provider, or any first-paint failure all fall back to a whole read


### PR DESCRIPTION
## Summary

Follow-up to #359 / #363. #363 made the **desktop** open path progressive (first paint from ranged reads, full bytes streamed in behind it) but gated **mobile** off: a phone pick of a OneDrive/iCloud/Drive file pays its whole cloud transport *inside the OS picker's copy*, before the app sees a byte or a path, so app-level ranged open couldn't intercept it.

This adds a **reference picker** + a **mobile ranged `PdfByteSource`**, wired into the same `_openProgressive` swap machinery #363 built. **Desktop is untouched.**

- **`PdfMobileByteSource`** (`app/lib/pdf_mobile_source.dart`) — reads ranges over an opaque native token through the `dev.milanko.dartpdf/mobile_file` method channel; the mobile sibling of `PdfBookmarkFileByteSource`. `file_io` gains `MobilePickedPdf`, `supportsMobileProgressiveOpen`, `pickPdfMobileReferences`, `pdfByteSourceForMobileToken`.
- **Wiring** (`editor_screen.dart`) — `_openProgressive` now takes `path` **or** `token`; `_progressiveSource` / `_readOriginFully` pick the origin; `DocumentTab` carries `originToken`. `_pickAndOpenMobile` opens a single **seekable** pick progressively and streams a **non-seekable / batch** pick whole (one read of the original, no OS copy — never worse than the old path). The complete bytes are snapshotted on the full-read swap so Recent/session restore reopen from the local copy. Falls back to the copy-based picker on a runner without the channel.
- **Android** (`MainActivity.kt`) — `ACTION_OPEN_DOCUMENT` keeping the `content://` Uri (persisted read permission) + `openFileDescriptor` / `Os.lseek` ranged reads. A `statSize` + `lseek` **seekability probe** detects the non-seekable SAF pipe many cloud providers return and streams whole instead.
- **iOS** (`SceneDelegate.swift`) — `UIDocumentPickerViewController` in `.open` mode + a security-scoped bookmark token + `NSFileCoordinator` coordinated `FileHandle` ranged reads.

Fail-safe by construction: a missing channel, cancelled pick, non-seekable provider, or any first-paint failure falls back to a whole read, so nothing a plain mobile open handled can regress — the only variable is whether the first-paint speedup materializes per provider.

## Affected packages

- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Performance change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (app — clean)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (full `app/` suite green, 233 tests; new `pdf_mobile_source_test.dart` + `mobile_progressive_open_test.dart`)

If any relevant check was not run, explain why:

**The native handlers cannot be exercised from CI or the desktop harness.** The Dart contract is covered by mocked-channel unit tests and an end-to-end pick → first-paint → full-read-swap widget test on an Android platform override. The Android/iOS ranged-read code itself needs **on-device verification against real cloud providers** — this is #364's stated acceptance criteria and is the pending work:

1. **Android spike:** confirm `openFileDescriptor` yields a **seekable** FD for a real OneDrive/Drive file on a device. If cloud providers return pipes, `probeSeekable` returns false and those picks stream whole (correct, no progressive win). If no mainstream provider is seekable, Android progressive isn't viable via SAF and should be scoped to iOS only — the plumbing already degrades to the stream path automatically.
2. **iOS:** verify a coordinated ranged read paints a large iCloud/OneDrive PDF before the whole file downloads.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`. (New Dart lives in the example `app/`, which already depends on Flutter.)
- [x] No `dart:io` imports in any `lib/` directory. (`PdfMobileByteSource` uses only the method channel.)
- [x] Layering is preserved.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Design + the on-device verification gap are written up in `doc/dev-log/2026-07-18-mobile-progressive-open.md`.
- The whole feature degrades safely to the prior behavior on any failure path, so it can land ahead of the device spike; the spike decides whether Android keeps the progressive path or is scoped to iOS only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018WRoDHgri4qhYcU9tbFvEr)_