### PR TITLE
perf(editor): memoize per-build search/selection rescans (#403 part 3)

### DIFF
--- a/doc/dev-log/2026-07-22-pointer-event-costs-403.md
+++ b/doc/dev-log/2026-07-22-pointer-event-costs-403.md
@@ -1,0 +1,41 @@
+# 2026-07-22 — pointer-event costs: per-build search/selection rescans (#403 part 3)
+
+#403 has three parts. Part 2 (resolve the hovered page once per pointer event
+instead of up to four times) already landed in **#442**, including the
+heavy-page gate that skips synchronous text extraction on hover. This is
+**part 3** — the per-build rescans during an active search or text selection.
+
+## Change (pdf_viewer.dart)
+
+- **Search matches by page.** `_matchesOn(pageIndex)` filtered the whole
+  `_matches` list per page per build — O(matches × visible-pages) every frame
+  while a search is active. Now `_setMatches` builds a `Map<int, List>` index
+  once when the matches change, and `_matchesOn` is an O(1) lookup. The three
+  `_matches =` sites (search start/land, clearSearch) route through `_setMatches`.
+- **Selection quads memoized.** `_selectionQuadsOn(pageIndex)` re-ran
+  `quadsFor` on every call, and `_textSelectionOn`, the selection-rects helper,
+  and the per-page build each asked for the same quads — several full
+  `quadsFor` scans per selected page per build. Now cached in a
+  `Map<int, List<PdfTextQuad>>` keyed on the selection range (`_selRange`, a
+  value-equal record): a new anchor/focus rebuilds the cache, a stable
+  selection computes each page once. Cleared explicitly in `_clearSelection`.
+
+Both are pure hot-path memoization — no behavioural change. Search and
+touch-selection widget suites pass unchanged.
+
+## Not done here
+
+- **Part 1 (overlay cursor repaint layer)** — the headline: the editing
+  overlay `setState`s per mouse-move to move a pen dot / eraser ring / count
+  mark, rebuilding its whole subtree. The file already has the right pattern
+  (`_ActiveStrokePainter` reads live `_state` fields and repaints via
+  `super(repaint: _state._activeStrokeRepaint)` on its own layer, no rebuild);
+  the fix is to move hover-cursor rendering out of the snapshot-arg
+  `_EditingPreviewPainter` onto a sibling repaint layer and have `_onHover`
+  bump a `_cursorRepaint` notifier instead of `setState`. That is a delicate
+  extraction in the render-critical overlay painter whose main failure mode
+  (cursor flicker / wrong z-order / stale cursor) is *visual* and not reliably
+  caught by widget tests — it wants eyes-on validation, so it is left as a
+  scoped follow-up rather than shipped blind.
+- The async/off-thread hover text extraction (part 2's remaining half) is
+  gated behind #396.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -303,7 +303,25 @@ class PdfViewerController extends ChangeNotifier {
   PdfSearchOptions _searchOptions = const PdfSearchOptions();
   List<PdfSearchResult> _results = const [];
   List<PdfTextMatch> _matches = const [];
+  // Matches grouped by page, rebuilt once when [_matches] changes so
+  // [_matchesOn] is an O(1) lookup rather than an O(matches) filter run per page
+  // per build - the per-build rescan #403 flagged during an active search.
+  Map<int, List<PdfTextMatch>> _matchesByPage = const {};
   int _currentMatch = -1;
+
+  /// Assigns [_matches] and rebuilds the by-page index in one pass.
+  void _setMatches(List<PdfTextMatch> matches) {
+    _matches = matches;
+    if (matches.isEmpty) {
+      _matchesByPage = const {};
+      return;
+    }
+    final byPage = <int, List<PdfTextMatch>>{};
+    for (final match in matches) {
+      (byPage[match.pageIndex] ??= <PdfTextMatch>[]).add(match);
+    }
+    _matchesByPage = byPage;
+  }
 
   int get pageCount => _pageCount;
 
@@ -590,7 +608,7 @@ class PdfViewerController extends ChangeNotifier {
     final opts = _searchOptions;
     _query = query;
     _results = const [];
-    _matches = const [];
+    _setMatches(const []);
     _currentMatch = -1;
     _searching = query.isNotEmpty;
     notifyListeners();
@@ -599,7 +617,7 @@ class PdfViewerController extends ChangeNotifier {
     // superseded by a newer search (changed query or options)
     if (_query != query || _searchOptions != opts) return;
     _results = results;
-    _matches = [for (final result in results) result.match];
+    _setMatches([for (final result in results) result.match]);
     _searching = false;
     _currentMatch = results.isEmpty ? -1 : 0;
     notifyListeners();
@@ -635,7 +653,7 @@ class PdfViewerController extends ChangeNotifier {
   void clearSearch() {
     _query = '';
     _results = const [];
-    _matches = const [];
+    _setMatches(const []);
     _currentMatch = -1;
     _searching = false;
     _notifySafely();
@@ -677,10 +695,8 @@ class PdfViewerController extends ChangeNotifier {
     }
   }
 
-  List<PdfTextMatch> _matchesOn(int pageIndex) => [
-        for (final m in _matches)
-          if (m.pageIndex == pageIndex) m
-      ];
+  List<PdfTextMatch> _matchesOn(int pageIndex) =>
+      _matchesByPage[pageIndex] ?? const [];
 }
 
 /// [ChangeNotifier.notifyListeners] is protected; this is the smallest
@@ -4531,6 +4547,8 @@ class _PdfViewerState extends State<PdfViewer>
 
   void _clearSelection() {
     _wordAnchor = null;
+    _selectionQuadCacheRange = null;
+    _selectionQuadCache.clear();
     if (_selAnchor != null || _selFocus != null || _touchSelecting) {
       setState(() {
         _selAnchor = null;
@@ -4570,16 +4588,33 @@ class _PdfViewerState extends State<PdfViewer>
 
   /// Baseline-aligned selection quads on [pageIndex], so the highlight
   /// rotates with rotated text instead of painting an axis-aligned box.
+  // Selection quads memoized per page, keyed on the selection range. The range
+  // is a value-equal record, so a new anchor/focus rebuilds the cache and a
+  // stable selection is computed once instead of per call - `_textSelectionOn`,
+  // `_selectionRectsOn`, and the per-page build each ask for the same quads
+  // (#403). Cleared explicitly in [_clearSelection]; also self-invalidates when
+  // the range changes (an active-selection drag).
+  ((int, int), (int, int))? _selectionQuadCacheRange;
+  final Map<int, List<PdfTextQuad>> _selectionQuadCache = {};
+
   List<PdfTextQuad> _selectionQuadsOn(int pageIndex) {
     final range = _selRange;
     if (range == null) return const [];
+    if (range != _selectionQuadCacheRange) {
+      _selectionQuadCacheRange = range;
+      _selectionQuadCache.clear();
+    }
+    final cached = _selectionQuadCache[pageIndex];
+    if (cached != null) return cached;
     final (start, end) = range;
-    if (pageIndex < start.$1 || pageIndex > end.$1) return const [];
+    if (pageIndex < start.$1 || pageIndex > end.$1) {
+      return _selectionQuadCache[pageIndex] = const [];
+    }
     final text = _pageText(pageIndex);
     final from = pageIndex == start.$1 ? start.$2 : 0;
     final to = pageIndex == end.$1 ? end.$2 : text.text.length;
-    if (from >= to) return const [];
-    return text.quadsFor(from, to);
+    if (from >= to) return _selectionQuadCache[pageIndex] = const [];
+    return _selectionQuadCache[pageIndex] = text.quadsFor(from, to);
   }
 
   void _showMatch(PdfTextMatch match) {

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -310,6 +310,11 @@ class PdfViewerController extends ChangeNotifier {
   int _currentMatch = -1;
 
   /// Assigns [_matches] and rebuilds the by-page index in one pass.
+  ///
+  /// The per-page lists are handed out by [_matchesOn] (unlike the old filter,
+  /// which returned a fresh list per call), so they are frozen unmodifiable -
+  /// the index stays the single source of truth even if a caller tries to
+  /// mutate what it gets back.
   void _setMatches(List<PdfTextMatch> matches) {
     _matches = matches;
     if (matches.isEmpty) {
@@ -320,7 +325,10 @@ class PdfViewerController extends ChangeNotifier {
     for (final match in matches) {
       (byPage[match.pageIndex] ??= <PdfTextMatch>[]).add(match);
     }
-    _matchesByPage = byPage;
+    _matchesByPage = {
+      for (final entry in byPage.entries)
+        entry.key: List<PdfTextMatch>.unmodifiable(entry.value),
+    };
   }
 
   int get pageCount => _pageCount;


### PR DESCRIPTION
#403 part 3. Part 2 (resolve the hovered page once per pointer event) already landed in **#442**; this is the per-build rescan half.

## Change (`pdf_viewer.dart`)

- **Search matches by page** — `_matchesOn(pageIndex)` filtered the whole `_matches` list per page per build (O(matches × visible-pages) every frame while a search is active). Now `_setMatches` builds a `Map<int, List>` index once when the matches change, and `_matchesOn` is an **O(1)** lookup. The three `_matches =` sites route through `_setMatches`.
- **Selection quads memoized** — `_selectionQuadsOn(pageIndex)` re-ran `quadsFor` on every call, and `_textSelectionOn`, the selection-rects helper, and the per-page build each asked for the same quads (several full scans per selected page per build). Now cached in a `Map<int, List<PdfTextQuad>>` keyed on the selection range (`_selRange`, a value-equal record): a stable selection computes each page once, a new anchor/focus rebuilds. Cleared in `_clearSelection`.

Pure memoization, **no behavioural change**.

## Testing

- `search_navigation_test`, `pdf_touch_selection_test`, `pdf_viewer_test` pass unchanged. `dart analyze` clean.

## Remaining #403 work (not in this PR)

- **Part 1 (overlay cursor repaint layer)** — the headline: the editing overlay `setState`s per mouse-move to move a pen dot / eraser ring / count mark, rebuilding its whole subtree. The file already has the right pattern (`_ActiveStrokePainter` reads live `_state` and repaints via `super(repaint: …)` on its own layer). The fix is to move hover-cursor rendering off the snapshot-arg `_EditingPreviewPainter` onto a sibling repaint layer and have `_onHover` bump a notifier instead of `setState`. That is a delicate extraction in the render-critical overlay painter whose failure mode (cursor flicker / z-order / staleness) is **visual** and not reliably caught by widget tests — left as a scoped follow-up needing eyes-on validation rather than shipped blind.
- Async/off-thread hover text extraction is gated behind #396.

Dev-log: `doc/dev-log/2026-07-22-pointer-event-costs-403.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)