### PR TITLE
Add Delete/Backspace shortcut for selected pages in thumbnail strip and grid

### DIFF
--- a/doc/dev-log/2026-07-22-thumbnail-delete-shortcut.md
+++ b/doc/dev-log/2026-07-22-thumbnail-delete-shortcut.md
@@ -1,0 +1,28 @@
+# Delete/Backspace shortcut on the thumbnail strip and grid
+
+The page thumbnail strip (`PdfThumbnailSidebar`) and the full-area grid
+(`PdfThumbnailView`) already bound copy/cut/paste to ⌘/Ctrl+C/X/V via
+their focus-scoped `CallbackShortcuts`. Delete had no keyboard binding -
+you had to reach for the selection bar's trash button or a per-tile
+delete.
+
+Added `Delete`/`Backspace` to both shortcut maps (guarded by
+`allowPageEditing`, alongside the clipboard shortcuts). Each calls a new
+`_deletePages()` that mirrors the clipboard-target logic:
+
+- if there is a page selection, `controller.removeSelectedPages()`;
+- otherwise delete the keyboard/current page via
+  `controller.removePage(_keyboardBase())`.
+
+Both controller paths already refuse to empty the document (the last
+remaining page is kept) and clear the selection, so no extra guarding was
+needed here.
+
+No conflict with the viewer's own Delete binding (annotation delete,
+`pdf_viewer.dart`) or the shell keybinding-capture dialog: the strip/grid
+handle the key inside their own `Focus` subtree, exactly the way the
+existing C/X/V bindings coexist with the viewer's.
+
+Tests: `editing_page_ops_test.dart` (strip - Delete on a multi-selection,
+Backspace on the bare navigation cursor) and `editing_page_clipboard_test.dart`
+(grid - Delete on a multi-selection).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -34,8 +34,10 @@ import 'thumbnail_cache.dart';
 /// clipboard, so pages copied here paste into a different document tab),
 /// insert a blank page before or after, export (when [onExportPages] is
 /// given), delete - that acts on the strip's selection when the tile
-/// belongs to it. Copy/cut/paste are also bound to ⌘/Ctrl+C/X/V. All of
-/// this (export aside) needs [allowPageEditing].
+/// belongs to it. Copy/cut/paste are also bound to ⌘/Ctrl+C/X/V, and
+/// Delete/Backspace removes the strip's selection (or the keyboard/current
+/// page when nothing is selected). All of this (export aside) needs
+/// [allowPageEditing].
 ///
 /// Built to stay light on large documents: thumbnails are rasterized at
 /// tile resolution and cached, keyed by
@@ -271,6 +273,16 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     if (widget.followsViewer) _revealPage(at);
   }
 
+  /// Deletes the strip's selection, or the keyboard/current page when
+  /// nothing is selected - the last remaining page is kept either way.
+  void _deletePages() {
+    if (widget.controller.hasPageSelection) {
+      widget.controller.removeSelectedPages();
+    } else if (widget.controller.document.pageCount > 0) {
+      widget.controller.removePage(_keyboardBase());
+    }
+  }
+
   Map<ShortcutActivator, VoidCallback> get _keyboardShortcuts => {
         const SingleActivator(LogicalKeyboardKey.arrowUp): () =>
             _moveKeyboardSelection(-1),
@@ -300,6 +312,8 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
               _pastePages,
           const SingleActivator(LogicalKeyboardKey.keyV, control: true):
               _pastePages,
+          const SingleActivator(LogicalKeyboardKey.delete): _deletePages,
+          const SingleActivator(LogicalKeyboardKey.backspace): _deletePages,
         },
       };
 
@@ -1200,6 +1214,16 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
     _revealPage(at);
   }
 
+  /// Deletes the grid's selection, or the keyboard/current page when
+  /// nothing is selected - the last remaining page is kept either way.
+  void _deletePages() {
+    if (widget.controller.hasPageSelection) {
+      widget.controller.removeSelectedPages();
+    } else if (widget.controller.document.pageCount > 0) {
+      widget.controller.removePage(_keyboardBase());
+    }
+  }
+
   Map<ShortcutActivator, VoidCallback> _keyboardShortcuts(int columns) => {
         const SingleActivator(LogicalKeyboardKey.arrowLeft): () =>
             _moveKeyboardSelection(-1),
@@ -1229,6 +1253,8 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
               _pastePages,
           const SingleActivator(LogicalKeyboardKey.keyV, control: true):
               _pastePages,
+          const SingleActivator(LogicalKeyboardKey.delete): _deletePages,
+          const SingleActivator(LogicalKeyboardKey.backspace): _deletePages,
         },
       };
 

