### PR TITLE
fix(worker): make the late-cancel regression test deterministic (#559)

### DIFF
--- a/doc/dev-log/2026-07-24-flaky-late-cancel-559.md
+++ b/doc/dev-log/2026-07-24-flaky-late-cancel-559.md
@@ -1,0 +1,104 @@
+# 2026-07-24 — killing the flaky late-cancel test (#559)
+
+`render_worker_strips_test` › *"a late cancel id cannot abort the next worker
+request"* failed intermittently (Expected 1, Actual 0), reddening unrelated PRs
+and forcing CI reruns. This session made it deterministic by deleting the
+wall-clock guess at its heart.
+
+## What it guards
+
+Issue #220: a request-scoped cancel can reach the worker *after* its target
+already replied and the next (often urgent) page has taken the slot. The worker
+must recognise that stale id and ignore it — comparing against `activeRequestId`
+and emitting `cancelIgnored` — rather than aborting the innocent next page. The
+test drives exactly that ordering and asserts the ignore fired once.
+
+## Why it flaked
+
+To *stage* the late arrival, the old test hook lived on the **main** isolate.
+`_cancelRequest` stashed the cancel id instead of sending it, and after the
+cancelled page replied and the next page was dispatched,
+`_deliverDeferredCancelToNextRequest` sent it — behind a fixed
+`Timer(5 ms)`:
+
+```dart
+Timer(const Duration(milliseconds: 5), () {
+  if (!_disposed) _toCancelPort?.send(id);
+});
+```
+
+The 5 ms was a bet that within that window the worker would dequeue the next
+request's message and set `activeRequestId` to the new id. On an unloaded box it
+always won; on a loaded CI runner the worker sometimes hadn't picked the message
+off its `requests` port yet, so when the cancel landed `activeRequestId` was
+*still the old id* — the branch matched, no `cancelIgnored` was sent, and the
+counter stayed 0. A cross-isolate race decided by wall-clock time: flaky by
+construction.
+
+## The fix — move the defer onto the worker's own event loop
+
+The staging now happens **inside the worker**, where message ordering is a hard
+guarantee rather than a timing bet. Under the (unchanged) test flag, the
+worker's cancel listener, on a cancel that targets the *currently active*
+request, stashes it instead of acting:
+
+```dart
+cancelPort.listen((message) {
+  if (message is! int) return;
+  if (deferStaleCancel &&
+      deferredStaleCancelId == null &&
+      message == activeRequestId) {
+    deferredStaleCancelId = message;   // hold it
+    return;
+  }
+  handleCancel(message);
+});
+```
+
+and replays it the instant the **next** request goes active — right after
+`activeRequestId` is reassigned in the request handler:
+
+```dart
+activeRequestId = id;
+final staleId = deferredStaleCancelId;
+if (staleId != null) {
+  deferredStaleCancelId = null;
+  handleCancel(staleId);   // targets the previous id → reported ignored
+}
+```
+
+Everything that used to race across two isolates now happens as consecutive
+steps on one event loop. The flag rides in via `_WorkerInit.deferStaleCancel`,
+read once at spawn — so the test sets the global **before** `startUncached`
+(the spawn reads globals synchronously as it runs). The whole main-side
+apparatus — `_deferredCancelId`, the defer branch in `_cancelRequest`,
+`_deliverDeferredCancelToNextRequest`, and the `Timer` — is gone; `_cancelRequest`
+is now just `_toCancelPort?.send(request.id)`.
+
+## Why it is now order-independent
+
+The cancel for page 0 and page 0's own request reach the worker on two
+different ports, so their relative processing order is not guaranteed. Both
+interleavings now yield the same result:
+
+- **request-then-cancel** (the intended path): page 0 active → cancel stashed →
+  page 0 finishes → page 1 active → replay → `page0 != page1` → ignored once.
+- **cancel-then-request**: `activeRequestId` is still the warm-up id, so the
+  cancel isn't stashed (it doesn't target the active id) and is reported ignored
+  immediately — still exactly once.
+
+Either way page 0 is never actually cancelled (its token is only ever touched
+when it is *not* the active request), so it completes in full, and
+`cancelIgnored` fires exactly once. The assertions hold on every interleaving.
+
+## Scope
+
+Native isolate only. The web twin (`render_worker_web_entry.dart`) has its own
+`activeRequestId`/`cancelIgnored` handling but never carried this defer hook and
+is not exercised by this VM-only test, so it is untouched.
+
+## Verified
+
+`fvm dart analyze` clean; the full `render_worker_strips_test.dart` (15 tests)
+green across repeated back-to-back runs where the old hook was the sole source of
+intermittent red.

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -16,9 +16,15 @@ import 'render_worker.dart';
 import 'render_worker_transcript_cache.dart'
     show compactTranscriptSourceCommands, retainedCommandGraphsWeight;
 
