### PR TITLE
feat(editor): keyboard shortcuts for every editing tool via Shift extensions

### DIFF
--- a/doc/dev-log/2026-07-22-tool-shortcut-extensions.md
+++ b/doc/dev-log/2026-07-22-tool-shortcut-extensions.md
@@ -1,0 +1,50 @@
+# Tool shortcut keys for every editing tool (Shift extensions)
+
+`pdfEditToolShortcuts` (`packages/dart_pdf_editor/lib/src/editing/
+tool_shortcuts.dart`) previously bound only the ~18 common tools to bare
+letters and deliberately left the multi-segment / rare-variant tools
+unbound. This change gives **every** `PdfEditTool` a shortcut by
+introducing a Shift "extension" for the less-common members of a tool
+group, so the mnemonics stay grouped once the plain letters run out.
+
+## The value type
+
+The map value changed from `LogicalKeyboardKey` to a small immutable
+`PdfToolShortcut` (trigger key + optional `shift`). It exposes:
+
+- `activator` → `SingleActivator(trigger, shift: shift)`, bound by the
+  viewer. Because a plain shortcut has `shift: false`, `SingleActivator`
+  only fires it when Shift is *up*, so a primary tool (`L` line) and its
+  Shift-extended sibling (`⇧L` polyline) never fire together.
+- `label` → `'R'` or `'⇧R'`, used in toolbar tooltips and the shortcut
+  sheet.
+
+This is the public API type behind `PdfViewer.toolShortcuts`,
+`PdfEditingToolbar.toolShortcuts`, `PdfEditorView.toolShortcuts` and
+`pdfEditToolShortcutLabel`, so all four were retyped. Only Shift is used
+as a modifier, keeping tool keys clear of the ⌘/Ctrl clipboard, undo/redo,
+delete and Escape bindings.
+
+## Assignments (the new Shift extensions)
+
+- Draw: `⇧H` freehand highlighter (beside `P` pen).
+- Shapes: `⇧L` polyline, `⇧Y` polygon, `⇧D` cloud polygon (beside `R`/`O`/
+  `L`/`A`).
+- Measure: `⇧P` perimeter, `⇧A` area, `⇧S` slope, `⇧N` angle, `⇧C` arc,
+  `⇧V` volume, `⇧M` calibrate (beside `M` distance — `⇧M` "sets the
+  measure scale").
+- Insert: `⇧T` count (beside `T` free text / `S` stamp).
+- Sign: `⇧B` signature box (beside `H` signature).
+
+`editing_tool_shortcuts_test.dart` now asserts every enum member is bound
+to a distinct combo and that Shift-extended keys arm their variant while
+the bare key still arms the primary.
+
+## Rebinding UI
+
+The shortcut sheet's key-capture dialog (`showPdfShellShortcutsSheet` in
+`shell_chrome.dart`) now records the Shift state at capture time, so users
+can rebind to Shift combos too; the "unbind" path still uses a
+`LogicalKeyboardKey(0)` sentinel and combo-stealing still works via
+`PdfToolShortcut` value equality. The capture hint copy mentions the Shift
+extension.

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -1042,7 +1042,7 @@
   "@shellPressAKey": {
     "description": "Dialog title shown while capturing a keyboard shortcut for an editing tool."
   },
-  "shellPressLetterKeyHint": "Press a letter key, or Delete to clear.",
+  "shellPressLetterKeyHint": "Press a letter key, add Shift for a variant, or Delete to clear.",
   "@shellPressLetterKeyHint": {
     "description": "Instructional text in the keyboard-shortcut capture dialog."
   },

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -1508,7 +1508,7 @@ abstract class DartPdfEditorLocalizations {
   /// Instructional text in the keyboard-shortcut capture dialog.
   ///
   /// In en, this message translates to:
-  /// **'Press a letter key, or Delete to clear.'**
+  /// **'Press a letter key, add Shift for a variant, or Delete to clear.'**
   String get shellPressLetterKeyHint;
 
   /// Compact control label that toggles the reflow (text reading) view.

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -798,7 +798,7 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
 
   @override
   String get shellPressLetterKeyHint =>
-      'Press a letter key, or Delete to clear.';
+      'Press a letter key, add Shift for a variant, or Delete to clear.';
 
   @override
   String get shellReflow => 'Reflow';

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -2,7 +2,6 @@ import 'dart:typed_data';
 
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:pdf_document/pdf_document.dart'
     show
         PdfAlignment,
@@ -133,7 +132,7 @@ class PdfEditingToolbar extends StatefulWidget {
   /// Shortcut labels to show in tooltips. Keep this in sync with
   /// [PdfViewer.toolShortcuts] when rebinding keys in the stock editor UI.
   /// Tools omitted from the map show no shortcut label.
-  final Map<PdfEditTool, LogicalKeyboardKey> toolShortcuts;
+  final Map<PdfEditTool, PdfToolShortcut> toolShortcuts;
 
   /// The tools to expose, null meaning all of them. A group disappears
   /// from the dock when none of its tools are in the set. Sub-controls

--- a/packages/dart_pdf_editor/lib/src/editing/tool_shortcuts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/tool_shortcuts.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 import 'editing_controller.dart';
 
@@ -81,7 +82,51 @@ PdfEditToolGroup pdfEditToolGroupOf(PdfEditTool tool) {
   }
 }
 
-/// Default single-key keyboard shortcuts for arming the common editing tools.
+/// A single keyboard shortcut for arming an editing tool: a trigger key,
+/// optionally "extended" with Shift.
+///
+/// The common tools sit on plain single letters (V select, P pen, R
+/// rectangle…). Once those run out, a tool group's less-common siblings
+/// reuse the group's letter with Shift held - the "extension" - so the
+/// mnemonics stay grouped: Shift+L for the poly*line* beside L for the
+/// line, Shift+M to calibrate the *measure* scale beside M for the
+/// distance measure, Shift+H for the *highlighter* beside P for the pen.
+/// Shift is the only modifier used, so tool shortcuts never collide with
+/// the ⌘/Ctrl clipboard and undo/redo bindings.
+@immutable
+class PdfToolShortcut {
+  const PdfToolShortcut(this.trigger, {this.shift = false});
+
+  /// The letter (or digit) key that arms the tool.
+  final LogicalKeyboardKey trigger;
+
+  /// Whether Shift must be held. Distinguishes a group's secondary variants
+  /// from its primary tool on the same [trigger].
+  final bool shift;
+
+  /// The activator the viewer binds for this shortcut. A plain
+  /// (`shift: false`) shortcut only fires when Shift is *up*, so a primary
+  /// tool and its Shift-extended sibling never fire together.
+  ShortcutActivator get activator => SingleActivator(trigger, shift: shift);
+
+  /// A short display label for tooltips and the shortcut sheet, e.g. `'R'`
+  /// or `'⇧R'`. Empty when [trigger] has no printable label.
+  String get label => shift ? '⇧${trigger.keyLabel}' : trigger.keyLabel;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfToolShortcut &&
+      other.trigger == trigger &&
+      other.shift == shift;
+
+  @override
+  int get hashCode => Object.hash(trigger, shift);
+
+  @override
+  String toString() => 'PdfToolShortcut($label)';
+}
+
+/// Default keyboard shortcuts for arming the editing tools.
 ///
 /// Pass a replacement map to [PdfViewer.toolShortcuts] (and to
 /// [PdfEditingToolbar.toolShortcuts] when using the stock toolbar) to rebind
@@ -93,38 +138,72 @@ PdfEditToolGroup pdfEditToolGroupOf(PdfEditTool tool) {
 /// are surfaced in the editing toolbar's tooltips for discoverability.
 ///
 /// Pressing a tool's key arms it; pressing it again drops back to
-/// [PdfEditTool.select], mirroring the toolbar chips. The keys carry no
-/// modifier, so they never collide with the ⌘/Ctrl clipboard and
-/// undo/redo shortcuts.
+/// [PdfEditTool.select], mirroring the toolbar chips.
 ///
-/// The less-common multi-segment variants (polyline, polygon, perimeter,
-/// area measurement) deliberately have no key - they live one tap away in
-/// their group's strip and would only need obscure bindings here.
-const Map<PdfEditTool, LogicalKeyboardKey> pdfEditToolShortcuts = {
-  PdfEditTool.select: LogicalKeyboardKey.keyV,
-  PdfEditTool.ink: LogicalKeyboardKey.keyP,
-  PdfEditTool.eraser: LogicalKeyboardKey.keyE,
-  PdfEditTool.rectangle: LogicalKeyboardKey.keyR,
-  PdfEditTool.ellipse: LogicalKeyboardKey.keyO,
-  PdfEditTool.line: LogicalKeyboardKey.keyL,
-  PdfEditTool.arrow: LogicalKeyboardKey.keyA,
-  PdfEditTool.freeText: LogicalKeyboardKey.keyT,
-  PdfEditTool.callout: LogicalKeyboardKey.keyQ,
-  PdfEditTool.note: LogicalKeyboardKey.keyN,
-  PdfEditTool.stamp: LogicalKeyboardKey.keyS,
-  PdfEditTool.image: LogicalKeyboardKey.keyI,
-  PdfEditTool.signature: LogicalKeyboardKey.keyH,
-  PdfEditTool.measureDistance: LogicalKeyboardKey.keyM,
-  PdfEditTool.form: LogicalKeyboardKey.keyF,
-  PdfEditTool.content: LogicalKeyboardKey.keyC,
-  PdfEditTool.redact: LogicalKeyboardKey.keyK,
-  PdfEditTool.snapshot: LogicalKeyboardKey.keyG,
+/// Every tool is covered. The common ones sit on plain letters; a group's
+/// less-common variants (the poly / cloud shapes, the extra measurement
+/// modes, calibrate, count, the freehand highlighter, the signature box)
+/// reuse their group's letter with Shift held - see [PdfToolShortcut].
+const Map<PdfEditTool, PdfToolShortcut> pdfEditToolShortcuts = {
+  // Select / move.
+  PdfEditTool.select: PdfToolShortcut(LogicalKeyboardKey.keyV),
+
+  // Draw group: pen, freehand highlighter, eraser.
+  PdfEditTool.ink: PdfToolShortcut(LogicalKeyboardKey.keyP),
+  PdfEditTool.highlight: PdfToolShortcut(LogicalKeyboardKey.keyH, shift: true),
+  PdfEditTool.eraser: PdfToolShortcut(LogicalKeyboardKey.keyE),
+
+  // Shapes group: rectangle, ellipse, line, arrow, and the poly/cloud
+  // variants on Shift.
+  PdfEditTool.rectangle: PdfToolShortcut(LogicalKeyboardKey.keyR),
+  PdfEditTool.ellipse: PdfToolShortcut(LogicalKeyboardKey.keyO),
+  PdfEditTool.line: PdfToolShortcut(LogicalKeyboardKey.keyL),
+  PdfEditTool.arrow: PdfToolShortcut(LogicalKeyboardKey.keyA),
+  PdfEditTool.polyline: PdfToolShortcut(LogicalKeyboardKey.keyL, shift: true),
+  PdfEditTool.polygon: PdfToolShortcut(LogicalKeyboardKey.keyY, shift: true),
+  PdfEditTool.cloudPolygon:
+      PdfToolShortcut(LogicalKeyboardKey.keyD, shift: true),
+
+  // Measure group: distance on M, the rest on Shift + a mnemonic letter,
+  // calibrate on Shift+M (the measure scale itself).
+  PdfEditTool.measureDistance: PdfToolShortcut(LogicalKeyboardKey.keyM),
+  PdfEditTool.measurePerimeter:
+      PdfToolShortcut(LogicalKeyboardKey.keyP, shift: true),
+  PdfEditTool.measureArea:
+      PdfToolShortcut(LogicalKeyboardKey.keyA, shift: true),
+  PdfEditTool.measureSlope:
+      PdfToolShortcut(LogicalKeyboardKey.keyS, shift: true),
+  PdfEditTool.measureAngle:
+      PdfToolShortcut(LogicalKeyboardKey.keyN, shift: true),
+  PdfEditTool.measureArc: PdfToolShortcut(LogicalKeyboardKey.keyC, shift: true),
+  PdfEditTool.measureVolume:
+      PdfToolShortcut(LogicalKeyboardKey.keyV, shift: true),
+  PdfEditTool.calibrate: PdfToolShortcut(LogicalKeyboardKey.keyM, shift: true),
+
+  // Insert group: text box, callout, note, stamp, count, signature, image.
+  PdfEditTool.freeText: PdfToolShortcut(LogicalKeyboardKey.keyT),
+  PdfEditTool.callout: PdfToolShortcut(LogicalKeyboardKey.keyQ),
+  PdfEditTool.note: PdfToolShortcut(LogicalKeyboardKey.keyN),
+  PdfEditTool.stamp: PdfToolShortcut(LogicalKeyboardKey.keyS),
+  PdfEditTool.count: PdfToolShortcut(LogicalKeyboardKey.keyT, shift: true),
+  PdfEditTool.signature: PdfToolShortcut(LogicalKeyboardKey.keyH),
+  PdfEditTool.image: PdfToolShortcut(LogicalKeyboardKey.keyI),
+
+  // Edit group: content, form, redact.
+  PdfEditTool.content: PdfToolShortcut(LogicalKeyboardKey.keyC),
+  PdfEditTool.form: PdfToolShortcut(LogicalKeyboardKey.keyF),
+  PdfEditTool.redact: PdfToolShortcut(LogicalKeyboardKey.keyK),
+
+  // Capture / sign.
+  PdfEditTool.snapshot: PdfToolShortcut(LogicalKeyboardKey.keyG),
+  PdfEditTool.signatureBox:
+      PdfToolShortcut(LogicalKeyboardKey.keyB, shift: true),
 };
 
-/// The display label for [tool]'s shortcut key (e.g. `'V'`), or null when
-/// the tool has no bound key.
+/// The display label for [tool]'s shortcut key (e.g. `'V'` or `'⇧L'`), or
+/// null when the tool has no bound key.
 String? pdfEditToolShortcutLabel(
   PdfEditTool tool, {
-  Map<PdfEditTool, LogicalKeyboardKey> shortcuts = pdfEditToolShortcuts,
+  Map<PdfEditTool, PdfToolShortcut> shortcuts = pdfEditToolShortcuts,
 }) =>
-    shortcuts[tool]?.keyLabel;
+    shortcuts[tool]?.label;

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -508,7 +508,7 @@ class PdfEditorView extends StatefulWidget {
   /// Single-key shortcuts for arming editing tools. Threaded to both the
   /// embedded [PdfViewer] bindings and [PdfEditingToolbar] tooltip labels.
   /// Pass an empty map to disable tool shortcuts.
-  final Map<PdfEditTool, LogicalKeyboardKey> toolShortcuts;
+  final Map<PdfEditTool, PdfToolShortcut> toolShortcuts;
 
   /// Custom widgets shown before the stock editing toolbar controls.
   ///
@@ -563,7 +563,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   // method-channel handler isn't claimed needlessly elsewhere.
   PdfPencilInteraction? _pencil;
 
-  late Map<PdfEditTool, LogicalKeyboardKey> _toolShortcuts;
+  late Map<PdfEditTool, PdfToolShortcut> _toolShortcuts;
 
   /// The revision length last reported through onDocumentChanged -
   /// revisions are byte prefixes of one buffer, so equal length means
@@ -588,7 +588,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
   void initState() {
     super.initState();
     _toolShortcuts =
-        Map<PdfEditTool, LogicalKeyboardKey>.of(widget.toolShortcuts);
+        Map<PdfEditTool, PdfToolShortcut>.of(widget.toolShortcuts);
     // In source mode the shell is owned by the inner byte-based PdfEditorView
     // the progressive builder mounts once the first-paint bytes arrive.
     if (_isSource) return;
@@ -634,7 +634,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
     super.didUpdateWidget(oldWidget);
     if (!mapEquals(widget.toolShortcuts, oldWidget.toolShortcuts)) {
       _toolShortcuts =
-          Map<PdfEditTool, LogicalKeyboardKey>.of(widget.toolShortcuts);
+          Map<PdfEditTool, PdfToolShortcut>.of(widget.toolShortcuts);
     }
     if (_isSource) return;
     final sourceChanging = widget.controller != oldWidget.controller ||

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -942,13 +942,14 @@ class PdfViewer extends StatefulWidget {
   /// runtime-safe preview, vector-first, and image-cap tuning live.
   final PdfPerformanceController? performance;
 
-  /// Single-key shortcuts that arm editing tools while [editing] is active.
+  /// Keyboard shortcuts that arm editing tools while [editing] is active.
   ///
   /// Defaults to [pdfEditToolShortcuts]. Pass a replacement map to rebind
   /// keys, omit tools to leave them unbound, or pass an empty map to disable
-  /// tool shortcuts entirely. Modifier-based viewer/editor shortcuts (copy,
-  /// undo, paste, delete, Escape, etc.) are not affected.
-  final Map<PdfEditTool, LogicalKeyboardKey> toolShortcuts;
+  /// tool shortcuts entirely. Each shortcut is a letter optionally extended
+  /// with Shift ([PdfToolShortcut]); the ⌘/Ctrl clipboard, undo/redo,
+  /// delete and Escape bindings are not affected.
+  final Map<PdfEditTool, PdfToolShortcut> toolShortcuts;
 
   final PdfViewerController? controller;
 
@@ -5392,11 +5393,11 @@ class _PdfViewerState extends State<PdfViewer>
                         () => editing.nudgeSelected(
                             0, _annotationNudgeStepCoarse),
                   },
-                  // unmodified single-key tool shortcuts (V select, P pen,
-                  // R rectangle, …) - safe because an open in-place text
+                  // tool shortcuts (V select, P pen, R rectangle, ⇧L
+                  // polyline, …) - safe because an open in-place text
                   // editor disables every binding above
                   for (final entry in widget.toolShortcuts.entries)
-                    SingleActivator(entry.value): () => _armTool(entry.key),
+                    entry.value.activator: () => _armTool(entry.key),
                 },
               },
         child: Focus(

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1199,8 +1199,8 @@ Future<void> _selectViewOption(
   required PdfEditingPreferences preferences,
   required bool pageColor,
   required VoidCallback? onAuthorPressed,
-  Map<PdfEditTool, LogicalKeyboardKey>? toolShortcuts,
-  ValueChanged<Map<PdfEditTool, LogicalKeyboardKey>>? onToolShortcutsChanged,
+  Map<PdfEditTool, PdfToolShortcut>? toolShortcuts,
+  ValueChanged<Map<PdfEditTool, PdfToolShortcut>>? onToolShortcutsChanged,
   Set<PdfEditTool>? tools,
 }) async {
   switch (option) {
@@ -1243,20 +1243,20 @@ Future<void> _selectViewOption(
   }
 }
 
-Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
+Future<Map<PdfEditTool, PdfToolShortcut>?> showPdfShellShortcutsSheet(
   BuildContext context, {
-  required Map<PdfEditTool, LogicalKeyboardKey> shortcuts,
+  required Map<PdfEditTool, PdfToolShortcut> shortcuts,
   Set<PdfEditTool>? tools,
 }) {
   final visibleTools = [
     for (final entry in pdfEditToolShortcuts.entries)
       if (tools == null || tools.contains(entry.key)) entry.key,
   ];
-  var draft = Map<PdfEditTool, LogicalKeyboardKey>.of(shortcuts);
+  var draft = Map<PdfEditTool, PdfToolShortcut>.of(shortcuts);
   var searchQuery = '';
 
-  Future<LogicalKeyboardKey?> captureKey(BuildContext context) {
-    return showDialog<LogicalKeyboardKey>(
+  Future<PdfToolShortcut?> captureKey(BuildContext context) {
+    return showDialog<PdfToolShortcut>(
       context: context,
       builder: (context) {
         final focusNode = FocusNode(debugLabel: 'PdfShortcutCapture');
@@ -1277,11 +1277,16 @@ Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
               }
               if (key == LogicalKeyboardKey.delete ||
                   key == LogicalKeyboardKey.backspace) {
-                Navigator.of(context).pop(const LogicalKeyboardKey(0));
+                Navigator.of(context)
+                    .pop(const PdfToolShortcut(LogicalKeyboardKey(0)));
                 return;
               }
+              // Hold Shift to record a Shift-extended shortcut; bare Shift
+              // (and other modifier keys) carry a multi-character keyLabel,
+              // so the letter/digit filter below skips them.
               if (key.keyLabel.isNotEmpty && key.keyLabel.length == 1) {
-                Navigator.of(context).pop(key);
+                Navigator.of(context).pop(PdfToolShortcut(key,
+                    shift: HardwareKeyboard.instance.isShiftPressed));
               }
             },
             child: Text(pdfL10n(context).shellPressLetterKeyHint),
@@ -1297,7 +1302,7 @@ Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
     );
   }
 
-  return showModalBottomSheet<Map<PdfEditTool, LogicalKeyboardKey>>(
+  return showModalBottomSheet<Map<PdfEditTool, PdfToolShortcut>>(
     context: context,
     showDragHandle: true,
     isScrollControlled: true,
@@ -1322,7 +1327,7 @@ Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
                     TextButton(
                       key: const ValueKey('pdf-shell-shortcuts-reset'),
                       onPressed: () => setSheetState(() => draft =
-                          Map<PdfEditTool, LogicalKeyboardKey>.of(
+                          Map<PdfEditTool, PdfToolShortcut>.of(
                               pdfEditToolShortcuts)),
                       child: Text(pdfL10n(context).reset),
                     ),
@@ -1391,14 +1396,15 @@ Future<Map<PdfEditTool, LogicalKeyboardKey>?> showPdfShellShortcutsSheet(
                             pdfEditToolShortcutLabel(tool, shortcuts: draft) ??
                                 l10n.shellUnbound),
                         onTap: () async {
-                          final key = await captureKey(context);
-                          if (key == null) return;
+                          final shortcut = await captureKey(context);
+                          if (shortcut == null) return;
                           setSheetState(() {
-                            draft.removeWhere((_, value) => value == key);
-                            if (key.keyId == 0) {
+                            // steal the combo from whatever tool held it
+                            draft.removeWhere((_, value) => value == shortcut);
+                            if (shortcut.trigger.keyId == 0) {
                               draft.remove(tool);
                             } else {
-                              draft[tool] = key;
+                              draft[tool] = shortcut;
                             }
                           });
                         },
@@ -1493,8 +1499,8 @@ Future<void> showPdfShellViewOptionsSheet(
   bool author = false,
   String? authorName,
   VoidCallback? onAuthorPressed,
-  Map<PdfEditTool, LogicalKeyboardKey>? toolShortcuts,
-  ValueChanged<Map<PdfEditTool, LogicalKeyboardKey>>? onToolShortcutsChanged,
+  Map<PdfEditTool, PdfToolShortcut>? toolShortcuts,
+  ValueChanged<Map<PdfEditTool, PdfToolShortcut>>? onToolShortcutsChanged,
   Set<PdfEditTool>? tools,
 }) {
   String hex(Color color) {
@@ -1702,8 +1708,8 @@ class PdfShellViewOptionsButton extends StatelessWidget {
   /// Opens the host prompt for editing the default annotation author.
   final VoidCallback? onAuthorPressed;
 
-  final Map<PdfEditTool, LogicalKeyboardKey>? toolShortcuts;
-  final ValueChanged<Map<PdfEditTool, LogicalKeyboardKey>>?
+  final Map<PdfEditTool, PdfToolShortcut>? toolShortcuts;
+  final ValueChanged<Map<PdfEditTool, PdfToolShortcut>>?
       onToolShortcutsChanged;
   final Set<PdfEditTool>? tools;
 

--- a/packages/dart_pdf_editor/test/editing_test.dart
+++ b/packages/dart_pdf_editor/test/editing_test.dart
@@ -1098,12 +1098,12 @@ void main() {
       await tester.tap(find.byTooltip('Ellipse (O)'));
       await tester.pump();
       expect(editing.tool, PdfEditTool.ellipse);
-      await tester.tap(find.byTooltip('Cloud polygon'));
+      await tester.tap(find.byTooltip('Cloud polygon (⇧D)'));
       await tester.pump();
       expect(editing.tool, PdfEditTool.cloudPolygon);
       // re-tapping the active tool drops back to Select (not a no-tool
       // limbo) so you can immediately select and move things
-      await tester.tap(find.byTooltip('Cloud polygon'));
+      await tester.tap(find.byTooltip('Cloud polygon (⇧D)'));
       await tester.pump();
       expect(editing.tool, PdfEditTool.select);
 
@@ -1149,7 +1149,7 @@ void main() {
       final highlightButton = tester.widget<IconButton>(
           find.widgetWithIcon(IconButton, Icons.border_color));
       expect(highlightButton.onPressed, isNotNull);
-      await tester.tap(find.byTooltip('Highlight - draw freehand'));
+      await tester.tap(find.byTooltip('Highlight - draw freehand (⇧H)'));
       await tester.pump();
       expect(editing.tool, PdfEditTool.highlight);
       expect(viewer.hasSelection, isFalse);
@@ -1164,7 +1164,7 @@ void main() {
       expect(editing.preferences.strokeWidth, 2);
       expect(editing.preferences.opacity, 1);
 
-      await tester.tap(find.byTooltip('Highlight - draw freehand'));
+      await tester.tap(find.byTooltip('Highlight - draw freehand (⇧H)'));
       await tester.pump();
       expect(editing.tool, PdfEditTool.highlight);
       expect(editing.color, const Color(0xFFFFD100));

--- a/packages/dart_pdf_editor/test/editing_tool_shortcuts_test.dart
+++ b/packages/dart_pdf_editor/test/editing_tool_shortcuts_test.dart
@@ -7,53 +7,90 @@ import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 void main() {
   group('pdfEditToolShortcuts map', () {
-    test('every tool maps to a distinct key with an uppercase label', () {
-      final keys = pdfEditToolShortcuts.values.toList();
-      expect(keys.toSet(), hasLength(keys.length),
-          reason: 'no two tools may share a key');
+    test('every tool is bound to a distinct combo', () {
+      // every PdfEditTool has a shortcut now
+      for (final tool in PdfEditTool.values) {
+        expect(pdfEditToolShortcuts.keys, contains(tool),
+            reason: '$tool must have a shortcut');
+      }
+      // no two tools share the same (key + shift) combo
+      final combos = pdfEditToolShortcuts.values.toList();
+      expect(combos.toSet(), hasLength(combos.length),
+          reason: 'no two tools may share a combo');
+    });
+
+    test('every tool reports a non-empty uppercase label', () {
       for (final tool in pdfEditToolShortcuts.keys) {
         final label = pdfEditToolShortcutLabel(tool);
         expect(label, isNotNull);
-        expect(label, label!.toUpperCase());
-        expect(label, hasLength(1));
+        expect(label, isNotEmpty);
+        // the letter part is uppercase (a Shift-extended label carries a
+        // leading ⇧ glyph)
+        final shortcut = pdfEditToolShortcuts[tool]!;
+        expect(label, endsWith(shortcut.trigger.keyLabel.toUpperCase()));
+        expect(label!.startsWith('⇧'), shortcut.shift);
       }
     });
 
-    test('the common tools are covered; rare variants are not', () {
-      expect(pdfEditToolShortcuts.keys, contains(PdfEditTool.select));
-      expect(pdfEditToolShortcuts.keys, contains(PdfEditTool.ink));
-      expect(pdfEditToolShortcuts.keys, contains(PdfEditTool.rectangle));
-      expect(pdfEditToolShortcuts.keys, contains(PdfEditTool.freeText));
-      expect(
-          pdfEditToolShortcuts[PdfEditTool.snapshot], LogicalKeyboardKey.keyG);
-      expect(
-          pdfEditToolShortcuts[PdfEditTool.signature], LogicalKeyboardKey.keyH);
-      // the multi-segment / extra measure variants live one tap away
-      expect(pdfEditToolShortcuts.keys, isNot(contains(PdfEditTool.polyline)));
-      expect(pdfEditToolShortcuts.keys, isNot(contains(PdfEditTool.polygon)));
-      expect(
-          pdfEditToolShortcuts.keys, isNot(contains(PdfEditTool.cloudPolygon)));
-      expect(
-          pdfEditToolShortcuts.keys, isNot(contains(PdfEditTool.measureArea)));
+    test('common tools sit on plain letters', () {
+      expect(pdfEditToolShortcuts[PdfEditTool.select],
+          const PdfToolShortcut(LogicalKeyboardKey.keyV));
+      expect(pdfEditToolShortcuts[PdfEditTool.ink],
+          const PdfToolShortcut(LogicalKeyboardKey.keyP));
+      expect(pdfEditToolShortcuts[PdfEditTool.rectangle],
+          const PdfToolShortcut(LogicalKeyboardKey.keyR));
+      expect(pdfEditToolShortcuts[PdfEditTool.snapshot],
+          const PdfToolShortcut(LogicalKeyboardKey.keyG));
+      expect(pdfEditToolShortcuts[PdfEditTool.signature],
+          const PdfToolShortcut(LogicalKeyboardKey.keyH));
+      // primary tools carry no Shift
+      expect(pdfEditToolShortcuts[PdfEditTool.rectangle]!.shift, isFalse);
     });
 
-    test('tools with no shortcut report a null label', () {
-      expect(pdfEditToolShortcutLabel(PdfEditTool.polyline), isNull);
-      expect(pdfEditToolShortcutLabel(PdfEditTool.cloudPolygon), isNull);
+    test('group variants extend their group letter with Shift', () {
+      // Shift+L polyline beside L line; Shift+M calibrate beside M measure;
+      // Shift+H highlighter beside P pen.
+      expect(pdfEditToolShortcuts[PdfEditTool.polyline],
+          const PdfToolShortcut(LogicalKeyboardKey.keyL, shift: true));
+      expect(pdfEditToolShortcuts[PdfEditTool.cloudPolygon],
+          const PdfToolShortcut(LogicalKeyboardKey.keyD, shift: true));
+      expect(pdfEditToolShortcuts[PdfEditTool.measureArea],
+          const PdfToolShortcut(LogicalKeyboardKey.keyA, shift: true));
+      expect(pdfEditToolShortcuts[PdfEditTool.calibrate],
+          const PdfToolShortcut(LogicalKeyboardKey.keyM, shift: true));
+      expect(pdfEditToolShortcutLabel(PdfEditTool.polyline), '⇧L');
+    });
+
+    test('activator matches the key and shift state', () {
+      final plain =
+          const PdfToolShortcut(LogicalKeyboardKey.keyL).activator
+              as SingleActivator;
+      expect(plain.trigger, LogicalKeyboardKey.keyL);
+      expect(plain.shift, isFalse);
+
+      final shifted =
+          const PdfToolShortcut(LogicalKeyboardKey.keyL, shift: true).activator
+              as SingleActivator;
+      expect(shifted.trigger, LogicalKeyboardKey.keyL);
+      expect(shifted.shift, isTrue);
     });
 
     test('labels can be read from a custom shortcut map', () {
       expect(
         pdfEditToolShortcutLabel(
           PdfEditTool.rectangle,
-          shortcuts: const {PdfEditTool.rectangle: LogicalKeyboardKey.keyB},
+          shortcuts: const {
+            PdfEditTool.rectangle: PdfToolShortcut(LogicalKeyboardKey.keyB)
+          },
         ),
         'B',
       );
       expect(
         pdfEditToolShortcutLabel(
           PdfEditTool.ink,
-          shortcuts: const {PdfEditTool.rectangle: LogicalKeyboardKey.keyB},
+          shortcuts: const {
+            PdfEditTool.rectangle: PdfToolShortcut(LogicalKeyboardKey.keyB)
+          },
         ),
         isNull,
       );
@@ -67,7 +104,7 @@ void main() {
 
     Future<PdfEditingController> pumpEditor(
       WidgetTester tester, {
-      Map<PdfEditTool, LogicalKeyboardKey> toolShortcuts = pdfEditToolShortcuts,
+      Map<PdfEditTool, PdfToolShortcut> toolShortcuts = pdfEditToolShortcuts,
     }) async {
       final editing = PdfEditingController(buildMultiPagePdf(2));
       final viewer = PdfViewerController();
@@ -119,6 +156,22 @@ void main() {
       expect(editing.tool, PdfEditTool.snapshot);
     });
 
+    testWidgets('a Shift-extended key arms its variant tool', (tester) async {
+      final editing = await pumpEditor(tester);
+      await focusViewer(tester);
+
+      // Shift+L arms the polyline; plain L still arms the line
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyL);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.pump();
+      expect(editing.tool, PdfEditTool.polyline);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyL);
+      await tester.pump();
+      expect(editing.tool, PdfEditTool.line);
+    });
+
     testWidgets('pressing a tool key again drops back to Select',
         (tester) async {
       final editing = await pumpEditor(tester);
@@ -148,7 +201,9 @@ void main() {
     testWidgets('custom tool shortcuts replace the defaults', (tester) async {
       final editing = await pumpEditor(
         tester,
-        toolShortcuts: const {PdfEditTool.rectangle: LogicalKeyboardKey.keyB},
+        toolShortcuts: const {
+          PdfEditTool.rectangle: PdfToolShortcut(LogicalKeyboardKey.keyB)
+        },
       );
       await focusViewer(tester);
 

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -350,10 +350,19 @@ void main() {
       await tester.pumpAndSettle();
     }
 
+    // Filters the (now full) tool list down to a single tool so its tile is
+    // on-screen and tappable regardless of list length.
+    Future<void> filterShortcuts(WidgetTester tester, String query) async {
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-shell-shortcuts-search')), query);
+      await tester.pumpAndSettle();
+    }
+
     testWidgets('rebinding a shortcut updates the label and persists on Done',
         (tester) async {
       await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
       await openShortcutsSheet(tester);
+      await filterShortcuts(tester, 'Rectangle');
 
       // Capture a new key for the rectangle tool.
       await tester
@@ -372,6 +381,7 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('pdf-shell-shortcuts-done')));
       await tester.pumpAndSettle();
       await openShortcutsSheet(tester);
+      await filterShortcuts(tester, 'Rectangle');
       expect(find.text('B'), findsOneWidget);
     });
 
@@ -379,6 +389,7 @@ void main() {
         (tester) async {
       await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
       await openShortcutsSheet(tester);
+      await filterShortcuts(tester, 'Rectangle');
 
       await tester
           .tap(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')));
@@ -397,6 +408,7 @@ void main() {
         (tester) async {
       await pump(tester, PdfEditorView(bytes: buildMultiPagePdf(2)));
       await openShortcutsSheet(tester);
+      await filterShortcuts(tester, 'Rectangle');
 
       await tester
           .tap(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')));
@@ -872,7 +884,7 @@ void main() {
       expect(editing.tool, PdfEditTool.ink);
       expect(editing.color, const Color(0xFF123456));
 
-      await tester.tap(find.byTooltip('Highlight - draw freehand'));
+      await tester.tap(find.byTooltip('Highlight - draw freehand (⇧H)'));
       await tester.pump();
       expect(editing.tool, PdfEditTool.highlight);
       expect(editing.color, const Color(0xFF123456));


### PR DESCRIPTION
## Summary

Every `PdfEditTool` now has a keyboard shortcut. Previously only the ~18 common tools were bound to bare letters and the multi-segment / rare-variant tools were deliberately left unbound. The remaining 13 tools are now reachable via **Shift "extensions"**: a tool group's less-common variants reuse the group's letter with Shift held, so the mnemonics stay grouped once the plain letters run out.

New bindings:
- **Draw**: `⇧H` freehand highlighter (beside `P` pen)
- **Shapes**: `⇧L` polyline, `⇧Y` polygon, `⇧D` cloud polygon
- **Measure**: `⇧P` perimeter, `⇧A` area, `⇧S` slope, `⇧N` angle, `⇧C` arc, `⇧V` volume, `⇧M` calibrate (beside `M` distance — "sets the measure scale")
- **Insert**: `⇧T` count
- **Sign**: `⇧B` signature box (beside `H` signature)

API impact: the map value behind `PdfViewer.toolShortcuts`, `PdfEditingToolbar.toolShortcuts`, `PdfEditorView.toolShortcuts` and `pdfEditToolShortcutLabel` changed from `LogicalKeyboardKey` to a new immutable `PdfToolShortcut` (trigger key + optional `shift`). It exposes a `SingleActivator` for binding and a `'⇧L'`-style label for tooltips. A plain shortcut only fires with Shift up, so a primary tool and its Shift-extended sibling never collide; only Shift is used, keeping tool keys clear of the ⌘/Ctrl clipboard, undo/redo, delete and Escape bindings. The shortcut-rebinding sheet now captures the Shift state, so users can rebind to Shift combos too.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (whole workspace — no issues)
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

If any relevant check was not run, explain why:

The full `dart_pdf_editor` suite passes except one pre-existing, unrelated failure: `ghent_render_test.dart` on the spot-color overprint baseline `2-SPOT/GWG030_Gray_K_black_OP_X1.pdf`. This diff touches only keyboard-shortcut wiring, one localization string, and tests — nothing in the render pipeline that test exercises.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `PdfToolShortcut` is a small public value type; the four public `toolShortcuts` APIs are retyped accordingly (a source-breaking change for callers passing a custom `Map<PdfEditTool, LogicalKeyboardKey>` — they now pass `Map<PdfEditTool, PdfToolShortcut>`).
- Shift-letter assignments were chosen to be unique and mnemonic (e.g. `⇧M` = calibrate the *measure* scale). Tests assert every enum member is bound to a distinct combo, and that a Shift-extended key arms its variant while the bare key still arms the primary.
- Design rationale in `doc/dev-log/2026-07-22-tool-shortcut-extensions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017R8uj9a4u7Q4RmYdUQLYmN

---
_Generated by [Claude Code](https://claude.ai/code/session_017R8uj9a4u7Q4RmYdUQLYmN)_