### PR TITLE
Signature pad: predictive ink + a touch more width

### DIFF
--- a/doc/dev-log/2026-07-22-signature-pad-prediction-width.md
+++ b/doc/dev-log/2026-07-22-signature-pad-prediction-width.md
@@ -1,0 +1,31 @@
+# Signature pad: predictive ink + a touch more width
+
+The signature-capture pad (`PdfSignatureDialog`, `editing_signature.dart`)
+drew its in-progress stroke with the ink appearance's Catmull-Rom smoothing
+and pressure-mapped width, but - unlike the ink tool's live layer
+(`_ActiveStrokePainter` in `editing_overlay.dart`) - it never applied the
+forward-extrapolated lead from `pdfPredictStrokeLead`
+(`stroke_prediction.dart`). So the pad line lagged the pen tip by the input
++ render latency the ink tool already masks.
+
+Fix: the pad now runs the same prediction on the active stroke. New
+`_activeDisplay` getter appends the display-only lead (and carries the last
+pressure onto it) to the in-progress stroke, recomputed every build so the
+next real sample replaces it and the lead never enters the captured
+`PdfInkSignature`. Gated by a new `predictStrokes` flag on
+`PdfSignatureDialog` / `showPdfSignatureDialog` (default true), mirroring
+`PdfViewer.predictStrokes`. It's a standalone dialog, so the flag defaults
+on rather than threading the viewer's value through every caller.
+
+Also nudged the pen a touch heavier, per the request:
+- pad preview `_baseWidth` 2.5 -> 3.0 (dialog only)
+- placed/stamped ink width `w / 75` -> `w / 60` in
+  `PdfEditingController.signaturePlacement` (~2.7pt at the default 160pt
+  width, was ~2pt) - this is what `placeSignature` commits into the
+  `/InkList` annotation.
+
+Tests: `editing_signature_prediction_test.dart` renders the pad, draws a
+stylus stroke, and asserts inked pixels reach past the last real sample
+with `predictStrokes: true` and stop at it with `false` - the pad analogue
+of `editing_prediction_test.dart`. Existing signature tests unchanged
+(none pinned the width value).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -2752,7 +2752,7 @@ class PdfEditingController extends ChangeNotifier {
       pressures: signature.pressures,
       // follow the selected toolbar colour, like every other tool
       color: _colorValue,
-      strokeWidth: w / 75, // pen-like: ~2pt at the default width
+      strokeWidth: w / 60, // pen-like: ~2.7pt at the default width
     );
   }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
@@ -6,6 +6,7 @@ import 'package:pdf_document/pdf_document.dart'
     show pdfInkCurveControls, pdfInkStrokeWidth;
 
 import '../l10n/pdf_l10n.dart';
+import 'stroke_prediction.dart';
 
 /// A hand-drawn signature, stored device-side and stamped onto pages as
 /// an Ink annotation ([PdfEditingController.placeSignature]).
@@ -109,18 +110,27 @@ class PdfInkSignature {
 }
 
 /// Shows the signature pad dialog; resolves to the drawn signature, or
-/// null on cancel.
-Future<PdfInkSignature?> showPdfSignatureDialog(BuildContext context) =>
+/// null on cancel. [predictStrokes] forward-extrapolates the in-progress
+/// stroke to mask input latency, exactly like the ink tool (see
+/// [PdfViewer.predictStrokes]); display only, never committed.
+Future<PdfInkSignature?> showPdfSignatureDialog(BuildContext context,
+        {bool predictStrokes = true}) =>
     showDialog<PdfInkSignature>(
       context: context,
-      builder: (context) => const PdfSignatureDialog(),
+      builder: (context) => PdfSignatureDialog(predictStrokes: predictStrokes),
     );
 
 /// A dialog with a drawing pad for capturing a signature: draw with
 /// mouse, finger, or stylus (pressure is recorded and rendered as
 /// variable width, like the ink tool), pick an ink color, clear, done.
 class PdfSignatureDialog extends StatefulWidget {
-  const PdfSignatureDialog({super.key});
+  const PdfSignatureDialog({super.key, this.predictStrokes = true});
+
+  /// Forward-extrapolates a short speculative lead beyond the pen tip on
+  /// the in-progress stroke, the same predictive ink the ink tool uses
+  /// ([PdfViewer.predictStrokes]). Display only - the lead is redrawn each
+  /// frame and never enters the captured signature.
+  final bool predictStrokes;
 
   @override
   State<PdfSignatureDialog> createState() => _PdfSignatureDialogState();
@@ -177,8 +187,31 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
     });
   }
 
+  /// The in-progress stroke with a display-only predicted lead appended
+  /// (and its last pressure carried onto the lead), recomputed each build
+  /// so the next real sample replaces it - the pad's analogue of the ink
+  /// tool's live prediction. Null when no stroke is active.
+  ({List<Offset> points, List<double>? pressures})? get _activeDisplay {
+    final active = _active;
+    if (active == null) return null;
+    var pressures = _activePressures;
+    if (widget.predictStrokes) {
+      final lead =
+          pdfPredictStrokeLead([for (final p in active) (p.dx, p.dy)]);
+      if (lead.isNotEmpty) {
+        final points = [...active, for (final (x, y) in lead) Offset(x, y)];
+        if (pressures != null) {
+          pressures = [...pressures, for (final _ in lead) pressures.last];
+        }
+        return (points: points, pressures: pressures);
+      }
+    }
+    return (points: active, pressures: pressures);
+  }
+
   @override
   Widget build(BuildContext context) {
+    final activeDisplay = _activeDisplay;
     return AlertDialog(
       title: Text(pdfL10n(context).sigTitle),
       content: Column(
@@ -209,10 +242,13 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
                     key: const ValueKey('pdf-signature-pad'),
                     size: const Size(360, 180),
                     painter: _SignaturePadPainter(
-                      strokes: [..._strokes, if (_active != null) _active!],
+                      strokes: [
+                        ..._strokes,
+                        if (activeDisplay != null) activeDisplay.points
+                      ],
                       pressures: [
                         ..._pressures,
-                        if (_active != null) _activePressures
+                        if (activeDisplay != null) activeDisplay.pressures
                       ],
                       color: _ink,
                     ),
@@ -288,7 +324,7 @@ class _SignaturePadPainter extends CustomPainter {
   final List<List<double>?> pressures;
   final Color color;
 
-  static const _baseWidth = 2.5;
+  static const _baseWidth = 3.0;
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/packages/dart_pdf_editor/test/editing_signature_prediction_test.dart
+++ b/packages/dart_pdf_editor/test/editing_signature_prediction_test.dart
@@ -1,0 +1,79 @@
+// The signature pad draws the same forward-extrapolated lead the ink tool
+// uses (stroke_prediction.dart), so the drawn line keeps up with the pen
+// tip. These tests prove the lead reaches pixels on the pad and that
+// predictStrokes:false turns it off. The pure geometry is covered by
+// stroke_prediction_test; the ink-tool wiring by editing_prediction_test.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+void main() {
+  Future<void> pumpPad(WidgetTester tester, GlobalKey boundary,
+      {required bool predict}) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: RepaintBoundary(
+          key: boundary,
+          child: PdfSignatureDialog(predictStrokes: predict),
+        ),
+      ),
+    ));
+    await tester.pump();
+  }
+
+  // Draws a short horizontal stylus stroke on the pad, holds it, and reports
+  // whether a dark (ink over white paper) pixel sits `beyond` px past the
+  // last sample along the stroke's line.
+  Future<bool> inkedBeyondLastSample(WidgetTester tester, GlobalKey boundary,
+      {required double beyond}) async {
+    final pad = find.byKey(const ValueKey('pdf-signature-pad'));
+    final topLeft = tester.getTopLeft(pad);
+    final start = topLeft + const Offset(60, 90);
+    final g = await tester.startGesture(start, kind: PointerDeviceKind.stylus);
+    var last = start;
+    for (var i = 0; i < 4; i++) {
+      last += const Offset(30, 0);
+      await g.moveTo(last);
+    }
+    await tester.pump();
+
+    final image = await tester.runAsync(() async {
+      final render =
+          boundary.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+      return render.toImage();
+    });
+    final data = (await tester.runAsync(image!.toByteData))!;
+    // pad-local -> repaint-boundary pixels (boundary is at 0,0 here)
+    final x = (last.dx + beyond).round();
+    var sawInk = false;
+    for (var dy = -4; dy <= 4 && !sawInk; dy++) {
+      final y = last.dy.round() + dy;
+      final i = (y * image.width + x) * 4;
+      // black ink over white paper: all channels drop; paper stays ~255.
+      sawInk = data.getUint8(i) < 140 && data.getUint8(i + 1) < 140;
+    }
+    await g.up();
+    await tester.pump();
+    image.dispose();
+    return sawInk;
+  }
+
+  testWidgets('the predicted lead inks past the last real sample on the pad',
+      (tester) async {
+    final boundary = GlobalKey();
+    await pumpPad(tester, boundary, predict: true);
+    // 12px beyond the last sample is within the lead (~0.9 of a 30px
+    // segment) but well past the unpredicted round cap (~1.5px).
+    expect(await inkedBeyondLastSample(tester, boundary, beyond: 12), isTrue);
+  });
+
+  testWidgets('predictStrokes:false leaves the pad line at the last sample',
+      (tester) async {
+    final boundary = GlobalKey();
+    await pumpPad(tester, boundary, predict: false);
+    expect(await inkedBeyondLastSample(tester, boundary, beyond: 12), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary

The signature-capture pad (`PdfSignatureDialog`) drew its in-progress stroke with the committed ink appearance's Catmull-Rom smoothing and pressure-mapped width, but — unlike the ink tool's live layer (`_ActiveStrokePainter`) — it never applied the forward-extrapolated lead from `pdfPredictStrokeLead`. So the pad line lagged the pen tip by the input+render latency the ink tool already masks.

This PR makes the signature pad use the **same predictive ink as the Ink annotation**, and nudges the pen a touch heavier per the request.

- Pad now runs `pdfPredictStrokeLead` on the active stroke via a new `_activeDisplay` getter: the display-only lead (with the last pressure carried onto it) is appended to the in-progress stroke, recomputed every build so the next real sample replaces it and it never enters the captured `PdfInkSignature`.
- New `predictStrokes` flag on `PdfSignatureDialog` / `showPdfSignatureDialog` (default `true`, mirroring `PdfViewer.predictStrokes`). Default-on because the dialog is standalone rather than threaded from the viewer.
- Width nudged up a touch: pad preview `_baseWidth` 2.5 → 3.0 (dialog only), and the placed/stamped ink width `w / 75` → `w / 60` in `PdfEditingController.signaturePlacement` (~2.7pt at the default 160pt width, was ~2pt) — this is what `placeSignature` commits into the `/InkList`.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (signature + prediction suites)

Ran the signature and prediction test suites plus `dart analyze` on the editor lib and new test — all green. Did not run the corpus/Ghent/example-app checks: this change is confined to the signature-capture dialog and one editor stroke-width constant, with no parser, renderer, or PDF-output impact.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

New test `editing_signature_prediction_test.dart` renders the pad, draws a stylus stroke, and asserts inked pixels reach past the last real sample with `predictStrokes: true` and stop at it with `false` — the pad analogue of `editing_prediction_test.dart`. Existing signature tests are unchanged (none pinned the width value). Dev-log note added under `doc/dev-log/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgVFx5iFVQ8ZqafWRPii9g)_