### PR TITLE
diag(app): forward the render trace into the devtools export

### DIFF
--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -112,6 +112,7 @@ class AppDevTools extends ChangeNotifier {
   bool _capturing = false;
   bool _notifyScheduled = false;
   bool _logTouchInput = false;
+  bool _logPerfTrace = false;
   final Map<int, _TouchTrack> _touchTracks = {};
   DateTime _lastNotify = DateTime.fromMillisecondsSinceEpoch(0);
 
@@ -206,6 +207,29 @@ class AppDevTools extends ChangeNotifier {
 
   static String _fmt(Offset o) =>
       '(${o.dx.toStringAsFixed(0)},${o.dy.toStringAsFixed(0)})';
+
+  // --- perf trace forwarding --------------------------------------------------
+
+  /// Whether [PdfPerfLog] runs AND its lines are forwarded into this log,
+  /// tagged `perf:`. Off by default. The export's pdfPerf block only covers
+  /// the document-open path; this is how the render path (worker traffic,
+  /// interprets, rasters, jank) gets into the same exported trace. Toggling
+  /// installs/removes the package's sink - the package never imports the app,
+  /// so the sink is the seam.
+  bool get logPerfTrace => _logPerfTrace;
+
+  set logPerfTrace(bool value) {
+    if (_logPerfTrace == value) return;
+    _logPerfTrace = value;
+    PdfPerfLog.enabled = value;
+    // The trace is verbose - a line per worker request/reply, interpret, and
+    // raster - and this log is a ring of only maxLogEntries, so a sustained
+    // trace WILL evict the earlier entries (the open-trace: lines included).
+    // Reproduce the problem, then export promptly; don't leave it running.
+    PdfPerfLog.sink = value ? (m) => addLog('perf: $m') : null;
+    addLog('devtools: perf trace logging ${value ? 'on' : 'off'}');
+    _scheduleNotify();
+  }
 
   void _record(DevLogLevel level, String message) {
     // debugPrint re-entrance guard: recording must never print.
@@ -322,7 +346,7 @@ class AppDevTools extends ChangeNotifier {
       if (map['perfOverlay'] case final bool v) {
         showPerformanceOverlay.value = v;
       }
-      if (map['perfLog'] case final bool v) PdfPerfLog.enabled = v;
+      if (map['perfLog'] case final bool v) logPerfTrace = v;
       if (map['logTouchInput'] case final bool v) logTouchInput = v;
       if (map['workers'] case final int v) {
         pdfRenderWorkerPoolSize = v.clamp(1, 8);
@@ -343,7 +367,7 @@ class AppDevTools extends ChangeNotifier {
           'tileBorders': pdfDebugPaintDetailBounds.value,
           'renderWindow': pdfDebugShowRenderWindow.value,
           'perfOverlay': showPerformanceOverlay.value,
-          'perfLog': PdfPerfLog.enabled,
+          'perfLog': _logPerfTrace,
           'logTouchInput': _logTouchInput,
           'workers': pdfRenderWorkerPoolSize,
         }),

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -817,14 +817,15 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
           theme,
           key: const ValueKey('devtools-perf-log'),
           title: 'Verbose render log (PdfPerfLog)',
-          help: 'Streams the render stack\'s diagnostic log lines '
-              '(vector-first routing, worker requests, detail settles, '
-              'jank markers) through debugPrint into this log. Also lights '
-              'up the PdfPerf accumulators. Chatty - enable to diagnose, '
+          help: 'Streams the render stack\'s diagnostic trace '
+              '(worker requests/replies, interprets, rasters, jank markers) '
+              'into this log as "perf:" lines, so the exported JSON carries '
+              'the render path too. Chatty - the 500-entry ring evicts older '
+              'lines quickly, so reproduce the problem and export promptly, '
               'then turn it off.',
-          value: PdfPerfLog.enabled,
+          value: _tools.logPerfTrace,
           onChanged: (v) => setState(() {
-            PdfPerfLog.enabled = v;
+            _tools.logPerfTrace = v;
             _persist();
           }),
         ),

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,5 +1,10 @@
 import 'dart:async';
 
+// The perf_log entry, NOT the package entry: main.dart runs before the
+// deferred app.dart loading unit (the splash), and importing the entry here
+// would drag the whole editor stack into the initial web download that the
+// deferred split exists to keep small.
+import 'package:dart_pdf_editor/perf_log.dart';
 import 'package:flutter/material.dart';
 
 import 'app.dart' deferred as app;
@@ -10,6 +15,16 @@ import 'app_info.dart' deferred as app_info;
 Future<void> main(List<String> args) async {
   // PackageInfo (loaded below) needs the binding; ensure it before awaiting.
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Diagnostics: turn on the in-app performance trace (interpret times,
+  // render-hold/scheduler transitions, prerender warms, and frame JANK,
+  // streamed to the browser console) without a rebuild by opening the app
+  // with `?perf=1`. Off otherwise - it's verbose and adds per-line print
+  // overhead. `Uri.base` carries the page URL on web (and is harmless on
+  // native, where there's no query string), so no `package:web` import.
+  if (Uri.base.queryParameters['perf'] == '1') {
+    PdfPerfLog.enabled = true;
+  }
 
   runApp(_DeferredApp(launchArgs: args));
 

--- a/packages/dart_pdf_editor/lib/perf_log.dart
+++ b/packages/dart_pdf_editor/lib/perf_log.dart
@@ -1,0 +1,14 @@
+/// Render-path diagnostic trace for the viewer.
+///
+/// UNSTABLE diagnostics surface with **no semver guarantee** - deliberately
+/// not exported from `package:dart_pdf_editor/dart_pdf_editor.dart`, mirroring
+/// `package:pdf_cos/perf.dart`.
+///
+/// Kept a separate entry point so a host can flip the trace on (and install a
+/// [PdfPerfLog.sink]) from code that must stay out of the editor's own loading
+/// unit - the app's `main.dart` runs before its deferred `app.dart` split, and
+/// importing the package entry there would pull the whole editor stack into
+/// the initial web download.
+library;
+
+export 'src/perf_log.dart';

--- a/packages/dart_pdf_editor/lib/src/perf_log.dart
+++ b/packages/dart_pdf_editor/lib/src/perf_log.dart
@@ -58,6 +58,13 @@ class PdfPerfLog {
     if (on) PdfPerf.sink = log;
   }
 
+  /// Optional host sink that receives every flushed line IN ADDITION to the
+  /// console. This is the seam by which a host app (whose devtools export
+  /// must never depend on a console the user can't reach) mirrors the trace
+  /// into its own log - the package must not import the host, so the host
+  /// hands us a closure instead. Not consulted at all while the log is off.
+  static void Function(String line)? sink;
+
   static final Stopwatch _clock = Stopwatch()..start();
   static final List<String> _buf = <String>[];
   static bool _hooked = false;
@@ -172,6 +179,11 @@ class PdfPerfLog {
       // extra cost is irrelevant, and it's still Timer-free, so it can't
       // trip widget tests' `!timersPending` (which stay off anyway).
       debugPrintSynchronously(line);
+      // A host's sink is foreign code: a throwing one must never break the
+      // render path this log is diagnosing, so its failures are swallowed.
+      try {
+        sink?.call(line);
+      } catch (_) {}
     }
     _buf.clear();
   }

--- a/packages/dart_pdf_editor/test/perf_log_test.dart
+++ b/packages/dart_pdf_editor/test/perf_log_test.dart
@@ -18,7 +18,10 @@ void main() {
     return lines;
   }
 
-  tearDown(() => PdfPerfLog.enabled = false);
+  tearDown(() {
+    PdfPerfLog.enabled = false;
+    PdfPerfLog.sink = null;
+  });
 
   test('disabled - log emits nothing', () {
     PdfPerfLog.enabled = false;
@@ -99,5 +102,41 @@ void main() {
     int seq(String line) =>
         int.parse(RegExp(r'n=(\d+)').firstMatch(line)!.group(1)!);
     expect(seq(lines[1]), seq(lines[0]) + 1);
+  });
+
+  test('sink receives every line while enabled, in addition to the console',
+      () {
+    final forwarded = <String>[];
+    final lines = capturePrints(() {
+      PdfPerfLog.sink = forwarded.add;
+      PdfPerfLog.enabled = true;
+      PdfPerfLog.log('alpha');
+      PdfPerfLog.log('beta');
+    });
+    // The console path must survive the sink being attached - hosts mirror,
+    // they don't redirect.
+    expect(lines, hasLength(2));
+    expect(forwarded, hasLength(2));
+    expect(forwarded[0], startsWith('[perf '));
+    expect(forwarded[0], contains('alpha'));
+    expect(forwarded[1], contains('beta'));
+  });
+
+  test('sink is not consulted while disabled', () {
+    var calls = 0;
+    PdfPerfLog.sink = (_) => calls++;
+    PdfPerfLog.enabled = false;
+    PdfPerfLog.log('nope');
+    expect(calls, 0);
+  });
+
+  test('a throwing sink does not propagate to the caller', () {
+    capturePrints(() {
+      PdfPerfLog.sink = (_) => throw StateError('host bug');
+      PdfPerfLog.enabled = true;
+      // Rendering must never break because a host's forwarding closure is
+      // broken - the log call itself must complete cleanly.
+      expect(() => PdfPerfLog.log('alpha'), returnsNormally);
+    });
   });
 }


### PR DESCRIPTION
## Why

Ben's ~4 s wait for the first page image on mobile web **cannot be diagnosed from an export today**. His capture proves what it *isn't* — the open path is 129 ms end to end, and the main thread isn't blocked (avg build 6.9 ms, raster 2.5 ms) — but the `pdfPerf` block carries only document-open phases. There is no `PdfPerfPhase` for interpret, worker round-trip, image decode, or raster. The instrumentation stops exactly where the problem starts.

## Why a sink, specifically

`PdfPerfLog` already produces every line we need — worker construct/ready, each record request and reply, interprets, rasters, jank. They only ever reached the console, and the app **cannot** capture them: `PdfPerfLog` prints through `debugPrintSynchronously`, which deliberately bypasses the `debugPrint` hook `AppDevTools` installs. So there is no way to intercept them, and the package must not import the app. A host-supplied sink is the only seam.

## Changes

- **`PdfPerfLog.sink`** — called for every flushed line **in addition to** the console. Hosts mirror, they don't redirect. A throwing sink is swallowed: foreign code must never break the render path this log exists to diagnose.
- **The devtools panel's existing "Verbose render log" switch** now drives a `logPerfTrace` toggle that installs the sink as well as enabling the log, so lines land in the exported JSON tagged `perf:`. Its help text claimed they already arrived *"through debugPrint into this log"* — they did not; corrected.
- **`app/lib/main.dart` gains `?perf=1`**, the opt-in the example app has had all along and the main app never had. A deployed build can now be traced without a rebuild.
- **New entry `package:dart_pdf_editor/perf_log.dart`**, mirroring `package:pdf_cos/perf.dart` — an unstable diagnostics surface kept out of the package entry.

## Known limit, commented at the toggle

`AppDevTools` keeps 500 entries and the trace is verbose, so a sustained run evicts the `open-trace:` lines. Reproduce, then export promptly. Called out rather than left to surprise someone.

## Provenance and review

Drafted with `opencode`/`kimi-k3`, reviewed here. Two things changed on review:

1. It reached into `package:dart_pdf_editor/src/perf_log.dart` behind an `implementation_imports` ignore. Its *reasoning* was right and non-obvious — `main.dart` runs before the deferred `app.dart` loading unit, so importing the package entry would pull the whole editor stack into the initial web download — but the mechanism was wrong for this repo, which already solves it with a separate public entry (`pdf_cos/perf.dart`). Replaced with that pattern.
2. Mutation-checked the guard: removing the `try/catch` does fail the throwing-sink test, so it guards something real.

I also verified there's no double-logging, which was my first concern given `AppDevTools` hooks `debugPrint` — `debugPrintSynchronously` bypasses it, so each line arrives once.

## Verification

`app`: **246 pass**. `perf_log_test`: **9 pass**. `dart analyze app packages/dart_pdf_editor/lib`: clean.

## What to do with it

Once deployed, open the app with `?perf=1` (or flip the switch in the F12 panel), reproduce the slow open, and export. The `perf:` lines will show where the 4 s sits — worker startup, the record round-trip, or the image decode.