### PR TITLE
fix(editor): share the Snapshot vector clipboard across document tabs

### DIFF
--- a/app/test/snapshot_clipboard_test.dart
+++ b/app/test/snapshot_clipboard_test.dart
@@ -14,6 +14,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dart_pdf_editor_app/image_clipboard.dart';
 
 void main() {
+  setUp(() {
+    // controllers share the process-wide snapshot clipboard by default; start
+    // each test from empty so one test's capture can't leak into the next.
+    PdfSnapshotClipboard.instance.clear();
+  });
+
   // A throwaway PdfSnapshot whose pngBytes are the only field the handler reads.
   PdfSnapshot makeSnapshot(Uint8List png) {
     SharedPreferences.setMockInitialValues({});

--- a/doc/dev-log/2026-07-22-snapshot-clipboard-cross-tab.md
+++ b/doc/dev-log/2026-07-22-snapshot-clipboard-cross-tab.md
@@ -1,0 +1,57 @@
+# Snapshot vector clipboard, shared across tabs
+
+The Snapshot tool captures a page region as **both** a raster PNG (dropped on
+the system clipboard) and a detached `PdfVectorSnapshot` kept in-app for
+paste-back as sharp vector graphics. But the vector half lived on the
+capturing `PdfEditingController` (`_snapshotClipboard`), which is **per tab**.
+So a snapshot taken in one document tab and pasted into another had no vector
+copy in the target tab: `hasSnapshotClipboard` was false there, `⌘V` fell
+through to the system-clipboard image path, and the region pasted as a flat
+**image** instead of vector.
+
+## The fix — a shared clipboard singleton
+
+Followed the exact `PdfPageClipboard` pattern (see
+`2026-07-16-page-clipboard.md`): a new `PdfSnapshotClipboard`
+(`editing_snapshot_clipboard.dart`) is a `ChangeNotifier` holding the current
+`PdfVectorSnapshot`, with a process-wide `instance`. Every
+`PdfEditingController` defaults to it (new `snapshotClipboard` constructor
+arg), so cross-tab paste works with **zero host wiring** — the app's
+`DocumentTab` still does `PdfEditingController(bytes, preferences: …)` and
+automatically shares it. Pass a private clipboard to isolate a session (tests
+do).
+
+The snapshot is already fully detached (page content + resources copied
+inline), so it survives the source tab being closed entirely — a paste never
+touches the originating document.
+
+## Controller changes (`editing_controller.dart`)
+
+- `_snapshotClipboard` field is gone; `copyVectorSnapshot` publishes to
+  `snapshotClipboard.set(…)`, `pasteSnapshot` reads
+  `snapshotClipboard.snapshot`, `hasSnapshotClipboard` delegates to
+  `snapshotClipboard.isNotEmpty`, and `copySelectedAnnotations`'s "last copy
+  wins" now `snapshotClipboard.clear()`s.
+- The old public `snapshotClipboard` getter (returned the `PdfVectorSnapshot?`)
+  is replaced by the shared-clipboard field of the same name; read the vector
+  via `snapshotClipboard.snapshot`.
+- Per-document paste bookkeeping (`_snapshotPasteCount`, the shared captured
+  `/Cap` form ref `_snapshotCapturedRef`) is now keyed to the active
+  snapshot's identity via `_snapshotPasteAnchor`. The shared clipboard can
+  change under a controller (recapture here, or a capture in another tab), so
+  `pasteSnapshot` resets the cascade and drops the captured-form ref whenever
+  the snapshot identity differs — the ref was materialized from the *previous*
+  snapshot into *this* document and would otherwise be reused wrongly.
+- The controller registers/removes a listener on `snapshotClipboard`
+  (mirroring `preferences`/`pageClipboard`), so every tab rebuilds its
+  Paste-as-vector affordance the instant any tab captures or clears.
+
+## Tests
+
+- `editing_snapshot_test.dart`: two new tests — a capture in one tab pastes as
+  vector (`/Cap Do` in the appearance) in another sharing the clipboard, and
+  the shared snapshot survives disposing the source tab. A `setUp` clears
+  `PdfSnapshotClipboard.instance` so the default singleton can't leak between
+  tests; the two vector-getter assertions moved to `.snapshotClipboard.snapshot`.
+- `editing_menu_test.dart` / app `snapshot_clipboard_test.dart`: same `setUp`
+  clear (both construct default-singleton controllers).

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -36,6 +36,7 @@ export 'src/editing/editing_preferences.dart';
 export 'src/editing/editing_properties.dart';
 export 'src/editing/editing_sidebar.dart';
 export 'src/editing/editing_signature.dart';
+export 'src/editing/editing_snapshot_clipboard.dart';
 export 'src/editing/editing_stamps.dart';
 export 'src/editing/editing_takeoff.dart';
 export 'src/editing/editing_thumbnails.dart';

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -13,6 +13,7 @@ import 'digital_signature.dart';
 import 'editing_measure.dart';
 import 'editing_page_clipboard.dart';
 import 'editing_preferences.dart';
+import 'editing_snapshot_clipboard.dart';
 import 'editing_tool_behavior.dart';
 import 'line_style.dart';
 import 'editing_stamps.dart';
@@ -331,17 +332,23 @@ class PdfEditingController extends ChangeNotifier {
     String password = '',
     PdfEditingPreferences? preferences,
     PdfPageClipboard? pageClipboard,
+    PdfSnapshotClipboard? snapshotClipboard,
   })  : _bytes = bytes,
         _used = bytes.length,
         _password = password,
         _revisions = [bytes.length],
         _document = PdfDocument.open(bytes, password: password),
         preferences = preferences ?? PdfEditingPreferences(),
-        pageClipboard = pageClipboard ?? PdfPageClipboard.instance {
+        pageClipboard = pageClipboard ?? PdfPageClipboard.instance,
+        snapshotClipboard =
+            snapshotClipboard ?? PdfSnapshotClipboard.instance {
     this.preferences.addListener(notifyListeners);
     // rebuild paste affordances live as the shared page clipboard fills or
     // clears - from this controller or from another document tab sharing it
     this.pageClipboard.addListener(notifyListeners);
+    // same for the shared snapshot clipboard, so a region captured in one tab
+    // lights up Paste-as-vector in every tab
+    this.snapshotClipboard.addListener(notifyListeners);
   }
 
   /// The persisted UI preferences that own the tool styles (stroke width,
@@ -358,6 +365,14 @@ class PdfEditingController extends ChangeNotifier {
   /// the process-wide [PdfPageClipboard.instance]; pass a private one to
   /// isolate a session. See [copyPages], [cutPages], and [pastePages].
   final PdfPageClipboard pageClipboard;
+
+  /// The clipboard the Snapshot tool's captured vector region lives in, shared
+  /// across document tabs so a region captured in one document pastes back as
+  /// vector into another (rather than falling back to the raster the capture
+  /// also drops on the system clipboard). Defaults to the process-wide
+  /// [PdfSnapshotClipboard.instance]; pass a private one to isolate a session.
+  /// See [copyVectorSnapshot] and [pasteSnapshot].
+  final PdfSnapshotClipboard snapshotClipboard;
 
   /// The session's shared page-thumbnail cache (and its viewport-ordered
   /// render queue). Every thumbnail surface - the docked strip, the
@@ -376,6 +391,7 @@ class PdfEditingController extends ChangeNotifier {
     thumbnailCache.dispose();
     preferences.removeListener(notifyListeners);
     pageClipboard.removeListener(notifyListeners);
+    snapshotClipboard.removeListener(notifyListeners);
     super.dispose();
   }
 
@@ -4358,7 +4374,7 @@ class PdfEditingController extends ChangeNotifier {
     _clipboardSourcePage = _selected.last.$1;
     _pasteCount = 0;
     // the most recent copy wins ⌘V (see [copyVectorSnapshot])
-    _snapshotClipboard = null;
+    snapshotClipboard.clear();
     notifyListeners();
     return snapshots.length;
   }
@@ -4481,24 +4497,23 @@ class PdfEditingController extends ChangeNotifier {
   // ---------------------------------------------------------------------
   // snapshot clipboard (the Snapshot tool's vector paste)
 
-  /// The in-app snapshot clipboard: a detached vector copy of a page
-  /// region ([captureVectorSnapshot]) that survives edits, undo, and
-  /// document swaps. Filled by the Snapshot tool, consumed by
-  /// [pasteSnapshot].
-  PdfVectorSnapshot? _snapshotClipboard;
   int _snapshotPasteCount = 0;
 
   /// The object number of the captured form materialized by the last paste
-  /// of [_snapshotClipboard] into the current document - reused so repeat
+  /// of the active snapshot into the current document - reused so repeat
   /// pastes share one XObject instead of re-embedding the page content.
-  /// Reset whenever a fresh snapshot is captured.
+  /// Reset whenever a different snapshot becomes active.
   int? _snapshotCapturedRef;
 
-  /// Whether [pasteSnapshot] has a captured region to paste.
-  bool get hasSnapshotClipboard => _snapshotClipboard != null;
+  /// Which snapshot [_snapshotCapturedRef] / [_snapshotPasteCount] belong to.
+  /// The shared [snapshotClipboard] can change under this controller (a
+  /// recapture here, or a capture in another tab), so paste keys its
+  /// per-document bookkeeping to the snapshot identity and resets when it
+  /// differs.
+  PdfVectorSnapshot? _snapshotPasteAnchor;
 
-  /// The captured region on the snapshot clipboard, or null.
-  PdfVectorSnapshot? get snapshotClipboard => _snapshotClipboard;
+  /// Whether [pasteSnapshot] has a captured region to paste.
+  bool get hasSnapshotClipboard => snapshotClipboard.isNotEmpty;
 
   /// Captures [region] (PDF user space) of [pageIndex] as a detached
   /// vector snapshot - the page graphics under the region, copied inline,
@@ -4513,9 +4528,10 @@ class PdfEditingController extends ChangeNotifier {
   /// clipboard. Returns the captured snapshot.
   PdfVectorSnapshot copyVectorSnapshot(int pageIndex, PdfRect region) {
     final snapshot = captureVectorSnapshot(pageIndex, region);
-    _snapshotClipboard = snapshot;
-    _snapshotPasteCount = 0;
-    _snapshotCapturedRef = null;
+    // publish to the shared clipboard; paste resets its per-document
+    // bookkeeping when it sees this new snapshot (identity differs from the
+    // anchor).
+    snapshotClipboard.set(snapshot);
     _clipboard = const [];
     notifyListeners();
     return snapshot;
@@ -4530,9 +4546,18 @@ class PdfEditingController extends ChangeNotifier {
   /// cascading 12pt down-right per repeat. The region always clamps into
   /// the page's crop box. Returns whether anything was pasted.
   bool pasteSnapshot(int pageIndex, {(double, double)? at}) {
-    final snapshot = _snapshotClipboard;
+    final snapshot = snapshotClipboard.snapshot;
     if (snapshot == null) return false;
     if (pageIndex < 0 || pageIndex >= _document.pageCount) return false;
+    // The shared clipboard may hold a different snapshot than the one this
+    // controller last pasted (recaptured here, or captured in another tab).
+    // Restart the position cascade and drop the captured-form ref, which was
+    // materialized from the previous snapshot into this document.
+    if (!identical(snapshot, _snapshotPasteAnchor)) {
+      _snapshotPasteAnchor = snapshot;
+      _snapshotPasteCount = 0;
+      _snapshotCapturedRef = null;
+    }
     final w = snapshot.displayWidth, h = snapshot.displayHeight;
     if (w <= 0 || h <= 0) return false;
     double left, bottom;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_snapshot_clipboard.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_snapshot_clipboard.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+/// A clipboard for the Snapshot tool's captured vector region, shared across
+/// documents: capture a region in one [PdfEditingController], then paste it
+/// back as sharp vector graphics into the same document - or into a different
+/// open document tab, since every controller shares the process-wide
+/// [instance] by default.
+///
+/// The captured [PdfVectorSnapshot] is fully detached - the page content and
+/// resources under the region are copied inline - so a paste never depends on
+/// the source document staying open (or even the tab it was captured from
+/// still existing). That is what lets a snapshot taken in one tab paste back
+/// as vector in another: without a shared clipboard the target tab has no
+/// vector copy and can only fall back to the raster (PNG) the capture also
+/// dropped on the system clipboard, pasting the region as a flat image.
+///
+/// A [ChangeNotifier] so paste affordances can enable and disable live as the
+/// clipboard fills and clears. Controllers default to the shared [instance] so
+/// a capture in one tab pastes into another with no wiring; pass a private
+/// clipboard to a controller to isolate it (tests do this).
+class PdfSnapshotClipboard extends ChangeNotifier {
+  /// The process-wide clipboard every [PdfEditingController] shares by
+  /// default, so a region captured in one document tab can be pasted as
+  /// vector into another.
+  static final PdfSnapshotClipboard instance = PdfSnapshotClipboard();
+
+  PdfVectorSnapshot? _snapshot;
+
+  /// The captured vector region waiting to be pasted, or null when empty.
+  PdfVectorSnapshot? get snapshot => _snapshot;
+
+  /// Whether there is a captured region waiting to be pasted.
+  bool get isNotEmpty => _snapshot != null;
+
+  /// Whether the clipboard is empty.
+  bool get isEmpty => _snapshot == null;
+
+  /// Fills the clipboard with [snapshot], replacing any previous contents and
+  /// notifying listeners.
+  void set(PdfVectorSnapshot snapshot) {
+    _snapshot = snapshot;
+    notifyListeners();
+  }
+
+  /// Empties the clipboard (a no-op, no notification, when already empty).
+  void clear() {
+    if (_snapshot == null) return;
+    _snapshot = null;
+    notifyListeners();
+  }
+}

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -15,6 +15,9 @@ Offset viewPoint(double x, double y) => Offset(x * scale, (792 - y) * scale);
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
+    // controllers share the process-wide snapshot clipboard by default; start
+    // each test from empty so one test's capture can't leak into the next.
+    PdfSnapshotClipboard.instance.clear();
   });
 
   group('controller z-order', () {

--- a/packages/dart_pdf_editor/test/editing_snapshot_test.dart
+++ b/packages/dart_pdf_editor/test/editing_snapshot_test.dart
@@ -12,6 +12,12 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  setUp(() {
+    // controllers share the process-wide snapshot clipboard by default; start
+    // each test from empty so one test's capture can't leak into the next.
+    PdfSnapshotClipboard.instance.clear();
+  });
+
   group('PdfEditingController snapshot clipboard', () {
     test('copyVectorSnapshot fills the clipboard; paste adds a vector stamp',
         () {
@@ -46,7 +52,7 @@ void main() {
           editing.captureVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
       expect(snap.region, const PdfRect(60, 700, 220, 740));
       expect(editing.hasSnapshotClipboard, isFalse);
-      expect(editing.snapshotClipboard, isNull);
+      expect(editing.snapshotClipboard.snapshot, isNull);
     });
 
     test('copying without a paste point cascades repeat pastes', () {
@@ -54,7 +60,7 @@ void main() {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
       editing.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
-      expect(editing.snapshotClipboard, isNotNull);
+      expect(editing.snapshotClipboard.snapshot, isNotNull);
 
       expect(editing.pasteSnapshot(0), isTrue);
       final first = editing.document.page(0).annotations.last.rect;
@@ -131,6 +137,51 @@ void main() {
       // pinned to the low edge of the 612x792 crop box
       expect(rect.left, closeTo(0, 1e-6));
       expect(rect.bottom, closeTo(0, 1e-6));
+    });
+
+    test('a snapshot captured in one tab pastes as vector in another', () {
+      SharedPreferences.setMockInitialValues({});
+      // two documents ("tabs") that share one snapshot clipboard, mirroring
+      // the app's process-wide PdfSnapshotClipboard.instance
+      final clip = PdfSnapshotClipboard();
+      final tabA = PdfEditingController(buildMultiPagePdf(1),
+          snapshotClipboard: clip);
+      final tabB = PdfEditingController(buildMultiPagePdf(1),
+          snapshotClipboard: clip);
+      addTearDown(tabA.dispose);
+      addTearDown(tabB.dispose);
+
+      // capture a region in tab A
+      tabA.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      // tab B sees it on the shared clipboard - so ⌘V pastes vector, not the
+      // raster the capture also dropped on the system clipboard
+      expect(tabB.hasSnapshotClipboard, isTrue);
+      expect(tabB.pasteSnapshot(0, at: (300, 400)), isTrue);
+
+      final stamp = tabB.document.page(0).annotations.single;
+      expect(stamp.subtype, 'Stamp');
+      final ap = latin1.decode(
+          tabB.document.cos.decodeStreamData(stamp.normalAppearance!));
+      // the appearance *draws* the captured form - it is vector, not an image
+      expect(ap, contains('/Cap Do'));
+    });
+
+    test('the shared clipboard survives closing the source tab', () {
+      SharedPreferences.setMockInitialValues({});
+      final clip = PdfSnapshotClipboard();
+      final tabA = PdfEditingController(buildMultiPagePdf(1),
+          snapshotClipboard: clip);
+      final tabB = PdfEditingController(buildMultiPagePdf(1),
+          snapshotClipboard: clip);
+      addTearDown(tabB.dispose);
+
+      tabA.copyVectorSnapshot(0, const PdfRect(60, 700, 220, 740));
+      // the source tab is closed before the paste (the snapshot is detached)
+      tabA.dispose();
+
+      expect(tabB.hasSnapshotClipboard, isTrue);
+      expect(tabB.pasteSnapshot(0, at: (300, 400)), isTrue);
+      expect(tabB.document.page(0).annotations.single.subtype, 'Stamp');
     });
   });
 


### PR DESCRIPTION
## Summary

The Snapshot tool captures a page region as **both** a raster PNG (dropped on the system clipboard) and a detached `PdfVectorSnapshot` kept in-app for paste-back as sharp vector graphics. The vector copy lived on the capturing `PdfEditingController`, which is **per tab** — so a snapshot taken in one document tab and pasted into another had no vector copy in the target tab, `hasSnapshotClipboard` was false there, and `⌘V` fell through to the system-clipboard image path. The region pasted as a flat **image** instead of vector.

This introduces a process-wide `PdfSnapshotClipboard` (a `ChangeNotifier` singleton), mirroring the existing `PdfPageClipboard` pattern already used for cross-tab page copy/paste. Every `PdfEditingController` defaults to the shared instance, so a region captured in one tab now pastes back as **vector** in another with zero host wiring; pass a private clipboard to isolate a session. The snapshot is already fully detached (page content + resources copied inline), so a paste survives the source tab being closed.

Per-document paste bookkeeping (the position cascade and the shared `/Cap` form object ref) is keyed to the active snapshot's identity, so it resets correctly when the shared clipboard changes under a controller (a recapture here, or a capture in another tab).

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only (dev-log)

## Change type

- [x] Bug fix
- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (no issues)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (`editing_snapshot_test.dart`, `editing_menu_test.dart`)
- [x] App test (`app/test/snapshot_clipboard_test.dart`)

## Notes for reviewers

- The old public `snapshotClipboard` getter (returned `PdfVectorSnapshot?`) is replaced by the shared-clipboard field of the same name; read the vector via `snapshotClipboard.snapshot`. The two in-repo callers were test assertions, updated here.
- `copySelectedAnnotations`'s "most recent copy wins" now clears the shared snapshot clipboard globally (an annotation copy in any tab supersedes the snapshot), consistent with the prior per-tab behavior.
- New tests cover the cross-tab vector paste and paste-after-source-tab-closed; a `setUp` clears `PdfSnapshotClipboard.instance` so the default singleton can't leak between tests. See `doc/dev-log/2026-07-22-snapshot-clipboard-cross-tab.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYDhJYAcCaacbtaMfdQzpH)_