### PR TITLE
i18n: localize built-in stamp date/time fields

### DIFF
--- a/doc/dev-log/2026-07-23-i18n-stamp-dates.md
+++ b/doc/dev-log/2026-07-23-i18n-stamp-dates.md
@@ -1,0 +1,75 @@
+# 2026-07-23 — i18n: locale-aware stamp dates
+
+Tiers 1 and 2 shipped 20 UI locales, but the built-in stamp date/time fields
+still emitted **hardcoded English**: month abbreviations (`Jan`…`Dec`) and
+`AM`/`PM`, baked into `editing_stamps.dart` as `_monthNames` and a literal
+`'AM'/'PM'` ternary. A French user placing a `{{date}}` stamp got `Jul` in an
+otherwise French UI. This session cashes in the top "Still open" roadmap item —
+`DateFormat` for stamp month abbreviations — while leaving the numeric readouts
+(zoom %, scale ×) for later.
+
+## What's localized (and what deliberately isn't)
+
+`PdfStampDateFormat.format` / `PdfStampTimeFormat.format` grew an optional
+`{String? localeName}`:
+
+- **Spelled-out month names** (`dayMonthNameYear`, `monthNameDayYear`) now come
+  from `intl.DateFormat.MMM(localeName)`.
+- **AM/PM markers** (the 12-hour time shapes) come from
+  `intl.DateFormat('a', localeName)`.
+- **Numeric shapes stay ASCII**: `iso` (a fixed technical format, `yyyy-MM-dd`)
+  and the `d/M/yyyy` slash forms keep padded ASCII digits regardless of locale,
+  as do the 24-hour times. This is deliberate — `iso` is not a localized format,
+  and digit **shaping** (Eastern-Arabic/Devanagari numerals) is a separate,
+  louder decision than month names, so it's out of scope here.
+
+`localeName == null` keeps the exact bundled-English behavior, so the
+no-delegate host path (and every existing widget test that asserts
+`'Jul 4, 2026 9:05:06 AM'`) is untouched.
+
+## Where the locale comes from
+
+The stamp text is materialized in `PdfEditingController`
+(`_resolvedStampTemplateValues`), which has no `BuildContext`. Added a plain
+`PdfEditingController.uiLocale` field (`ui.Locale?`, no `notifyListeners` — it's
+an output detail, not observable state). Resolution order:
+
+    uiLocale ?? preferences.locale  →  localeName  →  else English
+
+`uiLocale` is kept fresh by `_EditingPageOverlayState.didChangeDependencies`
+(`_controller.uiLocale = Localizations.localeOf(context)`) — the overlay is
+always mounted during an editing session and rebuilds when the locale changes,
+so the effective UI locale (which may differ from the persisted
+`preferences.locale` when that's null/"System default", or under the DevTools
+override) wins. `preferences.locale` is the fallback for the brief window before
+the overlay mounts. The stamp date-format **picker previews**
+(`_StampDateTimeFormatControls`) pass `Localizations.localeOf(context)` directly
+since they build with a context in hand.
+
+## Robustness: the `intl` locale-data trap
+
+`DateFormat.MMM('fr')` throws unless `fr`'s date symbols are loaded.
+`flutter_localizations` loads them for each locale its delegate resolves, so in
+a running app the active locale is always available. A plain unit test that
+never registers `flutter_localizations` has **no** symbols loaded, so both
+helpers (`_monthAbbr`, `_dayPeriod`) wrap the `intl` call in a `try/catch` and
+fall back to the English constant rather than crash a stamp placement. The new
+tests call `initializeDateFormatting()` in `setUpAll` to exercise the real
+localized path, and one case (`localeName: 'zzz-not-a-locale'`) pins the
+fallback.
+
+## Tests
+
+New `localized stamp date/time formatting` group in `editing_stamps_test.dart`
+(6 cases): English default preserved; `ja` month name (`7月`) on both name
+shapes; numeric shapes stay ASCII under `ja`/`ar`; `ja` AM marker (`午前`) on
+12-hour and none on 24-hour; unknown-locale fallback; and the controller
+resolving `{{date}}` through `uiLocale`. Full `editing_stamps_test.dart` green
+(49). Root `dart analyze --fatal-infos` clean. ARB coverage gate unaffected (57
+files) — no message keys were added; this is content formatting, not UI strings.
+
+## Next (unchanged from tier 2)
+
+`NumberFormat` for the remaining numeric readouts, engine-error→UI-message
+mapping, a per-script UI-font smoke test, CJK-glyph embedding into editing
+boxes, and community review of the seed translations.

--- a/doc/dev-log/2026-07-23-i18n-stamp-dates.md
+++ b/doc/dev-log/2026-07-23-i18n-stamp-dates.md
@@ -68,6 +68,20 @@ resolving `{{date}}` through `uiLocale`. Full `editing_stamps_test.dart` green
 (49). Root `dart analyze --fatal-infos` clean. ARB coverage gate unaffected (57
 files) — no message keys were added; this is content formatting, not UI strings.
 
+## Caught up with main: translate the lock/unlock + search-annotations keys
+
+Merging `main` in pulled the lock/unlock (#493) and search-annotations (#495)
+features, which had added five English editor keys (`menuLock`, `menuUnlock`,
+`searchAnnotations`, `sidebarLockAnnotation`, `sidebarUnlockAnnotation`) to
+`_en.arb` **without** translating them into the 19 locales — so the ARB
+coverage gate was red on `main` itself (and therefore on this PR's merge
+result). Filled in all 19 locales (three distinct strings: "Lock"/"Unlock"
+annotation verbs and "Search annotations"), matching each locale's existing
+`shellPanelAnnotations` term for "annotation" (e.g. 注释 zh, 註解 zh_Hant, 주석
+ko, Anmerkungen de), regenerated gen-l10n, and the gate is green again (57 files
+across 3 bundles). These are seed translations for the same community-review
+pass as the rest.
+
 ## Next (unchanged from tier 2)
 
 `NumberFormat` for the remaining numeric readouts, engine-error→UI-message

--- a/doc/dev-log/2026-07-23-i18n-stamp-dates.md
+++ b/doc/dev-log/2026-07-23-i18n-stamp-dates.md
@@ -82,6 +82,15 @@ ko, Anmerkungen de), regenerated gen-l10n, and the gate is green again (57 files
 across 3 bundles). These are seed translations for the same community-review
 pass as the rest.
 
