### PR TITLE
feat(app): take the picture from the camera on mobile

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<!-- The image tool's "Take photo" source. iOS terminates the app if the
+	     camera is opened without this string, so it must stay for as long as
+	     lib/camera_capture.dart exists. Only the camera is used - captures are
+	     never written to the photo library, so no photo-library key is needed. -->
+	<key>NSCameraUsageDescription</key>
+	<string>DartPDF uses the camera to photograph a picture to place in your document.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/app/lib/camera_capture.dart
+++ b/app/lib/camera_capture.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+import 'package:image_picker/image_picker.dart';
+
+/// Whether this platform can photograph the picture the user wants to place.
+///
+/// Phones and tablets only. `image_picker`'s desktop implementations have no
+/// camera at all (they re-open a file dialog), and on the web the browser's
+/// own file input already offers the camera where the device has one.
+bool get supportsCameraCapture =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS);
+
+/// Long-edge cap asked of the camera. A phone sensor shoots 12 MP+, far past
+/// what a picture placed on a page ever resolves to (2000 px across an A4
+/// width is ~240 dpi) - and every byte of it lands in the saved PDF. The
+/// native side does the downscale, so the full-size frame never crosses the
+/// platform channel.
+const double cameraCaptureMaxDimension = 2000;
+
+/// JPEG quality for that downscale, and for the re-encode when a rotated
+/// capture has to be baked upright.
+const int cameraCaptureQuality = 88;
+
+/// Takes a photo and returns its (upright) JPEG bytes, or null when the user
+/// backed out of the camera without shooting.
+///
+/// Throws whatever the platform throws - no camera on the device, permission
+/// refused - so the caller can say so.
+Future<Uint8List?> captureImageFromCamera({ImagePicker? picker}) async {
+  final file = await (picker ?? ImagePicker()).pickImage(
+    source: ImageSource.camera,
+    maxWidth: cameraCaptureMaxDimension,
+    maxHeight: cameraCaptureMaxDimension,
+    imageQuality: cameraCaptureQuality,
+    // We only want pixels. Skipping the metadata read also keeps iOS from
+    // asking for photo-library access on what is only a camera shot.
+    requestFullMetadata: false,
+  );
+  if (file == null) return null;
+  return uprightJpeg(await file.readAsBytes());
+}
+
+/// Bakes a JPEG's EXIF orientation into its pixels so it embeds upright.
+///
+/// `PdfEmbeddableImage.jpeg` hands JPEG bytes to the PDF verbatim (DCTDecode)
+/// and PDF has no orientation tag, so a capture whose pixels are sideways
+/// under an /Orientation of 6 - what Android camera apps write for a portrait
+/// shot, and what `image_picker` deliberately preserves when it rescales -
+/// would land on the page rotated. iOS bakes the rotation itself while
+/// rescaling, so this is a no-op there.
+///
+/// A normal (or absent) orientation is the fast path: the bytes pass through
+/// untouched, keeping the camera's own JPEG. Only a rotated one pays for a
+/// decode and re-encode, and that runs off the UI isolate.
+Future<Uint8List> uprightJpeg(Uint8List bytes) async {
+  final orientation = jpegExifOrientation(bytes);
+  if (orientation == null || orientation == 1) return bytes;
+  final offIsolate = debugBakeOrientationOffIsolate;
+  return offIsolate != null
+      ? offIsolate(bytes)
+      : compute(bakeJpegOrientation, bytes);
+}
+
+/// Test seam for the isolate hop above: `compute` never completes inside a
+/// widget test's fake-async zone, so a widget test that has to reach a rotated
+/// capture runs the bake in place instead. Null in production.
+@visibleForTesting
+Future<Uint8List> Function(Uint8List bytes)? debugBakeOrientationOffIsolate;
+
+/// Decodes, rotates and re-encodes [bytes] per its EXIF orientation. Top-level
+/// because it is what [compute] runs.
+@visibleForTesting
+Uint8List bakeJpegOrientation(Uint8List bytes) {
+  final decoded = img.decodeJpg(bytes);
+  // Undecodable here means undecodable in the embedder too - hand the original
+  // bytes back and let it report the format problem.
+  if (decoded == null) return bytes;
+  return img.encodeJpg(
+    img.bakeOrientation(decoded),
+    quality: cameraCaptureQuality,
+  );
+}
+
+/// Reads the EXIF orientation (TIFF tag 0x0112, values 1-8) out of a JPEG's
+/// APP1 segment. Returns null when the file carries no EXIF block, no
+/// orientation tag, or anything malformed on the way to it - all of which mean
+/// "assume it is already upright".
+int? jpegExifOrientation(Uint8List bytes) {
+  if (bytes.length < 4 || bytes[0] != 0xFF || bytes[1] != 0xD8) return null;
+  final data = ByteData.sublistView(bytes);
+  var offset = 2;
+  while (offset + 4 <= bytes.length) {
+    if (bytes[offset] != 0xFF) return null;
+    // Some encoders pad with 0xFF fill bytes before a marker.
+    if (bytes[offset + 1] == 0xFF) {
+      offset++;
+      continue;
+    }
+    final marker = bytes[offset + 1];
+    // Start of scan: the pixel data begins, so any APP1 is behind us.
+    if (marker == 0xDA || marker == 0xD9) return null;
+    // Standalone markers carry no length word.
+    if (marker >= 0xD0 && marker <= 0xD8) {
+      offset += 2;
+      continue;
+    }
+    final length = data.getUint16(offset + 2);
+    if (length < 2) return null;
+    final payload = offset + 4;
+    final end = payload + length - 2;
+    if (end > bytes.length) return null;
+    if (marker == 0xE1 && _isExifHeader(bytes, payload, end)) {
+      return _orientationInTiff(data, payload + 6, end);
+    }
+    offset = end;
+  }
+  return null;
+}
+
+/// `Exif\0\0`, the APP1 payload prefix that marks an EXIF block (as opposed to
+/// the XMP one, which shares the marker).
+bool _isExifHeader(Uint8List bytes, int start, int end) =>
+    end - start >= 6 &&
+    bytes[start] == 0x45 &&
+    bytes[start + 1] == 0x78 &&
+    bytes[start + 2] == 0x69 &&
+    bytes[start + 3] == 0x66 &&
+    bytes[start + 4] == 0 &&
+    bytes[start + 5] == 0;
+
+/// Walks IFD0 of the TIFF block starting at [tiff] for the orientation tag.
+int? _orientationInTiff(ByteData data, int tiff, int end) {
+  if (tiff + 8 > end) return null;
+  final byteOrder = data.getUint16(tiff);
+  if (byteOrder != 0x4949 && byteOrder != 0x4D4D) return null;
+  final endian = byteOrder == 0x4949 ? Endian.little : Endian.big;
+  if (data.getUint16(tiff + 2, endian) != 42) return null;
+  final ifd = tiff + data.getUint32(tiff + 4, endian);
+  if (ifd + 2 > end) return null;
+  final entries = data.getUint16(ifd, endian);
+  for (var i = 0; i < entries; i++) {
+    final entry = ifd + 2 + i * 12;
+    if (entry + 12 > end) return null;
+    if (data.getUint16(entry, endian) != 0x0112) continue;
+    // The value is inline in the entry's last four bytes (SHORT or LONG - both
+    // fit), left-aligned, so a SHORT reads straight off the front of it.
+    final type = data.getUint16(entry + 2, endian);
+    final value = switch (type) {
+      3 => data.getUint16(entry + 8, endian),
+      4 => data.getUint32(entry + 8, endian),
+      _ => null,
+    };
+    return value != null && value >= 1 && value <= 8 ? value : null;
+  }
+  return null;
+}

--- a/app/lib/digital_signature.dart
+++ b/app/lib/digital_signature.dart
@@ -51,9 +51,10 @@ typedef DigitalSignaturePrivateKeyPicker = Future<XFile?> Function();
 typedef DigitalSignatureCertificatePicker = Future<List<XFile>> Function();
 
 /// Supplies PNG or JPEG bytes for the signature box's logo backdrop
-/// ([PdfSignatureAppearance.backgroundImage]) - typically a file picker.
-/// Returns null to cancel.
-typedef SignatureLogoPicker = Future<Uint8List?> Function();
+/// ([PdfSignatureAppearance.backgroundImage]) - typically a file picker, or a
+/// source sheet on mobile, which is why it is handed the dialog's own
+/// [BuildContext] to present from. Returns null to cancel.
+typedef SignatureLogoPicker = Future<Uint8List?> Function(BuildContext context);
 
 /// The page and rectangle (PDF user space) a visible signature box will be
 /// drawn into - handed to the dialog by the signature-box placement tool.
@@ -505,7 +506,7 @@ class _DigitalSignatureDialogState extends State<DigitalSignatureDialog> {
   Future<void> _pickLogo() async {
     final picker = widget.logoPicker;
     if (picker == null) return;
-    final bytes = await picker();
+    final bytes = await picker(context);
     if (bytes == null || !mounted) return;
     // fail early on a format the embedder can't take, rather than at sign time
     try {

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -19,6 +19,7 @@ import 'document_tab.dart';
 import 'file_io.dart';
 import 'image_clipboard.dart';
 import 'image_export.dart';
+import 'image_source_picker.dart';
 import 'incoming_file.dart';
 import 'keyless_identity_cache.dart';
 import 'keyless_signing.dart';
@@ -1698,9 +1699,7 @@ class _EditorScreenState extends State<EditorScreen>
                         ? null
                         : (context) => _obtainKeyless(context, silentProvider),
                 placement: placement,
-                logoPicker: placement == null
-                    ? null
-                    : () => pickImageBytes(appL10n(context).fileTypeImages),
+                logoPicker: placement == null ? null : pickImageBytesFromSource,
                 pageCount: session.document.pageCount,
               ))(context);
       if (!mounted || options == null || !_tabs.contains(tab)) return;
@@ -2442,9 +2441,8 @@ class _EditorScreenState extends State<EditorScreen>
           pdfLabel: appL10n(context).fileTypePdf)),
       onAction: _onAction,
       annotationMenuBuilder: _annotationMenuActions,
-      formImagePicker: (context, field) =>
-          pickImageBytes(appL10n(context).fileTypeImages),
-      imagePicker: (context) => pickImageBytes(appL10n(context).fileTypeImages),
+      formImagePicker: (context, field) => pickImageBytesFromSource(context),
+      imagePicker: pickImageBytesFromSource,
       systemImagePasteProvider: (context) =>
           (widget.imageClipboardReader ?? readImageFromClipboard)(),
       systemTextPasteProvider: (context) =>

--- a/app/lib/image_source_picker.dart
+++ b/app/lib/image_source_picker.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'camera_capture.dart';
+import 'file_io.dart';
+import 'l10n/app_l10n.dart';
+
+/// Where the picture the user wants to place comes from.
+enum ImagePickSource { camera, file }
+
+/// Picks an image for the editor - the image tool, a form push button's icon,
+/// or a signature's logo backdrop.
+///
+/// On a phone or tablet the picture is as often in front of the camera as it
+/// is a file (a receipt, a whiteboard, a hand-signed page), and the OS file
+/// picker cannot offer the camera - so ask first, then take the photo or open
+/// the file picker. Everywhere else there is no camera worth offering and this
+/// goes straight to the file picker, exactly as before.
+///
+/// Returns null when the user cancels, at either step.
+Future<Uint8List?> pickImageBytesFromSource(BuildContext context) async {
+  final l10n = appL10n(context);
+  if (!supportsCameraCapture) return _pickImageFile(l10n.fileTypeImages);
+
+  final messenger = ScaffoldMessenger.maybeOf(context);
+  final source = await _showImageSourceSheet(context);
+  if (source == null) return null;
+  if (source == ImagePickSource.file) {
+    return _pickImageFile(l10n.fileTypeImages);
+  }
+
+  try {
+    return await captureImageFromCamera();
+  } catch (_) {
+    // No camera on the device, or camera access refused - the OS has already
+    // had its say in that case, so keep ours to a toast.
+    messenger?.showSnackBar(
+      SnackBar(content: Text(l10n.imageSourceCameraFailed)),
+    );
+    return null;
+  }
+}
+
+/// A file pick, put upright the same way a capture is: a photo picked out of
+/// the gallery (or off a desktop's disk) carries the very EXIF rotation the
+/// camera wrote, and the PDF embeds JPEG bytes verbatim either way. Anything
+/// already upright - and every PNG - passes through untouched.
+Future<Uint8List?> _pickImageFile(String label) async {
+  final bytes = await pickImageBytes(label);
+  return bytes == null ? null : uprightJpeg(bytes);
+}
+
+/// Asks where the picture should come from. Returns null when the sheet is
+/// dismissed without a choice.
+Future<ImagePickSource?> _showImageSourceSheet(BuildContext context) {
+  final l10n = appL10n(context);
+  return showModalBottomSheet<ImagePickSource>(
+    context: context,
+    builder: (context) => SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.photo_camera_outlined),
+            title: Text(l10n.imageSourceTakePhoto),
+            onTap: () => Navigator.pop(context, ImagePickSource.camera),
+          ),
+          ListTile(
+            leading: const Icon(Icons.image_outlined),
+            title: Text(l10n.imageSourceChooseFile),
+            onTap: () => Navigator.pop(context, ImagePickSource.file),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "جارٍ التنزيل… {percent}%",
   "updateRestarting": "جارٍ إعادة التشغيل لإكمال التحديث…",
   "updateHandedOff": "تم تنزيل التحديث. جارٍ فتح المُثبِّت…",
-  "updateFailed": "فشل التحديث: {error}"
+  "updateFailed": "فشل التحديث: {error}",
+  "imageSourceTakePhoto": "التقاط صورة",
+  "imageSourceChooseFile": "اختيار ملف",
+  "imageSourceCameraFailed": "تعذّر التقاط صورة"
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Wird heruntergeladen… {percent}%",
   "updateRestarting": "Neustart, um das Update abzuschließen…",
   "updateHandedOff": "Update heruntergeladen. Installationsprogramm wird geöffnet…",
-  "updateFailed": "Update fehlgeschlagen: {error}"
+  "updateFailed": "Update fehlgeschlagen: {error}",
+  "imageSourceTakePhoto": "Foto aufnehmen",
+  "imageSourceChooseFile": "Datei auswählen",
+  "imageSourceCameraFailed": "Foto konnte nicht aufgenommen werden"
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1259,5 +1259,17 @@
   "appSigErrorNoCertificateFound": "No X.509 certificates were found.",
   "@appSigErrorNoCertificateFound":   {
       "description": "Signing error: the chosen files contained no X.509 certificate."
+  },
+  "imageSourceTakePhoto": "Take photo",
+  "@imageSourceTakePhoto":   {
+      "description": "Bottom-sheet option (mobile only) that photographs the picture to insert with the device camera."
+  },
+  "imageSourceChooseFile": "Choose file",
+  "@imageSourceChooseFile":   {
+      "description": "Bottom-sheet option (mobile only) that picks the picture to insert from a file instead of the camera."
+  },
+  "imageSourceCameraFailed": "Couldn't take a photo",
+  "@imageSourceCameraFailed":   {
+      "description": "Toast shown when the camera cannot be opened - no camera on the device, or access refused."
   }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Descargando… {percent}%",
   "updateRestarting": "Reiniciando para completar la actualización…",
   "updateHandedOff": "Actualización descargada. Abriendo el instalador…",
-  "updateFailed": "Error en la actualización: {error}"
+  "updateFailed": "Error en la actualización: {error}",
+  "imageSourceTakePhoto": "Hacer foto",
+  "imageSourceChooseFile": "Elegir archivo",
+  "imageSourceCameraFailed": "No se pudo hacer la foto"
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Téléchargement… {percent}%",
   "updateRestarting": "Redémarrage pour terminer la mise à jour…",
   "updateHandedOff": "Mise à jour téléchargée. Ouverture du programme d’installation…",
-  "updateFailed": "Échec de la mise à jour : {error}"
+  "updateFailed": "Échec de la mise à jour : {error}",
+  "imageSourceTakePhoto": "Prendre une photo",
+  "imageSourceChooseFile": "Choisir un fichier",
+  "imageSourceCameraFailed": "Impossible de prendre une photo"
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "डाउनलोड हो रहा है… {percent}%",
   "updateRestarting": "अपडेट पूरा करने के लिए पुनरारंभ हो रहा है…",
   "updateHandedOff": "अपडेट डाउनलोड हो गया. इंस्टॉलर खोला जा रहा है…",
-  "updateFailed": "अपडेट विफल: {error}"
+  "updateFailed": "अपडेट विफल: {error}",
+  "imageSourceTakePhoto": "फ़ोटो लें",
+  "imageSourceChooseFile": "फ़ाइल चुनें",
+  "imageSourceCameraFailed": "फ़ोटो नहीं ली जा सकी"
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Mengunduh… {percent}%",
   "updateRestarting": "Memulai ulang untuk menyelesaikan pembaruan…",
   "updateHandedOff": "Pembaruan diunduh. Membuka penginstal…",
-  "updateFailed": "Pembaruan gagal: {error}"
+  "updateFailed": "Pembaruan gagal: {error}",
+  "imageSourceTakePhoto": "Ambil foto",
+  "imageSourceChooseFile": "Pilih berkas",
+  "imageSourceCameraFailed": "Tidak dapat mengambil foto"
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Download… {percent}%",
   "updateRestarting": "Riavvio per completare l’aggiornamento…",
   "updateHandedOff": "Aggiornamento scaricato. Apertura del programma di installazione…",
-  "updateFailed": "Aggiornamento non riuscito: {error}"
+  "updateFailed": "Aggiornamento non riuscito: {error}",
+  "imageSourceTakePhoto": "Scatta foto",
+  "imageSourceChooseFile": "Scegli file",
+  "imageSourceCameraFailed": "Impossibile scattare la foto"
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "ダウンロード中… {percent}%",
   "updateRestarting": "更新を完了するために再起動しています…",
   "updateHandedOff": "更新をダウンロードしました。インストーラーを開いています…",
-  "updateFailed": "更新に失敗しました: {error}"
+  "updateFailed": "更新に失敗しました: {error}",
+  "imageSourceTakePhoto": "写真を撮る",
+  "imageSourceChooseFile": "ファイルを選択",
+  "imageSourceCameraFailed": "写真を撮影できませんでした"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "다운로드 중… {percent}%",
   "updateRestarting": "업데이트를 완료하기 위해 다시 시작하는 중…",
   "updateHandedOff": "업데이트를 다운로드했습니다. 설치 프로그램을 여는 중…",
-  "updateFailed": "업데이트 실패: {error}"
+  "updateFailed": "업데이트 실패: {error}",
+  "imageSourceTakePhoto": "사진 촬영",
+  "imageSourceChooseFile": "파일 선택",
+  "imageSourceCameraFailed": "사진을 촬영하지 못했습니다"
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -1548,6 +1548,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No X.509 certificates were found.'**
   String get appSigErrorNoCertificateFound;
+
+  /// Bottom-sheet option (mobile only) that photographs the picture to insert with the device camera.
+  ///
+  /// In en, this message translates to:
+  /// **'Take photo'**
+  String get imageSourceTakePhoto;
+
+  /// Bottom-sheet option (mobile only) that picks the picture to insert from a file instead of the camera.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose file'**
+  String get imageSourceChooseFile;
+
+  /// Toast shown when the camera cannot be opened - no camera on the device, or access refused.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t take a photo'**
+  String get imageSourceCameraFailed;
 }
 
 class _AppLocalizationsDelegate

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -975,4 +975,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => 'لم يُعثر على أي شهادات X.509.';
+
+  @override
+  String get imageSourceTakePhoto => 'التقاط صورة';
+
+  @override
+  String get imageSourceChooseFile => 'اختيار ملف';
+
+  @override
+  String get imageSourceCameraFailed => 'تعذّر التقاط صورة';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -964,4 +964,13 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Es wurden keine X.509-Zertifikate gefunden.';
+
+  @override
+  String get imageSourceTakePhoto => 'Foto aufnehmen';
+
+  @override
+  String get imageSourceChooseFile => 'Datei auswählen';
+
+  @override
+  String get imageSourceCameraFailed => 'Foto konnte nicht aufgenommen werden';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -947,4 +947,13 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'No X.509 certificates were found.';
+
+  @override
+  String get imageSourceTakePhoto => 'Take photo';
+
+  @override
+  String get imageSourceChooseFile => 'Choose file';
+
+  @override
+  String get imageSourceCameraFailed => 'Couldn\'t take a photo';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -962,4 +962,13 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'No se encontraron certificados X.509.';
+
+  @override
+  String get imageSourceTakePhoto => 'Hacer foto';
+
+  @override
+  String get imageSourceChooseFile => 'Elegir archivo';
+
+  @override
+  String get imageSourceCameraFailed => 'No se pudo hacer la foto';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -963,4 +963,13 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Aucun certificat X.509 n\'a été trouvé.';
+
+  @override
+  String get imageSourceTakePhoto => 'Prendre une photo';
+
+  @override
+  String get imageSourceChooseFile => 'Choisir un fichier';
+
+  @override
+  String get imageSourceCameraFailed => 'Impossible de prendre une photo';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -949,4 +949,13 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => 'कोई X.509 प्रमाणपत्र नहीं मिला।';
+
+  @override
+  String get imageSourceTakePhoto => 'फ़ोटो लें';
+
+  @override
+  String get imageSourceChooseFile => 'फ़ाइल चुनें';
+
+  @override
+  String get imageSourceCameraFailed => 'फ़ोटो नहीं ली जा सकी';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -953,4 +953,13 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Tidak ada sertifikat X.509 yang ditemukan.';
+
+  @override
+  String get imageSourceTakePhoto => 'Ambil foto';
+
+  @override
+  String get imageSourceChooseFile => 'Pilih berkas';
+
+  @override
+  String get imageSourceCameraFailed => 'Tidak dapat mengambil foto';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -959,4 +959,13 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Nessun certificato X.509 trovato.';
+
+  @override
+  String get imageSourceTakePhoto => 'Scatta foto';
+
+  @override
+  String get imageSourceChooseFile => 'Scegli file';
+
+  @override
+  String get imageSourceCameraFailed => 'Impossibile scattare la foto';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -932,4 +932,13 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => 'X.509 証明書が見つかりませんでした。';
+
+  @override
+  String get imageSourceTakePhoto => '写真を撮る';
+
+  @override
+  String get imageSourceChooseFile => 'ファイルを選択';
+
+  @override
+  String get imageSourceCameraFailed => '写真を撮影できませんでした';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -930,4 +930,13 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => 'X.509 인증서를 찾을 수 없습니다.';
+
+  @override
+  String get imageSourceTakePhoto => '사진 촬영';
+
+  @override
+  String get imageSourceChooseFile => '파일 선택';
+
+  @override
+  String get imageSourceCameraFailed => '사진을 촬영하지 못했습니다';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -961,4 +961,13 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Er zijn geen X.509-certificaten gevonden.';
+
+  @override
+  String get imageSourceTakePhoto => 'Foto maken';
+
+  @override
+  String get imageSourceChooseFile => 'Bestand kiezen';
+
+  @override
+  String get imageSourceCameraFailed => 'Kan geen foto maken';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -983,4 +983,13 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Nie znaleziono certyfikatów X.509.';
+
+  @override
+  String get imageSourceTakePhoto => 'Zrób zdjęcie';
+
+  @override
+  String get imageSourceChooseFile => 'Wybierz plik';
+
+  @override
+  String get imageSourceCameraFailed => 'Nie udało się zrobić zdjęcia';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -959,4 +959,13 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Nenhum certificado X.509 foi encontrado.';
+
+  @override
+  String get imageSourceTakePhoto => 'Tirar foto';
+
+  @override
+  String get imageSourceChooseFile => 'Escolher arquivo';
+
+  @override
+  String get imageSourceCameraFailed => 'Não foi possível tirar a foto';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -966,4 +966,13 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => 'Сертификаты X.509 не найдены.';
+
+  @override
+  String get imageSourceTakePhoto => 'Сделать снимок';
+
+  @override
+  String get imageSourceChooseFile => 'Выбрать файл';
+
+  @override
+  String get imageSourceCameraFailed => 'Не удалось сделать снимок';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -944,4 +944,13 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => 'ไม่พบใบรับรอง X.509';
+
+  @override
+  String get imageSourceTakePhoto => 'ถ่ายภาพ';
+
+  @override
+  String get imageSourceChooseFile => 'เลือกไฟล์';
+
+  @override
+  String get imageSourceCameraFailed => 'ถ่ายภาพไม่สำเร็จ';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -950,4 +950,13 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Hiç X.509 sertifikası bulunamadı.';
+
+  @override
+  String get imageSourceTakePhoto => 'Fotoğraf çek';
+
+  @override
+  String get imageSourceChooseFile => 'Dosya seç';
+
+  @override
+  String get imageSourceCameraFailed => 'Fotoğraf çekilemedi';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -969,4 +969,13 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => 'Сертифікатів X.509 не знайдено.';
+
+  @override
+  String get imageSourceTakePhoto => 'Зробити знімок';
+
+  @override
+  String get imageSourceChooseFile => 'Вибрати файл';
+
+  @override
+  String get imageSourceCameraFailed => 'Не вдалося зробити знімок';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -950,4 +950,13 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get appSigErrorNoCertificateFound =>
       'Không tìm thấy chứng chỉ X.509 nào.';
+
+  @override
+  String get imageSourceTakePhoto => 'Chụp ảnh';
+
+  @override
+  String get imageSourceChooseFile => 'Chọn tệp';
+
+  @override
+  String get imageSourceCameraFailed => 'Không thể chụp ảnh';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -925,6 +925,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get appSigErrorNoCertificateFound => '未找到 X.509 证书。';
+
+  @override
+  String get imageSourceTakePhoto => '拍照';
+
+  @override
+  String get imageSourceChooseFile => '选择文件';
+
+  @override
+  String get imageSourceCameraFailed => '无法拍照';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).
@@ -1849,4 +1858,13 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get appSigErrorNoCertificateFound => '找不到 X.509 憑證。';
+
+  @override
+  String get imageSourceTakePhoto => '拍照';
+
+  @override
+  String get imageSourceChooseFile => '選擇檔案';
+
+  @override
+  String get imageSourceCameraFailed => '無法拍照';
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Downloaden… {percent}%",
   "updateRestarting": "Opnieuw opstarten om de update te voltooien…",
   "updateHandedOff": "Update gedownload. Installatieprogramma wordt geopend…",
-  "updateFailed": "Bijwerken mislukt: {error}"
+  "updateFailed": "Bijwerken mislukt: {error}",
+  "imageSourceTakePhoto": "Foto maken",
+  "imageSourceChooseFile": "Bestand kiezen",
+  "imageSourceCameraFailed": "Kan geen foto maken"
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Pobieranie… {percent}%",
   "updateRestarting": "Ponowne uruchamianie, aby dokończyć aktualizację…",
   "updateHandedOff": "Pobrano aktualizację. Otwieranie instalatora…",
