### PR TITLE
feat(i18n): web deferred locale loading + native locale-prune tool + docs

### DIFF
--- a/app/l10n.yaml
+++ b/app/l10n.yaml
@@ -2,3 +2,8 @@ arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 output-class: AppLocalizations
+# On Flutter web, load each locale as a deferred import so only the active
+# locale's JS chunk is downloaded (no effect on mobile/desktop AOT; see
+# doc/i18n.md). The English fallback wrapper imports the _en class directly,
+# so English stays eager.
+use-deferred-loading: true

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
-import 'app_localizations_en.dart';
+import 'app_localizations_en.dart' deferred as app_localizations_en;
 
 // ignore_for_file: type=lint
 
@@ -1349,7 +1348,7 @@ class _AppLocalizationsDelegate
 
   @override
   Future<AppLocalizations> load(Locale locale) {
-    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+    return lookupAppLocalizations(locale);
   }
 
   @override
@@ -1360,11 +1359,13 @@ class _AppLocalizationsDelegate
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
-AppLocalizations lookupAppLocalizations(Locale locale) {
+Future<AppLocalizations> lookupAppLocalizations(Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
     case 'en':
-      return AppLocalizationsEn();
+      return app_localizations_en
+          .loadLibrary()
+          .then((dynamic _) => app_localizations_en.AppLocalizationsEn());
   }
 
   throw FlutterError(

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -14,7 +14,9 @@ void main() {
   testWidgets('boots into the empty state with an Open button',
       (WidgetTester tester) async {
     await tester.pumpWidget(const DartPdfEditorApp());
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load
+    // asynchronously; settle so the localized empty state builds.
+    await tester.pumpAndSettle();
 
     // No document open yet: the empty state offers a way in.
     expect(find.widgetWithText(FilledButton, 'Open a PDF'), findsOneWidget);

--- a/doc/dev-log/2026-07-22-i18n-locale-sizing.md
+++ b/doc/dev-log/2026-07-22-i18n-locale-sizing.md
@@ -1,0 +1,89 @@
+# 2026-07-22 — i18n locale sizing: web deferred loading + native prune tool
+
+Follow-up to the phase-1 extraction (`2026-07-22-i18n-extraction.md`, PR #477).
+Question from Ben before committing to translating additional languages: can a
+host include only the locales it wants, to keep app size down — ideally
+following the parent app's i18n config automatically?
+
+## The constraint (why it isn't automatic)
+
+A Flutter dependency that ships its own `LocalizationsDelegate` compiles **every
+bundled locale** into the app. The host's `supportedLocales` only drives runtime
+resolution and which Material/Cupertino translations load — it does **not**
+tree-shake the package's locale classes (the generated delegate's lookup
+references all of them). Flutter has no built-in mechanism for a dependency's
+bundle to follow the host's locale list. So size control needs an explicit
+lever.
+
+## What landed
+
+Three bundles (`packages/dart_pdf_editor`, `app`, `.../example`):
+
+1. **Web deferred loading** — `use-deferred-loading: true` in each `l10n.yaml`.
+   gen-l10n now imports each locale `deferred as …` and resolves it via
+   `loadLibrary()`, so dart2js splits every locale into its own chunk and the
+   browser fetches only the active one. No effect on mobile/desktop AOT.
+   English stays **eager**: the `pdfL10n`/`appL10n` fallback wrappers import the
+   `_en` class directly, so the same file is both a direct import (wrapper) and
+   a deferred import (delegate) — legal in Dart, and it keeps the fallback
+   synchronously constructible.
+
+2. **`tool/trim_locales.sh`** — the native-size lever. `trim_locales.sh en es
+   fr` regenerates the checked-in gen-l10n output for just those locales (+ the
+   English template, always kept), then you `flutter build`, then `--restore`.
+   Implementation: for each bundle it moves the unwanted `*_<loc>.arb` out of
+   the arb-dir, runs `gen-l10n` (so the delegate + `supportedLocales` come back
+   sized to the kept set), restores the ARBs (source of truth never lost), then
+   deletes the now-orphaned generated `*_localizations_<loc>.dart` (gen-l10n
+   regenerates the delegate but never deletes stale outputs). A `RETURN` trap
+   guarantees the ARBs are put back even on failure. `--restore` just re-runs
+   gen-l10n across all three bundles; `--list` shows bundled locales.
+
+3. **`doc/i18n.md`** — how lookups/fallback/delegates work, adding
+   strings/languages, the two `dart analyze --fatal-infos` traps
+   (`Localizations.of` in initState, context across async gaps), and the size
+   section: web deferred (auto), `trim_locales.sh` (native), and the host-merge
+   alternative for external apps that consume the published package.
+
+## Verified
+
+- gen-l10n with `use-deferred-loading` produces valid deferred imports even
+  with the single `en` locale today; `dart analyze --fatal-infos` clean across
+  the workspace.
+- **Deferred loading makes the delegate load async on every platform**, which
+  broke widget tests that boot a localized app and assert on the first frame -
+  `WidgetsApp` doesn't build the app subtree until the (now-deferred) delegate
+  resolves, so the localized UI (and the example's post-frame demo open) isn't
+  there yet. Fixed 5 tests by settling the boot: `app/test/widget_test.dart`
+  and `example/test/{tabs,recent_files_menu}_test.dart` use `pumpAndSettle`;
+  `example/test/{demo,editing}_test.dart` can't (the opened demo's clock
+  overlay runs a periodic timer that never settles), so their `openDemo`
+  helper pumps a bounded number of frames until the demo `PdfViewer` appears.
+  Package suite is unaffected - its widget tests exercise the English fallback
+  (no registered delegate). All three suites green after the fix.
+- `trim_locales.sh` end-to-end: created a synthetic `dart_pdf_editor_es.arb`
+  (→ 2-locale delegate), ran `trim_locales.sh en`, confirmed the `_es` generated
+  class was removed and `supportedLocales` fell back to `[en]` while the `es`
+  ARB stayed on disk; `--restore` brought it back. Removed the synthetic locale
+  afterwards.
+
+## Cost of deferred loading (why it's a deliberate tradeoff)
+
+On **web** it's a clear win (only the active locale's chunk downloads). On
+**native** AOT it gives no size benefit (everything is bundled regardless) and
+adds a one-frame delay before localized UI paints, plus the test-settling
+requirement above. We enable it anyway (Ben's call) because web is where DartPDF
+ships the demo and where download size matters; native size is handled by
+`trim_locales.sh`. If the native first-frame delay ever bites, flip
+`use-deferred-loading` off in the l10n.yaml files and regenerate - the wrappers
+and everything else are unchanged by it. Any NEW widget test that boots a
+localized app must settle the async delegate load (see the fixed tests for the
+two patterns).
+
+## Gotcha
+
+`--restore` (plain `gen-l10n`) does not delete generated files whose ARB was
+*actually removed* — it only regenerates from ARBs present. That's correct for
+the trim→build→restore flow (the ARBs are only ever moved, never deleted); a
+genuinely deleted locale is a source change and its stale `_loc.dart` must be
+removed by hand (or by another `trim_locales.sh` run).

--- a/doc/dev-log/2026-07-22-i18n-locale-sizing.md
+++ b/doc/dev-log/2026-07-22-i18n-locale-sizing.md
@@ -35,9 +35,11 @@ Three bundles (`packages/dart_pdf_editor`, `app`, `.../example`):
    the arb-dir, runs `gen-l10n` (so the delegate + `supportedLocales` come back
    sized to the kept set), restores the ARBs (source of truth never lost), then
    deletes the now-orphaned generated `*_localizations_<loc>.dart` (gen-l10n
-   regenerates the delegate but never deletes stale outputs). A `RETURN` trap
-   guarantees the ARBs are put back even on failure. `--restore` just re-runs
-   gen-l10n across all three bundles; `--list` shows bundled locales.
+   regenerates the delegate but never deletes stale outputs). It restores the
+   stashed ARBs unconditionally after regenerating - even if gen-l10n fails
+   (`( … ) || rc=$?` keeps `set -e` from exiting before the restore) - so the
+   source tree never loses a language. `--restore` just re-runs gen-l10n across
+   all three bundles; `--list` shows bundled locales.
 
 3. **`doc/i18n.md`** — how lookups/fallback/delegates work, adding
    strings/languages, the two `dart analyze --fatal-infos` traps

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -1,0 +1,151 @@
+# Internationalization (i18n)
+
+DartPDF's UI is localized with the standard Flutter stack:
+`flutter_localizations` + `intl` + ARB files + `gen-l10n`, with the generated
+Dart **checked into git** (so pub consumers never run codegen). Three bundles:
+
+| Bundle | Package | Class | ARBs |
+|---|---|---|---|
+| Editor UI | `packages/dart_pdf_editor` | `DartPdfEditorLocalizations` | `lib/l10n/dart_pdf_editor_<locale>.arb` |
+| DartPDF app | `app` | `AppLocalizations` | `app/lib/l10n/app_<locale>.arb` |
+| Example | `packages/dart_pdf_editor/example` | `AppLocalizations` | `.../example/lib/l10n/app_<locale>.arb` |
+
+The engine packages (`pdf_cos` / `pdf_document` / `pdf_graphics`) stay English —
+their strings are developer-facing exceptions, not UI.
+
+## How lookups work
+
+Widgets read strings through a small fallback wrapper rather than the generated
+`.of(context)` directly:
+
+- `pdfL10n(context)` (`packages/dart_pdf_editor/lib/src/l10n/pdf_l10n.dart`)
+- `appL10n(context)` (`app/lib/l10n/app_l10n.dart`, and the example's copy)
+
+Each returns the ambient localizations **or an English instance when the host
+never registered the delegate**:
+
+```dart
+DartPdfEditorLocalizations pdfL10n(BuildContext context) =>
+    Localizations.of<DartPdfEditorLocalizations>(
+        context, DartPdfEditorLocalizations) ??
+    DartPdfEditorLocalizationsEn();
+```
+
+This is the key design decision: package widgets work out of the box for hosts
+that never opt into translations, and the widget tests (which find English via
+`find.text('Cancel')`) stay green without registering delegates. Because the
+wrapper imports the `_en` class **directly**, English is always eagerly
+available — even under deferred loading (below).
+
+## Registering the delegates (host apps)
+
+```dart
+MaterialApp(
+  localizationsDelegates: const [
+    ...AppLocalizations.localizationsDelegates,   // includes the global
+    DartPdfEditorLocalizations.delegate,          // Material/Widgets/Cupertino
+  ],
+  supportedLocales: AppLocalizations.supportedLocales,
+  ...
+)
+```
+
+`app/lib/app.dart`, `app/lib/main.dart`, and the example's `main.dart` show the
+wiring.
+
+## Adding / editing strings
+
+1. Edit the **template** ARB (`*_en.arb`) — add the key, its `@key`
+   description, and typed `placeholders` for any interpolation. Use ICU
+   plural/select rather than hand-rolled plurals or sentence concatenation.
+2. Regenerate: `cd <bundle-dir> && fvm flutter gen-l10n`.
+3. `fvm dart analyze` must be clean; commit the ARB **and** the regenerated
+   Dart together.
+
+Watch for two traps the analyzer/CI enforce (`dart analyze --fatal-infos`):
+`Localizations.of` is unavailable in `initState`/constructors (resolve in
+`build`/`didChangeDependencies` or a post-frame callback), and don't use
+`context` across an `await` — capture `final l10n = pdfL10n(context);` before
+the gap.
+
+## Adding a new language
+
+Drop a `*_<locale>.arb` next to the template (e.g.
+`dart_pdf_editor_es.arb`), translate the values, keep the same keys, run
+`gen-l10n`, and commit. `supportedLocales` and the delegate pick it up
+automatically. Add the same locale to each of the three bundles you want it in,
+plus the host app's `supportedLocales`.
+
+## Keeping app size down — only ship the locales you want
+
+A Flutter dependency that ships its own `LocalizationsDelegate` compiles **every
+bundled locale** into the app. The host's `supportedLocales` only controls
+*runtime resolution* and which **Material/Cupertino** translations load — it
+does **not** drop the package's compiled locale classes, and Flutter has no
+built-in way for a dependency's bundle to follow the parent app's locale list.
+Two levers ship in this repo, plus one alternative:
+
+### 1. Web — deferred loading (automatic, on by default)
+
+Each `l10n.yaml` sets `use-deferred-loading: true`. On Flutter **web**, every
+locale becomes a lazily-loaded JS chunk, so a browser downloads only the active
+locale instead of all of them. English stays eager (the fallback wrapper imports
+it directly). Zero host configuration; **no effect on mobile/desktop AOT**,
+where deferred imports are not split out.
+
+The tradeoff: deferred loading makes the localizations **delegate load
+asynchronously on every platform**. On native that means a one-frame delay
+before localized UI paints (no size benefit there — that's what `trim_locales.sh`
+below is for). It also means a **widget test that boots a localized app must
+settle the async load** before asserting: `await tester.pumpAndSettle()` after
+`pumpWidget`, or — when an open screen runs a periodic timer that never lets the
+tree settle — pump a bounded number of frames until the expected widget appears
+(see `example/test/demo_test.dart`'s `openDemo` for that pattern). Tests that use
+the English fallback (no registered delegate) are unaffected. To turn deferred
+loading off, delete the `use-deferred-loading` line from the `l10n.yaml` files
+and regenerate — nothing else depends on it.
+
+### 2. Native (mobile/desktop) — `tool/trim_locales.sh`
+
+For AOT builds the lever is to regenerate the checked-in output for just the
+locales you ship:
+
+```sh
+tool/trim_locales.sh --list          # show bundled locales per bundle
+tool/trim_locales.sh en es fr de     # keep English + Spanish/French/German
+fvm flutter build <target> ...        # build with only those compiled in
+tool/trim_locales.sh --restore        # regenerate the full set afterwards
+```
+
+English (the template/fallback) is always kept. The script never deletes an
+`.arb` — it only regenerates the produced Dart — so `--restore` (or
+`git checkout` of the `lib/l10n` dirs) always brings every language back. Run it
+as a release step; don't commit a trimmed tree.
+
+### 3. External hosts — the host-merge alternative
+
+Apps that consume the **published** package can't trim its pub-cache output.
+To compile only their own locales *and* have the set follow their own
+`supportedLocales` automatically, merge this package's ARBs into the host's own
+`arb-dir` and run the host's `gen-l10n` over the combined set, so the editor's
+strings become part of the host's `AppLocalizations`. This trades the
+out-of-the-box convenience (and would need the wrapper pointed at the host
+class) for a single generated bundle sized exactly to the host's languages.
+
+### Is it worth it?
+
+Each locale's generated class is ~30 KB of Dart source; the compiled payload is
+mostly the translated string bytes (~20–30 KB/locale). A dozen-plus locales is a
+few hundred KB uncompressed — a small slice of a PDF app where fonts and the
+engine dominate, and it gzips well on web. Reach for trimming only against a
+real native-size budget; on web, deferred loading already handles it.
+
+## Status & roadmap
+
+Phase 1 (infrastructure + English extraction of ~700 strings, ICU plurals) is
+done — see `doc/dev-log/2026-07-22-i18n-extraction.md`. Still open: the
+no-context strings that need a context-threading refactor (toolbar tool
+tooltips are the most visible), engine-error→UI-message mapping,
+`DateFormat`/`NumberFormat` for month abbreviations and numeric readouts, the
+RTL sweep, a Settings language picker, machine-translated seed ARBs for the
+tier-1/2 locales, and a per-locale CI coverage gate.

--- a/packages/dart_pdf_editor/example/l10n.yaml
+++ b/packages/dart_pdf_editor/example/l10n.yaml
@@ -2,3 +2,8 @@ arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 output-class: AppLocalizations
+# On Flutter web, load each locale as a deferred import so only the active
+# locale's JS chunk is downloaded (no effect on mobile/desktop AOT; see
+# doc/i18n.md). The English fallback wrapper imports the _en class directly,
+# so English stays eager.
+use-deferred-loading: true

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
-import 'app_localizations_en.dart';
+import 'app_localizations_en.dart' deferred as app_localizations_en;
 
 // ignore_for_file: type=lint
 
@@ -803,7 +802,7 @@ class _AppLocalizationsDelegate
 
   @override
   Future<AppLocalizations> load(Locale locale) {
-    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+    return lookupAppLocalizations(locale);
   }
 
   @override
@@ -814,11 +813,13 @@ class _AppLocalizationsDelegate
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
-AppLocalizations lookupAppLocalizations(Locale locale) {
+Future<AppLocalizations> lookupAppLocalizations(Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
     case 'en':
-      return AppLocalizationsEn();
+      return app_localizations_en
+          .loadLibrary()
+          .then((dynamic _) => app_localizations_en.AppLocalizationsEn());
   }
 
   throw FlutterError(

--- a/packages/dart_pdf_editor/example/test/demo_test.dart
+++ b/packages/dart_pdf_editor/example/test/demo_test.dart
@@ -10,7 +10,15 @@ void main() {
     // the mock store is process-global: start every test from defaults
     SharedPreferences.setMockInitialValues({});
     await tester.pumpWidget(const ViewerApp());
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load
+    // asynchronously, so the app subtree - and the post-frame demo open -
+    // only appear after the deferred unit resolves over several frames.
+    // pumpAndSettle can't be used (the open demo runs a periodic clock timer
+    // that never settles), so pump a bounded number of frames until the demo
+    // viewer is up.
+    for (var i = 0; i < 20 && find.byType(PdfViewer).evaluate().isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
   }
 
   /// Demo pages are 612×792pt and the viewer opens fit-page (the whole

--- a/packages/dart_pdf_editor/example/test/editing_test.dart
+++ b/packages/dart_pdf_editor/example/test/editing_test.dart
@@ -15,7 +15,15 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
     await tester.pumpWidget(const ViewerApp());
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load
+    // asynchronously, so the app subtree - and the post-frame demo open -
+    // only appear after the deferred unit resolves over several frames.
+    // pumpAndSettle can't be used (the open demo runs a periodic clock timer
+    // that never settles), so pump a bounded number of frames until the demo
+    // viewer is up.
+    for (var i = 0; i < 20 && find.byType(PdfViewer).evaluate().isEmpty; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
   }
 
   /// Demo pages are 612×792pt and the viewer opens fit-page, so the

--- a/packages/dart_pdf_editor/example/test/recent_files_menu_test.dart
+++ b/packages/dart_pdf_editor/example/test/recent_files_menu_test.dart
@@ -36,8 +36,9 @@ void main() {
     await seed.record('beta.pdf', doc(2));
 
     await tester.pumpWidget(ViewerApp(cacheStore: backend));
-    await tester.pump();
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load async; settle
+    // so the localized app (and its post-frame demo open) builds.
+    await tester.pumpAndSettle();
 
     await openAppMenu(tester);
     // the parent menu only shows the "Open Recent" row; the files
@@ -60,8 +61,9 @@ void main() {
     await seed.record('alpha.pdf', doc(1));
 
     await tester.pumpWidget(ViewerApp(cacheStore: backend));
-    await tester.pump();
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load async; settle
+    // so the localized app (and its post-frame demo open) builds.
+    await tester.pumpAndSettle();
 
     await openAppMenu(tester);
     expect(find.text(shortcut('S')), findsOneWidget);
@@ -72,7 +74,9 @@ void main() {
   testWidgets('app menu includes a feedback link', (tester) async {
     SharedPreferences.setMockInitialValues({});
     await tester.pumpWidget(ViewerApp(cacheStore: PdfMemoryCacheStore()));
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load async; settle
+    // so the localized app builds before opening the menu.
+    await tester.pumpAndSettle();
 
     await openAppMenu(tester);
     expect(find.text('Supply feedback…'), findsOneWidget);
@@ -88,8 +92,9 @@ void main() {
     await seed.record('alpha.pdf', doc(2));
 
     await tester.pumpWidget(ViewerApp(cacheStore: backend));
-    await tester.pump();
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load async; settle
+    // so the localized app (and its post-frame demo open) builds.
+    await tester.pumpAndSettle();
 
     // the demo title shows once, in the tab strip
     expect(find.text('Feature showcase'), findsOneWidget);
@@ -109,8 +114,9 @@ void main() {
     await seed.record('alpha.pdf', doc(1));
 
     await tester.pumpWidget(ViewerApp(cacheStore: backend));
-    await tester.pump();
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load async; settle
+    // so the localized app (and its post-frame demo open) builds.
+    await tester.pumpAndSettle();
 
     await openRecentsSubmenu(tester);
     await tester.tap(find.text('Clear recent files'));
@@ -126,7 +132,9 @@ void main() {
       (tester) async {
     SharedPreferences.setMockInitialValues({});
     await tester.pumpWidget(ViewerApp(cacheStore: PdfMemoryCacheStore()));
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load async; settle
+    // so the localized app builds before opening the menu.
+    await tester.pumpAndSettle();
 
     await openAppMenu(tester);
     expect(find.text('Open Recent'), findsOneWidget);

--- a/packages/dart_pdf_editor/example/test/tabs_test.dart
+++ b/packages/dart_pdf_editor/example/test/tabs_test.dart
@@ -9,7 +9,9 @@ void main() {
     // the mock store is process-global: start every test from defaults
     SharedPreferences.setMockInitialValues({});
     await tester.pumpWidget(const ViewerApp());
-    await tester.pump();
+    // use-deferred-loading makes the localizations delegate load async; settle
+    // so the localized app (and its post-frame demo open) builds.
+    await tester.pumpAndSettle();
   }
 
   // each open document carries one 'Close tab' button in the strip

--- a/packages/dart_pdf_editor/l10n.yaml
+++ b/packages/dart_pdf_editor/l10n.yaml
@@ -2,3 +2,9 @@ arb-dir: lib/l10n
 template-arb-file: dart_pdf_editor_en.arb
 output-localization-file: dart_pdf_editor_localizations.dart
 output-class: DartPdfEditorLocalizations
+# On Flutter web, load each locale as a deferred import so a host only
+# downloads the JS chunk for the active locale instead of every bundled
+# language (no effect on mobile/desktop AOT - see doc/i18n.md for trimming
+# native builds). The English fallback in src/l10n/pdf_l10n.dart imports the
+# _en class directly, so English stays eager and always available.
+use-deferred-loading: true

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
-import 'dart_pdf_editor_localizations_en.dart';
+import 'dart_pdf_editor_localizations_en.dart'
+    deferred as dart_pdf_editor_localizations_en;
 
 // ignore_for_file: type=lint
 
@@ -2760,8 +2760,7 @@ class _DartPdfEditorLocalizationsDelegate
 
   @override
   Future<DartPdfEditorLocalizations> load(Locale locale) {
-    return SynchronousFuture<DartPdfEditorLocalizations>(
-        lookupDartPdfEditorLocalizations(locale));
+    return lookupDartPdfEditorLocalizations(locale);
   }
 
   @override
@@ -2772,11 +2771,13 @@ class _DartPdfEditorLocalizationsDelegate
   bool shouldReload(_DartPdfEditorLocalizationsDelegate old) => false;
 }
 
-DartPdfEditorLocalizations lookupDartPdfEditorLocalizations(Locale locale) {
+Future<DartPdfEditorLocalizations> lookupDartPdfEditorLocalizations(
+    Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
     case 'en':
-      return DartPdfEditorLocalizationsEn();
+      return dart_pdf_editor_localizations_en.loadLibrary().then((dynamic _) =>
+          dart_pdf_editor_localizations_en.DartPdfEditorLocalizationsEn());
   }
 
   throw FlutterError(

--- a/tool/trim_locales.sh
+++ b/tool/trim_locales.sh
@@ -48,7 +48,9 @@ BUNDLES=(
 
 readonly TEMPLATE_LOCALE="en"
 
-usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
+# Print the leading comment block (everything after the shebang up to the
+# first non-comment line), with the '# ' prefix stripped.
+usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; }
 
 # Locale embedded in a "<prefix>_<locale>.<ext>" basename.
 locale_of() { # <basename> <prefix>
@@ -88,9 +90,6 @@ trim() { # <keep-locale>...
     local arbdir="$ROOT/$dir/lib/l10n"
     local stash removed=()
     stash="$(mktemp -d)"
-    # A trap per bundle guarantees the ARBs come back even on failure.
-    # shellcheck disable=SC2064
-    trap "mv \"$stash\"/*.arb \"$arbdir\"/ 2>/dev/null || true; rmdir \"$stash\" 2>/dev/null || true" RETURN
 
     # Move locales we are NOT keeping out of the arb-dir so gen-l10n omits them.
     for f in "$arbdir/${arb_prefix}"_*.arb; do
@@ -102,12 +101,17 @@ trim() { # <keep-locale>...
       esac
     done
 
-    ( cd "$ROOT/$dir" && $FLUTTER gen-l10n >/dev/null )
-
-    # Restore the ARBs (source of truth stays intact) ...
+    # Regenerate for the kept subset, then ALWAYS restore the stashed ARBs -
+    # even if gen-l10n fails - so the source tree is never left short a
+    # language. ( ... ) || rc=$? keeps `set -e` from exiting before we restore.
+    local rc=0
+    ( cd "$ROOT/$dir" && $FLUTTER gen-l10n >/dev/null ) || rc=$?
     mv "$stash"/*.arb "$arbdir"/ 2>/dev/null || true
     rmdir "$stash" 2>/dev/null || true
-    trap - RETURN
+    if [ "$rc" -ne 0 ]; then
+      echo "gen-l10n failed in $dir (rc=$rc); ARBs restored, aborting." >&2
+      exit "$rc"
+    fi
 
     # ... then drop the now-orphaned generated locale classes gen-l10n left
     # behind (it regenerates the delegate but never deletes stale outputs).

--- a/tool/trim_locales.sh
+++ b/tool/trim_locales.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Trim the localization bundles to a chosen set of locales so a release build
+# compiles only those languages instead of every bundled one.
+#
+#   tool/trim_locales.sh <locale> [<locale> ...]   # keep only these (+ en)
+#   tool/trim_locales.sh --restore                 # put the full set back
+#   tool/trim_locales.sh --list                    # show bundled locales
+#
+# Why: a Flutter dependency that ships its own LocalizationsDelegate compiles
+# ALL its locales into the app - the host's `supportedLocales` only affects
+# runtime resolution, not what the AOT snapshot bundles. On web,
+# `use-deferred-loading` (already set in each l10n.yaml) means only the active
+# locale's JS chunk downloads, so trimming is optional there. On mobile/desktop
+# AOT there is no such split, so this script is the lever for native size:
+# regenerate the checked-in gen-l10n output for just the locales you ship.
+#
+# Workflow for a release:
+#   tool/trim_locales.sh en es fr de     # keep English + Spanish/French/German
+#   fvm flutter build <target> ...        # build with only those compiled in
+#   tool/trim_locales.sh --restore        # regenerate the full set (or: git
+#                                          # checkout the lib/l10n dirs)
+#
+# English (the template locale) is always kept - it is the fallback that the
+# pdfL10n()/appL10n() wrappers construct directly. The script never deletes an
+# .arb file; it only regenerates the produced Dart, so `--restore` (or a plain
+# `flutter gen-l10n`) always brings every language back.
+#
+# See doc/i18n.md for the full picture, including the host-merge alternative
+# for external apps that consume the published package.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+
+FLUTTER=flutter
+if command -v fvm >/dev/null 2>&1; then
+  FLUTTER="fvm flutter"
+fi
+
+# Each localization bundle: "<dir>|<arb-prefix>|<generated-prefix>".
+# arb files are  <arb-prefix>_<locale>.arb  and gen-l10n emits
+# <generated-prefix>.dart (the delegate) + <generated-prefix>_<locale>.dart.
+BUNDLES=(
+  "packages/dart_pdf_editor|dart_pdf_editor|dart_pdf_editor_localizations"
+  "app|app|app_localizations"
+  "packages/dart_pdf_editor/example|app|app_localizations"
+)
+
+readonly TEMPLATE_LOCALE="en"
+
+usage() { sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'; }
+
+# Locale embedded in a "<prefix>_<locale>.<ext>" basename.
+locale_of() { # <basename> <prefix>
+  local base="$1" prefix="$2"
+  base="${base%.*}"          # strip extension
+  echo "${base#${prefix}_}"  # strip "<prefix>_"
+}
+
+list_locales() {
+  for entry in "${BUNDLES[@]}"; do
+    IFS='|' read -r dir arb_prefix _gen <<<"$entry"
+    local arbdir="$ROOT/$dir/lib/l10n" locs=()
+    for f in "$arbdir/${arb_prefix}"_*.arb; do
+      [ -e "$f" ] || continue
+      locs+=("$(locale_of "$(basename "$f")" "$arb_prefix")")
+    done
+    printf '%s: %s\n' "$dir" "${locs[*]:-(none)}"
+  done
+}
+
+regenerate_all() { # --restore: rebuild every bundle from all its ARBs
+  for entry in "${BUNDLES[@]}"; do
+    IFS='|' read -r dir _arb _gen <<<"$entry"
+    echo "restoring $dir ..."
+    ( cd "$ROOT/$dir" && $FLUTTER gen-l10n >/dev/null )
+  done
+  echo "Full locale set regenerated."
+}
+
+trim() { # <keep-locale>...
+  local keep=(" $TEMPLATE_LOCALE ")
+  for l in "$@"; do keep+=(" $l "); done
+  local keepstr="${keep[*]}"
+
+  for entry in "${BUNDLES[@]}"; do
+    IFS='|' read -r dir arb_prefix gen_prefix <<<"$entry"
+    local arbdir="$ROOT/$dir/lib/l10n"
+    local stash removed=()
+    stash="$(mktemp -d)"
+    # A trap per bundle guarantees the ARBs come back even on failure.
+    # shellcheck disable=SC2064
+    trap "mv \"$stash\"/*.arb \"$arbdir\"/ 2>/dev/null || true; rmdir \"$stash\" 2>/dev/null || true" RETURN
+
+    # Move locales we are NOT keeping out of the arb-dir so gen-l10n omits them.
+    for f in "$arbdir/${arb_prefix}"_*.arb; do
+      [ -e "$f" ] || continue
+      local loc; loc="$(locale_of "$(basename "$f")" "$arb_prefix")"
+      case "$keepstr" in
+        *" $loc "*) : ;;                    # keep
+        *) mv "$f" "$stash/"; removed+=("$loc") ;;
+      esac
+    done
+
+    ( cd "$ROOT/$dir" && $FLUTTER gen-l10n >/dev/null )
+
+    # Restore the ARBs (source of truth stays intact) ...
+    mv "$stash"/*.arb "$arbdir"/ 2>/dev/null || true
+    rmdir "$stash" 2>/dev/null || true
+    trap - RETURN
+
+    # ... then drop the now-orphaned generated locale classes gen-l10n left
+    # behind (it regenerates the delegate but never deletes stale outputs).
+    for f in "$arbdir/${gen_prefix}"_*.dart; do
+      [ -e "$f" ] || continue
+      local loc; loc="$(locale_of "$(basename "$f")" "$gen_prefix")"
+      case "$keepstr" in
+        *" $loc "*) : ;;
+        *) rm -f "$f" ;;
+      esac
+    done
+
+    local kept_shown; kept_shown="$(echo "$keepstr" | xargs -n1 | awk '!seen[$0]++' | xargs)"
+    printf '%s: kept [%s]' "$dir" "$kept_shown"
+    [ ${#removed[@]} -gt 0 ] && printf ' - removed [%s]' "${removed[*]}"
+    printf '\n'
+  done
+
+  echo
+  echo "Generated output trimmed. Build now, then 'tool/trim_locales.sh"
+  echo "--restore' (or 'git checkout' the lib/l10n dirs) to put them back."
+}
+
+case "${1:-}" in
+  ""|-h|--help) usage; exit 0 ;;
+  --list) list_locales; exit 0 ;;
+  --restore) regenerate_all; exit 0 ;;
+  -*) echo "unknown option: $1" >&2; usage; exit 2 ;;
+  *) trim "$@" ;;
+esac


### PR DESCRIPTION
## Summary

Give hosts a way to ship only the languages they want instead of every bundled locale — settled before the tier-1/2 translations land. A Flutter dependency that ships its own `LocalizationsDelegate` compiles **all** its locales into the app; the host's `supportedLocales` only affects runtime resolution, and Flutter has no built-in way for a dependency's bundle to follow the parent app's locale list. This PR adds the two levers plus documentation.

- **Web — deferred loading**: `use-deferred-loading: true` in all three `l10n.yaml` (`dart_pdf_editor`, `app`, `example`). On Flutter web each locale becomes a lazily-loaded JS chunk, so a browser downloads only the active locale. English stays eager — the `pdfL10n`/`appL10n` fallback wrappers import the `_en` class directly.
- **Native — `tool/trim_locales.sh`**: the AOT lever. Regenerates the checked-in gen-l10n output for a chosen locale subset (English always kept) for a release build, then `--restore`. `--list` shows bundled locales. It never deletes an `.arb`, so the full set always comes back. Verified end-to-end against a synthetic locale.
- **`doc/i18n.md`**: how lookups/fallback/delegates work, adding strings and languages, and the size controls — web deferred, the prune tool, and the host-merge alternative for external apps that consume the published package.

**Tradeoff (deliberate, Ben's call):** deferred loading makes the localizations delegate load **asynchronously on every platform**. On web that's the win. On native it gives no size benefit and adds a one-frame delay before localized UI paints — `trim_locales.sh` is the native size lever. It also means a widget test that boots a localized app must **settle the async delegate load**, so 5 tests were updated (details below).

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only

(Also the shipping app `app/` / `dart_pdf_editor_app`, which has no checklist entry, and the new `tool/trim_locales.sh`.)

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [x] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (ran `dart analyze --fatal-infos`, matching CI — clean across the workspace)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [x] Example app smoke test (example `flutter test` suite)

If any relevant check was not run, explain why: config + tooling + docs change with no engine/render impact, so the `pdf_cos`/`pdf_document`/`pdf_graphics` suites and corpus/Ghent render checks aren't relevant. `dart_pdf_editor` (+1820), `app` (251), and `example` (54) suites are green. The single `ghent_render_test.dart` `GWG030_Gray_K_black_OP_X1.pdf` baseline failure is **pre-existing** (fails identically on the base commit, a spot-color render diff unrelated to i18n).

## PDF fixtures and screenshots

None — no rendering or fixture changes.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`. (App/example already depend on Flutter.)
- [x] No `dart:io` imports in any `lib/` directory. (`tool/trim_locales.sh` is a shell script, not `lib/`.)
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output. (Unchanged.)
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required. (Unchanged.)
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets. (No fixture changes.)

## Notes for reviewers

- **Test changes from async delegate load** (5 files): `WidgetsApp` doesn't build the app subtree until the now-deferred delegate resolves, so tests asserting on the first frame need to settle it. `app/test/widget_test.dart` and `example/test/{tabs,recent_files_menu}_test.dart` use `pumpAndSettle`; `example/test/{demo,editing}_test.dart` can't (the opened demo's clock overlay runs a periodic timer that never settles), so their `openDemo` pumps a bounded number of frames until the demo `PdfViewer` appears. Package tests are unaffected — they exercise the English fallback (no registered delegate).
- **Reverting deferred loading** is a one-line change: delete `use-deferred-loading` from the `l10n.yaml` files and regenerate — the wrappers and everything else are unchanged by it.
- Design rationale and the verification of `trim_locales.sh` against a synthetic locale are in `doc/dev-log/2026-07-22-i18n-locale-sizing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7M8aGAzjnXGqrJ2X98fqy

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7M8aGAzjnXGqrJ2X98fqy)_