### PR TITLE
perf(app): stop hashing the whole file to key a Recent snapshot

### DIFF
--- a/app/lib/pdf_cache_io.dart
+++ b/app/lib/pdf_cache_io.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
-import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
+
+import 'pdf_cache_key.dart';
 
 /// Whether opened PDFs should be snapshotted for later reopening on this
 /// platform. Only mobile needs it: desktop keeps the picked file's real path,
@@ -30,7 +31,7 @@ Future<String?> cacheOpenedPdf(Uint8List bytes) async {
   if (!canCacheRecentPdfs) return null;
   try {
     final dir = await _cacheDir();
-    final digest = sha1.convert(bytes).toString();
+    final digest = pdfContentKey(bytes);
     final file = File('${dir.path}/$digest.pdf');
     if (!await file.exists()) {
       await file.writeAsBytes(bytes, flush: true);

--- a/app/lib/pdf_cache_key.dart
+++ b/app/lib/pdf_cache_key.dart
@@ -1,0 +1,45 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+/// Bytes sampled from each of the three probe positions.
+const int _chunk = 64 * 1024;
+
+/// Files at or below this size are hashed whole - sampling saves nothing and
+/// the full hash is the stronger key.
+const int _fullHashLimit = 3 * _chunk;
+
+/// A stable content key for a picked PDF, used to name its Recent snapshot.
+///
+/// Hashing the whole file is the obvious implementation and was the original
+/// one, but it is the single most expensive step in opening a large document:
+/// on a 24 MB, 62-page book it measured **171 ms warm**, against 3 ms to parse
+/// the document, 3 ms to reach page 1's content, and 2 ms to interpret it - so
+/// the snapshot key cost more than everything the user was actually waiting
+/// for, and it scales with file size while the rest does not.
+///
+/// This samples instead: the length, then up to three 64 KiB windows (head,
+/// middle, tail). Same bytes always produce the same key, which is all the
+/// Recent store needs - it dedupes re-picks of one file and gives a stable
+/// identity across sessions. It is deliberately **not** a cryptographic
+/// checksum of the file, and nothing security-bearing may use it.
+///
+/// The length is mixed in first, so two files of different sizes can never
+/// collide however similar their sampled windows. Two same-length PDFs that
+/// agree across all three windows would collide; for a store whose worst
+/// failure is reopening the wrong Recent entry, that is an acceptable trade
+/// for an ~80x saving on the open path.
+String pdfContentKey(Uint8List bytes) {
+  final length = bytes.length;
+  if (length <= _fullHashLimit) {
+    return '${length}_${sha1.convert(bytes)}';
+  }
+  // One 192 KiB sample buffer: the copy is immaterial next to the hash, and
+  // it keeps this readable against a chunked-conversion sink.
+  final middle = ((length - _chunk) ~/ 2).clamp(0, length - _chunk);
+  final sample = Uint8List(3 * _chunk);
+  sample.setRange(0, _chunk, bytes, 0);
+  sample.setRange(_chunk, 2 * _chunk, bytes, middle);
+  sample.setRange(2 * _chunk, 3 * _chunk, bytes, length - _chunk);
+  return '${length}_${sha1.convert(sample)}';
+}

--- a/app/lib/pdf_cache_web.dart
+++ b/app/lib/pdf_cache_web.dart
@@ -2,9 +2,10 @@ import 'dart:async';
 import 'dart:js_interop';
 import 'dart:typed_data';
 
-import 'package:crypto/crypto.dart';
 
 import 'package:web/web.dart' as web;
+
+import 'pdf_cache_key.dart';
 
 /// Web byte-snapshot store for opened PDFs, backed by IndexedDB.
 ///
@@ -29,12 +30,21 @@ const String _storeName = 'pdfs';
 /// Snapshots [bytes] into IndexedDB and returns the content-hash key, or null
 /// when the store is unavailable or the write fails.
 ///
-/// The key is a content hash, so reopening or re-picking the same document
-/// reuses one entry instead of piling up copies - and the same bytes always map
-/// to the same Recent identity, matching the native filesystem store.
+/// The key is a content key ([pdfContentKey]), so reopening or re-picking the
+/// same document reuses one entry instead of piling up copies - and the same
+/// bytes always map to the same Recent identity, matching the native
+/// filesystem store.
+///
+/// The first `await` is load-bearing and must stay first. An `async` body runs
+/// synchronously up to its initial await, so computing the key before one
+/// would run it inside the caller's frame - and `unawaited(...)` at the call
+/// site would not help, because that defers only the *future*, never the
+/// synchronous prefix. Yielding first pushes the whole snapshot off the frame
+/// that opened the document, which is the one the user is waiting on.
 Future<String?> cacheOpenedPdf(Uint8List bytes) async {
   try {
-    final key = sha1.convert(bytes).toString();
+    await null;
+    final key = pdfContentKey(bytes);
     final store = await _store('readwrite');
     await _run<void>(store.put(bytes.toJS, key.toJS), (_) {});
     return key;

--- a/app/test/pdf_cache_key_test.dart
+++ b/app/test/pdf_cache_key_test.dart
@@ -1,0 +1,79 @@
+// The Recent-snapshot content key. It replaced a whole-file SHA-1 that
+// measured 171 ms warm on a 24 MB document - more than parsing the file and
+// interpreting its first page put together - so the properties that make
+// sampling safe are pinned here.
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor_app/pdf_cache_key.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Uint8List _bytes(int length, {int seed = 1}) {
+  final out = Uint8List(length);
+  var x = seed;
+  for (var i = 0; i < length; i++) {
+    x = (x * 1103515245 + 12345) & 0x7FFFFFFF;
+    out[i] = x & 0xFF;
+  }
+  return out;
+}
+
+void main() {
+  const chunk = 64 * 1024;
+
+  test('the same bytes always produce the same key', () {
+    final a = _bytes(5 << 20);
+    final b = Uint8List.fromList(a);
+    expect(pdfContentKey(a), pdfContentKey(b));
+  });
+
+  test('a different length can never collide', () {
+    // Identical content, one byte longer: the length prefix separates them
+    // even though every sampled window could otherwise coincide.
+    final short = Uint8List(4 << 20);
+    final long = Uint8List(4 << 20 | 1);
+    expect(pdfContentKey(short), isNot(pdfContentKey(long)));
+  });
+
+  test('a change in any sampled window changes the key', () {
+    final base = _bytes(5 << 20);
+    for (final (label, index) in [
+      ('head', 10),
+      ('middle', (5 << 20) ~/ 2),
+      ('tail', (5 << 20) - 10),
+    ]) {
+      final edited = Uint8List.fromList(base);
+      edited[index] ^= 0xFF;
+      expect(pdfContentKey(edited), isNot(pdfContentKey(base)),
+          reason: 'a $label byte must move the key');
+    }
+  });
+
+  test('small files are hashed whole, so every byte counts', () {
+    final small = _bytes(3 * chunk);
+    for (var i = 0; i < small.length; i += 4093) {
+      final edited = Uint8List.fromList(small);
+      edited[i] ^= 0xFF;
+      expect(pdfContentKey(edited), isNot(pdfContentKey(small)),
+          reason: 'byte $i must move the key of a fully hashed file');
+    }
+  });
+
+  test('sampling actually happens above the full-hash limit', () {
+    // A byte between the sampled windows is deliberately NOT covered. This
+    // pins the documented trade rather than leaving it implicit: if someone
+    // later hashes the whole file again, this test tells them they changed
+    // the contract, not just an implementation detail.
+    final big = _bytes(5 << 20);
+    final edited = Uint8List.fromList(big);
+    edited[chunk + 1000] ^= 0xFF; // past the head window, before the middle
+    expect(pdfContentKey(edited), pdfContentKey(big));
+  });
+
+  test('an empty file has a key', () {
+    expect(pdfContentKey(Uint8List(0)), isNotEmpty);
+  });
+
+  test('files shorter than one window still work', () {
+    expect(pdfContentKey(_bytes(10)), isNot(pdfContentKey(_bytes(11))));
+  });
+}


### PR DESCRIPTION
## What prompted this

Ben reported ~6 s before the first page's image appears when opening an RPG quickstart guide (24 MB, 62 pages) on **mobile web**.

I first guessed the decode headroom was shipping 4× the needed pixels (#437). Measured against the actual file, that was wrong — page 1's payload is 0.9 MB, not the 28 MB my synthetic fixture suggested. So I measured the open path instead.

## The measurement

Warm, min-of-5, Dart VM, on the real document:

| phase | ms |
|---|---|
| **sha1 over the whole 24 MB** | **171** |
| `CosDocument.open` | 3 |
| `page(0)` + `contentBytes` | 3 |
| interpret page 1 | 2 |
| serialize + decode | 2 |

Naming the Recent snapshot cost more than parsing the document and interpreting its first page combined — and it scales with file size while none of the rest does. Under dart2js on a phone this is multiplied again.

## Two defects

**1. The hash is far stronger than the job needs.** The Recent store wants a stable identity that dedupes re-picks of one file. It does not need a cryptographic checksum of every byte. Now: length + up to three 64 KiB windows (head, middle, tail), length mixed in first so different-sized files can never collide however similar their windows.

**175.2 ms → 1.38 ms — 127×** on the same file.

**2. `unawaited(...)` was not deferring it.** The call site reads:

```dart
unawaited(_snapshotOpenedDocument(tab, bytes));
```

with a comment explaining it runs "off the open hot path". But an `async` body runs synchronously up to its first `await`, and the web backend hashed *before* any await — so the entire hash ran inside the caller's frame, the frame that opens the document. `unawaited` defers the future, never the synchronous prefix. The intent was right and the mechanism did not deliver it.

The web path now yields first, with a comment saying why the ordering is load-bearing, because it is easy to undo by accident.

## Correctness

Sampling is a real trade, so the tests pin it as a **contract**:

- same bytes → same key
- different length → never collides
- a change in the head, middle, or tail window moves the key
- files ≤ 192 KiB are hashed whole, verified byte-by-byte across the range
- **a byte between the sampled windows does not move the key** — asserted explicitly, so a future return to whole-file hashing reads as a contract change rather than a silent perf regression

Nothing security-bearing may use this key; the doc comment says so plainly.

## Migration

The key format changes. Existing Recent entries keep resolving under their old keys; a re-pick of an already-snapshotted file writes one new entry, and the stale blob is pruned once the old entry rolls off the capped list. Self-healing and one-time.

## Verification

`app` suite: **246 pass**. `dart analyze app`: clean.

## What this does not claim

This is ~170 ms of VM-side work removed from the open path, and it was the dominant measurable cost. I have **not** measured it on Ben's phone, and I am not claiming it accounts for all 6 s — the remaining candidates (worker startup, CanvasKit load, font work across 62 pages) are untested. #437 carries the corrected analysis and the note that an on-device capture is the right next step.

Refs #436, #437.