### PR TITLE
diag(editor): split the render timing into wait, build, and raster (#454)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -890,6 +890,10 @@ class _PdfPageViewState extends State<PdfPageView> {
   Future<(ui.Picture, PdfRetainedScene?, bool)?> _interpretPicture() async {
     final pageIndex = widget.previewIndex;
     final worker = widget.renderWorker;
+    // Phase clocks exist only while the perf log is on (the render_worker_web
+    // _perfClock pattern): this runs per page render, so even a cheap
+    // Stopwatch allocation stays off the ordinary path.
+    final waitClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
     if (worker != null && worker.isActive) {
       // priority 0: the on-screen page preempts background prefetch.
       // imagePixelRatio caps embedded images to ~2x the page's on-screen
@@ -905,6 +909,13 @@ class _PdfPageViewState extends State<PdfPageView> {
           widget.workerImagePixelRatioCap ?? double.infinity,
         ),
       );
+      // The wait phase ends when the record reply lands; the build phase is
+      // everything after - decoding images that shipped un-decoded and
+      // turning the command buffer into the picture.
+      final waitMs = waitClock == null
+          ? null
+          : waitClock.elapsedMicroseconds / 1000.0;
+      final buildClock = waitClock == null ? null : (Stopwatch()..start());
       // Abandoned while the worker ran - the State was disposed or the lazy
       // list recycled it onto another page (this is the cancel() path: a
       // cancelled request returns null). Skip the local fallback: the page is
@@ -918,6 +929,9 @@ class _PdfPageViewState extends State<PdfPageView> {
         _lastInterpretPath = 'worker';
         _lastInterpretResultBytes = _logImageStats(pageIndex, commands);
         final (picture, scene) = await _replayableFromCommands(commands);
+        _lastInterpretWaitMs = waitMs;
+        _lastInterpretBuildMs =
+            buildClock == null ? null : buildClock.elapsedMicroseconds / 1000.0;
         return (picture, scene, true);
       }
     }
@@ -926,15 +940,22 @@ class _PdfPageViewState extends State<PdfPageView> {
     // The worker may be active yet decline this page (it returns null), in
     // which case the interpret runs here - the log must say so, not 'worker'.
     _lastInterpretPath = 'recorded';
+    // The local path has no worker wait: record + decode + picture build are
+    // one UI-thread phase, reported entirely as build.
+    final buildClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
+    void stampLocalPhases() {
+      _lastInterpretWaitMs = buildClock == null ? null : 0;
+      _lastInterpretBuildMs =
+          buildClock == null ? null : buildClock.elapsedMicroseconds / 1000.0;
+    }
+
     if (!PdfPageView.retainedZoomReplay) {
-      return (
-        await PdfPageRenderer.renderPictureRecordedWithPlan(
-          widget.page,
-          _renderPlan,
-        ),
-        null,
-        false,
+      final result = await PdfPageRenderer.renderPictureRecordedWithPlan(
+        widget.page,
+        _renderPlan,
       );
+      stampLocalPhases();
+      return (result, null, false);
     }
     // Same record + decode renderPictureRecordedWithPlan runs internally,
     // but the command buffer and decoded images are kept for zoom replays
@@ -947,9 +968,12 @@ class _PdfPageViewState extends State<PdfPageView> {
       // cached-picture path serves this page's zooms.
       final picture = scene.replay(pixelRatio: 1);
       scene.dispose();
+      stampLocalPhases();
       return (picture, null, false);
     }
-    return (scene.replay(pixelRatio: 1), scene, false);
+    final picture = scene.replay(pixelRatio: 1);
+    stampLocalPhases();
+    return (picture, scene, false);
   }
 
   /// Whether a page's recorded commands should retain their scene - the
@@ -1181,6 +1205,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       return null;
     }
     final vectorRatio = _vectorFirstRatio();
+    final rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
     final image = await PdfPageRenderer.rasterize(
       picture,
       PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation),
@@ -1192,6 +1217,9 @@ class _PdfPageViewState extends State<PdfPageView> {
       imageWidth: image.width,
       imageHeight: image.height,
       ratio: vectorRatio,
+      elapsedMs: rasterClock == null
+          ? null
+          : rasterClock.elapsedMicroseconds / 1000.0,
     );
     picture.dispose();
     // Adopt the vector raster only if the full pass hasn't already landed (a
@@ -1257,13 +1285,23 @@ class _PdfPageViewState extends State<PdfPageView> {
   String _lastInterpretPath = 'recorded';
   int? _lastInterpretResultBytes;
 
+  /// The last interpret's phase split (worker-reply wait vs picture build),
+  /// for the perf log. Null while the log is off - the Stopwatches that
+  /// produce them are never allocated then.
+  double? _lastInterpretWaitMs;
+  double? _lastInterpretBuildMs;
+
   /// The actual interpret + rasterize, run once the first render is no
   /// longer gated (or directly for re-rasters of a cached picture).
   Future<void> _renderNow() async {
     final generation = _renderSession.beginFull();
     final pageIndex = widget.previewIndex;
     final firstInterpret = _picture == null;
-    if (firstInterpret) _lastInterpretResultBytes = null;
+    if (firstInterpret) {
+      _lastInterpretResultBytes = null;
+      _lastInterpretWaitMs = null;
+      _lastInterpretBuildMs = null;
+    }
     final sw = Stopwatch()..start();
     if (_renderPaused) {
       _render();
@@ -1337,6 +1375,8 @@ class _PdfPageViewState extends State<PdfPageView> {
         pageIndex,
         path: _lastInterpretPath,
         interpretMs: sw.elapsedMicroseconds / 1000.0,
+        waitMs: _lastInterpretWaitMs,
+        buildMs: _lastInterpretBuildMs,
         first: true,
       );
       widget.performance?.observe(
@@ -1468,19 +1508,26 @@ class _PdfPageViewState extends State<PdfPageView> {
       // or the kill switch) re-raster the cached picture.
       final scene = retainedScene;
       final ui.Image image;
+      // The clock starts at each rasterize, not above the branch: the strip
+      // path awaits a worker bin first, and attributing that queue wait to
+      // the raster itself would corrupt the number this log exists to read.
+      Stopwatch? rasterClock;
       if (scene != null && _stripReplayScene(scene)) {
         final stripPlan = await _workerStripPlan(scene, pixelRatio: effective);
         if (_superseded(generation, pageIndex)) return;
+        rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
         image = await scene.rasterizeStrips(
           pixelRatio: effective,
           stripPlan: stripPlan,
         );
       } else if (scene != null && !_sceneIsTileOnly(scene)) {
+        rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
         image = await scene.rasterize(pixelRatio: effective);
       } else {
         // No scene, or one retained only to feed tiles: a flat replay of a
         // dense transcript would be a UI-thread hitch, so the cached picture
         // stays the full-page base raster.
+        rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
         image = await PdfPageRenderer.rasterize(
           picture,
           _renderPlan.pageSize(widget.page),
@@ -1493,6 +1540,9 @@ class _PdfPageViewState extends State<PdfPageView> {
         imageWidth: image.width,
         imageHeight: image.height,
         ratio: effective,
+        elapsedMs: rasterClock == null
+            ? null
+            : rasterClock.elapsedMicroseconds / 1000.0,
       );
       if (_superseded(generation, pageIndex)) {
         image.dispose();
@@ -1627,6 +1677,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     if (_sceneIsVectorOnly &&
         heldScene != null &&
         !_imagesIntersectRegion(heldScene.commands, region)) {
+      final vectorClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
       final vectorImage = await heldScene.rasterizeRegion(
         region,
         pixelRatio: ratio,
@@ -1637,6 +1688,9 @@ class _PdfPageViewState extends State<PdfPageView> {
         imageWidth: vectorImage.width,
         imageHeight: vectorImage.height,
         ratio: ratio,
+        elapsedMs: vectorClock == null
+            ? null
+            : vectorClock.elapsedMicroseconds / 1000.0,
         region: (width: region.width, height: region.height),
       );
       if (mounted &&
@@ -1688,6 +1742,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       return true;
     }
     if (workerPicture != null) {
+      final rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
       final image = await PdfPageRenderer.rasterizeRegion(
         workerPicture,
         region,
@@ -1699,6 +1754,9 @@ class _PdfPageViewState extends State<PdfPageView> {
         imageWidth: image.width,
         imageHeight: image.height,
         ratio: ratio,
+        elapsedMs: rasterClock == null
+            ? null
+            : rasterClock.elapsedMicroseconds / 1000.0,
         region: (width: region.width, height: region.height),
       );
       workerPicture.dispose();
@@ -1756,6 +1814,10 @@ class _PdfPageViewState extends State<PdfPageView> {
     final scene = PdfPageView.retainedZoomReplay ? _scene : null;
     final ui.Image image;
     final String detailKind;
+    // Same per-branch clock placement as the base raster: the strip branch
+    // awaits a worker bin before rasterizing, and that wait must not read
+    // as raster time.
+    Stopwatch? rasterClock;
     if (scene != null && _stripReplayScene(scene)) {
       final stripPlan = await _workerStripPlan(
         scene,
@@ -1767,6 +1829,7 @@ class _PdfPageViewState extends State<PdfPageView> {
           _renderPaused) {
         return false;
       }
+      rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
       image = await scene.rasterizeRegionStrips(
         region,
         pixelRatio: ratio,
@@ -1774,12 +1837,14 @@ class _PdfPageViewState extends State<PdfPageView> {
       );
       detailKind = 'detail-strip';
     } else if (scene != null) {
+      rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
       image = await scene.rasterizeRegion(region, pixelRatio: ratio);
       detailKind = 'detail-region';
     } else {
       // Classic cached-picture path: replays the WHOLE page picture clipped to
       // [region] at [ratio]. On a huge (unretained) transcript this is where a
       // deep-zoom raster gets expensive - the raster instrumentation flags it.
+      rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
       image = await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
       detailKind = 'detail-picture';
     }
@@ -1789,6 +1854,9 @@ class _PdfPageViewState extends State<PdfPageView> {
       imageWidth: image.width,
       imageHeight: image.height,
       ratio: ratio,
+      elapsedMs: rasterClock == null
+          ? null
+          : rasterClock.elapsedMicroseconds / 1000.0,
       region: (width: region.width, height: region.height),
     );
     if (!mounted ||

--- a/packages/dart_pdf_editor/lib/src/perf_log.dart
+++ b/packages/dart_pdf_editor/lib/src/perf_log.dart
@@ -91,17 +91,29 @@ class PdfPerfLog {
 
   /// Logs a UI-thread interpret. [first] marks a page's first-ever interpret
   /// (the expensive content-stream walk), vs a cheap re-raster.
+  ///
+  /// [waitMs]/[buildMs] split [interpretMs] into its two real phases on the
+  /// worker path - waiting for the worker's record reply vs turning the
+  /// returned command buffer into a picture (image decode + build). Without
+  /// them a trace shows one multi-second interpret that is indistinguishable
+  /// from scheduler/hold queuing. [interpretMs] is still printed unchanged so
+  /// older traces stay comparable.
   static void interpret(int page,
       {required String path,
       required double interpretMs,
+      double? waitMs,
+      double? buildMs,
       double? rasterMs,
       bool first = true,
       String note = ''}) {
     if (!enabled) return;
     final raster = rasterMs == null ? '' : ' raster=${_ms(rasterMs)}';
+    final phases = (waitMs == null || buildMs == null)
+        ? ''
+        : ' wait=${_ms(waitMs)} build=${_ms(buildMs)}';
     final kind = first ? 'FIRST' : 're-raster';
     log('interpret page=$page path=$path $kind '
-        'interpret=${_ms(interpretMs)}$raster$note');
+        'interpret=${_ms(interpretMs)}$phases$raster$note');
   }
 
   static String _ms(double v) => '${v.toStringAsFixed(1)}ms';
@@ -132,24 +144,31 @@ class PdfPerfLog {
   /// an exported trace.
   ///
   /// [kind] is the raster path (e.g. 'detail', 'vector-first', 'base'). [region]
-  /// is null for a full-page raster. Off unless the perf log is [enabled].
+  /// is null for a full-page raster. [elapsedMs] is the measured duration of the
+  /// rasterize call itself - without it the cost of a 1.5MP readback can only
+  /// be inferred from the gap between log timestamps, which is unmeasurable
+  /// during the hangs this log exists to diagnose. Off unless the perf log is
+  /// [enabled].
   static void raster(
     String kind, {
     required int page,
     required int imageWidth,
     required int imageHeight,
     double? ratio,
+    double? elapsedMs,
     ({double width, double height})? region,
   }) {
     if (!enabled) return;
     final mp = (imageWidth * imageHeight) / 1e6;
     final ratioStr = ratio == null ? '' : ' ratio=${ratio.toStringAsFixed(1)}';
+    final msStr = elapsedMs == null ? '' : ' ms=${elapsedMs.toStringAsFixed(1)}';
     final regionStr = region == null
         ? ' full'
         : ' region=${region.width.toStringAsFixed(0)}x'
             '${region.height.toStringAsFixed(0)}pt';
     log('raster kind=$kind page=$page n=${++_rasterSeq}$regionStr$ratioStr '
-        'img=${imageWidth}x$imageHeight (${mp.toStringAsFixed(1)}MP)${rssSuffix()}');
+        'img=${imageWidth}x$imageHeight '
+        '(${mp.toStringAsFixed(1)}MP)$msStr${rssSuffix()}');
   }
 
   static void _onTimings(List<FrameTiming> timings) {

--- a/packages/dart_pdf_editor/test/perf_log_test.dart
+++ b/packages/dart_pdf_editor/test/perf_log_test.dart
@@ -79,6 +79,7 @@ void main() {
           imageWidth: 4730,
           imageHeight: 3548,
           ratio: 41.2,
+          elapsedMs: 912.34,
           region: (width: 115, height: 86));
       PdfPerfLog.raster('base-full',
           page: 2, imageWidth: 8192, imageHeight: 812, ratio: 1);
@@ -91,13 +92,19 @@ void main() {
     expect(lines[0], contains('region=115x86pt'));
     expect(lines[0], contains('ratio=41.2'));
     expect(lines[0], contains('img=4730x3548 (16.8MP)'));
+    // The measured duration of the rasterize call itself - the figure that
+    // used to require inferring gaps between log timestamps.
+    expect(lines[0], contains('ms=912.3'));
     expect(lines[0], matches(RegExp(r'rss=\d+MB')));
 
     // A full-page raster carries no region, and the sequence number advances so
-    // a per-frame raster loop is visible as `n` racing up.
+    // a per-frame raster loop is visible as `n` racing up. Without a measured
+    // duration the ms field stays off the line, keeping older call sites'
+    // output unchanged.
     expect(lines[1], contains('raster kind=base-full page=2'));
     expect(lines[1], contains(' full '));
     expect(lines[1], isNot(contains('region=')));
+    expect(lines[1], isNot(contains('ms=')));
 
     int seq(String line) =>
         int.parse(RegExp(r'n=(\d+)').firstMatch(line)!.group(1)!);
@@ -139,4 +146,23 @@ void main() {
       expect(() => PdfPerfLog.log('alpha'), returnsNormally);
     });
   });
+  test('interpret splits the worker wait from the picture build', () {
+    final lines = capturePrints(() {
+      PdfPerfLog.enabled = true;
+      PdfPerfLog.interpret(0,
+          path: 'worker', interpretMs: 2588.9, waitMs: 934.2, buildMs: 1228.7);
+      // Older call sites pass neither; the line must stay as it was so
+      // existing traces remain comparable.
+      PdfPerfLog.interpret(1, path: 'recorded', interpretMs: 42.0);
+    });
+
+    expect(lines[0], contains('interpret=2588.9ms'));
+    expect(lines[0], contains('wait=934.2ms'));
+    expect(lines[0], contains('build=1228.7ms'));
+
+    expect(lines[1], contains('interpret=42.0ms'));
+    expect(lines[1], isNot(contains('wait=')));
+    expect(lines[1], isNot(contains('build=')));
+  });
+
 }


### PR DESCRIPTION
## Why

A device trace of the ~3.6 s to first page image could not say where the time went, because the two phases holding ~60% of it were either mismeasured or unmeasured:

- **`interpret` reported one number** from a Stopwatch started before the render-hold / scheduler / worker wait. It read `interpret=2588.9ms` on a render whose worker reply took **58.9 ms** — indistinguishable from queuing.
- **`raster` logged no duration at all** — kind, page, size, ratio only. The ~915 ms to rasterise 1.5 MP had to be inferred from gaps between log timestamps, which is precisely what stops working during the hangs this log exists to diagnose.

## Change

`interpret` now also carries:

- `wait=` — waiting for the worker's record reply
- `build=` — decoding images that shipped un-decoded, and building the picture

`interpret=` is printed unchanged so older traces stay comparable. The local fallback path reports `wait=0` with `build` covering it. `raster` gains `ms=`.

Both new fields are optional: a call site passing neither prints exactly what it printed before.

## Safety

Instrumentation only — no control flow, caching, or rendering change. Two details worth noting:

- Phase clocks are allocated **only** while `PdfPerfLog.enabled`, following `render_worker_web`'s existing `_perfClock` pattern, so the ordinary path allocates nothing.
- The fields are cleared at the start of each first interpret, so a superseded render can never report a previous page's split — a stale number here would be worse than no number.

## Provenance and review

Drafted with `opencode`/`kimi-k3`, reviewed here.

It covered the raster duration in tests but **left the interpret split untested** — the more important of the two fields — so I added a test asserting both that the fields appear when supplied and that the line is unchanged when they are not. Mutation-checked: blanking either field fails its test.

I also verified the new fields cannot go stale across renders before accepting the design.

## Verification

`dart_pdf_editor`: **1790 pass**, only the pre-existing ghent GWG030. `dart analyze` clean.

A `raster_cache_test` failure on the first full-suite run did **not** reproduce, and passes in isolation both on this branch and on main — full-suite contention, the same flake seen earlier today. Called out rather than quietly re-run until green.

## Next

With this deployed, a capture will show whether that 1.2 s window is the JPEG decode, the command replay, or the GPU upload — which is the thing #454 needs before any fix can be chosen rather than guessed.