### PR TITLE
Fix dots in reduced-opacity ink annotations

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -5489,8 +5489,21 @@ void _paintInkStrokes(
     List<List<double>?> pressures,
     Color color,
     double strokeWidth) {
+  // Per-pressure segments (and crossing strokes) meet at overlapping round
+  // caps; at partial alpha, compositing each on its own double-paints those
+  // overlaps into visible dots. Mirror the committed appearance's
+  // transparency group: fade the whole set as one layer, painting the
+  // strokes opaquely inside so the overlaps composite once.
+  final grouped = color.a < 1;
+  if (grouped) {
+    canvas.saveLayer(
+        null,
+        Paint()
+          ..color = Color.from(alpha: color.a, red: 0, green: 0, blue: 0));
+  }
+  final drawColor = grouped ? color.withValues(alpha: 1) : color;
   final paint = Paint()
-    ..color = color
+    ..color = drawColor
     ..style = PaintingStyle.stroke
     ..strokeWidth = strokeWidth
     ..strokeCap = StrokeCap.round
@@ -5505,7 +5518,7 @@ void _paintInkStrokes(
       final width = pressure == null
           ? strokeWidth
           : pdfInkStrokeWidth(strokeWidth, pressure.first);
-      canvas.drawCircle(p, width / 2, Paint()..color = color);
+      canvas.drawCircle(p, width / 2, Paint()..color = drawColor);
       continue;
     }
     // the same Catmull-Rom smoothing the committed appearance uses
@@ -5515,7 +5528,7 @@ void _paintInkStrokes(
       // point pair at its own pressure-mapped width, round caps as the
       // seams
       final segment = Paint()
-        ..color = color
+        ..color = drawColor
         ..style = PaintingStyle.stroke
         ..strokeCap = StrokeCap.round;
       for (var i = 0; i < stroke.length - 1; i++) {
@@ -5546,6 +5559,7 @@ void _paintInkStrokes(
     }
     canvas.drawPath(path, paint);
   }
+  if (grouped) canvas.restore();
 }
 
 /// The single in-progress pencil/mouse stroke, on its own RepaintBoundary.

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -668,7 +668,7 @@ extension PdfAnnotationEditing on PdfEditor {
         'must parallel strokes point for point',
       );
     }
-    final (rect, w, gs) = _inkAppearance(
+    final (rect, w, resources) = _inkAppearance(
       strokes,
       pressures,
       color,
@@ -681,15 +681,23 @@ extension PdfAnnotationEditing on PdfEditor {
       _markupDict('Ink', rect, color, contents, author)
         ..['BS'] = _borderStyle(strokeWidth)
         ..['InkList'] = _inkListArray(strokes),
-      _form(rect, w, resources: _resources(extGState: gs)),
+      _form(rect, w, resources: resources),
       name: name,
     );
   }
 
   /// The generated Ink appearance for [strokes]: the padded rect (the
   /// Bézier control hull plus half the widest pen width), the content,
-  /// and the alpha ExtGState when [opacity] < 1. Shared by [addInk] and
+  /// and its /Resources (null at full [opacity]). Shared by [addInk] and
   /// [sliceInk] so sliced ink re-renders exactly as it was drawn.
+  ///
+  /// At reduced opacity the strokes are drawn at full alpha into an
+  /// isolated transparency-group form that the returned content paints
+  /// once under a constant-alpha ExtGState. Stroking each pressure
+  /// segment (and each separate stroke) on its own means the round caps
+  /// overlap at every join; compositing them individually at partial
+  /// alpha double-paints those overlaps into visible dots - drawing them
+  /// opaquely inside the group and fading the group as a whole avoids it.
   (PdfRect, ContentWriter, CosDictionary?) _inkAppearance(
     List<List<(double, double)>> strokes,
     List<List<double>?>? pressures,
@@ -726,10 +734,7 @@ extension PdfAnnotationEditing on PdfEditor {
     final pad = maxWidth / 2 + 1;
     final rect = PdfRect(minX - pad, minY - pad, maxX + pad, maxY + pad);
 
-    final w = ContentWriter();
-    final gs = _alphaState(opacity);
-    if (gs != null) w.extGState('GS0');
-    w
+    final w = ContentWriter()
       ..strokeColor(color)
       ..lineWidth(strokeWidth)
       ..roundLines();
@@ -774,7 +779,21 @@ extension PdfAnnotationEditing on PdfEditor {
           ..stroke();
       }
     }
-    return (rect, w, gs);
+
+    final gs = _alphaState(opacity);
+    if (gs == null) return (rect, w, null);
+    // Fade the strokes as one object: wrap them in an isolated
+    // transparency group and apply the constant alpha to the group at its
+    // `Do`, so overlapping round caps composite opaquely inside instead of
+    // darkening every join into a dot.
+    final innerRef = _updater.addObject(_form(rect, w, transparencyGroup: true));
+    return (
+      rect,
+      ContentWriter()
+        ..extGState('GS0')
+        ..drawXObject('Fm0'),
+      _resources(extGState: gs, xObject: CosDictionary({'Fm0': innerRef})),
+    );
   }
 
   CosArray _inkListArray(List<List<(double, double)>> strokes) => CosArray([
@@ -831,7 +850,7 @@ extension PdfAnnotationEditing on PdfEditor {
     }
     final opacity = form == null ? 1.0 : _appearanceOpacity(form);
     final color = annotation.color ?? 0x000000;
-    final (rect, w, gs) = _inkAppearance(
+    final (rect, w, resources) = _inkAppearance(
       strokes,
       pressures,
       color,
@@ -847,12 +866,12 @@ extension PdfAnnotationEditing on PdfEditor {
         form,
         rect,
         w,
-        resources: _resources(extGState: gs),
+        resources: resources,
       );
     } else {
       dict['AP'] = CosDictionary({
         'N': _updater.addObject(
-          _form(rect, w, resources: _resources(extGState: gs)),
+          _form(rect, w, resources: resources),
         ),
       });
     }
@@ -872,9 +891,13 @@ extension PdfAnnotationEditing on PdfEditor {
     double strokeWidth,
   ) {
     if (strokeWidth <= 0) return null;
+    // Reduced-opacity ink strokes live inside an isolated transparency
+    // group the /N form paints with `/GS0 gs /Fm0 Do`; unwrap to that
+    // inner form so the per-segment `w` recovery sees the stroke ops.
+    final drawing = _inkDrawingStream(form) ?? form;
     final List<ContentOperation> ops;
     try {
-      ops = ContentStreamParser.parse(document.cos.decodeStreamData(form));
+      ops = ContentStreamParser.parse(document.cos.decodeStreamData(drawing));
     } catch (_) {
       return null;
     }
@@ -934,6 +957,36 @@ extension PdfAnnotationEditing on PdfEditor {
       ]);
     }
     return anyPressure ? result : null;
+  }
+
+  /// If [form] is the wrapper this editor emits for reduced-opacity ink -
+  /// a single `Do` of an isolated transparency group carrying the strokes -
+  /// returns that inner group's stream; null when the form draws the
+  /// strokes directly (full opacity) or isn't one of ours.
+  CosStream? _inkDrawingStream(CosStream form) {
+    final cos = document.cos;
+    final List<ContentOperation> ops;
+    try {
+      ops = ContentStreamParser.parse(cos.decodeStreamData(form));
+    } catch (_) {
+      return null;
+    }
+    String? drawn;
+    for (final op in ops) {
+      if (op.operator == 'Do') {
+        if (op.operands.length != 1 || op.operands.single is! CosName) {
+          return null;
+        }
+        drawn = (op.operands.single as CosName).value;
+      }
+    }
+    if (drawn == null) return null;
+    final resources = cos.resolve(form.dictionary['Resources']);
+    if (resources is! CosDictionary) return null;
+    final xObjects = cos.resolve(resources['XObject']);
+    if (xObjects is! CosDictionary) return null;
+    final inner = cos.resolve(xObjects[drawn]);
+    return inner is CosStream ? inner : null;
   }
 
   /// Adds a rectangle annotation. At least one of [strokeColor] and
@@ -4562,7 +4615,7 @@ extension PdfAnnotationEditing on PdfEditor {
         final newColor = color ?? currentStyle.color ?? 0x000000;
         final newWidth = strokeWidth ?? oldWidth;
         final newOpacity = opacity ?? currentStyle.opacity;
-        final (rect, w, gs) =
+        final (rect, w, resources) =
             _inkAppearance(strokes, pressures, newColor, newWidth, newOpacity);
         dict['Rect'] = _rectArray(rect);
         dict['C'] = _colorComponents(newColor);
@@ -4573,12 +4626,12 @@ extension PdfAnnotationEditing on PdfEditor {
             form,
             rect,
             w,
-            resources: _resources(extGState: gs),
+            resources: resources,
           );
         } else {
           dict['AP'] = CosDictionary({
             'N': _updater.addObject(
-              _form(rect, w, resources: _resources(extGState: gs)),
+              _form(rect, w, resources: resources),
             ),
           });
         }
@@ -5683,6 +5736,7 @@ extension PdfAnnotationEditing on PdfEditor {
     PdfRect bbox,
     ContentWriter content, {
     CosDictionary? resources,
+    bool transparencyGroup = false,
   }) {
     final bytes = content.takeBytes();
     final dict = CosDictionary({
@@ -5691,6 +5745,15 @@ extension PdfAnnotationEditing on PdfEditor {
       'BBox': _rectArray(bbox),
       'Length': CosInteger(bytes.length),
     });
+    if (transparencyGroup) {
+      // An isolated transparency group (§11.6.6): a constant alpha set
+      // before this form's `Do` composites the group's result as one
+      // object, instead of compounding wherever the content self-overlaps.
+      dict['Group'] = CosDictionary({
+        'S': const CosName('Transparency'),
+        'I': const CosBoolean(true),
+      });
+    }
     if (resources != null) dict['Resources'] = resources;
     return CosStream(dict, bytes);
   }

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -150,6 +150,82 @@ void main() {
     expect(pdfInkStrokeWidth(4, 1), closeTo(6.4, 1e-9));
   });
 
+  test('reduced-opacity ink fades as one isolated transparency group', () {
+    // A pressure (trackpad/stylus) stroke paints each segment separately
+    // with round caps that overlap at every join. Compositing them
+    // individually at partial alpha double-paints those overlaps into
+    // visible dots, so the strokes are drawn opaquely inside a
+    // transparency group the /N form fades as a whole.
+    String innerDrawing(PdfDocument d, PdfAnnotation a) {
+      final resources =
+          d.cos.resolve(a.normalAppearance!.dictionary['Resources'])
+              as CosDictionary;
+      final xObjects = d.cos.resolve(resources['XObject']) as CosDictionary;
+      final inner =
+          d.cos.resolve(xObjects.entries.values.single) as CosStream;
+      return latin1.decode(d.cos.decodeStreamData(inner));
+    }
+
+    final doc = roundTrip((e) => e.addInk(
+          0,
+          [
+            [(100, 100), (150, 130), (200, 100)],
+          ],
+          strokeWidth: 4,
+          opacity: 0.5,
+          pressures: [
+            [0.0, 0.5, 1.0],
+          ],
+        ));
+    final ink = doc.page(0).annotations.single;
+    final form = ink.normalAppearance!;
+
+    // the /N form just fades and paints the group - no stroke ops leak
+    // out where the constant alpha would compound them
+    final outer = latin1.decode(doc.cos.decodeStreamData(form));
+    expect(outer, contains('/GS0 gs'));
+    expect(outer, contains('Do'));
+    expect(outer, isNot(contains(' S')));
+
+    // /GS0 carries the constant alpha; the inner form is an isolated
+    // transparency group
+    final resources =
+        doc.cos.resolve(form.dictionary['Resources']) as CosDictionary;
+    final gstates = doc.cos.resolve(resources['ExtGState']) as CosDictionary;
+    final gs0 = doc.cos.resolve(gstates['GS0']) as CosDictionary;
+    expect((doc.cos.resolve(gs0['ca']) as CosReal).value, closeTo(0.5, 1e-9));
+    expect((doc.cos.resolve(gs0['CA']) as CosReal).value, closeTo(0.5, 1e-9));
+
+    final xObjects = doc.cos.resolve(resources['XObject']) as CosDictionary;
+    final inner = doc.cos.resolve(xObjects.entries.values.single) as CosStream;
+    final group = doc.cos.resolve(inner.dictionary['Group']) as CosDictionary;
+    expect((doc.cos.resolve(group['S']) as CosName).value, 'Transparency');
+    expect(doc.cos.resolve(group['I']), const CosBoolean(true));
+
+    // the per-segment stroking lives inside the group, at full alpha
+    final drawing = innerDrawing(doc, ink);
+    expect(drawing, contains('2.8 w'));
+    expect(drawing, contains('5.2 w'));
+    expect('S'.allMatches(drawing).length, greaterThanOrEqualTo(2));
+    expect(drawing, isNot(contains('gs')));
+
+    // restyling recovers the pressures through the group wrapper, so a
+    // recolor stays per-segment instead of collapsing to a uniform pen
+    final editor = PdfEditor(doc)
+      ..restyleAnnotation(0, ink, color: 0x1E88E5);
+    final out = PdfDocument.open(editor.save());
+    final after = out.page(0).annotations.single;
+    expect(after.color, 0x1E88E5);
+    final afterDrawing = innerDrawing(out, after);
+    expect(afterDrawing, contains('RG'), reason: 'recolored');
+    // still per-segment: recovery inverts the group's segment widths back
+    // to pressures (a lossy re-average, 2.8/5.2 → 3.4/4.6) rather than
+    // flattening to a single uniform pen
+    expect(afterDrawing, contains('3.4 w'),
+        reason: 'pressures recovered through the group wrapper');
+    expect(afterDrawing, contains('4.6 w'));
+  });
+
   test('ink appearances smooth the polyline into Bézier curves', () {
     final doc = roundTrip((e) => e.addInk(0, [
           [(100, 100), (150, 130), (200, 100)],

--- a/packages/pdf_graphics/test/generated_appearance_test.dart
+++ b/packages/pdf_graphics/test/generated_appearance_test.dart
@@ -11,6 +11,7 @@ class CountingDevice implements PdfDevice {
   final strokes = <PdfColor>[];
   final texts = <PdfTextRun>[];
   final blendModes = <PdfBlendMode>[];
+  final groupAlphas = <double>[];
   var alphas = <double>[];
 
   @override
@@ -47,7 +48,8 @@ class CountingDevice implements PdfDevice {
   @override
   void drawImage(PdfImageRequest request) {}
   @override
-  void beginGroup(double alpha, {bool knockout = false}) {}
+  void beginGroup(double alpha, {bool knockout = false}) =>
+      groupAlphas.add(alpha);
   @override
   void endGroup() {}
   @override
@@ -106,6 +108,42 @@ void main() {
     expect(
         device.fills.any((c) => c.red > 0.99 && c.green < 0.01), isTrue);
     expect(device.blendModes, contains(PdfBlendMode.multiply));
+  });
+
+  test('reduced-opacity ink strokes composite once through a group', () {
+    // The per-pressure segments overlap at their round caps; without the
+    // transparency group each would composite separately at 0.5 alpha and
+    // darken every join into a dot. The group makes them one object faded
+    // once - the interpreter opens exactly one group at the ink's opacity.
+    final device = render(annotated((e) => e.addInk(
+          0,
+          [
+            [(100, 100), (150, 130), (200, 100)],
+          ],
+          strokeWidth: 6,
+          opacity: 0.5,
+          pressures: [
+            [0.2, 0.6, 1.0],
+          ],
+        )));
+    expect(device.groupAlphas, [closeTo(0.5, 1e-9)]);
+    // the strokes still reach the device (inside the group, at full alpha)
+    expect(device.strokes, isNotEmpty);
+  });
+
+  test('full-opacity ink strokes render without a group', () {
+    final device = render(annotated((e) => e.addInk(
+          0,
+          [
+            [(100, 100), (150, 130), (200, 100)],
+          ],
+          strokeWidth: 6,
+          pressures: [
+            [0.2, 0.6, 1.0],
+          ],
+        )));
+    expect(device.groupAlphas, isEmpty);
+    expect(device.strokes, isNotEmpty);
   });
 
   test('drawAnnotations skip omits the matched annotation, keeps the rest', () {


### PR DESCRIPTION
## Summary

Reduced-opacity ink drawn with pressure (trackpad/stylus) showed a row of darker dots along the stroke. Pressure ink renders as one stroked Bézier **per segment** with round caps, so consecutive caps overlap at every join. Under a constant-alpha ExtGState each per-segment `stroke()` composites separately, so the overlaps get painted twice and darken into dots. Full opacity hides the double-paint, and a single non-pressure stroke never self-compounds — so the artifact only appeared for pressured ink below full opacity.

The fix draws the strokes at full alpha into an **isolated transparency-group** form XObject that the `/N` appearance paints once under the constant-alpha `/GS0` ExtGState. The alpha then applies to the composited group *as a whole* (§11.6.6), so the overlapping caps merge opaquely and there are no dots. The live drawing preview groups its strokes in a `saveLayer` the same way, so the on-screen preview matches the committed result instead of showing dots that vanish on commit. Pressure recovery on slice/restyle unwraps the group to find the stroke ops.

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [x] `pdf_graphics` (tests only)
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze`
- [x] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/pdf_graphics && fvm dart test` (generated appearance render tests)
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Added tests: a `pdf_document` test asserting the reduced-opacity ink appearance is an isolated transparency group with the alpha on `/GS0` and the strokes in the inner form (plus pressure recovery through the wrapper surviving a restyle); two `pdf_graphics` interpreter render tests asserting reduced-opacity ink opens exactly one group at its opacity while full-opacity ink opens none.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The reduced-opacity `/N` appearance now nests one level: `/GS0 gs /Fm0 Do` where `Fm0` is an isolated transparency group carrying the per-segment strokes. Full-opacity ink is byte-identical to before. Flattening references the wrapper form whole (its own resources travel with it), and the stretch-resize path is unchanged since it only remaps `/InkList` and relies on BBox→Rect. `_recoverInkPressures` unwraps the group via the new `_inkDrawingStream` helper; its pressure round-trip is lossy as before (segment widths → pressures re-averaged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwDdWUASbkRMCv8qWFNZSq)_