### PR TITLE
Prevent macOS ranged-read errors from aborting DartPDF

### DIFF
--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		DA0CDD0E000000000000FB01 /* FileRangeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0CDD0E000000000000FA01 /* FileRangeReader.swift */; };
+		DA0CDD0E000000000000FB02 /* FileRangeReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA0CDD0E000000000000FA01 /* FileRangeReader.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		7B0F3384F791AEE9E0B4DFE9 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 670117DDCED554434E9B1814 /* Pods_Runner.framework */; };
 		DA0CDD0C000000000000FB02 /* DocumentIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = DA0CDD0C000000000000FA01 /* DocumentIcon.icns */; };
@@ -75,6 +77,7 @@
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
+		DA0CDD0E000000000000FA01 /* FileRangeReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileRangeReader.swift; sourceTree = "<group>"; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
@@ -183,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
+				DA0CDD0E000000000000FA01 /* FileRangeReader.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
@@ -464,6 +468,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA0CDD0E000000000000FB02 /* FileRangeReader.swift in Sources */,
 				331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -472,6 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA0CDD0E000000000000FB01 /* FileRangeReader.swift in Sources */,
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
@@ -517,7 +523,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.milanko.dartPdfEditorApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dart_pdf_editor_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/dart_pdf_editor_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DartPDF.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DartPDF";
 			};
 			name = Debug;
 		};
@@ -532,7 +538,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.milanko.dartPdfEditorApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dart_pdf_editor_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/dart_pdf_editor_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DartPDF.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DartPDF";
 			};
 			name = Release;
 		};
@@ -547,7 +553,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = dev.milanko.dartPdfEditorApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dart_pdf_editor_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/dart_pdf_editor_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DartPDF.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DartPDF";
 			};
 			name = Profile;
 		};

--- a/app/macos/Runner/FileRangeReader.swift
+++ b/app/macos/Runner/FileRangeReader.swift
@@ -1,0 +1,95 @@
+import Darwin
+import Foundation
+
+/// A recoverable failure while opening or reading a file range.
+///
+/// Foundation's legacy `FileHandle` range APIs raise Objective-C exceptions
+/// for I/O failures. Swift cannot catch those exceptions, so a transient File
+/// Provider error can abort the process. This error keeps the failing range
+/// and POSIX code in the ordinary Swift error path instead.
+struct FileRangeReadError: Error, LocalizedError {
+  let operation: String
+  let fileName: String
+  let offset: Int
+  let length: Int
+  let code: Int32
+
+  var errorDescription: String? {
+    let reason = String(cString: strerror(code))
+    return "Could not \(operation) \(fileName) at offset \(offset) "
+      + "for \(length) bytes: \(reason) (errno \(code))"
+  }
+}
+
+/// Reads independent file ranges without Foundation's exception-raising
+/// `FileHandle` seek/read/close methods.
+enum FileRangeReader {
+  static func read(url: URL, offset: Int, length: Int) throws -> Data {
+    let safeOffset = max(0, offset)
+    let safeLength = max(0, length)
+    guard safeLength > 0 else { return Data() }
+    guard safeOffset <= Int.max - safeLength else {
+      throw failure(
+        "read", url: url, offset: safeOffset, length: safeLength,
+        code: EOVERFLOW)
+    }
+
+    var openError = EINVAL
+    let descriptor = url.withUnsafeFileSystemRepresentation { path -> Int32 in
+      guard let path = path else { return -1 }
+      let result = Darwin.open(path, O_RDONLY | O_CLOEXEC)
+      if result < 0 { openError = errno }
+      return result
+    }
+    guard descriptor >= 0 else {
+      throw failure(
+        "open", url: url, offset: safeOffset, length: safeLength,
+        code: openError)
+    }
+    defer { _ = Darwin.close(descriptor) }
+
+    var data = Data(count: safeLength)
+    var total = 0
+    while total < safeLength {
+      let count = data.withUnsafeMutableBytes { bytes -> Int in
+        guard let base = bytes.baseAddress else { return 0 }
+        return Darwin.pread(
+          descriptor,
+          base.advanced(by: total),
+          safeLength - total,
+          off_t(safeOffset + total))
+      }
+      if count > 0 {
+        total += count
+        continue
+      }
+      if count == 0 { break }
+
+      let readError = errno
+      if readError == EINTR { continue }
+      throw failure(
+        "read", url: url, offset: safeOffset + total,
+        length: safeLength - total, code: readError)
+    }
+
+    if total < data.count {
+      data.removeSubrange(total..<data.count)
+    }
+    return data
+  }
+
+  private static func failure(
+    _ operation: String,
+    url: URL,
+    offset: Int,
+    length: Int,
+    code: Int32
+  ) -> FileRangeReadError {
+    FileRangeReadError(
+      operation: operation,
+      fileName: url.lastPathComponent,
+      offset: offset,
+      length: length,
+      code: code)
+  }
+}

