### PR TITLE
feat(i18n): no-context string extraction in the app + example

### DIFF
--- a/I18N_HANDOVER.md
+++ b/I18N_HANDOVER.md
@@ -73,9 +73,11 @@ gotchas, and the deferred no-context inventory.
       `MaterialApp` delegates
 - [x] Full verification: root `fvm dart analyze --fatal-infos` + all three
       test suites (package/app/example) green
-- [ ] Deferred: the no-context strings that need a context-threading
-      refactor (toolbar tool tooltips are the biggest) — full list in the
-      2026-07-22 dev-log note.
+- [x] Deferred: the no-context strings that need a context-threading
+      refactor — done for the editor package (PR #499,
+      `doc/dev-log/2026-07-22-i18n-no-context-refactors.md`) and the app +
+      example (`doc/dev-log/2026-07-22-i18n-app-no-context.md`). English
+      extraction is now complete across all three bundles.
 
 ## What's done (state of this branch)
 

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -294,6 +294,8 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
       context,
       const JsonEncoder.withIndent('  ').convert(snapshot),
       'dartpdf-devtools-$stamp.json',
+      // The developer tools stay English (excluded from the app l10n).
+      typeLabel: 'DartPDF stamps',
     );
     _tools.addLog('devtools: snapshot export ${result.runtimeType}');
   }

--- a/app/lib/digital_signature.dart
+++ b/app/lib/digital_signature.dart
@@ -25,19 +25,20 @@ String _acrobatSignDate(DateTime time) {
       "${two(utc.hour)}:${two(utc.minute)}:${two(utc.second)} +00'00'";
 }
 
-const digitalSignatureKeyTypeGroup = XTypeGroup(
-  label: 'RSA private keys',
-  extensions: ['pem', 'key', 'der'],
-  mimeTypes: ['application/x-pem-file', 'application/pkcs8'],
-  uniformTypeIdentifiers: ['public.data'],
-);
+// `label` is the localized file-dialog filter name; the caller resolves it.
+XTypeGroup digitalSignatureKeyTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['pem', 'key', 'der'],
+      mimeTypes: const ['application/x-pem-file', 'application/pkcs8'],
+      uniformTypeIdentifiers: const ['public.data'],
+    );
 
-const digitalSignatureCertificateTypeGroup = XTypeGroup(
-  label: 'X.509 certificates',
-  extensions: ['pem', 'crt', 'cer', 'der'],
-  mimeTypes: ['application/pkix-cert', 'application/x-x509-ca-cert'],
-  uniformTypeIdentifiers: ['public.x509-certificate', 'public.data'],
-);
+XTypeGroup digitalSignatureCertificateTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['pem', 'crt', 'cer', 'der'],
+      mimeTypes: const ['application/pkix-cert', 'application/x-x509-ca-cert'],
+      uniformTypeIdentifiers: const ['public.x509-certificate', 'public.data'],
+    );
 
 typedef DigitalSignatureOptionsProvider = Future<DigitalSignatureOptions?>
     Function(BuildContext context);
