### PR TITLE
feat(windows): Microsoft Store deployment, fully CLI-driven

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,3 +225,65 @@ jobs:
             cat /tmp/dartpdf-smoke.log || true
             exit 1
           fi
+
+  # Static validation of the Microsoft Store packaging scripts. The real
+  # submission needs a Windows runner and Partner Center credentials
+  # (release-windows-store.yml), so this keeps the PowerShell and the
+  # `msix_config` block from rotting without paying for either. `pwsh` is
+  # preinstalled on ubuntu-latest.
+  windows-store-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Parse-check the packaging PowerShell
+        shell: pwsh
+        run: |
+          $failed = $false
+          Get-ChildItem app/packaging/msstore -Filter *.ps1 | ForEach-Object {
+            $errors = $null
+            $tokens = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              $_.FullName, [ref]$tokens, [ref]$errors) | Out-Null
+            if ($errors -and $errors.Count -gt 0) {
+              $failed = $true
+              $errors | ForEach-Object {
+                Write-Host "::error file=app/packaging/msstore/$($_.Extent.File | Split-Path -Leaf),line=$($_.Extent.StartLineNumber)::$($_.Message)"
+              }
+            } else {
+              Write-Host "OK $($_.Name)"
+            }
+          }
+          if ($failed) { exit 1 }
+      - name: Check the Store MSIX config stays complete
+        shell: pwsh
+        run: |
+          $pubspec = Get-Content app/pubspec.yaml -Raw
+          if ($pubspec -notmatch '(?m)^msix_config:') {
+            Write-Host '::error::app/pubspec.yaml lost its msix_config block'
+            exit 1
+          }
+          # `store` true is what makes msix skip signing; a signed package is
+          # rejected by the Store, so losing it silently breaks submissions.
+          # Anchor to the real YAML key - the prose comments in pubspec.yaml
+          # mention these settings by name, so a substring match would pass
+          # even with the key flipped or deleted.
+          $required = @{
+            'store'          = '(?m)^\s+store:\s*true\s*$'
+            'file_extension' = '(?m)^\s+file_extension:\s*\.pdf\s*$'
+            'architecture'   = '(?m)^\s+architecture:\s*x64\s*$'
+          }
+          foreach ($key in $required.Keys) {
+            if ($pubspec -notmatch $required[$key]) {
+              Write-Host "::error::app/pubspec.yaml msix_config is missing or changed '$key'"
+              exit 1
+            }
+          }
+          # The identity values must NOT be checked in - they are account
+          # specific and a stale copy builds a package the Store refuses.
+          foreach ($key in @('identity_name:', 'publisher:', 'publisher_display_name:')) {
+            if ($pubspec -match "(?m)^\s+$([regex]::Escape($key))") {
+              Write-Host "::error::app/pubspec.yaml pins '$key' - pass it via build-msix.ps1 env instead"
+              exit 1
+            }
+          }
+          Write-Host 'msix_config OK'

--- a/.github/workflows/release-windows-store.yml
+++ b/.github/workflows/release-windows-store.yml
@@ -1,0 +1,165 @@
+name: Release Windows Store
+
+# Builds the Microsoft Store MSIX and pushes it into the Partner Center
+# submission for DartPDF. Entirely CLI-driven: `dart run msix:create --store`
+# for the package, the Microsoft Store Developer CLI for the upload.
+#
+# Safe by default. A tag push uploads a **draft** submission - nothing reaches
+# the public Store until a human reviews it in Partner Center, mirroring how
+# release-app.yml creates a *draft* GitHub Release. Committing to certification
+# is an explicit workflow_dispatch choice.
+#
+# The job no-ops (it does not fail) when the Partner Center secrets are not
+# configured, so it cannot block a release before the account exists. Setup is
+# documented in app/packaging/msstore/README.md.
+
+on:
+  push:
+    tags: ['app-v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version name, e.g. 3.0.0 (defaults to app/pubspec.yaml)'
+        required: false
+      commit:
+        description: 'Commit the submission to Store certification (otherwise leave it a draft)'
+        type: boolean
+        default: false
+      rollout_percentage:
+        description: 'Package rollout percentage 0-100 (only with commit; blank = no staged rollout)'
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  FLUTTER_VERSION: '3.44.4'
+  DOTNET_VERSION: '9.0.x'
+
+jobs:
+  store:
+    runs-on: windows-latest
+    env:
+      # Repository VARIABLES, not secrets: these four are public by
+      # construction - the first three are embedded in the shipped MSIX manifest
+      # and the Store ID is in the app's public Store URL. Masking them would
+      # only make these logs harder to read for no security gain.
+      MSSTORE_IDENTITY_NAME: ${{ vars.MSSTORE_IDENTITY_NAME }}
+      MSSTORE_PUBLISHER: ${{ vars.MSSTORE_PUBLISHER }}
+      MSSTORE_PUBLISHER_DISPLAY_NAME: ${{ vars.MSSTORE_PUBLISHER_DISPLAY_NAME }}
+      MSSTORE_PRODUCT_ID: ${{ vars.MSSTORE_PRODUCT_ID }}
+      # Real secrets. Only MSSTORE_CLIENT_SECRET is a credential; the tenant,
+      # client and seller IDs are identifiers, kept masked as defence in depth so
+      # a leaked client secret is not accompanied by everything needed to use it.
+      MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
+      MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+      MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+      MSSTORE_SELLER_ID: ${{ secrets.MSSTORE_SELLER_ID }}
+    steps:
+      # Skip rather than fail when the account isn't wired up yet: an unset
+      # variable or secret must not turn every `app-v*` tag red. The notice
+      # separates the two so it's obvious where each missing value belongs.
+      - name: Gate on configured Partner Center credentials
+        id: gate
+        shell: bash
+        run: |
+          missing_vars=
+          for name in MSSTORE_IDENTITY_NAME MSSTORE_PUBLISHER \
+                      MSSTORE_PUBLISHER_DISPLAY_NAME MSSTORE_PRODUCT_ID; do
+            if [ -z "${!name}" ]; then missing_vars="$missing_vars $name"; fi
+          done
+          missing_secrets=
+          for name in MSSTORE_TENANT_ID MSSTORE_CLIENT_ID \
+                      MSSTORE_CLIENT_SECRET MSSTORE_SELLER_ID; do
+            if [ -z "${!name}" ]; then missing_secrets="$missing_secrets $name"; fi
+          done
+          if [ -n "$missing_vars$missing_secrets" ]; then
+            note="Microsoft Store publishing is not configured - skipping."
+            if [ -n "$missing_vars" ]; then
+              note="$note Missing repository variables:$missing_vars."
+            fi
+            if [ -n "$missing_secrets" ]; then
+              note="$note Missing repository secrets:$missing_secrets."
+            fi
+            echo "::notice::$note See app/packaging/msstore/README.md."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v7
+        if: steps.gate.outputs.enabled == 'true'
+        with:
+          persist-credentials: false
+
+      - name: Resolve version
+        if: steps.gate.outputs.enabled == 'true'
+        id: v
+        shell: bash
+        run: |
+          REF="${GITHUB_REF_NAME}"
+          if [[ "$REF" == app-v* ]]; then
+            V="${REF#app-v}"
+          else
+            V="${{ github.event.inputs.version }}"
+          fi
+          if [ -z "$V" ]; then
+            # build-msix.ps1 falls back to the pubspec version itself.
+            echo "version=" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$V" >> "$GITHUB_OUTPUT"
+          fi
+
+      # msstore.exe is framework-dependent (net9.0), so the runtime must be
+      # present before publish-msix.ps1 runs it.
+      - uses: actions/setup-dotnet@v5
+        if: steps.gate.outputs.enabled == 'true'
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - uses: subosito/flutter-action@v2
+        if: steps.gate.outputs.enabled == 'true'
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - run: flutter pub get
+        if: steps.gate.outputs.enabled == 'true'
+
+      - name: Build Store MSIX
+        if: steps.gate.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          # Not $args - that is a PowerShell automatic variable.
+          $buildArgs = @{ BuildNumber = '${{ github.run_number }}' }
+          if ('${{ steps.v.outputs.version }}') {
+            $buildArgs['Version'] = '${{ steps.v.outputs.version }}'
+          }
+          ./app/packaging/msstore/build-msix.ps1 @buildArgs
+
+      # Keep the package even when the upload is skipped or fails, so a bad
+      # submission can be diagnosed from the artifact.
+      - uses: actions/upload-artifact@v7
+        if: steps.gate.outputs.enabled == 'true'
+        with:
+          name: windows-store-msix
+          path: app/build/windows/msstore/*.msix
+
+      - name: Publish to Microsoft Store
+        if: steps.gate.outputs.enabled == 'true'
+        shell: pwsh
+        run: |
+          $msix = (Get-ChildItem app/build/windows/msstore -Filter *.msix |
+            Select-Object -First 1).FullName
+          if (-not $msix) { throw 'No .msix to publish' }
+
+          $params = @{ MsixPath = $msix }
+          # Only a manual run may commit; a tag push always leaves a draft.
+          if ('${{ github.event.inputs.commit }}' -eq 'true') {
+            $params['Commit'] = $true
+            if ('${{ github.event.inputs.rollout_percentage }}') {
+              $params['RolloutPercentage'] = [int]'${{ github.event.inputs.rollout_percentage }}'
+            }
+          }
+          ./app/packaging/msstore/publish-msix.ps1 @params

--- a/app/RELEASING.md
+++ b/app/RELEASING.md
@@ -73,7 +73,8 @@ The web build is always served fresh, so it skips the check.
 | Android | `app-release.apk`, `app-release.aab` | Debug keys unless a release keystore is configured (below) |
 | iOS | `…-ios-unsigned.zip` (`.app`) | **No**, not installable; needs your Apple signing |
 | macOS | `…-macos.dmg` | Ad-hoc signed for internal consistency; needs Developer ID signing + notarization for public distribution |
-| Windows | `…-windows-installer.exe`, `…-windows-portable.exe`, `…-windows-x64.zip` | **No**, needs an Authenticode cert / MSIX |
+| Windows | `…-windows-installer.exe`, `…-windows-portable.exe`, `…-windows-x64.zip` | **No**, needs an Authenticode cert for non-Store distribution |
+| Windows (Store) | `dartpdf-windows-store.msix` (separate workflow, see below) | Intentionally unsigned - Microsoft re-signs Store submissions |
 | Linux | `…-linux-x64.tar.gz` | n/a |
 | Web | `…-web.zip` | n/a |
 
@@ -150,10 +151,26 @@ membership needed). What that means concretely:
 - CI produces an unsigned per-user NSIS installer. It installs under
   `%LOCALAPPDATA%\Programs\DartPDF`, creates Start Menu shortcuts, registers
   uninstall metadata, and adds DartPDF to the PDF "Open with" list.
-- For public distribution, sign the NSIS installer with an Authenticode
-  code-signing certificate, or package as MSIX (add the `msix` dev-dependency +
-  `msix_config`, which also declares the `.pdf` file association) and sign with
-  your cert.
+- For distribution **outside** the Store, sign that installer with an
+  Authenticode code-signing certificate.
+- **Microsoft Store** shipping is automated and entirely CLI-driven:
+  `.github/workflows/release-windows-store.yml` builds the Store MSIX
+  (`dart run msix:create --store`, configured by `msix_config` in
+  `app/pubspec.yaml` — which also declares the `.pdf` file association) and
+  uploads it with the Microsoft Store Developer CLI. Store submissions are
+  **unsigned**; Microsoft re-signs them, so no Authenticode cert is needed for
+  this channel. An `app-v*` tag uploads a **draft** submission; committing to
+  certification is an explicit manual workflow run.
+
+  The one-time account setup is *not* scriptable — the app must be created and
+  its name reserved in Partner Center by hand, an Azure AD app has to be
+  associated with the account, and the first submission's listing/age-rating
+  must be completed in the UI (the same boundary as Play and the App Store
+  above). Registration itself is free as of 2026. Configuration is four
+  repository **variables** (the public MSIX identity values + Store ID) and four
+  **secrets** (the Azure AD credentials); until they are set the workflow
+  **skips** rather than fails.
+  See [`packaging/msstore/README.md`](packaging/msstore/README.md).
 
 ### Linux
 - The tarball runs as-is. For distribution, wrap as AppImage / Flatpak / Snap /
@@ -170,8 +187,9 @@ The receive side ships in the app (see Phase 2). OS registration is per
 platform: macOS/iOS via the bundled Info.plist `CFBundleDocumentTypes`,
 Android via the manifest intent-filters, web via `manifest.json`
 `file_handlers`. Windows and Linux register the association at **install**
-time. Declare it in the MSIX manifest / `.desktop` file when you build those
-installers.
+time: the NSIS installer writes the ProgID registry keys, the Store MSIX
+declares it via `msix_config`'s `file_extension: .pdf`, and Linux ships it in
+the `.desktop` file's `MimeType`.
 
 ### Document (file) icon
 

--- a/app/packaging/msstore/README.md
+++ b/app/packaging/msstore/README.md
@@ -1,0 +1,144 @@
+# Microsoft Store packaging for DartPDF
+
+Builds the Store MSIX and pushes it into a Partner Center submission. Both
+halves are plain CLI, so the per-release path is fully headless:
+
+| Step | Tool | Script |
+|---|---|---|
+| Build the MSIX | [`msix`](https://pub.dev/packages/msix) pub package (`dart run msix:create --store`) | [`build-msix.ps1`](build-msix.ps1) |
+| Upload the submission | [Microsoft Store Developer CLI](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/overview) (`msstore publish`) | [`publish-msix.ps1`](publish-msix.ps1) |
+
+CI wiring is [`.github/workflows/release-windows-store.yml`](../../../.github/workflows/release-windows-store.yml).
+`.github/workflows/ci.yml`'s `windows-store-scripts` job parse-checks the
+PowerShell and the `msix_config` block on every PR, so neither can rot without a
+Windows runner.
+
+Both scripts are **Windows-only** at run time: `msix` shells out to the
+`makeappx.exe`/`makepri.exe` it bundles (no Windows SDK needed), and `msstore` is
+a Windows binary here. Everything else about the scripts is portable.
+
+## What is *not* scriptable
+
+Creating the app is a one-time manual job. **You cannot reserve an app name or
+create the app through the API** — Microsoft's own docs say you must create it in
+Partner Center first, after which the API can manage its submissions. Same shape
+as the Play/App Store boundary in [`app/RELEASING.md`](../../RELEASING.md).
+
+The one-time setup, all in <https://partner.microsoft.com/dashboard>:
+
+1. **Register a developer account.** As of 2026 registration is **free** for both
+   individual and company accounts (the old $19/$99 fees were dropped).
+2. **Reserve the app name** (`DartPDF`). This mints the identity values the MSIX
+   must carry.
+3. **Register an Azure AD application and associate it with the Partner Center
+   account** (*Account settings → User management → Azure AD applications*), then
+   create a client secret on it. This is what makes the CLI's non-interactive
+   auth work; without the association the credentials authenticate but see no
+   products.
+4. **Complete the first submission in the UI.** Listing description, screenshots,
+   category, privacy policy URL, and the age-rating questionnaire are required
+   before anything can pass certification, and the screenshot/age-rating parts
+   are not CLI-drivable. Expect the *first* release to be manual and every
+   release after it to be automated.
+
+After that, `release-windows-store.yml` handles each release.
+
+## Configuration: 4 variables + 4 secrets
+
+All eight are set in *Settings → Secrets and variables → Actions*, but on
+**different tabs**. The workflow **skips (does not fail)** while any is missing,
+so an unconfigured account cannot turn an `app-v*` tag red; its `::notice::` says
+which are missing and which tab each belongs on.
+
+**Repository *variables*** — public by construction, so masking them would only
+make the logs harder to read. The first three are embedded in the shipped MSIX
+manifest (unzip any Store package and you can read them); the Store ID is in the
+app's public Store URL.
+
+| Variable | Where to find it |
+|---|---|
+| `MSSTORE_IDENTITY_NAME` | Product → Product identity → `Package/Identity/Name` |
+| `MSSTORE_PUBLISHER` | Product → Product identity → `Package/Properties/Publisher` (a `CN=…` string) |
+| `MSSTORE_PUBLISHER_DISPLAY_NAME` | Product → Product identity → `Package/Properties/PublisherDisplayName` |
+| `MSSTORE_PRODUCT_ID` | Product → Product identity → **Store ID** |
+
+**Repository *secrets*** — only `MSSTORE_CLIENT_SECRET` is truly a credential.
+The three IDs are identifiers, kept masked as defence in depth so a leaked client
+secret isn't accompanied by everything needed to use it.
+
+| Secret | Where to find it |
+|---|---|
+| `MSSTORE_CLIENT_SECRET` | A client secret on the associated Azure AD app registration |
+| `MSSTORE_TENANT_ID` | Account settings → User management → Azure AD applications |
+| `MSSTORE_CLIENT_ID` | The associated Azure AD app registration |
+| `MSSTORE_SELLER_ID` | Account settings → Account details → **Seller ID** |
+
+**This repo is public, so Actions logs are world-readable.** GitHub masks
+registered secret values, but the scripts don't rely on that: they never echo a
+credential. `build-msix.ps1` does print the four public identifiers, which is the
+whole reason they are variables rather than secrets. Keep that split if you add
+logging. The workflow's artifact upload is a narrow `*.msix` glob, so the
+credential file `msstore reconfigure` writes cannot be picked up.
+
+The identity values are deliberately **not** in `app/pubspec.yaml`: a checked-in
+placeholder identity builds a package the Store silently refuses, so
+`build-msix.ps1` requires them from the environment and names the exact dashboard
+path in its error.
+
+## Per-release flow
+
+Pushing an `app-v*` tag builds the MSIX and uploads it as a **draft** submission
+— nothing reaches the public Store until you review it, mirroring the *draft*
+GitHub Release that `release-app.yml` creates.
+
+To send it to certification, run the workflow manually
+(Actions → Release Windows Store → Run workflow) with **commit** checked, and
+optionally a rollout percentage. Or locally, from `app/packaging/msstore`:
+
+```powershell
+$env:MSSTORE_IDENTITY_NAME = '…'; $env:MSSTORE_PUBLISHER = 'CN=…'
+$env:MSSTORE_PUBLISHER_DISPLAY_NAME = '…'
+./build-msix.ps1 -Version 3.0.0
+
+$env:MSSTORE_TENANT_ID = '…'; $env:MSSTORE_SELLER_ID = '…'
+$env:MSSTORE_CLIENT_ID = '…'; $env:MSSTORE_CLIENT_SECRET = '…'
+$env:MSSTORE_PRODUCT_ID = '…'
+./publish-msix.ps1 -MsixPath ../../build/windows/msstore/dartpdf-windows-store.msix -Commit
+```
+
+## Gotchas
+
+- **Submissions must be unsigned.** The Store re-signs with the publisher's
+  certificate, so a package we signed is rejected. `store: true` in `msix_config`
+  makes `msix` skip signing; `build-msix.ps1` asserts the output is unsigned
+  rather than trusting that.
+- **The version's revision field must be `0`** and the whole version must be
+  *higher than the last published one*. `build-msix.ps1` takes `X.Y.Z` and
+  appends `.0`; the pubspec build number goes to Flutter as `--build-number`, not
+  into the MSIX version. Bumping only the build number therefore produces a
+  version the Store rejects as a duplicate — bump `X.Y.Z`.
+- **The MSIX carries no MSVC runtime.** Unlike the NSIS/zip artifacts in
+  `release-app.yml`, which copy `msvcp140.dll` & friends to run on clean PCs, an
+  MSIX gets its runtime from the OS via the framework dependency.
+- **`.pdf` association** is declared by `msix_config`'s `file_extension`, which
+  is what registers DartPDF as a PDF handler at install time. The NSIS installer
+  does the same thing through the registry. Neither can make DartPDF the
+  *default* handler — see RELEASING.md's "File associations".
+- **The msstore CLI is framework-dependent** (`net9.0`), so a .NET 9 runtime must
+  be present; the workflow installs it with `actions/setup-dotnet`. The CLI
+  archive is pinned by version *and* SHA-256 in `publish-msix.ps1`, the way
+  `release-app.yml` pins `appimagetool`.
+- **Telemetry** is turned off (`msstore settings --enableTelemetry false`) before
+  any authenticated call.
+
+## Store MSIX vs. the existing Windows artifacts
+
+`release-app.yml`'s `windows` job keeps producing the unsigned portable zip, the
+self-extracting exe, and the NSIS installer — those feed the in-app update
+checker (`app/lib/update_installer.dart`), which reads GitHub Releases and knows
+those exact file names. The Store MSIX is an additional distribution channel and
+deliberately lands in a separate workflow so a Partner Center outage or a
+credential problem cannot fail the artifact build a release depends on.
+
+Store-installed builds update through the Store, so the in-app updater is
+redundant there; it is harmless because it only offers a download.

--- a/app/packaging/msstore/build-msix.ps1
+++ b/app/packaging/msstore/build-msix.ps1
@@ -1,0 +1,136 @@
+<#
+.SYNOPSIS
+  Builds the Microsoft Store MSIX for DartPDF.
+
+.DESCRIPTION
+  Runs `flutter build windows --release` and then `dart run msix:create --store`
+  over its output. Most settings come from `msix_config` in app/pubspec.yaml;
+  the three Partner Center identity values are supplied here from the
+  environment so no placeholder identity is checked in.
+
+  `--store` makes msix skip signing: the Store re-signs every submission with
+  the publisher's certificate, and a package we signed ourselves is rejected.
+
+  Windows-only - msix shells out to the makeappx.exe/makepri.exe it bundles.
+
+.PARAMETER Version
+  Marketing version, e.g. 3.0.0. The MSIX version becomes <Version>.0 because
+  the Store requires the revision field to be 0. Defaults to the `version:` in
+  app/pubspec.yaml.
+
+.PARAMETER BuildNumber
+  Passed to Flutter as --build-number. Defaults to the pubspec build number.
+
+.PARAMETER OutputDir
+  Where the .msix is written. Defaults to app/build/windows/msstore.
+
+.EXAMPLE
+  $env:MSSTORE_IDENTITY_NAME       = '12345ABCDE.DartPDF'
+  $env:MSSTORE_PUBLISHER           = 'CN=ABCD1234-...'
+  $env:MSSTORE_PUBLISHER_DISPLAY_NAME = 'Ben Milanko'
+  ./build-msix.ps1 -Version 3.0.0
+#>
+[CmdletBinding()]
+param(
+  [string]$Version,
+  [string]$BuildNumber,
+  [string]$OutputDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# app/ - the directory holding the pubspec msix reads.
+$appDir = (Resolve-Path (Join-Path $PSScriptRoot '..' '..')).Path
+
+function Get-RequiredEnv {
+  param([string]$Name, [string]$PartnerCenterPath)
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) {
+    throw @"
+$Name is not set.
+
+Find it in Partner Center:
+  $PartnerCenterPath
+
+See app/packaging/msstore/README.md for the full one-time setup.
+"@
+  }
+  return $value
+}
+
+# These identify the Store listing, so a wrong or missing value produces a
+# package the Store silently refuses rather than a build error. Demand them up
+# front, with the exact dashboard path to each.
+$identityName = Get-RequiredEnv 'MSSTORE_IDENTITY_NAME' `
+  'Product > Product identity > Package/Identity/Name'
+$publisher = Get-RequiredEnv 'MSSTORE_PUBLISHER' `
+  'Product > Product identity > Package/Properties/Publisher'
+$publisherDisplayName = Get-RequiredEnv 'MSSTORE_PUBLISHER_DISPLAY_NAME' `
+  'Product > Product identity > Package/Properties/PublisherDisplayName'
+
+# Fall back to the pubspec version, which is the single source of truth for
+# every other platform build (see app/RELEASING.md).
+$pubspecVersion = (Select-String -Path (Join-Path $appDir 'pubspec.yaml') `
+    -Pattern '^version:\s*(\S+)' | Select-Object -First 1
+).Matches[0].Groups[1].Value
+if (-not $pubspecVersion) { throw "Could not read version: from app/pubspec.yaml" }
+
+if (-not $Version)     { $Version     = ($pubspecVersion -split '\+')[0] }
+if (-not $BuildNumber) { $BuildNumber = ($pubspecVersion -split '\+')[1] }
+if (-not $BuildNumber) { $BuildNumber = '1' }
+if (-not $OutputDir)   { $OutputDir   = Join-Path $appDir 'build/windows/msstore' }
+
+# The Store wants exactly four parts with a 0 revision; it rejects anything
+# else and refuses a version <= the last published one.
+if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+  throw "Version must be X.Y.Z (got '$Version'); the Store revision field is forced to 0."
+}
+$msixVersion = "$Version.0"
+
+Write-Host "Building DartPDF $Version (build $BuildNumber) as MSIX $msixVersion"
+# Safe to print: all three are embedded in the shipped MSIX manifest, so they
+# are public by construction (anyone can unzip a Store package and read them).
+# That is why they are repository *variables* rather than secrets - see
+# packaging/msstore/README.md. The credentials in publish-msix.ps1 are never
+# printed. This repo is public, so Actions logs are world-readable - keep it
+# that way.
+Write-Host "  identity_name          : $identityName"
+Write-Host "  publisher              : $publisher"
+Write-Host "  publisher_display_name : $publisherDisplayName"
+
+Push-Location $appDir
+try {
+  & flutter build windows --release `
+    --build-name=$Version --build-number=$BuildNumber
+  if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed ($LASTEXITCODE)" }
+
+  # The Release folder is what the portable zip ships; the MSIX runtime is
+  # supplied by the OS, so no msvcp140/vcruntime140 copy is needed here (unlike
+  # the NSIS/zip artifacts in release-app.yml).
+  New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+  & dart run msix:create `
+    --store `
+    --version $msixVersion `
+    --identity-name $identityName `
+    --publisher $publisher `
+    --publisher-display-name $publisherDisplayName `
+    --output-path $OutputDir
+  if ($LASTEXITCODE -ne 0) { throw "msix:create failed ($LASTEXITCODE)" }
+} finally {
+  Pop-Location
+}
+
+$msix = Get-ChildItem -Path $OutputDir -Filter '*.msix' | Select-Object -First 1
+if (-not $msix) { throw "No .msix produced in $OutputDir" }
+
+# An unsigned package is the expected shape for a Store submission. Catch the
+# opposite mistake - a signed one, which the Store rejects - before upload.
+$signature = Get-AuthenticodeSignature $msix.FullName
+if ($signature.Status -eq 'Valid') {
+  throw "$($msix.Name) is signed; Store submissions must be unsigned (expected --store to skip signing)."
+}
+
+Write-Host "MSIX ready: $($msix.FullName) ($([math]::Round($msix.Length / 1MB, 1)) MB)"
+Write-Output $msix.FullName

--- a/app/packaging/msstore/publish-msix.ps1
+++ b/app/packaging/msstore/publish-msix.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+  Uploads a DartPDF MSIX to the Microsoft Store via the Microsoft Store
+  Developer CLI.
+
+.DESCRIPTION
+  Installs a pinned msstore CLI (checksum-verified), configures it from the
+  Partner Center credentials in the environment, and pushes the package into
+  the app's submission.
+
+  Defaults to leaving the submission as a **draft** (`--noCommit`), matching how
+  release-app.yml creates a *draft* GitHub Release: nothing reaches the public
+  Store until a human reviews it. Pass -Commit to send it to certification.
+
+.PARAMETER MsixPath
+  The .msix to upload - the output of build-msix.ps1.
+
+.PARAMETER Commit
+  Commit the submission (sends it to Store certification). Without this the
+  submission stays a draft in Partner Center.
+
+.PARAMETER RolloutPercentage
+  Package rollout percentage, 0-100. Only meaningful with -Commit.
+
+.PARAMETER CliVersion
+  msstore CLI release tag to install. Pinned so a CLI release cannot silently
+  change release behaviour.
+
+.EXAMPLE
+  $env:MSSTORE_TENANT_ID = '...'; $env:MSSTORE_SELLER_ID = '...'
+  $env:MSSTORE_CLIENT_ID = '...'; $env:MSSTORE_CLIENT_SECRET = '...'
+  $env:MSSTORE_PRODUCT_ID = '9NABCDEFGHIJ'
+  ./publish-msix.ps1 -MsixPath ../../build/windows/msstore/dartpdf-windows-store.msix
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$MsixPath,
+  [switch]$Commit,
+  [ValidateRange(0, 100)][int]$RolloutPercentage = -1,
+  [string]$CliVersion = 'v0.3.9',
+  [string]$CliSha256 = 'bf2f9aa47135eb0820c69a3936e2592a3847248fc650a6cda51cf3b5a8c605fb'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $MsixPath)) { throw "MSIX not found: $MsixPath" }
+$MsixPath = (Resolve-Path $MsixPath).Path
+
+function Get-RequiredEnv {
+  param([string]$Name, [string]$Where)
+  $value = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($value)) {
+    throw "$Name is not set. $Where`n`nSee app/packaging/msstore/README.md."
+  }
+  return $value
+}
+
+$tenantId     = Get-RequiredEnv 'MSSTORE_TENANT_ID' 'Partner Center > Account settings > User management > Azure AD applications.'
+$sellerId     = Get-RequiredEnv 'MSSTORE_SELLER_ID' 'Partner Center > Account settings > Account details > Seller ID.'
+$clientId     = Get-RequiredEnv 'MSSTORE_CLIENT_ID' 'The Azure AD app registration associated with the Partner Center account.'
+$clientSecret = Get-RequiredEnv 'MSSTORE_CLIENT_SECRET' 'A client secret on that Azure AD app registration.'
+$productId    = Get-RequiredEnv 'MSSTORE_PRODUCT_ID' 'Partner Center > Product > Product identity > Store ID.'
+
+# --- Install the CLI ------------------------------------------------------
+# Not `winget install`: winget is not reliably usable on hosted runners and
+# would float the version. A pinned, checksum-verified release archive matches
+# how release-app.yml pins appimagetool.
+$cliDir = Join-Path ([System.IO.Path]::GetTempPath()) "msstore-cli-$CliVersion"
+$msstore = Join-Path $cliDir 'msstore.exe'
+
+if (-not (Test-Path $msstore)) {
+  $zip = Join-Path ([System.IO.Path]::GetTempPath()) "MSStoreCLI-$CliVersion.zip"
+  $url = "https://github.com/microsoft/msstore-cli/releases/download/$CliVersion/MSStoreCLI-win-x64.zip"
+  Write-Host "Downloading msstore CLI $CliVersion"
+  Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+
+  $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($actual -ne $CliSha256.ToLowerInvariant()) {
+    throw "msstore CLI checksum mismatch`n  expected $CliSha256`n  actual   $actual"
+  }
+
+  New-Item -ItemType Directory -Force -Path $cliDir | Out-Null
+  Expand-Archive -Path $zip -DestinationPath $cliDir -Force
+  if (-not (Test-Path $msstore)) { throw "msstore.exe not found after extracting $zip" }
+}
+
+# The archive is framework-dependent (msstore.runtimeconfig.json targets
+# net9.0/Microsoft.NETCore.App 9.0.0), so a .NET 9 runtime must already be on
+# the machine - the workflow installs it with actions/setup-dotnet.
+& $msstore --version | Out-Host
+if ($LASTEXITCODE -ne 0) {
+  throw "msstore CLI failed to start ($LASTEXITCODE); is the .NET 9 runtime installed?"
+}
+
+# --- Configure ------------------------------------------------------------
+# Telemetry off before any authenticated call, so a CI run reports nothing.
+& $msstore settings --enableTelemetry false | Out-Null
+
+# This repo is public, so Actions logs are world-readable. GitHub masks
+# registered secret values, but don't rely on that - just never echo them.
+Write-Host 'Configuring msstore CLI from the Partner Center credentials in the environment'
+& $msstore reconfigure `
+  --tenantId $tenantId `
+  --sellerId $sellerId `
+  --clientId $clientId `
+  --clientSecret $clientSecret | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "msstore reconfigure failed ($LASTEXITCODE)" }
+
+# --- Publish --------------------------------------------------------------
+# --appId is needed because we never ran `msstore init` - the package is built
+# by build-msix.ps1, not by the CLI, so there is no CLI-side project state.
+$publishArgs = @('publish', '--inputFile', $MsixPath, '--appId', $productId)
+if (-not $Commit) {
+  Write-Host 'Uploading as a DRAFT submission (pass -Commit to send to certification)'
+  $publishArgs += '--noCommit'
+} else {
+  Write-Host 'Uploading and COMMITTING the submission - this sends it to Store certification'
+  if ($RolloutPercentage -ge 0) {
+    $publishArgs += @('--packageRolloutPercentage', "$RolloutPercentage")
+  }
+}
+
+& $msstore @publishArgs
+if ($LASTEXITCODE -ne 0) { throw "msstore publish failed ($LASTEXITCODE)" }
+
+Write-Host "`nSubmission status:"
+& $msstore submission status $productId
+
+Write-Host "`nReview the submission at https://partner.microsoft.com/dashboard"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -67,6 +67,10 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  # Builds the Microsoft Store MSIX from the `flutter build windows` output
+  # (`dart run msix:create --store`). Windows-only at run time; it is a
+  # dev-dependency so `msix_config` below travels with the app.
+  msix: ^3.16.8
   # Only used by tool/screenshots_main.dart (not by lib/) to borrow the
   # example's feature-showcase document for marketing screenshots.
   pdf_viewer_example:
@@ -79,6 +83,31 @@ dev_dependencies:
   # the recognized layer is selectable (pdf_ocr_ondevice is a runtime dep).
   pdf_graphics: ^3.0.0
   file_selector_platform_interface: ^2.7.0
+
+# Microsoft Store MSIX packaging. Only the account-neutral settings live here;
+# the three Partner Center identity values (identity_name, publisher,
+# publisher_display_name) are passed on the command line by
+# packaging/msstore/build-msix.ps1 so this file carries no placeholder identity
+# that would silently build a package the Store rejects.
+#
+# `store: true` makes msix skip signing - the Store re-signs submissions with
+# the publisher's own certificate, so a locally-signed package is rejected.
+msix_config:
+  display_name: DartPDF
+  # 1024x1024 source; msix derives the whole tile/logo matrix from it.
+  logo_path: ../doc/icon-1024.png
+  # The MSIX manifest is how Windows learns about the association at install
+  # time (see RELEASING.md "File associations"); the NSIS installer does the
+  # equivalent through the registry.
+  file_extension: .pdf
+  # Update checks, and the TSA/OCSP/Fulcio calls made when signing.
+  capabilities: internetClient
+  architecture: x64
+  output_name: dartpdf-windows-store
+  store: true
+  # The workflow runs `flutter build windows` itself so it can pass
+  # --build-name/--build-number like every other job in release-app.yml.
+  build_windows: false
 
 flutter:
   uses-material-design: true

--- a/doc/dev-log/2026-07-25-windows-store-deployment.md
+++ b/doc/dev-log/2026-07-25-windows-store-deployment.md
@@ -1,0 +1,123 @@
+# 2026-07-25 - Microsoft Store deployment (pure CLI)
+
+Added a headless Microsoft Store release path for the app. Constraint set by
+the request: **only if it can be pure CLI/script** - no GUI-driven release step.
+It can, for the per-release path; the account/app creation genuinely cannot, and
+that boundary is documented rather than papered over.
+
+## Shape
+
+Two halves, both plain CLI:
+
+- **Build** - the [`msix`](https://pub.dev/packages/msix) pub package as a
+  dev-dependency of `app`, driven by `dart run msix:create --store`.
+  Configuration lives in `msix_config` in `app/pubspec.yaml`.
+- **Upload** - Microsoft's [msstore CLI](https://github.com/microsoft/msstore-cli),
+  `msstore reconfigure` + `msstore publish --inputFile … --appId …`.
+
+Scripts in `app/packaging/msstore/` (`build-msix.ps1`, `publish-msix.ps1`),
+wired by `.github/workflows/release-windows-store.yml`. Docs:
+`app/packaging/msstore/README.md`.
+
+## Why a separate workflow, not a job in release-app.yml
+
+`release-app.yml` produces the artifacts the in-app update checker depends on
+(`app/lib/update_installer.dart` reads GitHub Releases and matches exact file
+names). A Partner Center outage or a credential problem must not fail that
+build. The Store MSIX is an additional channel, so it gets its own workflow with
+its own `workflow_dispatch` inputs (version / commit / rollout percentage) and
+can be re-run without rebuilding every platform.
+
+## Decisions worth remembering
+
+**The three Partner Center identity values are deliberately NOT in pubspec.yaml.**
+`identity_name`, `publisher`, `publisher_display_name` are account-specific, and
+a checked-in placeholder builds a package the Store *silently refuses* rather
+than failing the build. `build-msix.ps1` requires them from the environment and
+its error names the exact dashboard path for each. A `ci.yml` guard fails if
+anyone later pins them in the pubspec.
+
+**Store submissions must be unsigned.** Microsoft re-signs with the publisher's
+certificate, so a package we signed is rejected. `store: true` makes `msix` skip
+signing (`if (_config.signMsix && !_config.store)` in msix.dart). `build-msix.ps1`
+*asserts* the output is unsigned via `Get-AuthenticodeSignature` rather than
+trusting the flag - this is the failure mode that would otherwise only surface
+as a rejected submission days later. This is also why the Store channel needs no
+Authenticode cert while the NSIS installer still does.
+
+**Version revision must be 0**, and the whole version must exceed the last
+published one. `msix` derives `major.minor.patch.0` from the pubspec version;
+the build number goes to Flutter as `--build-number` and never into the MSIX
+version. So bumping only the build number yields a duplicate the Store rejects -
+bump `X.Y.Z`.
+
+**The workflow skips, not fails, when configuration is absent.** An unset secret
+must not turn every `app-v*` tag red - that trap already bit the web-worker PRs
+with `WORKER_REGEN_TOKEN`. A gate step checks all eight values and emits a
+`::notice::` naming which are missing and which tab each belongs on.
+
+**Four repository variables, four secrets** - not eight secrets. `identity_name`,
+`publisher`, `publisher_display_name` and the Store ID are public *by
+construction*: the first three are embedded in the shipped MSIX manifest (unzip
+any Store package to read them) and the Store ID is in the app's public Store
+URL. Registering them as secrets would mask them to `***` in the logs, costing
+debuggability for zero security gain. Only `MSSTORE_CLIENT_SECRET` is a real
+credential; the tenant/client/seller IDs stay secrets as defence in depth, so a
+leaked client secret isn't accompanied by everything needed to use it. This split
+is why `build-msix.ps1` may print its three identity values while
+`publish-msix.ps1` prints none of its inputs.
+
+**Tag push = draft submission.** Committing to certification is an explicit
+manual run, mirroring how `release-app.yml` creates a *draft* GitHub Release.
+
+**msstore CLI is framework-dependent** (`msstore.runtimeconfig.json` targets
+`net9.0`/`Microsoft.NETCore.App 9.0.0`), so the workflow installs .NET 9 with
+`actions/setup-dotnet`. Not `winget install` for the CLI itself - that floats the
+version; the release zip is pinned by tag *and* SHA-256
+(`bf2f9aa4…605fb` for v0.3.9), the way `release-app.yml` pins `appimagetool`.
+Note `msix` needs no Windows SDK - it bundles its own makeappx/makepri.
+
+**`file_extension: .pdf`** closes a long-standing TODO in `RELEASING.md`: the
+MSIX manifest is how Windows learns the association at install time, the
+equivalent of the NSIS installer's ProgID registry writes.
+
+## What is not scriptable (and why the docs say so)
+
+Microsoft's docs are explicit that the submission API cannot create an app - the
+name must be reserved in Partner Center by hand. Also manual, one-time: the
+Azure AD app registration and its *association* with the Partner Center account
+(without the association the credentials authenticate but see no products), and
+the first submission's listing/screenshots/age-rating. Registration itself is now
+free for both individual and company accounts (the old $19/$99 fees were dropped
+in 2026). Same boundary as Play and the App Store in `RELEASING.md`.
+
+## Verification
+
+No Windows machine here, so everything short of the two Windows binaries was
+exercised locally with a self-contained PowerShell 7.6.4:
+
+- Both scripts parse-checked with `Parser::ParseFile`; guard clauses tested
+  (missing credentials, bad version format, missing MSIX, rollout out of range),
+  and version derivation confirmed to yield `3.0.0` / build `20` → MSIX `3.0.0.0`.
+- The workflow's gate step tested for all-unset / all-set / one-missing.
+- `msix:create` run against a faked `Release/` folder: it validated the whole
+  config, resolved `logo_path: ../doc/icon-1024.png`, generated all **82** scaled
+  tile/logo PNGs, and emitted an `AppxManifest.xml` with the right `<Identity>`
+  (`Version="3.0.0.0"`, `ProcessorArchitecture="x64"`), `internetClient` +
+  `runFullTrust` capabilities, and the `.pdf` `FileTypeAssociation`. It stopped
+  exactly at `makepri.exe` - the Windows-only boundary.
+- A `ci.yml` job (`windows-store-scripts`, ubuntu + preinstalled `pwsh`) keeps
+  the PowerShell and `msix_config` from rotting without paying for a Windows
+  runner. Its config guard was mutation-tested: flipping `store` to false,
+  deleting it, changing `file_extension`, and deleting `architecture` are all
+  caught.
+
+One bug found by that mutation testing and fixed: the guard originally
+substring-matched `'store: true'`, which passed even with the key flipped to
+`false` because the explanatory comment in `pubspec.yaml` contains that same
+literal text. The checks are now anchored regexes against the real YAML keys.
+
+**Still unverified:** `makepri.exe`/`makeappx.exe` packaging, and the upload
+itself - both need Windows, and the upload needs a Partner Center account that
+does not exist yet. The first real run should be a `workflow_dispatch` without
+`commit`, so it lands as a draft.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: "71e43f1976c3eae2d9468a5b4d6600bf8cae61508b87f27fa1799228935d48ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
   clock:
     dependency: transitive
     description:
@@ -97,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  console:
+    dependency: transitive
+    description:
+      name: console
+      sha256: e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   convert:
     dependency: transitive
     description:
@@ -343,6 +359,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get_it:
+    dependency: transitive
+    description:
+      name: get_it
+      sha256: "568d62f0e68666fb5d95519743b3c24a34c7f19d834b0658c46e26d778461f66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.1"
   glob:
     dependency: transitive
     description:
@@ -500,6 +524,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  msix:
+    dependency: transitive
+    description:
+      name: msix
+      sha256: "61415c352e8aea084332b8a5514e6408c961c8cdeca202804fff1040eb555ac7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.18.0"
   node_preamble:
     dependency: transitive
     description:


### PR DESCRIPTION
Adds a headless Microsoft Store release path for the app. The constraint was
**only if it can be pure CLI/script** — it can for the per-release path, and the
one part that genuinely can't be scripted is documented rather than papered over.

| Step | Tool |
|---|---|
| Build the MSIX | `msix` pub dev-dependency → `dart run msix:create --store` |
| Upload | Microsoft Store Developer CLI → `msstore publish` |

- `app/pubspec.yaml` — `msix_config` (also declares the `.pdf` file association,
  closing a TODO in `RELEASING.md`)
- `app/packaging/msstore/{build-msix,publish-msix}.ps1` + README
- `.github/workflows/release-windows-store.yml`
- `ci.yml` job that parse-checks the PowerShell on **ubuntu** — no Windows runner

## Design calls

**Separate workflow, not a job in `release-app.yml`.** That workflow produces the
artifacts the in-app update checker matches by exact filename
(`app/lib/update_installer.dart`); a Partner Center outage or credential problem
must not fail it. The Store MSIX is an additional channel, and its own workflow
gets `workflow_dispatch` inputs (version / commit / rollout) and can re-run
without rebuilding every platform.

**Skips, not fails, when unconfigured.** An unset secret must not turn every
`app-v*` tag red — the `WORKER_REGEN_TOKEN` trap. The gate reports which values
are missing and which settings tab each belongs on.

**Tag push → draft submission.** Committing to certification is an explicit
manual run, mirroring the *draft* GitHub Release `release-app.yml` creates.

**Store submissions must be unsigned** — Microsoft re-signs, so a package we
signed is rejected. `store: true` skips signing and `build-msix.ps1` *asserts*
the output is unsigned rather than trusting the flag; that failure mode would
otherwise only surface as a rejected submission days later. This is also why the
Store channel needs no Authenticode cert while the NSIS installer still does.

**4 repository variables + 4 secrets, not 8 secrets.** The MSIX identity values
and Store ID are public *by construction* — the first three ship inside the
downloadable package, the Store ID is in the public Store URL — so masking them
would cost log readability for no security gain. Only `MSSTORE_CLIENT_SECRET` is
a real credential; the tenant/client/seller IDs stay masked as defence in depth.
This repo is public, so Actions logs are world-readable: the scripts never echo a
credential, and the artifact glob is a narrow `*.msix` so the credential file
`msstore reconfigure` writes can't be swept up.

**The identity values are deliberately not in `pubspec.yaml`** — a checked-in
placeholder builds a package the Store *silently refuses*, so `build-msix.ps1`
requires them from the env and names the exact dashboard path for each. A CI
guard fails if they're ever pinned.

## Not scriptable (one-time, manual)

Microsoft's API cannot reserve an app name, so the app must be created in Partner
Center by hand; likewise the Azure AD app registration + its *association* with
the account (without it the credentials authenticate but see no products), and
the first submission's listing/screenshots/age-rating. Same boundary as Play and
the App Store. Registration itself is free as of 2026.
See `app/packaging/msstore/README.md`.

## Verification

No Windows machine available, so everything short of the two Windows binaries was
exercised locally under a self-contained PowerShell 7.6.4:

- Both scripts parse-checked; guards tested (missing credentials, bad version
  format, missing MSIX, rollout out of range). Version derivation confirmed:
  `3.0.0` / build `20` → MSIX `3.0.0.0`.
- Gate step tested for nothing-set / variables-only / all-eight.
- `msix:create` against a faked `Release/` folder validated the whole config,
  resolved `logo_path`, generated all **82** scaled tile PNGs, and emitted an
  `AppxManifest.xml` with the right `<Identity Version="3.0.0.0"
  ProcessorArchitecture="x64">`, `internetClient` + `runFullTrust`, and the
  `.pdf` `FileTypeAssociation` — stopping exactly at `makepri.exe`.
- The new CI config guard was mutation-tested: flipping `store` to false,
  deleting it, changing `file_extension`, deleting `architecture` are all caught.
  That testing found a real bug in the guard — it substring-matched
  `'store: true'`, which passed even with the key flipped, because the
  explanatory comment in `pubspec.yaml` contains that literal. Now anchored
  regexes against the real YAML keys.
- `dart analyze` clean; all 321 app tests pass.

**Still unverified:** `makepri.exe`/`makeappx.exe` packaging and the upload
itself — both need Windows, and the upload needs a Partner Center account that
doesn't exist yet. First real run should be a `workflow_dispatch` **without**
`commit`, so it lands as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
