### PR TITLE
perf(viewer): sharpen visible CAD regions first

### DIFF
--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -5,9 +5,11 @@
 - Sharpen deep-zoom pages visible-first: the foreground render now covers the
   exact viewport. Once that sharp frame paints, tile-capable pages grow bounded
   pan-ahead underneath it; fallback pages avoid a second unpreemptible raster.
-  New settles cancel pending promotion, foreground paint telemetry remains
-  distinct, and every retained detail allocation rebalances the live-raster
-  budget, preventing visible quality and memory from stepping backwards.
+  Translation settles cannot abandon an in-flight exact recovery, and tile
+  admission is bounded across frames so unrelated repaints cannot build a long
+  GPU queue. Foreground paint telemetry remains distinct, and every retained
+  detail allocation rebalances the live-raster budget, preventing visible
+  quality and memory from stepping backwards.
 - Promote fast-scroll page previews through a configurable 200 -> 400 -> 800
   px LoD ladder before the final display raster. Intermediate levels warm only
   around the viewport, share a 32 MiB byte-budgeted LRU, and are generated from

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## Unreleased
 
 - Sharpen deep-zoom pages visible-first: the foreground render now covers the
-  exact viewport, then grows a preemptible 12.5% pan-ahead guard only after the
-  sharp frame paints. New settles cancel that speculative work, and the guard
-  is skipped when raster caps would reduce pixel density, preventing visible
-  quality from stepping backwards.
+  exact viewport. Once that sharp frame paints, tile-capable pages grow bounded
+  pan-ahead underneath it; fallback pages avoid a second unpreemptible raster.
+  New settles cancel pending promotion, foreground paint telemetry remains
+  distinct, and every retained detail allocation rebalances the live-raster
+  budget, preventing visible quality and memory from stepping backwards.
 - Promote fast-scroll page previews through a configurable 200 -> 400 -> 800
   px LoD ladder before the final display raster. Intermediate levels warm only
   around the viewport, share a 32 MiB byte-budgeted LRU, and are generated from

--- a/packages/dart_pdf_editor/CHANGELOG.md
+++ b/packages/dart_pdf_editor/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Sharpen deep-zoom pages visible-first: the foreground render now covers the
+  exact viewport, then grows a preemptible 12.5% pan-ahead guard only after the
+  sharp frame paints. New settles cancel that speculative work, and the guard
+  is skipped when raster caps would reduce pixel density, preventing visible
+  quality from stepping backwards.
 - Promote fast-scroll page previews through a configurable 200 -> 400 -> 800
   px LoD ladder before the final display raster. Intermediate levels warm only
   around the viewport, share a 32 MiB byte-budgeted LRU, and are generated from

--- a/packages/dart_pdf_editor/example/tool/build_web.sh
+++ b/packages/dart_pdf_editor/example/tool/build_web.sh
@@ -13,7 +13,7 @@ FLUTTER="${FLUTTER:-fvm flutter}"
 
 echo "==> Regenerating the bundled render worker asset"
 $DART run dart_pdf_editor:build_web_worker \
-  --out ../assets/web/pdf_render_worker.dart.js
+  --out ../../dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
 
 echo "==> flutter build web $*"
 $FLUTTER build web "$@"

--- a/packages/dart_pdf_editor/example/tool/cad_web_cold_start_benchmark.sh
+++ b/packages/dart_pdf_editor/example/tool/cad_web_cold_start_benchmark.sh
@@ -10,7 +10,7 @@ PORT=${CAD_PERF_PORT:-8765}
 
 if [[ "${CAD_PERF_SKIP_WORKER_BUILD:-0}" != "1" ]]; then
   fvm dart run dart_pdf_editor:build_web_worker \
-    --out ../assets/web/pdf_render_worker.dart.js
+    --out ../../dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
 fi
 
 python3 - "$ROOT/corpus" "$PORT" <<'PY' &

--- a/packages/dart_pdf_editor/example/tool/cad_web_detail_benchmark.sh
+++ b/packages/dart_pdf_editor/example/tool/cad_web_detail_benchmark.sh
@@ -21,7 +21,7 @@ MIN_SPEEDUP=${CAD_PERF_MIN_SPEEDUP:-1.10}
 
 if [[ "${CAD_PERF_SKIP_WORKER_BUILD:-0}" != "1" ]]; then
   fvm dart run dart_pdf_editor:build_web_worker \
-    --out ../assets/web/pdf_render_worker.dart.js
+    --out ../../dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
 fi
 
 # Flutter's app server owns a different origin, so expose the local corpus with

--- a/packages/dart_pdf_editor/example/tool/cad_web_perf.sh
+++ b/packages/dart_pdf_editor/example/tool/cad_web_perf.sh
@@ -15,7 +15,7 @@ PORT=8753
 if [[ "${1:-}" != "--serve" ]]; then
   [[ -f "$PDF" ]] || { echo "missing $PDF" >&2; exit 1; }
   fvm dart run dart_pdf_editor:build_web_worker \
-    --out ../assets/web/pdf_render_worker.dart.js
+    --out ../../dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
   fvm flutter build web --release --dart-define=PDF=cad.pdf
   cp "$PDF" build/web/cad.pdf
 fi

--- a/packages/dart_pdf_editor/example/tool/cad_web_spatial_replay_benchmark.sh
+++ b/packages/dart_pdf_editor/example/tool/cad_web_spatial_replay_benchmark.sh
@@ -10,7 +10,7 @@ PORT=${CAD_PERF_PORT:-8770}
 
 if [[ "${CAD_PERF_SKIP_WORKER_BUILD:-0}" != "1" ]]; then
   fvm dart run dart_pdf_editor:build_web_worker \
-    --out ../assets/web/pdf_render_worker.dart.js
+    --out ../../dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
 fi
 
 python3 - "$ROOT/corpus" "$PORT" <<'PY' &

--- a/packages/dart_pdf_editor/example/tool/cad_web_transcript_benchmark.sh
+++ b/packages/dart_pdf_editor/example/tool/cad_web_transcript_benchmark.sh
@@ -10,7 +10,7 @@ PORT=${CAD_PERF_PORT:-8765}
 
 if [[ "${CAD_PERF_SKIP_WORKER_BUILD:-0}" != "1" ]]; then
   fvm dart run dart_pdf_editor:build_web_worker \
-    --out ../assets/web/pdf_render_worker.dart.js
+    --out ../../dart_pdf_editor_assets/assets/web/pdf_render_worker.dart.js
 fi
 
 python3 - "$ROOT/corpus" "$PORT" <<'PY' &

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -736,28 +736,19 @@ class _PdfPageViewState extends State<PdfPageView>
   double? _detailPixelRatio;
   PdfPageRenderIntent? _detailIntent;
 
-  /// Low-priority pan-ahead pixels live underneath the exact foreground patch
-  /// instead of replacing it. Keeping the foreground layer on top makes the
-  /// overlap byte-for-byte stable: a late background completion cannot nudge
-  /// antialiasing or restart the visible-settle clock.
-  ui.Image? _detailHeadroomImage;
-  Rect? _detailHeadroomFraction;
-  double? _detailHeadroomPixelRatio;
-  PdfPageRenderIntent? _detailHeadroomIntent;
-
-  /// The settle generation whose scale change should temporarily bypass the
-  /// tile layer and sharpen the exact visible slice first. Translation-only
-  /// settles use the same visible-first patch geometry, but may keep the tile
-  /// route when its retained scene can answer the view.
+  /// The scale-settle generation that temporarily bypasses the tile layer and
+  /// sharpens the exact visible slice first. Tiles grow pan-ahead only after
+  /// that foreground patch has reached the compositor. Translation settles
+  /// retain the already-active pyramid so region-image requests can coalesce.
   int? _tightDetailGeneration;
 
-  /// Invalidates the optional low-priority pan-ahead pass. The foreground
-  /// patch always covers exactly the visible slice; once that sharp frame has
-  /// reached the compositor, a second pass may grow it by a small guard band.
-  /// A viewport/content change increments this token before scheduling its
-  /// replacement, so stale post-frame callbacks never start work.
-  int _detailHeadroomGeneration = 0;
-  bool _detailHeadroomScheduledOrRunning = false;
+  /// Invalidates the post-paint promotion from the exact patch to the bounded
+  /// tile pyramid. The pyramid rasterizes in small units; the legacy patch
+  /// path deliberately has no speculative second multi-megapixel raster,
+  /// because `Picture.toImage` cannot be preempted once submitted.
+  int _tilePanAheadGeneration = 0;
+  bool _tilePanAheadScheduled = false;
+  bool _tilePanAheadActive = false;
 
   /// A scale or layout-width update reached this lazy-list child while another
   /// page owns focus. Keep the previous raster (it remains a valid soft preview
@@ -1072,24 +1063,16 @@ class _PdfPageViewState extends State<PdfPageView>
         oldWidget.qualityPageCount != widget.qualityPageCount;
     if (scaleChanged) {
       _tightDetailGeneration = widget.settleGeneration;
+      _cancelTilePanAhead();
+    } else if (settleChanged) {
+      _cancelTilePanAhead();
     }
     final transition = _renderSession.update(_renderIntent(widget));
     if (transition.scheduleRender ||
         oldWidget.previewIndex != widget.previewIndex ||
         !identical(oldWidget.renderWorker, widget.renderWorker) ||
         oldWidget.renderPriority != widget.renderPriority) {
-      if (oldWidget.previewIndex != widget.previewIndex ||
-          !identical(oldWidget.renderWorker, widget.renderWorker)) {
-        oldWidget.renderWorker?.cancel(
-          oldWidget.previewIndex,
-          priority: _detailHeadroomWorkerPriority,
-        );
-        oldWidget.renderWorker?.cancelBinStrips(
-          oldWidget.previewIndex,
-          priority: _detailHeadroomWorkerPriority,
-        );
-      }
-      _cancelDetailHeadroom();
+      _cancelTilePanAhead();
     }
     if (!identical(oldWidget.renderWorker, widget.renderWorker) ||
         oldWidget.previewIndex != widget.previewIndex ||
@@ -1312,7 +1295,7 @@ class _PdfPageViewState extends State<PdfPageView>
     widget.renderHold?.removeListener(_onRenderHoldChanged);
     _liveTransformFor(widget)?.removeListener(_onLiveTransformChanged);
     _speculateTimer?.cancel();
-    _cancelDetailHeadroom();
+    _cancelTilePanAhead();
     // any pending speculative bin is reaped by the cancelBinStrips below;
     // its null result resolves into a future nobody awaits any more
     _speculativeStripPlan = null;
@@ -1337,7 +1320,6 @@ class _PdfPageViewState extends State<PdfPageView>
     _disposeTileRasterSessions();
     _image?.dispose();
     _detailImage?.dispose();
-    _detailHeadroomImage?.dispose();
     _tileDetailScene?.dispose();
     _preview?.dispose();
     super.dispose();
@@ -1602,170 +1584,99 @@ class _PdfPageViewState extends State<PdfPageView>
   }
 
   void _dropDetail() {
-    _cancelDetailHeadroom();
+    _cancelTilePanAhead();
     _invalidateTiles();
     _dropTileImageDetail();
     _renderSession.invalidateDetail();
-    final hadImage = _detailImage != null || _detailHeadroomImage != null;
+    final hadImage = _detailImage != null;
     _detailImage?.dispose();
     _detailImage = null;
     _detailFraction = null;
     _detailPixelRatio = null;
     _detailIntent = null;
-    _detailHeadroomImage?.dispose();
-    _detailHeadroomImage = null;
-    _detailHeadroomFraction = null;
-    _detailHeadroomPixelRatio = null;
-    _detailHeadroomIntent = null;
     if (hadImage && mounted) setState(() {});
   }
 
-  void _adoptDetail(ui.Image image, Rect fraction, double pixelRatio,
-      {bool scheduleHeadroom = true}) {
-    if (scheduleHeadroom) {
-      _detailImage?.dispose();
-      _detailImage = image;
-      _detailFraction = fraction;
-      _detailPixelRatio = pixelRatio;
-      _detailIntent = _renderIntent(widget);
-      _detailHeadroomImage?.dispose();
-      _detailHeadroomImage = null;
-      _detailHeadroomFraction = null;
-      _detailHeadroomPixelRatio = null;
-      _detailHeadroomIntent = null;
-      _scheduleDetailHeadroom();
-    } else {
-      _detailHeadroomImage?.dispose();
-      _detailHeadroomImage = image;
-      _detailHeadroomFraction = fraction;
-      _detailHeadroomPixelRatio = pixelRatio;
-      _detailHeadroomIntent = _renderIntent(widget);
-    }
+  void _adoptDetail(ui.Image image, Rect fraction, double pixelRatio) {
+    _detailImage?.dispose();
+    _detailImage = image;
+    _detailFraction = fraction;
+    _detailPixelRatio = pixelRatio;
+    _detailIntent = _renderIntent(widget);
+    _scheduleBudgetRebalance();
   }
 
-  void _cancelDetailHeadroom() {
-    _detailHeadroomGeneration++;
-    _detailHeadroomScheduledOrRunning = false;
-    final worker = widget.renderWorker;
-    if (worker == null) return;
-    worker.cancel(
-      widget.previewIndex,
-      priority: _detailHeadroomWorkerPriority,
-    );
-    worker.cancelBinStrips(
-      widget.previewIndex,
-      priority: _detailHeadroomWorkerPriority,
-    );
+  void _cancelTilePanAhead() {
+    _tilePanAheadGeneration++;
+    _tilePanAheadScheduled = false;
+    _tilePanAheadActive = false;
   }
 
-  bool _detailHeadroomContextIsCurrent(
+  bool _tilePanAheadContextIsCurrent(
     int token,
     int settleGeneration,
     double scale,
   ) =>
       mounted &&
-      token == _detailHeadroomGeneration &&
+      token == _tilePanAheadGeneration &&
       settleGeneration == widget.settleGeneration &&
       scale == widget.scale &&
       !_renderPaused;
 
-  /// Grows a completed exact-visible patch only after that sharp frame has
-  /// painted. The request runs in the worker's speculative priority class, so
-  /// a subsequent foreground settle preempts it on every worker backend. The
-  /// current exact patch remains on top after the same-density guarded layer
-  /// lands; if the larger region would lower the density under the raster caps,
-  /// it is skipped rather than stepping quality backwards.
-  void _scheduleDetailHeadroom() {
-    if (_detailHeadroomScheduledOrRunning) return;
-    _detailHeadroomScheduledOrRunning = true;
-    final token = ++_detailHeadroomGeneration;
+  /// Lets the bounded tile pyramid grow around a completed exact-visible patch
+  /// only after that patch has painted. A tile raster is deliberately small and
+  /// admitted one unit at a time on dense pages, so a new interaction is never
+  /// trapped behind the old implementation's speculative multi-megapixel
+  /// `Picture.toImage`. Pages that cannot tile simply keep the exact patch.
+  void _scheduleTilePanAhead() {
+    if (_tilePanAheadScheduled ||
+        !PdfPageView.tileStoreDetail ||
+        widget.qualityPageCount > 1) {
+      return;
+    }
+    _tilePanAheadScheduled = true;
+    final token = ++_tilePanAheadGeneration;
     final settleGeneration = widget.settleGeneration;
     final scale = widget.scale;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!_detailHeadroomContextIsCurrent(
-            token,
-            settleGeneration,
-            scale,
-          ) ||
-          !_detailContentIsCurrent()) {
-        if (token == _detailHeadroomGeneration) {
-          _detailHeadroomScheduledOrRunning = false;
-        }
-        return;
-      }
-      final existingFraction = _detailFraction;
-      final existingRatio = _detailPixelRatio;
-      if (_detailImage == null ||
-          existingFraction == null ||
-          existingRatio == null) {
-        _detailHeadroomScheduledOrRunning = false;
-        return;
-      }
-      final headroom = _detailGeometryAt(
+      final contextCurrent = _tilePanAheadContextIsCurrent(
+        token,
+        settleGeneration,
         scale,
-        inflation: _panDetailInflation,
       );
-      final retainedHeadroomFraction = _detailHeadroomFraction;
-      final retainedHeadroomRatio = _detailHeadroomPixelRatio;
-      if (headroom == null ||
-          headroom.pixelRatio < existingRatio * 0.99 ||
-          !_detailPatchCovers(
-            existingFraction,
-            headroom.visibleFraction,
-          ) ||
-          (_detailHeadroomImage != null &&
-              retainedHeadroomFraction != null &&
-              retainedHeadroomRatio != null &&
-              _detailHeadroomContentIsCurrent() &&
-              retainedHeadroomRatio >= headroom.pixelRatio * 0.99 &&
-              _detailPatchCovers(
-                retainedHeadroomFraction,
-                headroom.fraction,
-              )) ||
-          _detailPatchCovers(existingFraction, headroom.fraction)) {
-        _detailHeadroomScheduledOrRunning = false;
+      final contentCurrent = _detailContentIsCurrent();
+      if (!contextCurrent || !contentCurrent) {
+        if (token == _tilePanAheadGeneration) {
+          _tilePanAheadScheduled = false;
+        }
         return;
       }
-      PdfPerfLog.log(
-        'detail headroom page=${widget.previewIndex} '
-        'visible=${headroom.visibleFraction.width.toStringAsFixed(3)}x'
-        '${headroom.visibleFraction.height.toStringAsFixed(3)} '
-        'guarded=${headroom.fraction.width.toStringAsFixed(3)}x'
-        '${headroom.fraction.height.toStringAsFixed(3)} '
-        'ratio=${headroom.pixelRatio.toStringAsFixed(2)}',
-      );
-      unawaited(() async {
-        try {
-          await _updateDetail(
-            detailGeometry: headroom,
-            headroomPass: true,
-            workerPriority: _detailHeadroomWorkerPriority,
-            stillRelevant: () => _detailHeadroomContextIsCurrent(
-              token,
-              settleGeneration,
-              scale,
-            ),
-          );
-        } catch (error) {
-          // This pass is opportunistic: a failed guard-band render must never
-          // replace the already-sharp visible patch or escape as an unhandled
-          // asynchronous error.
-          PdfPerfLog.log(
-            'detail headroom failed page=${widget.previewIndex} error=$error',
-          );
-        } finally {
-          if (token == _detailHeadroomGeneration) {
-            _detailHeadroomScheduledOrRunning = false;
-          }
-        }
-      }());
+      if (_detailImage == null) {
+        _tilePanAheadScheduled = false;
+        return;
+      }
+      _activateTilePanAhead();
     });
   }
 
-  bool _detailContentIsCurrent() => _intentIsCurrent(_detailIntent);
+  void _activateTilePanAhead() {
+    _tilePanAheadScheduled = false;
+    if (!mounted ||
+        !PdfPageView.tileStoreDetail ||
+        widget.qualityPageCount > 1 ||
+        _detailImage == null ||
+        !_detailContentIsCurrent()) {
+      return;
+    }
+    setState(() => _tilePanAheadActive = true);
+    final active = _refreshTileGeometry();
+    PdfPerfLog.log(
+      'detail pan-ahead page=${widget.previewIndex} '
+      'route=${active ? 'tiles' : _tilePathStatus}',
+    );
+  }
 
-  bool _detailHeadroomContentIsCurrent() =>
-      _intentIsCurrent(_detailHeadroomIntent);
+  bool _detailContentIsCurrent() => _intentIsCurrent(_detailIntent);
 
   /// Whether pixels taken under [intent] still depict this page's current
   /// content. Shared by the detail patch and the base raster - both ask exactly
@@ -1857,7 +1768,6 @@ class _PdfPageViewState extends State<PdfPageView>
   int get liveRasterBytes =>
       _imageBytes(_image) +
       _imageBytes(_detailImage) +
-      _imageBytes(_detailHeadroomImage) +
       (_scene?.decodedImageBytes ?? 0) +
       (_tileDetailScene?.decodedImageBytes ?? 0);
 
@@ -3663,16 +3573,13 @@ class _PdfPageViewState extends State<PdfPageView>
     }());
   }
 
