### PR TITLE
feat(app): in-place app updates on desktop

### DIFF
--- a/app/RELEASING.md
+++ b/app/RELEASING.md
@@ -44,10 +44,19 @@ with a version input; that builds artifacts but only creates a Release on a tag.
 ## In-app update checker
 
 The app checks these Releases for a newer build (`app/lib/update.dart`,
-surfaced in Settings → Updates and a startup banner). It is a *checker*, not a
-silent updater: it points the user at the matching artifact for their platform
-(or the release page), since the desktop bundles are unsigned and the store
-builds update through their own channels. For it to work the published Release
+surfaced in Settings → Updates and a startup banner). On **desktop** the
+check is followed by a user-initiated *in-place update*
+(`app/lib/update_installer.dart`): "Update now" downloads the matching
+artifact in-app (with a progress dialog and a byte-size integrity check
+against the release metadata) and then applies it. A **Linux AppImage** is a
+single executable, so the new image is written next to the running one and
+atomically renamed over it before the app relaunches. On **macOS and
+Windows** — where swapping a running, unsigned bundle is fragile — the
+artifact is downloaded and handed to the OS installer (the `.dmg` mounts, the
+`.exe` runs). Anywhere without an in-app apply path (a Linux tarball install,
+mobile, a release page with no matching artifact) falls back to the old
+browser download. The apply and hand-off are still user-confirmed, not a
+silent background swap. For it to work the published Release
 must keep the **`app-v<version>` tag** (other tags, e.g. the pub-package
 release tags in this repo, are ignored) and keep the artifact file names CI
 produces (`dartpdf-macos.dmg`, `dartpdf-windows-portable.exe` /

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -34,6 +34,9 @@ import 'recents.dart';
 import 'session_store.dart';
 import 'settings_screen.dart';
 import 'update.dart';
+import 'update_install_flow.dart';
+import 'update_installer.dart';
+import 'update_platform.dart';
 import 'web_launch.dart';
 import 'welcome_screen.dart';
 
@@ -75,6 +78,7 @@ class EditorScreen extends StatefulWidget {
     this.launchArgs = const [],
     this.initialDocument,
     this.updateService,
+    this.updateInstaller,
     this.autoCheckUpdates = false,
     this.printDocument,
     this.digitalSignatureOptionsProvider,
@@ -100,6 +104,10 @@ class EditorScreen extends StatefulWidget {
   /// An update checker to use instead of the one the screen builds itself -
   /// the seam tests use to inject a fake without real network.
   final UpdateService? updateService;
+
+  /// The in-app updater used to download and apply a newer release (desktop).
+  /// Injected by tests with fake platform ops / HTTP; defaults to a real one.
+  final UpdateInstaller? updateInstaller;
 
   /// Whether to check for a newer release on startup (and show a banner if one
   /// is found). The host (production) sets this true; it defaults to false so
@@ -192,6 +200,10 @@ class _EditorScreenState extends State<EditorScreen>
   late final UpdateService _updates =
       widget.updateService ?? UpdateService(currentVersion: AppInfo.version);
   bool get _ownsUpdates => widget.updateService == null;
+
+  /// The in-app updater that downloads and applies a newer release.
+  late final UpdateInstaller _updateInstaller =
+      widget.updateInstaller ?? UpdateInstaller();
 
   /// True once the "update available" banner has been shown this session, so a
   /// later check (or rebuild) doesn't stack a second copy.
@@ -293,10 +305,17 @@ class _EditorScreenState extends State<EditorScreen>
           key: const ValueKey('update-banner-download'),
           onPressed: () {
             messenger.hideCurrentMaterialBanner();
-            final url = _updates.downloadUrl;
-            if (url != null) unawaited(_openExternal(Uri.parse(url)));
+            unawaited(startUpdateInstall(
+              context,
+              updates: _updates,
+              installer: _updateInstaller,
+            ));
           },
-          child: Text(appL10n(context).editorDownload),
+          child: Text(_updates.downloadAssetName != null &&
+                  _updateInstaller.modeFor(_updates.downloadAssetName) !=
+                      UpdateApplyMode.unsupported
+              ? appL10n(context).updateInstallNow
+              : appL10n(context).editorDownload),
         ),
       ],
     ));
@@ -2222,6 +2241,7 @@ class _EditorScreenState extends State<EditorScreen>
             prefs: _prefs,
             recents: _recents,
             updates: _updates,
