### PR TITLE
test(fixtures): image-heavy wide CAD sheet fixture, in two profiles

### DIFF
--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+export 'src/cad_image_strip.dart';
 export 'src/cad_strip.dart';
 export 'src/encrypted.dart';
 export 'src/icc_profiles.dart';

--- a/packages/pdf_test_fixtures/lib/src/cad_image_strip.dart
+++ b/packages/pdf_test_fixtures/lib/src/cad_image_strip.dart
@@ -1,0 +1,358 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:pdf_cos/pdf_cos.dart';
+
+/// How a tile's pixels are encoded into the PDF.
+enum PdfTileCodec {
+  /// `FlateDecode` 8-bit RGB - what the real drawing uses.
+  flateRgb,
+
+  /// `FlateDecode` 1-bit `/ImageMask` stencil - the linework layer.
+  imageMask,
+
+  /// `FlateDecode` 8-bit `/Indexed` palette.
+  indexed,
+
+  /// `DCTDecode` - payload supplied by the caller.
+  jpeg,
+
+  /// `JPXDecode` - payload supplied by the caller.
+  jpeg2000,
+}
+
+/// One image tile placed on the sheet.
+class PdfTileSpec {
+  const PdfTileSpec({
+    required this.codec,
+    required this.width,
+    required this.height,
+    this.payload,
+  });
+
+  final PdfTileCodec codec;
+  final int width;
+  final int height;
+
+  /// Pre-encoded bytes for [PdfTileCodec.jpeg] / [PdfTileCodec.jpeg2000].
+  ///
+  /// Those two are produced by external encoders (`cjpeg`, `opj_compress`)
+  /// because this library has no `dart:io` and ships no codecs - the tool that
+  /// writes the fixture supplies them. The Flate variants are generated here,
+  /// so the common case needs nothing external.
+  final Uint8List? payload;
+}
+
+/// Builds the **image-heavy** variant of the wide CAD strip
+/// (`buildSyntheticCadStrip`): the same ~8504 x 842 pt single-sheet drawing,
+/// with a grid of large raster tiles composited under the linework.
+///
+/// The shape is taken from a real 62 MB cathodic-protection sheet, profiled
+/// rather than guessed:
+///
+/// ```
+/// images: 1386  (93% of file bytes)
+/// dimensions: 2048x1754 x1385
+/// colorspaces: 923 ImageMask (1-bit), 445 DeviceRGB (8-bit), 18 Indexed
+/// smasks: 0        filters: FlateDecode only
+/// content: 8 streams, 3.93 MB raw -> 24.75 MB decoded
+/// total pixels: 4975 Mpx  ->  ~19.9 GB if every tile were decoded to RGBA
+/// ```
+///
+/// That last line is the point of the fixture: a 62 MB file that can ask for
+/// ~20 GB of decoded RGBA is what stresses the decoded-image cache budget, and
+/// the 1-bit `/ImageMask` stencil path is not covered by any other perf
+/// document. Tiles are drawn in a row across the strip so a horizontal pan
+/// crosses many of them, which is how the real sheet is read.
+///
+/// [tiles] describes each tile in draw order. [ops] vector primitives are drawn
+/// over the top so the page still carries CAD linework, split across [streams]
+/// `/Contents` streams like a real multi-pass export. Output is deterministic:
+/// seeded PRNG, no timestamps.
+Uint8List buildSyntheticCadImageStrip({
+  required List<PdfTileSpec> tiles,
+  int ops = 500000,
+  int streams = 8,
+  int seed = 20260720,
+  double pageW = 8503.939,
+  double pageH = 841.89,
+}) {
+  assert(streams > 0);
+  const zlib = ZLibEncoder();
+  final builder = CosDocumentBuilder();
+  final random = _Lcg(seed);
+
+  // Registration order: 1 = catalog, 2 = pages tree, then one object per tile
+  // (plus one palette object per indexed tile), then the content streams, then
+  // the page.
+  const catalogNum = 1;
+  const treeNum = 2;
+  final treeRef = const CosReference(treeNum, 0);
+
+  var next = 3;
+  final tileRefs = <CosReference>[];
+  final tileObjects = <CosObject>[];
+  final paletteObjects = <(int, CosObject)>[];
+  for (final tile in tiles) {
+    final paletteNum = tile.codec == PdfTileCodec.indexed ? next++ : null;
+    final tileNum = next++;
+    tileRefs.add(CosReference(tileNum, 0));
+    if (paletteNum != null) {
+      paletteObjects.add((paletteNum, _palette(zlib)));
+    }
+    tileObjects.add(_tileStream(tile, paletteNum, zlib, random));
+  }
+  final contentStart = next;
+  final contentRefs = [
+    for (var i = 0; i < streams; i++) CosReference(contentStart + i, 0)
+  ];
+  final pageRef = CosReference(contentStart + streams, 0);
+
+  builder.add(CosDictionary({
+    'Type': const CosName('Catalog'),
+    'Pages': treeRef,
+  }));
+  builder.add(CosDictionary({
+    'Type': const CosName('Pages'),
+    'Kids': CosArray([pageRef]),
+    'Count': const CosInteger(1),
+  }));
+
+  // Interleave palettes with their tiles so object numbers match the order
+  // reserved above.
+  var paletteIndex = 0;
+  for (var i = 0; i < tiles.length; i++) {
+    if (tiles[i].codec == PdfTileCodec.indexed) {
+      builder.add(paletteObjects[paletteIndex++].$2);
+    }
+    builder.add(tileObjects[i]);
+  }
+
+  // Lay the tiles out left to right across the strip, so a horizontal pan -
+  // how this drawing is actually read - crosses tile after tile.
+  final perStream = (tiles.length / streams).ceil();
+  final tileW = pageW / tiles.length * 1.6; // overlap, like a stitched scan
+  final buffers = <StringBuffer>[];
+  for (var s = 0; s < streams; s++) {
+    final buf = StringBuffer();
+    final from = s * perStream;
+    final to = (from + perStream).clamp(0, tiles.length);
+    for (var i = from; i < to; i++) {
+      final x = pageW * i / tiles.length;
+      buf.writeln('q ${_f(tileW)} 0 0 ${_f(pageH)} ${_f(x)} 0 cm '
+          '/Im$i Do Q');
+    }
+    // vector linework over the tiles, this stream's share
+    final opsHere = ops ~/ streams;
+    for (var i = 0; i < opsHere; i++) {
+      final x = random.range(0, pageW);
+      final y = random.range(0, pageH);
+      buf.writeln('${_f(random.range(0, 1))} G ${_f(random.range(0.2, 1.4))} w '
+          '${_f(x)} ${_f(y)} m ${_f(x + random.range(-40, 40))} '
+          '${_f(y + random.range(-30, 30))} l S');
+    }
+    buffers.add(buf);
+  }
+
+  for (final buf in buffers) {
+    final raw = Uint8List.fromList(buf.toString().codeUnits);
+    final deflated = Uint8List.fromList(zlib.encode(raw));
+    builder.add(CosStream(
+      CosDictionary({
+        'Filter': const CosName('FlateDecode'),
+        'Length': CosInteger(deflated.length),
+      }),
+      deflated,
+    ));
+  }
+
+  builder.add(CosDictionary({
+    'Type': const CosName('Page'),
+    'Parent': treeRef,
+    'MediaBox': CosArray([
+      const CosInteger(0),
+      const CosInteger(0),
+      CosReal(pageW),
+      CosReal(pageH),
+    ]),
+    'Resources': CosDictionary({
+      'XObject': CosDictionary({
+        for (var i = 0; i < tileRefs.length; i++) 'Im$i': tileRefs[i],
+      }),
+    }),
+    'Contents': CosArray(contentRefs),
+  }));
+
+  return builder.build(root: const CosReference(catalogNum, 0));
+}
+
+String _f(double v) => v.toStringAsFixed(2);
+
+/// A 256-entry ramp palette for the indexed tiles.
+CosStream _palette(ZLibEncoder zlib) {
+  final table = Uint8List(256 * 3);
+  for (var i = 0; i < 256; i++) {
+    table[i * 3] = i;
+    table[i * 3 + 1] = 255 - i;
+    table[i * 3 + 2] = (i * 7) & 0xFF;
+  }
+  final deflated = Uint8List.fromList(zlib.encode(table));
+  return CosStream(
+    CosDictionary({
+      'Filter': const CosName('FlateDecode'),
+      'Length': CosInteger(deflated.length),
+    }),
+    deflated,
+  );
+}
+
+CosStream _tileStream(
+    PdfTileSpec tile, int? paletteNum, ZLibEncoder zlib, _Lcg random) {
+  final w = tile.width;
+  final h = tile.height;
+
+  switch (tile.codec) {
+    case PdfTileCodec.jpeg:
+    case PdfTileCodec.jpeg2000:
+      final payload = tile.payload;
+      if (payload == null) {
+        throw ArgumentError('${tile.codec} tiles need a pre-encoded payload');
+      }
+      return CosStream(
+        CosDictionary({
+          'Type': const CosName('XObject'),
+          'Subtype': const CosName('Image'),
+          'Width': CosInteger(w),
+          'Height': CosInteger(h),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'BitsPerComponent': const CosInteger(8),
+          'Filter': CosName(
+              tile.codec == PdfTileCodec.jpeg ? 'DCTDecode' : 'JPXDecode'),
+          'Length': CosInteger(payload.length),
+        }),
+        payload,
+      );
+
+    case PdfTileCodec.imageMask:
+      // 1 bit per pixel, rows padded to byte boundaries - the stencil layer.
+      final rowBytes = (w + 7) >> 3;
+      final bits = Uint8List(rowBytes * h);
+      for (var y = 0; y < h; y++) {
+        // sparse diagonal hatching: cheap to generate, compresses like linework
+        for (var x = (y * 3) % 17; x < w; x += 17) {
+          bits[y * rowBytes + (x >> 3)] |= 0x80 >> (x & 7);
+        }
+      }
+      final deflated = Uint8List.fromList(zlib.encode(bits));
+      return CosStream(
+        CosDictionary({
+          'Type': const CosName('XObject'),
+          'Subtype': const CosName('Image'),
+          'Width': CosInteger(w),
+          'Height': CosInteger(h),
+          'ImageMask': const CosBoolean(true),
+          'BitsPerComponent': const CosInteger(1),
+          'Decode': CosArray([const CosInteger(0), const CosInteger(1)]),
+          'Filter': const CosName('FlateDecode'),
+          'Length': CosInteger(deflated.length),
+        }),
+        deflated,
+      );
+
+    case PdfTileCodec.indexed:
+      final pixels = Uint8List(w * h);
+      for (var i = 0; i < pixels.length; i++) {
+        pixels[i] = (i * 31 + random.intBelow(3)) & 0xFF;
+      }
+      final deflated = Uint8List.fromList(zlib.encode(pixels));
+      return CosStream(
+        CosDictionary({
+          'Type': const CosName('XObject'),
+          'Subtype': const CosName('Image'),
+          'Width': CosInteger(w),
+          'Height': CosInteger(h),
+          'ColorSpace': CosArray([
+            const CosName('Indexed'),
+            const CosName('DeviceRGB'),
+            const CosInteger(255),
+            CosReference(paletteNum!, 0),
+          ]),
+          'BitsPerComponent': const CosInteger(8),
+          'Filter': const CosName('FlateDecode'),
+          'Length': CosInteger(deflated.length),
+        }),
+        deflated,
+      );
+
+    case PdfTileCodec.flateRgb:
+      // A scanned drawing tile: near-white paper with sparse dark linework.
+      //
+      // This is load-bearing for the fixture's realism. An earlier version
+      // filled the tile with an `x ^ y` gradient, which is high-entropy noise:
+      // it deflated to ~6 MB per tile against the real file's ~42 KB average,
+      // making the fixture ~12x too large and turning a Flate-decode benchmark
+      // into a memory-bandwidth benchmark. Long runs of identical pixels are
+      // what a real scan compresses down to.
+      final rgb = Uint8List(w * h * 3)..fillRange(0, w * h * 3, 0xF8);
+      void mark(int x, int y) {
+        if (x < 0 || x >= w || y < 0 || y >= h) return;
+        final i = (y * w + x) * 3;
+        rgb[i] = 0x20;
+        rgb[i + 1] = 0x24;
+        rgb[i + 2] = 0x30;
+      }
+
+      // horizontal + vertical rules, the dominant feature of a CAD scan
+      for (var y = 0; y < h; y += 97) {
+        for (var x = 0; x < w; x++) {
+          mark(x, y);
+          mark(x, y + 1);
+        }
+      }
+      for (var x = 0; x < w; x += 131) {
+        for (var y = 0; y < h; y++) {
+          mark(x, y);
+        }
+      }
+      // a scattering of small filled blocks standing in for symbols and text
+      for (var i = 0; i < 240; i++) {
+        final bx = random.intBelow(w - 24);
+        final by = random.intBelow(h - 12);
+        for (var y = 0; y < 9; y++) {
+          for (var x = 0; x < 18; x++) {
+            if (((x * 7 + y * 3) & 3) != 0) mark(bx + x, by + y);
+          }
+        }
+      }
+      final deflated = Uint8List.fromList(zlib.encode(rgb));
+      return CosStream(
+        CosDictionary({
+          'Type': const CosName('XObject'),
+          'Subtype': const CosName('Image'),
+          'Width': CosInteger(w),
+          'Height': CosInteger(h),
+          'ColorSpace': const CosName('DeviceRGB'),
+          'BitsPerComponent': const CosInteger(8),
+          'Filter': const CosName('FlateDecode'),
+          'Length': CosInteger(deflated.length),
+        }),
+        deflated,
+      );
+  }
+}
+
+/// Deterministic 64-bit LCG (VM-only; see `cad_strip.dart`).
+class _Lcg {
+  _Lcg(this._state);
+  int _state;
+
+  int _next() =>
+      _state = (_state * 6364136223846793005 + 1442695040888963407) &
+          0x7FFFFFFFFFFFFFFF;
+
+  double unit() => (_next() >> 11) * (1.0 / (1 << 52));
+
+  double range(double lo, double hi) => lo + unit() * (hi - lo);
+
+  int intBelow(int n) => (unit() * n).floor();
+}

