### PR TITLE
perf(web): cap prefetched (off-focus) pages' image resolution (#451)

### DIFF
--- a/doc/dev-log/2026-07-22-prefetch-image-cap-451.md
+++ b/doc/dev-log/2026-07-22-prefetch-image-cap-451.md
@@ -1,0 +1,61 @@
+# 2026-07-22 — cap prefetch image resolution (#451, issue #1)
+
+A single page record reached 39 MB on the #451 mobile-web trace because
+FlateDecode images (unlike DCTDecode, which ships raw for the browser codec)
+decode in pure Dart and ship as **full RGBA at 2× headroom**. Those big records
+are shipped for **prefetched neighbours** too — pages the user isn't looking at —
+so they compete with the visible page on the single effective worker.
+
+## Change
+
+Off-focus (prefetch) pages decode their embedded images at a reduced
+resolution; the focused page always gets full resolution.
+
+- `PdfPageView.focusDistance` (0 = the page the viewport is on), wired from the
+  viewer as `|index − focusPage|` (mirroring `_renderPriority`).
+- `_imageRatioTarget()` multiplies the display image ratio by
+  `PdfPageView.prefetchImagePixelRatioFactor` (0.5) when `focusDistance > 0`.
+  Only images shrink — vectors/text are resolution-independent commands.
+- Invalidation: `_pictureImageRatio` records the ratio a buffer was built at.
+  `didUpdateWidget` drops a reduced buffer's *picture* when the page moves closer
+  to focus (`focusDistance` decreases) so it re-renders sharp, guarded on an
+  actual ratio increase (fires once on approach, not a churn loop). It leaves the
+  reduced base raster up (right geometry, soft images) until the full one
+  replaces it, so a page scrolling into focus never flashes blank. The three
+  preview/full-raster cache seeds are gated on `_renderedAtFullImageRatio()`, so
+  a reduced prefetch raster never seeds the dimension-keyed shared cache (which
+  would let `_restoreFullRaster` serve it back blurry to a now-focused page).
+
+The worker transcript cache keys on `(page, annotations)` and holds the *command
+graph* only — images are decoded at serialize time per the request's ratio — so
+a full-res focus request re-decodes full images even on a command-cache hit.
+No transcript-key change is needed.
+
+## Measured (real Chrome, `tool/perf.sh` web harness)
+
+A 6-page synthetic doc, two 4200×2700 FlateDecode underlays per page (the #451
+image shape). One scroll run, `PERF_VERBOSE` scraping the worker record log:
+
+```
+                  record     images decoded
+  focus/settled   45.0 MB    11.1 Mpx   (pages that settle under the viewport)
+  prefetch        11.8 MB     2.8 Mpx   (neighbours scrolled past)
+```
+
+**Prefetch neighbour records drop 45 → 11.8 MB (~74%, the 4× the 0.5 factor
+predicts).** Pages that settle as focus ship full resolution (11.1 Mpx), so the
+page being viewed is unaffected — confirmed by the per-page `decodedMpx` in the
+trace, not just the byte count. Frames stayed healthy (buildP50 1.1 ms, no new
+jank). In the #451 trace shape (viewing page 0, prefetching 1 & 2) this saves
+~58 MB of prefetch traffic and frees the worker to serve the visible page.
+
+An earlier run with 1600×1100 images showed only 3.5 → 2.8 Mpx — those images
+are near their display size, so the display cap barely binds and the reduction
+looks small. The cap (and the win) only bind hard on genuinely
+over-resolution artwork, which is exactly #451's class.
+
+## Not addressed here
+
+#451 issue #2 (background prerender should preempt the visible page on the
+worker) and the visible-page 39 MB record itself (that needs progressive
+first-record resolution, not a prefetch cap). This is issue #1.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -51,6 +51,7 @@ class PdfPageView extends StatefulWidget {
     this.renderHold,
     this.renderScheduler,
     this.renderPriority = 0,
+    this.focusDistance = 0,
     this.previewCache,
     this.previewIndex = 0,
     this.pageEpoch = 0,
