### PR TITLE
perf(cos): memoise the per-object decryption key (#400)

### DIFF
--- a/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor/assets/web/pdf_render_worker.dart.js
@@ -3693,7 +3693,8 @@ lw:function lw(a,b,c,d){var _=this
 _.b=a
 _.c=b
 _.d=c
-_.e=d},
+_.e=d
+_.x=_.w=_.r=_.f=null},
 lz:function lz(a,b){this.a=a
 this.b=b},
 lx:function lx(a,b){this.a=a
@@ -14926,11 +14927,19 @@ df(a,b,c,d){switch(a.a){case 0:return b
 case 1:return A.h_(this.f4(c,d,!1),b)
 case 2:return A.pU(this.f4(c,d,!0),b)
 case 3:return A.pU(this.b,b)}},
-f4(a,b,c){var s=new A.ba($.b3()),r=this.b
-s.i(0,r)
-s.i(0,A.b([a&255,B.b.q(a,8)&255,B.b.q(a,16)&255,b&255,B.b.q(b,8)&255],t.t))
-if(c)s.i(0,B.dI)
-return new Uint8Array(A.H(B.d.a2(B.H.ac(s.aN()).a,0,Math.min(r.length+5,16))))}}
+f4(a,b,c){var s,r,q,p=this
+if(p.f===a&&p.r===b&&p.w===c){s=p.x
+s.toString
+return s}r=new A.ba($.b3())
+s=p.b
+r.i(0,s)
+r.i(0,A.b([a&255,B.b.q(a,8)&255,B.b.q(a,16)&255,b&255,B.b.q(b,8)&255],t.t))
+if(c)r.i(0,B.dI)
+q=new Uint8Array(A.H(B.d.a2(B.H.ac(r.aN()).a,0,Math.min(s.length+5,16))))
+p.f=a
+p.r=b
+p.w=c
+return p.x=q}}
 A.lz.prototype={
 $2(a,b){var s=this.a.$1(this.b.a.h(0,a))
 return s instanceof A.m?s.a:b},

--- a/packages/pdf_cos/lib/src/crypto/standard_security_handler.dart
+++ b/packages/pdf_cos/lib/src/crypto/standard_security_handler.dart
@@ -472,9 +472,37 @@ class StandardSecurityHandler {
     }
   }
 
+  // Memo for the most recent [_objectKey] derivation.
+  //
+  // One entry is enough because the access pattern is strictly per-object:
+  // decryptObjectGraph / encryptObjectGraph walk one indirect object's whole
+  // graph under a fixed (objectNumber, generation), so every string in that
+  // object asks for the same key. A 50-string object cost 50 MD5s over the
+  // file key; it now costs one. A wider cache would grow with the object
+  // count for no additional hit rate.
+  int? _memoObject;
+  int? _memoGeneration;
+  bool? _memoAes;
+  Uint8List? _memoKey;
+
   /// Algorithm 1: file key + object number and generation (+ the AES salt).
   /// AES-256 (R5/R6) uses the file key directly.
   Uint8List _objectKey(int objectNumber, int generation,
+      {required bool aes}) {
+    if (_memoObject == objectNumber &&
+        _memoGeneration == generation &&
+        _memoAes == aes) {
+      return _memoKey!;
+    }
+    final key = _deriveObjectKey(objectNumber, generation, aes: aes);
+    _memoObject = objectNumber;
+    _memoGeneration = generation;
+    _memoAes = aes;
+    _memoKey = key;
+    return key;
+  }
+
+  Uint8List _deriveObjectKey(int objectNumber, int generation,
       {required bool aes}) {
     final input = BytesBuilder()
       ..add(_fileKey)

--- a/packages/pdf_cos/test/encryption_test.dart
+++ b/packages/pdf_cos/test/encryption_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
@@ -195,5 +196,53 @@ void main() {
     final doc = CosDocument.open(buildEncryptedPdf(revision: 6));
     expect(doc.encryption!.revision, 6);
     expect(doc.encryption!.streamCipher, PdfCipher.aes256);
+  });
+
+  // The object key is memoised for the most recently used
+  // (objectNumber, generation, aes) triple. These pin the staleness risk that
+  // introduces: interleaving objects, generations, and the string/stream
+  // cipher must never let one object's key serve another's content.
+  group('object-key memoisation', () {
+    test('interleaved objects decrypt as if each were done alone', () {
+      final doc = CosDocument.open(buildEncryptedPdf(revision: 3));
+      final handler = doc.encryption!;
+      final plain = Uint8List.fromList(List.generate(24, (i) => i * 5 & 0xFF));
+
+      final alone = [
+        for (final (n, g) in [(3, 0), (4, 0), (3, 1), (900, 7)])
+          handler.encryptString(plain, n, g),
+      ];
+      // Same derivations, now interleaved so the memo is evicted between
+      // every call and re-derived for a triple it has already seen.
+      final interleaved = <Uint8List>[];
+      for (final (n, g) in [(3, 0), (4, 0), (3, 1), (900, 7)]) {
+        handler.encryptString(plain, 12345, 0); // evict
+        interleaved.add(handler.encryptString(plain, n, g));
+      }
+      expect(interleaved, alone);
+    });
+
+    test('object number, generation, and the AES salt each change the key', () {
+      final doc = CosDocument.open(buildEncryptedPdf(revision: 3));
+      final handler = doc.encryption!;
+      final plain = Uint8List.fromList(List.filled(16, 0x5A));
+      final base = handler.encryptString(plain, 5, 0);
+      expect(handler.encryptString(plain, 6, 0), isNot(base));
+      expect(handler.encryptString(plain, 5, 1), isNot(base));
+      // Round-trips still hold after all that interleaving.
+      expect(handler.decryptString(base, 5, 0), plain);
+    });
+
+    test('a mixed string/stream cipher document keys each correctly', () {
+      // V4 can point /StrF and /StmF at different filters, so the same object
+      // alternates the AES salt between its strings and its stream.
+      final doc = CosDocument.open(buildEncryptedPdf(revision: 4));
+      final handler = doc.encryption!;
+      final plain = Uint8List.fromList(List.filled(32, 0x11));
+      final asString = handler.encryptString(plain, 8, 0);
+      final asStream = handler.encryptStream(plain, 8, 0);
+      expect(handler.decryptString(asString, 8, 0), plain);
+      expect(handler.decryptStream(asStream, 8, 0), plain);
+    });
   });
 }


