### PR TITLE
fix(editor): stop a failed deep-zoom detail render from stranding the full-image refinement

### DIFF
--- a/doc/dev-log/2026-07-20-vector-first-detail-strand.md
+++ b/doc/dev-log/2026-07-20-vector-first-detail-strand.md
@@ -1,0 +1,72 @@
+# A failed deep-zoom detail render stranded the full-image refinement
+
+## Symptom
+
+On a deep-zoomed page (a dense CAD sheet at several hundred percent) the
+document sometimes got stuck on its blurry, resolution-capped base raster and
+would not sharpen at all. Opening the browser devtools (F12) reliably fixed it.
+
+## Why F12 "fixed" it
+
+The devtools panel docks beside the viewer body in a `Row`, so opening it
+relays the viewer out narrower (see
+`2026-07-18-devtools-and-cache-ceiling.md`). That width change trips
+`_PdfPageViewState._noteLayoutWidth`, which posts a fresh `_render()` after the
+frame. Any relayout would do it - F12 is just the convenient trigger. So the
+page *could* render sharp; something was dropping the render that should have
+happened when the zoom settled, and only an unrelated `_render()` recovered it.
+
+## Root cause
+
+`deferFullRenderUntilDetailPaint` (default on) has a cold deep-zoom page paint
+its lightweight visible-region detail patch *before* it interprets the full
+image record, so the sharp slice lands first and the heavy full decode does not
+start under the main thread's detail work. `_renderNow` implements this by
+awaiting a `paintReady` completer that `_paintVectorFirst` wires up:
+
+```dart
+final paintReady = Completer<bool>();
+final detailFuture = _updateDetail(detailGeometry: ..., onPaint: () {
+  if (!paintReady.isCompleted) paintReady.complete(true);
+});
+_progressiveDetailFuture = paintReady.future;
+unawaited(detailFuture.then((ready) {                 // no onError!
+  if (!paintReady.isCompleted) paintReady.complete(ready);
+}));
+```
+
+`_updateDetail` can *throw* - a worker record that errors, a region raster that
+fails, an OOM on web. The `.then` had **no `onError`**, so a thrown detail left
+`paintReady` uncompleted forever. `_renderNow`'s `await progressiveDetail` then
+hung, the full-image record behind it never ran, `_picture` stayed null, and the
+page never sharpened until an external relayout kicked a new `_render` (which,
+with `_progressiveDetailFuture` already cleared and a soft preview usually
+present, skips the vector-first defer and interprets the full record directly -
+exactly the F12 recovery).
+
+The failure only bites when `onPaint` had not already fired, i.e. the local
+vector rasterize was skipped because an image draw overlaps the visible region
+(`_imagesIntersectRegion`) - the CAD-sheet case where the detail must come from
+the worker.
+
+## Fix (`pdf_page_view.dart`)
+
+1. Complete `paintReady` on error too: `detailFuture.then(onValue, onError:)`
+   treats a failed detail as "not ready" and lets the full pass proceed. The
+   deferral is an optimization, never a correctness gate.
+2. Defensive hygiene: read and clear `_progressiveDetailFuture` in `_renderNow`
+   *before* the supersession early-return, so a newer generation can never
+   inherit a stale progressive-detail future from an abandoned paint.
+
+## Test
+
+`test/vector_first_detail_error_test.dart` builds a full-page-image page (every
+detail region intersects the image, forcing the worker detail path), drives it
+at scale 8 through a worker that fails the pre-full-record region detail, and
+asserts the full-page image record still starts and the sharp base raster lands
+- no relayout needed. It times out (the strand) on the pre-fix code and passes
+after. The failure is modelled as transient (detail records after the full
+record escapes the strand are allowed through) because in production
+`_renderNow` runs under the render scheduler's try/catch, so a *persistently*
+failing detail just fails silently - it is the deferred full render that must
+never be starved.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -1151,9 +1151,22 @@ class _PdfPageViewState extends State<PdfPageView> {
       );
       _progressiveDetailFuture = paintReady.future;
       unawaited(
-        detailFuture.then((ready) {
-          if (!paintReady.isCompleted) paintReady.complete(ready);
-        }),
+        detailFuture.then(
+          (ready) {
+            if (!paintReady.isCompleted) paintReady.complete(ready);
+          },
+          // A detail render that throws (worker error, region raster failure,
+          // web OOM) must still complete this completer. deferFullRenderUntil-
+          // DetailPaint has _renderNow await paintReady before it interprets
+          // the full image record; a swallowed error here would leave that
+          // await hanging forever, so the page's blurry base raster never
+          // sharpens until an unrelated relayout (opening devtools, a window
+          // resize) fires a fresh _render. Treat a failed detail as "not
+          // ready" and let the full pass proceed.
+          onError: (Object _, StackTrace __) {
+            if (!paintReady.isCompleted) paintReady.complete(false);
+          },
+        ),
       );
       return;
     }
