### PR TITLE
Place substituted glyphs at the PDF's own advances (#649)

### DIFF
--- a/doc/dev-log/2026-08-06-substituted-glyph-placement-649.md
+++ b/doc/dev-log/2026-08-06-substituted-glyph-placement-649.md
@@ -1,0 +1,188 @@
+# Exact placement for substituted glyphs (#649)
+
+Second half of #647. That issue reported the selection band sitting beside
+the glyphs; #648 fixed the *range → geometry* half (`quadsFor` /
+`positionNear` now use exact per-character advances). This is the other
+half: where the substituted glyphs actually land.
+
+## The defect
+
+For a run with no embedded font program, `CanvasPdfDevice.drawText` shaped
+the whole string with a substituted system font and applied **one uniform
+horizontal scale** so the run total matched the PDF's advance:
+
+```dart
+final scaleX = targetWidth / layout.width;
+canvas.scale(scaleX / renderSize, -1 / renderSize);
+layout.paint(canvas, Offset(0, -layout.baseline));
+```
+
+That pins the run's two **endpoints** and nothing between them. Interior
+characters land at the substitute's own advance distribution. On page 1 of
+the demo document - a 77-character line drawn as a single `Tj` in
+non-embedded 12pt Helvetica - the drift is zero at both ends and **4.4pt at
+its worst, mid-run**: about two thirds of a lowercase glyph.
+
+Selection bands, search highlights, markup placed over a selection and
+content-element hit boxes all derive from the PDF's own advances, so every
+one of them reads as offset against the drawn glyphs by that amount.
+
+## The fix
+
+`PdfTextRun.charOffsets` (added by #648) is the em-space pen offset of
+every character boundary, and it is populated for substituted fonts
+precisely because it needs only metrics, not outlines. The device now lays
+the run out at those offsets instead of scaling the substitute's
+distribution to fit.
+
+Three pieces:
+
+1. **`PdfInterpreter`** collects the table for a run with **no glyph list**
+   whether or not `collectCharOffsets` was asked for. That flag stays the
+   opt-in for *every* run (text extraction wants embedded runs too); an
+   embedded run's `glyphs` already carry the same positions, so a painting
+   walk still pays nothing on the common embedded-font page.
+2. **`render_command_codec`** carries the table across the worker hop, for
+   substituted runs only (format version 4 → 5). An embedded run's
+   transcript is unchanged in size. `TranslatingPdfDevice` was dropping the
+   spacing fields as well as the new table on its way through a tiled
+   pattern cell; it carries all of them now.
+3. **`CanvasPdfDevice._buildPlacedLayout`** builds the run from parts, each
+   drawn at the offset the PDF gives it.
+
+Behind `CanvasPdfDevice.exactSubstitutedGlyphPlacement` (on by default).
+
+### Words, not characters
+
+The obvious reading of the issue - one part per character, each at
+`charOffsets[i]` - is exact, and it was the first implementation. It is
+also a `drawParagraph` per character, which measured **3.7x the record pass
+and 1.6x the full DPR-2 raster** on a page of 5,500 characters of
+non-embedded prose. That is not a price this fix is worth.
+
+So the unit is the **word** - a maximal span of non-whitespace characters -
+placed at its own offset and shaped whole. A word is broken down into
+characters only when it needs to be: `_wordHolds` walks it and compares the
+substitute's own cumulative advance against the PDF's at **every character
+boundary**, and any excursion past `_placementToleranceEm` (0.02 em, 0.24pt
+at 12pt) sends that one word to per-character placement.
+
+Checking every boundary rather than the word's total is the whole point:
+matching a total while the interior wanders is the defect being fixed, and
+a two-character word can have an exact total with a badly placed interior
+(`substituted_glyph_placement_test` pins exactly that case).
+
+What this buys: **word origins are always exact**, so drift can never
+accumulate along a line - the 4.4pt case is structurally impossible.
+Within a word the error is bounded by the tolerance, an order of magnitude
+under what the issue reports, and where even that would be exceeded the
+characters are placed individually. It also keeps intra-word kerning, which
+is why most substituted text renders unchanged.
+
+### Dropping the substitute's kerning is the point, not a cost
+
+`_composableRun` - #454's gate for the *natural-advance* composition - is
+deliberately narrow (no lowercase, letters may only neighbour digits or
+spaces) because composing there drops the substitute's cross-character
+kerning and the whole-run rendering was the reference.
+
+Placement inverts that reference. A PDF expresses its kerning as `TJ`
+adjustments; those are already inside `charOffsets`. The substitute's own
+kerning is not the document's - it is error. So `_placeableRun` does not
+care about kerning at all; it only asks whether the script lays one glyph
+out per character (Latin, Greek, Cyrillic, the common symbol blocks, CJK,
+Hangul syllables). Arabic, Hebrew, Indic, South-East Asian, Hangul jamo,
+combining sequences and astral characters keep whole-run shaping, as do
+vertical and RTL runs, which get no table in the first place.
+
+### The scale is measured over ink alone
+
+The glyph *shapes* still take one uniform squeeze - scaling each part to
+its own advance would squeeze an `i` far harder than an `o` and look ragged
+- but the ratio is `Σ natural ÷ Σ PDF advance` over the **non-whitespace**
+characters. That keeps two things out of it: the substitute's idea of a
+space (Skia's reported width for a lone whitespace layout is not something
+to build on) and the run's Tc/Tw, which are already inside the offsets. The
+space between two placed words is therefore whatever the PDF says, not
+whatever the substitute would have drawn - which is the second half of why
+lines stop drifting.
+
+As a consequence per-character layouts are now built with
+`applySpacing: false`: baking Tc/Tw into a glyph the caller positions
+itself would double-count it, and the `_glyphCache` key never carried
+spacing anyway, so the key is now honest rather than saved by a gate.
+
+Note the algebra: with the layout reporting `run.width × k` for a layout
+laid out at `k` units per em, the caller's own
+`scaleX = width × renderSize ÷ layout.width` recovers `renderSize ÷ k`, so
+part `i` lands at exactly `offsets[i]` em regardless of the run's total.
+`run.width` cancels out of the positions entirely - it only has to be
+positive.
+
+### The endpoint trade
+
+Whole-run shaping pins both endpoints exactly and gets every interior
+boundary wrong. Placement makes the reverse trade: every part's origin is
+exact, and the **last glyph's shape**, drawn at the run's average squeeze
+rather than its own, may overhang the run's end by a few percent of an em.
+That is the right way round - the origins are what selection, search and
+hit-testing are computed from. `substituted_glyph_placement_test` pins both
+sides of the trade so neither can drift silently.
+
+## Gotchas
+
+- **A placed layout owns its parts.** #454's composed layouts borrow from
+  `_glyphCache` and are transient for exactly that reason - the cache would
+  dispose a painter out from under them. A placed layout is *cached* (keyed
+  by text + style + a hash of the offsets, since the same text under
+  different advances is a different layout), so it shapes its own parts and
+  disposes them: `_TextLayout.composed(ownsParts: true)`.
+- **`_trimmedForPaint` had to slice the table.** A leading space carrying a
+  large `Tw` is how tabular content reaches its column; the device paints
+  the trimmed core and translates by `leadingSpace`. The sliced offsets are
+  rebased by **`run.leadingSpace`**, not by `offsets[start]`, so a
+  disagreement between this trim and the interpreter's per-glyph visibility
+  test shifts nothing - every character keeps its absolute page position.
+  `_trimEdges` (a `String.trim()`) became `_isTrimWhitespace`, an
+  index-wise predicate over the same code-unit set, because the slice needs
+  indices.
+- **A gradient or stroke keeps whole-run shaping.** Both paint through
+  their own fresh whole-run `TextPainter`, which no part can stand in for,
+  and the layout's width feeds the `scaleX` those painters are drawn under.
+- **One paragraph with a span per character does not work.** It would be a
+  single draw call, with each span's `letterSpacing` stretching that
+  character to the PDF's advance. The engine's reported boxes say the
+  spacing lands after the cluster; the rendered ink says otherwise, and the
+  two disagree differently for positive and negative spacing. Positions
+  could not be made exact that way, so it was abandoned - see the git
+  history of this branch if it looks tempting again.
+- **The transcript declines a table of the wrong length** rather than
+  indexing off the end of the run, the same way `deserializePageText`
+  already did for extraction.
+
+## Perf
+
+- `tool/perf.sh diff HEAD dartpdf-corpus` (VM sweep, 4 interleaved runs):
+  **VERDICT OK**. `interpretMs` 1.014x, `extractMs` 1.007x, `peakRssBytes`
+  1.002x - the per-run `charOffsets` list on substituted runs is noise, and
+  embedded-font pages allocate nothing new.
+- Paint, on a synthetic worst case (55 lines × 100 characters of
+  non-embedded Helvetica, and a *fixed-pitch* substitute, so **every** word
+  fails the tolerance and every character is placed individually): record
+  1.9 → 3.9 ms/page, full DPR-2 raster 15 → 21 ms/page. A substitute whose
+  relative widths track the PDF's keeps its words whole and costs one draw
+  per word; the flutter_test font cannot, which is what makes this a bound
+  rather than an estimate.
+- Pages whose fonts are embedded record the same commands as before, byte
+  for byte.
+- Not measured here: the real-Chrome harness (`tool/perf.sh webdiff`) on a
+  text-heavy scenario, which is the number that decides whether the
+  tolerance wants loosening. Worth running before assuming this is free on
+  a standard-14 document.
+
+## Baselines
+
+`ghent_render_test` only pixel-compares on macOS (baselines are rendered
+there; CI/Linux rasterizes text with different fonts and skips the diff),
+so this change needs the Ghent baselines re-accepted with `GHENT_UPDATE=1`
+on a macOS checkout for any patch whose text is not embedded.

--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -18,8 +18,7 @@ import 'perf_log.dart';
 /// engine produces real glyph outlines. Images must be pre-decoded into
 /// [images] (painting is synchronous).
 class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
-  CanvasPdfDevice(this.canvas,
-      {this.images = const {}, this.pixelRatio = 1});
+  CanvasPdfDevice(this.canvas, {this.images = const {}, this.pixelRatio = 1});
 
   final Canvas canvas;
 
@@ -98,6 +97,25 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
   /// 0% for every run this gate admits (kerning-pair uppercase words, the only
   /// divergent case, are excluded), so the speed-up carries no fidelity cost.
   static bool perGlyphSubstitutedText = true;
+
+  /// Place substituted glyphs at the PDF's own per-character pen offsets
+  /// ([PdfTextRun.charOffsets]) instead of letting the substitute distribute
+  /// them (#649).
+  ///
+  /// The uniform horizontal scale that makes a substituted run's total advance
+  /// match the PDF pins the run's two endpoints and nothing in between, so
+  /// interior glyphs land wherever the substitute's own advances put them -
+  /// measured at up to 4.4pt of drift on a 77-character 12pt Helvetica line,
+  /// zero at both ends and worst mid-run. Everything geometric (selection
+  /// bands, search highlights, markup placed over a selection, content-element
+  /// hit boxes) derives from the PDF's advances, so all of it reads as offset
+  /// against the drawn glyphs by that much.
+  ///
+  /// Placing each character at its own offset makes the interior correct by
+  /// construction. It drops the substitute's cross-character kerning, which is
+  /// the point: a PDF expresses its kerning as TJ adjustments, those are
+  /// already in the offsets, and the substitute's own kerning is error.
+  static bool exactSubstitutedGlyphPlacement = true;
 
   /// Em-space [ui.Path] per embedded-glyph outline, keyed by outline identity.
   /// An [Expando] ties each entry to its [PdfPath]'s lifetime (the font's own
@@ -750,13 +768,27 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
         ? _trimmedForPaint(run)
         : run;
 
-    final compose = perGlyphSubstitutedText &&
-        paintRun.gradient == null &&
-        paintRun.strokeColor == null &&
+    // A gradient or a stroke paints through its own whole-run painter below,
+    // which no per-character layout can stand in for - those keep whole-run
+    // shaping so painter and layout stay width-consistent.
+    final wholeRunPaint =
+        paintRun.gradient != null || paintRun.strokeColor != null;
+    // The PDF's own per-character pen offsets, when this run carries them and
+    // its script lays one glyph out per character (#649). Preferred over both
+    // the composed and the whole-run path: it is the only one whose interior
+    // matches the geometry selection and search are computed from.
+    final placements = exactSubstitutedGlyphPlacement && !wholeRunPaint
+        ? _placeableOffsets(paintRun)
+        : null;
+    final compose = placements == null &&
+        perGlyphSubstitutedText &&
+        !wholeRunPaint &&
         paintRun.letterSpacing == 0 &&
         paintRun.wordSpacing == 0 &&
         _composableRun(paintRun.text);
-    final layout = _measureLayout(paintRun, compose: compose);
+    final layout = placements != null
+        ? _placedLayout(paintRun, placements)
+        : _measureLayout(paintRun, compose: compose);
 
     canvas.save();
     canvas.transform(_toFloat64(run.transform));
@@ -783,8 +815,7 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
           gradientFill = TextPainter(
             text: TextSpan(
                 text: paintRun.text,
-                style: _styleFor(
-                    paintRun,
+                style: _styleFor(paintRun,
                     foreground: Paint()
                       ..shader = _shaderFor(gradient,
                           transform: gradient.transform.concat(pageToLocal))
@@ -801,7 +832,8 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
     TextPainter? strokePainter;
     if (paintRun.strokeColor != null) {
       final ts = run.transform.scaleFactor;
-      final w = paintRun.strokeWidth > 0 ? paintRun.strokeWidth : ts / renderSize;
+      final w =
+          paintRun.strokeWidth > 0 ? paintRun.strokeWidth : ts / renderSize;
       strokePainter = TextPainter(
         text: TextSpan(
           text: paintRun.text,
@@ -836,10 +868,29 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
   /// caller as a canvas translation, so it is zeroed here. Everything else -
   /// transform, colour, spacing, stroke, gradient - is carried through unchanged.
   static PdfTextRun _trimmedForPaint(PdfTextRun run) {
-    final core = _trimEdges(run.text);
+    final text = run.text;
+    var start = 0;
+    var end = text.length;
+    while (start < end && _isTrimWhitespace(text.codeUnitAt(start))) {
+      start++;
+    }
+    while (end > start && _isTrimWhitespace(text.codeUnitAt(end - 1))) {
+      end--;
+    }
+    final core = text.substring(start, end);
     final coreWidth = (run.visibleWidth ?? run.width) - run.leadingSpace;
+    // Rebase the per-character offsets onto the trimmed text. They are rebased
+    // by the caller's own translation ([leadingSpace]), not by `offsets[start]`,
+    // so a disagreement between this trim and the interpreter's per-glyph
+    // visibility test shifts nothing: every character keeps its absolute
+    // position on the page.
+    final offsets = run.charOffsets;
+    final coreOffsets = offsets != null && offsets.length == text.length + 1
+        ? [for (var i = start; i <= end; i++) offsets[i] - run.leadingSpace]
+        : null;
     return PdfTextRun(
       text: core,
+      charOffsets: coreOffsets,
       transform: run.transform,
       color: run.color,
       width: coreWidth,
@@ -855,10 +906,23 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
     );
   }
 
-  /// Strips leading and trailing Unicode whitespace, matching the interpreter's
-  /// `text.trim().isNotEmpty` visibility test that produced leadingSpace /
-  /// visibleWidth.
-  static String _trimEdges(String s) => s.trim();
+  /// The code units [String.trim] strips - the interpreter's
+  /// `text.trim().isNotEmpty` visibility test, which produced leadingSpace /
+  /// visibleWidth, uses the same set. Tested by index rather than by trimming a
+  /// substring so the character offsets can be sliced to match.
+  static bool _isTrimWhitespace(int cu) =>
+      (cu >= 0x09 && cu <= 0x0D) ||
+      cu == 0x20 ||
+      cu == 0x85 ||
+      cu == 0xA0 ||
+      cu == 0x1680 ||
+      (cu >= 0x2000 && cu <= 0x200A) ||
+      cu == 0x2028 ||
+      cu == 0x2029 ||
+      cu == 0x202F ||
+      cu == 0x205F ||
+      cu == 0x3000 ||
+      cu == 0xFEFF;
 
   /// A laid-out painter (+ width/baseline) for a substituted-font run, served
   /// from the process-wide cache. The key is (text, font, colour) — everything
@@ -871,16 +935,19 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
     final key = '${run.text} ${run.fontName ?? ''} '
         '${c.red},${c.green},${c.blue} '
         '${run.letterSpacing},${run.wordSpacing}';
-    if (!PdfPerfLog.enabled) {
-      return _textCache.getOrAdd(key, () => _shapeLayout(run));
-    }
-    // Instrumented path (#454): the factory runs only on a miss, so timing it
-    // isolates the shaping cost, and the flag separates miss from hit.
+    return _cachedLayout(key, () => _shapeLayout(run));
+  }
+
+  /// The run-cache lookup, with the shaping instrumentation (#454) wrapped
+  /// around it: [build] runs only on a miss, so timing it isolates the shaping
+  /// cost and the flag separates miss from hit.
+  _TextLayout _cachedLayout(String key, _TextLayout Function() build) {
+    if (!PdfPerfLog.enabled) return _textCache.getOrAdd(key, build);
     var missed = false;
     final layout = _textCache.getOrAdd(key, () {
       missed = true;
       final clock = Stopwatch()..start();
-      final l = _shapeLayout(run);
+      final l = build();
       debugTextShapeUs += clock.elapsedMicroseconds;
       return l;
     });
@@ -922,6 +989,9 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
   }
 
   /// A single character's cached layout, keyed like the run cache but per rune.
+  /// Laid out without the run's Tc/Tw: a per-character layout is positioned by
+  /// its caller, which knows the real advances, so baking spacing into the
+  /// glyph would double-count it - and it would make the key a lie.
   _TextLayout _glyphLayout(int rune, PdfTextRun run) {
     final c = run.color;
     final key = '$rune ${run.fontName ?? ''} ${c.red},${c.green},${c.blue}';
@@ -929,7 +999,7 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
       final painter = TextPainter(
         text: TextSpan(
             text: String.fromCharCode(rune),
-            style: _styleFor(run, foreground: null)),
+            style: _styleFor(run, foreground: null, applySpacing: false)),
         textDirection: TextDirection.ltr,
       )..layout();
       final baseline =
@@ -937,6 +1007,224 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
       return _TextLayout(painter, painter.width, baseline);
     });
   }
+
+  /// The per-character pen offsets to paint [run] at, or null when this run
+  /// must keep whole-run (or naturally composed) placement (#649).
+  ///
+  /// Requires a table of the right shape, a positive advance to scale against,
+  /// and a script that lays one glyph out per character - see [_placeableRun].
+  static List<double>? _placeableOffsets(PdfTextRun run) {
+    final offsets = run.charOffsets;
+    if (offsets == null || run.text.isEmpty || run.width <= 0) return null;
+    if (offsets.length != run.text.length + 1) return null;
+    return _placeableRun(run.text) ? offsets : null;
+  }
+
+  /// How far, in em, a word's own shaped advance may differ from the PDF's
+  /// before [_buildPlacedLayout] stops shaping it whole and places its
+  /// characters individually. 0.02 em is 0.24pt at 12pt - an order of
+  /// magnitude under the drift this fixes, and small enough that the
+  /// difference is invisible where it is tolerated.
+  static const double _placementToleranceEm = 0.02;
+
+  /// A run laid out at the PDF's own pen offsets (#649) instead of at the
+  /// substitute's cumulative advances, served from the run cache. The key
+  /// carries the offsets as well as everything [_styleFor] reads, because the
+  /// same text under different advances is a different layout.
+  _TextLayout _placedLayout(PdfTextRun run, List<double> offsets) {
+    final c = run.color;
+    final key = '${run.text} ${run.fontName ?? ''} '
+        '${c.red},${c.green},${c.blue} p${_offsetsHash(offsets)}';
+    // A run with nothing to scale against falls back to whole-run shaping,
+    // cached under this key too so the failed attempt is not repeated.
+    return _cachedLayout(
+        key, () => _buildPlacedLayout(run, offsets) ?? _shapeLayout(run));
+  }
+
+  /// Builds the layout [_placedLayout] caches: one part per **word** - a
+  /// maximal span of non-whitespace characters - drawn at that word's own
+  /// offset, so a word can never drift from the geometry selection and search
+  /// are computed from. A word whose shaped advance disagrees with the PDF's
+  /// by more than [_placementToleranceEm] is broken down further and placed
+  /// character by character, which is what a run of prose against a mismatched
+  /// substitute needs. Whitespace lays no ink down and is positioned by the
+  /// offsets around it, so it gets no part at all.
+  ///
+  /// Words rather than characters throughout because the draw call is the
+  /// cost: a `drawParagraph` per character measured 3.7x the record pass and
+  /// 1.6x the full DPR-2 raster on a page of non-embedded prose. Shaping a
+  /// word whole also keeps its internal kerning, which the PDF's own advances
+  /// do not contradict at this tolerance.
+  ///
+  /// The glyph *shapes* take one uniform horizontal scale, so their proportions
+  /// stay even (scaling each word to its own advance would squeeze an `i` far
+  /// harder than an `o`); only the origins become exact. That scale is
+  /// `Σ natural ÷ Σ PDF advance` over the ink-bearing characters alone, so
+  /// neither the substitute's idea of a space (Skia's width for a lone
+  /// whitespace layout is not something to build on) nor the run's Tc/Tw
+  /// (already inside [offsets]) can skew it.
+  ///
+  /// The caller derives `scaleX = run.width × renderSize ÷ layout.width` and
+  /// paints under `scaleX / renderSize`, so reporting `run.width × k` for a
+  /// layout laid out at `k` units per em recovers `renderSize ÷ k` whatever the
+  /// run's total advance is - and every part lands on exactly its own offset.
+  ///
+  /// Null when there is nothing measurable to scale against.
+  _TextLayout? _buildPlacedLayout(PdfTextRun run, List<double> offsets) {
+    final text = run.text;
+    var natural = 0.0; // Σ natural width of the ink-bearing glyphs
+    var advance = 0.0; // Σ PDF advance of the same glyphs
+    for (var i = 0; i < text.length;) {
+      final step = _runeLengthAt(text, i);
+      if (!_isTrimWhitespace(text.codeUnitAt(i))) {
+        natural += _glyphLayout(_runeAt(text, i), run).width;
+        advance += offsets[i + step] - offsets[i];
+      }
+      i += step;
+    }
+    if (natural <= 0 || advance <= 0) return null;
+
+    final k = natural / advance; // layout units per em
+    final style = _styleFor(run, foreground: null, applySpacing: false);
+    final parts = <_GlyphRun>[];
+    double? baseline;
+    var i = 0;
+    while (i < text.length) {
+      if (_isTrimWhitespace(text.codeUnitAt(i))) {
+        i++;
+        continue;
+      }
+      var end = i;
+      while (end < text.length && !_isTrimWhitespace(text.codeUnitAt(end))) {
+        end += _runeLengthAt(text, end);
+      }
+      if (_wordHolds(run, offsets, i, end, k)) {
+        final word = _shapeString(text.substring(i, end), style);
+        baseline ??= word.baseline;
+        parts.add(_GlyphRun(word, offsets[i] * k));
+      } else {
+        for (var j = i; j < end;) {
+          final step = _runeLengthAt(text, j);
+          final glyph = _shapeString(text.substring(j, j + step), style);
+          baseline ??= glyph.baseline;
+          parts.add(_GlyphRun(glyph, offsets[j] * k));
+          j += step;
+        }
+      }
+      i = end;
+    }
+    if (parts.isEmpty) return null;
+    return _TextLayout.composed(parts, run.width * k, baseline ?? 0,
+        ownsParts: true);
+  }
+
+  /// Whether the word `[start, end)` of [run] can be shaped whole without any
+  /// of its characters landing more than [_placementToleranceEm] from the
+  /// offset the PDF gives it.
+  ///
+  /// Checked at *every* character boundary, not just the word's end: matching
+  /// only a total is the very defect this replaces, and a two-character word
+  /// can have an exact total with a badly placed interior. The substitute's own
+  /// per-character advances stand in for where the shaped word would put each
+  /// character, so cross-character kerning is unaccounted for - a fraction of
+  /// the tolerance, and it only ever moves a word from whole-shaped to
+  /// per-character placement, which is the safe direction.
+  bool _wordHolds(
+      PdfTextRun run, List<double> offsets, int start, int end, double k) {
+    final tolerance = _placementToleranceEm;
+    var natural = 0.0; // em, from the substitute's own advances
+    for (var i = start; i < end;) {
+      final step = _runeLengthAt(run.text, i);
+      if ((natural - (offsets[i] - offsets[start])).abs() > tolerance) {
+        return false;
+      }
+      natural += _glyphLayout(_runeAt(run.text, i), run).width / k;
+      i += step;
+    }
+    return (natural - (offsets[end] - offsets[start])).abs() <= tolerance;
+  }
+
+  /// One laid-out [TextPainter] for [text] in [style], owned by the caller.
+  _TextLayout _shapeString(String text, TextStyle style) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    return _TextLayout(painter, painter.width,
+        painter.computeDistanceToActualBaseline(TextBaseline.alphabetic));
+  }
+
+  /// Order-sensitive hash of a run's character offsets, for the layout key.
+  static int _offsetsHash(List<double> offsets) {
+    var h = 0x811c9dc5;
+    for (final offset in offsets) {
+      h = ((h ^ offset.hashCode) * 0x01000193) & 0x3FFFFFFF;
+    }
+    return h;
+  }
+
+  /// 2 when [i] starts a surrogate pair in [s], 1 otherwise.
+  static int _runeLengthAt(String s, int i) {
+    final cu = s.codeUnitAt(i);
+    if (cu < 0xD800 || cu > 0xDBFF || i + 1 >= s.length) return 1;
+    final low = s.codeUnitAt(i + 1);
+    return low >= 0xDC00 && low <= 0xDFFF ? 2 : 1;
+  }
+
+  /// The code point starting at [i] in [s].
+  static int _runeAt(String s, int i) => _runeLengthAt(s, i) == 2
+      ? 0x10000 +
+          ((s.codeUnitAt(i) - 0xD800) << 10) +
+          (s.codeUnitAt(i + 1) - 0xDC00)
+      : s.codeUnitAt(i);
+
+  /// Whether [text] can be painted one character at a time at positions the
+  /// caller dictates.
+  ///
+  /// Unlike [_composableRun] this does not care about kerning - the PDF's
+  /// offsets replace it - only that the script needs no shaping: one glyph per
+  /// character, in logical order, with no combining marks, joining behaviour,
+  /// reordering, or format characters. So it admits Latin, Greek, Cyrillic,
+  /// the common symbol blocks and CJK/kana/Hangul-syllable text (ordinary
+  /// prose, which [_composableRun] excludes outright), and rejects Arabic,
+  /// Hebrew, Indic, South-East Asian, Hangul jamo, combining sequences and
+  /// anything astral, all of which keep whole-run shaping.
+  static bool _placeableRun(String text) {
+    for (var i = 0; i < text.length; i++) {
+      if (!_placeableChar(text.codeUnitAt(i))) return false;
+    }
+    return true;
+  }
+
+  static bool _placeableChar(int cu) =>
+      // ASCII printable, Latin-1 Supplement, Latin Extended-A/B, IPA and the
+      // spacing modifier letters (0x2B0-0x2FF); 0x300+ is combining marks.
+      (cu >= 0x20 && cu <= 0x2FF && cu != 0x7F) ||
+      // Greek and Coptic; Cyrillic either side of its combining block
+      // (0x483-0x489).
+      (cu >= 0x370 && cu <= 0x482) ||
+      (cu >= 0x48A && cu <= 0x52F) ||
+      // General punctuation, minus the format and bidi controls at 0x200B-
+      // 0x200F / 0x202A-0x202E / 0x2060+, and minus the combining marks at
+      // 0x20D0+.
+      (cu >= 0x2010 && cu <= 0x2027) ||
+      (cu >= 0x2030 && cu <= 0x205E) ||
+      (cu >= 0x20A0 && cu <= 0x20BF) ||
+      // Letterlike, number forms, arrows, maths, technical, enclosed
+      // alphanumerics, box drawing, geometric shapes and dingbats.
+      (cu >= 0x2100 && cu <= 0x23FF) ||
+      (cu >= 0x2460 && cu <= 0x27BF) ||
+      // CJK punctuation and kana, minus the combining voiced marks
+      // (0x3099/0x309A); ideographs; Hangul syllables (precomposed - jamo at
+      // 0x1100 compose and are excluded); CJK compatibility; halfwidth and
+      // fullwidth forms.
+      (cu >= 0x3000 && cu <= 0x3098) ||
+      (cu >= 0x309B && cu <= 0x30FF) ||
+      (cu >= 0x3400 && cu <= 0x4DBF) ||
+      (cu >= 0x4E00 && cu <= 0x9FFF) ||
+      (cu >= 0xAC00 && cu <= 0xD7A3) ||
+      (cu >= 0xF900 && cu <= 0xFAFF) ||
+      (cu >= 0xFF01 && cu <= 0xFFEE);
 
   /// Whether [text] can be composed from independent per-character layouts
   /// without visibly changing the result. Composition drops cross-character
@@ -978,7 +1266,19 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
 
   // . , - + / : = ( ) % # * _
   static const _composablePunct = <int>{
-    0x2E, 0x2C, 0x2D, 0x2B, 0x2F, 0x3A, 0x3D, 0x28, 0x29, 0x25, 0x23, 0x2A, 0x5F,
+    0x2E,
+    0x2C,
+    0x2D,
+    0x2B,
+    0x2F,
+    0x3A,
+    0x3D,
+    0x28,
+    0x29,
+    0x25,
+    0x23,
+    0x2A,
+    0x5F,
   };
 
   /// The em-space [ui.Path] for a glyph outline, built once per outline
@@ -1060,7 +1360,8 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
     canvas.restore();
   }
 
-  TextStyle _styleFor(PdfTextRun run, {Paint? foreground}) {
+  TextStyle _styleFor(PdfTextRun run,
+      {Paint? foreground, bool applySpacing = true}) {
     final name = run.fontName ?? '';
     final cjk = _cjkPrimaryFontFor(name);
     final symbol = name.contains('ZapfDingbats') || name.contains('Symbol');
@@ -1092,9 +1393,11 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
       // this the layout is tight and run.width's spacing is recovered by
       // stretching the glyph shapes - which explodes when a space carries a
       // large Tw (issue: over-wide table digits). letterSpacing/wordSpacing 0
-      // (the common case) is a no-op, so unspaced runs are unchanged.
-      letterSpacing: run.letterSpacing * 100,
-      wordSpacing: run.wordSpacing * 100,
+      // (the common case) is a no-op, so unspaced runs are unchanged. A
+      // per-character layout opts out: its caller places it from the PDF's own
+      // offsets, which already carry Tc/Tw.
+      letterSpacing: applySpacing ? run.letterSpacing * 100 : 0,
+      wordSpacing: applySpacing ? run.wordSpacing * 100 : 0,
       height: 1,
     );
   }
@@ -1251,17 +1554,26 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink {
 class _TextLayout {
   /// A whole-run layout: one [TextPainter] the cache owns and disposes.
   _TextLayout(TextPainter this.painter, this.width, this.baseline)
-      : parts = null;
+      : parts = null,
+        ownsParts = false;
 
-  /// A run composed from per-character layouts (#454). [parts] reference
-  /// glyph-cache layouts this layout does NOT own (the glyph cache disposes
-  /// them); a composed layout is transient - built per paint, never cached -
-  /// so the referenced glyphs cannot be evicted under it on the single thread.
-  _TextLayout.composed(List<_GlyphRun> this.parts, this.width, this.baseline)
+  /// A run built from several sub-layouts.
+  ///
+  /// With [ownsParts] false (#454's per-character composition) the parts are
+  /// glyph-cache layouts this one does NOT own; such a layout is transient -
+  /// built per paint, never cached - so the referenced glyphs cannot be
+  /// evicted under it on the single thread. With [ownsParts] true (#649's
+  /// word placement) the parts were shaped for this layout alone, which is
+  /// what lets it be cached: nothing else can dispose them out from under it.
+  _TextLayout.composed(List<_GlyphRun> this.parts, this.width, this.baseline,
+      {this.ownsParts = false})
       : painter = null;
 
   final TextPainter? painter;
   final List<_GlyphRun>? parts;
+
+  /// Whether [dispose] must dispose [parts] as well as [painter].
+  final bool ownsParts;
   final double width;
   final double baseline;
 
@@ -1277,9 +1589,16 @@ class _TextLayout {
     }
   }
 
-  /// Disposes the owned painter; a composed layout owns none (its glyphs
-  /// belong to the glyph cache).
-  void dispose() => painter?.dispose();
+  /// Disposes what this layout owns: its own painter, and its parts when they
+  /// were shaped for it rather than borrowed from the glyph cache.
+  void dispose() {
+    painter?.dispose();
+    if (ownsParts) {
+      for (final part in parts!) {
+        part.glyph.dispose();
+      }
+    }
+  }
 }
 
 /// One character's layout within a composed run: the shared glyph-cache
@@ -1289,4 +1608,3 @@ class _GlyphRun {
   final _TextLayout glyph;
   final double dx;
 }
-

--- a/packages/dart_pdf_editor/test/editing_redaction_test.dart
+++ b/packages/dart_pdf_editor/test/editing_redaction_test.dart
@@ -207,7 +207,10 @@ void main() {
       // the redaction region in preview pixels: previews are 200px on the
       // longest side, so a 612x792 page scales by 200/792; the box
       // [60,712]-[200,748] (page space, y-up) maps to roughly x∈[15,50],
-      // y∈[11,20] from the top. Sample its center.
+      // y∈[11,20] from the top. Sample inside it but clear of the "Page 1"
+      // glyphs, which end around x=37 - a sample on a glyph edge flips on a
+      // sub-pixel shift in text placement rather than on what this test is
+      // about.
       Future<int> previewLuma(int px, int py) async {
         final image = cache.imageFor(0);
         if (image == null) return -1;
@@ -226,7 +229,7 @@ void main() {
       // white page (thin "Page 1" glyphs), so it reads light
       await tester.runAsync(
           () => cache.renderPreview(0, editing.document.page(0)));
-      expect(await previewLuma(32, 15), greaterThan(140),
+      expect(await previewLuma(45, 15), greaterThan(140),
           reason: 'pre-redaction preview is light page');
 
       editing.addRedaction(0, const PdfRect(60, 712, 200, 748));
@@ -240,7 +243,7 @@ void main() {
         await tester
             .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 20)));
         await tester.pump();
-        luma = await previewLuma(32, 15);
+        luma = await previewLuma(45, 15);
         if (luma >= 0 && luma < 80) break;
       }
       expect(luma, lessThan(80),

--- a/packages/dart_pdf_editor/test/substituted_glyph_placement_test.dart
+++ b/packages/dart_pdf_editor/test/substituted_glyph_placement_test.dart
@@ -1,0 +1,214 @@
+// Exact placement of substituted glyphs (#649). Matching only a run's total
+// advance pins its two endpoints and lets everything between land wherever the
+// substitute's own advances put it - up to ~4.4pt of drift on a 12pt line, zero
+// at both ends and worst mid-run. Selection bands, search highlights, markup
+// placed over a selection and content-element hit boxes are all computed from
+// the PDF's advances, so they read as offset against the glyphs by that much.
+//
+// The device is handed those advances as PdfTextRun.charOffsets and must paint
+// each character at its own offset. These tests drive the ink directly: they
+// render a run whose PDF offsets deliberately disagree with the substitute's
+// natural distribution, and look at where the glyphs actually landed.
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+const _width = 400;
+const _height = 120;
+
+/// Renders one run and returns the x of every column carrying ink.
+Future<List<int>> _inkColumns(PdfTextRun run) async {
+  CanvasPdfDevice.clearTextLayoutCache();
+  final recorder = ui.PictureRecorder();
+  final canvas = ui.Canvas(recorder)
+    ..drawColor(const Color(0xFFFFFFFF), BlendMode.src);
+  CanvasPdfDevice(canvas).drawText(run);
+  final image = await recorder.endRecording().toImage(_width, _height);
+  try {
+    final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+    final pixels = Uint8List.view(data!.buffer);
+    final columns = <int>[];
+    for (var x = 0; x < _width; x++) {
+      for (var y = 0; y < _height; y++) {
+        if (pixels[(y * _width + x) * 4] != 0xFF) {
+          columns.add(x);
+          break;
+        }
+      }
+    }
+    return columns;
+  } finally {
+    image.dispose();
+  }
+}
+
+/// A two-character run drawn at 20pt from the page origin-ish, with the PDF
+/// claiming [offsets] for its character boundaries.
+PdfTextRun _run(String text, List<double>? offsets, double width) => PdfTextRun(
+      text: text,
+      transform: const PdfMatrix(20, 0, 0, 20, 20, 60),
+      color: const PdfColor(0, 0, 0),
+      width: width,
+      charOffsets: offsets,
+      fontName: 'Helvetica',
+      fontSize: 20,
+    );
+
+void main() {
+  tearDown(() {
+    CanvasPdfDevice.exactSubstitutedGlyphPlacement = true;
+    CanvasPdfDevice.clearTextLayoutCache();
+  });
+
+  testWidgets('each glyph lands on its own PDF advance, not a scaled share',
+      (tester) async {
+    await tester.runAsync(() async {
+      // The test font is fixed-pitch, so "natural" placement puts the two
+      // characters flush against each other. The PDF says the second starts at
+      // 1.6 em - the kind of interior disagreement a real substitute produces
+      // as accumulated drift. Placement must follow the PDF, opening a gap;
+      // matching the 2.6 em total alone would keep them flush and only stretch
+      // both glyphs.
+      final columns = await _inkColumns(_run('AA', [0, 1.6, 2.6], 2.6));
+      expect(columns, isNotEmpty);
+
+      // 2.6 em of PDF advance across 2 em of natural glyph = a 1.3x squeeze,
+      // so each glyph is 20 * 1.3 = 26pt wide, starting at 20 and at
+      // 20 + 1.6 * 20 = 52.
+      expect(columns.first, closeTo(20, 2));
+      expect(columns.last, closeTo(52 + 26, 2));
+      // The gap between them is real ink-free space, which the whole-run path
+      // cannot produce.
+      final gap = [
+        for (var x = columns.first; x <= columns.last; x++)
+          if (!columns.contains(x)) x,
+      ];
+      expect(gap, isNotEmpty, reason: 'the second glyph must start at 1.6 em');
+      expect(gap.first, closeTo(46, 3)); // 20 + 26
+      expect(gap.last, closeTo(52, 3));
+
+      // The whole-run path, for contrast: one solid block from 20 to the run's
+      // 2.6 em end at 72. Both endpoints are exact and every interior boundary
+      // is wrong - which is the defect. Placement makes the reverse trade: each
+      // character's origin is exact, and the last glyph's *shape* (drawn at the
+      // run's average squeeze, not its own) may overhang the run's end.
+      CanvasPdfDevice.exactSubstitutedGlyphPlacement = false;
+      final whole = await _inkColumns(_run('AA', [0, 1.6, 2.6], 2.6));
+      expect(whole.first, closeTo(20, 2));
+      expect(whole.last, closeTo(72, 2));
+      expect(whole.length, whole.last - whole.first + 1,
+          reason: 'whole-run shaping leaves no gap to find the drift by');
+    });
+  });
+
+  testWidgets('a word whose interior already holds is shaped whole',
+      (tester) async {
+    await tester.runAsync(() async {
+      // The test font is fixed-pitch, so offsets of exactly one em per
+      // character are what it would draw anyway. Nothing needs taking apart,
+      // and the result must be identical to whole-run shaping - the tolerance
+      // is what keeps ordinary text off the per-character path.
+      final held = await _inkColumns(_run('AA', [0, 1, 2], 2));
+      CanvasPdfDevice.exactSubstitutedGlyphPlacement = false;
+      final whole = await _inkColumns(_run('AA', [0, 1, 2], 2));
+      expect(held, whole);
+    });
+  });
+
+  testWidgets('word origins are exact even when the interiors hold',
+      (tester) async {
+    await tester.runAsync(() async {
+      // Two one-em words with a space between them, and the PDF putting the
+      // second word a full em later than the substitute's own space would.
+      // Each word holds internally, so each is one shaped part - but the
+      // second still starts exactly where the PDF says, which is the drift
+      // that accumulates across a line of prose.
+      final columns = await _inkColumns(_run('A A', [0, 1, 3, 4], 4));
+      final gap = [
+        for (var x = columns.first; x <= columns.last; x++)
+          if (!columns.contains(x)) x,
+      ];
+      expect(gap, isNotEmpty);
+      // The shape scale comes from the ink alone - 2 em of glyph against 2 em
+      // of PDF advance, so 1x - and the space absorbs the rest: the first word
+      // spans 20-40 and the second starts at 20 + 3 * 20 = 80.
+      expect(columns.first, closeTo(20, 2));
+      expect(gap.first, closeTo(40, 3));
+      expect(gap.last, closeTo(79, 3));
+    });
+  });
+
+  testWidgets('the kill switch restores whole-run distribution',
+      (tester) async {
+    await tester.runAsync(() async {
+      CanvasPdfDevice.exactSubstitutedGlyphPlacement = false;
+      final off = await _inkColumns(_run('AA', [0, 1.6, 2.6], 2.6));
+      final none = await _inkColumns(_run('AA', null, 2.6));
+      expect(off, none,
+          reason: 'with placement off, an offset table changes nothing');
+    });
+  });
+
+  testWidgets('a run with no offset table keeps whole-run shaping',
+      (tester) async {
+    await tester.runAsync(() async {
+      // Vertical writing mode and RTL runs get no table and must be untouched.
+      final placed = await _inkColumns(_run('AA', null, 2.6));
+      CanvasPdfDevice.exactSubstitutedGlyphPlacement = false;
+      final plain = await _inkColumns(_run('AA', null, 2.6));
+      expect(placed, plain);
+    });
+  });
+
+  testWidgets('a complex script keeps whole-run shaping', (tester) async {
+    await tester.runAsync(() async {
+      // Arabic needs joining and reorders; one glyph per character is not a
+      // valid rendering of it, so the offsets must be declined.
+      const arabic = 'مرحبا';
+      final offsets = [0.0, 0.9, 1.6, 2.4, 3.1, 3.8];
+      final placed = await _inkColumns(_run(arabic, offsets, 3.8));
+      CanvasPdfDevice.exactSubstitutedGlyphPlacement = false;
+      final plain = await _inkColumns(_run(arabic, offsets, 3.8));
+      expect(placed, plain);
+    });
+  });
+
+  testWidgets('a table of the wrong length is declined', (tester) async {
+    await tester.runAsync(() async {
+      // One entry per character plus the closing boundary, or nothing: a
+      // mismatched table would index off the end of the run.
+      final placed = await _inkColumns(_run('AA', [0, 1.6], 2.6));
+      CanvasPdfDevice.exactSubstitutedGlyphPlacement = false;
+      final plain = await _inkColumns(_run('AA', null, 2.6));
+      expect(placed, plain);
+    });
+  });
+
+  testWidgets('leading whitespace still opens its gap once', (tester) async {
+    await tester.runAsync(() async {
+      // A leading space carrying a large Tw is how tabular content reaches its
+      // column. The device translates by leadingSpace and paints the trimmed
+      // core, so the core's offsets must be rebased by exactly that much -
+      // double-counting it would push the glyphs a whole column right.
+      final spaced = PdfTextRun(
+        text: ' AA',
+        transform: const PdfMatrix(20, 0, 0, 20, 20, 60),
+        color: const PdfColor(0, 0, 0),
+        width: 4.6,
+        leadingSpace: 2.0,
+        visibleWidth: 4.6,
+        charOffsets: const [0, 2.0, 3.6, 4.6],
+        fontName: 'Helvetica',
+        fontSize: 20,
+      );
+      final columns = await _inkColumns(spaced);
+      expect(columns, isNotEmpty);
+      // First visible glyph at 2.0 em: 20 + 2.0 * 20 = 60.
+      expect(columns.first, closeTo(60, 2));
+    });
+  });
+}

--- a/packages/dart_pdf_editor/test/text_cache_test.dart
+++ b/packages/dart_pdf_editor/test/text_cache_test.dart
@@ -109,26 +109,44 @@ void main() {
       CanvasPdfDevice.clearTextLayoutCache();
       final page = PdfDocument.open(buildClassicPdf()).page(0);
 
+      // A Latin run is now painted per character at the PDF's own offsets
+      // (#649), so its shaping is memoized in the glyph cache rather than the
+      // run cache - an alphabet's worth of entries, shared by every run that
+      // uses those characters.
       await _raster(page);
-      final afterFirst = CanvasPdfDevice.debugTextLayoutCacheLength;
+      final afterFirst = CanvasPdfDevice.debugGlyphLayoutCacheLength;
       expect(afterFirst, greaterThan(0),
           reason: 'standard-font runs should be cached');
 
-      // Re-rendering the same page hits the cache for every run - no new
+      // Re-rendering the same page hits the cache for every character - no new
       // entries appear.
       await _raster(page);
-      expect(CanvasPdfDevice.debugTextLayoutCacheLength, afterFirst,
+      expect(CanvasPdfDevice.debugGlyphLayoutCacheLength, afterFirst,
           reason: 'a re-render is all cache hits, no new layouts');
     });
   });
 
-  testWidgets('clearTextLayoutCache empties the cache', (tester) async {
+  testWidgets('a run that keeps whole-run shaping caches as a run',
+      (tester) async {
+    await tester.runAsync(() async {
+      // Arabic needs joining and reordering, so it is not placeable per
+      // character (#649) and stays on whole-run shaping - and on the run cache.
+      CanvasPdfDevice.clearTextLayoutCache();
+      await _rasterSubstitutedArabic(throughDevice: true);
+      expect(CanvasPdfDevice.debugTextLayoutCacheLength, greaterThan(0));
+    });
+  });
+
+  testWidgets('clearTextLayoutCache empties both caches', (tester) async {
     await tester.runAsync(() async {
       final page = PdfDocument.open(buildClassicPdf()).page(0);
       await _raster(page);
+      await _rasterSubstitutedArabic(throughDevice: true);
       expect(CanvasPdfDevice.debugTextLayoutCacheLength, greaterThan(0));
+      expect(CanvasPdfDevice.debugGlyphLayoutCacheLength, greaterThan(0));
       CanvasPdfDevice.clearTextLayoutCache();
       expect(CanvasPdfDevice.debugTextLayoutCacheLength, 0);
+      expect(CanvasPdfDevice.debugGlyphLayoutCacheLength, 0);
     });
   });
 

--- a/packages/pdf_graphics/lib/src/interpreter.dart
+++ b/packages/pdf_graphics/lib/src/interpreter.dart
@@ -234,13 +234,18 @@ class PdfInterpreter {
   final bool resolveOverprint;
 
   /// Whether to fill in [PdfTextRun.charOffsets] - the em-space pen position
-  /// of every character boundary in a run (issue #647).
+  /// of every character boundary in a run (issue #647) - for *every* run.
   ///
   /// On for text extraction, which needs exact intra-run geometry to land a
   /// selection or search highlight on the glyphs of a proportional font.
-  /// Off for painting walks, which get the same positions from
-  /// [PdfTextRun.glyphs] when the font is embedded and would otherwise pay a
-  /// list per run for nothing.
+  /// Painting walks leave it off: an embedded font already carries those
+  /// positions in [PdfTextRun.glyphs], so the list would be paid for nothing.
+  ///
+  /// Runs with **no** embedded font program get the table regardless of this
+  /// flag (issue #649): the device substitutes a system font there, and
+  /// without the PDF's own per-character advances it can only match the run
+  /// total, letting interior glyphs drift by several points against the
+  /// geometry that selection, search, and hit-testing use.
   final bool collectCharOffsets;
 
   /// Process-wide kill switch for the colorant-buffer overprint path
@@ -2389,13 +2394,19 @@ class PdfInterpreter {
     // along y by the vertical displacement, and each glyph is shifted by its
     // position vector so the column centres on the baseline.
     final vertical = font.isVertical;
-    // Per-character pen positions for text extraction (issue #647). Only
-    // horizontal text has a meaningful x offset per character; vertical runs
-    // advance along y and leave this null.
-    final charOffsets =
-        collectCharOffsets && !vertical && !_scanImages && emScale != 0
-            ? <double>[]
-            : null;
+    // Per-character pen positions for text extraction (issue #647) and for
+    // painting substituted text (issue #649 - a device with no embedded font
+    // program has no other source for the PDF's intra-run distribution, so
+    // those runs get the table whether or not the caller asked for it; a
+    // glyph list already carries the same offsets). Only horizontal text has a
+    // meaningful x offset per character; vertical runs advance along y and
+    // leave this null.
+    final charOffsets = (collectCharOffsets || glyphs == null) &&
+            !vertical &&
+            !_scanImages &&
+            emScale != 0
+        ? <double>[]
+        : null;
     var lastOffset = 0.0; // tail of charOffsets, kept out of the list
     final hScale = _state.horizontalScale == 0 ? 1.0 : _state.horizontalScale;
     var advance = 0.0; // text-space along the writing direction (x or y)

--- a/packages/pdf_graphics/lib/src/render_command_codec.dart
+++ b/packages/pdf_graphics/lib/src/render_command_codec.dart
@@ -53,7 +53,7 @@ import 'text_extraction.dart';
 /// Format: little notion of versioning beyond a leading byte; the producer and
 /// consumer are the same build, shipped together, so a version mismatch is a
 /// programming error, asserted on read.
-const int _formatVersion = 4;
+const int _formatVersion = 5;
 
 /// Microseconds spent reconstructing worker command buffers on the consuming
 /// isolate. Accumulated for performance probes; this is the UI-thread half of
@@ -1371,6 +1371,18 @@ void _writeTextRun(_Writer w, PdfTextRun run) {
     w.boolean(true);
     w.f64(run.visibleWidth!);
   }
+  // Per-character pen offsets (issue #649). Only a substituted run needs them -
+  // an embedded run's glyph list above already carries the same positions - so
+  // they never inflate the transcript of an embedded-font page.
+  final offsets = glyphs == null ? run.charOffsets : null;
+  if (offsets == null) {
+    w.u32(0);
+  } else {
+    w.u32(offsets.length);
+    for (final offset in offsets) {
+      w.f64(offset);
+    }
+  }
 }
 
 PdfTextRun _readTextRun(_Reader r) {
@@ -1406,6 +1418,9 @@ PdfTextRun _readTextRun(_Reader r) {
   final wordSpacing = r.f64();
   final leadingSpace = r.f64();
   final visibleWidth = r.boolean() ? r.f64() : null;
+  final offsetCount = r.u32();
+  final offsets =
+      offsetCount == 0 ? null : [for (var i = 0; i < offsetCount; i++) r.f64()];
   return PdfTextRun(
     text: text,
     transform: transform,
@@ -1423,6 +1438,10 @@ PdfTextRun _readTextRun(_Reader r) {
     wordSpacing: wordSpacing,
     leadingSpace: leadingSpace,
     visibleWidth: visibleWidth,
+    // A table of the wrong length would mis-place glyphs; drop it and let the
+    // device fall back to whole-run shaping, like a run that never carried one.
+    charOffsets:
+        offsets != null && offsets.length == text.length + 1 ? offsets : null,
   );
 }
 

--- a/packages/pdf_graphics/lib/src/translating_device.dart
+++ b/packages/pdf_graphics/lib/src/translating_device.dart
@@ -71,7 +71,8 @@ class TranslatingPdfDevice implements PdfDevice {
   @override
   void fillMesh(PdfMesh mesh, double alpha) => target.fillMesh(
       PdfMesh([
-        for (final v in mesh.vertices) PdfMeshVertex(v.x + dx, v.y + dy, v.color),
+        for (final v in mesh.vertices)
+          PdfMeshVertex(v.x + dx, v.y + dy, v.color),
       ], mesh.triangles),
       alpha);
 
@@ -99,6 +100,14 @@ class TranslatingPdfDevice implements PdfDevice {
         strokeColor: run.strokeColor,
         strokeWidth: run.strokeWidth,
         mcid: run.mcid,
+        // Em-space, so a page-space translation leaves them alone - but they
+        // still have to be carried, or a tiled cell's substituted text loses
+        // its spacing and its per-character placement (#649).
+        letterSpacing: run.letterSpacing,
+        wordSpacing: run.wordSpacing,
+        leadingSpace: run.leadingSpace,
+        visibleWidth: run.visibleWidth,
+        charOffsets: run.charOffsets,
       ));
 
   @override

--- a/packages/pdf_graphics/test/interpreter_test.dart
+++ b/packages/pdf_graphics/test/interpreter_test.dart
@@ -387,6 +387,48 @@ void main() {
       expect(run.width, closeTo(5.501, 1e-9));
     });
 
+    test('a substituted run carries per-character offsets unasked (#649)', () {
+      // A device with no embedded font program substitutes a system font, and
+      // can only match the run's total advance - interior glyphs then drift
+      // several points from the geometry selection and search use. It needs the
+      // PDF's own per-character offsets to place them, and nothing else in the
+      // run carries them, so the painting walk gets the table without opting in.
+      final doc = PdfDocument.open(buildClassicPdf());
+      final device = RecordingDevice();
+      PdfInterpreter(cos: doc.cos, device: device).drawPage(doc.page(0));
+
+      final run = device.texts.single;
+      expect(run.glyphs, isNull, reason: 'the fixture font is not embedded');
+      final offsets = run.charOffsets;
+      expect(offsets, isNotNull);
+      expect(offsets, hasLength(run.text.length + 1));
+      expect(offsets!.first, 0);
+      expect(offsets.last, closeTo(run.width, 1e-9));
+      for (var i = 0; i < run.text.length; i++) {
+        expect(offsets[i],
+            closeTo(measureHelvetica(run.text.substring(0, i), 1), 1e-9));
+      }
+    });
+
+    test('an embedded run pays for no offset table (#649)', () {
+      // Its glyph list already carries the same positions, so collecting them
+      // again would be a list per run for nothing.
+      final doc = PdfDocument.open(buildEmbeddedFontPdf());
+      final device = RecordingDevice();
+      PdfInterpreter(cos: doc.cos, device: device).drawPage(doc.page(0));
+
+      final run = device.texts.single;
+      expect(run.glyphs, isNotNull);
+      expect(run.charOffsets, isNull);
+
+      // Text extraction still asks for them explicitly, and gets them.
+      final extracting = RecordingDevice();
+      PdfInterpreter(cos: doc.cos, device: extracting, collectCharOffsets: true)
+          .drawPage(doc.page(0));
+      expect(extracting.texts.single.charOffsets,
+          hasLength(extracting.texts.single.text.length + 1));
+    });
+
     test('word/char spacing and edge whitespace feed the substitute geometry',
         () {
       // A Type1 Helvetica resource (built-in AFM widths: a=b=0.556, space=0.278

--- a/packages/pdf_graphics/test/render_command_codec_test.dart
+++ b/packages/pdf_graphics/test/render_command_codec_test.dart
@@ -111,7 +111,7 @@ class _TranscriptDevice implements PdfDevice {
       'invisible=${run.invisible} sw=${run.strokeWidth} '
       'ls=${run.letterSpacing} ws=${run.wordSpacing} '
       'ld=${run.leadingSpace} vw=${run.visibleWidth} '
-      'glyphs=${run.glyphs?.length}');
+      'glyphs=${run.glyphs?.length} offsets=${run.charOffsets}');
 
   @override
   void drawImage(PdfImageRequest request) =>


### PR DESCRIPTION
Fixes #649.

## Summary

A run with no embedded font program was shaped whole with a substituted system font and squeezed by one uniform `scaleX` so its **total** advance matched the PDF's. That pins the run's two endpoints and nothing between them, so interior glyphs land at the substitute's own distribution — the 4.4pt of mid-run drift the issue measures, zero at both ends. Selection bands, search highlights, markup placed over a selection and content-element hit boxes are all computed from the PDF's advances, so all of them read as offset against the drawn glyphs by that much.

`CanvasPdfDevice` now lays such a run out at `PdfTextRun.charOffsets`:

- **One part per word**, placed at that word's own offset and shaped whole. Word origins are exact, so drift can no longer accumulate along a line — the reported 4.4pt case is structurally impossible.
- A word is broken down into **per-character** parts when it needs to be: `_wordHolds` compares the substitute's cumulative advance against the PDF's at *every character boundary* (matching only a total while the interior wanders is the defect being fixed) and any excursion past `_placementToleranceEm` (0.02 em ≈ 0.24pt at 12pt) sends that one word to per-character placement.
- The **shape scale** is `Σ natural ÷ Σ PDF advance` over the ink-bearing characters alone, so neither the substitute's idea of a space nor the run's Tc/Tw (already inside the offsets) can skew it. Glyph proportions stay even; only the origins become exact.

Why words rather than characters everywhere: per-character placement is also exact, but it is a `drawParagraph` per character — measured at **3.7x the record pass and 1.6x the full DPR-2 raster** on a page of non-embedded prose. Word granularity keeps that to one draw per word wherever the substitute tracks the PDF's metrics, and keeps intra-word kerning, which is why most substituted text renders unchanged.

Dropping the substitute's *cross-word* kerning is the point, not a cost: a PDF expresses its kerning as `TJ` adjustments and those are already inside `charOffsets`, so the substitute's own kerning is error. That is why the gate here (`_placeableRun`) is much wider than #454's `_composableRun` — it only asks whether the script lays one glyph out per character.

Getting the offsets to the device:

- `PdfInterpreter` collects the table for any run with **no glyph list**, whether or not `collectCharOffsets` was asked for. An embedded run's `glyphs` already carry the same positions, so embedded-font pages allocate nothing new; `collectCharOffsets` stays the opt-in for *every* run (text extraction).
- `render_command_codec` carries it across the worker hop for substituted runs only (format version 4 → 5). Embedded-run transcripts are unchanged in size.
- `TranslatingPdfDevice` was dropping `letterSpacing`/`wordSpacing`/`leadingSpace`/`visibleWidth` as well as the new table on the way through a tiled pattern cell; it carries all of them now.

Out of scope by design, keeping today's behaviour: vertical and RTL runs (no table), gradient and stroked text (they paint through their own whole-run painter), and scripts that need shaping — Arabic, Hebrew, Indic, South-East Asian, Hangul jamo, combining sequences, astral characters.

Kill switch: `CanvasPdfDevice.exactSubstitutedGlyphPlacement`, on by default.

Design notes, the measurements, and the dead end that a single paragraph with one `letterSpacing` span per character turned out to be: [`doc/dev-log/2026-08-06-substituted-glyph-placement-649.md`](doc/dev-log/2026-08-06-substituted-glyph-placement-649.md).

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [x] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` — clean
- [x] `cd packages/pdf_cos && fvm dart test` — 356 passing
- [x] `cd packages/pdf_document && fvm dart test` — 808 passing
- [x] `cd packages/pdf_graphics && fvm dart test` — 1011 passing
- [x] `cd packages/dart_pdf_editor && fvm flutter test` — 2123 passing, 35 env-gated skips
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why:

- **Ghent baselines.** `ghent_render_test` only pixel-compares on macOS (baselines are rendered there; CI/Linux rasterizes text with different fonts and skips the diff), and this session runs on Linux. Every Ghent page still rasterized and asserted non-blank. Any patch whose text is not embedded will need `GHENT_UPDATE=1` on a macOS checkout — please re-accept there before merging.
- **Real PDF corpus.** `corpus/` is git-ignored and not present in this environment. The checked-in `test_corpora/dartpdf`, `test_corpora/ghent` and `test_corpora/pdfjs` suites all ran as part of the package test runs above.
- **Example app smoke test.** No display in this environment.

Perf, since this is a rendering-path change:

- `tool/perf.sh diff HEAD dartpdf-corpus` (VM sweep, 4 interleaved runs): **VERDICT OK** — `interpretMs` 1.014x, `extractMs` 1.007x, `peakRssBytes` 1.002x. The per-run `charOffsets` list on substituted runs is noise.
- Paint, on a synthetic worst case (55 lines × 100 characters of non-embedded Helvetica against a *fixed-pitch* substitute, so **every** word fails the tolerance and every character is placed individually): record 1.9 → 3.9 ms/page, full DPR-2 raster 15 → 21 ms/page. A substitute whose relative widths track the PDF's keeps its words whole; flutter_test's font cannot, which makes this a bound rather than an estimate.
- `tool/perf.sh webdiff` on a text-heavy scenario was **not** run — no real Chrome here. That is the number that decides whether the 0.02 em tolerance wants loosening, and it is the one thing I would want before assuming this is free on a standard-14 document.

## PDF fixtures and screenshots

No new fixtures. `packages/dart_pdf_editor/test/substituted_glyph_placement_test.dart` drives the ink directly: it renders runs whose PDF offsets deliberately disagree with the substitute's natural distribution and asserts where the glyphs actually landed — the exact-placement case, the two-character word with an exact total and a badly placed interior, the word that already holds (identical to whole-run shaping), exact word origins across a space, the leading-`Tw` column case, and the declines (complex script, wrong-length table, kill switch).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **Intentional rendering change.** Substituted Latin text moves. Beyond the placement itself, the shape scale is now measured over ink rather than the whole run, so where the substitute's space is proportionally wider than the PDF's the glyphs come out slightly larger and the spaces slightly narrower. On `buildClassicPdf` the ink starts at the same pixel and ends ~3% further right.
- **Two test expectations moved with it.** `text_cache_test` asserted that a Latin page populates the *run* cache; that shaping now lands in the glyph cache, so it asserts there instead (and a new case pins that Arabic, which still shapes whole-run, still populates the run cache). `editing_redaction_test` sampled a preview pixel sitting on a glyph edge, which flips on any sub-pixel shift in text placement; the sample moved clear of the glyphs, into the same redaction box.
- **The endpoint trade is deliberate.** Whole-run shaping pinned both endpoints exactly and got every interior boundary wrong; this makes the reverse trade, so the last glyph's *shape* can overhang the run's end by a few percent of an em. Origins are what selection, search and hit-testing use. Both sides are pinned by tests.
- **Follow-up if the web harness shows a cost:** the tolerance is one constant (`_placementToleranceEm`), and loosening it trades intra-word exactness for draw calls one-for-one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLKnzuRgejV6uW9s6oyKbe)_