### PR DESCRIPTION
## What

`decryptObjectGraph` walks one indirect object's whole graph under a fixed `(objectNumber, generation)`, but every string in it re-derived the object key from scratch — an MD5 over the file key, per string. A 200-string object paid 200 MD5s for one distinct key.

Memoises the last derivation. **One entry is enough** precisely because the access pattern is per-object; a wider cache would grow with the object count for no extra hit rate.

## Measured

200-string object graph, min-of-200, alternating before/after runs:

| | before | after | |
|---|---|---|---|
| RC4-128 (R3) | 0.284 / 0.296 ms | 0.195 / 0.187 ms | **1.51×** |
| AES-128 (R4) | 0.349 / 0.357 ms | 0.262 / 0.250 ms | **1.38×** |

## Deliberately not included: the AES-CBC allocation half

#400 also asks to remove the per-block `Uint8List.fromList` in `Aes.cbcDecrypt`. I implemented it — the previous ciphertext block can be read in place from `data`, which CBC never modifies, exactly as `cbcEncrypt` already does with a view — and then could not measure any benefit:

| payload | before | after |
|---|---|---|
| 1 MB | 60.1 ms | 60.9 ms |
| 4 MB | 246.8 ms | 248.5 ms |
| 8 MB | 492.0 ms | 493.9 ms |

The block cipher dominates and the VM's young-generation allocation of a 16-byte list is free at this scale. Changing working crypto for an unmeasurable gain is a bad trade, so it is **dropped**, not shipped on the strength of the argument. Same call as the ICC per-pixel memo in #399.

If someone later shows allocation pressure matters here (a constrained mobile heap, or dart2js where allocation behaves differently), the change is three lines and the reasoning is recorded above.

## Tests

The three new tests are **correctness guards, not failing-first proofs** — they pass on main too, which is the point. They pin the staleness risk the memo introduces:

- interleaved objects decrypt identically to doing each alone (the memo is evicted between every call and re-derived for triples it has already seen)
- object number, generation, and the AES salt each change the key
- a V4 document with different `/StrF` and `/StmF` filters keys strings and streams correctly under one object number

Without them, a future change to the memo could silently serve one object's key for another's content — which decrypts to garbage rather than failing loudly.

`pdf_cos`: **335 tests pass**. `dart analyze lib`: clean.

Closes #400.