### PR TITLE
Fix zoomed raster cache promotion

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Keep off-screen neighbour pages at fit-resolution base rasters during deep
   zoom, promoting them only when they enter the viewport, so navigation no
   longer allocates high-zoom full-page rasters that are immediately replaced.
+  Cache-restored fit rasters now trigger that same promotion instead of
+  remaining enlarged after entering an already-zoomed viewport.
 - Require 750 ms of continuous viewer idle time before whole-document
   thumbnail warming starts or resumes, and restart that quiet window when
   navigation changes focus.

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -836,18 +836,28 @@ class _PdfPageViewState extends State<PdfPageView>
     // the reduced buffer (and its raster) so the render below rebuilds it
     // sharp. Guarded on an actual ratio increase, so it fires once as the page
     // approaches focus, not as a churn loop.
-    var droppedForFocus = false;
-    if ((widget.focusDistance < oldWidget.focusDistance ||
-            (widget.onScreen && !oldWidget.onScreen)) &&
-        !_renderedAtFullImageRatio()) {
-      // _dropPicture nulls _rasteredRatio, so the render below re-rasters
-      // rather than skipping. The reduced-resolution base raster is left up
-      // (it is the right geometry, only its images are soft) until the
-      // full-resolution one replaces it - no blank flash as a page scrolls in.
-      _dropPicture();
-      droppedForFocus = true;
+    var promoteForFocus = false;
+    final enteredViewport = widget.onScreen && !oldWidget.onScreen;
+    if (widget.focusDistance < oldWidget.focusDistance || enteredViewport) {
+      if (!_renderedAtFullImageRatio()) {
+        // _dropPicture nulls _rasteredRatio, so the render below re-rasters
+        // rather than skipping. The reduced-resolution base raster is left up
+        // (it is the right geometry, only its images are soft) until the
+        // full-resolution one replaces it - no blank flash as a page scrolls in.
+        _dropPicture();
+        promoteForFocus = true;
+      }
+      // onScreen deliberately does not participate in PdfPageRenderIntent: it
+      // is a scheduling hint, not part of pixel identity. It must still wake a
+      // zoomed page, though. An off-screen page may have restored an exact
+      // fit-size raster from PdfPagePreviewCache; that restore carries no
+      // retained picture and _pictureImageRatio is null, so the image-ratio
+      // promotion above correctly has nothing to invalidate. Without this
+      // explicit wake-up the fit raster remains enlarged after it scrolls into
+      // the zoomed viewport because no render-intent field changed.
+      if (enteredViewport && widget.scale > 1.05) promoteForFocus = true;
     }
-    if (transition.scheduleRender || droppedForFocus) {
+    if (transition.scheduleRender || promoteForFocus) {
       // scale change re-rasters the page; a settle that only moved the
       // viewport refreshes the detail patch. Both route through _render so
       // they pace and coalesce through the scheduler (_renderNow skips the

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -380,7 +380,7 @@ void main() {
             controller: controller,
             pageRasterCachePolicy: policy,
           ),
-        );
+    );
 
     await tester.pumpWidget(viewer(generous));
     expect(controller.pagePreviewCache!.maxFullRasterBytes,
@@ -616,6 +616,69 @@ void main() {
     expect(previewRaster, findsNothing);
     expect(scheduler.hasPending, isFalse,
         reason: 'a cache hit must not wait for scroll-settle release');
+  });
+
+  testWidgets('an off-screen cache hit promotes when it enters a zoomed view',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+
+    Widget pageView({required double scale, required bool onScreen}) =>
+        MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 400,
+              child: PdfPageView(
+                page: page,
+                scale: scale,
+                onScreen: onScreen,
+                previewCache: cache,
+              ),
+            ),
+          ),
+        );
+
+    // Seed the exact fit-size raster, then dispose the page state like the lazy
+    // viewer does after it leaves the build window.
+    await tester.pumpWidget(pageView(scale: 1, onScreen: true));
+    for (var i = 0;
+        i < 50 && (fullRaster.evaluate().isEmpty || cache.fullRasterCount == 0);
+        i++) {
+      await settle(tester);
+    }
+    final fitWidth = tester.widget<RawImage>(fullRaster).image!.width;
+    expect(cache.fullRasterCount, greaterThan(0));
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    // A global viewer zoom also reaches lazy-list neighbours. Off-screen pages
+    // deliberately stay at fit resolution, so this remount restores the cached
+    // fit raster even though the live transform is at 4x.
+    await tester.pumpWidget(pageView(scale: 4, onScreen: false));
+    await tester.pump();
+    expect(tester.widget<RawImage>(fullRaster).image!.width, fitWidth);
+
+    // Crossing into the viewport must promote that cache-only raster. Before
+    // the regression fix, onScreen was not a render-intent input and the cache
+    // restore carried no picture/image-ratio metadata, so this stayed enlarged
+    // from fit resolution forever.
+    await tester.pumpWidget(pageView(scale: 4, onScreen: true));
+    for (var i = 0; i < 100; i++) {
+      await settle(tester);
+      if (tester.widget<RawImage>(fullRaster).image!.width > fitWidth * 2) {
+        break;
+      }
+    }
+    expect(
+      tester.widget<RawImage>(fullRaster).image!.width,
+      greaterThan(fitWidth * 2),
+      reason: 'an on-screen zoom must replace the fit-size cached raster',
+    );
   });
 
   testWidgets('an on-screen render feeds the cache without re-interpreting',


### PR DESCRIPTION
## Summary

- promote cache-restored fit-size page rasters when they enter an already-zoomed viewport
- preserve the fit-resolution optimization for pages that remain off-screen
- add a regression test covering lazy-page disposal, exact-raster restoration, and viewport entry at 4× zoom

## Root cause

`onScreen` is intentionally a render scheduling hint rather than part of pixel identity. A page restored from `PdfPagePreviewCache` while off-screen had no retained picture and a null image-ratio marker, so the existing reduced-image promotion guard did not schedule any work when that page entered the viewport. The fit-size raster could therefore remain enlarged indefinitely.

## Impact

Raster-backed PDF content now sharpens consistently after a cached page scrolls into an already-zoomed viewport, without bringing back expensive high-zoom rendering for off-screen neighbour pages.

## Validation

- `fvm flutter test test/page_preview_test.dart test/page_on_screen_test.dart test/render_hold_test.dart test/tile_image_detail_test.dart test/tile_store_page_view_test.dart`
- `fvm flutter test test/pdf_page_view_test.dart test/full_raster_disk_cache_test.dart test/raster_warm_test.dart`
- `fvm dart analyze`
- `git diff --check`