### PR TITLE
feat(editor): group and search the keyboard-shortcuts editor

### DIFF
--- a/doc/dev-log/2026-07-22-shortcuts-group-search.md
+++ b/doc/dev-log/2026-07-22-shortcuts-group-search.md
@@ -1,0 +1,47 @@
+# Grouped, searchable keyboard-shortcuts editor
+
+The keyboard-shortcuts editor (Settings → Keyboard shortcuts…) listed every
+tool in one flat, insertion-ordered `ListView`. With ~18 bindings that reads
+as an undifferentiated wall. This groups the list by tool category and adds a
+search box to filter it.
+
+## What
+
+- **Grouping.** The sheet now renders a section header per tool category and
+  the tools under it, in the same order the toolbar dock reads
+  (Select → Draw → Shapes → Insert → Measure → Edit). Headers are keyed
+  `pdf-shell-shortcut-group-<group>`.
+- **Search.** A `TextField` (`pdf-shell-shortcuts-search`,
+  `shellShortcutsSearchHint`) filters tools by display name *or* by their
+  bound key label (so typing `r` finds the rectangle tool as well as
+  anything named with an "r"). An empty result shows a centred
+  `shellShortcutsNoMatches` message (`pdf-shell-shortcuts-no-matches`);
+  headers for groups with no surviving tool are dropped.
+
+## Where / why
+
+- `PdfEditToolGroup` **moved** from `editing_toolbar.dart` to
+  `editing/tool_shortcuts.dart`, joined by a new
+  `pdfEditToolGroupOf(PdfEditTool)`. `tool_shortcuts.dart` is the low-level
+  file both `editing_toolbar.dart` and `shell_chrome.dart` already import, so
+  this keeps the mapping in one place without an import cycle (the toolbar
+  imports the shortcuts lib, not vice-versa). Both files are exported from
+  `dart_pdf_editor.dart`, so `PdfEditToolGroup`'s public identity is
+  unchanged. `pdfEditToolGroupOf` is an **exhaustive** switch over
+  `PdfEditTool` — a new tool won't compile until it's assigned a group, so it
+  can't silently drop out of the sheet.
+- `shell_chrome.dart` — `showPdfShellShortcutsSheet` gained the search field,
+  the `byGroup` bucketing, and `_shortcutGroupLabel(context, group)` mapping
+  each group to its localized header. The uncontrolled search `TextField`
+  keeps its text across `setSheetState` rebuilds (its own `EditableText`
+  state), so no `TextEditingController` to dispose in a transient sheet.
+- The lazy `ListView` only builds on-screen children, so the grouping test
+  scrolls the lower `insert` header into view rather than asserting it built
+  eagerly.
+
+## l10n
+
+New keys in `dart_pdf_editor_en.arb` (regenerated with `flutter gen-l10n`):
+`shellShortcutsSearchHint`, `shellShortcutsNoMatches` (one `{query}`
+placeholder), and `shellShortcutGroup{Select,Markup,Draw,Shapes,Insert,
+Measure,Edit}`.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- The keyboard-shortcuts editor (Settings → Keyboard shortcuts…) now groups
+  tools under tool-category headers (Select, Draw, Shapes, Insert, Measure,
+  Edit) and adds a search box that filters by tool name or bound key. New
+  public `pdfEditToolGroupOf(PdfEditTool)`; `PdfEditToolGroup` moved to the
+  `tool_shortcuts` library (still exported, so no import change for callers).
+
 - **Breaking:** the six bundled editor fonts and the web render worker moved out
   of this package into the optional
   [`dart_pdf_editor_assets`](../dart_pdf_editor_assets) package, so viewer-only

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -961,6 +961,47 @@
   "@shellKeyboardShortcutsTitle": {
     "description": "Header of the keyboard shortcuts editor bottom sheet."
   },
