### PR TITLE
feat(i18n): RTL layout sweep + a DevTools locale override

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -106,8 +106,11 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
-      listenable: Listenable.merge(
-          [_prefs, AppDevTools.instance.showPerformanceOverlay]),
+      listenable: Listenable.merge([
+        _prefs,
+        AppDevTools.instance.showPerformanceOverlay,
+        AppDevTools.instance.localeOverride,
+      ]),
       builder: (context, _) => MaterialApp(
         title: 'DartPDF',
         localizationsDelegates: const [
@@ -115,6 +118,18 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
           DartPdfEditorLocalizations.delegate,
         ],
         supportedLocales: AppLocalizations.supportedLocales,
+        // A DevTools locale override wins over platform resolution: returning
+        // it here forces the app onto that locale even when it isn't in
+        // supportedLocales (untranslated app strings fall back to English, but
+        // Directionality and the Material delegates follow it - enough to test
+        // the RTL sweep). Null override falls through to the default resolution.
+        locale: AppDevTools.instance.localeOverride.value,
+        localeResolutionCallback: (locale, supportedLocales) {
+          final override = AppDevTools.instance.localeOverride.value;
+          if (override != null) return override;
+          return basicLocaleListResolution(
+              locale == null ? null : [locale], supportedLocales);
+        },
         showPerformanceOverlay:
             AppDevTools.instance.showPerformanceOverlay.value,
         theme: ThemeData(colorSchemeSeed: Colors.indigo, useMaterial3: true),

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -122,13 +122,14 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
         // it here forces the app onto that locale even when it isn't in
         // supportedLocales (untranslated app strings fall back to English, but
         // Directionality and the Material delegates follow it - enough to test
-        // the RTL sweep). Null override falls through to the default resolution.
-        locale: AppDevTools.instance.localeOverride.value,
-        localeResolutionCallback: (locale, supportedLocales) {
+        // the RTL sweep). With no override, defer to Flutter's own algorithm
+        // over the FULL preferred-locale list so the normal fallback chain is
+        // unchanged (a list callback, not the single-locale one, to keep the
+        // user's second/third preference in play).
+        localeListResolutionCallback: (locales, supportedLocales) {
           final override = AppDevTools.instance.localeOverride.value;
           if (override != null) return override;
-          return basicLocaleListResolution(
-              locale == null ? null : [locale], supportedLocales);
+          return basicLocaleListResolution(locales, supportedLocales);
         },
         showPerformanceOverlay:
             AppDevTools.instance.showPerformanceOverlay.value,

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -10,7 +10,7 @@ library;
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:ui' show FramePhase;
+import 'dart:ui' show FramePhase, Locale;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
@@ -104,6 +104,15 @@ class AppDevTools extends ChangeNotifier {
 
   /// Mirrored into [MaterialApp.showPerformanceOverlay] by the app root.
   final ValueNotifier<bool> showPerformanceOverlay = ValueNotifier(false);
+
+  /// Forces the whole app onto a locale for testing, bypassing the normal
+  /// [MaterialApp] resolution against `supportedLocales`. `null` follows the
+  /// platform. Set from the DevTools panel's Locale section; session-only (not
+  /// persisted, so a forced RTL locale never survives a restart). The main use
+  /// is exercising the RTL layout sweep by picking an RTL locale like Arabic —
+  /// even before its translations land, the Material delegates translate their
+  /// own strings and `Directionality` flips.
+  final ValueNotifier<Locale?> localeOverride = ValueNotifier(null);
 
   final ListQueue<DevLogEntry> _log = ListQueue();
   final ListQueue<FrameTiming> _timings = ListQueue();

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -151,6 +151,7 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _framesSection(theme),
+            _localeSection(theme),
             _memorySection(theme),
             _workersSection(theme),
             _deepZoomSection(theme),
@@ -354,6 +355,55 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               .copyWith(color: theme.colorScheme.outline),
         ),
       ]);
