### PR TITLE
fix(images): key the decoded-image cache by resolution on every path (#451)

### DIFF
--- a/packages/dart_pdf_editor/lib/src/image_decoder.dart
+++ b/packages/dart_pdf_editor/lib/src/image_decoder.dart
@@ -25,13 +25,23 @@ import 'performance_policy.dart';
 /// evict and stand in for the other (a blurry page, or a needlessly huge
 /// preview); the dimensions disambiguate them so each caches on its own.
 Object pdfImageKey(PdfImageRequest request) {
-  if (!request.isInline) return request.stream;
-  final content = PdfInlineImageKey(request.stream);
+  final content = pdfImageContentKey(request);
+  if (!request.isInline) return content;
   final decoded = request.decoded;
   return decoded == null
       ? content
       : PdfSizedImageKey(content, decoded.width, decoded.height);
 }
+
+/// Identifies [request]'s source image irrespective of the resolution anything
+/// decoded it at: stream identity for an XObject, a value key for an inline
+/// image (whose stream is synthesized fresh on every interpretation pass).
+///
+/// This is the base the shared cache's key is built on - see [decodeImages],
+/// which qualifies it with the size the image actually ends up at so every
+/// path addressing the same pixels agrees on one entry.
+Object pdfImageContentKey(PdfImageRequest request) =>
+    request.isInline ? PdfInlineImageKey(request.stream) : request.stream;
 
 /// A content key qualified by a decoded resolution - see [pdfImageKey].
 ///
@@ -288,10 +298,21 @@ Future<Map<Object, ui.Image>> decodeImages(
         ? null
         : _decodeTarget(cos, request, maxImagePixelRatio);
     // The returned map keys by the ratio-independent [pdfImageKey] so the paint
-    // side (which has no ratio) always matches. The shared cache keys by the
-    // target size too, so two zoom levels of the same image cache separately.
-    final cacheKey =
-        target == null ? key : PdfSizedImageKey(key, target.$1, target.$2);
+    // side (which has no ratio) always matches.
+    //
+    // The shared cache keys by the resolution the image *ends up at*, built on
+    // the content key rather than on [key], and it does so on every path. That
+    // is what lets a record carrying worker-decoded pixels and one that decodes
+    // the same image locally address a single entry (#451). Before, the two
+    // disagreed by shape: worker pixels produced a bare content key while a
+    // capped local decode produced a sized one, so the same pixels could be
+    // cached twice under different keys - and a record whose pixels were
+    // dropped would miss the entry its own decode had populated. They happened
+    // to coincide whenever the cap was a no-op, which hid it.
+    final size = _decodedSize(cos, request, target);
+    final cacheKey = size == null
+        ? key
+        : PdfSizedImageKey(pdfImageContentKey(request), size.$1, size.$2);
     final hit = cache?.take(cacheKey);
     if (hit != null) {
       out[key] = hit;
@@ -333,6 +354,34 @@ class _PendingDecode {
   final (int, int)? target;
 }
 
+/// The resolution [request]'s image ends up at, whichever path produced it:
+/// the pixels a worker already decoded, an explicit local [target], or the
+/// image's native size when nothing caps it. Null when the source declares no
+/// usable dimensions and there are no decoded pixels to measure.
+///
+/// [decodeImages] folds this into the shared cache key so all three paths
+/// address one entry - see the note there. Deliberately separate from
+/// [_decodeTarget]: that one answers "what should I ask the codec for" and
+/// keeps returning null for a no-op cap (so those images keep their
+/// byte-identical native decode), while this answers "what size will the
+/// result be", which is the question the cache key needs.
+(int, int)? _decodedSize(
+    CosDocument cos, PdfImageRequest request, (int, int)? target) {
+  final decoded = request.decoded;
+  if (decoded != null) return (decoded.width, decoded.height);
+  if (target != null) return target;
+  return _nativeSize(cos, request);
+}
+
+/// [request]'s declared source dimensions, or null when absent or degenerate.
+(int, int)? _nativeSize(CosDocument cos, PdfImageRequest request) {
+  final dict = request.stream.dictionary;
+  final w = _intOrNull(cos.resolve(dict['Width']));
+  final h = _intOrNull(cos.resolve(dict['Height']));
+  if (w == null || h == null || w < 1 || h < 1) return null;
+  return (w, h);
+}
+
 /// The display-capped decode size for [request]'s image, or null to decode at
 /// native resolution. Combines the image's native dimensions, its on-page
 /// footprint (from [PdfImageRequest.transform]), and [ratio] through the shared
@@ -343,10 +392,9 @@ class _PendingDecode {
 /// their byte-identical native decode and a bare cache key.
 (int, int)? _decodeTarget(
     CosDocument cos, PdfImageRequest request, double? ratio) {
-  final dict = request.stream.dictionary;
-  final w = _intOrNull(cos.resolve(dict['Width']));
-  final h = _intOrNull(cos.resolve(dict['Height']));
-  if (w == null || h == null || w < 1 || h < 1) return null;
+  final native = _nativeSize(cos, request);
+  if (native == null) return null;
+  final (w, h) = native;
   final t = request.transform;
   // The unit image square maps to page space through [transform]; the edge
   // lengths in points are the column norms.

--- a/packages/dart_pdf_editor/test/image_decoder_test.dart
+++ b/packages/dart_pdf_editor/test/image_decoder_test.dart
@@ -947,4 +947,142 @@ void main() {
       });
     });
   });
+
+  // The shared cache used to key worker-decoded pixels and locally-decoded
+  // pixels by different *shapes*: a request carrying pixels produced a bare
+  // content key, while a capped local decode produced a sized one. The same
+  // image could therefore occupy two entries, and a record whose pixels were
+  // dropped would miss the entry its own decode had populated. The two shapes
+  // coincided whenever the resolution cap happened to be a no-op, which is why
+  // it went unnoticed - so these pin both directions (#451).
+  group('cache key shape (#451)', () {
+    // A 2x2 image, and "worker" pixels for it in a colour a real decode of
+    // that stream would never produce. If a later local decode returns this
+    // colour, it resolved through the cache rather than decoding again -
+    // which is exactly what a shared key buys.
+    CosStream red2x2() => CosStream(
+          CosDictionary({
+            'Width': const CosInteger(2),
+            'Height': const CosInteger(2),
+            'BitsPerComponent': const CosInteger(8),
+            'ColorSpace': const CosName('DeviceRGB'),
+          }),
+          Uint8List.fromList([
+            for (var i = 0; i < 4; i++) ...[255, 0, 0],
+          ]),
+        );
+
+    PdfDecodedPixels marker(int w, int h) => PdfDecodedPixels(
+          Uint8List.fromList([
+            for (var i = 0; i < w * h; i++) ...[0, 255, 0, 255],
+          ]),
+          w,
+          h,
+        );
+
+    // A big image drawn small, so the resolution cap genuinely binds. That
+    // matters: for an image the cap leaves alone, `_decodeTarget` returns null
+    // and the old and new key shapes coincide - so a test on a small image
+    // passes either way and proves nothing.
+    CosStream big() => CosStream(
+          CosDictionary({
+            'Width': const CosInteger(64),
+            'Height': const CosInteger(64),
+            'BitsPerComponent': const CosInteger(8),
+            'ColorSpace': const CosName('DeviceRGB'),
+          }),
+          Uint8List.fromList([
+            for (var i = 0; i < 64 * 64; i++) ...[255, 0, 0],
+          ]),
+        );
+
+    testWidgets('worker-decoded and locally-decoded pixels share one entry',
+        (tester) async {
+      await tester.runAsync(() async {
+        final stream = big();
+        // 64x64 native drawn into an 8x8pt box at 0.5 px/pt.
+        final small = PdfMatrix(8, 0, 0, 8, 0, 0);
+        const ratio = 0.5;
+
+        // Discover the size the cap lands on rather than hard-coding the
+        // headroom arithmetic, then confirm it really did bind.
+        final probe = await decodeImages(
+            cos, [PdfImageRequest(stream: stream, transform: small)],
+            maxImagePixelRatio: ratio);
+        final capped = probe[stream]!;
+        expect(capped.width, lessThan(64),
+            reason: 'the cap must bind, or this test proves nothing');
+        final (cw, ch) = (capped.width, capped.height);
+
+        // The worker path: a record carrying pixels already decoded to that
+        // same capped size.
+        final cache = PdfImageCache();
+        final fromWorker = await decodeImages(
+            cos,
+            [
+              PdfImageRequest(
+                  stream: stream, transform: small, decoded: marker(cw, ch)),
+            ],
+            cache: cache);
+        expect(await pixelsOf(fromWorker[stream]!), marker(cw, ch).rgba);
+
+        // Then the same image with no pixels attached - the shape a record
+        // takes once its RGBA has been dropped. It must find the entry the
+        // worker path populated instead of decoding the stream afresh.
+        final local = await decodeImages(
+            cos, [PdfImageRequest(stream: stream, transform: small)],
+            cache: cache, maxImagePixelRatio: ratio);
+        expect(await pixelsOf(local[stream]!), marker(cw, ch).rgba,
+            reason: 'a local decode should hit the entry worker pixels stored');
+      });
+    });
+
+    testWidgets('two resolutions of one image still cache separately',
+        (tester) async {
+      await tester.runAsync(() async {
+        // The other direction: unifying the shape must not let a sharp decode
+        // and a small one stand in for each other. Distinct sizes, distinct
+        // marker pixels; each must come back as itself.
+        final cache = PdfImageCache();
+        final stream = red2x2();
+
+        final sharp = await decodeImages(
+            cos,
+            [
+              PdfImageRequest(
+                  stream: stream,
+                  transform: PdfMatrix.identity,
+                  decoded: marker(2, 2)),
+            ],
+            cache: cache);
+        expect(await pixelsOf(sharp[stream]!), marker(2, 2).rgba);
+
+        final tiny = await decodeImages(
+            cos,
+            [
+              PdfImageRequest(
+                  stream: stream,
+                  transform: PdfMatrix.identity,
+                  decoded: marker(1, 1)),
+            ],
+            cache: cache);
+        final tinyPixels = tiny[stream]!;
+        expect(tinyPixels.width, 1,
+            reason: 'the 1x1 decode must not be served the 2x2 entry');
+        expect(await pixelsOf(tinyPixels), marker(1, 1).rgba);
+
+        // And the sharp one must still be intact afterwards.
+        final again = await decodeImages(
+            cos,
+            [
+              PdfImageRequest(
+                  stream: stream,
+                  transform: PdfMatrix.identity,
+                  decoded: marker(2, 2)),
+            ],
+            cache: cache);
+        expect(again[stream]!.width, 2);
+      });
+    });
+  });
 }


### PR DESCRIPTION
Prerequisite for the record-headroom work on #451. Splitting it out because it is a correctness fix in its own right and is testable without a device.

## The bug

The shared decoded-image cache keyed the two decode paths by different **shapes**:

- a request carrying worker-decoded pixels takes `target == null`, so its cache key was the **bare content key**;
- a local decode whose resolution cap binds produced **`PdfSizedImageKey(key, tw, th)`**.

So the same image could occupy two entries under two keys, and neither could serve the other.

The two shapes coincide whenever the cap is a no-op — which is the common case, and is why this went unnoticed. On the 62-page book behind #451, **all 258 images decode at `scale 1.00`**, so the cap never binds and the keys always agreed there.

## The fix

Both paths now build the key from the content key qualified by the resolution the image *actually ends up at*: the worker's decoded dimensions, an explicit local target, or the native size when nothing caps it.

`_decodeTarget` is deliberately untouched and still returns null for a no-op cap, so what gets asked of the codec — and therefore every decoded pixel — is unchanged. Only the key is. `pdfImageKey` is also unchanged: it stays ratio-independent because the paint side has no ratio, and the new `pdfImageContentKey` just exposes the base it was already computing.

## Why it matters beyond the duplicate entries

This is what makes dropping a cached record's RGBA safe. Once a record's images are hydrated into `ui.Image`s, the RGBA inside the cached record is dead weight — but a pixel-stripped record decodes *locally*, and before this it would have missed the entry its own worker decode had populated, caching the same pixels twice instead of removing a copy. That change (page 27's cached record: 35.7 MB → ~3.3 MB) is the follow-up.

## Testing

Two tests pin both directions: a local decode hits the entry worker pixels stored, and two resolutions of one image still cache separately.

The first deliberately uses a 64×64 image drawn into an 8×8pt box **so the cap binds**. An earlier version used a 2×2 image and passed against both the old and new shapes — proving nothing, for exactly the reason the bug survived this long. Both tests were confirmed to fail against the old key shape, each for its own reason.

Zero Ghent baseline movement. pdf_graphics 953, dart_pdf_editor 1978, app 321 all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)