### PR TITLE
Corner radius on the annotation properties panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,8 @@ subsampling/PCRL-CPRL progressions.
   tapping a tile zooms to the annotation and pulses an attention ring.
 - Outline and bookmark sidebars let readers navigate the document and editors
   create, rename, and remove bookmarks.
-- Properties panel: type, page, color, fill, stroke width, opacity,
-  font, contents, author, and numeric position/size, all editable.
+- Properties panel: type, page, color, fill, stroke width, corner radius,
+  opacity, font, contents, author, and numeric position/size, all editable.
 - Search results panel with context snippets from page text and annotation
   contents, plus `PdfSearchField` and an editable `PdfPageNumberField`
   ("3 / 12") for app bars.

--- a/doc/dev-log/2026-07-29-properties-panel-corner-radius.md
+++ b/doc/dev-log/2026-07-29-properties-panel-corner-radius.md
@@ -1,0 +1,40 @@
+# Corner radius on the properties panel
+
+Follow-up to `2026-07-16-rectangle-corner-radius-restyle.md`, which made
+corner rounding an editable property of a selected /Square but only
+surfaced it in the toolbar's tune popup. The properties panel - the other
+place a selection's style is edited - had no row for it, so a rectangle's
+radius was invisible there.
+
+## Editor UI (`dart_pdf_editor`)
+
+- `editing_properties.dart`'s `_styleControls()` gains a "Corner radius"
+  slider (`pdf-prop-corner-radius`, 0–40 pt, typeable past the scale up to
+  `kPdfTypedSizeMax`), placed after stroke width and before the line-style
+  rows. It is gated on `PdfEditingController.canRoundSelectedCorners` - the
+  same gate the toolbar uses - so it shows only when *every* selected
+  annotation is a restylable /Square. Ellipses, polygons, text markups and
+  the rest never see it.
+- The value comes from the selected annotations' own `cornerRadius`
+  (`_common` over the selection, so a mixed multi-selection reads "Varies"
+  like the other rows) rather than the creation-default preference: the
+  panel is selection-only, so unlike the toolbar's shared slider there is no
+  armed-tool case to fall back to and no `preferences.cornerRadius` write.
+  `_draggingCornerRadius` holds the live thumb value while a drag is in
+  flight, mirroring `_draggingStroke`; the restyle commits one revision on
+  release via `restyleSelected(cornerRadius:)`.
+- The readout is unit-suffixed ("12 pt"), so it passes a `parse` that strips
+  the suffix - the default `double.tryParse` would reject its own display
+  string and revert the typed value.
+
+## l10n
+
+New `propCornerRadius` key (the panel uses `prop*` keys; `tbCornerRadius` is
+the toolbar's). Translations reuse the already-translated toolbar string in
+all 20 locale ARBs; regenerated with `flutter gen-l10n`.
+
+## Tests
+
+`editing_properties_test.dart`: dragging `pdf-prop-corner-radius` rounds a
+selected rectangle (and typing an exact value into the readout commits it);
+a selected ellipse gets the stroke row but no corner-radius row.

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
@@ -185,6 +185,7 @@
   "propColor": "اللون",
   "propColour": "اللون",
   "propContents": "المحتويات",
+  "propCornerRadius": "نصف قطر الزاوية",
   "propEditsApplyToAll": "تنطبق التعديلات على جميع التعليقات التوضيحية المتوافقة",
   "propFieldName": "اسم الحقل",
   "propFieldTypeCheckBox": "مربع اختيار",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
@@ -185,6 +185,7 @@
   "propColor": "Farbe",
   "propColour": "Farbe",
   "propContents": "Inhalt",
+  "propCornerRadius": "Eckenradius",
   "propEditsApplyToAll": "Änderungen gelten für alle kompatiblen Anmerkungen",
   "propFieldName": "Feldname",
   "propFieldTypeCheckBox": "Kontrollkästchen",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -722,6 +722,10 @@
   "@propContents": {
     "description": "Label for the editable contents/text of an annotation."
   },
+  "propCornerRadius": "Corner radius",
+  "@propCornerRadius": {
+    "description": "Slider label for the corner rounding of a selected rectangle annotation."
+  },
   "propEditsApplyToAll": "Edits apply to all compatible annotations",
   "@propEditsApplyToAll": {
     "description": "Subtitle explaining that edits in a multi-selection affect every compatible annotation."

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
@@ -185,6 +185,7 @@
   "propColor": "Color",
   "propColour": "Color",
   "propContents": "Contenido",
+  "propCornerRadius": "Radio de esquina",
   "propEditsApplyToAll": "Los cambios se aplican a todas las anotaciones compatibles",
   "propFieldName": "Nombre del campo",
   "propFieldTypeCheckBox": "Casilla",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
@@ -185,6 +185,7 @@
   "propColor": "Couleur",
   "propColour": "Couleur",
   "propContents": "Contenu",
+  "propCornerRadius": "Rayon des coins",
   "propEditsApplyToAll": "Les modifications s'appliquent à toutes les annotations compatibles",
   "propFieldName": "Nom du champ",
   "propFieldTypeCheckBox": "Case à cocher",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
@@ -185,6 +185,7 @@
   "propColor": "रंग",
   "propColour": "रंग",
   "propContents": "सामग्री",
+  "propCornerRadius": "कोना त्रिज्या",
   "propEditsApplyToAll": "संपादन सभी संगत एनोटेशन पर लागू होते हैं",
   "propFieldName": "फ़ील्ड नाम",
   "propFieldTypeCheckBox": "चेक बॉक्स",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
@@ -185,6 +185,7 @@
   "propColor": "Warna",
   "propColour": "Warna",
   "propContents": "Isi",
+  "propCornerRadius": "Radius sudut",
   "propEditsApplyToAll": "Perubahan berlaku untuk semua anotasi yang kompatibel",
   "propFieldName": "Nama bidang",
   "propFieldTypeCheckBox": "Kotak centang",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
@@ -185,6 +185,7 @@
   "propColor": "Colore",
   "propColour": "Colore",
   "propContents": "Contenuto",
+  "propCornerRadius": "Raggio angolo",
   "propEditsApplyToAll": "Le modifiche si applicano a tutte le annotazioni compatibili",
   "propFieldName": "Nome del campo",
   "propFieldTypeCheckBox": "Casella di controllo",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
@@ -185,6 +185,7 @@
   "propColor": "カラー",
   "propColour": "カラー",
   "propContents": "内容",
+  "propCornerRadius": "角の丸み",
   "propEditsApplyToAll": "編集はすべての互換注釈に適用されます",
   "propFieldName": "フィールド名",
   "propFieldTypeCheckBox": "チェックボックス",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
@@ -185,6 +185,7 @@
   "propColor": "색상",
   "propColour": "색상",
   "propContents": "내용",
+  "propCornerRadius": "모서리 반경",
   "propEditsApplyToAll": "편집 내용이 호환되는 모든 주석에 적용됩니다",
   "propFieldName": "필드 이름",
   "propFieldTypeCheckBox": "확인란",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -1118,6 +1118,12 @@ abstract class DartPdfEditorLocalizations {
   /// **'Contents'**
   String get propContents;
 
+  /// Slider label for the corner rounding of a selected rectangle annotation.
+  ///
+  /// In en, this message translates to:
+  /// **'Corner radius'**
+  String get propCornerRadius;
+
   /// Subtitle explaining that edits in a multi-selection affect every compatible annotation.
   ///
   /// In en, this message translates to:

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -576,6 +576,9 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get propContents => 'المحتويات';
 
   @override
+  String get propCornerRadius => 'نصف قطر الزاوية';
+
+  @override
   String get propEditsApplyToAll =>
       'تنطبق التعديلات على جميع التعليقات التوضيحية المتوافقة';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -563,6 +563,9 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get propContents => 'Inhalt';
 
   @override
+  String get propCornerRadius => 'Eckenradius';
+
+  @override
   String get propEditsApplyToAll =>
       'Änderungen gelten für alle kompatiblen Anmerkungen';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -562,6 +562,9 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get propContents => 'Contents';
 
   @override
+  String get propCornerRadius => 'Corner radius';
+
+  @override
   String get propEditsApplyToAll => 'Edits apply to all compatible annotations';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -564,6 +564,9 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get propContents => 'Contenido';
 
   @override
+  String get propCornerRadius => 'Radio de esquina';
+
+  @override
   String get propEditsApplyToAll =>
       'Los cambios se aplican a todas las anotaciones compatibles';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -565,6 +565,9 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get propContents => 'Contenu';
 
   @override
+  String get propCornerRadius => 'Rayon des coins';
+
+  @override
   String get propEditsApplyToAll =>
       'Les modifications s\'appliquent à toutes les annotations compatibles';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -562,6 +562,9 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get propContents => 'सामग्री';
 
   @override
+  String get propCornerRadius => 'कोना त्रिज्या';
+
+  @override
   String get propEditsApplyToAll => 'संपादन सभी संगत एनोटेशन पर लागू होते हैं';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -563,6 +563,9 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get propContents => 'Isi';
 
   @override
+  String get propCornerRadius => 'Radius sudut';
+
+  @override
   String get propEditsApplyToAll =>
       'Perubahan berlaku untuk semua anotasi yang kompatibel';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -564,6 +564,9 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get propContents => 'Contenuto';
 
   @override
+  String get propCornerRadius => 'Raggio angolo';
+
+  @override
   String get propEditsApplyToAll =>
       'Le modifiche si applicano a tutte le annotazioni compatibili';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -561,6 +561,9 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get propContents => '内容';
 
   @override
+  String get propCornerRadius => '角の丸み';
+
+  @override
   String get propEditsApplyToAll => '編集はすべての互換注釈に適用されます';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -561,6 +561,9 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get propContents => '내용';
 
   @override
+  String get propCornerRadius => '모서리 반경';
+
+  @override
   String get propEditsApplyToAll => '편집 내용이 호환되는 모든 주석에 적용됩니다';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -563,6 +563,9 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get propContents => 'Inhoud';
 
   @override
+  String get propCornerRadius => 'Hoekradius';
+
+  @override
   String get propEditsApplyToAll =>
       'Bewerkingen gelden voor alle compatibele annotaties';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -573,6 +573,9 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get propContents => 'Zawartość';
 
   @override
+  String get propCornerRadius => 'Promień narożnika';
+
+  @override
   String get propEditsApplyToAll =>
       'Zmiany dotyczą wszystkich zgodnych adnotacji';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -564,6 +564,9 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get propContents => 'Conteúdo';
 
   @override
+  String get propCornerRadius => 'Raio do canto';
+
+  @override
   String get propEditsApplyToAll =>
       'As edições se aplicam a todas as anotações compatíveis';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -573,6 +573,9 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get propContents => 'Содержимое';
 
   @override
+  String get propCornerRadius => 'Радиус скругления';
+
+  @override
   String get propEditsApplyToAll =>
       'Изменения применяются ко всем совместимым аннотациям';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -561,6 +561,9 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get propContents => 'เนื้อหา';
 
   @override
+  String get propCornerRadius => 'รัศมีมุม';
+
+  @override
   String get propEditsApplyToAll =>
       'การแก้ไขมีผลกับคำอธิบายประกอบที่เข้ากันได้ทั้งหมด';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -561,6 +561,9 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get propContents => 'İçerik';
 
   @override
+  String get propCornerRadius => 'Köşe yarıçapı';
+
+  @override
   String get propEditsApplyToAll =>
       'Düzenlemeler tüm uyumlu ek açıklamalara uygulanır';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -572,6 +572,9 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get propContents => 'Вміст';
 
   @override
+  String get propCornerRadius => 'Радіус кута';
+
+  @override
   String get propEditsApplyToAll =>
       'Зміни застосовуються до всіх сумісних анотацій';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -563,6 +563,9 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get propContents => 'Nội dung';
 
   @override
+  String get propCornerRadius => 'Bán kính góc';
+
+  @override
   String get propEditsApplyToAll =>
       'Các chỉnh sửa áp dụng cho tất cả chú thích tương thích';
 

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -561,6 +561,9 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get propContents => '内容';
 
   @override
+  String get propCornerRadius => '圆角半径';
+
+  @override
   String get propEditsApplyToAll => '编辑将应用于所有兼容的注释';
 
   @override
@@ -2543,6 +2546,9 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
 
   @override
   String get propContents => '內容';
+
+  @override
+  String get propCornerRadius => '圓角半徑';
 
   @override
   String get propEditsApplyToAll => '編輯會套用至所有相容的註解';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
@@ -185,6 +185,7 @@
   "propColor": "Kleur",
   "propColour": "Kleur",
   "propContents": "Inhoud",
+  "propCornerRadius": "Hoekradius",
   "propEditsApplyToAll": "Bewerkingen gelden voor alle compatibele annotaties",
   "propFieldName": "Veldnaam",
   "propFieldTypeCheckBox": "Selectievakje",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
@@ -185,6 +185,7 @@
   "propColor": "Kolor",
   "propColour": "Kolor",
   "propContents": "Zawartość",
+  "propCornerRadius": "Promień narożnika",
   "propEditsApplyToAll": "Zmiany dotyczą wszystkich zgodnych adnotacji",
   "propFieldName": "Nazwa pola",
   "propFieldTypeCheckBox": "Pole wyboru",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
@@ -185,6 +185,7 @@
   "propColor": "Cor",
   "propColour": "Cor",
   "propContents": "Conteúdo",
+  "propCornerRadius": "Raio do canto",
   "propEditsApplyToAll": "As edições se aplicam a todas as anotações compatíveis",
   "propFieldName": "Nome do campo",
   "propFieldTypeCheckBox": "Caixa de seleção",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
@@ -185,6 +185,7 @@
   "propColor": "Цвет",
   "propColour": "Цвет",
   "propContents": "Содержимое",
+  "propCornerRadius": "Радиус скругления",
   "propEditsApplyToAll": "Изменения применяются ко всем совместимым аннотациям",
   "propFieldName": "Имя поля",
   "propFieldTypeCheckBox": "Флажок",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
@@ -185,6 +185,7 @@
   "propColor": "สี",
   "propColour": "สี",
   "propContents": "เนื้อหา",
+  "propCornerRadius": "รัศมีมุม",
   "propEditsApplyToAll": "การแก้ไขมีผลกับคำอธิบายประกอบที่เข้ากันได้ทั้งหมด",
   "propFieldName": "ชื่อช่อง",
   "propFieldTypeCheckBox": "ช่องทำเครื่องหมาย",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
@@ -185,6 +185,7 @@
   "propColor": "Renk",
   "propColour": "Renk",
   "propContents": "İçerik",
+  "propCornerRadius": "Köşe yarıçapı",
   "propEditsApplyToAll": "Düzenlemeler tüm uyumlu ek açıklamalara uygulanır",
   "propFieldName": "Alan adı",
   "propFieldTypeCheckBox": "Onay kutusu",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
@@ -185,6 +185,7 @@
   "propColor": "Колір",
   "propColour": "Колір",
   "propContents": "Вміст",
+  "propCornerRadius": "Радіус кута",
   "propEditsApplyToAll": "Зміни застосовуються до всіх сумісних анотацій",
   "propFieldName": "Назва поля",
   "propFieldTypeCheckBox": "Прапорець",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
@@ -185,6 +185,7 @@
   "propColor": "Màu",
   "propColour": "Màu sắc",
   "propContents": "Nội dung",
+  "propCornerRadius": "Bán kính góc",
   "propEditsApplyToAll": "Các chỉnh sửa áp dụng cho tất cả chú thích tương thích",
   "propFieldName": "Tên trường",
   "propFieldTypeCheckBox": "Hộp kiểm",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
@@ -185,6 +185,7 @@
   "propColor": "颜色",
   "propColour": "颜色",
   "propContents": "内容",
+  "propCornerRadius": "圆角半径",
   "propEditsApplyToAll": "编辑将应用于所有兼容的注释",
   "propFieldName": "字段名称",
   "propFieldTypeCheckBox": "复选框",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
@@ -185,6 +185,7 @@
   "propColor": "顏色",
   "propColour": "顏色",
   "propContents": "內容",
+  "propCornerRadius": "圓角半徑",
   "propEditsApplyToAll": "編輯會套用至所有相容的註解",
   "propFieldName": "欄位名稱",
   "propFieldTypeCheckBox": "核取方塊",

--- a/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_properties.dart
@@ -18,8 +18,9 @@ import '../l10n/pdf_l10n.dart';
 /// A panel showing - and editing - the selected annotation's properties.
 ///
 /// With one annotation selected it shows its type and page plus whatever
-/// of these apply: color, fill, stroke width, opacity (restyled in place
-/// via [PdfEditingController.restyleSelected]), font and size for text
+/// of these apply: color, fill, stroke width, corner radius (rectangles
+/// only), opacity (restyled in place via
+/// [PdfEditingController.restyleSelected]), font and size for text
 /// boxes, the contents text, the author, and the position and size in
 /// page points. With several selected, common values are shown normally,
 /// mixed values read "Varies", and compatible edits act on the whole
@@ -124,6 +125,7 @@ class _PdfAnnotationPropertiesPanelState
   /// revision, so it lands on release, and the thumb shows the dragged
   /// value meanwhile.
   double? _draggingStroke;
+  double? _draggingCornerRadius;
   double? _draggingScale;
   double? _draggingOpacity;
   double? _draggingFontSize;
@@ -598,6 +600,30 @@ class _PdfAnnotationPropertiesPanelState
         onChangeEnd: (v) {
           _controller.restyleSelected(strokeWidth: v);
           setState(() => _draggingStroke = null);
+        },
+      ));
+    }
+    // rounding is rectangle-only (/Square) - the controller's gate keeps it
+    // off circles, polygons and everything else
+    if (_controller.canRoundSelectedCorners) {
+      final radii = _common<double>([
+        for (final annotation in annotations) annotation.cornerRadius,
+      ]);
+      children.add(_sliderRow(
+        pdfL10n(context).propCornerRadius,
+        _draggingCornerRadius ?? radii.value,
+        key: const ValueKey('pdf-prop-corner-radius'),
+        min: 0,
+        max: 40,
+        fieldMin: 0,
+        fieldMax: kPdfTypedSizeMax,
+        varies: _draggingCornerRadius == null && radii.varies,
+        display: (v) => '${v.round()} pt',
+        parse: (s) => double.tryParse(s.replaceAll(RegExp('[^0-9.]'), '')),
+        onChanged: (v) => setState(() => _draggingCornerRadius = v),
+        onChangeEnd: (v) {
+          _controller.restyleSelected(cornerRadius: v.roundToDouble());
+          setState(() => _draggingCornerRadius = null);
         },
       ));
     }

--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -260,6 +260,44 @@ void main() {
       expect(editing.selectedAnnotation!.borderWidth, width);
     });
 
+    testWidgets('the corner-radius slider rounds a selected rectangle',
+        (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 600, 220, 660));
+      addTearDown(editing.dispose);
+      await pumpPanel(tester, editing);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      // the row reads the rectangle's current (square) corners
+      final radius = find.byKey(const ValueKey('pdf-prop-corner-radius'));
+      expect(radius, findsOneWidget);
+      expect(editing.selectedCornerRadius, 0);
+
+      await tester.drag(radius, const Offset(60, 0));
+      await tester.pump();
+      expect(editing.selectedCornerRadius, greaterThan(0));
+      // the restyle kept the selection, and the annotation itself rounded
+      expect(editing.selectedAnnotation!.cornerRadius, greaterThan(0));
+
+      // typing an exact radius commits it too
+      await submit(
+          tester, const ValueKey('pdf-prop-corner-radius-input'), '12');
+      expect(editing.selectedAnnotation!.cornerRadius, closeTo(12, 1e-9));
+    });
+
+    testWidgets('an ellipse has no corner-radius row', (tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1))
+        ..addEllipse(0, const PdfRect(100, 600, 220, 660));
+      addTearDown(editing.dispose);
+      await pumpPanel(tester, editing);
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+
+      expect(find.byKey(const ValueKey('pdf-prop-stroke')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-prop-corner-radius')), findsNothing);
+    });
+
     testWidgets('a placed image gets a working opacity slider, no colour',
         (tester) async {
       final editing = PdfEditingController(buildMultiPagePdf(1));


### PR DESCRIPTION
## Summary

Corner rounding has been an editable property of a placed rectangle since
`doc/dev-log/2026-07-16-rectangle-corner-radius-restyle.md`, but it was only
reachable from the toolbar's tune popup. The properties panel — the other place
a selection's style is edited — had no row for it, so a rectangle's radius was
invisible there.

This adds a **Corner radius** slider to the panel's Appearance group
(`pdf-prop-corner-radius`, 0–40 pt, typeable past the scale up to
`kPdfTypedSizeMax`), placed after stroke width and before the line-style rows.

- Gated on `PdfEditingController.canRoundSelectedCorners` — the same gate the
  toolbar uses — so the row appears only when *every* selected annotation is a
  restylable `/Square`. Ellipses, polygons, text markups and the rest never see
  it.
- The value comes from the selected annotations' own `cornerRadius` (`_common`
  over the selection, so a mixed multi-selection reads "Varies" like the other
  rows) rather than the creation-default preference: the panel is selection-only,
  so unlike the toolbar's shared slider there is no armed-tool case to fall back
  to and no `preferences.cornerRadius` write. `_draggingCornerRadius` holds the
  live thumb value while a drag is in flight, mirroring `_draggingStroke`; the
  restyle commits one revision on release via
  `restyleSelected(cornerRadius:)`.
- The readout is unit-suffixed ("12 pt"), so it passes a `parse` that strips the
  suffix — the default `double.tryParse` would reject its own display string and
  revert a typed value.

No API or core (`pdf_document`) change: this is UI wiring onto the existing
`restyleSelected(cornerRadius:)` path.

New `propCornerRadius` string (the panel uses `prop*` keys; `tbCornerRadius` is
the toolbar's), translated across all 20 locale ARBs by reusing the
already-translated toolbar string, then regenerated with `flutter gen-l10n`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (README row list + a new
  `doc/dev-log/` note)

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2044 passing)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to
`dart_pdf_editor` UI code and its ARBs — no engine package is touched, and no
rendering path changes — so the engine suites and the render corpora have
nothing to exercise here. `tool/check_arb_coverage.dart` was also run and
reports all 57 locale files matching their templates.

## PDF fixtures and screenshots

None — the behavior is covered by widget tests over programmatic fixtures.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Two new widget tests in `editing_properties_test.dart`: dragging
`pdf-prop-corner-radius` rounds a selected rectangle (and typing an exact value
into the readout commits it), and a selected ellipse gets the stroke row but no
corner-radius row.

Scope note: rounding stays rectangle-only because that is what the core
supports — `PdfEditor.restyleAnnotation` only rewrites `/Border` for `/Square`,
and a radius-only call on a `/Circle` is deliberately a no-op. Rounding other
subtypes would be a core change, not a panel one.

---
_Generated by [Claude Code](https://claude.ai/code/session_012sXh8HFSv1FTGYrdQAvyg5)_