+A second catch-up merge pulled the image-crop feature (#504), which likewise
+added five untranslated English keys (`tbCropImage`, `tbCroppingImage`,
+`tbCropApply`, `tbCropCancel`, `tbCropReset`); translated across the 19 locales
+the same way (matching each locale's `stampImage`/`tbReplaceImage` term for
+"image"), regenerated, gate green. (The keyboard-shortcut PR #497 also merged in
+that pull but added no new strings.) These recurring red gates are the
+seed-translation debt catching up with feature PRs that ship English-only keys -
+worth a note for whoever wires up Weblate/Crowdin.
+
 ## Next (unchanged from tier 2)
 
 `NumberFormat` for the remaining numeric readouts, engine-error→UI-message

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -172,8 +172,19 @@ landed with Spanish:
   translated locale from shipping looking finished.
 
 These are seed translations (machine/LLM), pending native/community review.
-Still open: `DateFormat`/`NumberFormat` for stamp month abbreviations and
-user-visible numeric readouts (excluding PDF-syntax number emission); engine-
+
+**Locale-aware stamp dates** landed next
+(`doc/dev-log/2026-07-23-i18n-stamp-dates.md`): the built-in `{{date}}` /
+`{{datetime}}` / `{{time}}` stamp fields now localize their spelled-out month
+abbreviations and AM/PM markers through `intl`'s `DateFormat`, driven by the
+ambient UI locale (`PdfEditingController.uiLocale`, kept fresh by the editing
+overlay, falling back to the persisted Settings locale and finally English).
+Numeric date shapes (`iso`, the slash forms) and 24-hour times stay ASCII and
+locale-independent, and hosts that never register the delegate keep the English
+default unchanged.
+
+Still open: `NumberFormat` for the remaining user-visible numeric readouts
+(zoom %, scale ×; excluding PDF-syntax number emission); engine-
 error→UI-message mapping; a per-script UI-font smoke test; CJK-glyph embedding
 when typed into an editing text box (bundled editing fonts are Latin-only);
 and community review (Weblate/Crowdin) of the seed translations.

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ar",
+  "menuLock": "قفل",
+  "menuUnlock": "إلغاء القفل",
+  "searchAnnotations": "البحث في التعليقات التوضيحية",
+  "sidebarLockAnnotation": "قفل",
+  "sidebarUnlockAnnotation": "إلغاء القفل",
   "add": "إضافة",
   "annotCaret": "علامة إقحام",
   "annotCircle": "دائرة",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ar",
+  "tbCropImage": "اقتصاص الصورة",
+  "tbCroppingImage": "جارٍ اقتصاص الصورة",
+  "tbCropApply": "تطبيق الاقتصاص",
+  "tbCropCancel": "إلغاء الاقتصاص",
+  "tbCropReset": "إعادة تعيين الاقتصاص",
   "menuLock": "قفل",
   "menuUnlock": "إلغاء القفل",
   "searchAnnotations": "البحث في التعليقات التوضيحية",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "de",
+  "tbCropImage": "Bild zuschneiden",
+  "tbCroppingImage": "Bild wird zugeschnitten",
+  "tbCropApply": "Zuschnitt anwenden",
+  "tbCropCancel": "Zuschnitt abbrechen",
+  "tbCropReset": "Zuschnitt zurücksetzen",
   "menuLock": "Sperren",
   "menuUnlock": "Entsperren",
   "searchAnnotations": "Anmerkungen durchsuchen",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "de",
+  "menuLock": "Sperren",
+  "menuUnlock": "Entsperren",
+  "searchAnnotations": "Anmerkungen durchsuchen",
+  "sidebarLockAnnotation": "Sperren",
+  "sidebarUnlockAnnotation": "Entsperren",
   "add": "Hinzufügen",
   "annotCaret": "Einfügemarke",
   "annotCircle": "Kreis",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "es",
+  "tbCropImage": "Recortar imagen",
+  "tbCroppingImage": "Recortando imagen",
+  "tbCropApply": "Aplicar recorte",
+  "tbCropCancel": "Cancelar recorte",
+  "tbCropReset": "Restablecer recorte",
   "menuLock": "Bloquear",
   "menuUnlock": "Desbloquear",
   "searchAnnotations": "Buscar anotaciones",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "es",
+  "menuLock": "Bloquear",
+  "menuUnlock": "Desbloquear",
+  "searchAnnotations": "Buscar anotaciones",
+  "sidebarLockAnnotation": "Bloquear",
+  "sidebarUnlockAnnotation": "Desbloquear",
   "add": "Añadir",
   "annotCaret": "Cursor de inserción",
   "annotCircle": "Círculo",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "fr",
+  "tbCropImage": "Rogner l'image",
+  "tbCroppingImage": "Rognage de l'image",
+  "tbCropApply": "Appliquer le rognage",
+  "tbCropCancel": "Annuler le rognage",
+  "tbCropReset": "Réinitialiser le rognage",
   "menuLock": "Verrouiller",
   "menuUnlock": "Déverrouiller",
   "searchAnnotations": "Rechercher dans les annotations",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "fr",
+  "menuLock": "Verrouiller",
+  "menuUnlock": "Déverrouiller",
+  "searchAnnotations": "Rechercher dans les annotations",
+  "sidebarLockAnnotation": "Verrouiller",
+  "sidebarUnlockAnnotation": "Déverrouiller",
   "add": "Ajouter",
   "annotCaret": "Caret",
   "annotCircle": "Cercle",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "hi",
+  "tbCropImage": "छवि क्रॉप करें",
+  "tbCroppingImage": "छवि क्रॉप हो रही है",
+  "tbCropApply": "क्रॉप लागू करें",
+  "tbCropCancel": "क्रॉप रद्द करें",
+  "tbCropReset": "क्रॉप रीसेट करें",
   "menuLock": "लॉक करें",
   "menuUnlock": "अनलॉक करें",
   "searchAnnotations": "एनोटेशन खोजें",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "hi",
+  "menuLock": "लॉक करें",
+  "menuUnlock": "अनलॉक करें",
+  "searchAnnotations": "एनोटेशन खोजें",
+  "sidebarLockAnnotation": "लॉक करें",
+  "sidebarUnlockAnnotation": "अनलॉक करें",
   "add": "जोड़ें",
   "annotCaret": "कैरेट",
   "annotCircle": "वृत्त",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "id",
+  "tbCropImage": "Pangkas gambar",
+  "tbCroppingImage": "Memangkas gambar",
+  "tbCropApply": "Terapkan pangkas",
+  "tbCropCancel": "Batalkan pangkas",
+  "tbCropReset": "Atur ulang pangkas",
   "menuLock": "Kunci",
   "menuUnlock": "Buka kunci",
   "searchAnnotations": "Cari anotasi",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "id",
+  "menuLock": "Kunci",
+  "menuUnlock": "Buka kunci",
+  "searchAnnotations": "Cari anotasi",
+  "sidebarLockAnnotation": "Kunci",
+  "sidebarUnlockAnnotation": "Buka kunci",
   "add": "Tambah",
   "annotCaret": "Sisipan",
   "annotCircle": "Lingkaran",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "it",
+  "tbCropImage": "Ritaglia immagine",
+  "tbCroppingImage": "Ritaglio immagine in corso",
+  "tbCropApply": "Applica ritaglio",
+  "tbCropCancel": "Annulla ritaglio",
+  "tbCropReset": "Reimposta ritaglio",
   "menuLock": "Blocca",
   "menuUnlock": "Sblocca",
   "searchAnnotations": "Cerca annotazioni",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "it",
+  "menuLock": "Blocca",
+  "menuUnlock": "Sblocca",
+  "searchAnnotations": "Cerca annotazioni",
+  "sidebarLockAnnotation": "Blocca",
+  "sidebarUnlockAnnotation": "Sblocca",
   "add": "Aggiungi",
   "annotCaret": "Cursore",
   "annotCircle": "Cerchio",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ja",
+  "tbCropImage": "画像をトリミング",
+  "tbCroppingImage": "画像をトリミング中",
+  "tbCropApply": "トリミングを適用",
+  "tbCropCancel": "トリミングをキャンセル",
+  "tbCropReset": "トリミングをリセット",
   "menuLock": "ロック",
   "menuUnlock": "ロック解除",
   "searchAnnotations": "注釈を検索",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ja",
+  "menuLock": "ロック",
+  "menuUnlock": "ロック解除",
+  "searchAnnotations": "注釈を検索",
+  "sidebarLockAnnotation": "ロック",
+  "sidebarUnlockAnnotation": "ロック解除",
   "add": "追加",
   "annotCaret": "カレット",
   "annotCircle": "円",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ko",
+  "tbCropImage": "이미지 자르기",
+  "tbCroppingImage": "이미지 자르는 중",
+  "tbCropApply": "자르기 적용",
+  "tbCropCancel": "자르기 취소",
+  "tbCropReset": "자르기 재설정",
   "menuLock": "잠금",
   "menuUnlock": "잠금 해제",
   "searchAnnotations": "주석 검색",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ko",
+  "menuLock": "잠금",
+  "menuUnlock": "잠금 해제",
+  "searchAnnotations": "주석 검색",
+  "sidebarLockAnnotation": "잠금",
+  "sidebarUnlockAnnotation": "잠금 해제",
   "add": "추가",
   "annotCaret": "캐럿",
   "annotCircle": "원",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -1291,6 +1291,21 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'علامات الاختيار على المستند';
 
   @override
+  String get tbCropImage => 'اقتصاص الصورة';
+
+  @override
+  String get tbCroppingImage => 'جارٍ اقتصاص الصورة';
+
+  @override
+  String get tbCropApply => 'تطبيق الاقتصاص';
+
+  @override
+  String get tbCropCancel => 'إلغاء الاقتصاص';
+
+  @override
+  String get tbCropReset => 'إعادة تعيين الاقتصاص';
+
+  @override
   String get tbColorLabel => 'اللون';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -405,6 +405,12 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'تسطيح النموذج';
 
   @override
+  String get menuLock => 'قفل';
+
+  @override
+  String get menuUnlock => 'إلغاء القفل';
+
+  @override
   String get menuRecolour => 'إعادة التلوين…';
 
   @override
@@ -832,6 +838,9 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'غير معلّم';
 
   @override
+  String get searchAnnotations => 'البحث في التعليقات التوضيحية';
+
+  @override
   String get searchClearSearch => 'مسح البحث';
 
   @override
@@ -1002,6 +1011,12 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'حذف التوقيع';
+
+  @override
+  String get sidebarLockAnnotation => 'قفل';
+
+  @override
+  String get sidebarUnlockAnnotation => 'إلغاء القفل';
 
   @override
   String get sidebarMore => 'المزيد';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -397,6 +397,12 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Formular reduzieren';
 
   @override
+  String get menuLock => 'Sperren';
+
+  @override
+  String get menuUnlock => 'Entsperren';
+
+  @override
   String get menuRecolour => 'Umfärben…';
 
   @override
@@ -820,6 +826,9 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Nicht markiert';
 
   @override
+  String get searchAnnotations => 'Anmerkungen durchsuchen';
+
+  @override
   String get searchClearSearch => 'Suche leeren';
 
   @override
@@ -989,6 +998,12 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Signatur löschen';
+
+  @override
+  String get sidebarLockAnnotation => 'Sperren';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Entsperren';
 
   @override
   String get sidebarMore => 'Mehr';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -1271,6 +1271,21 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Häkchen auf dem Dokument';
 
   @override
+  String get tbCropImage => 'Bild zuschneiden';
+
+  @override
+  String get tbCroppingImage => 'Bild wird zugeschnitten';
+
+  @override
+  String get tbCropApply => 'Zuschnitt anwenden';
+
+  @override
+  String get tbCropCancel => 'Zuschnitt abbrechen';
+
+  @override
+  String get tbCropReset => 'Zuschnitt zurücksetzen';
+
+  @override
   String get tbColorLabel => 'Farbe';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -398,6 +398,12 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Aplanar formulario';
 
   @override
+  String get menuLock => 'Bloquear';
+
+  @override
+  String get menuUnlock => 'Desbloquear';
+
+  @override
   String get menuRecolour => 'Recolorear…';
 
   @override
@@ -821,6 +827,9 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Sin marcar';
 
   @override
+  String get searchAnnotations => 'Buscar anotaciones';
+
+  @override
   String get searchClearSearch => 'Borrar búsqueda';
 
   @override
@@ -989,6 +998,12 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Eliminar firma';
+
+  @override
+  String get sidebarLockAnnotation => 'Bloquear';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Desbloquear';
 
   @override
   String get sidebarMore => 'Más';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -1269,6 +1269,21 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Marcas en el documento';
 
   @override
+  String get tbCropImage => 'Recortar imagen';
+
+  @override
+  String get tbCroppingImage => 'Recortando imagen';
+
+  @override
+  String get tbCropApply => 'Aplicar recorte';
+
+  @override
+  String get tbCropCancel => 'Cancelar recorte';
+
+  @override
+  String get tbCropReset => 'Restablecer recorte';
+
+  @override
   String get tbColorLabel => 'Color';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -399,6 +399,12 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Aplatir le formulaire';
 
   @override
+  String get menuLock => 'Verrouiller';
+
+  @override
+  String get menuUnlock => 'Déverrouiller';
+
+  @override
   String get menuRecolour => 'Recoloriser…';
 
   @override
@@ -822,6 +828,9 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Non marqué';
 
   @override
+  String get searchAnnotations => 'Rechercher dans les annotations';
+
+  @override
   String get searchClearSearch => 'Effacer la recherche';
 
   @override
@@ -991,6 +1000,12 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Supprimer la signature';
+
+  @override
+  String get sidebarLockAnnotation => 'Verrouiller';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Déverrouiller';
 
   @override
   String get sidebarMore => 'Plus';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -1274,6 +1274,21 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Coches sur le document';
 
   @override
+  String get tbCropImage => 'Rogner l\'image';
+
+  @override
+  String get tbCroppingImage => 'Rognage de l\'image';
+
+  @override
+  String get tbCropApply => 'Appliquer le rognage';
+
+  @override
+  String get tbCropCancel => 'Annuler le rognage';
+
+  @override
+  String get tbCropReset => 'Réinitialiser le rognage';
+
+  @override
   String get tbColorLabel => 'Couleur';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -396,6 +396,12 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'फ़ॉर्म फ़्लैटन करें';
 
   @override
+  String get menuLock => 'लॉक करें';
+
+  @override
+  String get menuUnlock => 'अनलॉक करें';
+
+  @override
   String get menuRecolour => 'पुनः रंग दें…';
 
   @override
@@ -817,6 +823,9 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'अचिह्नित';
 
   @override
+  String get searchAnnotations => 'एनोटेशन खोजें';
+
+  @override
   String get searchClearSearch => 'खोज साफ़ करें';
 
   @override
@@ -986,6 +995,12 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'हस्ताक्षर हटाएँ';
+
+  @override
+  String get sidebarLockAnnotation => 'लॉक करें';
+
+  @override
+  String get sidebarUnlockAnnotation => 'अनलॉक करें';
 
   @override
   String get sidebarMore => 'अधिक';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -1266,6 +1266,21 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'दस्तावेज़ पर चेक-मार्क';
 
   @override
+  String get tbCropImage => 'छवि क्रॉप करें';
+
+  @override
+  String get tbCroppingImage => 'छवि क्रॉप हो रही है';
+
+  @override
+  String get tbCropApply => 'क्रॉप लागू करें';
+
+  @override
+  String get tbCropCancel => 'क्रॉप रद्द करें';
+
+  @override
+  String get tbCropReset => 'क्रॉप रीसेट करें';
+
+  @override
   String get tbColorLabel => 'रंग';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -397,6 +397,12 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Ratakan formulir';
 
   @override
+  String get menuLock => 'Kunci';
+
+  @override
+  String get menuUnlock => 'Buka kunci';
+
+  @override
   String get menuRecolour => 'Warnai ulang…';
 
   @override
@@ -820,6 +826,9 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Tak ditandai';
 
   @override
+  String get searchAnnotations => 'Cari anotasi';
+
+  @override
   String get searchClearSearch => 'Bersihkan pencarian';
 
   @override
@@ -989,6 +998,12 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Hapus tanda tangan';
+
+  @override
+  String get sidebarLockAnnotation => 'Kunci';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Buka kunci';
 
   @override
   String get sidebarMore => 'Lainnya';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -1271,6 +1271,21 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Tanda centang pada dokumen';
 
   @override
+  String get tbCropImage => 'Pangkas gambar';
+
+  @override
+  String get tbCroppingImage => 'Memangkas gambar';
+
+  @override
+  String get tbCropApply => 'Terapkan pangkas';
+
+  @override
+  String get tbCropCancel => 'Batalkan pangkas';
+
+  @override
+  String get tbCropReset => 'Atur ulang pangkas';
+
+  @override
   String get tbColorLabel => 'Warna';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -398,6 +398,12 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Rendi definitivo il modulo';
 
   @override
+  String get menuLock => 'Blocca';
+
+  @override
+  String get menuUnlock => 'Sblocca';
+
+  @override
   String get menuRecolour => 'Ricolora…';
 
   @override
@@ -821,6 +827,9 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Non contrassegnato';
 
   @override
+  String get searchAnnotations => 'Cerca annotazioni';
+
+  @override
   String get searchClearSearch => 'Cancella ricerca';
 
   @override
@@ -990,6 +999,12 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Elimina firma';
+
+  @override
+  String get sidebarLockAnnotation => 'Blocca';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Sblocca';
 
   @override
   String get sidebarMore => 'Altro';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -1271,6 +1271,21 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Segni di spunta sul documento';
 
   @override
+  String get tbCropImage => 'Ritaglia immagine';
+
+  @override
+  String get tbCroppingImage => 'Ritaglio immagine in corso';
+
+  @override
+  String get tbCropApply => 'Applica ritaglio';
+
+  @override
+  String get tbCropCancel => 'Annulla ritaglio';
+
+  @override
+  String get tbCropReset => 'Reimposta ritaglio';
+
+  @override
   String get tbColorLabel => 'Colore';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -1261,6 +1261,21 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'ドキュメント上のチェックマーク';
 
   @override
+  String get tbCropImage => '画像をトリミング';
+
+  @override
+  String get tbCroppingImage => '画像をトリミング中';
+
+  @override
+  String get tbCropApply => 'トリミングを適用';
+
+  @override
+  String get tbCropCancel => 'トリミングをキャンセル';
+
+  @override
+  String get tbCropReset => 'トリミングをリセット';
+
+  @override
   String get tbColorLabel => 'カラー';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -396,6 +396,12 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'フォームを統合';
 
   @override
+  String get menuLock => 'ロック';
+
+  @override
+  String get menuUnlock => 'ロック解除';
+
+  @override
   String get menuRecolour => '色を変更…';
 
   @override
@@ -816,6 +822,9 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'マーク解除済み';
 
   @override
+  String get searchAnnotations => '注釈を検索';
+
+  @override
   String get searchClearSearch => '検索をクリア';
 
   @override
@@ -983,6 +992,12 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => '署名を削除';
+
+  @override
+  String get sidebarLockAnnotation => 'ロック';
+
+  @override
+  String get sidebarUnlockAnnotation => 'ロック解除';
 
   @override
   String get sidebarMore => 'その他';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -396,6 +396,12 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get menuFlattenForm => '양식 병합';
 
   @override
+  String get menuLock => '잠금';
+
+  @override
+  String get menuUnlock => '잠금 해제';
+
+  @override
   String get menuRecolour => '색상 변경…';
 
   @override
@@ -816,6 +822,9 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => '표시 해제됨';
 
   @override
+  String get searchAnnotations => '주석 검색';
+
+  @override
   String get searchClearSearch => '검색 지우기';
 
   @override
@@ -983,6 +992,12 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => '서명 삭제';
+
+  @override
+  String get sidebarLockAnnotation => '잠금';
+
+  @override
+  String get sidebarUnlockAnnotation => '잠금 해제';
 
   @override
   String get sidebarMore => '더 보기';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -1262,6 +1262,21 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => '문서의 체크 표시';
 
   @override
+  String get tbCropImage => '이미지 자르기';
+
+  @override
+  String get tbCroppingImage => '이미지 자르는 중';
+
+  @override
+  String get tbCropApply => '자르기 적용';
+
+  @override
+  String get tbCropCancel => '자르기 취소';
+
+  @override
+  String get tbCropReset => '자르기 재설정';
+
+  @override
   String get tbColorLabel => '색상';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -1270,6 +1270,21 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Vinkjes op het document';
 
   @override
+  String get tbCropImage => 'Afbeelding bijsnijden';
+
+  @override
+  String get tbCroppingImage => 'Bezig met bijsnijden';
+
+  @override
+  String get tbCropApply => 'Bijsnijden toepassen';
+
+  @override
+  String get tbCropCancel => 'Bijsnijden annuleren';
+
+  @override
+  String get tbCropReset => 'Bijsnijden herstellen';
+
+  @override
   String get tbColorLabel => 'Kleur';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -397,6 +397,12 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Formulier afvlakken';
 
   @override
+  String get menuLock => 'Vergrendelen';
+
+  @override
+  String get menuUnlock => 'Ontgrendelen';
+
+  @override
   String get menuRecolour => 'Herkleuren…';
 
   @override
@@ -820,6 +826,9 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Niet gemarkeerd';
 
   @override
+  String get searchAnnotations => 'Annotaties doorzoeken';
+
+  @override
   String get searchClearSearch => 'Zoekopdracht wissen';
 
   @override
@@ -989,6 +998,12 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Handtekening verwijderen';
+
+  @override
+  String get sidebarLockAnnotation => 'Vergrendelen';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Ontgrendelen';
 
   @override
   String get sidebarMore => 'Meer';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -1288,6 +1288,21 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Znaczniki na dokumencie';
 
   @override
+  String get tbCropImage => 'Przytnij obraz';
+
+  @override
+  String get tbCroppingImage => 'Przycinanie obrazu';
+
+  @override
+  String get tbCropApply => 'Zastosuj przycięcie';
+
+  @override
+  String get tbCropCancel => 'Anuluj przycięcie';
+
+  @override
+  String get tbCropReset => 'Resetuj przycięcie';
+
+  @override
   String get tbColorLabel => 'Kolor';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -403,6 +403,12 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Spłaszcz formularz';
 
   @override
+  String get menuLock => 'Zablokuj';
+
+  @override
+  String get menuUnlock => 'Odblokuj';
+
+  @override
   String get menuRecolour => 'Zmień kolor…';
 
   @override
@@ -830,6 +836,9 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Nieoznaczono';
 
   @override
+  String get searchAnnotations => 'Szukaj w adnotacjach';
+
+  @override
   String get searchClearSearch => 'Wyczyść wyszukiwanie';
 
   @override
@@ -1001,6 +1010,12 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Usuń podpis';
+
+  @override
+  String get sidebarLockAnnotation => 'Zablokuj';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Odblokuj';
 
   @override
   String get sidebarMore => 'Więcej';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -398,6 +398,12 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Achatar formulário';
 
   @override
+  String get menuLock => 'Bloquear';
+
+  @override
+  String get menuUnlock => 'Desbloquear';
+
+  @override
   String get menuRecolour => 'Recolorir…';
 
   @override
@@ -821,6 +827,9 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Desmarcado';
 
   @override
+  String get searchAnnotations => 'Pesquisar anotações';
+
+  @override
   String get searchClearSearch => 'Limpar pesquisa';
 
   @override
@@ -990,6 +999,12 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Excluir assinatura';
+
+  @override
+  String get sidebarLockAnnotation => 'Bloquear';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Desbloquear';
 
   @override
   String get sidebarMore => 'Mais';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -1271,6 +1271,21 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Marcas de contagem no documento';
 
   @override
+  String get tbCropImage => 'Cortar imagem';
+
+  @override
+  String get tbCroppingImage => 'Cortando imagem';
+
+  @override
+  String get tbCropApply => 'Aplicar corte';
+
+  @override
+  String get tbCropCancel => 'Cancelar corte';
+
+  @override
+  String get tbCropReset => 'Redefinir corte';
+
+  @override
   String get tbColorLabel => 'Cor';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -403,6 +403,12 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Свести форму';
 
   @override
+  String get menuLock => 'Заблокировать';
+
+  @override
+  String get menuUnlock => 'Разблокировать';
+
+  @override
   String get menuRecolour => 'Перекрасить…';
 
   @override
@@ -830,6 +836,9 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Без отметки';
 
   @override
+  String get searchAnnotations => 'Поиск по аннотациям';
+
+  @override
   String get searchClearSearch => 'Очистить поиск';
 
   @override
@@ -1001,6 +1010,12 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Удалить подпись';
+
+  @override
+  String get sidebarLockAnnotation => 'Заблокировать';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Разблокировать';
 
   @override
   String get sidebarMore => 'Ещё';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -1288,6 +1288,21 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Галочки на документе';
 
   @override
+  String get tbCropImage => 'Обрезать изображение';
+
+  @override
+  String get tbCroppingImage => 'Обрезка изображения';
+
+  @override
+  String get tbCropApply => 'Применить обрезку';
+
+  @override
+  String get tbCropCancel => 'Отменить обрезку';
+
+  @override
+  String get tbCropReset => 'Сбросить обрезку';
+
+  @override
   String get tbColorLabel => 'Цвет';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -396,6 +396,12 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'รวมแบบฟอร์ม';
 
   @override
+  String get menuLock => 'ล็อก';
+
+  @override
+  String get menuUnlock => 'ปลดล็อก';
+
+  @override
   String get menuRecolour => 'เปลี่ยนสี…';
 
   @override
@@ -818,6 +824,9 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'ยกเลิกเครื่องหมายแล้ว';
 
   @override
+  String get searchAnnotations => 'ค้นหาคำอธิบายประกอบ';
+
+  @override
   String get searchClearSearch => 'ล้างการค้นหา';
 
   @override
@@ -986,6 +995,12 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'ลบลายเซ็น';
+
+  @override
+  String get sidebarLockAnnotation => 'ล็อก';
+
+  @override
+  String get sidebarUnlockAnnotation => 'ปลดล็อก';
 
   @override
   String get sidebarMore => 'เพิ่มเติม';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -1267,6 +1267,21 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'เครื่องหมายถูกบนเอกสาร';
 
   @override
+  String get tbCropImage => 'ครอบตัดรูปภาพ';
+
+  @override
+  String get tbCroppingImage => 'กำลังครอบตัดรูปภาพ';
+
+  @override
+  String get tbCropApply => 'ใช้การครอบตัด';
+
+  @override
+  String get tbCropCancel => 'ยกเลิกการครอบตัด';
+
+  @override
+  String get tbCropReset => 'รีเซ็ตการครอบตัด';
+
+  @override
   String get tbColorLabel => 'สี';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -1267,6 +1267,21 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Belge üzerindeki onay işaretleri';
 
   @override
+  String get tbCropImage => 'Görseli kırp';
+
+  @override
+  String get tbCroppingImage => 'Görsel kırpılıyor';
+
+  @override
+  String get tbCropApply => 'Kırpmayı uygula';
+
+  @override
+  String get tbCropCancel => 'Kırpmayı iptal et';
+
+  @override
+  String get tbCropReset => 'Kırpmayı sıfırla';
+
+  @override
   String get tbColorLabel => 'Renk';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -396,6 +396,12 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Formu düzleştir';
 
   @override
+  String get menuLock => 'Kilitle';
+
+  @override
+  String get menuUnlock => 'Kilidi aç';
+
+  @override
   String get menuRecolour => 'Yeniden renklendir…';
 
   @override
@@ -818,6 +824,9 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'İşareti kaldırıldı';
 
   @override
+  String get searchAnnotations => 'Ek açıklamalarda ara';
+
+  @override
   String get searchClearSearch => 'Aramayı temizle';
 
   @override
@@ -987,6 +996,12 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'İmzayı sil';
+
+  @override
+  String get sidebarLockAnnotation => 'Kilitle';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Kilidi aç';
 
   @override
   String get sidebarMore => 'Daha fazla';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -402,6 +402,12 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Звести форму';
 
   @override
+  String get menuLock => 'Заблокувати';
+
+  @override
+  String get menuUnlock => 'Розблокувати';
+
+  @override
   String get menuRecolour => 'Перефарбувати…';
 
   @override
@@ -829,6 +835,9 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Знято позначку';
 
   @override
+  String get searchAnnotations => 'Пошук в анотаціях';
+
+  @override
   String get searchClearSearch => 'Очистити пошук';
 
   @override
@@ -1000,6 +1009,12 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Видалити підпис';
+
+  @override
+  String get sidebarLockAnnotation => 'Заблокувати';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Розблокувати';
 
   @override
   String get sidebarMore => 'Більше';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -1286,6 +1286,21 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Позначки на документі';
 
   @override
+  String get tbCropImage => 'Обрізати зображення';
+
+  @override
+  String get tbCroppingImage => 'Обрізання зображення';
+
+  @override
+  String get tbCropApply => 'Застосувати обрізання';
+
+  @override
+  String get tbCropCancel => 'Скасувати обрізання';
+
+  @override
+  String get tbCropReset => 'Скинути обрізання';
+
+  @override
   String get tbColorLabel => 'Колір';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -397,6 +397,12 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get menuFlattenForm => 'Làm phẳng biểu mẫu';
 
   @override
+  String get menuLock => 'Khóa';
+
+  @override
+  String get menuUnlock => 'Mở khóa';
+
+  @override
   String get menuRecolour => 'Đổi màu…';
 
   @override
@@ -820,6 +826,9 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => 'Chưa đánh dấu';
 
   @override
+  String get searchAnnotations => 'Tìm chú thích';
+
+  @override
   String get searchClearSearch => 'Xóa tìm kiếm';
 
   @override
@@ -989,6 +998,12 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => 'Xóa chữ ký';
+
+  @override
+  String get sidebarLockAnnotation => 'Khóa';
+
+  @override
+  String get sidebarUnlockAnnotation => 'Mở khóa';
 
   @override
   String get sidebarMore => 'Thêm';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -1270,6 +1270,21 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => 'Dấu kiểm trên tài liệu';
 
   @override
+  String get tbCropImage => 'Cắt hình ảnh';
+
+  @override
+  String get tbCroppingImage => 'Đang cắt hình ảnh';
+
+  @override
+  String get tbCropApply => 'Áp dụng cắt';
+
+  @override
+  String get tbCropCancel => 'Hủy cắt';
+
+  @override
+  String get tbCropReset => 'Đặt lại cắt';
+
+  @override
   String get tbColorLabel => 'Màu';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -396,6 +396,12 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get menuFlattenForm => '展平表单';
 
   @override
+  String get menuLock => '锁定';
+
+  @override
+  String get menuUnlock => '解锁';
+
+  @override
   String get menuRecolour => '重新着色…';
 
   @override
@@ -815,6 +821,9 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get sbarStateUnmarked => '未标记';
 
   @override
+  String get searchAnnotations => '搜索注释';
+
+  @override
   String get searchClearSearch => '清除搜索';
 
   @override
@@ -982,6 +991,12 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
 
   @override
   String get sidebarDeleteSignature => '删除签名';
+
+  @override
+  String get sidebarLockAnnotation => '锁定';
+
+  @override
+  String get sidebarUnlockAnnotation => '解锁';
 
   @override
   String get sidebarMore => '更多';
@@ -2281,6 +2296,12 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
   String get menuFlattenForm => '平面化表單';
 
   @override
+  String get menuLock => '鎖定';
+
+  @override
+  String get menuUnlock => '解鎖';
+
+  @override
   String get menuRecolour => '重新上色…';
 
   @override
@@ -2700,6 +2721,9 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
   String get sbarStateUnmarked => '未標記';
 
   @override
+  String get searchAnnotations => '搜尋註解';
+
+  @override
   String get searchClearSearch => '清除搜尋';
 
   @override
@@ -2867,6 +2891,12 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
 
   @override
   String get sidebarDeleteSignature => '刪除簽章';
+
+  @override
+  String get sidebarLockAnnotation => '鎖定';
+
+  @override
+  String get sidebarUnlockAnnotation => '解鎖';
 
   @override
   String get sidebarMore => '更多';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -1259,6 +1259,21 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get tbCheckMarksOnDocument => '文档上的勾选标记';
 
   @override
+  String get tbCropImage => '裁剪图像';
+
+  @override
+  String get tbCroppingImage => '正在裁剪图像';
+
+  @override
+  String get tbCropApply => '应用裁剪';
+
+  @override
+  String get tbCropCancel => '取消裁剪';
+
+  @override
+  String get tbCropReset => '重置裁剪';
+
+  @override
   String get tbColorLabel => '颜色';
 
   @override
@@ -3157,6 +3172,21 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
 
   @override
   String get tbCheckMarksOnDocument => '文件上的勾選標記';
+
+  @override
+  String get tbCropImage => '裁剪影像';
+
+  @override
+  String get tbCroppingImage => '正在裁剪影像';
+
+  @override
+  String get tbCropApply => '套用裁剪';
+
+  @override
+  String get tbCropCancel => '取消裁剪';
+
+  @override
+  String get tbCropReset => '重設裁剪';
 
   @override
   String get tbColorLabel => '顏色';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "nl",
+  "tbCropImage": "Afbeelding bijsnijden",
+  "tbCroppingImage": "Bezig met bijsnijden",
+  "tbCropApply": "Bijsnijden toepassen",
+  "tbCropCancel": "Bijsnijden annuleren",
+  "tbCropReset": "Bijsnijden herstellen",
   "menuLock": "Vergrendelen",
   "menuUnlock": "Ontgrendelen",
   "searchAnnotations": "Annotaties doorzoeken",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "nl",
+  "menuLock": "Vergrendelen",
+  "menuUnlock": "Ontgrendelen",
+  "searchAnnotations": "Annotaties doorzoeken",
+  "sidebarLockAnnotation": "Vergrendelen",
+  "sidebarUnlockAnnotation": "Ontgrendelen",
   "add": "Toevoegen",
   "annotCaret": "Invoegteken",
   "annotCircle": "Cirkel",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "pl",
+  "menuLock": "Zablokuj",
+  "menuUnlock": "Odblokuj",
+  "searchAnnotations": "Szukaj w adnotacjach",
+  "sidebarLockAnnotation": "Zablokuj",
+  "sidebarUnlockAnnotation": "Odblokuj",
   "add": "Dodaj",
   "annotCaret": "Znak wstawiania",
   "annotCircle": "Okrąg",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "pl",
+  "tbCropImage": "Przytnij obraz",
+  "tbCroppingImage": "Przycinanie obrazu",
+  "tbCropApply": "Zastosuj przycięcie",
+  "tbCropCancel": "Anuluj przycięcie",
+  "tbCropReset": "Resetuj przycięcie",
   "menuLock": "Zablokuj",
   "menuUnlock": "Odblokuj",
   "searchAnnotations": "Szukaj w adnotacjach",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "pt",
+  "menuLock": "Bloquear",
+  "menuUnlock": "Desbloquear",
+  "searchAnnotations": "Pesquisar anotações",
+  "sidebarLockAnnotation": "Bloquear",
+  "sidebarUnlockAnnotation": "Desbloquear",
   "add": "Adicionar",
   "annotCaret": "Marca de inserção",
   "annotCircle": "Círculo",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "pt",
+  "tbCropImage": "Cortar imagem",
+  "tbCroppingImage": "Cortando imagem",
+  "tbCropApply": "Aplicar corte",
+  "tbCropCancel": "Cancelar corte",
+  "tbCropReset": "Redefinir corte",
   "menuLock": "Bloquear",
   "menuUnlock": "Desbloquear",
   "searchAnnotations": "Pesquisar anotações",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ru",
+  "menuLock": "Заблокировать",
+  "menuUnlock": "Разблокировать",
+  "searchAnnotations": "Поиск по аннотациям",
+  "sidebarLockAnnotation": "Заблокировать",
+  "sidebarUnlockAnnotation": "Разблокировать",
   "add": "Добавить",
   "annotCaret": "Знак вставки",
   "annotCircle": "Круг",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "ru",
+  "tbCropImage": "Обрезать изображение",
+  "tbCroppingImage": "Обрезка изображения",
+  "tbCropApply": "Применить обрезку",
+  "tbCropCancel": "Отменить обрезку",
+  "tbCropReset": "Сбросить обрезку",
   "menuLock": "Заблокировать",
   "menuUnlock": "Разблокировать",
   "searchAnnotations": "Поиск по аннотациям",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "th",
+  "tbCropImage": "ครอบตัดรูปภาพ",
+  "tbCroppingImage": "กำลังครอบตัดรูปภาพ",
+  "tbCropApply": "ใช้การครอบตัด",
+  "tbCropCancel": "ยกเลิกการครอบตัด",
+  "tbCropReset": "รีเซ็ตการครอบตัด",
   "menuLock": "ล็อก",
   "menuUnlock": "ปลดล็อก",
   "searchAnnotations": "ค้นหาคำอธิบายประกอบ",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "th",
+  "menuLock": "ล็อก",
+  "menuUnlock": "ปลดล็อก",
+  "searchAnnotations": "ค้นหาคำอธิบายประกอบ",
+  "sidebarLockAnnotation": "ล็อก",
+  "sidebarUnlockAnnotation": "ปลดล็อก",
   "add": "เพิ่ม",
   "annotCaret": "เครื่องหมายแทรก",
   "annotCircle": "วงกลม",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "tr",
+  "menuLock": "Kilitle",
+  "menuUnlock": "Kilidi aç",
+  "searchAnnotations": "Ek açıklamalarda ara",
+  "sidebarLockAnnotation": "Kilitle",
+  "sidebarUnlockAnnotation": "Kilidi aç",
   "add": "Ekle",
   "annotCaret": "Şapka işareti",
   "annotCircle": "Daire",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "tr",
+  "tbCropImage": "Görseli kırp",
+  "tbCroppingImage": "Görsel kırpılıyor",
+  "tbCropApply": "Kırpmayı uygula",
+  "tbCropCancel": "Kırpmayı iptal et",
+  "tbCropReset": "Kırpmayı sıfırla",
   "menuLock": "Kilitle",
   "menuUnlock": "Kilidi aç",
   "searchAnnotations": "Ek açıklamalarda ara",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "uk",
+  "tbCropImage": "Обрізати зображення",
+  "tbCroppingImage": "Обрізання зображення",
+  "tbCropApply": "Застосувати обрізання",
+  "tbCropCancel": "Скасувати обрізання",
+  "tbCropReset": "Скинути обрізання",
   "menuLock": "Заблокувати",
   "menuUnlock": "Розблокувати",
   "searchAnnotations": "Пошук в анотаціях",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "uk",
+  "menuLock": "Заблокувати",
+  "menuUnlock": "Розблокувати",
+  "searchAnnotations": "Пошук в анотаціях",
+  "sidebarLockAnnotation": "Заблокувати",
+  "sidebarUnlockAnnotation": "Розблокувати",
   "add": "Додати",
   "annotCaret": "Каретка",
   "annotCircle": "Коло",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "vi",
+  "menuLock": "Khóa",
+  "menuUnlock": "Mở khóa",
+  "searchAnnotations": "Tìm chú thích",
+  "sidebarLockAnnotation": "Khóa",
+  "sidebarUnlockAnnotation": "Mở khóa",
   "add": "Thêm",
   "annotCaret": "Dấu chèn",
   "annotCircle": "Hình tròn",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "vi",
+  "tbCropImage": "Cắt hình ảnh",
+  "tbCroppingImage": "Đang cắt hình ảnh",
+  "tbCropApply": "Áp dụng cắt",
+  "tbCropCancel": "Hủy cắt",
+  "tbCropReset": "Đặt lại cắt",
   "menuLock": "Khóa",
   "menuUnlock": "Mở khóa",
   "searchAnnotations": "Tìm chú thích",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "zh",
+  "tbCropImage": "裁剪图像",
+  "tbCroppingImage": "正在裁剪图像",
+  "tbCropApply": "应用裁剪",
+  "tbCropCancel": "取消裁剪",
+  "tbCropReset": "重置裁剪",
   "menuLock": "锁定",
   "menuUnlock": "解锁",
   "searchAnnotations": "搜索注释",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "zh",
+  "menuLock": "锁定",
+  "menuUnlock": "解锁",
+  "searchAnnotations": "搜索注释",
+  "sidebarLockAnnotation": "锁定",
+  "sidebarUnlockAnnotation": "解锁",
   "add": "添加",
   "annotCaret": "插入符",
   "annotCircle": "圆形",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "zh_Hant",
+  "tbCropImage": "裁剪影像",
+  "tbCroppingImage": "正在裁剪影像",
+  "tbCropApply": "套用裁剪",
+  "tbCropCancel": "取消裁剪",
+  "tbCropReset": "重設裁剪",
   "menuLock": "鎖定",
   "menuUnlock": "解鎖",
   "searchAnnotations": "搜尋註解",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
@@ -1,5 +1,10 @@
 {
   "@@locale": "zh_Hant",
+  "menuLock": "鎖定",
+  "menuUnlock": "解鎖",
+  "searchAnnotations": "搜尋註解",
+  "sidebarLockAnnotation": "鎖定",
+  "sidebarUnlockAnnotation": "解鎖",
   "add": "新增",
   "annotCaret": "插入符號",
   "annotCircle": "圓形",

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -1550,6 +1550,16 @@ class PdfEditingController extends ChangeNotifier {
   /// placeholders. Override in tests or when a host app needs a fixed clock.
   DateTime Function() stampTemplateClock = DateTime.now;
 
+  /// The UI locale used to localize the built-in `date`/`datetime` stamp
+  /// fields (month names, AM/PM). Kept fresh by the editing overlay from its
+  /// ambient [Localizations]; falls back to [PdfEditingPreferences.locale]
+  /// (the persisted Settings choice) and finally English. Purely an output
+  /// detail of the resolved stamp text - setting it never notifies listeners.
+  ui.Locale? uiLocale;
+
+  String? get _stampLocaleName =>
+      (uiLocale ?? preferences.locale)?.toString();
+
   /// Field names the stamp editor should offer for insertion.
   ///
   /// This includes the built-ins plus the current custom value keys.
@@ -1578,8 +1588,9 @@ class PdfEditingController extends ChangeNotifier {
 
   Map<String, String> _resolvedStampTemplateValues() {
     final now = stampTemplateClock();
-    final date = preferences.stampDateFormat.format(now);
-    final time = preferences.stampTimeFormat.format(now);
+    final localeName = _stampLocaleName;
+    final date = preferences.stampDateFormat.format(now, localeName: localeName);
+    final time = preferences.stampTimeFormat.format(now, localeName: localeName);
     return {
       'date': date,
       'time': time,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1058,6 +1058,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _controller.addListener(_onControllerChanged);
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Keep the controller's stamp-locale in sync with the ambient UI locale so
+    // the built-in {{date}}/{{datetime}} stamp fields localize their month
+    // names and AM/PM markers. Runs on mount and whenever the locale changes.
+    _controller.uiLocale = Localizations.localeOf(context);
+  }
+
   void _adoptInteraction() {
     _ownsInteraction = widget.interactionSession == null;
     _interaction =

--- a/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_stamps.dart
@@ -6,6 +6,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:intl/intl.dart' as intl;
 import 'package:pdf_document/pdf_document.dart';
 
 import '../l10n/pdf_l10n.dart';
@@ -33,6 +34,35 @@ const _monthNames = [
   'Dec',
 ];
 
+/// The abbreviated month name for [month] (1-12) in [localeName], falling back
+/// to the bundled English abbreviations.
+///
+/// `localeName == null` keeps the English default (the behavior for hosts that
+/// never register the localization delegate). When a locale is given but its
+/// `intl` date symbols aren't loaded yet - e.g. a plain unit test that never
+/// registered `flutter_localizations` - the lookup throws and we fall back to
+/// English rather than crash the stamp.
+String _monthAbbr(int month, String? localeName) {
+  if (localeName == null) return _monthNames[month - 1];
+  try {
+    return intl.DateFormat.MMM(localeName).format(DateTime(2000, month));
+  } catch (_) {
+    return _monthNames[month - 1];
+  }
+}
+
+/// The localized AM/PM marker for [value] in [localeName], falling back to
+/// English `AM`/`PM` (see [_monthAbbr] for the fallback rationale).
+String _dayPeriod(DateTime value, String? localeName) {
+  final fallback = value.hour < 12 ? 'AM' : 'PM';
+  if (localeName == null) return fallback;
+  try {
+    return intl.DateFormat('a', localeName).format(value);
+  } catch (_) {
+    return fallback;
+  }
+}
+
 /// Date formats used by the built-in `{{date}}` and `{{datetime}}` stamp
 /// template fields.
 enum PdfStampDateFormat {
@@ -42,11 +72,17 @@ enum PdfStampDateFormat {
   dayMonthNameYear,
   monthNameDayYear;
 
-  String format(DateTime value) {
+  /// Formats [value] for the stamp `{{date}}` field.
+  ///
+  /// [localeName] localizes the spelled-out month name (`dayMonthNameYear` /
+  /// `monthNameDayYear`); null keeps English. Numeric shapes ([iso] and the
+  /// slash forms) stay ASCII digits regardless - `iso` in particular is a
+  /// fixed technical format, not a localized one.
+  String format(DateTime value, {String? localeName}) {
     final year = _fourDigits(value.year);
     final month = _twoDigits(value.month);
     final day = _twoDigits(value.day);
-    final monthName = _monthNames[value.month - 1];
+    final monthName = _monthAbbr(value.month, localeName);
     return switch (this) {
       PdfStampDateFormat.iso => '$year-$month-$day',
       PdfStampDateFormat.dayMonthYear => '$day/$month/$year',
@@ -65,11 +101,15 @@ enum PdfStampTimeFormat {
   twentyFourHourSeconds,
   twelveHourSeconds;
 
-  String format(DateTime value) {
+  /// Formats [value] for the stamp `{{time}}` field.
+  ///
+  /// [localeName] localizes the AM/PM marker on the 12-hour shapes; null keeps
+  /// English. The 24-hour shapes carry no marker and are locale-independent.
+  String format(DateTime value, {String? localeName}) {
     final hour = _twoDigits(value.hour);
     final minute = _twoDigits(value.minute);
     final second = _twoDigits(value.second);
-    final suffix = value.hour < 12 ? 'AM' : 'PM';
+    final suffix = _dayPeriod(value, localeName);
     final hour12 = value.hour % 12 == 0 ? 12 : value.hour % 12;
     return switch (this) {
       PdfStampTimeFormat.twentyFourHour => '$hour:$minute',
@@ -357,12 +397,14 @@ class _StampDateTimeFormatControls extends StatelessWidget {
       PdfStampTimeFormat.twelveHourSeconds =>
         pdfL10n(context).stampTime12Hour,
     };
-    return '${format.format(sample)} ($suffix)';
+    final localeName = Localizations.localeOf(context).toString();
+    return '${format.format(sample, localeName: localeName)} ($suffix)';
   }
 
   @override
   Widget build(BuildContext context) {
     final sample = controller.stampTemplateClock();
+    final localeName = Localizations.localeOf(context).toString();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -379,7 +421,7 @@ class _StampDateTimeFormatControls extends StatelessWidget {
                 DropdownMenuItem<PdfStampDateFormat>(
                   key: ValueKey('pdf-stamp-date-format-${format.name}'),
                   value: format,
-                  child: Text(format.format(sample)),
+                  child: Text(format.format(sample, localeName: localeName)),
                 ),
             ],
             onChanged: (value) {

--- a/packages/dart_pdf_editor/test/editing_stamps_test.dart
+++ b/packages/dart_pdf_editor/test/editing_stamps_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/editing/editing_overlay.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -1706,6 +1707,88 @@ void main() {
       expect(find.text('Audit · external'), findsOneWidget);
       expect(find.byTooltip('Edit stamp'), findsNothing);
       expect(find.byTooltip('Delete stamp'), findsNothing);
+    });
+  });
+
+  group('localized stamp date/time formatting', () {
+    setUpAll(initializeDateFormatting);
+
+    final noon = DateTime(2026, 7, 4, 9, 5, 6);
+
+    test('defaults to English when no locale is given', () {
+      // Backward compatibility: hosts that never register the localization
+      // delegate (localeName == null) keep the bundled English shapes.
+      expect(PdfStampDateFormat.monthNameDayYear.format(noon), 'Jul 4, 2026');
+      expect(PdfStampDateFormat.dayMonthNameYear.format(noon), '4 Jul 2026');
+      expect(PdfStampTimeFormat.twelveHour.format(noon), '9:05 AM');
+    });
+
+    test('localizes the spelled-out month name', () {
+      expect(
+        PdfStampDateFormat.monthNameDayYear.format(noon, localeName: 'ja'),
+        contains('7月'),
+      );
+      expect(
+        PdfStampDateFormat.dayMonthNameYear.format(noon, localeName: 'ja'),
+        contains('7月'),
+      );
+      // English stays English even through the intl path.
+      expect(
+        PdfStampDateFormat.monthNameDayYear.format(noon, localeName: 'en'),
+        'Jul 4, 2026',
+      );
+    });
+
+    test('numeric date shapes stay ASCII regardless of locale', () {
+      // iso is a fixed technical format; the slash shapes carry no month name.
+      expect(
+        PdfStampDateFormat.iso.format(noon, localeName: 'ja'),
+        '2026-07-04',
+      );
+      expect(
+        PdfStampDateFormat.dayMonthYear.format(noon, localeName: 'ar'),
+        '04/07/2026',
+      );
+    });
+
+    test('localizes the AM/PM marker on 12-hour times', () {
+      final morning = PdfStampTimeFormat.twelveHour
+          .format(DateTime(2026, 7, 4, 9, 5), localeName: 'ja');
+      expect(morning, startsWith('9:05 '));
+      expect(morning, isNot(contains('AM')));
+      expect(morning, contains('午前'));
+      // 24-hour shapes carry no marker and are locale-independent.
+      expect(
+        PdfStampTimeFormat.twentyFourHour.format(noon, localeName: 'ja'),
+        '09:05',
+      );
+    });
+
+    test('falls back to English for an unknown locale instead of throwing', () {
+      expect(
+        () => PdfStampDateFormat.monthNameDayYear
+            .format(noon, localeName: 'zzz-not-a-locale'),
+        returnsNormally,
+      );
+      expect(
+        PdfStampDateFormat.monthNameDayYear
+            .format(noon, localeName: 'zzz-not-a-locale'),
+        'Jul 4, 2026',
+      );
+    });
+
+    test('controller resolves stamp fields through its uiLocale', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..stampTemplateClock = (() => noon)
+        ..preferences.stampDateFormat = PdfStampDateFormat.monthNameDayYear
+        ..uiLocale = const ui.Locale('ja');
+      addTearDown(editing.dispose);
+
+      expect(editing.resolvedStampTemplateValues['date'], contains('7月'));
+
+      // Clearing the override falls back to English (no persisted preference).
+      editing.uiLocale = null;
+      expect(editing.resolvedStampTemplateValues['date'], 'Jul 4, 2026');
     });
   });
 }


### PR DESCRIPTION
## Summary

Continues the i18n work by cashing in the top open roadmap item — locale-aware stamp dates. The built-in `{{date}}` / `{{datetime}}` / `{{time}}` stamp template fields previously emitted **hardcoded English** month abbreviations (`Jan`…`Dec`) and `AM`/`PM` markers regardless of the UI locale, so a stamp placed in a French/Japanese/… UI came out half-translated.

- `PdfStampDateFormat.format` / `PdfStampTimeFormat.format` gained an optional `{String? localeName}` and now source the spelled-out month name (`intl.DateFormat.MMM`) and AM/PM marker (`intl.DateFormat('a')`) from `intl`.
- **Numeric shapes stay ASCII and locale-independent**: `iso` (a fixed technical `yyyy-MM-dd` format), the `d/M/yyyy` slash forms, and 24-hour times keep padded ASCII digits. Digit shaping (Eastern-Arabic/Devanagari numerals) is deliberately out of scope.
- `localeName == null` keeps the exact bundled-English behavior, so the no-delegate host path and every existing widget test are unchanged.
- The locale is threaded through a new plain `PdfEditingController.uiLocale`, kept fresh by the editing overlay's `didChangeDependencies` (ambient `Localizations`), falling back to the persisted Settings locale, then English. The stamp-format picker previews pass their own context locale directly.
- Both `intl` helpers wrap the call in `try/catch` and fall back to the English constant if the locale's date symbols aren't loaded, so stamp placement never throws.

No ARB message keys were added — this is content formatting, not new UI strings — so the coverage gate is unaffected.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [x] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (root, `--fatal-infos`, clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (stamp + overlay suites; `editing_stamps_test.dart` green at 49, plus drag/count/shape-resize/chrome/preferences)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Not run: engine-package tests (`pdf_cos`/`pdf_document`/`pdf_graphics`) and corpus/Ghent renders — this change is confined to `dart_pdf_editor` stamp text formatting and touches no parsing/rendering path. Also ran the ARB coverage gate (`tool/check_arb_coverage.dart`, 57 files, green).

## PDF fixtures and screenshots

None — covered by a new programmatic test group (`localized stamp date/time formatting`) using `initializeDateFormatting()` and a fixed clock.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The effective locale prefers the ambient UI `Localizations` (so it tracks the DevTools override and hosts that set `MaterialApp.locale` directly), falling back to `PdfEditingPreferences.locale` for the brief window before the overlay mounts.
- Seed month/AM-PM strings come from `intl`/CLDR; tests assert stable CJK values (`7月`, `午前`) and substring/invariant checks elsewhere to avoid brittleness across intl versions.
- Follow-up i18n work still open (unchanged): `NumberFormat` for the remaining numeric readouts (zoom %, scale ×), engine-error→UI-message mapping, a per-script UI-font smoke test, CJK-glyph embedding into editing boxes, and community review of the seed translations. See `doc/dev-log/2026-07-23-i18n-stamp-dates.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qvQnE5YgbZy5dzVusaAxj)_