### PR TITLE
feat(editor): suppress annotation/text context menus via contextMenuEnabled

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -502,6 +502,7 @@ class EditingPageOverlay extends StatefulWidget {
     this.onResolvePagePoint,
     this.onMoveDragPreview,
     this.onTextEditClosed,
+    this.contextMenuEnabled = true,
   });
 
   final PdfEditingController controller;
@@ -555,6 +556,12 @@ class EditingPageOverlay extends StatefulWidget {
       onResolvePagePoint;
   final PdfMoveDragPreviewCallback? onMoveDragPreview;
   final VoidCallback? onTextEditClosed;
+
+  /// Whether the touch long-press annotation menu and the floating selection
+  /// chip's "More" button are allowed to show. Mirrors [PdfViewer.contextMenuEnabled];
+  /// see that property for the semantics. Has no effect without an editing
+  /// controller (the menu path is reader-mode only). Defaults to true.
+  final bool contextMenuEnabled;
 
   /// Whether the page raster on screen already shows the controller's
   /// current revision. While false (an edit just committed and the
@@ -3126,6 +3133,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// joins the arena when this is true), so a long-press that has nothing to
   /// offer never steals the gesture from text selection or the viewer. Form
   /// fields use selection + toolbar controls instead of a long-press menu.
+  ///
+  /// Note: the host's [contextMenuEnabled] gate lives in [_onMenuLongPress]
+  /// itself, not here - this predicate decides *gesture ownership*, so it
+  /// must mirror the no-op case (nothing to select, no clipboard) regardless
+  /// of the menu toggle, otherwise long-press selection silently dies when
+  /// the menu is suppressed.
   bool _menuLongPressClaims(Offset position) {
     if (_pointers.gestureBailed) return false;
     final (x, y) = _geometry.toPagePoint(position);
@@ -3141,6 +3154,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// right-clicking. A pressed annotation joins the selection first
   /// (an already-selected one keeps a multi-selection intact); empty
   /// page area opens the paste menu when the clipboard has content.
+  ///
+  /// When [contextMenuEnabled] is false the press still selects the
+  /// annotation (or, with a clipboard, still bails out the same way) -
+  /// only the popup is suppressed.
   void _onMenuLongPress(LongPressStartDetails details) {
     final position = details.localPosition;
     final (x, y) = _geometry.toPagePoint(position);
@@ -3153,6 +3170,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return;
     }
     HapticFeedback.selectionClick();
+    if (!widget.contextMenuEnabled) return;
     _host.showAnnotationMenu
         ?.call(details.globalPosition, widget.pageIndex, pagePoint: (x, y));
   }
@@ -4295,7 +4313,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                     if (rect != null) _openTextEditor(rect, existing: true);
                   },
                 ),
