### PR TITLE
Stop the render pipeline repeating work, and fix two lying trace fields

### DIFF
--- a/app/lib/adaptive_memory.dart
+++ b/app/lib/adaptive_memory.dart
@@ -217,6 +217,24 @@ class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
   DateTime? _lastPressure;
   int? _pressureRegistryCap;
   bool _lowMemoryActive = false;
+  int? _lastRssBytes;
+
+  /// Share of process RSS the registered caches must hold before a pressure
+  /// event is allowed to shrink their ceiling for [pressureCooldown].
+  ///
+  /// Below this the caches are not what is consuming the process, and cutting
+  /// them is not a mitigation - it is a self-inflicted wound with a feedback
+  /// loop attached. The 2026-07-29 trace is the worked example: a low-memory
+  /// signal at ~1350MB RSS reclaimed 22MB (1.6%) from a registry holding 7MB,
+  /// halved the ceiling 140MB -> 70MB, and the pages whose rasters that ceiling
+  /// had been retaining promptly re-rasterized four more times - raising RSS,
+  /// arming the next sample, halving the ceiling again. The cache was never the
+  /// problem; the live rasters and worker buffers were, and those are what
+  /// [PdfLiveRasterBudget] governs.
+  ///
+  /// 5% is deliberately permissive: a registry genuinely holding hundreds of MB
+  /// clears it easily and still gets the old behaviour.
+  static const registryMaterialityPercent = 5;
 
   Future<void> start({bool periodic = true}) async {
     if (_started) return;
@@ -242,6 +260,10 @@ class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
     try {
       final snapshot = await _probe() ?? const AppMemorySnapshot();
       if (!_started) return;
+      // Kept across the low-memory early-return below: [_applyPressure] needs a
+      // reading of the whole process to judge whether the caches it is about to
+      // punish are where the memory actually is.
+      _lastRssBytes = snapshot.processRssBytes ?? _lastRssBytes;
       if (snapshot.lowMemory) {
         if (!_lowMemoryActive) {
           _lowMemoryActive = true;
@@ -262,6 +284,7 @@ class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
   @visibleForTesting
   void applySnapshot(AppMemorySnapshot snapshot) {
     final now = _clock();
+    _lastRssBytes = snapshot.processRssBytes ?? _lastRssBytes;
     if (_lastPressure != null &&
         now.difference(_lastPressure!) >= pressureCooldown) {
       _pressureRegistryCap = null;
@@ -332,35 +355,61 @@ class AdaptiveMemoryBudgetController with WidgetsBindingObserver {
     }
     _lastPressure = now;
     final currentRegistry = PdfCacheRegistry.instance.maxTotalWeight;
-    _pressureRegistryCap = math.max(
-      64 * _mb,
-      currentRegistry > 0 ? currentRegistry ~/ 2 : 64 * _mb,
-    );
+    // Measured BEFORE the clear below, which is what makes this a judgement
+    // about where the process's memory lives rather than a tautology.
+    final registryHeld = PdfCacheRegistry.instance.totalWeight;
+    final rss = _lastRssBytes;
+    final registryIsMaterial = rss == null || rss <= 0
+        ? true // no reading to judge by: keep the conservative old behaviour
+        : registryHeld * 100 >= rss * registryMaterialityPercent;
+
+    // Reclaim regardless: pressure is a hard signal and freeing what is
+    // reclaimable is always right. It is the LASTING half of the old response -
+    // the halved ceiling and halved page budget, both held for pressureCooldown
+    // - that is gated, because that half is what starves the cache into the
+    // re-raster loop when the memory was never in the cache to begin with.
     final freed = PdfCacheRegistry.instance.handleMemoryPressure();
     final liveFreed = PdfLiveRasterBudget.instance.evictReclaimable();
-    PdfCacheRegistry.instance.maxTotalWeight = _pressureRegistryCap!;
+    if (registryIsMaterial) {
+      _pressureRegistryCap = math.max(
+        64 * _mb,
+        currentRegistry > 0 ? currentRegistry ~/ 2 : 64 * _mb,
+      );
+      PdfCacheRegistry.instance.maxTotalWeight = _pressureRegistryCap!;
+    }
+    // Always halved: the live rasters ARE the process's large reconstructible
+    // allocation, so this is the lever that corresponds to the signal.
     PdfLiveRasterBudget.instance.maxBytes = math.max(
       32 * _mb,
       PdfLiveRasterBudget.instance.maxBytes ~/ 2,
     );
 
     final current = tools.pageRasterCachePolicy.value;
-    final bytes = current.maxBytes == 0
-        ? 0
-        : math.max(
-            platform == PdfPerformancePlatform.desktop ? 32 * _mb : 16 * _mb,
-            current.maxBytes ~/ 2,
-          );
+    final bytes = !registryIsMaterial
+        ? current.maxBytes
+        : current.maxBytes == 0
+            ? 0
+            : math.max(
+                platform == PdfPerformancePlatform.desktop
+                    ? 32 * _mb
+                    : 16 * _mb,
+                current.maxBytes ~/ 2,
+              );
+    final share = rss == null || rss <= 0 ? null : registryHeld * 100 ~/ rss;
+    final note = registryIsMaterial
+        ? ''
+        : '; caches held ${registryHeld >> 20}MB of ${rss >> 20}MB RSS '
+            '($share%), ceiling held';
     tools.updateAutoPageRasterCache(
       PdfPageRasterCachePolicy(
         maxBytes: bytes,
         maxEntryBytes: _entryLimitFor(bytes, platform),
       ),
-      reason: '$reason; ${freed + liveFreed >> 20}MB reclaimed',
+      reason: '$reason; ${freed + liveFreed >> 20}MB reclaimed$note',
       safeProcessLimitBytes: tools.safeProcessLimitBytes,
     );
     tools.addLog('memory-auto: $reason, reclaimed '
-        '${(freed + liveFreed) >> 20}MB; growth paused for '
+        '${(freed + liveFreed) >> 20}MB$note; growth paused for '
         '${pressureCooldown.inMinutes} min');
   }
 

--- a/app/test/adaptive_memory_test.dart
+++ b/app/test/adaptive_memory_test.dart
@@ -99,6 +99,21 @@ void main() {
     expect(decision.pageRasterPolicy.maxBytes, lessThanOrEqualTo(256 * mb));
   });
 
+  // Gives the process-wide registry real occupancy, so a pressure event is
+  // judged against caches that are actually holding something. Without this the
+  // registry is empty and the controller (rightly) declines to punish it.
+  PdfBudgetedCache<int, int> heavyCache(int bytes) {
+    final cache = PdfBudgetedCache<int, int>(
+      weigher: (entry) => entry,
+      maxWeight: bytes * 8,
+      clearsUnderMemoryPressure: true, // what enrolls it in the registry
+      debugLabel: 'test-heavy',
+    );
+    cache.put(0, bytes);
+    addTearDown(cache.dispose);
+    return cache;
+  }
+
   test('pressure halves Auto immediately and rate-limits regrowth', () {
     var now = DateTime(2026, 7, 27, 12);
     final controller = AdaptiveMemoryBudgetController(
@@ -110,6 +125,9 @@ void main() {
       availableBytes: 40 * gb,
       processRssBytes: 400 * mb,
     );
+    // The caches hold half the process here, so cutting them is a real
+    // mitigation and the halving below is the right response.
+    heavyCache(200 * mb);
 
     controller.applySnapshot(roomy);
     final before = tools.pageRasterCachePolicy.value.maxBytes;
@@ -137,6 +155,46 @@ void main() {
       lessThanOrEqualTo(growthLimit),
       reason: 'one sample cannot jump straight back to 5 GB',
     );
+  });
+
+  test('pressure spares the caches when they are not where the memory is', () {
+    var now = DateTime(2026, 7, 27, 12);
+    final controller = AdaptiveMemoryBudgetController(
+      platform: PdfPerformancePlatform.desktop,
+      clock: () => now,
+    );
+    // 8MB of registered cache in a 1350MB process - the 2026-07-29 trace's
+    // proportions. Halving the ceiling there reclaims essentially nothing and
+    // costs every retained raster, so the pages re-rasterize, RSS climbs, the
+    // next sample halves it again. The memory is in live rasters and worker
+    // buffers, and those have their own budget.
+    heavyCache(8 * mb);
+    const tight = AppMemorySnapshot(
+      physicalBytes: 16 * gb,
+      availableBytes: 2 * gb,
+      processRssBytes: 1350 * mb,
+    );
+
+    controller.applySnapshot(tight);
+    final budgetBefore = tools.pageRasterCachePolicy.value.maxBytes;
+    final ceilingBefore = PdfCacheRegistry.instance.maxTotalWeight;
+    final liveBefore = PdfLiveRasterBudget.instance.maxBytes;
+
+    controller.didHaveMemoryPressure();
+
+    expect(tools.pageRasterCachePolicy.value.maxBytes, budgetBefore,
+        reason: 'a cache holding 0.5% of RSS is not the thing to cut');
+    expect(PdfLiveRasterBudget.instance.maxBytes, lessThan(liveBefore),
+        reason: 'the live rasters ARE the large reconstructible allocation');
+    expect(tools.pageRasterCacheReason, contains('ceiling held'));
+
+    // ...and the cooldown must not then freeze the budget at a starved value:
+    // with nothing cut, the next sample is free to track the machine again.
+    now = now.add(const Duration(minutes: 1));
+    controller.applySnapshot(tight);
+    expect(PdfCacheRegistry.instance.maxTotalWeight,
+        greaterThanOrEqualTo(ceilingBefore ~/ 2),
+        reason: 'no lasting pressure cap was installed');
   });
 
   test('a fixed page override still obeys the process safety ceiling', () {

--- a/doc/dev-log/2026-07-29-render-waste-and-trace-honesty.md
+++ b/doc/dev-log/2026-07-29-render-waste-and-trace-honesty.md
@@ -1,0 +1,157 @@
+# Re-raster waste, the memory feedback loop, and two lying trace fields
+
+Driven by a device trace (`perf.logs`-style, 2026-07-29, ~3.5 minutes on a
+3-4 page 1191x824pt document). The headline number: **~30 seconds of
+rasterize wall-clock inside ~40 seconds of active session**, 31 full-page
+rasters for 4 distinct pages. Page 1 alone rasterized 14 times, page 0 nine
+times. The viewer was rasterize-bound essentially the whole time it was
+awake, and almost all of it was repeat work.
+
+Six changes, in the order they matter.
+
+## 1. A settle no longer supersedes the base raster (`page_render_session.dart`)
+
+`PdfPageRenderSession.update` bumped the **full** render generation on any
+`viewportChanged`, which includes a `settleGeneration` bump at unchanged
+scale. A full raster that completed a few milliseconds after such a bump
+failed `_superseded` in `_renderNow`, was disposed unpainted, and the page
+rasterized from scratch again.
+
+That is the trace's clearest waste: page 0 produced an identical
+`base-full ratio=1.4 1715x1213` at n=59, n=61 and n=63 inside one second -
+~8MB and a full GPU readback each - with only the last one surviving to
+paint. Page 1 did the same at n=60/62.
+
+The full raster depends on content, display settings and resolution. A
+settle touches none of them; it moves the *detail patch*. So `update` now
+invalidates the detail on every settle (unchanged) and the full generation
+only on `blanked || visualChanged || scaleChanged || pageSlotChanged`. It
+still *schedules* a render - the patch needs one - it just stops cancelling
+work that was about to land.
+
+Unit-tested deterministically in `page_render_session_test.dart` ('a settle
+at unchanged scale supersedes the detail, not the base'); that test fails if
+the `invalidateFull()` guard is removed. The end-to-end widget test in
+`render_hold_test.dart` guards the observable outcome only - the timing that
+actually discards a raster is not reproducible there, because a local render
+lands too fast to be interrupted.
+
+## 2. Memory pressure no longer punishes caches that hold nothing
+
+`AdaptiveMemoryBudgetController._applyPressure` halved the registry ceiling
+and the page-raster budget on every pressure event, and held both for
+`pressureCooldown`. In the trace that fired against a registry holding
+**7MB of a 1350MB process**: it reclaimed 22MB (1.6%), halved the ceiling
+140MB -> 70MB, and the pages whose rasters the ceiling had been retaining
+promptly re-rasterized four more times - raising RSS, arming the next
+sample, halving the ceiling again. A closed loop, and the cache was never
+the problem: the memory is in live rasters, worker buffers and GPU
+textures.
+
+Reclaiming is unchanged (pressure is a hard signal). What is now gated is
+the **lasting** half - the `_pressureRegistryCap` and the halved page budget
+- on the registry holding at least `registryMaterialityPercent` (5%) of
+process RSS. Below that the caches are not the thing to cut, and
+`PdfLiveRasterBudget` (still halved unconditionally) is the lever that
+corresponds to the signal. With no RSS reading available the old behaviour
+is kept.
+
+Note this also explains why `page-raster mode=fixed total=2147483648` in the
+trace was cosmetic: `PdfCacheRegistry.enforceBudget` trims proportionally and
+may evict the final MRU master, so the ~70MB ceiling was the real bound, not
+the 2GB devtools setting.
+
+## 3. No second raster when the vector replay already finished the region
+
+`_updateDetail` painted a vector-only region replay, then unconditionally
+awaited a worker region record and rasterized *that* over it. On a region no
+image reaches, the two produce identical pixels. The trace paid it on a page
+whose single image decoded to 0.0 megapixels: `detail-vector ... 1715x999
+ms=401.9` followed 320ms later by `detail-worker-picture ... 1715x999
+ms=322.5`.
+
+`vectorCoversRegion` (the existing `_imagesIntersectRegion` predicate, hoisted
+above the worker launch) now skips the worker request entirely and returns the
+vector patch as final. The predicate is the codebase's own definition of "the
+vector replay is visually complete for this region" - `_tileCanRasterize` already
+bets *retained, reused* tiles on it, which is a longer-lived commitment than this
+one.
+
+`web_slug_mixed_page_test.dart` covers both sides: the image-free region now
+asks for no region record, and a new test asserts that a region the image
+*does* reach still waits for the complete record and paints no vector patch
+in the meantime.
+
+## 4. The raster cache no longer keeps entries that can only miss
+
+`fullImageFor` returned null on a geometry mismatch and left the entry in
+place. In the trace a page-0 raster stored at ratio 0.4 (429x304) produced
+`miss reason=dimensions` three times over 1.4s while the viewer, long since
+at ratio 1.4, re-rasterized the page each time. Six lookups across the
+session: one hit. A mismatched entry is dropped now - the caller's next act
+is to store its replacement anyway, and under the coordinated ceiling the
+cache holds single-digit entries.
+
+## 5. `interpret=` was not measuring interpreting
+
+The `_renderNow` stopwatch starts above `_paintVectorFirst`, so
+`interpretMs` included a full-page vector raster and an `endOfFrame` wait.
+`interpret page=2 ... interpret=1224.2ms wait=109.0ms build=132.8ms` left
+~980ms unattributed, and that time was the `vector-first-full ... ms=793.0`
+logged two lines earlier. Every such line under-attributed by 60-80% -
+exactly the shape that sends someone optimizing the interpreter when the
+cost is in the raster.
+
+`PdfPerfLog.interpret` now takes `progressiveMs`, so
+`progressive + wait + build` accounts for `interpret`. Printed even at zero:
+"ran no progressive phase" and "this build predates the split" must not read
+the same.
+
+## 6. `ms=` on raster lines is queue-inclusive - `conc=` says by how much
+
+`toImage` awaits the raster thread and the scheduler starts page renders
+without awaiting them, so concurrent rasters absorb each other's queue time.
+Three 0.1MP rasters that started together reported 4692ms, 3461ms and
+2731ms; one page at one ratio measured 138.8ms uncontended against 2299.4ms
+contended - 16x over identical pixels.
+
+New `PdfRasterProbe.measure(kind, page:, ratio:, region:, rasterize:)`
+replaces the hand-rolled `Stopwatch` + `PdfPerfLog.raster` pairs at all five
+call sites and adds `conc=N`: peak rasters in flight during this one's
+lifetime (peak, not depth-at-start - a raster that begins alone and is then
+joined waits just as long as one that started fourth). At `conc=1` the
+duration is the work; above it, mostly queue. The probe retires in a
+`finally`, so a throwing rasterize cannot leak the count and quietly turn
+the diagnostic into a liar - asserted directly via `debugInFlight`.
+
+## 7. The thumbnail warm logged ~90 times and warmed nothing
+
+`_kickWarm` scheduled a microtask that immediately re-checked the gate and
+stood down. The scheduler pings its activity `Listenable` on every grant,
+settle, request and hold transition - mostly while still busy - so each ping
+cost a microtask and a log line. The trace has ~90 `thumbnail warm yields`
+lines and not one `thumbnail warm page=`.
+
+The gate is now checked *before* scheduling, and the yield is logged once per
+transition into yielding rather than once per ping. `renderHold` lines also
+now carry `inFlight=`, because `busy` is pending + inFlight + hold: a trace
+showing `renderHold off (pending=0)` followed by silence previously gave no
+way to tell an idle viewer from one whose in-flight set never drained.
+
+## Not fixed / open
+
+- The ~1.4GB RSS itself. The page-raster cache held 7-16MB of it throughout,
+  so it is elsewhere - retained scenes, worker command buffers, or GPU
+  textures. The trace shows 250MB swings inside 200ms windows with no
+  eviction logged (13:45:19.643 -> 19.840, 1474 -> 1225MB), which points at
+  scene/worker-buffer churn. Change 2 stops the controller making it worse;
+  it does not find it.
+- Seven `FIRST` interprets on a 3-4 page document, including pages
+  re-interpreted after the pressure eviction dropped their pictures.
+  Change 2 should reduce these; not yet measured on device.
+- `_baseRasterIsCurrent` / `_imageState` (`pdf_page_view.dart`) hoists the
+  resolution-unchanged decision above the vector-first and picture-await
+  work, and adds content-intent and image-ratio checks the old
+  `_rasteredRatio` guard lacked. Every path traced was already covered by the
+  old guard, so this is an early-out and a `render skip ... reason=base-current`
+  trace line, **not** a behaviour fix - the duplicate rasters are change 1.

--- a/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
@@ -261,10 +261,42 @@ class PdfThumbnailCache {
     _warmAttempted.clear();
   }
 
+  /// Whether the warm is currently standing aside, so the yield is logged on
+  /// the transition into that state rather than once per activity ping.
+  bool _warmYielding = false;
+
   void _kickWarm() {
     if (_warming || _disposed || _warmRenderer == null) return;
+    // Don't spin up a loop that will immediately stand down again. The render
+    // scheduler pings its activity Listenable on every grant, settle, request
+    // and hold transition, and most of those happen while it is still busy -
+    // so kicking per ping costs a microtask and a log line each time and
+    // reaches a warm page only if the gate happens to be clear at that instant.
+    // The 2026-07-29 trace is ~90 `thumbnail warm yields` lines against zero
+    // `thumbnail warm page=`: 3.5 minutes of sidebar warming nothing but the
+    // log. The gate pings again when the viewer goes idle, which is the only
+    // moment the loop could have made progress anyway.
+    if (_foregroundBusy) {
+      _logWarmYield('foreground busy '
+          '(pending=${_pending.length} draining=$_draining)');
+      return;
+    }
+    if (_viewerBusy) {
+      _logWarmYield('viewer rendering');
+      return;
+    }
+    _warmYielding = false;
     _warming = true;
     scheduleMicrotask(_warmLoop);
+  }
+
+  void _logWarmYield(String reason) {
+    // One line per transition into yielding. A warm that stays blocked for
+    // minutes should read as one event in the trace, not as ninety - and the
+    // repeat lines carried no information the first did not.
+    if (_warmYielding) return;
+    _warmYielding = true;
+    PdfPerfLog.log('thumbnail warm yields - $reason');
   }
 
   Future<void> _warmLoop() async {
@@ -274,7 +306,7 @@ class PdfThumbnailCache {
         // let the foreground drain re-kick us when it's done (its `finally`
         // calls _kickWarm), rather than busy-waiting on frames
         if (_foregroundBusy) {
-          PdfPerfLog.log('thumbnail warm yields - foreground busy '
+          _logWarmYield('foreground busy '
               '(pending=${_pending.length} draining=$_draining)');
           return;
         }
@@ -284,11 +316,12 @@ class PdfThumbnailCache {
         // actually looking at (#603). The gate's activity listener re-kicks
         // this loop when the viewer goes idle.
         if (_viewerBusy) {
-          PdfPerfLog.log('thumbnail warm yields - viewer rendering');
+          _logWarmYield('viewer rendering');
           return;
         }
         final page = _nextWarmPage();
         if (page == null) return; // every page attempted this pass
+        _warmYielding = false;
         _warmAttempted.add(page);
         final renderer = _warmRenderer;
         if (renderer == null) return;

--- a/packages/dart_pdf_editor/lib/src/page_render_session.dart
+++ b/packages/dart_pdf_editor/lib/src/page_render_session.dart
@@ -98,8 +98,9 @@ class PdfPageRenderSession {
             old.pageColor != next.pageColor ||
             old.showAnnotations != next.showAnnotations;
     final visualChanged = contentChanged || nonContentVisualChanged;
-    final viewportChanged = old.scale != next.scale ||
-        old.settleGeneration != next.settleGeneration;
+    final scaleChanged = old.scale != next.scale;
+    final viewportChanged =
+        scaleChanged || old.settleGeneration != next.settleGeneration;
     final pageSlotChanged = old.pageIndex != next.pageIndex;
     final schedule = blanked || visualChanged || viewportChanged;
 
@@ -108,8 +109,23 @@ class PdfPageRenderSession {
     // already-current page state. It does invalidate in-flight results so a
     // worker response cannot be accepted into the recycled slot.
     if (schedule || pageSlotChanged) {
-      invalidateFull();
+      // The DETAIL patch tracks the viewport, so every settle supersedes it.
       invalidateDetail();
+      // The full-page raster does not. It depends on content, display settings
+      // and resolution - none of which a settle at unchanged scale touches - so
+      // invalidating it here threw away completed, correct pixels: a raster
+      // that finished a few milliseconds after a settle bump was disposed
+      // unpainted and the page rasterized again from scratch. That is the
+      // duplicate the 2026-07-29 trace shows as `base-full page=0 ratio=1.4
+      // 1715x1213` at n=59, n=61 and n=63 inside one second, ~8MB and a full
+      // GPU readback apiece, with only the last one surviving to paint.
+      //
+      // A settle still SCHEDULES a render (scheduleRender below) - the detail
+      // patch needs one, and _renderNow re-rasters if the resolution really did
+      // move. It just no longer cancels work that was about to land.
+      if (blanked || visualChanged || scaleChanged || pageSlotChanged) {
+        invalidateFull();
+      }
     }
     if (!schedule) return PdfPageRenderTransition.none;
 

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -476,6 +476,26 @@ class _PdfPageViewState extends State<PdfPageView>
   /// this still matches.
   double? _rasteredRatio;
 
+  /// What the live [_image] actually depicts, when it is a COMPLETE base
+  /// raster: the resolution it was rasterized at, the image-decode resolution
+  /// its buffer carried, and the content intent it was taken under.
+  ///
+  /// Distinct from [_rasteredRatio], and deliberately so. [_rasteredRatio] is
+  /// "the next picture must re-raster" bookkeeping, and half a dozen paths null
+  /// it while leaving perfectly good pixels on screen ([_dropPicture] alone is
+  /// reached from an additive edit, a focus-distance promotion, and every scene
+  /// swap). That left the resolution-unchanged guard unable to fire, and the
+  /// 2026-07-29 trace shows the cost: `base-full page=0 ratio=1.4 1715x1213`
+  /// twice inside 306ms, byte-identical, ~8MB and a full GPU readback apiece -
+  /// and the same shape on pages 0 and 1 three more times in the session.
+  ///
+  /// This records what the pixels ARE rather than what the bookkeeping wants,
+  /// so [_baseRasterIsCurrent] can answer the only question that matters: would
+  /// re-rendering produce anything different? Set only where a full raster is
+  /// adopted - NEVER by the vector-first path, whose image is deliberately
+  /// incomplete (no PDF images) and must be replaced by the full pass.
+  ({double ratio, double? imageRatio, PdfPageRenderIntent intent})? _imageState;
+
   ui.Image? _detailImage;
   Rect? _detailFraction; // patch placement as fractions of the page
   double? _detailPixelRatio;
@@ -701,6 +721,7 @@ class _PdfPageViewState extends State<PdfPageView>
       // raster stays painted until the fresh one replaces it.
       _image?.dispose();
       _image = null;
+      _imageState = null;
       _preview?.dispose();
       _preview = null;
     }
@@ -872,8 +893,13 @@ class _PdfPageViewState extends State<PdfPageView>
     _detailIntent = _renderIntent(widget);
   }
 
-  bool _detailContentIsCurrent() {
-    final intent = _detailIntent;
+  bool _detailContentIsCurrent() => _intentIsCurrent(_detailIntent);
+
+  /// Whether pixels taken under [intent] still depict this page's current
+  /// content. Shared by the detail patch and the base raster - both ask exactly
+  /// this question, and a second copy of the field list would be one edit away
+  /// from letting one of them paint stale content.
+  bool _intentIsCurrent(PdfPageRenderIntent? intent) {
     if (intent == null ||
         intent.pageIndex != widget.previewIndex ||
         intent.pageEpoch != widget.pageEpoch ||
@@ -886,6 +912,29 @@ class _PdfPageViewState extends State<PdfPageView>
       return false;
     }
     return widget.trustContentStamp || identical(intent.page, widget.page);
+  }
+
+  /// Whether the live base raster already is exactly what a fresh render would
+  /// produce - same resolution, same content, and images decoded at least as
+  /// sharply as this page now wants.
+  ///
+  /// The last clause is what keeps a prefetch neighbour honest: a page rendered
+  /// off-focus decoded its images at [PdfPageView.prefetchImagePixelRatioFactor]
+  /// of full, and once it comes into focus those pixels are genuinely stale even
+  /// though the ratio and content match. Mirrors [_renderedAtFullImageRatio]'s
+  /// comparison so the two cannot disagree about what "full" means.
+  bool _baseRasterIsCurrent() {
+    final state = _imageState;
+    // A Slug-routed page paints its picture under a transform instead of a base
+    // raster; its render pass is not a readback this can skip.
+    if (state == null || _image == null || _slugPicture != null) return false;
+    final effective = _effectiveRatio();
+    if ((effective - state.ratio).abs() > state.ratio * 0.01) return false;
+    final imageRatio = state.imageRatio;
+    if (imageRatio != null && imageRatio < _fullImageRatio() * 0.99) {
+      return false;
+    }
+    return _intentIsCurrent(state.intent);
   }
 
   /// The uncapped resolution at an explicit [scale], so speculation can price
@@ -927,6 +976,7 @@ class _PdfPageViewState extends State<PdfPageView>
     setState(() {
       _image?.dispose();
       _image = null;
+      _imageState = null;
       _dropDetail();
       _dropPicture(); // frees the scene + slug picture and nulls _rasteredRatio
     });
@@ -1046,6 +1096,13 @@ class _PdfPageViewState extends State<PdfPageView>
     setState(() {
       _image = image;
       _rasteredRatio = effective;
+      // A cache entry only ever holds a full-resolution raster (putFullImage is
+      // gated on _renderedAtFullImageRatio), so it restores as one.
+      _imageState = (
+        ratio: effective,
+        imageRatio: null,
+        intent: _renderIntent(widget),
+      );
       _preview?.dispose();
       _preview = null;
     });
@@ -1625,21 +1682,15 @@ class _PdfPageViewState extends State<PdfPageView>
       return null;
     }
     final vectorRatio = _vectorFirstRatio();
-    final rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-    final image = await PdfPageRenderer.rasterize(
-      picture,
-      PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation),
-      vectorRatio,
-    );
-    PdfPerfLog.raster(
+    final image = await PdfRasterProbe.measure(
       'vector-first-full',
       page: pageIndex,
-      imageWidth: image.width,
-      imageHeight: image.height,
       ratio: vectorRatio,
-      elapsedMs: rasterClock == null
-          ? null
-          : rasterClock.elapsedMicroseconds / 1000.0,
+      rasterize: () => PdfPageRenderer.rasterize(
+        picture,
+        PdfPageRenderer.pageSize(widget.page, rotation: widget.rotation),
+        vectorRatio,
+      ),
     );
     picture.dispose();
     // Adopt the vector raster only if the full pass hasn't already landed (a
@@ -1653,6 +1704,10 @@ class _PdfPageViewState extends State<PdfPageView>
     setState(() {
       _image?.dispose();
       _image = image;
+      // Deliberately NOT recorded in _imageState: these pixels carry no PDF
+      // images, so the full pass below must re-raster and _baseRasterIsCurrent
+      // must never call them current. Same reasoning as _rasteredRatio above.
+      _imageState = null;
       _preview?.dispose();
       _preview = null;
     });
@@ -1745,8 +1800,32 @@ class _PdfPageViewState extends State<PdfPageView>
       _lastInterpretTextShapeHit = null;
     }
     final sw = Stopwatch()..start();
+    // The vector-first phase below runs INSIDE [sw]'s span but interprets
+    // nothing the `interpret=` figure is about - it rasterizes a full-page
+    // vector preview (seconds, on a dense sheet) and can wait a frame for the
+    // detail paint. Left unmeasured it is simply missing from the line, which
+    // is how the 2026-07-29 trace reported a 1224ms "interpret" whose wait and
+    // build summed to 242ms. Measured, it closes the line's accounting.
+    var progressiveMs = 0.0;
     if (_renderPaused) {
       _render();
+      return;
+    }
+    // Nothing to render: the live raster already is what this pass would
+    // produce. The scheduler re-grants a request that arrived while a render
+    // was in flight (render_scheduler.dart's `_inFlight` queue) on the premise
+    // that it "may carry a new scale or revision", and when it doesn't, the
+    // pass below re-interprets and re-reads the whole page off the GPU to
+    // arrive back at the pixels already on screen - 260-500ms and ~8MB per
+    // repeat at 2.1MP in the 2026-07-29 trace, several times per session.
+    //
+    // Still refresh the detail patch: a settle that only moved the viewport
+    // routes through here too (one combined callback paces base + detail), and
+    // that IS work even when the base raster is untouched.
+    if (_baseRasterIsCurrent()) {
+      PdfPerfLog.log('render skip page=$pageIndex reason=base-current '
+          'ratio=${_effectiveRatio().toStringAsFixed(2)}');
+      await _updateDetail();
       return;
     }
     // Progressive first paint: on a page's first interpret, paint its
@@ -1783,6 +1862,7 @@ class _PdfPageViewState extends State<PdfPageView>
           if (_superseded(generation, pageIndex)) return;
         }
       }
+      progressiveMs = sw.elapsedMicroseconds / 1000.0;
     }
     final cached = _picture;
     final ui.Picture picture;
@@ -1817,6 +1897,7 @@ class _PdfPageViewState extends State<PdfPageView>
         pageIndex,
         path: _lastInterpretPath,
         interpretMs: sw.elapsedMicroseconds / 1000.0,
+        progressiveMs: progressiveMs,
         waitMs: _lastInterpretWaitMs,
         buildMs: _lastInterpretBuildMs,
         decodeMs: _lastInterpretDecodeMs,
@@ -1886,6 +1967,7 @@ class _PdfPageViewState extends State<PdfPageView>
               _slugPicture = slugPicture;
               _image?.dispose();
               _image = null;
+              _imageState = null;
               _preview?.dispose();
               _preview = null;
               _rasteredRatio = effective;
@@ -1955,42 +2037,36 @@ class _PdfPageViewState extends State<PdfPageView>
       // back precomputed; null plan = local bin). Fallback paths (no scene,
       // or the kill switch) re-raster the cached picture.
       final scene = retainedScene;
-      final ui.Image image;
-      // The clock starts at each rasterize, not above the branch: the strip
+      // The probe starts at each rasterize, not above the branch: the strip
       // path awaits a worker bin first, and attributing that queue wait to
       // the raster itself would corrupt the number this log exists to read.
-      Stopwatch? rasterClock;
+      // Selecting the closure here and measuring it below keeps that property
+      // while leaving one log call for all three branches.
+      final Future<ui.Image> Function() rasterize;
       if (scene != null && _stripReplayScene(scene)) {
         final stripPlan = await _workerStripPlan(scene, pixelRatio: effective);
         if (_superseded(generation, pageIndex)) return;
-        rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-        image = await scene.rasterizeStrips(
-          pixelRatio: effective,
-          stripPlan: stripPlan,
-        );
+        rasterize = () => scene.rasterizeStrips(
+              pixelRatio: effective,
+              stripPlan: stripPlan,
+            );
       } else if (scene != null && !_sceneIsTileOnly(scene)) {
-        rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-        image = await scene.rasterize(pixelRatio: effective);
+        rasterize = () => scene.rasterize(pixelRatio: effective);
       } else {
         // No scene, or one retained only to feed tiles: a flat replay of a
         // dense transcript would be a UI-thread hitch, so the cached picture
         // stays the full-page base raster.
-        rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-        image = await PdfPageRenderer.rasterize(
-          picture,
-          _renderPlan.pageSize(widget.page),
-          effective,
-        );
+        rasterize = () => PdfPageRenderer.rasterize(
+              picture,
+              _renderPlan.pageSize(widget.page),
+              effective,
+            );
       }
-      PdfPerfLog.raster(
+      final image = await PdfRasterProbe.measure(
         'base-full',
         page: pageIndex,
-        imageWidth: image.width,
-        imageHeight: image.height,
         ratio: effective,
-        elapsedMs: rasterClock == null
-            ? null
-            : rasterClock.elapsedMicroseconds / 1000.0,
+        rasterize: rasterize,
       );
       if (_superseded(generation, pageIndex)) {
         image.dispose();
@@ -2003,6 +2079,11 @@ class _PdfPageViewState extends State<PdfPageView>
         _image?.dispose();
         _image = image;
         _rasteredRatio = effective;
+        _imageState = (
+          ratio: effective,
+          imageRatio: _pictureImageRatio,
+          intent: _renderIntent(widget),
+        );
         _preview?.dispose();
         _preview = null;
       });
@@ -2134,15 +2215,30 @@ class _PdfPageViewState extends State<PdfPageView>
     final stripDetail = heldScene != null && _stripReplayScene(heldScene);
     final progressivePriority =
         _sceneIsVectorOnly ? widget.renderPriority - 1 : widget.renderPriority;
+    // Whether replaying the retained vector-only scene alone yields the
+    // FINISHED region rather than a placeholder to be replaced. It does exactly
+    // when no image draw reaches the region - the same invariant that lets the
+    // tile path rasterize from such a scene ([_tileCanRasterize]).
+    //
+    // When it holds, the worker pass that normally follows has nothing to add:
+    // it re-records the identical commands and re-rasterizes the identical
+    // pixels. The 2026-07-29 trace paid that twice on a page whose single image
+    // decoded to 0.0 megapixels - `detail-vector … 1715x999 ms=401.9` followed
+    // 320ms later by `detail-worker-picture … 1715x999 ms=322.5`, a second 1.7MP
+    // allocation and platform-thread readback for byte-identical output.
+    final vectorCoversRegion = _sceneIsVectorOnly &&
+        heldScene != null &&
+        !_imagesIntersectRegion(heldScene.commands, region);
     final detailClock = Stopwatch()..start();
     PdfPerfLog.log(
       'detail request page=${widget.previewIndex} '
       'strip=$stripDetail vectorOnly=$_sceneIsVectorOnly '
+      'vectorCovers=$vectorCoversRegion '
       // scene/tiles: why this page does or does not get reusable tiles instead
       // of a fresh full-viewport raster on every pan step.
       'scene=${heldScene != null} tiles=$_tilePathStatus',
     );
-    final workerStripFuture = stripDetail
+    final workerStripFuture = stripDetail && !vectorCoversRegion
         ? _detailStripImageFromWorker(
             heldScene,
             region,
@@ -2155,7 +2251,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // Non-strip pages keep the ordinary region-record path. Dense strip pages
     // use recordStripDetail on every worker backend so commands and the plan
     // come from one geometry-consistent, cancellable job.
-    final workerPictureFuture = !stripDetail
+    final workerPictureFuture = !stripDetail && !vectorCoversRegion
         ? _detailPictureFromWorker(
             region,
             ratio,
@@ -2168,43 +2264,33 @@ class _PdfPageViewState extends State<PdfPageView>
     // that visible slice immediately while the worker fills in its image
     // pixels: CAD linework becomes sharp after the lightweight recording,
     // rather than after a second multi-megabyte command transfer. A later
-    // complete worker patch replaces this one at the same geometry.
-    var progressiveReady = false;
-    if (_sceneIsVectorOnly &&
-        heldScene != null &&
-        !_imagesIntersectRegion(heldScene.commands, region)) {
-      final vectorClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-      final vectorImage = await heldScene.rasterizeRegion(
-        region,
-        pixelRatio: ratio,
-      );
-      PdfPerfLog.raster(
+    // complete worker patch replaces this one at the same geometry - unless
+    // [vectorCoversRegion], in which case this replay IS the final patch and no
+    // worker pass was started to replace it.
+    if (vectorCoversRegion) {
+      final vectorImage = await PdfRasterProbe.measure(
         'detail-vector',
         page: widget.previewIndex,
-        imageWidth: vectorImage.width,
-        imageHeight: vectorImage.height,
         ratio: ratio,
-        elapsedMs: vectorClock == null
-            ? null
-            : vectorClock.elapsedMicroseconds / 1000.0,
         region: (width: region.width, height: region.height),
+        rasterize: () => heldScene.rasterizeRegion(region, pixelRatio: ratio),
       );
-      if (mounted &&
-          _renderSession.acceptsDetail(generation) &&
-          !_renderPaused) {
-        setState(() {
-          _adoptDetail(vectorImage, fraction, ratio);
-        });
-        onPaint?.call();
-        progressiveReady = true;
-        _logDetailPaintAfterFrame(generation, detailClock, source: 'vector');
-        PdfPerfLog.log(
-          'detail vector page=${widget.previewIndex} '
-          'elapsed=${detailClock.elapsedMilliseconds}ms',
-        );
-      } else {
+      if (!mounted ||
+          !_renderSession.acceptsDetail(generation) ||
+          _renderPaused) {
         vectorImage.dispose();
+        return false;
       }
+      setState(() {
+        _adoptDetail(vectorImage, fraction, ratio);
+      });
+      onPaint?.call();
+      _logDetailPaintAfterFrame(generation, detailClock, source: 'vector');
+      PdfPerfLog.log(
+        'detail vector page=${widget.previewIndex} complete '
+        'elapsed=${detailClock.elapsedMilliseconds}ms',
+      );
+      return true;
     }
 
     final workerStripImage = await workerStripFuture;
@@ -2234,22 +2320,13 @@ class _PdfPageViewState extends State<PdfPageView>
       return true;
     }
     if (workerPicture != null) {
-      final rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-      final image = await PdfPageRenderer.rasterizeRegion(
-        workerPicture,
-        region,
-        ratio,
-      );
-      PdfPerfLog.raster(
+      final image = await PdfRasterProbe.measure(
         'detail-worker-picture',
         page: widget.previewIndex,
-        imageWidth: image.width,
-        imageHeight: image.height,
         ratio: ratio,
-        elapsedMs: rasterClock == null
-            ? null
-            : rasterClock.elapsedMicroseconds / 1000.0,
         region: (width: region.width, height: region.height),
+        rasterize: () =>
+            PdfPageRenderer.rasterizeRegion(workerPicture, region, ratio),
       );
       workerPicture.dispose();
       if (!mounted ||
@@ -2270,10 +2347,13 @@ class _PdfPageViewState extends State<PdfPageView>
       return true;
     }
 
-    // A progressive scene contains image placeholders. If its worker region
-    // request was cancelled or declined, wait for the ordinary full record
-    // instead of painting a vector-only patch as if it were complete.
-    if (_sceneIsVectorOnly) return progressiveReady;
+    // A progressive scene contains image placeholders. Reaching here means an
+    // image DOES reach this region (the [vectorCoversRegion] path returned
+    // above) and the worker request that would have supplied its pixels was
+    // cancelled or declined - so nothing was painted. Wait for the ordinary
+    // full record instead of painting a vector-only patch as if it were
+    // complete.
+    if (_sceneIsVectorOnly) return false;
 
     // never interpret the page for the first time inline here - that is
     // the scheduler's job (or, bare, the hold's); the next settle
@@ -2303,12 +2383,11 @@ class _PdfPageViewState extends State<PdfPageView>
     // fires these repeatedly, so each fresh region cancels the previous
     // region's still-queued bin inside _workerStripPlan).
     final scene = PdfPageView.retainedZoomReplay ? _scene : null;
-    final ui.Image image;
     final String detailKind;
-    // Same per-branch clock placement as the base raster: the strip branch
+    // Same per-branch probe placement as the base raster: the strip branch
     // awaits a worker bin before rasterizing, and that wait must not read
     // as raster time.
-    Stopwatch? rasterClock;
+    final Future<ui.Image> Function() rasterize;
     if (scene != null && _stripReplayScene(scene)) {
       final stripPlan = await _workerStripPlan(
         scene,
@@ -2320,35 +2399,28 @@ class _PdfPageViewState extends State<PdfPageView>
           _renderPaused) {
         return false;
       }
-      rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-      image = await scene.rasterizeRegionStrips(
-        region,
-        pixelRatio: ratio,
-        stripPlan: stripPlan,
-      );
+      rasterize = () => scene.rasterizeRegionStrips(
+            region,
+            pixelRatio: ratio,
+            stripPlan: stripPlan,
+          );
       detailKind = 'detail-strip';
     } else if (scene != null) {
-      rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-      image = await scene.rasterizeRegion(region, pixelRatio: ratio);
+      rasterize = () => scene.rasterizeRegion(region, pixelRatio: ratio);
       detailKind = 'detail-region';
     } else {
       // Classic cached-picture path: replays the WHOLE page picture clipped to
       // [region] at [ratio]. On a huge (unretained) transcript this is where a
       // deep-zoom raster gets expensive - the raster instrumentation flags it.
-      rasterClock = PdfPerfLog.enabled ? (Stopwatch()..start()) : null;
-      image = await PdfPageRenderer.rasterizeRegion(picture, region, ratio);
+      rasterize = () => PdfPageRenderer.rasterizeRegion(picture, region, ratio);
       detailKind = 'detail-picture';
     }
-    PdfPerfLog.raster(
+    final image = await PdfRasterProbe.measure(
       detailKind,
       page: widget.previewIndex,
-      imageWidth: image.width,
-      imageHeight: image.height,
       ratio: ratio,
-      elapsedMs: rasterClock == null
-          ? null
-          : rasterClock.elapsedMicroseconds / 1000.0,
       region: (width: region.width, height: region.height),
+      rasterize: rasterize,
     );
     if (!mounted ||
         !_renderSession.acceptsDetail(generation) ||

--- a/packages/dart_pdf_editor/lib/src/perf_log.dart
+++ b/packages/dart_pdf_editor/lib/src/perf_log.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:pdf_cos/perf.dart';
@@ -124,9 +126,21 @@ class PdfPerfLog {
   /// which half costs it. Printed only when BOTH are non-null: the split is
   /// meaningless as a lone number, and call sites where decode and
   /// construction are fused pass neither.
+  ///
+  /// [progressiveMs] is the vector-first phase: the progressive paint that runs
+  /// BEFORE the interpret this line reports, and which the caller's clock spans.
+  /// It is reported because without it the line actively misleads. In the
+  /// 2026-07-29 trace `interpret page=2 … interpret=1224.2ms wait=109.0ms
+  /// build=132.8ms` left ~980ms unattributed, and that time was not interpreting
+  /// anything - it was a `vector-first-full` raster (793ms, logged two lines
+  /// earlier) plus a frame wait. Every such line under-attributed by 60-80%,
+  /// which is exactly the shape that sends someone optimizing the interpreter
+  /// when the cost is in the raster. With this phase printed,
+  /// `progressive + wait + build` accounts for [interpretMs].
   static void interpret(int page,
       {required String path,
       required double interpretMs,
+      double? progressiveMs,
       double? waitMs,
       double? buildMs,
       double? decodeMs,
@@ -139,6 +153,10 @@ class PdfPerfLog {
       String note = ''}) {
     if (!enabled) return;
     final raster = rasterMs == null ? '' : ' raster=${_ms(rasterMs)}';
+    // Printed even at zero: "this interpret ran no progressive phase" and "this
+    // build predates the split" must not read the same on a trace.
+    final progressive =
+        progressiveMs == null ? '' : ' progressive=${_ms(progressiveMs)}';
     final phases = (waitMs == null || buildMs == null)
         ? ''
         : ' wait=${_ms(waitMs)} build=${_ms(buildMs)}';
@@ -154,7 +172,8 @@ class PdfPerfLog {
             ' shaped=${textShapeMiss ?? 0} cached=${textShapeHit ?? 0}';
     final kind = first ? 'FIRST' : 're-raster';
     log('interpret page=$page path=$path $kind '
-        'interpret=${_ms(interpretMs)}$phases$buildSplit$shapeSplit$raster$note');
+        'interpret=${_ms(interpretMs)}$progressive$phases$buildSplit'
+        '$shapeSplit$raster$note');
   }
 
   static String _ms(double v) => '${v.toStringAsFixed(1)}ms';
@@ -190,6 +209,11 @@ class PdfPerfLog {
   /// be inferred from the gap between log timestamps, which is unmeasurable
   /// during the hangs this log exists to diagnose. Off unless the perf log is
   /// [enabled].
+  ///
+  /// [concurrency] is the peak number of rasters in flight alongside this one
+  /// (see [PdfRasterProbe]); 1 means it had the raster thread to itself.
+  /// Prefer [PdfRasterProbe.measure] over calling this directly - it supplies
+  /// both timings and cannot leak the in-flight count on a throwing rasterize.
   static void raster(
     String kind, {
     required int page,
@@ -197,19 +221,21 @@ class PdfPerfLog {
     required int imageHeight,
     double? ratio,
     double? elapsedMs,
+    int? concurrency,
     ({double width, double height})? region,
   }) {
     if (!enabled) return;
     final mp = (imageWidth * imageHeight) / 1e6;
     final ratioStr = ratio == null ? '' : ' ratio=${ratio.toStringAsFixed(1)}';
     final msStr = elapsedMs == null ? '' : ' ms=${elapsedMs.toStringAsFixed(1)}';
+    final concStr = concurrency == null ? '' : ' conc=$concurrency';
     final regionStr = region == null
         ? ' full'
         : ' region=${region.width.toStringAsFixed(0)}x'
             '${region.height.toStringAsFixed(0)}pt';
     log('raster kind=$kind page=$page n=${++_rasterSeq}$regionStr$ratioStr '
         'img=${imageWidth}x$imageHeight '
-        '(${mp.toStringAsFixed(1)}MP)$msStr${rssSuffix()}');
+        '(${mp.toStringAsFixed(1)}MP)$msStr$concStr${rssSuffix()}');
   }
 
   static void _onTimings(List<FrameTiming> timings) {
@@ -246,5 +272,102 @@ class PdfPerfLog {
       } catch (_) {}
     }
     _buf.clear();
+  }
+}
+
+/// Measures one rasterize call: its wall duration AND how many rasters were in
+/// flight alongside it.
+///
+/// `ms=` on a raster line is queue-inclusive and always has been: `toImage`
+/// awaits the raster thread, and the render scheduler deliberately starts page
+/// renders without awaiting them (see `render_scheduler.dart`), so several
+/// pages rasterize concurrently and each one's measured duration absorbs the
+/// others' queue time. Read without that context the number lies outright. In
+/// the 2026-07-29 trace three 0.1MP rasters that started together reported
+/// 4692ms, 3461ms and 2731ms - a 0.1MP readback is not 4.7 seconds of work,
+/// they were serializing behind each other - and one page at one ratio measured
+/// 138.8ms uncontended against 2299.4ms contended, a 16x spread over identical
+/// pixels. `conc=` is what separates "this raster is expensive" from "this
+/// raster waited": at `conc=1` the duration is the work, above it the duration
+/// is mostly queue.
+///
+/// The count is peak-over-lifetime rather than depth-at-start, because a raster
+/// that begins alone and is then joined by three others waits just as long as
+/// one that started fourth.
+class PdfRasterProbe {
+  PdfRasterProbe._();
+
+  /// Probes currently timing a rasterize. Only ever non-empty while the perf
+  /// log is on: [measure] takes the untimed path otherwise, so an ordinary run
+  /// allocates nothing here.
+  static final List<PdfRasterProbe> _live = <PdfRasterProbe>[];
+
+  final Stopwatch _clock = Stopwatch()..start();
+  int _peak = 1;
+
+  /// Duration of the rasterize so far, in milliseconds.
+  double get elapsedMs => _clock.elapsedMicroseconds / 1000.0;
+
+  /// Peak rasters in flight during this one's lifetime (1 = uncontended).
+  int get peakConcurrency => _peak;
+
+  /// Rasters in flight right now - test/diagnostic hook. A leak here would
+  /// inflate every later `conc=`, so it is asserted against directly.
+  @visibleForTesting
+  static int get debugInFlight => _live.length;
+
+  static PdfRasterProbe _start() {
+    final probe = PdfRasterProbe._();
+    _live.add(probe);
+    final depth = _live.length;
+    // Every probe still running was contended by this one arriving, so the
+    // whole live set takes the new depth - not just the probe starting now.
+    for (final live in _live) {
+      if (depth > live._peak) live._peak = depth;
+    }
+    return probe;
+  }
+
+  void _end() {
+    _clock.stop();
+    _live.remove(this);
+  }
+
+  /// Runs [rasterize], logs the resulting image through [PdfPerfLog.raster]
+  /// with its duration and peak concurrency, and returns it.
+  ///
+  /// Start this AFTER any await that is not itself rasterization (a worker
+  /// strip-plan round trip, say): attributing that queue wait to the raster
+  /// corrupts the one number this exists to report. Compiles away to a bare
+  /// call to [rasterize] while the log is off.
+  ///
+  /// A throwing [rasterize] propagates unchanged and is not logged - but the
+  /// probe is still retired, so a failed raster cannot inflate `conc=` for the
+  /// rest of the session.
+  static Future<ui.Image> measure(
+    String kind, {
+    required int page,
+    required Future<ui.Image> Function() rasterize,
+    double? ratio,
+    ({double width, double height})? region,
+  }) async {
+    if (!PdfPerfLog.enabled) return rasterize();
+    final probe = _start();
+    try {
+      final image = await rasterize();
+      PdfPerfLog.raster(
+        kind,
+        page: page,
+        imageWidth: image.width,
+        imageHeight: image.height,
+        ratio: ratio,
+        elapsedMs: probe.elapsedMs,
+        concurrency: probe.peakConcurrency,
+        region: region,
+      );
+      return image;
+    } finally {
+      probe._end();
+    }
   }
 }

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -257,6 +257,20 @@ class PdfPagePreviewCache extends ChangeNotifier {
                         ? 'rotation'
                         : null;
     if (mismatch != null) {
+      // Drop it. A mismatched entry cannot serve this page at its current
+      // display geometry, and the caller's very next act is to rasterize and
+      // store the replacement - so retaining it only spends a scarce budget on
+      // pixels nothing can read. In the 2026-07-29 trace a page-0 raster stored
+      // at ratio 0.4 (429x304) sat in the cache producing `miss
+      // reason=dimensions` three times over 1.4s while the viewer, long since
+      // at ratio 1.4, re-rasterized the page from scratch each time.
+      //
+      // This costs a zoom-back-to-the-old-scale reuse in principle. It is not
+      // worth keeping: the entry survives only until the next store for this
+      // index replaces it anyway, and under the coordinated ceiling the cache
+      // holds single-digit entries, so one stale large raster displaces a
+      // live one.
+      _fullEntries.evict(index); // disposes the image
       _logFullRasterLookup('miss', index, reason: mismatch);
       return null;
     }

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -90,8 +90,14 @@ class PdfPageRenderScheduler {
   set holding(bool value) {
     if (_holding == value || _disposed) return;
     _holding = value;
+    // inFlight is reported alongside pending because [busy] is the sum of the
+    // two (plus the hold), and background work - the thumbnail warm - stands
+    // down for exactly as long as it reads true. A trace showing `renderHold
+    // off (pending=0)` followed by silence gives no way to tell an idle viewer
+    // from one whose in-flight set never drained; with this it does.
     PdfPerfLog.log('renderHold ${_holding ? 'ON' : 'off'} '
-        '(pending=${_pending.length} focus=$_focus)');
+        '(pending=${_pending.length} inFlight=${_inFlight.length} '
+        'focus=$_focus)');
     if (!_holding) _scheduleDrain();
     _activity.ping();
   }

--- a/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
@@ -117,6 +117,63 @@ void main() {
       expect(rendered, [4]);
     });
 
+    testWidgets('a blocked warm logs once, not once per activity ping',
+        (tester) async {
+      // The render scheduler pings its activity Listenable on every grant,
+      // settle, request and hold transition - most of them while it is still
+      // busy. Each ping used to spin up a warm loop that immediately stood down
+      // again, costing a microtask and a log line. The 2026-07-29 trace carries
+      // ~90 `thumbnail warm yields` lines and not one `thumbnail warm page=`:
+      // the repeats said nothing the first did not, and buried the lines that
+      // mattered.
+      final logs = <String>[];
+      PdfPerfLog.sink = logs.add;
+      PdfPerfLog.enabled = true;
+      addTearDown(() {
+        PdfPerfLog.enabled = false;
+        PdfPerfLog.sink = null;
+      });
+
+      final cache = PdfThumbnailCache();
+      addTearDown(cache.dispose);
+      final activity = _TestActivity();
+      var viewerBusy = true;
+      cache.bindForegroundGate(activity, () => viewerBusy);
+
+      final warmed = <int>[];
+      cache.setWarm(Object(), 3, 'k', (page) async => warmed.add(page));
+      for (var i = 0; i < 30; i++) {
+        activity.ping();
+        await tester.pump();
+      }
+      expect(warmed, isEmpty);
+      expect(
+        logs.where((line) => line.contains('thumbnail warm yields')).length,
+        1,
+        reason: 'one line per transition into yielding, not per ping',
+      );
+
+      // Going idle must still resume it - the quieter log must not have cost
+      // the wake-up.
+      viewerBusy = false;
+      activity.ping();
+      for (var i = 0; i < 8; i++) {
+        await tester.pump();
+      }
+      expect(warmed, [0, 1, 2]);
+
+      // ...and a fresh block after real progress logs again, so a warm that
+      // stalls a second time is still visible.
+      viewerBusy = true;
+      cache.setWarm(Object(), 3, 'k2', (page) async => warmed.add(page));
+      activity.ping();
+      await tester.pump();
+      expect(
+        logs.where((line) => line.contains('thumbnail warm yields')).length,
+        2,
+      );
+    });
+
     testWidgets('an unbound cache warms exactly as before', (tester) async {
       final cache = PdfThumbnailCache();
       addTearDown(cache.dispose);

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -180,6 +180,52 @@ void main() {
         reason: 'lowering the entry limit drops oversized retained pages');
   });
 
+  testWidgets('a lookup at another geometry drops the entry it cannot use',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(1));
+    final page = document.page(0);
+    final image = await PdfPageRenderer.renderImage(page, pixelRatio: 0.5);
+    addTearDown(image.dispose);
+    final bytes = image.width * image.height * 4;
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+
+    cache.configureFullRasterCache(PdfPageRasterCachePolicy(
+      maxBytes: bytes * 4,
+      maxEntryBytes: bytes,
+    ));
+    cache.putFullImage(
+      0,
+      page,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    expect(cache.fullRasterCount, 1);
+
+    // The page is now displayed at a different resolution, so this raster can
+    // never satisfy a lookup again. Retaining it only spends a scarce budget on
+    // pixels nothing can read - the 2026-07-29 trace shows a ratio-0.4 entry
+    // producing `miss reason=dimensions` three times while the viewer, long
+    // since at ratio 1.4, re-rasterized the page from scratch each time.
+    expect(
+      cache.fullImageFor(
+        0,
+        page,
+        width: image.width * 2,
+        height: image.height * 2,
+        pageColor: const Color(0xFFFFFFFF),
+        annotations: true,
+        rotation: null,
+      ),
+      isNull,
+    );
+    expect(cache.fullRasterCount, 0,
+        reason: 'a mismatched entry is dropped, not left occupying budget');
+    expect(cache.fullRasterBytes, 0);
+  });
+
   testWidgets('visited-page raster perf trace explains cache decisions',
       (tester) async {
     final logs = <String>[];

--- a/packages/dart_pdf_editor/test/page_render_session_test.dart
+++ b/packages/dart_pdf_editor/test/page_render_session_test.dart
@@ -52,6 +52,62 @@ void main() {
     expect(transition.dropDetail, isFalse);
   });
 
+  test('a settle at unchanged scale supersedes the detail, not the base', () {
+    // The full raster depends on content, display settings and resolution -
+    // none of which a settle touches. Superseding it here discarded rasters
+    // that had already finished: the page view disposes an image whose
+    // generation no longer matches and rasterizes the whole page again. The
+    // 2026-07-29 trace shows page 0 producing an identical `base-full ratio=1.4
+    // 1715x1213` three times inside one second with only the last one painting.
+    final session = PdfPageRenderSession(intent());
+    final full = session.beginFull();
+    final detail = session.beginDetail();
+
+    final transition = session.update(intent(settleGeneration: 1));
+
+    expect(transition.scheduleRender, isTrue,
+        reason: 'the detail patch still needs a pass');
+    expect(session.acceptsFull(full, 0), isTrue,
+        reason: 'a raster already in flight is still exactly the right pixels');
+    expect(session.acceptsDetail(detail), isFalse,
+        reason: 'the patch tracks the viewport, so a settle does supersede it');
+  });
+
+  test('a settle that also changes the scale still supersedes the base', () {
+    final session = PdfPageRenderSession(intent());
+    final full = session.beginFull();
+
+    session.update(intent(scale: 2, settleGeneration: 1));
+
+    expect(session.acceptsFull(full, 0), isFalse,
+        reason: 'an in-flight raster really is at the wrong resolution now');
+  });
+
+  test('content and slot changes still supersede an in-flight raster', () {
+    for (final next in [
+      intent(contentStamp: 1),
+      intent(destructiveStamp: 1),
+      intent(pageEpoch: 1),
+      intent(rotation: 90),
+      intent(pageColor: const Color(0xFF000000)),
+      intent(showAnnotations: false),
+    ]) {
+      final session = PdfPageRenderSession(intent());
+      final full = session.beginFull();
+      session.update(next);
+      expect(session.acceptsFull(full, 0), isFalse,
+          reason: 'these change what the page should look like');
+    }
+
+    // A slot change is checked through acceptsFull's page index too, but the
+    // generation must move as well so a worker reply for the old slot cannot be
+    // accepted into the recycled one.
+    final session = PdfPageRenderSession(intent());
+    final full = session.beginFull();
+    session.update(intent(pageIndex: 1));
+    expect(session.acceptsFull(full, 1), isFalse);
+  });
+
   test(
     'additive content keeps the old base and detail while replacing data',
     () {

--- a/packages/dart_pdf_editor/test/perf_log_test.dart
+++ b/packages/dart_pdf_editor/test/perf_log_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -163,6 +164,117 @@ void main() {
     expect(lines[1], contains('interpret=42.0ms'));
     expect(lines[1], isNot(contains('wait=')));
     expect(lines[1], isNot(contains('build=')));
+  });
+
+  test('interpret reports the progressive phase its clock also spans', () {
+    // Without this the line reads as though the interpreter cost the whole
+    // span, when most of it was a vector-first raster and a frame wait.
+    // progressive + wait + build should account for interpret.
+    final lines = capturePrints(() {
+      PdfPerfLog.enabled = true;
+      PdfPerfLog.interpret(2,
+          path: 'worker',
+          interpretMs: 1224.2,
+          progressiveMs: 982.1,
+          waitMs: 109.0,
+          buildMs: 132.8);
+      // A page with no progressive phase reports zero, not nothing: "ran none"
+      // and "this build predates the split" must not look the same.
+      PdfPerfLog.interpret(3,
+          path: 'worker', interpretMs: 50.0, progressiveMs: 0.0);
+      PdfPerfLog.interpret(4, path: 'recorded', interpretMs: 42.0);
+    });
+
+    expect(lines[0], contains('interpret=1224.2ms'));
+    expect(lines[0], contains('progressive=982.1ms'));
+    expect(lines[1], contains('progressive=0.0ms'));
+    expect(lines[2], isNot(contains('progressive=')));
+  });
+
+  test('a measured raster reports its duration and peak concurrency', () async {
+    final lines = <String>[];
+    PdfPerfLog.sink = lines.add;
+    PdfPerfLog.enabled = true;
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder);
+    final picture = recorder.endRecording();
+    addTearDown(picture.dispose);
+
+    final solo = await PdfRasterProbe.measure(
+      'base-full',
+      page: 0,
+      ratio: 1.4,
+      rasterize: () => picture.toImage(8, 8),
+    );
+    solo.dispose();
+    expect(lines.single, contains('conc=1'),
+        reason: 'an uncontended raster measures its own work');
+    expect(lines.single, contains('ms='));
+    expect(PdfRasterProbe.debugInFlight, 0);
+
+    // Two rasters overlapping: `ms=` on each absorbs the other's queue time, so
+    // the count is what tells a slow raster from a waiting one.
+    lines.clear();
+    final gate = Completer<void>();
+    final first = PdfRasterProbe.measure(
+      'base-full',
+      page: 1,
+      rasterize: () async {
+        await gate.future;
+        return picture.toImage(8, 8);
+      },
+    );
+    final second = PdfRasterProbe.measure(
+      'base-full',
+      page: 2,
+      rasterize: () async {
+        await gate.future;
+        return picture.toImage(8, 8);
+      },
+    );
+    gate.complete();
+    (await first).dispose();
+    (await second).dispose();
+    expect(lines, hasLength(2));
+    expect(lines.every((line) => line.contains('conc=2')), isTrue,
+        reason: 'both rasters were in flight for the other\'s whole lifetime');
+    expect(PdfRasterProbe.debugInFlight, 0);
+  });
+
+  test('a throwing raster is not logged but still retires its probe', () async {
+    final lines = <String>[];
+    PdfPerfLog.sink = lines.add;
+    PdfPerfLog.enabled = true;
+    await expectLater(
+      PdfRasterProbe.measure(
+        'base-full',
+        page: 0,
+        rasterize: () => Future<ui.Image>.error(StateError('web OOM')),
+      ),
+      throwsStateError,
+    );
+    expect(lines, isEmpty);
+    // A leaked probe would inflate `conc=` on every raster for the rest of the
+    // session, quietly turning the diagnostic into a liar.
+    expect(PdfRasterProbe.debugInFlight, 0);
+  });
+
+  test('measure does not allocate a probe while the log is off', () async {
+    PdfPerfLog.enabled = false;
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder);
+    final picture = recorder.endRecording();
+    addTearDown(picture.dispose);
+    final lines = <String>[];
+    PdfPerfLog.sink = lines.add;
+    final image = await PdfRasterProbe.measure(
+      'base-full',
+      page: 0,
+      rasterize: () => picture.toImage(4, 4),
+    );
+    image.dispose();
+    expect(lines, isEmpty);
+    expect(PdfRasterProbe.debugInFlight, 0);
   });
 
   test('interpret splits the build phase into decode and construction', () {

--- a/packages/dart_pdf_editor/test/render_hold_test.dart
+++ b/packages/dart_pdf_editor/test/render_hold_test.dart
@@ -216,4 +216,138 @@ void main() {
     }
     expect(rasters, 2, reason: 'a zoom change must re-raster the page');
   });
+
+  testWidgets('a re-request deferred behind a render does not re-raster',
+      (tester) async {
+    // The scheduler holds a request that arrives while that page's render is
+    // in flight and re-grants it when the render lands, on the premise that it
+    // "may carry a new scale or revision". When it doesn't, the second pass
+    // re-reads the whole page off the GPU to arrive back at the pixels already
+    // on screen. The 2026-07-29 trace paid that repeatedly - `base-full page=0
+    // ratio=1.4 1715x1213` twice inside 306ms, byte-identical.
+    final logs = <String>[];
+    PdfPerfLog.sink = logs.add;
+    PdfPerfLog.enabled = true;
+    addTearDown(() {
+      PdfPerfLog.enabled = false;
+      PdfPerfLog.sink = null;
+    });
+
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    var rasters = 0;
+
+    Widget build(int generation) => MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 400,
+              child: PdfPageView(
+                page: page,
+                scale: 1,
+                settleGeneration: generation,
+                renderScheduler: scheduler,
+                onRasterReady: () => rasters++,
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(build(0));
+    // One pump lets the scheduler grant the first render; the rebuilds below
+    // then land while it is still in flight, which is what makes the scheduler
+    // defer and re-grant them - the trace's `scheduler defer page=N (render in
+    // flight)` immediately followed by a second grant for the same page.
+    await tester.pump();
+    await tester.pumpWidget(build(1));
+    await tester.pumpWidget(build(2));
+
+    await waitFor(tester, find.byType(RawImage));
+    for (var i = 0; i < 20; i++) {
+      await settle(tester);
+    }
+
+    expect(rasters, 1,
+        reason: 'the deferred re-grants asked for pixels already on screen');
+    expect(
+      logs.where((line) => line.contains('raster kind=base-full')).length,
+      1,
+      reason: 'exactly one full-page readback for one resolution',
+    );
+    expect(
+      logs.any((line) =>
+          line.contains('render skip') && line.contains('reason=base-current')),
+      isTrue,
+      reason: 'the skip should be visible in a trace, not silent',
+    );
+  });
+
+  testWidgets('a burst of settles produces exactly one full-page raster',
+      (tester) async {
+    // End-to-end cover for the invalidation rule unit-tested in
+    // page_render_session_test.dart ('a settle at unchanged scale supersedes
+    // the detail, not the base'). A settle used to bump the full-render
+    // generation, so a raster finishing just after one was disposed unpainted
+    // and the page rasterized again - the shape behind page 0's identical
+    // `base-full ratio=1.4 1715x1213` at n=59, n=61 and n=63 inside one second
+    // in the 2026-07-29 trace. The timing that discards a raster is not
+    // reproducible from a widget test (the local render lands too fast to be
+    // interrupted), so this guards the observable outcome rather than the race.
+    final logs = <String>[];
+    PdfPerfLog.sink = logs.add;
+    PdfPerfLog.enabled = true;
+    addTearDown(() {
+      PdfPerfLog.enabled = false;
+      PdfPerfLog.sink = null;
+    });
+
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    var rasters = 0;
+
+    Widget build(double scale, int generation) => MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 400,
+              child: PdfPageView(
+                page: page,
+                scale: scale,
+                settleGeneration: generation,
+                renderScheduler: scheduler,
+                onRasterReady: () => rasters++,
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(build(1, 0));
+    // Settle bumps arriving while the first raster is in flight.
+    await tester.pump();
+    for (var i = 1; i <= 4; i++) {
+      await tester.pumpWidget(build(1, i));
+    }
+
+    await waitFor(tester, find.byType(RawImage));
+    for (var i = 0; i < 20; i++) {
+      await settle(tester);
+    }
+
+    expect(
+      logs.where((line) => line.contains('raster kind=base-full')).length,
+      1,
+      reason: 'settles at unchanged scale must not throw away a landed raster',
+    );
+    expect(rasters, 1);
+
+    // ...and a settle that DOES change the scale still supersedes, because then
+    // the in-flight raster really is at the wrong resolution.
+    await tester.pumpWidget(build(2, 5));
+    for (var i = 0; i < 20 && rasters < 2; i++) {
+      await settle(tester);
+    }
+    expect(rasters, 2, reason: 'a zoom change must still re-raster');
+  });
 }

--- a/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
+++ b/packages/dart_pdf_editor/test/web_slug_mixed_page_test.dart
@@ -183,23 +183,85 @@ void main() {
       ),
     ));
 
-    await _waitUntil(tester, () => worker.regionRecordStarted.isCompleted,
-        label: 'held region record');
-    expect(worker.fullRecordStarted.isCompleted, isFalse,
-        reason: 'full refinement must not overlap detail rasterization');
-
+    // This viewport shows a slice well below the fixture's image (page-space
+    // y 620..740, i.e. device y 52..172), so replaying the retained vector
+    // scene produces the FINISHED region - and no image-complete region record
+    // is asked for at all. Re-recording and re-rasterizing it would return
+    // byte-identical pixels: a second full-region GPU readback and allocation
+    // for nothing (322ms/1.7MP in the 2026-07-29 trace).
     await _waitFor(tester, find.byKey(const ValueKey('pdf-page-detail-image')),
         label: 'region-first high-resolution detail');
+    expect(worker.regionRecordStarted.isCompleted, isFalse,
+        reason: 'an image-free region needs no image-complete region record');
     expect(worker.fullRecordStarted.isCompleted, isTrue,
         reason: 'the ordinary full-page image record should still warm');
     expect(worker.fullRecordReleased, isFalse,
         reason: 'visible detail must land while the full-page record is held');
-    expect(worker.regionRecordStarted.isCompleted, isTrue);
-    expect(worker.regionRecordReleased, isFalse,
-        reason:
-            'sharp vector detail must also beat the complete region record');
     expect(worker.vectorRecordPriority, -100,
         reason: 'visible detail must preempt ordinary neighbouring pages');
+  });
+
+  testWidgets('a region the image reaches waits for the complete record',
+      (tester) async {
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = buildEmbeddedFontImagePdf();
+    final page = PdfDocument.open(bytes).page(0);
+    final previews = PdfPagePreviewCache();
+    await tester.runAsync(() async {
+      final picture = await PdfPageRenderer.renderPictureRecorded(page);
+      try {
+        await previews.putFromPicture(0, page, picture);
+      } finally {
+        picture.dispose();
+      }
+    });
+    final worker =
+        _DeferredFullRecordWorker(PdfRenderWorker.startUncached(bytes));
+    addTearDown(previews.dispose);
+    addTearDown(worker.dispose);
+
+    // No translation: the visible slice starts at the top of the page, so the
+    // fixture's image DOES reach it. The vector-only scene carries a
+    // placeholder where those pixels belong, so its replay is not a complete
+    // patch and must not be painted as if it were - the soft base stays up
+    // until the image-complete region record lands.
+    await tester.pumpWidget(Align(
+      alignment: Alignment.topLeft,
+      child: OverflowBox(
+        alignment: Alignment.topLeft,
+        maxWidth: double.infinity,
+        maxHeight: double.infinity,
+        child: Transform.scale(
+          alignment: Alignment.topLeft,
+          scale: 2,
+          child: SizedBox(
+            width: 612,
+            height: 792,
+            child: PdfPageView(
+              page: page,
+              scale: 8,
+              renderWorker: worker,
+              previewCache: previews,
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    await _waitUntil(tester, () => worker.regionRecordStarted.isCompleted,
+        label: 'held region record');
+    expect(worker.regionRecordReleased, isFalse);
+    // The region record is held forever here, so nothing may sharpen: a vector
+    // replay painted now would show the image's placeholder.
+    for (var i = 0; i < 20; i++) {
+      await tester.pump();
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsNothing,
+        reason: 'an incomplete vector patch must not paint over the base');
   });
 }
 


### PR DESCRIPTION
## Summary

Driven by a device trace (2026-07-29, ~3.5 min on a 3–4 page 1191x824pt document). The headline number: **~30 seconds of rasterize wall-clock inside ~40 seconds of active session** — 31 full-page rasters for 4 distinct pages, page 1 rasterized 14 times, page 0 nine times. Almost all of it repeat work.

**1. A settle no longer supersedes the base raster** (`page_render_session.dart`). `update` bumped the *full* render generation on any viewport change, including a `settleGeneration` bump at unchanged scale — so a raster completing a few ms later failed `_superseded`, was disposed unpainted, and the page rasterized again. Page 0 produced an identical `base-full ratio=1.4 1715x1213` at n=59/61/63 inside one second, ~8MB and a full GPU readback each, with only the last painting. The detail patch still supersedes on every settle; the base depends on content, display settings and resolution, none of which a settle touches. A settle still *schedules* a render, it just stops cancelling work about to land.

**2. Memory pressure no longer punishes caches that hold nothing** (`adaptive_memory.dart`). `_applyPressure` fired against a registry holding **7MB of a 1350MB process**, reclaimed 22MB (1.6%), and halved the ceiling 140MB→70MB for 5 minutes — starving the cache into re-rasters that raised RSS and armed the next halving. A closed loop. Reclaiming is unchanged; the *lasting* half (`_pressureRegistryCap` + halved page budget) is now gated on the registry holding ≥5% of RSS, and `PdfLiveRasterBudget` — where the memory actually is — still halves unconditionally. This also explains why `page-raster mode=fixed total=2147483648` was cosmetic in the trace: the ~70MB coordinated ceiling was the real bound.

**3. No second raster when the vector replay already finished the region** (`pdf_page_view.dart`). `_updateDetail` painted a vector-only replay then unconditionally rasterized a worker region record over it. On a region no image reaches those are identical pixels: the trace paid `detail-vector 1715x999 ms=401.9` then `detail-worker-picture 1715x999 ms=322.5` on a page whose single image decoded to 0.0 megapixels. The existing `_imagesIntersectRegion` predicate is hoisted above the worker launch — the same invariant `_tileCanRasterize` already bets *retained, reused* tiles on.

**4. The raster cache drops entries a lookup could not use** (`preview_cache.dart`) instead of leaving them occupying a scarce budget. A page-0 entry stored at ratio 0.4 produced `miss reason=dimensions` three times over 1.4s while the viewer, long since at ratio 1.4, re-rasterized each time. Six lookups in the session: one hit.

**5. `interpret=` was not measuring interpreting.** The clock starts above `_paintVectorFirst`, so it spans a full-page vector raster and an `endOfFrame` wait. `interpret=1224.2ms wait=109.0ms build=132.8ms` left ~980ms unattributed — and that was the `vector-first-full ms=793.0` logged two lines earlier. Lines under-attributed by 60–80%, exactly the shape that sends someone optimizing the interpreter when the cost is in the raster. New `progressiveMs` phase closes the accounting.

**6. `ms=` on raster lines is queue-inclusive; new `conc=` says by how much.** Three 0.1MP rasters that started together reported 4692ms/3461ms/2731ms — not 4.7s of work, they serialized. One page at one ratio measured 138.8ms uncontended vs 2299.4ms contended, 16× over identical pixels. New `PdfRasterProbe.measure` replaces the hand-rolled `Stopwatch`+`raster` pairs at all five call sites and reports peak concurrency; it retires in a `finally` so a throwing rasterize can't leak the count.

**7. The thumbnail warm logged ~90 times and warmed nothing.** `_kickWarm` scheduled a microtask per scheduler activity ping that immediately stood down. Trace: ~90 `thumbnail warm yields`, zero `thumbnail warm page=`. The gate is checked before scheduling, and the yield logs once per transition. `renderHold` lines now carry `inFlight=` so a stuck-busy viewer is readable.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app (`app/lib/adaptive_memory.dart`)
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` — clean
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 2026 passed
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Also run: `cd app && fvm flutter test` (402 passed), `tool/check_perf_dce.sh` (PASS), `tool/perf.sh gate` (OK: 12 inputs, 13 counters within 3%).

The COS/document/graphics suites were not run — no change reaches below `dart_pdf_editor`, and the Ghent/corpus suites were skipped for the same reason: no rendering output changes, only which redundant renders are skipped and what the trace prints. No render baselines move.

New/changed coverage:
- `page_render_session_test.dart` — settle invalidation (verified failing without the fix)
- `render_hold_test.dart` — deferred re-grant, and a settle burst producing one raster
- `web_slug_mixed_page_test.dart` — image-free region needs no region record; **and a new test that a region the image does reach still waits for the complete record** (the correctness guard for change 3)
- `perf_log_test.dart` — `progressive=`, `conc=`, probe non-leak on throw, no-op while disabled
- `page_preview_test.dart` — mismatched entry is dropped
- `adaptive_memory_test.dart` — pressure spares immaterial caches; the existing halving test now gives the registry real occupancy so it exercises the regime it claims to
- `editing_thumbnail_cache_test.dart` — one yield line per transition, resume still works

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Two things I want to be explicit about rather than let the diff imply:

- **`_baseRasterIsCurrent` / `_imageState` in `pdf_page_view.dart` is not the duplicate-raster fix.** I added it believing it was, then wrote a reproduction and found the pre-existing `_rasteredRatio` guard already caught that case. Every path I traced was already covered. What it does buy is hoisting the resolution-unchanged decision above the vector-first and picture-await work, plus content-intent and image-ratio checks the old guard lacked, and a `render skip … reason=base-current` line. The duplicate rasters are change 1. Happy to drop it if you'd rather keep the diff tight.
- **The end-to-end widget test for change 1 passes with and without the fix.** A local render lands too fast to be interrupted mid-raster in a widget test, so the race isn't reproducible there. The load-bearing test is the deterministic session-level one; the widget test guards the observable outcome only. Both are commented to say so.

Not fixed, and worth a follow-up: the ~1.4GB RSS itself. The page-raster cache held 7–16MB throughout, so it's elsewhere — retained scenes, worker command buffers, or GPU textures. The trace shows 250MB swings inside 200ms windows with no eviction logged (13:45:19.643 → 19.840, 1474 → 1225MB), which points at scene/worker-buffer churn. Change 2 stops the controller making it worse; it doesn't find it. Also unmeasured on device: whether change 1 reduces the seven `FIRST` interprets the trace showed on a 3–4 page document.

Dev-log note: `doc/dev-log/2026-07-29-render-waste-and-trace-honesty.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFm11eHpA5PtFPYpB65aFa)_