### PR TITLE
perf(search): yield to the event loop after every page (#396)

### DIFF
--- a/doc/dev-log/2026-07-24-search-yield-per-page-396.md
+++ b/doc/dev-log/2026-07-24-search-yield-per-page-396.md
@@ -1,0 +1,50 @@
+# Search yields per page (#396, part 3 — the short-term mitigation)
+
+#396 ("default render worker + off-UI-thread text extraction") has three parts:
+
+1. Ship a default `PdfRenderWorker` so interpretation is off-thread unless the
+   host opts out — the headline, a viewer-lifecycle change (its own follow-up).
+2. An off-thread `extractText(pageIndex)` worker job for search/hover — needs a
+   worker-protocol addition and the web bundle rebuild, so the web half waits on
+   the #422/#571 `WORKER_REGEN_TOKEN`.
+3. Short-term main-thread mitigation: yield per page in search, and gate the
+   hover text probe.
+
+This change is **part 3**, chosen to land first (safe, main-thread only, no
+worker/bundle involvement).
+
+## What changed
+
+`_searchAllPages` yielded a `Future.delayed(Duration.zero)` only every fifth page
+(`i % 5 == 4`). It now yields after **every** page. Each page still interprets a
+full content stream synchronously on the UI thread (100–420 ms on a heavy page —
+that is what part 1/2 move off-thread), so the yield does two things: a frame can
+paint between pages, and the superseding-search bail at the top of the loop
+(`_controller._query != query`) sees a newer keystroke's query one page later
+instead of up to five. Net: the worst uninterruptible span drops from five heavy
+pages to one, and a keystroke cancels a stale full-document walk that much sooner.
+
+The yield is deliberately a `Duration.zero` **timer**, not a microtask — a
+microtask wouldn't let the keystroke event (or rendering) run, so the bail would
+never see the new query.
+
+## The hover half was already done
+
+Part 3 also asked to gate the hover text probe. That guard is already in:
+`_hoverTextCursorAt` skips extraction for pages over
+`hoverTextExtractMaxRawContentBytes` (512 KB raw content) and returns "no text
+cursor" unless the page is already cached — so a heavy CAD sheet never triggers
+the multi-hundred-ms hover freeze. Pages under the threshold extract in a few ms.
+So no hover change was needed here.
+
+## Test fallout
+
+Small-document search tests used `unawaited(controller.search(...))` +
+`await tester.pump()`, relying on the search completing within one microtask
+drain (a <5-page doc never hit the every-fifth timer). With a per-page timer they
+must advance it, so three of them move to `pumpAndSettle(100 ms)` — the same
+pattern the sibling option-toggle tests already use. Results are unchanged; only
+the number of event-loop turns to complete a search moved.
+
+Files: `packages/dart_pdf_editor/lib/src/pdf_viewer.dart`,
+`packages/dart_pdf_editor/test/search_navigation_test.dart`.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3079,10 +3079,16 @@ class _PdfViewerState extends State<PdfViewer>
       if (options.searchAnnotations) {
         _searchAnnotations(i, query, options, results);
       }
-      // Yield to the event loop every few pages so frames paint and the
-      // superseding search gets a chance to run (a microtask wouldn't let
-      // timers/rendering in, so this is a Duration.zero delay).
-      if (i % 5 == 4) await Future<void>.delayed(Duration.zero);
+      // Yield to the event loop after every page so a frame can paint and the
+      // superseding search can run (updating _controller._query, which the
+      // check at the top of the next iteration reads to bail). Each page's
+      // extraction still interprets a full content stream on the UI thread
+      // (100-420ms on a heavy page - #396 moves that off-thread), so yielding
+      // per page rather than every fifth keeps the worst uninterruptible span
+      // to one page instead of five, and lets a keystroke cancel that much
+      // sooner. A microtask wouldn't let timers/rendering in, so this is a
+      // Duration.zero delay.
+      await Future<void>.delayed(Duration.zero);
     }
     return results;
   }

--- a/packages/dart_pdf_editor/test/search_navigation_test.dart
+++ b/packages/dart_pdf_editor/test/search_navigation_test.dart
@@ -186,7 +186,9 @@ void main() {
       await pumpViewer(tester, controller, buildMultiPagePdf(3));
 
       unawaited(controller.search('Page'));
-      await tester.pump();
+      // Search yields to a timer after every page (#396), so drain those timers
+      // before asserting rather than a single microtask-only pump.
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
       expect(controller.searchResults, hasLength(3));
       final first = controller.searchResults.first;
       expect(first.pageIndex, 0);
@@ -210,7 +212,7 @@ void main() {
 
       // case-insensitive search; the snippet shows the page's own case
       unawaited(controller.search('SENTINEL'));
-      await tester.pump();
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
       expect(controller.searchResults, hasLength(1));
       final result = controller.searchResults.single;
       expect(result.matchText, 'sentinel');
@@ -761,7 +763,7 @@ void main() {
           beside: PdfSearchResultsPanel(controller: controller));
 
       unawaited(controller.search('zzz'));
-      await tester.pump();
+      await tester.pumpAndSettle(const Duration(milliseconds: 100));
       expect(find.text('No matches for “zzz”'), findsOneWidget);
     });
 


### PR DESCRIPTION
Part of #396, part 3 (the short-term, main-thread mitigation). Deliberately small and safe — no worker/bundle involvement.

## The problem
`_searchAllPages` extracts each page's text on the UI thread (a full content-stream interpret, 100–420 ms on a heavy page) and yielded a `Duration.zero` delay only **every fifth page** (`i % 5 == 4`). Two consequences on a large/CAD document:
- The superseding-search bail at the top of the loop (`_controller._query != query`) couldn't see a newer keystroke's query — and no frame painted — for up to five heavy pages.
- So each keystroke stacked another partial full-document walk, and the field chugged.

## The change
Yield after **every** page instead of every fifth. The worst uninterruptible span drops from five heavy pages to one, and a stale full-document walk cancels a keystroke that much sooner. The yield stays a `Duration.zero` **timer** (not a microtask) — a microtask wouldn't let the keystroke event or rendering run, so the bail would never see the new query. Search results are unchanged; only the number of event-loop turns to complete a search moved.

## Scope note
This is the main-thread half of #396's part 3. The **hover** probe part 3 also names is already gated — `_hoverTextCursorAt` skips on-hover extraction for pages over `hoverTextExtractMaxRawContentBytes` (512 KB) unless already cached, so a heavy sheet never triggers the multi-hundred-ms hover freeze. Moving the per-page interpretation itself off the UI thread is:
- **Part 1** — a default render worker (viewer stands up its own worker when the host provides none). The headline; a focused follow-up with A/B measurement.
- **Part 2** — an off-thread `extractText` worker job for search/hover. Needs a worker-protocol addition + web bundle rebuild, so the web half waits on the #422/#571 `WORKER_REGEN_TOKEN`.

## Tests
Small-doc search tests used `unawaited(search(...))` + a single `pump()`, relying on the search finishing within one microtask drain (a <5-page doc never hit the every-fifth timer). With a per-page timer they must advance it, so three move to `pumpAndSettle(100ms)` — the same pattern the sibling option-toggle tests already use. Full `search_navigation_test` + the other three search-driving test files pass; root `dart analyze --fatal-infos` clean.

See `doc/dev-log/2026-07-24-search-yield-per-page-396.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho