### PR TITLE
perf(editor): global live-raster memory budget (#405)

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -59,6 +59,12 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
         192 << 20,
       _ => 384 << 20,
     };
+    // Cross-page ceiling over the base rasters, detail patches, and retained-
+    // scene images the live pages in the scroll cacheExtent hold at once - the
+    // additive-per-page memory #405 measured. Farther-from-viewport pages are
+    // reclaimed first when the sum exceeds this; the on-screen page and its
+    // neighbours always fit.
+    PdfLiveRasterBudget.instance.maxBytes = pdfDefaultLiveRasterBudgetBytes();
     // Persisted devtools options (deep-zoom mode, overlays, worker count)
     // override the defaults above once loaded.
     if (kDevToolsEnabled) unawaited(AppDevTools.instance.restoreOptions());

--- a/doc/dev-log/2026-07-22-live-raster-budget-405.md
+++ b/doc/dev-log/2026-07-22-live-raster-budget-405.md
@@ -1,0 +1,50 @@
+# 2026-07-22 — global live-raster memory budget (#405)
+
+Per-page raster caps were additive with no cross-page accounting: each live page
+in the scroll cacheExtent could simultaneously hold a base raster (up to
+`_maxPixels` = 16.7 Mpx ≈ 64 MB RGBA), a deep-zoom detail patch, and a retained
+scene's decoded images. With 3–5 pages live that is several hundred MB of GPU
+memory with nothing bounding the sum — the memory-pressure / jetsam shape #405
+(and the 2 GB RSS traces) describe on large-format documents.
+
+## Change
+
+A process-wide `PdfLiveRasterBudget` (`live_raster_budget.dart`) that every live
+page registers with, and that reclaims the farthest-from-viewport pages' rasters
+whenever the total exceeds `maxBytes`:
+
+- `PdfLiveRasterHolder` is a plain (`dart:ui`-free) interface — `liveRasterBytes`,
+  `liveRasterDistance` (0 = viewport), `evictLiveRaster()` — so the accounting and
+  eviction order are unit-tested against fakes with no Flutter binding.
+- `_PdfPageViewState implements PdfLiveRasterHolder`: bytes = base `_image` +
+  detail `_detailImage` + the retained scene's decoded images (new
+  `PdfRetainedScene.decodedImageBytes`, part 3 of the ticket); distance =
+  `widget.focusDistance` (the signal added for #451); evict drops the base
+  raster, detail patch, and scene (keeping the soft preview up) so the page
+  re-rasterises when scrolled back near the viewport.
+- `rebalance()` runs post-frame after a base raster lands (`_scheduleBudgetRebalance`,
+  debounced once per frame). It evicts farthest-first, **never the focused page**,
+  and **stops the moment the total fits** — so it is a reclaim budget, not a
+  reservation, and the near-viewport working set is never touched.
+- Memory pressure: `didHaveMemoryPressure` now calls `evictReclaimable()`, which
+  surrenders every off-viewport page's rasters. Live-page rasters used to be
+  exempt from the pressure signal that already trims the byte-budgeted caches —
+  the ticket's specific gap.
+- Platform default `pdfDefaultLiveRasterBudgetBytes()` (desktop 384 MB, mobile
+  192 MB, low-RAM web 128 MB), set at app boot next to the cache-registry ceiling.
+
+## Testing
+
+- `live_raster_budget_test.dart` — 9 unit tests over the eviction contract:
+  farthest-first, stops-when-it-fits, never-the-focused-page, keeps-evicting-outward,
+  distance-tie-breaks-by-size, disabled at `maxBytes <= 0`, and the pressure path.
+- Full `dart_pdf_editor` Flutter suite green (the eviction runs setState on
+  off-viewport page states; the render lifecycle re-rasterises them on scroll-back
+  exactly like a cache miss). `dart analyze` clean (package + app).
+
+## Not done (deliberately)
+
+- Part 2 (lower `_maxPixels` toward viewport² × maxUsefulZoom): a separate
+  per-page-cap tweak with detail-patch-engagement trade-offs of its own; left out
+  to keep this change to the cross-page budget, which is the headline fix. The
+  budget already bounds the sum regardless of the per-page cap.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -66,6 +66,7 @@ export 'src/page_range_dialog.dart';
 export 'src/pdf_editor_view.dart';
 export 'src/pdf_page_view.dart';
 export 'src/pdf_reader.dart';
+export 'src/live_raster_budget.dart';
 export 'src/pdf_reflow_view.dart';
 export 'src/pdf_viewer.dart';
 export 'src/performance_policy.dart';

--- a/packages/dart_pdf_editor/lib/src/live_raster_budget.dart
+++ b/packages/dart_pdf_editor/lib/src/live_raster_budget.dart
@@ -1,0 +1,120 @@
+/// A live page whose GPU/decoded raster memory is counted against the global
+/// [PdfLiveRasterBudget]. Implemented by the page view's state.
+///
+/// Kept `dart:ui`-free (a plain interface) so the budget's accounting and
+/// eviction order are unit-testable against fakes without a Flutter binding.
+abstract class PdfLiveRasterHolder {
+  /// Approximate bytes of raster/decoded-image memory this live page holds
+  /// right now (base raster + detail patch + retained-scene decoded images).
+  /// 0 while the page holds nothing rasterised.
+  int get liveRasterBytes;
+
+  /// Distance in pages from the focused page (0 = the page under the viewport).
+  /// Farthest-from-viewport pages are evicted first, and the focused page
+  /// (distance 0) is never evicted.
+  int get liveRasterDistance;
+
+  /// Drops this page's base + detail rasters (and retained scene) to free
+  /// memory. The page keeps its low-res preview up and re-rasterises when it is
+  /// next scrolled back into (or near) the viewport. Called only on a holder
+  /// with [liveRasterDistance] > 0.
+  void evictLiveRaster();
+}
+
+/// Process-wide budget over the rasters live page views hold simultaneously.
+///
+/// Per-page raster caps are additive: with several pages live in the scroll
+/// cacheExtent, each holding a base raster, a detail patch, and a retained
+/// scene's decoded images, the sum reaches several hundred MB of GPU memory
+/// with no cross-page accounting - the memory-pressure / jetsam shape #405
+/// describes on large-format documents. This registers every live page and,
+/// whenever the total exceeds [maxBytes], evicts the farthest-from-viewport
+/// pages' rasters until it fits, never touching the focused page.
+///
+/// It is a *reclaim* budget, not a reservation: pages rasterise freely and this
+/// trims afterward, so a momentary overshoot is fine and the near-viewport
+/// working set is never evicted (eviction is farthest-first and stops the
+/// moment the total fits).
+class PdfLiveRasterBudget {
+  PdfLiveRasterBudget._();
+
+  /// The shared instance every live page view registers with.
+  static final PdfLiveRasterBudget instance = PdfLiveRasterBudget._();
+
+  /// Total live-raster bytes allowed before eviction kicks in. Set once at
+  /// startup, sized to the platform (see `pdfDefaultLiveRasterBudgetBytes`).
+  /// 0 or negative disables the budget (no eviction).
+  int maxBytes = 256 << 20;
+
+  final _holders = <PdfLiveRasterHolder>{};
+
+  /// Registers a live page (its state's initState). Idempotent.
+  void register(PdfLiveRasterHolder holder) => _holders.add(holder);
+
+  /// Unregisters a live page (its state's dispose). Idempotent.
+  void unregister(PdfLiveRasterHolder holder) => _holders.remove(holder);
+
+  /// Number of registered live pages - test/diagnostic hook.
+  int get holderCount => _holders.length;
+
+  /// Total live-raster bytes across every registered page right now.
+  int get totalBytes {
+    var total = 0;
+    for (final holder in _holders) {
+      total += holder.liveRasterBytes;
+    }
+    return total;
+  }
+
+  /// Evicts farthest-from-viewport pages' rasters until [totalBytes] is within
+  /// [maxBytes]. Call after a page's raster grows (a base raster or detail
+  /// patch lands). Never evicts the focused page (distance 0); stops as soon as
+  /// the total fits, so the near-viewport working set is preserved.
+  ///
+  /// Returns the bytes freed (0 when already within budget).
+  int rebalance() {
+    if (maxBytes <= 0) return 0;
+    var total = totalBytes;
+    if (total <= maxBytes) return 0;
+
+    // Farthest first; on a tie the larger raster goes first (frees more per
+    // eviction). A stable order also makes the eviction sequence testable.
+    final ordered = _holders.toList()
+      ..sort((a, b) {
+        final byDistance =
+            b.liveRasterDistance.compareTo(a.liveRasterDistance);
+        return byDistance != 0
+            ? byDistance
+            : b.liveRasterBytes.compareTo(a.liveRasterBytes);
+      });
+
+    var freed = 0;
+    for (final holder in ordered) {
+      if (total <= maxBytes) break;
+      if (holder.liveRasterDistance <= 0) continue; // never the focused page
+      final bytes = holder.liveRasterBytes;
+      if (bytes <= 0) continue;
+      holder.evictLiveRaster();
+      total -= bytes;
+      freed += bytes;
+    }
+    return freed;
+  }
+
+  /// Surrenders every reclaimable (non-focused) page's raster regardless of the
+  /// budget - the memory-pressure path. Live-page rasters used to be exempt
+  /// from the pressure signal that trims the byte-budgeted caches (#405); this
+  /// hands the whole off-viewport working set back on a `didHaveMemoryPressure`.
+  /// Returns the bytes freed.
+  int evictReclaimable() {
+    var freed = 0;
+    for (final holder in _holders.toList()) {
+      if (holder.liveRasterDistance <= 0) continue;
+      final bytes = holder.liveRasterBytes;
+      if (bytes <= 0) continue;
+      holder.evictLiveRaster();
+      freed += bytes;
+    }
+    return freed;
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -14,6 +14,7 @@ import 'package:pdf_graphics/pdf_graphics.dart'
         PdfRenderCommand;
 
 import 'debug_overlays.dart';
+import 'live_raster_budget.dart';
 import 'perf_log.dart';
 import 'page_render_session.dart';
 import 'performance_policy.dart';
@@ -404,7 +405,8 @@ class PdfPageView extends StatefulWidget {
   State<PdfPageView> createState() => _PdfPageViewState();
 }
 
-class _PdfPageViewState extends State<PdfPageView> {
+class _PdfPageViewState extends State<PdfPageView>
+    implements PdfLiveRasterHolder {
   late final PdfPageRenderSession _renderSession;
   Future<ui.Picture>? _picture;
 
@@ -484,6 +486,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   void initState() {
     super.initState();
     PdfLivePageRegistry.instance.add(widget.previewIndex);
+    PdfLiveRasterBudget.instance.register(this);
     _renderSession = PdfPageRenderSession(_renderIntent(widget));
     widget.renderHold?.addListener(_onRenderHoldChanged);
     widget.previewCache?.addListener(_onPreviewCacheChanged);
@@ -681,6 +684,7 @@ class _PdfPageViewState extends State<PdfPageView> {
   @override
   void dispose() {
     PdfLivePageRegistry.instance.remove(widget.previewIndex);
+    PdfLiveRasterBudget.instance.unregister(this);
     PdfDebugDetailRegions.instance.report(widget.previewIndex, null);
     widget.renderHold?.removeListener(_onRenderHoldChanged);
     _liveTransformFor(widget)?.removeListener(_onLiveTransformChanged);
@@ -804,6 +808,54 @@ class _PdfPageViewState extends State<PdfPageView> {
 
   double _effectiveRatio() => _effectiveRatioAt(widget.scale);
 
+  // --- Live-raster budget (#405) --------------------------------------------
+
+  static int _imageBytes(ui.Image? image) =>
+      image == null ? 0 : image.width * image.height * 4;
+
+  @override
+  int get liveRasterBytes =>
+      _imageBytes(_image) +
+      _imageBytes(_detailImage) +
+      (_scene?.decodedImageBytes ?? 0);
+
+  @override
+  int get liveRasterDistance => widget.focusDistance;
+
+  @override
+  void evictLiveRaster() {
+    if (!mounted) return;
+    // Reclaim this off-viewport page's heavy rasters: the base raster, the
+    // deep-zoom detail patch, and the retained scene's decoded images. The soft
+    // preview (if any) stays up, and the page re-rasterises when it is next
+    // scrolled back near the viewport (_render re-runs because _image and
+    // _rasteredRatio are null). Never called on the focused page.
+    setState(() {
+      _image?.dispose();
+      _image = null;
+      _dropDetail();
+      _dropPicture(); // frees the scene + slug picture and nulls _rasteredRatio
+    });
+    PdfPerfLog.log(
+      'live-raster evict page=${widget.previewIndex} '
+      'dist=${widget.focusDistance}',
+    );
+  }
+
+  bool _budgetRebalanceScheduled = false;
+
+  /// Trims the global live-raster budget after this page's raster grew, once
+  /// per frame. Post-frame so evicting another page (its setState) never lands
+  /// mid-build of this one.
+  void _scheduleBudgetRebalance() {
+    if (_budgetRebalanceScheduled) return;
+    _budgetRebalanceScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _budgetRebalanceScheduled = false;
+      PdfLiveRasterBudget.instance.rebalance();
+    });
+  }
+
   /// The image-decode resolution this page's record should use: the display
   /// ratio (capped by [PdfPageView.workerImagePixelRatioCap]), reduced by
   /// [PdfPageView.prefetchImagePixelRatioFactor] when the page is an off-focus
@@ -903,6 +955,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       _preview?.dispose();
       _preview = null;
     });
+    _scheduleBudgetRebalance();
     PdfPerfLog.log(
       'full-raster cache hit page=${widget.previewIndex} '
       '${image.width}x${image.height}',
@@ -1330,6 +1383,7 @@ class _PdfPageViewState extends State<PdfPageView> {
       _preview?.dispose();
       _preview = null;
     });
+    _scheduleBudgetRebalance();
     PdfPerfLog.log('vector-first page=$pageIndex${PdfPerfLog.rssSuffix()}');
     // This path rasterized a full-page vector preview instead of arming a
     // region detail, so there is nothing for the caller to wait on.
@@ -1665,6 +1719,7 @@ class _PdfPageViewState extends State<PdfPageView> {
         _preview?.dispose();
         _preview = null;
       });
+      _scheduleBudgetRebalance();
       if (_renderedAtFullImageRatio()) {
         cache?.putFullImage(
           widget.previewIndex,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import 'annotation_tap.dart';
 import 'debug_overlays.dart';
+import 'live_raster_budget.dart';
 import 'editing/editing_controller.dart';
 import 'editing/editing_fonts.dart';
 import 'editing/editing_form_layer.dart';
@@ -1631,9 +1632,13 @@ class _PdfViewerState extends State<PdfViewer>
     // banded transcripts): dropped indices rebuild identically, evicted strips
     // re-materialize on demand, so this is free of any visual regression.
     final scenes = PdfRetainedScene.handleMemoryPressure();
+    // Live-page rasters were exempt from the pressure signal (#405): surrender
+    // every off-viewport page's base raster + detail patch + retained scene now.
+    final liveFreed = PdfLiveRasterBudget.instance.evictReclaimable();
     PdfPerfLog.log('memory-pressure cleared ${freed >> 20}MB across '
         '${PdfCacheRegistry.instance.registrationCount} caches, '
-        'shed spatial metadata on $scenes scene(s)'
+        'shed spatial metadata on $scenes scene(s), '
+        'freed ${liveFreed >> 20}MB of live rasters'
         '${PdfPerfLog.rssSuffix()}');
     _previews.clear();
   }

--- a/packages/dart_pdf_editor/lib/src/performance_policy.dart
+++ b/packages/dart_pdf_editor/lib/src/performance_policy.dart
@@ -102,6 +102,30 @@ int pdfDefaultImageCacheBytes({
   };
 }
 
+/// Platform-aware default for [PdfLiveRasterBudget.maxBytes]: the ceiling over
+/// the base rasters, detail patches, and retained-scene images the live pages
+/// in the scroll cacheExtent hold at once (#405).
+///
+/// Sized so the on-screen page plus its immediate neighbours always fit (they
+/// are never evicted), and only farther cache-window pages are reclaimed under
+/// pressure. Larger than the decoded-image cache because a single large-format
+/// base raster can be tens of MB and a few must coexist for smooth scrolling;
+/// smaller on memory-constrained mobile/web where jetsam bites first.
+int pdfDefaultLiveRasterBudgetBytes({
+  PdfPerformancePlatform? platform,
+  double? deviceMemoryGb,
+}) {
+  const mb = 1024 * 1024;
+  final family = platform ?? detectedPdfPerformancePlatform;
+  final ram = deviceMemoryGb ?? detectedPdfDeviceMemoryGb;
+  return switch (family) {
+    PdfPerformancePlatform.desktop => 384 * mb,
+    PdfPerformancePlatform.mobile => 192 * mb,
+    PdfPerformancePlatform.web => ram != null && ram <= 2 ? 128 * mb : 192 * mb,
+    PdfPerformancePlatform.other => 192 * mb,
+  };
+}
+
 /// The current auto-policy posture. Exposed in diagnostics and tests.
 enum PdfPerformanceTier { conservative, balanced, throughput }
 

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -198,6 +198,17 @@ class PdfRetainedScene {
   /// on the legacy full-page raster to avoid per-tile full-transcript replays.
   bool get supportsRegionRaster => _ensureRegionIndex().supported;
 
+  /// Approximate bytes of the decoded images this scene retains for replay
+  /// (RGBA, width*height*4). Counted against the live-raster budget (#405): a
+  /// dense sheet's underlays keep tens of MB of pixels resident per live page.
+  int get decodedImageBytes {
+    var total = 0;
+    for (final image in _images.values) {
+      total += image.width * image.height * 4;
+    }
+    return total;
+  }
+
   int get debugRegionReplayUnitCount => _ensureRegionIndex().units.length;
   int get debugRegionReplayEstimatedBytes =>
       _ensureRegionIndex().estimatedBytes;

--- a/packages/dart_pdf_editor/test/live_raster_budget_test.dart
+++ b/packages/dart_pdf_editor/test/live_raster_budget_test.dart
@@ -1,0 +1,151 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A fake live page: fixed bytes + distance, records whether it was evicted.
+class _FakeHolder implements PdfLiveRasterHolder {
+  _FakeHolder(this.label, {required int bytes, required this.distance})
+      : _bytes = bytes;
+
+  final String label;
+  int _bytes;
+  final int distance;
+  bool evicted = false;
+
+  @override
+  int get liveRasterBytes => _bytes;
+
+  @override
+  int get liveRasterDistance => distance;
+
+  @override
+  void evictLiveRaster() {
+    evicted = true;
+    _bytes = 0; // a real holder drops its rasters; mirror that for totalBytes
+  }
+}
+
+void main() {
+  final budget = PdfLiveRasterBudget.instance;
+  final registered = <PdfLiveRasterHolder>[];
+
+  void add(PdfLiveRasterHolder h) {
+    budget.register(h);
+    registered.add(h);
+  }
+
+  setUp(() {
+    // The singleton persists across tests; clear any registrations first.
+    for (final h in List.of(registered)) {
+      budget.unregister(h);
+    }
+    registered.clear();
+    budget.maxBytes = 256 << 20;
+  });
+
+  group('PdfLiveRasterBudget', () {
+    test('totalBytes sums every registered holder', () {
+      add(_FakeHolder('a', bytes: 10, distance: 0));
+      add(_FakeHolder('b', bytes: 25, distance: 1));
+      expect(budget.totalBytes, 35);
+      expect(budget.holderCount, 2);
+    });
+
+    test('rebalance is a no-op within budget', () {
+      budget.maxBytes = 100;
+      final a = _FakeHolder('a', bytes: 40, distance: 2);
+      add(a);
+      expect(budget.rebalance(), 0);
+      expect(a.evicted, isFalse);
+    });
+
+    test('evicts farthest-from-viewport first, and stops once it fits', () {
+      budget.maxBytes = 100;
+      final focus = _FakeHolder('focus', bytes: 60, distance: 0);
+      final near = _FakeHolder('near', bytes: 40, distance: 1);
+      final far = _FakeHolder('far', bytes: 50, distance: 3);
+      add(focus);
+      add(near);
+      add(far); // total 150 > 100
+      final freed = budget.rebalance();
+      // Dropping `far` (50) brings 150 -> 100, which fits: `near` is kept.
+      expect(freed, 50);
+      expect(far.evicted, isTrue);
+      expect(near.evicted, isFalse);
+      expect(focus.evicted, isFalse);
+      expect(budget.totalBytes, 100);
+    });
+
+    test('never evicts the focused page even when alone over budget', () {
+      budget.maxBytes = 10;
+      final focus = _FakeHolder('focus', bytes: 500, distance: 0);
+      add(focus);
+      expect(budget.rebalance(), 0);
+      expect(focus.evicted, isFalse);
+    });
+
+    test('keeps evicting outward until it fits', () {
+      budget.maxBytes = 50;
+      final focus = _FakeHolder('focus', bytes: 30, distance: 0);
+      final d1 = _FakeHolder('d1', bytes: 30, distance: 1);
+      final d2 = _FakeHolder('d2', bytes: 30, distance: 2);
+      final d3 = _FakeHolder('d3', bytes: 30, distance: 3);
+      add(focus);
+      add(d1);
+      add(d2);
+      add(d3); // total 120, budget 50 -> must drop d3 and d2 (down to 60?) then d1
+      budget.rebalance();
+      // 120 -> drop d3 (90) -> drop d2 (60) -> drop d1 (30) -> fits (<=50).
+      expect(d3.evicted, isTrue);
+      expect(d2.evicted, isTrue);
+      expect(d1.evicted, isTrue);
+      expect(focus.evicted, isFalse);
+      expect(budget.totalBytes, 30);
+    });
+
+    test('on a distance tie the larger raster is evicted first', () {
+      budget.maxBytes = 100;
+      final small = _FakeHolder('small', bytes: 20, distance: 2);
+      final big = _FakeHolder('big', bytes: 90, distance: 2);
+      final focus = _FakeHolder('focus', bytes: 40, distance: 0);
+      add(focus);
+      add(small);
+      add(big); // total 150 > 100
+      budget.rebalance();
+      // Evicting `big` (90) alone brings 150 -> 60, which fits: `small` kept.
+      expect(big.evicted, isTrue);
+      expect(small.evicted, isFalse);
+    });
+
+    test('maxBytes <= 0 disables eviction', () {
+      budget.maxBytes = 0;
+      final far = _FakeHolder('far', bytes: 999, distance: 9);
+      add(far);
+      expect(budget.rebalance(), 0);
+      expect(far.evicted, isFalse);
+    });
+
+    test('evictReclaimable sheds every non-focused page (pressure path)', () {
+      budget.maxBytes = 1 << 30; // well within budget - pressure ignores it
+      final focus = _FakeHolder('focus', bytes: 100, distance: 0);
+      final n1 = _FakeHolder('n1', bytes: 100, distance: 1);
+      final n2 = _FakeHolder('n2', bytes: 100, distance: 2);
+      add(focus);
+      add(n1);
+      add(n2);
+      final freed = budget.evictReclaimable();
+      expect(freed, 200);
+      expect(focus.evicted, isFalse);
+      expect(n1.evicted, isTrue);
+      expect(n2.evicted, isTrue);
+    });
+
+    test('unregister removes a holder from accounting', () {
+      final a = _FakeHolder('a', bytes: 50, distance: 1);
+      add(a);
+      expect(budget.totalBytes, 50);
+      budget.unregister(a);
+      registered.remove(a);
+      expect(budget.totalBytes, 0);
+    });
+  });
+}


### PR DESCRIPTION
Closes **#405**.

## Problem

Per-page raster caps were additive with no cross-page accounting: each live page in the scroll cacheExtent could simultaneously hold a base raster (up to `_maxPixels` = 16.7 Mpx ≈ 64 MB RGBA), a deep-zoom detail patch, and a retained scene's decoded images. With 3–5 pages live that is **several hundred MB of GPU memory with nothing bounding the sum** — the memory-pressure / jetsam shape #405 (and the ~2 GB RSS traces) describe on large-format documents.

## Change

A process-wide `PdfLiveRasterBudget` (`live_raster_budget.dart`) that every live page registers with, reclaiming the farthest-from-viewport pages' rasters when the total exceeds `maxBytes`:

- **`PdfLiveRasterHolder`** — a plain (`dart:ui`-free) interface: `liveRasterBytes`, `liveRasterDistance` (0 = viewport), `evictLiveRaster()`. So the accounting and eviction order **unit-test against fakes** with no Flutter binding.
- **`_PdfPageViewState implements PdfLiveRasterHolder`**: bytes = base `_image` + detail `_detailImage` + retained-scene decoded images (new `PdfRetainedScene.decodedImageBytes`, **part 3** of the ticket); distance = `widget.focusDistance` (the signal added for #451); evict drops the base raster, detail patch, and scene (keeping the soft preview up) so the page re-rasterises on scroll-back.
- **`rebalance()`** runs post-frame after a base raster lands (debounced once per frame). Evicts farthest-first, **never the focused page**, and **stops the moment the total fits** — a *reclaim* budget, not a reservation, so the near-viewport working set is never touched.
- **Memory pressure**: `didHaveMemoryPressure` now calls `evictReclaimable()`, surrendering every off-viewport page's rasters. Live-page rasters used to be **exempt** from the pressure signal that already trims the byte-budgeted caches — the ticket's specific gap.
- **Platform default** `pdfDefaultLiveRasterBudgetBytes()` (desktop 384 MB, mobile 192 MB, low-RAM web 128 MB), set at app boot next to the cache-registry ceiling.

## Testing

- **`live_raster_budget_test.dart`** — 9 unit tests over the eviction contract: farthest-first, stops-when-it-fits, never-the-focused-page, keeps-evicting-outward, distance-tie-breaks-by-size, disabled at `maxBytes <= 0`, and the pressure path.
- Full `dart_pdf_editor` Flutter suite green (1822 passed; GWG030 is the pre-existing Ghent spot/overprint failure). The eviction runs `setState` on off-viewport page states; the render lifecycle re-rasterises them on scroll-back exactly like a cache miss. `dart analyze` clean (package + app).

**In practice, eviction only touches fully-off-screen pages**: the budget is sized so the focused page + immediate neighbours fit, and farthest-first order reclaims distance ≥ 2 pages first — partially-visible peeks aren't blanked.

## Not in scope

Part 2 (lower `_maxPixels` toward viewport² × maxUsefulZoom) is a separate per-page-cap tweak with its own detail-patch-engagement trade-offs; the budget already bounds the sum regardless of the per-page cap.

Dev-log: `doc/dev-log/2026-07-22-live-raster-budget-405.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)