### PR TITLE
perf(app): defer bundled editor fonts off cold start

### DIFF
--- a/doc/dev-log/2026-07-24-lazy-bundled-font-registration.md
+++ b/doc/dev-log/2026-07-24-lazy-bundled-font-registration.md
@@ -1,0 +1,52 @@
+# 2026-07-24 — Lazy bundled-font registration (cold-start trim)
+
+## Why
+
+Prompted by a Reddit note on Flutter cold-start wins. Of its three tips, two
+don't apply here — the app has no BaaS clients to defer, and everything
+non-critical at startup is already `unawaited`/deferred (app metadata, update
+check, platform-font discovery, session restore, and the render-worker
+prewarm that deliberately overlaps the user picking a file; the whole editor
+is a deferred loading unit). The third — "asset preloading is a trap: the
+font cache locks while it parses declared fonts" — did land.
+
+`dart_pdf_editor_assets` declared all six editor fonts (~2.55 MB of TTF) in
+its pubspec `fonts:` block. Anything in that block goes into
+`FontManifest.json`, and under **CanvasKit web** (a first-class target here)
+the engine fetches and parses every manifest font at startup, before the
+first frame. The only Flutter-side consumer of those families is the
+font-menu preview (`editing_fonts.dart`, `_FontEntry.fontFamily`), which most
+sessions never open. Font *embedding* on pick and composite-text fallback
+(`loadFallbackFonts`) read raw bytes via `loadBundledFont`, not the engine
+family, so they never needed the declaration.
+
+## The catch that shaped the change
+
+One face can't be deferred: `CanvasPdfDevice._defaultFontFallbacks`
+(`canvas_device.dart:1071`) names `packages/dart_pdf_editor_assets/DejaVu Sans`
+as a `fontFamilyFallback` for Arabic/Hebrew/Greek/Cyrillic in arbitrary PDFs,
+and that family is registered *by the pubspec declaration*. Deleting the whole
+block would have produced tofu on real non-Latin PDFs — and the tests would
+have stayed green, because `flutter_test_config.dart` registers DejaVu
+manually. A trap. Only `DejaVu Sans` appears in any render fallback list;
+the other five are preview-only.
+
+## What changed
+
+- `packages/dart_pdf_editor_assets/pubspec.yaml`: keep **only `DejaVu Sans`**
+  in `fonts:`; drop DejaVu Serif, DejaVu Sans Mono, Fira Sans, Spectral,
+  Lobster (~1.85 MB, ~72% of the payload). All six stay under `assets:`.
+- `editing_fonts.dart`: new `_ensureBundledFontPreview` mirrors the existing
+  `_ensureDocumentFontPreview` — lazily `FontLoader`-registers a bundled
+  face under its label on first font-menu open, cached per session.
+  `showPdfFontMenu` registers bundled previews in the same `Future.wait` as
+  the document fonts; the bundled `_FontEntry` now previews with that
+  lazily-registered family. Removed the now-dead `_FontEntry.package` field
+  (the pubspec `package:` qualification was its only source).
+- New test: `a bundled font row previews in its own lazily-registered face`.
+
+## Net
+
+~1.85 MB of font fetch/parse moves off cold start to first font-menu open
+(one-time, off the hot path). DejaVu Sans render fallback unchanged. No engine
+fork. Measure the web cold-start delta with `tool/perf.sh webdiff`.

--- a/doc/dev-log/2026-07-24-lazy-bundled-font-registration.md
+++ b/doc/dev-log/2026-07-24-lazy-bundled-font-registration.md
@@ -45,6 +45,20 @@ the other five are preview-only.
   (the pubspec `package:` qualification was its only source).
 - New test: `a bundled font row previews in its own lazily-registered face`.
 
+## Follow-up: don't block the dialog on registration
+
+First cut registered the bundled previews inside the `await Future.wait([...])`
+that runs *before* `showDialog` — so the first click on the font button
+stalled while ~1.85 MB parsed, then the menu popped open with everything at
+once. Moved registration into `_PdfFontPickerDialogState.initState`, fired but
+never awaited: the dialog opens immediately, already-registered faces preview
+synchronously (instant re-open), and first-time faces `setState` their row
+into their own face as each `FontLoader.load()` completes. `_FontEntry` gained
+a `bundledFont` reference so the dialog knows which rows to register and can
+map results back (recents included). Regression guard: `the menu opens without
+waiting on bundled font registration` asserts the dialog is present after a
+single frame.
+
 ## Net
 
 ~1.85 MB of font fetch/parse moves off cold start to first font-menu open

