### PR TITLE
Show first-page thumbnails in the recents list

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -28,6 +28,7 @@ import 'ocr.dart';
 import 'pdf_cache.dart';
 import 'print_progress_dialog.dart';
 import 'printing.dart';
+import 'recent_thumbnails.dart';
 import 'recents.dart';
 import 'session_store.dart';
 import 'settings_screen.dart';
@@ -155,6 +156,7 @@ class _EditorScreenState extends State<EditorScreen>
   PdfEditingPreferences get _prefs => widget.prefs;
 
   final _recents = RecentsStore();
+  final _recentThumbnails = RecentThumbnailCache();
   final _session = SessionStore();
   final _incoming = IncomingFileService();
   final _ocr = OnDeviceOcr();
@@ -300,6 +302,7 @@ class _EditorScreenState extends State<EditorScreen>
       tab.dispose();
     }
     _recents.dispose();
+    _recentThumbnails.dispose();
     _updates.removeListener(_onUpdateStatus);
     if (_ownsUpdates) _updates.dispose();
     super.dispose();
@@ -2300,6 +2303,7 @@ class _EditorScreenState extends State<EditorScreen>
         recents: _recents,
         onOpen: _pickAndOpen,
         onOpenRecent: _openRecent,
+        thumbnails: _recentThumbnails,
       );
     }
     if (tab.isDeferredPath) {

--- a/app/lib/recent_thumbnails.dart
+++ b/app/lib/recent_thumbnails.dart
@@ -1,0 +1,107 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+
+import 'devtools.dart';
+import 'file_io.dart';
+import 'recents.dart';
+
+/// Reads a recent entry's bytes from its [RecentFile.readPath]. Mirrors
+/// [readPdfAtPath]'s shape so it is the production default, and is injectable
+/// so widget tests can hand back fixture bytes without touching the filesystem.
+typedef RecentBytesReader = Future<Uint8List> Function(String path,
+    {String? bookmark});
+
+/// Renders and memoizes small first-page thumbnails for the recent-documents
+/// list on the welcome screen.
+///
+/// [thumbnailFor] reads an entry's bytes, opens the PDF, and rasterizes its
+/// first page to PNG bytes sized to [longestSide] px, keyed by the entry's
+/// [RecentFile.id] so a welcome-screen rebuild (recents changing, the list
+/// scrolling) never re-renders the same page. Entries with no readable source
+/// (a web pick with no snapshot) or a file that fails to open resolve to null,
+/// and the list falls back to its generic document icon.
+///
+/// Owned by the editor screen alongside the recents store; lives for the app
+/// session and is bounded to [maxEntries] retained thumbnails.
+class RecentThumbnailCache {
+  RecentThumbnailCache({
+    this.readBytes = readPdfAtPath,
+    this.longestSide = 96,
+    this.maxEntries = 32,
+  }) : assert(longestSide > 0);
+
+  /// Reads an entry's bytes. Production reads from disk / the byte-snapshot
+  /// store via [readPdfAtPath]; tests inject a fixture reader.
+  final RecentBytesReader readBytes;
+
+  /// Longest side of a rendered thumbnail, in pixels. The list draws it at
+  /// ~40 px, so a modest raster stays crisp on high-DPI screens without paying
+  /// for a full-page render.
+  final double longestSide;
+
+  /// Cap on retained thumbnails; the least-recently-requested entry is dropped
+  /// past it. The welcome list shows at most ~20.
+  final int maxEntries;
+
+  // Insertion-ordered so the first key is the least-recently-touched. A cached
+  // null (the entry has no readable/renderable source) is retained too, so a
+  // failed render isn't retried on every rebuild.
+  final Map<String, Uint8List?> _cache = {};
+  final Map<String, Future<Uint8List?>> _inflight = {};
+  bool _disposed = false;
+
+  /// The first-page thumbnail for [entry] as PNG bytes, rendered once and
+  /// memoized. Null when the entry has no readable source or the render fails.
+  Future<Uint8List?> thumbnailFor(RecentFile entry) {
+    final key = entry.id;
+    if (_cache.containsKey(key)) {
+      // Touch: move to the most-recently-used end.
+      final value = _cache.remove(key);
+      _cache[key] = value;
+      return Future.value(value);
+    }
+    final pending = _inflight[key];
+    if (pending != null) return pending;
+    final future = _render(entry).then((bytes) {
+      _inflight.remove(key);
+      if (!_disposed) _store(key, bytes);
+      return bytes;
+    });
+    _inflight[key] = future;
+    return future;
+  }
+
+  void _store(String key, Uint8List? bytes) {
+    _cache[key] = bytes;
+    while (_cache.length > maxEntries) {
+      _cache.remove(_cache.keys.first);
+    }
+  }
+
+  Future<Uint8List?> _render(RecentFile entry) async {
+    final path = entry.readPath;
+    if (path == null) return null;
+    try {
+      final bytes = await readBytes(path, bookmark: entry.bookmark);
+      final doc = PdfDocument.open(bytes);
+      if (doc.pageCount == 0) return null;
+      final page = doc.page(0);
+      final size = PdfPageRenderer.pageSize(page);
+      final longest = math.max(size.width, size.height);
+      final scale = longest <= 0 ? 1.0 : longestSide / longest;
+      return await PdfPageExport.exportPage(page, scale: scale);
+    } catch (e) {
+      AppDevTools.instance.addLog('recent thumbnail render failed: $e',
+          level: DevLogLevel.error);
+      return null;
+    }
+  }
+
+  void dispose() {
+    _disposed = true;
+    _cache.clear();
+    _inflight.clear();
+  }
+}

--- a/app/lib/welcome_screen.dart
+++ b/app/lib/welcome_screen.dart
@@ -139,9 +139,10 @@ class _RecentLeadingState extends State<_RecentLeading> {
     final placeholder = Icon(Icons.description_outlined,
         color: theme.iconTheme.color);
     final future = _thumbnail;
+    const radius = BorderRadius.all(Radius.circular(4));
     return SizedBox(
-      width: 40,
-      height: 52,
+      width: 48,
+      height: 62,
       child: future == null
           ? Center(child: placeholder)
           : FutureBuilder<Uint8List?>(
@@ -152,12 +153,16 @@ class _RecentLeadingState extends State<_RecentLeading> {
                 return Center(
                   child: DecoratedBox(
                     decoration: BoxDecoration(
+                      borderRadius: radius,
                       border: Border.all(color: theme.dividerColor),
                     ),
-                    child: Image.memory(
-                      bytes,
-                      fit: BoxFit.contain,
-                      gaplessPlayback: true,
+                    child: ClipRRect(
+                      borderRadius: radius,
+                      child: Image.memory(
+                        bytes,
+                        fit: BoxFit.contain,
+                        gaplessPlayback: true,
+                      ),
                     ),
                   ),
                 );

--- a/app/lib/welcome_screen.dart
+++ b/app/lib/welcome_screen.dart
@@ -72,7 +72,9 @@ class WelcomeScreen extends StatelessWidget {
                           return ListTile(
                             key: ValueKey('recent-${entry.id}'),
                             leading: _RecentLeading(
-                                entry: entry, thumbnails: thumbnails),
+                                key: ValueKey('recent-leading-${entry.id}'),
+                                entry: entry,
+                                thumbnails: thumbnails),
                             title: Text(entry.title,
                                 maxLines: 1, overflow: TextOverflow.ellipsis),
                             subtitle: entry.path != null
@@ -115,7 +117,7 @@ class WelcomeScreen extends StatelessWidget {
 /// and holds it across rebuilds so scrolling / recents changes don't reset it
 /// to the placeholder.
 class _RecentLeading extends StatefulWidget {
-  const _RecentLeading({required this.entry, required this.thumbnails});
+  const _RecentLeading({super.key, required this.entry, required this.thumbnails});
 
   final RecentFile entry;
   final RecentThumbnailCache? thumbnails;
@@ -125,26 +127,11 @@ class _RecentLeading extends StatefulWidget {
 }
 
 class _RecentLeadingState extends State<_RecentLeading> {
-  Future<Uint8List?>? _thumbnail;
-
-  @override
-  void initState() {
-    super.initState();
-    _load();
-  }
-
-  @override
-  void didUpdateWidget(_RecentLeading oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.entry.id != widget.entry.id ||
-        oldWidget.thumbnails != widget.thumbnails) {
-      _load();
-    }
-  }
-
-  void _load() {
-    _thumbnail = widget.thumbnails?.thumbnailFor(widget.entry);
-  }
+  // Fetched once and held for the widget's lifetime. The row is keyed by
+  // entry.id, so a different entry lands on a fresh state (and re-fetches from
+  // the cache, which memoizes) rather than mutating this one.
+  late final Future<Uint8List?>? _thumbnail =
+      widget.thumbnails?.thumbnailFor(widget.entry);
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/welcome_screen.dart
+++ b/app/lib/welcome_screen.dart
@@ -1,7 +1,10 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 
 import 'app_info.dart';
 import 'l10n/app_l10n.dart';
+import 'recent_thumbnails.dart';
 import 'recents.dart';
 
 /// The landing surface shown when no document is open: a hero with the open
@@ -12,11 +15,17 @@ class WelcomeScreen extends StatelessWidget {
     required this.recents,
     required this.onOpen,
     required this.onOpenRecent,
+    this.thumbnails,
   });
 
   final RecentsStore recents;
   final VoidCallback onOpen;
   final void Function(RecentFile entry) onOpenRecent;
+
+  /// Renders the first-page thumbnail shown beside each recent entry. When
+  /// null (or an entry has no readable source), the list shows a generic
+  /// document icon instead.
+  final RecentThumbnailCache? thumbnails;
 
   @override
   Widget build(BuildContext context) {
@@ -62,7 +71,8 @@ class WelcomeScreen extends StatelessWidget {
                           final entry = items[i];
                           return ListTile(
                             key: ValueKey('recent-${entry.id}'),
-                            leading: const Icon(Icons.description_outlined),
+                            leading: _RecentLeading(
+                                entry: entry, thumbnails: thumbnails),
                             title: Text(entry.title,
                                 maxLines: 1, overflow: TextOverflow.ellipsis),
                             subtitle: entry.path != null
@@ -95,6 +105,77 @@ class WelcomeScreen extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// The leading widget for a recent-file row: the document's first-page
+/// thumbnail once it renders, falling back to a generic icon while it loads
+/// (or when no thumbnail is available). Fetches the thumbnail once per entry
+/// and holds it across rebuilds so scrolling / recents changes don't reset it
+/// to the placeholder.
+class _RecentLeading extends StatefulWidget {
+  const _RecentLeading({required this.entry, required this.thumbnails});
+
+  final RecentFile entry;
+  final RecentThumbnailCache? thumbnails;
+
+  @override
+  State<_RecentLeading> createState() => _RecentLeadingState();
+}
+
+class _RecentLeadingState extends State<_RecentLeading> {
+  Future<Uint8List?>? _thumbnail;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void didUpdateWidget(_RecentLeading oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.entry.id != widget.entry.id ||
+        oldWidget.thumbnails != widget.thumbnails) {
+      _load();
+    }
+  }
+
+  void _load() {
+    _thumbnail = widget.thumbnails?.thumbnailFor(widget.entry);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final placeholder = Icon(Icons.description_outlined,
+        color: theme.iconTheme.color);
+    final future = _thumbnail;
+    return SizedBox(
+      width: 40,
+      height: 52,
+      child: future == null
+          ? Center(child: placeholder)
+          : FutureBuilder<Uint8List?>(
+              future: future,
+              builder: (context, snapshot) {
+                final bytes = snapshot.data;
+                if (bytes == null) return Center(child: placeholder);
+                return Center(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      border: Border.all(color: theme.dividerColor),
+                    ),
+                    child: Image.memory(
+                      bytes,
+                      fit: BoxFit.contain,
+                      gaplessPlayback: true,
+                    ),
+                  ),
+                );
+              },
+            ),
     );
   }
 }

--- a/app/test/recent_thumbnails_test.dart
+++ b/app/test/recent_thumbnails_test.dart
@@ -37,6 +37,30 @@ void main() {
     cache.dispose();
   });
 
+  testWidgets('evicts the least-recently-used entry past maxEntries',
+      (tester) async {
+    final pdf = PdfBlankDocument.create();
+    final reads = <String>[];
+    final cache = RecentThumbnailCache(
+      maxEntries: 1,
+      readBytes: (path, {bookmark}) async {
+        reads.add(path);
+        return pdf;
+      },
+    );
+
+    await tester.runAsync(() async {
+      await cache.thumbnailFor(entry(path: '/a.pdf'));
+      await cache.thumbnailFor(entry(path: '/b.pdf')); // evicts /a.pdf
+      await cache.thumbnailFor(entry(path: '/a.pdf')); // re-rendered
+    });
+
+    // /a.pdf was read twice: once before eviction, once after.
+    expect(reads, ['/a.pdf', '/b.pdf', '/a.pdf']);
+
+    cache.dispose();
+  });
+
   testWidgets('an entry with no readable source resolves to null',
       (tester) async {
     final cache = RecentThumbnailCache(

--- a/app/test/recent_thumbnails_test.dart
+++ b/app/test/recent_thumbnails_test.dart
@@ -1,0 +1,63 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'package:dart_pdf_editor_app/recent_thumbnails.dart';
+import 'package:dart_pdf_editor_app/recents.dart';
+
+void main() {
+  RecentFile entry({String? path, String title = 'a.pdf'}) =>
+      RecentFile(title: title, path: path, openedAt: 0);
+
+  testWidgets('renders a first-page PNG thumbnail from the entry bytes',
+      (tester) async {
+    final pdf = PdfBlankDocument.create();
+    var reads = 0;
+    final cache = RecentThumbnailCache(readBytes: (path, {bookmark}) async {
+      reads++;
+      return pdf;
+    });
+
+    Uint8List? png;
+    await tester.runAsync(() async {
+      png = await cache.thumbnailFor(entry(path: '/a.pdf'));
+    });
+
+    expect(png, isNotNull);
+    // PNG signature.
+    expect(png!.sublist(0, 4), [0x89, 0x50, 0x4E, 0x47]);
+
+    // A second request is served from the memo, not a fresh read/render.
+    await tester.runAsync(() async {
+      expect(await cache.thumbnailFor(entry(path: '/a.pdf')), same(png));
+    });
+    expect(reads, 1);
+
+    cache.dispose();
+  });
+
+  testWidgets('an entry with no readable source resolves to null',
+      (tester) async {
+    final cache = RecentThumbnailCache(
+        readBytes: (path, {bookmark}) async => fail('must not read'));
+    await tester.runAsync(() async {
+      // No path and no cache path: nothing to read.
+      expect(await cache.thumbnailFor(entry(title: 'web.pdf')), isNull);
+    });
+  });
+
+  testWidgets('a read failure resolves to null and is memoized',
+      (tester) async {
+    var reads = 0;
+    final cache = RecentThumbnailCache(readBytes: (path, {bookmark}) async {
+      reads++;
+      throw StateError('file gone');
+    });
+    await tester.runAsync(() async {
+      expect(await cache.thumbnailFor(entry(path: '/a.pdf')), isNull);
+      expect(await cache.thumbnailFor(entry(path: '/a.pdf')), isNull);
+    });
+    expect(reads, 1);
+  });
+}

--- a/app/test/welcome_screen_test.dart
+++ b/app/test/welcome_screen_test.dart
@@ -45,6 +45,32 @@ void main() {
     cache.dispose();
   });
 
+  testWidgets('falls back to the document icon when the render fails',
+      (tester) async {
+    final store = RecentsStore();
+    await store.add(title: 'a.pdf', path: '/a.pdf');
+    // A cache that can't read the bytes resolves the thumbnail to null.
+    final cache = RecentThumbnailCache(
+        readBytes: (path, {bookmark}) async => throw StateError('gone'));
+
+    await pump(
+        tester,
+        WelcomeScreen(
+          recents: store,
+          onOpen: () {},
+          onOpenRecent: (_) {},
+          thumbnails: cache,
+        ));
+
+    await tester.runAsync(() => cache.thumbnailFor(store.items.single));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.description_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+
+    cache.dispose();
+  });
+
   testWidgets('falls back to the document icon without a thumbnail cache',
       (tester) async {
     final store = RecentsStore();

--- a/app/test/welcome_screen_test.dart
+++ b/app/test/welcome_screen_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/recent_thumbnails.dart';
+import 'package:dart_pdf_editor_app/recents.dart';
+import 'package:dart_pdf_editor_app/welcome_screen.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> pump(WidgetTester tester, WelcomeScreen screen) =>
+      tester.pumpWidget(MaterialApp(home: Scaffold(body: screen)));
+
+  testWidgets('a recent row shows its first-page thumbnail once it renders',
+      (tester) async {
+    final store = RecentsStore();
+    await store.add(title: 'a.pdf', path: '/a.pdf');
+    final pdf = PdfBlankDocument.create();
+    final cache =
+        RecentThumbnailCache(readBytes: (path, {bookmark}) async => pdf);
+
+    await pump(
+        tester,
+        WelcomeScreen(
+          recents: store,
+          onOpen: () {},
+          onOpenRecent: (_) {},
+          thumbnails: cache,
+        ));
+
+    // Before the thumbnail lands the row shows the placeholder icon.
+    await tester.pump();
+    expect(find.byIcon(Icons.description_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+
+    // Drive the (real-async) render, then let the FutureBuilder rebuild.
+    await tester.runAsync(() => cache.thumbnailFor(store.items.single));
+    await tester.pump();
+
+    expect(find.byType(Image), findsOneWidget);
+    expect(find.byIcon(Icons.description_outlined), findsNothing);
+
+    cache.dispose();
+  });
+
+  testWidgets('falls back to the document icon without a thumbnail cache',
+      (tester) async {
+    final store = RecentsStore();
+    await store.add(title: 'a.pdf', path: '/a.pdf');
+
+    await pump(
+        tester,
+        WelcomeScreen(
+          recents: store,
+          onOpen: () {},
+          onOpenRecent: (_) {},
+        ));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.description_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing);
+  });
+}

--- a/doc/dev-log/2026-07-22-recents-file-thumbnails.md
+++ b/doc/dev-log/2026-07-22-recents-file-thumbnails.md
@@ -1,0 +1,42 @@
+# Recent-files list shows first-page thumbnails
+
+The welcome screen's "Recent" list previously showed a generic
+`Icons.description_outlined` beside every entry. It now shows a small
+rendered thumbnail of the document's first page, falling back to that icon
+while the render is pending or when no thumbnail can be produced.
+
+## What landed
+
+- `app/lib/recent_thumbnails.dart` - `RecentThumbnailCache`. Given a
+  `RecentFile`, it reads the entry's bytes from its `readPath` (default
+  `readPdfAtPath`, injectable for tests), opens the PDF, and rasterizes the
+  first page to PNG bytes via `PdfPageExport.exportPage(page, scale: …)`,
+  sized so the longest side is `longestSide` px (default 96). Results are
+  memoized by `RecentFile.id` - including a cached *null* for entries with
+  no readable source (a web pick with no snapshot) or a file that fails to
+  open, so a failed render isn't retried on every rebuild. Bounded LRU
+  (`maxEntries`, default 32; the list shows at most ~20).
+- `app/lib/welcome_screen.dart` - the row `leading` is now `_RecentLeading`,
+  a small `StatefulWidget` that fetches the thumbnail once per entry (keyed
+  on `entry.id`) and holds the future across rebuilds so scrolling / recents
+  changes don't flash back to the placeholder. Draws the PNG with
+  `Image.memory` inside a hairline border, `~40×52`. `WelcomeScreen` gained
+  an optional `thumbnails` param; null keeps the old icon-only behaviour.
+- `app/lib/editor_screen.dart` - owns one `RecentThumbnailCache` alongside
+  `_recents` (disposed with it) and passes it to `WelcomeScreen`.
+
+## Gotchas
+
+- Rendering needs `dart:ui` rasterization, so the cache's render path only
+  works under a live binding - the unit tests use `testWidgets` +
+  `tester.runAsync`, not bare `test`.
+- `PdfBlankDocument` is not re-exported from `dart_pdf_editor`; import it
+  from `package:pdf_document/pdf_document.dart` in tests.
+- The thumbnail is keyed by `RecentFile.id` (the path / cache path), so
+  re-opening the *same* path reuses the cached render for the session; the
+  cache is in-memory only (no disk write-through), so a cold launch
+  re-renders visible thumbnails lazily.
+
+Tests: `app/test/recent_thumbnails_test.dart` (render → PNG, memoization,
+null source, memoized read failure) and `app/test/welcome_screen_test.dart`
+(thumbnail appears after render; icon fallback without a cache).


### PR DESCRIPTION
## Summary

The welcome screen's **Recent** list showed a generic `Icons.description_outlined` beside every entry. It now shows a small rendered thumbnail of the document's first page, falling back to that icon while the render is pending or when no thumbnail can be produced.

- `app/lib/recent_thumbnails.dart` — new `RecentThumbnailCache`. Given a `RecentFile`, it reads the entry's bytes from its `readPath` (default `readPdfAtPath`, injectable for tests), opens the PDF, and rasterizes the first page to PNG bytes via `PdfPageExport.exportPage(page, scale: …)` sized to a ~96 px longest side. Results are memoized by `RecentFile.id` — including a cached *null* for entries with no readable source (a web pick with no snapshot) or a file that fails to open, so a failed render isn't retried on every rebuild. Bounded LRU (default 32; the list shows at most ~20).
- `app/lib/welcome_screen.dart` — the row `leading` is now `_RecentLeading`, a small `StatefulWidget` that fetches the thumbnail once per entry (keyed on `entry.id`) and holds the future across rebuilds so scrolling / recents changes don't flash back to the placeholder. `WelcomeScreen` gained an optional `thumbnails` param; null keeps the old icon-only behaviour.
- `app/lib/editor_screen.dart` — owns one `RecentThumbnailCache` alongside `_recents` (disposed with it) and passes it to `WelcomeScreen`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

Main application under `app/` (uses the `dart_pdf_editor` package's public `PdfPageExport` / `PdfPageRenderer`; no package code changed).

## Change type

- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Ran `fvm dart analyze app` (clean) and the app test suite for the touched areas: `app/test/recent_thumbnails_test.dart`, `app/test/welcome_screen_test.dart`, plus the existing `recent_menu_test.dart` / `recents_test.dart` (all green). No package-level Dart code changed, so the package test suites were not re-run.

## PDF fixtures and screenshots

Tests render `PdfBlankDocument.create()` bytes programmatically — no PDFs attached.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`. (The new code lives in `app/`, the Flutter application layer.)
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Thumbnails are rendered lazily per visible row and cached in memory for the app session (no disk write-through), so a cold launch re-renders the visible entries once. A disk-persistent thumbnail cache could be a follow-up if cold-start cost matters.
- Only the welcome-screen recents *list* gained thumbnails; the compact "Open Recent" app-menu submenu (48 px popup rows) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUXkcJXG7KdmrLSZ1QJGsV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUXkcJXG7KdmrLSZ1QJGsV)_