### PR TITLE
Make scrollbar chapter markers optional and persistent

### DIFF
--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ar.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "عرض",
   "shellSettings": "الإعدادات",
   "shellShowAnnotations": "إظهار التعليقات التوضيحية",
+  "shellShowScrollbarChapters": "إظهار الفصول على شريط التمرير",
   "shellTabHere": "علامة تبويب هنا",
   "shellUnbound": "غير مربوط",
   "shellZoom": "تكبير",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_de.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Ansicht",
   "shellSettings": "Einstellungen",
   "shellShowAnnotations": "Anmerkungen anzeigen",
+  "shellShowScrollbarChapters": "Kapitel auf der Bildlaufleiste anzeigen",
   "shellTabHere": "Hier als Tab",
   "shellUnbound": "Nicht zugewiesen",
   "shellZoom": "Zoom",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_en.arb
@@ -1299,6 +1299,10 @@
   "@shellShowAnnotations": {
     "description": "Toggle label controlling whether annotations are shown."
   },
+  "shellShowScrollbarChapters": "Show chapters on scrollbar",
+  "@shellShowScrollbarChapters": {
+    "description": "Toggle label controlling whether PDF outline chapters appear as markers on the scrollbar."
+  },
   "shellTabHere": "Tab here",
   "@shellTabHere": {
     "description": "Drop hint shown when dragging a docked panel over another panel to combine them into a tabbed group."

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_es.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Vista",
   "shellSettings": "Ajustes",
   "shellShowAnnotations": "Mostrar anotaciones",
+  "shellShowScrollbarChapters": "Mostrar capítulos en la barra de desplazamiento",
   "shellTabHere": "Pestaña aquí",
   "shellUnbound": "Sin asignar",
   "shellZoom": "Zoom",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_fr.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Affichage",
   "shellSettings": "Paramètres",
   "shellShowAnnotations": "Afficher les annotations",
+  "shellShowScrollbarChapters": "Afficher les chapitres dans la barre de défilement",
   "shellTabHere": "Onglet ici",
   "shellUnbound": "Non attribué",
   "shellZoom": "Zoom",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_hi.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "दृश्य",
   "shellSettings": "सेटिंग्स",
   "shellShowAnnotations": "एनोटेशन दिखाएँ",
+  "shellShowScrollbarChapters": "स्क्रॉलबार पर अध्याय दिखाएँ",
   "shellTabHere": "यहाँ टैब करें",
   "shellUnbound": "अनबाउंड",
   "shellZoom": "ज़ूम",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_id.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Tampilan",
   "shellSettings": "Pengaturan",
   "shellShowAnnotations": "Tampilkan anotasi",
+  "shellShowScrollbarChapters": "Tampilkan bab pada bilah gulir",
   "shellTabHere": "Tab di sini",
   "shellUnbound": "Tak terikat",
   "shellZoom": "Zoom",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_it.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Vista",
   "shellSettings": "Impostazioni",
   "shellShowAnnotations": "Mostra annotazioni",
+  "shellShowScrollbarChapters": "Mostra capitoli sulla barra di scorrimento",
   "shellTabHere": "Scheda qui",
   "shellUnbound": "Non assegnato",
   "shellZoom": "Zoom",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ja.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "表示",
   "shellSettings": "設定",
   "shellShowAnnotations": "注釈を表示",
+  "shellShowScrollbarChapters": "スクロールバーに章を表示",
   "shellTabHere": "ここにタブ",
   "shellUnbound": "未割り当て",
   "shellZoom": "ズーム",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ko.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "보기",
   "shellSettings": "설정",
   "shellShowAnnotations": "주석 표시",
+  "shellShowScrollbarChapters": "스크롤바에 장 표시",
   "shellTabHere": "여기에 탭",
   "shellUnbound": "미지정",
   "shellZoom": "확대/축소",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations.dart
@@ -1922,6 +1922,12 @@ abstract class DartPdfEditorLocalizations {
   /// **'Show annotations'**
   String get shellShowAnnotations;
 
+  /// Toggle label controlling whether PDF outline chapters appear as markers on the scrollbar.
+  ///
+  /// In en, this message translates to:
+  /// **'Show chapters on scrollbar'**
+  String get shellShowScrollbarChapters;
+
   /// Drop hint shown when dragging a docked panel over another panel to combine them into a tabbed group.
   ///
   /// In en, this message translates to:

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -1005,7 +1005,7 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'إظهار التعليقات التوضيحية';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => 'إظهار الفصول على شريط التمرير';
 
   @override
   String get shellTabHere => 'علامة تبويب هنا';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ar.dart
@@ -1005,6 +1005,9 @@ class DartPdfEditorLocalizationsAr extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'إظهار التعليقات التوضيحية';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'علامة تبويب هنا';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -992,6 +992,9 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Anmerkungen anzeigen';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Hier als Tab';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_de.dart
@@ -992,7 +992,8 @@ class DartPdfEditorLocalizationsDe extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Anmerkungen anzeigen';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Kapitel auf der Bildlaufleiste anzeigen';
 
   @override
   String get shellTabHere => 'Hier als Tab';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_en.dart
@@ -989,6 +989,9 @@ class DartPdfEditorLocalizationsEn extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Show annotations';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Tab here';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -992,7 +992,8 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Mostrar anotaciones';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Mostrar capítulos en la barra de desplazamiento';
 
   @override
   String get shellTabHere => 'Pestaña aquí';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_es.dart
@@ -992,6 +992,9 @@ class DartPdfEditorLocalizationsEs extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Mostrar anotaciones';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Pestaña aquí';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -994,6 +994,9 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Afficher les annotations';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Onglet ici';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_fr.dart
@@ -994,7 +994,8 @@ class DartPdfEditorLocalizationsFr extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Afficher les annotations';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Afficher les chapitres dans la barre de défilement';
 
   @override
   String get shellTabHere => 'Onglet ici';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -989,6 +989,9 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'एनोटेशन दिखाएँ';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'यहाँ टैब करें';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_hi.dart
@@ -989,7 +989,7 @@ class DartPdfEditorLocalizationsHi extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'एनोटेशन दिखाएँ';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => 'स्क्रॉलबार पर अध्याय दिखाएँ';
 
   @override
   String get shellTabHere => 'यहाँ टैब करें';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -992,7 +992,7 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Tampilkan anotasi';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => 'Tampilkan bab pada bilah gulir';
 
   @override
   String get shellTabHere => 'Tab di sini';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_id.dart
@@ -992,6 +992,9 @@ class DartPdfEditorLocalizationsId extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Tampilkan anotasi';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Tab di sini';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -993,7 +993,8 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Mostra annotazioni';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Mostra capitoli sulla barra di scorrimento';
 
   @override
   String get shellTabHere => 'Scheda qui';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_it.dart
@@ -993,6 +993,9 @@ class DartPdfEditorLocalizationsIt extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Mostra annotazioni';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Scheda qui';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -986,7 +986,7 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => '注釈を表示';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => 'スクロールバーに章を表示';
 
   @override
   String get shellTabHere => 'ここにタブ';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ja.dart
@@ -986,6 +986,9 @@ class DartPdfEditorLocalizationsJa extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => '注釈を表示';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'ここにタブ';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -986,6 +986,9 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => '주석 표시';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => '여기에 탭';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ko.dart
@@ -986,7 +986,7 @@ class DartPdfEditorLocalizationsKo extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => '주석 표시';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => '스크롤바에 장 표시';
 
   @override
   String get shellTabHere => '여기에 탭';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -992,6 +992,9 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Annotaties tonen';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Tabblad hier';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_nl.dart
@@ -992,7 +992,8 @@ class DartPdfEditorLocalizationsNl extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Annotaties tonen';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Hoofdstukken op de schuifbalk tonen';
 
   @override
   String get shellTabHere => 'Tabblad hier';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -1004,6 +1004,9 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Pokaż adnotacje';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Dodaj jako kartę';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pl.dart
@@ -1004,7 +1004,8 @@ class DartPdfEditorLocalizationsPl extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Pokaż adnotacje';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Pokaż rozdziały na pasku przewijania';
 
   @override
   String get shellTabHere => 'Dodaj jako kartę';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -993,7 +993,8 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Mostrar anotações';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Mostrar capítulos na barra de rolagem';
 
   @override
   String get shellTabHere => 'Agrupar em aba aqui';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_pt.dart
@@ -993,6 +993,9 @@ class DartPdfEditorLocalizationsPt extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Mostrar anotações';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Agrupar em aba aqui';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -1004,7 +1004,8 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Показывать аннотации';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Показывать главы на полосе прокрутки';
 
   @override
   String get shellTabHere => 'Вкладка сюда';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_ru.dart
@@ -1004,6 +1004,9 @@ class DartPdfEditorLocalizationsRu extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Показывать аннотации';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Вкладка сюда';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -989,7 +989,7 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'แสดงคำอธิบายประกอบ';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => 'แสดงบทบนแถบเลื่อน';
 
   @override
   String get shellTabHere => 'แท็บที่นี่';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_th.dart
@@ -989,6 +989,9 @@ class DartPdfEditorLocalizationsTh extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'แสดงคำอธิบายประกอบ';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'แท็บที่นี่';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -990,6 +990,9 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Ek açıklamaları göster';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Buraya sekmele';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_tr.dart
@@ -990,7 +990,8 @@ class DartPdfEditorLocalizationsTr extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Ek açıklamaları göster';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Kaydırma çubuğunda bölümleri göster';
 
   @override
   String get shellTabHere => 'Buraya sekmele';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -1003,7 +1003,8 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Показувати анотації';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters =>
+      'Показувати розділи на смузі прокручування';
 
   @override
   String get shellTabHere => 'Вкладка тут';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_uk.dart
@@ -1003,6 +1003,9 @@ class DartPdfEditorLocalizationsUk extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Показувати анотації';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Вкладка тут';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -992,7 +992,7 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Hiện chú thích';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => 'Hiện các chương trên thanh cuộn';
 
   @override
   String get shellTabHere => 'Ghép thẻ tại đây';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_vi.dart
@@ -992,6 +992,9 @@ class DartPdfEditorLocalizationsVi extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => 'Hiện chú thích';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => 'Ghép thẻ tại đây';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -985,6 +985,9 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => '显示注释';
 
   @override
+  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+
+  @override
   String get shellTabHere => '停靠为标签页';
 
   @override

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_localizations_zh.dart
@@ -985,7 +985,7 @@ class DartPdfEditorLocalizationsZh extends DartPdfEditorLocalizations {
   String get shellShowAnnotations => '显示注释';
 
   @override
-  String get shellShowScrollbarChapters => 'Show chapters on scrollbar';
+  String get shellShowScrollbarChapters => '在滚动条上显示章节';
 
   @override
   String get shellTabHere => '停靠为标签页';
@@ -2970,6 +2970,9 @@ class DartPdfEditorLocalizationsZhHant extends DartPdfEditorLocalizationsZh {
 
   @override
   String get shellShowAnnotations => '顯示註解';
+
+  @override
+  String get shellShowScrollbarChapters => '在捲動軸上顯示章節';
 
   @override
   String get shellTabHere => '在此建立分頁';

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_nl.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Weergave",
   "shellSettings": "Instellingen",
   "shellShowAnnotations": "Annotaties tonen",
+  "shellShowScrollbarChapters": "Hoofdstukken op de schuifbalk tonen",
   "shellTabHere": "Tabblad hier",
   "shellUnbound": "Niet toegewezen",
   "shellZoom": "Zoom",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pl.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Widok",
   "shellSettings": "Ustawienia",
   "shellShowAnnotations": "Pokaż adnotacje",
+  "shellShowScrollbarChapters": "Pokaż rozdziały na pasku przewijania",
   "shellTabHere": "Dodaj jako kartę",
   "shellUnbound": "Nieprzypisane",
   "shellZoom": "Powiększenie",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_pt.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Exibição",
   "shellSettings": "Configurações",
   "shellShowAnnotations": "Mostrar anotações",
+  "shellShowScrollbarChapters": "Mostrar capítulos na barra de rolagem",
   "shellTabHere": "Agrupar em aba aqui",
   "shellUnbound": "Não vinculado",
   "shellZoom": "Zoom",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_ru.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Вид",
   "shellSettings": "Настройки",
   "shellShowAnnotations": "Показывать аннотации",
+  "shellShowScrollbarChapters": "Показывать главы на полосе прокрутки",
   "shellTabHere": "Вкладка сюда",
   "shellUnbound": "Не назначено",
   "shellZoom": "Масштаб",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_th.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "มุมมอง",
   "shellSettings": "การตั้งค่า",
   "shellShowAnnotations": "แสดงคำอธิบายประกอบ",
+  "shellShowScrollbarChapters": "แสดงบทบนแถบเลื่อน",
   "shellTabHere": "แท็บที่นี่",
   "shellUnbound": "ไม่ได้กำหนด",
   "shellZoom": "ซูม",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_tr.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Görünüm",
   "shellSettings": "Ayarlar",
   "shellShowAnnotations": "Ek açıklamaları göster",
+  "shellShowScrollbarChapters": "Kaydırma çubuğunda bölümleri göster",
   "shellTabHere": "Buraya sekmele",
   "shellUnbound": "Atanmamış",
   "shellZoom": "Yakınlaştırma",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_uk.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Перегляд",
   "shellSettings": "Налаштування",
   "shellShowAnnotations": "Показувати анотації",
+  "shellShowScrollbarChapters": "Показувати розділи на смузі прокручування",
   "shellTabHere": "Вкладка тут",
   "shellUnbound": "Не призначено",
   "shellZoom": "Масштаб",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_vi.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "Xem",
   "shellSettings": "Cài đặt",
   "shellShowAnnotations": "Hiện chú thích",
+  "shellShowScrollbarChapters": "Hiện các chương trên thanh cuộn",
   "shellTabHere": "Ghép thẻ tại đây",
   "shellUnbound": "Chưa gán",
   "shellZoom": "Thu phóng",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "视图",
   "shellSettings": "设置",
   "shellShowAnnotations": "显示注释",
+  "shellShowScrollbarChapters": "在滚动条上显示章节",
   "shellTabHere": "停靠为标签页",
   "shellUnbound": "未绑定",
   "shellZoom": "缩放",

--- a/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
+++ b/packages/dart_pdf_editor/lib/l10n/dart_pdf_editor_zh_Hant.arb
@@ -318,6 +318,7 @@
   "shellSectionView": "檢視",
   "shellSettings": "設定",
   "shellShowAnnotations": "顯示註解",
+  "shellShowScrollbarChapters": "在捲動軸上顯示章節",
   "shellTabHere": "在此建立分頁",
   "shellUnbound": "未綁定",
   "shellZoom": "縮放",

--- a/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_preferences.dart
@@ -79,6 +79,7 @@ class PdfEditingPreferences extends ChangeNotifier {
   List<String> _recentFonts = const [];
   Color _pageColor = const Color(0xFFFFFFFF);
   bool _showAnnotations = true;
+  bool _showScrollbarChapters = false;
   bool _highlightFormFields = true;
   bool _showReflowView = false;
   bool _showThumbnailView = false;
@@ -238,6 +239,9 @@ class PdfEditingPreferences extends ChangeNotifier {
       if (pageColor != null) _pageColor = Color(pageColor);
       _showAnnotations =
           store.getBool('${_prefix}showAnnotations') ?? _showAnnotations;
+      _showScrollbarChapters =
+          store.getBool('${_prefix}showScrollbarChapters') ??
+              _showScrollbarChapters;
       _highlightFormFields = store.getBool('${_prefix}highlightFormFields') ??
           _highlightFormFields;
       _showReflowView =
@@ -266,8 +270,8 @@ class PdfEditingPreferences extends ChangeNotifier {
       _searchWholeWord =
           store.getBool('${_prefix}searchWholeWord') ?? _searchWholeWord;
       _searchRegex = store.getBool('${_prefix}searchRegex') ?? _searchRegex;
-      _searchAnnotations = store.getBool('${_prefix}searchAnnotations') ??
-          _searchAnnotations;
+      _searchAnnotations =
+          store.getBool('${_prefix}searchAnnotations') ?? _searchAnnotations;
       _propertiesPanelWidth =
           store.getDouble('${_prefix}propertiesPanelWidth') ??
               _propertiesPanelWidth;
@@ -976,6 +980,17 @@ class PdfEditingPreferences extends ChangeNotifier {
     if (value == _showAnnotations) return;
     _showAnnotations = value;
     _write((s) => s.setBool('${_prefix}showAnnotations', value));
+    notifyListeners();
+  }
+
+  /// Whether document outline entries appear as chapter markers on the
+  /// viewer's main scrollbar. A display setting only, off by default.
+  bool get showScrollbarChapters => _showScrollbarChapters;
+
+  set showScrollbarChapters(bool value) {
+    if (value == _showScrollbarChapters) return;
+    _showScrollbarChapters = value;
+    _write((s) => s.setBool('${_prefix}showScrollbarChapters', value));
     notifyListeners();
   }
 

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -1369,6 +1369,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         backgroundColor: widget.backgroundColor,
                         pageColor: pageColor,
                         showAnnotations: prefs.showAnnotations,
+                        showScrollbarChapters: prefs.showScrollbarChapters,
                         highlightFormFields: prefs.highlightFormFields,
                         renderWorker: _shell.worker,
                         performance: _performance,

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -527,6 +527,7 @@ class _PdfReaderState extends State<PdfReader> {
                           backgroundColor: widget.backgroundColor,
                           pageColor: pageColor,
                           showAnnotations: prefs.showAnnotations,
+                          showScrollbarChapters: prefs.showScrollbarChapters,
                           highlightFormFields: prefs.highlightFormFields,
                           renderWorker: _shell.worker,
                           performance: _performance,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -950,6 +950,7 @@ class PdfViewer extends StatefulWidget {
     this.backgroundColor,
     this.pageColor = const Color(0xFFFFFFFF),
     this.showAnnotations = true,
+    this.showScrollbarChapters = false,
     this.highlightFormFields = true,
     this.interactiveForms = true,
     this.pagePreviews = true,
@@ -1269,6 +1270,10 @@ class PdfViewer extends StatefulWidget {
   /// and editing tools still work but draw over an unannotated page -
   /// hosts typically disarm editing while hiding.
   final bool showAnnotations;
+
+  /// Whether outline/bookmark destinations are shown as labelled markers on
+  /// the main scrollbar. Off by default to keep the scrollbar uncluttered.
+  final bool showScrollbarChapters;
 
   /// Washes every visible form-field widget with a translucent tint and
   /// a hairline border, the way desktop PDF editors mark fields - most
@@ -2554,6 +2559,7 @@ class _PdfViewerState extends State<PdfViewer>
     final count = document.pageCount;
     _pages = [for (var i = 0; i < count; i++) document.page(i)];
     _pageLabels = null; // recompute lazily for the (possibly new) document
+    _outline = null; // outline entries may change in an editing revision
     _recomputeAspects();
     _controller._setPageCount(count);
   }
@@ -2561,8 +2567,62 @@ class _PdfViewerState extends State<PdfViewer>
   /// The document's logical page labels (/PageLabels), parsed once per
   /// document and reset on a document swap in [_loadPages].
   PdfPageLabels? _pageLabels;
+  PdfOutline? _outline;
   PdfPageLabels get _labels =>
       _pageLabels ??= PdfPageLabels.of(_document);
+
+  PdfOutline get _documentOutline => _outline ??= PdfOutline.of(_document);
+
+  /// Scroll-track chapter ticks derived from the PDF outline. A breadcrumb
+  /// keeps nested headings understandable without permanently taking space
+  /// from the document; it appears only in the tick's tooltip.
+  List<PdfScrollbarMarker> _outlineScrollMarkers() {
+    var total = _pages.length * widget.pageSpacing;
+    for (var i = 0; i < _pages.length; i++) {
+      total += _pageMain(i);
+    }
+    if (total <= 0) return const [];
+    final markers = <PdfScrollbarMarker>[];
+
+    void visit(List<PdfOutlineItem> items, List<String> parents) {
+      for (final item in items) {
+        final title = item.title.trim();
+        final path = title.isEmpty ? parents : [...parents, title];
+        final destination = item.destination;
+        if (destination != null &&
+            destination.pageIndex >= 0 &&
+            destination.pageIndex < _pages.length) {
+          final page = destination.pageIndex;
+          var offset = _mainOffsetOf(page);
+          final box = _pages[page].cropBox;
+          if (_horizontal) {
+            final left = destination.left;
+            if (left != null && box.width > 0) {
+              offset += ((left - box.left) / box.width).clamp(0.0, 1.0) *
+                  _pageMain(page);
+            }
+          } else {
+            final top = destination.top;
+            if (top != null && box.height > 0) {
+              offset += ((box.top - top) / box.height).clamp(0.0, 1.0) *
+                  _pageMain(page);
+            }
+          }
+          markers.add(PdfScrollbarMarker(
+            position: (offset / total).clamp(0.0, 1.0),
+            label: path.isEmpty
+                ? 'Page ${_pageLabelFor(page)}'
+                : path.join(' › '),
+            onTap: () => _controller.showDestination(destination),
+          ));
+        }
+        visit(item.children, path);
+      }
+    }
+
+    visit(_documentOutline.items, const []);
+    return markers;
+  }
 
   /// The logical label for page [index], or its 1-based number when the
   /// document carries no labels.
@@ -6064,6 +6124,9 @@ class _PdfViewerState extends State<PdfViewer>
                     minOverflow: widget.pageSpacing,
                     onScrollBy: _scrollbarScrollBy,
                     thumbKey: const ValueKey('pdf-scrollbar-thumb'),
+                    markers: widget.showScrollbarChapters
+                        ? _outlineScrollMarkers()
+                        : const [],
                   )),
                 _positionedScrollbar(PdfScrollbar(
                   axis: _horizontal ? Axis.vertical : Axis.horizontal,

--- a/packages/dart_pdf_editor/lib/src/scrollbar.dart
+++ b/packages/dart_pdf_editor/lib/src/scrollbar.dart
@@ -32,7 +32,9 @@ class PdfScrollbar extends StatefulWidget {
     this.viewExtent,
     this.onScrollBy,
     this.thumbKey,
-  })  : assert(scroll != null || viewExtent != null,
+    this.markers = const [],
+  })  : assert(
+            scroll != null || viewExtent != null,
             'a scroll-driven bar needs a controller; a transform-only bar '
             'needs the cross-axis view extent'),
         assert(scroll != null || transform != null,
@@ -68,6 +70,11 @@ class PdfScrollbar extends StatefulWidget {
 
   /// A key for the thumb itself, for tests.
   final Key? thumbKey;
+
+  /// Named locations painted as ticks on the track. The stock viewer uses
+  /// these for PDF outline entries (bookmarks/chapters). Hovering a tick
+  /// reveals its title and activating it follows the outline destination.
+  final List<PdfScrollbarMarker> markers;
 
   @override
   State<PdfScrollbar> createState() => _PdfScrollbarState();
@@ -186,6 +193,14 @@ class _PdfScrollbarState extends State<PdfScrollbar> {
         if (thumb == null) return const SizedBox.shrink();
         final (thumbPos, thumbExtent) = thumb;
         final active = _hovered || _dragging;
+        PdfScrollbarMarker? markerAt(double at) {
+          for (final marker in widget.markers.reversed) {
+            final center = marker.position.clamp(0.0, 1.0) * trackExtent;
+            if ((at - center).abs() <= 5) return marker;
+          }
+          return null;
+        }
+
         void dragStart(DragStartDetails details) {
           final at =
               _vertical ? details.localPosition.dy : details.localPosition.dx;
@@ -219,6 +234,11 @@ class _PdfScrollbarState extends State<PdfScrollbar> {
               final at = _vertical
                   ? details.localPosition.dy
                   : details.localPosition.dx;
+              final marker = markerAt(at);
+              if (marker != null) {
+                marker.onTap?.call();
+                return;
+              }
               // a tap on the thumb itself is not a jump
               if (at < thumbPos || at > thumbPos + thumbExtent) {
                 _jumpTo(at, trackExtent);
@@ -244,6 +264,42 @@ class _PdfScrollbarState extends State<PdfScrollbar> {
                           ? theme?.trackActiveColor ?? _defaultTrackActive
                           : theme?.trackColor ?? _defaultTrack),
                 ),
+                for (var i = 0; i < widget.markers.length; i++)
+                  Positioned(
+                    top: _vertical
+                        ? (trackExtent - 10) *
+                            widget.markers[i].position.clamp(0.0, 1.0)
+                        : null,
+                    left: _vertical
+                        ? 1
+                        : (trackExtent - 10) *
+                            widget.markers[i].position.clamp(0.0, 1.0),
+                    right: _vertical ? 1 : null,
+                    bottom: _vertical ? null : 1,
+                    width: _vertical ? null : 10,
+                    height: _vertical ? 10 : null,
+                    child: Tooltip(
+                      message: widget.markers[i].label,
+                      preferBelow: false,
+                      child: Semantics(
+                        button: widget.markers[i].onTap != null,
+                        label: widget.markers[i].label,
+                        onTap: widget.markers[i].onTap,
+                        child: SizedBox(
+                          key: ValueKey('pdf-scrollbar-marker-$i'),
+                          child: Center(
+                            child: SizedBox(
+                              width: _vertical ? double.infinity : 3,
+                              height: _vertical ? 3 : double.infinity,
+                              child: ColoredBox(
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
                 Positioned(
                   top: _vertical ? thumbPos : null,
                   left: _vertical ? null : thumbPos,
@@ -272,4 +328,22 @@ class _PdfScrollbarState extends State<PdfScrollbar> {
       }),
     );
   }
+}
+
+/// A labelled location on a [PdfScrollbar] track.
+class PdfScrollbarMarker {
+  const PdfScrollbarMarker({
+    required this.position,
+    required this.label,
+    this.onTap,
+  });
+
+  /// Location along the document, normalized from 0 to 1.
+  final double position;
+
+  /// Tooltip and accessibility label (normally an outline title).
+  final String label;
+
+  /// Invoked when the tick is activated.
+  final VoidCallback? onTap;
 }

--- a/packages/dart_pdf_editor/lib/src/shell_chrome.dart
+++ b/packages/dart_pdf_editor/lib/src/shell_chrome.dart
@@ -1198,6 +1198,7 @@ void _maybeCloseShellControls(BuildContext context) {
 
 enum _ViewOption {
   annotations,
+  scrollbarChapters,
   formHighlight,
   reflow,
   pageGrid,
@@ -1219,6 +1220,8 @@ Future<void> _selectViewOption(
   switch (option) {
     case _ViewOption.annotations:
       preferences.showAnnotations = !preferences.showAnnotations;
+    case _ViewOption.scrollbarChapters:
+      preferences.showScrollbarChapters = !preferences.showScrollbarChapters;
     case _ViewOption.formHighlight:
       preferences.highlightFormFields = !preferences.highlightFormFields;
     case _ViewOption.reflow:
@@ -1566,6 +1569,22 @@ Future<void> showPdfShellViewOptionsSheet(
                 },
               ),
               SwitchListTile(
+                key: const ValueKey('pdf-shell-show-scrollbar-chapters'),
+                secondary: const Icon(Icons.bookmarks_outlined),
+                title: Text(pdfL10n(context).shellShowScrollbarChapters),
+                value: preferences.showScrollbarChapters,
+                onChanged: (_) async {
+                  await _selectViewOption(
+                    context,
+                    _ViewOption.scrollbarChapters,
+                    preferences: preferences,
+                    pageColor: pageColor,
+                    onAuthorPressed: onAuthorPressed,
+                  );
+                  setSheetState(() {});
+                },
+              ),
+              SwitchListTile(
                 key: const ValueKey('pdf-shell-highlight-forms'),
                 secondary: const Icon(Icons.dynamic_form_outlined),
                 title: Text(pdfL10n(context).shellHighlightFormFields),
@@ -1759,6 +1778,12 @@ class PdfShellViewOptionsButton extends StatelessWidget {
           value: _ViewOption.annotations,
           checked: preferences.showAnnotations,
           child: Text(pdfL10n(context).shellShowAnnotations),
+        ),
+        CheckedPopupMenuItem(
+          key: const ValueKey('pdf-shell-show-scrollbar-chapters'),
+          value: _ViewOption.scrollbarChapters,
+          checked: preferences.showScrollbarChapters,
+          child: Text(pdfL10n(context).shellShowScrollbarChapters),
         ),
         CheckedPopupMenuItem(
           key: const ValueKey('pdf-shell-highlight-forms'),

--- a/packages/dart_pdf_editor/test/editing_preferences_test.dart
+++ b/packages/dart_pdf_editor/test/editing_preferences_test.dart
@@ -23,6 +23,7 @@ void main() {
       a.author = 'Ben';
       a.colorPickerFormat = PdfColorFormat.cmyk;
       a.highlightFormFields = false;
+      a.showScrollbarChapters = true;
       a.showReflowView = true;
       a.lineStartEnding = PdfLineEnding.circle;
       a.lineEndEnding = PdfLineEnding.closedArrow;
@@ -48,6 +49,7 @@ void main() {
       expect(b.author, 'Ben');
       expect(b.colorPickerFormat, PdfColorFormat.cmyk);
       expect(b.highlightFormFields, isFalse);
+      expect(b.showScrollbarChapters, isTrue);
       expect(b.showReflowView, isTrue);
       expect(b.lineStartEnding, PdfLineEnding.circle);
       expect(b.lineEndEnding, PdfLineEnding.closedArrow);
@@ -139,6 +141,7 @@ void main() {
       expect(prefs.lineStartEnding, PdfLineEnding.none);
       expect(prefs.lineEndEnding, PdfLineEnding.none);
       expect(prefs.highlightFormFields, isTrue);
+      expect(prefs.showScrollbarChapters, isFalse);
       expect(prefs.showReflowView, isFalse);
       expect(prefs.searchMatchCase, isFalse);
       expect(prefs.searchWholeWord, isFalse);

--- a/packages/dart_pdf_editor/test/pdf_scrollbar_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_scrollbar_test.dart
@@ -11,20 +11,21 @@ void main() {
       {int pages = 5,
       PdfViewerFit fit = PdfViewerFit.width,
       PdfDocument? document,
-      bool showScrollbarChapters = false}) async {
-    final controller = PdfViewerController();
+      bool showScrollbarChapters = false,
+      PdfViewerController? controller}) async {
+    final resolvedController = controller ?? PdfViewerController();
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: PdfViewer(
           initialFit: fit,
           document: document ?? PdfDocument.open(buildMultiPagePdf(pages)),
-          controller: controller,
+          controller: resolvedController,
           showScrollbarChapters: showScrollbarChapters,
         ),
       ),
     ));
     await tester.pump();
-    return controller;
+    return resolvedController;
   }
 
   ScrollPosition scrollPosition(WidgetTester tester) =>
@@ -65,12 +66,14 @@ void main() {
     final editing = PdfEditingController(buildMultiPagePdf(5))
       ..addBookmark('Introduction', pageIndex: 0)
       ..addBookmark('Chapter 2', pageIndex: 3, parentPath: [0]);
-    await pumpViewer(tester, document: editing.document);
+    final controller = await pumpViewer(tester, document: editing.document);
 
     expect(find.byKey(const ValueKey('pdf-scrollbar-marker-0')), findsNothing);
 
-    final controller = await pumpViewer(tester,
-        document: editing.document, showScrollbarChapters: true);
+    await pumpViewer(tester,
+        document: editing.document,
+        showScrollbarChapters: true,
+        controller: controller);
 
     expect(
         find.byKey(const ValueKey('pdf-scrollbar-marker-0')), findsOneWidget);

--- a/packages/dart_pdf_editor/test/pdf_scrollbar_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_scrollbar_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
@@ -7,14 +8,18 @@ void main() {
   const thumb = ValueKey('pdf-scrollbar-thumb');
 
   Future<PdfViewerController> pumpViewer(WidgetTester tester,
-      {int pages = 5, PdfViewerFit fit = PdfViewerFit.width}) async {
+      {int pages = 5,
+      PdfViewerFit fit = PdfViewerFit.width,
+      PdfDocument? document,
+      bool showScrollbarChapters = false}) async {
     final controller = PdfViewerController();
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         body: PdfViewer(
           initialFit: fit,
-          document: PdfDocument.open(buildMultiPagePdf(pages)),
+          document: document ?? PdfDocument.open(buildMultiPagePdf(pages)),
           controller: controller,
+          showScrollbarChapters: showScrollbarChapters,
         ),
       ),
     ));
@@ -53,6 +58,41 @@ void main() {
     scrollPosition(tester).jumpTo(1000);
     await tester.pump();
     expect(tester.getTopLeft(find.byKey(thumb)).dy, greaterThan(before));
+  });
+
+  testWidgets('outline chapters appear on the track and navigate',
+      (tester) async {
+    final editing = PdfEditingController(buildMultiPagePdf(5))
+      ..addBookmark('Introduction', pageIndex: 0)
+      ..addBookmark('Chapter 2', pageIndex: 3, parentPath: [0]);
+    await pumpViewer(tester, document: editing.document);
+
+    expect(find.byKey(const ValueKey('pdf-scrollbar-marker-0')), findsNothing);
+
+    final controller = await pumpViewer(tester,
+        document: editing.document, showScrollbarChapters: true);
+
+    expect(
+        find.byKey(const ValueKey('pdf-scrollbar-marker-0')), findsOneWidget);
+    expect(
+        find.byKey(const ValueKey('pdf-scrollbar-marker-1')), findsOneWidget);
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer();
+    await mouse.moveTo(
+        tester.getCenter(find.byKey(const ValueKey('pdf-scrollbar-marker-1'))));
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(find.text('Introduction › Chapter 2'), findsOneWidget);
+    await mouse.moveTo(const Offset(400, 300));
+    await tester.pumpAndSettle();
+
+    final chapterMarker =
+        tester.getCenter(find.byKey(const ValueKey('pdf-scrollbar-marker-1')));
+    await mouse.moveTo(chapterMarker);
+    await mouse.down(chapterMarker);
+    await mouse.up();
+    await tester.pumpAndSettle();
+    expect(controller.currentPage, 3);
   });
 
   testWidgets('dragging the thumb scrolls the document', (tester) async {

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -206,7 +206,7 @@ void main() {
       expect(viewer.pageCount, 3);
     });
 
-    testWidgets('view options menu toggles annotation visibility',
+    testWidgets('view options menu toggles persisted display settings',
         (tester) async {
       final prefs = PdfEditingPreferences();
       addTearDown(prefs.dispose);
@@ -220,6 +220,21 @@ void main() {
           kind: PointerDeviceKind.mouse);
       await tester.pumpAndSettle();
       expect(prefs.showAnnotations, isFalse);
+
+      expect(prefs.showScrollbarChapters, isFalse);
+      await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      await tester.tap(
+          find.byKey(const ValueKey('pdf-shell-show-scrollbar-chapters')),
+          kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+      expect(prefs.showScrollbarChapters, isTrue);
+      expect(
+          tester
+              .widget<PdfViewer>(find.byType(PdfViewer))
+              .showScrollbarChapters,
+          isTrue);
     });
 
     testWidgets('view options can switch to reflow text', (tester) async {
@@ -437,7 +452,8 @@ void main() {
               find.byKey(const ValueKey('pdf-shell-shortcut-group-shapes')))
           .dy;
       final rectY = tester
-          .getTopLeft(find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')))
+          .getTopLeft(
+              find.byKey(const ValueKey('pdf-shell-shortcut-rectangle')))
           .dy;
       expect(headerY, lessThan(rectY));
 
@@ -1775,7 +1791,8 @@ void main() {
       }
     });
 
-    testWidgets('the overflow scroller never drag-scrolls, so its controls '
+    testWidgets(
+        'the overflow scroller never drag-scrolls, so its controls '
         'stay tappable (macOS trackpad)', (tester) async {
       await pump(
           tester, PdfEditorView(bytes: buildMultiPagePdf(2), onSave: (_) {}));


### PR DESCRIPTION
### Motivation

- Chapter ticks derived from the PDF outline are useful but may clutter the scrollbar, so they should be opt-in and remembered across sessions. 

### Description

- Added a persisted preference `PdfEditingPreferences.showScrollbarChapters` (default `false`) with getters/setters and stored restoration. (`lib/src/editing/editing_preferences.dart`)
- Plumbed a `showScrollbarChapters` option into `PdfViewer` and `PdfEditorView` and only construct/pass `markers` when the option is enabled. (`lib/src/pdf_viewer.dart`, `lib/src/pdf_editor_view.dart`)
- Exposed the toggle in the UI both in the popup and compact Settings sheet and added the localizable string `shellShowScrollbarChapters`; regenerated l10n bindings. (`lib/src/shell_chrome.dart`, `lib/l10n/*.arb`, generated localization files)
- Updated scrollbar/marker wiring and tests to verify default-off behavior, opt-in rendering/navigation, Settings toggle, and preference persistence; adjusted `test/pdf_scrollbar_test.dart`, `test/editing_preferences_test.dart`, and `test/pdf_shell_test.dart` accordingly. (`test/*`) 

### Testing

- Ran `flutter gen-l10n` and code format (`dart format`) successfully to refresh localization bindings and style. 
- Verified `git diff --check` and addressed issues before committing. 
- Updated widget tests `test/pdf_scrollbar_test.dart`, `test/editing_preferences_test.dart`, and `test/pdf_shell_test.dart`; a focused `flutter test` run was started but the test harness was interrupted by the command runner before final results could be produced, so full CI should validate the updated tests and run `dart analyze` across the package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a660266faac832b86d857ff64199945)