### PR TITLE
fix(editor): scope tile invalidation to the pages it names (#374)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -279,9 +279,17 @@ class PdfTileStore extends ChangeNotifier {
 
   /// Invalidation epochs: a tile whose page was invalidated after its raster
   /// was dispatched is discarded on completion (mirrors the render worker's
-  /// stale-inflight guard). [_globalEpoch] rises on every invalidation;
-  /// [_pageEpoch] records the epoch at which each page was last invalidated.
-  int _globalEpoch = 0;
+  /// stale-inflight guard).
+  ///
+  /// [_epochCounter] only stamps dispatches and invalidations in order - it is
+  /// deliberately NOT the staleness test. Only [_allPagesEpoch] (raised by a
+  /// full [invalidate]) and [_pageEpoch] (per page slot) make a tile stale, so
+  /// a targeted invalidation cannot reach across pages. That distinction is
+  /// load-bearing: the page view invalidates its own slot on every live
+  /// transform tick, and a shared counter would make each of those ticks throw
+  /// away every other live page's in-flight rasters (issue #374).
+  int _epochCounter = 0;
+  int _allPagesEpoch = -1;
   final Map<int, int> _pageEpoch = {};
 
   bool _tickScheduled = false;
@@ -595,7 +603,7 @@ class PdfTileStore extends ChangeNotifier {
       pending.add(key);
       return;
     }
-    final dispatchEpoch = _globalEpoch;
+    final dispatchEpoch = _epochCounter;
     rasterize(region, ratio).then((image) {
       _inFlight.remove(key);
       if (_disposed || _isStale(id.pageIndex, dispatchEpoch)) {
@@ -680,7 +688,7 @@ class PdfTileStore extends ChangeNotifier {
             (tyMax - tyMin + 1) * span),
         pageSize);
 
-    final dispatchEpoch = _globalEpoch;
+    final dispatchEpoch = _epochCounter;
     debugBatchesDispatched++;
     rasterize(batchRegion, ratio).then((slab) {
       for (final key in batch) {
@@ -745,7 +753,7 @@ class PdfTileStore extends ChangeNotifier {
   }
 
   bool _isStale(int pageIndex, int dispatchEpoch) =>
-      _globalEpoch > dispatchEpoch ||
+      _allPagesEpoch > dispatchEpoch ||
       (_pageEpoch[pageIndex] ?? -1) > dispatchEpoch;
 
   /// Drops retained (and in-flight) tiles. With [pages] null every tile is
@@ -754,12 +762,13 @@ class PdfTileStore extends ChangeNotifier {
   /// rasters for the affected pages are discarded on completion.
   void invalidate({Set<int>? pages}) {
     if (_disposed) return;
-    _globalEpoch++;
+    final epoch = ++_epochCounter;
     if (pages == null) {
+      _allPagesEpoch = epoch;
       _cache.clear();
     } else {
       for (final page in pages) {
-        _pageEpoch[page] = _globalEpoch;
+        _pageEpoch[page] = epoch;
       }
       _cache.evictWhere((key) => pages.contains(key.id.pageIndex));
     }

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -284,10 +284,14 @@ class PdfTileStore extends ChangeNotifier {
   /// [_epochCounter] only stamps dispatches and invalidations in order - it is
   /// deliberately NOT the staleness test. Only [_allPagesEpoch] (raised by a
   /// full [invalidate]) and [_pageEpoch] (per page slot) make a tile stale, so
-  /// a targeted invalidation cannot reach across pages. That distinction is
-  /// load-bearing: the page view invalidates its own slot on every live
-  /// transform tick, and a shared counter would make each of those ticks throw
-  /// away every other live page's in-flight rasters (issue #374).
+  /// a targeted invalidation cannot reach across pages.
+  ///
+  /// That distinction is load-bearing. `_PdfPageViewState._updateDetail` drops
+  /// its detail - and so invalidates its own slot - whenever
+  /// `_detailGeometryAt` returns null, which includes every page scrolled off
+  /// screen. With a shared counter, each settle of an off-screen page threw
+  /// away the in-flight tiles of the page actually being panned (issue #374;
+  /// measured at a 55% discard rate in issue #427).
   int _epochCounter = 0;
   int _allPagesEpoch = -1;
   final Map<int, int> _pageEpoch = {};

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -340,9 +340,9 @@ void main() {
         expect(store.inFlightCount, 8);
 
         // A targeted invalidation must not reach across pages. The page view
-        // fires this on every live transform tick, so a global stale check
-        // throws away the neighbouring page's in-flight work during the very
-        // pan that scheduled it (issue #374's discard rate).
+        // invalidates its own slot whenever its detail geometry resolves to
+        // null, so a global stale check throws away the neighbouring page's
+        // in-flight work during the very pan that scheduled it (#374).
         store.invalidate(pages: {0});
         await raster.flush();
 
@@ -407,6 +407,42 @@ void main() {
         await raster.flush();
         expect(store.tileCount, greaterThan(0));
         store.invalidate();
+        expect(store.tileCount, 0);
+        store.dispose();
+      });
+    });
+
+    testWidgets('null discards in-flight rasters on every page',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        for (var page = 0; page < 2; page++) {
+          store.viewFor(
+            id: _id(page),
+            pageSize: const Size(32, 32),
+            desiredRatio: 1.0,
+            visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+            rasterize: raster.call,
+          );
+        }
+        expect(store.inFlightCount, 8);
+
+        // The counterpart to the targeted cases above: a full invalidation
+        // reaches every page, including slots _pageEpoch has never seen. This
+        // is the only cover for the _allPagesEpoch arm of _isStale - the
+        // 'null clears every page' test flushes before invalidating, so it
+        // exercises cache clearing and never the in-flight guard.
+        store.invalidate();
+        await raster.flush();
+
+        expect(store.debugTilesDiscarded, 8);
+        expect(store.debugTilesLanded, 0);
         expect(store.tileCount, 0);
         store.dispose();
       });

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -318,6 +318,76 @@ void main() {
       });
     });
 
+    testWidgets('keeps in-flight rasters for the pages it did not invalidate',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+        for (var page = 0; page < 2; page++) {
+          store.viewFor(
+            id: _id(page),
+            pageSize: const Size(32, 32),
+            desiredRatio: 1.0,
+            visiblePageRect: const Rect.fromLTWH(0, 0, 32, 32),
+            rasterize: raster.call,
+          );
+        }
+        expect(store.inFlightCount, 8);
+
+        // A targeted invalidation must not reach across pages. The page view
+        // fires this on every live transform tick, so a global stale check
+        // throws away the neighbouring page's in-flight work during the very
+        // pan that scheduled it (issue #374's discard rate).
+        store.invalidate(pages: {0});
+        await raster.flush();
+
+        expect(store.debugTilesDiscarded, 4, reason: 'only page 0');
+        expect(store.debugTilesLanded, 4, reason: 'page 1 survives');
+        expect(store.containsTile(PdfTileKey(_id(1), 0, 0, 0)), isTrue);
+        store.dispose();
+      });
+    });
+
+    testWidgets('an off-screen neighbour settling does not starve the panned '
+        'page', (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+
+        // The shape of issue #427's session: page 0 is zoomed and panning, so
+        // each settle schedules its visible tiles; page 1 is scrolled off
+        // screen, so _detailGeometryAt returns null every settle and the page
+        // view drops its detail - invalidating only its own slot.
+        for (var settle = 0; settle < 8; settle++) {
+          store.viewFor(
+            id: _id(0),
+            pageSize: const Size(64, 64),
+            desiredRatio: 1.0,
+            visiblePageRect: Rect.fromLTWH(settle * 4.0, 0, 32, 32),
+            rasterize: raster.call,
+          );
+          store.invalidate(pages: {1});
+        }
+        await raster.flush();
+
+        expect(store.debugTilesScheduled, greaterThan(0));
+        expect(store.debugTilesDiscarded, 0,
+            reason: 'page 1 never had tiles; page 0 was never invalidated');
+        expect(store.debugTilesLanded, store.debugTilesScheduled);
+        store.dispose();
+      });
+    });
+
     testWidgets('null clears every page', (tester) async {
       await tester.runAsync(() async {
         final store = PdfTileStore(


### PR DESCRIPTION
## What

`PdfTileStore.invalidate(pages:)` documents that only the named page slots' in-flight rasters are discarded. It didn't behave that way: `_isStale` also tested a shared `_globalEpoch` that *every* invalidation bumped, so any targeted invalidation threw away every other page's in-flight tiles.

## Why it matters

This is not a rare edge case — it fires throughout ordinary deep-zoom reading.

`_PdfPageViewState._updateDetail` calls `_dropDetail()` whenever `_detailGeometryAt` returns null, and that includes **any page scrolled off screen** (`pdf_page_view.dart:1894` returns null on an empty visible rect). `_dropDetail()` invalidates that page's tile slot.

So on a two-page document, every settle of the **off-screen** page discarded the tile batch in flight for the page the user was actually panning. The more you pan, the more the other page starves you.

This is the concrete mechanism behind the discard rate reported in #427: **4,696 of 8,495 scheduled tiles (55%) discarded** in one session on a 2-page drawing. Each discarded tile still paid for its raster.

## The fix

Split the ordering counter from the staleness test:

- `_epochCounter` — monotonic, stamps dispatches and invalidations in order. Deliberately *not* the staleness test.
- `_allPagesEpoch` — raised only by a full `invalidate()`.
- `_pageEpoch` — per page slot, as before.

A targeted invalidation can no longer reach across pages. `invalidate()` with no argument is unchanged.

## Tests

Two new tests, **both fail on main and pass here**:

- `keeps in-flight rasters for the pages it did not invalidate` — two pages with 4 tiles each in flight, `invalidate(pages: {0})`. Main discards **8**; expected and now actual is **4**.
- `an off-screen neighbour settling does not starve the panned page` — replays #427's session shape (8 pan settles on page 0 interleaved with page 1's off-screen invalidations). Main discards tiles on every settle; now **0 discarded, all scheduled tiles land**.

Full `dart_pdf_editor` suite: 1775 pass, only the pre-existing `ghent_render_test` GWG030 failure, identical to main. `dart analyze` clean.

## Scope

This addresses the discard half of #427. The memory half (#405's global live-raster budget) is untouched and still open — see the note I'll add to #427.

Refs #374, #427.