### PR TITLE
Add saveSignedExternal: delegate the RSA operation to an external/keystore signer

### DIFF
--- a/packages/pdf_document/CHANGELOG.md
+++ b/packages/pdf_document/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 2.1.0
 
+- Add `PdfEditor.saveSignedExternal`: delegates the RSA operation to a
+  `PdfExternalSigner` callback so the private key can stay in a hardware keystore
+  (Android KeyStore, iOS Keychain). `PdfSignatureAppearance` gains overridable
+  `signedByLabel`/`dateLabel`/`reasonLabel`/`locationLabel`, and the visible `/M`
+  and signature-box date now preserve a non-UTC `signingTime`'s offset (UTC
+  input unchanged) (#507).
 - Cache `PdfPage` instances instead of rebuilding them per access, resolving
   inherited attributes live: a page holds only ancestor-derived values and
   reads its own `/Rotate`, `/MediaBox`, `/CropBox`, and `/Resources` from the

--- a/packages/pdf_document/lib/src/signature_editor.dart
+++ b/packages/pdf_document/lib/src/signature_editor.dart
@@ -1,5 +1,12 @@
 part of 'editor.dart';
 
+/// An external signing callback: receives the DER `SET OF` signed
+/// attributes and returns the RSA PKCS#1 v1.5 SHA-256 signature over those
+/// exact bytes — typically computed by a platform keystore (Android
+/// KeyStore, iOS Keychain) whose private key never leaves the device.
+typedef PdfExternalSigner = Future<Uint8List> Function(
+    Uint8List signedAttributes);
+
 /// The visible signature box drawn into a signature field's widget when
 /// signing - the two-column layout Acrobat and Bluebeam render once a
 /// field is signed: the signer's name (or a handwritten-signature image)
@@ -26,6 +33,10 @@ class PdfSignatureAppearance {
     this.backgroundColor,
     this.borderColor = 0x2E5E86,
     this.textColor = 0x1A1A1A,
+    this.signedByLabel = 'Digitally signed by',
+    this.dateLabel = 'Date:',
+    this.reasonLabel = 'Reason:',
+    this.locationLabel = 'Location:',
   });
 
   /// The 0-based page a newly created signature widget is placed on.
@@ -82,6 +93,19 @@ class PdfSignatureAppearance {
 
   /// The text color (0xRRGGBB).
   final int textColor;
+
+  /// Label prefixed to the signer name on the details panel. Override to
+  /// localise, e.g. 'Signature numérique de'.
+  final String signedByLabel;
+
+  /// Label prefixed to the signing date on the details panel.
+  final String dateLabel;
+
+  /// Label prefixed to the /Reason on the details panel.
+  final String reasonLabel;
+
+  /// Label prefixed to the /Location on the details panel.
+  final String locationLabel;
 }
 
 /// The signer details rendered into a visible signature box.
