### PR TITLE
perf(test): scanned-book JBIG2 scenario with shared /JBIG2Globals (#557)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,10 @@ open/search/edit) live in `app/tool/perf/scenarios.json`; add one for the
 workload your change touches if none fits (harness method + JSON entry —
 no driver change, see `app/tool/perf/README.md`). VM-layer changes still
 A/B through `tool/perf.sh diff`; the web harness catches dart2js-only and
-render/decode/memory effects the NullDevice VM sweep can't.
+render/memory effects the NullDevice VM sweep can't. Image-codec changes do
+have a VM window: a scenario can opt into the `decodeImages` measure
+(`"measures"` in scenarios.json), which times `decodePdfImagePixels` over
+every image the pages draw and reports `decodeMs`.
 
 ## Layering rules (strict)
 

--- a/doc/dev-log/2026-07-25-jbig2-scanned-book-scenario-557.md
+++ b/doc/dev-log/2026-07-25-jbig2-scanned-book-scenario-557.md
@@ -1,0 +1,118 @@
+# JBIG2 scanned-book perf scenario, and the #532 headline number (#557)
+
+`#532` (globals dictionary cache) landed justified *by construction* - a map
+copy replacing per-page symbol arithmetic-decode, plus a byte-identical
+cache-equivalence test - because nothing in the corpus could exhibit it. Every
+in-repo JBIG2 file inlines its globals into a single image stream (the pdfjs
+`bitmap-*`/`jbig2_*` samples) or is one image on one page (ghent GWG173), and
+the saving only exists when **many** page images share **one** `/JBIG2Globals`
+stream. This session built that workload and measured it.
+
+## A pure-Dart JBIG2 encoder instead of jbig2enc
+
+The issue assumed a pre-generated doc committed under `tool/perf/cache/`,
+because producing this shape normally needs `jbig2enc` (absent from CI, and
+JBIG2 arithmetic *encoding* was out of scope for our writers). It turned out
+cheaper to just write the encoder: the decoder already defines every context
+model, so the encoder is its mirror, and the only genuinely new algorithm is
+the MQ *coder* (T.88 Annex E.3 - CODEMPS/CODELPS, RENORME, BYTEOUT with carry
+propagation into the byte already written, and the SETBITS flush).
+
+`packages/pdf_test_fixtures/lib/src/jbig2_encoder.dart`, ~200 lines of profile:
+
+- MQ encoder + the Annex A.2 integer coder (IADH/IADW/IAEX/IADT/IAFS/IADS) and
+  IAID, each written directly against the decoder's `decodeInt`/`decodeId` so
+  the bit order and `prev` context walk match by inspection;
+- generic region encoding, template 0 with the nominal AT pixels, TPGDON off -
+  it re-uses the decoder's "sort the combined template by row then column"
+  rule, which is the only thing the two sides have to agree on;
+- one symbol dictionary segment (SDHUFF=0, REFAGG=0) for the globals stream,
+  symbols in height classes, export flags as `(skip 0, export all)`;
+- page-info + immediate text region segments (SBHUFF=0, SBSTRIPS=1, TOPLEFT)
+  per page image.
+
+Gotcha worth writing down: the text region's **last strip must not emit a
+closing OOB**. The decoder breaks out of the strip loop the moment `decoded`
+reaches `SBNUMINSTANCES`, before reading another IADS, so an encoder that
+symmetrically closes every strip desynchronises the final bytes.
+
+Validated by round-trip against the shipping decoder in
+`packages/pdf_cos/test/jbig2_roundtrip_test.dart` (place symbols, decode,
+compare to the bitmap composed directly). That is circular by nature - the
+encoder is checked against our own decoder - which is fine for a perf fixture
+and is *not* claimed as decoder validation; the decoder's own KATs against
+jbig2enc/jbig2dec output are unchanged and still the source of truth there.
+
+## The document
+
+`packages/pdf_test_fixtures/tool/gen_jbig2_scanned_pdf.dart` - 32 pages,
+1700x2200 px images (~200 dpi Letter), one shared 900-symbol globals stream
+(4.5 KB), ~2.7k symbol instances per page, 125 KB total, deterministic from a
+seed. Glyphs are stroke-built (stem + bar/bowl/diagonal/descender) rather than
+noise, so the arithmetic contexts adapt the way they do on real scanned text;
+ink coverage lands at 7.5%. Each page draws from a sliding third of the
+dictionary - the scanned-book property that makes the saving real: before
+#532 every page re-decoded the *whole* book-wide dictionary while only ever
+drawing a slice of it.
+
+Wired into `gen_perf_docs.sh` (it *is* generated in CI, unlike the
+cjpeg/opj_compress-dependent docs), `nightly.sh`, and pre-seeded by
+`backfill.sh`.
+
+## The vm-sweep had no window on image decode
+
+First run of the new scenario reported `interpretMs` 4.7 ms for 32 pages -
+because `perf_sweep`'s `NullDevice` swallows `drawImage`, and the interpreter
+hands the device an undecoded `PdfImageRequest`. The VM sweep never decoded an
+image; the "exercises image decode" note on `image-heavy` was only ever true of
+its `image-render` companion.
+
+So `perf_sweep` gained a `decodeImages` measure: interpret with a device that
+*keeps* the image requests, then time `decodePdfImagePixels` over them - the
+same pure-Dart path the render worker runs, no Flutter engine needed. It is
+opt-in via the scenario's existing `measures` key (it is the one measure that
+costs real time on image-heavy corpora, and every other scenario exists to
+track parse/interpret). New `decodeMs`/`imagesDecoded` result fields,
+`p50/p95/maxDecodeMsPerPage` in the summary, `decodeMs` added to `diff.dart`'s
+default metric list and the dashboard's curated order. Missing metrics are
+skipped per-metric by `diff.dart`, so old history stays comparable.
+
+`perf_diff.sh` needed two fixes to A/B a scenario that did not exist at the
+ref: the harness files (perf_sweep, perf_run_context, gen_cad_pdf,
+scenarios.json) are now **always** grafted into the ref worktree rather than
+only when absent - both sides must run the same apparatus, and a measure or
+scenario added after the ref exists only here - and `tool/perf/cache/` is
+pre-seeded into the worktree (`cp -Rn`, so the reused-worktree path stays
+cheap). The PdfPerf facade under `lib/` keeps the copy-only-if-absent rule:
+that is library code the ref must keep measuring for itself. This also
+unblocks `tool/perf.sh diff <ref> image-heavy`, which had the same problem.
+
+## The number
+
+`tool/perf.sh diff` between `d41fb18^` and `d41fb18` (the #532 commit
+isolated, harness and corpus grafted identically onto both), 3 interleaved
+runs, `jbig2-scanned-sweep`:
+
+| metric | before | after | ratio |
+|---|---|---|---|
+| decodeMs (32 pages) | 2769 ms | 1825 ms | **0.659x** |
+| openMs | 2.17 | 2.04 | 0.94x |
+| interpretMs | 4.32 | 3.71 | 0.86x |
+
+**1.52x faster image decode** on the scanned book. Isolating just the JBIG2
+decoder (decode each page with `debugResetGlobalsCache()` before it vs. not,
+excluding the 1bpp->RGBA expansion `decodePdfImagePixels` adds) puts the
+codec-level ratio at **1.92x** - 1967 ms vs 1026 ms over the same 32 pages.
+Both scale with symbols x pages, as predicted.
+
+The `jbig2-scanned-render` companion (flutter-render, 4 pages) is in for the
+raster trend but is *not* where the #532 number comes from: across the same
+two commits its `renderMs` ratios were 0.82x and 1.08x - noise. Expected, and
+worth not over-reading. Rasterization there is dominated by painting a
+1700x2200 image, the decoded-image cache means each page decodes once, and 4
+pages leaves only three saved globals decodes (~90 ms) inside an ~800 ms
+render on a 4-core box.
+
+So: #532's justification-by-construction was right, and the harness now shows
+it. `jbig2-scanned-sweep` is the regression guard for the JBIG2 symbol path
+from here.

