### PR TITLE
feat(viewer): make scroll indicators and scrubbers axis-aware (#428)

### DIFF
--- a/doc/dev-log/2026-07-20-axis-aware-scroll-indicator.md
+++ b/doc/dev-log/2026-07-20-axis-aware-scroll-indicator.md
@@ -1,0 +1,78 @@
+# Axis-aware scroll-indicator / page-scrubber API (issue #428)
+
+The public scroll-indicator API (`PdfViewer.scrollIndicatorBuilder`,
+`PdfScrollMetrics`, `PdfViewerController.jumpToNormalized`, from #326) was
+vertical-only: it hard-wired the vertical scroll axis, so a host that switched
+the viewer to `PdfPageLayout.horizontalContinuous` lost its custom bottom
+scrubber and fell back to the stock bar. This makes the whole API describe the
+viewer's **main layout axis** instead, so the same custom indicator works in
+both continuous layouts.
+
+All in `pdf_viewer.dart` (whole file is re-exported).
+
+## What changed
+
+- **`PdfScrollMetrics.scrollAxis`** - a new `Axis` field naming the main axis
+  (`Axis.vertical` for vertical continuous, `Axis.horizontal` for horizontal).
+  It defaults to `Axis.vertical` in the constructor, so existing const
+  construction stays source-compatible. Every other field (`position`,
+  `extent`, `pixels`, `maxPixels`, `viewportPixels`) is now documented as
+  main-axis rather than vertical; the numbers were already computed off the
+  main-axis scroll controller.
+- **`_verticalScrollExtents` → `_mainScrollExtents`.** The only genuinely
+  axis-bound line was the zoom-window unprojection: it read the transform's
+  **Y** translation (`storage[13]`) unconditionally. It now reads
+  `storage[_mainTranslate]` (13 for vertical, 12 for horizontal), reusing the
+  same main/cross axis plumbing the rest of the geometry/gesture code already
+  runs on (`_mainTranslate`, `_mainView`, `_pageMain`, …). Everything else -
+  `position.pixels`, `maxScrollExtent`, `viewportDimension` - already tracks
+  the scroll axis because the `ListView` scrolls along
+  `widget.pageLayout.scrollAxis`.
+- **The builder now fires in both layouts.** `build()` previously gated the
+  indicator on `pageLayout.scrollAxis == Axis.vertical` and otherwise showed
+  the stock main bar. That gate is gone: when `scrollIndicatorBuilder != null`
+  it replaces the main bar (right edge vertical, bottom edge horizontal) via
+  the same `Positioned.fill(child: _buildScrollIndicator())`. The cross-axis
+  (zoom-window) bar is untouched.
+
+## Why it was almost a one-liner
+
+The viewer was already written in main/cross-axis terms (see the block comment
+above `_horizontal` in `pdf_viewer.dart`): vertical is the identity case
+(main = Y, cross = X), horizontal swaps them. `jumpToNormalized` routes through
+`_scrollbarScrollBy`, which already uses `_mainTranslate` for the zoom-window
+spillover, so normalized scrolling worked on the horizontal axis the moment
+the extents did. The metrics snapshot was the last place still hard-coding Y.
+
+## Host contract
+
+`scrollIndicatorBuilder` fills the viewer (`Positioned.fill`) in either
+layout, so the host positions/orients its own widget. It reads
+`metrics.scrollAxis` to decide: an `Alignment.centerRight` vertical track vs.
+an `Alignment.bottomCenter` horizontal one, and a vertical- vs.
+horizontal-drag recognizer. The drag recognizer must match the scroll axis
+(and be opaque) to win the gesture arena over the scroll view underneath - a
+`PanGestureRecognizer` would fight the scrollable ambiguously, so the demo
+uses `onVerticalDrag*`/`onHorizontalDrag*` picked by axis.
+
+## Tests
+
+- `test/scroll_indicator_test.dart` - value equality now covers `scrollAxis`
+  (and its vertical default); a new `horizontal layout` group asserts
+  `scrollAxis == Axis.horizontal`, main-axis position/extent tracking under a
+  horizontal scroll, `jumpToNormalized` along X (top/mid/bottom), and the
+  builder replacing the stock bar with horizontal metrics. The existing
+  vertical test now also pins `scrollAxis == Axis.vertical`. (Pumping two
+  viewers with different layouts in one test leaves the second's metrics null
+  for a frame - the axis assertions pump a single viewer each.)
+- `example/test/scroll_indicator_demo_test.dart` - a new case flips the demo
+  into horizontal via the app-bar toggle, checks the readout reports
+  `axis: horizontal`, and drags the now-bottom scrubber to scroll.
+
+## Example app demo
+
+`example/lib/scroll_indicator_demo.dart` gained a layout toggle in the app bar
+and an axis-aware `_PageScrubber` that re-orients from `metrics.scrollAxis`
+(right-edge track + vertical drag vs. bottom-edge track + horizontal drag),
+with the readout showing the live `axis`. It exercises the whole API in both
+layouts from one screen.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Make the viewer scroll-indicator API axis-aware: `PdfScrollMetrics` now
+  describes the viewer's **main layout axis** and carries an `Axis scrollAxis`
+  saying which. In `PdfPageLayout.horizontalContinuous`,
+  `PdfViewer.scrollIndicatorBuilder` replaces the stock bottom bar (not just
+  the right-edge bar in vertical layout), the metrics report the horizontal
+  position/extent/pixels, and `jumpToNormalized` moves along the horizontal
+  axis; the cross-axis (zoom-window) scrollbar is unchanged. Vertical behavior
+  is source-compatible (`scrollAxis` defaults to `Axis.vertical`) (#428).
 - Add X-strip transcript banding to bound retained memory on extreme-aspect
   pages (`PdfBandedTranscript`): partition a page's `PdfRenderCommand`
   transcript into N vertical strips along the horizontal pan axis, retain only

--- a/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
+++ b/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
@@ -4,15 +4,20 @@ import 'package:flutter/material.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
 /// A self-contained showcase of the viewer's public scroll-indicator API
-/// (issue #326): [PdfViewer.scrollIndicatorBuilder] fed by a live
+/// (issues #326 and #428): [PdfViewer.scrollIndicatorBuilder] fed by a live
 /// [PdfScrollMetrics], driven back with
 /// [PdfViewerController.jumpToNormalized] and
 /// [PdfViewerController.animateToPage].
 ///
 /// The built-in scrollbar is replaced with a draggable page scrubber that
 /// pops a page bubble while dragging, and a corner readout mirrors the raw
-/// metrics so the numbers are visible as you scroll and zoom. The app opens
-/// it as a full-screen route from the DartPDF menu.
+/// metrics so the numbers are visible as you scroll and zoom. A layout toggle
+/// flips the viewer between vertical and horizontal continuous reading; the
+/// same scrubber re-orients itself from [PdfScrollMetrics.scrollAxis] (a
+/// right-edge track vertically, a bottom-edge one horizontally), showing that
+/// the metrics and [PdfViewerController.jumpToNormalized] describe whichever
+/// axis is active. The app opens it as a full-screen route from the DartPDF
+/// menu.
 class ScrollIndicatorDemoScreen extends StatefulWidget {
   const ScrollIndicatorDemoScreen({super.key, required this.bytes});
 
@@ -27,6 +32,9 @@ class ScrollIndicatorDemoScreen extends StatefulWidget {
 class _ScrollIndicatorDemoScreenState extends State<ScrollIndicatorDemoScreen> {
   final _controller = PdfViewerController();
   late final PdfDocument _document = PdfDocument.open(widget.bytes);
+
+  /// The viewer's current continuous layout, flipped by the app-bar toggle.
+  PdfPageLayout _layout = const PdfPageLayout.verticalContinuous();
 
   /// The latest metrics the viewer handed to [scrollIndicatorBuilder]. The
   /// corner readout renders from this so it is populated the moment the
@@ -59,20 +67,39 @@ class _ScrollIndicatorDemoScreenState extends State<ScrollIndicatorDemoScreen> {
     _controller.animateToPage(target);
   }
 
+  void _toggleLayout() {
+    setState(() {
+      _layout = _layout.scrollAxis == Axis.vertical
+          ? const PdfPageLayout.horizontalContinuous()
+          : const PdfPageLayout.verticalContinuous();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    final horizontal = _layout.scrollAxis == Axis.horizontal;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Scroll indicator API'),
         actions: [
           IconButton(
+            tooltip: horizontal
+                ? 'Switch to vertical layout'
+                : 'Switch to horizontal layout',
+            icon: Icon(horizontal ? Icons.view_day : Icons.view_column),
+            onPressed: _toggleLayout,
+          ),
+          IconButton(
             tooltip: 'Previous page',
-            icon: const Icon(Icons.keyboard_arrow_up),
+            icon: Icon(
+                horizontal ? Icons.keyboard_arrow_left : Icons.keyboard_arrow_up),
             onPressed: () => _step(-1),
           ),
           IconButton(
             tooltip: 'Next page',
-            icon: const Icon(Icons.keyboard_arrow_down),
+            icon: Icon(horizontal
+                ? Icons.keyboard_arrow_right
+                : Icons.keyboard_arrow_down),
             onPressed: () => _step(1),
           ),
           const SizedBox(width: 4),
@@ -83,7 +110,8 @@ class _ScrollIndicatorDemoScreenState extends State<ScrollIndicatorDemoScreen> {
           PdfViewer(
             document: _document,
             controller: _controller,
-            // width fit guarantees vertical overflow so the scrubber shows
+            pageLayout: _layout,
+            // width fit guarantees main-axis overflow so the scrubber shows
             initialFit: PdfViewerFit.width,
             // the whole point of the demo: swap the stock bar for our own
             scrollIndicatorBuilder: (context, controller, metrics) {
@@ -108,9 +136,11 @@ class _ScrollIndicatorDemoScreenState extends State<ScrollIndicatorDemoScreen> {
   }
 }
 
-/// A draggable page scrubber that mirrors the stock scrollbar's geometry
-/// from [PdfScrollMetrics] (thumb of height `extent` at `position`) and
-/// drives the view with [PdfViewerController.jumpToNormalized].
+/// A draggable page scrubber that mirrors the stock scrollbar's geometry from
+/// [PdfScrollMetrics] (thumb of size `extent` at `position`) and drives the
+/// view with [PdfViewerController.jumpToNormalized]. It orients itself from
+/// [PdfScrollMetrics.scrollAxis]: a right-edge vertical track for a vertical
+/// layout, a bottom-edge horizontal track for a horizontal one.
 class _PageScrubber extends StatefulWidget {
   const _PageScrubber({
     super.key,
@@ -126,99 +156,134 @@ class _PageScrubber extends StatefulWidget {
 }
 
 class _PageScrubberState extends State<_PageScrubber> {
-  static const _trackWidth = 48.0;
+  static const _trackBreadth = 48.0;
   static const _minThumb = 44.0;
 
   bool _dragging = false;
 
-  void _scrubTo(double localY, double trackHeight, double thumbHeight) {
-    final span = trackHeight - thumbHeight;
+  void _scrubTo(double localMain, double trackMain, double thumbMain) {
+    final span = trackMain - thumbMain;
     // map the pointer to the thumb's *centre*, so grabbing anywhere on the
     // thumb feels natural, then hand the fraction to the controller
     final fraction =
-        span <= 0 ? 0.0 : ((localY - thumbHeight / 2) / span).clamp(0.0, 1.0);
+        span <= 0 ? 0.0 : ((localMain - thumbMain / 2) / span).clamp(0.0, 1.0);
     widget.controller.jumpToNormalized(fraction);
   }
 
   @override
   Widget build(BuildContext context) {
     final metrics = widget.metrics;
-    final scheme = Theme.of(context).colorScheme;
+    final horizontal = metrics.scrollAxis == Axis.horizontal;
     return Align(
-      alignment: Alignment.centerRight,
+      // the track hugs the edge along the scroll axis: the bottom for a
+      // horizontal layout, the right for a vertical one
+      alignment: horizontal ? Alignment.bottomCenter : Alignment.centerRight,
       child: SizedBox(
-        width: _trackWidth,
+        width: horizontal ? null : _trackBreadth,
+        height: horizontal ? _trackBreadth : null,
         child: LayoutBuilder(builder: (context, constraints) {
-          final trackHeight = constraints.maxHeight;
-          final thumbHeight =
-              (metrics.extent * trackHeight).clamp(_minThumb, trackHeight);
-          final thumbTop = metrics.position * (trackHeight - thumbHeight);
+          // the "main" extent is the track's length along the scroll axis
+          final trackMain =
+              horizontal ? constraints.maxWidth : constraints.maxHeight;
+          final thumbMain =
+              (metrics.extent * trackMain).clamp(_minThumb, trackMain);
+          final thumbLead = metrics.position * (trackMain - thumbMain);
+          void start(DragStartDetails d) {
+            setState(() => _dragging = true);
+            _scrubTo(horizontal ? d.localPosition.dx : d.localPosition.dy,
+                trackMain, thumbMain);
+          }
+
+          void update(DragUpdateDetails d) => _scrubTo(
+              horizontal ? d.localPosition.dx : d.localPosition.dy,
+              trackMain,
+              thumbMain);
+          void end() => setState(() => _dragging = false);
           return GestureDetector(
-            // the drag target - a 48px strip down the right edge
+            // the drag target - a 48px strip along the scroll edge. The drag
+            // recognizer matches the scroll axis (like the stock bar's strip)
+            // so, being opaque and on top, it wins the arena over the scroll
+            // view underneath on that same axis.
             key: const ValueKey('demo-page-scrubber'),
-            // opaque so the scrubber wins the vertical-drag gesture arena
-            // over the scroll view underneath (as the stock bar's strip does)
             behavior: HitTestBehavior.opaque,
-            onVerticalDragStart: (d) {
-              setState(() => _dragging = true);
-              _scrubTo(d.localPosition.dy, trackHeight, thumbHeight);
-            },
-            onVerticalDragUpdate: (d) =>
-                _scrubTo(d.localPosition.dy, trackHeight, thumbHeight),
-            onVerticalDragEnd: (_) => setState(() => _dragging = false),
-            onVerticalDragCancel: () => setState(() => _dragging = false),
-            child: Stack(
-              clipBehavior: Clip.none,
-              children: [
-                // a faint track scrim down the right edge
-                Positioned(
-                  top: 0,
-                  bottom: 0,
-                  right: 8,
-                  width: 6,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: scheme.onSurface.withValues(alpha: 0.08),
-                      borderRadius: BorderRadius.circular(3),
-                    ),
-                  ),
-                ),
-                // the thumb - height is metrics.extent, offset is position
-                Positioned(
-                  top: thumbTop,
-                  right: 4,
-                  width: _trackWidth - 8,
-                  height: thumbHeight,
-                  child: Center(
-                    child: Container(
-                      width: _dragging ? 16 : 12,
-                      height: thumbHeight,
-                      decoration: BoxDecoration(
-                        color: _dragging
-                            ? scheme.primary
-                            : scheme.primary.withValues(alpha: 0.75),
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(
-                            color: scheme.onSurface.withValues(alpha: 0.25)),
-                      ),
-                    ),
-                  ),
-                ),
-                // a page bubble that follows the thumb while dragging
-                if (_dragging)
-                  Positioned(
-                    right: _trackWidth,
-                    top: (thumbTop + thumbHeight / 2 - 18)
-                        .clamp(0.0, trackHeight - 36),
-                    child: _Bubble(
-                      'Page ${metrics.currentPage + 1} / ${metrics.pageCount}',
-                    ),
-                  ),
-              ],
-            ),
+            onVerticalDragStart: horizontal ? null : start,
+            onVerticalDragUpdate: horizontal ? null : update,
+            onVerticalDragEnd: horizontal ? null : (_) => end(),
+            onVerticalDragCancel: horizontal ? null : end,
+            onHorizontalDragStart: horizontal ? start : null,
+            onHorizontalDragUpdate: horizontal ? update : null,
+            onHorizontalDragEnd: horizontal ? (_) => end() : null,
+            onHorizontalDragCancel: horizontal ? end : null,
+            child: _buildTrack(
+                context, horizontal, thumbLead, thumbMain, trackMain, metrics),
           );
         }),
       ),
+    );
+  }
+
+  Widget _buildTrack(BuildContext context, bool horizontal, double thumbLead,
+      double thumbMain, double trackMain, PdfScrollMetrics metrics) {
+    final scheme = Theme.of(context).colorScheme;
+    // the thumb's cross-axis thickness grows a little while dragging
+    final thumbCross = _dragging ? 16.0 : 12.0;
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        // a faint track scrim along the scroll edge
+        Positioned(
+          top: horizontal ? null : 0,
+          bottom: horizontal ? 8 : 0,
+          left: horizontal ? 0 : null,
+          right: horizontal ? 0 : 8,
+          width: horizontal ? null : 6,
+          height: horizontal ? 6 : null,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: scheme.onSurface.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(3),
+            ),
+          ),
+        ),
+        // the thumb - length is metrics.extent, offset is position
+        Positioned(
+          top: horizontal ? null : thumbLead,
+          bottom: horizontal ? 4 : null,
+          left: horizontal ? thumbLead : null,
+          right: horizontal ? null : 4,
+          width: horizontal ? thumbMain : _trackBreadth - 8,
+          height: horizontal ? _trackBreadth - 8 : thumbMain,
+          child: Center(
+            child: Container(
+              width: horizontal ? thumbMain : thumbCross,
+              height: horizontal ? thumbCross : thumbMain,
+              decoration: BoxDecoration(
+                color: _dragging
+                    ? scheme.primary
+                    : scheme.primary.withValues(alpha: 0.75),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                    color: scheme.onSurface.withValues(alpha: 0.25)),
+              ),
+            ),
+          ),
+        ),
+        // a page bubble that follows the thumb while dragging
+        if (_dragging)
+          Positioned(
+            right: horizontal ? null : _trackBreadth,
+            bottom: horizontal ? _trackBreadth : null,
+            left: horizontal
+                ? (thumbLead + thumbMain / 2 - 60).clamp(0.0, trackMain - 120)
+                : null,
+            top: horizontal
+                ? null
+                : (thumbLead + thumbMain / 2 - 18).clamp(0.0, trackMain - 36),
+            child: _Bubble(
+              'Page ${metrics.currentPage + 1} / ${metrics.pageCount}',
+            ),
+          ),
+      ],
     );
   }
 }
@@ -261,6 +326,7 @@ class _MetricsReadout extends StatelessWidget {
     final lines = m == null
         ? const ['scrollMetrics: null (not laid out)']
         : [
+            'axis:      ${m.scrollAxis.name}',
             'page:      ${m.currentPage + 1} / ${m.pageCount}',
             'position:  ${m.position.toStringAsFixed(3)}',
             'extent:    ${m.extent.toStringAsFixed(3)}',

--- a/packages/dart_pdf_editor/example/test/scroll_indicator_demo_test.dart
+++ b/packages/dart_pdf_editor/example/test/scroll_indicator_demo_test.dart
@@ -37,4 +37,30 @@ void main() {
     // drain the viewer's settle/motion-hold timers before teardown
     await tester.pumpAndSettle();
   });
+
+  testWidgets('the horizontal layout toggle re-orients the scrubber',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: ScrollIndicatorDemoScreen(bytes: buildDemoPdf()),
+    ));
+    await tester.pumpAndSettle();
+
+    // flip the viewer into horizontal continuous reading
+    await tester.tap(find.byTooltip('Switch to horizontal layout'));
+    await tester.pumpAndSettle();
+
+    // the readout now reports the horizontal main axis
+    expect(find.textContaining('axis:      horizontal'), findsOneWidget);
+
+    // a horizontal drag on the (now bottom-edge) scrubber scrolls the doc
+    final scroll =
+        tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+    expect(scroll.pixels, moreOrLessEquals(0, epsilon: 0.5));
+    await tester.drag(find.byKey(const ValueKey('demo-page-scrubber')),
+        const Offset(400, 0));
+    await tester.pump();
+    expect(scroll.pixels, greaterThan(0));
+
+    await tester.pumpAndSettle();
+  });
 }

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -143,18 +143,25 @@ class PdfViewSync {
   final Matrix4 transform;
 }
 
-/// A read-only snapshot of a [PdfViewer]'s vertical scroll state, enough to
-/// drive a custom scroll indicator or page scrubber without reaching into
-/// the viewer's private scroll controller. Read it from
+/// A read-only snapshot of a [PdfViewer]'s scroll state along its main layout
+/// axis, enough to drive a custom scroll indicator or page scrubber without
+/// reaching into the viewer's private scroll controller. Read it from
 /// [PdfViewerController.scrollMetrics] (or the [PdfScrollIndicatorBuilder]),
 /// and listen to [PdfViewerController.viewportChanges] to know when to
 /// re-read it.
 ///
+/// The metrics describe the viewer's **main axis** - the direction pages
+/// stack and the view scrolls. That is vertical for the default
+/// [PdfPageLayout.verticalContinuous] and horizontal for
+/// [PdfPageLayout.horizontalContinuous]; [scrollAxis] says which, so a host
+/// can orient its indicator (a right-edge track vs. a bottom-edge one)
+/// correctly for either layout.
+///
 /// The normalized [position] and [extent] behave the same as the built-in
 /// scrollbar's thumb (they account for zoom and mixed page sizes): a thumb
-/// of height `extent` sitting at `position` along the track mirrors the
+/// of size `extent` sitting at `position` along the track mirrors the
 /// stock bar. (The stock bar additionally floors its thumb at a minimum
-/// pixel height for grabbability, so on a very long document a thumb sized
+/// pixel size for grabbability, so on a very long document a thumb sized
 /// strictly by `extent` can come out shorter than the stock one.) The pixel
 /// fields are in the viewer's internal list space
 /// (logical pixels at the current layout zoom, before the zoom-window
@@ -171,6 +178,7 @@ class PdfScrollMetrics {
     required this.viewportPixels,
     required this.zoom,
     required this.hasOverflow,
+    this.scrollAxis = Axis.vertical,
   });
 
   /// Number of pages in the document.
@@ -180,36 +188,46 @@ class PdfScrollMetrics {
   /// value as [PdfViewerController.currentPage].
   final int currentPage;
 
-  /// Normalized scroll position along the vertical axis: 0 at the top, 1
-  /// fully scrolled to the bottom. 0 when there is no scrollable range at all
-  /// (the content is not taller than the viewport). When only the trailing
-  /// page margin overflows ([hasOverflow] is false) the range is tiny but
-  /// still nonzero, so scrolling into that margin can move this off 0.
+  /// Normalized scroll position along the main axis: 0 at the leading edge
+  /// (top for a vertical layout, left for a horizontal one), 1 fully scrolled
+  /// to the trailing edge. 0 when there is no scrollable range at all (the
+  /// content is not larger than the viewport). When only the trailing page
+  /// margin overflows ([hasOverflow] is false) the range is tiny but still
+  /// nonzero, so scrolling into that margin can move this off 0.
   final double position;
 
   /// The visible fraction of the scrollable content (0–1) - a page scrubber
   /// sizes its thumb by this. Approaches 1 when the whole document fits,
-  /// staying a hair below it because the list pads its bottom by the page
-  /// spacing (the same trailing margin that keeps [hasOverflow] false there).
+  /// staying a hair below it because the list pads its trailing edge by the
+  /// page spacing (the same margin that keeps [hasOverflow] false there).
   final double extent;
 
-  /// Leading (top) edge of the viewport in list-space pixels: the scroll
-  /// offset plus any zoom-window pan.
+  /// Leading edge of the viewport in list-space pixels along the main axis
+  /// (top for vertical, left for horizontal): the scroll offset plus any
+  /// zoom-window pan.
   final double pixels;
 
   /// The largest reachable [pixels] value (content extent minus the visible
   /// extent); 0 when nothing overflows.
   final double maxPixels;
 
-  /// The visible vertical extent in list-space pixels.
+  /// The visible extent along the main axis in list-space pixels.
   final double viewportPixels;
 
   /// Effective zoom in logical pixels per PDF point (1 = actual size) - the
   /// same value [PdfViewerController.zoom] reports.
   final double zoom;
 
-  /// Whether the document overflows the viewport vertically enough to
-  /// scroll - true exactly when the built-in scrollbar would show. A page
+  /// The viewer's main layout axis - the direction it scrolls and pages
+  /// stack. [Axis.vertical] for [PdfPageLayout.verticalContinuous],
+  /// [Axis.horizontal] for [PdfPageLayout.horizontalContinuous]. Every other
+  /// field on this snapshot is measured along this axis; use it to position
+  /// and orient a custom indicator (a right-edge track for a vertical layout,
+  /// a bottom-edge one for a horizontal layout).
+  final Axis scrollAxis;
+
+  /// Whether the document overflows the viewport along the main axis enough
+  /// to scroll - true exactly when the built-in scrollbar would show. A page
   /// that fits within a hair of the viewport (only the trailing page margin
   /// overflows) reports false, so an indicator can hide itself the same way
   /// the stock bar does. The viewer skips
@@ -227,16 +245,18 @@ class PdfScrollMetrics {
       other.maxPixels == maxPixels &&
       other.viewportPixels == viewportPixels &&
       other.zoom == zoom &&
+      other.scrollAxis == scrollAxis &&
       other.hasOverflow == hasOverflow;
 
   @override
   int get hashCode => Object.hash(pageCount, currentPage, position, extent,
-      pixels, maxPixels, viewportPixels, zoom, hasOverflow);
+      pixels, maxPixels, viewportPixels, zoom, scrollAxis, hasOverflow);
 
   @override
   String toString() => 'PdfScrollMetrics(page ${currentPage + 1}/$pageCount, '
       'position: ${position.toStringAsFixed(3)}, '
-      'extent: ${extent.toStringAsFixed(3)}, zoom: ${zoom.toStringAsFixed(2)})';
+      'extent: ${extent.toStringAsFixed(3)}, zoom: ${zoom.toStringAsFixed(2)}, '
+      'axis: ${scrollAxis.name})';
 }
 
 /// Drives a [PdfViewer] and reports its state: current page, zoom, and
@@ -422,20 +442,24 @@ class PdfViewerController extends ChangeNotifier {
     _reflow?.reflowJumpToPage(index);
   }
 
-  /// A read-only snapshot of the viewer's vertical scroll state - page,
-  /// normalized position/extent, pixel offsets, and zoom - for building a
-  /// custom scroll indicator or page scrubber (see [PdfScrollMetrics] and
-  /// [PdfViewer.scrollIndicatorBuilder]). Null while no viewer is attached
-  /// or it has not laid out yet. Listen to [viewportChanges] to know when
-  /// to re-read it, and drive the view with [jumpToNormalized],
+  /// A read-only snapshot of the viewer's main-axis scroll state - page,
+  /// normalized position/extent, pixel offsets, zoom, and the layout's
+  /// [PdfScrollMetrics.scrollAxis] - for building a custom scroll indicator
+  /// or page scrubber (see [PdfScrollMetrics] and
+  /// [PdfViewer.scrollIndicatorBuilder]). The metrics follow the active
+  /// layout axis (vertical or horizontal continuous). Null while no viewer is
+  /// attached or it has not laid out yet. Listen to [viewportChanges] to know
+  /// when to re-read it, and drive the view with [jumpToNormalized],
   /// [jumpToPage], or [animateToPage].
   PdfScrollMetrics? get scrollMetrics => _state?._scrollMetrics();
 
-  /// Scrolls so the vertical scroll position lands at [position], a fraction
-  /// clamped to 0 (top) … 1 (bottom) - what a page-scrubber thumb drag maps
-  /// to. Immediate (no animation), so it follows a drag frame by frame, and
-  /// zoom-aware: while zoomed in it spills into the zoom window exactly like
-  /// dragging the built-in scrollbar. A no-op while no viewer is attached.
+  /// Scrolls so the main-axis scroll position lands at [position], a fraction
+  /// clamped to 0 (leading edge) … 1 (trailing edge) - what a page-scrubber
+  /// thumb drag maps to. Moves along whichever axis the viewer scrolls
+  /// (vertical or horizontal continuous). Immediate (no animation), so it
+  /// follows a drag frame by frame, and zoom-aware: while zoomed in it spills
+  /// into the zoom window exactly like dragging the built-in scrollbar. A
+  /// no-op while no viewer is attached.
   void jumpToNormalized(double position) =>
       _state?._scrollToNormalized(position);
 
@@ -747,19 +771,22 @@ typedef PdfPageOverlayBuilder = List<Widget> Function(
     BuildContext context, int pageIndex, PdfPageGeometry geometry);
 
 /// Signature for [PdfViewer.scrollIndicatorBuilder]: builds a custom
-/// vertical scroll indicator (a compact page number, a draggable page
+/// main-axis scroll indicator (a compact page number, a draggable page
 /// scrubber, a platform-styled bar) in place of the viewer's built-in
-/// scrollbar. It is stacked over the viewer's right edge and rebuilt
-/// whenever the scroll position, zoom, or current page changes.
+/// scrollbar. It fills the viewer, rebuilt whenever the scroll position,
+/// zoom, or current page changes; use [PdfScrollMetrics.scrollAxis] to
+/// orient it - the viewer's right edge for a vertical
+/// [PdfPageLayout.verticalContinuous] layout, the bottom edge for a
+/// horizontal [PdfPageLayout.horizontalContinuous] one.
 ///
-/// Use [metrics] for the page count and the normalized position/extent, and
-/// drive the view through [controller] - [PdfViewerController.jumpToNormalized]
-/// for a scrubber-thumb drag, [PdfViewerController.jumpToPage] or
-/// [PdfViewerController.animateToPage] for page taps. Return an empty widget
-/// (e.g. `SizedBox.shrink()`) to show nothing; the indicator is not built at
-/// all before the viewer has laid out or when the document does not overflow
-/// ([PdfScrollMetrics.hasOverflow] is false), so a builder never has to guard
-/// those cases.
+/// Use [metrics] for the page count, the layout axis, and the normalized
+/// position/extent, and drive the view through [controller] -
+/// [PdfViewerController.jumpToNormalized] for a scrubber-thumb drag,
+/// [PdfViewerController.jumpToPage] or [PdfViewerController.animateToPage]
+/// for page taps. Return an empty widget (e.g. `SizedBox.shrink()`) to show
+/// nothing; the indicator is not built at all before the viewer has laid out
+/// or when the document does not overflow ([PdfScrollMetrics.hasOverflow] is
+/// false), so a builder never has to guard those cases.
 typedef PdfScrollIndicatorBuilder = Widget Function(
     BuildContext context,
     PdfViewerController controller,
@@ -933,15 +960,19 @@ class PdfViewer extends StatefulWidget {
   /// before the viewer's own selection and link handling.
   final PdfPageOverlayBuilder? pageOverlayBuilder;
 
-  /// Replaces the viewer's built-in vertical scrollbar with a custom scroll
+  /// Replaces the viewer's built-in main-axis scrollbar with a custom scroll
   /// indicator - a compact page number, a draggable page scrubber, a
   /// platform-styled bar. See [PdfScrollIndicatorBuilder]; it receives the
   /// live [PdfScrollMetrics] and the controller for page-aware navigation.
   ///
-  /// Null keeps the stock scrollbar. The horizontal (zoom-window) scrollbar
-  /// is unaffected - it still appears when zoomed in. The indicator is
-  /// stacked over the viewer's right edge outside the zoom transform, so it
-  /// holds its place and size at any zoom.
+  /// Works in both continuous layouts: it replaces the right-edge bar in a
+  /// vertical [PdfPageLayout.verticalContinuous] layout and the bottom-edge
+  /// bar in a horizontal [PdfPageLayout.horizontalContinuous] one, and the
+  /// metrics it receives describe that main axis (with
+  /// [PdfScrollMetrics.scrollAxis] telling the host which). Null keeps the
+  /// stock scrollbar. The cross-axis (zoom-window) scrollbar is unaffected -
+  /// it still appears when zoomed in. The indicator fills the viewer outside
+  /// the zoom transform, so it holds its place and size at any zoom.
   final PdfScrollIndicatorBuilder? scrollIndicatorBuilder;
 
   /// Stable transition/effect surface for editing gestures. The viewer uses
@@ -2702,12 +2733,13 @@ class _PdfViewerState extends State<PdfViewer>
     await _scroll.animateTo(clamped, duration: duration, curve: curve);
   }
 
-  /// The viewport's leading (top) edge and the scrollable range along the
-  /// vertical axis, both in list-space pixels: `(offset, total, visible)`.
+  /// The viewport's leading edge and the scrollable range along the main
+  /// (scroll) axis, both in list-space pixels: `(offset, total, visible)`.
   /// Mirrors the built-in scrollbar's own measurement (see
   /// [PdfScrollbar] / [_visibleFractionOf]) so a custom indicator lines up
-  /// with the stock bar. Null until the viewer has laid out.
-  (double offset, double total, double visible)? _verticalScrollExtents() {
+  /// with the stock bar in either continuous layout. Null until the viewer
+  /// has laid out.
+  (double offset, double total, double visible)? _mainScrollExtents() {
     if (_viewWidth <= 0 || !_scroll.hasClients) return null;
     final position = _scroll.position;
     if (!position.hasContentDimensions) return null;
@@ -2715,15 +2747,17 @@ class _PdfViewerState extends State<PdfViewer>
     final total = position.maxScrollExtent + position.viewportDimension;
     final visible = position.viewportDimension / scale;
     // the viewport unprojects to list space as (p - t) / s, riding the
-    // scroll offset (see _visibleFractionOf)
-    final offset = -_transform.value.storage[13] / scale + position.pixels;
+    // scroll offset (see _visibleFractionOf). The main-axis translation is
+    // storage[13] for a vertical layout, storage[12] for a horizontal one.
+    final offset =
+        -_transform.value.storage[_mainTranslate] / scale + position.pixels;
     return (offset, total, visible);
   }
 
   /// The public scroll snapshot behind [PdfViewerController.scrollMetrics]
   /// and [PdfViewer.scrollIndicatorBuilder].
   PdfScrollMetrics? _scrollMetrics() {
-    final extents = _verticalScrollExtents();
+    final extents = _mainScrollExtents();
     if (extents == null) return null;
     final (offset, total, visible) = extents;
     final range = total - visible;
@@ -2736,18 +2770,20 @@ class _PdfViewerState extends State<PdfViewer>
       maxPixels: range <= 0 ? 0 : range,
       viewportPixels: visible,
       zoom: _displayScale,
-      // the list pads its bottom by pageSpacing, so a fully visible document
-      // still carries that much nominal slack - the stock bar hides for it
-      // (see PdfScrollbar.minOverflow), and so does this
+      scrollAxis: widget.pageLayout.scrollAxis,
+      // the list pads its trailing edge by pageSpacing, so a fully visible
+      // document still carries that much nominal slack - the stock bar hides
+      // for it (see PdfScrollbar.minOverflow), and so does this
       hasOverflow: range > widget.pageSpacing + 0.5,
     );
   }
 
-  /// Scrolls so the normalized vertical position lands at [fraction]
-  /// (0 = top, 1 = bottom). Reuses the scrollbar's own list-space motion so
-  /// it spills into the zoom window at the extents just like a bar drag.
+  /// Scrolls so the normalized main-axis position lands at [fraction]
+  /// (0 = leading edge, 1 = trailing edge). Reuses the scrollbar's own
+  /// list-space motion so it spills into the zoom window at the extents just
+  /// like a bar drag.
   void _scrollToNormalized(double fraction) {
-    final extents = _verticalScrollExtents();
+    final extents = _mainScrollExtents();
     if (extents == null) return;
     final (offset, total, visible) = extents;
     final range = total - visible;
@@ -5514,13 +5550,13 @@ class _PdfViewerState extends State<PdfViewer>
                 // vertical bar's) - so the two never collide whichever axis
                 // is which.
                 //
-                // A host scrollIndicatorBuilder replaces the main bar, but
-                // only in a vertical layout: PdfScrollMetrics measures the
-                // vertical scroll axis, so the indicator is meaningful there
-                // (the standard right-edge scrollbar). In a horizontal layout
-                // the main bar runs along the bottom and the stock bar stands.
-                if (widget.scrollIndicatorBuilder != null &&
-                    widget.pageLayout.scrollAxis == Axis.vertical)
+                // A host scrollIndicatorBuilder replaces the main bar in
+                // either layout: PdfScrollMetrics measures the main scroll
+                // axis and carries a scrollAxis, so the host can orient its
+                // indicator for the right edge (vertical) or the bottom edge
+                // (horizontal). The cross-axis (zoom-window) bar below is
+                // untouched.
+                if (widget.scrollIndicatorBuilder != null)
                   Positioned.fill(child: _buildScrollIndicator())
                 else
                   _positionedScrollbar(PdfScrollbar(

--- a/packages/dart_pdf_editor/test/scroll_indicator_test.dart
+++ b/packages/dart_pdf_editor/test/scroll_indicator_test.dart
@@ -92,6 +92,12 @@ void main() {
       expect(a, isNot(d));
       expect(a.scrollAxis, Axis.vertical);
       expect(a.hasOverflow, isTrue);
+      // toString surfaces the page, position/extent/zoom, and the axis
+      expect(
+          a.toString(),
+          allOf(contains('page 2/5'), contains('position: 0.500'),
+              contains('axis: vertical')));
+      expect(d.toString(), contains('axis: horizontal'));
     });
   });
 

--- a/packages/dart_pdf_editor/test/scroll_indicator_test.dart
+++ b/packages/dart_pdf_editor/test/scroll_indicator_test.dart
@@ -17,12 +17,14 @@ void main() {
     PdfViewerFit fit = PdfViewerFit.width,
     PdfScrollIndicatorBuilder? indicator,
     PdfViewerController? controller,
+    PdfPageLayout layout = const PdfPageLayout.verticalContinuous(),
   }) async {
     final c = controller ?? PdfViewerController();
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: PdfViewer(
           initialFit: fit,
+          pageLayout: layout,
           document: PdfDocument.open(buildMultiPagePdf(pages)),
           controller: c,
           scrollIndicatorBuilder: indicator,
@@ -71,9 +73,24 @@ void main() {
         zoom: 1,
         hasOverflow: true,
       );
+      // scrollAxis defaults to vertical and participates in equality
+      const d = PdfScrollMetrics(
+        pageCount: 5,
+        currentPage: 1,
+        position: 0.5,
+        extent: 0.2,
+        pixels: 100,
+        maxPixels: 200,
+        viewportPixels: 60,
+        zoom: 1,
+        hasOverflow: true,
+        scrollAxis: Axis.horizontal, // differs
+      );
       expect(a, b);
       expect(a.hashCode, b.hashCode);
       expect(a, isNot(c));
+      expect(a, isNot(d));
+      expect(a.scrollAxis, Axis.vertical);
       expect(a.hasOverflow, isTrue);
     });
   });
@@ -88,6 +105,7 @@ void main() {
       expect(metrics, isNotNull);
       expect(metrics!.pageCount, 5);
       expect(metrics.currentPage, 0);
+      expect(metrics.scrollAxis, Axis.vertical);
       expect(metrics.position, moreOrLessEquals(0, epsilon: 0.001));
       expect(metrics.hasOverflow, isTrue);
       // extent is the visible fraction, matching the stock thumb sizing
@@ -243,6 +261,88 @@ void main() {
       expect(controller.scrollMetrics!.position, greaterThan(0.2));
       // drain the viewer's settle/motion-hold timers before teardown
       await tester.pumpAndSettle();
+    });
+  });
+
+  // The scroll-indicator API describes the viewer's main layout axis (issue
+  // #428): in a horizontal continuous layout the metrics, jumpToNormalized,
+  // and the indicator builder all follow the horizontal axis.
+  group('horizontal layout', () {
+    const horizontal = PdfPageLayout.horizontalContinuous();
+
+    testWidgets('scrollAxis reports the horizontal main axis', (tester) async {
+      final controller = await pumpViewer(tester, layout: horizontal);
+      final metrics = controller.scrollMetrics;
+      expect(metrics, isNotNull);
+      expect(metrics!.scrollAxis, Axis.horizontal);
+      expect(metrics.pageCount, 5);
+      expect(metrics.hasOverflow, isTrue);
+      expect(metrics.position, moreOrLessEquals(0, epsilon: 0.001));
+    });
+
+    testWidgets('position and extent track horizontal scrolling',
+        (tester) async {
+      final controller = await pumpViewer(tester, layout: horizontal);
+      final position = scrollPosition(tester);
+      // the list scrolls along X, so extent mirrors the visible fraction
+      final total = position.maxScrollExtent + position.viewportDimension;
+      expect(controller.scrollMetrics!.extent,
+          moreOrLessEquals(position.viewportDimension / total, epsilon: 0.001));
+
+      position.jumpTo(position.maxScrollExtent);
+      await tester.pump();
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(1, epsilon: 0.001));
+      expect(controller.scrollMetrics!.currentPage, 4);
+    });
+
+    testWidgets('jumpToNormalized moves along the horizontal axis',
+        (tester) async {
+      final controller = await pumpViewer(tester, layout: horizontal);
+      final position = scrollPosition(tester);
+
+      controller.jumpToNormalized(1);
+      await tester.pump();
+      expect(position.pixels,
+          moreOrLessEquals(position.maxScrollExtent, epsilon: 0.5));
+
+      controller.jumpToNormalized(0.5);
+      await tester.pump();
+      expect(position.pixels,
+          moreOrLessEquals(position.maxScrollExtent / 2, epsilon: 1));
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(0.5, epsilon: 0.01));
+
+      controller.jumpToNormalized(0);
+      await tester.pump();
+      expect(position.pixels, moreOrLessEquals(0, epsilon: 0.5));
+    });
+
+    testWidgets('the indicator replaces the stock bar in horizontal layout',
+        (tester) async {
+      PdfScrollMetrics? seen;
+      final controller = await pumpViewer(
+        tester,
+        layout: horizontal,
+        indicator: (context, controller, metrics) {
+          seen = metrics;
+          return const SizedBox.shrink(key: ValueKey('custom-indicator'));
+        },
+      );
+
+      // the stock main-axis thumb is gone, the custom indicator is up, and
+      // the metrics it receives describe the horizontal axis
+      expect(find.byKey(stockThumb), findsNothing);
+      expect(find.byKey(const ValueKey('custom-indicator')), findsOneWidget);
+      expect(seen, isNotNull);
+      expect(seen!.scrollAxis, Axis.horizontal);
+
+      // scrolling horizontally rebuilds the indicator with fresh metrics
+      scrollPosition(tester).jumpTo(scrollPosition(tester).maxScrollExtent);
+      await tester.pump();
+      expect(seen!.position, moreOrLessEquals(1, epsilon: 0.001));
+      expect(controller.scrollMetrics!.position,
+          moreOrLessEquals(1, epsilon: 0.001));
     });
   });
 }


