### PR TITLE
fix(editor): hit-test and chrome text-markups by /QuadPoints quad

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -4195,6 +4195,19 @@ class PdfEditingController extends ChangeNotifier {
           !isAnnotationEditable(annotation)) {
         continue;
       }
+      // For text-markups (Highlight / Underline / StrikeOut /
+      // Squiggly) the click must land on a /QuadPoints quad - a
+      // markup's bounding /Rect spans every line of the marked text
+      // (including the gap at line breaks) and so swallows clicks
+      // meant for an annotation behind it. The quads are what the user
+      // sees as their color swatches; hit-test those, never /Rect.
+      final quads = annotation.behavior.markupQuads;
+      if (quads != null && quads.isNotEmpty) {
+        for (final q in quads) {
+          if (q.contains(x, y)) return (i, annotation);
+        }
+        continue;
+      }
       if (annotation.rect.contains(x, y)) return (i, annotation);
     }
     return null;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -1582,6 +1582,14 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
     if (_controller.selectedPage != widget.pageIndex) return null;
     final annotation = _controller.selectedAnnotation;
     if (annotation == null) return null;
+    // match _selectedViewRects: a text-markup's primary chrome hugs
+    // its first /QuadPoints quad so the rest of the quads line up
+    // against it (the callout branch keeps /Rect - the leader arrow
+    // lives outside the text box and the chrome must enclose it).
+    final quads = annotation.behavior.markupQuads;
+    if (quads != null && quads.isNotEmpty) {
+      return _geometry.toViewRect(quads.first);
+    }
     // a callout's chrome hugs the text box, not the /Rect that also
     // encloses the leader + arrow, so resize handles size the box alone
     return _geometry.toViewRect(annotation.calloutBox ?? annotation.rect);
@@ -1600,13 +1608,31 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
 
   /// Every selected annotation's view rect on this page, in selection
   /// order (so the primary is last).
-  List<Rect> get _selectedViewRects => [
-        for (final slot in _controller.selectedAnnotationSlots)
-          if (slot.$1 == widget.pageIndex)
-            if (_controller.annotationAt(slot.$1, slot.$2)
-                case final annotation?)
-              _geometry.toViewRect(annotation.rect)
-      ];
+  ///
+  /// Text-markup annotations (Highlight / Underline / StrikeOut /
+  /// Squiggly) carry each colored run as its own /QuadPoints quad - a
+  /// highlight that wraps across a line break has one quad per line
+  /// and a /Rect that spans the gap between them. Paint one chrome
+  /// box per quad instead of one over the whole /Rect, so the chrome
+  /// hugs the user's color swatches and stops looking like it selects
+  /// the unmarked text in between.
+  List<Rect> get _selectedViewRects {
+    final result = <Rect>[];
+    for (final slot in _controller.selectedAnnotationSlots) {
+      if (slot.$1 != widget.pageIndex) continue;
+      final annotation = _controller.annotationAt(slot.$1, slot.$2);
+      if (annotation == null) continue;
+      final quads = annotation.behavior.markupQuads;
+      if (quads != null && quads.isNotEmpty) {
+        for (final q in quads) {
+          result.add(_geometry.toViewRect(q));
+        }
+      } else {
+        result.add(_geometry.toViewRect(annotation.rect));
+      }
+    }
+    return result;
+  }
 
   /// The primary selection's appearance quad in view space (BBox corner
   /// order: ll, lr, ur, ul), or null without an appearance stream.
@@ -5035,13 +5061,15 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
             ? _moveCurrent! - _moveStart!
             : Offset.zero;
     // the rest of a multi-selection on this page: chrome boxes without
-    // handles, riding along with a move drag
+    // handles, riding along with a move drag. The primary chrome box
+    // (matching `selected`) is drawn separately by the painter; this
+    // list carries every other box - for text-markups the other
+    // /QuadPoints quads of the primary plus the full set of every
+    // other selected annotation.
     final allSelected = _selectedViewRects;
     final extraSelected = [
-      for (final rect in selected == null
-          ? allSelected
-          : allSelected.sublist(0, allSelected.length - 1))
-        rect.shift(moveDelta)
+      for (final rect in allSelected)
+        if (selected == null || rect != selected) rect.shift(moveDelta)
     ];
     final rotating = _rotateStartAngle != null;
     final dragging =

--- a/packages/dart_pdf_editor/test/editing_chrome_test.dart
+++ b/packages/dart_pdf_editor/test/editing_chrome_test.dart
@@ -396,4 +396,71 @@ void main() {
       expect(after.to, geometry.toViewRect(editing.selectedAnnotation!.rect));
     });
   });
+
+  group('text-markup chrome per /QuadPoints quad', () {
+    /// 306×396 view of the 612×792 page (0.5 px/pt), with one selected
+    /// text-markup annotation. Returns the editing controller plus the
+    /// page geometry the overlay mounted with.
+    Future<(PdfEditingController, PdfPageGeometry)> pumpMarkupOverlay(
+        WidgetTester tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addMarkup(PdfMarkupKind.highlight, {
+          0: const [
+            // two quads on different vertical bands → /Rect spans
+            // the gap, exercising the per-quad chrome path
+            PdfRect(100, 700, 300, 712),
+            PdfRect(100, 685, 200, 697),
+          ],
+        })
+        ..tool = PdfEditTool.select
+        ..selectAnnotation(0, 0);
+      addTearDown(editing.dispose);
+      final geometry = PdfPageGeometry(
+        cropBox: editing.document.page(0).cropBox,
+        rotation: 0,
+        viewSize: const Size(306, 396),
+      );
+      await tester.pumpWidget(MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 306,
+            height: 396,
+            child: EditingPageOverlay(
+              controller: editing,
+              pageIndex: 0,
+              geometry: geometry,
+              textPrompt: showPdfTextPrompt,
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+      return (editing, geometry);
+    }
+
+    testWidgets(
+        'the primary chrome box hugs the first /QuadPoints quad, '
+        'not the annotation /Rect', (tester) async {
+      final (_, geometry) = await pumpMarkupOverlay(tester);
+      // 0.5 px/pt → the upper quad (100,700)-(300,712) becomes
+      // (50,40)-(150,46) in view space. The annotation /Rect would
+      // span the gap to the lower quad and reach (50,40)-(150,53.5).
+      final painter = overlayPainter(tester);
+      final expected = geometry.toViewRect(const PdfRect(100, 700, 300, 712));
+      expect(painter.selectionRect, expected);
+      expect(painter.selectionRect!.top, lessThan(50));
+    });
+
+    testWidgets(
+        'every /QuadPoints quad becomes its own chrome box in '
+        'extraSelectionRects', (tester) async {
+      final (_, geometry) = await pumpMarkupOverlay(tester);
+      final painter = overlayPainter(tester);
+      // the painter should carry one extra box for the second quad;
+      // the first quad is the primary and lives in selectionRect.
+      expect(painter.extraSelectionRects, hasLength(1));
+      final expected = geometry.toViewRect(const PdfRect(100, 685, 200, 697));
+      expect(painter.extraSelectionRects.single, expected);
+    });
+  });
 }

--- a/packages/dart_pdf_editor/test/editing_multiselect_test.dart
+++ b/packages/dart_pdf_editor/test/editing_multiselect_test.dart
@@ -124,6 +124,36 @@ void main() {
       expect(editing.selectedAnnotationSlots, [(0, 0)]);
       expect(editing.selectedAnnotation!.subtype, 'Circle');
     });
+
+    test(
+        'text-markup clicks must land on a /QuadPoints quad, '
+        'not just the annotation /Rect', () {
+      // One highlight with two quads on the same page: the first
+      // quad sits on the upper line, the second on the lower line,
+      // and the /Rect is the union of both (a single tall box that
+      // covers the gap between the lines as well). Without the
+      // quad-only hit test, a click anywhere inside that gap or
+      // outside the colored runs would still hit the highlight.
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addMarkup(PdfMarkupKind.highlight, {
+          0: const [
+            PdfRect(100, 700, 300, 712), // upper line quad
+            PdfRect(100, 685, 200, 697), // lower line quad
+          ],
+        });
+      // inside the upper quad → hit
+      expect(editing.selectableAnnotationAt(0, 150, 706), isNotNull);
+      // inside the lower quad → hit
+      expect(editing.selectableAnnotationAt(0, 150, 691), isNotNull);
+      // in the gap between the two lines - inside the /Rect, but
+      // outside every /QuadPoints quad → miss
+      expect(editing.selectableAnnotationAt(0, 150, 698), isNull);
+      // inside the /Rect but past the right edge of the lower quad →
+      // still misses, even though /Rect.contains is true
+      expect(editing.selectableAnnotationAt(0, 250, 691), isNull);
+      // well outside the highlight → miss
+      expect(editing.selectableAnnotationAt(0, 500, 500), isNull);
+    });
   });
 
   group('multi-selection in the viewer', () {


### PR DESCRIPTION
## Summary

<!-- What changed, and why? Keep this focused on behavior and API impact. -->

## Affected packages

<!-- Check every package touched by this PR. -->

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

<!-- Check the commands you ran. Leave unchecked if not applicable. -->

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [x] `cd packages/pdf_cos && fvm dart test`
- [x] `cd packages/pdf_document && fvm dart test`
- [x] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [x] Ghent corpus test or baseline update
- [x] Real PDF corpus parse/render smoke test
- [x] Example app smoke test

If any relevant check was not run, explain why:

## PDF fixtures and screenshots

<!--
Attach minimal PDFs, screenshots, or before/after images when they help review.
Do not upload private or confidential PDFs. Prefer programmatic fixtures in
tests, or minimized documents that reproduce the behavior.
-->

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

<!-- Known limitations, intentional baseline changes, migration notes, or follow-up work. -->

## Issued
<img width="2448" height="1440" alt="pdf_viewer_example2026-07-2820-18-35" src="https://github.com/user-attachments/assets/b264014f-0e73-49d5-ad53-f3e9a82ae0a8" />

## Fixed
<img width="2448" height="1440" alt="pdf_viewer_example" src="https://github.com/user-attachments/assets/5b2071a5-4c8a-4f48-a198-2ae29c72cd07" />

