### PR TITLE
Add adaptive page raster cache budgets

### DIFF
--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -6,6 +6,11 @@
   staying responsive through rapid mouse-wheel gestures.
 - Page previews remain visible during fast scrolling and settle cleanly into
   full-detail renders, with fewer dropped frames.
+- The visited-page raster cache now defaults to Auto: it sizes itself from
+  physical RAM, current process headroom, available memory, and platform app
+  limits; shrinks immediately under pressure, grows back gradually, and clears
+  on mobile backgrounding. Developer tools show the effective decision and
+  retain fixed diagnostic presets up to 8 GB (including 5 GB).
 
 ## 3.1.0
 

--- a/app/CHANGELOG.md
+++ b/app/CHANGELOG.md
@@ -10,7 +10,9 @@
   physical RAM, current process headroom, available memory, and platform app
   limits; shrinks immediately under pressure, grows back gradually, and clears
   on mobile backgrounding. Developer tools show the effective decision and
-  retain fixed diagnostic presets up to 8 GB (including 5 GB).
+  retain fixed diagnostic presets up to 8 GB (including 5 GB). Switching from
+  Auto or Off to a fixed preset now seeds a useful per-page admission limit,
+  and exported traces include cache hits, misses, rejections, and evictions.
 
 ## 3.1.0
 

--- a/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
@@ -1,6 +1,7 @@
 package dev.milanko.dart_pdf_editor_app
 
 import android.app.Activity
+import android.app.ActivityManager
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -34,6 +35,7 @@ class MainActivity : FlutterActivity() {
     private val imageClipboardChannelName = "dev.milanko.dartpdf/image_clipboard"
     private val nativePrintChannelName = "dev.milanko.dartpdf/native_print"
     private val mobileFileChannelName = "dev.milanko.dartpdf/mobile_file"
+    private val memoryChannelName = "dev.milanko.dartpdf/memory"
     private var channel: MethodChannel? = null
 
     /// The file the activity was launched with, drained by `getInitialFile`.
@@ -102,6 +104,26 @@ class MainActivity : FlutterActivity() {
         // MB. See MobileFileByteSource on the Dart side.
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, mobileFileChannelName)
             .setMethodCallHandler { call, result -> handleMobileFile(call, result) }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, memoryChannelName)
+            .setMethodCallHandler { call, result ->
+                if (call.method != "snapshot") {
+                    result.notImplemented()
+                    return@setMethodCallHandler
+                }
+                val manager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                val info = ActivityManager.MemoryInfo()
+                manager.getMemoryInfo(info)
+                result.success(
+                    mapOf(
+                        "physicalBytes" to info.totalMem,
+                        "availableBytes" to info.availMem,
+                        "processLimitBytes" to
+                            manager.memoryClass.toLong() * 1024L * 1024L,
+                        "lowMemory" to info.lowMemory,
+                    )
+                )
+            }
 
         channel = ch
         handleIntent(intent, initial = true)

--- a/app/ios/Runner/Runner-Bridging-Header.h
+++ b/app/ios/Runner/Runner-Bridging-Header.h
@@ -1,1 +1,2 @@
 #import "GeneratedPluginRegistrant.h"
+#include <os/proc.h>

--- a/app/ios/Runner/SceneDelegate.swift
+++ b/app/ios/Runner/SceneDelegate.swift
@@ -17,6 +17,7 @@ class SceneDelegate: FlutterSceneDelegate {
   private var pencilInteraction: AnyObject?
   private var imageClipboardChannel: FlutterMethodChannel?
   private var mobileFileChannel: FlutterMethodChannel?
+  private var memoryChannel: FlutterMethodChannel?
 
   /// The in-flight `pickDocuments` reply, held while the document picker is up
   /// (its result arrives asynchronously via the picker delegate).
@@ -34,8 +35,32 @@ class SceneDelegate: FlutterSceneDelegate {
     setupChannel()
     setupImageClipboardChannel()
     setupMobileFileChannel()
+    setupMemoryChannel()
     setupPencilInteraction()
     handle(connectionOptions.urlContexts)
+  }
+
+  private func setupMemoryChannel() {
+    guard memoryChannel == nil,
+      let controller = window?.rootViewController as? FlutterViewController
+    else { return }
+    let ch = FlutterMethodChannel(
+      name: "dev.milanko.dartpdf/memory",
+      binaryMessenger: controller.binaryMessenger)
+    ch.setMethodCallHandler { (call, result) in
+      guard call.method == "snapshot" else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      result([
+        "physicalBytes": Int64(ProcessInfo.processInfo.physicalMemory),
+        // Apple's advisory per-app headroom. Unlike system free memory this
+        // follows the current jetsam limit and can change over the app life.
+        "availableBytes": Int64(os_proc_available_memory()),
+        "lowMemory": false,
+      ])
+    }
+    memoryChannel = ch
   }
 
   override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/app/lib/adaptive_memory.dart
+++ b/app/lib/adaptive_memory.dart
@@ -1,0 +1,391 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/widgets.dart';
+
+import 'devtools.dart';
+import 'memory_probe.dart';
+import 'memory_snapshot.dart';
+
+const _mb = 1024 * 1024;
+const _gb = 1024 * _mb;
+
+typedef AppMemoryProbe = Future<AppMemorySnapshot?> Function();
+
+/// One computed allocation across the caches that can be reconstructed.
+@immutable
+class AdaptiveMemoryDecision {
+  const AdaptiveMemoryDecision({
+    required this.pageRasterPolicy,
+    required this.registryCeilingBytes,
+    required this.liveRasterBudgetBytes,
+    required this.safeProcessLimitBytes,
+    required this.reason,
+  });
+
+  final PdfPageRasterCachePolicy pageRasterPolicy;
+  final int registryCeilingBytes;
+  final int liveRasterBudgetBytes;
+  final int safeProcessLimitBytes;
+  final String reason;
+}
+
+/// Computes a conservative process-wide cache allocation from one memory
+/// snapshot. This is pure so synthetic 4/8/16/64-GB machines and low-headroom
+/// transitions can be tested without allocating memory.
+AdaptiveMemoryDecision computeAdaptiveMemoryDecision({
+  required AppMemorySnapshot snapshot,
+  required PdfPerformancePlatform platform,
+  required int reclaimableRegistryBytes,
+  required int liveRasterBytes,
+  int maxPageRasterBytes = 5 * _gb,
+}) {
+  final physical = snapshot.physicalBytes;
+  final rss = snapshot.processRssBytes;
+  final available = snapshot.availableBytes;
+
+  final candidates = <int>[];
+  if (snapshot.processLimitBytes case final limit?) {
+    candidates.add((limit * .72).round());
+  }
+  if (physical != null) {
+    final fraction = switch (platform) {
+      PdfPerformancePlatform.desktop => .20,
+      PdfPerformancePlatform.mobile => .12,
+      PdfPerformancePlatform.web => .10,
+      PdfPerformancePlatform.other => .15,
+    };
+    candidates.add((physical * fraction).round());
+  }
+  if (rss != null && available != null) {
+    final fraction = switch (platform) {
+      PdfPerformancePlatform.desktop => .50,
+      PdfPerformancePlatform.mobile => .30,
+      PdfPerformancePlatform.web => .25,
+      PdfPerformancePlatform.other => .35,
+    };
+    // Leave most currently-available memory to the OS and other apps. This
+    // candidate makes the target fall immediately when system headroom falls.
+    candidates.add(rss + (available * fraction).round());
+  }
+
+  final fallback = switch (platform) {
+    PdfPerformancePlatform.desktop => 2 * _gb,
+    PdfPerformancePlatform.mobile => 640 * _mb,
+    PdfPerformancePlatform.web => 512 * _mb,
+    PdfPerformancePlatform.other => 1 * _gb,
+  };
+  var safeProcessLimit =
+      candidates.isEmpty ? fallback : candidates.reduce(math.min);
+  final absoluteProcessCap = switch (platform) {
+    PdfPerformancePlatform.desktop => 8 * _gb,
+    PdfPerformancePlatform.mobile => 1280 * _mb,
+    PdfPerformancePlatform.web => 1 * _gb,
+    PdfPerformancePlatform.other => 2 * _gb,
+  };
+  safeProcessLimit = math.min(safeProcessLimit, absoluteProcessCap);
+
+  final reserveBase = switch (platform) {
+    PdfPerformancePlatform.desktop => 384 * _mb,
+    PdfPerformancePlatform.mobile => 96 * _mb,
+    PdfPerformancePlatform.web => 96 * _mb,
+    PdfPerformancePlatform.other => 192 * _mb,
+  };
+  final reserveCap = switch (platform) {
+    PdfPerformancePlatform.desktop => 1 * _gb,
+    PdfPerformancePlatform.mobile => 192 * _mb,
+    PdfPerformancePlatform.web => 192 * _mb,
+    PdfPerformancePlatform.other => 512 * _mb,
+  };
+  final reserve = physical == null
+      ? reserveBase
+      : math.min(
+          reserveCap,
+          math.max(reserveBase, (physical * .04).round()),
+        );
+
+  final reclaimable = reclaimableRegistryBytes + liveRasterBytes;
+  final estimatedNonCache = switch (platform) {
+    PdfPerformancePlatform.desktop => 384 * _mb,
+    PdfPerformancePlatform.mobile => 192 * _mb,
+    PdfPerformancePlatform.web => 192 * _mb,
+    PdfPerformancePlatform.other => 256 * _mb,
+  };
+  final nonCacheRss =
+      rss == null ? estimatedNonCache : math.max(0, rss - reclaimable);
+  final cacheEnvelope = math.max(0, safeProcessLimit - reserve - nonCacheRss);
+
+  // Live viewport pages need priority: exact visited-page rasters are a revisit
+  // optimization, while the live budget keeps the current page and neighbours
+  // responsive. The focused page remains exempt even when this reaches zero.
+  final defaultLive = pdfDefaultLiveRasterBudgetBytes(platform: platform);
+  final liveBudget =
+      math.max(32 * _mb, math.min(defaultLive, cacheEnvelope ~/ 4));
+  final allocatableRegistry = math.max(0, cacheEnvelope - liveBudget);
+  // PdfCacheRegistry uses zero to mean "ceiling disabled", so retain a small
+  // positive floor even when the calculation leaves no speculative headroom.
+  final registryCeiling = math.max(64 * _mb, allocatableRegistry);
+
+  final platformPageCap = switch (platform) {
+    PdfPerformancePlatform.desktop => maxPageRasterBytes,
+    PdfPerformancePlatform.mobile => math.min(maxPageRasterBytes, 256 * _mb),
+    PdfPerformancePlatform.web => math.min(maxPageRasterBytes, 256 * _mb),
+    PdfPerformancePlatform.other => math.min(maxPageRasterBytes, 512 * _mb),
+  };
+  final pageBytes =
+      math.min(platformPageCap, (allocatableRegistry * .88).round());
+  final minimumEntry =
+      platform == PdfPerformancePlatform.desktop ? 16 * _mb : 8 * _mb;
+  final entryBytes = pageBytes == 0
+      ? 0
+      : math.min(
+          pageBytes,
+          math.min(
+            256 * _mb,
+            math.max(minimumEntry, pageBytes ~/ 8),
+          ),
+        );
+
+  final hasMachineData = physical != null ||
+      available != null ||
+      snapshot.processLimitBytes != null;
+  final constrainedByAvailability = rss != null &&
+      available != null &&
+      safeProcessLimit ==
+          rss +
+              (available *
+                      switch (platform) {
+                        PdfPerformancePlatform.desktop => .50,
+                        PdfPerformancePlatform.mobile => .30,
+                        PdfPerformancePlatform.web => .25,
+                        PdfPerformancePlatform.other => .35,
+                      })
+                  .round();
+  final reason = constrainedByAvailability
+      ? 'available-memory headroom'
+      : hasMachineData
+          ? 'machine memory headroom'
+          : 'conservative platform fallback';
+
+  return AdaptiveMemoryDecision(
+    pageRasterPolicy: PdfPageRasterCachePolicy(
+      maxBytes: pageBytes,
+      maxEntryBytes: entryBytes,
+    ),
+    registryCeilingBytes: registryCeiling,
+    liveRasterBudgetBytes: liveBudget,
+    safeProcessLimitBytes: safeProcessLimit,
+    reason: reason,
+  );
+}
+
+/// Samples machine memory and continuously tunes reconstructible PDF caches.
+///
+/// Shrinks are immediate. Growth is rate-limited after the first sample and
+/// blocked for five minutes after memory pressure, avoiding oscillation around
+/// an OS threshold. A fixed Developer-tools page budget still passes through
+/// the process-wide registry ceiling, so a diagnostic 5-GB override cannot make
+/// two viewers reserve 10 GB between them.
+class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
+  AdaptiveMemoryBudgetController({
+    AppDevTools? tools,
+    AppMemoryProbe? probe,
+    PdfPerformancePlatform? platform,
+    DateTime Function()? clock,
+    this.sampleInterval = const Duration(seconds: 15),
+    this.growthInterval = const Duration(seconds: 45),
+    this.pressureCooldown = const Duration(minutes: 5),
+  })  : tools = tools ?? AppDevTools.instance,
+        _probe = probe ?? readAppMemorySnapshot,
+        platform = platform ?? detectedPdfPerformancePlatform,
+        _clock = clock ?? DateTime.now;
+
+  final AppDevTools tools;
+  final AppMemoryProbe _probe;
+  final PdfPerformancePlatform platform;
+  final DateTime Function() _clock;
+  final Duration sampleInterval;
+  final Duration growthInterval;
+  final Duration pressureCooldown;
+
+  Timer? _timer;
+  bool _started = false;
+  bool _sampling = false;
+  bool _hasSample = false;
+  DateTime? _lastGrowth;
+  DateTime? _lastPressure;
+  int? _pressureRegistryCap;
+  bool _lowMemoryActive = false;
+
+  Future<void> start({bool periodic = true}) async {
+    if (_started) return;
+    _started = true;
+    WidgetsBinding.instance.addObserver(this);
+    await sample();
+    if (periodic && _started) {
+      _timer = Timer.periodic(sampleInterval, (_) => unawaited(sample()));
+    }
+  }
+
+  void dispose() {
+    if (!_started) return;
+    _started = false;
+    _timer?.cancel();
+    _timer = null;
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  Future<void> sample() async {
+    if (!_started || _sampling) return;
+    _sampling = true;
+    try {
+      final snapshot = await _probe() ?? const AppMemorySnapshot();
+      if (!_started) return;
+      if (snapshot.lowMemory) {
+        if (!_lowMemoryActive) {
+          _lowMemoryActive = true;
+          _applyPressure('platform low-memory threshold');
+        }
+        return;
+      }
+      _lowMemoryActive = false;
+      applySnapshot(snapshot);
+    } catch (error) {
+      tools.addLog('memory-auto: sample failed: $error',
+          level: DevLogLevel.error);
+    } finally {
+      _sampling = false;
+    }
+  }
+
+  @visibleForTesting
+  void applySnapshot(AppMemorySnapshot snapshot) {
+    final now = _clock();
+    if (_lastPressure != null &&
+        now.difference(_lastPressure!) >= pressureCooldown) {
+      _pressureRegistryCap = null;
+    }
+
+    final decision = computeAdaptiveMemoryDecision(
+      snapshot: snapshot,
+      platform: platform,
+      reclaimableRegistryBytes: PdfCacheRegistry.instance.totalWeight,
+      liveRasterBytes: PdfLiveRasterBudget.instance.totalBytes,
+    );
+
+    var registryCeiling = decision.registryCeilingBytes;
+    if (_pressureRegistryCap != null) {
+      registryCeiling = math.min(registryCeiling, _pressureRegistryCap!);
+    }
+    PdfCacheRegistry.instance.maxTotalWeight = registryCeiling;
+    PdfLiveRasterBudget.instance.maxBytes = decision.liveRasterBudgetBytes;
+
+    var pagePolicy = decision.pageRasterPolicy;
+    final current = tools.pageRasterCachePolicy.value;
+    if (_hasSample && pagePolicy.maxBytes > current.maxBytes) {
+      final inCooldown = _lastPressure != null &&
+          now.difference(_lastPressure!) < pressureCooldown;
+      final canGrow = !inCooldown &&
+          (_lastGrowth == null ||
+              now.difference(_lastGrowth!) >= growthInterval);
+      if (!canGrow) {
+        pagePolicy = PdfPageRasterCachePolicy(
+          maxBytes: current.maxBytes,
+          maxEntryBytes: math.min(
+            current.maxBytes,
+            current.maxEntryBytes,
+          ),
+        );
+      } else {
+        final growthLimit = math.max(
+          current.maxBytes + 64 * _mb,
+          (current.maxBytes * 1.25).round(),
+        );
+        final bytes = math.min(pagePolicy.maxBytes, growthLimit);
+        pagePolicy = PdfPageRasterCachePolicy(
+          maxBytes: bytes,
+          maxEntryBytes: _entryLimitFor(bytes, platform),
+        );
+        _lastGrowth = now;
+      }
+    }
+
+    _hasSample = true;
+    tools.updateAutoPageRasterCache(
+      pagePolicy,
+      reason: decision.reason,
+      safeProcessLimitBytes: decision.safeProcessLimitBytes,
+    );
+  }
+
+  @override
+  void didHaveMemoryPressure() => _applyPressure('OS memory pressure');
+
+  void _applyPressure(String reason) {
+    final now = _clock();
+    // Coalesce a sustained low-memory state: repeated 15-second samples should
+    // not halve an already-empty cache all the way to zero.
+    if (_lastPressure != null &&
+        now.difference(_lastPressure!) < const Duration(seconds: 30)) {
+      return;
+    }
+    _lastPressure = now;
+    final currentRegistry = PdfCacheRegistry.instance.maxTotalWeight;
+    _pressureRegistryCap = math.max(
+      64 * _mb,
+      currentRegistry > 0 ? currentRegistry ~/ 2 : 64 * _mb,
+    );
+    final freed = PdfCacheRegistry.instance.handleMemoryPressure();
+    final liveFreed = PdfLiveRasterBudget.instance.evictReclaimable();
+    PdfCacheRegistry.instance.maxTotalWeight = _pressureRegistryCap!;
+    PdfLiveRasterBudget.instance.maxBytes = math.max(
+      32 * _mb,
+      PdfLiveRasterBudget.instance.maxBytes ~/ 2,
+    );
+
+    final current = tools.pageRasterCachePolicy.value;
+    final bytes = current.maxBytes == 0
+        ? 0
+        : math.max(
+            platform == PdfPerformancePlatform.desktop ? 32 * _mb : 16 * _mb,
+            current.maxBytes ~/ 2,
+          );
+    tools.updateAutoPageRasterCache(
+      PdfPageRasterCachePolicy(
+        maxBytes: bytes,
+        maxEntryBytes: _entryLimitFor(bytes, platform),
+      ),
+      reason: '$reason; ${freed + liveFreed >> 20}MB reclaimed',
+      safeProcessLimitBytes: tools.safeProcessLimitBytes,
+    );
+    tools.addLog('memory-auto: $reason, reclaimed '
+        '${(freed + liveFreed) >> 20}MB; growth paused for '
+        '${pressureCooldown.inMinutes} min');
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      unawaited(sample());
+      return;
+    }
+    if (platform != PdfPerformancePlatform.mobile ||
+        (state != AppLifecycleState.hidden &&
+            state != AppLifecycleState.paused &&
+            state != AppLifecycleState.detached)) {
+      return;
+    }
+    final freed = PdfCacheRegistry.instance.clearLabel('page-full-raster');
+    if (freed > 0) {
+      tools.addLog('memory-auto: backgrounded; cleared '
+          '${freed >> 20}MB of visited-page rasters');
+    }
+  }
+}
+
+int _entryLimitFor(int bytes, PdfPerformancePlatform platform) {
+  if (bytes <= 0) return 0;
+  final floor = platform == PdfPerformancePlatform.desktop ? 16 * _mb : 8 * _mb;
+  return math.min(bytes, math.min(256 * _mb, math.max(floor, bytes ~/ 8)));
+}

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -5,6 +5,7 @@ import 'package:dart_pdf_editor_assets/dart_pdf_editor_assets.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'adaptive_memory.dart';
 import 'devtools.dart';
 import 'editor_screen.dart';
 import 'l10n/app_localizations.dart';