### PR DESCRIPTION
## Summary

Makes the viewer's public scroll-indicator API describe the viewer's **main layout axis** rather than always the vertical axis, resolving #428.

Previously `PdfViewer.scrollIndicatorBuilder`, `PdfScrollMetrics`, and `PdfViewerController.jumpToNormalized` only applied to the default vertical layout. When `pageLayout: PdfPageLayout.horizontalContinuous()` was used, the viewer kept its stock bottom scrollbar and the metrics/navigation API still described the vertical axis, so a host couldn't keep a custom, page-aware bottom scrubber in horizontal book-like reading mode.

Now, in horizontal continuous mode:

- `scrollIndicatorBuilder` is invoked in place of the built-in bottom scrollbar (it already replaced the right-edge bar in vertical layout);
- `PdfScrollMetrics` exposes the horizontal main-axis position, extent, pixels, maximum pixels, and viewport size;
- `jumpToNormalized` moves along the active main axis;
- a new `Axis scrollAxis` field on `PdfScrollMetrics` tells the host which axis is active so it can position/orient its indicator (right-edge track vs. bottom-edge one);
- the cross-axis (zoom-window) scrollbar used while zoomed is retained unchanged.

Vertical behavior is source-compatible: `scrollAxis` defaults to `Axis.vertical`, and all existing vertical tests pass unmodified.