@@ -149,8 +150,10 @@ Future<DigitalSignatureOptions?> showDigitalSigningDialog(
     showDialog<DigitalSignatureOptions>(
       context: context,
       builder: (context) => DigitalSignatureDialog(
-        privateKeyPicker: privateKeyPicker ?? _pickPrivateKey,
-        certificatePicker: certificatePicker ?? _pickCertificates,
+        privateKeyPicker: privateKeyPicker ??
+            () => _pickPrivateKey(appL10n(context).appSigKeyFileType),
+        certificatePicker: certificatePicker ??
+            () => _pickCertificates(appL10n(context).appSigCertificateFileType),
         identityStore: identityStore ?? SecureIdentityStore(),
         createSelfSignedIdentity: createSelfSignedIdentity ??
             (context, store) =>
@@ -166,12 +169,12 @@ Future<DigitalSignatureOptions?> showDigitalSigningDialog(
       ),
     );
 
-Future<XFile?> _pickPrivateKey() => openFile(
-      acceptedTypeGroups: const [digitalSignatureKeyTypeGroup],
+Future<XFile?> _pickPrivateKey(String label) => openFile(
+      acceptedTypeGroups: [digitalSignatureKeyTypeGroup(label)],
     );
 
-Future<List<XFile>> _pickCertificates() => openFiles(
-      acceptedTypeGroups: const [digitalSignatureCertificateTypeGroup],
+Future<List<XFile>> _pickCertificates(String label) => openFiles(
+      acceptedTypeGroups: [digitalSignatureCertificateTypeGroup(label)],
     );
 
 class DigitalSignatureDialog extends StatefulWidget {
@@ -445,11 +448,36 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
         privateKey: key,
         certificates: _certificates,
       );
+    } on PdfSignatureIdentityException catch (error) {
+      _error = _localizeSignatureIdentityError(context, error);
     } on FormatException catch (error) {
       _error = error.message;
     } catch (_) {
       _error = appL10n(context).appSigKeyOrCertUnreadable;
     }
+  }
+
+  /// Maps a [PdfSignatureIdentityException] code (English `message` aside) to a
+  /// localized message. The engine model stays English-only; the translation
+  /// happens here, at the display site.
+  String _localizeSignatureIdentityError(
+    BuildContext context,
+    PdfSignatureIdentityException error,
+  ) {
+    final l10n = appL10n(context);
+    return switch (error.code) {
+      PdfSignatureIdentityError.noCertificateSelected =>
+        l10n.appSigErrorNoCertificateSelected,
+      PdfSignatureIdentityError.invalidCertificate =>
+        l10n.appSigErrorInvalidCertificate(error.certificateIndex ?? 0),
+      PdfSignatureIdentityError.keyCertificateMismatch =>
+        l10n.appSigErrorKeyCertificateMismatch,
+      PdfSignatureIdentityError.encryptedKeyUnsupported =>
+        l10n.appSigErrorEncryptedKeyUnsupported,
+      PdfSignatureIdentityError.keyNotRsa => l10n.appSigErrorKeyNotRsa,
+      PdfSignatureIdentityError.noCertificateFound =>
+        l10n.appSigErrorNoCertificateFound,
+    };
   }
 
   String? _value(TextEditingController controller) {

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -25,6 +25,7 @@ import 'keyless_signing.dart';
 import 'l10n/app_l10n.dart';
 import 'new_document.dart';
 import 'ocr.dart';
+import 'ocr_status_label.dart';
 import 'pdf_cache.dart';
 import 'print_progress_dialog.dart';
 import 'printing.dart';
@@ -998,7 +999,7 @@ class _EditorScreenState extends State<EditorScreen>
       }
     }
     try {
-      final files = await pickPdfFiles();
+      final files = await pickPdfFiles(l10n.fileTypePdf);
       if (files.isEmpty) return;
       // Opening a batch: defer parsing every file but the one that ends up
       // active, so the picker doesn't freeze while it opens all of them.
@@ -1338,7 +1339,7 @@ class _EditorScreenState extends State<EditorScreen>
     if (current == null) return;
     final l10n = appL10n(context);
     try {
-      final other = await pickPdfBytes();
+      final other = await pickPdfBytes(l10n.fileTypePdf);
       if (other == null) return;
       setState(() {
         _tabs.add(DocumentTab.comparison(
@@ -1535,7 +1536,9 @@ class _EditorScreenState extends State<EditorScreen>
   Future<void> _save(DocumentTab tab, {bool saveAs = false}) async {
     final bytes = tab.session?.bytes;
     if (bytes == null) return;
-    final saveAsDocument = widget.saveDocumentAs ?? saveBytesAs;
+    final saveAsDocument = widget.saveDocumentAs ??
+        (ctx, bytes, name) =>
+            saveBytesAs(ctx, bytes, name, pdfLabel: appL10n(ctx).fileTypePdf);
     final saveToPath = widget.saveDocumentToPath ?? saveBytesToPath;
     final inPlace = !saveAs && tab.originPath != null && supportsInPlaceSave;
     var result = inPlace
@@ -1628,7 +1631,9 @@ class _EditorScreenState extends State<EditorScreen>
                         ? null
                         : (context) => _obtainKeyless(context, silentProvider),
                 placement: placement,
-                logoPicker: placement == null ? null : pickImageBytes,
+                logoPicker: placement == null
+                    ? null
+                    : () => pickImageBytes(appL10n(context).fileTypeImages),
                 pageCount: session.document.pageCount,
               ))(context);
       if (!mounted || options == null || !_tabs.contains(tab)) return;
@@ -1815,8 +1820,9 @@ class _EditorScreenState extends State<EditorScreen>
       if (!mounted) return;
       final name =
           imageExportFileName(tab.title, pageIndex + 1, options.format);
-      final result =
-          await saveImageBytesAs(context, bytes, name, options.format.mimeType);
+      final result = await saveImageBytesAs(
+          context, bytes, name, options.format.mimeType,
+          imageLabel: appL10n(context).fileTypeImages);
       if (result.message != null) _toast(result.message!);
     } catch (_) {
       if (mounted) _toast(appL10n(context).editorCouldNotExport(tab.title));
@@ -1830,7 +1836,8 @@ class _EditorScreenState extends State<EditorScreen>
   ) async {
     final name = selectedContentImageFileName(tab.title, image.pageIndex + 1);
     final result = await saveImageBytesAs(
-        exportContext, image.pngBytes, name, 'image/png');
+        exportContext, image.pngBytes, name, 'image/png',
+        imageLabel: appL10n(exportContext).fileTypeImages);
     if (mounted && result.message != null) _toast(result.message!);
   }
 
@@ -1838,13 +1845,14 @@ class _EditorScreenState extends State<EditorScreen>
     BuildContext exportContext,
     List<PdfCustomStamp> stamps,
   ) async {
-    final result = await exportCustomStampsAs(exportContext, stamps);
+    final result = await exportCustomStampsAs(exportContext, stamps,
+        stampLabel: appL10n(exportContext).fileTypeStampBundle);
     if (mounted && result.message != null) _toast(result.message!);
   }
 
   Future<List<PdfCustomStamp>?> _importCustomStamps(BuildContext _) async {
     try {
-      return await importCustomStamps();
+      return await importCustomStamps(appL10n(context).fileTypeStampBundle);
     } catch (e) {
       if (mounted) _toast(appL10n(context).editorCouldNotImportStamps('$e'));
       return null;
@@ -2360,13 +2368,14 @@ class _EditorScreenState extends State<EditorScreen>
       // Save (button + Ctrl/⌘+S) live even before the first edit - the first
       // save writes the file via the Save As flow.
       alwaysAllowSave: tab.isUnsaved,
-      onPickPdfToInsert: pickPdfBytes,
-      onExportPages: (bytes) =>
-          unawaited(saveBytesAs(context, bytes, tab.title)),
+      onPickPdfToInsert: () => pickPdfBytes(appL10n(context).fileTypePdf),
+      onExportPages: (bytes) => unawaited(saveBytesAs(context, bytes, tab.title,
+          pdfLabel: appL10n(context).fileTypePdf)),
       onAction: _onAction,
       annotationMenuBuilder: _annotationMenuActions,
-      formImagePicker: (context, field) => pickImageBytes(),
-      imagePicker: (context) => pickImageBytes(),
+      formImagePicker: (context, field) =>
+          pickImageBytes(appL10n(context).fileTypeImages),
+      imagePicker: (context) => pickImageBytes(appL10n(context).fileTypeImages),
       systemImagePasteProvider: (context) =>
           (widget.imageClipboardReader ?? readImageFromClipboard)(),
       systemTextPasteProvider: (context) =>
@@ -3247,7 +3256,7 @@ class _OcrStatusChip extends StatelessWidget {
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  status.label,
+                  ocrStatusLabel(appL10n(context), status),
                   style: TextStyle(
                     fontSize: 12,
                     color: scheme.onSecondaryContainer,

--- a/app/lib/file_io.dart
+++ b/app/lib/file_io.dart
@@ -18,31 +18,36 @@ import 'web_file_picker_stub.dart'
 const _macosFileAccessChannel =
     MethodChannel('dev.milanko.dartpdf/file_access');
 
-/// One filter, every platform: desktop and web match on the extension,
-/// Android on the MIME type, iOS/macOS on the uniform type identifier -
-/// a type group missing the field a platform filters by throws there.
-const pdfTypeGroup = XTypeGroup(
-  label: 'PDF documents',
-  extensions: ['pdf'],
-  mimeTypes: ['application/pdf'],
-  uniformTypeIdentifiers: ['com.adobe.pdf'],
-);
+// The `label` shows in the native desktop file dialog's type-filter dropdown,
+// so it is localized: the callers (which have a BuildContext) pass the resolved
+// string in. Everything else is a stable platform identifier and stays put -
+// desktop and web match on the extension, Android on the MIME type, iOS/macOS
+// on the uniform type identifier; a group missing the field a platform filters
+// by throws there.
+
+/// The file filter for PDFs, labelled [label] (already localized by the caller).
+XTypeGroup pdfTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['pdf'],
+      mimeTypes: const ['application/pdf'],
+      uniformTypeIdentifiers: const ['com.adobe.pdf'],
+    );
 
 /// Images accepted by the form tool's push-button fill and the image tool.
-const imageTypeGroup = XTypeGroup(
-  label: 'Images',
-  extensions: ['png', 'jpg', 'jpeg'],
-  mimeTypes: ['image/png', 'image/jpeg'],
-  uniformTypeIdentifiers: ['public.png', 'public.jpeg'],
-);
+XTypeGroup imageTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['png', 'jpg', 'jpeg'],
+      mimeTypes: const ['image/png', 'image/jpeg'],
+      uniformTypeIdentifiers: const ['public.png', 'public.jpeg'],
+    );
 
 /// Custom stamp bundles exported from the Manage Stamps dialog.
-const stampBundleTypeGroup = XTypeGroup(
-  label: 'DartPDF stamps',
-  extensions: ['json'],
-  mimeTypes: ['application/json'],
-  uniformTypeIdentifiers: ['public.json'],
-);
+XTypeGroup stampBundleTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['json'],
+      mimeTypes: const ['application/json'],
+      uniformTypeIdentifiers: const ['public.json'],
+    );
 
 const _stampBundleFormat = 'dev.milanko.dartpdf.custom-stamps';
 
@@ -140,21 +145,21 @@ PdfByteSource pdfByteSourceForMobileToken(
 /// On the web this reads the picked file's bytes directly (see [pickPdfFileWeb])
 /// instead of going through `file_selector`, whose blob-URL XFiles hang on
 /// `readAsBytes()` under the deployed site's cross-origin isolation.
-Future<XFile?> pickPdfFile() => kIsWeb
+Future<XFile?> pickPdfFile(String pdfLabel) => kIsWeb
     ? pickPdfFileWeb()
-    : openFile(acceptedTypeGroups: const [pdfTypeGroup]);
+    : openFile(acceptedTypeGroups: [pdfTypeGroup(pdfLabel)]);
 
 /// Opens the system file picker for one or more PDFs. Returns an empty list
 /// when the user cancels. On the web, reads the bytes eagerly (see
 /// [pickPdfFilesWeb]) for the same reason as [pickPdfFile].
-Future<List<XFile>> pickPdfFiles() => kIsWeb
+Future<List<XFile>> pickPdfFiles(String pdfLabel) => kIsWeb
     ? pickPdfFilesWeb()
-    : openFiles(acceptedTypeGroups: const [pdfTypeGroup]);
+    : openFiles(acceptedTypeGroups: [pdfTypeGroup(pdfLabel)]);
 
 /// Opens the system file picker and reads the chosen PDF. Returns null when
 /// the user cancels. Throws if the file can't be read - callers surface that.
-Future<PickedPdf?> pickPdf() async {
-  final file = await pickPdfFile();
+Future<PickedPdf?> pickPdf(String pdfLabel) async {
+  final file = await pickPdfFile(pdfLabel);
   if (file == null) return null;
   final path = originPathForPickedFile(file);
   final bytes = await file.readAsBytes();
@@ -196,15 +201,15 @@ Future<String?> securityBookmarkForPath(String? path) async {
 
 /// Picks a PDF and returns just its bytes (null when cancelled) - the source
 /// for "Insert PDF…" and document comparison.
-Future<Uint8List?> pickPdfBytes() async {
-  final file = await openFile(acceptedTypeGroups: const [pdfTypeGroup]);
+Future<Uint8List?> pickPdfBytes(String pdfLabel) async {
+  final file = await openFile(acceptedTypeGroups: [pdfTypeGroup(pdfLabel)]);
   return file?.readAsBytes();
 }
 
 /// Picks an image and returns its bytes - used by the form image picker and
 /// the insert-image tool.
-Future<Uint8List?> pickImageBytes() async {
-  final file = await openFile(acceptedTypeGroups: const [imageTypeGroup]);
+Future<Uint8List?> pickImageBytes(String imageLabel) async {
+  final file = await openFile(acceptedTypeGroups: [imageTypeGroup(imageLabel)]);
   return file?.readAsBytes();
 }
 
@@ -248,8 +253,9 @@ PdfCustomStamp _decodeCustomStampEntry(Object? raw) {
 }
 
 /// Opens a JSON stamp bundle and returns the stamps inside it.
-Future<List<PdfCustomStamp>?> importCustomStamps() async {
-  final file = await openFile(acceptedTypeGroups: const [stampBundleTypeGroup]);
+Future<List<PdfCustomStamp>?> importCustomStamps(String stampLabel) async {
+  final file =
+      await openFile(acceptedTypeGroups: [stampBundleTypeGroup(stampLabel)]);
   if (file == null) return null;
   return decodeCustomStampBundle(utf8.decode(await file.readAsBytes()));
 }
@@ -453,8 +459,9 @@ Future<SaveResult> saveBytesToPath(
 Future<SaveResult> saveBytesAs(
   BuildContext context,
   Uint8List bytes,
-  String suggestedName,
-) async {
+  String suggestedName, {
+  required String pdfLabel,
+}) async {
   final name = ensurePdfName(suggestedName);
   final file = XFile.fromData(bytes, mimeType: 'application/pdf', name: name);
 
@@ -478,7 +485,7 @@ Future<SaveResult> saveBytesAs(
     default:
       final location = await getSaveLocation(
         suggestedName: name,
-        acceptedTypeGroups: const [pdfTypeGroup],
+        acceptedTypeGroups: [pdfTypeGroup(pdfLabel)],
       );
       if (location == null) return SaveResult.cancelled;
       // The dialog returns the path verbatim - if the user cleared or changed
@@ -496,9 +503,11 @@ Future<SaveResult> saveBytesAs(
 /// Exports user-managed custom stamps as a portable JSON bundle.
 Future<SaveResult> exportCustomStampsAs(
   BuildContext context,
-  List<PdfCustomStamp> stamps,
-) =>
-    saveJsonAs(context, encodeCustomStampBundle(stamps), 'dartpdf-stamps.json');
+  List<PdfCustomStamp> stamps, {
+  required String stampLabel,
+}) =>
+    saveJsonAs(context, encodeCustomStampBundle(stamps), 'dartpdf-stamps.json',
+        typeLabel: stampLabel);
 
 /// Save-as for a JSON document, with the same platform behaviour as
 /// [saveBytesAs]: a save dialog on desktop, a browser download on the web,
@@ -506,8 +515,9 @@ Future<SaveResult> exportCustomStampsAs(
 Future<SaveResult> saveJsonAs(
   BuildContext context,
   String json,
-  String name,
-) async {
+  String name, {
+  required String typeLabel,
+}) async {
   final bytes = Uint8List.fromList(utf8.encode(json));
   final file = XFile.fromData(
     bytes,
@@ -534,7 +544,7 @@ Future<SaveResult> saveJsonAs(
     default:
       final location = await getSaveLocation(
         suggestedName: name,
-        acceptedTypeGroups: const [stampBundleTypeGroup],
+        acceptedTypeGroups: [stampBundleTypeGroup(typeLabel)],
       );
       if (location == null) return SaveResult.cancelled;
       final path = ensureJsonExtension(location.path);
@@ -555,8 +565,9 @@ Future<SaveResult> saveImageBytesAs(
   BuildContext context,
   Uint8List bytes,
   String name,
-  String mimeType,
-) async {
+  String mimeType, {
+  required String imageLabel,
+}) async {
   final file = XFile.fromData(bytes, mimeType: mimeType, name: name);
 
   if (kIsWeb) {
@@ -578,7 +589,7 @@ Future<SaveResult> saveImageBytesAs(
     default:
       final location = await getSaveLocation(
         suggestedName: name,
-        acceptedTypeGroups: const [imageTypeGroup],
+        acceptedTypeGroups: [imageTypeGroup(imageLabel)],
       );
       if (location == null) return SaveResult.cancelled;
       try {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1109,5 +1109,101 @@
   "welcomeTapToReopen": "Tap to reopen",
   "@welcomeTapToReopen": {
     "description": "Subtitle for a recent file that can be reopened directly from a saved snapshot."
+  },
+  "settingsDefaultAppSubtitle": "{platform, select, web{Install the web app, then choose it for PDF files.} windows{Open Windows default apps settings for PDFs.} macos{Follow Finder’s “Always Open With” steps.} linux{Use your desktop’s default applications settings.} android{Choose DartPDF when opening a PDF, then tap Always.} ios{Use Share or Open In from Files to send PDFs here.} other{Configure your system’s PDF file handler.}}",
+  "@settingsDefaultAppSubtitle":   {
+      "description": "One-line hint on the Settings row explaining how to make DartPDF the default PDF app; the arm is chosen by the running platform.",
+      "placeholders": {
+          "platform": {
+              "type": "String"
+          }
+      }
+  },
+  "settingsDefaultAppInstructions": "{platform, select, web{Install DartPDF from your browser first. Then use the browser or operating system file-handler settings to associate PDF files with the installed app.} windows{Windows Settings will open to Default apps. Search for “.pdf” or “PDF”, choose the current PDF app, then select DartPDF.} macos{In Finder, select any PDF, choose File > Get Info, expand “Open with”, pick DartPDF, then click “Change All…”.} linux{Open your desktop settings for Default Applications, or right-click a PDF in Files, choose Properties, and set DartPDF as the default for PDF documents.} android{Open a PDF from Files or Downloads, choose DartPDF in the app picker, then select Always. If another app already opens PDFs, clear that app’s defaults in Android Settings first.} ios{iOS does not provide a global default PDF editor. Use Files > Share, or long-press a PDF and choose Share/Open In, then pick DartPDF.} other{Use the system settings for file handlers to associate PDF documents with DartPDF.}}",
+  "@settingsDefaultAppInstructions":   {
+      "description": "Full platform-specific steps for making DartPDF the default PDF app, shown in the setup dialog.",
+      "placeholders": {
+          "platform": {
+              "type": "String"
+          }
+      }
+  },
+  "ocrChipDownloadingModel": "Downloading OCR model…",
+  "@ocrChipDownloadingModel":   {
+      "description": "OCR progress chip while the recognition model downloads (size unknown)."
+  },
+  "ocrChipDownloadingModelPercent": "Downloading model {percent}%",
+  "@ocrChipDownloadingModelPercent":   {
+      "description": "OCR progress chip while the recognition model downloads, with percent.",
+      "placeholders": {
+          "percent": {
+              "type": "int"
+          }
+      }
+  },
+  "ocrChipRecognising": "OCR {page}/{pageCount}",
+  "@ocrChipRecognising":   {
+      "description": "OCR progress chip while recognizing text, showing page of total.",
+      "placeholders": {
+          "page": {
+              "type": "int"
+          },
+          "pageCount": {
+              "type": "int"
+          }
+      }
+  },
+  "ocrChipFinishing": "Finishing OCR…",
+  "@ocrChipFinishing":   {
+      "description": "OCR progress chip while assembling the recognized PDF after the last page."
+  },
+  "fileTypePdf": "PDF documents",
+  "@fileTypePdf":   {
+      "description": "File-picker filter label for PDF files."
+  },
+  "fileTypeImages": "Images",
+  "@fileTypeImages":   {
+      "description": "File-picker filter label for PNG/JPEG image files."
+  },
+  "fileTypeStampBundle": "DartPDF stamps",
+  "@fileTypeStampBundle":   {
+      "description": "File-picker filter label for exported custom-stamp JSON bundles."
+  },
+  "appSigKeyFileType": "RSA private keys",
+  "@appSigKeyFileType":   {
+      "description": "File-picker filter label when choosing a private key to sign with."
+  },
+  "appSigCertificateFileType": "X.509 certificates",
+  "@appSigCertificateFileType":   {
+      "description": "File-picker filter label when choosing signing certificates."
+  },
+  "appSigErrorNoCertificateSelected": "Select at least one X.509 certificate.",
+  "@appSigErrorNoCertificateSelected":   {
+      "description": "Signing error: the user picked a key but no certificate."
+  },
+  "appSigErrorInvalidCertificate": "Certificate {index} is not valid X.509.",
+  "@appSigErrorInvalidCertificate":   {
+      "description": "Signing error: a chosen certificate file could not be parsed as X.509.",
+      "placeholders": {
+          "index": {
+              "type": "int"
+          }
+      }
+  },
+  "appSigErrorKeyCertificateMismatch": "The private key does not match any selected RSA certificate.",
+  "@appSigErrorKeyCertificateMismatch":   {
+      "description": "Signing error: the key pairs with none of the chosen certificates."
+  },
+  "appSigErrorEncryptedKeyUnsupported": "Encrypted private keys are not supported. Choose an unencrypted RSA PKCS#1 or PKCS#8 key.",
+  "@appSigErrorEncryptedKeyUnsupported":   {
+      "description": "Signing error: the chosen private key is an encrypted PEM."
+  },
+  "appSigErrorKeyNotRsa": "The private key is not an unencrypted RSA PKCS#1 or PKCS#8 key.",
+  "@appSigErrorKeyNotRsa":   {
+      "description": "Signing error: the chosen private key could not be read as RSA."
+  },
+  "appSigErrorNoCertificateFound": "No X.509 certificates were found.",
+  "@appSigErrorNoCertificateFound":   {
+      "description": "Signing error: the chosen files contained no X.509 certificate."
   }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1340,6 +1340,108 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Tap to reopen'**
   String get welcomeTapToReopen;
+
+  /// One-line hint on the Settings row explaining how to make DartPDF the default PDF app; the arm is chosen by the running platform.
+  ///
+  /// In en, this message translates to:
+  /// **'{platform, select, web{Install the web app, then choose it for PDF files.} windows{Open Windows default apps settings for PDFs.} macos{Follow Finder’s “Always Open With” steps.} linux{Use your desktop’s default applications settings.} android{Choose DartPDF when opening a PDF, then tap Always.} ios{Use Share or Open In from Files to send PDFs here.} other{Configure your system’s PDF file handler.}}'**
+  String settingsDefaultAppSubtitle(String platform);
+
+  /// Full platform-specific steps for making DartPDF the default PDF app, shown in the setup dialog.
+  ///
+  /// In en, this message translates to:
+  /// **'{platform, select, web{Install DartPDF from your browser first. Then use the browser or operating system file-handler settings to associate PDF files with the installed app.} windows{Windows Settings will open to Default apps. Search for “.pdf” or “PDF”, choose the current PDF app, then select DartPDF.} macos{In Finder, select any PDF, choose File > Get Info, expand “Open with”, pick DartPDF, then click “Change All…”.} linux{Open your desktop settings for Default Applications, or right-click a PDF in Files, choose Properties, and set DartPDF as the default for PDF documents.} android{Open a PDF from Files or Downloads, choose DartPDF in the app picker, then select Always. If another app already opens PDFs, clear that app’s defaults in Android Settings first.} ios{iOS does not provide a global default PDF editor. Use Files > Share, or long-press a PDF and choose Share/Open In, then pick DartPDF.} other{Use the system settings for file handlers to associate PDF documents with DartPDF.}}'**
+  String settingsDefaultAppInstructions(String platform);
+
+  /// OCR progress chip while the recognition model downloads (size unknown).
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading OCR model…'**
+  String get ocrChipDownloadingModel;
+
+  /// OCR progress chip while the recognition model downloads, with percent.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading model {percent}%'**
+  String ocrChipDownloadingModelPercent(int percent);
+
+  /// OCR progress chip while recognizing text, showing page of total.
+  ///
+  /// In en, this message translates to:
+  /// **'OCR {page}/{pageCount}'**
+  String ocrChipRecognising(int page, int pageCount);
+
+  /// OCR progress chip while assembling the recognized PDF after the last page.
+  ///
+  /// In en, this message translates to:
+  /// **'Finishing OCR…'**
+  String get ocrChipFinishing;
+
+  /// File-picker filter label for PDF files.
+  ///
+  /// In en, this message translates to:
+  /// **'PDF documents'**
+  String get fileTypePdf;
+
+  /// File-picker filter label for PNG/JPEG image files.
+  ///
+  /// In en, this message translates to:
+  /// **'Images'**
+  String get fileTypeImages;
+
+  /// File-picker filter label for exported custom-stamp JSON bundles.
+  ///
+  /// In en, this message translates to:
+  /// **'DartPDF stamps'**
+  String get fileTypeStampBundle;
+
+  /// File-picker filter label when choosing a private key to sign with.
+  ///
+  /// In en, this message translates to:
+  /// **'RSA private keys'**
+  String get appSigKeyFileType;
+
+  /// File-picker filter label when choosing signing certificates.
+  ///
+  /// In en, this message translates to:
+  /// **'X.509 certificates'**
+  String get appSigCertificateFileType;
+
+  /// Signing error: the user picked a key but no certificate.
+  ///
+  /// In en, this message translates to:
+  /// **'Select at least one X.509 certificate.'**
+  String get appSigErrorNoCertificateSelected;
+
+  /// Signing error: a chosen certificate file could not be parsed as X.509.
+  ///
+  /// In en, this message translates to:
+  /// **'Certificate {index} is not valid X.509.'**
+  String appSigErrorInvalidCertificate(int index);
+
+  /// Signing error: the key pairs with none of the chosen certificates.
+  ///
+  /// In en, this message translates to:
+  /// **'The private key does not match any selected RSA certificate.'**
+  String get appSigErrorKeyCertificateMismatch;
+
+  /// Signing error: the chosen private key is an encrypted PEM.
+  ///
+  /// In en, this message translates to:
+  /// **'Encrypted private keys are not supported. Choose an unencrypted RSA PKCS#1 or PKCS#8 key.'**
+  String get appSigErrorEncryptedKeyUnsupported;
+
+  /// Signing error: the chosen private key could not be read as RSA.
+  ///
+  /// In en, this message translates to:
+  /// **'The private key is not an unencrypted RSA PKCS#1 or PKCS#8 key.'**
+  String get appSigErrorKeyNotRsa;
+
+  /// Signing error: the chosen files contained no X.509 certificate.
+  ///
+  /// In en, this message translates to:
+  /// **'No X.509 certificates were found.'**
+  String get appSigErrorNoCertificateFound;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -813,4 +813,101 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get welcomeTapToReopen => 'Tap to reopen';
+
+  @override
+  String settingsDefaultAppSubtitle(String platform) {
+    String _temp0 = intl.Intl.selectLogic(
+      platform,
+      {
+        'web': 'Install the web app, then choose it for PDF files.',
+        'windows': 'Open Windows default apps settings for PDFs.',
+        'macos': 'Follow Finder’s “Always Open With” steps.',
+        'linux': 'Use your desktop’s default applications settings.',
+        'android': 'Choose DartPDF when opening a PDF, then tap Always.',
+        'ios': 'Use Share or Open In from Files to send PDFs here.',
+        'other': 'Configure your system’s PDF file handler.',
+      },
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String settingsDefaultAppInstructions(String platform) {
+    String _temp0 = intl.Intl.selectLogic(
+      platform,
+      {
+        'web':
+            'Install DartPDF from your browser first. Then use the browser or operating system file-handler settings to associate PDF files with the installed app.',
+        'windows':
+            'Windows Settings will open to Default apps. Search for “.pdf” or “PDF”, choose the current PDF app, then select DartPDF.',
+        'macos':
+            'In Finder, select any PDF, choose File > Get Info, expand “Open with”, pick DartPDF, then click “Change All…”.',
+        'linux':
+            'Open your desktop settings for Default Applications, or right-click a PDF in Files, choose Properties, and set DartPDF as the default for PDF documents.',
+        'android':
+            'Open a PDF from Files or Downloads, choose DartPDF in the app picker, then select Always. If another app already opens PDFs, clear that app’s defaults in Android Settings first.',
+        'ios':
+            'iOS does not provide a global default PDF editor. Use Files > Share, or long-press a PDF and choose Share/Open In, then pick DartPDF.',
+        'other':
+            'Use the system settings for file handlers to associate PDF documents with DartPDF.',
+      },
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get ocrChipDownloadingModel => 'Downloading OCR model…';
+
+  @override
+  String ocrChipDownloadingModelPercent(int percent) {
+    return 'Downloading model $percent%';
+  }
+
+  @override
+  String ocrChipRecognising(int page, int pageCount) {
+    return 'OCR $page/$pageCount';
+  }
+
+  @override
+  String get ocrChipFinishing => 'Finishing OCR…';
+
+  @override
+  String get fileTypePdf => 'PDF documents';
+
+  @override
+  String get fileTypeImages => 'Images';
+
+  @override
+  String get fileTypeStampBundle => 'DartPDF stamps';
+
+  @override
+  String get appSigKeyFileType => 'RSA private keys';
+
+  @override
+  String get appSigCertificateFileType => 'X.509 certificates';
+
+  @override
+  String get appSigErrorNoCertificateSelected =>
+      'Select at least one X.509 certificate.';
+
+  @override
+  String appSigErrorInvalidCertificate(int index) {
+    return 'Certificate $index is not valid X.509.';
+  }
+
+  @override
+  String get appSigErrorKeyCertificateMismatch =>
+      'The private key does not match any selected RSA certificate.';
+
+  @override
+  String get appSigErrorEncryptedKeyUnsupported =>
+      'Encrypted private keys are not supported. Choose an unencrypted RSA PKCS#1 or PKCS#8 key.';
+
+  @override
+  String get appSigErrorKeyNotRsa =>
+      'The private key is not an unencrypted RSA PKCS#1 or PKCS#8 key.';
+
+  @override
+  String get appSigErrorNoCertificateFound =>
+      'No X.509 certificates were found.';
 }

--- a/app/lib/ocr_status.dart
+++ b/app/lib/ocr_status.dart
@@ -48,12 +48,6 @@ class OcrJobStatus {
         OcrPhase.finishing => null,
       };
 
-  /// A short label for the chip.
-  String get label => switch (phase) {
-        OcrPhase.downloading => downloadFraction == null
-            ? 'Downloading OCR model…'
-            : 'Downloading model ${(downloadFraction! * 100).round()}%',
-        OcrPhase.recognising => 'OCR $page/$pageCount',
-        OcrPhase.finishing => 'Finishing OCR…',
-      };
+  // The short chip label lives in the presentation layer (`ocrStatusLabel` in
+  // `ocr_status_label.dart`) so this model stays locale-free.
 }

--- a/app/lib/ocr_status_label.dart
+++ b/app/lib/ocr_status_label.dart
@@ -1,0 +1,19 @@
+import 'l10n/app_localizations.dart';
+import 'ocr_status.dart';
+
+/// The short chip label for an [OcrJobStatus], localized.
+///
+/// The [OcrPhase] and the numeric fields ([OcrJobStatus.page],
+/// [OcrJobStatus.pageCount], [OcrJobStatus.downloadFraction]) are the stable
+/// data; the visible string is resolved here, in the presentation layer, so the
+/// model itself stays Flutter- and locale-free (it only imports `foundation`).
+String ocrStatusLabel(AppLocalizations l10n, OcrJobStatus status) =>
+    switch (status.phase) {
+      OcrPhase.downloading => status.downloadFraction == null
+          ? l10n.ocrChipDownloadingModel
+          : l10n.ocrChipDownloadingModelPercent(
+              (status.downloadFraction! * 100).round()),
+      OcrPhase.recognising =>
+        l10n.ocrChipRecognising(status.page, status.pageCount),
+      OcrPhase.finishing => l10n.ocrChipFinishing,
+    };

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -8,38 +8,27 @@ import 'l10n/app_l10n.dart';
 import 'recents.dart';
 import 'update.dart';
 
-String get _defaultAppSubtitle {
-  if (kIsWeb) return 'Install the web app, then choose it for PDF files.';
+// The platform-specific default-app help lives in the ARB as one ICU `select`
+// key each (branches: web/windows/macos/linux/android/ios/other), resolved from
+// this selector. Both consumers below have a BuildContext, so no literal needs
+// to live at the no-context data site any more.
+String get _defaultAppPlatform {
+  if (kIsWeb) return 'web';
   return switch (defaultTargetPlatform) {
-    TargetPlatform.windows => 'Open Windows default apps settings for PDFs.',
-    TargetPlatform.macOS => 'Follow Finder’s “Always Open With” steps.',
-    TargetPlatform.linux => 'Use your desktop’s default applications settings.',
-    TargetPlatform.android =>
-      'Choose DartPDF when opening a PDF, then tap Always.',
-    TargetPlatform.iOS => 'Use Share or Open In from Files to send PDFs here.',
-    TargetPlatform.fuchsia => 'Configure your system’s PDF file handler.',
+    TargetPlatform.windows => 'windows',
+    TargetPlatform.macOS => 'macos',
+    TargetPlatform.linux => 'linux',
+    TargetPlatform.android => 'android',
+    TargetPlatform.iOS => 'ios',
+    TargetPlatform.fuchsia => 'fuchsia',
   };
 }
 
-String get _defaultAppInstructions {
-  if (kIsWeb) {
-    return 'Install DartPDF from your browser first. Then use the browser or operating system file-handler settings to associate PDF files with the installed app.';
-  }
-  return switch (defaultTargetPlatform) {
-    TargetPlatform.windows =>
-      'Windows Settings will open to Default apps. Search for “.pdf” or “PDF”, choose the current PDF app, then select DartPDF.',
-    TargetPlatform.macOS =>
-      'In Finder, select any PDF, choose File > Get Info, expand “Open with”, pick DartPDF, then click “Change All…”.',
-    TargetPlatform.linux =>
-      'Open your desktop settings for Default Applications, or right-click a PDF in Files, choose Properties, and set DartPDF as the default for PDF documents.',
-    TargetPlatform.android =>
-      'Open a PDF from Files or Downloads, choose DartPDF in the app picker, then select Always. If another app already opens PDFs, clear that app’s defaults in Android Settings first.',
-    TargetPlatform.iOS =>
-      'iOS does not provide a global default PDF editor. Use Files > Share, or long-press a PDF and choose Share/Open In, then pick DartPDF.',
-    TargetPlatform.fuchsia =>
-      'Use the system settings for file handlers to associate PDF documents with DartPDF.',
-  };
-}
+String _defaultAppSubtitle(BuildContext context) =>
+    appL10n(context).settingsDefaultAppSubtitle(_defaultAppPlatform);
+
+String _defaultAppInstructions(BuildContext context) =>
+    appL10n(context).settingsDefaultAppInstructions(_defaultAppPlatform);
 
 bool get _canOpenDefaultAppsSettings =>
     !kIsWeb && defaultTargetPlatform == TargetPlatform.windows;
@@ -59,7 +48,7 @@ Future<void> _showDefaultAppSetup(BuildContext context) {
     context: context,
     builder: (context) => AlertDialog(
       title: Text(appL10n(context).settingsSetUpAsDefault),
-      content: Text(_defaultAppInstructions),
+      content: Text(_defaultAppInstructions(context)),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
@@ -185,7 +174,7 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                   contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.assignment_turned_in_outlined),
                   title: Text(appL10n(context).settingsSetUpAsDefault),
-                  subtitle: Text(_defaultAppSubtitle),
+                  subtitle: Text(_defaultAppSubtitle(context)),
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () => _showDefaultAppSetup(context),
                 ),

--- a/app/test/digital_signature_test.dart
+++ b/app/test/digital_signature_test.dart
@@ -120,6 +120,54 @@ void main() {
     expect(result!.location, 'Melbourne');
   });
 
+  testWidgets('a key/cert mismatch shows a localized error, not a raw exception',
+      (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => FilledButton(
+            onPressed: () => showDigitalSigningDialog(
+              context,
+              // A valid key paired with a certificate for a different key -
+              // fromFiles throws PdfSignatureIdentityException(keyCertificateMismatch),
+              // which the app maps to a localized message at the display site.
+              privateKeyPicker: () async => XFile.fromData(
+                Uint8List.fromList(testSignerKeyPem.codeUnits),
+                name: 'signer-key.pem',
+              ),
+              certificatePicker: () async => [
+                XFile.fromData(
+                  Uint8List.fromList(testChainSignerCertPem.codeUnits),
+                  name: 'other-cert.pem',
+                ),
+              ],
+            ),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('digital-signature-advanced')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+        find.byKey(const ValueKey('digital-signature-private-key')));
+    await tester.tap(find.byKey(const ValueKey('digital-signature-private-key')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+        find.byKey(const ValueKey('digital-signature-certificates')));
+    await tester.tap(find.byKey(const ValueKey('digital-signature-certificates')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('digital-signature-error')), findsOneWidget);
+    expect(
+      find.text('The private key does not match any selected RSA certificate.'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('one-tap: create a self-signed identity and sign with it',
       (tester) async {
     DigitalSignatureOptions? result;

--- a/app/test/digital_signature_test.dart
+++ b/app/test/digital_signature_test.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:file_selector/file_selector.dart';
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart'
+    show FileSelectorPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -14,6 +16,38 @@ import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/file_io.dart';
 import 'package:dart_pdf_editor_app/keyless_signing.dart';
 import 'package:dart_pdf_editor_app/signature_appearance_store.dart';
+
+/// A fake file selector that hands back a prepared key file (single-file
+/// picker) and certificate files (multi-file picker), capturing the filter
+/// groups the default pickers pass so we can assert the localized labels.
+class _KeyCertSelector extends FileSelectorPlatform {
+  _KeyCertSelector(this.key, this.certs);
+
+  final XFile key;
+  final List<XFile> certs;
+  XTypeGroup? keyGroup;
+  XTypeGroup? certGroup;
+
+  @override
+  Future<XFile?> openFile({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    keyGroup = acceptedTypeGroups?.single;
+    return key;
+  }
+
+  @override
+  Future<List<XFile>> openFiles({
+    List<XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    certGroup = acceptedTypeGroups?.single;
+    return certs;
+  }
+}
 
 /// An unsigned OIDC token carrying [claims], enough for the keyless flow.
 String _jwt(Map<String, Object?> claims) {
@@ -166,6 +200,51 @@ void main() {
       find.text('The private key does not match any selected RSA certificate.'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('default pickers load key + cert with localized filter labels',
+      (tester) async {
+    final original = FileSelectorPlatform.instance;
+    final fake = _KeyCertSelector(
+      XFile.fromData(Uint8List.fromList(testSignerKeyPem.codeUnits),
+          name: 'signer-key.pem'),
+      [
+        XFile.fromData(Uint8List.fromList(testSignerCertPem.codeUnits),
+            name: 'signer-cert.pem'),
+      ],
+    );
+    FileSelectorPlatform.instance = fake;
+    addTearDown(() => FileSelectorPlatform.instance = original);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          // No injected pickers - exercises the default _pickPrivateKey /
+          // _pickCertificates, which resolve the localized filter labels.
+          builder: (context) => FilledButton(
+            onPressed: () => showDigitalSigningDialog(context),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('digital-signature-advanced')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+        find.byKey(const ValueKey('digital-signature-private-key')));
+    await tester.tap(find.byKey(const ValueKey('digital-signature-private-key')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(
+        find.byKey(const ValueKey('digital-signature-certificates')));
+    await tester.tap(find.byKey(const ValueKey('digital-signature-certificates')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dart PDF Test Signer'), findsOneWidget);
+    expect(fake.keyGroup?.label, 'RSA private keys');
+    expect(fake.certGroup?.label, 'X.509 certificates');
   });
 
   testWidgets('one-tap: create a self-signed identity and sign with it',

--- a/app/test/file_io_test.dart
+++ b/app/test/file_io_test.dart
@@ -91,9 +91,11 @@ void main() {
     fs.FileSelectorPlatform.instance = fake;
     addTearDown(() => fs.FileSelectorPlatform.instance = original);
 
-    final files = await pickPdfFiles();
+    final files = await pickPdfFiles('PDF documents');
     expect(fake.openedMultiple, isTrue);
-    expect(fake.acceptedTypeGroups, [pdfTypeGroup]);
+    expect(fake.acceptedTypeGroups, hasLength(1));
+    expect(fake.acceptedTypeGroups!.single.label, 'PDF documents');
+    expect(fake.acceptedTypeGroups!.single.extensions, ['pdf']);
     expect(files.map((f) => f.path), [a, b]);
   });
 
@@ -164,7 +166,8 @@ void main() {
         );
         try {
           final result = await saveBytesAs(
-              ctx, Uint8List.fromList([1, 2, 3, 4]), 'exported');
+              ctx, Uint8List.fromList([1, 2, 3, 4]), 'exported',
+              pdfLabel: 'PDF documents');
 
           expect(result.succeeded, isTrue);
           expect(result.path, '$chosen.pdf');

--- a/app/test/file_io_test.dart
+++ b/app/test/file_io_test.dart
@@ -28,6 +28,16 @@ class _FakeFileSelector extends fs.FileSelectorPlatform {
     this.acceptedTypeGroups = acceptedTypeGroups;
     return files;
   }
+
+  @override
+  Future<fs.XFile?> openFile({
+    List<fs.XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    this.acceptedTypeGroups = acceptedTypeGroups;
+    return files.isEmpty ? null : files.first;
+  }
 }
 
 void main() {
@@ -97,6 +107,48 @@ void main() {
     expect(fake.acceptedTypeGroups!.single.label, 'PDF documents');
     expect(fake.acceptedTypeGroups!.single.extensions, ['pdf']);
     expect(files.map((f) => f.path), [a, b]);
+  });
+
+  testWidgets('single-file pickers pass their localized filter label through',
+      (tester) async {
+    final original = fs.FileSelectorPlatform.instance;
+    final fake = _FakeFileSelector(
+        [fs.XFile.fromData(Uint8List.fromList([1, 2, 3]), name: 'x')]);
+    fs.FileSelectorPlatform.instance = fake;
+    addTearDown(() => fs.FileSelectorPlatform.instance = original);
+
+    await pickPdfBytes('PDF documents');
+    expect(fake.acceptedTypeGroups!.single.label, 'PDF documents');
+    expect(fake.acceptedTypeGroups!.single.extensions, ['pdf']);
+
+    await pickImageBytes('Images');
+    expect(fake.acceptedTypeGroups!.single.label, 'Images');
+    expect(fake.acceptedTypeGroups!.single.extensions,
+        containsAll(['png', 'jpg', 'jpeg']));
+  });
+
+  testWidgets('importCustomStamps filters on the stamp-bundle label',
+      (tester) async {
+    final stamp = PdfCustomStamp(
+      text: 'PAID',
+      color: 0xC03030,
+      template: PdfStampTemplate.text('PAID', 0xC03030),
+      type: 'Approval',
+    );
+    final original = fs.FileSelectorPlatform.instance;
+    final fake = _FakeFileSelector([
+      fs.XFile.fromData(
+        Uint8List.fromList(utf8.encode(encodeCustomStampBundle([stamp]))),
+        name: 'stamps.json',
+      ),
+    ]);
+    fs.FileSelectorPlatform.instance = fake;
+    addTearDown(() => fs.FileSelectorPlatform.instance = original);
+
+    final stamps = await importCustomStamps('DartPDF stamps');
+    expect(stamps, [stamp]);
+    expect(fake.acceptedTypeGroups!.single.label, 'DartPDF stamps');
+    expect(fake.acceptedTypeGroups!.single.extensions, ['json']);
   });
 
   test('saveBytesToPath overwrites the file in place', () async {

--- a/app/test/file_io_test.dart
+++ b/app/test/file_io_test.dart
@@ -236,4 +236,69 @@ void main() {
       debugDefaultTargetPlatformOverride = null;
     }
   }, timeout: const Timeout(Duration(seconds: 30)));
+
+  testWidgets('pickPdf reads the chosen file and passes the PDF filter label',
+      (tester) async {
+    // The platform override must be cleared before the test body returns (the
+    // binding asserts foundation debug vars are unset), so reset it inline.
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    final dir = Directory.systemTemp.createTempSync('dartpdf_pickpdf');
+    addTearDown(() => dir.deleteSync(recursive: true));
+    final path = '${dir.path}/doc.pdf';
+    File(path).writeAsBytesSync([37, 80, 68, 70]); // %PDF
+
+    final original = fs.FileSelectorPlatform.instance;
+    final fake = _FakeFileSelector([fs.XFile(path)]);
+    fs.FileSelectorPlatform.instance = fake;
+    addTearDown(() => fs.FileSelectorPlatform.instance = original);
+
+    try {
+      await tester.runAsync(() async {
+        final picked = await pickPdf('PDF documents');
+        expect(picked, isNotNull);
+        expect(picked!.bytes, [37, 80, 68, 70]);
+        expect(fake.acceptedTypeGroups!.single.label, 'PDF documents');
+      });
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }, timeout: const Timeout(Duration(seconds: 30)));
+
+  testWidgets('image and JSON save-as pass their filter label to the dialog',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+    late BuildContext ctx;
+    await tester.pumpWidget(Builder(builder: (context) {
+      ctx = context;
+      return const SizedBox.shrink();
+    }));
+    try {
+      await tester.runAsync(() async {
+        final dir = await Directory.systemTemp.createTemp('dartpdf_savemisc');
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/file_selector'),
+          (call) async =>
+              call.method == 'getSavePath' ? '${dir.path}/out' : null,
+        );
+        try {
+          final image = await saveImageBytesAs(
+              ctx, Uint8List.fromList([1, 2, 3]), 'page.png', 'image/png',
+              imageLabel: 'Images');
+          expect(image.succeeded, isTrue);
+
+          final json = await saveJsonAs(ctx, '{"a":1}', 'data.json',
+              typeLabel: 'DartPDF stamps');
+          expect(json.succeeded, isTrue);
+        } finally {
+          tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+            const MethodChannel('plugins.flutter.io/file_selector'),
+            null,
+          );
+          await dir.delete(recursive: true);
+        }
+      });
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  }, timeout: const Timeout(Duration(seconds: 30)));
 }

--- a/app/test/ocr_status_test.dart
+++ b/app/test/ocr_status_test.dart
@@ -1,9 +1,15 @@
 // The app-bar OCR chip is driven by OcrJobStatus - its fraction (determinate
-// where we know it, indeterminate otherwise) and short label per phase.
+// where we know it, indeterminate otherwise) and the short label per phase. The
+// label itself now lives in the presentation layer (`ocrStatusLabel`), resolved
+// from the localizations; here we drive it through the English bundle.
+import 'package:dart_pdf_editor_app/l10n/app_localizations_en.dart';
 import 'package:dart_pdf_editor_app/ocr_status.dart';
+import 'package:dart_pdf_editor_app/ocr_status_label.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  final l10n = AppLocalizationsEn();
+
   test('downloading: fraction follows the download, label shows percent', () {
     const s = OcrJobStatus(
       phase: OcrPhase.downloading,
@@ -11,13 +17,13 @@ void main() {
       downloadFraction: 0.42,
     );
     expect(s.fraction, 0.42);
-    expect(s.label, 'Downloading model 42%');
+    expect(ocrStatusLabel(l10n, s), 'Downloading model 42%');
   });
 
   test('downloading with unknown total is indeterminate', () {
     const s = OcrJobStatus(phase: OcrPhase.downloading, title: 'Scan.pdf');
     expect(s.fraction, isNull);
-    expect(s.label, 'Downloading OCR model…');
+    expect(ocrStatusLabel(l10n, s), 'Downloading OCR model…');
   });
 
   test('recognising: fraction is page/pageCount and label counts pages', () {
@@ -28,7 +34,7 @@ void main() {
       pageCount: 12,
     );
     expect(s.fraction, closeTo(0.25, 1e-9));
-    expect(s.label, 'OCR 3/12');
+    expect(ocrStatusLabel(l10n, s), 'OCR 3/12');
   });
 
   test('recognising with no pages yet is indeterminate (no divide-by-zero)',
@@ -40,6 +46,6 @@ void main() {
   test('finishing is indeterminate with a finishing label', () {
     const s = OcrJobStatus(phase: OcrPhase.finishing, title: 'Scan.pdf');
     expect(s.fraction, isNull);
-    expect(s.label, 'Finishing OCR…');
+    expect(ocrStatusLabel(l10n, s), 'Finishing OCR…');
   });
 }

--- a/doc/dev-log/2026-07-22-i18n-app-no-context.md
+++ b/doc/dev-log/2026-07-22-i18n-app-no-context.md
@@ -1,0 +1,94 @@
+# 2026-07-22 — i18n phase 2: no-context strings (app + example)
+
+Sibling of the editor-package no-context refactor
+(`2026-07-22-i18n-no-context-refactors.md`, PR #499). That session cleared the
+`dart_pdf_editor` package's inventory of user-facing English produced where no
+`BuildContext` was in scope; this one clears the remaining app/example items the
+#499 note flagged as "their own change". English extraction is now complete
+across all three bundles.
+
+## The pattern (unchanged)
+
+The enum / platform / error code is the stable key; the visible string is
+resolved from the localizations at the consumer, which has a context. Where the
+string was built inside a context-less helper, the label is threaded in as
+plain data (a resolved `String`) rather than a `BuildContext`, so nothing has to
+carry a context across an async gap.
+
+## What landed (20 new ARB keys)
+
+- **`settings_screen.dart` default-app help** — the two platform `switch`
+  getters (`_defaultAppSubtitle`, `_defaultAppInstructions`) dropped their
+  seven literal arms each. They now resolve one ICU `select` key apiece
+  (`settingsDefaultAppSubtitle` / `settingsDefaultAppInstructions`, branches
+  `web/windows/macos/linux/android/ios/other`, `other` = Fuchsia) from a small
+  `_defaultAppPlatform` selector. Both call sites already had a context.
+- **OCR chip label** — `OcrJobStatus.label` (a getter on the pure model, which
+  only imports `foundation`) is gone. The four phase strings now live in the app
+  ARB (`ocrChipDownloadingModel` / `…Percent` / `ocrChipRecognising` /
+  `ocrChipFinishing`) and resolve through a new presentation helper
+  `ocrStatusLabel(l10n, status)` (`app/lib/ocr_status_label.dart`). The chip in
+  `editor_screen.dart` calls it with `appL10n(context)`; `ocr_status_test.dart`
+  drives the same helper through `AppLocalizationsEn()`, so the string coverage
+  is preserved without pinning English on the model.
+- **`XTypeGroup` file-picker filter labels** — the desktop file dialog's
+  type-filter dropdown was the last English in the picker flow. The `const`
+  groups in `file_io.dart` (PDF / Images / DartPDF stamps),
+  `digital_signature.dart` (RSA private keys / X.509 certificates), and the
+  example's `main.dart` (PDF / Images / Fonts) became **functions taking the
+  localized `label`**; the platform matchers (extensions/MIME/UTI) stay `const`.
+  The `file_io` pickers gained a `String` label param and the savers a
+  `required String …Label`; every caller resolves `appL10n(context).fileType*`
+  (app ARB `fileTypePdf`/`fileTypeImages`/`fileTypeStampBundle` +
+  `appSigKeyFileType`/`appSigCertificateFileType`; example
+  `exFileTypePdf/Images/Fonts`). `devtools_panel.dart` stays English (out of the
+  app l10n) and passes a literal.
+- **Signing key/cert parse errors** — the package model
+  `PdfDigitalSignatureIdentity.fromFiles` used to throw plain `FormatException`s
+  with English messages. It now throws a `PdfSignatureIdentityException` (a
+  `FormatException` subclass, so `on FormatException` handlers and the existing
+  `.message` assertions keep working) carrying a `PdfSignatureIdentityError`
+  `code` (+ 1-based `certificateIndex` for the invalid-certificate case). The
+  app's key/cert loader maps the code to a localized message
+  (`appSigError*`, six keys) at the display site; the pure model stays
+  Flutter- and locale-free.
+
+## Why labels-as-data, not context, for the pickers
+
+Several pickers reach the file dialog as bare tearoffs handed to the package
+viewer's callbacks (`onPickPdfToInsert`, `logoPicker`, `formImagePicker`,
+`imagePicker`) — no `BuildContext` at the construction point, and the callback
+signatures are fixed. Passing a resolved `String` label keeps `file_io` free of
+context-lifetime concerns and lets each caller resolve the label from whatever
+context it does have. The tearoffs became small closures that capture the
+enclosing context and resolve the label synchronously before the first await.
+
+## Gotcha — the Save-As test seam
+
+`_EditorScreenState._save` picks `widget.saveDocumentAs ?? saveBytesAs`. Adding
+the `required String pdfLabel` to `saveBytesAs` broke that fallback: the seam's
+type is a three-positional-arg function, and the real function no longer matches
+it (it failed at runtime as a `NoSuchMethodError`, not at analysis, because the
+tearoff was coerced to the seam type). Fixed by binding the label in a
+three-arg closure — `(ctx, bytes, name) => saveBytesAs(ctx, bytes, name,
+pdfLabel: appL10n(ctx).fileTypePdf)` — which matches the seam and leaves the
+test double untouched. The lesson: when a converted function is also reachable
+through an injected function-typed seam, adapt at the seam, not just the direct
+call sites.
+
+## Verification
+
+- `dart analyze --fatal-infos` clean across app + `dart_pdf_editor` (incl. the
+  package model change).
+- App suite green (254 tests), `dart_pdf_editor` + example suites green.
+- New keys carry `@key` descriptions and typed placeholders; English values are
+  byte-identical to the previous literals (the platform help strings were pulled
+  from git to guarantee it), so the English-fallback path and text-finding
+  widget tests are unaffected.
+
+## Still deferred (unchanged)
+
+`DateFormat`/`NumberFormat` for the stamp month abbreviations and user-visible
+`toStringAsFixed` readouts, the RTL sweep, the Settings language picker, the
+machine-translated seed ARBs + tier-1/2 locales, and the per-locale CI coverage
+gate. `progressive_source.dart`'s engine-error interpolation is still kept as-is.

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -143,9 +143,11 @@ real native-size budget; on web, deferred loading already handles it.
 ## Status & roadmap
 
 Phase 1 (infrastructure + English extraction of ~700 strings, ICU plurals) is
-done — see `doc/dev-log/2026-07-22-i18n-extraction.md`. Still open: the
-no-context strings that need a context-threading refactor (toolbar tool
-tooltips are the most visible), engine-error→UI-message mapping,
+done — see `doc/dev-log/2026-07-22-i18n-extraction.md`. The phase-2 no-context
+refactors are also done: the editor package
+(`doc/dev-log/2026-07-22-i18n-no-context-refactors.md`) and the app + example
+(`doc/dev-log/2026-07-22-i18n-app-no-context.md`) — English extraction is now
+complete across all three bundles. Still open: engine-error→UI-message mapping,
 `DateFormat`/`NumberFormat` for month abbreviations and numeric readouts, the
 RTL sweep, a Settings language picker, machine-translated seed ARBs for the
 tier-1/2 locales, and a per-locale CI coverage gate.

--- a/packages/dart_pdf_editor/example/lib/l10n/app_en.arb
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_en.arb
@@ -623,5 +623,17 @@
   "undo": "Undo",
   "@undo": {
     "description": "Generic button/tooltip to undo the last change."
+  },
+  "exFileTypePdf": "PDF documents",
+  "@exFileTypePdf":   {
+      "description": "File-picker filter label for PDF files."
+  },
+  "exFileTypeImages": "Images",
+  "@exFileTypeImages":   {
+      "description": "File-picker filter label for image files."
+  },
+  "exFileTypeFonts": "Fonts",
+  "@exFileTypeFonts":   {
+      "description": "File-picker filter label for TrueType/OpenType font files."
   }
 }

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations.dart
@@ -794,6 +794,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Undo'**
   String get undo;
+
+  /// File-picker filter label for PDF files.
+  ///
+  /// In en, this message translates to:
+  /// **'PDF documents'**
+  String get exFileTypePdf;
+
+  /// File-picker filter label for image files.
+  ///
+  /// In en, this message translates to:
+  /// **'Images'**
+  String get exFileTypeImages;
+
+  /// File-picker filter label for TrueType/OpenType font files.
+  ///
+  /// In en, this message translates to:
+  /// **'Fonts'**
+  String get exFileTypeFonts;
 }
 
 class _AppLocalizationsDelegate

--- a/packages/dart_pdf_editor/example/lib/l10n/app_localizations_en.dart
+++ b/packages/dart_pdf_editor/example/lib/l10n/app_localizations_en.dart
@@ -429,4 +429,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get undo => 'Undo';
+
+  @override
+  String get exFileTypePdf => 'PDF documents';
+
+  @override
+  String get exFileTypeImages => 'Images';
+
+  @override
+  String get exFileTypeFonts => 'Fonts';
 }

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -47,45 +47,50 @@ PdfByteSource Function(Uri uri) remoteByteSourceFactory =
 /// One filter, every platform: desktop and web match on the extension,
 /// Android on the MIME type, iOS/macOS on the uniform type identifier -
 /// a type group missing the field a platform filters by throws there.
-const _pdfTypeGroup = XTypeGroup(
-  label: 'PDF documents',
-  extensions: ['pdf'],
-  mimeTypes: ['application/pdf'],
-  uniformTypeIdentifiers: ['com.adobe.pdf'],
-);
+// The `label` is the file-dialog filter name and is localized; the caller (it
+// always has a BuildContext) passes the resolved string in.
+XTypeGroup _pdfTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['pdf'],
+      mimeTypes: const ['application/pdf'],
+      uniformTypeIdentifiers: const ['com.adobe.pdf'],
+    );
 
 /// Images the form tool's push-button fill accepts.
-const _imageTypeGroup = XTypeGroup(
-  label: 'Images',
-  extensions: ['png', 'jpg', 'jpeg'],
-  mimeTypes: ['image/png', 'image/jpeg'],
-  uniformTypeIdentifiers: ['public.png', 'public.jpeg'],
-);
+XTypeGroup _imageTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['png', 'jpg', 'jpeg'],
+      mimeTypes: const ['image/png', 'image/jpeg'],
+      uniformTypeIdentifiers: const ['public.png', 'public.jpeg'],
+    );
 
 /// The form tool's image picker: tapped push-button fields (signature
 /// and logo slots in templates) fill with the chosen PNG or JPEG.
 Future<Uint8List?> _pickFormImage(BuildContext context, PdfFormField field) =>
-    openFile(acceptedTypeGroups: const [_imageTypeGroup])
+    openFile(acceptedTypeGroups: [_imageTypeGroup(appL10n(context).exFileTypeImages)])
         .then((file) => file?.readAsBytes());
 
 /// The image tool's picker: inserts the chosen PNG or JPEG as a stamp
 /// annotation the user can move, resize, and rotate.
 Future<Uint8List?> _pickImage(BuildContext context) =>
-    openFile(acceptedTypeGroups: const [_imageTypeGroup])
+    openFile(acceptedTypeGroups: [_imageTypeGroup(appL10n(context).exFileTypeImages)])
         .then((file) => file?.readAsBytes());
 
 /// Fonts the "Load font…" entry accepts.
-const _fontTypeGroup = XTypeGroup(
-  label: 'Fonts',
-  extensions: ['ttf', 'otf'],
-  mimeTypes: ['font/ttf', 'font/otf'],
-  uniformTypeIdentifiers: ['public.truetype-ttf-font', 'public.opentype-font'],
-);
+XTypeGroup _fontTypeGroup(String label) => XTypeGroup(
+      label: label,
+      extensions: const ['ttf', 'otf'],
+      mimeTypes: const ['font/ttf', 'font/otf'],
+      uniformTypeIdentifiers: const [
+        'public.truetype-ttf-font',
+        'public.opentype-font',
+      ],
+    );
 
 /// The font menu's "Load font…" picker: embeds the chosen TrueType or
 /// OpenType file so new text can use any font.
 Future<Uint8List?> _pickFont(BuildContext context) =>
-    openFile(acceptedTypeGroups: const [_fontTypeGroup])
+    openFile(acceptedTypeGroups: [_fontTypeGroup(appL10n(context).exFileTypeFonts)])
         .then((file) => file?.readAsBytes());
 
 @visibleForTesting
@@ -811,7 +816,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
   }
 
   Future<void> _pickFile() async {
-    final file = await openFile(acceptedTypeGroups: const [_pdfTypeGroup]);
+    final file =
+        await openFile(acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
     if (file == null) return;
     final loading = _openLoading(file.name);
     try {
@@ -910,7 +916,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
   /// Picks a PDF and returns its bytes (null when cancelled) - the source
   /// for the editor's "Insert PDF…" action.
   Future<Uint8List?> _pickPdfBytes() async {
-    final file = await openFile(acceptedTypeGroups: const [_pdfTypeGroup]);
+    final file =
+        await openFile(acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
     return file?.readAsBytes();
   }
 
@@ -921,7 +928,8 @@ class _ViewerScreenState extends State<ViewerScreen> {
     final current = tab?.session?.bytes;
     if (current == null) return;
     final l10n = appL10n(context);
-    final file = await openFile(acceptedTypeGroups: const [_pdfTypeGroup]);
+    final file =
+        await openFile(acceptedTypeGroups: [_pdfTypeGroup(appL10n(context).exFileTypePdf)]);
     if (file == null) return;
     try {
       final other = await file.readAsBytes();
@@ -1047,7 +1055,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
       default:
         final location = await getSaveLocation(
           suggestedName: name,
-          acceptedTypeGroups: const [_pdfTypeGroup],
+          acceptedTypeGroups: [_pdfTypeGroup(l10n.exFileTypePdf)],
         );
         if (location == null) return;
         try {
@@ -1088,7 +1096,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
       default:
         final location = await getSaveLocation(
           suggestedName: name,
-          acceptedTypeGroups: const [_imageTypeGroup],
+          acceptedTypeGroups: [_imageTypeGroup(l10n.exFileTypeImages)],
         );
         if (location == null) return;
         try {
@@ -1164,7 +1172,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
       default:
         final location = await getSaveLocation(
           suggestedName: name,
-          acceptedTypeGroups: const [_imageTypeGroup],
+          acceptedTypeGroups: [_imageTypeGroup(l10n.exFileTypeImages)],
         );
         if (location == null) return;
         try {

--- a/packages/dart_pdf_editor/lib/src/editing/digital_signature.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/digital_signature.dart
@@ -4,6 +4,52 @@ import 'dart:typed_data';
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_document/pdf_document.dart';
 
+/// Why [PdfDigitalSignatureIdentity.fromFiles] rejected the chosen files.
+///
+/// [PdfSignatureIdentityException.message] carries an English explanation for
+/// hosts that don't localize; a UI can switch on the [code] instead to show a
+/// translated message at the point it surfaces the error.
+enum PdfSignatureIdentityError {
+  /// No certificate files were selected.
+  noCertificateSelected,
+
+  /// A selected certificate is not valid X.509 (see
+  /// [PdfSignatureIdentityException.certificateIndex] for which one).
+  invalidCertificate,
+
+  /// The private key matches none of the selected RSA certificates.
+  keyCertificateMismatch,
+
+  /// The private key is an encrypted PEM, which is not supported.
+  encryptedKeyUnsupported,
+
+  /// The private key is not an unencrypted RSA PKCS#1 / PKCS#8 key.
+  keyNotRsa,
+
+  /// No X.509 certificate was found in the selected files.
+  noCertificateFound,
+}
+
+/// A [FormatException] raised while parsing signing key/certificate files,
+/// tagged with a machine-readable [code] so a host can localize the message.
+///
+/// It extends [FormatException] so existing `on FormatException` handlers keep
+/// working and `message` stays available as an English fallback.
+class PdfSignatureIdentityException extends FormatException {
+  const PdfSignatureIdentityException(
+    this.code,
+    String message, {
+    this.certificateIndex,
+  }) : super(message);
+
+  /// Which validation failed.
+  final PdfSignatureIdentityError code;
+
+  /// The 1-based index of the offending certificate for
+  /// [PdfSignatureIdentityError.invalidCertificate]; null otherwise.
+  final int? certificateIndex;
+}
+
 /// A certificate-backed identity used to create a cryptographic PDF
 /// signature.
 ///
@@ -27,7 +73,10 @@ class PdfDigitalSignatureIdentity {
     required List<Uint8List> certificates,
   }) {
     if (certificates.isEmpty) {
-      throw const FormatException('Select at least one X.509 certificate.');
+      throw const PdfSignatureIdentityException(
+        PdfSignatureIdentityError.noCertificateSelected,
+        'Select at least one X.509 certificate.',
+      );
     }
     final key = _parsePrivateKey(privateKey);
     final ders = _parseCertificates(certificates);
@@ -36,7 +85,11 @@ class PdfDigitalSignatureIdentity {
       try {
         parsed.add(X509Certificate.parse(ders[i]));
       } catch (_) {
-        throw FormatException('Certificate ${i + 1} is not valid X.509.');
+        throw PdfSignatureIdentityException(
+          PdfSignatureIdentityError.invalidCertificate,
+          'Certificate ${i + 1} is not valid X.509.',
+          certificateIndex: i + 1,
+        );
       }
     }
 
@@ -51,7 +104,8 @@ class PdfDigitalSignatureIdentity {
       }
     }
     if (signerIndex < 0) {
-      throw const FormatException(
+      throw const PdfSignatureIdentityException(
+        PdfSignatureIdentityError.keyCertificateMismatch,
         'The private key does not match any selected RSA certificate.',
       );
     }
@@ -117,7 +171,8 @@ RsaPrivateKey _parsePrivateKey(Uint8List bytes) {
   try {
     final text = utf8.decode(bytes, allowMalformed: true);
     if (text.contains('BEGIN ENCRYPTED PRIVATE KEY')) {
-      throw const FormatException(
+      throw const PdfSignatureIdentityException(
+        PdfSignatureIdentityError.encryptedKeyUnsupported,
         'Encrypted private keys are not supported. Choose an unencrypted '
         'RSA PKCS#1 or PKCS#8 key.',
       );
@@ -130,7 +185,8 @@ RsaPrivateKey _parsePrivateKey(Uint8List bytes) {
   } on FormatException {
     rethrow;
   } catch (_) {
-    throw const FormatException(
+    throw const PdfSignatureIdentityException(
+      PdfSignatureIdentityError.keyNotRsa,
       'The private key is not an unencrypted RSA PKCS#1 or PKCS#8 key.',
     );
   }
@@ -153,7 +209,10 @@ List<Uint8List> _parseCertificates(List<Uint8List> files) {
     }
   }
   if (out.isEmpty) {
-    throw const FormatException('No X.509 certificates were found.');
+    throw const PdfSignatureIdentityException(
+      PdfSignatureIdentityError.noCertificateFound,
+      'No X.509 certificates were found.',
+    );
   }
   return out;
 }

--- a/packages/dart_pdf_editor/test/editing_digital_signature_test.dart
+++ b/packages/dart_pdf_editor/test/editing_digital_signature_test.dart
@@ -41,13 +41,54 @@ void main() {
         ],
       ),
       throwsA(
-        isA<FormatException>().having(
-          (error) => error.message,
-          'message',
-          contains('does not match'),
-        ),
+        isA<PdfSignatureIdentityException>()
+            .having((e) => e.message, 'message', contains('does not match'))
+            .having((e) => e.code, 'code',
+                PdfSignatureIdentityError.keyCertificateMismatch),
       ),
     );
+  });
+
+  test('identity file errors carry a machine-readable code for localization',
+      () {
+    final key = Uint8List.fromList(testSignerKeyPem.codeUnits);
+    final cert = Uint8List.fromList(testSignerCertPem.codeUnits);
+
+    void expectCode(
+      PdfSignatureIdentityError code, {
+      required Uint8List privateKey,
+      required List<Uint8List> certificates,
+      int? certificateIndex,
+    }) {
+      var matcher = isA<PdfSignatureIdentityException>()
+          .having((e) => e, 'is a FormatException', isA<FormatException>())
+          .having((e) => e.code, 'code', code);
+      if (certificateIndex != null) {
+        matcher = matcher.having(
+            (e) => e.certificateIndex, 'certificateIndex', certificateIndex);
+      }
+      expect(
+        () => PdfDigitalSignatureIdentity.fromFiles(
+            privateKey: privateKey, certificates: certificates),
+        throwsA(matcher),
+      );
+    }
+
+    // No certificate chosen at all.
+    expectCode(PdfSignatureIdentityError.noCertificateSelected,
+        privateKey: key, certificates: const []);
+    // A chosen certificate file that isn't valid X.509 (1-based index).
+    expectCode(PdfSignatureIdentityError.invalidCertificate,
+        privateKey: key,
+        certificates: [Uint8List.fromList(const [1, 2, 3, 4])],
+        certificateIndex: 1);
+    // An encrypted PEM private key (unsupported).
+    expectCode(PdfSignatureIdentityError.encryptedKeyUnsupported,
+        privateKey: Uint8List.fromList(
+            '-----BEGIN ENCRYPTED PRIVATE KEY-----\nAAAA\n'
+                    '-----END ENCRYPTED PRIVATE KEY-----\n'
+                .codeUnits),
+        certificates: [cert]);
   });
 
   test('controller adds a valid PAdES signature as an undoable revision',


### PR DESCRIPTION
## Summary

Continues the i18n project after #499. That PR cleared the `dart_pdf_editor`
package's inventory of user-facing English produced where no `BuildContext` is
in scope; this PR clears the remaining app + example items #499 flagged as
"their own change". **English extraction is now complete across all three
localization bundles** (editor package, DartPDF app, example).

The pattern is the same as #499: the enum / platform / error code is the stable
key, and the visible string is resolved from the localizations at the consumer.
Where the string was built in a context-less helper, the label is threaded in as
plain `String` data rather than a `BuildContext`, so nothing carries a context
across an async gap.

What changed (20 new ARB keys — 17 app, 3 example):

- **Settings default-app help** — the two platform `switch` getters
  (`_defaultAppSubtitle` / `_defaultAppInstructions`) drop their seven literal
  arms each for one ICU `select` key apiece
  (`web/windows/macos/linux/android/ios/other`).
- **OCR chip label** — `OcrJobStatus.label` (a getter on the locale-free model,
  which only imports `foundation`) moves to a presentation helper
  `ocrStatusLabel(l10n, status)` in the new `app/lib/ocr_status_label.dart`;
  four app-ARB keys. Its unit test now drives the helper through
  `AppLocalizationsEn()`.
- **`XTypeGroup` file-picker filter labels** — the `const` groups in
  `file_io.dart`, `digital_signature.dart`, and the example's `main.dart` become
  functions taking the localized `label`; the platform matchers stay `const`.
  Pickers gained a `String` label param, savers a `required String …Label`, and
  every caller resolves the label from its own context. `devtools_panel.dart`
  stays English (out of the app l10n) and passes a literal.
- **Signing key/cert parse errors** — the package model
  `PdfDigitalSignatureIdentity.fromFiles` now throws a
  `PdfSignatureIdentityException` (a `FormatException` subclass, so existing
  `on FormatException` handlers and `.message` assertions keep working) carrying
  a machine-readable `PdfSignatureIdentityError` code. The app maps the code to
  a localized message at the display site; the pure model stays Flutter- and
  locale-free.

English values are byte-identical to the previous literals (the platform help
strings were pulled from git to guarantee it), so the English-fallback path and
the text-finding widget tests are unaffected. Also fixed the Save-As test seam,
which broke when `saveBytesAs` gained a required `pdfLabel`: the label is now
bound in a three-arg wrapper matching the seam.

The shipping DartPDF app (`app/`) is the primary target here; it is not in the
package checklist below. `dart_pdf_editor` is touched only by the typed signing
exception.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app
- [x] Documentation / CI / repository metadata only

(Also: the `app/` shipping application — the main target — plus its ARBs.)

## Change type

- [x] Refactor / cleanup
- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [x] Example app smoke test

If any relevant check was not run, explain why:

`dart analyze --fatal-infos` is clean across `app` and `dart_pdf_editor`. Suites:
app 254 passed, example 54 passed, `dart_pdf_editor` green apart from the
**pre-existing** `GWG030_Gray_K_black_OP_X1.pdf` spot-color render baseline
(documented in the phase-1 note; fails identically on the base branch and is
unrelated — this diff touches no rendering code). The engine (`pdf_cos` /
`pdf_document` / `pdf_graphics`) is untouched, so those pure-Dart suites and the
corpus/render sweeps were not run.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The one red package test (`GWG030` spot-color baseline) is pre-existing and
  unrelated; every other suite is green.
- `PdfSignatureIdentityException` / `PdfSignatureIdentityError` are new public
  exports of `dart_pdf_editor`. The exception extends `FormatException` and
  keeps the same English `message`, so it is backward compatible for existing
  hosts.
- Still deferred (unchanged): `DateFormat`/`NumberFormat` for month
  abbreviations and numeric readouts, the RTL sweep, the Settings language
  picker, machine-translated seed ARBs + tier-1/2 locales, and the per-locale
  CI coverage gate. See `doc/dev-log/2026-07-22-i18n-app-no-context.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmvvCSZgowDPK2HCQFoyCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmvvCSZgowDPK2HCQFoyCg)_