### PR TITLE
chore(release): pin Linux packages to 3.5.0

### DIFF
--- a/app/packaging/aur/.SRCINFO
+++ b/app/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dartpdf-bin
 	pkgdesc = Edit, annotate, sign, and fill in PDFs - a private, local PDF editor (prebuilt binary)
-	pkgver = 3.4.0
+	pkgver = 3.5.0
 	pkgrel = 1
 	url = https://dart-pdf.com
 	arch = x86_64
@@ -11,9 +11,9 @@ pkgbase = dartpdf-bin
 	provides = dartpdf
 	conflicts = dartpdf
 	options = !strip
-	source = dartpdf-3.4.0.tar.gz::https://github.com/ben-milanko/dart-pdf/releases/download/app-v3.4.0/dartpdf-linux-x64.tar.gz
-	source = LICENSE::https://raw.githubusercontent.com/ben-milanko/dart-pdf/app-v3.4.0/LICENSE
-	sha256sums = 57ef3076fb8068325f25c95b10cb55e0f0fd668560dff2e61663bbfd8c4f2ff6
+	source = dartpdf-3.5.0.tar.gz::https://github.com/ben-milanko/dart-pdf/releases/download/app-v3.5.0/dartpdf-linux-x64.tar.gz
+	source = LICENSE::https://raw.githubusercontent.com/ben-milanko/dart-pdf/app-v3.5.0/LICENSE
+	sha256sums = b74199d7340dff552f7fd64065faa9c197e5cd4e55e5f4613c9066102caf2602
 	sha256sums = cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30
 
 pkgname = dartpdf-bin

--- a/app/packaging/aur/PKGBUILD
+++ b/app/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ben Milanko <ben.milanko@protonmail.com>
 pkgname=dartpdf-bin
-pkgver=3.4.0
+pkgver=3.5.0
 pkgrel=1
 pkgdesc="Edit, annotate, sign, and fill in PDFs - a private, local PDF editor (prebuilt binary)"
 arch=('x86_64')
@@ -25,7 +25,7 @@ options=('!strip')  # bundled .so files are already stripped; don't touch the AO
 source=("dartpdf-${pkgver}.tar.gz::https://github.com/ben-milanko/dart-pdf/releases/download/app-v${pkgver}/dartpdf-linux-x64.tar.gz"
         "LICENSE::https://raw.githubusercontent.com/ben-milanko/dart-pdf/app-v${pkgver}/LICENSE")
 
-sha256sums=('57ef3076fb8068325f25c95b10cb55e0f0fd668560dff2e61663bbfd8c4f2ff6'
+sha256sums=('b74199d7340dff552f7fd64065faa9c197e5cd4e55e5f4613c9066102caf2602'
             'cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30')
 
 package() {

--- a/app/packaging/flatpak/dev.milanko.dartpdf.yml
+++ b/app/packaging/flatpak/dev.milanko.dartpdf.yml
@@ -67,8 +67,8 @@ modules:
     sources:
       # 1) The prebuilt Linux bundle (binary + data/ + lib/).
       - type: archive
-        url: https://github.com/ben-milanko/dart-pdf/releases/download/app-v3.4.0/dartpdf-linux-x64.tar.gz
-        sha256: 57ef3076fb8068325f25c95b10cb55e0f0fd668560dff2e61663bbfd8c4f2ff6
+        url: https://github.com/ben-milanko/dart-pdf/releases/download/app-v3.5.0/dartpdf-linux-x64.tar.gz
+        sha256: b74199d7340dff552f7fd64065faa9c197e5cd4e55e5f4613c9066102caf2602
         # Kept for standard Flatpak external-data tooling and downstream
         # packagers; the official repository publisher verifies GitHub's asset
         # digest independently before building.

--- a/app/packaging/snap/README.md
+++ b/app/packaging/snap/README.md
@@ -29,7 +29,7 @@ On Ubuntu 24.04 or newer:
 sudo snap install snapcraft --classic
 app/packaging/snap/build-release-snap.sh \
   --archive /path/to/dartpdf-linux-x64.tar.gz \
-  --version 3.4.0 \
+  --version 3.5.0 \
   --output /tmp/dartpdf-snap
 sudo snap install --dangerous /tmp/dartpdf-snap/dartpdf_*.snap
 snap run dartpdf

--- a/app/packaging/snap/snap/snapcraft.yaml
+++ b/app/packaging/snap/snap/snapcraft.yaml
@@ -44,8 +44,8 @@ plugs:
 parts:
   dartpdf:
     plugin: dump
-    source: https://github.com/ben-milanko/dart-pdf/releases/download/app-v3.4.0/dartpdf-linux-x64.tar.gz
+    source: https://github.com/ben-milanko/dart-pdf/releases/download/app-v3.5.0/dartpdf-linux-x64.tar.gz
     source-type: tar
-    source-checksum: sha256/57ef3076fb8068325f25c95b10cb55e0f0fd668560dff2e61663bbfd8c4f2ff6
+    source-checksum: sha256/b74199d7340dff552f7fd64065faa9c197e5cd4e55e5f4613c9066102caf2602
     parse-info:
       - share/metainfo/dev.milanko.dartpdf.metainfo.xml


### PR DESCRIPTION
Updates the checked-in Flatpak, Snap, and AUR sources to the published DartPDF 3.5.0 Linux tarball.\n\nThe SHA-256 is the digest verified by the successful Flatpak and Snap release workflows: `b74199d7340dff552f7fd64065faa9c197e5cd4e55e5f4613c9066102caf2602`.\n\nThis is post-release reproducibility housekeeping; the public Flatpak repository and Snap stable channel are already on 3.5.0.