@@ -27,6 +28,8 @@ class DartPdfEditorApp extends StatefulWidget {
 
 class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
   final _prefs = PdfEditingPreferences();
+  late final AdaptiveMemoryBudgetController _memoryBudget =
+      AdaptiveMemoryBudgetController();
 
   // Reuse a Sigstore login across Digitally sign dialogs: cache the id_token,
   // refresh it silently when it expires, and only sign in via the browser when
@@ -77,14 +80,21 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
     // reclaimed first when the sum exceeds this; the on-screen page and its
     // neighbours always fit.
     PdfLiveRasterBudget.instance.maxBytes = pdfDefaultLiveRasterBudgetBytes();
-    // Persisted devtools options (deep-zoom mode, overlays, worker count)
-    // override the defaults above once loaded.
-    if (kDevToolsEnabled) unawaited(AppDevTools.instance.restoreOptions());
+    // Persisted developer overrides load before the adaptive memory sampler.
+    // Fresh installs stay in Auto; an older build's explicit page-raster
+    // setting is migrated as a fixed diagnostic override.
+    unawaited(_startMemoryBudget());
     // Offer the host's installed fonts in the editor's font menu by default.
     // Fire-and-forget: the registry is read when a font menu opens, and an
     // empty result (web, or a locked-down platform) just leaves the base-14,
     // bundled and "Load font…" choices.
     unawaited(_loadPlatformFonts());
+  }
+
+  Future<void> _startMemoryBudget() async {
+    if (kDevToolsEnabled) await AppDevTools.instance.restoreOptions();
+    if (!mounted) return;
+    await _memoryBudget.start(periodic: !runningUnderFlutterTest);
   }
 
   Future<void> _loadPlatformFonts() async {
@@ -99,6 +109,7 @@ class _DartPdfEditorAppState extends State<DartPdfEditorApp> {
 
   @override
   void dispose() {
+    _memoryBudget.dispose();
     _prefs.dispose();
     super.dispose();
   }

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -31,6 +31,10 @@ import 'devtools_memory_stub.dart'
 const bool kDevToolsEnabled =
     bool.fromEnvironment('DEVTOOLS', defaultValue: true);
 
+/// Test seam for app-owned services that would otherwise leave periodic
+/// timers behind under `flutter test`.
+bool get runningUnderFlutterTest => memory.inFlutterTest();
+
 /// One captured log line.
 class DevLogEntry {
   DevLogEntry(this.time, this.level, this.message);
@@ -41,6 +45,10 @@ class DevLogEntry {
 }
 
 enum DevLogLevel { info, error }
+
+/// Whether the visited-page raster cache follows machine headroom or a fixed
+/// diagnostic override chosen in Developer tools.
+enum PageRasterCacheMode { auto, fixed }
 
 /// Per-pointer accumulator for touch-input logging: the net displacement,
 /// total path length, and move count between a pointer's down and up.
@@ -104,6 +112,30 @@ class AppDevTools extends ChangeNotifier {
 
   /// Mirrored into [MaterialApp.showPerformanceOverlay] by the app root.
   final ValueNotifier<bool> showPerformanceOverlay = ValueNotifier(false);
+
+  /// Full-resolution rasters retained after their page widgets leave the
+  /// viewport. The editor listens to this separately from [AppDevTools]
+  /// itself: log traffic notifies the panel frequently and must not rebuild
+  /// the mounted document, while a policy change should apply immediately.
+  final ValueNotifier<PdfPageRasterCachePolicy> pageRasterCachePolicy =
+      ValueNotifier(const PdfPageRasterCachePolicy());
+
+  PageRasterCacheMode _pageRasterCacheMode = PageRasterCacheMode.auto;
+  PdfPageRasterCachePolicy _fixedPageRasterCachePolicy =
+      const PdfPageRasterCachePolicy();
+  PdfPageRasterCachePolicy _lastAutoPageRasterCachePolicy =
+      const PdfPageRasterCachePolicy();
+  String _lastAutoPageRasterCacheReason = 'Waiting for a memory sample';
+  String _pageRasterCacheReason = 'Waiting for a memory sample';
+  int? _safeProcessLimitBytes;
+
+  PageRasterCacheMode get pageRasterCacheMode => _pageRasterCacheMode;
+  bool get pageRasterCacheAuto =>
+      _pageRasterCacheMode == PageRasterCacheMode.auto;
+  PdfPageRasterCachePolicy get fixedPageRasterCachePolicy =>
+      _fixedPageRasterCachePolicy;
+  String get pageRasterCacheReason => _pageRasterCacheReason;
+  int? get safeProcessLimitBytes => _safeProcessLimitBytes;
 
   /// Forces the whole app onto a locale for testing, bypassing the normal
   /// [MaterialApp] resolution against `supportedLocales`. `null` follows the
@@ -350,6 +382,53 @@ class AppDevTools extends ChangeNotifier {
     addLog('devtools: deep-zoom detail → $mode');
   }
 
+  /// Applies a fixed visited-page raster cache policy to every mounted viewer.
+  ///
+  /// This is the explicit diagnostic override. [useAutoPageRasterCache]
+  /// returns control to the machine-headroom policy.
+  void setPageRasterCachePolicy(PdfPageRasterCachePolicy policy) {
+    final unchanged = _pageRasterCacheMode == PageRasterCacheMode.fixed &&
+        _fixedPageRasterCachePolicy == policy;
+    _pageRasterCacheMode = PageRasterCacheMode.fixed;
+    _fixedPageRasterCachePolicy = policy;
+    _pageRasterCacheReason = 'Fixed Developer tools override';
+    pageRasterCachePolicy.value = policy;
+    if (unchanged) return;
+    addLog('devtools: visited-page rasters → '
+        '${policy.maxBytes >> 20}MB total, '
+        '${policy.maxEntryBytes >> 20}MB/page');
+  }
+
+  /// Returns the visited-page raster cache to adaptive machine-headroom mode.
+  void useAutoPageRasterCache() {
+    if (pageRasterCacheAuto) return;
+    _pageRasterCacheMode = PageRasterCacheMode.auto;
+    pageRasterCachePolicy.value = _lastAutoPageRasterCachePolicy;
+    _pageRasterCacheReason = _lastAutoPageRasterCacheReason;
+    addLog('devtools: visited-page rasters → Auto');
+  }
+
+  /// Receives one effective policy from the adaptive memory controller.
+  void updateAutoPageRasterCache(
+    PdfPageRasterCachePolicy policy, {
+    required String reason,
+    int? safeProcessLimitBytes,
+  }) {
+    _safeProcessLimitBytes = safeProcessLimitBytes;
+    _lastAutoPageRasterCachePolicy = policy;
+    _lastAutoPageRasterCacheReason = reason;
+    if (!pageRasterCacheAuto) return;
+    final changed = pageRasterCachePolicy.value != policy;
+    pageRasterCachePolicy.value = policy;
+    _pageRasterCacheReason = reason;
+    if (changed) {
+      addLog('memory-auto: visited rasters ${policy.maxBytes >> 20}MB, '
+          '${policy.maxEntryBytes >> 20}MB/page ($reason)');
+    } else {
+      _scheduleNotify();
+    }
+  }
+
   // --- option persistence ---------------------------------------------------
 
   static const _optionsKey = 'devtools.options';
@@ -381,6 +460,28 @@ class AppDevTools extends ChangeNotifier {
       if (map['workers'] case final int v) {
         pdfRenderWorkerPoolSize = v.clamp(1, 8);
       }
+      final currentRasterPolicy = _fixedPageRasterCachePolicy;
+      final rasterBytes = switch (map['pageRasterCacheBytes']) {
+        final int v when v >= 0 => v,
+        _ => currentRasterPolicy.maxBytes,
+      };
+      final rasterEntryBytes = switch (map['pageRasterCacheEntryBytes']) {
+        final int v when v >= 0 => v,
+        _ => currentRasterPolicy.maxEntryBytes,
+      };
+      final fixedPolicy = PdfPageRasterCachePolicy(
+        maxBytes: rasterBytes,
+        maxEntryBytes: rasterEntryBytes,
+      );
+      _fixedPageRasterCachePolicy = fixedPolicy;
+      if (map['pageRasterCacheMode'] == PageRasterCacheMode.auto.name) {
+        useAutoPageRasterCache();
+      } else if (map['pageRasterCacheMode'] ==
+              PageRasterCacheMode.fixed.name ||
+          map.containsKey('pageRasterCacheBytes') ||
+          map.containsKey('pageRasterCacheEntryBytes')) {
+        setPageRasterCachePolicy(fixedPolicy);
+      }
       _scheduleNotify();
     } catch (e) {
       addLog('devtools options restore failed: $e', level: DevLogLevel.error);
@@ -400,6 +501,10 @@ class AppDevTools extends ChangeNotifier {
           'perfLog': _logPerfTrace,
           'logTouchInput': _logTouchInput,
           'workers': pdfRenderWorkerPoolSize,
+          'pageRasterCacheMode': _pageRasterCacheMode.name,
+          'pageRasterCacheBytes': _fixedPageRasterCachePolicy.maxBytes,
+          'pageRasterCacheEntryBytes':
+              _fixedPageRasterCachePolicy.maxEntryBytes,
         }),
       );
     } catch (e) {

--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -393,6 +393,12 @@ class AppDevTools extends ChangeNotifier {
     _fixedPageRasterCachePolicy = policy;
     _pageRasterCacheReason = 'Fixed Developer tools override';
     pageRasterCachePolicy.value = policy;
+    PdfPerfLog.log(
+      'page-raster mode=fixed total=${policy.maxBytes} '
+      'entry=${policy.maxEntryBytes} '
+      'ceiling=${PdfCacheRegistry.instance.maxTotalWeight}'
+      '${PdfPerfLog.rssSuffix()}',
+    );
     if (unchanged) return;
     addLog('devtools: visited-page rasters → '
         '${policy.maxBytes >> 20}MB total, '
@@ -405,6 +411,14 @@ class AppDevTools extends ChangeNotifier {
     _pageRasterCacheMode = PageRasterCacheMode.auto;
     pageRasterCachePolicy.value = _lastAutoPageRasterCachePolicy;
     _pageRasterCacheReason = _lastAutoPageRasterCacheReason;
+    PdfPerfLog.log(
+      'page-raster mode=auto '
+      'total=${_lastAutoPageRasterCachePolicy.maxBytes} '
+      'entry=${_lastAutoPageRasterCachePolicy.maxEntryBytes} '
+      'processTarget=${_safeProcessLimitBytes ?? 0} '
+      'ceiling=${PdfCacheRegistry.instance.maxTotalWeight}'
+      '${PdfPerfLog.rssSuffix()}',
+    );
     addLog('devtools: visited-page rasters → Auto');
   }
 
@@ -424,6 +438,13 @@ class AppDevTools extends ChangeNotifier {
     if (changed) {
       addLog('memory-auto: visited rasters ${policy.maxBytes >> 20}MB, '
           '${policy.maxEntryBytes >> 20}MB/page ($reason)');
+      PdfPerfLog.log(
+        'page-raster mode=auto total=${policy.maxBytes} '
+        'entry=${policy.maxEntryBytes} '
+        'processTarget=${safeProcessLimitBytes ?? 0} '
+        'ceiling=${PdfCacheRegistry.instance.maxTotalWeight} '
+        'reason=$reason${PdfPerfLog.rssSuffix()}',
+      );
     } else {
       _scheduleNotify();
     }

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -247,6 +247,13 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
         'rssHighWaterBytes': _tools.maxRssBytes,
         'cacheTotalBytes': PdfCacheRegistry.instance.totalWeight,
         'cacheCeilingBytes': PdfCacheRegistry.instance.maxTotalWeight,
+        'pageRasterCacheBytes':
+            _tools.pageRasterCachePolicy.value.maxBytes,
+        'pageRasterCacheEntryBytes':
+            _tools.pageRasterCachePolicy.value.maxEntryBytes,
+        'pageRasterCacheMode': _tools.pageRasterCacheMode.name,
+        'pageRasterCacheReason': _tools.pageRasterCacheReason,
+        'safeProcessLimitBytes': _tools.safeProcessLimitBytes,
         'caches': [
           for (final cache in PdfCacheRegistry.instance.snapshot())
             {
@@ -438,9 +445,17 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
           Expanded(
             child: Text(key, style: theme.textTheme.bodySmall),
           ),
-          Text(value,
-              style: theme.textTheme.bodySmall!
-                  .copyWith(fontFeatures: const [FontFeature.tabularFigures()])),
+          Flexible(
+            child: Text(
+              value,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.end,
+              style: theme.textTheme.bodySmall!.copyWith(
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+          ),
         ],
       ),
     );
@@ -561,10 +576,108 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
 
   // --- memory ---------------------------------------------------------------
 
+  static const _pageRasterBudgets = <(int, String)>[
+    (-1, 'Auto (recommended)'),
+    (0, 'Off'),
+    (32 << 20, '32 MB'),
+    (64 << 20, '64 MB'),
+    (128 << 20, '128 MB'),
+    (256 << 20, '256 MB'),
+    (512 << 20, '512 MB'),
+    (1 << 30, '1 GB'),
+    (2 << 30, '2 GB'),
+    (5 * (1 << 30), '5 GB'),
+    (8 * (1 << 30), '8 GB'),
+  ];
+
+  static const _pageRasterEntryBudgets = <(int, String)>[
+    (0, 'Off'),
+    (4 << 20, '4 MB'),
+    (8 << 20, '8 MB'),
+    (16 << 20, '16 MB'),
+    (32 << 20, '32 MB'),
+    (64 << 20, '64 MB'),
+    (128 << 20, '128 MB'),
+    (256 << 20, '256 MB'),
+    (512 << 20, '512 MB'),
+    (1 << 30, '1 GB'),
+  ];
+
+  Widget _byteBudgetControl(
+    ThemeData theme, {
+    required Key key,
+    required String title,
+    required String help,
+    required int value,
+    String? valueLabel,
+    required List<(int, String)> choices,
+    required ValueChanged<int> onChanged,
+  }) =>
+      Row(
+        children: [
+          Expanded(
+            child: Tooltip(
+              message: help,
+              waitDuration: const Duration(milliseconds: 600),
+              child: InkWell(
+                onTap: () => _explain(title, help),
+                child: Text(title, style: theme.textTheme.bodySmall),
+              ),
+            ),
+          ),
+          PopupMenuButton<int>(
+            key: key,
+            tooltip: 'Change $title',
+            onSelected: onChanged,
+            itemBuilder: (context) => [
+              for (final (bytes, label) in choices)
+                PopupMenuItem<int>(
+                  value: bytes,
+                  child: Text(label),
+                ),
+            ],
+            child: Padding(
+              padding: const EdgeInsetsDirectional.fromSTEB(8, 4, 0, 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    valueLabel ?? _byteBudgetLabel(value),
+                    style: theme.textTheme.bodySmall!.copyWith(
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                  const Icon(Icons.arrow_drop_down, size: 18),
+                ],
+              ),
+            ),
+          ),
+        ],
+      );
+
+  static String _byteBudgetLabel(int bytes) {
+    if (bytes < 0) return 'Auto';
+    if (bytes == 0) return 'Off';
+    if (bytes % (1 << 30) == 0) return '${bytes ~/ (1 << 30)} GB';
+    return '${bytes ~/ (1 << 20)} MB';
+  }
+
+  void _setPageRasterCache({int? maxBytes, int? maxEntryBytes}) {
+    final current = _tools.fixedPageRasterCachePolicy;
+    _tools.setPageRasterCachePolicy(PdfPageRasterCachePolicy(
+      maxBytes: maxBytes ?? current.maxBytes,
+      maxEntryBytes: maxEntryBytes ?? current.maxEntryBytes,
+    ));
+    _persist();
+    setState(() {});
+  }
+
   Widget _memorySection(ThemeData theme) {
     final rss = _tools.currentRssBytes;
     final peak = _tools.maxRssBytes;
     final caches = PdfCacheRegistry.instance.snapshot();
+    final rasterPolicy = _tools.pageRasterCachePolicy.value;
+    final rasterAuto = _tools.pageRasterCacheAuto;
     return _section(
       theme,
       'Memory',
@@ -594,6 +707,77 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
                 "platform's memory-pressure signal (which desktop OSes "
                 'deliver too late, if at all). Over the ceiling, every cache '
                 'is trimmed proportionally, least-recently-used first.'),
+        _byteBudgetControl(
+          theme,
+          key: const ValueKey('devtools-page-raster-budget'),
+          title: 'Visited-page rasters',
+          help: 'Full-resolution rasters kept after a page scrolls out of the '
+              'viewer build window. Raising this makes revisits instant at the '
+              'cost of RAM; Off keeps only the small fast-scroll previews. '
+              'Changes apply immediately and persist across restarts.',
+          value: rasterAuto
+              ? -1
+              : _tools.fixedPageRasterCachePolicy.maxBytes,
+          valueLabel: rasterAuto
+              ? 'Auto · ${_byteBudgetLabel(rasterPolicy.maxBytes)}'
+              : null,
+          choices: _pageRasterBudgets,
+          onChanged: (value) {
+            if (value < 0) {
+              _tools.useAutoPageRasterCache();
+              _persist();
+              setState(() {});
+            } else {
+              _setPageRasterCache(maxBytes: value);
+            }
+          },
+        ),
+        if (rasterAuto)
+          _kv(
+            theme,
+            'Largest cached page',
+            _byteBudgetLabel(rasterPolicy.maxEntryBytes),
+            help: 'Auto derives the per-page admission limit from the total '
+                'headroom, capped at 256 MB. Switch the total cache to a fixed '
+                'preset to override it.',
+          )
+        else
+          _byteBudgetControl(
+            theme,
+            key: const ValueKey('devtools-page-raster-entry-budget'),
+            title: 'Largest cached page',
+            help: 'Per-page admission limit for the visited-page raster cache. '
+                'Large CAD sheets and high-DPI pages above this size are not '
+                'retained even when the total budget has room. The lower of '
+                'this value and the total budget is effective.',
+            value: _tools.fixedPageRasterCachePolicy.maxEntryBytes,
+            choices: _pageRasterEntryBudgets,
+            onChanged: (value) =>
+                _setPageRasterCache(maxEntryBytes: value),
+          ),
+        if (_tools.safeProcessLimitBytes case final limit?)
+          _kv(
+            theme,
+            'Auto process target',
+            _mb(limit),
+            help: 'Conservative process RSS target derived from physical RAM, '
+                'currently available memory, and any platform process limit. '
+                'The cache allocation leaves an additional safety reserve '
+                'below this target.',
+          ),
+        _kv(
+          theme,
+          'Raster policy reason',
+          _tools.pageRasterCacheReason,
+          help: 'Why Auto chose its current effective limit. Growth is slow; '
+              'low headroom and memory pressure shrink it immediately.',
+        ),
+        if (!rasterAuto)
+          Text(
+            'Fixed presets remain subject to the process-wide safety ceiling.',
+            style: theme.textTheme.bodySmall!
+                .copyWith(color: theme.colorScheme.outline),
+          ),
         for (final cache in caches)
           _kv(
               theme,

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -11,6 +11,7 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 
@@ -261,6 +262,9 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               'entries': cache.length,
               'bytes': cache.weight,
               'budgetBytes': cache.maxWeight,
+              'hits': cache.hits,
+              'misses': cache.misses,
+              'evictions': cache.evictions,
             },
         ],
       },
@@ -602,6 +606,7 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
     (512 << 20, '512 MB'),
     (1 << 30, '1 GB'),
   ];
+  static const _fixedEntrySeedBytes = 256 << 20;
 
   Widget _byteBudgetControl(
     ThemeData theme, {
@@ -663,10 +668,30 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
   }
 
   void _setPageRasterCache({int? maxBytes, int? maxEntryBytes}) {
-    final current = _tools.fixedPageRasterCachePolicy;
+    final wasAuto = _tools.pageRasterCacheAuto;
+    final current = wasAuto
+        ? _tools.pageRasterCachePolicy.value
+        : _tools.fixedPageRasterCachePolicy;
+    // Entering fixed mode from Auto should carry a useful per-page admission
+    // limit with it. Keeping the dormant fixed default (16 MB) made a 5 GB
+    // preset reject an ordinary capped CAD raster such as 8192×812 (25.4 MB),
+    // which made the total selector look broken. Once fixed mode is active,
+    // later total changes preserve the user's explicit non-zero per-page
+    // choice; moving from Off seeds it again.
+    final shouldSeedEntry = maxBytes != null &&
+        maxEntryBytes == null &&
+        (wasAuto || current.maxEntryBytes == 0);
+    final seededEntry = shouldSeedEntry
+        ? maxBytes == 0
+            ? 0
+            : math.min(
+                maxBytes,
+                math.max(current.maxEntryBytes, _fixedEntrySeedBytes),
+              )
+        : current.maxEntryBytes;
     _tools.setPageRasterCachePolicy(PdfPageRasterCachePolicy(
       maxBytes: maxBytes ?? current.maxBytes,
-      maxEntryBytes: maxEntryBytes ?? current.maxEntryBytes,
+      maxEntryBytes: maxEntryBytes ?? seededEntry,
     ));
     _persist();
     setState(() {});
@@ -784,8 +809,11 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               '  ${cache.label} (${cache.length})',
               cache.maxWeight > 0
                   ? '${_mb(cache.weight)} / ${_mb(cache.maxWeight)}'
-                  : _mb(cache.weight),
-              help: _cacheExplanation(cache.label)),
+                      ' · ${cache.hits}/${cache.misses}/${cache.evictions}'
+                  : '${_mb(cache.weight)}'
+                      ' · ${cache.hits}/${cache.misses}/${cache.evictions}',
+              help: '${_cacheExplanation(cache.label)} '
+                  'Trailing counters are hits/misses/evictions.'),
         Text(
           'Worker isolates hold parsed documents and command transcripts, '
           'not decoded pixels; their memory is not itemized here.',

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -2529,7 +2529,7 @@ class _EditorScreenState extends State<EditorScreen>
                 Positioned.fill(
                   child: Row(
                     children: [
-                      Expanded(child: _devToolsPointerLog(_buildBody(tab))),
+                      Expanded(child: _buildBodyWithDevTools(tab)),
                       if (_devToolsOpen && kDevToolsEnabled && !compactDevTools)
                         DevToolsPanel(
                           onClose: _toggleDevTools,
@@ -2569,8 +2569,21 @@ class _EditorScreenState extends State<EditorScreen>
     );
   }
 
+  /// Rebuild only the mounted document shell when its raster-cache policy
+  /// changes. Listening to the full [AppDevTools] model here would also rebuild
+  /// it for every captured log line and periodic panel refresh.
+  Widget _buildBodyWithDevTools(DocumentTab? tab) {
+    if (!kDevToolsEnabled) return _buildBody(tab);
+    return ValueListenableBuilder<PdfPageRasterCachePolicy>(
+      valueListenable: AppDevTools.instance.pageRasterCachePolicy,
+      builder: (context, _, __) => _devToolsPointerLog(_buildBody(tab)),
+    );
+  }
+
   Widget _buildBody(DocumentTab? tab) {
     final compact = _isCompactWidth(context);
+    final pageRasterCachePolicy =
+        AppDevTools.instance.pageRasterCachePolicy.value;
     if (tab == null) {
       return WelcomeScreen(
         recents: _recents,
@@ -2608,6 +2621,7 @@ class _EditorScreenState extends State<EditorScreen>
         key: ValueKey(tab),
         before: tab.compareBefore!,
         after: tab.compareAfter!,
+        pageRasterCachePolicy: pageRasterCachePolicy,
       );
     }
     if (tab.isPreview) {
@@ -2618,6 +2632,7 @@ class _EditorScreenState extends State<EditorScreen>
         tab: tab,
         preferences: _prefs,
         onAction: _onAction,
+        pageRasterCachePolicy: pageRasterCachePolicy,
       );
     }
     if (_readOnly) {
@@ -2628,6 +2643,7 @@ class _EditorScreenState extends State<EditorScreen>
         controller: tab.viewer,
         preferences: _prefs,
         onAction: _onAction,
+        pageRasterCachePolicy: pageRasterCachePolicy,
       );
     }
     return PdfEditorView(
@@ -2635,6 +2651,7 @@ class _EditorScreenState extends State<EditorScreen>
       documentId: tab.documentId,
       controller: tab.session,
       viewerController: tab.viewer,
+      pageRasterCachePolicy: pageRasterCachePolicy,
       onSave: (_) => unawaited(_save(tab)),
       onSaveAs: (_) => unawaited(_save(tab, saveAs: true)),
       showSaveButton: !compact,
@@ -3177,11 +3194,13 @@ class _ProgressivePreview extends StatelessWidget {
     required this.tab,
     required this.preferences,
     required this.onAction,
+    required this.pageRasterCachePolicy,
   });
 
   final DocumentTab tab;
   final PdfEditingPreferences preferences;
   final PdfActionHandler onAction;
+  final PdfPageRasterCachePolicy pageRasterCachePolicy;
 
   @override
   Widget build(BuildContext context) {
@@ -3194,6 +3213,7 @@ class _ProgressivePreview extends StatelessWidget {
             controller: tab.viewer,
             preferences: preferences,
             onAction: onAction,
+            pageRasterCachePolicy: pageRasterCachePolicy,
           ),
         ),
         Positioned(

--- a/app/lib/memory_probe.dart
+++ b/app/lib/memory_probe.dart
@@ -1,0 +1,8 @@
+import 'memory_snapshot.dart';
+import 'memory_probe_stub.dart'
+    if (dart.library.io) 'memory_probe_io.dart'
+    if (dart.library.js_interop) 'memory_probe_web.dart' as implementation;
+
+/// Reads the best memory snapshot this platform exposes.
+Future<AppMemorySnapshot?> readAppMemorySnapshot() =>
+    implementation.readAppMemorySnapshot();

--- a/app/lib/memory_probe_io.dart
+++ b/app/lib/memory_probe_io.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'memory_snapshot.dart';
+
+const _memoryChannel = MethodChannel('dev.milanko.dartpdf/memory');
+
+Future<AppMemorySnapshot?> readAppMemorySnapshot() async {
+  try {
+    final raw =
+        await _memoryChannel.invokeMapMethod<String, Object?>('snapshot');
+    return AppMemorySnapshot(
+      physicalBytes: _positiveInt(raw?['physicalBytes']),
+      availableBytes: _positiveInt(raw?['availableBytes']),
+      processRssBytes: ProcessInfo.currentRss,
+      processLimitBytes: _positiveInt(raw?['processLimitBytes']),
+      lowMemory: raw?['lowMemory'] == true,
+    );
+  } on MissingPluginException {
+    return AppMemorySnapshot(processRssBytes: ProcessInfo.currentRss);
+  } on PlatformException {
+    return AppMemorySnapshot(processRssBytes: ProcessInfo.currentRss);
+  }
+}
+
+int? _positiveInt(Object? value) {
+  final number = value is int
+      ? value
+      : value is num
+          ? value.toInt()
+          : null;
+  return number != null && number > 0 ? number : null;
+}

--- a/app/lib/memory_probe_stub.dart
+++ b/app/lib/memory_probe_stub.dart
@@ -1,0 +1,3 @@
+import 'memory_snapshot.dart';
+
+Future<AppMemorySnapshot?> readAppMemorySnapshot() async => null;

--- a/app/lib/memory_probe_web.dart
+++ b/app/lib/memory_probe_web.dart
@@ -1,0 +1,33 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:web/web.dart' as web;
+
+import 'memory_snapshot.dart';
+
+Future<AppMemorySnapshot?> readAppMemorySnapshot() async {
+  final navigator = web.window.navigator as JSObject;
+  final performance = web.window.performance as JSObject;
+
+  final deviceGb = _numberProperty(navigator, 'deviceMemory');
+  final memory = performance.getProperty<JSAny?>('memory'.toJS);
+  final memoryObject =
+      memory != null && memory.isA<JSObject>() ? memory as JSObject : null;
+  final heapLimit = _numberProperty(memoryObject, 'jsHeapSizeLimit');
+  final heapUsed = _numberProperty(memoryObject, 'usedJSHeapSize');
+
+  final physical = deviceGb == null ? null : (deviceGb * (1 << 30)).round();
+  return AppMemorySnapshot(
+    physicalBytes: physical,
+    processRssBytes: heapUsed?.round(),
+    processLimitBytes: heapLimit?.round(),
+  );
+}
+
+double? _numberProperty(JSObject? object, String name) {
+  if (object == null || !object.has(name)) return null;
+  final value = object.getProperty<JSAny?>(name.toJS);
+  if (value == null || !value.isA<JSNumber>()) return null;
+  final number = (value as JSNumber).toDartDouble;
+  return number.isFinite && number > 0 ? number : null;
+}

--- a/app/lib/memory_snapshot.dart
+++ b/app/lib/memory_snapshot.dart
@@ -1,0 +1,29 @@
+/// One best-effort reading of the memory constraints surrounding the app.
+///
+/// Every field is optional because browsers and native platforms expose
+/// different subsets. The adaptive policy remains conservative when a runner
+/// cannot provide the native snapshot channel.
+class AppMemorySnapshot {
+  const AppMemorySnapshot({
+    this.physicalBytes,
+    this.availableBytes,
+    this.processRssBytes,
+    this.processLimitBytes,
+    this.lowMemory = false,
+  });
+
+  /// Installed physical RAM (or the browser's coarse device-memory value).
+  final int? physicalBytes;
+
+  /// Memory the OS currently considers available without heavy reclamation.
+  final int? availableBytes;
+
+  /// Resident bytes attributed to this process/tab, where observable.
+  final int? processRssBytes;
+
+  /// A platform-provided per-process or JS-heap limit, where one exists.
+  final int? processLimitBytes;
+
+  /// The platform is already inside its low-memory threshold.
+  final bool lowMemory;
+}

--- a/app/linux/runner/my_application.cc
+++ b/app/linux/runner/my_application.cc
@@ -8,6 +8,7 @@
 #include <cairo.h>
 
 #include <cmath>
+#include <cstdio>
 #include <cstring>
 
 #include "flutter/generated_plugin_registrant.h"
@@ -26,6 +27,8 @@ struct _MyApplication {
   // arrive as Dart entrypoint arguments instead (see my_application_open), the
   // way the Dart side expects on Windows and Linux.
   FlMethodChannel* incoming_channel;
+  // Physical/available memory snapshots for the adaptive PDF cache policy.
+  FlMethodChannel* memory_channel;
   GPtrArray* print_pages;  // GBytes* per accumulated page image
   char* print_job_name;
 };
@@ -511,6 +514,59 @@ static void incoming_method_call_cb(FlMethodChannel* channel,
   }
 }
 
+// Reads Linux's authoritative available-memory estimate. MemAvailable includes
+// reclaimable page cache, unlike MemFree, and is therefore the useful signal
+// for deciding whether reconstructed PDF rasters may grow.
+static void memory_method_call_cb(FlMethodChannel* channel,
+                                  FlMethodCall* method_call,
+                                  gpointer user_data) {
+  const gchar* method = fl_method_call_get_name(method_call);
+  g_autoptr(FlMethodResponse) response = nullptr;
+  if (strcmp(method, "snapshot") != 0) {
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  } else {
+    g_autofree gchar* contents = nullptr;
+    gsize length = 0;
+    if (!g_file_get_contents("/proc/meminfo", &contents, &length, nullptr)) {
+      response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+          "memory_snapshot_failed", "Could not read /proc/meminfo", nullptr));
+    } else {
+      guint64 total_kb = 0;
+      guint64 available_kb = 0;
+      gchar** lines = g_strsplit(contents, "\n", -1);
+      for (gchar** line = lines; *line != nullptr; line++) {
+        if (sscanf(*line, "MemTotal: %" G_GUINT64_FORMAT " kB", &total_kb) ==
+            1) {
+          continue;
+        }
+        sscanf(*line, "MemAvailable: %" G_GUINT64_FORMAT " kB",
+               &available_kb);
+      }
+      g_strfreev(lines);
+      const guint64 total = total_kb * 1024;
+      const guint64 available = available_kb * 1024;
+      const guint64 low_threshold =
+          MAX(static_cast<guint64>(256) * 1024 * 1024, total / 20);
+      g_autoptr(FlValue) snapshot = fl_value_new_map();
+      fl_value_set_string_take(
+          snapshot, "physicalBytes",
+          fl_value_new_int(static_cast<gint64>(total)));
+      fl_value_set_string_take(
+          snapshot, "availableBytes",
+          fl_value_new_int(static_cast<gint64>(available)));
+      fl_value_set_string_take(snapshot, "lowMemory",
+                               fl_value_new_bool(available < low_threshold));
+      response =
+          FL_METHOD_RESPONSE(fl_method_success_response_new(snapshot));
+    }
+  }
+
+  g_autoptr(GError) error = nullptr;
+  if (!fl_method_call_respond(method_call, response, &error)) {
+    g_warning("Failed to send memory response: %s", error->message);
+  }
+}
+
 // Called when first Flutter frame received.
 static void first_frame_cb(MyApplication* self, FlView* view) {
   gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
@@ -596,6 +652,11 @@ static void my_application_activate(GApplication* application) {
   fl_method_channel_set_method_call_handler(
       self->incoming_channel, incoming_method_call_cb, self, nullptr);
 
+  self->memory_channel = fl_method_channel_new(
+      messenger, "dev.milanko.dartpdf/memory", FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      self->memory_channel, memory_method_call_cb, self, nullptr);
+
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }
 
@@ -660,6 +721,7 @@ static void my_application_dispose(GObject* object) {
   g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
   g_clear_object(&self->native_print_channel);
   g_clear_object(&self->incoming_channel);
+  g_clear_object(&self->memory_channel);
   g_clear_pointer(&self->print_pages, g_ptr_array_unref);
   g_clear_pointer(&self->print_job_name, g_free);
   G_OBJECT_CLASS(my_application_parent_class)->dispose(object);

--- a/app/macos/Runner/MainFlutterWindow.swift
+++ b/app/macos/Runner/MainFlutterWindow.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import Darwin
 import FlutterMacOS
 import PDFKit
 
@@ -78,6 +79,24 @@ class MainFlutterWindow: NSWindow {
           result(FlutterMethodNotImplemented)
         }
       }
+    }
+
+    let memoryChannel = FlutterMethodChannel(
+      name: "dev.milanko.dartpdf/memory",
+      binaryMessenger: flutterViewController.engine.binaryMessenger)
+    memoryChannel.setMethodCallHandler { (call, result) in
+      guard call.method == "snapshot" else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      var snapshot: [String: Any] = [
+        "physicalBytes": Int64(ProcessInfo.processInfo.physicalMemory),
+        "lowMemory": false,
+      ]
+      if let available = Self.availableProcessMemory() {
+        snapshot["availableBytes"] = Int64(available)
+      }
+      result(snapshot)
     }
 
     let fileAccessChannel = FlutterMethodChannel(
@@ -195,6 +214,21 @@ class MainFlutterWindow: NSWindow {
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+  }
+
+  /// `os_proc_available_memory` is not exposed by Swift's Darwin module map.
+  /// Resolve the documented libSystem function dynamically so the app can use
+  /// its advisory per-process headroom without a private API or helper plugin.
+  private static func availableProcessMemory() -> UInt64? {
+    guard let handle = dlopen(nil, RTLD_NOW) else { return nil }
+    defer { dlclose(handle) }
+    guard let symbol = dlsym(handle, "os_proc_available_memory") else {
+      return nil
+    }
+    typealias AvailableMemory = @convention(c) () -> UInt
+    let function = unsafeBitCast(symbol, to: AvailableMemory.self)
+    let bytes = function()
+    return bytes > 0 ? UInt64(bytes) : nil
   }
 
   /// Spools the whole PDF through AppKit's print panel via PDFKit. Returns

--- a/app/test/adaptive_memory_test.dart
+++ b/app/test/adaptive_memory_test.dart
@@ -1,0 +1,189 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:dart_pdf_editor_app/adaptive_memory.dart';
+import 'package:dart_pdf_editor_app/devtools.dart';
+import 'package:dart_pdf_editor_app/memory_snapshot.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const mb = 1024 * 1024;
+  const gb = 1024 * mb;
+  final tools = AppDevTools.instance;
+  late int oldRegistryCeiling;
+  late int oldLiveBudget;
+
+  void resetAuto() {
+    tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy());
+    tools.updateAutoPageRasterCache(
+      const PdfPageRasterCachePolicy(),
+      reason: 'test reset',
+    );
+    tools.useAutoPageRasterCache();
+  }
+
+  setUp(() {
+    oldRegistryCeiling = PdfCacheRegistry.instance.maxTotalWeight;
+    oldLiveBudget = PdfLiveRasterBudget.instance.maxBytes;
+    resetAuto();
+  });
+
+  tearDown(() {
+    PdfCacheRegistry.instance.handleMemoryPressure();
+    PdfCacheRegistry.instance.maxTotalWeight = oldRegistryCeiling;
+    PdfLiveRasterBudget.instance.maxBytes = oldLiveBudget;
+    resetAuto();
+    tools.clearLog();
+  });
+
+  test('larger desktop machines receive larger bounded raster budgets', () {
+    AdaptiveMemoryDecision desktop(int ramGb) => computeAdaptiveMemoryDecision(
+          snapshot: AppMemorySnapshot(
+            physicalBytes: ramGb * gb,
+            availableBytes: (ramGb * .7 * gb).round(),
+            processRssBytes: 400 * mb,
+          ),
+          platform: PdfPerformancePlatform.desktop,
+          reclaimableRegistryBytes: 0,
+          liveRasterBytes: 0,
+        );
+
+    final small = desktop(8);
+    final large = desktop(64);
+    expect(large.pageRasterPolicy.maxBytes,
+        greaterThan(small.pageRasterPolicy.maxBytes));
+    expect(large.pageRasterPolicy.maxBytes, 5 * gb,
+        reason: 'a high-headroom workstation may use the configured hard cap');
+    expect(small.pageRasterPolicy.maxBytes, lessThan(1 * gb));
+    expect(large.pageRasterPolicy.maxEntryBytes, lessThanOrEqualTo(256 * mb));
+  });
+
+  test('falling available memory shrinks the decision immediately', () {
+    AdaptiveMemoryDecision decide(int availableMb) =>
+        computeAdaptiveMemoryDecision(
+          snapshot: AppMemorySnapshot(
+            physicalBytes: 16 * gb,
+            availableBytes: availableMb * mb,
+            processRssBytes: 900 * mb,
+          ),
+          platform: PdfPerformancePlatform.desktop,
+          reclaimableRegistryBytes: 200 * mb,
+          liveRasterBytes: 100 * mb,
+        );
+
+    final roomy = decide(8000);
+    final tight = decide(500);
+    expect(tight.safeProcessLimitBytes, lessThan(roomy.safeProcessLimitBytes));
+    expect(tight.pageRasterPolicy.maxBytes,
+        lessThan(roomy.pageRasterPolicy.maxBytes));
+    expect(tight.reason, 'available-memory headroom');
+  });
+
+  test('mobile process limits cap exact rasters independently of device RAM',
+      () {
+    final decision = computeAdaptiveMemoryDecision(
+      snapshot: const AppMemorySnapshot(
+        physicalBytes: 16 * gb,
+        availableBytes: 8 * gb,
+        processRssBytes: 180 * mb,
+        processLimitBytes: 768 * mb,
+      ),
+      platform: PdfPerformancePlatform.mobile,
+      reclaimableRegistryBytes: 0,
+      liveRasterBytes: 0,
+    );
+
+    expect(decision.safeProcessLimitBytes, lessThanOrEqualTo(768 * mb));
+    expect(decision.pageRasterPolicy.maxBytes, lessThanOrEqualTo(256 * mb));
+  });
+
+  test('pressure halves Auto immediately and rate-limits regrowth', () {
+    var now = DateTime(2026, 7, 27, 12);
+    final controller = AdaptiveMemoryBudgetController(
+      platform: PdfPerformancePlatform.desktop,
+      clock: () => now,
+    );
+    const roomy = AppMemorySnapshot(
+      physicalBytes: 64 * gb,
+      availableBytes: 40 * gb,
+      processRssBytes: 400 * mb,
+    );
+
+    controller.applySnapshot(roomy);
+    final before = tools.pageRasterCachePolicy.value.maxBytes;
+    expect(before, 5 * gb);
+
+    controller.didHaveMemoryPressure();
+    final pressured = tools.pageRasterCachePolicy.value.maxBytes;
+    expect(pressured, lessThanOrEqualTo(before ~/ 2));
+    expect(tools.pageRasterCacheReason, contains('memory pressure'));
+
+    now = now.add(const Duration(minutes: 1));
+    controller.applySnapshot(roomy);
+    expect(tools.pageRasterCachePolicy.value.maxBytes, pressured,
+        reason: 'growth stays frozen during the pressure cooldown');
+
+    now = now.add(const Duration(minutes: 5));
+    controller.applySnapshot(roomy);
+    final regrown = tools.pageRasterCachePolicy.value.maxBytes;
+    expect(regrown, greaterThan(pressured));
+    final growthLimit = pressured + 64 * mb > (pressured * 1.25).round()
+        ? pressured + 64 * mb
+        : (pressured * 1.25).round();
+    expect(
+      regrown,
+      lessThanOrEqualTo(growthLimit),
+      reason: 'one sample cannot jump straight back to 5 GB',
+    );
+  });
+
+  test('a fixed page override still obeys the process safety ceiling', () {
+    tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy(
+      maxBytes: 5 * gb,
+      maxEntryBytes: 1 * gb,
+    ));
+    final controller = AdaptiveMemoryBudgetController(
+      platform: PdfPerformancePlatform.desktop,
+    );
+
+    controller.applySnapshot(const AppMemorySnapshot(
+      physicalBytes: 8 * gb,
+      availableBytes: 2 * gb,
+      processRssBytes: 700 * mb,
+    ));
+
+    expect(tools.pageRasterCachePolicy.value.maxBytes, 5 * gb,
+        reason: 'the explicit diagnostic setting remains visible');
+    expect(PdfCacheRegistry.instance.maxTotalWeight, lessThan(1 * gb),
+        reason: 'actual combined cache occupancy keeps the machine-safe cap');
+  });
+
+  test('mobile backgrounding clears only visited-page raster caches', () {
+    final pageCache = PdfBudgetedCache<int, int>(
+      weigher: (value) => value,
+      maxWeight: 1000,
+      clearsUnderMemoryPressure: true,
+      debugLabel: 'page-full-raster',
+    );
+    final otherCache = PdfBudgetedCache<int, int>(
+      weigher: (value) => value,
+      maxWeight: 1000,
+      clearsUnderMemoryPressure: true,
+      debugLabel: 'other-test-cache',
+    );
+    addTearDown(pageCache.dispose);
+    addTearDown(otherCache.dispose);
+    pageCache.put(0, 100);
+    otherCache.put(0, 100);
+    final controller = AdaptiveMemoryBudgetController(
+      platform: PdfPerformancePlatform.mobile,
+    );
+
+    controller.didChangeAppLifecycleState(AppLifecycleState.hidden);
+
+    expect(pageCache.length, 0);
+    expect(otherCache.length, 1);
+  });
+}

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -16,6 +16,14 @@ void main() {
     pdfDebugPaintDetailBounds.value = false;
     pdfDebugShowRenderWindow.value = false;
     AppDevTools.instance.showPerformanceOverlay.value = false;
+    AppDevTools.instance.setPageRasterCachePolicy(
+      const PdfPageRasterCachePolicy(),
+    );
+    AppDevTools.instance.updateAutoPageRasterCache(
+      const PdfPageRasterCachePolicy(),
+      reason: 'test reset',
+    );
+    AppDevTools.instance.useAutoPageRasterCache();
     PdfPerfLog.enabled = false;
     pdfRenderWorkerPoolSize = defaultPdfRenderWorkerPoolSize;
   });
@@ -28,6 +36,10 @@ void main() {
     pdfDebugPaintDetailBounds.value = true;
     pdfDebugShowRenderWindow.value = true;
     pdfRenderWorkerPoolSize = 5;
+    tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy(
+      maxBytes: 5 * 1024 * 1024 * 1024,
+      maxEntryBytes: 128 * 1024 * 1024,
+    ));
     await tools.persistOptions();
 
     // "Restart": globals back to defaults, then restore.
@@ -35,6 +47,7 @@ void main() {
     pdfDebugPaintDetailBounds.value = false;
     pdfDebugShowRenderWindow.value = false;
     pdfRenderWorkerPoolSize = 3;
+    tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy());
     await tools.restoreOptions();
 
     expect(tools.deepZoomMode, AppDevTools.modeBatched);
@@ -43,14 +56,62 @@ void main() {
     expect(pdfDebugPaintDetailBounds.value, isTrue);
     expect(pdfDebugShowRenderWindow.value, isTrue);
     expect(pdfRenderWorkerPoolSize, 5);
+    expect(
+      tools.pageRasterCachePolicy.value,
+      const PdfPageRasterCachePolicy(
+        maxBytes: 5 * 1024 * 1024 * 1024,
+        maxEntryBytes: 128 * 1024 * 1024,
+      ),
+    );
+    expect(tools.pageRasterCacheMode, PageRasterCacheMode.fixed);
+  });
+
+  test('Auto mode round-trips independently of its effective budget', () async {
+    SharedPreferences.setMockInitialValues({});
+    final tools = AppDevTools.instance;
+    tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy(
+      maxBytes: 5 * 1024 * 1024 * 1024,
+      maxEntryBytes: 128 * 1024 * 1024,
+    ));
+    tools.updateAutoPageRasterCache(
+      const PdfPageRasterCachePolicy(
+        maxBytes: 512 * 1024 * 1024,
+        maxEntryBytes: 64 * 1024 * 1024,
+      ),
+      reason: 'test machine headroom',
+    );
+    tools.useAutoPageRasterCache();
+    await tools.persistOptions();
+
+    tools.setPageRasterCachePolicy(const PdfPageRasterCachePolicy.disabled());
+    await tools.restoreOptions();
+
+    expect(tools.pageRasterCacheMode, PageRasterCacheMode.auto);
+    expect(
+      tools.fixedPageRasterCachePolicy.maxBytes,
+      5 * 1024 * 1024 * 1024,
+      reason: 'the last fixed diagnostic preset is retained behind Auto',
+    );
   });
 
   test('restore with nothing persisted leaves the defaults alone', () async {
     SharedPreferences.setMockInitialValues({});
     pdfRenderWorkerPoolSize = 3;
+    AppDevTools.instance.setPageRasterCachePolicy(
+      const PdfPageRasterCachePolicy(),
+    );
+    AppDevTools.instance.updateAutoPageRasterCache(
+      const PdfPageRasterCachePolicy(),
+      reason: 'test reset',
+    );
+    AppDevTools.instance.useAutoPageRasterCache();
     await AppDevTools.instance.restoreOptions();
     expect(AppDevTools.instance.deepZoomMode, AppDevTools.modePatch);
     expect(pdfRenderWorkerPoolSize, 3);
+    expect(
+      AppDevTools.instance.pageRasterCachePolicy.value,
+      const PdfPageRasterCachePolicy(),
+    );
   });
 
   test('a corrupt payload is logged, not thrown', () async {

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -120,6 +120,14 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('5 GB').last);
     await tester.pumpAndSettle();
+    expect(
+      AppDevTools.instance.pageRasterCachePolicy.value,
+      const PdfPageRasterCachePolicy(
+        maxBytes: 5 * 1024 * 1024 * 1024,
+        maxEntryBytes: 256 * 1024 * 1024,
+      ),
+      reason: 'entering fixed mode must not retain the dormant 16 MB default',
+    );
 
     final perPage =
         find.byKey(const ValueKey('devtools-page-raster-entry-budget'));
@@ -146,6 +154,18 @@ void main() {
     await tester.pump();
     await tester.tap(total);
     await tester.pumpAndSettle();
+    await tester.tap(find.text('2 GB').last);
+    await tester.pumpAndSettle();
+    expect(
+      AppDevTools.instance.pageRasterCachePolicy.value.maxEntryBytes,
+      128 * 1024 * 1024,
+      reason: 'fixed-to-fixed total changes preserve an explicit page limit',
+    );
+
+    await tester.ensureVisible(total);
+    await tester.pump();
+    await tester.tap(total);
+    await tester.pumpAndSettle();
     await tester.tap(find.text('Auto (recommended)').last);
     await tester.pumpAndSettle();
     expect(AppDevTools.instance.pageRasterCacheMode, PageRasterCacheMode.auto);
@@ -153,6 +173,22 @@ void main() {
       find.byKey(const ValueKey('devtools-page-raster-entry-budget')),
       findsNothing,
       reason: 'Auto owns the derived per-page admission limit',
+    );
+
+    await tester.ensureVisible(total);
+    await tester.tap(total);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Off').last);
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(total);
+    await tester.tap(total);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('5 GB').last);
+    await tester.pumpAndSettle();
+    expect(
+      AppDevTools.instance.pageRasterCachePolicy.value.maxEntryBytes,
+      256 * 1024 * 1024,
+      reason: 'moving from Off to a fixed budget reseeds page admission',
     );
   });
 

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -18,6 +18,15 @@ void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
     prefs = PdfEditingPreferences();
