### PR TITLE
Fix CAD tile sharpening latency

### DIFF
--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -4102,6 +4102,16 @@ class _PdfPageViewState extends State<PdfPageView>
   /// so the painter's identity check doesn't see a fresh closure every build.
   bool Function(Rect region)? _tileCanRasterize;
 
+  /// Whether the viewport moved beyond the one image-detail record currently
+  /// in flight. Only one region record is allowed at a time; when it finishes,
+  /// the latest stored geometry is re-evaluated once. Before this coalescing,
+  /// every small pan queued another multi-second decode for the same CAD page,
+  /// so the region on screen could sit tens of seconds behind the worker.
+  bool _tileDetailDeferred = false;
+
+  /// Invalidates an async tile-detail result when the page/scene is dropped.
+  int _tileDetailRequestGeneration = 0;
+
   /// Pan-ahead guard band for the tile path's visible slice, as a fraction of
   /// the viewport per side. Zero: the pyramid's prefetch ring already
   /// pre-rasters the border, so - unlike the single patch - the tile slice
@@ -4274,9 +4284,11 @@ class _PdfPageViewState extends State<PdfPageView>
     if (region == null || region.width <= 0 || region.height <= 0) return;
     if (_tileDetailCovers(region, imageRatio)) return;
     final pending = _tileDetailPending;
-    if (pending != null &&
-        pending.$2 >= imageRatio * 0.99 &&
-        _rectCovers(pending.$1, region, 0.5 / tileRatio)) {
+    if (pending != null) {
+      if (pending.$2 < imageRatio * 0.99 ||
+          !_rectCovers(pending.$1, region, 0.5 / tileRatio)) {
+        _tileDetailDeferred = true;
+      }
       return;
     }
     if (widget.renderWorker?.isActive != true) return;
@@ -4299,6 +4311,7 @@ class _PdfPageViewState extends State<PdfPageView>
       Rect region, double tileRatio, double imageRatio) async {
     final pageIndex = widget.previewIndex;
     final intent = _renderIntent(widget);
+    final generation = ++_tileDetailRequestGeneration;
     // Claim the slot BEFORE anything that can return: the `finally` clears the
     // tile veto only for the request that owns it, so an early return that
     // never claimed would leave tiles vetoed for good.
@@ -4317,7 +4330,12 @@ class _PdfPageViewState extends State<PdfPageView>
         imagePixelRatio: imageRatio,
         imageDecodeRegion: _pdfRegionForRasterRegion(region),
       );
-      if (commands == null || !mounted || _abandoned(pageIndex)) return;
+      if (commands == null ||
+          !mounted ||
+          _abandoned(pageIndex) ||
+          generation != _tileDetailRequestGeneration) {
+        return;
+      }
       if (!_intentIsCurrent(intent) || _renderPaused) return;
       final scene = await PdfRetainedScene.fromCommands(
         widget.page,
@@ -4327,7 +4345,10 @@ class _PdfPageViewState extends State<PdfPageView>
             widget.tileRasterBackend.prefersDirectDecodedImageUploads,
         maxImagePixelRatio: imageRatio,
       );
-      if (!mounted || _abandoned(pageIndex) || !_intentIsCurrent(intent)) {
+      if (!mounted ||
+          _abandoned(pageIndex) ||
+          !_intentIsCurrent(intent) ||
+          generation != _tileDetailRequestGeneration) {
         scene.dispose();
         return;
       }
@@ -4335,13 +4356,15 @@ class _PdfPageViewState extends State<PdfPageView>
     } catch (error) {
       PdfPerfLog.log('tile image detail failed page=$pageIndex error=$error');
     } finally {
-      if (_tileDetailPending?.$1 == region &&
-          _tileDetailPending?.$2 == imageRatio) {
+      if (generation == _tileDetailRequestGeneration) {
+        final rerun = _tileDetailDeferred;
+        _tileDetailDeferred = false;
         _tileDetailPending = null;
         // Whether it landed or not, stop holding tiles back: an adopted scene
         // now answers through [_tileDetailCovers], and a declined one must not
         // veto the page's tiles forever.
         _setTileDetailWanted(false);
+        if (rerun && mounted) _ensureTileImageDetail();
       }
     }
   }
@@ -4396,7 +4419,9 @@ class _PdfPageViewState extends State<PdfPageView>
   /// Frees the tile image-detail scene. Called wherever the page's content or
   /// retained scene is replaced - the decode is bound to both.
   void _dropTileImageDetail() {
+    _tileDetailRequestGeneration++;
     _tileDetailPending = null;
+    _tileDetailDeferred = false;
     _tileDetailWanted = false;
     if (_tileDetailScene == null) return;
     _disposeTileRasterSession(_tileDetailScene!);

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -3492,7 +3492,6 @@ class _PdfPageViewState extends State<PdfPageView>
     _DetailGeometry? detailGeometry,
     VoidCallback? onPaint,
   }) async {
-    final generation = _renderSession.beginDetail();
     if (_renderPaused) return false;
     // The viewer's global transform reaches cache-window neighbours too. They
     // keep a bounded fit-resolution base, but a detail raster is useful only
@@ -3603,6 +3602,15 @@ class _PdfPageViewState extends State<PdfPageView>
       );
       return true;
     }
+
+    // Claim the detail generation only when this pass is actually about to
+    // produce a replacement patch. The tile route above is a successful
+    // no-op for the single-patch adapter: beginning a generation before that
+    // return used to cancel an already-decoded tight zoom patch during the
+    // follow-up full-render grant. On the large raster CAD sheets that patch
+    // was ready in ~1.5 s, but was discarded immediately before rasterization;
+    // the user then waited for an 8-9 s, ~70 MB tile-prefetch decode instead.
+    final generation = _renderSession.beginDetail();
 
     // Dense strip-routed pages ask for one combined worker result: commands
     // whose images were decoded for this region plus the StripPlan binned
@@ -4441,8 +4449,8 @@ class _PdfPageViewState extends State<PdfPageView>
   /// tile path is inactive or the page is not zoomed past the base raster.
   ///
   /// [size] is the page-point size (the tile grid space). Placed above the base
-  /// raster so uncovered gaps show it through; it replaces the single detail
-  /// patch when active.
+  /// raster and any completed visible-region patch, so uncovered gaps keep the
+  /// sharpest already-available pixels while exact tiles land over them.
   Widget? _tileLayerWidget(Size size) {
     if (!_useTilePath) return null;
     final scene = _scene;
@@ -4510,6 +4518,13 @@ class _PdfPageViewState extends State<PdfPageView>
         allowCoarserFallback: widget.qualityPageCount == 1 &&
             _slugPicture == null &&
             _directPicture == null,
+        // An old pyramid rung is useful pan-ahead outside the current patch,
+        // but must not cover that sharper patch with stretched pixels. Exact
+        // tiles are not clipped and replace it normally as they land.
+        fallbackOcclusionFraction:
+            _detailImage != null && _detailContentIsCurrent()
+                ? _detailFraction
+                : null,
       ),
     );
   }
@@ -5087,8 +5102,10 @@ class _PdfPageViewState extends State<PdfPageView>
               // Publish this page's patch bounds for the thumbnail debug
               // overlay (report coalesces its notify past this build).
               if (pdfDebugPaintDetailBounds.value) {
-                PdfDebugDetailRegions.instance.report(widget.previewIndex,
-                    tileLayer == null && detail != null ? fraction : null);
+                PdfDebugDetailRegions.instance.report(
+                  widget.previewIndex,
+                  detail != null ? fraction : null,
+                );
               }
               return Stack(
                 alignment: Alignment.topLeft,
@@ -5130,9 +5147,14 @@ class _PdfPageViewState extends State<PdfPageView>
                     ),
                   if (webSurface != null) webSurface,
                   if (webDetail != null) webDetail,
-                  if (tileLayer != null)
-                    tileLayer
-                  else if (detail != null && fraction != null && w.isFinite)
+                  // Keep the fast, viewport-sized refinement underneath the
+                  // pyramid. The tile layer is sparse while its region image
+                  // decode is pending; making these alternatives hid the
+                  // completed refinement and exposed the soft base raster as
+                  // a conspicuous strip until the much larger tile scene
+                  // arrived. Exact tiles paint afterward and therefore can
+                  // only improve—not downgrade—the pixels below.
+                  if (detail != null && fraction != null && w.isFinite)
                     Positioned(
                       left: fraction.left * w,
                       top: fraction.top * h,
@@ -5161,6 +5183,7 @@ class _PdfPageViewState extends State<PdfPageView>
                               ),
                       ),
                     ),
+                  if (tileLayer != null) tileLayer,
                 ],
               );
             },

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -4494,6 +4494,7 @@ class _PdfPageViewState extends State<PdfPageView>
         : sceneCap == null
             ? sessionCap
             : math.min(sessionCap, sceneCap);
+    final fallbackOcclusion = _fallbackOcclusionFraction(store, desired);
     return Positioned.fill(
       child: PdfTileLayer(
         store: store,
@@ -4546,12 +4547,32 @@ class _PdfPageViewState extends State<PdfPageView>
         // An old pyramid rung is useful pan-ahead outside the current patch,
         // but must not cover that sharper patch with stretched pixels. Exact
         // tiles are not clipped and replace it normally as they land.
-        fallbackOcclusionFraction:
-            _detailImage != null && _detailContentIsCurrent()
-                ? _detailFraction
-                : null,
+        fallbackOcclusionFraction: fallbackOcclusion,
       ),
     );
+  }
+
+  /// The retained detail patch may hide a coarse tile only when it is at least
+  /// as dense as the sharpest fallback the store can present for this view.
+  ///
+  /// A scale change deliberately keeps the previous patch visible while the
+  /// new pixels are prepared. Without this ratio gate, that old patch (for
+  /// example 2x) could clip out a newer cached fallback (4x) merely because
+  /// the latter is still below the requested exact rung (5.7x), visibly
+  /// stepping the page backwards until the exact tiles landed.
+  Rect? _fallbackOcclusionFraction(PdfTileStore store, double desired) {
+    final detailRatio = _detailPixelRatio;
+    final fraction = _detailFraction;
+    if (_detailImage == null ||
+        detailRatio == null ||
+        fraction == null ||
+        !_detailContentIsCurrent()) {
+      return null;
+    }
+    final rung = store.ladder.rungAtOrAbove(desired);
+    if (rung <= store.ladder.minRung) return null;
+    final sharpestFallbackRatio = store.ladder.ratioFor(rung - 1);
+    return detailRatio >= sharpestFallbackRatio * 0.99 ? fraction : null;
   }
 
   PdfTilePersistence? get _tilePersistence {

--- a/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
+++ b/packages/dart_pdf_editor/lib/src/render_worker_web_entry.dart
@@ -1062,6 +1062,7 @@ Future<Uint8List?> _recordPageAsync(
       tally,
       maxImagePixelRatio: imagePixelRatio,
       imageBudgetScale: imageBudgetScale,
+      imageDecodeRegion: imageDecodeRegion,
       flateSampleCache: flateSampleCache,
     );
     if (decodeClock != null) {
@@ -1193,6 +1194,7 @@ Future<(Uint8List, Uint8List)?> _recordStripDetailAsync(
     sourceCommands,
     token,
     tally,
+    imageDecodeRegion: imageDecodeRegion,
   );
   if (decodeClock != null) {
     decodeClock.stop();
@@ -1330,6 +1332,7 @@ Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
   _BrowserDecodeTally? tally, {
   double? maxImagePixelRatio,
   double imageBudgetScale = 1.0,
+  PdfRect? imageDecodeRegion,
   _BrowserFlateSampleCache? flateSampleCache,
 }) async {
   var changed = false;
@@ -1339,6 +1342,21 @@ Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
     switch (command) {
       case PdfDrawImageCommand(:final request):
         if (request.isInline || request.decoded != null) {
+          out.add(command);
+          continue;
+        }
+        // Region records eventually pass through serializeCommands, whose
+        // imageDecodeRegion path replaces an axis-aligned off-region draw with
+        // one transparent pixel. Do not predecode that draw first. The native
+        // Flate acceleration used to inflate and colour-convert every image on
+        // the page here, only for the serializer to throw almost all of those
+        // pixels away. A tiled CAD sheet with 52 requests consequently spent
+        // ~8.5 s per small pan and queued newer viewport regions behind stale
+        // work. Unsupported rotated/skewed transforms deliberately keep the
+        // general path: the serializer cannot region-retarget those either.
+        if (imageDecodeRegion != null &&
+            _axisAlignedImageOutsideRegion(request, imageDecodeRegion)) {
+          tally?.regionSkip();
           out.add(command);
           continue;
         }
@@ -1483,6 +1501,7 @@ Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
           tally,
           maxImagePixelRatio: maxImagePixelRatio,
           imageBudgetScale: imageBudgetScale,
+          imageDecodeRegion: imageDecodeRegion,
           flateSampleCache: flateSampleCache,
         );
         if (!identical(decodedMaskCommands, maskCommands)) changed = true;
@@ -1501,6 +1520,28 @@ Future<List<PdfRenderCommand>> _withBrowserDecodedImages(
     }
   }
   return changed ? out : commands;
+}
+
+bool _axisAlignedImageOutsideRegion(
+  PdfImageRequest request,
+  PdfRect region,
+) {
+  final transform = request.transform;
+  const epsilon = 1e-9;
+  if (transform.a.abs() <= epsilon ||
+      transform.d.abs() <= epsilon ||
+      transform.b.abs() > epsilon ||
+      transform.c.abs() > epsilon) {
+    return false;
+  }
+  final left = math.min(transform.e, transform.e + transform.a);
+  final right = math.max(transform.e, transform.e + transform.a);
+  final bottom = math.min(transform.f, transform.f + transform.d);
+  final top = math.max(transform.f, transform.f + transform.d);
+  return right <= region.left ||
+      left >= region.right ||
+      top <= region.bottom ||
+      bottom >= region.top;
 }
 
 (int, int)? _browserFlateTarget(
@@ -2382,6 +2423,7 @@ List<String> _browserImageDecodeMissing() => <String>[
 class _BrowserDecodeTally {
   int codec = 0;
   int flate = 0;
+  int regionSkipped = 0;
 
   /// Images served from a previous record's decode instead of re-running the
   /// codec (#451). Reported separately so a trace shows the reuse directly
@@ -2394,17 +2436,25 @@ class _BrowserDecodeTally {
 
   void reused() => reusedCount++;
 
+  void regionSkip() => regionSkipped++;
+
   String format() {
     final declined = _declined.values.fold(0, (a, b) => a + b);
-    if (codec == 0 && flate == 0 && declined == 0 && reusedCount == 0) {
+    if (codec == 0 &&
+        flate == 0 &&
+        declined == 0 &&
+        reusedCount == 0 &&
+        regionSkipped == 0) {
       return 'none';
     }
     final nativeFlate = flate == 0 ? '' : ' flate=$flate';
     final reuse = reusedCount == 0 ? '' : ' reused=$reusedCount';
-    if (declined == 0) return 'codec=$codec$nativeFlate$reuse';
+    final region = regionSkipped == 0 ? '' : ' regionSkip=$regionSkipped';
+    if (declined == 0) return 'codec=$codec$nativeFlate$reuse$region';
     final reasons =
         _declined.entries.map((e) => '${e.key}:${e.value}').join(',');
-    return 'codec=$codec$nativeFlate$reuse declined=$declined($reasons)';
+    return 'codec=$codec$nativeFlate$reuse$region '
+        'declined=$declined($reasons)';
   }
 }
 

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -7,6 +7,8 @@
 /// widget layer.
 library;
 
+import 'dart:ui' as ui show ClipOp;
+
 import 'package:flutter/widgets.dart';
 
 import 'debug_overlays.dart';
@@ -34,6 +36,7 @@ class PdfTileLayer extends StatelessWidget {
     this.maxNewTilesPerPaint,
     this.prefetchRingOverride,
     this.allowCoarserFallback = true,
+    this.fallbackOcclusionFraction,
     this.filterQuality = FilterQuality.medium,
   })  : assert(maxNewTilesPerPaint == null || maxNewTilesPerPaint > 0),
         assert(prefetchRingOverride == null || prefetchRingOverride >= 0);
@@ -84,6 +87,13 @@ class PdfTileLayer extends StatelessWidget {
   /// the exact tile lands.
   final bool allowCoarserFallback;
 
+  /// Page fraction whose existing pixels are sharper than a coarse tile.
+  ///
+  /// Exact-rung tiles still paint across this region. Upscaled fallback tiles
+  /// are clipped out of it, so a fast visible-region refinement cannot regress
+  /// to a blurry rectangle while the exact rung is still being produced.
+  final Rect? fallbackOcclusionFraction;
+
   final FilterQuality filterQuality;
 
   @override
@@ -102,6 +112,7 @@ class PdfTileLayer extends StatelessWidget {
           maxNewTilesPerPaint: maxNewTilesPerPaint,
           prefetchRingOverride: prefetchRingOverride,
           allowCoarserFallback: allowCoarserFallback,
+          fallbackOcclusionFraction: fallbackOcclusionFraction,
           filterQuality: filterQuality,
         ),
       );
@@ -121,6 +132,7 @@ class _TilePagePainter extends CustomPainter {
     required this.maxNewTilesPerPaint,
     required this.prefetchRingOverride,
     required this.allowCoarserFallback,
+    required this.fallbackOcclusionFraction,
     required this.filterQuality,
   }) : super(
             // tick as sharper tiles land, and repaint on debug-border toggles
@@ -138,6 +150,7 @@ class _TilePagePainter extends CustomPainter {
   final int? maxNewTilesPerPaint;
   final int? prefetchRingOverride;
   final bool allowCoarserFallback;
+  final Rect? fallbackOcclusionFraction;
   final FilterQuality filterQuality;
 
   @override
@@ -166,6 +179,14 @@ class _TilePagePainter extends CustomPainter {
     );
     if (view.isEmpty) return;
     final paint = Paint()..filterQuality = filterQuality;
+    final fallbackOcclusion = fallbackOcclusionFraction == null
+        ? null
+        : Rect.fromLTRB(
+            fallbackOcclusionFraction!.left * size.width,
+            fallbackOcclusionFraction!.top * size.height,
+            fallbackOcclusionFraction!.right * size.width,
+            fallbackOcclusionFraction!.bottom * size.height,
+          );
     final debugBounds = pdfDebugPaintDetailBounds.value;
     final exactBorder = debugBounds
         ? (Paint()
@@ -186,11 +207,24 @@ class _TilePagePainter extends CustomPainter {
         placement.destFraction.right * size.width,
         placement.destFraction.bottom * size.height,
       );
+      final clipFallback = placement.isFallback &&
+          fallbackOcclusion != null &&
+          dest.overlaps(fallbackOcclusion);
+      if (clipFallback) {
+        canvas.save();
+        canvas.clipRect(dest, doAntiAlias: false);
+        canvas.clipRect(
+          fallbackOcclusion,
+          clipOp: ui.ClipOp.difference,
+          doAntiAlias: false,
+        );
+      }
       canvas.drawImageRect(placement.image, placement.src, dest, paint);
       if (debugBounds) {
         canvas.drawRect(
             dest, placement.isFallback ? fallbackBorder! : exactBorder!);
       }
+      if (clipFallback) canvas.restore();
     }
   }
 
@@ -208,5 +242,6 @@ class _TilePagePainter extends CustomPainter {
       old.maxNewTilesPerPaint != maxNewTilesPerPaint ||
       old.prefetchRingOverride != prefetchRingOverride ||
       old.allowCoarserFallback != allowCoarserFallback ||
+      old.fallbackOcclusionFraction != fallbackOcclusionFraction ||
       old.filterQuality != filterQuality;
 }

--- a/packages/dart_pdf_editor/test/tile_image_detail_test.dart
+++ b/packages/dart_pdf_editor/test/tile_image_detail_test.dart
@@ -9,6 +9,7 @@
 // raster's ~120 dpi no matter how far in you zoomed - visibly fuzzier than
 // PDFium/PDF.js, which sample the native JPEG for the window they draw. These
 // tests pin the region-scoped re-decode that closes the gap.
+import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
@@ -246,6 +247,72 @@ void main() {
         reason: 'a coarse retained rung must not cover the sharper patch');
   });
 
+  testWidgets('panning coalesces tile image detail behind one worker record',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = _scannedSheet();
+    store = PdfTileStore(tilePixels: 256, registerForMemoryPressure: false);
+    final blocking = _BlockingFirstDetailWorker(
+      PdfRenderWorker.startUncached(bytes),
+    );
+    worker = blocking;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+
+    final doc = PdfDocument.open(bytes);
+    final page = doc.page(0);
+    Widget at(double dy, int settleGeneration) => Center(
+          child: OverflowBox(
+            maxWidth: double.infinity,
+            maxHeight: double.infinity,
+            child: Transform.translate(
+              // The synthetic page is 6000pt tall. Moving by 3000 layout
+              // pixels shifts the requested PDF region by 600pt while the
+              // page remains on screen, well beyond one viewport of decode
+              // headroom.
+              offset: Offset(0, dy),
+              child: SizedBox(
+                width: page.mediaBox.width * 5,
+                child: PdfPageView(
+                  key: const ValueKey('coalesced-detail-page'),
+                  page: page,
+                  settleGeneration: settleGeneration,
+                  renderWorker: blocking,
+                ),
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(at(0, 0));
+    for (var i = 0; i < 100 && blocking.detailRecords == 0; i++) {
+      await _settle(tester, rounds: 1);
+    }
+    expect(blocking.detailRecords, 1,
+        reason: 'the first viewport should start one region record');
+
+    // Move far enough that the first region no longer covers the viewport,
+    // while leaving that first decode deliberately blocked. This used to
+    // enqueue another record after every settle and produced 20-36 second
+    // worker queue waits in the CAD trace.
+    await tester.pumpWidget(at(-3000, 1));
+    await _settle(tester, rounds: 10);
+    expect(blocking.detailRecords, 1,
+        reason: 'a new viewport must coalesce behind the active decode');
+    expect(blocking.maxActiveDetails, 1);
+
+    blocking.releaseFirst();
+    for (var i = 0; i < 150 && blocking.detailRecords < 2; i++) {
+      await _settle(tester, rounds: 1);
+    }
+    expect(blocking.detailRecords, 2,
+        reason: 'completion should immediately re-evaluate the latest view');
+    expect(blocking.maxActiveDetails, 1,
+        reason: 'tile image detail records must remain serialized');
+  });
+
   testWidgets('a worker that declines the region record still lets tiles land',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;
@@ -349,4 +416,84 @@ class _DecliningDetailWorker extends PdfRenderWorker {
 
   @override
   void dispose() => inner.dispose();
+}
+
+class _BlockingFirstDetailWorker extends PdfRenderWorker {
+  _BlockingFirstDetailWorker(this.inner);
+
+  final PdfRenderWorker inner;
+  final Completer<void> _firstRelease = Completer<void>();
+  int detailRecords = 0;
+  int activeDetails = 0;
+  int maxActiveDetails = 0;
+
+  void releaseFirst() {
+    if (!_firstRelease.isCompleted) _firstRelease.complete();
+  }
+
+  @override
+  bool get isActive => inner.isActive;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
+  }) async {
+    if (imageDecodeRegion != null) {
+      detailRecords++;
+      activeDetails++;
+      maxActiveDetails = math.max(maxActiveDetails, activeDetails);
+      try {
+        if (detailRecords == 1) await _firstRelease.future;
+        // The scheduling behavior under test does not depend on pixel data;
+        // complete immediately once released so fake-async time is spent on
+        // the PageView state machine, not a second synthetic image decode.
+        return const <PdfRenderCommand>[];
+      } finally {
+        activeDetails--;
+      }
+    }
+    return inner.record(
+      pageIndex,
+      annotations: annotations,
+      priority: priority,
+      imagePixelRatio: imagePixelRatio,
+      decodeImages: decodeImages,
+      commandLimit: commandLimit,
+      imageDecodeRegion: imageDecodeRegion,
+      onPartial: onPartial,
+    );
+  }
+
+  @override
+  Future<PdfRegionReplayIndex?> buildRegionIndex(
+    int pageIndex, {
+    required bool annotations,
+    required int maxCommands,
+    required bool buildGrid,
+    int priority = 0,
+  }) =>
+      inner.buildRegionIndex(
+        pageIndex,
+        annotations: annotations,
+        maxCommands: maxCommands,
+        buildGrid: buildGrid,
+        priority: priority,
+      );
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) =>
+      inner.cancel(pageIndex, priority: priority);
+
+  @override
+  void dispose() {
+    releaseFirst();
+    inner.dispose();
+  }
 }

--- a/packages/dart_pdf_editor/test/tile_image_detail_test.dart
+++ b/packages/dart_pdf_editor/test/tile_image_detail_test.dart
@@ -247,6 +247,75 @@ void main() {
         reason: 'a coarse retained rung must not cover the sharper patch');
   });
 
+  testWidgets('an older detail patch cannot hide a sharper fallback rung',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = _scannedSheet();
+    setUpTiles(bytes);
+    final doc = PdfDocument.open(bytes);
+    final page = doc.page(0);
+
+    Widget at(double widthFactor, int settleGeneration) => Center(
+          child: OverflowBox(
+            maxWidth: double.infinity,
+            maxHeight: double.infinity,
+            child: SizedBox(
+              width: page.mediaBox.width * widthFactor,
+              child: PdfPageView(
+                key: const ValueKey('quality-monotonic-page'),
+                page: page,
+                settleGeneration: settleGeneration,
+                renderWorker: worker,
+              ),
+            ),
+          ),
+        );
+
+    // Land a 2x single-patch refinement first.
+    PdfPageView.tileStoreDetail = false;
+    await tester.pumpWidget(at(2, 0));
+    for (var i = 0; i < 100; i++) {
+      await tester.pump();
+      if (find
+          .byKey(const ValueKey('pdf-page-detail-image'))
+          .evaluate()
+          .isNotEmpty) {
+        break;
+      }
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 20)),
+      );
+    }
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget);
+
+    // At 5x the requested exact rung is 5.657x and its sharpest fallback is
+    // 4x. The retained 2x patch should remain as backing pixels, but it must
+    // not clip that sharper 4x fallback out of the tile layer.
+    PdfPageView.tileStoreDetail = true;
+    await tester.pumpWidget(at(5, 1));
+    for (var i = 0; i < 20; i++) {
+      await tester.pump();
+      if (find
+          .byKey(const ValueKey('pdf-page-tile-layer'))
+          .evaluate()
+          .isNotEmpty) {
+        break;
+      }
+    }
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget);
+    final painter = tester
+        .widget<CustomPaint>(find.byKey(const ValueKey('pdf-page-tile-layer')))
+        .painter as dynamic;
+    expect(
+      painter.fallbackOcclusionFraction,
+      isNull,
+      reason: 'a lower-density patch must not hide a sharper cached rung',
+    );
+  });
+
   testWidgets('panning coalesces tile image detail behind one worker record',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;

--- a/packages/dart_pdf_editor/test/tile_image_detail_test.dart
+++ b/packages/dart_pdf_editor/test/tile_image_detail_test.dart
@@ -174,6 +174,78 @@ void main() {
     expect(PdfPageView.debugTileImageDetailAdoptions, 0);
   });
 
+  testWidgets('tiles retain the completed visible patch while sharpening',
+      (tester) async {
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final bytes = _scannedSheet();
+    setUpTiles(bytes);
+    final doc = PdfDocument.open(bytes);
+    final page = doc.page(0);
+
+    Widget at(int settleGeneration) => Center(
+          child: OverflowBox(
+            maxWidth: double.infinity,
+            maxHeight: double.infinity,
+            child: SizedBox(
+              width: page.mediaBox.width * 5,
+              child: PdfPageView(
+                page: page,
+                settleGeneration: settleGeneration,
+                renderWorker: worker,
+              ),
+            ),
+          ),
+        );
+
+    // First take the single-patch route. It is the quick visible answer that
+    // used to disappear as soon as the reusable pyramid engaged.
+    PdfPageView.tileStoreDetail = false;
+    await tester.pumpWidget(at(0));
+    for (var i = 0; i < 100; i++) {
+      await tester.pump();
+      if (find
+          .byKey(const ValueKey('pdf-page-detail-image'))
+          .evaluate()
+          .isNotEmpty) {
+        break;
+      }
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 20)),
+      );
+    }
+    expect(
+      find.byKey(const ValueKey('pdf-page-detail-image')),
+      findsOneWidget,
+      reason: 'the visible-region refinement must land before tile prefetch',
+    );
+
+    // A translation settle switches back to the reusable tile pyramid. The
+    // completed patch remains the visual fallback under its sparse tiles;
+    // previously the two widgets were mutually exclusive and the page fell
+    // back to its low-resolution full raster until the tile image scene landed.
+    PdfPageView.tileStoreDetail = true;
+    await tester.pumpWidget(at(1));
+    for (var i = 0; i < 20; i++) {
+      await tester.pump();
+      if (find
+          .byKey(const ValueKey('pdf-page-tile-layer'))
+          .evaluate()
+          .isNotEmpty) {
+        break;
+      }
+    }
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget,
+        reason: 'engaging tiles must not hide already-sharp visible pixels');
+    final painter = tester
+        .widget<CustomPaint>(find.byKey(const ValueKey('pdf-page-tile-layer')))
+        .painter as dynamic;
+    expect(painter.fallbackOcclusionFraction, isNotNull,
+        reason: 'a coarse retained rung must not cover the sharper patch');
+  });
+
   testWidgets('a worker that declines the region record still lets tiles land',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;

--- a/packages/dart_pdf_editor/test/tile_layer_test.dart
+++ b/packages/dart_pdf_editor/test/tile_layer_test.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -15,6 +16,17 @@ Future<ui.Image> _solidImage(int w, int h) {
   final image = picture.toImage(w, h);
   picture.dispose();
   return image;
+}
+
+Future<Color> _pixel(ui.Image image, int x, int y) async {
+  final bytes = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+  final offset = (y * image.width + x) * 4;
+  return Color.fromARGB(
+    bytes!.getUint8(offset + 3),
+    bytes.getUint8(offset),
+    bytes.getUint8(offset + 1),
+    bytes.getUint8(offset + 2),
+  );
 }
 
 class _Rasterizer {
@@ -124,6 +136,67 @@ void main() {
         ),
       );
       expect(tester.takeException(), isNull);
+      store.dispose();
+    });
+  });
+
+  testWidgets('a coarse fallback cannot cover a sharper patch', (tester) async {
+    await tester.runAsync(() async {
+      final store = PdfTileStore(
+        tilePixels: 32,
+        prefetchRing: 0,
+        registerForMemoryPressure: false,
+      );
+      final raster = _Rasterizer(tileSize: 32);
+      const boundaryKey = ValueKey('tile-fallback-occlusion');
+
+      Widget layer(double ratio, {Rect? occlusion}) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: RepaintBoundary(
+                key: boundaryKey,
+                child: SizedBox(
+                  width: 64,
+                  height: 64,
+                  child: ColoredBox(
+                    color: const Color(0xFFFF0000),
+                    child: PdfTileLayer(
+                      store: store,
+                      identity: _id(0),
+                      pageSize: const Size(64, 64),
+                      desiredRatio: ratio,
+                      visibleFraction: const Rect.fromLTRB(0, 0, 1, 1),
+                      rasterize: raster.call,
+                      fallbackOcclusionFraction: occlusion,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+      // Seed a complete blue 1x rung.
+      await tester.pumpWidget(layer(1));
+      await raster.flush();
+      await tester.pump();
+
+      // Ask for 2x but leave those exact tiles pending. The store now presents
+      // the blue 1x rung as a fallback; the central refined fraction must show
+      // the red backing through instead of being covered by stretched blue.
+      await tester.pumpWidget(layer(
+        2,
+        occlusion: const Rect.fromLTRB(0.25, 0.25, 0.75, 0.75),
+      ));
+      await tester.pump();
+      final boundary = tester.renderObject<RenderRepaintBoundary>(
+        find.byKey(boundaryKey),
+      );
+      final image = await boundary.toImage();
+      expect(await _pixel(image, 4, 4), const Color(0xFF2277EE),
+          reason: 'fallback remains useful outside the sharp patch');
+      expect(await _pixel(image, 32, 32), const Color(0xFFFF0000),
+          reason: 'fallback is clipped out of the sharp patch');
+      image.dispose();
       store.dispose();
     });
   });


### PR DESCRIPTION
## Summary

- preserve a sharp visible-region detail patch while coarse tile refinement is still landing
- clip lower-quality fallback tiles out of regions already covered by sharper detail
- skip browser-worker predecoding for axis-aligned image chunks that are outside the requested region
- coalesce viewport changes behind one active image-detail record and re-evaluate only the latest viewport when it completes
- reject stale detail results after the page or scene is invalidated

## Root cause

The affected CAD page draws 52 tiled raster image chunks. A visible-region worker request first predecoded all 52 chunks, even though command serialization later replaced off-region draws with transparent placeholders. Each small pan therefore spent about 8.1–8.6 seconds decoding data that was mostly discarded.

Viewport movement could also enqueue another region record while an older one was active. The supplied trace shows queue waits growing through 6.2, 13.5, 21.3, and 27.7 seconds, with the last result taking 36.5 seconds overall. Coarse tiles could meanwhile cover a sharper patch, producing the apparent quality regression.

## Impact

On the real `ly9-far-cad.pdf` page 30 workflow, an already-loaded document sharpened its visible region in about 417 ms in a local release Chromium run. New panned tile regions replayed in about 106–135 ms and were sharp by the first 500 ms capture.

The request coalescing is platform-neutral. The off-region native Flate predecode optimization applies to the browser worker path that produced the attached trace.

Cold first-time interpretation of this unusually dense page remains a separate performance target; this PR addresses the failure to sharpen and the stale refinement backlog after the page is loaded.

## Validation

- `fvm dart analyze`
- focused renderer/worker suite: 117 tests passed
- complete `dart_pdf_editor` suite: 2,289 tests passed, 29 expected skips
- local release Chromium visual/temporal check on `corpus/ly9-far-cad.pdf`, page 30