+
+  /// A short menu of locales for exercising localization at runtime - RTL ones
+  /// especially, to test the directional-layout sweep. Only English app
+  /// strings ship today, so a non-English pick shows the Material widgets'
+  /// own translations (and RTL layout for Arabic/Hebrew) while app text falls
+  /// back to English.
+  static const List<(Locale?, String)> _testLocales = [
+    (null, 'System default'),
+    (Locale('en'), 'English'),
+    (Locale('es'), 'Español (Spanish)'),
+    (Locale('de'), 'Deutsch (German)'),
+    (Locale('fr'), 'Français (French)'),
+    (Locale('ja'), '日本語 (Japanese)'),
+    (Locale('ar'), 'العربية (Arabic) — RTL'),
+    (Locale('he'), 'עברית (Hebrew) — RTL'),
+  ];
+
+  Widget _localeSection(ThemeData theme) {
+    final override = AppDevTools.instance.localeOverride;
+    final rtl = Directionality.of(context) == TextDirection.rtl;
+    return _section(theme, 'Locale (testing)', [
+      DropdownButton<Locale?>(
+        key: const ValueKey('devtools-locale-dropdown'),
+        isExpanded: true,
+        value: override.value,
+        items: [
+          for (final (locale, label) in _testLocales)
+            DropdownMenuItem<Locale?>(
+              value: locale,
+              child: Text(label, overflow: TextOverflow.ellipsis),
+            ),
+        ],
+        onChanged: (locale) => setState(() => override.value = locale),
+      ),
+      Text(
+        'Forces the whole app onto a locale, bypassing platform resolution. '
+        'Only English translations ship today, so other locales show the '
+        'Material widgets translated (and RTL layout for Arabic/Hebrew) while '
+        'app strings fall back to English. Session-only - not persisted.',
+        style:
+            theme.textTheme.bodySmall!.copyWith(color: theme.colorScheme.outline),
+      ),
+      const SizedBox(height: 4),
+      _kv(theme, 'Layout direction', rtl ? 'RTL (right-to-left)' : 'LTR (left-to-right)',
+          help: 'The ambient Directionality the app is currently laying out '
+              'with. RTL locales (Arabic, Hebrew) flip it; the chrome mirrors '
+              'via EdgeInsetsDirectional / AlignmentDirectional.'),
+    ]);
+  }
 
   Widget _section(ThemeData theme, String title, List<Widget> children,
           {Widget? trailing}) =>

