### PR TITLE
Drop a PDF at a position in the page thumbnails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,15 @@ size slider (`thumbnailViewTileWidth` pref), custom drag reorder
 onActivatePage`). `PdfEditorView` overlays it over the live viewer as a
 view mode (`showThumbnailView`, toggled from View options alongside
 reflow; `altView` = reflow-or-grid suppresses the panels/toolbar).
+Both panels take an external PDF **dropped between two tiles**:
+`PdfThumbnailDropController` (editing_thumbnail_drop.dart) is the seam -
+panels register a global-position→slot resolver and paint the insertion
+marker, the host (which owns the platform drag stream) drives
+`dragOver`/`indexAt`/`endDrag` and inserts at the returned index.
+`PdfEditorView(thumbnailDropController:)` forwards it; the app wires it
+to its `desktop_drop` `DropTarget`, so a positioned drop skips the
+open-or-insert dialog. See
+doc/dev-log/2026-08-06-thumbnail-file-drop-position.md.
 
 ## Development session log
 

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -251,6 +251,16 @@ class _EditorScreenState extends State<EditorScreen>
   /// True while a file is being dragged over the window (desktop/web).
   bool _dragging = false;
 
+  /// Bridges that drag to the page thumbnails: while it hovers the strip or
+  /// the page grid the panel marks the slot the pages would land in, and the
+  /// drop inserts them there instead of asking open-or-append.
+  final PdfThumbnailDropController _thumbnailDrop =
+      PdfThumbnailDropController();
+
+  /// True while the drag is over a thumbnail panel - the panel's own
+  /// insertion marker says everything, so the full-window hint steps aside.
+  bool _draggingOverThumbnails = false;
+
   final List<DocumentTab> _tabs = [];
   int _activeIndex = 0;
 
@@ -394,6 +404,7 @@ class _EditorScreenState extends State<EditorScreen>
     }
     _recents.dispose();
     _recentThumbnails.dispose();
+    _thumbnailDrop.dispose();
     _updates.removeListener(_onUpdateStatus);
     if (_ownsUpdates) _updates.dispose();
     super.dispose();
@@ -1372,20 +1383,30 @@ class _EditorScreenState extends State<EditorScreen>
   }
 
   /// Handles PDFs dropped onto the window (desktop and web). Non-PDFs are
-  /// ignored. With an editable document already open, the drop offers a
-  /// choice - open each PDF in its own tab, or insert their pages into the
-  /// current document; with nothing open (or in read-only mode) each PDF
-  /// just opens in its own tab.
-  Future<void> _onFilesDropped(List<DropItem> items) async {
+  /// ignored. A drop onto the page thumbnails (the strip or the full-area
+  /// grid) inserts the pages at the marked position - the drop point picked
+  /// the answer, so there's nothing to ask. Anywhere else, with an editable
+  /// document already open, the drop offers a choice - open each PDF in its
+  /// own tab, or append their pages to the current document; with nothing
+  /// open (or in read-only mode) each PDF just opens in its own tab.
+  Future<void> _onFilesDropped(DropDoneDetails details) async {
     final pdfs = [
-      for (final item in items)
+      for (final item in details.files)
         if (item.name.toLowerCase().endsWith('.pdf')) item,
     ];
+    // Read the drop slot before clearing the drag: the panels answer from
+    // their live geometry, which the clear repaints away.
+    final at = _thumbnailDrop.indexAt(details.globalPosition);
+    _thumbnailDrop.endDrag();
     if (pdfs.isEmpty) return;
 
     final tab = _active;
     final session = tab?.session;
     if (session != null && !_readOnly) {
+      if (at != null) {
+        await _insertDropped(pdfs, session, tab!.title, at: at);
+        return;
+      }
       final action = await _promptDropAction(pdfs.length, tab!.title);
       if (action == null || !mounted) return; // cancelled / disposed
       if (action == _DropAction.insert) {
@@ -1394,6 +1415,26 @@ class _EditorScreenState extends State<EditorScreen>
       }
     }
     await _openDropped(pdfs);
+  }
+
+  /// Tracks a file drag across the window so the thumbnail panels can mark
+  /// where a drop would insert the pages.
+  void _onDragMoved(Offset globalPosition) {
+    final over = _thumbnailDrop.dragOver(globalPosition) != null;
+    if (over == _draggingOverThumbnails && _dragging) return;
+    setState(() {
+      _dragging = true;
+      _draggingOverThumbnails = over;
+    });
+  }
+
+  /// The drag left the window (or ended): drop the hint and the marker.
+  void _onDragEnded() {
+    _thumbnailDrop.endDrag();
+    setState(() {
+      _dragging = false;
+      _draggingOverThumbnails = false;
+    });
   }
 
   /// Opens each dropped [pdfs] item in its own tab.
@@ -1421,17 +1462,25 @@ class _EditorScreenState extends State<EditorScreen>
     }
   }
 
-  /// Inserts the pages of each dropped PDF, appended in drop order, into the
-  /// active document's edit session. Unreadable files are skipped and
-  /// reported; the result is one undoable step per inserted file.
+  /// Inserts the pages of each dropped PDF into the active document's edit
+  /// session, in drop order: at page [at] when the drop landed on a
+  /// thumbnail panel, appended at the end otherwise. Unreadable files are
+  /// skipped and reported; the result is one undoable step per inserted
+  /// file. A positioned insert scrolls the viewer to the first new page.
   Future<void> _insertDropped(
-      List<DropItem> pdfs, PdfEditingController session, String title) async {
+      List<DropItem> pdfs, PdfEditingController session, String title,
+      {int? at}) async {
     var inserted = 0;
+    // each file lands after the ones already inserted, so a multi-file drop
+    // keeps its order
+    var next = at;
     final failed = <String>[];
     for (final item in pdfs) {
       try {
         final bytes = await item.readAsBytes();
-        session.insertPagesFromBytes(bytes);
+        final before = session.document.pageCount;
+        session.insertPagesFromBytes(bytes, at: next);
+        if (next != null) next += session.document.pageCount - before;
         inserted++;
       } catch (e) {
         AppDevTools.instance.addLog('insert failed: ${item.name} - $e',
@@ -1440,6 +1489,7 @@ class _EditorScreenState extends State<EditorScreen>
       }
     }
     if (!mounted) return;
+    if (at != null && inserted > 0) _revealInsertedPage(at);
     if (inserted == 0) {
       _toast(appL10n(context).editorCouldNotInsertDropped(pdfs.length));
     } else if (failed.isEmpty) {
@@ -1448,6 +1498,21 @@ class _EditorScreenState extends State<EditorScreen>
       _toast(appL10n(context)
           .editorInsertedButFailed(inserted, failed.join(', ')));
     }
+  }
+
+  /// Scrolls the active viewer to [index] - the first page a positioned
+  /// insert just added. The revision swap rebuilds the viewer and a
+  /// geometry-changing revision resets its scroll in a post-frame callback,
+  /// so navigate after two frames, once both have landed (the same route the
+  /// thumbnail strip's insert/paste takes).
+  void _revealInsertedPage(int index) {
+    final viewer = _active?.viewer;
+    if (viewer == null) return;
+    unawaited(() async {
+      await SchedulerBinding.instance.endOfFrame;
+      await SchedulerBinding.instance.endOfFrame;
+      await viewer.jumpToPage(index);
+    }());
   }
 
   /// Asks whether dropped PDFs (with a document already open) should open in
@@ -2514,11 +2579,15 @@ class _EditorScreenState extends State<EditorScreen>
               control: true, shift: true): _openMostRecent,
         },
         child: DropTarget(
-          onDragEntered: (_) => setState(() => _dragging = true),
-          onDragExited: (_) => setState(() => _dragging = false),
+          onDragEntered: (detail) => _onDragMoved(detail.globalPosition),
+          onDragUpdated: (detail) => _onDragMoved(detail.globalPosition),
+          onDragExited: (_) => _onDragEnded(),
           onDragDone: (detail) {
-            setState(() => _dragging = false);
-            _onFilesDropped(detail.files);
+            setState(() {
+              _dragging = false;
+              _draggingOverThumbnails = false;
+            });
+            _onFilesDropped(detail);
           },
           child: Builder(builder: (context) {
             final compactDevTools = _isCompactWidth(context);
@@ -2541,7 +2610,10 @@ class _EditorScreenState extends State<EditorScreen>
                     ],
                   ),
                 ),
-                if (_dragging)
+                // The full-window hint yields to the thumbnails' own
+                // insertion marker once the drag is over a page panel - the
+                // marker already says exactly where the pages will land.
+                if (_dragging && !_draggingOverThumbnails)
                   Positioned.fill(
                     child: _DropOverlay(
                       canInsert: tab?.session != null && !_readOnly,
@@ -2678,6 +2750,9 @@ class _EditorScreenState extends State<EditorScreen>
       // just handed back.
       alwaysAllowSave: tab.isUnsaved || tab.isDirty,
       onPickPdfToInsert: () => pickPdfBytes(appL10n(context).fileTypePdf),
+      // a PDF dragged in from the desktop can be dropped between two page
+      // thumbnails; the drop lands its pages exactly there
+      thumbnailDropController: _thumbnailDrop,
       onExportPages: (bytes) => unawaited(saveBytesAs(context, bytes, tab.title,
           pdfLabel: appL10n(context).fileTypePdf)),
       onAction: _onAction,

--- a/app/test/drop_insert_test.dart
+++ b/app/test/drop_insert_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/material.dart';
@@ -51,10 +52,13 @@ void main() {
   // the centre of the surface so it lands inside the editor body (DropTarget
   // only reports a done event for in-bounds drops). Send an update first so
   // the target is entered even when the test runs on a non-Linux host.
-  Future<void> dropPdf(WidgetTester tester, String name) async {
+  Future<void> dropPdf(WidgetTester tester, String name, {Offset? at}) async {
     final size = tester.view.physicalSize / tester.view.devicePixelRatio;
     const codec = StandardMethodCodec();
-    final point = <double>[size.width / 2, size.height / 2];
+    final point = <double>[
+      at?.dx ?? size.width / 2,
+      at?.dy ?? size.height / 2,
+    ];
     final update = codec.encodeMethodCall(MethodCall('updated', point));
     await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
       'desktop_drop',
@@ -124,6 +128,125 @@ void main() {
 
     expect(find.byKey(const ValueKey('drop-action-dialog')), findsNothing);
     expect(tabTitle('extra.pdf'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  // The desktop layout the docked thumbnail strip needs (it collapses on a
+  // compact surface).
+  void wideScreen(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  // A point in the upper (or lower) part of the strip's tile for [page] -
+  // the halves either side of the tile's middle are the slots before and
+  // after that page.
+  Offset inStripTile(WidgetTester tester, int page, double fraction) {
+    final tile = find.descendant(
+      of: find.byType(PdfThumbnailSidebar),
+      matching: find.byKey(ValueKey(page)),
+    );
+    final rect = tester.getRect(tile);
+    return Offset(rect.center.dx, rect.top + rect.height * fraction);
+  }
+
+  testWidgets('a drag over the thumbnail strip marks the insertion slot',
+      (tester) async {
+    wideScreen(tester);
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'base.pdf', buildMultiPagePdf(3));
+
+    const codec = StandardMethodCodec();
+    Future<void> dragTo(Offset point) async {
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'desktop_drop',
+        codec.encodeMethodCall(
+            MethodCall('updated', <double>[point.dx, point.dy])),
+        (_) {},
+      );
+      await tester.pump();
+    }
+
+    await dragTo(inStripTile(tester, 1, 0.25));
+
+    // the strip marks the slot before page 2 ...
+    expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-1-top')),
+        findsOneWidget);
+    // ... and the full-window "drop to open or insert" hint stands aside
+    expect(find.text('Drop PDF to open or insert'), findsNothing);
+
+    // dragging back over the page area restores the window-wide hint and
+    // clears the strip's marker
+    await dragTo(const Offset(1000, 450));
+    expect(find.text('Drop PDF to open or insert'), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-1-top')),
+        findsNothing);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  testWidgets('dropping onto the thumbnail strip inserts without asking',
+      (tester) async {
+    wideScreen(tester);
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'base.pdf', buildMultiPagePdf(2));
+
+    await dropPdf(tester, 'extra.pdf', at: inStripTile(tester, 0, 0.25));
+
+    // The drop point already said where the pages go, so no open/insert
+    // dialog - and no new tab, since this is an insert into the open file.
+    expect(find.byKey(const ValueKey('drop-action-dialog')), findsNothing);
+    expect(tabTitle('extra.pdf'), findsNothing);
+    expect(tabTitle('base.pdf'), findsOneWidget);
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  // The one drop test that reads a real file: it needs the *result* of the
+  // insert, not just the branch. The read is a dart:io future, so both the
+  // write and the drop delivery run inside runAsync (a real event loop) -
+  // possible here only because this path takes no UI tap, unlike the
+  // open/insert dialog above.
+  testWidgets('a drop on the strip merges the file into the open document',
+      (tester) async {
+    wideScreen(tester);
+    await tester.pumpWidget(MaterialApp(home: EditorScreen(prefs: prefs)));
+    await tester.pump();
+    await openTab(tester, 'base.pdf', buildMultiPagePdf(2));
+
+    Finder stripTile(int page) => find.descendant(
+          of: find.byType(PdfThumbnailSidebar),
+          matching: find.byKey(ValueKey(page)),
+        );
+    expect(stripTile(1), findsOneWidget);
+    expect(stripTile(2), findsNothing); // two pages so far
+
+    final point = inStripTile(tester, 0, 0.25); // the slot before page 1
+    await tester.runAsync(() async {
+      final dir = await Directory.systemTemp.createTemp('dartpdf-drop');
+      addTearDown(() => dir.deleteSync(recursive: true));
+      final file = File('${dir.path}/extra.pdf');
+      await file.writeAsBytes(buildMultiPagePdf(2));
+      const codec = StandardMethodCodec();
+      await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+        'desktop_drop',
+        codec.encodeMethodCall(MethodCall('performOperation_linux', <dynamic>[
+          Uri.file(file.path).toString(),
+          <double>[point.dx, point.dy],
+        ])),
+        (_) {},
+      );
+      // let the lazy byte read and the insert it feeds actually land
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // the dropped file's two pages joined the document (4 tiles now), with
+    // no dialog and no second tab
+    expect(stripTile(3), findsOneWidget);
+    expect(find.byKey(const ValueKey('drop-action-dialog')), findsNothing);
+    expect(tabTitle('extra.pdf'), findsNothing);
+    // settle the insert toast so no timer outlives the test
+    await tester.pump(const Duration(seconds: 6));
   }, timeout: const Timeout(Duration(seconds: 60)));
 
   testWidgets('dropping with nothing open skips the prompt and opens a tab',

--- a/doc/dev-log/2026-08-06-thumbnail-file-drop-position.md
+++ b/doc/dev-log/2026-08-06-thumbnail-file-drop-position.md
@@ -1,0 +1,80 @@
+# Dropping a PDF at a position in the thumbnail strip
+
+Dragging a PDF onto the window already offered *open in a new tab* or
+*insert pages* (appended at the end - see
+`2026-06-22-app-drag-drop-open-or-insert.md`). This session adds the
+placement the dialog can't express: drop the file **between two page
+thumbnails** and its pages land exactly there.
+
+## The seam
+
+The platform's drag stream (desktop_drop on desktop/web) lives with the
+host app; `dart_pdf_editor` must not depend on it, and the strip is the
+only thing that knows where its tiles are. So the two halves meet through
+a small controller - `PdfThumbnailDropController`
+(`editing/editing_thumbnail_drop.dart`, exported):
+
+- panels register a `PdfThumbnailDropResolver` (`int? Function(Offset
+  globalPosition)`) on mount and withdraw it on dispose;
+- the host calls `dragOver(globalPosition)` from `onDragEntered`/
+  `onDragUpdated`, `endDrag()` when the drag leaves, and `indexAt(...)`
+  on drop;
+- panels read `indicatorIndexFor(theirResolver)` while building and paint
+  an insertion marker at that slot.
+
+The most recently attached panel answers first, so the full-area page
+grid overlaid on a still-mounted docked strip wins the area it covers.
+Registration identity is `identical`, so each panel keeps its resolver in
+a `late final` field - a method tear-off is a fresh object every time
+it's read, and attach/detach would disagree.
+
+`pdfThumbnailDropIndexAt` does the geometry for both panels: bound the
+point to the panel's own render box, pick the **nearest built tile** by
+squared distance to its rect (a scrolled-away tile has no render object,
+and gaps/header/footer fall to the closest tile), then take the slot
+before or after it depending on which side of its centre the point is -
+`dy` for the stacked strip, `dx` for the flowing grid (flipped under
+RTL). The result is a slot in `0..pageCount`, i.e. exactly the `at:`
+`insertPagesFromBytes` wants.
+
+## Rendering the marker
+
+`_PasteInsertionMarker` became `_InsertionMarker` with an `axis`, so the
+same capped bar serves the paste indicator (bottom edge, horizontal) and
+the drop indicator (any edge; vertical on the grid). `_PageTile.dropEdge`
+carries the edge, computed by `_tileDropEdge`: the marker *leads* the
+tile the pages would land before, and *trails* the last tile for a drop
+past the end - so it always paints in the gap that will be filled. Keys
+are `pdf-thumbnail-drop-indicator-<page>-<edge>`; the panel also outlines
+itself (`pdf-thumbnail-drop-outline` /
+`pdf-thumbnail-view-drop-outline`).
+
+## App side
+
+`EditorScreen` owns one `PdfThumbnailDropController` and hands it to
+`PdfEditorView(thumbnailDropController:)`, which forwards it to the strip
+and the grid only when `PdfEditorFeatures.pageEditing` is on. `_onFilesDropped`
+now takes the whole `DropDoneDetails`: it reads the slot **before**
+`endDrag()` (clearing repaints the geometry away), and a non-null slot
+skips the open/insert dialog entirely - the drop point already answered
+the question. Multiple files keep their order by advancing the insert
+position by each file's page count. While the drag is over a panel the
+full-window "Drop PDF to open or insert" hint hides, since the strip's own
+marker is more precise.
+
+## Testing
+
+`packages/dart_pdf_editor/test/editing_thumbnail_drop_test.dart` covers
+the geometry (top/bottom half of a strip tile, left/right of a grid cell,
+past the last tile, off-panel, read-only panels decline) and the
+controller (detach clears, most-recent-panel-wins, notify-on-change only).
+
+`app/test/drop_insert_test.dart` gains the app half. One of them reads a
+**real file**: unlike the dialog path (whose byte read is triggered by a
+UI tap, so it can't be wrapped - see the 2026-06-22 note), the positioned
+drop takes no tap, so writing the temp file and delivering the
+`performOperation_linux` message inside `tester.runAsync` lets the lazy
+`XFile.readAsBytes` actually complete and the insert land. The test then
+asserts the strip grew to four tiles. Two caveats: pump the snackbar out
+(6 s) so no timer outlives the test, and give the surface a desktop width
+- the docked strip collapses on a compact one.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -40,6 +40,7 @@ export 'src/editing/editing_signature.dart';
 export 'src/editing/editing_snapshot_clipboard.dart';
 export 'src/editing/editing_stamps.dart';
 export 'src/editing/editing_takeoff.dart';
+export 'src/editing/editing_thumbnail_drop.dart';
 export 'src/editing/editing_thumbnails.dart';
 export 'src/editing/editing_toolbar.dart';
 export 'src/editing/line_style.dart';

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnail_drop.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnail_drop.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/widgets.dart';
+
+/// Resolves the insertion index a file drop at a global position would land
+/// on inside one thumbnail panel, or null when the position isn't over it.
+typedef PdfThumbnailDropResolver = int? Function(Offset globalPosition);
+
+/// Bridges the host's native file drag-and-drop (desktop_drop, the web's
+/// drop events, …) to the thumbnail panels, so a PDF dragged in from the
+/// desktop can be dropped *at a chosen position* in the page order instead
+/// of only being appended.
+///
+/// The package can't see the platform's drag stream - only the host does -
+/// so the host drives this controller and the panels answer with geometry:
+///
+/// ```dart
+/// final drop = PdfThumbnailDropController();
+/// ...
+/// DropTarget(
+///   onDragUpdated: (d) => drop.dragOver(d.globalPosition),
+///   onDragExited: (_) => drop.endDrag(),
+///   onDragDone: (d) {
+///     final at = drop.indexAt(d.globalPosition);
+///     drop.endDrag();
+///     if (at != null) session.insertPagesFromBytes(bytes, at: at);
+///   },
+///   child: PdfEditorView(thumbnailDropController: drop, ...),
+/// )
+/// ```
+///
+/// While a drag hovers a panel the panel paints an insertion marker at the
+/// index the drop would use; [endDrag] clears it. Pass the same controller
+/// to [PdfThumbnailSidebar] and [PdfThumbnailView] - whichever panel is
+/// under the pointer answers.
+class PdfThumbnailDropController extends ChangeNotifier {
+  /// The mounted panels, in attach order; the most recently attached one
+  /// answers first, so a full-area page grid overlaid on a still-mounted
+  /// docked strip wins the position it covers.
+  final List<PdfThumbnailDropResolver> _panels = [];
+
+  PdfThumbnailDropResolver? _target;
+  int? _index;
+
+  /// The insertion index the live drag would drop at, or null when no drag
+  /// is hovering a thumbnail panel. Panels paint their marker from this.
+  int? get dropIndex => _index;
+
+  /// Whether a drag is currently over a thumbnail panel - hosts use it to
+  /// step their own full-window drop hint out of the way.
+  bool get isOverPanel => _index != null;
+
+  /// Registers a panel's hit-test. Panels call this when they mount and
+  /// [detachPanel] when they go away; hosts don't.
+  void attachPanel(PdfThumbnailDropResolver resolver) {
+    _panels.add(resolver);
+  }
+
+  /// Withdraws a panel. Clears the live indicator when it was the one
+  /// showing it (a panel can be disposed mid-drag - the page grid closing,
+  /// a responsive breakpoint flip).
+  void detachPanel(PdfThumbnailDropResolver resolver) {
+    _panels.remove(resolver);
+    if (identical(_target, resolver)) {
+      _target = null;
+      _index = null;
+      notifyListeners();
+    }
+  }
+
+  /// Whether [resolver]'s panel owns the live indicator, and at which
+  /// index - null when the drag is elsewhere.
+  int? indicatorIndexFor(PdfThumbnailDropResolver resolver) =>
+      identical(_target, resolver) ? _index : null;
+
+  /// The insertion index a drop at [globalPosition] would use, without
+  /// touching the indicator. Null when the point is over no panel.
+  int? indexAt(Offset globalPosition) => _resolve(globalPosition)?.$2;
+
+  /// Reports a live drag at [globalPosition]: moves (or clears) the
+  /// insertion marker and returns the index a drop would use.
+  int? dragOver(Offset globalPosition) {
+    final hit = _resolve(globalPosition);
+    final target = hit?.$1;
+    final index = hit?.$2;
+    if (identical(target, _target) && index == _index) return index;
+    _target = target;
+    _index = index;
+    notifyListeners();
+    return index;
+  }
+
+  /// Ends the drag (dropped, cancelled, or left the window), clearing the
+  /// insertion marker.
+  void endDrag() {
+    if (_target == null && _index == null) return;
+    _target = null;
+    _index = null;
+    notifyListeners();
+  }
+
+  (PdfThumbnailDropResolver, int)? _resolve(Offset globalPosition) {
+    for (final panel in _panels.reversed) {
+      final index = panel(globalPosition);
+      if (index != null) return (panel, index);
+    }
+    return null;
+  }
+
+  @override
+  void dispose() {
+    _panels.clear();
+    // clear the target too: a panel outliving the controller (a host that
+    // disposes it first) then detaches without a notify-after-dispose
+    _target = null;
+    _index = null;
+    super.dispose();
+  }
+}
+
+/// Which edge of a page tile an insertion marker hugs. The docked strip
+/// stacks tiles vertically ([top]/[bottom]); the page grid flows them
+/// along the reading direction ([left]/[right]).
+enum PdfThumbnailDropEdge { top, bottom, left, right }
+
+/// The insertion index a drop at [globalPosition] lands on for a panel
+/// whose tiles are laid out along [axis], or null when the point is
+/// outside the panel.
+///
+/// [panelContext] bounds the hit to the panel's own box; [tileKeys] holds
+/// the panel's per-page tile keys (only the built ones answer - a
+/// scrolled-away tile has no render object, and the nearest built tile
+/// then wins). The result is a *slot*: 0..pageCount, the position the
+/// dropped pages would take.
+int? pdfThumbnailDropIndexAt({
+  required BuildContext? panelContext,
+  required Map<int, GlobalKey> tileKeys,
+  required int pageCount,
+  required Axis axis,
+  required Offset globalPosition,
+  bool reversed = false,
+}) {
+  final panel = panelContext?.findRenderObject();
+  if (panel is! RenderBox || !panel.hasSize || !panel.attached) return null;
+  final local = panel.globalToLocal(globalPosition);
+  if (!(Offset.zero & panel.size).contains(local)) return null;
+  if (pageCount <= 0) return 0;
+
+  int? nearest;
+  Rect? nearestRect;
+  var nearestDistance = double.infinity;
+  for (final entry in tileKeys.entries) {
+    if (entry.key >= pageCount) continue;
+    final box = entry.value.currentContext?.findRenderObject();
+    if (box is! RenderBox || !box.hasSize || !box.attached) continue;
+    final rect = box.localToGlobal(Offset.zero) & box.size;
+    final distance = _distanceTo(rect, globalPosition);
+    if (distance < nearestDistance) {
+      nearest = entry.key;
+      nearestRect = rect;
+      nearestDistance = distance;
+    }
+  }
+  if (nearest == null || nearestRect == null) return null;
+
+  final centre = nearestRect.center;
+  var after = axis == Axis.vertical
+      ? globalPosition.dy > centre.dy
+      : globalPosition.dx > centre.dx;
+  if (reversed) after = !after;
+  return (nearest + (after ? 1 : 0)).clamp(0, pageCount);
+}
+
+/// Squared distance from [point] to the nearest point of [rect] (zero
+/// inside it) - only the ordering matters, so the square root is skipped.
+double _distanceTo(Rect rect, Offset point) {
+  final dx = (rect.left - point.dx).clamp(0.0, double.infinity) +
+      (point.dx - rect.right).clamp(0.0, double.infinity);
+  final dy = (rect.top - point.dy).clamp(0.0, double.infinity) +
+      (point.dy - rect.bottom).clamp(0.0, double.infinity);
+  return dx * dx + dy * dy;
+}

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -24,6 +24,7 @@ import '../toast.dart';
 import 'editing_controller.dart';
 import 'editing_panel.dart';
 import 'editing_preferences.dart';
