### PR TITLE
fix(editor): make paste work on web (text via browser clipboard)

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -66,6 +66,7 @@ class EditorScreen extends StatefulWidget {
     this.saveDocumentToPath,
     this.imageClipboardWriter,
     this.imageClipboardReader,
+    this.textClipboardReader,
   });
 
   final PdfEditingPreferences prefs;
@@ -137,6 +138,12 @@ class EditorScreen extends StatefulWidget {
   /// Override for reading an image from the system clipboard. Tests inject a
   /// fake; production falls back to [readImageFromClipboard].
   final ImageClipboardReader? imageClipboardReader;
+
+  /// Override for reading text from the system clipboard. Tests inject a fake;
+  /// production falls back to [readTextFromClipboard] (which on the web reads
+  /// through the browser Async Clipboard API instead of Flutter's unreliable
+  /// `Clipboard.getData`).
+  final TextClipboardReader? textClipboardReader;
 
   @override
   State<EditorScreen> createState() => _EditorScreenState();
@@ -2341,6 +2348,8 @@ class _EditorScreenState extends State<EditorScreen>
       imagePicker: (context) => pickImageBytes(),
       systemImagePasteProvider: (context) =>
           (widget.imageClipboardReader ?? readImageFromClipboard)(),
+      systemTextPasteProvider: (context) =>
+          (widget.textClipboardReader ?? readTextFromClipboard)(),
       onExportSelectedContentImage: (context, image) =>
           _exportSelectedContentImage(context, tab, image),
       onExportCustomStamps: _exportCustomStamps,

--- a/app/lib/image_clipboard.dart
+++ b/app/lib/image_clipboard.dart
@@ -10,7 +10,7 @@ import 'image_clipboard_io.dart'
 
 export 'image_clipboard_io.dart'
     if (dart.library.js_interop) 'image_clipboard_web.dart'
-    show copyPngToClipboard, readImageFromClipboard;
+    show copyPngToClipboard, readImageFromClipboard, readTextFromClipboard;
 
 /// Writes PNG-encoded image [bytes] to the system clipboard. Returns true on
 /// success, false (or throws) when the running platform can't.
@@ -24,6 +24,10 @@ typedef ImageClipboardWriter = Future<bool> Function(Uint8List bytes);
 /// Reads PNG/JPEG-compatible image bytes from the system clipboard. Returns
 /// null when the clipboard has no image or the platform denies access.
 typedef ImageClipboardReader = Future<Uint8List?> Function();
+
+/// Reads plain text from the system clipboard. Returns null when the clipboard
+/// has no text or the platform denies access.
+typedef TextClipboardReader = Future<String?> Function();
 
 /// Builds the [PdfSnapshotHandler] the editor passes to the viewer's Snapshot
 /// tool. The tool already keeps a *vector* copy on the in-app clipboard for

--- a/app/lib/image_clipboard_io.dart
+++ b/app/lib/image_clipboard_io.dart
@@ -16,3 +16,11 @@ Future<bool> copyPngToClipboard(Uint8List bytes) async {
 Future<Uint8List?> readImageFromClipboard() async {
   return await _channel.invokeMethod<Uint8List>('readImage');
 }
+
+/// Reads plain text from the native system clipboard. Flutter's [Clipboard]
+/// works fine on desktop/mobile, so this just delegates to it (the web variant
+/// bypasses it because `Clipboard.getData` is unreliable in the browser).
+Future<String?> readTextFromClipboard() async {
+  final data = await Clipboard.getData(Clipboard.kTextPlain);
+  return data?.text;
+}

--- a/app/lib/image_clipboard_web.dart
+++ b/app/lib/image_clipboard_web.dart
@@ -23,23 +23,64 @@ Future<bool> copyPngToClipboard(Uint8List bytes) async {
   return true;
 }
 
-/// Reads a PNG/JPEG image from the browser clipboard. Browsers require a
-/// secure context and a user-initiated paste gesture; denied access or a
-/// clipboard without an image returns null.
-Future<Uint8List?> readImageFromClipboard() async {
-  try {
-    final items = (await web.window.navigator.clipboard.read().toDart).toDart;
-    for (final item in items) {
-      for (final jsType in item.types.toDart) {
-        final type = jsType.toDart;
-        if (type != 'image/png' && type != 'image/jpeg') continue;
+/// One paste triggers an image read immediately followed (when there's no
+/// image) by a text read. Browsers gate `navigator.clipboard.read()` on a
+/// user gesture, and a second gesture-less read within the same paste can be
+/// rejected, so we read the clipboard **once** and let the text reader reuse
+/// that result. The image reader always runs first and refreshes this, so the
+/// text reader never sees a stale payload.
+({Uint8List? image, String? text})? _pending;
+
+Future<({Uint8List? image, String? text})> _readClipboard() async {
+  final items = (await web.window.navigator.clipboard.read().toDart).toDart;
+  Uint8List? image;
+  String? text;
+  for (final item in items) {
+    for (final jsType in item.types.toDart) {
+      final type = jsType.toDart;
+      if (image == null && (type == 'image/png' || type == 'image/jpeg')) {
         final blob = await item.getType(type).toDart;
         final buffer = await blob.arrayBuffer().toDart;
-        return Uint8List.fromList(buffer.toDart.asUint8List());
+        image = Uint8List.fromList(buffer.toDart.asUint8List());
+      } else if (text == null && type == 'text/plain') {
+        final blob = await item.getType(type).toDart;
+        text = (await blob.text().toDart).toDart;
       }
     }
+  }
+  return (image: image, text: text);
+}
+
+/// Reads a PNG/JPEG image from the browser clipboard. Browsers require a
+/// secure context and a user-initiated paste gesture; denied access or a
+/// clipboard without an image returns null. Any text found alongside is
+/// stashed for a following [readTextFromClipboard] so the pair costs a single
+/// clipboard read.
+Future<Uint8List?> readImageFromClipboard() async {
+  try {
+    final read = await _readClipboard();
+    _pending = read;
+    return read.image;
+  } catch (_) {
+    _pending = null;
+    return null;
+  }
+}
+
+/// Reads plain text from the browser clipboard. Reuses the payload from a
+/// preceding [readImageFromClipboard] (same paste) when available so the two
+/// share one gesture-gated read; otherwise reads directly. Flutter's own
+/// `Clipboard.getData` is unreliable on the web, which is why the editor uses
+/// this instead.
+Future<String?> readTextFromClipboard() async {
+  final pending = _pending;
+  if (pending != null) {
+    _pending = null;
+    return pending.text;
+  }
+  try {
+    return (await _readClipboard()).text;
   } catch (_) {
     return null;
   }
-  return null;
 }

--- a/app/test/snapshot_clipboard_test.dart
+++ b/app/test/snapshot_clipboard_test.dart
@@ -156,6 +156,26 @@ void main() {
     expect(read, image);
   });
 
+  testWidgets('the default text reader reads Flutter\'s clipboard on native',
+      (tester) async {
+    var calls = 0;
+    tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      if (call.method == 'Clipboard.getData') {
+        calls++;
+        return const <String, Object?>{'text': 'Native clipboard text'};
+      }
+      return null;
+    });
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    final read = await readTextFromClipboard();
+
+    expect(calls, 1);
+    expect(read, 'Native clipboard text');
+  });
+
   group('Snapshot tool through the viewer', () {
     const scale = 800 / 612;
     Offset view(double x, double y) => Offset(x * scale, (792 - y) * scale);

--- a/doc/dev-log/2026-07-22-web-paste-text-fix.md
+++ b/doc/dev-log/2026-07-22-web-paste-text-fix.md
@@ -1,0 +1,65 @@
+# Paste on web — fix text paste (⌘V/Ctrl+V did nothing in the browser)
+
+## Symptom
+
+In the browser, ⌘V/Ctrl+V with something on the system clipboard (a copied
+line of text, most commonly) pasted nothing — even after the browser's
+clipboard-read permission prompt was accepted. Desktop pasted fine.
+
+## Cause
+
+`_pasteSystemClipboard` (`pdf_viewer.dart`) tries an image paste first, then
+falls back to text via **Flutter's `Clipboard.getData(kTextPlain)`**. Two
+problems compound on the web:
+
+1. `Clipboard.getData` is unreliable on Flutter web — it does not read text
+   back the way the platform-channel path does off-web.
+2. Even where a browser read would work, the fallback is a **second**
+   gesture-gated clipboard read: the image path already awaited
+   `navigator.clipboard.read()` (which is what raises the permission prompt),
+   and by the time the text read runs the transient user activation from the
+   Ctrl+V keystroke is gone, so the browser rejects it.
+
+So: image on the clipboard → pasted (single read, works). Text on the
+clipboard → image read finds nothing, text read fails → nothing happens. The
+permission prompt the user saw and accepted was the image read; the failure
+was the silent text fallback.
+
+## Fix
+
+Bypass Flutter's web clipboard for text the same way `copyPngToClipboard`
+already bypasses it for images (see `2026-06-23-snapshot-clipboard-web-fix.md`),
+and read the clipboard **once** per paste so there is no second gesture-gated
+call.
+
+- New seam `PdfViewer.systemTextPasteProvider`
+  (`PdfSystemTextPasteProvider`, in `text_prompt.dart`), threaded through
+  `PdfEditorView`. `_pasteSystemClipboardText` uses it in preference to
+  `Clipboard.getData` when set; unset keeps the old Flutter-clipboard path
+  (native still works through it, and existing tests are unchanged).
+- App wires it (`editor_screen.dart`) via a conditional-import
+  `readTextFromClipboard`, behind a `textClipboardReader` test seam mirroring
+  `imageClipboardReader`:
+  - `image_clipboard_io.dart` — native: delegates to `Clipboard.getData`.
+  - `image_clipboard_web.dart` — web: `navigator.clipboard.read()` through
+    `package:web`, extracting `text/plain` (`Blob.text()`).
+- **Single read shared across the pair.** A paste calls the image reader then
+  the text reader. On web `readImageFromClipboard` now does one
+  `navigator.clipboard.read()`, extracts both image (png/jpeg) and text, and
+  stashes the result; `readTextFromClipboard` consumes that stash instead of
+  reading again. The image reader always runs first and overwrites the stash,
+  so the text reader never sees a stale payload; a lone text read (no image
+  provider) reads directly.
+
+## Verified
+
+- `fvm dart analyze packages/dart_pdf_editor app` clean.
+- `fvm flutter build web` compiles, **incl. the Wasm dry run**, so the
+  `Blob.text()` js_interop path is valid for JS and WASM.
+- `editing_clipboard_test.dart`: text provider preferred over the platform
+  channel (channel never touched), and the no-image → text fallthrough (the
+  web case) pastes a FreeText box. `snapshot_clipboard_test.dart`: the default
+  native text reader reads Flutter's clipboard.
+
+The browser still needs a secure context and the clipboard-read permission; a
+denied read surfaces as null (silent no-op), unchanged.

--- a/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/text_prompt.dart
@@ -21,6 +21,14 @@ typedef PdfImagePicker = Future<Uint8List?> Function(BuildContext context);
 typedef PdfSystemImagePasteProvider = Future<Uint8List?> Function(
     BuildContext context);
 
+/// Supplies plain text for a system clipboard paste, used in preference to
+/// Flutter's [Clipboard] when set. Return null when the clipboard carries no
+/// text. Exists mainly for the web, where Flutter's `Clipboard.getData` is
+/// unreliable: the host injects a reader built on the browser Async Clipboard
+/// API so ⌘V/Ctrl+V can paste text into a [PdfEditTool.freeText] box.
+typedef PdfSystemTextPasteProvider = Future<String?> Function(
+    BuildContext context);
+
 /// A selected page-content image exported by the Content tool.
 class PdfSelectedContentImage {
   const PdfSelectedContentImage({

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -228,6 +228,7 @@ class PdfEditorView extends StatefulWidget {
     this.formImagePicker,
     this.imagePicker,
     this.systemImagePasteProvider,
+    this.systemTextPasteProvider,
     this.onExportSelectedContentImage,
     this.onExportCustomStamps,
     this.onImportCustomStamps,
@@ -304,6 +305,7 @@ class PdfEditorView extends StatefulWidget {
     this.formImagePicker,
     this.imagePicker,
     this.systemImagePasteProvider,
+    this.systemTextPasteProvider,
     this.onExportSelectedContentImage,
     this.onExportCustomStamps,
     this.onImportCustomStamps,
@@ -454,6 +456,9 @@ class PdfEditorView extends StatefulWidget {
 
   /// See [PdfViewer.systemImagePasteProvider].
   final PdfSystemImagePasteProvider? systemImagePasteProvider;
+
+  /// See [PdfViewer.systemTextPasteProvider].
+  final PdfSystemTextPasteProvider? systemTextPasteProvider;
 
   /// See [PdfEditingToolbar.onExportSelectedContentImage].
   final PdfSelectedContentImageHandler? onExportSelectedContentImage;
@@ -699,6 +704,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         formImagePicker: widget.formImagePicker,
         imagePicker: widget.imagePicker,
         systemImagePasteProvider: widget.systemImagePasteProvider,
+        systemTextPasteProvider: widget.systemTextPasteProvider,
         onExportSelectedContentImage: widget.onExportSelectedContentImage,
         onExportCustomStamps: widget.onExportCustomStamps,
         onImportCustomStamps: widget.onImportCustomStamps,
@@ -1335,6 +1341,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         imagePicker: widget.imagePicker,
                         systemImagePasteProvider:
                             widget.systemImagePasteProvider,
+                        systemTextPasteProvider:
+                            widget.systemTextPasteProvider,
                         onSnapshot: widget.onSnapshot,
                         onPlaceSignature: widget.onPlaceSignature,
                         editingTextPrompt: widget.textPrompt,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -829,6 +829,7 @@ class PdfViewer extends StatefulWidget {
     this.fontPicker,
     this.imagePicker,
     this.systemImagePasteProvider,
+    this.systemTextPasteProvider,
     this.onSnapshot,
     this.onPlaceSignature,
     this.pageSpacing = 12,
@@ -1060,6 +1061,12 @@ class PdfViewer extends StatefulWidget {
   /// no pointer location is known. When null or when it returns null, paste
   /// falls back to plain text from Flutter's system clipboard.
   final PdfSystemImagePasteProvider? systemImagePasteProvider;
+
+  /// Supplies plain text for ⌘V/Ctrl+V when neither the in-app clipboard nor
+  /// [systemImagePasteProvider] produced content. Used in preference to
+  /// Flutter's [Clipboard], which is unreliable on the web. When null, paste
+  /// reads text from [Clipboard] as before.
+  final PdfSystemTextPasteProvider? systemTextPasteProvider;
 
   /// Receives a region captured by the snapshot tool
   /// ([PdfEditTool.snapshot]) - typically to copy it to the clipboard,
@@ -3864,8 +3871,21 @@ class _PdfViewerState extends State<PdfViewer>
   }
 
   Future<void> _pasteSystemClipboardText(PdfEditingController editing) async {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    final text = data?.text;
+    // Prefer the host's reader (the web build wires one over the browser Async
+    // Clipboard API, since Flutter's Clipboard.getData is unreliable there);
+    // fall back to Flutter's clipboard when none is injected.
+    String? text;
+    final provider = widget.systemTextPasteProvider;
+    if (provider != null) {
+      try {
+        text = await provider(context);
+      } catch (_) {
+        text = null;
+      }
+    } else {
+      final data = await Clipboard.getData(Clipboard.kTextPlain);
+      text = data?.text;
+    }
     if (text == null || text.trim().isEmpty) return;
     if (!mounted || widget.editing != editing) return;
     final local = _lastPointerLocal;

--- a/packages/dart_pdf_editor/test/editing_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_clipboard_test.dart
@@ -238,7 +238,8 @@ void main() {
         WidgetTester tester,
         {int pages = 2,
         bool toolbar = false,
-        PdfSystemImagePasteProvider? systemImagePasteProvider}) async {
+        PdfSystemImagePasteProvider? systemImagePasteProvider,
+        PdfSystemTextPasteProvider? systemTextPasteProvider}) async {
       final editing = PdfEditingController(buildMultiPagePdf(pages));
       final viewer = PdfViewerController();
       addTearDown(editing.dispose);
@@ -253,6 +254,7 @@ void main() {
               controller: viewer,
               editing: editing,
               systemImagePasteProvider: systemImagePasteProvider,
+              systemTextPasteProvider: systemTextPasteProvider,
             ),
           ),
           bottomNavigationBar: toolbar
@@ -359,6 +361,78 @@ void main() {
       expect(annotation.contents, 'Pasted note');
       expect(annotation.rect, const PdfRect(290, 384.6, 510, 415.4));
       expect(editing.selectedAnnotationSlots, [(0, 0)]);
+      await settle(tester);
+    });
+
+    testWidgets(
+        'Ctrl+V prefers systemTextPasteProvider over Flutter Clipboard',
+        (tester) async {
+      // Flutter's Clipboard.getData is unreliable on the web; the host injects
+      // a provider (browser Async Clipboard API). It must win over the
+      // platform channel and never fall through to it.
+      var channelReads = 0;
+      tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.getData') {
+          channelReads++;
+          return const <String, Object?>{'text': 'From Flutter clipboard'};
+        }
+        return null;
+      });
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      var textReads = 0;
+      final (editing, _) = await pumpEditor(
+        tester,
+        systemTextPasteProvider: (context) async {
+          textReads++;
+          return 'From host provider';
+        },
+      );
+      await tester.tapAt(view(400, 400), kind: PointerDeviceKind.mouse);
+      await tester.pump();
+
+      await sendCtrl(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+
+      expect(textReads, 1);
+      expect(channelReads, 0);
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.subtype, 'FreeText');
+      expect(annotation.contents, 'From host provider');
+      await settle(tester);
+    });
+
+    testWidgets(
+        'Ctrl+V falls back to systemTextPasteProvider when no image is present',
+        (tester) async {
+      // The web paste path: the image read finds nothing, so paste must
+      // consult the text provider (rather than giving up).
+      var imageReads = 0;
+      var textReads = 0;
+      final (editing, _) = await pumpEditor(
+        tester,
+        systemImagePasteProvider: (context) async {
+          imageReads++;
+          return null;
+        },
+        systemTextPasteProvider: (context) async {
+          textReads++;
+          return 'Fallback note';
+        },
+      );
+      await tester.tapAt(view(400, 400), kind: PointerDeviceKind.mouse);
+      await tester.pump();
+
+      await sendCtrl(tester, LogicalKeyboardKey.keyV);
+      await tester.pump();
+
+      expect(imageReads, 1);
+      expect(textReads, 1);
+      final annotation = editing.document.page(0).annotations.single;
+      expect(annotation.subtype, 'FreeText');
+      expect(annotation.contents, 'Fallback note');
       await settle(tester);
     });
 


### PR DESCRIPTION
## Summary

On the web, ⌘V/Ctrl+V did nothing when the system clipboard held text (the common paste), even after the browser's clipboard-read permission prompt was accepted. Desktop pasted fine.

Two things compound on web:
1. The text fallback used Flutter's `Clipboard.getData(kTextPlain)`, which is unreliable in the browser.
2. It was a **second** gesture-gated clipboard read — the image path already awaited `navigator.clipboard.read()` (the call that raises the permission prompt), so by the time the text read ran the Ctrl+V transient user activation was spent and the browser rejected it. So image-on-clipboard pasted (single read) but text-on-clipboard silently did nothing.

The fix mirrors the existing web copy fix (`copyPngToClipboard`): bypass Flutter's web clipboard for text and read the clipboard **once** per paste.

- New `PdfViewer.systemTextPasteProvider` seam (`PdfSystemTextPasteProvider`), threaded through `PdfEditorView`. `_pasteSystemClipboardText` prefers it over `Clipboard.getData` when set; unset keeps the old path (native is unchanged).
- The app wires it via a conditional-import `readTextFromClipboard` (behind a `textClipboardReader` test seam mirroring `imageClipboardReader`): native delegates to `Clipboard.getData`; web reads through the Async Clipboard API (`package:web`).
- **Single shared read:** on web `readImageFromClipboard` now does one `navigator.clipboard.read()`, extracts both image (png/jpeg) and `text/plain`, and stashes the result; `readTextFromClipboard` consumes the stash instead of reading again, so the image+text pair costs a single gesture-gated read. The image reader always runs first and refreshes the stash, so the text reader never sees a stale payload.

The browser still needs a secure context + clipboard-read permission; a denied read stays a silent no-op.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran `editing_clipboard_test.dart`)
- [x] Example app smoke test (`fvm flutter build web`, incl. the Wasm dry run — validates the `Blob.text()` js_interop path for JS and WASM)

Ran the touched suites rather than every package: `editing_clipboard_test.dart` (text provider preferred over the platform channel; the no-image → text fallthrough that is the web case) and `app/test/snapshot_clipboard_test.dart` (default native text reader).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor` (the web interop lives in `/app`).
- [x] No `dart:io` imports in any `lib/` directory (web reader uses `dart:js_interop` + `package:web`).
- [x] Layering is preserved.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

- Web-only behavior change; native falls through the unchanged `Clipboard.getData` path.
- Dev-log: `doc/dev-log/2026-07-22-web-paste-text-fix.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFDguVjRoW9B6Vu9Vrohc3)_