-/// Test hook: hold a requested cancellation until the cancelled job answers
-/// and the next queued request is dispatched. That deterministically recreates
-/// the late-signal race request-scoped cancellation must reject.
+/// Test hook: inside the worker isolate, hold a cancel that targets the
+/// currently-active request and replay it only once the *next* request has
+/// gone active. That deterministically recreates the late-signal race
+/// request-scoped cancellation must reject (issue #220) - all ordering happens
+/// on the worker's single event loop, so there is no wall-clock guess.
+///
+/// Read once, at spawn, into [_WorkerInit.deferStaleCancel] - so a test must
+/// set this true BEFORE constructing the worker (the spawn reads globals
+/// synchronously). Setting it has no effect on an already-spawned worker.
 bool debugDeferPdfRenderWorkerCancelUntilNextRequest = false;
 
 /// Number of stale request-scoped cancel messages ignored by native workers.
@@ -82,7 +88,6 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   int _seq = 0;
   bool _disposed = false;
   bool _spawnFailed = false;
-  int? _deferredCancelId;
 
   @override
   bool get isActive => !_disposed && !_spawnFailed;
@@ -177,12 +182,12 @@ class _IsolateRenderWorker extends PdfRenderWorker {
                 data.materialize().asUint8List(),
             ]);
       _pump();
-      _deliverDeferredCancelToNextRequest();
     });
     final isolate = await Isolate.spawn(
       _workerMain,
       _WorkerInit(_fromWorker.sendPort, TransferableTypedData.fromList([bytes]),
-          perfEnabled: PdfPerfLog.enabled),
+          perfEnabled: PdfPerfLog.enabled,
+          deferStaleCancel: debugDeferPdfRenderWorkerCancelUntilNextRequest),
       debugName: 'pdf-render-worker',
       errorsAreFatal: false,
     );
@@ -474,26 +479,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
   }
 
   void _cancelRequest(_PendingRequest request) {
-    if (debugDeferPdfRenderWorkerCancelUntilNextRequest) {
-      _deferredCancelId = request.id;
-      return;
-    }
     _toCancelPort?.send(request.id);
-  }
-
-  void _deliverDeferredCancelToNextRequest() {
-    final id = _deferredCancelId;
-    if (!debugDeferPdfRenderWorkerCancelUntilNextRequest ||
-        id == null ||
-        _inFlight == null) {
-      return;
-    }
-    _deferredCancelId = null;
-    // Give the worker event loop time to enter the just-dispatched request;
-    // this branch exists only for the deterministic late-delivery test hook.
-    Timer(const Duration(milliseconds: 5), () {
-      if (!_disposed) _toCancelPort?.send(id);
-    });
   }
 
   @override