+import 'editing_thumbnail_drop.dart';
 import 'thumbnail_cache.dart';
 
 /// A panel of page thumbnails: tap one to jump there, drag a tile up or
@@ -81,6 +82,7 @@ class PdfThumbnailSidebar extends StatefulWidget {
     this.onClose,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.fileDropController,
     this.renderWorker,
     this.rasterCache,
   });
@@ -155,6 +157,15 @@ class PdfThumbnailSidebar extends StatefulWidget {
   /// footer menu.
   final void Function(Uint8List bytes)? onExportPages;
 
+  /// Lets a PDF dragged in from outside the app (the desktop, a browser
+  /// download) be dropped *between two tiles* - the strip paints an
+  /// insertion marker where the pages would land while the drag hovers,
+  /// and the host reads the index back to insert there. The platform's
+  /// drag stream lives with the host, so it drives the controller; the
+  /// strip only supplies the geometry. Null (the default) leaves the
+  /// strip inert to external drags. See [PdfThumbnailDropController].
+  final PdfThumbnailDropController? fileDropController;
+
   /// How many thumbnails have actually been rasterized - cache misses
   /// only, across all sidebars. Tests assert on the deltas.
   @visibleForTesting
@@ -197,6 +208,12 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
   /// selection stay in place as dimmed placeholders while the proxy carries
   /// the whole selection's page count.
   int? _reorderPage;
+
+  /// This strip's hit-test, registered with
+  /// [PdfThumbnailSidebar.fileDropController]. Held in a field so attach
+  /// and detach pass the *same* closure (a method tear-off is a fresh
+  /// object each time it's read).
+  late final PdfThumbnailDropResolver _dropResolver = _dropIndexAt;
 
   PdfEditingPreferences get _preferences => widget.controller.preferences;
 
@@ -386,11 +403,16 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     // scrolling the strip re-prioritizes the shared render queue toward the
     // tiles that just came into view
     _scroll.addListener(_onScroll);
+    _attachDrop(widget.fileDropController);
   }
 
   @override
   void didUpdateWidget(PdfThumbnailSidebar old) {
     super.didUpdateWidget(old);
+    if (!identical(old.fileDropController, widget.fileDropController)) {
+      _detachDrop(old.fileDropController);
+      _attachDrop(widget.fileDropController);
+    }
     if (!identical(old.viewerController, widget.viewerController)) {
       old.viewerController.removeListener(_onViewerChanged);
       widget.viewerController.addListener(_onViewerChanged);
@@ -410,6 +432,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
 
   @override
   void dispose() {
+    _detachDrop(widget.fileDropController);
     widget.viewerController.removeListener(_onViewerChanged);
     _preferences.removeListener(_onPreferences);
     HardwareKeyboard.instance.removeHandler(_onKeyEvent);
@@ -419,6 +442,37 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
     _scroll.dispose();
     _focusNode.dispose();
     super.dispose();
+  }
+
+  void _attachDrop(PdfThumbnailDropController? drop) {
+    drop
+      ?..attachPanel(_dropResolver)
+      ..addListener(_onDropChanged);
+  }
+
+  void _detachDrop(PdfThumbnailDropController? drop) {
+    drop
+      ?..removeListener(_onDropChanged)
+      ..detachPanel(_dropResolver);
+  }
+
+  /// The drag moved (or ended): repaint so the insertion marker follows it.
+  void _onDropChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// Where a PDF dropped at [globalPosition] would be inserted - the slot
+  /// between the tiles nearest the pointer. Null when the point misses the
+  /// strip, or when the strip can't take structural page edits at all.
+  int? _dropIndexAt(Offset globalPosition) {
+    if (!mounted || !widget.allowPageEditing) return null;
+    return pdfThumbnailDropIndexAt(
+      panelContext: context,
+      tileKeys: _tileKeys,
+      pageCount: widget.controller.document.pageCount,
+      axis: Axis.vertical,
+      globalPosition: globalPosition,
+    );
   }
 
   void _onPreferences() {
@@ -607,6 +661,13 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                   // controller's builder, so filling/clearing the clipboard
                   // (a controller notification) re-evaluates it.
                   final pasteInsertionPage = _pasteInsertionPage;
+                  // ...and the slot an external PDF being dragged over the
+                  // strip would drop into. The marker rides the top edge of
+                  // the tile the pages would land before - or the bottom
+                  // edge of the last tile for a drop past the end.
+                  final dropIndex = widget.fileDropController
+                      ?.indicatorIndexFor(_dropResolver);
+                  final pageCount = controller.document.pageCount;
                   return Column(
                     children: [
                       // page-level file actions sit in a slim header at the top so
@@ -720,6 +781,12 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
                                 renderWorker: widget.renderWorker,
                                 inRangePreview: rangePreview.contains(index),
                                 showPasteIndicator: pasteInsertionPage == index,
+                                dropEdge: _tileDropEdge(
+                                  dropIndex,
+                                  index,
+                                  pageCount,
+                                  Axis.vertical,
+                                ),
                                 showPageActions:
                                     !pdfPanelControlsRevealOnHover() ||
                                         _hoverPage == index,
@@ -781,6 +848,23 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
       scroll: _scroll,
       thumbKey: const ValueKey('pdf-thumbnail-scrollbar-thumb'),
     );
+    // an outline around the whole strip while a file drag hovers it, so the
+    // panel reads as the drop target the per-tile marker is aiming into
+    final dropOutline =
+        widget.fileDropController?.indicatorIndexFor(_dropResolver) == null
+            ? null
+            : Positioned.fill(
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    key: const ValueKey('pdf-thumbnail-drop-outline'),
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                          color: Theme.of(context).colorScheme.primary,
+                          width: 2),
+                    ),
+                  ),
+                ),
+              );
 
     // a bottom sheet spans the full width: the list fills it so a drag
     // anywhere in the sheet scrolls (not just over the narrow tile
@@ -792,6 +876,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
         return Stack(children: [
           Positioned.fill(child: buildList(inset)),
           Positioned(top: 0, bottom: 0, right: 0, child: scrollbar),
+          if (dropOutline != null) dropOutline,
         ]);
       });
     }
@@ -806,6 +891,7 @@ class _PdfThumbnailSidebarState extends State<PdfThumbnailSidebar> {
         right: geometry.scrollbarInset,
         child: scrollbar,
       ),
+      if (dropOutline != null) dropOutline,
     ]);
   }
 }
@@ -944,6 +1030,31 @@ class _PageSelectionBar extends StatelessWidget {
       ],
     );
   }
+}
+
+/// Which edge of tile [index] carries the file-drop insertion marker for a
+/// drag currently aimed at slot [dropIndex] (null: no drag over this
+/// panel). The marker leads the tile the dropped pages would land before -
+/// or trails the last tile when they'd go past the end - so it always
+/// paints in the gap the pages will fill. [reversed] flips the horizontal
+/// edges for a right-to-left grid.
+PdfThumbnailDropEdge? _tileDropEdge(
+  int? dropIndex,
+  int index,
+  int pageCount,
+  Axis axis, {
+  bool reversed = false,
+}) {
+  if (dropIndex == null) return null;
+  final leading = axis == Axis.vertical
+      ? PdfThumbnailDropEdge.top
+      : (reversed ? PdfThumbnailDropEdge.right : PdfThumbnailDropEdge.left);
+  final trailing = axis == Axis.vertical
+      ? PdfThumbnailDropEdge.bottom
+      : (reversed ? PdfThumbnailDropEdge.left : PdfThumbnailDropEdge.right);
+  if (dropIndex == index) return leading;
+  if (dropIndex >= pageCount && index == pageCount - 1) return trailing;
+  return null;
 }
 
 enum _PageAction { paste, insert, export }
@@ -1115,6 +1226,7 @@ class PdfThumbnailView extends StatefulWidget {
     this.allowPageEditing = true,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.fileDropController,
     this.onOpenPage,
     this.renderWorker,
     this.rasterCache,
@@ -1154,6 +1266,12 @@ class PdfThumbnailView extends StatefulWidget {
   /// "Export pages…" page-action and the selection bar's export.
   final void Function(Uint8List bytes)? onExportPages;
 
+  /// Lets a PDF dragged in from outside the app be dropped between two
+  /// tiles, at the marked position in the page order. The host drives the
+  /// controller from the platform's drag stream; the grid supplies the
+  /// geometry. See [PdfThumbnailDropController].
+  final PdfThumbnailDropController? fileDropController;
+
   /// Called after a double-click scrolls the viewer to [pageIndex]. Hosts
   /// that show the grid in place of the viewer turn it off here so the
   /// chosen page shows.
@@ -1190,6 +1308,11 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
   int? _keyboardPage;
   int? _dragPage;
 
+  /// This grid's hit-test, registered with
+  /// [PdfThumbnailView.fileDropController] - a stable closure so attach and
+  /// detach agree on identity (see the strip's copy).
+  late final PdfThumbnailDropResolver _dropResolver = _dropIndexAt;
+
   Set<int> get _rangePreview => _shiftHeld && _hoverPage != null
       ? widget.controller.pageRangePreviewTo(_hoverPage!).toSet()
       : const {};
@@ -1206,11 +1329,16 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
     // the grid builds every cell eagerly, so without a viewport focus every
     // page would compete equally; scroll position drives which render first
     _scroll.addListener(_onScroll);
+    _attachDrop(widget.fileDropController);
   }
 
   @override
   void didUpdateWidget(PdfThumbnailView old) {
     super.didUpdateWidget(old);
+    if (!identical(old.fileDropController, widget.fileDropController)) {
+      _detachDrop(old.fileDropController);
+      _attachDrop(widget.fileDropController);
+    }
     if (!identical(old.controller.preferences, _preferences)) {
       old.controller.preferences.removeListener(_onPreferences);
       _preferences.addListener(_onPreferences);
@@ -1224,6 +1352,7 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
 
   @override
   void dispose() {
+    _detachDrop(widget.fileDropController);
     _preferences.removeListener(_onPreferences);
     HardwareKeyboard.instance.removeHandler(_onKeyEvent);
     // the cache belongs to the session, not this grid - only withdraw its
@@ -1232,6 +1361,37 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
     _scroll.dispose();
     _focusNode.dispose();
     super.dispose();
+  }
+
+  void _attachDrop(PdfThumbnailDropController? drop) {
+    drop
+      ?..attachPanel(_dropResolver)
+      ..addListener(_onDropChanged);
+  }
+
+  void _detachDrop(PdfThumbnailDropController? drop) {
+    drop
+      ?..removeListener(_onDropChanged)
+      ..detachPanel(_dropResolver);
+  }
+
+  void _onDropChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// Where a PDF dropped at [globalPosition] would be inserted: the gap
+  /// between the grid cells nearest the pointer, along the reading
+  /// direction. Null when the point misses the grid or it is read-only.
+  int? _dropIndexAt(Offset globalPosition) {
+    if (!mounted || !widget.allowPageEditing) return null;
+    return pdfThumbnailDropIndexAt(
+      panelContext: context,
+      tileKeys: _tileKeys,
+      pageCount: widget.controller.document.pageCount,
+      axis: Axis.horizontal,
+      globalPosition: globalPosition,
+      reversed: Directionality.of(context) == TextDirection.rtl,
+    );
   }
 
   void _onPreferences() {
@@ -1461,6 +1621,12 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
                 listenable: controller,
                 builder: (context, _) {
                   final rangePreview = _rangePreview;
+                  // the slot an external PDF being dragged over the grid
+                  // would drop into - marked on the leading edge of the
+                  // cell its pages would land before
+                  final dropIndex = widget.fileDropController
+                      ?.indicatorIndexFor(_dropResolver);
+                  final rtl = Directionality.of(context) == TextDirection.rtl;
                   return Column(
                     children: [
                       // header: title, the tile-size control, and the page-actions menu
@@ -1545,6 +1711,13 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
                                             onActivatePage: _openPage,
                                             inRangePreview:
                                                 rangePreview.contains(i),
+                                            dropEdge: _tileDropEdge(
+                                              dropIndex,
+                                              i,
+                                              controller.document.pageCount,
+                                              Axis.horizontal,
+                                              reversed: rtl,
+                                            ),
                                             showPageActions:
                                                 !pdfPanelControlsRevealOnHover() ||
                                                     _hoverPage == i,
@@ -1582,6 +1755,24 @@ class _PdfThumbnailViewState extends State<PdfThumbnailView> {
                                   'pdf-thumbnail-view-scrollbar-thumb'),
                             ),
                           ),
+                          // the grid reads as the drop target while a file
+                          // drag hovers it
+                          if (dropIndex != null)
+                            Positioned.fill(
+                              child: IgnorePointer(
+                                child: DecoratedBox(
+                                  key: const ValueKey(
+                                      'pdf-thumbnail-view-drop-outline'),
+                                  decoration: BoxDecoration(
+                                    border: Border.all(
+                                      color:
+                                          Theme.of(context).colorScheme.primary,
+                                      width: 2,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
                         ]),
                       ),
                       // a footer to append a blank page; editable grids only
@@ -1670,6 +1861,7 @@ class _GridPageCell extends StatefulWidget {
     required this.onDragStarted,
     required this.onDragEnded,
     this.inRangePreview = false,
+    this.dropEdge,
     this.showPageActions = true,
     this.onHover,
     this.onFocusPage,
@@ -1690,6 +1882,10 @@ class _GridPageCell extends StatefulWidget {
   final VoidCallback onDragStarted;
   final VoidCallback onDragEnded;
   final bool inRangePreview;
+
+  /// The edge carrying the file-drop insertion marker, if this cell is the
+  /// one the hovering drag would insert against. See [_PageTile.dropEdge].
+  final PdfThumbnailDropEdge? dropEdge;
   final bool showPageActions;
   final void Function(bool hovering)? onHover;
   final void Function(int pageIndex)? onFocusPage;
@@ -1718,6 +1914,7 @@ class _GridPageCellState extends State<_GridPageCell> {
         onActivatePage: widget.onActivatePage,
         activateOnTap: false,
         inRangePreview: widget.inRangePreview,
+        dropEdge: widget.dropEdge,
         showPageActions: widget.showPageActions,
         onHover: widget.onHover,
         onFocusPage: widget.onFocusPage,
@@ -1933,6 +2130,7 @@ class _PageTile extends StatefulWidget {
     this.activateOnTap = true,
     this.inRangePreview = false,
     this.showPasteIndicator = false,
+    this.dropEdge,
     this.showPageActions = true,
     this.onHover,
     this.onFocusPage,
@@ -1959,6 +2157,12 @@ class _PageTile extends StatefulWidget {
   /// clipboard has pages, marking where ⌘/Ctrl+V (or the strip's paste)
   /// will drop them - right after this page. The grid leaves it false.
   final bool showPasteIndicator;
+
+  /// The edge to paint a file-drop insertion marker on while a PDF dragged
+  /// in from outside the app hovers the panel: the pages would land in the
+  /// gap the marker fills. Null (the usual case) paints nothing. See
+  /// [PdfThumbnailDropController].
+  final PdfThumbnailDropEdge? dropEdge;
 
   /// The mouse entering (true) or leaving (false) this tile, so the strip
   /// can track the hovered page for its Shift range preview. Null off the
@@ -2004,6 +2208,7 @@ class _PageTileState extends State<_PageTile> {
   PdfRenderWorker? get renderWorker => widget.renderWorker;
   bool get inRangePreview => widget.inRangePreview;
   bool get showPasteIndicator => widget.showPasteIndicator;
+  PdfThumbnailDropEdge? get dropEdge => widget.dropEdge;
   void Function(bool hovering)? get onHover => widget.onHover;
   void Function(int pageIndex)? get onActivatePage => widget.onActivatePage;
   bool get activateOnTap => widget.activateOnTap;
@@ -2294,9 +2499,35 @@ class _PageTileState extends State<_PageTile> {
             right: 0,
             bottom: 0,
             child: IgnorePointer(
-              child: _PasteInsertionMarker(
+              child: _InsertionMarker(
                 key: ValueKey('pdf-thumbnail-paste-indicator-$pageIndex'),
                 color: scheme.primary,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+    // the same bar, on the edge a file dragged in from outside the app
+    // would drop its pages into
+    final dropEdge = this.dropEdge;
+    if (dropEdge != null) {
+      final vertical = dropEdge == PdfThumbnailDropEdge.left ||
+          dropEdge == PdfThumbnailDropEdge.right;
+      content = Stack(
+        children: [
+          content,
+          Positioned(
+            left: dropEdge == PdfThumbnailDropEdge.right ? null : 0,
+            right: dropEdge == PdfThumbnailDropEdge.left ? null : 0,
+            top: dropEdge == PdfThumbnailDropEdge.bottom ? null : 0,
+            bottom: dropEdge == PdfThumbnailDropEdge.top ? null : 0,
+            child: IgnorePointer(
+              child: _InsertionMarker(
+                key: ValueKey(
+                    'pdf-thumbnail-drop-indicator-$pageIndex-${dropEdge.name}'),
+                color: scheme.primary,
+                axis: vertical ? Axis.vertical : Axis.horizontal,
               ),
             ),
           ),
@@ -2313,14 +2544,23 @@ class _PageTileState extends State<_PageTile> {
   }
 }
 
-/// A slim horizontal bar with rounded end caps, painted across a page
-/// tile's bottom edge to mark where a paste will insert the clipboard's
-/// pages - right after the tile it sits under. Purely decorative (the paste
-/// runs from the strip's keyboard/menu paste), so it ignores pointers.
-class _PasteInsertionMarker extends StatelessWidget {
-  const _PasteInsertionMarker({super.key, required this.color});
+/// A slim bar with rounded end caps, painted along a page tile's edge to
+/// mark where pages will be inserted - a paste (right after the tile it
+/// sits under) or a file dragged in from outside the app (into the gap the
+/// bar fills). Purely decorative - the insert runs from the strip's
+/// paste/drop handling - so it ignores pointers.
+class _InsertionMarker extends StatelessWidget {
+  const _InsertionMarker({
+    super.key,
+    required this.color,
+    this.axis = Axis.horizontal,
+  });
 
   final Color color;
+
+  /// The bar's own direction: horizontal along a top/bottom edge (the
+  /// stacked strip), vertical along a left/right one (the flowing grid).
+  final Axis axis;
 
   @override
   Widget build(BuildContext context) {
@@ -2329,21 +2569,23 @@ class _PasteInsertionMarker extends StatelessWidget {
           height: 6,
           decoration: BoxDecoration(color: color, shape: BoxShape.circle),
         );
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8),
-      child: Row(children: [
-        cap(),
-        Expanded(
-          child: Container(
-            height: 3,
-            decoration: BoxDecoration(
-              color: color,
-              borderRadius: BorderRadius.circular(1.5),
-            ),
-          ),
+    final bar = Expanded(
+      child: Container(
+        height: axis == Axis.horizontal ? 3 : null,
+        width: axis == Axis.vertical ? 3 : null,
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(1.5),
         ),
-        cap(),
-      ]),
+      ),
+    );
+    return Padding(
+      padding: axis == Axis.horizontal
+          ? const EdgeInsets.symmetric(horizontal: 8)
+          : const EdgeInsets.symmetric(vertical: 8),
+      child: axis == Axis.horizontal
+          ? Row(children: [cap(), bar, cap()])
+          : Column(children: [cap(), bar, cap()]),
     );
   }
 }

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -15,6 +15,7 @@ import 'editing/editing_preferences.dart';
 import 'editing/editing_properties.dart';
 import 'editing/editing_sidebar.dart';
 import 'editing/editing_stamps.dart';
+import 'editing/editing_thumbnail_drop.dart';
 import 'editing/editing_thumbnails.dart';
 import 'editing/editing_toolbar.dart';
 import 'editing/text_prompt.dart';
@@ -224,6 +225,7 @@ class PdfEditorView extends StatefulWidget {
     this.onDocumentChanged,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.thumbnailDropController,
     this.onAction,
     this.onAnnotationTap,
     this.pageOverlayBuilder,
@@ -304,6 +306,7 @@ class PdfEditorView extends StatefulWidget {
     this.onDocumentChanged,
     this.onPickPdfToInsert,
     this.onExportPages,
+    this.thumbnailDropController,
     this.onAction,
     this.onAnnotationTap,
     this.pageOverlayBuilder,
@@ -450,6 +453,15 @@ class PdfEditorView extends StatefulWidget {
   /// thumbnail strip's "Export pages…" action asks for the range, then
   /// hands the bytes here). When null the action is hidden.
   final void Function(Uint8List bytes)? onExportPages;
+
+  /// Lets a PDF dragged in from outside the app be dropped at a chosen
+  /// position in the page thumbnails (strip or full-area grid) instead of
+  /// only being appended: the panels paint an insertion marker where the
+  /// pages would land, and the host reads the index back on drop. Only the
+  /// host sees the platform's drag stream, so it drives the controller -
+  /// see [PdfThumbnailDropController] for the wiring. Needs
+  /// [PdfEditorFeatures.pageEditing].
+  final PdfThumbnailDropController? thumbnailDropController;
 
   /// See [PdfViewer.onAction].
   final PdfActionHandler? onAction;
@@ -720,6 +732,8 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         onDocumentChanged: complete ? widget.onDocumentChanged : null,
         onPickPdfToInsert: complete ? widget.onPickPdfToInsert : null,
         onExportPages: complete ? widget.onExportPages : null,
+        thumbnailDropController:
+            complete ? widget.thumbnailDropController : null,
         onAction: widget.onAction,
         onAnnotationTap: widget.onAnnotationTap,
         pageOverlayBuilder: widget.pageOverlayBuilder,
@@ -884,6 +898,11 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 onPickPdfToInsert:
                     features.pageEditing ? widget.onPickPdfToInsert : null,
                 onExportPages: widget.onExportPages,
+                // dropping a PDF between two tiles inserts it there; a
+                // read-only shell takes no structural page edits
+                fileDropController: features.pageEditing
+                    ? widget.thumbnailDropController
+                    : null,
                 renderWorker: _shell.worker,
                 rasterCache: thumbnailDisk,
               );
@@ -951,6 +970,9 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                 onPickPdfToInsert:
                     features.pageEditing ? widget.onPickPdfToInsert : null,
                 onExportPages: widget.onExportPages,
+                fileDropController: features.pageEditing
+                    ? widget.thumbnailDropController
+                    : null,
                 onOpenPage: (_) => prefs.showThumbnailView = false,
                 renderWorker: _shell.worker,
                 rasterCache: thumbnailDisk,

--- a/packages/dart_pdf_editor/test/editing_thumbnail_drop_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_drop_test.dart
@@ -1,0 +1,253 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Covers the geometry half of "drop a PDF at a position in the thumbnails":
+/// the panels answer a global drop point with the slot the pages would land
+/// in, and mark that slot while the drag hovers. The host's side of the
+/// bargain (reading the bytes and calling `insertPagesFromBytes(at:)`) is
+/// the app's - see app/test/drop_insert_test.dart.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  void wideScreen(WidgetTester tester) {
+    tester.view.physicalSize = const Size(1000, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  // thumbnails rasterize on a serialized async queue; let it settle so no
+  // work outlives the test
+  Future<void> drain(WidgetTester tester) =>
+      tester.pump(const Duration(seconds: 2));
+
+  Future<PdfThumbnailDropController> pumpStrip(
+    WidgetTester tester, {
+    int pages = 4,
+    bool allowPageEditing = true,
+  }) async {
+    final editing = PdfEditingController(buildMultiPagePdf(pages));
+    final viewer = PdfViewerController();
+    final drop = PdfThumbnailDropController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    addTearDown(drop.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Row(children: [
+          PdfThumbnailSidebar(
+            controller: editing,
+            viewerController: viewer,
+            allowPageEditing: allowPageEditing,
+            fileDropController: drop,
+          ),
+          const Expanded(child: SizedBox.expand()),
+        ]),
+      ),
+    ));
+    await tester.pump();
+    return drop;
+  }
+
+  Future<PdfThumbnailDropController> pumpGrid(
+    WidgetTester tester, {
+    int pages = 4,
+  }) async {
+    final editing = PdfEditingController(buildMultiPagePdf(pages));
+    final viewer = PdfViewerController();
+    final drop = PdfThumbnailDropController();
+    addTearDown(editing.dispose);
+    addTearDown(viewer.dispose);
+    addTearDown(drop.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfThumbnailView(
+          controller: editing,
+          viewerController: viewer,
+          fileDropController: drop,
+        ),
+      ),
+    ));
+    await tester.pump();
+    return drop;
+  }
+
+  /// A point inside tile [index] of the strip, [fraction] of the way down it.
+  Offset inTile(WidgetTester tester, Finder tile, double fraction) {
+    final rect = tester.getRect(tile);
+    return Offset(rect.center.dx, rect.top + rect.height * fraction);
+  }
+
+  Finder stripTile(int index) => find.byKey(ValueKey(index));
+  Finder gridCell(int index) =>
+      find.byKey(ValueKey('pdf-thumbnail-grid-cell-$index'));
+
+  group('PdfThumbnailSidebar file drops', () {
+    testWidgets('the top half of a tile drops before it, the bottom after',
+        (tester) async {
+      wideScreen(tester);
+      final drop = await pumpStrip(tester, pages: 4);
+
+      expect(drop.indexAt(inTile(tester, stripTile(1), 0.25)), 1);
+      expect(drop.indexAt(inTile(tester, stripTile(1), 0.75)), 2);
+      await drain(tester);
+    });
+
+    testWidgets('a point off the strip is not a drop target', (tester) async {
+      wideScreen(tester);
+      final drop = await pumpStrip(tester, pages: 4);
+
+      // the viewer area beside the strip
+      expect(drop.indexAt(const Offset(800, 400)), isNull);
+      await drain(tester);
+    });
+
+    testWidgets('a read-only strip declines external drops', (tester) async {
+      wideScreen(tester);
+      final drop = await pumpStrip(tester, pages: 4, allowPageEditing: false);
+
+      expect(drop.indexAt(inTile(tester, stripTile(1), 0.25)), isNull);
+      await drain(tester);
+    });
+
+    testWidgets('a hovering drag marks the slot, and ending it clears',
+        (tester) async {
+      wideScreen(tester);
+      final drop = await pumpStrip(tester, pages: 4);
+
+      expect(drop.dragOver(inTile(tester, stripTile(1), 0.25)), 1);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-1-top')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-outline')),
+          findsOneWidget);
+
+      // moving into the lower half of the same tile moves the marker down
+      expect(drop.dragOver(inTile(tester, stripTile(1), 0.75)), 2);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-1-top')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-2-top')),
+          findsOneWidget);
+
+      drop.endDrag();
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-2-top')),
+          findsNothing);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-outline')),
+          findsNothing);
+      await drain(tester);
+    });
+
+    testWidgets('a drop past the last tile marks its bottom edge',
+        (tester) async {
+      wideScreen(tester);
+      final drop = await pumpStrip(tester, pages: 2);
+
+      expect(drop.dragOver(inTile(tester, stripTile(1), 0.95)), 2);
+      await tester.pump();
+      expect(
+          find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-1-bottom')),
+          findsOneWidget);
+      await drain(tester);
+    });
+
+    testWidgets('a drag over the viewer clears a previous mark',
+        (tester) async {
+      wideScreen(tester);
+      final drop = await pumpStrip(tester, pages: 4);
+
+      drop.dragOver(inTile(tester, stripTile(0), 0.25));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-0-top')),
+          findsOneWidget);
+
+      expect(drop.dragOver(const Offset(800, 400)), isNull);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-0-top')),
+          findsNothing);
+      await drain(tester);
+    });
+  });
+
+  group('PdfThumbnailView file drops', () {
+    testWidgets('the left half of a cell drops before it, the right after',
+        (tester) async {
+      wideScreen(tester);
+      final drop = await pumpGrid(tester, pages: 4);
+      final rect = tester.getRect(gridCell(1));
+
+      expect(drop.indexAt(Offset(rect.left + rect.width * 0.2, rect.center.dy)),
+          1);
+      expect(drop.indexAt(Offset(rect.left + rect.width * 0.8, rect.center.dy)),
+          2);
+      await drain(tester);
+    });
+
+    testWidgets('a hovering drag marks the cell edge', (tester) async {
+      wideScreen(tester);
+      final drop = await pumpGrid(tester, pages: 4);
+      final rect = tester.getRect(gridCell(2));
+
+      drop.dragOver(Offset(rect.left + rect.width * 0.2, rect.center.dy));
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-2-left')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-view-drop-outline')),
+          findsOneWidget);
+      await drain(tester);
+    });
+  });
+
+  group('PdfThumbnailDropController', () {
+    test('a detached panel stops answering and clears its mark', () {
+      final drop = PdfThumbnailDropController();
+      addTearDown(drop.dispose);
+      int? resolver(Offset position) => position.dx > 100 ? 3 : null;
+      drop.attachPanel(resolver);
+
+      expect(drop.dragOver(const Offset(200, 0)), 3);
+      expect(drop.isOverPanel, isTrue);
+      expect(drop.indicatorIndexFor(resolver), 3);
+
+      drop.detachPanel(resolver);
+      expect(drop.isOverPanel, isFalse);
+      expect(drop.indexAt(const Offset(200, 0)), isNull);
+    });
+
+    test('the most recently attached panel answers first', () {
+      final drop = PdfThumbnailDropController();
+      addTearDown(drop.dispose);
+      int? strip(Offset position) => 1;
+      int? grid(Offset position) => 7;
+      drop
+        ..attachPanel(strip)
+        ..attachPanel(grid);
+
+      expect(drop.indexAt(Offset.zero), 7);
+      drop.detachPanel(grid);
+      expect(drop.indexAt(Offset.zero), 1);
+    });
+
+    test('notifies only when the marked slot changes', () {
+      final drop = PdfThumbnailDropController();
+      addTearDown(drop.dispose);
+      var notifications = 0;
+      drop
+        ..addListener(() => notifications++)
+        ..attachPanel((position) => position.dx.round());
+
+      drop.dragOver(const Offset(4, 0));
+      drop.dragOver(const Offset(4, 9)); // same slot: no repaint
+      expect(notifications, 1);
+      drop.dragOver(const Offset(5, 0));
+      expect(notifications, 2);
+      drop.endDrag();
+      expect(notifications, 3);
+      drop.endDrag(); // already clear
+      expect(notifications, 3);
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/editing_thumbnail_drop_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_drop_test.dart
@@ -154,6 +154,79 @@ void main() {
       await drain(tester);
     });
 
+    testWidgets('a bottom-sheet strip takes drops too', (tester) async {
+      wideScreen(tester);
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      final viewer = PdfViewerController();
+      final drop = PdfThumbnailDropController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      addTearDown(drop.dispose);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.bottomCenter,
+            child: SizedBox(
+              height: 400,
+              child: PdfThumbnailSidebar(
+                controller: editing,
+                viewerController: viewer,
+                bottomSheet: true,
+                fileDropController: drop,
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.pump();
+
+      expect(drop.dragOver(inTile(tester, stripTile(1), 0.25)), 1);
+      await tester.pump();
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-indicator-1-top')),
+          findsOneWidget);
+      expect(find.byKey(const ValueKey('pdf-thumbnail-drop-outline')),
+          findsOneWidget);
+      await drain(tester);
+    });
+
+    testWidgets('swapping the drop controller moves the registration',
+        (tester) async {
+      wideScreen(tester);
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      final viewer = PdfViewerController();
+      final first = PdfThumbnailDropController();
+      final second = PdfThumbnailDropController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+      Future<void> pumpWith(PdfThumbnailDropController drop) =>
+          tester.pumpWidget(MaterialApp(
+            home: Scaffold(
+              body: Row(children: [
+                PdfThumbnailSidebar(
+                  controller: editing,
+                  viewerController: viewer,
+                  fileDropController: drop,
+                ),
+                const Expanded(child: SizedBox.expand()),
+              ]),
+            ),
+          ));
+
+      await pumpWith(first);
+      await tester.pump();
+      final point = inTile(tester, stripTile(1), 0.25);
+      expect(first.indexAt(point), 1);
+
+      await pumpWith(second);
+      await tester.pump();
+      // the strip answers its new controller and no longer the old one
+      expect(second.indexAt(point), 1);
+      expect(first.indexAt(point), isNull);
+      await drain(tester);
+    });
+
     testWidgets('a drag over the viewer clears a previous mark',
         (tester) async {
       wideScreen(tester);
@@ -199,6 +272,41 @@ void main() {
           findsOneWidget);
       await drain(tester);
     });
+
+    testWidgets('swapping the drop controller moves the registration',
+        (tester) async {
+      wideScreen(tester);
+      final editing = PdfEditingController(buildMultiPagePdf(3));
+      final viewer = PdfViewerController();
+      final first = PdfThumbnailDropController();
+      final second = PdfThumbnailDropController();
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      addTearDown(first.dispose);
+      addTearDown(second.dispose);
+      Future<void> pumpWith(PdfThumbnailDropController drop) =>
+          tester.pumpWidget(MaterialApp(
+            home: Scaffold(
+              body: PdfThumbnailView(
+                controller: editing,
+                viewerController: viewer,
+                fileDropController: drop,
+              ),
+            ),
+          ));
+
+      await pumpWith(first);
+      await tester.pump();
+      final rect = tester.getRect(gridCell(1));
+      final point = Offset(rect.left + rect.width * 0.2, rect.center.dy);
+      expect(first.indexAt(point), 1);
+
+      await pumpWith(second);
+      await tester.pump();
+      expect(second.indexAt(point), 1);
+      expect(first.indexAt(point), isNull);
+      await drain(tester);
+    });
   });
 
   group('PdfThumbnailDropController', () {
@@ -210,10 +318,12 @@ void main() {
 
       expect(drop.dragOver(const Offset(200, 0)), 3);
       expect(drop.isOverPanel, isTrue);
+      expect(drop.dropIndex, 3);
       expect(drop.indicatorIndexFor(resolver), 3);
 
       drop.detachPanel(resolver);
       expect(drop.isOverPanel, isFalse);
+      expect(drop.dropIndex, isNull);
       expect(drop.indexAt(const Offset(200, 0)), isNull);
     });
 


### PR DESCRIPTION
## Summary

Dragging a PDF onto the window offered *open in a new tab* or *insert pages* — the latter always appending at the end. A drop onto the page thumbnails now places the pages exactly where it landed: the thumbnail strip (and the full-area page grid) paints an insertion marker in the gap under the pointer while the drag hovers, and the drop merges the file there without asking.

The platform's drag stream belongs to the host app and the tile geometry belongs to the panels, so the two meet through a new controller:

- **`PdfThumbnailDropController`** (`src/editing/editing_thumbnail_drop.dart`, exported). Panels register a `PdfThumbnailDropResolver` (`int? Function(Offset globalPosition)`) on mount and withdraw it on dispose; the host calls `dragOver(globalPosition)` while the drag moves, `indexAt(globalPosition)` on drop, and `endDrag()` when it ends. The most recently attached panel answers first, so an overlaid page grid wins the area it covers.
- **`pdfThumbnailDropIndexAt`** does the hit-test for both layouts: bound the point to the panel's box, pick the nearest *built* tile by distance to its rect, then take the slot before or after it — `dy` for the stacked strip, `dx` for the flowing grid (flipped under RTL). The result is a slot in `0..pageCount`, i.e. the `at:` index `insertPagesFromBytes` already takes.
- **New API surface:** `PdfThumbnailSidebar(fileDropController:)`, `PdfThumbnailView(fileDropController:)`, `PdfEditorView(thumbnailDropController:)` (forwarded to both panels only when `PdfEditorFeatures.pageEditing` is on). All default to null — existing hosts are unchanged and inert to external drags.
- `_PasteInsertionMarker` became `_InsertionMarker` with an `axis`, so the paste bar and the drop bar are one widget; `_PageTile.dropEdge` picks the edge (leading the tile the pages land before, trailing the last tile for a drop past the end).

App side: `EditorScreen` owns one controller and wires it to its existing `desktop_drop` `DropTarget`. A positioned drop skips the open/insert dialog (the drop point already answered the question), keeps multi-file order by advancing the insert position by each file's page count, reveals the first inserted page, and hides the full-window drop hint while the drag is over a panel.

Notes on the design and the testing gotchas: `doc/dev-log/2026-08-06-thumbnail-file-drop-position.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only (CLAUDE.md + dev-log note)

Also `/app` (the DartPDF app), which owns the drag stream.

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (repo-wide, clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2125 passed, 35 skipped)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Plus `cd app && fvm flutter test` — 415 passed.

If any relevant check was not run, explain why: the change is confined to editor-package UI plumbing and the app; nothing touches parsing, rendering, or the COS layer, so the pure-Dart package suites and the render corpora have no exposure to it.

## PDF fixtures and screenshots

New tests build their documents programmatically (`buildMultiPagePdf`). No fixtures added.

- `packages/dart_pdf_editor/test/editing_thumbnail_drop_test.dart` — the geometry (top/bottom half of a strip tile, left/right of a grid cell, a drop past the last tile, a point off the panel, read-only panels declining) and the controller (detach clears the mark, most-recently-attached panel answers first, notify only when the slot changes).
- `app/test/drop_insert_test.dart` — the drag marks the slot and the window-wide hint yields (and comes back over the page area); a positioned drop skips the dialog; and one test reads a **real file** so it can assert the insert actually landed (the strip grows to four tiles). That is possible here only because this path takes no UI tap, so the write and the drop delivery can run inside `tester.runAsync` — the dialog path's byte read still can't (see the 2026-06-22 dev-log note).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output. (n/a — no parser/writer changes)
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- Registration identity is `identical`, so each panel holds its resolver in a `late final` field — a method tear-off is a fresh object every read, and attach/detach would otherwise disagree.
- `_onFilesDropped` reads the slot **before** `endDrag()`: clearing the drag repaints the geometry the panels answer from.
- A drop on the panels is a plain insert, so it is one undoable step per dropped file, exactly like the existing append path.
- Not wired for `PdfReader` (read-only, no edit session) or for hosts that don't pass a controller.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5e1tsJyyhrVC72k7uHkjj)_