### PR TITLE
perf(app): stop the devtools timings callback from self-driving frames (#452)

### DIFF
--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -269,8 +269,19 @@ class AppDevTools extends ChangeNotifier {
     while (_timings.length > frameWindow) {
       _timings.removeFirst();
     }
-    _scheduleNotify();
+    // Deliberately does NOT notify (#452). A notify rebuilds the panel, and a
+    // panel rebuild is itself a frame, which fires this callback again - a
+    // self-sustaining ~1 Hz rebuild loop that keeps the app producing janky
+    // frames while it sits idle, and makes the measurement drive the thing it
+    // measures. The panel's own 1 s poll (devtools_panel.dart) refreshes the
+    // frame stats instead; the window keeps accumulating here regardless.
   }
+
+  /// Test seam (#452): drive the frame-timings path directly, to assert it
+  /// accumulates the sample window without scheduling a notify (which would
+  /// self-sustain a rebuild loop).
+  @visibleForTesting
+  void debugAddTimings(List<FrameTiming> timings) => _onTimings(timings);
 
   /// Aggregates over the retained frame window.
   DevFrameStats frameStats() {

--- a/app/test/devtools_notify_test.dart
+++ b/app/test/devtools_notify_test.dart
@@ -1,6 +1,9 @@
 // The devtools log/timing capture must not let its own notify machinery drive
-// the frames it measures: high-volume perf-trace lines record silently, and
-// nothing schedules a rebuild while the panel is closed.
+// the frames it measures: high-volume perf-trace lines record silently, nothing
+// schedules a rebuild while the panel is closed, and a frame-timings batch never
+// notifies (a panel rebuild is a frame, which would self-sustain - #452).
+import 'dart:ui' show FrameTiming;
+
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -70,5 +73,31 @@ void main() {
     // History is read from the log itself, not pushed through a notify.
     expect(tools.log.map((e) => e.message),
         contains('before the panel opened'));
+  });
+
+  test('a frame-timings batch accumulates the window but does not notify (#452)',
+      () async {
+    var notifies = 0;
+    void listener() => notifies++;
+    tools.addListener(listener);
+    addTearDown(() => tools.removeListener(listener));
+
+    // Even with a listener attached (panel open), the timings callback must not
+    // schedule a rebuild - a rebuild is a frame, which would fire this again.
+    FrameTiming frame(int buildMicros) => FrameTiming(
+          vsyncStart: 0,
+          buildStart: 0,
+          buildFinish: buildMicros,
+          rasterStart: buildMicros,
+          rasterFinish: buildMicros + 1000,
+          rasterFinishWallTime: buildMicros + 1000,
+        );
+
+    tools.debugAddTimings([frame(20000), frame(30000)]);
+    await pumpEventQueue();
+
+    expect(notifies, 0, reason: 'the timings callback must not self-drive');
+    // The window still accumulated, so the stats the 1 s poll reads are fresh.
+    expect(tools.frameStats().frames, 2);
   });
 }

