### PR TITLE
perf(editor): cache annotation appearance pictures by stream identity (#404)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5681,6 +5681,25 @@ class _AnnotationAppearanceLayerState
   List<ui.Picture> _pictures = const [];
   Size? _picturePageSize;
 
+  /// Rendered appearances keyed on the appearance stream itself.
+  ///
+  /// An incremental revision keeps the COS object cache (the byte prefix is
+  /// unchanged, so `CosDocument` hands back the same instances), which means
+  /// an untouched annotation's appearance stream is *identical* across
+  /// revisions. Every commit used to re-render every appearance on the page -
+  /// each one an ImageCollector scan, an image decode, and an interpreter
+  /// walk - so a page of 50 highlights paid 50 renders per stroke (#404).
+  ///
+  /// Only the entries whose stream changed are re-rendered. The cache owns
+  /// every picture in it; [_pictures] is an ordered view and never disposes.
+  ///
+  /// Keyed as `Object` because `CosStream` is not exported into this library.
+  /// `CosStream` uses identity equality, so this is keyed on the stream
+  /// instance - which is exactly the intent.
+  final Map<Object, ui.Picture> _cache = {};
+  int? _cacheRotation;
+  Size? _cacheSize;
+
   @override
   void initState() {
     super.initState();
@@ -5708,15 +5727,29 @@ class _AnnotationAppearanceLayerState
   void dispose() {
     _generation++;
     _disposePictures();
+    _disposeCache();
     super.dispose();
   }
 
+  /// Drops the ordered view. Pictures belong to [_cache], so this never
+  /// disposes - doing so would hand the painter freed handles on the next
+  /// frame that reuses a cached appearance.
   void _disposePictures() {
-    for (final picture in _pictures) {
-      picture.dispose();
-    }
     _pictures = const [];
     _picturePageSize = null;
+  }
+
+  void _disposeCache() {
+    for (final picture in _cache.values) {
+      picture.dispose();
+    }
+    _cache.clear();
+    _cacheRotation = null;
+    _cacheSize = null;
+    for (final picture in _retired) {
+      if (!picture.debugDisposed) picture.dispose();
+    }
+    _retired.clear();
   }
 
   void _notifyReady(int generation) {
@@ -5732,6 +5765,16 @@ class _AnnotationAppearanceLayerState
     final page = widget.page;
     final pageSize =
         PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation);
+    // Pictures bake in the page transform, so a rotation or size change
+    // invalidates every one of them. Retire rather than dispose: _pictures
+    // still references these until the next publish, and a frame can paint
+    // in between.
+    if (_cacheRotation != widget.rotation || _cacheSize != pageSize) {
+      _retire(_cache.values);
+      _cache.clear();
+      _cacheRotation = widget.rotation;
+      _cacheSize = pageSize;
+    }
     final annotations = [
       for (final annotation in page.annotations)
         if (!annotation.isHidden &&
@@ -5740,31 +5783,89 @@ class _AnnotationAppearanceLayerState
           annotation,
     ];
     if (annotations.isEmpty) {
-      _disposePictures();
-      _notifyReady(generation);
+      _publish(generation, const [], pageSize);
+      return;
+    }
+
+    // Retire appearances no longer on the page, so a page whose annotations
+    // are repeatedly replaced cannot accumulate pictures. Disposal waits for
+    // the publish below (see [_retire]).
+    final live = {
+      for (final annotation in annotations) annotation.normalAppearance!,
+    };
+    for (final source in _cache.keys.toList()) {
+      if (!live.contains(source)) _retire([_cache.remove(source)!]);
+    }
+
+    final missing = [
+      for (final annotation in annotations)
+        if (!_cache.containsKey(annotation.normalAppearance)) annotation,
+    ];
+    if (missing.isEmpty) {
+      _publish(generation, annotations, pageSize);
       return;
     }
     unawaited(Future.wait([
-      for (final annotation in annotations)
-        _renderAnnotation(page, annotation, widget.rotation),
-    ]).then((pictures) {
-      final next = [
-        for (final picture in pictures)
-          if (picture != null) picture,
-      ];
+      for (final annotation in missing)
+        _renderAnnotation(page, annotation, widget.rotation)
+            .then((picture) => (annotation.normalAppearance!, picture)),
+    ]).then((rendered) {
       if (!mounted || generation != _generation) {
-        for (final picture in next) {
-          picture.dispose();
+        for (final (_, picture) in rendered) {
+          picture?.dispose();
         }
         return;
       }
-      setState(() {
-        _disposePictures();
-        _pictures = next;
-        _picturePageSize = pageSize;
-      });
-      _notifyReady(generation);
+      for (final (source, picture) in rendered) {
+        if (picture == null) continue;
+        // A concurrent render may have filled this slot; keep one owner.
+        final existing = _cache[source];
+        if (existing != null) {
+          picture.dispose();
+          continue;
+        }
+        _cache[source] = picture;
+      }
+      _publish(generation, annotations, pageSize);
     }));
+  }
+
+  /// Rebuilds the ordered picture list from [_cache] and repaints, then frees
+  /// anything retired by the render that produced it.
+  void _publish(
+      int generation, List<PdfAnnotation> annotations, Size pageSize) {
+    if (!mounted || generation != _generation) return;
+    final next = [
+      for (final annotation in annotations)
+        if (_cache[annotation.normalAppearance] case final picture?) picture,
+    ];
+    setState(() {
+      _pictures = next;
+      _picturePageSize = pageSize;
+    });
+    _flushRetired();
+    _notifyReady(generation);
+  }
+
+  /// Pictures dropped from [_cache] but possibly still referenced by the
+  /// [_pictures] the painter is holding.
+  ///
+  /// Disposing one on the spot crashes the next paint that touches it -
+  /// `Canvas.drawPicture` asserts on a disposed picture - and there is a real
+  /// window for that, because a render awaits its missing appearances and a
+  /// frame can paint in between. They are freed once [_pictures] has been
+  /// replaced and no longer names them.
+  final List<ui.Picture> _retired = [];
+
+  void _retire(Iterable<ui.Picture> pictures) => _retired.addAll(pictures);
+
+  void _flushRetired() {
+    if (_retired.isEmpty) return;
+    final live = Set<ui.Picture>.identity()..addAll(_pictures);
+    for (final picture in _retired) {
+      if (!live.contains(picture)) picture.dispose();
+    }
+    _retired.clear();
   }
 
   Future<ui.Picture?> _renderAnnotation(

--- a/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
+++ b/packages/dart_pdf_editor/test/annotation_appearance_cache_test.dart
@@ -1,0 +1,91 @@
+// _AnnotationAppearanceLayer caches rendered appearances by appearance-stream
+// identity (#404), so committing one edit no longer re-renders every
+// annotation on the page.
+//
+// The risk caching introduces is lifetime, not reuse: a picture dropped from
+// the cache may still be referenced by the list the painter holds, and
+// Canvas.drawPicture ASSERTS on a disposed picture. A first cut disposed on
+// eviction and broke ~40 existing tests, because a render awaits its missing
+// appearances and a frame can paint during that window.
+//
+// These pump through the transitions that open that window. A
+// disposed-picture paint surfaces as an unhandled framework exception, which
+// flutter_test fails on by itself, so the pumps carry the real assertion and
+// the expects below just pin the document state.
+//
+// Re-run against the disposing version, the last TWO fail: restyling replaces
+// one appearance stream and deleting drops one, so both evict. The first only
+// adds annotations, so nothing is ever evicted and it passes either way - it
+// is here to cover the plain repeat-commit path, not the lifetime bug.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<PdfEditingController> pumpViewer(WidgetTester tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    addTearDown(editing.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ListenableBuilder(
+          listenable: editing,
+          builder: (context, _) => PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: editing.document,
+            editing: editing,
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    return editing;
+  }
+
+  testWidgets('repeated commits on an annotated page keep painting',
+      (tester) async {
+    final editing = await pumpViewer(tester);
+    for (var i = 0; i < 6; i++) {
+      editing.addRectangle(
+          0, PdfRect(100, 600.0 - i * 20, 250, 640.0 - i * 20));
+      await tester.pumpAndSettle();
+    }
+    expect(editing.document.page(0).annotations, hasLength(6));
+  });
+
+  testWidgets('restyling one annotation keeps the other on screen',
+      (tester) async {
+    final editing = await pumpViewer(tester);
+    editing.addRectangle(0, const PdfRect(100, 600, 250, 640));
+    editing.addRectangle(0, const PdfRect(300, 600, 450, 640));
+    await tester.pumpAndSettle();
+
+    // One appearance stream is replaced; the other is untouched and has to
+    // survive out of the cache while the replacement renders.
+    expect(editing.selectAnnotation(0, 0), isTrue);
+    expect(editing.restyleSelected(color: const Color(0xFF00FF00)), isTrue);
+    await tester.pumpAndSettle();
+    expect(editing.document.page(0).annotations, hasLength(2));
+  });
+
+  testWidgets('deleting then undoing retires and revives pictures safely',
+      (tester) async {
+    final editing = await pumpViewer(tester);
+    editing.addRectangle(0, const PdfRect(100, 600, 250, 640));
+    editing.addRectangle(0, const PdfRect(300, 600, 450, 640));
+    await tester.pumpAndSettle();
+
+    expect(editing.selectAnnotation(0, 0), isTrue);
+    editing.deleteSelected();
+    await tester.pumpAndSettle();
+    expect(editing.document.page(0).annotations, hasLength(1));
+
+    editing.undo();
+    await tester.pumpAndSettle();
+    expect(editing.document.page(0).annotations, hasLength(2));
+  });
+}


### PR DESCRIPTION
> **Stacked on #441** (`perf/page-instance-cache`). Review that first; this diff is the top commit only. It does not actually *depend* on the page cache — it keys on appearance streams, not pages — but it was branched from it.

## What

`_AnnotationAppearanceLayer` re-rendered **every** appearance on a page after **every** revision. A page of 40 highlights paid 40 renders per stroke — each an `ImageCollector` scan, an image decode, and an interpreter walk — though only one annotation had changed.

Pictures are now cached keyed on the appearance stream itself. An incremental revision keeps the COS object cache (the byte prefix is unchanged, so `CosDocument` hands back the same instances), so an untouched annotation's appearance stream is **identical** across revisions and only the edited one re-renders. `CosStream` uses identity equality, which is exactly the intent.

## Measured

Ten commits on a 40-annotation page:

| before | after | |
|---|---|---|
| 13.4 ms/commit | 7.8 ms/commit | **1.7×** |

The saving scales with annotation count, and these are cheap rectangle appearances — image-bearing markup gains more.

## The hazard is lifetime, not reuse

A first cut disposed pictures on eviction and **broke ~40 existing tests**. The painter still holds the previous `_pictures` list; a render awaits its missing appearances; a frame paints in that window; `Canvas.drawPicture` asserts on a disposed picture.

Eviction now **retires** pictures, and `_publish` frees them only once `_pictures` has been replaced and no longer names them. That ordering is the whole correctness argument, so it is commented where it lives.

## Tests

Three new tests. **Two fail against the disposing version** — restyle and delete both evict. The third only adds annotations, so nothing is ever evicted and it passes either way; its comment says so rather than implying it guards the lifetime bug. I checked this rather than assuming it, having first written a comment claiming all three failed.

There is no explicit matcher for the crash: a disposed-picture paint surfaces as an unhandled framework exception that `flutter_test` fails on by itself, so the pumps carry the assertion and the `expect`s pin document state.

## On the stated dependency

The ticket lists this as blocked by #393's parsed-ops cache. **It is not** — caching the finished picture skips the walk entirely, so #393 would only speed up the misses.

## Verification

`dart_pdf_editor`: **1782 pass**, only the pre-existing ghent GWG030. `dart analyze` clean.

Closes #404.