@@ -145,6 +169,52 @@ extension PdfSigning on PdfEditor {
       privateKey: privateKey,
       certificates: certificates,
       signingTime: time,
+    );
+    _writeContents(revision, cms);
+    return revision.saved;
+  }
+
+  /// Like [saveSigned], but the RSA operation is delegated to [signer], so
+  /// the private key can live in a hardware keystore. [signingTime] keeps
+  /// its own offset: pass a local DateTime to show local time in the
+  /// signature box and the /M date (the CMS signingTime attribute is
+  /// always encoded in UTC as RFC 5652 requires).
+  Future<Uint8List> saveSignedExternal({
+    required PdfExternalSigner signer,
+    required List<Uint8List> certificates,
+    String? fieldName,
+    String? signerName,
+    String? reason,
+    String? location,
+    String? contactInfo,
+    DateTime? signingTime,
+    PdfSignatureAppearance? appearance,
+  }) async {
+    if (certificates.isEmpty) {
+      throw ArgumentError('the signer certificate is required');
+    }
+    final time = signingTime ?? DateTime.now();
+    final revision = _emitSignatureRevision(
+      subFilter: 'adbe.pkcs7.detached',
+      capacity: _cmsCapacity(certificates),
+      fieldName: fieldName,
+      signingTime: time,
+      signerName: signerName,
+      reason: reason,
+      location: location,
+      contactInfo: contactInfo,
+      defaultSignerCert: certificates.first,
+      appearance: appearance,
+    );
+    final signedAttrs = cmsSignedAttributes(
+      contentDigest: revision.digestSha256(),
+      signingTime: time.toUtc(),
+    );
+    final signature = await signer(signedAttrs);
+    final cms = cmsAssembleSignedData(
+      signedAttributes: signedAttrs,
+      signature: signature,
+      certificates: certificates,
     );
     _writeContents(revision, cms);
     return revision.saved;
@@ -388,10 +458,14 @@ extension PdfSigning on PdfEditor {
   /// Ten digits so the patched real values always fit.
   static const _rangePlaceholder = 9999999999;
 
-  static String _pdfDate(DateTime utc) {
+  static String _pdfDate(DateTime time) {
     String two(int v) => v.toString().padLeft(2, '0');
-    return 'D:${utc.year}${two(utc.month)}${two(utc.day)}'
-        '${two(utc.hour)}${two(utc.minute)}${two(utc.second)}Z';
+    final base = 'D:${time.year}${two(time.month)}${two(time.day)}'
+        '${two(time.hour)}${two(time.minute)}${two(time.second)}';
+    final off = time.timeZoneOffset;
+    if (off == Duration.zero) return '${base}Z';
+    final sign = off.isNegative ? '-' : '+';
+    return "$base$sign${two(off.abs().inHours)}'${two(off.abs().inMinutes % 60)}'";
   }
 
   static String? _subjectCn(Uint8List certDer) {
@@ -661,17 +735,17 @@ extension PdfSigning on PdfEditor {
 
     final details = <String>[
       if (config.showName && name != null && name.isNotEmpty)
-        'Digitally signed by $name',
+        '${config.signedByLabel} $name',
       if (config.showDate && info.time != null)
-        'Date: ${_displaySignDate(info.time!)}',
+        '${config.dateLabel} ${_displaySignDate(info.time!)}',
       if (config.showReason &&
           info.reason != null &&
           info.reason!.isNotEmpty)
-        'Reason: ${info.reason}',
+        '${config.reasonLabel} ${info.reason}',
       if (config.showLocation &&
           info.location != null &&
           info.location!.isNotEmpty)
-        'Location: ${info.location}',
+        '${config.locationLabel} ${info.location}',
     ];
 
     // Column split coordinate (no drawn divider line): left panel when both
@@ -850,13 +924,15 @@ extension PdfSigning on PdfEditor {
     writer.restore();
   }
 
-  /// Acrobat-style display date: `2026.06.10 12:00:00 +00'00'`. Signing
-  /// times are normalized to UTC before display.
+  /// Acrobat-style display date: `2026.06.10 12:00:00 +00'00'`. The offset
+  /// of the [DateTime] passed is preserved; UTC input gives `+00'00'`.
   static String _displaySignDate(DateTime time) {
-    final utc = time.toUtc();
     String two(int v) => v.toString().padLeft(2, '0');
-    return '${utc.year}.${two(utc.month)}.${two(utc.day)} '
-        "${two(utc.hour)}:${two(utc.minute)}:${two(utc.second)} +00'00'";
+    final off = time.timeZoneOffset;
+    final sign = off.isNegative ? '-' : '+';
+    return '${time.year}.${two(time.month)}.${two(time.day)} '
+        '${two(time.hour)}:${two(time.minute)}:${two(time.second)} '
+        "$sign${two(off.abs().inHours)}'${two(off.abs().inMinutes % 60)}'";
   }
 }
 

--- a/packages/pdf_document/test/external_signing_test.dart
+++ b/packages/pdf_document/test/external_signing_test.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final key = RsaPrivateKey.fromPem(testSignerKeyPem);
+  final cert = pemBytes(testSignerCertPem);
+  // Signataire externe de référence : RSA PKCS#1 v1.5 sur le SHA-256 des
+  // signedAttributes — exactement ce que fera SHA256withRSA côté natif.
+  Future<Uint8List> signer(Uint8List attrs) async =>
+      rsaSign(key, '2.16.840.1.101.3.4.2.1', crypto.sha256.convert(attrs).bytes);
+
+  test('saveSignedExternal : signature intacte + cartouche localisé', () async {
+    final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(2)));
+    final signed = await editor.saveSignedExternal(
+      signer: signer,
+      certificates: [cert],
+      signingTime: DateTime(2026, 7, 22, 17, 34, 3),
+      appearance: const PdfSignatureAppearance(
+        page: 1,
+        rect: PdfRect(100, 100, 300, 180),
+        signedByLabel: 'Signature numérique de',
+        dateLabel: 'Date :',
+      ),
+    );
+    final doc = PdfDocument.open(signed);
+    final sig = PdfSignature.of(doc).single;
+    expect(sig.validate().intact, isTrue);
+  });
+
+  test('saveSignedExternal sans appearance : signature invisible intacte', () async {
+    final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+    final signed = await editor.saveSignedExternal(
+        signer: signer, certificates: [cert]);
+    expect(PdfSignature.of(PdfDocument.open(signed)).single.validate().intact,
+        isTrue);
+  });
+
+  test('_pdfDate et cartouche : offset local conservé', () async {
+    // Une heure NON-UTC doit produire un /M avec offset, pas un Z.
+    final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+    final t = DateTime(2026, 7, 22, 17, 34, 3); // locale du terminal de test
+    final signed = await editor.saveSignedExternal(
+        signer: signer, certificates: [cert], signingTime: t);
+    final text = String.fromCharCodes(signed);
+    if (t.timeZoneOffset == Duration.zero) {
+      expect(text, contains('D:20260722173403Z'));
+    } else {
+      final o = t.timeZoneOffset;
+      final sign = o.isNegative ? '-' : '+';
+      final hh = o.abs().inHours.toString().padLeft(2, '0');
+      final mm = (o.abs().inMinutes % 60).toString().padLeft(2, '0');
+      expect(text, contains("D:20260722173403$sign$hh'$mm'"));
+    }
+  });
+}


### PR DESCRIPTION
Adds an async external-signer variant of saveSigned (hardware keystores: Android KeyStore / iOS Secure Enclave-Keychain use cases), localizable signature-box labels, and local-time offsets in /M and the displayed date (UTC input keeps the previous output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)