### PR TITLE
feat(editor): show the tune button on the mobile toolbar

### DIFF
--- a/doc/dev-log/2026-07-25-mobile-tune-button.md
+++ b/doc/dev-log/2026-07-25-mobile-tune-button.md
@@ -1,0 +1,30 @@
+# 2026-07-25 - Tune button on the mobile toolbar
+
+The wide desktop editing strip has always carried the "tune" trigger (the
+`Icons.tune` gear that opens `_StyleMenu` - stroke width / opacity / font
+sliders, line endings, box colours) via `_tuneTrailing`. The collapsed
+mobile dock (`_buildMobile`, under `PdfEditingToolbar.mobileBreakpoint`)
+never did: its trailing cluster (`_mobileTrailing`) only ever offered the
+first three palette swatches for a colour-using tool, or a selection's
+quick actions. So on a phone the sliders were unreachable while drawing.
+
+Fix: `_mobileTrailing` now appends `_mobileTuneTrailing(context)`, which
+resolves the armed tool's group (`_groupForTool(controller.tool)`) and
+reuses the same `_tuneTrailing(context, _groupStyleFields(group))` the
+desktop strip uses - one code path, so the popup's contents track each
+tool's `PdfEditToolBehavior.styleFields` exactly as before (a rectangle
+never offers a font picker, ink never offers line endings, etc.). No armed
+tool, or a tool whose behaviour exposes nothing to tune, yields an empty
+list and no gear.
+
+The dock is width-constrained, so swatches + the gear overflowed the 380px
+test dock by 15px. Since the tune popup already carries the full palette,
+`_mobileSwatches` gained a `count` and the colour-tool branch now shows two
+quick swatches beside the gear (three when there's no gear). That keeps the
+whole cluster - undo/redo, tool label, swatches, tune, Tools handle -
+inside a narrow phone dock.
+
+Tests: `editing_mobile_tune_test.dart` (gear absent at rest, present once a
+stroke tool is armed, opens the sliders); the existing
+`editing_mobile_toolbar_test.dart` swatch/selection assertions still hold
+(they only check swatch-0).

--- a/doc/dev-log/2026-07-25-mobile-tune-button.md
+++ b/doc/dev-log/2026-07-25-mobile-tune-button.md
@@ -24,7 +24,16 @@ quick swatches beside the gear (three when there's no gear). That keeps the
 whole cluster - undo/redo, tool label, swatches, tune, Tools handle -
 inside a narrow phone dock.
 
+A selected annotation gets it too: the dock's `hasAnnotationSelection`
+branch (delete + optional edit-text) now appends
+`_tuneTrailing(context, _selectionStyleFields())` - the same builder the
+desktop selection strip uses - so a selected shape/free-text can be
+restyled (stroke/opacity/font/colour) from the phone dock. Form-field
+selections already carried a style entry via their "more" sheet
+(`pdf-selected-form-style`), so that path is unchanged.
+
 Tests: `editing_mobile_tune_test.dart` (gear absent at rest, present once a
-stroke tool is armed, opens the sliders); the existing
+stroke tool is armed, present for a selected annotation, opens the sliders
+in both cases with no dock overflow); the existing
 `editing_mobile_toolbar_test.dart` swatch/selection assertions still hold
 (they only check swatch-0).

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -2256,6 +2256,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             visualDensity: VisualDensity.compact,
             onPressed: () => _editSelectedText(context),
           ),
+        // the tune popup restyles the selection (stroke/opacity/font/colour) -
+        // reachable from the dock, mirroring the desktop selection strip
+        ..._tuneTrailing(context, _selectionStyleFields()),
       ];
     }
     if (controller.selectedElement != null) {

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -2320,18 +2320,32 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
           ),
       ];
     }
+    final tune = _mobileTuneTrailing(context);
     if (widget.showColor && controller.toolUsesColor) {
-      return _mobileSwatches(context);
+      // The tune popup carries the full palette, so a couple of quick swatches
+      // beside it are enough - and dropping the third keeps the whole cluster
+      // (swatches + tune) inside the narrow dock without overflowing.
+      return [..._mobileSwatches(context, count: tune.isEmpty ? 3 : 2), ...tune];
     }
-    return const [];
+    return tune;
   }
 
