### PR TITLE
Show paste-location indicator on thumbnail strip hover

### DIFF
--- a/doc/dev-log/2026-07-22-thumbnail-paste-indicator.md
+++ b/doc/dev-log/2026-07-22-thumbnail-paste-indicator.md
@@ -1,0 +1,46 @@
+# Paste-location hover indicator on the thumbnail strip
+
+The docked thumbnail strip (`PdfThumbnailSidebar`) now marks where a page
+paste will land while the mouse hovers it: with pages on the shared
+`PdfPageClipboard`, the tile under the cursor grows a slim primary-colored
+insertion bar (`_PasteInsertionMarker`) along its bottom edge, so the
+destination of the next ⌘/Ctrl+V reads ahead of the keystroke.
+
+## Where the mark shows (`editing_thumbnails.dart`)
+
+- `_PdfThumbnailSidebarState._pasteInsertionPage` is the hovered page when
+  the clipboard has pages **and** the platform has reliable hover
+  (`pdfPanelControlsRevealOnHover()` - desktop only; touch has no hover).
+  It's `null` otherwise, which hides the mark.
+- The tile owns the paint: `_PageTile.showPasteIndicator` overlays the
+  `_PasteInsertionMarker` (an `IgnorePointer` dot-line-dot bar) at
+  `bottom: 0` in a `Stack`, so it never reserves layout space, never eats a
+  pointer (tap/drag still work), and reads as "insert after this page".
+  Keyed `pdf-thumbnail-paste-indicator-$page` for tests.
+- Gotcha that bit once: `_pasteInsertionPage` must be computed **inside**
+  the `ListenableBuilder(listenable: controller)` builder, not in
+  `_buildFrame`. Filling/clearing the clipboard is a controller
+  notification that only rebuilds that inner builder; the outer frame keeps
+  its stale (empty-clipboard) value, so a mark hovered *before* the copy
+  would never appear. `rangePreview` stays in `_buildFrame` because it's
+  driven by `setState` (Shift/hover), not the controller.
+
+## Paste follows the mark
+
+`_pastePages` now aims at `_pasteInsertionPage` first, falling back to the
+old selection / keyboard-page anchor when nothing is hovered. So ⌘/Ctrl+V
+drops the pages exactly where the bar shows, and the indicator never lies.
+The header-menu and right-click-menu paste paths are unchanged (they carry
+their own explicit target - current page / right-clicked page).
+
+Scoped to the strip only, as asked. The full-area grid (`PdfThumbnailView`)
+leaves `showPasteIndicator` at its `false` default - its inserts are
+horizontal between tiles, a different affordance.
+
+Tests: `editing_page_clipboard_test.dart` gains a
+`PdfThumbnailSidebar paste indicator` group - the mark appears only with a
+filled clipboard, follows the cursor, clears on exit, and ⌘/Ctrl+V lands
+after the hovered tile rather than the selection. Both pin
+`debugDefaultTargetPlatformOverride = macOS` (reset in a `finally`, since
+`testWidgets` verifies foundation invariants before tearDown runs) so hover
+is treated as reliable.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -261,11 +261,29 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
 
   void _cutPages() => widget.controller.cutPages(_clipboardTargets());
 
+  /// The page a paste would drop the clipboard's pages after while the mouse
+  /// hovers the strip: the tile under the cursor, once the shared page
+  /// clipboard holds something. Null when nothing is copied, no tile is
+  /// hovered, or the platform has no reliable hover (touch). Drives both the
+  /// on-tile insertion indicator and where [_pastePages] lands, so the mark
+  /// always tells the truth about the next paste.
+  int? get _pasteInsertionPage => widget.allowPageEditing &&
+          widget.controller.hasPageClipboard &&
+          _hoverPage != null &&
+          pdfPanelControlsRevealOnHover()
+      ? _hoverPage
+      : null;
+
   /// Pastes the shared clipboard's pages after the selection (or the
-  /// keyboard/current page) and reveals where they landed.
+  /// keyboard/current page) and reveals where they landed. A live hover over
+  /// the strip - the case the insertion indicator marks - aims the paste at
+  /// the hovered tile instead, so ⌘/Ctrl+V drops the pages exactly where the
+  /// mark shows.
   void _pastePages() {
     final selected = widget.controller.selectedPages;
-    final at = (selected.isNotEmpty ? selected.last : _keyboardBase()) + 1;
+    final base = _pasteInsertionPage ??
+        (selected.isNotEmpty ? selected.last : _keyboardBase());
+    final at = base + 1;
     if (!widget.controller.pastePages(at: at)) return;
     _focusPage(at);
     if (widget.followsViewer) _revealPage(at);
@@ -531,137 +549,151 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                 listenable: controller,
                 // the implicit desktop scrollbar is replaced by the
                 // viewer-style bar below
-                builder: (context, _) => Column(
-                  children: [
-                    // page-level file actions sit in a slim header at the top so
-                    // they never collide with the floating editing toolbar (or a
-                    // snackbar) that hugs the bottom of the viewport. The slot is
-                    // a fixed height and always present, so swapping in the bulk-
-                    // action bar when 2+ pages are selected never reflows the
-                    // tiles below (a single selection is just the navigation
-                    // cursor - the per-tile delete handles it).
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(
-                          8 + inset, 2, _extraRightPadding + inset, 2),
-                      child: SizedBox(
-                        height: 36,
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: controller.selectedPageCount > 1
-                                  ? _PageSelectionBar(
-                                      controller: controller,
-                                      allowPageEditing: widget.allowPageEditing,
-                                      onExportPages: widget.onExportPages,
-                                      compact: true,
-                                    )
-                                  : Row(
-                                      children: [
-                                        Expanded(
-                                          child: Text(
-                                            pdfL10n(context).thumbPages,
-                                            style: Theme.of(context)
-                                                .textTheme
-                                                .labelMedium,
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        ),
-                                        if (widget.onPickPdfToInsert != null ||
-                                            widget.onExportPages != null ||
-                                            (widget.allowPageEditing &&
-                                                controller.hasPageClipboard))
-                                          _PageActionsButton(
-                                            controller: controller,
-                                            viewerController:
-                                                widget.viewerController,
-                                            allowPageEditing:
-                                                widget.allowPageEditing,
-                                            onPickPdfToInsert:
-                                                widget.onPickPdfToInsert,
-                                            onExportPages: widget.onExportPages,
-                                          ),
-                                      ],
-                                    ),
-                            ),
-                            // the drag-to-redock handle and the docked
-                            // strip's close button; a bottom sheet supplies
-                            // its own close in its sheet chrome
-                            if (geometry.moveHandle(
-                              key: const ValueKey('pdf-thumbnail-panel-move'),
-                            )
-                                case final moveHandle?)
-                              moveHandle,
-                            if (geometry.closeButton(
-                              key: const ValueKey('pdf-thumbnail-panel-close'),
-                            )
-                                case final closeButton?)
-                              closeButton,
-                          ],
-                        ),
-                      ),
-                    ),
-                    Expanded(
-                      child: ScrollConfiguration(
-                        behavior: ScrollConfiguration.of(context)
-                            .copyWith(scrollbars: false),
-                        child: ReorderableListView.builder(
-                          scrollController: _scroll,
-                          buildDefaultDragHandles: false,
-                          padding: EdgeInsets.fromLTRB(
-                              inset, 8, _extraRightPadding + inset, 8),
-                          itemCount: controller.document.pageCount,
-                          onReorderItem: controller.movePage,
-                          itemBuilder: (context, index) {
-                            final tile = _PageTile(
-                              key: _tileKeys[index] ??= GlobalKey(),
-                              controller: controller,
-                              viewerController: widget.viewerController,
-                              pageIndex: index,
-                              pageColor: widget.pageColor,
-                              showAnnotations: widget.showAnnotations,
-                              allowPageEditing: widget.allowPageEditing,
-                              onExportPages: widget.onExportPages,
-                              cache: _cache,
-                              tileWidth: _tileWidth,
-                              renderWorker: widget.renderWorker,
-                              inRangePreview: rangePreview.contains(index),
-                              showPageActions:
-                                  !pdfPanelControlsRevealOnHover() ||
-                                      _hoverPage == index,
-                              onHover: (hovering) => _setHover(index, hovering),
-                              onFocusPage: _focusPage,
-                            );
-                            // without the drag listener no reorder can ever start
-                            return widget.allowPageEditing
-                                ? _ReorderDragStartListener(
-                                    key: ValueKey(index),
-                                    index: index,
-                                    child: tile)
-                                : KeyedSubtree(
-                                    key: ValueKey(index), child: tile);
-                          },
-                        ),
-                      ),
-                    ),
-                    // a footer to append a blank page; only when the strip
-                    // is editable (a read-only strip is purely navigational)
-                    if (widget.allowPageEditing)
+                builder: (context, _) {
+                  // the tile a paste would land after while the mouse hovers -
+                  // marked with an insertion bar. Computed here, inside the
+                  // controller's builder, so filling/clearing the clipboard
+                  // (a controller notification) re-evaluates it.
+                  final pasteInsertionPage = _pasteInsertionPage;
+                  return Column(
+                    children: [
+                      // page-level file actions sit in a slim header at the top so
+                      // they never collide with the floating editing toolbar (or a
+                      // snackbar) that hugs the bottom of the viewport. The slot is
+                      // a fixed height and always present, so swapping in the bulk-
+                      // action bar when 2+ pages are selected never reflows the
+                      // tiles below (a single selection is just the navigation
+                      // cursor - the per-tile delete handles it).
                       Padding(
                         padding: EdgeInsets.fromLTRB(
-                            4 + inset, 2, _extraRightPadding + inset, 4),
-                        child: TextButton.icon(
-                          key: const ValueKey('pdf-thumbnail-add-page'),
-                          icon: const Icon(Icons.add, size: 16),
-                          label: Text(pdfL10n(context).thumbAddPage),
-                          style: TextButton.styleFrom(
-                            visualDensity: VisualDensity.compact,
-                            textStyle: Theme.of(context).textTheme.labelMedium,
+                            8 + inset, 2, _extraRightPadding + inset, 2),
+                        child: SizedBox(
+                          height: 36,
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: controller.selectedPageCount > 1
+                                    ? _PageSelectionBar(
+                                        controller: controller,
+                                        allowPageEditing:
+                                            widget.allowPageEditing,
+                                        onExportPages: widget.onExportPages,
+                                        compact: true,
+                                      )
+                                    : Row(
+                                        children: [
+                                          Expanded(
+                                            child: Text(
+                                              pdfL10n(context).thumbPages,
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .labelMedium,
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                          ),
+                                          if (widget.onPickPdfToInsert !=
+                                                  null ||
+                                              widget.onExportPages != null ||
+                                              (widget.allowPageEditing &&
+                                                  controller.hasPageClipboard))
+                                            _PageActionsButton(
+                                              controller: controller,
+                                              viewerController:
+                                                  widget.viewerController,
+                                              allowPageEditing:
+                                                  widget.allowPageEditing,
+                                              onPickPdfToInsert:
+                                                  widget.onPickPdfToInsert,
+                                              onExportPages:
+                                                  widget.onExportPages,
+                                            ),
+                                        ],
+                                      ),
+                              ),
+                              // the drag-to-redock handle and the docked
+                              // strip's close button; a bottom sheet supplies
+                              // its own close in its sheet chrome
+                              if (geometry.moveHandle(
+                                key: const ValueKey('pdf-thumbnail-panel-move'),
+                              )
+                                  case final moveHandle?)
+                                moveHandle,
+                              if (geometry.closeButton(
+                                key:
+                                    const ValueKey('pdf-thumbnail-panel-close'),
+                              )
+                                  case final closeButton?)
+                                closeButton,
+                            ],
                           ),
-                          onPressed: () => controller.addBlankPage(),
                         ),
                       ),
-                  ],
-                ),
+                      Expanded(
+                        child: ScrollConfiguration(
+                          behavior: ScrollConfiguration.of(context)
+                              .copyWith(scrollbars: false),
+                          child: ReorderableListView.builder(
+                            scrollController: _scroll,
+                            buildDefaultDragHandles: false,
+                            padding: EdgeInsets.fromLTRB(
+                                inset, 8, _extraRightPadding + inset, 8),
+                            itemCount: controller.document.pageCount,
+                            onReorderItem: controller.movePage,
+                            itemBuilder: (context, index) {
+                              final tile = _PageTile(
+                                key: _tileKeys[index] ??= GlobalKey(),
+                                controller: controller,
+                                viewerController: widget.viewerController,
+                                pageIndex: index,
+                                pageColor: widget.pageColor,
+                                showAnnotations: widget.showAnnotations,
+                                allowPageEditing: widget.allowPageEditing,
+                                onExportPages: widget.onExportPages,
+                                cache: _cache,
+                                tileWidth: _tileWidth,
+                                renderWorker: widget.renderWorker,
+                                inRangePreview: rangePreview.contains(index),
+                                showPasteIndicator: pasteInsertionPage == index,
+                                showPageActions:
+                                    !pdfPanelControlsRevealOnHover() ||
+                                        _hoverPage == index,
+                                onHover: (hovering) =>
+                                    _setHover(index, hovering),
+                                onFocusPage: _focusPage,
+                              );
+                              // without the drag listener no reorder can ever start
+                              return widget.allowPageEditing
+                                  ? _ReorderDragStartListener(
+                                      key: ValueKey(index),
+                                      index: index,
+                                      child: tile)
+                                  : KeyedSubtree(
+                                      key: ValueKey(index), child: tile);
+                            },
+                          ),
+                        ),
+                      ),
+                      // a footer to append a blank page; only when the strip
+                      // is editable (a read-only strip is purely navigational)
+                      if (widget.allowPageEditing)
+                        Padding(
+                          padding: EdgeInsets.fromLTRB(
+                              4 + inset, 2, _extraRightPadding + inset, 4),
+                          child: TextButton.icon(
+                            key: const ValueKey('pdf-thumbnail-add-page'),
+                            icon: const Icon(Icons.add, size: 16),
+                            label: Text(pdfL10n(context).thumbAddPage),
+                            style: TextButton.styleFrom(
+                              visualDensity: VisualDensity.compact,
+                              textStyle:
+                                  Theme.of(context).textTheme.labelMedium,
+                            ),
+                            onPressed: () => controller.addBlankPage(),
+                          ),
+                        ),
+                    ],
+                  );
+                },
               ),
             ),
           ),