--- a/packages/pdf_test_fixtures/tool/gen_cad_image_pdf.dart
+++ b/packages/pdf_test_fixtures/tool/gen_cad_image_pdf.dart
@@ -1,0 +1,158 @@
+// Writes the image-heavy wide-CAD perf fixture: one ~8504 x 842 pt sheet with
+// a grid of large raster tiles under vector linework. Two profiles:
+//
+//   faithful  mirrors the real 62 MB cathodic-protection drawing - FlateDecode
+//             only, ~2:1 ImageMask stencils to DeviceRGB tiles plus a few
+//             Indexed ones. This is the shape that actually ships to us.
+//
+//   mixed     the same sheet re-encoded with DCTDecode and JPXDecode tiles, to
+//             exercise the JPEG and JPEG 2000 decoders under a realistic
+//             page. Needs `cjpeg` (mozjpeg/libjpeg-turbo) and `opj_compress`
+//             (OpenJPEG) on PATH; both are generated once and the resulting
+//             PDF is pre-seeded into tool/perf/cache, so CI never needs them.
+//
+//   fvm dart run packages/pdf_test_fixtures/tool/gen_cad_image_pdf.dart \
+//       <out.pdf> [faithful|mixed] [tiles] [tileW] [tileH] [ops] [seed]
+//
+// Defaults: 1386 tiles of 2048x1754 and 500k vector ops - the profiled counts
+// (the real sheet is heavy in BOTH raster and vector: ~57.7 MB of image
+// streams *and* ~24.75 MB of decoded content across 8 /Contents streams).
+// The real file is ~62 MB and would decode to ~20 GB of RGBA if every tile
+// were resident at once; that ratio is the point of the fixture.
+//
+// JPX note: the codestream must stay inside what `JpxDecoder` supports - no
+// component subsampling and no code-block style options - so opj_compress is
+// invoked without -s and without -M.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main(List<String> args) {
+  final outPath = args.isNotEmpty ? args[0] : 'perf_cad_images.pdf';
+  final profile = args.length > 1 ? args[1] : 'faithful';
+  final tileCount = args.length > 2 ? int.parse(args[2]) : 1386;
+  final tileW = args.length > 3 ? int.parse(args[3]) : 2048;
+  final tileH = args.length > 4 ? int.parse(args[4]) : 1754;
+  final ops = args.length > 5 ? int.parse(args[5]) : 500000;
+  final seed = args.length > 6 ? int.parse(args[6]) : 20260720;
+
+  if (profile != 'faithful' && profile != 'mixed') {
+    stderr.writeln('profile must be "faithful" or "mixed"');
+    exitCode = 2;
+    return;
+  }
+
+  final tiles = <PdfTileSpec>[];
+  Uint8List? jpegPayload;
+  Uint8List? jpxPayload;
+
+  if (profile == 'mixed') {
+    // Encode one tile with each external codec and reuse the payload. Reuse is
+    // deliberate: the decoders do the same work per tile either way, and one
+    // encode keeps generation quick and byte-reproducible.
+    jpegPayload = _encodeJpeg(tileW, tileH);
+    jpxPayload = _encodeJpx(tileW, tileH);
+  }
+
+  for (var i = 0; i < tileCount; i++) {
+    // Profiled mix: 923 ImageMask : 445 DeviceRGB : 18 Indexed out of 1386,
+    // i.e. roughly 2 stencils per RGB tile with a sprinkle of Indexed.
+    final slot = i % 77;
+    final PdfTileCodec codec;
+    if (slot == 76) {
+      codec = PdfTileCodec.indexed;
+    } else if (slot % 3 == 2) {
+      codec = profile == 'mixed'
+          ? (i % 6 == 2 ? PdfTileCodec.jpeg2000 : PdfTileCodec.jpeg)
+          : PdfTileCodec.flateRgb;
+    } else {
+      codec = PdfTileCodec.imageMask;
+    }
+    tiles.add(PdfTileSpec(
+      codec: codec,
+      width: tileW,
+      height: tileH,
+      payload: switch (codec) {
+        PdfTileCodec.jpeg => jpegPayload,
+        PdfTileCodec.jpeg2000 => jpxPayload,
+        _ => null,
+      },
+    ));
+  }
+
+  final bytes = buildSyntheticCadImageStrip(tiles: tiles, ops: ops, seed: seed);
+  File(outPath)
+    ..parent.createSync(recursive: true)
+    ..writeAsBytesSync(bytes);
+
+  final counts = <PdfTileCodec, int>{};
+  for (final t in tiles) {
+    counts[t.codec] = (counts[t.codec] ?? 0) + 1;
+  }
+  final megapixels = tileCount * tileW * tileH / 1e6;
+  stderr.writeln('wrote $outPath: 1 page 8504x842pt, $profile profile, '
+      '$tileCount tiles of ${tileW}x$tileH, $ops vector ops, '
+      '${(bytes.length / (1 << 20)).toStringAsFixed(1)} MB, seed $seed');
+  stderr.writeln('  tiles: ${counts.entries.map((e) => '${e.key.name}=${e.value}').join(' ')}');
+  stderr.writeln('  ${megapixels.toStringAsFixed(0)} Mpx total -> '
+      '~${(megapixels * 4 / 1000).toStringAsFixed(1)} GB if all decoded to RGBA');
+}
+
+/// A deterministic RGB source image, written as binary PPM for the encoders.
+Uint8List _ppm(int w, int h) {
+  final header = Uint8List.fromList('P6\n$w $h\n255\n'.codeUnits);
+  final body = Uint8List(w * h * 3);
+  for (var y = 0; y < h; y++) {
+    final row = y * w * 3;
+    for (var x = 0; x < w; x++) {
+      final i = row + x * 3;
+      body[i] = x * 255 ~/ w;
+      body[i + 1] = y * 255 ~/ h;
+      body[i + 2] = (x ^ y) & 0xFF;
+    }
+  }
+  return Uint8List.fromList([...header, ...body]);
+}
+
+Uint8List _runCodec(
+    String exe, List<String> Function(String src, String dst) argv,
+    String srcExt, String dstExt, int w, int h) {
+  final dir = Directory.systemTemp.createTempSync('cadgen');
+  try {
+    final src = File('${dir.path}/src.$srcExt')..writeAsBytesSync(_ppm(w, h));
+    final dst = '${dir.path}/out.$dstExt';
+    final result = Process.runSync(exe, argv(src.path, dst));
+    if (result.exitCode != 0 || !File(dst).existsSync()) {
+      throw StateError('$exe failed (${result.exitCode}): ${result.stderr}');
+    }
+    return File(dst).readAsBytesSync();
+  } on ProcessException catch (e) {
+    throw StateError('$exe not found on PATH - needed for the "mixed" '
+        'profile. Install it (brew install mozjpeg openjpeg) or use the '
+        '"faithful" profile, which needs no external codecs. ($e)');
+  } finally {
+    dir.deleteSync(recursive: true);
+  }
+}
+
+Uint8List _encodeJpeg(int w, int h) => _runCodec(
+      'cjpeg',
+      (src, dst) => ['-quality', '80', '-outfile', dst, src],
+      'ppm',
+      'jpg',
+      w,
+      h,
+    );
+
+/// Raw JPEG 2000 codestream (`-o out.j2k`), inside what `JpxDecoder` supports:
+/// no `-s` (component subsampling is rejected) and no `-M` (code-block style
+/// options are rejected).
+Uint8List _encodeJpx(int w, int h) => _runCodec(
+      'opj_compress',
+      (src, dst) => ['-i', src, '-o', dst, '-r', '20'],
+      'ppm',
+      'j2k',
+      w,
+      h,
+    );

