### PR TITLE
feat(editor): lossless file-size compaction on save (#368)

### DIFF
--- a/doc/dev-log/2026-07-25-compress-lossless-368.md
+++ b/doc/dev-log/2026-07-25-compress-lossless-368.md
@@ -1,0 +1,85 @@
+# Lossless file-size compaction on save (#368, layer 1)
+
+## What
+
+`PdfEditor.compress()` rewrites the document into a fresh, smaller PDF and
+returns a `PdfCompressionResult` (before/after bytes, object counts, streams
+re-deflated, a `compacted` flag). It is the first of #368's independently
+shippable layers - the **lossless structural pass**. Image recompression,
+font subsetting, and cross-page dedup remain as separate follow-ups.
+
+The pass does three lossless things:
+
+1. **Reachability GC.** A whole-graph copy from the catalog (and `/Info`)
+   into a `CosDocumentBuilder` drops every object the tree no longer
+   references. Incremental edits accumulate dead objects - each revision
+   appends and supersedes - so a live editing session bloats the file
+   steadily. Compaction reclaims all of it.
+2. **Object-stream + xref-stream packing.** The builder gained a
+   `objectStreams: true` mode: non-stream objects pack into compressed
+   `/ObjStm` objects (128 per stream) addressed by a PDF 1.5 xref stream;
+   streams and the xref stream itself stay top-level. This is what makes the
+   rewrite a *win* on modern files rather than a loss - re-emitting a
+   1.5-era file as classic uncompressed objects would inflate it.
+3. **Re-deflate of uncompressed streams.** A stream stored with no
+   compression filter is deflated at level 9 and kept only when that
+   actually shrinks it. `FlateDecode` of the result reproduces the stored
+   bytes exactly, so decoded content is untouched.
+
+## Where
+
+- `pdf_cos/src/builder.dart` - `build(objectStreams:, deflateLevel:)`; the
+  classic table split out to `_buildClassic`, the new `_buildCompressed`
+  writes object streams + an xref stream (W `[1 4 2]`).
+- `pdf_cos/src/compactor.dart` (new) - `CosCompactor` + `CosCompactionResult`.
+  `_GraphCopier` is a boundary-free twin of page extraction's `_PageImporter`
+  (follows every reference; a dead object is simply never visited).
+- `pdf_document/src/editor.dart` - `PdfEditor.compress()` +
+  `PdfCompressionResult`, with the never-larger gate and pending-edit
+  inclusion.
+
+## Design calls
+
+- **From-scratch output, no `/Prev`.** Compaction is a rewrite, so it does
+  not preserve prior-revision history and it invalidates existing
+  signatures. That is inherent (you cannot shrink a file and keep its byte
+  prefix), which is why this is an explicit action, never part of `save()`.
+- **Encrypted documents are refused.** A faithful rewrite would have to
+  re-encrypt (out of scope) or silently drop encryption; the caller is told
+  to decrypt first. Same posture as "signing encrypted files is refused".
+- **Never larger than the input.** `compress()` compares the compacted
+  bytes to the current file and returns the smaller, with `compacted:false`
+  when it kept the original (already-objstm files, tiny files where framing
+  dominates). So it is always safe to call.
+- **Pending edits included.** With unsaved changes it compacts the applied
+  snapshot (`open(save())`); with none it compacts the live document
+  directly (no reopen).
+- **Number identity is not preserved.** Objects renumber densely from 1;
+  callers must not assume a compacted object keeps its old number.
+
+## Measured
+
+Round-tripped every `test_corpora` PDF (226 openable, unencrypted): **0
+page-count mismatches**, 3.0% aggregate saving. The aggregate is dragged
+down by already-compressed image/JPEG suites; the mechanism's reach shows
+per group and per file:
+
+| corpus | before | after | saved |
+|---|---|---|---|
+| pdfjs | 2933K | 2015K | **31.3%** |
+| ghent | 104.9M | 102.4M | 2.4% (image-dominated) |
+| dartpdf | 7453K | 7394K | 0.8% (already optimized) |
+
+Individual uncompressed-stream files: `calrgb.pdf` 315K -> 19K (93.9%),
+`colorkeymask.pdf` 158K -> 2K (98.7%).
+
+The headline case is the editor's own output. A 12-page file through 40
+incremental annotation edits bloats **8.8x** (3.4K -> 29.9K); compaction
+returns it to 9.7K (**67.6% off**) with all 40 annotations intact.
+
+## Follow-ups (open #368 checkboxes)
+
+Image downsample/recompress (opt-in lossy), embedded-font subsetting,
+identical-resource dedup, and the app's "Reduce file size…" action with
+ghostscript-style presets. Each layers on top of this pass without changing
+it.

--- a/packages/pdf_cos/lib/pdf_cos.dart
+++ b/packages/pdf_cos/lib/pdf_cos.dart
@@ -4,6 +4,7 @@ library;
 
 export 'src/builder.dart';
 export 'src/byte_source.dart';
+export 'src/compactor.dart';
 export 'src/content_parser.dart';
 export 'src/crypto/aes.dart';
 export 'src/crypto/asn1.dart';

--- a/packages/pdf_cos/lib/src/builder.dart
+++ b/packages/pdf_cos/lib/src/builder.dart
@@ -1,5 +1,7 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:archive/archive.dart';
 import 'package:crypto/crypto.dart' show md5;
 
 import 'objects.dart';
@@ -24,16 +26,27 @@ class CosDocumentBuilder {
     return CosReference(_objects.length, 0);
   }
 
-  /// Serializes the file: header, object bodies, a classic cross-reference
-  /// table, and the trailer. [root] must reference the document catalog.
+  /// Serializes the file: header, object bodies, a cross-reference section,
+  /// and the trailer. [root] must reference the document catalog.
+  ///
+  /// With [objectStreams] the non-stream objects are packed into compressed
+  /// object streams and the cross-reference is written as a PDF 1.5 xref
+  /// stream (§7.5.7-7.5.8) - much smaller for object-heavy documents.
+  /// [deflateLevel] (0-9) sets the object-stream and xref-stream compression
+  /// level; it is ignored for the classic table.
   Uint8List build({
     required CosReference root,
     CosReference? info,
     String version = '1.7',
+    bool objectStreams = false,
+    int deflateLevel = 6,
   }) {
     final t0 = PdfPerf.begin();
     try {
-      final built = _buildTimed(root: root, info: info, version: version);
+      final built = objectStreams
+          ? _buildCompressed(
+              root: root, info: info, version: version, level: deflateLevel)
+          : _buildClassic(root: root, info: info, version: version);
       PdfPerf.add(PdfPerfCount.savedBytes, built.length);
       PdfPerf.add(PdfPerfCount.savedObjects, _objects.length);
       return built;
@@ -42,15 +55,13 @@ class CosDocumentBuilder {
     }
   }
 
-  Uint8List _buildTimed({
+  Uint8List _buildClassic({
     required CosReference root,
     CosReference? info,
     String version = '1.7',
   }) {
     final out = BytesBuilder(copy: false);
-    _writeText(out, '%PDF-$version\n');
-    // a comment with bytes ≥ 128 so transports treat the file as binary
-    out.add(const [0x25, 0xE2, 0xE3, 0xCF, 0xD3, 0x0A]);
+    _writeHeader(out, version);
 
     final serializer = CosSerializer(out);
     final offsets = <int>[];
@@ -82,6 +93,170 @@ class CosDocumentBuilder {
     tail.writeTrailer(trailer);
     tail.writeEpilogue(xrefOffset);
     return out.takeBytes();
+  }
+
+  /// Object-stream + xref-stream output (PDF 1.5). Streams and the
+  /// cross-reference stream itself stay as top-level indirect objects
+  /// (type-1 xref entries); every other object is packed into a compressed
+  /// `/ObjStm` and addressed by a type-2 entry. Object numbers 1..N keep
+  /// their registration identity; the object streams and the xref stream
+  /// take the numbers above N.
+  Uint8List _buildCompressed({
+    required CosReference root,
+    CosReference? info,
+    required String version,
+    required int level,
+  }) {
+    // Object streams need a 1.5-era header even if the caller asked lower.
+    final out = BytesBuilder(copy: false);
+    _writeHeader(out, _atLeast15(version));
+    final serializer = CosSerializer(out);
+
+    final n = _objects.length;
+    final offsets = <int, int>{}; // type-1: object number -> byte offset
+    final compressed = <int, List<int>>{}; // type-2: number -> [objStm, index]
+
+    // Everything that is not a stream packs into object streams.
+    final packable = <int>[
+      for (var i = 0; i < n; i++)
+        if (_objects[i] is! CosStream) i + 1,
+    ];
+
+    var nextNumber = n + 1;
+    // Keep each object stream to a bounded member count so the per-stream
+    // header stays small and a corrupt one costs little.
+    const perStream = 128;
+    for (var start = 0; start < packable.length; start += perStream) {
+      final members =
+          packable.sublist(start, math.min(start + perStream, packable.length));
+      final streamNumber = nextNumber++;
+
+      final bodies = BytesBuilder();
+      final bodyOffsets = <int>[];
+      for (final number in members) {
+        bodyOffsets.add(bodies.length);
+        bodies.add(CosSerializer.serialize(_objects[number - 1]));
+        bodies.addByte(0x0A); // whitespace separator between bodies
+      }
+      final headerText = StringBuffer();
+      for (var j = 0; j < members.length; j++) {
+        headerText.write('${members[j]} ${bodyOffsets[j]} ');
+      }
+      final headerBytes = Uint8List.fromList(headerText.toString().codeUnits);
+      final first = headerBytes.length;
+      final plain = (BytesBuilder(copy: false)
+            ..add(headerBytes)
+            ..add(bodies.takeBytes()))
+          .takeBytes();
+      final payload = Uint8List.fromList(
+          const ZLibEncoder().encodeBytes(plain, level: level));
+
+      for (var j = 0; j < members.length; j++) {
+        compressed[members[j]] = [streamNumber, j];
+      }
+      offsets[streamNumber] = out.length;
+      serializer.writeIndirectObject(CosIndirectObject(
+        streamNumber,
+        0,
+        CosStream(
+          CosDictionary({
+            'Type': const CosName('ObjStm'),
+            'N': CosInteger(members.length),
+            'First': CosInteger(first),
+            'Filter': const CosName('FlateDecode'),
+            'Length': CosInteger(payload.length),
+          }),
+          payload,
+        ),
+      ));
+    }
+
+    // Stream objects stay uncompressed and top-level.
+    for (var i = 0; i < n; i++) {
+      if (_objects[i] is CosStream) {
+        offsets[i + 1] = out.length;
+        serializer.writeIndirectObject(CosIndirectObject(i + 1, 0, _objects[i]));
+      }
+    }
+
+    // The cross-reference stream lists itself, so it takes the next number
+    // and its own offset is known before it is written.
+    final xrefNumber = nextNumber++;
+    final xrefOffset = out.length;
+    offsets[xrefNumber] = xrefOffset;
+    final size = nextNumber; // one past the highest number (object 0..xref)
+
+    final id = Uint8List.fromList(md5.convert(out.toBytes()).bytes);
+    final data = BytesBuilder();
+    for (var number = 0; number < size; number++) {
+      if (number == 0) {
+        _xrefEntry(data, 0, 0, 0xFFFF); // free-list head
+      } else if (compressed.containsKey(number)) {
+        final loc = compressed[number]!;
+        _xrefEntry(data, 2, loc[0], loc[1]);
+      } else {
+        _xrefEntry(data, 1, offsets[number]!, 0);
+      }
+    }
+    final xrefPayload = Uint8List.fromList(
+        const ZLibEncoder().encodeBytes(data.takeBytes(), level: level));
+
+    serializer.writeIndirectObject(CosIndirectObject(
+      xrefNumber,
+      0,
+      CosStream(
+        CosDictionary({
+          'Type': const CosName('XRef'),
+          'Size': CosInteger(size),
+          'Root': root,
+          if (info != null) 'Info': info,
+          'W': CosArray(const [
+            CosInteger(1),
+            CosInteger(4),
+            CosInteger(2),
+          ]),
+          'Index': CosArray([const CosInteger(0), CosInteger(size)]),
+          'Filter': const CosName('FlateDecode'),
+          'Length': CosInteger(xrefPayload.length),
+          'ID': CosArray([
+            CosString(id, isHex: true),
+            CosString(id, isHex: true),
+          ]),
+        }),
+        xrefPayload,
+      ),
+    ));
+
+    _writeText(out, 'startxref\n$xrefOffset\n%%EOF\n');
+    return out.takeBytes();
+  }
+
+  /// Writes one `W [1 4 2]` cross-reference-stream entry: a one-byte type,
+  /// a four-byte second field, and a two-byte third field, all big-endian.
+  static void _xrefEntry(BytesBuilder out, int type, int field2, int field3) {
+    out
+      ..addByte(type)
+      ..addByte((field2 >> 24) & 0xFF)
+      ..addByte((field2 >> 16) & 0xFF)
+      ..addByte((field2 >> 8) & 0xFF)
+      ..addByte(field2 & 0xFF)
+      ..addByte((field3 >> 8) & 0xFF)
+      ..addByte(field3 & 0xFF);
+  }
+
+  static String _atLeast15(String version) {
+    final match = RegExp(r'^(\d+)\.(\d+)$').firstMatch(version);
+    if (match == null) return '1.7';
+    final major = int.parse(match.group(1)!);
+    final minor = int.parse(match.group(2)!);
+    if (major > 1 || (major == 1 && minor >= 5)) return version;
+    return '1.5';
+  }
+
+  static void _writeHeader(BytesBuilder out, String version) {
+    _writeText(out, '%PDF-$version\n');
+    // a comment with bytes ≥ 128 so transports treat the file as binary
+    out.add(const [0x25, 0xE2, 0xE3, 0xCF, 0xD3, 0x0A]);
   }
 
   static void _writeText(BytesBuilder out, String text) =>

--- a/packages/pdf_cos/lib/src/compactor.dart
+++ b/packages/pdf_cos/lib/src/compactor.dart
@@ -189,6 +189,10 @@ class _GraphCopier {
     if (ref != null) objectsWritten++;
     srcDict.entries.forEach((key, item) {
       if (key == 'Length') return; // recomputed below
+      // When we impose FlateDecode, drop any decode params the (unfiltered)
+      // source carried: a stray /DecodeParms would otherwise be paired with
+      // our fresh deflate output and mis-applied by the reader.
+      if (addFlate && (key == 'DecodeParms' || key == 'DP')) return;
       out.dictionary[key] = copyValue(item);
     });
     if (addFlate) out.dictionary['Filter'] = const CosName('FlateDecode');

--- a/packages/pdf_cos/lib/src/compactor.dart
+++ b/packages/pdf_cos/lib/src/compactor.dart
@@ -1,0 +1,208 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+
+import 'builder.dart';
+import 'document.dart';
+import 'objects.dart';
+
+/// The outcome of a [CosCompactor] run: the rewritten bytes plus a small
+/// before/after accounting so hosts can report "saved N%".
+class CosCompactionResult {
+  const CosCompactionResult({
+    required this.bytes,
+    required this.bytesBefore,
+    required this.objectsBefore,
+    required this.objectsAfter,
+    required this.streamsDeflated,
+  });
+
+  /// The compacted file.
+  final Uint8List bytes;
+
+  /// Length of the source document's bytes.
+  final int bytesBefore;
+
+  /// Number of object slots the source cross-reference declared.
+  final int objectsBefore;
+
+  /// Number of live objects written to the compacted file (excludes the
+  /// object streams and cross-reference stream the writer synthesises).
+  final int objectsAfter;
+
+  /// Number of previously uncompressed streams re-deflated by this pass.
+  final int streamsDeflated;
+
+  int get bytesAfter => bytes.length;
+
+  /// Fraction of the original size removed, in `[0, 1)`; 0 when the source
+  /// was empty.
+  double get ratio =>
+      bytesBefore == 0 ? 0 : (bytesBefore - bytesAfter) / bytesBefore;
+}
+
+/// Rewrites a [CosDocument] into a fresh, compacted PDF - the lossless
+/// structural pass of the file-size optimiser (#368).
+///
+/// The pass is lossless for rendered output: only objects reachable from the
+/// catalog (and `/Info`) survive, so the dead copies that incremental updates
+/// accumulate across revisions are dropped; the non-stream objects are packed
+/// into compressed object streams and addressed by a PDF 1.5 xref stream; and
+/// streams that were stored with no compression filter are re-deflated (kept
+/// only when that actually shrinks them). Every stream's decoded content is
+/// preserved bit-for-bit - already-encoded payloads pass through verbatim.
+///
+/// The output is a from-scratch file with no `/Prev` chain, so it does **not**
+/// preserve prior-revision history and it invalidates any existing digital
+/// signature - that is inherent to rewriting a file smaller, and is why this
+/// is an explicit action rather than part of a normal save.
+///
+/// Encrypted documents are refused: a faithful rewrite would have to either
+/// re-encrypt (out of scope here) or silently drop the encryption, so the
+/// caller is told to decrypt first.
+class CosCompactor {
+  CosCompactor(this.document, {this.deflateLevel = 9});
+
+  final CosDocument document;
+
+  /// zlib level (0-9) for the object streams, xref stream, and re-deflated
+  /// payloads. 9 favours size over speed, which suits an explicit "reduce
+  /// file size" action.
+  final int deflateLevel;
+
+  CosCompactionResult run() {
+    if (document.isEncrypted) {
+      throw ArgumentError(
+          'cannot compact an encrypted document; decrypt it first');
+    }
+    final rootRef = document.trailer['Root'];
+    if (rootRef is! CosReference) {
+      throw StateError('document has no indirect /Root catalog to compact');
+    }
+
+    final builder = CosDocumentBuilder();
+    final copier = _GraphCopier(document, builder, deflateLevel);
+
+    final rootDest = copier.copyValue(rootRef) as CosReference;
+    CosReference? infoDest;
+    final infoRef = document.trailer['Info'];
+    if (infoRef is CosReference && document.resolve(infoRef) is CosDictionary) {
+      infoDest = copier.copyValue(infoRef) as CosReference;
+    }
+
+    final bytes = builder.build(
+      root: rootDest,
+      info: infoDest,
+      version: '1.7',
+      objectStreams: true,
+      deflateLevel: deflateLevel,
+    );
+
+    return CosCompactionResult(
+      bytes: bytes,
+      bytesBefore: document.bytes.length,
+      objectsBefore: document.objectNumbers.length,
+      objectsAfter: copier.objectsWritten,
+      streamsDeflated: copier.streamsDeflated,
+    );
+  }
+}
+
+/// Deep-copies the whole reachable object graph of a document into a
+/// [CosDocumentBuilder], remapping references and breaking cycles by
+/// registering each destination object before its contents are filled in.
+///
+/// Unlike page extraction there is no copy boundary - every reference is
+/// followed - so a dead object simply never gets visited and is dropped.
+class _GraphCopier {
+  _GraphCopier(this.document, this._builder, this._deflateLevel);
+
+  final CosDocument document;
+  final CosDocumentBuilder _builder;
+  final int _deflateLevel;
+  final Map<CosReference, CosObject> _mapped = {};
+
+  int objectsWritten = 0;
+  int streamsDeflated = 0;
+
+  /// Copies any value. Direct containers copy structurally; references
+  /// allocate (once) in the destination and remap.
+  CosObject copyValue(CosObject value) {
+    switch (value) {
+      case CosReference ref:
+        return _mapped[ref] ??= _copyTarget(ref);
+      case CosStream stream: // direct streams are illegal, but tolerate
+        return _copyStream(null, stream);
+      case CosDictionary dict:
+        final out = CosDictionary();
+        dict.entries.forEach((key, item) => out[key] = copyValue(item));
+        return out;
+      case CosArray array:
+        return CosArray([for (final item in array.items) copyValue(item)]);
+      case CosString string:
+        return CosString(Uint8List.fromList(string.bytes), isHex: string.isHex);
+      default:
+        return value; // names, numbers, booleans, null are immutable
+    }
+  }
+
+  CosObject _copyTarget(CosReference ref) {
+    final target = document.resolve(ref);
+    switch (target) {
+      case CosStream stream:
+        return _copyStream(ref, stream);
+      case CosDictionary dict:
+        final out = CosDictionary();
+        final outRef = _builder.add(out);
+        _mapped[ref] = outRef;
+        objectsWritten++;
+        dict.entries.forEach((key, item) => out[key] = copyValue(item));
+        return outRef;
+      case CosNull():
+        return CosNull.instance;
+      default:
+        // an indirectly referenced scalar - inline it at the use site
+        return copyValue(target);
+    }
+  }
+
+  /// Copies a stream. An already-encoded payload passes through verbatim; a
+  /// stream stored with no compression filter is re-deflated when that
+  /// shrinks it (kept lossless - `FlateDecode` of the result reproduces the
+  /// stored bytes exactly).
+  CosObject _copyStream(CosReference? ref, CosStream stream) {
+    final srcDict = stream.dictionary;
+    var payload = stream.rawBytes;
+    var addFlate = false;
+    if (_isUnfiltered(srcDict)) {
+      final deflated = Uint8List.fromList(
+          const ZLibEncoder().encodeBytes(payload, level: _deflateLevel));
+      if (deflated.length < payload.length) {
+        payload = deflated;
+        addFlate = true;
+        streamsDeflated++;
+      }
+    }
+
+    final out = CosStream(CosDictionary(), payload);
+    final outRef = ref != null ? (_mapped[ref] = _builder.add(out)) : null;
+    if (ref != null) objectsWritten++;
+    srcDict.entries.forEach((key, item) {
+      if (key == 'Length') return; // recomputed below
+      out.dictionary[key] = copyValue(item);
+    });
+    if (addFlate) out.dictionary['Filter'] = const CosName('FlateDecode');
+    out.dictionary['Length'] = CosInteger(payload.length);
+    return outRef ?? out;
+  }
+
+  /// A stream is unfiltered when it declares no `/Filter` (or an empty array).
+  bool _isUnfiltered(CosDictionary dict) {
+    final filter = document.resolve(dict['Filter']);
+    return switch (filter) {
+      CosName() => false,
+      CosArray(:final items) => items.isEmpty,
+      _ => true,
+    };
+  }
+}

--- a/packages/pdf_cos/test/builder_test.dart
+++ b/packages/pdf_cos/test/builder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:test/test.dart';
 
@@ -71,6 +73,87 @@ void main() {
       final reopened = CosDocument.open(bytes);
       final infoDict = reopened.resolve(reopened.trailer['Info']);
       expect((infoDict as CosDictionary)['Title'], CosString.fromText('Doc'));
+    });
+  });
+
+  group('CosDocumentBuilder object streams', () {
+    CosReference buildOnePage(CosDocumentBuilder builder, {String? title}) {
+      final pages = CosDictionary({'Type': const CosName('Pages')});
+      final pagesRef = builder.add(pages);
+      final page = builder.add(CosDictionary({
+        'Type': const CosName('Page'),
+        'Parent': pagesRef,
+        'MediaBox': CosArray([
+          const CosInteger(0),
+          const CosInteger(0),
+          const CosInteger(200),
+          const CosInteger(300),
+        ]),
+      }));
+      pages['Kids'] = CosArray([page]);
+      pages['Count'] = const CosInteger(1);
+      return builder.add(CosDictionary({
+        'Type': const CosName('Catalog'),
+        'Pages': pagesRef,
+      }));
+    }
+
+    test('packs non-stream objects into a compressed xref-stream file', () {
+      final builder = CosDocumentBuilder();
+      final catalog = buildOnePage(builder);
+      final bytes = builder.build(root: catalog, objectStreams: true);
+
+      final text = String.fromCharCodes(bytes.sublist(0, 16));
+      // object streams force a >= 1.5 header
+      expect(text, startsWith('%PDF-1.7\n'));
+      // no classic table; the cross-reference is itself a stream
+      expect(String.fromCharCodes(bytes), isNot(contains('\ntrailer\n')));
+
+      final reopened = CosDocument.open(bytes);
+      expect(reopened.trailer.typeName, 'XRef');
+      // the catalog and page came back out of an object stream
+      expect(reopened.catalog.typeName, 'Catalog');
+      final pages = reopened.resolve(reopened.catalog['Pages']) as CosDictionary;
+      final kids = reopened.resolve(pages['Kids']) as CosArray;
+      final page = reopened.resolve(kids[0]) as CosDictionary;
+      expect(page.typeName, 'Page');
+    });
+
+    test('keeps streams top-level and addressable', () {
+      final builder = CosDocumentBuilder();
+      final pages = CosDictionary({'Type': const CosName('Pages')});
+      final pagesRef = builder.add(pages);
+      final content = builder.add(CosStream(
+        CosDictionary(),
+        Uint8List.fromList('BT /F1 12 Tf (hi) Tj ET'.codeUnits),
+      ));
+      final page = builder.add(CosDictionary({
+        'Type': const CosName('Page'),
+        'Parent': pagesRef,
+        'Contents': content,
+        'MediaBox': CosArray([
+          const CosInteger(0),
+          const CosInteger(0),
+          const CosInteger(200),
+          const CosInteger(300),
+        ]),
+      }));
+      pages['Kids'] = CosArray([page]);
+      pages['Count'] = const CosInteger(1);
+      final catalog = builder.add(CosDictionary({
+        'Type': const CosName('Catalog'),
+        'Pages': pagesRef,
+      }));
+
+      final bytes = builder.build(root: catalog, objectStreams: true);
+      final reopened = CosDocument.open(bytes);
+      final page2 = reopened.resolve(
+              (reopened.resolve((reopened.resolve(reopened.catalog['Pages'])
+                      as CosDictionary)['Kids']) as CosArray)[0])
+          as CosDictionary;
+      final stream = reopened.resolve(page2['Contents']) as CosStream;
+      expect(String.fromCharCodes(reopened.decodeStreamData(stream)),
+          'BT /F1 12 Tf (hi) Tj ET');
     });
   });
 }

--- a/packages/pdf_cos/test/compactor_test.dart
+++ b/packages/pdf_cos/test/compactor_test.dart
@@ -1,0 +1,114 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CosCompactor', () {
+    test('drops orphaned objects an incremental edit left behind', () {
+      final base = CosDocument.open(buildClassicPdf());
+      // add an object the tree never references, then save it as an update
+      final withOrphan = (CosIncrementalUpdater(base)
+            ..addObject(CosDictionary({'Orphan': const CosBoolean(true)})))
+          .save();
+
+      final doc = CosDocument.open(withOrphan);
+      final result = CosCompactor(doc).run();
+
+      // catalog, pages, page, content, font - the orphan is not copied
+      expect(result.objectsAfter, 5);
+      expect(result.objectsAfter, lessThan(result.objectsBefore),
+          reason: 'the unreferenced object should not be copied');
+
+      final compacted = CosDocument.open(result.bytes);
+      expect(compacted.catalog.typeName, 'Catalog');
+      final pages =
+          compacted.resolve(compacted.catalog['Pages']) as CosDictionary;
+      final kids = compacted.resolve(pages['Kids']) as CosArray;
+      final leaf = compacted.resolve(kids[0]) as CosDictionary;
+      expect(leaf.typeName, 'Page');
+    });
+
+    test('preserves page content byte-for-byte through the rewrite', () {
+      final doc = CosDocument.open(buildClassicPdf());
+      final result = CosCompactor(doc).run();
+      final compacted = CosDocument.open(result.bytes);
+
+      final pages =
+          compacted.resolve(compacted.catalog['Pages']) as CosDictionary;
+      final leaf = compacted
+          .resolve((compacted.resolve(pages['Kids']) as CosArray)[0])
+          as CosDictionary;
+      final content =
+          compacted.resolve(leaf['Contents']) as CosStream;
+      expect(String.fromCharCodes(compacted.decodeStreamData(content)),
+          'BT /F1 24 Tf 72 720 Td (Hello, world!) Tj ET');
+    });
+
+    test('re-deflates an uncompressed stream and round-trips it', () {
+      // a big, highly compressible unfiltered stream
+      final payload = Uint8List.fromList(List.filled(4000, 0x41)); // "AAAA..."
+      final builder = CosDocumentBuilder();
+      final pages = CosDictionary({'Type': const CosName('Pages')});
+      final pagesRef = builder.add(pages);
+      final content = builder.add(CosStream(CosDictionary(), payload));
+      final page = builder.add(CosDictionary({
+        'Type': const CosName('Page'),
+        'Parent': pagesRef,
+        'Contents': content,
+        'MediaBox': CosArray([
+          const CosInteger(0),
+          const CosInteger(0),
+          const CosInteger(200),
+          const CosInteger(300),
+        ]),
+      }));
+      pages['Kids'] = CosArray([page]);
+      pages['Count'] = const CosInteger(1);
+      final catalog = builder.add(CosDictionary({
+        'Type': const CosName('Catalog'),
+        'Pages': pagesRef,
+      }));
+      final doc = CosDocument.open(builder.build(root: catalog));
+
+      final result = CosCompactor(doc).run();
+      expect(result.streamsDeflated, greaterThanOrEqualTo(1));
+
+      final compacted = CosDocument.open(result.bytes);
+      final leaf = compacted
+          .resolve((compacted.resolve((compacted.resolve(compacted
+                          .catalog['Pages']) as CosDictionary)['Kids'])
+                  as CosArray)[0])
+          as CosDictionary;
+      final stream = compacted.resolve(leaf['Contents']) as CosStream;
+      expect(compacted.resolve(stream.dictionary['Filter']),
+          const CosName('FlateDecode'));
+      expect(compacted.decodeStreamData(stream), payload);
+    });
+
+    test('shrinks a classic, uncompressed multi-page file', () {
+      final original = buildMultiPagePdf(24);
+      final doc = CosDocument.open(original);
+      final result = CosCompactor(doc).run();
+      expect(result.bytes.length, lessThan(original.length));
+
+      final compacted = CosDocument.open(result.bytes);
+      expect(compacted.trailer.typeName, 'XRef');
+      // every page still resolves and shows its text
+      final pages =
+          compacted.resolve(compacted.catalog['Pages']) as CosDictionary;
+      final kids = compacted.resolve(pages['Kids']) as CosArray;
+      expect(kids.length, 24);
+      final last = compacted.resolve(kids[23]) as CosDictionary;
+      final content = compacted.resolve(last['Contents']) as CosStream;
+      expect(String.fromCharCodes(compacted.decodeStreamData(content)),
+          contains('(Page 24)'));
+    });
+
+    test('refuses an encrypted document', () {
+      final doc = CosDocument.open(buildEncryptedPdf());
+      expect(() => CosCompactor(doc).run(), throwsArgumentError);
+    });
+  });
+}

