### PR TITLE
Allow selected pages to be reordered together

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -3400,11 +3400,41 @@ class PdfEditingController extends ChangeNotifier {
   // ---------------------------------------------------------------------
   // pages
 
-  /// Moves the page at [from] so it ends up at index [to]. Structural
-  /// page edits shift page indices, so the annotation selection (a
-  /// page-indexed slot) is cleared first.
+  /// Moves the page at [from] so it ends up at index [to]. When [from] is
+  /// part of a multi-page selection, the whole selection moves with it,
+  /// preserving the selected pages' document order. The dragged page lands
+  /// at [to] whenever the block fits there; at either document edge the block
+  /// is clamped as a unit.
+  ///
+  /// Structural page edits shift page indices, so the annotation selection
+  /// (a page-indexed slot) is cleared first. A moved page selection follows
+  /// the pages to their new contiguous positions.
   void movePage(int from, int to) {
     if (from == to) return;
+    final moving = selectedPages;
+    if (moving.length > 1 && moving.contains(from)) {
+      // Dropping anywhere inside the selection is not a move. This also
+      // prevents a discontiguous selection from unexpectedly compacting when
+      // one of its own tiles is used as the drop target.
+      if (moving.contains(to)) return;
+      final draggedOffset = moving.indexOf(from);
+      final remaining = [
+        for (var i = 0; i < _document.pageCount; i++)
+          if (!moving.contains(i)) i,
+      ];
+      final start = (to - draggedOffset).clamp(0, remaining.length);
+      final order = List<int>.of(remaining)..insertAll(start, moving);
+
+      _selected.clear();
+      final changed = apply((e) => e.reorderPages(order));
+      if (!changed) return;
+      _selectedPages.addAll([
+        for (var i = 0; i < moving.length; i++) start + i,
+      ]);
+      _pageSelectionAnchor = start + draggedOffset;
+      notifyListeners();
+      return;
+    }
     _selected.clear();
     _selectedPages.clear();
     _pageSelectionAnchor = null;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -1605,8 +1605,9 @@ class _ThumbnailSizeControl extends StatelessWidget {
 /// reorder. A mouse picks a tile up immediately (it hovers first, so the
 /// cell knows a pointer is present); touch and stylus need a long press,
 /// so a finger drag still scrolls the grid. Dropping onto another cell
-/// moves the page there ([PdfEditingController.movePage]). With
-/// [allowPageEditing] off the cell is the bare tile - read-only grids
+/// moves the page there ([PdfEditingController.movePage]); if that page is
+/// part of a multi-page selection, the entire selection moves together.
+/// With [allowPageEditing] off the cell is the bare tile - read-only grids
 /// only navigate.
 class _GridPageCell extends StatefulWidget {
   const _GridPageCell({
@@ -1711,8 +1712,13 @@ class _GridPageCellState extends State<_GridPageCell> {
   }
 
   Widget _draggable(Widget tile) {
+    final selectedCount = widget.controller.isPageSelected(widget.pageIndex)
+        ? widget.controller.selectedPageCount
+        : 0;
     final feedback = _DragFeedback(
-      label: pdfL10n(context).thumbPageNumber(widget.pageIndex + 1),
+      label: selectedCount > 1
+          ? pdfL10n(context).thumbSelectedCount(selectedCount)
+          : pdfL10n(context).thumbPageNumber(widget.pageIndex + 1),
       width: widget.tileWidth,
     );
     // dim the page being dragged in place, leaving a gap-marker

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -229,6 +229,53 @@ void main() {
       expect(editing.document.pageCount, 3);
     });
 
+    test('dragging a selected page reorders the whole selection', () {
+      final editing = PdfEditingController(buildMultiPagePdf(6));
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      editing.togglePageSelection(3);
+
+      editing.movePage(1, 4);
+
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 3', 'Page 5', 'Page 6', 'Page 2', 'Page 4']);
+      expect(editing.selectedPages, [4, 5]);
+      expect(editing.pageSelectionAnchor, 4);
+      editing.undo();
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 4', 'Page 5', 'Page 6']);
+    });
+
+    test('a selected-page reorder preserves order and clamps at an edge', () {
+      final editing = PdfEditingController(buildMultiPagePdf(6));
+      addTearDown(editing.dispose);
+      editing.selectPage(2);
+      editing.togglePageSelection(4);
+
+      // Page 5 is the dragged member, so it cannot itself land at zero while
+      // Page 3 remains before it. Clamp the two-page block instead.
+      editing.movePage(4, 0);
+
+      expect(labelsOf(editing.document),
+          ['Page 3', 'Page 5', 'Page 1', 'Page 2', 'Page 4', 'Page 6']);
+      expect(editing.selectedPages, [0, 1]);
+      expect(editing.pageSelectionAnchor, 1);
+    });
+
+    test('dropping a selected page on its selection is a no-op', () {
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      editing.togglePageSelection(3);
+
+      editing.movePage(1, 3);
+
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 4', 'Page 5']);
+      expect(editing.selectedPages, [1, 3]);
+      expect(editing.isModified, isFalse);
+    });
+
     test('a structural page edit clears the selection', () {
       final editing = PdfEditingController(buildMultiPagePdf(4));
       addTearDown(editing.dispose);


### PR DESCRIPTION
### Motivation
- Enable dragging any page that is part of a multi-page selection to move the entire selected block as a unit, preserving order and matching typical thumbnail-strip UX.

### Description
- Update `PdfEditingController.movePage` to detect when the dragged index is inside a multi-page selection and, in that case, compute a new permutation that removes the selected indices and reinserts the contiguous block at the drop position, clamping at document edges and treating a drop onto the selection as a no-op.
- Preserve the page selection after a successful group move by repopulating `_selectedPages`, updating `_pageSelectionAnchor`, and calling `notifyListeners()` so the UI remains in sync.
- Improve grid drag feedback in `editing_thumbnails.dart` so the drag card shows a selected-page count when dragging a member of a multi-page selection instead of a single page label.
- Add unit/widget tests in `test/editing_page_ops_test.dart` to cover group drag reorder behavior, order preservation, edge clamping, no-op drops onto the selection, undo, and selection retention.

### Testing
- Ran the new page-ops tests with `fvm flutter test test/editing_page_ops_test.dart`, which passed (all tests green). 
- Ran static checks with `fvm dart analyze lib/src/editing/editing_controller.dart lib/src/editing/editing_thumbnails.dart test/editing_page_ops_test.dart`, which reported no issues. 
- Ran `git diff --check` to ensure no whitespace/check issues; it was clean after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f1632dae4832b9a925d2830937e85)