--- a/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_clipboard_test.dart
@@ -316,6 +316,24 @@ void main() {
       await drain(tester);
     });
 
+    testWidgets('Delete removes the grid selection', (tester) async {
+      wideScreen(tester);
+      final refs = await pumpGrid(tester, pages: 4);
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 3'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(refs.editing.selectedPages, [1, 2]);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.delete);
+      await tester.pump();
+      expect(labelsOf(refs.editing.document), ['Page 1', 'Page 4']);
+      expect(refs.editing.hasPageSelection, isFalse);
+      await drain(tester);
+    });
+
     testWidgets('the header page-actions menu pastes', (tester) async {
       wideScreen(tester);
       final refs = await pumpGrid(tester, pages: 2);

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -590,6 +590,74 @@ void main() {
       await tester.pump(const Duration(seconds: 2)); // drain tile renders
     });
 
+    testWidgets('Delete removes the strip selection', (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+      await tester.tap(find.text('Page 3'));
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+      await tester.pump();
+      expect(editing.selectedPages, [1, 2]);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.delete);
+      await tester.pump();
+      expect(labelsOf(editing.document), ['Page 1', 'Page 4', 'Page 5']);
+      expect(editing.hasPageSelection, isFalse);
+      await tester.pump(const Duration(seconds: 2)); // drain tile renders
+    });
+
+    testWidgets('Backspace deletes the keyboard page when nothing is selected',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+
+      // land the keyboard cursor on page 2, then clear the selection so only
+      // the navigation cursor remains
+      await tester.tap(find.text('Page 2'));
+      await tester.pump();
+      editing.clearPageSelection();
+      await tester.pump();
+      expect(editing.hasPageSelection, isFalse);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
+      await tester.pump();
+      expect(labelsOf(editing.document), ['Page 1', 'Page 3', 'Page 4']);
+      await tester.pump(const Duration(seconds: 2)); // drain tile renders
+    });
+
     testWidgets('ctrl-click toggles pages into the selection', (tester) async {
       tester.view.physicalSize = const Size(800, 1400);
       tester.view.devicePixelRatio = 1.0;


### PR DESCRIPTION
## Summary

The page thumbnail strip (`PdfThumbnailSidebar`) and full-area grid (`PdfThumbnailView`) already bound copy/cut/paste to ⌘/Ctrl+C/X/V, but deleting pages required the selection-bar trash button or a per-tile delete — there was no keyboard shortcut.

This binds **Delete** and **Backspace** in both surfaces (guarded by `allowPageEditing`, alongside the existing clipboard shortcuts). Each fires a small `_deletePages()` that mirrors the clipboard-target logic:

- if there is a page selection → `controller.removeSelectedPages()`;
- otherwise → delete the keyboard/current page via `controller.removePage(_keyboardBase())`.

Both controller paths already keep the last remaining page and clear the selection, so no extra guarding was needed. The bindings live inside each surface's own `Focus` subtree, so they coexist with the viewer's own Delete binding (annotation delete) exactly the way C/X/V already do — no conflict.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Editing behavior change
- [x] Feature

## Validation

- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Ran `dart analyze` on the changed source/tests (no issues) and the two affected test files (`editing_page_ops_test.dart`, `editing_page_clipboard_test.dart`) — all pass, including the new cases. Other suites/corpus checks unchanged by this UI-only shortcut addition.

## Notes for reviewers

New tests:
- strip: Delete on a multi-selection; Backspace on the bare navigation cursor (nothing selected).
- grid: Delete on a multi-selection.

Also added a dev-log note under `doc/dev-log/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139hjPRFZVueSWudkiK1Cqe

---
_Generated by [Claude Code](https://claude.ai/code/session_0139hjPRFZVueSWudkiK1Cqe)_