### PR TITLE
fix(gpu): pace final tile submissions

### DIFF
--- a/app/lib/devtools_panel.dart
+++ b/app/lib/devtools_panel.dart
@@ -1258,12 +1258,23 @@ class _DevToolsPanelState extends State<DevToolsPanel> {
           theme,
           'Tile replay',
           '${stats.tilesRendered} tiles · '
-              '${_averageMs(stats.submitMicros, stats.tilesRendered)} submit '
+              '${_averageMs(stats.issueMicros, stats.tilesRendered)} issue '
               'avg · ${stats.tilesRendered == 0 ? 'n/a' : (stats.selectedCommands / stats.tilesRendered).toStringAsFixed(1)} commands/tile',
-          help: 'GPU tiles rendered, synchronous command-buffer submit time, '
-              'and spatially selected commands per tile. This excludes GPU '
-              'completion time but exposes replay/selection growth on CAD '
-              'pages.',
+          help: 'GPU tiles rendered, synchronous texture/pass encoding and '
+              'submission time, and spatially selected commands per tile.',
+        ),
+        _kv(
+          theme,
+          'GPU completion',
+          '${stats.completedSubmissions} done · '
+              '${_averageMs(stats.completionMicros, stats.completedSubmissions)} avg · '
+              '${(stats.maxCompletionMicros / 1000).toStringAsFixed(1)} ms worst · '
+              '${stats.inFlightSubmissions} in flight',
+          help: 'Command-buffer submit-to-completion latency, including time '
+              'queued behind earlier GPU work. A growing in-flight count or '
+              'large worst latency reveals deferred raster-thread pressure '
+              'that synchronous submit timing cannot see. '
+              '${stats.failedSubmissions} submissions reported failure.',
         ),
         _kv(
           theme,

--- a/app/test/devtools_panel_test.dart
+++ b/app/test/devtools_panel_test.dart
@@ -177,7 +177,12 @@ void main() {
       ..compileMicros = 8000
       ..tilesRendered = 4
       ..selectedCommands = 40
+      ..issueMicros = 4000
       ..submitMicros = 2000
+      ..completedSubmissions = 3
+      ..completionMicros = 18000
+      ..maxCompletionMicros = 9000
+      ..inFlightSubmissions = 1
       ..lastTileRoute = 'canvas-fallback'
       ..lastRejection = 'unsupported blend mode';
     addTearDown(stats.reset);
@@ -194,6 +199,8 @@ void main() {
     expect(find.text('unsupported blend mode'), findsOneWidget);
     expect(find.text('Canvas fallback'), findsOneWidget);
     expect(find.textContaining('10.0 commands/tile'), findsOneWidget);
+    expect(find.textContaining('9.0 ms worst'), findsOneWidget);
+    expect(find.textContaining('1 in flight'), findsOneWidget);
     expect(
         find.byKey(const ValueKey('devtools-reset-gpu-stats')), findsOneWidget);
   });

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Let a tile raster session opt out of adjacent-tile slab batching and cap new
+  work admitted by each paint, while preserving Canvas batching and existing
+  third-party session compatibility. Expose the exact visible-tile budget
+  decision in diagnostics so single-patch fallbacks are explainable.
 - Keep off-screen neighbour pages at fit-resolution base rasters during deep
   zoom, promoting them only when they enter the viewport, so navigation no
   longer allocates high-zoom full-page rasters that are immediately replaced.

--- a/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/editing_thumbnails.dart
@@ -2878,6 +2878,7 @@ class _PageThumbnailState extends State<_PageThumbnail> {
       // nothing may escape: a single failing page must neither poison the
       // queue nor surface - it just keeps its placeholder
       try {
+        var deferred = false;
         final image = await rasterizeThumbnail(
           controller: controller,
           pageIndex: pageIndex,
@@ -2885,11 +2886,28 @@ class _PageThumbnailState extends State<_PageThumbnail> {
           annotations: annotations,
           pixelWidth: pixelWidth,
           worker: worker,
+          // The task may have been granted before a fast scroll and return
+          // from its worker during the render hold. Do not replay/rasterize
+          // that stale result on the platform thread; keep the viewer preview
+          // and let the shared queue retry after its foreground gate clears.
+          deferUiWork: () {
+            final value = cache.shouldDeferUiWork;
+            deferred |= value;
+            return value;
+          },
           // only persist/read disk for pages untouched this session - the
           // disk key is content-derived and render stamps reset per session
           disk: controller.pageRenderStamp(pageIndex) == 0 ? cache.disk : null,
         );
-        if (image == null) return;
+        if (image == null) {
+          if (deferred && mounted && _pendingKey == key) {
+            // This request has already been removed from the queue. Put the
+            // same token back while the gate is closed; its activity listener
+            // will grant it when the viewer becomes idle again.
+            _enqueue(key, pixelWidth);
+          }
+          return;
+        }
         PdfThumbnailSidebar.debugRasterizations++;
         cache.put(key, image);
         if (!mounted || _pendingKey != key) return;
@@ -3052,11 +3070,11 @@ Future<ui.Image?> rasterizeThumbnail({
         : null;
     final recordMs = sw.elapsedMicroseconds / 1000.0;
     if (commands != null) {
-      // A background warm may have started while the viewer was idle, then
-      // received its worker result after scrolling began. Do not turn that
-      // result into a picture/raster on the platform thread now: the page's
-      // visible tile already has a soft viewer preview, and foreground motion
-      // wins. The warm pass may leave this page for its on-demand tile render.
+      // A thumbnail may have started while the viewer was idle, then received
+      // its worker result after scrolling began. Do not turn that result into
+      // a picture/raster on the platform thread now: the tile already has a
+      // soft viewer preview, and foreground motion wins. A visible tile is
+      // re-queued; a warm pass may leave the page for its on-demand render.
       if (deferUiWork?.call() ?? false) {
         trace.instant('defer ui replay', arguments: {'ms': recordMs});
         PdfPerfLog.log('thumbnail page=$pageIndex $reason px=$pixelWidth '
@@ -3116,6 +3134,16 @@ Future<ui.Image?> rasterizeThumbnail({
       PdfPerfLog.log('thumbnail page=$pageIndex $reason px=$pixelWidth '
           'skip local fallback record=${_traceMs(recordMs)} '
           '${usingWorker ? '(worker declined)' : '(no worker)'}');
+      return null;
+    }
+    // The worker may have declined only after the viewer started moving. A
+    // visible tile normally falls back to a local interpret here, which is
+    // even more disruptive than replaying a returned command buffer; defer it
+    // under the same gate and retry after settle.
+    if (deferUiWork?.call() ?? false) {
+      trace.instant('defer ui local fallback', arguments: {'ms': recordMs});
+      PdfPerfLog.log('thumbnail page=$pageIndex $reason px=$pixelWidth '
+          'defer ui local fallback record=${_traceMs(recordMs)}');
       return null;
     }
     sw.reset();

--- a/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/editing/thumbnail_cache.dart
@@ -154,6 +154,15 @@ class PdfThumbnailCache {
   /// the warm behaves exactly as it did before the gate existed.
   bool get _viewerBusy => _gateBusy?.call() ?? false;
 
+  /// Whether a thumbnail result should avoid starting platform-thread work.
+  ///
+  /// A foreground tile can be granted while the viewer is idle, spend several
+  /// hundred milliseconds recording in a worker, then receive that result
+  /// after a fast scroll has begun. Callers poll this immediately before
+  /// replay/rasterization and leave their soft preview in place when true.
+  /// The viewer activity listener wakes the queued retry once motion settles.
+  bool get shouldDeferUiWork => !_disposed && _viewerBusy;
+
   /// Registers (or refreshes) [token]'s request to render on-screen tile
   /// [pageIndex]. [run] is invoked when the task's turn comes - the queue
   /// grants the pending task nearest [focus], one at a time. Calling again

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -1337,6 +1337,12 @@ class _PdfPageViewState extends State<PdfPageView>
         hold: widget.renderHold,
       );
 
+  Future<bool> _paceWorkerUiWork() async {
+    final scheduler = widget.renderScheduler;
+    if (scheduler == null) return true;
+    return scheduler.paceUiWork(this, widget.renderPriority);
+  }
+
   /// Interprets the page into a picture, off the UI thread when a worker is
   /// available and the page is serializable, else locally. The worker path
   /// records the page on a background isolate and replays the returned
@@ -1385,6 +1391,7 @@ class _PdfPageViewState extends State<PdfPageView>
       if (_abandoned(pageIndex)) return (_emptyPicture(), null, false);
       if (commands != null) {
         if (_renderPaused) return null;
+        if (!await _paceWorkerUiWork() || _abandoned(pageIndex)) return null;
         _lastInterpretPath = 'worker';
         _lastInterpretResultBytes = _logImageStats(pageIndex, commands);
         final (picture, scene) = await _replayableFromCommands(commands,
@@ -1628,6 +1635,12 @@ class _PdfPageViewState extends State<PdfPageView>
         _image != null) {
       return;
     }
+    if (!await _paceWorkerUiWork() ||
+        _superseded(generation, pageIndex) ||
+        _renderPaused ||
+        _image != null) {
+      return;
+    }
 
     final picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
       widget.page,
@@ -1685,6 +1698,14 @@ class _PdfPageViewState extends State<PdfPageView>
     // newer pass's larger one.
     if (commands.isEmpty ||
         _superseded(generation, pageIndex) ||
+        _renderPaused ||
+        _image != null ||
+        _slugPicture != null ||
+        seq <= _progressiveAppliedSeq) {
+      return;
+    }
+    if (!await _paceWorkerUiWork()) return;
+    if (_superseded(generation, pageIndex) ||
         _renderPaused ||
         _image != null ||
         _slugPicture != null ||
@@ -1771,6 +1792,11 @@ class _PdfPageViewState extends State<PdfPageView>
     if (_superseded(generation, pageIndex) ||
         _renderPaused ||
         commands == null) {
+      return null;
+    }
+    if (!await _paceWorkerUiWork() ||
+        _superseded(generation, pageIndex) ||
+        _renderPaused) {
       return null;
     }
 

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -3109,9 +3109,10 @@ class _PdfPageViewState extends State<PdfPageView>
     final store = PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance;
     final size = _renderPlan.pageSize(widget.page);
     if (size.width <= 0 || size.height <= 0) return false;
-    return store.viewFitsBudget(
+    final desired = _desiredRatioAt(widget.scale);
+    final status = store.viewBudgetStatus(
       pageSize: size,
-      desiredRatio: _desiredRatioAt(widget.scale),
+      desiredRatio: desired,
       visiblePageRect: Rect.fromLTRB(
         fraction.left * size.width,
         fraction.top * size.height,
@@ -3119,6 +3120,22 @@ class _PdfPageViewState extends State<PdfPageView>
         fraction.bottom * size.height,
       ),
     );
+    if (status == null) {
+      PdfPerfLog.log(
+        'tile fallback page=${widget.previewIndex} reason=invalid-geometry '
+        'desired=${desired.toStringAsFixed(2)}',
+      );
+      return false;
+    }
+    if (!status.fits) {
+      PdfPerfLog.log(
+        'tile fallback page=${widget.previewIndex} reason=budget '
+        'rung=${status.rung} visible=${status.visibleTiles} '
+        'limit=${status.limit} capacity=${status.capacity} '
+        'desired=${desired.toStringAsFixed(2)}',
+      );
+    }
+    return status.fits;
   }
 
   /// The [PdfTileStore] deep-zoom composite for this page, or null when the
@@ -3134,6 +3151,17 @@ class _PdfPageViewState extends State<PdfPageView>
     final desired = _tileDesiredRatio;
     if (scene == null || fraction == null || desired == null) return null;
     final store = PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance;
+    final session = _tileRasterSessionFor(scene);
+    final scheduling = session is PdfTileRasterScheduling
+        ? session as PdfTileRasterScheduling
+        : null;
+    final sessionCap = scheduling?.maxNewTilesPerPaint;
+    final sceneCap = scene.regionIndexBuildIsHeavy ? 1 : null;
+    final maxNewTiles = sessionCap == null
+        ? sceneCap
+        : sceneCap == null
+            ? sessionCap
+            : math.min(sessionCap, sceneCap);
     return Positioned.fill(
       child: PdfTileLayer(
         store: store,
@@ -3157,6 +3185,7 @@ class _PdfPageViewState extends State<PdfPageView>
         ),
         persistence: _tilePersistence,
         canRasterize: _tileRegionRasterizable,
+        batchRasters: scheduling?.batchAdjacentTiles,
         // A grid-indexed CAD scene can select tens of thousands of commands
         // across one viewport slab. replayRegion records those commands
         // synchronously before toImage yields, so batching every missing tile
@@ -3164,7 +3193,7 @@ class _PdfPageViewState extends State<PdfPageView>
         // Admit one tile per paint instead. A tile completion repaints the
         // layer and advances the center-out fill; ordinary scenes retain the
         // lower-overhead batched path.
-        maxNewTilesPerPaint: scene.regionIndexBuildIsHeavy ? 1 : null,
+        maxNewTilesPerPaint: maxNewTiles,
       ),
     );
   }
@@ -3718,7 +3747,8 @@ class _PdfPageViewState extends State<PdfPageView>
 /// serves that request (and every later one) through Canvas. The failed
 /// session stays owned until dispose: another slab may already be in flight,
 /// and the backend contract allows it to finish before resources are freed.
-class _FallbackTileRasterSession implements PdfTileRasterSession {
+class _FallbackTileRasterSession
+    implements PdfTileRasterSession, PdfTileRasterScheduling {
   _FallbackTileRasterSession({
     required PdfTileRasterSession primary,
     required this.fallback,
@@ -3734,6 +3764,22 @@ class _FallbackTileRasterSession implements PdfTileRasterSession {
 
   @override
   PdfRetainedScene get scene => fallback.scene;
+
+  @override
+  bool get batchAdjacentTiles {
+    final active = _primaryEnabled ? _primary : fallback;
+    return active is PdfTileRasterScheduling
+        ? (active as PdfTileRasterScheduling).batchAdjacentTiles
+        : true;
+  }
+
+  @override
+  int? get maxNewTilesPerPaint {
+    final active = _primaryEnabled ? _primary : fallback;
+    return active is PdfTileRasterScheduling
+        ? (active as PdfTileRasterScheduling).maxNewTilesPerPaint
+        : null;
+  }
 
   @override
   Future<ui.Image> rasterizeRegion(

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -402,6 +402,18 @@ class PdfPageView extends StatefulWidget {
   /// Set false to fall back to the single bounded [earlyPrefixPaint] snapshot.
   static bool progressiveStreamingPaint = true;
 
+  /// UI-time ceiling for progressive prefix replay. Once one prefix costs at
+  /// least this long, larger cumulative prefixes from the same record are
+  /// skipped and the final worker result is allowed to land next.
+  ///
+  /// This is deliberately a measured time budget rather than a command-count
+  /// limit: 8,000 simple lines and 8,000 clipped glyphs have radically
+  /// different costs, as do desktop and mobile GPUs. Twelve milliseconds
+  /// leaves roughly 4.7 ms of a 60 Hz frame for layout, input and composition.
+  /// Set null to keep painting every streamed prefix.
+  static Duration? progressivePartialUiBudget =
+      const Duration(milliseconds: 12);
+
   /// Composite deep-zoom detail from the [PdfTileStore] zoom-bucket pyramid
   /// instead of the single unbudgeted detail patch. When true (and the page
   /// retains a region-cullable scene), the visible slice is tiled: panning at
@@ -614,6 +626,23 @@ class _PdfPageViewState extends State<PdfPageView>
   /// an out-of-order async rasterize of an earlier partial can't clobber a later
   /// one. Only advances; a partial applies only if its seq exceeds this.
   int _progressiveAppliedSeq = 0;
+
+  /// Latest-only mailbox for cumulative progressive prefixes. The worker may
+  /// emit another (strict superset) while picture construction or rasterization
+  /// of the current prefix is awaiting the GPU. Retaining every callback as an
+  /// independent future kept all of those command buffers live and replayed
+  /// obsolete snapshots. One active build plus this one pending slot bounds the
+  /// transient memory and always advances to the newest available prefix.
+  ({
+    int generation,
+    int pageIndex,
+    List<PdfRenderCommand> commands,
+    int seq,
+  })? _progressivePending;
+  bool _progressiveDrainActive = false;
+  int _progressiveFinalizedThrough = 0;
+  int _progressiveBudgetGeneration = 0;
+  bool _progressiveBudgetSpent = false;
 
   // Full-page rasters stay within GPU texture limits and sane memory:
   // at most ~16.7M px (64 MB RGBA) and 8192 px per side. Past these caps
@@ -868,6 +897,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // its null result resolves into a future nobody awaits any more
     _speculativeStripPlan = null;
     _speculativeStripDetail = null;
+    _progressivePending = null;
     widget.renderScheduler?.cancel(this);
     // Scrolled out of the cache window: drop this page's queued worker request
     // so the worker's next slot serves a page still on screen (the abandoned
@@ -1337,10 +1367,19 @@ class _PdfPageViewState extends State<PdfPageView>
         hold: widget.renderHold,
       );
 
-  Future<bool> _paceWorkerUiWork() async {
+  Future<bool> _paceWorkerUiWork({bool replacePending = true}) async {
     final scheduler = widget.renderScheduler;
     if (scheduler == null) return true;
-    return scheduler.paceUiWork(this, widget.renderPriority);
+    // renderPriority includes large visibility boosts (for example -1000),
+    // while PdfPageRenderScheduler.focus is a real page index. Comparing the
+    // two made completion ordering effectively arbitrary. The state token
+    // already identifies the visible/preloaded slot; rank it by its actual
+    // page index and keep only its latest cumulative worker result.
+    return scheduler.paceUiWork(
+      this,
+      widget.previewIndex,
+      replacePending: replacePending,
+    );
   }
 
   /// Interprets the page into a picture, off the UI thread when a worker is
@@ -1396,6 +1435,11 @@ class _PdfPageViewState extends State<PdfPageView>
         _lastInterpretResultBytes = _logImageStats(pageIndex, commands);
         final (picture, scene) = await _replayableFromCommands(commands,
             maxImagePixelRatio: imageRatio);
+        if (_abandoned(pageIndex) || _renderPaused) {
+          picture.dispose();
+          scene?.dispose();
+          return null;
+        }
         _lastInterpretWaitMs = waitMs;
         _lastInterpretBuildMs =
             buildClock == null ? null : buildClock.elapsedMicroseconds / 1000.0;
@@ -1701,6 +1745,9 @@ class _PdfPageViewState extends State<PdfPageView>
         _renderPaused ||
         _image != null ||
         _slugPicture != null ||
+        generation <= _progressiveFinalizedThrough ||
+        (generation == _progressiveBudgetGeneration &&
+            _progressiveBudgetSpent) ||
         seq <= _progressiveAppliedSeq) {
       return;
     }
@@ -1709,9 +1756,13 @@ class _PdfPageViewState extends State<PdfPageView>
         _renderPaused ||
         _image != null ||
         _slugPicture != null ||
+        generation <= _progressiveFinalizedThrough ||
+        (generation == _progressiveBudgetGeneration &&
+            _progressiveBudgetSpent) ||
         seq <= _progressiveAppliedSeq) {
       return;
     }
+    final uiClock = Stopwatch()..start();
     final picture = await PdfPageRenderer.pictureFromCommandsWithPlan(
       widget.page,
       commands,
@@ -1724,6 +1775,7 @@ class _PdfPageViewState extends State<PdfPageView>
         _renderPaused ||
         _image != null ||
         _slugPicture != null ||
+        generation <= _progressiveFinalizedThrough ||
         seq <= _progressiveAppliedSeq) {
       picture.dispose();
       return;
@@ -1739,17 +1791,91 @@ class _PdfPageViewState extends State<PdfPageView>
         _renderPaused ||
         _image != null ||
         _slugPicture != null ||
+        generation <= _progressiveFinalizedThrough ||
         seq <= _progressiveAppliedSeq) {
       image.dispose();
       return;
     }
     _progressiveAppliedSeq = seq;
+    uiClock.stop();
+    final budget = PdfPageView.progressivePartialUiBudget;
+    final budgetSpent = budget != null && uiClock.elapsed >= budget;
+    if (budgetSpent && generation == _progressiveBudgetGeneration) {
+      _progressiveBudgetSpent = true;
+      // A pending partial is necessarily larger than this one and cannot fit
+      // the same frame budget. Release its cumulative command buffer now.
+      if (_progressivePending?.generation == generation) {
+        _progressivePending = null;
+      }
+    }
     setState(() {
       _preview?.dispose();
       _preview = image;
     });
     PdfPerfLog.log('progressive-partial page=$pageIndex seq=$seq '
-        'commands=${commands.length}${PdfPerfLog.rssSuffix()}');
+        'commands=${commands.length} ui='
+        '${(uiClock.elapsedMicroseconds / 1000).toStringAsFixed(1)}ms '
+        'budgetStop=$budgetSpent${PdfPerfLog.rssSuffix()}');
+  }
+
+  void _queueProgressivePartial(
+    int generation,
+    int pageIndex,
+    List<PdfRenderCommand> commands,
+    int seq,
+  ) {
+    if (generation <= _progressiveFinalizedThrough ||
+        _superseded(generation, pageIndex)) {
+      return;
+    }
+    if (generation > _progressiveBudgetGeneration) {
+      _progressiveBudgetGeneration = generation;
+      _progressiveBudgetSpent = false;
+    }
+    if (_progressiveBudgetSpent) return;
+    _progressivePending = (
+      generation: generation,
+      pageIndex: pageIndex,
+      commands: commands,
+      seq: seq,
+    );
+    if (_progressiveDrainActive) return;
+    _progressiveDrainActive = true;
+    unawaited(_drainProgressivePartials());
+  }
+
+  Future<void> _drainProgressivePartials() async {
+    try {
+      while (mounted) {
+        final pending = _progressivePending;
+        _progressivePending = null;
+        if (pending == null) return;
+        await _paintProgressivePartial(
+          pending.generation,
+          pending.pageIndex,
+          pending.commands,
+          pending.seq,
+        );
+      }
+    } finally {
+      _progressiveDrainActive = false;
+      // There is no await between observing a null mailbox and this finally on
+      // Dart's single isolate, but retain this guard for callbacks delivered by
+      // a custom worker during error unwinding.
+      if (mounted && _progressivePending != null) {
+        _progressiveDrainActive = true;
+        unawaited(_drainProgressivePartials());
+      }
+    }
+  }
+
+  void _finalizeProgressivePartials(int generation) {
+    if (generation > _progressiveFinalizedThrough) {
+      _progressiveFinalizedThrough = generation;
+    }
+    if ((_progressivePending?.generation ?? generation + 1) <= generation) {
+      _progressivePending = null;
+    }
   }
 
   Future<Completer<bool>?> _paintVectorFirst(
@@ -1785,8 +1911,7 @@ class _PdfPageViewState extends State<PdfPageView>
           ? null
           : (partial) {
               final seq = ++_progressiveSeqCounter;
-              unawaited(_paintProgressivePartial(
-                  generation, pageIndex, partial, seq));
+              _queueProgressivePartial(generation, pageIndex, partial, seq);
             },
     );
     if (_superseded(generation, pageIndex) ||
@@ -1794,6 +1919,10 @@ class _PdfPageViewState extends State<PdfPageView>
         commands == null) {
       return null;
     }
+    // Every partial is a subset of this final buffer. Clear the mailbox before
+    // requesting the final UI turn so it cannot wait behind or race another
+    // obsolete prefix from its own page.
+    _finalizeProgressivePartials(generation);
     if (!await _paceWorkerUiWork() ||
         _superseded(generation, pageIndex) ||
         _renderPaused) {
@@ -1917,7 +2046,9 @@ class _PdfPageViewState extends State<PdfPageView>
     // landed full raster has a non-null _rasteredRatio). Deliberately leave
     // _rasteredRatio null so the full pass below is not skipped by its
     // resolution-unchanged guard - it must re-raster to bring the images in.
-    if (_superseded(generation, pageIndex) || _rasteredRatio != null) {
+    if (_superseded(generation, pageIndex) ||
+        _renderPaused ||
+        _rasteredRatio != null) {
       image.dispose();
       return null;
     }
@@ -2289,8 +2420,9 @@ class _PdfPageViewState extends State<PdfPageView>
         ratio: effective,
         rasterize: rasterize,
       );
-      if (_superseded(generation, pageIndex)) {
+      if (_superseded(generation, pageIndex) || _renderPaused) {
         image.dispose();
+        if (!_superseded(generation, pageIndex)) _render();
         return;
       }
       final cache = widget.previewCache;

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -42,7 +42,7 @@ class PdfPageRenderScheduler {
   /// frame. This second queue paces those platform-thread completions while
   /// leaving all workers busy in parallel.
   final _uiPending = <_UiWorkRequest>[];
-  bool _uiDraining = false;
+  int? _uiFrameCallbackId;
 
   /// Tokens whose render has been granted but has not finished. Deduping
   /// only against [_pending] was not enough: the grant removes the
@@ -56,7 +56,7 @@ class PdfPageRenderScheduler {
 
   bool _holding = false;
   int _focus = 0;
-  bool _draining = false;
+  int? _renderFrameCallbackId;
   bool _disposed = false;
   final _activity = _Activity();
 
@@ -168,8 +168,27 @@ class PdfPageRenderScheduler {
   /// builds in one frame. This grants one completion per frame, nearest
   /// [focus] first, and waits through a fast-scroll [holding] interval.
   /// Returns false when [token] was cancelled or the scheduler was disposed.
-  Future<bool> paceUiWork(Object token, int priority) {
+  Future<bool> paceUiWork(
+    Object token,
+    int priority, {
+    bool replacePending = false,
+  }) {
     if (_disposed) return Future<bool>.value(false);
+    // Progressive worker replies are cumulative snapshots. If five prefixes
+    // arrive while this page is waiting for its UI replay turn, only the fifth
+    // can improve the pixels: replaying all five builds five successively
+    // larger pictures and transient rasters, then immediately discards four.
+    // Let the caller mark those results replaceable so a page owns at most one
+    // pending completion. The already-granted result remains uncancellable,
+    // but the queue behind it collapses to the newest snapshot (or final
+    // worker result).
+    if (replacePending) {
+      for (final pending
+          in _uiPending.where((r) => identical(r.token, token)).toList()) {
+        _uiPending.remove(pending);
+        if (!pending.ready.isCompleted) pending.ready.complete(false);
+      }
+    }
     final request = _UiWorkRequest(token, priority);
     _uiPending.add(request);
     _scheduleUiDrain();
@@ -193,97 +212,99 @@ class PdfPageRenderScheduler {
   }
 
   void _scheduleDrain() {
-    if (_draining || _holding || _disposed || _pending.isEmpty) return;
-    _draining = true;
-    // off the current build/layout stack (request fires from layout) and
-    // off the synchronous gesture turn, so the first grant lands after
-    // this frame rather than blocking it
-    scheduleMicrotask(_drain);
+    if (_renderFrameCallbackId != null ||
+        _holding ||
+        _disposed ||
+        _pending.isEmpty) {
+      return;
+    }
+    // request() commonly fires from layout. A transient frame callback gets
+    // the walk off that stack and gives the same hard one-grant-per-engine-
+    // frame guarantee as the worker-completion queue below.
+    _renderFrameCallbackId = SchedulerBinding.instance.scheduleFrameCallback(
+      _grantNextRender,
+    );
   }
 
-  Future<void> _drain() async {
-    try {
-      while (!_disposed && !_holding && _pending.isNotEmpty) {
-        // the pending request nearest the viewport focus
-        var pick = 0;
-        var best = (_pending[0].priority - _focus).abs();
-        for (var i = 1; i < _pending.length; i++) {
-          final distance = (_pending[i].priority - _focus).abs();
-          if (distance < best) {
-            best = distance;
-            pick = i;
-          }
-        }
-        final next = _pending.removeAt(pick);
-        PdfPerfLog.log('scheduler grant page=${next.priority} '
-            'focus=$_focus remaining=${_pending.length}');
-        _inFlight[next.token] = null;
-        // A granted async render has left the pending queue but still owns the
-        // platform thread for its replay/raster phase. Background thumbnail
-        // work must keep treating the viewer as busy through that window.
-        _activity.ping();
-        try {
-          // starts one page render this frame; the callback returns at its
-          // first await, so this does not block the pacing below
-          final running = next.render();
-          if (running is Future<void>) {
-            // deliberately not awaited: three workers must stay busy while
-            // this page records. Only the token's own re-request waits.
-            running.then(
-              (_) => _settle(next.token),
-              onError: (_) => _settle(next.token),
-            );
-          } else {
-            _settle(next.token);
-          }
-        } catch (_) {
-          // a page that throws mid-walk must not strand the rest of the
-          // queue - it simply keeps its preview/placeholder
-          _settle(next.token);
-        }
-        // let the engine breathe before the next walk: paint the frame
-        // this produced, service input, run animations. endOfFrame
-        // schedules a frame when idle so the drain can't stall;
-        // deliberately not a Timer (those pend in widget tests).
-        await SchedulerBinding.instance.endOfFrame;
+  void _grantNextRender(Duration _) {
+    _renderFrameCallbackId = null;
+    if (_disposed || _holding || _pending.isEmpty) return;
+    // the pending request nearest the viewport focus
+    var pick = 0;
+    var best = (_pending[0].priority - _focus).abs();
+    for (var i = 1; i < _pending.length; i++) {
+      final distance = (_pending[i].priority - _focus).abs();
+      if (distance < best) {
+        best = distance;
+        pick = i;
       }
-    } finally {
-      _draining = false;
-      _activity.ping();
     }
+    final next = _pending.removeAt(pick);
+    PdfPerfLog.log('scheduler grant page=${next.priority} '
+        'focus=$_focus remaining=${_pending.length}');
+    _inFlight[next.token] = null;
+    // A granted async render has left the pending queue but still owns the
+    // platform thread for its replay/raster phase. Background thumbnail work
+    // must keep treating the viewer as busy through that window.
+    _activity.ping();
+    try {
+      // Start the record without awaiting it so several workers remain busy.
+      // Only another *grant* waits for the following engine frame.
+      final running = next.render();
+      if (running is Future<void>) {
+        running.then(
+          (_) => _settle(next.token),
+          onError: (_) => _settle(next.token),
+        );
+      } else {
+        _settle(next.token);
+      }
+    } catch (_) {
+      // A page that throws mid-walk must not strand the rest of the queue - it
+      // simply keeps its preview/placeholder.
+      _settle(next.token);
+    }
+    _scheduleDrain();
   }
 
   void _scheduleUiDrain() {
-    if (_uiDraining || _holding || _disposed || _uiPending.isEmpty) return;
-    _uiDraining = true;
-    scheduleMicrotask(_drainUi);
+    if (_uiFrameCallbackId != null ||
+        _holding ||
+        _disposed ||
+        _uiPending.isEmpty) {
+      return;
+    }
+    // `endOfFrame` can already be complete when a continuation reaches it in
+    // the post-frame turn. A while-loop awaiting it therefore occasionally
+    // released several worker results only 1-2ms apart inside the same display
+    // frame. A transient callback is an actual next-frame boundary: exactly
+    // one result is granted by each engine frame, regardless of when the
+    // previous result's future resumed.
+    _uiFrameCallbackId = SchedulerBinding.instance.scheduleFrameCallback(
+      _grantNextUiWork,
+    );
   }
 
-  Future<void> _drainUi() async {
-    try {
-      while (!_disposed && !_holding && _uiPending.isNotEmpty) {
-        var pick = 0;
-        var best = (_uiPending[0].priority - _focus).abs();
-        for (var i = 1; i < _uiPending.length; i++) {
-          final distance = (_uiPending[i].priority - _focus).abs();
-          if (distance < best) {
-            best = distance;
-            pick = i;
-          }
-        }
-        final next = _uiPending.removeAt(pick);
-        PdfPerfLog.log('scheduler ui grant page=${next.priority} '
-            'focus=$_focus remaining=${_uiPending.length}');
-        if (!next.ready.isCompleted) next.ready.complete(true);
-        // The resumed future performs its replay in this turn. Do not release
-        // another result until that frame has painted and input had a chance
-        // to run, matching the first-interpret grant cadence above.
-        await SchedulerBinding.instance.endOfFrame;
+  void _grantNextUiWork(Duration _) {
+    _uiFrameCallbackId = null;
+    if (_disposed || _holding || _uiPending.isEmpty) return;
+    var pick = 0;
+    var best = (_uiPending[0].priority - _focus).abs();
+    for (var i = 1; i < _uiPending.length; i++) {
+      final distance = (_uiPending[i].priority - _focus).abs();
+      if (distance < best) {
+        best = distance;
+        pick = i;
       }
-    } finally {
-      _uiDraining = false;
-      if (_uiPending.isNotEmpty && !_holding) _scheduleUiDrain();
     }
+    final next = _uiPending.removeAt(pick);
+    PdfPerfLog.log('scheduler ui grant page=${next.priority} '
+        'focus=$_focus remaining=${_uiPending.length}');
+    if (!next.ready.isCompleted) next.ready.complete(true);
+    // Schedule the following result for the following engine frame before the
+    // resumed future starts its replay. Enqueues during that replay see this
+    // callback and cannot accidentally schedule a second grant in the frame.
+    _scheduleUiDrain();
   }
 
   /// [token]'s render has finished (or failed). Releases it and grants
@@ -306,6 +327,17 @@ class PdfPageRenderScheduler {
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    final renderFrameCallbackId = _renderFrameCallbackId;
+    if (renderFrameCallbackId != null) {
+      SchedulerBinding.instance
+          .cancelFrameCallbackWithId(renderFrameCallbackId);
+      _renderFrameCallbackId = null;
+    }
+    final uiFrameCallbackId = _uiFrameCallbackId;
+    if (uiFrameCallbackId != null) {
+      SchedulerBinding.instance.cancelFrameCallbackWithId(uiFrameCallbackId);
+      _uiFrameCallbackId = null;
+    }
     _pending.clear();
     for (final request in _uiPending) {
       if (!request.ready.isCompleted) request.ready.complete(false);

--- a/packages/dart_pdf_editor/lib/src/render_scheduler.dart
+++ b/packages/dart_pdf_editor/lib/src/render_scheduler.dart
@@ -22,15 +22,27 @@ import 'perf_log.dart';
 /// ([holding]) - so no frame runs more than one page's walk and the
 /// low-res previews cover everything still waiting its turn.
 ///
-/// A grant is only the *start* of a render: on the worker path the
+/// A render grant is only the *start* of a render: on the worker path the
 /// callback returns at its first await and the recording finishes
 /// hundreds of milliseconds later. The scheduler tracks that window (see
 /// [_inFlight]) so a rebuild arriving inside it queues behind the pass
 /// already running rather than racing a second one against it.
+///
+/// Worker replies have their own [paceUiWork] gate. Keeping several workers
+/// busy is valuable, but replaying all of their returned command buffers in
+/// the same UI frame is not; that gate separates the completion-side work
+/// without serializing the records themselves.
 class PdfPageRenderScheduler {
   PdfPageRenderScheduler();
 
   final _pending = <_RenderRequest>[];
+
+  /// Worker records finish independently, so records started one-per-frame can
+  /// still return together and replay several command buffers in one build
+  /// frame. This second queue paces those platform-thread completions while
+  /// leaving all workers busy in parallel.
+  final _uiPending = <_UiWorkRequest>[];
+  bool _uiDraining = false;
 
   /// Tokens whose render has been granted but has not finished. Deduping
   /// only against [_pending] was not enough: the grant removes the
@@ -97,8 +109,9 @@ class PdfPageRenderScheduler {
     // from one whose in-flight set never drained; with this it does.
     PdfPerfLog.log('renderHold ${_holding ? 'ON' : 'off'} '
         '(pending=${_pending.length} inFlight=${_inFlight.length} '
-        'focus=$_focus)');
+        'uiPending=${_uiPending.length} focus=$_focus)');
     if (!_holding) _scheduleDrain();
+    if (!_holding) _scheduleUiDrain();
     _activity.ping();
   }
 
@@ -147,6 +160,22 @@ class PdfPageRenderScheduler {
     _activity.ping();
   }
 
+  /// Waits for this worker result's platform-thread replay turn.
+  ///
+  /// Page records are deliberately allowed to run concurrently in workers,
+  /// but their returned command buffers are decoded/replayed on Flutter's UI
+  /// isolate. Several workers finishing together used to put all of those
+  /// builds in one frame. This grants one completion per frame, nearest
+  /// [focus] first, and waits through a fast-scroll [holding] interval.
+  /// Returns false when [token] was cancelled or the scheduler was disposed.
+  Future<bool> paceUiWork(Object token, int priority) {
+    if (_disposed) return Future<bool>.value(false);
+    final request = _UiWorkRequest(token, priority);
+    _uiPending.add(request);
+    _scheduleUiDrain();
+    return request.ready.future;
+  }
+
   /// Withdraws [token]'s pending request - its page rendered another way,
   /// or was disposed before its turn. Also drops any re-request queued
   /// behind a render still in flight, so a page recycled onto another
@@ -154,6 +183,11 @@ class PdfPageRenderScheduler {
   void cancel(Object token) {
     final before = _pending.length;
     _pending.removeWhere((r) => identical(r.token, token));
+    for (final request
+        in _uiPending.where((r) => identical(r.token, token)).toList()) {
+      _uiPending.remove(request);
+      if (!request.ready.isCompleted) request.ready.complete(false);
+    }
     if (_inFlight.containsKey(token)) _inFlight[token] = null;
     if (_pending.length != before) _activity.ping();
   }
@@ -219,6 +253,39 @@ class PdfPageRenderScheduler {
     }
   }
 
+  void _scheduleUiDrain() {
+    if (_uiDraining || _holding || _disposed || _uiPending.isEmpty) return;
+    _uiDraining = true;
+    scheduleMicrotask(_drainUi);
+  }
+
+  Future<void> _drainUi() async {
+    try {
+      while (!_disposed && !_holding && _uiPending.isNotEmpty) {
+        var pick = 0;
+        var best = (_uiPending[0].priority - _focus).abs();
+        for (var i = 1; i < _uiPending.length; i++) {
+          final distance = (_uiPending[i].priority - _focus).abs();
+          if (distance < best) {
+            best = distance;
+            pick = i;
+          }
+        }
+        final next = _uiPending.removeAt(pick);
+        PdfPerfLog.log('scheduler ui grant page=${next.priority} '
+            'focus=$_focus remaining=${_uiPending.length}');
+        if (!next.ready.isCompleted) next.ready.complete(true);
+        // The resumed future performs its replay in this turn. Do not release
+        // another result until that frame has painted and input had a chance
+        // to run, matching the first-interpret grant cadence above.
+        await SchedulerBinding.instance.endOfFrame;
+      }
+    } finally {
+      _uiDraining = false;
+      if (_uiPending.isNotEmpty && !_holding) _scheduleUiDrain();
+    }
+  }
+
   /// [token]'s render has finished (or failed). Releases it and grants
   /// the re-request that arrived while it was running, if any.
   void _settle(Object token) {
@@ -240,6 +307,10 @@ class PdfPageRenderScheduler {
     if (_disposed) return;
     _disposed = true;
     _pending.clear();
+    for (final request in _uiPending) {
+      if (!request.ready.isCompleted) request.ready.complete(false);
+    }
+    _uiPending.clear();
     _inFlight.clear();
     _activity.ping();
     _activity.dispose();
@@ -269,4 +340,12 @@ class _RenderRequest {
   final Object token;
   int priority;
   FutureOr<void> Function() render;
+}
+
+class _UiWorkRequest {
+  _UiWorkRequest(this.token, this.priority);
+
+  final Object token;
+  final int priority;
+  final Completer<bool> ready = Completer<bool>();
 }

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -30,6 +30,7 @@ class PdfTileLayer extends StatelessWidget {
     required this.rasterize,
     this.persistence,
     this.canRasterize,
+    this.batchRasters,
     this.maxNewTilesPerPaint,
     this.filterQuality = FilterQuality.medium,
   }) : assert(maxNewTilesPerPaint == null || maxNewTilesPerPaint > 0);
@@ -60,6 +61,9 @@ class PdfTileLayer extends StatelessWidget {
   /// returns false for is left to the fallback/base raster.
   final bool Function(Rect region)? canRasterize;
 
+  /// Per-view override for the store's adjacent-tile slab batching policy.
+  final bool? batchRasters;
+
   /// Optional admission cap for missing tiles scheduled by one paint.
   ///
   /// Dense retained scenes use this to keep their synchronous command replay
@@ -81,6 +85,7 @@ class PdfTileLayer extends StatelessWidget {
           rasterize: rasterize,
           persistence: persistence,
           canRasterize: canRasterize,
+          batchRasters: batchRasters,
           maxNewTilesPerPaint: maxNewTilesPerPaint,
           filterQuality: filterQuality,
         ),
@@ -97,6 +102,7 @@ class _TilePagePainter extends CustomPainter {
     required this.rasterize,
     required this.persistence,
     required this.canRasterize,
+    required this.batchRasters,
     required this.maxNewTilesPerPaint,
     required this.filterQuality,
   }) : super(
@@ -111,6 +117,7 @@ class _TilePagePainter extends CustomPainter {
   final PdfTileRasterizer rasterize;
   final PdfTilePersistence? persistence;
   final bool Function(Rect region)? canRasterize;
+  final bool? batchRasters;
   final int? maxNewTilesPerPaint;
   final FilterQuality filterQuality;
 
@@ -133,6 +140,7 @@ class _TilePagePainter extends CustomPainter {
       rasterize: rasterize,
       persistence: persistence,
       canRasterize: canRasterize,
+      batchRasters: batchRasters,
       maxNewTiles: maxNewTilesPerPaint,
     );
     if (view.isEmpty) return;
@@ -175,6 +183,7 @@ class _TilePagePainter extends CustomPainter {
       !identical(old.rasterize, rasterize) ||
       !identical(old.persistence, persistence) ||
       !identical(old.canRasterize, canRasterize) ||
+      old.batchRasters != batchRasters ||
       old.maxNewTilesPerPaint != maxNewTilesPerPaint ||
       old.filterQuality != filterQuality;
 }

--- a/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_raster_backend.dart
@@ -5,13 +5,13 @@ import 'package:flutter/painting.dart';
 import 'retained_scene.dart';
 import 'tile_store.dart';
 
-/// Creates a scene-scoped renderer for deep-zoom tile slabs.
+/// Creates a scene-scoped renderer for deep-zoom tiles or tile slabs.
 ///
 /// [PdfTileStore] remains responsible for LoD selection, batching, caching,
 /// and composition. A backend only turns a retained-scene region into an
 /// image. Keeping the session at scene lifetime lets accelerated backends
 /// tessellate commands and upload buffers or textures once, then reuse those
-/// resources for every slab the store requests.
+/// resources for every region the store requests.
 ///
 /// Returning null from [createSession], or throwing while creating or using a
 /// session, makes the page view fall back to [PdfCanvasTileRasterBackend] for
@@ -34,7 +34,7 @@ abstract class PdfTileRasterBackend {
 
   /// Creates a lightweight owner for resources retained across tile renders.
   ///
-  /// This is called lazily, when the tile path first needs a slab—not while
+  /// This is called lazily, when the tile path first needs pixels—not while
   /// the page's initial raster is being prepared. Expensive initialization
   /// should itself be deferred by the returned session until
   /// [PdfTileRasterSession.rasterizeRegion], so enabling an experimental
@@ -42,16 +42,16 @@ abstract class PdfTileRasterBackend {
   PdfTileRasterSession? createSession(PdfRetainedScene scene);
 }
 
-/// Scene-lifetime resources used to rasterize many tile slabs.
+/// Scene-lifetime resources used to rasterize many tile regions.
 abstract class PdfTileRasterSession {
   /// The retained scene this session was built for.
   PdfRetainedScene get scene;
 
   /// Rasterizes [region] in page-point, y-down raster space.
   ///
-  /// The tile store may request a slab spanning several adjacent tiles and
-  /// slice the returned image, so implementations should preserve the exact
-  /// output dimensions used by [PdfRetainedScene.rasterizeRegion]. A
+  /// The tile store may request one tile or a slab spanning several adjacent
+  /// tiles and slice the returned image, so implementations should preserve
+  /// the exact output dimensions used by [PdfRetainedScene.rasterizeRegion]. A
   /// wrong-sized result is disposed and treated as a backend failure. On
   /// success ownership of the returned image transfers to the tile store;
   /// sessions must return a uniquely owned image (or a clone), not a borrowed
@@ -70,6 +70,29 @@ abstract class PdfTileRasterSession {
   /// completed). Implementations should not throw; disposal failures are
   /// ignored so an optional backend cannot break page replacement or teardown.
   void dispose();
+}
+
+/// Optional scheduling hints implemented by tile sessions with non-Canvas
+/// submission costs.
+///
+/// This is deliberately separate from [PdfTileRasterSession]: existing custom
+/// session implementations retain the Canvas-compatible defaults without a
+/// source-breaking interface change.
+abstract interface class PdfTileRasterScheduling {
+  /// Whether adjacent missing tiles should be rendered as one slab and split.
+  ///
+  /// Canvas replay benefits from amortizing its fixed `toImage` overhead over
+  /// a slab. A backend that already produces a final GPU texture per request
+  /// should return false: splitting its slab queues one extra GPU texture copy
+  /// per tile and can move otherwise invisible work into a later raster frame.
+  bool get batchAdjacentTiles;
+
+  /// Optional admission cap for new tiles issued by one paint.
+  ///
+  /// A landed tile causes another paint, so accelerated backends can use this
+  /// to keep command submission and texture allocation within a frame budget
+  /// while the base/coarser image remains visible underneath.
+  int? get maxNewTilesPerPaint;
 }
 
 /// The universal retained-scene renderer used today and as a fallback for

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -223,6 +223,24 @@ class PdfTileView {
   bool get isEmpty => placements.isEmpty;
 }
 
+/// Byte-budget admission decision for one exact-bucket visible tile set.
+@immutable
+class PdfTileBudgetStatus {
+  const PdfTileBudgetStatus({
+    required this.rung,
+    required this.visibleTiles,
+    required this.capacity,
+    required this.limit,
+  });
+
+  final int rung;
+  final int visibleTiles;
+  final int capacity;
+  final int limit;
+
+  bool get fits => visibleTiles <= limit;
+}
+
 /// The tile pyramid. Instantiable (tests, an isolated page) with a shared
 /// process-wide default ([instance]) so one budget spans every page, replacing
 /// the unbudgeted per-page detail patch and image retention.
@@ -437,11 +455,30 @@ class PdfTileStore extends ChangeNotifier {
     required Size pageSize,
     required double desiredRatio,
     required Rect visiblePageRect,
+  }) =>
+      viewBudgetStatus(
+        pageSize: pageSize,
+        desiredRatio: desiredRatio,
+        visiblePageRect: visiblePageRect,
+      )?.fits ??
+      false;
+
+  /// Explains [viewFitsBudget] for field diagnostics and tuning.
+  PdfTileBudgetStatus? viewBudgetStatus({
+    required Size pageSize,
+    required double desiredRatio,
+    required Rect visiblePageRect,
   }) {
     final grid = _tileGrid(pageSize, desiredRatio, visiblePageRect);
-    if (grid == null) return false;
+    if (grid == null) return null;
     final visible = (grid.tx1 - grid.tx0 + 1) * (grid.ty1 - grid.ty0 + 1);
-    return visible <= (budgetTileCapacity * _budgetFitFraction).floor();
+    final capacity = budgetTileCapacity;
+    return PdfTileBudgetStatus(
+      rung: grid.rung,
+      visibleTiles: visible,
+      capacity: capacity,
+      limit: (capacity * _budgetFitFraction).floor(),
+    );
   }
 
   /// The best-available composite for [id] over [visiblePageRect] (page points)
@@ -460,6 +497,9 @@ class PdfTileStore extends ChangeNotifier {
   /// Tiles already cached or in flight are unaffected. A landed tile ticks the
   /// store, so a painting caller can use a small cap to spread synchronous
   /// retained-scene replay across frames while the view fills center-out.
+  /// [batchRasters] overrides this store's batching policy for this view. This
+  /// lets a GPU session request final tile textures directly while Canvas
+  /// sessions using the same shared store continue to amortize slab replay.
   ///
   /// Synchronous and side-effecting: every tile it *places* is touched to
   /// most-recently-used, so a concurrent completion's eviction can only drop
@@ -475,6 +515,7 @@ class PdfTileStore extends ChangeNotifier {
     required PdfTileRasterizer rasterize,
     PdfTilePersistence? persistence,
     bool Function(Rect region)? canRasterize,
+    bool? batchRasters,
     int? maxNewTiles,
   }) {
     assert(maxNewTiles == null || maxNewTiles > 0);
@@ -512,7 +553,7 @@ class PdfTileStore extends ChangeNotifier {
     });
 
     final placements = <PdfTilePlacement>[];
-    final pending = batchRasters ? <PdfTileKey>[] : null;
+    final pending = (batchRasters ?? this.batchRasters) ? <PdfTileKey>[] : null;
     var newTiles = 0;
     bool schedule(PdfTileKey key) {
       if (maxNewTiles != null && newTiles >= maxNewTiles) return false;

--- a/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
+++ b/packages/dart_pdf_editor/test/editing_thumbnail_cache_test.dart
@@ -118,6 +118,69 @@ void main() {
       expect(rendered, [4]);
     });
 
+    testWidgets(
+        'a granted visible tile defers its worker result and retries after '
+        'scroll settle', (tester) async {
+      // Regression for the 2026-08-11 trace: page 85 was granted while idle,
+      // spent 414 ms recording in the worker, then replayed/rasterized on the
+      // platform thread after the viewer's fast-scroll hold had begun.
+      SharedPreferences.setMockInitialValues({});
+      PdfThumbnailSidebar.debugRasterizations = 0;
+      final editing = PdfEditingController(buildMultiPagePdf(1));
+      final viewer = PdfViewerController();
+      final worker = _HeldFirstWorker();
+      final activity = _TestActivity();
+      var viewerBusy = false;
+      addTearDown(editing.dispose);
+      addTearDown(viewer.dispose);
+      addTearDown(worker.dispose);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            height: 240,
+            child: Row(children: [
+              PdfThumbnailSidebar(
+                controller: editing,
+                viewerController: viewer,
+                renderWorker: worker,
+              ),
+              const Expanded(child: SizedBox()),
+            ]),
+          ),
+        ),
+      ));
+      for (var i = 0; i < 10 && !worker.firstStarted.isCompleted; i++) {
+        await tester.pump();
+      }
+      expect(worker.firstStarted.isCompleted, isTrue,
+          reason: 'the tile should already be recording off-thread');
+
+      // Replace the unmounted viewer controller's idle gate with the exact
+      // busy transition from the trace, then release the worker reply.
+      viewerBusy = true;
+      editing.thumbnailCache.bindForegroundGate(activity, () => viewerBusy);
+      worker.releaseFirst();
+      for (var i = 0; i < 8; i++) {
+        await tester.pump();
+      }
+      expect(worker.calls, 1);
+      expect(PdfThumbnailSidebar.debugRasterizations, 0,
+          reason: 'no replay/raster should land during fast scrolling');
+
+      viewerBusy = false;
+      activity.ping();
+      for (var i = 0;
+          i < 100 && PdfThumbnailSidebar.debugRasterizations == 0;
+          i++) {
+        await tester.runAsync(
+            () => Future<void>.delayed(const Duration(milliseconds: 5)));
+        await tester.pump();
+      }
+      expect(worker.calls, 2, reason: 'the deferred tile should retry once');
+      expect(PdfThumbnailSidebar.debugRasterizations, 1);
+    });
+
     testWidgets('a blocked warm logs once, not once per activity ping',
         (tester) async {
       // The render scheduler pings its activity Listenable on every grant,
@@ -444,6 +507,31 @@ void main() {
               'after the viewer begins scrolling');
     });
 
+    testWidgets('a declined worker defers the local fallback during motion',
+        (tester) async {
+      final controller = PdfEditingController(buildMultiPagePdf(1));
+      final worker = _DecliningWorker();
+      addTearDown(controller.dispose);
+      addTearDown(worker.dispose);
+
+      ui.Image? rendered;
+      await tester.runAsync(() async {
+        rendered = await rasterizeThumbnail(
+          controller: controller,
+          pageIndex: 0,
+          pageColor: const Color(0xFFFFFFFF),
+          annotations: true,
+          pixelWidth: 128,
+          worker: worker,
+          deferUiWork: () => true,
+        );
+      });
+
+      expect(rendered, isNull,
+          reason: 'a declined worker must not trigger a UI-thread interpret '
+              'while the viewer is moving');
+    });
+
     testWidgets('a rendered thumbnail writes through to disk and reloads',
         (tester) async {
       final store = PdfMemoryCacheStore();
@@ -546,6 +634,74 @@ class _ImmediateWorker extends PdfRenderWorker {
     PdfPartialRecordSink? onPartial,
   }) async =>
       [PdfSaveCommand(), PdfRestoreCommand()];
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() => _active = false;
+}
+
+class _HeldFirstWorker extends PdfRenderWorker {
+  bool _active = true;
+  final firstStarted = Completer<void>();
+  final _firstRelease = Completer<void>();
+  int calls = 0;
+
+  @override
+  bool get isActive => _active;
+
+  void releaseFirst() {
+    if (!_firstRelease.isCompleted) _firstRelease.complete();
+  }
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
+  }) async {
+    calls++;
+    if (calls == 1) {
+      firstStarted.complete();
+      await _firstRelease.future;
+    }
+    return [PdfSaveCommand(), PdfRestoreCommand()];
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {}
+
+  @override
+  void dispose() {
+    _active = false;
+    releaseFirst();
+  }
+}
+
+class _DecliningWorker extends PdfRenderWorker {
+  bool _active = true;
+
+  @override
+  bool get isActive => _active;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
+  }) async =>
+      null;
 
   @override
   void cancel(int pageIndex, {int priority = 0}) {}

--- a/packages/dart_pdf_editor/test/progressive_streaming_paint_test.dart
+++ b/packages/dart_pdf_editor/test/progressive_streaming_paint_test.dart
@@ -37,16 +37,19 @@ Future<void> _settle(WidgetTester tester, {int rounds = 120}) async {
 
 void main() {
   late bool prevProgressive;
+  late Duration? prevProgressiveBudget;
   late bool prevEarly;
   late int prevMin;
 
   setUp(() {
     prevProgressive = PdfPageView.progressiveStreamingPaint;
+    prevProgressiveBudget = PdfPageView.progressivePartialUiBudget;
     prevEarly = PdfPageView.earlyPrefixPaint;
     prevMin = PdfPageView.earlyPrefixMinContentBytes;
   });
   tearDown(() {
     PdfPageView.progressiveStreamingPaint = prevProgressive;
+    PdfPageView.progressivePartialUiBudget = prevProgressiveBudget;
     PdfPageView.earlyPrefixPaint = prevEarly;
     PdfPageView.earlyPrefixMinContentBytes = prevMin;
     PdfPerfLog.enabled = false;
@@ -129,6 +132,10 @@ void main() {
   testWidgets('a streamed partial paints before the full raster lands',
       (tester) async {
     PdfPageView.progressiveStreamingPaint = true;
+    // One prefix is enough to prove the reveal. A zero budget deterministically
+    // exercises the adaptive stop: the latest-only mailbox must not replay the
+    // three larger cumulative snapshots queued behind it.
+    PdfPageView.progressivePartialUiBudget = Duration.zero;
     PdfPageView.earlyPrefixMinContentBytes = 0;
     final logs = <String>[];
     PdfPerfLog.enabled = true;
@@ -142,8 +149,8 @@ void main() {
     // stream live during the inner record) paint while _image is still null,
     // rather than being overtaken by the vector-first raster.
     final gate = Completer<void>();
-    final worker =
-        _StreamProbeWorker(PdfRenderWorker.startUncached(bytes), finalGate: gate);
+    final worker = _StreamProbeWorker(PdfRenderWorker.startUncached(bytes),
+        finalGate: gate);
     addTearDown(() {
       if (!gate.isCompleted) gate.complete();
       worker.dispose();
@@ -157,9 +164,13 @@ void main() {
     ));
     await _settle(tester, rounds: 60);
 
-    expect(logs.any((l) => l.contains('progressive-partial')), isTrue,
+    final partialLogs =
+        logs.where((l) => l.contains('progressive-partial')).toList();
+    expect(partialLogs, hasLength(1),
         reason: 'a streamed partial should have painted into the preview while '
-            'the vector-first final was held: ${logs.length} logs');
+            'the vector-first final was held, without replaying cumulative '
+            'snapshots after the UI budget was spent: ${logs.length} logs');
+    expect(partialLogs.single, contains('budgetStop=true'));
 
     gate.complete();
     await _settle(tester, rounds: 60);

--- a/packages/dart_pdf_editor/test/render_scheduler_test.dart
+++ b/packages/dart_pdf_editor/test/render_scheduler_test.dart
@@ -23,9 +23,8 @@ void main() {
     expect(order, isEmpty);
 
     await tester.pump();
-    // a frame in: some progress, but not the whole queue at once
-    expect(order, isNotEmpty);
-    expect(order.length, lessThan(4));
+    // exactly one engine frame, exactly one grant
+    expect(order, hasLength(1));
 
     // the nearest-the-viewport page drains first
     expect(order.first, 5);
@@ -35,6 +34,24 @@ void main() {
     }
     // every page interpreted, closest-to-focus order
     expect(order, [5, 6, 9, 0]);
+  });
+
+  testWidgets('render grants use distinct engine frames', (tester) async {
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    final frames = <int>[];
+    var frame = 0;
+    for (var page = 0; page < 3; page++) {
+      scheduler.request('p$page', page, () => frames.add(frame));
+    }
+
+    for (var i = 0; i < 5 && frames.length < 3; i++) {
+      frame++;
+      await tester.pump();
+    }
+    expect(frames, hasLength(3));
+    expect(frames.toSet(), hasLength(3),
+        reason: 'at most one page render may be started per frame');
   });
 
   testWidgets('holding blocks grants until released', (tester) async {
@@ -94,6 +111,48 @@ void main() {
       await tester.pump();
     }
     expect(order, [5, 6, 8, 0]);
+  });
+
+  testWidgets('worker UI grants use distinct engine frames', (tester) async {
+    final scheduler = PdfPageRenderScheduler();
+    addTearDown(scheduler.dispose);
+    final frames = <int>[];
+    var frame = 0;
+    for (var page = 0; page < 3; page++) {
+      scheduler.paceUiWork('p$page', page).then((ready) {
+        if (ready) frames.add(frame);
+      });
+    }
+
+    for (var i = 0; i < 5 && frames.length < 3; i++) {
+      frame++;
+      await tester.pump();
+    }
+    expect(frames, hasLength(3));
+    expect(frames.toSet(), hasLength(3),
+        reason: 'at most one worker replay may be released per frame');
+  });
+
+  testWidgets('replaceable worker UI work keeps only the latest per page',
+      (tester) async {
+    final scheduler = PdfPageRenderScheduler()..holding = true;
+    addTearDown(scheduler.dispose);
+    final token = Object();
+    final first = scheduler.paceUiWork(token, 4, replacePending: true);
+    final second = scheduler.paceUiWork(token, 4, replacePending: true);
+    final finalResult = scheduler.paceUiWork(token, 4, replacePending: true);
+
+    expect(await first, isFalse);
+    expect(await second, isFalse);
+    var finalReady = false;
+    finalResult.then((ready) => finalReady = ready);
+    expect(finalReady, isFalse);
+
+    scheduler.holding = false;
+    for (var i = 0; i < 3 && !finalReady; i++) {
+      await tester.pump();
+    }
+    expect(finalReady, isTrue);
   });
 
   testWidgets('holding and cancellation gate worker UI completions',

--- a/packages/dart_pdf_editor/test/render_scheduler_test.dart
+++ b/packages/dart_pdf_editor/test/render_scheduler_test.dart
@@ -72,6 +72,53 @@ void main() {
     expect(ran, isFalse);
   });
 
+  testWidgets('worker UI completions drain one per frame, nearest first',
+      (tester) async {
+    final scheduler = PdfPageRenderScheduler()..focus = 5;
+    addTearDown(scheduler.dispose);
+    final order = <int>[];
+    for (final page in [0, 8, 5, 6]) {
+      scheduler.paceUiWork('p$page', page).then((ready) {
+        if (ready) order.add(page);
+      });
+    }
+
+    expect(order, isEmpty);
+    await tester.pump();
+    expect(order, isNotEmpty);
+    expect(order.length, lessThan(4),
+        reason: 'worker replies must not all replay in one frame');
+    expect(order.first, 5);
+
+    for (var i = 0; i < 6; i++) {
+      await tester.pump();
+    }
+    expect(order, [5, 6, 8, 0]);
+  });
+
+  testWidgets('holding and cancellation gate worker UI completions',
+      (tester) async {
+    final scheduler = PdfPageRenderScheduler()..holding = true;
+    addTearDown(scheduler.dispose);
+    final cancelled = scheduler.paceUiWork('cancelled', 0);
+    final kept = scheduler.paceUiWork('kept', 1);
+    scheduler.cancel('cancelled');
+
+    for (var i = 0; i < 3; i++) {
+      await tester.pump();
+    }
+    expect(await cancelled, isFalse);
+    var keptReady = false;
+    kept.then((value) => keptReady = value);
+    expect(keptReady, isFalse);
+
+    scheduler.holding = false;
+    for (var i = 0; i < 3 && !keptReady; i++) {
+      await tester.pump();
+    }
+    expect(keptReady, isTrue);
+  });
+
   testWidgets('re-requesting a token interprets it once', (tester) async {
     final scheduler = PdfPageRenderScheduler();
     addTearDown(scheduler.dispose);

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -21,7 +21,11 @@ void main() {
 
     final store =
         PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
-    final backend = _RecordingTileRasterBackend(throwOnDispose: true);
+    final backend = _RecordingTileRasterBackend(
+      throwOnDispose: true,
+      batchAdjacentTiles: false,
+      maxNewTilesPerPaint: 1,
+    );
     PdfPageView.tileStoreDetail = true;
     PdfPageView.debugTileStoreOverride = store;
     addTearDown(() {
@@ -67,6 +71,13 @@ void main() {
     expect(store.tileCount, greaterThan(0));
     expect(backend.sessionCreates, 1);
     expect(backend.rasterizations, greaterThan(0));
+    final tilePaint = tester.widget<CustomPaint>(
+      find.byKey(const ValueKey('pdf-page-tile-layer')),
+    );
+    expect((tilePaint.painter as dynamic).batchRasters, isFalse,
+        reason: 'a final-texture backend must bypass slab slicing');
+    expect((tilePaint.painter as dynamic).maxNewTilesPerPaint, 1,
+        reason: 'the backend session owns its per-frame admission policy');
 
     await tester.pumpWidget(const SizedBox.shrink());
     expect(tester.takeException(), isNull,
@@ -409,12 +420,16 @@ class _RecordingTileRasterBackend extends PdfCanvasTileRasterBackend {
     this.failRasterization = false,
     this.wrongDimensions = false,
     this.throwOnDispose = false,
+    this.batchAdjacentTiles = true,
+    this.maxNewTilesPerPaint,
   });
 
   final bool failCreation;
   final bool failRasterization;
   final bool wrongDimensions;
   final bool throwOnDispose;
+  final bool batchAdjacentTiles;
+  final int? maxNewTilesPerPaint;
   int sessionCreates = 0;
   int sessionDisposals = 0;
   int rasterizations = 0;
@@ -434,13 +449,20 @@ class _RecordingTileRasterBackend extends PdfCanvasTileRasterBackend {
   }
 }
 
-class _RecordingTileRasterSession implements PdfTileRasterSession {
+class _RecordingTileRasterSession
+    implements PdfTileRasterSession, PdfTileRasterScheduling {
   _RecordingTileRasterSession(this.backend, this.scene);
 
   final _RecordingTileRasterBackend backend;
 
   @override
   final PdfRetainedScene scene;
+
+  @override
+  bool get batchAdjacentTiles => backend.batchAdjacentTiles;
+
+  @override
+  int? get maxNewTilesPerPaint => backend.maxNewTilesPerPaint;
 
   @override
   Future<ui.Image> rasterizeRegion(

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -87,7 +87,7 @@ class _Persistence implements PdfTilePersistence {
       {required Rect region,
       required double pixelRatio,
       required int width,
-    required int height}) async {
+      required int height}) async {
     loads++;
     if (pending != null) return pending!.future;
     return loaded?.clone();
@@ -287,6 +287,34 @@ void main() {
         expect(store.debugBatchesDispatched, 2);
         expect(raster.calls, hasLength(2));
 
+        store.dispose();
+      });
+    });
+
+    testWidgets('a view can bypass the store slab policy', (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer(sizeFromRegion: true);
+
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(64, 64),
+          desiredRatio: 1,
+          visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+          rasterize: raster.call,
+          batchRasters: false,
+          maxNewTiles: 1,
+        );
+
+        expect(store.debugBatchesDispatched, 0,
+            reason: 'no slab may be created for a final-texture backend');
+        expect(raster.calls, hasLength(1));
+        expect(raster.calls.single.region.size, const Size(16, 16));
+        await raster.flush();
         store.dispose();
       });
     });
@@ -670,6 +698,16 @@ void main() {
         ),
         isFalse,
       );
+      final status = store.viewBudgetStatus(
+        pageSize: const Size(1536, 1536),
+        desiredRatio: 1,
+        visiblePageRect: const Rect.fromLTWH(0, 0, 1536, 1536),
+      )!;
+      expect(status.rung, 0);
+      expect(status.visibleTiles, 9);
+      expect(status.capacity, 8);
+      expect(status.limit, 6);
+      expect(status.fits, isFalse);
       store.dispose();
     });
 

--- a/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
+++ b/packages/dart_pdf_editor_flutter_gpu/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Render final GPU tile textures directly and admit one per repaint, avoiding
+  deferred slab-to-tile texture-copy bursts. Track synchronous issue time and
+  command-buffer completion latency, failures, and in-flight submissions.
 - Render ordinary non-rectangular PDF clip stacks exactly with retained
   stencil geometry, including nested even-odd/nonzero clips and save/restore;
   rectangular clips keep the cheaper scissor path.

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -14,7 +14,7 @@ import 'package:vector_math/vector_math.dart' as vm;
 
 import 'backend_stats.dart';
 
-/// Scene-retained flutter_gpu backend for LoD tile slabs.
+/// Scene-retained flutter_gpu backend for final LoD tile textures.
 ///
 /// The first tile lazily compiles supported retained commands into page-space
 /// GPU buffers and uploads every decoded image once. Later tiles only query the
@@ -668,7 +668,8 @@ bool _commandNeedsDarken(
   };
 }
 
-class _FlutterGpuTileSession implements PdfTileRasterSession {
+class _FlutterGpuTileSession
+    implements PdfTileRasterSession, PdfTileRasterScheduling {
   _FlutterGpuTileSession({
     required this.scene,
     required this.context,
@@ -682,6 +683,18 @@ class _FlutterGpuTileSession implements PdfTileRasterSession {
 
   @override
   final PdfRetainedScene scene;
+
+  // This backend already returns a final GPU texture for every raster call.
+  // Slab splitting would queue another texture-to-texture copy per tile; those
+  // copies are deferred by Impeller and have shown up as later 90ms raster
+  // frames even though the synchronous split loop itself takes <1ms.
+  @override
+  bool get batchAdjacentTiles => false;
+
+  // Keep the base/coarse tile visible and issue one new texture per repaint.
+  // Completion ticks the store, naturally advancing the center-out queue.
+  @override
+  int get maxNewTilesPerPaint => 1;
   final gpu.GpuContext context;
   final _GpuPipelines pipelines;
   final List<_GpuUnit> units;
@@ -720,6 +733,7 @@ class _FlutterGpuTileSession implements PdfTileRasterSession {
     try {
       final compiled = await _compile();
       if (_disposed) throw StateError('flutter_gpu tile session disposed');
+      final issue = Stopwatch()..start();
       final selected = _selectGpuUnits(units, compiled.pageToRaster, region);
       stats.selectedCommands += selected.length;
       final image = compiled.render(
@@ -728,9 +742,20 @@ class _FlutterGpuTileSession implements PdfTileRasterSession {
         pixelRatio: pixelRatio,
         pipelines: pipelines,
         useMsaa: msaa,
+        tracePage: tracePage,
       );
       stats.tilesRendered++;
       stats.lastTileRoute = 'flutter_gpu';
+      PdfPerfLog.log(
+        'tile gpu issue page=${tracePage ?? '-'} '
+        'region=${region.width.toStringAsFixed(0)}x'
+        '${region.height.toStringAsFixed(0)}pt '
+        'ratio=${pixelRatio.toStringAsFixed(2)} '
+        'selected=${selected.length}/${units.length} '
+        'img=${image.width}x${image.height} '
+        'cpu=${(issue.elapsedMicroseconds / 1000).toStringAsFixed(1)}ms '
+        'inFlight=${stats.inFlightSubmissions}',
+      );
       return image;
     } catch (error) {
       if (!_failureReported && !_disposed) {
@@ -875,8 +900,28 @@ class _CompiledScene {
     geometryPool.releaseAll(geometryLeases, stats);
   }
 
-  void _completeSubmission(bool success) {
+  void _completeSubmission(
+    bool success,
+    Stopwatch completion,
+    int? tracePage,
+    int width,
+    int height,
+    int selectedCommands,
+  ) {
     if (_inFlight > 0) _inFlight--;
+    stats.inFlightSubmissions = math.max(0, stats.inFlightSubmissions - 1);
+    final elapsed = completion.elapsedMicroseconds;
+    stats
+      ..completedSubmissions += 1
+      ..completionMicros += elapsed
+      ..maxCompletionMicros = math.max(stats.maxCompletionMicros, elapsed);
+    if (!success) stats.failedSubmissions++;
+    PdfPerfLog.log(
+      'tile gpu complete page=${tracePage ?? '-'} '
+      'img=${width}x$height selected=$selectedCommands '
+      'queue=${(elapsed / 1000).toStringAsFixed(1)}ms '
+      'success=$success inFlight=${stats.inFlightSubmissions}',
+    );
     _releaseGeometryIfReady();
   }
 
@@ -886,6 +931,7 @@ class _CompiledScene {
     required double pixelRatio,
     required _GpuPipelines pipelines,
     required bool useMsaa,
+    int? tracePage,
   }) {
     final width = (region.width * pixelRatio).ceil().clamp(1, 1 << 14);
     final height = (region.height * pixelRatio).ceil().clamp(1, 1 << 14);
@@ -897,6 +943,7 @@ class _CompiledScene {
       useMsaa: useMsaa,
       width: width,
       height: height,
+      tracePage: tracePage,
     );
   }
 
@@ -908,7 +955,9 @@ class _CompiledScene {
     required bool useMsaa,
     required int width,
     required int height,
+    int? tracePage,
   }) {
+    final issue = Stopwatch()..start();
     final multisampled = useMsaa && context.doesSupportOffscreenMSAA;
     final resolve = context.createTexture(
       gpu.StorageMode.devicePrivate,
@@ -983,15 +1032,36 @@ class _CompiledScene {
     }
     stats.clipMaskRebuilds += encoder.clipMaskRebuilds;
     final submit = Stopwatch()..start();
+    final completion = Stopwatch()..start();
     _inFlight++;
+    stats
+      ..inFlightSubmissions += 1
+      ..peakInFlightSubmissions = math.max(
+        stats.peakInFlightSubmissions,
+        stats.inFlightSubmissions,
+      );
     try {
-      commandBuffer.submit(completionCallback: _completeSubmission);
+      commandBuffer.submit(
+        completionCallback: (success) => _completeSubmission(
+          success,
+          completion,
+          tracePage,
+          width,
+          height,
+          selected.length,
+        ),
+      );
     } catch (_) {
       _inFlight--;
+      stats
+        ..inFlightSubmissions = math.max(0, stats.inFlightSubmissions - 1)
+        ..failedSubmissions += 1;
       _releaseGeometryIfReady();
       rethrow;
     }
-    stats.submitMicros += submit.elapsedMicroseconds;
+    stats
+      ..submitMicros += submit.elapsedMicroseconds
+      ..issueMicros += issue.elapsedMicroseconds;
     return resolve.asImage();
   }
 

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_stats.dart
@@ -31,7 +31,14 @@ class FlutterGpuTileBackendStats {
   int peakTextureBytes = 0;
   int tilesRendered = 0;
   int selectedCommands = 0;
+  int issueMicros = 0;
   int submitMicros = 0;
+  int completedSubmissions = 0;
+  int completionMicros = 0;
+  int maxCompletionMicros = 0;
+  int failedSubmissions = 0;
+  int inFlightSubmissions = 0;
+  int peakInFlightSubmissions = 0;
 
   /// A JSON-safe snapshot suitable for diagnostics and benchmark artifacts.
   Map<String, Object?> toJson() => {
@@ -66,7 +73,14 @@ class FlutterGpuTileBackendStats {
         'peakTextureBytes': peakTextureBytes,
         'tilesRendered': tilesRendered,
         'selectedCommands': selectedCommands,
+        'issueMicros': issueMicros,
         'submitMicros': submitMicros,
+        'completedSubmissions': completedSubmissions,
+        'completionMicros': completionMicros,
+        'maxCompletionMicros': maxCompletionMicros,
+        'failedSubmissions': failedSubmissions,
+        'inFlightSubmissions': inFlightSubmissions,
+        'peakInFlightSubmissions': peakInFlightSubmissions,
       };
 
   /// Clears lifetime counters without corrupting live resource gauges.
@@ -98,7 +112,13 @@ class FlutterGpuTileBackendStats {
     peakTextureBytes = textureBytes;
     tilesRendered = 0;
     selectedCommands = 0;
+    issueMicros = 0;
     submitMicros = 0;
+    completedSubmissions = 0;
+    completionMicros = 0;
+    maxCompletionMicros = 0;
+    failedSubmissions = 0;
+    peakInFlightSubmissions = inFlightSubmissions;
     lastRejection = null;
     lastTileRoute = null;
   }
@@ -121,5 +141,10 @@ class FlutterGpuTileBackendStats {
       'activeLeases=$activeTextureLeases '
       'textureBytes=$textureBytes peakTextureBytes=$peakTextureBytes '
       'tiles=$tilesRendered lastRoute=$lastTileRoute '
-      'selected=$selectedCommands submitUs=$submitMicros';
+      'selected=$selectedCommands issueUs=$issueMicros '
+      'submitUs=$submitMicros completed=$completedSubmissions '
+      'completionUs=$completionMicros maxCompletionUs=$maxCompletionMicros '
+      'failedSubmissions=$failedSubmissions '
+      'inFlightSubmissions=$inFlightSubmissions '
+      'peakInFlightSubmissions=$peakInFlightSubmissions';
 }

--- a/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/backend_stats_test.dart
@@ -17,12 +17,20 @@ void main() {
       ..geometryBuffers = 3
       ..geometryBytes = 32 << 20
       ..peakGeometryBytes = 48 << 20
+      ..completedSubmissions = 8
+      ..completionMicros = 32000
+      ..maxCompletionMicros = 9000
+      ..failedSubmissions = 1
+      ..inFlightSubmissions = 2
+      ..peakInFlightSubmissions = 4
       ..lastTileRoute = 'canvas-fallback'
       ..lastRejection = 'test fallback';
 
     expect(stats.toJson(), containsPair('rasterFallbacks', 1));
     expect(stats.toJson(), containsPair('lastRejection', 'test fallback'));
     expect(stats.toJson(), containsPair('lastTileRoute', 'canvas-fallback'));
+    expect(stats.toJson(), containsPair('completedSubmissions', 8));
+    expect(stats.toJson(), containsPair('maxCompletionMicros', 9000));
 
     stats.reset();
     expect(stats.sessionsCreated, 0);
@@ -37,5 +45,9 @@ void main() {
     expect(stats.geometryBuffers, 3);
     expect(stats.geometryBytes, 32 << 20);
     expect(stats.peakGeometryBytes, 32 << 20);
+    expect(stats.completedSubmissions, 0);
+    expect(stats.completionMicros, 0);
+    expect(stats.inFlightSubmissions, 2);
+    expect(stats.peakInFlightSubmissions, 2);
   });
 }

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -68,7 +68,7 @@ void main() {
     });
   });
 
-  testWidgets('compiles once and replays retained buffers across tile slabs',
+  testWidgets('compiles once and replays retained buffers across tiles',
       (tester) async {
     await tester.runAsync(() async {
       if (!_gpuAvailable()) {
@@ -82,6 +82,10 @@ void main() {
       final session = backend.createSession(scene);
       expect(session, isNotNull, reason: backend.stats.lastRejection);
       addTearDown(session!.dispose);
+      expect(session, isA<PdfTileRasterScheduling>());
+      final scheduling = session as PdfTileRasterScheduling;
+      expect(scheduling.batchAdjacentTiles, isFalse);
+      expect(scheduling.maxNewTilesPerPaint, 1);
       expect(backend.stats.activeSessions, 1);
       expect(backend.stats.lastTileRoute, 'flutter_gpu-session');
 
@@ -103,7 +107,11 @@ void main() {
         difference += (expected[i] - actual[i]).abs();
       }
       expect(difference / expected.length, lessThan(12),
-          reason: 'GPU slab should agree with Canvas apart from AA edges');
+          reason: 'GPU tile should agree with Canvas apart from AA edges');
+      expect(backend.stats.completedSubmissions, 1);
+      expect(backend.stats.maxCompletionMicros, greaterThan(0));
+      expect(backend.stats.inFlightSubmissions, 0,
+          reason: 'pixel readback waits for the submitted render to finish');
       expect(backend.stats.scenesCompiled, 1);
       expect(backend.stats.texturesUploaded, 1);
       final buffers = backend.stats.geometryBuffers;


### PR DESCRIPTION
## What changed

- Added an optional `PdfTileRasterScheduling` capability at the scene-session boundary. Existing custom sessions keep Canvas-compatible defaults.
- Made the native `flutter_gpu` session request final tiles directly instead of batched slabs, and admit one new tile per repaint.
- Kept adjacent-tile slab batching for the Canvas backend, where it still amortizes `toImage` overhead.
- Added per-view tile-budget diagnostics, including rung, visible tiles, capacity, and the 75% admission limit, so a single-patch fallback no longer appears merely as `tiles=active` in traces.
- Added GPU issue/completion telemetry to backend stats and DevTools: average issue time, average/worst submit-to-completion latency, failures, and current/peak in-flight submissions.

## Why

The latest native trace showed slab slicing taking only 0.1 ms synchronously, followed several hundred milliseconds later by a roughly 90 ms raster-thread frame. Each `_sliceTile` call used `Picture.toImageSync`, which queued a texture copy; a 30-tile slab therefore created a deferred burst that the existing submit-only telemetry could not see.

`flutter_gpu` already produces a final GPU texture for each raster request. Rendering one final 512 px tile at a time removes the slab-to-tile copies and uses the existing store repaint notification as a natural frame-paced queue. The base or coarser LoD remains visible while sharper tiles fill center-out.

## Impact

- GPU tile work no longer creates the deferred texture-copy burst seen in the field trace.
- Canvas behavior and its lower-overhead slab path are unchanged.
- Third-party tile sessions are source-compatible because scheduling is an optional capability.
- DevTools can distinguish cheap command issue from delayed GPU queue completion and can explain why an oversized view used the bounded single detail patch.

## Real-document validation

Heavy CAD (`ly9-far-cad.pdf`, zero-based pages 68–70, 512 px at two LoDs, Impeller + flutter_gpu):

- all three scenes accepted; zero runtime fallbacks
- warm GPU tiles: 8.59 ms, 4.83 ms, and 3.24 ms
- peak in-flight submissions: 1
- the new completion metric exposed a 256.9 ms worst cold compile/upload completion rather than misreporting it as cheap submit work

Image-heavy quickstart sample (pages 27, 30, 29, 32, 31, 34, 37, 39, 28): page 32 stayed on GPU (19.4 ms warm versus 368.5 ms Canvas for the comparison tile); unsupported composite/group cases continued to reject conservatively to Canvas.

## Checks

- `fvm dart analyze`
- `packages/dart_pdf_editor`: full Flutter suite (2,183 passed)
- `packages/dart_pdf_editor_flutter_gpu`: full suite with `--enable-impeller --enable-flutter-gpu` (231 passed)
- `app`: full Flutter suite (421 passed)
- Ghent + PDF.js pure-Dart corpus gates
- Ghent pixel baselines + PDF.js render smoke gates
- native GPU real-document benchmarks for the CAD and image-heavy samples
