### PR TITLE
Fix duplicate annotations after property edits

### DIFF
--- a/packages/dart_pdf_editor/test/editing_properties_test.dart
+++ b/packages/dart_pdf_editor/test/editing_properties_test.dart
@@ -55,6 +55,21 @@ void main() {
       expect(after.contents, 'Changed');
     });
 
+    test('free-text property rewrite does not duplicate indirect annots', () {
+      final seeded = PdfEditor(PdfDocument.open(buildIndirectAnnotsPdf()))
+        ..addFreeText(0, const PdfRect(100, 560, 300, 620), 'Hello');
+      final editing = PdfEditingController(seeded.save());
+      addTearDown(editing.dispose);
+      editing.selectAnnotation(0, 0);
+
+      editing.restyleSelectedText(size: 24);
+
+      final after = editing.document.page(0).annotations;
+      expect(after, hasLength(1));
+      expect(after.single.defaultAppearance, contains('/Helv 24 Tf'));
+      expect(editing.selectedTextStyle?.size, 24);
+    });
+
     test('the author applies to the whole selection as one undo', () {
       final editing = PdfEditingController(buildMultiPagePdf(1))
         ..addRectangle(0, const PdfRect(100, 600, 200, 660))

--- a/packages/pdf_document/lib/src/page_annotation_list.dart
+++ b/packages/pdf_document/lib/src/page_annotation_list.dart
@@ -105,6 +105,12 @@ class _PdfPageAnnotationList {
     final next = CosArray(items);
     if (raw is CosReference && _cos.resolve(raw) is CosArray) {
       _updater.replaceObject(raw.objectNumber, next);
+      // A single editor transaction can remove and then re-add an annotation
+      // (for example when a FreeText property change regenerates its
+      // appearance). Make the replacement visible to that transaction's
+      // next `/Annots` read; otherwise resolve(raw) returns the original
+      // cached array and the append resurrects the removed annotation.
+      _cos.adoptObject(raw, next);
     } else {
       page.dict['Annots'] = next;
       _updater.markChanged(page.dict);

--- a/packages/pdf_document/test/annotation_editor_test.dart
+++ b/packages/pdf_document/test/annotation_editor_test.dart
@@ -937,12 +937,30 @@ void main() {
   });
 
   test('removeAnnotation on an existing indirect /Annots array', () {
-    final doc = PdfDocument.open(buildAnnotatedPdf());
+    final seeded = PdfEditor(PdfDocument.open(buildIndirectAnnotsPdf()))
+      ..addSquare(0, const PdfRect(100, 100, 200, 150))
+      ..addNote(0, 300, 700, 'keep me');
+    final doc = PdfDocument.open(seeded.save());
     final before = doc.page(0).annotations.length;
     final editor = PdfEditor(doc)
       ..removeAnnotation(0, doc.page(0).annotations.first);
     final reopened = PdfDocument.open(editor.save());
     expect(reopened.page(0).annotations.length, before - 1);
+  });
+
+  test('remove then append composes on an indirect /Annots array', () {
+    final seeded = PdfEditor(PdfDocument.open(buildIndirectAnnotsPdf()))
+      ..addSquare(0, const PdfRect(100, 100, 200, 150));
+    final doc = PdfDocument.open(seeded.save());
+    final removed = doc.page(0).annotations.single;
+    final editor = PdfEditor(doc)
+      ..removeAnnotation(0, removed)
+      ..addNote(0, 500, 700, 'replacement');
+
+    final after = PdfDocument.open(editor.save()).page(0).annotations;
+    expect(after, hasLength(1));
+    expect(after.single.subtype, 'Text');
+    expect(after.single.contents, 'replacement');
   });
 
   test('removeAnnotations deletes multiple annotations in one edit', () {

--- a/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
+++ b/packages/pdf_test_fixtures/lib/pdf_test_fixtures.dart
@@ -44,6 +44,42 @@ Uint8List buildClassicPdf() {
   return ascii(buffer.toString());
 }
 
+/// Builds a minimal one-page PDF whose `/Annots` array is indirect.
+///
+/// Most fixtures store `/Annots` directly in the page dictionary. This one
+/// exercises editors that replace the array object and then read it again in
+/// the same incremental-update transaction.
+Uint8List buildIndirectAnnotsPdf() {
+  const content = 'BT /F1 24 Tf 72 720 Td (Indirect annotations) Tj ET';
+  final objects = <String>[
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+        '/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> '
+        '/Annots 6 0 R >>',
+    '<< /Length ${content.length} >>\nstream\n$content\nendstream',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '[ ]',
+  ];
+  final buffer = StringBuffer('%PDF-1.4\n');
+  final offsets = <int>[];
+  for (var i = 0; i < objects.length; i++) {
+    offsets.add(buffer.length);
+    buffer.write('${i + 1} 0 obj\n${objects[i]}\nendobj\n');
+  }
+  final xrefOffset = buffer.length;
+  buffer
+    ..write('xref\n0 ${objects.length + 1}\n')
+    ..write('0000000000 65535 f \n');
+  for (final offset in offsets) {
+    buffer.write('${offset.toString().padLeft(10, '0')} 00000 n \n');
+  }
+  buffer
+    ..write('trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\n')
+    ..write('startxref\n$xrefOffset\n%%EOF\n');
+  return ascii(buffer.toString());
+}
+
 /// Builds a PDF in the "modern" 1.5+ layout: an uncompressed cross-reference
 /// stream, with the catalog and page tree packed into an object stream.
 Uint8List buildXrefStreamPdf() {


### PR DESCRIPTION
## What changed

- Make a staged replacement of an indirect `/Annots` array immediately visible to subsequent reads in the same editor transaction.
- Add a real indirect-`/Annots` fixture and document-level regression coverage.
- Add an editor regression covering a FreeText property change.

## Root cause

FreeText property changes regenerate the annotation by removing and re-adding it in one incremental-update transaction. When a page stored `/Annots` indirectly, the removal was staged for serialization but the COS resolver still returned the original cached array. The following append therefore resurrected the original annotation beside its replacement.

## Impact

Changing properties no longer duplicates annotations in PDFs that store their annotation array indirectly.

## Validation

- `fvm dart analyze`
- Full `pdf_document` test suite: 807 passed, 1 skipped
- Affected Flutter editing suites (`editing_properties_test.dart`, `editing_text_edit_test.dart`, `editing_clipboard_test.dart`): 98 passed
- Focused indirect-`/Annots` regressions passed