+  "shellShortcutsSearchHint": "Search shortcuts",
+  "@shellShortcutsSearchHint": {
+    "description": "Placeholder text in the search field of the keyboard shortcuts editor."
+  },
+  "shellShortcutsNoMatches": "No shortcuts match “{query}”",
+  "@shellShortcutsNoMatches": {
+    "description": "Message shown when a keyboard-shortcuts search matches no tools.",
+    "placeholders": {
+      "query": {
+        "type": "String"
+      }
+    }
+  },
+  "shellShortcutGroupSelect": "Select",
+  "@shellShortcutGroupSelect": {
+    "description": "Section header for the Select tool group in the keyboard shortcuts editor."
+  },
+  "shellShortcutGroupMarkup": "Markup",
+  "@shellShortcutGroupMarkup": {
+    "description": "Section header for the Markup tool group in the keyboard shortcuts editor."
+  },
+  "shellShortcutGroupDraw": "Draw",
+  "@shellShortcutGroupDraw": {
+    "description": "Section header for the Draw tool group in the keyboard shortcuts editor."
+  },
+  "shellShortcutGroupShapes": "Shapes",
+  "@shellShortcutGroupShapes": {
+    "description": "Section header for the Shapes tool group in the keyboard shortcuts editor."
+  },
+  "shellShortcutGroupInsert": "Insert",
+  "@shellShortcutGroupInsert": {
+    "description": "Section header for the Insert tool group in the keyboard shortcuts editor."
+  },
+  "shellShortcutGroupMeasure": "Measure",
+  "@shellShortcutGroupMeasure": {
+    "description": "Section header for the Measure tool group in the keyboard shortcuts editor."
+  },
+  "shellShortcutGroupEdit": "Edit",
+  "@shellShortcutGroupEdit": {
+    "description": "Section header for the Edit tool group in the keyboard shortcuts editor."
+  },
   "shellNotSet": "Not set",
   "@shellNotSet": {
     "description": "Subtitle shown for the default author when no author name is configured."

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -1391,6 +1391,60 @@ abstract class DartPdfEditorLocalizations {
   /// **'Keyboard shortcuts'**
   String get shellKeyboardShortcutsTitle;
 
+  /// Placeholder text in the search field of the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Search shortcuts'**
+  String get shellShortcutsSearchHint;
+
+  /// Message shown when a keyboard-shortcuts search matches no tools.
+  ///
+  /// In en, this message translates to:
+  /// **'No shortcuts match “{query}”'**
+  String shellShortcutsNoMatches(String query);
+
+  /// Section header for the Select tool group in the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Select'**
+  String get shellShortcutGroupSelect;
+
+  /// Section header for the Markup tool group in the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Markup'**
+  String get shellShortcutGroupMarkup;
+
+  /// Section header for the Draw tool group in the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Draw'**
+  String get shellShortcutGroupDraw;
+
+  /// Section header for the Shapes tool group in the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Shapes'**
+  String get shellShortcutGroupShapes;
+
+  /// Section header for the Insert tool group in the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Insert'**
+  String get shellShortcutGroupInsert;
+
+  /// Section header for the Measure tool group in the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure'**
+  String get shellShortcutGroupMeasure;
+
+  /// Section header for the Edit tool group in the keyboard shortcuts editor.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit'**
+  String get shellShortcutGroupEdit;
+
   /// Subtitle shown for the default author when no author name is configured.
   ///
   /// In en, this message translates to:

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -738,6 +738,35 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get shellKeyboardShortcutsTitle => 'Keyboard shortcuts';
 
   @override
+  String get shellShortcutsSearchHint => 'Search shortcuts';
+
+  @override
+  String shellShortcutsNoMatches(String query) {
+    return 'No shortcuts match “$query”';
+  }
+
+  @override
+  String get shellShortcutGroupSelect => 'Select';
+
+  @override
+  String get shellShortcutGroupMarkup => 'Markup';
+
+  @override
+  String get shellShortcutGroupDraw => 'Draw';
+
+  @override
+  String get shellShortcutGroupShapes => 'Shapes';
+
+  @override
+  String get shellShortcutGroupInsert => 'Insert';
+
+  @override
+  String get shellShortcutGroupMeasure => 'Measure';
+
+  @override
+  String get shellShortcutGroupEdit => 'Edit';
+
+  @override
   String get shellNotSet => 'Not set';
 
   @override

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -41,36 +41,6 @@ typedef PdfEditingToolbarWidgetBuilder = Widget Function(
   PdfViewerController viewerController,
 );
 
-/// A tool *type* - one dock group in [PdfEditingToolbar]. Pass a subset
-/// to [PdfEditingToolbar.groups] (or [PdfEditorFeatures.toolGroups]) to
-/// hide whole groups: e.g. `{PdfEditToolGroup.select,
-/// PdfEditToolGroup.markup}` shows only the Select and Markup groups.
-///
-/// This is the coarse axis. The finer [PdfEditingToolbar.tools] hides
-/// individual tools *within* the groups that survive this filter.
-enum PdfEditToolGroup {
-  /// Select / move / resize existing annotations.
-  select,
-
-  /// Text-markup actions (highlight, underline, strike out, squiggly).
-  markup,
-
-  /// Freehand drawing, freehand highlight, and the ink eraser.
-  draw,
-
-  /// Rectangle, ellipse, line, arrow, polyline, polygon.
-  shapes,
-
-  /// Text box, note, stamp, image, signature.
-  insert,
-
-  /// Distance, perimeter and area measurement.
-  measure,
-
-  /// Page content, form fields and redaction.
-  edit,
-}
-
 /// A ready-made toolbar for [PdfEditingController].
 ///
 /// The bar is organised as a **dock** of tool *groups* - Select, Markup,

--- a/packages/dart_pdf_editor/lib/src/editing/tool_shortcuts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/tool_shortcuts.dart
@@ -2,6 +2,85 @@ import 'package:flutter/services.dart';
 
 import 'editing_controller.dart';
 
+/// A tool *type* - one dock group in [PdfEditingToolbar]. Pass a subset
+/// to [PdfEditingToolbar.groups] (or [PdfEditorFeatures.toolGroups]) to
+/// hide whole groups: e.g. `{PdfEditToolGroup.select,
+/// PdfEditToolGroup.markup}` shows only the Select and Markup groups.
+///
+/// This is the coarse axis. The finer [PdfEditingToolbar.tools] hides
+/// individual tools *within* the groups that survive this filter. It also
+/// organises the keyboard-shortcuts editor (see [pdfEditToolGroupOf]).
+enum PdfEditToolGroup {
+  /// Select / move / resize existing annotations.
+  select,
+
+  /// Text-markup actions (highlight, underline, strike out, squiggly).
+  markup,
+
+  /// Freehand drawing, freehand highlight, and the ink eraser.
+  draw,
+
+  /// Rectangle, ellipse, line, arrow, polyline, polygon.
+  shapes,
+
+  /// Text box, note, stamp, image, signature.
+  insert,
+
+  /// Distance, perimeter and area measurement.
+  measure,
+
+  /// Page content, form fields and redaction.
+  edit,
+}
+
+/// The dock group [tool] belongs to. Mirrors the layout of
+/// [PdfEditingToolbar] so surfaces that list tools - the keyboard-shortcuts
+/// editor in particular - can organise them the same way the toolbar reads.
+///
+/// Exhaustive over [PdfEditTool]: the compiler flags a missing case when the
+/// tool set grows, so a new tool cannot silently land in the wrong group.
+PdfEditToolGroup pdfEditToolGroupOf(PdfEditTool tool) {
+  switch (tool) {
+    case PdfEditTool.select:
+      return PdfEditToolGroup.select;
+    case PdfEditTool.ink:
+    case PdfEditTool.highlight:
+    case PdfEditTool.eraser:
+      return PdfEditToolGroup.draw;
+    case PdfEditTool.rectangle:
+    case PdfEditTool.ellipse:
+    case PdfEditTool.line:
+    case PdfEditTool.arrow:
+    case PdfEditTool.polyline:
+    case PdfEditTool.polygon:
+    case PdfEditTool.cloudPolygon:
+      return PdfEditToolGroup.shapes;
+    case PdfEditTool.freeText:
+    case PdfEditTool.callout:
+    case PdfEditTool.note:
+    case PdfEditTool.stamp:
+    case PdfEditTool.count:
+    case PdfEditTool.image:
+    case PdfEditTool.signature:
+    case PdfEditTool.signatureBox:
+      return PdfEditToolGroup.insert;
+    case PdfEditTool.measureDistance:
+    case PdfEditTool.measurePerimeter:
+    case PdfEditTool.measureArea:
+    case PdfEditTool.measureSlope:
+    case PdfEditTool.measureAngle:
+    case PdfEditTool.measureArc:
+    case PdfEditTool.measureVolume:
+    case PdfEditTool.calibrate:
+      return PdfEditToolGroup.measure;
+    case PdfEditTool.content:
+    case PdfEditTool.form:
+    case PdfEditTool.redact:
+    case PdfEditTool.snapshot:
+      return PdfEditToolGroup.edit;
+  }
+}
+
 /// Default single-key keyboard shortcuts for arming the common editing tools.
 ///
 /// Pass a replacement map to [PdfViewer.toolShortcuts] (and to

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1253,6 +1253,7 @@ Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
       if (tools == null || tools.contains(entry.key)) entry.key,
   ];
   var draft = Map<PdfEditTool, LogicalKeyboardKey>.of(shortcuts);
+  var searchQuery = '';
 
   Future<LogicalKeyboardKey?> captureKey(BuildContext context) {
     return showDialog<LogicalKeyboardKey>(
@@ -1334,18 +1335,61 @@ Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
                 ),
               ),
               const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                child: TextField(
+                  key: const ValueKey('pdf-shell-shortcuts-search'),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    prefixIcon: const Icon(Icons.search),
+                    hintText: pdfL10n(context).shellShortcutsSearchHint,
+                    border: const OutlineInputBorder(),
+                  ),
+                  onChanged: (value) =>
+                      setSheetState(() => searchQuery = value),
+                ),
+              ),
               Flexible(
-                child: ListView(
-                  shrinkWrap: true,
-                  children: [
-                    for (final tool in visibleTools)
-                      ListTile(
+                child: Builder(builder: (context) {
+                  final l10n = pdfL10n(context);
+                  final query = searchQuery.trim().toLowerCase();
+                  bool matches(PdfEditTool tool) {
+                    if (query.isEmpty) return true;
+                    final label =
+                        pdfEditToolShortcutLabel(tool, shortcuts: draft) ?? '';
+                    return _toolName(tool).toLowerCase().contains(query) ||
+                        label.toLowerCase().contains(query);
+                  }
+
+                  final byGroup = <PdfEditToolGroup, List<PdfEditTool>>{};
+                  for (final tool in visibleTools.where(matches)) {
+                    byGroup
+                        .putIfAbsent(pdfEditToolGroupOf(tool), () => [])
+                        .add(tool);
+                  }
+
+                  if (byGroup.isEmpty) {
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 24, 16, 24),
+                      child: Text(
+                        l10n.shellShortcutsNoMatches(searchQuery.trim()),
+                        key: const ValueKey('pdf-shell-shortcuts-no-matches'),
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(color: Theme.of(context).hintColor),
+                      ),
+                    );
+                  }
+
+                  Widget tile(PdfEditTool tool) => ListTile(
                         key: ValueKey('pdf-shell-shortcut-${tool.name}'),
                         leading: const Icon(Icons.keyboard_outlined),
                         title: Text(_toolName(tool)),
                         trailing: Text(
                             pdfEditToolShortcutLabel(tool, shortcuts: draft) ??
-                                pdfL10n(context).shellUnbound),
+                                l10n.shellUnbound),
                         onTap: () async {
                           final key = await captureKey(context);
                           if (key == null) return;
@@ -1358,9 +1402,34 @@ Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
                             }
                           });
                         },
-                      ),
-                  ],
-                ),
+                      );
+
+                  return ListView(
+                    shrinkWrap: true,
+                    children: [
+                      for (final group in PdfEditToolGroup.values)
+                        if (byGroup[group] case final groupTools?) ...[
+                          Padding(
+                            key: ValueKey(
+                                'pdf-shell-shortcut-group-${group.name}'),
+                            padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                            child: Text(
+                              _shortcutGroupLabel(context, group),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelMedium
+                                  ?.copyWith(
+                                    color:
+                                        Theme.of(context).colorScheme.primary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                            ),
+                          ),
+                          for (final tool in groupTools) tile(tool),
+                        ],
+                    ],
+                  );
+                }),
               ),
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
@@ -1392,6 +1461,27 @@ String _toolName(PdfEditTool tool) {
   final words = tool.name.replaceAllMapped(
       RegExp(r'([A-Z])'), (match) => ' ${match.group(1)!.toLowerCase()}');
   return words[0].toUpperCase() + words.substring(1);
+}
+
+/// The localized section header for [group] in the keyboard-shortcuts editor.
+String _shortcutGroupLabel(BuildContext context, PdfEditToolGroup group) {
+  final l10n = pdfL10n(context);
+  switch (group) {
+    case PdfEditToolGroup.select:
+      return l10n.shellShortcutGroupSelect;
+    case PdfEditToolGroup.markup:
+      return l10n.shellShortcutGroupMarkup;
+    case PdfEditToolGroup.draw:
+      return l10n.shellShortcutGroupDraw;
+    case PdfEditToolGroup.shapes:
+      return l10n.shellShortcutGroupShapes;
+    case PdfEditToolGroup.insert:
+      return l10n.shellShortcutGroupInsert;
+    case PdfEditToolGroup.measure:
+      return l10n.shellShortcutGroupMeasure;
+    case PdfEditToolGroup.edit:
+      return l10n.shellShortcutGroupEdit;
+  }
 }
 
 Future<void> showPdfShellViewOptionsSheet(

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -409,6 +409,83 @@ void main() {
       expect(find.text('R'), findsOneWidget);
     });
 
+    testWidgets('shortcuts are grouped under tool-category headers',
+        (tester) async {
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+      await openShortcutsSheet(tester);
+
+      // The Shapes header sits above the rectangle tool it groups.
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-group-shapes')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')),
+          findsOneWidget);
+      expect(find.text('R'), findsOneWidget);
+      final headerY = tester
+          .getTopLeft(
+              find.byKey(const ValueKey('pdf-shell-shortcut-group-shapes')))
+          .dy;
+      final rectY = tester
+          .getTopLeft(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')))
+          .dy;
+      expect(headerY, lessThan(rectY));
+
+      // A group lower down builds once scrolled into view.
+      await tester.scrollUntilVisible(
+        find.byKey(const ValueKey('pdf-shell-shortcut-group-insert')),
+        200,
+        scrollable: find
+            .descendant(
+              of: find.byType(ListView),
+              matching: find.byType(Scrollable),
+            )
+            .first,
+      );
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-group-insert')),
+          findsOneWidget);
+    });
+
+    testWidgets('searching filters the shortcut list and its group headers',
+        (tester) async {
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+      await openShortcutsSheet(tester);
+
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-shell-shortcuts-search')), 'rect');
+      await tester.pumpAndSettle();
+
+      // Only the rectangle tool (and its Shapes header) survives the filter.
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-ellipse')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-group-shapes')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-group-insert')),
+          findsNothing);
+    });
+
+    testWidgets('searching by key label matches, and a miss shows a message',
+        (tester) async {
+      await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
+      await openShortcutsSheet(tester);
+
+      // The rectangle tool is bound to "R" - searching the key finds it.
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-shell-shortcuts-search')), 'r');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')),
+          findsOneWidget);
+
+      // A query no tool matches shows the empty-state message instead.
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-shell-shortcuts-search')), 'zzzz');
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('pdf-shell-shortcuts-no-matches')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')),
+          findsNothing);
+    });
+
     testWidgets('view options can switch the editor to reflow text',
         (tester) async {
       final prefs = PdfEditingPreferences();


### PR DESCRIPTION
## Summary

The keyboard-shortcuts editor (Settings → Keyboard shortcuts…) listed every tool in one flat, insertion-ordered list. This groups the tools under tool-category headers and adds a search box.

- **Grouping** — the sheet now renders a section header per tool category, with its tools underneath, in the same order the toolbar dock reads (Select → Draw → Shapes → Insert → Measure → Edit).
- **Search** — a search field filters tools by display name *or* by their bound key label (typing `r` finds the rectangle tool). Groups with no surviving tool drop their header; an empty result shows a "no shortcuts match" message.
- `PdfEditToolGroup` moved from `editing_toolbar.dart` to the low-level `tool_shortcuts.dart` (the file both the toolbar and the shell already import), joined by a new public `pdfEditToolGroupOf(PdfEditTool)` — an exhaustive switch, so a new tool won't compile until it's assigned a group. Both files stay exported from `dart_pdf_editor.dart`, so `PdfEditToolGroup`'s public identity is unchanged for callers.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean, whole workspace)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (`pdf_shell_test.dart`, `editing_tool_shortcuts_test.dart`, `editing_takeoff_test.dart` — all pass, including 3 new grouping/search tests)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Only `dart_pdf_editor` is touched (a UI-layer change to one bottom sheet plus a self-contained enum move), so the pure-Dart package suites and corpus/render checks aren't relevant here.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- New l10n keys were added to `dart_pdf_editor_en.arb` and regenerated with `flutter gen-l10n` (`shellShortcutsSearchHint`, `shellShortcutsNoMatches`, and `shellShortcutGroup{Select,Markup,Draw,Shapes,Insert,Measure,Edit}`). English-only; other locales aren't present in this repo.
- The search `TextField` is uncontrolled (keeps its text across `setSheetState` rebuilds via its own state), so there's no `TextEditingController` to dispose in the transient sheet.
- Dev-log note: `doc/dev-log/2026-07-22-shortcuts-group-search.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQH1Nst6hZrHrWj7vz6zrz)_