+    AppDevTools.instance.setPageRasterCachePolicy(
+      const PdfPageRasterCachePolicy(),
+    );
+    AppDevTools.instance.updateAutoPageRasterCache(
+      const PdfPageRasterCachePolicy(),
+      reason: 'test machine headroom',
+      safeProcessLimitBytes: 2 * 1024 * 1024 * 1024,
+    );
+    AppDevTools.instance.useAutoPageRasterCache();
   });
   tearDown(() {
     prefs.dispose();
@@ -28,6 +37,14 @@ void main() {
     // sink it installs) so it never leaks into another test.
     AppDevTools.instance.logTouchInput = false;
     AppDevTools.instance.localeOverride.value = null;
+    AppDevTools.instance.setPageRasterCachePolicy(
+      const PdfPageRasterCachePolicy(),
+    );
+    AppDevTools.instance.updateAutoPageRasterCache(
+      const PdfPageRasterCachePolicy(),
+      reason: 'test reset',
+    );
+    AppDevTools.instance.useAutoPageRasterCache();
     AppDevTools.instance.clearLog();
   });
 
@@ -87,6 +104,56 @@ void main() {
     await tapMode('patch');
     expect(PdfPageView.tileStoreDetail, isFalse);
     expect(PdfPageView.debugTileStoreOverride, isNull);
+  });
+
+  testWidgets('visited-page raster limits apply live from the memory section',
+      (tester) async {
+    await pumpWithDoc(tester);
+    await tester.sendKeyEvent(LogicalKeyboardKey.f12);
+    await tester.pump();
+
+    final total =
+        find.byKey(const ValueKey('devtools-page-raster-budget'));
+    await tester.ensureVisible(total);
+    await tester.pump();
+    await tester.tap(total);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('5 GB').last);
+    await tester.pumpAndSettle();
+
+    final perPage =
+        find.byKey(const ValueKey('devtools-page-raster-entry-budget'));
+    await tester.ensureVisible(perPage);
+    await tester.pump();
+    await tester.tap(perPage);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('128 MB').last);
+    await tester.pumpAndSettle();
+
+    const expected = PdfPageRasterCachePolicy(
+      maxBytes: 5 * 1024 * 1024 * 1024,
+      maxEntryBytes: 128 * 1024 * 1024,
+    );
+    expect(AppDevTools.instance.pageRasterCachePolicy.value, expected);
+    expect(
+      tester.widget<PdfViewer>(find.byType(PdfViewer))
+          .pageRasterCachePolicy,
+      expected,
+      reason: 'the open viewer receives the policy without being reopened',
+    );
+
+    await tester.ensureVisible(total);
+    await tester.pump();
+    await tester.tap(total);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Auto (recommended)').last);
+    await tester.pumpAndSettle();
+    expect(AppDevTools.instance.pageRasterCacheMode, PageRasterCacheMode.auto);
+    expect(
+      find.byKey(const ValueKey('devtools-page-raster-entry-budget')),
+      findsNothing,
+      reason: 'Auto owns the derived per-page admission limit',
+    );
   });
 
   testWidgets('the Locale section sets a testing override', (tester) async {

--- a/app/test/welcome_screen_test.dart
+++ b/app/test/welcome_screen_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -26,8 +29,18 @@ void main() {
     final store = RecentsStore();
     await store.add(title: 'a.pdf', path: '/a.pdf');
     final pdf = PdfBlankDocument.create();
+    final readGate = Completer<Uint8List>();
     final cache =
-        RecentThumbnailCache(readBytes: (path, {bookmark}) async => pdf);
+        RecentThumbnailCache(readBytes: (path, {bookmark}) => readGate.future);
+    late Future<RecentThumbnail?> thumbnail;
+
+    // The production renderer uses an isolate. Start it in runAsync's real
+    // async zone before the widget's FutureBuilder requests the same in-flight
+    // thumbnail from the fake-async test zone.
+    await tester.runAsync(() async {
+      thumbnail = cache.thumbnailFor(store.items.single);
+      await Future<void>.delayed(Duration.zero);
+    });
 
     await pump(
         tester,
@@ -44,7 +57,10 @@ void main() {
     expect(find.byType(Image), findsNothing);
 
     // Drive the (real-async) render, then let the FutureBuilder rebuild.
-    await tester.runAsync(() => cache.thumbnailFor(store.items.single));
+    await tester.runAsync(() async {
+      readGate.complete(pdf);
+      await thumbnail;
+    });
     await tester.pump();
 
     expect(find.byType(Image), findsOneWidget);
@@ -61,6 +77,9 @@ void main() {
     final cache = RecentThumbnailCache(
         readBytes: (path, {bookmark}) async => throw StateError('gone'));
 
+    // Resolve the real-async cache work before FutureBuilder observes it.
+    await tester.runAsync(() => cache.thumbnailFor(store.items.single));
+
     await pump(
         tester,
         WelcomeScreen(
@@ -70,7 +89,6 @@ void main() {
           thumbnails: cache,
         ));
 
-    await tester.runAsync(() => cache.thumbnailFor(store.items.single));
     await tester.pump();
 
     expect(find.byIcon(Icons.description_outlined), findsOneWidget);
@@ -200,14 +218,17 @@ void main() {
     expect(find.byKey(const ValueKey('recent-tile-/a.pdf')), findsNothing);
   });
 
-  testWidgets('grid tiles are shaped to the page aspect ratio',
-      (tester) async {
+  testWidgets('grid tiles are shaped to the page aspect ratio', (tester) async {
     final store = RecentsStore();
     await store.add(title: 'landscape.pdf', path: '/landscape.pdf');
     final landscape =
         PdfBlankDocument.create(pageSize: PdfPageSize.letter.landscape);
     final cache =
         RecentThumbnailCache(readBytes: (path, {bookmark}) async => landscape);
+
+    // PdfRenderWorker isolate replies must be driven from runAsync, not from
+    // the widget test binding's fake-async zone.
+    await tester.runAsync(() => cache.thumbnailFor(store.items.single));
 
     await pump(
         tester,
@@ -219,12 +240,11 @@ void main() {
           thumbnails: cache,
         ));
 
-    // Drive the render, then let the aspect-aware box relayout.
-    await tester.runAsync(() => cache.thumbnailFor(store.items.single));
+    // Let the aspect-aware box consume the cached render.
     await tester.pump();
 
-    final size = tester
-        .getSize(find.byKey(const ValueKey('recent-tile-thumb-/landscape.pdf')));
+    final size = tester.getSize(
+        find.byKey(const ValueKey('recent-tile-thumb-/landscape.pdf')));
     // A landscape page yields a wider-than-tall tile; the portrait placeholder
     // default (taller than wide) never would, so this proves the box follows
     // the rendered page's real aspect ratio.
@@ -245,6 +265,12 @@ void main() {
         readBytes: (path, {bookmark}) async =>
             path.contains('landscape') ? landscape : portrait);
 
+    await tester.runAsync(() async {
+      for (final e in store.items) {
+        await cache.thumbnailFor(e);
+      }
+    });
+
     await pump(
         tester,
         size: wide,
@@ -255,11 +281,6 @@ void main() {
           thumbnails: cache,
         ));
 
-    await tester.runAsync(() async {
-      for (final e in store.items) {
-        await cache.thumbnailFor(e);
-      }
-    });
     await tester.pump();
 
     final pThumb = tester

--- a/app/windows/runner/flutter_window.cpp
+++ b/app/windows/runner/flutter_window.cpp
@@ -32,6 +32,8 @@ constexpr const char kImageClipboardChannelName[] =
 constexpr const char kNativePrintChannelName[] =
     "dev.milanko.dartpdf/native_print";
 
+constexpr const char kMemoryChannelName[] = "dev.milanko.dartpdf/memory";
+
 // Looks up |key| in |map|, or returns null when absent.
 const flutter::EncodableValue* Lookup(const flutter::EncodableMap& map,
                                       const char* key) {
@@ -113,6 +115,37 @@ bool FlutterWindow::OnCreate() {
         } else {
           result->NotImplemented();
         }
+      });
+
+  memory_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(), kMemoryChannelName,
+          &flutter::StandardMethodCodec::GetInstance());
+  memory_channel_->SetMethodCallHandler(
+      [](const flutter::MethodCall<flutter::EncodableValue>& call,
+         std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+             result) {
+        if (call.method_name() != "snapshot") {
+          result->NotImplemented();
+          return;
+        }
+        MEMORYSTATUSEX status{};
+        status.dwLength = sizeof(status);
+        if (!::GlobalMemoryStatusEx(&status)) {
+          result->Error("memory_snapshot_failed",
+                        "GlobalMemoryStatusEx failed");
+          return;
+        }
+        result->Success(flutter::EncodableValue(flutter::EncodableMap{
+            {flutter::EncodableValue("physicalBytes"),
+             flutter::EncodableValue(
+                 static_cast<int64_t>(status.ullTotalPhys))},
+            {flutter::EncodableValue("availableBytes"),
+             flutter::EncodableValue(
+                 static_cast<int64_t>(status.ullAvailPhys))},
+            {flutter::EncodableValue("lowMemory"),
+             flutter::EncodableValue(status.dwMemoryLoad >= 90)},
+        }));
       });
 
   // Bridge the Snapshot tool's PNG raster to the Win32 clipboard so it can be

--- a/app/windows/runner/flutter_window.h
+++ b/app/windows/runner/flutter_window.h
@@ -51,6 +51,10 @@ class FlutterWindow : public Win32Window {
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       incoming_channel_;
 
+  // Reports physical/available memory to the adaptive PDF cache policy.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      memory_channel_;
+
   // Channel that copies Snapshot rasters to / reads images from the Win32
   // clipboard (`copyPng` / `readImage`). Created once the engine exists.
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -20,7 +20,9 @@
   hit, miss, admission rejection, store, and budget-eviction events, while
   cache diagnostics expose lifetime hit/miss/eviction counters. Dense
   deep-zoom scenes now bootstrap their worker-built spatial index correctly
-  instead of remaining on repeated full-viewport detail rasters indefinitely.
+  instead of remaining on repeated full-viewport detail rasters indefinitely;
+  the capped base remains visible during that warm-up rather than launching an
+  obsolete fallback record, and traces split tile replay/raster/slicing costs.
 
 ## 3.1.0
 

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -10,6 +10,13 @@
 - Bound speculative thumbnail warming on web and add command budgets to vector
   thumbnail previews, keeping long documents responsive without blanking pages
   during fast scrolling.
+- Add `PdfPageRasterCachePolicy` to configure the in-memory byte budget and
+  per-page limit for exact rasters of previously visited pages. The existing
+  32 MiB total / 16 MiB per-page defaults are unchanged; `PdfViewer`,
+  `PdfReader`, and `PdfEditorView` can now opt into a much larger desktop
+  working set. Retained full-page rasters participate in process-wide cache
+  accounting and memory-pressure cleanup, so multiple viewers share the
+  coordinated host ceiling.
 
 ## 3.1.0
 

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -18,7 +18,9 @@
   accounting and memory-pressure cleanup, so multiple viewers share the
   coordinated host ceiling. Performance traces now report exact-raster policy,
   hit, miss, admission rejection, store, and budget-eviction events, while
-  cache diagnostics expose lifetime hit/miss/eviction counters.
+  cache diagnostics expose lifetime hit/miss/eviction counters. Dense
+  deep-zoom scenes now bootstrap their worker-built spatial index correctly
+  instead of remaining on repeated full-viewport detail rasters indefinitely.
 
 ## 3.1.0
 

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -16,7 +16,9 @@
   `PdfReader`, and `PdfEditorView` can now opt into a much larger desktop
   working set. Retained full-page rasters participate in process-wide cache
   accounting and memory-pressure cleanup, so multiple viewers share the
-  coordinated host ceiling.
+  coordinated host ceiling. Performance traces now report exact-raster policy,
+  hit, miss, admission rejection, store, and budget-eviction events, while
+  cache diagnostics expose lifetime hit/miss/eviction counters.
 
 ## 3.1.0
 

--- a/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
@@ -22,7 +22,7 @@ import 'dart:math' as math;
 ///    the bound that stops image-free / vector-first buffers piling up one per
 ///    page on a long scroll (issue #283, the weight-0 unbounded-growth bug).
 ///
-/// Values that outlive their cache slot are handled by two hooks:
+/// Values that outlive their cache slot are handled by three hooks:
 ///
 ///  * [cloner] - when a value is handed out while a master stays cached (a
 ///    [ui.Image] shared by clone), [take] and [putAndClone] return
@@ -31,6 +31,9 @@ import 'dart:math' as math;
 ///  * [disposer] - run on every value the cache drops (eviction, [evict],
 ///    [clear], [dispose], or a same-key overwrite), so retained engine
 ///    resources are released deterministically.
+///  * [onEvicted] - optional diagnostics invoked only when a weight/count or
+///    coordinated process budget evicts an entry. Explicit invalidation,
+///    clearing, and same-key replacement do not count as policy evictions.
 ///
 /// Registering with [PdfCacheRegistry] (via `clearsUnderMemoryPressure: true`)
 /// wires the cache into the one coordinated memory-pressure path.
@@ -47,6 +50,7 @@ class PdfBudgetedCache<K, V> {
     int? maxEntries,
     void Function(V value)? disposer,
     V Function(V value)? cloner,
+    void Function(K key, V value)? onEvicted,
     bool rejectOversize = false,
     bool clearsUnderMemoryPressure = false,
     this.debugLabel = 'cache',
@@ -56,6 +60,7 @@ class PdfBudgetedCache<K, V> {
         _maxEntries = maxEntries == null ? null : math.max(1, maxEntries),
         _disposer = disposer,
         _cloner = cloner,
+        _onEvicted = onEvicted,
         _rejectOversize = rejectOversize,
         _clearsUnderMemoryPressure = clearsUnderMemoryPressure {
     if (_clearsUnderMemoryPressure) PdfCacheRegistry.instance.register(this);
@@ -66,6 +71,7 @@ class PdfBudgetedCache<K, V> {
   final int? _maxEntries;
   final void Function(V value)? _disposer;
   final V Function(V value)? _cloner;
+  final void Function(K key, V value)? _onEvicted;
 
   /// When set, a value whose weight alone exceeds [maxWeight] is not stored at
   /// all (rather than kept as the protected most-recently-used entry): caching
@@ -128,8 +134,7 @@ class PdfBudgetedCache<K, V> {
         protectMostRecent: protectMostRecent,
       );
       if (victim == null) break;
-      _removeEntry(victim);
-      _evictions++;
+      _removeEntry(victim, eviction: true);
     }
   }
 
@@ -297,10 +302,14 @@ class PdfBudgetedCache<K, V> {
     _evictions = 0;
   }
 
-  void _removeEntry(K key) {
+  void _removeEntry(K key, {bool eviction = false}) {
     final entry = _entries.remove(key);
     if (entry == null) return;
     _weight -= entry.weight;
+    if (eviction) {
+      _evictions++;
+      _onEvicted?.call(key, entry.value);
+    }
     _disposer?.call(entry.value);
   }
 
@@ -314,8 +323,7 @@ class PdfBudgetedCache<K, V> {
       while (_weight > _maxWeight) {
         final victim = _oldestEvictable(requireWeight: true);
         if (victim == null) break;
-        _removeEntry(victim);
-        _evictions++;
+        _removeEntry(victim, eviction: true);
       }
     }
     // Count cap: evict the least-recently-used entries - weight-0 or not -
@@ -325,8 +333,7 @@ class PdfBudgetedCache<K, V> {
       while (_entries.length > maxEntries) {
         final oldest = _entries.keys.first;
         if (oldest == _protectedKey) break;
-        _removeEntry(oldest);
-        _evictions++;
+        _removeEntry(oldest, eviction: true);
       }
     }
   }
@@ -418,9 +425,19 @@ class PdfCacheRegistry {
   }
 
   /// Diagnostic snapshot of every live registered cache: its [PdfBudgetedCache
-  /// .debugLabel], entry count, retained weight, and weight budget (0 when the
-  /// cache is bounded by entries only). For devtools-style displays.
-  List<({String label, int length, int weight, int maxWeight})> snapshot() {
+  /// .debugLabel], entry count, retained weight, weight budget (0 when the
+  /// cache is bounded by entries only), and lifetime lookup/eviction counters.
+  /// For devtools-style displays and exported performance traces.
+  List<
+      ({
+        String label,
+        int length,
+        int weight,
+        int maxWeight,
+        int hits,
+        int misses,
+        int evictions,
+      })> snapshot() {
     _pruneDead();
     return [
       for (final ref in _caches)
@@ -430,6 +447,9 @@ class PdfCacheRegistry {
             length: cache.length,
             weight: cache.weight,
             maxWeight: cache.maxWeight,
+            hits: cache.hits,
+            misses: cache.misses,
+            evictions: cache.evictions,
           ),
     ];
   }

--- a/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/budgeted_cache.dart
@@ -109,10 +109,24 @@ class PdfBudgetedCache<K, V> {
   /// coordinated ceiling shrinks caches *below* their individual budgets, so
   /// it needs a target other than [maxWeight].
   void trimToWeight(int target) {
+    _trimToWeight(target, protectMostRecent: true);
+  }
+
+  /// Registry-only hard trim. A process ceiling is a safety boundary, so it may
+  /// drop the final MRU master too; callers already hold independent clones and
+  /// can keep painting. Per-cache budgets continue to protect their MRU.
+  void _trimToWeightHard(int target) {
+    _trimToWeight(target, protectMostRecent: false);
+  }
+
+  void _trimToWeight(int target, {required bool protectMostRecent}) {
     if (_disposed || _weigher == null) return;
     final floor = math.max(0, target);
     while (_weight > floor) {
-      final victim = _oldestEvictable(requireWeight: true);
+      final victim = _oldestEvictable(
+        requireWeight: true,
+        protectMostRecent: protectMostRecent,
+      );
       if (victim == null) break;
       _removeEntry(victim);
       _evictions++;
@@ -324,8 +338,11 @@ class PdfBudgetedCache<K, V> {
   /// The least-recently-used key eligible for weight eviction: the oldest whose
   /// weight is non-zero (when [requireWeight]) and that is not the protected
   /// most-recently-used entry. Null when no such entry exists.
-  K? _oldestEvictable({required bool requireWeight}) {
-    final protikey = _protectedKey;
+  K? _oldestEvictable({
+    required bool requireWeight,
+    bool protectMostRecent = true,
+  }) {
+    final protikey = protectMostRecent ? _protectedKey : null;
     for (final entry in _entries.entries) {
       if (entry.key == protikey) continue;
       if (requireWeight && entry.value.weight == 0) continue;
@@ -437,9 +454,8 @@ class PdfCacheRegistry {
   /// [maxTotalWeight] (no-op when disabled or already under). Each cache is
   /// trimmed **proportionally** - it keeps the same fraction of its weight -
   /// so one hot large cache is not wiped to protect idle small ones, and no
-  /// cross-cache LRU clock is needed. Because each cache protects its
-  /// most-recently-used entry, the result can land slightly above the ceiling;
-  /// that residue is bounded by one entry per cache.
+  /// cross-cache LRU clock is needed. Unlike a cache's own performance budget,
+  /// this process safety boundary may evict its final MRU master.
   void enforceBudget() {
     if (_maxTotalWeight <= 0 || _enforcing) return;
     final total = totalWeight;
@@ -449,7 +465,7 @@ class PdfCacheRegistry {
       for (final ref in _caches.toList()) {
         final cache = ref.target;
         if (cache == null || cache.weight == 0) continue;
-        cache.trimToWeight(cache.weight * _maxTotalWeight ~/ total);
+        cache._trimToWeightHard(cache.weight * _maxTotalWeight ~/ total);
       }
     } finally {
       _enforcing = false;
@@ -469,6 +485,35 @@ class PdfCacheRegistry {
     }
     _pruneDead();
     return freed;
+  }
+
+  /// Clears every registered cache whose diagnostic label equals [label].
+  ///
+  /// This is the targeted counterpart to [handleMemoryPressure]. Hosts use it
+  /// when a lifecycle transition makes one reconstructible cache class
+  /// expendable (for example, dropping visited-page rasters when a mobile app
+  /// backgrounds) without also throwing away decoded images and render records.
+  /// Returns the approximate weight freed.
+  int clearLabel(String label) {
+    var freed = 0;
+    for (final ref in _caches.toList()) {
+      final cache = ref.target;
+      if (cache == null || cache.debugLabel != label) continue;
+      freed += cache.weight;
+      cache.clear();
+    }
+    _pruneDead();
+    return freed;
+  }
+
+  /// Current retained weight across registered caches named [label].
+  int weightForLabel(String label) {
+    var weight = 0;
+    for (final ref in _caches) {
+      final cache = ref.target;
+      if (cache?.debugLabel == label) weight += cache!.weight;
+    }
+    return weight;
   }
 
   void _pruneDead() => _caches.removeWhere((ref) => ref.target == null);

--- a/packages/dart_pdf_editor/lib/src/comparison/comparison_view.dart
+++ b/packages/dart_pdf_editor/lib/src/comparison/comparison_view.dart
@@ -9,6 +9,7 @@ import '../editing/editing_panel.dart';
 import '../l10n/pdf_l10n.dart';
 import '../page_geometry.dart';
 import '../pdf_viewer.dart';
+import '../preview_cache.dart';
 import '../scrollbar.dart';
 import '../theme.dart';
 import 'document_comparison.dart';
@@ -38,6 +39,7 @@ class PdfComparisonView extends StatefulWidget {
     this.showNavigator = true,
     this.pixelRatio = 1.5,
     this.viewerTheme,
+    this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
   });
 
   /// The original ("before") document bytes.
@@ -56,6 +58,10 @@ class PdfComparisonView extends StatefulWidget {
 
   /// Wraps both panes in a [PdfViewerTheme].
   final PdfViewerThemeData? viewerTheme;
+
+  /// Memory policy for exact full-resolution rasters of previously visited
+  /// pages in each comparison pane.
+  final PdfPageRasterCachePolicy pageRasterCachePolicy;
 
   @override
   State<PdfComparisonView> createState() => _PdfComparisonViewState();
@@ -196,6 +202,7 @@ class _PdfComparisonViewState extends State<PdfComparisonView> {
             document: _beforeDoc,
             controller: _beforeCtl,
             initialFit: PdfViewerFit.width,
+            pageRasterCachePolicy: widget.pageRasterCachePolicy,
           ),
         ),
       ),
@@ -208,6 +215,7 @@ class _PdfComparisonViewState extends State<PdfComparisonView> {
             document: _afterDoc,
             controller: _afterCtl,
             initialFit: PdfViewerFit.width,
+            pageRasterCachePolicy: widget.pageRasterCachePolicy,
           ),
         ),
       ),
@@ -223,6 +231,7 @@ class _PdfComparisonViewState extends State<PdfComparisonView> {
       document: _afterDoc,
       controller: _afterCtl,
       initialFit: PdfViewerFit.width,
+      pageRasterCachePolicy: widget.pageRasterCachePolicy,
       pageOverlayBuilder: _overlayBuilder,
     );
   }

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -24,6 +24,7 @@ import 'page_number_field.dart';
 import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
+import 'preview_cache.dart';
 import 'progressive_source.dart';
 import 'raster_cache.dart';
 import 'search_panel.dart';
@@ -252,6 +253,7 @@ class PdfEditorView extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
   })  : source = null,
         options = const PdfSourceLoadOptions(firstPaintPages: 1),
         onProgress = null,
@@ -329,6 +331,7 @@ class PdfEditorView extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
   })  : bytes = null,
         controller = null;
 
@@ -368,6 +371,10 @@ class PdfEditorView extends StatefulWidget {
   /// active edit session mutates page content, so its text is never served
   /// from the content-keyed persistent cache (in-memory only).
   final PdfPageTextCache? textCache;
+
+  /// Memory policy for exact full-resolution rasters of previously visited
+  /// pages. See [PdfViewer.pageRasterCachePolicy].
+  final PdfPageRasterCachePolicy pageRasterCachePolicy;
 
   /// A stable identifier for this document, used to remember its scroll
   /// position and zoom across sessions (persisted in the preferences).
@@ -1374,6 +1381,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         performance: _performance,
                         rasterCache: widget.rasterCache,
                         textCache: widget.textCache,
+                        pageRasterCachePolicy: widget.pageRasterCachePolicy,
                         documentId: _documentKey,
                         // while the full-area page grid overlays the viewer,
                         // pause the viewer entirely: its (invisible) page

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -2060,8 +2060,18 @@ class _PdfPageViewState extends State<PdfPageView>
     // _refreshTileGeometry also bootstraps a dense scene's worker-built region
     // index. Do not guard this call on _useTilePath: that gate cannot become
     // true until the very warm-up this call starts has completed.
-    if (PdfPageView.tileStoreDetail && _refreshTileGeometry()) {
-      return true;
+    if (PdfPageView.tileStoreDetail) {
+      if (_refreshTileGeometry()) return true;
+      // A worker-built grid takes a few hundred milliseconds on the dense CAD
+      // pages that need it. Keep the already-visible capped base raster during
+      // that one warm-up instead of launching a competing full-viewport detail
+      // record which will be obsolete before it can rasterize.
+      if (_tilePathStatus == 'index-warming') {
+        PdfPerfLog.log(
+          'detail waits for region-index page=${widget.previewIndex}',
+        );
+        return true;
+      }
     }
 
     // A Slug page picture is already transform-sharp for text and vector
@@ -2571,7 +2581,14 @@ class _PdfPageViewState extends State<PdfPageView>
         // A fallback detail request may have started while the index was
         // warming. Once tiles can cover this view, invalidate that generation
         // so its multi-megapixel worker picture is dropped instead of rastered.
-        if (tiling) _renderSession.invalidateDetail();
+        if (tiling) {
+          _renderSession.invalidateDetail();
+        } else {
+          // Unsupported grouped scenes and views too large for the tile budget
+          // still need the legacy detail patch. Re-enter now that the gate has
+          // a final verdict; _updateDetail will no longer take the warming wait.
+          _render();
+        }
       }
     } catch (error) {
       PdfPerfLog.log(
@@ -2677,8 +2694,11 @@ class _PdfPageViewState extends State<PdfPageView>
         pageSize: size,
         desiredRatio: desired,
         visibleFraction: fraction,
-        rasterize: (region, ratio) =>
-            scene.rasterizeRegion(region, pixelRatio: ratio),
+        rasterize: (region, ratio) => scene.rasterizeRegion(
+          region,
+          pixelRatio: ratio,
+          tracePage: widget.previewIndex,
+        ),
         canRasterize: _tileCanRasterize,
       ),
     );

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -489,6 +489,11 @@ class _PdfPageViewState extends State<PdfPageView>
   Rect? _tileFraction;
   double? _tileDesiredRatio;
 
+  /// The retained scene whose heavy region index this page has asked a worker
+  /// to build. Keeps repeated zoom settles from attaching duplicate completion
+  /// handlers while that one build is in flight.
+  PdfRetainedScene? _regionIndexWarmScene;
+
   /// Clone of this page's cached low-res preview; painted while no full
   /// raster exists, dropped (to free the buffer) the moment one lands.
   ui.Image? _preview;
@@ -798,6 +803,9 @@ class _PdfPageViewState extends State<PdfPageView>
   }) {
     _scene?.dispose();
     _scene = scene;
+    if (!identical(_regionIndexWarmScene, scene)) {
+      _regionIndexWarmScene = null;
+    }
     _sceneHasImageDraws =
         scene != null && PdfPageRenderer.hasImageDraws(scene.commands);
     _sceneFromWorker = scene != null && fromWorker;
@@ -2049,7 +2057,10 @@ class _PdfPageViewState extends State<PdfPageView>
     // _refreshTileGeometry returns false and we fall through to the single-patch
     // path below, which covers an arbitrarily large region in one raster
     // without thrashing the shared pyramid (issues #314/#360).
-    if (_useTilePath && _refreshTileGeometry()) {
+    // _refreshTileGeometry also bootstraps a dense scene's worker-built region
+    // index. Do not guard this call on _useTilePath: that gate cannot become
+    // true until the very warm-up this call starts has completed.
+    if (PdfPageView.tileStoreDetail && _refreshTileGeometry()) {
       return true;
     }
 
@@ -2517,18 +2528,61 @@ class _PdfPageViewState extends State<PdfPageView>
     final scene = PdfPageView.retainedZoomReplay ? _scene : null;
     if (scene == null ||
         scene.debugHasRegionReplayIndex ||
-        !scene.regionIndexBuildIsHeavy) {
+        !scene.regionIndexBuildIsHeavy ||
+        identical(_regionIndexWarmScene, scene)) {
       return;
     }
     final worker = _sceneFromWorker ? widget.renderWorker : null;
-    final warming = scene;
-    scene
-        .warmRegionIndex(worker, pageIndex: widget.previewIndex)
-        .then((_) {
+    final pageIndex = widget.previewIndex;
+    _regionIndexWarmScene = scene;
+    final clock = Stopwatch()..start();
+    PdfPerfLog.log(
+      'region-index warm page=$pageIndex '
+      'commands=${scene.commands.length} '
+      'requested=${worker != null && worker.isActive ? 'worker' : 'local'}',
+    );
+    unawaited(_completeRegionIndexWarm(scene, worker, pageIndex, clock));
+  }
+
+  Future<void> _completeRegionIndexWarm(
+    PdfRetainedScene scene,
+    PdfRenderWorker? worker,
+    int pageIndex,
+    Stopwatch clock,
+  ) async {
+    try {
+      final index = await scene.warmRegionIndex(
+        worker,
+        pageIndex: pageIndex,
+      );
+      PdfPerfLog.log(
+        'region-index ready page=$pageIndex '
+        'supported=${index.supported} units=${index.units.length} '
+        'bytes=${index.estimatedBytes} elapsed=${clock.elapsedMilliseconds}ms',
+      );
       // Only refresh if this is still the adopted scene and we're mounted; a
       // document swap or scroll-away may have replaced it while the worker ran.
-      if (mounted && identical(_scene, warming)) _refreshTileGeometry();
-    });
+      if (mounted && identical(_scene, scene)) {
+        final tiling = _refreshTileGeometry();
+        PdfPerfLog.log(
+          'region-index route page=$pageIndex '
+          'gate=$_tilePathStatus tiling=$tiling',
+        );
+        // A fallback detail request may have started while the index was
+        // warming. Once tiles can cover this view, invalidate that generation
+        // so its multi-megapixel worker picture is dropped instead of rastered.
+        if (tiling) _renderSession.invalidateDetail();
+      }
+    } catch (error) {
+      PdfPerfLog.log(
+        'region-index failed page=$pageIndex '
+        'elapsed=${clock.elapsedMilliseconds}ms error=$error',
+      );
+    } finally {
+      if (identical(_regionIndexWarmScene, scene)) {
+        _regionIndexWarmScene = null;
+      }
+    }
   }
 
   /// Per-tile veto for the tile store while the scene is vector-only: a tile

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -2119,7 +2119,7 @@ class _PdfPageViewState extends State<PdfPageView>
       'strip=$stripDetail vectorOnly=$_sceneIsVectorOnly '
       // scene/tiles: why this page does or does not get reusable tiles instead
       // of a fresh full-viewport raster on every pan step.
-      'scene=${heldScene != null} tiles=$_useTilePath',
+      'scene=${heldScene != null} tiles=$_tilePathStatus',
     );
     final workerStripFuture = stripDetail
         ? _detailStripImageFromWorker(
@@ -2484,10 +2484,16 @@ class _PdfPageViewState extends State<PdfPageView>
   /// [_tileCanRasterize] vetoes the regions an image draw intersects, which
   /// keep the fallback/base raster and heal automatically if the full record
   /// later replaces the scene.
-  bool get _useTilePath {
-    if (!PdfPageView.tileStoreDetail) return false;
+  bool get _useTilePath => _tilePathStatus == 'active';
+
+  /// Diagnostic state for the tile gate. The old boolean trace could only say
+  /// `tiles=false`, leaving patch mode, a missing/warming spatial index, and an
+  /// unsupported scene indistinguishable in field traces.
+  String get _tilePathStatus {
+    if (!PdfPageView.tileStoreDetail) return 'off';
+    if (!PdfPageView.retainedZoomReplay) return 'replay-off';
     final scene = PdfPageView.retainedZoomReplay ? _scene : null;
-    if (scene == null) return false;
+    if (scene == null) return 'no-scene';
     // A dense (grid-escalated) page's region index is a ~O(commands) build
     // (~210ms on the CAD probe, issue #384). Never pay it synchronously on the
     // UI isolate: defer the tile path until the warmed index is resident (built
@@ -2495,9 +2501,9 @@ class _PdfPageViewState extends State<PdfPageView>
     // Until then the base raster / single detail patch covers the view. Pages
     // below the grid ceiling keep the cheap synchronous linear build.
     if (scene.regionIndexBuildIsHeavy && !scene.debugHasRegionReplayIndex) {
-      return false;
+      return 'index-warming';
     }
-    return scene.supportsRegionRaster;
+    return scene.supportsRegionRaster ? 'active' : 'unsupported-scene';
   }
 
   /// Kicks the region-replay index build onto the render worker when the page

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -2700,6 +2700,14 @@ class _PdfPageViewState extends State<PdfPageView>
           tracePage: widget.previewIndex,
         ),
         canRasterize: _tileCanRasterize,
+        // A grid-indexed CAD scene can select tens of thousands of commands
+        // across one viewport slab. replayRegion records those commands
+        // synchronously before toImage yields, so batching every missing tile
+        // made the whole slab one UI-frame stall (271ms in the field trace).
+        // Admit one tile per paint instead. A tile completion repaints the
+        // layer and advances the center-out fill; ordinary scenes retain the
+        // lower-overhead batched path.
+        maxNewTilesPerPaint: scene.regionIndexBuildIsHeavy ? 1 : null,
       ),
     );
   }

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -14,6 +14,7 @@ import 'page_number_field.dart';
 import 'performance_policy.dart';
 import 'pdf_reflow_view.dart';
 import 'pdf_viewer.dart';
+import 'preview_cache.dart';
 import 'progressive_source.dart';
 import 'raster_cache.dart';
 import 'search_panel.dart';
@@ -140,6 +141,7 @@ class PdfReader extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
   })  : source = null,
         options = const PdfSourceLoadOptions(firstPaintPages: 1),
         onProgress = null,
@@ -183,6 +185,7 @@ class PdfReader extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
   }) : bytes = null;
 
   /// The PDF to show. Replacing it (by identity) opens the new
@@ -219,6 +222,10 @@ class PdfReader extends StatefulWidget {
   /// by [documentId], so reopening a document searches it without re-walking
   /// every page's content stream.
   final PdfPageTextCache? textCache;
+
+  /// Memory policy for exact full-resolution rasters of previously visited
+  /// pages. See [PdfViewer.pageRasterCachePolicy].
+  final PdfPageRasterCachePolicy pageRasterCachePolicy;
 
   /// A stable identifier for this document, used to remember its scroll
   /// position and zoom across sessions (persisted in [preferences]). Null
@@ -532,6 +539,7 @@ class _PdfReaderState extends State<PdfReader> {
                           performance: _performance,
                           rasterCache: widget.rasterCache,
                           textCache: widget.textCache,
+                          pageRasterCachePolicy: widget.pageRasterCachePolicy,
                           documentId: _documentKey,
                         ),
                 ),

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -954,6 +954,7 @@ class PdfViewer extends StatefulWidget {
     this.interactiveForms = true,
     this.pagePreviews = true,
     this.previewWindow = 6,
+    this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
     this.predictStrokes = true,
     this.toolShortcuts = pdfEditToolShortcuts,
     this.renderWorker,
@@ -994,6 +995,18 @@ class PdfViewer extends StatefulWidget {
   /// previously-seen document shows soft content immediately instead of
   /// blank paper. Requires [pagePreviews]; null keeps previews session-only.
   final PdfRasterCache? rasterCache;
+
+  /// Memory policy for exact full-resolution rasters of pages already visited.
+  ///
+  /// These rasters survive lazy page-widget disposal, making a same-size
+  /// revisit immediate. The default retains approximately 32 MiB total with a
+  /// 16 MiB per-page limit; desktop hosts may opt into substantially larger
+  /// budgets when memory is plentiful. See [PdfPageRasterCachePolicy].
+  ///
+  /// This is independent of [rasterCache], which persistently stores small
+  /// previews and thumbnails rather than full-resolution page rasters.
+  /// Requires [pagePreviews], which owns the shared in-memory cache.
+  final PdfPageRasterCachePolicy pageRasterCachePolicy;
 
   /// Persistent on-disk text cache (see [PdfPageTextCache]). When set with
   /// [documentId], full-document search extraction is read back from the
@@ -1805,6 +1818,7 @@ class _PdfViewerState extends State<PdfViewer>
         final animation = _zoomAnimation;
         if (animation != null) _transform.value = animation.value;
       });
+    _previews.configureFullRasterCache(widget.pageRasterCachePolicy);
     _loadPages();
     _snapshotContentStamps();
     _bindRasterCache();
@@ -2388,6 +2402,9 @@ class _PdfViewerState extends State<PdfViewer>
     // a revision (handled directly in _onRevisionControllerChanged)
     final documentSwapped = !identical(_loadedDocument, _document);
     if (documentSwapped) _swapDocument();
+    if (oldWidget.pageRasterCachePolicy != widget.pageRasterCachePolicy) {
+      _previews.configureFullRasterCache(widget.pageRasterCachePolicy);
+    }
     // Re-evaluate the owned default worker: a host worker may have been
     // supplied/removed, autoRenderWorker toggled, or the document swapped.
     _syncDefaultWorker();

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -11,6 +11,64 @@ import 'raster_cache.dart';
 import 'render_worker.dart';
 import 'renderer.dart';
 
+/// Memory policy for full-resolution rasters of pages the user has visited.
+///
+/// A page widget is disposed after it leaves the scroll view's build window.
+/// Its completed raster can outlive that widget in [PdfPagePreviewCache], so a
+/// revisit at the same physical size paints immediately without interpreting
+/// or rasterizing the page again.
+///
+/// The defaults preserve the package's bounded working set: 32 MiB total and
+/// 16 MiB for any one page. Desktop hosts that prefer revisit speed over
+/// memory can opt into a much larger budget:
+///
+/// ```dart
+/// PdfViewer(
+///   document: document,
+///   pageRasterCachePolicy: const PdfPageRasterCachePolicy(
+///     maxBytes: 5 * 1024 * 1024 * 1024,
+///     maxEntryBytes: 64 * 1024 * 1024,
+///   ),
+/// )
+/// ```
+///
+/// This controls only exact, already-rendered page rasters. Low-resolution
+/// fast-scroll previews, decoded PDF images, retained scenes, deep-zoom tiles,
+/// and render-worker records have their own bounds. A large value is therefore
+/// an upper limit on this cache, not on the process's total memory use.
+@immutable
+class PdfPageRasterCachePolicy {
+  const PdfPageRasterCachePolicy({
+    this.maxBytes = 32 * 1024 * 1024,
+    this.maxEntryBytes = 16 * 1024 * 1024,
+  })  : assert(maxBytes >= 0),
+        assert(maxEntryBytes >= 0);
+
+  /// Disables retention of full-resolution visited-page rasters.
+  const PdfPageRasterCachePolicy.disabled()
+      : maxBytes = 0,
+        maxEntryBytes = 0;
+
+  /// Total approximate RGBA byte budget for retained page rasters.
+  final int maxBytes;
+
+  /// Largest individual page raster admitted to the cache.
+  ///
+  /// This remains a separate guard even with a large [maxBytes], so one
+  /// unusually large-format or high-DPI page need not displace the useful
+  /// working set unless the host explicitly allows it.
+  final int maxEntryBytes;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfPageRasterCachePolicy &&
+      maxBytes == other.maxBytes &&
+      maxEntryBytes == other.maxEntryBytes;
+
+  @override
+  int get hashCode => Object.hash(maxBytes, maxEntryBytes);
+}
+
 /// Low-resolution page previews shown while a page's full render is
 /// pending - most visibly during fast scrolling, when [PdfPageView]
 /// holds the (UI-thread) first interpretation of pages flying past and
@@ -30,10 +88,12 @@ class PdfPagePreviewCache extends ChangeNotifier {
   PdfPagePreviewCache({
     this.longestSide = 200,
     this.capacity = 300,
-    this.maxFullRasterPixels = 8 << 20,
-    this.maxFullRasterEntryPixels = 4 << 20,
+    int maxFullRasterPixels = 8 << 20,
+    int maxFullRasterEntryPixels = 4 << 20,
   })  : assert(maxFullRasterPixels >= 0),
-        assert(maxFullRasterEntryPixels >= 0);
+        assert(maxFullRasterEntryPixels >= 0),
+        _maxFullRasterBytes = maxFullRasterPixels * 4,
+        _maxFullRasterEntryBytes = maxFullRasterEntryPixels * 4;
 
   /// Pixel size of a preview's longest side. Stretched to page size on
   /// screen the result is soft but recognizable - enough to navigate by.
@@ -47,7 +107,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// These entries remove the soft-preview delay when a lazy page widget is
   /// rebuilt during back-and-forth scrolling. The default is about 32 MiB of
   /// RGBA pixels. Set to zero to keep only low-resolution previews.
-  final int maxFullRasterPixels;
+  int get maxFullRasterPixels => _maxFullRasterBytes ~/ 4;
 
   /// Largest exact raster admitted to the recent-page cache.
   ///
@@ -55,7 +115,22 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// path instead of consuming the whole budget. The default is about 16 MiB
   /// of RGBA pixels, which covers ordinary document pages while excluding the
   /// large CAD rasters this cache is not intended to retain.
-  final int maxFullRasterEntryPixels;
+  int get maxFullRasterEntryPixels => _maxFullRasterEntryBytes ~/ 4;
+
+  /// Approximate bytes currently allowed for exact visited-page rasters.
+  int get maxFullRasterBytes => _maxFullRasterBytes;
+
+  /// Largest individual visited-page raster currently admitted.
+  int get maxFullRasterEntryBytes => _maxFullRasterEntryBytes;
+
+  /// Approximate bytes currently retained by the exact raster LRU.
+  int get fullRasterBytes => _fullEntries.weight;
+
+  /// Number of exact page rasters currently retained.
+  int get fullRasterCount => _fullEntries.length;
+
+  int _maxFullRasterBytes;
+  int _maxFullRasterEntryBytes;
 
   // Two shared budgeted LRUs: soft previews bounded by entry count, exact
   // recent-page rasters bounded by total pixels. Both dispose evicted images;
@@ -70,16 +145,33 @@ class PdfPagePreviewCache extends ChangeNotifier {
   );
   late final PdfBudgetedCache<int, _FullRasterEntry> _fullEntries =
       PdfBudgetedCache<int, _FullRasterEntry>(
-    weigher: (entry) => entry.pixels,
-    maxWeight: maxFullRasterPixels,
+    weigher: (entry) => entry.bytes,
+    maxWeight: _maxFullRasterBytes,
     disposer: (entry) => entry.image.dispose(),
+    clearsUnderMemoryPressure: true,
     debugLabel: 'page-full-raster',
   );
   bool _disposed = false;
 
   /// Pixels currently retained by the exact recent-page cache.
   @visibleForTesting
-  int get debugFullRasterPixels => _fullEntries.weight;
+  int get debugFullRasterPixels => _fullEntries.weight ~/ 4;
+
+  /// Applies a new full-resolution visited-page memory policy.
+  ///
+  /// Raising the budget lets later page renders occupy the extra room.
+  /// Lowering it trims the LRU immediately and also drops entries that exceed
+  /// the new per-page limit. Low-resolution previews are unaffected.
+  void configureFullRasterCache(PdfPageRasterCachePolicy policy) {
+    if (_disposed) return;
+    _maxFullRasterBytes = policy.maxBytes;
+    _maxFullRasterEntryBytes = policy.maxEntryBytes;
+    _fullEntries.evictWhere((index) {
+      final entry = _fullEntries.peek(index);
+      return entry != null && entry.bytes > _maxFullRasterEntryBytes;
+    });
+    _fullEntries.maxWeight = _maxFullRasterBytes;
+  }
 
   /// Optional persistent backing (see [PdfRasterCache]). When set, fresh
   /// previews are written through to disk as they render, and [loadFromDisk]
@@ -162,10 +254,10 @@ class PdfPagePreviewCache extends ChangeNotifier {
     required int? rotation,
   }) {
     if (_disposed) return;
-    final pixels = image.width * image.height;
-    if (maxFullRasterPixels == 0 ||
-        pixels > maxFullRasterEntryPixels ||
-        pixels > maxFullRasterPixels) {
+    final bytes = image.width * image.height * 4;
+    if (_maxFullRasterBytes == 0 ||
+        bytes > _maxFullRasterEntryBytes ||
+        bytes > _maxFullRasterBytes) {
       return;
     }
     // put disposes any prior entry for this index and evicts the LRU rasters
@@ -373,8 +465,8 @@ class PdfPagePreviewCache extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
-    _entries.clear(); // disposes every retained image
-    _fullEntries.clear();
+    _entries.dispose(); // disposes every retained image
+    _fullEntries.dispose();
     super.dispose();
   }
 }
@@ -402,5 +494,5 @@ class _FullRasterEntry {
   final bool annotations;
   final int? rotation;
 
-  int get pixels => image.width * image.height;
+  int get bytes => image.width * image.height * 4;
 }

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -148,6 +148,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
     weigher: (entry) => entry.bytes,
     maxWeight: _maxFullRasterBytes,
     disposer: (entry) => entry.image.dispose(),
+    onEvicted: _logFullRasterEviction,
     clearsUnderMemoryPressure: true,
     debugLabel: 'page-full-raster',
   );
@@ -164,6 +165,8 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// the new per-page limit. Low-resolution previews are unaffected.
   void configureFullRasterCache(PdfPageRasterCachePolicy policy) {
     if (_disposed) return;
+    final beforeCount = _fullEntries.length;
+    final beforeBytes = _fullEntries.weight;
     _maxFullRasterBytes = policy.maxBytes;
     _maxFullRasterEntryBytes = policy.maxEntryBytes;
     _fullEntries.evictWhere((index) {
@@ -171,6 +174,16 @@ class PdfPagePreviewCache extends ChangeNotifier {
       return entry != null && entry.bytes > _maxFullRasterEntryBytes;
     });
     _fullEntries.maxWeight = _maxFullRasterBytes;
+    PdfPerfLog.log(
+      'page-raster policy total=${policy.maxBytes} '
+      'entry=${policy.maxEntryBytes} retained=${_fullEntries.weight} '
+      'entries=${_fullEntries.length} '
+      'trimmedEntries=${beforeCount - _fullEntries.length} '
+      'trimmedBytes=${beforeBytes - _fullEntries.weight} '
+      'registry=${PdfCacheRegistry.instance.totalWeight} '
+      'ceiling=${PdfCacheRegistry.instance.maxTotalWeight}'
+      '${PdfPerfLog.rssSuffix()}',
+    );
   }
 
   /// Optional persistent backing (see [PdfRasterCache]). When set, fresh
@@ -228,15 +241,26 @@ class PdfPagePreviewCache extends ChangeNotifier {
     required int? rotation,
   }) {
     final entry = _fullEntries.take(index); // touch; the master stays cached
-    if (entry == null) return null;
-    if (!identical(entry.page, page) ||
-        entry.image.width != width ||
-        entry.image.height != height ||
-        entry.pageColor != pageColor ||
-        entry.annotations != annotations ||
-        entry.rotation != rotation) {
+    if (entry == null) {
+      _logFullRasterLookup('miss', index, reason: 'empty');
       return null;
     }
+    final mismatch = !identical(entry.page, page)
+        ? 'page-identity'
+        : entry.image.width != width || entry.image.height != height
+            ? 'dimensions'
+            : entry.pageColor != pageColor
+                ? 'page-color'
+                : entry.annotations != annotations
+                    ? 'annotations'
+                    : entry.rotation != rotation
+                        ? 'rotation'
+                        : null;
+    if (mismatch != null) {
+      _logFullRasterLookup('miss', index, reason: mismatch);
+      return null;
+    }
+    _logFullRasterLookup('hit', index, bytes: entry.bytes);
     return entry.image.clone();
   }
 
@@ -255,11 +279,23 @@ class PdfPagePreviewCache extends ChangeNotifier {
   }) {
     if (_disposed) return;
     final bytes = image.width * image.height * 4;
-    if (_maxFullRasterBytes == 0 ||
-        bytes > _maxFullRasterEntryBytes ||
-        bytes > _maxFullRasterBytes) {
+    final rejection = _maxFullRasterBytes == 0
+        ? 'disabled'
+        : bytes > _maxFullRasterEntryBytes
+            ? 'entry-limit'
+            : bytes > _maxFullRasterBytes
+                ? 'total-limit'
+                : null;
+    if (rejection != null) {
+      _logFullRasterLookup(
+        'reject',
+        index,
+        reason: rejection,
+        bytes: bytes,
+      );
       return;
     }
+    final beforeEvictions = _fullEntries.evictions;
     // put disposes any prior entry for this index and evicts the LRU rasters
     // past the pixel budget; the entry just stored (which the guard above kept
     // within budget) is never the one evicted.
@@ -273,6 +309,49 @@ class PdfPagePreviewCache extends ChangeNotifier {
         rotation: rotation,
       ),
     );
+    if (!_fullEntries.containsKey(index)) {
+      _logFullRasterLookup(
+        'reject',
+        index,
+        reason: 'coordinated-ceiling',
+        bytes: bytes,
+      );
+      return;
+    }
+    PdfPerfLog.log(
+      'page-raster store page=$index bytes=$bytes '
+      'evicted=${_fullEntries.evictions - beforeEvictions} '
+      '${_fullRasterState()}${PdfPerfLog.rssSuffix()}',
+    );
+  }
+
+  void _logFullRasterEviction(int index, _FullRasterEntry entry) {
+    PdfPerfLog.log(
+      'page-raster evict page=$index bytes=${entry.bytes} reason=budget '
+      '${_fullRasterState()}${PdfPerfLog.rssSuffix()}',
+    );
+  }
+
+  void _logFullRasterLookup(
+    String event,
+    int index, {
+    String? reason,
+    int? bytes,
+  }) {
+    PdfPerfLog.log(
+      'page-raster $event page=$index'
+      '${bytes == null ? '' : ' bytes=$bytes'}'
+      '${reason == null ? '' : ' reason=$reason'} '
+      '${_fullRasterState()}${PdfPerfLog.rssSuffix()}',
+    );
+  }
+
+  String _fullRasterState() {
+    final registry = PdfCacheRegistry.instance;
+    return 'retained=${_fullEntries.weight} entries=${_fullEntries.length} '
+        'totalLimit=$_maxFullRasterBytes '
+        'entryLimit=$_maxFullRasterEntryBytes '
+        'registry=${registry.totalWeight} ceiling=${registry.maxTotalWeight}';
   }
 
   /// Whether any preview (fresh or stale) exists for page [index].

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -23,6 +23,7 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'banded_transcript.dart';
 import 'canvas_device.dart';
 import 'image_decoder.dart';
+import 'perf_log.dart';
 import 'renderer.dart';
 import 'render_worker.dart';
 import 'region_replay_index.dart';
@@ -366,14 +367,39 @@ class PdfRetainedScene {
 
   /// Convenience: [replayRegion] + `toImage`, mirror of
   /// [PdfPageRenderer.rasterizeRegion].
+  ///
+  /// [tracePage] labels tile-pyramid calls for performance diagnostics. Null
+  /// keeps the ordinary path instrumentation-free.
   Future<ui.Image> rasterizeRegion(Rect region,
-      {required double pixelRatio}) async {
+      {required double pixelRatio, int? tracePage}) async {
+    final replayClock =
+        tracePage != null && PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
     final picture = replayRegion(region, pixelRatio: pixelRatio);
+    final replayMs = replayClock?.elapsedMicroseconds;
+    final selectedCommands = debugLastRegionReplayCommandCount;
+    final rasterClock =
+        tracePage != null && PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
     try {
-      return await picture.toImage(
+      final image = await picture.toImage(
         (region.width * pixelRatio).ceil().clamp(1, 1 << 14),
         (region.height * pixelRatio).ceil().clamp(1, 1 << 14),
       );
+      if (tracePage != null) {
+        final replayElapsedMs = (replayMs ?? 0) / 1000;
+        final rasterElapsedMs =
+            (rasterClock?.elapsedMicroseconds ?? 0) / 1000;
+        PdfPerfLog.log(
+          'tile replay page=$tracePage '
+          'region=${region.width.toStringAsFixed(0)}x'
+          '${region.height.toStringAsFixed(0)}pt '
+          'ratio=${pixelRatio.toStringAsFixed(2)} '
+          'selected=$selectedCommands/${commands.length} '
+          'replay=${replayElapsedMs.toStringAsFixed(1)}ms '
+          'raster=${rasterElapsedMs.toStringAsFixed(1)}ms '
+          'img=${image.width}x${image.height}${PdfPerfLog.rssSuffix()}',
+        );
+      }
+      return image;
     } finally {
       picture.dispose();
     }

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -29,8 +29,9 @@ class PdfTileLayer extends StatelessWidget {
     required this.visibleFraction,
     required this.rasterize,
     this.canRasterize,
+    this.maxNewTilesPerPaint,
     this.filterQuality = FilterQuality.medium,
-  });
+  }) : assert(maxNewTilesPerPaint == null || maxNewTilesPerPaint > 0);
 
   /// The pyramid to composite from.
   final PdfTileStore store;
@@ -54,6 +55,13 @@ class PdfTileLayer extends StatelessWidget {
   /// returns false for is left to the fallback/base raster.
   final bool Function(Rect region)? canRasterize;
 
+  /// Optional admission cap for missing tiles scheduled by one paint.
+  ///
+  /// Dense retained scenes use this to keep their synchronous command replay
+  /// inside one frame budget. Landed tiles tick the store and cause another
+  /// paint, so the viewport still fills center-out without a timer or queue.
+  final int? maxNewTilesPerPaint;
+
   final FilterQuality filterQuality;
 
   @override
@@ -67,6 +75,7 @@ class PdfTileLayer extends StatelessWidget {
           visibleFraction: visibleFraction,
           rasterize: rasterize,
           canRasterize: canRasterize,
+          maxNewTilesPerPaint: maxNewTilesPerPaint,
           filterQuality: filterQuality,
         ),
       );
@@ -81,6 +90,7 @@ class _TilePagePainter extends CustomPainter {
     required this.visibleFraction,
     required this.rasterize,
     required this.canRasterize,
+    required this.maxNewTilesPerPaint,
     required this.filterQuality,
   }) : super(
             // tick as sharper tiles land, and repaint on debug-border toggles
@@ -93,6 +103,7 @@ class _TilePagePainter extends CustomPainter {
   final Rect visibleFraction;
   final PdfTileRasterizer rasterize;
   final bool Function(Rect region)? canRasterize;
+  final int? maxNewTilesPerPaint;
   final FilterQuality filterQuality;
 
   @override
@@ -113,6 +124,7 @@ class _TilePagePainter extends CustomPainter {
       visiblePageRect: visiblePageRect,
       rasterize: rasterize,
       canRasterize: canRasterize,
+      maxNewTiles: maxNewTilesPerPaint,
     );
     if (view.isEmpty) return;
     final paint = Paint()..filterQuality = filterQuality;
@@ -153,5 +165,6 @@ class _TilePagePainter extends CustomPainter {
       old.visibleFraction != visibleFraction ||
       !identical(old.rasterize, rasterize) ||
       !identical(old.canRasterize, canRasterize) ||
+      old.maxNewTilesPerPaint != maxNewTilesPerPaint ||
       old.filterQuality != filterQuality;
 }

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -31,6 +31,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 
 import 'budgeted_cache.dart';
+import 'perf_log.dart';
 import 'renderer.dart';
 
 /// Rasterizes one tile: [region] is the tile's bounds in page points (the
@@ -703,6 +704,8 @@ class PdfTileStore extends ChangeNotifier {
         debugTilesDiscarded += batch.length;
         return;
       }
+      final sliceClock =
+          PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
       try {
         for (final key in batch) {
           final region = tileRegion(key);
@@ -715,6 +718,15 @@ class PdfTileStore extends ChangeNotifier {
       } finally {
         slab.dispose();
       }
+      final sliceElapsedMs =
+          (sliceClock?.elapsedMicroseconds ?? 0) / 1000;
+      PdfPerfLog.log(
+        'tile slice page=${id.pageIndex} rung=${batch.first.rung} '
+        'tiles=${batch.length} '
+        'elapsed=${sliceElapsedMs.toStringAsFixed(1)}ms '
+        'retained=${_cache.weight} entries=${_cache.length}'
+        '${PdfPerfLog.rssSuffix()}',
+      );
       _scheduleTick();
     }, onError: (Object _, StackTrace __) {
       for (final key in batch) {

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -427,6 +427,11 @@ class PdfTileStore extends ChangeNotifier {
   /// page view uses this to tile a vector-only progressive scene everywhere
   /// except the regions its absent image pixels would corrupt.
   ///
+  /// [maxNewTiles] optionally caps how many missing tiles this call admits.
+  /// Tiles already cached or in flight are unaffected. A landed tile ticks the
+  /// store, so a painting caller can use a small cap to spread synchronous
+  /// retained-scene replay across frames while the view fills center-out.
+  ///
   /// Synchronous and side-effecting: every tile it *places* is touched to
   /// most-recently-used, so a concurrent completion's eviction can only drop
   /// tiles outside the current view (the budget floor keeps a viewport's worth
@@ -440,7 +445,9 @@ class PdfTileStore extends ChangeNotifier {
     required Rect visiblePageRect,
     required PdfTileRasterizer rasterize,
     bool Function(Rect region)? canRasterize,
+    int? maxNewTiles,
   }) {
+    assert(maxNewTiles == null || maxNewTiles > 0);
     if (_disposed) return PdfTileView.empty;
     final grid = _tileGrid(pageSize, desiredRatio, visiblePageRect);
     if (grid == null) return PdfTileView.empty;
@@ -476,6 +483,15 @@ class PdfTileStore extends ChangeNotifier {
 
     final placements = <PdfTilePlacement>[];
     final pending = batchRasters ? <PdfTileKey>[] : null;
+    var newTiles = 0;
+    bool schedule(PdfTileKey key) {
+      if (maxNewTiles != null && newTiles >= maxNewTiles) return false;
+      final scheduled = _schedule(
+          key, id, pageSize, span, ratio, rasterize, pending, canRasterize);
+      if (scheduled) newTiles++;
+      return scheduled;
+    }
+
     var complete = true;
     for (final (tx, ty) in coords) {
       final key = PdfTileKey(id, rung, tx, ty);
@@ -489,8 +505,7 @@ class PdfTileStore extends ChangeNotifier {
         ));
       } else {
         complete = false;
-        _schedule(key, id, pageSize, span, ratio, rasterize, pending,
-            canRasterize);
+        schedule(key);
         final fallback = _coarserFallback(id, rung, tx, ty, span, pageSize);
         if (fallback != null) placements.add(fallback);
       }
@@ -517,8 +532,7 @@ class PdfTileStore extends ChangeNotifier {
           for (var tx = rx0; tx <= rx1; tx++) {
             if (tx >= tx0 && tx <= tx1 && ty >= ty0 && ty <= ty1) continue;
             if (ringHeadroom-- <= 0) break ring;
-            _schedule(PdfTileKey(id, rung, tx, ty), id, pageSize, span, ratio,
-                rasterize, pending, canRasterize);
+            schedule(PdfTileKey(id, rung, tx, ty));
           }
         }
       }
@@ -584,7 +598,7 @@ class PdfTileStore extends ChangeNotifier {
   /// Marks [key] in-flight and either dispatches its raster now or, when
   /// [pending] is non-null (one [viewFor] pass in [batchRasters] mode), defers
   /// it into the pass's batch.
-  void _schedule(
+  bool _schedule(
     PdfTileKey key,
     PdfTilePageIdentity id,
     Size pageSize,
@@ -594,19 +608,21 @@ class PdfTileStore extends ChangeNotifier {
     List<PdfTileKey>? pending,
     bool Function(Rect region)? canRasterize,
   ) {
-    if (_disposed || _cache.containsKey(key) || _inFlight.contains(key)) return;
+    if (_disposed || _cache.containsKey(key) || _inFlight.contains(key)) {
+      return false;
+    }
     final region = _clampToPage(
         Rect.fromLTWH(key.tx * span, key.ty * span, span, span), pageSize);
-    if (region.width <= 0 || region.height <= 0) return;
+    if (region.width <= 0 || region.height <= 0) return false;
     // Vetoed tiles are neither in-flight nor cached, so every pass re-asks -
     // the veto lifting (a scene upgrade) heals them without invalidation.
-    if (canRasterize != null && !canRasterize(region)) return;
+    if (canRasterize != null && !canRasterize(region)) return false;
 
     _inFlight.add(key);
     debugTilesScheduled++;
     if (pending != null) {
       pending.add(key);
-      return;
+      return true;
     }
     final dispatchEpoch = _epochCounter;
     rasterize(region, ratio).then((image) {
@@ -624,6 +640,7 @@ class PdfTileStore extends ChangeNotifier {
       _inFlight.remove(key);
       debugTilesDiscarded++;
     });
+    return true;
   }
 
   /// Splits one pass's missing tiles into raster batches: the whole set as a

--- a/packages/dart_pdf_editor/test/budgeted_cache_test.dart
+++ b/packages/dart_pdf_editor/test/budgeted_cache_test.dart
@@ -408,6 +408,44 @@ void main() {
           reason: 'growth is trimmed as it happens, not on a later signal');
     });
 
+    test('the process ceiling may evict each cache final MRU master', () {
+      final registry = PdfCacheRegistry.instance;
+      final a = registered();
+      final b = registered();
+      registry.maxTotalWeight = 50;
+
+      a.put(0, _Res(0, weight: 40));
+      b.put(0, _Res(1, weight: 40));
+
+      expect(registry.totalWeight, lessThanOrEqualTo(50),
+          reason: 'multiple viewers cannot each retain one oversize residue');
+    });
+
+    test('clearLabel targets one reconstructible cache class', () {
+      final registry = PdfCacheRegistry.instance;
+      final pages = PdfBudgetedCache<int, _Res>(
+        weigher: (r) => r.weight,
+        maxWeight: 1000,
+        clearsUnderMemoryPressure: true,
+        debugLabel: 'page-full-raster',
+      );
+      final images = PdfBudgetedCache<int, _Res>(
+        weigher: (r) => r.weight,
+        maxWeight: 1000,
+        clearsUnderMemoryPressure: true,
+        debugLabel: 'decoded-image-test',
+      );
+      addTearDown(pages.dispose);
+      addTearDown(images.dispose);
+      pages.put(0, _Res(0, weight: 40));
+      images.put(0, _Res(1, weight: 60));
+
+      expect(registry.weightForLabel('page-full-raster'), 40);
+      expect(registry.clearLabel('page-full-raster'), 40);
+      expect(pages.length, 0);
+      expect(images.length, 1);
+    });
+
     test('ceiling 0 (the default) never trims', () {
       final cache = registered();
       expect(PdfCacheRegistry.instance.maxTotalWeight, 0);

--- a/packages/dart_pdf_editor/test/budgeted_cache_test.dart
+++ b/packages/dart_pdf_editor/test/budgeted_cache_test.dart
@@ -200,6 +200,23 @@ void main() {
       cache.clear(); // disposes the survivor, the overwrite value 100
       expect(dropped, [0, 1, 2, 100]);
     });
+
+    test('onEvicted reports policy evictions but not explicit removals', () {
+      final evicted = <int>[];
+      final cache = PdfBudgetedCache<int, _Res>(
+        maxEntries: 2,
+        onEvicted: (key, value) => evicted.add(value.id),
+      );
+      cache.put(0, _Res(0));
+      cache.put(1, _Res(1));
+      cache.put(2, _Res(2)); // count-budget eviction
+      expect(evicted, [0]);
+      cache.evict(1);
+      cache.put(2, _Res(20)); // explicit remove + overwrite are not evictions
+      cache.clear();
+      expect(evicted, [0]);
+      expect(cache.evictions, 1);
+    });
   });
 
   group('getOrAdd', () {
@@ -482,6 +499,9 @@ void main() {
       expect(rows['images']!.length, 2);
       expect(rows['images']!.weight, 100);
       expect(rows['images']!.maxWeight, 500);
+      expect(rows['images']!.hits, 0);
+      expect(rows['images']!.misses, 0);
+      expect(rows['images']!.evictions, 0);
       // An entry-bounded cache has no weight budget: maxWeight is 0.
       expect(rows['records']!.length, 1);
       expect(rows['records']!.weight, 0);

--- a/packages/dart_pdf_editor/test/comparison_view_test.dart
+++ b/packages/dart_pdf_editor/test/comparison_view_test.dart
@@ -51,10 +51,18 @@ void main() {
   testWidgets('comparison view lists changes and toggles mode', (tester) async {
     final before = _textPdf('the quick brown fox');
     final after = _textPdf('the quick red fox');
+    const rasterPolicy = PdfPageRasterCachePolicy(
+      maxBytes: 256 * 1024 * 1024,
+      maxEntryBytes: 64 * 1024 * 1024,
+    );
 
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
-        body: PdfComparisonView(before: before, after: after),
+        body: PdfComparisonView(
+          before: before,
+          after: after,
+          pageRasterCachePolicy: rasterPolicy,
+        ),
       ),
     ));
     // build() runs after the first frame and notifies the navigator.
@@ -64,6 +72,12 @@ void main() {
     // Both panes mount in side-by-side mode.
     expect(find.byKey(const ValueKey('pdf-compare-before')), findsOneWidget);
     expect(find.byKey(const ValueKey('pdf-compare-after')), findsOneWidget);
+    expect(
+      tester
+          .widgetList<PdfViewer>(find.byType(PdfViewer))
+          .map((viewer) => viewer.pageRasterCachePolicy),
+      everyElement(rasterPolicy),
+    );
 
     // The navigator lists the replaced text.
     expect(find.byKey(const ValueKey('pdf-diff-change-0')), findsOneWidget);
@@ -73,6 +87,10 @@ void main() {
     await tester.pump();
     expect(find.byKey(const ValueKey('pdf-compare-overlay')), findsOneWidget);
     expect(find.byKey(const ValueKey('pdf-compare-before')), findsNothing);
+    expect(
+      tester.widget<PdfViewer>(find.byType(PdfViewer)).pageRasterCachePolicy,
+      rasterPolicy,
+    );
   });
 }
 

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -180,6 +180,102 @@ void main() {
         reason: 'lowering the entry limit drops oversized retained pages');
   });
 
+  testWidgets('visited-page raster perf trace explains cache decisions',
+      (tester) async {
+    final logs = <String>[];
+    PdfPerfLog.sink = logs.add;
+    PdfPerfLog.enabled = true;
+    addTearDown(() {
+      PdfPerfLog.enabled = false;
+      PdfPerfLog.sink = null;
+    });
+
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final first = document.page(0);
+    final second = document.page(1);
+    final image = await PdfPageRenderer.renderImage(first, pixelRatio: 0.5);
+    addTearDown(image.dispose);
+    final bytes = image.width * image.height * 4;
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+
+    cache.configureFullRasterCache(PdfPageRasterCachePolicy(
+      maxBytes: bytes,
+      maxEntryBytes: bytes,
+    ));
+    cache.putFullImage(
+      0,
+      first,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    cache.putFullImage(
+      1,
+      second,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    final hit = cache.fullImageFor(
+      1,
+      second,
+      width: image.width,
+      height: image.height,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    hit?.dispose();
+    expect(
+      cache.fullImageFor(
+        0,
+        first,
+        width: image.width,
+        height: image.height,
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: null,
+      ),
+      isNull,
+    );
+
+    cache.configureFullRasterCache(PdfPageRasterCachePolicy(
+      maxBytes: bytes,
+      maxEntryBytes: bytes - 1,
+    ));
+    cache.putFullImage(
+      0,
+      first,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+
+    expect(
+        logs.any((line) => line.contains('page-raster policy total=')), isTrue);
+    expect(
+        logs.any((line) => line.contains('page-raster store page=0')), isTrue);
+    expect(
+        logs.any((line) => line.contains('page-raster evict page=0')), isTrue);
+    expect(logs.any((line) => line.contains('page-raster hit page=1')), isTrue);
+    expect(
+      logs.any((line) =>
+          line.contains('page-raster miss page=0') &&
+          line.contains('reason=empty')),
+      isTrue,
+    );
+    expect(
+      logs.any((line) =>
+          line.contains('page-raster reject page=0') &&
+          line.contains('reason=entry-limit')),
+      isTrue,
+    );
+  });
+
   test('visited-page rasters join and leave process-wide accounting', () {
     final registry = PdfCacheRegistry.instance;
     final before = registry.registrationCount;

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -129,6 +129,100 @@ void main() {
         reason: 'oversized pages remain on the scheduled render path');
   });
 
+  testWidgets('byte policy raises and trims the visited-page raster cache',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(2));
+    final first = document.page(0);
+    final second = document.page(1);
+    final image = await PdfPageRenderer.renderImage(first, pixelRatio: 0.5);
+    addTearDown(image.dispose);
+    final imageBytes = image.width * image.height * 4;
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+
+    cache.configureFullRasterCache(PdfPageRasterCachePolicy(
+      maxBytes: imageBytes * 2,
+      maxEntryBytes: imageBytes,
+    ));
+    expect(cache.maxFullRasterBytes, imageBytes * 2);
+    cache.putFullImage(
+      0,
+      first,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    cache.putFullImage(
+      1,
+      second,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    expect(cache.fullRasterCount, 2);
+    expect(cache.fullRasterBytes, imageBytes * 2);
+
+    cache.configureFullRasterCache(PdfPageRasterCachePolicy(
+      maxBytes: imageBytes,
+      maxEntryBytes: imageBytes,
+    ));
+    expect(cache.fullRasterCount, 1,
+        reason: 'lowering the total budget trims the LRU immediately');
+    expect(cache.fullRasterBytes, imageBytes);
+
+    cache.configureFullRasterCache(PdfPageRasterCachePolicy(
+      maxBytes: imageBytes,
+      maxEntryBytes: imageBytes - 1,
+    ));
+    expect(cache.fullRasterCount, 0,
+        reason: 'lowering the entry limit drops oversized retained pages');
+  });
+
+  test('visited-page rasters join and leave process-wide accounting', () {
+    final registry = PdfCacheRegistry.instance;
+    final before = registry.registrationCount;
+    final cache = PdfPagePreviewCache();
+
+    cache.configureFullRasterCache(const PdfPageRasterCachePolicy());
+    expect(registry.registrationCount, before + 1);
+    expect(
+      registry.snapshot().where((row) => row.label == 'page-full-raster'),
+      isNotEmpty,
+    );
+
+    cache.dispose();
+    expect(registry.registrationCount, before);
+  });
+
+  testWidgets('viewer applies page raster policy updates', (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+    const generous = PdfPageRasterCachePolicy(
+      maxBytes: 5 * 1024 * 1024 * 1024,
+      maxEntryBytes: 64 * 1024 * 1024,
+    );
+
+    Widget viewer(PdfPageRasterCachePolicy policy) => MaterialApp(
+          home: PdfViewer(
+            document: document,
+            controller: controller,
+            pageRasterCachePolicy: policy,
+          ),
+        );
+
+    await tester.pumpWidget(viewer(generous));
+    expect(controller.pagePreviewCache!.maxFullRasterBytes,
+        generous.maxBytes);
+
+    await tester
+        .pumpWidget(viewer(const PdfPageRasterCachePolicy.disabled()));
+    expect(controller.pagePreviewCache!.maxFullRasterBytes, 0);
+    expect(controller.pagePreviewCache!.fullRasterCount, 0);
+  });
+
   testWidgets('rebind drops previews of pages whose content changed',
       (tester) async {
     // A same-geometry edit revision rebinds previews to the new page objects

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -76,6 +76,25 @@ void main() {
       expect(find.byType(PdfViewer), findsOneWidget);
     });
 
+    testWidgets('forwards the visited-page raster cache policy',
+        (tester) async {
+      final viewer = PdfViewerController();
+      addTearDown(viewer.dispose);
+      const policy = PdfPageRasterCachePolicy(
+        maxBytes: 2 * 1024 * 1024 * 1024,
+        maxEntryBytes: 64 * 1024 * 1024,
+      );
+      await pump(
+        tester,
+        PdfReader(
+          bytes: buildMultiPagePdf(2),
+          controller: viewer,
+          pageRasterCachePolicy: policy,
+        ),
+      );
+      expect(viewer.pagePreviewCache!.maxFullRasterBytes, policy.maxBytes);
+    });
+
     testWidgets('zoom menu changes and resets viewer zoom', (tester) async {
       final viewer = PdfViewerController();
       addTearDown(viewer.dispose);
@@ -298,6 +317,25 @@ void main() {
       expect(find.byKey(const ValueKey('pdf-shell-author')), findsOneWidget);
       expect(
           find.byKey(const ValueKey('pdf-shell-reflow-view')), findsOneWidget);
+    });
+
+    testWidgets('forwards the visited-page raster cache policy',
+        (tester) async {
+      final viewer = PdfViewerController();
+      addTearDown(viewer.dispose);
+      const policy = PdfPageRasterCachePolicy(
+        maxBytes: 2 * 1024 * 1024 * 1024,
+        maxEntryBytes: 64 * 1024 * 1024,
+      );
+      await pump(
+        tester,
+        PdfEditorView(
+          bytes: buildMultiPagePdf(2),
+          viewerController: viewer,
+          pageRasterCachePolicy: policy,
+        ),
+      );
+      expect(viewer.pagePreviewCache!.maxFullRasterBytes, policy.maxBytes);
     });
 
     testWidgets('customStamps are supplied to the owned editor session',

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -2,9 +2,14 @@
 // from the store instead of the single detail patch, while the base raster
 // keeps showing through. Kept in its own file so the global flag mutation can't
 // leak into other page-view tests.
+import 'dart:async';
+
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/region_replay_index.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 void main() {
@@ -54,6 +59,65 @@ void main() {
     expect(find.byType(RawImage), findsOneWidget);
     // Real tiles rastered from the page's retained scene.
     expect(store.tileCount, greaterThan(0));
+  });
+
+  testWidgets('heavy index warm does not launch an obsolete detail record',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final oldRegionLimit = PdfRetainedScene.spatialRegionReplayMaxCommands;
+    PdfRetainedScene.spatialRegionReplayMaxCommands = 0;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+
+    final bytes = buildClassicPdf();
+    final doc = PdfDocument.open(bytes);
+    final worker = _DelayedIndexWorker(PdfRenderWorker.startUncached(bytes));
+    addTearDown(() {
+      if (!worker.releaseIndex.isCompleted) worker.releaseIndex.complete();
+      worker.dispose();
+      PdfRetainedScene.spatialRegionReplayMaxCommands = oldRegionLimit;
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(
+            width: 6120,
+            child: PdfPageView(
+              page: doc.page(0),
+              renderWorker: worker,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 300 && worker.indexRequests == 0; i++) {
+      await tester.pump();
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(worker.indexRequests, 1, reason: 'the heavy index should start');
+    expect(worker.detailRecords, 0,
+        reason: 'the capped base stays visible while the index warms');
+
+    worker.releaseIndex.complete();
+    for (var i = 0; i < 300 && store.tileCount == 0; i++) {
+      await tester.pump();
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(store.tileCount, greaterThan(0));
+    expect(worker.detailRecords, 0,
+        reason: 'tiles make the fallback detail record obsolete');
   });
 
   testWidgets('a view over the tile budget falls back to the single patch',
@@ -115,4 +179,66 @@ void main() {
       scene.dispose();
     });
   });
+}
+
+class _DelayedIndexWorker extends PdfRenderWorker {
+  _DelayedIndexWorker(this.inner);
+
+  final PdfRenderWorker inner;
+  final releaseIndex = Completer<void>();
+  int indexRequests = 0;
+  int detailRecords = 0;
+
+  @override
+  bool get isActive => inner.isActive;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
+  }) {
+    if (imageDecodeRegion != null) detailRecords++;
+    return inner.record(
+      pageIndex,
+      annotations: annotations,
+      priority: priority,
+      imagePixelRatio: imagePixelRatio,
+      decodeImages: decodeImages,
+      commandLimit: commandLimit,
+      imageDecodeRegion: imageDecodeRegion,
+      onPartial: onPartial,
+    );
+  }
+
+  @override
+  Future<PdfRegionReplayIndex?> buildRegionIndex(
+    int pageIndex, {
+    required bool annotations,
+    required int maxCommands,
+    required bool buildGrid,
+    int priority = 0,
+  }) async {
+    indexRequests++;
+    await releaseIndex.future;
+    return inner.buildRegionIndex(
+      pageIndex,
+      annotations: annotations,
+      maxCommands: maxCommands,
+      buildGrid: buildGrid,
+      priority: priority,
+    );
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) =>
+      inner.cancel(pageIndex, priority: priority);
+
+  @override
+  void dispose() => inner.dispose();
 }

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -55,6 +55,11 @@ void main() {
     // The tile layer replaced the single detail patch.
     expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget);
     expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsNothing);
+    final tilePaint = tester.widget<CustomPaint>(
+      find.byKey(const ValueKey('pdf-page-tile-layer')),
+    );
+    expect((tilePaint.painter as dynamic).maxNewTilesPerPaint, 1,
+        reason: 'grid-indexed scenes must pace replay one tile per paint');
     // The base raster is still the only RawImage (tiles paint via CustomPaint).
     expect(find.byType(RawImage), findsOneWidget);
     // Real tiles rastered from the page's retained scene.

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -14,9 +14,15 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
 
     final store = PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final oldRegionLimit = PdfRetainedScene.spatialRegionReplayMaxCommands;
+    // Force even this small fixture through the heavy/grid index gate. This
+    // reproduces the field-trace failure where _useTilePath stayed
+    // `index-warming` forever because the warm-up was hidden behind that gate.
+    PdfRetainedScene.spatialRegionReplayMaxCommands = 0;
     PdfPageView.tileStoreDetail = true;
     PdfPageView.debugTileStoreOverride = store;
     addTearDown(() {
+      PdfRetainedScene.spatialRegionReplayMaxCommands = oldRegionLimit;
       PdfPageView.tileStoreDetail = false;
       PdfPageView.debugTileStoreOverride = null;
       store.dispose();

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -109,6 +109,54 @@ void main() {
   });
 
   group('PdfTileStore.viewFor', () {
+    testWidgets('an admission cap paces missing tiles across view passes',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 1,
+          ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(sizeFromRegion: true);
+        const pageSize = Size(64, 64); // 4×4 visible grid
+
+        final first = store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+          maxNewTiles: 1,
+        );
+        expect(first.complete, isFalse);
+        expect(store.inFlightCount, 1);
+        expect(store.debugTilesScheduled, 1);
+        expect(store.debugBatchesDispatched, 1);
+        expect(raster.calls, hasLength(1));
+        expect(raster.calls.single.region.size, const Size(16, 16));
+
+        await raster.flush();
+        expect(store.tileCount, 1);
+
+        final second = store.viewFor(
+          id: _id(0),
+          pageSize: pageSize,
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+          maxNewTiles: 1,
+        );
+        expect(second.placements, hasLength(1));
+        expect(store.inFlightCount, 1);
+        expect(store.debugTilesScheduled, 2);
+        expect(store.debugBatchesDispatched, 2);
+        expect(raster.calls, hasLength(2));
+
+        store.dispose();
+      });
+    });
+
     testWidgets('schedules the visible tiles center-out at the bucket ratio',
         (tester) async {
       await tester.runAsync(() async {


### PR DESCRIPTION
## What changed

- retain full-resolution rasters for recently visited pages behind an exact byte-budgeted LRU
- expose `PdfPageRasterCachePolicy` through `PdfViewer`, `PdfReader`, `PdfEditorView`, and comparison views
- add a process-wide hard ceiling across registered reconstructible caches, including multiple viewer instances
- make Auto the app default and size the page, registry, and live-raster budgets from current platform memory headroom
- add native memory snapshots for Android, iOS, macOS, Windows, and Linux, with browser capability fallbacks on web
- react immediately to OS memory pressure, pause growth for five minutes, rate-limit later growth, and clear visited-page rasters when mobile apps background
- add DevTools Auto/fixed controls, persisted overrides, effective limits, and diagnostic reasons; fixed presets remain subject to the process safety ceiling
- add page-raster and deep-zoom performance diagnostics, including cache decisions, region-index routing, selected tile commands, replay time, raster time, and retained bytes
- warm dense CAD region indexes on the render worker, suppress the obsolete fallback detail render while they warm, and pace grid-indexed tile replay to one new 512px tile per paint

## Why

The viewer discarded completed page rasters even when a machine had ample free memory, making revisits pay the full render cost again. A fixed large cache is unsafe across low-memory devices, very large pages, and multiple viewers. This change uses available headroom opportunistically while keeping reclaimable caches inside a coordinated process budget.

Desktop Auto may grow the visited-page cache as high as 5 GB on machines with sufficient headroom. Mobile and web Auto policies are capped at 256 MB. Shrinks are immediate; growth is deliberately slow to avoid oscillating around an OS pressure threshold.

Field traces from a 285,216-command CAD sheet also showed a separate deep-zoom hitch: the first 30-tile slab synchronously replayed 62,942 selected commands for 270.7 ms, matching a 287.1 ms build frame. Tile slicing itself took only 3.1 ms, and individual tile replays were generally 0–10 ms. Heavy grid-indexed scenes now admit one new center-out tile per paint while ordinary pages keep efficient slab batching.

## User/developer impact

- revisiting rendered pages can paint immediately from memory
- cache capacity scales with the machine instead of using one universal value
- pressure and lifecycle events release reconstructible data before the process becomes unstable
- developers can select Auto or diagnostic fixed limits in DevTools and inspect the effective process target
- package hosts can set `pageRasterCachePolicy` directly
- dense CAD pages keep their capped base raster visible while the index warms, then sharpen progressively without replaying an entire viewport slab in one UI frame

## Validation

- `fvm dart analyze`
- app adaptive/DevTools tests: 18 passed
- cache/viewer focused tests: 127 passed
- render-worker tests: 56 passed
- dense tile, retained-scene, worker-index, and synthetic wide-CAD tests: 42 passed
- debug builds: macOS, iOS simulator, Android, and web
- `git diff --check`

The full app sweep reached 380 passing tests before stalling in the unchanged recent-thumbnail worker test; the render-worker suite itself passes.