### PR TITLE
perf(worker): serialize inline ImageMask glyphs so Type3 pages reach the worker (#554)

### DIFF
--- a/doc/dev-log/2026-07-25-inline-stencil-worker-554.md
+++ b/doc/dev-log/2026-07-25-inline-stencil-worker-554.md
@@ -1,0 +1,54 @@
+# Inline ImageMask glyphs serialize — Type3 pages reach the worker (#554)
+
+`serializeCommands` (the wire codec the render worker ships transcripts through)
+declined **any** transcript containing an inline image (`BI .. ID .. EI`), because
+an inline image's `/CS` may name a page-resource colour space unreachable from the
+stream alone. Correct for colour inline images — but a TeX-era Type3 bitmap
+document is almost entirely **inline ImageMask** glyphs, so those pages declined
+the worker wholesale and interpreted + serialized + painted on the UI thread.
+
+## Why a stencil is safe
+
+An `/ImageMask true` inline image has **no colour space** — its paint is the
+stencil colour carried on the `PdfImageRequest` (`stencilColor`, from the graphics
+state's fill colour at draw time). The interpreter builds its request stream from
+the inline dict + inline bytes literally (`_drawInlineImage`), and a stencil dict
+carries only direct values (`/W /H /IM /BPC /F /D`) — no indirect refs, no `/CS`.
+So the stream is fully self-contained. And XObject ImageMasks already serialize
+through the exact same else-branch (`_inlineCos` + optional decode + `_writeImageCommand`,
+which already writes `isStencil`/`stencilColor`); the only thing blocking the
+inline ones was the `request.isInline` decline.
+
+## The change
+
+One condition, in `render_command_codec.dart`:
+
+```dart
+final declineInline = request.isInline && !request.isStencil;
+if (declineInline || cos == null) { … decline … }
+```
+
+Colour inline images still decline (kept the `_inlineImagePdf` `/CS /RGB` test
+green); stencil inline images now take the proven stencil path. Verified on the
+fixture: `type3-text-6p.pdf` went from **0 → 6 of 6 pages serialized** (17,424
+inline stencil glyphs across the doc that previously forced every page on-thread).
+
+Tests (`render_command_codec_test.dart`): an inline ImageMask serializes (not
+null), round-trips with `isStencil`/`isInline`/`stencilColor` intact, and also
+decodes off-thread (`decodeImages: true` embeds the mask). The existing
+colour-inline-declines test is unchanged.
+
+## Bundle note
+
+Unlike #530 (which touched only `render_worker_isolate.dart`, tree-shaken out of
+the web build), this changes shared `pdf_graphics` code reachable from the web
+worker entry, so the checked-in `pdf_render_worker.dart.js` bundle is stale and
+**rebuilt here** (`dart run dart_pdf_editor:build_web_worker`). With the #422/#571
+`WORKER_REGEN_TOKEN` still unset, CI's `worker-bundle` job verifies-and-fails, so
+the bundle had to ship in the PR rather than being auto-regenerated. If CI's
+rebuild disagrees byte-for-byte (the cross-runner nondeterminism #422 flagged),
+that job will fail and needs the token — or a fresh local rebuild taken from CI.
+
+Files: `packages/pdf_graphics/lib/src/render_command_codec.dart`,
+`packages/pdf_graphics/test/render_command_codec_test.dart`,
+`packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js` (regenerated).

--- a/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
+++ b/packages/dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
@@ -9621,7 +9621,7 @@ A.yW(c1,a0)
 break A}s=null
 a=c2 instanceof A.bf
 if(a)s=c2.a
-if(a){if(s.c||c3==null){if(!c7)throw A.d(B.aT)
+if(a){if(s.c&&!s.f||c3==null){if(!c7)throw A.d(B.aT)
 A.t8(c1,s,$.q5(),c0)}else{r=c3
 q=null
 if(c5)q=A.xS(r,s,c8,c4,c6)

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -40,11 +40,13 @@ import 'shading.dart';
 /// interpret synchronously on the UI thread.
 ///
 /// Two cases still decline (the buffer serializes to `null`, and the caller
-/// renders the page on the owning isolate): an INLINE image (`BI .. ID .. EI`),
-/// whose `/CS` may name a page-resource colour space that isn't reachable from
-/// the stream alone; and any image when no `cos` is supplied. Image-free pages
-/// - the dense vector/text pages that also dominate the interpret cost -
-/// serialize regardless.
+/// renders the page on the owning isolate): a COLOUR inline image
+/// (`BI .. ID .. EI`), whose `/CS` may name a page-resource colour space that
+/// isn't reachable from the stream alone; and any image when no `cos` is
+/// supplied. An ImageMask (stencil) inline image has no colour space and
+/// serializes fine (#554), so Type3 bitmap-glyph pages reach the worker.
+/// Image-free pages - the dense vector/text pages that also dominate the
+/// interpret cost - serialize regardless.
 ///
 /// Format: little notion of versioning beyond a leading byte; the producer and
 /// consumer are the same build, shipped together, so a version mismatch is a
@@ -464,12 +466,17 @@ void _writeCommand(_Writer w, PdfRenderCommand command, CosDocument? cos,
       w.u8(_tDrawText);
       _writeTextRun(w, run);
     case PdfDrawImageCommand(:final request):
-      // Inline images can name a page-resource colour space unreachable from
-      // the stream alone; decline them. XObjects serialize as a self-contained
-      // (inline-resolved, decrypted) stream subgraph - any failure inlining or
-      // decrypting it declines too, so the page falls back to a local render
-      // rather than shipping a broken image.
-      if (request.isInline || cos == null) {
+      // A COLOUR inline image can name a page-resource colour space unreachable
+      // from the stream alone; decline it. An ImageMask (stencil) inline image
+      // has no colour space - its paint is the stencil colour on the request -
+      // so its stream is fully self-contained and serializes like any other
+      // stencil (XObject ImageMasks already take the else branch). This is what
+      // lets Type3 bitmap-glyph pages reach the worker (#554). XObjects serialize
+      // as a self-contained (inline-resolved, decrypted) stream subgraph - any
+      // failure inlining or decrypting it declines too, so the page falls back
+      // to a local render rather than shipping a broken image.
+      final declineInline = request.isInline && !request.isStencil;
+      if (declineInline || cos == null) {
         if (!imagePlaceholders) throw const _UnserializableImage();
         _writeImageCommand(w, request, _imagePlaceholderStream, null);
       } else {

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -385,6 +385,46 @@ void main() {
     expect(_imageCommands(restored).single.request.decoded, isNull);
   });
 
+  test('an inline ImageMask (stencil) serializes - Type3 pages reach the '
+      'worker (#554)', () {
+    final doc = PdfDocument.open(_inlineStencilPdf());
+    final page = doc.page(0);
+    final ops = ContentStreamParser.parse(page.contentBytes());
+    final recorder = RecordingPdfDevice();
+    PdfInterpreter(cos: doc.cos, device: recorder).drawPageOperations(page, ops);
+    final request = recorder.imageRequests.single;
+    expect(request.isInline, isTrue);
+    expect(request.isStencil, isTrue);
+
+    // Unlike a colour inline image, a stencil has no /CS to resolve, so it does
+    // NOT decline - the whole point of #554 (Type3 bitmap-glyph pages).
+    final bytes = serializeCommands(recorder.commands, cos: doc.cos);
+    expect(bytes, isNotNull,
+        reason: 'a self-contained stencil inline image must not decline');
+
+    final restored = _imageCommands(deserializeCommands(bytes!)).single.request;
+    expect(restored.isStencil, isTrue);
+    expect(restored.isInline, isTrue);
+    expect(restored.stencilColor, request.stencilColor,
+        reason: 'the stencil paint colour round-trips');
+  });
+
+  test('the stencil inline image also decodes off-thread (#554)', () {
+    final doc = PdfDocument.open(_inlineStencilPdf());
+    final page = doc.page(0);
+    final ops = ContentStreamParser.parse(page.contentBytes());
+    final recorder = RecordingPdfDevice();
+    PdfInterpreter(cos: doc.cos, device: recorder).drawPageOperations(page, ops);
+
+    final bytes = serializeCommands(recorder.commands,
+        cos: doc.cos, decodeImages: true);
+    expect(bytes, isNotNull);
+    final restored = _imageCommands(deserializeCommands(bytes!)).single.request;
+    expect(restored.isStencil, isTrue);
+    expect(restored.decoded, isNotNull,
+        reason: 'the worker embeds the decoded stencil mask');
+  });
+
   // The worker path: serializeCommands(decodeImages: true) decodes each image
   // off-thread and embeds the premultiplied RGBA, so the reconstructed request
   // carries pixels that match the pure-Dart decode - and the replay transcript
@@ -838,13 +878,20 @@ List<PdfDrawImageCommand> _imageCommands(List<PdfRenderCommand> commands) {
 }
 
 /// A one-page PDF whose only content is a 4x4 inline image (BI .. ID .. EI).
-Uint8List _inlineImagePdf() {
-  const content = 'q 100 0 0 100 50 50 cm '
-      'BI /W 4 /H 4 /CS /RGB /BPC 8 /F /AHx ID\n'
-      'e63030 ffffff e63030 ffffff\n'
-      'ffffff e63030 ffffff e63030\n'
-      'e63030 ffffff e63030 ffffff\n'
-      'ffffff e63030 ffffff e63030 >\nEI Q\n';
+Uint8List _inlineImagePdf() => _inlinePdf('q 100 0 0 100 50 50 cm '
+    'BI /W 4 /H 4 /CS /RGB /BPC 8 /F /AHx ID\n'
+    'e63030 ffffff e63030 ffffff\n'
+    'ffffff e63030 ffffff e63030\n'
+    'e63030 ffffff e63030 ffffff\n'
+    'ffffff e63030 ffffff e63030 >\nEI Q\n');
+
+// A 4x4 1-bit ImageMask (stencil) inline image painted in blue. No /CS, so its
+// stream is self-contained (#554).
+Uint8List _inlineStencilPdf() => _inlinePdf('q 0 0 1 rg 100 0 0 100 50 50 cm '
+    'BI /W 4 /H 4 /IM true /BPC 1 /F /AHx ID\n'
+    'f0f0f0f0 >\nEI Q\n');
+
+Uint8List _inlinePdf(String content) {
   final objects = <String>[
     '<< /Type /Catalog /Pages 2 0 R >>',
     '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',


### PR DESCRIPTION
Fixes #554.

## Problem
`serializeCommands` (the wire codec the render worker ships transcripts through) declined **any** transcript containing an inline image (`BI .. ID .. EI`) — an inline image's `/CS` may name a page-resource colour space unreachable from the stream alone. Correct for colour inline images, but a TeX-era **Type3 bitmap document is almost entirely inline `ImageMask` glyphs**, so those pages declined the worker wholesale and interpreted + serialized + painted on the UI thread.

## Why a stencil is safe
An `/ImageMask true` inline image has **no colour space** — its paint is the stencil colour carried on the `PdfImageRequest` (`stencilColor`). The interpreter builds the request stream from the inline dict + bytes literally, and a stencil dict has only direct values (`/W /H /IM /BPC /F /D`) — no indirect refs, no `/CS`. So the stream is self-contained. XObject `ImageMask`s already serialize through the exact same else-branch (which already writes `isStencil`/`stencilColor`); only the `request.isInline` decline blocked the inline ones.

## Change
One condition:
```dart
final declineInline = request.isInline && !request.isStencil;
if (declineInline || cos == null) { … decline … }
```
Colour inline images still decline; stencil inline images take the proven stencil path.

**Verified on the fixture:** `type3-text-6p.pdf` goes from **0 → 6 of 6 pages serialized** (17,424 inline stencil glyphs across the doc that previously forced every page on-thread).

## Tests
New `render_command_codec_test.dart` cases: an inline `ImageMask` serializes (not null), round-trips with `isStencil`/`isInline`/`stencilColor` intact, and decodes off-thread (`decodeImages: true` embeds the mask). The existing colour-inline (`/CS /RGB`) declines test is unchanged. Full pdf_graphics suite (923) + `analyze --fatal-infos` clean.

## ⚠️ Bundle
Unlike #530 (isolate-only, tree-shaken out of the web build), this changes shared `pdf_graphics` code reachable from the web worker entry, so the checked-in `pdf_render_worker.dart.js` is stale and **rebuilt in this PR**. With the #422/#571 `WORKER_REGEN_TOKEN` still unset, CI's `worker-bundle` job can't auto-regen — it verifies-and-fails. The rebuilt bundle should satisfy it, **but if CI's rebuild disagrees byte-for-byte** (the cross-runner nondeterminism #422 flagged), that job will fail and needs the token (or a rebuild taken from CI). Setting `WORKER_REGEN_TOKEN` removes this friction for good.

See `doc/dev-log/2026-07-25-inline-stencil-worker-554.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho