### PR TITLE
feat(#378): expose progressive open on the reusable viewer widgets

### DIFF
--- a/app/lib/document_tab.dart
+++ b/app/lib/document_tab.dart
@@ -1,6 +1,5 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
-import 'package:pdf_document/pdf_document.dart';
 
 /// One open document. Holds its own edit session and viewer controller so
 /// switching tabs preserves edits, undo history, and scroll position.

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:file_selector/file_selector.dart';
@@ -343,51 +342,6 @@ PdfByteSource pdfByteSourceForPath(
     cancelToken: cancelToken,
     onProgress: onProgress,
   );
-}
-
-/// Reads a whole [source] into one contiguous buffer, reporting progress as it
-/// goes. Unlike the sparse buffer [PdfDocument.openSource] assembles (zeros in
-/// the free space the parser never reads), this is the complete file - what the
-/// edit session, signing, and the render workers need. Used for the background
-/// full read behind a progressive first paint.
-Future<Uint8List> readSourceFully(
-  PdfByteSource source, {
-  void Function(int received, int? total)? onProgress,
-  int chunk = 8 << 20,
-  PdfCancelToken? cancelToken,
-}) async {
-  final len = await source.length;
-  if (len != null && len >= 0) {
-    final out = Uint8List(len);
-    var pos = 0;
-    while (pos < len) {
-      cancelToken?.throwIfCancelled();
-      final end = pos + chunk < len ? pos + chunk : len;
-      final data = await source.readRange(pos, end);
-      if (data.isEmpty) break;
-      // Never trust a source to honour the requested length: a misbehaving one
-      // can answer with more bytes than asked for (a 200-style full body).
-      // Clamp so setRange can't run past the buffer.
-      final count = data.length < len - pos ? data.length : len - pos;
-      out.setRange(pos, pos + count, data);
-      pos += count;
-      onProgress?.call(pos, len);
-    }
-    return pos == len ? out : Uint8List.sublistView(out, 0, pos);
-  }
-  // Unknown length: chunk until a short read signals EOF.
-  final builder = BytesBuilder(copy: false);
-  var pos = 0;
-  while (true) {
-    cancelToken?.throwIfCancelled();
-    final data = await source.readRange(pos, pos + chunk);
-    if (data.isEmpty) break;
-    builder.add(data);
-    pos += data.length;
-    onProgress?.call(pos, null);
-    if (data.length < chunk) break;
-  }
-  return builder.toBytes();
 }
 
 /// Whether the current platform can open a local file's containing folder in

--- a/app/lib/native_print_io.dart
+++ b/app/lib/native_print_io.dart
@@ -1,6 +1,5 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/services.dart';
-import 'package:pdf_document/pdf_document.dart';
 
 /// The platform channel every native runner registers (see
 /// `windows/runner/native_print.cpp`, the macOS/iOS Swift handlers, the Android

--- a/app/test/pdf_file_source_test.dart
+++ b/app/test/pdf_file_source_test.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
-import 'package:dart_pdf_editor_app/file_io.dart';
 import 'package:dart_pdf_editor_app/pdf_file_source.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';

--- a/app/tool/perf/perf_harness.dart
+++ b/app/tool/perf/perf_harness.dart
@@ -32,7 +32,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:pdf_document/pdf_document.dart';
 
 // ---------------------------------------------------------------------------
 // Tunables - read from the URL query string at runtime (so the driver can vary

--- a/doc/dev-log/2026-07-19-progressive-open-viewer-widgets.md
+++ b/doc/dev-log/2026-07-19-progressive-open-viewer-widgets.md
@@ -1,0 +1,69 @@
+# Expose progressive open on the reusable viewer widgets (#378)
+
+Progressive open (#359, #328) already worked inside the standalone app, but the
+capability wasn't reachable through the published `dart_pdf_editor` public API:
+the reusable widgets only took `bytes: Uint8List`, `PdfDocument`/`openSource`
+weren't exported, and the background full-read helper (`readSourceFully`) lived
+in `app/lib/file_io.dart`. A `dart_pdf_editor`-only host (Trax's PDF viewer) had
+to re-implement ~150 lines of app orchestration against undocumented internals
+(`doc.cos.bytes` as a renderable sparse buffer).
+
+## What landed
+
+- **`readSourceFully` moved into the library.** Lifted verbatim from
+  `app/lib/file_io.dart` into `src/progressive_source.dart` (same signature:
+  `{onProgress, chunk = 8<<20, cancelToken}`) and exported. The app now imports
+  the library copy via the barrel; the app's own source tests are unchanged.
+- **`PdfProgressiveSourceBuilder`** (new, exported): the reusable orchestration.
+  It opens a sparse first-paint document from the source's ranges
+  (`PdfDocument.openSource(..., firstPaintPages: 1)`, reading `.cos.bytes`),
+  hands those bytes to a `builder(context, bytes, complete)` so page one paints
+  immediately, reads the rest with `readSourceFully` in the background (progress
+  + cancellation), then calls the builder again with the full buffer so it
+  swaps in place. Owns an internal `PdfCancelToken` cancelled on dispose; never
+  closes the host-owned source. Falls back to a plain full read when the first
+  paint can't be assembled (`openSource` throws) - a `loadingBuilder` shows
+  until bytes exist, `errorBuilder` only when nothing could be produced.
+- **`PdfReader.source(...)` / `PdfEditorView.source(...)`** (new named
+  constructors). Both are thin composition over `PdfProgressiveSourceBuilder`:
+  the builder returns the existing **byte-based** widget at the same tree
+  position, so the first-paint→full swap reopens in place (the inner widget owns
+  the shell/session/worker) and, with a stable `documentId`, keeps its scroll
+  position across the swap. API matches the issue: `source`, `options`,
+  `documentId`, `onProgress`, `onFirstPaint`, plus `loadingBuilder`/
+  `errorBuilder`.
+  - `PdfEditorView.source` **gates editing until the full file lands**: while
+    `!complete` it projects `features` through `_gatedFeatures` (toolbar, page
+    editing, markup, undo/redo, annotation/properties panels off) and suppresses
+    `onSave`/`onSaveAs`/`onDocumentChanged`/insert/export - the first-paint
+    buffer is deliberately incomplete and must not be edited or saved.
+- **`PdfDocument` exported** from `dart_pdf_editor` (added to the `pdf_document`
+  `show` list; `openSource` is a static on it). A host can now open a source
+  into a document with no direct `pdf_document` dependency.
+
+## Gotchas
+
+- Exporting `PdfDocument` from the barrel turned ~55 `import
+  'package:pdf_document/...'` lines across the package/app tests + examples into
+  `unnecessary_import` infos (CI runs `dart analyze --fatal-infos`). Removed each
+  flagged line - safe because the barrel re-exports the same symbols. One was an
+  `src/render_worker.dart` import surfaced by the same barrel change.
+- The widget's "fall back to a plain full read" branch (`preview == null`) is
+  defensive: `PdfDocument.openSource` already falls back to a full sequential
+  download *internally* for an unknown-length / non-ranged source and still
+  returns a renderable doc, so first paint fires there too. `preview` is only
+  null when `openSource` throws outright.
+- Source-mode widgets never build their `_shell`; `initState`/`didUpdateWidget`/
+  `dispose` early-return in source mode and the inner byte-mode widget the
+  builder mounts owns the shell. A widget instance is one mode for its lifetime.
+
+Not in scope (per the issue): host-specific sources (`dart:io` file source,
+Firebase Storage source) stay in the host; the app's multi-tab
+`DocumentTab.preview` orchestration is untouched. Bare `PdfViewer` (which takes
+a `PdfDocument`, not bytes, and has no shell/worker lifecycle) is left as-is - a
+host wraps it with `PdfProgressiveSourceBuilder` + `PdfDocument.open` directly.
+
+Test: `test/progressive_source_test.dart` covers `readSourceFully` (known/
+unknown length, cancellation), source → first-paint (ordering proves it beats
+the full-read completion) → full-read swap, the loader gate, dispose
+cancellation, the sequential fallback, and `PdfEditorView.source`.

--- a/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
+++ b/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 /// A self-contained showcase of the viewer's public scroll-indicator API

--- a/packages/dart_pdf_editor/example/lib/web_benchmark.dart
+++ b/packages/dart_pdf_editor/example/lib/web_benchmark.dart
@@ -30,7 +30,6 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:web/web.dart' as web;
 
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 void main() {

--- a/packages/dart_pdf_editor/example/lib/web_spatial_replay_benchmark.dart
+++ b/packages/dart_pdf_editor/example/lib/web_spatial_replay_benchmark.dart
@@ -7,7 +7,6 @@ import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:web/web.dart' as web;
 
 const _cadUrl = String.fromEnvironment('CAD_PERF_URL');

--- a/packages/dart_pdf_editor/example/tool/pdf_to_images.dart
+++ b/packages/dart_pdf_editor/example/tool/pdf_to_images.dart
@@ -19,7 +19,6 @@ import 'dart:io';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 
 void main() {
   testWidgets('export PDF pages to images', (tester) async {

--- a/packages/dart_pdf_editor/example/tool/showcase_sharpen_benchmark_test.dart
+++ b/packages/dart_pdf_editor/example/tool/showcase_sharpen_benchmark_test.dart
@@ -3,7 +3,6 @@ import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_viewer_example/demo_document.dart';
 
 int _percentile(List<int> values, double fraction) {

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -3,6 +3,7 @@ library;
 
 export 'package:pdf_document/pdf_document.dart'
     show
+        PdfDocument,
         PdfStampTemplate,
         PdfStampTemplateComponent,
         PdfStampTemplateComponentType,
@@ -54,6 +55,7 @@ export 'src/image_decoder.dart' show PdfImageCache;
 export 'src/ocr.dart';
 export 'src/page_export.dart';
 export 'src/print_rasterize.dart';
+export 'src/progressive_source.dart';
 export 'src/vector_print_ui.dart';
 export 'src/page_geometry.dart';
 export 'src/page_object_cache.dart';

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, mapEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
@@ -22,6 +23,7 @@ import 'page_number_field.dart';
 import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
+import 'progressive_source.dart';
 import 'raster_cache.dart';
 import 'search_panel.dart';
 import 'shell_chrome.dart';
@@ -246,14 +248,107 @@ class PdfEditorView extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
-  })  : assert((bytes == null) != (controller == null),
+  })  : source = null,
+        options = const PdfSourceLoadOptions(firstPaintPages: 1),
+        onProgress = null,
+        onFirstPaint = null,
+        loadingBuilder = null,
+        errorBuilder = null,
+        assert((bytes == null) != (controller == null),
             'Provide bytes or a controller, not both.'),
         assert(controller == null || preferences == null,
             'With an external controller, preferences come from it.');
 
+  /// An editor that opens progressively from a [PdfByteSource].
+  ///
+  /// Page one paints from a sparse first-paint open ([options],
+  /// defaulting to the first page) while the rest of the file downloads in the
+  /// background; when it lands the full buffer swaps in place. Editing stays
+  /// disabled until the whole file is present - the first-paint buffer is
+  /// deliberately incomplete, so it must not be edited or saved - then the full
+  /// toolbar and [onSave]/[onSaveAs]/[onDocumentChanged] callbacks come alive.
+  ///
+  /// Pass a stable [documentId] (the URL or path) so remembered scroll/zoom
+  /// survive the swap. [onProgress] reports the background read;
+  /// [onFirstPaint] fires when the first page is ready. Falls back to a plain
+  /// full read (no early paint) when the source can't serve useful ranges. The
+  /// in-flight load is cancelled when the widget is disposed; the [source] is
+  /// host-owned and not closed.
+  const PdfEditorView.source(
+    PdfByteSource this.source, {
+    super.key,
+    this.options = const PdfSourceLoadOptions(firstPaintPages: 1),
+    this.documentId,
+    this.onProgress,
+    this.onFirstPaint,
+    this.loadingBuilder,
+    this.errorBuilder,
+    this.viewerController,
+    this.preferences,
+    this.performance,
+    this.features = const PdfEditorFeatures(),
+    this.onSave,
+    this.onSaveAs,
+    this.showSaveButton = true,
+    this.alwaysAllowSave = false,
+    this.onDocumentChanged,
+    this.onPickPdfToInsert,
+    this.onExportPages,
+    this.onAction,
+    this.onAnnotationTap,
+    this.pageOverlayBuilder,
+    this.annotationMenuBuilder,
+    this.formImagePicker,
+    this.imagePicker,
+    this.systemImagePasteProvider,
+    this.onExportSelectedContentImage,
+    this.onExportCustomStamps,
+    this.onImportCustomStamps,
+    this.customStamps = const [],
+    this.fontPicker,
+    this.onSnapshot,
+    this.onPlaceSignature,
+    this.textPrompt,
+    this.styledTextPrompt,
+    this.palette = PdfEditingToolbar.defaultPalette,
+    this.toolShortcuts = pdfEditToolShortcuts,
+    this.toolbarLeading = const [],
+    this.toolbarTrailing = const [],
+    this.toolbarBuilder,
+    this.pageLayout = const PdfPageLayout.verticalContinuous(),
+    this.initialFit = PdfViewerFit.page,
+    this.backgroundColor,
+    this.pageColor,
+    this.viewerTheme,
+    this.rasterCache,
+    this.textCache,
+  })  : bytes = null,
+        controller = null;
+
   /// The PDF to edit. The widget owns the session; replacing the bytes
-  /// (by identity) opens a fresh session in place.
+  /// (by identity) opens a fresh session in place. Null when opened from a
+  /// [source] or an external [controller].
   final Uint8List? bytes;
+
+  /// The source to open progressively (via [PdfEditorView.source]); null
+  /// otherwise.
+  final PdfByteSource? source;
+
+  /// First-paint tuning for the [source] open. See
+  /// [PdfProgressiveSourceBuilder.options].
+  final PdfSourceLoadOptions options;
+
+  /// Background full-read progress for the [source] open, `(received, total)`.
+  final void Function(int received, int? total)? onProgress;
+
+  /// Fires when the first page painted from the [source].
+  final VoidCallback? onFirstPaint;
+
+  /// Shown while the first-paint bytes are still loading (source mode only).
+  final WidgetBuilder? loadingBuilder;
+
+  /// Shown when a [source] open fails before any page could paint.
+  final Widget Function(BuildContext context, Object error)? errorBuilder;
 
   /// Optional persistent on-disk preview cache (see [PdfRasterCache]).
   /// Keyed by [documentId] (or, with [bytes], their [pdfContentKey]), so
@@ -469,11 +564,16 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   /// [documentId]. With [bytes] one is derived from the content.
   String? get _documentKey => _shell.documentKey;
 
+  bool get _isSource => widget.source != null;
+
   @override
   void initState() {
     super.initState();
     _toolShortcuts =
         Map<PdfEditTool, LogicalKeyboardKey>.of(widget.toolShortcuts);
+    // In source mode the shell is owned by the inner byte-based PdfEditorView
+    // the progressive builder mounts once the first-paint bytes arrive.
+    if (_isSource) return;
     _shell = PdfShellSessionLifecycle(
       bytes: widget.bytes,
       controller: widget.controller,
@@ -518,6 +618,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
       _toolShortcuts =
           Map<PdfEditTool, LogicalKeyboardKey>.of(widget.toolShortcuts);
     }
+    if (_isSource) return;
     final sourceChanging = widget.controller != oldWidget.controller ||
         !identical(widget.bytes, oldWidget.bytes) ||
         (widget.controller == null &&
@@ -545,9 +646,102 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   @override
   void dispose() {
     _pencil?.dispose();
-    _shell.dispose();
+    if (!_isSource) _shell.dispose();
     super.dispose();
   }
+
+  /// The progressive-open path: paint page one from the sparse first-paint
+  /// buffer, then swap the full buffer in place. The inner byte-based
+  /// [PdfEditorView] owns the session/worker, so it reopens in place across the
+  /// swap. Editing is gated off until the full file lands - the first-paint
+  /// buffer is deliberately incomplete, so it must not be edited or saved.
+  Widget _buildFromSource() {
+    return PdfProgressiveSourceBuilder(
+      source: widget.source!,
+      options: widget.options,
+      onProgress: widget.onProgress,
+      onFirstPaint: widget.onFirstPaint,
+      loadingBuilder: widget.loadingBuilder,
+      errorBuilder: widget.errorBuilder,
+      builder: (context, bytes, complete) => PdfEditorView(
+        bytes: bytes,
+        documentId: widget.documentId,
+        viewerController: widget.viewerController,
+        preferences: widget.preferences,
+        performance: widget.performance,
+        features: complete ? widget.features : _gatedFeatures(widget.features),
+        // The first-paint buffer is incomplete: no save/change/insert/export
+        // until the whole file is present.
+        onSave: complete ? widget.onSave : null,
+        onSaveAs: complete ? widget.onSaveAs : null,
+        showSaveButton: widget.showSaveButton,
+        alwaysAllowSave: complete && widget.alwaysAllowSave,
+        onDocumentChanged: complete ? widget.onDocumentChanged : null,
+        onPickPdfToInsert: complete ? widget.onPickPdfToInsert : null,
+        onExportPages: complete ? widget.onExportPages : null,
+        onAction: widget.onAction,
+        onAnnotationTap: widget.onAnnotationTap,
+        pageOverlayBuilder: widget.pageOverlayBuilder,
+        annotationMenuBuilder: widget.annotationMenuBuilder,
+        formImagePicker: widget.formImagePicker,
+        imagePicker: widget.imagePicker,
+        systemImagePasteProvider: widget.systemImagePasteProvider,
+        onExportSelectedContentImage: widget.onExportSelectedContentImage,
+        onExportCustomStamps: widget.onExportCustomStamps,
+        onImportCustomStamps: widget.onImportCustomStamps,
+        customStamps: widget.customStamps,
+        fontPicker: widget.fontPicker,
+        onSnapshot: widget.onSnapshot,
+        onPlaceSignature: widget.onPlaceSignature,
+        textPrompt: widget.textPrompt,
+        styledTextPrompt: widget.styledTextPrompt,
+        palette: widget.palette,
+        toolShortcuts: widget.toolShortcuts,
+        toolbarLeading: widget.toolbarLeading,
+        toolbarTrailing: widget.toolbarTrailing,
+        toolbarBuilder: widget.toolbarBuilder,
+        pageLayout: widget.pageLayout,
+        initialFit: widget.initialFit,
+        backgroundColor: widget.backgroundColor,
+        pageColor: widget.pageColor,
+        viewerTheme: widget.viewerTheme,
+        rasterCache: widget.rasterCache,
+        textCache: widget.textCache,
+      ),
+    );
+  }
+
+  /// A read-only projection of [features] for the incomplete first-paint view:
+  /// the viewer, search, and navigation panels stay, but every editing
+  /// surface - the toolbar, page editing, markup, undo/redo, the
+  /// annotation/properties panels - is off until the full buffer lands.
+  static PdfEditorFeatures _gatedFeatures(PdfEditorFeatures f) =>
+      PdfEditorFeatures(
+        headerBar: f.headerBar,
+        search: f.search,
+        searchResultsPanel: f.searchResultsPanel,
+        pageNumber: f.pageNumber,
+        author: false,
+        authorEditable: false,
+        viewOptions: f.viewOptions,
+        reflowView: f.reflowView,
+        pageColorEditable: f.pageColorEditable,
+        thumbnails: f.thumbnails,
+        bookmarks: f.bookmarks,
+        pageEditing: false,
+        annotationSidebar: false,
+        propertiesPanel: false,
+        toolbar: false,
+        markup: false,
+        undoRedo: false,
+        colorControls: f.colorControls,
+        styleControls: f.styleControls,
+        flatten: false,
+        colorProcessing: false,
+        pencilEraserToggle: false,
+        tools: f.tools,
+        toolGroups: f.toolGroups,
+      );
 
   /// Whether there's anything to save: false while the document still
   /// matches what was opened, which disables the Save button (and makes
@@ -590,6 +784,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
 
   @override
   Widget build(BuildContext context) {
+    if (_isSource) return _buildFromSource();
     final features = widget.features;
     Widget body = LayoutBuilder(builder: (context, constraints) {
       return ListenableBuilder(

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -705,8 +705,13 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         backgroundColor: widget.backgroundColor,
         pageColor: widget.pageColor,
         viewerTheme: widget.viewerTheme,
-        rasterCache: widget.rasterCache,
-        textCache: widget.textCache,
+        // The first-paint buffer only holds the first page(s); its later pages
+        // render blank (and its text extracts empty). Keep the persistent
+        // content-keyed caches off until the full buffer lands so those blanks
+        // aren't written under the document's stable id and served back after
+        // the swap (and across app restarts).
+        rasterCache: complete ? widget.rasterCache : null,
+        textCache: complete ? widget.textCache : null,
       ),
     );
   }

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -574,8 +574,13 @@ class _PdfReaderState extends State<PdfReader> {
         backgroundColor: widget.backgroundColor,
         pageColor: widget.pageColor,
         viewerTheme: widget.viewerTheme,
-        rasterCache: widget.rasterCache,
-        textCache: widget.textCache,
+        // The first-paint buffer only holds the first page(s); its later pages
+        // render blank (and its text extracts empty). Keep the persistent
+        // content-keyed caches off until the full buffer lands so those blanks
+        // aren't written under the document's stable id and served back after
+        // the swap (and across app restarts).
+        rasterCache: complete ? widget.rasterCache : null,
+        textCache: complete ? widget.textCache : null,
       ),
     );
   }

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
@@ -12,6 +13,7 @@ import 'page_number_field.dart';
 import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
+import 'progressive_source.dart';
 import 'raster_cache.dart';
 import 'search_panel.dart';
 import 'shell_chrome.dart';
@@ -100,10 +102,25 @@ class PdfReaderFeatures {
 /// The widget is a plain body: give it bounded space (a [Scaffold]
 /// body, an [Expanded]...). Swapping [bytes] for a different document
 /// reopens in place.
+///
+/// ## Progressive open from a source
+///
+/// [PdfReader.source] points the reader at a [PdfByteSource] (an HTTP URL via
+/// [PdfHttpByteSource], a host's own file or cloud source) and paints page one
+/// from ranged reads before the whole file has downloaded, then swaps the
+/// complete buffer in behind the scenes:
+///
+/// ```dart
+/// PdfReader.source(
+///   PdfHttpByteSource(Uri.parse(url)),
+///   documentId: url,
+///   onProgress: (received, total) => setDownloadFraction(received, total),
+/// )
+/// ```
 class PdfReader extends StatefulWidget {
   const PdfReader({
     super.key,
-    required this.bytes,
+    required Uint8List this.bytes,
     this.documentId,
     this.controller,
     this.preferences,
@@ -120,11 +137,72 @@ class PdfReader extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
-  });
+  })  : source = null,
+        options = const PdfSourceLoadOptions(firstPaintPages: 1),
+        onProgress = null,
+        onFirstPaint = null,
+        loadingBuilder = null,
+        errorBuilder = null;
+
+  /// A view-only reader that opens progressively from a [PdfByteSource].
+  ///
+  /// Page one paints from a sparse first-paint open ([options],
+  /// defaulting to the first page) while the rest of the file downloads in the
+  /// background; when it lands the full buffer swaps in place. Pass a stable
+  /// [documentId] (the URL or path) so remembered scroll/zoom survive the swap.
+  /// [onProgress] reports the background read; [onFirstPaint] fires when
+  /// the first page is ready. Falls back to a plain full read (no early paint)
+  /// when the source can't serve useful ranges. The in-flight load is cancelled
+  /// when the widget is disposed; the [source] is host-owned and not closed.
+  const PdfReader.source(
+    PdfByteSource this.source, {
+    super.key,
+    this.options = const PdfSourceLoadOptions(firstPaintPages: 1),
+    this.documentId,
+    this.onProgress,
+    this.onFirstPaint,
+    this.loadingBuilder,
+    this.errorBuilder,
+    this.controller,
+    this.preferences,
+    this.performance,
+    this.features = const PdfReaderFeatures(),
+    this.onAction,
+    this.onAnnotationTap,
+    this.onLaunchUrl,
+    this.pageOverlayBuilder,
+    this.pageLayout = const PdfPageLayout.verticalContinuous(),
+    this.initialFit = PdfViewerFit.page,
+    this.backgroundColor,
+    this.pageColor,
+    this.viewerTheme,
+    this.rasterCache,
+    this.textCache,
+  }) : bytes = null;
 
   /// The PDF to show. Replacing it (by identity) opens the new
-  /// document in place.
-  final Uint8List bytes;
+  /// document in place. Null when opened from a [source].
+  final Uint8List? bytes;
+
+  /// The source to open progressively (via [PdfReader.source]); null for the
+  /// byte-based reader.
+  final PdfByteSource? source;
+
+  /// First-paint tuning for the [source] open. See
+  /// [PdfProgressiveSourceBuilder.options].
+  final PdfSourceLoadOptions options;
+
+  /// Background full-read progress for the [source] open, `(received, total)`.
+  final void Function(int received, int? total)? onProgress;
+
+  /// Fires when the first page painted from the [source].
+  final VoidCallback? onFirstPaint;
+
+  /// Shown while the first-paint bytes are still loading (source mode only).
+  final WidgetBuilder? loadingBuilder;
+
+  /// Shown when a [source] open fails before any page could paint.
+  final Widget Function(BuildContext context, Object error)? errorBuilder;
 
   /// Optional persistent on-disk preview cache (see [PdfRasterCache]).
   /// Keyed by [documentId] (or the bytes' [pdfContentKey]), so reopening
@@ -201,9 +279,14 @@ class _PdfReaderState extends State<PdfReader> {
   TextEditingController get _searchField => _shell.searchController;
   FocusNode get _searchFocus => _shell.searchFocus;
 
+  bool get _isSource => widget.source != null;
+
   @override
   void initState() {
     super.initState();
+    // In source mode the shell is owned by the inner byte-based PdfReader the
+    // progressive builder mounts once the first-paint bytes arrive.
+    if (_isSource) return;
     _shell = PdfShellSessionLifecycle(
       bytes: widget.bytes,
       controller: null,
@@ -217,6 +300,7 @@ class _PdfReaderState extends State<PdfReader> {
   @override
   void didUpdateWidget(PdfReader oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (_isSource) return;
     _shell.update(
       bytes: widget.bytes,
       controller: null,
@@ -229,12 +313,13 @@ class _PdfReaderState extends State<PdfReader> {
 
   @override
   void dispose() {
-    _shell.dispose();
+    if (!_isSource) _shell.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    if (_isSource) return _buildFromSource();
     final features = widget.features;
     Widget body = LayoutBuilder(builder: (context, constraints) {
       return ListenableBuilder(
@@ -459,5 +544,39 @@ class _PdfReaderState extends State<PdfReader> {
       );
     }
     return body;
+  }
+
+  /// The progressive-open path: paint page one from the sparse first-paint
+  /// buffer, then swap the full buffer in place. The inner byte-based
+  /// [PdfReader] owns the session/worker, so it reopens in place across the
+  /// swap and (with a stable [PdfReader.documentId]) keeps its scroll position.
+  Widget _buildFromSource() {
+    return PdfProgressiveSourceBuilder(
+      source: widget.source!,
+      options: widget.options,
+      onProgress: widget.onProgress,
+      onFirstPaint: widget.onFirstPaint,
+      loadingBuilder: widget.loadingBuilder,
+      errorBuilder: widget.errorBuilder,
+      builder: (context, bytes, complete) => PdfReader(
+        bytes: bytes,
+        documentId: widget.documentId,
+        controller: widget.controller,
+        preferences: widget.preferences,
+        performance: widget.performance,
+        features: widget.features,
+        onAction: widget.onAction,
+        onAnnotationTap: widget.onAnnotationTap,
+        onLaunchUrl: widget.onLaunchUrl,
+        pageOverlayBuilder: widget.pageOverlayBuilder,
+        pageLayout: widget.pageLayout,
+        initialFit: widget.initialFit,
+        backgroundColor: widget.backgroundColor,
+        pageColor: widget.pageColor,
+        viewerTheme: widget.viewerTheme,
+        rasterCache: widget.rasterCache,
+        textCache: widget.textCache,
+      ),
+    );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/progressive_source.dart
+++ b/packages/dart_pdf_editor/lib/src/progressive_source.dart
@@ -1,0 +1,242 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'http_byte_source.dart';
+
+/// Reads a whole [PdfByteSource] into one contiguous buffer, reporting progress
+/// as it goes.
+///
+/// This is the background "finish the download" half of progressive open:
+/// [PdfDocument.openSource] paints the first page(s) from a sparse buffer of
+/// just the bytes it needs (zeros in the free space the parser never reads),
+/// then a host reads the rest with this and swaps the full buffer in. Unlike
+/// that first-paint buffer, the bytes returned here are the complete file -
+/// what the edit session, signing, and the render workers need.
+///
+/// Progress is reported to [onProgress] after each read as `(received, total)`;
+/// `total` is the document length when the source knows it, else null. Pass a
+/// [cancelToken] to abort in flight - a fired token makes this throw
+/// [PdfHttpCancelledException] between reads (and any read the source itself
+/// aborts propagates). [chunk] bounds each read (and so the progress
+/// granularity).
+///
+/// A known-length source is read forward in [chunk] windows until it is
+/// exhausted; an unknown-length one is chunked until a short/empty read signals
+/// the end.
+Future<Uint8List> readSourceFully(
+  PdfByteSource source, {
+  void Function(int received, int? total)? onProgress,
+  int chunk = 8 << 20,
+  PdfCancelToken? cancelToken,
+}) async {
+  assert(chunk > 0);
+  final len = await source.length;
+  if (len != null && len >= 0) {
+    final out = Uint8List(len);
+    var pos = 0;
+    while (pos < len) {
+      cancelToken?.throwIfCancelled();
+      final end = pos + chunk < len ? pos + chunk : len;
+      final data = await source.readRange(pos, end);
+      if (data.isEmpty) break;
+      // Never trust a source to honour the requested length: a misbehaving one
+      // can answer with more bytes than asked for (a 200-style full body).
+      // Clamp so setRange can't run past the buffer.
+      final count = data.length < len - pos ? data.length : len - pos;
+      out.setRange(pos, pos + count, data);
+      pos += count;
+      onProgress?.call(pos, len);
+    }
+    return pos == len ? out : Uint8List.sublistView(out, 0, pos);
+  }
+  // Unknown length: chunk until a short read signals EOF.
+  final builder = BytesBuilder(copy: false);
+  var pos = 0;
+  while (true) {
+    cancelToken?.throwIfCancelled();
+    final data = await source.readRange(pos, pos + chunk);
+    if (data.isEmpty) break;
+    builder.add(data);
+    pos += data.length;
+    onProgress?.call(pos, null);
+    if (data.length < chunk) break;
+  }
+  return builder.toBytes();
+}
+
+/// Builds a viewer subtree progressively from an asynchronous [PdfByteSource].
+///
+/// This is the reusable orchestration behind [PdfReader.source] /
+/// [PdfEditorView.source], and the entry point for pointing any byte-based
+/// viewer at a source: it opens a sparse first-paint document from the source's
+/// ranges, calls [builder] with those bytes so page one paints immediately,
+/// reads the rest of the file in the background (progress + cancellation), then
+/// calls [builder] again with the complete buffer so it can swap in place.
+///
+/// [builder] receives `(context, bytes, complete)` - the best buffer available
+/// so far and whether it is the full file. Give the widget it returns a stable
+/// identity (a [PdfReader]/[PdfEditorView] at the same position, or a fixed
+/// key) so the first-paint→full swap reopens in place rather than remounting;
+/// pass a stable `documentId` down so remembered scroll/zoom survives the swap.
+///
+/// If the sparse first paint can't be assembled (a source that can't serve
+/// useful ranges, a malformed file), this falls back to a plain full read: no
+/// early paint, [loadingBuilder] shows until the whole file lands, then
+/// [builder] is called once with `complete: true`. The in-flight load is
+/// cancelled when the widget is disposed.
+class PdfProgressiveSourceBuilder extends StatefulWidget {
+  const PdfProgressiveSourceBuilder({
+    super.key,
+    required this.source,
+    required this.builder,
+    this.options = const PdfSourceLoadOptions(firstPaintPages: 1),
+    this.password = '',
+    this.onProgress,
+    this.onFirstPaint,
+    this.loadingBuilder,
+    this.errorBuilder,
+  });
+
+  /// The document source. Host-owned; the widget reads from it but never
+  /// closes it (a host may reuse it), and does not take ownership.
+  final PdfByteSource source;
+
+  /// Builds the viewer for the bytes available so far. `complete` is false
+  /// while showing the sparse first-paint buffer, true once the full file has
+  /// been read.
+  final Widget Function(BuildContext context, Uint8List bytes, bool complete)
+      builder;
+
+  /// Tuning for the sparse first-paint open (see
+  /// [PdfDocument.openSource]). Defaults to fetching just the first page;
+  /// `firstPaintPages: null` opens every object up front (no fast first paint).
+  final PdfSourceLoadOptions options;
+
+  /// Password for an encrypted source, forwarded to the open.
+  final String password;
+
+  /// Reports the background full-read progress as `(received, total)`; `total`
+  /// is null until/unless the source's length is known.
+  final void Function(int received, int? total)? onProgress;
+
+  /// Called once, right after the first-paint bytes are handed to [builder].
+  final VoidCallback? onFirstPaint;
+
+  /// Shown before any bytes are available (during the first-paint open, or the
+  /// whole full read when first paint fell back). Defaults to a centered
+  /// [CircularProgressIndicator].
+  final WidgetBuilder? loadingBuilder;
+
+  /// Shown when the load fails before any bytes could be produced. Defaults to
+  /// a centered error message. A failure of the *background* read after the
+  /// first paint is not surfaced here - the first-paint view stays up.
+  final Widget Function(BuildContext context, Object error)? errorBuilder;
+
+  @override
+  State<PdfProgressiveSourceBuilder> createState() =>
+      _PdfProgressiveSourceBuilderState();
+}
+
+class _PdfProgressiveSourceBuilderState
+    extends State<PdfProgressiveSourceBuilder> {
+  /// The sparse first-paint buffer (renderable for the covered pages only).
+  Uint8List? _preview;
+
+  /// The complete file, once the background read finishes.
+  Uint8List? _full;
+
+  /// A load failure that left us with nothing to show.
+  Object? _error;
+
+  /// Cancels the in-flight background read on dispose.
+  PdfCancelToken _cancel = PdfCancelToken();
+  bool _disposed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void didUpdateWidget(PdfProgressiveSourceBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A new source means a new document: cancel the old load and restart.
+    if (!identical(widget.source, oldWidget.source)) {
+      _cancel.cancel();
+      _cancel = PdfCancelToken();
+      _preview = null;
+      _full = null;
+      _error = null;
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final token = _cancel;
+    // First paint: fetch just the covered pages' bytes into a sparse buffer.
+    // Any failure here (a non-ranged source, a malformed file) just means we
+    // skip the early paint and wait for the full read - never a hard error.
+    Uint8List? preview;
+    try {
+      final doc = await PdfDocument.openSource(widget.source,
+          password: widget.password, options: widget.options);
+      preview = doc.cos.bytes;
+    } on Object {
+      preview = null;
+    }
+    if (_disposed || !identical(token, _cancel)) return;
+    if (preview != null) {
+      setState(() => _preview = preview);
+      widget.onFirstPaint?.call();
+    }
+
+    // Background full read: the complete, editable/persistable buffer.
+    try {
+      final full = await readSourceFully(widget.source,
+          cancelToken: token, onProgress: widget.onProgress);
+      if (_disposed || !identical(token, _cancel)) return;
+      setState(() => _full = full);
+    } on PdfHttpCancelledException {
+      // Disposed or superseded mid-read; nothing to do.
+    } on Object catch (error) {
+      if (_disposed || !identical(token, _cancel)) return;
+      // Keep any first-paint view up; only surface when we have nothing.
+      if (_preview == null) setState(() => _error = error);
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _cancel.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bytes = _full ?? _preview;
+    if (bytes == null) {
+      if (_error != null) {
+        return widget.errorBuilder?.call(context, _error!) ??
+            _defaultError(context, _error!);
+      }
+      return widget.loadingBuilder?.call(context) ?? _defaultLoading(context);
+    }
+    return widget.builder(context, bytes, _full != null);
+  }
+
+  static Widget _defaultLoading(BuildContext context) =>
+      const Center(child: CircularProgressIndicator());
+
+  static Widget _defaultError(BuildContext context, Object error) => Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text('Could not open document: $error',
+              textAlign: TextAlign.center),
+        ),
+      );
+}

--- a/packages/dart_pdf_editor/test/benchmark_phases_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_phases_test.dart
@@ -15,7 +15,6 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/image_decoder.dart';

--- a/packages/dart_pdf_editor/test/benchmark_render_session_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_render_session_test.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 void main() {

--- a/packages/dart_pdf_editor/test/benchmark_render_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_render_test.dart
@@ -21,7 +21,6 @@ import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 import 'render_smoke_test.dart' show loadSystemFonts;

--- a/packages/dart_pdf_editor/test/benchmark_strip_render_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_strip_render_test.dart
@@ -19,7 +19,6 @@ import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 

--- a/packages/dart_pdf_editor/test/benchmark_tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_tile_store_test.dart
@@ -34,7 +34,6 @@ import 'dart:ui' as ui;
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 
 import 'render_smoke_test.dart' show loadSystemFonts;
 

--- a/packages/dart_pdf_editor/test/command_replay_latency_test.dart
+++ b/packages/dart_pdf_editor/test/command_replay_latency_test.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 void main() {

--- a/packages/dart_pdf_editor/test/comparison_test.dart
+++ b/packages/dart_pdf_editor/test/comparison_test.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 import 'render_smoke_test.dart' show loadSystemFonts;

--- a/packages/dart_pdf_editor/test/comparison_view_test.dart
+++ b/packages/dart_pdf_editor/test/comparison_view_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 void main() {

--- a/packages/dart_pdf_editor/test/corpus_render_test.dart
+++ b/packages/dart_pdf_editor/test/corpus_render_test.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 import 'render_smoke_test.dart' show loadSystemFonts;

--- a/packages/dart_pdf_editor/test/dark_mode_test.dart
+++ b/packages/dart_pdf_editor/test/dark_mode_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/dash_pattern_test.dart
+++ b/packages/dart_pdf_editor/test/dash_pattern_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/gestures.dart' show kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/editing_thumbnail_view_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_view_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter/gestures.dart'
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/exact_extent_test.dart
+++ b/packages/dart_pdf_editor/test/exact_extent_test.dart
@@ -10,7 +10,6 @@ import 'dart:typed_data';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/ghent_render_test.dart
+++ b/packages/dart_pdf_editor/test/ghent_render_test.dart
@@ -28,7 +28,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 import 'render_gallery.dart';

--- a/packages/dart_pdf_editor/test/http_byte_source_test.dart
+++ b/packages/dart_pdf_editor/test/http_byte_source_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:pdf_cos/pdf_cos.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 /// A MockClient serving [data]. When [supportRange] is false it answers every

--- a/packages/dart_pdf_editor/test/image_cache_budget_test.dart
+++ b/packages/dart_pdf_editor/test/image_cache_budget_test.dart
@@ -10,7 +10,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 const int _mb = 1024 * 1024;

--- a/packages/dart_pdf_editor/test/inline_image_test.dart
+++ b/packages/dart_pdf_editor/test/inline_image_test.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 Uint8List buildPdf(String content) {

--- a/packages/dart_pdf_editor/test/knockout_group_test.dart
+++ b/packages/dart_pdf_editor/test/knockout_group_test.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/mesh_shading_test.dart
+++ b/packages/dart_pdf_editor/test/mesh_shading_test.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 /// A 100x100 page whose content paints a type 4 mesh: one triangle

--- a/packages/dart_pdf_editor/test/page_color_test.dart
+++ b/packages/dart_pdf_editor/test/page_color_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 Uint8List _assemble(List<String> objects) {

--- a/packages/dart_pdf_editor/test/pdf_scrollbar_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_scrollbar_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/pdfjs_render_test.dart
+++ b/packages/dart_pdf_editor/test/pdfjs_render_test.dart
@@ -18,7 +18,6 @@ import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 import 'render_gallery.dart';

--- a/packages/dart_pdf_editor/test/progressive_source_test.dart
+++ b/packages/dart_pdf_editor/test/progressive_source_test.dart
@@ -1,0 +1,175 @@
+// Widget-level progressive open: PdfReader.source / PdfEditorView.source paint
+// page one from a sparse first-paint open, then swap the full buffer in behind
+// a background read. Also covers the public readSourceFully helper and the
+// PdfProgressiveSourceBuilder it composes.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A range-serving in-memory source that records its reads and can gate them
+/// behind a [Completer], so a test can hold the background full read open while
+/// asserting that the first paint already happened.
+class _RecordingSource implements PdfByteSource {
+  _RecordingSource(this._bytes, {this.reportLength = true});
+
+  final Uint8List _bytes;
+  final bool reportLength;
+  final List<(int, int)> reads = [];
+  int closeCount = 0;
+
+  /// When set, every [readRange] awaits this before answering. Used to freeze
+  /// the background read mid-flight.
+  Completer<void>? gate;
+
+  @override
+  Future<int?> get length async => reportLength ? _bytes.length : null;
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async {
+    reads.add((start, endExclusive));
+    final g = gate;
+    if (g != null) await g.future;
+    final s = start < 0 ? 0 : (start > _bytes.length ? _bytes.length : start);
+    final e = endExclusive < s
+        ? s
+        : (endExclusive > _bytes.length ? _bytes.length : endExclusive);
+    return Uint8List.sublistView(_bytes, s, e);
+  }
+
+  @override
+  Future<void> close() async => closeCount++;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> pump(WidgetTester tester, Widget body) async {
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: body)));
+    await tester.pump();
+  }
+
+  group('readSourceFully', () {
+    test('reassembles the exact file with progress (known length)', () async {
+      final bytes = buildMultiPagePdf(3);
+      final source = _RecordingSource(bytes);
+      final events = <(int, int?)>[];
+      final full = await readSourceFully(source,
+          chunk: 64, onProgress: (r, t) => events.add((r, t)));
+      expect(full, bytes);
+      expect(events.last, (bytes.length, bytes.length));
+    });
+
+    test('reassembles over an unknown-length source', () async {
+      final bytes = buildMultiPagePdf(2);
+      final source = _RecordingSource(bytes, reportLength: false);
+      final full = await readSourceFully(source, chunk: 50);
+      expect(full, bytes);
+    });
+
+    test('a fired cancel token aborts before reading', () async {
+      final source = _RecordingSource(buildMultiPagePdf(2));
+      final token = PdfCancelToken()..cancel();
+      await expectLater(
+        readSourceFully(source, cancelToken: token),
+        throwsA(isA<PdfHttpCancelledException>()),
+      );
+    });
+  });
+
+  group('PdfReader.source', () {
+    testWidgets('paints from first paint before the full read completes',
+        (tester) async {
+      final source = _RecordingSource(buildMultiPagePdf(3));
+      final order = <String>[];
+      await pump(
+        tester,
+        PdfReader.source(
+          source,
+          documentId: 'doc-1',
+          onFirstPaint: () => order.add('first-paint'),
+          onProgress: (received, total) {
+            if (total != null && received == total) order.add('full-done');
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // First paint fired before the background read reached the full length -
+      // ordering proves page one was live before the file finished loading.
+      expect(order, ['first-paint', 'full-done']);
+      // The inner byte-based reader (and its viewer) mounted in place.
+      expect(find.byType(PdfViewer), findsOneWidget);
+      // The host-owned source is never closed by the widget.
+      expect(source.closeCount, 0);
+    });
+
+    testWidgets('shows a loader until the first paint, then the viewer',
+        (tester) async {
+      final source = _RecordingSource(buildMultiPagePdf(2));
+      source.gate = Completer<void>();
+      await pump(
+        tester,
+        PdfReader.source(source, documentId: 'doc-2'),
+      );
+      // Reads are gated: nothing has painted yet.
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(PdfViewer), findsNothing);
+
+      // Release the gate and let the open complete.
+      source.gate!.complete();
+      source.gate = null;
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfViewer), findsOneWidget);
+    });
+
+    testWidgets('cancels the in-flight read on dispose', (tester) async {
+      final source = _RecordingSource(buildMultiPagePdf(2));
+      source.gate = Completer<void>();
+      await pump(tester, PdfReader.source(source, documentId: 'doc-3'));
+      await tester.pump();
+
+      // Dispose while the first read is still gated; disposing must not throw
+      // and the pending read is cancelled cooperatively.
+      await tester.pumpWidget(const MaterialApp(home: Scaffold(body: SizedBox())));
+      source.gate!.complete();
+      await tester.pumpAndSettle();
+      // No exception surfaced from the abandoned load.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('opens an unknown-length source (sequential fallback)',
+        (tester) async {
+      // No length -> openSource can't serve ranges and falls back to a plain
+      // sequential download internally, still yielding a renderable document.
+      // The widget must open and paint it just the same.
+      final source = _RecordingSource(buildMultiPagePdf(2), reportLength: false);
+      await pump(tester, PdfReader.source(source, documentId: 'doc-4'));
+      await tester.pumpAndSettle();
+      expect(find.byType(PdfViewer), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('PdfEditorView.source', () {
+    testWidgets('opens progressively with editing gated until complete',
+        (tester) async {
+      final source = _RecordingSource(buildMultiPagePdf(3));
+      await pump(
+        tester,
+        PdfEditorView.source(source, documentId: 'edit-1'),
+      );
+      await tester.pumpAndSettle();
+      // Full bytes have landed: the editing toolbar is present.
+      expect(find.byType(PdfViewer), findsOneWidget);
+      expect(find.byType(PdfEditingToolbar), findsOneWidget);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/progressive_source_test.dart
+++ b/packages/dart_pdf_editor/test/progressive_source_test.dart
@@ -159,17 +159,105 @@ void main() {
   });
 
   group('PdfEditorView.source', () {
-    testWidgets('opens progressively with editing gated until complete',
+    testWidgets('gates the editing toolbar until the full read completes',
         (tester) async {
       final source = _RecordingSource(buildMultiPagePdf(3));
+      // Freeze the background full read the moment the first paint lands, so we
+      // can observe the gated (preview) state before the swap.
       await pump(
         tester,
-        PdfEditorView.source(source, documentId: 'edit-1'),
+        PdfEditorView.source(
+          source,
+          documentId: 'edit-1',
+          onFirstPaint: () => source.gate = Completer<void>(),
+        ),
       );
-      await tester.pumpAndSettle();
-      // Full bytes have landed: the editing toolbar is present.
+      // First paint is up but the full read is held: page shows, toolbar gated.
+      await tester.pump();
+      await tester.pump();
       expect(find.byType(PdfViewer), findsOneWidget);
+      expect(find.byType(PdfEditingToolbar), findsNothing);
+
+      // Release the full read: the buffer swaps and editing comes alive.
+      source.gate!.complete();
+      source.gate = null;
+      await tester.pumpAndSettle();
       expect(find.byType(PdfEditingToolbar), findsOneWidget);
     });
   });
+
+  group('PdfProgressiveSourceBuilder', () {
+    testWidgets('uses a custom loadingBuilder before any bytes land',
+        (tester) async {
+      final source = _RecordingSource(buildMultiPagePdf(1));
+      source.gate = Completer<void>();
+      await pump(
+        tester,
+        PdfProgressiveSourceBuilder(
+          source: source,
+          loadingBuilder: (_) => const Text('loading-pdf'),
+          builder: (_, __, ___) => const Text('viewer'),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('loading-pdf'), findsOneWidget);
+      source.gate!.complete();
+      source.gate = null;
+      await tester.pumpAndSettle();
+      expect(find.text('viewer'), findsOneWidget);
+    });
+
+    testWidgets('surfaces an errorBuilder when the open fails outright',
+        (tester) async {
+      final source = _ThrowingSource(24);
+      await pump(
+        tester,
+        PdfProgressiveSourceBuilder(
+          source: source,
+          errorBuilder: (_, error) => Text('failed: $error'),
+          builder: (_, __, ___) => const Text('viewer'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('failed:'), findsOneWidget);
+      expect(find.text('viewer'), findsNothing);
+    });
+
+    testWidgets('restarts when the source is swapped', (tester) async {
+      final first = _RecordingSource(buildMultiPagePdf(2));
+      final second = _RecordingSource(buildMultiPagePdf(2));
+      final swaps = <int>[];
+      Widget host(PdfByteSource source) => PdfProgressiveSourceBuilder(
+            source: source,
+            builder: (_, bytes, __) {
+              swaps.add(bytes.length);
+              return const Text('viewer');
+            },
+          );
+      await pump(tester, host(first));
+      await tester.pumpAndSettle();
+      await tester.pumpWidget(MaterialApp(home: Scaffold(body: host(second))));
+      await tester.pumpAndSettle();
+      // Both sources drove the builder; the second one was actually read.
+      expect(second.reads, isNotEmpty);
+      expect(find.text('viewer'), findsOneWidget);
+    });
+  });
+}
+
+/// A source that reports a length but throws on every read, so both the
+/// first-paint open and the background full read fail.
+class _ThrowingSource implements PdfByteSource {
+  _ThrowingSource(this._length);
+  final int _length;
+
+  @override
+  Future<int?> get length async => _length;
+
+  @override
+  Future<Uint8List> readRange(int start, int endExclusive) async =>
+      throw StateError('read failed');
+
+  @override
+  Future<void> close() async {}
 }

--- a/packages/dart_pdf_editor/test/progressive_source_test.dart
+++ b/packages/dart_pdf_editor/test/progressive_source_test.dart
@@ -66,11 +66,15 @@ void main() {
       expect(events.last, (bytes.length, bytes.length));
     });
 
-    test('reassembles over an unknown-length source', () async {
+    test('reassembles over an unknown-length source with progress', () async {
       final bytes = buildMultiPagePdf(2);
       final source = _RecordingSource(bytes, reportLength: false);
-      final full = await readSourceFully(source, chunk: 50);
+      final events = <(int, int?)>[];
+      final full = await readSourceFully(source,
+          chunk: 50, onProgress: (r, t) => events.add((r, t)));
       expect(full, bytes);
+      // Unknown length: total stays null, received climbs to the full size.
+      expect(events.last, (bytes.length, null));
     });
 
     test('a fired cancel token aborts before reading', () async {
@@ -221,6 +225,19 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.textContaining('failed:'), findsOneWidget);
       expect(find.text('viewer'), findsNothing);
+    });
+
+    testWidgets('shows the default error UI when no errorBuilder is given',
+        (tester) async {
+      await pump(
+        tester,
+        PdfProgressiveSourceBuilder(
+          source: _ThrowingSource(24),
+          builder: (_, __, ___) => const Text('viewer'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Could not open document'), findsOneWidget);
     });
 
     testWidgets('restarts when the source is swapped', (tester) async {

--- a/packages/dart_pdf_editor/test/render_hold_test.dart
+++ b/packages/dart_pdf_editor/test/render_hold_test.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/render_seam_test.dart
+++ b/packages/dart_pdf_editor/test/render_seam_test.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/render_smoke_test.dart
+++ b/packages/dart_pdf_editor/test/render_smoke_test.dart
@@ -8,7 +8,6 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/render_trace_gate_test.dart
+++ b/packages/dart_pdf_editor/test/render_trace_gate_test.dart
@@ -19,7 +19,6 @@ import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 /// One micro-corpus entry: a programmatically-built document, the page to

--- a/packages/dart_pdf_editor/test/render_worker_revision_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_revision_test.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
-import 'package:dart_pdf_editor/src/render_worker.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -9,7 +9,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/scroll_indicator_test.dart
+++ b/packages/dart_pdf_editor/test/scroll_indicator_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/search_navigation_test.dart
+++ b/packages/dart_pdf_editor/test/search_navigation_test.dart
@@ -8,7 +8,6 @@ import 'dart:typed_data';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/slug_worker_latency_test.dart
+++ b/packages/dart_pdf_editor/test/slug_worker_latency_test.dart
@@ -13,7 +13,6 @@ import 'dart:io';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 
 void main() {
   final path =

--- a/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
+++ b/packages/dart_pdf_editor/test/spatial_region_corpus_test.dart
@@ -5,7 +5,6 @@ import 'dart:ui' as ui;
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 
 const _fixtures = <String>[
   'rotation.pdf',

--- a/packages/dart_pdf_editor/test/strip_debug_test.dart
+++ b/packages/dart_pdf_editor/test/strip_debug_test.dart
@@ -7,7 +7,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 

--- a/packages/dart_pdf_editor/test/strip_parity_test.dart
+++ b/packages/dart_pdf_editor/test/strip_parity_test.dart
@@ -43,7 +43,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 import 'render_smoke_test.dart' show loadSystemFonts;

--- a/packages/dart_pdf_editor/test/strip_plan_device_test.dart
+++ b/packages/dart_pdf_editor/test/strip_plan_device_test.dart
@@ -19,7 +19,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 import 'strip_zoom_router_test.dart' show buildVectorPdf;

--- a/packages/dart_pdf_editor/test/strip_worker_latency_test.dart
+++ b/packages/dart_pdf_editor/test/strip_worker_latency_test.dart
@@ -42,7 +42,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/raster.dart' as raster show decodeStripPlanMicros;
 
 import 'render_smoke_test.dart' show loadSystemFonts;

--- a/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
+++ b/packages/dart_pdf_editor/test/strip_zoom_router_test.dart
@@ -23,7 +23,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 /// A one-page classic-xref PDF with solid vector content (fills + a

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -5,7 +5,6 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 void main() {

--- a/packages/dart_pdf_editor/test/transparency_group_test.dart
+++ b/packages/dart_pdf_editor/test/transparency_group_test.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 

--- a/packages/dart_pdf_editor/test/vector_print_ui_test.dart
+++ b/packages/dart_pdf_editor/test/vector_print_ui_test.dart
@@ -6,7 +6,6 @@ import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 /// Builds a one-page PDF whose content is [content], with optional image and

--- a/packages/dart_pdf_editor/test/viewport_test.dart
+++ b/packages/dart_pdf_editor/test/viewport_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/web_slug_fallback_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_fallback_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';

--- a/packages/dart_pdf_editor/test/web_slug_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_page_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';

--- a/packages/dart_pdf_editor/test/wheel_scroll_test.dart
+++ b/packages/dart_pdf_editor/test/wheel_scroll_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/dart_pdf_editor/test/zoom_latency_test.dart
+++ b/packages/dart_pdf_editor/test/zoom_latency_test.dart
@@ -42,7 +42,6 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/strips.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'render_smoke_test.dart' show loadSystemFonts;


### PR DESCRIPTION
## Summary

Progressive open (#359, #328) worked end-to-end inside the standalone app, but the capability was not reachable through the published `dart_pdf_editor` public API — a host depending only on `dart_pdf_editor` (e.g. Trax's PDF viewer) still had to read the whole file before the first page painted, and had to lean on undocumented internals (`doc.cos.bytes` as a renderable sparse buffer).

This packages the progressive orchestration into the reusable widgets and exports the supporting surface:

- **`PdfProgressiveSourceBuilder`** (new, `src/progressive_source.dart`, exported): the reusable orchestration. Opens a sparse first-paint document from a `PdfByteSource`'s ranges (`PdfDocument.openSource(..., firstPaintPages: 1)`), paints page one, reads the rest in the background with `readSourceFully` (progress + cancellation), then swaps the full buffer in place. Falls back to a plain full read when the first paint can't be assembled; cancels the in-flight load on dispose; never closes the host-owned source.
- **`PdfReader.source(...)` / `PdfEditorView.source(...)`** (new named constructors): thin composition over the builder around the existing byte-based widgets, so the first-paint→full swap reopens in place and (with a stable `documentId`) keeps scroll/zoom. `PdfEditorView.source` gates editing (toolbar, page editing, markup, undo/redo, save callbacks) until the full file lands — the first-paint buffer is deliberately incomplete.
- **`readSourceFully`** moved out of `app/lib/file_io.dart` into the library (same signature) and exported; the app now consumes the library copy.
- **`PdfDocument`** (and thus `openSource`) exported from `dart_pdf_editor`, so a host can open a source into a document without a direct `pdf_document` dependency.

Host-specific sources (a `dart:io` file source, Trax's Firebase-Storage source) stay in the host, as the issue scopes. The app's multi-tab `DocumentTab.preview` orchestration is untouched.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (`--fatal-infos`, whole workspace — clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (new `progressive_source_test.dart` + shell/http/render regression tests)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

The moved `readSourceFully` was also re-verified via the app's existing `pdf_file_source_test.dart` / `pdf_mobile_source_test.dart`.

## PDF fixtures and screenshots

No new fixtures — the widget test drives programmatic multi-page fixtures through a range-serving in-memory `PdfByteSource`.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Exporting `PdfDocument` from the `dart_pdf_editor` barrel turned ~55 `import 'package:pdf_document/...'` lines across the package/app tests + examples into `unnecessary_import` infos (CI runs `dart analyze --fatal-infos`). Each flagged line was removed — safe because the barrel re-exports the same symbols. This accounts for most of the diff's line count; the substantive change is in `progressive_source.dart`, `pdf_reader.dart`, `pdf_editor_view.dart`, `dart_pdf_editor.dart`, and `app/lib/file_io.dart`.
- The widget's "fall back to a plain full read" branch is defensive: `PdfDocument.openSource` already falls back to a full sequential download internally for an unknown-length / non-ranged source and still returns a renderable doc, so first paint fires there too. The widget's `preview == null` path only triggers when `openSource` throws outright.
- Bare `PdfViewer` (which takes a `PdfDocument`, not bytes, and owns no shell/worker lifecycle) is intentionally left as-is; a host wraps it with `PdfProgressiveSourceBuilder` + `PdfDocument.open` directly.
- See `doc/dev-log/2026-07-19-progressive-open-viewer-widgets.md` for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4qXwk5JtJCuVM68SyPCV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4qXwk5JtJCuVM68SyPCV3)_