### PR TITLE
Revert docked panels overlaying the PDF viewer

### DIFF
--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -110,34 +110,21 @@ class _PdfShellPanelLayoutState extends State<PdfShellPanelLayout> {
 
   @override
   Widget build(BuildContext context) {
-    // The panels OVERLAY the viewer rather than squeezing it: the viewer fills
-    // the whole content area and the docked panels float at its edges over the
-    // top. So opening, closing, or resizing a panel never changes the viewer's
-    // size - the document view is invariant to the panels (no zoom or position
-    // jump), and the panel simply reveals or covers a strip of the page beside
-    // it. The panels keep their original nesting - a column of top panels, a
-    // middle band of leading · gap · trailing, then a column of bottom panels -
-    // so their arrangement, resize grips, and drop zones are unchanged; only the
-    // viewer's old flex slot becomes a transparent gap the viewer shows through.
-    final panelsOverlay = Column(children: [
-      ...widget.topPanels,
+    final row = Row(children: [
+      ...widget.leadingPanels,
       Expanded(
-        child: Row(children: [
-          ...widget.leadingPanels,
-          // the viewer shows through here; an empty box takes no pointer input,
-          // so taps in the gap reach the viewer beneath in the stack
-          const Expanded(child: SizedBox.expand()),
-          ...widget.trailingPanels,
-        ]),
-      ),
-      ...widget.bottomPanels,
-    ]);
-    final content = Stack(children: [
-      Positioned.fill(
         key: const ValueKey('pdf-shell-viewer'),
         child: widget.viewer,
       ),
-      Positioned.fill(child: panelsOverlay),
+      ...widget.trailingPanels,
+    ]);
+    final stacked = Column(children: [
+      ...widget.topPanels,
+      Expanded(child: row),
+      ...widget.bottomPanels,
+    ]);
+    final content = Stack(children: [
+      Positioned.fill(child: stacked),
       ...widget.overlays,
       if (widget.floatingToolbar != null)
         Positioned(

--- a/packages/dart_pdf_editor/test/panel_dock_test.dart
+++ b/packages/dart_pdf_editor/test/panel_dock_test.dart
@@ -312,10 +312,7 @@ void main() {
     });
   });
 
-  group('viewer is invariant to the panels', () {
-    // Panels overlay the viewer rather than squeezing it, so opening, closing,
-    // or resizing a panel must not change the viewer's size - the document view
-    // can't zoom or shift under the reader when a panel toggles.
+  group('panels reserve space beside the viewer', () {
     Widget shell({List<Widget> leading = const [], double panelWidth = 260}) =>
         PdfShellPanelLayout(
           viewer: const SizedBox.expand(
@@ -341,7 +338,7 @@ void main() {
       expect(full.height, greaterThan(0));
     });
 
-    testWidgets('opening a panel does not resize the viewer', (tester) async {
+    testWidgets('opening a panel reduces the viewer width', (tester) async {
       await pump(tester, shell());
       final before = tester.getSize(find.byKey(const ValueKey('test-viewer')));
 
@@ -350,20 +347,19 @@ void main() {
       expect(find.byKey(const ValueKey('test-panel')), findsOneWidget);
       final after = tester.getSize(find.byKey(const ValueKey('test-viewer')));
 
-      expect(after, before,
-          reason: 'the viewer keeps the full content area - the panel '
-              'overlays it rather than pushing it');
+      expect(after.width, before.width - 260);
+      expect(after.height, before.height);
     });
 
-    testWidgets('resizing a panel does not resize the viewer', (tester) async {
+    testWidgets('resizing a panel adjusts the viewer width', (tester) async {
       await pump(tester, shell(leading: const [SizedBox()], panelWidth: 200));
       final before = tester.getSize(find.byKey(const ValueKey('test-viewer')));
 
       await pump(tester, shell(leading: const [SizedBox()], panelWidth: 360));
       final after = tester.getSize(find.byKey(const ValueKey('test-viewer')));
 
-      expect(after, before,
-          reason: 'a wider panel still overlays the viewer, size unchanged');
+      expect(after.width, before.width - 160);
+      expect(after.height, before.height);
     });
   });
 }


### PR DESCRIPTION
### Motivation
- Restore the previous shell layout behavior so docked panels reserve layout space beside/above/below the viewer instead of floating on top and covering page content.
- This change reverts a recent overlay layout that caused panels to obscure the viewer and produced unwanted zoom/scroll interactions when panels opened or resized.

### Description
- Reworked `PdfShellPanelLayout` (`packages/dart_pdf_editor/lib/src/shell_chrome.dart`) to use the canonical row/column composition (leading panels · `Expanded` viewer · trailing panels) so panels occupy layout space instead of overlaying the viewer. 
- Replaced the stacked overlay variant with the prior `Row`/`Column` structure and restored the `pdf-shell-viewer` `ValueKey` on the viewer slot. 
- Updated tests in `packages/dart_pdf_editor/test/panel_dock_test.dart` to assert that opening or resizing a docked panel adjusts the viewer width while preserving height.

### Testing
- Ran `fvm flutter test test/panel_dock_test.dart` from the `packages/dart_pdf_editor` package and the tests passed. 
- Ran `fvm flutter test test/pdf_shell_test.dart` from the `packages/dart_pdf_editor` package and the suite passed. 
- Performed `git diff --check` to validate no whitespace/mutation issues and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6dd2a7e684832b96c3494f887ef4bc)