### PR TITLE
Show grab cursor on Windows via move-cursor fallback

### DIFF
--- a/doc/dev-log/2026-07-22-grab-cursor-windows.md
+++ b/doc/dev-log/2026-07-22-grab-cursor-windows.md
@@ -1,0 +1,39 @@
+# 2026-07-22 - Grab cursor invisible on Windows
+
+## Symptom
+
+On Windows the "drag here to pan" affordance was invisible: hovering the
+document (or an off-page area) showed a plain arrow instead of the open-hand
+grab cursor, and starting a grab-pan didn't switch to the closed-hand grabbing
+cursor either. macOS, Linux, and the web all showed it correctly.
+
+## Cause
+
+Flutter's Windows embedder maps `MouseCursor`s to Win32 `IDC_*` handles, and
+there is no native handle for the open-/closed-hand grab cursors. Any
+`SystemMouseCursors.grab` / `grabbing` therefore falls back to the default
+`IDC_ARROW`, so nothing on the page hinted that a drag would pan. The other
+targets render grab natively - macOS (open/closed hand), GTK/Linux, and CSS
+`grab`/`grabbing` on the web - which is why the bug was Windows-only.
+
+## Fix
+
+Added `lib/src/platform_cursors.dart` with `grabCursor` / `grabbingCursor`
+getters. They return the real `SystemMouseCursors.grab` / `grabbing` everywhere
+except Windows, where they substitute `SystemMouseCursors.move` (the four-way
+`IDC_SIZEALL` arrows) - a supported cursor that reads as "drag to pan". Web is
+excluded from the substitution via `kIsWeb` since the browser renders grab
+natively regardless of the reported platform.
+
+Routed every grab-cursor site through the helper:
+
+- `pdf_viewer.dart` - the hover cursor over a pannable page / off-page area
+  (`_onHover`), the grabbing cursor while a mouse grab-pan is in progress, and
+  the grab cursor restored when the drag ends.
+- `editing_overlay.dart` - the grab cursor shown over a polygon vertex handle
+  in select mode.
+
+Existing widget tests assert `SystemMouseCursors.grab` under the default test
+platform (Android), so they keep passing unchanged. New coverage in
+`test/platform_cursors_test.dart` pins the Windows substitution and the native
+cursor on every other platform.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -13,6 +13,7 @@ import 'package:pdf_document/pdf_document.dart';
 import '../debug_overlays.dart';
 import '../l10n/pdf_l10n.dart';
 import '../page_geometry.dart';
+import '../platform_cursors.dart';
 import '../renderer.dart';
 import '../theme.dart';
 import 'editing_color_pick.dart';
@@ -4154,7 +4155,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   _rotatePoint(
                       event.localPosition, chrome.$1.center, -resting));
       if (vertex != null) {
-        cursor = SystemMouseCursors.grab;
+        cursor = grabCursor;
       } else if (handle != null) {
         cursor = _resizeCursorFor(handle);
       } else if (chrome != null &&

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -32,6 +32,7 @@ import 'page_geometry.dart';
 import 'page_object_cache.dart';
 import 'perf_log.dart';
 import 'performance_policy.dart';
+import 'platform_cursors.dart';
 import 'pdf_page_view.dart';
 import 'preview_cache.dart';
 import 'raster_cache.dart';
@@ -3814,12 +3815,12 @@ class _PdfViewerState extends State<PdfViewer>
       } else if (_hoverTextCursorAt(event.localPosition, at: at)) {
         cursor = SystemMouseCursors.text;
       } else {
-        cursor = SystemMouseCursors.grab;
+        cursor = grabCursor;
       }
     } else {
       // Off any page. Every probe above resolves through _pagePointAt, so
       // none of them could have matched: a mouse drag here grab-pans.
-      cursor = SystemMouseCursors.grab;
+      cursor = grabCursor;
     }
     if (cursor != _hoverCursor) setState(() => _hoverCursor = cursor);
   }
@@ -4175,7 +4176,7 @@ class _PdfViewerState extends State<PdfViewer>
       // instead (mouse drags don't reach the list's scrollable)
       _grabPanning = true;
       _beginMotionRenderHold();
-      setState(() => _hoverCursor = SystemMouseCursors.grabbing);
+      setState(() => _hoverCursor = grabbingCursor);
       _controller._setSelection('');
       return;
     }
@@ -4261,7 +4262,7 @@ class _PdfViewerState extends State<PdfViewer>
     if (!_grabPanning) return;
     _grabPanning = false;
     _scheduleMotionRenderHoldRelease();
-    setState(() => _hoverCursor = SystemMouseCursors.grab);
+    setState(() => _hoverCursor = grabCursor);
   }
 
   /// Word granularity: spans from the anchor word through the word

--- a/packages/dart_pdf_editor/lib/src/platform_cursors.dart
+++ b/packages/dart_pdf_editor/lib/src/platform_cursors.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:flutter/widgets.dart' show MouseCursor, SystemMouseCursors;
+
+/// Windows' Flutter embedder maps mouse cursors to Win32 `IDC_*` handles, and
+/// there is no native handle for the open-/closed-hand grab cursors. Any
+/// [SystemMouseCursors.grab] or [SystemMouseCursors.grabbing] therefore falls
+/// back to the plain arrow, so the "drag here to pan" affordance is invisible
+/// on Windows. Substitute the four-way move cursor (`IDC_SIZEALL`) there, which
+/// reads as "drag to pan". Every other target renders grab natively - macOS
+/// (open/closed hand), GTK/Linux, and CSS `grab`/`grabbing` on the web - so
+/// they keep the real cursor.
+bool get _grabCursorUnsupported =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.windows;
+
+/// [SystemMouseCursors.grab], or a visible stand-in on platforms that don't
+/// render it (see [_grabCursorUnsupported]).
+MouseCursor get grabCursor =>
+    _grabCursorUnsupported ? SystemMouseCursors.move : SystemMouseCursors.grab;
+
+/// [SystemMouseCursors.grabbing], or a visible stand-in on platforms that don't
+/// render it (see [_grabCursorUnsupported]).
+MouseCursor get grabbingCursor => _grabCursorUnsupported
+    ? SystemMouseCursors.move
+    : SystemMouseCursors.grabbing;

--- a/packages/dart_pdf_editor/test/platform_cursors_test.dart
+++ b/packages/dart_pdf_editor/test/platform_cursors_test.dart
@@ -1,0 +1,33 @@
+// The grab/grabbing cursors have no native Win32 handle, so Flutter's Windows
+// embedder falls them back to the plain arrow - the "drag to pan" affordance
+// vanishes. platform_cursors substitutes the four-way move cursor there and
+// keeps the real grab cursor everywhere else.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/src/platform_cursors.dart';
+
+void main() {
+  tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+  test('Windows substitutes the move cursor for grab/grabbing', () {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    expect(grabCursor, SystemMouseCursors.move);
+    expect(grabbingCursor, SystemMouseCursors.move);
+  });
+
+  for (final platform in const [
+    TargetPlatform.macOS,
+    TargetPlatform.linux,
+    TargetPlatform.android,
+    TargetPlatform.iOS,
+    TargetPlatform.fuchsia,
+  ]) {
+    test('$platform renders the native grab/grabbing cursor', () {
+      debugDefaultTargetPlatformOverride = platform;
+      expect(grabCursor, SystemMouseCursors.grab);
+      expect(grabbingCursor, SystemMouseCursors.grabbing);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

On Windows the "drag here to pan" affordance was invisible: hovering the document (or an off-page area) showed a plain arrow instead of the open-hand grab cursor, and starting a grab-pan never switched to the closed-hand grabbing cursor. macOS, Linux, and the web rendered it correctly.

Flutter's Windows embedder maps cursors to Win32 `IDC_*` handles and has no native handle for the open-/closed-hand grab cursors, so `SystemMouseCursors.grab` / `grabbing` fall back to the default arrow there.

The fix adds `lib/src/platform_cursors.dart` with `grabCursor` / `grabbingCursor` getters. They return the native grab cursor everywhere except Windows, where they substitute `SystemMouseCursors.move` (the four-way `IDC_SIZEALL` arrows) — a supported cursor that reads as "drag to pan". Web is excluded from the substitution via `kIsWeb`, since the browser renders grab natively. Every grab-cursor site in `pdf_viewer.dart` (hover, grab-pan start, grab-pan end) and the polygon vertex-handle cursor in `editing_overlay.dart` now route through the helper.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (new `platform_cursors_test.dart` + existing `editing_cursor_test.dart` / `hover_text_warm_test.dart`)

Ran only the cursor-related suites, since the change is scoped to the mouse-cursor mapping. New `test/platform_cursors_test.dart` pins the Windows substitution and the native cursor on every other platform; existing cursor tests run under the default test platform (Android) and pass unchanged.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.

## Notes for reviewers

`SystemMouseCursors.move` is the closest supported Win32 stand-in for grab-panning; there is no open-hand cursor available on the Windows embedder. Design rationale is recorded in `doc/dev-log/2026-07-22-grab-cursor-windows.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017bMSgxyHWBJMcy3e3pYWjc)_