### PR TITLE
Fix mobile touch pan: honour the platform's touch slop

### DIFF
--- a/doc/dev-log/2026-07-30-mobile-touch-pan-slop.md
+++ b/doc/dev-log/2026-07-30-mobile-touch-pan-slop.md
@@ -1,0 +1,95 @@
+# 2026-07-30 — mobile touch pan: the platform's touch slop, and the canvas beside the page
+
+Closes out the bug left open in
+[2026-07-19-devtools-mobile-touch-logging.md](2026-07-19-devtools-mobile-touch-logging.md)
+§3: *"panning while zoomed doesn't work from a fresh app open, but works after I
+pick the select tool."* That session's leading hypothesis was right —
+`InteractiveViewer`'s own `ScaleGestureRecognizer` wins the arena on-device and
+eats the drag as a no-op — but the *why* was missing, and without it the fix
+would have been a guess. Here it is, plus a second dead zone found on the way.
+
+## 1. `RawGestureDetector` does not propagate `gestureSettings`
+
+`GestureDetector.build` assigns `..gestureSettings = MediaQuery
+.maybeGestureSettingsOf(context)` to every recognizer it constructs (nine call
+sites). `Scrollable` does the same by hand for its drag recognizers.
+`RawGestureDetectorState._syncAll` does **not** — it calls the factory's
+`constructor()` and `initializer()` and nothing else. So a recognizer built in a
+`RawGestureDetector` keeps `gestureSettings == null` and falls back to the
+framework constants: `kTouchSlop` 18, `kPanSlop` 36 (`computePanSlop` in
+`gestures/events.dart`).
+
+Every gesture recognizer the viewer owns lives in a `RawGestureDetector`. So:
+
+| recognizer | built by | pan slop on a phone |
+| --- | --- | --- |
+| `_ZoomedTouchPanRecognizer` | the viewer's `RawGestureDetector` | **36** (default) |
+| IV's `ScaleGestureRecognizer` | `GestureDetector` inside `InteractiveViewer` | **~16** (`touchSlop * 2`, Android's 8dp) |
+
+`ScaleGestureRecognizer._advanceStateMachine` resolves **accepted** as soon as
+`focalPointDelta > computePanSlop(kind, gestureSettings)` — a *single* finger is
+enough. So on a device IV accepted a one-finger drag at ~16px, twenty pixels
+before the viewer's pan recognizer would even consider it, won the arena, and
+then did nothing with it: `panEnabled: false` means `_onScaleUpdate` ignores a
+one-pointer gesture. The drag was swallowed whole. Arming select "fixed" it
+because the editing overlay's per-page `GestureDetector` is both deeper *and*
+platform-configured, so it beats IV at the same 16px.
+
+This is exactly why it never reproduced in `flutter_test`: the test view reports
+no `physicalTouchSlop`, `MediaQuery.gestureSettings` is null, both sides fall
+back to 36, and the inner recognizer wins on dispatch order. Any test written
+without an explicit `DeviceGestureSettings` is blind to this class of bug.
+
+Fix: capture `MediaQuery.maybeGestureSettingsOf(context)` once in
+`_PdfViewerState.build` and assign it to all six recognizers the viewer mounts
+(double-tap, trackpad pan, eager pinch, zoomed touch pan, mouse selection pan,
+selection long-press). Note this makes the tie *safe*, not lucky: the viewer's
+recognizer is strictly inside IV's in the hit-test path, so it handles each move
+event first, and `DragGestureRecognizer` accumulates **path length** where
+`ScaleGestureRecognizer` measures **net displacement** — so at equal slop the
+pan crosses the threshold no later than IV, never later. It also removes 20px of
+dead travel before a zoomed pan starts moving, which was its own mobile
+paper-cut.
+
+## 2. The canvas beside the page was a dead zone at fit scale
+
+Found while reproducing #1. The list's `physics` is
+`NeverScrollableScrollPhysics` whenever a tool is armed *or* the viewer is
+zoomed, but `_zoomedTouchPanEnabledAt` bailed on `if (!_zoomed) return false`.
+So at fit scale with a tool armed, nothing owned an off-page touch drag: the
+list wouldn't scroll, the viewer's pan recognizer stayed out of the arena, and
+the editing overlay only covers pages. A drag starting on the canvas or in an
+inter-page gap moved nothing at all — and `PdfViewerFit.page`, the default,
+leaves canvas down both sides of a portrait page on a phone, which is precisely
+where a thumb lands.
+
+The gate's own comment already named this hazard ("Canvas and inter-page gaps
+have no overlay, so the viewer must claim them") — it just never got the chance
+below zoom. Fixed by making both sites read one invariant,
+`_listOwnsTouchScroll` (`!_zoomed && widget.editing?.tool == null`), so the
+physics and the pan gate cannot drift apart again. `_zoomedTouchPanEnabledAt` →
+`_touchPanEnabledAt`, and the gesture-log lines are `touch-pan gate:` now
+(they also carry `zoomed=` since the gate is no longer zoom-only).
+`_ZoomedTouchPanRecognizer` keeps its name; its doc comment carries the real
+condition.
+
+## Tests
+
+`mobile_touch_pan_test.dart` — pumps the viewer under a
+`MediaQuery(gestureSettings: DeviceGestureSettings(touchSlop: 8))`, which is the
+only way to see #1 from a test at all. Four of its six tests fail on the parent
+commit, and #1's failures are the reported symptom exactly: the visible region
+comes back *bit-identical* after the swipe, not merely short. Also asserts the
+viewer's six recognizers all carry the platform settings (constructing each from
+its live factory), that a tool-armed drag over a page still draws rather than
+pans, and that reader mode keeps `physics == null` and the platform fling.
+
+Full `dart analyze` clean; all 2048 `dart_pdf_editor` tests pass.
+
+## If this comes back
+
+The device-only signal is already wired: devtools → Log section → "Log touch
+input", then filter for `gesture`. A swallowed pan shows
+`InteractiveViewer interaction START` with **no** `viewer zoomed-touch-pan
+START`; a healthy one shows `touch-pan gate: ENABLED` followed by the pan's
+START/END pair.

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -5382,8 +5382,18 @@ class _PdfViewerState extends State<PdfViewer>
     _springBackCross();
   }
 
