### PR TITLE
Defer PDF thumbnail rendering during fast scrolls and disable speculative grid caching

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -3870,7 +3870,6 @@ class _TabDocumentPreviewState extends State<_TabDocumentPreview> {
   ui.Image? _image;
   Object? _pendingKey;
   Object? _imageKey;
-  bool _deferredFrameScheduled = false;
 
   Object get _key => (
         widget.controller,
@@ -3944,15 +3943,6 @@ class _TabDocumentPreviewState extends State<_TabDocumentPreview> {
     }
   }
 
-  void _retryAfterDeferredFrame() {
-    if (_deferredFrameScheduled) return;
-    _deferredFrameScheduled = true;
-    SchedulerBinding.instance.scheduleFrameCallback((_) {
-      _deferredFrameScheduled = false;
-      if (mounted) setState(() {});
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     final key = _key;
@@ -3970,7 +3960,9 @@ class _TabDocumentPreviewState extends State<_TabDocumentPreview> {
       // PDF thumbnail generation is substantially heavier than decoding, so
       // obey the same signal and retry once the scroll begins to settle.
       if (Scrollable.recommendDeferredLoadingForContext(context)) {
-        _retryAfterDeferredFrame();
+        SchedulerBinding.instance.scheduleFrameCallback((_) {
+          if (mounted) setState(() {});
+        });
       } else {
         unawaited(_render(key, MediaQuery.devicePixelRatioOf(context)));
       }

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -7,6 +7,7 @@ import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -2901,6 +2902,10 @@ class _EditorScreenState extends State<EditorScreen>
         Expanded(
           child: GridView.builder(
             key: ValueKey('$keyPrefix-tabs-grid'),
+            // A tile paints a real PDF thumbnail. Do not build the next row
+            // speculatively: with large documents that work competes with a
+            // fling even though the thumbnails are still off-screen.
+            scrollCacheExtent: const ScrollCacheExtent.pixels(0),
             padding: const EdgeInsets.all(12),
             gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
               maxCrossAxisExtent: 220,
@@ -3865,6 +3870,7 @@ class _TabDocumentPreviewState extends State<_TabDocumentPreview> {
   ui.Image? _image;
   Object? _pendingKey;
   Object? _imageKey;
+  bool _deferredFrameScheduled = false;
 
   Object get _key => (
         widget.controller,
@@ -3938,6 +3944,15 @@ class _TabDocumentPreviewState extends State<_TabDocumentPreview> {
     }
   }
 
+  void _retryAfterDeferredFrame() {
+    if (_deferredFrameScheduled) return;
+    _deferredFrameScheduled = true;
+    SchedulerBinding.instance.scheduleFrameCallback((_) {
+      _deferredFrameScheduled = false;
+      if (mounted) setState(() {});
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final key = _key;
@@ -3951,7 +3966,14 @@ class _TabDocumentPreviewState extends State<_TabDocumentPreview> {
       }
     }
     if (_imageKey != key && _pendingKey != key) {
-      unawaited(_render(key, MediaQuery.devicePixelRatioOf(context)));
+      // Flutter recommends deferring image decoding during fast scrolling.
+      // PDF thumbnail generation is substantially heavier than decoding, so
+      // obey the same signal and retry once the scroll begins to settle.
+      if (Scrollable.recommendDeferredLoadingForContext(context)) {
+        _retryAfterDeferredFrame();
+      } else {
+        unawaited(_render(key, MediaQuery.devicePixelRatioOf(context)));
+      }
     }
     final page = widget.controller.pageAt(widget.pageIndex);
     final pageSize = PdfPageRenderer.pageSize(

--- a/app/test/tabs_menu_test.dart
+++ b/app/test/tabs_menu_test.dart
@@ -10,6 +10,50 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dart_pdf_editor_app/editor_screen.dart';
 import 'package:dart_pdf_editor_app/incoming_file.dart';
 
+class _DeferredLoadingFlag {
+  bool value = true;
+}
+
+class _DeferredLoadingScrollBehavior extends MaterialScrollBehavior {
+  const _DeferredLoadingScrollBehavior(this.flag);
+
+  final _DeferredLoadingFlag flag;
+
+  @override
+  ScrollPhysics getScrollPhysics(BuildContext context) {
+    return _DeferredLoadingScrollPhysics(
+      shouldDefer: () => flag.value,
+      parent: super.getScrollPhysics(context),
+    );
+  }
+}
+
+class _DeferredLoadingScrollPhysics extends ScrollPhysics {
+  const _DeferredLoadingScrollPhysics({
+    required this.shouldDefer,
+    super.parent,
+  });
+
+  final bool Function() shouldDefer;
+
+  @override
+  _DeferredLoadingScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return _DeferredLoadingScrollPhysics(
+      shouldDefer: shouldDefer,
+      parent: buildParent(ancestor),
+    );
+  }
+
+  @override
+  bool recommendDeferredLoading(
+    double velocity,
+    ScrollMetrics metrics,
+    BuildContext context,
+  ) {
+    return shouldDefer();
+  }
+}
+
 void main() {
   late PdfEditingPreferences prefs;
 
@@ -273,6 +317,43 @@ void main() {
         closeTo(612 / 792, 0.001));
     expect(tester.getSize(previewFor('landscape.pdf')).aspectRatio,
         closeTo(792 / 612, 0.001));
+  });
+
+  testWidgets('tab thumbnail rendering resumes after deferred loading',
+      (tester) async {
+    final deferLoading = _DeferredLoadingFlag();
+    final scrollBehavior = _DeferredLoadingScrollBehavior(deferLoading);
+    await tester.pumpWidget(MaterialApp(
+      scrollBehavior: scrollBehavior,
+      home: EditorScreen(prefs: prefs),
+    ));
+    await tester.pump();
+    await openTab(tester, 'alpha.pdf');
+    await openTab(tester, 'beta.pdf');
+
+    await tester.tap(find.byKey(const ValueKey('desktop-tabs-button')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final grid = find.byKey(const ValueKey('desktop-tabs-grid'));
+    final previewImages = find.descendant(
+      of: grid,
+      matching: find.byKey(const ValueKey('mobile-tab-preview-image')),
+    );
+    expect(grid, findsOneWidget);
+    expect(previewImages, findsNothing);
+
+    // The scheduled retry rebuilds the previews once scrolling settles, then
+    // the normal asynchronous PDF render is allowed to complete.
+    deferLoading.value = false;
+    await tester.runAsync(() async {
+      for (var i = 0; i < 50 && previewImages.evaluate().isEmpty; i++) {
+        await tester.pump(const Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
+
+    expect(previewImages, findsNWidgets(2));
   });
 
   testWidgets('hovering an inactive desktop tab shows its page preview',


### PR DESCRIPTION
### Motivation
- Prevent expensive PDF thumbnail generation from competing with fast scroll flings and unnecessary off-screen work.

### Description
- Disable GridView speculative caching by setting `scrollCacheExtent: const ScrollCacheExtent.pixels(0)` on the tabs grid to avoid building the next row off-screen.
- Defer heavy thumbnail rendering when Flutter signals fast scrolling by using `Scrollable.recommendDeferredLoadingForContext(context)` and retrying later via a new `_retryAfterDeferredFrame` helper that schedules a frame callback with `SchedulerBinding.instance.scheduleFrameCallback`.
- Add a `_deferredFrameScheduled` guard to avoid scheduling repeated retries and preserve existing image cache/cleanup behavior when a thumbnail is finally produced.

### Testing
- Ran `flutter analyze` which completed successfully.
- Ran `flutter test` for the existing test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f2e0931b0832ba2b07ffa9750ecbc)