### PR TITLE
Fix signature detail text clipped at the top of the box

### DIFF
--- a/doc/dev-log/2026-07-22-signature-text-top-crop.md
+++ b/doc/dev-log/2026-07-22-signature-text-top-crop.md
@@ -1,0 +1,53 @@
+# Signature detail text clipped at the top of the box
+
+The visible-signature appearance box (`_installSignatureAppearance` in
+`signature_editor.dart`) draws its two detail blocks - the large name in
+the left panel and the "Digitally signed by … / Date … / Reason …" lines on
+the right - vertically centred via `writePdfTextBox`'s
+`PdfTextBoxVAlign.centerBlock`. In tight boxes the top line's ascenders were
+being shaved against the top edge (see the reported "Digitally signed by …"
+crop).
+
+## Cause
+
+`centerBlock` placed the first baseline one ascent below the centred block
+top:
+
+```
+blockTop = box.bottom + (box.height + N * lineHeight) / 2;
+firstY   = blockTop - ascentPts;
+```
+
+That pins the first line's ascent flush to `blockTop` and drops the entire
+per-line leading (`lineHeight - fontSize`, ~0.3·fontSize here) *below* the
+baselines. The block is therefore biased upward by half a line's leading.
+The auto-fit loop in `_drawSignatureText` grows the font until
+`N * lineHeight ≈ boxH`, so `blockTop ≈ box.top` and that upward bias pushes
+the first line's ascenders to within a fraction of a point of the clip - less
+than the amount real glyph tops exceed the nominal 718/1000 ascent, so they
+get clipped. Measured top margins collapsed to 0.2–0.95 pt while the bottom
+kept 2–4 pt of slack.
+
+## Fix
+
+Split the leading symmetrically: reserve half of it *above* the first line's
+ascent.
+
+```
+final halfLeading = math.max(0.0, (lineHeight - fontSize) / 2);
+firstY = blockTop - halfLeading - ascentPts;
+```
+
+This is the standard leading model (line box = `lineHeight`, glyph em =
+`fontSize`, leading split top/bottom). Top and bottom margins are now equal up
+to a constant `ascent + descent - fontSize` residual (the metric ascent+descent
+of 925/1000 is a hair under the em) - top margins rose to 0.9–2.3 pt across the
+same box heights and the first line clears the clip. Only the signature box
+uses `centerBlock`; form fields use `centerLine`/`top` and are untouched.
+
+## Tests
+
+`text_box_appearance_test.dart` - updated the `centreBlock` baseline
+expectation for the half-leading offset and added "centreBlock balances the
+top and bottom margins" asserting the top margin is positive and the top/bottom
+difference is exactly `ascent + descent - fontSize`.