### Implementation notes

The viewer was already written in main/cross-axis terms (`_horizontal`, `_mainTranslate`, `_pageMain`, …). The only genuinely axis-bound line in the metrics path was the zoom-window unprojection, which hard-coded the Y translation (`storage[13]`); it now uses `storage[_mainTranslate]`. `jumpToNormalized` already routed through `_scrollbarScrollBy` (main-axis aware), so it worked on the horizontal axis the moment the extents did. The build gate that skipped the builder in horizontal layout was removed.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (dart_pdf_editor: no issues)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran `scroll_indicator_test.dart` — 15 pass, `scroll_indicator_demo_test.dart` — 2 pass, `pdf_horizontal_layout_test.dart` — 16 pass)

Only the directly-affected editor/example test suites were run rather than the full multi-package matrix; the change is scoped to `dart_pdf_editor`'s viewer and its example.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `scrollAxis` participates in `PdfScrollMetrics` equality/hashCode; the value-equality test covers this and the vertical default.
- The example demo (`scroll_indicator_demo.dart`) gains an app-bar layout toggle and an axis-aware `_PageScrubber` that re-orients from `metrics.scrollAxis` (right-edge + vertical drag vs. bottom-edge + horizontal drag). The scrubber uses axis-specific drag recognizers (not a pan recognizer) so the opaque strip wins the gesture arena over the scroll view on the same axis.
- Dev-log note added: `doc/dev-log/2026-07-20-axis-aware-scroll-indicator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ad6ytctTkjDzLs5ncrYy2h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad6ytctTkjDzLs5ncrYy2h)_