### PR TITLE
Allow cropping placed images / raster snapshots

### DIFF
--- a/doc/dev-log/2026-07-22-image-stamp-crop.md
+++ b/doc/dev-log/2026-07-22-image-stamp-crop.md
@@ -1,0 +1,112 @@
+# Cropping placed images / raster snapshots
+
+Adds an interactive crop tool for image stamps - the `/Stamp` annotations
+that `PdfEditor.addImageStamp` produces for placed images and pasted raster
+pictures. You select a placed image, hit **Crop**, drag a rectangle over it,
+and confirm; the annotation's box shrinks to the cropped region and only that
+part of the source picture shows.
+
+## Model: the crop rides the appearance, not the image
+
+An image stamp draws a unit image mapped onto its rect
+(`_imageStampContent`, `annotation_editor.dart`). Cropping is baked into that
+one method: given a normalized crop rect `[cl cb cr ct]` in `[0,1]` (origin
+bottom-left, the source picture's own space), it clips the visual box and
+scales the picture so the crop's sub-rect fills the box -
+
+```
+box  W n                       % clip to the visual rect
+sx 0 0 sy tx ty cm             % sx = W/(cr-cl), tx = box.left - cl*sx, …
+/Img0 Do
+```
+
+A full crop `[0 0 1 1]` degrades to the old identity map (`W 0 0 H L B cm`),
+so uncropped stamps are byte-for-byte unchanged.
+
+Design decisions:
+
+- **The crop is a private marker, not inferred from the appearance.**
+  `addImageStamp(..., crop:)` writes `/DartPdfImageCrop [cl cb cr ct]` on the
+  annotation dict (same `DartPdf*` convention as `/DartPdfImageStamp`), and
+  `PdfAnnotation.imageStampCrop` reads it back (null for absent/full). This
+  matters because the appearance is regenerated on an **opacity restyle**
+  (`_regenerateStyledAppearance` → `_imageStampContent`): that path now reads
+  the crop off the dict, so changing transparency preserves the crop. A
+  full-image crop drops the marker, so an uncropped picture carries none.
+- **Resize needs no crop-awareness.** An image stamp resizes by the §12.5.5
+  BBox→Rect stretch (`resizeBehavior == stretch`), which scales the whole
+  baked appearance - clip and all - so a cropped stamp stretches
+  proportionally with zero extra code. Only opacity restyle and creation
+  regenerate the content, and both go through `_imageStampContent`.
+- **`cropImageStamp(pageIndex, annotation, {crop, rect})`** is the editor
+  entry: it re-references the same image XObject (`_stampImageRef`), rewrites
+  the appearance at the new crop, and optionally sets a new `/Rect`. The crop
+  composes against the *source* picture, so `crop: [0 0 1 1]` restores the
+  whole image regardless of an earlier crop. A rotated image stamp (folded
+  `/Matrix`) crops in place through the `_restyleRegenerate` local-frame path
+  (re-rotates after regenerating); the `rect` shrink is upright-only, since an
+  axis-aligned page rect can't describe a rotated frame.
+
+Tests: `image_stamp_test.dart` - crop clips + scales, full crop is identity,
+crop in place vs. box-shrink, opacity restyle preserves the crop, two crops
+compose, reset clears the marker, and a no-op on non-image stamps.
+
+## Controller: compose + shrink
+
+`PdfEditingController.cropSelectedImage(visibleRect)` takes a page-space
+rectangle inside the current box, converts it to fractions of the box,
+composes those into the source-normalized crop (so re-cropping keeps
+narrowing toward the source), and shrinks `/Rect` to `visibleRect` so the
+retained pixels keep their on-page scale instead of stretching to refill the
+old box. `resetSelectedImageCrop()` grows the box back to the full picture.
+`canCropSelected` gates on a single, upright image stamp (rotated ones are
+excluded - see above).
+
+Interactive crop is a transient mode on the controller
+(`isCroppingImage`/`imageCropDraft`, `beginImageCrop`/`updateImageCropDraft`/
+`commitImageCrop`/`cancelImageCrop`), auto-cancelled by the tool setter so a
+stray tool switch can't strand it.
+
+## UI: a self-contained overlay, driven through the working gesture path
+
+`PdfImageCropOverlay` (`editing_image_crop.dart`) is the on-page crop
+rectangle: a dim scrim over the image outside the crop, a rule-of-thirds
+grid, eight `HandleLayout` handles, and floating confirm/cancel chips. It is
+rendered as the topmost child of the editing overlay's Stack while
+`isCroppingImage`, and the editing overlay drops its own pan/tap recognizers
+(`cropping ? null : _panStart`, etc.) so the crop overlay owns every pointer
+on the page.
+
+Two gotchas cost time and are worth recording:
+
+- **`dragStartBehavior: DragStartBehavior.down`** on the crop overlay's
+  `GestureDetector` is mandatory. The default (`start`) reports the pan-start
+  position *after* the recognizer wins the arena (post-slop), so a handle grab
+  hit-tests against a point ~18px off the handle and silently becomes a
+  body-move. The editing overlay already uses `down` for the same reason.
+- **The confirm/cancel chips fire from `Listener.onPointerUp`, not just
+  `InkWell.onTap`.** The chips sit over the viewer's `SelectableRegion` and
+  the editing overlay's gesture stack, which win a plain tap's arena, so
+  `onTap` never fired in the viewer (it works fine in isolation). A raw
+  pointer-up listener fires regardless of the arena; `commit`/`cancel` are
+  idempotent, so the InkWell's `onTap` staying on for ripple feedback is
+  harmless. Tooltips were also dropped for `Semantics` labels - a `Tooltip`
+  schedules a timer that leaks past widget-tree disposal in tests.
+
+Toolbar: a `crop` icon in the selection strip (`canCropSelected`) arms the
+mode; while cropping the strip swaps to a crop bar (reset / cancel / apply).
+Escape cancels the crop before it clears the selection (`_onEscape`,
+`pdf_viewer.dart`). New l10n keys `tbCropImage`/`tbCroppingImage`/
+`tbCropApply`/`tbCropCancel`/`tbCropReset`.
+
+Tests: `editing_image_crop_test.dart` - the overlay widget (handle drag,
+interior move+clamp, chip callbacks), the viewer wiring (arm shows the
+overlay, drag-a-handle-then-confirm crops the annotation, cancel discards),
+and the toolbar (Crop button arms + swaps in the crop strip). Controller
+composition/lifecycle in `editing_image_test.dart`.
+
+## Not covered
+
+Vector snapshots (`PdfVectorSnapshot`, a form XObject replaying page
+operators) aren't croppable through this tool - only raster image stamps.
+Cropping a rotated image stamp works in place but can't shrink its box.

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -1367,6 +1367,26 @@
   "@tbCheckMarksOnDocument": {
     "description": "Tooltip on the tally chip counting check-marks placed by the Count tool."
   },
+  "tbCropImage": "Crop image",
+  "@tbCropImage": {
+    "description": "Tooltip on the button that starts cropping the selected image."
+  },
+  "tbCroppingImage": "Cropping image",
+  "@tbCroppingImage": {
+    "description": "Label shown on the toolbar while the image-crop tool is active."
+  },
+  "tbCropApply": "Apply crop",
+  "@tbCropApply": {
+    "description": "Tooltip on the button that confirms the pending image crop."
+  },
+  "tbCropCancel": "Cancel crop",
+  "@tbCropCancel": {
+    "description": "Tooltip on the button that abandons the pending image crop."
+  },
+  "tbCropReset": "Reset crop",
+  "@tbCropReset": {
+    "description": "Tooltip on the button that removes the crop and restores the whole image."
+  },
   "tbColorLabel": "Color",
   "@tbColorLabel": {
     "description": "Short button label for the color-processing action."

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -1955,6 +1955,36 @@ abstract class DartPdfEditorLocalizations {
   /// **'Check-marks on the document'**
   String get tbCheckMarksOnDocument;
 
+  /// Tooltip on the button that starts cropping the selected image.
+  ///
+  /// In en, this message translates to:
+  /// **'Crop image'**
+  String get tbCropImage;
+
+  /// Label shown on the toolbar while the image-crop tool is active.
+  ///
+  /// In en, this message translates to:
+  /// **'Cropping image'**
+  String get tbCroppingImage;
+
+  /// Tooltip on the button that confirms the pending image crop.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply crop'**
+  String get tbCropApply;
+
+  /// Tooltip on the button that abandons the pending image crop.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel crop'**
+  String get tbCropCancel;
+
+  /// Tooltip on the button that removes the crop and restores the whole image.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset crop'**
+  String get tbCropReset;
+
   /// Short button label for the color-processing action.
   ///
   /// In en, this message translates to:

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -1056,6 +1056,21 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Check-marks on the document';
 
   @override
+  String get tbCropImage => 'Crop image';
+
+  @override
+  String get tbCroppingImage => 'Cropping image';
+
+  @override
+  String get tbCropApply => 'Apply crop';
+
+  @override
+  String get tbCropCancel => 'Cancel crop';
+
+  @override
+  String get tbCropReset => 'Reset crop';
+
+  @override
   String get tbColorLabel => 'Color';
 
   @override

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1276,6 +1276,8 @@ class PdfEditingController extends ChangeNotifier {
     _tool = value;
     if (value != PdfEditTool.select) _selected.clear();
     if (value != PdfEditTool.content) _selectedElement = null;
+    _cropModeArmed = false;
+    _cropDraft = null;
     // each annotation tool remembers its own colour, stroke, opacity, … -
     // arming one restores its saved style and routes further style changes
     // back into its slot (see [PdfEditingPreferences.beginStyleScope])
@@ -3725,6 +3727,15 @@ class PdfEditingController extends ChangeNotifier {
   /// on when exactly one is selected).
   final List<(int page, int index)> _selected = [];
 
+  /// True while the interactive image-crop tool is armed on the selection.
+  /// See [beginImageCrop].
+  bool _cropModeArmed = false;
+
+  /// The pending crop rectangle (page space) the crop overlay is dragging,
+  /// or null when not cropping. Always a sub-rectangle of the selected image
+  /// stamp's /Rect.
+  PdfRect? _cropDraft;
+
   /// Pages cached per revision: [PdfDocument.page] rebuilds the page
   /// (and its lazily parsed annotation list) on every call, and the
   /// selection hit tests run per pointer event.
@@ -3834,6 +3845,26 @@ class PdfEditingController extends ChangeNotifier {
       _selected.length == 1 &&
       selectedAnnotation?.behavior.textEditable == true &&
       selectedAnnotation?.isLockedContents != true;
+
+  /// Whether the selection is a single upright image stamp that the crop
+  /// tool can operate on. Rotated image stamps are excluded: cropping shrinks
+  /// the box to an axis-aligned sub-rectangle, which cannot describe a
+  /// rotated frame.
+  bool get canCropSelected {
+    final annotation = selectedAnnotation;
+    if (_selected.length != 1 ||
+        annotation == null ||
+        !annotation.isImageStamp ||
+        annotation.normalAppearance == null) {
+      return false;
+    }
+    final quad = annotation.appearanceQuad;
+    if (quad == null || quad.length < 2) return true;
+    final (x0, y0) = quad[0];
+    final (x1, y1) = quad[1];
+    // Upright when the picture's bottom edge is horizontal.
+    return (y1 - y0).abs() <= 1e-3 * math.max(1.0, (x1 - x0).abs());
+  }
 
   /// The topmost selectable annotation under ([x], [y]) on [pageIndex],
   /// with its /Annots slot - the select tool's hit test (later entries
@@ -5022,6 +5053,127 @@ class PdfEditingController extends ChangeNotifier {
         pageRotation: _page(_selected.last.$1).rotation,
       ),
     );
+  }
+
+  /// Crops the selected image stamp so only the picture currently shown
+  /// inside [visibleRect] (page space) survives, shrinking the annotation's
+  /// box to that rectangle. [visibleRect] is clamped to the current box, and
+  /// the crop composes with any crop already applied, so it always narrows
+  /// towards the source picture. A no-op unless [canCropSelected].
+  void cropSelectedImage(PdfRect visibleRect) {
+    final annotation = selectedAnnotation;
+    if (annotation == null || !canCropSelected) return;
+    final rect = annotation.rect;
+    if (rect.width <= 0 || rect.height <= 0) return;
+    final v = visibleRect.intersect(rect);
+    if (v.width < 1 || v.height < 1) return;
+    // Untouched box → nothing to crop.
+    if ((v.left - rect.left).abs() < 0.5 &&
+        (v.bottom - rect.bottom).abs() < 0.5 &&
+        (v.right - rect.right).abs() < 0.5 &&
+        (v.top - rect.top).abs() < 0.5) {
+      return;
+    }
+    final current = annotation.imageStampCrop ?? const PdfRect(0, 0, 1, 1);
+    // Fractions of the current box the visible rect covers, composed into the
+    // source picture's normalized coordinates.
+    final fx0 = (v.left - rect.left) / rect.width;
+    final fx1 = (v.right - rect.left) / rect.width;
+    final fy0 = (v.bottom - rect.bottom) / rect.height;
+    final fy1 = (v.top - rect.bottom) / rect.height;
+    final crop = PdfRect(
+      current.left + fx0 * current.width,
+      current.bottom + fy0 * current.height,
+      current.left + fx1 * current.width,
+      current.bottom + fy1 * current.height,
+    );
+    apply(
+      (e) => e.cropImageStamp(
+        _selected.last.$1,
+        annotation,
+        crop: crop,
+        rect: v,
+      ),
+    );
+  }
+
+  /// Removes any crop from the selected image stamp, restoring the whole
+  /// picture. The box grows back to the picture's full extent at the current
+  /// scale. A no-op unless [canCropSelected] and a crop is applied.
+  void resetSelectedImageCrop() {
+    final annotation = selectedAnnotation;
+    if (annotation == null || !canCropSelected) return;
+    final current = annotation.imageStampCrop;
+    if (current == null) return;
+    // Grow the box back so the retained pixels keep their scale: the current
+    // box shows `current`, so the full picture spans box / current.
+    final rect = annotation.rect;
+    final fullWidth = rect.width / current.width;
+    final fullHeight = rect.height / current.height;
+    final left = rect.left - current.left * fullWidth;
+    final bottom = rect.bottom - current.bottom * fullHeight;
+    final full = PdfRect(left, bottom, left + fullWidth, bottom + fullHeight);
+    apply(
+      (e) => e.cropImageStamp(
+        _selected.last.$1,
+        annotation,
+        crop: const PdfRect(0, 0, 1, 1),
+        rect: full,
+      ),
+    );
+  }
+
+  /// Whether the interactive image-crop tool is armed. The overlay renders
+  /// its crop rectangle and handles while this is true, absorbing gestures;
+  /// the toolbar shows Done/Cancel. Auto-clears if the selection stops being
+  /// a croppable image stamp.
+  bool get isCroppingImage => _cropModeArmed && canCropSelected;
+
+  /// The crop rectangle the overlay is currently dragging (page space), or
+  /// null when [isCroppingImage] is false. Sub-rectangle of the selected
+  /// image stamp's /Rect.
+  PdfRect? get imageCropDraft => isCroppingImage ? _cropDraft : null;
+
+  /// Arms the interactive crop tool on the selected image stamp, seeding the
+  /// crop rectangle to the whole picture. A no-op unless [canCropSelected].
+  void beginImageCrop() {
+    final annotation = selectedAnnotation;
+    if (annotation == null || !canCropSelected) return;
+    _cropModeArmed = true;
+    _cropDraft = annotation.rect;
+    notifyListeners();
+  }
+
+  /// Updates the pending crop rectangle as the overlay drags a handle,
+  /// clamped to the selected image stamp's /Rect. A no-op unless cropping.
+  void updateImageCropDraft(PdfRect draft) {
+    if (!isCroppingImage) return;
+    final rect = selectedAnnotation!.rect;
+    final clamped = draft.intersect(rect);
+    if (clamped.width < 1 || clamped.height < 1) return;
+    if (clamped == _cropDraft) return;
+    _cropDraft = clamped;
+    notifyListeners();
+  }
+
+  /// Applies the pending crop and disarms the tool. A no-op (just disarms)
+  /// when the draft still covers the whole picture.
+  void commitImageCrop() {
+    final region = imageCropDraft;
+    _cropModeArmed = false;
+    _cropDraft = null;
+    if (region != null) cropSelectedImage(region);
+    // cropSelectedImage may no-op (unchanged box); repaint either way so the
+    // crop chrome disappears.
+    notifyListeners();
+  }
+
+  /// Disarms the crop tool, discarding the pending crop.
+  void cancelImageCrop() {
+    if (!_cropModeArmed && _cropDraft == null) return;
+    _cropModeArmed = false;
+    _cropDraft = null;
+    notifyListeners();
   }
 
   /// Moves a selected callout's arrow terminus to [target] (page space),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_image_crop.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_image_crop.dart
@@ -1,0 +1,373 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'handle_layout.dart';
+
+/// The interactive crop rectangle drawn over a selected image stamp while
+/// [PdfEditingController.isCroppingImage].
+///
+/// It is deliberately self-contained - its own [GestureDetector] absorbs every
+/// pointer over the page so it never entangles the main editing overlay's
+/// gesture machine. Drag a handle to resize the crop, drag the interior to
+/// move it, both clamped to [bounds] (the image's full on-screen rectangle).
+/// The area of the image outside the crop is dimmed; a rule-of-thirds grid and
+/// eight handles mark the crop. Confirm (✓) and cancel (✕) chips float below
+/// the rectangle.
+///
+/// The crop is tracked internally as fractions of [bounds] so it survives a
+/// zoom or scroll (which changes [bounds]) mid-crop, and reported back out in
+/// view space through [onChanged].
+class PdfImageCropOverlay extends StatefulWidget {
+  const PdfImageCropOverlay({
+    super.key,
+    required this.bounds,
+    required this.initialCrop,
+    required this.chromeScale,
+    required this.accentColor,
+    required this.onChanged,
+    required this.onCommit,
+    required this.onCancel,
+  });
+
+  /// The image's full rectangle in view space - the crop cannot grow past it.
+  final Rect bounds;
+
+  /// The crop rectangle to start from, in view space (defaults to [bounds]).
+  final Rect initialCrop;
+
+  /// View-pixels-per-logical for chrome, so handles stay a constant on-screen
+  /// size as the page zooms (`1 / zoom`).
+  final double chromeScale;
+
+  /// The selection-chrome accent (border + handle stroke).
+  final Color accentColor;
+
+  /// Fires as the crop rectangle changes, in view space.
+  final ValueChanged<Rect> onChanged;
+
+  /// Fires when the user confirms the crop.
+  final VoidCallback onCommit;
+
+  /// Fires when the user abandons the crop.
+  final VoidCallback onCancel;
+
+  @override
+  State<PdfImageCropOverlay> createState() => _PdfImageCropOverlayState();
+}
+
+class _PdfImageCropOverlayState extends State<PdfImageCropOverlay> {
+  // The crop as fractions of `bounds`, left/top/right/bottom in [0, 1].
+  late double _fl, _ft, _fr, _fb;
+
+  SelectionHandle? _handle;
+  bool _moving = false;
+  Offset? _dragStart;
+  // Fractions captured at drag start.
+  late double _sl, _st, _sr, _sb;
+
+  static const double _handleSize = 10;
+  static const double _minSpanPx = 16;
+
+  @override
+  void initState() {
+    super.initState();
+    _seedFractions();
+  }
+
+  @override
+  void didUpdateWidget(PdfImageCropOverlay old) {
+    super.didUpdateWidget(old);
+    // Re-seed only when the incoming crop identity changes and no drag is in
+    // flight (the overlay is authoritative while dragging).
+    if (_handle == null &&
+        !_moving &&
+        old.initialCrop != widget.initialCrop) {
+      _seedFractions();
+    }
+  }
+
+  void _seedFractions() {
+    final b = widget.bounds;
+    if (b.width <= 0 || b.height <= 0) {
+      _fl = 0;
+      _ft = 0;
+      _fr = 1;
+      _fb = 1;
+      return;
+    }
+    final c = widget.initialCrop;
+    _fl = ((c.left - b.left) / b.width).clamp(0.0, 1.0);
+    _ft = ((c.top - b.top) / b.height).clamp(0.0, 1.0);
+    _fr = ((c.right - b.left) / b.width).clamp(0.0, 1.0);
+    _fb = ((c.bottom - b.top) / b.height).clamp(0.0, 1.0);
+    if (_fr <= _fl) _fr = 1;
+    if (_fb <= _ft) _fb = 1;
+  }
+
+  Rect get _cropRect {
+    final b = widget.bounds;
+    return Rect.fromLTRB(
+      b.left + _fl * b.width,
+      b.top + _ft * b.height,
+      b.left + _fr * b.width,
+      b.top + _fb * b.height,
+    );
+  }
+
+  double get _minFracX =>
+      widget.bounds.width <= 0 ? 0.1 : _minSpanPx / widget.bounds.width;
+  double get _minFracY =>
+      widget.bounds.height <= 0 ? 0.1 : _minSpanPx / widget.bounds.height;
+
+  void _onPanStart(DragStartDetails details) {
+    final layout = HandleLayout(
+      rect: _cropRect,
+      chromeScale: widget.chromeScale,
+    );
+    _dragStart = details.localPosition;
+    _sl = _fl;
+    _st = _ft;
+    _sr = _fr;
+    _sb = _fb;
+    _handle = layout.handleAt(details.localPosition);
+    _moving = _handle == null && _cropRect.contains(details.localPosition);
+  }
+
+  void _onPanUpdate(DragUpdateDetails details) {
+    if (_dragStart == null) return;
+    final b = widget.bounds;
+    if (b.width <= 0 || b.height <= 0) return;
+    final d = details.localPosition - _dragStart!;
+    final dfx = d.dx / b.width;
+    final dfy = d.dy / b.height;
+    if (_handle case final handle?) {
+      var l = _sl, t = _st, r = _sr, bt = _sb;
+      if (handle.dx == -1) l = (_sl + dfx).clamp(0.0, r - _minFracX);
+      if (handle.dx == 1) r = (_sr + dfx).clamp(l + _minFracX, 1.0);
+      if (handle.dy == -1) t = (_st + dfy).clamp(0.0, bt - _minFracY);
+      if (handle.dy == 1) bt = (_sb + dfy).clamp(t + _minFracY, 1.0);
+      _apply(l, t, r, bt);
+    } else if (_moving) {
+      final w = _sr - _sl, h = _sb - _st;
+      final l = (_sl + dfx).clamp(0.0, 1.0 - w);
+      final t = (_st + dfy).clamp(0.0, 1.0 - h);
+      _apply(l, t, l + w, t + h);
+    }
+  }
+
+  void _onPanEnd(DragEndDetails details) {
+    _handle = null;
+    _moving = false;
+    _dragStart = null;
+  }
+
+  void _apply(double l, double t, double r, double bt) {
+    if (l == _fl && t == _ft && r == _fr && bt == _fb) return;
+    setState(() {
+      _fl = l;
+      _ft = t;
+      _fr = r;
+      _fb = bt;
+    });
+    widget.onChanged(_cropRect);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final crop = _cropRect;
+    // Confirm/cancel chips ride just below the crop, nudged back inside the
+    // image when the crop hugs the bottom edge.
+    final chipY = (crop.bottom + 10 * widget.chromeScale)
+        .clamp(widget.bounds.top, widget.bounds.bottom - 4);
+    final chipCenter = crop.center.dx
+        .clamp(widget.bounds.left + 44, widget.bounds.right - 44);
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            // start the drag at the press point (not where the recognizer won
+            // the arena) so a handle grab hit-tests against the down position
+            dragStartBehavior: DragStartBehavior.down,
+            onPanStart: _onPanStart,
+            onPanUpdate: _onPanUpdate,
+            onPanEnd: _onPanEnd,
+            child: CustomPaint(
+              painter: _CropPainter(
+                bounds: widget.bounds,
+                crop: crop,
+                accent: widget.accentColor,
+                chromeScale: widget.chromeScale,
+                handleSize: _handleSize,
+              ),
+              size: Size.infinite,
+            ),
+          ),
+        ),
+        Positioned(
+          left: chipCenter - 44,
+          top: chipY,
+          child: _CropActions(
+            accent: widget.accentColor,
+            onCommit: widget.onCommit,
+            onCancel: widget.onCancel,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The confirm/cancel chip pair floating beside the crop rectangle.
+class _CropActions extends StatelessWidget {
+  const _CropActions({
+    required this.accent,
+    required this.onCommit,
+    required this.onCancel,
+  });
+
+  final Color accent;
+  final VoidCallback onCommit;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _CropActionButton(
+          key: const ValueKey('pdf-crop-cancel'),
+          icon: Icons.close,
+          tooltip: MaterialLocalizations.of(context).cancelButtonLabel,
+          background: Colors.white,
+          foreground: Colors.black87,
+          onPressed: onCancel,
+        ),
+        const SizedBox(width: 8),
+        _CropActionButton(
+          key: const ValueKey('pdf-crop-confirm'),
+          icon: Icons.check,
+          tooltip: MaterialLocalizations.of(context).okButtonLabel,
+          background: accent,
+          foreground: Colors.white,
+          onPressed: onCommit,
+        ),
+      ],
+    );
+  }
+}
+
+class _CropActionButton extends StatelessWidget {
+  const _CropActionButton({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    required this.background,
+    required this.foreground,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final Color background;
+  final Color foreground;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    // The crop chips sit over the viewer's SelectableRegion and the editing
+    // overlay's gesture stack, which can win a plain tap's arena. A raw
+    // pointer-up listener fires regardless of the arena, so the button always
+    // responds; the InkWell stays for hover/press feedback. onPressed
+    // (commit/cancel) is idempotent, so a redundant fire is harmless.
+    return Listener(
+      onPointerUp: (_) => onPressed(),
+      child: Material(
+        color: background,
+        shape: const CircleBorder(),
+        elevation: 2,
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onPressed,
+          child: Semantics(
+            button: true,
+            label: tooltip,
+            child: Padding(
+              padding: const EdgeInsets.all(7),
+              child: Icon(icon, size: 20, color: foreground),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CropPainter extends CustomPainter {
+  _CropPainter({
+    required this.bounds,
+    required this.crop,
+    required this.accent,
+    required this.chromeScale,
+    required this.handleSize,
+  });
+
+  final Rect bounds;
+  final Rect crop;
+  final Color accent;
+  final double chromeScale;
+  final double handleSize;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Dim the image outside the crop (even-odd: image minus crop).
+    final scrim = Path.combine(
+      PathOperation.difference,
+      Path()..addRect(bounds),
+      Path()..addRect(crop),
+    );
+    canvas.drawPath(scrim, Paint()..color = Colors.black.withValues(alpha: 0.45));
+
+    // Rule-of-thirds grid inside the crop.
+    final grid = Paint()
+      ..color = Colors.white.withValues(alpha: 0.5)
+      ..strokeWidth = 0.75 * chromeScale;
+    for (var i = 1; i < 3; i++) {
+      final x = crop.left + crop.width * i / 3;
+      final y = crop.top + crop.height * i / 3;
+      canvas.drawLine(Offset(x, crop.top), Offset(x, crop.bottom), grid);
+      canvas.drawLine(Offset(crop.left, y), Offset(crop.right, y), grid);
+    }
+
+    // Crop border.
+    canvas.drawRect(
+      crop,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.5 * chromeScale
+        ..color = accent,
+    );
+
+    // Eight handles.
+    final layout = HandleLayout(rect: crop, chromeScale: chromeScale);
+    final fill = Paint()..color = Colors.white;
+    final stroke = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5 * chromeScale
+      ..color = accent;
+    final r = handleSize / 2 * chromeScale;
+    for (final handle in selectionHandles) {
+      final c = layout.handleCenter(handle);
+      final rect = Rect.fromCircle(center: c, radius: r);
+      canvas.drawRect(rect, fill);
+      canvas.drawRect(rect, stroke);
+    }
+  }
+
+  @override
+  bool shouldRepaint(_CropPainter old) =>
+      old.bounds != bounds ||
+      old.crop != crop ||
+      old.accent != accent ||
+      old.chromeScale != chromeScale;
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -18,6 +18,7 @@ import '../theme.dart';
 import 'editing_color_pick.dart';
 import 'editing_controller.dart';
 import 'editing_fonts.dart';
+import 'editing_image_crop.dart';
 import 'editing_interaction.dart';
 import 'editing_measure.dart';
 import 'editing_tool_behavior.dart';
@@ -1177,6 +1178,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// stream, stylus detection for palm rejection, multi-touch bail, and
   /// - with ink or the eraser armed - the stroke itself.
   void _onPointerDown(PointerDownEvent event) {
+    // the crop overlay owns all input while a crop is armed
+    if (_controller.isCroppingImage) return;
     _pointerPressure = _normalizedPressure(event);
     if (_lastPointerKind != event.kind) {
       // the selection action chip shows for touch/stylus input only
@@ -2897,6 +2900,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   void _panStart(DragStartDetails details) {
+    // while cropping, the crop overlay owns every pointer over the page
+    if (_controller.isCroppingImage) return;
     // raw-driven pointers own their gesture: the pan recognizer still
     // claims the arena (keeping the viewer's pan/zoom from fighting the
     // stroke) but its callbacks must not double-drive it
@@ -3178,6 +3183,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   void _panUpdate(DragUpdateDetails details) {
+    if (_controller.isCroppingImage) return;
     if (_pointers.gestureBailed || _pointers.rawPointer != null) return;
     final position = details.localPosition;
     _interaction.sample();
@@ -3317,6 +3323,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   }
 
   void _panEnd(DragEndDetails details) {
+    if (_controller.isCroppingImage) return;
     if (_pointers.rawPointer != null) return; // the raw pointer-up commits
     final before = _controller.revisionId;
     final transition = _interaction.state.transition;
@@ -3977,6 +3984,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       _endRawPointer(event, canceled: true);
 
   Future<void> _onTapUp(TapUpDetails details) async {
+    // the crop overlay owns taps while a crop is armed
+    if (_controller.isCroppingImage) return;
     // the eyedropper commits from the raw pointer-up instead
     if (_controller.isPickingColor) return;
     if (_pointers.gestureBailed) return;
@@ -4853,6 +4862,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // instead of waiting for the full-page raster. Dragging keeps using the
     // normal ghost path, and explicit commit afterimages take precedence.
     final selectedAnnotation = _controller.selectedAnnotation;
+    final cropping = _controller.isCroppingImage &&
+        _controller.selectedPage == widget.pageIndex;
     final washRestGhost = selectedAnnotation?.subtype == 'FreeText';
     final _AfterGhost? restGhost = !widget.rasterCurrent &&
             !dragging &&
@@ -4992,20 +5003,25 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // anchor drags at the press point, not where the recognizer won the
         // arena - a shape should start exactly where the pointer went down
         dragStartBehavior: DragStartBehavior.down,
-        onPanStart: _panStart,
-        onPanUpdate: _panUpdate,
-        onPanEnd: _panEnd,
-        onTapUp: _onTapUp,
-        onDoubleTapDown:
-            _polyTool || _tool == PdfEditTool.cloudPolygon ||
-                    _tool == PdfEditTool.form
-                ? _onDoubleTapDown
-                : null,
-        onDoubleTap:
-            _polyTool || _tool == PdfEditTool.cloudPolygon ||
-                    _tool == PdfEditTool.form
-                ? _onDoubleTap
-                : null,
+        // while cropping, the crop overlay owns the page: drop this detector's
+        // recognizers entirely so they never win the gesture arena over the
+        // crop rectangle's own handles and confirm/cancel chips
+        onPanStart: cropping ? null : _panStart,
+        onPanUpdate: cropping ? null : _panUpdate,
+        onPanEnd: cropping ? null : _panEnd,
+        onTapUp: cropping ? null : _onTapUp,
+        onDoubleTapDown: !cropping &&
+                (_polyTool ||
+                    _tool == PdfEditTool.cloudPolygon ||
+                    _tool == PdfEditTool.form)
+            ? _onDoubleTapDown
+            : null,
+        onDoubleTap: !cropping &&
+                (_polyTool ||
+                    _tool == PdfEditTool.cloudPolygon ||
+                    _tool == PdfEditTool.form)
+            ? _onDoubleTap
+            : null,
         child: MouseRegion(
           cursor: _cursor,
           onHover: _onHover,
@@ -5412,6 +5428,23 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                 _buildReadoutChip(text, anchor),
               if (_styleReadout() case (final text, final anchor))
                 _buildReadoutChip(text, anchor, keyValue: 'pdf-style-readout'),
+              if (_controller.isCroppingImage &&
+                  _controller.selectedPage == widget.pageIndex &&
+                  selectedAnnotation != null)
+                PdfImageCropOverlay(
+                  key: const ValueKey('pdf-image-crop-overlay'),
+                  bounds: _geometry.toViewRect(selectedAnnotation.rect),
+                  initialCrop: _geometry.toViewRect(
+                      _controller.imageCropDraft ?? selectedAnnotation.rect),
+                  chromeScale: _chromeScale,
+                  accentColor: PdfViewerTheme.of(context)
+                          .annotationChromeColor ??
+                      const Color(0xFF1E88E5),
+                  onChanged: (viewRect) => _controller
+                      .updateImageCropDraft(_geometry.toPageRect(viewRect)),
+                  onCommit: _controller.commitImageCrop,
+                  onCancel: _controller.cancelImageCrop,
+                ),
             ]),
           ),
         ),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1574,6 +1574,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// then the restyle settings that apply (colour, opacity, the tune
   /// popup carries stroke/font/etc).
   Widget _selectionStrip(BuildContext context) {
+    if (controller.isCroppingImage) return _cropStrip(context);
     final canRestyle = controller.canRestyleSelected;
     final selectedFieldName = controller.selectedWidgetFieldName;
     final settings = <Widget>[
@@ -1602,6 +1603,13 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                   tooltip: pdfL10n(context).tbDeleteAnnotations(
                       controller.selectedAnnotationSlots.length),
                   onPressed: controller.deleteSelected,
+                ),
+              if (controller.canCropSelected)
+                IconButton(
+                  key: const ValueKey('pdf-crop-image'),
+                  icon: const Icon(Icons.crop),
+                  tooltip: pdfL10n(context).tbCropImage,
+                  onPressed: controller.beginImageCrop,
                 ),
               if (controller.canEditSelectedText)
                 IconButton(
@@ -1632,6 +1640,57 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
               child: Row(mainAxisSize: MainAxisSize.min, children: settings),
             ),
           ],
+        ],
+      ),
+    );
+    return _centeredCard(context, padding: EdgeInsets.zero, child: row);
+  }
+
+  /// The toolbar shown while the interactive image-crop tool is armed: a
+  /// label, a reset-crop action, then cancel/apply. The on-page crop overlay
+  /// carries its own confirm/cancel chips; these mirror them for keyboard and
+  /// pointer users who reach for the toolbar.
+  Widget _cropStrip(BuildContext context) {
+    final l10n = pdfL10n(context);
+    final hasCrop = controller.selectedAnnotation?.imageStampCrop != null;
+    final row = IntrinsicHeight(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(12, 7, 4, 7),
+            child: Row(mainAxisSize: MainAxisSize.min, children: [
+              _StripLabel(l10n.tbCroppingImage),
+              if (hasCrop)
+                IconButton(
+                  key: const ValueKey('pdf-crop-reset'),
+                  icon: const Icon(Icons.restart_alt),
+                  tooltip: l10n.tbCropReset,
+                  onPressed: () {
+                    controller.cancelImageCrop();
+                    controller.resetSelectedImageCrop();
+                  },
+                ),
+            ]),
+          ),
+          const _StripDivider(),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 7),
+            child: Row(mainAxisSize: MainAxisSize.min, children: [
+              IconButton(
+                key: const ValueKey('pdf-crop-cancel-toolbar'),
+                icon: const Icon(Icons.close),
+                tooltip: l10n.tbCropCancel,
+                onPressed: controller.cancelImageCrop,
+              ),
+              IconButton(
+                key: const ValueKey('pdf-crop-apply-toolbar'),
+                icon: const Icon(Icons.check),
+                tooltip: l10n.tbCropApply,
+                onPressed: controller.commitImageCrop,
+              ),
+            ]),
+          ),
         ],
       ),
     );

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3989,6 +3989,10 @@ class _PdfViewerState extends State<PdfViewer>
         editing.cancelColorPick();
         return;
       }
+      if (editing.isCroppingImage) {
+        editing.cancelImageCrop();
+        return;
+      }
       if (editing.hasAnnotationSelection) {
         editing.clearAnnotationSelection();
         return;

--- a/packages/dart_pdf_editor/test/editing_image_crop_test.dart
+++ b/packages/dart_pdf_editor/test/editing_image_crop_test.dart
@@ -1,0 +1,250 @@
+// The interactive image-crop UI: the on-page crop rectangle
+// (PdfImageCropOverlay) and its wiring into the viewer and controller.
+import 'dart:convert';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/editing/editing_image_crop.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+final _png = base64.decode('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0k'
+    'AAAAGUlEQVR4nGP4z8DwHwgbWBgZ/jNyicr7AgA3BAUOTnqjAAAAAABJRU5ErkJggg==');
+
+String appearance(PdfDocument doc, PdfAnnotation annot) =>
+    latin1.decode(doc.cos.decodeStreamData(annot.normalAppearance!));
+
+void main() {
+  group('PdfImageCropOverlay widget', () {
+    testWidgets('dragging the top-right handle shrinks the crop', (tester) async {
+      const bounds = Rect.fromLTWH(0, 0, 200, 200);
+      Rect? changed;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Stack(children: [
+            PdfImageCropOverlay(
+              bounds: bounds,
+              initialCrop: bounds,
+              chromeScale: 1,
+              accentColor: const Color(0xFF1E88E5),
+              onChanged: (r) => changed = r,
+              onCommit: () {},
+              onCancel: () {},
+            ),
+          ]),
+        ),
+      ));
+
+      // top-right handle sits at (200, 0); drag it in by (-60, +60)
+      await tester.dragFrom(const Offset(200, 0), const Offset(-60, 60));
+      await tester.pump();
+
+      expect(changed, isNotNull);
+      expect(changed!.right, closeTo(140, 0.5));
+      expect(changed!.top, closeTo(60, 0.5));
+      // the left/bottom edges are untouched by a top-right drag
+      expect(changed!.left, closeTo(0, 0.5));
+      expect(changed!.bottom, closeTo(200, 0.5));
+    });
+
+    testWidgets('dragging the interior moves the crop, clamped to bounds',
+        (tester) async {
+      const bounds = Rect.fromLTWH(0, 0, 200, 200);
+      // start from a smaller centered crop so there is room to move
+      const start = Rect.fromLTWH(50, 50, 100, 100);
+      Rect? changed;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Stack(children: [
+            PdfImageCropOverlay(
+              bounds: bounds,
+              initialCrop: start,
+              chromeScale: 1,
+              accentColor: const Color(0xFF1E88E5),
+              onChanged: (r) => changed = r,
+              onCommit: () {},
+              onCancel: () {},
+            ),
+          ]),
+        ),
+      ));
+
+      // grab the interior (center) and drag up-left far enough to clamp
+      await tester.dragFrom(const Offset(100, 100), const Offset(-200, -200));
+      await tester.pump();
+      expect(changed, isNotNull);
+      // clamped into the bounds, size preserved
+      expect(changed!.left, closeTo(0, 0.5));
+      expect(changed!.top, closeTo(0, 0.5));
+      expect(changed!.width, closeTo(100, 0.5));
+      expect(changed!.height, closeTo(100, 0.5));
+    });
+
+    testWidgets('the confirm and cancel chips fire their callbacks',
+        (tester) async {
+      var committed = false, cancelled = false;
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Stack(children: [
+            PdfImageCropOverlay(
+              bounds: const Rect.fromLTWH(20, 20, 200, 200),
+              initialCrop: const Rect.fromLTWH(20, 20, 200, 200),
+              chromeScale: 1,
+              accentColor: const Color(0xFF1E88E5),
+              onChanged: (_) {},
+              onCommit: () => committed = true,
+              onCancel: () => cancelled = true,
+            ),
+          ]),
+        ),
+      ));
+
+      await tester.tap(find.byKey(const ValueKey('pdf-crop-confirm')));
+      expect(committed, isTrue);
+      await tester.tap(find.byKey(const ValueKey('pdf-crop-cancel')));
+      expect(cancelled, isTrue);
+    });
+  });
+
+  group('crop overlay in the viewer', () {
+    Future<PdfEditingController> pumpWithImage(WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      // a fully-visible image near the top of the page
+      expect(editing.addImageInRect(
+          0, const PdfRect(150, 520, 350, 700), _png), isTrue);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    testWidgets('beginImageCrop shows the overlay; confirm hides it',
+        (tester) async {
+      final editing = await pumpWithImage(tester);
+      expect(editing.canCropSelected, isTrue);
+      expect(find.byKey(const ValueKey('pdf-image-crop-overlay')), findsNothing);
+
+      editing.beginImageCrop();
+      await tester.pump();
+      expect(editing.isCroppingImage, isTrue);
+      expect(
+          find.byKey(const ValueKey('pdf-image-crop-overlay')), findsOneWidget);
+
+      // the on-page confirm chip commits and tears the overlay down
+      await tester.tap(find.byKey(const ValueKey('pdf-crop-confirm')));
+      // let the double-tap window and ink ripple timers drain
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+      expect(editing.isCroppingImage, isFalse);
+      expect(find.byKey(const ValueKey('pdf-image-crop-overlay')), findsNothing);
+    });
+
+    testWidgets('dragging a handle then confirming crops the image',
+        (tester) async {
+      final editing = await pumpWithImage(tester);
+      final rect = editing.selectedAnnotation!.rect; // [160,520,340,700]
+      editing.beginImageCrop();
+      await tester.pump();
+
+      // the page is laid out at 800px wide (page 612pt) → scale ≈ 1.307; the
+      // top-left handle sits at the image's top-left view corner
+      const s = 800 / 612;
+      final topLeft = Offset(rect.left * s, (792 - rect.top) * s);
+      final g = await tester.startGesture(topLeft);
+      await tester.pump();
+      await g.moveBy(const Offset(40, 40));
+      await tester.pump();
+      await g.up();
+      await tester.pump();
+
+      // the draft shrank from the top-left (page space: left grew, top fell)
+      expect(editing.imageCropDraft!.left, greaterThan(rect.left + 5));
+      expect(editing.imageCropDraft!.top, lessThan(rect.top - 5));
+
+      await tester.tap(find.byKey(const ValueKey('pdf-crop-confirm')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+
+      final stamp = editing.selectedAnnotation!;
+      expect(editing.isCroppingImage, isFalse);
+      expect(stamp.imageStampCrop, isNotNull);
+      // the box shrank to the dragged region
+      expect(stamp.rect.left, greaterThan(rect.left + 5));
+      expect(stamp.rect.top, lessThan(rect.top - 5));
+      expect(appearance(editing.document, stamp), contains('/Img0 Do'));
+    });
+
+    testWidgets('cancel via the overlay chip discards the crop', (tester) async {
+      final editing = await pumpWithImage(tester);
+      final rect = editing.selectedAnnotation!.rect;
+      editing.beginImageCrop();
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('pdf-crop-cancel')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+      expect(editing.isCroppingImage, isFalse);
+      expect(editing.selectedAnnotation!.imageStampCrop, isNull);
+      expect(editing.selectedAnnotation!.rect, rect);
+    });
+  });
+
+  group('crop in the toolbar', () {
+    Future<PdfEditingController> pumpToolbar(WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      expect(editing.addImageInRect(
+          0, const PdfRect(150, 520, 350, 700), _png), isTrue);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: const SizedBox.expand(),
+          bottomNavigationBar: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfEditingToolbar(
+                controller: editing, viewerController: viewer),
+          ),
+        ),
+      ));
+      return editing;
+    }
+
+    testWidgets('the Crop button arms cropping and swaps in the crop strip',
+        (tester) async {
+      final editing = await pumpToolbar(tester);
+      await tester.pump();
+      // the placed image is selected, so the Crop button shows
+      expect(find.byKey(const ValueKey('pdf-crop-image')), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-crop-image')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+      expect(editing.isCroppingImage, isTrue);
+      // the strip now shows the crop Done/Cancel actions
+      expect(find.byKey(const ValueKey('pdf-crop-apply-toolbar')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-crop-cancel-toolbar')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-crop-image')), findsNothing);
+
+      await tester.tap(find.byKey(const ValueKey('pdf-crop-cancel-toolbar')));
+      await tester.pumpAndSettle(const Duration(milliseconds: 400));
+      expect(editing.isCroppingImage, isFalse);
+      expect(find.byKey(const ValueKey('pdf-crop-image')), findsOneWidget);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_image_test.dart
+++ b/packages/dart_pdf_editor/test/editing_image_test.dart
@@ -175,4 +175,133 @@ void main() {
       expect(editing.document.page(0).annotations, isEmpty);
     });
   });