--- a/packages/pdf_document/lib/src/text_box_appearance.dart
+++ b/packages/pdf_document/lib/src/text_box_appearance.dart
@@ -177,9 +177,18 @@ void writePdfTextBox(
     case PdfTextBoxVAlign.top:
       firstY = box.top - padding - ascentPts;
     case PdfTextBoxVAlign.centerBlock:
+      // The N line boxes stack to `N*lineHeight`, centred in the box. Within
+      // each box the glyphs occupy the em (`fontSize`), so the extra
+      // `lineHeight - fontSize` of leading splits half above the ascent and
+      // half below the descent. Placing the first baseline one ascent below
+      // the block top would drop that whole gap below the last line and shove
+      // the block up until the top line's ascenders press against - and are
+      // clipped by - the top edge. Reserving the half-leading above the first
+      // line keeps the ink centred and the top line clear of the clip.
       final blockTop =
           box.bottom + (box.height + lines.length * lineHeight) / 2;
-      firstY = blockTop - ascentPts;
+      final halfLeading = math.max(0.0, (lineHeight - fontSize) / 2);
+      firstY = blockTop - halfLeading - ascentPts;
     case PdfTextBoxVAlign.centerLine:
       final centered = (box.height - ascentPts) / 2;
       firstY = box.bottom + (centered < padding ? padding : centered);

--- a/packages/pdf_document/test/text_box_appearance_test.dart
+++ b/packages/pdf_document/test/text_box_appearance_test.dart
@@ -136,9 +136,32 @@ void main() {
           lineHeight: 12, vAlign: PdfTextBoxVAlign.centerBlock);
       final ascent = 10 * font.ascent / 1000;
       final blockTop = (50 + 2 * 12) / 2;
+      // Half the per-line leading sits above the first ascent so the block's
+      // ink is centred and the top line clears the top edge.
+      const halfLeading = (12 - 10) / 2;
       final lines = _baselines(_content(w));
-      expect(lines[0].$2, closeTo(blockTop - ascent, 1e-6));
-      expect(lines[1].$2, closeTo(blockTop - ascent - 12, 1e-6));
+      expect(lines[0].$2, closeTo(blockTop - halfLeading - ascent, 1e-6));
+      expect(lines[1].$2, closeTo(blockTop - halfLeading - ascent - 12, 1e-6));
+    });
+
+    test('centreBlock balances the top and bottom margins', () {
+      // The block's ink clears both edges by (almost) the same amount - the
+      // top line is no longer shoved against the top. Any residual is exactly
+      // ascent + descent - fontSize, since the leading is split assuming the
+      // text height is the em (fontSize) rather than the metric ascent+descent.
+      const fontSize = 10.0, lineHeight = 12.0;
+      final w = ContentWriter();
+      writePdfTextBox(w, box, ['a', 'b'],
+          font: font, fontSize: fontSize, align: PdfTextAlign.left, padding: 0,
+          lineHeight: lineHeight, vAlign: PdfTextBoxVAlign.centerBlock);
+      final ascent = fontSize * font.ascent / 1000;
+      const descent = fontSize * 207 / 1000; // Helvetica descent, per 1000 em
+      final lines = _baselines(_content(w));
+      final topMargin = box.top - (lines.first.$2 + ascent);
+      final bottomMargin = (lines.last.$2 - descent) - box.bottom;
+      expect(topMargin, greaterThan(0));
+      expect(topMargin - bottomMargin,
+          closeTo(ascent + descent - fontSize, 1e-6));
     });
 
     test('leading emits a TL only when asked', () {


### PR DESCRIPTION
## Summary

The visible-signature appearance box centres its name and detail blocks (the "Digitally signed by … / Date … / Reason …" lines) with `writePdfTextBox`'s `PdfTextBoxVAlign.centerBlock`. That path pinned the first line's ascent flush to the centred block top and dropped the entire per-line leading *below* the baselines, biasing the whole block upward by half a line's leading. Because `_drawSignatureText`'s auto-fit grows the font until `N * lineHeight ≈ boxH`, the block nearly fills the box, so that upward bias pushed the top line's ascenders to within a fraction of a point of the clip — less than the amount real glyph tops exceed the nominal 718/1000 ascent — and they got shaved (the reported "Digitally signed by …" crop).

The fix splits the leading symmetrically, reserving half of `(lineHeight - fontSize)` **above** the first line's ascent (the standard leading model). The ink is now genuinely centred and the top line clears the top edge.

Measured top margins across a range of box heights rose from 0.2–0.95 pt to 0.9–2.3 pt, near-symmetric with the bottom. Only the signature box uses `centerBlock`; form fields (`centerLine`/`top`) are unaffected.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [ ] `fvm flutter pub get`
- [x] `fvm dart analyze` (changed files — clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test` (text_box_appearance, signature, pades, annotation, form fill/styling suites pass)
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to `pdf_document`'s shared text-box layout; ran the directly affected `pdf_document` suites plus the analyzer on the touched files.

## PDF fixtures and screenshots

Verified geometrically by reconstructing absolute baselines from the emitted `Td` deltas and comparing top/bottom ink margins before and after across box heights 26–55 pt (top margins 0.2–0.95 pt → 0.9–2.3 pt).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

A small constant residual asymmetry of `ascent + descent - fontSize` remains because the leading is split using the em (`fontSize`) as the text height rather than the metric ascent+descent (925/1000 for Helvetica); the new "centreBlock balances the top and bottom margins" test pins that exact relationship. Design rationale in `doc/dev-log/2026-07-22-signature-text-top-crop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNGF5mYw5CEKLL6eMTjQph)_