### PR TITLE
perf(record): write each glyph outline once per record (#451)

### DIFF
--- a/doc/dev-log/2026-07-25-record-glyph-outline-dedup-451.md
+++ b/doc/dev-log/2026-07-25-record-glyph-outline-dedup-451.md
@@ -1,0 +1,150 @@
+# 2026-07-25 — #451: a record's biggest item was the same glyph, written again
+
+A device trace from the #598 build (app 3.0.0+20, web release, 62-page /
+24 MB book, 3 render workers) reframed #451. The ticket's headline is a
+39 MB record; the trace says the cost of that size is **cache capacity**,
+and capacity is what drives everything else.
+
+## What the trace showed
+
+Across ~16 s of scrolling over pages 18–38:
+
+```
+575 MB of render records produced for 20 distinct pages
+ 50 records, 3-5 per page (page 31: five)
+193 MB of that is pure duplicate work
+```
+
+Both caches sat pinned at their ceiling — record 94.1 MB of 96 MB,
+decoded-image 128.1 MB of 134.2 MB. With single records reaching 33–39 MB,
+about three fill the cache while the window spans ~20 pages, so a page is
+recorded, evicted by its neighbour, and recorded again. Re-recording is not
+cheap; pages 28 and 29 each paid a 1.2–1.6 s `serialize` **twice**:
+
+```
+page=28  worker=1895ms  ser=1608ms
+page=28  worker=1723ms  ser=1505ms   <- same page, again
+```
+
+That saturates the workers, and the queue is where the user's time goes:
+**17.6 s of cumulative queueing against 20.4 s of work**, page 27 queued
+4.18 s. It surfaces as `wait=943.9ms` on the *visible* page's interpret.
+
+So #451's issue 1 (image headroom), demoted to third on the ticket, is
+upstream of the rest — but not for the reason recorded there (transfer
+bytes; transfer was only 2.1 s across all 50 records).
+
+## Measuring what is in a record
+
+New tool: **`packages/pdf_graphics/tool/bench_record_bytes.dart`**.
+
+The first split it produced was wrong, and worth recording as a trap:
+differencing `serializeCommands(decodeImages: true)` against
+`decodeImages: false` looks like it isolates the image payload, but the
+`false` run still embeds every image's *encoded* stream, so the difference
+charges those bytes to the commands. It reported "65% commands" for the
+wrong reason. The tool now measures the payload directly, by deserializing
+the record and summing what each command actually carries.
+
+Doing that surfaced the real item. A record carries, per image, **both** the
+decoded RGBA *and* the source stream beside it (`device.dart` — "the
+[stream] is still serialized so the decoded pixels cache by content"). And
+in the remainder, over the traced book:
+
+```
+62 pages: 394.0 MB of records
+   83.1 MB (21%) decoded RGBA
+   53.8 MB (14%) source image streams, carried beside the RGBA
+  257.1 MB (65%) draw commands and other resources
+      of which glyph outlines: 151.7 MB, across 100062 placements
+                               85% of it literal repetition
+```
+
+**Glyph outlines were the single largest item in a record — larger than the
+entire decoded-image payload.** `PdfGlyphPlacement.outline` rides on every
+*placement*, so a letter set 500 times serialized its geometry 500 times.
+
+## What landed
+
+The writer emits an outline's geometry once and references it by id
+thereafter (tag 0 = none, 1 = geometry follows and takes the next id,
+2 = u32 id of one already defined). Format version 3 → 4.
+
+Keyed on **object identity**, which is the detail that makes it free: the
+font engine hands the same `PdfPath` instance back for every placement of a
+glyph, so identity catches essentially all of the repetition (8464 distinct
+by identity vs 7765 by value over the same book) without hashing geometry in
+the hot path. Read-back shares one instance per glyph too, so the replayed
+commands hold no more copies than a local render.
+
+Version bump is safe: records are in-memory only for a session, producer and
+consumer ship together, and the app's IndexedDB caches hold PDF bytes and
+sessions — not records.
+
+## Result, including where it does nothing
+
+Byte counts are deterministic, so unlike the timing work in
+[#598](2026-07-25-image-decode-colour-memo-451.md) there is no interleaving
+caveat — two rounds produced identical figures.
+
+| document | before | after | |
+|---|---|---|---|
+| tide-quickstart (the traced book) | 394.0 MB | **270.8 MB** | −31% |
+| Flutter_CTO_Report | 423.5 MB | 413.1 MB | −2.5% |
+| FST-AT-8720-EN | 927.1 MB | 913.0 MB | −1.5% |
+| AMT-SP-101 | 208.3 MB | 207.0 MB | −0.6% |
+| Combined Design Pack | 1261.3 MB | 1261.3 MB | 0% |
+| ghent + pdfjs (495 pages) | 384.6 MB | 376.3 MB | −2.2% |
+
+**The 31% is document-specific and should not be quoted as a general
+number.** The saving only exists where embedded fonts yield glyph outlines.
+Scanned and CAD documents have none at all, and their records are dominated
+by something else entirely:
+
+```
+Combined Design Pack  58 pages: 1261.3 MB - 95% decoded RGBA, 0 outlines
+FST-AT-8720-EN       344 pages:  913.0 MB - 94% decoded RGBA
+```
+
+Those documents reach **61.6 MB in a single page's record — 64% of the
+whole 96 MB budget each**, so two cannot coexist in the cache. For that
+class, image headroom is the entire problem and this change is irrelevant.
+
+## Testing note worth keeping
+
+The codec's existing round-trip oracle logs `glyphs=${run.glyphs?.length}`
+and **never looks at outline geometry**, so all 929 pre-existing tests would
+have passed against a dedup that returned the wrong glyph. The new tests
+compare paths directly, and each was confirmed to fail against the specific
+mutation it targets — dedup disabled, and the table returning the most
+recent entry instead of the referenced id.
+
+Zero Ghent baseline movement. pdf_cos 356, pdf_document 805, pdf_graphics
+933, dart_pdf_editor 1975, app 321.
+
+## What is left
+
+1. **Image headroom on the focused record** — now clearly the dominant term
+   for scanned/CAD documents (94–95% of record bytes; 61.6 MB single pages).
+   #473 already caps *prefetch* neighbours; the focused record is uncapped.
+   Note #473's cap also means a page is deliberately re-recorded when it
+   gains focus, which is some of the 3–5 records per page in the trace.
+
+2. **The RGBA and its source stream are both in the record**, and the same
+   pixels are also in the decoded-image cache — 222 MB across both caches in
+   the trace. Referencing images by content key instead of inlining them
+   would store them once, but a record whose images have been evicted can no
+   longer replay, so it needs a fallback path.
+
+3. **Untracked scheduler problems** the trace exposes, neither filed:
+   `PdfPageRenderScheduler` grants one request per frame to enforce "no frame
+   runs more than one page's walk", but `render` is a `VoidCallback` and on
+   the worker path returns before the expensive build happens — so the
+   serialization it exists to provide has silently lapsed, and builds run in
+   record-arrival order rather than focus order. Separately, **every focus
+   page is granted exactly twice** (`(22,22):2, (24,24):2, (25,25):2,
+   (27,27):2, (30,30):2, (31,31):2` while neighbours are granted once).
+
+4. **`flate` = 4.66 s over 120 calls** on the main isolate in the trace —
+   98.7% of all measured phase time, 54 MB inflated at 11.6 MB/s. Cumulative
+   and unattributed; needs a targeted trace before anyone acts on it.

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -52,7 +52,7 @@ import 'text_extraction.dart';
 /// Format: little notion of versioning beyond a leading byte; the producer and
 /// consumer are the same build, shipped together, so a version mismatch is a
 /// programming error, asserted on read.
-const int _formatVersion = 3;
+const int _formatVersion = 4;
 
 /// Microseconds spent reconstructing worker command buffers on the consuming
 /// isolate. Accumulated for performance probes; this is the UI-thread half of
@@ -1021,6 +1021,54 @@ PdfRenderCommand _readCommand(_Reader r) {
 // pixel-identically to shipping the original double (verified against the Ghent
 // baselines). Everything that needs full precision - transforms, colours,
 // stroke widths, text placement - stays float64.
+/// Writes one glyph placement's outline, by reference when its geometry has
+/// already been written to this record.
+///
+/// Text dominates a record's bytes, and the outline rides on every *placement*
+/// (`PdfGlyphPlacement.outline`), so a letter set 500 times used to serialize
+/// its geometry 500 times. Measured over a 62-page book at ratio 2.0, glyph
+/// outlines were 151.7 MB of 394 MB of records and 85% of that was literal
+/// repetition - more than the entire decoded-RGBA payload (83 MB). Records are
+/// held in a byte-budgeted LRU, so this is cache capacity, and capacity is what
+/// decides how often a page has to be re-recorded (#451).
+///
+/// Tag byte: 0 = no outline, 1 = geometry follows (and takes the next id),
+/// 2 = a u32 id of an outline already defined in this record.
+void _writeGlyphOutline(_Writer w, PdfPath? outline) {
+  if (outline == null) {
+    w.u8(0);
+    return;
+  }
+  final existing = w._outlineIds[outline];
+  if (existing != null) {
+    w.u8(2);
+    w.u32(existing);
+    return;
+  }
+  w._outlineIds[outline] = w._outlineIds.length;
+  w.u8(1);
+  _writePath(w, outline);
+}
+
+PdfPath? _readGlyphOutline(_Reader r) {
+  switch (r.u8()) {
+    case 0:
+      return null;
+    case 1:
+      final path = _readPath(r);
+      r._outlines.add(path);
+      return path;
+    case 2:
+      final id = r.u32();
+      if (id >= r._outlines.length) {
+        throw FormatException('glyph outline id $id out of range');
+      }
+      return r._outlines[id];
+    default:
+      throw const FormatException('unknown glyph outline tag');
+  }
+}
+
 void _writePath(_Writer w, PdfPath path) {
   w.u32(path.segments.length);
   for (final s in path.segments) {
@@ -1197,12 +1245,7 @@ void _writeTextRun(_Writer w, PdfTextRun run) {
       w.f64(g.offset);
       w.f64(g.offsetY);
       w.strOpt(g.text);
-      if (g.outline == null) {
-        w.boolean(false);
-      } else {
-        w.boolean(true);
-        _writePath(w, g.outline!);
-      }
+      _writeGlyphOutline(w, g.outline);
     }
   }
   w.boolean(run.invisible);
@@ -1248,7 +1291,7 @@ PdfTextRun _readTextRun(_Reader r) {
       final offset = r.f64();
       final offsetY = r.f64();
       final text = r.strOpt();
-      final outline = r.boolean() ? _readPath(r) : null;
+      final outline = _readGlyphOutline(r);
       glyphs[i] = PdfGlyphPlacement(
           offset: offset, offsetY: offsetY, outline: outline, text: text);
     }
@@ -1433,6 +1476,13 @@ class _Writer {
   late ByteData _view = ByteData.view(_buf.buffer);
   int _len = 0;
 
+  /// Glyph outlines already written, so a repeated glyph costs an index
+  /// instead of its geometry ([_writeGlyphOutline]). Keyed by object
+  /// identity - [PdfPath] does not override `==`, and the font engine hands
+  /// the same instance back for every placement of a glyph, so identity
+  /// catches essentially all of the repetition with no hashing of geometry.
+  final Map<PdfPath, int> _outlineIds = {};
+
   void _ensure(int extra) {
     final need = _len + extra;
     if (need <= _buf.length) return;
@@ -1535,6 +1585,12 @@ class _Reader {
   final Uint8List _bytes;
   final ByteData _data;
   int _o = 0;
+
+  /// Glyph outlines seen so far, indexed as the writer numbered them
+  /// ([_readGlyphOutline]). Repeated glyphs share one [PdfPath] instance -
+  /// which is also how they arrive from the font engine before serialization,
+  /// so the replayed commands hold no more copies than a local render.
+  final List<PdfPath> _outlines = [];
 
   int u8() => _data.getUint8(_o++);
 

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -429,6 +429,119 @@ void main() {
   // off-thread and embeds the premultiplied RGBA, so the reconstructed request
   // carries pixels that match the pure-Dart decode - and the replay transcript
   // is unchanged (the decode never alters the command shape).
+  // A glyph outline rides on every *placement*, so text-heavy records used to
+  // carry one copy of a letter's geometry per occurrence: 151.7 MB of 394 MB
+  // over a 62-page book, 85% of it repetition (#451). The writer now emits the
+  // geometry once and references it by id.
+  //
+  // The transcript oracle above cannot police this - it logs `glyphs.length`
+  // and never looks at outline geometry - so these compare the paths directly.
+  group('glyph outline deduplication (#451)', () {
+    // One glyph's geometry, deliberately chunky so repetition is measurable.
+    PdfPath outline(double seed) => PdfPath([
+          PdfMoveTo(seed, 0),
+          for (var i = 0; i < 40; i++)
+            PdfCubicTo(seed + i, 1.5, seed + i + 0.25, 2.5, seed + i + 0.5, 3),
+          const PdfClosePath(),
+        ]);
+
+    List<PdfRenderCommand> run(List<PdfPath?> outlines) => [
+          PdfDrawTextCommand(PdfTextRun(
+            text: 'x' * outlines.length,
+            transform: PdfMatrix.identity,
+            color: PdfColor.black,
+            width: outlines.length.toDouble(),
+            glyphs: [
+              for (final (i, o) in outlines.indexed)
+                PdfGlyphPlacement(offset: i.toDouble(), outline: o),
+            ],
+          )),
+        ];
+
+    List<PdfPath?> restoredOutlines(Uint8List bytes) => [
+          for (final c in deserializeCommands(bytes))
+            if (c is PdfDrawTextCommand)
+              ...?c.run.glyphs?.map((g) => g.outline),
+        ];
+
+    void expectSamePath(PdfPath? actual, PdfPath? expected, String reason) {
+      if (expected == null) {
+        expect(actual, isNull, reason: reason);
+        return;
+      }
+      expect(actual, isNotNull, reason: reason);
+      expect(actual!.segments.length, expected.segments.length, reason: reason);
+      for (var i = 0; i < expected.segments.length; i++) {
+        final a = actual.segments[i], b = expected.segments[i];
+        expect(a.runtimeType, b.runtimeType, reason: '$reason seg $i');
+        if (a is PdfMoveTo && b is PdfMoveTo) {
+          expect(a.x, closeTo(b.x, 1e-3), reason: '$reason seg $i');
+          expect(a.y, closeTo(b.y, 1e-3), reason: '$reason seg $i');
+        } else if (a is PdfCubicTo && b is PdfCubicTo) {
+          expect(a.x1, closeTo(b.x1, 1e-3), reason: '$reason seg $i');
+          expect(a.y3, closeTo(b.y3, 1e-3), reason: '$reason seg $i');
+          expect(a.x3, closeTo(b.x3, 1e-3), reason: '$reason seg $i');
+        }
+      }
+    }
+
+    test('a repeated glyph costs its geometry once', () {
+      final glyph = outline(1);
+      final one = serializeCommands(run([glyph]))!;
+      final many = serializeCommands(run(List.filled(200, glyph)))!;
+
+      // The 199 extra placements must not each carry the geometry. Budget a
+      // generous 32 bytes of per-placement bookkeeping (tag + id + offsets);
+      // the geometry itself is ~1 KB.
+      expect(many.length, lessThan(one.length + 199 * 32),
+          reason: 'repeated placements should reference, not re-emit');
+
+      // The control: 200 separately-constructed paths with identical geometry.
+      // The table keys on identity, so these do not collapse - which is what
+      // the format cost before this change, measured through the same writer.
+      final unshared =
+          serializeCommands(run([for (var i = 0; i < 200; i++) outline(1)]))!;
+      expect(many.length * 10, lessThan(unshared.length),
+          reason: 'sharing one glyph should cost <10% of emitting it 200x');
+    });
+
+    test('every placement reads back with its own geometry intact', () {
+      // Distinct shapes, interleaved and repeated, so a table that returned
+      // the wrong entry (or the most recent one) is caught.
+      final a = outline(1), b = outline(2), c = outline(3);
+      final order = <PdfPath?>[a, b, a, c, null, b, c, c, a, null, b];
+      final restored = restoredOutlines(serializeCommands(run(order))!);
+
+      expect(restored.length, order.length);
+      for (var i = 0; i < order.length; i++) {
+        expectSamePath(restored[i], order[i], 'placement $i');
+      }
+    });
+
+    test('repeated placements share one instance after the round trip', () {
+      // The dedup exists to shrink the record, but sharing on read-back also
+      // means the replayed commands hold one path per glyph instead of N -
+      // the same shape they had before serialization.
+      final glyph = outline(1);
+      final restored =
+          restoredOutlines(serializeCommands(run(List.filled(50, glyph)))!);
+      expect(restored, hasLength(50));
+      for (final o in restored) {
+        expect(identical(o, restored.first), isTrue,
+            reason: 'one glyph should deserialize to one shared PdfPath');
+      }
+    });
+
+    test('a truncated record throws rather than replaying a wrong glyph', () {
+      // Records cross an isolate/worker boundary, where a short read is a real
+      // failure mode. It must fail loudly, not hand back plausible geometry.
+      final glyph = outline(1);
+      final bytes = serializeCommands(run([glyph, glyph, glyph]))!;
+      expect(() => deserializeCommands(bytes.sublist(0, bytes.length - 4)),
+          throwsA(anything));
+    });
+  });
+
   group('image decode offload', () {
     test('uses predecoded image request pixels', () {
       final cos = CosDocument.open(buildClassicPdf());

--- a/packages/pdf_graphics/tool/bench_record_bytes.dart
+++ b/packages/pdf_graphics/tool/bench_record_bytes.dart
@@ -108,10 +108,17 @@ void main(List<String> args) {
       '(the pre-#451 format)');
   stdout.writeln('  ${_round(deduped)} MB collapsed by shape, across '
       '$distinct distinct outlines');
-  stdout.writeln('  -> ${_round(outline - deduped)} MB '
-      '(${((1 - deduped / outline) * 100).round()}%) is repetition.');
-  stdout.writeln('  Distinct by object identity (what a writer-side table '
-      'would see without hashing): $ident vs $distinct by value.');
+  if (outline > 0) {
+    stdout.writeln('  -> ${_round(outline - deduped)} MB '
+        '(${((1 - deduped / outline) * 100).round()}%) is repetition.');
+    stdout.writeln('  Distinct by object identity (what a writer-side table '
+        'would see without hashing): $ident vs $distinct by value.');
+  } else {
+    // Scanned and CAD documents reach here: no embedded font yields outlines,
+    // so the dedup has nothing to collapse and the record is dominated by the
+    // decoded RGBA above.
+    stdout.writeln('  (no glyph outlines on these pages)');
+  }
 
   // What the cache can hold. The viewer caches whole records, so a page's
   // image payload occupies the record budget for as long as the record is

--- a/packages/pdf_graphics/tool/bench_record_bytes.dart
+++ b/packages/pdf_graphics/tool/bench_record_bytes.dart
@@ -1,0 +1,263 @@
+// #451: what is actually *in* a render record, by bytes?
+//
+// The device trace (app 3.0.0+20, 62-page book, web release) showed a single
+// page's record reaching 39 MB against a 96 MB record-cache budget - so three
+// such pages fill the cache and every neighbour is evicted and re-recorded.
+// The trace measured 575 MB of records produced for 20 distinct pages.
+//
+// This splits a record by bytes rather than time, into the decoded RGBA, the
+// source image streams carried beside it, and everything else - plus the glyph
+// outlines inside that remainder, which turned out to be the largest single
+// item (151.7 MB of 394 MB over a 62-page book, 85% of it repetition).
+//
+//   fvm dart tool/bench_record_bytes.dart [dir-or-file ...]
+//
+// Defaults to the checked-in test corpora. `--json` emits machine-readable
+// rows; `--budget=N` sets the assumed record-cache budget in MB (default 96,
+// the viewer's pdfRenderWorkerCacheBudgetBytes).
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+const _ratio = 2.0;
+
+void main(List<String> args) {
+  final json = args.contains('--json');
+  final budgetMB = double.tryParse(args
+          .firstWhere((a) => a.startsWith('--budget='), orElse: () => '')
+          .replaceFirst('--budget=', '')) ??
+      96.0;
+  final paths = args.where((a) => !a.startsWith('--')).toList();
+  final files = _collect(paths.isEmpty
+      ? const ['../../test_corpora/ghent', '../../test_corpora/pdfjs']
+      : paths);
+  if (files.isEmpty) {
+    stderr.writeln('no PDFs found');
+    exit(1);
+  }
+
+  final rows = <Map<String, Object?>>[];
+  for (final file in files) {
+    final PdfDocument doc;
+    final CosDocument cos;
+    final int pageCount;
+    try {
+      final bytes = File(file).readAsBytesSync();
+      cos = CosDocument.open(bytes);
+      doc = PdfDocument.open(bytes);
+      pageCount = doc.pageCount;
+    } catch (_) {
+      continue;
+    }
+    for (var i = 0; i < pageCount; i++) {
+      try {
+        final row = _measurePage(doc, cos, i, file);
+        if (row != null) rows.add(row);
+      } catch (_) {
+        // a page that will not interpret is not this tool's problem
+      }
+    }
+  }
+
+  if (json) {
+    stdout.writeln(const JsonEncoder.withIndent(' ').convert(rows));
+    return;
+  }
+
+  rows.sort((a, b) => (b['totalMB'] as num).compareTo(a['totalMB'] as num));
+  stdout.writeln('\nRecord byte composition at ratio $_ratio '
+      '(${rows.length} pages)\n');
+  stdout.writeln('  totalMB   rgbaMB  outlnMB  dedupMB  '
+      'glyphs/byValue/byIdentity  page');
+  for (final r in rows.take(25)) {
+    stdout.writeln('  ${_pad(r['totalMB'])}  ${_pad(r['rgbaMB'])}  '
+        '${_pad(r['outlineMB'])}  ${_pad(r['dedupedOutlineMB'])}  '
+        '${'${r['glyphs']}/${r['distinctOutlines']}/${r['identityOutlines']}'.padLeft(18)}  '
+        '${r['page']}');
+  }
+
+  final total = rows.fold<double>(0, (a, r) => a + (r['totalMB'] as num));
+  final rgba = rows.fold<double>(0, (a, r) => a + (r['rgbaMB'] as num));
+  final stream = rows.fold<double>(0, (a, r) => a + (r['streamMB'] as num));
+  stdout.writeln('\n${rows.length} pages: ${_round(total)} MB of records.');
+  stdout.writeln('  ${_round(rgba)} MB (${(rgba / total * 100).round()}%) '
+      'decoded RGBA');
+  stdout.writeln('  ${_round(stream)} MB (${(stream / total * 100).round()}%) '
+      'source image streams, carried *beside* the RGBA');
+  stdout.writeln('  ${_round(total - rgba - stream)} MB '
+      '(${((total - rgba - stream) / total * 100).round()}%) draw commands '
+      'and other resources');
+
+  final outline = rows.fold<double>(0, (a, r) => a + (r['outlineMB'] as num));
+  final deduped =
+      rows.fold<double>(0, (a, r) => a + (r['dedupedOutlineMB'] as num));
+  final allGlyphs = rows.fold<int>(0, (a, r) => a + (r['glyphs'] as int));
+  final distinct =
+      rows.fold<int>(0, (a, r) => a + (r['distinctOutlines'] as int));
+  final ident =
+      rows.fold<int>(0, (a, r) => a + (r['identityOutlines'] as int));
+  // These two are the *logical* cost of the outlines - what they would cost
+  // written inline on every placement, and what they cost collapsed by shape.
+  // Since #451 the writer collapses them, so the deduped figure is what the
+  // record actually carries and the gap is what the dedup saves.
+  stdout.writeln('\nGlyph outlines across $allGlyphs placements:');
+  stdout.writeln('  ${_round(outline)} MB written inline per placement '
+      '(the pre-#451 format)');
+  stdout.writeln('  ${_round(deduped)} MB collapsed by shape, across '
+      '$distinct distinct outlines');
+  stdout.writeln('  -> ${_round(outline - deduped)} MB '
+      '(${((1 - deduped / outline) * 100).round()}%) is repetition.');
+  stdout.writeln('  Distinct by object identity (what a writer-side table '
+      'would see without hashing): $ident vs $distinct by value.');
+
+  // What the cache can hold. The viewer caches whole records, so a page's
+  // image payload occupies the record budget for as long as the record is
+  // retained - on top of the same pixels living in the decoded-image cache.
+  final big = rows.where((r) => (r['totalMB'] as num) > budgetMB / 4).toList();
+  stdout.writeln('${big.length} pages exceed a quarter of the '
+      '${budgetMB.round()} MB record budget on their own'
+      '${big.isEmpty ? '.' : ':'}');
+  for (final r in big.take(10)) {
+    stdout.writeln('  ${_pad(r['totalMB'])} MB  '
+        '(${((r['totalMB'] as num) / budgetMB * 100).round()}% of budget)  '
+        '${r['page']}');
+  }
+}
+
+Map<String, Object?>? _measurePage(
+    PdfDocument doc, CosDocument cos, int index, String path) {
+  final page = doc.page(index);
+  final recorder = RecordingPdfDevice();
+  PdfInterpreter(cos: cos, device: recorder)
+    ..drawPage(page)
+    ..drawAnnotations(page);
+  final commands = recorder.commands;
+
+  final record = serializeCommands(commands,
+      cos: cos, decodeImages: true, maxImagePixelRatio: _ratio);
+  if (record == null) return null;
+
+  // Before serialization: does the font engine hand back the *same* PdfPath
+  // for a repeated glyph? If so a writer-side table can dedupe on identity
+  // alone, with no value hashing in the hot path.
+  final identityOutlines = Set<PdfPath>.identity();
+  for (final c in commands) {
+    if (c is! PdfDrawTextCommand) continue;
+    for (final g in c.run.glyphs ?? const <PdfGlyphPlacement>[]) {
+      if (g.outline != null) identityOutlines.add(g.outline!);
+    }
+  }
+
+  // Measure the payload exactly rather than by differencing against a
+  // decodeImages:false run - that run still embeds every image's *encoded*
+  // stream, so the difference attributes those bytes to the commands.
+  //
+  // A record carries both halves for each image: the premultiplied RGBA the
+  // worker decoded, and the source stream beside it (device.dart:194 - "the
+  // [stream] is still serialized so the decoded pixels cache by content").
+  var rgbaBytes = 0, streamBytes = 0, decodedImages = 0;
+  // Glyph outlines ride on every *placement* (device.dart:50), so a letter
+  // used 500 times serializes its outline 500 times. Count both the bytes
+  // they cost and what they would cost deduplicated by shape.
+  var glyphs = 0, outlineBytes = 0;
+  final distinctOutlines = <String, int>{};
+  for (final c in deserializeCommands(record)) {
+    if (c is PdfDrawImageCommand) {
+      final decoded = c.request.decoded;
+      if (decoded != null) {
+        rgbaBytes += decoded.rgba.length;
+        decodedImages++;
+      }
+      streamBytes += c.request.stream.rawBytes.length;
+    } else if (c is PdfDrawTextCommand) {
+      for (final g in c.run.glyphs ?? const <PdfGlyphPlacement>[]) {
+        final outline = g.outline;
+        if (outline == null) continue;
+        glyphs++;
+        final bytes = _pathBytes(outline);
+        outlineBytes += bytes;
+        distinctOutlines[_pathKey(outline)] = bytes;
+      }
+    }
+  }
+  final dedupedOutlineBytes =
+      distinctOutlines.values.fold<int>(0, (a, b) => a + b);
+
+  const mb = 1 << 20;
+  final totalMB = record.length / mb;
+  final rgbaMB = rgbaBytes / mb;
+  final streamMB = streamBytes / mb;
+  return <String, Object?>{
+    'page': '${path.split('/').last} p$index',
+    'totalMB': _round(totalMB),
+    'rgbaMB': _round(rgbaMB),
+    'streamMB': _round(streamMB),
+    'otherMB': _round(totalMB - rgbaMB - streamMB),
+    'rgbaPct': totalMB <= 0 ? 0 : (rgbaMB / totalMB * 100).round(),
+    'images': recorder.imageRequests.length,
+    'decodedImages': decodedImages,
+    'commands': commands.length,
+    'glyphs': glyphs,
+    'distinctOutlines': distinctOutlines.length,
+    'identityOutlines': identityOutlines.length,
+    'outlineMB': _round(outlineBytes / mb),
+    'dedupedOutlineMB': _round(dedupedOutlineBytes / mb),
+  };
+}
+
+/// Bytes [_writePath] spends on [path]: a tag per segment plus float32 per
+/// coordinate (render_command_codec.dart - "Path coordinates are carried at
+/// float32 precision").
+int _pathBytes(PdfPath path) {
+  var bytes = 0;
+  for (final s in path.segments) {
+    bytes += switch (s) {
+      PdfMoveTo() || PdfLineTo() => 1 + 8,
+      PdfCubicTo() => 1 + 24,
+      PdfClosePath() => 1,
+    };
+  }
+  return bytes;
+}
+
+/// Identifies an outline by shape, so the same glyph drawn twice collapses.
+String _pathKey(PdfPath path) {
+  final b = StringBuffer();
+  for (final s in path.segments) {
+    switch (s) {
+      case PdfMoveTo(:final x, :final y):
+        b.write('M$x,$y;');
+      case PdfLineTo(:final x, :final y):
+        b.write('L$x,$y;');
+      case PdfCubicTo(:final x1, :final y1, :final x2, :final y2, :final x3,
+            :final y3):
+        b.write('C$x1,$y1,$x2,$y2,$x3,$y3;');
+      case PdfClosePath():
+        b.write('Z;');
+    }
+  }
+  return b.toString();
+}
+
+String _pad(Object? v) => (v as num).toStringAsFixed(1).padLeft(7);
+
+double _round(double v) => (v * 10).round() / 10;
+
+List<String> _collect(List<String> paths) {
+  final out = <String>[];
+  for (final p in paths) {
+    final dir = Directory(p);
+    if (dir.existsSync()) {
+      for (final e in dir.listSync(recursive: true)) {
+        if (e is File && e.path.toLowerCase().endsWith('.pdf')) out.add(e.path);
+      }
+    } else if (File(p).existsSync()) {
+      out.add(p);
+    }
+  }
+  out.sort();
+  return out;
+}


### PR DESCRIPTION
Follow-on to #598, driven by a device trace from that build (app 3.0.0+20, web release, 62-page / 24 MB book, 3 render workers).

## The trace reframed the ticket

Across ~16 s of scrolling over pages 18–38:

```
575 MB of render records produced for 20 distinct pages
 50 records, 3-5 per page (page 31: five)
193 MB of that is pure duplicate work
```

Both caches sat pinned at their ceiling — record 94.1 / 96 MB, decoded-image 128.1 / 134.2 MB. With single records at 33–39 MB, ~3 fill the cache while the window spans ~20 pages, so pages evict each other and get re-recorded. Pages 28 and 29 each paid a 1.2–1.6 s `serialize` **twice**. The result is **17.6 s of cumulative worker queueing against 20.4 s of work** — surfacing as `wait=943.9ms` on the *visible* page's interpret.

So record size matters as **cache capacity**, not as transfer bytes (transfer was 2.1 s across all 50 records).

## What is actually in a record

New tool: `packages/pdf_graphics/tool/bench_record_bytes.dart`.

```
62 pages: 394.0 MB of records
   83.1 MB (21%) decoded RGBA
   53.8 MB (14%) source image streams, carried beside the RGBA
  257.1 MB (65%) draw commands and other resources
      of which glyph outlines: 151.7 MB / 100062 placements, 85% repetition
```

**Glyph outlines were the largest single item — bigger than the entire decoded-image payload.** `PdfGlyphPlacement.outline` rides on every *placement*, so a letter set 500 times serialized its geometry 500 times.

## The change

The writer emits an outline's geometry once and references it by id thereafter. Format version 3 → 4.

Keyed on **object identity**, which is what makes it free: the font engine returns the same `PdfPath` instance for every placement of a glyph, so identity catches essentially all of it (8464 distinct by identity vs 7765 by value) with no geometry hashing in the hot path. Read-back shares one instance per glyph, matching the shape commands had before serialization.

Version bump is safe — records are in-memory only, producer and consumer ship together, and the app's IndexedDB caches hold PDF bytes and sessions, not records.

## Result — and where it does nothing

Byte counts are deterministic; two rounds gave identical figures.

| document | before | after | |
|---|---|---|---|
| tide-quickstart (the traced book) | 394.0 MB | **270.8 MB** | −31% |
| Flutter_CTO_Report | 423.5 MB | 413.1 MB | −2.5% |
| FST-AT-8720-EN | 927.1 MB | 913.0 MB | −1.5% |
| AMT-SP-101 | 208.3 MB | 207.0 MB | −0.6% |
| Combined Design Pack | 1261.3 MB | 1261.3 MB | 0% |
| ghent + pdfjs (495 pages) | 384.6 MB | 376.3 MB | −2.2% |

**The 31% is document-specific and should not be quoted as a general number.** It exists only where embedded fonts yield outlines. Scanned/CAD documents have none, and are dominated by something else:

```
Combined Design Pack  58 pages: 1261.3 MB - 95% decoded RGBA, 0 outlines
FST-AT-8720-EN       344 pages:  913.0 MB - 94% decoded RGBA
```

Those reach **61.6 MB in a single page's record — 64% of the whole budget each**, so two cannot coexist in the cache. For that class this change is irrelevant and image headroom is the entire problem.

## Testing

The codec's existing round-trip oracle logs `glyphs.length` and **never inspects outline geometry** — all 929 pre-existing tests would have passed against a dedup that returned the wrong glyph. The new tests compare paths directly, and each was confirmed to fail against the specific mutation it targets (dedup disabled; table returning the most recent entry instead of the referenced id).

Zero Ghent baseline movement. pdf_cos 356, pdf_document 805, pdf_graphics 933, dart_pdf_editor 1975, app 321.

## Follow-ups the trace exposed

1. **Image headroom on the focused record** — the dominant term for scanned/CAD documents. #473 caps prefetch neighbours; the focused record is uncapped. (#473's cap also deliberately re-records a page on focus, which is some of the 3–5 records per page.)
2. **RGBA and its source stream are both in the record**, and the same pixels are also in the decoded-image cache (222 MB across both in the trace).
3. **Two untracked scheduler problems.** `PdfPageRenderScheduler` grants one request per frame to enforce "no frame runs more than one page's walk", but `render` is a `VoidCallback` that on the worker path returns before the build happens — so that serialization has silently lapsed and builds run in record-arrival order, not focus order. Separately, **every focus page is granted exactly twice** while neighbours are granted once.
4. **`flate` = 4.66 s over 120 calls** on the main isolate — 98.7% of measured phase time, 54 MB at 11.6 MB/s. Cumulative and unattributed; needs a targeted trace first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)