### PR TITLE
perf(worker): stream progressive record partials, native transport (#564 pt1)

### DIFF
--- a/doc/dev-log/2026-07-25-streaming-partials-564-pr1.md
+++ b/doc/dev-log/2026-07-25-streaming-partials-564-pr1.md
@@ -1,0 +1,85 @@
+# 2026-07-25 — Streaming record partials, PR1 of #564 (native transport, inert)
+
+#564 wants a PDFium-style top-down progressive reveal: the top band of a heavy
+page paints first and fills downward, instead of the whole page appearing at
+once when the record completes. The interpreter side has been ready since #530/
+#566 — `PdfInterpreter.beginPageContent` → `PdfPageContentWalk.advance()` records
+a bounded op chunk and resumes without re-walking, and chunk boundaries land only
+between top-level operators, so the graphics state is always at page level in
+between (which is what makes emitting a partial there safe). What remained was
+entirely the **worker transport**: the request/response contract is strictly 1:1
+(one request → one payload-bearing response, single in-flight slot), so a job
+cannot emit partials as it walks.
+
+This session lands **PR1 of the three-PR plan** on the issue: the native isolate
+backend can now stream progressive linework prefixes, opt-in, default-off, with
+**no host consumer and no web change** — so it is inert in production and fully
+VM-testable. PR2 (caching shared-stream dedup + web twin + bundle rebuild) and
+PR3 (`transcriptFor` chunk yield + host progressive paint behind a flag, measured
+on the web harness) stay ahead.
+
+## What changed
+
+- **`PdfRenderWorker.record` gains `onPartial` (`PdfPartialRecordSink?`)**
+  (`render_worker.dart`). A new typedef documents the contract: each call delivers
+  a spatially-growing *linework* prefix (image draws left as placeholders) before
+  the future resolves with the final decoded buffer. A page recorded in a single
+  chunk emits none.
+
+- **Isolate backend streams it** (`render_worker_isolate.dart`). The record wire
+  message carries a trailing `wantsPartials` bool. On the resumable
+  (`decodeImages: true`) path, `_recordResumablePage` serializes
+  `recorder.commands` after each *incomplete* chunk with `decodeImages: false,
+  imagePlaceholders: true` and ships it as `['partial', id, TransferableTypedData]`.
+  The main-side listener forwards a partial to the request's sink **without**
+  clearing `_inFlight` or completing the `Completer` — the final buffer still
+  arrives on the ordinary response path. A partial whose id no longer matches the
+  in-flight request (disposed, or requeued under a new id after preemption) is
+  dropped; the worker also stops emitting the moment its request loses the slot or
+  is cancelled.
+
+- **Pool forwards; the caching wrapper deliberately does not.** `PdfPooledRender-
+  Worker.record` threads `onPartial` to the routed/urgent worker.
+  `PdfCachingRenderWorker.record` accepts it but **drops it**: the cache collapses
+  concurrent callers onto one shared future, and a stream shared with late joiners
+  (who must replay already-emitted partials) is exactly the dedup redesign PR2
+  owns. Because `PdfRenderWorker.start()` returns the caching wrapper, production
+  is byte-identical to before — the feature is reachable only through
+  `startUncached`/the pool (tests today, the PR3 host path later). The stub and web
+  backends accept the param for interface parity and never call it.
+
+## Why this shape
+
+The subtle edges the issue flags all live in the parts PR1 *doesn't* touch:
+requeue-after-preemption across a shared future, explicit cancel mid-stream, and
+late-joiner replay are the caching wrapper's problem, and the caching wrapper
+does not stream in PR1. Keeping the caching path provably unchanged is what makes
+PR1 safe to land unsupervised — the class of regression that has bitten this
+subsystem before is web-only dart2js/`.toJS` hangs, and PR1 makes no web change.
+
+## Cost / correctness
+
+- The partial serialize is `decodeImages: false` (no image decode) — the cheap
+  linework pass, not a re-decode — so a page with images pays only prefix
+  serialization per chunk, and only when a sink is attached (off by default).
+- A chunk boundary is page-level graphics state, so a prefix of
+  `recorder.commands` is a valid replayable buffer (same call the final uses,
+  earlier and without decode). Each partial is a superset of the last.
+
+## Measurement
+
+PR1 adds no production code path (guarded behind `onPartial != null`; the caching
+wrapper drops it), so there is nothing to A/B yet — the 3–7× first-frame win is
+PR3's, measured on the web harness once a host consumer paints the partials.
+Ran the deterministic counter gate as the regression check: **`tool/perf.sh gate`
+→ 12 inputs, 13 counters within 3%**, and `render_trace_gate_test` green. The
+normal record path is unshifted.
+
+## Tests
+
+`test/partial_record_test.dart`: a multi-chunk page streams ≥1 partial, all
+before the final; each partial is a non-empty prefix (≤ final command count) and
+monotonically grows; requesting partials does not change the final buffer; a
+one-chunk page emits none; and the cached production wrapper streams none (the
+PR1 inert boundary). Existing worker suites (record/host/revision/strips/resume/
+early-prefix) stay green after adding the interface param to their fakes.

--- a/doc/dev-log/2026-07-25-streaming-partials-564-pr1.md
+++ b/doc/dev-log/2026-07-25-streaming-partials-564-pr1.md
@@ -60,11 +60,30 @@ subsystem before is web-only dart2js/`.toJS` hangs, and PR1 makes no web change.
 ## Cost / correctness
 
 - The partial serialize is `decodeImages: false` (no image decode) — the cheap
-  linework pass, not a re-decode — so a page with images pays only prefix
-  serialization per chunk, and only when a sink is attached (off by default).
+  linework pass, not a re-decode — and runs only when a sink is attached (off by
+  default).
+- **Caveat (found in adversarial review):** each incomplete chunk re-serializes
+  the *whole accumulated* `recorder.commands`, not just the new suffix, so the
+  streaming path is **O(commands²)** in serialize work across a page (and the
+  main side re-`deserializeCommands` each partial). That is genuinely inert today
+  — nothing reaches it in production — but it is the exact heavy page the feature
+  targets, so **PR3 must throttle emission or ship suffix-only deltas** rather
+  than the full prefix per chunk. Flagged in a code comment at the emit site.
 - A chunk boundary is page-level graphics state, so a prefix of
   `recorder.commands` is a valid replayable buffer (same call the final uses,
   earlier and without decode). Each partial is a superset of the last.
+
+## Adversarial review
+
+A reviewer scrutinized the diff for misrouting, preemption/requeue, and the
+inertness claim and found **no shipping bug**: the listener's type-check ordering
+means a `['partial', …]` message can never reach the `response[0] as int` cast;
+monotonic ids + the single in-flight slot make stale-partial misrouting
+impossible; production is byte-identical (the caching wrapper never references
+`onPartial`, so `wantsPartials` is always false on the wire); and the ordering
+test genuinely proves partials arrive *during* the record (per-port FIFO). The
+only finding was the O(commands²) cost above, addressed as a documented PR3
+follow-up.
 
 ## Measurement
 

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -103,6 +103,18 @@ bool pdfRenderWorkerReuseTranscripts = true;
 /// guard covers native and pooled workers.
 Duration pdfRenderWorkerRecordTimeout = const Duration(seconds: 90);
 
+/// Sink for progressive partial recordings (#564).
+///
+/// While the worker records a heavy page it can deliver spatially-growing
+/// *linework* prefixes of that page - each a superset of the last, image draws
+/// left as placeholders - before [PdfRenderWorker.record]'s future resolves with
+/// the final decoded buffer. The caller replays each partial with
+/// `PdfPageRenderer.pictureFromCommands(includeImages: false)` for a top-down
+/// progressive reveal, then swaps in the final buffer when it arrives. A page
+/// small enough to record in one chunk emits no partial; the future still
+/// resolves normally.
+typedef PdfPartialRecordSink = void Function(List<PdfRenderCommand> partial);
+
 /// One combined deep-zoom worker result.
 ///
 /// [commands] carry images decoded for the requested visible region and
@@ -261,6 +273,13 @@ abstract class PdfRenderWorker {
   /// draws and retarget their transforms to that crop. Full-page cached
   /// renders must leave this null; a region-specific buffer is only correct
   /// for rasterizing that same visible slice.
+  ///
+  /// [onPartial], when supplied on a full-page decoding record ([decodeImages]
+  /// true), receives progressive linework prefixes as the worker walks the page
+  /// (#564) - see [PdfPartialRecordSink]. Backends that do not stream partials
+  /// (the null fallback, the web worker until its twin lands, and - until the
+  /// caching wrapper's shared-stream dedup is in - a [PdfCachingRenderWorker])
+  /// simply never call it; the final result is unaffected either way.
   Future<List<PdfRenderCommand>?> record(
     int pageIndex, {
     bool annotations = true,
@@ -269,6 +288,7 @@ abstract class PdfRenderWorker {
     bool decodeImages = true,
     int? commandLimit,
     PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
   });
 
   /// Drops any QUEUED (not yet started) [record] request for [pageIndex] at
@@ -698,6 +718,7 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
     bool decodeImages = true,
     int? commandLimit,
     PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
   }) async {
     final urgent = _urgentWorkerFor(priority);
     if (urgent != null) {
@@ -709,6 +730,7 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
         decodeImages: decodeImages,
         commandLimit: commandLimit,
         imageDecodeRegion: imageDecodeRegion,
+        onPartial: onPartial,
       );
     }
     final worker = _lease(pageIndex, priority);
@@ -721,6 +743,7 @@ class PdfPooledRenderWorker extends PdfRenderWorker {
         decodeImages: decodeImages,
         commandLimit: commandLimit,
         imageDecodeRegion: imageDecodeRegion,
+        onPartial: onPartial,
       );
     } finally {
       _release(pageIndex, priority, worker);
@@ -1019,6 +1042,14 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
     return (_cache.weight / _budgetBytes).clamp(0.0, 1.0).toDouble();
   }
 
