### PR TITLE
perf(editor): apply incremental revisions in place on the commit path (#395)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -536,16 +536,64 @@ class PdfEditingController extends ChangeNotifier {
             newLength: _revisions[_cursor],
             changedPages: impact.visualPages,
           );
-    _reopen();
+    // redo re-extends to a revision already in the buffer: an append
+    _reopen(grew: true);
     _emitAnnotationChanges(beforeLength, impact.annotationPages);
   }
 
-  void _reopen() {
-    _document = PdfDocument.open(bytes, password: _password);
+  void _reopen({bool grew = false}) {
+    _reloadDocument(grew: grew);
     // the same /Annots slot may hold a different annotation now
     _selected.clear();
     _invalidateElements();
     notifyListeners();
+  }
+
+  /// Points [_document] at the current [bytes].
+  ///
+  /// Every edit is an incremental save, so a commit - and a redo, which
+  /// re-extends to a revision already sitting in the buffer - only ever
+  /// *appends* to what the open document already holds. Reopening from
+  /// scratch there re-walks the whole `/Prev` chain, so a session of N
+  /// revisions costs O(N^2) xref work and gets visibly slower the longer you
+  /// edit. [CosDocument.applyIncrementalUpdate] instead stops the walk at the
+  /// previous startxref and evicts only the objects the revision redefined.
+  ///
+  /// [grew] must be true only when [bytes] extends the currently open
+  /// document. Undo shrinks the buffer and [_resetTo] replaces it outright,
+  /// and neither is an append - those reopen.
+  void _reloadDocument({required bool grew}) {
+    if (grew && _tryApplyIncrementalUpdate()) return;
+    _document = PdfDocument.open(bytes, password: _password);
+  }
+
+  /// Folds the appended revision into the open document. False when it can't
+  /// be done incrementally (the document was opened through xref recovery,
+  /// or the appended xref chain is malformed), leaving [_document] untouched
+  /// for the caller to reopen from scratch.
+  bool _tryApplyIncrementalUpdate() {
+    assert(() {
+      // The updater builds each revision as "whole current file, then the
+      // appended objects", so the prefix is identical by construction. Verify
+      // it in debug builds only - a mismatch here would silently graft one
+      // document's xref onto another's bytes.
+      final next = bytes;
+      final current = _document.cos.bytes;
+      if (next.length <= current.length) return false;
+      for (var i = 0; i < current.length; i++) {
+        if (next[i] != current[i]) return false;
+      }
+      return true;
+    }(), 'incremental revision is not an append of the open document');
+    try {
+      // A *new* wrapper over the same updated COS layer: editing widgets read
+      // `identical(document, before)` as "the commit produced no revision",
+      // so the instance has to change even though the parse does not repeat.
+      _document = _document.withIncrementalUpdate(bytes);
+      return true;
+    } on CosParseException {
+      return false;
+    }
   }
 
   /// Runs [edit] against the current document and commits the result as a
@@ -606,7 +654,8 @@ class PdfEditingController extends ChangeNotifier {
           );
     if (_committingRemoteRevision) _undoFloor = _cursor;
     final selected = List.of(_selected);
-    _document = PdfDocument.open(bytes, password: _password);
+    // the incremental save appended to the previous revision
+    _reloadDocument(grew: true);
     // Existing controller mutations remap slots before committing when an
     // /Annots edit shifts them. The transaction validates that post-mutation
     // selection against the reopened revision in one place.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -567,24 +567,52 @@ class PdfEditingController extends ChangeNotifier {
     _document = PdfDocument.open(bytes, password: _password);
   }
 
+  /// Debug-only sanity check behind the assert in [_tryApplyIncrementalUpdate].
+  ///
+  /// Every revision reaching that method is an append *by construction*: the
+  /// updater writes "whole current file, then the appended objects" and the
+  /// editor that produced it was built from [_document], while redo just
+  /// lengthens a view over the same buffer. This guards against a *future*
+  /// call site breaking that, which would silently graft one document's xref
+  /// onto another's bytes ([CosDocument.applyIncrementalUpdate] only checks
+  /// the length, not the content).
+  ///
+  /// It deliberately samples rather than comparing the whole prefix: this runs
+  /// on every commit in debug builds - which is how the app is developed - and
+  /// a full memcmp of a 40 MB drawing per ink stroke is exactly the cost this
+  /// change set out to remove. A wrong-document mix-up differs in the header
+  /// and around the previous revision's tail; a byte-identical head, tail and
+  /// length is not a case any realistic bug produces.
+  bool _looksLikeAppend() {
+    final next = bytes;
+    final current = _document.cos.bytes;
+    if (next.length <= current.length) return false;
+    // Views over one buffer (the redo path) are provably a prefix - no compare.
+    if (identical(next.buffer, current.buffer) &&
+        next.offsetInBytes == current.offsetInBytes) {
+      return true;
+    }
+    const window = 4096;
+    bool sameRange(int from, int to) {
+      for (var i = from; i < to; i++) {
+        if (next[i] != current[i]) return false;
+      }
+      return true;
+    }
+
+    final headEnd = current.length < window ? current.length : window;
+    final tailStart =
+        current.length - window < headEnd ? headEnd : current.length - window;
+    return sameRange(0, headEnd) && sameRange(tailStart, current.length);
+  }
+
   /// Folds the appended revision into the open document. False when it can't
   /// be done incrementally (the document was opened through xref recovery,
   /// or the appended xref chain is malformed), leaving [_document] untouched
   /// for the caller to reopen from scratch.
   bool _tryApplyIncrementalUpdate() {
-    assert(() {
-      // The updater builds each revision as "whole current file, then the
-      // appended objects", so the prefix is identical by construction. Verify
-      // it in debug builds only - a mismatch here would silently graft one
-      // document's xref onto another's bytes.
-      final next = bytes;
-      final current = _document.cos.bytes;
-      if (next.length <= current.length) return false;
-      for (var i = 0; i < current.length; i++) {
-        if (next[i] != current[i]) return false;
-      }
-      return true;
-    }(), 'incremental revision is not an append of the open document');
+    assert(_looksLikeAppend(),
+        'incremental revision is not an append of the open document');
     try {
       // A *new* wrapper over the same updated COS layer: editing widgets read
       // `identical(document, before)` as "the commit produced no revision",

--- a/packages/dart_pdf_editor/test/editing_incremental_reload_test.dart
+++ b/packages/dart_pdf_editor/test/editing_incremental_reload_test.dart
@@ -44,10 +44,12 @@ void main() {
   }
 
   /// The controller's live document vs. a cold open of the same bytes.
-  void expectMatchesColdOpen(PdfEditingController editing, String reason) {
-    final cold = PdfDocument.open(editing.bytes);
-    expect(snapshot(editing.document).toString(), snapshot(cold).toString(),
-        reason: reason);
+  void expectMatchesColdOpen(PdfEditingController editing, String reason,
+      {String password = ''}) {
+    final cold = PdfDocument.open(editing.bytes, password: password);
+    // Deep map/list equality, not `.toString()` - the matcher reports which
+    // key diverged instead of dumping two multi-KB strings side by side.
+    expect(snapshot(editing.document), snapshot(cold), reason: reason);
   }
 
   test('a long session stays identical to a cold open at every revision', () {
@@ -136,6 +138,47 @@ void main() {
 
     editing.addRectangle(0, const PdfRect(140, 220, 200, 280));
     expectMatchesColdOpen(editing, 'after editing a reordered document');
+  });
+
+  test('an encrypted document survives a session on the incremental path', () {
+    // The two paths differ here in a way nothing else in this file exercises:
+    // the reopen fallback re-derives the security handler from the password,
+    // while the incremental path keeps the handler already on the shared
+    // CosDocument. If an in-place update ever dropped or re-derived it wrongly,
+    // strings and streams would decrypt to garbage from the second revision on.
+    final editing = PdfEditingController(buildEncryptedPdf(revision: 4));
+    addTearDown(editing.dispose);
+
+    for (var i = 0; i < 10; i++) {
+      editing.addRectangle(
+          0, PdfRect(100, 200 + i.toDouble() * 5, 180, 250));
+      expectMatchesColdOpen(editing, 'encrypted revision ${i + 1}');
+    }
+    expect(editing.document.page(0).annotations, hasLength(10));
+
+    // the decrypted content stream still reads as plaintext operators, so the
+    // file key survived the in-place updates rather than silently going stale
+    expect(String.fromCharCodes(editing.document.page(0).contentBytes()),
+        contains('Hello, world!'));
+
+    editing.undo();
+    expectMatchesColdOpen(editing, 'encrypted undo (reopen fallback)');
+    editing.redo();
+    expectMatchesColdOpen(editing, 'encrypted redo (incremental path)');
+  });
+
+  test('an AES-256 (R6) document survives the incremental path', () {
+    // R6 uses the file key directly rather than per-object keys, so it walks a
+    // different branch of the handler than the R4 case above.
+    final editing = PdfEditingController(buildEncryptedPdf(revision: 6));
+    addTearDown(editing.dispose);
+
+    for (var i = 0; i < 5; i++) {
+      editing.addRectangle(0, PdfRect(100, 200 + i.toDouble() * 5, 180, 250));
+      expectMatchesColdOpen(editing, 'R6 revision ${i + 1}');
+    }
+    expect(String.fromCharCodes(editing.document.page(0).contentBytes()),
+        contains('Hello, world!'));
   });
 
   test('the revision buffer stays a prefix chain (saves are still appends)',

--- a/packages/dart_pdf_editor/test/editing_incremental_reload_test.dart
+++ b/packages/dart_pdf_editor/test/editing_incremental_reload_test.dart
@@ -1,0 +1,160 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// The editing commit path folds each appended revision into the already-open
+/// document instead of reopening it, so a long session stops paying an
+/// O(revisions^2) walk of the `/Prev` chain.
+///
+/// Every test here is really the same assertion: **the incrementally updated
+/// document must be indistinguishable from one opened from scratch over the
+/// same bytes.** That is the entire risk of the change - a stale cached
+/// object or an unrefreshed trailer would show up as an edit that renders
+/// correctly right after it is made and wrongly after the file is reloaded.
+void main() {
+  /// Everything about a document that an edit can move.
+  ///
+  /// `pageIndexOf` is in here deliberately: it is the only reader of
+  /// `PdfDocument`'s lazily built leaf cache, so without it a stale
+  /// `_leafCache` surviving an in-place update would go unnoticed (verified -
+  /// deleting `invalidatePageCache()` from `applyIncrementalUpdate` passes
+  /// every other assertion here).
+  Map<String, Object?> snapshot(PdfDocument document) {
+    final pages = <Map<String, Object?>>[];
+    for (var i = 0; i < document.pageCount; i++) {
+      final page = document.page(i);
+      pages.add({
+        'mediaBox': page.mediaBox.toString(),
+        'rotation': page.rotation,
+        'contentLength': page.contentBytes().length,
+        'contentHash': Object.hashAll(page.contentBytes()),
+        'indexOf': document.pageIndexOf(page.dict),
+        'annotations': [
+          for (final annotation in page.annotations)
+            {
+              'subtype': annotation.subtype,
+              'rect': annotation.rect.toString(),
+              'contents': annotation.contents,
+            }
+        ],
+      });
+    }
+    return {'pageCount': document.pageCount, 'pages': pages};
+  }
+
+  /// The controller's live document vs. a cold open of the same bytes.
+  void expectMatchesColdOpen(PdfEditingController editing, String reason) {
+    final cold = PdfDocument.open(editing.bytes);
+    expect(snapshot(editing.document).toString(), snapshot(cold).toString(),
+        reason: reason);
+  }
+
+  test('a long session stays identical to a cold open at every revision', () {
+    final editing = PdfEditingController(buildMultiPagePdf(3));
+    addTearDown(editing.dispose);
+
+    // 40 revisions across both pages - well past the point where the /Prev
+    // chain is long enough for the old full-reopen path to be doing real work.
+    for (var i = 0; i < 40; i++) {
+      final page = i % 3;
+      editing.addRectangle(
+          page, PdfRect(100 + i.toDouble(), 200, 180 + i.toDouble(), 260));
+      expectMatchesColdOpen(editing, 'after revision ${i + 1}');
+    }
+
+    expect(editing.document.page(0).annotations, hasLength(14));
+    expect(editing.document.page(1).annotations, hasLength(13));
+    expect(editing.document.page(2).annotations, hasLength(13));
+  });
+
+  test('undo and redo both land on a document matching a cold open', () {
+    final editing = PdfEditingController(buildMultiPagePdf(2));
+    addTearDown(editing.dispose);
+
+    for (var i = 0; i < 6; i++) {
+      editing.addRectangle(0, PdfRect(100, 200 + i.toDouble() * 10, 180, 240));
+    }
+    expectMatchesColdOpen(editing, 'after the initial edits');
+
+    // undo shrinks the buffer - not an append, so this exercises the reopen
+    // fallback rather than the incremental path
+    for (var i = 0; i < 4; i++) {
+      editing.undo();
+      expectMatchesColdOpen(editing, 'after undo ${i + 1}');
+    }
+
+    // redo re-extends to bytes already in the buffer: an append again
+    for (var i = 0; i < 4; i++) {
+      editing.redo();
+      expectMatchesColdOpen(editing, 'after redo ${i + 1}');
+    }
+
+    expect(editing.document.page(0).annotations, hasLength(6));
+  });
+
+  test('editing after an undo (a discarded redo branch) stays consistent', () {
+    // The new revision is built on the *truncated* buffer, so its prefix is a
+    // different byte sequence from the one the previous head carried. If the
+    // append check were keyed on buffer identity rather than content this is
+    // where it would graft the wrong xref on.
+    final editing = PdfEditingController(buildMultiPagePdf(2));
+    addTearDown(editing.dispose);
+
+    editing.addRectangle(0, const PdfRect(100, 200, 180, 260));
+    editing.addRectangle(0, const PdfRect(200, 200, 280, 260));
+    editing.addRectangle(0, const PdfRect(300, 200, 380, 260));
+    editing.undo();
+    editing.undo();
+    expect(editing.document.page(0).annotations, hasLength(1));
+
+    editing.addRectangle(1, const PdfRect(120, 300, 200, 360));
+    expectMatchesColdOpen(editing, 'after branching off an undone revision');
+    expect(editing.document.page(0).annotations, hasLength(1));
+    expect(editing.document.page(1).annotations, hasLength(1));
+
+    expect(editing.canRedo, isFalse, reason: 'the redo branch was discarded');
+  });
+
+  test('structural page edits stay consistent through the incremental path',
+      () {
+    // Page reorder/removal rewrites the page tree, which is exactly the case
+    // where a stale cached /Pages node would survive an in-place update.
+    final editing = PdfEditingController(buildMultiPagePdf(4));
+    addTearDown(editing.dispose);
+
+    editing.addRectangle(0, const PdfRect(100, 200, 180, 260));
+    editing.addRectangle(3, const PdfRect(100, 200, 180, 260));
+
+    editing.movePage(0, 2);
+    expectMatchesColdOpen(editing, 'after movePage');
+    expect(editing.document.pageCount, 4);
+
+    editing.removePage(1);
+    expectMatchesColdOpen(editing, 'after removePage');
+    expect(editing.document.pageCount, 3);
+
+    editing.addRectangle(0, const PdfRect(140, 220, 200, 280));
+    expectMatchesColdOpen(editing, 'after editing a reordered document');
+  });
+
+  test('the revision buffer stays a prefix chain (saves are still appends)',
+      () {
+    // The incremental path is only sound while each revision appends to the
+    // last. If a mutation ever stopped being an append without routing through
+    // _resetTo, this is the guard that catches it.
+    final editing = PdfEditingController(buildMultiPagePdf(2));
+    addTearDown(editing.dispose);
+
+    var previous = editing.bytes;
+    for (var i = 0; i < 8; i++) {
+      editing.addRectangle(i.isEven ? 0 : 1,
+          PdfRect(100, 200 + i.toDouble() * 5, 180, 250));
+      final current = editing.bytes;
+      expect(current.length, greaterThan(previous.length));
+      expect(current.sublist(0, previous.length), previous,
+          reason: 'revision ${i + 1} is not an append of its predecessor');
+      previous = current;
+    }
+  });
+}

--- a/packages/pdf_document/lib/src/document.dart
+++ b/packages/pdf_document/lib/src/document.dart
@@ -118,6 +118,25 @@ class PdfDocument {
     return changed;
   }
 
+  /// Folds an append-only revision into the COS layer (see
+  /// [applyIncrementalUpdate]) and returns a *fresh* [PdfDocument] over it.
+  ///
+  /// Prefer this over [applyIncrementalUpdate] when the result is handed back
+  /// to UI code. Editing widgets across `dart_pdf_editor` use
+  /// `identical(document, previousDocument)` to mean "no new revision landed"
+  /// - an in-place update keeps the same wrapper and silently reads as "the
+  /// edit did nothing". The new wrapper restores that signal while still
+  /// skipping the full re-parse: the COS object cache is shared and only the
+  /// objects this revision redefined were evicted, and the new wrapper starts
+  /// with an empty page-tree cache.
+  ///
+  /// The previous wrapper must be discarded: it shares the now-updated
+  /// [CosDocument], so its cached page tree no longer matches.
+  PdfDocument withIncrementalUpdate(Uint8List newBytes) {
+    cos.applyIncrementalUpdate(newBytes);
+    return PdfDocument._(cos);
+  }
+
   /// Zero-based index of a page dictionary, or -1 if it isn't a leaf of
   /// this document's page tree. Resolved objects are cached by reference,
   /// so identity comparison is sound. Used to resolve link destinations.


### PR DESCRIPTION
## Summary

Addresses the main item of #395 (Phase 1 of the #408 performance review).

Every edit is an incremental save, so a commit — and a redo, which re-extends to a revision already sitting in the buffer — only ever **appends** to what the open document holds. The controller reopened from scratch each time (`editing_controller.dart:609`), and `CosXrefReader.read()` walks the entire `/Prev` chain per open (`xref.dart:105`), so an N-revision session cost O(N²) xref work and got visibly slower the longer you edited.

`CosDocument.applyIncrementalUpdate` already parses only the appended sections and evicts only the objects the revision redefined. The controller never used it — the render worker (`render_worker_isolate.dart:678`) was its only production caller.

Commits and redos now fold the revision in place. Undo shrinks the buffer and `_resetTo` replaces it outright; neither is an append, so both still reopen.

## Measured

1000 revisions on a 30-page document:

| | total | first 200 | last 200 |
|---|---|---|---|
| reopen (before) | 1575 ms | 184 ms | **509 ms** |
| incremental (after) | 812 ms | 136 ms | **218 ms** |

**1.94× overall, 2.3× on the marginal block.** The shape matters more than the totals: the old path's per-block cost climbs 184 → 509 ms, the new one flattens. The gap widens with session length, which is exactly the "editing gets slower the longer you edit" complaint.

The new path still grows slightly (136 → 218 ms). That residual is `updater.dart:86` re-copying the whole file per save, not the xref walk — filed as #413.

## Affected packages

- [x] `pdf_document`
- [x] `dart_pdf_editor`

## Change type

- [x] Performance change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean; the 5 `avoid_print` infos are in untracked local `tool/` scratch files, not this branch)
- [x] `cd packages/pdf_document && fvm dart test` (756 pass)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (1777 pass)
- [x] Bundled web worker checked — unchanged, since tree-shaking excludes the editing controller from the worker's reachable graph

Editor suite is green except the pre-existing `ghent GWG030` baseline failure, unrelated and predating this branch.

## Notes for reviewers

**Please look hardest at `PdfDocument.withIncrementalUpdate`, and at why it exists.**

The obvious implementation — update the open document in place — is wrong here, and fails silently. Roughly **20 sites** in `dart_pdf_editor` use `identical(document, before)` to mean *"the commit produced no revision"*:

```dart
final before = _controller.document;
commit();
if (identical(before, _controller.document)) {
  _clearAfterimage();   // "the edit did nothing"
  return;
}
```

That only ever worked because every commit allocated a fresh `PdfDocument`. Nothing documented or tested that invariant. Updating in place kept the same wrapper, so every one of those sites concluded the edit was a no-op — **17 widget tests failed** across stamp afterimages, drag previews, eraser slices and form layers.

So this PR keeps the invariant rather than refactoring 20 call sites: `withIncrementalUpdate` returns a *new* wrapper over the same updated `CosDocument`. The parse is not repeated (the object cache is shared, only redefined objects were evicted), but identity still changes. The underlying fragility is filed as #414 — that idiom should become an explicit revision token.

**On the test.** `editing_incremental_reload_test` asserts one thing repeatedly: the live document must be indistinguishable from a cold open of the same bytes, at every revision — across long sessions, undo/redo, branching off an undone revision, and structural page edits. That is the whole risk surface: a stale cached object would render correctly right after the edit and wrongly after a reload.

Its `snapshot()` includes `pageIndexOf` **deliberately**, and that is worth not "simplifying away". It is the only reader of `PdfDocument`'s lazily built leaf cache, so without it a stale `_leafCache` surviving an in-place update passes every other assertion in the file. I verified that by mutation: deleting `invalidatePageCache()` from `applyIncrementalUpdate` was undetected before adding it, and fails three tests after.

**Scope left on #395** (noted there, not silently dropped): `_emitAnnotationChanges` still does a full prefix-bytes open per commit when a sync listener is attached. #395 stays open for it.

**On #395's stated blocker (#392):** inverted in the current tree. There is no decoded-bytes cache yet, so nothing was blocking. The dependency runs the other way — #392 must add invalidation inside `applyIncrementalUpdate`, which this change now exercises on every commit rather than only in the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHF8boHzZGxFNijgPRSuaX
