### PR TITLE
perf(editor): let a page leave its sticky worker when that worker is busier

### DIFF
--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -611,7 +611,29 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
 
   int _workerForPage(int pageIndex) {
     final existing = _pageWorkers[pageIndex];
-    if (existing != null && _workers[existing].isActive) return existing;
+    if (existing != null && _workers[existing].isActive) {
+      // Stickiness buys a transcript hit: the sticky worker holds this page's
+      // warm caches, so a repeat record on it is near-free, while a cold
+      // worker re-records the page. Abandon that only when the page would
+      // otherwise queue behind unrelated work - i.e. another active worker
+      // has strictly lower load. Equal load keeps the sticky worker: a
+      // transcript miss is never worth paying to break a tie.
+      var alternative = -1;
+      var alternativeLoad = 1 << 62;
+      for (var i = 0; i < _workers.length; i++) {
+        if (i == existing || !_workers[i].isActive) continue;
+        final load = _loads[i];
+        if (load < alternativeLoad) {
+          alternative = i;
+          alternativeLoad = load;
+        }
+      }
+      if (alternative >= 0 && alternativeLoad < _loads[existing]) {
+        _pageWorkers[pageIndex] = alternative;
+        return alternative;
+      }
+      return existing;
+    }
     final worker = _leastLoadedWorker(pageIndex);
     _pageWorkers[pageIndex] = worker;
     return worker;

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -974,6 +974,69 @@ void main() {
       expect(only.cancels.single, (5, 0));
     });
 
+    test('a page keeps its sticky worker while loads are equal', () async {
+      final workers = [_ManualWorker(), _ManualWorker()];
+      final pool = PdfPooledRenderWorker.fromWorkers(workers);
+      // Page 0 sticks to worker 0; page 1 loads worker 1 to the same level.
+      final first = pool.record(0, priority: 1);
+      final other = pool.record(1, priority: 1);
+      final repeat = pool.record(0, priority: 0);
+      expect(workers[0].calls.map((c) => c.$1), [0, 0],
+          reason: 'equal load keeps the sticky worker (the transcript hit '
+              'is never traded away to break a tie)');
+      expect(workers[1].calls.map((c) => c.$1), [1]);
+      for (final worker in workers) {
+        worker.completeAll();
+      }
+      await Future.wait([first, other, repeat]);
+    });
+
+    test('a page re-routes to an idle worker when its sticky worker is busier',
+        () async {
+      final workers = [_ManualWorker(), _ManualWorker()];
+      final pool = PdfPooledRenderWorker.fromWorkers(workers);
+      // A background prefetch occupies page 0's sticky worker; the on-screen
+      // record (another priority, so a fresh lease) must not queue behind it.
+      final background = pool.record(0, priority: 1);
+      final onScreen = pool.record(0, priority: 0);
+      expect(workers[0].calls.map((c) => c.$1), [0]);
+      expect(workers[1].calls.map((c) => c.$1), [0],
+          reason: 'a strictly-less-loaded active worker wins over stickiness');
+      for (final worker in workers) {
+        worker.completeAll();
+      }
+      await Future.wait([background, onScreen]);
+    });
+
+    test('a re-routed page follows its new worker afterwards', () async {
+      final workers = [_ManualWorker(), _ManualWorker()];
+      final pool = PdfPooledRenderWorker.fromWorkers(workers);
+      final background = pool.record(0, priority: 1);
+      final onScreen = pool.record(0, priority: 0); // re-routes to worker 1
+      for (final worker in workers) {
+        worker.completeAll();
+      }
+      await Future.wait([background, onScreen]);
+
+      final revisit = pool.record(0);
+      expect(workers[1].calls.map((c) => c.$1), [0, 0],
+          reason: 'the page sticks to the worker it was re-routed to');
+      expect(workers[0].calls, hasLength(1));
+      workers[1].completeAll();
+      await revisit;
+    });
+
+    test('a single-worker pool always routes to worker 0', () async {
+      final only = _ManualWorker();
+      final pool = PdfPooledRenderWorker.fromWorkers([only]);
+      final first = pool.record(3, priority: 1);
+      final second = pool.record(3, priority: 0);
+      expect(only.calls.map((c) => c.$1), [3, 3],
+          reason: 'with one worker there is no alternative to re-route to');
+      only.completeAll();
+      await Future.wait([first, second]);
+    });
+
     test('every worker is seeded from one shared byte snapshot, not a '
         'per-worker copy', () {
       final source = Uint8List.fromList(List.generate(64, (i) => i & 0xff));


### PR DESCRIPTION
## The measurement

Device trace via #455's phase split — 62-page book, two workers:

```
phase worker=0 page=2 queue=1024.3ms worker=2613.0ms serialize=1817.0ms outcome=ok
phase worker=0 page=0 queue=2429.5ms worker=16.0ms   transcript=hit
raster base-full page=0 ms=80.5      <- image finally visible
```

**The visible page's image record waited 2.43 seconds for a worker that then did the job in 16 ms**, while worker 1 sat idle for most of that window. It is the single largest term in the ~4.7 s to first image — larger than worker startup, picture build, and raster combined.

## Root cause

`_workerForPage` pinned the page:

```dart
final existing = _pageWorkers[pageIndex];
if (existing != null && _workers[existing].isActive) return existing;
```

Once assigned, a page returned to the same worker for as long as it stayed active, with no regard to load. Page 0 was pinned to worker 0, which was mid-way through a 2613 ms background prerender of **page 2** — a page the user is not looking at.

## Why not simply drop stickiness

Because it is earning its keep. The sticky worker holds that page's warm transcript, which is precisely why the pinned request cost **16 ms** (`transcript=hit`). A cold worker re-records the page — that same page's first record on a cold worker took **130 ms**.

So the change abandons stickiness **only when another active worker has strictly lower load**. Equal load keeps the sticky worker: a transcript miss is never worth paying to break a tie. The trade taken here is ~130 ms against ~2430 ms.

Single-worker pools are untouched — the alternative scan skips the sticky worker itself, finds nothing, and returns it.

## Tests

Four, all **mutation-checked**:

- disabling the re-route → *"re-routes to an idle worker"* and *"a re-routed page follows its new worker"* both fail
- relaxing `<` to `<=` → *"keeps its sticky worker while loads are equal"* fails

So both the re-route and the strict-inequality boundary are pinned, not just asserted.

## Verification

`dart_pdf_editor`: **1793 pass**, only the pre-existing ghent GWG030. `dart analyze` clean.

## Scope

This is the preemption half of #451. Still open there: **page 2's serialize anomaly** — 5.3 MB taking 1817 ms while 39 MB takes 329 ms in the same worker, reproduced across three captures. That is what makes a prefetch long enough to collide in the first place, so it is worth fixing even with this routing change in.

Drafted with `opencode`/`kimi-k3`, reviewed and mutation-checked here.

Refs #451.