### PR TITLE
feat(app): stamp the app version and build into the devtools export

### DIFF
--- a/app/lib/app_info.dart
+++ b/app/lib/app_info.dart
@@ -13,12 +13,18 @@ class AppInfo {
 
   static String version = '1.4.1';
 
+  /// Build number from the same artifact (`+18` in `2.0.0+18`). Empty when
+  /// unavailable. Kept separate from [version] because two builds of one
+  /// version are otherwise indistinguishable in a diagnostics export.
+  static String buildNumber = '';
+
   /// Populates [version] from the platform package metadata. Best-effort: any
   /// failure leaves the fallback in place.
   static Future<void> load() async {
     try {
       final info = await PackageInfo.fromPlatform();
       if (info.version.isNotEmpty) version = info.version;
+      buildNumber = info.buildNumber;
     } catch (_) {
       // Keep the fallback; the About box is non-critical.
     }

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -13,6 +13,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+import 'app_info.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show debugRepaintRainbowEnabled;
@@ -220,6 +222,11 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
     final snapshot = <String, Object?>{
       'tool': 'dartpdf-devtools',
       'exportedAt': DateTime.now().toIso8601String(),
+      // Which build produced this export. Without it a report cannot be tied
+      // to a revision - "slow on 2.0.0" is unactionable when several builds
+      // share that version.
+      'appVersion': AppInfo.version,
+      'appBuild': AppInfo.buildNumber,
       'platform': kIsWeb ? 'web' : defaultTargetPlatform.name,
       'buildMode': kDebugMode
           ? 'debug'


### PR DESCRIPTION
## Summary

A devtools JSON export carried `platform` and `buildMode` but nothing identifying **which build produced it**. That made a field report like "slow on 2.0.0" unactionable — and it is worse than it sounds, because `app/pubspec.yaml` has sat at `2.0.0+18` across everything merged since the release build, so the version alone does not distinguish a shipped release from a build off current main.

`AppInfo` already loads the version from `PackageInfo` for the About box; it now also keeps the build number, and the export carries both as `appVersion` and `appBuild`.

## Affected packages

- [x] Example app

## Change type

- [x] Feature

## Validation

- [x] `fvm dart analyze` (clean)
- [x] `cd app && fvm flutter test` (239 pass)

## Notes for reviewers

`version` and `buildNumber` are kept as **separate** fields rather than one `2.0.0+18` string, deliberately: `UpdateService` compares `AppInfo.version` against published release versions (`update.dart:190`, `editor_screen.dart:167`) and must not start seeing a build suffix. Nothing else changes about how the version is displayed or compared.

Prompted by a Windows field report where the export could not be tied to a revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHF8boHzZGxFNijgPRSuaX