### PR TITLE
Group the annotation properties panel into collapsible sections

### DIFF
--- a/doc/dev-log/2026-07-23-properties-panel-grouping.md
+++ b/doc/dev-log/2026-07-23-properties-panel-grouping.md
@@ -1,0 +1,44 @@
+# 2026-07-23 - Collapsible groups in the properties panel
+
+`PdfAnnotationPropertiesPanel` (`editing_properties.dart`) had grown a long
+flat scroll of rows split only by plain `_section(title)` labels
+(Appearance, Text, Content, Position & size, Form field, Selection). With
+free-text and form-field controls now piling up under one selection it was
+getting busy, so the sections are now real **collapsible groups**.
+
+## What changed
+
+- Replaced the label-only `_section(String)` helper with
+  `_group(String id, String title, List<Widget> children)`: a header row
+  (label + expand/collapse chevron) wrapping its rows. Tapping the header
+  toggles `_expanded[id]`; when collapsed only the header stays and the rows
+  drop out of the tree (`if (expanded) ...children`).
+- Fold state lives in a `Map<String, bool> _expanded` on the panel State,
+  keyed by a stable group id and **defaulting to open** (absent = expanded).
+  It is per-group, not per-annotation, so a collapsed group stays collapsed
+  as the selection changes - held for the panel's lifetime (not persisted to
+  preferences; a lighter first cut).
+- `_buildSingle`/`_buildMulti` now assemble a `sections` list through a local
+  `addGroup(id, title, rows)` closure that skips empty groups, instead of
+  splicing `_section` headers into one flat list. The sub-builders
+  (`_styleControls`, `_textStyleControls`, `_formFieldControls`) return just
+  their body rows now - the caller supplies the group title.
+
+Group ids: `appearance`, `text`, `form-field`, `form-text`, `content`,
+`position-size` (single); `selection`, `appearance`, `content` (multi). The
+two "Text" groups (`text` for free-text style, `form-text` for form-field
+style) never co-occur but carry distinct ids so their fold state can't
+collide. Section header keys are `pdf-prop-section-<id>`.
+
+## Gotchas
+
+- Existing widget tests build the panel on a tall surface and find rows by
+  key without expanding anything. Defaulting groups to **open** keeps every
+  row in the tree, so all 21 prior tests pass untouched. A collapsed group
+  removes its rows, so any future test that collapses first must re-expand
+  before probing those rows.
+- Row keys, commit paths, and slider/geometry behaviour are unchanged - only
+  the enclosing layout moved. `flutter test test/editing_properties_test.dart`
+  (now 23, incl. two new collapse/expand tests), plus
+  `editing_form_style_test.dart`, `editing_line_endings_test.dart`, and
+  `pdf_shell_test.dart` stay green; `dart analyze` clean.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -25,6 +25,11 @@ import '../l10n/pdf_l10n.dart';
 /// mixed values read "Varies", and compatible edits act on the whole
 /// selection at once; with none it invites a selection.
 ///
+/// The rows are gathered under collapsible section headers (Appearance,
+/// Text, Content, Position & size, …) - tap a header to fold a group away
+/// and keep the panel legible as it fills up. The fold state is per-group,
+/// held for the panel's lifetime and shared across selections.
+///
 /// The inner edge is draggable ([resizable]); the chosen width persists
 /// via [PdfEditingPreferences.propertiesPanelWidth].
 ///
@@ -125,6 +130,13 @@ class _PdfAnnotationPropertiesPanelState
   double? _draggingLineSpacing;
   double? _draggingCharSpacing;
   double? _draggingFontWidth;
+
+  /// Whether each collapsible property group is open, keyed by the group's
+  /// stable id. Absent means open - groups start expanded, so nothing is
+  /// hidden until the user collapses it. The choice is per-group (not
+  /// per-annotation), so a collapsed group stays collapsed across selection
+  /// changes for the panel's lifetime.
+  final Map<String, bool> _expanded = {};
 
   PdfEditingController get _controller => widget.controller;
 
@@ -325,10 +337,35 @@ class _PdfAnnotationPropertiesPanelState
     }
   }
 
-  Widget _section(String title) => Padding(
-        padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
-        child: Text(title, style: Theme.of(context).textTheme.labelLarge),
-      );
+  /// A collapsible titled group of property rows. Tapping the header toggles
+  /// [_expanded] for [id]; groups start expanded. Grouping keeps the panel
+  /// legible as it fills up - a collapsed group hides its rows and just
+  /// leaves its header behind.
+  Widget _group(String id, String title, List<Widget> children) {
+    final expanded = _expanded[id] ?? true;
+    final scheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        InkWell(
+          key: ValueKey('pdf-prop-section-$id'),
+          onTap: () => setState(() => _expanded[id] = !expanded),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 8, 4),
+            child: Row(children: [
+              Expanded(
+                child: Text(title,
+                    style: Theme.of(context).textTheme.labelLarge),
+              ),
+              Icon(expanded ? Icons.expand_more : Icons.chevron_right,
+                  size: 20, color: scheme.onSurfaceVariant),
+            ]),
+          ),
+        ),
+        if (expanded) ...children,
+      ],
+    );
+  }
 
   Widget _swatchRow(String label, Color? color,
       {required Key key,
@@ -520,7 +557,6 @@ class _PdfAnnotationPropertiesPanelState
     ];
     final style = _controller.selectedAnnotationStyle;
     if (style == null) return children;
-    children.add(_section(pdfL10n(context).propSectionAppearance));
     // An image stamp (a pasted picture) has no tintable colour - only its
     // opacity applies - so the swatch is hidden for it while opacity stays.
     if (_allSelected((behavior) => behavior.supportsColor)) {
@@ -669,7 +705,6 @@ class _PdfAnnotationPropertiesPanelState
     final border = annotation.behavior.style.borderColor;
     final borderColor = border == null ? null : Color(0xFF000000 | border);
     return [
-      _section(pdfL10n(context).propSectionText),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         child: Row(children: [
@@ -803,7 +838,6 @@ class _PdfAnnotationPropertiesPanelState
     final style = _controller.selectedFormFieldStyle;
     if (name == null || style == null) return const [];
     return [
-      _section(pdfL10n(context).propSectionText),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         child: Row(children: [
@@ -888,31 +922,38 @@ class _PdfAnnotationPropertiesPanelState
 
   List<Widget> _buildSingle(PdfAnnotation annotation) {
     final slot = _controller.selectedAnnotationSlot!;
-    return [
+    final l = pdfL10n(context);
+    final sections = <Widget>[
       ListTile(
         leading: Icon(annotation.isCallout
             ? Icons.chat_bubble_outline
             : pdfAnnotationIcon(annotation.subtype)),
         title: Text(annotation.isCallout
-            ? pdfL10n(context).propCallout
+            ? l.propCallout
             : pdfAnnotationLabel(context, annotation.subtype)),
-        subtitle: Text(pdfL10n(context).propPageNumber(slot.$1 + 1)),
+        subtitle: Text(l.propPageNumber(slot.$1 + 1)),
       ),
-      ..._styleControls(),
-      ..._textStyleControls(annotation),
-      // a form widget's /T is its field name, not an author, and /V (not
-      // /Contents) is its value - so widgets get a "Field name" row instead
-      // of the generic Contents/Author section
-      if (annotation.subtype == 'Widget') ...[
-        if (_controller.selectedWidgetFieldName != null) ...[
-          _section(pdfL10n(context).propSectionFormField),
-          _textRow(pdfL10n(context).propFieldName, _fieldName,
+    ];
+
+    void addGroup(String id, String title, List<Widget> rows) {
+      if (rows.isNotEmpty) sections.add(_group(id, title, rows));
+    }
+
+    addGroup('appearance', l.propSectionAppearance, _styleControls());
+    addGroup('text', l.propSectionText, _textStyleControls(annotation));
+    // a form widget's /T is its field name, not an author, and /V (not
+    // /Contents) is its value - so widgets get a "Field name" group instead
+    // of the generic Contents/Author group
+    if (annotation.subtype == 'Widget') {
+      if (_controller.selectedWidgetFieldName != null) {
+        addGroup('form-field', l.propSectionFormField, [
+          _textRow(l.propFieldName, _fieldName,
               key: const ValueKey('pdf-prop-field-name'),
               onCommit: _commitFieldName),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             child: Row(children: [
-              Expanded(child: Text(pdfL10n(context).propType)),
+              Expanded(child: Text(l.propType)),
               PdfSelectedFormFieldTypeMenu(
                 controller: _controller,
                 buttonKey: const ValueKey('pdf-prop-form-type'),
@@ -921,46 +962,45 @@ class _PdfAnnotationPropertiesPanelState
               ),
             ]),
           ),
-        ],
-        ..._formFieldControls(),
-      ] else ...[
-        ..._formFieldControls(),
-        _section(pdfL10n(context).propSectionContent),
-        _textRow(pdfL10n(context).propContents, _contents,
+        ]);
+      }
+      addGroup('form-text', l.propSectionText, _formFieldControls());
+    } else {
+      addGroup('form-text', l.propSectionText, _formFieldControls());
+      addGroup('content', l.propSectionContent, [
+        _textRow(l.propContents, _contents,
             key: const ValueKey('pdf-prop-contents'),
             onCommit: _commitContents,
             maxLines: 4),
         if (widget.showAuthor)
-          _textRow(pdfL10n(context).propAuthor, _author,
+          _textRow(l.propAuthor, _author,
               key: const ValueKey('pdf-prop-author'), onCommit: _commitAuthor),
-      ],
-      _section(pdfL10n(context).propSectionPositionSize),
+      ]);
+    }
+    addGroup('position-size', l.propSectionPositionSize, [
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         child: Row(children: [
-          _geometryField(pdfL10n(context).propGeometryX, _x,
-              const ValueKey('pdf-prop-x'),
+          _geometryField(l.propGeometryX, _x, const ValueKey('pdf-prop-x'),
               enabled: true),
           const SizedBox(width: 8),
-          _geometryField(pdfL10n(context).propGeometryY, _y,
-              const ValueKey('pdf-prop-y'),
+          _geometryField(l.propGeometryY, _y, const ValueKey('pdf-prop-y'),
               enabled: true),
         ]),
       ),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         child: Row(children: [
-          _geometryField(pdfL10n(context).propGeometryWidth, _w,
-              const ValueKey('pdf-prop-w'),
+          _geometryField(l.propGeometryWidth, _w, const ValueKey('pdf-prop-w'),
               enabled: _controller.canResizeSelected),
           const SizedBox(width: 8),
-          _geometryField(pdfL10n(context).propGeometryHeight, _h,
-              const ValueKey('pdf-prop-h'),
+          _geometryField(l.propGeometryHeight, _h, const ValueKey('pdf-prop-h'),
               enabled: _controller.canResizeSelected),
         ]),
       ),
-      const SizedBox(height: 16),
-    ];
+    ]);
+    sections.add(const SizedBox(height: 16));
+    return sections;
   }
 
   List<Widget> _buildMulti(int count) {
@@ -975,28 +1015,36 @@ class _PdfAnnotationPropertiesPanelState
       for (final (page, _) in _controller.selectedAnnotationSlots) page + 1,
     ]);
     final hasWidget = annotations.any((a) => a.subtype == 'Widget');
-    return [
+    final l = pdfL10n(context);
+    final sections = <Widget>[
       ListTile(
         leading: const Icon(Icons.select_all),
-        title: Text(pdfL10n(context).propAnnotationCount(count)),
-        subtitle: Text(pdfL10n(context).propEditsApplyToAll),
+        title: Text(l.propAnnotationCount(count)),
+        subtitle: Text(l.propEditsApplyToAll),
       ),
-      _section(pdfL10n(context).propSectionSelection),
+    ];
+
+    void addGroup(String id, String title, List<Widget> rows) {
+      if (rows.isNotEmpty) sections.add(_group(id, title, rows));
+    }
+
+    addGroup('selection', l.propSectionSelection, [
       _readOnlyRow(
-        pdfL10n(context).propType,
-        type.varies ? pdfL10n(context).propVaries : type.value,
+        l.propType,
+        type.varies ? l.propVaries : type.value,
         const ValueKey('pdf-prop-type-value'),
       ),
       _readOnlyRow(
-        pdfL10n(context).propPageLabel,
-        page.varies ? pdfL10n(context).propVaries : '${page.value}',
+        l.propPageLabel,
+        page.varies ? l.propVaries : '${page.value}',
         const ValueKey('pdf-prop-page-value'),
       ),
-      ..._styleControls(),
-      if (!hasWidget) ...[
-        _section(pdfL10n(context).propSectionContent),
+    ]);
+    addGroup('appearance', l.propSectionAppearance, _styleControls());
+    if (!hasWidget) {
+      addGroup('content', l.propSectionContent, [
         _textRow(
-          pdfL10n(context).propContents,
+          l.propContents,
           _contents,
           key: const ValueKey('pdf-prop-contents'),
           onCommit: _commitContents,
@@ -1006,16 +1054,17 @@ class _PdfAnnotationPropertiesPanelState
         ),
         if (widget.showAuthor)
           _textRow(
-            pdfL10n(context).propAuthor,
+            l.propAuthor,
             _author,
             key: const ValueKey('pdf-prop-author'),
             onCommit: _commitAuthor,
             enabled: _controller.canSetSelectedAuthor,
             varies: _authorVaries,
           ),
-      ],
-      const SizedBox(height: 16),
-    ];
+      ]);
+    }
+    sections.add(const SizedBox(height: 16));
+    return sections;
   }
 
   @override

--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -628,6 +628,56 @@ void main() {
       );
     });
 
+    testWidgets('a section header collapses and re-expands its rows',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 600, 220, 660));
+      addTearDown(editing.dispose);
+      await pumpPanel(tester, editing);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      // groups start expanded, so the position rows are visible
+      final header = find.byKey(const ValueKey('pdf-prop-section-position-size'));
+      expect(header, findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-prop-x')), findsOneWidget);
+
+      // collapsing the group hides its rows but keeps the header
+      await tester.tap(header);
+      await tester.pump();
+      expect(header, findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-prop-x')), findsNothing);
+
+      // and re-expanding brings them back
+      await tester.tap(header);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-prop-x')), findsOneWidget);
+    });
+
+    testWidgets('a collapsed group stays collapsed across selection changes',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 600, 220, 660))
+        ..addEllipse(0, const PdfRect(250, 600, 350, 660));
+      addTearDown(editing.dispose);
+      await pumpPanel(tester, editing);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      await tester
+          .tap(find.byKey(const ValueKey('pdf-prop-section-appearance')));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-prop-stroke')), findsNothing);
+
+      // selecting a different annotation keeps the group collapsed - the
+      // choice is per-group, not per-annotation
+      editing.selectAnnotation(0, 1);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-prop-section-appearance')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-prop-stroke')), findsNothing);
+    });
+
     testWidgets('the dragged width persists as a preference', (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));
       addTearDown(editing.dispose);


### PR DESCRIPTION
## Summary

The annotation properties panel (`PdfAnnotationPropertiesPanel`) had grown a long flat scroll of rows split only by plain section labels. As free-text and form-field controls piled up under one selection, it got busy — so the sections are now real **collapsible groups**: tap a header to fold a group away and keep the panel legible.

- Replaced the label-only `_section(title)` helper with `_group(id, title, children)`: a header row (label + expand/collapse chevron) wrapping its rows. Collapsing drops the rows from the tree and leaves only the header (`if (expanded) ...children`).
- Fold state lives in a `Map<String, bool> _expanded` on the panel State, keyed by a stable group id and **defaulting to open**. It is per-group (not per-annotation), so a collapsed group stays collapsed across selection changes — held for the panel's lifetime, not persisted to preferences (a lighter first cut).
- `_buildSingle`/`_buildMulti` now assemble the layout through a local `addGroup(id, title, rows)` closure that skips empty groups, instead of splicing headers into one flat list. The style sub-builders (`_styleControls`, `_textStyleControls`, `_formFieldControls`) return just their body rows now.

Row keys, commit paths, and slider/geometry behaviour are unchanged — only the enclosing layout moved. Section header keys are `pdf-prop-section-<id>`.

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [x] Editing behavior change
- [x] Refactor / cleanup

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Ran `editing_properties_test.dart` (now 23, including two new collapse/expand tests), plus `editing_form_style_test.dart`, `editing_line_endings_test.dart`, and `pdf_shell_test.dart` — all green. Analyze clean. Pure-Dart package tests and corpus suites are unaffected (UI-only change).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

Groups default to expanded, so every existing widget test (which builds the panel on a tall surface and finds rows by key without expanding) passes untouched. A future test that collapses a group first must re-expand before probing its rows. Fold state is intentionally in-memory only for this first cut; persisting it to `PdfEditingPreferences` would be a straightforward follow-up if desired. Dev-log: `doc/dev-log/2026-07-23-properties-panel-grouping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmN8rLoSinkzyD4PHTAtsh)_