### PR TITLE
Show the selected annotation's colour in the toolbar palette

### DIFF
--- a/doc/dev-log/2026-08-06-selection-colour-in-toolbar.md
+++ b/doc/dev-log/2026-08-06-selection-colour-in-toolbar.md
@@ -1,0 +1,53 @@
+# The toolbar swatches read back the selection's colour
+
+Selecting an annotation left the toolbar's palette ringing the *last-used*
+creation colour. Draw a red box, pick blue for the next one, then click the
+red box: the ring said blue while every other control in the same strip -
+stroke width, opacity, line style, shape fill - had already switched to
+showing the box's own values. Tapping a swatch there recolours the
+selection, so the row was a readout of something it wasn't about to change.
+
+## The fix
+
+`PdfEditingController.displayColor` (editing_controller.dart, beside
+`selectedAnnotationStyle`) is the one reading:
+
+```dart
+Color get displayColor {
+  if (!canRestyleSelected) return color;
+  final rgb = selectedAnnotation?.behavior.style.color;
+  return rgb == null ? color : Color(0xFF000000 | rgb);
+}
+```
+
+Two gates matter:
+
+- **`canRestyleSelected`, not just "something is selected".** It is exactly
+  the condition under which a swatch tap recolours in place
+  (`_applyColor` → `restyleSelected`). A selected annotation the editor
+  can't restyle still only moves the creation default, so it keeps showing
+  that default. Same predicate `_strokePresets` and the tune popup already
+  use.
+- **Reading `behavior.style.color` (an `int?`) rather than
+  `selectedAnnotationStyle.color`.** That record maps a missing `/C` to
+  `Color(0xFF000000 | 0)`, i.e. black - fine as a mutation default, a lie
+  as a readout. An image stamp or a shape with no `/C` falls back to the
+  creation colour instead of claiming to be black. Free text resolves to
+  its `/DA` text colour, which is what a swatch tap changes there.
+
+Call sites in editing_toolbar.dart: `_colorCluster` (swatch rings, the
+"more colours" palette icon *and* the colour picker's `initial`),
+`_mobileSwatches`, and the tune popup's `strokeColorValue` - which also
+picks up the null-`/C` fix, since its old `annotationStyle?.color ??
+controller.color` could never see the null.
+
+`_StyleFields`' free-text `textValue` was left alone on purpose: it is gated
+on `canRestyleSelectedText` (any single FreeText), a broader condition than
+`displayColor`'s, and already carries its own fallback chain.
+
+Tests: `test/editing_selection_color_test.dart` - controller readback
+(no selection / selected / deselected / after a restyle / free text /
+multi-select primary) plus a widget test that watches the 3px ring move
+between the red and blue palette swatches as the selection comes and goes.
+The strip only carries the palette when a group is open, so the
+no-selection half of that test arms the rectangle tool.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -5140,6 +5140,21 @@ class PdfEditingController extends ChangeNotifier {
     );
   }
 
+  /// The colour the style controls should show: with a selection they
+  /// recolour ([canRestyleSelected]), the primary selected annotation's own
+  /// colour rather than [color], the last-used creation colour - a swatch
+  /// row is a readout of what the next tap changes, so it has to follow the
+  /// selection the way the stroke/opacity controls already do.
+  ///
+  /// Falls back to [color] when nothing restylable is selected, or when the
+  /// annotation carries no colour of its own (an image stamp, a shape with
+  /// no /C) - showing black there would be a lie about the annotation.
+  Color get displayColor {
+    if (!canRestyleSelected) return color;
+    final rgb = selectedAnnotation?.behavior.style.color;
+    return rgb == null ? color : Color(0xFF000000 | rgb);
+  }
+
   /// Whether [restyleSelected]'s `fill` parameter applies to every selected
   /// annotation (shapes and FreeText boxes).
   bool get canFillSelected =>

--- a/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_toolbar.dart
@@ -1857,6 +1857,9 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   List<Widget> _colorCluster(BuildContext context) {
     if (!widget.showColor) return const [];
     final scheme = Theme.of(context).colorScheme;
+    // with a restylable selection the swatches show - and change - its
+    // colour; otherwise the creation default
+    final current = controller.displayColor;
     return [
       for (final color in widget.palette)
         Padding(
@@ -1871,10 +1874,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                 color: color,
                 shape: BoxShape.circle,
                 border: Border.all(
-                  color: controller.color == color
-                      ? scheme.primary
-                      : scheme.outline,
-                  width: controller.color == color ? 3 : 1,
+                  color: current == color ? scheme.primary : scheme.outline,
+                  width: current == color ? 3 : 1,
                 ),
               ),
             ),
@@ -1891,16 +1892,16 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
             child: InkWell(
               customBorder: const CircleBorder(),
               onTap: () async {
-                final picked = await pickEditingColor(context, controller,
-                    initial: controller.color);
+                final picked =
+                    await pickEditingColor(context, controller, initial: current);
                 if (picked != null) _applyColor(picked);
               },
               child: SizedBox(
                 width: 40,
                 height: 40,
                 child: Center(
-                  child: Icon(Icons.palette_outlined,
-                      color: controller.color, size: 20),
+                  child:
+                      Icon(Icons.palette_outlined, color: current, size: 20),
                 ),
               ),
             ),
@@ -2346,6 +2347,7 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
   /// The first [count] palette swatches, sized for the mobile dock.
   List<Widget> _mobileSwatches(BuildContext context, {int count = 3}) {
     final scheme = Theme.of(context).colorScheme;
+    final current = controller.displayColor;
     var i = 0;
     return [
       for (final color in widget.palette.take(count))
@@ -2362,10 +2364,8 @@ class _PdfEditingToolbarState extends State<PdfEditingToolbar> {
                 color: color,
                 shape: BoxShape.circle,
                 border: Border.all(
-                  color: controller.color == color
-                      ? scheme.primary
-                      : scheme.outline,
-                  width: controller.color == color ? 3 : 1,
+                  color: current == color ? scheme.primary : scheme.outline,
+                  width: current == color ? 3 : 1,
                 ),
               ),
             ),
@@ -3522,9 +3522,7 @@ class _StyleMenuState extends State<_StyleMenu> {
                 : controller.preferences.shapeFillColor;
             // shape/cloud/line outline: a selected shape shows its own /C,
             // else the creation default
-            final strokeColorValue = restylingAnnotation
-                ? (annotationStyle?.color ?? controller.color)
-                : controller.color;
+            final strokeColorValue = controller.displayColor;
             return Container(
               width: 300,
               padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),

--- a/packages/dart_pdf_editor/test/editing_selection_color_test.dart
+++ b/packages/dart_pdf_editor/test/editing_selection_color_test.dart
@@ -1,0 +1,154 @@
+// The colour the style controls read back: with an annotation selected the
+// swatches show its own colour, not the last-used creation colour.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_document/pdf_document.dart';
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _red = Color(0xFFE53935);
+const _blue = Color(0xFF1E88E5);
+const _green = Color(0xFF43A047);
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  group('displayColor on the controller', () {
+    test('without a selection it is the creation colour', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))..color = _red;
+      addTearDown(editing.dispose);
+      expect(editing.displayColor, _red);
+    });
+
+    test('a selected annotation shows its own colour', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))..color = _red;
+      addTearDown(editing.dispose);
+      editing
+        ..addRectangle(0, const PdfRect(100, 100, 300, 200))
+        ..color = _blue // draw red, then move the creation default on
+        ..selectAnnotation(0, 0);
+      expect(editing.displayColor, _red);
+      expect(editing.color, _blue, reason: 'the creation default is untouched');
+    });
+
+    test('deselecting falls back to the creation colour', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))..color = _red;
+      addTearDown(editing.dispose);
+      editing
+        ..addRectangle(0, const PdfRect(100, 100, 300, 200))
+        ..color = _blue
+        ..selectAnnotation(0, 0)
+        ..clearAnnotationSelection();
+      expect(editing.displayColor, _blue);
+    });
+
+    test('it follows a restyle of the selection', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))..color = _red;
+      addTearDown(editing.dispose);
+      editing
+        ..addRectangle(0, const PdfRect(100, 100, 300, 200))
+        ..selectAnnotation(0, 0);
+      expect(editing.restyleSelected(color: _green), isTrue);
+      expect(editing.displayColor, _green);
+    });
+
+    test('a selected free text shows its text colour', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))..color = _red;
+      addTearDown(editing.dispose);
+      editing
+        ..addFreeText(0, const PdfRect(100, 100, 300, 160), 'hello')
+        ..color = _blue
+        ..selectAnnotation(0, 0);
+      expect(editing.canRestyleSelected, isTrue);
+      expect(editing.displayColor, _red);
+    });
+
+    test('a multi-selection shows the primary annotation colour', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1))..color = _red;
+      addTearDown(editing.dispose);
+      editing
+        ..addRectangle(0, const PdfRect(100, 100, 300, 200))
+        ..color = _green
+        ..addEllipse(0, const PdfRect(320, 100, 400, 200))
+        ..color = _blue
+        ..selectAnnotationsIn(0, const PdfRect(0, 0, 612, 792));
+      expect(editing.selectedAnnotationSlots, hasLength(2));
+      // the primary is the last slot added to the selection
+      final primary = editing.selectedAnnotation!;
+      expect(editing.displayColor, Color(0xFF000000 | primary.color!));
+    });
+  });
+
+  group('in the toolbar', () {
+    Future<PdfEditingController> pumpEditor(WidgetTester tester) async {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: ListenableBuilder(
+            listenable: editing,
+            builder: (context, _) => PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: editing.document,
+              controller: viewer,
+              editing: editing,
+            ),
+          ),
+          bottomNavigationBar:
+              PdfEditingToolbar(controller: editing, viewerController: viewer),
+        ),
+      ));
+      await tester.pump();
+      return editing;
+    }
+
+    /// The ring width the palette swatch for [color] is drawn with - 3 when
+    /// it reads as the current colour, 1 otherwise.
+    double ringWidth(WidgetTester tester, Color color) {
+      final swatch = find.descendant(
+        of: find.byType(PdfEditingToolbar),
+        matching: find.byWidgetPredicate((w) =>
+            w is Container &&
+            w.decoration is BoxDecoration &&
+            (w.decoration! as BoxDecoration).color == color &&
+            (w.decoration! as BoxDecoration).shape == BoxShape.circle),
+      );
+      expect(swatch, findsOneWidget);
+      final decoration =
+          tester.widget<Container>(swatch).decoration! as BoxDecoration;
+      return (decoration.border! as Border).top.width;
+    }
+
+    testWidgets('the palette ring follows the selected annotation',
+        (tester) async {
+      final editing = await pumpEditor(tester);
+      editing
+        ..color = _red
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750))
+        ..color = _blue
+        // arm a shape tool so the strip carries the palette with nothing
+        // selected; a selection takes the strip over and carries it too
+        ..tool = PdfEditTool.rectangle;
+      await tester.pump();
+      expect(ringWidth(tester, _blue), 3, reason: 'the last-used colour');
+      expect(ringWidth(tester, _red), 1);
+
+      editing.selectAnnotation(0, 0);
+      await tester.pump();
+      expect(ringWidth(tester, _red), 3, reason: "the selection's own colour");
+      expect(ringWidth(tester, _blue), 1);
+
+      editing
+        ..clearAnnotationSelection()
+        ..tool = PdfEditTool.rectangle;
+      await tester.pump();
+      expect(ringWidth(tester, _blue), 3);
+      expect(ringWidth(tester, _red), 1);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Selecting an annotation left the toolbar's palette ringing the **last-used creation colour**. Draw a red box, pick blue for the next one, then click the red box: the ring said blue, while every other control in the same strip — stroke width, opacity, line style, shape fill — had already switched to the box's own values. Tapping a swatch there recolours the selection, so the row was a readout of something it wasn't about to change.

New `PdfEditingController.displayColor` is the single reading:

```dart
Color get displayColor {
  if (!canRestyleSelected) return color;
  final rgb = selectedAnnotation?.behavior.style.color;
  return rgb == null ? color : Color(0xFF000000 | rgb);
}
```

Two gates matter:

- **`canRestyleSelected`, not just "something is selected"** — exactly the condition under which a swatch tap recolours in place (`_applyColor` → `restyleSelected`). A selected annotation the editor can't restyle still only moves the creation default, so it keeps showing that default. Same predicate `_strokePresets` and the tune popup already use.
- **Reading `behavior.style.color` (an `int?`) rather than `selectedAnnotationStyle.color`** — that record maps a missing `/C` to black, fine as a mutation default but a lie as a readout. An image stamp or a shape with no `/C` falls back to the creation colour. Free text resolves to its `/DA` text colour, which is what a swatch tap changes there.

Call sites in `editing_toolbar.dart`: `_colorCluster` (swatch rings, the "more colours" palette icon, and the colour picker's `initial`), `_mobileSwatches`, and the tune popup's `strokeColorValue` — which also picks up the null-`/C` fix, since its old `annotationStyle?.color ?? controller.color` could never see the null.

`_StyleFields`' free-text `textValue` is left alone on purpose: it is gated on `canRestyleSelectedText` (any single FreeText), broader than `displayColor`'s gate, and already carries its own fallback chain.

No behaviour change to what a tap *does* — only to what the controls report.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (workspace-wide, clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (targeted: the new file plus every toolbar/style/selection suite — `editing_selection_color`, `editing_clipboard`, `editing_mobile_toolbar`, `editing_mobile_tune`, `editing_shape_styles`, `editing_text_style`, `editing_properties`, `editing_polish`, `editing_tune_focus`, `editing_multiselect`, `editing_set_default_style`, `editing_test`, `pdf_shell`, `editing_stamps`, `editing_measure`, `editing_line_endings`, `editing_form_style`, `dark_mode`, `editing_takeoff_tools`, `editing_menu` — all green)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is Flutter-side UI state in `dart_pdf_editor` only — it touches no parser, renderer, or page content, so the corpus/Ghent render suites and the pure-Dart package tests can't be affected. Rather than the full Flutter suite, the toolbar, style-control, and selection suites were run in full.

## PDF fixtures and screenshots

None needed — covered by programmatic fixtures. `test/editing_selection_color_test.dart` adds controller readback tests (no selection / selected / deselected / after a restyle / free text / multi-select primary) plus a widget test that watches the 3px selection ring move between the red and blue palette swatches as the selection comes and goes. (The strip only carries the palette when a group is open, so the no-selection half of that test arms the rectangle tool.)

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `displayColor` is new public API on `PdfEditingController`; hosts with custom chrome can use it for their own swatch rows.
- With a multi-selection of mixed colours the row shows the **primary** (last-selected) annotation's colour. A dedicated "varies" state would be a bigger change to the swatch row — worth doing if it comes up, but out of scope here.
- Session notes: `doc/dev-log/2026-08-06-selection-colour-in-toolbar.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyP9trRkTEcQmXsdTBi2kV)_