-  /// Renders (or drops) the deep-zoom patch at the resolution the zoom asks
-  /// for. Foreground calls cover exactly the visible slice; once it paints,
-  /// [headroomPass] may grow it by [_panDetailInflation] at speculative worker
-  /// priority without delaying the first sharp frame.
+  /// Renders (or drops) the exact visible deep-zoom patch at the resolution the
+  /// zoom asks for. After it paints, tile-capable pages may grow bounded
+  /// pan-ahead underneath it; the single-patch fallback does no speculative
+  /// second raster because that work cannot be preempted cross-platform.
   Future<bool> _updateDetail({
     _DetailGeometry? detailGeometry,
     VoidCallback? onPaint,
-    bool headroomPass = false,
-    int? workerPriority,
-    bool Function()? stillRelevant,
   }) async {
     if (_renderPaused) return false;
     // The viewer's global transform reaches cache-window neighbours too. They
@@ -3707,7 +3614,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // index. Do not guard this call on _useTilePath: that gate cannot become
     // true until the very warm-up this call starts has completed.
     final tightDetail = _tightDetailGeneration == widget.settleGeneration;
-    if (PdfPageView.tileStoreDetail && (!tightDetail || headroomPass)) {
+    if (PdfPageView.tileStoreDetail && !tightDetail) {
       if (_refreshTileGeometry()) return true;
       // A worker-built grid takes a few hundred milliseconds on the dense CAD
       // pages that need it. Keep the already-visible capped base raster during
@@ -3752,43 +3659,28 @@ class _PdfPageViewState extends State<PdfPageView>
     final region = detailGeometry.region;
     final ratio = detailGeometry.pixelRatio;
 
-    // Foreground work asks only for the live viewport. A completed background
-    // pass may already contain that viewport plus its small pan guard; keep
-    // using those pixels rather than rebuilding them. The headroom pass checks
-    // its whole requested fraction so the exact patch does not make it return
-    // early merely because the visible centre is already sharp.
-    //
+    // Foreground work asks only for the live viewport. Keep using an existing
+    // exact patch while it covers that viewport at the requested density.
     // Content identity is checked separately: additive edits intentionally
     // leave the old patch painted until its replacement lands, but that stale
     // patch must never satisfy this fast path. A higher-density request (zoom
     // in, or a smaller cap-bound region) also gets a fresh raster.
     final existingFraction = _detailFraction;
     final existingRatio = _detailPixelRatio;
-    final requiredFraction =
-        headroomPass ? detailGeometry.fraction : detailGeometry.visibleFraction;
+    final requiredFraction = detailGeometry.visibleFraction;
     final primaryCovers = _detailImage != null &&
         existingFraction != null &&
         existingRatio != null &&
         _detailContentIsCurrent() &&
         existingRatio >= ratio * 0.99 &&
         _detailPatchCovers(existingFraction, requiredFraction);
-    final headroomFraction = _detailHeadroomFraction;
-    final headroomRatio = _detailHeadroomPixelRatio;
-    final headroomCovers = _detailHeadroomImage != null &&
-        headroomFraction != null &&
-        headroomRatio != null &&
-        _detailHeadroomContentIsCurrent() &&
-        headroomRatio >= ratio * 0.99 &&
-        _detailPatchCovers(headroomFraction, requiredFraction);
-    if (primaryCovers || headroomCovers) {
+    if (primaryCovers) {
       PdfPageView.debugDetailPatchReuses++;
       onPaint?.call();
-      if (!headroomPass && !headroomCovers) _scheduleDetailHeadroom();
+      _scheduleTilePanAhead();
       PdfPerfLog.log(
         'detail reuse page=${widget.previewIndex} '
-        'pass=${headroomPass ? 'headroom' : 'visible'} '
-        'source=${primaryCovers ? 'visible' : 'headroom'} '
-        'ratio=${(primaryCovers ? existingRatio : headroomRatio)!.toStringAsFixed(2)}',
+        'source=visible ratio=${existingRatio.toStringAsFixed(2)}',
       );
       return true;
     }
@@ -3810,10 +3702,8 @@ class _PdfPageViewState extends State<PdfPageView>
     // through to the retained base scene below.
     final heldScene = PdfPageView.retainedZoomReplay ? _scene : null;
     final stripDetail = heldScene != null && _stripReplayScene(heldScene);
-    final progressivePriority = workerPriority ??
-        (_sceneIsVectorOnly
-            ? widget.renderPriority - 1
-            : widget.renderPriority);
+    final progressivePriority =
+        _sceneIsVectorOnly ? widget.renderPriority - 1 : widget.renderPriority;
     // Whether replaying the retained vector-only scene alone yields the
     // FINISHED region rather than a placeholder to be replaced. It does exactly
     // when no image draw reaches the region - the same invariant that lets the
@@ -3832,7 +3722,7 @@ class _PdfPageViewState extends State<PdfPageView>
     final detailClock = Stopwatch()..start();
     PdfPerfLog.log(
       'detail request page=${widget.previewIndex} '
-      'pass=${headroomPass ? 'headroom' : 'visible'} '
+      'pass=visible '
       'strip=$stripDetail vectorOnly=$_sceneIsVectorOnly '
       'retainedCovers=$retainedCoversRegion '
       // scene/tiles: why this page does or does not get reusable tiles instead
@@ -3870,8 +3760,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // worker pass was started to replace it.
     if (retainedCoversRegion) {
       final cachedPicture = await _picture;
-      if (!(stillRelevant?.call() ?? true) ||
-          !mounted ||
+      if (!mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         return false;
@@ -3885,23 +3774,21 @@ class _PdfPageViewState extends State<PdfPageView>
             ? heldScene.rasterizeRegion(region, pixelRatio: ratio)
             : PdfPageRenderer.rasterizeRegion(cachedPicture, region, ratio),
       );
-      if (!(stillRelevant?.call() ?? true) ||
-          !mounted ||
+      if (!mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         retainedImage.dispose();
         return false;
       }
       setState(() {
-        _adoptDetail(
-          retainedImage,
-          fraction,
-          ratio,
-          scheduleHeadroom: !headroomPass,
-        );
+        _adoptDetail(retainedImage, fraction, ratio);
       });
       onPaint?.call();
-      _logDetailPaintAfterFrame(generation, detailClock, source: 'retained');
+      _observeDetailPaintAfterFrame(
+        generation,
+        detailClock,
+        source: 'retained',
+      );
       PdfPerfLog.log(
         'detail retained page=${widget.previewIndex} complete '
         'elapsed=${detailClock.elapsedMilliseconds}ms',
@@ -3916,8 +3803,7 @@ class _PdfPageViewState extends State<PdfPageView>
       'elapsed=${detailClock.elapsedMilliseconds}ms '
       'stripImage=${workerStripImage != null} picture=${workerPicture != null}',
     );
-    if (!(stillRelevant?.call() ?? true) ||
-        !mounted ||
+    if (!mounted ||
         !_renderSession.acceptsDetail(generation) ||
         _renderPaused) {
       workerStripImage?.dispose();
@@ -3926,15 +3812,10 @@ class _PdfPageViewState extends State<PdfPageView>
     }
     if (workerStripImage != null) {
       setState(() {
-        _adoptDetail(
-          workerStripImage,
-          fraction,
-          ratio,
-          scheduleHeadroom: !headroomPass,
-        );
+        _adoptDetail(workerStripImage, fraction, ratio);
       });
       onPaint?.call();
-      _logDetailPaintAfterFrame(
+      _observeDetailPaintAfterFrame(
         generation,
         detailClock,
         source: 'worker-strip',
@@ -3951,23 +3832,17 @@ class _PdfPageViewState extends State<PdfPageView>
             PdfPageRenderer.rasterizeRegion(workerPicture, region, ratio),
       );
       workerPicture.dispose();
-      if (!(stillRelevant?.call() ?? true) ||
-          !mounted ||
+      if (!mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         image.dispose();
         return false;
       }
       setState(() {
-        _adoptDetail(
-          image,
-          fraction,
-          ratio,
-          scheduleHeadroom: !headroomPass,
-        );
+        _adoptDetail(image, fraction, ratio);
       });
       onPaint?.call();
-      _logDetailPaintAfterFrame(
+      _observeDetailPaintAfterFrame(
         generation,
         detailClock,
         source: 'worker-picture',
@@ -3999,8 +3874,7 @@ class _PdfPageViewState extends State<PdfPageView>
       widget.page,
       _renderPlan,
     ));
-    if (!(stillRelevant?.call() ?? true) ||
-        !mounted ||
+    if (!mounted ||
         !_renderSession.acceptsDetail(generation) ||
         _renderPaused) {
       return false;
@@ -4023,8 +3897,7 @@ class _PdfPageViewState extends State<PdfPageView>
         pixelRatio: ratio,
         region: region,
       );
-      if (!(stillRelevant?.call() ?? true) ||
-          !mounted ||
+      if (!mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         return false;
@@ -4052,38 +3925,37 @@ class _PdfPageViewState extends State<PdfPageView>
       region: (width: region.width, height: region.height),
       rasterize: rasterize,
     );
-    if (!(stillRelevant?.call() ?? true) ||
-        !mounted ||
+    if (!mounted ||
         !_renderSession.acceptsDetail(generation) ||
         _renderPaused) {
       image.dispose();
       return false;
     }
     setState(() {
-      _adoptDetail(
-        image,
-        fraction,
-        ratio,
-        scheduleHeadroom: !headroomPass,
-      );
+      _adoptDetail(image, fraction, ratio);
     });
     onPaint?.call();
-    _logDetailPaintAfterFrame(generation, detailClock, source: 'local');
+    _observeDetailPaintAfterFrame(generation, detailClock, source: 'local');
     return true;
   }
 
-  void _logDetailPaintAfterFrame(
+  void _observeDetailPaintAfterFrame(
     int generation,
     Stopwatch clock, {
     required String source,
   }) {
-    if (!PdfPerfLog.enabled) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !_renderSession.acceptsDetail(generation)) return;
-      PdfPerfLog.log(
-        'detail paint page=${widget.previewIndex} source=$source '
-        'elapsed=${clock.elapsedMicroseconds / 1000.0}ms',
-      );
+      if (PdfPerfLog.enabled) {
+        PdfPerfLog.log(
+          'detail paint page=${widget.previewIndex} pass=visible '
+          'source=$source elapsed=${clock.elapsedMicroseconds / 1000.0}ms',
+        );
+      }
+      // This callback itself observes the first frame containing the exact
+      // patch, so promotion can happen directly without nesting another
+      // post-frame callback (which can otherwise stall while the app is idle).
+      _activateTilePanAhead();
     });
   }
 
@@ -4203,16 +4075,6 @@ class _PdfPageViewState extends State<PdfPageView>
   /// Foreground detail always covers exactly the visible viewport. This keeps
   /// time-to-sharp proportional to visible pixels on zoom and pan settles.
   static const _visibleDetailInflation = 0.0;
-
-  /// Optional pan-ahead growth after the exact patch paints. One eighth of a
-  /// viewport per side makes the guarded image 1.25x in each dimension (1.56x
-  /// the pixels), versus the historical 0.5-per-side patch's 4x cost.
-  static const _panDetailInflation = 0.125;
-
-  /// Positive priorities are speculative in [PdfPooledRenderWorker]: they
-  /// preserve one worker lane for foreground work and are preempted by a new
-  /// visible-page request on both isolate and web-worker backends.
-  static const _detailHeadroomWorkerPriority = 1;
 
   /// Whether the [PdfPageView.tileStoreDetail] tile path drives deep-zoom
   /// detail for this page: the flag is on and the retained scene is
@@ -4701,8 +4563,8 @@ class _PdfPageViewState extends State<PdfPageView>
   /// tile path is inactive or the page is not zoomed past the base raster.
   ///
   /// [size] is the page-point size (the tile grid space). Placed above the base
-  /// raster and any completed visible-region patch, so uncovered gaps keep the
-  /// sharpest already-available pixels while exact tiles land over them.
+  /// raster but below any completed exact-visible patch, so tiles can fill the
+  /// surrounding pan-ahead area without changing pixels that already settled.
   Widget? _tileLayerWidget(Size size) {
     if (!_useTilePath) return null;
     final scene = _scene;
@@ -4754,11 +4616,13 @@ class _PdfPageViewState extends State<PdfPageView>
         // layer and advances the center-out fill; ordinary scenes retain the
         // lower-overhead batched path.
         maxNewTilesPerPaint: maxNewTiles,
-        // A scale-changing frame sharpens the visible tiles first. Once a pan
-        // advances the settle generation, the store's configured ring resumes
-        // and supplies the usual pan-ahead headroom.
+        // A scale-changing settle sharpens the exact visible patch first. Only
+        // after that patch reaches the compositor does [_tilePanAheadActive]
+        // restore the store's configured ring around it. Translation settles
+        // retain the active pyramid and its coalesced image-detail request.
         prefetchRingOverride: widget.qualityPageCount > 1 ||
-                _tightDetailGeneration == widget.settleGeneration
+                (_tightDetailGeneration == widget.settleGeneration &&
+                    !_tilePanAheadActive)
             ? 0
             : null,
         // A retained picture keeps vector/text edges transform-sharp. An
@@ -5287,8 +5151,6 @@ class _PdfPageViewState extends State<PdfPageView>
               final h = inner.maxHeight;
               final detail = _detailImage;
               final fraction = _detailFraction;
-              final detailHeadroom = _detailHeadroomImage;
-              final headroomFraction = _detailHeadroomFraction;
               final slugPicture = _slugPicture;
               final directPicture = _directPicture;
               final tileLayer = _tileLayerWidget(size);
@@ -5425,32 +5287,12 @@ class _PdfPageViewState extends State<PdfPageView>
                     ),
                   if (webSurface != null) webSurface,
                   if (webDetail != null) webDetail,
-                  // Pan-ahead is painted first. The exact visible patch stays
-                  // on top, so background completion cannot alter a pixel in
-                  // the viewport that just reached sharpness. As the user
-                  // pans, the guarded layer is already waiting underneath.
-                  if (detailHeadroom != null &&
-                      headroomFraction != null &&
-                      w.isFinite)
-                    Positioned(
-                      left: headroomFraction.left * w,
-                      top: headroomFraction.top * h,
-                      width: headroomFraction.width * w,
-                      height: headroomFraction.height * h,
-                      child: RawImage(
-                        key: const ValueKey('pdf-page-detail-headroom-image'),
-                        image: detailHeadroom,
-                        fit: BoxFit.fill,
-                        filterQuality: FilterQuality.medium,
-                      ),
-                    ),
-                  // Keep the fast, viewport-sized refinement underneath the
-                  // pyramid. The tile layer is sparse while its region image
-                  // decode is pending; making these alternatives hid the
-                  // completed refinement and exposed the soft base raster as
-                  // a conspicuous strip until the much larger tile scene
-                  // arrived. Exact tiles paint afterward and therefore can
-                  // only improve—not downgrade—the pixels below.
+                  // The pyramid grows pan-ahead in bounded tiles after the
+                  // foreground patch paints. Keep it underneath that exact
+                  // patch: late tiles can populate the surrounding page but
+                  // cannot restart the visible-settle clock or perturb an
+                  // already-sharp viewport pixel.
+                  if (tileLayer != null) tileLayer,
                   if (detail != null && fraction != null && w.isFinite)
                     Positioned(
                       left: fraction.left * w,
@@ -5480,7 +5322,6 @@ class _PdfPageViewState extends State<PdfPageView>
                               ),
                       ),
                     ),
-                  if (tileLayer != null) tileLayer,
                 ],
               );
             },

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -736,11 +736,14 @@ class _PdfPageViewState extends State<PdfPageView>
   double? _detailPixelRatio;
   PdfPageRenderIntent? _detailIntent;
 
-  /// The scale-settle generation that temporarily bypasses the tile layer and
-  /// sharpens the exact visible slice first. Tiles grow pan-ahead only after
-  /// that foreground patch has reached the compositor. Translation settles
-  /// retain the already-active pyramid so region-image requests can coalesce.
-  int? _tightDetailGeneration;
+  /// Whether a foreground deep-zoom view is still waiting for its exact
+  /// visible patch to reach the compositor. This deliberately survives
+  /// translation-only settles: a tiny scroll can cancel an in-flight worker
+  /// region, and falling straight back to tiles then exposes their staggered
+  /// completion patches. It also covers a page entering the viewport while the
+  /// viewer is already zoomed. The flag clears only when an exact patch paints
+  /// or the worker definitively declines it and the tile fallback takes over.
+  bool _awaitingExactDetailPaint = false;
 
   /// Invalidates the post-paint promotion from the exact patch to the bounded
   /// tile pyramid. The pyramid rasterizes in small units; the legacy patch
@@ -1008,6 +1011,15 @@ class _PdfPageViewState extends State<PdfPageView>
       return;
     }
     _layoutWidth = width;
+    // A page can be created while the viewer is already deeply zoomed (page
+    // jump, or scrolling across a page boundary). There is no scale-change
+    // didUpdateWidget in that case, so first layout must establish the same
+    // exact-first obligation. Otherwise its first visible surface is the tile
+    // pyramid and the user watches the viewport sharpen square by square.
+    if (widget.onScreen && widget.qualityVisible && widget.scale > 1.05) {
+      _awaitingExactDetailPaint = true;
+      _cancelTilePanAhead();
+    }
     // A retained scene can be adopted from initState before LayoutBuilder has
     // supplied the page's real width. At that point the fallback 1 px/pt
     // target can make a 1.25x speculative scene look final-quality even when
@@ -1051,18 +1063,32 @@ class _PdfPageViewState extends State<PdfPageView>
   @override
   void didUpdateWidget(PdfPageView oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.page, widget.page) ||
+    final pagePixelsChanged = !identical(oldWidget.page, widget.page) ||
         oldWidget.pageEpoch != widget.pageEpoch ||
         oldWidget.contentStamp != widget.contentStamp ||
-        oldWidget.destructiveStamp != widget.destructiveStamp) {
+        oldWidget.destructiveStamp != widget.destructiveStamp;
+    if (pagePixelsChanged) {
       _imageOnlyPage = null;
     }
     final scaleChanged = oldWidget.scale != widget.scale;
     final settleChanged = oldWidget.settleGeneration != widget.settleGeneration;
     final tileShareChanged =
         oldWidget.qualityPageCount != widget.qualityPageCount;
-    if (scaleChanged) {
-      _tightDetailGeneration = widget.settleGeneration;
+    final enteredDeepForeground = widget.onScreen &&
+        widget.qualityVisible &&
+        _detailRequiredAt(widget.scale) &&
+        (scaleChanged ||
+            pagePixelsChanged ||
+            oldWidget.previewIndex != widget.previewIndex ||
+            !oldWidget.onScreen ||
+            !oldWidget.qualityVisible);
+    if (enteredDeepForeground) {
+      _awaitingExactDetailPaint = true;
+      _cancelTilePanAhead();
+    } else if (scaleChanged) {
+      // Zooming back inside the full-page raster's sharp range needs no exact
+      // patch and must not leave a stale admission gate behind.
+      _awaitingExactDetailPaint = false;
       _cancelTilePanAhead();
     } else if (settleChanged) {
       _cancelTilePanAhead();
@@ -1661,6 +1687,10 @@ class _PdfPageViewState extends State<PdfPageView>
 
   void _activateTilePanAhead() {
     _tilePanAheadScheduled = false;
+    // Reaching this method means the exact patch has survived to a compositor
+    // frame (or an already-painted exact patch was reused). A translation-only
+    // settle may now use the pyramid without abandoning foreground recovery.
+    _awaitingExactDetailPaint = false;
     if (!mounted ||
         !PdfPageView.tileStoreDetail ||
         widget.qualityPageCount > 1 ||
@@ -1674,6 +1704,22 @@ class _PdfPageViewState extends State<PdfPageView>
       'detail pan-ahead page=${widget.previewIndex} '
       'route=${active ? 'tiles' : _tilePathStatus}',
     );
+  }
+
+  /// Releases an exact-first obligation only after the current worker request
+  /// has returned a real, uncancelled refusal. Cancellation and render hold are
+  /// filtered by [_updateDetail] before this is reached, so a tiny translation
+  /// still retries the foreground patch. A backend that genuinely cannot
+  /// produce one must nevertheless be allowed to fall back to bounded tiles.
+  bool _releaseExactDetailToTiles(String reason) {
+    if (!_awaitingExactDetailPaint || !mounted) return false;
+    setState(() => _awaitingExactDetailPaint = false);
+    final active = _refreshTileGeometry();
+    PdfPerfLog.log(
+      'detail exact fallback page=${widget.previewIndex} reason=$reason '
+      'route=${active ? 'tiles' : _tilePathStatus}',
+    );
+    return active;
   }
 
   bool _detailContentIsCurrent() => _intentIsCurrent(_detailIntent);
@@ -1744,6 +1790,15 @@ class _PdfPageViewState extends State<PdfPageView>
         devicePixelRatio: _pixelRatio ?? 1.0,
         scale: scale,
       );
+
+  /// Whether the current layout outruns the bounded full-page raster enough to
+  /// need a visible-region recovery. Before first layout, an interactive zoom
+  /// above 1x is the conservative answer; [_noteLayoutWidth] recomputes the
+  /// exact geometry once the page width is known.
+  bool _detailRequiredAt(double scale) {
+    if (_layoutWidth == null) return scale > 1.05;
+    return _desiredRatioAt(scale) > _effectiveRatioAt(scale) * 1.05;
+  }
 
   /// Scale used by the whole-page base raster.
   ///
@@ -3613,7 +3668,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // _refreshTileGeometry also bootstraps a dense scene's worker-built region
     // index. Do not guard this call on _useTilePath: that gate cannot become
     // true until the very warm-up this call starts has completed.
-    final tightDetail = _tightDetailGeneration == widget.settleGeneration;
+    final tightDetail = _awaitingExactDetailPaint;
     if (PdfPageView.tileStoreDetail && !tightDetail) {
       if (_refreshTileGeometry()) return true;
       // A worker-built grid takes a few hundred milliseconds on the dense CAD
@@ -3856,7 +3911,9 @@ class _PdfPageViewState extends State<PdfPageView>
     // cancelled or declined - so nothing was painted. Wait for the ordinary
     // full record instead of painting a vector-only patch as if it were
     // complete.
-    if (_sceneIsVectorOnly) return false;
+    if (_sceneIsVectorOnly) {
+      return _releaseExactDetailToTiles('worker-declined');
+    }
 
     // never interpret the page for the first time inline here - that is
     // the scheduler's job (or, bare, the hold's); the next settle
@@ -4566,7 +4623,11 @@ class _PdfPageViewState extends State<PdfPageView>
   /// raster but below any completed exact-visible patch, so tiles can fill the
   /// surrounding pan-ahead area without changing pixels that already settled.
   Widget? _tileLayerWidget(Size size) {
-    if (!_useTilePath) return null;
+    // Keep the already-stable base/old patch on screen until the exact region
+    // has painted. Showing newly landing tiles during this interval is the
+    // checkerboard tail this state exists to remove; the pyramid continues to
+    // warm underneath and becomes eligible as one layer after promotion.
+    if (_awaitingExactDetailPaint || !_useTilePath) return null;
     final scene = _scene;
     final fraction = _tileFraction;
     final desired = _tileDesiredRatio;
@@ -4583,6 +4644,13 @@ class _PdfPageViewState extends State<PdfPageView>
         : sceneCap == null
             ? sessionCap
             : math.min(sessionCap, sceneCap);
+    // Per-paint admission alone is not a queue bound: any unrelated frame can
+    // paint the layer again before the first raster lands. Ordinary scenes get
+    // one eight-tile slab; dense/session-paced scenes keep two of their smaller
+    // admission windows live. Either way a subsequent pan is never trapped
+    // behind the 30-35 tile submissions seen in the field trace.
+    final maxInFlightTiles =
+        maxNewTiles == null ? 8 : math.max(2, maxNewTiles * 2);
     final fallbackOcclusion = _fallbackOcclusionFraction(store, desired);
     return Positioned.fill(
       child: PdfTileLayer(
@@ -4616,13 +4684,13 @@ class _PdfPageViewState extends State<PdfPageView>
         // layer and advances the center-out fill; ordinary scenes retain the
         // lower-overhead batched path.
         maxNewTilesPerPaint: maxNewTiles,
+        maxInFlightTiles: maxInFlightTiles,
         // A scale-changing settle sharpens the exact visible patch first. Only
         // after that patch reaches the compositor does [_tilePanAheadActive]
         // restore the store's configured ring around it. Translation settles
         // retain the active pyramid and its coalesced image-detail request.
         prefetchRingOverride: widget.qualityPageCount > 1 ||
-                (_tightDetailGeneration == widget.settleGeneration &&
-                    !_tilePanAheadActive)
+                (_awaitingExactDetailPaint && !_tilePanAheadActive)
             ? 0
             : null,
         // A retained picture keeps vector/text edges transform-sharp. An

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -736,13 +736,28 @@ class _PdfPageViewState extends State<PdfPageView>
   double? _detailPixelRatio;
   PdfPageRenderIntent? _detailIntent;
 
-  /// The settle generation whose scale change should sharpen only the visible
-  /// slice plus a small guard. A zoom has an existing raster transformed under
-  /// it, so its first sharp frame should not pay for a half-viewport of unseen
-  /// pixels on every side. A later pan increments [widget.settleGeneration]
-  /// without changing [widget.scale] and falls back to the normal, generous
-  /// guard that makes successive pan settles reusable.
+  /// Low-priority pan-ahead pixels live underneath the exact foreground patch
+  /// instead of replacing it. Keeping the foreground layer on top makes the
+  /// overlap byte-for-byte stable: a late background completion cannot nudge
+  /// antialiasing or restart the visible-settle clock.
+  ui.Image? _detailHeadroomImage;
+  Rect? _detailHeadroomFraction;
+  double? _detailHeadroomPixelRatio;
+  PdfPageRenderIntent? _detailHeadroomIntent;
+
+  /// The settle generation whose scale change should temporarily bypass the
+  /// tile layer and sharpen the exact visible slice first. Translation-only
+  /// settles use the same visible-first patch geometry, but may keep the tile
+  /// route when its retained scene can answer the view.
   int? _tightDetailGeneration;
+
+  /// Invalidates the optional low-priority pan-ahead pass. The foreground
+  /// patch always covers exactly the visible slice; once that sharp frame has
+  /// reached the compositor, a second pass may grow it by a small guard band.
+  /// A viewport/content change increments this token before scheduling its
+  /// replacement, so stale post-frame callbacks never start work.
+  int _detailHeadroomGeneration = 0;
+  bool _detailHeadroomScheduledOrRunning = false;
 
   /// A scale or layout-width update reached this lazy-list child while another
   /// page owns focus. Keep the previous raster (it remains a valid soft preview
@@ -1059,6 +1074,23 @@ class _PdfPageViewState extends State<PdfPageView>
       _tightDetailGeneration = widget.settleGeneration;
     }
     final transition = _renderSession.update(_renderIntent(widget));
+    if (transition.scheduleRender ||
+        oldWidget.previewIndex != widget.previewIndex ||
+        !identical(oldWidget.renderWorker, widget.renderWorker) ||
+        oldWidget.renderPriority != widget.renderPriority) {
+      if (oldWidget.previewIndex != widget.previewIndex ||
+          !identical(oldWidget.renderWorker, widget.renderWorker)) {
+        oldWidget.renderWorker?.cancel(
+          oldWidget.previewIndex,
+          priority: _detailHeadroomWorkerPriority,
+        );
+        oldWidget.renderWorker?.cancelBinStrips(
+          oldWidget.previewIndex,
+          priority: _detailHeadroomWorkerPriority,
+        );
+      }
+      _cancelDetailHeadroom();
+    }
     if (!identical(oldWidget.renderWorker, widget.renderWorker) ||
         oldWidget.previewIndex != widget.previewIndex ||
         !identical(oldWidget.page, widget.page) ||
@@ -1280,6 +1312,7 @@ class _PdfPageViewState extends State<PdfPageView>
     widget.renderHold?.removeListener(_onRenderHoldChanged);
     _liveTransformFor(widget)?.removeListener(_onLiveTransformChanged);
     _speculateTimer?.cancel();
+    _cancelDetailHeadroom();
     // any pending speculative bin is reaped by the cancelBinStrips below;
     // its null result resolves into a future nobody awaits any more
     _speculativeStripPlan = null;
@@ -1304,6 +1337,7 @@ class _PdfPageViewState extends State<PdfPageView>
     _disposeTileRasterSessions();
     _image?.dispose();
     _detailImage?.dispose();
+    _detailHeadroomImage?.dispose();
     _tileDetailScene?.dispose();
     _preview?.dispose();
     super.dispose();
@@ -1568,31 +1602,170 @@ class _PdfPageViewState extends State<PdfPageView>
   }
 
   void _dropDetail() {
+    _cancelDetailHeadroom();
     _invalidateTiles();
     _dropTileImageDetail();
     _renderSession.invalidateDetail();
-    final hadImage = _detailImage != null;
+    final hadImage = _detailImage != null || _detailHeadroomImage != null;
     _detailImage?.dispose();
     _detailImage = null;
     _detailFraction = null;
     _detailPixelRatio = null;
     _detailIntent = null;
+    _detailHeadroomImage?.dispose();
+    _detailHeadroomImage = null;
+    _detailHeadroomFraction = null;
+    _detailHeadroomPixelRatio = null;
+    _detailHeadroomIntent = null;
     if (hadImage && mounted) setState(() {});
   }
 
-  void _adoptDetail(
-    ui.Image image,
-    Rect fraction,
-    double pixelRatio,
-  ) {
-    _detailImage?.dispose();
-    _detailImage = image;
-    _detailFraction = fraction;
-    _detailPixelRatio = pixelRatio;
-    _detailIntent = _renderIntent(widget);
+  void _adoptDetail(ui.Image image, Rect fraction, double pixelRatio,
+      {bool scheduleHeadroom = true}) {
+    if (scheduleHeadroom) {
+      _detailImage?.dispose();
+      _detailImage = image;
+      _detailFraction = fraction;
+      _detailPixelRatio = pixelRatio;
+      _detailIntent = _renderIntent(widget);
+      _detailHeadroomImage?.dispose();
+      _detailHeadroomImage = null;
+      _detailHeadroomFraction = null;
+      _detailHeadroomPixelRatio = null;
+      _detailHeadroomIntent = null;
+      _scheduleDetailHeadroom();
+    } else {
+      _detailHeadroomImage?.dispose();
+      _detailHeadroomImage = image;
+      _detailHeadroomFraction = fraction;
+      _detailHeadroomPixelRatio = pixelRatio;
+      _detailHeadroomIntent = _renderIntent(widget);
+    }
+  }
+
+  void _cancelDetailHeadroom() {
+    _detailHeadroomGeneration++;
+    _detailHeadroomScheduledOrRunning = false;
+    final worker = widget.renderWorker;
+    if (worker == null) return;
+    worker.cancel(
+      widget.previewIndex,
+      priority: _detailHeadroomWorkerPriority,
+    );
+    worker.cancelBinStrips(
+      widget.previewIndex,
+      priority: _detailHeadroomWorkerPriority,
+    );
+  }
+
+  bool _detailHeadroomContextIsCurrent(
+    int token,
+    int settleGeneration,
+    double scale,
+  ) =>
+      mounted &&
+      token == _detailHeadroomGeneration &&
+      settleGeneration == widget.settleGeneration &&
+      scale == widget.scale &&
+      !_renderPaused;
+
+  /// Grows a completed exact-visible patch only after that sharp frame has
+  /// painted. The request runs in the worker's speculative priority class, so
+  /// a subsequent foreground settle preempts it on every worker backend. The
+  /// current exact patch remains on top after the same-density guarded layer
+  /// lands; if the larger region would lower the density under the raster caps,
+  /// it is skipped rather than stepping quality backwards.
+  void _scheduleDetailHeadroom() {
+    if (_detailHeadroomScheduledOrRunning) return;
+    _detailHeadroomScheduledOrRunning = true;
+    final token = ++_detailHeadroomGeneration;
+    final settleGeneration = widget.settleGeneration;
+    final scale = widget.scale;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_detailHeadroomContextIsCurrent(
+            token,
+            settleGeneration,
+            scale,
+          ) ||
+          !_detailContentIsCurrent()) {
+        if (token == _detailHeadroomGeneration) {
+          _detailHeadroomScheduledOrRunning = false;
+        }
+        return;
+      }
+      final existingFraction = _detailFraction;
+      final existingRatio = _detailPixelRatio;
+      if (_detailImage == null ||
+          existingFraction == null ||
+          existingRatio == null) {
+        _detailHeadroomScheduledOrRunning = false;
+        return;
+      }
+      final headroom = _detailGeometryAt(
+        scale,
+        inflation: _panDetailInflation,
+      );
+      final retainedHeadroomFraction = _detailHeadroomFraction;
+      final retainedHeadroomRatio = _detailHeadroomPixelRatio;
+      if (headroom == null ||
+          headroom.pixelRatio < existingRatio * 0.99 ||
+          !_detailPatchCovers(
+            existingFraction,
+            headroom.visibleFraction,
+          ) ||
+          (_detailHeadroomImage != null &&
+              retainedHeadroomFraction != null &&
+              retainedHeadroomRatio != null &&
+              _detailHeadroomContentIsCurrent() &&
+              retainedHeadroomRatio >= headroom.pixelRatio * 0.99 &&
+              _detailPatchCovers(
+                retainedHeadroomFraction,
+                headroom.fraction,
+              )) ||
+          _detailPatchCovers(existingFraction, headroom.fraction)) {
+        _detailHeadroomScheduledOrRunning = false;
+        return;
+      }
+      PdfPerfLog.log(
+        'detail headroom page=${widget.previewIndex} '
+        'visible=${headroom.visibleFraction.width.toStringAsFixed(3)}x'
+        '${headroom.visibleFraction.height.toStringAsFixed(3)} '
+        'guarded=${headroom.fraction.width.toStringAsFixed(3)}x'
+        '${headroom.fraction.height.toStringAsFixed(3)} '
+        'ratio=${headroom.pixelRatio.toStringAsFixed(2)}',
+      );
+      unawaited(() async {
+        try {
+          await _updateDetail(
+            detailGeometry: headroom,
+            headroomPass: true,
+            workerPriority: _detailHeadroomWorkerPriority,
+            stillRelevant: () => _detailHeadroomContextIsCurrent(
+              token,
+              settleGeneration,
+              scale,
+            ),
+          );
+        } catch (error) {
+          // This pass is opportunistic: a failed guard-band render must never
+          // replace the already-sharp visible patch or escape as an unhandled
+          // asynchronous error.
+          PdfPerfLog.log(
+            'detail headroom failed page=${widget.previewIndex} error=$error',
+          );
+        } finally {
+          if (token == _detailHeadroomGeneration) {
+            _detailHeadroomScheduledOrRunning = false;
+          }
+        }
+      }());
+    });
   }
 
   bool _detailContentIsCurrent() => _intentIsCurrent(_detailIntent);
+
+  bool _detailHeadroomContentIsCurrent() =>
+      _intentIsCurrent(_detailHeadroomIntent);
 
   /// Whether pixels taken under [intent] still depict this page's current
   /// content. Shared by the detail patch and the base raster - both ask exactly
@@ -1684,6 +1857,7 @@ class _PdfPageViewState extends State<PdfPageView>
   int get liveRasterBytes =>
       _imageBytes(_image) +
       _imageBytes(_detailImage) +
+      _imageBytes(_detailHeadroomImage) +
       (_scene?.decodedImageBytes ?? 0) +
       (_tileDetailScene?.decodedImageBytes ?? 0);
 
@@ -2727,8 +2901,12 @@ class _PdfPageViewState extends State<PdfPageView>
     // its sharp region. Give it a clear lead over ordinary neighbouring-page
     // work so it preempts the pool instead of being cancelled and requeued as
     // the scheduler drains the cache window around it.
-    final visibleDetailRequested =
-        _detailGeometryAt(widget.scale, force: true, inflation: 0.125) != null;
+    final visibleDetailRequested = _detailGeometryAt(
+          widget.scale,
+          force: true,
+          inflation: _visibleDetailInflation,
+        ) !=
+        null;
     final priority = visibleDetailRequested
         ? widget.renderPriority - 100
         : widget.renderPriority;
@@ -2827,7 +3005,7 @@ class _PdfPageViewState extends State<PdfPageView>
     final progressiveDetail = _detailGeometryAt(
       widget.scale,
       force: true,
-      inflation: 0.125,
+      inflation: _visibleDetailInflation,
     );
     final needsDetail = progressiveDetail != null;
     PdfPerfLog.log(
@@ -3485,12 +3663,16 @@ class _PdfPageViewState extends State<PdfPageView>
     }());
   }
 
-  /// Renders (or drops) the deep-zoom patch: the visible slice of the
-  /// page, inflated by half a viewport on each side, at the resolution
-  /// the zoom actually asks for.
+  /// Renders (or drops) the deep-zoom patch at the resolution the zoom asks
+  /// for. Foreground calls cover exactly the visible slice; once it paints,
+  /// [headroomPass] may grow it by [_panDetailInflation] at speculative worker
+  /// priority without delaying the first sharp frame.
   Future<bool> _updateDetail({
     _DetailGeometry? detailGeometry,
     VoidCallback? onPaint,
+    bool headroomPass = false,
+    int? workerPriority,
+    bool Function()? stillRelevant,
   }) async {
     if (_renderPaused) return false;
     // The viewer's global transform reaches cache-window neighbours too. They
@@ -3525,7 +3707,7 @@ class _PdfPageViewState extends State<PdfPageView>
     // index. Do not guard this call on _useTilePath: that gate cannot become
     // true until the very warm-up this call starts has completed.
     final tightDetail = _tightDetailGeneration == widget.settleGeneration;
-    if (PdfPageView.tileStoreDetail && !tightDetail) {
+    if (PdfPageView.tileStoreDetail && (!tightDetail || headroomPass)) {
       if (_refreshTileGeometry()) return true;
       // A worker-built grid takes a few hundred milliseconds on the dense CAD
       // pages that need it. Keep the already-visible capped base raster during
@@ -3560,9 +3742,7 @@ class _PdfPageViewState extends State<PdfPageView>
     }
     detailGeometry ??= _detailGeometryAt(
       widget.scale,
-      inflation: _tightDetailGeneration == widget.settleGeneration
-          ? _zoomDetailInflation
-          : 0.5,
+      inflation: _visibleDetailInflation,
     );
     if (detailGeometry == null) {
       _dropDetail();
@@ -3572,12 +3752,11 @@ class _PdfPageViewState extends State<PdfPageView>
     final region = detailGeometry.region;
     final ratio = detailGeometry.pixelRatio;
 
-    // The single-patch fallback deliberately rasterizes half a viewport of
-    // headroom on every side. Keep using those pixels while they still cover
-    // the live viewport instead of rebuilding an almost-identical 3-6 MP
-    // raster after every wheel-scroll settle. This is the fallback for pages
-    // that cannot use the reusable tile pyramid, so without this coverage
-    // check the guard band was pure extra work.
+    // Foreground work asks only for the live viewport. A completed background
+    // pass may already contain that viewport plus its small pan guard; keep
+    // using those pixels rather than rebuilding them. The headroom pass checks
+    // its whole requested fraction so the exact patch does not make it return
+    // early merely because the visible centre is already sharp.
     //
     // Content identity is checked separately: additive edits intentionally
     // leave the old patch painted until its replacement lands, but that stale
@@ -3585,20 +3764,31 @@ class _PdfPageViewState extends State<PdfPageView>
     // in, or a smaller cap-bound region) also gets a fresh raster.
     final existingFraction = _detailFraction;
     final existingRatio = _detailPixelRatio;
-    if (_detailImage != null &&
+    final requiredFraction =
+        headroomPass ? detailGeometry.fraction : detailGeometry.visibleFraction;
+    final primaryCovers = _detailImage != null &&
         existingFraction != null &&
         existingRatio != null &&
         _detailContentIsCurrent() &&
         existingRatio >= ratio * 0.99 &&
-        _detailPatchCovers(
-          existingFraction,
-          detailGeometry.visibleFraction,
-        )) {
+        _detailPatchCovers(existingFraction, requiredFraction);
+    final headroomFraction = _detailHeadroomFraction;
+    final headroomRatio = _detailHeadroomPixelRatio;
+    final headroomCovers = _detailHeadroomImage != null &&
+        headroomFraction != null &&
+        headroomRatio != null &&
+        _detailHeadroomContentIsCurrent() &&
+        headroomRatio >= ratio * 0.99 &&
+        _detailPatchCovers(headroomFraction, requiredFraction);
+    if (primaryCovers || headroomCovers) {
       PdfPageView.debugDetailPatchReuses++;
       onPaint?.call();
+      if (!headroomPass && !headroomCovers) _scheduleDetailHeadroom();
       PdfPerfLog.log(
         'detail reuse page=${widget.previewIndex} '
-        'ratio=${existingRatio.toStringAsFixed(2)}',
+        'pass=${headroomPass ? 'headroom' : 'visible'} '
+        'source=${primaryCovers ? 'visible' : 'headroom'} '
+        'ratio=${(primaryCovers ? existingRatio : headroomRatio)!.toStringAsFixed(2)}',
       );
       return true;
     }
@@ -3620,8 +3810,10 @@ class _PdfPageViewState extends State<PdfPageView>
     // through to the retained base scene below.
     final heldScene = PdfPageView.retainedZoomReplay ? _scene : null;
     final stripDetail = heldScene != null && _stripReplayScene(heldScene);
-    final progressivePriority =
-        _sceneIsVectorOnly ? widget.renderPriority - 1 : widget.renderPriority;
+    final progressivePriority = workerPriority ??
+        (_sceneIsVectorOnly
+            ? widget.renderPriority - 1
+            : widget.renderPriority);
     // Whether replaying the retained vector-only scene alone yields the
     // FINISHED region rather than a placeholder to be replaced. It does exactly
     // when no image draw reaches the region - the same invariant that lets the
@@ -3640,6 +3832,7 @@ class _PdfPageViewState extends State<PdfPageView>
     final detailClock = Stopwatch()..start();
     PdfPerfLog.log(
       'detail request page=${widget.previewIndex} '
+      'pass=${headroomPass ? 'headroom' : 'visible'} '
       'strip=$stripDetail vectorOnly=$_sceneIsVectorOnly '
       'retainedCovers=$retainedCoversRegion '
       // scene/tiles: why this page does or does not get reusable tiles instead
@@ -3677,7 +3870,8 @@ class _PdfPageViewState extends State<PdfPageView>
     // worker pass was started to replace it.
     if (retainedCoversRegion) {
       final cachedPicture = await _picture;
-      if (!mounted ||
+      if (!(stillRelevant?.call() ?? true) ||
+          !mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         return false;
@@ -3691,14 +3885,20 @@ class _PdfPageViewState extends State<PdfPageView>
             ? heldScene.rasterizeRegion(region, pixelRatio: ratio)
             : PdfPageRenderer.rasterizeRegion(cachedPicture, region, ratio),
       );
-      if (!mounted ||
+      if (!(stillRelevant?.call() ?? true) ||
+          !mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         retainedImage.dispose();
         return false;
       }
       setState(() {
-        _adoptDetail(retainedImage, fraction, ratio);
+        _adoptDetail(
+          retainedImage,
+          fraction,
+          ratio,
+          scheduleHeadroom: !headroomPass,
+        );
       });
       onPaint?.call();
       _logDetailPaintAfterFrame(generation, detailClock, source: 'retained');
@@ -3716,7 +3916,8 @@ class _PdfPageViewState extends State<PdfPageView>
       'elapsed=${detailClock.elapsedMilliseconds}ms '
       'stripImage=${workerStripImage != null} picture=${workerPicture != null}',
     );
-    if (!mounted ||
+    if (!(stillRelevant?.call() ?? true) ||
+        !mounted ||
         !_renderSession.acceptsDetail(generation) ||
         _renderPaused) {
       workerStripImage?.dispose();
@@ -3725,7 +3926,12 @@ class _PdfPageViewState extends State<PdfPageView>
     }
     if (workerStripImage != null) {
       setState(() {
-        _adoptDetail(workerStripImage, fraction, ratio);
+        _adoptDetail(
+          workerStripImage,
+          fraction,
+          ratio,
+          scheduleHeadroom: !headroomPass,
+        );
       });
       onPaint?.call();
       _logDetailPaintAfterFrame(
@@ -3745,14 +3951,20 @@ class _PdfPageViewState extends State<PdfPageView>
             PdfPageRenderer.rasterizeRegion(workerPicture, region, ratio),
       );
       workerPicture.dispose();
-      if (!mounted ||
+      if (!(stillRelevant?.call() ?? true) ||
+          !mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         image.dispose();
         return false;
       }
       setState(() {
-        _adoptDetail(image, fraction, ratio);
+        _adoptDetail(
+          image,
+          fraction,
+          ratio,
+          scheduleHeadroom: !headroomPass,
+        );
       });
       onPaint?.call();
       _logDetailPaintAfterFrame(
@@ -3787,7 +3999,8 @@ class _PdfPageViewState extends State<PdfPageView>
       widget.page,
       _renderPlan,
     ));
-    if (!mounted ||
+    if (!(stillRelevant?.call() ?? true) ||
+        !mounted ||
         !_renderSession.acceptsDetail(generation) ||
         _renderPaused) {
       return false;
@@ -3810,7 +4023,8 @@ class _PdfPageViewState extends State<PdfPageView>
         pixelRatio: ratio,
         region: region,
       );
-      if (!mounted ||
+      if (!(stillRelevant?.call() ?? true) ||
+          !mounted ||
           !_renderSession.acceptsDetail(generation) ||
           _renderPaused) {
         return false;
@@ -3838,14 +4052,20 @@ class _PdfPageViewState extends State<PdfPageView>
       region: (width: region.width, height: region.height),
       rasterize: rasterize,
     );
-    if (!mounted ||
+    if (!(stillRelevant?.call() ?? true) ||
+        !mounted ||
         !_renderSession.acceptsDetail(generation) ||
         _renderPaused) {
       image.dispose();
       return false;
     }
     setState(() {
-      _adoptDetail(image, fraction, ratio);
+      _adoptDetail(
+        image,
+        fraction,
+        ratio,
+        scheduleHeadroom: !headroomPass,
+      );
     });
     onPaint?.call();
     _logDetailPaintAfterFrame(generation, detailClock, source: 'local');
@@ -3922,7 +4142,7 @@ class _PdfPageViewState extends State<PdfPageView>
   _DetailGeometry? _detailGeometryAt(
     double scale, {
     bool force = false,
-    double inflation = 0.5,
+    double inflation = _visibleDetailInflation,
   }) {
     final desired = _desiredRatioAt(scale);
     final effective = _effectiveRatioAt(scale);
@@ -3940,10 +4160,9 @@ class _PdfPageViewState extends State<PdfPageView>
       return null;
     }
 
-    // Visible slice as fractions of the page. Settled cap-driven patches use
-    // 50% per-side panning headroom. The progressive region-first request is
-    // deliberately tighter: its job is to beat the still-warming full page,
-    // and a large guard band would re-decode most of that page again.
+    // Visible slice as fractions of the page. Foreground patches deliberately
+    // use the exact viewport: their job is to beat the still-soft base. A
+    // small guarded replacement is requested only after those pixels paint.
     Rect fractionAt(double amount) => Rect.fromLTRB(
           ((visible.left - pageRect.left - visible.width * amount) /
                   pageRect.width)
@@ -3981,11 +4200,19 @@ class _PdfPageViewState extends State<PdfPageView>
     return _DetailGeometry(fraction, visibleFraction, region, ratio);
   }
 
-  /// The first sharp zoom patch covers exactly the visible viewport. It lands
-  /// before any pan-ahead work and avoids rasterizing 56% extra pixels for the
-  /// old 1/8-viewport guard. A later translation-only settle uses the normal
-  /// 0.5 guard above, so sustained panning still gains reusable headroom.
-  static const _zoomDetailInflation = 0.0;
+  /// Foreground detail always covers exactly the visible viewport. This keeps
+  /// time-to-sharp proportional to visible pixels on zoom and pan settles.
+  static const _visibleDetailInflation = 0.0;
+
+  /// Optional pan-ahead growth after the exact patch paints. One eighth of a
+  /// viewport per side makes the guarded image 1.25x in each dimension (1.56x
+  /// the pixels), versus the historical 0.5-per-side patch's 4x cost.
+  static const _panDetailInflation = 0.125;
+
+  /// Positive priorities are speculative in [PdfPooledRenderWorker]: they
+  /// preserve one worker lane for foreground work and are preempted by a new
+  /// visible-page request on both isolate and web-worker backends.
+  static const _detailHeadroomWorkerPriority = 1;
 
   /// Whether the [PdfPageView.tileStoreDetail] tile path drives deep-zoom
   /// detail for this page: the flag is on and the retained scene is
@@ -4713,7 +4940,10 @@ class _PdfPageViewState extends State<PdfPageView>
     // Past the full-page pixel cap the settle does not re-raster the base; it
     // moves a sharper region patch instead. Compute that patch from the live
     // post-transform page bounds so translation-only pans can speculate too.
-    final detail = _detailGeometryAt(anticipated);
+    final detail = _detailGeometryAt(
+      anticipated,
+      inflation: _visibleDetailInflation,
+    );
     if (detail != null) {
       // A retained scene whose image samples are already complete for this
       // region takes the direct replay path in _updateDetail. Do not enqueue a
@@ -5057,6 +5287,8 @@ class _PdfPageViewState extends State<PdfPageView>
               final h = inner.maxHeight;
               final detail = _detailImage;
               final fraction = _detailFraction;
+              final detailHeadroom = _detailHeadroomImage;
+              final headroomFraction = _detailHeadroomFraction;
               final slugPicture = _slugPicture;
               final directPicture = _directPicture;
               final tileLayer = _tileLayerWidget(size);
@@ -5092,7 +5324,7 @@ class _PdfPageViewState extends State<PdfPageView>
                   webDetailGeometry = _detailGeometryAt(
                     widget.scale,
                     force: true,
-                    inflation: _zoomDetailInflation,
+                    inflation: _visibleDetailInflation,
                   );
                 }
               }
@@ -5193,6 +5425,25 @@ class _PdfPageViewState extends State<PdfPageView>
                     ),
                   if (webSurface != null) webSurface,
                   if (webDetail != null) webDetail,
+                  // Pan-ahead is painted first. The exact visible patch stays
+                  // on top, so background completion cannot alter a pixel in
+                  // the viewport that just reached sharpness. As the user
+                  // pans, the guarded layer is already waiting underneath.
+                  if (detailHeadroom != null &&
+                      headroomFraction != null &&
+                      w.isFinite)
+                    Positioned(
+                      left: headroomFraction.left * w,
+                      top: headroomFraction.top * h,
+                      width: headroomFraction.width * w,
+                      height: headroomFraction.height * h,
+                      child: RawImage(
+                        key: const ValueKey('pdf-page-detail-headroom-image'),
+                        image: detailHeadroom,
+                        fit: BoxFit.fill,
+                        filterQuality: FilterQuality.medium,
+                      ),
+                    ),
                   // Keep the fast, viewport-sized refinement underneath the
                   // pyramid. The tile layer is sparse while its region image
                   // decode is pending; making these alternatives hid the

--- a/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
+++ b/packages/dart_pdf_editor/lib/src/pdf_page_view.dart
@@ -753,6 +753,13 @@ class _PdfPageViewState extends State<PdfPageView>
   bool _tilePanAheadScheduled = false;
   bool _tilePanAheadActive = false;
 
+  /// A fully resident exact-rung tile view that is allowed to paint above the
+  /// quick visible patch. Promotion is intentionally limited to a
+  /// region-decoded image-detail scene: ordinary pan-ahead tiles keep the
+  /// already-settled patch in front, while tiles carrying demonstrably sharper
+  /// image samples can become the final foreground atomically.
+  ({Rect fraction, int rung, PdfRetainedScene scene})? _tileForeground;
+
   /// A scale or layout-width update reached this lazy-list child while another
   /// page owns focus. Keep the previous raster (it remains a valid soft preview
   /// under the transform) and sharpen it only when it becomes focus. Otherwise
@@ -1620,6 +1627,7 @@ class _PdfPageViewState extends State<PdfPageView>
     _detailFraction = null;
     _detailPixelRatio = null;
     _detailIntent = null;
+    _tileForeground = null;
     if (hadImage && mounted) setState(() {});
   }
 
@@ -1629,6 +1637,7 @@ class _PdfPageViewState extends State<PdfPageView>
     _detailFraction = fraction;
     _detailPixelRatio = pixelRatio;
     _detailIntent = _renderIntent(widget);
+    _tileForeground = null;
     _scheduleBudgetRebalance();
   }
 
@@ -1636,6 +1645,7 @@ class _PdfPageViewState extends State<PdfPageView>
     _tilePanAheadGeneration++;
     _tilePanAheadScheduled = false;
     _tilePanAheadActive = false;
+    _tileForeground = null;
   }
 
   bool _tilePanAheadContextIsCurrent(
@@ -4300,6 +4310,7 @@ class _PdfPageViewState extends State<PdfPageView>
       setState(() {
         _tileFraction = fraction;
         _tileDesiredRatio = desired;
+        _tileForeground = null;
       });
     }
     if (tiling) _ensureTileImageDetail();
@@ -4549,6 +4560,7 @@ class _PdfPageViewState extends State<PdfPageView>
       _tileDetailScene = scene;
       _tileDetailRegion = region;
       _tileDetailRatio = imageRatio;
+      _tileForeground = null;
     });
     PdfPageView.debugTileImageDetailAdoptions++;
     PdfPageView.debugTileImageDetailRatio = imageRatio;
@@ -4569,6 +4581,7 @@ class _PdfPageViewState extends State<PdfPageView>
     _tileDetailPending = null;
     _tileDetailDeferred = false;
     _tileDetailWanted = false;
+    _tileForeground = null;
     if (_tileDetailScene == null) return;
     _disposeTileRasterSession(_tileDetailScene!);
     _tileDetailScene?.dispose();
@@ -4619,10 +4632,10 @@ class _PdfPageViewState extends State<PdfPageView>
   /// The [PdfTileStore] deep-zoom composite for this page, or null when the
   /// tile path is inactive or the page is not zoomed past the base raster.
   ///
-  /// [size] is the page-point size (the tile grid space). Placed above the base
-  /// raster but below any completed exact-visible patch, so tiles can fill the
-  /// surrounding pan-ahead area without changing pixels that already settled.
-  Widget? _tileLayerWidget(Size size) {
+  /// [size] is the page-point size (the tile grid space). Ordinary tiles stay
+  /// below the completed exact-visible patch; a complete image-detail rung may
+  /// be rebuilt above it after [_promoteSharpTileForeground] approves it.
+  Widget? _tileLayerWidget(Size size, {required bool foreground}) {
     // Keep the already-stable base/old patch on screen until the exact region
     // has painted. Showing newly landing tiles during this interval is the
     // checkerboard tail this state exists to remove; the pyramid continues to
@@ -4652,7 +4665,9 @@ class _PdfPageViewState extends State<PdfPageView>
     final maxInFlightTiles =
         maxNewTiles == null ? 8 : math.max(2, maxNewTiles * 2);
     final fallbackOcclusion = _fallbackOcclusionFraction(store, desired);
+    final tileDetailScene = _tileDetailScene;
     return Positioned.fill(
+      key: foreground ? const ValueKey('pdf-page-sharp-tile-foreground') : null,
       child: PdfTileLayer(
         store: store,
         identity: PdfTilePageIdentity(
@@ -4707,8 +4722,93 @@ class _PdfPageViewState extends State<PdfPageView>
         // but must not cover that sharper patch with stretched pixels. Exact
         // tiles are not clipped and replace it normally as they land.
         fallbackOcclusionFraction: fallbackOcclusion,
+        onExactViewReady: (view) => _promoteSharpTileForeground(
+          view,
+          fraction,
+          tileDetailScene,
+        ),
       ),
     );
+  }
+
+  /// Promotes a completed tile view only when it is a genuine quality upgrade
+  /// over the quick exact patch.
+  ///
+  /// The tile painter reports readiness after painting a complete exact rung.
+  /// Requiring the same current region-decoded scene closes the race where an
+  /// older, softer tile set completes just as a sharper image scene is
+  /// adopted and its tiles are invalidated. The old patch remains mounted
+  /// underneath, so the promotion itself cannot expose a gap.
+  void _promoteSharpTileForeground(
+    PdfTileView view,
+    Rect fraction,
+    PdfRetainedScene? detailScene,
+  ) {
+    if (!mounted ||
+        !view.complete ||
+        view.isEmpty ||
+        detailScene == null ||
+        !identical(detailScene, _tileDetailScene) ||
+        fraction != _tileFraction ||
+        _detailImage == null ||
+        !_detailContentIsCurrent()) {
+      return;
+    }
+    final desired = _tileDesiredRatio;
+    final patchRatio = _detailPixelRatio;
+    if (desired == null || patchRatio == null) return;
+    final store = PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance;
+    final expectedRung = store.ladder.rungAtOrAbove(desired);
+    if (view.rung != expectedRung) return;
+    final tileRatio = store.ladder.ratioFor(view.rung);
+    // Never replace the patch with fewer output samples. Equal output density
+    // is still an upgrade when the tile scene carries the 2x image-decode
+    // headroom that the quick patch deliberately omits.
+    if (tileRatio < patchRatio * 0.99) return;
+    final pageSize = _renderPlan.pageSize(widget.page);
+    final visibleRegion = Rect.fromLTRB(
+      fraction.left * pageSize.width,
+      fraction.top * pageSize.height,
+      fraction.right * pageSize.width,
+      fraction.bottom * pageSize.height,
+    );
+    final imageRatio = _tileImageRatio(tileRatio);
+    if (!_tileDetailCovers(visibleRegion, imageRatio) ||
+        (_tileDetailRatio ?? 0) <= patchRatio * 1.05) {
+      return;
+    }
+    final next = (fraction: fraction, rung: view.rung, scene: detailScene);
+    final current = _tileForeground;
+    if (current != null &&
+        current.fraction == next.fraction &&
+        current.rung == next.rung &&
+        identical(current.scene, next.scene)) {
+      return;
+    }
+    setState(() => _tileForeground = next);
+    PdfPerfLog.log(
+      'tile foreground promote page=${widget.previewIndex} '
+      'rung=${view.rung} tileRatio=${tileRatio.toStringAsFixed(2)} '
+      'patchRatio=${patchRatio.toStringAsFixed(2)} '
+      'imageRatio=${imageRatio.toStringAsFixed(2)}',
+    );
+  }
+
+  bool _sharpTileForegroundIsCurrent() {
+    final foreground = _tileForeground;
+    final fraction = _tileFraction;
+    final desired = _tileDesiredRatio;
+    if (foreground == null ||
+        fraction == null ||
+        desired == null ||
+        foreground.fraction != fraction ||
+        !identical(foreground.scene, _tileDetailScene) ||
+        _detailImage == null ||
+        !_detailContentIsCurrent()) {
+      return false;
+    }
+    final store = PdfPageView.debugTileStoreOverride ?? PdfTileStore.instance;
+    return foreground.rung == store.ladder.rungAtOrAbove(desired);
   }
 
   /// The retained detail patch may hide a coarse tile only when it is at least
@@ -5221,7 +5321,11 @@ class _PdfPageViewState extends State<PdfPageView>
               final fraction = _detailFraction;
               final slugPicture = _slugPicture;
               final directPicture = _directPicture;
-              final tileLayer = _tileLayerWidget(size);
+              final sharpTilesInFront = _sharpTileForegroundIsCurrent();
+              final tileLayer = _tileLayerWidget(
+                size,
+                foreground: sharpTilesInFront,
+              );
               final worker = widget.renderWorker;
               (int, int)? webDimensions;
               _DetailGeometry? webDetailGeometry;
@@ -5355,12 +5459,10 @@ class _PdfPageViewState extends State<PdfPageView>
                     ),
                   if (webSurface != null) webSurface,
                   if (webDetail != null) webDetail,
-                  // The pyramid grows pan-ahead in bounded tiles after the
-                  // foreground patch paints. Keep it underneath that exact
-                  // patch: late tiles can populate the surrounding page but
-                  // cannot restart the visible-settle clock or perturb an
-                  // already-sharp viewport pixel.
-                  if (tileLayer != null) tileLayer,
+                  // Ordinary pan-ahead remains under the exact patch. A fully
+                  // covered rung carrying a sharper region image decode is
+                  // promoted as one foreground layer only after it paints.
+                  if (tileLayer != null && !sharpTilesInFront) tileLayer,
                   if (detail != null && fraction != null && w.isFinite)
                     Positioned(
                       left: fraction.left * w,
@@ -5390,6 +5492,7 @@ class _PdfPageViewState extends State<PdfPageView>
                               ),
                       ),
                     ),
+                  if (tileLayer != null && sharpTilesInFront) tileLayer,
                 ],
               );
             },

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -38,6 +38,7 @@ class PdfTileLayer extends StatelessWidget {
     this.prefetchRingOverride,
     this.allowCoarserFallback = true,
     this.fallbackOcclusionFraction,
+    this.onExactViewReady,
     this.filterQuality = FilterQuality.medium,
   })  : assert(maxNewTilesPerPaint == null || maxNewTilesPerPaint > 0),
         assert(maxInFlightTiles == null || maxInFlightTiles > 0),
@@ -101,6 +102,15 @@ class PdfTileLayer extends StatelessWidget {
   /// to a blurry rectangle while the exact rung is still being produced.
   final Rect? fallbackOcclusionFraction;
 
+  /// Called after a frame in which every visible tile was present at the
+  /// exact requested rung.
+  ///
+  /// The callback is deliberately post-paint: callers may use it to promote
+  /// this layer above an older foreground raster without changing the widget
+  /// tree during paint. Missing tiles, vetoed regions, and coarser fallbacks
+  /// never report ready.
+  final ValueChanged<PdfTileView>? onExactViewReady;
+
   final FilterQuality filterQuality;
 
   @override
@@ -121,6 +131,7 @@ class PdfTileLayer extends StatelessWidget {
           prefetchRingOverride: prefetchRingOverride,
           allowCoarserFallback: allowCoarserFallback,
           fallbackOcclusionFraction: fallbackOcclusionFraction,
+          onExactViewReady: onExactViewReady,
           filterQuality: filterQuality,
         ),
       );
@@ -142,6 +153,7 @@ class _TilePagePainter extends CustomPainter {
     required this.prefetchRingOverride,
     required this.allowCoarserFallback,
     required this.fallbackOcclusionFraction,
+    required this.onExactViewReady,
     required this.filterQuality,
   }) : super(
             // tick as sharper tiles land, and repaint on debug-border toggles
@@ -161,7 +173,9 @@ class _TilePagePainter extends CustomPainter {
   final int? prefetchRingOverride;
   final bool allowCoarserFallback;
   final Rect? fallbackOcclusionFraction;
+  final ValueChanged<PdfTileView>? onExactViewReady;
   final FilterQuality filterQuality;
+  bool _reportedExactView = false;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -188,6 +202,16 @@ class _TilePagePainter extends CustomPainter {
       prefetchRingOverride: prefetchRingOverride,
       allowCoarserFallback: allowCoarserFallback,
     );
+    if (view.complete && !view.isEmpty) {
+      if (!_reportedExactView && onExactViewReady != null) {
+        _reportedExactView = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          onExactViewReady!(view);
+        });
+      }
+    } else {
+      _reportedExactView = false;
+    }
     if (view.isEmpty) return;
     final paint = Paint()..filterQuality = filterQuality;
     final fallbackOcclusion = fallbackOcclusionFraction == null

--- a/packages/dart_pdf_editor/lib/src/tile_layer.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_layer.dart
@@ -34,11 +34,13 @@ class PdfTileLayer extends StatelessWidget {
     this.canRasterize,
     this.batchRasters,
     this.maxNewTilesPerPaint,
+    this.maxInFlightTiles,
     this.prefetchRingOverride,
     this.allowCoarserFallback = true,
     this.fallbackOcclusionFraction,
     this.filterQuality = FilterQuality.medium,
   })  : assert(maxNewTilesPerPaint == null || maxNewTilesPerPaint > 0),
+        assert(maxInFlightTiles == null || maxInFlightTiles > 0),
         assert(prefetchRingOverride == null || prefetchRingOverride >= 0);
 
   /// The pyramid to composite from.
@@ -77,6 +79,11 @@ class PdfTileLayer extends StatelessWidget {
   /// paint, so the viewport still fills center-out without a timer or queue.
   final int? maxNewTilesPerPaint;
 
+  /// Optional cross-paint cap for unresolved visible tile rasters. This pairs
+  /// with [maxNewTilesPerPaint]: the per-paint cap protects one frame, while
+  /// this cap prevents unrelated frames from growing an unbounded GPU queue.
+  final int? maxInFlightTiles;
+
   /// Overrides [PdfTileStore.prefetchRing] for this paint. Zero prioritizes
   /// only the visible tiles; null uses the store's normal pan-ahead ring.
   final int? prefetchRingOverride;
@@ -110,6 +117,7 @@ class PdfTileLayer extends StatelessWidget {
           canRasterize: canRasterize,
           batchRasters: batchRasters,
           maxNewTilesPerPaint: maxNewTilesPerPaint,
+          maxInFlightTiles: maxInFlightTiles,
           prefetchRingOverride: prefetchRingOverride,
           allowCoarserFallback: allowCoarserFallback,
           fallbackOcclusionFraction: fallbackOcclusionFraction,
@@ -130,6 +138,7 @@ class _TilePagePainter extends CustomPainter {
     required this.canRasterize,
     required this.batchRasters,
     required this.maxNewTilesPerPaint,
+    required this.maxInFlightTiles,
     required this.prefetchRingOverride,
     required this.allowCoarserFallback,
     required this.fallbackOcclusionFraction,
@@ -148,6 +157,7 @@ class _TilePagePainter extends CustomPainter {
   final bool Function(Rect region)? canRasterize;
   final bool? batchRasters;
   final int? maxNewTilesPerPaint;
+  final int? maxInFlightTiles;
   final int? prefetchRingOverride;
   final bool allowCoarserFallback;
   final Rect? fallbackOcclusionFraction;
@@ -174,6 +184,7 @@ class _TilePagePainter extends CustomPainter {
       canRasterize: canRasterize,
       batchRasters: batchRasters,
       maxNewTiles: maxNewTilesPerPaint,
+      maxInFlightTiles: maxInFlightTiles,
       prefetchRingOverride: prefetchRingOverride,
       allowCoarserFallback: allowCoarserFallback,
     );
@@ -240,6 +251,7 @@ class _TilePagePainter extends CustomPainter {
       !identical(old.canRasterize, canRasterize) ||
       old.batchRasters != batchRasters ||
       old.maxNewTilesPerPaint != maxNewTilesPerPaint ||
+      old.maxInFlightTiles != maxInFlightTiles ||
       old.prefetchRingOverride != prefetchRingOverride ||
       old.allowCoarserFallback != allowCoarserFallback ||
       old.fallbackOcclusionFraction != fallbackOcclusionFraction ||

--- a/packages/dart_pdf_editor/lib/src/tile_store.dart
+++ b/packages/dart_pdf_editor/lib/src/tile_store.dart
@@ -264,11 +264,13 @@ class PdfTileStore extends ChangeNotifier {
     this.ladder = const PdfTileZoomLadder(),
     int maxBytes = _defaultMaxBytes,
     this.prefetchRing = 1,
+    this.maxPrefetchInFlightTiles = 4,
     this.maxFallbackDepth = 4,
     this.batchRasters = true,
     this.maxBatchTilesPerAxis = 8,
     bool registerForMemoryPressure = true,
-  })  : assert(tilePixels * maxBatchTilesPerAxis <= 1 << 14,
+  })  : assert(maxPrefetchInFlightTiles > 0),
+        assert(tilePixels * maxBatchTilesPerAxis <= 1 << 14,
             'a batch slab must fit the engine texture limit'),
         _cache = PdfBudgetedCache<PdfTileKey, PdfTile>(
           weigher: (tile) => tile.bytes,
@@ -304,6 +306,12 @@ class PdfTileStore extends ChangeNotifier {
   /// How many tiles beyond the visible range to pre-raster on each side, so a
   /// pan reveals ready tiles instead of blanks.
   final int prefetchRing;
+
+  /// Maximum exact-rung prefetch tiles submitted concurrently for one page
+  /// view. Ring work is background work: bounding it prevents unrelated
+  /// repaints from filling the Canvas/GPU queue with every off-screen batch.
+  /// A newly visible tile then waits behind at most this small window.
+  final int maxPrefetchInFlightTiles;
 
   /// How many buckets coarser [viewFor] will search for an upscaled fallback
   /// before leaving the base raster to show through.
@@ -548,6 +556,10 @@ class PdfTileStore extends ChangeNotifier {
   /// Tiles already cached or in flight are unaffected. A landed tile ticks the
   /// store, so a painting caller can use a small cap to spread synchronous
   /// retained-scene replay across frames while the view fills center-out.
+  /// [maxInFlightTiles] additionally caps the number of admitted visible tiles
+  /// that may remain unresolved across repeated paints. Unlike [maxNewTiles],
+  /// this closes the loophole where unrelated frames each admitted one more
+  /// raster before the first completion freed the queue.
   /// [batchRasters] overrides this store's batching policy for this view. This
   /// lets a GPU session request final tile textures directly while Canvas
   /// sessions using the same shared store continue to amortize slab replay.
@@ -578,10 +590,12 @@ class PdfTileStore extends ChangeNotifier {
     bool Function(Rect region)? canRasterize,
     bool? batchRasters,
     int? maxNewTiles,
+    int? maxInFlightTiles,
     int? prefetchRingOverride,
     bool allowCoarserFallback = true,
   }) {
     assert(maxNewTiles == null || maxNewTiles > 0);
+    assert(maxInFlightTiles == null || maxInFlightTiles > 0);
     assert(prefetchRingOverride == null || prefetchRingOverride >= 0);
     if (_disposed) return PdfTileView.empty;
     final grid = _tileGrid(pageSize, desiredRatio, visiblePageRect);
@@ -619,8 +633,20 @@ class PdfTileStore extends ChangeNotifier {
     final placements = <PdfTilePlacement>[];
     final pending = (batchRasters ?? this.batchRasters) ? <PdfTileKey>[] : null;
     var newTiles = 0;
-    bool schedule(PdfTileKey key, {required bool notifyOnLand}) {
+    var inFlightForView =
+        _inFlight.where((key) => key.id == id && key.rung == rung).length;
+    bool schedule(
+      PdfTileKey key, {
+      required bool notifyOnLand,
+      int? inFlightLimit,
+    }) {
       if (maxNewTiles != null && newTiles >= maxNewTiles) return false;
+      // Already-admitted work consumes no new slot. Its original visible/ring
+      // completion will tick the layer, so the current view will see it land.
+      if (_inFlight.contains(key)) return false;
+      if (inFlightLimit != null && inFlightForView >= inFlightLimit) {
+        return false;
+      }
       final scheduled = _schedule(
         key,
         id,
@@ -633,7 +659,10 @@ class PdfTileStore extends ChangeNotifier {
         canRasterize,
         notifyOnLand: notifyOnLand,
       );
-      if (scheduled) newTiles++;
+      if (scheduled) {
+        newTiles++;
+        inFlightForView++;
+      }
       return scheduled;
     }
 
@@ -650,7 +679,11 @@ class PdfTileStore extends ChangeNotifier {
         ));
       } else {
         complete = false;
-        schedule(key, notifyOnLand: true);
+        schedule(
+          key,
+          notifyOnLand: true,
+          inFlightLimit: maxInFlightTiles,
+        );
         final fallback = allowCoarserFallback
             ? _coarserFallback(id, rung, tx, ty, span, pageSize)
             : null;
@@ -685,7 +718,11 @@ class PdfTileStore extends ChangeNotifier {
             if (ringHeadroom-- <= 0) break ring;
             schedule(
               PdfTileKey(id, rung, tx, ty),
-              notifyOnLand: false,
+              // The bounded ring is advanced by completion ticks. This also
+              // promotes a ring tile cleanly when a pan makes it visible while
+              // its raster is already in flight.
+              notifyOnLand: true,
+              inFlightLimit: maxPrefetchInFlightTiles,
             );
           }
         }
@@ -702,10 +739,10 @@ class PdfTileStore extends ChangeNotifier {
           ratio,
           rasterize,
           persistence,
-          // Ring batches are admitted only when the visible set was already
-          // complete. Their landing changes no current pixels, so avoid a
-          // redundant compositor frame; the next pan rebuild reads the cache.
-          notifyOnLand: !complete,
+          // Ring batches are bounded and advance on their own completion tick;
+          // visible batches already need that tick to present their pixels.
+          notifyOnLand: true,
+          prefetch: complete,
         );
       }
     }
@@ -877,6 +914,7 @@ class PdfTileStore extends ChangeNotifier {
     PdfTileRasterizer rasterize,
     PdfTilePersistence? persistence, {
     required bool notifyOnLand,
+    required bool prefetch,
   }) {
     Rect tileRegion(PdfTileKey key) => _clampToPage(
         Rect.fromLTWH(key.tx * span, key.ty * span, span, span), pageSize);
@@ -923,6 +961,7 @@ class PdfTileStore extends ChangeNotifier {
       final sliceElapsedMs = (sliceClock?.elapsedMicroseconds ?? 0) / 1000;
       PdfPerfLog.log(
         'tile slice page=${id.pageIndex} rung=${batch.first.rung} '
+        'class=${prefetch ? 'prefetch' : 'visible'} '
         'tiles=${batch.length} '
         'elapsed=${sliceElapsedMs.toStringAsFixed(1)}ms '
         'retained=${_cache.weight} entries=${_cache.length}'

--- a/packages/dart_pdf_editor/test/pdf_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_page_view_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -269,7 +270,7 @@ void main() {
   testWidgets(
       'an off-screen page defers its cold and scale raster until visible',
       (tester) async {
-    tester.view.physicalSize = const Size(800, 600);
+    tester.view.physicalSize = const Size(400, 300);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -1029,8 +1030,9 @@ void main() {
     await tester.pumpWidget(at(content: 1));
     await tester.pump();
 
-    expect(find.byType(RawImage), findsNWidgets(2),
-        reason: 'the stale detail patch stays up for sharpness');
+    expect(find.byType(RawImage), findsAtLeastNWidgets(2),
+        reason: 'the stale exact patch (and any completed pan-ahead layer) '
+            'stay up for sharpness');
     expect(ready, 1,
         reason: 'the annotation afterimage must stay until a fresh detail '
             'patch is ready');
@@ -1110,7 +1112,7 @@ void main() {
         moreOrLessEquals(10, epsilon: 0.5)); // the uncapped desired ratio
   });
 
-  testWidgets('zoom sharpens a tight patch before restoring the pan guard',
+  testWidgets('zoom and pan sharpen visibly before growing a small guard',
       (tester) async {
     tester.view.physicalSize = const Size(800, 600);
     tester.view.devicePixelRatio = 1.0;
@@ -1119,6 +1121,7 @@ void main() {
     final doc = PdfDocument.open(buildClassicPdf());
     final page = doc.page(0);
     const detailKey = ValueKey('pdf-page-detail-image');
+    const headroomKey = ValueKey('pdf-page-detail-headroom-image');
 
     Widget at(double scale, int generation, {double dx = 0}) => Center(
           child: Transform.translate(
@@ -1164,13 +1167,182 @@ void main() {
     expect(tight.image!.width, closeTo(1600, 2));
     expect(tight.image!.height, closeTo(1200, 2));
 
-    // A later pan at the same scale moves outside that small guard. Its
-    // replacement restores the normal half-viewport headroom: 160x120 page
-    // points at the same ratio, ready for successive small pans to reuse.
+    // A later pan first sharpens the same exact-visible 80x60pt patch. The
+    // historical 50%-per-side guard made this 4x larger and delayed the first
+    // sharp frame on image-heavy CAD pages.
     await tester.pumpWidget(at(2, 2, dx: -200));
-    final guarded = await waitForDetail(differentFrom: tight.image);
-    expect(guarded.image!.width, closeTo(3200, 2));
-    expect(guarded.image!.height, closeTo(2400, 2));
+    final panned = await waitForDetail(differentFrom: tight.image);
+    expect(panned.image!.width, closeTo(1600, 2));
+    expect(panned.image!.height, closeTo(1200, 2));
+
+    // Only after that exact patch paints does a low-priority 1/8-viewport
+    // guard replace it: 100x75pt, or 1.56x rather than 4x the visible pixels.
+    for (var i = 0;
+        i < 200 && find.byKey(headroomKey).evaluate().isEmpty;
+        i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 10)),
+      );
+    }
+    final guarded = tester.widget<RawImage>(find.byKey(headroomKey));
+    expect(guarded.image!.width, closeTo(2000, 2));
+    expect(guarded.image!.height, closeTo(1500, 2));
+    expect(tester.widget<RawImage>(find.byKey(detailKey)).image,
+        same(panned.image),
+        reason: 'pan-ahead must not replace the exact foreground pixels');
+  });
+
+  testWidgets('pan headroom is lower priority and cancelled by a new settle',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 300);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final bytes = buildSyntheticRasterUnderlaySheet(
+      underlays: const [PdfUnderlaySpec(width: 2048, height: 2048)],
+      layers: 1,
+      ops: 0,
+      pageW: 256,
+      pageH: 256,
+    );
+    final document = PdfDocument.open(bytes);
+    final worker = _HeadroomTrackingWorker(_LocalCommandWorker(bytes));
+    addTearDown(worker.dispose);
+
+    Widget at(double dx, int generation) => Center(
+          child: Transform.translate(
+            offset: Offset(dx, 0),
+            child: OverflowBox(
+              maxWidth: double.infinity,
+              maxHeight: double.infinity,
+              child: SizedBox(
+                width: 512,
+                child: PdfPageView(
+                  page: document.page(0),
+                  baseRasterScale: 1,
+                  scale: 4,
+                  settleGeneration: generation,
+                  renderWorker: worker,
+                ),
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(at(0, 0));
+    for (var i = 0; i < 300 && worker.headroomStarts == 0; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(worker.headroomStarts, 1,
+        reason: 'the exact visible patch should paint before guarded work');
+    final visible = worker.regionRequests.firstWhere((r) => r.$1 <= 0).$2;
+    final guarded = worker.regionRequests.firstWhere((r) => r.$1 == 1).$2;
+    final visibleArea =
+        (visible.right - visible.left) * (visible.top - visible.bottom);
+    final guardedArea =
+        (guarded.right - guarded.left) * (guarded.top - guarded.bottom);
+    expect(guardedArea / visibleArea, moreOrLessEquals(1.5625, epsilon: 0.02));
+
+    // The low-priority worker request is deliberately held. Moving beyond the
+    // exact patch must invalidate and cancel it before starting replacement
+    // foreground work for the new viewport.
+    await tester.pumpWidget(at(-200, 1));
+    for (var i = 0; i < 50 && worker.regionRequests.last.$1 > 0; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 2)),
+      );
+    }
+    expect(worker.headroomCancels, 1);
+    expect(worker.regionRequests.last.$1, lessThanOrEqualTo(0),
+        reason: 'the replacement viewport must return to foreground priority');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('pan headroom changes zero pixels under the exact patch',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 300);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final bytes = buildSyntheticRasterUnderlaySheet(
+      underlays: const [PdfUnderlaySpec(width: 2048, height: 2048)],
+      layers: 1,
+      ops: 0,
+      pageW: 256,
+      pageH: 256,
+    );
+    final document = PdfDocument.open(bytes);
+    final worker = _HeadroomTrackingWorker(_LocalCommandWorker(bytes));
+    addTearDown(worker.dispose);
+    const boundaryKey = ValueKey('detail-pixel-boundary');
+    const headroomKey = ValueKey('pdf-page-detail-headroom-image');
+
+    await tester.pumpWidget(RepaintBoundary(
+      key: boundaryKey,
+      child: Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(
+            width: 512,
+            child: PdfPageView(
+              page: document.page(0),
+              baseRasterScale: 1,
+              scale: 4,
+              renderWorker: worker,
+            ),
+          ),
+        ),
+      ),
+    ));
+    for (var i = 0; i < 300 && worker.headroomStarts == 0; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(worker.headroomStarts, 1);
+
+    Future<Uint8List> pixels() async {
+      return (await tester.runAsync(() async {
+        final boundary = tester.renderObject<RenderRepaintBoundary>(
+          find.byKey(boundaryKey),
+        );
+        final image = await boundary.toImage(pixelRatio: 1);
+        final data = await image.toByteData(
+          format: ui.ImageByteFormat.rawRgba,
+        );
+        image.dispose();
+        return data!.buffer.asUint8List();
+      }))!;
+    }
+
+    final exactPixels = await pixels();
+    worker.releaseHeadroom();
+    for (var i = 0;
+        i < 300 && find.byKey(headroomKey).evaluate().isEmpty;
+        i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(find.byKey(headroomKey), findsOneWidget);
+    await tester.pump();
+    final guardedPixels = await pixels();
+    var changed = 0;
+    for (var i = 0; i < exactPixels.length; i++) {
+      if (exactPixels[i] != guardedPixels[i]) changed++;
+    }
+    expect(changed, 0,
+        reason: 'the guarded layer must remain completely occluded by the '
+            'already-sharp exact patch inside the current viewport');
   });
 
   testWidgets('deep zoom reuses a current fit raster as its base',
@@ -1224,6 +1396,7 @@ void main() {
     final doc = PdfDocument.open(buildClassicPdf());
     final page = doc.page(0);
     const detailKey = ValueKey('pdf-page-detail-image');
+    const headroomKey = ValueKey('pdf-page-detail-headroom-image');
 
     Widget at(double dx, int generation, {int contentStamp = 0}) => Center(
           child: Transform.translate(
@@ -1245,6 +1418,8 @@ void main() {
 
     Object detailImage() =>
         tester.widget<RawImage>(find.byKey(detailKey)).image!;
+    Object headroomImage() =>
+        tester.widget<RawImage>(find.byKey(headroomKey)).image!;
 
     Future<void> waitForDetail({Object? differentFrom}) async {
       for (var i = 0; i < 200; i++) {
@@ -1262,22 +1437,33 @@ void main() {
 
     await tester.pumpWidget(at(0, 0));
     await waitForDetail();
-    final first = detailImage();
+    final visible = detailImage();
+    for (var i = 0;
+        i < 200 && find.byKey(headroomKey).evaluate().isEmpty;
+        i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 10)),
+      );
+    }
+    final guarded = headroomImage();
 
-    // The patch is inflated by half a viewport per side. A 100 px pan remains
-    // inside it, so the next settle must reuse the exact raster.
+    // The background patch adds 1/8 viewport per side. A 100 px pan remains
+    // inside it, so the next settle must reuse the exact raster without
+    // delaying the initial sharp frame to buy that headroom.
     await tester.pumpWidget(at(-100, 1));
     for (var i = 0; i < 20 && PdfPageView.debugDetailPatchReuses == 0; i++) {
       await tester.pump();
     }
     expect(PdfPageView.debugDetailPatchReuses, 1);
-    expect(detailImage(), same(first));
+    expect(detailImage(), same(visible));
+    expect(headroomImage(), same(guarded));
 
     // An additive edit leaves the old sharp patch painted while the
     // replacement is rendering. It must not be mistaken for reusable current
     // content even though its geometry still covers the viewport.
     await tester.pumpWidget(at(-100, 2, contentStamp: 1));
-    await waitForDetail(differentFrom: first);
+    await waitForDetail(differentFrom: visible);
     final edited = detailImage();
     expect(PdfPageView.debugDetailPatchReuses, 1);
 
@@ -1389,6 +1575,77 @@ class _RatioRecordingWorker extends PdfRenderWorker {
 
   @override
   void dispose() => _inner.dispose();
+}
+
+class _HeadroomTrackingWorker extends PdfRenderWorker {
+  _HeadroomTrackingWorker(this._inner);
+
+  final PdfRenderWorker _inner;
+  final List<(int, PdfRect)> regionRequests = [];
+  Completer<void>? _headroomGate;
+  bool _headroomCancelled = false;
+  int headroomStarts = 0;
+  int headroomCancels = 0;
+
+  @override
+  bool get isActive => _inner.isActive;
+
+  @override
+  Future<List<PdfRenderCommand>?> record(
+    int pageIndex, {
+    bool annotations = true,
+    int priority = 0,
+    double? imagePixelRatio,
+    bool decodeImages = true,
+    int? commandLimit,
+    PdfRect? imageDecodeRegion,
+    PdfPartialRecordSink? onPartial,
+  }) async {
+    if (imageDecodeRegion != null) {
+      regionRequests.add((priority, imageDecodeRegion));
+    }
+    if (priority == 1 && imageDecodeRegion != null) {
+      headroomStarts++;
+      final gate = _headroomGate = Completer<void>();
+      await gate.future;
+      _headroomGate = null;
+      if (_headroomCancelled) {
+        _headroomCancelled = false;
+        return null;
+      }
+    }
+    return _inner.record(
+      pageIndex,
+      annotations: annotations,
+      priority: priority,
+      imagePixelRatio: imagePixelRatio,
+      decodeImages: decodeImages,
+      commandLimit: commandLimit,
+      imageDecodeRegion: imageDecodeRegion,
+      onPartial: onPartial,
+    );
+  }
+
+  @override
+  void cancel(int pageIndex, {int priority = 0}) {
+    if (priority == 1 && _headroomGate != null && !_headroomGate!.isCompleted) {
+      headroomCancels++;
+      _headroomCancelled = true;
+      _headroomGate!.complete();
+    }
+    _inner.cancel(pageIndex, priority: priority);
+  }
+
+  void releaseHeadroom() {
+    final gate = _headroomGate;
+    if (gate != null && !gate.isCompleted) gate.complete();
+  }
+
+  @override
+  void dispose() {
+    if (!(_headroomGate?.isCompleted ?? true)) _headroomGate!.complete();
+    _inner.dispose();
+  }
 }
 
 /// In-process command worker used by the image-LoD tests. The production

--- a/packages/dart_pdf_editor/test/pdf_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/pdf_page_view_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -1112,7 +1111,7 @@ void main() {
         moreOrLessEquals(10, epsilon: 0.5)); // the uncapped desired ratio
   });
 
-  testWidgets('zoom and pan sharpen visibly before growing a small guard',
+  testWidgets('zoom and pan sharpen exactly the visible viewport',
       (tester) async {
     tester.view.physicalSize = const Size(800, 600);
     tester.view.devicePixelRatio = 1.0;
@@ -1120,8 +1119,16 @@ void main() {
     addTearDown(tester.view.resetDevicePixelRatio);
     final doc = PdfDocument.open(buildClassicPdf());
     final page = doc.page(0);
+    final logs = <String>[];
+    final oldPerfEnabled = PdfPerfLog.enabled;
+    final oldPerfSink = PdfPerfLog.sink;
+    PdfPerfLog.enabled = true;
+    PdfPerfLog.sink = logs.add;
+    addTearDown(() {
+      PdfPerfLog.enabled = oldPerfEnabled;
+      PdfPerfLog.sink = oldPerfSink;
+    });
     const detailKey = ValueKey('pdf-page-detail-image');
-    const headroomKey = ValueKey('pdf-page-detail-headroom-image');
 
     Widget at(double scale, int generation, {double dx = 0}) => Center(
           child: Transform.translate(
@@ -1174,175 +1181,66 @@ void main() {
     final panned = await waitForDetail(differentFrom: tight.image);
     expect(panned.image!.width, closeTo(1600, 2));
     expect(panned.image!.height, closeTo(1200, 2));
-
-    // Only after that exact patch paints does a low-priority 1/8-viewport
-    // guard replace it: 100x75pt, or 1.56x rather than 4x the visible pixels.
-    for (var i = 0;
-        i < 200 && find.byKey(headroomKey).evaluate().isEmpty;
-        i++) {
-      await tester.pump();
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 10)),
-      );
-    }
-    final guarded = tester.widget<RawImage>(find.byKey(headroomKey));
-    expect(guarded.image!.width, closeTo(2000, 2));
-    expect(guarded.image!.height, closeTo(1500, 2));
-    expect(tester.widget<RawImage>(find.byKey(detailKey)).image,
-        same(panned.image),
-        reason: 'pan-ahead must not replace the exact foreground pixels');
+    expect(
+      find.byKey(const ValueKey('pdf-page-detail-headroom-image')),
+      findsNothing,
+      reason: 'the fallback must not start an unpreemptible second raster',
+    );
+    final paintLogs = logs.where((line) => line.contains('detail paint'));
+    expect(paintLogs.length, greaterThanOrEqualTo(3));
+    expect(paintLogs, everyElement(contains('pass=visible')),
+        reason: 'foreground time-to-sharp observations must survive later '
+            'pan-ahead scheduling');
   });
 
-  testWidgets('pan headroom is lower priority and cancelled by a new settle',
+  testWidgets('detail adoption rebalances reclaimable live rasters',
       (tester) async {
-    tester.view.physicalSize = const Size(400, 300);
     tester.view.devicePixelRatio = 1.0;
-    addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
-    final bytes = buildSyntheticRasterUnderlaySheet(
-      underlays: const [PdfUnderlaySpec(width: 2048, height: 2048)],
-      layers: 1,
-      ops: 0,
-      pageW: 256,
-      pageH: 256,
-    );
-    final document = PdfDocument.open(bytes);
-    final worker = _HeadroomTrackingWorker(_LocalCommandWorker(bytes));
-    addTearDown(worker.dispose);
+    final budget = PdfLiveRasterBudget.instance;
+    final oldMax = budget.maxBytes;
+    final reclaimable = _BudgetProbeHolder(bytes: 1, distance: 9);
+    addTearDown(() {
+      budget.unregister(reclaimable);
+      budget.maxBytes = oldMax;
+    });
 
-    Widget at(double dx, int generation) => Center(
-          child: Transform.translate(
-            offset: Offset(dx, 0),
-            child: OverflowBox(
-              maxWidth: double.infinity,
-              maxHeight: double.infinity,
-              child: SizedBox(
-                width: 512,
-                child: PdfPageView(
-                  page: document.page(0),
-                  baseRasterScale: 1,
-                  scale: 4,
-                  settleGeneration: generation,
-                  renderWorker: worker,
-                ),
-              ),
-            ),
-          ),
-        );
-
-    await tester.pumpWidget(at(0, 0));
-    for (var i = 0; i < 300 && worker.headroomStarts == 0; i++) {
-      await tester.pump();
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 5)),
-      );
-    }
-    expect(worker.headroomStarts, 1,
-        reason: 'the exact visible patch should paint before guarded work');
-    final visible = worker.regionRequests.firstWhere((r) => r.$1 <= 0).$2;
-    final guarded = worker.regionRequests.firstWhere((r) => r.$1 == 1).$2;
-    final visibleArea =
-        (visible.right - visible.left) * (visible.top - visible.bottom);
-    final guardedArea =
-        (guarded.right - guarded.left) * (guarded.top - guarded.bottom);
-    expect(guardedArea / visibleArea, moreOrLessEquals(1.5625, epsilon: 0.02));
-
-    // The low-priority worker request is deliberately held. Moving beyond the
-    // exact patch must invalidate and cancel it before starting replacement
-    // foreground work for the new viewport.
-    await tester.pumpWidget(at(-200, 1));
-    for (var i = 0; i < 50 && worker.regionRequests.last.$1 > 0; i++) {
-      await tester.pump();
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 2)),
-      );
-    }
-    expect(worker.headroomCancels, 1);
-    expect(worker.regionRequests.last.$1, lessThanOrEqualTo(0),
-        reason: 'the replacement viewport must return to foreground priority');
-
-    await tester.pumpWidget(const SizedBox.shrink());
-  });
-
-  testWidgets('pan headroom changes zero pixels under the exact patch',
-      (tester) async {
-    tester.view.physicalSize = const Size(400, 300);
-    tester.view.devicePixelRatio = 1.0;
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
-    final bytes = buildSyntheticRasterUnderlaySheet(
-      underlays: const [PdfUnderlaySpec(width: 2048, height: 2048)],
-      layers: 1,
-      ops: 0,
-      pageW: 256,
-      pageH: 256,
-    );
-    final document = PdfDocument.open(bytes);
-    final worker = _HeadroomTrackingWorker(_LocalCommandWorker(bytes));
-    addTearDown(worker.dispose);
-    const boundaryKey = ValueKey('detail-pixel-boundary');
-    const headroomKey = ValueKey('pdf-page-detail-headroom-image');
-
-    await tester.pumpWidget(RepaintBoundary(
-      key: boundaryKey,
-      child: Center(
-        child: OverflowBox(
-          maxWidth: double.infinity,
-          maxHeight: double.infinity,
+    final doc = PdfDocument.open(buildClassicPdf());
+    Widget page(double scale, int generation) => Center(
           child: SizedBox(
-            width: 512,
+            width: 612,
             child: PdfPageView(
-              page: document.page(0),
-              baseRasterScale: 1,
-              scale: 4,
-              renderWorker: worker,
+              page: doc.page(0),
+              baseRasterScale: 4,
+              scale: scale,
+              settleGeneration: generation,
             ),
           ),
-        ),
-      ),
-    ));
-    for (var i = 0; i < 300 && worker.headroomStarts == 0; i++) {
+        );
+
+    await tester.pumpWidget(page(1, 0));
+    for (var i = 0; i < 200 && find.byType(RawImage).evaluate().isEmpty; i++) {
       await tester.pump();
       await tester.runAsync(
         () => Future<void>.delayed(const Duration(milliseconds: 5)),
       );
     }
-    expect(worker.headroomStarts, 1);
-
-    Future<Uint8List> pixels() async {
-      return (await tester.runAsync(() async {
-        final boundary = tester.renderObject<RenderRepaintBoundary>(
-          find.byKey(boundaryKey),
-        );
-        final image = await boundary.toImage(pixelRatio: 1);
-        final data = await image.toByteData(
-          format: ui.ImageByteFormat.rawRgba,
-        );
-        image.dispose();
-        return data!.buffer.asUint8List();
-      }))!;
-    }
-
-    final exactPixels = await pixels();
-    worker.releaseHeadroom();
-    for (var i = 0;
-        i < 300 && find.byKey(headroomKey).evaluate().isEmpty;
-        i++) {
-      await tester.pump();
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 5)),
-      );
-    }
-    expect(find.byKey(headroomKey), findsOneWidget);
+    // Drain the base raster's own post-frame rebalance before introducing the
+    // probe. The scale change below retains that capped base and adds only the
+    // exact deep-zoom detail allocation.
     await tester.pump();
-    final guardedPixels = await pixels();
-    var changed = 0;
-    for (var i = 0; i < exactPixels.length; i++) {
-      if (exactPixels[i] != guardedPixels[i]) changed++;
+    budget.register(reclaimable);
+    budget.maxBytes = budget.totalBytes - 1;
+
+    await tester.pumpWidget(page(8, 1));
+    for (var i = 0; i < 300 && !reclaimable.evicted; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
     }
-    expect(changed, 0,
-        reason: 'the guarded layer must remain completely occluded by the '
-            'already-sharp exact patch inside the current viewport');
+    expect(reclaimable.evicted, isTrue,
+        reason: 'retaining the new detail image must run the global budget');
   });
 
   testWidgets('deep zoom reuses a current fit raster as its base',
@@ -1386,7 +1284,7 @@ void main() {
         reason: 'deep zoom must not replace the whole-page backing raster');
   });
 
-  testWidgets('detail guard band reuses the patch across small pan settles',
+  testWidgets('exact detail reuse still validates current content',
       (tester) async {
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -1396,7 +1294,6 @@ void main() {
     final doc = PdfDocument.open(buildClassicPdf());
     final page = doc.page(0);
     const detailKey = ValueKey('pdf-page-detail-image');
-    const headroomKey = ValueKey('pdf-page-detail-headroom-image');
 
     Widget at(double dx, int generation, {int contentStamp = 0}) => Center(
           child: Transform.translate(
@@ -1418,8 +1315,6 @@ void main() {
 
     Object detailImage() =>
         tester.widget<RawImage>(find.byKey(detailKey)).image!;
-    Object headroomImage() =>
-        tester.widget<RawImage>(find.byKey(headroomKey)).image!;
 
     Future<void> waitForDetail({Object? differentFrom}) async {
       for (var i = 0; i < 200; i++) {
@@ -1438,41 +1333,52 @@ void main() {
     await tester.pumpWidget(at(0, 0));
     await waitForDetail();
     final visible = detailImage();
-    for (var i = 0;
-        i < 200 && find.byKey(headroomKey).evaluate().isEmpty;
-        i++) {
-      await tester.pump();
-      await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 10)),
-      );
-    }
-    final guarded = headroomImage();
 
-    // The background patch adds 1/8 viewport per side. A 100 px pan remains
-    // inside it, so the next settle must reuse the exact raster without
-    // delaying the initial sharp frame to buy that headroom.
-    await tester.pumpWidget(at(-100, 1));
+    // A settle with unchanged geometry reuses the exact current patch.
+    await tester.pumpWidget(at(0, 1));
     for (var i = 0; i < 20 && PdfPageView.debugDetailPatchReuses == 0; i++) {
       await tester.pump();
     }
     expect(PdfPageView.debugDetailPatchReuses, 1);
     expect(detailImage(), same(visible));
-    expect(headroomImage(), same(guarded));
 
     // An additive edit leaves the old sharp patch painted while the
     // replacement is rendering. It must not be mistaken for reusable current
     // content even though its geometry still covers the viewport.
-    await tester.pumpWidget(at(-100, 2, contentStamp: 1));
+    await tester.pumpWidget(at(0, 2, contentStamp: 1));
     await waitForDetail(differentFrom: visible);
     final edited = detailImage();
     expect(PdfPageView.debugDetailPatchReuses, 1);
 
-    // Move farther than the guard band. The old patch no longer covers the
-    // viewport, so a replacement must land.
+    // A moved viewport no longer fits the exact patch, so a replacement lands.
     await tester.pumpWidget(at(-1000, 3, contentStamp: 1));
     await waitForDetail(differentFrom: edited);
     expect(PdfPageView.debugDetailPatchReuses, 1);
   });
+}
+
+class _BudgetProbeHolder implements PdfLiveRasterHolder {
+  _BudgetProbeHolder({required int bytes, required this.distance})
+      : _bytes = bytes;
+
+  int _bytes;
+  final int distance;
+  bool evicted = false;
+
+  @override
+  int get liveRasterBytes => _bytes;
+
+  @override
+  int get liveRasterDistance => distance;
+
+  @override
+  bool get liveRasterOnScreen => false;
+
+  @override
+  void evictLiveRaster() {
+    evicted = true;
+    _bytes = 0;
+  }
 }
 
 class _DeferredRecordWorker extends PdfRenderWorker {
@@ -1575,77 +1481,6 @@ class _RatioRecordingWorker extends PdfRenderWorker {
 
   @override
   void dispose() => _inner.dispose();
-}
-
-class _HeadroomTrackingWorker extends PdfRenderWorker {
-  _HeadroomTrackingWorker(this._inner);
-
-  final PdfRenderWorker _inner;
-  final List<(int, PdfRect)> regionRequests = [];
-  Completer<void>? _headroomGate;
-  bool _headroomCancelled = false;
-  int headroomStarts = 0;
-  int headroomCancels = 0;
-
-  @override
-  bool get isActive => _inner.isActive;
-
-  @override
-  Future<List<PdfRenderCommand>?> record(
-    int pageIndex, {
-    bool annotations = true,
-    int priority = 0,
-    double? imagePixelRatio,
-    bool decodeImages = true,
-    int? commandLimit,
-    PdfRect? imageDecodeRegion,
-    PdfPartialRecordSink? onPartial,
-  }) async {
-    if (imageDecodeRegion != null) {
-      regionRequests.add((priority, imageDecodeRegion));
-    }
-    if (priority == 1 && imageDecodeRegion != null) {
-      headroomStarts++;
-      final gate = _headroomGate = Completer<void>();
-      await gate.future;
-      _headroomGate = null;
-      if (_headroomCancelled) {
-        _headroomCancelled = false;
-        return null;
-      }
-    }
-    return _inner.record(
-      pageIndex,
-      annotations: annotations,
-      priority: priority,
-      imagePixelRatio: imagePixelRatio,
-      decodeImages: decodeImages,
-      commandLimit: commandLimit,
-      imageDecodeRegion: imageDecodeRegion,
-      onPartial: onPartial,
-    );
-  }
-
-  @override
-  void cancel(int pageIndex, {int priority = 0}) {
-    if (priority == 1 && _headroomGate != null && !_headroomGate!.isCompleted) {
-      headroomCancels++;
-      _headroomCancelled = true;
-      _headroomGate!.complete();
-    }
-    _inner.cancel(pageIndex, priority: priority);
-  }
-
-  void releaseHeadroom() {
-    final gate = _headroomGate;
-    if (gate != null && !gate.isCompleted) gate.complete();
-  }
-
-  @override
-  void dispose() {
-    if (!(_headroomGate?.isCompleted ?? true)) _headroomGate!.complete();
-    _inner.dispose();
-  }
 }
 
 /// In-process command worker used by the image-LoD tests. The production

--- a/packages/dart_pdf_editor/test/tile_image_detail_test.dart
+++ b/packages/dart_pdf_editor/test/tile_image_detail_test.dart
@@ -237,7 +237,10 @@ void main() {
         break;
       }
     }
+    const foregroundKey = ValueKey('pdf-page-sharp-tile-foreground');
     expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget);
+    expect(find.byKey(foregroundKey), findsNothing,
+        reason: 'a partially populated rung must remain behind the patch');
     expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget,
         reason: 'engaging tiles must not hide already-sharp visible pixels');
     final painter = tester
@@ -245,6 +248,20 @@ void main() {
         .painter as dynamic;
     expect(painter.fallbackOcclusionFraction, isNotNull,
         reason: 'a coarse retained rung must not cover the sharper patch');
+
+    // Once the region-scoped image decode and every visible exact-rung tile
+    // have landed, that complete layer is a real quality upgrade over the
+    // quick patch and must move in front atomically. The patch stays mounted
+    // underneath as the fallback for a later pan.
+    for (var i = 0;
+        i < 150 && find.byKey(foregroundKey).evaluate().isEmpty;
+        i++) {
+      await _settle(tester, rounds: 1);
+    }
+    expect(find.byKey(foregroundKey), findsOneWidget,
+        reason: 'completed higher-detail tiles must become visible');
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget,
+        reason: 'the exact patch remains underneath as an atomic fallback');
   });
 
   testWidgets('an older detail patch cannot hide a sharper fallback rung',

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -3,10 +3,12 @@
 // keeps showing through. Kept in its own file so the global flag mutation can't
 // leak into other page-view tests.
 import 'dart:async';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:dart_pdf_editor/src/region_replay_index.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pdf_document/pdf_document.dart';
@@ -289,6 +291,127 @@ void main() {
     expect(find.byType(RawImage), findsOneWidget);
     // Real tiles rastered from the page's retained scene.
     expect(store.tileCount, greaterThan(0));
+  });
+
+  testWidgets('late tile pan-ahead changes no exact foreground pixels',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 300);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = PdfTileStore(
+      tilePixels: 128,
+      prefetchRing: 1,
+      registerForMemoryPressure: false,
+    );
+    final backend = _SolidTileRasterBackend();
+    final oldTiles = PdfPageView.tileStoreDetail;
+    final oldDirect = PdfPageView.directPicturePresentation;
+    PdfPageView.tileStoreDetail = false;
+    PdfPageView.directPicturePresentation = false;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = oldTiles;
+      PdfPageView.directPicturePresentation = oldDirect;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final bytes = buildSyntheticRasterUnderlaySheet(
+      underlays: const [PdfUnderlaySpec(width: 2048, height: 2048)],
+      layers: 1,
+      ops: 0,
+      pageW: 256,
+      pageH: 256,
+    );
+    final doc = PdfDocument.open(bytes);
+    const boundaryKey = ValueKey('tile-under-detail-boundary');
+    const detailKey = ValueKey('pdf-page-detail-image');
+    const tileKey = ValueKey('pdf-page-tile-layer');
+
+    Widget page(double scale, int generation) => RepaintBoundary(
+          key: boundaryKey,
+          child: Center(
+            child: OverflowBox(
+              maxWidth: double.infinity,
+              maxHeight: double.infinity,
+              child: SizedBox(
+                width: 2560,
+                child: PdfPageView(
+                  page: doc.page(0),
+                  baseRasterScale: 1,
+                  scale: scale,
+                  settleGeneration: generation,
+                  tileRasterBackend: backend,
+                ),
+              ),
+            ),
+          ),
+        );
+
+    Future<ui.Image> waitForDetail() async {
+      for (var i = 0; i < 300; i++) {
+        await tester.pump();
+        if (find.byKey(detailKey).evaluate().isNotEmpty) {
+          final image = tester.widget<RawImage>(find.byKey(detailKey)).image;
+          if (image != null) return image;
+        }
+        await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 5)),
+        );
+      }
+      fail('exact detail did not land');
+    }
+
+    Future<Uint8List> pixels() async {
+      final boundary = tester.renderObject<RenderRepaintBoundary>(
+        find.byKey(boundaryKey),
+      );
+      for (var i = 0; i < 300 && boundary.debugNeedsPaint; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 1)),
+        );
+      }
+      expect(boundary.debugNeedsPaint, isFalse);
+      return (await tester.runAsync(() async {
+        final image = await boundary.toImage(pixelRatio: 1);
+        final data = await image.toByteData(
+          format: ui.ImageByteFormat.rawRgba,
+        );
+        image.dispose();
+        return data!.buffer.asUint8List();
+      }))!;
+    }
+
+    await tester.pumpWidget(page(2, 0));
+    final exact = await waitForDetail();
+    final before = await pixels();
+
+    // Enable the production-default tile route on a new settle with unchanged
+    // geometry. The current exact patch is reused; its post-paint callback then
+    // admits the pyramid and its ring underneath.
+    PdfPageView.tileStoreDetail = true;
+    await tester.pumpWidget(page(2, 1));
+    for (var i = 0;
+        i < 300 &&
+            (find.byKey(tileKey).evaluate().isEmpty || store.tileCount == 0);
+        i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(find.byKey(tileKey), findsOneWidget);
+    expect(backend.rasterizations, greaterThan(0));
+    expect(store.tileCount, greaterThan(0));
+    await tester.pump();
+    final after = await pixels();
+    expect(after, orderedEquals(before),
+        reason: 'deliberately different late tile pixels must stay occluded '
+            'by the exact visible patch');
+    expect(tester.widget<RawImage>(find.byKey(detailKey)).image, same(exact));
   });
 
   testWidgets('an active tile target never steps down in quality',
@@ -580,6 +703,58 @@ void main() {
       scene.dispose();
     });
   });
+}
+
+class _SolidTileRasterBackend extends PdfCanvasTileRasterBackend {
+  int rasterizations = 0;
+
+  @override
+  String get debugLabel => 'solid';
+
+  @override
+  PdfTileRasterSession createSession(PdfRetainedScene scene) =>
+      _SolidTileRasterSession(this, scene);
+}
+
+class _SolidTileRasterSession
+    implements PdfTileRasterSession, PdfTileRasterScheduling {
+  _SolidTileRasterSession(this.backend, this.scene);
+
+  final _SolidTileRasterBackend backend;
+
+  @override
+  final PdfRetainedScene scene;
+
+  @override
+  bool get batchAdjacentTiles => false;
+
+  @override
+  int get maxNewTilesPerPaint => 1;
+
+  @override
+  Future<ui.Image> rasterizeRegion(
+    Rect region, {
+    required double pixelRatio,
+    int? tracePage,
+  }) async {
+    backend.rasterizations++;
+    final width = (region.width * pixelRatio).ceil().clamp(1, 1 << 14);
+    final height = (region.height * pixelRatio).ceil().clamp(1, 1 << 14);
+    final recorder = ui.PictureRecorder();
+    ui.Canvas(recorder).drawRect(
+      Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+      ui.Paint()..color = const Color(0xFFFF00FF),
+    );
+    final picture = recorder.endRecording();
+    try {
+      return await picture.toImage(width, height);
+    } finally {
+      picture.dispose();
+    }
+  }
+
+  @override
+  void dispose() {}
 }
 
 // Deliberately subclasses the stock backend: custom subclasses still override

--- a/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_page_view_test.dart
@@ -80,6 +80,8 @@ void main() {
         reason: 'a final-texture backend must bypass slab slicing');
     expect((tilePaint.painter as dynamic).maxNewTilesPerPaint, 1,
         reason: 'the backend session owns its per-frame admission policy');
+    expect((tilePaint.painter as dynamic).maxInFlightTiles, 2,
+        reason: 'repaints must not grow the backend submission queue');
 
     await tester.pumpWidget(const SizedBox.shrink());
     expect(tester.takeException(), isNull,
@@ -287,6 +289,8 @@ void main() {
     );
     expect((tilePaint.painter as dynamic).maxNewTilesPerPaint, 1,
         reason: 'grid-indexed scenes must pace replay one tile per paint');
+    expect((tilePaint.painter as dynamic).maxInFlightTiles, 2,
+        reason: 'the cross-frame queue remains bounded while tiles land');
     // The base raster is still the only RawImage (tiles paint via CustomPaint).
     expect(find.byType(RawImage), findsOneWidget);
     // Real tiles rastered from the page's retained scene.
@@ -412,6 +416,171 @@ void main() {
         reason: 'deliberately different late tile pixels must stay occluded '
             'by the exact visible patch');
     expect(tester.widget<RawImage>(find.byKey(detailKey)).image, same(exact));
+  });
+
+  testWidgets('translation cannot abandon exact-first recovery for tiles',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 300);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = PdfTileStore(
+      tilePixels: 128,
+      prefetchRing: 1,
+      registerForMemoryPressure: false,
+    );
+    final oldTiles = PdfPageView.tileStoreDetail;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = oldTiles;
+      PdfPageView.debugTileStoreOverride = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    Widget page(double scale, int generation, double dx) => Center(
+          child: Transform.translate(
+            offset: Offset(dx, 0),
+            child: OverflowBox(
+              maxWidth: double.infinity,
+              maxHeight: double.infinity,
+              child: SizedBox(
+                width: 1024,
+                child: PdfPageView(
+                  page: doc.page(0),
+                  baseRasterScale: 1,
+                  scale: scale,
+                  settleGeneration: generation,
+                ),
+              ),
+            ),
+          ),
+        );
+
+    await tester.pumpWidget(page(1, 0, 0));
+    for (var i = 0; i < 200 && find.byType(RawImage).evaluate().isEmpty; i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+
+    await tester.pumpWidget(page(4, 1, 0));
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsNothing,
+        reason: 'a scale settle keeps incremental tiles hidden');
+
+    // Reproduce the trace: a tiny translation advances the settle while the
+    // exact region is still in flight. The old generation-based gate forgot
+    // the exact-first obligation here and exposed a staggered tile tail.
+    await tester.pumpWidget(page(4, 2, -12));
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsNothing,
+        reason: 'translation must retain exact-first recovery');
+
+    for (var i = 0;
+        i < 300 &&
+            find
+                .byKey(const ValueKey('pdf-page-detail-image'))
+                .evaluate()
+                .isEmpty;
+        i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget);
+    for (var i = 0;
+        i < 50 &&
+            find
+                .byKey(const ValueKey('pdf-page-tile-layer'))
+                .evaluate()
+                .isEmpty;
+        i++) {
+      await tester.pump();
+    }
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget,
+        reason: 'tiles become pan-ahead only after exact pixels paint');
+  });
+
+  testWidgets('a page entered at deep zoom paints exact before tile batches',
+      (tester) async {
+    tester.view.physicalSize = const Size(400, 300);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final store = PdfTileStore(
+      tilePixels: 512,
+      prefetchRing: 1,
+      registerForMemoryPressure: false,
+    );
+    final logs = <String>[];
+    final oldTiles = PdfPageView.tileStoreDetail;
+    PdfPageView.tileStoreDetail = true;
+    PdfPageView.debugTileStoreOverride = store;
+    PdfPerfLog.enabled = true;
+    PdfPerfLog.sink = logs.add;
+    addTearDown(() {
+      PdfPageView.tileStoreDetail = oldTiles;
+      PdfPageView.debugTileStoreOverride = null;
+      PdfPerfLog.enabled = false;
+      PdfPerfLog.sink = null;
+      store.dispose();
+    });
+
+    final doc = PdfDocument.open(buildClassicPdf());
+    await tester.pumpWidget(
+      Center(
+        child: OverflowBox(
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+          child: SizedBox(
+            width: 1024,
+            child: PdfPageView(
+              page: doc.page(0),
+              baseRasterScale: 1,
+              scale: 4,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    for (var i = 0;
+        i < 300 &&
+            (find
+                    .byKey(const ValueKey('pdf-page-tile-layer'))
+                    .evaluate()
+                    .isEmpty ||
+                store.tileCount == 0);
+        i++) {
+      await tester.pump();
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 5)),
+      );
+    }
+
+    final exactPaint = logs.indexWhere(
+      (line) => line.contains('detail paint page=0 pass=visible'),
+    );
+    final firstTile = logs.indexWhere(
+      (line) =>
+          line.contains('tile slice page=0') && line.contains('class=visible'),
+    );
+    expect(exactPaint, greaterThanOrEqualTo(0));
+    expect(firstTile, greaterThan(exactPaint),
+        reason: 'a newly visible deep-zoom page must not sharpen in patches');
+    expect(find.byKey(const ValueKey('pdf-page-detail-image')), findsOneWidget);
+    expect(find.byKey(const ValueKey('pdf-page-tile-layer')), findsOneWidget);
+    final painter = tester
+        .widget<CustomPaint>(
+          find.byKey(const ValueKey('pdf-page-tile-layer')),
+        )
+        .painter as dynamic;
+    expect(painter.maxInFlightTiles, 8,
+        reason: 'ordinary scenes get one bounded visible slab at a time');
   });
 
   testWidgets('an active tile target never steps down in quality',

--- a/packages/dart_pdf_editor/test/tile_store_test.dart
+++ b/packages/dart_pdf_editor/test/tile_store_test.dart
@@ -337,6 +337,44 @@ void main() {
       });
     });
 
