### PR TITLE
perf(editor): budget the thumbnail record to its tile and keep the warm off the platform thread (#603)

### DIFF
--- a/doc/dev-log/2026-07-25-thumbnail-warm-platform-thread.md
+++ b/doc/dev-log/2026-07-25-thumbnail-warm-platform-thread.md
@@ -1,0 +1,125 @@
+# Thumbnail warm: budget the record to the tile, and stop competing for the platform thread (#603)
+
+A ~20.8 s capture of scrolling a 62-page / 24 MB book (web release, 3
+render workers) totalled **~6.7 s of main-thread `replay`** across the
+background thumbnail warm — more, per tile, than the pages those tiles
+preview (`build=44–472 ms` against `replay=376–860 ms`). The warm's
+existing throttles are all on the *worker* side (priority 3 vs 2, decline
+the UI-thread fallback), and none of them reach the half of a thumbnail
+that runs on the platform thread: `PdfPageRenderer.pictureFromCommands`
+plus the rasterize.
+
+Three things were wrong, and they are three separate fixes.
+
+## 1. The page image budget was a multiple of the wrong raster
+
+`serializeCommands`' page image budget bounds the *total* decoded image
+pixels a buffer may carry, because a sheet layered from dozens of
+overlapping raster tiles sums to many times the page raster even when
+every individual image is capped to its own on-screen footprint. The
+budget was `imageBudgetFactor × _maxImagePixels`, and `_maxImagePixels`
+(1 << 24, ~17 MP) is documented as "the viewer's full-page raster cap, so
+it is also the natural unit for the page image budget."
+
+It is the *cap*, not the raster. A 256px-wide tile of a Letter page
+rasterizes ~85 000 pixels. Budgeting it 17 MP is 200× what it can ever
+show — which is how a warm thumbnail ended up producing ~10 MB records
+(`page=49 … 9955392B`), and how the main thread ended up building
+`ui.Image`s for every one of those pixels at replay.
+
+So `serializeCommands` gained `pageRasterPixels`: how many pixels the
+raster this buffer is drawn into actually has. The budget becomes
+`min(factor × 17 MP, headroom² × factor × pageRasterPixels)`.
+
+- `headroom` is `cappedImagePixelSize`'s own 2× linear headroom, squared.
+  That makes the new term a **no-op for a single full-bleed image** — a
+  lone underlay a page render legitimately wants at 2× is never scaled
+  by the page budget. It only bites where the per-image cap can't help:
+  many images summing past the raster.
+- It is a floor under the 17 MP cap, never a raise. `pageRasterPixels:
+  1 << 30` serializes byte-identically to passing nothing.
+
+**No wire change.** Both worker entries already know the page and the
+ratio, so they compute it themselves via the new
+`pdfPageRasterPixels(page.cropBox, imagePixelRatio)` and pass it to their
+`serializeCommands` calls (`render_worker_isolate.dart`'s one-shot,
+resumable-final and partial paths; `render_worker_web_entry.dart`'s
+`_recordPageAsync`). The strip-detail paths are left alone — an
+`imageDecodeRegion` already derives its own budget from the region.
+
+Measured on `buildSyntheticRasterUnderlaySheet` (3 × 1400×1000 underlays
+with soft masks), recorded at the tile ratio:
+
+| tile | record bytes | decoded pixels |
+| --- | --- | --- |
+| 256px | 2 312 080 → 830 320 (−64%) | 556 032 → 185 592 |
+| 128px | 643 984 → 274 432 (−57%) | 139 008 → 46 620 |
+
+The record does not shrink by the full decoded delta because the source
+streams are still written beside the pixels to key the decode by content
+— that floor is #451's, not this one's.
+
+## 2. The thumbnail replay decoded declined images at native size
+
+`rasterizeThumbnail` passed `imagePixelRatio: ratio` to the worker but
+called `pictureFromCommands` with no `maxImagePixelRatio`. Any image the
+worker's codec declined (`declined=57(decodeNull:7,notDct:50)` in the
+capture) arrives un-decoded, so it decoded at its **native** resolution —
+on the platform thread — to fill a 256px tile. `PdfPageView` had always
+passed the cap on this path; the thumbnail never did.
+`pictureFromCommands` gained the parameter (it only existed on
+`pictureFromCommandsWithPlan`) and the thumbnail passes its own ratio.
+
+## 3. The warm competed with the viewer, and nothing said so
+
+`PdfThumbnailCache`'s warm loop yielded on `_foregroundBusy` — but that
+only tracks *thumbnail tile* tasks. Across the capture the warmer walked
+pages 29→53 while the user scrolled 27→41, and the visible page's `wait=`
+ran 244–938 ms over fourteen pages.
+
+`PdfPageRenderScheduler` now exposes `busy` (a hold is up, or pages are
+queued for their first interpret) and `activity` (a bare `Listenable`
+pinged whenever `busy` may have moved). `PdfViewerController` republishes
+them as `isPageRenderBusy` / `pageRenderActivity`, and both thumbnail
+panels bind them into the shared cache with
+`PdfThumbnailCache.bindForegroundGate`. The warm now returns before
+starting a page while the viewer is rendering, and the activity ping —
+not a frame poll — is what resumes it.
+
+**The trap: `parked` ≠ `holding`.** `PdfViewer.active: false` sets
+`holding = true` forever, and the full-area page grid (`PdfEditorView`'s
+`showThumbnailView`) overlays the viewer with exactly that. Gating on
+`holding` alone would have deadlocked the grid's own warm behind a hold
+that never lifts. So the scheduler carries a separate `parked` flag, set
+alongside every `holding = … || !widget.active`, and `busy` is
+`!parked && (holding || pending)`. `render_scheduler_test.dart` and a
+widget test in `editing_thumbnail_cache_test.dart` (a strip beside an
+`active: false` viewer must still warm all pages) pin it.
+
+The controller-side listenable is a `_PdfForwardingListenable`: the
+controller outlives the viewer state, so a gate subscribed directly to a
+live scheduler would be left holding a disposed object when the host
+reparents the viewer. Swapping its `source` moves the subscription and
+fires once.
+
+Finally, the replay is wrapped in its own `TimelineTask` slice
+(`thumbnail replay`, tagged page + reason), so a DevTools capture
+attributes a stolen frame to the thumbnail that stole it instead of
+leaving it indistinguishable from foreground work — the issue's "nothing
+currently attributes it."
+
+## What is deliberately not here
+
+- **Command culling for a thumbnail-grade record** (the issue's first
+  direction). Checked before writing it: the pages in the capture are
+  1400–1800 commands of *book text*, and 9 pt text at the tile's 0.42
+  ratio is still ~3.8 device pixels — nothing sub-pixel to drop. Culling
+  would pay an O(commands) bounds pass to save approximately nothing on
+  the document that filed the bug. It is the right tool for a CAD sheet,
+  not for this.
+- **Deriving the thumbnail from an existing page raster** (direction 2).
+  The viewer's page rasters live in `PdfPageView`'s tile store, not
+  anywhere the thumbnail panels can reach; wiring that across is a
+  larger change than these three.
+- **Not shipping the source stream beside decoded pixels.** That is the
+  remaining floor under the record size, and it is #451.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -419,6 +419,11 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     if (mounted) setState(() {});
   }
 
+  /// The gate the shared cache's background warm consults: true while the
+  /// viewer still has foreground page work in flight. See
+  /// [PdfThumbnailCache.bindForegroundGate].
+  bool _viewerRenderBusy() => widget.viewerController.isPageRenderBusy;
+
   /// Pushes the strip's scroll position into the shared cache as the render
   /// focus, so the tiles nearest the visible band render before the rest.
   void _onScroll() {
@@ -543,6 +548,11 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // yields to every visible tile, so it never delays one.
     final pixelWidth =
         _thumbnailBucket(_tileWidth * MediaQuery.devicePixelRatioOf(context));
+    // ...and hold it off entirely while the viewer is rendering: the warm's
+    // replay/rasterize run on the platform thread, so a lower worker priority
+    // alone still lets it land on the frame the visible page needs (#603).
+    _cache.bindForegroundGate(
+        widget.viewerController.pageRenderActivity, _viewerRenderBusy);
     _cache.setWarm(
       this,
       controller.document.pageCount,
@@ -1180,6 +1190,11 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
     if (mounted) setState(() {});
   }
 
+  /// The gate the shared cache's background warm consults: true while the
+  /// viewer still has foreground page work in flight. See
+  /// [PdfThumbnailCache.bindForegroundGate].
+  bool _viewerRenderBusy() => widget.viewerController.isPageRenderBusy;
+
   /// Pushes the grid's scroll position into the shared cache as the render
   /// focus, so the rows on screen render before the rest of the document and
   /// scrolling re-prioritizes toward what just came into view.
@@ -1358,6 +1373,9 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
     // paced loop that yields to every visible cell, so it never delays one.
     final pixelWidth = _thumbnailBucket(
         (tileWidth - 21) * MediaQuery.devicePixelRatioOf(context));
+    // see the strip's copy: the warm stands down while the viewer renders
+    _cache.bindForegroundGate(
+        widget.viewerController.pageRenderActivity, _viewerRenderBusy);
     _cache.setWarm(
       this,
       controller.document.pageCount,
@@ -2652,8 +2670,18 @@ Future<ui.Image?> rasterizeThumbnail({
       trace.instant('worker.record',
           arguments: {'ms': recordMs, 'commands': commands.length});
       sw.reset();
-      final picture = await PdfPageRenderer.pictureFromCommands(page, commands,
-          pageColor: pageColor);
+      // The replay is the one part of a thumbnail that CANNOT leave the
+      // platform thread, so it gets the tile's own resolution too: any image
+      // the worker's codec declined arrives un-decoded, and without the cap it
+      // would decode at native size here - a 10-megapixel scan run through the
+      // pure-Dart codec to fill a 256px tile (#603). Sliced into the timeline
+      // as its own span so a trace attributes it to the thumbnail rather than
+      // to whatever frame it lands in.
+      final picture = await _timedReplay(
+          pageIndex,
+          reason,
+          () => PdfPageRenderer.pictureFromCommands(page, commands,
+              pageColor: pageColor, maxImagePixelRatio: ratio));
       final replayMs = sw.elapsedMicroseconds / 1000.0;
       sw.reset();
       try {
@@ -2700,6 +2728,25 @@ Future<ui.Image?> rasterizeThumbnail({
 }
 
 String _traceMs(double v) => '${v.toStringAsFixed(1)}ms';
+
+/// Wraps a thumbnail's command replay in its own async timeline slice.
+///
+/// The replay builds a `ui.Picture` on the platform thread - the same thread
+/// the visible page's build needs - so in a DevTools capture it is otherwise
+/// indistinguishable from foreground work. A named slice per page/reason is
+/// what lets a trace say "this frame went to warming page 47's thumbnail"
+/// (#603). Free when nothing is recording.
+Future<T> _timedReplay<T>(
+    int pageIndex, String reason, Future<T> Function() replay) async {
+  final flow = TimelineTask()
+    ..start('thumbnail replay',
+        arguments: {'page': pageIndex, 'reason': reason});
+  try {
+    return await replay();
+  } finally {
+    flow.finish();
+  }
+}
 
 /// Marks the viewer's viewport on a thumbnail: [region] is the visible
 /// part of the page as fractions of its area.

--- a/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:developer' show Timeline;
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../budgeted_cache.dart';
@@ -73,6 +74,36 @@ class PdfThumbnailCache {
   bool _draining = false;
   int _focus = 0;
 
+  Listenable? _gateActivity;
+  bool Function()? _gateBusy;
+
+  /// Binds the *viewer's* foreground-render signal to the background warm.
+  ///
+  /// [isBusy] is polled before every warm page and [activity] re-kicks the
+  /// loop when it may have gone idle - so a warm pass stands down for the whole
+  /// time the viewer is scrolling or has pages queued for their first
+  /// interpret, not just while another thumbnail tile is rendering.
+  ///
+  /// The gate exists because the warm's cost is not where its throttles are.
+  /// It already renders at a lower worker priority and declines the UI-thread
+  /// fallback, but the record it gets back still has to be replayed into a
+  /// `ui.Picture` and rasterized *here*, on the platform thread the visible
+  /// page's build needs and the one thing that cannot move to an isolate. A
+  /// 20 s scroll measured ~6.7 s of that replay landing on foreground frames
+  /// (#603); a worker priority cannot govern it, only not starting can.
+  ///
+  /// Passing nulls unbinds. Rebinding the same [activity] just refreshes
+  /// [isBusy], so calling this from a build is cheap.
+  void bindForegroundGate(Listenable? activity, bool Function()? isBusy) {
+    if (_disposed) return;
+    _gateBusy = isBusy;
+    if (identical(_gateActivity, activity)) return;
+    _gateActivity?.removeListener(_kickWarm);
+    _gateActivity = activity;
+    _gateActivity?.addListener(_kickWarm);
+    _kickWarm();
+  }
+
   /// The page index nearest the viewport. Foreground tasks (and the warm
   /// loop) closest to it are served first; pushing a new focus (a panel
   /// scrolled) re-orders the work toward what just came into view.
@@ -88,6 +119,11 @@ class PdfThumbnailCache {
   /// Whether any on-screen tile is queued or rendering - the warm loop holds
   /// off while this is true so the visible pages always win the worker.
   bool get _foregroundBusy => _draining || _pending.isNotEmpty;
+
+  /// Whether the viewer itself is still rendering pages (see
+  /// [bindForegroundGate]). Unbound - a panel with no viewer - reads false, so
+  /// the warm behaves exactly as it did before the gate existed.
+  bool get _viewerBusy => _gateBusy?.call() ?? false;
 
   /// Registers (or refreshes) [token]'s request to render on-screen tile
   /// [pageIndex]. [run] is invoked when the task's turn comes - the queue
@@ -200,6 +236,7 @@ class PdfThumbnailCache {
   /// swapped). A no-op if another owner has since taken over.
   void clearWarm(Object owner) {
     if (!identical(_warmOwner, owner)) return;
+    bindForegroundGate(null, null);
     _warmOwner = null;
     _warmRenderer = null;
     _warmSignature = null;
@@ -222,6 +259,15 @@ class PdfThumbnailCache {
         if (_foregroundBusy) {
           PdfPerfLog.log('thumbnail warm yields - foreground busy '
               '(pending=${_pending.length} draining=$_draining)');
+          return;
+        }
+        // ...and never while the VIEWER is rendering: the warm's replay and
+        // rasterize run on the platform thread, so starting one mid-scroll
+        // buys a background thumbnail at the cost of the page the user is
+        // actually looking at (#603). The gate's activity listener re-kicks
+        // this loop when the viewer goes idle.
+        if (_viewerBusy) {
+          PdfPerfLog.log('thumbnail warm yields - viewer rendering');
           return;
         }
         final page = _nextWarmPage();
@@ -289,6 +335,9 @@ class PdfThumbnailCache {
     _disposed = true;
     _pending.clear();
     _warmRenderer = null;
+    _gateActivity?.removeListener(_kickWarm);
+    _gateActivity = null;
+    _gateBusy = null;
     _images.dispose(); // clears every raster and unregisters from the registry
   }
 }

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -438,6 +438,25 @@ class PdfViewerController extends ChangeNotifier {
   @visibleForTesting
   bool get debugRenderHold => _state?._renderScheduler.holding ?? false;
 
+  /// Whether the attached viewer still has foreground page work in flight: a
+  /// scroll holding renders back, or pages queued for their first interpret.
+  /// False when no viewer is attached.
+  ///
+  /// Background passes that build pictures on the platform thread - the page
+  /// thumbnail panels' whole-document warm - stand down while this is true, so
+  /// they cannot land a replay on top of the frame the visible page needs. A
+  /// lower render-worker priority does not cover this: the worker orders the
+  /// isolate's queue, but the replay that follows every record runs here (#603).
+  /// Pair it with [pageRenderActivity] to know when to resume.
+  bool get isPageRenderBusy => _state?._renderScheduler.busy ?? false;
+
+  /// Notifies whenever [isPageRenderBusy] may have changed. Never null - it
+  /// forwards whichever viewer is attached, so a listener survives the viewer
+  /// being swapped underneath it.
+  Listenable get pageRenderActivity => _pageRenderActivity;
+  final _PdfForwardingListenable _pageRenderActivity =
+      _PdfForwardingListenable();
+
   String _selectedText = '';
 
   /// The currently selected text, '' with no selection. Drag with a mouse
@@ -633,6 +652,7 @@ class PdfViewerController extends ChangeNotifier {
   @override
   void dispose() {
     _viewport.dispose();
+    _pageRenderActivity.dispose();
     super.dispose();
   }
 
@@ -741,6 +761,33 @@ class PdfViewerController extends ChangeNotifier {
 /// way to hand out a bare [Listenable] the viewer can fire.
 class _ViewportNotifier extends ChangeNotifier {
   void notify() => notifyListeners();
+}
+
+/// A [Listenable] that relays whichever [source] is currently attached.
+///
+/// The controller outlives the viewer state it drives (and can be handed a new
+/// one when the host reparents the viewer), so a listener that subscribed to
+/// the live render scheduler directly would be left holding a disposed object.
+/// This sits in between: swapping [source] moves the subscription and fires
+/// once, so listeners re-read through the controller and see the new truth.
+class _PdfForwardingListenable extends ChangeNotifier {
+  Listenable? _source;
+
+  Listenable? get source => _source;
+  set source(Listenable? next) {
+    if (identical(_source, next)) return;
+    _source?.removeListener(notifyListeners);
+    _source = next;
+    _source?.addListener(notifyListeners);
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _source?.removeListener(notifyListeners);
+    _source = null;
+    super.dispose();
+  }
 }
 
 /// How [PdfViewer] zooms the document when it first appears.
@@ -1544,6 +1591,7 @@ class _PdfViewerState extends State<PdfViewer>
 
   void _settleRenderHold() {
     _renderScheduler.holding = _motionRenderHoldActive || !widget.active;
+    _renderScheduler.parked = !widget.active;
   }
 
   void _beginMotionRenderHold() {
@@ -1719,6 +1767,7 @@ class _PdfViewerState extends State<PdfViewer>
     _controller = widget.controller ?? PdfViewerController();
     _ownsController = widget.controller == null;
     _controller._state = this;
+    _controller._pageRenderActivity.source = _renderScheduler.activity;
     widget.performance?.addListener(_onPerformanceChanged);
     if (widget.performance != null) {
       SchedulerBinding.instance.addTimingsCallback(_onPerformanceTimings);
@@ -1726,6 +1775,7 @@ class _PdfViewerState extends State<PdfViewer>
     // mounted already paused (overlaid by another view) - hold rendering from
     // the first frame so covered pages never interpret
     if (!widget.active) _renderScheduler.holding = true;
+    _renderScheduler.parked = !widget.active;
     _pendingViewport = widget.initialViewport;
     // subscribe to the revision controller directly: it owns the document
     // revisions, so the viewer reads the current one and rebuilds itself when
@@ -2288,6 +2338,7 @@ class _PdfViewerState extends State<PdfViewer>
         'hold=${hold ? 'ON' : 'off'}');
     // a paused viewer (overlaid by another view) holds unconditionally
     _renderScheduler.holding = hold || !widget.active;
+    _renderScheduler.parked = !widget.active;
   }
 
   @override
@@ -2364,6 +2415,7 @@ class _PdfViewerState extends State<PdfViewer>
     // the viewer was paused (e.g. the full-area page grid overlaid it) and is
     // foreground again - release the render hold and resume the prerender
     if (oldWidget.active != widget.active) {
+      _renderScheduler.parked = !widget.active;
       if (!widget.active) {
         _renderScheduler.holding = true;
       } else {
@@ -2644,7 +2696,12 @@ class _PdfViewerState extends State<PdfViewer>
     // controller still points here, or the new viewer is severed and every
     // controller call (jumpToPage, visiblePageRegion, search) silently
     // no-ops
-    if (identical(_controller._state, this)) _controller._state = null;
+    if (identical(_controller._state, this)) {
+      _controller._state = null;
+      // the scheduler is about to be disposed; stop forwarding it, and tell
+      // anyone gated on it that nothing is busy any more
+      _controller._pageRenderActivity.source = null;
+    }
     if (_ownsController) _controller.dispose();
     _scroll.dispose();
     _transform.dispose();

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'perf_log.dart';
@@ -28,6 +29,40 @@ class PdfPageRenderScheduler {
   int _focus = 0;
   bool _draining = false;
   bool _disposed = false;
+  final _activity = _Activity();
+
+  /// Notifies whenever [busy] may have changed - a hold raised or lowered, a
+  /// request queued, the queue drained. Background work that must not compete
+  /// with the viewer for the platform thread (the thumbnail warm) listens here
+  /// to know when to stand down and when to resume, instead of polling frames.
+  Listenable get activity => _activity;
+
+  /// Whether the viewer still has foreground page work in flight: a scroll is
+  /// holding renders back, or pages are queued for their first interpret.
+  ///
+  /// This is the *platform-thread* gate. The render worker's own priorities
+  /// order the isolate's queue, but the picture build and rasterization that
+  /// follow every record run here, on the one thread the visible page's build
+  /// also needs - so a background pass that only lowers its worker priority
+  /// still lands its replay on top of a foreground frame (#603).
+  ///
+  /// A [parked] viewer reads idle however much it has queued: it is overlaid
+  /// by another view and will not render any of it, so it is not competing for
+  /// anything. Without that the full-area page grid - which parks the viewer
+  /// it covers - would gate its own thumbnails behind a hold that never lifts.
+  bool get busy => !_parked && (_holding || _pending.isNotEmpty);
+
+  bool _parked = false;
+
+  /// True while the viewer is overlaid by another view and renders nothing
+  /// (`PdfViewer.active` false). Distinct from [holding], which is a *live*
+  /// viewer deferring work it still intends to do.
+  bool get parked => _parked;
+  set parked(bool value) {
+    if (_parked == value || _disposed) return;
+    _parked = value;
+    _activity.ping();
+  }
 
   /// True while a fast scroll is in flight: the viewer raises it from its
   /// velocity estimate. No request is granted while held; lowering it
@@ -39,6 +74,7 @@ class PdfPageRenderScheduler {
     PdfPerfLog.log('renderHold ${_holding ? 'ON' : 'off'} '
         '(pending=${_pending.length} focus=$_focus)');
     if (!_holding) _scheduleDrain();
+    _activity.ping();
   }
 
   /// The page index nearest the viewport. Pending requests closest to it
@@ -69,12 +105,15 @@ class PdfPageRenderScheduler {
     }
     _pending.add(_RenderRequest(token, priority, render));
     _scheduleDrain();
+    _activity.ping();
   }
 
   /// Withdraws [token]'s pending request - its page rendered another way,
   /// or was disposed before its turn.
   void cancel(Object token) {
+    final before = _pending.length;
     _pending.removeWhere((r) => identical(r.token, token));
+    if (_pending.length != before) _activity.ping();
   }
 
   void _scheduleDrain() {
@@ -116,14 +155,36 @@ class PdfPageRenderScheduler {
       }
     } finally {
       _draining = false;
+      _activity.ping();
     }
   }
 
   /// Drops all pending requests and stops granting. Safe to call more
   /// than once.
   void dispose() {
+    if (_disposed) return;
     _disposed = true;
     _pending.clear();
+    _activity.ping();
+    _activity.dispose();
+  }
+}
+
+/// A bare [Listenable] the scheduler pings when [PdfPageRenderScheduler.busy]
+/// may have moved. Deliberately not a value notifier: listeners re-read [busy]
+/// themselves, so a redundant ping is harmless and no state can go stale.
+class _Activity extends ChangeNotifier {
+  void ping() {
+    if (!_alive) return;
+    notifyListeners();
+  }
+
+  bool _alive = true;
+
+  @override
+  void dispose() {
+    _alive = false;
+    super.dispose();
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_isolate.dart
@@ -1050,6 +1050,7 @@ Future<Uint8List?> _recordPageAsync(
       cos: document.cos,
       decodeImages: false,
       maxImagePixelRatio: imagePixelRatio,
+      pageRasterPixels: pdfPageRasterPixels(page.cropBox, imagePixelRatio),
       imageDecodeRegion: imageDecodeRegion,
       imagePlaceholders: true,
       commandLimit: commandLimit,
@@ -1132,6 +1133,8 @@ Future<Uint8List?> _recordResumablePage(
         cos: document.cos,
         decodeImages: false,
         maxImagePixelRatio: imagePixelRatio,
+        pageRasterPixels:
+            pdfPageRasterPixels(entry.page.cropBox, imagePixelRatio),
         imageDecodeRegion: imageDecodeRegion,
         imagePlaceholders: true,
         compactStateScopes: true);
@@ -1150,6 +1153,8 @@ Future<Uint8List?> _recordResumablePage(
       cos: document.cos,
       decodeImages: decodeImages,
       maxImagePixelRatio: imagePixelRatio,
+      pageRasterPixels:
+          pdfPageRasterPixels(entry.page.cropBox, imagePixelRatio),
       imageDecodeRegion: imageDecodeRegion,
       imagePlaceholders: !decodeImages,
       commandLimit: commandLimit,

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -607,6 +607,7 @@ Future<Uint8List?> _recordPageAsync(
     cos: document.cos,
     decodeImages: decodeImages,
     maxImagePixelRatio: imagePixelRatio,
+    pageRasterPixels: pdfPageRasterPixels(page.cropBox, imagePixelRatio),
     imageDecodeRegion: imageDecodeRegion,
     imagePlaceholders: !decodeImages,
     commandLimit: commandLimit,

--- a/packages/dart_pdf_editor/lib/src/renderer.dart
+++ b/packages/dart_pdf_editor/lib/src/renderer.dart
@@ -235,16 +235,25 @@ class PdfPageRenderer {
   /// every image. This is the fast first pass of progressive rendering: a heavy
   /// raster underlay can take many seconds to decode, so the page paints its
   /// linework immediately and the images drop in on a later full pass.
+  ///
+  /// [maxImagePixelRatio] caps those decodes to the resolution the picture is
+  /// about to be rasterized at, exactly as in [pictureFromCommandsWithPlan].
+  /// Pass it whenever the buffer may carry un-decoded images (the worker's
+  /// codec declined them) and the target is smaller than the page: without it
+  /// a 256px thumbnail decodes a declined image at its native size, on the
+  /// platform thread (#603).
   static Future<ui.Picture> pictureFromCommands(
       PdfPage page, List<PdfRenderCommand> commands,
       {Color pageColor = const Color(0xFFFFFFFF),
       int? rotation,
-      bool includeImages = true}) async {
+      bool includeImages = true,
+      double? maxImagePixelRatio}) async {
     return pictureFromCommandsWithPlan(
       page,
       commands,
       PdfPageRenderPlan(pageColor: pageColor, rotation: rotation),
       includeImages: includeImages,
+      maxImagePixelRatio: maxImagePixelRatio,
     );
   }
 

--- a/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
@@ -55,6 +55,61 @@ void main() {
     });
   });
 
+  // #603: the warm already yields to on-screen TILES and renders at a lower
+  // worker priority, but its replay and rasterize still run on the platform
+  // thread - the one the visible page's build needs, and the one a worker
+  // priority cannot reach. The gate is what makes it stand down for the viewer.
+  group('PdfThumbnailCache foreground gate', () {
+    testWidgets('the warm stands down while the viewer renders, and resumes '
+        'when it goes idle', (tester) async {
+      final cache = PdfThumbnailCache();
+      addTearDown(cache.dispose);
+      final activity = _TestActivity();
+      var viewerBusy = true;
+      cache.bindForegroundGate(activity, () => viewerBusy);
+
+      final warmed = <int>[];
+      cache.setWarm(Object(), 3, 'k', (page) async => warmed.add(page));
+      for (var i = 0; i < 5; i++) {
+        await tester.pump();
+      }
+      expect(warmed, isEmpty, reason: 'the viewer is still rendering');
+
+      // the viewer went idle: its activity ping re-kicks the loop - the warm
+      // must not be waiting on a frame poll that never comes
+      viewerBusy = false;
+      activity.ping();
+      for (var i = 0; i < 8; i++) {
+        await tester.pump();
+      }
+      expect(warmed, [0, 1, 2]);
+    });
+
+    testWidgets('an unbound cache warms exactly as before', (tester) async {
+      final cache = PdfThumbnailCache();
+      addTearDown(cache.dispose);
+      final warmed = <int>[];
+      cache.setWarm(Object(), 2, 'k', (page) async => warmed.add(page));
+      for (var i = 0; i < 8; i++) {
+        await tester.pump();
+      }
+      expect(warmed, [0, 1]);
+    });
+
+    testWidgets('withdrawing the warm releases the gate', (tester) async {
+      final cache = PdfThumbnailCache();
+      addTearDown(cache.dispose);
+      final activity = _TestActivity();
+      final owner = Object();
+      cache.bindForegroundGate(activity, () => true);
+      cache.setWarm(owner, 2, 'k', (page) async {});
+      expect(activity.listeners, 1);
+      cache.clearWarm(owner);
+      expect(activity.listeners, 0,
+          reason: 'a disposed panel must not keep the viewer subscribed');
+    });
+  });
+
   group('PdfThumbnailCache raster store', () {
     Future<ui.Image> solid(int w, int h) {
       final px = Uint8List(w * h * 4)..fillRange(0, w * h * 4, 255);
@@ -189,6 +244,43 @@ void main() {
       await tester.pump();
       expect(PdfThumbnailSidebar.debugRasterizations, 3);
     });
+
+    testWidgets('a parked viewer does not gate the warm', (tester) async {
+      // The full-area page grid overlays the viewer and parks it
+      // (PdfViewer.active false), which holds its renders forever. Gating the
+      // warm on that hold would mean the grid never fills in - so a parked
+      // viewer must read idle (#603).
+      final bytes = buildMultiPagePdf(4);
+      final editing = PdfEditingController(bytes);
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            Expanded(
+              child: PdfViewer(
+                active: false,
+                document: PdfDocument.open(bytes),
+                controller: viewer,
+              ),
+            ),
+          ]),
+        ),
+      ));
+      expect(viewer.isPageRenderBusy, isFalse);
+
+      for (var i = 0;
+          i < 300 && PdfThumbnailSidebar.debugRasterizations < 4;
+          i++) {
+        await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 10)));
+        await tester.pump();
+      }
+      expect(PdfThumbnailSidebar.debugRasterizations, 4);
+    });
   });
 
   group('thumbnail disk persistence', () {
@@ -273,4 +365,24 @@ void main() {
       fromDisk!.dispose();
     });
   });
+}
+
+/// A [Listenable] whose subscriptions are observable - the gate must let go of
+/// the viewer when its panel does, or a disposed strip keeps waking the warm.
+class _TestActivity implements Listenable {
+  final _callbacks = <VoidCallback>[];
+
+  int get listeners => _callbacks.length;
+
+  @override
+  void addListener(VoidCallback listener) => _callbacks.add(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => _callbacks.remove(listener);
+
+  void ping() {
+    for (final callback in List<VoidCallback>.of(_callbacks)) {
+      callback();
+    }
+  }
 }

--- a/packages/dart_pdf_editor/test/render_scheduler_test.dart
+++ b/packages/dart_pdf_editor/test/render_scheduler_test.dart
@@ -99,4 +99,60 @@ void main() {
     expect(reached, isTrue);
     expect(scheduler.hasPending, isFalse);
   });
+  // #603: the thumbnail warm builds its pictures on the platform thread, so it
+  // needs a signal for "the viewer still wants that thread". `busy` is it, and
+  // `activity` is how a gated pass learns the answer changed without polling
+  // frames.
+  testWidgets('busy tracks the hold and the queue, and pings activity',
+      (tester) async {
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    var pings = 0;
+    scheduler.activity.addListener(() => pings++);
+
+    expect(scheduler.busy, isFalse);
+
+    scheduler.holding = true;
+    expect(scheduler.busy, isTrue);
+    expect(pings, 1);
+
+    scheduler.request('a', 0, () {});
+    expect(pings, 2);
+    scheduler.holding = false;
+    expect(scheduler.busy, isTrue, reason: 'the request is still queued');
+
+    for (var i = 0; i < 4; i++) {
+      await tester.pump();
+    }
+    expect(scheduler.busy, isFalse);
+    expect(pings, greaterThan(2), reason: 'the drain must announce going idle');
+
+    // a request withdrawn before its turn also lands the scheduler idle
+    scheduler.holding = true;
+    scheduler.request('b', 0, () {});
+    scheduler.cancel('b');
+    scheduler.holding = false;
+    expect(scheduler.busy, isFalse);
+  });
+
+  testWidgets('a parked viewer reads idle however much it is holding',
+      (tester) async {
+    // PdfViewer.active false (the full-area page grid overlaid it) holds every
+    // render forever. That is not competition for the platform thread - and
+    // gating the grid's own thumbnails behind it would deadlock the warm.
+    final scheduler = PdfPageRenderScheduler()..holding = true;
+    addTearDown(scheduler.dispose);
+    scheduler.request('a', 0, () {});
+    expect(scheduler.busy, isTrue);
+
+    var pings = 0;
+    scheduler.activity.addListener(() => pings++);
+    scheduler.parked = true;
+    expect(scheduler.busy, isFalse);
+    expect(pings, 1);
+
+    scheduler.parked = false;
+    expect(scheduler.busy, isTrue);
+    expect(pings, 2);
+  });
 }

--- a/packages/dart_pdf_editor/test/render_worker_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_test.dart
@@ -225,6 +225,50 @@ void main() {
     });
   });
 
+  testWidgets('a thumbnail-ratio record is budgeted to the tile it fills '
+      '(#603)', (tester) async {
+    await tester.runAsync(() async {
+      // The warm pass asks for a page at ~0.4 px per point to fill a 256px
+      // tile. Before this the buffer it got back was budgeted against the
+      // FULL-PAGE raster cap (17 MP) - so a layered sheet shipped megabytes of
+      // decoded pixels the tile can never show, and the main thread paid for
+      // every one of them again turning them into ui.Images at replay.
+      final bytes = buildSyntheticRasterUnderlaySheet(
+        underlays: const [
+          PdfUnderlaySpec(width: 1400, height: 1000),
+          PdfUnderlaySpec(width: 1400, height: 1000),
+          PdfUnderlaySpec(width: 1400, height: 1000),
+        ],
+        layers: 2,
+        ops: 40,
+      );
+      final worker = PdfRenderWorker.start(bytes);
+      addTearDown(worker.dispose);
+      final size = PdfPageRenderer.pageSize(PdfDocument.open(bytes).page(0));
+
+      const tilePixels = 256.0;
+      final tileRatio = tilePixels / size.width;
+      final commands = await worker.record(0, imagePixelRatio: tileRatio);
+      expect(commands, isNotNull, reason: 'the sheet must offload');
+      final (count, pixels) = PdfPageRenderer.decodedImageStats(commands!);
+      expect(count, greaterThan(0), reason: 'nothing decoded - proves nothing');
+
+      // The tile's own raster, times the per-image resolution headroom (2x
+      // linear) squared. Slop: every image rounds its scaled edges up, so a
+      // page of them lands a hair over the budget by construction.
+      final raster = tilePixels * (size.height * tileRatio);
+      expect(pixels, lessThanOrEqualTo((4 * raster * 1.02).ceil()),
+          reason: '$pixels decoded pixels shipped to fill a '
+              '${raster.round()}-pixel tile');
+
+      // ...and the same page at its own resolution is not squeezed by it: the
+      // budget follows the raster, it is not a blanket tightening.
+      final full = await worker.record(0, imagePixelRatio: 2.0);
+      final (_, fullPixels) = PdfPageRenderer.decodedImageStats(full!);
+      expect(fullPixels, greaterThan(pixels * 8));
+    });
+  });
+
   testWidgets('decodeImages:false records vector/text but ships images raw',
       (tester) async {
     await tester.runAsync(() async {

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -108,6 +108,14 @@ class _UnserializableImage implements Exception {
 /// re-rasters the page. Null leaves images at native resolution (the historic
 /// behavior). Only consulted when [decodeImages] is true.
 ///
+/// [pageRasterPixels] is how many pixels the raster this buffer will be drawn
+/// into actually has (page area x [maxImagePixelRatio]^2, or the tile's own
+/// width x height). It bounds the *total* decoded image pixels the buffer may
+/// carry to a small multiple of what the raster can ever show. Null falls back
+/// to the full-page raster cap, which is 17 MP - right for a page render,
+/// wildly generous for a 256px thumbnail tile (#603). Only consulted when
+/// [decodeImages] is true.
+///
 /// [imageDecodeRegion], when supplied, is a PDF page-space rectangle for the
 /// visible detail patch. Axis-aligned image draws are decoded only for the
 /// intersecting source pixels and their image transform is retargeted to the
@@ -124,23 +132,43 @@ class _UnserializableImage implements Exception {
 /// isolate; the default stays false so the public codec remains a lossless
 /// command-transcript round trip.
 /// The page raster never exceeds this many pixels (the viewer's full-page
-/// raster cap), so it is also the natural unit for the page image budget.
+/// raster cap), so it is the ceiling on the page image budget - the fallback
+/// unit when the caller does not say what raster the buffer is drawn into.
 const int _maxImagePixels = 1 << 24;
 
-/// Total decoded image pixels per page are bounded to this multiple of
-/// [_maxImagePixels]. The per-image cap keeps each image near its own
-/// on-screen footprint, but a sheet layered from dozens of overlapping raster
-/// tiles can still sum to many times the page raster - only the topmost layer
-/// per pixel is ever shown, so the rest is decoded, shipped, and cached for
-/// nothing. This ceiling (~17 MP at the default) scales every image down to
-/// fit, bounding the command buffer and the decoded-image cache no matter how
-/// the sheet is layered. Larger keeps more sharpness on heavy overlap at the
-/// cost of a bigger payload.
+/// Total decoded image pixels per page are bounded to this multiple of the
+/// raster the buffer is drawn into. The per-image cap keeps each image near
+/// its own on-screen footprint, but a sheet layered from dozens of overlapping
+/// raster tiles can still sum to many times the page raster - only the topmost
+/// layer per pixel is ever shown, so the rest is decoded, shipped, and cached
+/// for nothing. This ceiling scales every image down to fit, bounding the
+/// command buffer and the decoded-image cache no matter how the sheet is
+/// layered. Larger keeps more sharpness on heavy overlap at the cost of a
+/// bigger payload.
 const double _imageBudgetFactor = 1.0;
 
+/// The per-image cap ([cappedImagePixelSize]) keeps this much linear headroom
+/// over an image's on-screen footprint, so ONE full-bleed image legitimately
+/// carries this squared times the raster's pixels. The page budget starts
+/// there, otherwise a single underlay would trip it on its own.
+const double _imageBudgetHeadroom = 2.0;
+
 int _imageBudgetPixels(double ratio, double factor,
-    {PdfRect? imageDecodeRegion}) {
+    {PdfRect? imageDecodeRegion, int? pageRasterPixels}) {
   var budget = (factor * _maxImagePixels).round();
+  // What the buffer is actually drawn into. `_maxImagePixels` is only the
+  // *cap* on a full-page raster; a 256px thumbnail tile rasterizes ~85k
+  // pixels, and budgeting it 17 MP of decoded images (200x what it can ever
+  // show) is what let warm thumbnails ship ~10 MB records - and pay for every
+  // one of those pixels again as main-thread `ui.Image` work at replay (#603).
+  if (pageRasterPixels != null && pageRasterPixels > 0) {
+    final scaled = (factor *
+            _imageBudgetHeadroom *
+            _imageBudgetHeadroom *
+            pageRasterPixels)
+        .round();
+    if (scaled > 0 && scaled < budget) budget = scaled;
+  }
   if (imageDecodeRegion != null &&
       imageDecodeRegion.width > 0 &&
       imageDecodeRegion.height > 0 &&
@@ -155,12 +183,33 @@ int _imageBudgetPixels(double ratio, double factor,
   return budget;
 }
 
+/// How many pixels a page whose media/crop box is [box] rasterizes into at
+/// [ratio] screen pixels per page point - `serializeCommands`'s
+/// `pageRasterPixels`.
+///
+/// The render worker calls this for every record it serializes: it knows both
+/// the page box and the ratio the caller asked for, so the buffer's image
+/// budget can follow the raster the caller will actually draw (a 256px
+/// thumbnail tile, a full-resolution page) instead of the worst-case full-page
+/// raster cap. Null when [ratio] or the box is degenerate - the codec then
+/// falls back to that cap, the historic behaviour.
+int? pdfPageRasterPixels(PdfRect box, double? ratio) {
+  if (ratio == null || !(ratio > 0)) return null;
+  final width = box.width * ratio;
+  final height = box.height * ratio;
+  if (!(width > 0) || !(height > 0)) return null;
+  final pixels = width * height;
+  if (!pixels.isFinite) return null;
+  return pixels.ceil();
+}
+
 Uint8List? serializeCommands(List<PdfRenderCommand> commands,
     {CosDocument? cos,
     bool decodeImages = false,
     double? maxImagePixelRatio,
     PdfRect? imageDecodeRegion,
     double imageBudgetFactor = _imageBudgetFactor,
+    int? pageRasterPixels,
     bool imagePlaceholders = false,
     int? commandLimit,
     bool compactStateScopes = false}) {
@@ -180,7 +229,8 @@ Uint8List? serializeCommands(List<PdfRenderCommand> commands,
         cos,
         maxImagePixelRatio,
         _imageBudgetPixels(maxImagePixelRatio, imageBudgetFactor,
-            imageDecodeRegion: imageDecodeRegion),
+            imageDecodeRegion: imageDecodeRegion,
+            pageRasterPixels: pageRasterPixels),
         imageDecodeRegion: imageDecodeRegion);
   }
   try {

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -847,6 +847,164 @@ void main() {
       });
     }
   });
+
+  // #603: a thumbnail warm shipped ~10 MB records to fill a 256px tile,
+  // because the page image budget was a multiple of the full-page raster CAP
+  // (17 MP) rather than of the raster the buffer is actually drawn into. Every
+  // one of those pixels is then paid for again as main-thread ui.Image work at
+  // replay, which is the half of the cost no worker priority can move.
+  group('pageRasterPixels', () {
+    test('is page area x ratio^2, and declines degenerate input', () {
+      expect(pdfPageRasterPixels(const PdfRect(0, 0, 200, 400), 1.0), 80000);
+      expect(pdfPageRasterPixels(const PdfRect(0, 0, 200, 400), 0.5), 20000);
+      // 256px wide tile of a US-Letter page: ~85 Kpx, against the 17 MP cap
+      // the budget used to assume for it.
+      expect(pdfPageRasterPixels(const PdfRect(0, 0, 612, 792), 256 / 612),
+          lessThan(90000));
+      expect(pdfPageRasterPixels(const PdfRect(0, 0, 200, 200), null), isNull);
+      expect(pdfPageRasterPixels(const PdfRect(0, 0, 200, 200), 0), isNull);
+      expect(pdfPageRasterPixels(const PdfRect(0, 0, 200, 200), -1), isNull);
+      expect(pdfPageRasterPixels(const PdfRect(0, 0, 0, 200), 1.0), isNull);
+    });
+
+    test('holds a layered page to what the tile can show', () {
+      // Four full-bleed 512x512 images on a 200pt page - the layered shape a
+      // scanned book page has, and the one the per-image cap cannot bound
+      // (each image IS its own footprint; only their sum is the problem).
+      final doc = PdfDocument.open(_layeredImagePdf(draws: 4));
+      final page = doc.page(0);
+      final recorder = RecordingPdfDevice();
+      PdfInterpreter(cos: doc.cos, device: recorder).drawPageOperations(
+          page, ContentStreamParser.parse(page.contentBytes()));
+
+      // A 256px-wide tile, exactly what the thumbnail warm asks for.
+      final box = page.cropBox;
+      final ratio = 256 / box.width;
+      final raster = pdfPageRasterPixels(box, ratio)!;
+
+      final unbudgeted = serializeCommands(recorder.commands,
+          cos: doc.cos, decodeImages: true, maxImagePixelRatio: ratio)!;
+      final budgeted = serializeCommands(recorder.commands,
+          cos: doc.cos,
+          decodeImages: true,
+          maxImagePixelRatio: ratio,
+          pageRasterPixels: raster)!;
+
+      // Pixels only - the command stream is identical either way, so the tile
+      // replays the same drawing at a resolution it can actually show.
+      expect(_transcript(deserializeCommands(budgeted)),
+          equals(_transcript(deserializeCommands(unbudgeted))));
+
+      final before = _decodedPixelSum(deserializeCommands(unbudgeted));
+      final after = _decodedPixelSum(deserializeCommands(budgeted));
+      // The per-image 2x headroom alone ships 4 raster-fulls PER image; the
+      // page budget is that headroom squared for the whole page.
+      expect(before, 4 * 512 * 512);
+      expect(after, lessThanOrEqualTo(4 * raster + 4 * 16 + 64));
+      expect(after * 4, lessThanOrEqualTo(before),
+          reason: 'the tile-sized budget did not bind');
+      // The record crossing the worker seam sheds every one of those pixels
+      // (4 bytes of premultiplied RGBA each). What it does NOT shed is the
+      // source streams written beside them to key the decode by content -
+      // that floor is #451's, not this one's.
+      expect(unbudgeted.length - budgeted.length,
+          greaterThanOrEqualTo(4 * (before - after) - 1024));
+    });
+
+    test('never scales a lone underlay a page render legitimately wants', () {
+      final doc = PdfDocument.open(_layeredImagePdf(draws: 1));
+      final page = doc.page(0);
+      final recorder = RecordingPdfDevice();
+      PdfInterpreter(cos: doc.cos, device: recorder).drawPageOperations(
+          page, ContentStreamParser.parse(page.contentBytes()));
+      final box = page.cropBox;
+      for (final ratio in const [2.0, 1.28, 0.5]) {
+        final plain = serializeCommands(recorder.commands,
+            cos: doc.cos, decodeImages: true, maxImagePixelRatio: ratio);
+        final budgeted = serializeCommands(recorder.commands,
+            cos: doc.cos,
+            decodeImages: true,
+            maxImagePixelRatio: ratio,
+            pageRasterPixels: pdfPageRasterPixels(box, ratio));
+        expect(budgeted, equals(plain),
+            reason: 'ratio $ratio: the raster-derived budget must leave the '
+                'per-image cap alone for a single full-bleed image');
+      }
+    });
+
+    test('is a floor under the 17 MP cap, never a raise', () {
+      final doc = PdfDocument.open(_layeredImagePdf(draws: 4));
+      final page = doc.page(0);
+      final recorder = RecordingPdfDevice();
+      PdfInterpreter(cos: doc.cos, device: recorder).drawPageOperations(
+          page, ContentStreamParser.parse(page.contentBytes()));
+      final plain = serializeCommands(recorder.commands,
+          cos: doc.cos, decodeImages: true, maxImagePixelRatio: 1e6);
+      final huge = serializeCommands(recorder.commands,
+          cos: doc.cos,
+          decodeImages: true,
+          maxImagePixelRatio: 1e6,
+          pageRasterPixels: 1 << 30);
+      expect(huge, equals(plain));
+    });
+  });
+}
+
+/// A one-page 200x200 pt PDF that draws one 512x512 raw DeviceRGB image
+/// [draws] times, full bleed. The layered-raster shape the page image budget
+/// exists to bound: every draw is at its own on-screen footprint, so only
+/// their SUM is out of proportion to the raster.
+Uint8List _layeredImagePdf({required int draws}) {
+  const size = 512;
+  final pixels = Uint8List(size * size * 3);
+  for (var i = 0; i < pixels.length; i++) {
+    pixels[i] = (i * 7) & 0xff;
+  }
+  final content = StringBuffer();
+  for (var i = 0; i < draws; i++) {
+    content.write('q 200 0 0 200 0 0 cm /Im0 Do Q\n');
+  }
+  final contentBytes = Uint8List.fromList(content.toString().codeUnits);
+
+  final out = BytesBuilder();
+  final offsets = <int>[];
+  void obj(int number, String head, [Uint8List? stream]) {
+    offsets.add(out.length);
+    out.add(Uint8List.fromList('$number 0 obj\n$head\n'.codeUnits));
+    if (stream != null) {
+      out.add(Uint8List.fromList('stream\n'.codeUnits));
+      out.add(stream);
+      out.add(Uint8List.fromList('\nendstream\n'.codeUnits));
+    }
+    out.add(Uint8List.fromList('endobj\n'.codeUnits));
+  }
+
+  out.add(Uint8List.fromList('%PDF-1.4\n'.codeUnits));
+  obj(1, '<< /Type /Catalog /Pages 2 0 R >>');
+  obj(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>');
+  obj(
+      3,
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] '
+          '/Resources << /XObject << /Im0 5 0 R >> >> /Contents 4 0 R >>');
+  obj(4, '<< /Length ${contentBytes.length} >>', contentBytes);
+  obj(
+      5,
+      '<< /Type /XObject /Subtype /Image /Width $size /Height $size '
+          '/ColorSpace /DeviceRGB /BitsPerComponent 8 '
+          '/Length ${pixels.length} >>',
+      pixels);
+
+  final xref = out.length;
+  final tail = StringBuffer('xref\n0 ${offsets.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final off in offsets) {
+    tail.write('${off.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  tail
+    ..write('trailer << /Size ${offsets.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xref\n%%EOF\n');
+  out.add(Uint8List.fromList(tail.toString().codeUnits));
+  return out.takeBytes();
 }
 
 /// Sum of decoded pixels across every image draw (DFS, soft-mask groups too).


### PR DESCRIPTION
## Summary

Fixes #603 — the background thumbnail warm spending ~6.7 s of **main-thread** replay in a 20 s scroll, more per tile than the pages those tiles preview.

The warm's existing throttles are all worker-side (priority 3 vs 2, declining the UI-thread fallback), and none of them reach the half of a thumbnail that runs on the platform thread: `pictureFromCommands` plus the rasterize. Three independent causes, three fixes.

**1. The page image budget was a multiple of the wrong raster.** `serializeCommands`' page image budget was `imageBudgetFactor × _maxImagePixels`, and `_maxImagePixels` (~17 MP) is the full-page raster **cap**, not the raster. A 256px-wide tile of a Letter page rasterizes ~85 000 pixels, so a warm thumbnail was budgeted 200× what it can ever show — which is how it produced ~10 MB records, and how the main thread ended up building `ui.Image`s for every one of those pixels at replay.

`serializeCommands` gains `pageRasterPixels`; the budget becomes `min(factor × 17 MP, headroom² × factor × pageRasterPixels)`. The headroom term is `cappedImagePixelSize`'s own 2× linear headroom squared, which makes the new bound a **no-op for a single full-bleed image** — it only bites where the per-image cap can't help, i.e. many images summing past the raster. It is a floor under the 17 MP cap, never a raise (`pageRasterPixels: 1 << 30` serializes byte-identically to passing nothing).

No wire change: both worker entries already know the page and the ratio, so they compute it via the new `pdfPageRasterPixels(page.cropBox, imagePixelRatio)`. Strip-detail paths are untouched — an `imageDecodeRegion` already derives its own budget.

Measured on `buildSyntheticRasterUnderlaySheet` (3 × 1400×1000 underlays with soft masks), recorded at the tile ratio:

| tile | record bytes | decoded pixels |
| --- | --- | --- |
| 256px | 2 312 080 → 830 320 (−64%) | 556 032 → 185 592 |
| 128px | 643 984 → 274 432 (−57%) | 139 008 → 46 620 |

The record doesn't shrink by the full decoded delta because the source streams are still written beside the pixels to key the decode by content — that floor is #451's.

**2. The thumbnail replay decoded worker-declined images at native size.** `rasterizeThumbnail` passed `imagePixelRatio` to the worker but called `pictureFromCommands` with no `maxImagePixelRatio`, so an image the worker's codec declined (`declined=57(decodeNull:7,notDct:50)` in the capture) decoded at its **native** resolution, on the platform thread, to fill a 256px tile. `PdfPageView` always passed the cap on this path; the thumbnail never did.

**3. The warm competed with the viewer, and nothing said so.** `PdfThumbnailCache`'s warm yielded on `_foregroundBusy`, which only tracks *thumbnail tile* tasks. `PdfPageRenderScheduler` now exposes `busy` and an `activity` `Listenable`; `PdfViewerController` republishes them as `isPageRenderBusy` / `pageRenderActivity`; both thumbnail panels bind them through the new `PdfThumbnailCache.bindForegroundGate`. The warm returns before starting a page while the viewer is rendering, and the activity ping — not a frame poll — resumes it.

The replay is also wrapped in its own `TimelineTask` slice (`thumbnail replay`, tagged page + reason), so a capture attributes a stolen frame to the thumbnail that stole it.

### API impact

Additive only: `serializeCommands(pageRasterPixels:)`, `pdfPageRasterPixels()`, `pictureFromCommands(maxImagePixelRatio:)`, `PdfPageRenderScheduler.busy`/`activity`/`parked`, `PdfViewerController.isPageRenderBusy`/`pageRenderActivity`, `PdfThumbnailCache.bindForegroundGate`. Every new parameter defaults to the previous behaviour.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [x] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` — clean
- [x] `cd packages/pdf_cos && fvm dart test` — 356 pass
- [x] `cd packages/pdf_document && fvm dart test` — 805 pass
- [x] `cd packages/pdf_graphics && fvm dart test` — 953 pass
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 1983 pass
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Also ran `tool/perf.sh gate` — *counter gate OK: 12 inputs, 13 counters within 3%*.

Ghent baselines were not re-run: the codec change is inert unless `pageRasterPixels` is supplied, and only the two render-worker entries supply it — the Ghent renders go through the local renderer, which is untouched. The counter gate covers the deterministic side.

## PDF fixtures and screenshots

No new committed PDFs. The codec test builds its layered-image page programmatically in-test; the worker test reuses the existing `buildSyntheticRasterUnderlaySheet` fixture.

New tests:
- `render_command_codec_test.dart` — `pdfPageRasterPixels` arithmetic and degenerate input; a layered page held to what the tile can show (transcript unchanged, pixels down 4×, record sheds 4 bytes per dropped pixel); a lone underlay never scaled at three ratios; a raster past the cap never raising the budget.
- `render_worker_test.dart` — end-to-end: a thumbnail-ratio record is budgeted to its tile, while the same page at 2.0 is not squeezed.
- `render_scheduler_test.dart` — `busy` tracks hold + queue and pings `activity`; a parked viewer reads idle.
- `editing_thumbnail_cache_test.dart` — the warm stands down while the viewer renders and resumes on the ping; an unbound cache is unchanged; `clearWarm` releases the subscription; and a strip beside an `active: false` viewer still warms every page.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

**The one real trap, `parked` ≠ `holding`.** `PdfViewer.active: false` sets `holding = true` forever, and the full-area page grid (`PdfEditorView`'s `showThumbnailView`) overlays the viewer with exactly that. Gating the warm on `holding` alone would have deadlocked the grid's own thumbnails behind a hold that never lifts. Hence a separate `parked` flag, set alongside every `holding = … || !widget.active`, with `busy = !parked && (holding || pending)`. Pinned by a scheduler unit test and a widget test.

The controller-side listenable is a `_PdfForwardingListenable` because the controller outlives the viewer state it drives — a gate subscribed straight to a live scheduler would be left holding a disposed object when the host reparents the viewer.

**Deliberately not in scope**, with reasons in [the dev-log note](doc/dev-log/2026-07-25-thumbnail-warm-platform-thread.md):

- *Command culling for a thumbnail-grade record* (issue direction 1). Checked before writing it: the capture's pages are 1400–1800 commands of book **text**, and 9 pt text at the tile's 0.42 ratio is still ~3.8 device pixels — nothing sub-pixel to drop. Culling would pay an O(commands) bounds pass to save roughly nothing on the document that filed the bug. It's the right tool for a CAD sheet, not this one.
- *Deriving the thumbnail from an existing page raster* (direction 2). Those rasters live in `PdfPageView`'s tile store, out of reach of the thumbnail panels; wiring it across is larger than these three fixes.
- *Not shipping the source stream beside decoded pixels* — the remaining floor under record size, and #451's.

Direction 3 is implemented in full.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAMnDfkBJahm1M7Wky2sqU)_