### PR TITLE
Reflow reading view: lazy scrolling, navigation, saved position, figure viewer

### DIFF
--- a/doc/dev-log/2026-07-19-reflow-scrolling-and-figures.md
+++ b/doc/dev-log/2026-07-19-reflow-scrolling-and-figures.md
@@ -1,0 +1,103 @@
+# Reflow reading view: lazy scrolling, navigation, saved position, figure viewer
+
+Reworked the text reflow reading view (`PdfReflowView`,
+`dart_pdf_editor/src/pdf_reflow_view.dart`) so it holds up on large books,
+and wired it into the shell chrome as a first-class reading mode. Five
+strands, all triggered by "scrolling a 600-page book in reflow is
+horrifically slow, the panels don't work there, and mobile can't reach
+it".
+
+## 1. Lazy layout (the actual perf fix)
+
+The old view walked **every** page's content stream up front in `_load`
+(`PdfTextExtractor.reflowPage` × pageCount), pre-decoded **every** image
+in the book, then laid every page out non-lazily in a
+`SingleChildScrollView` + `Column` (a deliberate choice for exact scroll
+extent - see the removed comment). On a 600-page book that is tens of
+thousands of `SelectableText`s built and laid out at once, plus the whole
+book's decoded pixels resident - so scrolling crawled.
+
+Now:
+
+- **Lazy widgets**: a plain `ListView.builder`, so only the pages near the
+  viewport build. Scroll extent is estimated (it wobbles slightly as
+  mixed-height pages enter/leave the build window) - the accepted trade
+  for not freezing. `ExactExtentListView` is *not* usable here: it needs
+  each item's extent up front, but a reflow page's height depends on text
+  wrap and image aspect, unknown without laying it out.
+- **Lazy reflow**: `_pageAt(i)` extracts + caches per page on demand.
+- **Lazy images**: each page item (`_ReflowPageItem`) decodes its own
+  figures when it scrolls into the build window and disposes the decoded
+  clones when it scrolls out - only the visible pages hold pixels.
+- **Empty-state without a full pass**: `_probeContent` scans for the first
+  non-empty page and stops (a real doc resolves on page 0), so the "No
+  extractable content" message stays correct without walking all pages.
+
+`_settle` in the test now pumps a few extra frames after the spinner
+clears, because image decode is per-item async now, not part of `_load`.
+
+## 2. Navigation panels work in reflow
+
+The panels were gated off whenever `altView` (reflow **or** page grid) was
+active. The nav panels (Pages, Bookmarks) now stay available in reflow;
+only the full-area page grid still hides them, and the canvas-bound panels
+(search results, annotations, properties) still yield since they have no
+page to act on.
+
+To make them actually drive the reading view without a mounted
+`PdfViewer`, `PdfViewerController` gained an **additive** reflow backend
+(`PdfReflowBackend` in `pdf_viewer.dart`). A mounted viewer (`_state`)
+always wins; the controller only consults `_reflow` when there is no page
+canvas. `jumpToPage`/`animateToPage`/`showDestination`/`captureViewport`/
+`restoreViewport`/`visiblePageRegion` fall through to it, and the reflow
+view reports `currentPage`/`pageCount`/`viewportChanges` back. So the
+thumbnail strip (taps + current-page highlight + viewport indicator) and
+bookmarks navigate the reading view for free. Gotcha fixed along the way:
+the deferred-notify guards in `_bumpViewport`/`_notifySafely` checked
+`_state != null` and would drop notifications in reflow - now
+`_state != null || _reflow != null`.
+
+Jump-to-page in a lazy list (no `scrollable_positioned_list` dep): estimate
+the offset from the average built-item extent, `jumpTo`, then align
+precisely via the target item's `GlobalKey` once the frame builds it
+(`_correctTo`, a few retries). Approximate for far jumps but converges for
+the fairly uniform pages of a book.
+
+## 3. Saved reading position
+
+Reflow implements `captureViewport`/`restoreViewport` as `PdfViewport`
+{page, fraction-into-page}, so the shells' existing `PdfViewportMemory`
+persists and restores the reading position per document with **zero** new
+plumbing. **Gotcha that cost the most time**: `reflowRestoreViewport`
+first only did `addPostFrameCallback` - which never fires on its own if
+nothing scheduled a frame, so the restore ran at teardown
+(`mounted=false`). `jumpToPage` worked because its synchronous
+`_scroll.jumpTo` schedules the frame. Fix: apply the restore eagerly when
+the list has clients (the jump schedules the frame the corrections ride
+on), and `scheduleFrame()` when we must defer for first layout.
+
+## 4. Mobile bottom-sheet reflow toggle
+
+Reflow was reachable on phones only via Controls → Settings → Reflow text.
+Added a one-tap `pdf-shell-reflow-toggle` tile to the compact Controls
+sheet in both shells (`PdfEditorView`, `PdfReader`) - it mirrors the
+Settings toggle (turning reflow on clears the page grid in the editor).
+
+## 5. Tap a figure → fullscreen viewer
+
+Tapping a decoded figure in reflow opens a fullscreen
+`_FullscreenReflowImage`: dark backdrop, `InteractiveViewer` (pan +
+pinch/scroll zoom), close, and - when a host `onShareImage` handler is
+supplied - a save/share action that renders the figure to PNG. The route
+holds its **own clone** of the `ui.Image`, so it survives the source page
+scrolling out and disposing its decode. Threaded as
+`PdfReflowView.onShareImage` → `PdfEditorView.onShareReflowImage` /
+`PdfReader.onShareReflowImage`; the example app wires it to its existing
+`_saveImageBytes` (share sheet on phones, save dialog on desktop, download
+on web). No handler → fullscreen view still works, just no share action.
+
+Tests: `test/pdf_reflow_view_test.dart` (lazy build, controller
+jump+track, capture/restore, fullscreen tap+share, share-absent) and an
+updated `pdf_shell_test.dart` reflow expectation (the Pages strip now stays
+in reflow). The old "scroll extent stays stable" test is gone - exact
+extent was the very thing making it slow.

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -1429,6 +1429,9 @@ class _ViewerScreenState extends State<ViewerScreen> {
                                 imagePicker: _pickImage,
                                 fontPicker: _pickFont,
                                 onSnapshot: _saveSnapshot,
+                                onShareReflowImage: (context, png) =>
+                                    _saveImageBytes(
+                                        png, 'figure.png', 'image/png'),
                               ),
       ),
     );

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -232,6 +232,7 @@ class PdfEditorView extends StatefulWidget {
     this.fontPicker,
     this.onSnapshot,
     this.onPlaceSignature,
+    this.onShareReflowImage,
     this.textPrompt,
     this.styledTextPrompt,
     this.palette = PdfEditingToolbar.defaultPalette,
@@ -380,6 +381,11 @@ class PdfEditorView extends StatefulWidget {
 
   /// See [PdfViewer.onPlaceSignature].
   final PdfSignaturePlacer? onPlaceSignature;
+
+  /// Saves or shares a figure the reader taps to open fullscreen in the text
+  /// reflow view (see [PdfReflowView.onShareImage]). Null still allows
+  /// fullscreen pan/pinch-zoom viewing; it just hides the share action.
+  final PdfReflowImageShareHandler? onShareReflowImage;
 
   /// How dialog-based tools ask for text. Defaults to
   /// [showPdfTextPrompt], a Material dialog.
@@ -720,14 +726,19 @@ class _PdfEditorViewState extends State<PdfEditorView> {
           final reflowActive =
               features.reflowView && prefs.showReflowView && !gridActive;
           final altView = reflowActive || gridActive;
+          // The navigational panels (Pages, Bookmarks) drive the reflow view
+          // through the shared controller, so they stay available while
+          // reading; only the full-area page grid hides them. The canvas-bound
+          // panels (search results, annotations, properties) have no page to
+          // act on in reflow, so they still yield to [altView].
           final showThumbnailsPanel =
-              features.thumbnails && showThumbnails && !altView;
+              features.thumbnails && showThumbnails && !gridActive;
           final showSearchPanel = features.search &&
               features.searchResultsPanel &&
               prefs.showSearchResultsPanel &&
               !altView;
           final showBookmarksPanel =
-              features.bookmarks && prefs.showBookmarkSidebar && !altView;
+              features.bookmarks && prefs.showBookmarkSidebar && !gridActive;
           final showAnnotationsPanel = features.annotationSidebar &&
               prefs.showAnnotationSidebar &&
               !altView;
@@ -938,6 +949,20 @@ class _PdfEditorViewState extends State<PdfEditorView> {
               );
             },
           );
+          // A one-tap Reflow toggle for the compact Controls sheet - reading
+          // reflow is something phone users reach for often, so it earns a
+          // direct tile instead of living only inside Settings. Mirrors the
+          // Settings toggle: turning reflow on clears the page grid.
+          final reflowControl = PdfShellControlItem(
+            key: const ValueKey('pdf-shell-reflow-toggle'),
+            icon: Icons.article_outlined,
+            label: 'Reflow',
+            selected: reflowActive,
+            onPressed: () {
+              prefs.showThumbnailView = false;
+              prefs.showReflowView = !prefs.showReflowView;
+            },
+          );
           final panelItems = [
             if (features.searchResultsPanel)
               PdfShellPanelItem(
@@ -1058,6 +1083,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 ],
                 compactControls: [
                   if (features.viewOptions) viewOptionsControl,
+                  if (features.reflowView) reflowControl,
                   for (final item in panelItems)
                     PdfShellControlItem(
                       key: item.key,
@@ -1085,6 +1111,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 viewer: reflowActive
                     ? PdfReflowView(
                         document: session.document,
+                        controller: _viewer,
+                        onShareImage: widget.onShareReflowImage,
                         backgroundColor: widget.backgroundColor,
                       )
                     : PdfViewer(

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -309,6 +309,7 @@ class PdfEditorView extends StatefulWidget {
     this.fontPicker,
     this.onSnapshot,
     this.onPlaceSignature,
+    this.onShareReflowImage,
     this.textPrompt,
     this.styledTextPrompt,
     this.palette = PdfEditingToolbar.defaultPalette,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -171,6 +171,7 @@ class PdfReader extends StatefulWidget {
     this.onAction,
     this.onAnnotationTap,
     this.onLaunchUrl,
+    this.onShareReflowImage,
     this.pageOverlayBuilder,
     this.pageLayout = const PdfPageLayout.verticalContinuous(),
     this.initialFit = PdfViewerFit.page,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -112,6 +112,7 @@ class PdfReader extends StatefulWidget {
     this.onAction,
     this.onAnnotationTap,
     this.onLaunchUrl,
+    this.onShareReflowImage,
     this.pageOverlayBuilder,
     this.pageLayout = const PdfPageLayout.verticalContinuous(),
     this.initialFit = PdfViewerFit.page,
@@ -165,6 +166,11 @@ class PdfReader extends StatefulWidget {
 
   /// See [PdfViewer.onLaunchUrl].
   final PdfUrlLauncher? onLaunchUrl;
+
+  /// Saves or shares a figure the reader taps to open fullscreen in the text
+  /// reflow view (see [PdfReflowView.onShareImage]). Null still allows
+  /// fullscreen pan/pinch-zoom viewing; it just hides the share action.
+  final PdfReflowImageShareHandler? onShareReflowImage;
 
   /// See [PdfViewer.pageOverlayBuilder].
   final PdfPageOverlayBuilder? pageOverlayBuilder;
@@ -247,11 +253,12 @@ class _PdfReaderState extends State<PdfReader> {
           // on a narrow screen the strip floats up from the bottom as a
           // sheet instead of docking to the side and crowding the page
           final useSheets = pdfShellUseBottomSheets(constraints);
-          final showThumbnailsPanel =
-              features.thumbnails && showThumbnails && !prefs.showReflowView;
-          final showBookmarksPanel = features.bookmarks &&
-              prefs.showBookmarkSidebar &&
-              !prefs.showReflowView;
+          // Pages and Bookmarks stay available in the reflow reading view -
+          // they drive it through the shared controller (page taps scroll the
+          // reader, the strip tracks the reading position).
+          final showThumbnailsPanel = features.thumbnails && showThumbnails;
+          final showBookmarksPanel =
+              features.bookmarks && prefs.showBookmarkSidebar;
 
           // Distinct keys for docked vs sheet so the strip is remounted, not
           // reparented, when the breakpoint flips - reparenting reactivates
@@ -364,6 +371,16 @@ class _PdfReaderState extends State<PdfReader> {
                         );
                       },
                     ),
+                  // A direct Reflow toggle for phone readers, who reach for the
+                  // reading view most - no need to dig into Settings.
+                  PdfShellControlItem(
+                    key: const ValueKey('pdf-shell-reflow-toggle'),
+                    icon: Icons.article_outlined,
+                    label: 'Reflow',
+                    selected: prefs.showReflowView,
+                    onPressed: () =>
+                        prefs.showReflowView = !prefs.showReflowView,
+                  ),
                   if (features.thumbnails)
                     PdfShellControlItem(
                       key: const ValueKey('pdf-shell-thumbnails-toggle'),
@@ -400,6 +417,8 @@ class _PdfReaderState extends State<PdfReader> {
                   builder: (context, _) => prefs.showReflowView
                       ? PdfReflowView(
                           document: _session.document,
+                          controller: _viewer,
+                          onShareImage: widget.onShareReflowImage,
                           backgroundColor: widget.backgroundColor,
                         )
                       : PdfViewer(

--- a/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
@@ -93,6 +93,30 @@ class _PdfReflowViewState extends State<PdfReflowView>
   /// A page to jump to once the list has laid out (a tap before first layout).
   int? _pendingJump;
 
+  /// Running average height of resolved page items, used to size the
+  /// placeholders of not-yet-resolved pages and to estimate jump offsets. A
+  /// placeholder that matches its eventual height keeps the list from
+  /// reflowing (and the scroll from drifting) as pages resolve.
+  double _resolvedExtentSum = 0;
+  int _resolvedExtentCount = 0;
+
+  double get _typicalExtent => _resolvedExtentCount == 0
+      ? 360.0
+      : _resolvedExtentSum / _resolvedExtentCount;
+
+  void _noteResolvedExtent(double extent) {
+    if (extent <= 0) return;
+    _resolvedExtentSum += extent;
+    _resolvedExtentCount++;
+  }
+
+  /// The page a jump is currently settling on. Because pages resolve their
+  /// text asynchronously (so a heavy page can't freeze the UI), items above
+  /// the target grow from placeholder to full height and push it around; the
+  /// jump keeps re-pinning this page to the top across a few frames until the
+  /// neighbourhood settles. A newer jump supersedes it.
+  int? _jumpTarget;
+
   @override
   void initState() {
     super.initState();
@@ -112,8 +136,11 @@ class _PdfReflowViewState extends State<PdfReflowView>
         widget.showImages != oldWidget.showImages) {
       _reflowed.clear();
       _itemKeys.clear();
+      _resolvedExtentSum = 0;
+      _resolvedExtentCount = 0;
       _pendingRestore = null;
       _pendingJump = null;
+      _jumpTarget = null;
       _hasContent = _probeContent();
       widget.controller?.reflowReportPageCount(widget.document.pageCount);
       if (_scroll.hasClients) _scroll.jumpTo(0);
@@ -143,14 +170,15 @@ class _PdfReflowViewState extends State<PdfReflowView>
       widget.showImages ? page.items.isEmpty : page.blocks.isEmpty;
 
   Future<bool> _probeContent() async {
-    // Give the first frame a chance to show progress; then scan for the first
-    // page with content, caching what it reflows so those pages don't reflow
-    // twice. A real document resolves on page 0.
+    // Only the first page gates the reading view - a single (cached) reflow.
+    // A multi-page document opens even when page 0 is blank (front matter),
+    // so we never reflow a run of heavy pages up front just to decide whether
+    // to show the "no content" message; per-page items take it from here.
     await Future<void>.delayed(Duration.zero);
-    for (var i = 0; i < widget.document.pageCount; i++) {
-      if (!_isEmpty(_pageAt(i))) return true;
-    }
-    return false;
+    final pageCount = widget.document.pageCount;
+    if (pageCount == 0) return false;
+    if (!_isEmpty(_pageAt(0))) return true;
+    return pageCount > 1;
   }
 
   GlobalKey _keyFor(int index) =>
@@ -210,20 +238,6 @@ class _PdfReflowViewState extends State<PdfReflowView>
     widget.controller?.reflowReportPage(page);
   }
 
-  double _averageExtent() {
-    var sum = 0.0;
-    var n = 0;
-    for (final index in _itemKeys.keys) {
-      final box =
-          _keyFor(index).currentContext?.findRenderObject() as RenderBox?;
-      if (box == null || !box.attached) continue;
-      sum += box.size.height;
-      n++;
-    }
-    // A sensible default before anything is measured (a text page is roughly
-    // this tall at the default width); ensureVisible corrects any estimate.
-    return n == 0 ? 640.0 : sum / n;
-  }
 
   // --- PdfReflowBackend ------------------------------------------------------
 
@@ -236,16 +250,31 @@ class _PdfReflowViewState extends State<PdfReflowView>
       _pendingJump = index;
       return;
     }
-    // Already built: align it precisely. Otherwise estimate, jump, and correct
-    // after the frame builds the target into view.
-    if (_alignTop(index)) {
-      widget.controller?.reflowReportPage(index);
+    _jumpTarget = index;
+    _pinToTarget(framesLeft: 16);
+  }
+
+  /// Aligns [_jumpTarget]'s top to the viewport top, then repeats over the
+  /// next several frames so the target stays put as nearby pages finish
+  /// resolving (and growing from their placeholders). Estimates the offset for
+  /// a target that is not built yet, to bring it into the build window.
+  void _pinToTarget({required int framesLeft}) {
+    final index = _jumpTarget;
+    if (index == null || !mounted || !_scroll.hasClients) return;
+    if (!_alignTop(index)) {
+      final estimate = widget.padding.resolve(TextDirection.ltr).top +
+          _typicalExtent * index;
+      _scroll.jumpTo(estimate.clamp(0.0, _scroll.position.maxScrollExtent));
+    }
+    widget.controller?.reflowReportPage(index);
+    if (framesLeft <= 0) {
+      _jumpTarget = null;
       return;
     }
-    final estimate = widget.padding.resolve(TextDirection.ltr).top +
-        _averageExtent() * index;
-    _scroll.jumpTo(estimate.clamp(0.0, _scroll.position.maxScrollExtent));
-    _correctTo(index, triesLeft: 4);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_jumpTarget != index) return; // superseded by a newer jump
+      _pinToTarget(framesLeft: framesLeft - 1);
+    });
   }
 
   /// Jumps so item [index]'s top aligns with the viewport top; returns false
@@ -257,21 +286,6 @@ class _PdfReflowViewState extends State<PdfReflowView>
         .clamp(0.0, _scroll.position.maxScrollExtent);
     _scroll.jumpTo(target);
     return true;
-  }
-
-  void _correctTo(int index, {required int triesLeft}) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_scroll.hasClients) return;
-      if (_alignTop(index)) {
-        widget.controller?.reflowReportPage(index);
-      } else if (triesLeft > 0) {
-        // Re-estimate from the pages that did build and try again.
-        final estimate = widget.padding.resolve(TextDirection.ltr).top +
-            _averageExtent() * index;
-        _scroll.jumpTo(estimate.clamp(0.0, _scroll.position.maxScrollExtent));
-        _correctTo(index, triesLeft: triesLeft - 1);
-      }
-    });
   }
 
   @override
@@ -308,18 +322,10 @@ class _PdfReflowViewState extends State<PdfReflowView>
       return;
     }
     _pendingRestore = null;
+    // Restore to the saved page (the pin loop settles it at the top). Page
+    // granularity is enough to reopen where the reader left off; chasing the
+    // exact sub-page fraction would fight the pin as pages resolve.
     reflowJumpToPage(viewport.page);
-    if (viewport.top == 0) return;
-    // After the page aligns to the top, nudge down by the saved fraction.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_scroll.hasClients) return;
-      final box = _keyFor(viewport.page).currentContext?.findRenderObject()
-          as RenderBox?;
-      if (box == null || box.size.height <= 0) return;
-      final target = (_scroll.position.pixels + viewport.top * box.size.height)
-          .clamp(0.0, _scroll.position.maxScrollExtent);
-      _scroll.jumpTo(target);
-    });
   }
 
   @override
@@ -386,8 +392,11 @@ class _PdfReflowViewState extends State<PdfReflowView>
                     child: RepaintBoundary(
                       child: _ReflowPageItem(
                         key: _keyFor(index),
+                        pageIndex: index,
                         document: widget.document,
-                        page: _pageAt(index),
+                        resolvePage: () => _pageAt(index),
+                        placeholderExtent: () => _typicalExtent,
+                        onResolvedExtent: _noteResolvedExtent,
                         showImages: widget.showImages,
                         onShareImage: widget.onShareImage,
                       ),
@@ -403,20 +412,41 @@ class _PdfReflowViewState extends State<PdfReflowView>
   }
 }
 
-/// One page of the reading view. Decodes its own images lazily when it scrolls
-/// into the build window, and disposes the decoded clones when it scrolls back
-/// out - so only the pages near the viewport hold decoded pixels.
+/// One page of the reading view. Extracts its reflow and decodes its images
+/// lazily - and *off* the layout pass: the page text is resolved on a
+/// microtask after the frame, not synchronously in the item builder, so
+/// scrolling a run of heavy pages into view never blocks the UI thread for
+/// their combined extraction cost. A short placeholder holds the slot until
+/// the text is ready; decoded image clones are disposed when the page scrolls
+/// out, so only the pages near the viewport hold pixels.
 class _ReflowPageItem extends StatefulWidget {
   const _ReflowPageItem({
     super.key,
+    required this.pageIndex,
     required this.document,
-    required this.page,
+    required this.resolvePage,
+    required this.placeholderExtent,
+    required this.onResolvedExtent,
     required this.showImages,
     this.onShareImage,
   });
 
+  final int pageIndex;
   final PdfDocument document;
-  final PdfReflowPage page;
+
+  /// Extracts (or returns the cached) reflow for this page. Called off the
+  /// build/layout pass so its cost never janks a frame.
+  final PdfReflowPage Function() resolvePage;
+
+  /// The height to give this page's placeholder before it resolves - the
+  /// running typical page height, so the slot barely changes size when the
+  /// real content lands (no scroll drift).
+  final double Function() placeholderExtent;
+
+  /// Reports this page's laid-out height once resolved, feeding
+  /// [placeholderExtent] for the pages still to come.
+  final void Function(double extent) onResolvedExtent;
+
   final bool showImages;
   final PdfReflowImageShareHandler? onShareImage;
 
@@ -425,20 +455,26 @@ class _ReflowPageItem extends StatefulWidget {
 }
 
 class _ReflowPageItemState extends State<_ReflowPageItem> {
+  /// The resolved reflow, or null while it is still being extracted.
+  PdfReflowPage? _page;
+
   /// Decoded images keyed by [pdfImageKey]; the clones are ours to dispose.
   Map<Object, ui.Image> _images = const {};
 
   @override
   void initState() {
     super.initState();
-    _decode();
+    _resolve();
   }
 
   @override
   void didUpdateWidget(_ReflowPageItem oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(widget.page, oldWidget.page) ||
-        widget.showImages != oldWidget.showImages) {
+    if (widget.pageIndex != oldWidget.pageIndex ||
+        !identical(widget.document, oldWidget.document)) {
+      _page = null;
+      _resolve();
+    } else if (widget.showImages != oldWidget.showImages) {
       _decode();
     }
   }
@@ -456,12 +492,32 @@ class _ReflowPageItemState extends State<_ReflowPageItem> {
     _images = const {};
   }
 
+  /// Extracts the page reflow after yielding, so the frame that mounted this
+  /// item completes first (one heavy page can't stall layout, and a viewport
+  /// full of them extract one after another with the UI live between).
+  Future<void> _resolve() async {
+    await Future<void>.delayed(Duration.zero);
+    if (!mounted) return;
+    final page = widget.resolvePage();
+    if (!mounted) return;
+    setState(() => _page = page);
+    _decode();
+    // Feed the laid-out height back so later pages' placeholders match.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final height = context.size?.height;
+      if (height != null) widget.onResolvedExtent(height);
+    });
+  }
+
   Future<void> _decode() async {
+    final page = _page;
+    if (page == null) return;
     if (!widget.showImages) {
       if (_images.isNotEmpty) setState(_disposeImages);
       return;
     }
-    final requests = [for (final image in widget.page.images) image.request];
+    final requests = [for (final image in page.images) image.request];
     if (requests.isEmpty) {
       if (_images.isNotEmpty) setState(_disposeImages);
       return;
@@ -495,12 +551,29 @@ class _ReflowPageItemState extends State<_ReflowPageItem> {
   }
 
   @override
-  Widget build(BuildContext context) => _ReflowPage(
-        page: widget.page,
-        images: _images,
-        showImages: widget.showImages,
-        onTapImage: _openImage,
+  Widget build(BuildContext context) {
+    final page = _page;
+    if (page == null) {
+      // A placeholder sized to the typical page holds the slot (and gives the
+      // list a stable extent) until this page's text is extracted.
+      return SizedBox(
+        height: widget.placeholderExtent(),
+        child: const Center(
+          child: SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ),
       );
+    }
+    return _ReflowPage(
+      page: page,
+      images: _images,
+      showImages: widget.showImages,
+      onTapImage: _openImage,
+    );
+  }
 }
 
 class _ReflowPage extends StatelessWidget {
@@ -682,10 +755,13 @@ class _FullscreenReflowImageState extends State<_FullscreenReflowImage> {
       body: Stack(
         children: [
           Positioned.fill(
+            // SizedBox.expand gives RawImage tight viewport constraints, so
+            // BoxFit.contain scales the figure to fit and centres it (a bare
+            // RawImage would sit top-left at its intrinsic pixel size).
             child: InteractiveViewer(
               minScale: 0.5,
               maxScale: 8,
-              child: Center(
+              child: SizedBox.expand(
                 child: RawImage(
                   image: widget.image,
                   fit: BoxFit.contain,

--- a/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
@@ -93,30 +93,6 @@ class _PdfReflowViewState extends State<PdfReflowView>
   /// A page to jump to once the list has laid out (a tap before first layout).
   int? _pendingJump;
 
-  /// Running average height of resolved page items, used to size the
-  /// placeholders of not-yet-resolved pages and to estimate jump offsets. A
-  /// placeholder that matches its eventual height keeps the list from
-  /// reflowing (and the scroll from drifting) as pages resolve.
-  double _resolvedExtentSum = 0;
-  int _resolvedExtentCount = 0;
-
-  double get _typicalExtent => _resolvedExtentCount == 0
-      ? 360.0
-      : _resolvedExtentSum / _resolvedExtentCount;
-
-  void _noteResolvedExtent(double extent) {
-    if (extent <= 0) return;
-    _resolvedExtentSum += extent;
-    _resolvedExtentCount++;
-  }
-
-  /// The page a jump is currently settling on. Because pages resolve their
-  /// text asynchronously (so a heavy page can't freeze the UI), items above
-  /// the target grow from placeholder to full height and push it around; the
-  /// jump keeps re-pinning this page to the top across a few frames until the
-  /// neighbourhood settles. A newer jump supersedes it.
-  int? _jumpTarget;
-
   @override
   void initState() {
     super.initState();
@@ -136,11 +112,8 @@ class _PdfReflowViewState extends State<PdfReflowView>
         widget.showImages != oldWidget.showImages) {
       _reflowed.clear();
       _itemKeys.clear();
-      _resolvedExtentSum = 0;
-      _resolvedExtentCount = 0;
       _pendingRestore = null;
       _pendingJump = null;
-      _jumpTarget = null;
       _hasContent = _probeContent();
       widget.controller?.reflowReportPageCount(widget.document.pageCount);
       if (_scroll.hasClients) _scroll.jumpTo(0);
@@ -250,31 +223,50 @@ class _PdfReflowViewState extends State<PdfReflowView>
       _pendingJump = index;
       return;
     }
-    _jumpTarget = index;
-    _pinToTarget(framesLeft: 16);
-  }
-
-  /// Aligns [_jumpTarget]'s top to the viewport top, then repeats over the
-  /// next several frames so the target stays put as nearby pages finish
-  /// resolving (and growing from their placeholders). Estimates the offset for
-  /// a target that is not built yet, to bring it into the build window.
-  void _pinToTarget({required int framesLeft}) {
-    final index = _jumpTarget;
-    if (index == null || !mounted || !_scroll.hasClients) return;
-    if (!_alignTop(index)) {
-      final estimate = widget.padding.resolve(TextDirection.ltr).top +
-          _typicalExtent * index;
-      _scroll.jumpTo(estimate.clamp(0.0, _scroll.position.maxScrollExtent));
-    }
-    widget.controller?.reflowReportPage(index);
-    if (framesLeft <= 0) {
-      _jumpTarget = null;
+    // Already built: align it precisely. Otherwise estimate from the average
+    // built-item height, jump, and correct once the frame builds the target
+    // into view. Page heights are final on build (text extracts synchronously),
+    // so the estimate is stable and a couple of corrections converge.
+    if (_alignTop(index)) {
+      widget.controller?.reflowReportPage(index);
       return;
     }
+    _scroll.jumpTo(_estimateOffset(index));
+    _correctTo(index, triesLeft: 4);
+  }
+
+  double _estimateOffset(int index) {
+    final offset = widget.padding.resolve(TextDirection.ltr).top +
+        _averageExtent() * index;
+    return offset.clamp(0.0, _scroll.position.maxScrollExtent);
+  }
+
+  void _correctTo(int index, {required int triesLeft}) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_jumpTarget != index) return; // superseded by a newer jump
-      _pinToTarget(framesLeft: framesLeft - 1);
+      if (!mounted || !_scroll.hasClients) return;
+      if (_alignTop(index)) {
+        widget.controller?.reflowReportPage(index);
+      } else if (triesLeft > 0) {
+        _scroll.jumpTo(_estimateOffset(index));
+        _correctTo(index, triesLeft: triesLeft - 1);
+      }
     });
+  }
+
+  /// Average height of the currently built page items - the estimate for
+  /// pages not yet laid out. Text extracts synchronously so these heights are
+  /// final, not placeholders.
+  double _averageExtent() {
+    var sum = 0.0;
+    var n = 0;
+    for (final index in _itemKeys.keys) {
+      final box =
+          _keyFor(index).currentContext?.findRenderObject() as RenderBox?;
+      if (box == null || !box.attached) continue;
+      sum += box.size.height;
+      n++;
+    }
+    return n == 0 ? 640.0 : sum / n;
   }
 
   /// Jumps so item [index]'s top aligns with the viewport top; returns false
@@ -392,11 +384,8 @@ class _PdfReflowViewState extends State<PdfReflowView>
                     child: RepaintBoundary(
                       child: _ReflowPageItem(
                         key: _keyFor(index),
-                        pageIndex: index,
                         document: widget.document,
-                        resolvePage: () => _pageAt(index),
-                        placeholderExtent: () => _typicalExtent,
-                        onResolvedExtent: _noteResolvedExtent,
+                        page: _pageAt(index),
                         showImages: widget.showImages,
                         onShareImage: widget.onShareImage,
                       ),
@@ -412,41 +401,24 @@ class _PdfReflowViewState extends State<PdfReflowView>
   }
 }
 
-/// One page of the reading view. Extracts its reflow and decodes its images
-/// lazily - and *off* the layout pass: the page text is resolved on a
-/// microtask after the frame, not synchronously in the item builder, so
-/// scrolling a run of heavy pages into view never blocks the UI thread for
-/// their combined extraction cost. A short placeholder holds the slot until
-/// the text is ready; decoded image clones are disposed when the page scrolls
-/// out, so only the pages near the viewport hold pixels.
+/// One page of the reading view. The page's text is laid out from the
+/// [page] reflow synchronously, so the item's height is final the moment it
+/// builds - the list never resizes a laid-out page under the viewport, which
+/// is what would make the scroll jump. Images decode lazily (their slot keeps
+/// a fixed aspect-ratio box either way, so that stays height-stable) and their
+/// clones are disposed when the page scrolls out, so only the pages near the
+/// viewport hold pixels.
 class _ReflowPageItem extends StatefulWidget {
   const _ReflowPageItem({
     super.key,
-    required this.pageIndex,
     required this.document,
-    required this.resolvePage,
-    required this.placeholderExtent,
-    required this.onResolvedExtent,
+    required this.page,
     required this.showImages,
     this.onShareImage,
   });
 
-  final int pageIndex;
   final PdfDocument document;
-
-  /// Extracts (or returns the cached) reflow for this page. Called off the
-  /// build/layout pass so its cost never janks a frame.
-  final PdfReflowPage Function() resolvePage;
-
-  /// The height to give this page's placeholder before it resolves - the
-  /// running typical page height, so the slot barely changes size when the
-  /// real content lands (no scroll drift).
-  final double Function() placeholderExtent;
-
-  /// Reports this page's laid-out height once resolved, feeding
-  /// [placeholderExtent] for the pages still to come.
-  final void Function(double extent) onResolvedExtent;
-
+  final PdfReflowPage page;
   final bool showImages;
   final PdfReflowImageShareHandler? onShareImage;
 
@@ -455,26 +427,20 @@ class _ReflowPageItem extends StatefulWidget {
 }
 
 class _ReflowPageItemState extends State<_ReflowPageItem> {
-  /// The resolved reflow, or null while it is still being extracted.
-  PdfReflowPage? _page;
-
   /// Decoded images keyed by [pdfImageKey]; the clones are ours to dispose.
   Map<Object, ui.Image> _images = const {};
 
   @override
   void initState() {
     super.initState();
-    _resolve();
+    _decode();
   }
 
   @override
   void didUpdateWidget(_ReflowPageItem oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.pageIndex != oldWidget.pageIndex ||
-        !identical(widget.document, oldWidget.document)) {
-      _page = null;
-      _resolve();
-    } else if (widget.showImages != oldWidget.showImages) {
+    if (!identical(widget.page, oldWidget.page) ||
+        widget.showImages != oldWidget.showImages) {
       _decode();
     }
   }
@@ -492,32 +458,12 @@ class _ReflowPageItemState extends State<_ReflowPageItem> {
     _images = const {};
   }
 
-  /// Extracts the page reflow after yielding, so the frame that mounted this
-  /// item completes first (one heavy page can't stall layout, and a viewport
-  /// full of them extract one after another with the UI live between).
-  Future<void> _resolve() async {
-    await Future<void>.delayed(Duration.zero);
-    if (!mounted) return;
-    final page = widget.resolvePage();
-    if (!mounted) return;
-    setState(() => _page = page);
-    _decode();
-    // Feed the laid-out height back so later pages' placeholders match.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      final height = context.size?.height;
-      if (height != null) widget.onResolvedExtent(height);
-    });
-  }
-
   Future<void> _decode() async {
-    final page = _page;
-    if (page == null) return;
     if (!widget.showImages) {
       if (_images.isNotEmpty) setState(_disposeImages);
       return;
     }
-    final requests = [for (final image in page.images) image.request];
+    final requests = [for (final image in widget.page.images) image.request];
     if (requests.isEmpty) {
       if (_images.isNotEmpty) setState(_disposeImages);
       return;
@@ -551,29 +497,12 @@ class _ReflowPageItemState extends State<_ReflowPageItem> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    final page = _page;
-    if (page == null) {
-      // A placeholder sized to the typical page holds the slot (and gives the
-      // list a stable extent) until this page's text is extracted.
-      return SizedBox(
-        height: widget.placeholderExtent(),
-        child: const Center(
-          child: SizedBox(
-            width: 20,
-            height: 20,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
+  Widget build(BuildContext context) => _ReflowPage(
+        page: widget.page,
+        images: _images,
+        showImages: widget.showImages,
+        onTapImage: _openImage,
       );
-    }
-    return _ReflowPage(
-      page: page,
-      images: _images,
-      showImages: widget.showImages,
-      onTapImage: _openImage,
-    );
-  }
 }
 
 class _ReflowPage extends StatelessWidget {

--- a/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -5,6 +6,14 @@ import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 
 import 'image_decoder.dart';
+import 'pdf_viewer.dart';
+
+/// Receives a figure the reader tapped in [PdfReflowView], rendered as a PNG,
+/// to save or share it (typically the platform share sheet / a save dialog).
+/// With no handler the fullscreen image viewer still opens (pan and pinch to
+/// zoom) - it just omits the share action.
+typedef PdfReflowImageShareHandler = Future<void> Function(
+    BuildContext context, Uint8List pngBytes);
 
 /// A text-first view of a PDF document.
 ///
@@ -14,10 +23,23 @@ import 'image_decoder.dart';
 /// figures and diagrams in place. This is useful for narrow screens and
 /// accessibility-style reading where fixed page layout is less important than
 /// continuous, reflowable content.
+///
+/// Pages are laid out lazily: each page's content is only extracted, and its
+/// images only decoded, once it scrolls near the viewport - so opening (and
+/// scrolling) a 600-page book stays responsive instead of walking every
+/// content stream and decoding every image up front.
+///
+/// When a [controller] is given the view registers as its
+/// [PdfReflowBackend], so the thumbnail strip, bookmarks, and the shell's
+/// saved-position memory drive and follow the reading view exactly as they do
+/// the page viewer - page taps scroll here, and the reading position is
+/// remembered per document.
 class PdfReflowView extends StatefulWidget {
   const PdfReflowView({
     super.key,
     required this.document,
+    this.controller,
+    this.onShareImage,
     this.backgroundColor,
     this.padding = const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
     this.maxWidth = 760,
@@ -25,6 +47,16 @@ class PdfReflowView extends StatefulWidget {
   });
 
   final PdfDocument document;
+
+  /// The shared viewer controller. When present, the reading view registers
+  /// as its navigation backend (page jumps, current-page tracking, saved
+  /// position); null keeps the view standalone.
+  final PdfViewerController? controller;
+
+  /// Saves or shares a figure the reader taps to open fullscreen. Null hides
+  /// the share action but still allows fullscreen pan/pinch-zoom viewing.
+  final PdfReflowImageShareHandler? onShareImage;
+
   final Color? backgroundColor;
   final EdgeInsetsGeometry padding;
   final double maxWidth;
@@ -37,75 +69,275 @@ class PdfReflowView extends StatefulWidget {
   State<PdfReflowView> createState() => _PdfReflowViewState();
 }
 
-class _ReflowContent {
-  const _ReflowContent(this.pages, this.images);
+class _PdfReflowViewState extends State<PdfReflowView>
+    implements PdfReflowBackend {
+  final ScrollController _scroll = ScrollController();
 
-  final List<PdfReflowPage> pages;
+  /// The list's viewport, keyed so we can read its render box for scroll math.
+  final GlobalKey _listKey = GlobalKey();
 
-  /// Decoded images keyed by [pdfImageKey]; a key is absent when the image
-  /// could not be decoded.
-  final Map<Object, ui.Image> images;
-}
+  /// One key per built page item, for measuring and `ensureVisible`.
+  final Map<int, GlobalKey> _itemKeys = {};
 
-class _PdfReflowViewState extends State<PdfReflowView> {
-  late Future<_ReflowContent> _content;
-  Map<Object, ui.Image> _ownedImages = const {};
-  final ScrollController _scrollController = ScrollController();
+  /// Reflowed pages, computed on demand and cached for the document's life.
+  final Map<int, PdfReflowPage> _reflowed = {};
+
+  /// Resolves once we know whether the document has any extractable content
+  /// (scans lazily, stopping at the first non-empty page - so a real book
+  /// resolves after one page).
+  late Future<bool> _hasContent;
+
+  /// A viewport (page + fraction) to restore once the list has laid out.
+  PdfViewport? _pendingRestore;
+
+  /// A page to jump to once the list has laid out (a tap before first layout).
+  int? _pendingJump;
 
   @override
   void initState() {
     super.initState();
-    _content = _load();
+    _hasContent = _probeContent();
+    _scroll.addListener(_onScroll);
+    _attachBackend();
   }
 
   @override
   void didUpdateWidget(PdfReflowView oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(widget.controller, oldWidget.controller)) {
+      oldWidget.controller?.detachReflowBackend(this);
+      _attachBackend();
+    }
     if (!identical(widget.document, oldWidget.document) ||
         widget.showImages != oldWidget.showImages) {
-      _content = _load();
+      _reflowed.clear();
+      _itemKeys.clear();
+      _pendingRestore = null;
+      _pendingJump = null;
+      _hasContent = _probeContent();
+      widget.controller?.reflowReportPageCount(widget.document.pageCount);
+      if (_scroll.hasClients) _scroll.jumpTo(0);
     }
   }
 
   @override
   void dispose() {
-    _scrollController.dispose();
-    _disposeImages();
+    widget.controller?.detachReflowBackend(this);
+    _scroll.removeListener(_onScroll);
+    _scroll.dispose();
     super.dispose();
   }
 
-  void _disposeImages() {
-    for (final image in _ownedImages.values) {
-      image.dispose();
-    }
-    _ownedImages = const {};
+  void _attachBackend() {
+    final controller = widget.controller;
+    if (controller == null) return;
+    controller
+      ..attachReflowBackend(this)
+      ..reflowReportPageCount(widget.document.pageCount);
   }
 
-  Future<_ReflowContent> _load() async {
-    // Give the first frame a chance to show progress before long documents walk
-    // every content stream.
+  PdfReflowPage _pageAt(int index) => _reflowed.putIfAbsent(
+      index, () => PdfTextExtractor.reflowPage(widget.document, index));
+
+  bool _isEmpty(PdfReflowPage page) =>
+      widget.showImages ? page.items.isEmpty : page.blocks.isEmpty;
+
+  Future<bool> _probeContent() async {
+    // Give the first frame a chance to show progress; then scan for the first
+    // page with content, caching what it reflows so those pages don't reflow
+    // twice. A real document resolves on page 0.
     await Future<void>.delayed(Duration.zero);
-    final pages = [
-      for (var i = 0; i < widget.document.pageCount; i++)
-        PdfTextExtractor.reflowPage(widget.document, i),
-    ];
-    var images = const <Object, ui.Image>{};
-    if (widget.showImages) {
-      final requests = [
-        for (final page in pages)
-          for (final image in page.images) image.request,
-      ];
-      if (requests.isNotEmpty) {
-        images = await decodeImages(widget.document.cos, requests,
-            cache: PdfImageCache.instance);
+    for (var i = 0; i < widget.document.pageCount; i++) {
+      if (!_isEmpty(_pageAt(i))) return true;
+    }
+    return false;
+  }
+
+  GlobalKey _keyFor(int index) =>
+      _itemKeys.putIfAbsent(index, () => GlobalKey());
+
+  // --- scroll math -----------------------------------------------------------
+
+  RenderBox? get _viewportBox =>
+      _listKey.currentContext?.findRenderObject() as RenderBox?;
+
+  /// Item [index]'s top edge, in pixels below the viewport's top edge; null
+  /// when the item is not currently built.
+  double? _itemTop(int index) {
+    final viewport = _viewportBox;
+    final box = _keyFor(index).currentContext?.findRenderObject() as RenderBox?;
+    if (viewport == null || box == null || !box.attached) return null;
+    return box.localToGlobal(Offset.zero).dy -
+        viewport.localToGlobal(Offset.zero).dy;
+  }
+
+  /// The topmost page currently occupying the viewport's top edge (the page
+  /// the reader is "on"), or null while nothing is laid out.
+  int? _topVisiblePage() {
+    final viewport = _viewportBox;
+    if (viewport == null) return null;
+    final height = viewport.size.height;
+    int? cover; // an item straddling the top edge
+    double coverTop = double.negativeInfinity;
+    int? firstVisible;
+    double firstTop = double.infinity;
+    for (final index in _itemKeys.keys) {
+      final box =
+          _keyFor(index).currentContext?.findRenderObject() as RenderBox?;
+      if (box == null || !box.attached) continue;
+      final top = box.localToGlobal(Offset.zero).dy -
+          viewport.localToGlobal(Offset.zero).dy;
+      final bottom = top + box.size.height;
+      if (bottom <= 0 || top >= height) continue; // off-screen
+      if (top < firstTop) {
+        firstTop = top;
+        firstVisible = index;
+      }
+      if (top <= 0 && top > coverTop) {
+        coverTop = top;
+        cover = index;
       }
     }
-    // The decoded clones are ours to dispose; drop the previous load's set
-    // and hold the new one for the widget's life (and reloads).
-    _disposeImages();
-    _ownedImages = images;
-    return _ReflowContent(pages, images);
+    return cover ?? firstVisible;
   }
+
+  void _onScroll() {
+    final page = _topVisiblePage();
+    if (page == null) return;
+    // Reports the page (when changed) and always bumps the viewport, so the
+    // thumbnail indicator and the shell's saved-position memory follow the
+    // scroll.
+    widget.controller?.reflowReportPage(page);
+  }
+
+  double _averageExtent() {
+    var sum = 0.0;
+    var n = 0;
+    for (final index in _itemKeys.keys) {
+      final box =
+          _keyFor(index).currentContext?.findRenderObject() as RenderBox?;
+      if (box == null || !box.attached) continue;
+      sum += box.size.height;
+      n++;
+    }
+    // A sensible default before anything is measured (a text page is roughly
+    // this tall at the default width); ensureVisible corrects any estimate.
+    return n == 0 ? 640.0 : sum / n;
+  }
+
+  // --- PdfReflowBackend ------------------------------------------------------
+
+  @override
+  void reflowJumpToPage(int index) {
+    final pageCount = widget.document.pageCount;
+    if (pageCount == 0) return;
+    index = index.clamp(0, pageCount - 1);
+    if (!_scroll.hasClients) {
+      _pendingJump = index;
+      return;
+    }
+    // Already built: align it precisely. Otherwise estimate, jump, and correct
+    // after the frame builds the target into view.
+    if (_alignTop(index)) {
+      widget.controller?.reflowReportPage(index);
+      return;
+    }
+    final estimate = widget.padding.resolve(TextDirection.ltr).top +
+        _averageExtent() * index;
+    _scroll.jumpTo(estimate.clamp(0.0, _scroll.position.maxScrollExtent));
+    _correctTo(index, triesLeft: 4);
+  }
+
+  /// Jumps so item [index]'s top aligns with the viewport top; returns false
+  /// when the item is not built (so the caller can estimate first).
+  bool _alignTop(int index) {
+    final top = _itemTop(index);
+    if (top == null) return false;
+    final target = (_scroll.position.pixels + top)
+        .clamp(0.0, _scroll.position.maxScrollExtent);
+    _scroll.jumpTo(target);
+    return true;
+  }
+
+  void _correctTo(int index, {required int triesLeft}) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scroll.hasClients) return;
+      if (_alignTop(index)) {
+        widget.controller?.reflowReportPage(index);
+      } else if (triesLeft > 0) {
+        // Re-estimate from the pages that did build and try again.
+        final estimate = widget.padding.resolve(TextDirection.ltr).top +
+            _averageExtent() * index;
+        _scroll.jumpTo(estimate.clamp(0.0, _scroll.position.maxScrollExtent));
+        _correctTo(index, triesLeft: triesLeft - 1);
+      }
+    });
+  }
+
+  @override
+  PdfViewport? reflowCaptureViewport() {
+    if (!_scroll.hasClients) return _pendingRestore;
+    final page = _topVisiblePage();
+    if (page == null) return null;
+    var fraction = 0.0;
+    final top = _itemTop(page);
+    final box = _keyFor(page).currentContext?.findRenderObject() as RenderBox?;
+    if (top != null && box != null && box.size.height > 0) {
+      fraction = (-top / box.size.height).clamp(0.0, 1.0);
+    }
+    return PdfViewport(page: page, top: fraction);
+  }
+
+  @override
+  void reflowRestoreViewport(PdfViewport viewport) {
+    _pendingRestore = viewport;
+    // Apply straight away when the list is laid out (scrolling schedules the
+    // frame the corrections ride on); otherwise wait for layout - and ask for
+    // a frame, since a bare post-frame callback never runs on its own.
+    _applyRestoreIfPending();
+  }
+
+  void _applyRestoreIfPending() {
+    if (!mounted) return;
+    final viewport = _pendingRestore;
+    if (viewport == null) return;
+    if (!_scroll.hasClients) {
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => _applyRestoreIfPending());
+      WidgetsBinding.instance.scheduleFrame();
+      return;
+    }
+    _pendingRestore = null;
+    reflowJumpToPage(viewport.page);
+    if (viewport.top == 0) return;
+    // After the page aligns to the top, nudge down by the saved fraction.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scroll.hasClients) return;
+      final box = _keyFor(viewport.page).currentContext?.findRenderObject()
+          as RenderBox?;
+      if (box == null || box.size.height <= 0) return;
+      final target = (_scroll.position.pixels + viewport.top * box.size.height)
+          .clamp(0.0, _scroll.position.maxScrollExtent);
+      _scroll.jumpTo(target);
+    });
+  }
+
+  @override
+  Rect? reflowVisibleFraction(int index) {
+    final viewport = _viewportBox;
+    final top = _itemTop(index);
+    final box = _keyFor(index).currentContext?.findRenderObject() as RenderBox?;
+    if (viewport == null || top == null || box == null) return null;
+    final height = box.size.height;
+    if (height <= 0) return null;
+    final bottom = top + height;
+    if (bottom <= 0 || top >= viewport.size.height) return null;
+    final topFrac = (-top / height).clamp(0.0, 1.0);
+    final botFrac = ((viewport.size.height - top) / height).clamp(0.0, 1.0);
+    return Rect.fromLTRB(0, topFrac, 1, botFrac);
+  }
+
+  // --- build -----------------------------------------------------------------
 
   @override
   Widget build(BuildContext context) {
@@ -114,17 +346,13 @@ class _PdfReflowViewState extends State<PdfReflowView> {
         widget.backgroundColor ?? theme.colorScheme.surfaceContainerLowest;
     return ColoredBox(
       color: background,
-      child: FutureBuilder<_ReflowContent>(
-        future: _content,
+      child: FutureBuilder<bool>(
+        future: _hasContent,
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
-          final content = snapshot.data;
-          final pages = content?.pages ?? const <PdfReflowPage>[];
-          bool empty(PdfReflowPage page) =>
-              widget.showImages ? page.items.isEmpty : page.blocks.isEmpty;
-          if (pages.every(empty)) {
+          if (snapshot.data != true) {
             return Center(
               child: Text(
                 'No extractable content',
@@ -132,36 +360,40 @@ class _PdfReflowViewState extends State<PdfReflowView> {
               ),
             );
           }
-          // A non-lazy scroll lays every page out once, so the total scroll
-          // extent is exact and the scrollbar thumb stays put. A lazy
-          // ListView estimates the extent from built children, which jumps
-          // as reflow pages of wildly different heights (text vs. tall image
-          // pages) come into view - the heights can't be precomputed because
-          // they depend on text wrap and image aspect ratio.
-          final imageMap = content?.images ?? const <Object, ui.Image>{};
-          return Scrollbar(
-            controller: _scrollController,
-            child: SingleChildScrollView(
-              key: const ValueKey('pdf-reflow-view'),
-              controller: _scrollController,
-              padding: widget.padding,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  for (final page in pages)
-                    Center(
-                      child: ConstrainedBox(
-                        constraints: BoxConstraints(maxWidth: widget.maxWidth),
-                        child: RepaintBoundary(
-                          child: _ReflowPage(
-                            page: page,
-                            images: imageMap,
-                            showImages: widget.showImages,
-                          ),
-                        ),
+          // Apply any restore/jump queued before the list existed.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            if (_pendingRestore != null) {
+              _applyRestoreIfPending();
+            } else if (_pendingJump != null && _scroll.hasClients) {
+              final index = _pendingJump!;
+              _pendingJump = null;
+              reflowJumpToPage(index);
+            }
+          });
+          return KeyedSubtree(
+            key: const ValueKey('pdf-reflow-view'),
+            child: Scrollbar(
+              controller: _scroll,
+              child: ListView.builder(
+                key: _listKey,
+                controller: _scroll,
+                padding: widget.padding,
+                itemCount: widget.document.pageCount,
+                itemBuilder: (context, index) => Center(
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(maxWidth: widget.maxWidth),
+                    child: RepaintBoundary(
+                      child: _ReflowPageItem(
+                        key: _keyFor(index),
+                        document: widget.document,
+                        page: _pageAt(index),
+                        showImages: widget.showImages,
+                        onShareImage: widget.onShareImage,
                       ),
                     ),
-                ],
+                  ),
+                ),
               ),
             ),
           );
@@ -171,16 +403,120 @@ class _PdfReflowViewState extends State<PdfReflowView> {
   }
 }
 
+/// One page of the reading view. Decodes its own images lazily when it scrolls
+/// into the build window, and disposes the decoded clones when it scrolls back
+/// out - so only the pages near the viewport hold decoded pixels.
+class _ReflowPageItem extends StatefulWidget {
+  const _ReflowPageItem({
+    super.key,
+    required this.document,
+    required this.page,
+    required this.showImages,
+    this.onShareImage,
+  });
+
+  final PdfDocument document;
+  final PdfReflowPage page;
+  final bool showImages;
+  final PdfReflowImageShareHandler? onShareImage;
+
+  @override
+  State<_ReflowPageItem> createState() => _ReflowPageItemState();
+}
+
+class _ReflowPageItemState extends State<_ReflowPageItem> {
+  /// Decoded images keyed by [pdfImageKey]; the clones are ours to dispose.
+  Map<Object, ui.Image> _images = const {};
+
+  @override
+  void initState() {
+    super.initState();
+    _decode();
+  }
+
+  @override
+  void didUpdateWidget(_ReflowPageItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(widget.page, oldWidget.page) ||
+        widget.showImages != oldWidget.showImages) {
+      _decode();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposeImages();
+    super.dispose();
+  }
+
+  void _disposeImages() {
+    for (final image in _images.values) {
+      image.dispose();
+    }
+    _images = const {};
+  }
+
+  Future<void> _decode() async {
+    if (!widget.showImages) {
+      if (_images.isNotEmpty) setState(_disposeImages);
+      return;
+    }
+    final requests = [for (final image in widget.page.images) image.request];
+    if (requests.isEmpty) {
+      if (_images.isNotEmpty) setState(_disposeImages);
+      return;
+    }
+    final images = await decodeImages(widget.document.cos, requests,
+        cache: PdfImageCache.instance);
+    if (!mounted) {
+      for (final image in images.values) {
+        image.dispose();
+      }
+      return;
+    }
+    setState(() {
+      _disposeImages();
+      _images = images;
+    });
+  }
+
+  /// Opens a decoded figure fullscreen. The route holds its own clone, so it
+  /// is unaffected if this page scrolls out and disposes its images.
+  void _openImage(ui.Image image) {
+    final owned = image.clone();
+    Navigator.of(context).push(PageRouteBuilder<void>(
+      opaque: false,
+      barrierColor: Colors.black,
+      pageBuilder: (context, _, __) =>
+          _FullscreenReflowImage(image: owned, onShare: widget.onShareImage),
+      transitionsBuilder: (context, animation, _, child) =>
+          FadeTransition(opacity: animation, child: child),
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) => _ReflowPage(
+        page: widget.page,
+        images: _images,
+        showImages: widget.showImages,
+        onTapImage: _openImage,
+      );
+}
+
 class _ReflowPage extends StatelessWidget {
   const _ReflowPage({
     required this.page,
     required this.images,
     required this.showImages,
+    this.onTapImage,
   });
 
   final PdfReflowPage page;
   final Map<Object, ui.Image> images;
   final bool showImages;
+
+  /// Opens a decoded figure fullscreen when tapped.
+  final void Function(ui.Image image)? onTapImage;
 
   @override
   Widget build(BuildContext context) {
@@ -235,7 +571,7 @@ class _ReflowPage extends StatelessWidget {
       // reading position still reflects that something sat here.
       return _ImagePlaceholder(aspectRatio: image.aspectRatio);
     }
-    return ClipRRect(
+    final picture = ClipRRect(
       borderRadius: BorderRadius.circular(4),
       child: AspectRatio(
         aspectRatio: image.aspectRatio <= 0 ? 1 : image.aspectRatio,
@@ -243,6 +579,20 @@ class _ReflowPage extends StatelessWidget {
           image: decoded,
           fit: BoxFit.contain,
           filterQuality: FilterQuality.medium,
+        ),
+      ),
+    );
+    if (onTapImage == null) return picture;
+    // Tap a figure to view it fullscreen (pan and pinch to zoom, share).
+    return Semantics(
+      button: true,
+      label: 'View figure',
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => onTapImage!(decoded),
+          child: picture,
         ),
       ),
     );
@@ -283,6 +633,100 @@ class _ImagePlaceholder extends StatelessWidget {
             color: theme.colorScheme.onSurfaceVariant,
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// A fullscreen figure viewer: a dark backdrop with the image centered,
+/// pan and pinch/scroll to zoom ([InteractiveViewer]), a close button, and -
+/// when a share handler is supplied - a save/share action that renders the
+/// image to a PNG. Owns [image] (a clone) and disposes it on close.
+class _FullscreenReflowImage extends StatefulWidget {
+  const _FullscreenReflowImage({required this.image, this.onShare});
+
+  final ui.Image image;
+  final PdfReflowImageShareHandler? onShare;
+
+  @override
+  State<_FullscreenReflowImage> createState() => _FullscreenReflowImageState();
+}
+
+class _FullscreenReflowImageState extends State<_FullscreenReflowImage> {
+  bool _sharing = false;
+
+  @override
+  void dispose() {
+    widget.image.dispose();
+    super.dispose();
+  }
+
+  Future<void> _share() async {
+    final handler = widget.onShare;
+    if (handler == null || _sharing) return;
+    setState(() => _sharing = true);
+    try {
+      final data =
+          await widget.image.toByteData(format: ui.ImageByteFormat.png);
+      if (!mounted || data == null) return;
+      await handler(context, data.buffer.asUint8List());
+    } finally {
+      if (mounted) setState(() => _sharing = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          Positioned.fill(
+            child: InteractiveViewer(
+              minScale: 0.5,
+              maxScale: 8,
+              child: Center(
+                child: RawImage(
+                  image: widget.image,
+                  fit: BoxFit.contain,
+                  filterQuality: FilterQuality.high,
+                ),
+              ),
+            ),
+          ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                children: [
+                  IconButton(
+                    key: const ValueKey('pdf-reflow-image-close'),
+                    icon: const Icon(Icons.close),
+                    color: Colors.white,
+                    tooltip: 'Close',
+                    onPressed: () => Navigator.of(context).maybePop(),
+                  ),
+                  const Spacer(),
+                  if (widget.onShare != null)
+                    IconButton(
+                      key: const ValueKey('pdf-reflow-image-share'),
+                      icon: _sharing
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2, color: Colors.white),
+                            )
+                          : const Icon(Icons.ios_share),
+                      color: Colors.white,
+                      tooltip: 'Save or share',
+                      onPressed: _sharing ? null : _share,
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -240,8 +240,38 @@ class PdfScrollMetrics {
 
 /// Drives a [PdfViewer] and reports its state: current page, zoom, and
 /// search results. Listeners fire on any change.
+/// The subset of viewer navigation a text reading view ([PdfReflowView])
+/// implements so the shared [PdfViewerController] can drive it - page jumps,
+/// the visible-region indicator, and saved-position capture/restore - while
+/// no page [PdfViewer] is mounted.
+///
+/// Internal wiring: a mounted [PdfViewer] always takes precedence, so the
+/// controller only consults a reflow backend in the text reflow view where
+/// there is no page canvas. Not part of the stable public API.
+abstract class PdfReflowBackend {
+  /// Scrolls the reading view so page [index] is at the top.
+  void reflowJumpToPage(int index);
+
+  /// The reading view's scroll position as a resolution-independent snapshot
+  /// (page at the top plus the fraction scrolled into it), or null before it
+  /// has laid out.
+  PdfViewport? reflowCaptureViewport();
+
+  /// Restores a [reflowCaptureViewport] snapshot (applied once laid out).
+  void reflowRestoreViewport(PdfViewport viewport);
+
+  /// The visible part of page [index] as page-area fractions (0–1, y-down),
+  /// or null when the page is off-screen - feeds the thumbnail strip's
+  /// viewport indicator.
+  Rect? reflowVisibleFraction(int index);
+}
+
 class PdfViewerController extends ChangeNotifier {
   _PdfViewerState? _state;
+
+  /// Set while a text reflow view drives navigation in place of a mounted
+  /// page viewer; a mounted [PdfViewer] ([_state]) always wins.
+  PdfReflowBackend? _reflow;
 
   int _pageCount = 0;
   int _currentPage = 0;
@@ -370,7 +400,10 @@ class PdfViewerController extends ChangeNotifier {
   /// Zero-based index into the matches, or -1 with no active match.
   int get currentMatch => _currentMatch;
 
-  Future<void> jumpToPage(int index) async => _state?._jumpToPage(index);
+  Future<void> jumpToPage(int index) async {
+    if (_state != null) return _state!._jumpToPage(index);
+    _reflow?.reflowJumpToPage(index);
+  }
 
   /// Scrolls to [index] with a smooth animation. Unlike [jumpToPage] (which
   /// snaps when the target is far away, to avoid animating every intervening
@@ -381,8 +414,12 @@ class PdfViewerController extends ChangeNotifier {
     int index, {
     Duration duration = const Duration(milliseconds: 250),
     Curve curve = Curves.easeInOut,
-  }) async =>
-      _state?._jumpToPage(index, duration: duration, curve: curve);
+  }) async {
+    if (_state != null) {
+      return _state!._jumpToPage(index, duration: duration, curve: curve);
+    }
+    _reflow?.reflowJumpToPage(index);
+  }
 
   /// A read-only snapshot of the viewer's vertical scroll state - page,
   /// normalized position/extent, pixel offsets, and zoom - for building a
@@ -402,9 +439,16 @@ class PdfViewerController extends ChangeNotifier {
       _state?._scrollToNormalized(position);
 
   /// Scrolls to a PDF destination, using the same `/Fit`, `/FitH`, and
-  /// `/XYZ` handling as in-document GoTo links.
-  void showDestination(PdfDestination destination) =>
-      _state?._scrollToDestination(destination);
+  /// `/XYZ` handling as in-document GoTo links. In the text reflow view,
+  /// where there is no page canvas to fit, it jumps to the destination's
+  /// page.
+  void showDestination(PdfDestination destination) {
+    if (_state != null) {
+      _state!._scrollToDestination(destination);
+    } else {
+      _reflow?.reflowJumpToPage(destination.pageIndex);
+    }
+  }
 
   /// Sets the viewer zoom around the center of the viewport.
   ///
@@ -431,12 +475,18 @@ class PdfViewerController extends ChangeNotifier {
   /// user where they left off. Null while no viewer is attached or it has
   /// not laid out yet. Restore it with [restoreViewport] or
   /// [PdfViewer.initialViewport].
-  PdfViewport? captureViewport() => _state?._captureViewport();
+  PdfViewport? captureViewport() =>
+      _state?._captureViewport() ?? _reflow?.reflowCaptureViewport();
 
   /// Scrolls and zooms to a [captureViewport] snapshot. A no-op while no
   /// viewer is attached; it applies once the viewer has laid out.
-  void restoreViewport(PdfViewport viewport) =>
-      _state?._restoreViewport(viewport);
+  void restoreViewport(PdfViewport viewport) {
+    if (_state != null) {
+      _state!._restoreViewport(viewport);
+    } else {
+      _reflow?.reflowRestoreViewport(viewport);
+    }
+  }
 
   final _viewport = _ViewportNotifier();
 
@@ -450,7 +500,8 @@ class PdfViewerController extends ChangeNotifier {
   /// displayed area (0–1 both axes, y-down from the page's top-left), or
   /// null while the page is entirely off-screen.
   Rect? visiblePageRegion(int pageIndex) =>
-      _state?._visibleFractionOf(pageIndex);
+      _state?._visibleFractionOf(pageIndex) ??
+      _reflow?.reflowVisibleFraction(pageIndex);
 
   /// A snapshot of the viewer's scroll position and zoom, for mirroring it
   /// onto another viewer (the comparison view's synchronized panes). Null
@@ -464,11 +515,33 @@ class PdfViewerController extends ChangeNotifier {
   /// geometry). Guard against feedback loops at the call site.
   void applyViewSync(PdfViewSync sync) => _state?._applyViewSync(sync);
 
+  /// Registers [backend] as the navigation target while the text reflow view
+  /// shows in place of the page viewer, so the thumbnail strip, bookmarks,
+  /// and saved-position memory keep working there. Internal - a mounted
+  /// [PdfViewer] takes precedence. See [PdfReflowBackend].
+  void attachReflowBackend(PdfReflowBackend backend) => _reflow = backend;
+
+  /// Detaches [backend] if it is the current reflow backend.
+  void detachReflowBackend(PdfReflowBackend backend) {
+    if (identical(_reflow, backend)) _reflow = null;
+  }
+
+  /// The reflow backend calls this once it knows the document's page count.
+  void reflowReportPageCount(int count) => _setPageCount(count);
+
+  /// The reflow backend calls this as the reading view scrolls, so
+  /// [currentPage] tracks the top page and [viewportChanges] fires for the
+  /// thumbnail strip's indicator.
+  void reflowReportPage(int page) {
+    _setCurrentPage(page);
+    _bumpViewport();
+  }
+
   void _bumpViewport() {
     if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (_state != null) _viewport.notify();
+        if (_state != null || _reflow != null) _viewport.notify();
       });
     } else {
       _viewport.notify();
@@ -571,7 +644,7 @@ class PdfViewerController extends ChangeNotifier {
     if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (_state != null) notifyListeners();
+        if (_state != null || _reflow != null) notifyListeners();
       });
     } else {
       notifyListeners();

--- a/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
@@ -84,12 +84,27 @@ Uint8List _imagePdf() => _doc('${_text(100, 700, 'Above the figure')}\n'
     '${_text(100, 360, 'Below the figure')}');
 
 /// Pumps frames (driving real async for image decoding) until the
-/// FutureBuilder resolves and the loading spinner disappears.
+/// FutureBuilder resolves and the loading spinner disappears, then a few
+/// extra frames so the visible pages' lazily-decoded images land.
 Future<void> _settle(WidgetTester tester) async {
-  for (var i = 0; i < 60; i++) {
+  var clearedAt = -1;
+  for (var i = 0; i < 80; i++) {
     await tester.pump(const Duration(milliseconds: 16));
     await Future<void>.delayed(const Duration(milliseconds: 5));
-    if (find.byType(CircularProgressIndicator).evaluate().isEmpty) return;
+    if (find.byType(CircularProgressIndicator).evaluate().isEmpty) {
+      if (clearedAt < 0) clearedAt = i;
+      // Give per-page image decoding a handful of frames to complete.
+      if (i - clearedAt >= 12) return;
+    }
+  }
+}
+
+/// Pumps a handful of frames so the reflow view's post-frame jump/restore
+/// corrections (estimate → build → align) run to completion.
+Future<void> _pumpFrames(WidgetTester tester, [int frames = 10]) async {
+  for (var i = 0; i < frames; i++) {
+    await tester.pump(const Duration(milliseconds: 16));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
   }
 }
 
@@ -177,39 +192,147 @@ void main() {
     });
   });
 
-  testWidgets('scroll extent stays stable across scrolling', (tester) async {
+  testWidgets('lazily builds only the pages near the viewport', (tester) async {
     await tester.runAsync(() async {
-      // Alternate tall image pages with short text pages: a lazy ListView's
-      // extent estimate would drift as the differing heights build, jumping
-      // the scrollbar. The non-lazy scroll keeps it exact.
+      // A long document: a non-lazy layout would build every page's
+      // SelectableText up front (the old, slow behaviour). The lazy list
+      // builds only the pages near the viewport, so a far page is absent.
       final doc = PdfDocument.open(_multiPageDoc([
-        for (var i = 0; i < 6; i++)
-          i.isEven
-              ? '$_imageContent\n${_text(100, 440, 'Image page $i')}'
-              : _text(100, 700, 'Text page $i'),
+        for (var i = 0; i < 40; i++) _text(100, 700, 'Text page $i'),
       ]));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: PdfReflowView(document: doc, showImages: false)),
+      ));
+      await _settle(tester);
+
+      expect(find.text('Text page 0'), findsOneWidget);
+      expect(find.text('Text page 39'), findsNothing,
+          reason: 'a far page is not built until it scrolls near the viewport');
+    });
+  });
+
+  testWidgets('a controller jumps the reading view to a page and tracks it',
+      (tester) async {
+    await tester.runAsync(() async {
+      final controller = PdfViewerController();
+      addTearDown(controller.dispose);
+      final doc = PdfDocument.open(_multiPageDoc([
+        for (var i = 0; i < 40; i++) _text(100, 700, 'Text page $i'),
+      ]));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfReflowView(
+              document: doc, controller: controller, showImages: false),
+        ),
+      ));
+      await _settle(tester);
+
+      // The reading view reports the document's page count to the controller.
+      expect(controller.pageCount, 40);
+
+      await controller.jumpToPage(30);
+      await _pumpFrames(tester);
+
+      expect(find.text('Text page 30'), findsOneWidget,
+          reason: 'jumpToPage scrolls the reading view to the target page');
+      expect(controller.currentPage, 30,
+          reason: 'the reading view reports its current page back');
+    });
+  });
+
+  testWidgets('captures and restores the reading position', (tester) async {
+    await tester.runAsync(() async {
+      final contents = [
+        for (var i = 0; i < 40; i++) _text(100, 700, 'Text page $i'),
+      ];
+      final first = PdfViewerController();
+      addTearDown(first.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfReflowView(
+              document: PdfDocument.open(_multiPageDoc(contents)),
+              controller: first,
+              showImages: false),
+        ),
+      ));
+      await _settle(tester);
+
+      await first.jumpToPage(20);
+      await _pumpFrames(tester);
+      final saved = first.captureViewport();
+      expect(saved, isNotNull);
+      expect(saved!.page, 20);
+
+      // Reopen the document in a fresh reading view and restore the snapshot -
+      // the reader lands back on the saved page.
+      final second = PdfViewerController();
+      addTearDown(second.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfReflowView(
+              document: PdfDocument.open(_multiPageDoc(contents)),
+              controller: second,
+              showImages: false),
+        ),
+      ));
+      await _settle(tester);
+      second.restoreViewport(saved);
+      await _pumpFrames(tester);
+
+      expect(find.text('Text page 20'), findsOneWidget);
+    });
+  });
+
+  testWidgets('tapping a figure opens it fullscreen with zoom and share',
+      (tester) async {
+    await tester.runAsync(() async {
+      Uint8List? shared;
+      final doc = PdfDocument.open(_imagePdf());
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfReflowView(
+            document: doc,
+            onShareImage: (context, png) async => shared = png,
+          ),
+        ),
+      ));
+      await _settle(tester);
+      expect(find.byType(RawImage), findsOneWidget);
+
+      await tester.tap(find.byType(RawImage));
+      await tester.pumpAndSettle();
+
+      // The fullscreen viewer is an InteractiveViewer (pan / pinch-zoom).
+      expect(find.byType(InteractiveViewer), findsOneWidget);
+      final shareButton =
+          find.byKey(const ValueKey('pdf-reflow-image-share'));
+      expect(shareButton, findsOneWidget);
+
+      await tester.tap(shareButton);
+      await _pumpFrames(tester);
+      expect(shared, isNotNull, reason: 'the share handler receives PNG bytes');
+
+      await tester.tap(find.byKey(const ValueKey('pdf-reflow-image-close')));
+      await tester.pumpAndSettle();
+      expect(find.byType(InteractiveViewer), findsNothing);
+    });
+  });
+
+  testWidgets('the fullscreen figure hides share when no handler is given',
+      (tester) async {
+    await tester.runAsync(() async {
+      final doc = PdfDocument.open(_imagePdf());
       await tester.pumpWidget(MaterialApp(
         home: Scaffold(body: PdfReflowView(document: doc)),
       ));
       await _settle(tester);
 
-      // The outer scroll view's Scrollable is the first descendant of the
-      // keyed widget (the SelectableTexts add their own deeper ones).
-      final position = tester
-          .state<ScrollableState>(find
-              .descendant(
-                of: find.byKey(const ValueKey('pdf-reflow-view')),
-                matching: find.byType(Scrollable),
-              )
-              .first)
-          .position;
-      final before = position.maxScrollExtent;
-      expect(before, greaterThan(0));
+      await tester.tap(find.byType(RawImage));
+      await tester.pumpAndSettle();
 
-      position.jumpTo(position.maxScrollExtent);
-      await tester.pump();
-      // Exact extent: jumping to the end does not revise it.
-      expect(position.maxScrollExtent, before);
+      expect(find.byType(InteractiveViewer), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-reflow-image-share')), findsNothing,
+          reason: 'no share handler → no share action, viewing still works');
     });
   });
 

--- a/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_reflow_view_test.dart
@@ -100,7 +100,7 @@ Future<void> _settle(WidgetTester tester) async {
 
 /// Pumps a handful of frames so the reflow view's post-frame jump/restore
 /// corrections (estimate → build → align) run to completion.
-Future<void> _pumpFrames(WidgetTester tester, [int frames = 10]) async {
+Future<void> _pumpFrames(WidgetTester tester, [int frames = 30]) async {
   for (var i = 0; i < frames; i++) {
     await tester.pump(const Duration(milliseconds: 16));
     await Future<void>.delayed(const Duration(milliseconds: 5));
@@ -303,6 +303,15 @@ void main() {
 
       // The fullscreen viewer is an InteractiveViewer (pan / pinch-zoom).
       expect(find.byType(InteractiveViewer), findsOneWidget);
+      // The image fills the viewport (BoxFit.contain, centred) rather than
+      // sitting at its intrinsic pixel size in the top-left corner.
+      final fsImage = find.descendant(
+        of: find.byType(InteractiveViewer),
+        matching: find.byType(RawImage),
+      );
+      expect(fsImage, findsOneWidget);
+      expect(tester.getSize(fsImage),
+          tester.getSize(find.byType(InteractiveViewer)));
       final shareButton =
           find.byKey(const ValueKey('pdf-reflow-image-share'));
       expect(shareButton, findsOneWidget);

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -239,7 +239,10 @@ void main() {
 
       expect(prefs.showReflowView, isTrue);
       expect(find.byType(PdfViewer), findsNothing);
-      expect(find.byType(PdfThumbnailSidebar), findsNothing);
+      // The Pages strip stays available in reflow - it drives the reading view
+      // (page taps scroll it) - while the canvas-bound search and page-number
+      // controls, which have no page to act on, drop away.
+      expect(find.byType(PdfThumbnailSidebar), findsOneWidget);
       expect(find.byKey(const ValueKey('pdf-search-field')), findsNothing);
       expect(find.byKey(const ValueKey('pdf-page-number-field')), findsNothing);
       expect(find.byType(PdfReflowView), findsOneWidget);


### PR DESCRIPTION
## Summary

Reworks the text **reflow reading view** (`PdfReflowView`) so it holds up on large books, and wires it in as a first-class reading mode.

- **Lazy layout (the perf fix).** The old view walked *every* page's content stream up front, pre-decoded *every* image in the book, then laid all pages out non-lazily (a deliberate choice for exact scroll extent) — on a 600-page book that is tens of thousands of `SelectableText`s built at once plus the whole book's decoded pixels resident, so scrolling crawled. Now: a `ListView.builder` builds only pages near the viewport, each page's reflow is extracted on demand, and a page's figures decode only while it is near the viewport (disposed when it scrolls out). Scroll extent is estimated rather than exact — the accepted trade for not freezing.
- **Navigation panels work in reflow.** `PdfViewerController` gains an *additive* reflow backend (`PdfReflowBackend`): a mounted `PdfViewer` always wins, and the controller only consults the reflow view when there is no page canvas. So the Pages strip and Bookmarks drive and track the reading view (page taps scroll it; current page + viewport indicator follow). Search/annotation/properties panels still yield in reflow — they act on a page.
- **Saved reading position.** Reflow implements `captureViewport`/`restoreViewport` as `PdfViewport{page, fraction}`, so the shells' existing `PdfViewportMemory` persists and restores the reading position per document — no new plumbing.
- **Mobile.** A one-tap Reflow toggle (`pdf-shell-reflow-toggle`) in the compact Controls sheet of both shells, so phone users don't have to dig into Settings.
- **Tap a figure → fullscreen.** Pan + pinch/scroll zoom (`InteractiveViewer`), plus an optional save/share action that renders the figure to PNG. Threaded as `PdfReflowView.onShareImage` → `PdfEditorView.onShareReflowImage` / `PdfReader.onShareReflowImage`; the example app wires it to its share-sheet/save handler. With no handler the fullscreen viewer still works, just without the share action.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Example app

## Change type

- [x] Feature
- [x] Performance change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean, repo-wide)
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

The full editor suite passes except one **pre-existing, unrelated** Ghent render-baseline failure (`2-SPOT/GWG030_Gray_K_black_OP_X1.pdf`), which was verified to fail identically on the base branch without this change. Nothing here touches the render path.

## Compatibility checklist

- [x] No `dart:ui`/Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/`.
- [x] Layering preserved.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use programmatic builders.

## Notes for reviewers

- Jump-to-page in a lazy list (no `scrollable_positioned_list` dependency) is estimate-then-align: estimate the offset from the average built-item extent, `jumpTo`, then align precisely via the target item's `GlobalKey` once it builds. Approximate for far jumps but converges for the fairly uniform pages of a book.
- Restore had to be applied eagerly (not via a bare `addPostFrameCallback`, which never fires unless something schedules a frame — it was running at teardown). The synchronous `_scroll.jumpTo` schedules the frame the corrections ride on; `scheduleFrame()` covers the defer-until-first-layout case.
- The old "scroll extent stays stable" test was removed — exact extent was the very thing making scrolling slow.
- Design notes: `doc/dev-log/2026-07-19-reflow-scrolling-and-figures.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XofQmsxaSntx1v9YPgqBVo)_