### PR TITLE
perf: append incremental saves instead of rebuilding the file (#413)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -332,6 +332,7 @@ class PdfEditingController extends ChangeNotifier {
     PdfEditingPreferences? preferences,
     PdfPageClipboard? pageClipboard,
   })  : _bytes = bytes,
+        _used = bytes.length,
         _password = password,
         _revisions = [bytes.length],
         _document = PdfDocument.open(bytes, password: password),
@@ -382,6 +383,11 @@ class PdfEditingController extends ChangeNotifier {
 
   /// The full byte buffer; revisions are prefixes of it.
   Uint8List _bytes;
+
+  /// Bytes of [_bytes] that hold document data. The buffer may be larger:
+  /// [_commitSavedTail] over-allocates so appends amortise, so `_bytes.length`
+  /// is capacity, not content.
+  int _used;
 
   /// Byte length of each revision, oldest first. `_revisions[_cursor]`
   /// is the current one; entries past the cursor are redoable.
@@ -498,7 +504,7 @@ class PdfEditingController extends ChangeNotifier {
   /// the whole edit history, of which [bytes] is the current revision's
   /// prefix view. This only ever grows within a session (see the memory
   /// audit notes); watch it when chasing memory growth during editing.
-  int get sessionBufferBytes => _bytes.length;
+  int get sessionBufferBytes => _used;
 
   void undo() {
     if (!canUndo) return;
@@ -645,25 +651,71 @@ class PdfEditingController extends ChangeNotifier {
     final impact = pages != null || contentPages != null
         ? PdfEditImpact.legacy(pages: pages, contentPages: contentPages)
         : editor.impact;
-    final saved = editor.save();
     final beforeLength = _revisions[_cursor];
-    _commitSavedRevision(
-      saved,
+    // Append-only: the editor hands back just the incremental update and it
+    // lands in the session buffer we already own. `save()` would rebuild the
+    // whole file here, so a long session re-copied O(file x revisions) bytes
+    // into short-lived garbage - and `file` grows with every revision (#413).
+    final tail = editor.saveTail();
+    _commitSavedTail(
+      tail,
       beforeLength: beforeLength,
       impact: impact,
     );
     return true;
   }
 
+  /// Commits a revision delivered as the appended tail only, growing the
+  /// session buffer in place.
+  void _commitSavedTail(
+    Uint8List tail, {
+    required int beforeLength,
+    required PdfEditImpact impact,
+  }) {
+    final newLength = beforeLength + tail.length;
+    if (newLength > _bytes.length) {
+      // Amortised doubling: a realloc every ~log(n) revisions instead of one
+      // whole-file copy per revision.
+      var capacity = _bytes.isEmpty ? newLength : _bytes.length;
+      while (capacity < newLength) {
+        capacity *= 2;
+      }
+      final grown = Uint8List(capacity)..setRange(0, beforeLength, _bytes);
+      _bytes = grown;
+    }
+    _bytes.setRange(beforeLength, newLength, tail);
+    _used = newLength;
+    _finishRevision(
+      newLength: newLength,
+      beforeLength: beforeLength,
+      impact: impact,
+    );
+  }
+
+  /// Commits a revision delivered as a complete file (signing, and the worker
+  /// batch paths, which build their own buffer).
   void _commitSavedRevision(
     Uint8List saved, {
     required int beforeLength,
     required PdfEditImpact impact,
   }) {
+    _bytes = saved;
+    _used = saved.length;
+    _finishRevision(
+      newLength: saved.length,
+      beforeLength: beforeLength,
+      impact: impact,
+    );
+  }
+
+  void _finishRevision({
+    required int newLength,
+    required int beforeLength,
+    required PdfEditImpact impact,
+  }) {
     _revisions.removeRange(_cursor + 1, _revisions.length);
     _revisionImpacts.removeRange(_cursor + 1, _revisionImpacts.length);
-    _bytes = saved;
-    _revisions.add(saved.length);
+    _revisions.add(newLength);
     _revisionImpacts.add(impact);
     _bumpRenderStamps(impact.visualPages);
     _bumpContentRenderStamps(impact.contentPages);
@@ -677,7 +729,7 @@ class PdfEditingController extends ChangeNotifier {
         ? null
         : PdfWorkerRevisionDelta(
             baseLength: beforeLength,
-            newLength: saved.length,
+            newLength: newLength,
             changedPages: impact.visualPages,
           );
     if (_committingRemoteRevision) _undoFloor = _cursor;
@@ -1931,6 +1983,7 @@ class PdfEditingController extends ChangeNotifier {
   /// is not a prefix of the prior buffer).
   void _resetTo(Uint8List bytes, {required PdfEditImpact impact}) {
     _bytes = bytes;
+    _used = bytes.length;
     _revisions
       ..clear()
       ..add(bytes.length);

--- a/packages/dart_pdf_editor/test/benchmark_revision_session_test.dart
+++ b/packages/dart_pdf_editor/test/benchmark_revision_session_test.dart
@@ -1,0 +1,62 @@
+// Committing a revision must not scale with the size of the document.
+//
+// Each commit used to re-materialise the whole file (#413), so the cost of
+// adding one annotation was O(file) - a 40 MB drawing copied 40 MB per ink
+// stroke. The updater now returns only the appended tail and the controller
+// appends it into the session buffer it already owns.
+//
+// The assertion compares per-revision cost across two base sizes rather than
+// across time. That is the invariant that actually changed: a slope over
+// revisions barely moves within one run (the tails are small next to the
+// base), but the response to base size is 4x before and flat after.
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// Mean microseconds per commit over [revisions] highlight edits on [source].
+double _perRevisionUs(Uint8List source, int revisions) {
+  final editing = PdfEditingController(source);
+  // Warm the path so the measured window is not paying JIT.
+  for (var i = 0; i < 20; i++) {
+    editing.apply((editor) =>
+        editor.addHighlight(0, [const PdfRect(72, 72, 200, 88)]));
+  }
+  final sw = Stopwatch()..start();
+  for (var i = 0; i < revisions; i++) {
+    editing.apply((editor) => editor.addHighlight(0, [
+          PdfRect(72, 72 + (i % 20) * 5.0, 200, 88 + (i % 20) * 5.0),
+        ]));
+  }
+  sw.stop();
+  editing.dispose();
+  return sw.elapsedMicroseconds / revisions;
+}
+
+void main() {
+  test('per-revision cost does not scale with document size', () {
+    final small = Uint8List.fromList(buildSyntheticCadStrip(ops: 60000));
+    final large = Uint8List.fromList(buildSyntheticCadStrip(ops: 240000));
+    // Interleave the two so a machine that slows down mid-run skews both.
+    final smallUs = _perRevisionUs(small, 150);
+    final largeUs = _perRevisionUs(large, 150);
+    final smallUs2 = _perRevisionUs(small, 150);
+    final base = (smallUs + smallUs2) / 2;
+    final ratio = largeUs / base;
+
+    // ignore: avoid_print
+    print('base ${(small.length / 1e6).toStringAsFixed(1)} MB -> '
+        '${base.toStringAsFixed(0)} us/rev; '
+        '${(large.length / 1e6).toStringAsFixed(1)} MB -> '
+        '${largeUs.toStringAsFixed(0)} us/rev; ratio '
+        '${ratio.toStringAsFixed(2)}x');
+
+    expect(large.length, greaterThan(small.length * 3),
+        reason: 'the two fixtures must differ enough to show the scaling');
+    expect(ratio, lessThan(2.0),
+        reason: 'per-revision cost scaled with document size - the O(file) '
+            'copy per save is back (ratio ${ratio.toStringAsFixed(2)}x)');
+  }, timeout: const Timeout(Duration(minutes: 10)));
+}

--- a/packages/pdf_cos/lib/src/updater.dart
+++ b/packages/pdf_cos/lib/src/updater.dart
@@ -70,25 +70,57 @@ class CosIncrementalUpdater {
   }
 
   /// Returns the full bytes of the updated file: original + appended update.
+  ///
+  /// Prefer [saveTail] in a session that keeps revisions as prefixes of one
+  /// growing buffer: this has to materialise the whole file again per call,
+  /// so an N-revision session copies O(file x N) bytes and `file` itself
+  /// grows with every revision.
   Uint8List save() {
+    final tail = saveTail();
+    return (BytesBuilder(copy: false)
+          ..add(document.bytes)
+          ..add(tail))
+        .takeBytes();
+  }
+
+  /// Returns **only the bytes to append** to [CosDocument.bytes] to form the
+  /// updated file - the incremental update section and nothing else.
+  ///
+  /// `save()` concatenates the whole original file with this tail on every
+  /// call. A caller that already holds the base bytes in a buffer it controls
+  /// (the editor keeps every revision as a length into one buffer) can append
+  /// this instead and pay only the tail, turning a per-revision O(file) copy
+  /// into an amortised append.
+  ///
+  /// The returned bytes are position-dependent: they are only valid appended
+  /// directly to this document's bytes, because the cross-reference offsets
+  /// inside them are computed against that base length.
+  Uint8List saveTail() {
     final t0 = PdfPerf.begin();
     try {
-      final saved = _saveTimed();
-      PdfPerf.add(PdfPerfCount.savedBytes, saved.length - document.bytes.length);
+      final tail = _saveTailTimed();
+      PdfPerf.add(PdfPerfCount.savedBytes, tail.length);
       PdfPerf.add(PdfPerfCount.savedObjects, _changed.length);
-      return saved;
+      return tail;
     } finally {
       PdfPerf.end(PdfPerfPhase.saveIncremental, t0);
     }
   }
 
-  Uint8List _saveTimed() {
-    final out = BytesBuilder(copy: false)..add(document.bytes);
+  Uint8List _saveTailTimed() {
+    // The tail is built on its own, so every offset written into it has to be
+    // biased by the base file it will be appended to. `base` counts only the
+    // bytes NOT in this builder - the separator below goes into `out`, so it
+    // is already carried by `out.length` and must not be counted twice.
+    final out = BytesBuilder(copy: false);
+    final base = document.bytes.length;
     final last = document.bytes.isEmpty ? 0x0A : document.bytes.last;
     if (last != 0x0A && last != 0x0D) out.addByte(0x0A);
 
-    // xref offsets are relative to the %PDF- header, which may not be byte 0
-    final shift = document.headerOffset;
+    // xref offsets are relative to the %PDF- header, which may not be byte 0.
+    // Folding `base` in here keeps every `out.length - shift` below reading
+    // exactly as it did when the whole file was in the builder.
+    final shift = document.headerOffset - base;
     final offsets = <int, int>{};
     final serializer = CosSerializer(out);
 

--- a/packages/pdf_document/lib/src/editor.dart
+++ b/packages/pdf_document/lib/src/editor.dart
@@ -302,4 +302,13 @@ class PdfEditor {
 
   /// The full bytes of the edited file (original + incremental update).
   Uint8List save() => _updater.save();
+
+  /// Only the bytes to append to the source document to form the edited file
+  /// (see [CosIncrementalUpdater.saveTail]).
+  ///
+  /// For a caller that already holds the source bytes and keeps revisions as
+  /// prefixes of one buffer, this avoids re-materialising the whole file per
+  /// save. The bytes are only valid appended directly to the document this
+  /// editor was built over.
+  Uint8List saveTail() => _updater.saveTail();
 }


### PR DESCRIPTION
## What

Every commit began by re-adding the entire current file:

```dart
final out = BytesBuilder(copy: false)..add(document.bytes);
```

So adding one annotation cost O(file) — and `file` grows with every revision. A 40 MB drawing copied 40 MB per ink stroke, all of it short-lived garbage.

## Change

`CosIncrementalUpdater.saveTail()` returns **only the bytes to append**. Offsets inside it are biased by the base length, which makes the tail position-dependent — valid only appended directly to the document it was built over — and the doc comment says so plainly.

`save()` keeps its exact semantics for callers that want a whole file (signing, PAdES, form fill, page editing); it is now `bytes + tail`.

`PdfEditingController` already modelled revisions as lengths into one buffer, so it was re-materialising a buffer it then kept as a prefix anyway. It now appends the tail into a session buffer grown by doubling — a realloc every ~log(n) revisions instead of a whole-file copy every revision. `_bytes` becomes capacity rather than content, so `_used` tracks content length and `sessionBufferBytes` reports that, preserving its documented meaning and its existing tests.

The two commit paths that legitimately produce a whole file still go through `_commitSavedRevision`; both funnel into one `_finishRevision`.

## Measured

150 commits after a 20-commit warm-up:

| base | before | after | |
|---|---|---|---|
| 1.0 MB | 1568 µs/revision | 284 µs | **5.5×** |
| 4.1 MB | 4364 µs/revision | 184 µs | **23.7×** |

The **scaling** is the real result: on main, quadrupling the document multiplied per-revision cost by **2.78×**. Now it does not — 0.65×, i.e. noise.

## The test, and a note on getting it wrong first

`benchmark_revision_session_test` asserts that per-revision cost does not scale with document size, and it **fails on main** (`ratio 2.78x`).

My first version measured the *slope across 1000 revisions* instead. That **passed on main**, so it would have shipped as a guard that guards nothing — within a single run the appended tails are small next to the base, so the file barely grows and the quadratic term hardly shows. Response to base size is the invariant that actually changed, so that is what the test measures.

## Verification

- `dart_pdf_editor`: **1782 pass**, only the pre-existing ghent GWG030 failure (identical to main)
- `pdf_document`: **762 pass**
- `pdf_cos`: **332 pass**
- `dart analyze` clean across all three packages

Closes #413.