--- a/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
@@ -330,6 +330,7 @@ class _FontEntry {
     required this.choice,
     this.subtitle,
     this.fontFamily,
+    this.bundledFont,
     this.recentKey,
     this.section,
     this.limited = false,
@@ -340,7 +341,16 @@ class _FontEntry {
   final String? subtitle;
   final String searchText;
   final _FontChoice choice;
+
+  /// The engine font-family name to preview this row in, if one is registered.
+  /// For bundled fonts this fills in lazily once [bundledFont] registers (see
+  /// [_PdfFontPickerDialogState]); null previews in the default UI face.
   final String? fontFamily;
+
+  /// The bundled face this row offers, when it is one. The picker dialog
+  /// registers it with the engine on open (off the cold-start path) to preview
+  /// the row in its own face; null for every non-bundled row.
+  final PdfBundledFont? bundledFont;
 
   /// Whether this is a document subset font that can't cover the basic Latin
   /// alphabet, so typing new text in it would drop unavailable characters -
@@ -375,6 +385,43 @@ class _PdfFontPickerDialog extends StatefulWidget {
 class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
   late final TextEditingController _search = TextEditingController()
     ..addListener(() => setState(() {}));
+
+  /// Bundled preview families resolved for this open, keyed by font label.
+  /// Seeded synchronously from the cache and filled in as each lazy
+  /// registration completes, so the dialog appears immediately and each
+  /// bundled row swaps into its own face without ever blocking the open.
+  final Map<String, String> _bundledPreview = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _registerBundledPreviews();
+  }
+
+  /// Registers the bundled faces this menu offers with the engine so their
+  /// rows can preview in their own face. Already-registered faces resolve
+  /// synchronously (an instant re-open); the rest register in the background
+  /// and [setState] their row when ready. Never awaited by [showPdfFontMenu],
+  /// which is what keeps the ~1.85 MB of bundled parsing off the click that
+  /// opens the dialog (and off cold start).
+  void _registerBundledPreviews() {
+    final fonts = <String, PdfBundledFont>{};
+    for (final entry in [...widget.entries, ...widget.recent]) {
+      final font = entry.bundledFont;
+      if (font != null) fonts[font.label] = font;
+    }
+    for (final font in fonts.values) {
+      if (_bundledPreviewFamilies.contains(font.label)) {
+        _bundledPreview[font.label] = font.label; // already registered
+        continue;
+      }
+      _ensureBundledFontPreview(font).then((family) {
+        if (family != null && mounted) {
+          setState(() => _bundledPreview[font.label] = family);
+        }
+      });
+    }
+  }
 
   @override
   void dispose() {
@@ -448,6 +495,12 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
                           final row = rows[index];
                           if (row is String) return _sectionHeader(context, row);
                           final entry = row as _FontEntry;
+                          // Bundled rows preview in the family the dialog
+                          // registered on open (once ready); everything else
+                          // uses the family resolved when the entry was built.
+                          final previewFamily = entry.bundledFont != null
+                              ? _bundledPreview[entry.bundledFont!.label]
+                              : entry.fontFamily;
                           return ListTile(
                             key: entry.key,
                             dense: true,
@@ -455,7 +508,7 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
                               entry.label,
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(
-                                fontFamily: entry.fontFamily,
+                                fontFamily: previewFamily,
                               ),
                             ),
                             subtitle: entry.subtitle == null
@@ -537,21 +590,12 @@ Future<void> showPdfFontMenu({
   // characters the file already used, so flag it "limited".
   final limited = [for (final f in inDocument) !f.canRender(_typeableProbe)];
   final previewFamilies = <int, String>{};
-  // Bundled faces (except DejaVu Sans) are no longer declared in the assets
-  // package's pubspec `fonts:` block, so register them with the engine here -
-  // lazily, on menu open - to preview each row in its own face. This keeps
-  // their parse cost off cold start (see [_ensureBundledFontPreview]).
-  final bundledPreviewFamilies = <int, String>{};
   await Future.wait([
     for (var i = 0; i < inDocument.length; i++)
       if (inDocument[i].canRender(inDocument[i].displayName))
         _ensureDocumentFontPreview(inDocument[i]).then((family) {
           if (family != null) previewFamilies[i] = family;
         }),
-    for (var i = 0; i < bundledFonts.length; i++)
-      _ensureBundledFontPreview(bundledFonts[i]).then((family) {
-        if (family != null) bundledPreviewFamilies[i] = family;
-      }),
   ]);
   if (!context.mounted) return;
 
@@ -611,7 +655,13 @@ Future<void> showPdfFontMenu({
         subtitle: pdfL10n(context).propBundledFont,
         searchText: '${bundledFonts[i].label} bundled font'.toLowerCase(),
         choice: _BundledChoice(bundledFonts[i]),
-        fontFamily: bundledPreviewFamilies[i],
+        // Seed the preview face from the cache so a re-open is instant; a
+        // first open shows the default face and the dialog swaps it in as the
+        // lazy registration completes (see [_PdfFontPickerDialogState]).
+        fontFamily: _bundledPreviewFamilies.contains(bundledFonts[i].label)
+            ? bundledFonts[i].label
+            : null,
+        bundledFont: bundledFonts[i],
         recentKey: 'bundled:${bundledFonts[i].label}',
         section: pdfL10n(context).propSectionAllFonts,
       ),
@@ -657,6 +707,7 @@ Future<void> showPdfFontMenu({
       searchText: match.searchText,
       choice: match.choice,
       fontFamily: match.fontFamily,
+      bundledFont: match.bundledFont,
       recentKey: match.recentKey,
       section: match.section,
       limited: match.limited,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_fonts.dart
@@ -290,6 +290,38 @@ Future<String?> _ensureDocumentFontPreview(PdfEmbeddedFont font) async {
   }
 }
 
+/// Bundled font labels already registered with the engine for menu previews
+/// (see [_ensureBundledFontPreview]), so each registers once per session.
+final Set<String> _bundledPreviewFamilies = <String>{};
+
+/// Registers a bundled font's program bytes with the engine under its own
+/// label so its menu row previews in that face, returning the family name
+/// (null when the bytes can't load or the engine can't register them, e.g. a
+/// headless test - the row then previews in the default UI face and the font
+/// still embeds fine on pick).
+///
+/// The bundled faces used to be declared in `dart_pdf_editor_assets`'s pubspec
+/// `fonts:` block, which registered every one of them at startup (a real
+/// fetch-and-parse before the first frame under CanvasKit web) for previews
+/// most sessions never open. Registering here, on first font-menu open, keeps
+/// that cost off cold start. DejaVu Sans stays pubspec-declared - the renderer
+/// names it as a script fallback and needs it from the first paint - and
+/// re-registering it under its bare label here is harmless.
+Future<String?> _ensureBundledFontPreview(PdfBundledFont font) async {
+  final family = font.label;
+  if (_bundledPreviewFamilies.contains(family)) return family;
+  try {
+    final bytes = await loadBundledFont(font);
+    await (FontLoader(family)
+          ..addFont(Future.value(ByteData.sublistView(bytes))))
+        .load();
+    _bundledPreviewFamilies.add(family);
+    return family;
+  } catch (_) {
+    return null; // preview only - the font still embeds fine on pick
+  }
+}
+
 class _FontEntry {
   const _FontEntry({
     required this.key,
@@ -298,7 +330,6 @@ class _FontEntry {
     required this.choice,
     this.subtitle,
     this.fontFamily,
-    this.package,
     this.recentKey,
     this.section,
     this.limited = false,
@@ -310,7 +341,6 @@ class _FontEntry {
   final String searchText;
   final _FontChoice choice;
   final String? fontFamily;
-  final String? package;
 
   /// Whether this is a document subset font that can't cover the basic Latin
   /// alphabet, so typing new text in it would drop unavailable characters -
@@ -426,7 +456,6 @@ class _PdfFontPickerDialogState extends State<_PdfFontPickerDialog> {
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(
                                 fontFamily: entry.fontFamily,
-                                package: entry.package,
                               ),
                             ),
                             subtitle: entry.subtitle == null
@@ -508,12 +537,21 @@ Future<void> showPdfFontMenu({
   // characters the file already used, so flag it "limited".
   final limited = [for (final f in inDocument) !f.canRender(_typeableProbe)];
   final previewFamilies = <int, String>{};
+  // Bundled faces (except DejaVu Sans) are no longer declared in the assets
+  // package's pubspec `fonts:` block, so register them with the engine here -
+  // lazily, on menu open - to preview each row in its own face. This keeps
+  // their parse cost off cold start (see [_ensureBundledFontPreview]).
+  final bundledPreviewFamilies = <int, String>{};
   await Future.wait([
     for (var i = 0; i < inDocument.length; i++)
       if (inDocument[i].canRender(inDocument[i].displayName))
         _ensureDocumentFontPreview(inDocument[i]).then((family) {
           if (family != null) previewFamilies[i] = family;
         }),
+    for (var i = 0; i < bundledFonts.length; i++)
+      _ensureBundledFontPreview(bundledFonts[i]).then((family) {
+        if (family != null) bundledPreviewFamilies[i] = family;
+      }),
   ]);
   if (!context.mounted) return;
 
@@ -573,8 +611,7 @@ Future<void> showPdfFontMenu({
         subtitle: pdfL10n(context).propBundledFont,
         searchText: '${bundledFonts[i].label} bundled font'.toLowerCase(),
         choice: _BundledChoice(bundledFonts[i]),
-        fontFamily: bundledFonts[i].label,
-        package: bundledFonts[i].package,
+        fontFamily: bundledPreviewFamilies[i],
         recentKey: 'bundled:${bundledFonts[i].label}',
         section: pdfL10n(context).propSectionAllFonts,
       ),
@@ -620,7 +657,6 @@ Future<void> showPdfFontMenu({
       searchText: match.searchText,
       choice: match.choice,
       fontFamily: match.fontFamily,
-      package: match.package,
       recentKey: match.recentKey,
       section: match.section,
       limited: match.limited,

--- a/packages/dart_pdf_editor/test/editing_fonts_test.dart
+++ b/packages/dart_pdf_editor/test/editing_fonts_test.dart
@@ -344,6 +344,27 @@ void main() {
       expect(title.style?.fontFamily, startsWith('pdf-doc-font::'));
     });
 
+    testWidgets('a bundled font row previews in its own lazily-registered face',
+        (tester) async {
+      // The bundled faces (except DejaVu Sans) are no longer declared in the
+      // assets package's pubspec `fonts:` block; the menu registers them with
+      // the engine on open and previews each row in its own label. Spectral is
+      // the fifth bundled entry.
+      final c = PdfEditingController(buildMultiPagePdf(1));
+      await pumpButton(tester, c);
+      await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
+      await tester.pumpAndSettle();
+      // Filter to the single Spectral row so the lazy list builds it on screen.
+      await tester.enterText(
+          find.byKey(const ValueKey('pdf-font-search')), 'spectral');
+      await tester.pumpAndSettle();
+      final title = tester.widget<Text>(find.descendant(
+        of: find.byKey(const ValueKey('pdf-font-bundled-4')),
+        matching: find.text('Spectral'),
+      ));
+      expect(title.style?.fontFamily, 'Spectral');
+    });
+
     testWidgets('a picked font shows up under "Recently used" next time',
         (tester) async {
       final c = PdfEditingController(buildMultiPagePdf(1));

--- a/packages/dart_pdf_editor/test/editing_fonts_test.dart
+++ b/packages/dart_pdf_editor/test/editing_fonts_test.dart
@@ -365,6 +365,22 @@ void main() {
       expect(title.style?.fontFamily, 'Spectral');
     });
 
+    testWidgets('the menu opens without waiting on bundled font registration',
+        (tester) async {
+      // Regression guard: bundled previews register in the dialog's initState
+      // and are never awaited before the dialog is shown, so the menu appears
+      // immediately (previously the ~1.85 MB parse blocked the opening click).
+      // The bundled rows are present up front; their own-face previews fill in
+      // afterwards.
+      final c = PdfEditingController(buildMultiPagePdf(1));
+      await pumpButton(tester, c);
+      await tester.tap(find.byKey(const ValueKey('pdf-font-menu')));
+      await tester.pump(); // one frame: enough for the dialog to appear
+      expect(find.byKey(const ValueKey('pdf-font-search')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-font-bundled-0')), findsOneWidget);
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('a picked font shows up under "Recently used" next time',
         (tester) async {
       final c = PdfEditingController(buildMultiPagePdf(1));

--- a/packages/dart_pdf_editor_assets/pubspec.yaml
+++ b/packages/dart_pdf_editor_assets/pubspec.yaml
@@ -42,22 +42,18 @@ flutter:
     - assets/fonts/FiraSans-Regular.ttf
     - assets/fonts/Spectral-Regular.ttf
     - assets/fonts/Lobster-Regular.ttf
+  # Only DejaVu Sans is declared as an engine font family here, because the
+  # renderer names it as a script fallback (`CanvasPdfDevice`'s
+  # `_defaultFontFallbacks` - Arabic/Hebrew/Greek/Cyrillic in arbitrary PDFs)
+  # and needs it registered from the first paint. Declaring a family puts it in
+  # FontManifest.json, which CanvasKit fetches and parses at web startup before
+  # the first frame - so the other five faces, used only to preview their own
+  # menu rows, are deliberately NOT declared here. They stay listed under
+  # `assets:` above (loaded as raw bytes for embedding, and for composite-text
+  # fallback) and are registered lazily with the engine the first time the font
+  # menu opens (`_ensureBundledFontPreview` in editing_fonts.dart), keeping
+  # ~1.85 MB of font parsing off cold start.
   fonts:
     - family: DejaVu Sans
       fonts:
         - asset: assets/fonts/DejaVuSans.ttf
-    - family: DejaVu Serif
-      fonts:
-        - asset: assets/fonts/DejaVuSerif.ttf
-    - family: DejaVu Sans Mono
-      fonts:
-        - asset: assets/fonts/DejaVuSansMono.ttf
-    - family: Fira Sans
-      fonts:
-        - asset: assets/fonts/FiraSans-Regular.ttf
-    - family: Spectral
-      fonts:
-        - asset: assets/fonts/Spectral-Regular.ttf
-    - family: Lobster
-      fonts:
-        - asset: assets/fonts/Lobster-Regular.ttf


### PR DESCRIPTION
## Summary

The optional `dart_pdf_editor_assets` package declared all six editor fonts (~2.55 MB of TTF) in its pubspec `fonts:` block. Anything declared there lands in `FontManifest.json`, and under **CanvasKit web** (a first-class target here) the engine fetches and parses every manifest font at startup, before the first frame — the "asset-preload trap." The only Flutter-side consumer of those families is the font-menu preview (`_FontEntry.fontFamily`), which most sessions never open. Font *embedding* on pick and composite-text fallback (`loadFallbackFonts`) read raw bytes via `loadBundledFont`, not the engine family, so they never needed the declaration.

One face can't be deferred: `CanvasPdfDevice._defaultFontFallbacks` names `packages/dart_pdf_editor_assets/DejaVu Sans` as a script `fontFamilyFallback` (Arabic/Hebrew/Greek/Cyrillic in arbitrary PDFs), and that family is registered *by the pubspec declaration*. Only DejaVu Sans appears in any render fallback list; the other five are preview-only.

**Change:** keep only `DejaVu Sans` declared in `fonts:`; drop the other five families (DejaVu Serif, DejaVu Sans Mono, Fira Sans, Spectral, Lobster — ~1.85 MB, ~72% of the payload) and register them lazily with the engine via `FontLoader` on first font-menu open, mirroring the existing document-font preview path (`_ensureDocumentFontPreview`). All six fonts remain under `assets:` for byte loading and fallback embedding. Removes the now-dead `_FontEntry.package` field.

This moves ~1.85 MB of font fetch/parse off cold start to first font-menu open (one-time, off the hot path). This win is at CanvasKit's `FontManifest.json` init, *before* Dart `main()` — so the in-app scenario harness (`tool/perf.sh webdiff`, which runs after startup) can't observe it; the verifiable signal is the manifest shrinking from 6 font families to 1.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only <!-- dart_pdf_editor_assets pubspec + dev-log -->

## Change type

- [x] Performance change
- [x] Refactor / cleanup <!-- removed dead _FontEntry.package field -->

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (full root — no issues)
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [x] Ghent corpus test

If any relevant check was not run, explain why:

The full `dart_pdf_editor` suite passes except the 20 `ghent_render_test.dart` pixel-diffs, which are the known macOS-baseline comparisons that always fail on a local Linux run (`CI != 'true'`); they are unrelated to this change (Ghent render tests never open the font menu, and the test package doesn't consume the assets pubspec — `flutter_test_config.dart` registers DejaVu manually). Re-running Ghent with `CI=true` (real-CI mode, baseline diff skipped) is fully green. `pdf_cos`/`pdf_document`/`pdf_graphics` tests were not run — those packages are untouched.

## Notes for reviewers

- DejaVu Sans render fallback behavior is unchanged; deleting the *whole* `fonts:` block would have caused tofu on real non-Latin PDFs while tests stayed green (a trap) — hence keeping the one render-critical face declared.
- First font-menu open now pays a one-time ~1.85 MB parse (previews register lazily, cached per session), same tradeoff already accepted for document-font previews.
- Design rationale in `doc/dev-log/2026-07-24-lazy-bundled-font-registration.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019i4eg2ANQ86aPUHh5nFrjH)_