### PR TITLE
perf(cos): drop the double copy of every inflated stream (#533)

### DIFF
--- a/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
@@ -15505,7 +15505,7 @@ bL(a,b){var s
 t.L.a(a)
 s=A.vA(32768)
 B.cK.kP(A.oL(a,B.aG,null,null),s,!1,!1)
-return A.rS(new Uint8Array(A.I(s.ho())),b)}}
+return A.rS(s.ho(),b)}}
 A.ks.prototype={
 fh(b2){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0=this,b1=A.aH(b2)
 for(s=b2.length,r=t.t,q=b0.b,p=b0.a,o=p*q,n=b0.e,m=b0.d,l=b0.c,k=0;k+11<=s;k=a1){j=b1.getUint32(k,!1)

--- a/packages/pdf_cos/lib/src/filters/flate.dart
+++ b/packages/pdf_cos/lib/src/filters/flate.dart
@@ -11,7 +11,9 @@ class FlateFilter extends CosFilter {
 
   @override
   Uint8List decode(Uint8List data, CosDictionary? params) {
-    final inflated = Uint8List.fromList(const ZLibDecoder().decodeBytes(data));
+    // decodeBytes already returns a Uint8List; copying it again would double
+    // the allocation for every inflated stream in the document (#533).
+    final inflated = const ZLibDecoder().decodeBytes(data);
     return applyPredictor(inflated, params);
   }
 }

--- a/packages/pdf_document/lib/src/png.dart
+++ b/packages/pdf_document/lib/src/png.dart
@@ -78,8 +78,8 @@ class PngImage {
       throw ArgumentError('unsupported PNG bit depth $bitDepth');
     }
 
-    final raw =
-        Uint8List.fromList(const ZLibDecoder().decodeBytes(idat.takeBytes()));
+    // decodeBytes already returns a freshly allocated Uint8List (#533).
+    final raw = const ZLibDecoder().decodeBytes(idat.takeBytes());
 
     // raw channel data, 8 bits per channel, full image. Palette indices
     // must stay verbatim - only real samples scale to 0–255.


### PR DESCRIPTION
Fixes #533.

`ZLibDecoder.decodeBytes` (archive 4.x) already returns a freshly allocated
`Uint8List`, so wrapping it in `Uint8List.fromList` copied **every inflated
stream in the stack** — content streams, fonts, xref streams, functions,
ToUnicode — a second time. This PR drops the copy at both call sites:

- `pdf_cos` `FlateFilter.decode` (the universal path)
- `pdf_document` `png.dart` IDAT inflate (same pattern)

PDFium's `FlateUncompress` preallocates and stitches with exactly one final
copy; this brings us to parity on copy count for the common case.

No behavioural change: the decoded buffer is fresh (no aliasing), and the
predictor/unfilter stages operate on it exactly as before.

## Measurements (`tool/perf.sh diff main <scenario>`, 4 interleaved runs, per-file median ratios)

**dartpdf-corpus** (14 files) — VERDICT OK:
| metric | ratio vs main |
|---|---|
| interpretMs | **0.957x** |
| peakRssBytes | **0.944x** |
| extractMs | 0.980x |
| firstPageMs | 0.998x |
| openMs | 1.010x |
| saveMs | 1.038x |

**ghent-suite-open** (54 files) — VERDICT OK, all metrics flat within noise
(openMs 1.028x, interpretMs 0.995x, peakRssBytes 0.998x); perf targets PASS.

The VM-side win is modest because native zlib dominates decode time there;
the removed copy mainly buys allocation/GC headroom, which is worth most
under dart2js (the ticket's framing). No regression anywhere.

## Testing

- `fvm dart analyze` — clean
- `packages/pdf_cos` + `packages/pdf_document` full test suites — pass
- `tool/perf.sh gate` — 12 inputs, 13 counters within 3% (no counter shift:
  the change removes an allocation, not a counted operation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
