### PR TITLE
fix(editor): give each render its own vector-first detail completer (#420)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -415,7 +415,6 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   ui.Image? _detailImage;
   Rect? _detailFraction; // patch placement as fractions of the page
-  Future<bool>? _progressiveDetailFuture;
 
   /// Visible slice (fraction of the page) and desired ratio for the
   /// [PdfPageView.tileStoreDetail] tile layer, recomputed on each settle in
@@ -1056,9 +1055,10 @@ class _PdfPageViewState extends State<PdfPageView> {
   ///
   /// When the page draws no images the fast buffer is the whole page, so it is
   /// cached as [_picture] for the full pass to reuse - no second record.
-  Future<void> _paintVectorFirst(int generation, int pageIndex) async {
+  Future<Completer<bool>?> _paintVectorFirst(
+      int generation, int pageIndex) async {
     final worker = widget.renderWorker;
-    if (worker == null || !worker.isActive) return;
+    if (worker == null || !worker.isActive) return null;
     // A zoomed, visible page's lightweight transcript is the prerequisite for
     // its sharp region. Give it a clear lead over ordinary neighbouring-page
     // work so it preempts the pool instead of being cancelled and requeued as
@@ -1076,7 +1076,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (_superseded(generation, pageIndex) ||
         _renderPaused ||
         commands == null) {
-      return;
+      return null;
     }
 
     final retainScene = _retainScene(commands);
@@ -1095,7 +1095,7 @@ class _PdfPageViewState extends State<PdfPageView> {
         );
         if (_superseded(generation, pageIndex)) {
           scene.dispose();
-          return;
+          return null;
         }
         _setScene(scene, fromWorker: true);
         _picture = Future.value(scene.replay(pixelRatio: 1));
@@ -1106,7 +1106,7 @@ class _PdfPageViewState extends State<PdfPageView> {
           _renderPlan,
         );
       }
-      return;
+      return null;
     }
 
     // In a zoomed view the visible region can sharpen without waiting
@@ -1134,7 +1134,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       );
       if (_superseded(generation, pageIndex) || _renderPaused) {
         scene.dispose();
-        return;
+        return null;
       }
       _setScene(scene, fromWorker: true, vectorOnly: true);
       // Keep the already-painted soft preview as the base and sharpen the
@@ -1149,7 +1149,6 @@ class _PdfPageViewState extends State<PdfPageView> {
           if (!paintReady.isCompleted) paintReady.complete(true);
         },
       );
-      _progressiveDetailFuture = paintReady.future;
       unawaited(
         detailFuture.then(
           (ready) {
@@ -1168,7 +1167,7 @@ class _PdfPageViewState extends State<PdfPageView> {
           },
         ),
       );
-      return;
+      return paintReady;
     }
 
     final picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