-  bool _zoomedTouchPanEnabledAt(Offset localPosition) {
-    if (!_zoomed) return false;
+  /// Whether the page list's own drag recognizer still owns touch scrolling.
+  /// It is stood down while a tool is armed (the editing overlay must win
+  /// strokes) and while zoomed (the viewer drives the scroll extent and the
+  /// zoom window together) - see the list's `physics`, which reads this. When
+  /// it is false, every touch pan the viewer wants has to come from
+  /// [_ZoomedTouchPanRecognizer] or an editing overlay, so the two must agree
+  /// on the condition or a drag lands on nothing at all.
+  bool get _listOwnsTouchScroll => !_zoomed && widget.editing?.tool == null;
+
+  bool _touchPanEnabledAt(Offset localPosition) {
+    // Leave native list scrolling (and its platform fling) alone.
+    if (_listOwnsTouchScroll) return false;
     final editing = widget.editing;
     // An armed tool, eyedropper, or selected annotation mounts an editing
     // overlay whose touch pan already calls _touchGrabPanBy. Do not enter the
@@ -5392,22 +5402,25 @@ class _PdfViewerState extends State<PdfViewer>
         (editing.tool == null &&
             !editing.isPickingColor &&
             !editing.hasAnnotationSelection)) {
-      pdfLogGesture('zoomed-pan gate: ENABLED (viewer owns pan)',
-          () => 'tool=${editing?.tool?.name ?? 'none'}');
+      pdfLogGesture('touch-pan gate: ENABLED (viewer owns pan)',
+          () => 'tool=${editing?.tool?.name ?? 'none'} zoomed=$_zoomed');
       return true;
     }
     // An armed tool/selection handles touches through its per-page overlay.
     // Canvas and inter-page gaps have no overlay, so the viewer must claim
-    // them or scrolling becomes bounded to the small visible page islands.
+    // them or scrolling becomes bounded to the small visible page islands -
+    // at fit scale as much as zoomed in, and a phone at PdfViewerFit.page
+    // leaves canvas down both sides of a portrait page for a thumb to land on.
     final overPage = _pageContainsListPoint(localPosition);
     pdfLogGesture(
-        'zoomed-pan gate: ${overPage ? 'DISABLED (overlay owns page)' : 'ENABLED (canvas gap)'}',
-        () => 'tool=${editing.tool?.name ?? 'selection/eyedropper'}');
+        'touch-pan gate: ${overPage ? 'DISABLED (overlay owns page)' : 'ENABLED (canvas gap)'}',
+        () => 'tool=${editing.tool?.name ?? 'selection/eyedropper'} '
+            'zoomed=$_zoomed');
     if (overPage) {
       // On the console channel too: when the overlay owns the page the viewer
       // never sees the drag, so no fling line is emitted at all - without this
       // an absent fling is indistinguishable from a broken one.
-      PdfPerfLog.log('zoomed-pan gate DISABLED (overlay owns page) '
+      PdfPerfLog.log('touch-pan gate DISABLED (overlay owns page) '
           'tool=${editing.tool?.name ?? 'selection/eyedropper'}');
     }
     return !overPage;
@@ -5737,6 +5750,19 @@ class _PdfViewerState extends State<PdfViewer>
     // the rubber-band marquee's chrome, matching the editing overlay's
     final marqueeColor = PdfViewerTheme.of(context).annotationChromeColor ??
         const Color(0xFF1E88E5);
+    // The platform's own touch slop, for every recognizer this build creates.
+    // [GestureDetector] does this for the recognizers it owns, but
+    // [RawGestureDetector] does NOT (`_syncAll` never touches
+    // `gestureSettings`), so hand-built recognizers silently keep the
+    // framework defaults - kTouchSlop 18 / kPanSlop 36 - while a phone
+    // reports ~8/16. That mismatch is not cosmetic: InteractiveViewer's own
+    // ScaleGestureRecognizer (a GestureDetector, so platform-configured)
+    // then accepted a one-finger touch drag at ~16px, 20px before
+    // [_ZoomedTouchPanRecognizer] would even consider it, won the arena, and
+    // swallowed the drag as a no-op (`panEnabled: false`) - zoomed panning
+    // did nothing on a device while every widget test passed, because the
+    // test view reports no touch slop and both sides fell back to 36.
+    final gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
     return LayoutBuilder(builder: (context, constraints) {
       // _viewWidth/_viewHeight still hold the previous layout's size here; a
       // change to the cross (fit) dimension rescales every page, so pin the
@@ -5799,9 +5825,9 @@ class _PdfViewerState extends State<PdfViewer>
         // (_onTrackpadPanZoomUpdate drives the position directly); wheel
         // events - including web trackpad pans, which arrive as wheel -
         // are refused by these physics and handled by _onPointerSignal.
-        physics: editing?.tool != null || _zoomed
-            ? const NeverScrollableScrollPhysics()
-            : null,
+        physics: _listOwnsTouchScroll
+            ? null
+            : const NeverScrollableScrollPhysics(),
         // every page's extent is known up front, so give the sliver exact
         // geometry instead of letting it estimate from built children -
         // estimates drift on long mixed-size documents, landing jumps
@@ -5993,6 +6019,7 @@ class _PdfViewerState extends State<PdfViewer>
                   },
                 ),
                 (recognizer) => recognizer
+                  ..gestureSettings = gestureSettings
                   ..onDoubleTapDown = ((details) => _doubleTapDetails = details)
                   ..onDoubleTap = _onDoubleTap,
               ),
