### PR TITLE
Render digital signature boxes in the signer's local timezone

### DIFF
--- a/app/lib/digital_signature.dart
+++ b/app/lib/digital_signature.dart
@@ -17,12 +17,16 @@ import 'signature_raster.dart';
 const double _signatureLogoOpacity = 0.2;
 
 /// The Acrobat-style signing date the signed box renders, so the preview
-/// matches it: `2026.07.18 05:40:17 +00'00'`, in UTC.
+/// matches it: `2026.07.18 15:40:17 +10'00'`. The signer's local offset is
+/// preserved (mirroring `_displaySignDate` in signature_editor.dart); a UTC
+/// input renders `+00'00'`.
 String _acrobatSignDate(DateTime time) {
-  final utc = time.toUtc();
   String two(int v) => v.toString().padLeft(2, '0');
-  return '${utc.year}.${two(utc.month)}.${two(utc.day)} '
-      "${two(utc.hour)}:${two(utc.minute)}:${two(utc.second)} +00'00'";
+  final off = time.timeZoneOffset;
+  final sign = off.isNegative ? '-' : '+';
+  return '${time.year}.${two(time.month)}.${two(time.day)} '
+      '${two(time.hour)}:${two(time.minute)}:${two(time.second)} '
+      "$sign${two(off.abs().inHours)}'${two(off.abs().inMinutes % 60)}'";
 }
 
 // `label` is the localized file-dialog filter name; the caller resolves it.

--- a/doc/dev-log/2026-07-24-local-timezone-signature-boxes.md
+++ b/doc/dev-log/2026-07-24-local-timezone-signature-boxes.md
@@ -1,0 +1,49 @@
+# Local timezone for digital signature boxes
+
+## Problem
+
+The visible signature box (and the `/M` signing-date entry) rendered the
+signing time in UTC, so a signer in Melbourne saw `05:40:17 +00'00'`
+instead of their wall-clock `15:40:17 +10'00'`. The Acrobat-style date the
+box draws preserves whatever offset the `DateTime` carries
+(`_displaySignDate` / `_pdfDate` in `signature_editor.dart`), but the entry
+points forced the time to UTC before handing it to the appearance builder.
+
+`saveSignedExternal` already did the right thing - keep the signer's own
+offset for the box + `/M`, encode the CMS `signingTime` attribute in UTC (as
+RFC 5652 requires; `derUtcTime` normalises to UTC internally anyway). The
+other paths didn't.
+
+## Change
+
+- `PdfEditor.saveSigned` and `saveSignedEcdsa`
+  (`packages/pdf_document/lib/src/signature_editor.dart`): stop calling
+  `.toUtc()` on the display time; pass the local `time` to the appearance /
+  `/M`, and `time.toUtc()` to the CMS. `saveSelfSigned` flows through
+  `saveSignedEcdsa`, so one-tap self-signed signing picks this up too.
+- `PdfEditor._saveSignedPades`
+  (`packages/pdf_document/lib/src/pades_editor.dart`): same split - local
+  time for the box, `time.toUtc()` for `cmsSignedAttributes`. Covers B-B
+  through B-LTA and the keyless (Fulcio) B-T path.
+- App live preview `_acrobatSignDate` (`app/lib/digital_signature.dart`):
+  was hard-coded to UTC and documented as "matching" the signed box - now
+  mirrors `_displaySignDate`, preserving the local offset so the preview and
+  the rendered box agree.
+
+The editor controller methods (`addSelfSignedSignature`,
+`addKeylessSignature`, `addDigitalSignature`) already default `signingTime`
+to `null` → `DateTime.now()` (local), so the fix reaches the UI without any
+call-site change.
+
+## Notes
+
+- The CMS `signingTime` signed attribute is still UTC everywhere - only the
+  human-facing box and `/M` gained the local offset. `PdfSignature.signingTime`
+  (parsed back from the CMS) therefore stays UTC.
+- A UTC `DateTime` input still renders `+00'00'`, so tests that sign with
+  `DateTime.utc(...)` are unaffected.
+- New coverage: `signature_test.dart` "the box shows the signing time in the
+  local offset, not UTC" signs with a local `DateTime` and asserts the box,
+  the `/M` entry, and the UTC-normalised CMS `signingTime`. The existing
+  `external_signing_test.dart` already pinned the offset-preserving behaviour
+  for the external path.

--- a/packages/pdf_document/lib/src/pades_editor.dart
+++ b/packages/pdf_document/lib/src/pades_editor.dart
@@ -164,7 +164,9 @@ extension PdfPadesSigning on PdfEditor {
       throw ArgumentError(
           'PAdES ${level.name} requires a timestampClient for the timestamp');
     }
-    final time = (signingTime ?? DateTime.now()).toUtc();
+    // Keep the signer's own offset for the visible box and the /M date; the
+    // CMS signingTime attribute is always UTC.
+    final time = signingTime ?? DateTime.now();
     final signerCert = X509Certificate.parse(certificates.first);
     final signerChain = [for (final c in certificates) X509Certificate.parse(c)];
 
@@ -185,7 +187,7 @@ extension PdfPadesSigning on PdfEditor {
     );
     final signedAttrs = cmsSignedAttributes(
       contentDigest: revision.digestSha256(),
-      signingTime: time,
+      signingTime: time.toUtc(),
       essCertificate: signerCert,
     );
     final signature =

--- a/packages/pdf_document/lib/src/signature_editor.dart
+++ b/packages/pdf_document/lib/src/signature_editor.dart
@@ -151,7 +151,9 @@ extension PdfSigning on PdfEditor {
     if (certificates.isEmpty) {
       throw ArgumentError('the signer certificate is required');
     }
-    final time = (signingTime ?? DateTime.now()).toUtc();
+    // Keep the signer's own offset for the visible box and the /M date (see
+    // saveSignedExternal); the CMS signingTime attribute is always UTC.
+    final time = signingTime ?? DateTime.now();
     final revision = _emitSignatureRevision(
       subFilter: 'adbe.pkcs7.detached',
       capacity: _cmsCapacity(certificates),
@@ -168,7 +170,7 @@ extension PdfSigning on PdfEditor {
       contentDigest: revision.digestSha256(),
       privateKey: privateKey,
       certificates: certificates,
-      signingTime: time,
+      signingTime: time.toUtc(),
     );
     _writeContents(revision, cms);
     return revision.saved;
@@ -239,7 +241,9 @@ extension PdfSigning on PdfEditor {
     if (certificates.isEmpty) {
       throw ArgumentError('the signer certificate is required');
     }
-    final time = (signingTime ?? DateTime.now()).toUtc();
+    // Keep the signer's own offset for the visible box and the /M date (see
+    // saveSignedExternal); the CMS signingTime attribute is always UTC.
+    final time = signingTime ?? DateTime.now();
     final revision = _emitSignatureRevision(
       subFilter: 'adbe.pkcs7.detached',
       capacity: _cmsCapacity(certificates),
@@ -256,7 +260,7 @@ extension PdfSigning on PdfEditor {
       contentDigest: revision.digestSha256(),
       privateKey: privateKey,
       certificates: certificates,
-      signingTime: time,
+      signingTime: time.toUtc(),
     );
     _writeContents(revision, cms);
     return revision.saved;

--- a/packages/pdf_document/test/signature_test.dart
+++ b/packages/pdf_document/test/signature_test.dart
@@ -211,6 +211,43 @@ void main() {
       expect(shown, isNot(contains('Location:')));
     });
 
+    test('the box shows the signing time in the local offset, not UTC', () {
+      // A local (non-UTC) signingTime keeps its own offset in the visible box
+      // and the /M date; the CMS signingTime attribute is still UTC.
+      final localTime = DateTime(2026, 6, 10, 12, 0, 0); // terminal's local zone
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
+      final signed = editor.saveSigned(
+        privateKey: key,
+        certificates: [cert],
+        signingTime: localTime,
+        appearance: const PdfSignatureAppearance(
+          rect: PdfRect(72, 600, 320, 700),
+        ),
+      );
+      final doc = PdfDocument.open(signed);
+      final signature = PdfSignature.of(doc).single;
+      expect(signature.validate().intact, isTrue);
+
+      String two(int v) => v.toString().padLeft(2, '0');
+      final off = localTime.timeZoneOffset;
+      final sign = off.isNegative ? '-' : '+';
+      final offset =
+          "$sign${two(off.abs().inHours)}'${two(off.abs().inMinutes % 60)}'";
+      final shown = shownText(appearanceContent(doc, signature.field)!);
+      expect(shown, contains('Date: 2026.06.10 12:00:00 $offset'));
+
+      // the /M entry carries the same local offset, not a UTC Z
+      final text = String.fromCharCodes(signed);
+      if (off == Duration.zero) {
+        expect(text, contains('D:20260610120000Z'));
+      } else {
+        expect(text, contains('D:20260610120000$offset'));
+      }
+
+      // the CMS signingTime attribute normalises to the equivalent UTC instant
+      expect(signature.signingTime, localTime.toUtc());
+    });
+
     test('a graphic renders in the left panel as an image XObject', () {
       final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(1)));
       final signed = editor.saveSigned(


### PR DESCRIPTION
## Summary

The visible signature box and the `/M` signing-date entry rendered the signing time in UTC, so a signer in (e.g.) Melbourne saw `05:40:17 +00'00'` instead of their wall-clock `15:40:17 +10'00'`.

The Acrobat-style date the box draws already preserves whatever offset the `DateTime` carries (`_displaySignDate` / `_pdfDate` in `signature_editor.dart`) — but the entry points forced the time to UTC before handing it to the appearance builder. `saveSignedExternal` already did the right thing (local offset for the box + `/M`, UTC for the CMS attribute); the other paths didn't. This PR makes them consistent:

- **`PdfEditor.saveSigned` / `saveSignedEcdsa`** — pass the local `time` to the appearance and `/M`, and `time.toUtc()` to the CMS. `saveSelfSigned` routes through `saveSignedEcdsa`, so one-tap self-signed signing is covered.
- **`PdfEditor._saveSignedPades`** — same split (local for the box, `time.toUtc()` for `cmsSignedAttributes`), covering B-B → B-LTA and the keyless (Fulcio) B-T path.
- **App live preview `_acrobatSignDate`** — was hard-coded to UTC and documented as "matching" the signed box; now mirrors `_displaySignDate` so the preview and the rendered box agree.

The CMS `signingTime` signed attribute stays UTC everywhere (RFC 5652; `derUtcTime` normalises internally regardless), so `PdfSignature.signingTime` parsed back out is still UTC. A UTC `DateTime` input still renders `+00'00'`. The editor controller methods already default `signingTime` to `null` → `DateTime.now()` (local), so the fix reaches the UI with no call-site change.

## Affected packages

- [x] `pdf_document`
- [x] `dart_pdf_editor` (example app: `app/lib/digital_signature.dart` preview)
- [x] Documentation / CI / repository metadata only (dev-log)

## Change type

- [x] Bug fix

## Validation

- [x] `fvm dart analyze` (changed sources — no issues)
- [x] `cd packages/pdf_document && fvm dart test` (signature / ec_signing / pades / fulcio / external_signing suites pass)

Flutter widget tests for the example app were not run in this environment; the app change is a display-string formatter with no behavioral branch.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Parsers remain lenient on input and writers strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

New coverage in `signature_test.dart` ("the box shows the signing time in the local offset, not UTC") signs with a local `DateTime` and asserts the box text, the `/M` entry, and the UTC-normalised CMS `signingTime`. The behavior is timezone-portable: it derives the expected offset from the test host's zone, and a UTC host still asserts the `Z`/`+00'00'` form. Existing UTC-based signing tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012izDZDFgpZuFDCyZzqqkHV

---
_Generated by [Claude Code](https://claude.ai/code/session_012izDZDFgpZuFDCyZzqqkHV)_