### PR TITLE
perf(editor): hoist the overlay's hover cursors onto a repaint layer (#403 part 1)

### DIFF
--- a/app/tool/perf/README.md
+++ b/app/tool/perf/README.md
@@ -25,7 +25,7 @@ measures.
 Declared in [`scenarios.json`](scenarios.json) — a name → `{kind, pdf, params}`
 registry. `pdf` is a repo-relative file from the CC0 `test_corpora/dartpdf`
 corpus, so **any checkout (and any A/B worktree) can run every scenario** with
-no magic local file. Four workload kinds ship:
+no magic local file. Five workload kinds ship:
 
 | kind | what it measures | headline metrics |
 |---|---|---|
@@ -33,9 +33,11 @@ no magic local file. Four workload kinds ship:
 | `open` | cold-open profile: bytes → `PdfDocument.open` → `pageCount` → first painted content on a target page | `openBytesMs`, `openDocMs`, `openPageCountMs`, `openFirstContentMs` |
 | `search` | full-document text search latency + hit count (best-of-N) | `searchMs`, `searchMatches` |
 | `edit` | apply a batch of annotations through the real `PdfEditingController`: incremental-save + appearance-gen cost | `editApplyMs`, `editApplyMsPerOp`, `editRevisions`, `editBufferGrowthKb` |
+| `hover` | mouse-move over a page with an editing tool armed: what following the painted cursor costs per pointer event | `hoverBuildMsTotal`, `hoverBuildMsPerEvent`, `hoverBuildMsP50/P95/Max`, `hoverFrames` |
 
 Stock scenarios: `scroll-plan`, `scroll-scan`, `scroll-diagram`, `open-plan`,
-`open-text`, `search-text`, `edit-annotate` (default `scroll-plan`).
+`open-text`, `search-text`, `edit-annotate`, `hover-ink`, `hover-eraser`
+(default `scroll-plan`).
 
 ### Adding a scenario going forward
 
@@ -123,6 +125,7 @@ searchMs                52.30       38.10       -27.2%    ✓ faster
 | `PERF_TARGET_PAGE` | scenario | open/scroll target page |
 | `PERF_QUERY` / `PERF_REPEAT` | scenario | search needle / best-of-N |
 | `PERF_OPS` | scenario | edit: annotations to apply |
+| `PERF_EVENTS` / `PERF_TOOL` | scenario | hover: pointer events to dispatch / the armed tool |
 | `PERF_IMAGE_CACHE_MB` | `0` | decoded-image cache budget, MB |
 | `PERF_HEADLESS` | `true` | `false` for a visible window |
 | `PERF_TIMEOUT` | `300` | overall budget, seconds |

--- a/app/tool/perf/perf_harness.dart
+++ b/app/tool/perf/perf_harness.dart
@@ -535,13 +535,17 @@ class _PerfHarnessAppState extends State<_PerfHarnessApp> {
     final editing = _editing!;
     // Let the first page paint before the pointer starts moving over it.
     await Future<void>.delayed(const Duration(milliseconds: 1200));
+    // A typo'd ?tool= must not quietly arm nothing and then report numbers for
+    // a workload that never happened - only the explicit 'none' disarms.
     editing.tool = switch (_hoverToolName) {
       'ink' => PdfEditTool.ink,
       'eraser' => PdfEditTool.eraser,
       'count' => PdfEditTool.count,
       'stamp' => PdfEditTool.stamp,
       'select' => PdfEditTool.select,
-      _ => null,
+      'none' => null,
+      _ => throw StateError('unknown ?tool=$_hoverToolName '
+          '(ink|eraser|count|stamp|select|none)'),
     };
     await Future<void>.delayed(const Duration(milliseconds: 300));
 

--- a/app/tool/perf/perf_harness.dart
+++ b/app/tool/perf/perf_harness.dart
@@ -22,6 +22,9 @@
 //   edit    - apply a batch of annotations (highlight/rectangle/ink) through
 //             the real PdfEditingController; incremental-save + appearance-gen
 //             cost, revision count, and session-buffer growth.
+//   hover   - mouse-move over the page with an editing tool armed: synthetic
+//             PointerHoverEvents at frame cadence, measuring the build-phase
+//             cost each one provokes (the cursor-overlay work of #403).
 //
 // Adding a scenario going forward = add one `_drive<Kind>()` method + a `case`
 // in `_drive()`, and emit numbers with `_metric(name, value)`. The driver reads
@@ -40,6 +43,8 @@
 //   query      search: text to search for        (default "the")
 //   repeat     search: best-of-N internal runs   (default 3)
 //   ops        edit: annotations to apply        (default 24)
+//   events     hover: pointer-hover events        (default 240)
+//   tool       hover: armed tool                  (default ink)
 //   imageCacheMb  decoded-image cache budget, MB (default 0 = platform default)
 //
 // The driver reads these JS globals this installs:
@@ -53,12 +58,14 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
+import 'dart:math' as math;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 // PdfRect isn't in the dart_pdf_editor barrel's `show` list; pull it directly
 // (app depends on pdf_document). Only the edit scenario's annotation coords.
 import 'package:pdf_document/pdf_document.dart' show PdfRect;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -108,6 +115,16 @@ final int _searchRepeat =
 /// `?ops=`: how many annotations the `edit` scenario applies.
 final int _editOps =
     _qInt('ops', const int.fromEnvironment('PERF_OPS', defaultValue: 24));
+
+/// `?events=` / `?tool=`: how many pointer-hover events the `hover` scenario
+/// dispatches, and which editing tool is armed while they land (the tools with
+/// a painted cursor - ink, eraser, count, stamp - are the interesting ones;
+/// `none` arms nothing, for the plain-viewer baseline).
+final int _hoverEvents =
+    _qInt('events', const int.fromEnvironment('PERF_EVENTS', defaultValue: 240));
+final String _hoverToolName = (_q['tool'] ??
+        const String.fromEnvironment('PERF_TOOL', defaultValue: 'ink'))
+    .toLowerCase();
 
 /// Decoded-image cache budget, MB. 0 leaves the platform default in place; the
 /// driver sweeps it to measure what each budget costs a real tab (issue #281).
@@ -259,7 +276,8 @@ class _PerfHarnessAppState extends State<_PerfHarnessApp> {
   PdfEditingController? _editing;
   String? _error;
 
-  bool get _isEdit => _scenario == 'edit';
+  /// Both scenarios that touch the editor mount the editing stack.
+  bool get _isEdit => _scenario == 'edit' || _scenario == 'hover';
 
   @override
   void initState() {
@@ -338,6 +356,8 @@ class _PerfHarnessAppState extends State<_PerfHarnessApp> {
           await _driveSearch(coldOpen);
         case 'edit':
           await _driveEdit(coldOpen);
+        case 'hover':
+          await _driveHover(coldOpen);
         case 'scroll':
         default:
           await _driveScroll(coldOpen);
@@ -499,6 +519,81 @@ class _PerfHarnessAppState extends State<_PerfHarnessApp> {
         'buffer=${editing.sessionBufferBytes}B revisions=${editing.revisionCount}');
     // Let the last repaint settle.
     await Future<void>.delayed(const Duration(milliseconds: 500));
+  }
+
+  // ----- hover: what a mouse-move costs with an editing tool armed ---------
+  //
+  // The workload behind #403: with ink/eraser/count/stamp armed the overlay
+  // paints its own cursor, and every pointer-hover event has to move it. The
+  // question this answers is whether that move costs a *rebuild* of the
+  // overlay subtree or a repaint of one small layer, and the frame timings
+  // captured across the hover window answer it directly - build-phase ms is
+  // the rebuild, raster ms is the repaint.
+  Future<void> _driveHover(Stopwatch coldOpen) async {
+    final count = await _awaitPageCount(coldOpen);
+    if (count <= 0) throw StateError('pageCount never became positive');
+    final editing = _editing!;
+    // Let the first page paint before the pointer starts moving over it.
+    await Future<void>.delayed(const Duration(milliseconds: 1200));
+    editing.tool = switch (_hoverToolName) {
+      'ink' => PdfEditTool.ink,
+      'eraser' => PdfEditTool.eraser,
+      'count' => PdfEditTool.count,
+      'stamp' => PdfEditTool.stamp,
+      'select' => PdfEditTool.select,
+      _ => null,
+    };
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+
+    final view = WidgetsBinding.instance.platformDispatcher.implicitView!;
+    final size = view.physicalSize / view.devicePixelRatio;
+    final center = Offset(size.width / 2, size.height / 2);
+    // a circle well inside the page, so every event lands on the overlay
+    final radius = math.min(size.width, size.height) * 0.22;
+    final events = _hoverEvents.clamp(1, 4000);
+    _record('[perf] HARNESS HOVER tool=$_hoverToolName events=$events '
+        'view=${size.width.toStringAsFixed(0)}x${size.height.toStringAsFixed(0)}');
+
+    const device = 77; // any id the engine won't also be using
+    GestureBinding.instance.handlePointerEvent(PointerAddedEvent(
+        position: center, kind: PointerDeviceKind.mouse, device: device));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    final framesBefore = _frames.length;
+    final sw = Stopwatch()..start();
+    for (var i = 0; i < events; i++) {
+      // an irrational-ish step so no two consecutive events repeat a position
+      // (the overlay short-circuits an unchanged one, which would flatter us)
+      final angle = i * 0.37;
+      GestureBinding.instance.handlePointerEvent(PointerHoverEvent(
+        position: center + Offset(math.cos(angle), math.sin(angle)) * radius,
+        kind: PointerDeviceKind.mouse,
+        device: device,
+        timeStamp: Duration(microseconds: sw.elapsedMicroseconds),
+      ));
+      // one event per frame: a real mouse at 60Hz, the cadence the cost is
+      // paid at
+      await Future<void>.delayed(const Duration(milliseconds: 16));
+    }
+    sw.stop();
+    // let the trailing frames land in the timing callback
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+
+    final builds = <double>[
+      for (final f in _frames.skip(framesBefore))
+        f.buildDuration.inMicroseconds / 1000.0,
+    ];
+    final total = builds.fold<double>(0, (a, b) => a + b);
+    builds.sort();
+    _metric('hoverEvents', events);
+    _metric('hoverFrames', builds.length);
+    _metric('hoverBuildMsTotal', total);
+    _metric('hoverBuildMsPerEvent', total / events);
+    if (builds.isNotEmpty) {
+      _metric('hoverBuildMsP50', builds[builds.length ~/ 2]);
+      _metric('hoverBuildMsP95', builds[((builds.length - 1) * 0.95).round()]);
+      _metric('hoverBuildMsMax', builds.last);
+    }
   }
 
   @override

--- a/app/tool/perf/scenarios.json
+++ b/app/tool/perf/scenarios.json
@@ -1,5 +1,5 @@
 {
-  "_readme": "Declarative registry for the reusable web perf harness. Each scenario names a workload kind (scroll|open|search|edit), a repo-relative PDF (portable, from the CC0 test_corpora/dartpdf corpus so any checkout - and any git worktree in an A/B diff - can run it), and kind-specific params passed to the harness via URL query. The driver (driver.mjs) serves `pdf` at /perf.pdf, sets the query from `params`, and merges whatever window.__perfMetrics() returns into the run envelope - so adding a scenario needs NO driver change. Pick one with `node driver.mjs --scenario <name>` or `tool/perf.sh web <name>`; A/B two revisions with `tool/perf.sh webdiff <ref> <name>`.",
+  "_readme": "Declarative registry for the reusable web perf harness. Each scenario names a workload kind (scroll|open|search|edit|hover), a repo-relative PDF (portable, from the CC0 test_corpora/dartpdf corpus so any checkout - and any git worktree in an A/B diff - can run it), and kind-specific params passed to the harness via URL query. The driver (driver.mjs) serves `pdf` at /perf.pdf, sets the query from `params`, and merges whatever window.__perfMetrics() returns into the run envelope - so adding a scenario needs NO driver change. Pick one with `node driver.mjs --scenario <name>` or `tool/perf.sh web <name>`; A/B two revisions with `tool/perf.sh webdiff <ref> <name>`.",
   "default": "scroll-plan",
   "scenarios": {
     "scroll-plan": {
@@ -62,7 +62,25 @@
       "params": { "query": "Page", "repeat": 3 },
       "note": "Full-document text search latency + match count on a 40p text report (best-of-3). 'Page' hits ~1.1k times, spread across every page - a stable, comparable workload."
     },
-    "edit-annotate": {
+    "hover-ink": {
+   "kind": "hover",
+   "pdf": "test_corpora/dartpdf/plan-set-16p.pdf",
+   "params": {
+    "events": 240,
+    "tool": "ink"
+   },
+   "note": "240 pointer-hover events over a dense vector sheet with the ink tool armed - the painted pen cursor has to follow the mouse. Measures whether that costs a rebuild of the editing overlay's subtree or a repaint of the cursor layer (#403): watch hoverBuildMsTotal / hoverBuildMsPerEvent."
+  },
+  "hover-eraser": {
+   "kind": "hover",
+   "pdf": "test_corpora/dartpdf/plan-set-16p.pdf",
+   "params": {
+    "events": 240,
+    "tool": "eraser"
+   },
+   "note": "Same hover sweep with the eraser armed (the ring cursor). Same metrics as hover-ink; a second armed tool so a regression in one cursor path doesn't hide behind the other."
+  },
+  "edit-annotate": {
       "kind": "edit",
       "pdf": "test_corpora/dartpdf/styled-booklet-24p.pdf",
       "params": { "ops": 24 },

--- a/doc/dev-log/2026-07-25-overlay-cursor-repaint-layer-403.md
+++ b/doc/dev-log/2026-07-25-overlay-cursor-repaint-layer-403.md
@@ -106,6 +106,35 @@ ms *is* the rebuild cost, so the metric names the thing the fix removes.
   paint frame, which this change cannot touch. The in-window max is
   `hoverBuildMsMax` above.
 
+## Review follow-up: the `_penCursor` tick invariant
+
+Self-review caught two stroke-start sites (`_onPointerDown`'s raw/stylus path
+and `_panStart`'s ink case) that assign `_penCursor` and then tick only
+`_activeStrokeRepaint`. That was correct before this change - the pen dot was
+painted by `_ActiveStrokePainter`, so the stroke tick repainted it - and is
+stale now that the dot lives on the cursor layer. Both now call `_bumpCursor()`
+too, and `_ActiveStrokePainter`'s doc states the invariant: *any site that moves
+`_penCursor` ticks `_cursorRepaint` as well as this one.*
+
+**This is hygiene, not a bug fix, and the distinction is worth recording** so
+nobody "simplifies" the bumps back out on the grounds that nothing broke:
+
+- The *field* is assigned correctly either way; only the repaint scheduling was
+  missing.
+- It isn't observable today. Both sites immediately set a one-point
+  `_activeStroke` and tick the stroke layer, and `_paintInkStrokes` draws a
+  single point as a dot - at the same position, in the same colour, in the same
+  frame as the pen cursor would have. The dot you see is the stroke's.
+- It becomes observable the moment either of those coincidences stops holding
+  (the stroke layer skipping single-point strokes, the cursor gaining a
+  distinct look, a stroke start that doesn't seed a point).
+
+Two attempts to write a failing test both proved the point rather than the bug:
+a getter-based assertion can't see repaint scheduling at all, and a pixel
+assertion at the press point sees the stroke's dot. The test that landed
+(`a stylus press positions the pen cursor with no hover first`) is honest about
+asserting *state*, and is worth keeping for the raw-pointer path regardless.
+
 ## Not done here
 
 - The async/off-thread hover text extraction (part 2's remaining half) is still

--- a/doc/dev-log/2026-07-25-overlay-cursor-repaint-layer-403.md
+++ b/doc/dev-log/2026-07-25-overlay-cursor-repaint-layer-403.md
@@ -1,0 +1,116 @@
+# 2026-07-25 — pointer-event costs: the overlay cursor repaint layer (#403 part 1)
+
+#403's headline, and the last of its three parts. Part 2 (one `_pagePointAt`
+per pointer event instead of four, plus the heavy-page hover-extraction gate)
+landed in **#442**; part 3 (per-build search/selection rescans) in **#479**,
+whose note left this one as a scoped follow-up. See
+[2026-07-22-pointer-event-costs-403.md](2026-07-22-pointer-event-costs-403.md).
+
+## The problem
+
+With ink, the eraser, count, stamp or the signature tool armed - or the
+eyedropper picking - the editing overlay paints its own cursor, and the
+cursor's position was a *snapshot argument* of `_EditingPreviewPainter`. Moving
+it therefore meant `setState`: every `PointerHoverEvent` rebuilt
+`_EditingPageOverlayState`'s whole subtree (annotation widgets, selection
+chrome, the ~7000-line overlay's build method, and a fresh
+`_EditingPreviewPainter` with ~50 recomputed arguments) to move a dot a few
+pixels. Continuous build-phase cost through exactly the moment the user is
+about to draw.
+
+## The fix (editing_overlay.dart)
+
+A sibling of the pattern the file already had for the in-progress stroke
+(`_ActiveStrokePainter` + `_activeStrokeRepaint`):
+
+- **`_cursorRepaint`** — a `ValueNotifier<int>`, bumped by `_bumpCursor()`.
+- **`_HoverCursorPainter`** — a new `CustomPainter` on its own
+  `RepaintBoundary`, `super(repaint: _state._cursorRepaint)`, reading the live
+  `_penCursor` / `_eraserCursor` / `_countCursor` / `_stampPreview` /
+  `_rotateCursor` / `_signaturePreview` fields straight off the state. It sits
+  above the active-stroke layer, so the cursors are topmost among the painted
+  layers (they used to be the tail of the preview painter, below the stroke).
+- `_onHover` (and the signature drag, and `_extendActiveStroke`) now assign the
+  field and `_bumpCursor()` instead of `setState`. The one hover outcome that
+  still rebuilds is a *change of system cursor kind*, which lives on the
+  `MouseRegion` and only changes at tool/zone boundaries, not per event.
+- The eyedropper's swatch is a widget, so it can't join the painter: it
+  subscribes to the same notifier through a `ValueListenableBuilder`, rebuilding
+  the chip alone.
+- `_EditingPreviewPainter` lost `eraserCursor`/`eraserRadius`/`penCursor`/
+  `penOpacity`/`countPreview`/`stampPreview`/`rotateCursor` (fields, paint code
+  and `shouldRepaint` terms), and the signature preview left its `extraInk`.
+  `_paintStampAfterimage` and the three stamp-template helpers became top-level
+  functions taking the view `scale`, so both painters draw the identical mark.
+
+### Two details worth keeping in mind
+
+- **`shouldRepaint` is `true` here**, unlike `_ActiveStrokePainter`'s `false`.
+  The stroke layer's notifier ticks on every mutation of its buffers, so it can
+  own its repainting outright. The cursor layer also depends on inputs it does
+  *not* observe - the armed tool, pen colour/width, zoom (`_geometry`),
+  `_chromeScale` - and those change through ordinary rebuilds. A fresh painter
+  instance means the overlay rebuilt for one of them; repainting a few circles
+  and an arc then is cheaper than tracking which input moved.
+- **The paint gates are the debug getters.** `_state._eraserCursor` outlives
+  the eraser (nothing clears it when the tool is put away); `eraserCursor` -
+  the getter `paint()` reads - is what is actually drawn. Tests assert on the
+  getters for that reason.
+
+## Measuring it
+
+Two independent checks, because they answer different questions.
+
+**Structural, in widget tests.** `_EditingPreviewPainter`'s *identity* is the
+tell: a rebuild constructs a fresh one from new arguments, so the same instance
+still being mounted after a pointer move means no rebuild ran.
+`editing_cursor_test.dart` asserts exactly that for ink / eraser / count /
+stamp / signature, and - so the assertion can't quietly become vacuous - that a
+change the overlay really does rebuild for (setting the controller colour) does
+swap the painter out.
+
+**Wall-clock, in real Chrome.** The web harness gained a **`hover` kind**
+(`app/tool/perf/perf_harness.dart` + `hover-ink` / `hover-eraser` in
+`scenarios.json`): it arms a tool and dispatches N synthetic
+`PointerHoverEvent`s at frame cadence over a dense vector sheet, reporting
+`hoverBuildMs*` from the `FrameTiming`s captured across the sweep. Build-phase
+ms *is* the rebuild cost, so the metric names the thing the fix removes.
+
+`tool/perf.sh webdiff HEAD hover-ink`, 3 iterations per side (240 events over
+`plan-set-16p.pdf`), medians:
+
+| metric | baseline | this branch | Δ |
+|---|---|---|---|
+| `hoverBuildMsP50` | 1.46 | 1.10 | **−24.6%** |
+| `hoverBuildMsTotal` | 527 | 493 | −6.5% |
+| `hoverBuildMsPerEvent` | 2.20 | 2.05 | −6.5% |
+| `hoverBuildMsP95` | 4.96 | 5.08 | +2.5% |
+
+**Read these carefully.**
+
+- `hoverBuildMsP50` is the one clean result: every working-tree run measured
+  1.1 ms and every baseline run 1.4–1.7 ms, so the ranges don't overlap. A
+  quarter off the *typical* build frame during an armed hover.
+- The totals overlap between runs (WT 468/493/524 vs baseline 525/527/620);
+  −6.5% is the right sign but n=3 can't tighten it. It is diluted by design:
+  240 frames over a 16-page plan set contain plenty of build work the overlay
+  has nothing to do with (page views, prerender, scroll), and the harness can't
+  attribute build time per widget. The widget tests are what prove the overlay's
+  own share went to zero.
+- **`hoverBuildMsMax` (33.35 → 7.67, "−77%") is not a result.** Both sides threw
+  a ~40 ms outlier in one of three runs (WT 7.7/7.6/40.9, baseline 33.4/40.8/7.4);
+  the medians only separate because the outliers landed differently. Don't quote
+  it without more iterations.
+- The reported `buildMax` "regression" (71.3 → 78.5) is the *whole-run* max, and
+  the run has only ~8 frames outside the hover window - it is a cold-open first-
+  paint frame, which this change cannot touch. The in-window max is
+  `hoverBuildMsMax` above.
+
+## Not done here
+
+- The async/off-thread hover text extraction (part 2's remaining half) is still
+  gated behind #396. Nothing here touches `pdf_viewer.dart`.
+- `_polyHover` (the polygon/cloud rubber band) deliberately stays on `setState`:
+  it feeds `dragPath` on the preview painter, i.e. it changes what the *page*
+  preview draws, not just a cursor. Same for the erase-drag preview, whose
+  sliced/faded stroke sets the preview painter owns.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1320,8 +1320,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         // hold the auto-commit while this stroke is on the page
         _controller.beginInkStroke();
         final pressure = _pointerPressure;
+        // no setState: the stroke and the pen dot each live on their own
+        // repaint layer, and each needs its own tick. Nothing here is
+        // currently *visible* if the cursor tick is missed - the one-point
+        // stroke below paints its own dot at this exact spot, in the same
+        // colour - but the invariant has to hold locally rather than lean on
+        // that coincidence.
         _penCursor = event.localPosition;
-        // no setState: the active stroke lives on its own repaint layer
+        _bumpCursor();
         _activeStroke = [_geometry.toPagePoint(event.localPosition)];
         _activeStrokePressures = pressure == null ? null : [pressure];
         _bumpActiveStroke();
@@ -3073,9 +3079,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         final pressure = _pointerPressure;
         // While the mouse is pressed, hover events stop. Keep the painted
         // pen cursor's stored position moving with the drag so it reappears
-        // at the stroke end, not where the stroke started.
+        // at the stroke end, not where the stroke started. No setState: the
+        // stroke and the pen dot each live on their own repaint layer, and
+        // each needs its own tick.
         _penCursor = position;
-        // no setState: the active stroke lives on its own repaint layer
+        _bumpCursor();
         _activeStroke = [_geometry.toPagePoint(position)];
         // the first event decides: a pressure device varies the whole
         // stroke, anything else stays uniform
@@ -5788,6 +5796,11 @@ void _paintInkStrokes(
 /// the repaint Listenable is the sole driver (the start, every point, and the
 /// clear on commit/bail all tick it), and the buffers are mutated in place so
 /// the painter always sees the current points.
+///
+/// The pen dot is NOT here - it belongs to [_HoverCursorPainter], because it
+/// shows with the tool merely armed, not only mid-stroke. Any site that moves
+/// [_EditingPageOverlayState._penCursor] therefore has to tick
+/// [_EditingPageOverlayState._cursorRepaint] as well as this one.
 class _ActiveStrokePainter extends CustomPainter {
   _ActiveStrokePainter(this._state)
       : super(repaint: _state._activeStrokeRepaint);

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -736,6 +736,24 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
 
   void _bumpActiveStroke() => _activeStrokeRepaint.value++;
 
+  /// Repaint signal for the hover-cursor layer - the pen dot, eraser ring,
+  /// count/stamp/signature previews, the rotate glyph and the eyedropper
+  /// chip. A mouse-move with any of those armed used to `setState`, which
+  /// rebuilt this overlay's whole subtree (every annotation widget, the
+  /// snapshot-arg [_EditingPreviewPainter], the chrome) just to move a dot a
+  /// few pixels - continuous build-phase cost through exactly the moment the
+  /// user is about to draw (#403). The cursors now live on their own
+  /// RepaintBoundary'd [_HoverCursorPainter], which reads the fields straight
+  /// off this state and repaints when this ticks: a move is a repaint of one
+  /// small layer, not a rebuild. Every hover-driven mutation of
+  /// [_penCursor]/[_eraserCursor]/[_countCursor]/[_stampPreview]/
+  /// [_rotateCursor]/[_signaturePreview]/[_pickPosition]/[_pickPreview] must
+  /// call [_bumpCursor] (a plain `setState` still works - it rebuilds, and the
+  /// painter's shouldRepaint is true - so the rarer paths keep using it).
+  final ValueNotifier<int> _cursorRepaint = ValueNotifier<int>(0);
+
+  void _bumpCursor() => _cursorRepaint.value++;
+
   /// Extends the in-progress ink stroke to the view-space [localPosition].
   /// Normally each sample appends, tracing the freehand path; while Shift is
   /// held the stroke collapses to a single straight segment from where it
@@ -744,6 +762,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
   /// and gesture-arena draw paths.
   void _extendActiveStroke(Offset localPosition) {
     _penCursor = localPosition;
+    _bumpCursor();
     final page = _geometry.toPagePoint(localPosition);
     final pressures = _activeStrokePressures;
     final pressure = _pointerPressure ?? pressures?.last;
@@ -2296,6 +2315,7 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     _clearSourceClean();
     _flashController.dispose();
     _activeStrokeRepaint.dispose();
+    _cursorRepaint.dispose();
     _autoScrollTicker.dispose();
     if (_interaction.isActive &&
         _interaction.state.pageIndex == widget.pageIndex) {
@@ -3024,7 +3044,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return;
     }
     if (_stampPreview != null) {
-      setState(() => _stampPreview = null);
+      _stampPreview = null;
+      _bumpCursor();
     }
     if (_selectMode) {
       _selectPanStart(details);
@@ -3308,7 +3329,10 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       return;
     }
     if (_signatureDrag) {
-      setState(() => _signaturePreview = position);
+      // drag-frequency, and the preview is painted on the cursor layer:
+      // repaint it, don't rebuild the overlay
+      _signaturePreview = position;
+      _bumpCursor();
       return;
     }
     if (_activeStroke != null) {
@@ -4090,12 +4114,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     return _samplerFuture!;
   }
 
+  /// Moves the eyedropper's swatch. Hover-frequency, so it repaints the
+  /// cursor layer (and the chip, which rides its own ValueListenableBuilder)
+  /// instead of rebuilding the overlay - see [_cursorRepaint].
   void _updatePickPreview(Offset position) {
     unawaited(_ensureSampler());
-    setState(() {
-      _pickPosition = position;
-      _pickPreview = _sampler?.colorAt(position / _geometry.scale);
-    });
+    _pickPosition = position;
+    _pickPreview = _sampler?.colorAt(position / _geometry.scale);
+    _bumpCursor();
   }
 
   /// Releasing the pointer commits the raw gesture (stroke or erase
@@ -4306,7 +4332,8 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           _hitsRotateHandle(chrome.$1, resting, event.localPosition)) {
         // no system rotation cursor: hide it and paint a curved-arrow glyph
         if (_rotateCursor != event.localPosition) {
-          setState(() => _rotateCursor = event.localPosition);
+          _rotateCursor = event.localPosition;
+          _bumpCursor();
         }
         cursor = SystemMouseCursors.none;
       } else if (_selectedViewRects
@@ -4328,20 +4355,23 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       // the painted dot (pen colour at pen width) is the cursor, so the
       // chosen colour and stroke width are visible before drawing
       if (_penCursor != event.localPosition) {
-        setState(() => _penCursor = event.localPosition);
+        _penCursor = event.localPosition;
+        _bumpCursor();
       }
       cursor = SystemMouseCursors.none;
     } else if (_tool == PdfEditTool.eraser) {
       // the painted ring is the cursor
       if (_eraserCursor != event.localPosition) {
-        setState(() => _eraserCursor = event.localPosition);
+        _eraserCursor = event.localPosition;
+        _bumpCursor();
       }
       cursor = SystemMouseCursors.none;
     } else if (_tool == PdfEditTool.count) {
       // the painted check-mark is the cursor, showing exactly what a click
       // will place before the page gets a new annotation.
       if (_countCursor != event.localPosition) {
-        setState(() => _countCursor = event.localPosition);
+        _countCursor = event.localPosition;
+        _bumpCursor();
       }
       cursor = SystemMouseCursors.none;
     } else if (_tool == PdfEditTool.stamp) {
@@ -4351,16 +4381,21 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
       // make the click target visible.
       final preview = _stampHoverAfterimageAt(event.localPosition);
       if (preview == null) {
-        if (_stampPreview != null) setState(() => _stampPreview = null);
+        if (_stampPreview != null) {
+          _stampPreview = null;
+          _bumpCursor();
+        }
       } else if (_stampPreview != event.localPosition) {
-        setState(() => _stampPreview = event.localPosition);
+        _stampPreview = event.localPosition;
+        _bumpCursor();
       }
       cursor = SystemMouseCursors.precise;
     } else if (_tool == PdfEditTool.signature) {
       // the live preview rides the mouse; a click commits it
       if (_controller.preferences.signature != null &&
           event.localPosition != _signaturePreview) {
-        setState(() => _signaturePreview = event.localPosition);
+        _signaturePreview = event.localPosition;
+        _bumpCursor();
       }
       cursor = SystemMouseCursors.precise;
     } else if (_polyTool || _tool == PdfEditTool.cloudPolygon) {
@@ -4401,18 +4436,27 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     // the rotate glyph shows only over the knob (the lone `none` in select
     // mode), the pen dot only with the ink tool armed
     final overKnob = _selectMode && cursor == SystemMouseCursors.none;
+    var retracted = false;
     if (!overKnob && _rotateCursor != null) {
-      setState(() => _rotateCursor = null);
+      _rotateCursor = null;
+      retracted = true;
     }
     if (!_inkTool && _penCursor != null) {
-      setState(() => _penCursor = null);
+      _penCursor = null;
+      retracted = true;
     }
     if (_tool != PdfEditTool.count && _countCursor != null) {
-      setState(() => _countCursor = null);
+      _countCursor = null;
+      retracted = true;
     }
     if (_tool != PdfEditTool.stamp && _stampPreview != null) {
-      setState(() => _stampPreview = null);
+      _stampPreview = null;
+      retracted = true;
     }
+    if (retracted) _bumpCursor();
+    // the system cursor lives on the MouseRegion, so a *kind* change is the
+    // one hover outcome that still needs a rebuild - it changes at tool and
+    // zone boundaries, not per event
     if (cursor != _cursor) setState(() => _cursor = cursor);
   }
 
@@ -5053,24 +5097,12 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
         wrapResize == null && _resizeHandle != null && _resizeRect != null
             ? _shapeResizeStyle(_resizeRect!, _resizeAngle)
             : _afterShapeResize;
-    // strokes beyond the pending ink: the committed-ink afterimage (held
-    // until the new raster lands) and the signature tool's live preview
+    // strokes beyond the pending ink: the committed-ink afterimage, held
+    // until the new raster lands. (The signature tool's live preview is
+    // pointer-frequency, so it rides the cursor layer instead.)
     final committedInk = widget.rasterCurrent
         ? null
         : _controller.committedInkOn(widget.pageIndex);
-    _InkPaint? signaturePreview;
-    if (_signaturePreview != null && _tool == PdfEditTool.signature) {
-      final (x, y) = _geometry.toPagePoint(_signaturePreview!);
-      final placement = _controller.signaturePlacement(widget.pageIndex, x, y);
-      if (placement != null) {
-        signaturePreview = (
-          strokes: placement.strokes,
-          pressures: placement.pressures,
-          color: Color(0xFF000000 | placement.color).withValues(alpha: 0.55),
-          strokeWidth: placement.strokeWidth * _geometry.scale,
-        );
-      }
-    }
     final extraInk = <_InkPaint>[
       if (committedInk != null)
         (
@@ -5080,7 +5112,6 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
           strokeWidth: committedInk.strokeWidth * _geometry.scale,
         ),
       if (_afterSignature != null) _afterSignature!,
-      if (signaturePreview != null) signaturePreview,
       // the eraser's live remainders, then the committed slice held
       // until its raster lands - painted over the fade wash
       ..._eraseSliced.values,
@@ -5097,7 +5128,6 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     }
     // warm the eyedropper's raster so the first preview is instant-ish
     if (_controller.isPickingColor) unawaited(_ensureSampler());
-    final preview = _controller.isPickingColor ? _pickPosition : null;
     // placed vertices are already snapped; only the live rubber-band edge to
     // the hover point snaps here (and only while Shift is held)
     final polyPreview = _polyPoints == null
@@ -5286,26 +5316,11 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                       ...?_afterEraseFade,
                     ],
                     fadeColor: widget.pageColor.withValues(alpha: 0.72),
-                    eraserCursor:
-                        _tool == PdfEditTool.eraser || _pointers.rawErasing
-                            ? _eraserCursor
-                            : null,
-                    eraserRadius: _controller.preferences.eraserRadius * _geometry.scale,
-                    // the pen-preview dot (ink tool) and the rotation glyph
-                    // (rotate knob): painted in place of the system cursor
-                    penCursor:
-                        _inkTool && _activeStroke == null ? _penCursor : null,
-                    penOpacity: _controller.preferences.opacity,
-                    countPreview:
-                        _tool == PdfEditTool.count && _countCursor != null
-                            ? _countPreviewAt(_countCursor!)
-                            : null,
-                    stampPreview: _tool == PdfEditTool.stamp &&
-                            _dragStart == null &&
-                            _stampPreview != null
-                        ? _stampHoverAfterimageAt(_stampPreview!)
-                        : null,
-                    rotateCursor: _rotateCursor,
+                    // the pointer-tracking cursors (eraser ring, pen dot,
+                    // count/stamp/signature previews, rotate glyph) are NOT
+                    // here - they ride the _HoverCursorPainter layer below,
+                    // repainted from _cursorRepaint so a mouse-move never
+                    // rebuilds this painter's snapshot arguments (#403)
                     afterGhost: afterGhost,
                     afterShape: _afterShape,
                     afterStamp: _afterStamp,
@@ -5338,6 +5353,18 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                 child: RepaintBoundary(
                   child: CustomPaint(
                     painter: _ActiveStrokePainter(this),
+                    size: Size.infinite,
+                  ),
+                ),
+              ),
+              // The pointer-tracking cursors, on their own RepaintBoundary
+              // above the ink: a hover moves them by ticking _cursorRepaint,
+              // which repaints this layer alone (#403). Topmost of the
+              // painted layers, so a cursor is never buried under a preview.
+              Positioned.fill(
+                child: RepaintBoundary(
+                  child: CustomPaint(
+                    painter: _HoverCursorPainter(this),
                     size: Size.infinite,
                   ),
                 ),
@@ -5381,14 +5408,28 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                   underline: after.underline,
                   lineSpacing: after.lineSpacing,
                 ),
-              if (preview != null)
-                Positioned(
-                  left: preview.dx + 14,
-                  top: preview.dy - 38,
-                  child: IgnorePointer(
-                    child: _EyedropperChip(color: _pickPreview),
+              // the eyedropper's swatch: a widget, so it can't join the
+              // cursor painter - it subscribes to the same notifier instead,
+              // rebuilding just the chip as the pointer moves
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: ValueListenableBuilder<int>(
+                    valueListenable: _cursorRepaint,
+                    builder: (context, _, __) {
+                      final preview =
+                          _controller.isPickingColor ? _pickPosition : null;
+                      if (preview == null) return const SizedBox.shrink();
+                      return Stack(children: [
+                        Positioned(
+                          left: preview.dx + 14,
+                          top: preview.dy - 38,
+                          child: _EyedropperChip(color: _pickPreview),
+                        ),
+                      ]);
+                    },
                   ),
                 ),
+              ),
               if (_textEditRect != null)
                 Positioned.fromRect(
                   rect: _textEditRect!.inflate(2),
@@ -5753,9 +5794,6 @@ class _ActiveStrokePainter extends CustomPainter {
 
   final _EditingPageOverlayState _state;
 
-  @visibleForTesting
-  Offset? get debugPenCursor => _state._penCursor;
-
   @override
   void paint(Canvas canvas, Size size) {
     final stroke = _state._activeStroke;
@@ -5783,17 +5821,8 @@ class _ActiveStrokePainter extends CustomPainter {
       _state._controller.color,
       _state._controller.preferences.strokeWidth * geometry.scale,
     );
-    final cursor = _state._penCursor;
-    if (cursor != null && _state._inkTool) {
-      _paintPenCursor(
-        canvas,
-        cursor,
-        strokeWidth: _state._controller.preferences.strokeWidth * geometry.scale,
-        chromeScale: _state._chromeScale,
-        color: _state._controller.color,
-        opacity: _state._controller.preferences.opacity,
-      );
-    }
+    // the pen dot rides the sibling _HoverCursorPainter (it must show with
+    // the tool merely armed, not only mid-stroke)
   }
 
   @override
@@ -5820,6 +5849,434 @@ void _paintPenCursor(
         ..color = const Color(0xB3FFFFFF)
         ..style = PaintingStyle.stroke
         ..strokeWidth = 1 * chromeScale);
+}
+
+/// The pointer-tracking cursors and hover previews, on their own
+/// RepaintBoundary above the ink layer.
+///
+/// Every mark here follows the pointer, so it changes at pointer-event
+/// frequency; painting it from [_EditingPreviewPainter]'s snapshot arguments
+/// meant a `setState` per mouse-move, rebuilding the overlay's whole subtree
+/// (annotation widgets, chrome, the heavy preview painter) to move a dot a few
+/// pixels - through exactly the moment the user is about to draw (#403). Like
+/// [_ActiveStrokePainter], this reads the live fields straight off
+/// [_EditingPageOverlayState] and repaints from
+/// [_EditingPageOverlayState._cursorRepaint], so a move is one small layer's
+/// repaint. [shouldRepaint] stays true (unlike the stroke layer's): a fresh
+/// instance means the overlay rebuilt for some *other* reason - a tool, colour,
+/// zoom or geometry change the cursors also depend on - and this layer is a few
+/// circles and an arc, so repainting it then is cheaper than tracking which of
+/// those inputs moved.
+class _HoverCursorPainter extends CustomPainter {
+  _HoverCursorPainter(this._state) : super(repaint: _state._cursorRepaint);
+
+  final _EditingPageOverlayState _state;
+
+  /// The marks this layer would paint right now, as the old snapshot fields
+  /// exposed them. These *are* the paint gates (paint() reads them), so a
+  /// test asserting on them asserts on what is drawn - the state fields
+  /// themselves outlive their tool (nothing clears [_state._eraserCursor]
+  /// when the eraser is put away; the gate does).
+  @visibleForTesting
+  Offset? get eraserCursor =>
+      _state._tool == PdfEditTool.eraser || _state._pointers.rawErasing
+          ? _state._eraserCursor
+          : null;
+
+  /// The eraser ring's radius in view pixels - the page-space eraser radius
+  /// scaled, so the ring is exactly the area a swipe removes at any zoom.
+  @visibleForTesting
+  double get eraserRadius =>
+      _state._controller.preferences.eraserRadius * _state._geometry.scale;
+
+  /// The ink tool's pen dot - shown with the tool merely armed and kept
+  /// riding the tip mid-stroke.
+  @visibleForTesting
+  Offset? get penCursor => _state._inkTool ? _state._penCursor : null;
+
+  @visibleForTesting
+  _StampAfterimage? get countPreview {
+    final at = _state._countCursor;
+    if (at == null || _state._tool != PdfEditTool.count) return null;
+    return _state._countPreviewAt(at);
+  }
+
+  @visibleForTesting
+  _StampAfterimage? get stampPreview {
+    final at = _state._stampPreview;
+    if (at == null ||
+        _state._tool != PdfEditTool.stamp ||
+        _state._dragStart != null) {
+      return null;
+    }
+    return _state._stampHoverAfterimageAt(at);
+  }
+
+  @visibleForTesting
+  Offset? get rotateCursor => _state._rotateCursor;
+
+  /// Where the signature tool's live placement preview is anchored - the
+  /// stored signature is laid out from here exactly as a click would commit
+  /// it.
+  @visibleForTesting
+  Offset? get signaturePreview => _state._tool == PdfEditTool.signature
+      ? _state._signaturePreview
+      : null;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final state = _state;
+    final geometry = state._geometry;
+    final chromeScale = state._chromeScale;
+    final preferences = state._controller.preferences;
+
+    // the signature tool's live placement preview, under the cursors: the
+    // stored signature, laid out exactly where a click would commit it
+    final signatureAt = signaturePreview;
+    if (signatureAt != null) {
+      final (x, y) = geometry.toPagePoint(signatureAt);
+      final placement =
+          state._controller.signaturePlacement(state.widget.pageIndex, x, y);
+      if (placement != null) {
+        _paintInkStrokes(
+          canvas,
+          geometry,
+          placement.strokes,
+          placement.pressures,
+          Color(0xFF000000 | placement.color).withValues(alpha: 0.55),
+          placement.strokeWidth * geometry.scale,
+        );
+      }
+    }
+
+    // the eraser's ring cursor: page-space radius (it shows exactly what a
+    // swipe removes), screen-constant line weight - a light ring over a dark
+    // halo so it reads on any page color
+    final eraser = eraserCursor;
+    final eraserRadius = this.eraserRadius;
+    if (eraser != null && eraserRadius > 0) {
+      canvas.drawCircle(
+          eraser, eraserRadius, Paint()..color = const Color(0x14000000));
+      canvas.drawCircle(
+          eraser,
+          eraserRadius,
+          Paint()
+            ..color = const Color(0x66000000)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = 3 * chromeScale);
+      canvas.drawCircle(
+          eraser,
+          eraserRadius,
+          Paint()
+            ..color = const Color(0xFFFFFFFF)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = 1.5 * chromeScale);
+    }
+
+    // the ink tool's pen-preview dot: the pen colour at its opacity, sized to
+    // the stroke width, with a halo + hairline so it reads on any page. Also
+    // painted mid-stroke, so the dot keeps riding the pen tip.
+    final pen = penCursor;
+    if (pen != null) {
+      _paintPenCursor(
+        canvas,
+        pen,
+        strokeWidth: preferences.strokeWidth * geometry.scale,
+        chromeScale: chromeScale,
+        color: state._controller.color,
+        opacity: preferences.opacity,
+      );
+    }
+
+    final count = countPreview;
+    if (count != null) {
+      _paintStampAfterimageAt(canvas, count, geometry.scale);
+    }
+
+    final stamp = stampPreview;
+    if (stamp != null) {
+      _paintStampAfterimageAt(canvas, stamp, geometry.scale);
+    }
+
+    // the rotate knob's cursor: a curved arrow (no system rotation cursor)
+    final rotate = rotateCursor;
+    if (rotate != null) {
+      final rr = 9 * chromeScale;
+      // a 290° arc, leaving a gap for the arrowhead at its end
+      const start = -math.pi / 2;
+      const sweep = 290 * math.pi / 180;
+      final box = Rect.fromCircle(center: rotate, radius: rr);
+      final halo = Paint()
+        ..color = const Color(0x66000000)
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round
+        ..strokeWidth = 4 * chromeScale;
+      final arc = Paint()
+        ..color = const Color(0xFFFFFFFF)
+        ..style = PaintingStyle.stroke
+        ..strokeCap = StrokeCap.round
+        ..strokeWidth = 2 * chromeScale;
+      canvas.drawArc(box, start, sweep, false, halo);
+      canvas.drawArc(box, start, sweep, false, arc);
+      // arrowhead tangent to the arc end
+      final end = start + sweep;
+      final tip = rotate + Offset(math.cos(end), math.sin(end)) * rr;
+      final tangent = end + math.pi / 2; // clockwise travel
+      final wing = 4 * chromeScale;
+      for (final a in [tangent + 2.5, tangent - 2.5]) {
+        final p = tip + Offset(math.cos(a), math.sin(a)) * wing;
+        canvas.drawLine(tip, p, halo);
+        canvas.drawLine(tip, p, arc);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_HoverCursorPainter oldDelegate) => true;
+}
+
+/// Paints a stamp/count afterimage (or hover preview) at its already
+/// view-space [_StampAfterimage.rect]. Top-level so both the snapshot-arg
+/// [_EditingPreviewPainter] and the pointer-frequency [_HoverCursorPainter]
+/// draw the identical mark; [scale] is the page geometry's view scale, the
+/// only geometry the mark needs (border weight, padding, corner radius).
+void _paintStampAfterimageAt(
+    Canvas canvas, _StampAfterimage stamp, double scale) {
+  final rect = stamp.rect;
+  if (rect.isEmpty) return;
+  final color = stamp.color.withValues(alpha: stamp.opacity);
+  final template = stamp.template;
+  if (template != null) {
+    _paintStampTemplateAfterimage(canvas, rect, template, stamp.opacity);
+    return;
+  }
+  if (stamp.check) {
+    final s = math.min(rect.width, rect.height);
+    if (s <= 0) return;
+    final ox = rect.left + (rect.width - s) / 2;
+    final oy = rect.top + (rect.height - s) / 2;
+    final path = Path()
+      ..moveTo(ox + s * 0.18, oy + s * 0.50)
+      ..lineTo(ox + s * 0.42, oy + s * 0.74)
+      ..lineTo(ox + s * 0.82, oy + s * 0.26);
+    canvas.drawPath(
+        path,
+        Paint()
+          ..color = color
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = s * 0.16
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round);
+    return;
+  }
+
+  final borderWidth = math.max(0.5, 2 * scale);
+  final pad = 6 * scale;
+  final box = rect.deflate(borderWidth / 2);
+  if (box.width > 0 && box.height > 0) {
+    canvas.drawRRect(
+        RRect.fromRectAndRadius(box, Radius.circular(4 * scale)),
+        Paint()
+          ..color = color
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = borderWidth);
+  }
+
+  final text = stamp.text;
+  if (text == null || text.isEmpty) return;
+  final availableWidth = math.max(0.0, rect.width - 2 * pad);
+  final availableHeight = math.max(0.0, rect.height - 2 * pad);
+  if (availableWidth == 0 || availableHeight == 0) return;
+  var fontSize = availableHeight * 0.72;
+  if (fontSize <= 0) return;
+
+  TextPainter painterFor(double size) => TextPainter(
+        text: TextSpan(
+          text: text,
+          style: TextStyle(
+            color: color,
+            fontFamily: 'Helvetica',
+            fontWeight: FontWeight.bold,
+            fontSize: size,
+            height: 1,
+          ),
+        ),
+        textDirection: _flutterTextDirection(text),
+        maxLines: 1,
+      )..layout(maxWidth: double.infinity);
+
+  var textPainter = painterFor(fontSize);
+  if (textPainter.width > availableWidth && textPainter.width > 0) {
+    fontSize *= availableWidth / textPainter.width;
+    textPainter = painterFor(fontSize);
+  }
+  textPainter.paint(
+      canvas,
+      Offset(rect.left + (rect.width - textPainter.width) / 2,
+          rect.top + (rect.height - textPainter.height) / 2));
+}
+
+void _paintStampTemplateAfterimage(
+    Canvas canvas, Rect rect, PdfStampTemplate template, double opacity) {
+  if (!template.isValid || rect.isEmpty) return;
+  canvas.saveLayer(
+      rect,
+      Paint()
+        ..color = const Color(0xFFFFFFFF)
+            .withValues(alpha: opacity.clamp(0.0, 1.0)));
+  final sx = rect.width / template.width;
+  final sy = rect.height / template.height;
+  final strokeScale = math.min(sx, sy);
+  for (final component in template.components) {
+    if (component.width <= 0 || component.height <= 0) continue;
+    final componentRect = Rect.fromLTWH(
+      rect.left + component.x * sx,
+      rect.top + component.y * sy,
+      component.width * sx,
+      component.height * sy,
+    );
+    _paintStampTemplateComponent(
+        canvas, component, componentRect, strokeScale);
+  }
+  canvas.restore();
+}
+
+void _paintStampTemplateComponent(Canvas canvas,
+    PdfStampTemplateComponent component, Rect rect, double strokeScale) {
+  final strokeWidth = math.max(0.1, component.strokeWidth * strokeScale);
+  switch (component.type) {
+    case PdfStampTemplateComponentType.rectangle:
+      final shape = rect.deflate(strokeWidth / 2);
+      if (shape.isEmpty) return;
+      final rrect = RRect.fromRectAndRadius(
+          shape, Radius.circular(component.radius * strokeScale));
+      if (component.fillColor != null) {
+        canvas.drawRRect(
+            rrect, Paint()..color = Color(0xFF000000 | component.fillColor!));
+      }
+      canvas.drawRRect(
+          rrect,
+          Paint()
+            ..color = Color(0xFF000000 | component.color)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = strokeWidth);
+    case PdfStampTemplateComponentType.ellipse:
+      final shape = rect.deflate(strokeWidth / 2);
+      if (shape.isEmpty) return;
+      if (component.fillColor != null) {
+        canvas.drawOval(
+            shape, Paint()..color = Color(0xFF000000 | component.fillColor!));
+      }
+      canvas.drawOval(
+          shape,
+          Paint()
+            ..color = Color(0xFF000000 | component.color)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = strokeWidth);
+    case PdfStampTemplateComponentType.text:
+      final text = component.text.trim();
+      if (text.isEmpty || rect.width <= 0 || rect.height <= 0) return;
+      var fontSize =
+          (component.fontSize ?? component.height * 0.72) * strokeScale;
+      fontSize = math.min(fontSize, rect.height * 0.9);
+      if (fontSize <= 0) return;
+      TextPainter painterFor(double size) => TextPainter(
+            text: TextSpan(
+              text: text,
+              style: TextStyle(
+                color: Color(0xFF000000 | component.color),
+                fontFamily: _textEditUiFamily(component.font),
+                fontWeight: component.font.isBold
+                    ? FontWeight.bold
+                    : FontWeight.normal,
+                fontStyle: component.font.isItalic
+                    ? FontStyle.italic
+                    : FontStyle.normal,
+                fontSize: size,
+                height: 1,
+              ),
+            ),
+            textDirection: _flutterTextDirection(text),
+            maxLines: 1,
+          )..layout(maxWidth: double.infinity);
+      var textPainter = painterFor(fontSize);
+      if (textPainter.width > rect.width && textPainter.width > 0) {
+        fontSize *= rect.width / textPainter.width;
+        textPainter = painterFor(fontSize);
+      }
+      textPainter.paint(
+          canvas,
+          Offset(rect.left + (rect.width - textPainter.width) / 2,
+              rect.top + (rect.height - textPainter.height) / 2));
+    case PdfStampTemplateComponentType.image:
+      canvas.drawRect(
+          rect, Paint()..color = const Color(0xFFE0E0E0).withAlpha(0x99));
+      canvas.drawRect(
+          rect.deflate(0.5),
+          Paint()
+            ..color = Color(0xFF000000 | component.color)
+            ..style = PaintingStyle.stroke
+            ..strokeWidth = math.max(0.5, strokeScale));
+    case PdfStampTemplateComponentType.signature:
+      _paintStampTemplateSignature(canvas, component, rect, strokeScale);
+  }
+}
+
+void _paintStampTemplateSignature(Canvas canvas,
+    PdfStampTemplateComponent component, Rect rect, double strokeScale) {
+  if (component.strokes.isEmpty || rect.width <= 0 || rect.height <= 0) {
+    return;
+  }
+  final baseWidth = math.max(0.1, component.strokeWidth * strokeScale);
+  final color = Color(0xFF000000 | component.color);
+  for (var i = 0; i < component.strokes.length; i++) {
+    final stroke = [
+      for (final (x, y) in component.strokes[i])
+        Offset(rect.left + x * rect.width, rect.top + y * rect.height),
+    ];
+    if (stroke.isEmpty) continue;
+    final controls =
+        pdfInkCurveControls([for (final p in stroke) (p.dx, p.dy)]);
+    final pressure =
+        i < component.pressures.length ? component.pressures[i] : null;
+    if (stroke.length == 1) {
+      canvas.drawCircle(
+          stroke.single,
+          pdfInkStrokeWidth(
+                  baseWidth,
+                  pressure == null || pressure.length != 1
+                      ? 0.5
+                      : pressure.first) /
+              2,
+          Paint()..color = color);
+      continue;
+    }
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+    if (pressure == null || pressure.length != stroke.length) {
+      paint.strokeWidth = baseWidth;
+      final path = Path()..moveTo(stroke.first.dx, stroke.first.dy);
+      for (var j = 0; j < stroke.length - 1; j++) {
+        final ((c1x, c1y), (c2x, c2y)) = controls[j];
+        path.cubicTo(c1x, c1y, c2x, c2y, stroke[j + 1].dx, stroke[j + 1].dy);
+      }
+      canvas.drawPath(path, paint);
+      continue;
+    }
+    for (var j = 0; j < stroke.length - 1; j++) {
+      paint.strokeWidth =
+          pdfInkStrokeWidth(baseWidth, (pressure[j] + pressure[j + 1]) / 2);
+      final ((c1x, c1y), (c2x, c2y)) = controls[j];
+      canvas.drawPath(
+          Path()
+            ..moveTo(stroke[j].dx, stroke[j].dy)
+            ..cubicTo(c1x, c1y, c2x, c2y, stroke[j + 1].dx, stroke[j + 1].dy),
+          paint);
+    }
+  }
 }
 
 class _EditingPreviewPainter extends CustomPainter {
@@ -5860,13 +6317,6 @@ class _EditingPreviewPainter extends CustomPainter {
     this.fadeRects = const [],
     this.fadeInk = const [],
     this.fadeColor = const Color(0x00000000),
-    this.eraserCursor,
-    this.eraserRadius = 0,
-    this.penCursor,
-    this.penOpacity = 1,
-    this.countPreview,
-    this.stampPreview,
-    this.rotateCursor,
     required this.afterGhost,
     required this.afterShape,
     required this.afterStamp,
@@ -5986,32 +6436,6 @@ class _EditingPreviewPainter extends CustomPainter {
   /// around it or spilling off the page.
   final List<_InkPaint> fadeInk;
   final Color fadeColor;
-
-  /// The circle eraser's ring cursor: view position and radius (the
-  /// page-space eraser radius scaled into view pixels, so the ring is
-  /// exactly the area the eraser removes at any zoom).
-  final Offset? eraserCursor;
-  final double eraserRadius;
-
-  /// The ink tool's pen-preview cursor: a filled dot in [color] at
-  /// [penOpacity], sized to the pen width ([strokeWidth], view pixels),
-  /// painted in place of the system cursor so the colour and width that
-  /// will be drawn are visible before the stroke starts.
-  final Offset? penCursor;
-  final double penOpacity;
-
-  /// The count tool's hover preview: the check mark that a click will place,
-  /// already clamped to the same page-space rect as the committed annotation.
-  final _StampAfterimage? countPreview;
-
-  /// The stamp tool's hover preview: the active custom stamp that a click
-  /// will place, already clamped to the same rect as the committed annotation.
-  final _StampAfterimage? stampPreview;
-
-  /// The rotate knob's cursor: a small curved-arrow glyph painted here
-  /// (Flutter has no built-in rotation cursor, so the system cursor is
-  /// hidden over the knob and this tracks the pointer instead).
-  final Offset? rotateCursor;
 
   /// A just-committed move/resize/rotate, kept painted at full strength
   /// until the new revision's raster lands. [source] is the old
@@ -6235,243 +6659,9 @@ class _EditingPreviewPainter extends CustomPainter {
     return area / 2;
   }
 
-  void _paintStampAfterimage(Canvas canvas, _StampAfterimage stamp) {
-    final rect = stamp.rect;
-    if (rect.isEmpty) return;
-    final color = stamp.color.withValues(alpha: stamp.opacity);
-    final template = stamp.template;
-    if (template != null) {
-      _paintStampTemplateAfterimage(canvas, rect, template, stamp.opacity);
-      return;
-    }
-    if (stamp.check) {
-      final s = math.min(rect.width, rect.height);
-      if (s <= 0) return;
-      final ox = rect.left + (rect.width - s) / 2;
-      final oy = rect.top + (rect.height - s) / 2;
-      final path = Path()
-        ..moveTo(ox + s * 0.18, oy + s * 0.50)
-        ..lineTo(ox + s * 0.42, oy + s * 0.74)
-        ..lineTo(ox + s * 0.82, oy + s * 0.26);
-      canvas.drawPath(
-          path,
-          Paint()
-            ..color = color
-            ..style = PaintingStyle.stroke
-            ..strokeWidth = s * 0.16
-            ..strokeCap = StrokeCap.round
-            ..strokeJoin = StrokeJoin.round);
-      return;
-    }
+  void _paintStampAfterimage(Canvas canvas, _StampAfterimage stamp) =>
+      _paintStampAfterimageAt(canvas, stamp, geometry.scale);
 
-    final borderWidth = math.max(0.5, 2 * geometry.scale);
-    final pad = 6 * geometry.scale;
-    final box = rect.deflate(borderWidth / 2);
-    if (box.width > 0 && box.height > 0) {
-      canvas.drawRRect(
-          RRect.fromRectAndRadius(box, Radius.circular(4 * geometry.scale)),
-          Paint()
-            ..color = color
-            ..style = PaintingStyle.stroke
-            ..strokeWidth = borderWidth);
-    }
-
-    final text = stamp.text;
-    if (text == null || text.isEmpty) return;
-    final availableWidth = math.max(0.0, rect.width - 2 * pad);
-    final availableHeight = math.max(0.0, rect.height - 2 * pad);
-    if (availableWidth == 0 || availableHeight == 0) return;
-    var fontSize = availableHeight * 0.72;
-    if (fontSize <= 0) return;
-
-    TextPainter painterFor(double size) => TextPainter(
-          text: TextSpan(
-            text: text,
-            style: TextStyle(
-              color: color,
-              fontFamily: 'Helvetica',
-              fontWeight: FontWeight.bold,
-              fontSize: size,
-              height: 1,
-            ),
-          ),
-          textDirection: _flutterTextDirection(text),
-          maxLines: 1,
-        )..layout(maxWidth: double.infinity);
-
-    var textPainter = painterFor(fontSize);
-    if (textPainter.width > availableWidth && textPainter.width > 0) {
-      fontSize *= availableWidth / textPainter.width;
-      textPainter = painterFor(fontSize);
-    }
-    textPainter.paint(
-        canvas,
-        Offset(rect.left + (rect.width - textPainter.width) / 2,
-            rect.top + (rect.height - textPainter.height) / 2));
-  }
-
-  void _paintStampTemplateAfterimage(
-      Canvas canvas, Rect rect, PdfStampTemplate template, double opacity) {
-    if (!template.isValid || rect.isEmpty) return;
-    canvas.saveLayer(
-        rect,
-        Paint()
-          ..color = const Color(0xFFFFFFFF)
-              .withValues(alpha: opacity.clamp(0.0, 1.0)));
-    final sx = rect.width / template.width;
-    final sy = rect.height / template.height;
-    final strokeScale = math.min(sx, sy);
-    for (final component in template.components) {
-      if (component.width <= 0 || component.height <= 0) continue;
-      final componentRect = Rect.fromLTWH(
-        rect.left + component.x * sx,
-        rect.top + component.y * sy,
-        component.width * sx,
-        component.height * sy,
-      );
-      _paintStampTemplateComponent(
-          canvas, component, componentRect, strokeScale);
-    }
-    canvas.restore();
-  }
-
-  void _paintStampTemplateComponent(Canvas canvas,
-      PdfStampTemplateComponent component, Rect rect, double strokeScale) {
-    final strokeWidth = math.max(0.1, component.strokeWidth * strokeScale);
-    switch (component.type) {
-      case PdfStampTemplateComponentType.rectangle:
-        final shape = rect.deflate(strokeWidth / 2);
-        if (shape.isEmpty) return;
-        final rrect = RRect.fromRectAndRadius(
-            shape, Radius.circular(component.radius * strokeScale));
-        if (component.fillColor != null) {
-          canvas.drawRRect(
-              rrect, Paint()..color = Color(0xFF000000 | component.fillColor!));
-        }
-        canvas.drawRRect(
-            rrect,
-            Paint()
-              ..color = Color(0xFF000000 | component.color)
-              ..style = PaintingStyle.stroke
-              ..strokeWidth = strokeWidth);
-      case PdfStampTemplateComponentType.ellipse:
-        final shape = rect.deflate(strokeWidth / 2);
-        if (shape.isEmpty) return;
-        if (component.fillColor != null) {
-          canvas.drawOval(
-              shape, Paint()..color = Color(0xFF000000 | component.fillColor!));
-        }
-        canvas.drawOval(
-            shape,
-            Paint()
-              ..color = Color(0xFF000000 | component.color)
-              ..style = PaintingStyle.stroke
-              ..strokeWidth = strokeWidth);
-      case PdfStampTemplateComponentType.text:
-        final text = component.text.trim();
-        if (text.isEmpty || rect.width <= 0 || rect.height <= 0) return;
-        var fontSize =
-            (component.fontSize ?? component.height * 0.72) * strokeScale;
-        fontSize = math.min(fontSize, rect.height * 0.9);
-        if (fontSize <= 0) return;
-        TextPainter painterFor(double size) => TextPainter(
-              text: TextSpan(
-                text: text,
-                style: TextStyle(
-                  color: Color(0xFF000000 | component.color),
-                  fontFamily: _textEditUiFamily(component.font),
-                  fontWeight: component.font.isBold
-                      ? FontWeight.bold
-                      : FontWeight.normal,
-                  fontStyle: component.font.isItalic
-                      ? FontStyle.italic
-                      : FontStyle.normal,
-                  fontSize: size,
-                  height: 1,
-                ),
-              ),
-              textDirection: _flutterTextDirection(text),
-              maxLines: 1,
-            )..layout(maxWidth: double.infinity);
-        var textPainter = painterFor(fontSize);
-        if (textPainter.width > rect.width && textPainter.width > 0) {
-          fontSize *= rect.width / textPainter.width;
-          textPainter = painterFor(fontSize);
-        }
-        textPainter.paint(
-            canvas,
-            Offset(rect.left + (rect.width - textPainter.width) / 2,
-                rect.top + (rect.height - textPainter.height) / 2));
-      case PdfStampTemplateComponentType.image:
-        canvas.drawRect(
-            rect, Paint()..color = const Color(0xFFE0E0E0).withAlpha(0x99));
-        canvas.drawRect(
-            rect.deflate(0.5),
-            Paint()
-              ..color = Color(0xFF000000 | component.color)
-              ..style = PaintingStyle.stroke
-              ..strokeWidth = math.max(0.5, strokeScale));
-      case PdfStampTemplateComponentType.signature:
-        _paintStampTemplateSignature(canvas, component, rect, strokeScale);
-    }
-  }
-
-  void _paintStampTemplateSignature(Canvas canvas,
-      PdfStampTemplateComponent component, Rect rect, double strokeScale) {
-    if (component.strokes.isEmpty || rect.width <= 0 || rect.height <= 0) {
-      return;
-    }
-    final baseWidth = math.max(0.1, component.strokeWidth * strokeScale);
-    final color = Color(0xFF000000 | component.color);
-    for (var i = 0; i < component.strokes.length; i++) {
-      final stroke = [
-        for (final (x, y) in component.strokes[i])
-          Offset(rect.left + x * rect.width, rect.top + y * rect.height),
-      ];
-      if (stroke.isEmpty) continue;
-      final controls =
-          pdfInkCurveControls([for (final p in stroke) (p.dx, p.dy)]);
-      final pressure =
-          i < component.pressures.length ? component.pressures[i] : null;
-      if (stroke.length == 1) {
-        canvas.drawCircle(
-            stroke.single,
-            pdfInkStrokeWidth(
-                    baseWidth,
-                    pressure == null || pressure.length != 1
-                        ? 0.5
-                        : pressure.first) /
-                2,
-            Paint()..color = color);
-        continue;
-      }
-      final paint = Paint()
-        ..color = color
-        ..style = PaintingStyle.stroke
-        ..strokeCap = StrokeCap.round
-        ..strokeJoin = StrokeJoin.round;
-      if (pressure == null || pressure.length != stroke.length) {
-        paint.strokeWidth = baseWidth;
-        final path = Path()..moveTo(stroke.first.dx, stroke.first.dy);
-        for (var j = 0; j < stroke.length - 1; j++) {
-          final ((c1x, c1y), (c2x, c2y)) = controls[j];
-          path.cubicTo(c1x, c1y, c2x, c2y, stroke[j + 1].dx, stroke[j + 1].dy);
-        }
-        canvas.drawPath(path, paint);
-        continue;
-      }
-      for (var j = 0; j < stroke.length - 1; j++) {
-        paint.strokeWidth =
-            pdfInkStrokeWidth(baseWidth, (pressure[j] + pressure[j + 1]) / 2);
-        final ((c1x, c1y), (c2x, c2y)) = controls[j];
-        canvas.drawPath(
-            Path()
-              ..moveTo(stroke[j].dx, stroke[j].dy)
-              ..cubicTo(c1x, c1y, c2x, c2y, stroke[j + 1].dx, stroke[j + 1].dy),
-            paint);
-      }
-    }
-  }
 
   /// Draws a Square/Circle at [s.rect] the way the editor regenerates it:
   /// a constant-width stroke inset by half its width (so it stays inside
@@ -6892,84 +7082,6 @@ class _EditingPreviewPainter extends CustomPainter {
             ..strokeWidth = 3 * chromeScale);
     }
 
-    // the eraser's ring cursor, topmost: page-space radius (it shows
-    // exactly what a stamp removes), screen-constant line weight - a
-    // light ring over a dark halo so it reads on any page color
-    final cursor = eraserCursor;
-    if (cursor != null && eraserRadius > 0) {
-      canvas.drawCircle(
-          cursor, eraserRadius, Paint()..color = const Color(0x14000000));
-      canvas.drawCircle(
-          cursor,
-          eraserRadius,
-          Paint()
-            ..color = const Color(0x66000000)
-            ..style = PaintingStyle.stroke
-            ..strokeWidth = 3 * chromeScale);
-      canvas.drawCircle(
-          cursor,
-          eraserRadius,
-          Paint()
-            ..color = const Color(0xFFFFFFFF)
-            ..style = PaintingStyle.stroke
-            ..strokeWidth = 1.5 * chromeScale);
-    }
-
-    // the ink tool's pen-preview dot: the pen colour at its opacity, sized
-    // to the stroke width, with a halo + hairline so it reads on any page
-    final pen = penCursor;
-    if (pen != null) {
-      _paintPenCursor(
-        canvas,
-        pen,
-        strokeWidth: strokeWidth,
-        chromeScale: chromeScale,
-        color: color,
-        opacity: penOpacity,
-      );
-    }
-
-    final count = countPreview;
-    if (count != null) {
-      _paintStampAfterimage(canvas, count);
-    }
-
-    final stamp = stampPreview;
-    if (stamp != null) {
-      _paintStampAfterimage(canvas, stamp);
-    }
-
-    // the rotate knob's cursor: a curved arrow (no system rotation cursor)
-    final rotate = rotateCursor;
-    if (rotate != null) {
-      final rr = 9 * chromeScale;
-      // a 290° arc, leaving a gap for the arrowhead at its end
-      const start = -math.pi / 2;
-      const sweep = 290 * math.pi / 180;
-      final box = Rect.fromCircle(center: rotate, radius: rr);
-      final halo = Paint()
-        ..color = const Color(0x66000000)
-        ..style = PaintingStyle.stroke
-        ..strokeCap = StrokeCap.round
-        ..strokeWidth = 4 * chromeScale;
-      final arc = Paint()
-        ..color = const Color(0xFFFFFFFF)
-        ..style = PaintingStyle.stroke
-        ..strokeCap = StrokeCap.round
-        ..strokeWidth = 2 * chromeScale;
-      canvas.drawArc(box, start, sweep, false, halo);
-      canvas.drawArc(box, start, sweep, false, arc);
-      // arrowhead tangent to the arc end
-      final end = start + sweep;
-      final tip = rotate + Offset(math.cos(end), math.sin(end)) * rr;
-      final tangent = end + math.pi / 2; // clockwise travel
-      final wing = 4 * chromeScale;
-      for (final a in [tangent + 2.5, tangent - 2.5]) {
-        final p = tip + Offset(math.cos(a), math.sin(a)) * wing;
-        canvas.drawLine(tip, p, halo);
-        canvas.drawLine(tip, p, arc);
-      }
-    }
   }
 
   /// Cheap inequality for the extra ink sets: counts plus each set's
@@ -7025,13 +7137,6 @@ class _EditingPreviewPainter extends CustomPainter {
       !listEquals(oldDelegate.fadeRects, fadeRects) ||
       _inkChanged(oldDelegate.fadeInk, fadeInk) ||
       oldDelegate.fadeColor != fadeColor ||
-      oldDelegate.eraserCursor != eraserCursor ||
-      oldDelegate.eraserRadius != eraserRadius ||
-      oldDelegate.penCursor != penCursor ||
-      oldDelegate.penOpacity != penOpacity ||
-      oldDelegate.countPreview != countPreview ||
-      oldDelegate.stampPreview != stampPreview ||
-      oldDelegate.rotateCursor != rotateCursor ||
       oldDelegate.afterGhost != afterGhost ||
       oldDelegate.afterShape != afterShape ||
       oldDelegate.afterStamp != afterStamp ||

--- a/packages/dart_pdf_editor/test/editing_count_test.dart
+++ b/packages/dart_pdf_editor/test/editing_count_test.dart
@@ -28,6 +28,18 @@ dynamic overlayPainter(WidgetTester tester) => tester
         .first)
     .painter;
 
+/// The overlay's hover-cursor layer - the pen dot, eraser ring, count/stamp
+/// previews and rotate glyph, which read live state and repaint without a
+/// rebuild. Read through a dynamic cast (the painter class is private).
+dynamic cursorPainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.descendant(
+      of: find.byType(EditingPageOverlay),
+      matching: find.byType(CustomPaint),
+    ))
+    .map((paint) => paint.painter)
+    .firstWhere(
+        (painter) => painter.runtimeType.toString() == '_HoverCursorPainter');
+
 void main() {
   group('PdfEditingController check-marks', () {
     test('placeCheckMark drops a /Stamp /Check centered on the tap', () {
@@ -248,7 +260,7 @@ void main() {
       await gesture.moveTo(origin + local(240, 420));
       await tester.pump();
 
-      final preview = overlayPainter(tester).countPreview;
+      final preview = cursorPainter(tester).countPreview;
       expect(preview, isNotNull);
       expect(preview.check, isTrue);
       expect(preview.text, isNull);

--- a/packages/dart_pdf_editor/test/editing_cursor_test.dart
+++ b/packages/dart_pdf_editor/test/editing_cursor_test.dart
@@ -22,14 +22,19 @@ dynamic overlayPainter(WidgetTester tester) => tester
         .first)
     .painter;
 
-dynamic activeStrokePainter(WidgetTester tester) => tester
+/// The overlay's hover-cursor layer: the pen dot, eraser ring, count/stamp
+/// previews and the rotation glyph all live here, read off the live overlay
+/// state and repainted from a notifier - a hover moves them without
+/// rebuilding the overlay, so the *painter instance* may predate the hover
+/// and its getters must be read fresh.
+dynamic cursorPainter(WidgetTester tester) => tester
     .widgetList<CustomPaint>(find.descendant(
       of: find.byType(EditingPageOverlay),
       matching: find.byType(CustomPaint),
     ))
     .map((paint) => paint.painter)
     .singleWhere(
-      (painter) => painter.runtimeType.toString() == '_ActiveStrokePainter',
+      (painter) => painter.runtimeType.toString() == '_HoverCursorPainter',
     );
 
 /// The overlay's own MouseRegion cursor (the one wrapping the preview
@@ -134,7 +139,7 @@ void main() {
     final top = view(225, 550);
     await hoverAt(tester, Offset(top.dx, top.dy - 22));
     expect(regionCursor(tester), SystemMouseCursors.none);
-    expect(overlayPainter(tester).rotateCursor, isNotNull);
+    expect(cursorPainter(tester).rotateCursor, isNotNull);
   });
 
   testWidgets('the ink tool paints a pen-preview dot in place of the cursor',
@@ -147,10 +152,9 @@ void main() {
 
     await hoverAt(tester, view(300, 400));
     expect(regionCursor(tester), SystemMouseCursors.none);
-    final painter = overlayPainter(tester);
-    expect(painter.penCursor, isNotNull);
+    expect(cursorPainter(tester).penCursor, isNotNull);
     // the dot draws in the selected pen colour
-    expect((painter.color as Color).toARGB32(), 0xFF1565C0);
+    expect((overlayPainter(tester).color as Color).toARGB32(), 0xFF1565C0);
   });
 
   testWidgets('the ink cursor follows a mouse-drawn stroke', (tester) async {
@@ -168,11 +172,11 @@ void main() {
 
     await g.moveTo(end);
     await tester.pump();
-    expect(activeStrokePainter(tester).debugPenCursor, end);
+    expect(cursorPainter(tester).penCursor, end);
     await g.up();
     await tester.pump();
 
-    expect(overlayPainter(tester).penCursor, end);
+    expect(cursorPainter(tester).penCursor, end);
   });
 
   testWidgets('leaving the page retracts the painted pen dot', (tester) async {
@@ -181,10 +185,87 @@ void main() {
     await tester.pump();
 
     final g = await hoverAt(tester, view(300, 400));
-    expect(overlayPainter(tester).penCursor, isNotNull);
+    expect(cursorPainter(tester).penCursor, isNotNull);
     // move far outside the viewer to fire MouseRegion.onExit
     await g.moveTo(const Offset(-50, -50));
     await tester.pump();
-    expect(overlayPainter(tester).penCursor, isNull);
+    expect(cursorPainter(tester).penCursor, isNull);
+  });
+
+  // #403: the cursors used to be snapshot arguments of the heavy preview
+  // painter, so every mouse-move setState'd the overlay - rebuilding its
+  // whole subtree through exactly the moment the user is about to draw.
+  // They now live on a repaint-only layer. The tell is the preview painter's
+  // identity: a rebuild constructs a fresh one from new arguments, so the
+  // same instance still being mounted after a move means no rebuild ran.
+  group('hover moves cursors without rebuilding the overlay', () {
+    Future<void> expectNoRebuildOnHover(
+      WidgetTester tester,
+      PdfEditTool tool,
+      Object? Function(dynamic cursors) read, {
+      void Function(PdfEditingController editing)? setUp,
+    }) async {
+      final editing = await pumpViewer(tester);
+      setUp?.call(editing);
+      editing.tool = tool;
+      await tester.pump();
+
+      final from = view(300, 400);
+      final to = view(340, 420);
+      final g = await hoverAt(tester, from);
+      expect(read(cursorPainter(tester)), isNotNull,
+          reason: '$tool arms a painted cursor');
+      final painterBefore = overlayPainter(tester);
+
+      await g.moveTo(to);
+      await tester.pump();
+
+      expect(read(cursorPainter(tester)), isNotNull,
+          reason: '$tool cursor still painted after the move');
+      expect(identical(overlayPainter(tester), painterBefore), isTrue,
+          reason: 'a $tool hover rebuilt the overlay');
+
+      // ...and the identity check is sensitive: a change the overlay really
+      // does rebuild for swaps the painter out
+      editing.color = const Color(0xFF7B1FA2);
+      await tester.pump();
+      expect(identical(overlayPainter(tester), painterBefore), isFalse);
+    }
+
+    testWidgets('ink', (tester) async {
+      await expectNoRebuildOnHover(
+          tester, PdfEditTool.ink, (cursors) => cursors.penCursor);
+    });
+
+    testWidgets('eraser', (tester) async {
+      await expectNoRebuildOnHover(
+          tester, PdfEditTool.eraser, (cursors) => cursors.eraserCursor);
+    });
+
+    testWidgets('count', (tester) async {
+      await expectNoRebuildOnHover(
+          tester, PdfEditTool.count, (cursors) => cursors.countPreview);
+    });
+
+    testWidgets('stamp', (tester) async {
+      await expectNoRebuildOnHover(
+          tester, PdfEditTool.stamp, (cursors) => cursors.stampPreview);
+    });
+
+    testWidgets('signature', (tester) async {
+      await expectNoRebuildOnHover(
+        tester,
+        PdfEditTool.signature,
+        (cursors) => cursors.signaturePreview,
+        setUp: (editing) => editing.preferences.signature = PdfInkSignature(
+          strokes: const [
+            [(0.0, 0.0), (1.0, 0.5), (0.0, 1.0)],
+          ],
+          pressures: const [null],
+          color: 0x1A237E,
+          aspect: 2,
+        ),
+      );
+    });
   });
 }

--- a/packages/dart_pdf_editor/test/editing_cursor_test.dart
+++ b/packages/dart_pdf_editor/test/editing_cursor_test.dart
@@ -179,6 +179,29 @@ void main() {
     expect(cursorPainter(tester).penCursor, end);
   });
 
+  // A stylus never hovers, so pointer-down is the only thing that positions
+  // the pen dot for it. This pins that the raw-pointer stroke path sets it -
+  // it asserts the *state*, not that the cursor layer was repainted (a widget
+  // test reading the painter's getter can't see repaint scheduling, and the
+  // one-point stroke paints its own dot at the same spot anyway).
+  testWidgets('a stylus press positions the pen cursor with no hover first',
+      (tester) async {
+    final editing = await pumpViewer(tester);
+    editing
+      ..inkCommitDelay = null
+      ..tool = PdfEditTool.ink;
+    await tester.pump();
+
+    final start = view(250, 450);
+    final g = await tester.startGesture(start, kind: PointerDeviceKind.stylus);
+    await tester.pump();
+
+    expect(cursorPainter(tester).penCursor, start);
+
+    await g.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('leaving the page retracts the painted pen dot', (tester) async {
     final editing = await pumpViewer(tester);
     editing.tool = PdfEditTool.ink;

--- a/packages/dart_pdf_editor/test/editing_eraser_test.dart
+++ b/packages/dart_pdf_editor/test/editing_eraser_test.dart
@@ -21,6 +21,18 @@ dynamic overlayPainter(WidgetTester tester) => tester
         .first)
     .painter;
 
+/// The overlay's hover-cursor layer - the pen dot, eraser ring, count/stamp
+/// previews and rotate glyph, which read live state and repaint without a
+/// rebuild. Read through a dynamic cast (the painter class is private).
+dynamic cursorPainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.descendant(
+      of: find.byType(EditingPageOverlay),
+      matching: find.byType(CustomPaint),
+    ))
+    .map((paint) => paint.painter)
+    .firstWhere(
+        (painter) => painter.runtimeType.toString() == '_HoverCursorPainter');
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
@@ -351,8 +363,10 @@ void main() {
       expect(extraInk, hasLength(1));
       expect((extraInk.single.strokes as List), hasLength(2));
       // the ring cursor rides the pointer at the page-space radius
-      expect(painter.eraserCursor, isNotNull);
-      expect(painter.eraserRadius, closeTo(editing.preferences.eraserRadius * scale, 1e-6));
+      final cursors = cursorPainter(tester);
+      expect(cursors.eraserCursor, isNotNull);
+      expect(cursors.eraserRadius,
+          closeTo(editing.preferences.eraserRadius * scale, 1e-6));
 
       await g.up();
       await tester.pump();
@@ -390,7 +404,7 @@ void main() {
       await gesture.moveTo(view(300, 400));
       await tester.pump();
 
-      final painter = overlayPainter(tester);
+      final painter = cursorPainter(tester);
       expect(painter.eraserCursor, isNotNull);
       expect(painter.eraserRadius, greaterThan(0));
     });

--- a/packages/dart_pdf_editor/test/editing_stamps_test.dart
+++ b/packages/dart_pdf_editor/test/editing_stamps_test.dart
@@ -31,6 +31,18 @@ dynamic overlayPainter(WidgetTester tester) => tester
         .first)
     .painter;
 
+/// The overlay's hover-cursor layer - the pen dot, eraser ring, count/stamp
+/// previews and rotate glyph, which read live state and repaint without a
+/// rebuild. Read through a dynamic cast (the painter class is private).
+dynamic cursorPainter(WidgetTester tester) => tester
+    .widgetList<CustomPaint>(find.descendant(
+      of: find.byType(EditingPageOverlay),
+      matching: find.byType(CustomPaint),
+    ))
+    .map((paint) => paint.painter)
+    .firstWhere(
+        (painter) => painter.runtimeType.toString() == '_HoverCursorPainter');
+
 (int r, int g, int b, int a) pixelAt(ByteData pixels, int width, int x, int y) {
   final i = (y * width + x) * 4;
   return (
@@ -902,7 +914,7 @@ void main() {
       await tester.pump();
 
       expect(editing.document.page(0).annotations, isEmpty);
-      final preview = overlayPainter(tester).stampPreview;
+      final preview = cursorPainter(tester).stampPreview;
       expect(preview, isNotNull);
       expect(preview.text, 'PAID');
       expect(preview.template, isNotNull);
@@ -913,7 +925,7 @@ void main() {
 
       await mouse.moveTo(origin + const Offset(-20, -20));
       await tester.pump();
-      expect(overlayPainter(tester).stampPreview, isNull);
+      expect(cursorPainter(tester).stampPreview, isNull);
     });
 
     testWidgets('stamp hover previews a TEXT placeholder without an active stamp',
@@ -960,7 +972,7 @@ void main() {
       // hovering shows the placeholder; nothing is committed until a click
       // prompts for the real caption.
       expect(editing.document.page(0).annotations, isEmpty);
-      final preview = overlayPainter(tester).stampPreview;
+      final preview = cursorPainter(tester).stampPreview;
       expect(preview, isNotNull);
       expect(preview.text, 'TEXT');
       expect(preview.rect.center.dx, moreOrLessEquals(local(300, 400).dx));
@@ -968,7 +980,7 @@ void main() {
 
       await mouse.moveTo(origin + const Offset(-20, -20));
       await tester.pump();
-      expect(overlayPainter(tester).stampPreview, isNull);
+      expect(cursorPainter(tester).stampPreview, isNull);
     });
 
     testWidgets('adding a stamp keeps existing annotations painted',


### PR DESCRIPTION
## Summary

Closes the last open part of #403.

With ink, the eraser, count, stamp or the signature tool armed — or the eyedropper picking — the editing overlay paints its own cursor, and the cursor's position was a **snapshot argument of `_EditingPreviewPainter`**. Moving it therefore meant `setState`: every `PointerHoverEvent` rebuilt `_EditingPageOverlayState`'s whole subtree (annotation widgets, selection chrome, the ~7000-line build method, and a fresh preview painter with ~50 recomputed arguments) to move a dot a few pixels — continuous build-phase cost through exactly the moment the user is about to draw.

The fix is a sibling of the pattern the file already had for the in-progress stroke (`_ActiveStrokePainter` + `_activeStrokeRepaint`):

- **`_HoverCursorPainter`** — a new painter on its own `RepaintBoundary`, `super(repaint: _state._cursorRepaint)`, reading the live `_penCursor` / `_eraserCursor` / `_countCursor` / `_stampPreview` / `_rotateCursor` / `_signaturePreview` fields straight off the state. It sits above the active-stroke layer, so the cursors are topmost among the painted layers (they used to be the tail of the preview painter, *below* the stroke).
- `_onHover`, the signature drag and `_extendActiveStroke` assign the field and bump `_cursorRepaint` instead of `setState`. The one hover outcome that still rebuilds is a change of **system cursor kind**, which lives on the `MouseRegion` and only changes at tool/zone boundaries, not per event.
- The eyedropper's swatch is a widget, so it can't join the painter — it subscribes to the same notifier through a `ValueListenableBuilder`, rebuilding the chip alone.
- `_EditingPreviewPainter` loses `eraserCursor`/`eraserRadius`/`penCursor`/`penOpacity`/`countPreview`/`stampPreview`/`rotateCursor`, and the signature preview leaves its `extraInk`. `_paintStampAfterimage` and the three stamp-template helpers become top-level functions taking the view `scale`, so both painters draw the identical mark.

No behaviour change is intended: same marks, same gates, one layer higher in z-order.

Parts 2 and 3 of #403 already landed (#442, #479); `pdf_viewer.dart` is untouched here.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app *(perf-harness tooling under `app/tool/perf/` only — no app code)*
- [x] Documentation / CI / repository metadata only *(dev-log + perf README)*

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` — clean at repo root
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — **1969 passed**
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to `dart_pdf_editor`'s widget layer — it touches no COS/parse/render path, so the pure-Dart package suites and the Ghent/corpus render baselines have nothing to exercise. No render baseline could move: the same marks are drawn, only on a different layer.

### Performance

Two independent checks, because they answer different questions.

**Structural (widget tests).** `_EditingPreviewPainter`'s *identity* is the tell — a rebuild constructs a fresh one from new arguments, so the same instance still being mounted after a pointer move means no rebuild ran. `editing_cursor_test.dart` asserts that for ink / eraser / count / stamp / signature, plus (so the assertion can't quietly go vacuous) that a change the overlay really does rebuild for — setting the controller colour — *does* swap the painter out.

**Wall-clock (real Chrome).** The web harness gains a `hover` kind (`hover-ink`, `hover-eraser`): arm a tool, dispatch N synthetic `PointerHoverEvent`s at frame cadence over a dense vector sheet, report `hoverBuildMs*` from the `FrameTiming`s across the sweep. `tool/perf.sh webdiff HEAD hover-ink`, 3 iterations per side, 240 events over `plan-set-16p.pdf`, medians:

| metric | baseline | this branch | Δ |
|---|---|---|---|
| `hoverBuildMsP50` | 1.46 | 1.10 | **−24.6%** |
| `hoverBuildMsTotal` | 527 | 493 | −6.5% |
| `hoverBuildMsPerEvent` | 2.20 | 2.05 | −6.5% |
| `hoverBuildMsP95` | 4.96 | 5.08 | +2.5% |

Reading these honestly:

- `hoverBuildMsP50` is the clean result — every working-tree run measured 1.1 ms, every baseline run 1.4–1.7 ms, so the ranges don't overlap. A quarter off the *typical* build frame during an armed hover.
- The totals overlap run to run (WT 468/493/524 vs baseline 525/527/620). −6.5% is the right sign, but it's diluted by design: 240 frames over a 16-page plan set contain plenty of build work the overlay has nothing to do with, and the harness can't attribute build time per widget. The widget tests are what prove the overlay's own share went to zero.
- **The tool also prints `hoverBuildMsMax` 33.35 → 7.67 ("−77%"). That is not a result** — both sides threw a ~40 ms outlier in one of three runs (WT 7.7/7.6/40.9, baseline 33.4/40.8/7.4); the medians only separate because the outliers landed differently. Please don't quote it.
- The tool flags `buildMax` 71.3 → 78.5 as a regression. That's the *whole-run* max, and the run has only ~8 frames outside the hover window — it's a cold-open first-paint frame, which this change can't touch. The in-window max is `hoverBuildMsMax` above.

## PDF fixtures and screenshots

None — no document bytes change. The one visual difference is z-order: the painted cursors now sit above the in-progress stroke instead of below it (strictly better; the eraser ring was already documented as "topmost" within its old layer).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output. *(untouched)*
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required. *(untouched)*
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **`shouldRepaint` is `true` on the new painter**, unlike `_ActiveStrokePainter`'s `false`. The stroke layer's notifier ticks on every mutation of its buffers, so it can own its repainting outright. The cursor layer also depends on inputs it does *not* observe — armed tool, pen colour/width, zoom (`_geometry`), `_chromeScale` — which change through ordinary rebuilds. A fresh painter instance means the overlay rebuilt for one of them; repainting a few circles and an arc then is cheaper than tracking which input moved.
- **The paint gates are the debug getters.** `_state._eraserCursor` outlives the eraser (nothing clears it when the tool is put away); the `eraserCursor` getter — what `paint()` reads — is what's actually drawn, so the tests assert on the getters rather than the raw fields.
- **Deliberately left on `setState`:** `_polyHover` (polygon/cloud rubber band) and the erase-drag preview. Both change what the *page* preview draws — `dragPath`, the sliced/faded stroke sets — not just a cursor, so they belong to the preview painter.
- The remaining #403 follow-up, async/off-thread hover text extraction, is still gated behind #396.
- Reviewers who want the numbers themselves: `tool/perf.sh webdiff main hover-ink` (or `hover-eraser`) now works out of the box.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2bAjHQowJKKgqVeCvZUAb)_