### PR TITLE
feat(editor): group large context menus with dividers

### DIFF
--- a/doc/dev-log/2026-07-22-context-menu-dividers.md
+++ b/doc/dev-log/2026-07-22-context-menu-dividers.md
@@ -1,0 +1,44 @@
+# 2026-07-22 — Dividers for large context menus
+
+The annotation and form-field context menus (`editing_menu.dart`) had
+grown long enough to read as one undifferentiated column: on a plain
+rectangle the annotation menu is copy / cut / apply-to-pages / paste /
+bring-to-front / send-to-back / delete, and a polygon or a pasted vector
+snapshot adds node editing and recolour on top of that. Nothing ruled the
+clusters apart, so users scanned the whole list every time.
+
+## What changed
+
+Both stock menus now build their entries as **groups** and hand them to a
+shared `_menuRowsWithDividers(List<List<PdfAnnotationMenuItem>>)`, which:
+
+- drops empty groups, and
+- inserts a single `PopupMenuDivider` between the groups that survive.
+
+Annotation menu groups, in order: **clipboard** (copy/cut/apply-to-pages/
+paste) · **arrange** (bring-to-front/send-to-back) · **nodes** (add/remove
+vertex) · **recolour** · **delete** · then the host's `customActions`.
+Form-field menu groups: **edit** (edit value + text style) · **structure**
+(rename + convert-to-{text,checkbox,button}) · **destructive**
+(delete-field + flatten-form).
+
+Because empty groups draw no divider, a small menu still reads tight:
+
+- a **paste-only** menu (empty-area right-click with a clipboard) is one
+  group → **no** dividers;
+- a **plain rectangle** is clipboard | arrange | delete → **two** dividers;
+- a **text form field** is edit | structure | destructive → **two**.
+
+The host `customActions` divider that already existed falls out of the same
+mechanism (custom is just the last non-empty group), so
+`PdfAnnotationMenuBuilder`'s "divider before the custom ones" contract is
+unchanged — it's now one code path instead of a special case.
+
+## Tests
+
+`editing_menu_test.dart` gained divider-count assertions for the plain
+rectangle, the paste-only menu, and (via a direct `showPdfFormFieldMenu`
+pump) a text form field. The existing "host actions ride below a divider"
+test was updated from `findsOneWidget` to the grouped count. No menu-item
+keys moved, so the longpress / clipboard / iPad / form suites were
+unaffected.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_menu.dart
@@ -105,7 +105,12 @@ Future<void> showPdfAnnotationMenu({
   final canPaste = canPasteSnapshot || controller.hasAnnotationClipboard;
   final hasSelection = request.annotations.isNotEmpty;
   if (!hasSelection && !canPaste) return;
-  final stock = <PdfAnnotationMenuItem>[
+
+  // The stock entries are grouped so [_menuRowsWithDividers] can rule off
+  // each cluster: clipboard, z-order arrange, node editing, recolour, then
+  // the destructive delete. Empty groups drop out and no divider is drawn
+  // for them, so a small selection still reads as a tight menu.
+  final clipboard = <PdfAnnotationMenuItem>[
     if (hasSelection) ...[
       PdfAnnotationMenuItem(
         key: const ValueKey('pdf-annot-menu-copy'),
@@ -151,6 +156,8 @@ Future<void> showPdfAnnotationMenu({
           ? request.controller.pasteSnapshot(pageIndex, at: pagePoint)
           : request.controller.pasteAnnotations(pageIndex, at: pagePoint),
     ),
+  ];
+  final arrange = <PdfAnnotationMenuItem>[
     if (hasSelection) ...[
       PdfAnnotationMenuItem(
         key: const ValueKey('pdf-annot-menu-front'),
@@ -166,44 +173,54 @@ Future<void> showPdfAnnotationMenu({
         enabled: controller.canSendSelectedToBack,
         onSelected: (request) => request.controller.sendSelectedToBack(),
       ),
-      // A right-click on a /PolyLine or /Polygon can grow or drop a vertex
-      // at the click point. Needs the page point the menu opened on; the
-      // selection-chip "More" path (no point) hides these.
-      if (pagePoint != null && controller.canAddSelectedVertex) ...[
-        PdfAnnotationMenuItem(
-          key: const ValueKey('pdf-annot-menu-add-node'),
-          label: pdfL10n(context).menuAddNode,
-          icon: Icons.add_location_alt_outlined,
-          onSelected: (request) =>
-              request.controller.addSelectedVertexAt(pagePoint),
-        ),
-        PdfAnnotationMenuItem(
-          key: const ValueKey('pdf-annot-menu-remove-node'),
-          label: pdfL10n(context).menuRemoveNode,
-          icon: Icons.wrong_location_outlined,
-          enabled: controller.canRemoveSelectedVertex,
-          onSelected: (request) =>
-              request.controller.removeSelectedVertexNear(pagePoint),
-        ),
-      ],
-      if (controller.canRecolorSnapshotSelected)
-        PdfAnnotationMenuItem(
-          key: const ValueKey('pdf-annot-menu-recolor-snapshot'),
-          label: pdfL10n(context).menuRecolour,
-          icon: Icons.palette_outlined,
-          onSelected: (request) async {
-            final picked = await showPdfColorPicker(
-              context,
-              initial: request.controller.color,
-              initialFormat: request.controller.preferences.colorPickerFormat,
-              onFormatChanged: (format) =>
-                  request.controller.preferences.colorPickerFormat = format,
-            );
-            if (picked != null) {
-              request.controller.recolorSnapshotSelected(picked);
-            }
-          },
-        ),
+    ],
+  ];
+  final nodes = <PdfAnnotationMenuItem>[
+    // A right-click on a /PolyLine or /Polygon can grow or drop a vertex
+    // at the click point. Needs the page point the menu opened on; the
+    // selection-chip "More" path (no point) hides these.
+    if (hasSelection &&
+        pagePoint != null &&
+        controller.canAddSelectedVertex) ...[
+      PdfAnnotationMenuItem(
+        key: const ValueKey('pdf-annot-menu-add-node'),
+        label: pdfL10n(context).menuAddNode,
+        icon: Icons.add_location_alt_outlined,
+        onSelected: (request) =>
+            request.controller.addSelectedVertexAt(pagePoint),
+      ),
+      PdfAnnotationMenuItem(
+        key: const ValueKey('pdf-annot-menu-remove-node'),
+        label: pdfL10n(context).menuRemoveNode,
+        icon: Icons.wrong_location_outlined,
+        enabled: controller.canRemoveSelectedVertex,
+        onSelected: (request) =>
+            request.controller.removeSelectedVertexNear(pagePoint),
+      ),
+    ],
+  ];
+  final recolor = <PdfAnnotationMenuItem>[
+    if (hasSelection && controller.canRecolorSnapshotSelected)
+      PdfAnnotationMenuItem(
+        key: const ValueKey('pdf-annot-menu-recolor-snapshot'),
+        label: pdfL10n(context).menuRecolour,
+        icon: Icons.palette_outlined,
+        onSelected: (request) async {
+          final picked = await showPdfColorPicker(
+            context,
+            initial: request.controller.color,
+            initialFormat: request.controller.preferences.colorPickerFormat,
+            onFormatChanged: (format) =>
+                request.controller.preferences.colorPickerFormat = format,
+          );
+          if (picked != null) {
+            request.controller.recolorSnapshotSelected(picked);
+          }
+        },
+      ),
+  ];
+  final destructive = <PdfAnnotationMenuItem>[
+    if (hasSelection)
       PdfAnnotationMenuItem(
         key: const ValueKey('pdf-annot-menu-delete'),
         label: pdfL10n(context).delete,
@@ -211,7 +228,6 @@ Future<void> showPdfAnnotationMenu({
         enabled: true,
         onSelected: (request) => request.controller.deleteSelected(),
       ),
-    ],
   ];
   final custom =
       customActions?.call(context, request) ?? const <PdfAnnotationMenuItem>[];
@@ -221,11 +237,8 @@ Future<void> showPdfAnnotationMenu({
     context: context,
     position:
         RelativeRect.fromRect(position & Size.zero, Offset.zero & overlay.size),
-    items: [
-      for (final item in stock) _menuRow(item),
-      if (custom.isNotEmpty) const PopupMenuDivider(),
-      for (final item in custom) _menuRow(item),
-    ],
+    items: _menuRowsWithDividers(
+        [clipboard, arrange, nodes, recolor, destructive, custom]),
   );
   await picked?.onSelected(request);
 }
@@ -264,7 +277,8 @@ Future<void> showPdfFormFieldMenu({
           enabled: enabled,
           onSelected: (_) async {
             final value = await textPrompt(context,
-                title: pdfL10n(context).menuFieldValue, initial: field.value ?? '');
+                title: pdfL10n(context).menuFieldValue,
+                initial: field.value ?? '');
             if (value != null) controller.setFormFieldText(fieldName, value);
           },
         );
@@ -342,7 +356,9 @@ Future<void> showPdfFormFieldMenu({
     }
   }
 
-  final items = <PdfAnnotationMenuItem>[
+  // Grouped so [_menuRowsWithDividers] rules off value edits, the
+  // rename/convert structure changes, and the destructive delete/flatten.
+  final edit = <PdfAnnotationMenuItem>[
     if (editItem() case final item?) item,
     if (type == PdfFieldType.text)
       PdfAnnotationMenuItem(
@@ -360,6 +376,8 @@ Future<void> showPdfFormFieldMenu({
           );
         },
       ),
+  ];
+  final structure = <PdfAnnotationMenuItem>[
     PdfAnnotationMenuItem(
       key: const ValueKey('pdf-form-menu-rename'),
       label: pdfL10n(context).menuRename,
@@ -397,6 +415,8 @@ Future<void> showPdfFormFieldMenu({
       onSelected: (_) => controller.changeFormFieldKind(
           fieldName, PdfFormFieldKind.pushButton),
     ),
+  ];
+  final destructive = <PdfAnnotationMenuItem>[
     PdfAnnotationMenuItem(
       key: const ValueKey('pdf-form-menu-delete'),
       label: pdfL10n(context).menuDeleteField,
@@ -416,11 +436,28 @@ Future<void> showPdfFormFieldMenu({
     context: context,
     position:
         RelativeRect.fromRect(position & Size.zero, Offset.zero & overlay.size),
-    items: [for (final item in items) _menuRow(item)],
+    items: _menuRowsWithDividers([edit, structure, destructive]),
   );
   // the request param is unused by these closures; reuse the row type
   // so the menu plumbing stays shared with the annotation menu
   await picked?.onSelected(PdfAnnotationMenuRequest._(controller, -1));
+}
+
+/// Flattens [groups] of menu items into popup entries, dropping empty
+/// groups and ruling a [PopupMenuDivider] between the ones that survive.
+/// Large menus read as labelled clusters; a menu that collapses to a
+/// single group draws no divider at all.
+List<PopupMenuEntry<PdfAnnotationMenuItem>> _menuRowsWithDividers(
+    List<List<PdfAnnotationMenuItem>> groups) {
+  final entries = <PopupMenuEntry<PdfAnnotationMenuItem>>[];
+  for (final group in groups) {
+    if (group.isEmpty) continue;
+    if (entries.isNotEmpty) entries.add(const PopupMenuDivider());
+    for (final item in group) {
+      entries.add(_menuRow(item));
+    }
+  }
+  return entries;
 }
 
 PopupMenuItem<PdfAnnotationMenuItem> _menuRow(PdfAnnotationMenuItem item) =>

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -321,8 +321,7 @@ void main() {
 
       await tester.tap(find.byKey(const ValueKey('pdf-annot-menu-add-node')));
       await tester.pumpAndSettle();
-      expect(
-          editing.document.page(0).annotations.last.vertices, hasLength(5));
+      expect(editing.document.page(0).annotations.last.vertices, hasLength(5));
     });
 
     testWidgets('Remove node from the menu drops the nearest vertex',
@@ -347,8 +346,8 @@ void main() {
       await pumpViewer(tester);
 
       await rightClick(tester, viewPoint(110, 725)); // rectangle A
-      expect(find.byKey(const ValueKey('pdf-annot-menu-add-node')),
-          findsNothing);
+      expect(
+          find.byKey(const ValueKey('pdf-annot-menu-add-node')), findsNothing);
       expect(find.byKey(const ValueKey('pdf-annot-menu-remove-node')),
           findsNothing);
     });
@@ -369,7 +368,9 @@ void main() {
       );
 
       await rightClick(tester, viewPoint(110, 725));
-      expect(find.byType(PopupMenuDivider), findsOneWidget);
+      // stock entries are grouped (clipboard | arrange | delete) and the
+      // host action rides in its own group below the last divider
+      expect(find.byType(PopupMenuDivider), findsNWidgets(3));
       expect(find.text('Bring to front'), findsOneWidget);
 
       await tester.tap(find.byKey(const ValueKey('host-copy-comment')));
@@ -388,6 +389,69 @@ void main() {
       await rightClick(tester, viewPoint(450, 400));
       expect(find.text('Bring to front'), findsNothing);
       expect(editing.hasAnnotationSelection, isFalse);
+    });
+
+    testWidgets('a plain rectangle menu rules off clipboard, arrange, delete',
+        (tester) async {
+      await pumpViewer(tester);
+
+      await rightClick(tester, viewPoint(110, 725)); // rectangle A
+      // clipboard (copy/cut/apply/paste) | arrange (front/back) | delete
+      expect(find.byType(PopupMenuDivider), findsNWidgets(2));
+    });
+
+    testWidgets('a paste-only menu draws no dividers', (tester) async {
+      final editing = await pumpViewer(tester);
+      editing
+        ..selectAnnotation(0, 0)
+        ..copySelectedAnnotations()
+        ..clearAnnotationSelection();
+      await tester.pump();
+
+      // empty-area right-click with a clipboard: the lone Paste group has
+      // nothing to be ruled off from
+      await rightClick(tester, viewPoint(450, 400));
+      expect(
+          find.byKey(const ValueKey('pdf-annot-menu-paste')), findsOneWidget);
+      expect(find.byType(PopupMenuDivider), findsNothing);
+    });
+  });
+
+  group('form field menu', () {
+    Future<PdfEditingController> openMenu(
+        WidgetTester tester, String fieldName) async {
+      final editing = PdfEditingController(buildAcroFormPdf());
+      addTearDown(editing.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () => showPdfFormFieldMenu(
+                  context: context,
+                  position: const Offset(200, 200),
+                  controller: editing,
+                  fieldName: fieldName,
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      return editing;
+    }
+
+    testWidgets('a text field rules off edit, structure, and delete',
+        (tester) async {
+      await openMenu(tester, 'name');
+      expect(find.byKey(const ValueKey('pdf-form-menu-rename')), findsOneWidget);
+      expect(
+          find.byKey(const ValueKey('pdf-form-menu-flatten')), findsOneWidget);
+      // edit (value + style) | rename/convert | delete/flatten
+      expect(find.byType(PopupMenuDivider), findsNWidgets(2));
     });
   });
 


### PR DESCRIPTION
## Summary

The annotation and form-field context menus (`editing_menu.dart`) had grown into one long, undifferentiated column of items. On a plain rectangle the annotation menu is copy / cut / apply-to-pages / paste / bring-to-front / send-to-back / delete, and a polygon or a pasted vector snapshot piles node editing and recolour on top of that — nothing ruled the clusters apart.

Both stock menus now build their entries as **logical groups** and hand them to a shared `_menuRowsWithDividers` helper, which drops empty groups and rules a single `PopupMenuDivider` between the ones that survive:

- **Annotation menu:** clipboard (copy/cut/apply-to-pages/paste) · arrange (front/back) · nodes (add/remove vertex) · recolour · delete · host `customActions`.
- **Form-field menu:** edit (edit value + text style) · structure (rename + convert-to-{text,checkbox,button}) · destructive (delete field + flatten form).

Because empty groups draw no divider, small menus stay tight: a paste-only menu (empty-area right-click with a clipboard) draws **no** dividers, a plain rectangle draws **two**, a text form field draws **two**. No menu-item keys moved, and the existing "divider before host `customActions`" behavior now falls out of the same mechanism (custom is just the last non-empty group) instead of being a special case.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Ran `dart analyze` (no issues) and the editor's menu/clipboard/longpress/form/iPad test suites (all pass). Non-editor package tests and corpus/example smoke tests were not run — this change is scoped to `dart_pdf_editor` context-menu presentation only.

## PDF fixtures and screenshots

No new fixtures; the form-menu test reuses the programmatic `buildAcroFormPdf()` fixture.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

The grouping is purely presentational — item order, keys, labels, and `onSelected` behavior are unchanged. Divider-count assertions were added to `editing_menu_test.dart` (plain rectangle, paste-only menu, and a text form field via a direct `showPdfFormFieldMenu` pump), and the existing "host actions ride below a divider" test was updated from a single-divider count to the grouped count. Dev-log note in `doc/dev-log/2026-07-22-context-menu-dividers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBKTehTq4YBjN8nojAZRQH)_