-  /// The first three palette swatches, sized for the mobile dock.
-  List<Widget> _mobileSwatches(BuildContext context) {
+  /// The tune popup trigger for the mobile dock's armed tool, or empty when
+  /// no tool is armed or its controls carry nothing to tune. Mirrors the
+  /// desktop strip's [_tuneTrailing] so the same stroke/opacity/font sliders
+  /// are one tap away on a phone.
+  List<Widget> _mobileTuneTrailing(BuildContext context) {
+    final group = _groupForTool(controller.tool);
+    if (group == null) return const [];
+    return _tuneTrailing(context, _groupStyleFields(group));
+  }
+
+  /// The first [count] palette swatches, sized for the mobile dock.
+  List<Widget> _mobileSwatches(BuildContext context, {int count = 3}) {
     final scheme = Theme.of(context).colorScheme;
     var i = 0;
     return [
-      for (final color in widget.palette.take(3))
+      for (final color in widget.palette.take(count))
         Padding(
           key: ValueKey('pdf-mobile-swatch-${i++}'),
           padding: const EdgeInsets.symmetric(horizontal: 3),

--- a/packages/dart_pdf_editor/test/editing_mobile_tune_test.dart
+++ b/packages/dart_pdf_editor/test/editing_mobile_tune_test.dart
@@ -1,6 +1,7 @@
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -48,6 +49,28 @@ void main() {
     expect(find.byIcon(Icons.tune), findsOneWidget);
 
     // and it opens the style popup's stroke/opacity sliders
+    await tester.tap(find.byIcon(Icons.tune));
+    await tester.pumpAndSettle();
+    expect(find.byType(Slider), findsWidgets);
+  });
+
+  testWidgets('the mobile dock shows the tune button for a selected annotation',
+      (tester) async {
+    final (editing, _) = await pumpMobileToolbar(tester);
+
+    // draw a shape and select it - the dock now carries delete + tune
+    editing.addEllipse(0, const PdfRect(100, 600, 300, 700));
+    await tester.pump();
+    expect(editing.selectAnnotation(0, 0), isTrue);
+    await tester.pump();
+
+    expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+    expect(find.byIcon(Icons.tune), findsOneWidget,
+        reason: 'a selected annotation can be restyled from the dock');
+    expect(tester.takeException(), isNull,
+        reason: 'the selection actions + tune fit the narrow dock');
+
+    // the popup restyles the selection
     await tester.tap(find.byIcon(Icons.tune));
     await tester.pumpAndSettle();
     expect(find.byType(Slider), findsWidgets);

--- a/packages/dart_pdf_editor/test/editing_mobile_tune_test.dart
+++ b/packages/dart_pdf_editor/test/editing_mobile_tune_test.dart
@@ -1,0 +1,55 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// The tune popup trigger must be reachable from the collapsed mobile dock,
+/// not just the wide desktop strip. It appears once a tool with tune-able
+/// controls is armed and opens the same stroke/opacity sliders.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<(PdfEditingController, PdfViewerController)> pumpMobileToolbar(
+      WidgetTester tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(1));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.bottomCenter,
+          child: SizedBox(
+            // below PdfEditingToolbar.mobileBreakpoint (600) -> collapsed dock
+            width: 380,
+            child: PdfEditingToolbar(
+              controller: editing,
+              viewerController: viewer,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return (editing, viewer);
+  }
+
+  testWidgets('the mobile dock shows the tune button for an armed draw tool',
+      (tester) async {
+    final (editing, _) = await pumpMobileToolbar(tester);
+
+    // no tool armed: nothing to tune, no gear icon
+    expect(find.byIcon(Icons.tune), findsNothing);
+
+    // arm a stroke-using tool (freehand ink) - the tune trigger appears
+    editing.tool = PdfEditTool.ink;
+    await tester.pump();
+    expect(find.byIcon(Icons.tune), findsOneWidget);
+
+    // and it opens the style popup's stroke/opacity sliders
+    await tester.tap(find.byIcon(Icons.tune));
+    await tester.pumpAndSettle();
+    expect(find.byType(Slider), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary

The wide desktop editing strip has always carried the **tune** trigger (the `Icons.tune` gear that opens the style popup — stroke width / opacity / font sliders, line endings, box colours). The collapsed **mobile dock** (`_buildMobile`, under `PdfEditingToolbar.mobileBreakpoint`) never did: its trailing cluster only offered a colour tool's palette swatches or a selection's quick actions, so on a phone the style sliders were unreachable while drawing.

This adds the tune button to the mobile dock. `_mobileTrailing` now appends `_mobileTuneTrailing(context)`, which resolves the armed tool's group (`_groupForTool(controller.tool)`) and reuses the same `_tuneTrailing(context, _groupStyleFields(group))` code path as the desktop strip — one path, so the popup's contents track each tool's `PdfEditToolBehavior.styleFields` exactly as before (a rectangle never offers a font picker, ink never offers line endings, and so on). No armed tool, or a tool that exposes nothing to tune, yields no gear.

The dock is width-constrained, so swatches + the gear overflowed the narrow dock. Since the tune popup already carries the full palette, `_mobileSwatches` gained a `count` and the colour-tool branch shows two quick swatches beside the gear (three when there's no gear), keeping the whole cluster inside a narrow phone dock.

## Affected packages

- [x] `dart_pdf_editor`

## Change type

- [x] Editing behavior change

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`

Ran the editing suites touching the toolbar (`editing_mobile_tune_test.dart`, `editing_mobile_toolbar_test.dart`, `editing_test.dart`, `editing_tune_focus_test.dart`, `editing_takeoff_test.dart`, `editing_chrome_test.dart`, shape/form style). Corpus/render checks not applicable — no rendering or parser change.

## PDF fixtures and screenshots

New widget test `editing_mobile_tune_test.dart`: the gear is absent at rest, appears once a stroke tool is armed, and opens the style popup's sliders. Existing mobile-toolbar swatch/selection assertions still hold.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved.
- [x] Test fixtures use builders/programmatic generation.

## Notes for reviewers

UI-only change confined to the mobile dock layout; the desktop strip is untouched and the two share the tune-building code. Dev-log note added at `doc/dev-log/2026-07-25-mobile-tune-button.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015k3mEVfjjdjdvLG3ZmD9mW)_