--- a/tool/perf/gen_perf_docs.sh
+++ b/tool/perf/gen_perf_docs.sh
@@ -13,6 +13,8 @@ CAD="$ROOT/tool/perf/cache/cad-138-6000-20260718.pdf"
 CADWIDE="$ROOT/tool/perf/cache/cad-wide-850000-8-20260718.pdf"
 IMG="$ROOT/tool/perf/cache/image-heavy/image-heavy-24p.pdf"
 DN="$ROOT/tool/perf/cache/devicen/devicen-8p.pdf"
+CADIMG="$ROOT/tool/perf/cache/cad-images/cad-images-1386-20260720.pdf"
+CADIMGMIX="$ROOT/tool/perf/cache/cad-images/cad-images-mixed-200-20260720.pdf"
 
 if [ ! -f "$CAD" ]; then
   echo "gen cad-138p -> $CAD"
@@ -30,6 +32,27 @@ if [ ! -f "$IMG" ]; then
   echo "gen image-heavy -> $IMG"
   mkdir -p "$(dirname "$IMG")"
   ( cd "$ROOT" && $DART run packages/pdf_cos/tool/gen_image_pdf.dart "$IMG" 24 1240 1650 )
+fi
+
+if [ ! -f "$CADIMG" ]; then
+  echo "gen cad-images (image-heavy wide CAD sheet) -> $CADIMG"
+  mkdir -p "$(dirname "$CADIMG")"
+  ( cd "$ROOT" && $DART run packages/pdf_test_fixtures/tool/gen_cad_image_pdf.dart \
+      "$CADIMG" faithful )
+fi
+
+# The mixed-codec variant needs cjpeg + opj_compress, which CI does not have -
+# generate it locally and pre-seed like the others. Skipped (not failed) when
+# the encoders are missing, so a plain `gen_perf_docs.sh` still succeeds.
+if [ ! -f "$CADIMGMIX" ]; then
+  if command -v cjpeg >/dev/null 2>&1 && command -v opj_compress >/dev/null 2>&1; then
+    echo "gen cad-images-mixed (DCT + JPX tiles) -> $CADIMGMIX"
+    mkdir -p "$(dirname "$CADIMGMIX")"
+    ( cd "$ROOT" && $DART run packages/pdf_test_fixtures/tool/gen_cad_image_pdf.dart \
+        "$CADIMGMIX" mixed 200 2048 1754 100000 )
+  else
+    echo "skip cad-images-mixed: cjpeg/opj_compress not on PATH" >&2
+  fi
 fi
 
 if [ ! -f "$DN" ]; then