+  /// [onPartial] is intentionally NOT forwarded through the cache: this wrapper
+  /// collapses concurrent callers for one key onto a single shared future, and a
+  /// progressive stream shared across late joiners (a caller that joins after
+  /// some partials have already been emitted, and must replay them) is the
+  /// caching-dedup redesign tracked as the next step of #564. Until that lands
+  /// the production (cached) path records exactly as before and streams no
+  /// partials; the raw backend ([PdfRenderWorker.startUncached]) and the pool do
+  /// stream them.
   @override
   Future<List<PdfRenderCommand>?> record(
     int pageIndex, {
@@ -1028,6 +1059,7 @@ class PdfCachingRenderWorker extends PdfRenderWorker {
     bool decodeImages = true,
     int? commandLimit,
     PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
   }) {
     if (!_inner.isActive) {
       return _inner.record(

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -150,6 +150,22 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         );
         return;
       }
+      // ['partial', int id, TransferableTypedData data] - a progressive linework
+      // prefix of a record still in flight (#564). Forward it to the request's
+      // sink WITHOUT clearing _inFlight or completing the completer: the final
+      // decoded buffer still arrives on the ordinary response path. A partial for
+      // a request that is no longer the one in flight (disposed, or requeued
+      // under a new id after preemption) is dropped.
+      if (message is List<Object?> &&
+          message.isNotEmpty &&
+          message.first == 'partial') {
+        final id = message[1] as int;
+        final request = _inFlight;
+        if (request == null || request.id != id) return;
+        final data = (message[2] as TransferableTypedData);
+        request.onPartialBytes?.call(data.materialize().asUint8List());
+        return;
+      }
       // [int id, TransferableTypedData? data, ...] - null means "render
       // locally". Combined strip-detail responses carry command and plan
       // buffers as two separately transferable payloads.
@@ -212,7 +228,8 @@ class _IsolateRenderWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) async {
+      PdfRect? imageDecodeRegion,
+      PdfPartialRecordSink? onPartial}) async {
     if (_disposed || _spawnFailed) return null;
     final request = _PendingRequest.record(
         priority,
@@ -222,7 +239,21 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         imagePixelRatio,
         decodeImages,
         commandLimit,
-        imageDecodeRegion);
+        imageDecodeRegion,
+        // Deserialize each interim linework buffer on arrival and hand the caller
+        // real commands. A corrupt partial is dropped silently - the final buffer
+        // still arrives through the completer.
+        onPartial == null
+            ? null
+            : (bytes) {
+                final List<PdfRenderCommand> commands;
+                try {
+                  commands = deserializeCommands(bytes);
+                } catch (_) {
+                  return;
+                }
+                onPartial(commands);
+              });
     _queue.add(request);
     _pump();
     final buffers = await request.completer.future;