@@ -1716,6 +1748,7 @@ class _PageTile extends StatefulWidget {
     this.onActivatePage,
     this.activateOnTap = true,
     this.inRangePreview = false,
+    this.showPasteIndicator = false,
     this.showPageActions = true,
     this.onHover,
     this.onFocusPage,
@@ -1736,6 +1769,12 @@ class _PageTile extends StatefulWidget {
   /// right now - painted as a faint preview of the selection chip while
   /// the strip's Shift hover is live. Ignored when already [selected].
   final bool inRangePreview;
+
+  /// Whether to paint a paste-insertion bar along this tile's bottom edge:
+  /// the strip sets it on the tile the mouse hovers while the shared page
+  /// clipboard has pages, marking where ⌘/Ctrl+V (or the strip's paste)
+  /// will drop them - right after this page. The grid leaves it false.
+  final bool showPasteIndicator;
 
   /// The mouse entering (true) or leaving (false) this tile, so the strip
   /// can track the hovered page for its Shift range preview. Null off the
@@ -1780,6 +1819,7 @@ class _PageTileState extends State<_PageTile> {
   double get tileWidth => widget.tileWidth;
   PdfRenderWorker? get renderWorker => widget.renderWorker;
   bool get inRangePreview => widget.inRangePreview;
+  bool get showPasteIndicator => widget.showPasteIndicator;
   void Function(bool hovering)? get onHover => widget.onHover;
   void Function(int pageIndex)? get onActivatePage => widget.onActivatePage;
   bool get activateOnTap => widget.activateOnTap;
@@ -2057,12 +2097,69 @@ class _PageTileState extends State<_PageTile> {
         ),
       ),
     );
+    // an insertion bar hugging the bottom edge marks where a paste would
+    // drop the clipboard's pages (right after this page) while the mouse
+    // hovers the strip; it never eats a pointer, so tap/drag still work
+    Widget content = tile;
+    if (showPasteIndicator) {
+      content = Stack(
+        children: [
+          content,
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: IgnorePointer(
+              child: _PasteInsertionMarker(
+                key: ValueKey('pdf-thumbnail-paste-indicator-$pageIndex'),
+                color: scheme.primary,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
     final onHover = this.onHover;
-    if (onHover == null) return tile;
+    if (onHover == null) return content;
     return MouseRegion(
       onEnter: (_) => onHover(true),
       onExit: (_) => onHover(false),
-      child: tile,
+      child: content,
+    );
+  }
+}
+
+/// A slim horizontal bar with rounded end caps, painted across a page
+/// tile's bottom edge to mark where a paste will insert the clipboard's
+/// pages - right after the tile it sits under. Purely decorative (the paste
+/// runs from the strip's keyboard/menu paste), so it ignores pointers.
+class _PasteInsertionMarker extends StatelessWidget {
+  const _PasteInsertionMarker({super.key, required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget cap() => Container(
+          width: 6,
+          height: 6,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        );
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(children: [
+        cap(),
+        Expanded(
+          child: Container(
+            height: 3,
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(1.5),
+            ),
+          ),
+        ),
+        cap(),
+      ]),
     );
   }
 }

--- a/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
@@ -3,7 +3,9 @@
 // pasting, and the thumbnail-view UI (selection-bar buttons, the context
 // menu, the ⌘/Ctrl+C/X/V shortcuts, and the header paste entry).
 
-import 'package:flutter/gestures.dart' show kSecondaryButton;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, debugDefaultTargetPlatformOverride;
+import 'package:flutter/gestures.dart' show PointerDeviceKind, kSecondaryButton;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -51,8 +53,8 @@ void main() {
       addTearDown(PdfPageClipboard.instance.clear);
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);
-      expect(identical(editing.pageClipboard, PdfPageClipboard.instance),
-          isTrue);
+      expect(
+          identical(editing.pageClipboard, PdfPageClipboard.instance), isTrue);
     });
   });
 
