### PR TITLE
perf(editor): turn the progressive top-down reveal on by default (#564)

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 // would drag the whole editor stack into the initial web download that the
 // deferred split exists to keep small.
 import 'package:dart_pdf_editor/dart_pdf_editor.dart'
-    show DartPdfEditorLocalizations, PdfPageView;
+    show DartPdfEditorLocalizations;
 import 'package:dart_pdf_editor/perf_log.dart';
 import 'package:flutter/material.dart';
 
@@ -19,8 +19,6 @@ import 'app_info.dart' deferred as app_info;
 Future<void> main(List<String> args) async {
   // PackageInfo (loaded below) needs the binding; ensure it before awaiting.
   WidgetsFlutterBinding.ensureInitialized();
-
-  PdfPageView.progressiveStreamingPaint = true;
 
   // Diagnostics: turn on the in-app performance trace (interpret times,
   // render-hold/scheduler transitions, prerender warms, and frame JANK,

--- a/doc/dev-log/2026-07-25-streaming-partials-564-default-on.md
+++ b/doc/dev-log/2026-07-25-streaming-partials-564-default-on.md
@@ -1,0 +1,46 @@
+# 2026-07-25 — Progressive reveal on by default (#564 closes)
+
+PR1–5 built the streaming reveal end to end behind
+`PdfPageView.progressiveStreamingPaint`, default **off**: partial transport on
+the isolate (PR1), dedup fan-out (PR2), cost bounds (PR3), the host paint
+consumer (PR4), and the web-worker transport twin (PR5). This flips the default
+**on** and removes the app's now-redundant opt-in.
+
+## Why now — the three gates the flag was waiting on
+
+1. **Both backends stream.** PR5 landed the web twin, so a dense page no longer
+   loses the #527 bounded prefix without gaining the reveal on web.
+2. **Measured, not eyeballed.** Real-Chrome A/B on the dense diagram sheet
+   (`tool/perf.sh web open-diagram` vs `open-diagram-progressive`, median of 5):
+   first content **~430 ms via `early-prefix` → ~322 ms via
+   `progressive-partial`**, ~25% faster first ink, every run ahead. That
+   understates it — the baseline shows one bounded snapshot while the reveal
+   keeps filling in on the doubling schedule, and the gap widens with density
+   (a 249k-command CAD sheet logged first ink ~866 ms against a ~12.9 s full
+   raster).
+3. **Reviewed.** Each PR went through an adversarial review; no shipping bug was
+   found, and every latent finding (concurrent-pass ordering, slug short-circuit,
+   pause re-check, emit-cadence burst) was fixed before landing.
+
+## The flip
+
+- `pdf_page_view.dart` — `progressiveStreamingPaint = true`, doc comment
+  rewritten to describe the opt-**out** and cite the measurement.
+- `app/lib/main.dart` — dropped the explicit `= true` (and the now-unused
+  `PdfPageView` import); the app just takes the library default.
+- `early_prefix_paint_test.dart` — pins the flag **off** in `setUp`. Not a
+  workaround: the reveal deliberately *replaces* the single bounded prefix on a
+  dense page, so with the new default that suite would have been asserting a
+  path its own subject no longer takes. It now covers the documented fallback,
+  and `progressive_streaming_paint_test.dart` covers the default.
+
+## What is actually on
+
+Only a page over `earlyPrefixMinContentBytes` (512 KB raw content) streams — the
+same density proxy the bounded prefix used, an O(streams) size check with no
+decode. Ordinary pages take exactly the path they took before and are never
+charged a second worker job. A backend that doesn't stream (the null worker)
+returns the final with no partials and renders as before. `= false` restores the
+#527 bounded snapshot.
+
+#564 is complete.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -364,12 +364,14 @@ class PdfPageView extends StatefulWidget {
   /// of prefixes rather than one snapshot - and lands *before* the vector-first
   /// full raster, so it is strictly more information sooner.
   ///
-  /// Default **off**: only the native isolate backend streams partials today (the
-  /// web worker twin is the follow-up), and the reveal's smoothness is a visual
-  /// judgement, so this is opt-in until validated. Gated on the same
-  /// [earlyPrefixMinContentBytes] density proxy. Backends that don't stream make
-  /// it a no-op - the page renders exactly as before.
-  static bool progressiveStreamingPaint = false;
+  /// Default **on**: both backends stream (isolate and web worker), and the
+  /// reveal measured ~25% faster first ink than the bounded prefix it replaces
+  /// on a dense sheet in real Chrome (`tool/perf.sh web open-diagram` vs
+  /// `open-diagram-progressive`). Gated on the same [earlyPrefixMinContentBytes]
+  /// density proxy, so an ordinary page is untouched. Backends that don't stream
+  /// (the null worker) make it a no-op - the page renders exactly as before.
+  /// Set false to fall back to the single bounded [earlyPrefixPaint] snapshot.
+  static bool progressiveStreamingPaint = true;
 
   /// Composite deep-zoom detail from the [PdfTileStore] zoom-bucket pyramid
   /// instead of the single unbudgeted detail patch. When true (and the page

--- a/packages/dart_pdf_editor/test/early_prefix_paint_test.dart
+++ b/packages/dart_pdf_editor/test/early_prefix_paint_test.dart
@@ -24,16 +24,23 @@ void main() {
   late int prevLimit;
   late int prevMin;
   late bool prevOn;
+  late bool prevProgressive;
 
   setUp(() {
     prevLimit = PdfPageView.earlyPrefixCommandLimit;
     prevMin = PdfPageView.earlyPrefixMinContentBytes;
     prevOn = PdfPageView.earlyPrefixPaint;
+    prevProgressive = PdfPageView.progressiveStreamingPaint;
+    // The #564 reveal, on by default, deliberately REPLACES the single bounded
+    // prefix on a dense page. This suite covers the fallback path, so pin it
+    // off; progressive_streaming_paint_test.dart covers the default.
+    PdfPageView.progressiveStreamingPaint = false;
   });
   tearDown(() {
     PdfPageView.earlyPrefixCommandLimit = prevLimit;
     PdfPageView.earlyPrefixMinContentBytes = prevMin;
     PdfPageView.earlyPrefixPaint = prevOn;
+    PdfPageView.progressiveStreamingPaint = prevProgressive;
   });
 
   testWidgets('a dense page records a bounded prefix before the full pass',

--- a/packages/dart_pdf_editor/test/progressive_streaming_paint_test.dart
+++ b/packages/dart_pdf_editor/test/progressive_streaming_paint_test.dart
@@ -77,8 +77,8 @@ void main() {
             'flag is on and the page is dense: ${worker.baseRecordHadPartial}');
   });
 
-  testWidgets('the default-off flag streams nothing', (tester) async {
-    PdfPageView.progressiveStreamingPaint = false; // the shipped default
+  testWidgets('opting the flag back off streams nothing', (tester) async {
+    PdfPageView.progressiveStreamingPaint = false; // the documented opt-out
     PdfPageView.earlyPrefixMinContentBytes = 0;
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.resetDevicePixelRatio);


### PR DESCRIPTION
Flips `PdfPageView.progressiveStreamingPaint` to **on**, the last step of #564.

## The three gates the flag was waiting on

1. **Both backends stream.** #594 landed the web-worker twin, so a dense page no longer loses the #527 bounded prefix without gaining the reveal on web.
2. **Measured, not eyeballed.** Real-Chrome A/B on the dense diagram sheet (`tool/perf.sh web open-diagram` vs `open-diagram-progressive`, median of 5):

   | | time to first content |
   |---|---|
   | #527 bounded prefix (baseline) | ~430 ms via `early-prefix` |
   | **#564 reveal** | **~322 ms** via `progressive-partial` |

   **~25% faster first ink, every run ahead.** It understates the win: the baseline shows one bounded snapshot while the reveal keeps filling in on the doubling schedule, and the gap widens with density — a 249k-command CAD sheet logged first ink ~866 ms against a ~12.9 s full raster in real-app logs.
3. **Reviewed.** Every PR in the stack went through an adversarial review; no shipping bug, and each latent finding (concurrent-pass ordering, slug short-circuit, pause re-check, emit-cadence burst) was fixed before landing.

## What is actually on

Only a page over `earlyPrefixMinContentBytes` (512 KB raw content) streams — the same O(streams) density proxy the bounded prefix already used, no decode. An ordinary page takes exactly the path it took before and is never charged a second worker job. A backend that doesn't stream (the null worker) returns the final with no partials and renders as before. `= false` restores the #527 bounded snapshot.

## Also

- `app/lib/main.dart` drops its explicit opt-in (and the now-unused `PdfPageView` import) and just takes the library default.
- `early_prefix_paint_test.dart` pins the flag **off** in `setUp`. Not a workaround: the reveal deliberately *replaces* the single bounded prefix on a dense page, so under the new default that suite would assert a path its own subject no longer takes. It now covers the documented fallback; `progressive_streaming_paint_test.dart` covers the default.

## Tests

Full `dart_pdf_editor` suite: **1955 passed**. The only failures are `ghent_render_test`'s 20 pre-existing baselines (#550), unrelated to a page-view flag.

Closes #564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)