### PR TITLE
fix(app): don't nudge Android/iOS about GitHub releases they can't install

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -251,7 +251,7 @@ class _EditorScreenState extends State<EditorScreen>
     // Re-open the documents that were open when the app last closed, unless the
     // app was launched to open a specific file (that explicit target wins).
     unawaited(_restoreSession());
-    if (widget.autoCheckUpdates && UpdateService.supported) {
+    if (widget.autoCheckUpdates && _updates.supported) {
       _updates.addListener(_onUpdateStatus);
       unawaited(_startupUpdateCheck());
     }

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -251,7 +251,7 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                       widget.onOpenDevTools!();
                     },
                   ),
-                if (widget.updates != null && UpdateService.supported) ...[
+                if (widget.updates != null && widget.updates!.supported) ...[
                   const Divider(height: 32),
                   _UpdateSection(updates: widget.updates!),
                 ],

--- a/app/lib/update.dart
+++ b/app/lib/update.dart
@@ -226,12 +226,35 @@ class UpdateService extends ChangeNotifier {
   String? _dismissedTag;
   Future<void> _restored = Future.value();
 
-  /// Whether update checks make sense on this platform. The web build is always
-  /// served fresh (and an installed PWA refreshes through its service worker),
-  /// so there is nothing to check there.
-  static bool get supported => !kIsWeb;
-
   TargetPlatform get _targetPlatform => _platform ?? defaultTargetPlatform;
+
+  /// Whether update checks make sense on this platform.
+  ///
+  /// Only the desktop builds are distributed as direct downloads from GitHub
+  /// Releases, so only they benefit from a "newer build available, download it"
+  /// nudge. Two platforms opt out:
+  ///
+  /// * The web build is always served fresh (and an installed PWA refreshes
+  ///   through its service worker), so there is nothing to check.
+  /// * The Android/iOS builds update through their app stores, and a GitHub
+  ///   release routinely lands *before* the store review clears. Checking
+  ///   GitHub there would nag mobile users about a version they can't install
+  ///   yet, and the "Download" button would only send them to a GitHub page
+  ///   that isn't their update channel - exactly the confusing dead end we
+  ///   want to avoid.
+  ///
+  /// This is an instance getter (not static) so the injected [platform] is
+  /// honoured and the gate is testable.
+  bool get supported {
+    if (kIsWeb) return false;
+    return switch (_targetPlatform) {
+      TargetPlatform.macOS ||
+      TargetPlatform.windows ||
+      TargetPlatform.linux =>
+        true,
+      _ => false,
+    };
+  }
 
   AppVersion? get _current => AppVersion.tryParse(currentVersion);
 
@@ -251,8 +274,9 @@ class UpdateService extends ChangeNotifier {
       );
 
   /// The best download URL for [latest] on the current platform: the matching
-  /// release asset when there is one, else the release page (iOS, and anything
-  /// without a direct artifact, send the user to the page).
+  /// release asset when there is one, else the release page (a desktop build
+  /// with no direct artifact falls back to the page). Only resolved on the
+  /// desktop platforms where updates are [supported].
   String? get downloadUrl {
     final release = _latest;
     if (release == null) return null;
@@ -325,7 +349,9 @@ class UpdateService extends ChangeNotifier {
           'dartpdf-linux-x86_64.AppImage',
           'dartpdf-linux-x64.tar.gz',
         ],
-      TargetPlatform.android => ['app-release.apk'],
+      // Mobile (Android/iOS) never reaches here: those platforms opt out of
+      // update checks (see [supported]) because they update through their app
+      // stores, so downloadUrl is only ever resolved for the desktop builds.
       _ => const <String>[],
     };
     for (final pattern in patterns) {

--- a/app/test/update_settings_test.dart
+++ b/app/test/update_settings_test.dart
@@ -18,9 +18,14 @@ ReleaseInfo _release(String tag) => ReleaseInfo(
 UpdateService _fakeService({
   required String current,
   required List<ReleaseInfo> releases,
+  // Update checks are a desktop-only feature (mobile updates through the app
+  // stores), and widget tests default to the Android target platform, so pin a
+  // desktop platform to exercise the update UI.
+  TargetPlatform platform = TargetPlatform.macOS,
 }) =>
     UpdateService(
       currentVersion: current,
+      platform: platform,
       fetcher: () async => releases,
     );
 
@@ -149,4 +154,55 @@ void main() {
       findsNothing,
     );
   });
+
+  for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+    testWidgets('no startup banner on ${platform.name} (updates via the store)',
+        (tester) async {
+      final updates = _fakeService(
+        current: '1.2.0',
+        releases: [_release('app-v1.3.0')],
+        platform: platform,
+      );
+      addTearDown(updates.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: EditorScreen(
+          prefs: prefs,
+          updateService: updates,
+          autoCheckUpdates: true,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('update-available-banner')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('Settings hides the Updates section on ${platform.name}',
+        (tester) async {
+      final updates = _fakeService(
+        current: '1.2.0',
+        releases: [_release('app-v1.3.0')],
+        platform: platform,
+      );
+      addTearDown(updates.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: EditorScreen(prefs: prefs, updateService: updates),
+      ));
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('DartPDF menu'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Settings'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('settings-check-updates')),
+        findsNothing,
+      );
+    });
+  }
 }

--- a/app/test/update_test.dart
+++ b/app/test/update_test.dart
@@ -40,7 +40,10 @@ UpdateService _service(
   bool throwOnFetch = false,
   Duration checkInterval = const Duration(hours: 24),
   DateTime Function()? now,
-  TargetPlatform? platform,
+  // Update checks are desktop-only, and widget/unit tests default to the
+  // Android target platform, so pin a desktop platform unless a test overrides
+  // it to exercise the mobile opt-out.
+  TargetPlatform platform = TargetPlatform.macOS,
 }) =>
     UpdateService(
       currentVersion: current,
@@ -181,6 +184,7 @@ void main() {
       final service = UpdateService(
         currentVersion: '1.2.2',
         checkInterval: const Duration(hours: 24),
+        platform: TargetPlatform.macOS,
         fetcher: () async {
           calls++;
           return [_release('app-v1.3.0')];
@@ -212,9 +216,10 @@ void main() {
       'dartpdf-windows-installer.exe': 'https://example.test/win-installer',
       'dartpdf-windows-x64.zip': 'https://example.test/win',
       'dartpdf-linux-x86_64.AppImage': 'https://example.test/appimage',
-      'app-release.apk': 'https://example.test/apk',
     };
 
+    // Only the desktop builds resolve a download; mobile opts out of update
+    // checks entirely (see UpdateService.supported).
     for (final scenario in [
       (platform: TargetPlatform.macOS, url: 'https://example.test/dmg'),
       (
@@ -222,7 +227,6 @@ void main() {
         url: 'https://example.test/win-installer'
       ),
       (platform: TargetPlatform.linux, url: 'https://example.test/appimage'),
-      (platform: TargetPlatform.android, url: 'https://example.test/apk'),
     ]) {
       test('points at the ${scenario.platform.name} artifact', () async {
         final service = _service(
@@ -261,11 +265,49 @@ void main() {
         releases: [
           _release('app-v1.3.0', html: 'https://example.test/page'),
         ],
-        platform: TargetPlatform.iOS,
+        platform: TargetPlatform.linux,
       );
       await service.checkForUpdates();
       expect(service.downloadUrl, 'https://example.test/page');
     });
+  });
+
+  group('UpdateService.supported', () {
+    for (final platform in [
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+      TargetPlatform.linux,
+    ]) {
+      test('is on for the desktop ${platform.name} build', () {
+        final service = _service('1.2.2', releases: const [], platform: platform);
+        addTearDown(service.dispose);
+        expect(service.supported, isTrue);
+      });
+    }
+
+    // Mobile updates through the app stores, where a store review routinely
+    // lags the GitHub release - so we must not nudge those users toward a
+    // build they can't install yet.
+    for (final platform in [TargetPlatform.android, TargetPlatform.iOS]) {
+      test('is off for the store-distributed ${platform.name} build', () {
+        final service = _service('1.2.2', releases: const [], platform: platform);
+        addTearDown(service.dispose);
+        expect(service.supported, isFalse);
+      });
+
+      test('checkForUpdates is a no-op on ${platform.name}', () async {
+        final service = _service(
+          '1.2.2',
+          releases: [_release('app-v1.3.0')],
+          platform: platform,
+        );
+        addTearDown(service.dispose);
+        await service.checkForUpdates(force: true);
+        expect(service.status, UpdateStatus.idle);
+        expect(service.updateAvailable, isFalse);
+        expect(service.shouldNotify, isFalse);
+      });
+    }
   });
 
   group('UpdateService default GitHub fetcher', () {
@@ -312,6 +354,7 @@ void main() {
     test('a non-200 response surfaces as a failed check', () async {
       final service = UpdateService(
         currentVersion: '1.2.2',
+        platform: TargetPlatform.macOS,
         clientFactory: () =>
             MockClient((_) async => http.Response('rate limited', 403)),
       );
@@ -326,6 +369,7 @@ void main() {
     test('a non-list body is treated as no releases', () async {
       final service = UpdateService(
         currentVersion: '1.2.2',
+        platform: TargetPlatform.macOS,
         clientFactory: () =>
             MockClient((_) async => http.Response('{"message":"nope"}', 200)),
       );

--- a/doc/dev-log/2026-07-24-mobile-update-check-opt-out.md
+++ b/doc/dev-log/2026-07-24-mobile-update-check-opt-out.md
@@ -1,0 +1,43 @@
+# Mobile opts out of the GitHub-release update check
+
+## Problem
+
+On Android and iOS the "new version available" banner (and the Settings
+"Updates" section) fired off the same GitHub Releases check as the desktop
+builds. But mobile updates ship through the app stores, and a GitHub release
+routinely lands *before* the App Store / Play review clears. So mobile users
+were nagged about a version they couldn't install yet, and the "Download"
+button just sent them to a GitHub page (iOS: the release page; Android: a
+sideload APK) that isn't their update channel.
+
+## Fix
+
+`UpdateService.supported` (`app/lib/update.dart`) is now an **instance** getter
+(was `static bool get supported => !kIsWeb`) that gates on the target platform:
+only the desktop builds (macOS / Windows / Linux) — the ones distributed as
+direct GitHub downloads — are supported. Web (served fresh / PWA service
+worker) and Android/iOS (store-updated) opt out.
+
+`supported` already gated `checkForUpdates` (early-returns when off), so the
+mobile path now short-circuits before any network call, the startup banner
+(`editor_screen.dart` `_onUpdateStatus`), and the Settings section
+(`settings_screen.dart`). The two call sites moved from the static
+`UpdateService.supported` to the instance getter (`_updates.supported` /
+`widget.updates!.supported`) — both already hold an instance.
+
+Making it an instance getter (reading the injected `platform`) also makes the
+gate directly unit-testable.
+
+## Fallout
+
+- `_platformAsset` dropped its now-unreachable `TargetPlatform.android =>
+  ['app-release.apk']` branch: `downloadUrl` is only ever read on desktop
+  (both UI surfaces are gated by `supported`), so the APK mapping was dead.
+  The release still ships the APK artifact for manual sideloaders; the app
+  just no longer surfaces it.
+- Widget/unit tests default to the **Android** target platform, so the
+  update-flow tests now pin a desktop platform (the `_service`/`_fakeService`
+  helpers default to `TargetPlatform.macOS`). New tests cover the mobile
+  opt-out: `supported` false + `checkForUpdates` no-op on Android/iOS
+  (`update_test.dart`), and no startup banner / no Settings "Updates" section
+  on Android/iOS (`update_settings_test.dart`).


### PR DESCRIPTION
## Summary

On Android and iOS the "new version available" banner (and the Settings "Updates" section) ran the same GitHub Releases check as the desktop builds. But mobile updates ship through the app stores, and a GitHub release routinely lands **before** the App Store / Play review clears — so mobile users were nagged about a version they couldn't install yet, and the "Download" button just sent them to a GitHub page that isn't their update channel (iOS: the release page; Android: a sideload APK).

The fix gates update checks to the desktop builds only:

- `UpdateService.supported` (`app/lib/update.dart`) is now an **instance** getter (was `static bool get supported => !kIsWeb`) that returns true only for macOS / Windows / Linux — the builds distributed as direct GitHub downloads. Web (served fresh / PWA service worker) and Android/iOS (store-updated) opt out.
- `supported` already short-circuits `checkForUpdates` and both UI surfaces (the startup banner in `editor_screen.dart` and the Settings section in `settings_screen.dart`), so the whole mobile update path is now silent — no network call, no banner, no download redirect. The two call sites moved from the static getter to the instance getter (both already hold an instance), which also makes the gate directly unit-testable via the injected `platform`.
- Dropped the now-unreachable `TargetPlatform.android => ['app-release.apk']` branch from `_platformAsset`: `downloadUrl` is only ever read on desktop. The release still ships the APK for manual sideloaders; the app just no longer surfaces it.

## Affected packages

- [x] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix

## Validation

- [x] `fvm dart analyze` (app/lib + app/test — no issues)
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran the touched app suites: `update_test.dart`, `update_settings_test.dart` — all 36 pass)

Widget/unit tests default to the **Android** target platform, so the update-flow tests now pin a desktop platform (the `_service` / `_fakeService` helpers default to `TargetPlatform.macOS`). New tests cover the mobile opt-out: `supported` false + `checkForUpdates` no-op on Android/iOS, and no startup banner / no Settings "Updates" section on Android/iOS.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Behavior change is mobile-only: desktop update checks are unchanged. If direct Android APK download nudges are ever wanted back, the `_platformAsset` APK branch and the Android `supported` case would both need to return (git history preserves them). Dev-log note: `doc/dev-log/2026-07-24-mobile-update-check-opt-out.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BmEX4NmX24v5hasd1Dcbi

---
_Generated by [Claude Code](https://claude.ai/code/session_016BmEX4NmX24v5hasd1Dcbi)_