### PR TITLE
perf(editor): paint a bounded command prefix before the full vector record (#527)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -337,6 +337,25 @@ class PdfPageView extends StatefulWidget {
   /// thread turns the returned detail commands into the sharp on-screen patch.
   static bool deferFullRenderUntilDetailPaint = true;
 
+  /// Paints a bounded command *prefix* before the full vector record, so a
+  /// dense sheet shows real ink instead of blank paper while its whole-page
+  /// transcript is still being built.
+  ///
+  /// The worker maps `commandLimit` to the parse cursor's `operationLimit`, so
+  /// a limited record genuinely stops early rather than recording everything
+  /// and trimming. See [_paintEarlyPrefix]; set false to disable.
+  static bool earlyPrefixPaint = true;
+
+  /// Commands in that first bounded record - large enough for the prefix to be
+  /// recognizable, small enough to land in a fraction of a dense page's walk.
+  static int earlyPrefixCommandLimit = 20000;
+
+  /// Only pages whose raw (still-encoded) content exceeds this pay the extra
+  /// record. [PdfPage.rawContentLength] is an O(streams) size proxy that costs
+  /// no decode, so an ordinary few-KB page skips the prefix entirely and is
+  /// never charged a second worker job.
+  static int earlyPrefixMinContentBytes = 512 * 1024;
+
   /// Composite deep-zoom detail from the [PdfTileStore] zoom-bucket pyramid
   /// instead of the single unbudgeted detail patch. When true (and the page
   /// retains a region-cullable scene), the visible slice is tiled: panning at
@@ -1237,6 +1256,89 @@ class _PdfPageViewState extends State<PdfPageView>
   ///
   /// When the page draws no images the fast buffer is the whole page, so it is
   /// cached as [_picture] for the full pass to reuse - no second record.
+  /// Rasterizes a bounded command prefix into the preview slot before the full
+  /// vector record runs.
+  ///
+  /// On a dense sheet the `worker.record` in [_paintVectorFirst] walks the
+  /// whole page, which can take seconds - and until it returns the page is
+  /// blank paper. A `commandLimit`'d record stops the parse cursor early, so
+  /// this lands in a small fraction of that time and puts real ink on screen;
+  /// the vector and full passes replace it as they arrive.
+  ///
+  /// This is deliberately a *painter-order prefix*, not PDFium's spatial
+  /// top-down band: our worker protocol is strictly one-request-one-response,
+  /// so a true streaming band is a much larger change (tracked as #564). On a
+  /// sheet authored in region order the prefix reads naturally; on one authored
+  /// by layer it is a partial drawing. Either way it is strictly more
+  /// information than blank paper, and it is transient.
+  ///
+  /// Only dense pages pay the extra record - see [earlyPrefixMinContentBytes].
+  Future<void> _paintEarlyPrefix(
+    int generation,
+    int pageIndex,
+    PdfRenderWorker worker,
+    int priority,
+  ) async {
+    if (!PdfPageView.earlyPrefixPaint || _renderPaused) return;
+    // Something is already on screen for this page; there is nothing to
+    // improve on, and overwriting it would be a downgrade.
+    if (_image != null || _preview != null || _slugPicture != null) return;
+    if (widget.page.rawContentLength < PdfPageView.earlyPrefixMinContentBytes) return;
+
+    final commands = await worker.record(
+      pageIndex,
+      // The prefix is transient, so keep it pure page content: annotations are
+      // drawn after the (truncated) content walk and the full passes bring
+      // them in anyway.
+      annotations: false,
+      priority: priority,
+      decodeImages: false,
+      commandLimit: PdfPageView.earlyPrefixCommandLimit,
+    );
+    if (commands == null ||
+        commands.isEmpty ||
+        _superseded(generation, pageIndex) ||
+        _renderPaused ||
+        // A full pass may have overtaken us while the prefix was recording.
+        _image != null) {
+      return;
+    }
+
+    final picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
+      widget.page,
+      commands,
+      _renderPlan,
+      includeImages: false,
+    );
+    if (_superseded(generation, pageIndex) || _renderPaused || _image != null) {
+      picture.dispose();
+      return;
+    }
+    // _vectorFirstRatio is already bounded by _previewMaxPixels, so a large
+    // sheet cannot turn this into an expensive fill.
+    final ratio = _vectorFirstRatio();
+    final image = await PdfPageRenderer.rasterize(
+      picture,
+      PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation),
+      ratio,
+    );
+    picture.dispose();
+    if (_superseded(generation, pageIndex) || _image != null) {
+      image.dispose();
+      return;
+    }
+    if (!mounted) {
+      image.dispose();
+      return;
+    }
+    setState(() {
+      _preview?.dispose();
+      _preview = image;
+    });
+    PdfPerfLog.log('early-prefix page=$pageIndex commands=${commands.length} '
+        'limit=${PdfPageView.earlyPrefixCommandLimit}${PdfPerfLog.rssSuffix()}');
+  }
+
   Future<Completer<bool>?> _paintVectorFirst(
       int generation, int pageIndex) async {
     final worker = widget.renderWorker;
@@ -1247,12 +1349,17 @@ class _PdfPageViewState extends State<PdfPageView>
     // the scheduler drains the cache window around it.
     final visibleDetailRequested =
         _detailGeometryAt(widget.scale, force: true, inflation: 0.125) != null;
+    final priority = visibleDetailRequested
+        ? widget.renderPriority - 100
+        : widget.renderPriority;
+    // On a dense sheet the full record below is a multi-second wait on blank
+    // paper; put a bounded prefix on screen first. No-ops on ordinary pages.
+    await _paintEarlyPrefix(generation, pageIndex, worker, priority);
+    if (_superseded(generation, pageIndex) || _renderPaused) return null;
     final commands = await worker.record(
       pageIndex,
       annotations: widget.showAnnotations,
-      priority: visibleDetailRequested
-          ? widget.renderPriority - 100
-          : widget.renderPriority,
+      priority: priority,
       decodeImages: false,
     );
     if (_superseded(generation, pageIndex) ||

--- a/packages/dart_pdf_editor/test/early_prefix_paint_test.dart
+++ b/packages/dart_pdf_editor/test/early_prefix_paint_test.dart
@@ -1,0 +1,180 @@
+// Covers the bounded-prefix early paint (#527 Option A): on a dense sheet the
+// vector-first pass issues a `commandLimit`'d record *before* the full one, so
+// real ink reaches the screen while the whole-page transcript is still being
+// built. The gate matters as much as the win - an ordinary page must never be
+// charged the extra worker job.
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/strips.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart' show PdfRenderCommand;
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+Future<void> _settle(WidgetTester tester, {int rounds = 120}) async {
+  for (var i = 0; i < rounds; i++) {
+    await tester.pump();
+    tester.takeException();
+    await tester
+        .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 5)));
+  }
+}
+
+void main() {
+  late int prevLimit;
+  late int prevMin;
+  late bool prevOn;
+
+  setUp(() {
+    prevLimit = PdfPageView.earlyPrefixCommandLimit;
+    prevMin = PdfPageView.earlyPrefixMinContentBytes;
+    prevOn = PdfPageView.earlyPrefixPaint;
+  });
+  tearDown(() {
+    PdfPageView.earlyPrefixCommandLimit = prevLimit;
+    PdfPageView.earlyPrefixMinContentBytes = prevMin;
+    PdfPageView.earlyPrefixPaint = prevOn;
+  });
+
+  testWidgets('a dense page records a bounded prefix before the full pass',
+      (tester) async {
+    PdfPageView.earlyPrefixPaint = true;
+    PdfPageView.earlyPrefixCommandLimit = 64;
+    PdfPageView.earlyPrefixMinContentBytes = 0; // every page counts as dense
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildSyntheticCadStrip(ops: 2000, streams: 2);
+    final page = PdfDocument.open(bytes).page(0);
+    final worker = _RecordingWorker(PdfRenderWorker.startUncached(bytes));
+    addTearDown(worker.dispose);
+
+    await tester.pumpWidget(Center(
+      child: SizedBox(
+        width: 600,
+        child: PdfPageView(page: page, scale: 1, renderWorker: worker),
+      ),
+    ));
+    await _settle(tester);
+
+    // The prefix must be requested, bounded, and must come first: its whole
+    // purpose is to beat the full walk to the screen.
+    final limits = worker.commandLimits;
+    expect(limits, contains(64),
+        reason: 'no bounded prefix record was issued: $limits');
+    final firstPrefix = limits.indexOf(64);
+    final firstFull = limits.indexOf(null);
+    expect(firstPrefix, greaterThanOrEqualTo(0));
+    if (firstFull >= 0) {
+      expect(firstPrefix, lessThan(firstFull),
+          reason: 'the prefix record must precede the full record: $limits');
+    }
+  });
+
+  testWidgets('an ordinary page is not charged an extra record',
+      (tester) async {
+    PdfPageView.earlyPrefixPaint = true;
+    PdfPageView.earlyPrefixCommandLimit = 64;
+    // The real gate: a page whose raw content is below the threshold must skip
+    // the prefix entirely, so light documents pay nothing for this feature.
+    PdfPageView.earlyPrefixMinContentBytes = 1 << 30;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildSyntheticCadStrip(ops: 2000, streams: 2);
+    final page = PdfDocument.open(bytes).page(0);
+    final worker = _RecordingWorker(PdfRenderWorker.startUncached(bytes));
+    addTearDown(worker.dispose);
+
+    await tester.pumpWidget(Center(
+      child: SizedBox(
+        width: 600,
+        child: PdfPageView(page: page, scale: 1, renderWorker: worker),
+      ),
+    ));
+    await _settle(tester);
+
+    expect(worker.commandLimits.where((l) => l != null), isEmpty,
+        reason: 'a below-threshold page must not issue a bounded record: '
+            '${worker.commandLimits}');
+  });
+}
+
+/// Delegates everything, recording the `commandLimit` of each record call in
+/// order so the test can assert both that the prefix fires and where.
+class _RecordingWorker extends PdfRenderWorker {
+  _RecordingWorker(this._inner);
+
+  final PdfRenderWorker _inner;
+  final commandLimits = <int?>[];
+
+  @override
+  bool get isActive => _inner.isActive;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+      {bool annotations = true,
+      int priority = 0,
+      double? imagePixelRatio,
+      bool decodeImages = true,
+      int? commandLimit,
+      PdfRect? imageDecodeRegion}) {
+    // Only the base record ladder is interesting; deep-zoom detail records
+    // carry a region and would be noise.
+    if (imageDecodeRegion == null) commandLimits.add(commandLimit);
+    return _inner.record(pageIndex,
+        annotations: annotations,
+        priority: priority,
+        imagePixelRatio: imagePixelRatio,
+        decodeImages: decodeImages,
+        commandLimit: commandLimit,
+        imageDecodeRegion: imageDecodeRegion);
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) =>
+      _inner.cancel(pageIndex, priority: priority);
+
+  @override
+  Future<StripPlan?> binStrips(int pageIndex,
+          {required bool annotations,
+          required List<double> pageToDevice,
+          required int deviceWidth,
+          required int deviceHeight,
+          required double pixelRatio,
+          bool slugGlyphs = false,
+          int priority = 0}) =>
+      _inner.binStrips(pageIndex,
+          annotations: annotations,
+          pageToDevice: pageToDevice,
+          deviceWidth: deviceWidth,
+          deviceHeight: deviceHeight,
+          pixelRatio: pixelRatio,
+          slugGlyphs: slugGlyphs,
+          priority: priority);
+
+  @override
+  Future<PdfStripDetail?> recordStripDetail(int pageIndex,
+          {required bool annotations,
+          required List<double> pageToDevice,
+          required int deviceWidth,
+          required int deviceHeight,
+          required double pixelRatio,
+          required PdfRect imageDecodeRegion,
+          int priority = 0}) =>
+      _inner.recordStripDetail(pageIndex,
+          annotations: annotations,
+          pageToDevice: pageToDevice,
+          deviceWidth: deviceWidth,
+          deviceHeight: deviceHeight,
+          pixelRatio: pixelRatio,
+          imageDecodeRegion: imageDecodeRegion,
+          priority: priority);
+
+  @override
+  void cancelBinStrips(int pageIndex, {int priority = 0}) =>
+      _inner.cancelBinStrips(pageIndex, priority: priority);
+
+  @override
+  void dispose() => _inner.dispose();
+}


