### PR TITLE
Fix Ctrl-wheel zoom after constrained drawing

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -1957,10 +1957,13 @@ class _PdfViewerState extends State<PdfViewer>
       _hBounceController.stop();
       _touchPanning = false;
       if (_zoomModifierDown) {
-        // not while a draw tool is armed - on the web a trackpad pinch
-        // surfaces as a modifier-flagged wheel event, and zooming would
-        // disrupt the stroke
-        if (!_drawToolArmed) _applyWheelZoom(scroll);
+        // This modifier is tracked from real keyboard events, so this is an
+        // explicit Ctrl/Cmd+wheel request even when a drawing tool is armed.
+        // Trackpad pinches are guarded separately in the pan/zoom and
+        // InteractiveViewer paths; treating an armed pen as a reason to drop
+        // this event made Ctrl+wheel appear to stick after Shift-constrained
+        // drawing.
+        _applyWheelZoom(scroll);
         return;
       }
       final matrix = _transform.value.clone();

--- a/packages/dart_pdf_editor/test/editing_straight_lines_test.dart
+++ b/packages/dart_pdf_editor/test/editing_straight_lines_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -29,11 +31,12 @@ void main() {
   Future<void> settle(WidgetTester tester) =>
       tester.pumpAndSettle(const Duration(milliseconds: 400));
 
-  Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
+  Future<PdfEditingController> pumpEditor(WidgetTester tester,
+      {PdfViewerController? viewerController}) async {
     final editing = PdfEditingController(buildMultiPagePdf(1));
-    final viewer = PdfViewerController();
+    final viewer = viewerController ?? PdfViewerController();
     addTearDown(editing.dispose);
-    addTearDown(viewer.dispose);
+    if (viewerController == null) addTearDown(viewer.dispose);
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: ListenableBuilder(
@@ -80,7 +83,8 @@ void main() {
     // a ~40° drag lands nearest the 45° diagonal
     await drag(tester, view(100, 700), view(200, 780));
 
-    final ((x1, y1), (x2, y2)) = editing.document.page(0).annotations.single.line!;
+    final ((x1, y1), (x2, y2)) =
+        editing.document.page(0).annotations.single.line!;
     expect((x2 - x1).abs(), closeTo((y2 - y1).abs(), 1),
         reason: 'equal run and rise is a 45° segment');
     await settle(tester);
@@ -172,5 +176,28 @@ void main() {
     editing.finishInk();
     expect(editing.document.page(0).annotations.single.subtype, 'Ink');
     await settle(tester);
+  });
+
+  testWidgets('Ctrl+wheel zooms after Shift-constrained ink', (tester) async {
+    final viewer = PdfViewerController();
+    addTearDown(viewer.dispose);
+    final editing = await pumpEditor(tester, viewerController: viewer);
+    editing.tool = PdfEditTool.ink;
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await drag(tester, view(100, 700), view(200, 730));
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+
+    final before = viewer.zoom;
+    final pointer = TestPointer(23, PointerDeviceKind.mouse);
+    pointer.hover(const Offset(400, 300));
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+    await tester.sendEventToBinding(pointer.scroll(const Offset(0, -200)));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+    expect(viewer.zoom, greaterThan(before));
   });
 }


### PR DESCRIPTION
### Motivation

- Ctrl/Cmd+wheel zoom stopped responding after using Shift to draw straight ink/lines because the wheel-zoom path skipped modifier zoom when a drawing tool was armed; this change restores the explicit modifier-zoom behavior. 

### Description

- In `packages/dart_pdf_editor/lib/src/pdf_viewer.dart` the pointer-wheel handler `_onPointerSignal` now honors explicit Ctrl/Cmd+wheel requests by calling `_applyWheelZoom` even when a freehand drawing tool is armed, while trackpad-pinch protections remain handled separately. 
- Added a regression test in `packages/dart_pdf_editor/test/editing_straight_lines_test.dart` named `Ctrl+wheel zooms after Shift-constrained ink` that draws a Shift-constrained ink stroke, releases Shift, then verifies `Ctrl+wheel` increases `viewer.zoom`. 
- Updated the test helper `pumpEditor` to accept an injected `PdfViewerController` so the test can assert viewer zoom, and imported `PointerDeviceKind` where needed. 
- Applied Dart formatting to the modified files.

### Testing

- Ran `fvm flutter test test/editing_straight_lines_test.dart` and all tests in that file passed (including the new regression test). 
- Ran `fvm dart analyze` against the changed files; analysis completed with a single informational lint about braces (`curly_braces_in_flow_control_structures`) but no errors. 
- Ran the formatter on the modified files (`dart format`) prior to tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6746f4f5ec832bb66c41a9b39811d3)