### PR TITLE
perf(document): O(1) widget→page, cached widgets, hoisted /Widths (#406)

### DIFF
--- a/packages/pdf_document/lib/src/form.dart
+++ b/packages/pdf_document/lib/src/form.dart
@@ -102,24 +102,43 @@ class PdfAcroForm {
         for (var i = 0; i < document.pageCount; i++) document.page(i).dict,
       ];
 
+  /// Widget dictionary → the first page whose /Annots lists it, built by one
+  /// walk of every page's /Annots instead of one walk per widget.
+  ///
+  /// Batch form work resolves a page for every widget of every field, so the
+  /// old per-widget scan was O(fields x widgets x pages x annots) for a single
+  /// operation (#406). Resolved objects are cached by reference, so keying on
+  /// the dictionary is identity-keyed as intended.
+  Map<CosDictionary, int>? _widgetPageCache;
+
+  Map<CosDictionary, int> get _widgetPages => _widgetPageCache ??= () {
+        final cos = document.cos;
+        final out = <CosDictionary, int>{};
+        for (var i = 0; i < _pages.length; i++) {
+          final annots = cos.resolve(_pages[i]['Annots']);
+          if (annots is! CosArray) continue;
+          for (final item in annots.items) {
+            final annot = cos.resolve(item);
+            // putIfAbsent keeps "the FIRST page whose /Annots lists it",
+            // matching the scan this replaces.
+            if (annot is CosDictionary) out.putIfAbsent(annot, () => i);
+          }
+        }
+        return out;
+      }();
+
   /// The page index of [widget]: its /P entry when present, otherwise
   /// the first page whose /Annots lists it. −1 when no page claims it.
   int _pageIndexOf(CosDictionary widget) {
-    final cos = document.cos;
-    final p = cos.resolve(widget['P']);
+    final p = document.cos.resolve(widget['P']);
     if (p is CosDictionary) {
-      for (var i = 0; i < _pages.length; i++) {
-        if (identical(_pages[i], p)) return i;
-      }
+      // pageIndexOf is an identity map lookup (#397/#417) and returns -1 for
+      // a /P that is not a leaf of this tree, which falls through exactly as
+      // the old linear scan over _pages did.
+      final byP = document.pageIndexOf(p);
+      if (byP >= 0) return byP;
     }
-    for (var i = 0; i < _pages.length; i++) {
-      final annots = cos.resolve(_pages[i]['Annots']);
-      if (annots is! CosArray) continue;
-      for (final item in annots.items) {
-        if (identical(cos.resolve(item), widget)) return i;
-      }
-    }
-    return -1;
+    return _widgetPages[widget] ?? -1;
   }
 
   /// A node with /T-carrying kids is an internal node; a node whose kids
@@ -300,7 +319,18 @@ class PdfFormField {
   /// [PdfAcroForm._reconcileOrphanWidgets], or null for a normally
   /// structured field. When set, [widgets] returns these (they are what
   /// the page actually shows) and [value]/[isChecked] consult them first.
-  List<CosDictionary>? _reconciled;
+  ///
+  /// Assigned after construction, so it must drop [_widgets]: a field whose
+  /// widgets were read before reconciliation would otherwise keep serving the
+  /// pre-adoption list for the rest of its life.
+  List<CosDictionary>? get _reconciled => _reconciledValue;
+
+  set _reconciled(List<CosDictionary>? value) {
+    _reconciledValue = value;
+    _widgets = null;
+  }
+
+  List<CosDictionary>? _reconciledValue;
 
   /// The widgets this field adopted from outside /Fields during
   /// reconciliation (empty for well-formed fields). The field dictionary
@@ -460,7 +490,14 @@ class PdfFormField {
   /// The widget annotations displaying this field: the on-page copies
   /// adopted by reconciliation when present, otherwise its /Kids without a
   /// /T of their own, or the field dictionary itself when merged.
-  List<CosDictionary> get widgets {
+  List<CosDictionary> get widgets => _widgets ??= _resolveWidgets();
+
+  /// Resolved once per field instance: [widgets] is read repeatedly per fill
+  /// (appearance regeneration, rect lookups, page resolution) and re-walked
+  /// /Kids every time.
+  List<CosDictionary>? _widgets;
+
+  List<CosDictionary> _resolveWidgets() {
     if (_reconciled != null) return _reconciled!;
     final kids = _cos.resolve(dict['Kids']);
     if (kids is CosArray) {

--- a/packages/pdf_document/lib/src/form_editor.dart
+++ b/packages/pdf_document/lib/src/form_editor.dart
@@ -462,6 +462,10 @@ extension PdfFormFilling on PdfEditor {
     // its program so the appearance can encode and measure with it. A
     // base-14 /DR entry stays on the simple byte path. Text past Latin-1 is
     // only sanitized for the simple fonts - an embedded font can show it.
+    // /Widths resolved once for this regeneration. The auto-size loop
+    // re-measures the same text up to ~16 times while shrinking, and each
+    // measure used to `cos.resolve` one array entry PER CHARACTER (#406).
+    final fontWidths = fontDict == null ? null : _fieldWidthMetrics(fontDict);
     final embedded = fontDict == null
         ? null
         : PdfEmbeddedFont.fromFontDict(cos, fontDict, da.fontName);
@@ -480,7 +484,7 @@ extension PdfFormFilling on PdfEditor {
 
       double measure(String s, double size) => embedded != null
           ? embedded.measure(s, size)
-          : _measureFieldText(fontDict, s, size);
+          : _measureFieldText(fontDict, s, size, widths: fontWidths);
 
       final multiline = field.isMultiline;
       // Line boxes are laid out and clipped in the field's own /Widths (or the
@@ -746,22 +750,39 @@ extension PdfFormFilling on PdfEditor {
 
   /// Text width in user units: explicit /Widths when the font has them,
   /// otherwise Helvetica metrics (the dominant /DR font family).
-  double _measureFieldText(CosDictionary? font, String text, double size) {
+  /// A font's /FirstChar plus its /Widths flattened to plain doubles, or null
+  /// when the font carries no usable metrics.
+  (int, List<double>)? _fieldWidthMetrics(CosDictionary font) {
+    final cos = document.cos;
+    final widths = cos.resolve(font['Widths']);
+    final first = cos.resolve(font['FirstChar']);
+    if (widths is! CosArray || first is! CosInteger) return null;
+    return (
+      first.value,
+      <double>[
+        for (final item in widths.items)
+          switch (cos.resolve(item)) {
+            CosInteger(:final value) => value.toDouble(),
+            CosReal(:final value) => value,
+            // Matches the per-character fallback this replaces: a missing or
+            // non-numeric entry measures as 500.
+            _ => 500.0,
+          },
+      ],
+    );
+  }
+
+  double _measureFieldText(CosDictionary? font, String text, double size,
+      {(int, List<double>)? widths}) {
     final cos = document.cos;
     if (font != null) {
-      final widths = cos.resolve(font['Widths']);
-      final first = cos.resolve(font['FirstChar']);
-      if (widths is CosArray && first is CosInteger) {
+      final metrics = widths ?? _fieldWidthMetrics(font);
+      if (metrics != null) {
+        final (first, table) = metrics;
         var total = 0.0;
         for (final code in text.codeUnits) {
-          final index = code - first.value;
-          double? width;
-          if (index >= 0 && index < widths.length) {
-            final n = cos.resolve(widths[index]);
-            if (n is CosInteger) width = n.value.toDouble();
-            if (n is CosReal) width = n.value;
-          }
-          total += width ?? 500;
+          final index = code - first;
+          total += index >= 0 && index < table.length ? table[index] : 500;
         }
         return total * size / 1000;
       }


### PR DESCRIPTION
Three of the ticket's four items.

## 1. Widget → page in O(1)

`_pageIndexOf` scanned **every page's `/Annots` per widget**, so one batch form operation was O(fields × widgets × pages × annots). It now consults a map built by a single walk of every page's `/Annots`, and the `/P` fast path goes through `PdfDocument.pageIndexOf`, which #417 made an identity lookup.

Semantics preserved deliberately: `putIfAbsent` keeps *"the first page whose `/Annots` lists it"*, and a `/P` that is not a leaf of this tree still falls through to the map exactly as it fell through the old linear scan.

## 2. `PdfFormField.widgets` cached

It re-walked `/Kids` on every access, and a single fill reads it repeatedly — appearance regeneration, rect lookups, page resolution.

The subtlety: `_reconciled` is assigned **after** construction, so it is now a setter that drops the cache. Without that, a field whose widgets were read before orphan reconciliation would serve the pre-adoption list for the rest of its life.

I checked that this matters rather than assuming it: deleting that one line makes `form_reconcile_test`'s *"describeFields reports the visible page, not -1"* fail. The hazard is already covered, so it needs no new test.

## 3. `/Widths` hoisted out of the auto-size loop

`_measureFieldText` resolved one `/Widths` entry **per character**, inside a loop that re-measures the same string up to ~16 times while shrinking to fit. The array is flattened to a `List<double>` once per regeneration and threaded in. The 500-unit fallback for a missing or non-numeric entry is preserved exactly.

## Measured

On the AcroForm fixture:

| | before | after | |
|---|---|---|---|
| 20 × auto-size fill | 6.7 ms | 3.9 ms | **1.7×** |
| 50 × `describeFields` | 1.7 ms | 1.5 ms | 1.13× |

**The `describeFields` number is weak evidence and I want to be plain about that.** That fixture is a *single page with 7 widgets* — precisely the case where the widget map barely helps. Its win is algorithmic and shows on the shape the ticket names (server-side batch filling across many pages), and I did not build a large multi-page form to measure it.

## Not done

**Item 2 — caching `PdfAcroForm` on the document.** That needs an invalidation story tied to the page cache, and getting it wrong means serving a stale form after an edit. Left for a change that can carry its own tests rather than bolted on here.

## Verification

`pdf_document`: **762 pass**. `dart analyze` clean.

Refs #406.