### PR TITLE
fix(viewer): keep visible neighbour pages out of the prefetch path (#657)

### DIFF
--- a/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
+++ b/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
@@ -76,15 +76,20 @@ numbering and render focus are untouched.
 
 Two things worth knowing:
 
-- **It rebuilds when the span changes.** Previously the page views only
-  learned their new `focusDistance` at the 200 ms transform settle or the
-  500 ms scroll settle, so a page crossing the edge kept its stale
-  prefetch treatment for the whole gesture and then re-rendered in a batch
-  at the settle - part of why the pop was so visible. The span changes at
-  most a couple of times per page crossing, so this is far cheaper than a
-  per-frame rebuild, and it lands the flag when it matters.
+- **The page views learn it when it changes, not at the next settle.**
+  Previously they only picked up their new `focusDistance` at the 200 ms
+  transform settle or the 500 ms scroll settle, so a page crossing the edge
+  kept its stale prefetch treatment for the whole gesture and then
+  re-rendered in a batch at the settle - part of why the pop was so
+  visible.
+
+  This first landed as a `setState` on the viewer, which measured badly
+  enough to be worth its own section - see "Measuring it, and the rebuild
+  that cost" below. The span ended up a `Listenable` each page subscribes
+  to instead.
 - **Scroll listeners can fire during layout**, so a mid-frame span change
-  defers its `setState` to a post-frame callback - the same hazard
+  defers to a post-frame callback before notifying (a listening page's
+  `setState` would be illegal there) - the same hazard
   `PdfViewerController._notifySafely` guards.
 
 ## Testing notes

--- a/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
+++ b/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
@@ -122,3 +122,42 @@ window at rest, which the full-width fixture cannot produce (at 800px wide
 each page is 1035px tall and page 1 is not built until it approaches). A
 300px-wide viewer makes each page 388px tall: pages 0 and 1 share the
 screen and page 2 sits below the fold, built and off-screen.
+
+## Measuring it, and the rebuild that cost
+
+`tool/perf.sh webdiff <base> scroll-scan` (12p A3 scanned grayscale - the
+scenario built to stress image decode and the image cache) on the first
+version of this fix, 3 interleaved runs:
+
+```
+buildMax      48.74 -> 73.94   +51.7%   ✗
+buildP95       3.73 ->  4.36   +16.8%   ✗
+buildP50       2.12 ->  2.18    +3.0%   ·
+```
+
+`openPageCountMs` also tripped the 1.1x threshold (468 -> 538, +15%), but
+per-iteration it is 459/538/468 against 473/538/664 - overlapping ranges,
+and nothing in this change runs before the page-tree walk. Noise.
+
+The build numbers were not noise. p50 flat with p95 and max moving is the
+signature of *occasional* expensive frames, and the cause was
+`_setOnScreenRange` calling the viewer's own `setState`. The span changes a
+couple of times per page crossing - far more often than the settle the page
+views used to rebuild on - and the viewer's `build` is enormous (the list,
+every mounted page's whole subtree, gesture recognizers, scrollbar,
+chrome). Rebuilding all of it to hand a bool to the two or three pages
+whose flag actually flipped is most of a frame on a dense sheet.
+
+So the span is a `Listenable` (`_PdfOnScreenSpan`), not viewer state: each
+`_PdfViewerPage` subscribes, recomputes its own answer, and setStates only
+when that answer flips. Same house pattern as `viewportChanges`, which
+exists for the same reason (the controller stays quiet during scrolling so
+the thumbnail strip's indicator does not spam every listener).
+
+One consequence worth stating, because a test asserted it before and no
+longer can: `focusDistance` still only reaches the page views on a viewer
+rebuild, so it stays *stale mid-scroll* - as it always has. That is fine,
+and is rather the point. Stale focus now costs nothing that matters:
+`onScreen` (delivered promptly) decides the image ratio and shields both
+visible pages from reclaim, and focus is left doing what it is actually
+good for - ordering evictions among the pages nobody is looking at.

--- a/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
+++ b/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
@@ -106,3 +106,19 @@ Budget ordering is unit-tested against fakes in
 `test/live_raster_budget_test.dart` (the fake defaults to "only the
 focused page is visible", the shape the pre-existing ordering tests
 assume; the new cases pass `onScreen` explicitly).
+
+## Follow-up: initialising the span
+
+A document that opens and is never scrolled or zoomed calls neither
+`_onScroll` nor `_onTransformChanged`, so the span stayed at `(-1, -1)` and
+`_onScreenPage` fell through to its pre-layout "everything is visible"
+answer - safe (it never blanks a page) but it skipped the prefetch
+reduction on the pages behind the fold for the whole session. The build's
+initial-fit block now takes the measurement in a post-frame callback, once
+the extents that layout creates exist.
+
+Testing that needs a viewport where a *third* page lands in the cache
+window at rest, which the full-width fixture cannot produce (at 800px wide
+each page is 1035px tall and page 1 is not built until it approaches). A
+300px-wide viewer makes each page 388px tall: pages 0 and 1 share the
+screen and page 2 sits below the fold, built and off-screen.

--- a/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
+++ b/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
@@ -1,0 +1,108 @@
+# Pages popping in and out at the screen edge (#657)
+
+Reported against a 63-page, 36 MB CAD/scan correlation pack on Windows:
+scrolling around, the pages above and below the one being read visibly
+**pop in and out** as they sit near the screen edge. The attached devtools
+export showed the decoded-image cache thrashing (11 entries / 130 MB held,
+210 misses against 146 evictions) and the render-record cache at 67 MB of
+100 MB with 201 evictions - a working set churning, not a working set
+fitting.
+
+## Root cause: focus is one page index, visibility is a range
+
+Three separate prefetch economies keyed off `PdfPageView.focusDistance`,
+which is `|index - controller.currentPage|`, and `currentPage` is
+`_updateCurrentPage`'s answer to "which page is the viewport **centre**
+on". On any document whose pages are taller than the viewport - every CAD
+sheet, every A3 scan - there is always a *second* page filling a large
+part of the screen at distance 1. All three treated it as an off-screen
+prefetch neighbour:
+
+1. `_imageRatioTarget()` decoded its embedded images at
+   `prefetchImagePixelRatioFactor` (0.5x, #451). On a scan the image *is*
+   the page, so half the screen rendered soft.
+2. `PdfLiveRasterBudget.rebalance()` evicted farthest-distance-first and
+   protected only distance 0, so the visible neighbour was the budget's
+   first casualty when the on-screen pair alone exceeded the desktop
+   384 MB ceiling - two large-format base rasters plus their retained
+   scenes get there easily. `evictLiveRaster()` drops the base raster, the
+   detail patch and the scene, leaving the soft preview: **the pop-out.**
+3. The pressure path `evictReclaimable()` shed *every* non-focused page,
+   visible ones included, on each platform low-memory signal (the export's
+   log has these firing every 30-75 s).
+
+And the flip is symmetric, so it oscillates: cross the midpoint and the
+page that just lost focus is demoted while the page that gained it drops
+its reduced-resolution buffer (`droppedForFocus` in `didUpdateWidget`) and
+re-interprets at full ratio. Because `PdfImageCache` keys by content *and
+decoded size* (`PdfSizedImageKey`), the 0.5x and 1.0x decodes of the same
+scan are two entries - so the flip is a guaranteed miss, a fresh decode of
+tens of MB, and an eviction of whatever the other page was holding. That
+is the 146-evictions-for-210-misses signature in the export.
+
+## The fix: `onScreen` as a first-class input
+
+`PdfPageView.onScreen` (defaulting to true, so a directly-embedded page
+view is unaffected) now says whether *any part* of the page overlaps the
+viewport, and it - not `focusDistance` - gates the prefetch economies:
+
+- `_imageRatioTarget()` returns the full ratio for any on-screen page.
+  `focusDistance` still governs the reduction for genuinely off-screen
+  cache-window neighbours, which is what #451 was actually about.
+- `PdfLiveRasterHolder` gained `liveRasterOnScreen`, and `rebalance()`
+  runs two passes over the same farthest-first order: every off-screen
+  page first, and only if the total is *still* over budget does it reach
+  the visible ones (zoomed far enough out, the visible set alone can
+  exceed the ceiling - the valve has to stay open, it just isn't the
+  first move any more).
+- `evictReclaimable()` skips on-screen pages entirely. An on-screen page
+  re-rasterizes the instant it is dropped, so evicting it under pressure
+  buys a flicker and a *higher* peak - the same feedback loop
+  `adaptive_memory.dart`'s `registryMaterialityPercent` comment documents
+  from the 2026-07-29 trace.
+- `didUpdateWidget`'s `droppedForFocus` also fires on
+  `!oldWidget.onScreen && widget.onScreen`, so a page that scrolls in
+  upgrades its reduced buffer on arrival instead of waiting to become the
+  centre page.
+
+## Where `onScreen` comes from
+
+`_updateCurrentPage` already unprojected the viewport centre through the
+zoom window and walked the page offsets; it now computes the viewport's
+main-axis *span* in the same pass and records the first/last overlapping
+index (`_setOnScreenRange`). One loop, same cost, and `currentPage` keeps
+its exact old rule (the spacing after a page counts as that page) so page
+numbering and render focus are untouched.
+
+Two things worth knowing:
+
+- **It rebuilds when the span changes.** Previously the page views only
+  learned their new `focusDistance` at the 200 ms transform settle or the
+  500 ms scroll settle, so a page crossing the edge kept its stale
+  prefetch treatment for the whole gesture and then re-rendered in a batch
+  at the settle - part of why the pop was so visible. The span changes at
+  most a couple of times per page crossing, so this is far cheaper than a
+  per-frame rebuild, and it lands the flag when it matters.
+- **Scroll listeners can fire during layout**, so a mid-frame span change
+  defers its `setState` to a post-frame callback - the same hazard
+  `PdfViewerController._notifySafely` guards.
+
+## Testing notes
+
+`test/page_on_screen_test.dart` covers the viewer half. Gotcha: the
+prefetch band is *offstage* - pages inside the list's 250 px cache extent
+but past the viewport edge are laid out and not painted, so
+`find.byType(PdfPageView)` misses them. Pass `skipOffstage: false` or the
+"off-screen but mounted" case looks like "not mounted at all". At the
+800x600 test surface with the 612x792pt fixture at fit-width each page is
+1035.3 px tall and the band is narrow: scroll offset 440 has page 1
+mounted and off-screen, 460 has it visible.
+
+One test pins `onScreen` to `PdfViewerController.visiblePageRegion`
+across a sweep of offsets, so the flag and the thumbnail strip's viewport
+indicator can never drift apart about what "visible" means.
+
+Budget ordering is unit-tested against fakes in
+`test/live_raster_budget_test.dart` (the fake defaults to "only the
+focused page is visible", the shape the pre-existing ordering tests
+assume; the new cases pass `onScreen` explicitly).

--- a/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
+++ b/doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md
@@ -161,3 +161,42 @@ and is rather the point. Stale focus now costs nothing that matters:
 `onScreen` (delivered promptly) decides the image ratio and shields both
 visible pages from reclaim, and focus is left doing what it is actually
 good for - ordering evictions among the pages nobody is looking at.
+
+### The result, at enough iterations to mean something
+
+Re-run after moving the span onto a `Listenable`, 7 interleaved runs
+(3 was not enough - `buildMax`'s run-to-run spread on the *baseline* alone
+was 40-83 ms, wider than the effect being measured):
+
+```
+buildP50       2.19 ->  2.23   +1.8%   ·
+buildP95       3.77 ->  3.85   +2.0%   ·      (was +16.8%)
+openPageCountMs 482 ->   497   +3.0%   ·      (was +15.1% - noise, as suspected)
+buildMax      54.18 -> 74.73  +37.9%   ✗
+```
+
+The rebuild fix recovered p95 and p50 entirely. **`buildMax` is a real
+regression and stays one.** At 7 samples it separates: current
+63.6/65.4/69.6/74.7/77.6/81.1/87.5 against base
+47.1/48.5/49.4/54.2/58.1/66.6/73.7 - the baseline's *worst* run is below
+the current median.
+
+It is also exactly one frame. The over-budget counts are unchanged run for
+run (1-2 frames >16 ms, exactly 1 >32 ms, 0-1 >50 ms, in both), so nothing
+new crosses a threshold; the single worst build frame got ~20 ms worse.
+
+That frame is the intended cost. It is where a newly-visible page's
+full-resolution scene lands, and on this scenario a page *is* one big A3
+scan - four times the pixels the 0.5x prefetch buffer used to replay. Note
+the work did not appear from nowhere: the old scheme rendered that page
+twice (soft on approach, full on becoming focused), so total work is
+*lower* now - the peak simply moved earlier, into the scroll rather than
+after the settle that followed the focus flip. The soft neighbour was
+cheap per-frame because it was wrong.
+
+Left as-is deliberately rather than tuned away: an intermediate ratio for
+visible-but-not-focused pages would reinstate a smaller version of the
+softening this fix exists to remove. If the spike ever needs flattening,
+the lever is the existing motion render hold (let a page that just crossed
+the edge paint its preview and take the full-resolution render at the
+settle), not the resolution it eventually renders at.

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Stop treating a page that shares the screen with the current one as an
+  off-screen prefetch neighbour: `PdfPageView.onScreen` now gates the
+  reduced-resolution image decode and the live-raster reclaim, so pages above
+  and below no longer soften and blank as they cross the viewport edge on
+  large-format scans (#657). `PdfLiveRasterHolder` implementations must add
+  `liveRasterOnScreen`.
+
 ## 3.4.0
 
 - Add `PdfAnnotationSnapshotClipboard`, shared by default across editing

--- a/packages/dart_pdf_editor/lib/src/live_raster_budget.dart
+++ b/packages/dart_pdf_editor/lib/src/live_raster_budget.dart
@@ -14,6 +14,18 @@ abstract class PdfLiveRasterHolder {
   /// (distance 0) is never evicted.
   int get liveRasterDistance;
 
+  /// Whether any part of this page currently overlaps the viewport.
+  ///
+  /// Distinct from `liveRasterDistance == 0`, and the distinction is the whole
+  /// point: focus is a single page index (the one under the viewport centre),
+  /// so on any document whose pages are taller than the viewport there is a
+  /// second page - often half the screen - sitting at distance 1. Evicting
+  /// *that* is not reclaiming an off-screen prefetch, it is blanking a page the
+  /// user is looking at, which re-renders immediately and flickers on the way
+  /// back (#657). On-screen pages are the working set; they are reclaimed only
+  /// when dropping every off-screen page still leaves the total over budget.
+  bool get liveRasterOnScreen;
+
   /// Drops this page's base + detail rasters (and retained scene) to free
   /// memory. The page keeps its low-res preview up and re-rasterises when it is
   /// next scrolled back into (or near) the viewport. Called only on a holder
@@ -71,6 +83,13 @@ class PdfLiveRasterBudget {
   /// patch lands). Never evicts the focused page (distance 0); stops as soon as
   /// the total fits, so the near-viewport working set is preserved.
   ///
+  /// Off-screen pages go first, in full, before any on-screen page is
+  /// considered ([PdfLiveRasterHolder.liveRasterOnScreen]) - a large-format
+  /// document where two visible pages alone exceed the budget must reclaim the
+  /// prefetch window rather than blank a page under the user's eyes. Only if
+  /// the total is still over after every off-screen page is gone does the
+  /// second pass reach the visible ones, farthest first.
+  ///
   /// Returns the bytes freed (0 when already within budget).
   int rebalance() {
     if (maxBytes <= 0) return 0;
@@ -89,27 +108,40 @@ class PdfLiveRasterBudget {
       });
 
     var freed = 0;
-    for (final holder in ordered) {
-      if (total <= maxBytes) break;
-      if (holder.liveRasterDistance <= 0) continue; // never the focused page
-      final bytes = holder.liveRasterBytes;
-      if (bytes <= 0) continue;
-      holder.evictLiveRaster();
-      total -= bytes;
-      freed += bytes;
+    // Pass 1 off-screen only, pass 2 the visible remainder (still never the
+    // focused page). Two passes over the same order, not two sorts.
+    for (final onScreenPass in const [false, true]) {
+      for (final holder in ordered) {
+        if (total <= maxBytes) return freed;
+        if (holder.liveRasterDistance <= 0) continue; // never the focused page
+        if (holder.liveRasterOnScreen != onScreenPass) continue;
+        final bytes = holder.liveRasterBytes;
+        if (bytes <= 0) continue;
+        holder.evictLiveRaster();
+        total -= bytes;
+        freed += bytes;
+      }
     }
     return freed;
   }
 
-  /// Surrenders every reclaimable (non-focused) page's raster regardless of the
+  /// Surrenders every reclaimable off-screen page's raster regardless of the
   /// budget - the memory-pressure path. Live-page rasters used to be exempt
   /// from the pressure signal that trims the byte-budgeted caches (#405); this
   /// hands the whole off-viewport working set back on a `didHaveMemoryPressure`.
+  ///
+  /// On-screen pages are left alone: they re-rasterize the moment they are
+  /// dropped, so evicting them costs a visible flicker and *raises* peak RSS
+  /// (the re-render allocates before the old raster's memory is reused) - the
+  /// same feedback loop the adaptive-memory damper documents. Pressure has to
+  /// come from what the user is not looking at.
+  ///
   /// Returns the bytes freed.
   int evictReclaimable() {
     var freed = 0;
     for (final holder in _holders.toList()) {
       if (holder.liveRasterDistance <= 0) continue;
+      if (holder.liveRasterOnScreen) continue;
       final bytes = holder.liveRasterBytes;
       if (bytes <= 0) continue;
       holder.evictLiveRaster();

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -54,6 +54,7 @@ class PdfPageView extends StatefulWidget {
     this.renderScheduler,
     this.renderPriority = 0,
     this.focusDistance = 0,
+    this.onScreen = true,
     this.previewCache,
     this.previewIndex = 0,
     this.pageEpoch = 0,
@@ -188,7 +189,24 @@ class PdfPageView extends StatefulWidget {
   /// keep record traffic down (a Flate raster underlay ships as full RGBA - a
   /// single page can reach tens of MB, starving the visible page, #451). The
   /// page re-renders at full image resolution the moment it becomes focused.
+  ///
+  /// Focus is a *ranking*, not a visibility test - see [onScreen], which is
+  /// what decides whether this page is treated as a prefetch neighbour at all.
   final int focusDistance;
+
+  /// Whether any part of this page currently overlaps the viewport.
+  ///
+  /// A page can be half the screen and still sit at [focusDistance] 1, because
+  /// focus is the single page under the viewport *centre*. Prefetch economies -
+  /// reduced-resolution image decodes, live-raster reclaim - apply to pages the
+  /// user cannot see; applying them to a visible page is what made the pages
+  /// above and below the centre soften and blank as they crossed the screen
+  /// edge on large-format scans (#657).
+  ///
+  /// Defaults to true: a page mounted on its own is on screen, and a host
+  /// embedding [PdfPageView] directly gets full-resolution behaviour without
+  /// having to say so.
+  final bool onScreen;
 
   /// Called whenever a full-page raster for the current [page] object
   /// lands on screen. Lets the editing overlay hold its just-committed
@@ -790,12 +808,14 @@ class _PdfPageViewState extends State<PdfPageView>
       }
     }
     // A prefetch neighbour decoded its images at reduced resolution
-    // ([prefetchImagePixelRatioFactor]); now that it is closer to focus and
-    // wants full-resolution images, drop the reduced buffer (and its raster) so
-    // the render below rebuilds it sharp. Guarded on an actual ratio increase,
-    // so it fires once as the page approaches focus, not as a churn loop.
+    // ([prefetchImagePixelRatioFactor]); now that it is closer to focus - or
+    // has scrolled into view at all - and wants full-resolution images, drop
+    // the reduced buffer (and its raster) so the render below rebuilds it
+    // sharp. Guarded on an actual ratio increase, so it fires once as the page
+    // approaches focus, not as a churn loop.
     var droppedForFocus = false;
-    if (widget.focusDistance < oldWidget.focusDistance &&
+    if ((widget.focusDistance < oldWidget.focusDistance ||
+            (widget.onScreen && !oldWidget.onScreen)) &&
         !_renderedAtFullImageRatio()) {
       // _dropPicture nulls _rasteredRatio, so the render below re-rasters
       // rather than skipping. The reduced-resolution base raster is left up
@@ -1018,6 +1038,9 @@ class _PdfPageViewState extends State<PdfPageView>
   int get liveRasterDistance => widget.focusDistance;
 
   @override
+  bool get liveRasterOnScreen => widget.onScreen;
+
+  @override
   void evictLiveRaster() {
     if (!mounted) return;
     // Reclaim this off-viewport page's heavy rasters: the base raster, the
@@ -1034,7 +1057,8 @@ class _PdfPageViewState extends State<PdfPageView>
     });
     PdfPerfLog.log(
       'live-raster evict page=${widget.previewIndex} '
-      'dist=${widget.focusDistance}',
+      'dist=${widget.focusDistance} '
+      'onScreen=${widget.onScreen}',
     );
   }
 
@@ -1054,12 +1078,13 @@ class _PdfPageViewState extends State<PdfPageView>
 
   /// The image-decode resolution this page's record should use: the display
   /// ratio (capped by [PdfPageView.workerImagePixelRatioCap]), reduced by
-  /// [PdfPageView.prefetchImagePixelRatioFactor] when the page is an off-focus
-  /// prefetch neighbour (#451). A focused page always gets the full ratio, so a
-  /// page re-rendered on becoming focused decodes its images at full resolution.
+  /// [PdfPageView.prefetchImagePixelRatioFactor] when the page is an off-screen
+  /// prefetch neighbour (#451). A page any part of which is on screen always
+  /// gets the full ratio, so a page scrolling in decodes sharp once instead of
+  /// landing soft and re-rendering when it reaches the centre (#657).
   double _imageRatioTarget() {
     final base = _fullImageRatio();
-    if (widget.focusDistance <= 0) return base;
+    if (widget.onScreen || widget.focusDistance <= 0) return base;
     return base * PdfPageView.prefetchImagePixelRatioFactor;
   }
 

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -6220,6 +6220,17 @@ class _PdfViewerState extends State<PdfViewer>
                   ? (_mainView / firstMainAtFit).clamp(widget.minZoom, 1.0)
                   : 1.0;
         }
+        if (_firstOnScreenPage < 0) {
+          // A document that opens and is never scrolled or zoomed calls
+          // neither _onScroll nor _onTransformChanged, so the visible span
+          // would stay uninitialised and every mounted page would read as on
+          // screen - safe (it never blanks a page) but it skips the prefetch
+          // reduction on the pages behind the fold. Measure it once the
+          // extents this layout creates exist.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted && _firstOnScreenPage < 0) _updateCurrentPage();
+          });
+        }
       }
       // no implicit desktop scrollbar: it would attach here, inside the
       // zoom transform - thin, low-contrast, and scaled or translated out

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -786,6 +786,37 @@ class _ViewportNotifier extends ChangeNotifier {
   void notify() => notifyListeners();
 }
 
+/// The contiguous span of pages overlapping the viewport, as a [Listenable]
+/// the page views subscribe to individually.
+///
+/// Deliberately *not* viewer state behind a `setState`. The span changes a
+/// couple of times per page crossing - far more often than the scroll settle
+/// the page views used to rebuild on - and rebuilding the whole viewer to hand
+/// a bool to the two or three pages whose flag actually flipped costs a
+/// visible slice of the frame budget on a dense sheet (it moved `scroll-scan`'s
+/// buildP95 and buildMax when #657's fix first landed that way). Each
+/// [_PdfViewerPage] listens and rebuilds only itself, and only when its own
+/// answer changes.
+class _PdfOnScreenSpan extends ChangeNotifier {
+  /// -1 until the first layout has measured the viewport.
+  int first = -1;
+  int last = -1;
+
+  void set(int newFirst, int newLast) {
+    if (newFirst == first && newLast == last) return;
+    first = newFirst;
+    last = newLast;
+    notifyListeners();
+  }
+
+  /// Whether page [index] overlaps the viewport. Before the first measurement
+  /// every mounted page counts as on screen: the reduced-resolution prefetch
+  /// path must never be the *first* thing a page renders at, or the initial
+  /// paint lands soft.
+  bool contains(int index) =>
+      first < 0 || (index >= first && index <= last);
+}
+
 /// A [Listenable] that relays whichever [source] is currently attached.
 ///
 /// The controller outlives the viewer state it drives (and can be handed a new
@@ -3114,6 +3145,7 @@ class _PdfViewerState extends State<PdfViewer>
     _touchFlinger.dispose();
     _hBounceController.dispose();
     _focusNode.dispose();
+    _onScreenSpan.dispose();
     super.dispose();
   }
 
@@ -3359,38 +3391,23 @@ class _PdfViewerState extends State<PdfViewer>
     _setOnScreenRange(first < 0 ? current : first, last < 0 ? current : last);
   }
 
-  /// Indices of the first and last page overlapping the viewport, or (-1, -1)
-  /// before layout. Pages outside this range are prefetch neighbours: they
-  /// decode their images at reduced resolution and are the live-raster
-  /// budget's first reclaim. Tracked separately from
-  /// [PdfViewerController.currentPage] because a page can be half the screen
-  /// and still not be the one under the viewport centre - treating it as
-  /// off-screen is what blanked and softened neighbours mid-scroll (#657).
-  int _firstOnScreenPage = -1;
-  int _lastOnScreenPage = -1;
+  /// The span of pages overlapping the viewport - see [_PdfOnScreenSpan].
+  final _onScreenSpan = _PdfOnScreenSpan();
 
-  bool _onScreenPage(int index) =>
-      // Pre-layout every mounted page counts as on screen: the reduced-
-      // resolution prefetch path must never be the *first* thing a page
-      // renders at, or the initial paint lands soft.
-      _firstOnScreenPage < 0 ||
-      (index >= _firstOnScreenPage && index <= _lastOnScreenPage);
-
-  /// Rebuilds when the visible span changes so the flag reaches the page views
-  /// as they cross the edge, not at the next settle. Scroll listeners can fire
-  /// during layout, so a mid-frame change defers to after the frame (the same
-  /// hazard `PdfViewerController._notifySafely` guards).
+  /// Records the visible span, notifying the page views whose flag flipped.
+  ///
+  /// Scroll listeners can fire during layout, and a listening page's setState
+  /// would be illegal there, so a mid-frame change defers to after the frame
+  /// (the same hazard `PdfViewerController._notifySafely` guards).
   void _setOnScreenRange(int first, int last) {
-    if (first == _firstOnScreenPage && last == _lastOnScreenPage) return;
-    _firstOnScreenPage = first;
-    _lastOnScreenPage = last;
+    if (first == _onScreenSpan.first && last == _onScreenSpan.last) return;
     if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
       SchedulerBinding.instance.addPostFrameCallback((_) {
-        if (mounted) setState(() {});
+        if (mounted) _onScreenSpan.set(first, last);
       });
     } else {
-      setState(() {});
+      _onScreenSpan.set(first, last);
     }
   }
 
@@ -6220,7 +6237,7 @@ class _PdfViewerState extends State<PdfViewer>
                   ? (_mainView / firstMainAtFit).clamp(widget.minZoom, 1.0)
                   : 1.0;
         }
-        if (_firstOnScreenPage < 0) {
+        if (_onScreenSpan.first < 0) {
           // A document that opens and is never scrolled or zoomed calls
           // neither _onScroll nor _onTransformChanged, so the visible span
           // would stay uninitialised and every mounted page would read as on
@@ -6228,7 +6245,7 @@ class _PdfViewerState extends State<PdfViewer>
           // reduction on the pages behind the fold. Measure it once the
           // extents this layout creates exist.
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (mounted && _firstOnScreenPage < 0) _updateCurrentPage();
+            if (mounted && _onScreenSpan.first < 0) _updateCurrentPage();
           });
         }
       }
@@ -6299,7 +6316,7 @@ class _PdfViewerState extends State<PdfViewer>
                 renderPriority: _renderPriority(index),
                 focusDistance:
                     (index - (_jumpFocusPage ?? _controller.currentPage)).abs(),
-                onScreen: _onScreenPage(index),
+                onScreenSpan: _onScreenSpan,
                 matches: _controller._matchesOn(index),
                 currentMatch: _controller._currentMatch >= 0
                     ? _controller._matches[_controller._currentMatch]
@@ -7094,7 +7111,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.destructiveStamp,
     required this.renderPriority,
     required this.focusDistance,
-    required this.onScreen,
+    required this.onScreenSpan,
     required this.matches,
     required this.currentMatch,
     required this.selection,
@@ -7163,9 +7180,9 @@ class _PdfViewerPage extends StatefulWidget {
   final int renderPriority;
   final int focusDistance;
 
-  /// Whether any part of this page overlaps the viewport - see
-  /// [PdfPageView.onScreen].
-  final bool onScreen;
+  /// The viewer's visible-page span. This page subscribes to it and rebuilds
+  /// only itself when its own answer flips - see [_PdfOnScreenSpan].
+  final _PdfOnScreenSpan onScreenSpan;
   final List<PdfTextMatch> matches;
   final PdfTextMatch? currentMatch;
   final List<PdfTextQuad> selection;
@@ -7241,9 +7258,40 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
   bool _rastered = false;
   bool _annotationLayerCurrent = true;
 
+  /// Whether this page overlaps the viewport (#657). Read from
+  /// [_PdfViewerPage.onScreenSpan] rather than passed down, so a span change
+  /// rebuilds only the pages whose answer actually flipped.
+  late bool _onScreen = widget.onScreenSpan.contains(widget.index);
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onScreenSpan.addListener(_onSpanChanged);
+  }
+
+  void _onSpanChanged() {
+    final next = widget.onScreenSpan.contains(widget.index);
+    if (next == _onScreen || !mounted) return;
+    setState(() => _onScreen = next);
+  }
+
+  @override
+  void dispose() {
+    widget.onScreenSpan.removeListener(_onSpanChanged);
+    super.dispose();
+  }
+
   @override
   void didUpdateWidget(_PdfViewerPage oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.onScreenSpan, widget.onScreenSpan) ||
+        oldWidget.index != widget.index) {
+      // The lazy list reused this State for another page, or the viewer handed
+      // over a new span: re-answer for whoever this slot is now.
+      oldWidget.onScreenSpan.removeListener(_onSpanChanged);
+      widget.onScreenSpan.addListener(_onSpanChanged);
+      _onScreen = widget.onScreenSpan.contains(widget.index);
+    }
     final pageImageChanged = oldWidget.pageEpoch != widget.pageEpoch ||
         oldWidget.destructiveStamp != widget.destructiveStamp ||
         oldWidget.contentStamp != widget.contentStamp ||
@@ -7306,7 +7354,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         destructiveStamp: widget.destructiveStamp,
         renderPriority: widget.renderPriority,
         focusDistance: widget.focusDistance,
-        onScreen: widget.onScreen,
+        onScreen: _onScreen,
         pageColor: widget.pageColor,
         showAnnotations: widget.pageImagesShowAnnotations,
         trustContentStamp: widget.trustContentStamp,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -3320,22 +3320,78 @@ class _PdfViewerState extends State<PdfViewer>
       return;
     }
     final matrix = _transform.value;
-    final scale = matrix.getMaxScaleOnAxis();
-    // Unproject the screen centre (along the scroll axis) through the zoom
-    // window. The old scroll+viewport/2 calculation was only valid while the
+    final rawScale = matrix.getMaxScaleOnAxis();
+    final scale = rawScale.isFinite && rawScale > 0 ? rawScale : 1.0;
+    // Unproject the viewport (along the scroll axis) through the zoom window.
+    // The old scroll+viewport/2 calculation was only valid while the
     // transform's main-axis translation sat at its focal-centred default.
-    final center = _scroll.offset +
-        (_mainView / 2 - matrix.storage[_mainTranslate]) /
-            (scale.isFinite && scale > 0 ? scale : 1.0);
+    final viewStart =
+        _scroll.offset - matrix.storage[_mainTranslate] / scale;
+    final viewEnd = viewStart + _mainView / scale;
+    final center = viewStart + _mainView / (2 * scale);
+    var current = _pages.length - 1;
+    var found = false;
+    var first = -1;
+    var last = -1;
     var offset = 0.0;
     for (var i = 0; i < _pages.length; i++) {
-      offset += _pageMain(i) + widget.pageSpacing;
-      if (center < offset) {
-        _controller._setCurrentPage(i);
-        return;
+      final main = _pageMain(i);
+      // The page's own extent decides visibility; the spacing that follows it
+      // belongs to no page. `current` keeps the original rule (the spacing
+      // after a page counts as that page) so the reported page number and
+      // render focus are unchanged by this pass.
+      if (offset < viewEnd && offset + main > viewStart) {
+        if (first < 0) first = i;
+        last = i;
       }
+      offset += main + widget.pageSpacing;
+      if (!found && center < offset) {
+        current = i;
+        found = true;
+      }
+      // Pages are laid out in order, so once one starts past the viewport
+      // nothing after it can be visible either.
+      if (found && offset - widget.pageSpacing >= viewEnd) break;
     }
-    _controller._setCurrentPage(_pages.length - 1);
+    _controller._setCurrentPage(current);
+    // A viewport that fell entirely inside the gap between two pages overlaps
+    // none of them; the page the centre is on is still what the user is at.
+    _setOnScreenRange(first < 0 ? current : first, last < 0 ? current : last);
+  }
+
+  /// Indices of the first and last page overlapping the viewport, or (-1, -1)
+  /// before layout. Pages outside this range are prefetch neighbours: they
+  /// decode their images at reduced resolution and are the live-raster
+  /// budget's first reclaim. Tracked separately from
+  /// [PdfViewerController.currentPage] because a page can be half the screen
+  /// and still not be the one under the viewport centre - treating it as
+  /// off-screen is what blanked and softened neighbours mid-scroll (#657).
+  int _firstOnScreenPage = -1;
+  int _lastOnScreenPage = -1;
+
+  bool _onScreenPage(int index) =>
+      // Pre-layout every mounted page counts as on screen: the reduced-
+      // resolution prefetch path must never be the *first* thing a page
+      // renders at, or the initial paint lands soft.
+      _firstOnScreenPage < 0 ||
+      (index >= _firstOnScreenPage && index <= _lastOnScreenPage);
+
+  /// Rebuilds when the visible span changes so the flag reaches the page views
+  /// as they cross the edge, not at the next settle. Scroll listeners can fire
+  /// during layout, so a mid-frame change defers to after the frame (the same
+  /// hazard `PdfViewerController._notifySafely` guards).
+  void _setOnScreenRange(int first, int last) {
+    if (first == _firstOnScreenPage && last == _lastOnScreenPage) return;
+    _firstOnScreenPage = first;
+    _lastOnScreenPage = last;
+    if (SchedulerBinding.instance.schedulerPhase ==
+        SchedulerPhase.persistentCallbacks) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) setState(() {});
+      });
+    } else {
+      setState(() {});
+    }
   }
 
   void _onScroll() {
@@ -6232,6 +6288,7 @@ class _PdfViewerState extends State<PdfViewer>
                 renderPriority: _renderPriority(index),
                 focusDistance:
                     (index - (_jumpFocusPage ?? _controller.currentPage)).abs(),
+                onScreen: _onScreenPage(index),
                 matches: _controller._matchesOn(index),
                 currentMatch: _controller._currentMatch >= 0
                     ? _controller._matches[_controller._currentMatch]
@@ -7026,6 +7083,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.destructiveStamp,
     required this.renderPriority,
     required this.focusDistance,
+    required this.onScreen,
     required this.matches,
     required this.currentMatch,
     required this.selection,
@@ -7093,6 +7151,10 @@ class _PdfViewerPage extends StatefulWidget {
   final int destructiveStamp;
   final int renderPriority;
   final int focusDistance;
+
+  /// Whether any part of this page overlaps the viewport - see
+  /// [PdfPageView.onScreen].
+  final bool onScreen;
   final List<PdfTextMatch> matches;
   final PdfTextMatch? currentMatch;
   final List<PdfTextQuad> selection;
@@ -7233,6 +7295,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         destructiveStamp: widget.destructiveStamp,
         renderPriority: widget.renderPriority,
         focusDistance: widget.focusDistance,
+        onScreen: widget.onScreen,
         pageColor: widget.pageColor,
         showAnnotations: widget.pageImagesShowAnnotations,
         trustContentStamp: widget.trustContentStamp,

--- a/packages/dart_pdf_editor/test/live_raster_budget_test.dart
+++ b/packages/dart_pdf_editor/test/live_raster_budget_test.dart
@@ -2,13 +2,21 @@ import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// A fake live page: fixed bytes + distance, records whether it was evicted.
+///
+/// [onScreen] defaults to "only the focused page is visible" - the shape of a
+/// document whose pages each fill the viewport, which is what the ordering
+/// tests below are about. Cases where a neighbour is *also* on screen pass it
+/// explicitly.
 class _FakeHolder implements PdfLiveRasterHolder {
-  _FakeHolder(this.label, {required int bytes, required this.distance})
-      : _bytes = bytes;
+  _FakeHolder(this.label,
+      {required int bytes, required this.distance, bool? onScreen})
+      : _bytes = bytes,
+        onScreen = onScreen ?? distance == 0;
 
   final String label;
   int _bytes;
   final int distance;
+  final bool onScreen;
   bool evicted = false;
 
   @override
@@ -16,6 +24,9 @@ class _FakeHolder implements PdfLiveRasterHolder {
 
   @override
   int get liveRasterDistance => distance;
+
+  @override
+  bool get liveRasterOnScreen => onScreen;
 
   @override
   void evictLiveRaster() {
@@ -124,6 +135,74 @@ void main() {
       expect(far.evicted, isFalse);
     });
 
+    test('a farther off-screen page goes before a nearer visible one', () {
+      // The #657 shape: two large-format pages share the screen (the centre is
+      // on `focus`, so its neighbour sits at distance 1 while still filling
+      // half the viewport) with a prefetched page behind them. Reclaiming the
+      // visible neighbour blanks a page the user is reading; the prefetch is
+      // there to be given back.
+      budget.maxBytes = 100;
+      final focus = _FakeHolder('focus', bytes: 50, distance: 0);
+      final visibleNeighbour =
+          _FakeHolder('visible', bytes: 50, distance: 1, onScreen: true);
+      final prefetch =
+          _FakeHolder('prefetch', bytes: 50, distance: 2, onScreen: false);
+      add(focus);
+      add(visibleNeighbour);
+      add(prefetch); // total 150 > 100
+      expect(budget.rebalance(), 50);
+      expect(prefetch.evicted, isTrue);
+      expect(visibleNeighbour.evicted, isFalse);
+      expect(focus.evicted, isFalse);
+    });
+
+    test('every off-screen page goes before any visible one', () {
+      // Ordering across the two passes, not just the single nearest/farthest
+      // pair: the visible neighbour is farther from focus than both prefetches
+      // and must still outlive them.
+      budget.maxBytes = 100;
+      final focus = _FakeHolder('focus', bytes: 40, distance: 0);
+      final visible =
+          _FakeHolder('visible', bytes: 60, distance: 3, onScreen: true);
+      final p1 = _FakeHolder('p1', bytes: 40, distance: 1, onScreen: false);
+      final p2 = _FakeHolder('p2', bytes: 40, distance: 2, onScreen: false);
+      add(focus);
+      add(visible);
+      add(p1);
+      add(p2); // total 180 > 100
+      budget.rebalance();
+      // 180 -> drop p2 (140) -> drop p1 (100) -> fits, visible untouched.
+      expect(p2.evicted, isTrue);
+      expect(p1.evicted, isTrue);
+      expect(visible.evicted, isFalse);
+      expect(budget.totalBytes, 100);
+    });
+
+    test('reaches visible pages only once the off-screen ones are gone', () {
+      // The safety valve: zoomed out far enough that the visible pages alone
+      // blow the budget, the reclaim must still make progress rather than
+      // grow without bound.
+      budget.maxBytes = 100;
+      final focus = _FakeHolder('focus', bytes: 60, distance: 0);
+      final near =
+          _FakeHolder('near', bytes: 60, distance: 1, onScreen: true);
+      final far = _FakeHolder('far', bytes: 60, distance: 2, onScreen: true);
+      final prefetch =
+          _FakeHolder('prefetch', bytes: 60, distance: 5, onScreen: false);
+      add(focus);
+      add(near);
+      add(far);
+      add(prefetch); // total 240 > 100
+      budget.rebalance();
+      // 240 -> prefetch (180) -> then visible, farthest first: far (120),
+      // near (60) -> fits. The focused page is never touched.
+      expect(prefetch.evicted, isTrue);
+      expect(far.evicted, isTrue);
+      expect(near.evicted, isTrue);
+      expect(focus.evicted, isFalse);
+      expect(budget.totalBytes, 60);
+    });
+
     test('evictReclaimable sheds every non-focused page (pressure path)', () {
       budget.maxBytes = 1 << 30; // well within budget - pressure ignores it
       final focus = _FakeHolder('focus', bytes: 100, distance: 0);
@@ -137,6 +216,25 @@ void main() {
       expect(focus.evicted, isFalse);
       expect(n1.evicted, isTrue);
       expect(n2.evicted, isTrue);
+    });
+
+    test('evictReclaimable spares pages that are still on screen', () {
+      // Pressure has to come from what the user is not looking at: an
+      // on-screen page re-rasterizes the instant it is dropped, so evicting it
+      // buys a flicker and a higher peak, not headroom.
+      budget.maxBytes = 1 << 30;
+      final focus = _FakeHolder('focus', bytes: 100, distance: 0);
+      final visible =
+          _FakeHolder('visible', bytes: 100, distance: 1, onScreen: true);
+      final prefetch =
+          _FakeHolder('prefetch', bytes: 100, distance: 2, onScreen: false);
+      add(focus);
+      add(visible);
+      add(prefetch);
+      expect(budget.evictReclaimable(), 100);
+      expect(focus.evicted, isFalse);
+      expect(visible.evicted, isFalse);
+      expect(prefetch.evicted, isTrue);
     });
 
     test('unregister removes a holder from accounting', () {

--- a/packages/dart_pdf_editor/test/page_on_screen_test.dart
+++ b/packages/dart_pdf_editor/test/page_on_screen_test.dart
@@ -61,14 +61,18 @@ void main() {
     // centre (1100) is on page 1, so page 0 sits at focus distance 1 - the
     // exact shape that used to soften and blank it.
     await scrollTo(tester, 800);
-    expect(controller.currentPage, 1);
+    expect(controller.currentPage, 1,
+        reason: 'the viewport centre has moved onto page 1');
 
     final pages = mountedPages(tester);
     expect(pages[0], isNotNull);
-    expect(pages[0]!.focusDistance, 1, reason: 'the centre is on page 1');
     expect(pages[0]!.onScreen, isTrue,
         reason: 'page 0 still fills the top of the viewport');
     expect(pages[1]!.onScreen, isTrue);
+    // Deliberately not asserting page 0's focusDistance here. Focus reaches
+    // the page views on the viewer's own rebuild (the scroll/transform
+    // settle), so mid-scroll it is stale by design - which is exactly why the
+    // prefetch economies must not be the thing keyed on it.
   });
 
   testWidgets('a prefetched page just past the edge is not on screen',

--- a/packages/dart_pdf_editor/test/page_on_screen_test.dart
+++ b/packages/dart_pdf_editor/test/page_on_screen_test.dart
@@ -1,0 +1,129 @@
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+/// [PdfPageView.onScreen] - the visibility flag the prefetch economies key on
+/// (#657).
+///
+/// Focus ([PdfPageView.focusDistance]) is the single page under the viewport
+/// *centre*, so on any document whose pages are taller than the viewport there
+/// is a second page filling half the screen at distance 1. Treating that page
+/// as an off-screen prefetch neighbour is what softened it (reduced-resolution
+/// image decodes) and blanked it (live-raster reclaim) as it crossed the screen
+/// edge on large-format scans.
+void main() {
+  // 800x600 test surface, 612x792pt pages at fit-width: each page is
+  // 792 * 800/612 = 1035.3px tall, and pages start 12px (pageSpacing) apart.
+  const pageExtent = 792 * 800 / 612;
+  const pageSpacing = 12.0;
+
+  Future<PdfViewerController> pumpViewer(WidgetTester tester,
+      {int pages = 5}) async {
+    final controller = PdfViewerController();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          initialFit: PdfViewerFit.width,
+          document: PdfDocument.open(buildMultiPagePdf(pages)),
+          controller: controller,
+        ),
+      ),
+    ));
+    await tester.pump();
+    return controller;
+  }
+
+  ScrollPosition scrollPosition(WidgetTester tester) =>
+      tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+
+  /// The mounted page views by page index. The lazy list only builds pages
+  /// inside its cache window, so far pages are simply absent - and the ones
+  /// inside it but past the viewport edge are offstage, which is exactly the
+  /// prefetch band under test.
+  Map<int, PdfPageView> mountedPages(WidgetTester tester) => {
+        for (final view in tester.widgetList<PdfPageView>(
+            find.byType(PdfPageView, skipOffstage: false)))
+          view.previewIndex: view,
+      };
+
+  Future<void> scrollTo(WidgetTester tester, double offset) async {
+    scrollPosition(tester).jumpTo(offset);
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets('a page sharing the screen with the current one stays on screen',
+      (tester) async {
+    final controller = await pumpViewer(tester);
+    // Straddle the boundary: the viewport spans [800, 1400], page 0 occupies
+    // [0, 1035.3] and page 1 [1047.3, 2082.6]. Both are on screen, but the
+    // centre (1100) is on page 1, so page 0 sits at focus distance 1 - the
+    // exact shape that used to soften and blank it.
+    await scrollTo(tester, 800);
+    expect(controller.currentPage, 1);
+
+    final pages = mountedPages(tester);
+    expect(pages[0], isNotNull);
+    expect(pages[0]!.focusDistance, 1, reason: 'the centre is on page 1');
+    expect(pages[0]!.onScreen, isTrue,
+        reason: 'page 0 still fills the top of the viewport');
+    expect(pages[1]!.onScreen, isTrue);
+  });
+
+  testWidgets('a prefetched page just past the edge is not on screen',
+      (tester) async {
+    await pumpViewer(tester);
+    // Viewport [440, 1040]. Page 1 starts at 1047.3 - just outside the
+    // viewport but inside the list's cache window, so it is built offstage as
+    // a prefetch neighbour.
+    await scrollTo(tester, 440);
+
+    final pages = mountedPages(tester);
+    expect(pages[0]!.onScreen, isTrue);
+    expect(pages[1], isNotNull,
+        reason: 'the page below is prefetched into the cache window');
+    expect(pages[1]!.onScreen, isFalse);
+  });
+
+  testWidgets('onScreen tracks the viewer\'s own visibility measurement',
+      (tester) async {
+    final controller = await pumpViewer(tester, pages: 6);
+    // Sweep across a couple of page boundaries and hold the flag to the same
+    // truth the thumbnail strip's viewport indicator reads
+    // (PdfViewerController.visiblePageRegion), so the two can never disagree
+    // about what "visible" means.
+    for (final offset in [
+      0.0,
+      350.0,
+      440.0,
+      800.0,
+      pageExtent + pageSpacing,
+      2 * (pageExtent + pageSpacing) - 200,
+      3 * (pageExtent + pageSpacing),
+    ]) {
+      await scrollTo(tester, offset);
+      final pages = mountedPages(tester);
+      expect(pages, isNotEmpty);
+      for (final entry in pages.entries) {
+        expect(entry.value.onScreen, controller.visiblePageRegion(entry.key) != null,
+            reason: 'page ${entry.key} at scroll offset $offset');
+      }
+    }
+  });
+
+  testWidgets('the flag reaches the page before the scroll settles',
+      (tester) async {
+    // The viewer used to rebuild its page views only on the 500ms scroll
+    // settle, so a page crossing the edge kept its stale prefetch treatment
+    // for the whole gesture and then re-rendered. A single frame after the
+    // scroll is enough now.
+    await pumpViewer(tester);
+    scrollPosition(tester).jumpTo(800);
+    await tester.pump();
+
+    final pages = mountedPages(tester);
+    expect(pages[1], isNotNull);
+    expect(pages[1]!.onScreen, isTrue);
+  });
+}

--- a/packages/dart_pdf_editor/test/page_on_screen_test.dart
+++ b/packages/dart_pdf_editor/test/page_on_screen_test.dart
@@ -112,6 +112,43 @@ void main() {
     }
   });
 
+  testWidgets('the span is measured on a document that never scrolls',
+      (tester) async {
+    // Opening a document calls neither the scroll nor the transform listener,
+    // so the span has to be taken once the first layout's extents exist -
+    // otherwise the pages behind the fold read as on screen forever and never
+    // get the prefetch reduction.
+    //
+    // A 300px-wide viewer makes each page 388px tall, so two fit on screen at
+    // rest and a third sits in the cache window below them - the arrangement
+    // the full-width fixture can't produce (there, page 1 is not even built
+    // until it approaches).
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 300,
+            height: 600,
+            child: PdfViewer(
+              initialFit: PdfViewerFit.width,
+              document: PdfDocument.open(buildMultiPagePdf(5)),
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    await tester.pump();
+
+    final pages = mountedPages(tester);
+    expect(pages[0]!.onScreen, isTrue);
+    expect(pages[1]!.onScreen, isTrue);
+    expect(pages[2], isNotNull,
+        reason: 'page 2 is prefetched into the cache window');
+    expect(pages[2]!.onScreen, isFalse,
+        reason: 'page 2 starts below the fold and was never scrolled to');
+  });
+
   testWidgets('the flag reaches the page before the scroll settles',
       (tester) async {
     // The viewer used to rebuild its page views only on the 500ms scroll


### PR DESCRIPTION
## Summary

Scrolling around a large-format scan or CAD sheet made the pages above and below the current one visibly **pop in and out** as they sat near the screen edge.

Focus is a single page index — `focusDistance = |index - controller.currentPage|`, where `currentPage` is the page under the viewport **centre**. On any document whose pages are taller than the viewport (every CAD sheet, every A3 scan) there is always a *second* page filling much of the screen at distance 1. Three prefetch economies keyed off that distance and so applied to a page the user could plainly see:

1. `_imageRatioTarget()` decoded its images at `prefetchImagePixelRatioFactor` (0.5×, #451). On a scan the image *is* the page, so half the screen rendered soft.
2. `PdfLiveRasterBudget.rebalance()` evicted farthest-distance-first and protected only distance 0, so the visible neighbour was the first casualty once the on-screen pair exceeded the 384 MB desktop ceiling — two large-format base rasters plus their retained scenes get there easily. `evictLiveRaster()` drops the base raster, detail patch and scene, leaving the soft preview: the pop-out.
3. `evictReclaimable()` shed *every* non-focused page, visible ones included, on each platform low-memory signal.

Crossing the midpoint flips which page gets which treatment, so it oscillates. Because `PdfImageCache` keys by content *and* decoded size (`PdfSizedImageKey`), the 0.5× and 1.0× decodes of the same scan are two entries — each flip is a guaranteed miss, a fresh multi-MB decode, and an eviction of whatever the other page held. A devtools export from the reported session shows exactly that: decoded-image cache holding 11 entries / 130 MB with **210 misses against 146 evictions**, render-record cache at 67/100 MB with 201 evictions.

### The fix

`PdfPageView.onScreen` — whether *any part* of the page overlaps the viewport — now gates the prefetch economies instead of `focusDistance`:

- full-resolution image decode for every on-screen page; the reduction still applies to genuinely off-screen cache-window neighbours, which is what #451 was about;
- `rebalance()` runs two passes over the same farthest-first order — every off-screen page first, and only if the total is *still* over budget does it reach the visible ones (zoomed far enough out the visible set alone can exceed the ceiling, so the valve stays open, it just isn't the first move);
- `evictReclaimable()` spares on-screen pages: they re-rasterize the instant they are dropped, so evicting them under pressure buys a flicker and a *higher* peak — the same feedback loop `adaptive_memory.dart`'s `registryMaterialityPercent` comment documents;
- `didUpdateWidget` upgrades a reduced buffer when a page scrolls into view, not when it becomes the centre page.

`_updateCurrentPage` computes the visible span in the pass it already made over the page offsets. The span is a `Listenable` (`_PdfOnScreenSpan`) that each `_PdfViewerPage` subscribes to individually, so a crossing rebuilds only the pages that crossed — see the perf note below for why that matters. `currentPage` keeps its exact old rule, so page numbering and render focus are untouched.

Full write-up in `doc/dev-log/2026-08-10-visible-page-prefetch-demotion.md`.

**API impact:** `PdfLiveRasterHolder` gains `liveRasterOnScreen`; implementations must add it. `PdfPageView.onScreen` defaults to `true`, so a directly-embedded page view is unaffected.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [x] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze`
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

If any relevant check was not run, explain why: the change is confined to `dart_pdf_editor`'s viewer widgets and the live-raster budget, none of which the other packages' suites or the render baselines exercise — no rendering output changes, only when a page's raster and image decode are kept versus reclaimed. The full 2171-test `dart_pdf_editor` suite passes.

### Perf

Measured with the real-Chrome harness: **`tool/perf.sh webdiff 3cafba1 scroll-scan --iterations 7`**. Numbers and analysis in [this comment](https://github.com/ben-milanko/dart-pdf/pull/658#issuecomment-5236025021). Headline:

- `buildP50` +1.8%, `buildP95` +2.0% — flat.
- `buildMax` +37.9% (54.2 → 74.7 ms) — **a real regression, and a deliberate one.** It is exactly one frame per run (over-budget counts are unchanged run for run), the frame where a newly-visible page's full-resolution scene lands. Total work is *lower* than before — the old scheme rendered that page twice, soft then full — the peak just moved earlier, into the scroll instead of after the settle. Not tuned away, because an intermediate ratio would reinstate a smaller version of the softening this PR removes.
- The first cut of this PR regressed `buildP95` +16.8% by calling `setState` on the whole viewer for every span change; `731ed7c` fixed that (→ +2.0%) by making the span a `Listenable`.

### New tests

- `test/page_on_screen_test.dart` — a page sharing the screen with the current one stays on-screen; a prefetched page just past the edge does not; the span is measured on a document that never scrolls; the flag lands one frame after the scroll rather than at the settle; and `onScreen` is pinned to `PdfViewerController.visiblePageRegion` across a sweep of scroll offsets so the flag and the thumbnail strip's viewport indicator cannot drift apart.
- `test/live_raster_budget_test.dart` — four new ordering cases: a farther off-screen page goes before a nearer visible one, every off-screen page goes before any visible one, the safety valve reaches visible pages once the off-screen ones are gone, and the pressure path spares on-screen pages.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **`focusDistance` is stale mid-scroll, by design and as it always has been** — it only reaches the page views on a viewer rebuild. That is now load-bearing rather than incidental: `onScreen` is delivered promptly and decides the image ratio and reclaim protection, leaving focus to do what it is good for, ordering evictions among pages nobody is looking at. A test that asserted fresh `focusDistance` was removed for this reason.
- **Testing gotcha:** the prefetch band is *offstage*. Pages inside the list's cache extent but past the viewport edge are laid out and not painted, so `find.byType(PdfPageView)` misses them — pass `skipOffstage: false` or "off-screen but mounted" looks like "not mounted at all".
- **Harness bug found along the way (not fixed here):** `app/tool/perf/driver.mjs:65` defaults Chrome to the macOS app path with no fallback, so `webdiff` cannot run unattended on Linux without an explicit `PERF_CHROME`. Happy to add a `PATH` fallback here or separately.