### PR TITLE
Hide the image tool when no imagePicker is wired

### DIFF
--- a/doc/dev-log/2026-07-24-image-tool-hidden-without-picker.md
+++ b/doc/dev-log/2026-07-24-image-tool-hidden-without-picker.md
@@ -1,0 +1,43 @@
+# Image tool hides itself when no `imagePicker` is wired
+
+## Symptom
+
+A downstream app (a `PdfEditorView` host) enabled the Insert tool group but
+never supplied an `imagePicker`. The Insert group still offered the image
+tool, so tapping it was a silent no-op - a dead button with no feedback. The
+reporter hit it and reasonably assumed the feature was broken.
+
+The image tool is inert without a picker *by design*: the picture has to come
+from somewhere (a file picker, a clipboard read), and the package can't pull
+in `dart:io`/plugin dependencies to provide one. `PdfViewer.imagePicker` /
+`PdfEditorView.imagePicker` / `PdfEditingToolbar.imagePicker` is the seam the
+host wires. The bug was only that we *showed the button anyway* when the seam
+was left unwired.
+
+## Fix
+
+Two parts, both cheap:
+
+1. **Hide, don't no-op.** `PdfEditingToolbar._entryVisible` now drops
+   `PdfEditTool.image` from the Insert group when `imagePicker == null`. This
+   is the same visibility path the existing `tools` / `groups` filters use, so
+   it covers both the desktop group strip and the mobile bottom-sheet grid, and
+   flows through `PdfEditorView` (which builds the stock toolbar with
+   `imagePicker: widget.imagePicker`). The overlay's tap/drag handlers already
+   short-circuit on a null picker, so arming the tool directly through the
+   controller stays a safe no-op - the toolbar just no longer offers a way in.
+
+2. **Make the seam obvious.** Doc comments on `imagePicker`
+   (`pdf_viewer.dart`, `pdf_editor_view.dart`, `editing_overlay.dart`,
+   `editing_toolbar.dart`) and on the `PdfEditTool.image` enum value now spell
+   out that the callback *must* be wired for the tool to appear/work, name the
+   typical wiring, and describe the hide-when-null behavior - so the next
+   human or AI reading the API sees the requirement instead of discovering a
+   dead button.
+
+## Test
+
+`editing_image_test.dart` gains an "image tool visibility in the toolbar"
+group: the image tool is `findsNothing` with no picker and `findsOneWidget`
+once an `imagePicker` is supplied (Insert strip raised by arming the always-
+present free-text tool).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -178,7 +178,9 @@ enum PdfEditTool {
 
   /// Insert a raster image (PNG or JPEG). Tapping places it at a default
   /// size; dragging out a box fits it within the box. The picked image
-  /// comes from [PdfViewer.imagePicker]; with none the tool does nothing.
+  /// comes from [PdfViewer.imagePicker] - **that callback must be wired**
+  /// for this tool to do anything. Without it the stock [PdfEditingToolbar]
+  /// hides the tool, and arming it directly is a no-op on tap/drag.
   /// The image becomes a /Stamp annotation, so it can be moved, resized,
   /// rotated, and deleted like any other annotation.
   image,

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -524,7 +524,9 @@ class EditingPageOverlay extends StatefulWidget {
   final PdfFormImagePicker? formImagePicker;
 
   /// How the image tool ([PdfEditTool.image]) asks for the picture to
-  /// insert. With none, the image tool does nothing.
+  /// insert. With none, arming the image tool is a no-op on tap/drag - the
+  /// stock [PdfEditingToolbar] hides the tool in that case so users don't
+  /// meet a dead button. See [PdfViewer.imagePicker].
   final PdfImagePicker? imagePicker;
 
   /// Receives a region captured by the snapshot tool

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -105,7 +105,13 @@ class PdfEditingToolbar extends StatefulWidget {
   /// rich-text overrides (colour, size, bold, italic).
   final PdfStyledTextPrompt styledTextPrompt;
 
-  /// How selected page-content images are replaced from the element strip.
+  /// How the image tool ([PdfEditTool.image]) sources a picture to insert,
+  /// and how selected page-content images are replaced from the element
+  /// strip. Typically a file picker returning PNG or JPEG bytes.
+  ///
+  /// When null the image tool is dropped from the Insert group (rather than
+  /// left as a button that no-ops) and the element strip's replace-image
+  /// action is hidden. See [PdfViewer.imagePicker].
   final PdfImagePicker? imagePicker;
 
   /// How the selected push-button field's toolbar action obtains an image.
@@ -450,7 +456,13 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
 
   bool _entryVisible(_GroupTool entry) {
     final tool = entry.tool;
-    if (tool != null) return _shows(tool);
+    if (tool != null) {
+      // The image tool can't insert anything without an [imagePicker] to
+      // source the picture, so drop it from the Insert group rather than
+      // show a button that silently no-ops. Wire [imagePicker] to offer it.
+      if (tool == PdfEditTool.image && widget.imagePicker == null) return false;
+      return _shows(tool);
+    }
     if (entry.markup != null) return widget.showMarkup;
     return true;
   }

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -452,7 +452,10 @@ class PdfEditorView extends StatefulWidget {
   /// See [PdfViewer.formImagePicker].
   final PdfFormImagePicker? formImagePicker;
 
-  /// See [PdfViewer.imagePicker].
+  /// How the Insert group's image tool ([PdfEditTool.image]) sources a
+  /// picture to insert. Supply this to enable the tool; when null it is
+  /// hidden from the toolbar rather than left as a no-op button. See
+  /// [PdfViewer.imagePicker].
   final PdfImagePicker? imagePicker;
 
   /// See [PdfViewer.systemImagePasteProvider].

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1106,8 +1106,15 @@ class PdfViewer extends StatefulWidget {
   final PdfFontPicker? fontPicker;
 
   /// How the image tool ([PdfEditTool.image]) asks for the picture to
-  /// insert - typically a file picker returning PNG or JPEG bytes. With
-  /// none, the image tool does nothing.
+  /// insert - typically a file picker returning PNG or JPEG bytes.
+  ///
+  /// This callback is what makes the image tool work: **you must supply it**
+  /// for the Insert group's image tool to do anything. When it is null the
+  /// stock [PdfEditingToolbar] hides the image tool entirely (so users never
+  /// meet a button that silently no-ops), and arming [PdfEditTool.image]
+  /// directly through the controller becomes a no-op on tap/drag. A typical
+  /// wiring returns bytes from `file_selector`/`image_picker` (or a system
+  /// clipboard read); return null from the callback to mean "user cancelled".
   final PdfImagePicker? imagePicker;
 
   /// Supplies image bytes for ⌘V/Ctrl+V when the in-app annotation/vector

--- a/packages/dart_pdf_editor/test/editing_image_test.dart
+++ b/packages/dart_pdf_editor/test/editing_image_test.dart
@@ -176,6 +176,47 @@ void main() {
     });
   });
 
+  group('image tool visibility in the toolbar', () {
+    // Anything whose tooltip starts with the image tool's - it carries a
+    // trailing " (I)" shortcut hint we don't want to hard-code.
+    final imageTool = find.byWidgetPredicate((w) =>
+        w is IconButton &&
+        (w.tooltip?.startsWith('Image - tap to place') ?? false));
+
+    Future<PdfEditingController> pumpToolbar(WidgetTester tester,
+        {PdfImagePicker? imagePicker}) async {
+      SharedPreferences.setMockInitialValues({});
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: PdfEditingToolbar(
+            controller: editing,
+            viewerController: viewer,
+            imagePicker: imagePicker,
+          ),
+        ),
+      ));
+      // Arm a tool that's always in the Insert group to raise its strip.
+      editing.tool = PdfEditTool.freeText;
+      await tester.pump();
+      return editing;
+    }
+
+    testWidgets('is hidden from the Insert group when no picker is wired',
+        (tester) async {
+      await pumpToolbar(tester);
+      expect(imageTool, findsNothing);
+    });
+
+    testWidgets('appears once an imagePicker is supplied', (tester) async {
+      await pumpToolbar(tester, imagePicker: (context) => Future.value(_png));
+      expect(imageTool, findsOneWidget);
+    });
+  });
+
   group('PdfEditingController image cropping', () {
     PdfEditingController placedImage() {
       SharedPreferences.setMockInitialValues({});


### PR DESCRIPTION
## Summary

The Insert group's image tool (`PdfEditTool.image`) is inert unless the host wires an `imagePicker` - the picture has to come from a host-supplied file picker or clipboard read, which the package can't provide itself without `dart:io`/plugin dependencies. Previously the tool was shown even when no picker was wired, so tapping it was a **silent no-op**: a dead button that a host (or its users) could easily mistake for a broken feature. This was reported by a downstream `PdfEditorView` host that enabled the Insert group but never supplied an `imagePicker`.

This PR does two things:

1. **Hide, don't no-op.** `PdfEditingToolbar` now drops the image tool from the Insert group when `imagePicker == null`, via the same `_entryVisible` path the existing `tools`/`groups` filters use - so it covers the desktop group strip *and* the mobile bottom-sheet grid, and flows through `PdfEditorView` (which builds the stock toolbar with `imagePicker: widget.imagePicker`). Arming the tool directly through the controller stays a safe no-op; the toolbar just no longer offers a way in to a dead button.
2. **Make the seam obvious for humans/AI.** Doc comments on every `imagePicker` seam (`PdfViewer`, `PdfEditorView`, `EditingPageOverlay`, `PdfEditingToolbar`) and on the `PdfEditTool.image` enum value now state that the callback **must** be wired for the tool to appear/work, name the typical wiring, and describe the hide-when-null behavior - so the requirement is visible in the API instead of surfacing as a dead button.

## Affected packages

- [x] `dart_pdf_editor`
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [x] Editing behavior change
- [x] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (ran `editing_image_test.dart`, `editing_mobile_toolbar_test.dart`, `editing_polish_test.dart`)

`editing_image_test.dart` gains an "image tool visibility in the toolbar" group: the image tool is `findsNothing` with no picker and `findsOneWidget` once an `imagePicker` is supplied.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Behavior-only change to which toolbar buttons render; no change to the image-insertion pipeline itself. A host that already wires `imagePicker` sees no difference. Dev-log note added at `doc/dev-log/2026-07-24-image-tool-hidden-without-picker.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018E7N52yDrLB7PDNmSzmVGh)_