### PR TITLE
Put selection geometry on the glyphs of proportional fonts (#647)

### DIFF
--- a/doc/dev-log/2026-08-05-per-character-advances-647.md
+++ b/doc/dev-log/2026-08-05-per-character-advances-647.md
@@ -1,0 +1,75 @@
+# Per-character advances for selection geometry (#647)
+
+Selection and search highlights sat beside the glyphs instead of on them.
+`PdfPageText.quadsFor` had carried a placeholder since the beginning:
+
+```dart
+// approximate within-run positions by character fraction; per-glyph
+// geometry arrives with the font engine
+final logicalStart = (overlapStart - run.startIndex) / run.text.length;
+```
+
+Slicing a run's width by *character count* assumes every character is the
+same width. In a proportional font they are not. On the `buildClassicPdf`
+fixture - `Hello, world!` in 24pt Helvetica, the issue's own repro -
+double-clicking `world` produced a band 3pt to the right of the word and
+6.5pt too narrow. The error scales with how uneven the run is: `I` is
+0.278em and `W` is 0.944em, so on `IIIIII WWWWWW` the highlight misses by
+more than a quarter of the run, which is the "roughly 1/3" the reporter saw.
+
+Both halves of selection were wrong and compounded: `positionNear` mapped a
+click to a character by the same linear fraction, then `quadsFor` mapped it
+back.
+
+## The fix
+
+The interpreter already accumulates the exact pen position per glyph - it
+just threw it away for anything but embedded outlines. Now it can keep it:
+
+- `PdfTextRun.charOffsets` - em-space offset of every character boundary,
+  length `text.length + 1`, last entry `== width`.
+- `PdfInterpreter(collectCharOffsets:)` - **off by default**. Painting walks
+  get the same positions from `PdfTextRun.glyphs` when the font is embedded
+  and would otherwise pay a list per run for nothing;
+  `PdfTextExtractor._interpret` turns it on.
+
+The flag is what makes this work for the reported case at all. `glyphs` is
+only built for `font.hasOutlines || font.isType3`, so a **non-embedded**
+standard-14 Helvetica - exactly the issue's PDF - has no glyph list.
+`charOffsets` needs only the metrics, so it covers substituted fonts too.
+
+`PdfExtractedRun.charOffsets` carries the table through to
+`quadsFor`/`positionNear` (which now binary-searches for the nearest
+boundary instead of scaling a fraction).
+
+## Gotchas
+
+- **The BiDi pass invalidates the table.** `_bidiLine` reverses runs and
+  re-splits them per glyph, so the offsets no longer line up with the
+  piece's characters. `_sliceCharOffsets` returns null unless the piece is
+  the source's own characters in their own order (`sourceEnd - sourceStart
+  == text.length`, and not RTL). RTL keeps the old interpolation exactly -
+  it already had per-glyph geometry from its own path.
+- **Vertical writing mode gets null**: the pen advances along y there, so a
+  per-character *x* offset is meaningless.
+- **One code can map to several characters** through a /ToUnicode ligature.
+  The PDF positions the code, not its pieces, so the advance splits evenly
+  across them - the invariant that matters is that the table stays
+  `text.length + 1` long (asserted at the emit site).
+- **Offsets are clamped non-decreasing.** A negative `Tc` tighter than a
+  glyph's own width walks the pen backwards; consumers binary-search these.
+  `_bidiLine` already did the same `math.max` for glyph offsets.
+- **Two codecs, not one.** `serializePageText` in `render_command_codec.dart`
+  is the render-worker hop - the app extracts text off-thread, so *that* is
+  the path the fix actually travels in production; missing it would have
+  left the bug live everywhere but tests. `pdfEncodePageText` in
+  `text_cache.dart` is the on-disk tier (magic bumped `PTX2` → `PTX3` so
+  stale blobs miss rather than mis-parse).
+
+## Measurements
+
+`tool/perf.sh gate`: 12 inputs, 13 counters within 3%.
+`tool/perf.sh diff d84479b type3-text-sweep` (~7400 glyphs/page, the densest
+text scenario): `interpretMs` 0.953x, `extractMs` 1.037x, `peakRssBytes`
+1.033x - VERDICT OK. The ~4% on extract is the offset table itself; the
+render path is untouched because the flag leaves `charOffsets` null.

--- a/doc/dev-log/2026-08-05-per-character-advances-647.md
+++ b/doc/dev-log/2026-08-05-per-character-advances-647.md
@@ -65,11 +65,45 @@ boundary instead of scaling a fraction).
   left the bug live everywhere but tests. `pdfEncodePageText` in
   `text_cache.dart` is the on-disk tier (magic bumped `PTX2` → `PTX3` so
   stale blobs miss rather than mis-parse).
+- **Both codecs' tests passed with the offsets dropped.** The worker test
+  compared search *hit counts*, and the disk-cache sample runs carried no
+  `charOffsets` at all, so neither would have noticed a field missing from
+  the wire. Both now compare geometry (quad corners, hit-test positions);
+  the worker one was verified to fail with the field removed. A codec test
+  that doesn't assert the new field buys nothing - and on the disk tier the
+  failure would only appear on a *reopened* document, long after the suite
+  went green.
 
 ## Measurements
 
 `tool/perf.sh gate`: 12 inputs, 13 counters within 3%.
 `tool/perf.sh diff d84479b type3-text-sweep` (~7400 glyphs/page, the densest
 text scenario): `interpretMs` 0.953x, `extractMs` 1.037x, `peakRssBytes`
-1.033x - VERDICT OK. The ~4% on extract is the offset table itself; the
-render path is untouched because the flag leaves `charOffsets` null.
+1.033x - VERDICT OK. The render path is untouched because the flag leaves
+`charOffsets` null.
+
+**The corpus sweep caught a real regression the single-scenario run didn't.**
+`diff d84479b dartpdf-corpus` first came back `extractMs` **1.114x -
+REGRESSED** (over the 1.10 gate), worst on `text-report-40p.pdf` at 1.45x.
+Two causes, both obvious in hindsight:
+
+- `_sliceCharOffsets` **copied the whole table per run**. The common case is
+  one extracted run per source run, where the slice is the whole thing
+  already rebased at 0 - so it now returns the source list directly. Nothing
+  mutates it, and it saves an allocation *and* a copy on every run.
+- the per-glyph loop read `charOffsets.last` to clamp against the previous
+  boundary. That is a bounds-checked call once per glyph; `lastOffset` now
+  tracks the tail in a local.
+
+After both: `extractMs` **1.009x**, everything else ≤1.017x, VERDICT OK.
+
+Two process notes worth keeping:
+
+- The first corpus number was measured while sources were being edited
+  mid-run. `CLAUDE.md` forbids that ("NEVER edit sources or run builds while
+  a sweep is measuring") and it is not pedantry - `diff` interleaves
+  checkouts of the ref and the working tree, so an edit lands inside
+  somebody's measurement. It was discarded and re-run clean.
+- `type3-text-sweep` alone said 1.037x and looked fine. The regression only
+  showed on the 16-file corpus. For anything touching extraction, run the
+  corpus scenario too - one dense synthetic document is not a substitute.

--- a/packages/dart_pdf_editor/test/render_worker_extract_text_test.dart
+++ b/packages/dart_pdf_editor/test/render_worker_extract_text_test.dart
@@ -31,6 +31,25 @@ void main() {
       final matchesLocal = local.findAll('Page');
       final matchesWorker = viaWorker.findAll('Page');
       expect(matchesWorker.length, matchesLocal.length);
+      expect(matchesLocal, isNotEmpty);
+      for (var i = 0; i < matchesLocal.length; i++) {
+        // Corner-for-corner, not just hit counts - the per-character advances
+        // (#647) that put a highlight on the glyphs ride this same buffer, and
+        // dropping them from the codec would still match here on count alone.
+        expect(matchesWorker[i].quads.map((q) => q.corners),
+            matchesLocal[i].quads.map((q) => q.corners));
+      }
+      for (var i = 0; i < local.runs.length; i++) {
+        expect(viaWorker.runs[i].charOffsets, local.runs[i].charOffsets);
+      }
+      // And a point maps back to the same character offset.
+      final run = local.runs.firstWhere((r) => r.text.trim().isNotEmpty);
+      final mid = (
+        (run.bounds.left + run.bounds.right) / 2,
+        (run.bounds.bottom + run.bounds.top) / 2
+      );
+      expect(viaWorker.positionNear(mid.$1, mid.$2),
+          local.positionNear(mid.$1, mid.$2));
     });
   });
 

--- a/packages/pdf_graphics/lib/src/device.dart
+++ b/packages/pdf_graphics/lib/src/device.dart
@@ -67,6 +67,7 @@ class PdfTextRun {
     this.fontName,
     this.fontSize = 0,
     this.glyphs,
+    this.charOffsets,
     this.invisible = false,
     this.fill = true,
     this.strokeColor,
@@ -168,6 +169,21 @@ class PdfTextRun {
   /// Real glyph outlines from the embedded font, when available. Devices
   /// should prefer these over substituted text rendering.
   final List<PdfGlyphPlacement>? glyphs;
+
+  /// Em-space pen offset of every character boundary in [text] - entry `i` is
+  /// the advance from the run origin to the start of `text[i]`, and the last
+  /// entry (index `text.length`) is [width]. Always ascending.
+  ///
+  /// Unlike [glyphs] this is populated for substituted fonts too (it needs
+  /// only the metrics, not outlines), so consumers get exact intra-run
+  /// geometry for any horizontal run. A character code that maps to several
+  /// characters (a ligature through /ToUnicode) splits its advance evenly
+  /// across them, since the PDF exposes no finer position.
+  ///
+  /// Null unless the interpreter was built with `collectCharOffsets`, and
+  /// null for vertical writing mode, where the pen advances along y. Callers
+  /// must fall back to interpolating across [width] when it is absent.
+  final List<double>? charOffsets;
 
   bool get hasOutlines =>
       glyphs != null && glyphs!.any((g) => g.outline != null);
@@ -271,7 +287,8 @@ abstract interface class PdfDevice {
   /// approximation cannot act on its zero-component distinction, which is a
   /// colorant-space question the buffer has already answered. Non-compositing
   /// devices can ignore all three.
-  void setOverprint({required bool fill, required bool stroke, required int mode});
+  void setOverprint(
+      {required bool fill, required bool stroke, required int mode});
 
   /// Brackets a transparency-group form (§11.6.6) whose composite result
   /// paints at [alpha]. Inside the group, alpha starts over at 1.0; the

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -206,6 +206,7 @@ class PdfInterpreter {
       required this.device,
       bool scanImagesOnly = false,
       this.resolveOverprint = true,
+      this.collectCharOffsets = false,
       this.cancellation})
       : _scanImagesOnly = scanImagesOnly,
         _scanImages = scanImagesOnly;
@@ -231,6 +232,16 @@ class PdfInterpreter {
   /// colour (text extraction, the image-collect scan), which would only pay
   /// for the buffer.
   final bool resolveOverprint;
+
+  /// Whether to fill in [PdfTextRun.charOffsets] - the em-space pen position
+  /// of every character boundary in a run (issue #647).
+  ///
+  /// On for text extraction, which needs exact intra-run geometry to land a
+  /// selection or search highlight on the glyphs of a proportional font.
+  /// Off for painting walks, which get the same positions from
+  /// [PdfTextRun.glyphs] when the font is embedded and would otherwise pay a
+  /// list per run for nothing.
+  final bool collectCharOffsets;
 
   /// Process-wide kill switch for the colorant-buffer overprint path
   /// (issue #502). Off, overprint state is still parsed and delivered but no
@@ -485,7 +496,8 @@ class PdfInterpreter {
     // Expressed through the resumable walk so the two share one implementation
     // - this path is exercised by the whole corpus, which is what keeps the
     // chunked form honest.
-    final walk = beginPageContent(page, content, operationLimit: operationLimit);
+    final walk =
+        beginPageContent(page, content, operationLimit: operationLimit);
     await walk.advance(yieldInterval: yieldInterval);
   }
 
@@ -678,8 +690,7 @@ class PdfInterpreter {
     final rect = annotation.calloutBox ?? annotation.rect;
     if (rect.width <= 0 || rect.height <= 0) return;
     final da = cos.resolve(annotation.dict['DA']);
-    final style =
-        _parseDefaultAppearance(da is CosString ? da.text : '');
+    final style = _parseDefaultAppearance(da is CosString ? da.text : '');
     final size = style.size;
     const pad = 2.0;
     final lineHeight = size * 1.15;
@@ -705,8 +716,7 @@ class PdfInterpreter {
       device.strokePath(
           PdfPath([
             PdfMoveTo(callout.first.$1, callout.first.$2),
-            for (final point in callout.skip(1))
-              PdfLineTo(point.$1, point.$2),
+            for (final point in callout.skip(1)) PdfLineTo(point.$1, point.$2),
           ]),
           _pdfColor(freeText?.borderColor ?? annotation.color ?? 0x000000),
           _annotationStroke(annotation),
@@ -913,9 +923,12 @@ class PdfInterpreter {
     }
   }
 
-  ({String fontName, double size, PdfColor color})
-      _parseWidgetDefaultAppearance(PdfWidgetAnnotation annotation) =>
-          _parseDefaultAppearance(_widgetDefaultAppearance(annotation) ?? '');
+  ({
+    String fontName,
+    double size,
+    PdfColor color
+  }) _parseWidgetDefaultAppearance(PdfWidgetAnnotation annotation) =>
+      _parseDefaultAppearance(_widgetDefaultAppearance(annotation) ?? '');
 
   /// Parses a /DA default-appearance string (§12.7.3.3) into the font name,
   /// size and colour it selects - the shared core behind text-field widgets
@@ -1563,14 +1576,12 @@ class PdfInterpreter {
         // but not yet given components must not keep the previous space's
         // colorant reading (a stale one would overprint the wrong channels).
         _state.fillInk = null;
-        _state.fillSpace = PdfColorSpace.parse(
-            cos, o.isEmpty ? null : o[0],
+        _state.fillSpace = PdfColorSpace.parse(cos, o.isEmpty ? null : o[0],
             resources: resources, iccCache: _iccCache);
       case 'CS':
         if (_scanImages) break;
         _state.strokeInk = null;
-        _state.strokeSpace = PdfColorSpace.parse(
-            cos, o.isEmpty ? null : o[0],
+        _state.strokeSpace = PdfColorSpace.parse(cos, o.isEmpty ? null : o[0],
             resources: resources, iccCache: _iccCache);
       case 'sc' || 'scn':
         // The fill pattern is tracked even while scanning - a tiling pattern
@@ -2097,8 +2108,8 @@ class PdfInterpreter {
               opaque: _opaquePaint(_state.fillAlpha));
           _deliverOverprint(_state.fillOverprint && resolved == null,
               _state.strokeOverprint, _state.overprintMode);
-          device.fillPath(path, resolved ?? _state.fillColor, fill,
-              _state.fillAlpha);
+          device.fillPath(
+              path, resolved ?? _state.fillColor, fill, _state.fillAlpha);
         }
       }
       if (stroke) {
@@ -2174,8 +2185,8 @@ class PdfInterpreter {
     if (_state.fillOverprint != beforeFill ||
         _state.strokeOverprint != beforeStroke ||
         _state.overprintMode != beforeMode) {
-      _deliverOverprint(_state.fillOverprint, _state.strokeOverprint,
-          _state.overprintMode);
+      _deliverOverprint(
+          _state.fillOverprint, _state.strokeOverprint, _state.overprintMode);
     }
   }
 
@@ -2378,6 +2389,14 @@ class PdfInterpreter {
     // along y by the vertical displacement, and each glyph is shifted by its
     // position vector so the column centres on the baseline.
     final vertical = font.isVertical;
+    // Per-character pen positions for text extraction (issue #647). Only
+    // horizontal text has a meaningful x offset per character; vertical runs
+    // advance along y and leave this null.
+    final charOffsets =
+        collectCharOffsets && !vertical && !_scanImages && emScale != 0
+            ? <double>[]
+            : null;
+    var lastOffset = 0.0; // tail of charOffsets, kept out of the list
     final hScale = _state.horizontalScale == 0 ? 1.0 : _state.horizontalScale;
     var advance = 0.0; // text-space along the writing direction (x or y)
     // Pen advance bracketing the visible (non-whitespace) glyphs: [leadingAdv]
@@ -2425,6 +2444,7 @@ class PdfInterpreter {
           size != 0) {
         _drawType3Glyph(font, code, advance);
       }
+      final advanceBefore = advance;
       if (vertical) {
         // Tc applies along the writing direction; Tw only to single-byte 0x20.
         advance += font.verticalAdvanceOf(code) * size + _state.charSpacing;
@@ -2433,8 +2453,31 @@ class PdfInterpreter {
         if (!font.isCid && code == 0x20) tx += _state.wordSpacing;
         advance += tx * _state.horizontalScale;
       }
+      if (charOffsets != null && text.isNotEmpty) {
+        // Consumers binary-search these, so keep them non-decreasing: a
+        // pathological negative Tc can tighten past a glyph's own width and
+        // walk the pen backwards. `lastOffset` tracks the tail in a local -
+        // this runs once per glyph, so avoid re-reading charOffsets.last.
+        final start = math.max(advanceBefore / emScale, lastOffset);
+        if (text.length == 1) {
+          charOffsets.add(start);
+          lastOffset = start;
+        } else {
+          // One code can map to several characters through /ToUnicode (a
+          // ligature). The PDF positions the code, not its pieces, so split
+          // the advance evenly across them.
+          final end = math.max(advance / emScale, start);
+          final step = (end - start) / text.length;
+          for (var i = 0; i < text.length; i++) {
+            charOffsets.add(start + step * i);
+          }
+          lastOffset = start + step * (text.length - 1);
+        }
+      }
       if (visible) visibleAdvance = advance;
     }
+    // Closing boundary, so charOffsets always has text.length + 1 entries.
+    charOffsets?.add(math.max(advance / emScale, lastOffset));
 
     if (size != 0 && _contentVisible && !_scanImages) {
       // text rendering matrix: em space → page space (§9.4.4).
@@ -2465,6 +2508,10 @@ class PdfInterpreter {
         }
       }
 
+      assert(
+          charOffsets == null || charOffsets.length == text.length + 1,
+          'charOffsets must have one entry per character plus the closing '
+          'boundary (${charOffsets.length} vs ${text.length + 1})');
       if (text.trim().isNotEmpty || glyphs != null) {
         final fillText = mode == 0 || mode == 2 || mode == 4 || mode == 6;
         final strokeText = mode == 1 || mode == 2 || mode == 5 || mode == 6;
@@ -2529,11 +2576,11 @@ class PdfInterpreter {
           // carries size and Th, so normalise to em (divide by size) - Th
           // cancels. Tw never applies to composite fonts (§9.3.3).
           letterSpacing: size == 0 ? 0 : _state.charSpacing / size,
-          wordSpacing:
-              size == 0 || font.isCid ? 0 : _state.wordSpacing / size,
+          wordSpacing: size == 0 || font.isCid ? 0 : _state.wordSpacing / size,
           fontName: font.baseFont,
           fontSize: size,
           glyphs: glyphs,
+          charOffsets: charOffsets,
           invisible: mode == 3 || mode == 7 || paintedAsTiling,
           mcid: _currentMcid,
         ));
@@ -2568,8 +2615,8 @@ class PdfInterpreter {
     final width = emScale == 0 ? 0.0 : advance / emScale;
     final box = PdfPath([
       PdfMoveTo(transform.transformX(0, -0.25), transform.transformY(0, -0.25)),
-      PdfLineTo(
-          transform.transformX(width, -0.25), transform.transformY(width, -0.25)),
+      PdfLineTo(transform.transformX(width, -0.25),
+          transform.transformY(width, -0.25)),
       PdfLineTo(transform.transformX(width, 1), transform.transformY(width, 1)),
       PdfLineTo(transform.transformX(0, 1), transform.transformY(0, 1)),
       const PdfClosePath(),
@@ -2649,8 +2696,8 @@ class PdfInterpreter {
       code,
       decode: (proc) {
         try {
-          return _opsCache.putIfAbsent(
-              proc, () => ContentStreamParser.parse(cos.decodeStreamData(proc)));
+          return _opsCache.putIfAbsent(proc,
+              () => ContentStreamParser.parse(cos.decodeStreamData(proc)));
         } on Exception {
           return const [];
         }
@@ -2702,9 +2749,7 @@ class PdfInterpreter {
             final sink = device;
             if (sink is PdfTiledCellSink) {
               (sink as PdfTiledCellSink).drawTiledCell(PdfDrawTiledCellCommand(
-                  cell.$1,
-                  Float64List(1)..[0] = dx,
-                  Float64List(1)..[0] = dy));
+                  cell.$1, Float64List(1)..[0] = dx, Float64List(1)..[0] = dy));
             } else if (dx == 0 && dy == 0) {
               replayCommands(cell.$1, device);
             } else {
@@ -3093,8 +3138,14 @@ class PdfInterpreter {
   /// the tile's transform, §8.7.3.1 BBox clip, the cell content, and any
   /// pending soft-mask finalize - through whatever [device] currently is
   /// (the real target for direct tiles, a recorder for the #524 capture).
-  void _runPatternCell(List<ContentOperation> ops, CosDictionary resources,
-      List<double> bbox, PdfMatrix matrix, int i, int j, double xStep,
+  void _runPatternCell(
+      List<ContentOperation> ops,
+      CosDictionary resources,
+      List<double> bbox,
+      PdfMatrix matrix,
+      int i,
+      int j,
+      double xStep,
       double yStep,
       {PdfColor? patternColor}) {
     _state = _GraphicsState()
@@ -3443,8 +3494,8 @@ class PdfInterpreter {
   /// read as DeviceCMYK by operand count for the colour, so the colorants must
   /// come from the same reading - otherwise the paint looks colorant-less and
   /// an overprint over it falls back to the approximation.
-  static PdfInkColorants? _resolveInk(PdfColorSpace space,
-      List<CosObject> operands, PdfInkColorants? current) {
+  static PdfInkColorants? _resolveInk(
+      PdfColorSpace space, List<CosObject> operands, PdfInkColorants? current) {
     final values = [
       for (final item in operands)
         if (item is CosInteger || item is CosReal) _numOf(item),

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -444,6 +444,15 @@ Uint8List serializePageText(PdfPageText page) {
     w.f64(run.width);
     _writeRect(w, run.bounds);
     w.boolean(run.isRightToLeft);
+    // Per-character advances (issue #647) - without them the UI isolate falls
+    // back to interpolating a highlight across the run and misses the glyphs.
+    final offsets = run.charOffsets;
+    w.u32(offsets?.length ?? 0);
+    if (offsets != null) {
+      for (final offset in offsets) {
+        w.f64(offset);
+      }
+    }
   }
   return w.takeBytes();
 }
@@ -466,6 +475,10 @@ PdfPageText deserializePageText(Uint8List bytes) {
     final width = r.f64();
     final bounds = _readRect(r);
     final isRightToLeft = r.boolean();
+    final offsetCount = r.u32();
+    final offsets = offsetCount == 0
+        ? null
+        : [for (var j = 0; j < offsetCount; j++) r.f64()];
     runs.add(PdfExtractedRun(
       text: runText,
       startIndex: startIndex,
@@ -473,6 +486,11 @@ PdfPageText deserializePageText(Uint8List bytes) {
       transform: transform,
       width: width,
       bounds: bounds,
+      // A table of the wrong length would throw out of quadsFor; drop it and
+      // interpolate instead, like a run that never carried one.
+      charOffsets: offsets != null && offsets.length == runText.length + 1
+          ? offsets
+          : null,
       isRightToLeft: isRightToLeft,
     ));
   }

--- a/packages/pdf_graphics/lib/src/text_cache.dart
+++ b/packages/pdf_graphics/lib/src/text_cache.dart
@@ -10,7 +10,7 @@ import 'text_extraction.dart';
 /// Magic + version word at the head of an encoded [PdfPageText] blob.
 /// Bump the low byte when the layout below changes; mismatched blobs
 /// decode to null (a miss) rather than mis-parsing.
-const int _textBlobMagic = 0x50545832; // 'PTX2'
+const int _textBlobMagic = 0x50545833; // 'PTX3'
 
 /// Serializes [page] into a compact binary blob for the on-disk text
 /// cache. The format is little-endian and self-describing enough to
@@ -41,6 +41,17 @@ Uint8List pdfEncodePageText(PdfPageText page) {
       ..f64(b.bottom)
       ..f64(b.right)
       ..f64(b.top);
+    // Per-character advances (issue #647). Length-prefixed, 0 meaning absent -
+    // a present table is always run.text.length + 1 entries.
+    final offsets = run.charOffsets;
+    if (offsets == null) {
+      out.u32(0);
+    } else {
+      out.u32(offsets.length);
+      for (final offset in offsets) {
+        out.f64(offset);
+      }
+    }
   }
   return out.takeBytes();
 }
@@ -64,12 +75,19 @@ PdfPageText? pdfDecodePageText(Uint8List bytes) {
           PdfMatrix(r.f64(), r.f64(), r.f64(), r.f64(), r.f64(), r.f64());
       final width = r.f64();
       final bounds = PdfRect(r.f64(), r.f64(), r.f64(), r.f64());
+      final offsetCount = r.u32();
+      final offsets = offsetCount == 0
+          ? null
+          : [for (var j = 0; j < offsetCount; j++) r.f64()];
       runs.add(PdfExtractedRun(
         text: runText,
         startIndex: startIndex,
         transform: transform,
         width: width,
         bounds: bounds,
+        charOffsets: offsets != null && offsets.length == runText.length + 1
+            ? offsets
+            : null,
         isRightToLeft: isRightToLeft,
       ));
     }

--- a/packages/pdf_graphics/lib/src/text_extraction.dart
+++ b/packages/pdf_graphics/lib/src/text_extraction.dart
@@ -23,6 +23,7 @@ class PdfExtractedRun {
     required this.transform,
     required this.width,
     required this.bounds,
+    this.charOffsets,
     this.isRightToLeft = false,
     this.mcid,
   });
@@ -45,6 +46,18 @@ class PdfExtractedRun {
 
   /// Page-space bounding box.
   final PdfRect bounds;
+
+  /// Em-space offset of every character boundary in [text], measured from this
+  /// run's own origin: entry `i` is the advance to the start of `text[i]`, and
+  /// the last entry (index `text.length`) is [width]. Ascending, length
+  /// `text.length + 1`.
+  ///
+  /// This is what puts a selection or search highlight on the actual glyphs of
+  /// a proportional font (issue #647) - `world` in `Hello, world!` starts 51.5%
+  /// of the way along the run, not 7/13 = 53.8% of it. Null when the source
+  /// run carried no metrics (vertical writing mode, or text reordered by the
+  /// BiDi pass); callers then interpolate across [width] as before.
+  final List<double>? charOffsets;
 
   /// Whether logical character order runs opposite this run's em-space
   /// advance. Search and selection use this to map logical Arabic/Hebrew
@@ -211,16 +224,28 @@ class PdfPageText {
       final overlapStart = math.max(start, run.startIndex);
       final overlapEnd = math.min(end, runEnd);
       if (overlapStart >= overlapEnd) continue;
-      // approximate within-run positions by character fraction; per-glyph
-      // geometry arrives with the font engine
-      final logicalStart = (overlapStart - run.startIndex) / run.text.length;
-      final logicalEnd = (overlapEnd - run.startIndex) / run.text.length;
-      final f0 = run.isRightToLeft ? 1 - logicalEnd : logicalStart;
-      final f1 = run.isRightToLeft ? 1 - logicalStart : logicalEnd;
+      // The offsets ascend with the em advance, so they only index logical
+      // character order on an LTR run - extraction leaves them null for RTL.
+      final offsets = run.isRightToLeft ? null : run.charOffsets;
+      double x0, x1;
+      if (offsets != null) {
+        // Real per-character metrics: the highlight lands on the glyphs even
+        // when they have wildly different widths (issue #647).
+        x0 = offsets[overlapStart - run.startIndex];
+        x1 = offsets[overlapEnd - run.startIndex];
+      } else {
+        // No metrics for this run - approximate by character fraction.
+        final logicalStart = (overlapStart - run.startIndex) / run.text.length;
+        final logicalEnd = (overlapEnd - run.startIndex) / run.text.length;
+        final f0 = run.isRightToLeft ? 1 - logicalEnd : logicalStart;
+        final f1 = run.isRightToLeft ? 1 - logicalStart : logicalEnd;
+        x0 = run.width * f0;
+        x1 = run.width * f1;
+      }
       quads.add(_quadOf(
         run.transform,
-        run.width * f0,
-        run.width * f1,
+        x0,
+        x1,
         isRightToLeft: run.isRightToLeft,
       ));
     }
@@ -276,12 +301,34 @@ class PdfPageText {
       }
     }
     if (best == null || bestDistance > tolerance * tolerance) return -1;
-    // fraction along the run's baseline, in em space
+    // offset along the run's baseline, in em space
     final inverse = best.transform.inverted();
     final ex = inverse == null ? 0.0 : inverse.transformX(x, y);
+    final offsets = best.isRightToLeft ? null : best.charOffsets;
+    if (offsets != null) {
+      return best.startIndex + _nearestBoundary(offsets, ex);
+    }
     final fraction = best.width > 0 ? (ex / best.width).clamp(0.0, 1.0) : 0.0;
     final logicalFraction = best.isRightToLeft ? 1 - fraction : fraction;
     return best.startIndex + (logicalFraction * best.text.length).round();
+  }
+
+  /// The index into the ascending [offsets] whose value is closest to [ex] -
+  /// the caret position a click at [ex] snaps to.
+  static int _nearestBoundary(List<double> offsets, double ex) {
+    // Binary search for the first boundary at or past `ex`.
+    var lo = 0, hi = offsets.length - 1;
+    while (lo < hi) {
+      final mid = (lo + hi) >> 1;
+      if (offsets[mid] < ex) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    if (lo == 0) return 0;
+    // `lo - 1` sits before `ex` and `lo` at or past it - snap to the nearer.
+    return ex - offsets[lo - 1] <= offsets[lo] - ex ? lo - 1 : lo;
   }
 }
 
@@ -415,12 +462,16 @@ class PdfReflowPage {
   final List<PdfReflowItem> items;
 
   /// The text blocks only, in reading order.
-  List<PdfReflowBlock> get blocks =>
-      [for (final item in items) if (item is PdfReflowBlock) item];
+  List<PdfReflowBlock> get blocks => [
+        for (final item in items)
+          if (item is PdfReflowBlock) item
+      ];
 
   /// The images only, in reading order.
-  List<PdfReflowImage> get images =>
-      [for (final item in items) if (item is PdfReflowImage) item];
+  List<PdfReflowImage> get images => [
+        for (final item in items)
+          if (item is PdfReflowImage) item
+      ];
 
   /// The reading-order text - blocks joined with blank lines (images skipped).
   String get text => blocks.map((block) => block.text).join('\n\n');
@@ -454,8 +505,14 @@ class PdfTextExtractor {
     final device = _ExtractionDevice();
     // Extraction reads geometry and Unicode, never colour, so the overprint
     // colorant buffer (§8.6.7) would be pure cost on a page that uses it.
-    PdfInterpreter(cos: document.cos, device: device, resolveOverprint: false)
-        .drawPage(document.page(pageIndex));
+    PdfInterpreter(
+      cos: document.cos,
+      device: device,
+      resolveOverprint: false,
+      // Selection and search highlights need the real per-character advances,
+      // not a linear guess across the run (issue #647).
+      collectCharOffsets: true,
+    ).drawPage(document.page(pageIndex));
     return device;
   }
 
@@ -653,11 +710,21 @@ class PdfTextExtractor {
     double? sourceX0,
     double? sourceX1,
   }) {
-    final sourceLength = source.text.length;
-    final f0 = sourceLength == 0 ? 0.0 : sourceStart / sourceLength;
-    final f1 = sourceLength == 0 ? 1.0 : sourceEnd / sourceLength;
-    final x0 = sourceX0 ?? source.width * f0;
-    final width = (sourceX1 ?? source.width * f1) - x0;
+    final offsets =
+        _sliceCharOffsets(source, text, sourceStart, sourceEnd, rightToLeft);
+    final double x0, width;
+    if (offsets != null) {
+      // Exact metrics beat both the caller's glyph bracket and the character
+      // fraction below, and keep bounds consistent with `offsets`.
+      x0 = source.charOffsets![sourceStart];
+      width = offsets.last;
+    } else {
+      final sourceLength = source.text.length;
+      final f0 = sourceLength == 0 ? 0.0 : sourceStart / sourceLength;
+      final f1 = sourceLength == 0 ? 1.0 : sourceEnd / sourceLength;
+      x0 = sourceX0 ?? source.width * f0;
+      width = (sourceX1 ?? source.width * f1) - x0;
+    }
     final transform = x0 == 0
         ? source.transform
         : PdfMatrix.translation(x0, 0).concat(source.transform);
@@ -669,9 +736,35 @@ class PdfTextExtractor {
       transform: transform,
       width: width,
       bounds: _boundsOf(transform, 0, width),
+      charOffsets: offsets,
       isRightToLeft: rightToLeft,
       mcid: source.mcid,
     ));
+  }
+
+  /// [source]'s character offsets for `[sourceStart, sourceEnd)`, rebased so
+  /// entry 0 is 0 - or null when they can't be trusted for [text].
+  ///
+  /// The BiDi pass reverses and re-splits runs, so the offsets only line up
+  /// when [text] is still the source's own characters in their own order.
+  /// Everything else falls back to interpolating across the run width.
+  static List<double>? _sliceCharOffsets(
+    PdfTextRun source,
+    String text,
+    int sourceStart,
+    int sourceEnd,
+    bool rightToLeft,
+  ) {
+    final all = source.charOffsets;
+    if (all == null || rightToLeft) return null;
+    if (sourceEnd - sourceStart != text.length) return null;
+    if (sourceStart < 0 || sourceEnd >= all.length) return null;
+    final base = all[sourceStart];
+    // The overwhelmingly common case is one extracted run per source run, so
+    // the slice is the whole table already rebased at 0 - share it rather
+    // than copying every run's advances. Nothing mutates it.
+    if (base == 0 && sourceEnd == all.length - 1) return all;
+    return [for (var i = sourceStart; i <= sourceEnd; i++) all[i] - base];
   }
 
   /// Groups zero-advance marks with their following base run, then orders the
@@ -1097,8 +1190,7 @@ class PdfTextReflower {
 
   /// A line that opens with a bullet glyph or an enumerator (`1.`, `a)`,
   /// `(iv)`) followed by whitespace - the start of a list item.
-  static final RegExp _listMarker = RegExp(
-      r'^\s*([•‣◦⁃∙·▪●❖*\-–-]'
+  static final RegExp _listMarker = RegExp(r'^\s*([•‣◦⁃∙·▪●❖*\-–-]'
       r'|\(?([0-9]{1,3}|[A-Za-z]|[ivxlcdmIVXLCDM]{1,5})[.)])\s+\S');
 
   static bool _startsListItem(String text) => _listMarker.hasMatch(text);
@@ -1335,7 +1427,8 @@ double _horizontalOverlap(PdfRect a, PdfRect b) =>
 /// (0 when they don't overlap, 1 when one contains the other).
 double _overlapFraction(PdfRect a, PdfRect b) {
   final w = _horizontalOverlap(a, b);
-  final h = math.max(0.0, math.min(a.top, b.top) - math.max(a.bottom, b.bottom));
+  final h =
+      math.max(0.0, math.min(a.top, b.top) - math.max(a.bottom, b.bottom));
   final overlap = w * h;
   if (overlap <= 0) return 0;
   final smaller = math.min(a.width * a.height, b.width * b.height);
@@ -1370,9 +1463,8 @@ double _medianWith(List<double> sorted, double extra) {
   final length = sorted.length + 1;
   final pos = _lowerBound(sorted, extra);
   // the merged sequence is sorted[0..pos) + [extra] + sorted[pos..)
-  double at(int rank) => rank < pos
-      ? sorted[rank]
-      : (rank == pos ? extra : sorted[rank - 1]);
+  double at(int rank) =>
+      rank < pos ? sorted[rank] : (rank == pos ? extra : sorted[rank - 1]);
   final middle = length ~/ 2;
   if (length.isOdd) return at(middle);
   return (at(middle - 1) + at(middle)) / 2;

--- a/packages/pdf_graphics/test/page_text_codec_test.dart
+++ b/packages/pdf_graphics/test/page_text_codec_test.dart
@@ -13,6 +13,7 @@ void _expectRunEquals(PdfExtractedRun a, PdfExtractedRun b) {
   expect(b.mcid, a.mcid);
   expect(b.width, a.width);
   expect(b.isRightToLeft, a.isRightToLeft);
+  expect(b.charOffsets, a.charOffsets);
   expect([b.transform.a, b.transform.b, b.transform.c, b.transform.d,
     b.transform.e, b.transform.f],
       [a.transform.a, a.transform.b, a.transform.c, a.transform.d,

--- a/packages/pdf_graphics/test/text_cache_test.dart
+++ b/packages/pdf_graphics/test/text_cache_test.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:pdf_document/pdf_document.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 import 'package:test/test.dart';
 
 PdfPageText _sample() => PdfPageText(
@@ -14,6 +15,8 @@ PdfPageText _sample() => PdfPageText(
           transform: PdfMatrix(12, 0, 0, 12, 72, 700),
           width: 2.5,
           bounds: PdfRect(72, 694, 132, 712),
+          // Uneven, like a proportional font's real advances (#647).
+          charOffsets: [0, 0.72, 1.28, 1.5, 1.72, 2.5],
         ),
         PdfExtractedRun(
           text: 'wörld',
@@ -35,6 +38,7 @@ void _expectSame(PdfPageText a, PdfPageText b) {
     expect(b.runs[i].startIndex, a.runs[i].startIndex);
     expect(b.runs[i].isRightToLeft, a.runs[i].isRightToLeft);
     expect(b.runs[i].width, a.runs[i].width);
+    expect(b.runs[i].charOffsets, a.runs[i].charOffsets);
     final ta = a.runs[i].transform, tb = b.runs[i].transform;
     expect([tb.a, tb.b, tb.c, tb.d, tb.e, tb.f],
         [ta.a, ta.b, ta.c, ta.d, ta.e, ta.f]);
@@ -66,6 +70,46 @@ void main() {
       final page = PdfPageText(pageIndex: 0, text: '', runs: const []);
       final decoded = pdfDecodePageText(pdfEncodePageText(page));
       _expectSame(page, decoded!);
+    });
+
+    test('a real extraction round-trips with its selection geometry', () {
+      // The disk tier serves cached text on every reopen, so per-character
+      // advances (#647) have to survive it - otherwise a cache hit silently
+      // reverts highlights to the interpolated positions the issue reported.
+      final original =
+          PdfTextExtractor.extract(PdfDocument.open(buildClassicPdf()), 0);
+      final decoded = pdfDecodePageText(pdfEncodePageText(original))!;
+      _expectSame(original, decoded);
+      expect(original.runs.single.charOffsets, isNotNull);
+
+      final start = original.text.indexOf('world');
+      expect(decoded.quadsFor(start, start + 5).single.corners,
+          original.quadsFor(start, start + 5).single.corners);
+      final mid = 72 + measureHelvetica('Hello, wor', 24);
+      expect(decoded.positionNear(mid, 726), original.positionNear(mid, 726));
+    });
+
+    test('a table of the wrong length is dropped, not trusted', () {
+      // Lenient on input: a stale or corrupt blob whose offsets no longer
+      // match the run text falls back to interpolation instead of throwing
+      // out of quadsFor.
+      const page = PdfPageText(
+        pageIndex: 0,
+        text: 'abc',
+        runs: [
+          PdfExtractedRun(
+            text: 'abc',
+            startIndex: 0,
+            transform: PdfMatrix(12, 0, 0, 12, 0, 0),
+            width: 1.5,
+            bounds: PdfRect(0, 0, 18, 12),
+            charOffsets: [0, 0.5, 1.5], // one short: needs text.length + 1
+          ),
+        ],
+      );
+      final decoded = pdfDecodePageText(pdfEncodePageText(page))!;
+      expect(decoded.runs.single.charOffsets, isNull);
+      expect(decoded.quadsFor(0, 3), hasLength(1)); // and still usable
     });
   });
 

--- a/packages/pdf_graphics/test/text_extraction_test.dart
+++ b/packages/pdf_graphics/test/text_extraction_test.dart
@@ -24,7 +24,7 @@ void main() {
     expect(run.bounds.top, closeTo(720 + 0.75 * 24, 1e-6));
   });
 
-  test('findAll locates substrings with interpolated rects', () {
+  test('findAll locates substrings on the actual glyphs', () {
     final doc = PdfDocument.open(buildClassicPdf());
     final text = PdfTextExtractor.extract(doc, 0);
 
@@ -33,11 +33,16 @@ void main() {
     final match = matches.single;
     expect(text.text.substring(match.start, match.end), 'world');
     final rect = match.rects.single;
-    // 'world' starts at char 7 of 13; rects interpolate linearly across
-    // the run's drawn width
+    // Rects follow the font's own advances, so they sit on the glyphs even
+    // though Helvetica's characters are far from uniform width (issue #647).
+    expect(rect.left, closeTo(72 + measureHelvetica('Hello, ', 24), 1e-6));
+    expect(
+        rect.right, closeTo(72 + measureHelvetica('Hello, world', 24), 1e-6));
+    // The linear-interpolation approximation this replaced was ~3pt out on
+    // both edges - a visible miss at 24pt.
     final width = measureHelvetica('Hello, world!', 24);
-    expect(rect.left, closeTo(72 + width * (7 / 13), 1e-6));
-    expect(rect.right, closeTo(72 + width * (12 / 13), 1e-6));
+    expect((rect.left - (72 + width * 7 / 13)).abs(), greaterThan(2));
+    expect((rect.right - (72 + width * 12 / 13)).abs(), greaterThan(2));
   });
 
   test('search is case-insensitive by default', () {
@@ -77,14 +82,13 @@ void main() {
   test('positionNear maps page points to character offsets', () {
     final doc = PdfDocument.open(buildClassicPdf());
     final text = PdfTextExtractor.extract(doc, 0);
-    // 'Hello, world!' at 72,720 in 24pt; offsets interpolate linearly
-    // across the run width
-    final perChar = measureHelvetica('Hello, world!', 24) / 13;
+    // 'Hello, world!' at 72,720 in 24pt; offsets follow the font's advances
+    final beforeW = 72 + measureHelvetica('Hello, ', 24);
     expect(text.positionNear(72, 720), 0);
-    expect(text.positionNear(72 + perChar * 7, 720), 7); // before 'w'
+    expect(text.positionNear(beforeW, 720), 7); // before 'w'
     expect(text.positionNear(228, 720), 13); // past the end
     // snaps vertically from outside the bounds
-    expect(text.positionNear(72 + perChar * 7, 750), 7);
+    expect(text.positionNear(beforeW, 750), 7);
     // but respects a finite tolerance
     expect(text.positionNear(72, 400, tolerance: 20), -1);
     expect(text.positionNear(400, 400, tolerance: 20), -1);
@@ -94,9 +98,121 @@ void main() {
     final doc = PdfDocument.open(buildClassicPdf());
     final text = PdfTextExtractor.extract(doc, 0);
     final rect = text.rectsFor(7, 12).single;
-    final perChar = measureHelvetica('Hello, world!', 24) / 13;
-    expect(rect.left, closeTo(72 + perChar * 7, 1e-6));
-    expect(rect.right, closeTo(72 + perChar * 12, 1e-6));
+    expect(rect.left, closeTo(72 + measureHelvetica('Hello, ', 24), 1e-6));
+    expect(
+        rect.right, closeTo(72 + measureHelvetica('Hello, world', 24), 1e-6));
+  });
+
+  group('per-character advances (issue #647)', () {
+    // The regression the issue reports: interpolating a highlight linearly
+    // across a run's width assumes every character is the same width. In a
+    // proportional font they are not, and the selection band slides off the
+    // glyphs. 'I' is 0.278em in Helvetica and 'W' is 0.944em - a 3.4x spread,
+    // so the error here is a large fraction of the run rather than a few
+    // points.
+    const line = 'IIIIII WWWWWW';
+
+    PdfPageText extract() => PdfTextExtractor.extract(
+        PdfDocument.open(
+            _buildTextPdf(['BT /F1 24 Tf 72 720 Td ($line) Tj ET'])),
+        0);
+
+    test('charOffsets are the font advances, ascending and complete', () {
+      final run = extract().runs.single;
+      final offsets = run.charOffsets;
+      expect(offsets, isNotNull);
+      expect(offsets, hasLength(line.length + 1));
+      expect(offsets!.first, 0);
+      expect(offsets.last, closeTo(run.width, 1e-9));
+      for (var i = 0; i < line.length; i++) {
+        expect(offsets[i],
+            closeTo(measureHelvetica(line.substring(0, i), 1), 1e-9));
+        expect(offsets[i + 1], greaterThanOrEqualTo(offsets[i]));
+      }
+    });
+
+    test('the highlight lands on the wide word, not a third of a run away', () {
+      final text = extract();
+      final start = line.indexOf('W');
+      final rect = text.rectsFor(start, line.length).single;
+      expect(rect.left, closeTo(72 + measureHelvetica('IIIIII ', 24), 1e-6));
+      expect(rect.right, closeTo(72 + measureHelvetica(line, 24), 1e-6));
+
+      // What linear interpolation would have produced, for contrast: off by
+      // more than a quarter of the run, which is what the issue describes.
+      final width = measureHelvetica(line, 24);
+      final interpolated = 72 + width * start / line.length;
+      expect((interpolated - rect.left).abs(), greaterThan(width * 0.25));
+    });
+
+    test('hit-testing snaps to the character actually under the point', () {
+      final text = extract();
+      // The centre of the 4th 'W'. Under linear interpolation this point sits
+      // two thirds of the way along the run and would map into the 'I's.
+      final x = 72 +
+          measureHelvetica('IIIIII WWW', 24) + //
+          measureHelvetica('W', 24) / 2;
+      expect(text.positionNear(x, 726), 10);
+      // every boundary round-trips through its own offset
+      for (var i = 0; i <= line.length; i++) {
+        expect(
+            text.positionNear(
+                72 + measureHelvetica(line.substring(0, i), 24), 726),
+            i);
+      }
+    });
+
+    test('character and word spacing are inside the offsets', () {
+      // Tc 5 adds 5pt after every glyph, Tw 10 adds 10pt after each space.
+      final text = PdfTextExtractor.extract(
+          PdfDocument.open(_buildTextPdf(
+              ['BT /F1 24 Tf 5 Tc 10 Tw 72 720 Td (ab cd) Tj ET'])),
+          0);
+      final offsets = text.runs.single.charOffsets!;
+      // offsets are in em (the run transform carries the 24pt size)
+      double at(int i) => offsets[i] * 24;
+      expect(at(0), 0);
+      expect(at(1), closeTo(measureHelvetica('a', 24) + 5, 1e-9));
+      expect(at(2), closeTo(measureHelvetica('ab', 24) + 10, 1e-9));
+      // the space carries Tc *and* Tw
+      expect(at(3), closeTo(measureHelvetica('ab ', 24) + 15 + 10, 1e-9));
+      expect(at(5), closeTo(text.runs.single.width * 24, 1e-9));
+    });
+
+    test('a rotated run keeps its quad on the glyphs', () {
+      // 90° CCW baseline: the advance runs up the page, so a wrong offset
+      // shows up in y rather than x.
+      final text = PdfTextExtractor.extract(
+          PdfDocument.open(_buildTextPdf(
+              ['BT /F1 24 Tf 0 1 -1 0 300 400 Tm ($line) Tj ET'])),
+          0);
+      final start = line.indexOf('W');
+      final quad = text.quadsFor(start, line.length).single;
+      // lower-left corner of the quad sits at the start of the wide word
+      expect(quad.corners[0].$2,
+          closeTo(400 + measureHelvetica('IIIIII ', 24), 1e-6));
+      expect(
+          quad.corners[1].$2, closeTo(400 + measureHelvetica(line, 24), 1e-6));
+    });
+
+    test('runs split across show operators each carry their own offsets', () {
+      // A TJ array emits one run per string element; each must be measured
+      // from its own origin, not the line's.
+      final text = PdfTextExtractor.extract(
+          PdfDocument.open(_buildTextPdf(
+              ['BT /F1 24 Tf 72 720 Td [(IIIIII) -2000 (WWWWWW)] TJ ET'])),
+          0);
+      for (final run in text.runs) {
+        final offsets = run.charOffsets!;
+        expect(offsets.first, 0);
+        expect(offsets, hasLength(run.text.length + 1));
+        expect(offsets.last, closeTo(run.width, 1e-9));
+      }
+      final second = text.runs.last;
+      // the -2000 kern (2 em at 24pt) opens a real gap before 'WWWWWW'
+      expect(second.bounds.left,
+          closeTo(72 + measureHelvetica('IIIIII', 24) + 48, 1e-6));
+    });
   });
 
   test('quadsFor matches the rect for horizontal text', () {


### PR DESCRIPTION
Refs #647 — deliberately **not** `Fixes`, so merging this leaves the issue open.

#647 has two independent halves. This PR fixes the first: the selection's own geometry (range → rectangle), which is now exact. The second is glyph *painting* — for a substituted font the device matches only the run's **total** width, so interior glyphs drift up to ~4pt mid-run and a correctly placed band still reads as offset. That half is split out as #649, with the measurements. #647 should close when both have landed.

## Summary

`PdfPageText.quadsFor` sliced a run's width by character **count**, which assumes every character is the same width. In a proportional font they are not, so the selection band sat beside the glyphs rather than on them. It had carried a placeholder since the beginning:

```dart
// approximate within-run positions by character fraction; per-glyph
// geometry arrives with the font engine
```

`positionNear` made the same assumption in reverse, so a double-click's two halves — point → character, character → rectangle — compounded the error.

On the issue's own repro (`Hello, world!` in 24pt Helvetica) the `world` band landed 3pt right and 6.5pt narrow. The error scales with how uneven the run is: `I` is 0.278em in Helvetica and `W` is 0.944em, so on `IIIIII WWWWWW` the highlight misses by more than a quarter of the run — the "roughly 1/3" the issue reports.

**The fix** carries the real advances end to end. The interpreter already accumulates the exact pen position per glyph; it just discarded it for anything but embedded outlines.

- `PdfTextRun.charOffsets` — em-space offset of every character boundary, length `text.length + 1`, last entry `== width`.
- `PdfInterpreter(collectCharOffsets:)` — **off by default**. Painting walks get the same positions from `PdfTextRun.glyphs` and would otherwise pay a list per run for nothing; `PdfTextExtractor` turns it on.

The flag is what makes the reported case work at all: `glyphs` is only built for `hasOutlines || isType3`, so a **non-embedded** standard-14 Helvetica — exactly the issue's PDF — has no glyph list. `charOffsets` needs only the metrics, so it covers substituted fonts too.

`PdfExtractedRun.charOffsets` carries the table to `quadsFor`/`positionNear`, which now binary-searches for the nearest boundary instead of scaling a fraction.

API impact: two new optional fields and one new optional constructor parameter. No existing signature changes; runs without a table fall back to the previous interpolation.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [x] `pdf_graphics`
- [x] `dart_pdf_editor` (test only)
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` — clean
- [x] `cd packages/pdf_cos && fvm dart test` — 356 pass
- [x] `cd packages/pdf_document && fvm dart test` — 808 pass
- [x] `cd packages/pdf_graphics && fvm dart test` — 1009 pass
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 2114 pass
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

The render path is untouched — the flag leaves `charOffsets` null for every painting walk — so no render baseline can move. Covered instead by the deterministic counter gate (`tool/perf.sh gate`: 12 inputs, 13 counters within 3%) and the corpus A/B below, which does exercise the real 16-file corpus through parse + interpret + extract.

## Performance

Text extraction is on the changed path, so it was measured rather than eyeballed. `tool/perf.sh diff d84479b SCENARIO`, 4 interleaved runs:

| metric | `type3-text-sweep` | `dartpdf-corpus` |
| --- | --- | --- |
| `openMs` | 1.031x | 0.976x |
| `firstPageMs` | 0.934x | 0.991x |
| `interpretMs` | 0.953x | 0.979x |
| `extractMs` | 1.037x | 1.009x |
| `saveMs` | 1.031x | 0.990x |
| `peakRssBytes` | 1.033x | 1.017x |

Both VERDICT OK.

**The corpus sweep caught a regression the single-scenario run missed.** `extractMs` first came back at **1.114x — REGRESSED**, over the 1.10 gate, worst on `text-report-40p.pdf` at 1.45x. Two causes, both fixed in the first commit:

- `_sliceCharOffsets` copied the whole advance table per run, when the common case is one extracted run per source run and the slice is the whole thing already rebased at 0. It now shares the source list — nothing mutates it — saving an allocation and a copy per run.
- the per-glyph clamp read `charOffsets.last` (a bounds-checked call once per glyph); the tail is now tracked in a local.

`type3-text-sweep` alone said 1.037x and looked fine, so for extraction changes the corpus scenario is the one that matters. Also worth stating plainly: the first 1.114x was measured while I had sources open mid-run, which `CLAUDE.md` forbids for exactly this reason, so I discarded it and re-ran clean. Both columns above are complete uninterrupted runs.

## Notes for reviewers

Gotchas worth a look:

- **The BiDi pass invalidates the table.** `_bidiLine` reverses runs and re-splits them per glyph, so the offsets stop lining up with a piece's characters. `_sliceCharOffsets` declines unless the piece is the source's own characters in their own order, and `quadsFor`/`positionNear` additionally ignore a table on an RTL run. RTL keeps the previous interpolation exactly.
- **Vertical writing mode gets null** — the pen advances along y, so a per-character *x* offset is meaningless.
- **A /ToUnicode ligature** maps one code to several characters. The PDF positions the code, not its pieces, so the advance splits evenly; the invariant that matters is the `text.length + 1` length, asserted at the emit site.
- **Offsets are clamped non-decreasing.** A negative `Tc` tighter than a glyph's own width walks the pen backwards, and consumers binary-search these. `_bidiLine` already did the same `math.max` for glyph offsets.
- **Two codecs, not one — and both their tests passed with the offsets dropped.** `serializePageText` (`render_command_codec.dart`) is the render-worker hop, the path this fix actually travels in production; its test compared only search *hit counts*. `pdfEncodePageText` (`text_cache.dart`) is the on-disk tier (magic `PTX2` → `PTX3`); its sample runs carried no `charOffsets` at all. Neither would have noticed a field missing from the wire. Both now compare geometry, and the worker one was verified to fail with the field removed.

Three existing tests pinned the old approximation by name ("interpolated rects", a `perChar` expectation) and were rewritten to the exact metrics; one now also asserts the old value is >2pt away, so the approximation cannot quietly return.

Two lines remain uncovered by choice: the vertical-writing bail-out, and the partial-slice rebase that only runs for per-glyph LTR pieces inside a bidirectional line. A mixed-script fixture for the latter looked disproportionate given RTL geometry is unchanged here, but say the word and I'll pin it.

Session notes: `doc/dev-log/2026-08-05-per-character-advances-647.md`.