### PR TITLE
Share the annotation clipboard across document tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ subsampling/PCRL-CPRL progressions.
 - The eraser slices ink: it removes exactly the stroke segments under
   the swept circle, splitting strokes where it crosses them.
 - Copy/cut/paste via keyboard and context menu; copies are deep
-  snapshots that survive undo and paste into other documents. Z-order
+  snapshots that survive undo, and the clipboard is shared across tabs,
+  so an annotation copied in one open document pastes into another
+  (even after the tab it came from is closed). Z-order
   edits reorder the page's /Annots array so they stick in any viewer.
   Touch reaches the same context menu with a long-press (on an
   annotation, a form field, or empty page area when the clipboard has

--- a/doc/dev-log/2026-08-06-annotation-clipboard-across-tabs.md
+++ b/doc/dev-log/2026-08-06-annotation-clipboard-across-tabs.md
@@ -1,0 +1,85 @@
+# Annotation copy/paste across document tabs
+
+Annotation copy/cut/paste already produced fully detached snapshots, but the
+clipboard holding them was a private field on `PdfEditingController`, so a
+copy only ever pasted back into the tab it was made in. Moved it out to a
+process-wide `ChangeNotifier` - the same shape the page and vector-snapshot
+clipboards already use - so annotations copied in one open document paste
+into another.
+
+## The shared clipboard
+
+`PdfAnnotationSnapshotClipboard`
+(`dart_pdf_editor/lib/src/editing/editing_annotation_clipboard.dart`) holds
+the copied `PdfAnnotationSnapshot`s plus the bookkeeping the paste cascade
+needs:
+
+- `snapshots` / `length` / `isEmpty` / `isNotEmpty` - the payload.
+- `sourceOwner` + `sourcePage`, compared through `isSource(owner, page)`.
+- `pasteCount`, stepped by `markPasted()`.
+
+`instance` is the process-wide singleton every `PdfEditingController`
+defaults to (new `annotationClipboard` constructor arg), so cross-tab paste
+needs **zero host wiring** - the app's tabs each build a plain
+`PdfEditingController(bytes, preferences: ...)` and share it automatically.
+Pass a private clipboard to isolate a session (the tests do).
+
+The controller registers `notifyListeners` on it in the constructor and
+removes it in `dispose`, exactly like `pageClipboard` / `snapshotClipboard`,
+so every tab's Paste affordance lights up the instant any tab copies.
+
+### Why the name
+
+`pdf_document` already exports `extension PdfAnnotationClipboard on
+PdfEditor` (the `pasteAnnotation` half). `dart_pdf_editor` imports
+`pdf_document`, so reusing that name would be ambiguous in every file that
+sees both. Hence `PdfAnnotationSnapshotClipboard`, which also matches what it
+actually holds - `PdfAnnotationSnapshot`s - the way `PdfSnapshotClipboard`
+holds a `PdfVectorSnapshot`.
+
+## Cascade across tabs
+
+The old cascade rule was `pageIndex == _clipboardSourcePage`: paste onto the
+page you copied from and the first paste already steps 12pt so the copy
+doesn't sit exactly on its source. Page 3 of *another* tab's document is not
+that page, so the comparison now has to include the owner - hence
+`isSource(this, pageIndex)`, an identity check against the controller that
+filled the clipboard. Pasting a copy into a different document lands it at
+exactly the coordinates it was copied from, which is what you want when
+carrying an annotation between two revisions of the same page.
+
+`sourceOwner` is held **only** to compare identity. The source tab may well
+have been closed (and its controller disposed) before the paste - nothing
+ever reads through the reference. The snapshots themselves are detached
+(dictionary and every referenced object, appearance streams included, copied
+inline by `_SnapshotCopier`), so they outlive the document they came from;
+that part already worked, it just had no way to travel.
+
+`pasteCount` lives on the clipboard rather than the controller so one copy
+keeps stepping its cascade wherever it is pasted. `markPasted()` deliberately
+does **not** notify: what can be pasted hasn't changed, and the pasting
+controller notifies anyway.
+
+## Most-recent-copy-wins, now global
+
+`copySelectedAnnotations` clears `snapshotClipboard` and `copyVectorSnapshot`
+clears `annotationClipboard`, so ⌘V always pastes whatever was copied last.
+Both clipboards being shared means that rule now holds across tabs too: copy
+a region as vector in tab B and tab A's ⌘V stops pasting the annotation it
+copied earlier.
+
+## Tests
+
+`editing_clipboard_test.dart` gained two groups: `PdfAnnotationSnapshotClipboard`
+(notify semantics, the shared-instance default, private-clipboard isolation)
+and `clipboard shared across document tabs` (copy in one controller pastes
+into another with no cascade and the right style; the copy notifies the other
+tab; repeat pastes cascade; the clipboard outlives `dispose()` of the source
+controller; a later copy in either tab replaces the payload everywhere).
+
+Because the clipboard is now process-wide, tests that copy annotations must
+start from empty or one test's copy leaks into the next -
+`PdfAnnotationSnapshotClipboard.instance.clear()` in `setUp` of
+`editing_clipboard_test`, `editing_menu_test`, `editing_longpress_menu_test`,
+and `editing_snapshot_test` (the same tax the snapshot clipboard already
+pays).

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -25,6 +25,7 @@ export 'src/editing/editing_controller.dart';
 export 'src/editing/create_signing_identity_dialog.dart';
 export 'src/editing/digital_signature.dart';
 export 'src/editing/signing_identity_store.dart';
+export 'src/editing/editing_annotation_clipboard.dart';
 export 'src/editing/editing_fonts.dart';
 export 'src/editing/editing_interaction.dart';
 export 'src/editing/editing_link.dart';

--- a/packages/dart_pdf_editor/lib/src/editing/editing_annotation_clipboard.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_annotation_clipboard.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/foundation.dart';
+import 'package:pdf_document/pdf_document.dart';
+
+/// A clipboard for copied annotations, shared across documents: copy or cut
+/// annotations in one [PdfEditingController], then paste them back into the
+/// same document - or into a different open document tab, since every
+/// controller shares the process-wide [instance] by default.
+///
+/// The payload is a list of [PdfAnnotationSnapshot]s: each one is fully
+/// detached from the document it was captured in (its dictionary and every
+/// object it references - appearance streams included - copied inline), so a
+/// paste never depends on the source document staying open, on the revision
+/// it was copied from surviving an undo, or even on the tab it came from
+/// still existing. That is what lets an annotation copied in one tab paste
+/// into another: PDF annotations don't round-trip the OS clipboard, so
+/// without a shared clipboard the target tab has nothing to paste.
+///
+/// A [ChangeNotifier] so paste affordances can enable and disable live as the
+/// clipboard fills and clears. Controllers default to the shared [instance] so
+/// a copy in one tab pastes into another with no wiring; pass a private
+/// clipboard to a controller to isolate it (tests do this).
+class PdfAnnotationSnapshotClipboard extends ChangeNotifier {
+  /// The process-wide clipboard every [PdfEditingController] shares by
+  /// default, so annotations copied in one document tab can be pasted into
+  /// another.
+  static final PdfAnnotationSnapshotClipboard instance =
+      PdfAnnotationSnapshotClipboard();
+
+  List<PdfAnnotationSnapshot> _snapshots = const [];
+  Object? _sourceOwner;
+  int _sourcePage = -1;
+  int _pasteCount = 0;
+
+  /// The captured annotations waiting to be pasted (empty when the
+  /// clipboard is empty).
+  List<PdfAnnotationSnapshot> get snapshots => _snapshots;
+
+  /// How many annotations the clipboard currently holds (0 when empty).
+  int get length => _snapshots.length;
+
+  /// Whether there are annotations waiting to be pasted.
+  bool get isNotEmpty => _snapshots.isNotEmpty;
+
+  /// Whether the clipboard is empty.
+  bool get isEmpty => _snapshots.isEmpty;
+
+  /// The controller that filled the clipboard, held only to compare identity
+  /// (never to read from - the snapshots are detached, and the owner may
+  /// have been disposed with its tab). Paired with [sourcePage] it answers
+  /// "is this paste landing back on the page the copy came from?", which
+  /// decides whether the position cascade kicks in.
+  Object? get sourceOwner => _sourceOwner;
+
+  /// The page index the copy came from within [sourceOwner]'s document, or
+  /// -1 when the clipboard is empty. Meaningless without [sourceOwner]:
+  /// page 3 of another tab's document is not the page this one copied from.
+  int get sourcePage => _sourcePage;
+
+  /// Pastes since the clipboard was last filled - each one cascades the
+  /// default paste position by another 12pt so copies don't stack. Counted
+  /// on the clipboard, not per controller, so the cascade keeps stepping as
+  /// one copy is pasted repeatedly, wherever it lands.
+  int get pasteCount => _pasteCount;
+
+  /// Fills the clipboard with [snapshots] copied from [sourcePage] of
+  /// [owner]'s document, replacing any previous contents (and resetting the
+  /// paste cascade) and notifying listeners.
+  void set(
+    List<PdfAnnotationSnapshot> snapshots, {
+    required Object owner,
+    required int sourcePage,
+  }) {
+    _snapshots = List.unmodifiable(snapshots);
+    _sourceOwner = owner;
+    _sourcePage = sourcePage;
+    _pasteCount = 0;
+    notifyListeners();
+  }
+
+  /// Records that the contents were pasted once more, stepping the position
+  /// cascade. Does not notify: what can be pasted has not changed, and a
+  /// paste already rebuilds its own controller.
+  void markPasted() => _pasteCount++;
+
+  /// Whether a paste onto page [pageIndex] of [owner]'s document is landing
+  /// back where the copy came from - the case that has to cascade on the
+  /// very first paste so the copy doesn't sit exactly on its source.
+  bool isSource(Object owner, int pageIndex) =>
+      identical(owner, _sourceOwner) && pageIndex == _sourcePage;
+
+  /// Empties the clipboard (a no-op, no notification, when already empty).
+  void clear() {
+    if (_snapshots.isEmpty) return;
+    _snapshots = const [];
+    _sourceOwner = null;
+    _sourcePage = -1;
+    _pasteCount = 0;
+    notifyListeners();
+  }
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_controller.dart
@@ -10,6 +10,7 @@ import 'package:pdf_document/pdf_document.dart';
 import '../page_geometry.dart';
 import '../renderer.dart';
 import 'digital_signature.dart';
+import 'editing_annotation_clipboard.dart';
 import 'editing_measure.dart';
 import 'editing_page_clipboard.dart';
 import 'editing_preferences.dart';
@@ -375,6 +376,7 @@ class PdfEditingController extends ChangeNotifier {
     PdfEditingPreferences? preferences,
     PdfPageClipboard? pageClipboard,
     PdfSnapshotClipboard? snapshotClipboard,
+    PdfAnnotationSnapshotClipboard? annotationClipboard,
     PdfTrustStore? trustStore,
   })  : _bytes = bytes,
         _used = bytes.length,
@@ -384,8 +386,9 @@ class PdfEditingController extends ChangeNotifier {
         _trustStore = trustStore,
         preferences = preferences ?? PdfEditingPreferences(),
         pageClipboard = pageClipboard ?? PdfPageClipboard.instance,
-        snapshotClipboard =
-            snapshotClipboard ?? PdfSnapshotClipboard.instance {
+        snapshotClipboard = snapshotClipboard ?? PdfSnapshotClipboard.instance,
+        annotationClipboard =
+            annotationClipboard ?? PdfAnnotationSnapshotClipboard.instance {
     this.preferences.addListener(notifyListeners);
     // rebuild paste affordances live as the shared page clipboard fills or
     // clears - from this controller or from another document tab sharing it
@@ -393,6 +396,9 @@ class PdfEditingController extends ChangeNotifier {
     // same for the shared snapshot clipboard, so a region captured in one tab
     // lights up Paste-as-vector in every tab
     this.snapshotClipboard.addListener(notifyListeners);
+    // and for the shared annotation clipboard, so annotations copied in one
+    // tab light up Paste in every tab
+    this.annotationClipboard.addListener(notifyListeners);
   }
 
   /// The persisted UI preferences that own the tool styles (stroke width,
@@ -418,6 +424,15 @@ class PdfEditingController extends ChangeNotifier {
   /// See [copyVectorSnapshot] and [pasteSnapshot].
   final PdfSnapshotClipboard snapshotClipboard;
 
+  /// The clipboard copied/cut annotations live in, shared across document tabs
+  /// so annotations copied in one document paste into another (PDF annotations
+  /// don't round-trip the OS clipboard, so nothing else carries them between
+  /// tabs). Defaults to the process-wide
+  /// [PdfAnnotationSnapshotClipboard.instance]; pass a private one to isolate
+  /// a session. See [copySelectedAnnotations], [cutSelectedAnnotations], and
+  /// [pasteAnnotations].
+  final PdfAnnotationSnapshotClipboard annotationClipboard;
+
   /// The session's shared page-thumbnail cache (and its viewport-ordered
   /// render queue). Every thumbnail surface - the docked strip, the
   /// full-area page grid - draws from this one cache, so a page rendered for
@@ -436,6 +451,7 @@ class PdfEditingController extends ChangeNotifier {
     preferences.removeListener(notifyListeners);
     pageClipboard.removeListener(notifyListeners);
     snapshotClipboard.removeListener(notifyListeners);
+    annotationClipboard.removeListener(notifyListeners);
     super.dispose();
   }
 
@@ -4848,22 +4864,14 @@ class PdfEditingController extends ChangeNotifier {
   // ---------------------------------------------------------------------
   // clipboard
 
-  /// The in-app annotation clipboard: detached snapshots that survive
-  /// edits, undo, and document swaps (PDF annotations don't round-trip
-  /// the OS clipboard). Filled by copy/cut, consumed by
-  /// [pasteAnnotations].
-  List<PdfAnnotationSnapshot> _clipboard = const [];
-  int _clipboardSourcePage = -1;
+  /// Whether [pasteAnnotations] has anything to paste - including a copy
+  /// made in another document tab, since [annotationClipboard] is shared.
+  bool get hasAnnotationClipboard => annotationClipboard.isNotEmpty;
 
-  /// Pastes since the clipboard was last filled - each one cascades the
-  /// default paste position by another 12pt so copies don't stack.
-  int _pasteCount = 0;
-
-  /// Whether [pasteAnnotations] has anything to paste.
-  bool get hasAnnotationClipboard => _clipboard.isNotEmpty;
-
-  /// Copies the selected annotations to the in-app clipboard as
-  /// detached snapshots. Popups, links, and form widgets never copy
+  /// Copies the selected annotations to the in-app [annotationClipboard]
+  /// as detached snapshots - they survive edits, undo, and closing the
+  /// document they came from, and because the clipboard is shared they
+  /// paste into any open tab. Popups, links, and form widgets never copy
   /// (they can't be selected either). Returns how many were copied; the
   /// document is untouched.
   int copySelectedAnnotations() {
@@ -4876,9 +4884,8 @@ class PdfEditingController extends ChangeNotifier {
       if (snapshot != null) snapshots.add(snapshot);
     }
     if (snapshots.isEmpty) return 0;
-    _clipboard = snapshots;
-    _clipboardSourcePage = _selected.last.$1;
-    _pasteCount = 0;
+    annotationClipboard.set(snapshots,
+        owner: this, sourcePage: _selected.last.$1);
     // the most recent copy wins ⌘V (see [copyVectorSnapshot])
     snapshotClipboard.clear();
     notifyListeners();
@@ -4895,20 +4902,24 @@ class PdfEditingController extends ChangeNotifier {
   }
 
   /// Pastes the clipboard onto [pageIndex] and selects the pasted
-  /// annotations (one revision - one undo removes them all).
+  /// annotations (one revision - one undo removes them all). The clipboard
+  /// is shared across tabs, so what pastes may have been copied from
+  /// another document.
   ///
   /// With [at] the group centers on that page point (the context menu
   /// pastes where the right-click landed). Without it the group keeps
   /// its position, shifted 12pt down-right per repeat paste - and per
-  /// the first paste too when it would sit exactly on the source. The
+  /// the first paste too when it would sit exactly on the source (the
+  /// page it was copied from, in the document it was copied from). The
   /// group always clamps into the page's crop box. Returns whether
   /// anything was pasted.
   bool pasteAnnotations(int pageIndex, {(double, double)? at}) {
-    if (_clipboard.isEmpty) return false;
+    final clipboard = annotationClipboard.snapshots;
+    if (clipboard.isEmpty) return false;
     if (pageIndex < 0 || pageIndex >= _document.pageCount) return false;
     var left = double.infinity, bottom = double.infinity;
     var right = double.negativeInfinity, top = double.negativeInfinity;
-    for (final snapshot in _clipboard) {
+    for (final snapshot in clipboard) {
       final r = snapshot.rect;
       if (r.left < left) left = r.left;
       if (r.bottom < bottom) bottom = r.bottom;
@@ -4920,24 +4931,25 @@ class PdfEditingController extends ChangeNotifier {
       dx = at.$1 - (left + right) / 2;
       dy = at.$2 - (bottom + top) / 2;
     } else {
-      final cascade = 12.0 *
-          (pageIndex == _clipboardSourcePage ? _pasteCount + 1 : _pasteCount);
+      final steps = annotationClipboard.pasteCount +
+          (annotationClipboard.isSource(this, pageIndex) ? 1 : 0);
+      final cascade = 12.0 * steps;
       dx = cascade;
       dy = -cascade;
     }
     final box = _page(pageIndex).cropBox;
     dx += _clampShift(left + dx, right + dx, box.left, box.right);
     dy += _clampShift(bottom + dy, top + dy, box.bottom, box.top);
-    final count = _clipboard.length;
+    final count = clipboard.length;
     final pasted = apply(
       (e) {
-        for (final snapshot in _clipboard) {
+        for (final snapshot in clipboard) {
           e.pasteAnnotation(pageIndex, snapshot, dx: dx, dy: dy);
         }
       },
     );
     if (!pasted) return false;
-    _pasteCount++;
+    annotationClipboard.markPasted();
     // pasted entries appended to /Annots - select them, like any editor
     tool = PdfEditTool.select;
     final total = _page(pageIndex).annotations.length;
@@ -5038,7 +5050,7 @@ class PdfEditingController extends ChangeNotifier {
     // bookkeeping when it sees this new snapshot (identity differs from the
     // anchor).
     snapshotClipboard.set(snapshot);
-    _clipboard = const [];
+    annotationClipboard.clear();
     notifyListeners();
     return snapshot;
   }

--- a/packages/dart_pdf_editor/test/editing_clipboard_test.dart
+++ b/packages/dart_pdf_editor/test/editing_clipboard_test.dart
@@ -20,6 +20,10 @@ final _png = base64.decode('iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0k'
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
+    // controllers share the process-wide annotation clipboard by default;
+    // start each test from empty so one test's copy can't leak into the next.
+    PdfAnnotationSnapshotClipboard.instance.clear();
+    PdfSnapshotClipboard.instance.clear();
   });
 
   group('controller clipboard', () {
@@ -146,6 +150,162 @@ void main() {
       expect(editing.document.page(1).annotations, isEmpty);
       expect(editing.document.page(2).annotations, isEmpty);
       expect(editing.document.page(0).annotations, hasLength(1));
+    });
+  });
+
+  group('PdfAnnotationSnapshotClipboard', () {
+    test('set / clear notify, and clearing an empty clipboard does not', () {
+      final clip = PdfAnnotationSnapshotClipboard();
+      var notified = 0;
+      clip.addListener(() => notified++);
+      expect(clip.isEmpty, isTrue);
+      expect(clip.length, 0);
+      // clearing an already-empty clipboard is a silent no-op
+      clip.clear();
+      expect(notified, 0);
+
+      final source = PdfEditingController(buildMultiPagePdf(1),
+          annotationClipboard: clip)
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750));
+      addTearDown(source.dispose);
+      source.selectAnnotation(0, 0);
+      expect(source.copySelectedAnnotations(), 1);
+      expect(clip.isNotEmpty, isTrue);
+      expect(clip.length, 1);
+      expect(identical(clip.sourceOwner, source), isTrue);
+      expect(clip.sourcePage, 0);
+      expect(notified, 1);
+
+      clip.clear();
+      expect(clip.isEmpty, isTrue);
+      expect(clip.sourceOwner, isNull);
+      expect(clip.sourcePage, -1);
+      expect(notified, 2);
+      clip.clear();
+      expect(notified, 2);
+    });
+
+    test('a controller defaults to the shared process-wide instance', () {
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(editing.dispose);
+      expect(
+          identical(editing.annotationClipboard,
+              PdfAnnotationSnapshotClipboard.instance),
+          isTrue);
+    });
+
+    test('a private clipboard isolates a controller from the shared one', () {
+      final shared = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750));
+      addTearDown(shared.dispose);
+      final isolated = PdfEditingController(buildMultiPagePdf(1),
+          annotationClipboard: PdfAnnotationSnapshotClipboard());
+      addTearDown(isolated.dispose);
+
+      shared.selectAnnotation(0, 0);
+      shared.copySelectedAnnotations();
+
+      expect(isolated.hasAnnotationClipboard, isFalse);
+      expect(isolated.pasteAnnotations(0), isFalse);
+      expect(isolated.document.page(0).annotations, isEmpty);
+    });
+  });
+
+  group('clipboard shared across document tabs', () {
+    test('an annotation copied in one tab pastes into another', () {
+      final a = PdfEditingController(buildMultiPagePdf(1))
+        ..color = const Color(0xFFE53935)
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750));
+      addTearDown(a.dispose);
+      final b = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(b.dispose);
+      expect(b.hasAnnotationClipboard, isFalse);
+
+      a.selectAnnotation(0, 0);
+      expect(a.copySelectedAnnotations(), 1);
+      // the copy lights up Paste in the other tab
+      expect(b.hasAnnotationClipboard, isTrue);
+
+      expect(b.pasteAnnotations(0), isTrue);
+      final pasted = b.document.page(0).annotations.single;
+      expect(pasted.subtype, 'Square');
+      expect(pasted.color, 0xE53935);
+      // a different document is never "the source page": no cascade, the
+      // annotation lands exactly where it was copied from
+      expect(pasted.rect, const PdfRect(100, 650, 250, 750));
+      expect(b.selectedAnnotationSlots, [(0, 0)]);
+
+      // the source document is untouched by the paste, and one undo in the
+      // receiving tab removes it
+      expect(a.document.page(0).annotations, hasLength(1));
+      b.undo();
+      expect(b.document.page(0).annotations, isEmpty);
+    });
+
+    test('filling the clipboard in one tab notifies the others', () {
+      final a = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750));
+      addTearDown(a.dispose);
+      final b = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(b.dispose);
+      var notified = 0;
+      b.addListener(() => notified++);
+
+      a.selectAnnotation(0, 0);
+      a.copySelectedAnnotations();
+      expect(notified, greaterThan(0),
+          reason: 'paste affordances in other tabs rebuild live');
+    });
+
+    test('repeat pastes into another tab cascade', () {
+      final a = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750));
+      addTearDown(a.dispose);
+      final b = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(b.dispose);
+
+      a.selectAnnotation(0, 0);
+      a.copySelectedAnnotations();
+      b.pasteAnnotations(0);
+      b.pasteAnnotations(0);
+
+      final annotations = b.document.page(0).annotations;
+      expect(annotations[0].rect.left, closeTo(100, 1e-6));
+      expect(annotations[1].rect.left, closeTo(112, 1e-6));
+    });
+
+    test('the clipboard outlives the tab it was copied from', () {
+      final a = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750));
+      final b = PdfEditingController(buildMultiPagePdf(1));
+      addTearDown(b.dispose);
+
+      a.selectAnnotation(0, 0);
+      a.cutSelectedAnnotations();
+      a.dispose(); // the source tab is closed
+
+      expect(b.hasAnnotationClipboard, isTrue);
+      expect(b.pasteAnnotations(0), isTrue);
+      expect(b.document.page(0).annotations.single.subtype, 'Square');
+    });
+
+    test('a copy in one tab replaces what another tab copied', () {
+      final a = PdfEditingController(buildMultiPagePdf(1))
+        ..addRectangle(0, const PdfRect(100, 650, 250, 750));
+      addTearDown(a.dispose);
+      final b = PdfEditingController(buildMultiPagePdf(1))
+        ..addEllipse(0, const PdfRect(300, 650, 380, 720));
+      addTearDown(b.dispose);
+
+      a.selectAnnotation(0, 0);
+      a.copySelectedAnnotations();
+      b.selectAnnotation(0, 0);
+      b.copySelectedAnnotations();
+
+      // the most recent copy wins everywhere, so pasting back in the first
+      // tab yields the *other* tab's annotation
+      expect(a.pasteAnnotations(0), isTrue);
+      expect(a.document.page(0).annotations.last.subtype, 'Circle');
     });
   });
 

--- a/packages/dart_pdf_editor/test/editing_longpress_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_longpress_menu_test.dart
@@ -23,6 +23,9 @@ Offset viewPoint(double x, double y) => Offset(x * scale, (792 - y) * scale);
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({});
+    // controllers share the process-wide annotation clipboard by default;
+    // start each test from empty so one test's copy can't leak into the next.
+    PdfAnnotationSnapshotClipboard.instance.clear();
   });
 
   Future<PdfEditingController> pumpViewer(WidgetTester tester,

--- a/packages/dart_pdf_editor/test/editing_menu_test.dart
+++ b/packages/dart_pdf_editor/test/editing_menu_test.dart
@@ -18,6 +18,7 @@ void main() {
     // controllers share the process-wide snapshot clipboard by default; start
     // each test from empty so one test's capture can't leak into the next.
     PdfSnapshotClipboard.instance.clear();
+    PdfAnnotationSnapshotClipboard.instance.clear();
   });
 
   group('controller z-order', () {

--- a/packages/dart_pdf_editor/test/editing_snapshot_test.dart
+++ b/packages/dart_pdf_editor/test/editing_snapshot_test.dart
@@ -16,6 +16,7 @@ void main() {
     // controllers share the process-wide snapshot clipboard by default; start
     // each test from empty so one test's capture can't leak into the next.
     PdfSnapshotClipboard.instance.clear();
+    PdfAnnotationSnapshotClipboard.instance.clear();
   });
 
   group('PdfEditingController snapshot clipboard', () {


### PR DESCRIPTION
## Summary

Annotation copy/cut already produced fully detached `PdfAnnotationSnapshot`s, but the clipboard holding them was a private field on `PdfEditingController` (`_clipboard`), so a copy only ever pasted back into the tab it was made in. This moves it out to a process-wide clipboard, so annotations copied in one open document paste into another.

- New `PdfAnnotationSnapshotClipboard` (`editing_annotation_clipboard.dart`), a `ChangeNotifier` with the same shape as the existing `PdfPageClipboard` / `PdfSnapshotClipboard`. Holds the snapshots plus the paste bookkeeping (`sourceOwner`, `sourcePage`, `pasteCount`).
- `PdfEditingController` gains an `annotationClipboard` constructor arg defaulting to the process-wide `instance`, and listens to it (removed in `dispose`) - so cross-tab paste needs zero host wiring and every tab's Paste affordance updates the instant any tab copies.
- Paste cascade fix: the old rule compared only the source page index, which would treat page 3 of *another* document as "the page this was copied from" and offset the paste by 12pt. It now checks the owning controller's identity too (`isSource(this, pageIndex)`), so a cross-document paste lands at exactly the coordinates it was copied from. The owner reference is held only for that identity comparison - never read through - since the source tab may be disposed before the paste.
- `pasteCount` moved onto the clipboard so one copy keeps stepping its cascade wherever it is pasted; `markPasted()` deliberately does not notify (what can be pasted is unchanged).
- Most-recent-copy-wins now holds across tabs in both directions: `copySelectedAnnotations` clears the shared snapshot clipboard, `copyVectorSnapshot` clears the shared annotation clipboard.

Named `PdfAnnotationSnapshotClipboard` rather than `PdfAnnotationClipboard` because `pdf_document` already exports `extension PdfAnnotationClipboard on PdfEditor` (the `pasteAnnotation` half), which `dart_pdf_editor` imports - the shorter name would be ambiguous. The longer one also matches what it holds, the way `PdfSnapshotClipboard` holds a `PdfVectorSnapshot`.

No API removals: `hasAnnotationClipboard`, `copySelectedAnnotations`, `cutSelectedAnnotations`, and `pasteAnnotations` keep their signatures and semantics within a single tab.

Details in `doc/dev-log/2026-08-06-annotation-clipboard-across-tabs.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (README wording + dev-log note)

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (repo root, no issues)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2122 passing)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Also ran the app suite (`cd app && fvm flutter test`, 412 passing) since its tabs each own a controller and now share the clipboard.

The pure-Dart package suites, corpus sweeps, and render baselines were not run: the change is confined to `dart_pdf_editor`'s controller-level clipboard plumbing and touches no parsing, writing, or rendering path.

## PDF fixtures and screenshots

None needed - tests build documents programmatically via `buildMultiPagePdf`.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output (untouched).
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required (untouched).
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

New tests in `editing_clipboard_test.dart`: a `PdfAnnotationSnapshotClipboard` group (notify semantics, the shared-instance default, private-clipboard isolation) and a `clipboard shared across document tabs` group (copy in one controller pastes into another with the right style and no cascade; the copy notifies the other tab; repeat pastes cascade; the clipboard outlives `dispose()` of the source controller; a later copy in either tab replaces the payload everywhere).

Because the clipboard is now process-wide, tests that copy annotations have to start from empty or one test's copy leaks into the next - `PdfAnnotationSnapshotClipboard.instance.clear()` was added to `setUp` in `editing_clipboard_test`, `editing_menu_test`, `editing_longpress_menu_test`, and `editing_snapshot_test`. That is the same tax the snapshot clipboard already pays; worth knowing if a future test copies annotations without clearing.

Follow-up worth considering: nothing persists the clipboard across app restarts, and the payload never reaches the OS clipboard (PDF annotations don't round-trip it), so copy/paste between two separate app instances is still out of scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VriQHb9RFQd6yHgtggcA7U)_