### PR TITLE
ci(worker): harden web-worker auto-regen — concurrency, re-triggering push, loop guard (#422)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, deploy]
   pull_request:
 
+# Cancel superseded PR runs so two quick pushes can't leave two `worker-bundle`
+# jobs racing to push the regenerated bundle (issue #422, defect 1). Keyed by PR
+# number on pull_request and by commit SHA otherwise, so every push to main/deploy
+# gets its own group and is never cancelled - each landed commit keeps its record.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -153,6 +161,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # A dedicated token (PAT or GitHub App) so the auto-regen commit
+          # RE-TRIGGERS CI - a default GITHUB_TOKEN push does not, which left PR
+          # heads with zero checks (issue #422, defect 3). If this secret is
+          # absent the script does NOT push (a bare, unchecked head is worse than
+          # a visible failure); it fails with the exact rebuild command instead.
+          REGEN_TOKEN: ${{ secrets.WORKER_REGEN_TOKEN }}
         run: bash tool/ci/regen_web_worker.sh
 
   # Build the Linux desktop target and validate its desktop-integration files.

--- a/doc/dev-log/2026-07-24-ci-worker-regen-hardening-422.md
+++ b/doc/dev-log/2026-07-24-ci-worker-regen-hardening-422.md
@@ -1,0 +1,73 @@
+# CI web-worker auto-regen: concurrency, re-triggering push, loop guard (#422)
+
+The bundled web render worker (`packages/dart_pdf_editor_assets/assets/web/
+pdf_render_worker.dart.js`) is a `dart compile js` output that links most of the
+stack, so almost any change to pdf_cos/pdf_document/pdf_graphics/dart_pdf_editor
+makes it stale. CI regenerates and pushes it back instead of failing (#411/#412).
+That mechanism had three defects that hit 4 of 9 PRs in one session; all three
+are addressed here.
+
+## Defect 1 — no concurrency group → double push
+
+Two pushes in quick succession left two `worker-bundle` jobs running at once;
+both rebuilt and both pushed, producing bot commits five seconds apart.
+
+Fix: a top-level `concurrency` group in `ci.yml`, keyed by PR number on
+`pull_request` and by `github.sha` otherwise, with `cancel-in-progress` **only**
+for pull requests. Superseded PR runs are cancelled before they can race to
+push; every landed main/deploy commit keeps its own run and record.
+
+## Defect 3 — a GITHUB_TOKEN push leaves the head unchecked (the merge-blocker)
+
+A push made with the default `GITHUB_TOKEN` does not re-trigger workflows (the
+GitHub anti-loop rule). So the bot's follow-up commit became the PR head with
+**zero checks** — `gh pr checks` reported "no checks reported on the branch",
+`mergeable` still read `MERGEABLE`, and a rollup that only counts *failures*
+saw it as clean. That is a merge-of-unverified-code hazard, not just friction,
+and the only known remedy was closing and reopening the PR.
+
+Fix: push with a dedicated token (`secrets.WORKER_REGEN_TOKEN`, a PAT or GitHub
+App token) so the regen commit **does** re-trigger CI. The script is idempotent
+— the re-triggered run finds the bundle fresh and no-ops — so this cannot loop
+on its own. **If the secret is absent the script does not push at all**; it
+fails with the exact `dart run dart_pdf_editor:build_web_worker` command. A
+visible, actionable failure is strictly safer than a silently unchecked head,
+so we never fall back to the bare-headed GITHUB_TOKEN push.
+
+### Required setup (one-time, by a maintainer)
+
+Auto-regen stays *disabled* (verify-and-fail) until the secret exists:
+
+- Create a token that can push to this repo and trigger Actions — a fine-grained
+  PAT with `contents: write` on the repo, or (preferred) a GitHub App installation
+  token. A classic PAT with `repo` scope also works.
+- Add it as the repo/org Actions secret **`WORKER_REGEN_TOKEN`**.
+
+Until then, worker-affecting PRs fail with the rebuild command instead of being
+auto-fixed — the pre-existing behavior for forks, now the default everywhere.
+
+## Defect 2 — cross-run drift / ping-pong, and the loop guard
+
+The within-run reproducibility check (build twice, require byte-match) only
+proves determinism *within one runner in one run*. Across runs the output was
+observed to differ by 3 bytes (976190 vs 976193), so a re-triggering token could
+in principle push A→B→A forever. The comment on that check is corrected to say
+what it actually proves.
+
+Loop guard: before committing, if the current head is already an auto-regen bot
+commit (`%s` equals the fixed regen subject **and** the author is
+`github-actions[bot]`) and the bundle is *still* stale, we refuse the second
+consecutive bot push and fail loudly — that is genuine cross-run drift to
+investigate, not something to paper over. A new human push resets the head to a
+non-bot commit and re-arms exactly one auto-regen. Net: at most one bot commit
+per human push, and the head always ends with real checks (a green no-op run, or
+a visible failure) — never a silent bare head.
+
+## Not done here
+
+The underlying 3-byte nondeterminism is bounded, not root-caused. If it recurs
+after the token lands (visible now as the loud loop-guard failure rather than a
+silent ping-pong), the real fix is pinning whatever `dart compile js` output
+varies on — runner image, environment, or embedded paths.
+
+Files: `.github/workflows/ci.yml`, `tool/ci/regen_web_worker.sh`.

--- a/tool/ci/regen_web_worker.sh
+++ b/tool/ci/regen_web_worker.sh
@@ -10,8 +10,10 @@
 # should never happen is a human having to remember to rebuild it.
 #
 # On a same-repo pull request this rebuilds the bundle and, if it changed,
-# commits it to the PR head branch and pushes. On forks and push events (where
-# a push back is not available) it falls back to the old verify-and-fail.
+# commits it to the PR head branch and pushes - but only when a re-triggering
+# token (REGEN_TOKEN) is configured, so the pushed head gets its own CI run
+# (issue #422, defect 3). Without that token, and on forks / push events, it
+# falls back to the old verify-and-fail rather than leaving an unchecked head.
 #
 # The build runs against the checked-out tree. On a `pull_request` event
 # `actions/checkout` checks out the merge ref (the PR head merged with the base
@@ -20,10 +22,12 @@
 # produce a bundle that goes stale again the moment it merges.
 #
 # Env (set by the workflow):
-#   ASSET        path to the checked-in bundle (required)
-#   EVENT_NAME   github.event_name
-#   IS_SAME_REPO "true" when the PR head repo is this repo (not a fork)
-#   HEAD_REF     github.event.pull_request.head.ref (the PR branch)
+#   ASSET             path to the checked-in bundle (required)
+#   EVENT_NAME        github.event_name
+#   IS_SAME_REPO      "true" when the PR head repo is this repo (not a fork)
+#   HEAD_REF          github.event.pull_request.head.ref (the PR branch)
+#   REGEN_TOKEN       optional PAT/App token whose push re-triggers CI (#422)
+#   GITHUB_REPOSITORY owner/repo, used to build the authenticated push URL
 set -euo pipefail
 
 ASSET="${ASSET:?ASSET must point at the checked-in bundle}"
@@ -41,9 +45,11 @@ build() {
 echo "==> Building the web render worker from the checked-out (merged) source"
 build "$TMP1"
 
-# Reproducibility: a second build must byte-match the first, confirming the
-# output is not machine-dependent (stable across macOS arm64 and CI Linux x64
-# on the pinned SDK). This caught a real problem on #410.
+# Reproducibility: a second build must byte-match the first. This proves the
+# output is stable WITHIN a single runner in a single run (it caught a real
+# machine-dependent build on #410) - it does NOT prove determinism ACROSS runs
+# or runners (issue #422, defect 2). The loop guard below bounds any residual
+# cross-run drift to a single bot commit per human push.
 echo "==> Rebuilding to confirm the output is reproducible"
 build "$TMP2"
 if ! cmp -s "$TMP1" "$TMP2"; then
@@ -58,47 +64,77 @@ fi
 
 echo "==> Bundled web render worker is stale (source changed since last build)."
 
-# Only a same-repo pull request can push the regenerated bundle back. The
-# default GITHUB_TOKEN is read-only for fork PRs, and we do not auto-commit to
-# main on push events.
-if [ "${EVENT_NAME:-}" = "pull_request" ] && [ "${IS_SAME_REPO:-}" = "true" ]; then
-  : "${HEAD_REF:?HEAD_REF must be set for a same-repo pull request}"
-  echo "==> Regenerating on PR branch '$HEAD_REF' and pushing"
+# The actionable failure used whenever we cannot (or must not) auto-push.
+fail_stale() {
+  echo "::error::Bundled web render worker is stale. Rebuild it with"
+  echo "::error::  dart run dart_pdf_editor:build_web_worker --out $ASSET"
+  echo "::error::and commit the result. $*"
+  exit 1
+}
 
-  # Move onto the real head branch (the build ran on the detached merge ref) so
-  # the commit lands on the PR branch. `-f` discards the merge-ref working tree
-  # and anything `flutter pub get` touched (e.g. pubspec.lock).
-  git fetch origin "$HEAD_REF"
-  git checkout -f -B "$HEAD_REF" "origin/$HEAD_REF"
+# Auto-push is only possible on a same-repo pull request (forks get a read-only
+# GITHUB_TOKEN; we never auto-commit to main on push events).
+if [ "${EVENT_NAME:-}" != "pull_request" ] || [ "${IS_SAME_REPO:-}" != "true" ]; then
+  fail_stale "(forks and push events cannot be auto-regenerated.)"
+fi
 
-  # Overlay the merged-source build onto the head branch. Committing it to head
-  # alone is correct: it is byte-identical to what the tree produces once the PR
-  # merges, so it will not re-stale on merge.
-  cp "$TMP1" "$ASSET"
+# Without a re-triggering token, a GITHUB_TOKEN push would land a bot commit
+# that CI never runs against - a silently unchecked PR head (#422, defect 3).
+# A visible failure the author can fix is strictly safer, so refuse to push.
+if [ -z "${REGEN_TOKEN:-}" ]; then
+  fail_stale "(set the WORKER_REGEN_TOKEN secret to let CI regenerate it automatically.)"
+fi
 
-  if git diff --quiet -- "$ASSET"; then
-    echo "==> Head branch copy already matches the merged-source build; nothing to commit."
-    exit 0
-  fi
+: "${HEAD_REF:?HEAD_REF must be set for a same-repo pull request}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set to push}"
+echo "==> Regenerating on PR branch '$HEAD_REF' and pushing"
 
-  git config user.name "github-actions[bot]"
-  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-  git add "$ASSET"
-  # A push made with the default GITHUB_TOKEN does NOT re-trigger workflows, so
-  # this cannot loop. The follow-up commit therefore carries no CI run of its
-  # own; the reproducible build in this run is the evidence it is correct. Swap
-  # in a PAT/App token if you want the follow-up commit to re-run checks (this
-  # script is idempotent - it no-ops once the bundle is fresh, so that is safe).
-  git commit -m "chore(editor): rebuild the bundled web render worker
+# Move onto the real head branch (the build ran on the detached merge ref) so
+# the commit lands on the PR branch. `-f` discards the merge-ref working tree
+# and anything `flutter pub get` touched (e.g. pubspec.lock).
+git fetch origin "$HEAD_REF"
+git checkout -f -B "$HEAD_REF" "origin/$HEAD_REF"
 
-Regenerated by CI because a source change left the bundle stale. A textual
-merge of two dart2js outputs is meaningless, so CI owns the regeneration.
-See issue #411."
-  git push origin "HEAD:$HEAD_REF"
-  echo "::notice::Regenerated and pushed the bundled web render worker to $HEAD_REF."
+# Overlay the merged-source build onto the head branch. Committing it to head
+# alone is correct: it is byte-identical to what the tree produces once the PR
+# merges, so it will not re-stale on merge.
+cp "$TMP1" "$ASSET"
+
+if git diff --quiet -- "$ASSET"; then
+  echo "==> Head branch copy already matches the merged-source build; nothing to commit."
   exit 0
 fi
 
-# Forks and push events: cannot push back, so fail with the actionable message.
-echo "::error::Bundled web worker is stale; run app/tool/build_web.sh (or push from a same-repo branch so CI can regenerate it)."
-exit 1
+# Loop guard (#422, defect 2). REGEN_TOKEN re-triggers CI, so a build that is not
+# stable across runs (base moved, or a residual nondeterminism the within-run
+# check can't see) could push A->B->A forever. If the head we are about to amend
+# is ALREADY an auto-regen commit, this would be the second consecutive bot push:
+# treat that as genuine cross-run drift and fail loudly instead of looping. A new
+# human push resets the head to a non-bot commit and re-arms one auto-regen.
+readonly REGEN_SUBJECT="chore(editor): rebuild the bundled web render worker"
+if [ "$(git log -1 --format='%s')" = "$REGEN_SUBJECT" ] \
+   && git log -1 --format='%ae' | grep -q 'github-actions\[bot\]'; then
+  echo "::error::Web render worker bundle is still stale immediately after an"
+  echo "::error::automated regeneration - the build is not reproducible across"
+  echo "::error::runs (issue #422, defect 2). Refusing to push a second bot"
+  echo "::error::commit. Investigate the nondeterminism before relying on auto-regen."
+  exit 1
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add "$ASSET"
+git commit -m "$REGEN_SUBJECT
+
+Regenerated by CI because a source change left the bundle stale. A textual
+merge of two dart2js outputs is meaningless, so CI owns the regeneration.
+Pushed with WORKER_REGEN_TOKEN so this commit gets its own CI run.
+See issues #411 and #422."
+
+# Push with the dedicated token (not the default GITHUB_TOKEN) so the new head
+# re-triggers CI. The script is idempotent - the next run finds the bundle fresh
+# and no-ops - and the loop guard above bounds it to one bot commit per push.
+git push "https://x-access-token:${REGEN_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  "HEAD:$HEAD_REF"
+echo "::notice::Regenerated and pushed the bundled web render worker to $HEAD_REF (CI will re-run on the new head)."
+exit 0


### PR DESCRIPTION
Fixes #422.

The bundled web render worker (`packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js`) is a `dart compile js` output CI regenerates and pushes back when a source change leaves it stale (#411/#412). That mechanism had three defects that hit **4 of 9 PRs in one session** — the worst leaving PR heads silently unchecked.

## Defect 1 — no concurrency group → double push
Two pushes in quick succession left two `worker-bundle` jobs running at once; both rebuilt and both pushed (bot commits five seconds apart).

**Fix:** a top-level `concurrency` group in `ci.yml`, keyed by PR number on `pull_request` and by `github.sha` otherwise, with `cancel-in-progress` **only** for pull requests. Superseded PR runs are cancelled before they can race; every landed main/deploy commit keeps its own run and record.

## Defect 3 — a `GITHUB_TOKEN` push leaves the head unchecked (the merge-blocker)
A default-`GITHUB_TOKEN` push does not re-trigger workflows, so the bot's follow-up commit became the PR head with **zero checks** — `mergeable` still read `MERGEABLE` and a failure-only rollup saw it as clean. Merge-of-unverified-code hazard; the only remedy was close/reopen.

**Fix:** push with a dedicated token (`secrets.WORKER_REGEN_TOKEN`) so the regen commit **re-triggers CI**. The script is idempotent (the re-triggered run finds the bundle fresh and no-ops), so it can't loop. **If the secret is absent the script does not push at all** — it fails with the exact `dart run dart_pdf_editor:build_web_worker` command. A visible, actionable failure is strictly safer than a bare unchecked head.

## Defect 2 — cross-run drift, and the loop guard
The within-run reproducibility check only proves determinism *within one runner in one run*; across runs the output was seen to differ by 3 bytes, so a re-triggering token could in principle push A→B→A forever.

**Fix:** a loop guard — if the head is already an auto-regen bot commit and the bundle is *still* stale, refuse the second consecutive bot push and fail loudly. Bounds it to **one bot commit per human push**; the head always ends with real checks (a green no-op run, or a visible failure). The reproducibility-check comment is corrected to say what it actually proves.

## ⚠️ Required one-time setup (maintainer)
Auto-regen stays **disabled** (verify-and-fail) until the secret exists:
- Create a token that can push and trigger Actions — a fine-grained PAT with `contents: write`, or (preferred) a GitHub App token (classic `repo`-scope PAT also works).
- Add it as the Actions secret **`WORKER_REGEN_TOKEN`**.

Until then, worker-affecting PRs fail with the rebuild command instead of auto-fixing — the pre-existing fork behavior, now the default everywhere.

## Not done here
The underlying 3-byte nondeterminism is **bounded, not root-caused**. If it recurs after the token lands (now a loud loop-guard failure rather than a silent ping-pong), the real fix is pinning whatever `dart compile js` output varies on.

See `doc/dev-log/2026-07-24-ci-worker-regen-hardening-422.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho