### PR TITLE
perf(scheduler): stop granting a page a second concurrent render (#451)

### DIFF
--- a/doc/dev-log/2026-07-26-scheduler-concurrent-grant-451.md
+++ b/doc/dev-log/2026-07-26-scheduler-concurrent-grant-451.md
@@ -1,0 +1,127 @@
+# 2026-07-26 — #451: the scheduler could grant one page two concurrent renders
+
+Item 3 of the [#601 write-up](2026-07-25-record-glyph-outline-dedup-451.md)
+listed two untracked scheduler problems the device trace exposed. This is
+the second one — "every focus page is granted exactly twice" — chased to a
+mechanism, fixed, and pinned. **The fix is correct and exercised, but no
+local scenario shows a measurable win.** That caveat is the point of this
+note.
+
+## The race
+
+`PdfPageRenderScheduler.request` documents "the page is interpreted at most
+once", and deduplicates by token. But it only compares against `_pending`,
+and `_drain` *removes* the request before invoking it:
+
+```dart
+final next = _pending.removeAt(pick);
+next.render();                       // returns at its first await
+await SchedulerBinding.instance.endOfFrame;
+```
+
+`render` was typed `VoidCallback`, and Dart happily coerces the
+`Future<void> Function()` both call sites pass — so the future was dropped
+on the floor. On the worker path the callback returns in microseconds and
+the recording lands hundreds of milliseconds later. A rebuild inside that
+window finds an empty `_pending`, enqueues, and the next `endOfFrame`
+grants the same page a **second concurrent pass**.
+
+Both passes record the page in full. `_renderNow` opens with
+`_renderSession.beginFull()`, so the newer pass bumps the generation and the
+older one's result is discarded by its own `_superseded` guard when it
+lands — a complete wasted record. `pdf_page_view.dart:1725` already
+described the interleaving as a known hazard and defended the *state*
+against it; nothing stopped the duplicate work itself.
+
+The device trace's smallest same-page gap was 3 ms, which is exactly one
+`endOfFrame` when a frame is already in flight.
+
+## The fix
+
+The scheduler now tracks the in-flight window: `request` for a token whose
+render has not settled stores the re-request instead of queueing it, and
+`_settle` (hung off the returned future, with `onError` so an async throw
+cannot wedge a page out of the queue) grants it once the running pass
+finishes. `cancel` drops a queued re-request so a recycled page is not
+granted again when its abandoned render lands.
+
+The re-request is **held, not dropped** — the rebuild that asked may carry a
+new scale or revision. By the time it runs the page has its picture, so it
+takes `_renderNow`'s `cached != null` branch and re-rasters rather than
+recording from scratch.
+
+Frame pacing is deliberately unchanged: `_drain` still awaits only
+`endOfFrame`, never the render. Awaiting renders would serialize every page
+behind the slowest worker round trip and defeat the point of three workers.
+A test pins that (`an in-flight render does not block other pages`).
+
+`VoidCallback` → `FutureOr<void> Function()`. Both call sites already passed
+async functions.
+
+## Measurement — and why it shows nothing
+
+Interleaved web A/B, `scroll-scan` (the image/cache-heaviest scenario),
+3 iterations vs the pre-fix commit: every metric inside noise, and the
+grant log is **byte-identical modulo a startup offset** — 42 grants, 4 per
+page, `worker=31 recorded=0` on both sides. (`jankCount` 1 → 2 tripped the
+gate; it is a count of log lines, and the run before it went the other way.)
+
+So the fix is a no-op there. To find out whether the race fires at all, the
+coalesce now logs `scheduler defer page=N (render in flight)`. Across seven
+scenarios:
+
+| scenario | grants | defers |
+|---|---|---|
+| scroll-scan | 42 | 10 |
+| scroll-plan | 25 | 5 |
+| scroll-diagram | 6 | 0 |
+| scroll-cad-labels | 8 | 0 |
+| scroll-hatch | 8 | 0 |
+| open-diagram-progressive | 2 | 0 |
+| edit-annotate | 1 | 0 |
+
+It fires — but reading the interleaving shows what it catches locally is
+benign:
+
+```
+[perf 2359] scheduler grant page=2
+[perf 2651] webworker result kind=record page=2 5589896B → worker
+[perf 2651] scheduler defer page=2 (render in flight)
+[perf 2857] scheduler grant page=2
+[perf 2859] interpret page=2 path=worker FIRST interpret=1.5ms wait=0.0ms
+```
+
+The re-request arrives *as the record lands*, and the deferred grant replays
+the record it already has in 1.5 ms. One record, not two. Serializing it
+costs nothing and saves nothing — which is why `worker=` does not move.
+
+The wasteful shape is in the device trace and not reproduced locally:
+
+```
+page=28  worker=1895ms  ser=1608ms
+page=28  worker=1723ms  ser=1505ms   <- same page, again
+```
+
+Two full 1.5 s records for one page. Local records are ~450 ms against a
+12-page corpus; the device ran a 62-page book on three workers with records
+an order of magnitude slower, which is what widens the in-flight window
+enough for a second *recording* pass to start. **Confirming the win needs a
+device trace on this build** — count `scheduler defer` lines and check
+whether any page still produces two large records.
+
+## Adjacent, not chased
+
+The same log shows page 1's 41277 B vector-only record produced at
+`[perf 169]` and again at `[perf 2924]` — an identical re-record the record
+cache should have served. Different problem, not scoped here.
+
+Item 3's *first* half also stands: `_drain`'s one-per-frame pacing is
+nominal on the worker path, since the grant returns before the expensive
+work. Fixing that means awaiting renders, which as above is the wrong
+trade; the real serialization now needed is per-token, which is what this
+change adds.
+
+Tests: four new, each confirmed to fail against the specific mutation it
+targets (dedup removed, `cancel` leaving the re-request, `onError` dropped,
+`_settle` discarding instead of granting). dart_pdf_editor 1982, analyzer
+clean.

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -21,10 +21,27 @@ import 'perf_log.dart';
 /// viewport ([focus]) first, and never while a fast scroll is in flight
 /// ([holding]) - so no frame runs more than one page's walk and the
 /// low-res previews cover everything still waiting its turn.
+///
+/// A grant is only the *start* of a render: on the worker path the
+/// callback returns at its first await and the recording finishes
+/// hundreds of milliseconds later. The scheduler tracks that window (see
+/// [_inFlight]) so a rebuild arriving inside it queues behind the pass
+/// already running rather than racing a second one against it.
 class PdfPageRenderScheduler {
   PdfPageRenderScheduler();
 
   final _pending = <_RenderRequest>[];
+
+  /// Tokens whose render has been granted but has not finished. Deduping
+  /// only against [_pending] was not enough: the grant removes the
+  /// request, so a re-request landing mid-render found an empty queue and
+  /// started a second concurrent pass for the same page. Both passes
+  /// recorded the page in full and the older one's result was then thrown
+  /// away by the page's own generation guard - a whole wasted record, and
+  /// the reason the device trace showed every focus page granted twice
+  /// and 3-5 records produced per page.
+  final _inFlight = <Object, _RenderRequest?>{};
+
   bool _holding = false;
   int _focus = 0;
   bool _draining = false;
@@ -92,8 +109,22 @@ class PdfPageRenderScheduler {
   /// turn comes; [priority] is the page index, ranked against [focus].
   /// Calling again for the same [token] (a re-layout before the grant)
   /// just refreshes it - the page is interpreted at most once.
-  void request(Object token, int priority, VoidCallback render) {
+  ///
+  /// If [render] returns a future the scheduler treats the page as busy
+  /// until it settles: a re-request in that window is held back and
+  /// granted once, after the running pass finishes. It is not dropped -
+  /// the rebuild that asked may carry a new scale or revision - but by
+  /// then the page has its picture, so the deferred pass re-rasters
+  /// instead of recording the page from scratch a second time.
+  void request(Object token, int priority, FutureOr<void> Function() render) {
     if (_disposed) return;
+    final queued = _RenderRequest(token, priority, render);
+    if (_inFlight.containsKey(token)) {
+      PdfPerfLog.log('scheduler defer page=$priority '
+          '(render in flight)${_inFlight[token] == null ? '' : ' [repeat]'}');
+      _inFlight[token] = queued;
+      return;
+    }
     for (final r in _pending) {
       if (identical(r.token, token)) {
         r
@@ -103,16 +134,19 @@ class PdfPageRenderScheduler {
         return;
       }
     }
-    _pending.add(_RenderRequest(token, priority, render));
+    _pending.add(queued);
     _scheduleDrain();
     _activity.ping();
   }
 
   /// Withdraws [token]'s pending request - its page rendered another way,
-  /// or was disposed before its turn.
+  /// or was disposed before its turn. Also drops any re-request queued
+  /// behind a render still in flight, so a page recycled onto another
+  /// index does not get granted again when that render lands.
   void cancel(Object token) {
     final before = _pending.length;
     _pending.removeWhere((r) => identical(r.token, token));
+    if (_inFlight.containsKey(token)) _inFlight[token] = null;
     if (_pending.length != before) _activity.ping();
   }
 
@@ -141,11 +175,25 @@ class PdfPageRenderScheduler {
         final next = _pending.removeAt(pick);
         PdfPerfLog.log('scheduler grant page=${next.priority} '
             'focus=$_focus remaining=${_pending.length}');
+        _inFlight[next.token] = null;
         try {
-          next.render(); // starts one page render this frame
+          // starts one page render this frame; the callback returns at its
+          // first await, so this does not block the pacing below
+          final running = next.render();
+          if (running is Future<void>) {
+            // deliberately not awaited: three workers must stay busy while
+            // this page records. Only the token's own re-request waits.
+            running.then(
+              (_) => _settle(next.token),
+              onError: (_) => _settle(next.token),
+            );
+          } else {
+            _settle(next.token);
+          }
         } catch (_) {
           // a page that throws mid-walk must not strand the rest of the
           // queue - it simply keeps its preview/placeholder
+          _settle(next.token);
         }
         // let the engine breathe before the next walk: paint the frame
         // this produced, service input, run animations. endOfFrame
@@ -159,12 +207,25 @@ class PdfPageRenderScheduler {
     }
   }
 
+  /// [token]'s render has finished (or failed). Releases it and grants
+  /// the re-request that arrived while it was running, if any.
+  void _settle(Object token) {
+    final queued = _inFlight.remove(token);
+    if (queued == null || _disposed) return;
+    _pending.add(queued);
+    _scheduleDrain();
+    // re-queueing makes the viewer busy again (#603) - the thumbnail warm
+    // must stand down for it, exactly as it would for a fresh request
+    _activity.ping();
+  }
+
   /// Drops all pending requests and stops granting. Safe to call more
   /// than once.
   void dispose() {
     if (_disposed) return;
     _disposed = true;
     _pending.clear();
+    _inFlight.clear();
     _activity.ping();
     _activity.dispose();
   }
@@ -192,5 +253,5 @@ class _RenderRequest {
   _RenderRequest(this.token, this.priority, this.render);
   final Object token;
   int priority;
-  VoidCallback render;
+  FutureOr<void> Function() render;
 }

--- a/packages/dart_pdf_editor/test/render_scheduler_test.dart
+++ b/packages/dart_pdf_editor/test/render_scheduler_test.dart
@@ -2,6 +2,8 @@
 // a settling fast scroll can't fire them all in one event-loop turn - the
 // burst that froze fast scrolling on iPad. These tests pin the pacing,
 // the priority order, and the hold gate.
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
@@ -83,6 +85,116 @@ void main() {
       await tester.pump();
     }
     expect(count, 1);
+  });
+
+  group('in-flight renders (#451)', () {
+    testWidgets('a token re-requested mid-render is not granted twice',
+        (tester) async {
+      final scheduler = PdfPageRenderScheduler();
+      addTearDown(scheduler.dispose);
+      final gate = Completer<void>();
+      var grants = 0;
+      Future<void> render() async {
+        grants++;
+        await gate.future;
+      }
+
+      scheduler.request('a', 0, render);
+      await tester.pump();
+      expect(grants, 1);
+
+      // The grant removed 'a' from the pending list, but its render is
+      // still in flight - the worker round trip takes hundreds of ms. A
+      // rebuild in that window used to enqueue a second, concurrent pass.
+      scheduler.request('a', 0, render);
+      for (var i = 0; i < 4; i++) {
+        await tester.pump();
+      }
+      expect(grants, 1, reason: 'the first pass has not finished yet');
+
+      gate.complete();
+      for (var i = 0; i < 4; i++) {
+        await tester.pump();
+      }
+      // The re-request is honoured, just serialized behind the first pass -
+      // which by now has its picture, so this one re-rasters instead of
+      // recording the page a second time.
+      expect(grants, 2);
+      expect(scheduler.hasPending, isFalse);
+    });
+
+    testWidgets('an in-flight render does not block other pages',
+        (tester) async {
+      final scheduler = PdfPageRenderScheduler();
+      addTearDown(scheduler.dispose);
+      final gate = Completer<void>();
+      final order = <int>[];
+      scheduler
+        ..focus = 0
+        ..request('a', 0, () async {
+          order.add(0);
+          await gate.future;
+        })
+        ..request('b', 1, () => order.add(1))
+        ..request('c', 2, () => order.add(2));
+
+      for (var i = 0; i < 4; i++) {
+        await tester.pump();
+      }
+      // Pacing is unchanged: the drain never awaits a render, only the
+      // frame. Three workers must stay busy while page 0 is recording.
+      expect(order, [0, 1, 2]);
+      gate.complete();
+      await tester.pump();
+    });
+
+    testWidgets('cancelling mid-render drops the queued re-request',
+        (tester) async {
+      final scheduler = PdfPageRenderScheduler();
+      addTearDown(scheduler.dispose);
+      final gate = Completer<void>();
+      var grants = 0;
+      Future<void> render() async {
+        grants++;
+        await gate.future;
+      }
+
+      scheduler.request('a', 0, render);
+      await tester.pump();
+      scheduler.request('a', 0, render);
+      // the page was recycled onto another index before its pass finished
+      scheduler.cancel('a');
+      gate.complete();
+      for (var i = 0; i < 4; i++) {
+        await tester.pump();
+      }
+      expect(grants, 1);
+      expect(scheduler.hasPending, isFalse);
+    });
+
+    testWidgets('a render that throws mid-flight still clears in-flight',
+        (tester) async {
+      final scheduler = PdfPageRenderScheduler();
+      addTearDown(scheduler.dispose);
+      final gate = Completer<void>();
+      var grants = 0;
+      Future<void> render() async {
+        grants++;
+        await gate.future;
+        throw StateError('boom');
+      }
+
+      scheduler.request('a', 0, render);
+      await tester.pump();
+      scheduler.request('a', 0, render);
+      gate.complete();
+      for (var i = 0; i < 4; i++) {
+        await tester.pump();
+      }
+      // an asynchronous failure must not wedge the page out of the queue
+      // forever - the re-request still runs
+      expect(grants, 2);
+    });
   });
 
   testWidgets('a render that throws does not strand the queue', (tester) async {


### PR DESCRIPTION
Item 3 of the [#601 write-up](https://github.com/ben-milanko/dart-pdf/blob/main/doc/dev-log/2026-07-25-record-glyph-outline-dedup-451.md) listed two untracked scheduler problems the device trace exposed. This is the second — "every focus page is granted exactly twice" — chased to a mechanism, fixed, and pinned.

**Read the measurement section before merging: the fix is correct and exercised, but no local scenario shows a win.**

## The race

`request` documents "the page is interpreted at most once" and dedupes by token, but only against `_pending` — and `_drain` *removes* the request before invoking it:

```dart
final next = _pending.removeAt(pick);
next.render();                       // returns at its first await
await SchedulerBinding.instance.endOfFrame;
```

`render` was typed `VoidCallback`, and Dart coerces the `Future<void> Function()` both call sites pass — so the future was dropped on the floor. On the worker path the callback returns in microseconds and the recording lands hundreds of ms later. A rebuild inside that window finds an empty `_pending`, enqueues, and the next `endOfFrame` grants the same page a **second concurrent pass**.

Both passes record the page in full. `_renderNow` opens with `beginFull()`, so the newer pass bumps the generation and the older one's result is discarded by its own `_superseded` guard when it lands — a whole wasted record. `pdf_page_view.dart:1725` already described the interleaving as a known hazard and defended the *state* against it; nothing stopped the duplicate work.

The device trace's smallest same-page gap was 3 ms — exactly one `endOfFrame` when a frame is already in flight.

## The fix

The scheduler tracks the in-flight window. A re-request for a token whose render has not settled is stored rather than queued; `_settle` (hung off the returned future, with `onError` so an async throw cannot wedge a page out of the queue) grants it once the running pass finishes. `cancel` drops a queued re-request so a recycled page is not granted again.

Held, **not dropped** — the rebuild may carry a new scale or revision. By the time it runs the page has its picture, so it takes `_renderNow`'s `cached != null` branch.

Frame pacing is deliberately unchanged: `_drain` still awaits only `endOfFrame`, never the render. Awaiting renders would serialize every page behind the slowest worker round trip and defeat three workers. A test pins that.

`VoidCallback` → `FutureOr<void> Function()`; both call sites already passed async functions. `_settle` pings `activity` so #603's thumbnail warm stands down for a re-queue as it would for a fresh request.

## Measurement — and why it shows nothing

Interleaved web A/B, `scroll-scan` (the image/cache-heaviest scenario), 3 iterations vs the pre-fix commit: every metric inside noise, and the grant log is **byte-identical modulo a startup offset** — 42 grants, 4 per page, `worker=31 recorded=0` both sides. (`jankCount` 1 → 2 tripped the gate; it counts log lines, and the run before went the other way.)

To find out whether the race fires at all, the coalesce now logs `scheduler defer page=N (render in flight)`:

| scenario | grants | defers |
|---|---|---|
| scroll-scan | 42 | 10 |
| scroll-plan | 25 | 5 |
| scroll-diagram | 6 | 0 |
| scroll-cad-labels | 8 | 0 |
| scroll-hatch | 8 | 0 |
| open-diagram-progressive | 2 | 0 |
| edit-annotate | 1 | 0 |

It fires — but what it catches locally is benign:

```
[perf 2359] scheduler grant page=2
[perf 2651] webworker result kind=record page=2 5589896B → worker
[perf 2651] scheduler defer page=2 (render in flight)
[perf 2857] scheduler grant page=2
[perf 2859] interpret page=2 path=worker FIRST interpret=1.5ms wait=0.0ms
```

The re-request arrives *as the record lands*, and the deferred grant replays the record it already has in 1.5 ms. One record, not two. Serializing it costs nothing and saves nothing — which is why `worker=` does not move.

The wasteful shape is in the device trace and is not reproduced locally:

```
page=28  worker=1895ms  ser=1608ms
page=28  worker=1723ms  ser=1505ms   <- same page, again
```

Local records are ~450 ms over a 12-page corpus; the device ran a 62-page book on three workers with records an order of magnitude slower, which is what widens the window enough for a second *recording* pass to start. **Confirming the win needs a device trace on this build** — count `scheduler defer` lines and check whether any page still produces two large records.

## Adjacent, not chased

The same log shows page 1's 41277 B vector-only record produced at `[perf 169]` and again at `[perf 2924]` — an identical re-record the record cache should have served. Different problem.

## Testing

Four new tests, each confirmed to fail against the specific mutation it targets: in-flight dedup removed, `cancel` leaving the re-request, `onError` dropped, `_settle` discarding instead of granting. dart_pdf_editor 1989, analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)