### PR TITLE
Add right-click context menu to the tabs preview grid

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -1424,7 +1424,15 @@ class _EditorScreenState extends State<EditorScreen>
   /// Opens the right-click context menu for the tab at [index] at [position]
   /// (global coordinates), offering Close / Close others / Close to the right /
   /// Close all. Entries that would close nothing are disabled.
-  Future<void> _showTabMenu(int index, Offset position) async {
+  ///
+  /// [onChanged] runs after the chosen action resolves; the tabs-grid overlay
+  /// passes it to refresh (or dismiss itself once the last tab is gone), since
+  /// the modal grid does not rebuild off the screen's own [setState].
+  Future<void> _showTabMenu(
+    int index,
+    Offset position, {
+    VoidCallback? onChanged,
+  }) async {
     final tab = _tabs[index];
     final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
     final selected = await showMenu<_TabMenuAction>(
@@ -1494,6 +1502,7 @@ class _EditorScreenState extends State<EditorScreen>
       case _TabMenuAction.closeAll:
         await _closeTabs(List.of(_tabs));
     }
+    onChanged?.call();
   }
 
   Future<bool> _confirmDiscard(String message) async {
@@ -2586,6 +2595,17 @@ class _EditorScreenState extends State<EditorScreen>
             itemBuilder: (context, index) {
               final tab = _tabs[index];
               final selected = index == _activeIndex;
+              // Refresh the modal grid after a mutation (or dismiss it once no
+              // tabs remain); it does not rebuild off the screen's setState.
+              void refreshOverlay() {
+                if (!mounted || !overlayContext.mounted) return;
+                if (_tabs.isEmpty) {
+                  Navigator.of(overlayContext).pop();
+                } else {
+                  setOverlayState(() {});
+                }
+              }
+
               return _MobileTabTile(
                 key: ValueKey('$keyPrefix-tab-${tab.hashCode}'),
                 tab: tab,
@@ -2596,12 +2616,15 @@ class _EditorScreenState extends State<EditorScreen>
                 },
                 onClose: () async {
                   await _closeTabs([tab]);
-                  if (!mounted || !overlayContext.mounted) return;
-                  if (_tabs.isEmpty) {
-                    Navigator.of(overlayContext).pop();
-                  } else {
-                    setOverlayState(() {});
-                  }
+                  refreshOverlay();
+                },
+                onContextMenu: (position) {
+                  // Re-resolve by identity: the grid can reorder under us.
+                  final i = _tabs.indexOf(tab);
+                  if (i < 0) return;
+                  unawaited(
+                    _showTabMenu(i, position, onChanged: refreshOverlay),
+                  );
                 },
               );
             },
@@ -3254,12 +3277,17 @@ class _MobileTabTile extends StatelessWidget {
     required this.selected,
     required this.onTap,
     required this.onClose,
+    this.onContextMenu,
   });
 
   final DocumentTab tab;
   final bool selected;
   final VoidCallback onTap;
   final VoidCallback onClose;
+
+  /// Opens the tab's context menu at the given global position (right-click on
+  /// desktop, long-press on touch). Null disables the affordance.
+  final void Function(Offset globalPosition)? onContextMenu;
 
   @override
   Widget build(BuildContext context) {
@@ -3286,6 +3314,18 @@ class _MobileTabTile extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
+        onSecondaryTapUp: onContextMenu == null
+            ? null
+            : (details) => onContextMenu!(details.globalPosition),
+        onLongPress: onContextMenu == null
+            ? null
+            : () {
+                // InkWell's long-press carries no position, so anchor the menu
+                // at the tile's centre (touch parity for the right-click menu).
+                final box = context.findRenderObject() as RenderBox?;
+                if (box == null || !box.hasSize) return;
+                onContextMenu!(box.localToGlobal(box.size.center(Offset.zero)));
+              },
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -82,6 +82,33 @@ void main() {
     await openTab(tester, 'gamma.pdf');
   }
 
+  // Opens the desktop tabs preview grid (grid_view button in the tab strip).
+  Future<void> openTabsGrid(WidgetTester tester) async {
+    await tester.tap(find.byKey(const ValueKey('desktop-tabs-button')));
+    await tester.pumpAndSettle();
+  }
+
+  // The grid tile whose title is [name] (scoped to the preview grid).
+  Finder gridTile(String name) => find.ancestor(
+        of: find.descendant(
+          of: find.byKey(const ValueKey('desktop-tabs-grid')),
+          matching: find.text(name),
+        ),
+        matching: find.byKey(const ValueKey('mobile-tab-tile')),
+      );
+
+  // Right-clicks the grid tile labelled [name] to open its context menu.
+  Future<void> rightClickGridTile(WidgetTester tester, String name) async {
+    final gesture = await tester.startGesture(
+      tester.getCenter(gridTile(name)),
+      kind: PointerDeviceKind.mouse,
+      buttons: kSecondaryButton,
+    );
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
   testWidgets('incoming file shows an opening indicator', (tester) async {
     await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
     await tester.pump();
@@ -300,6 +327,53 @@ void main() {
     expect(find.byKey(const ValueKey('tab-menu-close-others')), findsOneWidget);
     expect(find.byKey(const ValueKey('tab-menu-close-right')), findsOneWidget);
     expect(find.byKey(const ValueKey('tab-menu-close-all')), findsOneWidget);
+  });
+
+  testWidgets('right-click on a grid tile opens the tab context menu',
+      (tester) async {
+    await openTabs(tester);
+    await openTabsGrid(tester);
+
+    await rightClickGridTile(tester, 'beta.pdf');
+
+    expect(find.byKey(const ValueKey('tab-menu-close')), findsOneWidget);
+    expect(find.byKey(const ValueKey('tab-menu-close-others')), findsOneWidget);
+    expect(find.byKey(const ValueKey('tab-menu-close-right')), findsOneWidget);
+    expect(find.byKey(const ValueKey('tab-menu-close-all')), findsOneWidget);
+  });
+
+  testWidgets('grid tile Close others leaves only the clicked tab, grid open',
+      (tester) async {
+    await openTabs(tester);
+    await openTabsGrid(tester);
+
+    await rightClickGridTile(tester, 'beta.pdf');
+    await tester.tap(find.byKey(const ValueKey('tab-menu-close-others')));
+    await tester.pumpAndSettle();
+
+    // The grid stays open and refreshes to the single surviving tab.
+    expect(find.byKey(const ValueKey('desktop-tabs-grid')), findsOneWidget);
+    expect(gridTile('beta.pdf'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('desktop-tabs-grid')),
+        matching: find.byKey(const ValueKey('mobile-tab-tile')),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('grid tile Close all empties the grid and dismisses the dialog',
+      (tester) async {
+    await openTabs(tester);
+    await openTabsGrid(tester);
+
+    await rightClickGridTile(tester, 'alpha.pdf');
+    await tester.tap(find.byKey(const ValueKey('tab-menu-close-all')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('desktop-tabs-dialog')), findsNothing);
+    expect(find.byKey(const ValueKey('tab-strip')), findsNothing);
   });
 
   testWidgets(

--- a/doc/dev-log/2026-07-22-tab-grid-context-menu.md
+++ b/doc/dev-log/2026-07-22-tab-grid-context-menu.md
@@ -1,0 +1,39 @@
+# 2026-07-22 - Right-click context menu for the tabs grid view
+
+The desktop tab strip already had a right-click context menu
+(`EditorScreen._showTabMenu`: Open in Finder / Close / Close others /
+Close to the right / Close all). The tabs **preview grid** - the tile grid
+shown in the desktop "view all tabs" dialog (`desktop-tabs-grid`) and the
+mobile tabs bottom sheet (`mobile-tabs-grid`), both built by
+`_buildTabsGrid` from `_MobileTabTile` - only supported tap-to-activate and
+the per-tile close button. This adds the same context menu to the grid.
+
+## What changed (`app/lib/editor_screen.dart`)
+
+- `_MobileTabTile` gained an optional
+  `onContextMenu(Offset globalPosition)` callback. It fires from the tile's
+  `InkWell.onSecondaryTapUp` (right-click, carries the pointer position) and
+  from `InkWell.onLongPress` for touch parity - long-press has no position,
+  so we anchor the menu at the tile's centre via
+  `context.findRenderObject()`/`localToGlobal`. Null (the default) leaves the
+  tile as it was, so no other caller changes behaviour.
+- `_buildTabsGrid` wires `onContextMenu` to the existing `_showTabMenu`,
+  re-resolving the tab index by identity first (the grid can reorder).
+- `_showTabMenu` took an optional `onChanged` callback, run after the chosen
+  action resolves. The grid passes a `refreshOverlay` closure (extracted from
+  the tile's existing `onClose` path) so the modal grid rebuilds after a close
+  action, or dismisses itself once the last tab is gone - the modal grid does
+  not rebuild off the screen's own `setState`. The tab-strip call site omits
+  it, so its behaviour is unchanged.
+
+Reusing `_showTabMenu` means the grid menu is automatically consistent with
+the strip: same items, same enable/disable rules (Close others needs >1 tab,
+Close to the right disabled on the last tab), same "Open in Finder" gating on
+`supportsOpenContainingFolder && tab.originPath != null`.
+
+## Tests (`app/test/tabs_menu_test.dart`)
+
+Added `openTabsGrid`/`gridTile`/`rightClickGridTile` helpers and three cases:
+right-click on a grid tile opens the menu; "Close others" from the grid leaves
+one tile with the grid still open; "Close all" empties the grid and dismisses
+the dialog.


### PR DESCRIPTION
## Summary

The desktop tab strip already offered a right-click context menu (Close / Close others / Close to the right / Close all, plus "Open in Finder" for file-backed tabs). The **tabs preview grid** — the desktop "view all tabs" dialog (`desktop-tabs-grid`) and the mobile tabs bottom sheet (`mobile-tabs-grid`) — only supported tap-to-activate and the per-tile close button.

This wires the same context menu onto the grid tiles:

- `_MobileTabTile` gains an optional `onContextMenu(Offset globalPosition)` callback, fired from `InkWell.onSecondaryTapUp` (right-click, carries the pointer position) and from `InkWell.onLongPress` for touch parity (anchored at the tile centre, since long-press carries no position).
- `_buildTabsGrid` routes it to the existing `_showTabMenu`, re-resolving the tab by identity first (the grid can reorder).
- `_showTabMenu` gains an optional `onChanged` callback so the modal grid refreshes after a close action, or dismisses itself once the last tab is gone. The tab-strip call site omits it, so its behaviour is unchanged.

Reusing `_showTabMenu` keeps the grid menu automatically consistent with the strip: same items, same enable/disable rules, same "Open in Finder" gating.

## Affected packages

- [x] Example app

(Change lives entirely in `app/lib/editor_screen.dart`, the example/host app.)

## Change type

- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran `app`'s `tabs_menu_test.dart` — 17 tests pass, including 3 new grid-menu cases)

## PDF fixtures and screenshots

No new fixtures — tests reuse the programmatic `buildClassicPdf` fixture and drive the menu via widget-test gestures.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The grid menu shares `_showTabMenu` with the tab strip, so items, enable/disable rules, and the "Open in Finder" gating stay in one place. Touch long-press support was added alongside right-click since the preview grid is also the mobile tabs surface. Dev-log note: `doc/dev-log/2026-07-22-tab-grid-context-menu.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01575R7aBWp8vo3RC4G2uzZc)_