### PR TITLE
perf(worker): bound the partial-stream cost — doubling emit + O(1) replay (#564 pt3)

### DIFF
--- a/doc/dev-log/2026-07-25-streaming-partials-564-pr3-costbound.md
+++ b/doc/dev-log/2026-07-25-streaming-partials-564-pr3-costbound.md
@@ -1,0 +1,84 @@
+# 2026-07-25 — Streaming record partials, PR3 of #564 (cost-bounding + a host-paint finding)
+
+PR1 (native transport) and PR2 (caching shared-stream dedup) landed the streaming
+*transport* for progressive record partials, both merged. This PR does the
+**cost-bounding** both adversarial reviews flagged as a must-fix before any
+consumer ships, and records a design finding that reshapes the remaining work.
+
+## Cost-bounding
+
+Two independent bounds, both previously O(n) or worse in the page's command
+count, now flat or logarithmic:
+
+1. **Doubling emit schedule** (`render_worker_isolate.dart`, `_recordResumable-
+   Page`). Each partial re-serializes the *whole accumulated* prefix, so emitting
+   one per chunk is O(commands²) across a page. Now partials fire only after
+   chunks 1, 2, 4, 8, … — O(log chunks) emits whose serialize work is a geometric
+   series dominated by the last (full-page) prefix, i.e. **O(commands) total**,
+   ~2× a single full serialize. It also fronts the reveals (dense early, sparse
+   late), which is where a top-down reveal matters. The schedule counters live on
+   `_SuspendedRecord`, so they persist across a preempt/resume instead of
+   restarting the cadence on requeue.
+
+2. **O(1) replay buffer** (`render_worker.dart`, `_InflightRecord`). PR2 buffered
+   every emitted partial for late-joiner replay — O(chunks) retention. But every
+   partial is a cumulative **superset** of its predecessors, so a late joiner only
+   needs the *latest* to be fully caught up. `_InflightRecord` now keeps a single
+   `_latest` instead of a list; present subscribers still get every partial live.
+
+Together these mean a consumer can stream a heavy page's reveal without the
+streaming path scaling worse than one extra full serialize plus one small
+retained buffer.
+
+## The host-paint finding (why the consumer is NOT in this PR)
+
+I wired a host consumer (`PdfPageView`, behind a default-off flag) onto the heavy
+`decodeImages: true` record — the multi-second image-decode pass — and painted
+each streamed linework prefix into the preview slot. A widget test with an
+image-bearing dense CAD fixture showed the mechanism works, but the perf log
+revealed it adds **no visible value where I hooked it**:
+
+```
+vector-first detail page=0 ... commands=12001
+raster kind=vector-first-full page=0 ... img=600x60   <- full linework already on screen
+```
+
+By the time the heavy `decodeImages: true` record runs, the **vector-first pass
+has already rastered the whole page's linework** into the preview. The streamed
+partials are linework prefixes with images excluded — i.e. a *subset* of what is
+already painted. The reveal only adds information if it lands **before** the
+vector-first full raster, which means hooking the stream into the first paint
+(replacing #527's single bounded early-prefix with a growing sequence) or
+reordering the vector-first raster — a real paint-ordering change whose value and
+smoothness can only be judged **visually, in a preview**. Nailing that blind
+would ship a flag that does redundant work, so I reverted the host consumer and
+left the placement to a follow-up done with a preview in the loop.
+
+This is the honest boundary the whole #564 rollout has respected: land the safe,
+testable, inert infrastructure; do the visually-judged UI integration with a
+human watching. The transport and its cost bounds are now all in; the consumer
+placement is the open design question.
+
+## Measurement
+
+Still no production streaming path (the consumer was reverted), so nothing to A/B
+— the first-frame win waits on the (visually-validated) consumer. `tool/perf.sh
+gate` → 12 inputs, 13 counters within 3%. The cost-bounding is proven by unit
+test, not the harness.
+
+## Tests
+
+`partial_record_test.dart`: a large page (~15 worker chunks) emits a handful of
+partials, not fifteen (the doubling bound), each a strictly larger prefix.
+`caching_partial_dedup_test.dart` and the rest of the partial suite stay green
+with keep-latest replay (a late joiner replays the latest prefix, which is a
+superset of all prior).
+
+## Follow-up (#564)
+
+The host progressive paint: decide where the reveal hooks so it lands *before*
+the vector-first full raster (a growing early-prefix sequence, or a vector-first
+reorder), validated on a deploy preview / native run; then the web transport twin
+(`render_worker_web` + entry) so the web preview shows it and `tool/perf.sh web`
+measures the first-frame win. The bundle-rebuild is no longer a blocker (#582
+removed `WORKER_REGEN_TOKEN`; the preview builds the real worker).

--- a/packages/dart_pdf_editor/lib/src/render_worker.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker.dart
@@ -1336,27 +1336,32 @@ class _CachedRecord {
 ///
 /// Concurrent callers for the same page share this: each that passed an
 /// `onPartial` sink [subscribe]s, and every partial the backend [emit]s reaches
-/// them all. A caller that joins after some partials landed replays the buffered
-/// prefixes on subscribe, so it is caught up before the live ones resume. When
-/// the dispatcher opted out of streaming, no partials are ever emitted and the
-/// buffer stays empty - joiners then simply await [future].
+/// them all. A caller that joins after some partials landed replays the most
+/// recent prefix on subscribe, so it is caught up before the live ones resume.
+/// When the dispatcher opted out of streaming, no partials are ever emitted and
+/// there is nothing to replay - joiners then simply await [future].
 class _InflightRecord {
   final _completer = Completer<List<PdfRenderCommand>?>();
 
-  /// Prefixes emitted so far, kept so a late [subscribe] can replay them. Held
-  /// only until the decode completes (this record is then dropped from the map).
-  final _partials = <List<PdfRenderCommand>>[];
+  /// The most recent partial, kept so a late [subscribe] can catch a joiner up.
+  /// Only the latest is retained, not the whole history: every partial is a
+  /// cumulative superset of its predecessors (#564), so the newest one alone
+  /// brings a joiner fully current - O(1) memory instead of O(chunks). Present
+  /// subscribers still receive every partial live through [emit]. Cleared when
+  /// the decode completes (this record is then dropped from the map).
+  List<PdfRenderCommand>? _latest;
   final _sinks = <PdfPartialRecordSink>[];
   var _done = false;
 
   Future<List<PdfRenderCommand>?> get future => _completer.future;
 
-  /// Delivers a partial to every current subscriber and buffers it for late
-  /// joiners. A no-op once the record has completed (a stray late partial from a
-  /// backend that raced its own final must not reach a caller after its future).
+  /// Delivers a partial to every current subscriber and retains it as the latest
+  /// for late joiners. A no-op once the record has completed (a stray late
+  /// partial from a backend that raced its own final must not reach a caller
+  /// after its future).
   void emit(List<PdfRenderCommand> partial) {
     if (_done) return;
-    _partials.add(partial);
+    _latest = partial;
     // Iterate a copy: a sink that itself calls record() (subscribing another) on
     // this key would otherwise mutate _sinks mid-iteration.
     for (final sink in _sinks.toList(growable: false)) {
@@ -1364,32 +1369,27 @@ class _InflightRecord {
     }
   }
 
-  /// Adds [sink], first replaying every partial already emitted so the joiner is
-  /// not behind. Replays synchronously - the caller passed the sink into
+  /// Adds [sink], first replaying the latest partial (if any) so the joiner is
+  /// caught up. Replays synchronously - the caller passed the sink into
   /// record(), so it may fire before that call returns its future.
   void subscribe(PdfPartialRecordSink sink) {
     if (_done) return;
-    // Iterate a copy for the same reason [emit] copies _sinks: if a replayed
-    // sink synchronously drove the backend to emit (growing _partials), a bare
-    // loop would throw ConcurrentModificationError. Not reachable while the
-    // backend is suspended during replay, but PR3 wires a real consumer.
-    for (final partial in _partials.toList(growable: false)) {
-      sink(partial);
-    }
+    final latest = _latest;
+    if (latest != null) sink(latest);
     _sinks.add(sink);
   }
 
   void complete(List<PdfRenderCommand>? commands) {
     _done = true;
     _sinks.clear();
-    _partials.clear();
+    _latest = null;
     if (!_completer.isCompleted) _completer.complete(commands);
   }
 
   void completeError(Object error, StackTrace stackTrace) {
     _done = true;
     _sinks.clear();
-    _partials.clear();
+    _latest = null;
     if (!_completer.isCompleted) _completer.completeError(error, stackTrace);
   }
 }

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -1097,6 +1097,14 @@ Future<Uint8List?> _recordResumablePage(
   }
 
   final walk = entry.walk;
+  // Emit partials on a DOUBLING chunk schedule (after chunks 1, 2, 4, 8, ...)
+  // rather than every chunk. Each partial re-serializes the whole accumulated
+  // prefix, so emitting every chunk is O(commands^2) across a page; a doubling
+  // schedule is O(log n) emits whose serialize work is a geometric series
+  // dominated by the last (full-page) prefix - i.e. O(commands) total, ~2x one
+  // full serialize. It also fronts the reveals: dense early (1,2,4...), when a
+  // top-down reveal matters most, sparse late. `entry.emittedChunks` persists
+  // across a preempt/resume so the schedule doesn't restart on requeue.
   while (!await walk.advance(operations: _resumeRecordChunkOperations)) {
     if (token.cancelled) {
       // Keep the partial recording so the requeued render resumes here rather
@@ -1104,29 +1112,26 @@ Future<Uint8List?> _recordResumablePage(
       suspended.keep(entry);
       throw const PdfCancelledException();
     }
-    // Emit a progressive linework prefix (#564): a chunk boundary is always at
-    // page-level graphics state, so the commands recorded so far serialize to a
-    // valid, replayable buffer. Images are left as placeholders (decodeImages
-    // false) - the prefix is the fast top-down reveal; the final decoded buffer
-    // follows when the walk completes. Each partial is a superset of the last.
-    //
-    // Note this re-serializes the whole accumulated prefix every chunk, so the
-    // streaming path is O(commands^2) in serialize work across a page (and the
-    // main side re-deserializes each partial). Harmless while off-by-default
-    // (no consumer reaches here), but the host-facing PR3 must throttle emission
-    // or ship suffix-only deltas rather than the full prefix each time.
-    if (onPartial != null) {
-      final partial = serializeCommands(entry.recorder.commands,
-          cos: document.cos,
-          decodeImages: false,
-          maxImagePixelRatio: imagePixelRatio,
-          imageDecodeRegion: imageDecodeRegion,
-          imagePlaceholders: true,
-          compactStateScopes: true);
-      // Null only on an unserializable image, which placeholders preclude here;
-      // if it ever happens, skip this partial - the final buffer still arrives.
-      if (partial != null) onPartial(partial);
+    entry.chunksAdvanced++;
+    if (onPartial == null || entry.chunksAdvanced < entry.nextEmitAtChunk) {
+      continue;
     }
+    entry.nextEmitAtChunk *= 2;
+    // A chunk boundary is always at page-level graphics state, so the commands
+    // recorded so far serialize to a valid, replayable buffer. Images are left
+    // as placeholders (decodeImages false) - the prefix is the fast top-down
+    // reveal; the final decoded buffer follows when the walk completes. Each
+    // partial is a superset of the last.
+    final partial = serializeCommands(entry.recorder.commands,
+        cos: document.cos,
+        decodeImages: false,
+        maxImagePixelRatio: imagePixelRatio,
+        imageDecodeRegion: imageDecodeRegion,
+        imagePlaceholders: true,
+        compactStateScopes: true);
+    // Null only on an unserializable image, which placeholders preclude here;
+    // if it ever happens, skip this partial - the final buffer still arrives.
+    if (partial != null) onPartial(partial);
   }
 
   if (annotations) entry.interpreter.drawAnnotations(entry.page);
@@ -1153,6 +1158,12 @@ class _SuspendedRecord {
   final RecordingPdfDevice recorder;
   final PdfInterpreter interpreter;
   final PdfPageContentWalk walk;
+
+  // Progressive-partial schedule (#564), carried across a preempt/resume so the
+  // doubling cadence continues rather than restarting: total chunks advanced so
+  // far, and the chunk count at which the next partial is emitted (1, 2, 4, ...).
+  int chunksAdvanced = 0;
+  int nextEmitAtChunk = 1;
 }
 
 /// A one-slot cache of the most recently suspended full-page record.

--- a/packages/dart_pdf_editor/test/partial_record_test.dart
+++ b/packages/dart_pdf_editor/test/partial_record_test.dart
@@ -96,6 +96,35 @@ void main() {
     }
   });
 
+  test('the doubling emit schedule keeps partial count logarithmic (#564 pt3)',
+      () async {
+    // A large page spans many worker chunks (4096 ops each). Emitting a partial
+    // every chunk would re-serialize the whole growing prefix each time -
+    // O(commands^2). The doubling schedule (emit after chunks 1, 2, 4, 8, ...)
+    // caps the emit count at O(log chunks), so a page with ~15 chunks yields a
+    // handful of partials, not fifteen. This pins that bound.
+    final big = _linesPdf(20000); // ~60k ops -> ~15 worker chunks
+    final worker = PdfRenderWorker.startUncached(big);
+    addTearDown(worker.dispose);
+
+    final partials = <List<PdfRenderCommand>>[];
+    final result = await worker.record(0, onPartial: partials.add);
+
+    expect(result, isNotNull);
+    // ~15 chunks -> emits at chunks 1,2,4,8 = 4 partials. Bound generously to
+    // stay robust to chunk-count drift while still proving it is logarithmic,
+    // not linear (linear would be ~15).
+    expect(partials.length, greaterThanOrEqualTo(2));
+    expect(partials.length, lessThanOrEqualTo(6),
+        reason: 'doubling schedule must keep emits logarithmic in chunks, '
+            'got ${partials.length}');
+    // Each doubling step is a strictly larger prefix (a real reveal, not repeats).
+    for (var i = 1; i < partials.length; i++) {
+      expect(partials[i].length, greaterThan(partials[i - 1].length),
+          reason: 'each scheduled partial should cover more of the page');
+    }
+  });
+
   test('requesting partials does not change the final buffer', () async {
     final plainWorker = PdfRenderWorker.startUncached(bytes);
     addTearDown(plainWorker.dispose);


### PR DESCRIPTION
Part 3 of #564, on `main` (PR1 #589 and PR2 #590 are merged). This lands the **cost-bounding** both adversarial reviews flagged as a must-fix before any consumer ships — and reports a design finding that reshapes the remaining work.

## Cost-bounding (two independent bounds)

1. **Doubling emit schedule** (`render_worker_isolate.dart`). Each partial re-serializes the *whole accumulated* prefix, so emitting one per chunk is **O(commands²)**. Partials now fire only after chunks 1, 2, 4, 8, … — O(log chunks) emits whose serialize work is a geometric series dominated by the last full-page prefix, i.e. **O(commands) total** (~2× one full serialize). It also fronts the reveals (dense early, sparse late). The schedule counters live on `_SuspendedRecord`, so they persist across a preempt/resume instead of restarting the cadence.

2. **O(1) replay buffer** (`render_worker.dart`, `_InflightRecord`). PR2 buffered *every* emitted partial for late-joiner replay — O(chunks) retention. But each partial is a cumulative **superset** of its predecessors, so a late joiner only needs the *latest* to be caught up. Keep a single `_latest`, not a list; present subscribers still get every partial live.

## Why the host consumer is NOT here (the finding)

I wired a host consumer (`PdfPageView`, default-off flag) onto the heavy `decodeImages: true` record and tested it with an image-bearing dense CAD fixture. The mechanism works, but the perf log showed it adds **no visible value where I hooked it**:

```
vector-first detail page=0 ... commands=12001
raster kind=vector-first-full page=0 ... img=600x60   <- full linework already on screen
```

By the time the heavy record runs, the **vector-first pass has already rastered the whole page's linework** into the preview. The streamed partials are linework prefixes with images excluded — a *subset* of what's already painted. The reveal only adds information if it lands **before** the vector-first raster (replacing #527's single bounded early-prefix with a growing sequence, or reordering the vector-first raster) — a paint-ordering change whose value and smoothness can only be judged **visually, in a preview**. Nailing it blind would ship a flag that does redundant work, so I reverted the consumer and left the placement to a follow-up done with a preview in the loop.

This is the boundary the whole #564 rollout has respected: land the safe, testable, inert infrastructure; do the visually-judged UI integration with a human watching.

## Measurement

Still no production streaming path (consumer reverted), so nothing to A/B — the first-frame win waits on the validated consumer. `tool/perf.sh gate` → 12 inputs, 13 counters within 3%. The cost-bounding is proven by unit test.

## Tests

`partial_record_test.dart` pins the doubling bound (a ~15-chunk page emits a handful of partials, not fifteen, each a strictly larger prefix). The dedup suite stays green with keep-latest replay.

## Follow-up (#564)

The host progressive paint: decide where the reveal hooks so it lands *before* the vector-first full raster, validated on a preview / native run; then the web transport twin so the web preview shows it and `tool/perf.sh web` measures the first-frame win. The bundle-rebuild is **no longer a blocker** — #582 removed `WORKER_REGEN_TOKEN`, and the preview builds the real worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)