### PR TITLE
perf(images): memoize colour conversion — halve image-decode time in a record serialize (#451)

### DIFF
--- a/doc/dev-log/2026-07-25-image-decode-colour-memo-451.md
+++ b/doc/dev-log/2026-07-25-image-decode-colour-memo-451.md
@@ -1,0 +1,174 @@
+# 2026-07-25 — #451: the record-serialize outlier is colour conversion, not resolution
+
+Issue #451 opened on a device trace where a render record's cost tracked
+neither its payload nor its command count: **5.3 MB serialised in 1817 ms
+while 39 MB serialised in 329 ms**, same worker, same run. A later comment
+root-caused it as full-resolution decode ahead of the downsample, and
+proposed *downsampling in the source colour space before converting*.
+
+Measuring per image first says the proposal would have missed most of the
+cost. This is what the measurement found, what landed, and what is left.
+
+## Reproducing it on the VM
+
+Two new tools, both in `packages/pdf_graphics/tool/`:
+
+- **`bench_image_serialize.dart`** — runs the record path's exact call
+  (`serializeCommands(cos:, decodeImages: true, maxImagePixelRatio: 2.0)`)
+  over a corpus and splits each page's serialize into its image half and
+  its command-encode half.
+- **`bench_image_decode.dart`** — one level down: for every image a page
+  draws, decodes it at the size the record path actually asks for
+  (`cappedImagePixelSize` at ratio 2.0) and reports the cost beside the
+  image's *shape* — colour space, bits, filters, mask, source vs target
+  pixels. Best-of-5, because a single sample cannot separate a real change
+  from scheduler jitter.
+
+The device profile reproduces immediately. Pure command encode tops out at
+~22 ms for 6k commands — no superlinearity there. With image decode on, the
+outliers appear, and they are disproportionate to output bytes:
+`GWG205_ICC-V4-CMYK-Image_x4.pdf` p0 cost **235 ms for 110 commands and
+1.43 MB of output**.
+
+## What the shape breakdown showed
+
+Across the Ghent + PDF.js corpora at ratio 2.0 (155 images), before any
+change:
+
+```
+     732.7ms    30 images  DeviceCMYK/8b      <- 65% of all image-decode time
+     167.6ms     3 images  DeviceN/8b
+      58.9ms    25 images  DeviceGray/1b
+      55.9ms     5 images  DeviceRGB/8b
+      46.6ms    40 images  Indexed/8b
+      37.5ms     1 images  Indexed/8b+Stencil
+```
+
+The decisive detail: **almost every one of those CMYK images is drawn at or
+above native size** (scale 1.00 in the per-image table). Decoding straight
+to the display size cannot help an image that is not being downscaled. The
+tool's closing line makes the ceiling explicit — of 1125 ms total, only
+463 ms was spent on images that are downscaled *at all*, and the saving on
+those is proportional to `1 − scale`, not to the whole.
+
+So the cost is the per-pixel conversion itself. Timed directly on GWG205's
+profile:
+
+| path | per pixel |
+|---|---|
+| `PdfColor.cmyk` (the SWOP polynomial) | 0.147 µs |
+| `IccProfile.toSrgb` (v4 CMYK, 4-D CLUT over 16 corners) | 0.853 µs |
+
+At 0.853 µs/px, GWG205's 227695 pixels are 194 ms of its 235 ms.
+
+## What actually collapses it: the tuples repeat
+
+GWG205's image resolves to **29027 distinct colours across 227695 pixels**
+(12.7%); GWG1610's to 8785 across 154135 (5.7%). Press artwork is built from
+a small ink palette, and even photographic content has strong local
+coherence. So memoize the conversion on the sample tuple.
+
+This is not a new idea in this file — `_alternateToRgba` already did it for
+tint transforms. What landed applies it where the corpus says the time is,
+with a table that holds up under pressure.
+
+### `_ColorMemo`
+
+Direct-mapped over a pair of typed arrays rather than a `Map`:
+
+- no hashing of boxed keys, no rehash growth;
+- **no cliff when the working set exceeds capacity** — a colliding tuple
+  evicts and is recomputed, where the old size-capped `Map` stopped learning
+  at 65536 entries and then paid a *failed* lookup on every remaining pixel
+  of the image.
+
+It replaces that `Map` on the tint path too, which retires a latent web bug
+along the way. The old key packed up to 8 components into one int via
+`key = (key << 8) | sample`. Past four 8-bit components that exceeds 32 bits,
+where dart2js's bitwise operators wrap and the VM's do not — so two distinct
+tuples would compare equal **on the web only** and silently take each other's
+colour. Keys are now compared as raw component bytes, which is exact
+everywhere.
+
+Two deliberate choices worth keeping:
+
+- **Slot hash by small multiplies** (`s0*7 + s1*31 + …`), not shift-and-mix:
+  every partial sum stays far inside the 53-bit range dart2js gives a plain
+  int, so a tuple lands in the same slot on the VM and on the web.
+- **A pixel-count floor** (`_minPixels`, 8192): below it the tables cost more
+  to allocate than the conversions they save, so small images are untouched.
+
+### Allocation-free `_Lut.apply`
+
+The second part. `_Lut.apply` is the inner loop of every ICC-managed image
+and allocated **five lists per call** — mapped inputs, low indices,
+fractions, accumulator, PCS output. Those now live on the profile and are
+reused; `apply` reads its input and its single call site consumes the
+returned PCS values on the next line, so one set serves a whole image.
+
+## Result
+
+Best of 5, same corpora, versus the pre-#451 baseline:
+
+| shape | before | after | |
+|---|---|---|---|
+| DeviceCMYK/8b | 732.7 ms | **213.5 ms** | −71% |
+| Separation/8b | 14.5 ms | 6.4 ms | −56% |
+| DeviceN/8b | 167.6 ms | 140.7 ms | −16% |
+| **total** | **1125 ms** | **561 ms** | **−50%** |
+
+## Why this is safe, and how that was checked rather than asserted
+
+A memo hit returns the colour that tuple genuinely converts to, so both
+parts are output-preserving *by construction*. That claim is verified, not
+trusted:
+
+- **`tool/hash_image_decodes.dart`** (written for an earlier decode change,
+  exactly the right tool here) hashes every image XObject through both decode
+  entry points. All **420 images** across both corpora hash **byte-identically**
+  before and after.
+- `ghent_render_test` needs **no baseline change** — which matters given
+  [the #550 finding](2026-07-25-ghent-baseline-drift-550.md) that a green
+  Ghent run is not by itself proof of correctness. Here the stronger claim
+  (zero baseline movement) is available, so it is the one being made.
+- Full suites: pdf_cos 356, pdf_document 805, pdf_graphics 927,
+  dart_pdf_editor 1969, app 321.
+
+The new unit test targets the one way this could go wrong. A fixed-size
+direct-mapped table can lie in exactly two ways — a stale eviction, and two
+tuples hashing to one slot — so the test makes it thrash on purpose: 65536
+distinct CMYK tuples through 16384 slots, every pixel checked against an
+independently computed conversion. It was confirmed to **fail** when the key
+comparison is deleted.
+
+## What is left, and why it was not bundled
+
+Three things the measurement surfaced, all deliberately out of this change
+because they alter output and the issue itself warns against landing colour
+changes blind:
+
+1. **Downsample before converting** — #451's original proposal. Still real,
+   but now bounded: only 168 ms of the remaining 561 ms is spent on
+   downscaled images at all, and the saving is a fraction of that. Worth
+   doing *after* the free wins, not instead of them.
+
+2. **The scaled fast path stops at direct device colour spaces.**
+   `GWG161_Transp_Basic_BM_ICCBasedRGB` decodes 2045×1018 to display at
+   128×64 — a 254× overdraw — because `_isDirectDeviceColorSpace` rejects the
+   `ICCBased` array even when the profile is sRGB-equivalent and the
+   conversion is the identity copy. Extending it there looks free, but the
+   fast path resamples **bilinearly** while the full path box-filters, so at
+   a 16× downscale it would trade decode time for aliasing on a
+   pixel-enforced Ghent page. That is a quality decision, not a perf one.
+
+3. **A mask larger than its base blows the decode up to the mask's grid.**
+   `pdfApplyImageAlpha` upsamples the base to the mask resolution to preserve
+   the cutout's detail — deliberate, and right in principle, but unbounded:
+   `issue4246.pdf` decodes a **50×40** image to **1000×800** (400×, 3.2 MB of
+   RGBA for 2000 source pixels), and `smaskdim.pdf` a 2×2 to 76×102 (1938×).
+   The fix is not to clamp to the base — that would destroy exactly the
+   detail the upsample exists to keep — but to bound the blow-up by the
+   *display* cap, which `_targetDecodedSize` currently cannot express because
+   it derives the target from the declared base size alone. Only 2 images in
+   these corpora, but it is a memory pathology as much as a time one, and the
+   39 MB page-1 record in the original trace is the shape that would expose it.

--- a/doc/dev-log/2026-07-25-image-decode-colour-memo-451.md
+++ b/doc/dev-log/2026-07-25-image-decode-colour-memo-451.md
@@ -33,7 +33,7 @@ outliers appear, and they are disproportionate to output bytes:
 ## What the shape breakdown showed
 
 Across the Ghent + PDF.js corpora at ratio 2.0 (155 images), before any
-change:
+change (single-shot run — see the caveat under *Result* about interleaving):
 
 ```
      732.7ms    30 images  DeviceCMYK/8b      <- 65% of all image-decode time
@@ -95,8 +95,17 @@ Two deliberate choices worth keeping:
 - **Slot hash by small multiplies** (`s0*7 + s1*31 + …`), not shift-and-mix:
   every partial sum stays far inside the 53-bit range dart2js gives a plain
   int, so a tuple lands in the same slot on the VM and on the web.
-- **A pixel-count floor** (`_minPixels`, 8192): below it the tables cost more
-  to allocate than the conversions they save, so small images are untouched.
+- **A table sized to the image** — the next power of two at or above the
+  pixel count, floored at 256 and capped at 16384. The first version of this
+  gated the memo behind a *minimum pixel count* instead, which got the trade
+  backwards: the case a floor excludes is the small image, which is where a
+  memo is most effective. A 90x90 spot-colour logo has at most 256 distinct
+  samples and a type 4 tint transform to evaluate for each, so the floor made
+  it pay 8100 PostScript evaluations to avoid allocating a couple of
+  kilobytes — and since `_alternateToRgba` memoized unconditionally before
+  this branch, that was a straight regression. Codecov caught it by flagging
+  `memo?.store` as unreachable: the floor had left every Separation/DeviceN
+  unit test running with no memo at all.
 
 ### Allocation-free `_Lut.apply`
 
@@ -108,14 +117,22 @@ returned PCS values on the next line, so one set serves a whole image.
 
 ## Result
 
-Best of 5, same corpora, versus the pre-#451 baseline:
+Best of 5 per image, and — after a first pass produced numbers that moved
+between runs — measured by **interleaving** the two revisions in one session
+(A, B, A, B) rather than trusting figures taken minutes apart. That matters:
+a non-interleaved run gave DeviceCMYK a 732.7 ms baseline where the
+interleaved one gives 624 ms, purely from machine state. The interleaved
+figures are the honest ones, and two rounds agreed to within 1%:
 
 | shape | before | after | |
 |---|---|---|---|
-| DeviceCMYK/8b | 732.7 ms | **213.5 ms** | −71% |
-| Separation/8b | 14.5 ms | 6.4 ms | −56% |
-| DeviceN/8b | 167.6 ms | 140.7 ms | −16% |
-| **total** | **1125 ms** | **561 ms** | **−50%** |
+| DeviceCMYK/8b | 623.6 / 624.0 ms | **211.2 / 208.9 ms** | −66% |
+| Separation/8b | 10.3 / 10.4 ms | 6.5 / 6.3 ms | −38% |
+| DeviceN/8b | 167.8 / 166.1 ms | 138.4 / 139.6 ms | −17% |
+
+The lesson is worth keeping for the next perf change in this area: on this
+machine a single-shot before/after can be off by 15% in either direction, so
+interleave.
 
 ## Why this is safe, and how that was checked rather than asserted
 
@@ -131,15 +148,26 @@ trusted:
   [the #550 finding](2026-07-25-ghent-baseline-drift-550.md) that a green
   Ghent run is not by itself proof of correctness. Here the stronger claim
   (zero baseline movement) is available, so it is the one being made.
-- Full suites: pdf_cos 356, pdf_document 805, pdf_graphics 927,
+- Full suites: pdf_cos 356, pdf_document 805, pdf_graphics 929,
   dart_pdf_editor 1969, app 321.
 
-The new unit test targets the one way this could go wrong. A fixed-size
-direct-mapped table can lie in exactly two ways — a stale eviction, and two
-tuples hashing to one slot — so the test makes it thrash on purpose: 65536
-distinct CMYK tuples through 16384 slots, every pixel checked against an
-independently computed conversion. It was confirmed to **fail** when the key
-comparison is deleted.
+Three unit tests, each aimed at a specific way this could go wrong, and each
+confirmed to fail when that specific bug is introduced:
+
+- **Memo eviction and collision.** A fixed-size direct-mapped table can lie
+  in exactly two ways — a stale eviction, and two tuples hashing to one slot
+  — so the test makes it thrash on purpose: 65536 distinct CMYK tuples
+  through 16384 slots, every pixel checked against an independently computed
+  conversion. Fails when the key comparison is deleted.
+- **The ICC-managed CMYK image path**, decoded end to end with every pixel
+  checked against the profile itself. This is the 0.85 µs/px path, and the
+  one now feeding a reused `Float64List` to the transform. Fails when an
+  input component is left stale between pixels.
+- **LUT scratch reuse**, driving one profile the way an image does: many
+  colours, out of order, revisited, with unrelated colours pushed through in
+  between. A single-colour test cannot catch this because the first call is
+  still right. Fails when the accumulator is not re-zeroed — precisely the
+  bug reusing a buffer introduces.
 
 ## What is left, and why it was not bundled
 

--- a/packages/pdf_graphics/lib/src/icc.dart
+++ b/packages/pdf_graphics/lib/src/icc.dart
@@ -331,6 +331,20 @@ class _Lut {
   /// mft2 stores Lab with the legacy 0xFF00 == 100.0 encoding.
   final bool legacyLab16;
 
+  /// Per-call scratch, allocated once per profile rather than per pixel.
+  /// [apply] runs on every pixel of an ICC-managed image - a CMYK press
+  /// profile made it the single most expensive step in a record serialize
+  /// (issue #451) - and it used to allocate four lists each time. It reads
+  /// its input and hands its output straight to the caller's conversion, so
+  /// one set of buffers serves the whole image. Not re-entrant, which
+  /// [apply]'s straight-line body guarantees.
+  late final Float64List _mapped = Float64List(inChannels);
+  late final Int32List _low = Int32List(inChannels);
+  late final Float64List _frac = Float64List(inChannels);
+  late final Float64List _out = Float64List(outChannels);
+  // The Lab branch writes three components regardless of outChannels.
+  late final Float64List _pcs = Float64List(math.max(outChannels, 3));
+
   static _Lut? parse(Uint8List bytes, int offset, {required bool pcsIsLab}) {
     final data = ByteData.sublistView(bytes);
     final type = String.fromCharCodes(bytes, offset, offset + 4);
@@ -468,21 +482,24 @@ class _Lut {
   /// Runs [values] through the pipeline; returns PCS values (Lab
   /// decoded to L 0..100 / a,b -128..127, or XYZ 0..~2).
   List<double> apply(List<double> values) {
-    final mapped = [
-      for (var c = 0; c < inChannels; c++)
-        _Curve._sample(inputCurves[c], values[c].clamp(0.0, 1.0)),
-    ];
+    final mapped = _mapped;
+    final low = _low;
+    final frac = _frac;
+    final out = _out;
+    for (var c = 0; c < inChannels; c++) {
+      mapped[c] = _Curve._sample(inputCurves[c], values[c].clamp(0.0, 1.0));
+    }
 
     // multilinear interpolation over the 2^n cell corners
-    final low = List<int>.filled(inChannels, 0);
-    final frac = List<double>.filled(inChannels, 0);
     for (var c = 0; c < inChannels; c++) {
       final g = gridPoints[c];
       final position = mapped[c] * (g - 1);
       low[c] = math.min(position.floor(), g - 2).clamp(0, g - 1);
       frac[c] = (position - low[c]).clamp(0.0, 1.0);
     }
-    final out = List<double>.filled(outChannels, 0);
+    for (var o = 0; o < outChannels; o++) {
+      out[o] = 0;
+    }
     final corners = 1 << inChannels;
     for (var corner = 0; corner < corners; corner++) {
       var weight = 1.0;
@@ -504,18 +521,24 @@ class _Lut {
       out[o] = _Curve._sample(outputCurves[o], out[o]);
     }
 
+    final pcs = _pcs;
     if (pcsIsLab) {
       if (legacyLab16) {
         // legacy 16-bit Lab: 0xFF00 is 100.0 / +127
-        return [
-          out[0] * 65535 / 652.80,
-          out[1] * 65535 / 256 - 128,
-          out[2] * 65535 / 256 - 128,
-        ];
+        pcs[0] = out[0] * 65535 / 652.80;
+        pcs[1] = out[1] * 65535 / 256 - 128;
+        pcs[2] = out[2] * 65535 / 256 - 128;
+        return pcs;
       }
-      return [out[0] * 100, out[1] * 255 - 128, out[2] * 255 - 128];
+      pcs[0] = out[0] * 100;
+      pcs[1] = out[1] * 255 - 128;
+      pcs[2] = out[2] * 255 - 128;
+      return pcs;
     }
     // XYZ: u16 0..0xFFFF spans 0..1.99997
-    return [for (final v in out) v * 65535 / 32768];
+    for (var o = 0; o < outChannels; o++) {
+      pcs[o] = out[o] * 65535 / 32768;
+    }
+    return pcs;
   }
 }

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -1625,23 +1625,21 @@ Uint8List? _toRgba(CosDocument cos, CosDictionary dict, Uint8List data,
 /// and the VM's do not, so two different tuples would compare equal on the web
 /// and silently take each other's colour.
 class _ColorMemo {
-  _ColorMemo._(this._components)
-      : _keys = Uint8List(_slots * _components),
-        _rgb = Int32List(_slots)..fillRange(0, _slots, _empty);
-
-  /// 16 K slots: ~128 KB of tables, small against the megabytes of RGBA an
-  /// image this size decodes to, and enough that a page's ink palette lands
-  /// essentially collision-free.
-  static const int _bits = 14;
-  static const int _slots = 1 << _bits;
-  static const int _mask = _slots - 1;
+  _ColorMemo._(this._components, int slots)
+      : _mask = slots - 1,
+        _keys = Uint8List(slots * _components),
+        _rgb = Int32List(slots)..fillRange(0, slots, _empty);
 
   /// Packed sRGB is never negative, so -1 marks a slot that was never filled.
   static const int _empty = -1;
 
-  /// Below this the tables cost more to allocate than the conversions they
-  /// would save, so small images convert straight through.
-  static const int _minPixels = 1 << 13;
+  /// Slot-count bounds. The floor is 256 because that is the number of
+  /// distinct samples a single-colorant space can produce at all, so a
+  /// Separation image is collision-free at the smallest table worth
+  /// allocating. The ceiling keeps a large image's tables (~128 KB at four
+  /// components) small against the megabytes of RGBA it decodes to.
+  static const int _minSlots = 1 << 8;
+  static const int _maxSlots = 1 << 14;
 
   /// Per-component multipliers for the slot hash. Every partial sum stays far
   /// inside the 53-bit range dart2js gives a plain int, so a tuple maps to the
@@ -1651,6 +1649,7 @@ class _ColorMemo {
   ];
 
   final int _components;
+  final int _mask;
   final Uint8List _keys;
   final Int32List _rgb;
 
@@ -1658,13 +1657,23 @@ class _ColorMemo {
   int _slot = 0;
 
   /// A memo for an image of [pixels] pixels in a [components]-channel space,
-  /// or null when it is too small, or too wide, to be worth one.
-  static _ColorMemo? forPixels(int pixels, int components) =>
-      pixels >= _minPixels &&
-              components > 0 &&
-              components <= _hashPrimes.length
-          ? _ColorMemo._(components)
-          : null;
+  /// or null when the space is wider than the hash can key.
+  ///
+  /// The table is sized to the image rather than gated behind a minimum pixel
+  /// count. A fixed floor looks reasonable and gets the trade backwards: the
+  /// case it excludes is the small image, which is exactly where a memo is
+  /// most effective - a 90x90 spot-colour logo has at most 256 distinct
+  /// samples and an expensive type 4 tint transform to evaluate for each, so
+  /// a floor would make it pay 8100 evaluations to avoid allocating a table
+  /// that only ever needed to be a couple of kilobytes.
+  static _ColorMemo? forPixels(int pixels, int components) {
+    if (components <= 0 || components > _hashPrimes.length) return null;
+    var slots = _minSlots;
+    while (slots < pixels && slots < _maxSlots) {
+      slots <<= 1;
+    }
+    return _ColorMemo._(components, slots);
+  }
 
   /// The packed sRGB remembered for the [_components] samples starting at
   /// [base] in [data], or -1 on a miss. After a miss the caller converts and

--- a/packages/pdf_graphics/lib/src/image_pixels.dart
+++ b/packages/pdf_graphics/lib/src/image_pixels.dart
@@ -1542,28 +1542,50 @@ Uint8List? _toRgba(CosDocument cos, CosDictionary dict, Uint8List data,
           lut3 = _lutFor(ranges, 3);
       final cmykIcc = icc != null && icc.channels == 4 ? icc : null;
       final key = colorKey;
-      // CMYK→RGB is the heaviest per-pixel path (a quadratic polynomial, or an
-      // ICC LUT). The conversion math is unchanged, but the per-pixel sample
-      // and value lists - and the keyed() argument list - are gone, which is
-      // most of the old cost.
+      // CMYK→RGB is the heaviest per-pixel path by a wide margin: a quadratic
+      // polynomial, or - for an ICCBased CMYK press profile - a 4-D CLUT
+      // interpolation over 16 cell corners. Measured at ratio 2.0 on the Ghent
+      // suite, DeviceCMYK images are 55% of all image-decode time in a record
+      // serialize, at 0.15 µs/px unmanaged and 0.85 µs/px through an ICC v4
+      // profile (issue #451).
+      //
+      // The tuple → colour memo is the same trick [_alternateToRgba] already
+      // uses for tint transforms, and it pays here for the same reason: press
+      // artwork reuses a handful of inks, so the distinct-tuple count is a
+      // small fraction of the pixel count. A hit returns the value the
+      // conversion would have computed for that exact tuple, so the output is
+      // unchanged byte for byte - only the number of conversions falls.
+      final memo = _ColorMemo.forPixels(count, 4);
+      // Reused across pixels: the ICC transform reads its input and keeps no
+      // reference to it, so one buffer serves the whole image.
+      final iccValues = cmykIcc == null ? null : Float64List(4);
       for (var i = 0; i < count; i++) {
         final base = i * 4;
         final s0 = data[base],
             s1 = data[base + 1],
             s2 = data[base + 2],
             s3 = data[base + 3];
-        final color = cmykIcc != null
-            ? cmykIcc.toSrgb([
-                lut0[s0] / 255,
-                lut1[s1] / 255,
-                lut2[s2] / 255,
-                lut3[s3] / 255
-              ])
-            : PdfColor.cmyk(
+        var rgb = memo == null ? -1 : memo.lookup(data, base);
+        if (rgb < 0) {
+          final PdfColor color;
+          if (cmykIcc != null) {
+            iccValues![0] = lut0[s0] / 255;
+            iccValues[1] = lut1[s1] / 255;
+            iccValues[2] = lut2[s2] / 255;
+            iccValues[3] = lut3[s3] / 255;
+            color = cmykIcc.toSrgb(iccValues);
+          } else {
+            color = PdfColor.cmyk(
                 lut0[s0] / 255, lut1[s1] / 255, lut2[s2] / 255, lut3[s3] / 255);
-        out[base] = (color.red * 255).round();
-        out[base + 1] = (color.green * 255).round();
-        out[base + 2] = (color.blue * 255).round();
+          }
+          rgb = ((color.red * 255).round().clamp(0, 255) << 16) |
+              ((color.green * 255).round().clamp(0, 255) << 8) |
+              (color.blue * 255).round().clamp(0, 255);
+          memo?.store(data, base, rgb);
+        }
+        out[base] = (rgb >> 16) & 0xff;
+        out[base + 1] = (rgb >> 8) & 0xff;
+        out[base + 2] = rgb & 0xff;
         out[base + 3] = key != null &&
                 s0 >= key[0].$1 &&
                 s0 <= key[0].$2 &&
@@ -1581,12 +1603,98 @@ Uint8List? _toRgba(CosDocument cos, CosDictionary dict, Uint8List data,
   return null;
 }
 
-/// A packed sample tuple must fit an int key; wider spaces skip the table.
-const int _tintMemoMaxComponents = 8;
+/// A fixed-size, direct-mapped memo from an 8-bit sample tuple to the packed
+/// sRGB triple its colour conversion produces (issue #451).
+///
+/// Colour conversion is the dominant per-pixel cost of decoding a CMYK image
+/// or anything behind a tint transform, and the tuples repeat heavily: press
+/// artwork is built from a small ink palette, and even a photograph has strong
+/// local coherence. A hit returns the value the conversion computed for that
+/// **exact** tuple, so a decode is byte-identical with the memo on or off - it
+/// only converts less often.
+///
+/// Direct-mapped rather than a `Map`: a fixed pair of typed arrays means no
+/// hashing of boxed keys, no rehash growth, and no cliff when the working set
+/// exceeds capacity - a colliding tuple simply evicts and is recomputed, where
+/// a size-capped `Map` stops learning entirely and then pays a failed lookup
+/// on every remaining pixel.
+///
+/// Keys are compared as raw component bytes rather than packed into one int.
+/// A packed key is the obvious encoding and the wrong one here: past four
+/// 8-bit components it exceeds 32 bits, where dart2js's bitwise operators wrap
+/// and the VM's do not, so two different tuples would compare equal on the web
+/// and silently take each other's colour.
+class _ColorMemo {
+  _ColorMemo._(this._components)
+      : _keys = Uint8List(_slots * _components),
+        _rgb = Int32List(_slots)..fillRange(0, _slots, _empty);
 
-/// Ceiling on distinct tuples remembered, so a wide space whose tuples never
-/// repeat cannot grow the table with the pixel count.
-const int _tintMemoMaxEntries = 1 << 16;
+  /// 16 K slots: ~128 KB of tables, small against the megabytes of RGBA an
+  /// image this size decodes to, and enough that a page's ink palette lands
+  /// essentially collision-free.
+  static const int _bits = 14;
+  static const int _slots = 1 << _bits;
+  static const int _mask = _slots - 1;
+
+  /// Packed sRGB is never negative, so -1 marks a slot that was never filled.
+  static const int _empty = -1;
+
+  /// Below this the tables cost more to allocate than the conversions they
+  /// would save, so small images convert straight through.
+  static const int _minPixels = 1 << 13;
+
+  /// Per-component multipliers for the slot hash. Every partial sum stays far
+  /// inside the 53-bit range dart2js gives a plain int, so a tuple maps to the
+  /// same slot on the VM and on the web.
+  static const List<int> _hashPrimes = [
+    7, 31, 127, 8191, 131071, 524287, 2097143, 8388593, //
+  ];
+
+  final int _components;
+  final Uint8List _keys;
+  final Int32List _rgb;
+
+  /// The slot [lookup] last probed, so [store] fills it without rehashing.
+  int _slot = 0;
+
+  /// A memo for an image of [pixels] pixels in a [components]-channel space,
+  /// or null when it is too small, or too wide, to be worth one.
+  static _ColorMemo? forPixels(int pixels, int components) =>
+      pixels >= _minPixels &&
+              components > 0 &&
+              components <= _hashPrimes.length
+          ? _ColorMemo._(components)
+          : null;
+
+  /// The packed sRGB remembered for the [_components] samples starting at
+  /// [base] in [data], or -1 on a miss. After a miss the caller converts and
+  /// hands the result to [store].
+  int lookup(Uint8List data, int base) {
+    var hash = 0;
+    for (var c = 0; c < _components; c++) {
+      hash += data[base + c] * _hashPrimes[c];
+    }
+    _slot = hash & _mask;
+    final rgb = _rgb[_slot];
+    if (rgb == _empty) return _empty;
+    final keyBase = _slot * _components;
+    for (var c = 0; c < _components; c++) {
+      if (_keys[keyBase + c] != data[base + c]) return _empty;
+    }
+    return rgb;
+  }
+
+  /// Remembers [rgb] as the colour of the tuple at [base], in the slot the
+  /// matching [lookup] probed. The tuple is re-read rather than cached because
+  /// a miss may be an eviction, which has to overwrite the resident key too.
+  void store(Uint8List data, int base, int rgb) {
+    final keyBase = _slot * _components;
+    for (var c = 0; c < _components; c++) {
+      _keys[keyBase + c] = data[base + c];
+    }
+    _rgb[_slot] = rgb;
+  }
+}
 
 /// Separation and DeviceN samples reach the alternate space through a tint
 /// transform, which - a type 4 calculator especially - costs orders of
@@ -1608,20 +1716,13 @@ Uint8List? _alternateToRgba(
   final components = alternate.channels;
   if (data.length < count * components) return null;
   final luts = [for (var c = 0; c < components; c++) _lutFor(ranges, c)];
-  final memo = components <= _tintMemoMaxComponents ? <int, int>{} : null;
+  final memo = _ColorMemo.forPixels(count, components);
   // Reused across pixels: evaluateAt reads its input and keeps no reference.
   final values = Float64List(components);
 
   for (var i = 0; i < count; i++) {
     final base = i * components;
-    var key = 0;
-    if (memo != null) {
-      for (var c = 0; c < components; c++) {
-        key = (key << 8) | data[base + c];
-      }
-    }
-    // Packed RGB is never negative, so -1 stands in for "not remembered".
-    var rgb = memo?[key] ?? -1;
+    var rgb = memo == null ? -1 : memo.lookup(data, base);
     if (rgb < 0) {
       for (var c = 0; c < components; c++) {
         values[c] = luts[c][data[base + c]] / 255;
@@ -1630,7 +1731,7 @@ Uint8List? _alternateToRgba(
       rgb = ((color.red * 255).round().clamp(0, 255) << 16) |
           ((color.green * 255).round().clamp(0, 255) << 8) |
           ((color.blue * 255).round().clamp(0, 255));
-      if (memo != null && memo.length < _tintMemoMaxEntries) memo[key] = rgb;
+      memo?.store(data, base, rgb);
     }
     out[i * 4] = (rgb >> 16) & 0xff;
     out[i * 4 + 1] = (rgb >> 8) & 0xff;

--- a/packages/pdf_graphics/test/icc_test.dart
+++ b/packages/pdf_graphics/test/icc_test.dart
@@ -115,6 +115,44 @@ void main() {
         [180, 142, 105]);
   });
 
+  test('a LUT profile stays correct across interleaved calls (#451)', () {
+    // The LUT pipeline reuses per-profile scratch buffers instead of
+    // allocating five lists per pixel. That is only sound if nothing survives
+    // one call into the next, and a leak would be invisible to a test that
+    // converts a single colour: the first call would still be right.
+    //
+    // So drive the profile the way an image does - the same instance, many
+    // colours, out of order, revisited - and require the pinned littleCMS
+    // values to hold every time regardless of what was converted in between.
+    final profile = IccProfile.parse(genericCmykIcc())!;
+    const cases = <(List<double>, List<int>)>[
+      ([1, 0, 0, 0], [0, 164, 219]), // cyan
+      ([0, 0, 0, 1], [25, 26, 25]), // rich black
+      ([50 / 255, 100 / 255, 150 / 255, 20 / 255], [180, 142, 105]),
+    ];
+
+    for (var round = 0; round < 4; round++) {
+      // Interleave in both directions, and push unrelated colours through
+      // between the pinned ones so any retained state would be the wrong one.
+      for (final (input, want) in cases) {
+        profile.toSrgb([0.2, 0.4, 0.6, 0.8]);
+        expectSrgb(profile.toSrgb(input), want);
+      }
+      for (final (input, want) in cases.reversed) {
+        expectSrgb(profile.toSrgb(input), want);
+      }
+    }
+
+    // The caller passes a reused buffer too; the profile must not retain it.
+    final scratch = Float64List(4);
+    for (final (input, want) in cases) {
+      scratch.setAll(0, input);
+      final color = profile.toSrgb(scratch);
+      scratch.fillRange(0, 4, 0); // clobber after the call
+      expectSrgb(color, want);
+    }
+  });
+
   test('sRGB-equivalent profiles are detected and bypassed (#531)', () {
     final profile = IccProfile.parse(buildSrgbIccProfile())!;
     expect(profile.channels, 3);

--- a/packages/pdf_graphics/test/image_pixels_test.dart
+++ b/packages/pdf_graphics/test/image_pixels_test.dart
@@ -301,6 +301,55 @@ void main() {
         reason: 'the memo handed back a colour belonging to another tuple');
   });
 
+  test('an ICC-managed CMYK image converts through the memo unchanged', () {
+    // The ICCBased CMYK branch is the one #451 measured at 0.85 us/px, and the
+    // one this change touches most: it now feeds a reused Float64List to the
+    // profile and reads its colours back through the memo. Both are chances to
+    // leak state between pixels, so decode an image whose every pixel has an
+    // independently known answer.
+    final profile = IccProfile.parse(genericCmykIcc())!;
+    const size = 64; // 4096 px: enough to exercise a real table
+    final samples = Uint8List(size * size * 4);
+    for (var p = 0; p < size * size; p++) {
+      final s = p * 4;
+      samples[s] = (p * 37) & 0xff;
+      samples[s + 1] = (p * 11) & 0xff;
+      samples[s + 2] = (p * 5) & 0xff;
+      samples[s + 3] = (p ~/ size) & 0xff;
+    }
+
+    final stream = flateImage({
+      'Width': const CosInteger(size),
+      'Height': const CosInteger(size),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': CosArray([
+        const CosName('ICCBased'),
+        CosStream(
+            CosDictionary({'N': const CosInteger(4)}), genericCmykIcc()),
+      ]),
+    }, samples);
+
+    final pixels = decodePdfImagePixels(cos, stream)!;
+
+    var mismatches = 0;
+    for (var p = 0; p < size * size; p++) {
+      final s = p * 4;
+      final expected = profile.toSrgb([
+        samples[s] / 255,
+        samples[s + 1] / 255,
+        samples[s + 2] / 255,
+        samples[s + 3] / 255,
+      ]);
+      if (pixels.rgba[s] != (expected.red * 255).round() ||
+          pixels.rgba[s + 1] != (expected.green * 255).round() ||
+          pixels.rgba[s + 2] != (expected.blue * 255).round()) {
+        mismatches++;
+      }
+    }
+    expect(mismatches, 0,
+        reason: 'the ICC CMYK path disagreed with the profile itself');
+  });
+
   test('scaled DeviceRGB Flate decodes directly to target size', () {
     final stream = image({
       'Width': const CosInteger(4),

--- a/packages/pdf_graphics/test/image_pixels_test.dart
+++ b/packages/pdf_graphics/test/image_pixels_test.dart
@@ -251,6 +251,56 @@ void main() {
     });
   });
 
+  test('the CMYK colour memo survives eviction and collision', () {
+    // The decode path memoizes sample-tuple → sRGB (issue #451), which is only
+    // sound if a hit is always the colour that tuple really converts to. The
+    // danger is the two ways a fixed-size direct-mapped table can lie: an
+    // eviction that leaves a stale colour behind, and two different tuples
+    // hashing to one slot.
+    //
+    // So make the table thrash on purpose. 256x256 = 65536 pixels, every one a
+    // distinct CMYK tuple, against a table an order of magnitude smaller: the
+    // slot for any given tuple is overwritten many times over. Then check every
+    // pixel against the conversion computed independently. A table that ever
+    // returned a neighbour's colour cannot pass this.
+    const size = 256;
+    final samples = Uint8List(size * size * 4);
+    for (var y = 0; y < size; y++) {
+      for (var x = 0; x < size; x++) {
+        final i = (y * size + x) * 4;
+        samples[i] = x;
+        samples[i + 1] = y;
+        samples[i + 2] = (x * 7 + y * 13) & 0xff;
+        samples[i + 3] = (x ^ y) & 0xff;
+      }
+    }
+
+    final stream = flateImage({
+      'Width': const CosInteger(size),
+      'Height': const CosInteger(size),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': const CosName('DeviceCMYK'),
+    }, samples);
+
+    final pixels = decodePdfImagePixels(cos, stream)!;
+    expect(pixels.width, size);
+    expect(pixels.height, size);
+
+    var mismatches = 0;
+    for (var p = 0; p < size * size; p++) {
+      final s = p * 4;
+      final expected = PdfColor.cmyk(samples[s] / 255, samples[s + 1] / 255,
+          samples[s + 2] / 255, samples[s + 3] / 255);
+      if (pixels.rgba[s] != (expected.red * 255).round() ||
+          pixels.rgba[s + 1] != (expected.green * 255).round() ||
+          pixels.rgba[s + 2] != (expected.blue * 255).round()) {
+        mismatches++;
+      }
+    }
+    expect(mismatches, 0,
+        reason: 'the memo handed back a colour belonging to another tuple');
+  });
+
   test('scaled DeviceRGB Flate decodes directly to target size', () {
     final stream = image({
       'Width': const CosInteger(4),

--- a/packages/pdf_graphics/tool/bench_image_decode.dart
+++ b/packages/pdf_graphics/tool/bench_image_decode.dart
@@ -1,0 +1,202 @@
+// #451, one level down from bench_image_serialize: per *image*, what does the
+// record path pay to decode it, and what shape is it?
+//
+// The record path asks `decodePdfImage` for the capped display size
+// (`cappedImagePixelSize` at ratio 2.0). This reproduces that call for every
+// image every corpus page draws and prints the cost next to the image's
+// shape - colour space, filters, bits, mask, source vs target pixels - so the
+// expensive shapes are identifiable rather than guessed at.
+//
+//   fvm dart tool/bench_image_decode.dart [dir-or-file ...]
+import 'dart:io';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'dart:math' as math;
+
+const _ratio = 2.0;
+
+/// Decode time is noisy; report the best of this many runs per image.
+const _runs = 5;
+
+void main(List<String> args) {
+  final paths = args.where((a) => !a.startsWith('--')).toList();
+  final files = _collect(paths.isEmpty
+      ? const ['../../test_corpora/ghent', '../../test_corpora/pdfjs']
+      : paths);
+
+  final rows = <_Row>[];
+  for (final file in files) {
+    final PdfDocument doc;
+    final int pageCount;
+    try {
+      doc = PdfDocument.open(file.readAsBytesSync());
+      pageCount = doc.pageCount;
+    } catch (_) {
+      continue;
+    }
+    for (var i = 0; i < pageCount; i++) {
+      try {
+        rows.addAll(_measurePage(file.path, doc, i));
+      } catch (_) {
+        // Uninterpretable pages are not this benchmark's concern.
+      }
+    }
+  }
+
+  rows.sort((a, b) => b.ms.compareTo(a.ms));
+  stdout.writeln('Per-image decode at the record path\'s capped size '
+      '(ratio $_ratio, ${rows.length} images)\n');
+  stdout.writeln('      ms   src px    dst px  scale  bits  space        '
+      'mask  filters               page');
+  for (final r in rows.take(30)) {
+    stdout.writeln(r);
+  }
+  final total = rows.fold<double>(0, (s, r) => s + r.ms);
+  stdout.writeln('\ntotal ${total.toStringAsFixed(0)}ms across '
+      '${rows.length} images');
+
+  // Group the cost by shape, which is what a fix has to target.
+  final byShape = <String, (double, int)>{};
+  for (final r in rows) {
+    final key = '${r.space}/${r.bits}b'
+        '${r.mask.isEmpty ? '' : '+${r.mask}'}';
+    final prev = byShape[key] ?? (0.0, 0);
+    byShape[key] = (prev.$1 + r.ms, prev.$2 + 1);
+  }
+  final shapes = byShape.entries.toList()
+    ..sort((a, b) => b.value.$1.compareTo(a.value.$1));
+  stdout.writeln('\nCost by image shape:');
+  for (final e in shapes.take(15)) {
+    stdout.writeln('  ${e.value.$1.toStringAsFixed(1).padLeft(8)}ms  '
+        '${e.value.$2.toString().padLeft(4)} images  ${e.key}');
+  }
+
+  // How much of the cost is on images that are downscaled at all? That is the
+  // ceiling on any "downsample before converting" fix.
+  var downscaled = 0.0, native = 0.0;
+  for (final r in rows) {
+    if (r.dstPixels < r.srcPixels) {
+      downscaled += r.ms;
+    } else {
+      native += r.ms;
+    }
+  }
+  stdout.writeln('\ndownscaled images: ${downscaled.toStringAsFixed(0)}ms   '
+      'drawn at/above native: ${native.toStringAsFixed(0)}ms');
+}
+
+List<_Row> _measurePage(String path, PdfDocument doc, int index) {
+  final page = doc.page(index);
+  final cos = doc.cos;
+  final recorder = RecordingPdfDevice();
+  PdfInterpreter(cos: cos, device: recorder)
+    ..drawPage(page)
+    ..drawAnnotations(page);
+
+  final rows = <_Row>[];
+  final seen = <CosStream>{};
+  for (final request in recorder.imageRequests) {
+    if (!seen.add(request.stream)) continue;
+    final dict = request.stream.dictionary;
+    final w = _intOf(cos.resolve(dict['Width']));
+    final h = _intOf(cos.resolve(dict['Height']));
+    if (w <= 0 || h <= 0) continue;
+
+    final t = request.transform;
+    final widthPts = math.sqrt(t.a * t.a + t.b * t.b);
+    final heightPts = math.sqrt(t.c * t.c + t.d * t.d);
+    final capped = cappedImagePixelSize(w, h, widthPts, heightPts, _ratio);
+
+    // Warm the stream/ICC caches, then take the best of a few runs: decode
+    // time is noisy enough between runs that a single sample cannot tell a
+    // real change from scheduler jitter.
+    decodePdfImage(cos, request.stream,
+        targetWidth: capped.$1, targetHeight: capped.$2);
+    var bestUs = -1;
+    for (var run = 0; run < _runs; run++) {
+      final sw = Stopwatch()..start();
+      final decoded = decodePdfImage(cos, request.stream,
+          targetWidth: capped.$1, targetHeight: capped.$2);
+      sw.stop();
+      if (decoded == null) break;
+      if (bestUs < 0 || sw.elapsedMicroseconds < bestUs) {
+        bestUs = sw.elapsedMicroseconds;
+      }
+    }
+    if (bestUs < 0) continue;
+
+    rows.add(_Row(
+      ms: bestUs / 1000,
+      srcWidth: w,
+      srcHeight: h,
+      dstWidth: capped.$1,
+      dstHeight: capped.$2,
+      bits: _intOf(cos.resolve(dict['BitsPerComponent']), fallback: 8),
+      space: pdfImageColorFamily(cos, dict),
+      mask: [
+        if (dict.containsKey('SMask')) 'SMask',
+        if (cos.resolve(dict['Mask']) is CosArray) 'ColorKey',
+        if (cos.resolve(dict['Mask']) is CosStream) 'Stencil',
+        if (cos.resolve(dict['ImageMask']) == const CosBoolean(true))
+          'ImageMask',
+      ].join('+'),
+      filters: pdfImageFilters(cos, dict).join(','),
+      page: '${path.split('/').last} p$index',
+    ));
+  }
+  return rows;
+}
+
+class _Row {
+  _Row({
+    required this.ms,
+    required this.srcWidth,
+    required this.srcHeight,
+    required this.dstWidth,
+    required this.dstHeight,
+    required this.bits,
+    required this.space,
+    required this.mask,
+    required this.filters,
+    required this.page,
+  });
+
+  final double ms;
+  final int srcWidth, srcHeight, dstWidth, dstHeight, bits;
+  final String space, mask, filters, page;
+
+  int get srcPixels => srcWidth * srcHeight;
+  int get dstPixels => dstWidth * dstHeight;
+
+  @override
+  String toString() {
+    final scale = srcPixels == 0 ? 0.0 : dstPixels / srcPixels;
+    return '  ${ms.toStringAsFixed(1).padLeft(6)}  '
+        '${'${srcWidth}x$srcHeight'.padLeft(9)} '
+        '${'${dstWidth}x$dstHeight'.padLeft(9)}  '
+        '${scale.toStringAsFixed(2).padLeft(5)}  '
+        '${bits.toString().padLeft(4)}  ${space.padRight(12)} '
+        '${mask.padRight(5)} ${filters.padRight(21)} $page';
+  }
+}
+
+int _intOf(CosObject? o, {int fallback = 0}) =>
+    o is CosInteger ? o.value : o is CosReal ? o.value.round() : fallback;
+
+List<File> _collect(List<String> paths) {
+  final out = <File>[];
+  for (final p in paths) {
+    final dir = Directory(p);
+    if (dir.existsSync()) {
+      out.addAll(dir.listSync(recursive: true).whereType<File>().where((f) =>
+          f.path.toLowerCase().endsWith('.pdf') && !f.path.contains('/_')));
+      continue;
+    }
+    final file = File(p);
+    if (file.existsSync()) out.add(file);
+  }
+  out.sort((a, b) => a.path.compareTo(b.path));
+  return out;
+}

--- a/packages/pdf_graphics/tool/bench_image_serialize.dart
+++ b/packages/pdf_graphics/tool/bench_image_serialize.dart
@@ -1,0 +1,162 @@
+// #451: where does a render-record serialize actually spend its time?
+//
+// The device traces showed a 5.3 MB record serialising in 1817 ms while a
+// 39 MB one took 329 ms in the same worker - so the cost is not the payload.
+// This reproduces that on the VM by running the record path's exact call
+// (`serializeCommands(cos:, decodeImages: true, maxImagePixelRatio: 2.0)`)
+// over a corpus and reporting, per page, the serialize time split into the
+// image half and the command-encode half.
+//
+//   fvm dart tool/bench_image_serialize.dart [dir-or-file ...]
+//
+// Defaults to the checked-in test corpora. `--json` emits machine-readable
+// rows so an A/B can diff two revisions; `--runs=N` takes the best of N.
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+const _ratio = 2.0;
+
+void main(List<String> args) {
+  final json = args.contains('--json');
+  final runs = int.tryParse(
+          args.firstWhere((a) => a.startsWith('--runs='), orElse: () => '')
+              .replaceFirst('--runs=', '')) ??
+      1;
+  final paths = args.where((a) => !a.startsWith('--')).toList();
+  final files = _collect(paths.isEmpty
+      ? const ['../../test_corpora/ghent', '../../test_corpora/pdfjs']
+      : paths);
+  if (files.isEmpty) {
+    stderr.writeln('no PDFs found');
+    exit(1);
+  }
+
+  final rows = <Map<String, Object?>>[];
+  for (final file in files) {
+    final PdfDocument doc;
+    final int pageCount;
+    try {
+      doc = PdfDocument.open(file.readAsBytesSync());
+      pageCount = doc.pageCount;
+    } catch (_) {
+      continue;
+    }
+    for (var i = 0; i < pageCount; i++) {
+      try {
+        final row = _measurePage(file.path, doc, i, runs);
+        if (row != null) rows.add(row);
+      } catch (_) {
+        // A page that cannot be interpreted is not this benchmark's concern.
+      }
+    }
+  }
+
+  rows.sort((a, b) => (b['imageMs'] as num).compareTo(a['imageMs'] as num));
+  if (json) {
+    stdout.writeln(const JsonEncoder.withIndent('  ').convert(rows));
+    return;
+  }
+
+  stdout.writeln('Image cost inside serialize at ratio $_ratio '
+      '(${rows.length} pages, best of $runs)\n');
+  stdout.writeln('  imageMs  encodeMs   cmds   imgs     outMB   srcMpx  page');
+  for (final r in rows.take(25)) {
+    stdout.writeln('  ${_pad(r['imageMs'], 7)}  ${_pad(r['encodeMs'], 8)}  '
+        '${_pad(r['commands'], 5)}  ${_pad(r['images'], 4)}  '
+        '${_pad(r['outMB'], 8)}  ${_pad(r['sourceMpx'], 7)}  ${r['page']}');
+  }
+  final totalImage = rows.fold<double>(0, (s, r) => s + (r['imageMs'] as num));
+  final totalEncode = rows.fold<double>(0, (s, r) => s + (r['encodeMs'] as num));
+  final withImages = rows.where((r) => (r['images'] as int) > 0).length;
+  stdout.writeln('\n$withImages/${rows.length} pages draw images; '
+      'total image=${totalImage.toStringAsFixed(0)}ms '
+      'encode=${totalEncode.toStringAsFixed(0)}ms');
+}
+
+Map<String, Object?>? _measurePage(
+    String path, PdfDocument doc, int index, int runs) {
+  final page = doc.page(index);
+  final cos = doc.cos;
+  final recorder = RecordingPdfDevice();
+  PdfInterpreter(cos: cos, device: recorder)
+    ..drawPage(page)
+    ..drawAnnotations(page);
+  final commands = recorder.commands;
+
+  // Warm whatever the real worker would already have warm (fonts, parsed ICC
+  // profiles, the stream cache) so the first page of a file is not charged for
+  // it, and confirm the page serializes at all.
+  if (serializeCommands(commands,
+          cos: cos, decodeImages: true, maxImagePixelRatio: _ratio) ==
+      null) {
+    return null;
+  }
+
+  var encodeUs = -1, totalUs = -1;
+  var bytes = 0;
+  for (var run = 0; run < runs; run++) {
+    final encodeSw = Stopwatch()..start();
+    serializeCommands(commands, cos: cos, decodeImages: false);
+    encodeSw.stop();
+
+    final sw = Stopwatch()..start();
+    final buf = serializeCommands(commands,
+        cos: cos, decodeImages: true, maxImagePixelRatio: _ratio);
+    sw.stop();
+    if (buf == null) return null;
+    bytes = buf.length;
+    if (encodeUs < 0 || encodeSw.elapsedMicroseconds < encodeUs) {
+      encodeUs = encodeSw.elapsedMicroseconds;
+    }
+    if (totalUs < 0 || sw.elapsedMicroseconds < totalUs) {
+      totalUs = sw.elapsedMicroseconds;
+    }
+  }
+
+  return <String, Object?>{
+    'page': '${path.split('/').last} p$index',
+    'imageMs': _round((totalUs - encodeUs) / 1000),
+    'encodeMs': _round(encodeUs / 1000),
+    'commands': commands.length,
+    'images': recorder.imageRequests.length,
+    'outMB': _round(bytes / (1 << 20)),
+    'sourceMpx': _round(_sourceMpx(recorder.imageRequests, cos)),
+  };
+}
+
+/// Total declared source pixels of every image the page draws - the quantity
+/// the heavy colour-conversion path scales with (as opposed to output bytes).
+double _sourceMpx(List<PdfImageRequest> requests, CosDocument cos) {
+  var pixels = 0.0;
+  for (final request in requests) {
+    final dict = request.stream.dictionary;
+    final w = cos.resolve(dict['Width']);
+    final h = cos.resolve(dict['Height']);
+    if (w is CosInteger && h is CosInteger) pixels += w.value * h.value;
+  }
+  return pixels / 1e6;
+}
+
+List<File> _collect(List<String> paths) {
+  final out = <File>[];
+  for (final p in paths) {
+    final dir = Directory(p);
+    if (dir.existsSync()) {
+      out.addAll(dir.listSync(recursive: true).whereType<File>().where((f) =>
+          f.path.toLowerCase().endsWith('.pdf') && !f.path.contains('/_')));
+      continue;
+    }
+    final file = File(p);
+    if (file.existsSync()) out.add(file);
+  }
+  out.sort((a, b) => a.path.compareTo(b.path));
+  return out;
+}
+
+double _round(double v) => double.parse(v.toStringAsFixed(2));
+
+String _pad(Object? v, int width) => v.toString().padLeft(width);


### PR DESCRIPTION
Refs #451.

#451 opened on a device trace where a render record's cost tracked neither its payload nor its command count: **5.3 MB serialised in 1817 ms while 39 MB serialised in 329 ms**, same worker, same run. The root-cause comment on the issue attributed it to full-resolution decode ahead of the downsample, and proposed downsampling in the source colour space before converting.

**Measuring per image first says that proposal would have missed most of the cost.** This PR lands what the measurement actually points at, and leaves the rest measured rather than guessed.

## What the measurement showed

Two new tools reproduce the device profile on the VM — `bench_image_serialize.dart` splits a record serialize into its image and command-encode halves, `bench_image_decode.dart` drills into each image at the size the record path actually asks for. Across Ghent + PDF.js at ratio 2.0, DeviceCMYK images are ~65% of all image-decode time.

The decisive detail: **almost every one of those CMYK images is drawn at or above native size.** Decoding straight to display size cannot help an image nobody is downscaling — only ~40% of the total is spent on images that are downscaled at all, and the saving there is proportional to `1 − scale`.

The cost is the conversion itself — 0.147 µs/px for the CMYK polynomial, **0.853 µs/px** through an ICC v4 press profile (a 4-D CLUT over 16 corners, allocating five lists per pixel).

## What collapses it

The tuples repeat. GWG205's image resolves to 29027 distinct colours across 227695 pixels; GWG1610's to 8785 across 154135. So memoize the conversion on the sample tuple — the trick `_alternateToRgba` already used for tint transforms, applied where the corpus says the time is.

`_ColorMemo` is direct-mapped over typed arrays rather than a `Map`: no boxed-key hashing, no rehash growth, and **no cliff when the working set exceeds capacity** — a colliding tuple evicts and is recomputed, where the old size-capped `Map` stopped learning at 65536 entries and then paid a failed lookup on every remaining pixel.

Replacing that `Map` also retires a latent **web-only correctness bug**: its key packed up to 8 components into one int, and past four that exceeds 32 bits, where dart2js's bitwise operators wrap and the VM's do not — two distinct tuples would compare equal on the web and take each other's colour. Keys are now compared as raw bytes.

Part 2 removes the five per-pixel list allocations from `_Lut.apply`.

## Result

Measured by **interleaving** the two revisions in one session (A, B, A, B). An earlier non-interleaved pass gave DeviceCMYK a 732.7 ms baseline where the interleaved one gives 624 ms — 15% of pure machine state — so these are the honest numbers. Two rounds agreed to within 1%:

| shape | before | after | |
|---|---|---|---|
| DeviceCMYK/8b | 623.6 / 624.0 ms | **211.2 / 208.9 ms** | −66% |
| Separation/8b | 10.3 / 10.4 ms | 6.5 / 6.3 ms | −38% |
| DeviceN/8b | 167.8 / 166.1 ms | 138.4 / 139.6 ms | −17% |

## This is output-preserving, and that is checked

A memo hit returns the colour that tuple genuinely converts to, so both parts preserve output by construction. Verified rather than trusted:

- **`tool/hash_image_decodes.dart` hashes all 420 decoded images across both corpora byte-identically before and after.**
- `ghent_render_test` needs **no baseline change** — worth stating plainly given #550, where a green Ghent run turned out not to be proof of correctness. Here the stronger claim is available, so it is the one being made.
- pdf_cos 356, pdf_document 805, pdf_graphics 929, dart_pdf_editor 1969, app 321 — all pass.

Three unit tests, each aimed at one failure mode and each **confirmed to fail when that bug is introduced**: memo eviction/collision (65536 tuples through 16384 slots), the ICC-managed CMYK image path end to end, and LUT scratch reuse across interleaved calls.

## Review pass — one real bug found and fixed

Self-review, backed by codecov flagging `memo?.store` as unreachable, caught that my first version gated the memo behind a **minimum pixel count**, which got the trade backwards. The case a floor excludes is the *small* image, which is where a memo is most effective: a 90×90 spot-colour logo has at most 256 distinct samples and a type 4 tint transform to evaluate for each, so the floor made it pay 8100 PostScript evaluations to avoid allocating a couple of kilobytes. Since `_alternateToRgba` memoized unconditionally before this branch, that was a straight regression — and it had left every Separation/DeviceN unit test running with no memo at all.

The table is now sized to the image (next power of two ≥ pixel count, floored at 256, capped at 16384). Measured back to back, that costs nothing on the corpus.

## Deliberately not bundled

Three things the measurement surfaced that change output, which #451 itself warns against landing blind. All written up in the dev-log:

1. **Downsample before converting** — the original proposal. Still real, now bounded to a fraction of the remaining time.
2. **The scaled fast path rejects `ICCBased` even when the profile is a no-op** — `GWG161` decodes 2045×1018 to display at 128×64. Looks free, but that path resamples bilinearly where the full path box-filters, so it would trade decode time for aliasing on a pixel-enforced page. A quality decision, not a perf one.
3. **A mask larger than its base blows the decode up to the mask's grid** — `issue4246.pdf` decodes a 50×40 image to 1000×800 (400×; 3.2 MB of RGBA for 2000 source pixels). The bound should be the display cap, not the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)