@@ -1179,7 +1178,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     );
     if (_superseded(generation, pageIndex) || _renderPaused) {
       picture.dispose();
-      return;
+      return null;
     }
     final vectorRatio = _vectorFirstRatio();
     final image = await PdfPageRenderer.rasterize(
@@ -1201,7 +1200,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     // resolution-unchanged guard - it must re-raster to bring the images in.
     if (_superseded(generation, pageIndex) || _rasteredRatio != null) {
       image.dispose();
-      return;
+      return null;
     }
     setState(() {
       _image?.dispose();
@@ -1210,6 +1209,9 @@ class _PdfPageViewState extends State<PdfPageView> {
       _preview = null;
     });
     PdfPerfLog.log('vector-first page=$pageIndex${PdfPerfLog.rssSuffix()}');
+    // This path rasterized a full-page vector preview instead of arming a
+    // region detail, so there is nothing for the caller to wait on.
+    return null;
   }
 
   /// Reports, when the perf log is on, how many images a worker buffer carries
@@ -1281,17 +1283,19 @@ class _PdfPageViewState extends State<PdfPageView> {
         _scene == null &&
         (widget.renderWorker?.isActive ?? false);
     if (firstInterpret && (!previewFresh || needsRegionBootstrap)) {
-      await _paintVectorFirst(generation, pageIndex);
-      // Read and clear before the supersession check: whenever _paintVectorFirst
-      // armed a progressive-detail future, this render must consume it so a
-      // newer generation can never inherit a stale future belonging to an
-      // already-abandoned paint.
-      final progressiveDetail = _progressiveDetailFuture;
-      _progressiveDetailFuture = null;
+      // The armed detail completer is returned, not parked in a field. Renders
+      // are not serialized - PdfPageRenderScheduler invokes render() without
+      // awaiting it (render_scheduler.dart, "starts one page render this
+      // frame") and only de-duplicates *pending* requests, so two _renderNow
+      // passes for one page can interleave. With shared state, whichever pass
+      // read the field last either inherited a future belonging to an
+      // abandoned paint or stole the live pass's own. A local keeps each pass
+      // with exactly the completer it armed.
+      final progressiveDetail = await _paintVectorFirst(generation, pageIndex);
       if (_superseded(generation, pageIndex)) return;
       if (PdfPageView.deferFullRenderUntilDetailPaint &&
           progressiveDetail != null) {
-        final detailReady = await progressiveDetail;
+        final detailReady = await progressiveDetail.future;
         if (_superseded(generation, pageIndex)) return;
         if (detailReady) {
           PdfPerfLog.log('full refine waits for detail paint page=$pageIndex');


### PR DESCRIPTION
## Summary

Follow-up to #420, from a post-merge review. **#420's `onError` fix is the real bug fix and stands untouched** — this revisits only its second change: moving the `_progressiveDetailFuture` read/clear ahead of the supersession early-return.

## Why the reorder isn't safe as written

It assumes two renders for one page can't overlap. They can:

- `PdfPageRenderScheduler` invokes `next.render()` **without awaiting it** (`render_scheduler.dart:106` — *"starts one page render this frame"*).
- Its de-duplication covers only **pending** requests (`request()` scans `_pending`), not one already running.

So a second `_renderNow` can start while the first is still awaiting, and they interleave across the microtask gap after `_paintVectorFirst` returns.

With `_progressiveDetailFuture` shared between them, the reorder swaps one hazard for its mirror image:

| | hazard |
|---|---|
| **before #420** | a new pass inherits a future from an abandoned paint |
| **after #420** | an already-superseded pass reads and clears the **live** pass's future, so the live pass sees `null` and skips the vector-first defer entirely |

The second is not a correctness bug — the full render still runs — but it quietly disables the very optimization the change exists to protect. And #420's `onError` fix already guarantees the future always completes, which removes most of the original rationale: inheriting a stale-but-completed future is at worst a spurious "ready", never the hang that #420 fixed.

## The fix

`_progressiveDetailFuture` had **exactly one writer and one reader** — it was a return value smuggled through a field.

`_paintVectorFirst` now returns the `Completer<bool>` it armed (null when it took the full-page-preview path or bailed early), the field is deleted, and the supersession check goes back to running first. With no shared state, there is nothing to race on: neither pass can see the other's completer.

Returning the completer rather than the future is deliberate — an `async` function returning `Future<Future<bool>?>` would flatten the inner future on `return`.

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [x] Bug fix
- [x] Refactor / cleanup

## Validation

- [x] `fvm dart analyze` (clean)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 1780 pass, only the pre-existing `ghent GWG030` baseline failure
- [x] **#420's regression test still catches the original bug**: removing the `onError` handler makes `vector_first_detail_error_test` fail with *"full image record after a failed detail render did not arrive"*, exactly as before this change

## Notes for reviewers

The mutation check above is the important one. This refactor moves the plumbing #420's fix runs through, so the thing to confirm is that its coverage survives — it does, verified by deleting the handler and watching the test strand.

No behaviour change is intended for the single-render case, which is the overwhelmingly common one; this only removes the cross-render interference window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHF8boHzZGxFNijgPRSuaX