+    testWidgets('an in-flight cap survives unrelated repaint passes',
+        (tester) async {
+      await tester.runAsync(() async {
+        final store = PdfTileStore(
+          tilePixels: 16,
+          prefetchRing: 0,
+          batchRasters: false,
+          registerForMemoryPressure: false,
+        );
+        final raster = _Rasterizer();
+
+        void paint() => store.viewFor(
+              id: _id(0),
+              pageSize: const Size(64, 64),
+              desiredRatio: 1,
+              visiblePageRect: const Rect.fromLTWH(0, 0, 64, 64),
+              rasterize: raster.call,
+              maxNewTiles: 1,
+              maxInFlightTiles: 2,
+            );
+
+        for (var i = 0; i < 20; i++) {
+          paint();
+        }
+        expect(store.inFlightCount, 2,
+            reason: 'per-paint admission must not grow into a long GPU queue');
+        expect(raster.calls, hasLength(2));
+
+        await raster.flush();
+        paint();
+        expect(store.inFlightCount, 1,
+            reason: 'a completion frees the next center-out admission slot');
+        expect(raster.calls, hasLength(3));
+        await raster.flush();
+        store.dispose();
+      });
+    });
+
     testWidgets('a view can bypass the store slab policy', (tester) async {
       await tester.runAsync(() async {
         final store = PdfTileStore(
@@ -453,11 +491,21 @@ void main() {
           visiblePageRect: const Rect.fromLTWH(32, 32, 16, 16),
           rasterize: raster.call,
         );
-        expect(store.inFlightCount, 8,
-            reason: 'the next paint schedules the surrounding ring');
+        expect(store.inFlightCount, 4,
+            reason: 'only a bounded window of the ring may enter the queue');
         await raster.flush();
-        expect(ticks, 1,
-            reason: 'off-screen arrivals must not repaint current pixels');
+        expect(ticks, 2,
+            reason: 'the completion tick advances the next bounded window');
+        store.viewFor(
+          id: _id(0),
+          pageSize: const Size(80, 80),
+          desiredRatio: 1.0,
+          visiblePageRect: const Rect.fromLTWH(32, 32, 16, 16),
+          rasterize: raster.call,
+        );
+        expect(store.inFlightCount, 4);
+        await raster.flush();
+        expect(ticks, 3);
         store.dispose();
       });
     });
@@ -883,6 +931,7 @@ void main() {
         final roomy = PdfTileStore(
           tilePixels: 512,
           prefetchRing: 1,
+          maxPrefetchInFlightTiles: 16,
           maxBytes: 128 << 20, // 128 tiles
           ladder: const PdfTileZoomLadder(stepsPerOctave: 1),
           batchRasters: false,


### PR DESCRIPTION
## Summary

- render the exact visible deep-zoom region first, including pages that enter the viewport while the viewer is already zoomed
- keep that exact-first obligation across translation-only settles, so a tiny scroll cannot expose staggered tiles after cancelling a worker request
- keep incomplete/coarser tiles below the settled exact patch; once the current exact rung has complete visible coverage and carries demonstrably sharper image samples, promote the whole tile layer atomically
- retain the exact patch underneath a promoted tile layer as a gap-free fallback for later pans
- cap unresolved visible tile work across repaints (8 tiles for ordinary Canvas slabs, 2 for dense/session-paced paths) and cap prefetch to 4 tiles
- classify tile telemetry as `class=visible` or `class=prefetch`
- let a worker that genuinely declines the exact region fall back cleanly to bounded tiles
- rebalance retained detail allocations through the coordinated live-raster budget
- repair the local web/performance scripts after the package split so they generate the real worker in `dart_pdf_editor_assets`

## Correctness guarantees

- no visible quality downgrade: incomplete, stale, differently positioned, or lower-density tile sets cannot replace the exact patch
- the sharper foreground handoff occurs only after every visible tile exists at the current exact rung, the image-detail scene is current, and its image decode is measurably sharper
- the handoff is atomic; the previous exact patch stays mounted underneath
- translation settles cannot abandon an in-flight exact recovery
- a page entered at deep zoom paints the exact foreground before its first visible tile batch
- unrelated repaints cannot grow the GPU queue beyond the configured cross-frame cap
- a declined exact request cannot leave tiles hidden indefinitely
- fallback pages do not start a speculative second unpreemptible multi-megapixel raster

Regression coverage includes:

- a byte-for-byte framebuffer check using deliberately magenta late tiles
- incomplete exact-rung tiles remaining behind the exact patch
- a complete higher-detail exact rung becoming the foreground while the patch remains underneath
- exact-first recovery surviving a translation settle
- exact foreground telemetry preceding visible tile telemetry on page entry
- repeated unrelated paints respecting the in-flight queue cap
- bounded prefetch advancing in completion windows

## Performance evidence

Release-mode Chromium/Puppeteer run against `corpus/ly9-far-cad.pdf`, page target 30 at 4×:

- exact worker result: 94 ms
- exact visible patch painted: 118 ms from request
- stable DartPDF zoom sharpen: 149 ms
- PDFium stable zoom in this run: 43 ms
- first visual: DartPDF 38 ms, PDFium 43 ms
- first tile work began only after the exact patch painted: one 8-tile visible slab, then prefetch windows capped at 4

Field-reproduction run for the reported page 31 position at 50%:

- exact visible patch painted 360 ms after its request
- sharper image-detail scene landed next
- all 8 visible exact-rung tiles completed before promotion
- foreground promotion occurred 2.14 s after the request (1.78 s after the quick patch)
- prefetch tiles began only after that visible promotion

The original trace already contained the sharper 0.5× tile data, but the 0.4× exact patch remained above it forever. This change makes the completed quality upgrade visible without reintroducing tile flashes or high-to-low transitions.

This does **not** claim zoom parity: stable zoom remains about 3.45× PDFium in the original normalized harness, and page-jump latency remains a separate large gap.

The harness still names/captures adjacent page indices differently between engines, so the PR does not present an overall DartPDF-vs-PDFium score as authoritative. A publishable cross-engine comparison still needs normalized page-space bounds, physical viewport, pixels-per-point, and screenshot validation.

## Validation

- `fvm dart analyze`
- `fvm flutter test test/tile_image_detail_test.dart test/tile_store_page_view_test.dart test/tile_layer_test.dart test/pdf_page_view_test.dart` — 50 passed
- broader tile/render-worker suite from the initial PR — 167 passed
- `fvm flutter test test/ghent_render_test.dart` — passed, including checked-in pixel baselines
- isolated worker-failure regression — passed
- release Chromium CAD run against the supplied real-world file — final foreground promotion observed and visually verified
- all six local web/performance harness scripts pass `bash -n` and now build the worker into the package that actually owns the asset