### PR TITLE
Fix text color changes for embedded fonts

### DIFF
--- a/packages/pdf_document/lib/src/annotation_behavior.dart
+++ b/packages/pdf_document/lib/src/annotation_behavior.dart
@@ -210,8 +210,8 @@ class PdfAnnotationBehavior {
         (annotation.vertices?.length ?? 0) >= 2,
     'Polygon' => annotation.normalAppearance != null &&
         (annotation.vertices?.length ?? 0) >= 3,
-    'FreeText' =>
-      annotation.normalAppearance != null && standardTextFont != null,
+    'FreeText' => annotation.normalAppearance != null &&
+        (standardTextFont != null || hasEmbeddedTextFont),
     'Ink' => annotation.inkList?.isNotEmpty ?? false,
     'Highlight' ||
     'Underline' ||

--- a/packages/pdf_document/lib/src/annotation_editor.dart
+++ b/packages/pdf_document/lib/src/annotation_editor.dart
@@ -4577,8 +4577,8 @@ extension PdfAnnotationEditing on PdfEditor {
   /// [to] from the style its dictionary carries, replacing the /AP /N
   /// stream. Returns false - leaving the caller on the §12.5.5 stretch
   /// path - for other subtypes and for styles it can't reproduce
-  /// faithfully: cloudy (/BE) shape borders, free text whose /DA doesn't
-  /// name a standard font.
+  /// faithfully: cloudy (/BE) shape borders, or free text whose /DA font
+  /// is neither a standard face nor recoverable from its appearance.
   ///
   /// [opacity], when given, replaces the alpha the old appearance
   /// carried - [restyleAnnotation]'s opacity path.
@@ -5049,7 +5049,13 @@ extension PdfAnnotationEditing on PdfEditor {
         return _restyleRegenerate(pageIndex, dict, opacity: opacity);
       case 'FreeText':
         final style = currentStyle.freeText!;
-        final font = behavior.standardTextFont!;
+        // /DA only identifies base-14 faces directly. Recover an embedded
+        // face from the appearance resources just as the resize path does;
+        // otherwise changing the colour of text written in a custom font
+        // cannot rebuild its appearance.
+        final font = behavior.standardTextFont ??
+            PdfEmbeddedFont.fromFreeText(annotation);
+        if (font == null) return false;
         final textColor = color ?? style.color;
         final fill = fillColor != null ? fillColor.$1 : style.fillColor;
         final border = style.borderColor != null && style.borderWidth > 0

--- a/packages/pdf_document/test/font_embed_test.dart
+++ b/packages/pdf_document/test/font_embed_test.dart
@@ -196,6 +196,34 @@ void main() {
       expect(font.glyphForRune(0x00E9), greaterThan(0));
       expect(font.glyphForRune(0x03A9), greaterThan(0));
     });
+
+    test('restyleAnnotation changes colour without losing embedded font', () {
+      final font = PdfEmbeddedFont.parse(fontBytes);
+      final original = roundTrip((e) => e.addFreeText(
+            0,
+            const PdfRect(72, 600, 320, 680),
+            'Custom face',
+            font: font,
+          ));
+      final editor = PdfEditor(original);
+
+      expect(
+        editor.restyleAnnotation(
+          0,
+          original.page(0).annotations.single,
+          color: 0x1E88E5,
+        ),
+        isTrue,
+      );
+
+      final restyled = PdfDocument.open(editor.save());
+      final annotation = restyled.page(0).annotations.single;
+      expect(annotation.freeTextStyle?.color, 0x1E88E5);
+      expect(PdfEmbeddedFont.fromFreeText(annotation), isNotNull);
+      expect(isType0(restyled, annotation), isTrue);
+      expect(appearanceText(restyled, annotation),
+          contains('0.118 0.533 0.898 rg'));
+    });
   });
 
   group('rich FreeText', () {


### PR DESCRIPTION
### Motivation
- FreeText annotations using embedded/custom fonts could not be restyled (text colour changes) because the restyle path assumed a base-14 standard font and could not rebuild the appearance for embedded fonts.

### Description
- Allow `FreeText` annotations to be considered restylable when an embedded font is recoverable by updating `PdfAnnotationBehavior.canRestyle` to accept `hasEmbeddedTextFont` in addition to `standardTextFont`.
- During appearance regeneration, recover and reuse the embedded font via `PdfEmbeddedFont.fromFreeText(annotation)` when no base-14 standard font is present, and bail out when neither is available, so colour changes can rebuild a valid `/AP` using the original embedded face.
- Add a regression test (`test/font_embed_test.dart`) that creates a FreeText with an embedded font, calls `restyleAnnotation` to change its colour, and verifies the annotation still embeds a Type0 font and the new colour appears in the regenerated appearance.

### Testing
- Ran `cd packages/pdf_document && dart test test/font_embed_test.dart` and the new/updated tests passed.
- Ran `cd packages/dart_pdf_editor && flutter test test/editing_text_edit_test.dart` and widget tests passed.
- Ran `dart analyze packages/pdf_document/lib/src/annotation_behavior.dart packages/pdf_document/lib/src/annotation_editor.dart packages/pdf_document/test/font_embed_test.dart` with no issues reported.
- Ran `git diff --check` to ensure no whitespace/check warnings; it was clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f190dc6c0832bbe6c6355d23d1379)