@@ -1269,9 +1282,13 @@ class _PdfPageViewState extends State<PdfPageView> {
         (widget.renderWorker?.isActive ?? false);
     if (firstInterpret && (!previewFresh || needsRegionBootstrap)) {
       await _paintVectorFirst(generation, pageIndex);
-      if (_superseded(generation, pageIndex)) return;
+      // Read and clear before the supersession check: whenever _paintVectorFirst
+      // armed a progressive-detail future, this render must consume it so a
+      // newer generation can never inherit a stale future belonging to an
+      // already-abandoned paint.
       final progressiveDetail = _progressiveDetailFuture;
       _progressiveDetailFuture = null;
+      if (_superseded(generation, pageIndex)) return;
       if (PdfPageView.deferFullRenderUntilDetailPaint &&
           progressiveDetail != null) {
         final detailReady = await progressiveDetail;

--- a/packages/dart_pdf_editor/test/vector_first_detail_error_test.dart
+++ b/packages/dart_pdf_editor/test/vector_first_detail_error_test.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart' show PdfRenderCommand;
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+Future<void> _waitUntil(
+  WidgetTester tester,
+  bool Function() predicate, {
+  String label = 'condition',
+}) async {
+  for (var i = 0; i < 400; i++) {
+    await tester.pump();
+    final exception = tester.takeException();
+    if (exception != null) fail('$label failed: $exception');
+    if (predicate()) return;
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 10)));
+  }
+  fail('$label did not arrive');
+}
+
+/// A page whose single image covers the whole MediaBox, so every deep-zoom
+/// detail region intersects an image draw. That forces the vector-first detail
+/// patch through the worker (the local vector rasterize is skipped when an
+/// image overlaps the region), which is exactly the path whose failure used to
+/// strand the deferred full-image render.
+Uint8List _fullPageImagePdf() {
+  final font = buildTestTrueTypeFont();
+  const content = 'q 612 0 0 792 0 0 cm '
+      'BI /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 '
+      '/Filter /ASCIIHexDecode ID E0E8FF> EI Q '
+      'BT /F1 24 Tf 72 700 Td 0 0 0 rg (AB) Tj ET';
+  final bodies = <Uint8List>[
+    ascii('<< /Type /Catalog /Pages 2 0 R >>'),
+    ascii('<< /Type /Pages /Kids [3 0 R] /Count 1 >>'),
+    ascii('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>'),
+    ascii('<< /Length ${content.length} >>\nstream\n$content\nendstream'),
+    ascii('<< /Type /Font /Subtype /TrueType /BaseFont /TestFont '
+        '/FirstChar 65 /LastChar 66 /Widths [600 1000] '
+        '/Encoding /WinAnsiEncoding /FontDescriptor 7 0 R >>'),
+    (BytesBuilder()
+          ..add(ascii('<< /Length ${font.length} /Length1 ${font.length} >>'
+              '\nstream\n'))
+          ..add(font)
+          ..add(ascii('\nendstream')))
+        .takeBytes(),
+    ascii('<< /Type /FontDescriptor /FontName /TestFont /Flags 32 '
+        '/FontBBox [0 0 1000 1000] /ItalicAngle 0 /Ascent 800 '
+        '/Descent -200 /CapHeight 800 /StemV 80 /FontFile2 6 0 R >>'),
+  ];
+  final out = BytesBuilder()..add(ascii('%PDF-1.4\n'));
+  final offsets = <int>[];
+  for (var i = 0; i < bodies.length; i++) {
+    offsets.add(out.length);
+    out.add(ascii('${i + 1} 0 obj\n'));
+    out.add(bodies[i]);
+    out.add(ascii('\nendobj\n'));
+  }
+  final xrefOffset = out.length;
+  final buffer = StringBuffer()
+    ..write('xref\n0 ${bodies.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${bodies.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  out.add(ascii(buffer.toString()));
+  return out.takeBytes();
+}
+
+void main() {
+  testWidgets(
+      'a failed deep-zoom detail render still lets the full image record land',
+      (tester) async {
+    // The single detail patch (not the tile pyramid) is the path a dense
+    // deep-zoom page takes when the pyramid is off; pin it so the region
+    // record whose failure we are exercising is actually requested.
+    final wasTiles = PdfPageView.tileStoreDetail;
+    final wasDefer = PdfPageView.deferFullRenderUntilDetailPaint;
+    PdfPageView.tileStoreDetail = false;
+    PdfPageView.deferFullRenderUntilDetailPaint = true;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = wasTiles;
+      PdfPageView.deferFullRenderUntilDetailPaint = wasDefer;
+    });
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = _fullPageImagePdf();
+    final page = PdfDocument.open(bytes).page(0);
+    final worker = _FailingDetailWorker(PdfRenderWorker.startUncached(bytes));
+    addTearDown(worker.dispose);
+
+    await tester.pumpWidget(Center(
+      child: SizedBox(
+        width: 612,
+        child: PdfPageView(
+          page: page,
+          scale: 8,
+          renderWorker: worker,
+        ),
+      ),
+    ));
+
+    // The visible region record fails (the worker throws). Before the fix the
+    // deferred full render awaited the detail paint forever, so this never ran
+    // and the page stayed on its blurry base raster. It must now warm.
+    await _waitUntil(tester, () => worker.fullRecordStarted.isCompleted,
+        label: 'full image record after a failed detail render');
+    expect(worker.detailRecordFailed, isTrue,
+        reason: 'the regression requires the detail render to have failed');
+
+    // The sharp full-page base raster lands - the page recovered without any
+    // external relayout (opening devtools, resizing) to kick it.
+    await _waitUntil(
+      tester,
+      () => find.byType(RawImage).evaluate().isNotEmpty,
+      label: 'sharp base raster',
+    );
+  });
+}
+
+/// Delegates the cheap vector-first record but fails every image-decode-region
+/// (deep-zoom detail) record, while signalling when the ordinary full-page
+/// image record starts.
+class _FailingDetailWorker extends PdfRenderWorker {
+  _FailingDetailWorker(this._inner);
+
+  final PdfRenderWorker _inner;
+  final fullRecordStarted = Completer<void>();
+  bool detailRecordFailed = false;
+
+  @override
+  bool get isActive => _inner.isActive;
+
+  // The deep-zoom detail record that fires from the vector-first pass, before
+  // the full-page image record: failing it is what used to strand the deferred
+  // full render. A real failure is transient, so detail records that fire after
+  // the full record has escaped the strand are allowed through (otherwise the
+  // full pass's own detail refresh would throw uncaught here).
+  bool get _detailShouldFail => !fullRecordStarted.isCompleted;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true,
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) {
+    if (decodeImages && imageDecodeRegion != null && _detailShouldFail) {
+      detailRecordFailed = true;
+      return Future.error(StateError('detail record failed'));
+    }
+    if (decodeImages && imageDecodeRegion == null) {
+      if (!fullRecordStarted.isCompleted) fullRecordStarted.complete();
+    }
+    return _inner.record(pageIndex,
+        annotations: annotations,
+        priority: priority,
+        imagePixelRatio: imagePixelRatio,
+        decodeImages: decodeImages,
+        commandLimit: commandLimit,
+        imageDecodeRegion: imageDecodeRegion);
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) =>
+      _inner.cancel(pageIndex, priority: priority);
+
+  @override
+  Future<StripPlan?> binStrips(int pageIndex,
+          {required bool annotations,
+          required List<double> pageToDevice,
+          required int deviceWidth,
+          required int deviceHeight,
+          required double pixelRatio,
+          bool slugGlyphs = false,
+          int priority = 0}) =>
+      _inner.binStrips(pageIndex,
+          annotations: annotations,
+          pageToDevice: pageToDevice,
+          deviceWidth: deviceWidth,
+          deviceHeight: deviceHeight,
+          pixelRatio: pixelRatio,
+          slugGlyphs: slugGlyphs,
+          priority: priority);
+
+  @override
+  Future<PdfStripDetail?> recordStripDetail(int pageIndex,
+      {required bool annotations,
+      required List<double> pageToDevice,
+      required int deviceWidth,
+      required int deviceHeight,
+      required double pixelRatio,
+      required PdfRect imageDecodeRegion,
+      int priority = 0}) {
+    if (_detailShouldFail) {
+      detailRecordFailed = true;
+      return Future.error(StateError('strip detail record failed'));
+    }
+    return _inner.recordStripDetail(pageIndex,
+        annotations: annotations,
+        pageToDevice: pageToDevice,
+        deviceWidth: deviceWidth,
+        deviceHeight: deviceHeight,
+        pixelRatio: pixelRatio,
+        imageDecodeRegion: imageDecodeRegion,
+        priority: priority);
+  }
+
+  @override
+  void cancelBinStrips(int pageIndex, {int priority = 0}) =>
+      _inner.cancelBinStrips(pageIndex, priority: priority);
+
+  @override
+  void dispose() => _inner.dispose();
+}