### PR DESCRIPTION
## What

On a dense sheet the vector-first pass's `worker.record` walks the **whole page** before anything reaches the screen — a multi-second wait on blank paper. This issues a `commandLimit`'d record **first**, rasterizes it into the existing preview slot, and lets the vector and full passes replace it as they arrive.

Part of #520. Addresses #527 (Option A from the [scoping comment](https://github.com/ben-milanko/dart-pdf/issues/527#issuecomment-5064724328)).

## Measured — first ink

Synthetic CAD strip, uncached worker, `record(decodeImages: false)`:

| fixture | full record | bounded prefix (limit 20000) | first ink |
|---|---|---|---|
| 120k ops (2.1 MB raw) | 420 ms | **57 ms** (4501 cmds) | **7.4× sooner** |
| 400k ops (6.9 MB raw) | 923 ms | **97 ms** (4501 cmds) | **9.5× sooner** |

The prefix costs ~10% of the full walk, so the *complete* page lands ~10% later. That's the expected trade for progressive rendering — and it's only paid on pages that would otherwise have been blank for most of a second.

(Note `commandLimit` maps to *operations*, so 20000 ops yields 4501 commands.)

## Why it's safe

- The worker already maps `commandLimit` → the parse cursor's `operationLimit` (`render_worker_isolate.dart` `_recordPageAsync`), so a bounded record **genuinely stops early** rather than recording everything and trimming.
- `PdfCachingRenderWorker` already keys its cache on the limit, so bounded and full records coexist without poisoning each other.
- A truncated prefix is **replay-safe**: `serializeCommands` takes the prefix *before* q/Q compaction, so unbalanced prefixes keep their unmatched state commands.
- Delivered into `_preview`, the existing "before the first render lands" slot — already view-owned and already cleared when `_image` arrives. Every await is followed by a `_superseded`/`_image != null` guard, so a full pass that overtakes the prefix is never downgraded.

## Only dense pages pay

The gate is `PdfPage.rawContentLength` — an O(streams) size proxy that costs **no decode** (it exists precisely so callers can gate work without paying one). An ordinary few-KB page issues no extra record at all. Tunables: `PdfPageView.earlyPrefixPaint` / `earlyPrefixCommandLimit` (20000) / `earlyPrefixMinContentBytes` (512 KB).

## Scope note

This is deliberately a **painter-order prefix**, not PDFium's spatial top-down band. The worker protocol is strictly one-request-one-response, so true streaming is a much larger change — filed as **#564**, to be built together with #530 (same resumable-cursor primitive). On a sheet authored in region order the prefix reads naturally; on one authored by layer it's a partial drawing. Either way it is strictly more information than blank paper, and transient.

## Tests

- New `early_prefix_paint_test.dart`: the prefix is issued, is bounded, and **precedes** the full record on a dense page; a below-threshold page issues **no** bounded record (the gate is the point).
- Full `dart_pdf_editor` suite: 1906 passed, the only failures the 20 pre-existing `ghent_render_test` baselines (#550 — CMYK overprint/softmask/ICC, unrelated and identical on main). Root `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)