@@ -178,6 +179,14 @@ class PdfPageView extends StatefulWidget {
   /// values win. The viewer ranks the page nearest the viewport above cache-
   /// window neighbours so a long jump paints the destination first.
   final int renderPriority;
+
+  /// Distance in pages from the focused page (0 = the page the viewport is on).
+  /// Off-focus neighbours are prefetched, so their embedded images are decoded
+  /// and shipped at a reduced resolution ([prefetchImagePixelRatioFactor]) to
+  /// keep record traffic down (a Flate raster underlay ships as full RGBA - a
+  /// single page can reach tens of MB, starving the visible page, #451). The
+  /// page re-renders at full image resolution the moment it becomes focused.
+  final int focusDistance;
 
   /// Called whenever a full-page raster for the current [page] object
   /// lands on screen. Lets the editing overlay hold its just-committed
@@ -341,6 +350,16 @@ class PdfPageView extends StatefulWidget {
   /// ([pdfDefaultTileStoreDetail], issues #314/#360) now the budget-vs-demand
   /// guard keeps a dense view from thrashing the shared pyramid.
   static bool tileStoreDetail = pdfDefaultTileStoreDetail();
+
+  /// Factor applied to a prefetched (off-focus) page's image-decode resolution,
+  /// relative to the focused page's. Off-focus pages aren't being looked at, so
+  /// shipping their embedded images at full 2x-headroom resolution wastes record
+  /// bandwidth (a Flate raster underlay ships as full RGBA - tens of MB) and
+  /// competes with the visible page on the worker (#451). 0.5 halves the image
+  /// ratio (~4x smaller image payload); the page re-decodes at full resolution
+  /// the moment it becomes focused. Only images are affected - vectors and text
+  /// are resolution-independent commands. 1.0 disables the reduction.
+  static double prefetchImagePixelRatioFactor = 0.5;
 
   /// Test seam: the store the tile layer draws from. Null uses the shared
   /// [PdfTileStore.instance].
@@ -635,7 +654,22 @@ class _PdfPageViewState extends State<PdfPageView> {
         _dropDetail();
       }
     }
-    if (transition.scheduleRender) {
+    // A prefetch neighbour decoded its images at reduced resolution
+    // ([prefetchImagePixelRatioFactor]); now that it is closer to focus and
+    // wants full-resolution images, drop the reduced buffer (and its raster) so
+    // the render below rebuilds it sharp. Guarded on an actual ratio increase,
+    // so it fires once as the page approaches focus, not as a churn loop.
+    var droppedForFocus = false;
+    if (widget.focusDistance < oldWidget.focusDistance &&
+        !_renderedAtFullImageRatio()) {
+      // _dropPicture nulls _rasteredRatio, so the render below re-rasters
+      // rather than skipping. The reduced-resolution base raster is left up
+      // (it is the right geometry, only its images are soft) until the
+      // full-resolution one replaces it - no blank flash as a page scrolls in.
+      _dropPicture();
+      droppedForFocus = true;
+    }
+    if (transition.scheduleRender || droppedForFocus) {
       // scale change re-rasters the page; a settle that only moved the
       // viewport refreshes the detail patch. Both route through _render so
       // they pace and coalesce through the scheduler (_renderNow skips the
@@ -770,6 +804,36 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   double _effectiveRatio() => _effectiveRatioAt(widget.scale);
 
+  /// The image-decode resolution this page's record should use: the display
+  /// ratio (capped by [PdfPageView.workerImagePixelRatioCap]), reduced by
+  /// [PdfPageView.prefetchImagePixelRatioFactor] when the page is an off-focus
+  /// prefetch neighbour (#451). A focused page always gets the full ratio, so a
+  /// page re-rendered on becoming focused decodes its images at full resolution.
+  double _imageRatioTarget() {
+    final base = _fullImageRatio();
+    if (widget.focusDistance <= 0) return base;
+    return base * PdfPageView.prefetchImagePixelRatioFactor;
+  }
+
+  /// The full (unreduced) image-decode ratio for a focused page.
+  double _fullImageRatio() => math.min(
+        _effectiveRatio(),
+        widget.workerImagePixelRatioCap ?? double.infinity,
+      );
+
+  /// The image ratio [_picture]/[_scene] were interpreted at, so a later render
+  /// can tell a reduced-resolution prefetch buffer from a full-resolution one
+  /// and drop it when the page becomes focused (null = none / unknown).
+  double? _pictureImageRatio;
+
+  /// Whether the current buffer decoded its images at full resolution - i.e.
+  /// this is not a reduced-resolution prefetch buffer. Only such buffers seed
+  /// the shared full-raster cache, so [_restoreFullRaster] never serves a
+  /// blurry prefetch raster to a page that has since become focused (#451).
+  bool _renderedAtFullImageRatio() =>
+      _pictureImageRatio == null ||
+      _pictureImageRatio! >= _fullImageRatio() * 0.99;
+
   /// [_effectiveRatio] at an explicit [scale] (see [_desiredRatioAt]).
   double _effectiveRatioAt(double scale) {
     final size = _renderPlan.pageSize(widget.page);
@@ -900,10 +964,8 @@ class _PdfPageViewState extends State<PdfPageView> {
       // resolution so a CAD raster underlay isn't decoded/shipped/rasterized
       // at its native 100+ megapixels (the deep-zoom patch re-rasters the
       // visible region for sharper zoom).
-      final imageRatio = math.min(
-        _effectiveRatio(),
-        widget.workerImagePixelRatioCap ?? double.infinity,
-      );
+      final imageRatio = _imageRatioTarget();
+      _pictureImageRatio = imageRatio;
       final commands = await worker.record(
         pageIndex,
         annotations: widget.showAnnotations,
@@ -942,6 +1004,8 @@ class _PdfPageViewState extends State<PdfPageView> {
     // The worker may be active yet decline this page (it returns null), in
     // which case the interpret runs here - the log must say so, not 'worker'.
     _lastInterpretPath = 'recorded';
+    final localImageRatio = _imageRatioTarget();
+    _pictureImageRatio = localImageRatio;
     // The local path has no worker wait: record + decode + picture build are
     // one UI-thread phase, reported entirely as build.
     final buildClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
@@ -955,6 +1019,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       final result = await PdfPageRenderer.renderPictureRecordedWithPlan(
         widget.page,
         _renderPlan,
+        maxImagePixelRatio: localImageRatio,
       );
       stampLocalPhases();
       return (result, null, false);
@@ -963,7 +1028,7 @@ class _PdfPageViewState extends State<PdfPageView> {
     // but the command buffer and decoded images are kept for zoom replays
     // instead of being discarded after the 1:1 replay below.
     final scene = await PdfRetainedScene.record(widget.page,
-        plan: _renderPlan, maxImagePixelRatio: _effectiveRatio());
+        plan: _renderPlan, maxImagePixelRatio: localImageRatio);
     _lastInterpretResultBytes = _logImageStats(pageIndex, scene.commands);
     if (!_retainScene(scene.commands)) {
       // Too dense or too fragmented to replay per zoom settle: take the 1:1
@@ -1487,6 +1552,7 @@ class _PdfPageViewState extends State<PdfPageView> {
             _dropDetail();
             final cache = widget.previewCache;
             if (cache != null &&
+                _renderedAtFullImageRatio() &&
                 !cache.isFresh(
                   widget.previewIndex,
                   widget.page,
@@ -1599,18 +1665,21 @@ class _PdfPageViewState extends State<PdfPageView> {
         _preview?.dispose();
         _preview = null;
       });
-      cache?.putFullImage(
-        widget.previewIndex,
-        widget.page,
-        image,
-        pageColor: widget.pageColor,
-        annotations: widget.showAnnotations,
-        rotation: widget.rotation,
-      );
+      if (_renderedAtFullImageRatio()) {
+        cache?.putFullImage(
+          widget.previewIndex,
+          widget.page,
+          image,
+          pageColor: widget.pageColor,
+          annotations: widget.showAnnotations,
+          rotation: widget.rotation,
+        );
+      }
       // feed the preview cache from the picture we already paid to
       // interpret - this is how previews appear for pages the background
       // prerender hasn't reached (and refresh after edits)
       if (cache != null &&
+          _renderedAtFullImageRatio() &&
           !cache.isFresh(
             widget.previewIndex,
             widget.page,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5201,6 +5201,8 @@ class _PdfViewerState extends State<PdfViewer>
                 contentStamp: _contentStamp(index),
                 destructiveStamp: _destructiveStamp(index),
                 renderPriority: _renderPriority(index),
+                focusDistance:
+                    (index - (_jumpFocusPage ?? _controller.currentPage)).abs(),
                 matches: _controller._matchesOn(index),
                 currentMatch: _controller._currentMatch >= 0
                     ? _controller._matches[_controller._currentMatch]
@@ -5963,6 +5965,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.contentStamp,
     required this.destructiveStamp,
     required this.renderPriority,
+    required this.focusDistance,
     required this.matches,
     required this.currentMatch,
     required this.selection,
@@ -6029,6 +6032,7 @@ class _PdfViewerPage extends StatefulWidget {
   /// can't linger on screen. 0 outside an editing session.
   final int destructiveStamp;
   final int renderPriority;
+  final int focusDistance;
   final List<PdfTextMatch> matches;
   final PdfTextMatch? currentMatch;
   final List<PdfTextQuad> selection;
@@ -6168,6 +6172,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         contentStamp: widget.contentStamp,
         destructiveStamp: widget.destructiveStamp,
         renderPriority: widget.renderPriority,
+        focusDistance: widget.focusDistance,
         pageColor: widget.pageColor,
         showAnnotations: widget.pageImagesShowAnnotations,
         trustContentStamp: widget.trustContentStamp,


### PR DESCRIPTION
Addresses **#451 issue #1**. Validated on-device via the `tool/perf.sh` web harness (real Chrome).

## Problem

FlateDecode images decode in pure Dart and ship as **full RGBA at 2× headroom** in a worker record, so a single page reaches tens of MB. Those big records are shipped for **prefetched neighbours** too — pages the user isn't looking at — competing with the visible page on the one effective worker.

## Change

Off-focus (prefetch) pages decode their embedded images at a reduced resolution; the focused page always gets full resolution.

- `PdfPageView.focusDistance` (0 = the viewport's page), wired from the viewer as `|index − focusPage|`.
- `_imageRatioTarget()` × `prefetchImagePixelRatioFactor` (0.5) when off-focus. **Only images shrink** — vectors/text are resolution-independent commands.
- **Invalidation:** `_pictureImageRatio` records the ratio a buffer used. `didUpdateWidget` drops the reduced *picture* (leaving its base raster up — no blank flash) when the page nears focus so it re-renders sharp; guarded on an actual ratio increase (fires once on approach, no churn loop). The three preview/full-raster cache seeds are gated on `_renderedAtFullImageRatio()` so a reduced raster never seeds the dimension-keyed shared cache and gets served back blurry to a now-focused page.
- The worker transcript caches the **command graph** (ratio-independent) and decodes images per the request's ratio at serialize time, so a full-res focus request re-decodes full images even on a command-cache hit — no transcript-key change needed (verified in the trace: prefetch requests hit the command cache and re-serialize at reduced ratio).

## Measured (real Chrome, `tool/perf.sh` web harness)

6-page synthetic doc, two 4200×2700 FlateDecode underlays per page (the #451 image shape), one scroll run scraping the worker record log:

| | record | images decoded |
|---|---|---|
| **focus / settled** (pages that settle under the viewport) | **45.0 MB** | **11.1 Mpx** (full) |
| **prefetch** (neighbours scrolled past) | **11.8 MB** | **2.8 Mpx** (reduced) |

**Prefetch neighbour records drop 45 → 11.8 MB (~74%, the 4× the 0.5 factor predicts)**, while pages that settle as focus ship full resolution (confirmed by per-page `decodedMpx`, not just byte count) — so the page you're actually viewing is unaffected. Frames stayed healthy (buildP50 1.1 ms, no new jank). In the #451 trace shape (viewing page 0, prefetching 1 & 2) this saves ~58 MB of prefetch traffic and frees the worker for the visible page.

An earlier 1600×1100-image run showed only 3.5 → 2.8 Mpx — small images sit near their display size so the display cap barely binds; the win binds hard on genuinely over-resolution artwork, which is #451's class.

## Testing

- Full `dart_pdf_editor` Flutter suite green (1811 passed; GWG030 is the pre-existing Ghent spot/overprint failure, fails identically on main).
- `dart analyze` clean.
- On-device record-size + focus-resolution + frame health via the web harness (above).

## Not in scope

#451 issue #2 (background prerender should preempt the visible page on the worker) and the visible-page record itself (needs progressive first-record resolution, not a prefetch cap).

Dev-log: `doc/dev-log/2026-07-22-prefetch-image-cap-451.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)