### PR TITLE
Extend flutter_gpu tiles for heavy CAD workloads

### DIFF
--- a/app/lib/devtools.dart
+++ b/app/lib/devtools.dart
@@ -158,11 +158,15 @@ class AppDevTools extends ChangeNotifier {
   FlutterGpuTileRasterBackend? _flutterGpuTileRasterBackend;
   int _gpuTextureBytes = 256 << 20;
   int _gpuGeometryBytes = 256 << 20;
+  bool _gpuOverprintApproximation = false;
+
+  bool get gpuOverprintApproximation => _gpuOverprintApproximation;
 
   FlutterGpuTileRasterBackend get flutterGpuTileRasterBackend =>
       _flutterGpuTileRasterBackend ??= FlutterGpuTileRasterBackend(
         maxTextureBytes: _gpuTextureBytes,
         maxGeometryBytes: _gpuGeometryBytes,
+        allowOverprintApproximation: _gpuOverprintApproximation,
       );
 
   static const PdfCanvasTileRasterBackend _canvasTileRasterBackend =
@@ -205,6 +209,7 @@ class AppDevTools extends ChangeNotifier {
     _flutterGpuTileRasterBackend = FlutterGpuTileRasterBackend(
       maxTextureBytes: textureBytes,
       maxGeometryBytes: geometryBytes,
+      allowOverprintApproximation: _gpuOverprintApproximation,
     );
     // Unpinned texture ownership can go immediately. Active sessions keep
     // their leases until the viewer rebuild below disposes them.
@@ -219,6 +224,31 @@ class AppDevTools extends ChangeNotifier {
     addLog('devtools: GPU budgets → '
         '${textureBytes >> 20}MB textures, '
         '${geometryBytes >> 20}MB geometry');
+  }
+
+  /// Enables the deliberately inexact source-over approximation for
+  /// non-black overprint paints. Exact Canvas fallback remains the default.
+  /// Replacing the backend retires all scene sessions so a toggle can never
+  /// leave already-compiled scenes using the previous correctness policy.
+  void setGpuOverprintApproximation(bool enabled) {
+    if (_gpuOverprintApproximation == enabled) return;
+    final previous = _flutterGpuTileRasterBackend;
+    _gpuOverprintApproximation = enabled;
+    _flutterGpuTileRasterBackend = FlutterGpuTileRasterBackend(
+      maxTextureBytes: _gpuTextureBytes,
+      maxGeometryBytes: _gpuGeometryBytes,
+      allowOverprintApproximation: enabled,
+    );
+    previous?.clearImageCache();
+    if (tileRasterBackendMode.value == TileRasterBackendMode.flutterGpu) {
+      if (PdfPageView.tileStoreDetail) {
+        (PdfPageView.debugTileStoreOverride ?? PdfTileStore.instanceOrNull)
+            ?.invalidate();
+      }
+      tileRasterBackendRevision.value++;
+    }
+    addLog('devtools: GPU non-black overprint approximation '
+        '${enabled ? 'ON' : 'off (exact Canvas fallback)'}');
   }
 
   /// Releases reusable GPU image-cache ownership. Active scene leases remain
@@ -598,6 +628,9 @@ class AppDevTools extends ChangeNotifier {
         maxTextureBytes: textureBytes,
         maxGeometryBytes: geometryBytes,
       );
+      if (map['gpuOverprintApproximation'] case final bool enabled) {
+        setGpuOverprintApproximation(enabled);
+      }
       if (map['tileRasterBackend'] case final String mode) {
         final restored = TileRasterBackendMode.values
             .where((value) => value.name == mode)
@@ -670,6 +703,7 @@ class AppDevTools extends ChangeNotifier {
           'tileRasterBackend': tileRasterBackendMode.value.name,
           'gpuTextureBytes': flutterGpuTileRasterBackend.maxTextureBytes,
           'gpuGeometryBytes': flutterGpuTileRasterBackend.maxGeometryBytes,
+          'gpuOverprintApproximation': _gpuOverprintApproximation,
           'tileBorders': pdfDebugPaintDetailBounds.value,
           'renderWindow': pdfDebugShowRenderWindow.value,
           'perfOverlay': showPerformanceOverlay.value,

--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -287,6 +287,7 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
         'observedOutcome': _tileBackendOutcome(),
         'maxTextureBytes': _tools.flutterGpuTileRasterBackend.maxTextureBytes,
         'maxGeometryBytes': _tools.flutterGpuTileRasterBackend.maxGeometryBytes,
+        'overprintApproximation': _tools.gpuOverprintApproximation,
         'stats': _tools.flutterGpuTileRasterBackend.stats.toJson(),
       },
       if (store != null)
@@ -1197,6 +1198,20 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
           choices: _gpuBudgets,
           onChanged: (value) => _setGpuBudget(geometryBytes: value),
         ),
+        _helpSwitch(
+          theme,
+          key: const ValueKey('devtools-gpu-overprint-approximation'),
+          title: 'Approximate non-black overprint',
+          help: 'Experimental and intentionally inexact. Uses source-over for '
+              'non-black overprint so more CAD pages can stay on flutter_gpu. '
+              'Off keeps the exact Canvas fallback and is the default.',
+          value: _tools.gpuOverprintApproximation,
+          onChanged: (value) {
+            _tools.setGpuOverprintApproximation(value);
+            _persist();
+            setState(() {});
+          },
+        ),
         _kv(
           theme,
           'GPU sessions',
@@ -1228,6 +1243,16 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
               '${_averageMs(stats.compileMicros, stats.scenesCompiled)} avg',
           help: 'One-time retained-scene tessellation, buffer creation, and '
               'image upload. It should grow per scene, not per tile or LoD.',
+        ),
+        _kv(
+          theme,
+          'Exact clip masks',
+          '${stats.clipPathsCompiled} paths · '
+              '${stats.clipMaskRebuilds} tile rebuilds',
+          help: 'Non-rectangular PDF clip paths compiled once with the scene '
+              'and exact stencil intersections rebuilt when selected commands '
+              'change clip stack. Rectangular clips stay on the cheaper '
+              'hardware-scissor route.',
         ),
         _kv(
           theme,

--- a/app/test/devtools_options_test.dart
+++ b/app/test/devtools_options_test.dart
@@ -30,6 +30,7 @@ void main() {
       maxTextureBytes: 256 << 20,
       maxGeometryBytes: 256 << 20,
     );
+    AppDevTools.instance.setGpuOverprintApproximation(false);
     AppDevTools.instance
         .setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
     AppDevTools.instance.flutterGpuTileRasterBackend.stats.reset();
@@ -47,6 +48,7 @@ void main() {
       maxTextureBytes: 1 << 30,
       maxGeometryBytes: 512 << 20,
     );
+    tools.setGpuOverprintApproximation(true);
     pdfDebugPaintDetailBounds.value = true;
     pdfDebugShowRenderWindow.value = true;
     pdfRenderWorkerPoolSize = 5;
@@ -63,6 +65,7 @@ void main() {
       maxTextureBytes: 256 << 20,
       maxGeometryBytes: 256 << 20,
     );
+    tools.setGpuOverprintApproximation(false);
     pdfDebugPaintDetailBounds.value = false;
     pdfDebugShowRenderWindow.value = false;
     pdfRenderWorkerPoolSize = 3;
@@ -73,6 +76,9 @@ void main() {
     expect(tools.tileRasterBackendMode.value, TileRasterBackendMode.flutterGpu);
     expect(tools.flutterGpuTileRasterBackend.maxTextureBytes, 1 << 30);
     expect(tools.flutterGpuTileRasterBackend.maxGeometryBytes, 512 << 20);
+    expect(tools.gpuOverprintApproximation, isTrue);
+    expect(
+        tools.flutterGpuTileRasterBackend.allowOverprintApproximation, isTrue);
     expect(PdfPageView.tileStoreDetail, isTrue);
     expect(PdfPageView.debugTileStoreOverride!.batchRasters, isTrue);
     expect(pdfDebugPaintDetailBounds.value, isTrue);

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -32,6 +32,7 @@ void main() {
       maxTextureBytes: 256 << 20,
       maxGeometryBytes: 256 << 20,
     );
+    AppDevTools.instance.setGpuOverprintApproximation(false);
     AppDevTools.instance
         .setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
     AppDevTools.instance.flutterGpuTileRasterBackend.stats.reset();
@@ -57,6 +58,7 @@ void main() {
       maxTextureBytes: 256 << 20,
       maxGeometryBytes: 256 << 20,
     );
+    AppDevTools.instance.setGpuOverprintApproximation(false);
     AppDevTools.instance
         .setTileRasterBackendMode(TileRasterBackendMode.flutterGpu);
     AppDevTools.instance.flutterGpuTileRasterBackend.stats.reset();
@@ -144,6 +146,23 @@ void main() {
       tester.widget<PdfViewer>(find.byType(PdfViewer)).tileRasterBackend,
       same(tools.flutterGpuTileRasterBackend),
       reason: 'budget changes replace the selected backend live',
+    );
+
+    final budgetedBackend = tools.flutterGpuTileRasterBackend;
+    final overprint =
+        find.byKey(const ValueKey('devtools-gpu-overprint-approximation'));
+    await tester.ensureVisible(overprint);
+    await tester.pump();
+    await tester.tap(overprint);
+    await tester.pumpAndSettle();
+    expect(tools.gpuOverprintApproximation, isTrue);
+    expect(tools.flutterGpuTileRasterBackend, isNot(same(budgetedBackend)));
+    expect(
+        tools.flutterGpuTileRasterBackend.allowOverprintApproximation, isTrue);
+    expect(
+      tester.widget<PdfViewer>(find.byType(PdfViewer)).tileRasterBackend,
+      same(tools.flutterGpuTileRasterBackend),
+      reason: 'correctness experiment changes retire live GPU sessions',
     );
   });
 

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Keep off-screen neighbour pages at fit-resolution base rasters during deep
+  zoom, promoting them only when they enter the viewport, so navigation no
+  longer allocates high-zoom full-page rasters that are immediately replaced.
+- Require 750 ms of continuous viewer idle time before whole-document
+  thumbnail warming starts or resumes, and restart that quiet window when
+  navigation changes focus.
+- Let optional tile backends expose their latest session rejection reason and
+  include requested backend, actual route, reason, and command count in perf
+  logs.
 - Add an optional persistent tier for 512 px LoD tiles. Disk reads race live
   rendering, writes happen after display admission, cache keys include the
   complete page visual identity, and the existing byte-budgeted memory LRU and

--- a/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
@@ -44,10 +44,22 @@ import '../raster_cache.dart';
 /// document never adds latency to the visible page. See the panels'
 /// `_warmRender`.
 class PdfThumbnailCache {
-  PdfThumbnailCache({this.capacity = 256});
+  PdfThumbnailCache({
+    this.capacity = 256,
+    this.warmIdleDelay = const Duration(milliseconds: 750),
+  });
 
   /// Maximum number of cached rasters (LRU eviction past it).
   final int capacity;
+
+  /// Continuous quiet time required before whole-document warming starts.
+  ///
+  /// This matches the page-raster warm policy's default: it is longer than the
+  /// viewer's 150-250 ms navigation/zoom settle windows, so a thumbnail replay
+  /// cannot claim the platform thread in the gap between navigation dispatch
+  /// and the destination page's heavy render. Foreground/visible thumbnail
+  /// requests do not wait for this delay.
+  final Duration warmIdleDelay;
 
   /// Optional persistent backing for thumbnails, bound to the open document
   /// (see [PdfRasterCache]). The thumbnail surfaces set this each build; when
@@ -98,7 +110,11 @@ class PdfThumbnailCache {
     if (_disposed) return;
     _gateBusy = isBusy;
     if (identical(_gateActivity, activity)) {
-      _onGateActivity();
+      // Panels bind from build. Refreshing the same callback must not look like
+      // fresh viewer activity and perpetually restart the quiet window as
+      // thumbnails themselves repaint.
+      _scheduleDrain();
+      _scheduleWarmAfterIdle();
       return;
     }
     _gateActivity?.removeListener(_onGateActivity);
@@ -113,7 +129,7 @@ class PdfThumbnailCache {
   /// stealing a scrolling frame.
   void _onGateActivity() {
     _scheduleDrain();
-    _kickWarm();
+    _scheduleWarmAfterIdle(restart: true);
   }
 
   /// The page index nearest the viewport. Foreground tasks (and the warm
@@ -123,7 +139,8 @@ class PdfThumbnailCache {
     if (_focus == index || _disposed) return;
     _focus = index;
     _scheduleDrain();
-    _kickWarm(); // a moved viewport may re-aim the warm pass too
+    _scheduleWarmAfterIdle(
+        restart: true); // navigation re-aims and restarts quiet time
   }
 
   int get focus => _focus;
@@ -209,7 +226,7 @@ class PdfThumbnailCache {
       if (_pending.isNotEmpty && !_viewerBusy) _scheduleDrain();
       // a tile that just finished may have been the last thing holding the
       // warm pass back
-      _kickWarm();
+      _scheduleWarmAfterIdle();
     }
   }
 
@@ -224,6 +241,8 @@ class PdfThumbnailCache {
   Future<void> Function(int page)? _warmRenderer;
   final Set<int> _warmAttempted = {};
   bool _warming = false;
+  Timer? _warmIdleTimer;
+  bool _warmRestartPending = false;
 
   /// Arms (or refreshes) the background warm of every page into the cache for
   /// [owner], rendering through [renderPage]. Cheap to call from every build:
@@ -239,14 +258,14 @@ class PdfThumbnailCache {
     _warmOwner = owner;
     _warmRenderer = renderPage;
     if (signature == _warmSignature && pageCount == _warmCount) {
-      _kickWarm(); // same pass; just make sure the loop is running
+      _scheduleWarmAfterIdle();
       return;
     }
     _warmSignature = signature;
     _warmCount = pageCount;
     _warmAttempted.clear();
     PdfPerfLog.log('thumbnail warm armed pages=$pageCount key=$signature');
-    _kickWarm();
+    _scheduleWarmAfterIdle(restart: true);
   }
 
   /// Stops [owner]'s background warm (its panel was disposed, or the session
@@ -256,6 +275,9 @@ class PdfThumbnailCache {
     bindForegroundGate(null, null);
     _warmOwner = null;
     _warmRenderer = null;
+    _warmIdleTimer?.cancel();
+    _warmIdleTimer = null;
+    _warmRestartPending = false;
     _warmSignature = null;
     _warmCount = 0;
     _warmAttempted.clear();
@@ -264,6 +286,36 @@ class PdfThumbnailCache {
   /// Whether the warm is currently standing aside, so the yield is logged on
   /// the transition into that state rather than once per activity ping.
   bool _warmYielding = false;
+
+  void _scheduleWarmAfterIdle({bool restart = false}) {
+    if (_warming) {
+      if (restart) _warmRestartPending = true;
+      return;
+    }
+    if (!restart && _warmIdleTimer != null) return;
+    _warmIdleTimer?.cancel();
+    _warmIdleTimer = null;
+    if (_disposed || _warmRenderer == null) return;
+    if (_foregroundBusy) {
+      _logWarmYield('foreground busy '
+          '(pending=${_pending.length} draining=$_draining)');
+      return;
+    }
+    if (_viewerBusy) {
+      _logWarmYield('viewer rendering');
+      return;
+    }
+    void start() {
+      _warmIdleTimer = null;
+      _kickWarm();
+    }
+
+    if (warmIdleDelay == Duration.zero) {
+      scheduleMicrotask(start);
+    } else {
+      _warmIdleTimer = Timer(warmIdleDelay, start);
+    }
+  }
 
   void _kickWarm() {
     if (_warming || _disposed || _warmRenderer == null) return;
@@ -336,9 +388,13 @@ class PdfThumbnailCache {
         // breathe between heavy pages so input and animations run, and a tile
         // that arrived meanwhile is picked up before the next warm page
         await SchedulerBinding.instance.endOfFrame;
+        if (_warmRestartPending) return;
       }
     } finally {
+      final restart = _warmRestartPending;
+      _warmRestartPending = false;
       _warming = false;
+      if (restart) _scheduleWarmAfterIdle(restart: true);
     }
   }
 
@@ -385,6 +441,9 @@ class PdfThumbnailCache {
     _disposed = true;
     _pending.clear();
     _warmRenderer = null;
+    _warmIdleTimer?.cancel();
+    _warmIdleTimer = null;
+    _warmRestartPending = false;
     _gateActivity?.removeListener(_onGateActivity);
     _gateActivity = null;
     _gateBusy = null;

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -1048,7 +1048,19 @@ class _PdfPageViewState extends State<PdfPageView>
         scale: scale,
       );
 
-  double _effectiveRatio() => _effectiveRatioAt(widget.scale);
+  /// Scale used by the whole-page base raster.
+  ///
+  /// The InteractiveViewer's live zoom is global, so lazy-list neighbours also
+  /// receive it even when no pixel of those pages is visible. Rasterizing them
+  /// at that zoom produced 60-70 MB full-page images that were immediately
+  /// replaced by fit rasters as navigation moved on. Off-screen pages instead
+  /// keep (or first build) the fit-resolution safety net; once a page overlaps
+  /// the viewport its ordinary promotion path requests the sharp base and
+  /// region/tile detail.
+  double get _baseRasterScale =>
+      widget.onScreen ? widget.scale : math.min(1.0, widget.scale);
+
+  double _effectiveRatio() => _effectiveRatioAt(_baseRasterScale);
 
   // --- Live-raster budget (#405) --------------------------------------------
 
@@ -2020,7 +2032,8 @@ class _PdfPageViewState extends State<PdfPageView>
     // fit scale. Once zoomed, however, the lightweight worker recording also
     // bootstraps the visible-region request that can beat a slow full-page
     // image decode. Ask for it even when soft preview pixels already exist.
-    final needsRegionBootstrap = widget.scale > 1.05 &&
+    final needsRegionBootstrap = widget.onScreen &&
+        widget.scale > 1.05 &&
         _scene == null &&
         (widget.renderWorker?.isActive ?? false);
     if (firstInterpret && (!previewFresh || needsRegionBootstrap)) {
@@ -3187,7 +3200,20 @@ class _PdfPageViewState extends State<PdfPageView>
         }
         final fallback =
             const PdfCanvasTileRasterBackend().createSession(scene);
-        if (preferred == null) return fallback;
+        if (preferred == null) {
+          PdfPerfLog.log(
+            'tile backend session page=${widget.previewIndex} '
+            'requested=${label()} route=canvas '
+            'reason=${backend.lastSessionRejection ?? 'backend declined'} '
+            'commands=${scene.commands.length}',
+          );
+          return fallback;
+        }
+        PdfPerfLog.log(
+          'tile backend session page=${widget.previewIndex} '
+          'requested=${label()} route=${preferred == fallback ? 'canvas' : label()} '
+          'commands=${scene.commands.length}',
+        );
         // Skip the adapter only for the stock implementation itself. A
         // subclass may override createSession and must receive the same
         // failure and output-validation guarantees as every other backend.

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -24,6 +24,14 @@ abstract class PdfTileRasterBackend {
   /// A short diagnostics label, such as `canvas` or `flutter_gpu`.
   String get debugLabel;
 
+  /// Why the most recent [createSession] call returned null, when known.
+  ///
+  /// This deliberately describes the latest call rather than lifetime state:
+  /// page-level perf logs can name the exact reason a requested backend routed
+  /// a scene to Canvas without depending on that backend's diagnostics type.
+  /// Implementations that do not expose a reason may leave this null.
+  String? get lastSessionRejection => null;
+
   /// Creates a lightweight owner for resources retained across tile renders.
   ///
   /// This is called lazily, when the tile path first needs a slab—not while

--- a/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
@@ -68,9 +68,10 @@ void main() {
   // thread - the one the visible page's build needs, and the one a worker
   // priority cannot reach. The gate is what makes it stand down for the viewer.
   group('PdfThumbnailCache foreground gate', () {
-    testWidgets('the warm stands down while the viewer renders, and resumes '
+    testWidgets(
+        'the warm stands down while the viewer renders, and resumes '
         'when it goes idle', (tester) async {
-      final cache = PdfThumbnailCache();
+      final cache = PdfThumbnailCache(warmIdleDelay: Duration.zero);
       addTearDown(cache.dispose);
       final activity = _TestActivity();
       var viewerBusy = true;
@@ -134,7 +135,7 @@ void main() {
         PdfPerfLog.sink = null;
       });
 
-      final cache = PdfThumbnailCache();
+      final cache = PdfThumbnailCache(warmIdleDelay: Duration.zero);
       addTearDown(cache.dispose);
       final activity = _TestActivity();
       var viewerBusy = true;
@@ -175,7 +176,7 @@ void main() {
     });
 
     testWidgets('an unbound cache warms exactly as before', (tester) async {
-      final cache = PdfThumbnailCache();
+      final cache = PdfThumbnailCache(warmIdleDelay: Duration.zero);
       addTearDown(cache.dispose);
       final warmed = <int>[];
       cache.setWarm(Object(), 2, 'k', (page) async => warmed.add(page));
@@ -186,7 +187,7 @@ void main() {
     });
 
     testWidgets('withdrawing the warm releases the gate', (tester) async {
-      final cache = PdfThumbnailCache();
+      final cache = PdfThumbnailCache(warmIdleDelay: Duration.zero);
       addTearDown(cache.dispose);
       final activity = _TestActivity();
       final owner = Object();
@@ -196,6 +197,27 @@ void main() {
       cache.clearWarm(owner);
       expect(activity.listeners, 0,
           reason: 'a disposed panel must not keep the viewer subscribed');
+    });
+
+    testWidgets('navigation focus restarts the thumbnail warm quiet period',
+        (tester) async {
+      final cache =
+          PdfThumbnailCache(warmIdleDelay: const Duration(milliseconds: 750));
+      addTearDown(cache.dispose);
+      final warmed = <int>[];
+      cache.setWarm(Object(), 3, 'k', (page) async => warmed.add(page));
+
+      await tester.pump(const Duration(milliseconds: 500));
+      cache.focus = 2;
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(warmed, isEmpty,
+          reason: 'the destination page still owns the platform thread');
+
+      await tester.pump(const Duration(milliseconds: 251));
+      for (var i = 0; i < 6; i++) {
+        await tester.pump();
+      }
+      expect(warmed, [2, 1, 0]);
     });
   });
 
@@ -273,14 +295,15 @@ void main() {
         isTrue,
         reason: 'page 12 should be off-screen / unbuilt',
       );
-
       // drive the serialized async render queue (rasterization needs runAsync)
+      // and advance fake time so the idle window starts after the foreground
+      // tiles have drained, just as it does between frames in the real app.
       for (var i = 0;
           i < 300 && PdfThumbnailSidebar.debugRasterizations < 12;
           i++) {
         await tester.runAsync(
             () => Future<void>.delayed(const Duration(milliseconds: 10)));
-        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
       }
       // every page rendered exactly once, even the off-screen ones
       expect(PdfThumbnailSidebar.debugRasterizations, 12);
@@ -360,13 +383,12 @@ void main() {
         ),
       ));
       expect(viewer.isPageRenderBusy, isFalse);
-
       for (var i = 0;
           i < 300 && PdfThumbnailSidebar.debugRasterizations < 4;
           i++) {
         await tester.runAsync(
             () => Future<void>.delayed(const Duration(milliseconds: 10)));
-        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 10));
       }
       expect(PdfThumbnailSidebar.debugRasterizations, 4);
     });

--- a/packages/dart_pdf_editor/test/pdf_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_page_view_test.dart
@@ -51,6 +51,36 @@ void main() {
     expect(zoomed.width, 612 * 3);
   });
 
+  testWidgets('off-screen neighbours stay at fit raster resolution',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final page = PdfDocument.open(buildClassicPdf()).page(0);
+    Widget at({required bool onScreen}) => Center(
+          child: SizedBox(
+            width: 612,
+            child: PdfPageView(
+              page: page,
+              scale: 4,
+              onScreen: onScreen,
+              focusDistance: onScreen ? 0 : 1,
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(at(onScreen: false));
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image!.width, 612,
+        reason: 'global zoom must not allocate a sharp off-screen page');
+
+    await tester.pumpWidget(at(onScreen: true));
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    expect(tester.widget<RawImage>(find.byType(RawImage)).image!.width, 2448,
+        reason: 'entering the viewport promotes the page normally');
+  });
+
   testWidgets(
       'pages denser than retainedZoomReplayMaxCommands zoom via the '
       'cached-picture fallback', (tester) async {
@@ -121,7 +151,8 @@ void main() {
     await tester.pumpWidget(at(3));
     await tester.runAsync(() => Future<void>.delayed(Duration.zero));
     await tester.pump();
-    expect(tester.widget<RawImage>(find.byType(RawImage)).image!.width, 612 * 3);
+    expect(
+        tester.widget<RawImage>(find.byType(RawImage)).image!.width, 612 * 3);
   });
 
   testWidgets('raster resolution follows the on-screen width', (tester) async {

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -177,12 +177,17 @@ void main() {
     final store =
         PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
     final backend = _RecordingTileRasterBackend(failCreation: true);
+    final logs = <String>[];
+    PdfPerfLog.enabled = true;
+    PdfPerfLog.sink = logs.add;
     PdfPageView.tileStoreDetail = true;
     PdfPageView.debugTileStoreOverride = store;
     addTearDown(() {
       PdfPageView.tileStoreDetail = false;
       PdfPageView.debugTileStoreOverride = null;
       store.dispose();
+      PdfPerfLog.enabled = false;
+      PdfPerfLog.sink = null;
     });
 
     final doc = PdfDocument.open(buildClassicPdf());
@@ -213,6 +218,12 @@ void main() {
     expect(backend.sessionCreates, 1);
     expect(backend.rasterizations, 0);
     expect(store.tileCount, greaterThan(0));
+    expect(
+      logs,
+      contains(contains(
+          'requested=recording route=canvas reason=test unsupported clip')),
+      reason: 'field traces must explain why the requested backend declined',
+    );
   });
 
   testWidgets('tile path composites deep-zoom tiles instead of the patch',
@@ -220,7 +231,8 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    final store = PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final store =
+        PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
     final oldRegionLimit = PdfRetainedScene.spatialRegionReplayMaxCommands;
     // Force even this small fixture through the heavy/grid index gate. This
     // reproduces the field-trace failure where _useTilePath stayed
@@ -249,8 +261,8 @@ void main() {
     );
     // Let the base render, the tile-geometry refresh, and the tile rasters land.
     for (var i = 0; i < 4; i++) {
-      await tester
-          .runAsync(() => Future<void>.delayed(const Duration(milliseconds: 60)));
+      await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 60)));
       await tester.pump();
     }
 
@@ -273,7 +285,8 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    final store = PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final store =
+        PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
     final oldRegionLimit = PdfRetainedScene.spatialRegionReplayMaxCommands;
     PdfRetainedScene.spatialRegionReplayMaxCommands = 0;
     PdfPageView.tileStoreDetail = true;
@@ -408,6 +421,10 @@ class _RecordingTileRasterBackend extends PdfCanvasTileRasterBackend {
 
   @override
   String get debugLabel => 'recording';
+
+  @override
+  String? get lastSessionRejection =>
+      failCreation ? 'test unsupported clip' : null;
 
   @override
   PdfTileRasterSession createSession(PdfRetainedScene scene) {

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Render ordinary non-rectangular PDF clip stacks exactly with retained
+  stencil geometry, including nested even-odd/nonzero clips and save/restore;
+  rectangular clips keep the cheaper scissor path.
+- Report compiled clip paths and per-tile clip-mask rebuilds in backend stats.
+
 ## 0.1.0
 
 - Add an opt-in Impeller `flutter_gpu` backend for retained-scene LoD tiles.

--- a/packages/dart_pdf_editor_flutter_gpu/README.md
+++ b/packages/dart_pdf_editor_flutter_gpu/README.md
@@ -49,12 +49,15 @@ PDF features return to the Canvas tile backend automatically. Web gets a
 compile-time stub and therefore preserves the all-platform host surface.
 
 The current exact subset is solid paths and strokes, embedded-outline text,
-decoded images/image masks, Gouraud meshes, normal blending, rectangular
-clips, and the common isolated single-image soft-mask group. That mask case
-keeps the base and mask as two GPU textures and combines them during tile
-replay; it never builds an eager full-size RGBA composite or reads pixels back
-to the CPU. Worker-retained RGBA uploads directly; locally platform-decoded
-images pay at most one readback before entering the shared texture cache. A
+decoded images/image masks, Gouraud meshes, normal blending, rectangular and
+arbitrary path clips, and the common isolated single-image soft-mask group.
+Rectangles use hardware scissors; other clip stacks compile once into retained
+stencil geometry and preserve nonzero/even-odd plus save/restore semantics. The
+mask case keeps the base and mask as two GPU textures and combines them during
+tile replay; it never builds an eager full-size RGBA composite or reads pixels
+back to the CPU. Worker-retained RGBA uploads directly; locally
+platform-decoded images pay at most one readback before entering the shared
+texture cache. A
 backend-wide byte-budgeted LRU preserves decoded texture identity
 across scenes, pages, workers, zoom levels, and LoDs.
 Pinned scene textures count toward the same ceiling; if no unpinned entry can
@@ -69,15 +72,17 @@ native finalizers; a scene that cannot lease enough geometry also falls back.
 tile route, runtime fallback reasons, scene compile and tile-submit time,
 spatially selected command counts, upload/readback paths, cache hits and
 evictions, budget fallbacks, retained bytes, and live resource leases.
+Clip diagnostics separately report paths compiled and tile-mask rebuilds.
 `backend.stats.toJson()` is suitable for benchmark artifacts. Keep the backend
 instance alive when comparing pages so those counters and cross-page caches
 describe the real workload rather than one page at a time.
 
 Pages with other transparency groups or soft masks, non-normal blends,
-gradients, tiling cells, unsafe overprint, non-rectangular clips,
-substituted/stroked text, hairlines, or missing image pixels are rejected as a
-whole rather than approximated. `allowOverprintApproximation` exists only for
-controlled benchmarks and defaults to false.
+gradients, tiling cells, unsafe overprint, complex clips nested inside the
+single-image soft-mask shortcut, substituted/stroked text, hairlines, or
+missing image pixels are rejected as a whole rather than approximated.
+`allowOverprintApproximation` exists only for controlled experiments and
+defaults to false.
 
 ## Persistent LoD tiles
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -24,9 +24,12 @@ import 'backend_stats.dart';
 ///
 /// The exact subset includes a common isolated single-image soft-mask group:
 /// content and mask stay as separate scene-lifetime textures and are combined
-/// by the tile shader. Other isolated groups, non-normal blend modes,
-/// non-rectangular clips, gradients, substituted/stroked text, tiling cells,
-/// unsafe overprint, or missing image pixels reject the whole scene.
+/// by the tile shader. Ordinary PDF clip paths are retained as exact stencil
+/// masks (with rectangular clips additionally using the hardware scissor).
+/// Other isolated groups, non-normal blend modes, complex clips *inside* the
+/// special soft-mask-image shortcut, gradients, substituted/stroked text,
+/// tiling cells, unsafe overprint, or missing image pixels reject the whole
+/// scene.
 /// dart_pdf_editor then permanently uses its Canvas session for that scene.
 class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   FlutterGpuTileRasterBackend({
@@ -69,6 +72,10 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   final FlutterGpuTileBackendStats stats;
   final _GpuImageCache _imageCache;
   final _GpuGeometryPool _geometryPool;
+  String? _lastSessionRejection;
+
+  @override
+  String? get lastSessionRejection => _lastSessionRejection;
 
   /// True when this build includes the native flutter_gpu implementation.
   ///
@@ -87,11 +94,13 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
 
   @override
   PdfTileRasterSession? createSession(PdfRetainedScene scene) {
+    _lastSessionRejection = null;
     try {
       final context = gpu.gpuContext;
       final unitBuild = _buildGpuUnits(scene.commands);
       final units = unitBuild.units;
       if (units == null) {
+        _lastSessionRejection = unitBuild.rejection;
         stats.lastRejection = unitBuild.rejection;
         stats.lastTileRoute = 'canvas-fallback';
         stats.sessionsRejected++;
@@ -100,6 +109,7 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
       final rejection =
           _unsupportedReason(scene, units, allowOverprintApproximation);
       if (rejection != null) {
+        _lastSessionRejection = rejection;
         stats.lastRejection = rejection;
         stats.lastTileRoute = 'canvas-fallback';
         stats.sessionsRejected++;
@@ -124,7 +134,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         geometryPool: _geometryPool,
       );
     } catch (error) {
-      stats.lastRejection = 'initialization failed: $error';
+      _lastSessionRejection = 'initialization failed: $error';
+      stats.lastRejection = _lastSessionRejection;
       stats.lastTileRoute = 'canvas-fallback';
       stats.sessionsRejected++;
       return null;
@@ -238,13 +249,35 @@ class _GpuUnit {
   final int commandIndex;
   final int endCommandIndex;
   final PdfRect bounds;
-  final PdfRect? clip;
+  final _GpuClipState clip;
   final PdfBlendMode blendMode;
   final bool fillOverprint;
   final bool strokeOverprint;
   final bool darken;
   final _SoftMaskImageSpec? composite;
 }
+
+/// One immutable graphics-state clip. Rectangles only narrow [scissor]; every
+/// other path adds a persistent [node] that is rebuilt into the stencil when
+/// the command stream changes clip state. Save/restore can therefore retain
+/// and recover the exact intersection without copying paths.
+class _GpuClipState {
+  const _GpuClipState(this.scissor, this.node, {this.empty = false});
+
+  final PdfRect? scissor;
+  final _GpuClipNode? node;
+  final bool empty;
+}
+
+class _GpuClipNode {
+  const _GpuClipNode(this.path, this.rule, this.previous);
+
+  final PdfPath path;
+  final PdfFillRule rule;
+  final _GpuClipNode? previous;
+}
+
+const _rootGpuClip = _GpuClipState(null, null);
 
 class _GpuUnitBuild {
   const _GpuUnitBuild(this.units, this.rejection);
@@ -256,7 +289,7 @@ class _CompositeCapture {
   _CompositeCapture(this.start, this.clip, this.blendMode, this.fillOverprint,
       this.strokeOverprint);
   final int start;
-  final PdfRect? clip;
+  final _GpuClipState clip;
   final PdfBlendMode blendMode;
   final bool fillOverprint;
   final bool strokeOverprint;
@@ -293,8 +326,8 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
     return const _GpuUnitBuild(null, 'retained scene exceeds GPU index cap');
   }
   final units = <_GpuUnit>[];
-  final saved = <(PdfRect?, PdfBlendMode, bool, bool)>[];
-  PdfRect? clip;
+  final saved = <(_GpuClipState, PdfBlendMode, bool, bool)>[];
+  var clip = _rootGpuClip;
   var blend = PdfBlendMode.normal;
   var fillOverprint = false;
   var strokeOverprint = false;
@@ -314,15 +347,8 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
         blend = state.$2;
         fillOverprint = state.$3;
         strokeOverprint = state.$4;
-      case PdfClipPathCommand(:final path):
-        if (!FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
-          return const _GpuUnitBuild(null, 'non-rectangular clip');
-        }
-        final bounds = pdfRenderPathBounds(path);
-        if (bounds == null) {
-          return const _GpuUnitBuild(null, 'empty rectangular clip');
-        }
-        clip = _pdfIntersection(clip, bounds);
+      case PdfClipPathCommand(:final path, :final rule):
+        clip = _pushGpuClip(clip, path, rule);
       case PdfSetBlendModeCommand(:final mode):
         blend = mode;
       case PdfSetOverprintCommand(:final fill, :final stroke):
@@ -343,7 +369,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
             commands,
             capture.start,
             i,
-            initialClip: capture.clip,
+            initialClip: capture.clip.scissor,
           );
           if (parsed.$1 == null) return _GpuUnitBuild(null, parsed.$2);
           final bounds = capture.bounds;
@@ -352,7 +378,7 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
               commandIndex: capture.start,
               endCommandIndex: i,
               bounds: _inflatePdf(bounds, 2),
-              clip: parsed.$1!.contentClip ?? capture.clip,
+              clip: _withGpuRectClip(capture.clip, parsed.$1!.contentClip),
               blendMode: capture.blendMode,
               fillOverprint: capture.fillOverprint,
               strokeOverprint: capture.strokeOverprint,
@@ -365,7 +391,10 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
       default:
         final bounds = pdfRenderCommandBounds(command);
         if (bounds == null) continue;
-        final clipped = _pdfIntersection(clip, bounds);
+        if (clip.empty) continue;
+        final clipped = clip.scissor == null
+            ? bounds
+            : _pdfIntersection(clip.scissor, bounds);
         if (clipped == null) continue;
         if (composite != null) {
           composite.bounds = _pdfUnion(composite.bounds, clipped);
@@ -391,6 +420,41 @@ _GpuUnitBuild _buildGpuUnits(List<PdfRenderCommand> commands) {
     return const _GpuUnitBuild(null, 'unterminated composite group');
   }
   return _GpuUnitBuild(List.unmodifiable(units), null);
+}
+
+_GpuClipState _pushGpuClip(
+    _GpuClipState current, PdfPath path, PdfFillRule rule) {
+  if (current.empty) return current;
+  final bounds = pdfRenderPathBounds(path);
+  if (bounds == null) {
+    return _GpuClipState(current.scissor, current.node, empty: true);
+  }
+  final narrowed = current.scissor == null
+      ? bounds
+      : _pdfIntersection(current.scissor, bounds);
+  if (narrowed == null) {
+    return _GpuClipState(current.scissor, current.node, empty: true);
+  }
+  if (FlutterGpuTileRasterBackend._isAxisAlignedRect(path)) {
+    return _GpuClipState(narrowed, current.node);
+  }
+  return _GpuClipState(
+    narrowed,
+    _GpuClipNode(path, rule, current.node),
+  );
+}
+
+/// Adds a rectangle already discovered inside the single-image soft-mask
+/// shortcut to the outer graphics-state clip. The outer arbitrary path stays
+/// in [state.node] and is applied by the tile pass; the inner rectangle remains
+/// a cheap exact scissor.
+_GpuClipState _withGpuRectClip(_GpuClipState state, PdfRect? rect) {
+  if (rect == null || state.empty) return state;
+  final narrowed =
+      state.scissor == null ? rect : _pdfIntersection(state.scissor, rect);
+  return narrowed == null
+      ? _GpuClipState(state.scissor, state.node, empty: true)
+      : _GpuClipState(narrowed, state.node);
 }
 
 (_SoftMaskImageSpec?, String?) _parseSoftMaskImage(
@@ -697,6 +761,7 @@ class _CompiledScene {
     required this.pageToRaster,
     required this.paper,
     required this.draws,
+    required this.clipDraws,
     required this.stats,
     required this.imageCache,
     required this.textureLeases,
@@ -714,10 +779,18 @@ class _CompiledScene {
   ) async {
     final clock = Stopwatch()..start();
     final draws = <int, _GpuDraw>{};
+    final clipDraws = Map<_GpuClipNode, _GpuClipDraw>.identity();
     final textureLeases = <_GpuImageTexture>[];
     final geometry = _GpuGeometryArena(context, stats, geometryPool);
     try {
       for (final unit in units) {
+        for (_GpuClipNode? node = unit.clip.node;
+            node != null;
+            node = node.previous) {
+          final clipNode = node;
+          clipDraws.putIfAbsent(
+              clipNode, () => _compileClip(geometry, clipNode));
+        }
         final _GpuDraw? draw;
         if (unit.composite == null) {
           final pending = _compileCommand(
@@ -756,6 +829,7 @@ class _CompiledScene {
         ),
         paper: paper,
         draws: draws,
+        clipDraws: clipDraws,
         stats: stats,
         imageCache: imageCache,
         textureLeases: textureLeases,
@@ -764,6 +838,7 @@ class _CompiledScene {
       );
       stats
         ..scenesCompiled += 1
+        ..clipPathsCompiled += clipDraws.length
         ..compileMicros += clock.elapsedMicroseconds;
       return result;
     } catch (_) {
@@ -777,6 +852,7 @@ class _CompiledScene {
   final PdfMatrix pageToRaster;
   final _SolidDraw paper;
   final Map<int, _GpuDraw> draws;
+  final Map<_GpuClipNode, _GpuClipDraw> clipDraws;
   final FlutterGpuTileBackendStats stats;
   final _GpuImageCache imageCache;
   final List<_GpuImageTexture> textureLeases;
@@ -893,9 +969,11 @@ class _CompiledScene {
       pixelRatio: pixelRatio,
       width: width,
       height: height,
+      clipDraws: clipDraws,
+      stencilClear: paper.vertices,
     );
     encoder
-      ..setClip(null)
+      ..setClip(_rootGpuClip)
       ..solid(paper.vertices);
     for (final unit in selected) {
       final draw = draws[unit.commandIndex];
@@ -903,6 +981,7 @@ class _CompiledScene {
       encoder.setClip(unit.clip);
       draw.encode(encoder);
     }
+    stats.clipMaskRebuilds += encoder.clipMaskRebuilds;
     final submit = Stopwatch()..start();
     _inFlight++;
     try {
@@ -945,6 +1024,19 @@ class _CompiledScene {
     ]);
     return ByteData.sublistView(m);
   }
+}
+
+_GpuClipDraw _compileClip(_GpuGeometryArena geometry, _GpuClipNode node) {
+  final subpaths = flattenPath(node.path, PdfMatrix.identity, tolerance: 0.01);
+  final parts = _stencilGeometry(geometry, subpaths);
+  if (parts == null) {
+    throw StateError('empty non-rectangular clip');
+  }
+  return _GpuClipDraw(
+    parts.$1,
+    _coverGeometry(geometry, parts.$2, const [0, 0, 0, 0]),
+    node.rule,
+  );
 }
 
 _SolidDraw _paperDraw(_GpuGeometryArena geometry, PdfRetainedScene scene) {
@@ -1362,8 +1454,27 @@ _StencilDraw? _stencilDraw(
   PdfFillRule rule,
   bool union,
 ) {
+  if (alpha <= 0) return null;
+  final parts = _stencilGeometry(geometry, subpaths);
+  if (parts == null) return null;
+  final fanBuffer = parts.$1;
+  final a = alpha.clamp(0.0, 1.0);
+  final rgba = _premul(color, a);
+  return _StencilDraw(
+    fanBuffer,
+    _coverGeometry(geometry, parts.$2, rgba),
+    rule,
+    union,
+  );
+}
+
+/// Compiles the shared fan + bounds cover used by both painted paths and clip
+/// paths. The fan is intentionally the same winding/parity representation for
+/// both, so clipping cannot disagree with a fill of the same PDF path.
+(_GpuBuffer, FlatBounds)? _stencilGeometry(
+    _GpuGeometryArena geometry, List<FlatSubpath> subpaths) {
   final bounds = FlatBounds.of(subpaths);
-  if (bounds == null || alpha <= 0) return null;
+  if (bounds == null) return null;
   final fan = FloatBuilder(1024);
   for (final sub in subpaths) {
     final p = sub.points;
@@ -1378,8 +1489,11 @@ _StencilDraw? _stencilDraw(
     }
   }
   if (fan.isEmpty) return null;
-  final a = alpha.clamp(0.0, 1.0);
-  final rgba = _premul(color, a);
+  return (geometry.add(fan.bytes, fan.length ~/ 2), bounds);
+}
+
+_GpuBuffer _coverGeometry(
+    _GpuGeometryArena geometry, FlatBounds bounds, List<double> rgba) {
   final cover = FloatBuilder(36);
   for (final (x, y) in <(double, double)>[
     (bounds.left, bounds.bottom),
@@ -1391,12 +1505,7 @@ _StencilDraw? _stencilDraw(
   ]) {
     cover.add6(x, y, rgba[0], rgba[1], rgba[2], rgba[3]);
   }
-  return _StencilDraw(
-    geometry.add(fan.bytes, fan.length ~/ 2),
-    geometry.add(cover.bytes, 6),
-    rule,
-    union,
-  );
+  return geometry.add(cover.bytes, 6);
 }
 
 List<double> _premul(PdfColor color, double alpha) => [
@@ -1580,6 +1689,14 @@ class _StencilDraw implements _GpuDraw {
       encoder.stencil(fan, cover, rule: rule, union: union);
 }
 
+class _GpuClipDraw {
+  const _GpuClipDraw(this.fan, this.cover, this.rule);
+
+  final _GpuBuffer fan;
+  final _GpuBuffer cover;
+  final PdfFillRule rule;
+}
+
 class _TextureDraw implements _GpuDraw {
   const _TextureDraw(this.vertices, this.texture, this.info);
   final _GpuBuffer vertices;
@@ -1613,6 +1730,8 @@ class _GpuEncoder {
     required this.pixelRatio,
     required this.width,
     required this.height,
+    required this.clipDraws,
+    required this.stencilClear,
   });
 
   final gpu.RenderPass pass;
@@ -1623,6 +1742,21 @@ class _GpuEncoder {
   final double pixelRatio;
   final int width;
   final int height;
+  final Map<_GpuClipNode, _GpuClipDraw> clipDraws;
+  final _GpuBuffer stencilClear;
+
+  // The upper two stencil bits hold alternating clip intersections. The lower
+  // six hold temporary winding/parity values for clip construction and normal
+  // path fills. Alternating bits let an intersection be built without reading
+  // and writing the same bit in one pass.
+  static const _clipBitA = 0x80;
+  static const _clipBitB = 0x40;
+  static const _pathMask = 0x3f;
+  static const _allStencilBits = 0xff;
+
+  _GpuClipState? _clipState;
+  int _activeClipBit = 0;
+  int clipMaskRebuilds = 0;
 
   static final _srcOver = gpu.ColorBlendEquation(
     sourceColorBlendFactor: gpu.BlendFactor.one,
@@ -1637,18 +1771,20 @@ class _GpuEncoder {
     destinationAlphaBlendFactor: gpu.BlendFactor.one,
   );
 
-  void setClip(PdfRect? clip) {
+  void setClip(_GpuClipState clip) {
+    if (identical(_clipState, clip)) return;
     var target = Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble());
-    if (clip != null) {
+    final scissor = clip.scissor;
+    if (scissor != null) {
       final points = <Offset>[
-        Offset(pageToRaster.transformX(clip.left, clip.bottom),
-            pageToRaster.transformY(clip.left, clip.bottom)),
-        Offset(pageToRaster.transformX(clip.right, clip.bottom),
-            pageToRaster.transformY(clip.right, clip.bottom)),
-        Offset(pageToRaster.transformX(clip.right, clip.top),
-            pageToRaster.transformY(clip.right, clip.top)),
-        Offset(pageToRaster.transformX(clip.left, clip.top),
-            pageToRaster.transformY(clip.left, clip.top)),
+        Offset(pageToRaster.transformX(scissor.left, scissor.bottom),
+            pageToRaster.transformY(scissor.left, scissor.bottom)),
+        Offset(pageToRaster.transformX(scissor.right, scissor.bottom),
+            pageToRaster.transformY(scissor.right, scissor.bottom)),
+        Offset(pageToRaster.transformX(scissor.right, scissor.top),
+            pageToRaster.transformY(scissor.right, scissor.top)),
+        Offset(pageToRaster.transformX(scissor.left, scissor.top),
+            pageToRaster.transformY(scissor.left, scissor.top)),
       ];
       final left = points.map((p) => p.dx).reduce((a, b) => a < b ? a : b);
       final right = points.map((p) => p.dx).reduce((a, b) => a > b ? a : b);
@@ -1671,6 +1807,50 @@ class _GpuEncoder {
               target.top.floor().clamp(0, height))
           .clamp(0, height),
     ));
+    _clipState = clip;
+    _activeClipBit = 0;
+    final leaf = clip.node;
+    if (leaf == null || clip.empty || target.isEmpty) return;
+    clipMaskRebuilds++;
+
+    // A restored clip can be broader than the state used by the preceding
+    // draw. Rebuild from the persistent root rather than trying to preserve an
+    // ancestor bit whose alternating slot may since have been reused.
+    _clearStencil(_allStencilBits);
+    final chain = <_GpuClipNode>[];
+    for (_GpuClipNode? node = leaf; node != null; node = node.previous) {
+      chain.add(node);
+    }
+    for (final node in chain.reversed) {
+      final nextBit = _activeClipBit == _clipBitA ? _clipBitB : _clipBitA;
+      _clearStencil(_pathMask | nextBit);
+      final draw = clipDraws[node]!;
+      _accumulateStencil(
+        draw.fan,
+        rule: draw.rule,
+        union: false,
+        requiredClipBit: _activeClipBit,
+      );
+      pass
+        ..setStencilReference(nextBit)
+        ..setColorBlendEquation(_noWrite)
+        ..setStencilConfig(gpu.StencilConfig(
+          compareFunction: gpu.CompareFunction.notEqual,
+          depthStencilPassOperation: gpu.StencilOperation.setToReferenceValue,
+          stencilFailureOperation: gpu.StencilOperation.keep,
+          readMask: _pathMask,
+          writeMask: nextBit,
+        ))
+        ..bindPipeline(pipelines.solid)
+        ..bindUniform(pipelines.solidTransform, transform)
+        ..bindVertexBuffer(draw.cover.view, draw.cover.vertices)
+        ..draw();
+      // The lower bits are scratch. Clearing them here leaves the final clip
+      // bit intact and makes the following PDF fill independent of how many
+      // contours built this mask.
+      _clearStencil(_pathMask);
+      _activeClipBit = nextBit;
+    }
   }
 
   void solid(_GpuBuffer vertices) {
@@ -1685,49 +1865,80 @@ class _GpuEncoder {
 
   void stencil(_GpuBuffer fan, _GpuBuffer cover,
       {required PdfFillRule rule, required bool union}) {
+    _accumulateStencil(fan,
+        rule: rule, union: union, requiredClipBit: _activeClipBit);
     pass
-      ..setColorBlendEquation(_noWrite)
-      ..bindPipeline(pipelines.stencil)
-      ..bindUniform(pipelines.stencilTransform, transform);
-    if (union) {
-      pass.setStencilConfig(gpu.StencilConfig(
-        compareFunction: gpu.CompareFunction.always,
-        depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
-      ));
-    } else if (rule == PdfFillRule.evenOdd) {
-      pass.setStencilConfig(gpu.StencilConfig(
-        compareFunction: gpu.CompareFunction.always,
-        depthStencilPassOperation: gpu.StencilOperation.invert,
-      ));
-    } else {
-      pass
-        ..setStencilConfig(
-          gpu.StencilConfig(
-            compareFunction: gpu.CompareFunction.always,
-            depthStencilPassOperation: gpu.StencilOperation.incrementWrap,
-          ),
-          targetFace: gpu.StencilFace.front,
-        )
-        ..setStencilConfig(
-          gpu.StencilConfig(
-            compareFunction: gpu.CompareFunction.always,
-            depthStencilPassOperation: gpu.StencilOperation.decrementWrap,
-          ),
-          targetFace: gpu.StencilFace.back,
-        );
-    }
-    pass
-      ..bindVertexBuffer(fan.view, fan.vertices)
-      ..draw()
+      ..setStencilReference(0)
       ..setColorBlendEquation(_srcOver)
       ..setStencilConfig(gpu.StencilConfig(
         compareFunction: gpu.CompareFunction.notEqual,
         depthStencilPassOperation: gpu.StencilOperation.zero,
         stencilFailureOperation: gpu.StencilOperation.keep,
+        readMask: _pathMask,
+        writeMask: _pathMask,
       ))
       ..bindPipeline(pipelines.solid)
       ..bindUniform(pipelines.solidTransform, transform)
       ..bindVertexBuffer(cover.view, cover.vertices)
+      ..draw();
+  }
+
+  void _accumulateStencil(
+    _GpuBuffer fan, {
+    required PdfFillRule rule,
+    required bool union,
+    required int requiredClipBit,
+  }) {
+    final compare = requiredClipBit == 0
+        ? gpu.CompareFunction.always
+        : gpu.CompareFunction.equal;
+    gpu.StencilConfig config(gpu.StencilOperation operation) =>
+        gpu.StencilConfig(
+          compareFunction: compare,
+          depthStencilPassOperation: operation,
+          stencilFailureOperation: gpu.StencilOperation.keep,
+          readMask: requiredClipBit == 0 ? 0 : requiredClipBit,
+          writeMask: _pathMask,
+        );
+    pass
+      ..setStencilReference(requiredClipBit)
+      ..setColorBlendEquation(_noWrite)
+      ..bindPipeline(pipelines.stencil)
+      ..bindUniform(pipelines.stencilTransform, transform);
+    if (union) {
+      pass.setStencilConfig(config(gpu.StencilOperation.incrementWrap));
+    } else if (rule == PdfFillRule.evenOdd) {
+      pass.setStencilConfig(config(gpu.StencilOperation.invert));
+    } else {
+      pass
+        ..setStencilConfig(
+          config(gpu.StencilOperation.incrementWrap),
+          targetFace: gpu.StencilFace.front,
+        )
+        ..setStencilConfig(
+          config(gpu.StencilOperation.decrementWrap),
+          targetFace: gpu.StencilFace.back,
+        );
+    }
+    pass
+      ..bindVertexBuffer(fan.view, fan.vertices)
+      ..draw();
+  }
+
+  void _clearStencil(int mask) {
+    if (mask == 0) return;
+    pass
+      ..setStencilReference(0)
+      ..setColorBlendEquation(_noWrite)
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: gpu.CompareFunction.always,
+        depthStencilPassOperation: gpu.StencilOperation.zero,
+        readMask: 0,
+        writeMask: mask,
+      ))
+      ..bindPipeline(pipelines.solid)
+      ..bindUniform(pipelines.solidTransform, transform)
+      ..bindVertexBuffer(stencilClear.view, stencilClear.vertices)
       ..draw();
   }
 
@@ -1772,10 +1983,18 @@ class _GpuEncoder {
     pass.clearBindings();
   }
 
-  void _defaultStencil() => pass.setStencilConfig(gpu.StencilConfig(
-        compareFunction: gpu.CompareFunction.always,
+  void _defaultStencil() {
+    pass
+      ..setStencilReference(_activeClipBit)
+      ..setStencilConfig(gpu.StencilConfig(
+        compareFunction: _activeClipBit == 0
+            ? gpu.CompareFunction.always
+            : gpu.CompareFunction.equal,
         depthStencilPassOperation: gpu.StencilOperation.keep,
+        readMask: _activeClipBit == 0 ? 0 : _activeClipBit,
+        writeMask: 0,
       ));
+  }
 }
 
 class _GpuPipelines {

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -13,6 +13,8 @@ class FlutterGpuTileBackendStats {
   int compileMicros = 0;
   int geometryBuffers = 0;
   int geometryVertices = 0;
+  int clipPathsCompiled = 0;
+  int clipMaskRebuilds = 0;
   int geometryBudgetFallbacks = 0;
   int activeGeometryLeases = 0;
   int geometryBytes = 0;
@@ -46,6 +48,8 @@ class FlutterGpuTileBackendStats {
         'compileMicros': compileMicros,
         'geometryBuffers': geometryBuffers,
         'geometryVertices': geometryVertices,
+        'clipPathsCompiled': clipPathsCompiled,
+        'clipMaskRebuilds': clipMaskRebuilds,
         'geometryBudgetFallbacks': geometryBudgetFallbacks,
         'activeGeometryLeases': activeGeometryLeases,
         'geometryBytes': geometryBytes,
@@ -80,6 +84,8 @@ class FlutterGpuTileBackendStats {
     scenesCompiled = 0;
     compileMicros = 0;
     geometryVertices = 0;
+    clipPathsCompiled = 0;
+    clipMaskRebuilds = 0;
     geometryBudgetFallbacks = 0;
     peakGeometryBytes = geometryBytes;
     texturesUploaded = 0;
@@ -104,6 +110,7 @@ class FlutterGpuTileBackendStats {
       'overprintApprox=$overprintApproximationSessions '
       'compiled=$scenesCompiled compileUs=$compileMicros '
       'buffers=$geometryBuffers vertices=$geometryVertices '
+      'clips=$clipPathsCompiled clipRebuilds=$clipMaskRebuilds '
       'geometryBudgetFallbacks=$geometryBudgetFallbacks '
       'activeGeometryLeases=$activeGeometryLeases '
       'geometryBytes=$geometryBytes peakGeometryBytes=$peakGeometryBytes '

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stub.dart
@@ -17,6 +17,10 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
   final int maxTextureBytes;
   final int maxGeometryBytes;
   final FlutterGpuTileBackendStats stats;
+  String? _lastSessionRejection;
+
+  @override
+  String? get lastSessionRejection => _lastSessionRejection;
 
   /// False for the compile-time web/unsupported implementation.
   bool get isPlatformSupported => false;
@@ -28,7 +32,8 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
 
   @override
   PdfTileRasterSession? createSession(PdfRetainedScene scene) {
-    stats.lastRejection = 'flutter_gpu is unavailable on this platform';
+    _lastSessionRejection = 'flutter_gpu is unavailable on this platform';
+    stats.lastRejection = _lastSessionRejection;
     stats.lastTileRoute = 'canvas-fallback';
     stats.sessionsRejected++;
     return null;

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -168,6 +168,72 @@ void main() {
     });
   });
 
+  testWidgets('nested arbitrary clips and restored ancestors match Canvas',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      const triangle = PdfPath([
+        PdfMoveTo(50, 80),
+        PdfLineTo(500, 120),
+        PdfLineTo(260, 700),
+        PdfClosePath(),
+      ]);
+      const evenOdd = PdfPath([
+        PdfMoveTo(100, 150),
+        PdfLineTo(450, 150),
+        PdfLineTo(450, 600),
+        PdfLineTo(100, 600),
+        PdfClosePath(),
+        PdfMoveTo(190, 260),
+        PdfLineTo(360, 260),
+        PdfLineTo(360, 490),
+        PdfLineTo(190, 490),
+        PdfClosePath(),
+      ]);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfFillPathCommand(_rect(0, 0, 612, 792),
+            const PdfColor(0.92, 0.92, 0.92), PdfFillRule.nonzero, 1),
+        const PdfSaveCommand(),
+        const PdfClipPathCommand(triangle, PdfFillRule.nonzero),
+        PdfFillPathCommand(_rect(0, 0, 612, 792), const PdfColor(0.1, 0.4, 0.9),
+            PdfFillRule.nonzero, 0.8),
+        const PdfSaveCommand(),
+        const PdfClipPathCommand(evenOdd, PdfFillRule.evenOdd),
+        PdfFillPathCommand(_rect(0, 0, 612, 792),
+            const PdfColor(0.9, 0.15, 0.1), PdfFillRule.nonzero, 0.75),
+        const PdfRestoreCommand(),
+        PdfFillPathCommand(_rect(20, 300, 580, 390),
+            const PdfColor(0.1, 0.75, 0.25), PdfFillRule.nonzero, 0.7),
+        const PdfRestoreCommand(),
+        PdfFillPathCommand(_rect(520, 650, 590, 740),
+            const PdfColor(1, 0.75, 0), PdfFillRule.nonzero, 1),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      final session = backend.createSession(scene);
+      expect(session, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(session!.dispose);
+      final region = Offset.zero & scene.pageSize;
+      final expected = await scene.rasterizeRegion(region, pixelRatio: 0.75);
+      final actual = await session.rasterizeRegion(region, pixelRatio: 0.75);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(4));
+      expect(backend.stats.clipPathsCompiled, 2);
+      expect(backend.stats.clipMaskRebuilds, greaterThanOrEqualTo(3),
+          reason: 'nested state and restored ancestor are rebuilt exactly');
+    });
+  });
+
   testWidgets('image textures survive sessions under a byte budget',
       (tester) async {
     await tester.runAsync(() async {
@@ -487,8 +553,23 @@ void main() {
         const PdfRestoreCommand(),
       ]);
       addTearDown(nonRectClip.dispose);
-      expect(backend.createSession(nonRectClip), isNull);
-      expect(backend.stats.lastRejection, contains('clip'));
+      final clipSession = backend.createSession(nonRectClip);
+      expect(clipSession, isNotNull, reason: backend.stats.lastRejection);
+      addTearDown(clipSession!.dispose);
+      const clipRegion = Rect.fromLTWH(0, 0, 320, 320);
+      final expected =
+          await nonRectClip.rasterizeRegion(clipRegion, pixelRatio: 1);
+      final actual =
+          await clipSession.rasterizeRegion(clipRegion, pixelRatio: 1);
+      addTearDown(expected.dispose);
+      addTearDown(actual.dispose);
+      final a = await _pixels(expected), b = await _pixels(actual);
+      var difference = 0;
+      for (var i = 0; i < a.length; i++) {
+        difference += (a[i] - b[i]).abs();
+      }
+      expect(difference / a.length, lessThan(3),
+          reason: 'arbitrary PDF clips should use the exact stencil route');
     });
   });
 }


### PR DESCRIPTION
## What changed

- render ordinary non-rectangular PDF clip stacks exactly in the flutter_gpu backend using retained stencil geometry, including nested nonzero/even-odd clips and save/restore
- retain rectangular clips on the hardware-scissor path and report clip compilation/rebuild counters in DevTools
- add a persisted, explicitly experimental DevTools switch for approximating non-black overprint; exact Canvas fallback remains the default
- keep off-screen neighbours at fit-resolution base rasters during deep zoom and only promote them when they enter the viewport
- require 750 ms of continuous idle time before whole-document thumbnail warming, restarting the window after navigation
- log the requested tile backend, actual route, rejection reason, and retained command count

## Why

Field traces from the heavy CAD document showed pages falling back solely for non-rectangular clipping, high-zoom neighbour pages allocating large full-page rasters off screen, and thumbnail warming competing with navigation. The remaining non-black-overprint pages need an explicit way to test the speed/correctness tradeoff without weakening the default exact route.

## Validation

- `fvm dart analyze`
- full `dart_pdf_editor` Flutter suite: 2,182 tests passed
- full preview-app Flutter suite
- full native flutter_gpu suite with Impeller/flutter_gpu enabled, including Ghent and PDF.js routing corpora
- pure-Dart Ghent and PDF.js corpus suites
- release web build
- heavy CAD pages 68–87:
  - exact mode: 13 GPU, 7 explicit non-black-overprint Canvas fallbacks
  - approximation mode: 20 GPU, 0 rejected
  - pages 71–72 now stay on GPU; warm tile replay measured about 17–19 ms and 11–12 ms
- original 8100 difficult-page sweep in exact and approximation modes; unsupported composite/blend cases continue to fall back conservatively