### PR TITLE
perf(cos): int-key the loaded-object cache so warm resolves allocate nothing (#522)

### DIFF
--- a/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
@@ -3729,7 +3729,7 @@ this.b=b},
 lE:function lE(a){this.a=a},
 lG:function lG(a){this.a=a},
 q9(a,b,c,d,e){var s=t.S
-return new A.hl(a,b,c,d,A.w(t.md,t.l),new A.d2(t.l9),A.w(s,t.c4),A.w(t.nv,t.p),A.aQ(s))},
+return new A.hl(a,b,c,d,A.w(s,t.l),new A.d2(t.l9),A.w(s,t.c4),A.w(t.nv,t.p),A.aQ(s))},
 uX(a,b){var s,r,q,p,o,n,m,l=A.cG()
 try{p=a.length
 o=A.rA(a,"%PDF-",0,p<1024?p:1024)
@@ -15112,30 +15112,31 @@ p.z=A.wc(m,q,a,p.ghg())},
 gce(){var s=this.j(this.d.a.h(0,"Root"))
 if(!(s instanceof A.q))throw A.d(A.D("document has no /Root catalog",null))
 return s},
-by(a,b){var s,r,q,p,o,n,m,l,k=this,j=new A.au(a,b),i=k.f,h=i.h(0,j)
-if(h!=null)return h
-s=k.c.h(0,a)
+by(a,b){var s,r,q,p,o,n,m,l,k,j=this,i=a*65536+b,h=j.f,g=h.h(0,i)
+if(g!=null)return g
+s=j.c.h(0,a)
 if(s==null)return B.n
-o=k.as
+o=j.as
 if(!o.i(0,a))return B.n
 A.bD(B.bP,1)
 r=null
 try{switch(s.a.a){case 0:r=B.n
 break
-case 1:n=k.fe(s.b,a)
-q=n==null?k.jx(a):n
+case 1:n=j.fe(s.b,a)
+q=n==null?j.jx(a):n
 if(q==null)r=B.n
 else{r=q.c
-m=k.z
-if(m!=null&&a!==k.Q)m.cR(r,a,q.b)}break
+m=j.z
+if(m!=null&&a!==j.Q)m.cR(r,a,q.b)}break
 case 2:p=null
-try{p=k.f8(s.d).lf(a,s.e)}catch(l){m=A.J(l)
+try{p=j.f8(s.d).lf(a,s.e)}catch(l){m=A.J(l)
 if(t.I.b(m))p=B.n
 else if(t.b0.b(m))p=B.n
 else throw l}r=p
-break}}finally{o.aN(0,a)}if(r instanceof A.z)r.c=j
-i.k(0,j,r)
-k.r.k(0,r,j)
+break}}finally{o.aN(0,a)}k=new A.au(a,b)
+if(r instanceof A.z)r.c=k
+h.k(0,i,r)
+j.r.k(0,r,k)
 return r},
 fe(a,b){var s,r,q,p
 try{s=new A.c1(new A.bL(this.a,a+this.b),this.gfs(),A.b([],t.O))

--- a/packages/pdf_cos/lib/src/document.dart
+++ b/packages/pdf_cos/lib/src/document.dart
@@ -33,7 +33,10 @@ class CosDocument {
   /// `startxref` keyword. An incremental update points /Prev here.
   int startXref;
 
-  final Map<CosReference, CosObject> _cache = {};
+  // Loaded-object cache keyed by the packed (objectNumber, generation) int
+  // (see [_cacheKey]) so [getObject] - the hottest path in the package -
+  // resolves a warm object without allocating a CosReference per call (#522).
+  final Map<int, CosObject> _cache = {};
   // Identity-keyed reverse index of [_cache]: object -> the ref it loaded
   // under. Keeps [referenceTo] O(1) instead of a linear scan of the cache on
   // every call (editing code maps a mutated object back to its number per
@@ -183,9 +186,13 @@ class CosDocument {
 
     // Drop cached state for every redefined object so the next resolve re-reads
     // it from the appended bytes; untouched objects keep their warm cache.
-    _cache.removeWhere((ref, obj) {
-      if (!changed.contains(ref.objectNumber)) return false;
-      if (identical(_reverseCache[obj], ref)) _reverseCache.remove(obj);
+    _cache.removeWhere((key, obj) {
+      if (!changed.contains(key ~/ 65536)) return false;
+      final reverse = _reverseCache[obj];
+      if (reverse != null &&
+          _cacheKey(reverse.objectNumber, reverse.generation) == key) {
+        _reverseCache.remove(obj);
+      }
       return true;
     });
     _objectStreams.removeWhere((number, _) => changed.contains(number));
@@ -467,14 +474,21 @@ class CosDocument {
   /// pending update is saved. [CosIncrementalUpdater.addObject] calls this
   /// for every object it allocates.
   void adoptObject(CosReference ref, CosObject object) {
-    _cache[ref] = object;
+    _cache[_cacheKey(ref.objectNumber, ref.generation)] = object;
     _reverseCache[object] = ref;
   }
 
+  /// Packs (objectNumber, generation) into one int cache key. Generations
+  /// are at most 65535 (a 5-digit xref field), and object numbers stay far
+  /// below 2^37, so the product fits dart2js's 53 safe bits. Multiplication,
+  /// not `<< 16`: JS bitwise shifts truncate to 32 bits under dart2js.
+  static int _cacheKey(int objectNumber, int generation) =>
+      objectNumber * 65536 + generation;
+
   /// Loads an object by number, parsing it on first access.
   CosObject getObject(int objectNumber, int generation) {
-    final ref = CosReference(objectNumber, generation);
-    final cached = _cache[ref];
+    final key = _cacheKey(objectNumber, generation);
+    final cached = _cache[key];
     if (cached != null) return cached;
 
     final entry = _xref[objectNumber];
@@ -536,11 +550,14 @@ class CosDocument {
     } finally {
       _loadingObjects.remove(objectNumber);
     }
+    // The CosReference materializes only on this miss path - a warm resolve
+    // above returns without allocating one (#522).
+    final ref = CosReference(objectNumber, generation);
     // Record the ref every loaded stream was parsed from: its encryption
     // key derives from it, and its presence marks the payload as still the
     // file's original bytes (see [CosStream.sourceRef]).
     if (result is CosStream) result.sourceRef = ref;
-    _cache[ref] = result;
+    _cache[key] = result;
     _reverseCache[result] = ref;
     return result;
   }


### PR DESCRIPTION
Fixes #522.

`CosDocument.getObject` — the hottest path in pdf_cos — allocated a fresh
`CosReference` (plus its `Object.hash`) on **every** resolve just to probe the
cache, warm or cold. PDFium keys its parsed-object cache by integer object
number and allocates nothing per lookup.

This PR int-keys the cache:

- `_cache` becomes `Map<int, CosObject>` keyed by
  `objectNumber * 65536 + generation` (generations cap at 65535 — a 5-digit
  xref field — and object numbers stay far below 2³⁷, so the product sits
  within dart2js's 53 safe integer bits; multiplication rather than `<< 16`
  because JS bitwise shifts truncate to 32 bits).
- A warm `getObject` now allocates nothing; the `CosReference` materializes
  only on the miss path, where it is still needed for `CosStream.sourceRef`
  and the `_reverseCache` (which keeps its `CosReference` values —
  `referenceTo`'s contract is unchanged).
- `adoptObject` and the incremental-append `removeWhere` invalidation pack
  the same key; the reverse-cache lockstep is preserved (the identity check
  becomes a packed-key equality check, same semantics).

## Measurements (`tool/perf.sh diff main <scenario>`, 4 interleaved runs, per-file median ratios)

**ghent-suite-open** (54 files, the reliable aggregate) — VERDICT OK:
| metric | ratio vs main |
|---|---|
| openMs | **0.984x** |
| interpretMs | **0.982x** |
| extractMs | **0.983x** |
| firstPageMs | 1.013x |
| saveMs | 1.007x |
| peakRssBytes | 0.999x |

**cad-138p-sweep** (1 file, sub-ms medians — noisy): run 1 flagged
firstPageMs 1.135x / saveMs 1.157x while simultaneously showing openMs
0.877x improved; run 2 came back all-improved (openMs 0.651x, firstPageMs
0.440x, interpretMs 0.844x, VERDICT OK). The two runs disagree far beyond
the change's possible effect, so the single-file scenario is noise-bound at
these absolute times (~2–6 ms medians); the 54-file ghent aggregate is the
signal: a small consistent win, no regression.

As with #533, the allocation savings matter most under dart2js GC pressure,
which the VM sweep can't see.

## Testing

- `fvm dart analyze` — clean
- `packages/pdf_cos` (340 tests) + `packages/pdf_document` suites — pass
- `tool/perf.sh gate` — 12 inputs, 13 counters within 3%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