+
+  group('PdfEditingController image cropping', () {
+    PdfEditingController placedImage() {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      // a 200x200 box centered on (300, 400): [200, 300, 400, 500]
+      expect(editing.addImageInRect(
+          0, const PdfRect(200, 300, 400, 500), _png), isTrue);
+      return editing;
+    }
+
+    test('canCropSelected is true only for a selected image stamp', () {
+      final editing = placedImage();
+      addTearDown(editing.dispose);
+      expect(editing.selectedAnnotation?.isImageStamp, isTrue);
+      expect(editing.canCropSelected, isTrue);
+
+      // a note is not croppable
+      final other = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(other.dispose);
+      other.addNote(0, 100, 100, 'hi');
+      expect(other.canCropSelected, isFalse);
+    });
+
+    test('cropSelectedImage shrinks the box and records the crop', () {
+      final editing = placedImage();
+      addTearDown(editing.dispose);
+      final rect = editing.selectedAnnotation!.rect;
+      // crop to the top-right quarter of the box
+      final cx = (rect.left + rect.right) / 2;
+      final cy = (rect.bottom + rect.top) / 2;
+      editing.cropSelectedImage(PdfRect(cx, cy, rect.right, rect.top));
+
+      final stamp = editing.document.page(0).annotations.single;
+      // the box shrank to the visible quarter
+      expect(stamp.rect.left, closeTo(cx, 1e-6));
+      expect(stamp.rect.bottom, closeTo(cy, 1e-6));
+      expect(stamp.rect.right, closeTo(rect.right, 1e-6));
+      expect(stamp.rect.top, closeTo(rect.top, 1e-6));
+      // the crop is the top-right quarter of the source
+      final crop = stamp.imageStampCrop!;
+      expect(crop.left, closeTo(0.5, 1e-6));
+      expect(crop.bottom, closeTo(0.5, 1e-6));
+      expect(crop.right, closeTo(1.0, 1e-6));
+      expect(crop.top, closeTo(1.0, 1e-6));
+    });
+
+    test('cropping composes against the source across two crops', () {
+      final editing = placedImage();
+      addTearDown(editing.dispose);
+      final rect = editing.selectedAnnotation!.rect;
+      // first crop: left half
+      editing.cropSelectedImage(PdfRect(
+          rect.left, rect.bottom, (rect.left + rect.right) / 2, rect.top));
+      var crop = editing.selectedAnnotation!.imageStampCrop!;
+      expect(crop.right, closeTo(0.5, 1e-6));
+      // second crop: left half of what remains → left quarter of the source
+      final r2 = editing.selectedAnnotation!.rect;
+      editing.cropSelectedImage(PdfRect(
+          r2.left, r2.bottom, (r2.left + r2.right) / 2, r2.top));
+      crop = editing.selectedAnnotation!.imageStampCrop!;
+      expect(crop.right, closeTo(0.25, 1e-6));
+    });
+
+    test('resetSelectedImageCrop restores the whole picture and box', () {
+      final editing = placedImage();
+      addTearDown(editing.dispose);
+      final original = editing.selectedAnnotation!.rect;
+      editing.cropSelectedImage(PdfRect(original.left, original.bottom,
+          (original.left + original.right) / 2, original.top));
+      expect(editing.selectedAnnotation!.imageStampCrop, isNotNull);
+
+      editing.resetSelectedImageCrop();
+      final stamp = editing.selectedAnnotation!;
+      expect(stamp.imageStampCrop, isNull);
+      // the box grew back to the original full extent
+      expect(stamp.rect.left, closeTo(original.left, 1e-4));
+      expect(stamp.rect.right, closeTo(original.right, 1e-4));
+      expect(stamp.rect.bottom, closeTo(original.bottom, 1e-4));
+      expect(stamp.rect.top, closeTo(original.top, 1e-4));
+    });
+
+    test('crop-mode lifecycle: begin, update, commit', () {
+      final editing = placedImage();
+      addTearDown(editing.dispose);
+      final rect = editing.selectedAnnotation!.rect;
+      expect(editing.isCroppingImage, isFalse);
+
+      editing.beginImageCrop();
+      expect(editing.isCroppingImage, isTrue);
+      expect(editing.imageCropDraft, rect);
+
+      // dragging a smaller draft, clamped to the box
+      final draft = PdfRect(
+          rect.left + 10, rect.bottom + 10, rect.right - 10, rect.top - 10);
+      editing.updateImageCropDraft(draft);
+      expect(editing.imageCropDraft, draft);
+      // an out-of-bounds draft is clamped to the box
+      editing.updateImageCropDraft(PdfRect(
+          rect.left - 100, rect.bottom + 10, rect.right - 10, rect.top - 10));
+      expect(editing.imageCropDraft!.left, closeTo(rect.left, 1e-6));
+
+      editing.commitImageCrop();
+      expect(editing.isCroppingImage, isFalse);
+      expect(editing.selectedAnnotation!.imageStampCrop, isNotNull);
+    });
+
+    test('crop-mode cancel discards the pending crop', () {
+      final editing = placedImage();
+      addTearDown(editing.dispose);
+      final rect = editing.selectedAnnotation!.rect;
+      editing.beginImageCrop();
+      editing.updateImageCropDraft(PdfRect(
+          rect.left + 10, rect.bottom + 10, rect.right - 10, rect.top - 10));
+      editing.cancelImageCrop();
+      expect(editing.isCroppingImage, isFalse);
+      expect(editing.selectedAnnotation!.imageStampCrop, isNull);
+      expect(editing.selectedAnnotation!.rect, rect);
+    });
+
+    test('changing tool cancels an in-flight crop', () {
+      final editing = placedImage();
+      addTearDown(editing.dispose);
+      editing.beginImageCrop();
+      expect(editing.isCroppingImage, isTrue);
+      editing.tool = PdfEditTool.ink;
+      expect(editing.isCroppingImage, isFalse);
+    });
+  });
 }

