### PR TITLE
perf(worker): resume a preempted page record instead of restarting (#530)

### DIFF
--- a/doc/dev-log/2026-07-24-resume-cancelled-record-530.md
+++ b/doc/dev-log/2026-07-24-resume-cancelled-record-530.md
@@ -1,0 +1,101 @@
+# Resume a preempted page record instead of restarting (#530)
+
+#566 landed the resumable-cursor primitive (`PdfInterpreter.beginPageContent` →
+`PdfPageContentWalk`): a walk records a bounded chunk of operations and can be
+called again to continue from where it stopped, appending to the same device.
+#530 is the render-path consumer: hold that walk across a cancellation so a
+requeued render resumes instead of re-interpreting the prefix.
+
+## Where the restart actually was
+
+The issue named `render_scheduler.dart` / `page_render_session.dart`. Those are a
+synchronous main-thread control plane and never touch the interpreter walk. The
+mid-walk cancel-and-restart lives in the **render worker**:
+`render_worker_isolate.dart` (native) and its full twin
+`render_worker_web_entry.dart` (web).
+
+The mechanism is the existing **preemption requeue**
+(`PdfRenderWorker._pump` → `requeueAfterPreemption`): when a higher-priority page
+is queued while a record is interpreting, the in-flight record is cancelled, the
+worker replies `[id, null]`, and the main side puts the *same* record back on the
+queue behind the urgent page. Pre-#530 the requeued record re-ran
+`_recordPageAsync` from operation 0 — the whole prefix re-interpreted.
+
+## The change (isolate worker only)
+
+`_recordPageAsync`'s full-page path (`decodeImages == true`, i.e. no operation
+cap) now runs through `_recordResumablePage`, backed by a one-slot
+`_SuspendedRecordCache`:
+
+- **Fresh start or resume.** `take(page, annotations)` returns a walk suspended
+  by an earlier cancel of the same page, or the record starts a new
+  `beginPageContent` walk.
+- **Chunked, tokenless drive.** The interpreter carries **no** cancellation
+  token, because a token makes `advance` throw mid-chunk, which *finishes* the
+  walk and restores the device — discarding the partial. Instead the loop
+  advances `_resumeRecordChunkOperations` (4096) at a time and checks
+  `token.cancelled` between chunks. 4096 bounds the post-cancel overshoot to a
+  sliver of a heavy page while keeping per-chunk cost negligible; the walk still
+  yields internally every 512 ops so the isolate keeps servicing the cancel port.
+- **Suspend on cancel.** `keep(entry)` stashes the partial walk (cursor +
+  interpreter graphics state + recorder commands + page) and the record rethrows
+  `PdfCancelledException`; the outer handler replies null and the main side
+  requeues, exactly as before. The next record of that page resumes.
+- **Completion is unchanged.** On the last chunk the walk auto-finishes (the
+  balancing `device.restore()` runs), then annotations + `serializeCommands`
+  happen once, identical to the one-shot path.
+
+Preview/prefix records (`decodeImages == false`, bounded by `commandLimit`) keep
+the simple discard-on-cancel path — they are already cheap and their op cap makes
+resume pointless.
+
+### One slot, and why it's enough
+
+The target workload is: page P is preempted by an urgent neighbour, the neighbour
+records fresh, then P requeues and resumes. `take` only removes the slot's entry
+on a *matching* page, so the neighbour's fresh record leaves P's suspended walk in
+place. Nested preemption of a second page evicts the first (`keep` abandons the
+previous) — a bounded-memory trade that degrades the older page to today's
+restart, never a correctness problem, since an abandoned walk's partial recording
+is just discarded.
+
+### Eviction
+
+A suspended walk reads the old document, so it follows `_BinCommandCache`'s
+eviction: on a revision `update` the worker calls `suspendedRecord.evict(changed
+pages)` (or clears all on a re-open). Updates only arrive when the worker is idle,
+and suspending completes the record request (the worker goes idle), so a resume
+can only happen against the identical document.
+
+## Scope: isolate first, web twin is a follow-up
+
+Deliberately native-only. Reasons:
+
+- The iPad heavy-page hang this targets runs on the **isolate** worker, so this
+  is the actual target.
+- The web worker is a separate twin; editing it forces a `dart compile js` bundle
+  rebuild, which is currently gated on the `WORKER_REGEN_TOKEN` from #422/#571
+  that isn't configured yet. Leaving `render_worker_web_entry.dart` untouched
+  keeps the checked-in bundle fresh and CI green.
+
+The web twin should get the same treatment once the regen token is in place;
+tracked on #530.
+
+## Tests / measurement
+
+- `interpreter_test.dart` already proves the chunked walk emits the same device
+  calls as the unbounded one. New `resume_record_test.dart` adds the
+  serialization round-trip: a walk suspended mid-page and resumed serializes
+  **byte-identically** to a one-shot record, and the bytes are independent of
+  chunk size.
+- Existing real-isolate suites pass unchanged (`render_worker*`,
+  `render_record_replay`, `strip_worker_latency`, `retained_scene`,
+  `command_replay_latency`); the CAD strip-latency numbers are unmoved.
+- The win is **perceived latency** — a preempted heavy page no longer throws away
+  its interpretation — which is inherently hard to put a throughput number on
+  without a cancel-mid-scroll harness. Correctness (identical output) is what the
+  tests pin; the saved work is structural (the resumed walk starts at the cursor,
+  not op 0).
+
+Files: `packages/dart_pdf_editor/lib/src/render_worker_isolate.dart`,
+`packages/dart_pdf_editor/test/resume_record_test.dart`.

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -972,6 +972,12 @@ Future<Uint8List?> _recordResumablePage(
     PdfRect? imageDecodeRegion,
     PdfCancellationToken token) async {
   var entry = suspended.take(pageIndex, annotations);
+  // Defensive: a finished walk cannot be resumed - its advance is a no-op that
+  // reports incomplete, which would spin the completion loop below forever and
+  // hang the worker. The cache only ever stashes a live walk (evict/displace
+  // finish a walk as they remove it), so this is unreachable today; keep it so
+  // a future change can't turn that invariant into a hang.
+  if (entry != null && entry.walk.isFinished) entry = null;
   if (entry == null) {
     final page = document.page(pageIndex);
     final recorder = RecordingPdfDevice();

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -702,6 +702,7 @@ void _workerMain(_WorkerInit init) {
   }
 
   final binCommands = _BinCommandCache();
+  final suspendedRecord = _SuspendedRecordCache();
 
   PdfCancellationToken? activeToken;
   int? activeRequestId;
@@ -779,8 +780,10 @@ void _workerMain(_WorkerInit init) {
         workerBytes = rebuilt;
         // On the in-place fast path only the changed pages' cached commands are
         // stale; a re-open makes a fresh document, so every cached command
-        // (which referenced the old one) must go.
+        // (which referenced the old one) must go. A suspended record walks the
+        // old document too, so it follows the same eviction.
         binCommands.evictPages(incremental ? changed : null);
+        suspendedRecord.evict(incremental ? changed : null);
       } catch (_) {
         // Malformed update: leave the document and buffer as they were and just
         // free the worker slot below so it keeps serving other pages.
@@ -861,6 +864,7 @@ void _workerMain(_WorkerInit init) {
               : null;
           buffer = await _recordPageAsync(
               doc,
+              suspendedRecord,
               pageIndex,
               annotations,
               imagePixelRatio,
@@ -898,8 +902,16 @@ void _workerMain(_WorkerInit init) {
 
 /// Records one page into a serialized command buffer, yielding periodically
 /// so the cancel port's listener can fire and set [token.cancelled].
+///
+/// The full-page record (the heavy case a scroll preempts and then requeues)
+/// runs through [_recordResumablePage], which keeps a cancelled walk in
+/// [suspended] so the requeued render continues from where it stopped instead
+/// of re-interpreting the prefix (#530). Bounded preview/prefix records
+/// (`decodeImages` false) stay on the simple discard-on-cancel path - they are
+/// already cheap and their operation cap makes resume pointless.
 Future<Uint8List?> _recordPageAsync(
     PdfDocument document,
+    _SuspendedRecordCache suspended,
     int pageIndex,
     bool annotations,
     double? imagePixelRatio,
@@ -908,22 +920,149 @@ Future<Uint8List?> _recordPageAsync(
     PdfRect? imageDecodeRegion,
     PdfCancellationToken token) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
+
+  if (decodeImages) {
+    return _recordResumablePage(document, suspended, pageIndex, annotations,
+        imagePixelRatio, commandLimit, imageDecodeRegion, token);
+  }
+
   final page = document.page(pageIndex);
-  final previewOperationLimit = decodeImages ? null : commandLimit;
   final recorder = RecordingPdfDevice();
   final interpreter =
       PdfInterpreter(cos: document.cos, device: recorder, cancellation: token);
   await interpreter.drawPageContentAsync(page, page.contentBytes(),
-      operationLimit: previewOperationLimit);
+      operationLimit: commandLimit);
   if (annotations) interpreter.drawAnnotations(page);
   return serializeCommands(recorder.commands,
       cos: document.cos,
-      decodeImages: decodeImages,
+      decodeImages: false,
       maxImagePixelRatio: imagePixelRatio,
       imageDecodeRegion: imageDecodeRegion,
-      imagePlaceholders: !decodeImages,
+      imagePlaceholders: true,
       commandLimit: commandLimit,
       compactStateScopes: true);
+}
+
+/// Operations recorded per [PdfPageContentWalk.advance] chunk on the resumable
+/// record path. Bounds how much extra interpretation runs after a cancel before
+/// the walk suspends (the walk carries no cancellation token, so it cannot abort
+/// mid-chunk - see [_recordResumablePage]); small enough that the post-cancel
+/// overshoot is a sliver of a heavy page, large enough that the per-chunk cost
+/// stays noise. The walk still yields internally every 512 ops, so the isolate
+/// keeps servicing the cancel port within a chunk.
+const int _resumeRecordChunkOperations = 4096;
+
+/// The full-page record that survives preemption. Resumes a walk [suspended] by
+/// an earlier cancel of this same page, or starts a fresh one, then advances in
+/// bounded chunks. On cancel it stashes the partial walk and rethrows (the
+/// caller replies null and the main side requeues the record); on completion it
+/// draws annotations and serializes exactly as the one-shot path did.
+///
+/// The interpreter deliberately carries no cancellation token: a token makes
+/// [PdfPageContentWalk.advance] throw mid-chunk, which finishes the walk and
+/// restores the device - discarding the partial. Driving bounded chunks and
+/// checking the token between them is what keeps the recording resumable.
+Future<Uint8List?> _recordResumablePage(
+    PdfDocument document,
+    _SuspendedRecordCache suspended,
+    int pageIndex,
+    bool annotations,
+    double? imagePixelRatio,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfCancellationToken token) async {
+  var entry = suspended.take(pageIndex, annotations);
+  if (entry == null) {
+    final page = document.page(pageIndex);
+    final recorder = RecordingPdfDevice();
+    final interpreter = PdfInterpreter(cos: document.cos, device: recorder);
+    final walk = interpreter.beginPageContent(page, page.contentBytes());
+    entry = _SuspendedRecord(
+        pageIndex, annotations, page, recorder, interpreter, walk);
+  }
+
+  final walk = entry.walk;
+  while (!await walk.advance(operations: _resumeRecordChunkOperations)) {
+    if (token.cancelled) {
+      // Keep the partial recording so the requeued render resumes here rather
+      // than re-walking the prefix.
+      suspended.keep(entry);
+      throw const PdfCancelledException();
+    }
+  }
+
+  if (annotations) entry.interpreter.drawAnnotations(entry.page);
+  return serializeCommands(entry.recorder.commands,
+      cos: document.cos,
+      decodeImages: true,
+      maxImagePixelRatio: imagePixelRatio,
+      imageDecodeRegion: imageDecodeRegion,
+      imagePlaceholders: false,
+      commandLimit: commandLimit,
+      compactStateScopes: true);
+}
+
+/// A full-page record cancelled mid-walk, held so the next record of the same
+/// page resumes it (#530). Bundles everything the resumed walk needs: the walk
+/// cursor, the interpreter holding the graphics state, the recorder holding the
+/// commands drawn so far, and the page for the closing annotation pass.
+class _SuspendedRecord {
+  _SuspendedRecord(this.pageIndex, this.annotations, this.page, this.recorder,
+      this.interpreter, this.walk);
+  final int pageIndex;
+  final bool annotations;
+  final PdfPage page;
+  final RecordingPdfDevice recorder;
+  final PdfInterpreter interpreter;
+  final PdfPageContentWalk walk;
+}
+
+/// A one-slot cache of the most recently suspended full-page record.
+///
+/// One slot is enough for the workload this targets: a page is preempted by an
+/// urgent neighbour, that neighbour records fresh (which leaves this page's
+/// suspended walk untouched in the slot - [take] only removes it on a matching
+/// page), then the page requeues and resumes. Nested preemption of a second
+/// page evicts the first ([keep] abandons the previous), degrading it to
+/// today's restart-from-scratch - a bounded-memory trade, not a correctness
+/// issue, since the abandoned walk's partial recording is simply discarded.
+class _SuspendedRecordCache {
+  _SuspendedRecord? _entry;
+
+  /// Removes and returns the suspended record for ([pageIndex], [annotations]),
+  /// or null when the slot holds a different page (which is left in place, so a
+  /// fresh record of an urgent neighbour does not evict the page waiting to
+  /// resume).
+  _SuspendedRecord? take(int pageIndex, bool annotations) {
+    final entry = _entry;
+    if (entry != null &&
+        entry.pageIndex == pageIndex &&
+        entry.annotations == annotations) {
+      _entry = null;
+      return entry;
+    }
+    return null;
+  }
+
+  /// Stashes [entry] to resume on the next record of its page, abandoning any
+  /// previously stashed walk so the balancing device restore runs.
+  void keep(_SuspendedRecord entry) {
+    final previous = _entry;
+    if (previous != null && !identical(previous, entry)) previous.walk.abandon();
+    _entry = entry;
+  }
+
+  /// Drops the stashed walk after a revision update (or shutdown). [pages]
+  /// limits eviction to the changed pages, matching [_BinCommandCache.evictPages];
+  /// null clears the slot unconditionally (a re-open replaced the document).
+  void evict(Set<int>? pages) {
+    final entry = _entry;
+    if (entry == null) return;
+    if (pages == null || pages.contains(entry.pageIndex)) {
+      entry.walk.abandon();
+      _entry = null;
+    }
+  }
 }
 
 /// Bins one page's strips for the requested device geometry and returns the

--- a/packages/dart_pdf_editor/test/resume_record_test.dart
+++ b/packages/dart_pdf_editor/test/resume_record_test.dart
@@ -1,0 +1,104 @@
+// The worker's resumable full-page record (#530) must produce exactly what the
+// one-shot record produced. The render worker records a heavy page in bounded
+// [PdfPageContentWalk.advance] chunks so a scroll that preempts it can requeue
+// and *resume* the walk instead of re-interpreting the prefix. This pins the
+// property the resume rides on: a walk suspended mid-page and resumed serializes
+// to the same command buffer as a walk run to completion in one go.
+//
+// interpreter_test.dart already proves the chunked walk emits the same device
+// calls as the unbounded one; this adds the serialization round-trip, which is
+// the worker's actual output (the bytes the UI isolate deserializes).
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+/// A single-page PDF whose content stream is [opCount] stroked line segments -
+/// enough operations to span many small advance chunks.
+Uint8List _linesPdf(int opCount) {
+  final content = StringBuffer('1 0 0 1 0 0 cm\n0 0 0 RG\n');
+  for (var i = 0; i < opCount; i++) {
+    final x = (i % 100).toDouble();
+    final y = (i % 50).toDouble();
+    content.write('${x.toStringAsFixed(1)} ${y.toStringAsFixed(1)} m '
+        '${(x + 1).toStringAsFixed(1)} ${(y + 1).toStringAsFixed(1)} l S\n');
+  }
+  final stream = content.toString();
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R '
+        '/Resources << >> >>',
+    '<< /Length ${stream.length} >>\nstream\n$stream\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xref = buffer.length;
+  buffer.write('xref\n0 ${objects.length + 1}\n0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer.write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n'
+      'startxref\n$xref\n%%EOF');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
+
+/// Records page 0 in one unbounded walk - the pre-#530 shape.
+Future<Uint8List?> _recordOneShot(Uint8List bytes) async {
+  final doc = PdfDocument.open(bytes);
+  final page = doc.page(0);
+  final recorder = RecordingPdfDevice();
+  final walk = PdfInterpreter(cos: doc.cos, device: recorder)
+      .beginPageContent(page, page.contentBytes());
+  await walk.advance(); // unbounded: runs to completion
+  expect(walk.isComplete, isTrue);
+  return serializeCommands(recorder.commands,
+      cos: doc.cos, decodeImages: true, compactStateScopes: true);
+}
+
+/// Records page 0 the way `_recordResumablePage` does: bounded [chunk] advances
+/// with the walk left suspended (not finished) between them, then resumed to
+/// completion. Asserts the fixture actually spanned several chunks.
+Future<Uint8List?> _recordResumed(Uint8List bytes, {required int chunk}) async {
+  final doc = PdfDocument.open(bytes);
+  final page = doc.page(0);
+  final recorder = RecordingPdfDevice();
+  final walk = PdfInterpreter(cos: doc.cos, device: recorder)
+      .beginPageContent(page, page.contentBytes());
+  var chunks = 0;
+  while (!await walk.advance(operations: chunk)) {
+    chunks++;
+    expect(chunks, lessThan(100000), reason: 'walk did not terminate');
+  }
+  expect(chunks, greaterThan(1),
+      reason: 'the fixture must span several chunks to exercise resume');
+  expect(walk.isComplete, isTrue);
+  return serializeCommands(recorder.commands,
+      cos: doc.cos, decodeImages: true, compactStateScopes: true);
+}
+
+void main() {
+  test('a resumed record serializes identically to a one-shot record',
+      () async {
+    final bytes = _linesPdf(500);
+    final oneShot = await _recordOneShot(bytes);
+    final resumed = await _recordResumed(bytes, chunk: 20);
+    expect(oneShot, isNotNull);
+    expect(resumed, isNotNull);
+    expect(resumed, equals(oneShot),
+        reason: 'suspending mid-walk and resuming must not change the bytes');
+  });
+
+  test('chunk size does not change the recorded bytes', () async {
+    final bytes = _linesPdf(300);
+    final small = await _recordResumed(bytes, chunk: 7);
+    final large = await _recordResumed(bytes, chunk: 128);
+    expect(small, isNotNull);
+    expect(small, equals(large));
+  });
+}


### PR DESCRIPTION
Part of #530 (and #520). Consumes the resumable-cursor primitive #566 landed.

## The restart this fixes
When a higher-priority page preempts an in-flight record, `PdfRenderWorker._pump` cancels it, the worker replies `[id, null]`, and the main side **requeues the same record** (`requeueAfterPreemption`). Pre-#530 the requeue re-ran `_recordPageAsync` from operation 0 — re-interpreting the entire prefix of a heavy page (the #454 ~2.6 s CAD interpret is the case that hurts).

The issue named `render_scheduler`/`page_render_session`, but those are a synchronous control plane and never touch the walk. The mid-walk cancel-and-restart is in the **render worker**.

## The change (isolate worker only)
The full-page record path now runs through `_recordResumablePage`, backed by a one-slot `_SuspendedRecordCache`:

- Drives a `PdfPageContentWalk` in bounded **4096-op** chunks with **no** interpreter cancellation token — a token throws mid-chunk and *finishes* the walk (restoring the device, discarding the partial), which is exactly what we must avoid. The token is checked **between** chunks instead; the walk still yields internally every 512 ops so the cancel port stays serviced.
- On cancel it stashes the partial walk (cursor + interpreter graphics state + recorded commands + page) and rethrows; the next record of that page **resumes from the cursor** instead of op 0.
- Completion (annotations + `serializeCommands`) is byte-for-byte the one-shot path.
- A revision `update` evicts the suspended walk alongside `_BinCommandCache`.

**One slot, and why it's enough:** `take` only reclaims the slot on a *matching* page, so an urgent neighbour's fresh record leaves the suspended page in place to resume. Nested preemption of a second page evicts the first (bounded memory), degrading it to today's restart — never a correctness issue. Preview/prefix records (op-capped) keep the simple discard-on-cancel path.

## Scope: isolate first, web twin is a follow-up
Deliberately native-only:
- The iPad heavy-page hang this targets runs on the **isolate** worker — the actual target.
- The web worker is a separate twin; editing it forces a `dart compile js` bundle rebuild, currently gated on the `WORKER_REGEN_TOKEN` from #422/#571 that isn't configured yet. Leaving `render_worker_web_entry.dart` untouched keeps the checked-in bundle fresh and CI green.

The web twin gets the same treatment once the regen token lands; tracked on #530.

## Tests
- New `resume_record_test.dart`: a walk suspended mid-page and resumed serializes **byte-identically** to a one-shot record, and the bytes are independent of chunk size.
- `interpreter_test.dart` already proves the chunked walk equals the unbounded one at the device-call level.
- Existing real-isolate suites pass unchanged (`render_worker*`, `render_record_replay`, `strip_worker_latency`, `retained_scene`, `command_replay_latency`); CAD strip-latency numbers unmoved. Root `dart analyze --fatal-infos` clean; perf counter gate OK.

## On measurement
The win is **perceived latency** — a preempted heavy page keeps its interpretation instead of throwing it away — which is hard to put a throughput number on without a cancel-mid-scroll harness. The tests pin correctness (identical output); the saved work is structural (the resumed walk starts at the cursor, not op 0).

See `doc/dev-log/2026-07-24-resume-cancelled-record-530.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho