### PR TITLE
Keep session restore responsive for remote PDFs

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -516,7 +516,9 @@ class _EditorScreenState extends State<EditorScreen>
     if (recovered.isEmpty || !mounted) return;
     final count = recovered.length;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _toast(appL10n(context).editorRecoveredUnsavedChanges(count));
+      if (mounted) {
+        _toast(appL10n(context).editorRecoveredUnsavedChanges(count));
+      }
     });
   }
 
@@ -527,27 +529,16 @@ class _EditorScreenState extends State<EditorScreen>
     // restores from its private snapshot instead.
     final originPath = doc.path.isNotEmpty ? doc.path : null;
 
-    // Desktop origin: restore lazily and progressively. Probe the file length
-    // first - cheap metadata, no content read or cloud hydration - so a moved
-    // or deleted file is still dropped silently, then add a path-only tab that
-    // reads nothing until it is shown, when it opens progressively. This keeps
-    // launch cheap even when the last session held several big files: only the
-    // active tab pulls bytes, and it first-paints from ranges.
+    // Desktop origin: restore every tab immediately, without awaiting even a
+    // metadata probe. A cloud provider can stall file coordination for one
+    // origin; making the restore loop await it would hide every later tab until
+    // that provider responded. Path-only tabs read nothing until selected, so
+    // the user can switch to another restored document while a remote one is
+    // hydrating. A missing file is dropped when its lazy open fails.
     if (progressiveOpenSupported(originPath)) {
-      final source = pdfByteSourceForPath(originPath!, bookmark: doc.bookmark);
-      int? length;
-      try {
-        length = await source.length;
-      } catch (_) {
-        length = null;
-      } finally {
-        await source.close();
-      }
-      if (!mounted) return;
-      if (length == null || length <= 0) return; // gone: drop silently
       _addTab(DocumentTab.deferredPath(
         title: doc.title,
-        originPath: originPath,
+        originPath: originPath!,
         originBookmark: doc.bookmark,
         cachePath: doc.cachePath,
       ));
@@ -850,6 +841,16 @@ class _EditorScreenState extends State<EditorScreen>
         bookmark: tab.originBookmark,
         cachePath: tab.cachePath,
         into: tab,
+        onOpenFailed: (_) {
+          // Session restoration is best-effort. A source that disappeared
+          // since the previous run should vanish quietly rather than leave a
+          // permanent error tab. `_closeTabs` removes synchronously until its
+          // first await for these clean placeholders, so the fallback's later
+          // replacement sees that the tab is already gone.
+          if (mounted && _tabs.contains(tab)) {
+            unawaited(_closeTabs([tab]));
+          }
+        },
       );
     });
   }

--- a/app/macos/Runner/MainFlutterWindow.swift
+++ b/app/macos/Runner/MainFlutterWindow.swift
@@ -2,7 +2,52 @@ import Cocoa
 import FlutterMacOS
 import PDFKit
 
+/// Runs security-scoped filesystem work away from AppKit's main thread.
+///
+/// Flutter invokes macOS method-channel handlers on the main thread. A read
+/// from an iCloud/OneDrive placeholder may block while File Provider hydrates
+/// it, so doing the work inline freezes every frame and input event. The queue
+/// is concurrent so one slow remote document does not prevent another restored
+/// tab backed by a local file from loading. Results return on the main thread,
+/// where Flutter's binary messenger expects them.
+final class FileAccessExecutor {
+  private let queue: DispatchQueue
+
+  init(
+    queue: DispatchQueue = DispatchQueue(
+      label: "dev.milanko.dartpdf.file-access",
+      qos: .userInitiated,
+      attributes: .concurrent)
+  ) {
+    self.queue = queue
+  }
+
+  func perform(
+    errorCode: String,
+    result: @escaping FlutterResult,
+    _ operation: @escaping () throws -> Any?
+  ) {
+    queue.async {
+      do {
+        let value = try operation()
+        DispatchQueue.main.async {
+          result(value)
+        }
+      } catch {
+        DispatchQueue.main.async {
+          result(FlutterError(
+            code: errorCode,
+            message: error.localizedDescription,
+            details: nil))
+        }
+      }
+    }
+  }
+}
+
 class MainFlutterWindow: NSWindow {
+  private let fileAccess = FileAccessExecutor()
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     let windowFrame = self.frame
@@ -179,21 +224,16 @@ class MainFlutterWindow: NSWindow {
     return nil
   }
 
-  private func createBookmark(path: String, result: FlutterResult) {
-    let url = URL(fileURLWithPath: path)
-    let scoped = url.startAccessingSecurityScopedResource()
-    defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-    do {
+  private func createBookmark(path: String, result: @escaping FlutterResult) {
+    fileAccess.perform(errorCode: "bookmark_failed", result: result) {
+      let url = URL(fileURLWithPath: path)
+      let scoped = url.startAccessingSecurityScopedResource()
+      defer { if scoped { url.stopAccessingSecurityScopedResource() } }
       let data = try url.bookmarkData(
         options: [.withSecurityScope],
         includingResourceValuesForKeys: nil,
         relativeTo: nil)
-      result(FlutterStandardTypedData(bytes: data))
-    } catch {
-      result(FlutterError(
-        code: "bookmark_failed",
-        message: error.localizedDescription,
-        details: nil))
+      return FlutterStandardTypedData(bytes: data)
     }
   }
 
@@ -212,34 +252,24 @@ class MainFlutterWindow: NSWindow {
       bookmarkDataIsStale: &stale)
   }
 
-  private func readFile(bookmark: String, result: FlutterResult) {
-    do {
-      let url = try resolveBookmarkedURL(bookmark)
+  private func readFile(bookmark: String, result: @escaping FlutterResult) {
+    fileAccess.perform(errorCode: "read_failed", result: result) {
+      let url = try self.resolveBookmarkedURL(bookmark)
       let scoped = url.startAccessingSecurityScopedResource()
       defer { if scoped { url.stopAccessingSecurityScopedResource() } }
       let data = try Data(contentsOf: url)
-      result(FlutterStandardTypedData(bytes: data))
-    } catch {
-      result(FlutterError(
-        code: "read_failed",
-        message: error.localizedDescription,
-        details: nil))
+      return FlutterStandardTypedData(bytes: data)
     }
   }
 
   /// The byte length of a bookmarked file, for the progressive/ranged loader.
-  private func fileLength(bookmark: String, result: FlutterResult) {
-    do {
-      let url = try resolveBookmarkedURL(bookmark)
+  private func fileLength(bookmark: String, result: @escaping FlutterResult) {
+    fileAccess.perform(errorCode: "length_failed", result: result) {
+      let url = try self.resolveBookmarkedURL(bookmark)
       let scoped = url.startAccessingSecurityScopedResource()
       defer { if scoped { url.stopAccessingSecurityScopedResource() } }
       let values = try url.resourceValues(forKeys: [.fileSizeKey])
-      result(values.fileSize ?? 0)
-    } catch {
-      result(FlutterError(
-        code: "length_failed",
-        message: error.localizedDescription,
-        details: nil))
+      return values.fileSize ?? 0
     }
   }
 
@@ -250,37 +280,30 @@ class MainFlutterWindow: NSWindow {
   /// after, so no handle or scope leaks between reads. A short read near EOF
   /// returns fewer bytes; an offset past EOF returns an empty list.
   private func readFileRange(
-    bookmark: String, offset: Int, length: Int, result: FlutterResult
+    bookmark: String, offset: Int, length: Int,
+    result: @escaping FlutterResult
   ) {
-    do {
-      let url = try resolveBookmarkedURL(bookmark)
+    fileAccess.perform(errorCode: "read_failed", result: result) {
+      let url = try self.resolveBookmarkedURL(bookmark)
       let scoped = url.startAccessingSecurityScopedResource()
       defer { if scoped { url.stopAccessingSecurityScopedResource() } }
       let handle = try FileHandle(forReadingFrom: url)
       defer { handle.closeFile() }
       handle.seek(toFileOffset: UInt64(max(0, offset)))
       let data = handle.readData(ofLength: max(0, length))
-      result(FlutterStandardTypedData(bytes: data))
-    } catch {
-      result(FlutterError(
-        code: "read_failed",
-        message: error.localizedDescription,
-        details: nil))
+      return FlutterStandardTypedData(bytes: data)
     }
   }
 
-  private func writeFile(bookmark: String, bytes: Data, result: FlutterResult) {
-    do {
-      let url = try resolveBookmarkedURL(bookmark)
+  private func writeFile(
+    bookmark: String, bytes: Data, result: @escaping FlutterResult
+  ) {
+    fileAccess.perform(errorCode: "write_failed", result: result) {
+      let url = try self.resolveBookmarkedURL(bookmark)
       let scoped = url.startAccessingSecurityScopedResource()
       defer { if scoped { url.stopAccessingSecurityScopedResource() } }
       try bytes.write(to: url, options: .atomic)
-      result(true)
-    } catch {
-      result(FlutterError(
-        code: "write_failed",
-        message: error.localizedDescription,
-        details: nil))
+      return true
     }
   }
 

--- a/app/test/progressive_open_test.dart
+++ b/app/test/progressive_open_test.dart
@@ -2,6 +2,7 @@
 // first paint renders the sparse document, then the complete bytes stream in
 // behind it and the tab swaps to a full edit session. Driven on Linux so the
 // source is a plain RandomAccessFile (no macOS security-scoped channel).
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -116,6 +117,109 @@ void main() {
       expect(log, contains('progressive open: "restored.pdf" first paint'));
       expect(find.byType(PdfEditorView), findsOneWidget);
     } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets(
+      'restored tabs remain usable while another macOS cloud read is pending',
+      (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    const channel = MethodChannel('dev.milanko.dartpdf/file_access');
+    final remoteStarted = Completer<void>();
+    final releaseRemote = Completer<void>();
+    final bytes = Uint8List.fromList(buildClassicPdf());
+
+    try {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (call) async {
+          final args = (call.arguments as Map).cast<Object?, Object?>();
+          final bookmark = args['bookmark'] as String?;
+          switch (call.method) {
+            case 'fileLength':
+              if (bookmark == 'remote-bookmark' && !releaseRemote.isCompleted) {
+                if (!remoteStarted.isCompleted) remoteStarted.complete();
+                await releaseRemote.future;
+              }
+              return bytes.length;
+            case 'readFileRange':
+              final offset = args['offset'] as int;
+              final length = args['length'] as int;
+              final end = (offset + length).clamp(0, bytes.length);
+              if (offset >= bytes.length) return Uint8List(0);
+              return Uint8List.sublistView(bytes, offset, end);
+            case 'readFile':
+              return bytes;
+          }
+          return null;
+        },
+      );
+
+      // The remote document is last, so it is the active restored tab. Both
+      // tab placeholders must appear before its first native read completes.
+      SharedPreferences.setMockInitialValues({
+        'dart_pdf_editor_app.session': jsonEncode([
+          {
+            't': 'local.pdf',
+            'p': '/local.pdf',
+            'b': 'local-bookmark',
+          },
+          {
+            't': 'remote.pdf',
+            'p': '/remote.pdf',
+            'b': 'remote-bookmark',
+          },
+        ]),
+      });
+
+      await tester.runAsync(() async {
+        await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+        for (var i = 0;
+            i < 20 &&
+                (!remoteStarted.isCompleted ||
+                    tabTitle('local.pdf').evaluate().isEmpty);
+            i++) {
+          await tester.pump(const Duration(milliseconds: 20));
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+      });
+      await tester.pump();
+
+      expect(remoteStarted.isCompleted, isTrue);
+      expect(tabTitle('local.pdf'), findsOneWidget);
+      expect(tabTitle('remote.pdf'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsWidgets);
+
+      // Switching tabs must start and finish the local read even while the
+      // remote File Provider request remains unresolved.
+      await tester.runAsync(() async {
+        await tester.tap(tabTitle('local.pdf'));
+        for (var i = 0;
+            i < 30 && find.byType(PdfEditorView).evaluate().isEmpty;
+            i++) {
+          await tester.pump(const Duration(milliseconds: 20));
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+      });
+      await tester.pump();
+
+      expect(releaseRemote.isCompleted, isFalse);
+      expect(find.byType(PdfEditorView), findsOneWidget);
+
+      // Let the abandoned remote request unwind cleanly before the widget and
+      // its method channel are disposed.
+      releaseRemote.complete();
+      await tester.runAsync(() async {
+        for (var i = 0; i < 10; i++) {
+          await tester.pump(const Duration(milliseconds: 20));
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+      });
+    } finally {
+      if (!releaseRemote.isCompleted) releaseRemote.complete();
+      tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
       debugDefaultTargetPlatformOverride = null;
     }
   });


### PR DESCRIPTION
## What changed

- move macOS security-scoped bookmark and file I/O onto a concurrent background queue
- return method-channel results on the main thread
- restore all desktop session tabs immediately without waiting for a metadata probe
- keep missing-file restore behavior by removing a deferred tab if its lazy open fails
- add a regression test proving a local restored tab remains usable while a remote tab is blocked

## Why

On launch, reopening an iCloud or OneDrive placeholder could block in `Data(contentsOf:)`, `FileHandle.readData`, or URL resource metadata lookup. The macOS method-channel handler performed those operations synchronously on AppKit's main thread, so File Provider hydration beachballed the whole app and prevented the existing loading spinner from animating.

Session restoration also awaited a length probe for each document before inserting its tab, which meant one delayed cloud file could hide all later restored tabs.

## User impact

The loading state now remains animated and interactive while a remote PDF hydrates. All restored tabs appear immediately, and users can switch to and load another local tab without waiting for the remote file.

## Validation

- `fvm flutter analyze lib/editor_screen.dart test/progressive_open_test.dart`
- `fvm flutter test test/progressive_open_test.dart test/session_restore_test.dart` (11 tests passed)
- `fvm flutter build macos --debug`