--- a/packages/pdf_document/lib/src/annotation.dart
+++ b/packages/pdf_document/lib/src/annotation.dart
@@ -161,6 +161,32 @@ class PdfAnnotation {
     return value is CosBoolean && value.value;
   }
 
+  /// The cropped sub-region of an image stamp's source picture that its
+  /// appearance draws, in normalized image coordinates (origin bottom-left,
+  /// `[0,0,1,1]` is the whole image). Null when this is not an image stamp
+  /// or the whole picture is shown (no crop applied).
+  ///
+  /// The editor writes this private marker when an image stamp is cropped
+  /// ([PdfAnnotationEditing.cropImageStamp]) so the crop survives saves,
+  /// copies, and reopens, and is re-baked whenever the appearance is
+  /// regenerated (opacity restyle). Absent on an uncropped picture.
+  PdfRect? get imageStampCrop {
+    if (!isImageStamp) return null;
+    final value = document.cos.resolve(dict['DartPdfImageCrop']);
+    if (value is! CosArray || value.length < 4) return null;
+    final crop = pdfRectFrom(document.cos, value);
+    if (crop == null) return null;
+    // A degenerate or full-image marker reads as "no crop".
+    if (crop.width <= 0 || crop.height <= 0) return null;
+    if (crop.left <= 0 &&
+        crop.bottom <= 0 &&
+        crop.right >= 1 &&
+        crop.top >= 1) {
+      return null;
+    }
+    return crop;
+  }
+
   /// App-defined labels attached to a custom stamp annotation.
   ///
   /// These are stored as private annotation metadata beside [stampType].

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -3455,6 +3455,7 @@ extension PdfAnnotationEditing on PdfEditor {
     int? pageRotation,
     String? author,
     String? name,
+    PdfRect? crop,
   }) {
     final effectivePageRotation = _appearancePageRotation(
       pageIndex,
@@ -3463,16 +3464,19 @@ extension PdfAnnotationEditing on PdfEditor {
     final imageRef = _updater.addObject(
       image.toXObject((smask) => _updater.addObject(smask)),
     );
+    final effectiveCrop = _normalizeImageCrop(crop);
     final (w, resources) = _imageStampContent(
       rect,
       imageRef,
       opacity,
       pageRotation: effectivePageRotation,
+      crop: effectiveCrop,
     );
     // Mark it a picture stamp so the restyle path re-bakes only its alpha
     // over this image, and never mistakes it for a text/template stamp.
     final dict = _markupDict('Stamp', rect, 0xC03030, null, author)
       ..['DartPdfImageStamp'] = const CosBoolean(true);
+    _writeImageCropMarker(dict, effectiveCrop);
     _addAnnotation(
       pageIndex,
       dict,
@@ -3481,17 +3485,58 @@ extension PdfAnnotationEditing on PdfEditor {
     );
   }
 
+  /// Clamps [crop] to the unit square and normalizes its corners; null or a
+  /// degenerate crop becomes the whole image `[0,0,1,1]`.
+  static PdfRect _normalizeImageCrop(PdfRect? crop) {
+    if (crop == null) return const PdfRect(0, 0, 1, 1);
+    double c(double v) => v < 0 ? 0 : (v > 1 ? 1 : v);
+    final r = PdfRect.normalized(
+      c(crop.left),
+      c(crop.bottom),
+      c(crop.right),
+      c(crop.top),
+    );
+    if (r.width <= 0 || r.height <= 0) return const PdfRect(0, 0, 1, 1);
+    return r;
+  }
+
+  /// Records (or clears) an image stamp's crop on its annotation dict as the
+  /// private `/DartPdfImageCrop` marker. A full-image crop drops the marker so
+  /// an uncropped picture carries none. Read back by [PdfAnnotation.imageStampCrop].
+  static void _writeImageCropMarker(CosDictionary dict, PdfRect crop) {
+    final full = crop.left <= 0 &&
+        crop.bottom <= 0 &&
+        crop.right >= 1 &&
+        crop.top >= 1;
+    if (full) {
+      dict.entries.remove('DartPdfImageCrop');
+    } else {
+      dict['DartPdfImageCrop'] = CosArray([
+        CosReal(crop.left),
+        CosReal(crop.bottom),
+        CosReal(crop.right),
+        CosReal(crop.top),
+      ]);
+    }
+  }
+
   /// Builds an image stamp's appearance: a unit image (1×1 at the origin)
   /// mapped onto [rect]'s oriented visual box, gated by [opacity]'s alpha.
   /// The form's BBox stays the page-space rect, so unrotated appearances fit
   /// as an identity mapping. Shared by [addImageStamp] and the opacity
   /// restyle path so a pasted picture keeps its image when its transparency
   /// changes.
+  ///
+  /// [crop] is the normalized sub-region of the source picture to show
+  /// (origin bottom-left, `[0,0,1,1]` is the whole image). When it is less
+  /// than the full image, the visual box is clipped and the picture is scaled
+  /// so that sub-region fills the box - only the cropped part paints.
   (ContentWriter, CosDictionary?) _imageStampContent(
     PdfRect rect,
     CosObject imageRef,
     double opacity, {
     int pageRotation = 0,
+    PdfRect crop = const PdfRect(0, 0, 1, 1),
   }) {
     final w = ContentWriter();
     final gs = _alphaState(opacity);
@@ -3501,9 +3546,34 @@ extension PdfAnnotationEditing on PdfEditor {
       w.save();
       _orientedCounterRotation(w, rect, pageRotation);
     }
+    final cropped = crop.width < 1 || crop.height < 1 ||
+        crop.left > 0 || crop.bottom > 0;
+    w.save();
+    if (cropped) {
+      // The scaled-up picture overflows the visual box; the box clips it so
+      // only the cropped sub-region shows. (The form BBox also clips, but an
+      // explicit clip keeps the appearance correct under a non-identity
+      // BBox->Rect fit and matches the counter-rotated frame.)
+      w
+        ..rect(vr.left, vr.bottom, vr.width, vr.height)
+        ..clip();
+      // Map the crop's sub-rect of the unit image onto the visual box:
+      // (crop.left, crop.bottom) lands at the box origin, the crop's span
+      // fills the box.
+      final sx = vr.width / crop.width;
+      final sy = vr.height / crop.height;
+      w.concatMatrix(
+        sx,
+        0,
+        0,
+        sy,
+        vr.left - crop.left * sx,
+        vr.bottom - crop.bottom * sy,
+      );
+    } else {
+      w.concatMatrix(vr.width, 0, 0, vr.height, vr.left, vr.bottom);
+    }
     w
-      ..save()
-      ..concatMatrix(vr.width, 0, 0, vr.height, vr.left, vr.bottom)
       ..drawXObject('Img0')
       ..restore();
     if (pageRotation != 0) w.restore();
@@ -3532,6 +3602,63 @@ extension PdfAnnotationEditing on PdfEditor {
       if (subtype is CosName && subtype.value == 'Image') return entry;
     }
     return null;
+  }
+
+  /// Crops the image stamp [annotation] (one placed by [addImageStamp]) to
+  /// show only [crop] - the normalized sub-region of its source picture,
+  /// origin bottom-left, `[0,0,1,1]` being the whole image. The crop composes
+  /// against the *source* picture, so passing `[0,0,1,1]` restores the full
+  /// image regardless of any earlier crop.
+  ///
+  /// When [rect] is supplied it becomes the annotation's new page-space
+  /// /Rect. Size it to the visible sub-region (the on-page footprint of
+  /// [crop] within the current box) so the retained pixels keep their scale
+  /// instead of stretching to refill the old box - the standard "crop shrinks
+  /// the frame" behaviour. Omit [rect] to crop in place, stretching the
+  /// sub-region across the unchanged box.
+  ///
+  /// The picture is preserved (the same image XObject is re-referenced), as
+  /// are the current opacity and any baked-in rotation. Returns false when
+  /// [annotation] is not a restyleable image stamp. A [rect] argument is
+  /// ignored for a rotated image stamp (the crop still applies, in place),
+  /// because an axis-aligned page rect cannot express the rotated frame.
+  bool cropImageStamp(
+    int pageIndex,
+    PdfAnnotation annotation, {
+    required PdfRect crop,
+    PdfRect? rect,
+  }) {
+    if (!annotation.isImageStamp) return false;
+    final form = annotation.normalAppearance;
+    if (form == null) return false;
+    if (_stampImageRef(form) == null) return false;
+    final effectiveCrop = _normalizeImageCrop(crop);
+    final dict = annotation.dict;
+    // Record the crop first so the regeneration below (which reads it back
+    // off the dict via PdfAnnotation.imageStampCrop) bakes the new region.
+    _writeImageCropMarker(dict, effectiveCrop);
+    final quad = annotation.appearanceQuad;
+    final rotated = quad != null && _quadRotation(quad).abs() > 1e-9;
+    if (rect == null || rotated) {
+      // Crop in place at the current geometry, preserving rotation. Re-wrap
+      // so the just-written marker is visible to the regenerator.
+      return _restyleRegenerate(
+        pageIndex,
+        dict,
+        pageRotation: _appearancePageRotation(pageIndex, null),
+      );
+    }
+    // Shrink the box to the cropped sub-region (upright stamp only).
+    dict['Rect'] = _rectArray(rect);
+    if (!_regenerateStyledAppearance(
+      PdfAnnotation.fromDict(document, dict),
+      rect,
+      pageRotation: _appearancePageRotation(pageIndex, null),
+    )) {
+      return false;
+    }
+    _markAnnotationChanged(pageIndex, dict);
+    return true;
   }
 
   /// Removes [annotation] from the page, along with its popup, if any.
@@ -4862,6 +4989,7 @@ extension PdfAnnotationEditing on PdfEditor {
               imageRef,
               opacity ?? _appearanceOpacity(form),
               pageRotation: pageRotation,
+              crop: annotation.imageStampCrop ?? const PdfRect(0, 0, 1, 1),
             );
             _replaceAppearance(
               annotation.dict,

--- a/packages/pdf_document/test/image_stamp_test.dart
+++ b/packages/pdf_document/test/image_stamp_test.dart
@@ -185,4 +185,149 @@ void main() {
     final stamp = doc.page(0).annotations.single;
     expect(stamp.appearanceOpacity, closeTo(0.5, 1e-9));
   });
+
+  group('image stamp cropping', () {
+    final image = PdfEmbeddableImage.decode(_png);
+
+    test('addImageStamp with a crop clips the box and scales the picture', () {
+      // The central half of the source fills the 120x120 box: the scaled
+      // picture (240x240) is clipped to the box so only the crop shows.
+      final doc = roundTrip((e) => e.addImageStamp(
+          0, const PdfRect(100, 500, 220, 620), image,
+          crop: const PdfRect(0.25, 0.25, 0.75, 0.75)));
+      final stamp = doc.page(0).annotations.single;
+      expect(stamp.isImageStamp, isTrue);
+      expect(stamp.imageStampCrop, const PdfRect(0.25, 0.25, 0.75, 0.75));
+      final content =
+          latin1.decode(doc.cos.decodeStreamData(stamp.normalAppearance!));
+      expect(content, contains('/Img0 Do'));
+      // clip rect = the box; scaled cm maps the crop onto it
+      expect(content, contains('100 500 120 120 re'));
+      expect(content, contains('W'));
+      expect(content, contains('240 0 0 240 40 440 cm'));
+    });
+
+    test('a full crop reads back as no crop and bakes an identity map', () {
+      final doc = roundTrip((e) => e.addImageStamp(
+          0, const PdfRect(100, 500, 220, 620), image,
+          crop: const PdfRect(0, 0, 1, 1)));
+      final stamp = doc.page(0).annotations.single;
+      // full-image crop drops the marker
+      expect(stamp.imageStampCrop, isNull);
+      expect(stamp.dict.containsKey('DartPdfImageCrop'), isFalse);
+      final content =
+          latin1.decode(doc.cos.decodeStreamData(stamp.normalAppearance!));
+      // identity fit, no clip
+      expect(content, contains('120 0 0 120 100 500 cm'));
+    });
+
+    test('cropImageStamp crops in place at the current box', () {
+      final base = PdfDocument.open(buildClassicPdf());
+      final editor = PdfEditor(base)
+        ..addImageStamp(0, const PdfRect(0, 0, 100, 100), image);
+      final reopened = PdfDocument.open(editor.save());
+      final stamp = reopened.page(0).annotations.single;
+
+      final crop = PdfEditor(reopened)
+        ..cropImageStamp(0, stamp, crop: const PdfRect(0, 0, 0.5, 1));
+      final after = PdfDocument.open(crop.save());
+      final cropped = after.page(0).annotations.single;
+      // box unchanged, crop recorded
+      expect(cropped.rect, const PdfRect(0, 0, 100, 100));
+      expect(cropped.imageStampCrop, const PdfRect(0, 0, 0.5, 1));
+      final content =
+          latin1.decode(after.cos.decodeStreamData(cropped.normalAppearance!));
+      // left half fills the box: x scaled by 2, y unchanged
+      expect(content, contains('0 0 100 100 re'));
+      expect(content, contains('200 0 0 100 0 0 cm'));
+    });
+
+    test('cropImageStamp with a rect shrinks the box to the crop', () {
+      final base = PdfDocument.open(buildClassicPdf());
+      final editor = PdfEditor(base)
+        ..addImageStamp(0, const PdfRect(0, 0, 100, 100), image);
+      final reopened = PdfDocument.open(editor.save());
+      final stamp = reopened.page(0).annotations.single;
+
+      final crop = PdfEditor(reopened)
+        ..cropImageStamp(0, stamp,
+            crop: const PdfRect(0, 0, 0.5, 1),
+            rect: const PdfRect(0, 0, 50, 100));
+      final after = PdfDocument.open(crop.save());
+      final cropped = after.page(0).annotations.single;
+      expect(cropped.rect, const PdfRect(0, 0, 50, 100));
+      expect(cropped.imageStampCrop, const PdfRect(0, 0, 0.5, 1));
+      final content =
+          latin1.decode(after.cos.decodeStreamData(cropped.normalAppearance!));
+      // the retained left half keeps its scale (100 pt wide source → 50 pt
+      // box shows the left 50 pt), so the cm re-maps at the same scale
+      expect(content, contains('0 0 50 100 re'));
+      expect(content, contains('100 0 0 100 0 0 cm'));
+    });
+
+    test('an opacity restyle preserves the crop', () {
+      final base = PdfDocument.open(buildClassicPdf());
+      final editor = PdfEditor(base)
+        ..addImageStamp(0, const PdfRect(0, 0, 100, 100), image,
+            crop: const PdfRect(0.1, 0.2, 0.9, 0.8));
+      final reopened = PdfDocument.open(editor.save());
+      final stamp = reopened.page(0).annotations.single;
+      expect(stamp.imageStampCrop, const PdfRect(0.1, 0.2, 0.9, 0.8));
+
+      final restyle = PdfEditor(reopened)
+        ..restyleAnnotation(0, stamp, opacity: 0.4);
+      final after = PdfDocument.open(restyle.save());
+      final restyled = after.page(0).annotations.single;
+      expect(restyled.appearanceOpacity, closeTo(0.4, 1e-9));
+      // the crop marker and the clipped appearance both survive
+      expect(restyled.imageStampCrop, const PdfRect(0.1, 0.2, 0.9, 0.8));
+      final content =
+          latin1.decode(after.cos.decodeStreamData(restyled.normalAppearance!));
+      expect(content, contains('/Img0 Do'));
+      expect(content, contains('W'));
+      expect(content, contains(' re'));
+    });
+
+    test('cropping composes: a second crop narrows towards the source', () {
+      final base = PdfDocument.open(buildClassicPdf());
+      final editor = PdfEditor(base)
+        ..addImageStamp(0, const PdfRect(0, 0, 100, 100), image,
+            crop: const PdfRect(0, 0, 0.5, 1));
+      final reopened = PdfDocument.open(editor.save());
+      final stamp = reopened.page(0).annotations.single;
+      // caller composes against the source: the left quarter overall
+      final crop = PdfEditor(reopened)
+        ..cropImageStamp(0, stamp, crop: const PdfRect(0, 0, 0.25, 1));
+      final after = PdfDocument.open(crop.save());
+      expect(after.page(0).annotations.single.imageStampCrop,
+          const PdfRect(0, 0, 0.25, 1));
+    });
+
+    test('cropImageStamp back to full clears the crop marker', () {
+      final base = PdfDocument.open(buildClassicPdf());
+      final editor = PdfEditor(base)
+        ..addImageStamp(0, const PdfRect(0, 0, 100, 100), image,
+            crop: const PdfRect(0.25, 0.25, 0.75, 0.75));
+      final reopened = PdfDocument.open(editor.save());
+      final stamp = reopened.page(0).annotations.single;
+
+      final reset = PdfEditor(reopened)
+        ..cropImageStamp(0, stamp, crop: const PdfRect(0, 0, 1, 1));
+      final after = PdfDocument.open(reset.save());
+      final cleared = after.page(0).annotations.single;
+      expect(cleared.imageStampCrop, isNull);
+      expect(cleared.dict.containsKey('DartPdfImageCrop'), isFalse);
+    });
+
+    test('cropImageStamp is a no-op on a non-image stamp', () {
+      final base = PdfDocument.open(buildClassicPdf());
+      final editor = PdfEditor(base)
+        ..addNote(0, 100, 100, 'hi');
+      final reopened = PdfDocument.open(editor.save());
+      final note = reopened.page(0).annotations.single;
+      final tried = PdfEditor(reopened)
+          .cropImageStamp(0, note, crop: const PdfRect(0, 0, 0.5, 0.5));
+      expect(tried, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Adds an interactive **crop** tool for image stamps — the `/Stamp` annotations that `PdfEditor.addImageStamp` produces for placed images and pasted raster snapshots. Select a placed image, hit **Crop**, drag a rectangle over it, and confirm: the annotation's box shrinks to the cropped region and only that part of the source picture shows.

**Model (`pdf_document`).** `_imageStampContent` bakes a normalized crop rect (`[0,1]`, source-picture space) by clipping the visual box and scaling the picture so the crop fills it. A full crop degrades to the old identity map, so uncropped stamps are byte-for-byte unchanged. The crop is a private `/DartPdfImageCrop` marker, read back via `PdfAnnotation.imageStampCrop`; the opacity-restyle regeneration reads it so transparency changes preserve the crop, and the §12.5.5 stretch resize scales the whole baked appearance (clip and all) with no extra code. `cropImageStamp(pageIndex, annotation, {crop, rect})` re-references the same image XObject and rewrites the appearance; the crop composes against the source, so `[0 0 1 1]` restores the whole picture. Rotated stamps crop in place (the box-shrink is upright-only, since an axis-aligned page rect can't describe a rotated frame).

**Controller (`dart_pdf_editor`).** `cropSelectedImage` composes + shrinks the box; `resetSelectedImageCrop` restores the full picture; `canCropSelected` gates on a single upright image stamp. Interactive crop is a transient mode (`isCroppingImage`/`imageCropDraft` + `begin`/`update`/`commit`/`cancel`), auto-cancelled by the tool setter.

**UI.** `PdfImageCropOverlay` draws the on-page crop rectangle (scrim, rule-of-thirds grid, eight handles, confirm/cancel chips) atop the editing overlay while cropping; the editing overlay drops its own pan/tap recognizers so the crop overlay owns the page. A **Crop** button in the selection strip arms the mode, which swaps the strip for a reset/cancel/apply bar; Escape cancels.

See `doc/dev-log/2026-07-22-image-stamp-crop.md` for design notes, including two gesture-integration gotchas (`dragStartBehavior: down` for handle hit-testing, and `Listener.onPointerUp` chips to beat the viewer's `SelectableRegion` gesture arena).

## Affected packages

- [ ] `pdf_cos`
- [x] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm dart analyze` (clean over `pdf_document` and `dart_pdf_editor`)
- [x] `cd packages/pdf_document && fvm dart test` (`image_stamp_test.dart`)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (`editing_image_test.dart`, `editing_image_crop_test.dart`, plus regression runs of the resize/multiselect/rotate/touch-selection/properties/stamps/align suites)

New coverage: crop bake/read/persist/compose/reset at the model level; controller composition + crop-mode lifecycle; the overlay widget (handle drag, interior move+clamp, chip callbacks), the viewer wiring (arm → drag a handle → confirm crops the annotation; cancel discards), and the toolbar (Crop button arms + swaps in the crop strip).

## PDF fixtures and screenshots

Uses the existing programmatic 2×2 PNG fixture; no external PDFs. The crop appearance is asserted at the operator level (`re W n` clip + `cm` scale + `/Img0 Do`).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Crop targets **raster image stamps** (placed images and pasted raster snapshots). Vector snapshots (`PdfVectorSnapshot`, a form XObject replaying page operators) are out of scope for this tool.
- Cropping a rotated image stamp works in place but can't shrink its box; `canCropSelected` therefore excludes rotated stamps from the interactive tool.
- The crop marker follows the existing `DartPdf*` private-metadata convention, so it survives save/reopen and annotation copy/paste, and re-bakes on opacity restyle and resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013crG81NCBEYvUzxamTaBN7

---
_Generated by [Claude Code](https://claude.ai/code/session_013crG81NCBEYvUzxamTaBN7)_