### PR TITLE
fix(editor): place the text selection menu under the zoom transform

### DIFF
--- a/doc/dev-log/2026-08-06-zoomed-text-selection-menu.md
+++ b/doc/dev-log/2026-08-06-zoomed-text-selection-menu.md
@@ -1,0 +1,101 @@
+# 2026-08-06 — the paste menu that wasn't: text selection toolbars under the zoom transform
+
+Reported from an iPhone: *"if the page is zoomed in more than 100%, holding
+in a text box doesn't bring up the paste menu."* The long press was fine.
+The menu came up — hundreds of pixels away from the field, off the side of
+the screen.
+
+## Why 100% is the threshold
+
+The viewer splits zoom in two (`_zoomTo` in `pdf_viewer.dart`): at or below
+fit-width the *pages lay out* smaller and the `InteractiveViewer` matrix
+stays identity; above it the layout is pinned and the zoom lives in the
+transform. So >100% is exactly "the page, and every editor over it, is now
+inside a scaled `Transform`". Anything that assumed the field's transform to
+the screen was a pure translation breaks at that line and only at that line.
+
+Flutter's selection toolbar assumes exactly that. `SelectionOverlay
+.showToolbar` wraps the menu in
+
+```dart
+CompositedTransformFollower(
+  link: toolbarLayerLink,                       // leader: the field
+  offset: -renderBox.localToGlobal(Offset.zero),// the field's global origin
+  child: contextMenuBuilder(context),
+)
+```
+
+(`_SelectionToolbarWrapper`, framework `widgets/text_selection.dart`). The
+menu itself lays out in **screen** coordinates — `AdaptiveTextSelectionToolbar`
+positions itself around `editableTextState.contextMenuAnchors`, which are
+global — so the follower's transform and that negated origin are meant to
+cancel out. Write the follower's map for a leader at global origin `G` under
+scale `s`:
+
+```
+p ↦ G + s·(offset + p) = G + s·(-G + p) = (1 - s)·G + s·p
+```
+
+At `s = 1` that's the identity, as intended. At `s = 2` the menu is drawn
+twice as large **and translated by `-G`** — i.e. displaced by the whole
+distance from the screen origin to the field. Measured in a widget test
+(800×600, 2× zoom, a free-text box mid-viewport): the menu's buttons landed
+269px to the right of where the framework had anchored them. On a 390pt-wide
+phone that is entirely off-screen, which is what "holding does nothing"
+looks like from the outside.
+
+The scale half of this was already known and half-treated: the editing
+overlay counter-scaled the menu with `Transform.scale(_chromeScale, alignment:
+topCenter)` and still counter-scales the handles (`_ScaledTextSelectionControls`).
+Scaling about the menu's own top-centre fixes its size and leaves the
+displacement untouched, so the menu stayed lost.
+
+## The fix
+
+`editing_text_menu.dart` — `pdfPlacedTextSelectionMenu(editableTextState, menu)`
+wraps the menu in the inverse of the field's own transform, taken about the
+field's origin:
+
+```dart
+correction = translate(origin) · inverse(fieldToGlobal)
+```
+
+Composed with the follower (`fieldToGlobal ∘ translate(-origin)`) that is
+exactly the identity, so the menu lands on the anchors the framework
+measured — at any scale, and rotation too (the free-text editor spins its
+box with `Transform.rotate`). When the field is unscaled the correction *is*
+the identity and the framework's own placement is returned untouched, so
+nothing changes below 100%.
+
+Both in-page text inputs use it: the editing overlay's free-text / form
+editor (replacing the counter-scale hack — the inverse carries the `1/s`
+itself) and the reader's inline form-field editor in `editing_form_layer.dart`,
+which had no treatment at all and so was both oversized and displaced.
+
+Residual, noted in the source: the follower links to the field's inner
+scroll viewport while the correction is measured on the box the framework
+negates (the `EditableText`), so a field scrolled inside itself is off by
+its own scroll offset — times the zoom now, rather than once. Our in-page
+editors are sized to their content and don't scroll internally.
+
+## Tests
+
+- `editing_text_edit_test.dart` — *the long-press selection menu holds its
+  place while zoomed*: long-presses the free-text editor unzoomed and at 2×
+  and requires the menu's button bounds to sit in the same place relative to
+  `contextMenuAnchors.primaryAnchor`, at the same size, and on screen.
+  Measuring against the anchor rather than the press point is what makes the
+  two comparable: the caret line is twice as tall at 2×, so the press-relative
+  offset legitimately differs. Fails on the parent commit by 269px.
+- `editing_form_interactive_test.dart` — *the long-press selection menu lands
+  on a zoomed field*: the same property for the reader's form-field editor at
+  1.5×. Fails on the parent commit by 117px. It types into the field first —
+  an empty field parks its caret at the left edge, which this zoom has pushed
+  off-screen, and a menu clamped by the screen edge says nothing about where
+  it was anchored.
+
+Both run with `debugDefaultTargetPlatformOverride = TargetPlatform.iOS` and a
+mocked clipboard, since long-press-shows-the-menu on a collapsed selection is
+iOS behaviour.
+
+`dart analyze` clean; all 2116 `dart_pdf_editor` tests pass.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_form_layer.dart
@@ -8,6 +8,7 @@ import '../annotation_tap.dart';
 import '../page_geometry.dart';
 import '../theme.dart';
 import 'editing_controller.dart';
+import 'editing_text_menu.dart';
 import 'text_prompt.dart';
 
 TextDirection _flutterTextDirection(String text) =>
@@ -439,6 +440,14 @@ class _FormInteractionLayerState extends State<FormInteractionLayer> {
             // own focus steal while editing, so the field keeps focus
             // until this fires
             onTapOutside: (_) => _commitText(),
+            // the zoom transform would otherwise scale AND displace the
+            // long-press selection menu off-screen
+            contextMenuBuilder: (context, editableTextState) =>
+                pdfPlacedTextSelectionMenu(
+                  editableTextState,
+                  AdaptiveTextSelectionToolbar.editableText(
+                      editableTextState: editableTextState),
+                ),
             textDirection: _flutterTextDirection(_text.text),
             textAlign: _flutterTextDirection(_text.text) == TextDirection.rtl
                 ? TextAlign.right

--- a/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_overlay.dart
@@ -23,6 +23,7 @@ import 'editing_image_crop.dart';
 import 'editing_interaction.dart';
 import 'editing_link.dart';
 import 'editing_measure.dart';
+import 'editing_text_menu.dart';
 import 'editing_tool_behavior.dart';
 import 'handle_layout.dart';
 import 'stroke_prediction.dart';
@@ -5591,18 +5592,17 @@ class _EditingPageOverlayState extends State<EditingPageOverlay>
                                 selectionControls: _ScaledTextSelectionControls(
                                     _chromeScale,
                                     _inlineTextHandleColor(context)),
+                                // the zoom transform would otherwise scale
+                                // AND displace the menu off-screen
                                 contextMenuBuilder:
-                                    (context, editableTextState) {
-                                  final menu =
-                                      AdaptiveTextSelectionToolbar.editableText(
-                                          editableTextState: editableTextState);
-                                  if (_chromeScale == 1) return menu;
-                                  return Transform.scale(
-                                    scale: _chromeScale,
-                                    alignment: Alignment.topCenter,
-                                    child: menu,
-                                  );
-                                },
+                                    (context, editableTextState) =>
+                                        pdfPlacedTextSelectionMenu(
+                                          editableTextState,
+                                          AdaptiveTextSelectionToolbar
+                                              .editableText(
+                                                  editableTextState:
+                                                      editableTextState),
+                                        ),
                                 // mirrors the committed appearance: same size
                                 // in view pixels, same leading/spacing,
                                 // matching family, color and underline

--- a/packages/dart_pdf_editor/lib/src/editing/editing_text_menu.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_text_menu.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+/// Places a text field's selection toolbar - the long-press copy/paste
+/// menu - where the framework computed it, even when the field lives
+/// inside the viewer's zoom transform.
+///
+/// Flutter shows that toolbar through a [CompositedTransformFollower]
+/// linked to the field, with the field's global origin subtracted again as
+/// the follower's offset (`_SelectionToolbarWrapper` in the framework's
+/// `text_selection.dart`). The menu itself lays out in *screen*
+/// coordinates - around anchors taken from the same field - so the two
+/// cancel and it lands where it was measured. That cancellation only holds
+/// while the field's transform to the screen is a pure translation.
+///
+/// Above 100% zoom it isn't: the page (and every editor over it) sits
+/// under the viewer's `InteractiveViewer` scale `s`, so the follower maps
+/// the menu's origin to `(1 - s) * fieldOrigin` instead of `Offset.zero`.
+/// The menu is drawn `s` times too large and displaced by the *whole
+/// distance from the screen origin to the field*, scaled - hundreds of
+/// pixels on a phone, i.e. entirely off-screen. The long press works; its
+/// menu is just somewhere nobody can see, which reads as "holding the text
+/// box does nothing".
+///
+/// Wrapping the menu in the inverse of the field's transform, taken about
+/// the field's own origin, cancels the follower exactly - at any scale or
+/// rotation, and as the identity when the field is unscaled (so an
+/// unzoomed page keeps the framework's own placement, untouched).
+///
+/// Residual: the follower is linked to the field's inner scroll viewport,
+/// not to the box measured here, so a field scrolled inside itself is off
+/// by its own scroll offset (times the zoom). Our in-page editors are
+/// sized to their content and don't scroll.
+Widget pdfPlacedTextSelectionMenu(
+    EditableTextState editableTextState, Widget menu) {
+  final box = editableTextState.context.findRenderObject() as RenderBox?;
+  if (box == null || !box.attached || !box.hasSize) return menu;
+  final toGlobal = box.getTransformTo(null);
+  final inverse = Matrix4.tryInvert(toGlobal);
+  if (inverse == null) return menu;
+  final origin = box.localToGlobal(Offset.zero);
+  final correction = Matrix4.translationValues(origin.dx, origin.dy, 0)
+    ..multiply(inverse);
+  if (_isIdentity(correction)) return menu;
+  return Transform(transform: correction, child: menu);
+}
+
+/// [Matrix4.isIdentity] is exact; the correction is a product of two
+/// float matrices, so an unscaled field lands a hair off it.
+bool _isIdentity(Matrix4 matrix) {
+  final identity = Matrix4.identity().storage;
+  final storage = matrix.storage;
+  for (var i = 0; i < 16; i++) {
+    if ((storage[i] - identity[i]).abs() > 1e-6) return false;
+  }
+  return true;
+}

--- a/packages/dart_pdf_editor/test/editing_form_interactive_test.dart
+++ b/packages/dart_pdf_editor/test/editing_form_interactive_test.dart
@@ -1,3 +1,8 @@
+import 'dart:ui' show PointerDeviceKind;
+
+import 'package:flutter/cupertino.dart'
+    show CupertinoTextSelectionToolbar, CupertinoTextSelectionToolbarButton;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -116,6 +121,75 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pump();
       expect(session.isEditingText, isFalse);
+      await settle(tester);
+    });
+
+    testWidgets('the long-press selection menu lands on a zoomed field',
+        (tester) async {
+      // Above 100% the field sits under the viewer's zoom transform, which
+      // Flutter's selection toolbar inherits through its
+      // CompositedTransformFollower - it used to throw the menu hundreds of
+      // pixels off the field (off-screen on a phone), so a long press in a
+      // zoomed field looked dead. See editing_text_menu.dart.
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.getData') {
+          return <String, dynamic>{'text': 'pasteable'};
+        }
+        if (call.method == 'Clipboard.hasStrings') {
+          return <String, dynamic>{'value': true};
+        }
+        return null;
+      });
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      // the reader's own inline editor (no editing controller), zoomed
+      // enough that the transform, not the layout, carries the zoom
+      await pumpViewer(tester, asReader: true, zoom: 1.5 * scale);
+      // the multi-line 'address' field, which stays mid-viewport at 1.5x
+      await tap(tester, const Offset(164, 147));
+      final editor = find.byKey(const ValueKey('pdf-form-text-editor'));
+      expect(editor, findsOneWidget);
+
+      // type first: an empty field parks its caret at the left edge, which
+      // this zoom has pushed off-screen, and a menu clamped by the screen
+      // edge can't say anything about where it was anchored
+      await tester.enterText(editor, 'address line one');
+      await tester.pump();
+      final field = tester.getRect(editor);
+      final press = Offset(250, field.top + 20);
+      final gesture =
+          await tester.startGesture(press, kind: PointerDeviceKind.touch);
+      await tester.pump(const Duration(milliseconds: 700));
+      await gesture.up();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      final buttons = find.descendant(
+          of: find.byType(CupertinoTextSelectionToolbar),
+          matching: find.byType(CupertinoTextSelectionToolbarButton));
+      expect(buttons, findsWidgets);
+      final menu = List.generate(buttons.evaluate().length, (i) => i)
+          .map((i) => tester.getRect(buttons.at(i)))
+          .reduce((a, b) => a.expandToInclude(b));
+      final anchor = tester
+          .state<EditableTextState>(find.byType(EditableText))
+          .contextMenuAnchors
+          .primaryAnchor;
+      // centred on the anchor the framework measured (within the menu's own
+      // padding), above it, and on screen
+      expect(menu.center.dx, closeTo(anchor.dx, 12), reason: 'menu $menu');
+      expect(menu.bottom, lessThan(anchor.dy));
+      final screen =
+          Offset.zero & tester.view.physicalSize / tester.view.devicePixelRatio;
+      expect(screen.contains(menu.topLeft), isTrue, reason: 'menu $menu');
+      expect(screen.contains(menu.bottomRight), isTrue, reason: 'menu $menu');
+
+      debugDefaultTargetPlatformOverride = null;
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
       await settle(tester);
     });
 

--- a/packages/dart_pdf_editor/test/editing_text_edit_test.dart
+++ b/packages/dart_pdf_editor/test/editing_text_edit_test.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:ui' show PointerDeviceKind;
 
+import 'package:flutter/cupertino.dart'
+    show CupertinoTextSelectionToolbar, CupertinoTextSelectionToolbarButton;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1408,6 +1411,103 @@ void main() {
       expect(scaled.getHandleSize(20).width, closeTo(18, 0.01));
       expect(field.contextMenuBuilder, isNotNull);
 
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      await settle(tester);
+    });
+
+    testWidgets('the long-press selection menu holds its place while zoomed',
+        (tester) async {
+      // The zoom transform used to drag the menu with it: Flutter places it
+      // through a CompositedTransformFollower linked to the field, which
+      // re-applies the field's scale to a menu already laid out in screen
+      // coordinates. At 2x that displaced it by the whole distance from the
+      // screen origin to the field - off-screen on a phone, so a long press
+      // in a zoomed text box looked like it did nothing.
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.getData') {
+          return <String, dynamic>{'text': 'pasteable'};
+        }
+        if (call.method == 'Clipboard.hasStrings') {
+          return <String, dynamic>{'value': true};
+        }
+        return null;
+      });
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+
+      final (editing, viewer) = await pumpEditor(tester);
+      // sits mid-viewport both unzoomed and at 2x, so neither menu is
+      // clamped by a screen edge
+      editing.addFreeText(0, const PdfRect(200, 550, 380, 600), 'Zoom menu');
+      await tester.pump();
+      editing.tool = PdfEditTool.select;
+      await tester.pump();
+      await tap(tester, view(290, 575)); // select
+      await tap(tester, view(290, 575)); // edit
+
+      /// The bounds of the menu's buttons - the visible menu. Its own
+      /// widget lays out over the whole screen, and which buttons the menu
+      /// offers depends on the selection, so measure the buttons and let
+      /// the caller compare centers.
+      Rect menuBounds() {
+        final buttons = find.descendant(
+            of: find.byType(CupertinoTextSelectionToolbar),
+            matching: find.byType(CupertinoTextSelectionToolbarButton));
+        expect(buttons, findsWidgets);
+        return List.generate(buttons.evaluate().length, (i) => i)
+            .map((i) => tester.getRect(buttons.at(i)))
+            .reduce((a, b) => a.expandToInclude(b));
+      }
+
+      /// Long-presses the middle of the editor and returns where the menu
+      /// landed relative to the anchor the framework measured for it, plus
+      /// the height of its buttons.
+      Future<(Offset, double)> pressAndMeasure() async {
+        final field = tester.getRect(find.byKey(editorKey));
+        final gesture = await tester.startGesture(field.center,
+            kind: PointerDeviceKind.touch);
+        await tester.pump(const Duration(milliseconds: 700));
+        await gesture.up();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        final menu = menuBounds();
+        // the anchor is in screen coordinates, and the menu is supposed to
+        // be laid out around it - whatever the field's own transform is
+        final anchor = tester
+            .state<EditableTextState>(find.byType(EditableText))
+            .contextMenuAnchors
+            .primaryAnchor;
+        return (
+          Offset(menu.center.dx - anchor.dx, menu.bottom - anchor.dy),
+          menu.height,
+        );
+      }
+
+      final (unzoomedOffset, unzoomedHeight) = await pressAndMeasure();
+      // on the anchor (within the menu's own padding) and above it
+      expect(unzoomedOffset.dx, closeTo(0, 12));
+      expect(unzoomedOffset.dy, lessThan(0));
+
+      await tap(tester, view(290, 575)); // dismiss the menu, keep editing
+      viewer.setZoom(2 * scale); // 2x transform scale over fit-width
+      await tester.pump();
+
+      final (zoomedOffset, zoomedHeight) = await pressAndMeasure();
+      expect(zoomedOffset.dx, closeTo(unzoomedOffset.dx, 1));
+      expect(zoomedOffset.dy, closeTo(unzoomedOffset.dy, 1));
+      // and at its natural size, not the zoom's
+      expect(zoomedHeight, closeTo(unzoomedHeight, 0.5));
+      // wholly on screen, which is the symptom that started this
+      final screen = Offset.zero &
+          tester.view.physicalSize / tester.view.devicePixelRatio;
+      final menu = menuBounds();
+      expect(screen.contains(menu.topLeft), isTrue, reason: 'menu $menu');
+      expect(screen.contains(menu.bottomRight), isTrue, reason: 'menu $menu');
+
+      debugDefaultTargetPlatformOverride = null;
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pump();
       await settle(tester);


### PR DESCRIPTION
## Summary

Reported on iOS: above 100% zoom, holding in a text box doesn't bring up the paste menu. The long press works fine — the menu comes up hundreds of pixels away from the field, off the side of the screen.

The viewer splits zoom in two (`_zoomTo`): at or below fit-width the pages lay out smaller and the `InteractiveViewer` matrix stays identity; above it the zoom lives in the transform. So >100% is exactly "the field is now inside a scaled `Transform`" — which is what breaks.

Flutter shows a field's selection toolbar through a `CompositedTransformFollower` linked to that field, with the field's global origin negated as the follower's offset, so a menu laid out in **screen** coordinates (around `contextMenuAnchors`) lands back where it was measured. Writing the follower's map for a leader at global origin `G` under scale `s`:

```
p ↦ G + s·(-G + p) = (1 - s)·G + s·p
```

Identity at `s = 1`, as intended. At `s = 2` the menu is drawn twice as large **and translated by `-G`** — displaced by the whole distance from the screen origin to the field. Measured in a widget test at 2×: 269px off in an 800px viewport. On a 390pt phone that is off-screen entirely, which is what "holding does nothing" looks like from the outside.

The fix (`editing_text_menu.dart`) wraps the menu in the inverse of the field's own transform, taken about the field's origin — `translate(origin) · inverse(fieldToGlobal)`. Composed with the follower that is exactly the identity, so the menu lands on the anchors the framework measured, at any scale and rotation. When the field is unscaled the correction *is* the identity and the framework's own placement is returned untouched, so nothing changes below 100%.

Both in-page inputs use it: the editing overlay's free-text/form editor (replacing a `Transform.scale` counter-scale that fixed the menu's size but left it displaced) and the reader's inline form-field editor in `editing_form_layer.dart`, which had no treatment at all and so was both oversized and displaced.

Known residual, documented in the source: the follower links to the field's inner scroll viewport while the correction is measured on the box the framework negates (the `EditableText`), so a field scrolled inside itself is off by its own scroll offset — times the zoom now, rather than once. The in-page editors are sized to their content and don't scroll internally.

Background: `doc/dev-log/2026-08-06-zoomed-text-selection-menu.md`.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [ ] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [x] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2116 pass, 35 skipped)
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to widget-level chrome in `dart_pdf_editor` — no COS, document, or rendering code is touched, so the pure-Dart suites and the render corpora can't observe it.

## PDF fixtures and screenshots

None — both regression tests build their document programmatically (`buildMultiPagePdf` / `buildAcroFormPdf`).

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

Two regression tests, both verified to fail on the parent commit (by 269px and 117px respectively):

- `editing_text_edit_test.dart` — *the long-press selection menu holds its place while zoomed*: long-presses the free-text editor unzoomed and at 2× and requires the menu's button bounds in the same place relative to `contextMenuAnchors.primaryAnchor`, at the same size, and on screen. Measuring against the anchor rather than the press point is what makes the two comparable — the caret line is twice as tall at 2×, so the press-relative offset legitimately differs.
- `editing_form_interactive_test.dart` — *the long-press selection menu lands on a zoomed field*: same property for the reader's form-field editor at 1.5×. It types into the field first: an empty field parks its caret at the left edge, which the zoom has pushed off-screen, and a menu clamped by the screen edge says nothing about where it was anchored.

Both run under `debugDefaultTargetPlatformOverride = TargetPlatform.iOS` with a mocked clipboard, since long-press-shows-the-menu on a collapsed selection is iOS behaviour.

The handles keep their existing `_ScaledTextSelectionControls` size counter-scale — handle followers take their offset in the leader's own space, so they track the field correctly and only ever needed the size treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdpNeHHHNiQyoX4VLoKM2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdpNeHHHNiQyoX4VLoKM2R)_