-              if (_host.showAnnotationMenu != null)
+              if (_host.showAnnotationMenu != null && widget.contextMenuEnabled)
                 IconButton(
                   key: const ValueKey('pdf-selection-chip-menu'),
                   icon: const Icon(Icons.more_horiz),

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -224,6 +224,7 @@ class PdfEditorView extends StatefulWidget {
     this.onAnnotationTap,
     this.pageOverlayBuilder,
     this.annotationMenuBuilder,
+    this.contextMenuEnabled = true,
     this.formImagePicker,
     this.imagePicker,
     this.systemImagePasteProvider,
@@ -299,6 +300,7 @@ class PdfEditorView extends StatefulWidget {
     this.onAnnotationTap,
     this.pageOverlayBuilder,
     this.annotationMenuBuilder,
+    this.contextMenuEnabled = true,
     this.formImagePicker,
     this.imagePicker,
     this.systemImagePasteProvider,
@@ -440,6 +442,9 @@ class PdfEditorView extends StatefulWidget {
 
   /// See [PdfViewer.annotationMenuBuilder].
   final PdfAnnotationMenuBuilder? annotationMenuBuilder;
+
+  /// See [PdfViewer.contextMenuEnabled].
+  final bool contextMenuEnabled;
 
   /// See [PdfViewer.formImagePicker].
   final PdfFormImagePicker? formImagePicker;
@@ -690,6 +695,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         onAnnotationTap: widget.onAnnotationTap,
         pageOverlayBuilder: widget.pageOverlayBuilder,
         annotationMenuBuilder: widget.annotationMenuBuilder,
+        contextMenuEnabled: widget.contextMenuEnabled,
         formImagePicker: widget.formImagePicker,
         imagePicker: widget.imagePicker,
         systemImagePasteProvider: widget.systemImagePasteProvider,
@@ -1324,6 +1330,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         onAnnotationTap: widget.onAnnotationTap,
                         pageOverlayBuilder: widget.pageOverlayBuilder,
                         annotationMenuBuilder: widget.annotationMenuBuilder,
+                        contextMenuEnabled: widget.contextMenuEnabled,
                         formImagePicker: widget.formImagePicker,
                         imagePicker: widget.imagePicker,
                         systemImagePasteProvider:

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -131,6 +131,7 @@ class PdfReader extends StatefulWidget {
     this.onLaunchUrl,
     this.onShareReflowImage,
     this.pageOverlayBuilder,
+    this.contextMenuEnabled = true,
     this.pageLayout = const PdfPageLayout.verticalContinuous(),
     this.initialFit = PdfViewerFit.page,
     this.backgroundColor,
@@ -173,6 +174,7 @@ class PdfReader extends StatefulWidget {
     this.onLaunchUrl,
     this.onShareReflowImage,
     this.pageOverlayBuilder,
+    this.contextMenuEnabled = true,
     this.pageLayout = const PdfPageLayout.verticalContinuous(),
     this.initialFit = PdfViewerFit.page,
     this.backgroundColor,
@@ -253,6 +255,9 @@ class PdfReader extends StatefulWidget {
 
   /// See [PdfViewer.pageOverlayBuilder].
   final PdfPageOverlayBuilder? pageOverlayBuilder;
+
+  /// See [PdfViewer.contextMenuEnabled].
+  final bool contextMenuEnabled;
 
   /// See [PdfViewer.pageLayout].
   final PdfPageLayout pageLayout;
@@ -515,6 +520,7 @@ class _PdfReaderState extends State<PdfReader> {
                           onAnnotationTap: widget.onAnnotationTap,
                           onLaunchUrl: widget.onLaunchUrl,
                           pageOverlayBuilder: widget.pageOverlayBuilder,
+                          contextMenuEnabled: widget.contextMenuEnabled,
                           pageLayout: widget.pageLayout,
                           initialFit: widget.initialFit,
                           backgroundColor: widget.backgroundColor,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5212,6 +5212,7 @@ class _PdfViewerState extends State<PdfViewer>
                 onSnapshot: widget.onSnapshot,
                 onPlaceSignature: widget.onPlaceSignature,
                 onAnnotationTap: widget.onAnnotationTap,
+                contextMenuEnabled: widget.contextMenuEnabled,
                 interactionHost: PdfEditingInteractionHost(
                   panViewport: _touchGrabPanBy,
                   endViewportPan: _flingViewport,
@@ -5980,6 +5981,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.renderWorker,
     required this.performance,
     required this.predictStrokes,
+    required this.contextMenuEnabled,
   });
 
   final PdfPage page;
@@ -6079,6 +6081,11 @@ class _PdfViewerPage extends StatefulWidget {
 
   /// See [PdfViewer.predictStrokes].
   final bool predictStrokes;
+
+  /// See [PdfViewer.contextMenuEnabled] - forwarded to the editing overlay
+  /// so its long-press recognizer and the floating selection chip both
+  /// honor the host's intent.
+  final bool contextMenuEnabled;
 
   @override
   State<_PdfViewerPage> createState() => _PdfViewerPageState();
@@ -6272,6 +6279,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
                                 rasterCurrent: rasterCurrent,
                                 zoom: zoom,
                                 predictStrokes: widget.predictStrokes,
+                                contextMenuEnabled: widget.contextMenuEnabled,
                               ),
                             ),
                           );

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -824,6 +824,7 @@ class PdfViewer extends StatefulWidget {
     this.textSelectionEditing = true,
     this.textSelectionMarkup = true,
     this.annotationMenuBuilder,
+    this.contextMenuEnabled = true,
     this.formImagePicker,
     this.fontPicker,
     this.imagePicker,
@@ -1025,6 +1026,12 @@ class PdfViewer extends StatefulWidget {
   /// appear below a divider. Needs [editing] - without a controller
   /// there is no context menu.
   final PdfAnnotationMenuBuilder? annotationMenuBuilder;
+
+  /// Whether right-click (desktop) and long-press (touch/stylus) open the
+  /// annotation context menu. When false, the selection and link behaviors
+  /// still run normally; only the popup menu is suppressed. Defaults to
+  /// true. Has no effect without [editing].
+  final bool contextMenuEnabled;
 
   /// How the form tool fills a tapped push-button field with an image
   /// (signature and logo fields) - typically a file picker returning
@@ -3345,6 +3352,7 @@ class _PdfViewerState extends State<PdfViewer>
   Future<void> _onSecondaryTapUp(TapUpDetails details) async {
     final point = _pagePointAt(details.localPosition);
     if (point == null) return;
+    if (!widget.contextMenuEnabled) return;
     final (page, x, y) = point;
     final editing = widget.editing;
     if (editing != null && !editing.isPickingColor) {
@@ -4255,7 +4263,10 @@ class _PdfViewerState extends State<PdfViewer>
   /// content. Returns whether a menu opened.
   bool _maybeAnnotationMenu(LongPressStartDetails details) {
     final editing = widget.editing;
-    if (editing == null || editing.tool != null || editing.isPickingColor) {
+    if (editing == null ||
+        editing.tool != null ||
+        editing.isPickingColor ||
+        !widget.contextMenuEnabled) {
       return false;
     }
     final point = _pagePointAt(details.localPosition);

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1027,10 +1027,15 @@ class PdfViewer extends StatefulWidget {
   /// there is no context menu.
   final PdfAnnotationMenuBuilder? annotationMenuBuilder;
 
-  /// Whether right-click (desktop) and long-press (touch/stylus) open the
-  /// annotation context menu. When false, the selection and link behaviors
-  /// still run normally; only the popup menu is suppressed. Defaults to
-  /// true. Has no effect without [editing].
+  /// Whether right-click (desktop) and long-press (touch/stylus) open a
+  /// context menu. When false, selection, link taps, and pan/zoom still run
+  /// normally; only the popup menus are suppressed. Defaults to true.
+  ///
+  /// This covers the desktop right-click **text** menu even without [editing]
+  /// (reader mode), plus - when [editing] is set - the right-click and
+  /// long-press **annotation** menus and the floating selection chip's "More"
+  /// button. The long-press annotation menu and selection-chip button require
+  /// [editing]; the desktop text menu does not.
   final bool contextMenuEnabled;
 
   /// How the form tool fills a tapped push-button field with an image

--- a/packages/dart_pdf_editor/test/editing_longpress_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_longpress_menu_test.dart
@@ -182,4 +182,101 @@ void main() {
       await tester.pump(const Duration(milliseconds: 400));
     });
   });
+
+  // When the host sets `contextMenuEnabled: false`, the popup menu is
+  // suppressed but the underlying gesture outcomes (annotation selection,
+  // text selection) must still run. The recognizer returns early in
+  // `_maybeAnnotationMenu` (`pdf_viewer.dart`) and `_onSecondaryTapUp` so
+  // neither annotation nor plain-text menus reach the user.
+  group('contextMenuEnabled: false', () {
+    Future<PdfEditingController> pumpViewerNoContextMenu(
+        WidgetTester tester,
+        {Uint8List? bytes}) async {
+      final editing =
+          PdfEditingController(bytes ?? buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              editing: editing,
+              contextMenuEnabled: false,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    testWidgets(
+        'long-press on an annotation in select mode suppresses the menu '
+        'but still selects the annotation',
+        (tester) async {
+      final editing = await pumpViewerNoContextMenu(tester);
+      editing
+        ..addRectangle(0, const PdfRect(300, 400, 400, 450))
+        ..tool = PdfEditTool.select;
+      await tester.pump();
+
+      await longPressAt(tester, viewPoint(350, 425));
+      expect(editing.selectedAnnotationSlots, [(0, 0)],
+          reason: 'annotation selection still happens; only the popup is '
+              'suppressed');
+      expect(find.byKey(const ValueKey('pdf-annot-menu-delete')),
+          findsNothing);
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets(
+        'long-press on an annotation in reader mode suppresses the menu',
+        (tester) async {
+      final editing = await pumpViewerNoContextMenu(tester);
+      editing.addRectangle(0, const PdfRect(300, 400, 400, 450));
+      await tester.pump();
+      expect(editing.tool, isNull);
+
+      await longPressAt(tester, viewPoint(350, 425));
+      expect(find.byKey(const ValueKey('pdf-annot-menu-delete')),
+          findsNothing);
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets(
+        'long-press on plain page text still selects the word; no menu pops',
+        (tester) async {
+      final controller = PdfViewerController();
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: controller,
+              editing: editing,
+              contextMenuEnabled: false,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      // 'Page 1' baseline at (72, 720), 24pt - press mid-word
+      await longPressAt(tester, viewPoint(100, 726));
+      expect(controller.selectedText, 'Page',
+          reason: 'text selection survives; only the context menu is '
+              'suppressed');
+      expect(find.byKey(const ValueKey('pdf-text-menu-copy')), findsNothing);
+      expect(
+          find.byKey(const ValueKey('pdf-text-menu-select-all')),
+          findsNothing);
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+  });
 }

--- a/packages/dart_pdf_editor/test/pdf_viewer_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_viewer_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flutter/gestures.dart' show kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1441,6 +1442,65 @@ void main() {
       await tester.pump();
       expect(controller.pageCount, 2,
           reason: 'the viewer subscribes to the form controller as well');
+    });
+  });
+
+  // The viewer routes desktop right-click / touch secondary-tap to the
+  // text menu via GestureDetector.onSecondaryTapUp → `_onSecondaryTapUp`.
+  // When the host sets `contextMenuEnabled: false`, the menu must be
+  // suppressed; the recognizer still runs so text selection, links, etc.
+  // are unaffected.
+  group('contextMenuEnabled', () {
+    test('defaults to true', () {
+      expect(
+          PdfViewer(
+                  document: PdfDocument.open(buildMultiPagePdf(1)))
+              .contextMenuEnabled,
+          isTrue);
+    });
+
+    testWidgets(
+        'right-click on plain page text opens the text menu by default',
+        (tester) async {
+      final controller = await pumpViewer(tester, pages: 2);
+      // 'Page 1' baseline at (72, 720), 24pt - mid-word of "Page"
+      await tester.tapAt(annotView(100, 720),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('pdf-text-menu-copy')), findsOneWidget);
+      expect(
+          find.byKey(const ValueKey('pdf-text-menu-select-all')),
+          findsOneWidget);
+      // dismiss the menu so the teardown of the viewer does not race it
+      await tester.tapAt(const Offset(10, 10));
+      await tester.pumpAndSettle();
+      expect(controller.selectedText, isNotNull,
+          reason: 'selection survives menu dismissal');
+    });
+
+    testWidgets(
+        'right-click on plain page text is suppressed when '
+        'contextMenuEnabled is false', (tester) async {
+      final controller = PdfViewerController();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfViewer(
+            initialFit: PdfViewerFit.width,
+            document: PdfDocument.open(buildMultiPagePdf(2)),
+            controller: controller,
+            contextMenuEnabled: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      await tester.tapAt(annotView(100, 720),
+          buttons: kSecondaryButton);
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('pdf-text-menu-copy')), findsNothing);
+      expect(
+          find.byKey(const ValueKey('pdf-text-menu-select-all')),
+          findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

Adds contextMenuEnabled to PdfViewer, PdfEditorView, and PdfReader. When set to false, the host can fully suppress all three default popup-menu triggers — desktop right-click on text, touch long-press on annotations, and the floating selection chip's "More" button — while keeping every other gesture outcome intact (selection, link tap, pan/zoom). Default stays true, so existing apps are unaffected.

## Affected packages

The package already supports the "augment the default menu" pattern: pass annotationMenuBuilder to PdfEditorView and your extras ride alongside the stock items. But there is no way to replace the default surface — the stock menu still pops, so hosts that own their own menu UI end up showing two menus, or hiding actions behind localization they don't control (the stock labels are not yet localized to the host's bundled l10n catalog).

The new contextMenuEnabled: false switch is the "replace" counterpart:

A host that renders its own right-click / long-press menu can now disable the stock one and route annotationMenuBuilder's actions into its own surface.
A host that has its own annotation actions (share, jump-to-page, app-specific commands like "Send to X") and wants the viewer to expose only its own menu items, in its own labels, in its own language — contextMenuEnabled: false + annotationMenuBuilder is the supported composition.
A host that wants the gesture outcomes but no popup at all (kiosk, screencast, automated captures) is also covered.
The flag is independent of annotationMenuBuilder: leave it true to keep the augmented-stock mode; set it to false to take over the surface entirely.

- [x] `pdf_cos`
- [x] `pdf_document`
- [x] `pdf_graphics`
- [x] `dart_pdf_editor`
- [x] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Feature
- [x] Rendering change
- [x] Editing behavior change
- [x] Performance change
- [x] Refactor / cleanup
- [x] Tests / fixtures only
- [x] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [x] Ghent corpus test or baseline update
- [x] Real PDF corpus parse/render smoke test
- [x] Example app smoke test

If any relevant check was not run, explain why:

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->
