### PR TITLE
diag(editor): split the build phase into image decode and picture construction

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -1053,22 +1053,41 @@ class _PdfPageViewState extends State<PdfPageView> {
   Future<(ui.Picture, PdfRetainedScene?)> _replayableFromCommands(
     List<PdfRenderCommand> commands,
   ) async {
+    // The build-split instrumentation exists only while the perf log is on
+    // (the phase-clock pattern in _interpretPicture): the carrier and the
+    // replay clock stay off the ordinary path. 'build' is the dominant
+    // opaque figure in a cold-open trace, and whether it is the image decode
+    // or the canvas calls is exactly what these two numbers answer.
+    final timing = PdfPerfLog.enabled ? PdfSceneBuildTiming() : null;
     if (!_retainScene(commands)) {
-      return (
-        await PdfPageRenderer.pictureFromCommandsWithPlan(
-          widget.page,
-          commands,
-          _renderPlan,
-        ),
-        null,
+      final picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
+        widget.page,
+        commands,
+        _renderPlan,
       );
+      // Deliberately unmeasured: this branch decodes INSIDE
+      // pictureFromCommandsWithPlan and constructs the picture in the same
+      // call, so a replayMs to pair with a decodeMs doesn't exist here -
+      // and PdfPerfLog.interpret prints the split only as a pair, so a lone
+      // decode would never surface anyway. Threading a carrier into the
+      // public renderer API to collect an unprintable number is cost without
+      // signal; both fields stay null and the line omits them.
+      _lastInterpretDecodeMs = null;
+      _lastInterpretReplayMs = null;
+      return (picture, null);
     }
     final scene = await PdfRetainedScene.fromCommands(
       widget.page,
       commands,
       plan: _renderPlan,
+      timing: timing,
     );
-    return (scene.replay(pixelRatio: 1), scene);
+    final replayClock = timing == null ? null : (Stopwatch()..start());
+    final picture = scene.replay(pixelRatio: 1);
+    _lastInterpretDecodeMs = timing?.decodeMs;
+    _lastInterpretReplayMs =
+        replayClock == null ? null : replayClock.elapsedMicroseconds / 1000.0;
+    return (picture, scene);
   }
 
   /// Progressive rendering's fast first pass: records the page WITHOUT decoding
@@ -1291,6 +1310,14 @@ class _PdfPageViewState extends State<PdfPageView> {
   double? _lastInterpretWaitMs;
   double? _lastInterpretBuildMs;
 
+  /// The last interpret's build-phase split (image decode vs picture
+  /// construction), for the perf log. Null while the log is off - the
+  /// Stopwatch and timing carrier that produce them are never allocated then.
+  /// Also null on the local 'recorded' path, where decode and construction
+  /// are fused into one walk and no split exists to report.
+  double? _lastInterpretDecodeMs;
+  double? _lastInterpretReplayMs;
+
   /// The actual interpret + rasterize, run once the first render is no
   /// longer gated (or directly for re-rasters of a cached picture).
   Future<void> _renderNow() async {
@@ -1301,6 +1328,8 @@ class _PdfPageViewState extends State<PdfPageView> {
       _lastInterpretResultBytes = null;
       _lastInterpretWaitMs = null;
       _lastInterpretBuildMs = null;
+      _lastInterpretDecodeMs = null;
+      _lastInterpretReplayMs = null;
     }
     final sw = Stopwatch()..start();
     if (_renderPaused) {
@@ -1377,6 +1406,8 @@ class _PdfPageViewState extends State<PdfPageView> {
         interpretMs: sw.elapsedMicroseconds / 1000.0,
         waitMs: _lastInterpretWaitMs,
         buildMs: _lastInterpretBuildMs,
+        decodeMs: _lastInterpretDecodeMs,
+        replayMs: _lastInterpretReplayMs,
         first: true,
       );
       widget.performance?.observe(

--- a/packages/dart_pdf_editor/lib/src/perf_log.dart
+++ b/packages/dart_pdf_editor/lib/src/perf_log.dart
@@ -98,11 +98,20 @@ class PdfPerfLog {
   /// them a trace shows one multi-second interpret that is indistinguishable
   /// from scheduler/hold queuing. [interpretMs] is still printed unchanged so
   /// older traces stay comparable.
+  ///
+  /// [decodeMs]/[replayMs] split the build phase one level deeper - image
+  /// decode vs the canvas-call picture construction - because a cold-open
+  /// trace showed build dominating the whole open while saying nothing about
+  /// which half costs it. Printed only when BOTH are non-null: the split is
+  /// meaningless as a lone number, and call sites where decode and
+  /// construction are fused pass neither.
   static void interpret(int page,
       {required String path,
       required double interpretMs,
       double? waitMs,
       double? buildMs,
+      double? decodeMs,
+      double? replayMs,
       double? rasterMs,
       bool first = true,
       String note = ''}) {
@@ -111,9 +120,12 @@ class PdfPerfLog {
     final phases = (waitMs == null || buildMs == null)
         ? ''
         : ' wait=${_ms(waitMs)} build=${_ms(buildMs)}';
+    final buildSplit = (decodeMs == null || replayMs == null)
+        ? ''
+        : ' decode=${_ms(decodeMs)} replay=${_ms(replayMs)}';
     final kind = first ? 'FIRST' : 're-raster';
     log('interpret page=$page path=$path $kind '
-        'interpret=${_ms(interpretMs)}$phases$raster$note');
+        'interpret=${_ms(interpretMs)}$phases$buildSplit$raster$note');
   }
 
   static String _ms(double v) => '${v.toStringAsFixed(1)}ms';

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -28,6 +28,17 @@ import 'render_worker.dart';
 import 'region_replay_index.dart';
 import 'strips/strip_device.dart';
 
+/// Mutable carrier for the image-decode half of a [PdfRetainedScene.fromCommands]
+/// build, so the perf log can split the render 'build' phase into decode vs
+/// canvas-call construction without [PdfRetainedScene.fromCommands] growing a
+/// second return channel. The caller allocates one only while
+/// [PdfPerfLog.enabled] - an ordinary render never pays for it.
+class PdfSceneBuildTiming {
+  /// Wall time of the `decodeImages` await, in milliseconds. Stays 0 when
+  /// the buffer carried no images (or `includeImages` was false).
+  double decodeMs = 0;
+}
+
 /// A page retained as a replayable scene: the recorded interpreter command
 /// buffer plus its decoded images, both produced exactly once in [record].
 ///
@@ -254,18 +265,30 @@ class PdfRetainedScene {
   /// must have been recorded for [page] under [plan]. Set [includeImages] to
   /// false for a deliberate vector-only progressive buffer; image draws then
   /// stay transparent until a complete scene replaces it.
+  ///
+  /// [timing], when non-null, receives the duration of the decode pass - the
+  /// perf log's way of splitting the render 'build' phase into image decode
+  /// vs the canvas-call construction that follows. Null (the default)
+  /// measures nothing.
   static Future<PdfRetainedScene> fromCommands(
     PdfPage page,
     List<PdfRenderCommand> commands, {
     PdfPageRenderPlan plan = const PdfPageRenderPlan(),
     bool includeImages = true,
+    PdfSceneBuildTiming? timing,
   }) async {
     final images = <Object, ui.Image>{};
     if (includeImages) {
       final requests = <PdfImageRequest>[];
       PdfPageRenderer.collectImageRequests(commands, requests);
+      // The clock exists only when a caller asked for the split; an ordinary
+      // render never pays for it.
+      final clock = timing == null ? null : (Stopwatch()..start());
       images.addAll(await decodeImages(page.document.cos, requests,
           cache: PdfImageCache.instance));
+      if (clock != null) {
+        timing!.decodeMs = clock.elapsedMicroseconds / 1000.0;
+      }
     }
     return PdfRetainedScene._(page, plan, commands, images);
   }

--- a/packages/dart_pdf_editor/test/perf_log_test.dart
+++ b/packages/dart_pdf_editor/test/perf_log_test.dart
@@ -165,4 +165,35 @@ void main() {
     expect(lines[1], isNot(contains('build=')));
   });
 
+  test('interpret splits the build phase into decode and construction', () {
+    final lines = capturePrints(() {
+      PdfPerfLog.enabled = true;
+      PdfPerfLog.interpret(0,
+          path: 'worker',
+          interpretMs: 1652.3,
+          waitMs: 36.3,
+          buildMs: 1055.8,
+          decodeMs: 1021.4,
+          replayMs: 32.9);
+      // Fused call sites (the local 'recorded' path decodes and constructs in
+      // one walk) pass neither, and a lone half is meaningless - so the pair
+      // is all-or-nothing.
+      PdfPerfLog.interpret(1,
+          path: 'recorded', interpretMs: 42.0, waitMs: 0, buildMs: 42.0);
+      PdfPerfLog.interpret(2,
+          path: 'worker', interpretMs: 10.0, decodeMs: 5.0);
+    });
+
+    expect(lines[0], contains('build=1055.8ms'));
+    expect(lines[0], contains('decode=1021.4ms'));
+    expect(lines[0], contains('replay=32.9ms'));
+
+    expect(lines[1], contains('build=42.0ms'));
+    expect(lines[1], isNot(contains('decode=')));
+    expect(lines[1], isNot(contains('replay=')));
+
+    expect(lines[2], isNot(contains('decode=')),
+        reason: 'a decode without a replay must not print half a split');
+  });
+
 }


### PR DESCRIPTION
## Why

With #455 in, a **cold-tab** capture shows the build phase dominating:

```
interpret page=0 FIRST interpret=1652.3ms wait=36.3ms build=1055.8ms
raster base-full page=0 ms=49.8
```

| phase | ms | share |
|---|---|---|
| worker startup | 290 | 16% |
| record queue + worker | 383 | 21% |
| **picture build** | **1056** | **57%** |
| base raster | 50 | 3% |

`build` is 57% of an 1853 ms open and is a single opaque number. Page 0 records only **53 commands**, so construction *should* be trivial and the image decode *should* dominate — but that is a guess, and guesses about this bug have been wrong four times now (AES allocations, decode headroom, the unserializable-image fallback, and my own inference that raster cost 915 ms when it is 80 ms).

## Change

- `PdfRetainedScene.fromCommands` takes an optional `PdfSceneBuildTiming` that receives the decode duration.
- `_replayableFromCommands` separately times the `replay()` that follows.
- `interpret` gains `decode=` / `replay=`, printed **only when both are present** — a lone half is meaningless.

The non-retained branch stays deliberately unmeasured and says why in a comment: `pictureFromCommandsWithPlan` decodes and constructs inside one call, so there is no replay figure to pair with a decode, and threading a carrier through the public renderer API to collect a number that would never print is cost without signal.

## Safety

Instrumentation only. The carrier and both clocks are allocated **only** while `PdfPerfLog.enabled`, and the fields clear at the start of each first interpret so a superseded render cannot report a stale split.

## Provenance

Drafted with `opencode`/`kimi-k3`, reviewed here. It produced the source changes — including the reasoning about the non-retained branch, which is sound — but stalled before writing tests, so the test is mine.

It pins three things: both fields printing together, the fused path printing neither, and **a lone `decode` not printing half a split**. Mutation-checked: blanking the field fails it.

## Verification

`dart_pdf_editor`: **1791 pass**, only the pre-existing ghent GWG030. `dart analyze` clean.

## What it answers

Next cold-tab capture will say whether that ~1 s is the browser JPEG decode of page 0's two `/DCTDecode` images or the canvas calls. If it is the decode — which I expect but will not act on until measured — the fix is to move it off the main thread (`createImageBitmap` in a worker, or WebCodecs `ImageDecoder`), or decode small first and refine.

Refs #454.