--- a/packages/pdf_cos/test/compactor_test.dart
+++ b/packages/pdf_cos/test/compactor_test.dart
@@ -87,6 +87,50 @@ void main() {
       expect(compacted.decodeStreamData(stream), payload);
     });
 
+    test('drops stale /DecodeParms when it imposes FlateDecode', () {
+      // an unfiltered stream that (malformed) also carries decode params: the
+      // params must not survive onto our re-deflated payload.
+      final payload = Uint8List.fromList(List.filled(4000, 0x42));
+      final builder = CosDocumentBuilder();
+      final pages = CosDictionary({'Type': const CosName('Pages')});
+      final pagesRef = builder.add(pages);
+      final content = builder.add(CosStream(
+        CosDictionary({
+          'DecodeParms': CosDictionary({'Predictor': const CosInteger(12)}),
+        }),
+        payload,
+      ));
+      final page = builder.add(CosDictionary({
+        'Type': const CosName('Page'),
+        'Parent': pagesRef,
+        'Contents': content,
+        'MediaBox': CosArray([
+          const CosInteger(0),
+          const CosInteger(0),
+          const CosInteger(200),
+          const CosInteger(300),
+        ]),
+      }));
+      pages['Kids'] = CosArray([page]);
+      pages['Count'] = const CosInteger(1);
+      final catalog = builder.add(CosDictionary(
+          {'Type': const CosName('Catalog'), 'Pages': pagesRef}));
+      final doc = CosDocument.open(builder.build(root: catalog));
+
+      final result = CosCompactor(doc).run();
+      expect(result.streamsDeflated, greaterThanOrEqualTo(1));
+
+      final compacted = CosDocument.open(result.bytes);
+      final leaf = compacted
+          .resolve((compacted.resolve((compacted.resolve(compacted
+                          .catalog['Pages']) as CosDictionary)['Kids'])
+                  as CosArray)[0])
+          as CosDictionary;
+      final stream = compacted.resolve(leaf['Contents']) as CosStream;
+      expect(stream.dictionary['DecodeParms'], isNull);
+      expect(compacted.decodeStreamData(stream), payload);
+    });
+
     test('shrinks a classic, uncompressed multi-page file', () {
       final original = buildMultiPagePdf(24);
       final doc = CosDocument.open(original);

--- a/packages/pdf_document/lib/src/editor.dart
+++ b/packages/pdf_document/lib/src/editor.dart
@@ -311,4 +311,76 @@ class PdfEditor {
   /// save. The bytes are only valid appended directly to the document this
   /// editor was built over.
   Uint8List saveTail() => _updater.saveTail();
+
+  /// Rewrites the document as a compacted PDF and returns the result plus a
+  /// before/after report - the lossless structural pass of the file-size
+  /// optimiser (#368).
+  ///
+  /// The rewrite drops the dead objects that incremental edits accumulate,
+  /// packs objects into compressed object streams, and re-deflates streams
+  /// that were stored uncompressed - all lossless for rendered output.
+  /// Pending unsaved edits are included. Because it is a from-scratch file
+  /// (no `/Prev`), it does not preserve prior-revision history and it
+  /// invalidates any existing signature - hence an explicit action, not part
+  /// of [save].
+  ///
+  /// If the compacted file would not be smaller (an already object-stream
+  /// document, or one small enough that framing dominates), the current bytes
+  /// are returned unchanged and [PdfCompressionResult.compacted] is false.
+  /// Throws if the document is encrypted (decrypt it first).
+  PdfCompressionResult compress({int deflateLevel = 9}) {
+    final current =
+        _updater.hasChanges ? _updater.save() : document.cos.bytes;
+    final snapshot =
+        _updater.hasChanges ? PdfDocument.open(current).cos : document.cos;
+    final result =
+        CosCompactor(snapshot, deflateLevel: deflateLevel).run();
+    final smaller = result.bytes.length < current.length;
+    return PdfCompressionResult(
+      bytes: smaller ? result.bytes : Uint8List.fromList(current),
+      bytesBefore: current.length,
+      bytesAfter: smaller ? result.bytes.length : current.length,
+      objectsBefore: result.objectsBefore,
+      objectsAfter: result.objectsAfter,
+      streamsDeflated: result.streamsDeflated,
+      compacted: smaller,
+    );
+  }
+}
+
+/// The outcome of [PdfEditor.compress]: the (possibly rewritten) bytes and a
+/// before/after accounting hosts can surface as "saved N%".
+class PdfCompressionResult {
+  const PdfCompressionResult({
+    required this.bytes,
+    required this.bytesBefore,
+    required this.bytesAfter,
+    required this.objectsBefore,
+    required this.objectsAfter,
+    required this.streamsDeflated,
+    required this.compacted,
+  });
+
+  /// The file to keep: the compacted bytes when smaller, otherwise a copy of
+  /// the input unchanged.
+  final Uint8List bytes;
+  final int bytesBefore;
+  final int bytesAfter;
+
+  /// Object slots the source cross-reference declared, versus live objects
+  /// written to the compacted file.
+  final int objectsBefore;
+  final int objectsAfter;
+
+  /// Previously uncompressed streams that were re-deflated.
+  final int streamsDeflated;
+
+  /// Whether the compacted output was actually smaller and was kept.
+  final bool compacted;
+
+  /// Bytes removed (0 when the input was kept).
+  int get bytesSaved => bytesBefore - bytesAfter;
+
+  /// Fraction of the original size removed, in `[0, 1)`.
+  double get ratio => bytesBefore == 0 ? 0 : bytesSaved / bytesBefore;
 }

--- a/packages/pdf_document/test/compress_test.dart
+++ b/packages/pdf_document/test/compress_test.dart
@@ -1,0 +1,49 @@
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PdfEditor.compress', () {
+    test('shrinks a classic multi-page file and keeps every page', () {
+      final original = buildMultiPagePdf(24);
+      final editor = PdfEditor(PdfDocument.open(original));
+      final result = editor.compress();
+
+      expect(result.compacted, isTrue);
+      expect(result.bytesAfter, lessThan(result.bytesBefore));
+      expect(result.bytes.length, result.bytesAfter);
+      expect(result.ratio, greaterThan(0));
+
+      final reopened = PdfDocument.open(result.bytes);
+      expect(reopened.pageCount, 24);
+    });
+
+    test('includes pending unsaved edits in the compacted output', () {
+      final editor = PdfEditor(PdfDocument.open(buildMultiPagePdf(6)))
+        ..setInfo(title: 'Compacted');
+      final result = editor.compress();
+
+      final reopened = PdfDocument.open(result.bytes);
+      expect(reopened.info['Title'], 'Compacted');
+      expect(reopened.pageCount, 6);
+    });
+
+    test('never returns a larger file than the input', () {
+      // an already object-stream file has little structural slack; the gate
+      // must keep the smaller of compacted vs. original.
+      final original = buildXrefStreamPdf();
+      final result = PdfEditor(PdfDocument.open(original)).compress();
+
+      expect(result.bytesAfter, lessThanOrEqualTo(result.bytesBefore));
+      if (!result.compacted) {
+        expect(result.bytes, original);
+        expect(result.bytesSaved, 0);
+      }
+    });
+
+    test('refuses an encrypted document', () {
+      final editor = PdfEditor(PdfDocument.open(buildEncryptedPdf()));
+      expect(editor.compress, throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
Closes part of #368 — the **lossless structural pass**, the first of the ticket's independently shippable layers.

## What

`PdfEditor.compress()` rewrites a document into a fresh, smaller PDF and returns a `PdfCompressionResult` (before/after bytes, object counts, streams re-deflated, a `compacted` flag). Three lossless mechanisms:

1. **Reachability GC** — a whole-graph copy from the catalog (+`/Info`) into a `CosDocumentBuilder` drops every object the tree no longer references. Incremental edits accumulate dead objects (each revision appends + supersedes), so a live editing session bloats steadily; compaction reclaims all of it.
2. **Object-stream + xref-stream packing** — the builder gains `objectStreams: true`: non-stream objects pack into compressed `/ObjStm` (128/stream) behind a PDF 1.5 xref stream (`W [1 4 2]`); streams stay top-level. Without this, re-emitting a 1.5-era file as classic objects would *inflate* it.
3. **Re-deflate of uncompressed streams** — level-9 deflate, kept only when smaller. `FlateDecode` of the result reproduces the stored bytes exactly.

## Design calls

- **From-scratch output (no `/Prev`)** — a rewrite can't preserve the byte prefix, so it drops prior-revision history and invalidates existing signatures. Hence an explicit action, never part of `save()`.
- **Encrypted docs refused** — decrypt first (same posture as refusing to sign encrypted files).
- **Never larger than input** — returns the smaller of compacted vs. current, `compacted:false` when it kept the original. Always safe to call.
- **Pending edits included**; **object numbers renumber densely** (not identity-preserving).

## Measured

Round-tripped all 226 openable `test_corpora` PDFs: **0 page-count mismatches.**

| corpus | before | after | saved |
|---|---|---|---|
| pdfjs | 2933K | 2015K | **31.3%** |
| ghent | 104.9M | 102.4M | 2.4% (image-dominated) |
| dartpdf | 7453K | 7394K | 0.8% (already optimized) |

Per-file up to 98.7% (`colorkeymask.pdf` 158K→2K). Headline case — the editor's own output: a 12-page file through 40 incremental annotation edits bloats **8.8×** (3.4K→29.9K); compaction returns it to 9.7K (**67.6% off**), all 40 annotations intact.

## Tests

- `pdf_cos`: `builder_test` (object-stream round-trip, streams stay addressable), `compactor_test` (orphan drop, byte-exact content, re-deflate round-trip, multi-page shrink, encryption refusal).
- `pdf_document`: `compress_test` (shrink + page preservation, pending-edit inclusion, never-larger gate, encryption refusal).

## Follow-ups (open #368 checkboxes)

Image downsample/recompress (lossy, opt-in), font subsetting, resource dedup, and the app's "Reduce file size…" action — each layers on top without changing this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYG2AabktXygJ8Mxk9xXho