### PR TITLE
Hide the page colour tool in view mode

### DIFF
--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -2654,6 +2654,10 @@ class _EditorScreenState extends State<EditorScreen>
         controller: tab.viewer,
         preferences: _prefs,
         onAction: _onAction,
+        // View mode is for reading the document as it is: the paper colour is
+        // an authoring choice, so the View options menu drops "Page color…"
+        // here and keeps it in edit mode.
+        features: const PdfReaderFeatures(pageColorEditable: false),
         pageRasterCachePolicy: pageRasterCachePolicy,
         pageRasterWarmPolicy: pageRasterWarmPolicy,
       );

--- a/app/test/read_only_view_options_test.dart
+++ b/app/test/read_only_view_options_test.dart
@@ -1,0 +1,66 @@
+// The app's read-only ("view") mode swaps PdfEditorView for PdfReader. Paper
+// colour is an authoring choice, so the View options menu drops "Page color…"
+// while reading and keeps it while editing.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor_app/editor_screen.dart';
+
+void main() {
+  late PdfEditingPreferences prefs;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    prefs = PdfEditingPreferences();
+  });
+  tearDown(() => prefs.dispose());
+
+  Future<void> pumpWithDoc(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        initialDocument: (bytes: buildClassicPdf(), title: 'Report.pdf'),
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  Future<void> switchToReadOnly(WidgetTester tester) async {
+    await tester.tap(find.byTooltip('DartPDF menu'));
+    await tester.pumpAndSettle();
+    final item = find.text('Switch to read-only');
+    await tester.ensureVisible(item);
+    await tester.pumpAndSettle();
+    await tester.tap(item);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> openViewOptions(WidgetTester tester) async {
+    await tester.tap(find.byKey(const ValueKey('pdf-shell-view-options')));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('view mode hides the page-color item', (tester) async {
+    await pumpWithDoc(tester);
+    await switchToReadOnly(tester);
+
+    expect(find.byType(PdfReader), findsOneWidget);
+    await openViewOptions(tester);
+    // the menu is open (annotations item shows) but page color is gone
+    expect(
+        find.byKey(const ValueKey('pdf-shell-show-annotations')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-shell-page-color')), findsNothing);
+  });
+
+  testWidgets('edit mode still offers the page-color item', (tester) async {
+    await pumpWithDoc(tester);
+
+    expect(find.byType(PdfEditorView), findsOneWidget);
+    await openViewOptions(tester);
+    expect(find.byKey(const ValueKey('pdf-shell-page-color')), findsOneWidget);
+  });
+}

--- a/doc/dev-log/2026-08-06-hide-page-colour-in-view-mode.md
+++ b/doc/dev-log/2026-08-06-hide-page-colour-in-view-mode.md
@@ -1,0 +1,20 @@
+# Hide the page colour tool in view mode
+
+The app's read-only ("view") mode swaps `PdfEditorView` for `PdfReader`
+(`EditorScreen._readOnly`, toggled from the DartPDF menu's "Switch to
+read-only"). Until now that reader used the stock `PdfReaderFeatures`, so the
+View options menu still offered "Page color…" — paper colour is an authoring
+choice, not something a reader should be changing.
+
+The plumbing already existed: `PdfReaderFeatures.pageColorEditable` gates the
+item in both the desktop popup and the mobile sheet (`shell_chrome.dart`, key
+`pdf-shell-page-color`). The fix is just to pass
+`features: const PdfReaderFeatures(pageColorEditable: false)` when
+`EditorScreen` builds the reader. Edit mode is untouched — `PdfEditorView`
+keeps its own `pageColorEditable`, still defaulting to true.
+
+Covered by `app/test/read_only_view_options_test.dart`: the item is gone after
+switching to read-only and present in edit mode. Note the read-only menu entry
+carries no `ValueKey`, so the test drives it by its label and calls
+`ensureVisible` first — with a document open the menu runs past the fold of the
+default 600px-high test window and a plain tap hits the scrim.


### PR DESCRIPTION
## Summary

The app's read-only ("view") mode swaps `PdfEditorView` for `PdfReader`
(`EditorScreen._readOnly`, toggled from the DartPDF menu's "Switch to
read-only"). That reader was built with the stock `PdfReaderFeatures`, so the
View options menu still offered "Page color…" while reading — paper colour is an
authoring choice, not a reader control.

The plumbing already existed: `PdfReaderFeatures.pageColorEditable` gates the
item in both the desktop popup and the mobile bottom sheet (`shell_chrome.dart`,
key `pdf-shell-page-color`). The change is to pass
`features: const PdfReaderFeatures(pageColorEditable: false)` when
`EditorScreen` builds the reader. Edit mode is untouched — `PdfEditorView` keeps
its own `pageColorEditable`, still defaulting to true — and no library defaults
or public API changed, so embedders of `PdfReader` see no behaviour change.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app <!-- the DartPDF app under app/ -->
- [x] Documentation / CI / repository metadata only <!-- dev-log note -->

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change <!-- UI affordance only -->
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (on the changed files — no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [x] Example app smoke test — `cd app && fvm flutter test`, 414 tests pass

If any relevant check was not run, explain why: the change is confined to
`app/lib/editor_screen.dart` and touches no library code, no parsing, and no
rendering, so the package suites and the corpus/Ghent sweeps have nothing to
exercise here.

## PDF fixtures and screenshots

None needed — the new test drives the real menus with the programmatic
`buildClassicPdf()` fixture.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

`app/test/read_only_view_options_test.dart` pins both directions: the item is
gone after switching to read-only, and still present in edit mode. The read-only
menu entry carries no `ValueKey`, so the test drives it by its label and calls
`ensureVisible` first — with a document open the menu runs past the fold of the
default 600px-high test window and a plain tap lands on the scrim.

Session note added at `doc/dev-log/2026-08-06-hide-page-colour-in-view-mode.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhvFNWRhho2DwVnpzTsMjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhvFNWRhho2DwVnpzTsMjC)_