### PR DESCRIPTION
## Summary

Fixes the bug where a deep-zoomed page (a dense CAD sheet at several hundred
percent) would sometimes get stuck on its blurry, resolution-capped base raster
and refuse to sharpen — until opening the browser devtools (F12) or otherwise
relaying out the viewer kicked it loose.

`deferFullRenderUntilDetailPaint` (default on) has `_renderNow` await a
`paintReady` completer before it interprets the full image record, so the sharp
visible slice lands first and the heavy full decode doesn't start under the main
thread's detail work. `_paintVectorFirst` completed that completer from
`detailFuture.then(...)` — but the callback had **no `onError`**. When
`_updateDetail` threw (a worker record that errors, a region raster failure, a
web OOM), `paintReady` was never completed, `_renderNow`'s `await
progressiveDetail` hung forever, the full-image record behind it never ran, and
`_picture` stayed null. The page never sharpened until an unrelated relayout
posted a fresh `_render` — which, with `_progressiveDetailFuture` already
cleared and a soft preview present, skips the vector-first defer and interprets
the full record directly. That is exactly the "F12 fixes it" behavior (the
devtools panel docks beside the viewer in a `Row`, so opening it relays the
viewer out narrower → `_noteLayoutWidth` → a new `_render`).

The fix:

1. Complete `paintReady` on error too — a failed detail is treated as "not
   ready" and the full pass proceeds. The deferral is an optimization, never a
   correctness gate.
2. Read and clear `_progressiveDetailFuture` before the supersession
   early-return in `_renderNow`, so a newer generation can never inherit a stale
   progressive-detail future from an abandoned paint.

Background write-up: `doc/dev-log/2026-07-20-vector-first-detail-strand.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (changed files — no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (new regression test plus the surrounding render/zoom/session suites: `vector_first_detail_error_test`, `web_slug_mixed_page_test`, `render_hold_test`, `zoom_latency_test`, `pdf_page_view_test`, `page_render_session_test`)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: this is a control-flow fix in
the page-view render session; no rendering output, filters, or COS/parse paths
change, so the corpus/Ghent baselines and example-app smoke are not implicated.

## PDF fixtures and screenshots

The new test builds its fixture programmatically (a full-page-image page, so
every deep-zoom detail region intersects an image draw and the detail must come
from the worker), driven at scale 8 through a worker that fails the
pre-full-record region detail. It asserts the full-page image record still warms
and the sharp base raster lands with no relayout. It times out (the strand) on
the pre-fix code and passes after.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The regression is modelled as a *transient* detail failure (detail records that
fire after the full record escapes the strand are allowed through). This mirrors
production, where `_renderNow` runs under the render scheduler's `try/catch`, so
a *persistently* failing detail just fails silently — it is the deferred full
render that must never be starved, which is what this PR guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuNWvFJnu5pGPcCSGwPD5G)_