@@ -6051,6 +6078,7 @@ class _PdfViewerState extends State<PdfViewer>
                               _TrackpadPanRecognizer>(
                         () => _TrackpadPanRecognizer(debugOwner: this),
                         (recognizer) => recognizer
+                          ..gestureSettings = gestureSettings
                           ..onStart = _onTrackpadPanZoomStart
                           ..onUpdate = _onTrackpadPanZoomUpdate
                           ..onEnd = _onTrackpadPanZoomEnd,
@@ -6062,6 +6090,7 @@ class _PdfViewerState extends State<PdfViewer>
                               _EagerPinchRecognizer>(
                         () => _EagerPinchRecognizer(debugOwner: this),
                         (recognizer) => recognizer
+                          ..gestureSettings = gestureSettings
                           ..onStart = _onPinchStart
                           ..onUpdate = _onPinchUpdate
                           ..onEnd = _onPinchEnd,
@@ -6074,7 +6103,10 @@ class _PdfViewerState extends State<PdfViewer>
                               _ZoomedTouchPanRecognizer>(
                         () => _ZoomedTouchPanRecognizer(debugOwner: this),
                         (recognizer) => recognizer
-                          ..isEnabled = _zoomedTouchPanEnabledAt
+                          // must match InteractiveViewer's scale recognizer or
+                          // IV wins this drag and drops it (see above)
+                          ..gestureSettings = gestureSettings
+                          ..isEnabled = _touchPanEnabledAt
                           ..onStart = _onZoomedTouchPanStart
                           ..onUpdate = _onZoomedTouchPanUpdate
                           ..onEnd = _onZoomedTouchPanEnd
@@ -6123,6 +6155,7 @@ class _PdfViewerState extends State<PdfViewer>
                                     },
                                   ),
                                   (recognizer) => recognizer
+                                    ..gestureSettings = gestureSettings
                                     ..onStart = _onSelectionStart
                                     ..onUpdate = _onSelectionUpdate
                                     ..onEnd = _onSelectionEnd
@@ -6138,6 +6171,7 @@ class _PdfViewerState extends State<PdfViewer>
                                   () => _SelectionLongPressRecognizer(
                                       debugOwner: this),
                                   (recognizer) => recognizer
+                                    ..gestureSettings = gestureSettings
                                     ..isEnabled = (() =>
                                         widget.editing?.tool == null &&
                                         widget.editing?.isPickingColor != true)
@@ -7268,10 +7302,18 @@ class _EagerPinchRecognizer extends ScaleGestureRecognizer {
   String get debugDescription => 'eager pinch';
 }
 
-/// Owns one-pointer touch/stylus drags only while the viewer is zoomed. It
-/// stays out of the arena at fit scale so the ListView retains normal platform
-/// scrolling; when a second finger lands, [_EagerPinchRecognizer] claims the
-/// pinch before either pan crosses touch slop.
+/// Owns one-pointer touch/stylus drags the page list can't take itself -
+/// whenever the viewer is zoomed or an editing tool has stood the list's own
+/// drag recognizer down (`_listOwnsTouchScroll`), and then only where no
+/// editing overlay already handles the touch. It stays out of the arena while
+/// the list scrolls natively, so plain reading keeps normal platform physics;
+/// when a second finger lands, [_EagerPinchRecognizer] claims the pinch before
+/// either pan crosses touch slop.
+///
+/// The host must hand this recognizer the platform's `gestureSettings`:
+/// [RawGestureDetector] does not, and the framework's default 36px pan slop
+/// loses the arena to InteractiveViewer's platform-configured (~16px) scale
+/// recognizer, which then drops the drag.
 class _ZoomedTouchPanRecognizer extends PanGestureRecognizer {
   _ZoomedTouchPanRecognizer({super.debugOwner})
       : super(supportedDevices: {

--- a/packages/dart_pdf_editor/test/mobile_touch_pan_test.dart
+++ b/packages/dart_pdf_editor/test/mobile_touch_pan_test.dart
@@ -1,0 +1,212 @@
+// Touch panning on a phone, where the two things that made it fail live:
+//
+//  1. the platform's real touch slop. Recognizers built in a
+//     [RawGestureDetector] (the viewer's) are NOT given the ambient
+//     `gestureSettings`, so they used the framework's 36px pan slop while
+//     InteractiveViewer's own scale recognizer - a [GestureDetector], so
+//     platform-configured - accepted at ~16px, won the arena, and dropped
+//     the drag (`panEnabled: false`). Every test passed because the test
+//     view reports no touch slop and both sides fell back to 36.
+//  2. the canvas beside a page. With a tool armed the list's own drag
+//     recognizer is stood down and only the per-page editing overlay pans -
+//     so at fit scale a drag starting off-page moved nothing at all, and
+//     PdfViewerFit.page (the phone default) leaves canvas down both sides.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  /// A phone's touch slop: Android's 8dp (iOS is the same order), which the
+  /// engine reports as `physicalTouchSlop` and MediaQuery hands to
+  /// recognizers as `touchSlop` - half the framework's 18px default, so
+  /// `panSlop` is 16 instead of 36.
+  const phone = DeviceGestureSettings(touchSlop: 8);
+
+  Future<(PdfEditingController, PdfViewerController)> pumpViewer(
+    WidgetTester tester, {
+    PdfViewerFit fit = PdfViewerFit.width,
+    int pages = 3,
+  }) async {
+    final editing = PdfEditingController(buildMultiPagePdf(pages));
+    final viewer = PdfViewerController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          // the viewer and InteractiveViewer both read their slop from here
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(gestureSettings: phone),
+            child: ListenableBuilder(
+              listenable: editing,
+              builder: (context, _) => PdfViewer(
+                initialFit: fit,
+                document: editing.document,
+                controller: viewer,
+                editing: editing,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return (editing, viewer);
+  }
+
+  /// One ordinary swipe, in 16ms steps so the velocity tracker sees a drag.
+  Future<void> swipe(WidgetTester tester, Offset from, Offset step,
+      {int steps = 8}) async {
+    final gesture =
+        await tester.startGesture(from, kind: PointerDeviceKind.touch);
+    var stamp = Duration.zero;
+    for (var i = 0; i < steps; i++) {
+      stamp += const Duration(milliseconds: 16);
+      await gesture.moveBy(step, timeStamp: stamp);
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    await gesture.up(timeStamp: stamp);
+    await tester.pumpAndSettle();
+  }
+
+  /// Double-tap zoom, then settle the disambiguation timer.
+  Future<void> zoomIn(WidgetTester tester, PdfViewerController viewer) async {
+    await tester.tapAt(const Offset(400, 300));
+    await tester.pump(const Duration(milliseconds: 80));
+    await tester.tapAt(const Offset(400, 300));
+    await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    expect(viewer.zoom, greaterThan(1), reason: 'double tap should zoom in');
+  }
+
+  group('at the platform touch slop', () {
+    testWidgets('a zoomed one-finger pan moves the page, not nothing',
+        (tester) async {
+      final (_, viewer) = await pumpViewer(tester);
+      await zoomIn(tester, viewer);
+      final before = viewer.visiblePageRegion(0)!;
+
+      // Drag left: the visible window travels right across the page. With the
+      // viewer's pan recognizer on the framework's 36px slop, IV's scale
+      // recognizer accepted this at 16px and swallowed it - the window never
+      // moved.
+      await swipe(tester, const Offset(400, 300), const Offset(-20, 0));
+
+      expect(viewer.visiblePageRegion(0)!.left, greaterThan(before.left),
+          reason: 'a zoomed touch pan must reach the viewer, not '
+              "InteractiveViewer's no-op scale handler");
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('a zoomed one-finger pan moves vertically too', (tester) async {
+      final (_, viewer) = await pumpViewer(tester);
+      await zoomIn(tester, viewer);
+      final before = viewer.visiblePageRegion(0)!;
+
+      await swipe(tester, const Offset(400, 300), const Offset(0, -20));
+
+      expect(viewer.visiblePageRegion(0)!.top, greaterThan(before.top),
+          reason: 'the vertical half of the same drag path');
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('every recognizer the viewer builds takes the platform slop',
+        (tester) async {
+      // The regression itself: whatever slop IV's recognizer uses, the
+      // viewer's must match it, or IV wins every one-finger drag on a device.
+      // [RawGestureDetector] will not do this for us - Scrollable and
+      // GestureDetector both assign `gestureSettings` by hand for the same
+      // reason, so the viewer has to as well.
+      await pumpViewer(tester);
+      var checked = 0;
+      for (final detector in tester
+          .widgetList<RawGestureDetector>(find.byType(RawGestureDetector))) {
+        detector.gestures.forEach((type, factory) {
+          if (!_viewerRecognizers.contains(type.toString())) return;
+          final recognizer = factory.constructor();
+          addTearDown(recognizer.dispose);
+          factory.initializer(recognizer);
+          checked++;
+          expect(recognizer.gestureSettings, phone,
+              reason: '$type kept the framework slop; InteractiveViewer will '
+                  'outrace it on a device');
+        });
+      }
+      expect(checked, _viewerRecognizers.length,
+          reason: 'every viewer-owned recognizer should have been mounted and '
+              'checked - update _viewerRecognizers if one was renamed');
+    });
+  });
+
+  group('with a tool armed at fit scale', () {
+    testWidgets('a drag on the canvas beside the page still scrolls',
+        (tester) async {
+      // PdfViewerFit.page is the phone default: a portrait page leaves canvas
+      // down both sides, and the list's own drag recognizer is stood down
+      // because a tool is armed, so this drag used to move nothing.
+      final (editing, viewer) =
+          await pumpViewer(tester, fit: PdfViewerFit.page, pages: 5);
+      editing.tool = PdfEditTool.select;
+      await tester.pump();
+      expect(viewer.currentPage, 0);
+
+      await swipe(tester, const Offset(16, 300), const Offset(0, -25));
+
+      expect(viewer.currentPage, greaterThan(0),
+          reason: 'a thumb in the canvas margin must scroll the document');
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+
+    testWidgets('a drag over the page still belongs to the overlay',
+        (tester) async {
+      // The other half of the gate: the page itself stays the overlay's, so
+      // arming ink still draws instead of panning.
+      final (editing, viewer) =
+          await pumpViewer(tester, fit: PdfViewerFit.page, pages: 5);
+      editing.tool = PdfEditTool.ink;
+      await tester.pump();
+
+      await swipe(tester, const Offset(400, 300), const Offset(6, 6));
+      // the stroke's commit debounce
+      await tester.pump(const Duration(milliseconds: 900));
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final annotations = editing.document.page(0).annotations;
+      expect(annotations, hasLength(1), reason: 'the stroke should have drawn');
+      expect(annotations.single.subtype, 'Ink');
+      expect(viewer.currentPage, 0, reason: 'and must not have panned');
+    });
+
+    testWidgets("reader mode keeps the list's own physics", (tester) async {
+      // No tool, not zoomed: the list scrolls natively (platform fling), and
+      // the viewer's pan recognizer must stay out of the arena.
+      final (_, viewer) = await pumpViewer(tester, fit: PdfViewerFit.page);
+      expect(tester.widget<Scrollable>(find.byType(Scrollable).first).physics,
+          isNull);
+
+      await swipe(tester, const Offset(400, 300), const Offset(0, -25));
+      expect(viewer.currentPage, greaterThan(0));
+      await tester.pump(const Duration(milliseconds: 400));
+    });
+  });
+}
+
+/// The recognizers `PdfViewer` mounts with itself, by type name - the ones
+/// that have to be handed the platform's `gestureSettings` because
+/// [RawGestureDetector] won't. Everything else in the tree (Scrollable's
+/// drags, the editing overlay's [GestureDetector]) is the framework's to
+/// configure. Handle-drag recognizers, mounted only with a live text
+/// selection, aren't listed: they accept on pointer-down, so no slop applies.
+const _viewerRecognizers = {
+  'DoubleTapGestureRecognizer',
+  '_TrackpadPanRecognizer',
+  '_EagerPinchRecognizer',
+  '_ZoomedTouchPanRecognizer',
+  'PanGestureRecognizer',
+  '_SelectionLongPressRecognizer',
+};


### PR DESCRIPTION
## Summary

Panning on a phone did nothing: while zoomed, a one-finger drag was swallowed whole rather than moving the page. This closes the bug left deliberately unfixed in `doc/dev-log/2026-07-19-devtools-mobile-touch-logging.md` §3 — *"panning while zoomed doesn't work from a fresh app open, but works after I pick the select tool."* That session's leading suspect (InteractiveViewer's scale recognizer) was right; the mechanism was missing.

**`RawGestureDetector` does not propagate `gestureSettings`.** `GestureDetector.build` assigns `..gestureSettings = MediaQuery.maybeGestureSettingsOf(context)` to every recognizer it constructs, and `Scrollable` does the same by hand — but `RawGestureDetectorState._syncAll` calls the factory's `constructor()`/`initializer()` and nothing else. Every recognizer the viewer owns lives in a `RawGestureDetector`, so they all silently kept the framework's `kPanSlop` of 36px:

| recognizer | built by | pan slop on a phone |
| --- | --- | --- |
| `_ZoomedTouchPanRecognizer` | the viewer's `RawGestureDetector` | **36** (framework default) |
| IV's `ScaleGestureRecognizer` | `GestureDetector` inside `InteractiveViewer` | **~16** (`touchSlop * 2`, Android's 8dp) |

`ScaleGestureRecognizer._advanceStateMachine` resolves **accepted** as soon as `focalPointDelta > computePanSlop(...)` — a *single* finger is enough. So on a device IV accepted the drag at ~16px, twenty pixels before the viewer's pan recognizer would consider it, won the arena, and then dropped it: `panEnabled: false` makes `_onScaleUpdate` a no-op for one pointer. Arming select "fixed" it because the editing overlay's per-page `GestureDetector` is both deeper *and* platform-configured.

This never reproduced in a widget test because the test view reports no `physicalTouchSlop`, so both sides fell back to 36 and the inner recognizer won on dispatch order.

The fix captures the platform settings once in `_PdfViewerState.build` and hands them to all six recognizers the viewer mounts. The resulting tie is safe rather than lucky: the viewer's recognizer sits strictly inside IV's in the hit-test path, so it handles each move event first, and `DragGestureRecognizer` accumulates **path length** where `ScaleGestureRecognizer` measures **net displacement** — at equal slop the pan crosses the threshold no later than IV, never later. It also removes 20px of dead travel before a zoomed pan starts moving, a mobile paper-cut in its own right.

**Second dead zone, found while reproducing the first.** With a tool armed at fit scale, nothing owned an off-page touch drag. The list's physics are `NeverScrollableScrollPhysics` whenever a tool is armed *or* the viewer is zoomed, but the pan gate bailed on `if (!_zoomed) return false`, and the editing overlay only covers pages — so a drag starting on the canvas or in an inter-page gap moved nothing at all. `PdfViewerFit.page` (the default) leaves canvas down both sides of a portrait page on a phone, which is exactly where a thumb lands. The gate's own comment already named this hazard; it just never got the chance below zoom. Both sites now read one invariant, `_listOwnsTouchScroll`, so the physics and the pan gate cannot drift apart again.

No API change. `_zoomedTouchPanEnabledAt` → `_touchPanEnabledAt` (private), and the gesture-log lines are `touch-pan gate:` now, carrying `zoomed=` since the gate is no longer zoom-only.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (whole repo, no issues found)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2048 pass, 33 skipped)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to `dart_pdf_editor`'s gesture wiring, so it cannot affect the COS/document/graphics packages or any rendered output — the corpus and Ghent suites have no reachable surface here. No on-device pass was possible in this environment; see "Notes for reviewers".

## PDF fixtures and screenshots

None needed — the new tests build their documents programmatically via `buildMultiPagePdf`.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

**The new test file is the interesting part of the review.** `mobile_touch_pan_test.dart` pumps the viewer under a `MediaQuery(gestureSettings: DeviceGestureSettings(touchSlop: 8))` — without that, this whole class of bug is invisible to `flutter_test`, which is why the July 19 session couldn't reproduce it. Four of its six tests fail on the parent commit, and the first bug's failures are the reported symptom exactly: the visible region comes back **bit-identical** after the swipe (`Expected: a value greater than <0.3> / Actual: <0.3>`), not merely short. It also asserts the six viewer-owned recognizers all carry the platform settings, that a tool-armed drag over a page still draws rather than pans, and that reader mode keeps `physics == null` and its platform fling.

Worth a second opinion on: making the viewer's recognizers *more* eager (16px instead of 36px) is a behaviour change for touch everywhere, not just mobile. I believe it's safe — the pan gate keeps the recognizer out of the arena entirely whenever the list still scrolls itself, so there's no new competition with native scrolling — but that reasoning is the load-bearing part, and the full suite passing is evidence rather than proof.

**Not verified on a device.** This environment has no phone or simulator, so the on-device confirmation the July 19 session was waiting for still hasn't happened; the mechanism is derived from the Flutter 3.44.8 sources (cited in the dev-log) and pinned by tests at device-like slop. If it's convenient to check on hardware before merging, the devtools signal is already wired: Log section → "Log touch input", filter `gesture`. A healthy zoomed pan now logs `touch-pan gate: ENABLED` followed by the pan's START/END pair; the broken one logged `InteractiveViewer interaction START` with no pan START at all.

Dev-log: `doc/dev-log/2026-07-30-mobile-touch-pan-slop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163TL1VmTgPfWSN8pQz7WKf

---
_Generated by [Claude Code](https://claude.ai/code/session_0163TL1VmTgPfWSN8pQz7WKf)_