@@ -669,7 +655,8 @@ class _PendingRequest {
 }
 
 class _WorkerInit {
-  _WorkerInit(this.reply, this.bytes, {this.perfEnabled = false});
+  _WorkerInit(this.reply, this.bytes,
+      {this.perfEnabled = false, this.deferStaleCancel = false});
 
   /// The port the worker sends its own command port (and every response) on.
   final SendPort reply;
@@ -679,6 +666,11 @@ class _WorkerInit {
 
   /// Switch on the worker isolate's own (isolate-local) PdfPerf facade.
   final bool perfEnabled;
+
+  /// Test hook (see [debugDeferPdfRenderWorkerCancelUntilNextRequest]): hold a
+  /// cancel that targets the active request and replay it once the next request
+  /// goes active, recreating issue #220's late-arrival ordering deterministically.
+  final bool deferStaleCancel;
 }
 
 /// Isolate entrypoint: open the document once, then serve record and bin
@@ -713,15 +705,35 @@ void _workerMain(_WorkerInit init) {
 
   PdfCancellationToken? activeToken;
   int? activeRequestId;
-  cancelPort.listen((message) {
-    // A cancel can arrive after its target already replied and the next job
-    // became active. Ignore that stale id instead of aborting the next (often
-    // urgent) page. This is the native half of issue #220.
-    if (message is int && message == activeRequestId) {
+
+  // Act on a cancel id: abort it if it targets the request currently holding
+  // the slot, otherwise report it ignored (issue #220 - a signal that arrived
+  // after its target replied must not abort the next, often urgent, page).
+  void handleCancel(int id) {
+    if (id == activeRequestId) {
       activeToken?.cancelled = true;
-    } else if (message is int) {
-      init.reply.send(['cancelIgnored', message, activeRequestId]);
+    } else {
+      init.reply.send(['cancelIgnored', id, activeRequestId]);
     }
+  }
+
+  // Test hook (see [debugDeferPdfRenderWorkerCancelUntilNextRequest]): when set,
+  // a cancel that targets the *active* request is stashed rather than acted on,
+  // then replayed the instant the next request goes active (below). That stages
+  // a stale cancel landing while a different request owns the slot, with all
+  // ordering on this one event loop - no cross-isolate wall-clock race.
+  final deferStaleCancel = init.deferStaleCancel;
+  int? deferredStaleCancelId;
+
+  cancelPort.listen((message) {
+    if (message is! int) return;
+    if (deferStaleCancel &&
+        deferredStaleCancelId == null &&
+        message == activeRequestId) {
+      deferredStaleCancelId = message;
+      return;
+    }
+    handleCancel(message);
   });
 
   requests.listen((message) async {
@@ -783,6 +795,14 @@ void _workerMain(_WorkerInit init) {
     final token = PdfCancellationToken();
     activeToken = token;
     activeRequestId = id;
+    // A different request now owns the slot: replay any cancel the defer test
+    // hook withheld. It targets the previous id, so handleCancel reports it
+    // ignored - the #220 path, reached deterministically.
+    final staleId = deferredStaleCancelId;
+    if (staleId != null) {
+      deferredStaleCancelId = null;
+      handleCancel(staleId);
+    }
     Uint8List? buffer;
     Uint8List? detailPlanBuffer;
     // Snapshot the (reassignable) document so an 'update' arriving between

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -437,16 +437,19 @@ void main() {
       (tester) async {
     await tester.runAsync(() async {
       final bytes = _buildTwoPageDenseVectorPdf();
-      final worker = PdfRenderWorker.startUncached(bytes);
-      addTearDown(worker.dispose);
+      // Enable the defer hook BEFORE spawning: the worker reads the global into
+      // its init synchronously as it starts, so a later assignment is too late.
       isolate_worker.debugDeferPdfRenderWorkerCancelUntilNextRequest = true;
-      isolate_worker.debugPdfRenderWorkerIgnoredStaleCancels = 0;
       addTearDown(() => isolate_worker
           .debugDeferPdfRenderWorkerCancelUntilNextRequest = false);
+      isolate_worker.debugPdfRenderWorkerIgnoredStaleCancels = 0;
+      final worker = PdfRenderWorker.startUncached(bytes);
+      addTearDown(worker.dispose);
 
       // Warm the handshake, then let page 1 request preemption while page 0
-      // is already running. The test hook withholds page 0's cancel until its
-      // response has dispatched page 1, recreating the old cross-request race.
+      // is already running. The worker withholds page 0's cancel until page 1
+      // goes active, then replays it - recreating the old cross-request race
+      // deterministically, on the worker's own event loop.
       expect(await worker.record(1), isNotNull);
       final first = worker.record(0, priority: 10);
       final next = worker.record(1, priority: 0);


### PR DESCRIPTION
## The flake

`render_worker_strips_test` › *"a late cancel id cannot abort the next worker request"* failed intermittently on CI (Expected `1`, Actual `0`), reddening unrelated PRs (#553 among them) and forcing reruns. Frequency this session: ~50% of runs.

## Root cause

The test guards #220 — a request-scoped cancel that reaches the worker *after* its target replied and the next page took the slot must be recognised as stale and ignored, not abort the innocent page. To **stage** that ordering, the old hook lived on the **main** isolate and released the withheld cancel behind a fixed `Timer(5 ms)`:

```dart
Timer(const Duration(milliseconds: 5), () {
  if (!_disposed) _toCancelPort?.send(id);
});
```

The 5 ms bet that the worker would dequeue the next request (setting `activeRequestId` to the new id) first. On a loaded runner it sometimes hadn't, so when the cancel landed `activeRequestId` was still the old id → the branch matched → no `cancelIgnored` → counter stayed `0`. A cross-isolate race decided by wall-clock time.

## Fix — move the defer onto the worker's own event loop

Staging now happens **inside the worker**, where message ordering is a hard guarantee. Under the (unchanged) test flag, the worker holds a cancel that targets the *active* request and replays it the instant the **next** request goes active — right after `activeRequestId` is reassigned. All the ordering that used to race across two isolates is now consecutive steps on one event loop.

The whole main-side apparatus — `_deferredCancelId`, the `_cancelRequest` defer branch, `_deliverDeferredCancelToNextRequest`, and the `Timer` — is **deleted**; `_cancelRequest` is now just `_toCancelPort?.send(request.id)`. The flag rides in via `_WorkerInit.deferStaleCancel`, read once at spawn, so the test sets it **before** `startUncached`.

## Why it's now order-independent

The cancel and page 0's own request reach the worker on two different ports, so their relative order isn't guaranteed. Both interleavings now converge:

- **request-then-cancel**: page 0 active → cancel stashed → page 0 finishes → page 1 active → replay → `page0 != page1` → ignored once.
- **cancel-then-request**: `activeRequestId` is still the warm-up id → cancel isn't stashed → reported ignored immediately — still exactly once.

Either way page 0 is never actually cancelled and completes in full, and `cancelIgnored` fires exactly once.

## Scope

Native isolate only. The web twin (`render_worker_web_entry.dart`) has its own `activeRequestId`/`cancelIgnored` handling but never carried this defer hook and isn't exercised by this VM-only test — untouched.

## Verified

- `fvm dart analyze` — clean.
- Full `render_worker_strips_test.dart` (15 tests) — green **8/8** back-to-back (the old hook was the sole intermittent-red source).
- Worker + scheduler suite (`render_worker`, `render_worker_revision`, `render_scheduler`, `render_hold`, `region_replay_index_worker` — 75 tests) — green.

Closes #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho