### PR TITLE
perf(document): reuse the caller's element snapshot on a targeted edit (#402)

### DIFF
--- a/packages/pdf_document/lib/src/content_editor.dart
+++ b/packages/pdf_document/lib/src/content_editor.dart
@@ -220,6 +220,11 @@ extension PdfContentEditing on PdfEditor {
       fallbackFonts: fallbackFonts,
       style: style,
       operationRange: (element.start, element.end),
+      // The caller already parsed the page to obtain [element]; reusing that
+      // snapshot saves a second decode + full tokenization of the content
+      // stream, which on a dense CAD page is the dominant cost of a
+      // single-word correction (#402).
+      snapshot: elements,
     );
   }
 
@@ -230,6 +235,7 @@ extension PdfContentEditing on PdfEditor {
     required List<PdfEmbeddedFont> fallbackFonts,
     required PdfTextStyle? style,
     (int start, int end)? operationRange,
+    PdfPageElements? snapshot,
   }) {
     if (find.isEmpty) throw ArgumentError.value(find, 'find', 'is empty');
     // the simple-font path is byte-encoded; non-Latin-1 strings can only be
@@ -238,7 +244,17 @@ extension PdfContentEditing on PdfEditor {
     final replaceBytes = _tryLatin1(replace);
 
     final page = document.page(index);
-    final elements = PdfPageElements.of(document, index);
+    // Reuse the caller's snapshot only while this session has not already
+    // rewritten this page's content. A second targeted edit against a
+    // pre-first-edit snapshot would serialize stale operations and silently
+    // drop the earlier one - the identity check in replaceElementText proves
+    // the element belongs to the snapshot, not that the snapshot is current.
+    // A null contentPages means "every page" (a structural edit), so it
+    // invalidates too.
+    final contentPages = _impact.contentPages;
+    final stale = contentPages == null || contentPages.contains(index);
+    final elements =
+        (stale ? null : snapshot) ?? PdfPageElements.of(document, index);
     final cos = document.cos;
     final fonts = cos.resolve(page.resources['Font']);
 

--- a/packages/pdf_document/test/content_edit_test.dart
+++ b/packages/pdf_document/test/content_edit_test.dart
@@ -172,6 +172,69 @@ void main() {
       expect(text, ['Sheet 1', 'Page 2']);
     });
 
+    test('repeated edits through one snapshot compose', () {
+      // replaceElementText reuses the caller's PdfPageElements to skip a
+      // second decode + tokenization (#402). Edits mutate that snapshot's
+      // operation list in place, so successive edits through the SAME
+      // snapshot stay consistent - this pins that contract.
+      final doc = PdfDocument.open(buildContentPdf(
+          'BT /F1 12 Tf 72 700 Td (Page 1) Tj 0 -20 Td (Page 2) Tj ET'));
+      final elements = PdfPageElements.of(doc, 0);
+      final texts = elements.elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .toList();
+      final editor = PdfEditor(doc);
+
+      expect(
+          editor.replaceElementText(elements, texts.first, 'Page', 'Sheet'), 1);
+      expect(
+          editor.replaceElementText(elements, texts[1], 'Page', 'Folio'), 1);
+
+      final reopened = PdfDocument.open(editor.save());
+      final text = PdfPageElements.of(reopened, 0)
+          .elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .map((element) => element.text)
+          .toList();
+      expect(text, ['Sheet 1', 'Folio 2'],
+          reason: 'the first edit must survive the second');
+    });
+
+    test('an edit made through another snapshot is not clobbered', () {
+      // The hazard the snapshot reuse actually introduces: a DIFFERENT
+      // snapshot rewrites the page in between, so the held one no longer
+      // describes the document. Reusing it there would serialize operations
+      // that predate the other edit and silently undo it.
+      final doc = PdfDocument.open(buildContentPdf('BT /F1 12 Tf 72 700 Td '
+          '(Page 1) Tj 0 -20 Td (Page 2) Tj 0 -20 Td (Page 3) Tj ET'));
+      final held = PdfPageElements.of(doc, 0);
+      final texts = held.elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .toList();
+      final editor = PdfEditor(doc);
+
+      expect(editor.replaceElementText(held, texts.first, 'Page', 'Sheet'), 1);
+
+      // A separate snapshot deletes the third run.
+      final fresh = PdfPageElements.of(doc, 0);
+      final freshTexts = fresh.elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .toList();
+      editor.deleteElements(fresh, [freshTexts.last.id]);
+
+      // Back to the held snapshot, which knows nothing of that delete.
+      expect(editor.replaceElementText(held, texts[1], 'Page', 'Folio'), 1);
+
+      final reopened = PdfDocument.open(editor.save());
+      final text = PdfPageElements.of(reopened, 0)
+          .elements
+          .where((element) => element.kind == PdfElementKind.text)
+          .map((element) => element.text)
+          .toList();
+      expect(text, ['Sheet 1', 'Folio 2'],
+          reason: 'the delete made through the other snapshot must survive');
+    });
+
     test('a miss returns zero and queues nothing', () {
       final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
       expect(editor.replaceText(0, 'absent text', 'x'), 0);


### PR DESCRIPTION
## What

`replaceElementText` re-decoded and re-tokenized the **whole content stream** even though the caller had just parsed it to obtain the element being edited. On a dense page that second parse dominates a one-word correction.

Measured on a **265,549-operation** CAD page — open + snapshot + one targeted edit:

| before | after | |
|---|---|---|
| 333.7 ms | 229.1 ms | **1.46×** |

## The guard, and how I found it was needed

`_replaceText` rewrites the page from the snapshot it holds, so a snapshot that no longer describes the document would serialize operations predating another edit and **silently undo it**. Reuse is therefore gated on this session not having already rewritten that page (a null `contentPages` — a structural edit — counts as rewritten).

It is conservative rather than exact. Successive edits through *one* snapshot are actually fine, because applying a rewrite mutates that snapshot's operation list in place, so it stays consistent. Tracking which snapshot last wrote each page would keep the fast path there too — but the fallback is simply today's behaviour, so the conservative version is never worse than main and needs no extra state.

## Two tests, and why both exist

- **`repeated edits through one snapshot compose`** — pins the in-place mutation contract. Passes with *or without* the guard.
- **`an edit made through another snapshot is not clobbered`** — deletes a run via a second snapshot between two edits made through the first. **This one fails without the guard.**

I wrote the first believing it proved the guard, checked, and found it passed with the guard removed. That is what led to identifying the real hazard and writing the second.

## Deliberately not done

**Item 3** — replacing `double.parse(value.toStringAsFixed(3))` with `(value * 1000).roundToDouble() / 1000`. The ticket presents this as a straightforward swap. **It is not the same function**: over 480,009 sampled values they disagree **9,739 times**, systematically at the `.0005` boundary —

```
-9.9995 -> toStringAsFixed -9.999   vs   scaled -10.0
-9.9985 -> toStringAsFixed -9.998   vs   scaled -9.999
```

That changes content-stream output bytes for ~2% of numbers. A rendering-baseline shift is a bad price for what the ticket itself calls a "minor amplifier". If it is wanted, it should be taken as a deliberate output change with baselines reviewed.

**Item 2** (byte-span splicing) remains blocked on #392, as the ticket says: it needs the decoded bytes retained, and that cache is where they live.

## Verification

`pdf_document`: **764 pass**. `dart analyze` clean.

Refs #402.