--- a/app/lib/digital_signature.dart
+++ b/app/lib/digital_signature.dart
@@ -737,7 +737,7 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
                       style: theme.textTheme.bodySmall),
                   children: [
                     Align(
-                      alignment: Alignment.centerLeft,
+                      alignment: AlignmentDirectional.centerStart,
                       child: Text(
                         appL10n(context).appSigChooseKeyDescription,
                         style: theme.textTheme.bodySmall,

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -2432,7 +2432,7 @@ class _EditorScreenState extends State<EditorScreen>
 
       if (compact && !_readOnly && tab?.session != null)
         Padding(
-          padding: const EdgeInsets.only(right: 8),
+          padding: const EdgeInsetsDirectional.only(end: 8),
           child: FilledButton.icon(
             key: const ValueKey('mobile-app-save'),
             style: FilledButton.styleFrom(
@@ -2778,7 +2778,7 @@ class _EditorScreenState extends State<EditorScreen>
           children: [
             if (tab.isDirty)
               Padding(
-                padding: const EdgeInsets.only(right: 6),
+                padding: const EdgeInsetsDirectional.only(end: 6),
                 child: Icon(Icons.circle, size: 8, color: scheme.primary),
               ),
             Flexible(child: text),
@@ -2808,7 +2808,7 @@ class _EditorScreenState extends State<EditorScreen>
               onSecondaryTapUp: (details) =>
                   _showTabMenu(index, details.globalPosition),
               child: Padding(
-                padding: const EdgeInsets.only(left: 12, right: 2),
+                padding: const EdgeInsetsDirectional.only(start: 12, end: 2),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -3242,7 +3242,7 @@ class _OcrStatusChip extends StatelessWidget {
           color: scheme.secondaryContainer,
           borderRadius: BorderRadius.circular(20),
           child: Padding(
-            padding: const EdgeInsets.only(left: 10),
+            padding: const EdgeInsetsDirectional.only(start: 10),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -296,7 +296,7 @@ class _UpdateSection extends StatelessWidget {
             if (updates.updateAvailable) ...[
               const SizedBox(height: 8),
               Align(
-                alignment: Alignment.centerLeft,
+                alignment: AlignmentDirectional.centerStart,
                 child: FilledButton.icon(
                   key: const ValueKey('settings-download-update'),
                   icon: const Icon(Icons.download_outlined, size: 18),

--- a/app/lib/welcome_screen.dart
+++ b/app/lib/welcome_screen.dart
@@ -49,7 +49,7 @@ class WelcomeScreen extends StatelessWidget {
                   if (items.isNotEmpty) ...[
                     const SizedBox(height: 28),
                     Align(
-                      alignment: Alignment.centerLeft,
+                      alignment: AlignmentDirectional.centerStart,
                       child: Text(appL10n(context).welcomeRecent,
                           style: theme.textTheme.titleSmall),
                     ),

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -27,6 +27,7 @@ void main() {
     // Touch logging is a process-global singleton; reset it (and the viewer
     // sink it installs) so it never leaks into another test.
     AppDevTools.instance.logTouchInput = false;
+    AppDevTools.instance.localeOverride.value = null;
     AppDevTools.instance.clearLog();
   });
 
@@ -86,6 +87,25 @@ void main() {
     await tapMode('patch');
     expect(PdfPageView.tileStoreDetail, isFalse);
     expect(PdfPageView.debugTileStoreOverride, isNull);
+  });
+
+  testWidgets('the Locale section sets a testing override', (tester) async {
+    await pumpWithDoc(tester);
+    await tester.sendKeyEvent(LogicalKeyboardKey.f12);
+    await tester.pump();
+
+    expect(AppDevTools.instance.localeOverride.value, isNull);
+
+    final dropdown = find.byKey(const ValueKey('devtools-locale-dropdown'));
+    await tester.ensureVisible(dropdown);
+    await tester.pump();
+    await tester.tap(dropdown);
+    await tester.pumpAndSettle();
+    // Pick Arabic (RTL) from the opened menu.
+    await tester.tap(find.text('العربية (Arabic) — RTL').last);
+    await tester.pumpAndSettle();
+
+    expect(AppDevTools.instance.localeOverride.value, const Locale('ar'));
   });
 
   testWidgets('captured logs appear and the filter narrows them',

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:dart_pdf_editor_app/app.dart';
+import 'package:dart_pdf_editor_app/devtools.dart';
 
 void main() {
   setUp(() {
@@ -10,6 +11,8 @@ void main() {
     // preferences never leak into this one.
     SharedPreferences.setMockInitialValues({});
   });
+
+  tearDown(() => AppDevTools.instance.localeOverride.value = null);
 
   testWidgets('boots into the empty state with an Open button',
       (WidgetTester tester) async {
@@ -21,5 +24,37 @@ void main() {
     // No document open yet: the empty state offers a way in.
     expect(find.widgetWithText(FilledButton, 'Open a PDF'), findsOneWidget);
     expect(find.byIcon(Icons.picture_as_pdf_outlined), findsOneWidget);
+  });
+
+  testWidgets('a DevTools locale override forces the app onto that locale',
+      (WidgetTester tester) async {
+    // Forcing a locale with no shipped ARB makes Flutter log a debug-only
+    // "not supported by all of its localization delegates" warning (app
+    // strings fall back to English by design). That's expected for this
+    // dev-only testing toggle; swallow just that warning so the test asserts
+    // on the behaviour, not the diagnostic.
+    final priorOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      if (details
+          .exceptionAsString()
+          .contains('not supported by all of its localization delegates')) {
+        return;
+      }
+      priorOnError?.call(details);
+    };
+    addTearDown(() => FlutterError.onError = priorOnError);
+
+    // Arabic is not in supportedLocales, but the override wins over platform
+    // resolution and flips Directionality to RTL - the seam the RTL layout
+    // sweep is tested through. App strings still fall back to English.
+    AppDevTools.instance.localeOverride.value = const Locale('ar');
+    await tester.pumpWidget(const DartPdfEditorApp());
+    await tester.pumpAndSettle();
+
+    final direction =
+        Directionality.of(tester.element(find.byType(Scaffold).first));
+    expect(direction, TextDirection.rtl);
+    // The empty state's English fallback is unaffected by the missing ar ARB.
+    expect(find.widgetWithText(FilledButton, 'Open a PDF'), findsOneWidget);
   });
 }

--- a/doc/dev-log/2026-07-23-i18n-rtl-sweep.md
+++ b/doc/dev-log/2026-07-23-i18n-rtl-sweep.md
@@ -1,0 +1,121 @@
+# 2026-07-23 — i18n phase 2: RTL layout sweep + a DevTools locale override
+
+Follows the completed English extraction across all three bundles (PRs #477,
+#483, #499, #510 and the dev-logs `2026-07-22-i18n-*.md`). The handover
+(`I18N_HANDOVER.md`) put Arabic in tier 1 deliberately "to force the RTL work
+early"; this session does that sweep, and adds a DevTools lever to test it
+without shipping any translated ARB yet.
+
+## The sweep: physical → direction-relative geometry
+
+The rule, straight from the handover: **UI chrome uses direction-relative
+geometry so it mirrors under an RTL `Directionality`; page-space geometry stays
+physical** (PDF coordinates must never flip). Concretely:
+
+- `EdgeInsets.only(left:/right:)` → `EdgeInsetsDirectional.only(start:/end:)`
+- `Alignment.centerLeft` / `topLeft` chrome → `AlignmentDirectional.centerStart`
+  / `topStart`
+
+Sites changed (all verified LTR-identical, so existing widget tests that find
+UI by English text are unaffected):
+
+- **package** (`dart_pdf_editor/lib`): `editing_bookmarks.dart` (tree indent),
+  `editing_properties.dart`, `editing_toolbar.dart` (opacity chip, group-tab
+  strip, style column, three menu `centerLeft`s), `editing_sidebar.dart`
+  (by-author), `editing_signature.dart` + `editing_stamps.dart` (ink-swatch
+  rows, stamp-preview list tile), `pdf_reflow_view.dart` (list-item hang),
+  `search_panel.dart` (options bar ×2), `shell_chrome.dart` (panel label),
+  `toast.dart`.
+- **app** (`app/lib`): `editor_screen.dart` (mobile save pad, tab paddings, the
+  three dirty-dot pads), `welcome_screen.dart`, `settings_screen.dart`,
+  `digital_signature.dart` (the choose-key description only).
+- **example**: `main.dart` (tab pad + help button align),
+  `scroll_indicator_demo.dart` (vertical track hugs the trailing edge:
+  `centerRight` → `AlignmentDirectional.centerEnd`).
+
+### What was deliberately left physical (page-space)
+
+- `pdf_page_view.dart` page `Stack(alignment: topLeft)`; the page-overlay
+  chip counter-scale anchors in `editing_overlay.dart`; the form-field chrome
+  scale anchors in `editing_form_layer.dart`.
+- **PDF text alignment**: `editing_overlay.dart`'s `PdfTextAlign.left/right →
+  Alignment.topLeft/topRight` and `editing_form_layer.dart`'s field-content
+  alignment (already keyed off the field's *own* text direction via
+  `_flutterTextDirection`, not the UI locale).
+- **`pdf_viewer.dart` horizontal page-spacing** (`EdgeInsets.only(right/left:
+  pageSpacing)`): it feeds `ExactExtentListView`'s scroll geometry and the
+  page-navigation offset math, which assume a physical axis. Flipping it would
+  reverse page order and desync scroll targets — out of scope for a layout
+  sweep.
+- **Signature-appearance previews** (`digital_signature.dart:1061/1072`,
+  `fitText(..., Alignment.centerLeft)` and the "match the box the user drew"
+  preview): these mirror what gets *drawn into the PDF*, so they stay physical
+  like the rendered output.
+
+### Directional icons were already handled by Material
+
+The plan listed `matchTextDirection: true` for undo/redo/chevron. Turns out
+`matchTextDirection` is a field on **`IconData`, not the `Icon` widget** — and
+Material already ships `Icons.undo`, `Icons.redo`, and `Icons.chevron_right`
+with it baked in, so a plain `Icon` mirrors them automatically under RTL. No
+per-site change needed (my first pass tried to pass it to the widget and hit
+`undefined_named_parameter` — reverted). `rtl_directionality_test.dart` guards
+that assumption (`Icons.undo.matchTextDirection == true`) against a future
+icon-set change. The alignment tool buttons (`align_horizontal_left/right`)
+were intentionally **not** touched — they set physical `PdfAlignment`, so their
+glyphs must not mirror.
+
+### Gotcha — `EdgeInsetsDirectional` is not an `EdgeInsets`
+
+`toast.dart`'s `pdfFloatingToastMargin` returned `EdgeInsets`; the two types
+are siblings under `EdgeInsetsGeometry`, not sub/superclass. Widening the
+return type to `EdgeInsetsGeometry` was required (every caller only forwards it
+to `SnackBar.margin`, which takes `EdgeInsetsGeometry?`, so no other churn).
+The wide-window branch now hugs the **trailing** edge (bottom-right LTR,
+bottom-left RTL).
+
+## The DevTools locale override (Ben's ask, mid-session)
+
+A new **Locale (testing)** section in the F12 DevTools panel
+(`devtools_panel.dart`) — a dropdown of System default + en/es/de/fr/ja plus
+**ar/he flagged RTL** — writes `AppDevTools.instance.localeOverride`
+(a `ValueNotifier<Locale?>`, session-only, not persisted). It also shows the
+live ambient `Directionality` (LTR/RTL).
+
+The wiring that makes an *unsupported* locale actually take effect is in
+`app.dart`'s `MaterialApp`: a `localeResolutionCallback` returns the override
+verbatim when one is set, **bypassing the normal resolution against
+`supportedLocales`** (which is `[en]` today); a null override falls through to
+`basicLocaleListResolution`. Forcing `ar` therefore flips `Directionality` to
+RTL and loads the global Material/Cupertino/Widgets Arabic strings, while the
+app's own ARB has no `ar` entry so `appL10n`/`pdfL10n` fall back to English —
+exactly what's needed to eyeball the RTL sweep before translations land. The
+`localeOverride` notifier is merged into the app-root `ListenableBuilder`.
+
+Flutter logs a debug-only "locale ar is not supported by all of its
+localization delegates" warning in that state — expected and harmless (DevTools
+is debug/profile-only anyway). The end-to-end test swallows *that specific*
+warning and asserts the app lays out RTL.
+
+## Verification
+
+- `dart analyze --fatal-infos` clean across package + app + example.
+- New `rtl_directionality_test.dart` (package): `pdfFloatingToastMargin`
+  resolves to the physical right in LTR and the physical left in RTL on a wide
+  window, symmetric on a narrow one; the directional icons carry
+  `matchTextDirection`.
+- New app tests: the DevTools Locale dropdown sets the override notifier
+  (`devtools_panel_test.dart`); a forced `ar` override boots the real app into
+  RTL while the empty-state English fallback still renders (`widget_test.dart`).
+- All three suites green. The package suite's 10 CMYK/softmask
+  `ghent_render_test` failures are **pre-existing** (identical on the base
+  commit `9b291a2`) — spot-color/transparency render baselines, unrelated to
+  these UI-chrome changes.
+
+## Still deferred (unchanged)
+
+`DateFormat`/`NumberFormat` for stamp month abbreviations and user-visible
+`toStringAsFixed` readouts; the Settings language picker (persisted, distinct
+from this dev-only override); machine-translated seed ARBs + the tier-1/2
+locales; the per-locale CI coverage gate. A widget-test pass in `de` (overflow)
+/ `ar` (RTL) / `ja` (fonts) waits on those locales existing.

--- a/packages/dart_pdf_editor/example/lib/main.dart
+++ b/packages/dart_pdf_editor/example/lib/main.dart
@@ -1570,7 +1570,7 @@ class _ViewerScreenState extends State<ViewerScreen> {
           borderRadius: BorderRadius.circular(8),
           onTap: () => setState(() => _activeIndex = index),
           child: Padding(
-            padding: const EdgeInsets.only(left: 12, right: 2),
+            padding: const EdgeInsetsDirectional.only(start: 12, end: 2),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -1911,7 +1911,7 @@ class _OcrSettingsDialogState extends State<_OcrSettingsDialog> {
             ),
             const SizedBox(height: 8),
             Align(
-              alignment: Alignment.centerLeft,
+              alignment: AlignmentDirectional.centerStart,
               child: TextButton.icon(
                 icon: const Icon(Icons.help_outline, size: 18),
                 label: Text(appL10n(context).exHowToSetupOcr),

--- a/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
+++ b/packages/dart_pdf_editor/example/lib/scroll_indicator_demo.dart
@@ -178,8 +178,10 @@ class _PageScrubberState extends State<_PageScrubber> {
     final horizontal = metrics.scrollAxis == Axis.horizontal;
     return Align(
       // the track hugs the edge along the scroll axis: the bottom for a
-      // horizontal layout, the right for a vertical one
-      alignment: horizontal ? Alignment.bottomCenter : Alignment.centerRight,
+      // horizontal layout, the trailing edge (right in LTR, left in RTL) for
+      // a vertical one
+      alignment:
+          horizontal ? Alignment.bottomCenter : AlignmentDirectional.centerEnd,
       child: SizedBox(
         width: horizontal ? null : _trackBreadth,
         height: horizontal ? _trackBreadth : null,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_bookmarks.dart
@@ -232,7 +232,8 @@ class _PdfBookmarkSidebarState extends State<PdfBookmarkSidebar> {
         key: ValueKey('pdf-bookmark-tile-$pathKey'),
         onTap: destination == null ? null : () => _activate(item),
         child: Padding(
-          padding: EdgeInsets.only(left: 6 + row.depth * 16.0, right: 4),
+          padding:
+              EdgeInsetsDirectional.only(start: 6 + row.depth * 16.0, end: 4),
           child: ConstrainedBox(
             constraints: const BoxConstraints(minHeight: 46),
             child: Row(children: [

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -392,7 +392,7 @@ class _PdfAnnotationPropertiesPanelState
       bool varies = false}) {
     final base = key is ValueKey ? '${key.value}' : '$key';
     return Padding(
-      padding: const EdgeInsets.only(left: 16, right: 8),
+      padding: const EdgeInsetsDirectional.only(start: 16, end: 8),
       child: Row(children: [
         Text(label),
         Expanded(

--- a/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_sidebar.dart
@@ -576,7 +576,7 @@ class _PdfAnnotationSidebarState extends State<PdfAnnotationSidebar> {
             if (entry.author != null && entry.author!.isNotEmpty)
               Expanded(
                 child: Padding(
-                  padding: const EdgeInsets.only(left: 6),
+                  padding: const EdgeInsetsDirectional.only(start: 6),
                   child: Text(pdfL10n(context).sidebarByAuthor(entry.author!),
                       style: textTheme.bodySmall
                           ?.copyWith(color: cs.onSurfaceVariant),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_signature.dart
@@ -261,7 +261,7 @@ class _PdfSignatureDialogState extends State<PdfSignatureDialog> {
           Row(children: [
             for (final ink in _inks)
               Padding(
-                padding: const EdgeInsets.only(right: 8),
+                padding: const EdgeInsetsDirectional.only(end: 8),
                 child: InkWell(
                   onTap: () => setState(() => _ink = ink),
                   customBorder: const CircleBorder(),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
@@ -269,7 +269,7 @@ class PdfStampPickerDialog extends StatelessWidget {
                 for (final stamp in controller.customStamps)
                   ListTile(
                     title: Align(
-                      alignment: Alignment.centerLeft,
+                      alignment: AlignmentDirectional.centerStart,
                       child: PdfStampPreview(
                           stamp: stamp,
                           templateValues:
@@ -928,7 +928,7 @@ class _PdfStampEditorDialogState extends State<PdfStampEditorDialog> {
               Row(children: [
                 for (final ink in _inks)
                   Padding(
-                    padding: const EdgeInsets.only(right: 8),
+                    padding: const EdgeInsetsDirectional.only(end: 8),
                     child: InkWell(
                       onTap: () => _setSelectedColor(ink),
                       customBorder: const CircleBorder(),

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1905,7 +1905,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
         controller.preferences.opacity;
     return Row(mainAxisSize: MainAxisSize.min, children: [
       const Padding(
-        padding: EdgeInsets.only(right: 2),
+        padding: EdgeInsetsDirectional.only(end: 2),
         child: Icon(Icons.opacity, size: 18),
       ),
       SizedBox(
@@ -2329,7 +2329,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                       child: Row(children: [
                         for (final g in groups)
                           Padding(
-                            padding: const EdgeInsets.only(right: 7),
+                            padding: const EdgeInsetsDirectional.only(end: 7),
                             child: _GroupChip(
                               key: ValueKey('pdf-group-tab-${g.id}'),
                               group: g,
@@ -2517,7 +2517,7 @@ class _StripLabel extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return Padding(
-      padding: const EdgeInsets.only(right: 8, left: 2),
+      padding: const EdgeInsetsDirectional.only(end: 8, start: 2),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -2911,7 +2911,7 @@ class _StampMenuPanel extends StatelessWidget {
                           Padding(
                             padding: const EdgeInsets.fromLTRB(16, 6, 16, 10),
                             child: Align(
-                              alignment: Alignment.centerLeft,
+                              alignment: AlignmentDirectional.centerStart,
                               child: Text(
                                 pdfL10n(context).tbNoCustomStamps,
                                 style: TextStyle(
@@ -2977,7 +2977,7 @@ class _StampMenuItem extends StatelessWidget {
             height: 38,
             child: FittedBox(
               fit: BoxFit.scaleDown,
-              alignment: Alignment.centerLeft,
+              alignment: AlignmentDirectional.centerStart,
               child: PdfStampPreview(
                 stamp: stamp,
                 templateValues: templateValues,
@@ -3685,7 +3685,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                             width: 86, child: Text(pdfL10n(context).tbFont)),
                         Expanded(
                           child: Align(
-                            alignment: Alignment.centerLeft,
+                            alignment: AlignmentDirectional.centerStart,
                             child: PdfFontMenuButton(
                               controller: controller,
                               fontPicker: widget.fontPicker,

--- a/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reflow_view.dart
@@ -562,7 +562,7 @@ class _ReflowPage extends StatelessWidget {
     if (!block.isListItem) return text;
     // Hang the wrapped lines under the marker's text.
     return Padding(
-      padding: const EdgeInsets.only(left: 16),
+      padding: const EdgeInsetsDirectional.only(start: 16),
       child: text,
     );
   }

--- a/packages/dart_pdf_editor/lib/src/search_panel.dart
+++ b/packages/dart_pdf_editor/lib/src/search_panel.dart
@@ -157,7 +157,7 @@ class _PdfSearchFieldState extends State<PdfSearchField> {
           ),
           if (widget.showOptions)
             Padding(
-              padding: const EdgeInsets.only(left: 4),
+              padding: const EdgeInsetsDirectional.only(start: 4),
               child: _SearchOptionsBar(
                   controller: controller, preferences: widget.preferences),
             ),
@@ -445,7 +445,7 @@ class _PdfSearchResultsPanelState extends State<PdfSearchResultsPanel> {
                 Padding(
                   padding: const EdgeInsets.fromLTRB(8, 6, 8, 6),
                   child: Align(
-                    alignment: Alignment.centerLeft,
+                    alignment: AlignmentDirectional.centerStart,
                     child: _SearchOptionsBar(
                         controller: controller,
                         preferences: widget.preferences),

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1847,7 +1847,7 @@ class PdfShellPanelSwitch extends StatelessWidget {
       child: Row(mainAxisSize: MainAxisSize.min, children: [
         if (items.length > 1)
           Padding(
-            padding: const EdgeInsets.only(left: 4, right: 6),
+            padding: const EdgeInsetsDirectional.only(start: 4, end: 6),
             child: Text(
               pdfL10n(context).shellPanels,
               style: Theme.of(context).textTheme.labelSmall?.copyWith(

--- a/packages/dart_pdf_editor/lib/src/toast.dart
+++ b/packages/dart_pdf_editor/lib/src/toast.dart
@@ -14,15 +14,20 @@ import 'package:flutter/material.dart';
 /// ```
 ///
 /// On wide windows (≥600px) the toast is a compact [pill]-wide bubble in
-/// the bottom-right corner so it never covers the page; on narrow windows
-/// it spans the width with a 16px gutter.
-EdgeInsets pdfFloatingToastMargin(BuildContext context, {double pill = 360}) {
+/// the bottom trailing corner (bottom-right in LTR, bottom-left in RTL) so it
+/// never covers the page; on narrow windows it spans the width with a 16px
+/// gutter.
+EdgeInsetsGeometry pdfFloatingToastMargin(BuildContext context,
+    {double pill = 360}) {
   final size = MediaQuery.sizeOf(context);
   // The dock sits at the bottom; lift the toast above it AND above the
   // device's bottom safe-area inset, which the dock pads itself out by.
   final bottom = 96.0 + MediaQuery.paddingOf(context).bottom;
   if (size.width >= 600) {
-    return EdgeInsets.only(left: size.width - pill - 24, right: 24, bottom: bottom);
+    // Directional so the pill hugs the trailing edge (bottom-right in LTR,
+    // bottom-left in RTL) instead of always the physical right.
+    return EdgeInsetsDirectional.only(
+        start: size.width - pill - 24, end: 24, bottom: bottom);
   }
   return EdgeInsets.fromLTRB(16, 0, 16, bottom);
 }

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -1354,8 +1354,8 @@ void main() {
   group('floating toast margin', () {
     testWidgets('lifts the toast above the dock and the safe-area inset',
         (tester) async {
-      late EdgeInsets withoutInset;
-      late EdgeInsets withInset;
+      late EdgeInsetsGeometry withoutInset;
+      late EdgeInsetsGeometry withInset;
       await tester.pumpWidget(MaterialApp(
         home: MediaQuery(
           data: const MediaQueryData(size: Size(800, 600)),
@@ -1377,10 +1377,12 @@ void main() {
           }),
         ),
       ));
+      final withoutInsetLtr = withoutInset.resolve(TextDirection.ltr);
+      final withInsetLtr = withInset.resolve(TextDirection.ltr);
       // clears the floating editing toolbar dock…
-      expect(withoutInset.bottom, greaterThanOrEqualTo(84));
+      expect(withoutInsetLtr.bottom, greaterThanOrEqualTo(84));
       // …and adds the device's bottom safe-area inset on top
-      expect(withInset.bottom, withoutInset.bottom + 34);
+      expect(withInsetLtr.bottom, withoutInsetLtr.bottom + 34);
     });
   });
 

--- a/packages/dart_pdf_editor/test/rtl_directionality_test.dart
+++ b/packages/dart_pdf_editor/test/rtl_directionality_test.dart
@@ -1,0 +1,73 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the RTL sweep: chrome uses direction-relative geometry
+/// (`EdgeInsetsDirectional` / `AlignmentDirectional`) so it mirrors under an
+/// RTL `Directionality`, while page-space geometry stays physical.
+void main() {
+  Future<EdgeInsetsGeometry> captureToastMargin(
+    WidgetTester tester, {
+    required Size size,
+  }) async {
+    late EdgeInsetsGeometry margin;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: MediaQueryData(size: size),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Builder(builder: (context) {
+            margin = pdfFloatingToastMargin(context);
+            return const SizedBox.shrink();
+          }),
+        ),
+      ),
+    );
+    return margin;
+  }
+
+  group('pdfFloatingToastMargin', () {
+    testWidgets('wide window: pill hugs the trailing edge in both directions',
+        (tester) async {
+      // 1000px wide, default pill 360 → start inset 1000-360-24 = 616.
+      final margin = await captureToastMargin(tester, size: const Size(1000, 800));
+
+      expect(margin, isA<EdgeInsetsDirectional>());
+
+      final ltr = margin.resolve(TextDirection.ltr);
+      // LTR: hugs the physical right (small right inset, large left inset).
+      expect(ltr.right, 24);
+      expect(ltr.left, 616);
+      expect(ltr.bottom, 96);
+
+      final rtl = margin.resolve(TextDirection.rtl);
+      // RTL: mirrored — hugs the physical left instead.
+      expect(rtl.left, 24);
+      expect(rtl.right, 616);
+      expect(rtl.bottom, 96);
+    });
+
+    testWidgets('narrow window: symmetric gutter, direction-independent',
+        (tester) async {
+      final margin = await captureToastMargin(tester, size: const Size(400, 800));
+
+      final ltr = margin.resolve(TextDirection.ltr);
+      final rtl = margin.resolve(TextDirection.rtl);
+      expect(ltr.left, 16);
+      expect(ltr.right, 16);
+      // Nothing to mirror when both sides match.
+      expect(rtl.left, ltr.left);
+      expect(rtl.right, ltr.right);
+    });
+  });
+
+  test('directional chrome icons mirror automatically under RTL', () {
+    // The sweep relies on Material shipping these glyphs with
+    // matchTextDirection baked into the IconData, so the plain Icon widget
+    // flips them under an RTL Directionality with no per-site handling. Guard
+    // that assumption against a future icon-set change.
+    expect(Icons.undo.matchTextDirection, isTrue);
+    expect(Icons.redo.matchTextDirection, isTrue);
+    expect(Icons.chevron_right.matchTextDirection, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Phase-2 i18n follow-up now that English extraction is complete across all three bundles (#477, #483, #499, #510). The handover put Arabic in tier 1 deliberately "to force the RTL work early" — this does the RTL layout sweep, and adds a DevTools lever to test it before any translated ARB ships.

**RTL sweep** — UI chrome moves to direction-relative geometry so it mirrors under an RTL `Directionality`, while page-space geometry stays physical (PDF coordinates must never flip):

- `EdgeInsets.only(left:/right:)` → `EdgeInsetsDirectional.only(start:/end:)` and `Alignment.*Left` → `AlignmentDirectional.*Start` across package chrome (bookmarks, properties, toolbar, sidebar, signature, stamps, reflow, search, shell, toast), the app (editor tab paddings, welcome, settings, the choose-key label), and the example (tab strip, scroll-indicator track).
- **Left physical on purpose:** the page `Stack`/overlay/form-layer anchors, PDF text alignment (`PdfTextAlign` and the field-content direction already keyed off the field's own text), the viewer's horizontal page-spacing (feeds `ExactExtentListView` scroll geometry + page-nav offsets), and the signature-appearance previews (they mirror what's drawn into the PDF).
- **Directional icons need no change:** `Icons.undo`/`redo`/`chevron_right` already ship with `matchTextDirection` in their `IconData`, so a plain `Icon` mirrors them automatically under RTL. (`matchTextDirection` is an `IconData` field, not an `Icon` widget parameter.)
- `pdfFloatingToastMargin`'s return type widened to `EdgeInsetsGeometry` (`EdgeInsetsDirectional` is a sibling of `EdgeInsets`, not a subtype); the wide-window bubble now hugs the trailing edge (bottom-right LTR, bottom-left RTL).

**DevTools locale override** (requested mid-review) — a new **Locale (testing)** section in the F12 panel picks a locale (incl. `ar`/`he` flagged RTL) into a session-only `ValueNotifier<Locale?>`. `app.dart`'s `MaterialApp` gains a `localeResolutionCallback` that returns the override verbatim, **bypassing resolution against `supportedLocales`** (`[en]` today) so an untranslated locale still flips `Directionality`; app strings fall back to English via the existing `appL10n`/`pdfL10n` wrappers. The panel also shows the live ambient direction.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Example app
- [x] App (`app/`)
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Feature
- [x] Editing behavior change (UI-chrome layout only; LTR-identical)

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (`--fatal-infos`, clean across workspace incl. tests)
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [x] Example app test suite
- [x] App test suite

Every RTL change is byte-identical under the default LTR direction, so existing widget tests that find UI by English text are unaffected. New coverage: `rtl_directionality_test.dart` (toast margin resolves right in LTR / left in RTL; the directional icons carry `matchTextDirection`); app tests for the dropdown wiring (`devtools_panel_test.dart`) and a forced-`ar` boot laying out RTL with the English empty-state fallback intact (`widget_test.dart`).

The package suite's 10 `ghent_render_test` CMYK/softmask baseline failures are **pre-existing** — they fail identically on the base commit `9b291a2` (spot-color/transparency render baselines, unrelated to these UI-chrome changes).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `dart_pdf_editor` (the `dart:ui show Locale` is in `app/`).
- [x] No `dart:io` imports in any `lib/`.
- [x] Layering preserved (UI-only change).
- [x] Parsers/writers untouched.
- [x] Raw PDF stream bytes untouched.
- [x] Test fixtures programmatic.

## Notes for reviewers

- The locale override intentionally forces locales outside `supportedLocales`; Flutter logs a debug-only "not supported by all of its localization delegates" warning in that state — expected and harmless (DevTools is debug/profile-only). The end-to-end test swallows only that specific warning.
- Write-up: `doc/dev-log/2026-07-23-i18n-rtl-sweep.md`.
- Still deferred (unchanged): `DateFormat`/`NumberFormat`, the persisted Settings language picker (distinct from this dev-only override), machine-translated seed ARBs + tier-1/2 locales, and the per-locale CI coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ygQrZq4ALp3xv7bHZnCVo

---
_Generated by [Claude Code](https://claude.ai/code/session_019ygQrZq4ALp3xv7bHZnCVo)_