### PR TITLE
fix(app): grant macOS sandbox access for non-.pdf Finder opens

### DIFF
--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -46,6 +46,32 @@
 				<string>com.adobe.pdf</string>
 			</array>
 		</dict>
+		<!--
+		  Generic-file fallback so the sandbox grants file access when the user
+		  explicitly picks DartPDF via "Open With" for a file that doesn't
+		  resolve to the com.adobe.pdf UTI - e.g. a PDF delivered without a
+		  .pdf extension (document-management/engineering exports) or with an
+		  unrecognised dynamic UTI. A sandboxed app only receives the implicit
+		  security-scoped grant for a Finder-opened file when the file's type
+		  matches one of its declared CFBundleDocumentTypes; without this entry
+		  such a file is refused with "does not have permission to open".
+		  LSHandlerRank "None" means we never advertise as a handler or become a
+		  default for arbitrary files - the grant is issued only on an explicit
+		  user "Open With".
+		-->
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Any file</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>None</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.data</string>
+				<string>public.content</string>
+			</array>
+		</dict>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>

--- a/doc/dev-log/2026-07-22-macos-finder-open-permission.md
+++ b/doc/dev-log/2026-07-22-macos-finder-open-permission.md
@@ -1,0 +1,48 @@
+# macOS "does not have permission to open" via Finder
+
+Opening a file with the app from Finder ("Open With" / double-click /
+drag onto the dock icon) could fail before the app ever saw the file, with
+the system dialog:
+
+> The application "DartPDF" does not have permission to open "CH458 Leeor Loop".
+
+## Root cause
+
+DartPDF's macOS runner is sandboxed (`com.apple.security.app-sandbox`).
+For a sandboxed app, the entitlement `files.user-selected.read-write` only
+covers files chosen through the app's own open/save panels (Powerbox). A
+file the app is *launched to open by Finder* is instead granted an implicit
+security-scoped sandbox extension by LaunchServices - **but only when the
+file's UTI matches one of the app's declared `CFBundleDocumentTypes`.**
+
+The app declared exactly one document type, `com.adobe.pdf`. That works for
+a file whose type resolves to the PDF UTI (normally via a `.pdf`
+extension). It does **not** cover a PDF delivered without a `.pdf`
+extension or with an unrecognised dynamic UTI - common for files exported
+from document-management / engineering systems (the reporting file,
+"CH458 Leeor Loop", is a signalling drawing). Such a file resolves to
+`public.data` (or a `dyn.*` UTI), which the app didn't declare, so
+LaunchServices refused to issue the grant and Finder showed the
+permission error. Nothing in the Swift runner (`AppDelegate.application(_:
+open:)` → `deliver` → `payload`) is reached in that case.
+
+## Fix
+
+`app/macos/Runner/Info.plist`: add a second `CFBundleDocumentTypes` entry
+declaring the generic base types `public.data` + `public.content` with
+`CFBundleTypeRole` `Viewer` and, crucially, `LSHandlerRank` `None`.
+
+`LSHandlerRank None` means the app is never advertised as a handler and
+never becomes the default for arbitrary files - so this does **not** put
+DartPDF in every file's "Open With" list. It only tells LaunchServices
+that the app *can* be assigned to any file, which is enough for the sandbox
+to issue the security-scoped grant when the user explicitly force-opens a
+file with DartPDF. The existing `com.adobe.pdf` / `Alternate` entry is
+unchanged, so genuine `.pdf` files keep offering DartPDF as an alternate
+handler with the PDF document icon.
+
+Scope: macOS only (the reported failure is Finder-specific). The
+`packages/dart_pdf_editor/example` runner declares no document types, so it
+is unaffected. The runner's file-read path already degrades gracefully -
+`payload(for:)` still returns `path`/`bookmark` when byte reading fails -
+so the Dart `IncomingFileService` fallback is unchanged.


### PR DESCRIPTION
## Summary

Fixes the macOS Finder error when opening certain files with the app:

> The application "DartPDF" does not have permission to open "CH458 Leeor Loop".

DartPDF's macOS runner is sandboxed. A sandboxed app only receives the implicit security-scoped grant for a file opened via Finder ("Open With" / double-click / drag onto the dock icon) when the file's UTI matches one of its declared `CFBundleDocumentTypes`. The runner declared only `com.adobe.pdf`, so a PDF delivered **without a `.pdf` extension** (common for document-management / engineering exports — the reporting file is a signalling drawing) resolves to `public.data` / a `dyn.*` UTI. LaunchServices then refuses to issue the grant and Finder shows the permission error *before the app ever sees the file* — `AppDelegate.application(_:open:)` is never reached.

The fix adds a second `CFBundleDocumentTypes` entry declaring the generic base types `public.data` + `public.content` with `LSHandlerRank` **`None`**. `None` means DartPDF is never advertised as a handler and never becomes the default for arbitrary files — it does *not* appear in every file's "Open With" list — but it lets LaunchServices issue the sandbox grant when the user explicitly force-opens a file with the app. The existing `com.adobe.pdf` / `Alternate` entry is unchanged, so genuine `.pdf` files keep offering DartPDF as an alternate handler with the document icon.

Config-only change to the `/app` macOS runner; no Dart or library code touched. The runner's read path already degrades gracefully (`payload(for:)` still returns `path`/`bookmark` when byte reading fails), so the Dart `IncomingFileService` flow is unchanged. Rationale captured in `doc/dev-log/2026-07-22-macos-finder-open-permission.md`.

## Affected packages

- [x] Documentation / CI / repository metadata only

_Scope is the `/app` macOS runner `Info.plist` (native app metadata) plus a dev-log note — no package library code. The `packages/dart_pdf_editor/example` runner declares no document types and is unaffected._

## Change type

- [x] Bug fix

## Validation

- [ ] `fvm flutter pub get`
- [ ] `fvm dart analyze`
- [ ] test suites
- [ ] Example app smoke test

No Dart/library code changed, so the Dart analyzer and test suites are not relevant to this diff. `Info.plist` was validated as a well-formed property list with `plistlib` and both document-type entries parse as expected. The macOS build / real Finder "Open With" round-trip needs Xcode and a signed sandboxed build, which isn't available in this environment — worth a manual smoke test (force-open an extensionless PDF via **Open With → DartPDF**) before release.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.

## Notes for reviewers

- `LSHandlerRank None` is the intentional choice over `Alternate`/`Default`: it enables the explicit-open sandbox grant without polluting the "Open With" menu for non-PDF files or competing to become a default handler.
- Change is macOS-only because the reported failure is Finder-specific. iOS uses a different document-access model (`LSSupportsOpeningDocumentsInPlace` / Files provider) and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc4eEHWujUF1DxKotyMsvc)_