--- a/doc/dev-log/2026-07-25-devtools-idle-jank-452.md
+++ b/doc/dev-log/2026-07-25-devtools-idle-jank-452.md
@@ -1,0 +1,53 @@
+# The idle ~1 Hz jank was the devtools observer loop (#452)
+
+The mobile-web trace showed the app producing janky frames (`build` 25–110 ms)
+roughly twice a second, indefinitely, with the document idle. Ben had already
+root-caused it to a self-sustaining loop in the app's devtools panel and landed
+two of the three fixes; this closes the last edge.
+
+## The loop
+
+`AppDevTools` (a `ChangeNotifier`, `app/lib/devtools.dart`) both records logs and
+watches frame timings. Three notify edges fed the panel:
+
+1. **Perf-sink JANK lines** → `_record(notify: true)`. **Already fixed** — the
+   sink records with `notify: false` (a JANK line per janky frame must not
+   schedule a rebuild).
+2. **Any notify while the panel is closed** → **already fixed** — `_scheduleNotify`
+   returns early unless `hasListeners`.
+3. **`_onTimings`** → `_scheduleNotify()` on *every* frame-timings batch. Still
+   live, and the last self-sustaining edge: a notify rebuilds the panel, a panel
+   rebuild is itself a frame, that frame fires `_onTimings` again → notify →
+   rebuild → … The 250 ms leading-edge throttle paces it, and each rebuild is a
+   25–110 ms build on a throttled phone, so the effective cadence lands at the
+   observed ~1–2 Hz. The measurement was driving the thing it measured.
+
+With the panel *closed*, edge 2 already suppressed all of this - so a normal user
+never saw it. But the export button lives inside the panel, so every exported
+trace was taken with the panel open and the loop running.
+
+## The fix
+
+`_onTimings` no longer notifies. It still accumulates the frame-timing window
+(that's what `frameStats()` reads), but the panel's own 1 s `Timer.periodic` poll
+(`devtools_panel.dart`, already present for cache/RSS/PdfPerf stats that have no
+change notification) is what refreshes the display. So while the panel is open
+and idle, it rebuilds once a second from the timer - a controlled tick, not a
+frame→notify→frame loop - and log entries still notify immediately via `addLog`.
+
+One line removed, plus a `debugAddTimings` test seam and a guard in
+`devtools_notify_test.dart`: a frame-timings batch accumulates the window
+(`frameStats().frames == 2`) but fires zero notifies even with a listener
+attached.
+
+## What this does and doesn't settle
+
+It definitively removes the observer loop, so exported traces (panel open) are now
+trustworthy and the app no longer self-perpetuates frames while idle. What it
+can't settle from here is whether any *real* idle-frame source remains underneath
+- that needs an on-device capture with the panel **closed** via the `?perf=1`
+boot hook (JANK lines go to the browser console, no sink, no panel). With the
+loop gone, such a trace would now attribute cleanly. My expectation: panel-closed
+was already loop-free (edge 2), so a clean `?perf=1` run should be quiet.
+
+Files: `app/lib/devtools.dart`, `app/test/devtools_notify_test.dart`.


### PR DESCRIPTION
Fixes #452.

## The idle jank was the observer
The mobile-web trace showed janky frames (`build` 25–110 ms) ~twice a second, indefinitely, with the document idle. Root cause (Ben's analysis on the issue): a self-sustaining loop in the app's devtools panel. `AppDevTools` (`app/lib/devtools.dart`) had three notify edges into the panel:

1. **Perf-sink JANK lines** → already fixed (`_record(notify: false)`).
2. **Any notify while the panel is closed** → already fixed (`_scheduleNotify` returns early unless `hasListeners`).
3. **`_onTimings` → `_scheduleNotify()` on every frame-timings batch** → the last live edge. A notify rebuilds the panel; a panel rebuild is itself a frame; that frame fires `_onTimings` again → notify → rebuild → … The 250 ms throttle paces it and each rebuild is a 25–110 ms build on a throttled phone, so the effective cadence is the observed ~1–2 Hz. The measurement drove the thing it measured.

The export button lives *inside* the panel, so every exported trace was taken with the panel open and the loop running — which is why it looked like a permanent app-level problem.

## The fix
`_onTimings` no longer notifies — it only accumulates the frame-timing window (`frameStats()` reads it). The panel's own **1 s `Timer.periodic` poll** (already present for cache/RSS/PdfPerf stats that have no change notification) refreshes the display, so an idle open panel ticks once a second instead of looping; log entries still notify immediately via `addLog`. Panel *closed* was already loop-free via the `hasListeners` guard.

Adds a `debugAddTimings` seam and a guard test: a frame-timings batch accumulates the window (`frameStats().frames == 2`) but fires **zero** notifies even with a listener attached. Full app suite + `dart analyze --fatal-infos` clean.

## Verification note
This removes the observer loop, so exported traces are now trustworthy. Whether any *real* idle-frame source remains underneath needs an on-device capture with the panel **closed** via the `?perf=1` boot hook (JANK → browser console, no sink, no panel). Since panel-closed was already loop-free, I expect a clean `?perf=1` run to be quiet — but that confirmation needs a device I don't have here.

See `doc/dev-log/2026-07-25-devtools-idle-jank-452.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho