### PR TITLE
feat(viewer): add stable tile raster backend seam

### DIFF
--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -84,9 +84,12 @@ export 'src/render_trace.dart';
 export 'src/render_worker.dart';
 export 'src/renderer.dart';
 export 'src/retained_scene.dart';
+export 'src/region_replay_index.dart'
+    show PdfRegionClipState, PdfRegionReplayUnit;
 export 'src/search_panel.dart';
 export 'src/scrollbar.dart';
 export 'src/theme.dart';
 export 'src/tile_layer.dart';
+export 'src/tile_raster_backend.dart';
 export 'src/tile_store.dart';
 export 'src/toast.dart';

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -34,6 +34,7 @@ import 'search_panel.dart';
 import 'shell_chrome.dart';
 import 'shell_session.dart';
 import 'theme.dart';
+import 'tile_raster_backend.dart';
 
 /// Builds the editing toolbar for [PdfEditorView].
 ///
@@ -217,6 +218,7 @@ class PdfEditorView extends StatefulWidget {
     this.viewerController,
     this.preferences,
     this.performance,
+    this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
     this.features = const PdfEditorFeatures(),
     this.onSave,
     this.onSaveAs,
@@ -298,6 +300,7 @@ class PdfEditorView extends StatefulWidget {
     this.viewerController,
     this.preferences,
     this.performance,
+    this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
     this.features = const PdfEditorFeatures(),
     this.onSave,
     this.onSaveAs,
@@ -413,6 +416,9 @@ class PdfEditorView extends StatefulWidget {
   /// Auto controller. Worker-count recommendations apply only when this shell
   /// naturally restarts its revision-bound worker.
   final PdfPerformanceController? performance;
+
+  /// See [PdfViewer.tileRasterBackend].
+  final PdfTileRasterBackend tileRasterBackend;
 
   final PdfEditorFeatures features;
 
@@ -722,6 +728,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
         viewerController: widget.viewerController,
         preferences: widget.preferences,
         performance: widget.performance,
+        tileRasterBackend: widget.tileRasterBackend,
         features: complete ? widget.features : _gatedFeatures(widget.features),
         // The first-paint buffer is incomplete: no save/change/insert/export
         // until the whole file is present.
@@ -1422,6 +1429,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         highlightFormFields: prefs.highlightFormFields,
                         renderWorker: _shell.worker,
                         performance: _performance,
+                        tileRasterBackend: widget.tileRasterBackend,
                         rasterCache: widget.rasterCache,
                         textCache: widget.textCache,
                         pageRasterCachePolicy: widget.pageRasterCachePolicy,

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -3168,19 +3168,23 @@ class _PdfPageViewState extends State<PdfPageView>
   PdfTileRasterSession _tileRasterSessionFor(PdfRetainedScene scene) =>
       _tileRasterSessions.putIfAbsent(scene, () {
         final backend = widget.tileRasterBackend;
+        String label() => _tileBackendLabel(backend);
         PdfTileRasterSession? preferred;
         try {
           preferred = backend.createSession(scene);
         } catch (error) {
           PdfPerfLog.log(
             'tile backend init fallback page=${widget.previewIndex} '
-            'backend=${backend.debugLabel} error=$error',
+            'backend=${label()} error=$error',
           );
         }
         final fallback =
             const PdfCanvasTileRasterBackend().createSession(scene);
         if (preferred == null) return fallback;
-        if (backend is PdfCanvasTileRasterBackend) {
+        // Skip the adapter only for the stock implementation itself. A
+        // subclass may override createSession and must receive the same
+        // failure and output-validation guarantees as every other backend.
+        if (backend.runtimeType == PdfCanvasTileRasterBackend) {
           fallback.dispose();
           return preferred;
         }
@@ -3189,20 +3193,41 @@ class _PdfPageViewState extends State<PdfPageView>
           fallback: fallback,
           onFallback: (error) => PdfPerfLog.log(
             'tile backend raster fallback page=${widget.previewIndex} '
-            'backend=${backend.debugLabel} error=$error',
+            'backend=${label()} error=$error',
           ),
         );
       });
 
   void _disposeTileRasterSession(PdfRetainedScene scene) {
-    _tileRasterSessions.remove(scene)?.dispose();
+    final session = _tileRasterSessions.remove(scene);
+    if (session != null) _disposeTileRasterSessionSafely(session);
   }
 
   void _disposeTileRasterSessions() {
-    for (final session in _tileRasterSessions.values) {
-      session.dispose();
-    }
+    final sessions = _tileRasterSessions.values.toList();
     _tileRasterSessions.clear();
+    for (final session in sessions) {
+      _disposeTileRasterSessionSafely(session);
+    }
+  }
+
+  void _disposeTileRasterSessionSafely(PdfTileRasterSession session) {
+    try {
+      session.dispose();
+    } catch (error) {
+      PdfPerfLog.log(
+        'tile backend dispose ignored page=${widget.previewIndex} '
+        'session=${session.runtimeType} error=$error',
+      );
+    }
+  }
+
+  static String _tileBackendLabel(PdfTileRasterBackend backend) {
+    try {
+      return backend.debugLabel;
+    } catch (_) {
+      return backend.runtimeType.toString();
+    }
   }
 
   /// Whether worker strip binning may be asked for at all - shared by
@@ -3683,13 +3708,31 @@ class _FallbackTileRasterSession implements PdfTileRasterSession {
     int? tracePage,
   }) async {
     if (_primaryEnabled) {
+      ui.Image? image;
       try {
-        return await _primary.rasterizeRegion(
+        image = await _primary.rasterizeRegion(
           region,
           pixelRatio: pixelRatio,
           tracePage: tracePage,
         );
+        final expectedWidth =
+            (region.width * pixelRatio).ceil().clamp(1, 1 << 14);
+        final expectedHeight =
+            (region.height * pixelRatio).ceil().clamp(1, 1 << 14);
+        if (image.width != expectedWidth || image.height != expectedHeight) {
+          final actual = '${image.width}x${image.height}';
+          image.dispose();
+          image = null;
+          throw StateError(
+            'tile backend returned $actual, expected '
+            '${expectedWidth}x$expectedHeight',
+          );
+        }
+        return image;
       } catch (error) {
+        // A backend may throw after producing an image (for example from a
+        // validation getter); never leak that rejected slab.
+        image?.dispose();
         if (_primaryEnabled) {
           _primaryEnabled = false;
           onFallback(error);

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -26,6 +26,7 @@ import 'renderer.dart';
 import 'retained_scene.dart';
 import 'strips/strip_device.dart';
 import 'tile_layer.dart';
+import 'tile_raster_backend.dart';
 import 'tile_store.dart';
 
 /// Displays a single PDF page, rendered natively in Dart.
@@ -66,6 +67,7 @@ class PdfPageView extends StatefulWidget {
     this.workerImagePixelRatioCap,
     this.transformScale,
     this.transformChanges,
+    this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
   });
 
   final PdfPage page;
@@ -109,6 +111,15 @@ class PdfPageView extends StatefulWidget {
   /// Null falls back to [transformScale], preserving the standalone widget's
   /// zoom-only speculation behavior.
   final Listenable? transformChanges;
+
+  /// Scene-scoped renderer for deep-zoom tile slabs.
+  ///
+  /// The default replays the retained scene through Flutter Canvas. An
+  /// experimental backend can instead retain GPU buffers and textures once
+  /// per scene. It is created lazily only after the tile path engages, so it
+  /// cannot delay the page's initial raster; null sessions and failures fall
+  /// back to the Canvas implementation.
+  final PdfTileRasterBackend tileRasterBackend;
 
   /// Shared low-res previews (see [PdfPagePreviewCache]): while this
   /// page's full render is pending - most visibly under [renderHold]
@@ -490,6 +501,13 @@ class _PdfPageViewState extends State<PdfPageView>
   /// [_picture] re-raster runs) and when [PdfPageView.retainedZoomReplay]
   /// is off. Lives and dies with [_picture] (see [_dropPicture]).
   PdfRetainedScene? _scene;
+
+  /// Tile sessions are keyed by retained-scene identity. Usually this holds
+  /// the base scene and, on image-heavy deep zooms, one sharper detail scene.
+  /// Keeping the owner here—not in PdfTileStore—makes uploads scene-lifetime
+  /// while the store remains backend-agnostic and document-revision safe.
+  final Map<PdfRetainedScene, PdfTileRasterSession> _tileRasterSessions =
+      Map.identity();
   ui.Image? _image;
   double? _pixelRatio;
   double? _layoutWidth;
@@ -743,6 +761,11 @@ class _PdfPageViewState extends State<PdfPageView>
       oldWidget.renderScheduler?.cancel(this);
       // the new scheduler picks this page up on its next _render
     }
+    if (!identical(oldWidget.tileRasterBackend, widget.tileRasterBackend)) {
+      // Cached tiles remain valid because every backend promises the same
+      // pixels. Only scene-level resources and future misses change owner.
+      _disposeTileRasterSessions();
+    }
     final oldLiveTransform = _liveTransformFor(oldWidget);
     final liveTransform = _liveTransformFor(widget);
     if (!identical(oldLiveTransform, liveTransform)) {
@@ -861,6 +884,7 @@ class _PdfPageViewState extends State<PdfPageView>
     widget.previewCache?.removeListener(_onPreviewCacheChanged);
     _renderSession.dispose();
     _dropPicture();
+    _disposeTileRasterSessions();
     _image?.dispose();
     _detailImage?.dispose();
     _tileDetailScene?.dispose();
@@ -892,7 +916,11 @@ class _PdfPageViewState extends State<PdfPageView>
     bool fromWorker = false,
     bool vectorOnly = false,
   }) {
-    _scene?.dispose();
+    final previous = _scene;
+    if (previous != null) {
+      _disposeTileRasterSession(previous);
+      previous.dispose();
+    }
     _scene = scene;
     // The image-detail decode belongs to the scene it sharpened; a new scene
     // (new content, or the same page re-recorded) invalidates it.
@@ -3025,7 +3053,11 @@ class _PdfPageViewState extends State<PdfPageView>
   /// images were decoded at, so a blurry tile WOULD otherwise be reused
   /// unchanged - the veto is what makes dropping unnecessary.)
   void _adoptTileDetailScene(PdfRetainedScene scene, Rect region, double ratio) {
-    _tileDetailScene?.dispose();
+    final previous = _tileDetailScene;
+    if (previous != null) {
+      _disposeTileRasterSession(previous);
+      previous.dispose();
+    }
     setState(() {
       _tileDetailScene = scene;
       _tileDetailRegion = region;
@@ -3047,6 +3079,7 @@ class _PdfPageViewState extends State<PdfPageView>
     _tileDetailPending = null;
     _tileDetailWanted = false;
     if (_tileDetailScene == null) return;
+    _disposeTileRasterSession(_tileDetailScene!);
     _tileDetailScene?.dispose();
     _tileDetailScene = null;
     _tileDetailRegion = null;
@@ -3101,13 +3134,12 @@ class _PdfPageViewState extends State<PdfPageView>
         // Images come from the region-scoped detail scene wherever it reaches
         // (that is the only thing the base scene cannot supply at this zoom);
         // everything else replays identically from either.
-        rasterize: (region, ratio) => (_tileDetailCovers(region, ratio)
-                ? _tileDetailScene ?? scene
-                : scene)
-            .rasterizeRegion(
+        rasterize: (region, ratio) => _rasterizeTile(
+          _tileDetailCovers(region, ratio)
+              ? _tileDetailScene ?? scene
+              : scene,
           region,
-          pixelRatio: ratio,
-          tracePage: widget.previewIndex,
+          ratio,
         ),
         canRasterize: _tileRegionRasterizable,
         // A grid-indexed CAD scene can select tens of thousands of commands
@@ -3120,6 +3152,57 @@ class _PdfPageViewState extends State<PdfPageView>
         maxNewTilesPerPaint: scene.regionIndexBuildIsHeavy ? 1 : null,
       ),
     );
+  }
+
+  Future<ui.Image> _rasterizeTile(
+    PdfRetainedScene scene,
+    Rect region,
+    double pixelRatio,
+  ) =>
+      _tileRasterSessionFor(scene).rasterizeRegion(
+        region,
+        pixelRatio: pixelRatio,
+        tracePage: widget.previewIndex,
+      );
+
+  PdfTileRasterSession _tileRasterSessionFor(PdfRetainedScene scene) =>
+      _tileRasterSessions.putIfAbsent(scene, () {
+        final backend = widget.tileRasterBackend;
+        PdfTileRasterSession? preferred;
+        try {
+          preferred = backend.createSession(scene);
+        } catch (error) {
+          PdfPerfLog.log(
+            'tile backend init fallback page=${widget.previewIndex} '
+            'backend=${backend.debugLabel} error=$error',
+          );
+        }
+        final fallback =
+            const PdfCanvasTileRasterBackend().createSession(scene);
+        if (preferred == null) return fallback;
+        if (backend is PdfCanvasTileRasterBackend) {
+          fallback.dispose();
+          return preferred;
+        }
+        return _FallbackTileRasterSession(
+          primary: preferred,
+          fallback: fallback,
+          onFallback: (error) => PdfPerfLog.log(
+            'tile backend raster fallback page=${widget.previewIndex} '
+            'backend=${backend.debugLabel} error=$error',
+          ),
+        );
+      });
+
+  void _disposeTileRasterSession(PdfRetainedScene scene) {
+    _tileRasterSessions.remove(scene)?.dispose();
+  }
+
+  void _disposeTileRasterSessions() {
+    for (final session in _tileRasterSessions.values) {
+      session.dispose();
+    }
+    _tileRasterSessions.clear();
   }
 
   /// Whether worker strip binning may be asked for at all - shared by
@@ -3570,6 +3653,60 @@ class _PdfPageViewState extends State<PdfPageView>
         );
       },
     );
+  }
+}
+
+/// Permanently retires an accelerated session after its first failure and
+/// serves that request (and every later one) through Canvas. The failed
+/// session stays owned until dispose: another slab may already be in flight,
+/// and the backend contract allows it to finish before resources are freed.
+class _FallbackTileRasterSession implements PdfTileRasterSession {
+  _FallbackTileRasterSession({
+    required PdfTileRasterSession primary,
+    required this.fallback,
+    required this.onFallback,
+  })  : _primary = primary,
+        assert(identical(primary.scene, fallback.scene));
+
+  final PdfTileRasterSession _primary;
+  final PdfTileRasterSession fallback;
+  final void Function(Object error) onFallback;
+  bool _primaryEnabled = true;
+
+  @override
+  PdfRetainedScene get scene => fallback.scene;
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) async {
+    if (_primaryEnabled) {
+      try {
+        return await _primary.rasterizeRegion(
+          region,
+          pixelRatio: pixelRatio,
+          tracePage: tracePage,
+        );
+      } catch (error) {
+        if (_primaryEnabled) {
+          _primaryEnabled = false;
+          onFallback(error);
+        }
+      }
+    }
+    return fallback.rasterizeRegion(
+      region,
+      pixelRatio: pixelRatio,
+      tracePage: tracePage,
+    );
+  }
+
+  @override
+  void dispose() {
+    _primary.dispose();
+    fallback.dispose();
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -23,6 +23,7 @@ import 'search_panel.dart';
 import 'shell_chrome.dart';
 import 'shell_session.dart';
 import 'theme.dart';
+import 'tile_raster_backend.dart';
 
 /// Which pieces of chrome a [PdfReader] shows. Everything defaults on;
 /// turn features off rather than rebuilding the layout by hand.
@@ -129,6 +130,7 @@ class PdfReader extends StatefulWidget {
     this.controller,
     this.preferences,
     this.performance,
+    this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
     this.features = const PdfReaderFeatures(),
     this.onAction,
     this.onAnnotationTap,
@@ -175,6 +177,7 @@ class PdfReader extends StatefulWidget {
     this.controller,
     this.preferences,
     this.performance,
+    this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
     this.features = const PdfReaderFeatures(),
     this.onAction,
     this.onAnnotationTap,
@@ -254,6 +257,9 @@ class PdfReader extends StatefulWidget {
   /// Auto controller. Pass one to select fixed worker settings at runtime or
   /// expose [PdfPerformanceController.diagnostics] in host UI.
   final PdfPerformanceController? performance;
+
+  /// See [PdfViewer.tileRasterBackend].
+  final PdfTileRasterBackend tileRasterBackend;
 
   final PdfReaderFeatures features;
 
@@ -552,6 +558,7 @@ class _PdfReaderState extends State<PdfReader> {
                           highlightFormFields: prefs.highlightFormFields,
                           renderWorker: _shell.worker,
                           performance: _performance,
+                          tileRasterBackend: widget.tileRasterBackend,
                           rasterCache: widget.rasterCache,
                           textCache: widget.textCache,
                           pageRasterCachePolicy: widget.pageRasterCachePolicy,
@@ -615,6 +622,7 @@ class _PdfReaderState extends State<PdfReader> {
         controller: widget.controller,
         preferences: widget.preferences,
         performance: widget.performance,
+        tileRasterBackend: widget.tileRasterBackend,
         features: widget.features,
         onAction: widget.onAction,
         onAnnotationTap: widget.onAnnotationTap,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -45,6 +45,7 @@ import 'renderer.dart';
 import 'retained_scene.dart';
 import 'scrollbar.dart';
 import 'theme.dart';
+import 'tile_raster_backend.dart';
 import 'toast.dart';
 import 'viewport.dart';
 
@@ -1016,6 +1017,7 @@ class PdfViewer extends StatefulWidget {
     this.renderWorker,
     this.autoRenderWorker = true,
     this.performance,
+    this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
     this.rasterCache,
     this.textCache,
     this.documentId,
@@ -1123,6 +1125,14 @@ class PdfViewer extends StatefulWidget {
   /// owning shell when it starts [renderWorker]; the viewer consumes its
   /// runtime-safe preview, vector-first, and image-cap tuning live.
   final PdfPerformanceController? performance;
+
+  /// Scene-scoped renderer for LoD tile slabs.
+  ///
+  /// The stock Canvas backend preserves current behavior. Experimental GPU
+  /// backends are initialized lazily after first paint, retain resources once
+  /// per retained scene, and automatically fall back to Canvas if unsupported
+  /// or unavailable.
+  final PdfTileRasterBackend tileRasterBackend;
 
   /// Keyboard shortcuts that arm editing tools while [editing] is active.
   ///
@@ -6353,6 +6363,7 @@ class _PdfViewerState extends State<PdfViewer>
                 previewCache: widget.pagePreviews ? _previews : null,
                 renderWorker: _effectiveRenderWorker,
                 performance: widget.performance,
+                tileRasterBackend: widget.tileRasterBackend,
                 predictStrokes: widget.predictStrokes,
               ),
             ),
@@ -7134,6 +7145,7 @@ class _PdfViewerPage extends StatefulWidget {
     required this.previewCache,
     required this.renderWorker,
     required this.performance,
+    required this.tileRasterBackend,
     required this.predictStrokes,
     required this.contextMenuEnabled,
   });
@@ -7237,6 +7249,8 @@ class _PdfViewerPage extends StatefulWidget {
   final PdfRenderWorker? renderWorker;
 
   final PdfPerformanceController? performance;
+
+  final PdfTileRasterBackend tileRasterBackend;
 
   /// See [PdfViewer.predictStrokes].
   final bool predictStrokes;
@@ -7363,6 +7377,7 @@ class _PdfViewerPageState extends State<_PdfViewerPage> {
         previewCache: widget.previewCache,
         renderWorker: widget.renderWorker,
         performance: widget.performance,
+        tileRasterBackend: widget.tileRasterBackend,
         workerImagePixelRatioCap: widget.performance?.tuning.imagePixelRatioCap,
         // the live matrix scale lets dense strip-routed pages bin their
         // settle's strip plan speculatively while the gesture quiesces; the

--- a/packages/dart_pdf_editor/lib/src/region_replay_index.dart
+++ b/packages/dart_pdf_editor/lib/src/region_replay_index.dart
@@ -208,6 +208,28 @@ class PdfRegionReplayIndex {
     }
     return replayed;
   }
+
+  /// Selects the paint units intersecting [region] in painter order.
+  ///
+  /// This is the retained-scene backend boundary: a renderer that does not
+  /// implement [PdfDevice] can consume the same conservative culling verdict
+  /// as [replay], including the clip and blend state captured on every unit.
+  /// Unsupported indices return an empty list; callers must check
+  /// [supported] and fall back to full-scene rendering rather than treating
+  /// that as an empty region.
+  List<PdfRegionReplayUnit> select(PdfRect region) {
+    if (!supported) return const [];
+    final grid = this.grid;
+    if (grid != null) {
+      return [
+        for (final index in grid.select(region, units)) units[index],
+      ];
+    }
+    return [
+      for (final unit in units)
+        if (_intersects(unit.bounds, region)) unit,
+    ];
+  }
 }
 
 /// Uniform-grid spatial index over painter-ordered replay units.
@@ -349,6 +371,31 @@ class PdfRegionReplayGrid {
     List<PdfRenderCommand> commands,
     PdfDevice device,
   ) {
+    final candidates = select(region, units);
+    var replayed = 0;
+    for (final idx in candidates) {
+      final unit = units[idx];
+      device.save();
+      device.setBlendMode(unit.blendMode);
+      unit.clips?.replay(device);
+      replayCommands(
+        commands,
+        device,
+        start: unit.commandIndex,
+        end: unit.commandIndex + 1,
+      );
+      device.restore();
+      replayed++;
+    }
+    return replayed;
+  }
+
+  /// Unit-list indices intersecting [region], de-duplicated and sorted into
+  /// painter order.
+  List<int> select(
+    PdfRect region,
+    List<PdfRegionReplayUnit> units,
+  ) {
     final gen = ++_generation;
     // Gather candidate unit indices (deduped) from the touched cells + broad.
     final candidates = <int>[];
@@ -376,22 +423,7 @@ class PdfRegionReplayGrid {
     }
     // Painter order = ascending unit index.
     candidates.sort();
-    var replayed = 0;
-    for (final idx in candidates) {
-      final unit = units[idx];
-      device.save();
-      device.setBlendMode(unit.blendMode);
-      unit.clips?.replay(device);
-      replayCommands(
-        commands,
-        device,
-        start: unit.commandIndex,
-        end: unit.commandIndex + 1,
-      );
-      device.restore();
-      replayed++;
-    }
-    return replayed;
+    return candidates;
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/retained_scene.dart
+++ b/packages/dart_pdf_editor/lib/src/retained_scene.dart
@@ -281,6 +281,16 @@ class PdfRetainedScene {
   /// Decoded images keyed by [pdfImageKey], owned by this scene.
   final Map<Object, ui.Image> _images;
 
+  /// The already-decoded image for [request], or null when its codec failed or
+  /// this is a deliberate vector-only progressive scene.
+  ///
+  /// Accelerated backends use this to upload each image once at session
+  /// creation instead of decoding or uploading it once per tile.
+  ui.Image? imageFor(PdfImageRequest request) {
+    assert(!_disposed, 'imageFor after dispose');
+    return _images[pdfImageKey(request)];
+  }
+
   bool _disposed = false;
 
   /// Page size in points after the plan's rotation - the raster size at
@@ -469,6 +479,24 @@ class PdfRetainedScene {
       maxCommands: params.maxCommands,
       buildGrid: params.buildGrid,
     );
+  }
+
+  /// Selects the painter-order units needed for [rasterRegion].
+  ///
+  /// [rasterRegion] uses the same page-point, y-down space as
+  /// [rasterizeRegion]. Each returned unit carries its command index plus the
+  /// clip and blend state active at that command. Null means the scene cannot
+  /// be split safely (for example, it contains an isolated group or soft
+  /// mask), so a backend must decline the scene and let the Canvas fallback
+  /// render it whole. An empty list means the supported region is genuinely
+  /// blank.
+  List<PdfRegionReplayUnit>? selectRegion(Rect rasterRegion) {
+    assert(!_disposed, 'selectRegion after dispose');
+    final index = _ensureRegionIndex();
+    if (!index.supported) return null;
+    final pageRegion = _pageSpaceRegion(rasterRegion);
+    if (pageRegion == null) return null;
+    return index.select(pageRegion);
   }
 
   /// The `(maxCommands, buildGrid)` the region index builds under for this

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -1,0 +1,95 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/painting.dart';
+
+import 'retained_scene.dart';
+import 'tile_store.dart';
+
+/// Creates a scene-scoped renderer for deep-zoom tile slabs.
+///
+/// [PdfTileStore] remains responsible for LoD selection, batching, caching,
+/// and composition. A backend only turns a retained-scene region into an
+/// image. Keeping the session at scene lifetime lets accelerated backends
+/// tessellate commands and upload buffers or textures once, then reuse those
+/// resources for every slab the store requests.
+///
+/// Returning null from [createSession], or throwing while creating or using a
+/// session, makes the page view fall back to [PdfCanvasTileRasterBackend] for
+/// that scene. Implementations should therefore reject unsupported command
+/// mixes conservatively instead of approximating painter order, groups,
+/// clipping, or blending.
+abstract class PdfTileRasterBackend {
+  const PdfTileRasterBackend();
+
+  /// A short diagnostics label, such as `canvas` or `flutter_gpu`.
+  String get debugLabel;
+
+  /// Creates a lightweight owner for resources retained across tile renders.
+  ///
+  /// This is called lazily, when the tile path first needs a slab—not while
+  /// the page's initial raster is being prepared. Expensive initialization
+  /// should itself be deferred by the returned session until
+  /// [PdfTileRasterSession.rasterizeRegion], so enabling an experimental
+  /// backend cannot delay first paint.
+  PdfTileRasterSession? createSession(PdfRetainedScene scene);
+}
+
+/// Scene-lifetime resources used to rasterize many tile slabs.
+abstract class PdfTileRasterSession {
+  /// The retained scene this session was built for.
+  PdfRetainedScene get scene;
+
+  /// Rasterizes [region] in page-point, y-down raster space.
+  ///
+  /// The tile store may request a slab spanning several adjacent tiles and
+  /// slice the returned image, so implementations should preserve the exact
+  /// output dimensions used by [PdfRetainedScene.rasterizeRegion].
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  });
+
+  /// Releases scene-level GPU/CPU resources.
+  ///
+  /// A page can be replaced while an already-submitted raster is in flight.
+  /// Implementations must allow futures returned before this call to finish
+  /// safely (for example by retiring resources after the command buffer has
+  /// completed).
+  void dispose();
+}
+
+/// The universal retained-scene renderer used today and as a fallback for
+/// accelerated backends.
+class PdfCanvasTileRasterBackend extends PdfTileRasterBackend {
+  const PdfCanvasTileRasterBackend();
+
+  @override
+  String get debugLabel => 'canvas';
+
+  @override
+  PdfTileRasterSession createSession(PdfRetainedScene scene) =>
+      _PdfCanvasTileRasterSession(scene);
+}
+
+class _PdfCanvasTileRasterSession implements PdfTileRasterSession {
+  _PdfCanvasTileRasterSession(this.scene);
+
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) =>
+      scene.rasterizeRegion(
+        region,
+        pixelRatio: pixelRatio,
+        tracePage: tracePage,
+      );
+
+  @override
+  void dispose() {}
+}

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -43,7 +43,11 @@ abstract class PdfTileRasterSession {
   ///
   /// The tile store may request a slab spanning several adjacent tiles and
   /// slice the returned image, so implementations should preserve the exact
-  /// output dimensions used by [PdfRetainedScene.rasterizeRegion].
+  /// output dimensions used by [PdfRetainedScene.rasterizeRegion]. A
+  /// wrong-sized result is disposed and treated as a backend failure. On
+  /// success ownership of the returned image transfers to the tile store;
+  /// sessions must return a uniquely owned image (or a clone), not a borrowed
+  /// cached image.
   Future<ui.Image> rasterizeRegion(
     Rect region, {
     required double pixelRatio,
@@ -55,7 +59,8 @@ abstract class PdfTileRasterSession {
   /// A page can be replaced while an already-submitted raster is in flight.
   /// Implementations must allow futures returned before this call to finish
   /// safely (for example by retiring resources after the command buffer has
-  /// completed).
+  /// completed). Implementations should not throw; disposal failures are
+  /// ignored so an optional backend cannot break page replacement or teardown.
   void dispose();
 }
 

--- a/packages/dart_pdf_editor/test/retained_scene_test.dart
+++ b/packages/dart_pdf_editor/test/retained_scene_test.dart
@@ -69,6 +69,20 @@ void main() {
     });
   });
 
+  testWidgets('retained scene exposes its already-decoded images',
+      (tester) async {
+    await tester.runAsync(() async {
+      final page = PdfDocument.open(buildEmbeddedFontImagePdf()).page(0);
+      final scene = await PdfRetainedScene.record(page);
+      addTearDown(scene.dispose);
+      final imageCommand = scene.commands.whereType<PdfDrawImageCommand>().first;
+      final image = scene.imageFor(imageCommand.request);
+      expect(image, isNotNull);
+      expect(image!.width, greaterThan(0));
+      expect(image.height, greaterThan(0));
+    });
+  });
+
   testWidgets(
       'region replay selects paints, preserves clips, and stays bounded',
       (tester) async {
@@ -144,6 +158,11 @@ void main() {
       expect(scene.debugRegionReplayUnitCount, 3,
           reason: 'the clipped-away and far-right paints are not indexed');
       expect(scene.debugRegionReplayEstimatedBytes, lessThan(512));
+      final selected = scene.selectRegion(region)!;
+      expect(selected.map((unit) => unit.commandIndex), [2, 6]);
+      expect(selected.first.clips?.command, same(commands[1]));
+      expect(selected.first.blendMode, PdfBlendMode.normal);
+      expect(selected.last.blendMode, PdfBlendMode.multiply);
       scene.dispose();
       expect(scene.debugHasRegionReplayIndex, isFalse,
           reason: 'disposing the scene releases retained index metadata');

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -3,6 +3,7 @@
 // keeps showing through. Kept in its own file so the global flag mutation can't
 // leak into other page-view tests.
 import 'dart:async';
+import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/region_replay_index.dart';
@@ -13,6 +14,156 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 void main() {
+  testWidgets('tile backend is lazy, scene-scoped, and disposed',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store =
+        PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final backend = _RecordingTileRasterBackend();
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    Widget page(double width) => Center(
+          child: OverflowBox(
+            maxWidth: double.infinity,
+            maxHeight: double.infinity,
+            child: SizedBox(
+              width: width,
+              child: PdfPageView(
+                page: doc.page(0),
+                tileRasterBackend: backend,
+              ),
+            ),
+          ),
+        );
+
+    // A normal first paint records and rasterizes the page, but never creates
+    // the optional tile backend.
+    await tester.pumpWidget(page(612));
+    for (var i = 0; i < 100 && find.byType(RawImage).evaluate().isEmpty; i++) {
+      await tester.pump();
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(find.byType(RawImage), findsOneWidget);
+    expect(backend.sessionCreates, 0);
+
+    // Deep zoom engages the existing tile scheduler. Every slab goes through
+    // one session retained for this scene.
+    await tester.pumpWidget(page(6120));
+    for (var i = 0; i < 300 && store.tileCount == 0; i++) {
+      await tester.pump();
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+    expect(store.tileCount, greaterThan(0));
+    expect(backend.sessionCreates, 1);
+    expect(backend.rasterizations, greaterThan(0));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    expect(backend.sessionDisposals, 1);
+  });
+
+  testWidgets('a failed tile backend falls back to Canvas', (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store =
+        PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final backend = _RecordingTileRasterBackend(failRasterization: true);
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(
+            width: 6120,
+            child: PdfPageView(
+              page: doc.page(0),
+              tileRasterBackend: backend,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 300 && store.tileCount == 0; i++) {
+      await tester.pump();
+      final exception = tester.takeException();
+      if (exception != null) fail('Canvas fallback failed: $exception');
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(backend.sessionCreates, 1);
+    expect(backend.rasterizations, greaterThan(0));
+    expect(store.tileCount, greaterThan(0),
+        reason: 'the failed backend request must be retried through Canvas');
+  });
+
+  testWidgets('an unavailable tile backend falls back during initialization',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store =
+        PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final backend = _RecordingTileRasterBackend(failCreation: true);
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(
+            width: 6120,
+            child: PdfPageView(
+              page: doc.page(0),
+              tileRasterBackend: backend,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 300 && store.tileCount == 0; i++) {
+      await tester.pump();
+      final exception = tester.takeException();
+      if (exception != null) fail('Canvas fallback failed: $exception');
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(backend.sessionCreates, 1);
+    expect(backend.rasterizations, 0);
+    expect(store.tileCount, greaterThan(0));
+  });
+
   testWidgets('tile path composites deep-zoom tiles instead of the patch',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;
@@ -184,6 +335,58 @@ void main() {
       scene.dispose();
     });
   });
+}
+
+class _RecordingTileRasterBackend extends PdfTileRasterBackend {
+  _RecordingTileRasterBackend({
+    this.failCreation = false,
+    this.failRasterization = false,
+  });
+
+  final bool failCreation;
+  final bool failRasterization;
+  int sessionCreates = 0;
+  int sessionDisposals = 0;
+  int rasterizations = 0;
+
+  @override
+  String get debugLabel => 'recording';
+
+  @override
+  PdfTileRasterSession createSession(PdfRetainedScene scene) {
+    sessionCreates++;
+    if (failCreation) throw StateError('experimental backend unavailable');
+    return _RecordingTileRasterSession(this, scene);
+  }
+}
+
+class _RecordingTileRasterSession implements PdfTileRasterSession {
+  _RecordingTileRasterSession(this.backend, this.scene);
+
+  final _RecordingTileRasterBackend backend;
+
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) {
+    backend.rasterizations++;
+    if (backend.failRasterization) {
+      return Future<ui.Image>.error(StateError('experimental backend failed'));
+    }
+    return scene.rasterizeRegion(
+      region,
+      pixelRatio: pixelRatio,
+      tracePage: tracePage,
+    );
+  }
+
+  @override
+  void dispose() => backend.sessionDisposals++;
 }
 
 class _DelayedIndexWorker extends PdfRenderWorker {

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -14,14 +14,14 @@ import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
 
 void main() {
-  testWidgets('tile backend is lazy, scene-scoped, and disposed',
+  testWidgets('tile backend is lazy, scene-scoped, and disposal-safe',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
 
     final store =
         PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
-    final backend = _RecordingTileRasterBackend();
+    final backend = _RecordingTileRasterBackend(throwOnDispose: true);
     PdfPageView.tileStoreDetail = true;
     PdfPageView.debugTileStoreOverride = store;
     addTearDown(() {
@@ -69,6 +69,8 @@ void main() {
     expect(backend.rasterizations, greaterThan(0));
 
     await tester.pumpWidget(const SizedBox.shrink());
+    expect(tester.takeException(), isNull,
+        reason: 'an optional backend must not break page teardown');
     expect(backend.sessionDisposals, 1);
   });
 
@@ -116,6 +118,53 @@ void main() {
     expect(backend.rasterizations, greaterThan(0));
     expect(store.tileCount, greaterThan(0),
         reason: 'the failed backend request must be retried through Canvas');
+  });
+
+  testWidgets('a wrong-sized backend slab falls back to Canvas',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store =
+        PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final backend = _RecordingTileRasterBackend(wrongDimensions: true);
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = false;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(
+            width: 6120,
+            child: PdfPageView(
+              page: doc.page(0),
+              tileRasterBackend: backend,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0; i < 300 && store.tileCount == 0; i++) {
+      await tester.pump();
+      final exception = tester.takeException();
+      if (exception != null) fail('Canvas fallback failed: $exception');
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)));
+    }
+
+    expect(backend.sessionCreates, 1);
+    expect(backend.rasterizations, greaterThan(0));
+    expect(store.tileCount, greaterThan(0),
+        reason: 'malformed backend pixels must not enter the tile cache');
   });
 
   testWidgets('an unavailable tile backend falls back during initialization',
@@ -337,14 +386,20 @@ void main() {
   });
 }
 
-class _RecordingTileRasterBackend extends PdfTileRasterBackend {
+// Deliberately subclasses the stock backend: custom subclasses still override
+// createSession and must not bypass the failure adapter.
+class _RecordingTileRasterBackend extends PdfCanvasTileRasterBackend {
   _RecordingTileRasterBackend({
     this.failCreation = false,
     this.failRasterization = false,
+    this.wrongDimensions = false,
+    this.throwOnDispose = false,
   });
 
   final bool failCreation;
   final bool failRasterization;
+  final bool wrongDimensions;
+  final bool throwOnDispose;
   int sessionCreates = 0;
   int sessionDisposals = 0;
   int rasterizations = 0;
@@ -373,10 +428,19 @@ class _RecordingTileRasterSession implements PdfTileRasterSession {
     Rect region, {
     required double pixelRatio,
     int? tracePage,
-  }) {
+  }) async {
     backend.rasterizations++;
     if (backend.failRasterization) {
-      return Future<ui.Image>.error(StateError('experimental backend failed'));
+      throw StateError('experimental backend failed');
+    }
+    if (backend.wrongDimensions) {
+      final recorder = ui.PictureRecorder();
+      final picture = recorder.endRecording();
+      try {
+        return await picture.toImage(1, 1);
+      } finally {
+        picture.dispose();
+      }
     }
     return scene.rasterizeRegion(
       region,
@@ -386,7 +450,12 @@ class _RecordingTileRasterSession implements PdfTileRasterSession {
   }
 
   @override
-  void dispose() => backend.sessionDisposals++;
+  void dispose() {
+    backend.sessionDisposals++;
+    if (backend.throwOnDispose) {
+      throw StateError('experimental backend dispose failed');
+    }
+  }
 }
 
 class _DelayedIndexWorker extends PdfRenderWorker {


### PR DESCRIPTION
## What changed

- add a public, scene-scoped `PdfTileRasterBackend` / `PdfTileRasterSession` seam
- keep the existing retained-scene Canvas renderer as the default and universal fallback
- create backend sessions lazily only when deep-zoom tiles are first requested
- retain one backend session per retained scene and dispose it with that scene
- permanently fall back to Canvas when backend initialization or rasterization fails
- expose retained decoded images and painter-order region selection for future accelerated backends
- thread backend selection through `PdfPageView`, `PdfViewer`, `PdfReader`, and `PdfEditorView`, including progressive-open flows

## Why

This establishes the integration boundary for an optional Flutter GPU tile renderer without adding `flutter_gpu`, requiring Flutter master, raising the package's minimum Flutter version, or delaying initial page paint. A future companion backend can upload scene resources once, render the slabs already scheduled by `PdfTileStore`, and return a GPU-backed `ui.Image`.

## Impact

Default rendering behavior is unchanged: every existing caller uses `PdfCanvasTileRasterBackend`. Experimental backends are opt-in and conservatively fall back to Canvas for unsupported scenes or unavailable contexts.

Persistent tile storage is intentionally outside this PR. The existing preview/full-raster cache remains the cold-open path while GPU tile rendering can begin after first paint.

## Validation

- `fvm dart analyze`
- `fvm flutter test test/tile_store_page_view_test.dart test/pdf_shell_test.dart`
- `fvm flutter test test/retained_scene_test.dart test/region_replay_grid_test.dart test/tile_store_page_view_test.dart`

All checks pass.