@@ -406,6 +437,7 @@ class _IsolateRenderWorker extends PdfRenderWorker {
         request.imageDecodeRegion?.bottom,
         request.imageDecodeRegion?.right,
         request.imageDecodeRegion?.top,
+        request.onPartialBytes != null, // wantsPartials (#564)
       ]);
     } else if (request.kind == _RequestKind.bin) {
       port.send([
@@ -537,7 +569,8 @@ class _PendingRequest {
       this.imagePixelRatio,
       this.decodeImages,
       this.commandLimit,
-      this.imageDecodeRegion)
+      this.imageDecodeRegion,
+      [this.onPartialBytes])
       : kind = _RequestKind.record,
         pageToDevice = null,
         deviceWidth = 0,
@@ -571,7 +604,8 @@ class _PendingRequest {
         newLength = 0,
         changedPages = null,
         regionMaxCommands = 0,
-        regionBuildGrid = false;
+        regionBuildGrid = false,
+        onPartialBytes = null;
 
   _PendingRequest.detail(
       this.priority,
@@ -593,7 +627,8 @@ class _PendingRequest {
         newLength = 0,
         changedPages = null,
         regionMaxCommands = 0,
-        regionBuildGrid = false;
+        regionBuildGrid = false,
+        onPartialBytes = null;
 
   _PendingRequest.regionIndex(
       this.priority,
@@ -615,7 +650,8 @@ class _PendingRequest {
         baseLength = 0,
         appendedBytes = null,
         newLength = 0,
-        changedPages = null;
+        changedPages = null,
+        onPartialBytes = null;
 
   _PendingRequest.extractText(this.priority, this.seq, this.pageIndex)
       : kind = _RequestKind.extractText,
@@ -634,7 +670,8 @@ class _PendingRequest {
         newLength = 0,
         changedPages = null,
         regionMaxCommands = 0,
-        regionBuildGrid = false;
+        regionBuildGrid = false,
+        onPartialBytes = null;
 
   _PendingRequest.update(
       this.priority,
@@ -656,7 +693,8 @@ class _PendingRequest {
         binPixelRatio = 0,
         slugGlyphs = false,
         regionMaxCommands = 0,
-        regionBuildGrid = false;
+        regionBuildGrid = false,
+        onPartialBytes = null;
 
   final _RequestKind kind;
   final int priority;
@@ -686,6 +724,10 @@ class _PendingRequest {
   // regionIndex-only
   final int regionMaxCommands;
   final bool regionBuildGrid;
+
+  // record-only: forwards each interim linework buffer (#564) to the caller's
+  // sink. Null on every other kind and on records that opted out of partials.
+  final void Function(Uint8List)? onPartialBytes;
 
   final completer = Completer<List<Uint8List>?>();
   bool requeueAfterPreemption = false;
@@ -902,6 +944,19 @@ void _workerMain(_WorkerInit init) {
               ? PdfRect(request[7] as double, request[8] as double,
                   request[9] as double, request[10] as double)
               : null;
+          // Progressive partials (#564): the main side sets this when the caller
+          // passed an onPartial sink. Send each interim linework buffer only
+          // while this request still owns the slot and has not been cancelled, so
+          // a preempted/superseded record stops streaming immediately (the main
+          // side drops any partial whose id no longer matches _inFlight anyway).
+          final wantsPartials = request.length > 11 && request[11] == true;
+          void emitPartial(Uint8List bytes) {
+            if (activeRequestId == id && !token.cancelled) {
+              init.reply
+                  .send(['partial', id, TransferableTypedData.fromList([bytes])]);
+            }
+          }
+
           buffer = await _recordPageAsync(
               doc,
               suspendedRecord,
@@ -911,7 +966,8 @@ void _workerMain(_WorkerInit init) {
               decodeImages,
               commandLimit,
               imageDecodeRegion,
-              token);
+              token,
+              onPartial: wantsPartials ? emitPartial : null);
         }
       }
     } on PdfCancelledException {
@@ -968,12 +1024,14 @@ Future<Uint8List?> _recordPageAsync(
     bool decodeImages,
     int? commandLimit,
     PdfRect? imageDecodeRegion,
-    PdfCancellationToken token) async {
+    PdfCancellationToken token,
+    {void Function(Uint8List)? onPartial}) async {
   if (pageIndex < 0 || pageIndex >= document.pageCount) return null;
 
   if (decodeImages) {
     return _recordResumablePage(document, suspended, pageIndex, annotations,
-        imagePixelRatio, commandLimit, imageDecodeRegion, token);
+        imagePixelRatio, commandLimit, imageDecodeRegion, token,
+        onPartial: onPartial);
   }
 
   final page = document.page(pageIndex);
@@ -1020,7 +1078,8 @@ Future<Uint8List?> _recordResumablePage(
     double? imagePixelRatio,
     int? commandLimit,
     PdfRect? imageDecodeRegion,
-    PdfCancellationToken token) async {
+    PdfCancellationToken token,
+    {void Function(Uint8List)? onPartial}) async {
   var entry = suspended.take(pageIndex, annotations);
   // Defensive: a finished walk cannot be resumed - its advance is a no-op that
   // reports incomplete, which would spin the completion loop below forever and
@@ -1044,6 +1103,23 @@ Future<Uint8List?> _recordResumablePage(
       // than re-walking the prefix.
       suspended.keep(entry);
       throw const PdfCancelledException();
+    }
+    // Emit a progressive linework prefix (#564): a chunk boundary is always at
+    // page-level graphics state, so the commands recorded so far serialize to a
+    // valid, replayable buffer. Images are left as placeholders (decodeImages
+    // false) - the prefix is the fast top-down reveal; the final decoded buffer
+    // follows when the walk completes. Each partial is a superset of the last.
+    if (onPartial != null) {
+      final partial = serializeCommands(entry.recorder.commands,
+          cos: document.cos,
+          decodeImages: false,
+          maxImagePixelRatio: imagePixelRatio,
+          imageDecodeRegion: imageDecodeRegion,
+          imagePlaceholders: true,
+          compactStateScopes: true);
+      // Null only on an unserializable image, which placeholders preclude here;
+      // if it ever happens, skip this partial - the final buffer still arrives.
+      if (partial != null) onPartial(partial);
     }
   }
 

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -1109,6 +1109,12 @@ Future<Uint8List?> _recordResumablePage(
     // valid, replayable buffer. Images are left as placeholders (decodeImages
     // false) - the prefix is the fast top-down reveal; the final decoded buffer
     // follows when the walk completes. Each partial is a superset of the last.
+    //
+    // Note this re-serializes the whole accumulated prefix every chunk, so the
+    // streaming path is O(commands^2) in serialize work across a page (and the
+    // main side re-deserializes each partial). Harmless while off-by-default
+    // (no consumer reaches here), but the host-facing PR3 must throttle emission
+    // or ship suffix-only deltas rather than the full prefix each time.
     if (onPartial != null) {
       final partial = serializeCommands(entry.recorder.commands,
           cos: document.cos,

--- a/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_stub.dart
@@ -29,7 +29,8 @@ class _NullRenderWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion}) async =>
+          PdfRect? imageDecodeRegion,
+          PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/lib/src/render_worker_web.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web.dart
@@ -344,6 +344,10 @@ class _WebRenderWorker extends PdfRenderWorker {
     bool decodeImages = true,
     int? commandLimit,
     PdfRect? imageDecodeRegion,
+    // Partial streaming is the web twin's follow-up (#564 PR2); the web backend
+    // records whole pages, so this sink is accepted for interface parity and
+    // never called.
+    PdfPartialRecordSink? onPartial,
   }) async {
     if (_disposed || _failed) {
       _wlog(

--- a/packages/dart_pdf_editor/test/default_worker_test.dart
+++ b/packages/dart_pdf_editor/test/default_worker_test.dart
@@ -25,7 +25,7 @@ class _FakeWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion}) async =>
+          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/test/early_prefix_paint_test.dart
+++ b/packages/dart_pdf_editor/test/early_prefix_paint_test.dart
@@ -118,7 +118,7 @@ class _RecordingWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) {
     // Only the base record ladder is interesting; deep-zoom detail records
     // carry a region and would be noise.
     if (imageDecodeRegion == null) commandLimits.add(commandLimit);

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -625,7 +625,7 @@ class _PreviewWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) async {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async {
     calls.add((pageIndex, decodeImages, imagePixelRatio));
     final request = PdfImageRequest(
       stream: CosStream(CosDictionary(), Uint8List(0)),
@@ -657,7 +657,7 @@ class _DecliningWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) async {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async {
     calls.add((pageIndex, decodeImages, imagePixelRatio));
     return null;
   }
@@ -682,7 +682,7 @@ class _VectorOnlyWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) async {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async {
     commandLimits.add(commandLimit);
     return const [PdfSaveCommand(), PdfRestoreCommand()];
   }

--- a/packages/dart_pdf_editor/test/partial_record_test.dart
+++ b/packages/dart_pdf_editor/test/partial_record_test.dart
@@ -1,0 +1,145 @@
+// PR1 of #564: the native render worker can stream progressive linework
+// prefixes of a heavy page (a top-down PDFium-style reveal) BEFORE its final
+// decoded buffer resolves. This pins the transport contract that PR1 adds:
+//
+//  - a record with an `onPartial` sink receives one or more partial buffers,
+//    each a valid deserializable command list, all arriving before the final;
+//  - each partial is a prefix (no more commands than the final);
+//  - the final buffer is byte-identical whether or not partials were requested
+//    (the sink must not perturb the recording);
+//  - the production CACHED wrapper deliberately does NOT stream partials yet
+//    (that is the shared-stream dedup redesign, PR2), so opting in there is
+//    inert - the final still arrives unchanged.
+//
+// No host consumer and no web change land in PR1, so this is the whole
+// observable surface of the feature.
+import 'dart:typed_data';
+
+import 'package:dart_pdf_editor/src/render_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+/// A single-page PDF whose content stream is [opCount] stroked line segments -
+/// enough operators (~3 per line) to span several of the worker's resumable
+/// record chunks, so a full-page record emits progressive partials. Mirrors the
+/// fixture in resume_record_test.dart.
+Uint8List _linesPdf(int opCount) {
+  final content = StringBuffer('1 0 0 1 0 0 cm\n0 0 0 RG\n');
+  for (var i = 0; i < opCount; i++) {
+    final x = (i % 100).toDouble();
+    final y = (i % 50).toDouble();
+    content.write('${x.toStringAsFixed(1)} ${y.toStringAsFixed(1)} m '
+        '${(x + 1).toStringAsFixed(1)} ${(y + 1).toStringAsFixed(1)} l S\n');
+  }
+  final stream = content.toString();
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R '
+        '/Resources << >> >>',
+    '<< /Length ${stream.length} >>\nstream\n$stream\nendstream',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xref = buffer.length;
+  buffer.write('xref\n0 ${objects.length + 1}\n0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer.write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n'
+      'startxref\n$xref\n%%EOF');
+  return Uint8List.fromList(buffer.toString().codeUnits);
+}
+
+void main() {
+  // The worker chunks at 4096 operators; ~9000 operators here spans several
+  // chunks, so the resumable record emits partials between them.
+  final bytes = _linesPdf(3000);
+
+  test('a full-page record streams linework partials before the final',
+      () async {
+    final worker = PdfRenderWorker.startUncached(bytes);
+    addTearDown(worker.dispose);
+
+    final events = <String>[];
+    final partials = <List<PdfRenderCommand>>[];
+    final result = await worker.record(0, onPartial: (partial) {
+      events.add('partial');
+      partials.add(partial);
+    });
+    events.add('final');
+
+    expect(result, isNotNull, reason: 'the final record must still resolve');
+    expect(partials, isNotEmpty,
+        reason: 'a multi-chunk page must emit at least one partial');
+
+    // Ordering: every partial event precedes the single final event. The final
+    // event is appended only after `await`, so this proves the partials landed
+    // during the record, not after it.
+    expect(events.last, 'final');
+    expect(events.where((e) => e == 'partial').length, partials.length);
+    expect(events.indexOf('final'), events.length - 1);
+
+    // Each partial is a valid, non-empty prefix: no more commands than the
+    // final, and monotonically growing (a superset reveal).
+    for (final partial in partials) {
+      expect(partial, isNotEmpty);
+      expect(partial.length, lessThanOrEqualTo(result!.length));
+    }
+    for (var i = 1; i < partials.length; i++) {
+      expect(partials[i].length, greaterThanOrEqualTo(partials[i - 1].length),
+          reason: 'partials must grow, each a superset of the last');
+    }
+  });
+
+  test('requesting partials does not change the final buffer', () async {
+    final plainWorker = PdfRenderWorker.startUncached(bytes);
+    addTearDown(plainWorker.dispose);
+    final streamedWorker = PdfRenderWorker.startUncached(bytes);
+    addTearDown(streamedWorker.dispose);
+
+    final plain = await plainWorker.record(0);
+    var partialCount = 0;
+    final streamed =
+        await streamedWorker.record(0, onPartial: (_) => partialCount++);
+
+    expect(plain, isNotNull);
+    expect(streamed, isNotNull);
+    expect(partialCount, greaterThan(0));
+    // The sink is a pure observer: the completed recording is identical.
+    expect(streamed!.length, plain!.length);
+  });
+
+  test('a tiny single-chunk page emits no partial but still records', () async {
+    final worker = PdfRenderWorker.startUncached(_linesPdf(3));
+    addTearDown(worker.dispose);
+
+    var partialCount = 0;
+    final result = await worker.record(0, onPartial: (_) => partialCount++);
+
+    expect(result, isNotNull);
+    expect(partialCount, 0,
+        reason: 'a page recorded in one chunk has no prefix to reveal');
+  });
+
+  test('the cached production wrapper does not stream partials (PR1 is inert)',
+      () async {
+    // PdfRenderWorker.start wraps the backend in PdfCachingRenderWorker, whose
+    // shared-future dedup cannot fan a partial stream to late joiners yet
+    // (PR2). Opting in there must be a no-op, not a crash, and the final must
+    // still arrive.
+    final worker = PdfRenderWorker.start(bytes);
+    addTearDown(worker.dispose);
+
+    var partialCount = 0;
+    final result = await worker.record(0, onPartial: (_) => partialCount++);
+
+    expect(result, isNotNull, reason: 'the cached final must still resolve');
+    expect(partialCount, 0,
+        reason: 'the caching wrapper does not forward partials in PR1');
+  });
+}

--- a/packages/dart_pdf_editor/test/region_replay_index_worker_test.dart
+++ b/packages/dart_pdf_editor/test/region_replay_index_worker_test.dart
@@ -54,7 +54,7 @@ class _RoundTripIndexWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion}) async =>
+          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/test/render_worker_host_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_host_test.dart
@@ -36,7 +36,7 @@ class _FakeWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion}) async =>
+          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/test/render_worker_revision_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_revision_test.dart
@@ -37,6 +37,7 @@ class _FakeBackend extends PdfRenderWorker {
     bool decodeImages = true,
     int? commandLimit,
     PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
   }) async {
     recordCounts[pageIndex] = (recordCounts[pageIndex] ?? 0) + 1;
     if (gate != null) await gate!.future;

--- a/packages/dart_pdf_editor/test/render_worker_strips_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_strips_test.dart
@@ -588,7 +588,7 @@ class _BinLogWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) async {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async {
     recordCalls.add((pageIndex, priority));
     return null;
   }
@@ -653,7 +653,7 @@ class _DefaultWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion}) async =>
+          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -48,7 +48,7 @@ class _SyncWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) async {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async {
     if (_disposed || pageIndex < 0 || pageIndex >= _doc.pageCount) return null;
     final page = _doc.page(pageIndex);
     final previewOperationLimit = decodeImages ? null : commandLimit;
@@ -1113,7 +1113,7 @@ class _SeedWorker extends PdfRenderWorker {
           double? imagePixelRatio,
           bool decodeImages = true,
           int? commandLimit,
-          PdfRect? imageDecodeRegion}) async =>
+          PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async =>
       null;
 
   @override
@@ -1149,7 +1149,7 @@ class _CountingWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) async {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) async {
     calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
     commandLimits.add(commandLimit);
     if (returnNull || !active) return null;
@@ -1198,7 +1198,7 @@ class _ManualWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) {
     calls.add((pageIndex, annotations, decodeImages, imagePixelRatio));
     priorities.add(priority);
     final completer = Completer<List<PdfRenderCommand>?>();
@@ -1249,7 +1249,7 @@ class _HangingWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) {
     if (!active) return Future.value(null);
     callsByKey[(pageIndex, priority)] =
         (callsByKey[(pageIndex, priority)] ?? 0) + 1;

--- a/packages/dart_pdf_editor/test/vector_first_detail_error_test.dart
+++ b/packages/dart_pdf_editor/test/vector_first_detail_error_test.dart
@@ -156,7 +156,7 @@ class _FailingDetailWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) {
     if (decodeImages && imageDecodeRegion != null && _detailShouldFail) {
       detailRecordFailed = true;
       return Future.error(StateError('detail record failed'));

--- a/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
@@ -229,7 +229,7 @@ class _DeferredFullRecordWorker extends PdfRenderWorker {
       double? imagePixelRatio,
       bool decodeImages = true,
       int? commandLimit,
-      PdfRect? imageDecodeRegion}) {
+      PdfRect? imageDecodeRegion, PdfPartialRecordSink? onPartial}) {
     if (decodeImages && imageDecodeRegion != null) {
       if (!regionRecordStarted.isCompleted) regionRecordStarted.complete();
       return _regionRecord.future;


### PR DESCRIPTION
Part 1 of 3 for #564 (PDFium-style top-down progressive reveal). Splits the transport work into reviewable, default-off increments; this PR is **native-only, inert, and fully VM-tested** — no host consumer, no web change.

## Why

#564 wants the top band of a heavy page to paint first and fill downward, which needs a record job that emits partials *as it walks*. The interpreter side has been ready since #530/#566 (the resumable `PdfPageContentWalk`; chunk boundaries land only at page-level graphics state, which is what makes emitting a partial there safe). The blocker was the strictly 1:1 worker protocol — one request → one payload-bearing response. This PR breaks that on the native backend only.

## What changed

- **`PdfRenderWorker.record` gains `onPartial` (`PdfPartialRecordSink?`)** — each call delivers a spatially-growing *linework* prefix (image draws left as placeholders) before the future resolves with the final decoded buffer. A one-chunk page emits none.
- **Isolate backend streams it.** The record wire message carries a trailing `wantsPartials` bool; on the resumable (`decodeImages: true`) path, `_recordResumablePage` serializes `recorder.commands` after each *incomplete* chunk (`decodeImages: false, imagePlaceholders: true`) and ships `['partial', id, data]`. The main-side listener forwards it to the request's sink **without** clearing `_inFlight` or completing the `Completer`. A partial whose id no longer matches the in-flight request (disposed, or requeued under a new id after preemption) is dropped, and the worker stops emitting the instant its request loses the slot or is cancelled.
- **Pool forwards; caching wrapper deliberately drops.** `PdfCachingRenderWorker` collapses concurrent callers onto one shared future; fanning a stream to late joiners (who must replay already-emitted partials) is the **caching-dedup redesign PR2 owns**. Since `PdfRenderWorker.start()` returns the caching wrapper, **production is byte-identical** — the feature is reachable only through `startUncached`/the pool. Stub/web accept the param for interface parity and never call it.

## Why it's safe to land now

The subtle edges the issue flags (requeue-after-preemption across a shared future, cancel mid-stream, late-joiner replay) all live in the caching wrapper — which does not stream in PR1. The regression class that has bitten this subsystem before is web-only dart2js/`.toJS` hangs; PR1 makes **no web change**.

## Measurement

Inert by construction (guarded behind `onPartial != null`; caching drops it), so there is nothing to A/B yet — the 3–7× first-frame win is PR3's, measured on the web harness once a host paints the partials. Regression check: **`tool/perf.sh gate` → 12 inputs, 13 counters within 3%**, `render_trace_gate_test` green.

## Tests

`test/partial_record_test.dart`: a multi-chunk page streams ≥1 partial, all before the final; each partial is a non-empty prefix (≤ final command count) that monotonically grows; requesting partials doesn't change the final buffer; a one-chunk page emits none; the cached production wrapper streams none (the PR1 inert boundary). Existing worker suites (record/host/revision/strips/resume/early-prefix, 91 tests) stay green after adding the interface param to their fakes.

## Follow-ups (tracked on #564)

- **PR2:** caching worker shared-**stream** dedup with late-joiner replay; twin the web transport + entry; rebuild the bundle; `dart compile js` in CI.
- **PR3:** `transcriptFor` chunk yield + host progressive paint behind a flag; flip on once the first-frame win holds on the web harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)