### PR TITLE
feat(viewer): add intermediate fast-scroll preview LoDs

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Promote fast-scroll page previews through a configurable 200 -> 400 -> 800
+  px LoD ladder before the final display raster. Intermediate levels warm only
+  around the viewport, share a 32 MiB byte-budgeted LRU, and are generated from
+  completed page rasters by serial image blits when possible; live pages never
+  downgrade when a cached level is evicted. Expose LoD occupancy and evictions
+  through `PdfViewerController.pagePreviewLodStats` and perf logs.
 - Let a tile raster session opt out of adjacent-tile slab batching and cap new
   work admitted by each paint, while preserving Canvas batching and existing
   third-party session compatibility. Expose the exact visible-tile budget

--- a/packages/dart_pdf_editor/lib/src/comparison/comparison_view.dart
+++ b/packages/dart_pdf_editor/lib/src/comparison/comparison_view.dart
@@ -41,6 +41,7 @@ class PdfComparisonView extends StatefulWidget {
     this.showNavigator = true,
     this.pixelRatio = 1.5,
     this.viewerTheme,
+    this.pagePreviewLodPolicy = const PdfPagePreviewLodPolicy(),
     this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
     this.pageRasterWarmPolicy = const PdfPageRasterWarmPolicy.disabled(),
     this.tileRasterBackend = const PdfCanvasTileRasterBackend(),
@@ -62,6 +63,9 @@ class PdfComparisonView extends StatefulWidget {
 
   /// Wraps both panes in a [PdfViewerTheme].
   final PdfViewerThemeData? viewerTheme;
+
+  /// Intermediate fast-scroll preview levels and their shared memory budget.
+  final PdfPagePreviewLodPolicy pagePreviewLodPolicy;
 
   /// Memory policy for exact full-resolution rasters of previously visited
   /// pages in each comparison pane.
@@ -213,6 +217,7 @@ class _PdfComparisonViewState extends State<PdfComparisonView> {
             document: _beforeDoc,
             controller: _beforeCtl,
             initialFit: PdfViewerFit.width,
+            pagePreviewLodPolicy: widget.pagePreviewLodPolicy,
             pageRasterCachePolicy: widget.pageRasterCachePolicy,
             pageRasterWarmPolicy: widget.pageRasterWarmPolicy,
             tileRasterBackend: widget.tileRasterBackend,
@@ -228,6 +233,7 @@ class _PdfComparisonViewState extends State<PdfComparisonView> {
             document: _afterDoc,
             controller: _afterCtl,
             initialFit: PdfViewerFit.width,
+            pagePreviewLodPolicy: widget.pagePreviewLodPolicy,
             pageRasterCachePolicy: widget.pageRasterCachePolicy,
             pageRasterWarmPolicy: widget.pageRasterWarmPolicy,
             tileRasterBackend: widget.tileRasterBackend,
@@ -246,6 +252,7 @@ class _PdfComparisonViewState extends State<PdfComparisonView> {
       document: _afterDoc,
       controller: _afterCtl,
       initialFit: PdfViewerFit.width,
+      pagePreviewLodPolicy: widget.pagePreviewLodPolicy,
       pageRasterCachePolicy: widget.pageRasterCachePolicy,
       pageRasterWarmPolicy: widget.pageRasterWarmPolicy,
       tileRasterBackend: widget.tileRasterBackend,

--- a/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_editor_view.dart
@@ -260,6 +260,7 @@ class PdfEditorView extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pagePreviewLodPolicy = const PdfPagePreviewLodPolicy(),
     this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
     this.pageRasterWarmPolicy = const PdfPageRasterWarmPolicy.disabled(),
   })  : source = null,
@@ -342,6 +343,7 @@ class PdfEditorView extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pagePreviewLodPolicy = const PdfPagePreviewLodPolicy(),
     this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
     this.pageRasterWarmPolicy = const PdfPageRasterWarmPolicy.disabled(),
   })  : bytes = null,
@@ -383,6 +385,10 @@ class PdfEditorView extends StatefulWidget {
   /// active edit session mutates page content, so its text is never served
   /// from the content-keyed persistent cache (in-memory only).
   final PdfPageTextCache? textCache;
+
+  /// Intermediate fast-scroll preview levels and their shared memory budget.
+  /// See [PdfViewer.pagePreviewLodPolicy].
+  final PdfPagePreviewLodPolicy pagePreviewLodPolicy;
 
   /// Memory policy for exact full-resolution rasters of previously visited
   /// pages. See [PdfViewer.pageRasterCachePolicy].
@@ -1432,6 +1438,7 @@ class _PdfEditorViewState extends State<PdfEditorView> {
                         tileRasterBackend: widget.tileRasterBackend,
                         rasterCache: widget.rasterCache,
                         textCache: widget.textCache,
+                        pagePreviewLodPolicy: widget.pagePreviewLodPolicy,
                         pageRasterCachePolicy: widget.pageRasterCachePolicy,
                         pageRasterWarmPolicy: widget.pageRasterWarmPolicy,
                         documentId: _documentKey,

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -613,6 +613,7 @@ class _PdfPageViewState extends State<PdfPageView>
   /// Clone of this page's cached low-res preview; painted while no full
   /// raster exists, dropped (to free the buffer) the moment one lands.
   ui.Image? _preview;
+  int? _previewCacheGeneration;
 
   /// Monotonic sequence assigned to each streamed progressive partial (#564),
   /// never reset - so partials from a newer render pass always outrank an older
@@ -735,7 +736,7 @@ class _PdfPageViewState extends State<PdfPageView>
     if (!mounted ||
         _image != null ||
         _slugPicture != null ||
-        _preview != null) {
+        (_preview != null && _previewCacheGeneration == null)) {
       return;
     }
     setState(_refreshPreview);
@@ -744,11 +745,32 @@ class _PdfPageViewState extends State<PdfPageView>
   void _refreshPreview() {
     final cache = widget.previewCache;
     if (cache == null || _image != null || _slugPicture != null) return;
-    final next = cache.imageFor(widget.previewIndex);
-    if (next == null) return; // keep whatever we already hold
+    final frame = cache.previewFor(widget.previewIndex);
+    if (frame == null) return; // keep whatever we already hold
+    final next = frame.image;
+    if (_preview != null) {
+      if (_previewCacheGeneration == frame.generation) {
+        next.dispose();
+        return;
+      }
+      final currentPixels = _preview!.width * _preview!.height;
+      final nextPixels = next.width * next.height;
+      if (nextPixels < currentPixels) {
+        // A byte-budget eviction can remove the sharpest cached LoD while the
+        // page still owns a live clone. Keep painting that clone rather than
+        // visibly stepping backward to the base preview.
+        next.dispose();
+        return;
+      }
+    }
     _preview?.dispose();
     _preview = next;
-    PdfPerfLog.log('preview-paint page=${widget.previewIndex}');
+    _previewCacheGeneration = frame.generation;
+    PdfPerfLog.log(
+      'preview-paint page=${widget.previewIndex} '
+      'lod=${frame.lod == PdfPagePreviewLod.base ? 'base' : '${frame.targetLongestSide}px'} '
+      '${next.width}x${next.height}',
+    );
   }
 
   @override
@@ -824,6 +846,7 @@ class _PdfPageViewState extends State<PdfPageView>
       widget.previewCache?.addListener(_onPreviewCacheChanged);
       _preview?.dispose();
       _preview = null;
+      _previewCacheGeneration = null;
       _refreshPreview();
     }
     if (transition.dropBaseRaster) {
@@ -843,6 +866,7 @@ class _PdfPageViewState extends State<PdfPageView>
       _imageState = null;
       _preview?.dispose();
       _preview = null;
+      _previewCacheGeneration = null;
     }
     if (transition.dropPicture) {
       // Re-interpret at the new content/page. Unless we blanked above, the
@@ -1726,6 +1750,7 @@ class _PdfPageViewState extends State<PdfPageView>
     setState(() {
       _preview?.dispose();
       _preview = image;
+      _previewCacheGeneration = null;
     });
     PdfPerfLog.log('early-prefix page=$pageIndex commands=${commands.length} '
         'limit=${PdfPageView.earlyPrefixCommandLimit}${PdfPerfLog.rssSuffix()}');
@@ -1821,6 +1846,7 @@ class _PdfPageViewState extends State<PdfPageView>
     setState(() {
       _preview?.dispose();
       _preview = image;
+      _previewCacheGeneration = null;
     });
     PdfPerfLog.log('progressive-partial page=$pageIndex seq=$seq '
         'commands=${commands.length} ui='

--- a/packages/dart_pdf_editor/lib/src/pdf_reader.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_reader.dart
@@ -146,6 +146,7 @@ class PdfReader extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pagePreviewLodPolicy = const PdfPagePreviewLodPolicy(),
     this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
     this.pageRasterWarmPolicy = const PdfPageRasterWarmPolicy.disabled(),
   })  : source = null,
@@ -193,6 +194,7 @@ class PdfReader extends StatefulWidget {
     this.viewerTheme,
     this.rasterCache,
     this.textCache,
+    this.pagePreviewLodPolicy = const PdfPagePreviewLodPolicy(),
     this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
     this.pageRasterWarmPolicy = const PdfPageRasterWarmPolicy.disabled(),
   }) : bytes = null;
@@ -231,6 +233,10 @@ class PdfReader extends StatefulWidget {
   /// by [documentId], so reopening a document searches it without re-walking
   /// every page's content stream.
   final PdfPageTextCache? textCache;
+
+  /// Intermediate fast-scroll preview levels and their shared memory budget.
+  /// See [PdfViewer.pagePreviewLodPolicy].
+  final PdfPagePreviewLodPolicy pagePreviewLodPolicy;
 
   /// Memory policy for exact full-resolution rasters of previously visited
   /// pages. See [PdfViewer.pageRasterCachePolicy].
@@ -561,6 +567,7 @@ class _PdfReaderState extends State<PdfReader> {
                           tileRasterBackend: widget.tileRasterBackend,
                           rasterCache: widget.rasterCache,
                           textCache: widget.textCache,
+                          pagePreviewLodPolicy: widget.pagePreviewLodPolicy,
                           pageRasterCachePolicy: widget.pageRasterCachePolicy,
                           pageRasterWarmPolicy: widget.pageRasterWarmPolicy,
                           documentId: _documentKey,

--- a/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_viewer.dart
@@ -435,6 +435,10 @@ class PdfViewerController extends ChangeNotifier {
   /// shows during a fast scroll, shared rather than re-rendered.
   PdfPagePreviewCache? get pagePreviewCache => _state?._previews;
 
+  /// Current occupancy and evictions for the base/intermediate fast-scroll
+  /// preview ladder. Null when no viewer is attached.
+  PdfPagePreviewLodStats? get pagePreviewLodStats => _state?._previews.lodStats;
+
   /// Test hook: whether the attached viewer is currently holding page
   /// renders back for a fast scroll; false when no viewer is attached.
   @visibleForTesting
@@ -1009,6 +1013,7 @@ class PdfViewer extends StatefulWidget {
     this.highlightFormFields = true,
     this.interactiveForms = true,
     this.pagePreviews = true,
+    this.pagePreviewLodPolicy = const PdfPagePreviewLodPolicy(),
     this.previewWindow = 6,
     this.pageRasterCachePolicy = const PdfPageRasterCachePolicy(),
     this.pageRasterWarmPolicy = const PdfPageRasterWarmPolicy.disabled(),
@@ -1419,9 +1424,16 @@ class PdfViewer extends StatefulWidget {
   /// free as pages are viewed; pages never seen are filled in by a
   /// background prerender (nearest the viewport first, paused while the
   /// user scrolls). Costs one interpreter walk per page over the
-  /// session plus up to ~40 MB of preview pixels on very long
-  /// documents.
+  /// session plus up to ~40 MB of tiny previews on very long documents;
+  /// [pagePreviewLodPolicy] adds a separate byte-bounded nearby working set
+  /// (32 MiB by default).
   final bool pagePreviews;
+
+  /// The intermediate steps between the tiny fast-scroll fallback and the
+  /// final display raster. The default 200 -> 400 -> 800 -> final ladder is
+  /// warmed only near the viewport and shares a byte-budgeted LRU; see
+  /// [PdfPagePreviewLodPolicy]. [pagePreviews] must be true.
+  final PdfPagePreviewLodPolicy pagePreviewLodPolicy;
 
   /// See the constructor doc - false pauses page rendering and the preview
   /// prerender while another view overlays the viewer.
@@ -1528,6 +1540,7 @@ class _PdfViewerState extends State<PdfViewer>
   /// identity), so a page whose render throws can't be retried forever.
   final _previewAttempts = Set<PdfPage>.identity();
   final _previewVectorAttempts = Set<PdfPage>.identity();
+  final Map<double, Set<PdfPage>> _intermediatePreviewAttempts = {};
   bool _prerendering = false;
 
   /// Pages the idle full-raster warm already produced (or gave up on), by page
@@ -1940,10 +1953,12 @@ class _PdfViewerState extends State<PdfViewer>
         if (animation != null) _transform.value = animation.value;
       });
     _previews.configureFullRasterCache(widget.pageRasterCachePolicy);
+    _previews.configurePreviewLods(widget.pagePreviewLodPolicy);
     // Background full-raster encodes yield to scrolling and to a foreground
     // render holding the raster thread (#615).
     _previews.deferBackgroundIo = () => !mounted || _motionRenderHoldActive;
     _loadPages();
+    _previews.bindPages(_pages);
     _snapshotContentStamps();
     _bindRasterCache();
     _scroll.addListener(_onScroll);
@@ -2004,6 +2019,9 @@ class _PdfViewerState extends State<PdfViewer>
         'freed ${liveFreed >> 20}MB of live rasters'
         '${PdfPerfLog.rssSuffix()}');
     _previews.clear();
+    _previewAttempts.clear();
+    _previewVectorAttempts.clear();
+    _intermediatePreviewAttempts.clear();
   }
 
   void _onPerformanceChanged() {
@@ -2307,7 +2325,9 @@ class _PdfViewerState extends State<PdfViewer>
             workerActive &&
             (widget.performance?.tuning.vectorFirstPreviews ?? false) &&
             _nextPreviewIndex(_pages,
-                    requireImages: false, allowNearViewport: false) !=
+                    requireImages: false,
+                    allowNearViewport: false,
+                    targetLongestSide: null) !=
                 null;
         final vectorOnly = motionVector || policyVector;
         if (!vectorOnly &&
@@ -2323,12 +2343,42 @@ class _PdfViewerState extends State<PdfViewer>
           continue;
         }
         final pages = _pages;
-        final index = _nextPreviewIndex(pages,
-            requireImages: !vectorOnly, allowNearViewport: false);
+        double? targetLongestSide;
+        var index = _nextPreviewIndex(
+          pages,
+          requireImages: !vectorOnly,
+          allowNearViewport: false,
+          targetLongestSide: null,
+        );
+        // Base coverage always wins: the 200px level is the only one cheap
+        // enough to be the immediate fallback everywhere. Once it is covered,
+        // promote the near working set one geometric level at a time. Never
+        // do these image-complete promotions during motion/vector-first mode.
+        if (index == null && !vectorOnly) {
+          for (final target in _previews.intermediateLongestSides) {
+            index = _nextPreviewIndex(
+              pages,
+              requireImages: true,
+              allowNearViewport: false,
+              targetLongestSide: target,
+            );
+            if (index != null) {
+              targetLongestSide = target;
+              break;
+            }
+          }
+        }
         if (index == null) return; // every page covered (or attempted)
         final page = pages[index];
         if (vectorOnly) {
           _previewVectorAttempts.add(page);
+        } else if (targetLongestSide != null) {
+          _intermediatePreviewAttempts
+              .putIfAbsent(
+                targetLongestSide,
+                () => Set<PdfPage>.identity(),
+              )
+              .add(page);
         } else {
           _previewAttempts.add(page);
         }
@@ -2339,6 +2389,7 @@ class _PdfViewerState extends State<PdfViewer>
             worker: _effectiveRenderWorker,
             rotation: _effectiveRotation(index),
             decodeImages: !vectorOnly,
+            targetLongestSide: targetLongestSide,
             commandLimit: vectorOnly ? _jumpPreviewOperationLimit : null,
             deferUiWork: vectorOnly
                 ? () {
@@ -2347,6 +2398,18 @@ class _PdfViewerState extends State<PdfViewer>
                     return defer;
                   }
                 : null);
+        if (targetLongestSide != null &&
+            _previews.isFresh(
+              index,
+              page,
+              requireImages: true,
+              targetLongestSide: targetLongestSide,
+            )) {
+          // Success is represented by the cache itself, not the failure guard:
+          // if the byte LRU later evicts this level after the viewport moves,
+          // returning here should make it eligible for promotion again.
+          _intermediatePreviewAttempts[targetLongestSide]?.remove(page);
+        }
         if (deferredPreview && mounted) {
           // The worker may finish while the gesture is still moving. In that
           // case renderPreview deliberately skips the UI replay/raster step;
@@ -2371,7 +2434,15 @@ class _PdfViewerState extends State<PdfViewer>
   /// window render fully on their own - their full picture feeds the
   /// cache, so prerendering them too would interpret twice).
   int? _nextPreviewIndex(List<PdfPage> pages,
-      {required bool requireImages, required bool allowNearViewport}) {
+      {required bool requireImages,
+      required bool allowNearViewport,
+      required double? targetLongestSide}) {
+    if (targetLongestSide != null &&
+        (!widget.pagePreviewLodPolicy.enabled ||
+            widget.pagePreviewLodPolicy.intermediateWindow == 0 ||
+            !_previews.intermediateLongestSides.contains(targetLongestSide))) {
+      return null;
+    }
     final current =
         pages.isEmpty ? 0 : _controller.currentPage.clamp(0, pages.length - 1);
     final hasMetrics = _scroll.hasClients && _viewWidth > 0;
@@ -2398,14 +2469,27 @@ class _PdfViewerState extends State<PdfViewer>
       // bound the proactive warm to a window around the viewport - far
       // pages render on demand on arrival (render hold) and feed the
       // cache for free when scrolled through (putFromPicture)
-      final window = _effectivePreviewWindow(requireImages: requireImages);
+      final window = targetLongestSide == null
+          ? _effectivePreviewWindow(requireImages: requireImages)
+          : widget.pagePreviewLodPolicy.intermediateWindow;
       if (window > 0 && distance > window) continue;
-      if (requireImages) {
+      if (targetLongestSide != null) {
+        if ((_intermediatePreviewAttempts[targetLongestSide]
+                ?.contains(pages[i]) ??
+            false)) {
+          continue;
+        }
+      } else if (requireImages) {
         if (_previewAttempts.contains(pages[i])) continue;
       } else if (_previewVectorAttempts.contains(pages[i])) {
         continue;
       }
-      if (_previews.isFresh(i, pages[i], requireImages: requireImages)) {
+      if (_previews.isFresh(
+        i,
+        pages[i],
+        requireImages: requireImages,
+        targetLongestSide: targetLongestSide,
+      )) {
         continue;
       }
       if (distance < bestDistance) {
@@ -2733,6 +2817,13 @@ class _PdfViewerState extends State<PdfViewer>
       _rasterWarmAttempts.clear();
       _scheduleRasterWarm();
     }
+    if (oldWidget.pagePreviewLodPolicy != widget.pagePreviewLodPolicy) {
+      _previews.configurePreviewLods(widget.pagePreviewLodPolicy);
+      _intermediatePreviewAttempts.clear();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _prerenderPreviews();
+      });
+    }
     // Re-evaluate the owned default worker: a host worker may have been
     // supplied/removed, autoRenderWorker toggled, or the document swapped.
     _syncDefaultWorker();
@@ -2750,6 +2841,7 @@ class _PdfViewerState extends State<PdfViewer>
       _bindRasterCache();
       _previewAttempts.clear();
       _previewVectorAttempts.clear();
+      _intermediatePreviewAttempts.clear();
       // paper color and annotation visibility are part of the raster
       // signature, so every warmed raster just became unreachable
       _rasterWarmAttempts.clear();
@@ -2832,6 +2924,7 @@ class _PdfViewerState extends State<PdfViewer>
     _controller.clearSearch();
     _clearSelection();
     _loadPages();
+    _previews.bindPages(_pages);
     // an edit revision keeps its previews (rebound to the new page
     // objects - edited pages refresh from their on-screen render); a
     // different document starts clean
@@ -2860,6 +2953,7 @@ class _PdfViewerState extends State<PdfViewer>
     _bindRasterCache(prime: !sameGeometry);
     _previewAttempts.clear();
     _previewVectorAttempts.clear();
+    _intermediatePreviewAttempts.clear();
     // page objects changed, so every warmed raster is either rebound (content
     // unchanged) or gone; re-arm the pass over the new revision's pages
     _rasterWarmAttempts.clear();
@@ -3055,6 +3149,7 @@ class _PdfViewerState extends State<PdfViewer>
     _bindRasterCache();
     _previewAttempts.clear();
     _previewVectorAttempts.clear();
+    _intermediatePreviewAttempts.clear();
     // rotation is part of the raster signature (and changes the page's
     // physical size): nothing warmed under the old one can be reused
     _rasterWarmAttempts.clear();

--- a/packages/dart_pdf_editor/lib/src/preview_cache.dart
+++ b/packages/dart_pdf_editor/lib/src/preview_cache.dart
@@ -71,6 +71,124 @@ class PdfPageRasterCachePolicy {
   int get hashCode => Object.hash(maxBytes, maxEntryBytes);
 }
 
+/// Memory and background-work policy for the middle steps in the page-preview
+/// ladder.
+///
+/// Fast scrolling always keeps the existing tiny preview (200 px on its
+/// longest side by default) as the cheapest immediate fallback. When the
+/// viewer is idle, pages close to the viewport are additionally promoted to
+/// [intermediateLongestSides]. A completed on-screen raster can also populate
+/// these tiers with scaled image blits, without another PDF interpretation.
+/// The final display-sized raster remains separate.
+///
+/// The defaults make the visible steps roughly 200 px -> 400 px -> 800 px ->
+/// the display raster. Each promotion doubles linear resolution (and therefore
+/// quadruples pixels), so every level is visibly worthwhile. A shared 32 MiB
+/// RGBA budget keeps the ladder around the working set rather than one for
+/// every page in a long document. All values are configurable because a
+/// desktop document workstation and a memory-constrained phone should not be
+/// forced into the same trade-off.
+@immutable
+class PdfPagePreviewLodPolicy {
+  const PdfPagePreviewLodPolicy({
+    this.intermediateLongestSides = const [400, 800],
+    this.intermediateWindow = 2,
+    this.maxBytes = 32 * 1024 * 1024,
+    this.maxEntryBytes = 4 * 1024 * 1024,
+  })  : assert(intermediateWindow >= 0),
+        assert(maxBytes >= 0),
+        assert(maxEntryBytes >= 0);
+
+  /// Keeps only the tiny preview and the final raster.
+  const PdfPagePreviewLodPolicy.disabled()
+      : intermediateLongestSides = const [],
+        intermediateWindow = 0,
+        maxBytes = 0,
+        maxEntryBytes = 0;
+
+  /// Pixel sizes of the intermediate previews' longest sides.
+  ///
+  /// Values at or below the base preview size, duplicates, and non-positive
+  /// values are ignored; the remaining values are used in ascending order.
+  /// Keep this list short: each entry is another idle rasterization level.
+  final List<double> intermediateLongestSides;
+
+  /// Pages on either side of the current page proactively promoted while
+  /// idle. Pages actually viewed can still enter the tier outside this
+  /// window by being downscaled from their completed display raster.
+  final int intermediateWindow;
+
+  /// Total approximate RGBA byte budget for intermediate previews.
+  final int maxBytes;
+
+  /// Largest individual intermediate preview admitted to the cache.
+  final int maxEntryBytes;
+
+  bool get enabled =>
+      intermediateLongestSides.isNotEmpty && maxBytes > 0 && maxEntryBytes > 0;
+
+  @override
+  bool operator ==(Object other) =>
+      other is PdfPagePreviewLodPolicy &&
+      listEquals(intermediateLongestSides, other.intermediateLongestSides) &&
+      intermediateWindow == other.intermediateWindow &&
+      maxBytes == other.maxBytes &&
+      maxEntryBytes == other.maxEntryBytes;
+
+  @override
+  int get hashCode => Object.hash(Object.hashAll(intermediateLongestSides),
+      intermediateWindow, maxBytes, maxEntryBytes);
+}
+
+/// The progressive page-preview levels below the final display raster.
+enum PdfPagePreviewLod { base, intermediate }
+
+/// Snapshot of the preview pyramid's retained working set.
+///
+/// Exposed through [PdfViewerController.pagePreviewLodStats] and emitted in
+/// `preview-store` performance lines so DevTools/support traces can distinguish
+/// a genuinely missing middle level from one that was warmed and evicted.
+@immutable
+class PdfPagePreviewLodStats {
+  const PdfPagePreviewLodStats({
+    required this.baseEntries,
+    required this.baseBytes,
+    required this.intermediateEntries,
+    required this.intermediateBytes,
+    required this.intermediateEvictions,
+  });
+
+  final int baseEntries;
+  final int baseBytes;
+  final int intermediateEntries;
+  final int intermediateBytes;
+  final int intermediateEvictions;
+
+  @override
+  String toString() => 'preview-lod base=$baseEntries/${baseBytes}B '
+      'intermediate=$intermediateEntries/${intermediateBytes}B '
+      'evictions=$intermediateEvictions';
+}
+
+/// One owned preview clone plus the quality metadata needed to promote a live
+/// page without accidentally downgrading it when an LRU eviction occurs.
+class PdfPagePreviewFrame {
+  const PdfPagePreviewFrame({
+    required this.image,
+    required this.lod,
+    required this.targetLongestSide,
+    required this.includesImages,
+    required this.generation,
+  });
+
+  /// The caller-owned image clone.
+  final ui.Image image;
+  final PdfPagePreviewLod lod;
+  final double targetLongestSide;
+  final bool includesImages;
+  final int generation;
+}
+
 /// Everything that changes the pixels of a baked full-resolution page raster.
 ///
 /// This is the exact-raster cache's key. It is deliberately *not* just the page
@@ -154,10 +272,17 @@ class PdfPagePreviewCache extends ChangeNotifier {
   PdfPagePreviewCache({
     this.longestSide = 200,
     this.capacity = 300,
+    PdfPagePreviewLodPolicy lodPolicy = const PdfPagePreviewLodPolicy(),
     int maxFullRasterPixels = 8 << 20,
     int maxFullRasterEntryPixels = 4 << 20,
   })  : assert(maxFullRasterPixels >= 0),
         assert(maxFullRasterEntryPixels >= 0),
+        _intermediateLongestSides = _normalizedIntermediateSides(
+          longestSide,
+          lodPolicy.intermediateLongestSides,
+        ),
+        _maxIntermediateBytes = lodPolicy.maxBytes,
+        _maxIntermediateEntryBytes = lodPolicy.maxEntryBytes,
         _maxFullRasterBytes = maxFullRasterPixels * 4,
         _maxFullRasterEntryBytes = maxFullRasterEntryPixels * 4;
 
@@ -168,11 +293,37 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// Maximum number of cached previews (LRU eviction past it).
   final int capacity;
 
+  List<double> _intermediateLongestSides;
+  int _maxIntermediateBytes;
+  int _maxIntermediateEntryBytes;
+
+  /// Pixel sizes of the configured intermediate previews' longest sides.
+  List<double> get intermediateLongestSides =>
+      List<double>.unmodifiable(_intermediateLongestSides);
+
+  /// Approximate bytes retained by intermediate previews.
+  int get intermediateBytes => _intermediateEntries.weight;
+
+  /// Number of retained intermediate previews.
+  int get intermediateCount => _intermediateEntries.length;
+
+  /// Intermediate previews evicted by the byte budget.
+  int get intermediateEvictions => _intermediateEntries.evictions;
+
+  /// Current low/intermediate cache occupancy for diagnostics.
+  PdfPagePreviewLodStats get lodStats => PdfPagePreviewLodStats(
+        baseEntries: _entries.length,
+        baseBytes: _entries.values.fold(0, (sum, entry) => sum + entry.bytes),
+        intermediateEntries: _intermediateEntries.length,
+        intermediateBytes: _intermediateEntries.weight,
+        intermediateEvictions: _intermediateEntries.evictions,
+      );
+
   /// Total pixel budget for exact, recently-viewed page rasters.
   ///
   /// These entries remove the soft-preview delay when a lazy page widget is
   /// rebuilt during back-and-forth scrolling. The default is about 32 MiB of
-  /// RGBA pixels. Set to zero to keep only low-resolution previews.
+  /// RGBA pixels. Set to zero to keep only the progressive preview ladder.
   int get maxFullRasterPixels => _maxFullRasterBytes ~/ 4;
 
   /// Largest exact raster admitted to the recent-page cache.
@@ -198,9 +349,9 @@ class PdfPagePreviewCache extends ChangeNotifier {
   int _maxFullRasterBytes;
   int _maxFullRasterEntryBytes;
 
-  // Two shared budgeted LRUs: soft previews bounded by entry count, exact
-  // recent-page rasters bounded by total pixels. Both dispose evicted images;
-  // the pixel budget and count cap live in PdfBudgetedCache (and are
+  // Three shared budgeted LRUs: base previews bounded by entry count,
+  // intermediate previews and exact recent-page rasters bounded by bytes. All
+  // dispose evicted images; the budgets live in PdfBudgetedCache (and are
   // property-tested there), so this class keeps only the preview-domain logic
   // (disk write-through, rebinding, staleness) on top.
   late final PdfBudgetedCache<int, _PreviewEntry> _entries =
@@ -208,6 +359,21 @@ class PdfPagePreviewCache extends ChangeNotifier {
     maxEntries: capacity,
     disposer: (entry) => entry.image.dispose(),
     debugLabel: 'page-preview',
+  );
+  late final PdfBudgetedCache<_IntermediatePreviewKey, _PreviewEntry>
+      _intermediateEntries =
+      PdfBudgetedCache<_IntermediatePreviewKey, _PreviewEntry>(
+    weigher: (entry) => entry.bytes,
+    maxWeight: _maxIntermediateBytes,
+    disposer: (entry) => entry.image.dispose(),
+    onEvicted: (key, entry) => PdfPerfLog.log(
+      'preview-evict page=${key.pageIndex} lod=${key.longestSide}px '
+      'bytes=${entry.bytes} '
+      'retained=${_intermediateEntries.weight} '
+      'limit=$_maxIntermediateBytes${PdfPerfLog.rssSuffix()}',
+    ),
+    clearsUnderMemoryPressure: true,
+    debugLabel: 'page-preview-intermediate',
   );
   late final PdfBudgetedCache<PdfPageRasterSignature, _FullRasterEntry>
       _fullEntries = PdfBudgetedCache<PdfPageRasterSignature, _FullRasterEntry>(
@@ -219,6 +385,26 @@ class PdfPagePreviewCache extends ChangeNotifier {
     debugLabel: 'page-full-raster',
   );
   bool _disposed = false;
+  int _previewGeneration = 0;
+  List<PdfPage>? _boundPages;
+
+  /// Binds future asynchronous cache admissions to the viewer's current page
+  /// objects.
+  ///
+  /// A render or image-scale operation can complete after an edit has swapped
+  /// the document revision. Without this guard that old result can re-enter a
+  /// changed page's cache after [rebind] deliberately invalidated it (most
+  /// visibly flashing removed content after a redaction). Standalone cache
+  /// users do not have to bind; the viewer always does.
+  void bindPages(List<PdfPage> pages) {
+    _boundPages = List<PdfPage>.of(pages, growable: false);
+  }
+
+  bool _acceptsPage(int index, PdfPage page) {
+    final pages = _boundPages;
+    return pages == null ||
+        (index >= 0 && index < pages.length && identical(pages[index], page));
+  }
 
   /// Distinct raster geometries retained for any one page.
   ///
@@ -273,6 +459,48 @@ class PdfPagePreviewCache extends ChangeNotifier {
     );
   }
 
+  /// Applies a new intermediate-LoD policy and trims the working set now.
+  ///
+  /// Changing only the byte limits preserves compatible images. Changing the
+  /// requested sizes drops the middle ladder because its cache keys no longer
+  /// describe levels the viewer will request; the tiny persistent preview and
+  /// exact display rasters are unaffected.
+  void configurePreviewLods(PdfPagePreviewLodPolicy policy) {
+    if (_disposed) return;
+    final sides = _normalizedIntermediateSides(
+      longestSide,
+      policy.intermediateLongestSides,
+    );
+    var changed = false;
+    if (!listEquals(sides, _intermediateLongestSides)) {
+      _intermediateEntries.clear();
+      _intermediateLongestSides = sides;
+      changed = true;
+    }
+    final beforeCount = _intermediateEntries.length;
+    final beforeBytes = _intermediateEntries.weight;
+    _maxIntermediateBytes = policy.maxBytes;
+    _maxIntermediateEntryBytes = policy.maxEntryBytes;
+    _intermediateEntries.evictWhere((key) {
+      final entry = _intermediateEntries.peek(key);
+      return entry != null && entry.bytes > _maxIntermediateEntryBytes;
+    });
+    _intermediateEntries.maxWeight = _maxIntermediateBytes;
+    changed |= beforeCount != _intermediateEntries.length;
+    PdfPerfLog.log(
+      'preview-lod policy levels=${_intermediateLongestSides.join(',')} '
+      'window=${policy.intermediateWindow} total=${policy.maxBytes} '
+      'entry=${policy.maxEntryBytes} retained=${_intermediateEntries.weight} '
+      'entries=${_intermediateEntries.length} '
+      'trimmedEntries=${beforeCount - _intermediateEntries.length} '
+      'trimmedBytes=${beforeBytes - _intermediateEntries.weight} '
+      'registry=${PdfCacheRegistry.instance.totalWeight} '
+      'ceiling=${PdfCacheRegistry.instance.maxTotalWeight}'
+      '${PdfPerfLog.rssSuffix()}',
+    );
+    if (changed && !_disposed) notifyListeners();
+  }
+
   /// Optional persistent backing (see [PdfRasterCache]). When set, fresh
   /// previews are written through to disk as they render, and [loadFromDisk]
   /// can prime the in-memory cache from a previous session. The viewer
@@ -320,17 +548,56 @@ class PdfPagePreviewCache extends ChangeNotifier {
       }
       // adopt without writing back - these bytes just came from disk. put
       // trims to capacity, disposing the LRU and never the entry just loaded.
-      _entries.put(i, _PreviewEntry(pages[i], image, includesImages: true));
+      _entries.put(
+        i,
+        _PreviewEntry(
+          pages[i],
+          image,
+          includesImages: true,
+          generation: ++_previewGeneration,
+        ),
+      );
       notifyListeners();
     }
   }
 
   /// The preview for page [index], as a clone the caller owns (and must
   /// dispose), or null when none is cached. Counts as a use for LRU.
-  ui.Image? imageFor(int index) {
+  ui.Image? imageFor(int index) => previewFor(index)?.image;
+
+  /// The sharpest cached preview for [index], with an owned image clone and
+  /// enough metadata for a live page to accept genuine promotions while
+  /// ignoring unrelated cache notifications or an LRU-driven downgrade.
+  PdfPagePreviewFrame? previewFor(int index) {
+    _IntermediatePreviewKey? bestKey;
+    _PreviewEntry? best;
+    for (final key in _intermediateEntries.keys) {
+      if (key.pageIndex != index) continue;
+      final entry = _intermediateEntries.peek(key)!;
+      if (best == null || entry.pixels > best.pixels) {
+        bestKey = key;
+        best = entry;
+      }
+    }
+    if (bestKey != null) {
+      final entry = _intermediateEntries.take(bestKey)!;
+      return PdfPagePreviewFrame(
+        image: entry.image.clone(),
+        lod: PdfPagePreviewLod.intermediate,
+        targetLongestSide: bestKey.longestSide,
+        includesImages: entry.includesImages,
+        generation: entry.generation,
+      );
+    }
     final entry = _entries.take(index); // touch; the master stays cached
     if (entry == null) return null;
-    return entry.image.clone();
+    return PdfPagePreviewFrame(
+      image: entry.image.clone(),
+      lod: PdfPagePreviewLod.base,
+      targetLongestSide: longestSide,
+      includesImages: entry.includesImages,
+      generation: entry.generation,
+    );
   }
 
   /// Returns an exact cached raster matching this page and display geometry.
@@ -414,7 +681,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
     required int? rotation,
     String revision = '',
   }) {
-    if (_disposed) return;
+    if (_disposed || !_acceptsPage(index, page)) return;
     // Write through before the memory admission below, deliberately: the disk
     // tier is also the *overflow* path for a RAM budget smaller than the
     // document's useful working set, so a raster the policy rejects is still
@@ -427,6 +694,17 @@ class PdfPagePreviewCache extends ChangeNotifier {
       rotation: rotation,
       revision: revision,
     );
+    // The sharp raster is already paid for and on screen. Populate every
+    // configured middle level by scaling that image, which is a cheap GPU
+    // blit/readback and never another PDF interpretation or image decode.
+    // This starts only after the full raster has landed, so first paint wins.
+    if (_intermediateLongestSides.isNotEmpty) {
+      unawaited(_putIntermediateLadderFromImage(
+        index,
+        page,
+        image.clone(),
+      ));
+    }
     _admitFullImage(
       index,
       page,
@@ -707,21 +985,41 @@ class PdfPagePreviewCache extends ChangeNotifier {
   }
 
   /// Whether any preview (fresh or stale) exists for page [index].
-  bool has(int index) => _entries.containsKey(index);
+  bool has(int index) =>
+      _entries.containsKey(index) ||
+      _intermediateEntries.keys.any((key) => key.pageIndex == index);
+
+  /// Whether at least one middle-LoD preview exists for [index]. When
+  /// [targetLongestSide] is supplied, checks that exact configured level.
+  bool hasIntermediate(int index, {double? targetLongestSide}) =>
+      targetLongestSide == null
+          ? _intermediateEntries.keys.any((key) => key.pageIndex == index)
+          : _intermediateEntries.containsKey(
+              _IntermediatePreviewKey(index, targetLongestSide),
+            );
 
   /// Whether the cached preview for [index] was rendered from exactly
   /// this [page] object - the staleness test both fill paths use to
   /// skip redundant work.
-  bool isFresh(int index, PdfPage page, {bool requireImages = false}) {
-    final entry = _entries.peek(index); // a staleness check, not a use
+  bool isFresh(
+    int index,
+    PdfPage page, {
+    bool requireImages = false,
+    double? targetLongestSide,
+  }) {
+    final entry = targetLongestSide == null
+        ? _entries.peek(index)
+        : _intermediateEntries.peek(
+            _IntermediatePreviewKey(index, targetLongestSide),
+          ); // a staleness check, not a use
     if (!identical(entry?.page, page)) return false;
     return !requireImages || entry!.includesImages;
   }
 
-  double _ratioFor(Size size) {
+  double _ratioFor(Size size, {double? targetLongestSide}) {
     final longest = math.max(size.width, size.height);
     if (longest <= 0) return 1;
-    return math.min(1, longestSide / longest);
+    return math.min(1, (targetLongestSide ?? longestSide) / longest);
   }
 
   /// Interprets [page] and stores its preview - the background-prerender
@@ -737,10 +1035,27 @@ class PdfPagePreviewCache extends ChangeNotifier {
       PdfRenderWorker? worker,
       int? rotation,
       bool decodeImages = true,
+      double? targetLongestSide,
       int priority = 1,
       int? commandLimit,
       bool Function()? deferUiWork}) async {
-    if (_disposed || isFresh(index, page, requireImages: decodeImages)) return;
+    final intermediate = targetLongestSide != null;
+    if (_disposed ||
+        !_acceptsPage(index, page) ||
+        (intermediate &&
+            !_intermediateLongestSides.contains(targetLongestSide)) ||
+        isFresh(
+          index,
+          page,
+          requireImages: decodeImages,
+          targetLongestSide: targetLongestSide,
+        )) {
+      return;
+    }
+    // Command-limited/vector-first pixels are the instant fallback. Promoting
+    // that incomplete display would spend middle-tier memory on a preview
+    // known to omit content, so intermediates are image-complete only.
+    if (intermediate && !decodeImages) return;
     if (!decodeImages && (worker == null || !worker.isActive)) {
       // A vector-first preview is only cheap through the worker. The local
       // fallback would run a full UI-thread render and decode the images, which
@@ -750,7 +1065,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
     try {
       final sw = Stopwatch()..start();
       final size = PdfPageRenderer.pageSize(page, rotation: rotation);
-      final ratio = _ratioFor(size);
+      final ratio = _ratioFor(size, targetLongestSide: targetLongestSide);
       // priority 1: prefetch yields to any on-screen page the worker owes.
       // The preview is rasterized at [ratio] (longest side ~200px), so cap the
       // worker's images to that - a heavy raster underlay need not ship at full
@@ -770,7 +1085,14 @@ class PdfPagePreviewCache extends ChangeNotifier {
         return;
       }
       if (deferUiWork?.call() ?? false) return;
-      if (_disposed || isFresh(index, page, requireImages: decodeImages)) {
+      if (_disposed ||
+          !_acceptsPage(index, page) ||
+          isFresh(
+            index,
+            page,
+            requireImages: decodeImages,
+            targetLongestSide: targetLongestSide,
+          )) {
         return;
       }
       final ui.Image image;
@@ -783,7 +1105,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
             pageColor: pageColor,
             rotation: rotation,
             includeImages: decodeImages);
-        if (deferUiWork?.call() ?? false) {
+        if (!_acceptsPage(index, page) || (deferUiWork?.call() ?? false)) {
           picture.dispose();
           return;
         }
@@ -807,14 +1129,28 @@ class PdfPagePreviewCache extends ChangeNotifier {
       }
       sw.stop();
       PdfPerfLog.log('prerender page=$index '
+          'lod=${targetLongestSide == null ? 'base' : '${targetLongestSide.toStringAsFixed(0)}px'} '
           '${commands != null ? 'worker ' : ''}'
           '${includesImages ? 'full' : 'vector'} '
           'warm=${(sw.elapsedMicroseconds / 1000).toStringAsFixed(1)}ms');
-      if (_disposed || isFresh(index, page, requireImages: decodeImages)) {
+      if (_disposed ||
+          !_acceptsPage(index, page) ||
+          isFresh(
+            index,
+            page,
+            requireImages: decodeImages,
+            targetLongestSide: targetLongestSide,
+          )) {
         image.dispose();
         return;
       }
-      _store(index, page, image, includesImages: includesImages);
+      _store(
+        index,
+        page,
+        image,
+        includesImages: includesImages,
+        targetLongestSide: targetLongestSide,
+      );
     } catch (_) {
       // no preview is strictly better than a crash mid-scroll
     }
@@ -980,7 +1316,11 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// second interpreter walk). The picture stays owned by the caller.
   Future<void> putFromPicture(int index, PdfPage page, ui.Picture picture,
       {int? rotation}) async {
-    if (_disposed || isFresh(index, page, requireImages: true)) return;
+    if (_disposed ||
+        !_acceptsPage(index, page) ||
+        isFresh(index, page, requireImages: true)) {
+      return;
+    }
     try {
       final size = PdfPageRenderer.pageSize(page, rotation: rotation);
       final image =
@@ -991,20 +1331,168 @@ class PdfPagePreviewCache extends ChangeNotifier {
     }
   }
 
+  Future<void> _putIntermediateFromImage(
+    int index,
+    PdfPage page,
+    ui.Image source, {
+    required double targetLongestSide,
+  }) async {
+    try {
+      if (_disposed ||
+          !_acceptsPage(index, page) ||
+          !_intermediateLongestSides.contains(targetLongestSide) ||
+          isFresh(
+            index,
+            page,
+            requireImages: true,
+            targetLongestSide: targetLongestSide,
+          )) {
+        return;
+      }
+      final sourceLongest = math.max(source.width, source.height).toDouble();
+      final scale = math.min(1.0, targetLongestSide / sourceLongest);
+      final width = math.max(1, (source.width * scale).round());
+      final height = math.max(1, (source.height * scale).round());
+      final recorder = ui.PictureRecorder();
+      final canvas = ui.Canvas(recorder);
+      canvas.drawImageRect(
+        source,
+        ui.Rect.fromLTWH(
+          0,
+          0,
+          source.width.toDouble(),
+          source.height.toDouble(),
+        ),
+        ui.Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+        ui.Paint()..filterQuality = ui.FilterQuality.medium,
+      );
+      final picture = recorder.endRecording();
+      late final ui.Image image;
+      try {
+        image = await picture.toImage(width, height);
+      } finally {
+        picture.dispose();
+      }
+      if (_disposed ||
+          !_acceptsPage(index, page) ||
+          isFresh(
+            index,
+            page,
+            requireImages: true,
+            targetLongestSide: targetLongestSide,
+          )) {
+        image.dispose();
+        return;
+      }
+      _store(
+        index,
+        page,
+        image,
+        includesImages: true,
+        targetLongestSide: targetLongestSide,
+      );
+    } catch (_) {
+      // The source may be disposed by a page/document swap while the engine is
+      // rasterizing. The idle worker path can fill this level later.
+    } finally {
+      source.dispose();
+    }
+  }
+
+  Future<void> _putIntermediateLadderFromImage(
+      int index, PdfPage page, ui.Image source) async {
+    try {
+      // Serialize promotions for this completed raster. Two simultaneous
+      // toImage readbacks can turn a harmless post-paint cache fill into the
+      // same completion burst the page scheduler deliberately avoids.
+      final sourceLongest = math.max(source.width, source.height).toDouble();
+      for (final target in _intermediateLongestSides.toList()) {
+        if (_disposed || !_acceptsPage(index, page)) return;
+        if (isFresh(
+          index,
+          page,
+          requireImages: true,
+          targetLongestSide: target,
+        )) {
+          continue;
+        }
+        await _putIntermediateFromImage(
+          index,
+          page,
+          source.clone(),
+          targetLongestSide: target,
+        );
+        // This source cannot contribute a sharper next level. Keeping the same
+        // pixels under another nominal key only burns the shared byte budget.
+        if (target >= sourceLongest) break;
+      }
+    } finally {
+      source.dispose();
+    }
+  }
+
   void _store(int index, PdfPage page, ui.Image image,
-      {required bool includesImages}) {
-    if (_disposed) {
+      {required bool includesImages, double? targetLongestSide}) {
+    if (_disposed || !_acceptsPage(index, page)) {
       image.dispose();
+      if (!_disposed) {
+        PdfPerfLog.log(
+          'preview-reject page=$index '
+          'lod=${targetLongestSide == null ? 'base' : '${targetLongestSide}px'} '
+          'reason=page-revision${PdfPerfLog.rssSuffix()}',
+        );
+      }
       return;
     }
-    // put disposes any prior preview for this index and evicts the LRU past
-    // capacity, never the entry just stored.
-    _entries.put(
-        index, _PreviewEntry(page, image, includesImages: includesImages));
+    final entry = _PreviewEntry(
+      page,
+      image,
+      includesImages: includesImages,
+      generation: ++_previewGeneration,
+    );
+    if (targetLongestSide == null) {
+      // put disposes any prior preview for this index and evicts the LRU past
+      // capacity, never the entry just stored.
+      _entries.put(index, entry);
+    } else {
+      final bytes = entry.bytes;
+      final rejection = _maxIntermediateBytes == 0
+          ? 'disabled'
+          : bytes > _maxIntermediateEntryBytes
+              ? 'entry-limit'
+              : bytes > _maxIntermediateBytes
+                  ? 'total-limit'
+                  : null;
+      if (rejection != null) {
+        image.dispose();
+        PdfPerfLog.log(
+          'preview-reject page=$index lod=${targetLongestSide}px '
+          'bytes=$bytes reason=$rejection retained=${_intermediateEntries.weight} '
+          'limit=$_maxIntermediateBytes entryLimit=$_maxIntermediateEntryBytes'
+          '${PdfPerfLog.rssSuffix()}',
+        );
+        return;
+      }
+      _intermediateEntries.put(
+        _IntermediatePreviewKey(index, targetLongestSide),
+        entry,
+      );
+    }
+    PdfPerfLog.log(
+      'preview-store page=$index '
+      'lod=${targetLongestSide == null ? 'base' : '${targetLongestSide}px'} '
+      '${image.width}x${image.height} bytes=${entry.bytes} '
+      'baseEntries=${_entries.length} '
+      'intermediateEntries=${_intermediateEntries.length} '
+      'intermediateBytes=${_intermediateEntries.weight}'
+      '${PdfPerfLog.rssSuffix()}',
+    );
     // Write through to disk so the next session opens with this preview
     // already on screen. Fire-and-forget: the encode is a raster-thread
     // readback and a slow/failed store must never stall rendering.
-    if (includesImages) disk?.storePreview(index, image);
+    if (targetLongestSide == null && includesImages) {
+      disk?.storePreview(index, image);
+    }
     notifyListeners();
   }
 
@@ -1022,6 +1510,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// scroll paints blank (then re-renders) instead of flashing now-deleted
   /// content. The rest rebind in place as before.
   void rebind(List<PdfPage> pages, {bool Function(int index)? changed}) {
+    bindPages(pages);
     var dropped = false;
     for (final index in _entries.keys.toList()) {
       if (changed != null && changed(index)) {
@@ -1029,6 +1518,18 @@ class PdfPagePreviewCache extends ChangeNotifier {
         dropped = true;
       } else if (index < pages.length) {
         _entries.peek(index)!.page = pages[index]; // rebind, no reorder
+      }
+    }
+    for (final key in _intermediateEntries.keys.toList()) {
+      final index = key.pageIndex;
+      if (changed != null && changed(index)) {
+        _intermediateEntries.evict(key); // disposes the image
+        dropped = true;
+      } else if (index < pages.length) {
+        _intermediateEntries.peek(key)!.page = pages[index];
+      } else {
+        _intermediateEntries.evict(key);
+        dropped = true;
       }
     }
     for (final key in _fullEntries.keys.toList()) {
@@ -1050,6 +1551,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
   /// Drops every preview (different document, page color change...).
   void clear() {
     _entries.clear(); // disposes every retained image
+    _intermediateEntries.clear();
     _fullEntries.clear();
     // Queued writes belong to the document being left behind.
     _dropPendingFullWrites();
@@ -1060,6 +1562,7 @@ class PdfPagePreviewCache extends ChangeNotifier {
   void dispose() {
     _disposed = true;
     _entries.dispose(); // disposes every retained image
+    _intermediateEntries.dispose();
     _fullEntries.dispose();
     // A drain in flight sees _disposed and clears the rest itself; clearing
     // here covers the (usual) case where nothing is draining.
@@ -1087,11 +1590,47 @@ class _PendingFullRasterWrite {
 }
 
 class _PreviewEntry {
-  _PreviewEntry(this.page, this.image, {required this.includesImages});
+  _PreviewEntry(
+    this.page,
+    this.image, {
+    required this.includesImages,
+    required this.generation,
+  });
 
   PdfPage page;
   final ui.Image image;
   final bool includesImages;
+  final int generation;
+
+  int get pixels => image.width * image.height;
+  int get bytes => pixels * 4;
+}
+
+@immutable
+class _IntermediatePreviewKey {
+  const _IntermediatePreviewKey(this.pageIndex, this.longestSide);
+
+  final int pageIndex;
+  final double longestSide;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _IntermediatePreviewKey &&
+      pageIndex == other.pageIndex &&
+      longestSide == other.longestSide;
+
+  @override
+  int get hashCode => Object.hash(pageIndex, longestSide);
+}
+
+List<double> _normalizedIntermediateSides(
+    double baseLongestSide, Iterable<double> values) {
+  final sides = values
+      .where((value) => value.isFinite && value > baseLongestSide)
+      .toSet()
+      .toList()
+    ..sort();
+  return sides;
 }
 
 class _FullRasterEntry {

--- a/packages/dart_pdf_editor/test/comparison_view_test.dart
+++ b/packages/dart_pdf_editor/test/comparison_view_test.dart
@@ -55,6 +55,9 @@ void main() {
       maxBytes: 256 * 1024 * 1024,
       maxEntryBytes: 64 * 1024 * 1024,
     );
+    const lodPolicy = PdfPagePreviewLodPolicy(
+      intermediateLongestSides: [360, 720],
+    );
     final tileBackend = _TestTileBackend();
 
     await tester.pumpWidget(MaterialApp(
@@ -62,6 +65,7 @@ void main() {
         body: PdfComparisonView(
           before: before,
           after: after,
+          pagePreviewLodPolicy: lodPolicy,
           pageRasterCachePolicy: rasterPolicy,
           tileRasterBackend: tileBackend,
         ),
@@ -83,6 +87,12 @@ void main() {
     expect(
       tester
           .widgetList<PdfViewer>(find.byType(PdfViewer))
+          .map((viewer) => viewer.pagePreviewLodPolicy),
+      everyElement(lodPolicy),
+    );
+    expect(
+      tester
+          .widgetList<PdfViewer>(find.byType(PdfViewer))
           .map((viewer) => viewer.tileRasterBackend),
       everyElement(same(tileBackend)),
     );
@@ -98,6 +108,10 @@ void main() {
     expect(
       tester.widget<PdfViewer>(find.byType(PdfViewer)).pageRasterCachePolicy,
       rasterPolicy,
+    );
+    expect(
+      tester.widget<PdfViewer>(find.byType(PdfViewer)).pagePreviewLodPolicy,
+      lodPolicy,
     );
     expect(tester.widget<PdfViewer>(find.byType(PdfViewer)).tileRasterBackend,
         same(tileBackend));

--- a/packages/dart_pdf_editor/test/editing_redaction_test.dart
+++ b/packages/dart_pdf_editor/test/editing_redaction_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -218,7 +219,13 @@ void main() {
         await tester.runAsync(() async {
           final data =
               (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!;
-          final i = (py * image.width + px) * 4;
+          // [px]/[py] are expressed in the historical 200px preview grid.
+          // The cache now returns its sharpest available LoD, so preserve the
+          // same page-space sample when that is a 400/800px promotion.
+          final scale = math.max(image.width, image.height) / 200;
+          final sampleX = (px * scale).round().clamp(0, image.width - 1);
+          final sampleY = (py * scale).round().clamp(0, image.height - 1);
+          final i = (sampleY * image.width + sampleX) * 4;
           luma = (data.getUint8(i) + data.getUint8(i + 1) + data.getUint8(i + 2)) ~/ 3;
         });
         image.dispose();

--- a/packages/dart_pdf_editor/test/page_preview_test.dart
+++ b/packages/dart_pdf_editor/test/page_preview_test.dart
@@ -3,6 +3,7 @@
 // raster instead of blank paper - Bluebeam-style. The cache is fed for
 // free from on-screen renders and by the viewer's background prerender.
 import 'dart:async';
+import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -59,6 +60,107 @@ void main() {
     expect(clone.width, greaterThan(0));
     expect(clone.width, lessThanOrEqualTo(200));
     clone.dispose();
+  });
+
+  testWidgets('cache promotes through a geometric preview ladder',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    const levels = [400.0, 800.0];
+    final cache = PdfPagePreviewCache(
+      lodPolicy: const PdfPagePreviewLodPolicy(
+        intermediateLongestSides: levels,
+        maxBytes: 8 * 1024 * 1024,
+        maxEntryBytes: 4 * 1024 * 1024,
+      ),
+    );
+    addTearDown(cache.dispose);
+
+    await tester.runAsync(() async {
+      await cache.renderPreview(0, page);
+      await cache.renderPreview(0, page, targetLongestSide: levels[0]);
+      await cache.renderPreview(0, page, targetLongestSide: levels[1]);
+    });
+
+    expect(cache.hasIntermediate(0, targetLongestSide: levels[0]), isTrue);
+    expect(cache.hasIntermediate(0, targetLongestSide: levels[1]), isTrue);
+    expect(cache.lodStats.baseEntries, 1);
+    expect(cache.lodStats.intermediateEntries, 2);
+    expect(
+        cache.lodStats.intermediateBytes, lessThanOrEqualTo(8 * 1024 * 1024));
+
+    final frame = cache.previewFor(0)!;
+    expect(frame.lod, PdfPagePreviewLod.intermediate);
+    expect(frame.targetLongestSide, levels[1]);
+    expect(math.max(frame.image.width, frame.image.height),
+        inInclusiveRange(790, 800),
+        reason: 'preview ratios do not upscale a sub-800pt page past 1x');
+    frame.image.dispose();
+  });
+
+  testWidgets('a late intermediate promotion cannot cross page revisions',
+      (tester) async {
+    final before = PdfDocument.open(buildClassicPdf());
+    final after = PdfDocument.open(buildClassicPdf());
+    final oldPage = before.page(0);
+    final newPage = after.page(0);
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+    cache.bindPages([oldPage]);
+
+    await tester.runAsync(() async {
+      final image = await PdfPageRenderer.renderImage(oldPage);
+      cache.putFullImage(
+        0,
+        oldPage,
+        image,
+        pageColor: Colors.white,
+        annotations: true,
+        rotation: null,
+      );
+      // The 400/800px scales are asynchronous. Invalidate their source page
+      // before they finish, exactly as a destructive edit does.
+      cache.rebind([newPage], changed: (_) => true);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      image.dispose();
+    });
+
+    expect(cache.hasIntermediate(0), isFalse);
+    expect(cache.fullRasterCount, 0);
+  });
+
+  testWidgets('intermediate levels share a configurable byte LRU',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    const levels = [400.0, 800.0];
+    final cache = PdfPagePreviewCache(
+      lodPolicy: const PdfPagePreviewLodPolicy(
+        intermediateLongestSides: levels,
+        maxBytes: 8 * 1024 * 1024,
+        maxEntryBytes: 4 * 1024 * 1024,
+      ),
+    );
+    addTearDown(cache.dispose);
+    await tester.runAsync(() async {
+      await cache.renderPreview(0, page, targetLongestSide: levels[0]);
+      await cache.renderPreview(0, page, targetLongestSide: levels[1]);
+    });
+    final sharp = cache.previewFor(0)!;
+    final sharpBytes = sharp.image.width * sharp.image.height * 4;
+    sharp.image.dispose();
+
+    cache.configurePreviewLods(PdfPagePreviewLodPolicy(
+      intermediateLongestSides: levels,
+      maxBytes: sharpBytes,
+      maxEntryBytes: sharpBytes,
+    ));
+
+    expect(cache.intermediateBytes, lessThanOrEqualTo(sharpBytes));
+    expect(cache.intermediateCount, 1,
+        reason: 'the shared budget should retain the touched 800px level');
+    expect(cache.hasIntermediate(0, targetLongestSide: levels[0]), isFalse);
+    expect(cache.hasIntermediate(0, targetLongestSide: levels[1]), isTrue);
   });
 
   testWidgets('exact raster cache enforces entry and total pixel budgets',
@@ -380,16 +482,41 @@ void main() {
             controller: controller,
             pageRasterCachePolicy: policy,
           ),
-    );
+        );
 
     await tester.pumpWidget(viewer(generous));
-    expect(controller.pagePreviewCache!.maxFullRasterBytes,
-        generous.maxBytes);
+    expect(controller.pagePreviewCache!.maxFullRasterBytes, generous.maxBytes);
 
-    await tester
-        .pumpWidget(viewer(const PdfPageRasterCachePolicy.disabled()));
+    await tester.pumpWidget(viewer(const PdfPageRasterCachePolicy.disabled()));
     expect(controller.pagePreviewCache!.maxFullRasterBytes, 0);
     expect(controller.pagePreviewCache!.fullRasterCount, 0);
+  });
+
+  testWidgets('viewer applies intermediate LoD policy updates', (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+
+    Widget viewer(PdfPagePreviewLodPolicy policy) => MaterialApp(
+          home: PdfViewer(
+            document: document,
+            controller: controller,
+            pagePreviewLodPolicy: policy,
+          ),
+        );
+
+    await tester.pumpWidget(viewer(const PdfPagePreviewLodPolicy.disabled()));
+    expect(controller.pagePreviewCache!.intermediateLongestSides, isEmpty);
+
+    const custom = PdfPagePreviewLodPolicy(
+      intermediateLongestSides: [360, 720, 1440],
+      intermediateWindow: 3,
+      maxBytes: 64 * 1024 * 1024,
+      maxEntryBytes: 8 * 1024 * 1024,
+    );
+    await tester.pumpWidget(viewer(custom));
+    expect(controller.pagePreviewCache!.intermediateLongestSides,
+        [360, 720, 1440]);
   });
 
   testWidgets('rebind drops previews of pages whose content changed',
@@ -568,6 +695,72 @@ void main() {
     expect(previewRaster, findsNothing);
   });
 
+  testWidgets('a held page promotes through cached preview LoDs',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+    await tester.runAsync(() => cache.renderPreview(0, page));
+
+    final hold = ValueNotifier<bool>(true);
+    addTearDown(hold.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Center(
+        child: SizedBox(
+          width: 400,
+          child: PdfPageView(
+            page: page,
+            renderHold: hold,
+            previewCache: cache,
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    expect(previewRaster, findsOneWidget);
+
+    await tester
+        .runAsync(() => cache.renderPreview(0, page, targetLongestSide: 400));
+    await tester.pump();
+    var image = tester.widget<RawImage>(find.byType(RawImage)).image!;
+    expect(math.max(image.width, image.height), inInclusiveRange(399, 400));
+
+    await tester
+        .runAsync(() => cache.renderPreview(0, page, targetLongestSide: 800));
+    await tester.pump();
+    image = tester.widget<RawImage>(find.byType(RawImage)).image!;
+    expect(math.max(image.width, image.height), inInclusiveRange(790, 800));
+    expect(hold.value, isTrue,
+        reason: 'preview promotion must not release the full render hold');
+  });
+
+  testWidgets('completed display raster seeds every intermediate LoD by blit',
+      (tester) async {
+    final document = PdfDocument.open(buildClassicPdf());
+    final page = document.page(0);
+    final cache = PdfPagePreviewCache();
+    addTearDown(cache.dispose);
+    final image = await PdfPageRenderer.renderImage(page, pixelRatio: 2);
+    addTearDown(image.dispose);
+
+    cache.putFullImage(
+      0,
+      page,
+      image,
+      pageColor: const Color(0xFFFFFFFF),
+      annotations: true,
+      rotation: null,
+    );
+    for (var i = 0; i < 50 && cache.intermediateCount < 2; i++) {
+      await settle(tester);
+    }
+
+    expect(cache.hasIntermediate(0, targetLongestSide: 400), isTrue);
+    expect(cache.hasIntermediate(0, targetLongestSide: 800), isTrue);
+    expect(cache.lodStats.intermediateEntries, 2);
+  });
+
   testWidgets('a recycled page restores its exact raster through render hold',
       (tester) async {
     final document = PdfDocument.open(buildClassicPdf());
@@ -736,6 +929,43 @@ void main() {
       await settle(tester);
     }
     expect(fullRaster, findsWidgets);
+  });
+
+  testWidgets('idle prerender promotes only the nearby LoD working set',
+      (tester) async {
+    final document = PdfDocument.open(buildMultiPagePdf(8));
+    final controller = PdfViewerController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: PdfViewer(
+          document: document,
+          controller: controller,
+          initialFit: PdfViewerFit.width,
+          previewWindow: 4,
+          pagePreviewLodPolicy: const PdfPagePreviewLodPolicy(
+            intermediateLongestSides: [400, 800],
+            intermediateWindow: 2,
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    final cache = controller.debugPreviewCache!;
+
+    for (var i = 0;
+        i < 150 && !cache.hasIntermediate(2, targetLongestSide: 800);
+        i++) {
+      await settle(tester);
+    }
+    expect(cache.hasIntermediate(2, targetLongestSide: 400), isTrue);
+    expect(cache.hasIntermediate(2, targetLongestSide: 800), isTrue);
+    expect(cache.has(4), isTrue,
+        reason: 'the inexpensive base level covers the wider preview window');
+    expect(cache.hasIntermediate(4), isFalse,
+        reason: 'middle levels stay inside their tighter byte working set');
+    expect(controller.pagePreviewLodStats!.intermediateEntries,
+        greaterThanOrEqualTo(2));
   });
 
   testWidgets('the prerender warms only a window of pages around the viewport',

--- a/packages/dart_pdf_editor/test/pdf_shell_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_shell_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(find.byType(PdfViewer), findsOneWidget);
     });
 
-    testWidgets('forwards the visited-page raster cache policy',
+    testWidgets('forwards page preview and raster cache policies',
         (tester) async {
       final viewer = PdfViewerController();
       addTearDown(viewer.dispose);
@@ -84,15 +84,21 @@ void main() {
         maxBytes: 2 * 1024 * 1024 * 1024,
         maxEntryBytes: 64 * 1024 * 1024,
       );
+      const lodPolicy = PdfPagePreviewLodPolicy(
+        intermediateLongestSides: [360, 720],
+      );
       await pump(
         tester,
         PdfReader(
           bytes: buildMultiPagePdf(2),
           controller: viewer,
+          pagePreviewLodPolicy: lodPolicy,
           pageRasterCachePolicy: policy,
         ),
       );
       expect(viewer.pagePreviewCache!.maxFullRasterBytes, policy.maxBytes);
+      expect(viewer.pagePreviewCache!.intermediateLongestSides,
+          lodPolicy.intermediateLongestSides);
     });
 
     testWidgets('zoom menu changes and resets viewer zoom', (tester) async {
@@ -334,7 +340,7 @@ void main() {
           find.byKey(const ValueKey('pdf-shell-reflow-view')), findsOneWidget);
     });
 
-    testWidgets('forwards the visited-page raster cache policy',
+    testWidgets('forwards page preview and raster cache policies',
         (tester) async {
       final viewer = PdfViewerController();
       addTearDown(viewer.dispose);
@@ -342,15 +348,21 @@ void main() {
         maxBytes: 2 * 1024 * 1024 * 1024,
         maxEntryBytes: 64 * 1024 * 1024,
       );
+      const lodPolicy = PdfPagePreviewLodPolicy(
+        intermediateLongestSides: [360, 720],
+      );
       await pump(
         tester,
         PdfEditorView(
           bytes: buildMultiPagePdf(2),
           viewerController: viewer,
+          pagePreviewLodPolicy: lodPolicy,
           pageRasterCachePolicy: policy,
         ),
       );
       expect(viewer.pagePreviewCache!.maxFullRasterBytes, policy.maxBytes);
+      expect(viewer.pagePreviewCache!.intermediateLongestSides,
+          lodPolicy.intermediateLongestSides);
     });
 
     testWidgets('customStamps are supplied to the owned editor session',


### PR DESCRIPTION
## What changed

- promotes fast-scroll page previews through a default 200 → 400 → 800 px ladder before the final display raster
- keeps intermediate levels in a shared 32 MiB byte-budgeted LRU and proactively warms only the current page ±2
- populates middle levels from completed display rasters with serialized scale blits where possible, avoiding another PDF interpretation or image decode
- keeps a live page on its sharpest owned preview when the LRU evicts a level, while rejecting late results from older document revisions
- forwards the configurable `PdfPagePreviewLodPolicy` through `PdfViewer`, `PdfReader`, `PdfEditorView`, and `PdfComparisonView`
- exposes `PdfViewerController.pagePreviewLodStats` and LoD-specific perf events for occupancy, stores, paints, rejection, and eviction

## Why

Fast scrolling previously jumped directly from the tiny 200 px whole-page fallback to the final raster. On dense CAD and image-heavy pages that left a visibly soft page on screen for hundreds of milliseconds. Two geometric middle steps materially improve readability without turning the preview cache into an unbounded page mip pyramid.

Chromium's PDFium integration primarily progressively paints dirty visible rectangles at the current target resolution rather than retaining a large fixed mip chain. The retained tile/region path remains the equivalent long-term mechanism here; this bounded page-preview ladder covers the current render-hold gap.

## Defaults and memory

The default 200 → 400 → 800 progression doubles linear resolution at each step (4× pixels), so each retained level is visually meaningful. The two middle levels share 32 MiB, reject any single entry over 4 MiB, and proactively cover at most five page indices around the viewport. Hosts can change the levels, working window, and byte limits or disable middle LoDs entirely.

## Validation

- `fvm dart analyze`
- `fvm flutter test`: 2,198 passed, 35 environment-gated diagnostics skipped
- focused LoD, revision-race, redaction, shell, and comparison-view tests
- release web build
- Quickstart PDF pages 27 and 30 render smoke tests
- `ly9-far-cad.pdf` page 4: 98,936 commands; 2382×1684 capped render; full/vector checks passed