--- a/tool/perf/scenarios.json
+++ b/tool/perf/scenarios.json
@@ -89,6 +89,24 @@
     "timeoutS": 300,
     "ciSafe": false
   },
+  "cad-images-1p-sweep": {
+    "suite": "vm-sweep",
+    "note": "the image-heavy variant of the wide CAD strip, profiled from a real 62 MB cathodic-protection sheet rather than guessed: 1386 tiles of 2048x1754 (918 one-bit /ImageMask stencils, 450 DeviceRGB, 18 Indexed - all FlateDecode, no SMasks) under ~500k vector ops in 8 /Contents streams. ~4979 Mpx, so the page would decode to ~20 GB of RGBA from a ~78 MB file: the decoded-image-cache-budget shape. Also the only perf doc exercising the 1-bit ImageMask stencil path. Pre-seeded into tool/perf/cache/cad-images.",
+    "corpus": "tool/perf/cache/cad-images",
+    "maxPages": 0,
+    "repeat": 2,
+    "timeoutS": 900,
+    "ciSafe": true
+  },
+  "cad-images-mixed-sweep": {
+    "suite": "vm-sweep",
+    "note": "the same sheet re-encoded with DCTDecode and JPXDecode tiles, for decoder coverage the faithful profile cannot give (the real file is Flate-only). CAVEAT: a non-CMYK DCTDecode base is handed to the platform codec (ui.instantiateImageCodec), not our Dart code, so on a vm-sweep only the JPX and Flate tiles exercise us - the JPEG half needs a flutter-render suite to mean anything. Generation needs cjpeg + opj_compress locally; pre-seeded, never generated in CI.",
+    "corpus": "tool/perf/cache/cad-images",
+    "maxPages": 0,
+    "repeat": 2,
+    "timeoutS": 900,
+    "ciSafe": false
+  },
   "cad-133p-scroll": {
     "suite": "chrome-scroll",
     "note": "app/tool/perf loop against the real local CAD PDF ($PERF_PDF); manual/local only",


### PR DESCRIPTION
## Summary

Adds an **image-heavy** variant of the wide CAD sheet fixture, in two profiles, plus two perf scenarios.

No existing perf document combines heavy vector content with heavy raster: `cad-wide-1p` is pure vector, `image-heavy` is pure images. Real construction drawings are both.

## The shape is profiled, not guessed — and that mattered

I first inferred the profile from sibling drawings in the same industry toolchain. That predicted a large `JPXDecode 4630x2797` backdrop plus ~900 small `DCT`+`SMask` pairs — **a completely different document**. Profiling the actual 62 MB cathodic-protection sheet gave:

```
images: 1386  (93% of file bytes)   dimensions: 2048x1754 x1385
colorspaces: 923 ImageMask (1-bit), 445 DeviceRGB, 18 Indexed
smasks: 0        filters: FlateDecode only  -  no DCT, no JPX
content: 8 streams, 3.93 MB raw -> 24.75 MB decoded
4975 Mpx  ->  ~19.9 GB of RGBA if every tile were resident
```

A uniform tile grid: 1-bit stencils layered over RGB tiles. **The upshot is that no new encoder was needed at all** — the JPX encoder I had scoped as "large effort" was answering a question the real file doesn't ask.

The `faithful` profile reproduces it: 1386 images, 4979 Mpx, 918:450:18, 24.80 MB decoded content.

That ~20 GB-of-RGBA-from-a-78 MB-file ratio is the point — it is the decoded-image-cache-budget shape (`PdfImageCache.maxBytes`, #405) — and the 1-bit `/ImageMask` stencil path is not exercised by any other perf document.

## The `mixed` profile

Re-encodes tiles as `DCTDecode`/`JPXDecode` for decoder coverage the real file cannot give. **No encoder is written**: payloads come from `cjpeg` and `opj_compress` at generation time, matching the `gen_pkix_fixtures.sh` precedent, and the library stays `dart:io`-free by accepting pre-encoded bytes.

`opj_compress` runs without `-s` and without `-M`, keeping the codestream inside what `JpxDecoder` supports (it rejects component subsampling at `jpx.dart:236` and code-block style options at `:265`). Verified 5/5 JPX tiles decode through `decodePdfImagePixels`.

**Caveat recorded on the scenario:** a non-CMYK `DCTDecode` base returns null from `decodePdfImagePixels` **by design** (`image_pixels.dart:70`) and is handed to `ui.instantiateImageCodec`. So on a vm-sweep the JPEG tiles exercise Skia, not our Dart code — only JPX and Flate exercise us there. The JPEG half needs a flutter-render suite to mean anything. I nearly filed that as a decoder bug before checking.

## Affected packages

- [x] `pdf_test_fixtures`
- [x] Documentation / CI / repository metadata only (perf scenarios + generator script)

## Change type

- [x] Tests / fixtures only

## Validation

- [x] `fvm dart analyze` (clean)
- [x] Both profiles generate and parse (`inspect.dart`: 2 ok, 0 failed)
- [x] Full-scale `faithful` output profiled against the real file — matches on image count, pixel total, colorspace mix, SMask count, and decoded content size
- [x] `scenarios.json` valid JSON; `gen_perf_docs.sh` passes `bash -n`

## Notes for reviewers

Two calibrations are load-bearing and were found by measuring against the real file, not by inspection:

- **The RGB tile generator originally filled tiles with an `x ^ y` gradient.** That is high-entropy noise: it deflated to ~6 MB per tile against the real ~42 KB average, making the fixture **~12x too large** and quietly turning a Flate-decode benchmark into a memory-bandwidth one. Tiles are now near-white paper with sparse linework — what a scan actually compresses to (46 KB/tile). There is a comment saying so, because the "realistic-looking" noise version is the tempting one.
- **Default `ops` is 500k, not the wide-strip fixture's 850k.** These primitives are wordier; 850k overshot the profiled content size by ~70% (42 MB vs 24.75 MB decoded). 500k lands at 24.80 MB.

`gen_perf_docs.sh` **skips** rather than fails the mixed profile when `cjpeg`/`opj_compress` are absent, so a plain run still succeeds on a machine without them; the scenario is marked `ciSafe: false` and pre-seeded like `image-heavy`.

Split out of #417, which is now the `pageIndexOf` change alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHF8boHzZGxFNijgPRSuaX