--- a/packages/pdf_cos/test/jbig2_roundtrip_test.dart
+++ b/packages/pdf_cos/test/jbig2_roundtrip_test.dart
@@ -1,0 +1,141 @@
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+/// Round-trips the pure-Dart JBIG2 encoder in pdf_test_fixtures through the
+/// shipping decoder. The encoder exists to build the scanned-book perf
+/// scenario (#557) - a separate /JBIG2Globals symbol dictionary shared by many
+/// page images, the one shape no corpus file has - so what has to hold is that
+/// its output decodes to exactly the bitmaps that went in.
+void main() {
+  /// The rendered page as a `width * height` list of 0/1 ink values, unpacking
+  /// the decoder's PDF-polarity output (a 0 bit is black).
+  List<int> ink(Uint8List packed, int width, int height) {
+    final rowBytes = (width + 7) >> 3;
+    return [
+      for (var y = 0; y < height; y++)
+        for (var x = 0; x < width; x++)
+          (packed[y * rowBytes + (x >> 3)] >> (7 - (x & 7))) & 1 ^ 1,
+    ];
+  }
+
+  /// The same page composed directly, as the decoder should reproduce it.
+  List<int> expected(
+    int width,
+    int height,
+    List<Jbig2Bitmap> symbols,
+    List<Jbig2Placement> placements,
+  ) {
+    final page = Jbig2Bitmap(width, height);
+    for (final placement in placements) {
+      final symbol = symbols[placement.symbol];
+      for (var y = 0; y < symbol.height; y++) {
+        for (var x = 0; x < symbol.width; x++) {
+          if (symbol.get(x, y) != 0) page.set(placement.x + x, placement.y + y, 1);
+        }
+      }
+    }
+    return page.data.toList();
+  }
+
+  /// A deterministic, glyph-shaped symbol: a left stem plus a feature or two,
+  /// so the arithmetic contexts adapt the way they do on real text.
+  Jbig2Bitmap glyph(int seed, int width, int height) {
+    final bitmap = Jbig2Bitmap(width, height);
+    bitmap.fillRect(1, 1, 2, height - 2);
+    if (seed.isEven) bitmap.fillRect(1, height ~/ 2, width - 3, 2);
+    if (seed % 3 == 0) bitmap.fillRect(width - 3, 1, 2, height - 2);
+    if (seed % 5 == 0) bitmap.fillRect(1, 1, width - 3, 2);
+    return bitmap;
+  }
+
+  test('a shared globals dictionary decodes back to the placed symbols', () {
+    final symbols = sortSymbolsForDictionary([
+      for (var i = 0; i < 12; i++) glyph(i, 6 + i % 4, 8 + i % 5),
+    ]);
+    final globals = encodeJbig2Globals(symbols);
+
+    const width = 160;
+    const height = 90;
+    // Three lines of "text", the shape the scanned-book scenario emits.
+    final placements = <Jbig2Placement>[];
+    for (var line = 0; line < 3; line++) {
+      var x = 4;
+      for (var i = 0; i < 14; i++) {
+        final id = (line * 7 + i * 5) % symbols.length;
+        placements.add(Jbig2Placement(id, x, 6 + line * 24));
+        x += symbols[id].width + 2;
+      }
+    }
+    final page = encodeJbig2TextPage(
+      width: width,
+      height: height,
+      symbols: symbols,
+      placements: placements,
+    );
+
+    Jbig2Decoder.debugResetGlobalsCache();
+    final decoded = Jbig2Decoder.decode(
+      data: page,
+      globals: globals,
+      width: width,
+      height: height,
+    );
+    expect(decoded, isNotNull);
+    expect(ink(decoded!, width, height),
+        expected(width, height, symbols, placements));
+  });
+
+  test('a second page reuses the cached globals and decodes identically (#532)',
+      () {
+    final symbols = sortSymbolsForDictionary([
+      for (var i = 0; i < 9; i++) glyph(i, 7 + i % 3, 10 + i % 4),
+    ]);
+    final globals = encodeJbig2Globals(symbols);
+    const width = 96;
+    const height = 40;
+    final placements = [
+      for (var i = 0; i < 8; i++) Jbig2Placement(i % symbols.length, 2 + i * 11, 5),
+      for (var i = 0; i < 8; i++) Jbig2Placement(i % symbols.length, 2 + i * 11, 22),
+    ];
+    final page = encodeJbig2TextPage(
+      width: width,
+      height: height,
+      symbols: symbols,
+      placements: placements,
+    );
+
+    Jbig2Decoder.debugResetGlobalsCache();
+    Uint8List? run() => Jbig2Decoder.decode(
+          data: page,
+          globals: globals,
+          width: width,
+          height: height,
+        );
+    final cold = run();
+    final warm = run();
+    expect(cold, isNotNull);
+    expect(warm, cold);
+    expect(ink(cold!, width, height),
+        expected(width, height, symbols, placements));
+  });
+
+  test('the page stream alone carries no symbols', () {
+    final symbols = sortSymbolsForDictionary([glyph(1, 8, 12), glyph(2, 9, 12)]);
+    final page = encodeJbig2TextPage(
+      width: 40,
+      height: 20,
+      symbols: symbols,
+      placements: const [Jbig2Placement(0, 2, 2), Jbig2Placement(1, 14, 2)],
+    );
+    // No globals: the text region refers to a dictionary that isn't there, so
+    // the decoder bails rather than inventing symbols.
+    Jbig2Decoder.debugResetGlobalsCache();
+    expect(
+      Jbig2Decoder.decode(data: page, width: 40, height: 20),
+      isNull,
+    );
+  });
+}

--- a/packages/pdf_graphics/tool/perf_sweep.dart
+++ b/packages/pdf_graphics/tool/perf_sweep.dart
@@ -8,6 +8,9 @@
 //   interpretMs   interpret all pages (up to --max-pages) to a NullDevice
 //   extractMs     text extraction over the same pages
 //   saveMs        incremental-save round trip (catalog rewrite)
+//   decodeMs      pure-Dart decode of every image the pages draw (opt-in, see
+//                 the "measures" scenario key) - the codec half of a render,
+//                 which the NullDevice interpret pass never reaches
 //   peakRssBytes  the child process's ProcessInfo.maxRss
 //
 // Each file is measured in its own killable child process (parent re-spawns