@@ -89,8 +91,8 @@ void main() {
       editing.copyPages([0]); // "Page 1"
 
       expect(editing.pastePages(at: 2), isTrue);
-      expect(labelsOf(editing.document),
-          ['Page 1', 'Page 2', 'Page 1', 'Page 3']);
+      expect(
+          labelsOf(editing.document), ['Page 1', 'Page 2', 'Page 1', 'Page 3']);
       // the pasted run is selected so the strip highlights what landed
       expect(editing.selectedPages, [2]);
 
@@ -171,10 +173,12 @@ void main() {
     test('pages copied in one controller paste into another sharing the clip',
         () {
       final clip = PdfPageClipboard();
-      final tabA = PdfEditingController(buildMultiPagePdf(3), pageClipboard: clip)
-        ..addBlankPage(); // keep this session distinct
+      final tabA =
+          PdfEditingController(buildMultiPagePdf(3), pageClipboard: clip)
+            ..addBlankPage(); // keep this session distinct
       addTearDown(tabA.dispose);
-      final tabB = PdfEditingController(buildMultiPagePdf(2), pageClipboard: clip);
+      final tabB =
+          PdfEditingController(buildMultiPagePdf(2), pageClipboard: clip);
       addTearDown(tabB.dispose);
 
       expect(tabA.copyPages([0, 2]), isTrue); // "Page 1", "Page 3"
@@ -212,7 +216,8 @@ void main() {
       addTearDown(tester.view.reset);
     }
 
-    Future<({PdfEditingController editing, PdfViewerController viewer})> pumpGrid(
+    Future<({PdfEditingController editing, PdfViewerController viewer})>
+        pumpGrid(
       WidgetTester tester, {
       int pages = 4,
       PdfEditingController? controller,
@@ -329,8 +334,7 @@ void main() {
       await tester
           .tap(find.byKey(const ValueKey('pdf-thumbnail-page-actions')));
       await tester.pumpAndSettle();
-      await tester
-          .tap(find.byKey(const ValueKey('pdf-thumbnail-paste-pages')));
+      await tester.tap(find.byKey(const ValueKey('pdf-thumbnail-paste-pages')));
       await tester.pumpAndSettle();
       // the header paste lands after the current page (index 0)
       expect(labelsOf(refs.editing.document), ['Page 1', 'Page 1', 'Page 2']);
@@ -359,6 +363,112 @@ void main() {
       expect(labelsOf(refs.editing.document),
           ['Page 1', 'Page 2', 'Page 3', 'Page 1']);
       await drain(tester);
+    });
+  });
+
+  group('PdfThumbnailSidebar paste indicator', () {
+    Future<({PdfEditingController editing, PdfViewerController viewer})>
+        pumpStrip(
+      WidgetTester tester, {
+      int pages = 4,
+    }) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final editing = PdfEditingController(buildMultiPagePdf(pages),
+          pageClipboard: PdfPageClipboard());
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+      return (editing: editing, viewer: viewer);
+    }
+
+    Finder marker(int i) =>
+        find.byKey(ValueKey('pdf-thumbnail-paste-indicator-$i'));
+
+    testWidgets('hovering the strip marks where a copied page would paste',
+        (tester) async {
+      // the insertion mark is a desktop-hover affordance - pin a desktop
+      // platform so hover is treated as reliable (touch has no hover). The
+      // override must clear before the test body ends, so reset in finally.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        final refs = await pumpStrip(tester, pages: 4);
+
+        // hover Page 2 (index 1) with a mouse before anything is copied
+        final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await mouse.addPointer(location: Offset.zero);
+        addTearDown(mouse.removePointer);
+        await mouse.moveTo(tester.getCenter(find.text('Page 2')));
+        await tester.pump();
+        // nothing on the clipboard yet - no insertion mark
+        expect(marker(1), findsNothing);
+
+        // copy a page: the hovered tile now shows the insertion bar, alone
+        refs.editing.copyPages([0]);
+        await tester.pump();
+        expect(marker(1), findsOneWidget);
+        expect(marker(0), findsNothing);
+        expect(marker(2), findsNothing);
+
+        // the mark follows the cursor to another tile
+        await mouse.moveTo(tester.getCenter(find.text('Page 3')));
+        await tester.pump();
+        expect(marker(1), findsNothing);
+        expect(marker(2), findsOneWidget);
+
+        // leaving the strip clears it
+        await mouse.moveTo(const Offset(700, 700));
+        await tester.pump();
+        expect(marker(2), findsNothing);
+        await tester.pump(const Duration(seconds: 2)); // drain tile renders
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('⌘/Ctrl+V lands after the hovered tile, not the selection',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        final refs = await pumpStrip(tester, pages: 3);
+
+        // select page 1 (the non-hover paste anchor) and copy it
+        await tester.tap(find.text('Page 1'));
+        await tester.pump();
+        expect(refs.editing.selectedPages, [0]);
+        refs.editing.copyPages([0]);
+        await tester.pump();
+
+        // hover Page 3 (index 2): the mark, and the paste, follow the cursor
+        final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await mouse.addPointer(location: Offset.zero);
+        addTearDown(mouse.removePointer);
+        await mouse.moveTo(tester.getCenter(find.text('Page 3')));
+        await tester.pump();
+        expect(marker(2), findsOneWidget);
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+        await tester.sendKeyEvent(LogicalKeyboardKey.keyV);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+        await tester.pump();
+
+        // pasted after the hovered Page 3, not after the selected Page 1
+        expect(labelsOf(refs.editing.document),
+            ['Page 1', 'Page 2', 'Page 3', 'Page 1']);
+        await tester.pump(const Duration(seconds: 2)); // drain tile renders
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary

Hovering a tile in the docked thumbnail strip (`PdfThumbnailSidebar`) while the shared page clipboard has pages now paints a slim primary-colored insertion bar along that tile's bottom edge, marking where a page paste would land (right after the hovered page). ⌘/Ctrl+V follows the mark — it lands after the hovered tile instead of the current selection — so the indicator always tells the truth about the next paste.

- New `_PasteInsertionMarker` (a dot–line–dot bar) overlaid via a `Stack` at `bottom: 0`, wrapped in `IgnorePointer` so it reserves no layout space and never intercepts a tap/drag.
- `_PdfThumbnailSidebarState._pasteInsertionPage` gates the mark on a filled clipboard **and** reliable hover (`pdfPanelControlsRevealOnHover()` — desktop only; touch has no hover). Computed inside the controller's `ListenableBuilder` so filling/clearing the clipboard re-evaluates it.
- `_pastePages` aims at the hovered insertion point first, falling back to the old selection / keyboard-page anchor when nothing is hovered. Header-menu and right-click-menu paste paths are unchanged (they carry their own explicit target).
- Scoped to the strip only; the full-area grid (`PdfThumbnailView`) is unchanged (its inserts are horizontal between tiles — a different affordance).

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Editing behavior change

## Validation

- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Ran `dart analyze` on `dart_pdf_editor` (no issues) and `flutter test` for `editing_page_clipboard_test.dart`, `editing_page_ops_test.dart`, `editing_thumbnail_view_test.dart`, and `editing_multiselect_test.dart` (all pass). Rendering/corpus checks not applicable — no render-pipeline changes.

## PDF fixtures and screenshots

None — behavior is covered by widget tests using programmatic fixtures.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

New `PdfThumbnailSidebar paste indicator` test group pins `debugDefaultTargetPlatformOverride = macOS` (reset in a `finally`, since `testWidgets` verifies foundation invariants before tearDown runs) so hover is treated as reliable. Design rationale and the "compute inside the ListenableBuilder" gotcha are written up in `doc/dev-log/2026-07-22-thumbnail-paste-indicator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQ7n5u3UgEGUDQntvQ4qNs)_