### PR TITLE
feat(i18n): phase 2 — no-context string extraction in the editor package

### DIFF
--- a/doc/dev-log/2026-07-22-i18n-no-context-refactors.md
+++ b/doc/dev-log/2026-07-22-i18n-no-context-refactors.md
@@ -1,0 +1,94 @@
+# 2026-07-22 — i18n phase 2: no-context string refactors (editor package)
+
+Follows the phase-1 extraction (`2026-07-22-i18n-extraction.md`, PR #477)
+and the locale-sizing work (`2026-07-22-i18n-locale-sizing.md`, PR #483).
+Phase 1 left a "deferred — no-context strings" inventory: user-facing
+English that lives in `static`/`const` data, enum getters, or top-level
+helpers with no `BuildContext` at the point the text is produced. This
+session clears that inventory for the `dart_pdf_editor` package.
+
+## The pattern
+
+Every one of these was a literal produced where no context was in scope.
+The fix is always the same shape the handover called for: **the enum /
+subtype / id is the stable key; the visible string is resolved from the
+localizations at the consumer** (which does have a context). Two concrete
+moves:
+
+- Model→label helpers that are shared across consumers were centralized in
+  `annotation_presentation.dart` (already the Flutter-presentation layer)
+  as context-taking functions, so the same mapping is translated once and
+  reused: `pdfAnnotationLabel(context, subtype)` (now takes context),
+  `pdfLineStyleLabel(context, style)`, `pdfMeasurementKindLabel(context,
+  kind)`, `pdfLineEndingLabel(context, ending)`. The pure models
+  (`PdfLineStyle`, `PdfMeasurementKind`, `PdfLineEnding`) stay unchanged in
+  their engine/enum homes — no Flutter dependency added there.
+- Per-file statics/getters were made instance methods (so they can use the
+  `State`'s own `context`) or given a `BuildContext` parameter threaded
+  from the build-time call site.
+
+## What landed (107 new ARB keys)
+
+- **`editing_toolbar.dart`** (the big one, most-visible remaining English —
+  every tool tooltip and dock-group label). The `static const _groups`
+  list dropped its `label`/`tip` **literals** entirely: `_ToolGroup` now
+  carries only `(id, icon, tools)` and `_GroupTool` only `(tool|markup,
+  icon)`. Names/tips are resolved from the enum via `_toolName`/`_toolTip`/
+  `_markupName`/`_markupTip`, and the group name via a `_ToolGroup.label(
+  context)` method (put on the class so the separate `_GroupChip` widget
+  can call it too). This also **deleted the string-splitting hacks** —
+  `_activeToolLabel` used to parse the tip's leading clause before `" -"`,
+  and the mobile sheet stripped `" selection"` off markup tips; both are
+  gone, replaced by direct name lookups. The toolbar's duplicate
+  `_endingLabel` was removed in favour of the shared
+  `pdfLineEndingLabel` (reuses the `propLineEnding*` keys the Properties
+  panel already localized in phase 1), and the line-style dropdown now
+  calls `pdfLineStyleLabel`. `calibrate` (a tool not in `_groups`) maps to
+  the existing `measCalibrate` key.
+- **`editing_sidebar.dart`**: `_fieldLabel`, `_actionLabel`, `_stateChip`
+  de-`static`'d to instance methods; `_title`'s `'Callout'` and the
+  annotation-label call now localized. `_actionLabel`'s `'Page N'` became
+  an ICU key with an `int` placeholder (`sbarActionPage`).
+- **`editing_takeoff.dart`**: `_kindLabel` deleted; the panel calls the
+  shared `pdfMeasurementKindLabel`.
+- **`editing_panel.dart`**: `PdfDockablePanel` dropped its stored `label`
+  literal for a `label(context)` method reusing the shell's `shellPanel*`
+  keys (Pages/Search results/Bookmarks/Annotations/Properties). Both
+  consumers (the drag chip and `shell_chrome.dart`'s dock tab) updated.
+- **`editing_stamps.dart`**: `_timePreview` (`24 hr`/`12 hr`), `_caption`
+  (`Custom stamp` fallback), `_fontLabel` (`Bold`/`Italic` — the family
+  names stay as proper nouns), `_fieldLabel` (Date/Time/Date & time/
+  Username). The `_monthNames` array and the AM/PM in `format()` are
+  **left** — that output is stamped into document content and belongs with
+  the separate `DateFormat`/`NumberFormat` follow-up.
+- **`annotation_presentation.dart`**: `pdfAnnotationLabel` now maps a
+  fuller set of subtypes (it previously returned most raw), still falling
+  back to the raw subtype for anything unknown. Two English strings
+  changed as a side effect: `FileAttachment` → "File attachment" (was the
+  raw camelCase) and `Redact` → "Redaction".
+
+Every new key carries a `@key` translator description and typed
+placeholders where relevant. English values were kept byte-identical to
+the previous literals (except the two annotation labels above), so the
+English-fallback path — and the existing widget tests that find UI by
+English text — are unaffected.
+
+## Verification
+
+- `dart analyze --fatal-infos` clean across the whole workspace.
+- `dart_pdf_editor` `flutter test` green.
+- The English `.arb` grew from 443 → 550 keys; `gen-l10n` regenerated.
+
+## Still deferred (unchanged from the phase-1 inventory)
+
+- **App/example strings**: `settings_screen.dart` default subtitle/
+  instructions, `ocr_status.dart` `OcrJobStatus.label`, the `XTypeGroup`
+  file-picker labels, and the `digital_signature.dart` model's
+  `FormatException` messages (a **pure** model — localize at the app's
+  `error.message` display site in `app/lib/digital_signature.dart:449`,
+  with app-ARB keys). These live in the separate app/example ARBs and are
+  their own change.
+- **`DateFormat`/`NumberFormat`** for the stamp month abbreviations and
+  user-visible `toStringAsFixed` values.
+- The RTL sweep, the Settings language picker, the machine-translated seed
+  ARBs + tier-1/2 locales, and the per-locale CI coverage gate.

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -4,6 +4,78 @@
   "@add": {
     "description": "Generic button that adds a new item."
   },
+  "annotCaret": "Caret",
+  "@annotCaret": {
+    "description": "Annotation type name: a caret marking an insertion point."
+  },
+  "annotCircle": "Circle",
+  "@annotCircle": {
+    "description": "Annotation type name: a circle/ellipse shape."
+  },
+  "annotFileAttachment": "File attachment",
+  "@annotFileAttachment": {
+    "description": "Annotation type name: an embedded file attachment."
+  },
+  "annotFreeText": "Text box",
+  "@annotFreeText": {
+    "description": "Annotation type name: a free-text box drawn on the page."
+  },
+  "annotHighlight": "Highlight",
+  "@annotHighlight": {
+    "description": "Annotation type name: a text highlight."
+  },
+  "annotInk": "Ink",
+  "@annotInk": {
+    "description": "Annotation type name: a freehand ink drawing."
+  },
+  "annotLine": "Line",
+  "@annotLine": {
+    "description": "Annotation type name: a straight line."
+  },
+  "annotLink": "Link",
+  "@annotLink": {
+    "description": "Annotation type name: a hyperlink."
+  },
+  "annotPolygon": "Polygon",
+  "@annotPolygon": {
+    "description": "Annotation type name: a closed polygon shape."
+  },
+  "annotPolyline": "Polyline",
+  "@annotPolyline": {
+    "description": "Annotation type name: an open multi-segment line."
+  },
+  "annotRedact": "Redaction",
+  "@annotRedact": {
+    "description": "Annotation type name: a redaction region."
+  },
+  "annotSquare": "Square",
+  "@annotSquare": {
+    "description": "Annotation type name: a rectangle/square shape."
+  },
+  "annotSquiggly": "Squiggly",
+  "@annotSquiggly": {
+    "description": "Annotation type name: a squiggly (wavy) underline."
+  },
+  "annotStamp": "Stamp",
+  "@annotStamp": {
+    "description": "Annotation type name: a rubber stamp."
+  },
+  "annotStrikeOut": "Strike-out",
+  "@annotStrikeOut": {
+    "description": "Annotation type name: a strike-through over text."
+  },
+  "annotText": "Note",
+  "@annotText": {
+    "description": "Annotation type name: a sticky note / text comment."
+  },
+  "annotUnderline": "Underline",
+  "@annotUnderline": {
+    "description": "Annotation type name: a text underline."
+  },
+  "annotWidget": "Form field",
+  "@annotWidget": {
+    "description": "Annotation type name: an interactive form field widget."
+  },
   "apply": "Apply",
   "@apply": {
     "description": "Generic button that applies pending changes."
@@ -290,6 +362,22 @@
   "@editorViewAuthorNameTitle": {
     "description": "Dialog title for the prompt that sets the default annotation author name."
   },
+  "lineStyleDashDot": "Dash-dot",
+  "@lineStyleDashDot": {
+    "description": "Border line style: an alternating dash-dot line."
+  },
+  "lineStyleDashed": "Dashed",
+  "@lineStyleDashed": {
+    "description": "Border line style: a dashed line."
+  },
+  "lineStyleDotted": "Dotted",
+  "@lineStyleDotted": {
+    "description": "Border line style: a dotted line."
+  },
+  "lineStyleSolid": "Solid",
+  "@lineStyleSolid": {
+    "description": "Border line style: an unbroken solid line."
+  },
   "measCalibrate": "Calibrate",
   "@measCalibrate": {
     "description": "Button that switches from typing a scale to calibrating by drawing a reference segment."
@@ -301,6 +389,42 @@
   "measDepthLabel": "Depth: ",
   "@measDepthLabel": {
     "description": "Inline label preceding the volume depth input field."
+  },
+  "measKindAngle": "Angle",
+  "@measKindAngle": {
+    "description": "Measurement kind: an angle measurement."
+  },
+  "measKindArc": "Arc",
+  "@measKindArc": {
+    "description": "Measurement kind: an arc-length measurement."
+  },
+  "measKindArea": "Area",
+  "@measKindArea": {
+    "description": "Measurement kind: an area measurement."
+  },
+  "measKindCount": "Count",
+  "@measKindCount": {
+    "description": "Measurement kind: a running count of tally marks."
+  },
+  "measKindLength": "Length",
+  "@measKindLength": {
+    "description": "Measurement kind: a distance/length measurement."
+  },
+  "measKindNetArea": "Net area",
+  "@measKindNetArea": {
+    "description": "Measurement kind: an area with cut-outs subtracted."
+  },
+  "measKindPerimeter": "Perimeter",
+  "@measKindPerimeter": {
+    "description": "Measurement kind: the perimeter of a shape."
+  },
+  "measKindSlope": "Slope",
+  "@measKindSlope": {
+    "description": "Measurement kind: a slope (rise over run)."
+  },
+  "measKindVolume": "Volume",
+  "@measKindVolume": {
+    "description": "Measurement kind: a volume (area times depth)."
   },
   "measLineRepresents": "The line you drew represents:",
   "@measLineRepresents": {
@@ -882,6 +1006,67 @@
   "@save": {
     "description": "Generic button that saves the document or changes."
   },
+  "sbarActionJavaScript": "JavaScript",
+  "@sbarActionJavaScript": {
+    "description": "Link target subtitle: runs a JavaScript action."
+  },
+  "sbarActionPage": "Page {page}",
+  "@sbarActionPage": {
+    "description": "Link target subtitle: jumps to the given 1-based page number.",
+    "placeholders": {
+      "page": {
+        "type": "int"
+      }
+    }
+  },
+  "sbarCallout": "Callout",
+  "@sbarCallout": {
+    "description": "Annotation title for a callout (a text box with a leader line)."
+  },
+  "sbarFieldButton": "Button field",
+  "@sbarFieldButton": {
+    "description": "Form-field type shown as an annotation title: a button (push/check/radio)."
+  },
+  "sbarFieldChoice": "Choice field",
+  "@sbarFieldChoice": {
+    "description": "Form-field type shown as an annotation title: a list/combo choice field."
+  },
+  "sbarFieldGeneric": "Form field",
+  "@sbarFieldGeneric": {
+    "description": "Fallback form-field type shown as an annotation title."
+  },
+  "sbarFieldSignature": "Signature field",
+  "@sbarFieldSignature": {
+    "description": "Form-field type shown as an annotation title: a digital-signature field."
+  },
+  "sbarFieldText": "Text field",
+  "@sbarFieldText": {
+    "description": "Form-field type shown as an annotation title: a text input field."
+  },
+  "sbarStateAccepted": "Accepted",
+  "@sbarStateAccepted": {
+    "description": "Review-state chip: the markup was accepted."
+  },
+  "sbarStateCancelled": "Cancelled",
+  "@sbarStateCancelled": {
+    "description": "Review-state chip: the markup was cancelled."
+  },
+  "sbarStateMarked": "Marked",
+  "@sbarStateMarked": {
+    "description": "Review-state chip: the markup is flagged/marked."
+  },
+  "sbarStateRejected": "Rejected",
+  "@sbarStateRejected": {
+    "description": "Review-state chip: the markup was rejected."
+  },
+  "sbarStateResolved": "Resolved",
+  "@sbarStateResolved": {
+    "description": "Review-state chip: the comment thread is resolved/completed."
+  },
+  "sbarStateUnmarked": "Unmarked",
+  "@sbarStateUnmarked": {
+    "description": "Review-state chip: the markup's mark was cleared."
+  },
   "searchClearSearch": "Clear search",
   "@searchClearSearch": {
     "description": "Tooltip on the button that clears the document search field."
@@ -1181,6 +1366,10 @@
   "@stampCircle": {
     "description": "Label of the button that adds an ellipse component to the stamp template."
   },
+  "stampCustomCaption": "Custom stamp",
+  "@stampCustomCaption": {
+    "description": "Default display name for a custom stamp that has no text component."
+  },
   "stampDateFormat": "Date format",
   "@stampDateFormat": {
     "description": "Label for the dropdown selecting the date format used by stamp {{date}} fields."
@@ -1201,9 +1390,33 @@
   "@stampExport": {
     "description": "Label of the button that exports saved custom stamps out of the app."
   },
+  "stampFieldDate": "Date",
+  "@stampFieldDate": {
+    "description": "Insertable stamp template field: the current date."
+  },
+  "stampFieldDateTime": "Date & time",
+  "@stampFieldDateTime": {
+    "description": "Insertable stamp template field: the current date and time."
+  },
+  "stampFieldTime": "Time",
+  "@stampFieldTime": {
+    "description": "Insertable stamp template field: the current time."
+  },
+  "stampFieldUsername": "Username",
+  "@stampFieldUsername": {
+    "description": "Insertable stamp template field: the current user's name."
+  },
   "stampFont": "Font",
   "@stampFont": {
     "description": "Tooltip on the button that chooses the font of the selected stamp text component."
+  },
+  "stampFontBold": "Bold",
+  "@stampFontBold": {
+    "description": "Font-style modifier shown after a font family name in the stamp font menu."
+  },
+  "stampFontItalic": "Italic",
+  "@stampFontItalic": {
+    "description": "Font-style modifier shown after a font family name in the stamp font menu."
   },
   "stampHeight": "Height",
   "@stampHeight": {
@@ -1252,6 +1465,14 @@
   "stampText": "Text",
   "@stampText": {
     "description": "Label of the button that adds a text component to the stamp template."
+  },
+  "stampTime12Hour": "12 hr",
+  "@stampTime12Hour": {
+    "description": "Suffix in the stamp time-format preview marking a 12-hour (AM/PM) clock format."
+  },
+  "stampTime24Hour": "24 hr",
+  "@stampTime24Hour": {
+    "description": "Suffix in the stamp time-format preview marking a 24-hour clock format."
   },
   "stampTimeFormat": "Time format",
   "@stampTimeFormat": {
@@ -1514,6 +1735,34 @@
   "@tbFormFieldsFlattened": {
     "description": "Snackbar confirming form fields were baked into the page content."
   },
+  "tbGroupDraw": "Draw",
+  "@tbGroupDraw": {
+    "description": "Toolbar dock group label: freehand drawing tools."
+  },
+  "tbGroupEdit": "Edit",
+  "@tbGroupEdit": {
+    "description": "Toolbar dock group label: document-editing tools (content/form/redact/…)."
+  },
+  "tbGroupInsert": "Insert",
+  "@tbGroupInsert": {
+    "description": "Toolbar dock group label: insert tools (text box/note/stamp/…)."
+  },
+  "tbGroupMarkup": "Markup",
+  "@tbGroupMarkup": {
+    "description": "Toolbar dock group label: text-markup tools (highlight/underline/…)."
+  },
+  "tbGroupMeasure": "Measure",
+  "@tbGroupMeasure": {
+    "description": "Toolbar dock group label: measurement tools."
+  },
+  "tbGroupSelect": "Select",
+  "@tbGroupSelect": {
+    "description": "Toolbar dock group label: the selection tools."
+  },
+  "tbGroupShapes": "Shapes",
+  "@tbGroupShapes": {
+    "description": "Toolbar dock group label: shape tools (rectangle/line/…)."
+  },
   "tbImageButtonOption": "Image button",
   "@tbImageButtonOption": {
     "description": "Menu option: create an image push-button form field."
@@ -1538,9 +1787,145 @@
   "@tbManageStamps": {
     "description": "Stamp menu item that opens the manage-stamps dialog."
   },
+  "tbMarkupHighlight": "Highlight",
+  "@tbMarkupHighlight": {
+    "description": "Text-markup action name: highlight the text selection."
+  },
+  "tbMarkupHighlightTip": "Highlight selection",
+  "@tbMarkupHighlightTip": {
+    "description": "Tooltip: highlight the current text selection."
+  },
+  "tbMarkupSquiggly": "Squiggly-underline",
+  "@tbMarkupSquiggly": {
+    "description": "Text-markup action name: squiggly-underline the text selection."
+  },
+  "tbMarkupSquigglyTip": "Squiggly-underline selection",
+  "@tbMarkupSquigglyTip": {
+    "description": "Tooltip: squiggly-underline the current text selection."
+  },
+  "tbMarkupStrikeOut": "Strike out",
+  "@tbMarkupStrikeOut": {
+    "description": "Text-markup action name: strike out the text selection."
+  },
+  "tbMarkupStrikeOutTip": "Strike out selection",
+  "@tbMarkupStrikeOutTip": {
+    "description": "Tooltip: strike out the current text selection."
+  },
+  "tbMarkupUnderline": "Underline",
+  "@tbMarkupUnderline": {
+    "description": "Text-markup action name: underline the text selection."
+  },
+  "tbMarkupUnderlineTip": "Underline selection",
+  "@tbMarkupUnderlineTip": {
+    "description": "Tooltip: underline the current text selection."
+  },
   "tbMoreColors": "More colors…",
   "@tbMoreColors": {
     "description": "Tooltip for the button opening the full color picker."
+  },
+  "tbNameArrow": "Arrow",
+  "@tbNameArrow": {
+    "description": "Tool name: draw an arrow."
+  },
+  "tbNameCallout": "Callout",
+  "@tbNameCallout": {
+    "description": "Tool name: insert a callout (text box with a leader line)."
+  },
+  "tbNameCloudPolygon": "Cloud polygon",
+  "@tbNameCloudPolygon": {
+    "description": "Tool name: draw a cloud-outline polygon."
+  },
+  "tbNameCount": "Count",
+  "@tbNameCount": {
+    "description": "Tool name: drop tally check-marks."
+  },
+  "tbNameDigitalSignature": "Digital signature",
+  "@tbNameDigitalSignature": {
+    "description": "Tool name: place and cryptographically sign a signature box."
+  },
+  "tbNameDraw": "Draw",
+  "@tbNameDraw": {
+    "description": "Tool name: freehand ink drawing."
+  },
+  "tbNameEllipse": "Ellipse",
+  "@tbNameEllipse": {
+    "description": "Tool name: draw an ellipse shape."
+  },
+  "tbNameEraser": "Erase ink strokes",
+  "@tbNameEraser": {
+    "description": "Tool name: erases ink strokes."
+  },
+  "tbNameHighlight": "Highlight",
+  "@tbNameHighlight": {
+    "description": "Tool name: freehand highlighter."
+  },
+  "tbNameImage": "Image",
+  "@tbNameImage": {
+    "description": "Tool name: insert a raster image."
+  },
+  "tbNameLine": "Line",
+  "@tbNameLine": {
+    "description": "Tool name: draw a straight line."
+  },
+  "tbNameMeasureAngle": "Measure angle",
+  "@tbNameMeasureAngle": {
+    "description": "Tool name: measure an interior angle."
+  },
+  "tbNameMeasureArc": "Measure arc length",
+  "@tbNameMeasureArc": {
+    "description": "Tool name: measure an arc length."
+  },
+  "tbNameMeasureArea": "Measure area",
+  "@tbNameMeasureArea": {
+    "description": "Tool name: measure an area."
+  },
+  "tbNameMeasureDistance": "Measure distance",
+  "@tbNameMeasureDistance": {
+    "description": "Tool name: measure a straight-line distance."
+  },
+  "tbNameMeasurePerimeter": "Measure perimeter",
+  "@tbNameMeasurePerimeter": {
+    "description": "Tool name: measure a perimeter."
+  },
+  "tbNameMeasureSlope": "Measure slope (rise/run)",
+  "@tbNameMeasureSlope": {
+    "description": "Tool name: measure a slope as rise over run."
+  },
+  "tbNameMeasureVolume": "Measure volume (area × depth)",
+  "@tbNameMeasureVolume": {
+    "description": "Tool name: measure a volume as area times depth."
+  },
+  "tbNameNote": "Note",
+  "@tbNameNote": {
+    "description": "Tool name: insert a sticky note."
+  },
+  "tbNamePolygon": "Polygon",
+  "@tbNamePolygon": {
+    "description": "Tool name: draw a closed polygon."
+  },
+  "tbNamePolyline": "Polyline",
+  "@tbNamePolyline": {
+    "description": "Tool name: draw an open multi-segment line."
+  },
+  "tbNameRectangle": "Rectangle",
+  "@tbNameRectangle": {
+    "description": "Tool name: draw a rectangle shape."
+  },
+  "tbNameSelect": "Select",
+  "@tbNameSelect": {
+    "description": "Tool name: the select/move tool."
+  },
+  "tbNameSignature": "Signature",
+  "@tbNameSignature": {
+    "description": "Tool name: place a saved handwritten signature."
+  },
+  "tbNameStamp": "Stamp",
+  "@tbNameStamp": {
+    "description": "Tool name: insert a rubber stamp."
+  },
+  "tbNameTextBox": "Text box",
+  "@tbNameTextBox": {
+    "description": "Tool name: insert a free-text box."
   },
   "tbNewFieldType": "New field type - drag on a page to add one",
   "@tbNewFieldType": {
@@ -1703,6 +2088,54 @@
   "tbTextTitle": "Text",
   "@tbTextTitle": {
     "description": "Dialog title for editing a free-text annotation's text."
+  },
+  "tbTipCallout": "Callout - drag from the point to where the box goes",
+  "@tbTipCallout": {
+    "description": "Tooltip for the callout tool, explaining the drag gesture."
+  },
+  "tbTipContent": "Edit page content",
+  "@tbTipContent": {
+    "description": "Tooltip for the page-content editing tool."
+  },
+  "tbTipCount": "Count - tap to drop check-marks and tally them",
+  "@tbTipCount": {
+    "description": "Tooltip for the count tool."
+  },
+  "tbTipDigitalSignature": "Digital signature - drag a box to place and sign",
+  "@tbTipDigitalSignature": {
+    "description": "Tooltip for the digital-signature box tool."
+  },
+  "tbTipForm": "Form fields - tap to select, double-tap to fill, drag to add",
+  "@tbTipForm": {
+    "description": "Tooltip for the form-fields tool."
+  },
+  "tbTipHighlightDraw": "Highlight - draw freehand",
+  "@tbTipHighlightDraw": {
+    "description": "Tooltip for the freehand highlighter tool."
+  },
+  "tbTipImage": "Image - tap to place, or drag out a box",
+  "@tbTipImage": {
+    "description": "Tooltip for the insert-image tool."
+  },
+  "tbTipMeasureAngle": "Measure angle - click three points",
+  "@tbTipMeasureAngle": {
+    "description": "Tooltip for the angle-measurement tool."
+  },
+  "tbTipMeasureArc": "Measure arc length - click three points",
+  "@tbTipMeasureArc": {
+    "description": "Tooltip for the arc-length-measurement tool."
+  },
+  "tbTipRedact": "Redact - drag a region, then apply",
+  "@tbTipRedact": {
+    "description": "Tooltip for the redaction tool."
+  },
+  "tbTipSignature": "Signature - tap a page to place it",
+  "@tbTipSignature": {
+    "description": "Tooltip for placing a saved handwritten signature."
+  },
+  "tbTipSnapshot": "Snapshot - drag a region to capture it (paste back as vector)",
+  "@tbTipSnapshot": {
+    "description": "Tooltip for the snapshot capture tool."
   },
   "tbToolContent": "Content",
   "@tbToolContent": {

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -101,6 +101,114 @@ abstract class DartPdfEditorLocalizations {
   /// **'Add'**
   String get add;
 
+  /// Annotation type name: a caret marking an insertion point.
+  ///
+  /// In en, this message translates to:
+  /// **'Caret'**
+  String get annotCaret;
+
+  /// Annotation type name: a circle/ellipse shape.
+  ///
+  /// In en, this message translates to:
+  /// **'Circle'**
+  String get annotCircle;
+
+  /// Annotation type name: an embedded file attachment.
+  ///
+  /// In en, this message translates to:
+  /// **'File attachment'**
+  String get annotFileAttachment;
+
+  /// Annotation type name: a free-text box drawn on the page.
+  ///
+  /// In en, this message translates to:
+  /// **'Text box'**
+  String get annotFreeText;
+
+  /// Annotation type name: a text highlight.
+  ///
+  /// In en, this message translates to:
+  /// **'Highlight'**
+  String get annotHighlight;
+
+  /// Annotation type name: a freehand ink drawing.
+  ///
+  /// In en, this message translates to:
+  /// **'Ink'**
+  String get annotInk;
+
+  /// Annotation type name: a straight line.
+  ///
+  /// In en, this message translates to:
+  /// **'Line'**
+  String get annotLine;
+
+  /// Annotation type name: a hyperlink.
+  ///
+  /// In en, this message translates to:
+  /// **'Link'**
+  String get annotLink;
+
+  /// Annotation type name: a closed polygon shape.
+  ///
+  /// In en, this message translates to:
+  /// **'Polygon'**
+  String get annotPolygon;
+
+  /// Annotation type name: an open multi-segment line.
+  ///
+  /// In en, this message translates to:
+  /// **'Polyline'**
+  String get annotPolyline;
+
+  /// Annotation type name: a redaction region.
+  ///
+  /// In en, this message translates to:
+  /// **'Redaction'**
+  String get annotRedact;
+
+  /// Annotation type name: a rectangle/square shape.
+  ///
+  /// In en, this message translates to:
+  /// **'Square'**
+  String get annotSquare;
+
+  /// Annotation type name: a squiggly (wavy) underline.
+  ///
+  /// In en, this message translates to:
+  /// **'Squiggly'**
+  String get annotSquiggly;
+
+  /// Annotation type name: a rubber stamp.
+  ///
+  /// In en, this message translates to:
+  /// **'Stamp'**
+  String get annotStamp;
+
+  /// Annotation type name: a strike-through over text.
+  ///
+  /// In en, this message translates to:
+  /// **'Strike-out'**
+  String get annotStrikeOut;
+
+  /// Annotation type name: a sticky note / text comment.
+  ///
+  /// In en, this message translates to:
+  /// **'Note'**
+  String get annotText;
+
+  /// Annotation type name: a text underline.
+  ///
+  /// In en, this message translates to:
+  /// **'Underline'**
+  String get annotUnderline;
+
+  /// Annotation type name: an interactive form field widget.
+  ///
+  /// In en, this message translates to:
+  /// **'Form field'**
+  String get annotWidget;
+
   /// Generic button that applies pending changes.
   ///
   /// In en, this message translates to:
@@ -461,6 +569,30 @@ abstract class DartPdfEditorLocalizations {
   /// **'Author name'**
   String get editorViewAuthorNameTitle;
 
+  /// Border line style: an alternating dash-dot line.
+  ///
+  /// In en, this message translates to:
+  /// **'Dash-dot'**
+  String get lineStyleDashDot;
+
+  /// Border line style: a dashed line.
+  ///
+  /// In en, this message translates to:
+  /// **'Dashed'**
+  String get lineStyleDashed;
+
+  /// Border line style: a dotted line.
+  ///
+  /// In en, this message translates to:
+  /// **'Dotted'**
+  String get lineStyleDotted;
+
+  /// Border line style: an unbroken solid line.
+  ///
+  /// In en, this message translates to:
+  /// **'Solid'**
+  String get lineStyleSolid;
+
   /// Button that switches from typing a scale to calibrating by drawing a reference segment.
   ///
   /// In en, this message translates to:
@@ -478,6 +610,60 @@ abstract class DartPdfEditorLocalizations {
   /// In en, this message translates to:
   /// **'Depth: '**
   String get measDepthLabel;
+
+  /// Measurement kind: an angle measurement.
+  ///
+  /// In en, this message translates to:
+  /// **'Angle'**
+  String get measKindAngle;
+
+  /// Measurement kind: an arc-length measurement.
+  ///
+  /// In en, this message translates to:
+  /// **'Arc'**
+  String get measKindArc;
+
+  /// Measurement kind: an area measurement.
+  ///
+  /// In en, this message translates to:
+  /// **'Area'**
+  String get measKindArea;
+
+  /// Measurement kind: a running count of tally marks.
+  ///
+  /// In en, this message translates to:
+  /// **'Count'**
+  String get measKindCount;
+
+  /// Measurement kind: a distance/length measurement.
+  ///
+  /// In en, this message translates to:
+  /// **'Length'**
+  String get measKindLength;
+
+  /// Measurement kind: an area with cut-outs subtracted.
+  ///
+  /// In en, this message translates to:
+  /// **'Net area'**
+  String get measKindNetArea;
+
+  /// Measurement kind: the perimeter of a shape.
+  ///
+  /// In en, this message translates to:
+  /// **'Perimeter'**
+  String get measKindPerimeter;
+
+  /// Measurement kind: a slope (rise over run).
+  ///
+  /// In en, this message translates to:
+  /// **'Slope'**
+  String get measKindSlope;
+
+  /// Measurement kind: a volume (area times depth).
+  ///
+  /// In en, this message translates to:
+  /// **'Volume'**
+  String get measKindVolume;
 
   /// Prompt above the length input in the calibration dialog, asking what real-world length the drawn line represents.
   ///
@@ -1295,6 +1481,90 @@ abstract class DartPdfEditorLocalizations {
   /// **'Save'**
   String get save;
 
+  /// Link target subtitle: runs a JavaScript action.
+  ///
+  /// In en, this message translates to:
+  /// **'JavaScript'**
+  String get sbarActionJavaScript;
+
+  /// Link target subtitle: jumps to the given 1-based page number.
+  ///
+  /// In en, this message translates to:
+  /// **'Page {page}'**
+  String sbarActionPage(int page);
+
+  /// Annotation title for a callout (a text box with a leader line).
+  ///
+  /// In en, this message translates to:
+  /// **'Callout'**
+  String get sbarCallout;
+
+  /// Form-field type shown as an annotation title: a button (push/check/radio).
+  ///
+  /// In en, this message translates to:
+  /// **'Button field'**
+  String get sbarFieldButton;
+
+  /// Form-field type shown as an annotation title: a list/combo choice field.
+  ///
+  /// In en, this message translates to:
+  /// **'Choice field'**
+  String get sbarFieldChoice;
+
+  /// Fallback form-field type shown as an annotation title.
+  ///
+  /// In en, this message translates to:
+  /// **'Form field'**
+  String get sbarFieldGeneric;
+
+  /// Form-field type shown as an annotation title: a digital-signature field.
+  ///
+  /// In en, this message translates to:
+  /// **'Signature field'**
+  String get sbarFieldSignature;
+
+  /// Form-field type shown as an annotation title: a text input field.
+  ///
+  /// In en, this message translates to:
+  /// **'Text field'**
+  String get sbarFieldText;
+
+  /// Review-state chip: the markup was accepted.
+  ///
+  /// In en, this message translates to:
+  /// **'Accepted'**
+  String get sbarStateAccepted;
+
+  /// Review-state chip: the markup was cancelled.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancelled'**
+  String get sbarStateCancelled;
+
+  /// Review-state chip: the markup is flagged/marked.
+  ///
+  /// In en, this message translates to:
+  /// **'Marked'**
+  String get sbarStateMarked;
+
+  /// Review-state chip: the markup was rejected.
+  ///
+  /// In en, this message translates to:
+  /// **'Rejected'**
+  String get sbarStateRejected;
+
+  /// Review-state chip: the comment thread is resolved/completed.
+  ///
+  /// In en, this message translates to:
+  /// **'Resolved'**
+  String get sbarStateResolved;
+
+  /// Review-state chip: the markup's mark was cleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Unmarked'**
+  String get sbarStateUnmarked;
+
   /// Tooltip on the button that clears the document search field.
   ///
   /// In en, this message translates to:
@@ -1691,6 +1961,12 @@ abstract class DartPdfEditorLocalizations {
   /// **'Circle'**
   String get stampCircle;
 
+  /// Default display name for a custom stamp that has no text component.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom stamp'**
+  String get stampCustomCaption;
+
   /// Label for the dropdown selecting the date format used by stamp {{date}} fields.
   ///
   /// In en, this message translates to:
@@ -1721,11 +1997,47 @@ abstract class DartPdfEditorLocalizations {
   /// **'Export…'**
   String get stampExport;
 
+  /// Insertable stamp template field: the current date.
+  ///
+  /// In en, this message translates to:
+  /// **'Date'**
+  String get stampFieldDate;
+
+  /// Insertable stamp template field: the current date and time.
+  ///
+  /// In en, this message translates to:
+  /// **'Date & time'**
+  String get stampFieldDateTime;
+
+  /// Insertable stamp template field: the current time.
+  ///
+  /// In en, this message translates to:
+  /// **'Time'**
+  String get stampFieldTime;
+
+  /// Insertable stamp template field: the current user's name.
+  ///
+  /// In en, this message translates to:
+  /// **'Username'**
+  String get stampFieldUsername;
+
   /// Tooltip on the button that chooses the font of the selected stamp text component.
   ///
   /// In en, this message translates to:
   /// **'Font'**
   String get stampFont;
+
+  /// Font-style modifier shown after a font family name in the stamp font menu.
+  ///
+  /// In en, this message translates to:
+  /// **'Bold'**
+  String get stampFontBold;
+
+  /// Font-style modifier shown after a font family name in the stamp font menu.
+  ///
+  /// In en, this message translates to:
+  /// **'Italic'**
+  String get stampFontItalic;
 
   /// Label for the stamp template height input field.
   ///
@@ -1798,6 +2110,18 @@ abstract class DartPdfEditorLocalizations {
   /// In en, this message translates to:
   /// **'Text'**
   String get stampText;
+
+  /// Suffix in the stamp time-format preview marking a 12-hour (AM/PM) clock format.
+  ///
+  /// In en, this message translates to:
+  /// **'12 hr'**
+  String get stampTime12Hour;
+
+  /// Suffix in the stamp time-format preview marking a 24-hour clock format.
+  ///
+  /// In en, this message translates to:
+  /// **'24 hr'**
+  String get stampTime24Hour;
 
   /// Label for the dropdown selecting the time format used by stamp {{time}} fields.
   ///
@@ -2153,6 +2477,48 @@ abstract class DartPdfEditorLocalizations {
   /// **'Form fields flattened into the pages'**
   String get tbFormFieldsFlattened;
 
+  /// Toolbar dock group label: freehand drawing tools.
+  ///
+  /// In en, this message translates to:
+  /// **'Draw'**
+  String get tbGroupDraw;
+
+  /// Toolbar dock group label: document-editing tools (content/form/redact/…).
+  ///
+  /// In en, this message translates to:
+  /// **'Edit'**
+  String get tbGroupEdit;
+
+  /// Toolbar dock group label: insert tools (text box/note/stamp/…).
+  ///
+  /// In en, this message translates to:
+  /// **'Insert'**
+  String get tbGroupInsert;
+
+  /// Toolbar dock group label: text-markup tools (highlight/underline/…).
+  ///
+  /// In en, this message translates to:
+  /// **'Markup'**
+  String get tbGroupMarkup;
+
+  /// Toolbar dock group label: measurement tools.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure'**
+  String get tbGroupMeasure;
+
+  /// Toolbar dock group label: the selection tools.
+  ///
+  /// In en, this message translates to:
+  /// **'Select'**
+  String get tbGroupSelect;
+
+  /// Toolbar dock group label: shape tools (rectangle/line/…).
+  ///
+  /// In en, this message translates to:
+  /// **'Shapes'**
+  String get tbGroupShapes;
+
   /// Menu option: create an image push-button form field.
   ///
   /// In en, this message translates to:
@@ -2189,11 +2555,215 @@ abstract class DartPdfEditorLocalizations {
   /// **'Manage stamps…'**
   String get tbManageStamps;
 
+  /// Text-markup action name: highlight the text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Highlight'**
+  String get tbMarkupHighlight;
+
+  /// Tooltip: highlight the current text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Highlight selection'**
+  String get tbMarkupHighlightTip;
+
+  /// Text-markup action name: squiggly-underline the text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Squiggly-underline'**
+  String get tbMarkupSquiggly;
+
+  /// Tooltip: squiggly-underline the current text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Squiggly-underline selection'**
+  String get tbMarkupSquigglyTip;
+
+  /// Text-markup action name: strike out the text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Strike out'**
+  String get tbMarkupStrikeOut;
+
+  /// Tooltip: strike out the current text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Strike out selection'**
+  String get tbMarkupStrikeOutTip;
+
+  /// Text-markup action name: underline the text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Underline'**
+  String get tbMarkupUnderline;
+
+  /// Tooltip: underline the current text selection.
+  ///
+  /// In en, this message translates to:
+  /// **'Underline selection'**
+  String get tbMarkupUnderlineTip;
+
   /// Tooltip for the button opening the full color picker.
   ///
   /// In en, this message translates to:
   /// **'More colors…'**
   String get tbMoreColors;
+
+  /// Tool name: draw an arrow.
+  ///
+  /// In en, this message translates to:
+  /// **'Arrow'**
+  String get tbNameArrow;
+
+  /// Tool name: insert a callout (text box with a leader line).
+  ///
+  /// In en, this message translates to:
+  /// **'Callout'**
+  String get tbNameCallout;
+
+  /// Tool name: draw a cloud-outline polygon.
+  ///
+  /// In en, this message translates to:
+  /// **'Cloud polygon'**
+  String get tbNameCloudPolygon;
+
+  /// Tool name: drop tally check-marks.
+  ///
+  /// In en, this message translates to:
+  /// **'Count'**
+  String get tbNameCount;
+
+  /// Tool name: place and cryptographically sign a signature box.
+  ///
+  /// In en, this message translates to:
+  /// **'Digital signature'**
+  String get tbNameDigitalSignature;
+
+  /// Tool name: freehand ink drawing.
+  ///
+  /// In en, this message translates to:
+  /// **'Draw'**
+  String get tbNameDraw;
+
+  /// Tool name: draw an ellipse shape.
+  ///
+  /// In en, this message translates to:
+  /// **'Ellipse'**
+  String get tbNameEllipse;
+
+  /// Tool name: erases ink strokes.
+  ///
+  /// In en, this message translates to:
+  /// **'Erase ink strokes'**
+  String get tbNameEraser;
+
+  /// Tool name: freehand highlighter.
+  ///
+  /// In en, this message translates to:
+  /// **'Highlight'**
+  String get tbNameHighlight;
+
+  /// Tool name: insert a raster image.
+  ///
+  /// In en, this message translates to:
+  /// **'Image'**
+  String get tbNameImage;
+
+  /// Tool name: draw a straight line.
+  ///
+  /// In en, this message translates to:
+  /// **'Line'**
+  String get tbNameLine;
+
+  /// Tool name: measure an interior angle.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure angle'**
+  String get tbNameMeasureAngle;
+
+  /// Tool name: measure an arc length.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure arc length'**
+  String get tbNameMeasureArc;
+
+  /// Tool name: measure an area.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure area'**
+  String get tbNameMeasureArea;
+
+  /// Tool name: measure a straight-line distance.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure distance'**
+  String get tbNameMeasureDistance;
+
+  /// Tool name: measure a perimeter.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure perimeter'**
+  String get tbNameMeasurePerimeter;
+
+  /// Tool name: measure a slope as rise over run.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure slope (rise/run)'**
+  String get tbNameMeasureSlope;
+
+  /// Tool name: measure a volume as area times depth.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure volume (area × depth)'**
+  String get tbNameMeasureVolume;
+
+  /// Tool name: insert a sticky note.
+  ///
+  /// In en, this message translates to:
+  /// **'Note'**
+  String get tbNameNote;
+
+  /// Tool name: draw a closed polygon.
+  ///
+  /// In en, this message translates to:
+  /// **'Polygon'**
+  String get tbNamePolygon;
+
+  /// Tool name: draw an open multi-segment line.
+  ///
+  /// In en, this message translates to:
+  /// **'Polyline'**
+  String get tbNamePolyline;
+
+  /// Tool name: draw a rectangle shape.
+  ///
+  /// In en, this message translates to:
+  /// **'Rectangle'**
+  String get tbNameRectangle;
+
+  /// Tool name: the select/move tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Select'**
+  String get tbNameSelect;
+
+  /// Tool name: place a saved handwritten signature.
+  ///
+  /// In en, this message translates to:
+  /// **'Signature'**
+  String get tbNameSignature;
+
+  /// Tool name: insert a rubber stamp.
+  ///
+  /// In en, this message translates to:
+  /// **'Stamp'**
+  String get tbNameStamp;
+
+  /// Tool name: insert a free-text box.
+  ///
+  /// In en, this message translates to:
+  /// **'Text box'**
+  String get tbNameTextBox;
 
   /// Tooltip for the menu selecting which type of form field a drag will create.
   ///
@@ -2422,6 +2992,78 @@ abstract class DartPdfEditorLocalizations {
   /// In en, this message translates to:
   /// **'Text'**
   String get tbTextTitle;
+
+  /// Tooltip for the callout tool, explaining the drag gesture.
+  ///
+  /// In en, this message translates to:
+  /// **'Callout - drag from the point to where the box goes'**
+  String get tbTipCallout;
+
+  /// Tooltip for the page-content editing tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit page content'**
+  String get tbTipContent;
+
+  /// Tooltip for the count tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Count - tap to drop check-marks and tally them'**
+  String get tbTipCount;
+
+  /// Tooltip for the digital-signature box tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Digital signature - drag a box to place and sign'**
+  String get tbTipDigitalSignature;
+
+  /// Tooltip for the form-fields tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Form fields - tap to select, double-tap to fill, drag to add'**
+  String get tbTipForm;
+
+  /// Tooltip for the freehand highlighter tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Highlight - draw freehand'**
+  String get tbTipHighlightDraw;
+
+  /// Tooltip for the insert-image tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Image - tap to place, or drag out a box'**
+  String get tbTipImage;
+
+  /// Tooltip for the angle-measurement tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure angle - click three points'**
+  String get tbTipMeasureAngle;
+
+  /// Tooltip for the arc-length-measurement tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Measure arc length - click three points'**
+  String get tbTipMeasureArc;
+
+  /// Tooltip for the redaction tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Redact - drag a region, then apply'**
+  String get tbTipRedact;
+
+  /// Tooltip for placing a saved handwritten signature.
+  ///
+  /// In en, this message translates to:
+  /// **'Signature - tap a page to place it'**
+  String get tbTipSignature;
+
+  /// Tooltip for the snapshot capture tool.
+  ///
+  /// In en, this message translates to:
+  /// **'Snapshot - drag a region to capture it (paste back as vector)'**
+  String get tbTipSnapshot;
 
   /// Label for the page-content editing tool.
   ///

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -12,6 +12,60 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get add => 'Add';
 
   @override
+  String get annotCaret => 'Caret';
+
+  @override
+  String get annotCircle => 'Circle';
+
+  @override
+  String get annotFileAttachment => 'File attachment';
+
+  @override
+  String get annotFreeText => 'Text box';
+
+  @override
+  String get annotHighlight => 'Highlight';
+
+  @override
+  String get annotInk => 'Ink';
+
+  @override
+  String get annotLine => 'Line';
+
+  @override
+  String get annotLink => 'Link';
+
+  @override
+  String get annotPolygon => 'Polygon';
+
+  @override
+  String get annotPolyline => 'Polyline';
+
+  @override
+  String get annotRedact => 'Redaction';
+
+  @override
+  String get annotSquare => 'Square';
+
+  @override
+  String get annotSquiggly => 'Squiggly';
+
+  @override
+  String get annotStamp => 'Stamp';
+
+  @override
+  String get annotStrikeOut => 'Strike-out';
+
+  @override
+  String get annotText => 'Note';
+
+  @override
+  String get annotUnderline => 'Underline';
+
+  @override
+  String get annotWidget => 'Form field';
+
+  @override
   String get apply => 'Apply';
 
   @override
@@ -226,6 +280,18 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get editorViewAuthorNameTitle => 'Author name';
 
   @override
+  String get lineStyleDashDot => 'Dash-dot';
+
+  @override
+  String get lineStyleDashed => 'Dashed';
+
+  @override
+  String get lineStyleDotted => 'Dotted';
+
+  @override
+  String get lineStyleSolid => 'Solid';
+
+  @override
   String get measCalibrate => 'Calibrate';
 
   @override
@@ -233,6 +299,33 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
 
   @override
   String get measDepthLabel => 'Depth: ';
+
+  @override
+  String get measKindAngle => 'Angle';
+
+  @override
+  String get measKindArc => 'Arc';
+
+  @override
+  String get measKindArea => 'Area';
+
+  @override
+  String get measKindCount => 'Count';
+
+  @override
+  String get measKindLength => 'Length';
+
+  @override
+  String get measKindNetArea => 'Net area';
+
+  @override
+  String get measKindPerimeter => 'Perimeter';
+
+  @override
+  String get measKindSlope => 'Slope';
+
+  @override
+  String get measKindVolume => 'Volume';
 
   @override
   String get measLineRepresents => 'The line you drew represents:';
@@ -678,6 +771,50 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get save => 'Save';
 
   @override
+  String get sbarActionJavaScript => 'JavaScript';
+
+  @override
+  String sbarActionPage(int page) {
+    return 'Page $page';
+  }
+
+  @override
+  String get sbarCallout => 'Callout';
+
+  @override
+  String get sbarFieldButton => 'Button field';
+
+  @override
+  String get sbarFieldChoice => 'Choice field';
+
+  @override
+  String get sbarFieldGeneric => 'Form field';
+
+  @override
+  String get sbarFieldSignature => 'Signature field';
+
+  @override
+  String get sbarFieldText => 'Text field';
+
+  @override
+  String get sbarStateAccepted => 'Accepted';
+
+  @override
+  String get sbarStateCancelled => 'Cancelled';
+
+  @override
+  String get sbarStateMarked => 'Marked';
+
+  @override
+  String get sbarStateRejected => 'Rejected';
+
+  @override
+  String get sbarStateResolved => 'Resolved';
+
+  @override
+  String get sbarStateUnmarked => 'Unmarked';
+
+  @override
   String get searchClearSearch => 'Clear search';
 
   @override
@@ -906,6 +1043,9 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get stampCircle => 'Circle';
 
   @override
+  String get stampCustomCaption => 'Custom stamp';
+
+  @override
   String get stampDateFormat => 'Date format';
 
   @override
@@ -921,7 +1061,25 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get stampExport => 'Export…';
 
   @override
+  String get stampFieldDate => 'Date';
+
+  @override
+  String get stampFieldDateTime => 'Date & time';
+
+  @override
+  String get stampFieldTime => 'Time';
+
+  @override
+  String get stampFieldUsername => 'Username';
+
+  @override
   String get stampFont => 'Font';
+
+  @override
+  String get stampFontBold => 'Bold';
+
+  @override
+  String get stampFontItalic => 'Italic';
 
   @override
   String get stampHeight => 'Height';
@@ -958,6 +1116,12 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
 
   @override
   String get stampText => 'Text';
+
+  @override
+  String get stampTime12Hour => '12 hr';
+
+  @override
+  String get stampTime24Hour => '24 hr';
 
   @override
   String get stampTimeFormat => 'Time format';
@@ -1177,6 +1341,27 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get tbFormFieldsFlattened => 'Form fields flattened into the pages';
 
   @override
+  String get tbGroupDraw => 'Draw';
+
+  @override
+  String get tbGroupEdit => 'Edit';
+
+  @override
+  String get tbGroupInsert => 'Insert';
+
+  @override
+  String get tbGroupMarkup => 'Markup';
+
+  @override
+  String get tbGroupMeasure => 'Measure';
+
+  @override
+  String get tbGroupSelect => 'Select';
+
+  @override
+  String get tbGroupShapes => 'Shapes';
+
+  @override
   String get tbImageButtonOption => 'Image button';
 
   @override
@@ -1195,7 +1380,109 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get tbManageStamps => 'Manage stamps…';
 
   @override
+  String get tbMarkupHighlight => 'Highlight';
+
+  @override
+  String get tbMarkupHighlightTip => 'Highlight selection';
+
+  @override
+  String get tbMarkupSquiggly => 'Squiggly-underline';
+
+  @override
+  String get tbMarkupSquigglyTip => 'Squiggly-underline selection';
+
+  @override
+  String get tbMarkupStrikeOut => 'Strike out';
+
+  @override
+  String get tbMarkupStrikeOutTip => 'Strike out selection';
+
+  @override
+  String get tbMarkupUnderline => 'Underline';
+
+  @override
+  String get tbMarkupUnderlineTip => 'Underline selection';
+
+  @override
   String get tbMoreColors => 'More colors…';
+
+  @override
+  String get tbNameArrow => 'Arrow';
+
+  @override
+  String get tbNameCallout => 'Callout';
+
+  @override
+  String get tbNameCloudPolygon => 'Cloud polygon';
+
+  @override
+  String get tbNameCount => 'Count';
+
+  @override
+  String get tbNameDigitalSignature => 'Digital signature';
+
+  @override
+  String get tbNameDraw => 'Draw';
+
+  @override
+  String get tbNameEllipse => 'Ellipse';
+
+  @override
+  String get tbNameEraser => 'Erase ink strokes';
+
+  @override
+  String get tbNameHighlight => 'Highlight';
+
+  @override
+  String get tbNameImage => 'Image';
+
+  @override
+  String get tbNameLine => 'Line';
+
+  @override
+  String get tbNameMeasureAngle => 'Measure angle';
+
+  @override
+  String get tbNameMeasureArc => 'Measure arc length';
+
+  @override
+  String get tbNameMeasureArea => 'Measure area';
+
+  @override
+  String get tbNameMeasureDistance => 'Measure distance';
+
+  @override
+  String get tbNameMeasurePerimeter => 'Measure perimeter';
+
+  @override
+  String get tbNameMeasureSlope => 'Measure slope (rise/run)';
+
+  @override
+  String get tbNameMeasureVolume => 'Measure volume (area × depth)';
+
+  @override
+  String get tbNameNote => 'Note';
+
+  @override
+  String get tbNamePolygon => 'Polygon';
+
+  @override
+  String get tbNamePolyline => 'Polyline';
+
+  @override
+  String get tbNameRectangle => 'Rectangle';
+
+  @override
+  String get tbNameSelect => 'Select';
+
+  @override
+  String get tbNameSignature => 'Signature';
+
+  @override
+  String get tbNameStamp => 'Stamp';
+
+  @override
+  String get tbNameTextBox => 'Text box';
 
   @override
   String get tbNewFieldType => 'New field type - drag on a page to add one';
@@ -1321,6 +1608,46 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
 
   @override
   String get tbTextTitle => 'Text';
+
+  @override
+  String get tbTipCallout =>
+      'Callout - drag from the point to where the box goes';
+
+  @override
+  String get tbTipContent => 'Edit page content';
+
+  @override
+  String get tbTipCount => 'Count - tap to drop check-marks and tally them';
+
+  @override
+  String get tbTipDigitalSignature =>
+      'Digital signature - drag a box to place and sign';
+
+  @override
+  String get tbTipForm =>
+      'Form fields - tap to select, double-tap to fill, drag to add';
+
+  @override
+  String get tbTipHighlightDraw => 'Highlight - draw freehand';
+
+  @override
+  String get tbTipImage => 'Image - tap to place, or drag out a box';
+
+  @override
+  String get tbTipMeasureAngle => 'Measure angle - click three points';
+
+  @override
+  String get tbTipMeasureArc => 'Measure arc length - click three points';
+
+  @override
+  String get tbTipRedact => 'Redact - drag a region, then apply';
+
+  @override
+  String get tbTipSignature => 'Signature - tap a page to place it';
+
+  @override
+  String get tbTipSnapshot =>
+      'Snapshot - drag a region to capture it (paste back as vector)';
 
   @override
   String get tbToolContent => 'Content';

--- a/packages/dart_pdf_editor/lib/src/editing/annotation_presentation.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/annotation_presentation.dart
@@ -1,16 +1,87 @@
 import 'package:flutter/material.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import '../l10n/pdf_l10n.dart';
+import 'line_style.dart';
 
 /// Flutter-only presentation for PDF annotation subtypes.
 ///
 /// Semantic editing policy lives in `PdfAnnotation.behavior` in
 /// pdf_document; Material names and icons stay above the Flutter boundary.
-String pdfAnnotationLabel(String subtype) => switch (subtype) {
-      'StrikeOut' => 'Strike-out',
-      'FreeText' => 'Text box',
-      'Text' => 'Note',
-      'Widget' => 'Form field',
-      _ => subtype,
-    };
+/// The subtype string is the stable key; the visible name is resolved from
+/// the localizations so the same mapping serves every consumer.
+String pdfAnnotationLabel(BuildContext context, String subtype) {
+  final l = pdfL10n(context);
+  return switch (subtype) {
+    'Highlight' => l.annotHighlight,
+    'Underline' => l.annotUnderline,
+    'StrikeOut' => l.annotStrikeOut,
+    'Squiggly' => l.annotSquiggly,
+    'Ink' => l.annotInk,
+    'Square' => l.annotSquare,
+    'Circle' => l.annotCircle,
+    'Line' => l.annotLine,
+    'Polygon' => l.annotPolygon,
+    'PolyLine' => l.annotPolyline,
+    'FreeText' => l.annotFreeText,
+    'Text' => l.annotText,
+    'Stamp' => l.annotStamp,
+    'Link' => l.annotLink,
+    'Widget' => l.annotWidget,
+    'FileAttachment' => l.annotFileAttachment,
+    'Caret' => l.annotCaret,
+    'Redact' => l.annotRedact,
+    _ => subtype,
+  };
+}
+
+/// The localized name of a border [PdfLineStyle] (Solid/Dashed/…), for the
+/// line-style pickers. The enum is the stable key.
+String pdfLineStyleLabel(BuildContext context, PdfLineStyle style) {
+  final l = pdfL10n(context);
+  return switch (style) {
+    PdfLineStyle.solid => l.lineStyleSolid,
+    PdfLineStyle.dashed => l.lineStyleDashed,
+    PdfLineStyle.dotted => l.lineStyleDotted,
+    PdfLineStyle.dashDot => l.lineStyleDashDot,
+  };
+}
+
+/// The localized name of a [PdfMeasurementKind], for the takeoff register
+/// and measurement chrome.
+String pdfMeasurementKindLabel(BuildContext context, PdfMeasurementKind kind) {
+  final l = pdfL10n(context);
+  return switch (kind) {
+    PdfMeasurementKind.count => l.measKindCount,
+    PdfMeasurementKind.distance => l.measKindLength,
+    PdfMeasurementKind.perimeter => l.measKindPerimeter,
+    PdfMeasurementKind.area => l.measKindArea,
+    PdfMeasurementKind.areaCutout => l.measKindNetArea,
+    PdfMeasurementKind.volume => l.measKindVolume,
+    PdfMeasurementKind.angle => l.measKindAngle,
+    PdfMeasurementKind.arc => l.measKindArc,
+    PdfMeasurementKind.slope => l.measKindSlope,
+  };
+}
+
+/// The localized name of a [PdfLineEnding] (None/Square/Open arrow/…), for
+/// the line-ending pickers. Shared by the toolbar strip and the
+/// Properties panel.
+String pdfLineEndingLabel(BuildContext context, PdfLineEnding ending) {
+  final l = pdfL10n(context);
+  return switch (ending) {
+    PdfLineEnding.none => l.none,
+    PdfLineEnding.square => l.propLineEndingSquare,
+    PdfLineEnding.circle => l.propLineEndingCircle,
+    PdfLineEnding.diamond => l.propLineEndingDiamond,
+    PdfLineEnding.openArrow => l.propLineEndingOpenArrow,
+    PdfLineEnding.closedArrow => l.propLineEndingClosedArrow,
+    PdfLineEnding.butt => l.propLineEndingButt,
+    PdfLineEnding.rOpenArrow => l.propLineEndingOpenArrowRev,
+    PdfLineEnding.rClosedArrow => l.propLineEndingClosedArrowRev,
+    PdfLineEnding.slash => l.propLineEndingSlash,
+  };
+}
 
 IconData pdfAnnotationIcon(String subtype) => switch (subtype) {
       'Highlight' => Icons.border_color,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_panel.dart
@@ -38,19 +38,30 @@ enum PdfPanelDock {
 /// dragged from a move handle onto a drop zone and the identity a shell maps
 /// to the panel's persisted [PdfPanelDock].
 enum PdfDockablePanel {
-  thumbnails('Pages', Icons.grid_view),
-  search('Search results', Icons.manage_search),
-  bookmarks('Bookmarks', Icons.bookmarks_outlined),
-  annotations('Annotations', Icons.list_alt),
-  properties('Properties', Icons.tune);
+  thumbnails(Icons.grid_view),
+  search(Icons.manage_search),
+  bookmarks(Icons.bookmarks_outlined),
+  annotations(Icons.list_alt),
+  properties(Icons.tune);
 
-  const PdfDockablePanel(this.label, this.icon);
-
-  /// A human-readable name shown on the drag feedback chip.
-  final String label;
+  const PdfDockablePanel(this.icon);
 
   /// The panel's glyph, shown on the drag feedback chip.
   final IconData icon;
+
+  /// A localized, human-readable name shown on the drag feedback chip and
+  /// panel headers. Reuses the shell's panel names so the same words are
+  /// translated once.
+  String label(BuildContext context) {
+    final l = pdfL10n(context);
+    return switch (this) {
+      PdfDockablePanel.thumbnails => l.shellPanelPages,
+      PdfDockablePanel.search => l.shellPanelSearchResults,
+      PdfDockablePanel.bookmarks => l.shellPanelBookmarks,
+      PdfDockablePanel.annotations => l.shellPanelAnnotations,
+      PdfDockablePanel.properties => l.shellPanelProperties,
+    };
+  }
 }
 
 /// Whether panel row controls should be revealed by mouse hover.
@@ -184,7 +195,7 @@ class PdfPanelDragFeedback extends StatelessWidget {
         child: Row(mainAxisSize: MainAxisSize.min, children: [
           Icon(panel.icon, size: 18, color: scheme.onPrimaryContainer),
           const SizedBox(width: 8),
-          Text(panel.label,
+          Text(panel.label(context),
               style: TextStyle(
                   color: scheme.onPrimaryContainer,
                   fontWeight: FontWeight.w500)),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -599,7 +599,7 @@ class _PdfAnnotationPropertiesPanelState
                 DropdownMenuItem(
                     value: style,
                     key: ValueKey('pdf-prop-line-type-${style.name}'),
-                    child: Text(style.label)),
+                    child: Text(pdfLineStyleLabel(context, style))),
             ],
             onChanged: (style) {
               if (style != null) _controller.restyleSelected(lineStyle: style);
@@ -909,7 +909,7 @@ class _PdfAnnotationPropertiesPanelState
             : pdfAnnotationIcon(annotation.subtype)),
         title: Text(annotation.isCallout
             ? pdfL10n(context).propCallout
-            : pdfAnnotationLabel(annotation.subtype)),
+            : pdfAnnotationLabel(context, annotation.subtype)),
         subtitle: Text(pdfL10n(context).propPageNumber(slot.$1 + 1)),
       ),
       ..._styleControls(),
@@ -983,7 +983,7 @@ class _PdfAnnotationPropertiesPanelState
       for (final annotation in annotations)
         annotation.isCallout
             ? pdfL10n(context).propCallout
-            : pdfAnnotationLabel(annotation.subtype),
+            : pdfAnnotationLabel(context, annotation.subtype),
     ]);
     final page = _common<int>([
       for (final (page, _) in _controller.selectedAnnotationSlots) page + 1,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -163,20 +163,6 @@ class _PdfAnnotationPropertiesPanelState
     if (mounted) setState(() {});
   }
 
-  String _endingLabel(PdfLineEnding ending) => switch (ending) {
-        PdfLineEnding.none => pdfL10n(context).none,
-        PdfLineEnding.square => pdfL10n(context).propLineEndingSquare,
-        PdfLineEnding.circle => pdfL10n(context).propLineEndingCircle,
-        PdfLineEnding.diamond => pdfL10n(context).propLineEndingDiamond,
-        PdfLineEnding.openArrow => pdfL10n(context).propLineEndingOpenArrow,
-        PdfLineEnding.closedArrow => pdfL10n(context).propLineEndingClosedArrow,
-        PdfLineEnding.butt => pdfL10n(context).propLineEndingButt,
-        PdfLineEnding.rOpenArrow => pdfL10n(context).propLineEndingOpenArrowRev,
-        PdfLineEnding.rClosedArrow =>
-          pdfL10n(context).propLineEndingClosedArrowRev,
-        PdfLineEnding.slash => pdfL10n(context).propLineEndingSlash,
-      };
-
   Widget _lineEndingRow({
     required String label,
     required Key key,
@@ -198,7 +184,7 @@ class _PdfAnnotationPropertiesPanelState
               for (final ending in PdfLineEnding.values)
                 DropdownMenuItem(
                   value: ending,
-                  child: Text(_endingLabel(ending),
+                  child: Text(pdfLineEndingLabel(context, ending),
                       overflow: TextOverflow.ellipsis),
                 ),
             ],

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -175,21 +175,21 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   }
 
   /// A finer title for form fields, from the inherited /FT.
-  static String _fieldLabel(String? fieldType) => switch (fieldType) {
-        'Tx' => 'Text field',
-        'Btn' => 'Button field',
-        'Ch' => 'Choice field',
-        'Sig' => 'Signature field',
-        _ => 'Form field',
+  String _fieldLabel(String? fieldType) => switch (fieldType) {
+        'Tx' => pdfL10n(context).sbarFieldText,
+        'Btn' => pdfL10n(context).sbarFieldButton,
+        'Ch' => pdfL10n(context).sbarFieldChoice,
+        'Sig' => pdfL10n(context).sbarFieldSignature,
+        _ => pdfL10n(context).sbarFieldGeneric,
       };
 
   /// Where an action leads, for a link tile's subtitle.
-  static String? _actionLabel(PdfAction? action) => switch (action) {
+  String? _actionLabel(PdfAction? action) => switch (action) {
         PdfUriAction(:final uri) => uri,
         PdfGoToAction(:final destination) =>
-          'Page ${destination.pageIndex + 1}',
+          pdfL10n(context).sbarActionPage(destination.pageIndex + 1),
         PdfNamedAction(:final name) => name,
-        PdfJavaScriptAction() => 'JavaScript',
+        PdfJavaScriptAction() => pdfL10n(context).sbarActionJavaScript,
         PdfUnknownAction(:final type) => type.isEmpty ? null : type,
         null => null,
       };
@@ -241,8 +241,8 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
   String _title(PdfAnnotation annotation) => annotation is PdfWidgetAnnotation
       ? _fieldLabel(annotation.fieldType)
       : annotation.isCallout
-          ? 'Callout'
-          : pdfAnnotationLabel(annotation.subtype);
+          ? pdfL10n(context).sbarCallout
+          : pdfAnnotationLabel(context, annotation.subtype);
 
   bool _matches(String query, int pageIndex, PdfAnnotation annotation) {
     if (query.isEmpty) return true;
@@ -526,16 +526,18 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
 
   /// The label and accent color for a review state chip, or null when the
   /// state is `None` (an open/unresolved thread shows no chip).
-  static (String, Color)? _stateChip(PdfReviewState state, ColorScheme cs) =>
-      switch (state) {
-        PdfReviewState.completed => ('Resolved', Colors.green),
-        PdfReviewState.accepted => ('Accepted', Colors.green),
-        PdfReviewState.rejected => ('Rejected', Colors.red),
-        PdfReviewState.cancelled => ('Cancelled', Colors.orange),
-        PdfReviewState.marked => ('Marked', Colors.blue),
-        PdfReviewState.unmarked => ('Unmarked', cs.outline),
-        PdfReviewState.none => null,
-      };
+  (String, Color)? _stateChip(PdfReviewState state, ColorScheme cs) {
+    final l = pdfL10n(context);
+    return switch (state) {
+      PdfReviewState.completed => (l.sbarStateResolved, Colors.green),
+      PdfReviewState.accepted => (l.sbarStateAccepted, Colors.green),
+      PdfReviewState.rejected => (l.sbarStateRejected, Colors.red),
+      PdfReviewState.cancelled => (l.sbarStateCancelled, Colors.orange),
+      PdfReviewState.marked => (l.sbarStateMarked, Colors.blue),
+      PdfReviewState.unmarked => (l.sbarStateUnmarked, cs.outline),
+      PdfReviewState.none => null,
+    };
+  }
 
   /// Each comment in [root]'s reply tree with its depth (root = 0), in
   /// document/pre-order.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
@@ -347,14 +347,15 @@ class _StampDateTimeFormatControls extends StatelessWidget {
 
   final PdfEditingController controller;
 
-  static String _timePreview(PdfStampTimeFormat format, DateTime sample) {
+  static String _timePreview(
+      BuildContext context, PdfStampTimeFormat format, DateTime sample) {
     final suffix = switch (format) {
       PdfStampTimeFormat.twentyFourHour ||
       PdfStampTimeFormat.twentyFourHourSeconds =>
-        '24 hr',
+        pdfL10n(context).stampTime24Hour,
       PdfStampTimeFormat.twelveHour ||
       PdfStampTimeFormat.twelveHourSeconds =>
-        '12 hr',
+        pdfL10n(context).stampTime12Hour,
     };
     return '${format.format(sample)} ($suffix)';
   }
@@ -400,7 +401,7 @@ class _StampDateTimeFormatControls extends StatelessWidget {
                 DropdownMenuItem<PdfStampTimeFormat>(
                   key: ValueKey('pdf-stamp-time-format-${format.name}'),
                   value: format,
-                  child: Text(_timePreview(format, sample)),
+                  child: Text(_timePreview(context, format, sample)),
                 ),
             ],
             onChanged: (value) {
@@ -511,7 +512,7 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
         return component.text.trim();
       }
     }
-    return 'Custom stamp';
+    return pdfL10n(context).stampCustomCaption;
   }
 
   int get _primaryColor =>
@@ -888,7 +889,7 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
                             key: ValueKey('pdf-stamp-field-$field'),
                             value: field,
                             height: 34,
-                            child: Text(_fieldLabel(field)),
+                            child: Text(_fieldLabel(context, field)),
                           ),
                       ],
                     ),
@@ -906,7 +907,7 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
                             value: font,
                             height: 34,
                             child: Text(
-                              _fontLabel(font),
+                              _fontLabel(context, font),
                               style: TextStyle(
                                 fontFamily: _uiFamily(font),
                                 fontWeight: font.isBold
@@ -1615,11 +1616,12 @@ String? _stampDetail(PdfCustomStamp stamp) {
   return parts.isEmpty ? null : parts.join(' · ');
 }
 
-String _fontLabel(PdfStandardFont font) {
+String _fontLabel(BuildContext context, PdfStandardFont font) {
   final family = font.family.label;
+  final l = pdfL10n(context);
   final style = [
-    if (font.isBold) 'Bold',
-    if (font.isItalic) 'Italic',
+    if (font.isBold) l.stampFontBold,
+    if (font.isItalic) l.stampFontItalic,
   ].join(' ');
   return style.isEmpty ? family : '$family $style';
 }
@@ -1641,11 +1643,11 @@ List<String> _normalizeFields(Iterable<String> fields) {
   return List.unmodifiable(normalized);
 }
 
-String _fieldLabel(String field) => switch (field) {
-      'date' => 'Date',
-      'time' => 'Time',
-      'datetime' => 'Date & time',
-      'username' => 'Username',
+String _fieldLabel(BuildContext context, String field) => switch (field) {
+      'date' => pdfL10n(context).stampFieldDate,
+      'time' => pdfL10n(context).stampFieldTime,
+      'datetime' => pdfL10n(context).stampFieldDateTime,
+      'username' => pdfL10n(context).stampFieldUsername,
       _ => field
           .split(RegExp(r'[_\s]+'))
           .where((part) => part.isNotEmpty)

--- a/packages/dart_pdf_editor/lib/src/editing/editing_takeoff.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_takeoff.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:pdf_document/pdf_document.dart';
 
 import '../l10n/pdf_l10n.dart';
+import 'annotation_presentation.dart';
 import 'editing_controller.dart';
 
 /// A compact takeoff register: the per-tool running totals over the live
@@ -70,7 +71,7 @@ class PdfTakeoffPanel extends StatelessWidget {
                     dense: true,
                     leading: Icon(_iconFor(g.kind), size: 20),
                     title: Text(g.label),
-                    subtitle: Text(_kindLabel(g.kind)),
+                    subtitle: Text(pdfMeasurementKindLabel(context, g.kind)),
                     trailing: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.end,
@@ -123,18 +124,6 @@ class PdfTakeoffPanel extends StatelessWidget {
         PdfMeasurementKind.angle => Icons.architecture,
         PdfMeasurementKind.arc => Icons.gesture,
         PdfMeasurementKind.slope => Icons.trending_up,
-      };
-
-  static String _kindLabel(PdfMeasurementKind kind) => switch (kind) {
-        PdfMeasurementKind.count => 'Count',
-        PdfMeasurementKind.distance => 'Length',
-        PdfMeasurementKind.perimeter => 'Perimeter',
-        PdfMeasurementKind.area => 'Area',
-        PdfMeasurementKind.areaCutout => 'Net area',
-        PdfMeasurementKind.volume => 'Volume',
-        PdfMeasurementKind.angle => 'Angle',
-        PdfMeasurementKind.arc => 'Arc',
-        PdfMeasurementKind.slope => 'Slope',
       };
 }
 

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -17,6 +17,7 @@ import 'package:pdf_document/pdf_document.dart'
 import '../l10n/pdf_l10n.dart';
 import '../pdf_viewer.dart';
 import '../toast.dart';
+import 'annotation_presentation.dart';
 import 'editing_color_pick.dart';
 import 'editing_color_processing.dart';
 import 'editing_controller.dart';
@@ -246,13 +247,12 @@ class PdfEditingToolbar extends StatefulWidget {
 /// text-markup action ([PdfMarkupKind], which acts on the live text
 /// selection rather than arming a tool).
 class _GroupTool {
-  const _GroupTool.tool(this.tool, this.icon, this.tip) : markup = null;
-  const _GroupTool.markup(this.markup, this.icon, this.tip) : tool = null;
+  const _GroupTool.tool(this.tool, this.icon) : markup = null;
+  const _GroupTool.markup(this.markup, this.icon) : tool = null;
 
   final PdfEditTool? tool;
   final PdfMarkupKind? markup;
   final IconData icon;
-  final String tip;
 }
 
 /// A dock group: a labelled chip that raises a contextual strip of
@@ -261,14 +261,27 @@ class _GroupTool {
 /// first tool has a prerequisite (Measure needs a scale, Insert's
 /// signature needs a drawing) leave it null and wait for an explicit tap.
 class _ToolGroup {
-  const _ToolGroup(this.id, this.label, this.icon, this.tools,
-      {this.defaultTool});
+  const _ToolGroup(this.id, this.icon, this.tools, {this.defaultTool});
 
   final String id;
-  final String label;
   final IconData icon;
   final List<_GroupTool> tools;
   final PdfEditTool? defaultTool;
+
+  /// The localized group name (the stable [id] is the translation key).
+  String label(BuildContext context) {
+    final l = pdfL10n(context);
+    return switch (id) {
+      'select' => l.tbGroupSelect,
+      'markup' => l.tbGroupMarkup,
+      'draw' => l.tbGroupDraw,
+      'shapes' => l.tbGroupShapes,
+      'insert' => l.tbGroupInsert,
+      'measure' => l.tbGroupMeasure,
+      'edit' => l.tbGroupEdit,
+      _ => id,
+    };
+  }
 }
 
 enum _SelectedFormOverflowAction {
@@ -316,98 +329,151 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   static const _groups = <_ToolGroup>[
     _ToolGroup(
         'select',
-        'Select',
         Icons.near_me,
         [
-          _GroupTool.tool(PdfEditTool.select, Icons.near_me, 'Select'),
+          _GroupTool.tool(PdfEditTool.select, Icons.near_me),
         ],
         defaultTool: PdfEditTool.select),
-    _ToolGroup('markup', 'Markup', Icons.edit_note, [
-      _GroupTool.markup(
-          PdfMarkupKind.highlight, Icons.border_color, 'Highlight selection'),
-      _GroupTool.markup(PdfMarkupKind.underline, Icons.format_underlined,
-          'Underline selection'),
-      _GroupTool.markup(PdfMarkupKind.strikeOut, Icons.format_strikethrough,
-          'Strike out selection'),
-      _GroupTool.markup(PdfMarkupKind.squiggly, Icons.gesture,
-          'Squiggly-underline selection'),
+    _ToolGroup('markup', Icons.edit_note, [
+      _GroupTool.markup(PdfMarkupKind.highlight, Icons.border_color),
+      _GroupTool.markup(PdfMarkupKind.underline, Icons.format_underlined),
+      _GroupTool.markup(PdfMarkupKind.strikeOut, Icons.format_strikethrough),
+      _GroupTool.markup(PdfMarkupKind.squiggly, Icons.gesture),
     ]),
     _ToolGroup(
         'draw',
-        'Draw',
         Icons.draw,
         [
-          _GroupTool.tool(PdfEditTool.ink, Icons.draw, 'Draw'),
-          _GroupTool.tool(PdfEditTool.highlight, Icons.border_color,
-              'Highlight - draw freehand'),
-          _GroupTool.tool(
-              PdfEditTool.eraser, Icons.auto_fix_normal, 'Erase ink strokes'),
+          _GroupTool.tool(PdfEditTool.ink, Icons.draw),
+          _GroupTool.tool(PdfEditTool.highlight, Icons.border_color),
+          _GroupTool.tool(PdfEditTool.eraser, Icons.auto_fix_normal),
         ],
         defaultTool: PdfEditTool.ink),
     _ToolGroup(
         'shapes',
-        'Shapes',
         Icons.rectangle_outlined,
         [
-          _GroupTool.tool(
-              PdfEditTool.rectangle, Icons.rectangle_outlined, 'Rectangle'),
-          _GroupTool.tool(
-              PdfEditTool.ellipse, Icons.circle_outlined, 'Ellipse'),
-          _GroupTool.tool(PdfEditTool.line, Icons.horizontal_rule, 'Line'),
-          _GroupTool.tool(PdfEditTool.arrow, Icons.arrow_right_alt, 'Arrow'),
-          _GroupTool.tool(PdfEditTool.polyline, Icons.timeline, 'Polyline'),
-          _GroupTool.tool(PdfEditTool.polygon, Icons.change_history, 'Polygon'),
-          _GroupTool.tool(
-              PdfEditTool.cloudPolygon, Icons.cloud_outlined, 'Cloud polygon'),
+          _GroupTool.tool(PdfEditTool.rectangle, Icons.rectangle_outlined),
+          _GroupTool.tool(PdfEditTool.ellipse, Icons.circle_outlined),
+          _GroupTool.tool(PdfEditTool.line, Icons.horizontal_rule),
+          _GroupTool.tool(PdfEditTool.arrow, Icons.arrow_right_alt),
+          _GroupTool.tool(PdfEditTool.polyline, Icons.timeline),
+          _GroupTool.tool(PdfEditTool.polygon, Icons.change_history),
+          _GroupTool.tool(PdfEditTool.cloudPolygon, Icons.cloud_outlined),
         ],
         defaultTool: PdfEditTool.rectangle),
     _ToolGroup(
         'insert',
-        'Insert',
         Icons.text_fields,
         [
-          _GroupTool.tool(PdfEditTool.freeText, Icons.text_fields, 'Text box'),
-          _GroupTool.tool(PdfEditTool.callout, Icons.chat_bubble_outline,
-              'Callout - drag from the point to where the box goes'),
-          _GroupTool.tool(
-              PdfEditTool.note, Icons.sticky_note_2_outlined, 'Note'),
-          _GroupTool.tool(PdfEditTool.stamp, Icons.approval, 'Stamp'),
-          _GroupTool.tool(PdfEditTool.count, Icons.task_alt,
-              'Count - tap to drop check-marks and tally them'),
-          _GroupTool.tool(PdfEditTool.image, Icons.image_outlined,
-              'Image - tap to place, or drag out a box'),
-          _GroupTool.tool(PdfEditTool.signature, Icons.history_edu,
-              'Signature - tap a page to place it'),
-          _GroupTool.tool(PdfEditTool.signatureBox, Icons.draw_outlined,
-              'Digital signature - drag a box to place and sign'),
+          _GroupTool.tool(PdfEditTool.freeText, Icons.text_fields),
+          _GroupTool.tool(PdfEditTool.callout, Icons.chat_bubble_outline),
+          _GroupTool.tool(PdfEditTool.note, Icons.sticky_note_2_outlined),
+          _GroupTool.tool(PdfEditTool.stamp, Icons.approval),
+          _GroupTool.tool(PdfEditTool.count, Icons.task_alt),
+          _GroupTool.tool(PdfEditTool.image, Icons.image_outlined),
+          _GroupTool.tool(PdfEditTool.signature, Icons.history_edu),
+          _GroupTool.tool(PdfEditTool.signatureBox, Icons.draw_outlined),
         ],
         defaultTool: PdfEditTool.freeText),
-    _ToolGroup('measure', 'Measure', Icons.straighten, [
-      _GroupTool.tool(
-          PdfEditTool.measureDistance, Icons.straighten, 'Measure distance'),
-      _GroupTool.tool(
-          PdfEditTool.measurePerimeter, Icons.timeline, 'Measure perimeter'),
-      _GroupTool.tool(PdfEditTool.measureArea, Icons.crop_din, 'Measure area'),
-      _GroupTool.tool(PdfEditTool.measureVolume, Icons.view_in_ar,
-          'Measure volume (area × depth)'),
-      _GroupTool.tool(PdfEditTool.measureSlope, Icons.trending_up,
-          'Measure slope (rise/run)'),
-      _GroupTool.tool(PdfEditTool.measureAngle, Icons.architecture,
-          'Measure angle - click three points'),
-      _GroupTool.tool(PdfEditTool.measureArc, Icons.gesture,
-          'Measure arc length - click three points'),
+    _ToolGroup('measure', Icons.straighten, [
+      _GroupTool.tool(PdfEditTool.measureDistance, Icons.straighten),
+      _GroupTool.tool(PdfEditTool.measurePerimeter, Icons.timeline),
+      _GroupTool.tool(PdfEditTool.measureArea, Icons.crop_din),
+      _GroupTool.tool(PdfEditTool.measureVolume, Icons.view_in_ar),
+      _GroupTool.tool(PdfEditTool.measureSlope, Icons.trending_up),
+      _GroupTool.tool(PdfEditTool.measureAngle, Icons.architecture),
+      _GroupTool.tool(PdfEditTool.measureArc, Icons.gesture),
     ]),
-    _ToolGroup('edit', 'Edit', Icons.design_services, [
-      _GroupTool.tool(
-          PdfEditTool.content, Icons.format_shapes, 'Edit page content'),
-      _GroupTool.tool(PdfEditTool.form, Icons.ballot_outlined,
-          'Form fields - tap to select, double-tap to fill, drag to add'),
-      _GroupTool.tool(PdfEditTool.redact, Icons.gradient,
-          'Redact - drag a region, then apply'),
-      _GroupTool.tool(PdfEditTool.snapshot, Icons.crop,
-          'Snapshot - drag a region to capture it (paste back as vector)'),
+    _ToolGroup('edit', Icons.design_services, [
+      _GroupTool.tool(PdfEditTool.content, Icons.format_shapes),
+      _GroupTool.tool(PdfEditTool.form, Icons.ballot_outlined),
+      _GroupTool.tool(PdfEditTool.redact, Icons.gradient),
+      _GroupTool.tool(PdfEditTool.snapshot, Icons.crop),
     ]),
   ];
+
+  /// The bare, localized name of a tool - shown on labelled buttons, the
+  /// mobile tool tiles, and the active-tool caption. The enum is the key.
+  String _toolName(BuildContext context, PdfEditTool tool) {
+    final l = pdfL10n(context);
+    return switch (tool) {
+      PdfEditTool.select => l.tbNameSelect,
+      PdfEditTool.ink => l.tbNameDraw,
+      PdfEditTool.highlight => l.tbNameHighlight,
+      PdfEditTool.eraser => l.tbNameEraser,
+      PdfEditTool.rectangle => l.tbNameRectangle,
+      PdfEditTool.ellipse => l.tbNameEllipse,
+      PdfEditTool.line => l.tbNameLine,
+      PdfEditTool.arrow => l.tbNameArrow,
+      PdfEditTool.polyline => l.tbNamePolyline,
+      PdfEditTool.polygon => l.tbNamePolygon,
+      PdfEditTool.cloudPolygon => l.tbNameCloudPolygon,
+      PdfEditTool.measureDistance => l.tbNameMeasureDistance,
+      PdfEditTool.measurePerimeter => l.tbNameMeasurePerimeter,
+      PdfEditTool.measureArea => l.tbNameMeasureArea,
+      PdfEditTool.measureVolume => l.tbNameMeasureVolume,
+      PdfEditTool.measureSlope => l.tbNameMeasureSlope,
+      PdfEditTool.measureAngle => l.tbNameMeasureAngle,
+      PdfEditTool.measureArc => l.tbNameMeasureArc,
+      PdfEditTool.calibrate => l.measCalibrate,
+      PdfEditTool.freeText => l.tbNameTextBox,
+      PdfEditTool.callout => l.tbNameCallout,
+      PdfEditTool.note => l.tbNameNote,
+      PdfEditTool.stamp => l.tbNameStamp,
+      PdfEditTool.count => l.tbNameCount,
+      PdfEditTool.signature => l.tbNameSignature,
+      PdfEditTool.image => l.tbNameImage,
+      PdfEditTool.content => l.tbToolContent,
+      PdfEditTool.form => l.tbToolForm,
+      PdfEditTool.redact => l.tbToolRedact,
+      PdfEditTool.snapshot => l.tbToolSnapshot,
+      PdfEditTool.signatureBox => l.tbNameDigitalSignature,
+    };
+  }
+
+  /// The full tooltip for a tool. Tools whose tip is just their name fall
+  /// through to [_toolName]; the rest carry a fuller how-to hint.
+  String _toolTip(BuildContext context, PdfEditTool tool) {
+    final l = pdfL10n(context);
+    return switch (tool) {
+      PdfEditTool.highlight => l.tbTipHighlightDraw,
+      PdfEditTool.callout => l.tbTipCallout,
+      PdfEditTool.count => l.tbTipCount,
+      PdfEditTool.image => l.tbTipImage,
+      PdfEditTool.signature => l.tbTipSignature,
+      PdfEditTool.signatureBox => l.tbTipDigitalSignature,
+      PdfEditTool.measureAngle => l.tbTipMeasureAngle,
+      PdfEditTool.measureArc => l.tbTipMeasureArc,
+      PdfEditTool.content => l.tbTipContent,
+      PdfEditTool.form => l.tbTipForm,
+      PdfEditTool.redact => l.tbTipRedact,
+      PdfEditTool.snapshot => l.tbTipSnapshot,
+      _ => _toolName(context, tool),
+    };
+  }
+
+  /// The bare, localized name of a text-markup action (for mobile tiles).
+  String _markupName(BuildContext context, PdfMarkupKind markup) {
+    final l = pdfL10n(context);
+    return switch (markup) {
+      PdfMarkupKind.highlight => l.tbMarkupHighlight,
+      PdfMarkupKind.underline => l.tbMarkupUnderline,
+      PdfMarkupKind.strikeOut => l.tbMarkupStrikeOut,
+      PdfMarkupKind.squiggly => l.tbMarkupSquiggly,
+    };
+  }
+
+  /// The full tooltip for a text-markup action.
+  String _markupTip(BuildContext context, PdfMarkupKind markup) {
+    final l = pdfL10n(context);
+    return switch (markup) {
+      PdfMarkupKind.highlight => l.tbMarkupHighlightTip,
+      PdfMarkupKind.underline => l.tbMarkupUnderlineTip,
+      PdfMarkupKind.strikeOut => l.tbMarkupStrikeOutTip,
+      PdfMarkupKind.squiggly => l.tbMarkupSquigglyTip,
+    };
+  }
 
   bool _shows(PdfEditTool tool) => widget.tools?.contains(tool) ?? true;
 
@@ -1288,7 +1354,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
       if (entry.markup != null) {
         toolButtons.add(IconButton(
           icon: Icon(entry.icon),
-          tooltip: entry.tip,
+          tooltip: _markupTip(context, entry.markup!),
           onPressed: hasTextSelection
               ? () =>
                   _applyMarkup(entry.markup!, restoreTool: group.id != 'markup')
@@ -1298,14 +1364,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         final tool = entry.tool!;
         toolButtons.add(_LabeledToolButton(
           icon: entry.icon,
-          label: switch (tool) {
-            PdfEditTool.content => pdfL10n(context).tbToolContent,
-            PdfEditTool.form => pdfL10n(context).tbToolForm,
-            PdfEditTool.redact => pdfL10n(context).tbToolRedact,
-            PdfEditTool.snapshot => pdfL10n(context).tbToolSnapshot,
-            _ => _entryLabel(entry),
-          },
-          tooltip: _entryTip(entry),
+          label: _toolName(context, tool),
+          tooltip: _entryTip(context, entry),
           active: controller.tool == tool,
           onTap: () => _armGroupTool(context, tool),
         ));
@@ -1314,7 +1374,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         if (tool == PdfEditTool.stamp) {
           toolButtons.add(_StampToolPopupButton(
             controller: controller,
-            tooltip: _entryTip(entry),
+            tooltip: _entryTip(context, entry),
             active: controller.tool == tool,
             onArm: _armStampToolForMenu,
             onManage: _manageStamps,
@@ -1322,7 +1382,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         } else {
           toolButtons.add(IconButton(
             icon: Icon(entry.icon),
-            tooltip: _entryTip(entry),
+            tooltip: _entryTip(context, entry),
             isSelected: controller.tool == tool,
             onPressed: () => _armGroupTool(context, tool),
           ));
@@ -1352,7 +1412,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             padding: const EdgeInsets.fromLTRB(12, 7, 10, 7),
             child: Row(mainAxisSize: MainAxisSize.min, children: [
               _StripLabel(
-                group.label,
+                group.label(context),
                 hint: group.id == 'markup' && !hasTextSelection
                     ? pdfL10n(context).tbSelectTextForMarkup
                     : null,
@@ -2102,7 +2162,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    _activeToolLabel(tool),
+                    _activeToolLabel(context, tool),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     softWrap: false,
@@ -2265,32 +2325,10 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     return Icons.near_me;
   }
 
-  String _activeToolLabel(PdfEditTool? tool) {
-    if (tool == null) return 'Select';
-    switch (tool) {
-      case PdfEditTool.content:
-        return 'Content';
-      case PdfEditTool.form:
-        return 'Form';
-      case PdfEditTool.redact:
-        return 'Redact';
-      case PdfEditTool.snapshot:
-        return 'Snapshot';
-      default:
-        break;
-    }
-    for (final group in _groups) {
-      for (final entry in group.tools) {
-        if (entry.tool == tool) {
-          // the tip's leading clause is the tool's name
-          final tip = entry.tip;
-          final dash = tip.indexOf(' -');
-          return dash == -1 ? tip : tip.substring(0, dash);
-        }
-      }
-    }
-    return 'Select';
-  }
+  String _activeToolLabel(BuildContext context, PdfEditTool? tool) =>
+      tool == null
+          ? pdfL10n(context).tbNameSelect
+          : _toolName(context, tool);
 
   /// Opens the mobile tools sheet: group tabs, a tool grid, and the active
   /// tool's settings. The tab state lives in the sheet so switching groups
@@ -2340,7 +2378,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                     ),
                     const SizedBox(height: 14),
                     _SheetSectionLabel(
-                      group.label,
+                      group.label(context),
                       hint:
                           group.id == 'markup' && !viewerController.hasSelection
                               ? pdfL10n(context).tbSelectTextForMarkup
@@ -2382,8 +2420,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             _SheetToolTile(
               icon: entry.icon,
               label: entry.markup != null
-                  ? entry.tip.replaceAll(' selection', '')
-                  : _entryLabel(entry),
+                  ? _markupName(context, entry.markup!)
+                  : _entryLabel(context, entry),
               active: entry.tool != null && controller.tool == entry.tool,
               enabled: entry.markup == null || hasTextSelection,
               onTap: () async {
@@ -2424,20 +2462,19 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
     );
   }
 
-  static String _entryLabel(_GroupTool entry) {
-    final dash = entry.tip.indexOf(' -');
-    return dash == -1 ? entry.tip : entry.tip.substring(0, dash);
-  }
+  String _entryLabel(BuildContext context, _GroupTool entry) =>
+      _toolName(context, entry.tool!);
 
   /// A tool's tooltip with its keyboard shortcut appended (e.g.
   /// "Rectangle (R)"), so the bindings in [pdfEditToolShortcuts] are
   /// discoverable on hover. Markups and unbound tools keep the plain tip.
-  String _entryTip(_GroupTool entry) {
-    final tool = entry.tool;
-    final key = tool == null
-        ? null
-        : pdfEditToolShortcutLabel(tool, shortcuts: widget.toolShortcuts);
-    return key == null ? entry.tip : '${entry.tip} ($key)';
+  String _entryTip(BuildContext context, _GroupTool entry) {
+    final markup = entry.markup;
+    if (markup != null) return _markupTip(context, markup);
+    final tool = entry.tool!;
+    final tip = _toolTip(context, tool);
+    final key = pdfEditToolShortcutLabel(tool, shortcuts: widget.toolShortcuts);
+    return key == null ? tip : '$tip ($key)';
   }
 
   /// The settings block under the sheet's tool grid - reuses the same
@@ -2609,7 +2646,7 @@ class _GroupChip extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final on = active;
     final fg = on ? scheme.primary : scheme.onSurfaceVariant;
-    final label = _toolsHandle ? pdfL10n(context).tbTools : group!.label;
+    final label = _toolsHandle ? pdfL10n(context).tbTools : group!.label(context);
     final icon = _toolsHandle ? Icons.keyboard_arrow_up : group!.icon;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 3),
@@ -3303,20 +3340,6 @@ class _StyleMenuState extends State<_StyleMenu> {
             pickEditingColor(context, controller, initial: initial),
       );
 
-  /// A short human label for a line ending in the picker.
-  static String _endingLabel(PdfLineEnding ending) => switch (ending) {
-        PdfLineEnding.none => 'None',
-        PdfLineEnding.square => 'Square',
-        PdfLineEnding.circle => 'Circle',
-        PdfLineEnding.diamond => 'Diamond',
-        PdfLineEnding.openArrow => 'Open arrow',
-        PdfLineEnding.closedArrow => 'Closed arrow',
-        PdfLineEnding.butt => 'Butt',
-        PdfLineEnding.rOpenArrow => 'Open arrow (rev.)',
-        PdfLineEnding.rClosedArrow => 'Closed arrow (rev.)',
-        PdfLineEnding.slash => 'Slash',
-      };
-
   /// One line-ending dropdown (start or end), each item previewed with a
   /// tiny icon of the shape on a short segment. [atEnd] orients the
   /// preview so the start picker draws its ending on the left.
@@ -3354,7 +3377,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                     ),
                     const SizedBox(width: 8),
                     Flexible(
-                      child: Text(_endingLabel(ending),
+                      child: Text(pdfLineEndingLabel(context, ending),
                           overflow: TextOverflow.ellipsis),
                     ),
                   ]),
@@ -3559,7 +3582,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                                 DropdownMenuItem(
                                   value: style,
                                   key: ValueKey('pdf-line-type-${style.name}'),
-                                  child: Text(style.label),
+                                  child: Text(pdfLineStyleLabel(context, style)),
                                 ),
                             ],
                             onChanged: (value) {

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -413,7 +413,7 @@ class _PanelTab extends StatelessWidget {
               size: 16,
               color: selected ? scheme.primary : scheme.onSurfaceVariant),
           const SizedBox(width: 6),
-          Text(panel.label,
+          Text(panel.label(context),
               style: TextStyle(
                 color: selected ? scheme.onSurface : scheme.onSurfaceVariant,
                 fontWeight: selected ? FontWeight.w600 : FontWeight.w400,


### PR DESCRIPTION
## Summary

Clears the phase-1 **"deferred — no-context strings"** inventory for the `dart_pdf_editor` package: user-facing English that lived in `static`/`const` data, enum getters, or top-level helpers with no `BuildContext` at the point the text was produced. In every case the enum / subtype / group id is the stable key, and the visible string is now resolved from the localizations at the build-time consumer.

- **Shared model→label mappers** centralized in `annotation_presentation.dart` as context-taking functions — same mapping translated once and reused: `pdfAnnotationLabel(context, subtype)` (now takes context), plus new `pdfLineStyleLabel` / `pdfMeasurementKindLabel` / `pdfLineEndingLabel`. The pure models (`PdfLineStyle`, `PdfMeasurementKind`, `PdfLineEnding`) stay Flutter-free in their engine/enum homes.
- **`editing_toolbar.dart`** (the most-visible remaining English — every tool tooltip and dock-group label): dropped the `label`/`tip` literals out of the `static const _groups` data entirely — `_ToolGroup` now carries only `(id, icon, tools)` and `_GroupTool` only `(tool|markup, icon)`. Names/tips resolve from the enum via `_toolName`/`_toolTip`/`_markupName`/`_markupTip`, and the group name via a `_ToolGroup.label(context)` method. This also **deletes the string-splitting hacks** — `_activeToolLabel` parsing the tip's clause before `" -"`, and the mobile sheet stripping `" selection"` — plus the duplicate `_endingLabel` (now the shared `pdfLineEndingLabel`, reusing the `propLineEnding*` keys the Properties panel already localized in phase 1).
- **`editing_sidebar.dart`**: de-`static`'d `_fieldLabel`/`_actionLabel`/`_stateChip`; localized the callout/annotation titles. `"Page N"` became an ICU key with an `int` placeholder.
- **`editing_takeoff.dart`**: uses the shared `pdfMeasurementKindLabel`.
- **`editing_panel.dart`**: `PdfDockablePanel` gained a `label(context)` method reusing the shell's `shellPanel*` keys; both consumers (drag chip + `shell_chrome.dart` dock tab) updated.
- **`editing_stamps.dart`**: localized the time-format preview suffix (`24 hr`/`12 hr`), the custom-stamp caption fallback, the `Bold`/`Italic` font modifiers (family names stay as proper nouns), and the insertable-field names. The `_monthNames` array and `format()` AM/PM are **left** — that output is stamped into document content and belongs with the separate `DateFormat`/`NumberFormat` follow-up.

**107 new ARB keys**, each with a `@key` translator description and typed placeholders where relevant. English values kept byte-identical to the prior literals (bar two annotation subtype labels: `FileAttachment` → "File attachment", `Redact` → "Redaction"), so the English-fallback path — and the existing widget tests that find UI by English text — are unaffected. Template ARB grew 443 → 550 keys; `gen-l10n` regenerated.

## Affected packages

- [x] `dart_pdf_editor`
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Refactor / cleanup

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (`--fatal-infos`, clean across the whole workspace)
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

The `dart_pdf_editor` suite is green except the lone `ghent_render_test.dart` `2-SPOT/GWG030_Gray_K_black_OP_X1.pdf` baseline — a spot-color render diff that is **pre-existing** (fails identically on the base commit) and unrelated to this string-only change.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` ← `pdf_document` ← `pdf_graphics` ← `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Design write-up in `doc/dev-log/2026-07-22-i18n-no-context-refactors.md`.

Still deferred (their own follow-ups, unchanged from the phase-1 inventory): the **app/example** strings (`XTypeGroup` file-picker labels, `settings_screen` defaults, `ocr_status.OcrJobStatus.label`, and the `digital_signature` pure-model `FormatException` messages localized at the app's `error.message` display site) — these live in the separate app/example ARBs; `DateFormat`/`NumberFormat` for month abbreviations and `toStringAsFixed` values; the RTL sweep; the Settings language picker; and the machine-translated seed ARBs + tier-1/2 locales + per-locale CI coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8U7XM2jYuiZ2UwAZjZmwa

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8U7XM2jYuiZ2UwAZjZmwa)_