@@ -40,7 +43,24 @@ class NullDevice implements PdfDevice {
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
-const _allMeasures = {'open', 'firstPage', 'interpret', 'extract', 'save'};
+/// A [NullDevice] that keeps the image draws, so the `decodeImages` measure can
+/// run the decode a real device would - without a Flutter engine.
+class _ImageCollectingDevice implements PdfDevice {
+  final requests = <PdfImageRequest>[];
+
+  @override
+  void drawImage(PdfImageRequest request) => requests.add(request);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+const _defaultMeasures = {'open', 'firstPage', 'interpret', 'extract', 'save'};
+
+/// `decodeImages` is opt-in: it is the only measure that costs real time on
+/// image-heavy corpora, and most scenarios exist to track the parse/interpret
+/// path. Scenarios ask for it with the "measures" key.
+const _allMeasures = {..._defaultMeasures, 'decodeImages'};
 
 class _Args {
   String? corpus;
@@ -52,7 +72,7 @@ class _Args {
   int repeat = 3;
   int timeoutS = 120;
   bool phases = false;
-  Set<String> measures = _allMeasures;
+  Set<String> measures = _defaultMeasures;
 }
 
 _Args _parse(List<String> argv) {
@@ -96,7 +116,7 @@ _Args _parse(List<String> argv) {
     stderr.writeln(
         'usage: perf_sweep.dart <corpus-dir-or-file> | --scenario <name>\n'
         '  [--max-pages N] [--repeat N] [--timeout S] [--phases]\n'
-        '  [--measures open,firstPage,interpret,extract,save]\n'
+        '  [--measures open,firstPage,interpret,extract,save,decodeImages]\n'
         '  [--out envelope.json] [--append-history history.ndjson]');
     exit(2);
   }
@@ -115,6 +135,7 @@ Map<String, Object?> _measureOne(_Args args) {
 
   var pages = 0;
   var pagesRendered = 0;
+  var images = 0;
   String? error;
   final best = <String, double>{};
   void record(String key, int us) {
@@ -177,6 +198,33 @@ Map<String, Object?> _measureOne(_Args args) {
       record('extractMs', sw.elapsedMicroseconds);
     }
 
+    if (args.measures.contains('decodeImages')) {
+      // Collect the image draws first (interpretation is already measured
+      // above), then time only the decode - the pure-Dart path the render
+      // worker runs, so the number is engine-free but real.
+      final collector = _ImageCollectingDevice();
+      var done = 0;
+      for (var i = 0; i < limit; i++) {
+        try {
+          PdfInterpreter(cos: doc.cos, device: collector).drawPage(doc.page(i));
+          done++;
+        } catch (e) {
+          error ??= 'collect images page $i: $e';
+        }
+      }
+      if (done > pagesRendered) pagesRendered = done;
+      sw.reset();
+      for (final request in collector.requests) {
+        try {
+          decodePdfImagePixels(doc.cos, request.stream);
+        } catch (e) {
+          error ??= 'decode image: $e';
+        }
+      }
+      record('decodeMs', sw.elapsedMicroseconds);
+      images = collector.requests.length;
+    }
+
     if (args.measures.contains('save')) {
       sw.reset();
       try {
@@ -205,6 +253,8 @@ Map<String, Object?> _measureOne(_Args args) {
     if (best.containsKey('interpretMs')) 'interpretMs': best['interpretMs'],
     if (best.containsKey('extractMs')) 'extractMs': best['extractMs'],
     if (best.containsKey('saveMs')) 'saveMs': best['saveMs'],
+    if (best.containsKey('decodeMs')) 'decodeMs': best['decodeMs'],
+    if (best.containsKey('decodeMs')) 'imagesDecoded': images,
     'peakRssBytes': ProcessInfo.maxRss,
     'error': error,
     if (args.phases) 'perf': PdfPerf.snapshot().toJson(),
@@ -404,6 +454,7 @@ Map<String, Object?> _aggregate(List<Map<String, Object?>> results) {
     ...dist('interpretMs', perPage: true),
     ...dist('extractMs', perPage: true),
     ...dist('saveMs'),
+    ...dist('decodeMs', perPage: true),
     if (rss.isNotEmpty) 'maxPeakRssBytes': percentile(rss, 100).round(),
   };
 }

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -4,6 +4,7 @@ export 'src/cad_image_strip.dart';
 export 'src/cad_strip.dart';
 export 'src/encrypted.dart';
 export 'src/icc_profiles.dart';
+export 'src/jbig2_encoder.dart';
 export 'src/pkix_ltv.dart';
 export 'src/raster_underlay_sheet.dart';
 export 'src/rtl_text.dart';

--- a/packages/pdf_test_fixtures/lib/src/jbig2_encoder.dart
+++ b/packages/pdf_test_fixtures/lib/src/jbig2_encoder.dart
@@ -1,0 +1,491 @@
+/// A minimal pure-Dart JBIG2 *encoder* for the PDF embedded profile
+/// (ITU-T T.88), enough to build the one shape no in-repo corpus has: a
+/// separate `/JBIG2Globals` stream carrying a multi-symbol arithmetic symbol
+/// dictionary, referenced by many per-page `JBIG2Decode` images - the scanned
+/// book (issue #557).
+///
+/// Scope is deliberately narrow, matching what `jbig2enc -s` emits and what
+/// [Jbig2Decoder] reads back:
+///
+/// * MQ arithmetic coding (Annex E), no Huffman tables;
+/// * generic region template 0 with the nominal AT pixels, TPGDON off;
+/// * one symbol dictionary segment (SDHUFF=0, REFAGG=0) per globals stream;
+/// * one page-info + one immediate text region segment (SBHUFF=0, REFINE=0,
+///   SBSTRIPS=1, TOPLEFT reference corner) per page stream.
+///
+/// Real-world *encoding* quality (symbol clustering, refinement, generic-region
+/// tuning) is out of scope - the goal is a decodable, representative workload,
+/// not a competitive encoder. The round-trip is asserted against the shipping
+/// decoder in `pdf_cos/test/jbig2_roundtrip_test.dart`.
+library;
+
+import 'dart:typed_data';
+
+/// A 1-bit-per-pixel bitmap in JBIG2 polarity: 1 is black.
+class Jbig2Bitmap {
+  Jbig2Bitmap(this.width, this.height) : data = Uint8List(width * height);
+
+  final int width;
+  final int height;
+  final Uint8List data;
+
+  int get(int x, int y) {
+    if (x < 0 || x >= width || y < 0 || y >= height) return 0;
+    return data[y * width + x];
+  }
+
+  void set(int x, int y, int value) {
+    if (x < 0 || x >= width || y < 0 || y >= height) return;
+    data[y * width + x] = value;
+  }
+
+  /// Fills the axis-aligned rectangle at ([x], [y]) with black.
+  void fillRect(int x, int y, int w, int h) {
+    for (var dy = 0; dy < h; dy++) {
+      for (var dx = 0; dx < w; dx++) {
+        set(x + dx, y + dy, 1);
+      }
+    }
+  }
+}
+
+/// One symbol instance on a page: [symbol] drawn with its top-left corner at
+/// ([x], [y]) in image pixels.
+class Jbig2Placement {
+  const Jbig2Placement(this.symbol, this.x, this.y);
+
+  final int symbol;
+  final int x;
+  final int y;
+}
+
+/// Encodes [symbols] as a standalone `/JBIG2Globals` stream: a single
+/// arithmetic symbol dictionary segment (number 0) exporting every symbol.
+///
+/// Symbols are coded in height classes, so [symbols] must be ordered by
+/// non-decreasing height - run it through [sortSymbolsForDictionary] first.
+/// Symbol ids are positions in that list; pass the same list to
+/// [encodeJbig2TextPage].
+Uint8List encodeJbig2Globals(List<Jbig2Bitmap> symbols) {
+  if (symbols.isEmpty) throw ArgumentError('a dictionary needs symbols');
+  for (var i = 1; i < symbols.length; i++) {
+    if (symbols[i].height < symbols[i - 1].height) {
+      throw ArgumentError('symbols must be sorted by non-decreasing height');
+    }
+  }
+  final sorted = symbols;
+  final payload = BytesBuilder()
+    ..add(_u16(0)) // SDHUFF=0, REFAGG=0, SDTEMPLATE=0, no retained contexts
+    ..add(_atBytes(_nominalAt)) // SDAT: template 0 takes four AT pixels
+    ..add(_u32(sorted.length)) // SDNUMEXSYMS
+    ..add(_u32(sorted.length)); // SDNUMNEWSYMS
+
+  final mq = _MqEncoder();
+  final generic = _ArithContexts(1 << 16);
+  final iadh = _ArithContexts(512);
+  final iadw = _ArithContexts(512);
+  final iaex = _ArithContexts(512);
+
+  var heightClass = 0;
+  var index = 0;
+  while (index < sorted.length) {
+    final height = sorted[index].height;
+    mq.encodeInt(iadh, height - heightClass);
+    heightClass = height;
+    var symbolWidth = 0;
+    while (index < sorted.length && sorted[index].height == height) {
+      final symbol = sorted[index++];
+      mq.encodeInt(iadw, symbol.width - symbolWidth);
+      symbolWidth = symbol.width;
+      _encodeGeneric(mq, generic, symbol);
+    }
+    mq.encodeInt(iadw, null); // OOB closes the height class
+  }
+  // Export flags are alternating (skip, export) runs: skip none, export all.
+  mq
+    ..encodeInt(iaex, 0)
+    ..encodeInt(iaex, sorted.length);
+  payload.add(mq.flush());
+
+  return _segment(
+    number: _globalsDictionarySegment,
+    type: 0, // symbol dictionary
+    referred: const [],
+    page: 0,
+    payload: payload.takeBytes(),
+  );
+}
+
+/// [symbols] in the height-class order a symbol dictionary needs, ties broken
+/// by the caller's order (Dart's [List.sort] is not stable on its own).
+List<Jbig2Bitmap> sortSymbolsForDictionary(List<Jbig2Bitmap> symbols) {
+  final indexed = [
+    for (var i = 0; i < symbols.length; i++) (symbols[i], i),
+  ]..sort((a, b) =>
+      a.$1.height != b.$1.height ? a.$1.height - b.$1.height : a.$2 - b.$2);
+  return [for (final (symbol, _) in indexed) symbol];
+}
+
+/// Encodes one page's `JBIG2Decode` image stream: a page-information segment
+/// plus an immediate lossless text region that places [placements] (symbol ids
+/// index [symbols], which must be the dictionary order) over a [width] x
+/// [height] page.
+///
+/// The stream refers to the symbol dictionary in the globals stream produced
+/// by [encodeJbig2Globals], so it only decodes when that stream is passed as
+/// `/DecodeParms << /JBIG2Globals ... >>`.
+Uint8List encodeJbig2TextPage({
+  required int width,
+  required int height,
+  required List<Jbig2Bitmap> symbols,
+  required List<Jbig2Placement> placements,
+}) {
+  if (placements.isEmpty) throw ArgumentError('a text region needs instances');
+
+  final pageInfo = BytesBuilder()
+    ..add(_u32(width))
+    ..add(_u32(height))
+    ..add(_u32(0)) // X resolution: unknown
+    ..add(_u32(0)) // Y resolution: unknown
+    ..addByte(1) // flags: lossless, default pixel 0, default OR combination
+    ..add(_u16(0)); // striping information
+
+  // Strips of instances sharing one T coordinate (SBSTRIPS = 1), in the
+  // top-to-bottom, left-to-right order a text region is coded in.
+  final strips = <int, List<Jbig2Placement>>{};
+  for (final placement in placements) {
+    (strips[placement.y] ??= []).add(placement);
+  }
+  final stripTs = strips.keys.toList()..sort();
+  for (final t in stripTs) {
+    strips[t]!.sort((a, b) => a.x - b.x);
+  }
+
+  var codeLength = 0;
+  while ((1 << codeLength) < symbols.length) {
+    codeLength++;
+  }
+  if (codeLength == 0) codeLength = 1;
+
+  final region = BytesBuilder()
+    ..add(_u32(width)) // region width
+    ..add(_u32(height)) // region height
+    ..add(_u32(0)) // region X
+    ..add(_u32(0)) // region Y
+    ..addByte(0) // external combination operator: OR
+    // SBHUFF=0, REFINE=0, LOGSBSTRIPS=0, REFCORNER=TOPLEFT, TRANSPOSED=0,
+    // SBCOMBOP=OR, SBDEFPIXEL=0, SBDSOFFSET=0, SBRTEMPLATE=0
+    ..add(_u16(1 << 4))
+    ..add(_u32(placements.length));
+
+  final mq = _MqEncoder();
+  final iadt = _ArithContexts(512);
+  final iafs = _ArithContexts(512);
+  final iads = _ArithContexts(512);
+  final iaid = _ArithContexts(1 << (codeLength + 1));
+
+  mq.encodeInt(iadt, 0); // STRIPT: the first strip's T is absolute
+  var stripT = 0;
+  var firstS = 0;
+  var placed = 0;
+  outer:
+  for (final t in stripTs) {
+    mq.encodeInt(iadt, t - stripT);
+    stripT = t;
+    final strip = strips[t]!;
+    mq.encodeInt(iafs, strip.first.x - firstS);
+    firstS = strip.first.x;
+    var curS = firstS;
+    for (var i = 0; i < strip.length; i++) {
+      if (i > 0) {
+        mq.encodeInt(iads, strip[i].x - curS);
+        curS = strip[i].x;
+      }
+      mq.encodeId(iaid, codeLength, strip[i].symbol);
+      curS += symbols[strip[i].symbol].width - 1;
+      placed++;
+      // The decoder stops on the instance count without reading a closing
+      // OOB, so the last strip must not emit one.
+      if (placed >= placements.length) break outer;
+    }
+    mq.encodeInt(iads, null); // OOB closes the strip
+  }
+  region.add(mq.flush());
+
+  return Uint8List.fromList([
+    ..._segment(
+      number: 1,
+      type: 48, // page information
+      referred: const [],
+      page: 1,
+      payload: pageInfo.takeBytes(),
+    ),
+    ..._segment(
+      number: 2,
+      type: 6, // immediate text region
+      referred: const [_globalsDictionarySegment],
+      page: 1,
+      payload: region.takeBytes(),
+    ),
+  ]);
+}
+
+// The symbol dictionary lives in the globals stream as segment 0; every page's
+// text region refers to it by that number.
+const _globalsDictionarySegment = 0;
+
+/// Nominal AT pixels for generic region template 0 (what every encoder emits).
+const _nominalAt = [(3, -1), (-3, -1), (2, -2), (-2, -2)];
+
+/// Template 0's fixed pixels (T.88 figure 4), without the AT slots.
+const _template0 = [
+  (-1, -2), (0, -2), (1, -2), //
+  (-2, -1), (-1, -1), (0, -1), (1, -1), (2, -1),
+  (-4, 0), (-3, 0), (-2, 0), (-1, 0),
+];
+
+/// Encodes [bitmap] with the generic region procedure (§6.2), template 0.
+///
+/// The context is the combined template sorted by row then column, most
+/// significant bit first - the same order the decoder builds it in, which is
+/// all that has to agree.
+void _encodeGeneric(_MqEncoder mq, _ArithContexts cx, Jbig2Bitmap bitmap) {
+  final pixels = [..._template0, ..._nominalAt]
+    ..sort((a, b) => a.$2 != b.$2 ? a.$2 - b.$2 : a.$1 - b.$1);
+  for (var y = 0; y < bitmap.height; y++) {
+    for (var x = 0; x < bitmap.width; x++) {
+      var context = 0;
+      for (final (dx, dy) in pixels) {
+        context = (context << 1) | bitmap.get(x + dx, y + dy);
+      }
+      mq.encode(cx, context, bitmap.get(x, y));
+    }
+  }
+}
+
+/// Wraps [payload] in a segment header (§7.2). Segment and referred-to numbers
+/// stay under 257 so the referred-to fields are one byte each, and the page
+/// association is the one-byte form.
+Uint8List _segment({
+  required int number,
+  required int type,
+  required List<int> referred,
+  required int page,
+  required Uint8List payload,
+}) {
+  if (referred.length > 4) {
+    throw ArgumentError('the short referred-to form holds at most 4 entries');
+  }
+  return Uint8List.fromList([
+    ..._u32(number),
+    type, // segment header flags: type, one-byte page association
+    referred.length << 5, // referred-to count, no retain bits
+    ...referred,
+    page,
+    ..._u32(payload.length),
+    ...payload,
+  ]);
+}
+
+List<int> _u16(int v) => [(v >> 8) & 0xFF, v & 0xFF];
+
+List<int> _u32(int v) =>
+    [(v >> 24) & 0xFF, (v >> 16) & 0xFF, (v >> 8) & 0xFF, v & 0xFF];
+
+List<int> _atBytes(List<(int, int)> at) =>
+    [for (final (x, y) in at) ...[x & 0xFF, y & 0xFF]];
+
+/// Adaptive probability state for one arithmetic context set.
+class _ArithContexts {
+  _ArithContexts(int size)
+      : mps = Int8List(size),
+        index = Uint8List(size);
+
+  final Int8List mps;
+  final Uint8List index;
+}
+
+/// The MQ arithmetic *encoder* (T.88 Annex E.3) - the inverse of pdf_cos's
+/// `MqDecoder`, in the standard software formulation (the one OpenJPEG and
+/// jbig2enc share): CODEMPS/CODELPS, RENORME, BYTEOUT with carry propagation
+/// into the previous byte, and the SETBITS flush.
+class _MqEncoder {
+  // Index 0 is the "byte before the buffer" the spec's BYTEOUT reads and
+  // carries into; the real output is [1..bp]. Dropped by flush().
+  final List<int> _out = [0];
+  int _bp = 0;
+  int _a = 0x8000;
+  int _c = 0;
+  int _ct = 12;
+
+  static const _qe = [
+    (0x5601, 1, 1, 1), (0x3401, 2, 6, 0), (0x1801, 3, 9, 0), //
+    (0x0AC1, 4, 12, 0), (0x0521, 5, 29, 0), (0x0221, 38, 33, 0),
+    (0x5601, 7, 6, 1), (0x5401, 8, 14, 0), (0x4801, 9, 14, 0),
+    (0x3801, 10, 14, 0), (0x3001, 11, 17, 0), (0x2401, 12, 18, 0),
+    (0x1C01, 13, 20, 0), (0x1601, 29, 21, 0), (0x5601, 15, 14, 1),
+    (0x5401, 16, 14, 0), (0x5101, 17, 15, 0), (0x4801, 18, 16, 0),
+    (0x3801, 19, 17, 0), (0x3401, 20, 18, 0), (0x3001, 21, 19, 0),
+    (0x2801, 22, 19, 0), (0x2401, 23, 20, 0), (0x2201, 24, 21, 0),
+    (0x1C01, 25, 22, 0), (0x1801, 26, 23, 0), (0x1601, 27, 24, 0),
+    (0x1401, 28, 25, 0), (0x1201, 29, 26, 0), (0x1101, 30, 27, 0),
+    (0x0AC1, 31, 28, 0), (0x09C1, 32, 29, 0), (0x08A1, 33, 30, 0),
+    (0x0521, 34, 31, 0), (0x0441, 35, 32, 0), (0x02A1, 36, 33, 0),
+    (0x0221, 37, 34, 0), (0x0141, 38, 35, 0), (0x0111, 39, 36, 0),
+    (0x0085, 40, 37, 0), (0x0049, 41, 38, 0), (0x0025, 42, 39, 0),
+    (0x0015, 43, 40, 0), (0x0009, 44, 41, 0), (0x0005, 45, 42, 0),
+    (0x0001, 45, 43, 0), (0x5601, 46, 46, 0),
+  ];
+
+  /// Codes decision [d] in context [context] of [cx].
+  void encode(_ArithContexts cx, int context, int d) {
+    final i = cx.index[context];
+    final mps = cx.mps[context];
+    final (qe, nmps, nlps, sw) = _qe[i];
+
+    if (d == mps) {
+      _a -= qe;
+      if (_a & 0x8000 == 0) {
+        if (_a < qe) {
+          _a = qe;
+        } else {
+          _c += qe;
+        }
+        cx.index[context] = nmps;
+        _renorm();
+      } else {
+        _c += qe;
+      }
+    } else {
+      _a -= qe;
+      if (_a < qe) {
+        _c += qe;
+      } else {
+        _a = qe;
+      }
+      if (sw == 1) cx.mps[context] = 1 - mps;
+      cx.index[context] = nlps;
+      _renorm();
+    }
+  }
+
+  void _renorm() {
+    do {
+      _a = (_a << 1) & 0xFFFF;
+      _c = (_c << 1) & 0xFFFFFFFF;
+      _ct--;
+      if (_ct == 0) _byteOut();
+    } while (_a & 0x8000 == 0);
+  }
+
+  void _byteOut() {
+    if (_out[_bp] == 0xFF) {
+      _emit((_c >> 20) & 0xFF);
+      _c &= 0xFFFFF;
+      _ct = 7;
+    } else if (_c & 0x8000000 == 0) {
+      _emit((_c >> 19) & 0xFF);
+      _c &= 0x7FFFF;
+      _ct = 8;
+    } else {
+      // Carry out of C propagates into the byte already written.
+      _out[_bp]++;
+      if (_out[_bp] == 0xFF) {
+        _c &= 0x7FFFFFF;
+        _emit((_c >> 20) & 0xFF);
+        _c &= 0xFFFFF;
+        _ct = 7;
+      } else {
+        _emit((_c >> 19) & 0xFF);
+        _c &= 0x7FFFF;
+        _ct = 8;
+      }
+    }
+  }
+
+  void _emit(int byte) {
+    _bp++;
+    _out.add(byte);
+  }
+
+  /// Codes an integer with the Annex A.2 procedure; null is OOB.
+  void encodeInt(_ArithContexts cx, int? value) {
+    var prev = 1;
+    void bit(int b) {
+      encode(cx, prev, b);
+      prev = prev < 256 ? (prev << 1) | b : ((((prev << 1) | b) & 511) | 256);
+    }
+
+    void bits(int v, int count) {
+      for (var i = count - 1; i >= 0; i--) {
+        bit((v >> i) & 1);
+      }
+    }
+
+    // OOB is the otherwise-unrepresentable "negative zero".
+    final magnitude = value == null ? 0 : value.abs();
+    bit(value == null || value < 0 ? 1 : 0);
+    if (magnitude < 4) {
+      bit(0);
+      bits(magnitude, 2);
+    } else if (magnitude < 20) {
+      bit(1);
+      bit(0);
+      bits(magnitude - 4, 4);
+    } else if (magnitude < 84) {
+      bit(1);
+      bit(1);
+      bit(0);
+      bits(magnitude - 20, 6);
+    } else if (magnitude < 340) {
+      bit(1);
+      bit(1);
+      bit(1);
+      bit(0);
+      bits(magnitude - 84, 8);
+    } else if (magnitude < 4436) {
+      bit(1);
+      bit(1);
+      bit(1);
+      bit(1);
+      bit(0);
+      bits(magnitude - 340, 12);
+    } else {
+      bit(1);
+      bit(1);
+      bit(1);
+      bit(1);
+      bit(1);
+      bits(magnitude - 4436, 32);
+    }
+  }
+
+  /// Codes a symbol id with the IAID procedure: [codeLength] bits, most
+  /// significant first, each in the context of the bits already coded.
+  void encodeId(_ArithContexts cx, int codeLength, int id) {
+    var prev = 1;
+    for (var i = codeLength - 1; i >= 0; i--) {
+      final b = (id >> i) & 1;
+      encode(cx, prev, b);
+      prev = (prev << 1) | b;
+    }
+  }
+
+  /// Terminates the codestream and returns its bytes (T.88 E.3.8).
+  Uint8List flush() {
+    // SETBITS: push as many 1 bits into C as the interval allows.
+    final tempc = _c + _a;
+    _c |= 0xFFFF;
+    if (_c >= tempc) _c -= 0x8000;
+    _c = (_c << _ct) & 0xFFFFFFFF;
+    _byteOut();
+    _c = (_c << _ct) & 0xFFFFFFFF;
+    _byteOut();
+    // A trailing 0xFF carries no information - it is the marker prefix.
+    final length = _out[_bp] == 0xFF ? _bp - 1 : _bp;
+    return Uint8List.fromList([
+      ..._out.sublist(1, 1 + length),
+      0xFF, 0xAC, // the end-of-codestream marker
+    ]);
+  }
+}

--- a/packages/pdf_test_fixtures/tool/gen_jbig2_scanned_pdf.dart
+++ b/packages/pdf_test_fixtures/tool/gen_jbig2_scanned_pdf.dart
@@ -1,0 +1,226 @@
+// Generates the scanned-book JBIG2 document the #557 perf scenarios measure:
+// ONE shared /JBIG2Globals stream carrying a multi-symbol arithmetic symbol
+// dictionary, referenced by every page's JBIG2Decode image.
+//
+//   fvm dart run packages/pdf_test_fixtures/tool/gen_jbig2_scanned_pdf.dart \
+//       <out.pdf> [pages] [symbols] [width] [height] [seed]
+//
+// Defaults: 32 pages, 900 symbols, 1700x2200 px images (~200 dpi US Letter).
+//
+// That shape is the point. Every in-repo JBIG2 file (the pdfjs bitmap-*/jbig2_*
+// samples, ghent GWG173) inlines its globals into a single image stream, so
+// none of them can exhibit the #532 globals cache: the saving is one symbol
+// dictionary arithmetic-decode per *page* that no longer happens, and it needs
+// many pages sharing one dictionary to show up at all. Real scanners emit
+// exactly this - jbig2enc's `-s -p` mode writes a book-wide symbol dictionary
+// to a separate stream and each page becomes a text region referring to it.
+//
+// jbig2enc is not in CI (and JBIG2 arithmetic *encoding* was out of scope for
+// the pure-Dart writers), so the encoder lives in pdf_test_fixtures instead -
+// enough of T.88 to emit this profile, round-tripped against the shipping
+// decoder in pdf_cos/test/jbig2_roundtrip_test.dart. Output is deterministic
+// for a given seed: generate once, pre-seed the same bytes into every backfill
+// worktree so each version measures identical input.
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+void main(List<String> args) {
+  final outPath = args.isNotEmpty ? args[0] : 'jbig2-scanned.pdf';
+  final pageCount = args.length > 1 ? int.parse(args[1]) : 32;
+  final symbolCount = args.length > 2 ? int.parse(args[2]) : 900;
+  final imgW = args.length > 3 ? int.parse(args[3]) : 1700;
+  final imgH = args.length > 4 ? int.parse(args[4]) : 2200;
+  final seed = args.length > 5 ? int.parse(args[5]) : 20260725;
+
+  const pageW = 612.0; // US Letter, points
+  const pageH = 792.0;
+
+  final symbols = sortSymbolsForDictionary(_buildGlyphs(symbolCount, seed));
+  final globals = encodeJbig2Globals(symbols);
+
+  final builder = CosDocumentBuilder();
+
+  // Object numbers are assigned in registration order starting at 1:
+  //   1 = catalog, 2 = page tree, 3 = the shared globals stream, then per page
+  //   i (0-based) three objects in this add() order:
+  //   content = 4+i*3, image = 4+i*3+1, page = 4+i*3+2.
+  const catalogNum = 1;
+  const treeNum = 2;
+  const globalsNum = 3;
+  final treeRef = const CosReference(treeNum, 0);
+  final globalsRef = const CosReference(globalsNum, 0);
+  final pageRefs = [
+    for (var i = 0; i < pageCount; i++) CosReference(4 + i * 3 + 2, 0),
+  ];
+
+  builder.add(CosDictionary({
+    'Type': const CosName('Catalog'),
+    'Pages': treeRef,
+  }));
+  builder.add(CosDictionary({
+    'Type': const CosName('Pages'),
+    'Kids': CosArray(pageRefs),
+    'Count': CosInteger(pageCount),
+  }));
+  // The globals stream is stored raw: JBIG2 data is already arithmetic-coded,
+  // and that is how scanners write it.
+  builder.add(CosStream(
+    CosDictionary({'Length': CosInteger(globals.length)}),
+    globals,
+  ));
+
+  final content = Uint8List.fromList(
+      'q\n$pageW 0 0 $pageH 0 0 cm\n/Im0 Do\nQ\n'.codeUnits);
+
+  var instances = 0;
+  var imageBytes = 0;
+  for (var i = 0; i < pageCount; i++) {
+    final contentRef = CosReference(4 + i * 3, 0);
+    final imageRef = CosReference(4 + i * 3 + 1, 0);
+
+    builder.add(CosStream(
+      CosDictionary({'Length': CosInteger(content.length)}),
+      content,
+    ));
+
+    final placements = _layoutPage(symbols, imgW, imgH, i, symbolCount);
+    instances += placements.length;
+    final page = encodeJbig2TextPage(
+      width: imgW,
+      height: imgH,
+      symbols: symbols,
+      placements: placements,
+    );
+    imageBytes += page.length;
+    builder.add(CosStream(
+      CosDictionary({
+        'Type': const CosName('XObject'),
+        'Subtype': const CosName('Image'),
+        'Width': CosInteger(imgW),
+        'Height': CosInteger(imgH),
+        'ColorSpace': const CosName('DeviceGray'),
+        'BitsPerComponent': CosInteger(1),
+        'Filter': const CosName('JBIG2Decode'),
+        'DecodeParms': CosDictionary({'JBIG2Globals': globalsRef}),
+        'Length': CosInteger(page.length),
+      }),
+      page,
+    ));
+
+    builder.add(CosDictionary({
+      'Type': const CosName('Page'),
+      'Parent': treeRef,
+      'MediaBox': CosArray([
+        CosInteger(0),
+        CosInteger(0),
+        CosReal(pageW),
+        CosReal(pageH),
+      ]),
+      'Resources': CosDictionary({
+        'XObject': CosDictionary({'Im0': imageRef}),
+      }),
+      'Contents': contentRef,
+    }));
+  }
+
+  final bytes = builder.build(root: const CosReference(catalogNum, 0));
+  File(outPath).writeAsBytesSync(bytes);
+  stdout.writeln('wrote $outPath: ${bytes.length} bytes, $pageCount pages, '
+      'image ${imgW}x$imgH, $symbolCount shared symbols '
+      '(${globals.length} B globals), $instances symbol instances '
+      '(${(imageBytes / pageCount).round()} B/page)');
+}
+
+/// A deterministic bank of glyph-shaped symbols: a left stem plus a few
+/// features, at text-ish sizes. Structured strokes (rather than noise) matter -
+/// they are what make the arithmetic contexts adapt the way they do on real
+/// scanned text, so the per-page decode this scenario measures is honest.
+List<Jbig2Bitmap> _buildGlyphs(int count, int seed) {
+  var state = seed & 0x7FFFFFFF;
+  int next(int bound) {
+    state = (state * 1103515245 + 12345) & 0x7FFFFFFF;
+    return state % bound;
+  }
+
+  return [
+    for (var i = 0; i < count; i++) _glyph(next, 14 + next(12), 18 + next(16)),
+  ];
+}
+
+Jbig2Bitmap _glyph(int Function(int) next, int width, int height) {
+  final bitmap = Jbig2Bitmap(width, height);
+  final stroke = 2 + next(2);
+  final ascender = next(4) == 0 ? 0 : height ~/ 4;
+  // Left stem: the one feature almost every glyph has.
+  bitmap.fillRect(1, ascender, stroke, height - ascender - 1);
+  switch (next(6)) {
+    case 0: // a bar across the middle, like e/f/t
+      bitmap.fillRect(1, height ~/ 2, width - 3, stroke);
+    case 1: // a right stem, like n/u/h
+      bitmap.fillRect(width - stroke - 1, ascender, stroke, height - ascender - 1);
+    case 2: // a closed bowl, like o/d/p
+      bitmap
+        ..fillRect(width - stroke - 1, ascender, stroke, height - ascender - 1)
+        ..fillRect(1, ascender, width - 2, stroke)
+        ..fillRect(1, height - stroke - 1, width - 2, stroke);
+    case 3: // a top bar and a foot, like z/s
+      bitmap
+        ..fillRect(1, ascender, width - 2, stroke)
+        ..fillRect(1, height - stroke - 1, width - 2, stroke);
+    case 4: // a diagonal, like v/x/y
+      for (var y = ascender; y < height - 1; y++) {
+        final x = 1 + ((y - ascender) * (width - 3)) ~/ (height - ascender - 1);
+        bitmap.fillRect(x, y, stroke, 1);
+      }
+    case _: // a descender tail, like g/q/j
+      bitmap.fillRect(1, height - stroke - 1, width ~/ 2, stroke);
+  }
+  return bitmap;
+}
+
+/// Lays a page of "text" out: justified-ish lines of words, drawn from a
+/// page-local window over the shared dictionary. The window is the scanned-book
+/// property that makes the #532 saving visible - every page re-decoded the
+/// *whole* book-wide dictionary before the cache, while only ever drawing a
+/// slice of it.
+List<Jbig2Placement> _layoutPage(
+  List<Jbig2Bitmap> symbols,
+  int width,
+  int height,
+  int pageIndex,
+  int symbolCount,
+) {
+  var state = (pageIndex + 1) * 2654435761 & 0x7FFFFFFF;
+  int next(int bound) {
+    state = (state * 1103515245 + 12345) & 0x7FFFFFFF;
+    return state % bound;
+  }
+
+  const margin = 120;
+  const leading = 44;
+  const wordGap = 12;
+  const letterGap = 3;
+  // Roughly a third of the dictionary per page, sliding across the book.
+  final windowSize = (symbolCount / 3).ceil();
+  final windowStart = symbolCount <= windowSize
+      ? 0
+      : (pageIndex * 37) % (symbolCount - windowSize);
+
+  final placements = <Jbig2Placement>[];
+  for (var y = margin; y + leading < height - margin; y += leading) {
+    var x = margin;
+    while (x < width - margin) {
+      final wordLength = 2 + next(8);
+      for (var i = 0; i < wordLength && x < width - margin; i++) {
+        final id = windowStart + next(windowSize);
+        placements.add(Jbig2Placement(id, x, y));
+        x += symbols[id].width + letterGap;
+      }
+      x += wordGap;
+    }
+  }
+  return placements;
+}

--- a/tool/perf/SCHEMA.md
+++ b/tool/perf/SCHEMA.md
@@ -37,6 +37,8 @@ unknown keys).
       "openMs": 1.2,           // best-of-N (matches legacy tools)
       "firstPageMs": 8.0, "interpretMs": 30.1, "renderMs": 45.6,
       "extractMs": 4.0, "saveMs": 2.1, "peakRssBytes": 91234304,
+      "decodeMs": 210.4,       // only with the `decodeImages` measure
+      "imagesDecoded": 32,     // images the pages drew, alongside decodeMs
       "error": null,
       "perf": { "phases": {}, "counts": {}, "events": {} } // PdfPerf
                                // snapshot when the run passed --phases

--- a/tool/perf/backfill.sh
+++ b/tool/perf/backfill.sh
@@ -46,6 +46,7 @@ GRAFT=(
 "$(dirname "$0")/gen_perf_docs.sh"
 CAD_CACHE="tool/perf/cache/cad-138-6000-20260718.pdf"
 IMG_CACHE_DIR="tool/perf/cache/image-heavy"
+JBIG2_CACHE_DIR="tool/perf/cache/jbig2-scanned"
 
 ok=0; skipped=""
 for ref in "$@"; do
@@ -67,6 +68,9 @@ for ref in "$@"; do
   fi
   if [ -d "$ROOT/$IMG_CACHE_DIR" ]; then
     mkdir -p "$wt/$IMG_CACHE_DIR"; cp "$ROOT/$IMG_CACHE_DIR"/*.pdf "$wt/$IMG_CACHE_DIR/" 2>/dev/null || true
+  fi
+  if [ -d "$ROOT/$JBIG2_CACHE_DIR" ]; then
+    mkdir -p "$wt/$JBIG2_CACHE_DIR"; cp "$ROOT/$JBIG2_CACHE_DIR"/*.pdf "$wt/$JBIG2_CACHE_DIR/" 2>/dev/null || true
   fi
   if ! ( cd "$wt" && $FLUTTER pub get ) >/dev/null 2>&1; then
     echo "  pub get failed (dep drift); skip"; skipped="$skipped $ref"

--- a/tool/perf/diff.dart
+++ b/tool/perf/diff.dart
@@ -20,6 +20,7 @@ const _defaultMetrics = [
   'interpretMs',
   'extractMs',
   'saveMs',
+  'decodeMs',
   'peakRssBytes',
 ];
 

--- a/tool/perf/gen_perf_docs.sh
+++ b/tool/perf/gen_perf_docs.sh
@@ -15,6 +15,7 @@ IMG="$ROOT/tool/perf/cache/image-heavy/image-heavy-24p.pdf"
 DN="$ROOT/tool/perf/cache/devicen/devicen-8p.pdf"
 CADIMG="$ROOT/tool/perf/cache/cad-images/cad-images-1386-20260720.pdf"
 CADIMGMIX="$ROOT/tool/perf/cache/cad-images/cad-images-mixed-200-20260720.pdf"
+JBIG2="$ROOT/tool/perf/cache/jbig2-scanned/jbig2-scanned-32p-20260725.pdf"
 
 if [ ! -f "$CAD" ]; then
   echo "gen cad-138p -> $CAD"
@@ -53,6 +54,17 @@ if [ ! -f "$CADIMGMIX" ]; then
   else
     echo "skip cad-images-mixed: cjpeg/opj_compress not on PATH" >&2
   fi
+fi
+
+# Scanned book: one shared /JBIG2Globals symbol dictionary across every page
+# image (#557). No corpus file has that shape, and producing one normally needs
+# jbig2enc - the pure-Dart encoder in pdf_test_fixtures stands in, so this one
+# IS generated in CI like the rest.
+if [ ! -f "$JBIG2" ]; then
+  echo "gen jbig2-scanned (shared /JBIG2Globals, 32 pages) -> $JBIG2"
+  mkdir -p "$(dirname "$JBIG2")"
+  ( cd "$ROOT" && $DART run packages/pdf_test_fixtures/tool/gen_jbig2_scanned_pdf.dart \
+      "$JBIG2" 32 900 1700 2200 20260725 )
 fi
 
 if [ ! -f "$DN" ]; then

--- a/tool/perf/nightly.sh
+++ b/tool/perf/nightly.sh
@@ -35,6 +35,7 @@ sweep save-incremental
 sweep cad-138p-sweep
 sweep cad-wide-1p-sweep
 sweep image-heavy
+sweep jbig2-scanned-sweep
 
 # Render trend (Flutter rasterization: interpret + paint + toImage). Captures
 # the paint- and image-decode-path gains the NullDevice vm-sweep can't see.
@@ -51,6 +52,7 @@ render_bench() { # render_bench <scenario> <corpus-rel-to-dart_pdf_editor> <scal
 render_bench ghent-render "../../test_corpora/ghent" 2 3
 render_bench image-render "../../tool/perf/cache/image-heavy" 1.5 4
 render_bench devicen-render "../../tool/perf/cache/devicen" 1 2
+render_bench jbig2-scanned-render "../../tool/perf/cache/jbig2-scanned" 1 4
 
 # Progressive first-paint: bytes a remote reader pulls to paint page 1 through
 # the ranged PdfByteSource vs a full read (#328/#359). PdfDocument.openSource is

--- a/tool/perf/perf_diff.sh
+++ b/tool/perf/perf_diff.sh
@@ -44,16 +44,27 @@ else
   echo "reusing cached worktree $WORKTREE"
 fi
 
-# Bootstrap refs that predate the perf tooling: copy the harness (and the
-# PdfPerf facade it imports) into the worktree when absent. All additive
-# files - the ref still measures its own library code.
-BOOTSTRAP=(
-  packages/pdf_cos/lib/perf.dart
-  packages/pdf_cos/lib/src/perf/perf.dart
+# The measuring apparatus itself - harness scripts and the workload list, none
+# of it library code. Both sides must run the SAME harness or the comparison is
+# apples to oranges, and a measure or scenario added after the ref exists only
+# here, so these are always overwritten (backfill.sh grafts them the same way).
+HARNESS=(
   packages/pdf_cos/tool/gen_cad_pdf.dart
   packages/pdf_graphics/tool/perf_sweep.dart
   packages/pdf_graphics/tool/perf_run_context.dart
   tool/perf/scenarios.json
+)
+for f in "${HARNESS[@]}"; do
+  mkdir -p "$WORKTREE/$(dirname "$f")"
+  cp "$ROOT/$f" "$WORKTREE/$f"
+done
+
+# Bootstrap refs that predate the perf tooling with the PdfPerf facade the
+# harness imports - but only when absent: this one lives in lib/, and the ref
+# must keep measuring its own library code.
+BOOTSTRAP=(
+  packages/pdf_cos/lib/perf.dart
+  packages/pdf_cos/lib/src/perf/perf.dart
 )
 for f in "${BOOTSTRAP[@]}"; do
   if [ ! -e "$WORKTREE/$f" ]; then
@@ -61,6 +72,13 @@ for f in "${BOOTSTRAP[@]}"; do
     cp "$ROOT/$f" "$WORKTREE/$f"
   fi
 done
+
+# Pre-seed the generated corpora so both sides read byte-identical input and
+# the ref needs no generator. -n keeps the reused-worktree path cheap.
+if [ -d "$ROOT/tool/perf/cache" ]; then
+  mkdir -p "$WORKTREE/tool/perf/cache"
+  cp -Rn "$ROOT/tool/perf/cache/." "$WORKTREE/tool/perf/cache/" 2>/dev/null || true
+fi
 
 OUT="${TMPDIR:-/tmp}/dart-pdf-perf-ab/results-$SHA-$$"
 mkdir -p "$OUT"

--- a/tool/perf/report/build_report.mjs
+++ b/tool/perf/report/build_report.mjs
@@ -28,6 +28,7 @@ const preferred = [
   'p50OpenMs', 'p95OpenMs', 'p50FirstPageMs',
   'p50InterpretMsPerPage', 'p95InterpretMsPerPage',
   'p50ExtractMsPerPage', 'p50SaveMs', 'p95SaveMs',
+  'p50DecodeMsPerPage', 'p95DecodeMsPerPage',
   'maxPeakRssBytes', 'errors',
   'jankCount', 'buildP50', 'buildP95', 'buildOver50',
 ];

--- a/tool/perf/scenarios.json
+++ b/tool/perf/scenarios.json
@@ -152,5 +152,23 @@
     "maxPages": 0,
     "repeat": 3,
     "ciSafe": true
+  },
+  "jbig2-scanned-sweep": {
+    "suite": "vm-sweep",
+    "note": "The scanned-book JBIG2 shape (#557): one shared /JBIG2Globals stream carrying a 900-symbol arithmetic symbol dictionary, referenced by 32 per-page JBIG2Decode images (1700x2200, ~2.7k symbol instances each). Every in-repo JBIG2 file inlines its globals into a single image, so this is the only workload that exhibits the #532 globals cache - the saving is one dictionary arithmetic-decode per page that no longer happens, and it scales with symbols x pages. Generated + pre-seeded (gen_jbig2_scanned_pdf.dart, seed 20260725) because JBIG2 arithmetic encoding needs jbig2enc, absent from CI - the pure-Dart encoder in pdf_test_fixtures stands in.",
+    "corpus": "tool/perf/cache/jbig2-scanned",
+    "maxPages": 0,
+    "repeat": 2,
+    "measures": ["open", "firstPage", "interpret", "decodeImages"],
+    "ciSafe": true
+  },
+  "jbig2-scanned-render": {
+    "suite": "flutter-render",
+    "note": "Rasterizes the scanned-book JBIG2 doc (globals-shared symbol decode + text-region composition + 1-bit-to-RGBA expansion + paint). Raster half of #557; same generated corpus as jbig2-scanned-sweep.",
+    "corpus": "tool/perf/cache/jbig2-scanned",
+    "scale": 1,
+    "maxPages": 4,
+    "repeat": 2,
+    "ciSafe": true
   }
 }


### PR DESCRIPTION
## Summary

Closes #557. Builds the workload `#532`'s globals-dictionary cache exists for — many page images sharing **one** `/JBIG2Globals` symbol dictionary — and measures the win, which until now was justified by construction plus a cache-equivalence test rather than by a harness number.

Three parts:

**1. A pure-Dart JBIG2 encoder** (`packages/pdf_test_fixtures/lib/src/jbig2_encoder.dart`). Producing this shape normally needs `jbig2enc`, absent from CI, so the issue expected a committed pre-generated doc. Writing the encoder turned out cheaper: the decoder already defines every context model, so the encoder mirrors it, and the only genuinely new algorithm is the MQ coder (T.88 Annex E.3). Scope is exactly the profile the decoder reads — MQ coder, the Annex A.2 integer coders + IAID, generic region template 0, one arithmetic symbol dictionary segment (SDHUFF=0, REFAGG=0), and page-info + immediate text region segments. Round-tripped against the shipping decoder in `packages/pdf_cos/test/jbig2_roundtrip_test.dart`. That check is circular by nature (our encoder against our decoder) — fine for a perf fixture, and it is **not** claimed as decoder validation; the decoder's KATs against jbig2enc/jbig2dec output are untouched and remain the source of truth there.

**2. The scenarios.** `gen_jbig2_scanned_pdf.dart` emits 32 pages of 1700x2200 text (~2.7k symbol instances/page) over a shared 900-symbol globals stream, 125 KB total, byte-identical from a seed — generated and pre-seeded like the other synthetic perf docs (it *is* generated in CI, unlike the cjpeg/opj_compress-dependent ones). `jbig2-scanned-sweep` (vm-sweep) + `jbig2-scanned-render` (flutter-render), wired into `gen_perf_docs.sh`, `nightly.sh`, and `backfill.sh`.

**3. Harness fixes the measurement needed.** The VM sweep had no window on image decode at all — `NullDevice` swallows `drawImage` and the interpreter hands the device undecoded streams — so the first run of the new scenario reported 4.7 ms of interpret for 32 pages of imagery. `perf_sweep` gains an **opt-in** `decodeImages` measure (via the existing `measures` scenario key) that interprets with a device which keeps the image requests, then times `decodePdfImagePixels` over them: the same pure-Dart path the render worker runs, no Flutter engine needed. New `decodeMs`/`imagesDecoded` fields, `p50/p95/maxDecodeMsPerPage` in the summary, `decodeMs` added to `diff.dart`'s default metrics and the dashboard's curated order (missing metrics are skipped per-metric, so old history stays comparable). `perf_diff.sh` now always grafts the harness files into the ref worktree instead of only when absent — both sides must run the same apparatus, and a measure or scenario added *after* the ref exists only in the current tree — and pre-seeds `tool/perf/cache/` into it. That also unblocks `tool/perf.sh diff <ref> image-heavy`, which had the same problem.

### The number

`#532` isolated (`d41fb18^` → `d41fb18`, harness and corpus grafted identically onto both, 3 interleaved runs, `jbig2-scanned-sweep`):

| metric | before | after | ratio |
|---|---|---|---|
| decodeMs (32 pages) | 2769 ms | 1825 ms | **0.659x** |
| openMs | 2.17 | 2.04 | 0.94x |
| interpretMs | 4.32 | 3.71 | 0.86x |

**1.52x faster image decode.** At the codec layer alone (decode each page with `debugResetGlobalsCache()` first vs. not, excluding the 1bpp→RGBA expansion) it is **1.92x** — 1967 ms vs 1026 ms over the same 32 pages. Both scale with symbols x pages, as predicted.

Full write-up: `doc/dev-log/2026-07-25-jbig2-scanned-book-scenario-557.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [x] `pdf_graphics` — `tool/perf_sweep.dart` only, no library change
- [ ] `dart_pdf_editor`
- [x] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only — perf tooling, SCHEMA, dashboard, CLAUDE.md

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change — measurement only; no library code changes behaviour
- [ ] Refactor / cleanup
- [x] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (workspace, clean)
- [x] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

Nothing in `dart_pdf_editor` changed; it was exercised through `benchmark_render_test.dart` for the `jbig2-scanned-render` scenario. No renderer or parser code changed, so the Ghent baselines and the corpus sweeps cannot move — no library file outside `tool/` is touched. Additionally run: `tool/perf.sh gate` (OK, 12 inputs / 13 counters), the new sweep and render scenarios end to end, and a from-scratch `gen_perf_docs.sh` producing a byte-identical document.

## PDF fixtures and screenshots

The generated document is deterministic and git-ignored under `tool/perf/cache/` (125 KB, 32 pages, `sha256 7188c450…`), matching how the other synthetic perf docs are handled. Regenerate with:

```
fvm dart run packages/pdf_test_fixtures/tool/gen_jbig2_scanned_pdf.dart \
    tool/perf/cache/jbig2-scanned/jbig2-scanned-32p-20260725.pdf 32 900 1700 2200 20260725
```

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory. (The encoder library is pure; `dart:io` is confined to `tool/`.)
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **The render scenario is not where the number comes from.** `jbig2-scanned-render` is in for the raster trend; across the same two commits its `renderMs` ratios were 0.82x and 1.08x — noise. Expected: rasterization is dominated by painting a 1700x2200 image, the decoded-image cache means each page decodes once, and 4 pages leaves only three saved globals decodes (~90 ms) inside an ~800 ms render on a 4-core box. Worth not over-reading either way.
- **Encoder gotcha, in case it ever gets extended:** the text region's last strip must *not* emit a closing OOB. The decoder breaks out the moment `decoded` reaches `SBNUMINSTANCES`, before reading another IADS, so symmetric strip termination desynchronises the final bytes.
- `decodeImages` is deliberately opt-in rather than a default measure: it is the only measure that costs real time on image-heavy corpora, and every other scenario exists to track the parse/interpret path. Turning it on for `image-heavy`/`cad-images` later is a one-line scenario edit if the trend is wanted.
- The `perf_diff.sh` graft change is a behaviour change to an existing tool. The old copy-only-if-absent rule meant the ref ran *its own* harness, so any newly-added measure or scenario failed the ref side outright. `lib/perf.dart` and `lib/src/perf/perf.dart` keep the old rule — those are library code the ref must keep measuring for itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MLuVV1FSfjbM9zMmKj6Qt

---
_Generated by [Claude Code](https://claude.ai/code/session_015MLuVV1FSfjbM9zMmKj6Qt)_