-  "updateFailed": "Aktualizacja nie powiodła się: {error}"
+  "updateFailed": "Aktualizacja nie powiodła się: {error}",
+  "imageSourceTakePhoto": "Zrób zdjęcie",
+  "imageSourceChooseFile": "Wybierz plik",
+  "imageSourceCameraFailed": "Nie udało się zrobić zdjęcia"
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Baixando… {percent}%",
   "updateRestarting": "Reiniciando para concluir a atualização…",
   "updateHandedOff": "Atualização baixada. Abrindo o instalador…",
-  "updateFailed": "Falha na atualização: {error}"
+  "updateFailed": "Falha na atualização: {error}",
+  "imageSourceTakePhoto": "Tirar foto",
+  "imageSourceChooseFile": "Escolher arquivo",
+  "imageSourceCameraFailed": "Não foi possível tirar a foto"
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Загрузка… {percent}%",
   "updateRestarting": "Перезапуск для завершения обновления…",
   "updateHandedOff": "Обновление загружено. Открытие установщика…",
-  "updateFailed": "Не удалось обновить: {error}"
+  "updateFailed": "Не удалось обновить: {error}",
+  "imageSourceTakePhoto": "Сделать снимок",
+  "imageSourceChooseFile": "Выбрать файл",
+  "imageSourceCameraFailed": "Не удалось сделать снимок"
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "กำลังดาวน์โหลด… {percent}%",
   "updateRestarting": "กำลังรีสตาร์ทเพื่อสิ้นสุดการอัปเดต…",
   "updateHandedOff": "ดาวน์โหลดการอัปเดตแล้ว กำลังเปิดตัวติดตั้ง…",
-  "updateFailed": "การอัปเดตล้มเหลว: {error}"
+  "updateFailed": "การอัปเดตล้มเหลว: {error}",
+  "imageSourceTakePhoto": "ถ่ายภาพ",
+  "imageSourceChooseFile": "เลือกไฟล์",
+  "imageSourceCameraFailed": "ถ่ายภาพไม่สำเร็จ"
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "İndiriliyor… {percent}%",
   "updateRestarting": "Güncellemeyi tamamlamak için yeniden başlatılıyor…",
   "updateHandedOff": "Güncelleme indirildi. Yükleyici açılıyor…",
-  "updateFailed": "Güncelleme başarısız: {error}"
+  "updateFailed": "Güncelleme başarısız: {error}",
+  "imageSourceTakePhoto": "Fotoğraf çek",
+  "imageSourceChooseFile": "Dosya seç",
+  "imageSourceCameraFailed": "Fotoğraf çekilemedi"
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Завантаження… {percent}%",
   "updateRestarting": "Перезапуск для завершення оновлення…",
   "updateHandedOff": "Оновлення завантажено. Відкриття інсталятора…",
-  "updateFailed": "Не вдалося оновити: {error}"
+  "updateFailed": "Не вдалося оновити: {error}",
+  "imageSourceTakePhoto": "Зробити знімок",
+  "imageSourceChooseFile": "Вибрати файл",
+  "imageSourceCameraFailed": "Не вдалося зробити знімок"
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "Đang tải xuống… {percent}%",
   "updateRestarting": "Đang khởi động lại để hoàn tất cập nhật…",
   "updateHandedOff": "Đã tải xuống bản cập nhật. Đang mở trình cài đặt…",
-  "updateFailed": "Cập nhật thất bại: {error}"
+  "updateFailed": "Cập nhật thất bại: {error}",
+  "imageSourceTakePhoto": "Chụp ảnh",
+  "imageSourceChooseFile": "Chọn tệp",
+  "imageSourceCameraFailed": "Không thể chụp ảnh"
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "正在下载… {percent}%",
   "updateRestarting": "正在重启以完成更新…",
   "updateHandedOff": "更新已下载。正在打开安装程序…",
-  "updateFailed": "更新失败：{error}"
+  "updateFailed": "更新失败：{error}",
+  "imageSourceTakePhoto": "拍照",
+  "imageSourceChooseFile": "选择文件",
+  "imageSourceCameraFailed": "无法拍照"
 }

--- a/app/lib/l10n/app_zh_Hant.arb
+++ b/app/lib/l10n/app_zh_Hant.arb
@@ -235,5 +235,8 @@
   "updateDownloadingPercent": "正在下載… {percent}%",
   "updateRestarting": "正在重新啟動以完成更新…",
   "updateHandedOff": "更新已下載。正在開啟安裝程式…",
-  "updateFailed": "更新失敗：{error}"
+  "updateFailed": "更新失敗：{error}",
+  "imageSourceTakePhoto": "拍照",
+  "imageSourceChooseFile": "選擇檔案",
+  "imageSourceCameraFailed": "無法拍照"
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -60,6 +60,14 @@ dependencies:
   # pubspec version above), so the About box can't drift from the release.
   package_info_plus: ^10.2.1
   web: ^1.1.1
+  # The camera source for the image tool on phones and tablets - the OS file
+  # picker cannot offer one (see lib/image_source_picker.dart). Needs
+  # NSCameraUsageDescription in ios/Runner/Info.plist.
+  image_picker: ^1.2.3
+  # Re-encodes a camera capture whose EXIF says it is rotated: PDF embeds JPEG
+  # bytes verbatim and has no orientation tag, so the rotation has to be baked
+  # into the pixels (lib/camera_capture.dart).
+  image: ^4.9.1
 
 dev_dependencies:
   flutter_test:
@@ -83,6 +91,9 @@ dev_dependencies:
   # the recognized layer is selectable (pdf_ocr_ondevice is a runtime dep).
   pdf_graphics: ^3.0.0
   file_selector_platform_interface: ^2.7.0
+  # Lets the widget tests stand in for the camera the way they already stand in
+  # for the file picker.
+  image_picker_platform_interface: ^2.11.1
 
 # Microsoft Store MSIX packaging. Only the account-neutral settings live here;
 # the three Partner Center identity values (identity_name, publisher,

--- a/app/test/digital_signature_test.dart
+++ b/app/test/digital_signature_test.dart
@@ -494,7 +494,7 @@ void main() {
                 createSelfSignedIdentity: (context, store) async =>
                     PdfSigningIdentity.generate(name: 'Ada Lovelace'),
                 placement: (page: 0, rect: const PdfRect(72, 640, 320, 720)),
-                logoPicker: () async => logo,
+                logoPicker: (_) async => logo,
                 pageCount: 4,
               );
             },
@@ -564,7 +564,7 @@ void main() {
                 createSelfSignedIdentity: (context, s) async =>
                     PdfSigningIdentity.generate(name: 'Ada Lovelace'),
                 placement: (page: 0, rect: const PdfRect(72, 640, 320, 720)),
-                logoPicker: () async => logo,
+                logoPicker: (_) async => logo,
                 appearanceStore: store,
               ),
               child: const Text('Open'),