--- a/app/macos/Runner/MainFlutterWindow.swift
+++ b/app/macos/Runner/MainFlutterWindow.swift
@@ -329,10 +329,8 @@ class MainFlutterWindow: NSWindow {
       let url = try self.resolveBookmarkedURL(bookmark)
       let scoped = url.startAccessingSecurityScopedResource()
       defer { if scoped { url.stopAccessingSecurityScopedResource() } }
-      let handle = try FileHandle(forReadingFrom: url)
-      defer { handle.closeFile() }
-      handle.seek(toFileOffset: UInt64(max(0, offset)))
-      let data = handle.readData(ofLength: max(0, length))
+      let data = try FileRangeReader.read(
+        url: url, offset: offset, length: length)
       return FlutterStandardTypedData(bytes: data)
     }
   }

--- a/app/macos/RunnerTests/RunnerTests.swift
+++ b/app/macos/RunnerTests/RunnerTests.swift
@@ -1,12 +1,63 @@
 import Cocoa
+import Darwin
 import FlutterMacOS
 import XCTest
 
 class RunnerTests: XCTestCase {
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  func testFileRangeReaderReturnsRequestedBytesAndShortReadsAtEOF() throws {
+    let directory = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let file = directory.appendingPathComponent("fixture.pdf")
+    try Data((0..<10).map(UInt8.init)).write(to: file)
+
+    XCTAssertEqual(
+      try FileRangeReader.read(url: file, offset: 3, length: 4),
+      Data([3, 4, 5, 6]))
+    XCTAssertEqual(
+      try FileRangeReader.read(url: file, offset: 8, length: 8),
+      Data([8, 9]))
+    XCTAssertEqual(
+      try FileRangeReader.read(url: file, offset: 20, length: 8),
+      Data())
   }
 
+  func testFileRangeReaderClampsNegativeAndEmptyRanges() throws {
+    let directory = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let file = directory.appendingPathComponent("fixture.pdf")
+    try Data([1, 2, 3]).write(to: file)
+
+    XCTAssertEqual(
+      try FileRangeReader.read(url: file, offset: -5, length: 2),
+      Data([1, 2]))
+    XCTAssertEqual(
+      try FileRangeReader.read(url: file, offset: 0, length: -1),
+      Data())
+  }
+
+  func testFileRangeReaderThrowsSwiftErrorForReadFailure() throws {
+    let directory = try temporaryDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    XCTAssertThrowsError(
+      try FileRangeReader.read(url: directory, offset: 0, length: 1)
+    ) { error in
+      guard let readError = error as? FileRangeReadError else {
+        return XCTFail("Expected FileRangeReadError, got \(error)")
+      }
+      XCTAssertEqual(readError.operation, "read")
+      XCTAssertEqual(readError.code, EISDIR)
+      XCTAssertEqual(readError.offset, 0)
+      XCTAssertEqual(readError.length, 1)
+    }
+  }
+
+  private func temporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: directory, withIntermediateDirectories: true)
+    return directory
+  }
 }

--- a/doc/dev-log/2026-07-18-progressive-file-open.md
+++ b/doc/dev-log/2026-07-18-progressive-file-open.md
@@ -51,8 +51,10 @@ Factory + helpers in `file_io.dart`:
 Native (macOS runner, `MainFlutterWindow.swift`): `fileLength` and
 `readFileRange(bookmark, offset, length)` reactivate the security scope per
 call (no leaked handle/scope), so the loader pulls only the ranges it needs
-from a cloud-synced file. Deployment target is 10.15, so it uses the classic
-`FileHandle` seek/readData API (no `read(upToCount:)` availability guard).
+from a cloud-synced file. `FileRangeReader` uses `pread` so an I/O or File
+Provider failure becomes a catchable Swift error on every supported macOS
+version; the legacy `FileHandle` range APIs raise an uncatchable Objective-C
+exception for the same failure.
 
 ## 2. First paint from ranges, full bytes behind it
 


### PR DESCRIPTION
## Summary

- replace the macOS ranged-read path's exception-raising `FileHandle` calls with `open`/`pread`
- surface open and read failures as catchable `FileRangeReadError` values so the method channel returns a Flutter error instead of aborting the process
- preserve the existing negative-range clamping and short-read-at-EOF behavior
- add native regression coverage and repair the stale DartPDF XCTest host path
- document why the low-level reader is required

## Root cause

The crash at `MainFlutterWindow.swift:335` comes from `-[NSConcreteFileHandle readDataOfLength:]`. On an I/O or File Provider failure, that legacy API raises an Objective-C `NSFileHandleOperationException`; Swift `do/catch` cannot catch it. The exception therefore escaped the `dev.milanko.dartpdf.file-access` queue and terminated the app with `SIGABRT`.

## Validation

- `FileRangeReader` compiled for the macOS 10.15 deployment target and passed direct runtime checks for normal ranges, EOF short reads, reads past EOF, and a failing directory read (`EISDIR`)
- `flutter test test/progressive_open_test.dart` — 4 passed
- `dart analyze` — no issues
- strict Swift formatting passed for the new reader and regression tests
- Xcode project plist validation and `git diff --check` passed

A full `xcodebuild test` compiles the app target and the new reader, but the repository's existing **Normalize Embedded Code Signatures** phase rejects Xcode's empty `RunnerTests.xctest` placeholder before the test bundle can be built. That signing-phase issue is outside this crash fix.