+            updateInstaller: _updateInstaller,
             onOpenDevTools: kDevToolsEnabled ? _toggleDevTools : null,
           ),
           child: _appMenuTile(

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "المفتاح الخاص لا يطابق أي شهادة RSA محددة.",
   "appSigErrorEncryptedKeyUnsupported": "المفاتيح الخاصة المشفّرة غير مدعومة. اختر مفتاح RSA غير مشفّر بصيغة PKCS#1 أو PKCS#8.",
   "appSigErrorKeyNotRsa": "المفتاح الخاص ليس مفتاح RSA غير مشفّر بصيغة PKCS#1 أو PKCS#8.",
-  "appSigErrorNoCertificateFound": "لم يُعثر على أي شهادات X.509."
+  "appSigErrorNoCertificateFound": "لم يُعثر على أي شهادات X.509.",
+  "updateInstallNow": "التحديث الآن",
+  "updateDownloadingTitle": "جارٍ تنزيل التحديث",
+  "updatePreparing": "جارٍ التحضير…",
+  "updateDownloadingPercent": "جارٍ التنزيل… {percent}%",
+  "updateRestarting": "جارٍ إعادة التشغيل لإكمال التحديث…",
+  "updateHandedOff": "تم تنزيل التحديث. جارٍ فتح المُثبِّت…",
+  "updateFailed": "فشل التحديث: {error}"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "Der private Schlüssel passt zu keinem ausgewählten RSA-Zertifikat.",
   "appSigErrorEncryptedKeyUnsupported": "Verschlüsselte private Schlüssel werden nicht unterstützt. Wählen Sie einen unverschlüsselten RSA-PKCS#1- oder PKCS#8-Schlüssel.",
   "appSigErrorKeyNotRsa": "Der private Schlüssel ist kein unverschlüsselter RSA-PKCS#1- oder PKCS#8-Schlüssel.",
-  "appSigErrorNoCertificateFound": "Es wurden keine X.509-Zertifikate gefunden."
+  "appSigErrorNoCertificateFound": "Es wurden keine X.509-Zertifikate gefunden.",
+  "updateInstallNow": "Jetzt aktualisieren",
+  "updateDownloadingTitle": "Update wird heruntergeladen",
+  "updatePreparing": "Wird vorbereitet…",
+  "updateDownloadingPercent": "Wird heruntergeladen… {percent}%",
+  "updateRestarting": "Neustart, um das Update abzuschließen…",
+  "updateHandedOff": "Update heruntergeladen. Installationsprogramm wird geöffnet…",
+  "updateFailed": "Update fehlgeschlagen: {error}"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -761,6 +761,44 @@
   "@editorUpdateLater": {
     "description": "Update banner action to dismiss the update notice for now."
   },
+  "updateInstallNow": "Update now",
+  "@updateInstallNow": {
+    "description": "Button that downloads and installs the newer release in place (desktop), instead of opening a browser download."
+  },
+  "updateDownloadingTitle": "Downloading update",
+  "@updateDownloadingTitle": {
+    "description": "Title of the dialog shown while an in-app update is downloading."
+  },
+  "updatePreparing": "Preparing…",
+  "@updatePreparing": {
+    "description": "Status shown before download progress is known."
+  },
+  "updateDownloadingPercent": "Downloading… {percent}%",
+  "@updateDownloadingPercent": {
+    "description": "Download progress line with the percentage complete.",
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "updateRestarting": "Restarting to finish the update…",
+  "@updateRestarting": {
+    "description": "Status shown after the AppImage is replaced, just before the app relaunches."
+  },
+  "updateHandedOff": "Update downloaded. Opening the installer…",
+  "@updateHandedOff": {
+    "description": "Snackbar shown after a macOS/Windows update is downloaded and handed to the OS installer."
+  },
+  "updateFailed": "Update failed: {error}",
+  "@updateFailed": {
+    "description": "Snackbar shown when an in-app update download or install fails.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "editorViewAllTabs": "View all tabs",
   "@editorViewAllTabs": {
     "description": "Tooltip on the desktop button that opens the all-tabs grid dialog."

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "La clave privada no coincide con ningún certificado RSA seleccionado.",
   "appSigErrorEncryptedKeyUnsupported": "Las claves privadas cifradas no son compatibles. Elige una clave RSA PKCS#1 o PKCS#8 sin cifrar.",
   "appSigErrorKeyNotRsa": "La clave privada no es una clave RSA PKCS#1 o PKCS#8 sin cifrar.",
-  "appSigErrorNoCertificateFound": "No se encontraron certificados X.509."
+  "appSigErrorNoCertificateFound": "No se encontraron certificados X.509.",
+  "updateInstallNow": "Actualizar ahora",
+  "updateDownloadingTitle": "Descargando actualización",
+  "updatePreparing": "Preparando…",
+  "updateDownloadingPercent": "Descargando… {percent}%",
+  "updateRestarting": "Reiniciando para completar la actualización…",
+  "updateHandedOff": "Actualización descargada. Abriendo el instalador…",
+  "updateFailed": "Error en la actualización: {error}"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "La clé privée ne correspond à aucun certificat RSA sélectionné.",
   "appSigErrorEncryptedKeyUnsupported": "Les clés privées chiffrées ne sont pas prises en charge. Choisissez une clé RSA PKCS#1 ou PKCS#8 non chiffrée.",
   "appSigErrorKeyNotRsa": "La clé privée n'est pas une clé RSA PKCS#1 ou PKCS#8 non chiffrée.",
-  "appSigErrorNoCertificateFound": "Aucun certificat X.509 n'a été trouvé."
+  "appSigErrorNoCertificateFound": "Aucun certificat X.509 n'a été trouvé.",
+  "updateInstallNow": "Mettre à jour maintenant",
+  "updateDownloadingTitle": "Téléchargement de la mise à jour",
+  "updatePreparing": "Préparation…",
+  "updateDownloadingPercent": "Téléchargement… {percent}%",
+  "updateRestarting": "Redémarrage pour terminer la mise à jour…",
+  "updateHandedOff": "Mise à jour téléchargée. Ouverture du programme d’installation…",
+  "updateFailed": "Échec de la mise à jour : {error}"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "निजी कुंजी किसी भी चयनित RSA प्रमाणपत्र से मेल नहीं खाती।",
   "appSigErrorEncryptedKeyUnsupported": "एन्क्रिप्टेड निजी कुंजियाँ समर्थित नहीं हैं। कोई अनएन्क्रिप्टेड RSA PKCS#1 या PKCS#8 कुंजी चुनें।",
   "appSigErrorKeyNotRsa": "निजी कुंजी अनएन्क्रिप्टेड RSA PKCS#1 या PKCS#8 कुंजी नहीं है।",
-  "appSigErrorNoCertificateFound": "कोई X.509 प्रमाणपत्र नहीं मिला।"
+  "appSigErrorNoCertificateFound": "कोई X.509 प्रमाणपत्र नहीं मिला।",
+  "updateInstallNow": "अभी अपडेट करें",
+  "updateDownloadingTitle": "अपडेट डाउनलोड हो रहा है",
+  "updatePreparing": "तैयार हो रहा है…",
+  "updateDownloadingPercent": "डाउनलोड हो रहा है… {percent}%",
+  "updateRestarting": "अपडेट पूरा करने के लिए पुनरारंभ हो रहा है…",
+  "updateHandedOff": "अपडेट डाउनलोड हो गया. इंस्टॉलर खोला जा रहा है…",
+  "updateFailed": "अपडेट विफल: {error}"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "Kunci privat tidak cocok dengan sertifikat RSA yang dipilih mana pun.",
   "appSigErrorEncryptedKeyUnsupported": "Kunci privat terenkripsi tidak didukung. Pilih kunci RSA PKCS#1 atau PKCS#8 yang tidak terenkripsi.",
   "appSigErrorKeyNotRsa": "Kunci privat bukan kunci RSA PKCS#1 atau PKCS#8 yang tidak terenkripsi.",
-  "appSigErrorNoCertificateFound": "Tidak ada sertifikat X.509 yang ditemukan."
+  "appSigErrorNoCertificateFound": "Tidak ada sertifikat X.509 yang ditemukan.",
+  "updateInstallNow": "Perbarui sekarang",
+  "updateDownloadingTitle": "Mengunduh pembaruan",
+  "updatePreparing": "Menyiapkan…",
+  "updateDownloadingPercent": "Mengunduh… {percent}%",
+  "updateRestarting": "Memulai ulang untuk menyelesaikan pembaruan…",
+  "updateHandedOff": "Pembaruan diunduh. Membuka penginstal…",
+  "updateFailed": "Pembaruan gagal: {error}"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "La chiave privata non corrisponde a nessun certificato RSA selezionato.",
   "appSigErrorEncryptedKeyUnsupported": "Le chiavi private crittografate non sono supportate. Scegli una chiave RSA PKCS#1 o PKCS#8 non crittografata.",
   "appSigErrorKeyNotRsa": "La chiave privata non è una chiave RSA PKCS#1 o PKCS#8 non crittografata.",
-  "appSigErrorNoCertificateFound": "Nessun certificato X.509 trovato."
+  "appSigErrorNoCertificateFound": "Nessun certificato X.509 trovato.",
+  "updateInstallNow": "Aggiorna ora",
+  "updateDownloadingTitle": "Download dell’aggiornamento",
+  "updatePreparing": "Preparazione…",
+  "updateDownloadingPercent": "Download… {percent}%",
+  "updateRestarting": "Riavvio per completare l’aggiornamento…",
+  "updateHandedOff": "Aggiornamento scaricato. Apertura del programma di installazione…",
+  "updateFailed": "Aggiornamento non riuscito: {error}"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "秘密鍵が、選択したどの RSA 証明書とも一致しません。",
   "appSigErrorEncryptedKeyUnsupported": "暗号化された秘密鍵はサポートされていません。暗号化されていない RSA PKCS#1 または PKCS#8 鍵を選択してください。",
   "appSigErrorKeyNotRsa": "秘密鍵は暗号化されていない RSA PKCS#1 または PKCS#8 鍵ではありません。",
-  "appSigErrorNoCertificateFound": "X.509 証明書が見つかりませんでした。"
+  "appSigErrorNoCertificateFound": "X.509 証明書が見つかりませんでした。",
+  "updateInstallNow": "今すぐ更新",
+  "updateDownloadingTitle": "更新をダウンロード中",
+  "updatePreparing": "準備中…",
+  "updateDownloadingPercent": "ダウンロード中… {percent}%",
+  "updateRestarting": "更新を完了するために再起動しています…",
+  "updateHandedOff": "更新をダウンロードしました。インストーラーを開いています…",
+  "updateFailed": "更新に失敗しました: {error}"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "개인 키가 선택한 어떤 RSA 인증서와도 일치하지 않습니다.",
   "appSigErrorEncryptedKeyUnsupported": "암호화된 개인 키는 지원되지 않습니다. 암호화되지 않은 RSA PKCS#1 또는 PKCS#8 키를 선택하세요.",
   "appSigErrorKeyNotRsa": "개인 키가 암호화되지 않은 RSA PKCS#1 또는 PKCS#8 키가 아닙니다.",
-  "appSigErrorNoCertificateFound": "X.509 인증서를 찾을 수 없습니다."
+  "appSigErrorNoCertificateFound": "X.509 인증서를 찾을 수 없습니다.",
+  "updateInstallNow": "지금 업데이트",
+  "updateDownloadingTitle": "업데이트 다운로드 중",
+  "updatePreparing": "준비 중…",
+  "updateDownloadingPercent": "다운로드 중… {percent}%",
+  "updateRestarting": "업데이트를 완료하기 위해 다시 시작하는 중…",
+  "updateHandedOff": "업데이트를 다운로드했습니다. 설치 프로그램을 여는 중…",
+  "updateFailed": "업데이트 실패: {error}"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -973,6 +973,48 @@ abstract class AppLocalizations {
   /// **'Later'**
   String get editorUpdateLater;
 
+  /// Button that downloads and installs the newer release in place (desktop), instead of opening a browser download.
+  ///
+  /// In en, this message translates to:
+  /// **'Update now'**
+  String get updateInstallNow;
+
+  /// Title of the dialog shown while an in-app update is downloading.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading update'**
+  String get updateDownloadingTitle;
+
+  /// Status shown before download progress is known.
+  ///
+  /// In en, this message translates to:
+  /// **'Preparing…'**
+  String get updatePreparing;
+
+  /// Download progress line with the percentage complete.
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading… {percent}%'**
+  String updateDownloadingPercent(int percent);
+
+  /// Status shown after the AppImage is replaced, just before the app relaunches.
+  ///
+  /// In en, this message translates to:
+  /// **'Restarting to finish the update…'**
+  String get updateRestarting;
+
+  /// Snackbar shown after a macOS/Windows update is downloaded and handed to the OS installer.
+  ///
+  /// In en, this message translates to:
+  /// **'Update downloaded. Opening the installer…'**
+  String get updateHandedOff;
+
+  /// Snackbar shown when an in-app update download or install fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Update failed: {error}'**
+  String updateFailed(String error);
+
   /// Tooltip on the desktop button that opens the all-tabs grid dialog.
   ///
   /// In en, this message translates to:

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -580,6 +580,31 @@ class AppLocalizationsAr extends AppLocalizations {
   String get editorUpdateLater => 'لاحقًا';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'عرض جميع علامات التبويب';
 
   @override

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -580,28 +580,28 @@ class AppLocalizationsAr extends AppLocalizations {
   String get editorUpdateLater => 'لاحقًا';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'التحديث الآن';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'جارٍ تنزيل التحديث';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'جارٍ التحضير…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'جارٍ التنزيل… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'جارٍ إعادة التشغيل لإكمال التحديث…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'تم تنزيل التحديث. جارٍ فتح المُثبِّت…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'فشل التحديث: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -566,6 +566,31 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editorUpdateLater => 'Später';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Alle Tabs anzeigen';
 
   @override

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -566,28 +566,29 @@ class AppLocalizationsDe extends AppLocalizations {
   String get editorUpdateLater => 'Später';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Jetzt aktualisieren';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Update wird heruntergeladen';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Wird vorbereitet…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Wird heruntergeladen… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Neustart, um das Update abzuschließen…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff =>
+      'Update heruntergeladen. Installationsprogramm wird geöffnet…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Update fehlgeschlagen: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -559,6 +559,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get editorUpdateLater => 'Later';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'View all tabs';
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -564,28 +564,29 @@ class AppLocalizationsEs extends AppLocalizations {
   String get editorUpdateLater => 'Más tarde';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Actualizar ahora';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Descargando actualización';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Preparando…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Descargando… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Reiniciando para completar la actualización…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff =>
+      'Actualización descargada. Abriendo el instalador…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Error en la actualización: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -564,6 +564,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get editorUpdateLater => 'Más tarde';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Ver todas las pestañas';
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -565,28 +565,29 @@ class AppLocalizationsFr extends AppLocalizations {
   String get editorUpdateLater => 'Plus tard';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Mettre à jour maintenant';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Téléchargement de la mise à jour';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Préparation…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Téléchargement… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Redémarrage pour terminer la mise à jour…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff =>
+      'Mise à jour téléchargée. Ouverture du programme d’installation…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Échec de la mise à jour : $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -565,6 +565,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get editorUpdateLater => 'Plus tard';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Afficher tous les onglets';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -560,6 +560,31 @@ class AppLocalizationsHi extends AppLocalizations {
   String get editorUpdateLater => 'बाद में';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'सभी टैब देखें';
 
   @override

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -560,28 +560,29 @@ class AppLocalizationsHi extends AppLocalizations {
   String get editorUpdateLater => 'बाद में';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'अभी अपडेट करें';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'अपडेट डाउनलोड हो रहा है';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'तैयार हो रहा है…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'डाउनलोड हो रहा है… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'अपडेट पूरा करने के लिए पुनरारंभ हो रहा है…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff =>
+      'अपडेट डाउनलोड हो गया. इंस्टॉलर खोला जा रहा है…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'अपडेट विफल: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -564,6 +564,31 @@ class AppLocalizationsId extends AppLocalizations {
   String get editorUpdateLater => 'Nanti';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Lihat semua tab';
 
   @override

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -564,28 +564,28 @@ class AppLocalizationsId extends AppLocalizations {
   String get editorUpdateLater => 'Nanti';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Perbarui sekarang';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Mengunduh pembaruan';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Menyiapkan…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Mengunduh… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Memulai ulang untuk menyelesaikan pembaruan…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'Pembaruan diunduh. Membuka penginstal…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Pembaruan gagal: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -564,28 +564,29 @@ class AppLocalizationsIt extends AppLocalizations {
   String get editorUpdateLater => 'Più tardi';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Aggiorna ora';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Download dell’aggiornamento';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Preparazione…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Download… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Riavvio per completare l’aggiornamento…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff =>
+      'Aggiornamento scaricato. Apertura del programma di installazione…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Aggiornamento non riuscito: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -564,6 +564,31 @@ class AppLocalizationsIt extends AppLocalizations {
   String get editorUpdateLater => 'Più tardi';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Visualizza tutte le schede';
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -552,28 +552,28 @@ class AppLocalizationsJa extends AppLocalizations {
   String get editorUpdateLater => '後で';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => '今すぐ更新';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => '更新をダウンロード中';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => '準備中…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'ダウンロード中… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => '更新を完了するために再起動しています…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => '更新をダウンロードしました。インストーラーを開いています…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return '更新に失敗しました: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -552,6 +552,31 @@ class AppLocalizationsJa extends AppLocalizations {
   String get editorUpdateLater => '後で';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'すべてのタブを表示';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -550,6 +550,31 @@ class AppLocalizationsKo extends AppLocalizations {
   String get editorUpdateLater => '나중에';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => '모든 탭 보기';
 
   @override

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -550,28 +550,28 @@ class AppLocalizationsKo extends AppLocalizations {
   String get editorUpdateLater => '나중에';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => '지금 업데이트';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => '업데이트 다운로드 중';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => '준비 중…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return '다운로드 중… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => '업데이트를 완료하기 위해 다시 시작하는 중…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => '업데이트를 다운로드했습니다. 설치 프로그램을 여는 중…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return '업데이트 실패: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -565,28 +565,29 @@ class AppLocalizationsNl extends AppLocalizations {
   String get editorUpdateLater => 'Later';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Nu bijwerken';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Update downloaden';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Voorbereiden…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Downloaden… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Opnieuw opstarten om de update te voltooien…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff =>
+      'Update gedownload. Installatieprogramma wordt geopend…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Bijwerken mislukt: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -565,6 +565,31 @@ class AppLocalizationsNl extends AppLocalizations {
   String get editorUpdateLater => 'Later';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Alle tabbladen weergeven';
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -579,28 +579,29 @@ class AppLocalizationsPl extends AppLocalizations {
   String get editorUpdateLater => 'Później';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Aktualizuj teraz';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Pobieranie aktualizacji';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Przygotowywanie…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Pobieranie… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting =>
+      'Ponowne uruchamianie, aby dokończyć aktualizację…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'Pobrano aktualizację. Otwieranie instalatora…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Aktualizacja nie powiodła się: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -579,6 +579,31 @@ class AppLocalizationsPl extends AppLocalizations {
   String get editorUpdateLater => 'Później';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Wyświetl wszystkie karty';
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -564,28 +564,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get editorUpdateLater => 'Depois';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Atualizar agora';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Baixando atualização';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Preparando…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Baixando… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Reiniciando para concluir a atualização…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'Atualização baixada. Abrindo o instalador…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Falha na atualização: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -564,6 +564,31 @@ class AppLocalizationsPt extends AppLocalizations {
   String get editorUpdateLater => 'Depois';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Ver todas as abas';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -565,6 +565,31 @@ class AppLocalizationsRu extends AppLocalizations {
   String get editorUpdateLater => 'Позже';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Показать все вкладки';
 
   @override

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -565,28 +565,28 @@ class AppLocalizationsRu extends AppLocalizations {
   String get editorUpdateLater => 'Позже';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Обновить сейчас';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Загрузка обновления';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Подготовка…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Загрузка… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Перезапуск для завершения обновления…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'Обновление загружено. Открытие установщика…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Не удалось обновить: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -558,28 +558,28 @@ class AppLocalizationsTh extends AppLocalizations {
   String get editorUpdateLater => 'ภายหลัง';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'อัปเดตทันที';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'กำลังดาวน์โหลดการอัปเดต';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'กำลังเตรียม…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'กำลังดาวน์โหลด… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'กำลังรีสตาร์ทเพื่อสิ้นสุดการอัปเดต…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'ดาวน์โหลดการอัปเดตแล้ว กำลังเปิดตัวติดตั้ง…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'การอัปเดตล้มเหลว: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -558,6 +558,31 @@ class AppLocalizationsTh extends AppLocalizations {
   String get editorUpdateLater => 'ภายหลัง';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'ดูแท็บทั้งหมด';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -560,6 +560,31 @@ class AppLocalizationsTr extends AppLocalizations {
   String get editorUpdateLater => 'Daha sonra';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Tüm sekmeleri görüntüle';
 
   @override

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -560,28 +560,29 @@ class AppLocalizationsTr extends AppLocalizations {
   String get editorUpdateLater => 'Daha sonra';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Şimdi güncelle';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Güncelleme indiriliyor';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Hazırlanıyor…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'İndiriliyor… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting =>
+      'Güncellemeyi tamamlamak için yeniden başlatılıyor…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'Güncelleme indirildi. Yükleyici açılıyor…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Güncelleme başarısız: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -566,6 +566,31 @@ class AppLocalizationsUk extends AppLocalizations {
   String get editorUpdateLater => 'Пізніше';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Переглянути всі вкладки';
 
   @override

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -566,28 +566,28 @@ class AppLocalizationsUk extends AppLocalizations {
   String get editorUpdateLater => 'Пізніше';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Оновити зараз';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Завантаження оновлення';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Підготовка…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Завантаження… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Перезапуск для завершення оновлення…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => 'Оновлення завантажено. Відкриття інсталятора…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Не вдалося оновити: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -558,28 +558,29 @@ class AppLocalizationsVi extends AppLocalizations {
   String get editorUpdateLater => 'Để sau';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => 'Cập nhật ngay';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => 'Đang tải xuống bản cập nhật';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => 'Đang chuẩn bị…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return 'Đang tải xuống… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => 'Đang khởi động lại để hoàn tất cập nhật…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff =>
+      'Đã tải xuống bản cập nhật. Đang mở trình cài đặt…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return 'Cập nhật thất bại: $error';
   }
 
   @override

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -558,6 +558,31 @@ class AppLocalizationsVi extends AppLocalizations {
   String get editorUpdateLater => 'Để sau';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => 'Xem tất cả các thẻ';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -549,6 +549,31 @@ class AppLocalizationsZh extends AppLocalizations {
   String get editorUpdateLater => '稍后';
 
   @override
+  String get updateInstallNow => 'Update now';
+
+  @override
+  String get updateDownloadingTitle => 'Downloading update';
+
+  @override
+  String get updatePreparing => 'Preparing…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return 'Downloading… $percent%';
+  }
+
+  @override
+  String get updateRestarting => 'Restarting to finish the update…';
+
+  @override
+  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+
+  @override
+  String updateFailed(String error) {
+    return 'Update failed: $error';
+  }
+
+  @override
   String get editorViewAllTabs => '查看所有标签页';
 
   @override

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -549,28 +549,28 @@ class AppLocalizationsZh extends AppLocalizations {
   String get editorUpdateLater => '稍后';
 
   @override
-  String get updateInstallNow => 'Update now';
+  String get updateInstallNow => '立即更新';
 
   @override
-  String get updateDownloadingTitle => 'Downloading update';
+  String get updateDownloadingTitle => '正在下载更新';
 
   @override
-  String get updatePreparing => 'Preparing…';
+  String get updatePreparing => '正在准备…';
 
   @override
   String updateDownloadingPercent(int percent) {
-    return 'Downloading… $percent%';
+    return '正在下载… $percent%';
   }
 
   @override
-  String get updateRestarting => 'Restarting to finish the update…';
+  String get updateRestarting => '正在重启以完成更新…';
 
   @override
-  String get updateHandedOff => 'Update downloaded. Opening the installer…';
+  String get updateHandedOff => '更新已下载。正在打开安装程序…';
 
   @override
   String updateFailed(String error) {
-    return 'Update failed: $error';
+    return '更新失败：$error';
   }
 
   @override
@@ -1470,6 +1470,31 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get editorUpdateLater => '稍後';
+
+  @override
+  String get updateInstallNow => '立即更新';
+
+  @override
+  String get updateDownloadingTitle => '正在下載更新';
+
+  @override
+  String get updatePreparing => '正在準備…';
+
+  @override
+  String updateDownloadingPercent(int percent) {
+    return '正在下載… $percent%';
+  }
+
+  @override
+  String get updateRestarting => '正在重新啟動以完成更新…';
+
+  @override
+  String get updateHandedOff => '更新已下載。正在開啟安裝程式…';
+
+  @override
+  String updateFailed(String error) {
+    return '更新失敗：$error';
+  }
 
   @override
   String get editorViewAllTabs => '檢視所有分頁';

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "De privésleutel komt met geen enkel geselecteerd RSA-certificaat overeen.",
   "appSigErrorEncryptedKeyUnsupported": "Versleutelde privésleutels worden niet ondersteund. Kies een onversleutelde RSA PKCS#1- of PKCS#8-sleutel.",
   "appSigErrorKeyNotRsa": "De privésleutel is geen onversleutelde RSA PKCS#1- of PKCS#8-sleutel.",
-  "appSigErrorNoCertificateFound": "Er zijn geen X.509-certificaten gevonden."
+  "appSigErrorNoCertificateFound": "Er zijn geen X.509-certificaten gevonden.",
+  "updateInstallNow": "Nu bijwerken",
+  "updateDownloadingTitle": "Update downloaden",
+  "updatePreparing": "Voorbereiden…",
+  "updateDownloadingPercent": "Downloaden… {percent}%",
+  "updateRestarting": "Opnieuw opstarten om de update te voltooien…",
+  "updateHandedOff": "Update gedownload. Installatieprogramma wordt geopend…",
+  "updateFailed": "Bijwerken mislukt: {error}"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "Klucz prywatny nie pasuje do żadnego wybranego certyfikatu RSA.",
   "appSigErrorEncryptedKeyUnsupported": "Zaszyfrowane klucze prywatne nie są obsługiwane. Wybierz niezaszyfrowany klucz RSA PKCS#1 lub PKCS#8.",
   "appSigErrorKeyNotRsa": "Klucz prywatny nie jest niezaszyfrowanym kluczem RSA PKCS#1 lub PKCS#8.",
-  "appSigErrorNoCertificateFound": "Nie znaleziono certyfikatów X.509."
+  "appSigErrorNoCertificateFound": "Nie znaleziono certyfikatów X.509.",
+  "updateInstallNow": "Aktualizuj teraz",
+  "updateDownloadingTitle": "Pobieranie aktualizacji",
+  "updatePreparing": "Przygotowywanie…",
+  "updateDownloadingPercent": "Pobieranie… {percent}%",
+  "updateRestarting": "Ponowne uruchamianie, aby dokończyć aktualizację…",
+  "updateHandedOff": "Pobrano aktualizację. Otwieranie instalatora…",
+  "updateFailed": "Aktualizacja nie powiodła się: {error}"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "A chave privada não corresponde a nenhum certificado RSA selecionado.",
   "appSigErrorEncryptedKeyUnsupported": "Chaves privadas criptografadas não são suportadas. Escolha uma chave RSA PKCS#1 ou PKCS#8 não criptografada.",
   "appSigErrorKeyNotRsa": "A chave privada não é uma chave RSA PKCS#1 ou PKCS#8 não criptografada.",
-  "appSigErrorNoCertificateFound": "Nenhum certificado X.509 foi encontrado."
+  "appSigErrorNoCertificateFound": "Nenhum certificado X.509 foi encontrado.",
+  "updateInstallNow": "Atualizar agora",
+  "updateDownloadingTitle": "Baixando atualização",
+  "updatePreparing": "Preparando…",
+  "updateDownloadingPercent": "Baixando… {percent}%",
+  "updateRestarting": "Reiniciando para concluir a atualização…",
+  "updateHandedOff": "Atualização baixada. Abrindo o instalador…",
+  "updateFailed": "Falha na atualização: {error}"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "Закрытый ключ не соответствует ни одному выбранному сертификату RSA.",
   "appSigErrorEncryptedKeyUnsupported": "Зашифрованные закрытые ключи не поддерживаются. Выберите незашифрованный ключ RSA PKCS#1 или PKCS#8.",
   "appSigErrorKeyNotRsa": "Закрытый ключ не является незашифрованным ключом RSA PKCS#1 или PKCS#8.",
-  "appSigErrorNoCertificateFound": "Сертификаты X.509 не найдены."
+  "appSigErrorNoCertificateFound": "Сертификаты X.509 не найдены.",
+  "updateInstallNow": "Обновить сейчас",
+  "updateDownloadingTitle": "Загрузка обновления",
+  "updatePreparing": "Подготовка…",
+  "updateDownloadingPercent": "Загрузка… {percent}%",
+  "updateRestarting": "Перезапуск для завершения обновления…",
+  "updateHandedOff": "Обновление загружено. Открытие установщика…",
+  "updateFailed": "Не удалось обновить: {error}"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "คีย์ส่วนตัวไม่ตรงกับใบรับรอง RSA ที่เลือกใด ๆ",
   "appSigErrorEncryptedKeyUnsupported": "ไม่รองรับคีย์ส่วนตัวที่เข้ารหัส เลือกคีย์ RSA PKCS#1 หรือ PKCS#8 ที่ไม่ได้เข้ารหัส",
   "appSigErrorKeyNotRsa": "คีย์ส่วนตัวไม่ใช่คีย์ RSA PKCS#1 หรือ PKCS#8 ที่ไม่ได้เข้ารหัส",
-  "appSigErrorNoCertificateFound": "ไม่พบใบรับรอง X.509"
+  "appSigErrorNoCertificateFound": "ไม่พบใบรับรอง X.509",
+  "updateInstallNow": "อัปเดตทันที",
+  "updateDownloadingTitle": "กำลังดาวน์โหลดการอัปเดต",
+  "updatePreparing": "กำลังเตรียม…",
+  "updateDownloadingPercent": "กำลังดาวน์โหลด… {percent}%",
+  "updateRestarting": "กำลังรีสตาร์ทเพื่อสิ้นสุดการอัปเดต…",
+  "updateHandedOff": "ดาวน์โหลดการอัปเดตแล้ว กำลังเปิดตัวติดตั้ง…",
+  "updateFailed": "การอัปเดตล้มเหลว: {error}"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "Özel anahtar, seçilen hiçbir RSA sertifikasıyla eşleşmiyor.",
   "appSigErrorEncryptedKeyUnsupported": "Şifrelenmiş özel anahtarlar desteklenmiyor. Şifrelenmemiş bir RSA PKCS#1 veya PKCS#8 anahtarı seçin.",
   "appSigErrorKeyNotRsa": "Özel anahtar, şifrelenmemiş bir RSA PKCS#1 veya PKCS#8 anahtarı değil.",
-  "appSigErrorNoCertificateFound": "Hiç X.509 sertifikası bulunamadı."
+  "appSigErrorNoCertificateFound": "Hiç X.509 sertifikası bulunamadı.",
+  "updateInstallNow": "Şimdi güncelle",
+  "updateDownloadingTitle": "Güncelleme indiriliyor",
+  "updatePreparing": "Hazırlanıyor…",
+  "updateDownloadingPercent": "İndiriliyor… {percent}%",
+  "updateRestarting": "Güncellemeyi tamamlamak için yeniden başlatılıyor…",
+  "updateHandedOff": "Güncelleme indirildi. Yükleyici açılıyor…",
+  "updateFailed": "Güncelleme başarısız: {error}"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "Приватний ключ не відповідає жодному вибраному сертифікату RSA.",
   "appSigErrorEncryptedKeyUnsupported": "Зашифровані приватні ключі не підтримуються. Виберіть незашифрований ключ RSA PKCS#1 або PKCS#8.",
   "appSigErrorKeyNotRsa": "Приватний ключ не є незашифрованим ключем RSA PKCS#1 або PKCS#8.",
-  "appSigErrorNoCertificateFound": "Сертифікатів X.509 не знайдено."
+  "appSigErrorNoCertificateFound": "Сертифікатів X.509 не знайдено.",
+  "updateInstallNow": "Оновити зараз",
+  "updateDownloadingTitle": "Завантаження оновлення",
+  "updatePreparing": "Підготовка…",
+  "updateDownloadingPercent": "Завантаження… {percent}%",
+  "updateRestarting": "Перезапуск для завершення оновлення…",
+  "updateHandedOff": "Оновлення завантажено. Відкриття інсталятора…",
+  "updateFailed": "Не вдалося оновити: {error}"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "Khóa riêng tư không khớp với bất kỳ chứng chỉ RSA nào đã chọn.",
   "appSigErrorEncryptedKeyUnsupported": "Không hỗ trợ khóa riêng tư được mã hóa. Hãy chọn khóa RSA PKCS#1 hoặc PKCS#8 chưa mã hóa.",
   "appSigErrorKeyNotRsa": "Khóa riêng tư không phải là khóa RSA PKCS#1 hoặc PKCS#8 chưa mã hóa.",
-  "appSigErrorNoCertificateFound": "Không tìm thấy chứng chỉ X.509 nào."
+  "appSigErrorNoCertificateFound": "Không tìm thấy chứng chỉ X.509 nào.",
+  "updateInstallNow": "Cập nhật ngay",
+  "updateDownloadingTitle": "Đang tải xuống bản cập nhật",
+  "updatePreparing": "Đang chuẩn bị…",
+  "updateDownloadingPercent": "Đang tải xuống… {percent}%",
+  "updateRestarting": "Đang khởi động lại để hoàn tất cập nhật…",
+  "updateHandedOff": "Đã tải xuống bản cập nhật. Đang mở trình cài đặt…",
+  "updateFailed": "Cập nhật thất bại: {error}"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "私钥与所选的任何 RSA 证书都不匹配。",
   "appSigErrorEncryptedKeyUnsupported": "不支持加密的私钥。请选择未加密的 RSA PKCS#1 或 PKCS#8 密钥。",
   "appSigErrorKeyNotRsa": "私钥不是未加密的 RSA PKCS#1 或 PKCS#8 密钥。",
-  "appSigErrorNoCertificateFound": "未找到 X.509 证书。"
+  "appSigErrorNoCertificateFound": "未找到 X.509 证书。",
+  "updateInstallNow": "立即更新",
+  "updateDownloadingTitle": "正在下载更新",
+  "updatePreparing": "正在准备…",
+  "updateDownloadingPercent": "正在下载… {percent}%",
+  "updateRestarting": "正在重启以完成更新…",
+  "updateHandedOff": "更新已下载。正在打开安装程序…",
+  "updateFailed": "更新失败：{error}"
 }

--- a/app/lib/l10n/app_zh_Hant.arb
+++ b/app/lib/l10n/app_zh_Hant.arb
@@ -228,5 +228,12 @@
   "appSigErrorKeyCertificateMismatch": "私密金鑰與任何選取的 RSA 憑證都不相符。",
   "appSigErrorEncryptedKeyUnsupported": "不支援加密的私密金鑰。請選擇未加密的 RSA PKCS#1 或 PKCS#8 金鑰。",
   "appSigErrorKeyNotRsa": "私密金鑰不是未加密的 RSA PKCS#1 或 PKCS#8 金鑰。",
-  "appSigErrorNoCertificateFound": "找不到 X.509 憑證。"
+  "appSigErrorNoCertificateFound": "找不到 X.509 憑證。",
+  "updateInstallNow": "立即更新",
+  "updateDownloadingTitle": "正在下載更新",
+  "updatePreparing": "正在準備…",
+  "updateDownloadingPercent": "正在下載… {percent}%",
+  "updateRestarting": "正在重新啟動以完成更新…",
+  "updateHandedOff": "更新已下載。正在開啟安裝程式…",
+  "updateFailed": "更新失敗：{error}"
 }

--- a/app/lib/settings_screen.dart
+++ b/app/lib/settings_screen.dart
@@ -9,6 +9,8 @@ import 'l10n/app_localizations.dart';
 import 'language_names.dart';
 import 'recents.dart';
 import 'update.dart';
+import 'update_install_flow.dart';
+import 'update_installer.dart';
 
 // The platform-specific default-app help lives in the ARB as one ICU `select`
 // key each (branches: web/windows/macos/linux/android/ios/other), resolved from
@@ -80,6 +82,7 @@ Future<void> showAppSettings(
   required PdfEditingPreferences prefs,
   required RecentsStore recents,
   UpdateService? updates,
+  UpdateInstaller? updateInstaller,
   VoidCallback? onOpenDevTools,
 }) {
   return showDialog<void>(
@@ -88,6 +91,7 @@ Future<void> showAppSettings(
       prefs: prefs,
       recents: recents,
       updates: updates,
+      updateInstaller: updateInstaller,
       onOpenDevTools: onOpenDevTools,
     ),
   );
@@ -150,12 +154,14 @@ class _SettingsDialog extends StatefulWidget {
     required this.prefs,
     required this.recents,
     this.updates,
+    this.updateInstaller,
     this.onOpenDevTools,
   });
 
   final PdfEditingPreferences prefs;
   final RecentsStore recents;
   final UpdateService? updates;
+  final UpdateInstaller? updateInstaller;
 
   /// Non-null in debug/profile builds: closes the dialog and opens the
   /// developer tools panel (same as F12).
@@ -253,7 +259,10 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                   ),
                 if (widget.updates != null && UpdateService.supported) ...[
                   const Divider(height: 32),
-                  _UpdateSection(updates: widget.updates!),
+                  _UpdateSection(
+                    updates: widget.updates!,
+                    installer: widget.updateInstaller,
+                  ),
                 ],
                 const Divider(height: 32),
                 Text(appL10n(context).settingsAbout,
@@ -302,23 +311,18 @@ class _SettingsDialogState extends State<_SettingsDialog> {
 /// button (opening the platform artifact or release page) when a newer build
 /// is available.
 class _UpdateSection extends StatelessWidget {
-  const _UpdateSection({required this.updates});
+  const _UpdateSection({required this.updates, this.installer});
 
   final UpdateService updates;
 
-  Future<void> _openDownload(BuildContext context) async {
-    final url = updates.downloadUrl;
-    if (url == null) return;
-    final opened = await launchUrl(
-      Uri.parse(url),
-      mode: LaunchMode.externalApplication,
-    );
-    if (!opened && context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text(appL10n(context).settingsCouldNotOpenDownload),
-      ));
-    }
-  }
+  /// The in-app updater; null defaults to a real one (tests inject a fake).
+  final UpdateInstaller? installer;
+
+  Future<void> _install(BuildContext context) => startUpdateInstall(
+        context,
+        updates: updates,
+        installer: installer ?? UpdateInstaller(),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -361,7 +365,7 @@ class _UpdateSection extends StatelessWidget {
                   icon: const Icon(Icons.download_outlined, size: 18),
                   label: Text(appL10n(context).settingsDownloadVersion(
                       updates.latest!.version.toString())),
-                  onPressed: () => _openDownload(context),
+                  onPressed: () => _install(context),
                 ),
               ),
             ],

--- a/app/lib/update.dart
+++ b/app/lib/update.dart
@@ -90,6 +90,7 @@ class ReleaseInfo {
     required this.notes,
     required this.htmlUrl,
     required this.assets,
+    this.assetSizes = const {},
   });
 
   final AppVersion version;
@@ -101,6 +102,11 @@ class ReleaseInfo {
   /// Asset file name → `browser_download_url`.
   final Map<String, String> assets;
 
+  /// Asset file name → byte size, from the GitHub release metadata. Used to
+  /// verify an in-app update download landed complete (a truncated download
+  /// is rejected rather than written over the running install).
+  final Map<String, int> assetSizes;
+
   /// Builds a release from one element of the GitHub `/releases` array,
   /// returning null when the tag isn't a parseable version (so non-app tags
   /// and malformed entries are simply skipped).
@@ -110,13 +116,18 @@ class ReleaseInfo {
     final version = AppVersion.tryParse(tag);
     if (version == null) return null;
     final assets = <String, String>{};
+    final assetSizes = <String, int>{};
     final rawAssets = json['assets'];
     if (rawAssets is List) {
       for (final asset in rawAssets) {
         if (asset is! Map) continue;
         final name = asset['name'];
         final url = asset['browser_download_url'];
-        if (name is String && url is String) assets[name] = url;
+        if (name is String && url is String) {
+          assets[name] = url;
+          final size = asset['size'];
+          if (size is int && size > 0) assetSizes[name] = size;
+        }
       }
     }
     return ReleaseInfo(
@@ -128,6 +139,7 @@ class ReleaseInfo {
       notes: (json['body'] as String?)?.trim() ?? '',
       htmlUrl: (json['html_url'] as String?) ?? '',
       assets: assets,
+      assetSizes: assetSizes,
     );
   }
 }
@@ -256,8 +268,28 @@ class UpdateService extends ChangeNotifier {
   String? get downloadUrl {
     final release = _latest;
     if (release == null) return null;
-    final asset = _platformAsset(release.assets);
+    final name = _platformAssetName(release.assets);
+    final asset = name == null ? null : release.assets[name];
     return asset ?? (release.htmlUrl.isEmpty ? null : release.htmlUrl);
+  }
+
+  /// The file name of the platform artifact for [latest], or null when there
+  /// is no direct artifact (so only the release page is available). The
+  /// in-app installer needs the name to decide how to apply the update and
+  /// where to stage the download.
+  String? get downloadAssetName {
+    final release = _latest;
+    if (release == null) return null;
+    return _platformAssetName(release.assets);
+  }
+
+  /// The expected byte size of [downloadAssetName], when GitHub reported one,
+  /// for verifying an in-app download landed complete.
+  int? get downloadAssetSize {
+    final release = _latest;
+    final name = downloadAssetName;
+    if (release == null || name == null) return null;
+    return release.assetSizes[name];
   }
 
   /// Queries GitHub for a newer release. Throttled to [_checkInterval] unless
@@ -312,7 +344,7 @@ class UpdateService extends ChangeNotifier {
     return last != null && _now().difference(last) < _checkInterval;
   }
 
-  String? _platformAsset(Map<String, String> assets) {
+  String? _platformAssetName(Map<String, String> assets) {
     if (assets.isEmpty) return null;
     final patterns = switch (_targetPlatform) {
       TargetPlatform.macOS => ['dartpdf-macos.dmg'],
@@ -330,7 +362,7 @@ class UpdateService extends ChangeNotifier {
     };
     for (final pattern in patterns) {
       for (final entry in assets.entries) {
-        if (entry.key == pattern) return entry.value;
+        if (entry.key == pattern) return entry.key;
       }
     }
     return null;

--- a/app/lib/update_install_flow.dart
+++ b/app/lib/update_install_flow.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'l10n/app_l10n.dart';
+import 'l10n/app_localizations.dart';
+import 'update.dart';
+import 'update_installer.dart';
+import 'update_platform.dart';
+
+/// Runs the interactive "update now" flow for the update [updates] found: on
+/// desktop, downloads the artifact in a progress dialog and applies it in place
+/// (AppImage self-replace + relaunch) or hands it to the OS installer
+/// (macOS/Windows). Where no in-app apply path exists, or on failure, it falls
+/// back to opening the browser download.
+///
+/// Reused by both the Settings "Update now" button and the startup banner.
+Future<void> startUpdateInstall(
+  BuildContext context, {
+  required UpdateService updates,
+  required UpdateInstaller installer,
+}) async {
+  final url = updates.downloadUrl;
+  if (url == null) return;
+  final assetName = updates.downloadAssetName;
+
+  // Capture the messenger and localizations before any await, so a snackbar
+  // still resolves after the async download even if the context is unmounted.
+  final messenger = ScaffoldMessenger.of(context);
+  final l10n = appL10n(context);
+
+  // No in-app apply path (mobile, a release page only, a Linux tarball): keep
+  // the old behaviour and open the download in the browser.
+  if (installer.modeFor(assetName) == UpdateApplyMode.unsupported) {
+    await _openInBrowser(messenger, l10n, url);
+    return;
+  }
+
+  final progress = ValueNotifier<double?>(null);
+  var cancelled = false;
+
+  final dialogFuture = showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) => _UpdateProgressDialog(
+      progress: progress,
+      onCancel: () => cancelled = true,
+    ),
+  );
+
+  UpdateInstallOutcome? outcome;
+  Object? failure;
+  try {
+    outcome = await installer.downloadAndApply(
+      url: url,
+      assetName: assetName!,
+      expectedSize: updates.downloadAssetSize,
+      isCancelled: () => cancelled,
+      onProgress: (received, total) {
+        progress.value =
+            (total != null && total > 0) ? received / total : null;
+      },
+    );
+  } on UpdateCancelledException {
+    // User cancelled - close the dialog quietly, no toast.
+  } catch (e) {
+    failure = e;
+  }
+
+  // Dismiss the progress dialog. (An AppImage relaunch already exited the
+  // process, so this only runs on hand-off, cancel, or failure.)
+  if (context.mounted) {
+    Navigator.of(context, rootNavigator: true).pop();
+  }
+  await dialogFuture;
+  progress.dispose();
+
+  if (failure != null) {
+    final message =
+        failure is UpdateInstallException ? failure.message : '$failure';
+    messenger.showSnackBar(SnackBar(
+      key: const ValueKey('update-install-failed'),
+      content: Text(l10n.updateFailed(message)),
+      action: SnackBarAction(
+        label: l10n.editorDownload,
+        onPressed: () =>
+            launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication),
+      ),
+    ));
+    return;
+  }
+
+  if (outcome == UpdateInstallOutcome.handedOff) {
+    messenger.showSnackBar(SnackBar(
+      key: const ValueKey('update-handed-off'),
+      content: Text(l10n.updateHandedOff),
+    ));
+  }
+}
+
+Future<void> _openInBrowser(
+  ScaffoldMessengerState messenger,
+  AppLocalizations l10n,
+  String url,
+) async {
+  final opened =
+      await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  if (!opened) {
+    messenger.showSnackBar(SnackBar(
+      content: Text(l10n.settingsCouldNotOpenDownload),
+    ));
+  }
+}
+
+/// Modal progress dialog for an in-app update download, with a cancel button.
+class _UpdateProgressDialog extends StatelessWidget {
+  const _UpdateProgressDialog({required this.progress, required this.onCancel});
+
+  final ValueListenable<double?> progress;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const ValueKey('update-progress-dialog'),
+      title: Text(appL10n(context).updateDownloadingTitle),
+      content: ValueListenableBuilder<double?>(
+        valueListenable: progress,
+        builder: (context, fraction, _) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(fraction == null
+                  ? appL10n(context).updatePreparing
+                  : appL10n(context)
+                      .updateDownloadingPercent((fraction * 100).round())),
+              const SizedBox(height: 16),
+              LinearProgressIndicator(value: fraction),
+            ],
+          );
+        },
+      ),
+      actions: [
+        TextButton(
+          key: const ValueKey('update-progress-cancel'),
+          onPressed: onCancel,
+          child: Text(appL10n(context).cancel),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/update_install_flow.dart
+++ b/app/lib/update_install_flow.dart
@@ -31,12 +31,14 @@ Future<void> startUpdateInstall(
 
   // No in-app apply path (mobile, a release page only, a Linux tarball): keep
   // the old behaviour and open the download in the browser.
-  if (installer.modeFor(assetName) == UpdateApplyMode.unsupported) {
+  final mode = installer.modeFor(assetName);
+  if (mode == UpdateApplyMode.unsupported) {
     await _openInBrowser(messenger, l10n, url);
     return;
   }
 
-  final progress = ValueNotifier<double?>(null);
+  final progress =
+      ValueNotifier<_UpdateProgress>(const _UpdateProgress(fraction: null));
   var cancelled = false;
 
   final dialogFuture = showDialog<void>(
@@ -57,9 +59,14 @@ Future<void> startUpdateInstall(
       expectedSize: updates.downloadAssetSize,
       isCancelled: () => cancelled,
       onProgress: (received, total) {
-        progress.value =
-            (total != null && total > 0) ? received / total : null;
+        progress.value = _UpdateProgress(
+            fraction: (total != null && total > 0) ? received / total : null);
       },
+      // The AppImage path relaunches immediately after applying; show a
+      // "restarting" state so the dialog isn't frozen at 100% before exit.
+      onApplying: mode == UpdateApplyMode.inPlaceRelaunch
+          ? () => progress.value = const _UpdateProgress(applying: true)
+          : null,
     );
   } on UpdateCancelledException {
     // User cancelled - close the dialog quietly, no toast.
@@ -112,11 +119,20 @@ Future<void> _openInBrowser(
   }
 }
 
+/// The progress dialog's state: download [fraction] (null before it's known),
+/// or [applying] once the download is done and the update is being applied
+/// (the AppImage restart).
+class _UpdateProgress {
+  const _UpdateProgress({this.fraction, this.applying = false});
+  final double? fraction;
+  final bool applying;
+}
+
 /// Modal progress dialog for an in-app update download, with a cancel button.
 class _UpdateProgressDialog extends StatelessWidget {
   const _UpdateProgressDialog({required this.progress, required this.onCancel});
 
-  final ValueListenable<double?> progress;
+  final ValueListenable<_UpdateProgress> progress;
   final VoidCallback onCancel;
 
   @override
@@ -124,19 +140,25 @@ class _UpdateProgressDialog extends StatelessWidget {
     return AlertDialog(
       key: const ValueKey('update-progress-dialog'),
       title: Text(appL10n(context).updateDownloadingTitle),
-      content: ValueListenableBuilder<double?>(
+      content: ValueListenableBuilder<_UpdateProgress>(
         valueListenable: progress,
-        builder: (context, fraction, _) {
+        builder: (context, value, _) {
+          final l10n = appL10n(context);
+          final label = value.applying
+              ? l10n.updateRestarting
+              : value.fraction == null
+                  ? l10n.updatePreparing
+                  : l10n.updateDownloadingPercent((value.fraction! * 100)
+                      .round());
           return Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Text(fraction == null
-                  ? appL10n(context).updatePreparing
-                  : appL10n(context)
-                      .updateDownloadingPercent((fraction * 100).round())),
+              Text(label),
               const SizedBox(height: 16),
-              LinearProgressIndicator(value: fraction),
+              // Indeterminate bar (null value) while applying/restarting.
+              LinearProgressIndicator(
+                  value: value.applying ? null : value.fraction),
             ],
           );
         },

--- a/app/lib/update_installer.dart
+++ b/app/lib/update_installer.dart
@@ -1,0 +1,205 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import 'update_platform.dart';
+import 'update_platform_stub.dart'
+    if (dart.library.io) 'update_platform_io.dart';
+
+/// Thrown when the user cancels an in-progress update download.
+class UpdateCancelledException implements Exception {
+  const UpdateCancelledException();
+  @override
+  String toString() => 'Update cancelled';
+}
+
+/// Thrown when the download or apply step fails (HTTP error, truncated file,
+/// write failure). Carries a short human-readable [message].
+class UpdateInstallException implements Exception {
+  const UpdateInstallException(this.message);
+  final String message;
+  @override
+  String toString() => 'UpdateInstallException: $message';
+}
+
+/// What happened when an update was applied.
+enum UpdateInstallOutcome {
+  /// The running binary was replaced and the app is relaunching (Linux
+  /// AppImage). In practice the process exits before this is observed.
+  relaunching,
+
+  /// The artifact was downloaded and handed to the OS installer (macOS /
+  /// Windows). The app keeps running.
+  handedOff,
+
+  /// This platform/release has no in-app apply path; the caller should open
+  /// the browser download instead.
+  unsupported,
+}
+
+/// Downloads a newer release artifact and applies it in place on desktop.
+///
+/// This turns the update *checker* into an actual updater where it can be done
+/// safely: the Linux AppImage is a single executable, so the new build is
+/// downloaded, verified against the release's reported size, written next to
+/// the running image, and atomically renamed over it before relaunching. On
+/// macOS and Windows - where swapping a running, unsigned bundle is fragile -
+/// the artifact is downloaded and handed to the OS installer instead of just
+/// opening a browser tab.
+///
+/// The filesystem/process work goes through an injectable [UpdatePlatformOps]
+/// and the download through an injectable [http.Client], so the whole flow is
+/// unit-testable without touching the real disk or network.
+class UpdateInstaller {
+  UpdateInstaller({
+    UpdatePlatformOps? ops,
+    http.Client Function()? clientFactory,
+  })  : _ops = ops ?? defaultUpdatePlatformOps(),
+        _clientFactory = clientFactory ?? http.Client.new;
+
+  final UpdatePlatformOps _ops;
+  final http.Client Function() _clientFactory;
+
+  /// How [assetName] would be applied on the current platform, without
+  /// downloading anything. [assetName] is the release artifact's file name
+  /// (e.g. `dartpdf-linux-x86_64.AppImage`); null when the release exposes
+  /// only its web page.
+  UpdateApplyMode modeFor(String? assetName) {
+    if (assetName == null || assetName.isEmpty) {
+      return UpdateApplyMode.unsupported;
+    }
+    switch (_ops.platform) {
+      case TargetPlatform.linux:
+        // A clean, atomic self-replace is only possible when the running
+        // process is an AppImage and the artifact is one too. A tarball
+        // install has no single file to swap, so fall back to the browser.
+        final isAppImage = assetName.toLowerCase().endsWith('.appimage');
+        return (isAppImage && _ops.appImagePath != null)
+            ? UpdateApplyMode.inPlaceRelaunch
+            : UpdateApplyMode.unsupported;
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return UpdateApplyMode.openArtifact;
+      default:
+        return UpdateApplyMode.unsupported;
+    }
+  }
+
+  /// Downloads [url] and applies it according to [modeFor]. [assetName] names
+  /// the artifact; [expectedSize], when known, is checked against the number of
+  /// bytes received so a truncated download is never written over the install.
+  ///
+  /// [onProgress] reports `(received, total)` bytes (total null until known).
+  /// [isCancelled] is polled while streaming so a UI cancel button can abort
+  /// (throwing [UpdateCancelledException]).
+  ///
+  /// Returns [UpdateInstallOutcome.unsupported] without downloading when the
+  /// platform has no apply path. Throws [UpdateInstallException] on failure.
+  Future<UpdateInstallOutcome> downloadAndApply({
+    required String url,
+    required String assetName,
+    int? expectedSize,
+    void Function(int received, int? total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    final mode = modeFor(assetName);
+    if (mode == UpdateApplyMode.unsupported) {
+      return UpdateInstallOutcome.unsupported;
+    }
+
+    final bytes = await _download(
+      url,
+      expectedSize: expectedSize,
+      onProgress: onProgress,
+      isCancelled: isCancelled,
+    );
+
+    switch (mode) {
+      case UpdateApplyMode.inPlaceRelaunch:
+        await _applyInPlace(bytes);
+        // relaunchAndExit terminates the process; unreachable in practice.
+        return UpdateInstallOutcome.relaunching;
+      case UpdateApplyMode.openArtifact:
+        await _applyByHandoff(bytes, assetName);
+        return UpdateInstallOutcome.handedOff;
+      case UpdateApplyMode.unsupported:
+        return UpdateInstallOutcome.unsupported;
+    }
+  }
+
+  Future<void> _applyInPlace(Uint8List bytes) async {
+    final target = _ops.appImagePath;
+    if (target == null) {
+      throw const UpdateInstallException('The running app is not an AppImage');
+    }
+    // Stage the new image next to the target so the replace is a
+    // same-filesystem atomic rename (a temp dir is often a different mount).
+    final dir = _ops.parentDirectory(target);
+    final staged = _ops.joinPath(dir, '.dartpdf-update.AppImage.part');
+    try {
+      await _ops.writeArtifact(staged, bytes, executable: true);
+      await _ops.replaceInPlace(from: staged, to: target);
+    } catch (e) {
+      throw UpdateInstallException('Could not write the update: $e');
+    }
+    await _ops.relaunchAndExit(target);
+  }
+
+  Future<void> _applyByHandoff(Uint8List bytes, String assetName) async {
+    try {
+      final dir = await _ops.downloadDirectory();
+      final path = _ops.joinPath(dir, assetName);
+      await _ops.writeArtifact(path, bytes);
+      await _ops.openArtifact(path);
+    } catch (e) {
+      throw UpdateInstallException('Could not save the update: $e');
+    }
+  }
+
+  Future<Uint8List> _download(
+    String url, {
+    int? expectedSize,
+    void Function(int received, int? total)? onProgress,
+    bool Function()? isCancelled,
+  }) async {
+    final client = _clientFactory();
+    try {
+      final response = await client.send(http.Request('GET', Uri.parse(url)));
+      if (response.statusCode != 200) {
+        throw UpdateInstallException('Download failed (HTTP '
+            '${response.statusCode})');
+      }
+      final total = expectedSize ?? response.contentLength;
+      final builder = BytesBuilder(copy: false);
+      var received = 0;
+      onProgress?.call(0, total);
+      await for (final chunk in response.stream) {
+        if (isCancelled?.call() ?? false) {
+          throw const UpdateCancelledException();
+        }
+        builder.add(chunk);
+        received += chunk.length;
+        onProgress?.call(received, total);
+      }
+      final bytes = builder.toBytes();
+      if (bytes.isEmpty) {
+        throw const UpdateInstallException('The download was empty');
+      }
+      if (expectedSize != null && bytes.length != expectedSize) {
+        throw UpdateInstallException('The download was incomplete '
+            '(${bytes.length} of $expectedSize bytes)');
+      }
+      return bytes;
+    } on UpdateCancelledException {
+      rethrow;
+    } on UpdateInstallException {
+      rethrow;
+    } catch (e) {
+      throw UpdateInstallException('Download failed: $e');
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/app/lib/update_installer.dart
+++ b/app/lib/update_installer.dart
@@ -93,7 +93,10 @@ class UpdateInstaller {
   ///
   /// [onProgress] reports `(received, total)` bytes (total null until known).
   /// [isCancelled] is polled while streaming so a UI cancel button can abort
-  /// (throwing [UpdateCancelledException]).
+  /// (throwing [UpdateCancelledException]). [onApplying] fires once the download
+  /// has landed and verified, just before the artifact is applied - the cue for
+  /// a UI to switch from download progress to an "applying / restarting" state
+  /// (the AppImage path relaunches immediately after).
   ///
   /// Returns [UpdateInstallOutcome.unsupported] without downloading when the
   /// platform has no apply path. Throws [UpdateInstallException] on failure.
@@ -103,10 +106,20 @@ class UpdateInstaller {
     int? expectedSize,
     void Function(int received, int? total)? onProgress,
     bool Function()? isCancelled,
+    void Function()? onApplying,
   }) async {
     final mode = modeFor(assetName);
     if (mode == UpdateApplyMode.unsupported) {
       return UpdateInstallOutcome.unsupported;
+    }
+
+    // We are about to write (and, for the AppImage, execute) whatever comes
+    // back, so refuse anything but a plain HTTPS URL. GitHub release assets are
+    // always https; a non-https URL means something upstream is wrong.
+    final uri = Uri.tryParse(url);
+    if (uri == null || uri.scheme != 'https') {
+      throw const UpdateInstallException(
+          'Refusing to download an update over an insecure URL');
     }
 
     final bytes = await _download(
@@ -116,6 +129,7 @@ class UpdateInstaller {
       isCancelled: isCancelled,
     );
 
+    onApplying?.call();
     switch (mode) {
       case UpdateApplyMode.inPlaceRelaunch:
         await _applyInPlace(bytes);

--- a/app/lib/update_platform.dart
+++ b/app/lib/update_platform.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+
+/// How an available update can be applied on the running platform.
+enum UpdateApplyMode {
+  /// Replace the running binary on disk and relaunch it. Used for the Linux
+  /// AppImage, which is a single self-contained executable - the one desktop
+  /// packaging where an atomic self-replace is clean and reliable.
+  inPlaceRelaunch,
+
+  /// Download the artifact and hand it to the OS: run the installer
+  /// (`.dmg` / `.exe`) or reveal it so the user completes the update. Used on
+  /// macOS and Windows, where swapping a running app bundle is fragile and the
+  /// bundles are unsigned anyway.
+  openArtifact,
+
+  /// No supported in-app apply path (web, mobile, a Linux tarball install, or
+  /// a release with no direct artifact). Callers fall back to the browser
+  /// download.
+  unsupported,
+}
+
+/// The filesystem and process operations the in-app updater needs, factored
+/// behind an interface so [UpdateInstaller] stays testable (a fake records the
+/// calls) and web-compilable (the real implementation pulls in `dart:io` only
+/// through a conditional import; the web stub reports [UpdateApplyMode
+/// .unsupported]).
+abstract class UpdatePlatformOps {
+  TargetPlatform get platform;
+
+  /// Absolute path of the running AppImage (`$APPIMAGE`), or null when the
+  /// process is not an AppImage - the signal that a clean single-file
+  /// self-replace is possible on Linux.
+  String? get appImagePath;
+
+  /// A user-visible directory for hand-off downloads (the Downloads folder,
+  /// falling back to a temp directory), where the macOS/Windows installer
+  /// artifact is saved before the OS opens it.
+  Future<String> downloadDirectory();
+
+  /// Joins [dir] and [name] with the platform path separator.
+  String joinPath(String dir, String name);
+
+  /// The directory containing [path]. In-place AppImage staging writes here so
+  /// the replace is a same-filesystem (atomic) rename.
+  String parentDirectory(String path);
+
+  /// Writes [bytes] to [path] (overwriting), marking it executable when asked.
+  Future<void> writeArtifact(String path, List<int> bytes,
+      {bool executable = false});
+
+  /// Atomically moves [from] onto [to], replacing it. Both paths must live on
+  /// the same filesystem so the rename is atomic (no half-written binary).
+  Future<void> replaceInPlace({required String from, required String to});
+
+  /// Launches [path] detached and terminates this process so the freshly
+  /// written binary takes over. Never returns.
+  Future<Never> relaunchAndExit(String path);
+
+  /// Opens [path] with the OS default handler (the installer), falling back to
+  /// revealing it in the file manager so the user can run it themselves.
+  Future<void> openArtifact(String path);
+}

--- a/app/lib/update_platform_io.dart
+++ b/app/lib/update_platform_io.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'update_platform.dart';
+
+/// Native (`dart:io`) platform ops for the in-app updater: real filesystem
+/// writes, an atomic rename to swap the running AppImage, and OS hand-off for
+/// the macOS/Windows installer artifacts.
+UpdatePlatformOps defaultUpdatePlatformOps() => IoUpdatePlatformOps();
+
+class IoUpdatePlatformOps implements UpdatePlatformOps {
+  @override
+  TargetPlatform get platform => defaultTargetPlatform;
+
+  @override
+  String? get appImagePath {
+    // AppImage runtimes export $APPIMAGE with the absolute path of the mounted
+    // image file (the thing on disk, not the FUSE mount point). Only trust it
+    // when it points at a real file we could rewrite.
+    final path = Platform.environment['APPIMAGE'];
+    if (path == null || path.isEmpty) return null;
+    return File(path).existsSync() ? path : null;
+  }
+
+  @override
+  Future<String> downloadDirectory() async {
+    try {
+      final downloads = await getDownloadsDirectory();
+      if (downloads != null) return downloads.path;
+    } catch (_) {
+      // Fall through to the system temp directory below.
+    }
+    return Directory.systemTemp.path;
+  }
+
+  @override
+  String joinPath(String dir, String name) {
+    final sep = Platform.pathSeparator;
+    return dir.endsWith(sep) ? '$dir$name' : '$dir$sep$name';
+  }
+
+  @override
+  String parentDirectory(String path) => File(path).parent.path;
+
+  @override
+  Future<void> writeArtifact(String path, List<int> bytes,
+      {bool executable = false}) async {
+    await File(path).writeAsBytes(bytes, flush: true);
+    if (executable && !Platform.isWindows) {
+      // Dart's File API has no chmod; shell out. A failure here surfaces to the
+      // caller, which aborts before swapping the running binary.
+      final result = await Process.run('chmod', ['+x', path]);
+      if (result.exitCode != 0) {
+        throw FileSystemException(
+            'chmod +x failed: ${result.stderr}', path);
+      }
+    }
+  }
+
+  @override
+  Future<void> replaceInPlace(
+      {required String from, required String to}) async {
+    // Same-filesystem rename: atomic, and on Linux it replaces the path even
+    // while the old inode is still mapped by the running process.
+    await File(from).rename(to);
+  }
+
+  @override
+  Future<Never> relaunchAndExit(String path) async {
+    await Process.start(path, const [], mode: ProcessStartMode.detached);
+    exit(0);
+  }
+
+  @override
+  Future<void> openArtifact(String path) async {
+    // Go through url_launcher (NSWorkspace on macOS, ShellExecute on Windows,
+    // xdg-open on Linux) rather than spawning a shell: it is the path that
+    // works under the macOS App Sandbox, where `Process.start('open', …)` is
+    // denied. Opening the file runs the installer (`.dmg` mounts; `.exe`
+    // launches) or opens it with the default handler.
+    final launched =
+        await launchUrl(Uri.file(path), mode: LaunchMode.externalApplication);
+    if (!launched) {
+      throw const FileSystemException('Could not open the downloaded update');
+    }
+  }
+}

--- a/app/lib/update_platform_stub.dart
+++ b/app/lib/update_platform_stub.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/foundation.dart';
+
+import 'update_platform.dart';
+
+/// Web build's platform ops: there is no filesystem to write to and update
+/// checks are disabled on web ([UpdateService.supported] is false), so this is
+/// only a compile-time placeholder. It reports no AppImage and throws if any
+/// filesystem operation is somehow reached.
+UpdatePlatformOps defaultUpdatePlatformOps() => const _StubUpdatePlatformOps();
+
+class _StubUpdatePlatformOps implements UpdatePlatformOps {
+  const _StubUpdatePlatformOps();
+
+  @override
+  TargetPlatform get platform => defaultTargetPlatform;
+
+  @override
+  String? get appImagePath => null;
+
+  Never _unsupported() =>
+      throw UnsupportedError('In-app updates are not available on this build');
+
+  @override
+  Future<String> downloadDirectory() => _unsupported();
+
+  @override
+  String joinPath(String dir, String name) => _unsupported();
+
+  @override
+  String parentDirectory(String path) => _unsupported();
+
+  @override
+  Future<void> writeArtifact(String path, List<int> bytes,
+          {bool executable = false}) =>
+      _unsupported();
+
+  @override
+  Future<void> replaceInPlace({required String from, required String to}) =>
+      _unsupported();
+
+  @override
+  Future<Never> relaunchAndExit(String path) => _unsupported();
+
+  @override
+  Future<void> openArtifact(String path) => _unsupported();
+}

--- a/app/macos/Runner/DebugProfile.entitlements
+++ b/app/macos/Runner/DebugProfile.entitlements
@@ -12,6 +12,8 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
 	<key>com.apple.security.print</key>

--- a/app/macos/Runner/Release.entitlements
+++ b/app/macos/Runner/Release.entitlements
@@ -10,6 +10,8 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
 	<key>com.apple.security.print</key>

--- a/app/test/update_install_flow_test.dart
+++ b/app/test/update_install_flow_test.dart
@@ -1,0 +1,102 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+import 'package:dart_pdf_editor_app/update.dart';
+import 'package:dart_pdf_editor_app/update_installer.dart';
+import 'package:dart_pdf_editor_app/update_platform.dart';
+
+/// Records apply calls without touching disk. macOS hand-off avoids the
+/// AppImage self-replace path (which would call exit(0)).
+class _FakeOps implements UpdatePlatformOps {
+  _FakeOps({required this.platform});
+
+  @override
+  final TargetPlatform platform;
+  @override
+  final String? appImagePath = null;
+
+  String? opened;
+
+  @override
+  Future<String> downloadDirectory() async => '/downloads';
+  @override
+  String joinPath(String dir, String name) => '$dir/$name';
+  @override
+  String parentDirectory(String path) =>
+      path.substring(0, path.lastIndexOf('/'));
+  @override
+  Future<void> writeArtifact(String path, List<int> bytes,
+      {bool executable = false}) async {}
+  @override
+  Future<void> replaceInPlace(
+      {required String from, required String to}) async {}
+  @override
+  Future<Never> relaunchAndExit(String path) async =>
+      throw StateError('relaunch not expected in hand-off test');
+  @override
+  Future<void> openArtifact(String path) async => opened = path;
+}
+
+ReleaseInfo _dmgRelease() => ReleaseInfo(
+      version: const AppVersion(1, 3, 0),
+      tagName: 'app-v1.3.0',
+      name: 'app-v1.3.0',
+      notes: '',
+      htmlUrl: 'https://example.test/app-v1.3.0',
+      assets: const {'dartpdf-macos.dmg': 'https://example.test/dmg'},
+      assetSizes: const {'dartpdf-macos.dmg': 64},
+    );
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+  tearDown(() => prefs.dispose());
+
+  testWidgets('the banner "Update now" downloads and hands off the artifact',
+      (tester) async {
+    final updates = UpdateService(
+      currentVersion: '1.2.0',
+      platform: TargetPlatform.macOS,
+      fetcher: () async => [_dmgRelease()],
+    );
+    addTearDown(updates.dispose);
+
+    final ops = _FakeOps(platform: TargetPlatform.macOS);
+    final bytes = Uint8List.fromList(List.generate(64, (i) => i));
+    final installer = UpdateInstaller(
+      ops: ops,
+      clientFactory: () => MockClient.streaming((request, body) async =>
+          http.StreamedResponse(Stream.value(bytes), 200, contentLength: 64)),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        updateService: updates,
+        updateInstaller: installer,
+        autoCheckUpdates: true,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // The button reads "Update now" because an in-app apply path exists.
+    expect(find.text('Update now'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('update-banner-download')));
+    await tester.pumpAndSettle();
+
+    // Downloaded and handed to the OS installer, with a confirming snackbar.
+    expect(ops.opened, '/downloads/dartpdf-macos.dmg');
+    expect(find.byKey(const ValueKey('update-handed-off')), findsOneWidget);
+  });
+}

--- a/app/test/update_install_flow_test.dart
+++ b/app/test/update_install_flow_test.dart
@@ -99,4 +99,37 @@ void main() {
     expect(ops.opened, '/downloads/dartpdf-macos.dmg');
     expect(find.byKey(const ValueKey('update-handed-off')), findsOneWidget);
   });
+
+  testWidgets('a download failure surfaces a snackbar with a fallback action',
+      (tester) async {
+    final updates = UpdateService(
+      currentVersion: '1.2.0',
+      platform: TargetPlatform.macOS,
+      fetcher: () async => [_dmgRelease()],
+    );
+    addTearDown(updates.dispose);
+
+    // A 404 makes downloadAndApply throw UpdateInstallException, driving the
+    // flow's failure branch (dismiss dialog, show the failed snackbar).
+    final installer = UpdateInstaller(
+      ops: _FakeOps(platform: TargetPlatform.macOS),
+      clientFactory: () => MockClient((_) async => http.Response('no', 404)),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        updateService: updates,
+        updateInstaller: installer,
+        autoCheckUpdates: true,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('update-banner-download')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('update-progress-dialog')), findsNothing);
+    expect(find.byKey(const ValueKey('update-install-failed')), findsOneWidget);
+  });
 }

--- a/app/test/update_installer_test.dart
+++ b/app/test/update_installer_test.dart
@@ -149,15 +149,26 @@ void main() {
       final bytes = _bytes(1024);
       final installer = UpdateInstaller(ops: ops, clientFactory: _okClient(bytes));
 
+      var applyingBeforeWrite = false;
+      var onApplyingCalls = 0;
+
       await expectLater(
         installer.downloadAndApply(
           url: 'https://example.test/appimage',
           assetName: appImageAsset,
           expectedSize: bytes.length,
+          onApplying: () {
+            onApplyingCalls++;
+            // Fires after the download but before anything is written to disk.
+            applyingBeforeWrite = ops.written.isEmpty;
+          },
         ),
         throwsA(isA<_ExitCalled>()),
       );
 
+      // onApplying fired once, right after the verified download.
+      expect(onApplyingCalls, 1);
+      expect(applyingBeforeWrite, isTrue);
       // Staged next to the target (same directory) and marked executable.
       expect(ops.written.keys.single, '/apps/.dartpdf-update.AppImage.part');
       expect(ops.written.values.single, bytes);
@@ -240,10 +251,32 @@ void main() {
       );
 
       await expectLater(
-        installer.downloadAndApply(url: 'u', assetName: dmgAsset),
+        installer.downloadAndApply(url: 'https://example.test/dmg', assetName: dmgAsset),
         throwsA(isA<UpdateInstallException>()),
       );
       expect(ops.opened, isNull);
+    });
+
+    test('refuses a non-https artifact URL before downloading', () async {
+      final ops = _FakeOps(platform: TargetPlatform.macOS);
+      var built = false;
+      final installer = UpdateInstaller(
+        ops: ops,
+        clientFactory: () {
+          built = true;
+          return MockClient((_) async => http.Response('x', 200));
+        },
+      );
+
+      await expectLater(
+        installer.downloadAndApply(
+          url: 'http://example.test/dmg', // not https
+          assetName: dmgAsset,
+        ),
+        throwsA(isA<UpdateInstallException>()),
+      );
+      expect(built, isFalse, reason: 'must reject before any network use');
+      expect(ops.written, isEmpty);
     });
 
     test('a non-200 response fails', () async {
@@ -255,7 +288,7 @@ void main() {
       );
 
       await expectLater(
-        installer.downloadAndApply(url: 'u', assetName: dmgAsset),
+        installer.downloadAndApply(url: 'https://example.test/dmg', assetName: dmgAsset),
         throwsA(isA<UpdateInstallException>()),
       );
     });
@@ -268,7 +301,7 @@ void main() {
 
       await expectLater(
         installer.downloadAndApply(
-          url: 'u',
+          url: 'https://example.test/dmg',
           assetName: dmgAsset,
           isCancelled: () => true,
         ),
@@ -290,7 +323,7 @@ void main() {
       final received = <int>[];
       int? seenTotal;
       await installer.downloadAndApply(
-        url: 'u',
+        url: 'https://example.test/dmg',
         assetName: dmgAsset,
         expectedSize: bytes.length,
         onProgress: (r, t) {

--- a/app/test/update_installer_test.dart
+++ b/app/test/update_installer_test.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:dart_pdf_editor_app/update_installer.dart';
+import 'package:dart_pdf_editor_app/update_platform.dart';
+
+/// A fake [UpdatePlatformOps] that records every call instead of touching the
+/// real disk or spawning processes, so the installer's apply sequence is
+/// asserted deterministically.
+class _FakeOps implements UpdatePlatformOps {
+  _FakeOps({required this.platform, this.appImagePath});
+
+  @override
+  final TargetPlatform platform;
+  @override
+  final String? appImagePath;
+
+  final List<String> log = [];
+  final Map<String, Uint8List> written = {};
+  String? replacedFrom;
+  String? replacedTo;
+  String? relaunched;
+  String? opened;
+
+  @override
+  Future<String> downloadDirectory() async => '/downloads';
+
+  @override
+  String joinPath(String dir, String name) => '$dir/$name';
+
+  @override
+  String parentDirectory(String path) =>
+      path.substring(0, path.lastIndexOf('/'));
+
+  @override
+  Future<void> writeArtifact(String path, List<int> bytes,
+      {bool executable = false}) async {
+    written[path] = Uint8List.fromList(bytes);
+    log.add('write:$path:exec=$executable');
+  }
+
+  @override
+  Future<void> replaceInPlace(
+      {required String from, required String to}) async {
+    replacedFrom = from;
+    replacedTo = to;
+    log.add('replace:$from->$to');
+  }
+
+  @override
+  Future<Never> relaunchAndExit(String path) async {
+    relaunched = path;
+    log.add('relaunch:$path');
+    // The real implementation calls exit(0) here and never returns; the fake
+    // throws a sentinel so callers can observe that a relaunch was requested.
+    throw const _ExitCalled();
+  }
+
+  @override
+  Future<void> openArtifact(String path) async {
+    opened = path;
+    log.add('open:$path');
+  }
+}
+
+class _ExitCalled implements Exception {
+  const _ExitCalled();
+}
+
+/// A client that streams [bytes] back in [chunks] pieces with a 200 status.
+http.Client Function() _okClient(Uint8List bytes, {int chunks = 1, int? len}) {
+  final pieces = <List<int>>[];
+  final step = (bytes.length / chunks).ceil();
+  for (var i = 0; i < bytes.length; i += step) {
+    pieces.add(bytes.sublist(i, (i + step).clamp(0, bytes.length)));
+  }
+  return () => MockClient.streaming((request, bodyStream) async =>
+      http.StreamedResponse(Stream.fromIterable(pieces), 200,
+          contentLength: len ?? bytes.length));
+}
+
+Uint8List _bytes(int n) =>
+    Uint8List.fromList(List.generate(n, (i) => i % 256));
+
+void main() {
+  const appImageAsset = 'dartpdf-linux-x86_64.AppImage';
+  const tarAsset = 'dartpdf-linux-x64.tar.gz';
+  const dmgAsset = 'dartpdf-macos.dmg';
+  const exeAsset = 'dartpdf-windows-installer.exe';
+
+  group('UpdateInstaller.modeFor', () {
+    test('AppImage running as an AppImage self-replaces', () {
+      final installer = UpdateInstaller(
+        ops: _FakeOps(
+            platform: TargetPlatform.linux, appImagePath: '/apps/DartPDF'),
+      );
+      expect(installer.modeFor(appImageAsset), UpdateApplyMode.inPlaceRelaunch);
+    });
+
+    test('AppImage asset but not running as one falls back to unsupported', () {
+      final installer = UpdateInstaller(
+        ops: _FakeOps(platform: TargetPlatform.linux, appImagePath: null),
+      );
+      expect(installer.modeFor(appImageAsset), UpdateApplyMode.unsupported);
+    });
+
+    test('a Linux tarball has no in-place path', () {
+      final installer = UpdateInstaller(
+        ops: _FakeOps(
+            platform: TargetPlatform.linux, appImagePath: '/apps/DartPDF'),
+      );
+      expect(installer.modeFor(tarAsset), UpdateApplyMode.unsupported);
+    });
+
+    test('macOS and Windows hand off to the OS installer', () {
+      expect(
+        UpdateInstaller(ops: _FakeOps(platform: TargetPlatform.macOS))
+            .modeFor(dmgAsset),
+        UpdateApplyMode.openArtifact,
+      );
+      expect(
+        UpdateInstaller(ops: _FakeOps(platform: TargetPlatform.windows))
+            .modeFor(exeAsset),
+        UpdateApplyMode.openArtifact,
+      );
+    });
+
+    test('a missing asset name is unsupported', () {
+      final installer =
+          UpdateInstaller(ops: _FakeOps(platform: TargetPlatform.macOS));
+      expect(installer.modeFor(null), UpdateApplyMode.unsupported);
+      expect(installer.modeFor(''), UpdateApplyMode.unsupported);
+    });
+
+    test('mobile platforms are unsupported', () {
+      final installer =
+          UpdateInstaller(ops: _FakeOps(platform: TargetPlatform.android));
+      expect(installer.modeFor('app-release.apk'), UpdateApplyMode.unsupported);
+    });
+  });
+
+  group('UpdateInstaller.downloadAndApply - AppImage in place', () {
+    test('writes an executable, replaces the running image, and relaunches',
+        () async {
+      final ops = _FakeOps(
+          platform: TargetPlatform.linux, appImagePath: '/apps/DartPDF');
+      final bytes = _bytes(1024);
+      final installer = UpdateInstaller(ops: ops, clientFactory: _okClient(bytes));
+
+      await expectLater(
+        installer.downloadAndApply(
+          url: 'https://example.test/appimage',
+          assetName: appImageAsset,
+          expectedSize: bytes.length,
+        ),
+        throwsA(isA<_ExitCalled>()),
+      );
+
+      // Staged next to the target (same directory) and marked executable.
+      expect(ops.written.keys.single, '/apps/.dartpdf-update.AppImage.part');
+      expect(ops.written.values.single, bytes);
+      expect(ops.log, contains('write:/apps/.dartpdf-update.AppImage.part:'
+          'exec=true'));
+      expect(ops.replacedFrom, '/apps/.dartpdf-update.AppImage.part');
+      expect(ops.replacedTo, '/apps/DartPDF');
+      expect(ops.relaunched, '/apps/DartPDF');
+    });
+  });
+
+  group('UpdateInstaller.downloadAndApply - hand off', () {
+    test('downloads to the download dir and opens it (macOS)', () async {
+      final ops = _FakeOps(platform: TargetPlatform.macOS);
+      final bytes = _bytes(2048);
+      final installer = UpdateInstaller(ops: ops, clientFactory: _okClient(bytes));
+
+      final outcome = await installer.downloadAndApply(
+        url: 'https://example.test/dmg',
+        assetName: dmgAsset,
+        expectedSize: bytes.length,
+      );
+
+      expect(outcome, UpdateInstallOutcome.handedOff);
+      expect(ops.written['/downloads/dartpdf-macos.dmg'], bytes);
+      // Hand-off artifacts are not marked executable.
+      expect(ops.log, contains('write:/downloads/dartpdf-macos.dmg:exec=false'));
+      expect(ops.opened, '/downloads/dartpdf-macos.dmg');
+      expect(ops.relaunched, isNull);
+    });
+  });
+
+  group('UpdateInstaller.downloadAndApply - guards', () {
+    test('returns unsupported without downloading', () async {
+      final ops = _FakeOps(platform: TargetPlatform.linux, appImagePath: null);
+      var built = false;
+      final installer = UpdateInstaller(
+        ops: ops,
+        clientFactory: () {
+          built = true;
+          return MockClient((_) async => http.Response('x', 200));
+        },
+      );
+
+      final outcome = await installer.downloadAndApply(
+        url: 'https://example.test/appimage',
+        assetName: appImageAsset,
+      );
+
+      expect(outcome, UpdateInstallOutcome.unsupported);
+      expect(built, isFalse, reason: 'no download for an unsupported apply');
+      expect(ops.written, isEmpty);
+    });
+
+    test('a size mismatch aborts before writing anything', () async {
+      final ops = _FakeOps(
+          platform: TargetPlatform.linux, appImagePath: '/apps/DartPDF');
+      final bytes = _bytes(500);
+      final installer = UpdateInstaller(ops: ops, clientFactory: _okClient(bytes));
+
+      await expectLater(
+        installer.downloadAndApply(
+          url: 'https://example.test/appimage',
+          assetName: appImageAsset,
+          expectedSize: 999, // wrong
+        ),
+        throwsA(isA<UpdateInstallException>()),
+      );
+      expect(ops.written, isEmpty);
+      expect(ops.replacedTo, isNull);
+      expect(ops.relaunched, isNull);
+    });
+
+    test('an empty download is rejected', () async {
+      final ops = _FakeOps(platform: TargetPlatform.macOS);
+      final installer = UpdateInstaller(
+        ops: ops,
+        clientFactory: () => MockClient.streaming((request, body) async =>
+            http.StreamedResponse(const Stream.empty(), 200, contentLength: 0)),
+      );
+
+      await expectLater(
+        installer.downloadAndApply(url: 'u', assetName: dmgAsset),
+        throwsA(isA<UpdateInstallException>()),
+      );
+      expect(ops.opened, isNull);
+    });
+
+    test('a non-200 response fails', () async {
+      final ops = _FakeOps(platform: TargetPlatform.macOS);
+      final installer = UpdateInstaller(
+        ops: ops,
+        clientFactory: () =>
+            MockClient((_) async => http.Response('nope', 404)),
+      );
+
+      await expectLater(
+        installer.downloadAndApply(url: 'u', assetName: dmgAsset),
+        throwsA(isA<UpdateInstallException>()),
+      );
+    });
+
+    test('cancellation stops the download and applies nothing', () async {
+      final ops = _FakeOps(platform: TargetPlatform.macOS);
+      final bytes = _bytes(1000);
+      final installer =
+          UpdateInstaller(ops: ops, clientFactory: _okClient(bytes, chunks: 4));
+
+      await expectLater(
+        installer.downloadAndApply(
+          url: 'u',
+          assetName: dmgAsset,
+          isCancelled: () => true,
+        ),
+        throwsA(isA<UpdateCancelledException>()),
+      );
+      expect(ops.written, isEmpty);
+      expect(ops.opened, isNull);
+    });
+  });
+
+  group('UpdateInstaller.downloadAndApply - progress', () {
+    test('reports monotonically increasing received bytes up to the total',
+        () async {
+      final ops = _FakeOps(platform: TargetPlatform.macOS);
+      final bytes = _bytes(1000);
+      final installer =
+          UpdateInstaller(ops: ops, clientFactory: _okClient(bytes, chunks: 5));
+
+      final received = <int>[];
+      int? seenTotal;
+      await installer.downloadAndApply(
+        url: 'u',
+        assetName: dmgAsset,
+        expectedSize: bytes.length,
+        onProgress: (r, t) {
+          received.add(r);
+          seenTotal = t;
+        },
+      );
+
+      expect(seenTotal, 1000);
+      expect(received.first, 0);
+      expect(received.last, 1000);
+      for (var i = 1; i < received.length; i++) {
+        expect(received[i], greaterThanOrEqualTo(received[i - 1]));
+      }
+    });
+  });
+}

--- a/app/test/update_platform_io_test.dart
+++ b/app/test/update_platform_io_test.dart
@@ -1,0 +1,76 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/update_platform_io.dart';
+
+/// Exercises the real (dart:io) platform ops against a temp directory. The two
+/// operations that can't be unit-tested — `relaunchAndExit` (calls exit(0)) and
+/// `openArtifact` (spawns the OS handler via url_launcher) — are covered by the
+/// installer's fake-ops tests instead.
+void main() {
+  late Directory tmp;
+
+  setUp(() => tmp = Directory.systemTemp.createTempSync('dartpdf-update-test'));
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  final ops = IoUpdatePlatformOps();
+
+  test('joinPath uses the platform separator and avoids doubling it', () {
+    final sep = Platform.pathSeparator;
+    expect(ops.joinPath('dir', 'file.bin'), 'dir${sep}file.bin');
+    expect(ops.joinPath('dir$sep', 'file.bin'), 'dir${sep}file.bin');
+  });
+
+  test('parentDirectory returns the containing directory', () {
+    final child = ops.joinPath(tmp.path, 'child.bin');
+    expect(ops.parentDirectory(child), tmp.path);
+  });
+
+  test('appImagePath is null when not running as an AppImage', () {
+    // The test runner is not an AppImage, so $APPIMAGE is unset/invalid.
+    expect(ops.appImagePath, isNull);
+  });
+
+  test('downloadDirectory resolves to a real writable directory', () async {
+    final dir = await ops.downloadDirectory();
+    expect(dir, isNotEmpty);
+    expect(Directory(dir).existsSync(), isTrue);
+  });
+
+  test('writeArtifact writes the bytes', () async {
+    final path = ops.joinPath(tmp.path, 'plain.bin');
+    await ops.writeArtifact(path, [1, 2, 3, 4]);
+    expect(File(path).readAsBytesSync(), [1, 2, 3, 4]);
+  });
+
+  test('writeArtifact marks the file executable when asked', () async {
+    final path = ops.joinPath(tmp.path, 'runnable.bin');
+    await ops.writeArtifact(path, [0, 1, 2], executable: true);
+    expect(File(path).readAsBytesSync(), [0, 1, 2]);
+    if (!Platform.isWindows) {
+      // Owner-execute bit (0o100) set by chmod +x.
+      expect(File(path).statSync().mode & 0x40, isNonZero);
+    }
+  }, skip: Platform.isWindows ? 'chmod is a no-op on Windows' : false);
+
+  test('replaceInPlace atomically renames over the target', () async {
+    final target = ops.joinPath(tmp.path, 'target.bin');
+    final staged = ops.joinPath(tmp.path, 'staged.bin');
+    await ops.writeArtifact(target, [9, 9, 9]);
+    await ops.writeArtifact(staged, [1, 2, 3]);
+    await ops.replaceInPlace(from: staged, to: target);
+    expect(File(target).readAsBytesSync(), [1, 2, 3]);
+    expect(File(staged).existsSync(), isFalse);
+  });
+
+  test('reports the host platform', () {
+    expect(ops.platform, defaultTargetPlatform);
+  });
+}

--- a/app/test/update_test.dart
+++ b/app/test/update_test.dart
@@ -124,9 +124,62 @@ void main() {
       expect(release.assets['dartpdf-macos.dmg'], 'https://example.test/dmg');
     });
 
+    test('reads asset byte sizes when present', () {
+      final release = ReleaseInfo.fromJson({
+        'tag_name': 'app-v1.3.0',
+        'assets': [
+          {
+            'name': 'dartpdf-linux-x86_64.AppImage',
+            'browser_download_url': 'https://example.test/appimage',
+            'size': 12345,
+          },
+          {
+            'name': 'nosize.zip',
+            'browser_download_url': 'https://example.test/zip',
+          },
+        ],
+      });
+      expect(release!.assetSizes['dartpdf-linux-x86_64.AppImage'], 12345);
+      // A missing/zero size is simply absent (no false integrity check).
+      expect(release.assetSizes.containsKey('nosize.zip'), isFalse);
+    });
+
     test('returns null for a non-version tag', () {
       expect(ReleaseInfo.fromJson({'tag_name': 'pdf_cos-v1.0.0'}), isNull);
       expect(ReleaseInfo.fromJson(const {}), isNull);
+    });
+  });
+
+  group('UpdateService download asset resolution', () {
+    ReleaseInfo linuxRelease() => ReleaseInfo(
+          version: const AppVersion(1, 3, 0),
+          tagName: 'app-v1.3.0',
+          name: 'app-v1.3.0',
+          notes: '',
+          htmlUrl: 'https://example.test/app-v1.3.0',
+          assets: const {
+            'dartpdf-linux-x86_64.AppImage': 'https://example.test/appimage',
+          },
+          assetSizes: const {'dartpdf-linux-x86_64.AppImage': 999},
+        );
+
+    test('exposes the platform artifact name and size', () async {
+      final service = _service('1.2.0',
+          releases: [linuxRelease()], platform: TargetPlatform.linux);
+      await service.checkForUpdates(force: true);
+      expect(service.downloadAssetName, 'dartpdf-linux-x86_64.AppImage');
+      expect(service.downloadAssetSize, 999);
+      expect(service.downloadUrl, 'https://example.test/appimage');
+    });
+
+    test('a release with no matching artifact has no asset name', () async {
+      // macOS has no asset in this Linux-only release, so only the page URL.
+      final service = _service('1.2.0',
+          releases: [linuxRelease()], platform: TargetPlatform.macOS);
+      await service.checkForUpdates(force: true);
+      expect(service.downloadAssetName, isNull);
+      expect(service.downloadAssetSize, isNull);
+      expect(service.downloadUrl, 'https://example.test/app-v1.3.0');
     });
   });
 

--- a/doc/dev-log/2026-07-23-desktop-in-place-updates.md
+++ b/doc/dev-log/2026-07-23-desktop-in-place-updates.md
@@ -1,0 +1,78 @@
+# 2026-07-23 — Desktop in-place app updates
+
+Branch `claude/desktop-in-place-updates-xhvrb8`. Turn the desktop update
+*checker* into an actual updater: "Update now" downloads the newer release
+in-app and applies it, instead of only opening a browser tab at the release
+download. Deliberately still user-initiated and confirmed — not a silent
+background swap — because the bundles are unsigned (the reasoning the old
+`update.dart` header called out).
+
+## The apply strategy (per platform)
+
+`app/lib/update_installer.dart`'s `UpdateInstaller.modeFor(assetName)` picks
+one of three modes, keyed off the artifact CI produces and how the process is
+running:
+
+- **Linux AppImage → `inPlaceRelaunch`.** An AppImage is a single executable,
+  so the update is clean: download the new image, write it *next to* the
+  running one (same directory, so the replace is a same-filesystem atomic
+  rename — a temp dir is often a different mount and `rename` would `EXDEV`),
+  `chmod +x`, rename over `$APPIMAGE`, then relaunch and `exit(0)`. Only taken
+  when `$APPIMAGE` is set **and** points at a real file (`appImagePath`), so a
+  tarball/`flutter run` install never hits it.
+- **macOS `.dmg` / Windows `.exe` → `openArtifact`.** Swapping a running,
+  unsigned app bundle is fragile, so instead download to the Downloads folder
+  and hand the file to the OS: the `.dmg` mounts (user drags the app over),
+  the installer `.exe` runs. Downloaded, not silently applied.
+- **Everything else → `unsupported`.** Linux tarball, mobile, or a release
+  with no matching artifact (only the page URL): fall back to the old browser
+  download.
+
+## Testability: the `dart:io` seam
+
+All filesystem/process work lives behind `UpdatePlatformOps`
+(`update_platform.dart`, no `dart:io`), with the real implementation in
+`update_platform_io.dart` pulled in through a conditional import
+(`update_platform_stub.dart` on web, where update checks are disabled anyway).
+`UpdateInstaller` takes the ops and an `http.Client` factory injected, so the
+whole download→verify→apply flow is unit-tested with a fake ops (records
+`write`/`replace`/`relaunch`/`open`) and a `MockClient` — no real disk, no
+real network, and crucially no real `exit(0)` (the fake's `relaunchAndExit`
+throws a sentinel the test asserts on). See `test/update_installer_test.dart`
+(mode selection, the AppImage write/replace/relaunch sequence, hand-off,
+size-mismatch/empty/non-200/cancel guards, progress monotonicity).
+
+## Integrity + progress
+
+The download streams through `http.Client.send`, reports `(received, total)`
+for the progress dialog, polls an `isCancelled` closure (dialog Cancel
+button), and — when GitHub reported an asset `size` — rejects a download whose
+byte count doesn't match before anything is written over the install. Sizes
+are new on `ReleaseInfo.assetSizes`, parsed from the release JSON's
+`asset.size`; `UpdateService` exposes `downloadAssetName` / `downloadAssetSize`
+alongside the existing `downloadUrl`.
+
+## UI wiring
+
+`update_install_flow.dart`'s `startUpdateInstall(...)` is shared by the
+Settings → Updates button and the startup banner: it shows a progress dialog,
+runs the installer, and on hand-off toasts a confirmation (the AppImage path
+just relaunches). On `unsupported` or any failure it falls back to
+`launchUrl(downloadUrl)`, so nothing regresses where in-place can't apply. The
+banner button reads "Update now" when an in-app apply path exists, else the
+old "Download". `EditorScreen` and `showAppSettings` gained an injectable
+`updateInstaller` seam mirroring the existing `updateService` one.
+
+## macOS sandbox gotcha
+
+The macOS build is sandboxed. Two things had to change for the hand-off to
+actually work there:
+
+- `openArtifact` goes through `url_launcher` (`NSWorkspace` on macOS,
+  `ShellExecute` on Windows, `xdg-open` on Linux), **not** `Process.start`
+  — spawning `open`/`cmd` is denied under the App Sandbox.
+- Added `com.apple.security.files.downloads.read-write` to both
+  `macos/Runner/*.entitlements` so the download can land in `~/Downloads`.
+
+The AppImage self-replace (Linux, unsandboxed) and the Windows hand-off keep
+using `Process`/relaunch directly.


### PR DESCRIPTION
## Summary

Turns the desktop update **checker** into an actual updater. Previously "Download" only opened a browser tab at the release artifact; now **"Update now"** downloads the newer release in-app (progress dialog + a byte-size integrity check against the release metadata) and applies it — per platform, and still user-initiated (not a silent background swap, since the bundles are unsigned).

`UpdateInstaller.modeFor(assetName)` (`app/lib/update_installer.dart`) picks:

- **Linux AppImage → self-replace + relaunch.** An AppImage is a single executable: download the new image, write it *next to* the running one (same directory, so the replace is a same-filesystem atomic rename — a temp dir is often a different mount and `rename` would `EXDEV`), `chmod +x`, rename over `$APPIMAGE`, then relaunch and `exit(0)`. Only taken when `$APPIMAGE` is set and points at a real file.
- **macOS `.dmg` / Windows `.exe` → download + OS hand-off.** Swapping a running, unsigned bundle is fragile, so download to Downloads and let the OS open it (the `.dmg` mounts, the installer `.exe` runs).
- **Everything else → browser download fallback** (Linux tarball, mobile, or a release with no matching artifact).

Design notes:

- All filesystem/process work sits behind an injectable `UpdatePlatformOps` seam (`update_platform.dart`, no `dart:io`), with the real impl in `update_platform_io.dart` pulled in via conditional import and a web stub — the same web-guarded pattern the app already uses (`pdf_file_source_io`, `native_print_io`, `oidc_signin_io`). This makes the whole download → verify → apply flow unit-testable with a fake ops + `MockClient` (no real disk, network, or `exit(0)`).
- `ReleaseInfo` gained `assetSizes` (from the release JSON `asset.size`); `UpdateService` exposes `downloadAssetName` / `downloadAssetSize` alongside `downloadUrl`.
- Shared UI flow (`update_install_flow.dart`) drives both **Settings → Updates** and the **startup banner**; on `unsupported` or any failure it falls back to `launchUrl(downloadUrl)`, so nothing regresses.
- `openArtifact` goes through `url_launcher` (NSWorkspace / ShellExecute / xdg-open) rather than spawning a shell — `Process.start('open', …)` is denied under the macOS App Sandbox — and the macOS entitlements gain `com.apple.security.files.downloads.read-write`.

## Affected packages

- [x] Example app _(the standalone `app/` — desktop updater, no library changes)_
- [x] Documentation / CI / repository metadata only _(RELEASING.md, dev-log, macOS entitlements)_

## Change type

- [x] Feature

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` _(`fvm dart analyze app` — no issues)_
- [x] `cd packages/dart_pdf_editor && fvm flutter test` _(ran the app's update suites: `update_test.dart`, `update_installer_test.dart`, `update_install_flow_test.dart`, `update_settings_test.dart` — 44 passing)_

If any relevant check was not run, explain why: library-package test suites were not re-run because no `packages/*` code changed — the diff is entirely in the standalone `app/`.

## PDF fixtures and screenshots

None — no rendering or document changes. New tests use programmatic fakes (a recording `UpdatePlatformOps` + `MockClient`).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`. _(Changes are in the standalone `app/`.)_
- [x] No `dart:io` imports in any `lib/` directory. _(No `packages/*/lib` touched. `app/lib/update_platform_io.dart` uses `dart:io` behind a `dart.library.io` conditional import with a web stub — the established `app/lib` pattern.)_
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- The macOS `.dmg` hand-off relies on the App Sandbox additions above; without a `Developer ID` signature the mounted app still gets Gatekeeper-quarantined on first run (unchanged from today's manual download). AppImage self-replace and the Windows hand-off run unsandboxed.
- The download verifies length only (GitHub's basic release JSON carries `size`, not a digest); a mismatch aborts before anything is written over the install.
- Generated `app_localizations_*.dart` are included (gen-l10n) for 7 new strings; non-English locales fall back to English until translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yEnrh8RUYUW4pdJyeVhB1)_