### PR TITLE
Enable multi-page selection drag-and-drop reordering with UI feedback

### DIFF
--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -3400,11 +3400,41 @@ class PdfEditingController extends ChangeNotifier {
   // ---------------------------------------------------------------------
   // pages
 
-  /// Moves the page at [from] so it ends up at index [to]. Structural
-  /// page edits shift page indices, so the annotation selection (a
-  /// page-indexed slot) is cleared first.
+  /// Moves the page at [from] so it ends up at index [to]. When [from] is
+  /// part of a multi-page selection, the whole selection moves with it,
+  /// preserving the selected pages' document order. The dragged page lands
+  /// at [to] whenever the block fits there; at either document edge the block
+  /// is clamped as a unit.
+  ///
+  /// Structural page edits shift page indices, so the annotation selection
+  /// (a page-indexed slot) is cleared first. A moved page selection follows
+  /// the pages to their new contiguous positions.
   void movePage(int from, int to) {
     if (from == to) return;
+    final moving = selectedPages;
+    if (moving.length > 1 && moving.contains(from)) {
+      // Dropping anywhere inside the selection is not a move. This also
+      // prevents a discontiguous selection from unexpectedly compacting when
+      // one of its own tiles is used as the drop target.
+      if (moving.contains(to)) return;
+      final draggedOffset = moving.indexOf(from);
+      final remaining = [
+        for (var i = 0; i < _document.pageCount; i++)
+          if (!moving.contains(i)) i,
+      ];
+      final start = (to - draggedOffset).clamp(0, remaining.length);
+      final order = List<int>.of(remaining)..insertAll(start, moving);
+
+      _selected.clear();
+      final changed = apply((e) => e.reorderPages(order));
+      if (!changed) return;
+      _selectedPages.addAll([
+        for (var i = 0; i < moving.length; i++) start + i,
+      ]);
+      _pageSelectionAnchor = start + draggedOffset;
+      notifyListeners();
+      return;
+    }
     _selected.clear();
     _selectedPages.clear();
     _pageSelectionAnchor = null;

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -193,6 +193,11 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   /// page selection or viewer page supplies the starting point.
   int? _keyboardPage;
 
+  /// The selected tile currently driving a reorder. Other pages in the same
+  /// selection stay in place as dimmed placeholders while the proxy carries
+  /// the whole selection's page count.
+  int? _reorderPage;
+
   PdfEditingPreferences get _preferences => widget.controller.preferences;
 
   /// The pages the strip is previewing as a shift-click range: empty
@@ -685,9 +690,23 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                             padding: EdgeInsets.fromLTRB(
                                 inset, 8, _extraRightPadding + inset, 8),
                             itemCount: controller.document.pageCount,
+                            onReorderStart: (index) =>
+                                setState(() => _reorderPage = index),
+                            onReorderEnd: (_) {
+                              if (mounted) setState(() => _reorderPage = null);
+                            },
+                            proxyDecorator: (child, index, animation) {
+                              final count = controller.isPageSelected(index)
+                                  ? controller.selectedPageCount
+                                  : 1;
+                              return count > 1
+                                  ? _MultiPageDragProxy(
+                                      count: count, child: child)
+                                  : child;
+                            },
                             onReorderItem: controller.movePage,
                             itemBuilder: (context, index) {
-                              final tile = _PageTile(
+                              Widget tile = _PageTile(
                                 key: _tileKeys[index] ??= GlobalKey(),
                                 controller: controller,
                                 viewerController: widget.viewerController,
@@ -708,6 +727,17 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                                     _setHover(index, hovering),
                                 onFocusPage: _focusPage,
                               );
+                              if (_reorderPage != null &&
+                                  index != _reorderPage &&
+                                  controller.isPageSelected(_reorderPage!) &&
+                                  controller.isPageSelected(index)) {
+                                tile = Opacity(
+                                  key: ValueKey(
+                                      'pdf-thumbnail-reorder-companion-$index'),
+                                  opacity: 0.35,
+                                  child: tile,
+                                );
+                              }
                               // without the drag listener no reorder can ever start
                               return widget.allowPageEditing
                                   ? _ReorderDragStartListener(
@@ -1158,6 +1188,7 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
 
   bool _shiftHeld = HardwareKeyboard.instance.isShiftPressed;
   int? _keyboardPage;
+  int? _dragPage;
 
   Set<int> get _rangePreview => _shiftHeld && _hoverPage != null
       ? widget.controller.pageRangePreviewTo(_hoverPage!).toSet()
@@ -1520,6 +1551,19 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
                                             onHover: (hovering) =>
                                                 _setHover(i, hovering),
                                             onFocusPage: _focusPage,
+                                            dimmed: _dragPage != null &&
+                                                i != _dragPage &&
+                                                controller.isPageSelected(
+                                                    _dragPage!) &&
+                                                controller.isPageSelected(i),
+                                            onDragStarted: () =>
+                                                setState(() => _dragPage = i),
+                                            onDragEnded: () {
+                                              if (mounted) {
+                                                setState(
+                                                    () => _dragPage = null);
+                                              }
+                                            },
                                           ),
                                         ),
                                       ),
@@ -1605,8 +1649,9 @@ class _ThumbnailSizeControl extends StatelessWidget {
 /// reorder. A mouse picks a tile up immediately (it hovers first, so the
 /// cell knows a pointer is present); touch and stylus need a long press,
 /// so a finger drag still scrolls the grid. Dropping onto another cell
-/// moves the page there ([PdfEditingController.movePage]). With
-/// [allowPageEditing] off the cell is the bare tile - read-only grids
+/// moves the page there ([PdfEditingController.movePage]); if that page is
+/// part of a multi-page selection, the entire selection moves together.
+/// With [allowPageEditing] off the cell is the bare tile - read-only grids
 /// only navigate.
 class _GridPageCell extends StatefulWidget {
   const _GridPageCell({
@@ -1621,6 +1666,9 @@ class _GridPageCell extends StatefulWidget {
     required this.tileWidth,
     required this.renderWorker,
     required this.onActivatePage,
+    required this.dimmed,
+    required this.onDragStarted,
+    required this.onDragEnded,
     this.inRangePreview = false,
     this.showPageActions = true,
     this.onHover,
@@ -1638,6 +1686,9 @@ class _GridPageCell extends StatefulWidget {
   final double tileWidth;
   final PdfRenderWorker? renderWorker;
   final void Function(int pageIndex) onActivatePage;
+  final bool dimmed;
+  final VoidCallback onDragStarted;
+  final VoidCallback onDragEnded;
   final bool inRangePreview;
   final bool showPageActions;
   final void Function(bool hovering)? onHover;
@@ -1677,10 +1728,15 @@ class _GridPageCellState extends State<_GridPageCell> {
     final tile = _tile();
     if (!widget.allowPageEditing) return tile;
 
-    final draggable = MouseRegion(
-      onEnter: (_) => setState(() => _hasMouse = true),
-      onExit: (_) => setState(() => _hasMouse = false),
-      child: _draggable(tile),
+    final draggable = AnimatedOpacity(
+      key: ValueKey('pdf-thumbnail-grid-reorder-companion-${widget.pageIndex}'),
+      opacity: widget.dimmed ? 0.35 : 1,
+      duration: const Duration(milliseconds: 120),
+      child: MouseRegion(
+        onEnter: (_) => setState(() => _hasMouse = true),
+        onExit: (_) => setState(() => _hasMouse = false),
+        child: _draggable(tile),
+      ),
     );
     return DragTarget<int>(
       // a page never drops onto itself
@@ -1711,8 +1767,13 @@ class _GridPageCellState extends State<_GridPageCell> {
   }
 
   Widget _draggable(Widget tile) {
+    final selectedCount = widget.controller.isPageSelected(widget.pageIndex)
+        ? widget.controller.selectedPageCount
+        : 0;
     final feedback = _DragFeedback(
-      label: pdfL10n(context).thumbPageNumber(widget.pageIndex + 1),
+      label: selectedCount > 1
+          ? _dragPageCountLabel(context, selectedCount)
+          : pdfL10n(context).thumbPageNumber(widget.pageIndex + 1),
       width: widget.tileWidth,
     );
     // dim the page being dragged in place, leaving a gap-marker
@@ -1720,6 +1781,8 @@ class _GridPageCellState extends State<_GridPageCell> {
     return _hasMouse
         ? Draggable<int>(
             data: widget.pageIndex,
+            onDragStarted: widget.onDragStarted,
+            onDragEnd: (_) => widget.onDragEnded(),
             dragAnchorStrategy: pointerDragAnchorStrategy,
             feedback: feedback,
             childWhenDragging: placeholder,
@@ -1727,12 +1790,55 @@ class _GridPageCellState extends State<_GridPageCell> {
           )
         : LongPressDraggable<int>(
             data: widget.pageIndex,
+            onDragStarted: widget.onDragStarted,
+            onDragEnd: (_) => widget.onDragEnded(),
             dragAnchorStrategy: pointerDragAnchorStrategy,
             feedback: feedback,
             childWhenDragging: placeholder,
             child: tile,
           );
   }
+}
+
+String _dragPageCountLabel(BuildContext context, int count) =>
+    '$count ${pdfL10n(context).thumbPages.toLowerCase()}';
+
+/// Marks the reorder proxy as representing every selected page rather than
+/// only the thumbnail under the pointer.
+class _MultiPageDragProxy extends StatelessWidget {
+  const _MultiPageDragProxy({required this.count, required this.child});
+
+  final int count;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => Stack(
+        clipBehavior: Clip.none,
+        children: [
+          child,
+          Positioned(
+            top: 8,
+            right: 8,
+            child: Material(
+              key: const ValueKey('pdf-thumbnail-reorder-count'),
+              color: Theme.of(context).colorScheme.primary,
+              borderRadius: BorderRadius.circular(16),
+              elevation: 3,
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                child: Text(
+                  _dragPageCountLabel(context, count),
+                  style: TextStyle(
+                    color: Theme.of(context).colorScheme.onPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
 }
 
 /// The little card that rides the cursor while a grid tile is dragged.

--- a/packages/dart_pdf_editor/test/editing_page_ops_test.dart
+++ b/packages/dart_pdf_editor/test/editing_page_ops_test.dart
@@ -229,6 +229,53 @@ void main() {
       expect(editing.document.pageCount, 3);
     });
 
+    test('dragging a selected page reorders the whole selection', () {
+      final editing = PdfEditingController(buildMultiPagePdf(6));
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      editing.togglePageSelection(3);
+
+      editing.movePage(1, 4);
+
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 3', 'Page 5', 'Page 6', 'Page 2', 'Page 4']);
+      expect(editing.selectedPages, [4, 5]);
+      expect(editing.pageSelectionAnchor, 4);
+      editing.undo();
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 4', 'Page 5', 'Page 6']);
+    });
+
+    test('a selected-page reorder preserves order and clamps at an edge', () {
+      final editing = PdfEditingController(buildMultiPagePdf(6));
+      addTearDown(editing.dispose);
+      editing.selectPage(2);
+      editing.togglePageSelection(4);
+
+      // Page 5 is the dragged member, so it cannot itself land at zero while
+      // Page 3 remains before it. Clamp the two-page block instead.
+      editing.movePage(4, 0);
+
+      expect(labelsOf(editing.document),
+          ['Page 3', 'Page 5', 'Page 1', 'Page 2', 'Page 4', 'Page 6']);
+      expect(editing.selectedPages, [0, 1]);
+      expect(editing.pageSelectionAnchor, 1);
+    });
+
+    test('dropping a selected page on its selection is a no-op', () {
+      final editing = PdfEditingController(buildMultiPagePdf(5));
+      addTearDown(editing.dispose);
+      editing.selectPage(1);
+      editing.togglePageSelection(3);
+
+      editing.movePage(1, 3);
+
+      expect(labelsOf(editing.document),
+          ['Page 1', 'Page 2', 'Page 3', 'Page 4', 'Page 5']);
+      expect(editing.selectedPages, [1, 3]);
+      expect(editing.isModified, isFalse);
+    });
+
     test('a structural page edit clears the selection', () {
       final editing = PdfEditingController(buildMultiPagePdf(4));
       addTearDown(editing.dispose);
@@ -866,6 +913,50 @@ void main() {
       expect(chipBorderColor(2), Colors.transparent);
       expect(find.byIcon(Icons.check), findsNothing);
       await tester.pump(const Duration(seconds: 2));
+    });
+
+    testWidgets('multi-page reorder shows a count and dims companion pages',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final editing = PdfEditingController(buildMultiPagePdf(4));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Row(children: [
+            PdfThumbnailSidebar(controller: editing, viewerController: viewer),
+            const Expanded(child: SizedBox()),
+          ]),
+        ),
+      ));
+      await tester.pump();
+      editing.selectPage(1);
+      editing.selectPageRange(2);
+      await tester.pump();
+
+      final list = tester.widget<ReorderableListView>(
+        find.byType(ReorderableListView),
+      );
+      list.onReorderStart!(1);
+      await tester.pump();
+      final companion = tester.widget<Opacity>(
+        find.byKey(const ValueKey('pdf-thumbnail-reorder-companion-2')),
+      );
+      expect(companion.opacity, 0.35);
+
+      final proxy = list.proxyDecorator!(
+        const SizedBox(width: 100, height: 100),
+        1,
+        const AlwaysStoppedAnimation(1),
+      );
+      await tester.pumpWidget(MaterialApp(home: Scaffold(body: proxy)));
+      expect(find.byKey(const ValueKey('pdf-thumbnail-reorder-count')),
+          findsOneWidget);
+      expect(find.text('2 pages'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
### Motivation
- Allow dragging any page that is part of a multi-page selection to relocate the entire selected block while preserving document order and clamping the block at document edges.
- Improve thumbnail UI feedback during multi-page drag operations by dimming companion tiles and showing a count badge on the drag proxy.

### Description
- Updated `PdfEditingController.movePage` to detect when the dragged index is part of a multi-page selection and reorder the whole selected block as a unit, preserve selection positions, set the `pageSelectionAnchor`, and treat drops inside the selection as a no-op.
- Enhanced thumbnail sidebar and grid rendering in `editing_thumbnails.dart` by adding `onReorderStart`/`onReorderEnd`, a `proxyDecorator` that renders `_MultiPageDragProxy` for multi-page drags, companion dimming while reordering via `_reorderPage`/`_dragPage`, and a localized drag label via `_dragPageCountLabel`.
- Made grid cells support callbacks for drag start/end and animate dimming for non-dragged selected pages while a multi-page drag is active, and ensured drag feedback shows the selected page count when appropriate.
- Added the `_MultiPageDragProxy` widget and small UI polish to the `_DragFeedback` label logic.
- Modified `editing_page_ops_test.dart` to include unit tests for selection-aware reorders and a widget test verifying the multi-page reorder UI behavior.

### Testing
- Ran the modified unit tests in `editing_page_ops_test.dart` which include `dragging a selected page reorders the whole selection`, `a selected-page reorder preserves order and clamps at an edge`, and `dropping a selected page on its selection is a no-op`, and they passed.
- Executed the widget test `multi-page reorder shows a count and dims companion pages` (via the Flutter test runner), and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f1632dae4832b9a925d2830937e85)