### PR TITLE
perf(graphics): adaptively subdivide Coons/tensor mesh patches (#536)

### DIFF
--- a/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
@@ -320,7 +320,7 @@ if(typeof a=="string")return JSON.stringify(a)
 if(a instanceof A.aX)return a.m(0)
 if(a instanceof A.aR)return a.fW(!0)
 s=$.uq()
-for(r=0;r<1;++r){q=s[r].lQ(a)
+for(r=0;r<1;++r){q=s[r].lR(a)
 if(q!=null)return q}return"Instance of '"+A.iq(a)+"'"},
 wn(){return Date.now()},
 wp(){var s,r
@@ -659,7 +659,7 @@ if(b instanceof A.dL){s=b.gfn()
 s.lastIndex=0
 return a.replace(s,A.te(c))}return A.zn(a,b,c)},
 zn(a,b,c){var s,r,q,p
-for(s=J.q2(b,a),s=s.gV(s),r=0,q="";s.u();){p=s.gF()
+for(s=J.q2(b,a),s=s.gV(s),r=0,q="";s.u();){p=s.gG()
 q=q+a.substring(r,p.gdn())+c
 r=p.gd6()}s=q+a.substring(r)
 return s.charCodeAt(0)==0?s:s},
@@ -2043,7 +2043,7 @@ return q},
 ai(a,b){var s,r
 if(Array.isArray(a))return A.b(a.slice(0),b.l("o<0>"))
 s=A.b([],b.l("o<0>"))
-for(r=J.b8(a);r.u();)B.a.i(s,r.gF())
+for(r=J.b8(a);r.u();)B.a.i(s,r.gG())
 return s},
 vF(a,b,c){var s,r=J.kD(a,c)
 for(s=0;s<a;++s)B.a.k(r,s,b.$1(s))
@@ -2071,9 +2071,9 @@ return A.wr(a,b,c==null||c>s?s:c)},
 c2(a){return new A.dL(a,A.qy(a,!1,!0,!1,!1,""))},
 rb(a,b,c){var s=J.b8(b)
 if(!s.u())return a
-if(c.length===0){do a+=A.v(s.gF())
-while(s.u())}else{a+=A.v(s.gF())
-while(s.u())a=a+c+A.v(s.gF())}return a},
+if(c.length===0){do a+=A.v(s.gG())
+while(s.u())}else{a+=A.v(s.gG())
+while(s.u())a=a+c+A.v(s.gG())}return a},
 wv(){return A.cv(new Error())},
 hA(a){if(typeof a=="number"||A.bz(a)||a==null)return J.d_(a)
 if(typeof a=="string")return JSON.stringify(a)
@@ -2118,19 +2118,19 @@ return r.charCodeAt(0)==0?r:r},
 yc(a,b){var s,r,q,p,o,n,m,l=a.gV(a),k=0,j=0
 for(;;){if(!(k<80||j<3))break
 if(!l.u())return
-s=A.v(l.gF())
+s=A.v(l.gG())
 B.a.i(b,s)
 k+=s.length+2;++j}if(!l.u()){if(j<=5)return
 if(0>=b.length)return A.a(b,-1)
 r=b.pop()
 if(0>=b.length)return A.a(b,-1)
-q=b.pop()}else{p=l.gF();++j
+q=b.pop()}else{p=l.gG();++j
 if(!l.u()){if(j<=4){B.a.i(b,A.v(p))
 return}r=A.v(p)
 if(0>=b.length)return A.a(b,-1)
 q=b.pop()
-k+=r.length+2}else{o=l.gF();++j
-for(;l.u();p=o,o=n){n=l.gF();++j
+k+=r.length+2}else{o=l.gG();++j
+for(;l.u();p=o,o=n){n=l.gG();++j
 if(j>100){for(;;){if(!(k>75&&j>3))break
 if(0>=b.length)return A.a(b,-1)
 k-=b.pop().length+2;--j}B.a.i(b,"...")
@@ -2445,8 +2445,8 @@ e=j/p
 d=i/f
 c=new A.lu(b9,e)
 b=new A.lv(b9,d)
-a=B.c.G(p*0.25)
-a0=B.c.G(b9.d*0.25)
+a=B.c.F(p*0.25)
+a0=B.c.F(b9.d*0.25)
 a1=b9.c*b9.d
 a2=new Int32Array(a1)
 a3=A.b([],t.t)
@@ -2524,7 +2524,7 @@ d=a5
 if(s){c=a9.a
 e=a9.b
 d=a9.c}else c=a5
-if(s){for(s=J.b8(c),b=a5;s.u();){a=A.tu(s.gF())
+if(s){for(s=J.b8(c),b=a5;s.u();){a=A.tu(s.gG())
 if(a!=null)b=b==null?a:A.t_(b,a)}if(b==null||e.length===0)return a5
 s=e.length
 if(0>=s)return A.a(e,0)
@@ -2777,7 +2777,7 @@ _.r=_.f=_.e=_.d=_.c=0
 _.x=!1
 _.y=null},
 oy(a){var s,r,q
-for(s=J.b8(a),r=0;s.u();){q=s.gF();++r
+for(s=J.b8(a),r=0;s.u();){q=s.gG();++r
 if(q instanceof A.aF)r+=A.oy(q.c)
 else if(q instanceof A.b1)r+=A.oy(q.a)}return r},
 yT(a,b){var s,r,q,p={}
@@ -2818,7 +2818,7 @@ a.postMessage(r,A.b([s],t.f))},
 rF(a,b,c){var s,r
 if(b==null||c==null)return
 s=$.dg
-if(s){a.cosStats=B.cC.la(A.wj().hB(),null)
+if(s){a.cosStats=B.cC.lb(A.wj().hB(),null)
 A.wi()}a.workerUs=c
 a.parseUs=0
 a.interpretUs=b.d
@@ -2999,7 +2999,7 @@ var $async$ee=A.aW(function(a3,a4){if(a3===1)return A.aS(a4,r)
 for(;;)switch(s){case 0:b=A.b([],t.A)
 p=J.b8(a0),o=!1
 case 3:if(!p.u()){s=4
-break}n=p.gF()
+break}n=p.gG()
 if(a1.a)throw A.d(new A.cG())
 m=n instanceof A.be
 l=m?n.a:null
@@ -3704,7 +3704,7 @@ for(m=0;m<64;m=l){o=p.length
 l=m+1
 B.d.D(n,m*o,l*o,p)}p=s.length
 o=new Uint8Array(s.subarray(0,A.h3(0,16,p)))
-r=new A.ha((o.length/4|0)+6,A.q7(o)).kT(new Uint8Array(s.subarray(16,A.h3(16,32,p))),n)
+r=new A.ha((o.length/4|0)+6,A.q7(o)).kU(new Uint8Array(s.subarray(16,A.h3(16,32,p))),n)
 for(p=r.length,k=0,m=0;m<16;++m){if(!(m<p))return A.a(r,m)
 k+=r[m]}j=B.b.am(k,3)
 A:{if(0===j){f.a(r)
@@ -3776,7 +3776,7 @@ v9(a,b){var s,r,q,p=A.cJ()
 try{r=a.length
 q=A.yh(a,"startxref",r>2048?r-2048:0)
 if(q<0)A.Q(A.C("missing startxref",null))
-s=new A.ke(a,b).lS(new A.ca(new A.bN(a,q+9),null,A.b([],t.O)).el())
+s=new A.ke(a,b).lT(new A.ca(new A.bN(a,q+9),null,A.b([],t.O)).el())
 r=A.qn(a,b,s.a,s.b,s.c)
 return r}finally{A.cK(B.bX,p)}},
 va(a,b,c){var s,r=A.cJ()
@@ -4125,7 +4125,7 @@ B.a.R(s,g)
 B.a.bZ(s,new A.kH())
 r=A.cR(d,e,0)
 for(q=0,p=0;p<e;++p){if(h){q=(q^a.aj(b,c,B.dN[f]))>>>0
-if(q===1){r.kV(p)
+if(q===1){r.kW(p)
 continue}}for(o=0;o<d;++o){for(n=s.length,m=0,l=0;l<s.length;s.length===n||(0,A.j)(s),++l){k=s[l]
 m=(m<<1|r.a1(o+k.a,p+k.b))>>>0}if(a.aj(b,c,m)!==0)r.cz(o,p,1)}}return r},
 vu(a,b,c,d,e,f,g,a0,a1){var s,r,q,p,o,n,m,l,k,j,i,h=A.cR(d,e,0)
@@ -4746,7 +4746,7 @@ if(!(j instanceof A.q)||j.a.length===0)return l
 s=j.a
 if(0>=s.length)return A.a(s,0)
 r=k.j(s[0])
-if(r instanceof A.r){q=a.gjt().h(0,r)
+if(r instanceof A.r){q=a.gju().h(0,r)
 if(q==null)q=-1}else if(r instanceof A.m)q=r.a
 else return l
 if(q<0)return l
@@ -6114,7 +6114,7 @@ s=new A.nj(a6)
 r=new A.nh(s)
 q=new A.ng(a6)
 p=new A.ni(a6)
-for(o=J.b8(a5),n=a7+1,m=t.ez,l=a6.$flags|0;o.u();){k=o.gF()
+for(o=J.b8(a5),n=a7+1,m=t.ez,l=a6.$flags|0;o.u();){k=o.gG()
 if(typeof k=="number"){B.a.i(a6,k)
 continue}if(m.b(k)){B.a.i(a6,k)
 continue}A.ab(k)
@@ -6965,8 +6965,8 @@ return B.b.n(B.c.v((a*s+b*e)*(1-f)+(c*s+d*e)*f),0,255)},
 o2(a,b,c,d,e){var s,r,q,p,o
 if(a<1||b<1)return new A.i(a,b)
 if(!(e>0)||!(c>0)||!(d>0))return new A.i(a,b)
-s=B.c.G(c*e*2)
-r=B.c.G(d*e*2)
+s=B.c.F(c*e*2)
+r=B.c.F(d*e*2)
 if(s>=a&&r>=b)return new A.i(a,b)
 if(s>a)s=a
 if(r>b)r=b
@@ -8244,7 +8244,7 @@ b=o.f
 a=c-3*e+3*g-i
 a0=b-3*d+3*f-h
 a1=Math.sqrt(3)/36*Math.sqrt(a*a+a0*a0)
-a2=a1<=0.001?1:B.b.n(B.c.G(Math.pow(a1/0.001,0.3333333333333333)),1,64)
+a2=a1<=0.001?1:B.b.n(B.c.F(Math.pow(a1/0.001,0.3333333333333333)),1,64)
 a3=new A.oj(i,g,e,c)
 a4=new A.ok(h,f,d,b)
 a5=new A.om(g,i,e,c)
@@ -8296,7 +8296,7 @@ a5=n.b
 m=n.d
 l=n.f
 d=B.c.U((Math.min(a5,Math.min(m,l))-r)/j)
-c=B.c.G((Math.max(a5,Math.max(m,l))-r)/j)-1
+c=B.c.F((Math.max(a5,Math.max(m,l))-r)/j)-1
 if(d<0)d=0
 if(c>=a7)c=f
 for(b=d;b<=c;++b){if(!(b<h.length))return A.a(h,b)
@@ -8304,7 +8304,7 @@ B.a.i(h[b],e)}a5=n.a
 m=n.c
 l=n.e
 a=B.c.U((Math.min(a5,Math.min(m,l))-s)/i)
-a0=B.c.G((Math.max(a5,Math.max(m,l))-s)/i)-1
+a0=B.c.F((Math.max(a5,Math.max(m,l))-s)/i)-1
 if(a<0)a=0
 if(a0>=a7)a0=f
 for(b=a;b<=a0;++b){if(!(b<g.length))return A.a(g,b)
@@ -8472,7 +8472,7 @@ a5=d.f
 b0=o*a4+n*a5+m
 b1=l*a4+k*a5+j
 b2=Math.max(Math.max(Math.abs(g-2*a6+a8),Math.abs(f-2*a7+a9)),Math.max(Math.abs(a6-2*a8+b0),Math.abs(a7-2*a9+b1)))
-b3=b2<=c6?1:B.b.n(B.c.G(Math.sqrt(3*b2/p)),1,128)
+b3=b2<=c6?1:B.b.n(B.c.F(Math.sqrt(3*b2/p)),1,128)
 for(b4=1;b4<=b3;++b4){b5=b4/b3
 b6=1-b5
 b7=b6*b6*b6
@@ -9447,8 +9447,8 @@ rI(a){if(a instanceof A.m)return a.a
 if(a instanceof A.T)return B.c.v(a.a)
 return null},
 rG(a,b,c,d){var s=b.a,r=b.b,q=b.c,p=b.d,o=a.b,n=a.c,m=A.o2(o,n,Math.sqrt(s*s+r*r),Math.sqrt(q*q+p*p),c),l=m.a,k=m.b
-if(d<1){l=B.b.n(B.c.G(l*d),1,o)
-k=B.b.n(B.c.G(k*d),1,n)}if(l===o&&k===n)return a
+if(d<1){l=B.b.n(B.c.F(l*d),1,o)
+k=B.b.n(B.c.F(k*d),1,n)}if(l===o&&k===n)return a
 return A.pN(a,l,k)},
 ta(a){var s,r,q=new A.aw()
 $.aC()
@@ -9652,8 +9652,8 @@ q=k.b
 n=A.o2(r,q,p,o,c)
 m=n.a
 l=n.b
-if(d<1){m=B.b.n(B.c.G(m*d),1,r)
-l=B.b.n(B.c.G(l*d),1,q)}if(m===r&&l===q)return null
+if(d<1){m=B.b.n(B.c.F(m*d),1,r)
+l=B.b.n(B.c.F(l*d),1,q)}if(m===r&&l===q)return null
 return new A.i(m,l)},
 rM(b5,b6,b7,b8,b9){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4=A.ps(b5,b6.a)
 if(b4==null)return null
@@ -9690,9 +9690,9 @@ a2=Math.min(b,a)
 a3=Math.max(b,a)
 if(a1<=a0||a3<=a2)return null
 a4=B.b.n(B.c.U(a0*s),0,s-1)
-a5=B.b.n(B.c.G(a1*s),a4+1,s)
+a5=B.b.n(B.c.F(a1*s),a4+1,s)
 a6=B.b.n(B.c.U((1-a3)*r),0,r-1)
-a7=B.b.n(B.c.G((1-a2)*r),a6+1,r)
+a7=B.b.n(B.c.F((1-a2)*r),a6+1,r)
 a8=a5-a4
 a9=a7-a6
 b0=new A.a0(a8/s,0,0,a9/r,a4/s,1-a7/r).a6(q)
@@ -9703,8 +9703,8 @@ k=b0.d
 b1=A.o2(a8,a9,Math.sqrt(p*p+o*o),Math.sqrt(n*n+k*k),b8)
 b2=b1.a
 b3=b1.b
-if(b9<1){b2=B.b.n(B.c.G(b2*b9),1,a8)
-b3=B.b.n(B.c.G(b3*b9),1,a9)}}else{b3=a9
+if(b9<1){b2=B.b.n(B.c.F(b2*b9),1,a8)
+b3=B.b.n(B.c.F(b3*b9),1,a9)}}else{b3=a9
 b2=a8}return new A.ja(b0,a4,a6,a8,a9,b2,b3,!1)},
 nD(a,b,c){var s=c==null?a.d:c
 return new A.c_(a.a,b,a.c,s,a.e,a.f,a.r)},
@@ -9998,7 +9998,7 @@ o=s.getFloat64(a.c+=8,!1)
 n=s.getFloat64(a.c+=8,!1)
 m=s.getFloat64(a.c+=8,!1)
 a.c+=8
-k.push(new A.ci(q,p,new A.L(o,n,m)))}return new A.df(k,a.lk())},
+k.push(new A.ci(q,p,new A.L(o,n,m)))}return new A.df(k,a.ll())},
 yN(a,b){var s,r,q,p,o,n
 a.c1(b.f)
 A.pH(a,b.r)
@@ -10128,7 +10128,7 @@ case 2:s=a.b.getFloat64(a.c,!1)
 a.c+=8
 return new A.m(B.c.M(s))
 case 3:return new A.T(a.L())
-case 4:return new A.N(a.kS(),a.O()===1)
+case 4:return new A.N(a.kT(),a.O()===1)
 case 5:return new A.u(a.c0())
 case 6:r=a.Z()
 q=A.b([],t.q)
@@ -10632,7 +10632,7 @@ R(a,b){var s
 A.aq(a).l("p<1>").a(b)
 a.$flags&1&&A.e(a,"addAll",2)
 if(Array.isArray(b)){this.i1(a,b)
-return}for(s=J.b8(b);s.u();)a.push(s.gF())},
+return}for(s=J.b8(b);s.u();)a.push(s.gG())},
 i1(a,b){var s,r
 t.dG.a(b)
 s=b.length
@@ -10704,8 +10704,8 @@ if(typeof n!=="number")return n.eA()
 if(n>0){a[0]=q
 a[1]=r}return}p=0
 if(n.c.b(null))for(o=0;o<a.length;++o)if(a[o]===void 0){a[o]=null;++p}a.sort(A.eg(b,2))
-if(p>0)this.kl(a,p)},
-kl(a,b){var s,r=a.length
+if(p>0)this.km(a,p)},
+km(a,b){var s,r=a.length
 for(;s=r-1,r>0;r=s)if(a[s]===null){a[s]=void 0;--b
 if(b===0)break}},
 Y(a,b){var s
@@ -10732,7 +10732,7 @@ $iG:1,
 $ip:1,
 $ik:1}
 J.hT.prototype={
-lQ(a){var s,r,q
+lR(a){var s,r,q
 if(!Array.isArray(a))return null
 s=a.$flags|0
 if((s&4)!==0)r="const, "
@@ -10743,7 +10743,7 @@ if(r==="")return q
 return q+" ("+r+"length: "+a.length+")"}}
 J.kE.prototype={}
 J.eo.prototype={
-gF(){var s=this.d
+gG(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 u(){var s,r=this,q=r.a,p=q.length
 if(r.b!==p){q=A.j(q)
@@ -10769,7 +10769,7 @@ M(a){var s
 if(a>=-2147483648&&a<=2147483647)return a|0
 if(isFinite(a)){s=a<0?Math.ceil(a):Math.floor(a)
 return s+0}throw A.d(A.bH(""+a+".toInt()"))},
-G(a){var s,r
+F(a){var s,r
 if(a>=0){if(a<=2147483647){s=a|0
 return a===s?s:s+1}}else if(a>=-2147483648)return a|0
 r=Math.ceil(a)
@@ -10871,7 +10871,7 @@ s=!(s==null?b.e=b.iv():s)}else s=!1
 if(s)return A.b(a.split(b.b),t.s)
 else return this.iS(a,b)}},
 iS(a,b){var s,r,q,p,o,n,m=A.b([],t.s)
-for(s=J.q2(b,a),s=s.gV(s),r=0,q=1;s.u();){p=s.gF()
+for(s=J.q2(b,a),s=s.gV(s),r=0,q=1;s.u();){p=s.gG()
 o=p.gdn()
 n=p.gd6()
 q=n-o
@@ -10902,7 +10902,7 @@ for(s=a,r="";;){if((b&1)===1)r=s+r
 b=b>>>1
 if(b===0)break
 s+=s}return r},
-lw(a,b,c){var s=b-a.length
+lx(a,b,c){var s=b-a.length
 if(s<=0)return a
 return this.a5(c,s)+a},
 dd(a,b){var s=a.indexOf(b,0)
@@ -11021,10 +11021,10 @@ r=p.aG(0,0)
 for(q=1;q<s;++q){r=b.$2(r,p.aG(0,q))
 if(s!==p.gp(p))throw A.d(A.b9(p))}return r}}
 A.fj.prototype={
-gj5(){var s=J.a9(this.a),r=this.c
+gj6(){var s=J.a9(this.a),r=this.c
 if(r==null||r>s)return s
 return r},
-gkB(){var s=J.a9(this.a),r=this.b
+gkC(){var s=J.a9(this.a),r=this.b
 if(r>s)return s
 return r},
 gp(a){var s,r=J.a9(this.a),q=this.b
@@ -11032,8 +11032,8 @@ if(q>=r)return 0
 s=this.c
 if(s==null||s>=r)return r-q
 return s-q},
-aG(a,b){var s=this,r=s.gkB()+b
-if(b<0||r>=s.gj5())throw A.d(A.oY(b,s.gp(0),s,"index"))
+aG(a,b){var s=this,r=s.gkC()+b
+if(b<0||r>=s.gj6())throw A.d(A.oY(b,s.gp(0),s,"index"))
 return J.q5(s.a,r)},
 aP(a,b){var s,r,q=this
 A.fc(b,"count")
@@ -11042,7 +11042,7 @@ r=q.c
 if(r!=null&&s>=r)return new A.es(q.$ti.l("es<1>"))
 return A.dX(q.a,s,r,q.$ti.c)}}
 A.b_.prototype={
-gF(){var s=this.d
+gG(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 u(){var s,r=this,q=r.a,p=J.ac(q),o=p.gp(q)
 if(r.b!==o)throw A.d(A.b9(q))
@@ -11057,10 +11057,10 @@ gp(a){return J.a9(this.a)}}
 A.er.prototype={$iG:1}
 A.eR.prototype={
 u(){var s=this,r=s.b
-if(r.u()){s.a=s.c.$1(r.gF())
+if(r.u()){s.a=s.c.$1(r.gG())
 return!0}s.a=null
 return!1},
-gF(){var s=this.a
+gG(){var s=this.a
 return s==null?this.$ti.y[1].a(s):s},
 $ia7:1}
 A.bd.prototype={
@@ -11070,24 +11070,24 @@ A.fq.prototype={
 gV(a){return new A.fr(J.b8(this.a),this.b,this.$ti.l("fr<1>"))}}
 A.fr.prototype={
 u(){var s,r
-for(s=this.a,r=this.b;s.u();)if(r.$1(s.gF()))return!0
+for(s=this.a,r=this.b;s.u();)if(r.$1(s.gG()))return!0
 return!1},
-gF(){return this.a.gF()},
+gG(){return this.a.gG()},
 $ia7:1}
 A.es.prototype={
 gV(a){return B.ct},
 gp(a){return 0}}
 A.et.prototype={
 u(){return!1},
-gF(){throw A.d(A.bi())},
+gG(){throw A.d(A.bi())},
 $ia7:1}
 A.fs.prototype={
 gV(a){return new A.ft(J.b8(this.a),this.$ti.l("ft<1>"))}}
 A.ft.prototype={
 u(){var s,r
-for(s=this.a,r=this.$ti.c;s.u();)if(r.b(s.gF()))return!0
+for(s=this.a,r=this.$ti.c;s.u();)if(r.b(s.gG()))return!0
 return!1},
-gF(){return this.$ti.c.a(this.a.gF())},
+gG(){return this.$ti.c.a(this.a.gG())},
 $ia7:1}
 A.aZ.prototype={}
 A.dj.prototype={
@@ -11134,7 +11134,7 @@ gp(a){return this.a.length},
 gV(a){var s=this.a
 return new A.fG(s,s.length,this.$ti.l("fG<1>"))}}
 A.fG.prototype={
-gF(){var s=this.d
+gG(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 u(){var s=this,r=s.c
 if(r>=s.b){s.d=null
@@ -11207,7 +11207,7 @@ A.aX.prototype={
 m(a){var s=this.constructor,r=s==null?null:s.name
 return"Closure '"+A.tz(r==null?"unknown":r)+"'"},
 $icc:1,
-glW(){return this},
+glX(){return this},
 $C:"$1",
 $R:1,
 $D:null}
@@ -11236,8 +11236,8 @@ if(typeof a=="string"){s=this.b
 if(s==null)return!1
 return s[a]!=null}else if(typeof a=="number"&&(a&0x3fffffff)===a){r=this.c
 if(r==null)return!1
-return r[a]!=null}else return this.lm(a)},
-lm(a){var s=this.d
+return r[a]!=null}else return this.ln(a)},
+ln(a){var s=this.d
 if(s==null)return!1
 return this.bS(s[this.bR(a)],a)>=0},
 R(a,b){A.D(this).l("bx<1,2>").a(b).ak(0,new A.kM(this))},
@@ -11250,8 +11250,8 @@ return q}else if(typeof b=="number"&&(b&0x3fffffff)===b){p=this.c
 if(p==null)return o
 r=p[b]
 q=r==null?o:r.b
-return q}else return this.ln(b)},
-ln(a){var s,r,q=this.d
+return q}else return this.lo(b)},
+lo(a){var s,r,q=this.d
 if(q==null)return null
 s=q[this.bR(a)]
 r=this.bS(s,a)
@@ -11262,8 +11262,8 @@ p.c.a(b)
 p.y[1].a(c)
 if(typeof b=="string"){s=q.b
 q.eH(s==null?q.b=q.dP():s,b,c)}else if(typeof b=="number"&&(b&0x3fffffff)===b){r=q.c
-q.eH(r==null?q.c=q.dP():r,b,c)}else q.lp(b,c)},
-lp(a,b){var s,r,q,p,o=this,n=A.D(o)
+q.eH(r==null?q.c=q.dP():r,b,c)}else q.lq(b,c)},
+lq(a,b){var s,r,q,p,o=this,n=A.D(o)
 n.c.a(a)
 n.y[1].a(b)
 s=o.d
@@ -11284,8 +11284,8 @@ return r},
 aI(a,b){var s=this
 if(typeof b=="string")return s.fK(s.b,b)
 else if(typeof b=="number"&&(b&0x3fffffff)===b)return s.fK(s.c,b)
-else return s.lo(b)},
-lo(a){var s,r,q,p,o=this,n=o.d
+else return s.lp(b)},
+lp(a){var s,r,q,p,o=this,n=o.d
 if(n==null)return null
 s=o.bR(a)
 r=n[s]
@@ -11358,7 +11358,7 @@ gV(a){var s=this.a
 return new A.aE(s,s.r,s.e,this.$ti.l("aE<1>"))},
 Y(a,b){return this.a.a9(b)}}
 A.aE.prototype={
-gF(){return this.d},
+gG(){return this.d},
 u(){var s,r=this,q=r.a
 if(r.b!==q.r)throw A.d(A.b9(q))
 s=r.c
@@ -11372,7 +11372,7 @@ gp(a){return this.a.a},
 gV(a){var s=this.a
 return new A.d6(s,s.r,s.e,this.$ti.l("d6<1>"))}}
 A.d6.prototype={
-gF(){return this.d},
+gG(){return this.d},
 u(){var s,r=this,q=r.a
 if(r.b!==q.r)throw A.d(A.b9(q))
 s=r.c
@@ -11386,7 +11386,7 @@ gp(a){return this.a.a},
 gV(a){var s=this.a
 return new A.d5(s,s.r,s.e,this.$ti.l("d5<1,2>"))}}
 A.d5.prototype={
-gF(){var s=this.d
+gG(){var s=this.d
 s.toString
 return s},
 u(){var s,r=this,q=r.a
@@ -11422,7 +11422,7 @@ $1(a){return this.a(A.ab(a))},
 $S:81}
 A.aR.prototype={
 m(a){return this.fW(!1)},
-fW(a){var s,r,q,p,o,n=this.jb(),m=this.cM(),l=(a?"Record ":"")+"("
+fW(a){var s,r,q,p,o,n=this.jc(),m=this.cM(),l=(a?"Record ":"")+"("
 for(s=n.length,r="",q=0;q<s;++q,r=", "){l+=r
 p=n[q]
 if(typeof p=="string")l=l+p+": "
@@ -11430,7 +11430,7 @@ if(!(q<m.length))return A.a(m,q)
 o=m[q]
 l=a?l+A.r_(o):l+A.v(o)}l+=")"
 return l.charCodeAt(0)==0?l:l},
-jb(){var s,r=this.$s
+jc(){var s,r=this.$s
 while($.nn.length<=r)B.a.i($.nn,null)
 s=$.nn[r]
 if(s==null){s=this.iu()
@@ -11472,7 +11472,7 @@ cp(a){var s=this.b.exec(a)
 if(s==null)return null
 return new A.fJ(s)},
 bJ(a,b){return new A.iN(this,b,0)},
-j9(a,b){var s,r=this.gfn()
+ja(a,b){var s,r=this.gfn()
 if(r==null)r=A.e9(r)
 r.lastIndex=b
 s=r.exec(a)
@@ -11489,14 +11489,14 @@ $icm:1}
 A.iN.prototype={
 gV(a){return new A.e_(this.a,this.b,this.c)}}
 A.e_.prototype={
-gF(){var s=this.d
+gG(){var s=this.d
 return s==null?t.F.a(s):s},
 u(){var s,r,q,p,o,n,m=this,l=m.b
 if(l==null)return!1
 s=m.c
 r=l.length
 if(s<=r){q=m.a
-p=q.j9(l,s)
+p=q.ja(l,s)
 if(p!=null){m.d=p
 o=p.gd6()
 if(p.b.index===o){s=!1
@@ -11526,7 +11526,7 @@ return!1}r=s+n
 q.d=new A.iC(s,o)
 q.c=r===q.c?r+1:r
 return!0},
-gF(){var s=this.d
+gG(){var s=this.d
 s.toString
 return s},
 $ia7:1}
@@ -11566,9 +11566,9 @@ A.dQ.prototype={$idQ:1}
 A.eW.prototype={
 gt(a){if(((a.$flags|0)&2)!==0)return new A.jy(a.buffer)
 else return a.buffer},
-jr(a,b,c,d){var s=A.aG(b,0,c,d,null)
+js(a,b,c,d){var s=A.aG(b,0,c,d,null)
 throw A.d(s)},
-eP(a,b,c,d){if(b>>>0!==b||b>c)this.jr(a,b,c,d)}}
+eP(a,b,c,d){if(b>>>0!==b||b>c)this.js(a,b,c,d)}}
 A.jy.prototype={
 d_(a,b,c){var s=A.qD(this.a,b,c)
 s.$flags=3
@@ -11757,9 +11757,9 @@ A.nY.prototype={
 $2(a,b){this.a(A.y(a),b)},
 $S:57}
 A.bo.prototype={
-gF(){var s=this.b
+gG(){var s=this.b
 return s==null?this.$ti.c.a(s):s},
-ko(a,b){var s,r,q
+kp(a,b){var s,r,q
 a=A.y(a)
 b=b
 s=this.a
@@ -11768,10 +11768,10 @@ return r}catch(q){b=q
 a=1}},
 u(){var s,r,q,p,o=this,n=null,m=0
 for(;;){s=o.d
-if(s!=null)try{if(s.u()){o.b=s.gF()
+if(s!=null)try{if(s.u()){o.b=s.gG()
 return!0}else o.d=null}catch(r){n=r
 m=1
-o.d=null}q=o.ko(m,n)
+o.d=null}q=o.kp(m,n)
 if(1===q)return!0
 if(0===q){o.b=null
 p=o.e
@@ -11792,7 +11792,7 @@ return!1}if(0>=p.length)return A.a(p,-1)
 o.a=p.pop()
 m=1
 continue}throw A.d(A.b4("sync*"))}return!1},
-kJ(a){var s,r,q=this
+kK(a){var s,r,q=this
 if(a instanceof A.cT){s=a.a()
 r=q.e
 if(r==null)r=q.e=[]
@@ -11823,10 +11823,10 @@ s=this.a
 if((s.a&30)!==0)throw A.d(A.b4("Future already completed"))
 s.eK(r.l("1/").a(a))}}
 A.dm.prototype={
-lt(a){if((this.c&15)!==6)return!0
+lu(a){if((this.c&15)!==6)return!0
 return this.b.b.ep(t.iW.a(this.d),a.a,t.k4,t.K)},
-li(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
-if(t.ng.b(q))p=l.lN(q,m,a.b,o,n,t.k)
+lj(a){var s,r=this,q=r.e,p=null,o=t.z,n=t.K,m=a.a,l=r.b.b
+if(t.ng.b(q))p=l.lO(q,m,a.b,o,n,t.k)
 else p=l.ep(t.mq.a(q),m,o,n)
 try{o=r.$ti.l("2/").a(p)
 return o}catch(s){if(t.do.b(A.J(s))){if((r.c&1)!==0)throw A.d(A.br("The error handler of Future.then must return a value of the returned future's type","onError"))
@@ -11844,7 +11844,7 @@ r.ae(c).l("1/(2)").a(a)
 s=new A.au($.af,c.l("au<0>"))
 this.dr(new A.dm(s,19,a,b,r.l("@<1>").ae(c).l("dm<1,2>")))
 return s},
-kw(a){this.a=this.a&1|16
+kx(a){this.a=this.a&1|16
 this.c=a},
 cG(a){this.a=a.a&30|this.a&1
 this.c=a.c},
@@ -11893,7 +11893,7 @@ r=q.cb()
 q.cG(a)
 A.dn(q,r)},
 dz(a){var s=this.cb()
-this.kw(a)
+this.kx(a)
 A.dn(this,s)},
 eK(a){var s=this.$ti
 s.l("1/").a(a)
@@ -11926,7 +11926,7 @@ $S:0}
 A.mW.prototype={
 $0(){var s,r,q,p,o,n,m,l,k=this,j=null
 try{q=k.a.a
-j=q.b.b.lM(t.mY.a(q.d),t.z)}catch(p){s=A.J(p)
+j=q.b.b.lN(t.mY.a(q.d),t.z)}catch(p){s=A.J(p)
 r=A.cv(p)
 if(k.c&&t.v.a(k.b.a.c).a===s){q=k.a
 q.c=t.v.a(k.b.a.c)}else{q=s
@@ -11972,7 +11972,7 @@ A.mU.prototype={
 $0(){var s,r,q,p,o,n,m,l=this
 try{s=t.v.a(l.a.a.c)
 p=l.b
-if(p.a.lt(s)&&p.a.e!=null){p.c=p.a.li(s)
+if(p.a.lu(s)&&p.a.e!=null){p.c=p.a.lj(s)
 p.b=!1}}catch(o){r=A.J(o)
 q=A.cv(o)
 p=t.v.a(l.a.a.c)
@@ -11989,28 +11989,28 @@ A.iP.prototype={}
 A.js.prototype={}
 A.h2.prototype={$iri:1}
 A.jj.prototype={
-lO(a){var s,r,q
+lP(a){var s,r,q
 t.M.a(a)
 try{if(B.B===$.af){a.$0()
 return}A.rV(null,null,this,a,t.o)}catch(q){s=A.J(q)
 r=A.cv(q)
 A.pD(A.e9(s),t.k.a(r))}},
 h8(a){return new A.no(this,t.M.a(a))},
-lM(a,b){b.l("0()").a(a)
+lN(a,b){b.l("0()").a(a)
 if($.af===B.B)return a.$0()
 return A.rV(null,null,this,a,b)},
 ep(a,b,c,d){c.l("@<0>").ae(d).l("1(2)").a(a)
 d.a(b)
 if($.af===B.B)return a.$1(b)
 return A.ys(null,null,this,a,b,c,d)},
-lN(a,b,c,d,e,f){d.l("@<0>").ae(e).ae(f).l("1(2,3)").a(a)
+lO(a,b,c,d,e,f){d.l("@<0>").ae(e).ae(f).l("1(2,3)").a(a)
 e.a(b)
 f.a(c)
 if($.af===B.B)return a.$2(b,c)
 return A.yr(null,null,this,a,b,c,d,e,f)},
 hx(a,b,c,d){return b.l("@<0>").ae(c).ae(d).l("1(2,3)").a(a)}}
 A.no.prototype={
-$0(){return this.a.lO(this.b)},
+$0(){return this.a.lP(this.b)},
 $S:0}
 A.nU.prototype={
 $0(){A.vi(this.a,this.b)},
@@ -12044,8 +12044,8 @@ q.push(p.dw(a))}return!0},
 aI(a,b){var s=this
 if(typeof b=="string"&&b!=="__proto__")return s.eT(s.b,b)
 else if(typeof b=="number"&&(b&1073741823)===b)return s.eT(s.c,b)
-else return s.kj(b)},
-kj(a){var s,r,q,p,o=this,n=o.d
+else return s.kk(b)},
+kk(a){var s,r,q,p,o=this,n=o.d
 if(n==null)return!1
 s=o.cI(a)
 r=n[s]
@@ -12096,7 +12096,7 @@ for(r=0;r<s;++r){q=a[r].a
 if(q==null?b==null:q===b)return r}return-1}}
 A.jd.prototype={}
 A.fH.prototype={
-gF(){var s=this.d
+gG(){var s=this.d
 return s==null?this.$ti.c.a(s):s},
 u(){var s=this,r=s.c,q=s.a
 if(s.b!==q.r)throw A.d(A.b9(q))
@@ -12135,7 +12135,7 @@ $ik:1}
 A.az.prototype={
 ak(a,b){var s,r,q,p=A.D(this)
 p.l("~(az.K,az.V)").a(b)
-for(s=this.gbs(),s=s.gV(s),p=p.l("az.V");s.u();){r=s.gF()
+for(s=this.gbs(),s=s.gV(s),p=p.l("az.V");s.u();){r=s.gG()
 q=this.h(0,r)
 b.$2(r,q==null?p.a(q):q)}},
 aa(a,b){var s,r=this,q=A.D(r)
@@ -12220,9 +12220,9 @@ return(this.b!=null?"Converting object to an encodable object failed:":"Converti
 A.i_.prototype={
 m(a){return"Cyclic error in JSON stringify"}}
 A.hZ.prototype={
-la(a,b){var s=A.x7(a,this.glb().b,null)
+lb(a,b){var s=A.x7(a,this.glc().b,null)
 return s},
-glb(){return B.dC}}
+glc(){return B.dC}}
 A.i0.prototype={}
 A.n7.prototype={
 hF(a){var s,r,q,p,o,n,m=a.length
@@ -12309,23 +12309,23 @@ s.a+='"'
 q.hF(a)
 s.a+='"'
 return!0}else if(t.gs.b(a)){q.du(a)
-q.lT(a)
+q.lU(a)
 s=q.a
 if(0>=s.length)return A.a(s,-1)
 s.pop()
 return!0}else if(t.av.b(a)){q.du(a)
-r=q.lU(a)
+r=q.lV(a)
 s=q.a
 if(0>=s.length)return A.a(s,-1)
 s.pop()
 return r}else return!1},
-lT(a){var s,r,q=this.c
+lU(a){var s,r,q=this.c
 q.a+="["
 s=J.ac(a)
 if(s.gcr(a)){this.dj(s.h(a,0))
 for(r=1;r<s.gp(a);++r){q.a+=","
 this.dj(s.h(a,r))}}q.a+="]"},
-lU(a){var s,r,q,p,o,n,m=this,l={}
+lV(a){var s,r,q,p,o,n,m=this,l={}
 if(a.gau(a)){m.c.a+="{}"
 return!0}s=a.gp(a)*2
 r=A.R(s,null,!1,t.iD)
@@ -12357,13 +12357,13 @@ A.i1.prototype={}
 A.iL.prototype={
 d3(a,b){t.L.a(a)
 return(b===!0?B.hf:B.he).ac(a)},
-l2(a){return this.d3(a,null)}}
+l3(a){return this.d3(a,null)}}
 A.iM.prototype={
 ac(a){var s,r,q,p=a.length,o=A.bm(0,null,p)
 if(o===0)return new Uint8Array(0)
 s=new Uint8Array(o*3)
 r=new A.nv(s)
-if(r.jc(a,0,o)!==o){q=o-1
+if(r.jd(a,0,o)!==o){q=o-1
 if(!(q>=0&&q<p))return A.a(a,q)
 r.eb()}return B.d.a2(s,0,r.b)}}
 A.nv.prototype={
@@ -12378,7 +12378,7 @@ q[o]=191
 r.b=p+1
 if(!(p<s))return A.a(q,p)
 q[p]=189},
-kI(a,b){var s,r,q,p,o,n=this
+kJ(a,b){var s,r,q,p,o,n=this
 if((b&64512)===56320){s=65536+((a&1023)<<10)|b&1023
 r=n.c
 q=n.b
@@ -12398,7 +12398,7 @@ if(!(p<o))return A.a(r,p)
 r[p]=s&63|128
 return!0}else{n.eb()
 return!1}},
-jc(a,b,c){var s,r,q,p,o,n,m,l,k=this
+jd(a,b,c){var s,r,q,p,o,n,m,l,k=this
 if(b!==c){s=c-1
 if(!(s>=0&&s<a.length))return A.a(a,s)
 s=(a.charCodeAt(s)&64512)===55296}else s=!1
@@ -12413,7 +12413,7 @@ s[m]=n}else{m=n&64512
 if(m===55296){if(k.b+4>q)break
 m=o+1
 if(!(m<p))return A.a(a,m)
-if(k.kI(n,a.charCodeAt(m)))o=m}else if(m===56320){if(k.b+3>q)break
+if(k.kJ(n,a.charCodeAt(m)))o=m}else if(m===56320){if(k.b+3>q)break
 k.eb()}else if(n<=2047){m=k.b
 l=m+1
 if(l>=q)break
@@ -12458,8 +12458,8 @@ dB(a,b,c,d){var s,r,q=this
 if(c-b>1000){s=B.b.W(b+c,2)
 r=q.dB(a,b,s,!1)
 if((q.b&1)!==0)return r
-return r+q.dB(a,s,c,d)}return q.l3(a,b,c,d)},
-l3(a,b,a0,a1){var s,r,q,p,o,n,m,l,k=this,j="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFFFFFFFFFFFFFFFFGGGGGGGGGGGGGGGGHHHHHHHHHHHHHHHHHHHHHHHHHHHIHHHJEEBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBKCCCCCCCCCCCCDCLONNNMEEEEEEEEEEE",i=" \x000:XECCCCCN:lDb \x000:XECCCCCNvlDb \x000:XECCCCCN:lDb AAAAA\x00\x00\x00\x00\x00AAAAA00000AAAAA:::::AAAAAGG000AAAAA00KKKAAAAAG::::AAAAA:IIIIAAAAA000\x800AAAAA\x00\x00\x00\x00 AAAAA",h=65533,g=k.b,f=k.c,e=new A.c3(""),d=b+1,c=a.length
+return r+q.dB(a,s,c,d)}return q.l4(a,b,c,d)},
+l4(a,b,a0,a1){var s,r,q,p,o,n,m,l,k=this,j="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFFFFFFFFFFFFFFFFGGGGGGGGGGGGGGGGHHHHHHHHHHHHHHHHHHHHHHHHHHHIHHHJEEBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBKCCCCCCCCCCCCDCLONNNMEEEEEEEEEEE",i=" \x000:XECCCCCN:lDb \x000:XECCCCCNvlDb \x000:XECCCCCN:lDb AAAAA\x00\x00\x00\x00\x00AAAAA00000AAAAA:::::AAAAAGG000AAAAA00KKKAAAAAG::::AAAAA:IIIIAAAAA000\x800AAAAA\x00\x00\x00\x00 AAAAA",h=65533,g=k.b,f=k.c,e=new A.c3(""),d=b+1,c=a.length
 if(!(b>=0&&b<c))return A.a(a,b)
 s=a[b]
 A:for(r=k.a;;){for(;;d=o){if(!(s>=0&&s<256))return A.a(j,s)
@@ -12508,7 +12508,7 @@ A.hx.prototype={
 J(a,b){if(b==null)return!1
 return b instanceof A.hx},
 gE(a){return B.b.gE(0)},
-m(a){return"0:00:00."+B.f.lw(B.b.m(0),6,"0")}}
+m(a){return"0:00:00."+B.f.lx(B.b.m(0),6,"0")}}
 A.mN.prototype={
 m(a){return this.aR()}}
 A.a6.prototype={
@@ -12594,37 +12594,37 @@ A.p.prototype={
 bQ(a,b,c,d){var s,r
 d.a(b)
 A.D(this).ae(d).l("1(1,p.E)").a(c)
-for(s=this.gV(this),r=b;s.u();)r=c.$2(r,s.gF())
+for(s=this.gV(this),r=b;s.u();)r=c.$2(r,s.gG())
 return r},
 b2(a,b){var s,r,q=this.gV(this)
 if(!q.u())return""
-s=J.d_(q.gF())
+s=J.d_(q.gG())
 if(!q.u())return s
 if(b.length===0){r=s
-do r+=J.d_(q.gF())
+do r+=J.d_(q.gG())
 while(q.u())}else{r=s
-do r=r+b+J.d_(q.gF())
+do r=r+b+J.d_(q.gG())
 while(q.u())}return r.charCodeAt(0)==0?r:r},
 gp(a){var s,r=this.gV(this)
 for(s=0;r.u();)++s
 return s},
 gaH(a){var s=this.gV(this)
 if(!s.u())throw A.d(A.bi())
-return s.gF()},
+return s.gG()},
 gaq(a){var s,r=this.gV(this)
 if(!r.u())throw A.d(A.bi())
-do s=r.gF()
+do s=r.gG()
 while(r.u())
 return s},
 gbY(a){var s,r=this.gV(this)
 if(!r.u())throw A.d(A.bi())
-s=r.gF()
+s=r.gG()
 if(r.u())throw A.d(A.qu())
 return s},
 aG(a,b){var s,r
 A.fc(b,"index")
 s=this.gV(this)
-for(r=b;s.u();){if(r===0)return s.gF();--r}throw A.d(A.oY(b,b-r,this,"index"))},
+for(r=b;s.u();){if(r===0)return s.gG();--r}throw A.d(A.oY(b,b-r,this,"index"))},
 m(a){return A.vq(this,"(",")")}}
 A.bc.prototype={
 m(a){return"MapEntry("+A.v(this.a)+": "+A.v(this.b)+")"}}
@@ -12652,7 +12652,7 @@ s.b=null}}}
 A.it.prototype={
 gV(a){return new A.is(this.a)}}
 A.is.prototype={
-gF(){return this.d},
+gG(){return this.d},
 u(){var s,r,q,p=this,o=p.b=p.c,n=p.a,m=n.length
 if(o===m){p.d=-1
 return!1}if(!(o<m))return A.a(n,o)
@@ -12700,7 +12700,7 @@ n=n<<1>>>0
 m=m<<1>>>0}}}
 A.mj.prototype={}
 A.ny.prototype={
-l6(a,b,c,d){var s,r,q,p,o,n,m=null
+l7(a,b,c,d){var s,r,q,p,o,n,m=null
 for(;;){s=a.c
 r=a.d
 r===$&&A.l()
@@ -12719,7 +12719,7 @@ if(B.b.am(o*256+n,31)!==0)return!1
 if((n>>>5&1)!==0){a.av()
 return!1}if(m!=null)b.cu(m)
 s=new A.f_(new Uint8Array(32768))
-new A.kA(a,s).jp()
+new A.kA(a,s).jq()
 m=J.aH(B.d.gt(s.c),s.c.byteOffset,s.b)
 a.av()}if(m!=null)b.cu(m)
 return!0}}
@@ -12728,7 +12728,7 @@ gaY(){var s=this.a
 if(s==null)return s
 s.d===$&&A.l()
 return s},
-jp(){var s,r,q=this
+jq(){var s,r,q=this
 q.e=q.d=0
 if(q.gaY()==null)return
 for(;;){s=q.gaY()
@@ -12736,8 +12736,8 @@ r=s.c
 s=s.d
 s===$&&A.l()
 if(!(r<s))break
-if(!q.jF())return}},
-jF(){var s,r,q,p=this,o=p.gaY()
+if(!q.jG())return}},
+jG(){var s,r,q,p=this,o=p.gaY()
 if(o!=null){s=o.c
 r=o.d
 r===$&&A.l()
@@ -12745,11 +12745,11 @@ r=s>=r
 s=r}else s=!0
 if(s)return!1
 q=p.aK(3)
-switch(B.b.q(q,1)){case 0:if(p.jP()===-1)return!1
+switch(B.b.q(q,1)){case 0:if(p.jQ()===-1)return!1
 break
 case 1:if(p.eZ($.tR(),$.tQ())===-1)return!1
 break
-case 2:if(p.jH()===-1)return!1
+case 2:if(p.jI()===-1)return!1
 break
 default:return!1}return(q&1)===0},
 aK(a){var s,r,q,p,o=this
@@ -12798,7 +12798,7 @@ m=n>>>16
 l.d=B.b.ah(q,m)
 l.e=r-m
 return n&65535},
-jP(){var s,r,q,p=this
+jQ(){var s,r,q,p=this
 p.e=p.d=0
 s=p.aK(16)
 r=p.aK(16)
@@ -12807,9 +12807,9 @@ if(s>p.gaY().gp(0))return-1
 r=p.gaY()
 q=r.hN(s,r.c)
 r.c=r.c+q.gp(0)
-p.c.lV(q)
+p.c.lW(q)
 return 0},
-jH(){var s,r,q,p,o,n,m,l,k,j,i=this,h=i.aK(5)
+jI(){var s,r,q,p,o,n,m,l,k,j,i=this,h=i.aK(5)
 if(h===-1)return-1
 h+=257
 if(h>288)return-1
@@ -12836,7 +12836,7 @@ eZ(a,b){var s,r,q,p,o,n,m,l,k=this
 for(s=k.c;;){r=k.dY(a)
 if(r<0||r>285)return-1
 if(r===256)break
-if(r<256){if(s.b===s.c.length)s.ja()
+if(r<256){if(s.b===s.c.length)s.jb()
 q=s.c
 p=s.b++
 q.$flags&2&&A.e(q)
@@ -12917,7 +12917,7 @@ s=a.length
 while(r=n.b,q=r+s,p=n.c,o=p.length,q>o)n.dI(q-o)
 B.d.D(p,r,q,a)
 n.b+=s},
-lV(a){var s,r,q,p,o,n,m=this
+lW(a){var s,r,q,p,o,n,m=this
 for(;;){s=m.b
 r=a.b
 q=r==null
@@ -12936,7 +12936,7 @@ bA(a){return this.eD(a,null)},
 dI(a){var s=a!=null?a>32768?a:32768:32768,r=this.c,q=r.length,p=new Uint8Array((q+s)*2)
 B.d.D(p,0,q,r)
 this.c=p},
-ja(){return this.dI(null)},
+jb(){return this.dI(null)},
 gp(a){return this.b}}
 A.i9.prototype={}
 A.aY.prototype={
@@ -13354,7 +13354,7 @@ return null}++q.as
 s.k(0,b,r)
 s=r.a
 return s},
-lC(a,b){var s,r=this,q=r.$ti
+lD(a,b){var s,r=this,q=r.$ti
 q.c.a(a)
 q.y[1].a(b)
 s=r.a.$1(b)
@@ -13362,21 +13362,21 @@ if(s==null)s=0
 r.e2(a)
 r.y.k(0,a,new A.fB(b,s,q.l("fB<2>")))
 r.z+=s
-r.kG()
+r.kH()
 return b},
 e2(a){var s=this,r=s.y.aI(0,s.$ti.c.a(a))
 if(r==null)return
 s.z=s.z-r.b},
-kG(){var s,r,q,p,o,n,m=this
-if(m.b)for(s=m.x;m.z>s;){r=m.jA(!0)
+kH(){var s,r,q,p,o,n,m=this
+if(m.b)for(s=m.x;m.z>s;){r=m.jB(!0)
 if(r==null)break
 m.e2(r);++m.ax}q=m.c
 if(q!=null)for(s=m.y,p=A.D(s).l("a2<1>");s.a>q;){o=new A.a2(s,p).gV(0)
 if(!o.u())A.Q(A.bi())
-n=o.gF()
+n=o.gG()
 if(J.W(n,s.a===0?null:new A.a2(s,p).gaq(0)))break
 m.e2(n);++m.ax}},
-jA(a){var s,r,q,p=this.y,o=p.a===0?null:new A.a2(p,A.D(p).l("a2<1>")).gaq(0)
+jB(a){var s,r,q,p=this.y,o=p.a===0?null:new A.a2(p,A.D(p).l("a2<1>")).gaq(0)
 for(p=new A.ce(p,A.D(p).l("ce<1,2>")).gV(0);p.u();){s=p.d
 r=s.a
 if(J.W(r,o))continue
@@ -13545,7 +13545,7 @@ if(h)g=null
 else{g=new A.aw()
 $.aC()
 g.ag()}s=3
-return A.am(i.l8(l,l.hc(),a6),$async$by)
+return A.am(i.l9(l,l.hc(),a6),$async$by)
 case 3:if(g!=null){if(g.b==null)g.b=$.aN.$0()
 a5.c=a5.c+g.gad()}if(h)f=null
 else{f=new A.aw()
@@ -13570,7 +13570,7 @@ s=1
 break}a=b
 j=A.oy(a)
 a0=new A.cN(a,c,j+(a===c?0:A.oy(c)))
-n.lC(o,a0)
+n.lD(o,a0)
 q=a0
 s=1
 break
@@ -13942,7 +13942,7 @@ q=b0+1
 i=b8.av()
 if(J.W(i,r))break
 else r=i}catch(b5){break}}for(a3=new A.d6(a3,a3.r,a3.e,A.D(a3).l("d6<2>"));a3.u();){h=a3.d
-for(a5=B.br.gbs(),a5=a5.gV(a5);a5.u();){g=a5.gF()
+for(a5=B.br.gbs(),a5=a5.gV(a5);a5.u();){g=a5.gG()
 b0=A.y(g)
 if(h.a.a9(b0))try{f=J.a5(h,g).M(0)
 b0=s
@@ -13989,7 +13989,7 @@ case 1:i.b=new A.ey(new Uint8Array(A.I(p.bw(j).bV())))
 break
 case 7:i.b=new A.eK(new Uint8Array(A.I(p.bw(j).bV())))
 break
-case 2:i.b=new A.ez(j===0?"":p.lG(j-1))
+case 2:i.b=new A.ez(j===0?"":p.lH(j-1))
 break
 case 3:o=new A.eI(new Uint16Array(j))
 o.hU(p,j)
@@ -14253,7 +14253,7 @@ s=A.v(s[0])}else s=A.v(s)
 return s}}
 A.eA.prototype={
 hQ(a,b){var s,r
-for(s=this.a,r=0;r<b;++r)B.an.k(s,r,a.lD())},
+for(s=this.a,r=0;r<b;++r)B.an.k(s,r,a.lE())},
 gaF(){return B.b5},
 gp(a){return this.a.length},
 J(a,b){var s,r
@@ -14298,7 +14298,7 @@ A.cz.prototype={}
 A.kJ.prototype={
 aT(a){var s,r,q,p,o,n,m,l,k,j,i,h=this
 h.a=A.qt(t.L.a(a),!0,null,0)
-h.jX()
+h.jY()
 if(h.y.length!==1)throw A.d(A.bD("Only single frame JPEGs supported"))
 s=h.d
 for(r=s.z,q=s.y,p=h.as,o=0;o<r.length;++o){n=q.h(0,r[o])
@@ -14312,7 +14312,7 @@ else m=m===1&&l===4?2:1
 if(k===j)l=0
 else l=k===1&&j===4?2:1
 B.a.i(p,new A.hr(i,m,l))}},
-jX(){var s,r,q,p,o,n,m,l,k=this
+jY(){var s,r,q,p,o,n,m,l,k=this
 if(k.dR()!==216)throw A.d(A.bD("Start Of Image marker not found."))
 s=k.dR()
 for(;;){if(s!==217){r=k.a
@@ -14326,18 +14326,18 @@ if(q<2)A.Q(A.bD("Invalid Block"))
 r=k.a
 p=r.bA(q-2)
 o=r.d=r.d+(p.c-p.d)
-switch(s){case 224:case 225:case 226:case 227:case 228:case 229:case 230:case 231:case 232:case 233:case 234:case 235:case 236:case 237:case 238:case 239:case 254:k.jY(s,p)
+switch(s){case 224:case 225:case 226:case 227:case 228:case 229:case 230:case 231:case 232:case 233:case 234:case 235:case 236:case 237:case 238:case 239:case 254:k.jZ(s,p)
 break
-case 219:k.k_(p)
+case 219:k.k0(p)
 break
-case 192:case 193:case 194:k.k5(s,p)
+case 192:case 193:case 194:k.k6(s,p)
 break
 case 195:case 197:case 198:case 199:case 200:case 201:case 202:case 203:case 205:case 206:case 207:throw A.d(A.bD("Unhandled frame type "+B.b.ev(s,16)))
-case 196:k.jZ(p)
+case 196:k.k_(p)
 break
 case 221:k.e=p.aC()
 break
-case 218:k.ke(p)
+case 218:k.kf(p)
 break
 case 255:n=r.a
 if(!(o>=0&&o<n.length))return A.a(n,o)
@@ -14368,14 +14368,14 @@ q=q.d<q.c}else q=!1}while(q)
 if(s===0){q=r.a
 q=q.d<q.c}else q=!1}while(q)
 return s},
-k9(a){var s,r,q,p
+ka(a){var s,r,q,p
 for(s=a.a,r=s.length,q=0;q<12;++q){p=a.d++
 if(!(p>=0&&p<r))return A.a(s,p)
 if(s[p]!==B.ek[q])return}a.bV()},
-k0(a){if(a.av()!==1165519206)return
+k5(a){if(a.av()!==1165519206)return
 if(a.aC()!==0)return
 this.w.aT(a)},
-jY(a,b){var s,r,q,p,o,n,m=this,l=b
+jZ(a,b){var s,r,q,p,o,n,m=this,l=b
 if(a===224){s=l
 r=s.a
 s=s.d
@@ -14440,8 +14440,8 @@ if(!(r>=0&&r<p.length))return A.a(p,r)
 r=p[r]
 s.r=r
 m.b=s
-l.eE(14+3*q*r,14)}}else if(a===225)m.k0(l)
-else if(a===226)m.k9(l)
+l.eE(14+3*q*r,14)}}else if(a===225)m.k5(l)
+else if(a===226)m.ka(l)
 else if(a===238){s=l
 r=s.a
 s=s.d
@@ -14494,8 +14494,8 @@ s=r.a
 r=r.d+11
 if(!(r>=0&&r<s.length))return A.a(s,r)
 o.d=s[r]
-m.c=o}}else if(a===254)try{l.lH()}catch(n){}},
-k_(a){var s,r,q,p,o,n,m,l,k,j,i
+m.c=o}}else if(a===254)try{l.lI()}catch(n){}},
+k0(a){var s,r,q,p,o,n,m,l,k,j,i
 for(s=a.c,r=a.a,q=r.length,p=this.x;o=a.d,n=o<s,n;){a.d=o+1
 if(!(o>=0&&o<q))return A.a(r,o)
 m=r[o]
@@ -14513,7 +14513,7 @@ n=n[j]
 k.$flags&2&&A.e(k)
 if(!(n<64))return A.a(k,n)
 k[n]=i}}if(n)throw A.d(A.bD("Bad length for DQT block"))},
-k5(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this
+k6(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this
 if(f.d!=null)throw A.d(A.bD("Duplicate JPG frame data found."))
 s=A.w(t.S,t.fh)
 r=A.b([],t.t)
@@ -14534,10 +14534,10 @@ b.d=k+1
 if(!(k>=0&&k<n))return A.a(o,k)
 g=o[k]
 B.a.i(r,i)
-s.k(0,i,new A.cz(h>>>4&15,h&15,m,g))}q.lB()
+s.k(0,i,new A.cz(h>>>4&15,h&15,m,g))}q.lC()
 f.d=q
 B.a.i(f.y,q)},
-jZ(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f
+k_(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f
 for(s=a.c,r=this.Q,q=a.a,p=q.length,o=this.z;n=a.d,n<s;){m=a.d=n+1
 if(!(n>=0&&n<p))return A.a(q,n)
 l=q[n]
@@ -14553,7 +14553,7 @@ if((l&16)!==0){l-=16
 f=o}else f=r
 if(f.length<=l)B.a.sp(f,l+1)
 B.a.k(f,l,this.ih(k,g))}},
-ke(a1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=this,a0=a1.aB()
+kf(a1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=this,a0=a1.aB()
 if(a0<1||a0>4)throw A.d(A.bD("Invalid SOS block"))
 s=a.d
 s.toString
@@ -14639,25 +14639,25 @@ d=n[d]
 if(d!=null)B.d.ar(d,c,e,p,b<<3>>>0)}}}return n}}
 A.e2.prototype={}
 A.hW.prototype={
-lB(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=this
+lC(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a=this
 for(s=a.y,r=A.D(s).l("aE<1>"),q=new A.aE(s,s.r,s.e,r);q.u();){p=s.h(0,q.d)
 a.f=Math.max(a.f,p.a)
 a.r=Math.max(a.r,p.b)}q=a.e
 q.toString
-a.w=B.c.G(q/8/a.f)
+a.w=B.c.F(q/8/a.f)
 q=a.d
 q.toString
-a.x=B.c.G(q/8/a.r)
+a.x=B.c.F(q/8/a.r)
 for(r=new A.aE(s,s.r,s.e,r),q=t.n5,o=t.bW,n=t.kn;r.u();){m=s.h(0,r.d)
 m.toString
 l=a.e
 l.toString
 k=m.a
-j=B.c.G(B.c.G(l/8)*k/a.f)
+j=B.c.F(B.c.F(l/8)*k/a.f)
 l=a.d
 l.toString
 i=m.b
-h=B.c.G(B.c.G(l/8)*i/a.r)
+h=B.c.F(B.c.F(l/8)*i/a.r)
 g=a.w*k
 f=a.x*i
 e=J.qv(f,n)
@@ -14901,8 +14901,8 @@ return s[r]},
 bw(a){var s=this.bA(a)
 this.d=this.d+(s.c-s.d)
 return s},
-lG(a){return A.a3(this.bw(a).bV(),0,null)},
-lH(){var s,r,q,p,o,n=this,m=A.b([],t.t)
+lH(a){return A.a3(this.bw(a).bV(),0,null)},
+lI(){var s,r,q,p,o,n=this,m=A.b([],t.t)
 for(s=n.c,r=n.a,q=r.length;p=n.d,p<s;){n.d=p+1
 if(!(p>=0&&p<q))return A.a(r,p)
 o=r[p]
@@ -14930,8 +14930,8 @@ if(!(l>=0&&l<k))return A.a(n,l)
 p=n[l]&255
 if(o.e)return(s<<24|r<<16|q<<8|p)>>>0
 return(p<<24|q<<16|r<<8|s)>>>0},
-lD(){return A.zr(this.lI())},
-lI(){var s,r,q,p,o,n,m,l,k=this,j=k.a,i=k.d,h=k.d=i+1,g=j.length
+lE(){return A.zr(this.lJ())},
+lJ(){var s,r,q,p,o,n,m,l,k=this,j=k.a,i=k.d,h=k.d=i+1,g=j.length
 if(!(i>=0&&i<g))return A.a(j,i)
 s=j[i]&255
 i=k.d=h+1
@@ -15016,7 +15016,7 @@ eX(a){var s=this,r=++s.e,q=s.a
 if(q!=null&&r>=q){s.f=!0
 s.fL()}return a}}
 A.ha.prototype={
-kT(a,b){var s,r,q,p,o,n,m,l,k,j
+kU(a,b){var s,r,q,p,o,n,m,l,k,j
 t.L.a(a)
 s=b.length
 r=new Uint8Array(s)
@@ -15028,7 +15028,7 @@ l=b[l]
 if(!(m<n))return A.a(q,m)
 k=q[m]
 if(!(m<16))return A.a(p,m)
-p[m]=l^k}this.j4(p)
+p[m]=l^k}this.j5(p)
 j=o+16
 B.d.D(r,o,j,p)
 q=A.V(r,o,j)}return r},
@@ -15046,7 +15046,7 @@ if(!(l<m))return A.a(p,l)
 i=p[l]
 if(!(k<s))return A.a(r,k)
 r[k]=j^i}}return r},
-j4(a){var s,r,q,p,o,n=this
+j5(a){var s,r,q,p,o,n=this
 n.bB(a,0)
 for(s=n.a,r=1;r<s;++r){for(q=0;q<16;++q){p=$.jM()
 o=a[q]
@@ -15241,13 +15241,13 @@ r=null
 try{switch(s.a.a){case 0:r=B.n
 break
 case 1:n=j.fz(s.b,a)
-q=n==null?j.jO(a):n
+q=n==null?j.jP(a):n
 if(q==null)r=B.n
 else{r=q.c
 m=j.z
 if(m!=null&&a!==j.Q)m.d4(r,a,q.b)}break
 case 2:p=null
-try{p=j.fq(s.d).lv(a,s.e)}catch(l){m=A.J(l)
+try{p=j.fq(s.d).lw(a,s.e)}catch(l){m=A.J(l)
 if(t.I.b(m))p=B.n
 else if(t.b0.b(m))p=B.n
 else throw l}r=p
@@ -15264,7 +15264,7 @@ return q}catch(p){q=A.J(p)
 if(t.I.b(q))return null
 else if(t.b0.b(q))return null
 else throw p}},
-jO(a){var s,r,q,p=this
+jP(a){var s,r,q,p=this
 if(p.at==null)A.qV(B.bV,"")
 s=p.at
 r=(s==null?p.at=A.qo(p.a,p.b):s).h(0,a)
@@ -15299,10 +15299,10 @@ r=A.D(s).l("a2<1>")
 for(;;){if(!(n>16777216&&s.a>1))break
 q=new A.a2(s,r).gV(0)
 if(!q.u())A.Q(A.bi())
-p=q.gF()
+p=q.gG()
 n=o.y-s.aI(0,p).length
 o.y=n}},
-kn(a){return this.bz(a.a,a.b)},
+ko(a){return this.bz(a.a,a.b)},
 fq(a){return this.w.aa(a,new A.k6(this,a))}}
 A.k7.prototype={
 $2(a,b){this.a.a.k(0,A.ab(a),t.l.a(b))},
@@ -15348,7 +15348,7 @@ o=n.length!==0?B.a.af(n,0):p.a.N()
 if(o.a!==B.w)A.Q(A.C(l+o.m(0),o.b))
 B.a.i(s,new A.i(q,A.y(o.c)))}catch(m){if(A.J(m) instanceof A.dE)break
 else throw m}},
-lv(a,b){var s,r,q,p,o=this,n=o.c
+lw(a,b){var s,r,q,p,o=this,n=o.c
 n=b<n.length&&n[b].a===a
 if(n){n=o.c
 if(!(b<n.length))return A.a(n,b)
@@ -15419,7 +15419,7 @@ o=g.c
 n=o!==0
 m=0
 for(;;){if(!(!n||m<o))break
-if(p)if(a.c!==0){a.c=0;++a.b}g.kz()
+if(p)if(a.c!==0){a.c=0;++a.b}g.kA()
 if(a.b>=q)break
 s=null
 if(a0)s=!0
@@ -15431,7 +15431,7 @@ if(k)break
 s=l===0}r=null
 try{r=s?g.iQ(c):g.iN()}catch(j){if(A.J(j) instanceof A.fy)break
 else throw j}if(r==null)break
-d.i(0,g.kk(r,e));++m
+d.i(0,g.kl(r,e));++m
 k=A.ai(r,b)
 k.push(f)
 k.push(f)
@@ -15441,7 +15441,7 @@ h=new Uint8Array(f)
 B.d.ap(h,0,f,g.d?0:255)
 B.d.D(h,0,i.length,i)
 return h}return i},
-kk(a,b){var s,r,q,p,o,n,m,l,k,j
+kl(a,b){var s,r,q,p,o,n,m,l,k,j
 t.L.a(a)
 s=new Uint8Array(b)
 r=this.d
@@ -15456,9 +15456,9 @@ q=s[r]
 p=B.b.H(255,j)
 if(!(r<b))return A.a(s,r)
 s[r]=q&p}}return s},
-kz(){var s,r
+kA(){var s,r
 for(s=this.f;;){r=s.bu(12)
-if(r==null){if(s.glK()){s.b=s.a.length
+if(r==null){if(s.glL()){s.b=s.a.length
 s.c=0}return}if(r===1){s.aP(0,12)
 continue}if(r>>>1===0){s.aP(0,1)
 continue}return}},
@@ -15476,7 +15476,7 @@ r=b.b=b.c=!0
 for(q=a.length,p=1;p<q;++p)if(a[p]<a[p-1]){b.b=!1
 break}b.d=0
 o=new A.jQ(b,a)
-for(n=c.b;b.a<n;){m=c.ka()
+for(n=c.b;b.a<n;){m=c.kb()
 if(m==null){if(s.length===0&&b.a<=0)return null
 throw A.d(B.ae)}l=o.$0()
 q=a.length
@@ -15497,14 +15497,14 @@ B.a.i(s,e)
 B.a.i(s,d)
 b.a=d
 break
-case 2:case 3:case 4:case 5:case 6:case 7:case 8:e=k+m.glR()
+case 2:case 3:case 4:case 5:case 6:case 7:case 8:e=k+m.glS()
 B.a.i(s,e)
 b.a=e
 b.c=!b.c
 break
 case 9:if(s.length===0)return null
 return s}}return s},
-ka(){var s,r,q,p,o,n=this.f
+kb(){var s,r,q,p,o,n=this.f
 if(n.bu(12)===1){n.aP(0,12)
 return B.cq}s=n.geo()
 if(s<=0)return null
@@ -15523,11 +15523,11 @@ n=B.b.q(p,4)-1
 if(!(n>=0&&n<10))return A.a(B.bm,n)
 return B.bm[n]},
 dZ(a){var s,r
-for(s=0;;){r=this.kd(a)
+for(s=0;;){r=this.ke(a)
 if(r==null)return null
 s+=r
 if(r<64)return s}},
-kd(a){var s,r,q,p,o=a?$.tK():$.tH(),n=this.f,m=n.geo()
+ke(a){var s,r,q,p,o=a?$.tK():$.tH(),n=this.f,m=n.geo()
 if(m<=0)return null
 if(m>=13){s=n.bu(13)
 s.toString
@@ -15582,7 +15582,7 @@ return B.b.bo(B.b.q(a,16),B.b.q(b,16))},
 $S:5}
 A.aB.prototype={
 aR(){return"_Mode."+this.b},
-glR(){var s,r=this
+glS(){var s,r=this
 A:{s=0
 if(B.aB===r)break A
 if(B.aC===r){s=1
@@ -15594,7 +15594,7 @@ break A}if(B.aH===r){s=-3
 break A}break A}return s}}
 A.fy.prototype={$iad:1}
 A.iS.prototype={
-glK(){var s,r=this.b,q=this.a,p=q.length
+glL(){var s,r=this.b,q=this.a,p=q.length
 if(r>=p)return!0
 if((q[r]&B.b.ah(255,this.c))!==0)return!1
 for(s=r+1;s<p;++s)if(q[s]!==0)return!1
@@ -15623,7 +15623,7 @@ A.hG.prototype={
 bM(a,b){var s
 t.L.a(a)
 s=A.vS(32768)
-B.cK.l6(A.oZ(a,B.aI,null,null),s,!1,!1)
+B.cK.l7(A.oZ(a,B.aI,null,null),s,!1,!1)
 return A.t3(s.hG(),b)}}
 A.kF.prototype={
 fC(b2){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0=this,b1=A.aI(b2)
@@ -15652,10 +15652,10 @@ if(a0===4294967295)throw A.d(B.dr)
 a1=k+a0
 if(a1>s)break
 a2=A.V(b2,k,a1)
-B:{if(0===g){l.k(0,j,b0.kg(a2,d))
-break B}if(16===g){m.k(0,j,b0.kc(a2))
-break B}if(20===g||22===g||23===g){b0.k6(a2,d)
-break B}if(4===g||6===g||7===g){b0.kh(a2,d)
+B:{if(0===g){l.k(0,j,b0.kh(a2,d))
+break B}if(16===g){m.k(0,j,b0.kd(a2))
+break B}if(20===g||22===g||23===g){b0.k7(a2,d)
+break B}if(4===g||6===g||7===g){b0.ki(a2,d)
 break B}if(36===g){n.k(0,j,b0.fI(a2).a[0])
 break B}if(38===g||39===g){i=b0.fI(a2).a
 a3=i[0]
@@ -15724,18 +15724,18 @@ i=new A.i(r.getInt8(18),r.getInt8(19))
 h=new A.i(r.getInt8(20),r.getInt8(21))
 g=22}else{g=18
 i=B.M
-h=B.M}f=this.jh(b)
+h=B.M}f=this.ji(b)
 e=A.dP(A.V(a,g,null))
 s=q?8192:1024
 d=new Int8Array(s)
 return new A.E([A.vu(e,d,new Uint8Array(s),p,o,f,j,i,h),n,m,l])},
-jh(a){var s,r,q,p,o
+ji(a){var s,r,q,p,o
 t.L.a(a)
 for(s=a.length,r=this.e,q=0;q<a.length;a.length===s||(0,A.j)(a),++q){p=r.h(0,a[q])
 if(p!=null)return p}o=this.f
 if(o!=null)return o
 throw A.d(B.d3)},
-kc(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e
+kd(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e
 if(a.length<7)throw A.d(B.cY)
 s=A.aI(a)
 r=a[0]
@@ -15757,7 +15757,7 @@ f=-p
 j=A.kG(i,h,g,l,o,q,q===0?A.b([new A.i(f,0),B.ay,B.av,B.cb],m):A.b([new A.i(f,0)],m),!1)}m=A.b([],t.j)
 for(e=0;e<n;++e)m.push(A.qz(j,e*p,0,p,o))
 return m},
-k6(b0,b1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9
+k7(b0,b1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9
 t.L.a(b1)
 if(b0.length<38)throw A.d(B.cZ)
 s=A.aI(b0)
@@ -15808,12 +15808,12 @@ for(e=0;e<a3;++e)for(m=e*a2,d=0;d<a2;++d){for(c=0,q=0;q<a4;++q)c=(c|B.b.X(r[q].a
 l=m+d
 if(!(l<n))return A.a(f,l)
 f[l]=c}return f},
-kg(b2,b3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1
+kh(b2,b3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1
 t.L.a(b3)
 s=A.aI(b2)
 r=s.getUint16(0,!1)
 q=r>>>10&3
-if((r&1)===1)return this.k7(b2,b3)
+if((r&1)===1)return this.k8(b2,b3)
 if((r>>>1&1)===1)throw A.d(B.dp)
 p=A.b([],t.u)
 o=q===0?4:1
@@ -15855,7 +15855,7 @@ if(!(a8>=0&&a8<i.length))return A.a(i,a8)
 B.a.i(a7,i[a8]);++m
 a8=b1}}else a8+=b0
 a9=!a9}return a7},
-k7(b6,b7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5
+k8(b6,b7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5
 t.L.a(b7)
 s=A.aI(b6)
 r=s.getUint16(0,!1)
@@ -15889,7 +15889,7 @@ j=e.b
 a6=j&7
 if(a6!==0)e.b=j+(8-a6)
 j=a5.a
-a7=j===0?e.lE(a3,b):A.p2(e.bw(j),a3,b)
+a7=j===0?e.lF(a3,b):A.p2(e.bw(j),a3,b)
 for(a8=a,a9=0;a8<a1;++a8){if(!(a8>=0&&a8<l))return A.a(c,a8)
 B.a.k(d,a8,A.qz(a7,a9,0,c[a8],b))
 a9+=c[a8]}}p=A.b([],k)
@@ -15909,7 +15909,7 @@ if(!(b2>=0&&b2<p.length))return A.a(p,b2)
 B.a.i(b1,p[b2]);++a8
 b2=b5}}else b2+=b4.a
 b3=!b3}return b1},
-kh(c1,c2){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0
+ki(c1,c2){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0
 t.L.a(c2)
 s=A.aI(c1)
 r=A.hV(s).a
@@ -15923,7 +15923,7 @@ k=l>>>4&3
 j=l>>>7&3
 i=l>>>10&31
 if(i>15)i-=32
-if((l&1)===1){this.k8(c1,c2)
+if((l&1)===1){this.k9(c1,c2)
 return}r=(l>>>1&1)===1
 h=r&&(l>>>15&1)===0?23:19
 g=s.getUint32(h,!1)
@@ -15961,7 +15961,7 @@ for(b5=b1,b6=!0;;b6=!1){if(!b6){b7=a1.b9(a4)
 if(b7==null)break
 b5+=b7+i}if(d)b8=0
 else{b=a1.b9(a5)
-b8=b==null?0:b}b9=a1.l4(a7,a8,a)
+b8=b==null?0:b}b9=a1.l5(a7,a8,a)
 if(r){b=a1.b9(a6)
 b=(b==null?0:b)!==0}else b=!1
 if(b)throw A.d(B.da)
@@ -15972,7 +15972,7 @@ c0=f[b9]
 A.qA(a9,c0,b5,b0+b8,j,k,e)
 b5+=(e?c0.b:c0.a)-1;++b2
 if(b2>=g)break}}this.dD().bp(a9,o,n,m)},
-k8(b5,b6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4
+k9(b5,b6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4
 t.L.a(b6)
 s=A.aI(b5)
 r=A.hV(s).a
@@ -16042,7 +16042,7 @@ p=o.a
 if(q>p.length)throw A.d(B.b0)
 o.b=s+a*8
 return A.V(p,r,q)},
-lE(a,b){var s,r,q,p,o,n,m,l
+lF(a,b){var s,r,q,p,o,n,m,l
 this.dm()
 s=B.b.q(a+7,3)
 r=this.bw(s*b)
@@ -16052,7 +16052,7 @@ if(!(l<p))return A.a(r,l)
 if((B.b.a8(r[l],7-(m&7))&1)!==0)q.cz(m,o,1)}return q},
 b4(a){var s,r,q,p,o,n
 for(s=0,r=1;r<=a.b;++r){s=(s<<1|this.bv(1))>>>0
-q=a.lc(r,s)
+q=a.ld(r,s)
 if(q==null)continue
 p=q.d
 o=q.c
@@ -16077,7 +16077,7 @@ j=r&&m===q-1
 i=n+1
 B.a.i(g,new A.j9(n,o,l.b,l.c,m===q-k,j))
 n=i}}},
-lc(a,b){var s,r,q,p
+ld(a,b){var s,r,q,p
 for(s=this.c,r=s.length,q=0;q<r;++q){p=s[q]
 if(p.b===a&&p.a===b)return p}return null}}
 A.j7.prototype={}
@@ -16096,7 +16096,7 @@ s=b*r.a+a
 q.$flags&2&&A.e(q)
 if(!(s>=0&&s<q.length))return A.a(q,s)
 q[s]=c},
-kV(a){var s,r
+kW(a){var s,r
 if(a===0)return
 s=this.c
 r=this.a
@@ -16122,11 +16122,11 @@ j[a1]=a}}}}
 A.kL.prototype={}
 A.j_.prototype={}
 A.fz.prototype={
-slA(a){this.z=t.L.a(a)},
-slz(a){this.Q=t.L.a(a)}}
+slB(a){this.z=t.L.a(a)},
+slA(a){this.Q=t.L.a(a)}}
 A.fR.prototype={
-sld(a){this.c=t.L.a(a)},
-sls(a){this.d=t.L.a(a)}}
+sle(a){this.c=t.L.a(a)},
+slt(a){this.d=t.L.a(a)}}
 A.n2.prototype={
 bL(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6=this,b7=b6.b
 if(b7.getUint16(0,!1)!==65359)throw A.d(B.d4)
@@ -16135,7 +16135,7 @@ A:for(r=b6.a,q=r.length,p=b6.ax,o=b6.at,n=b6.Q,m=b6.as,l=t.a,k=2;j=k+4,j<=q;){i=
 if(i===65497)break A
 h=k+2
 g=b7.getUint16(h,!1)
-switch(i){case 65361:b6.kf(j)
+switch(i){case 65361:b6.kg(j)
 break
 case 65362:if(!(j>=0&&j<q))return A.a(r,j)
 f=r[j]
@@ -16198,14 +16198,14 @@ p=b6.x
 p===$&&A.l()
 o=b6.r
 o===$&&A.l()
-a3=B.c.G((q-p)/o)
+a3=B.c.F((q-p)/o)
 o=b6.d
 o===$&&A.l()
 p=b6.y
 p===$&&A.l()
 q=b6.w
 q===$&&A.l()
-for(q=a3*B.c.G((o-p)/q),a4=0;a4<q;++a4){a5=s.h(0,a4)
+for(q=a3*B.c.F((o-p)/q),a4=0;a4<q;++a4){a5=s.h(0,a4)
 if(a5==null)continue
 b6.iP(a4,A.rm(a5),r)}q=b6.c
 p=b6.e
@@ -16229,7 +16229,7 @@ o=b4*b7.length+e
 n=B.b.n(b5,0,255)
 if(!(o<q))return A.a(a8,o)
 a8[o]=n}}return new A.kL(a6,a7,p,a8)},
-kf(a){var s,r,q,p,o,n,m,l,k,j,i,h,g=this,f=g.b
+kg(a){var s,r,q,p,o,n,m,l,k,j,i,h,g=this,f=g.b
 g.c=f.getUint32(a+2,!1)
 g.d=f.getUint32(a+6,!1)
 g.e=f.getUint32(a+10,!1)
@@ -16275,8 +16275,8 @@ for(s=a+5,o=0;o<=b.d;++o){r=s+o
 if(!(r<l))return A.a(m,r)
 n=m[r]
 B.a.i(q,n&15)
-B.a.i(p,n>>>4)}b.slA(q)
-b.slz(p)}},
+B.a.i(p,n>>>4)}b.slB(q)
+b.slA(p)}},
 fJ(a,b,c){var s,r,q,p,o,n,m=this.a,l=m.length
 if(!(a>=0&&a<l))return A.a(m,a)
 s=m[a]
@@ -16291,8 +16291,8 @@ B.a.i(q,m[o]>>>3)
 B.a.i(p,0)}else{c.a=r===1?1:2
 for(o=a+1,m=a+b,l=this.b;o+1<m;o+=2){n=l.getUint16(o,!1)
 B.a.i(q,n>>>11)
-B.a.i(p,n&2047)}}c.sld(q)
-c.sls(p)},
+B.a.i(p,n&2047)}}c.sle(q)
+c.slt(p)},
 iP(b4,b5,b6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3=this
 t.iu.a(b6)
 s=b3.c
@@ -16301,7 +16301,7 @@ r=b3.x
 r===$&&A.l()
 q=b3.r
 q===$&&A.l()
-p=B.c.G((s-r)/q)
+p=B.c.F((s-r)/q)
 o=B.b.am(b4,p)
 n=B.b.S(b4,p)
 q=b3.x
@@ -16331,7 +16331,7 @@ a=new A.cU(m,j,i,h,d,c,b,A.b([],q))
 a.hZ(m,j,i,h,d,c,b)
 r.push(a)}b3.iO(b5,r)
 s=A.b([],t.mr)
-for(q=r.length,a0=0;l=r.length,a0<l;r.length===q||(0,A.j)(r),++a0)s.push(r[a0].lJ())
+for(q=r.length,a0=0;l=r.length,a0<l;r.length===q||(0,A.j)(r),++a0)s.push(r[a0].lK())
 a1=i-m
 a2=h-j
 if(g.c===1&&s.length>=3){q=s.length
@@ -16422,7 +16422,7 @@ p===$&&A.l()
 q=r.r
 q===$&&A.l()
 if(c>=Math.max(p*q,0))return
-this.b.lF(r,c,d)},
+this.b.lG(r,c,d)},
 $S:44}
 A.n4.prototype={
 $2(a,b){var s,r
@@ -16445,10 +16445,10 @@ for(s=a0.e,r=a0.w,q=t.bl,p=a0.a,o=a0.b,n=a0.c,m=a0.d,l=0;l<=s.d;++l){k=A.b([],q)
 j=new A.ji(l,k)
 i=s.d-l
 h=B.b.H(1,i)
-g=j.b=B.c.G(p/h)
-f=j.c=B.c.G(o/h)
-e=j.d=B.c.G(n/h)
-h=j.e=B.c.G(m/h)
+g=j.b=B.c.F(p/h)
+f=j.c=B.c.F(o/h)
+e=j.d=B.c.F(n/h)
+h=j.e=B.c.F(m/h)
 d=s.z
 c=d.length
 if(c===0)b=15
@@ -16457,13 +16457,13 @@ b=d[l]}d=s.Q
 c=d.length
 if(c===0)a=15
 else{if(!(l<c))return A.a(d,l)
-a=d[l]}j.f=e>g?B.c.G(e/B.b.X(1,b))-B.b.q(g,b):0
-j.r=h>f?B.c.G(h/B.b.X(1,a))-B.b.q(f,a):0
+a=d[l]}j.f=e>g?B.c.F(e/B.b.X(1,b))-B.b.q(g,b):0
+j.r=h>f?B.c.F(h/B.b.X(1,a))-B.b.q(f,a):0
 if(l===0)B.a.i(k,A.mp(j,a0,0,0,0,i))
 else{B.a.i(k,A.mp(j,a0,1,0,1,i))
 B.a.i(k,A.mp(j,a0,0,1,1,i))
 B.a.i(k,A.mp(j,a0,1,1,2,i))}B.a.i(r,j)}},
-lJ(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3=this
+lK(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3=this
 for(s=a3.w,r=s.length,q=a3.e,p=0;o=s.length,p<o;s.length===r||(0,A.j)(s),++p)for(o=s[p].w,n=o.length,m=0;m<o.length;o.length===n||(0,A.j)(o),++m){l=o[m]
 for(k=l.Q,j=k.length,i=0;i<k.length;k.length===j||(0,A.j)(k),++i){h=k[i]
 g=l.d
@@ -16523,17 +16523,17 @@ a4.x!==$&&A.dx()
 a4.x=s}else{r=B.b.H(1,b1+1)
 q=B.b.H(1,b1)
 s=q*a9
-p=B.c.G((a8.a-s)/r)
+p=B.c.F((a8.a-s)/r)
 a4.f!==$&&A.dx()
 a4.f=p
 p=q*b0
-o=B.c.G((a8.b-p)/r)
+o=B.c.F((a8.b-p)/r)
 a4.r!==$&&A.dx()
 a4.r=o
-s=B.c.G((a8.c-s)/r)
+s=B.c.F((a8.c-s)/r)
 a4.w!==$&&A.dx()
 a4.w=s
-p=B.c.G((a8.d-p)/r)
+p=B.c.F((a8.d-p)/r)
 a4.x!==$&&A.dx()
 a4.x=p
 s=p}p=a8.e
@@ -16561,13 +16561,13 @@ m=s<=m
 s=m}else s=!0
 if(s)return
 i=B.b.aA(n,k)
-h=B.c.G(o/B.b.H(1,k))
+h=B.c.F(o/B.b.H(1,k))
 s=a4.r
 s===$&&A.l()
 g=B.b.aA(s,j)
 m=a4.x
 m===$&&A.l()
-f=B.c.G(m/B.b.H(1,j))
+f=B.c.F(m/B.b.H(1,j))
 for(l=a4.Q,e=t.a,d=g;d<f;d=g)for(g=d+1,c=i;c<h;c=b){b=c+1
 B.a.i(l,new A.c5(Math.max(B.b.H(c,k),n),Math.max(B.b.H(d,j),s),Math.min(B.b.H(b,k),o),Math.min(B.b.H(g,j),m),A.b([],e)))}o=p.z
 m=o.length
@@ -16591,7 +16591,7 @@ a7===$&&A.l()
 a5=a5.r
 a5===$&&A.l()
 a4.as=A.vF(Math.max(a7*a5,0),new A.mr(a4),t.gB)},
-jS(a,b){var s,r,q,p,o,n,m=this.h9(a)
+jT(a,b){var s,r,q,p,o,n,m=this.h9(a)
 if(m.length!==0){s=A.aq(m)
 r=s.l("c(1)")
 s=s.l("bd<1,c>")
@@ -16605,7 +16605,7 @@ for(s=this.Q,r=s.length,q=0;q<s.length;s.length===r||(0,A.j)(s),++q){p=s[q]
 if(p.e===a)o.push(p)}return o}}
 A.mr.prototype={
 $1(a){var s=this.a,r=s.Q,q=A.aq(r)
-return s.jS(a,new A.fq(r,q.l("X(1)").a(new A.mq(a)),q.l("fq<1>")).gp(0))},
+return s.jT(a,new A.fq(r,q.l("X(1)").a(new A.mq(a)),q.l("fq<1>")).gp(0))},
 $S:91}
 A.mq.prototype={
 $1(a){return t.U.a(a).e===this.a},
@@ -16645,7 +16645,7 @@ h[0]=4
 h[17]=3
 h[18]=46
 k.ax=(c&2)!==0
-k.l5(j.x)
+k.l6(j.x)
 j.z=p
 j.Q=o
 j.as=n}}
@@ -16665,7 +16665,7 @@ return B.b.a8(p.e,o)&1},
 cO(a){var s,r
 for(s=0,r=0;r<a;++r)s=(s<<1|this.bn())>>>0
 return s},
-lF(a4,a5,a6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2=this,a3=!1
+lG(a4,a5,a6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2=this,a3=!1
 if(a2.b){s=a2.d
 r=a2.a
 q=r.length
@@ -16707,7 +16707,7 @@ q===$&&A.l()
 d=B.b.aA(f.b,q)-h
 if(!(!f.f?k.hd(a2,e,d,s):a2.bn()===1))continue
 if(!f.f){f.f=!0
-f.r=j.l7(a2,e,d)}c=a2.kb()
+f.r=j.l8(a2,e,d)}c=a2.kc()
 b=f.w
 while(a2.bn()===1)++b
 f.w=b
@@ -16729,7 +16729,7 @@ a2.d=a3}for(s=p.length,r=a2.a,q=r.length,g=0;g<p.length;p.length===s||(0,A.j)(p)
 a1=Math.min(a3+a0.b,q)
 B.a.i(a0.a.y,A.V(r,a3,a1))
 a2.d=a1}},
-kb(){var s,r,q=this
+kc(){var s,r,q=this
 if(q.bn()===0)return 1
 if(q.bn()===0)return 2
 s=q.cO(2)
@@ -16758,8 +16758,8 @@ p=o*n
 B.a.i(q,new Int32Array(p))
 B.a.i(s,new Uint8Array(p))
 if(o===1&&n===1)break
-o=B.c.G(o/2)
-n=B.c.G(n/2)}},
+o=B.c.F(o/2)
+n=B.c.F(n/2)}},
 hd(a,b,c,d){var s,r,q,p,o,n,m,l,k,j=this.b,i=j.length
 for(s=i-1,r=this.c,q=this.a,p=i,o=0;s>=0;--s){n=B.b.aA(b,s)
 m=B.b.aA(c,s)
@@ -16798,7 +16798,7 @@ if(0>=q.length)return A.a(q,0)
 q=c*q[0]+b
 if(!(q>=0&&q<j.length))return A.a(j,q)
 return j[q]<d},
-l7(a,b,c){var s,r,q
+l8(a,b,c){var s,r,q
 for(s=1;!this.hd(a,b,c,s);)++s
 r=this.b
 if(0>=r.length)return A.a(r,0)
@@ -16907,7 +16907,7 @@ if(i<0||i>=r||!l||k)continue
 h=n*r+i
 if(!(h>=0&&h<q))return A.a(s,h)
 if(s[h]!==0)return!0}return!1},
-l5(a){var s,r=this,q=r.c-1,p=0,o=2
+l6(a){var s,r=this,q=r.c-1,p=0,o=2
 for(;;){if(!(p<a&&q>=0))break
 if(r.ax){s=r.Q
 s===$&&A.l()
@@ -16918,15 +16918,15 @@ B.d.ap(s,0,19,0)
 s.$flags&2&&A.e(s)
 s[0]=4
 s[17]=3
-s[18]=46}switch(o){case 0:r.kx(q)
+s[18]=46}switch(o){case 0:r.ky(q)
 break
-case 1:r.ki(q)
+case 1:r.kj(q)
 break
 case 2:r.iq(q)
 break}++p
 if(o===2){--q
 o=0}else ++o}},
-kx(a6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=this,a5=B.b.H(1,a6)
+ky(a6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=this,a5=B.b.H(1,a6)
 for(s=a4.b,r=a4.a,q=a4.z,p=q.$flags|0,o=a4.e,n=a4.x,m=n.length,l=n.$flags|0,k=a4.r,j=k.$flags|0,i=a4.f,h=i.$flags|0,g=a4.w,f=g.$flags|0,e=0;e<s;e=d)for(d=e+4,c=0;c<r;++c)for(b=Math.min(d,s),a=e;a<b;++a){a0=a*r+c
 if(!(a0>=0&&a0<m))return A.a(n,a0)
 if(n[a0]!==0||!a4.dL(c,a))continue
@@ -16950,7 +16950,7 @@ i[a0]=a5
 f&2&&A.e(g)
 if(!(a0<g.length))return A.a(g,a0)
 g[a0]=a6}}},
-ki(a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5=this,a6=B.b.H(1,a7)
+kj(a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5=this,a6=B.b.H(1,a7)
 for(s=a5.b,r=a5.a,q=a5.w,p=q.$flags|0,o=a5.e,n=a5.y,m=n.length,l=a5.x,k=l.length,j=a5.z,i=j.length,h=n.$flags|0,g=a5.f,f=g.length,e=g.$flags|0,d=0;d<s;d=c)for(c=d+4,b=0;b<r;++b)for(a=Math.min(c,s),a0=d;a0<a;++a0){a1=a0*r+b
 if(!(a1>=0&&a1<k))return A.a(l,a1)
 if(l[a1]!==0){if(!(a1<i))return A.a(j,a1)
@@ -17199,7 +17199,7 @@ if(typeof q!=="number")return A.n(q)
 o=(o<<1|q)>>>0}o+=4436}q=r===1
 if(q&&o===0)return null
 return q?-o:o},
-l4(a,b,c){var s,r
+l5(a,b,c){var s,r
 for(s=1,r=0;r<c;++r)s=(s<<1|this.aj(a,b,s))>>>0
 return s-B.b.X(1,c)}}
 A.kV.prototype={
@@ -17248,32 +17248,32 @@ case 93:n.b=s+1
 return new A.ay(B.aW,s,m)
 case 60:o=s+1
 if(o<q&&r[o]===60){n.b=s+2
-return new A.ay(B.cP,s,m)}return n.jo(s)
+return new A.ay(B.cP,s,m)}return n.jp(s)
 case 62:o=s+1
 if(o<q&&r[o]===62){n.b=s+2
 return new A.ay(B.ah,s,m)}throw A.d(A.C('unexpected ">"',s))
-case 40:return n.ju(s)
+case 40:return n.jv(s)
 case 41:throw A.d(A.C('unexpected ")"',s))
-case 47:return n.jx(s)
+case 47:return n.jy(s)
 case 123:n.b=s+1
 return new A.ay(B.p,s,"{")
 case 125:n.b=s+1
 return new A.ay(B.p,s,"}")
 default:r=!0
 if(p!==43)if(p!==45)if(p!==46)r=p>=48&&p<=57
-if(r)return n.jz(s)
-return n.js(s)}},
-jz(a){var s,r,q,p,o,n,m,l,k,j=this,i='malformed number "',h=j.b
+if(r)return n.jA(s)
+return n.jt(s)}},
+jA(a){var s,r,q,p,o,n,m,l,k,j=this,i='malformed number "',h=j.b
 for(s=j.a,r=s.length,q=!1;h<r;){if(!(h>=0))return A.a(s,h)
 p=s[h]
 if(!(p>=48&&p<=57||p===43||p===45)){if(p!==46)break
 q=!0}++h}j.b=h
-if(!q){o=j.jJ(a,h)
+if(!q){o=j.jK(a,h)
 if(o!=null)return new A.ay(B.w,a,o)
 n=A.a3(s,a,h)
 m=A.qZ(n,null)
 if(m==null)throw A.d(A.C(i+n+'"',a))
-return new A.ay(B.w,a,m)}l=j.jN(a,h)
+return new A.ay(B.w,a,m)}l=j.jO(a,h)
 if(l!=null)return new A.ay(B.aU,a,l)
 n=A.a3(s,a,h)
 k=B.f.aJ(n,".")?"0"+n:n
@@ -17281,7 +17281,7 @@ if(B.f.aJ(k,"-."))k="-0"+B.f.bh(k,1)
 o=A.cO(B.f.hg(k,".")?k+"0":k)
 if(o==null)throw A.d(A.C(i+n+'"',a))
 return new A.ay(B.aU,a,o)},
-jN(a,b){var s,r,q,p,o,n,m,l,k,j,i,h=this.a,g=h.length
+jO(a,b){var s,r,q,p,o,n,m,l,k,j,i,h=this.a,g=h.length
 if(!(a>=0&&a<g))return A.a(h,a)
 s=h[a]
 if(s===43||s===45){r=s===45
@@ -17297,7 +17297,7 @@ l=!0}}if(!l||o>15)return null
 if(!(n<16))return A.a(B.bq,n)
 i=p/B.bq[n]
 return r?-i:i},
-jJ(a,b){var s,r,q,p,o,n=this.a,m=n.length
+jK(a,b){var s,r,q,p,o,n=this.a,m=n.length
 if(!(a>=0&&a<m))return A.a(n,a)
 s=n[a]
 if(s===43||s===45){r=s===45
@@ -17307,7 +17307,7 @@ for(p=0;q<b;++q){if(!(q<m))return A.a(n,q)
 o=n[q]-48
 if(o<0||o>9)return null
 p=p*10+o}return r?-p:p},
-ju(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this,e="unterminated string";++f.b
+jv(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this,e="unterminated string";++f.b
 s=new A.bf($.b7())
 for(r=f.a,q=r.length,p=1;;){o=f.b
 for(n=o;n<q;){if(!(n>=0))return A.a(r,n)
@@ -17347,7 +17347,7 @@ s.ai(k)}else{if(l<q){if(!(l>=0))return A.a(r,l)
 n=r[l]===10}else n=!1
 if(n)f.b=l+1
 s.ai(10)}}return new A.ay(B.cO,a,s.aO())},
-jo(a){var s,r,q,p,o,n,m,l,k=this;++k.b
+jp(a){var s,r,q,p,o,n,m,l,k=this;++k.b
 s=new A.bf($.b7())
 for(r=k.a,q=r.length,p=null;;){o=k.b
 if(o>=q)throw A.d(A.C("unterminated hex string",a))
@@ -17363,15 +17363,15 @@ if(p==null)p=l
 else{s.ai((p<<4|l)>>>0)
 p=null}}if(p!=null)s.ai(p<<4>>>0)
 return new A.ay(B.I,a,s.aO())},
-jx(a){var s,r=this,q=++r.b,p=r.a,o=p.length,n=q
+jy(a){var s,r=this,q=++r.b,p=r.a,o=p.length,n=q
 for(;;){if(n<o){if(!(n>=0))return A.a(p,n)
 s=p[n]
 s=!(s===0||s===9||s===10||s===12||s===13||s===32)&&!A.hv(s)}else s=!1
 if(!s)break
 if(!(n>=0&&n<o))return A.a(p,n)
-if(p[n]===35)return r.jy(a,q);++n
+if(p[n]===35)return r.jz(a,q);++n
 r.b=n}return new A.ay(B.Q,a,A.a3(p,q,n))},
-jy(a,b){var s,r,q,p,o,n,m,l,k=this
+jz(a,b){var s,r,q,p,o,n,m,l,k=this
 k.b=b
 s=new A.bf($.b7())
 r=k.a
@@ -17391,14 +17391,14 @@ if(!(p<q))return A.a(r,p)
 l=A.kb(r[p])
 if(m!=null&&l!=null){n=(m<<4|l)>>>0
 k.b=o+2}}s.ai(n)}return new A.ay(B.Q,a,A.a3(s.aO(),0,null))},
-js(a){var s,r=this,q=r.b,p=r.a,o=p.length,n=q
+jt(a){var s,r=this,q=r.b,p=r.a,o=p.length,n=q
 for(;;){if(n<o){if(!(n>=0))return A.a(p,n)
 s=p[n]
 s=!(s===0||s===9||s===10||s===12||s===13||s===32)&&!A.hv(s)}else s=!1
 if(!s)break;++n}if(n===a){if(!(q>=0&&q<o))return A.a(p,q)
 throw A.d(A.C("unexpected byte 0x"+B.b.ev(p[q],16),a))}r.b=n
-return new A.ay(B.p,a,r.jq(a,n))},
-jq(a,b){var s,r,q,p,o,n,m=b-a
+return new A.ay(B.p,a,r.jr(a,n))},
+jr(a,b){var s,r,q,p,o,n,m=b-a
 if(m>3)return A.a3(this.a,a,b)
 s=this.a
 r=s.length
@@ -17527,8 +17527,8 @@ case 3:p.N()
 return new A.N(t.p.a(o.c),!0)
 case 4:p.N()
 return new A.u(A.ab(o.c))
-case 5:return p.jE()
-case 7:return p.jG()
+case 5:return p.jF()
+case 7:return p.jH()
 case 9:p.N()
 switch(A.ab(o.c)){case"true":return B.r
 case"false":return B.ag
@@ -17541,7 +17541,7 @@ s=q.bt()
 r=q.bg()
 if(r.a===B.p&&r.c==="endobj")q.N()
 return new A.ka(p,o,s)},
-jE(){var s,r,q,p=this
+jF(){var s,r,q,p=this
 p.N()
 s=A.b([],t.q)
 for(;;){r=p.bg()
@@ -17551,7 +17551,7 @@ if(q.length!==0)B.a.af(q,0)
 else p.a.N()
 break}if(q===B.E)throw A.d(A.C("unterminated array",r.b))
 B.a.i(s,p.bt())}return new A.q(s)},
-jG(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this
+jH(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this
 f.N()
 s=A.aO(null)
 for(r=s.a,q=f.a,p=f.c;;){o=f.bg()
@@ -17578,21 +17578,21 @@ if(k){++n
 q.b=n}}else{if(j){if(!(n>=0))return A.a(l,n)
 k=l[n]===10}else k=!1
 if(k){++n
-q.b=n}}h=f.km(r.h(0,"Length"))
-if(h!=null&&!f.j6(n+h))h=null
-r=n+(h==null?f.kt(n):h)
+q.b=n}}h=f.kn(r.h(0,"Length"))
+if(h!=null&&!f.j7(n+h))h=null
+r=n+(h==null?f.ku(n):h)
 g=A.V(l,n,r)
 B.a.C(p)
 q.b=r
 f.d8("endstream")
 return new A.A(s,g)}return s},
-km(a){var s,r
+kn(a){var s,r
 if(a instanceof A.av){s=this.b
 if(s==null)return null
 r=s.$1(a)}else r=a
 if(r instanceof A.m&&r.a>=0)return r.a
 return null},
-j6(a){var s,r,q,p
+j7(a){var s,r,q,p
 if(a<0||a>this.a.a.length)return!1
 s=this.a.a
 r=s.length
@@ -17606,7 +17606,7 @@ if(a+q>o)return!1
 for(s=0;s<q;++s){r=a+s
 if(!(r>=0&&r<o))return A.a(p,r)
 if(p[r]!==b.charCodeAt(s))return!1}return!0},
-kt(a){var s,r,q,p,o
+ku(a){var s,r,q,p,o
 for(s=this.a.a,r=s.length,q=a;q+9<=r;++q){if(!(q>=0&&q<r))return A.a(s,q)
 if(s[q]===101&&this.fl(q,"endstream")){if(q>a){p=q-1
 if(!(p>=0))return A.a(s,p)
@@ -17654,10 +17654,10 @@ A.bC.prototype={}
 A.hw.prototype={}
 A.kd.prototype={}
 A.ke.prototype={
-lS(a){var s,r,q,p,o,n,m=t.S,l=A.w(m,t.x),k=A.aO(null),j=this.b,i=A.b([a+j],t.t),h=A.aP(m)
+lT(a){var s,r,q,p,o,n,m=t.S,l=A.w(m,t.x),k=A.aO(null),j=this.b,i=A.b([a+j],t.t),h=A.aP(m)
 for(s=!1;i.length!==0;){r=B.a.af(i,0)
 if(!h.i(0,r))continue
-q=this.ly(r)
+q=this.lz(r)
 for(m=q.a,m=new A.d5(m,m.r,m.e,A.D(m).l("d5<1,2>"));m.u();){p=m.d
 l.aa(p.a,new A.kl(p))}if(!s){k=q.b
 s=!0}m=q.b.a
@@ -17665,7 +17665,7 @@ o=m.h(0,"XRefStm")
 if(o instanceof A.m)B.a.i(i,o.a+j)
 n=m.h(0,"Prev")
 if(n instanceof A.m)B.a.i(i,n.a+j)}return new A.kd(l,k,a)},
-ly(a){var s,r
+lz(a){var s,r
 if(a<0||a>=this.a.length)throw A.d(A.C("cross-reference offset out of range",a))
 s=new A.ca(new A.bN(this.a,a),null,A.b([],t.O))
 r=s.bg()
@@ -17701,17 +17701,17 @@ if(2>=q)return A.a(r,2)
 return new A.bC(B.aX,0,0,s,r[2])},
 $S:4}
 A.db.prototype={
-glq(){var s,r=this.b.a
+glr(){var s,r=this.b.a
 if(r.h(0,"IRT")==null)return!1
 s=this.a.a.j(r.h(0,"RT"))
 s=s instanceof A.u?s.a:null
 return s==null||s==="R"},
-gkQ(){var s,r=this.a.a,q=r.j(this.b.a.h(0,"BS"))
+gkR(){var s,r=this.a.a,q=r.j(this.b.a.h(0,"BS"))
 if(!(q instanceof A.r))return null
 s=r.j(q.a.h(0,"W"))
 if(s instanceof A.m)return s.a
 return s instanceof A.T?s.a:null},
-gkP(){var s,r,q,p,o,n,m=null,l=this.a.a,k=l.j(this.b.a.h(0,"BS"))
+gkQ(){var s,r,q,p,o,n,m=null,l=this.a.a,k=l.j(this.b.a.h(0,"BS"))
 if(!(k instanceof A.r))return m
 s=l.j(k.a.h(0,"D"))
 if(!(s instanceof A.q))return m
@@ -17719,7 +17719,7 @@ r=A.b([],t.n)
 for(q=s.a,p=q.length,o=0;o<q.length;q.length===p||(0,A.j)(q),++o){n=A.dR(l.j(q[o]))
 if(n==null||n<0)return m
 B.a.i(r,n)}return B.a.b8(r,new A.l_())?r:m},
-glr(){var s,r,q,p,o,n,m
+gls(){var s,r,q,p,o,n,m
 if(this.c!=="Line")return null
 s=this.a.a
 r=s.j(this.b.a.h(0,"L"))
@@ -17766,7 +17766,7 @@ if(typeof n!=="number")return n.H()
 m=r.$1(m.c)
 if(typeof m!=="number")return A.n(m)
 return(q<<16|n<<8|m)>>>0},
-gll(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d=null
+glm(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d=null
 if(this.c!=="Ink")return d
 s=this.a.a
 r=s.j(this.b.a.h(0,"InkList"))
@@ -17781,7 +17781,7 @@ if(!(h<j.length))return A.a(j,h)
 e=A.dR(s.j(j[h]))
 if(f==null||e==null)return d
 B.a.i(k,new A.i(f,e))}B.a.i(q,k)}return q},
-glu(){var s,r,q=this.a.a,p=this.b.a,o=q.j(p.h(0,"AP"))
+glv(){var s,r,q=this.a.a,p=this.b.a,o=q.j(p.h(0,"AP"))
 if(!(o instanceof A.r))return null
 s=q.j(o.a.h(0,"N"))
 if(s instanceof A.r){r=q.j(p.h(0,"AS"))
@@ -17797,7 +17797,7 @@ $1(a){return B.c.v(B.c.n(a,0,1)*255)},
 $S:9}
 A.ie.prototype={}
 A.f9.prototype={
-gle(){var s,r,q,p,o,n=this.a.a,m=this.b,l=A.aP(t.C)
+glf(){var s,r,q,p,o,n=this.a.a,m=this.b,l=A.aP(t.C)
 for(;;){if(!(m!=null&&l.i(0,m)))break
 s=m.a
 r=n.j(s.h(0,"V"))
@@ -17825,14 +17825,14 @@ s=m.b
 r=s.h(0,a)
 if(r!=null)return r
 q=t.C
-p=m.jg(m.gdT(),new A.j0(a),B.cn,A.aP(q))
+p=m.jh(m.gdT(),new A.j0(a),B.cn,A.aP(q))
 if(p!=null){s.k(0,a,p)
 return p}o=new A.j0(a)
 n=m.dJ(m.gdT(),o,B.cn,A.aP(q),!1)
 if(n==null)throw A.d(A.ws("page index "+a+" out of range: document has only "+(a-o.a)+" reachable pages"))
 s.k(0,a,n)
 return n},
-gjt(){var s,r=this,q=r.d
+gju(){var s,r=this,q=r.d
 if(q==null){q=A.w(t.C,t.S)
 for(s=0;s<J.a9(r.gcP());++s)q.k(0,J.a5(r.gcP(),s),s)
 r.d=q}return q},
@@ -17877,7 +17877,7 @@ l=l>=0&&a0.a>=l}else l=!1
 if(l){a0.a=a0.a-e.a
 continue}}d=this.dJ(g,a0,j,a2,a3)
 if(d!=null)return d}return c},
-jg(a,b,c,d){return this.dJ(a,b,c,d,!0)}}
+jh(a,b,c,d){return this.dJ(a,b,c,d,!0)}}
 A.l3.prototype={
 $0(){var s=A.cJ(),r=A.b([],t.cN),q=this.a
 q.eR(q.gdT(),r,A.aP(t.C))
@@ -17892,9 +17892,9 @@ A.pJ(c,t.l,"T","_own")
 c.l("0?").a(b)
 s=this.a.a.j(this.b.a.h(0,a))
 return c.b(s)?s:b},
-ghq(){var s=this.kE(this.fu("MediaBox",this.d,t.W))
+ghq(){var s=this.kF(this.fu("MediaBox",this.d,t.W))
 return s!=null&&s.c-s.a>0&&s.d-s.b>0?s:B.eV},
-gkM(){var s,r,q,p,o=this,n=o.a,m=n.a,l=m.j(o.b.a.h(0,"Annots")),k=l instanceof A.q,j=k?l.a.length:-1,i=o.r
+gkN(){var s,r,q,p,o=this,n=o.a,m=n.a,l=m.j(o.b.a.h(0,"Annots")),k=l instanceof A.q,j=k?l.a.length:-1,i=o.r
 if(i!=null&&l===o.w&&j===o.x)return i
 o.w=l
 o.x=j
@@ -17911,7 +17911,7 @@ r=null
 try{r=k.a7(s)}catch(l){if(p.b(A.J(l)))continue
 else throw l}if(m.gcr(0))m.ai(10)
 m.i(0,r)}return m.aO()},
-kE(a){var s,r,q,p,o,n,m
+kF(a){var s,r,q,p,o,n,m
 if(a==null||a.a.length<4)return null
 s=A.b([],t.n)
 for(r=this.a.a,q=a.a,p=0;p<4;++p){if(!(p<q.length))return A.a(q,p)
@@ -18096,7 +18096,7 @@ A.ch.prototype={}
 A.dV.prototype={}
 A.c_.prototype={}
 A.ib.prototype={
-lL(a,b,c){var s,r,q,p
+lM(a,b,c){var s,r,q,p
 t.oc.a(b)
 t.gf.a(c)
 s=this.db
@@ -18141,8 +18141,8 @@ if(q>=p)return 0
 if(!(r>=0&&r<p))return A.a(s,r)
 o=s[r]
 if(!(q>=0))return A.a(s,q)
-return(o<<8|s[q])>>>0}if(i.as||h.glj()){n=h.hI(a)
-if(n!==0)return n}m=i.j3(a)
+return(o<<8|s[q])>>>0}if(i.as||h.glk()){n=h.hI(a)
+if(n!==0)return n}m=i.j4(a)
 if(m!=null){n=h.ez(m)
 if(n!==0)return n}l=i.ha(a)
 if(l.length!==0){n=h.ez(new A.it(l).gaH(0))
@@ -18151,11 +18151,11 @@ if(k!==0)return k
 if(h.bE().length===0){j=i.ay.h(0,a)
 if(j==null){q=i.z
 j=q==null?null:q.d.h(0,a)}if(j!=null){q=h.x
-n=(q==null?h.x=h.jM():q).h(0,j)
+n=(q==null?h.x=h.jN():q).h(0,j)
 if(n==null)n=0
 if(n!==0)return n}}if(h.bE().length===0&&a<h.d)return a
 return 0},
-j3(a){var s,r,q,p=this
+j4(a){var s,r,q,p=this
 if(p.b)return null
 s=p.ay.h(0,a)
 if(s==null){r=p.z
@@ -18165,7 +18165,7 @@ if(A.qL(r)){q=B.bu.h(0,a)
 if(q!=null)return q}if(A.qN(r)){q=B.bt.h(0,a)
 if(q!=null)return q}if(a>=32&&a<=255)return a
 return null},
-kU(a){var s,r,q,p
+kV(a){var s,r,q,p
 if(this.at)return A.w0(a)
 s=this.ax
 if(s!=null)return s.ba(0,a)
@@ -18181,7 +18181,7 @@ q=s.h(0,a&255)
 return r+(q==null?j.d:q)}p=j.c.h(0,a)
 if(p!=null)return p
 o=j.x
-if(o!=null){n=o.kL(j.fb(a))
+if(o!=null){n=o.kM(j.fb(a))
 if(n!=null&&n>0)return n}m=j.y
 if(m!=null){s=j.eN(a)
 m.cs(s)
@@ -18349,7 +18349,7 @@ return r}catch(n){return null}},
 $S:12}
 A.k0.prototype={
 $4(a,b,c,d){var s=this.a,r=s.ft(c),q=s.ft(d)
-if(r!=null)this.b.cT().kN(r)
+if(r!=null)this.b.cT().kO(r)
 if(q!=null)this.b.cT().h0(q,a,b)},
 $S:61}
 A.k_.prototype={
@@ -18654,9 +18654,9 @@ s.at=f},
 im(){if(this.ch){B.a.i(this.z,B.q)
 this.ch=!1}},
 h0(a,b,c){var s,r,q,p,o=this,n=o.c4(b,c),m=o.c5(b,c)
-for(s=a.a,r=s.length,q=o.z,p=0;p<s.length;s.length===r||(0,A.j)(s),++p)B.a.i(q,o.kF(s[p],n,m))},
-kN(a){return this.h0(a,0,0)},
-kF(a,b,c){var s
+for(s=a.a,r=s.length,q=o.z,p=0;p<s.length;s.length===r||(0,A.j)(s),++p)B.a.i(q,o.kG(s[p],n,m))},
+kO(a){return this.h0(a,0,0)},
+kG(a,b,c){var s
 A:{if(a instanceof A.Y){s=new A.Y(a.a+b,a.b+c)
 break A}if(a instanceof A.M){s=new A.M(a.a+b,a.b+c)
 break A}if(a instanceof A.a8){s=new A.a8(a.a+b,a.b+c,a.c+b,a.d+c,a.e+b,a.f+c)
@@ -18734,7 +18734,7 @@ continue}}B.a.i(k,o)}return k},
 bW(a){return a>=55296&&a<=57343?"":A.O(a)}}
 A.m8.prototype={
 cs(a){return this.r.aa(a,new A.mc(this,a))},
-kL(a){var s,r,q=this,p=q.b.h(0,"hmtx")
+kM(a){var s,r,q=this,p=q.b.h(0,"hmtx")
 if(p==null||q.f===0)return null
 s=Math.min(a,q.f-1)
 r=new A.cq(q.a)
@@ -18757,8 +18757,8 @@ return p.df(a)}return 0},
 hH(a){var s,r,q,p
 for(s=this.bE(),r=s.length,q=0;q<r;++q){p=s[q]
 if(p.c===1&&p.d===0)return p.df(a)}return 0},
-glj(){return B.a.b8(this.bE(),new A.mb())},
-jM(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=this.b.h(0,"post")
+glk(){return B.a.b8(this.bE(),new A.mb())},
+jN(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=this.b.h(0,"post")
 if(a1==null)return B.Z
 try{d=new A.cq(this.a)
 d.b=a1.a
@@ -18829,7 +18829,7 @@ else{q=g
 if(typeof q!=="number")return q.aW()
 e=q-258
 q=e
-if(typeof q!=="number")return q.lX()
+if(typeof q!=="number")return q.lY()
 if(q>=0){q=e
 k=J.a9(n)
 if(typeof q!=="number")return q.a4()
@@ -18839,7 +18839,7 @@ f=q?J.a5(n,e):null}if(f!=null)i.aa(f,new A.ma(h))
 q=h
 if(typeof q!=="number")return q.P()
 h=q+1}return i}catch(a0){return B.Z}},
-jm(a){var s,r,q,p=this,o=p.b,n=o.h(0,"loca"),m=o.h(0,"glyf")
+jn(a){var s,r,q,p=this,o=p.b,n=o.h(0,"loca"),m=o.h(0,"glyf")
 if(n==null||m==null)return null
 if(a<0||a>=p.d)return null
 s=new A.cq(p.a)
@@ -18853,15 +18853,15 @@ o=m.a
 return new A.i(o+r,o+q)},
 fc(a,b){var s,r,q,p=this
 if(b>5)return null
-s=p.jm(a)
+s=p.jn(a)
 if(s==null)return null
 r=new A.cq(p.a)
 r.b=s.a
 q=r.dl()
 r.b+=8
-if(q>=0)return p.ky(r,q)
+if(q>=0)return p.kz(r,q)
 return p.it(r,b)},
-ky(a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2=t.t,a3=A.b([],a2)
+kz(a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2=t.t,a3=A.b([],a2)
 for(s=0;s<a5;++s)a3.push(a4.I())
 r=a5===0?0:B.a.gaq(a3)+1
 q=a4.I()
@@ -18923,7 +18923,7 @@ j=(o>32767?o-65536:o)/16384}else{i=1
 j=1}h=this.fc(p,s)
 if(h!=null)for(g=h.length,f=0;f<h.length;h.length===g||(0,A.j)(h),++f){e=h[f]
 d=A.b([],r)
-for(c=B.a.gV(e);c.u();){b=c.gF()
+for(c=B.a.gV(e);c.u();){b=c.gG()
 a=b.a
 a0=b.b
 d.push(new A.bI(i*a+k*a0+n,l*a+j*a0+m,b.c))}B.a.i(a1,d)}if((q&32)===0)break}return a1},
@@ -19005,7 +19005,7 @@ s.b+=4
 s.b+=a
 i=s.O()
 return i
-case 4:i=this.jk(s,a)
+case 4:i=this.jl(s,a)
 return i
 case 6:s.b+=4
 q=s.I()
@@ -19048,7 +19048,7 @@ return i+(a-h)}i=n
 if(typeof i!=="number")return i.P()
 n=i+1}return 0
 default:return 0}}catch(g){return 0}},
-jk(a,b){var s,r,q,p,o,n,m,l,k,j,i,h
+jl(a,b){var s,r,q,p,o,n,m,l,k,j,i,h
 if(b<0||b>65535)return 0
 a.b+=4
 s=a.I()/2|0
@@ -19243,10 +19243,10 @@ p=o
 break
 case 12:p=o+1
 if(!(o<c))return A.a(a,o)
-d.j8(a[o])
+d.j9(a[o])
 break
 default:p=o}}}--d.ax},
-j8(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this
+j9(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this
 switch(a){case 0:case 1:case 2:B.a.C(f.e)
 break
 case 6:s=f.aQ(0)
@@ -19476,7 +19476,7 @@ if(b1){n=o[i]
 if(!(i<p))return A.a(s,i)
 b2=Math.min(n+1,s[i]-1)}else b2=o[i]
 b0+=b2*a4[i]}if(a9===0)continue
-for(p=b0*q,g=0;g<q;++g)B.a.k(a6,g,a6[g]+a9*b3.ks(p+g)/a5)}s=A.b([],t.n)
+for(p=b0*q,g=0;g<q;++g)B.a.k(a6,g,a6[g]+a9*b3.kt(p+g)/a5)}s=A.b([],t.n)
 for(g=0;g<q;++g)s.push(b3.f0(a6[g],g))
 return s},
 f0(a,b){var s,r,q,p,o,n,m,l,k=this.r
@@ -19493,7 +19493,7 @@ m=r[s]
 if(!(p<n))return A.a(r,p)
 l=r[p]
 return B.c.n(q+a*(o-q),Math.min(m,l),Math.max(m,l))},
-ks(a){var s,r,q,p,o,n,m,l,k=this,j=k.d
+kt(a){var s,r,q,p,o,n,m,l,k=this,j=k.d
 if(j===8){j=k.c
 s=j.length
 if(a<s){if(!(a>=0))return A.a(j,a)
@@ -19617,7 +19617,7 @@ A.kv.prototype={
 $1(a){return this.a.h(0,a)},
 $S:70}
 A.kt.prototype={
-$1(a){var s,r,q,p,o=this.a.kO(t.H.a(a))
+$1(a){var s,r,q,p,o=this.a.kP(t.H.a(a))
 if(this.b==="Lab "){s=o.length
 if(0>=s)return A.a(o,0)
 r=o[0]
@@ -19747,7 +19747,7 @@ A.H(a)
 return a>=s.a?Math.pow(s.b*a+s.c,s.d)+s.e:s.f*a+s.r},
 $S:1}
 A.je.prototype={
-kO(a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3=this
+kP(a4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3=this
 t.H.a(a4)
 s=t.n
 r=A.b([],s)
@@ -19822,15 +19822,15 @@ $1(a){t.y.a(a)
 return a.a===0&&a.b===1},
 $S:74}
 A.fC.prototype={
-sl1(a){this.a=t.ge.a(a)},
-slh(a){this.y=t.H.a(a)}}
+sl2(a){this.a=t.ge.a(a)},
+sli(a){this.y=t.H.a(a)}}
 A.mk.prototype={}
 A.f0.prototype={}
 A.cG.prototype={$iad:1}
 A.id.prototype={
-cl(a,b,c,d){return this.l9(a,b,c,d)},
-l8(a,b,c){return this.cl(a,b,null,c)},
-l9(a,b,c,d){var s=0,r=A.aV(t.o),q=1,p=[],o=[],n=this,m,l,k
+cl(a,b,c,d){return this.la(a,b,c,d)},
+l9(a,b,c){return this.cl(a,b,null,c)},
+la(a,b,c,d){var s=0,r=A.aV(t.o),q=1,p=[],o=[],n=this,m,l,k
 var $async$cl=A.aW(function(e,f){if(e===1){p.push(f)
 s=q}for(;;)switch(s){case 0:if(d<=0)throw A.d(A.hb(d,"yieldInterval","must be > 0"))
 n.e=A.j8()
@@ -19858,17 +19858,17 @@ case 1:return A.aS(p.at(-1),r)}})
 return A.aU($async$cl,r)},
 hf(a){var s,r,q,p,o,n,m
 this.ay=a.ghq()
-for(s=a.gkM(),r=s.length,q=0;q<s.length;s.length===r||(0,A.j)(s),++q){p=s[q]
+for(s=a.gkN(),r=s.length,q=0;q<s.length;s.length===r||(0,A.j)(s),++q){p=s[q]
 o=p.e
 if((o&2)!==0||(o&32)!==0)continue
 if(p.c==="Popup")continue
-if(!p.glq()){n=p.a.a.j(p.b.a.h(0,"StateModel"))
+if(!p.glr()){n=p.a.a.j(p.b.a.h(0,"StateModel"))
 o=(n instanceof A.N?n.gaU():null)!=null}else o=!0
 if(o)continue
-m=p.glu()
-if(m==null)this.iW(p)
-else this.iV(m,p.d)}},
-iW(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b=this
+m=p.glv()
+if(m==null)this.iX(p)
+else this.iW(m,p.d)}},
+iX(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b=this
 A:{s=a.c
 if("Square"===s){r=b.bC(a)
 q=b.e0(b.fh(a.d,r.a/2))
@@ -19915,11 +19915,11 @@ m=a.b6(m.h(0,"C"))
 n=b.bm(m==null?0:m)
 m=b.aX(a,"CA")
 if(m==null)m=1
-B.a.i(p.gB(),new A.b3(q,n,r,m))}break A}if("Line"===s){b.iY(a)
-break A}if("Ink"===s){b.iX(a)
-break A}if("Highlight"===s||"Underline"===s||"StrikeOut"===s||"Squiggly"===s){b.iZ(a)
-break A}if("Widget"===s)if(a instanceof A.f9)b.j_(a)}},
-iY(a){var s,r,q,p,o,n=this,m=a.glr()
+B.a.i(p.gB(),new A.b3(q,n,r,m))}break A}if("Line"===s){b.iZ(a)
+break A}if("Ink"===s){b.iY(a)
+break A}if("Highlight"===s||"Underline"===s||"StrikeOut"===s||"Squiggly"===s){b.j_(a)
+break A}if("Widget"===s)if(a instanceof A.f9)b.j0(a)}},
+iZ(a){var s,r,q,p,o,n=this,m=a.gls()
 if(m==null)return
 s=n.b
 r=m.a
@@ -19931,9 +19931,9 @@ p=n.bC(a)
 o=n.aX(a,"CA")
 if(o==null)o=1
 B.a.i(s.gB(),new A.b3(new A.an(q),r,p,o))},
-iX(a){var s,r,q,p,o,n,m,l,k,j,i,h,g=this,f=a.gll()
+iY(a){var s,r,q,p,o,n,m,l,k,j,i,h,g=this,f=a.glm()
 if(f==null)return
-s=g.bC(a).l_(1,B.C,1)
+s=g.bC(a).l0(1,B.C,1)
 for(r=f.length,q=a.b.a,p=t.g,o=0;o<f.length;f.length===r||(0,A.j)(f),++o){n=f[o]
 if(B.a.gau(n))continue
 m=A.b([new A.Y(B.a.gaH(n).a,B.a.gaH(n).b)],p)
@@ -19947,7 +19947,7 @@ if(i==null)i=1
 h=l.c
 if(h===$)h=l.c=l.a
 B.a.i(h,new A.b3(new A.an(m),k,s,i))}},
-iZ(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this,e=f.jU(a)
+j_(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f=this,e=f.jV(a)
 if(e.length===0)return
 s=a.b6(a.b.a.h(0,"C"))
 r=f.bm(s==null?16776960:s)
@@ -19976,23 +19976,23 @@ k=m.c
 if(k===$)k=m.c=m.a
 B.a.i(k,new A.b3(new A.an(h),r,l,g))}break A}if("Squiggly"===q)for(s=e.length,p=0;p<e.length;e.length===s||(0,A.j)(e),++p){o=e[p]
 n=f.b
-m=f.kA(o)
+m=f.kB(o)
 l=f.bC(a).cj(Math.max(1,(o.d-o.b)*0.06))
 h=f.aX(a,"CA")
 if(h==null)h=1
 k=n.c
 if(k===$)k=n.c=n.a
 B.a.i(k,new A.b3(m,r,l,h))}}},
-j_(a){var s,r,q,p,o,n,m,l,k,j,i,h,g=this,f=null
+j0(a){var s,r,q,p,o,n,m,l,k,j,i,h,g=this,f=null
 if(a.w!=="Tx")return
-m=a.gle()
+m=a.glf()
 if(m==null||m.length===0)return
 s=a.d
 l=s
 if(!(l.c-l.a<=0)){l=s
 l=l.d-l.b<=0}else l=!0
 if(l)return
-r=g.jQ(a)
+r=g.jR(a)
 q=r.c
 p=A.tx(m,"\n"," ")
 l=A.zc(p,q)
@@ -20015,7 +20015,7 @@ l=s.a
 i=r.a
 h=r.b
 B.a.i(k.gB(),new A.bW(new A.dV(f,!0,f,0,!1,p,new A.a0(q,0,0,q,l+2,n),i,f,o,h,q,f)))}finally{B.a.i(g.b.gB(),B.u)}},
-jQ(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d=this.kH(a)
+jR(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d=this.kI(a)
 if(d==null)d=""
 s=A.c2("/(\\S+)\\s+([\\d.]+)\\s+Tf").cp(d)
 r=s==null
@@ -20053,7 +20053,7 @@ j=j[3]
 e=A.cO(j==null?"":j)
 if(e==null)e=0
 l=new A.L(B.c.n(g,0,1),B.c.n(f,0,1),B.c.n(e,0,1))}}return new A.fT(l,p,n)},
-kH(a){var s,r,q,p,o=a.a.a,n=a.b,m=A.aP(t.C)
+kI(a){var s,r,q,p,o=a.a.a,n=a.b,m=A.aP(t.C)
 for(;;){if(!(n!=null&&m.i(0,n)))break
 s=n.a
 r=o.j(s.h(0,"DA"))
@@ -20062,10 +20062,10 @@ q=o.j(s.h(0,"Parent"))
 n=q instanceof A.r?q:null}p=o.j(o.gci().a.h(0,"AcroForm"))
 if(p instanceof A.r){r=o.j(p.a.h(0,"DA"))
 if(r instanceof A.N)return r.gaU()}return null},
-bC(a){var s,r=a.gkQ()
+bC(a){var s,r=a.gkR()
 if(r==null)r=this.i4(a)
 if(r==null)r=1
-s=a.gkP()
+s=a.gkQ()
 return new A.dU(r,0,0,10,s==null?B.C:s,0)},
 i4(a){var s,r,q,p=this.a,o=p.j(a.b.a.h(0,"Border"))
 if(!(o instanceof A.q)||o.a.length<3)return null
@@ -20092,7 +20092,7 @@ e0(a){var s=a.a,r=a.b,q=a.c,p=a.d
 return new A.an(A.b([new A.Y(s,r),new A.M(q,r),new A.M(q,p),new A.M(s,p),B.q],t.g))},
 fh(a,b){var s=a.c,r=a.a,q=Math.min(b,(s-r)/2),p=a.d,o=a.b,n=Math.min(b,(p-o)/2)
 return new A.al(r+q,o+n,s-q,p-n)},
-jU(a){var s,r,q,p,o,n,m,l,k,j,i=this.a,h=i.j(a.b.a.h(0,"QuadPoints"))
+jV(a){var s,r,q,p,o,n,m,l,k,j,i=this.a,h=i.j(a.b.a.h(0,"QuadPoints"))
 if(!(h instanceof A.q))return B.ee
 s=A.b([],t.eF)
 for(r=h.a,q=t.n,p=0;p+7<r.length;p+=8){o=A.b([],q)
@@ -20104,7 +20104,7 @@ if(!(l<r.length))return A.a(r,l)
 j=A.aj(i.j(r[l]))
 B.a.i(o,k)
 B.a.i(n,j)}B.a.i(s,new A.al(B.a.aD(o,B.U),B.a.aD(n,B.U),B.a.aD(o,B.V),B.a.aD(n,B.V)))}return s},
-kA(a){var s,r=a.b,q=a.d-r,p=r+q*0.12,o=Math.max(1,q*0.06),n=o*2,m=a.a,l=A.b([new A.Y(m,p)],t.g)
+kB(a){var s,r=a.b,q=a.d-r,p=r+q*0.12,o=Math.max(1,q*0.06),n=o*2,m=a.a,l=A.b([new A.Y(m,p)],t.g)
 for(r=a.c,q=-o,s=!0;m<r;){m=Math.min(r,m+n)
 B.a.i(l,new A.M(m,p+(s?o:q)))
 s=!s}return new A.an(l)},
@@ -20115,7 +20115,7 @@ try{s=this.a.a7(a)}catch(r){if(t.I.b(A.J(r)))return null
 else throw r}q=A.k4(s)
 p.k(0,a,q)
 return q},
-iV(b2,b3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0=this,b1=b0.dU(b2)
+iW(b2,b3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0=this,b1=b0.dU(b2)
 if(b1==null)return
 s=b2.a
 k=b0.a
@@ -20142,7 +20142,7 @@ g=b0.x
 n=g.length
 B.a.i(b0.b.gB(),B.o)
 try{f=A.j8()
-f.sl1(q)
+f.sl2(q)
 b0.e=f
 if(J.a9(r)>=4)b0.cF(r)
 m=k.j(s.a.h(0,"Resources"))
@@ -20173,7 +20173,7 @@ s=n.at
 q=n.x
 r=q.length
 n.at=c
-try{n.kq(a,b,c)}finally{for(;;){p=q.length
+try{n.kr(a,b,c)}finally{for(;;){p=q.length
 o=r
 if(typeof o!=="number")return A.n(o)
 if(!(p>o))break
@@ -20185,8 +20185,8 @@ if(typeof o!=="number")return A.n(o)
 if(!(p>o))break
 if(0>=p)return A.a(q,-1)
 q.pop()}n.at=s}},
-cV(a,b,c,d){return this.kp(a,b,c,d)},
-kp(a,b,c,d){var s=0,r=A.aV(t.o),q,p=2,o=[],n=[],m=this,l,k,j,i,h
+cV(a,b,c,d){return this.kq(a,b,c,d)},
+kq(a,b,c,d){var s=0,r=A.aV(t.o),q,p=2,o=[],n=[],m=this,l,k,j,i,h
 var $async$cV=A.aW(function(e,f){if(e===1){o.push(f)
 s=p}for(;;)A:switch(s){case 0:j=m.at
 i=m.x
@@ -20242,8 +20242,8 @@ s=3
 break
 case 4:case 1:return A.aT(q,r)}})
 return A.aU($async$cW,r)},
-kq(a,b,c){var s,r,q,p=this.c
-for(s=J.b8(t.D.a(a)),r=0;s.u();){q=s.gF();++r
+kr(a,b,c){var s,r,q,p=this.c
+for(s=J.b8(t.D.a(a)),r=0;s.u();){q=s.gG();++r
 if((r&63)===0)if(p.a)throw A.d(B.A)
 this.f6(q,b,c)}},
 f6(a4,a5,a6){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1=this,a2=null,a3=a4.b
@@ -20276,7 +20276,7 @@ break A}if("b"===s){a1.c6()
 a1.bl(B.l,!0)
 break A}if("b*"===s){a1.c6()
 a1.bl(B.F,!0)
-break A}if("n"===s){a1.jD()
+break A}if("n"===s){a1.jE()
 break A}if("W"===s){a1.dx=B.l
 break A}if("W*"===s){a1.dx=B.F
 break A}if("q"===s){B.a.i(a1.f,A.pi(a1.e))
@@ -20301,11 +20301,11 @@ B.a.i(a1.b.gB(),B.u)}break A}if("cm"===s){a1.e.a=A.f5(a3).a6(a1.e.a)
 break A}if("w"===s){n=a1.e
 n.f=n.f.cj(A.x(a3,0))
 break A}if("J"===s){n=a1.e
-n.f=n.f.kW(B.c.M(A.x(a3,0)))
-break A}if("j"===s){n=a1.e
 n.f=n.f.kX(B.c.M(A.x(a3,0)))
+break A}if("j"===s){n=a1.e
+n.f=n.f.kY(B.c.M(A.x(a3,0)))
 break A}if("M"===s){n=a1.e
-n.f=n.f.kY(A.x(a3,0))
+n.f=n.f.kZ(A.x(a3,0))
 break A}if("d"===s){n=a1.e
 m=n.f
 j=a3.length
@@ -20317,7 +20317,7 @@ i=t.W.a(a3[0]).a
 h=i.length
 g=0
 for(;g<i.length;i.length===h||(0,A.j)(i),++g)j.push(A.aj(i[g]))}else j=B.C
-n.f=m.kZ(j,A.x(a3,1))
+n.f=m.l_(j,A.x(a3,1))
 break A}if("gs"===s){a1.i8(a1.iT(a5,"ExtGState",a3))
 break A}if("ri"===s||"i"===s)break A
 if("g"===s){n=a1.e
@@ -20348,8 +20348,8 @@ if(a3.length!==0&&B.a.gaq(a3) instanceof A.u){a1.e.x=a1.e4(a5,"Pattern",t.G.a(B.
 n=a1.e
 m=A.b([],t.n)
 for(j=a3.length,g=0;g<a3.length;a3.length===j||(0,A.j)(a3),++g){f=a3[g]
-if(f instanceof A.m||f instanceof A.T)m.push(A.aj(f))}n.slh(m)}else{n=a1.e
-n.b=A.qT(n.r,a3,n.b)}break A}if("SC"===s||"SCN"===s){if(a3.length!==0&&B.a.gaq(a3) instanceof A.u){e=a1.jR(a1.e4(a5,"Pattern",t.G.a(B.a.gaq(a3))))
+if(f instanceof A.m||f instanceof A.T)m.push(A.aj(f))}n.sli(m)}else{n=a1.e
+n.b=A.qT(n.r,a3,n.b)}break A}if("SC"===s||"SCN"===s){if(a3.length!==0&&B.a.gaq(a3) instanceof A.u){e=a1.jS(a1.e4(a5,"Pattern",t.G.a(B.a.gaq(a3))))
 if(e!=null)a1.e.c=e}else{n=a1.e
 n.c=A.qT(n.w,a3,n.c)}break A}if("BT"===s){a1.id=a1.go=B.v
 a1.k1=!1
@@ -20413,12 +20413,12 @@ i=i==null?a2:i.e
 h=j.ax
 a0=a1.go
 if(i===!0)a1.go=new A.a0(1,0,0,1,0,-A.aj(a)/1000*h).a6(a0)
-else a1.go=new A.a0(1,0,0,1,-A.aj(a)/1000*h*j.CW,0).a6(a0)}}}break A}if("Do"===s){if(a1.gbF())a1.iU(a5,a3,a6)
-break A}if("BI"===s){if(a1.gbF())a1.j0(a3)
+else a1.go=new A.a0(1,0,0,1,-A.aj(a)/1000*h*j.CW,0).a6(a0)}}}break A}if("Do"===s){if(a1.gbF())a1.iV(a5,a3,a6)
+break A}if("BI"===s){if(a1.gbF())a1.j1(a3)
 break A}if("sh"===s){n=a1.gbF()
 if(n)a1.i9(a5,a3)
-break A}if("BDC"===s){B.a.i(a1.x,a1.jw(a5,a3))
-B.a.i(a1.y,a1.jv(a5,a3))
+break A}if("BDC"===s){B.a.i(a1.x,a1.jx(a5,a3))
+B.a.i(a1.y,a1.jw(a5,a3))
 break A}if("BMC"===s){B.a.i(a1.x,!0)
 B.a.i(a1.y,a2)
 break A}if("EMC"===s){n=a1.x
@@ -20432,7 +20432,7 @@ gbF(){return B.a.bP(this.x,new A.lc())},
 giz(){var s,r,q
 for(s=this.y,r=s.length-1;r>=0;--r){q=s[r]
 if(q!=null)return q}return null},
-jv(a,b){var s,r,q,p,o,n=null
+jw(a,b){var s,r,q,p,o,n=null
 t.Q.a(b)
 if(b.length<2)return n
 s=b[1]
@@ -20443,7 +20443,7 @@ if(p==null)return n
 s=r.j(p)}if(!(s instanceof A.r))return n
 o=this.a.j(s.a.h(0,"MCID"))
 return o instanceof A.m?o.a:n},
-jw(a,b){var s,r,q,p
+jx(a,b){var s,r,q,p
 t.Q.a(b)
 s=b.length
 if(s>=2){if(0>=s)return A.a(b,0)
@@ -20453,8 +20453,8 @@ if(r)return!0
 if(1>=s)return A.a(b,1)
 q=b[1]
 if(q instanceof A.u){p=this.a.j(a.a.h(0,"Properties"))
-q=p instanceof A.r?p.a.h(0,q.a):null}return this.jC(q)},
-jC(a){var s,r,q,p,o
+q=p instanceof A.r?p.a.h(0,q.a):null}return this.jD(q)},
+jD(a){var s,r,q,p,o
 if(a==null)return!0
 s=this.a
 r=s.j(a)
@@ -20494,8 +20494,8 @@ switch(n){case"Not":return!l.dG(m.gp(0)===0?null:m.gaH(0))
 case"And":return m.bP(0,l.gf5())
 case"Or":return m.b8(0,l.gf5())
 default:return!0}},
-c8(a){return new A.cT(this.jB(a),t.lp)},
-jB(a){var s=this
+c8(a){return new A.cT(this.jC(a),t.lp)},
+jC(a){var s=this
 return function(){var r=a
 var q=0,p=2,o=[],n,m,l,k,j
 return function $async$c8(b,c,d){if(c===1){o.push(d)
@@ -20512,7 +20512,7 @@ break
 case 6:k=j.a,n=k.length,m=0
 case 9:if(!(m<k.length)){q=11
 break}q=12
-return b.kJ(s.c8(k[m]))
+return b.kK(s.c8(k[m]))
 case 12:case 10:k.length===n||(0,A.j)(k),++m
 q=9
 break
@@ -20528,13 +20528,13 @@ return b.b=l,1
 case 17:case 16:case 14:case 7:case 1:return 0
 case 2:return b.c=o.at(-1),3}}}},
 dS(a){var s,r=this
-r.j7()
+r.j8()
 s=r.Q
 if((s==null?null:s.Y(0,a))===!0)return!1
 s=r.z
 if((s==null?null:s.Y(0,a))===!0)return!0
 return r.as!=="OFF"},
-j7(){var s,r,q,p,o,n,m=this
+j8(){var s,r,q,p,o,n,m=this
 if(m.z!=null)return
 p=t.md
 m.z=A.aP(p)
@@ -20590,7 +20590,7 @@ k=l.e.f
 r=A.b([],t.n)
 for(q=l.e.f.e,o=q.length,n=0;n<q.length;q.length===o||(0,A.j)(q),++n)r.push(q[n]*p)
 q=l.e
-m=k.l0(r,q.f.f*p,k.a*p)
+m=k.l1(r,q.f.f*p,k.a*p)
 k=l.b
 r=q.c
 q=q.e
@@ -20599,7 +20599,7 @@ if(k!=null)B.a.i(l.b.gB(),new A.aQ(j,k))}l.dx=null
 l.ch=A.b([],i)},
 fw(a){return this.bl(null,a)},
 fv(a){return this.bl(a,!1)},
-jD(){return this.bl(null,!1)},
+jE(){return this.bl(null,!1)},
 i8(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c=this
 if(a==null)return
 s=c.a
@@ -20709,7 +20709,7 @@ s=this.b
 r=this.ay
 if(r==null)r=B.ar
 s.cm(r,a.d,new A.li(this,a),a.c,a.f,a.e)},
-kr(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
+ks(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
 if(e.at>=16)return
 j=a.a
 s=e.dU(j)
@@ -20751,7 +20751,7 @@ B.a.i(e.b.gB(),B.u)}},
 cd(a,b){this.go=this.id=A.ig(a,b).a6(this.id)},
 cX(c3){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8=this,b9=null,c0=b8.e,c1=c0.as,c2=c0.ax
 if(c1==null)return
-s=c1.kU(c3)
+s=c1.kV(c3)
 r=b8.k4
 if(r)q=new A.c3("")
 else{q=b8.k3
@@ -20775,7 +20775,7 @@ a2=g?0:c/c2-a2/1000
 B.a.i(o,new A.ch(-a3/m,a2,c1.hs(a),a0))}else{a2=h?0:c/p
 B.a.i(o,new A.ch(a2,0,c1.hs(a),a0))}if(k){a2=b8.e.db
 a2=a2!==3&&a2!==7&&d}else a2=!1
-if(a2)b8.j1(c1,a,c)
+if(a2)b8.j2(c1,a,c)
 if(n){a2=e.h(0,a)
 if(a2==null)a2=b9
 else{if(0>=a2.length)return A.a(a2,0)
@@ -20799,7 +20799,7 @@ A.qS(l,a8,new A.a0(1,0,0,1,a7.a,a7.b).a6(a5))}}if(B.f.ew(a0).length!==0||i){a9=a
 c0=a6!==1
 b0=!c0||a6===2||a6===5||a6===6
 b1=a9?b8.e.x:b9
-if(a9&&i&&b8.fi(b1)){b2=b8.jl(o,a5)
+if(a9&&i&&b8.fi(b1)){b2=b8.jm(o,a5)
 b3=b2!=null
 if(b3){b1.toString
 b8.f9(b2,B.l,b1)}}else b3=!1
@@ -20815,7 +20815,7 @@ c0=c0?b8.e.c:b5
 k=i?!0:b4
 j=j&&b0?b8.e.c:b9
 g=b8.e.f
-i=(i?a9:b4)?b8.jn(b1):b9
+i=(i?a9:b4)?b8.jo(b1):b9
 h=h?0:c/p
 f=c1.a
 e=a6===3||a6===7||b3
@@ -20823,9 +20823,9 @@ d=b8.giz()
 B.a.i(l.gB(),new A.bW(new A.dV(d,k,j,g.a*b7,e,a0,a5,c0,i,h,f,c2,o)))}}c0=n?A.ig(0,c):A.ig(c,0)
 b8.go=c0.a6(b8.go)
 b8.k4=r},
-j1(a,b,c){var s=this
+j2(a,b,c){var s=this
 if(!s.gbF()||s.at>=16)return
-a.lL(b,new A.lf(s),new A.lg(s,s.e.ax,c,a,b))},
+a.lM(b,new A.lf(s),new A.lg(s,s.e.ax,c,a,b))},
 f7(a,b,c){var s,r,q,p,o,n,m,l,k,j,i,h,g=this
 t.D.a(a)
 s=g.e
@@ -20867,7 +20867,7 @@ if(a instanceof A.r)return a
 return null},
 cS(a){var s=this.a.j(a.a.h(0,"Matrix"))
 return s instanceof A.q&&s.a.length>=6?A.f5(s.a):B.v},
-jR(a){var s,r,q,p,o=null,n=this.dV(a)
+jS(a){var s,r,q,p,o=null,n=this.dV(a)
 if(n==null)return o
 s=this.a
 r=n.a
@@ -20879,13 +20879,13 @@ s=p.di(B.v)
 s=s==null?o:s.gcg()
 if(s==null){s=p.es(B.v)
 s=s==null?o:s.gcg()}if(s==null){s=p.er(B.v)
-s=s==null?o:s.gcg()}if(s==null){s=p.lP(B.v)
+s=s==null?o:s.gcg()}if(s==null){s=p.lQ(B.v)
 s=s==null?o:s.gcg()}return s},
 fV(a){var s,r,q,p,o,n,m,l,k,j=this,i=null,h=j.a.j(a.a.a.h(0,"PaintType"))
 if(h instanceof A.m&&h.a===2){r=j.e.y
 return r.length!==0?A.h8(r,i):i}s=null
 try{s=j.r.aa(a,new A.ln(j,a))}catch(q){if(t.I.b(A.J(q)))return i
-else throw q}for(r=J.b8(s),p=i;r.u();){o=r.gF()
+else throw q}for(r=J.b8(s),p=i;r.u();){o=r.gG()
 n=o.b
 switch(o.a){case"g":o=0<n.length?A.aj(n[0]):0
 p=new A.L(o,o,o)
@@ -20901,7 +20901,7 @@ l=1<o?A.aj(n[1]):0
 k=2<o?A.aj(n[2]):0
 p=A.dc(m,l,k,3<o?A.aj(n[3]):0)
 break}}return p},
-jn(a){var s,r,q,p=this.dV(a)
+jo(a){var s,r,q,p=this.dV(a)
 if(p==null)return null
 s=this.a
 r=p.a
@@ -20913,7 +20913,7 @@ fi(a){var s
 if(!(a instanceof A.A))return!1
 s=this.a.j(a.a.a.h(0,"PatternType"))
 return s instanceof A.m&&s.a===1},
-jl(a,b){var s,r,q,p,o
+jm(a,b){var s,r,q,p,o
 t.aY.a(a)
 s=A.b([],t.g)
 for(r=a.length,q=0;q<a.length;a.length===r||(0,A.j)(a),++q){p=a[q]
@@ -20942,8 +20942,8 @@ B.a.i(k.b.gB(),new A.aQ(a,b))
 s=k.b
 r=k.e.d
 B.a.i(s.gB(),new A.bX(l,r))
-B.a.i(k.b.gB(),B.u)}return}if(p===1&&c instanceof A.A)k.jf(a,b,c)},
-jf(d9,e0,e1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,d0,d1,d2,d3,d4,d5,d6=this,d7=null,d8=d6.ax
+B.a.i(k.b.gB(),B.u)}return}if(p===1&&c instanceof A.A)k.jg(a,b,c)},
+jg(d9,e0,e1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,d0,d1,d2,d3,d4,d5,d6=this,d7=null,d8=d6.ax
 if(d8.Y(0,e1)){d8=d6.e.y
 b0=d8.length!==0?A.h8(d8,d7):B.G
 d8=d6.b
@@ -20988,7 +20988,7 @@ m=B.c.U((c4-b1)/b4)-1
 b4=J.a5(q,0)
 b1=p
 if(typeof b1!=="number")return A.n(b1)
-l=B.c.G((c6-b4)/b1)
+l=B.c.F((c6-b4)/b1)
 b1=J.a5(q,1)
 b4=o
 if(typeof b4!=="number")return A.n(b4)
@@ -20996,7 +20996,7 @@ k=B.c.U((c5-b1)/b4)-1
 b4=J.a5(q,1)
 b1=o
 if(typeof b1!=="number")return A.n(b1)
-j=B.c.G((c7-b4)/b1)
+j=B.c.F((c7-b4)/b1)
 b1=l
 b4=m
 if(typeof b1!=="number")return b1.aW()
@@ -21204,7 +21204,7 @@ if(!(r instanceof A.r))return null
 if(0>=c.length)return A.a(c,0)
 q=s.j(r.a.h(0,t.G.a(c[0]).a))
 return q instanceof A.r?q:null},
-iU(a7,a8,a9){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6=this
+iV(a7,a8,a9){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6=this
 t.Q.a(a8)
 h=a8.length
 if(h!==0){if(0>=h)return A.a(a8,0)
@@ -21290,7 +21290,7 @@ h=i.a
 i=i.b
 i=new A.M(q*h+p*i+o,m*h+l*i+k)}r.push(i)}r.push(B.q)
 B.a.i(this.b.gB(),new A.aQ(new A.an(r),B.l))},
-j0(a){var s,r,q,p,o
+j1(a){var s,r,q,p,o
 t.Q.a(a)
 s=a.length
 r=!0
@@ -21322,7 +21322,7 @@ A.lm.prototype={
 $1(a){return A.bg(a)},
 $S:6}
 A.li.prototype={
-$0(){return this.a.kr(this.b)},
+$0(){return this.a.ks(this.b)},
 $S:0}
 A.lf.prototype={
 $1(a){var s,r
@@ -21387,13 +21387,13 @@ p+=m.b
 o+=m.c}if(r===0)r=1
 return new A.L(q/r,p/r,o/r)}}
 A.lo.prototype={
-lx(){var s,r,q=this
+ly(){var s,r,q=this
 try{s=q.a
-switch(s){case 4:q.jI()
+switch(s){case 4:q.jJ()
 break
-case 5:q.jK()
+case 5:q.jL()
 break
-case 6:case 7:q.jL(s===7)
+case 6:case 7:q.jM(s===7)
 break
 default:return null}}catch(r){if(!(A.J(r) instanceof A.fO))throw r}s=q.as
 if(s.length===0)return null
@@ -21410,7 +21410,7 @@ r.push(s.dN(q.aT(p),p,2+l));++l}if(m){if(0>=r.length)return A.a(r,0)
 return s.x.$1(n.aN(r[0]))}return s.x.$1(r)},
 c9(){var s=this.bI()
 return new A.ci(s.a,s.b,this.fF())},
-jI(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
+jJ(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
 for(s=e.z,r=e.d,q=s.a.length,p=e.as,o=t.t,n=e.Q,m=null,l=null,k=null;(q-s.b)*8-s.c>=r;){j=s.aT(r)
 if(j===0){B.a.i(n,e.c9())
 i=n.length-1
@@ -21430,7 +21430,7 @@ m=l}else{m.toString
 B.a.R(p,A.b([m,k,f],o))}}else return
 l=k
 k=f}}},
-jK(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c=this,b=c.r
+jL(){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c=this,b=c.r
 if(b<2)return
 s=c.z
 r=2*c.b
@@ -21460,7 +21460,7 @@ if(!(g<e))return A.a(i,g)
 d=i[g]
 if(!(h<e))return A.a(i,h)
 B.a.R(k,A.b([f,d,i[h]],p))}j=i}},
-jL(a8){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7=this
+jM(a8){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7=this
 for(s=a7.z,r=a7.d,q=s.a.length,p=t.hv,o=t.y,n=t.eH,m=t.c,l=t.b,k=null,j=null;(q-s.b)*8-s.c>=r;j=f,k=h){i=s.aT(r)
 h=A.b(new Array(4),n)
 for(g=0;g<4;++g)h[g]=A.R(4,B.c9,!1,o)
@@ -21501,36 +21501,59 @@ if(2>=h.length)return A.a(h,2)
 B.a.k(h[2],1,a7.bI())}else A.wh(h)
 a4=e?0:2
 for(;a4<4;++a4)B.a.k(f,a4,a7.fF())
-a7.kD(h,f)}},
-kD(a6,a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5
-t.aZ.a(a6)
-t.ot.a(a7)
-s=this.Q
-r=s.length
-for(q=0;q<=8;++q){p=q/8
-for(o=0;o<=8;++o){n=o/8
-for(m=0,l=0,k=0;k<4;++k){j=A.qU(k,p)
-for(i=0;i<4;++i){h=j*A.qU(i,n)
-g=a6[k][i]
-m+=g.a*h
-l+=g.b*h}}g=a7[0]
-f=g.a
-e=a7[1]
-d=a7[2]
-c=a7[3]
-b=c.a
-a=f+(e.a-f)*n
-f=g.b
-a0=c.b
-a1=f+(e.b-f)*n
-g=g.c
-c=c.c
-a2=g+(e.c-g)*n
-B.a.i(s,new A.ci(m,l,new A.L(a+(b+(d.a-b)*n-a)*p,a1+(a0+(d.b-a0)*n-a1)*p,a2+(c+(d.c-c)*n-a2)*p)))}}for(s=this.as,g=t.t,q=0;q<8;++q)for(f=r+q*9,o=0;o<8;++o){a3=f+o
-a4=a3+1
-a5=a3+9
-B.a.R(s,A.b([a3,a4,a5],g))
-B.a.R(s,A.b([a4,a5+1,a5],g))}}}
+a7.kE(h,f)}},
+iU(a,b){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e
+t.aZ.a(a)
+t.ot.a(b)
+s=a[0]
+r=s[0]
+s=s[3]
+q=a[3]
+p=[r,s,q[3],q[0]]
+for(o=0,n=0;n<4;n=m)for(m=n+1,l=m;l<4;++l){s=p[n]
+r=p[l]
+k=s.a-r.a
+j=s.b-r.b
+i=k*k+j*j
+if(i>o)o=i}h=B.c.F(Math.sqrt(o)/12)
+for(g=0,n=0;n<4;n=m)for(m=n+1,l=m;l<4;++l){s=b[n]
+r=b[l]
+i=Math.max(Math.abs(s.a-r.a),Math.max(Math.abs(s.b-r.b),Math.abs(s.c-r.c)))
+if(i>g)g=i}f=g<=0.01568627450980392?0:B.c.F(g*8)
+e=Math.max(h,f)
+if(e<1)s=1
+else s=e>8?8:e
+return s},
+kE(a7,a8){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6
+t.aZ.a(a7)
+t.ot.a(a8)
+s=this.iU(a7,a8)
+r=this.Q
+q=r.length
+for(p=0;p<=s;++p){o=p/s
+for(n=0;n<=s;++n){m=n/s
+for(l=0,k=0,j=0;j<4;++j){i=A.qU(j,o)
+for(h=0;h<4;++h){g=i*A.qU(h,m)
+f=a7[j][h]
+l+=f.a*g
+k+=f.b*g}}f=a8[0]
+e=f.a
+d=a8[1]
+c=a8[2]
+b=a8[3]
+a=b.a
+a0=e+(d.a-e)*m
+e=f.b
+a1=b.b
+a2=e+(d.b-e)*m
+f=f.c
+b=b.c
+a3=f+(d.c-f)*m
+B.a.i(r,new A.ci(l,k,new A.L(a0+(a+(c.a-a)*m-a0)*o,a2+(a1+(c.b-a1)*m-a2)*o,a3+(b+(c.c-b)*m-a3)*o)))}}for(r=s+1,f=this.as,e=t.t,p=0;p<s;++p)for(d=q+p*r,n=0;n<s;++n){a4=d+n
+a5=a4+1
+a6=a4+r
+B.a.R(f,A.b([a4,a5,a6],e))
+B.a.R(f,A.b([a5,a6+1,a6],e))}}}
 A.lp.prototype={
 $1(a){var s,r,q,p,o,n
 t.cn.a(a)
@@ -21570,16 +21593,16 @@ o=b==null?n.e:b
 return new A.dU(s,r,q,p,o,c==null?n.f:c)},
 cj(a){var s=null
 return this.bq(s,s,s,s,s,a)},
-kW(a){var s=null
-return this.bq(a,s,s,s,s,s)},
 kX(a){var s=null
-return this.bq(s,s,s,a,s,s)},
+return this.bq(a,s,s,s,s,s)},
 kY(a){var s=null
+return this.bq(s,s,s,a,s,s)},
+kZ(a){var s=null
 return this.bq(s,s,s,s,a,s)},
-kZ(a,b){var s=null
+l_(a,b){var s=null
 return this.bq(s,a,b,s,s,s)},
-l0(a,b,c){return this.bq(null,a,b,null,null,c)},
-l_(a,b,c){return this.bq(a,b,null,c,null,null)}}
+l1(a,b,c){return this.bq(null,a,b,null,null,c)},
+l0(a,b,c){return this.bq(a,b,null,c,null,null)}}
 A.fb.prototype={
 gho(){return Math.max(this.a,Math.max(this.c,this.e))},
 ghp(){return Math.max(this.b,Math.max(this.d,this.f))},
@@ -21710,7 +21733,7 @@ A.fg.prototype={}
 A.iA.prototype={}
 A.iz.prototype={}
 A.lJ.prototype={
-kK(a6,a7,a8,a9,b0,b1){var s,r,q,p,o,n,m,l,k,j,i=this,h=B.b.n(B.c.v(a9*16),1,65535),g=B.b.n(B.c.v(b0*16),1,65535),f=i.a.aa(new A.ao(a6,h,g),new A.lK(i,a7,h,g)),e=h/16,d=g/16,c=16/h,b=16/g,a=a7.d-c,a0=a7.f+c,a1=a7.e-b,a2=a7.r+b,a3=a7.w,a4=2+(a-a3)*e,a5=2+(a0-a3)*e
+kL(a6,a7,a8,a9,b0,b1){var s,r,q,p,o,n,m,l,k,j,i=this,h=B.b.n(B.c.v(a9*16),1,65535),g=B.b.n(B.c.v(b0*16),1,65535),f=i.a.aa(new A.ao(a6,h,g),new A.lK(i,a7,h,g)),e=h/16,d=g/16,c=16/h,b=16/g,a=a7.d-c,a0=a7.f+c,a1=a7.e-b,a2=a7.r+b,a3=a7.w,a4=2+(a-a3)*e,a5=2+(a0-a3)*e
 a3=a7.x
 s=2+(a1-a3)*d
 r=2+(a2-a3)*d
@@ -21735,7 +21758,7 @@ a3.cY(a4,s,a5,s)
 a3.cY(a4,r,a5,r)
 B.a.i(i.w,f)
 B.a.R(i.r,A.b([b1,b1,b1,b1],t.t));++i.y},
-kR(c0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8=this,b9=65535
+kS(c0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8=this,b9=65535
 if(b8.y===0)return null
 s=b8.b
 r=s.length
@@ -21882,7 +21905,7 @@ da(a,b,c,d){var s,r=this
 if(r.gcC())s=r.Q
 else s=!0
 if(s){r.bG(new A.lY(r,a,b,c,d))
-return}r.y.lg(a,r.a,c,A.oF(b,d),0.02)},
+return}r.y.lh(a,r.a,c,A.oF(b,d),0.02)},
 cD(a,b,c,d){var s,r,q,p=this
 if(p.gcC())s=p.as
 else s=!0
@@ -21909,7 +21932,7 @@ if(g==null){g=new A.ew(A.tg(k,B.v,0.0009765625))
 i.$ti.l("1?").a(g)
 h.set(k,g)
 i=g}else i=g
-n.lf(i,j,r)}},
+n.lg(i,j,r)}},
 bN(a){this.bG(new A.lU(this,a))},
 cA(a){this.z=a},
 cB(a,b,c){this.Q=a
@@ -22030,20 +22053,20 @@ q.z=new Int32Array(r)}B.D.ap(s,0,r,-1)
 q.ay=q.as=0
 r=q.a
 r.r=r.a=0},
-lg(a,b,c,d,e){var s,r=this,q=a.a.length
+lh(a,b,c,d,e){var s,r=this,q=a.a.length
 if(q===0||r.f===0)return
 s=r.c
 if(s!=null&&q<=64&&r.fQ(s,a,b,c,null,d,e))return
-r.je(a,b,c,d,e)},
-je(a,b,c,d,e){if(a.a.length>8&&this.iy(a,b))return
-this.ji(a,b,e)
+r.jf(a,b,c,d,e)},
+jf(a,b,c,d,e){if(a.a.length>8&&this.iy(a,b))return
+this.jj(a,b,e)
 this.cL(c,d)},
 hM(a,b,c,d,e){var s,r=this,q=a.a.length
 if(q===0||r.f===0)return
 s=r.c
 if(s!=null&&q<=64&&r.fQ(s,a,b,B.l,c,d,e))return
-r.kC(a,b,c,d,e)},
-kC(a,b,c,d,e){var s,r,q,p,o=b.gbX(),n=A.tg(a,b,e)
+r.kD(a,b,c,d,e)},
+kD(a,b,c,d,e){var s,r,q,p,o=b.gbX(),n=A.tg(a,b,e)
 if(n.length===0)return
 s=c.e
 if(s.length!==0&&B.a.b8(s,new A.m5())){r=A.b([],t.n)
@@ -22062,11 +22085,11 @@ p=q[p]
 q=p}p=a.b
 if(!(r<p.length))return A.a(p,r)
 this.i2(s,q,p[r])}this.cL(B.l,b)},
-lf(a,b,c){var s,r=this
+lg(a,b,c){var s,r=this
 if(r.f===0)return
 s=r.b
 if(s==null){r.cJ(a,b,c)
-return}r.jd(s,a,b,c)},
+return}r.je(s,a,b,c)},
 cJ(a3,a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c=a4.a,b=a4.b,a=a4.c,a0=a4.d,a1=a4.e,a2=a4.f
 for(s=a3.a,r=s.length,q=!1,p=0;p<s.length;s.length===r||(0,A.j)(s),++p){o=s[p].a
 n=o.length
@@ -22080,7 +22103,7 @@ d=b*h+a0*f+a2
 if(i===0){l=d
 m=e}else this.b7(k,j,e,d)}if(k!==m||j!==l)this.b7(k,j,m,l)
 q=!0}if(q)this.cL(B.l,a5)},
-jd(b8,b9,c0,c1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7=this
+je(b8,b9,c0,c1){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7=this
 if(!b9.b){b9.c=A.vj(b9.a)
 b9.b=!0}s=b9.c
 if(s==null)return
@@ -22113,8 +22136,8 @@ if(a8<a1)a1=a8
 if(a8>a3)a3=a8}if(!(isFinite(a0)&&isFinite(a1)&&isFinite(a2)&&isFinite(a3)))return
 a9=B.c.U(a0)
 b0=4*B.c.U(a1/4)
-b1=B.c.G(a2)-a9+1
-b2=B.c.G(a3)-b0+1
+b1=B.c.F(a2)-a9+1
+b2=B.c.F(a3)-b0+1
 b3=m+a9
 b4=k+b0
 if(b1>512||b2>512||b3<0||b4<0||b3+b1>b7.d||b4+b2>b7.f*4){++b8.r
@@ -22123,7 +22146,7 @@ return}b5=new A.fV([b9,r,q,p,o,l,j])
 b6=b8.c.h(0,b5)
 n=b6==null
 if(!n)++b8.e
-if(n){if(!b8.kv(A.ej(b9),r,q,p,o,l,j)){b7.cJ(b9,new A.a0(i,h,g,f,m+e,k+d),c1)
+if(n){if(!b8.kw(A.ej(b9),r,q,p,o,l,j)){b7.cJ(b9,new A.a0(i,h,g,f,m+e,k+d),c1)
 return}b6=b8.ic(b5,b9,new A.a0(i,h,g,f,e-a9,d-b0),b1,b2)}b7.e3(b6.a,b6.b,b6.c,b3,b4,c1)},
 e3(a0,a1,a2,a3,a4,a5){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a
 if(a1===0)return
@@ -22260,8 +22283,8 @@ a9-=b4
 a8+=b4
 b0+=b4}b5=B.c.U(a7)
 b6=4*B.c.U(a9/4)
-b7=B.c.G(a8)-b5+1
-b8=B.c.G(b0)-b6+1
+b7=B.c.F(a8)-b5+1
+b8=B.c.F(b0)-b6+1
 b9=a1+b5
 c0=a3+b6
 if(b7>512||b8>512||b9<0||c0<0||b9+b7>d2.d||c0+b8>d2.f*4){++d5.x
@@ -22269,11 +22292,11 @@ return!1}c1=A.wE(d2.dy,d2.fr)
 c2=d5.c.h(0,c1)
 if(c2==null)c2=d5.d.h(0,c1)
 if(c2!=null){if(A.wD(c2.d,d2.dy,d2.fr)){++d5.r
-d5.jT(c1,c2)
+d5.jU(c1,c2)
 d2.e3(c2.a,c2.b,c2.c,b9,c0,e0)
 return!0}++d5.z
 d2.dW(d2.dy,d2.fr,a1,a3,e0)
-return!0}if(!d5.ku(c1)){d2.dW(d2.dy,d2.fr,a1,a3,e0)
+return!0}if(!d5.kv(c1)){d2.dW(d2.dy,d2.fr,a1,a3,e0)
 return!0}r=d2.dy
 j=d2.fr;++d5.w
 c3=d5.Q
@@ -22326,15 +22349,15 @@ if(!(i<a))return A.a(a0,i)
 d=a0[i]/64
 B.a.k(g,f,d)
 if(d>0)h=!0}}else g=null
-c=b.jj(a0,i,a1,q,p,r)
+c=b.jk(a0,i,a1,q,p,r)
 if(c.length===0)return
 if(h){g.toString
 c=A.t6(c,g,k/64)}a=b.dx
 a.C(0)
 A.ty(c,n,m,l/64,a,o/64)
-b.hh(a,a4)}else{b.j2(a0,4,a1,q,p,r)
+b.hh(a,a4)}else{b.j3(a0,4,a1,q,p,r)
 b.cL((s&1)!==0?B.F:B.l,a4)}},
-jj(b3,b4,b5,b6,b7,b8){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1={},b2=A.b([],t.gM)
+jk(b3,b4,b5,b6,b7,b8){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1={},b2=A.b([],t.gM)
 b1.a=null
 b1.b=!1
 s=new A.m3(b1,b2)
@@ -22385,7 +22408,7 @@ if(!(p<r))return A.a(b3,p)
 a1=b7+b3[p]/64
 if(e==null){p=k
 continue}a2=Math.max(Math.max(Math.abs(m-2*d+b),Math.abs(l-2*c+a)),Math.max(Math.abs(d-2*b+a0),Math.abs(c-2*a+a1)))
-a3=a2<=b8?1:B.b.n(B.c.G(Math.sqrt(3*a2/q)),1,128)
+a3=a2<=b8?1:B.b.n(B.c.F(Math.sqrt(3*a2/q)),1,128)
 for(a4=1;a4<=a3;++a4){a5=a4/a3
 a6=1-a5
 a7=a6*a6*a6
@@ -22403,7 +22426,7 @@ p=k
 l=n
 m=o}}}s.$0()
 return b2},
-j2(a9,b0,b1,b2,b3,b4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8=this
+j3(a9,b0,b1,b2,b3,b4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8=this
 a8.db=!1
 for(s=a9.length,r=4*b4,q=b0;q<b1;){p=q+1
 if(!(q<s))return A.a(a9,q)
@@ -22446,7 +22469,7 @@ if(!(q<s))return A.a(a9,q)
 g=b3+a9[q]/64
 if(!a8.db){q=p
 continue}f=Math.max(Math.max(Math.abs(a8.ch-2*l+j),Math.abs(a8.CW-2*k+i)),Math.max(Math.abs(l-2*j+h),Math.abs(k-2*i+g)))
-e=f<=b4?1:B.b.n(B.c.G(Math.sqrt(3*f/r)),1,128)
+e=f<=b4?1:B.b.n(B.c.F(Math.sqrt(3*f/r)),1,128)
 d=a8.ch
 c=a8.CW
 for(b=1;b<=e;++b,c=a7,d=a6){a=b/e
@@ -22492,7 +22515,7 @@ continue}if(o instanceof A.b0)continue}r=h.d
 q=h.b
 if(r<q)return!0
 return h.c<=0||h.a>=this.f*4||r<=0||q>=this.d},
-ji(c2,c3,c4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0=this,c1=null
+jj(c2,c3,c4){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0=this,c1=null
 c0.db=!1
 for(s=c2.a,r=s.length,q=4*c4,p=c3.a,o=c3.c,n=c3.e,m=c3.b,l=c3.d,k=c3.f,j=0;j<s.length;s.length===r||(0,A.j)(s),++j){i=s[j]
 A:{h=i instanceof A.Y
@@ -22535,7 +22558,7 @@ a0=i.f
 a5=p*a+o*a0+n
 a6=m*a+l*a0+k
 a7=Math.max(Math.max(Math.abs(c0.ch-2*a1+a3),Math.abs(c0.CW-2*a2+a4)),Math.max(Math.abs(a1-2*a3+a5),Math.abs(a2-2*a4+a6)))
-a8=a7<=c4?1:B.b.n(B.c.G(Math.sqrt(3*a7/q)),1,128)
+a8=a7<=c4?1:B.b.n(B.c.F(Math.sqrt(3*a7/q)),1,128)
 a9=c0.ch
 b0=c0.CW
 for(b1=1;b1<=a8;++b1,b0=b9,a9=b8){b2=b1/a8
@@ -22623,7 +22646,7 @@ p=s?a:a0
 o=((s?a0:a)-p)/(q-r)
 n=c.d
 m=B.c.U(r*0.25)
-l=B.c.G(q*0.25)-1
+l=B.c.F(q*0.25)-1
 if(m<0)m=0
 k=c.f
 if(l>=k)l=k-1
@@ -22677,7 +22700,7 @@ k=b<d
 q=k?b:d
 p=k?d:b
 o=B.c.U(q)
-n=B.c.G(p)
+n=B.c.F(p)
 if(r===-1){k=m.as
 j=m.Q
 i=j.length
@@ -22707,12 +22730,12 @@ cL(a,b){var s,r,q,p=this,o=a===B.F
 for(s=0;s<p.as;++s){r=p.Q
 if(!(s<r.length))return A.a(r,s)
 q=r[s]
-p.jW(q,o,b)
+p.jX(q,o,b)
 r=p.x
 r.$flags&2&&A.e(r)
 if(!(q>=0&&q<r.length))return A.a(r,q)
 r[q]=-1}p.ay=p.as=0},
-jW(f8,f9,g0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,d0,d1,d2,d3,d4,d5,d6,d7,d8,d9,e0,e1,e2,e3,e4,e5,e6,e7,e8,e9,f0,f1=this,f2=4294967295,f3=f1.w,f4=f1.r,f5=f1.at,f6=f1.ax,f7=f1.x
+jX(f8,f9,g0){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9,c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,d0,d1,d2,d3,d4,d5,d6,d7,d8,d9,e0,e1,e2,e3,e4,e5,e6,e7,e8,e9,f0,f1=this,f2=4294967295,f3=f1.w,f4=f1.r,f5=f1.at,f6=f1.ax,f7=f1.x
 if(!(f8>=0&&f8<f7.length))return A.a(f7,f8)
 s=f7[f8]
 for(f7=f3.length,r=f5.length,q=f6.length,p=f3.$flags|0;s!==-1;){o=4*s
@@ -22739,7 +22762,7 @@ k=n
 n=f
 g=-1}e=(k-n)/(i-h)
 d=B.c.U(h)
-c=B.c.G(i)-1
+c=B.c.F(i)-1
 if(d<0)d=0
 b=h
 a=n
@@ -22931,7 +22954,7 @@ k.a=s},
 $S:84}
 A.hl.prototype={}
 A.kq.prototype={
-kv(a,b,c,d,e,f,g){var s=A.bT(a,b,c,d,e,f,g),r=this.y
+kw(a,b,c,d,e,f,g){var s=A.bT(a,b,c,d,e,f,g),r=this.y
 if(r.Y(0,s))return!0
 if(r.a>=131072){r.b=r.c=r.d=r.e=r.f=null
 r.a=0
@@ -22962,18 +22985,18 @@ l=A.D(o).l("a2<1>")
 for(;;){if(!(o.a>32768||n>33554432))break
 j=new A.a2(o,l).gV(0)
 if(!j.u())A.Q(A.bi())
-i=j.gF()
+i=j.gG()
 n=h.d-o.aI(0,i).c*4
 h.d=n}return k}}
 A.hm.prototype={}
 A.lI.prototype={
-ku(a){var s,r=this
+kv(a){var s,r=this
 if(r.as.Y(0,a)||r.at.Y(0,a))return!0
 s=r.as
 if(s.a>=65536){r.at=s
 s=r.as=A.aP(t.S)}s.i(0,a);++r.y
 return!1},
-jT(a,b){var s=this,r=s.d.aI(0,a)
+jU(a,b){var s=this,r=s.d.aI(0,a)
 if(r==null)return
 s.f=s.f-(r.a.byteLength+r.d.byteLength)
 s.fg(a,r)},
@@ -23016,9 +23039,9 @@ h=new Float32Array(256)
 k=f.dy=new A.lJ(A.w(t.i0,t.S),q,j,i,new A.hH(h),new A.hH(new Float32Array(256)),A.b([],p),A.b([],p))}for(q=a.length,m=0;m<a.length;a.length===q||(0,A.j)(a),++m){g=a[m]
 l=g.c
 if(l==null)continue
-k.kK(l,A.r5(l),new A.a0(1,0,0,1,g.a,g.b).a6(s),o,n,c)}if(k.b.length*(k.x+4)>8192)f.fa(f.ch-1)
+k.kL(l,A.r5(l),new A.a0(1,0,0,1,g.a,g.b).a6(s),o,n,c)}if(k.b.length*(k.x+4)>8192)f.fa(f.ch-1)
 return!0},
-fa(a){var s=this,r=s.dy,q=r==null?null:r.kR(a)
+fa(a){var s=this,r=s.dy,q=r==null?null:r.kS(a)
 if(q==null)return
 B.a.i(s.dx,q)
 s.fr=s.fr+q.f}}
@@ -23111,7 +23134,7 @@ r.T(e,f)
 s.bH()},
 $S:85}
 A.oH.prototype={
-$4(a,b,c,d){var s,r,q,p=Math.max(2,B.c.G(Math.abs(d)/0.35)),o=this.a,n=o.a
+$4(a,b,c,d){var s,r,q,p=Math.max(2,B.c.F(Math.abs(d)/0.35)),o=this.a,n=o.a
 o.d=n.b
 n.T(a,b)
 for(s=this.b,r=0;r<=p;++r){q=c+d*r/p
@@ -23199,7 +23222,7 @@ B.a.i(p.gB(),new A.aF(d,a,s,b,f,e))},
 $if1:1}
 A.lG.prototype={
 $1(a){var s,r,q
-for(s=J.b8(t.J.a(a)),r=this.a.b;s.u();){q=s.gF()
+for(s=J.b8(t.J.a(a)),r=this.a.b;s.u();){q=s.gG()
 if(q instanceof A.be)B.a.i(r,q.a)
 else if(q instanceof A.aF)this.$1(q.c)
 else if(q instanceof A.b1)this.$1(q.a)}},
@@ -23227,7 +23250,7 @@ $S:0}
 A.h1.prototype={$iad:1}
 A.nH.prototype={
 $1(a){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e=this
-for(s=J.b8(t.J.a(a)),r=e.d,q=e.a,p=e.c,o=e.b,n=o==null;s.u();){m=s.gF()
+for(s=J.b8(t.J.a(a)),r=e.d,q=e.a,p=e.c,o=e.b,n=o==null;s.u();){m=s.gG()
 if(m instanceof A.be){l=n?null:A.rM(p,m.a,o,r,1)
 if(l!=null)q.a=q.a+l.f*l.r
 else{m=m.a
@@ -23339,18 +23362,18 @@ return s},
 ef(a){var s=this,r=s.Z(),q=s.c,p=A.V(s.a,q,q+r),o=a&&r>=1048576?p:new Uint8Array(A.I(p))
 s.c+=r
 return o},
-kS(){return this.ef(!1)},
+kT(){return this.ef(!1)},
 L(){var s=this.b.getFloat64(this.c,!1)
 this.c+=8
 return s},
-c0(){var s=this,r=s.Z(),q=s.c,p=B.X.l2(A.V(s.a,q,q+r))
+c0(){var s=this,r=s.Z(),q=s.c,p=B.X.l3(A.V(s.a,q,q+r))
 s.c+=r
 return p},
 cn(){var s,r,q,p=this,o=p.Z(),n=A.b([],t.n)
 for(s=p.b,r=0;r<o;++r){q=s.getFloat64(p.c,!1)
 p.c+=8
 n.push(q)}return n},
-lk(){var s,r,q,p=this,o=p.Z(),n=A.b([],t.t)
+ll(){var s,r,q,p=this,o=p.Z(),n=A.b([],t.t)
 for(s=p.b,r=0;r<o;++r){q=s.getInt32(p.c,!1)
 p.c+=4
 n.push(q)}return n}}
@@ -23371,7 +23394,7 @@ r=new A.ly(n,l)
 s=null
 try{s=n.a7(m)}catch(q){if(t.I.b(A.J(q)))return null
 else throw q}p=s
-return new A.lo(k,r.$2("BitsPerCoordinate",16),r.$2("BitsPerComponent",8),r.$2("BitsPerFlag",8),A.lw(n,l.a.h(0,"Decode")),o.d,r.$2("VerticesPerRow",0),o.c,o.e,a,new A.mx(p),A.b([],t.w),A.b([],t.t)).lx()},
+return new A.lo(k,r.$2("BitsPerCoordinate",16),r.$2("BitsPerComponent",8),r.$2("BitsPerFlag",8),A.lw(n,l.a.h(0,"Decode")),o.d,r.$2("VerticesPerRow",0),o.c,o.e,a,new A.mx(p),A.b([],t.w),A.b([],t.t)).ly()},
 er(a7){var s,r,q,p,o,n,m,l,k,j,i,h,g,f,e,d,c,b,a,a0,a1,a2,a3,a4=this,a5=a4.c,a6=!0
 if(a4.a===1)a6=a5==null
 if(a6)return null
@@ -23404,9 +23427,9 @@ di(a){var s,r=this,q=r.c
 if(q==null)return null
 s=r.a
 if(s===2&&r.b.length>=4)return r.fO(q,!1,a)
-if(s===3&&r.b.length>=6){if(!r.jV())return null
+if(s===3&&r.b.length>=6){if(!r.jW())return null
 return r.fO(q,!0,a)}return null},
-jV(){var s,r,q,p,o,n=this.b
+jW(){var s,r,q,p,o,n=this.b
 if(n.length<6)return!0
 s=n[3]-n[0]
 r=n[4]-n[1]
@@ -23489,7 +23512,7 @@ B.a.i(c3,c8)
 B.a.i(c3,c7)
 B.a.i(c3,c8+1)
 B.a.i(c3,c8)}}return new A.df(b5,c3)},
-lP(a){return this.eu(a,null)},
+lQ(a){return this.eu(a,null)},
 fO(a,b,c){var s,r,q,p,o,n,m=this,l=A.b([],t.b),k=A.b([],t.n)
 for(s=m.f,r=m.e,q=0;q<=32;++q){p=q/32
 o=s.length
@@ -23562,7 +23585,7 @@ q(n,"giJ","iK",7)
 q(n,"giB","iC",7)
 q(n,"giD","iE",7)
 p(n=A.hu.prototype,"ghy","j",34)
-p(n,"gfM","kn",49)
+p(n,"gfM","ko",49)
 p(A.cS.prototype,"gbT","ab",3)
 p(A.fP.prototype,"gbT","ab",3)
 p(A.fx.prototype,"gbT","ab",3)

--- a/packages/pdf_graphics/lib/src/mesh.dart
+++ b/packages/pdf_graphics/lib/src/mesh.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'color.dart';
@@ -292,11 +293,62 @@ class PdfMeshParser {
     ]);
   }
 
+  /// Chooses a per-patch subdivision count (#536, PDFium's adaptive
+  /// Coons/tensor tessellation): a patch small on the page or nearly flat in
+  /// colour needs far fewer than [_patchDivisions] cells, and a 1000-patch
+  /// mesh otherwise always emits 128k triangles. Driven by the larger of two
+  /// metrics so a big patch never under-tessellates its geometry even when
+  /// its corners share a colour:
+  ///  - screen size: the max page-space span of the four corners, one cell
+  ///    per [_patchTargetEdge] units;
+  ///  - colour delta: the max per-channel corner-colour difference, scaled so
+  ///    a full-range transition still asks for the full division count
+  ///    (PDFium's 4/255 corner-delta threshold is the floor below which a
+  ///    patch reads as flat).
+  /// Clamped to `[1, _patchDivisions]` - 8 stays the ceiling.
+  static const double _patchTargetEdge = 12; // page units per cell
+  static const double _flatColorDelta = 4 / 255;
+
+  int _divisionsFor(
+      List<List<(double, double)>> grid, List<PdfColor> colors) {
+    // Four corners of the bicubic grid.
+    final corners = [grid[0][0], grid[0][3], grid[3][3], grid[3][0]];
+    var span = 0.0;
+    for (var i = 0; i < 4; i++) {
+      for (var j = i + 1; j < 4; j++) {
+        final dx = corners[i].$1 - corners[j].$1;
+        final dy = corners[i].$2 - corners[j].$2;
+        final d = dx * dx + dy * dy;
+        if (d > span) span = d;
+      }
+    }
+    final sizeDiv = (math.sqrt(span) / _patchTargetEdge).ceil();
+
+    var colorDelta = 0.0;
+    for (var i = 0; i < 4; i++) {
+      for (var j = i + 1; j < 4; j++) {
+        final d = math.max(
+            (colors[i].red - colors[j].red).abs(),
+            math.max((colors[i].green - colors[j].green).abs(),
+                (colors[i].blue - colors[j].blue).abs()));
+        if (d > colorDelta) colorDelta = d;
+      }
+    }
+    // Below the flat threshold the colour contributes nothing; above it, ramp
+    // linearly to the full division count at a full-range transition.
+    final colorDiv = colorDelta <= _flatColorDelta
+        ? 0
+        : (colorDelta * _patchDivisions).ceil();
+
+    final n = math.max(sizeDiv, colorDiv);
+    return n < 1 ? 1 : (n > _patchDivisions ? _patchDivisions : n);
+  }
+
   /// Evaluates the bicubic Bézier surface on a regular grid and emits
   /// triangles with bilinearly interpolated corner colors.
   void _tessellatePatch(
       List<List<(double, double)>> grid, List<PdfColor> colors) {
-    const n = _patchDivisions;
+    final n = _divisionsFor(grid, colors);
     final base = _vertices.length;
     for (var si = 0; si <= n; si++) {
       final s = si / n;

--- a/packages/pdf_graphics/test/shading_test.dart
+++ b/packages/pdf_graphics/test/shading_test.dart
@@ -491,6 +491,67 @@ void main() {
       expect(xs.reduce((a, b) => a > b ? a : b), closeTo(180, 1e-6));
     });
 
+    test('a small flat patch subdivides far less than 8 (#536)', () {
+      // A 6x6-unit patch whose four corners are the same colour: nothing to
+      // resolve geometrically or chromatically, so it collapses toward one
+      // cell instead of 128 triangles.
+      final shading = PdfShading.parse(
+          cos,
+          meshStream(6, [
+            0,
+            0, 0, 0, 2, 0, 4, 0, 6, //
+            2, 6, 4, 6, 6, 6, //
+            6, 4, 6, 2, 6, 0, //
+            4, 0, 2, 0, //
+            128, 128, 128, // c1
+            128, 128, 128, // c2
+            128, 128, 128, // c3
+            128, 128, 128, // c4
+          ]))!;
+      final mesh = shading.toMesh(PdfMatrix.identity)!;
+      // n == 1: a 2x2 vertex grid, one cell, two triangles.
+      expect(mesh.vertices, hasLength(4));
+      expect(mesh.triangles, hasLength(2 * 3));
+    });
+
+    test('a large flat patch still tessellates finely for geometry (#536)', () {
+      // Same flat colour but a big patch: the size metric keeps the division
+      // count high so a curved surface is not under-tessellated - the
+      // fidelity guard. Corners span 90 units -> 8 cells.
+      final shading = PdfShading.parse(
+          cos,
+          meshStream(6, [
+            0,
+            0, 0, 0, 30, 0, 60, 0, 90, //
+            30, 90, 60, 90, 90, 90, //
+            90, 60, 90, 30, 90, 0, //
+            60, 0, 30, 0, //
+            200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200,
+          ]))!;
+      final mesh = shading.toMesh(PdfMatrix.identity)!;
+      expect(mesh.triangles, hasLength(128 * 3),
+          reason: 'large patch keeps the full division count');
+    });
+
+    test('a small patch with a hard colour transition stays subdivided (#536)',
+        () {
+      // Tiny but full-range corner colours: the colour metric alone keeps the
+      // count high so the gradient is not banded.
+      final shading = PdfShading.parse(
+          cos,
+          meshStream(6, [
+            0,
+            0, 0, 0, 2, 0, 4, 0, 6, //
+            2, 6, 4, 6, 6, 6, //
+            6, 4, 6, 2, 6, 0, //
+            4, 0, 2, 0, //
+            255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255,
+          ]))!;
+      final mesh = shading.toMesh(PdfMatrix.identity)!;
+      expect(mesh.triangles, hasLength(128 * 3),
+          reason: 'a full-range colour transition needs the full count');
+    });
+
     test('non-mesh types return no mesh', () {
       final shading = PdfShading.parse(
         cos,


### PR DESCRIPTION
Fixes #536 (round-2 gap sweep of #520; low priority per the ticket).

`cpdf_rendershading.cpp` subdivides Coons/tensor patches adaptively — recursing only while a patch is large on screen *and* its corner-colour delta exceeds a threshold. dart-pdf used a fixed `_patchDivisions = 8` (128 triangles) per patch regardless, so a 1000-patch mesh always produced 128k triangles.

`_divisionsFor` now picks the count from `max(size metric, colour metric)`, clamped to `[1, 8]`:
- **size**: the max page-space span of the four corners, one cell per 12 units;
- **colour**: the max per-channel corner-colour delta, scaled to the full count at a full-range transition, with PDFium's **4/255** as the flat-floor below which colour contributes nothing.

Taking the *max* is the fidelity guard the fixed count lacked: a large patch keeps the full division count even when its corners share a colour, so a curved surface is never under-tessellated — while a small or flat patch collapses toward one cell.

## Tests

- Small flat patch → **2 triangles** (was 128).
- Large flat patch → **128** (geometry fidelity), and a small hard-transition patch → **128** (colour fidelity).
- Existing full-range 90×90 patch test unchanged (both metrics saturate to 8).
- Ghent render suite: mesh pages **byte-identical** vs main (failing set unchanged; the one differing page, GWG161, is #556's already-merged ICC bypass, not this change).
- `pdf_graphics` 902/902, analyze clean, counter gate OK.

## Measurement — honest scale note

coons/tensor render A/B (3×, 4 repeats): **0.854x** (coons) / 0.976x (tensor) — directional but noisy, because the only in-repo type-6/7 files carry just a handful of patches. The real win is triangle + vertex-buffer count on **patch-dense prepress meshes** (the ticket's cited 1000-patch case), which no corpus/generatable scenario exercises; it's proven at the unit level (128→2 triangles for the small-flat case). Landed as a correct, fidelity-guarded polish. Happy to close instead if you'd prefer evidence-first.

Part of #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)