--- a/app/test/image_source_picker_test.dart
+++ b/app/test/image_source_picker_test.dart
@@ -1,0 +1,250 @@
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart'
+    as fs;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+
+import 'package:dart_pdf_editor_app/camera_capture.dart';
+import 'package:dart_pdf_editor_app/image_source_picker.dart';
+
+/// Stands in for the OS file picker (the "Choose file" branch).
+class _FakeFileSelector extends fs.FileSelectorPlatform {
+  _FakeFileSelector(this.file);
+
+  final fs.XFile? file;
+  bool opened = false;
+
+  @override
+  Future<fs.XFile?> openFile({
+    List<fs.XTypeGroup>? acceptedTypeGroups,
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    opened = true;
+    return file;
+  }
+}
+
+/// Stands in for the camera (the "Take photo" branch).
+class _FakeImagePicker extends ImagePickerPlatform {
+  _FakeImagePicker({this.photo, this.error});
+
+  final Uint8List? photo;
+  final Object? error;
+  ImageSource? requestedSource;
+  ImagePickerOptions? options;
+
+  @override
+  Future<XFile?> getImageFromSource({
+    required ImageSource source,
+    ImagePickerOptions options = const ImagePickerOptions(),
+  }) async {
+    requestedSource = source;
+    this.options = options;
+    if (error != null) throw error!;
+    final bytes = photo;
+    return bytes == null ? null : XFile.fromData(bytes, name: 'photo.jpg');
+  }
+}
+
+/// A real (tiny) JPEG, optionally tagged with an EXIF orientation.
+Uint8List _jpeg({int width = 8, int height = 4, int? orientation}) {
+  final image = img.Image(width: width, height: height);
+  img.fill(image, color: img.ColorRgb8(200, 40, 40));
+  // A stripe down the left edge, so a rotation is visible in the pixels.
+  img.fillRect(image,
+      x1: 0, y1: 0, x2: 0, y2: height - 1, color: img.ColorRgb8(0, 0, 0));
+  if (orientation != null) image.exif.imageIfd.orientation = orientation;
+  return img.encodeJpg(image, quality: 95);
+}
+
+/// Starts a pick and hands back its still-pending future, so the test can
+/// drive the sheet before awaiting the result.
+Future<Future<Uint8List?>> _startPick(WidgetTester tester) async {
+  late Future<Uint8List?> pending;
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: Builder(
+        builder: (context) => TextButton(
+          onPressed: () => pending = pickImageBytesFromSource(context),
+          child: const Text('pick'),
+        ),
+      ),
+    ),
+  ));
+  await tester.tap(find.text('pick'));
+  await tester.pumpAndSettle();
+  return pending;
+}
+
+/// A [testWidgets] that runs as [platform]. The override has to be cleared
+/// before the body returns - the binding checks it as an invariant, ahead of
+/// any tearDown.
+void testWidgetsOn(
+  String description,
+  TargetPlatform platform,
+  Future<void> Function(WidgetTester tester) body,
+) {
+  testWidgets(description, (tester) async {
+    debugDefaultTargetPlatformOverride = platform;
+    try {
+      await body(tester);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}
+
+void main() {
+  group('source sheet', () {
+    testWidgetsOn('mobile offers the camera, and shoots when it is chosen',
+        TargetPlatform.android, (tester) async {
+      final camera = _FakeImagePicker(photo: _jpeg());
+      final originalCamera = ImagePickerPlatform.instance;
+      ImagePickerPlatform.instance = camera;
+      addTearDown(() => ImagePickerPlatform.instance = originalCamera);
+      final files = _FakeFileSelector(null);
+      final originalFiles = fs.FileSelectorPlatform.instance;
+      fs.FileSelectorPlatform.instance = files;
+      addTearDown(() => fs.FileSelectorPlatform.instance = originalFiles);
+
+      final picked = await _startPick(tester);
+      expect(find.text('Take photo'), findsOneWidget);
+      expect(find.text('Choose file'), findsOneWidget);
+
+      await tester.tap(find.text('Take photo'));
+      await tester.pumpAndSettle();
+
+      expect(await picked, isNotNull);
+      expect(camera.requestedSource, ImageSource.camera);
+      // The full-size sensor frame never crosses the channel.
+      expect(camera.options!.maxWidth, cameraCaptureMaxDimension);
+      expect(camera.options!.maxHeight, cameraCaptureMaxDimension);
+      expect(camera.options!.imageQuality, cameraCaptureQuality);
+      expect(files.opened, isFalse);
+    });
+
+    testWidgetsOn('"Choose file" still goes to the OS file picker',
+        TargetPlatform.android, (tester) async {
+      final camera = _FakeImagePicker(photo: _jpeg());
+      final originalCamera = ImagePickerPlatform.instance;
+      ImagePickerPlatform.instance = camera;
+      addTearDown(() => ImagePickerPlatform.instance = originalCamera);
+      final files =
+          _FakeFileSelector(fs.XFile.fromData(_jpeg(), name: 'photo.jpg'));
+      final originalFiles = fs.FileSelectorPlatform.instance;
+      fs.FileSelectorPlatform.instance = files;
+      addTearDown(() => fs.FileSelectorPlatform.instance = originalFiles);
+
+      final picked = await _startPick(tester);
+      await tester.tap(find.text('Choose file'));
+      await tester.pumpAndSettle();
+
+      expect(await picked, isNotNull);
+      expect(files.opened, isTrue);
+      expect(camera.requestedSource, isNull);
+    });
+
+    testWidgetsOn('a rotated file pick is put upright too',
+        TargetPlatform.android, (tester) async {
+      final files = _FakeFileSelector(
+          fs.XFile.fromData(_jpeg(orientation: 6), name: 'photo.jpg'));
+      final originalFiles = fs.FileSelectorPlatform.instance;
+      fs.FileSelectorPlatform.instance = files;
+      addTearDown(() => fs.FileSelectorPlatform.instance = originalFiles);
+
+      // A widget test cannot await the real isolate hop (`compute` makes no
+      // progress in the fake-async zone), so bake in place here. The isolate
+      // path itself is covered by the plain tests below.
+      debugBakeOrientationOffIsolate = (bytes) async =>
+          bakeJpegOrientation(bytes);
+      addTearDown(() => debugBakeOrientationOffIsolate = null);
+
+      final picked = await _startPick(tester);
+      await tester.tap(find.text('Choose file'));
+      await tester.pumpAndSettle();
+
+      final bytes = await picked;
+      expect(jpegExifOrientation(bytes!), isNull);
+      expect(img.decodeJpg(bytes)!.width, 4);
+    });
+
+    testWidgetsOn('dismissing the sheet cancels the pick',
+        TargetPlatform.android, (tester) async {
+      final files = _FakeFileSelector(null);
+      final originalFiles = fs.FileSelectorPlatform.instance;
+      fs.FileSelectorPlatform.instance = files;
+      addTearDown(() => fs.FileSelectorPlatform.instance = originalFiles);
+
+      final picked = await _startPick(tester);
+      await tester.tapAt(const Offset(400, 20)); // the scrim
+      await tester.pumpAndSettle();
+
+      expect(await picked, isNull);
+      expect(files.opened, isFalse);
+    });
+
+    testWidgetsOn('a camera that will not open toasts instead of throwing',
+        TargetPlatform.android, (tester) async {
+      final camera = _FakeImagePicker(error: StateError('no camera'));
+      final originalCamera = ImagePickerPlatform.instance;
+      ImagePickerPlatform.instance = camera;
+      addTearDown(() => ImagePickerPlatform.instance = originalCamera);
+
+      final picked = await _startPick(tester);
+      await tester.tap(find.text('Take photo'));
+      await tester.pumpAndSettle();
+
+      expect(await picked, isNull);
+      expect(find.text("Couldn't take a photo"), findsOneWidget);
+    });
+
+    testWidgetsOn('desktop skips the sheet and opens the file picker',
+        TargetPlatform.linux, (tester) async {
+      final files =
+          _FakeFileSelector(fs.XFile.fromData(_jpeg(), name: 'photo.jpg'));
+      final originalFiles = fs.FileSelectorPlatform.instance;
+      fs.FileSelectorPlatform.instance = files;
+      addTearDown(() => fs.FileSelectorPlatform.instance = originalFiles);
+
+      final picked = await _startPick(tester);
+      expect(find.text('Take photo'), findsNothing);
+
+      expect(await picked, isNotNull);
+      expect(files.opened, isTrue);
+    });
+  });
+
+  group('EXIF orientation', () {
+    test('reads the orientation tag out of a JPEG', () {
+      expect(jpegExifOrientation(_jpeg(orientation: 6)), 6);
+      expect(jpegExifOrientation(_jpeg(orientation: 1)), 1);
+    });
+
+    test('a JPEG without EXIF, or a non-JPEG, reads as unrotated', () {
+      expect(jpegExifOrientation(_jpeg()), isNull);
+      expect(jpegExifOrientation(Uint8List.fromList([1, 2, 3, 4])), isNull);
+      expect(jpegExifOrientation(Uint8List(0)), isNull);
+    });
+
+    test('an unrotated capture is embedded byte-for-byte', () async {
+      final bytes = _jpeg();
+      expect(await uprightJpeg(bytes), same(bytes));
+      final tagged = _jpeg(orientation: 1);
+      expect(await uprightJpeg(tagged), same(tagged));
+    });
+
+    test('a rotated capture is baked upright', () async {
+      // Orientation 6: the pixels are stored rotated 90° counter-clockwise
+      // from how the photo should read, so upright swaps width and height.
+      final bytes = _jpeg(width: 8, height: 4, orientation: 6);
+      final upright = img.decodeJpg(await uprightJpeg(bytes))!;
+      expect(upright.width, 4);
+      expect(upright.height, 8);
+      // The tag is cleared, so nothing downstream rotates it a second time.
+      expect(jpegExifOrientation(await uprightJpeg(bytes)), isNull);
+    });
+  });
+}

--- a/doc/dev-log/2026-07-25-mobile-camera-image-source.md
+++ b/doc/dev-log/2026-07-25-mobile-camera-image-source.md
@@ -1,0 +1,110 @@
+# Mobile: take the picture instead of finding it (camera image source)
+
+Every image the app inserts — the image tool, a form push button's icon,
+a signature's logo backdrop — went through one function,
+`pickImageBytes()` in `app/lib/file_io.dart`, which opens the OS *file*
+picker. That is the right and only answer on desktop. On a phone it is
+the wrong half of the story: the picture the user wants on the page is
+usually still in front of the camera (a receipt, a whiteboard, a
+hand-signed page), and neither Android's SAF picker nor iOS's Files sheet
+can offer a camera.
+
+So on Android/iOS the pick now starts with a source sheet — **Take
+photo** / **Choose file** — and only then opens the camera or the file
+picker. Desktop and web skip the sheet entirely and behave exactly as
+before (`supportsCameraCapture` is false there: `image_picker`'s desktop
+implementations have no camera, and a browser's file input already
+surfaces one where the device has it).
+
+New files, both in `app/lib`:
+
+- `image_source_picker.dart` — `pickImageBytesFromSource(context)`, the
+  drop-in replacement for `pickImageBytes` at the three call sites, plus
+  the sheet itself. Dismissing the sheet means "cancelled", same as
+  backing out of the file dialog.
+- `camera_capture.dart` — the capture, and the orientation fix below.
+
+`SignatureLogoPicker` grew a `BuildContext` parameter so the signature
+dialog presents the sheet from its own context rather than the editor's.
+
+## The capture is bounded before it crosses the channel
+
+A phone sensor shoots 12 MP+. Every one of those bytes would land in the
+saved PDF, for a picture that resolves to a fraction of a page (2000 px
+across an A4 width is already ~240 dpi). So the capture asks for
+`maxWidth`/`maxHeight` of 2000 and quality 88, which `image_picker`
+applies **natively** — the full-size frame never reaches Dart.
+
+## EXIF orientation has to be baked, or half of all photos land sideways
+
+This is the part that isn't obvious. `PdfEmbeddableImage.jpeg` embeds
+JPEG bytes **verbatim** under DCTDecode (that's the whole point — no
+re-encode, no quality loss), and PDF image XObjects have no orientation
+tag. A portrait phone shot, though, is normally stored as landscape
+pixels plus an EXIF `/Orientation` of 6, and `image_picker`'s Android
+resizer *deliberately* preserves that tag while rescaling
+(`ExifDataCopier` documents it as "crucial for proper display"). Embedded
+verbatim, that photo arrives on the page rotated 90°.
+
+iOS doesn't have the problem — its `scaledImage:` draws through a
+graphics context, which bakes the rotation into the pixels — but Android
+does, so the fix lives in Dart where it covers both:
+
+- `jpegExifOrientation()` walks the JPEG marker chain to APP1, checks the
+  `Exif\0\0` header (XMP shares the marker), and reads tag `0x0112` out
+  of IFD0 in whichever endianness the TIFF block declares. Anything
+  missing or malformed reads as null = "assume upright".
+- `uprightJpeg()` returns the **same bytes** when the orientation is
+  absent or 1 — the overwhelmingly common case, and the one where the
+  camera's own JPEG should reach the PDF untouched. Only a genuinely
+  rotated capture pays for `decodeJpg` → `bakeOrientation` → `encodeJpg`,
+  and that runs through `compute()` on a background isolate. Baking also
+  clears the tag, so nothing downstream can rotate it a second time.
+
+The **file** branch gets the same treatment, on every platform: a photo
+picked out of the gallery (or off a desktop's disk) carries the very
+rotation the camera wrote, so it embedded sideways before this change
+too. PNGs and already-upright JPEGs take the identity path, so nothing
+that was lossless stops being lossless.
+
+## Platform wiring
+
+- `image_picker: ^1.2.3` and `image: ^4.9.1` are new app dependencies
+  (`image` was already in the resolved tree via `dart_pdf_editor`, which
+  uses it to encode JPEG page exports).
+- `ios/Runner/Info.plist` gained `NSCameraUsageDescription` — iOS
+  **terminates** the app if the camera opens without it. No
+  photo-library key is needed: `requestFullMetadata: false` keeps the
+  capture off the library entirely.
+- Android needs nothing. The camera runs through `ACTION_IMAGE_CAPTURE`
+  and the plugin's own `FileProvider`, so there is no `CAMERA`
+  permission to declare — and declaring one would only add a runtime
+  prompt we don't otherwise need.
+
+## Tests
+
+`app/test/image_source_picker_test.dart` fakes both platforms the way the
+existing `file_io_test.dart` fakes the file selector — a
+`FileSelectorPlatform` for the file branch and an `ImagePickerPlatform`
+for the camera — and covers: the sheet appearing on mobile and shooting
+with the documented bounds, "Choose file" still reaching the file picker,
+dismissal cancelling, a camera that won't open toasting rather than
+throwing, and desktop never seeing the sheet. The orientation tests build
+real JPEGs with `package:image`, assert the tag reads back, that an
+unrotated capture is passed through by identity (`same()`), and that an
+orientation-6 capture comes back with its width and height swapped and
+the tag gone.
+
+Two flutter_test gotchas here. `compute()` never completes inside a
+widget test's fake-async zone — the isolate's reply is delivered on the
+real event loop, which the fake clock isn't draining, and `runAsync`
+can't rescue a future that was created outside it. Hence
+`debugBakeOrientationOffIsolate`, a null-in-production seam the one
+widget test that needs a rotated image sets to run the bake in place; the
+real `compute` path stays covered by the plain (non-widget) tests.
+
+And `debugDefaultTargetPlatformOverride` must be
+cleared **before the test body returns** — the binding verifies it as an
+invariant ahead of any `tearDown`, so a `tearDown`/`addTearDown` reset
+fails every test. Hence the local `testWidgetsOn(description, platform,
+body)` wrapper.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,6 +288,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_secure_storage:
     dependency: transitive
     description:
@@ -415,6 +423,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.1"
+  image_picker:
+    dependency: transitive
+    description:
+      name: image_picker
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+19"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   integration_test:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
## Summary

Every image the app inserts — the image tool, a form push button's icon, a signature's logo backdrop — went through one function, `pickImageBytes()`, which opens the OS **file** picker. That's the only sensible answer on desktop, but on a phone the picture is usually still in front of the camera (a receipt, a whiteboard, a hand-signed page), and neither Android's SAF picker nor iOS's Files sheet can offer one.

On Android/iOS a pick now starts with a source sheet — **Take photo** / **Choose file** — and only then opens the camera or the file picker. Desktop and web skip the sheet and behave exactly as before (`supportsCameraCapture` is false there: `image_picker`'s desktop implementations have no camera, and a browser's file input already surfaces one where the device has it). Dismissing the sheet means "cancelled", same as backing out of the file dialog; a camera that won't open (no camera, access refused) toasts instead of throwing.

Two details that aren't obvious:

- **The capture is bounded before it crosses the channel.** `maxWidth`/`maxHeight` 2000, quality 88, applied natively — a 12 MP sensor frame never reaches Dart, and never lands whole in the saved PDF (2000 px across an A4 width is already ~240 dpi).
- **EXIF orientation has to be baked, or half of all photos land sideways.** `PdfEmbeddableImage.jpeg` embeds JPEG bytes *verbatim* under DCTDecode and PDF image XObjects carry no orientation tag, while a portrait Android shot is stored as landscape pixels plus `/Orientation` 6 — which `image_picker`'s Android resizer deliberately preserves. So `uprightJpeg()` reads the tag out of APP1 and, only when it is not 1, decodes → `bakeOrientation` → re-encodes through `compute()` on a background isolate (and clears the tag, so nothing rotates it twice). Absent/normal orientation and every PNG take an identity path — nothing that was lossless stops being lossless. File picks get the same treatment on every platform, since a gallery photo carries the very same rotation.

Behaviour change outside mobile is limited to that last point: a rotated JPEG chosen from disk on desktop is now re-encoded upright instead of embedding sideways.

New files (both `app/lib`): `image_source_picker.dart` (the sheet + `pickImageBytesFromSource`, the drop-in for the three call sites) and `camera_capture.dart` (the capture + orientation fix). `SignatureLogoPicker` gained a `BuildContext` parameter so the signature dialog presents the sheet from its own context. Background and file pointers: `doc/dev-log/2026-07-25-mobile-camera-image-source.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

(Plus the DartPDF app itself — `app/`, which the list above doesn't name: `lib/`, its 20 ARB bundles, `pubspec.yaml`, and `ios/Runner/Info.plist`.)

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (`--fatal-infos`, clean across the workspace)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: nothing outside `app/` changed, so the engine package suites and the render corpora can't be affected — there is no interpreter, filter or rendering code in the diff. Instead: `cd app && fvm flutter test` (331 passing, including the 10 new ones) and `fvm flutter build web --release` to prove the new plugin dependency doesn't break the web target. The camera itself can only be exercised on a device — the tests fake `ImagePickerPlatform` the way the existing `file_io_test.dart` fakes the file selector.

## PDF fixtures and screenshots

None — the new tests build their JPEGs programmatically with `package:image` (including the EXIF-tagged ones).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **New dependencies:** `image_picker: ^1.2.3` (the camera) and `image: ^4.9.1` (the re-encode — already in the resolved tree via `dart_pdf_editor`, which uses it for JPEG page exports).
- **iOS:** `NSCameraUsageDescription` is now in `Info.plist` — iOS *terminates* the app if the camera opens without it, so it must stay as long as `camera_capture.dart` does. No photo-library key is needed: `requestFullMetadata: false` keeps captures off the library. **Android needs nothing** — the capture goes through `ACTION_IMAGE_CAPTURE` and the plugin's own `FileProvider`, so declaring a `CAMERA` permission would only add a runtime prompt.
- **Deliberately not included:** a third "Photo library" entry. `image_picker`'s gallery source would reach iOS Photos more directly than the Files sheet does, but that's a separate UX call and a separate permission story; this PR is the camera.
- **Two flutter_test gotchas**, both written up in the dev-log: `compute()` never completes inside a widget test's fake-async zone (hence `debugBakeOrientationOffIsolate`, a null-in-production seam — the real `compute` path stays covered by the plain tests), and `debugDefaultTargetPlatformOverride` must be cleared *before the test body returns*, ahead of any `tearDown` (hence the local `testWidgetsOn` wrapper).
- Translations for the three new strings were added to all 20 locale bundles and `gen-l10n` re-run; a native reader's eye on any of them is welcome.

---
_Generated by [Claude Code](https://claude.ai/code/session_019grZp1CHE3tTqcbQe1vfgL)_