### PR TITLE
perf(editor): PdfViewer starts a default render worker (#396)

### DIFF
--- a/doc/dev-log/2026-07-24-default-render-worker-396.md
+++ b/doc/dev-log/2026-07-24-default-render-worker-396.md
@@ -1,0 +1,88 @@
+# A default render worker for a bare PdfViewer (#396 part 1)
+
+Page interpretation runs on the UI thread unless a `PdfRenderWorker` is attached.
+The shipping app attaches one through `PdfShellSessionLifecycle`, so it is fine -
+but a host embedding a bare `PdfViewer` (and the comparison view, which mounts two)
+got on-thread interpretation and the frame-freezing that comes with it. Part 1
+makes the viewer stand up its own worker by default.
+
+## Extraction first (behavior-preserving)
+
+The worker lifecycle - incremental `updateRevision` for a byte-prefix append vs a
+full restart otherwise (#308), generation counting, dispose - lived inside
+`PdfShellSessionLifecycle._syncWorker`. Pulled it into `PdfRenderWorkerHost`
+(`render_worker_host.dart`), a widget/editing-free state machine:
+`sync({document, bytes, pageCount, revision})` + `dispose()`, with a `workerCount`
+provider and an `onGeneration` hook (the shell's diagnostics log). The shell now
+delegates; all shell/session/revision tests pass unchanged. This is what lets the
+viewer reuse the *identical* logic instead of a second copy that drifts.
+
+## The viewer wiring
+
+`_PdfViewerState` owns a `PdfRenderWorkerHost` when `renderWorker == null` and
+`autoRenderWorker` (new, default true). `_syncDefaultWorker()`:
+
+- **Editing/form session** - drives the host from the revision controller's
+  revision-aware `bytes` + `lastRevisionDelta`, so each edit streams in
+  incrementally and the worker never renders a stale page. Called from
+  `_onRevisionControllerChanged` (per revision), `didUpdateWidget`, and
+  `initState`.
+- **Read-only document** - drives it from `document.cos.bytes`, no revisions.
+
+A single `_effectiveRenderWorker` getter (`widget.renderWorker ?? host.worker`)
+replaces every `widget.renderWorker` read in the state, so the default fills in
+transparently; children receive it through the existing `renderWorker:`
+pass-downs. Disposed in `dispose()`.
+
+### Deliberate choices
+
+- **Single worker, not a pool.** `workerCount: () => 1`, so a bare viewer - or
+  several on one screen (the comparison panes) - costs at most one isolate each.
+  A pooled multi-worker backend for a long document still needs an explicit
+  `renderWorker` via the shell.
+- **Opt-out** via `autoRenderWorker: false` (force on-thread) - documented for a
+  host that mounts many viewers or manages its own workers. An explicit
+  `renderWorker` always wins; the shell paths (`pdf_reader`, `pdf_editor_view`)
+  pass `_shell.worker`, so no redundant worker under the shell.
+- **Web is safe by default.** With no worker script, `startRenderWorker` returns
+  an inactive worker and the viewer already falls back to on-thread - unchanged.
+- **Async activation.** Like the shell's non-prewarmed path, the worker's
+  `isActive` flips true after the isolate handshake; the first frame may render
+  on-thread and later pages use the worker. No activation-rebuild machinery.
+
+## Tests
+
+- `render_worker_host_test.dart` - the state machine with a fake worker via a new
+  `PdfRenderWorkerHost.debugSpawnOverride` seam: first sync starts one generation,
+  same document is a no-op, a byte-prefix append updates in place (no new
+  generation), a length-mismatch restarts (old worker disposed), dispose is
+  idempotent, `onGeneration` fires per fresh generation only.
+- `default_worker_test.dart` - the viewer wiring: a bare viewer spawns one single
+  worker, `autoRenderWorker: false` spawns none, an explicit `renderWorker`
+  suppresses the default (and isn't disposed by the viewer), the default is
+  disposed with the viewer, and an editing session gets one too.
+
+### Suite-wide: default worker off in tests
+
+Auto-spawning a real isolate per viewer turned synchronous render assertions
+async - three editing render-timing tests (eraser/interaction/stamps) saw
+`committed` instead of `rasterReady` because the worker record hadn't landed in
+the pump budget. So `flutter_test_config.dart` sets
+`PdfViewer.debugAutoRenderWorkerEnabled = false` for the whole suite (deterministic
+on-thread, no isolates, no test slowdown); `default_worker_test.dart` re-enables
+it. Worker-specific suites already spin up their own real workers explicitly and
+are unaffected.
+
+The remaining ghent CMYK/overprint baseline failures are pre-existing (#550 -
+they fail on clean main and `ghent_render_test` never touches `PdfViewer`), not a
+regression here.
+
+## Not done here
+
+Part 2 (an off-thread `extractText` worker job for search/hover) still routes
+extraction on the UI thread; its web half needs the #422/#571
+`WORKER_REGEN_TOKEN`. Part 3 (search yields per page) shipped separately (#575).
+
+Files: `render_worker_host.dart` (new), `shell_session.dart`, `pdf_viewer.dart`,
+`test/render_worker_host_test.dart` (new), `test/default_worker_test.dart` (new),
+`test/flutter_test_config.dart`.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -39,6 +39,7 @@ import 'preview_cache.dart';
 import 'raster_cache.dart';
 import 'render_scheduler.dart';
 import 'render_worker.dart';
+import 'render_worker_host.dart';
 import 'renderer.dart';
 import 'retained_scene.dart';
 import 'scrollbar.dart';
@@ -860,6 +861,12 @@ class PdfViewer extends StatefulWidget {
   /// above any ordinary text page and well below a heavy vector drawing.
   static int hoverTextExtractMaxRawContentBytes = 512 * 1024;
 
+  /// Test seam: set false to suppress the owned default worker
+  /// ([autoRenderWorker]) suite-wide, so widget tests keep the deterministic,
+  /// isolate-free on-thread render path. The package's `flutter_test_config.dart`
+  /// turns it off for every test; production leaves it true.
+  static bool debugAutoRenderWorkerEnabled = true;
+
   const PdfViewer({
     super.key,
     this.document,
@@ -903,6 +910,7 @@ class PdfViewer extends StatefulWidget {
     this.predictStrokes = true,
     this.toolShortcuts = pdfEditToolShortcuts,
     this.renderWorker,
+    this.autoRenderWorker = true,
     this.performance,
     this.rasterCache,
     this.textCache,
@@ -964,6 +972,22 @@ class PdfViewer extends StatefulWidget {
   /// always render locally. Null and the web fallback keep today's
   /// on-thread behavior.
   final PdfRenderWorker? renderWorker;
+
+  /// When no [renderWorker] is provided, the viewer starts and owns a single
+  /// default one so page interpretation runs off the UI thread instead of
+  /// freezing frames (#396). It is kept in step with the document - an editing
+  /// session's per-revision updates stream in incrementally - and disposed with
+  /// the viewer, so a host embedding a bare [PdfViewer] gets off-thread
+  /// rendering for free.
+  ///
+  /// Set false to force on-thread interpretation (the pre-#396 behavior) - e.g.
+  /// a host that mounts many viewers and does not want an isolate each, or one
+  /// that manages its own worker pool. An explicit [renderWorker] always wins
+  /// over this; on web without a worker script the default worker is inactive
+  /// and rendering stays on-thread regardless. A pooled multi-worker backend
+  /// for a long document still requires an explicit [renderWorker] (via the
+  /// shell) - the default is deliberately a single worker.
+  final bool autoRenderWorker;
 
   /// Optional adaptive performance policy. Worker counts are applied by the
   /// owning shell when it starts [renderWorker]; the viewer consumes its
@@ -1373,6 +1397,66 @@ class _PdfViewerState extends State<PdfViewer>
   /// controller advancing to the next revision) is detected against this.
   PdfDocument? _loadedDocument;
 
+  /// The default render worker the viewer owns when the host passes none and
+  /// [PdfViewer.autoRenderWorker] is on (#396). Kept in step with [_document]
+  /// by [_syncDefaultWorker]; null when a host [PdfViewer.renderWorker] is used
+  /// or auto-worker is off.
+  PdfRenderWorkerHost? _defaultWorkerHost;
+
+  /// The render worker pages should use: the host-provided one, else the
+  /// viewer's own default. Read everywhere in place of `widget.renderWorker` so
+  /// the default transparently fills in.
+  PdfRenderWorker? get _effectiveRenderWorker =>
+      widget.renderWorker ?? _defaultWorkerHost?.worker;
+
+  /// A single-worker count for the owned default. The pooled multi-worker
+  /// backend is reserved for an explicit host worker (the shell), so a bare
+  /// viewer - possibly one of many on screen - costs at most one isolate.
+  static int _oneDefaultWorker() => 1;
+
+  /// Brings the owned default worker in line with the current document: creates
+  /// it on demand, streams an editing session's incremental revisions in place
+  /// (so it never renders stale pages), and tears it down when a host worker
+  /// takes over or auto-worker is switched off. A no-op when the document is
+  /// already the loaded one, so calling it per revision / rebuild is cheap.
+  void _syncDefaultWorker() {
+    if (widget.renderWorker != null ||
+        !widget.autoRenderWorker ||
+        !PdfViewer.debugAutoRenderWorkerEnabled) {
+      _defaultWorkerHost?.dispose();
+      _defaultWorkerHost = null;
+      return;
+    }
+    final host =
+        _defaultWorkerHost ??= PdfRenderWorkerHost(workerCount: _oneDefaultWorker);
+    final controller = _revisionController;
+    if (controller != null) {
+      // Editing/form session: revision-aware bytes and the incremental delta.
+      final delta = controller.lastRevisionDelta;
+      host.sync(
+        document: controller.document,
+        bytes: controller.bytes,
+        pageCount: controller.document.pageCount,
+        revision: delta == null
+            ? null
+            : (
+                baseLength: delta.baseLength,
+                newLength: delta.newLength,
+                changedPages: delta.changedPages,
+              ),
+      );
+    } else {
+      // Read-only document: its source bytes, no revisions.
+      final document = _document;
+      host.sync(
+        document: document,
+        bytes: document.cos.bytes,
+        pageCount: document.pageCount,
+        revision: null,
+      );
+    }
+  }
+
   /// Displayed width of each page in PDF points (after /Rotate + view
   /// rotation). Pages lay out at this width times [_fitScale] (and the
   /// layout zoom), so they keep their true sizes relative to one another
@@ -1641,6 +1725,7 @@ class _PdfViewerState extends State<PdfViewer>
     // it notifies, instead of leaning on the host to rebuild with a matching
     // document (the old unchecked invariant).
     _revisionController?.addListener(_onRevisionControllerChanged);
+    _syncDefaultWorker();
     _zoomAnimator = AnimationController(
         vsync: this, duration: const Duration(milliseconds: 200))
       ..addListener(() {
@@ -1989,7 +2074,7 @@ class _PdfViewerState extends State<PdfViewer>
     _prerendering = true;
     try {
       while (mounted && widget.pagePreviews && widget.active) {
-        final workerActive = widget.renderWorker?.isActive ?? false;
+        final workerActive = _effectiveRenderWorker?.isActive ?? false;
         final motionVector = _vectorFirstPrefetch && workerActive;
         final policyVector = !motionVector &&
             workerActive &&
@@ -2024,7 +2109,7 @@ class _PdfViewerState extends State<PdfViewer>
         await _previews.renderPreview(index, page,
             pageColor: widget.pageColor,
             annotations: _pageImagesShowAnnotations,
-            worker: widget.renderWorker,
+            worker: _effectiveRenderWorker,
             rotation: _effectiveRotation(index),
             decodeImages: !vectorOnly,
             commandLimit: vectorOnly ? _jumpPreviewOperationLimit : null,
@@ -2124,7 +2209,7 @@ class _PdfViewerState extends State<PdfViewer>
       window = math.min(window, 4);
     }
 
-    final worker = widget.renderWorker;
+    final worker = _effectiveRenderWorker;
     if (worker is PdfCachingRenderWorker) {
       final pressure = worker.cachePressure;
       if (pressure >= 0.85) {
@@ -2156,7 +2241,7 @@ class _PdfViewerState extends State<PdfViewer>
       _scrollBurstStart = now;
       _scrollSamples.add((now, pixels));
       _beginMotionRenderHold();
-      _vectorFirstPrefetch = widget.renderWorker?.isActive ?? false;
+      _vectorFirstPrefetch = _effectiveRenderWorker?.isActive ?? false;
       return;
     }
     if (_scrollSamples.last.$1 == now) {
@@ -2187,7 +2272,7 @@ class _PdfViewerState extends State<PdfViewer>
     final activeMotion = _motionRenderHoldActive;
     final hold =
         activeMotion || opening || velocity > math.max(800, 2 * viewport);
-    _vectorFirstPrefetch = hold && (widget.renderWorker?.isActive ?? false);
+    _vectorFirstPrefetch = hold && (_effectiveRenderWorker?.isActive ?? false);
     PdfPerfLog.log('scroll page=${_controller.currentPage} '
         'v=${velocity.toStringAsFixed(0)}px/s '
         'threshold=${math.max(800, 2 * viewport).toStringAsFixed(0)} '
@@ -2225,6 +2310,9 @@ class _PdfViewerState extends State<PdfViewer>
     // a revision (handled directly in _onRevisionControllerChanged)
     final documentSwapped = !identical(_loadedDocument, _document);
     if (documentSwapped) _swapDocument();
+    // Re-evaluate the owned default worker: a host worker may have been
+    // supplied/removed, autoRenderWorker toggled, or the document swapped.
+    _syncDefaultWorker();
     final oldPageImagesShowAnnotations = oldWidget.showAnnotations &&
         _pageImagesShowAnnotationsFor(
           editing: oldWidget.editing,
@@ -2287,6 +2375,9 @@ class _PdfViewerState extends State<PdfViewer>
   /// itself so the displayed document can't lag the controller.
   void _onRevisionControllerChanged() {
     if (!mounted) return;
+    // Stream the new revision into the owned worker before the rebuild reads
+    // the effective worker, so a resumed render sees current pages, not stale.
+    _syncDefaultWorker();
     if (!identical(_loadedDocument, _document)) {
       _swapDocument();
     } else {
@@ -2528,6 +2619,7 @@ class _PdfViewerState extends State<PdfViewer>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _defaultWorkerHost?.dispose();
     _revisionController?.removeListener(_onRevisionControllerChanged);
     widget.performance?.removeListener(_onPerformanceChanged);
     if (widget.performance != null) {
@@ -5508,7 +5600,7 @@ class _PdfViewerState extends State<PdfViewer>
                 transformChanges: _transform,
                 renderScheduler: _renderScheduler,
                 previewCache: widget.pagePreviews ? _previews : null,
-                renderWorker: widget.renderWorker,
+                renderWorker: _effectiveRenderWorker,
                 performance: widget.performance,
                 predictStrokes: widget.predictStrokes,
               ),
@@ -5889,7 +5981,7 @@ class _PdfViewerState extends State<PdfViewer>
 
   void _warmJumpTargetPreview(int index) {
     if (!widget.pagePreviews) return;
-    final worker = widget.renderWorker;
+    final worker = _effectiveRenderWorker;
     if (worker == null ||
         !worker.isActive ||
         index < 0 ||

--- a/packages/dart_pdf_editor/lib/src/render_worker_host.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_host.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+import 'render_worker.dart';
+
+/// Owns a [PdfRenderWorker]'s lifecycle across a document's revisions: starts
+/// it, feeds incremental edits in place, restarts it on a non-incremental
+/// change, and disposes it.
+///
+/// This is the worker half of a document session, factored out of the shell so
+/// both the shell ([PdfShellSessionLifecycle]) and a bare [PdfViewer] standing
+/// up its own default worker drive one identical state machine instead of two
+/// that can drift. It knows nothing about editing, viewports, or widgets - just
+/// "here is the current document/bytes, bring the worker in line".
+class PdfRenderWorkerHost {
+  /// [workerCount] supplies the pool size for each fresh generation (and may
+  /// carry a side effect, e.g. advancing a performance controller's generation
+  /// counter); null lets [startPdfRenderWorker] fall back to the global default.
+  /// [onGeneration] fires just after a fresh worker starts (not on an in-place
+  /// revision update) - the shell uses it to log its performance diagnostics.
+  PdfRenderWorkerHost({int Function()? workerCount, VoidCallback? onGeneration})
+      : _workerCount = workerCount,
+        _onGeneration = onGeneration;
+
+  final int Function()? _workerCount;
+  final VoidCallback? _onGeneration;
+
+  PdfRenderWorker? _worker;
+  Object? _workerDocument;
+  int _generations = 0;
+
+  /// The live worker, or null before the first [sync] (or after [dispose]).
+  PdfRenderWorker? get worker => _worker;
+
+  /// How many worker generations this host has started - a fresh generation is
+  /// a full (re)start, not an in-place revision update.
+  int get generations => _generations;
+
+  /// Brings the worker in line with [document].
+  ///
+  /// A no-op when [document] is already the loaded one. When [revision]
+  /// describes a byte-prefix append to the current buffer (and its `newLength`
+  /// matches [bytes]), the append is streamed into the live worker and only the
+  /// changed pages' caches drop - no restart, so warm caches survive an edit.
+  /// Otherwise (fresh open, a backend that can't update in place, or a
+  /// structural/redaction change that replaced the buffer) a new generation
+  /// starts.
+  void sync({
+    required PdfDocument document,
+    required Uint8List bytes,
+    required int pageCount,
+    ({int baseLength, int newLength, Set<int>? changedPages})? revision,
+  }) {
+    if (identical(document, _workerDocument)) return;
+
+    final worker = _worker;
+    if (worker != null &&
+        worker.supportsRevisionUpdate &&
+        revision != null &&
+        revision.newLength == bytes.length) {
+      final appended = revision.newLength > revision.baseLength
+          ? Uint8List.fromList(
+              Uint8List.sublistView(bytes, revision.baseLength))
+          : Uint8List(0);
+      worker.updateRevision(
+        revision.baseLength,
+        appended,
+        revision.newLength,
+        revision.changedPages,
+      );
+      _workerDocument = document;
+      return;
+    }
+
+    _worker?.dispose();
+    // The session's grow-only buffer is replaced on edit, never mutated in
+    // place, so the pool can seed from it directly - no defensive copy of a
+    // possibly-huge document (#359).
+    _worker = startPdfRenderWorker(bytes,
+        pageCount: pageCount,
+        workerCount: _workerCount?.call(),
+        copySource: false);
+    _workerDocument = document;
+    _generations++;
+    _onGeneration?.call();
+  }
+
+  void dispose() {
+    _worker?.dispose();
+    _worker = null;
+    _workerDocument = null;
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/render_worker_host.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_host.dart
@@ -25,6 +25,18 @@ class PdfRenderWorkerHost {
   final int Function()? _workerCount;
   final VoidCallback? _onGeneration;
 
+  /// Test seam: when set, a fresh generation spawns through this instead of
+  /// [startPdfRenderWorker], so the lifecycle state machine (no-op / in-place
+  /// revision / restart / dispose) can be exercised with a fake worker and no
+  /// real isolate. Null in production.
+  @visibleForTesting
+  static PdfRenderWorker Function(
+    Uint8List bytes, {
+    required int pageCount,
+    int? workerCount,
+    bool copySource,
+  })? debugSpawnOverride;
+
   PdfRenderWorker? _worker;
   Object? _workerDocument;
   int _generations = 0;
@@ -76,7 +88,8 @@ class PdfRenderWorkerHost {
     // The session's grow-only buffer is replaced on edit, never mutated in
     // place, so the pool can seed from it directly - no defensive copy of a
     // possibly-huge document (#359).
-    _worker = startPdfRenderWorker(bytes,
+    final spawn = debugSpawnOverride ?? startPdfRenderWorker;
+    _worker = spawn(bytes,
         pageCount: pageCount,
         workerCount: _workerCount?.call(),
         copySource: false);

--- a/packages/dart_pdf_editor/lib/src/shell_session.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_session.dart
@@ -7,6 +7,7 @@ import 'perf_log.dart';
 import 'performance_policy.dart';
 import 'pdf_viewer.dart';
 import 'render_worker.dart';
+import 'render_worker_host.dart';
 import 'shell_chrome.dart';
 
 typedef PdfShellPrepareSession = void Function(PdfEditingController session);
@@ -65,9 +66,10 @@ class PdfShellSessionLifecycle {
   PdfViewerController? _ownedViewer;
   PdfPerformanceController? _ownedPerformance;
   PdfViewportMemory? _viewportMemory;
-  PdfRenderWorker? _worker;
-  Object? _workerDocument;
-  int _workerGenerations = 0;
+  late final PdfRenderWorkerHost _workerHost = PdfRenderWorkerHost(
+    workerCount: performance.beginWorkerGeneration,
+    onGeneration: () => PdfPerfLog.log(performance.diagnostics.toString()),
+  );
 
   final TextEditingController searchController = TextEditingController();
   final FocusNode searchFocus = FocusNode();
@@ -83,13 +85,13 @@ class PdfShellSessionLifecycle {
       _externalPerformance ??
       (_ownedPerformance ??= PdfPerformanceController());
 
-  PdfRenderWorker? get worker => _worker;
+  PdfRenderWorker? get worker => _workerHost.worker;
 
   String? get documentKey =>
       _documentId ?? (_bytes == null ? null : pdfDocumentKey(_bytes!));
 
   /// Number of actual worker generations started by this lifecycle.
-  int get debugWorkerGenerations => _workerGenerations;
+  int get debugWorkerGenerations => _workerHost.generations;
   bool get debugOwnsSession => _ownedSession != null;
   bool get debugOwnsPreferences => _ownedPreferences != null;
   bool get debugOwnsViewer => _ownedViewer != null;
@@ -117,9 +119,7 @@ class PdfShellSessionLifecycle {
 
   void _closeSession() {
     session.removeListener(_handleSessionChanged);
-    _worker?.dispose();
-    _worker = null;
-    _workerDocument = null;
+    _workerHost.dispose();
     _ownedSession?.dispose();
     _ownedSession = null;
   }
@@ -130,48 +130,22 @@ class PdfShellSessionLifecycle {
   }
 
   void _syncWorker() {
-    if (identical(session.document, _workerDocument)) return;
-
-    // Revision-aware fast path: revisions are byte prefixes of one growing
-    // buffer, so an edit to one page leaves every other page byte-identical.
-    // Feed the incremental append into the live worker and evict only the
-    // changed pages' cached renders instead of tearing down the whole pool and
-    // re-parsing N private documents from cold. See issue #308.
-    final worker = _worker;
+    // The worker state machine (incremental revision update vs a fresh
+    // generation, per issue #308) lives in [PdfRenderWorkerHost] so the bare
+    // [PdfViewer] default worker drives the identical logic - see #396.
     final delta = session.lastRevisionDelta;
-    if (worker != null &&
-        worker.supportsRevisionUpdate &&
-        delta != null &&
-        delta.newLength == session.bytes.length) {
-      final appended = delta.newLength > delta.baseLength
-          ? Uint8List.fromList(
-              Uint8List.sublistView(session.bytes, delta.baseLength))
-          : Uint8List(0);
-      worker.updateRevision(
-        delta.baseLength,
-        appended,
-        delta.newLength,
-        delta.changedPages,
-      );
-      _workerDocument = session.document;
-      return;
-    }
-
-    // Fresh open, a backend that can't update in place (web/null), or a
-    // non-incremental transition (a structural edit or a redaction burn that
-    // replaced the buffer): start a new worker generation.
-    _worker?.dispose();
-    final workerCount = performance.beginWorkerGeneration();
-    // The session's grow-only buffer is replaced on edit, never mutated in
-    // place, so the pool can seed from it directly - no defensive copy of a
-    // possibly-huge document (#359).
-    _worker = startPdfRenderWorker(session.bytes,
-        pageCount: session.document.pageCount,
-        workerCount: workerCount,
-        copySource: false);
-    _workerDocument = session.document;
-    _workerGenerations++;
-    PdfPerfLog.log(performance.diagnostics.toString());
+    _workerHost.sync(
+      document: session.document,
+      bytes: session.bytes,
+      pageCount: session.document.pageCount,
+      revision: delta == null
+          ? null
+          : (
+              baseLength: delta.baseLength,
+              newLength: delta.newLength,
+              changedPages: delta.changedPages,
+            ),
+    );
   }
 
   void _bindViewportMemory({required bool recreate}) {

--- a/packages/dart_pdf_editor/test/default_worker_test.dart
+++ b/packages/dart_pdf_editor/test/default_worker_test.dart
@@ -1,0 +1,114 @@
+// PdfViewer stands up its own render worker when the host provides none, so a
+// bare embed gets off-thread interpretation (#396 part 1). These pin the wiring
+// via the host's debug spawn seam - no real isolate - so they assert *whether*
+// a default worker is created, disposed, and sized, not the isolate itself.
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/render_worker_host.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+class _FakeWorker extends PdfRenderWorker {
+  bool disposed = false;
+
+  @override
+  bool get isActive => !disposed;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio,
+          bool decodeImages = true,
+          int? commandLimit,
+          PdfRect? imageDecodeRegion}) async =>
+      null;
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => disposed = true;
+}
+
+void main() {
+  late List<_FakeWorker> spawned;
+  late List<int?> spawnedCounts;
+
+  setUp(() {
+    // flutter_test_config.dart disables the default worker suite-wide; this file
+    // is the one that exercises it, so turn it back on.
+    PdfViewer.debugAutoRenderWorkerEnabled = true;
+    spawned = [];
+    spawnedCounts = [];
+    PdfRenderWorkerHost.debugSpawnOverride = (bytes,
+        {required int pageCount, int? workerCount, bool copySource = false}) {
+      final worker = _FakeWorker();
+      spawned.add(worker);
+      spawnedCounts.add(workerCount);
+      return worker;
+    };
+  });
+
+  tearDown(() {
+    PdfRenderWorkerHost.debugSpawnOverride = null;
+    PdfViewer.debugAutoRenderWorkerEnabled = false; // restore the suite default
+  });
+
+  Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: child)),
+      );
+
+  Widget viewer(Uint8List bytes,
+          {bool autoRenderWorker = true, PdfRenderWorker? renderWorker}) =>
+      PdfViewer(
+        document: PdfDocument.open(bytes),
+        initialFit: PdfViewerFit.width,
+        autoRenderWorker: autoRenderWorker,
+        renderWorker: renderWorker,
+      );
+
+  testWidgets('a bare viewer starts its own single default worker',
+      (tester) async {
+    await pump(tester, viewer(buildMultiPagePdf(3)));
+    expect(spawned, hasLength(1), reason: 'the viewer must own a default worker');
+    expect(spawnedCounts.single, 1, reason: 'the default is a single worker');
+  });
+
+  testWidgets('autoRenderWorker: false leaves interpretation on-thread',
+      (tester) async {
+    await pump(tester, viewer(buildMultiPagePdf(3), autoRenderWorker: false));
+    expect(spawned, isEmpty);
+  });
+
+  testWidgets('an explicit renderWorker suppresses the default', (tester) async {
+    final host = _FakeWorker();
+    await pump(tester, viewer(buildMultiPagePdf(3), renderWorker: host));
+    expect(spawned, isEmpty, reason: 'the host worker is used, none is spawned');
+    expect(host.disposed, isFalse, reason: 'the viewer does not own the host worker');
+  });
+
+  testWidgets('the default worker is disposed with the viewer', (tester) async {
+    await pump(tester, viewer(buildMultiPagePdf(3)));
+    final worker = spawned.single;
+    expect(worker.disposed, isFalse);
+
+    await pump(tester, const SizedBox());
+    expect(worker.disposed, isTrue);
+  });
+
+  testWidgets('an editing session gets a default worker too', (tester) async {
+    final controller = PdfEditingController(buildMultiPagePdf(3));
+    addTearDown(controller.dispose);
+    await pump(
+      tester,
+      PdfViewer(editing: controller, initialFit: PdfViewerFit.width),
+    );
+    expect(spawned, hasLength(1),
+        reason: 'the editing branch reads the controller bytes and spawns one');
+  });
+}

--- a/packages/dart_pdf_editor/test/flutter_test_config.dart
+++ b/packages/dart_pdf_editor/test/flutter_test_config.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:dart_pdf_editor/dart_pdf_editor.dart' show PdfViewer;
 import 'package:flutter/services.dart' show FontLoader;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -19,6 +20,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   TestWidgetsFlutterBinding.ensureInitialized();
   SharedPreferences.setMockInitialValues({});
+  // Keep the deterministic, isolate-free on-thread render path for the suite:
+  // the owned default worker (#396) would otherwise spawn a real isolate per
+  // viewer and turn synchronous render assertions async. Tests that exercise the
+  // default worker re-enable it (see default_worker_test.dart).
+  PdfViewer.debugAutoRenderWorkerEnabled = false;
   await _registerBundledDejaVu();
   await testMain();
 }

--- a/packages/dart_pdf_editor/test/render_worker_host_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_host_test.dart
@@ -1,0 +1,167 @@
+// The worker lifecycle state machine extracted from the shell (#396): a no-op
+// when the document is unchanged, an in-place updateRevision for a byte-prefix
+// append, and a full restart otherwise. Driven here with a fake worker via the
+// debug spawn seam, so it exercises the logic without spawning a real isolate.
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/src/render_worker.dart';
+import 'package:dart_pdf_editor/src/render_worker_host.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+class _FakeWorker extends PdfRenderWorker {
+  _FakeWorker(this.bytesLength);
+  final int bytesLength;
+  bool disposed = false;
+  final revisions = <(int base, int newLen, Set<int>? pages)>[];
+
+  @override
+  bool get supportsRevisionUpdate => true;
+
+  @override
+  void updateRevision(
+      int baseLength, Uint8List appended, int newLength, Set<int>? changedPages) {
+    revisions.add((baseLength, newLength, changedPages));
+  }
+
+  @override
+  bool get isActive => !disposed;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(int pageIndex,
+          {bool annotations = true,
+          int priority = 0,
+          double? imagePixelRatio,
+          bool decodeImages = true,
+          int? commandLimit,
+          PdfRect? imageDecodeRegion}) async =>
+      null;
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => disposed = true;
+}
+
+void main() {
+  final spawned = <_FakeWorker>[];
+
+  setUp(() {
+    spawned.clear();
+    PdfRenderWorkerHost.debugSpawnOverride = (bytes,
+        {required int pageCount, int? workerCount, bool copySource = false}) {
+      final worker = _FakeWorker(bytes.length);
+      spawned.add(worker);
+      return worker;
+    };
+  });
+
+  tearDown(() => PdfRenderWorkerHost.debugSpawnOverride = null);
+
+  PdfDocument openDoc() => PdfDocument.open(buildMultiPagePdf(3));
+
+  test('first sync starts exactly one generation', () {
+    final host = PdfRenderWorkerHost();
+    final doc = openDoc();
+    host.sync(document: doc, bytes: doc.cos.bytes, pageCount: 3, revision: null);
+
+    expect(host.generations, 1);
+    expect(spawned, hasLength(1));
+    expect(identical(host.worker, spawned.single), isTrue);
+  });
+
+  test('the same document is a no-op', () {
+    final host = PdfRenderWorkerHost();
+    final doc = openDoc();
+    host.sync(document: doc, bytes: doc.cos.bytes, pageCount: 3, revision: null);
+    host.sync(document: doc, bytes: doc.cos.bytes, pageCount: 3, revision: null);
+
+    expect(host.generations, 1, reason: 'unchanged document must not restart');
+    expect(spawned, hasLength(1));
+  });
+
+  test('a byte-prefix append updates in place, no new generation', () {
+    final host = PdfRenderWorkerHost();
+    final doc1 = openDoc();
+    host.sync(
+        document: doc1, bytes: doc1.cos.bytes, pageCount: 3, revision: null);
+
+    // A new document object (a revision) whose bytes extend the first.
+    final baseLength = doc1.cos.bytes.length;
+    final appended = Uint8List(16);
+    final grown = Uint8List(baseLength + appended.length)
+      ..setRange(0, baseLength, doc1.cos.bytes);
+    final doc2 = openDoc(); // distinct object; identity is what drives the sync
+    host.sync(
+      document: doc2,
+      bytes: grown,
+      pageCount: 3,
+      revision: (baseLength: baseLength, newLength: grown.length, changedPages: {1}),
+    );
+
+    expect(host.generations, 1, reason: 'an incremental edit keeps the worker');
+    expect(spawned, hasLength(1));
+    expect(spawned.single.revisions, hasLength(1));
+    expect(spawned.single.revisions.single.$1, baseLength);
+    expect(spawned.single.revisions.single.$2, grown.length);
+    expect(spawned.single.revisions.single.$3, {1});
+  });
+
+  test('a revision whose length disagrees with the buffer restarts', () {
+    final host = PdfRenderWorkerHost();
+    final doc1 = openDoc();
+    host.sync(
+        document: doc1, bytes: doc1.cos.bytes, pageCount: 3, revision: null);
+
+    // newLength that doesn't match the passed bytes (a structural edit / buffer
+    // replacement) can't be applied as a prefix append, so a fresh generation.
+    final doc2 = openDoc();
+    host.sync(
+      document: doc2,
+      bytes: doc2.cos.bytes,
+      pageCount: 3,
+      revision: (baseLength: 0, newLength: doc2.cos.bytes.length + 999, changedPages: null),
+    );
+
+    expect(host.generations, 2);
+    expect(spawned, hasLength(2));
+    expect(spawned.first.disposed, isTrue, reason: 'the old worker is disposed');
+    expect(spawned.last.disposed, isFalse);
+  });
+
+  test('dispose tears down the worker and is idempotent', () {
+    final host = PdfRenderWorkerHost();
+    final doc = openDoc();
+    host.sync(document: doc, bytes: doc.cos.bytes, pageCount: 3, revision: null);
+    final worker = spawned.single;
+
+    host.dispose();
+    expect(worker.disposed, isTrue);
+    expect(host.worker, isNull);
+    host.dispose(); // idempotent
+    expect(host.worker, isNull);
+  });
+
+  test('onGeneration fires per fresh generation, not per in-place update', () {
+    var generations = 0;
+    final host = PdfRenderWorkerHost(onGeneration: () => generations++);
+    final doc1 = openDoc();
+    host.sync(
+        document: doc1, bytes: doc1.cos.bytes, pageCount: 3, revision: null);
+    expect(generations, 1);
+
+    // In-place update: no onGeneration.
+    final baseLength = doc1.cos.bytes.length;
+    final grown = Uint8List(baseLength + 8)..setRange(0, baseLength, doc1.cos.bytes);
+    host.sync(
+      document: openDoc(),
+      bytes: grown,
+      pageCount: 3,
+      revision: (baseLength: baseLength, newLength: grown.length, changedPages: {0}),
+    );
+    expect(generations, 1);
+  });
+}


### PR DESCRIPTION
#396 part 1 (the headline). Part 3 shipped in #575; Part 2 (off-thread extractText) is a later follow-up whose web half needs #571's token.

## Problem
Page interpretation runs on the UI thread unless a `PdfRenderWorker` is attached. The shipping app attaches one via `PdfShellSessionLifecycle`, but a host embedding a bare `PdfViewer` — and the comparison view, which mounts two panes — got on-thread interpretation and the frame-freezing that comes with it.

## Two commits

**1. Extract `PdfRenderWorkerHost` (behavior-preserving).** The worker lifecycle — incremental `updateRevision` for a byte-prefix append vs a full restart (#308), generation counting, dispose — lived in `PdfShellSessionLifecycle._syncWorker`. Pulled into a widget/editing-free state machine (`sync({document, bytes, pageCount, revision})` + `dispose()`, a `workerCount` provider, an `onGeneration` hook). The shell delegates; all shell/session/revision tests pass unchanged. This is what lets the viewer reuse the *identical* logic instead of a drifting copy.

**2. Wire it into `PdfViewer`.** The state owns a host when `renderWorker == null` and `autoRenderWorker` (new, default true). `_syncDefaultWorker()` drives it from the revision controller's revision-aware bytes+delta (editing — streams edits in, never renders stale) or `document.cos.bytes` (read-only). A single `_effectiveRenderWorker` getter replaces every `widget.renderWorker` read; children receive it through the existing pass-downs; disposed with the viewer.

### Deliberate choices
- **Single worker, not a pool** (`workerCount: () => 1`) — a bare viewer, or several on one screen, costs at most one isolate each. A pooled backend for a long document still needs an explicit `renderWorker` via the shell.
- **Opt-out** `autoRenderWorker: false` forces on-thread. An explicit `renderWorker` always wins; the shell paths pass `_shell.worker`, so no redundant worker under the shell.
- **Web safe by default** — no worker script ⇒ inactive worker ⇒ on-thread, unchanged.

## Tests
- `render_worker_host_test.dart` — the state machine via a new `debugSpawnOverride` seam (no real isolate): no-op / in-place update / restart-and-dispose / idempotent dispose / `onGeneration` per generation only.
- `default_worker_test.dart` — the wiring: bare viewer spawns one single worker, `autoRenderWorker: false` spawns none, an explicit `renderWorker` suppresses the default (and isn't disposed by the viewer), the default is disposed with the viewer, an editing session gets one.
- **Suite-wide:** auto-spawning a real isolate per viewer turned three editing render-timing assertions async (`committed` instead of `rasterReady`). `flutter_test_config.dart` disables the default worker for the whole suite (deterministic on-thread, no isolates, no slowdown); `default_worker_test` re-enables it. Full suite: **zero new failures** — the 20 remaining are the pre-existing ghent CMYK/overprint baselines (#550), which fail on clean main and never touch `PdfViewer`.

See `doc/dev-log/2026-07-24-default-render-worker-396.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho