### PR TITLE
fix(render): keep image /SMask compositing correct on Impeller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+      # Every other render test here runs on Skia, but the shipped Android app
+      # runs on Impeller - which honours a slightly different subset of the
+      # canvas API (issue #675: a draw paint's blend mode is dropped when the
+      # same paint carries a colour filter). Run the compositing tests that
+      # encode those invariants on Impeller too, so the divergence is caught
+      # here rather than on a device.
+      - name: Test dart_pdf_editor compositing on Impeller
+        working-directory: packages/dart_pdf_editor
+        run: flutter test --enable-impeller test/image_soft_mask_composite_test.dart
+
+      # The optional flutter_gpu tile backend is the default wherever the
+      # platform supports it (Android ships with it enabled), and its corpus
+      # suite asserts GPU/Canvas parity on every page it accepts. Every
+      # assertion self-skips when the runner cannot open a GPU context, so this
+      # is a no-op rather than a failure on a host without one.
+      - name: Test dart_pdf_editor_flutter_gpu
+        working-directory: packages/dart_pdf_editor_flutter_gpu
+        run: flutter test --enable-impeller --enable-flutter-gpu
+
       - name: Test pdf_ocr_vlm
         working-directory: packages/pdf_ocr_vlm
         run: flutter test --coverage

--- a/doc/dev-log/2026-08-13-impeller-image-soft-mask-black.md
+++ b/doc/dev-log/2026-08-13-impeller-image-soft-mask-black.md
@@ -1,0 +1,99 @@
+# Image /SMask composite turned black on Impeller (#675)
+
+Reported against 3.5.0 on Android: one page of a 62-page print PDF (a
+card-sheet page dense with JPEGs) rendered as black rectangles where the
+artwork should be. The same build on Android **web** was correct.
+
+## What was actually broken
+
+Not the decoder, not Android. `CanvasPdfDevice.drawImage` composited a
+deferred image /SMask with a single paint carrying **both**
+`BlendMode.dstIn` **and** a red→alpha `ColorFilter.matrix`:
+
+```dart
+canvas.drawImageRect(softMask, src, unit, Paint()
+  ..blendMode = BlendMode.dstIn
+  ..colorFilter = const ColorFilter.matrix(_redToAlpha));
+```
+
+Skia honours both. **Impeller drops the blend mode when the same draw paint
+carries a colour filter** - the mask then composites `srcOver`, painting its
+filtered samples (opaque black wherever the mask is white, transparent
+wherever it is black) *over* the base instead of cutting the base's alpha.
+The result is an inverted, blackened image: exactly the reported page.
+
+Both the blend and the filter now live on a `saveLayer` paint, which both
+engines honour. That is the same shape `beginSoftMaskComposite` already used
+for group soft masks - which is why /SMask **groups** were never affected.
+
+## Why only some images, and why only native
+
+The companion-mask path (`_gpuSoftMasks`, added with the deferred-DCT
+soft-mask work in #659) is only reached when the base image comes back from
+the **platform JPEG codec**: `deferSimpleDctSoftMask` keeps the grayscale
+mask as its own GPU surface rather than multiplying it into the base's
+pixels. So the failing set is precisely:
+
+- **non-CMYK DCTDecode images** - `decodePdfImageBase` returns null for them
+  (`image_pixels.dart`), so `_decodeOne` runs `ui.instantiateImageCodec` and
+  attaches a companion mask;
+- everything else - CMYK JPEGs, Flate, Indexed, CCITT, JPX - decodes in pure
+  Dart with the mask already multiplied in, so it has no companion and never
+  took the broken paint.
+
+On **web** neither half applies: the worker decodes colour JPEGs with the
+libjpeg-turbo WASM accelerator / the browser codec (`jpeg_accelerator_web`,
+`browser_jpeg_decode_web`), so the pixels arrive pre-masked. That is the whole
+of "broken on Android, fine on Android web".
+
+On the reported page this split is stark and made the diagnosis easy: the
+CMYK logos rendered perfectly while every DeviceRGB JPEG went black.
+
+## Reproducing without a device
+
+`flutter test --enable-impeller` reproduces it exactly on Linux - the render
+of the reported page under Impeller is pixel-for-pixel the user's screenshot.
+That also names the gap that let it ship: **every render test in CI runs on
+Skia**, while the Android app enables Impeller in its manifest.
+
+`test/image_soft_mask_composite_test.dart` pins the invariant with a JPEG
+base under a half-transparent Flate /SMask: the masked-out half must keep the
+page background. It passes on Skia with *either* paint shape, so ci.yml now
+runs that one file a second time with `--enable-impeller`. Broadening that
+job to more of the render suite is the obvious follow-up - the engines differ
+by ~2/255 mean on antialiased content, so the pixel-baseline suites (Ghent,
+PDF.js) need their own tolerance before they can join it.
+
+## The flutter_gpu tile backend had its own half of this
+
+Fixing the canvas device exposed a second divergence on exactly the same
+images. `FlutterGpuTileRasterBackend` uploads **one texture per image** and
+never consults `pdfGpuSoftMaskOf`, so a companion mask was silently dropped
+and the base painted opaque - and a cut-out sticker's JPEG is solid black
+outside the subject, so the tile still rendered a black rectangle. That
+backend is the **default wherever the platform supports it**, and Android's
+manifest enables flutter_gpu, so at the deep zoom in the report it owned the
+visible tiles.
+
+`_unsupportedReason` now declines a scene carrying such an image
+(`'deferred image soft mask'`), which routes the page to the now-correct
+Canvas path - the same conservative fallback the backend already uses for
+gradients, tiled patterns and non-normal blends. Corpus acceptance is
+unchanged (PDF.js 90/89, Ghent 16/41), so no page in either suite has this
+shape - which is also why the GPU/Canvas parity suite never caught it.
+
+Uploading the mask as its own texture and sampling it in `pdf_tile_texture.frag`
+would recover the GPU path for these pages; the readback branch of
+`_uploadImageTexture` already pays a `toByteData`, so the alternative of
+multiplying the mask into the base's alpha at upload is also open. Neither is
+needed for correctness.
+
+## Sibling worth knowing about
+
+The stencil (`/ImageMask`) branch of the same method still sets
+`ColorFilter.mode(..., srcIn)` alongside `_elementBlend`. When that blend is
+not `srcOver` - an explicit /BM, or `BlendMode.src` inside a knockout group -
+Impeller will drop it the same way. It is deliberately left alone here: the
+layer rewrite that fixes the /SMask case would change knockout semantics
+(§11.4.5 elements must replace only their own coverage, with no full-bounds
+layer), and no corpus page currently exercises the combination.

--- a/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
+++ b/packages/dart_pdf_editor/lib/dart_pdf_editor.dart
@@ -61,7 +61,8 @@ export 'package:pdf_cos/pdf_cos.dart'
 export 'src/http_byte_source.dart';
 export 'l10n/dart_pdf_editor_localizations.dart';
 export 'src/l10n/pdf_l10n.dart';
-export 'src/image_decoder.dart' show PdfImageCache, pdfImageContentKey;
+export 'src/image_decoder.dart'
+    show PdfImageCache, pdfImageContentKey, pdfGpuSoftMaskOf;
 export 'src/ocr.dart';
 export 'src/page_export.dart';
 export 'src/print_rasterize.dart';

--- a/packages/dart_pdf_editor/lib/src/canvas_device.dart
+++ b/packages/dart_pdf_editor/lib/src/canvas_device.dart
@@ -1538,6 +1538,19 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
       paint,
     );
     if (softMask != null) {
+      // The dstIn and the red->alpha filter go on a *layer* paint, not on the
+      // mask's own draw paint. Impeller ignores a draw paint's blend mode when
+      // that same paint also carries a colour filter: the mask then composites
+      // srcOver, painting its filtered samples (opaque black where the mask is
+      // white) over the base instead of cutting the base's alpha - every
+      // /SMask'd JPEG on the page turns into a black rectangle (#675). Skia
+      // honours both on one paint, and both engines honour this shape.
+      canvas.saveLayer(
+        const Rect.fromLTWH(0, 0, 1, 1),
+        Paint()
+          ..blendMode = BlendMode.dstIn
+          ..colorFilter = const ColorFilter.matrix(_redToAlpha),
+      );
       canvas.drawImageRect(
         softMask,
         Rect.fromLTWH(
@@ -1549,10 +1562,9 @@ class CanvasPdfDevice implements PdfDevice, PdfTiledCellSink, PdfTextBatchSink {
         const Rect.fromLTWH(0, 0, 1, 1),
         Paint()
           ..filterQuality = FilterQuality.medium
-          ..isAntiAlias = false
-          ..blendMode = BlendMode.dstIn
-          ..colorFilter = const ColorFilter.matrix(_redToAlpha),
+          ..isAntiAlias = false,
       );
+      canvas.restore();
       canvas.restore();
     }
     canvas.restore();

--- a/packages/dart_pdf_editor/test/image_soft_mask_composite_test.dart
+++ b/packages/dart_pdf_editor/test/image_soft_mask_composite_test.dart
@@ -1,0 +1,129 @@
+// Regression test for issue #675: an image /SMask kept as a companion GPU
+// surface must cut the base's alpha, not paint over it.
+//
+// `CanvasPdfDevice.drawImage` composites a deferred grayscale /SMask with
+// `BlendMode.dstIn` plus a red->alpha `ColorFilter.matrix`. Those two were on
+// the mask's own draw paint, which Skia honours - and which **Impeller
+// silently degrades**: it drops a draw paint's blend mode when that same paint
+// carries a colour filter, so the filtered mask (opaque black wherever the
+// mask is white) composited srcOver and turned every /SMask'd JPEG into a
+// black rectangle. Both must live on a layer paint instead.
+//
+// The assertions below pass on Skia either way, so this test earns its keep
+// under `flutter test --enable-impeller` (see the CI job of the same name).
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dart_pdf_editor/dart_pdf_editor.dart';
+import 'package:dart_pdf_editor/src/image_decoder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:pdf_cos/pdf_cos.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+
+const _width = 64;
+const _height = 64;
+
+/// A solid green JPEG with a gray /SMask that is transparent on the left half
+/// and opaque on the right.
+CosStream _maskedJpeg() {
+  final rgb = img.Image(width: _width, height: _height);
+  for (final p in rgb) {
+    p
+      ..r = 40
+      ..g = 200
+      ..b = 90;
+  }
+  final mask = Uint8List(_width * _height);
+  for (var y = 0; y < _height; y++) {
+    for (var x = 0; x < _width; x++) {
+      mask[y * _width + x] = x < _width ~/ 2 ? 0 : 0xFF;
+    }
+  }
+  final maskBytes = Uint8List.fromList(ZLibCodec(level: 6).encode(mask));
+  return CosStream(
+    CosDictionary({
+      'Subtype': const CosName('Image'),
+      'Width': const CosInteger(_width),
+      'Height': const CosInteger(_height),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': const CosName('DeviceRGB'),
+      'Filter': const CosName('DCTDecode'),
+      'SMask': CosStream(
+        CosDictionary({
+          'Subtype': const CosName('Image'),
+          'Width': const CosInteger(_width),
+          'Height': const CosInteger(_height),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceGray'),
+          'Filter': const CosName('FlateDecode'),
+          'Length': CosInteger(maskBytes.length),
+        }),
+        maskBytes,
+      ),
+    }),
+    Uint8List.fromList(img.encodeJpg(rgb, quality: 100)),
+  );
+}
+
+void main() {
+  testWidgets('a deferred image /SMask cuts the base instead of painting over '
+      'it', (tester) async {
+    await tester.runAsync(() async {
+      final cos = CosDocument.open(buildClassicPdf());
+      final request = PdfImageRequest(
+        stream: _maskedJpeg(),
+        // Unit square -> the middle 100x100 of a 200x200 page.
+        transform: PdfMatrix(100, 0, 0, 100, 50, 50),
+      );
+      final images = await decodeImages(cos, [request]);
+      final image = images[pdfImageKey(request)];
+      expect(image, isNotNull,
+          reason: 'the JPEG base must decode through the platform codec');
+      // The shape under test: the mask stayed a companion GPU surface rather
+      // than being multiplied into the base's pixels.
+      expect(pdfGpuSoftMaskOf(image!), isNotNull,
+          reason: 'this test only covers the deferred (companion) mask path');
+
+      const size = 200.0;
+      final recorder = ui.PictureRecorder();
+      final canvas = Canvas(recorder)
+        ..drawRect(const Rect.fromLTWH(0, 0, size, size),
+            Paint()..color = const Color(0xFFFFFFFF))
+        // Page space is y-up, as CanvasPdfDevice expects.
+        ..translate(0, size)
+        ..scale(1, -1);
+      CanvasPdfDevice(canvas, images: images).drawImage(request);
+      final picture = recorder.endRecording();
+      final raster = await picture.toImage(size.round(), size.round());
+      final data = await raster.toByteData(format: ui.ImageByteFormat.rawRgba);
+      final pixels = data!.buffer.asUint8List();
+      raster.dispose();
+      picture.dispose();
+
+      List<int> at(int x, int y) {
+        final i = (y * size.round() + x) * 4;
+        return [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]];
+      }
+
+      // Masked-out (left) half: the page background survives untouched. With
+      // the blend mode dropped this reads as opaque black.
+      expect(at(75, 100), [255, 255, 255, 255]);
+      // Opaque (right) half: the base colour, give or take JPEG rounding.
+      final opaque = at(125, 100);
+      expect(opaque[0], closeTo(40, 6));
+      expect(opaque[1], closeTo(200, 6));
+      expect(opaque[2], closeTo(90, 6));
+      expect(opaque[3], 255);
+      // Outside the image quad nothing was painted.
+      expect(at(20, 100), [255, 255, 255, 255]);
+
+      for (final decoded in images.values) {
+        disposePdfDecodedImage(decoded);
+      }
+    });
+  });
+}

--- a/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/lib/src/backend_native.dart
@@ -175,7 +175,18 @@ class FlutterGpuTileRasterBackend extends PdfTileRasterBackend {
         case PdfFillMeshCommand():
           break;
         case PdfDrawImageCommand(:final request):
-          if (scene.imageFor(request) == null) return 'missing image pixels';
+          final image = scene.imageFor(request);
+          if (image == null) return 'missing image pixels';
+          // A platform-codec base keeps its /SMask as a companion GPU surface
+          // that only CanvasPdfDevice knows how to compose (dstIn over the
+          // base). This backend uploads one texture per image, so drawing it
+          // here would paint the base opaque - the JPEG's masked-out area is
+          // usually solid black, so a cut-out sticker renders as a black
+          // rectangle (#675). Hand the scene to Canvas until the mask is
+          // uploaded as its own texture.
+          if (pdfGpuSoftMaskOf(image) != null) {
+            return 'deferred image soft mask';
+          }
         case PdfDrawTextCommand(:final run):
           if (run.invisible) continue;
           if (run.glyphs == null ||

--- a/packages/dart_pdf_editor_flutter_gpu/pubspec.yaml
+++ b/packages/dart_pdf_editor_flutter_gpu/pubspec.yaml
@@ -30,6 +30,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
+  # Encodes the JPEG fixture whose /SMask stays a companion GPU surface.
+  image: ^4.9.1
   pdf_test_fixtures: '>=1.4.0 <4.0.0'
 
 flutter:

--- a/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
+++ b/packages/dart_pdf_editor_flutter_gpu/test/flutter_gpu_tile_backend_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show ZLibCodec;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -6,6 +7,7 @@ import 'package:dart_pdf_editor_flutter_gpu/dart_pdf_editor_flutter_gpu.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
 import 'package:pdf_cos/pdf_cos.dart';
 import 'package:pdf_graphics/pdf_graphics.dart';
 import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
@@ -603,4 +605,68 @@ void main() {
           reason: 'arbitrary PDF clips should use the exact stencil route');
     });
   });
+
+  testWidgets('an image whose /SMask stayed a companion surface falls back',
+      (tester) async {
+    await tester.runAsync(() async {
+      if (!_gpuAvailable()) {
+        markTestSkipped('run with --enable-impeller --enable-flutter-gpu');
+        return;
+      }
+      // A non-CMYK JPEG decodes through the platform codec, which keeps a
+      // simple grayscale /SMask as a companion `ui.Image` that only
+      // CanvasPdfDevice knows how to compose. This backend uploads one texture
+      // per image, so it must decline the scene rather than paint the base
+      // opaque - the JPEG's masked-out area is solid black (#675).
+      final page = PdfDocument.open(buildClassicPdf()).page(0);
+      final scene = await PdfRetainedScene.fromCommands(page, [
+        PdfDrawImageCommand(PdfImageRequest(
+          stream: _maskedJpegStream(),
+          transform: PdfMatrix(100, 0, 0, 100, 50, 50),
+        )),
+      ]);
+      addTearDown(scene.dispose);
+      final backend = FlutterGpuTileRasterBackend();
+      expect(backend.createSession(scene), isNull);
+      expect(backend.stats.lastRejection, contains('soft mask'));
+    });
+  });
+}
+
+/// A solid-colour JPEG with a Flate grayscale /SMask: the shape whose mask the
+/// decoder defers to paint time as a companion GPU surface.
+CosStream _maskedJpegStream() {
+  const size = 32;
+  final rgb = img.Image(width: size, height: size);
+  for (final p in rgb) {
+    p
+      ..r = 40
+      ..g = 200
+      ..b = 90;
+  }
+  final mask = Uint8List(size * size)..fillRange(0, size * size ~/ 2, 0xFF);
+  final maskBytes = Uint8List.fromList(ZLibCodec(level: 6).encode(mask));
+  return CosStream(
+    CosDictionary({
+      'Subtype': const CosName('Image'),
+      'Width': const CosInteger(size),
+      'Height': const CosInteger(size),
+      'BitsPerComponent': const CosInteger(8),
+      'ColorSpace': const CosName('DeviceRGB'),
+      'Filter': const CosName('DCTDecode'),
+      'SMask': CosStream(
+        CosDictionary({
+          'Subtype': const CosName('Image'),
+          'Width': const CosInteger(size),
+          'Height': const CosInteger(size),
+          'BitsPerComponent': const CosInteger(8),
+          'ColorSpace': const CosName('DeviceGray'),
+          'Filter': const CosName('FlateDecode'),
+          'Length': CosInteger(maskBytes.length),
+        }),
+        maskBytes,
+      ),
+    }),
+    Uint8List.fromList(img.encodeJpg(rgb, quality: 100)),
+  );
 }


### PR DESCRIPTION
## Summary

A page dense with JPEGs rendered as black rectangles on Android in 3.5.0, while
the same build was correct on Android web.

`CanvasPdfDevice.drawImage` composited a deferred image `/SMask` with a single
paint carrying **both** `BlendMode.dstIn` **and** a red→alpha
`ColorFilter.matrix`. Skia honours both. **Impeller drops a draw paint's blend
mode when that same paint carries a colour filter**, so the filtered mask
composited `srcOver` instead — painting opaque black wherever the mask was
white, and leaving the base intact wherever it should have been cut away. Both
now live on a `saveLayer` paint, the shape `beginSoftMaskComposite` already used
for group soft masks (which is why `/SMask` *groups* were never affected).

Only images whose base comes back from the **platform JPEG codec** keep their
mask as a companion GPU surface (`_gpuSoftMasks`, from #659), so the failing set
was exactly the non-CMYK `DCTDecode` images — CMYK/Flate/Indexed/CCITT/JPX
decode in pure Dart with the mask already multiplied in. On web the worker
decodes colour JPEGs itself (libjpeg-turbo WASM / browser codec) and ships
pre-masked pixels, which is the whole of "broken on Android, fine on Android
web". On the reported page the split was stark: the CMYK logos rendered
perfectly while every DeviceRGB JPEG went black.

Fixing the canvas device exposed a second half of the same bug.
`FlutterGpuTileRasterBackend` — the **default wherever the platform supports
it**, and Android's manifest enables flutter_gpu — uploads one texture per image
and never consulted `pdfGpuSoftMaskOf`, so it painted the base opaque; a cut-out
sticker's JPEG is solid black outside the subject, so the tile stayed a black
rectangle. It now declines such a scene to the Canvas path, the same
conservative fallback it already uses for gradients, tiled patterns, and
non-normal blends. Corpus acceptance is unchanged (PDF.js 90/89, Ghent 16/41),
so no page in either suite has this shape — which is also why the GPU/Canvas
parity suite never caught it.

`flutter test --enable-impeller` reproduces the reported page pixel-for-pixel on
Linux, which also names the gap that let this ship: **every render test in CI ran
on Skia**, while the shipped Android app runs Impeller.

Background: [doc/dev-log/2026-08-13-impeller-image-soft-mask-black.md](doc/dev-log/2026-08-13-impeller-image-soft-mask-black.md).

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [x] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [ ] Example app
- [x] Documentation / CI / repository metadata only

(also `dart_pdf_editor_flutter_gpu`, which the list predates)

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (`--fatal-infos`, clean; lockstep constraint check passes)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [x] `cd packages/dart_pdf_editor && fvm flutter test` (2298 passed)
- [x] Ghent corpus test or baseline update (44 passed, no baseline change)
- [x] Real PDF corpus parse/render smoke test (PDF.js suite, 164 passed)
- [ ] Example app smoke test

Also run: `app` suite (422 passed); `packages/dart_pdf_editor_flutter_gpu`
with and without `--enable-impeller --enable-flutter-gpu` (232 passed with a
live GPU context); the new compositing test under both engines. `pdf_cos`,
`pdf_document` and `pdf_graphics` are untouched by this change.

## PDF fixtures and screenshots

The reporter's document is not public, so both new tests build their fixture
programmatically: a solid-colour JPEG (`img.encodeJpg`) under a half-transparent
Flate grayscale `/SMask`, which is the exact shape that keeps a companion mask.

`test/image_soft_mask_composite_test.dart` asserts the masked-out half keeps the
page background. It passes on Skia with *either* paint shape, so CI now runs
that one file a second time with `--enable-impeller`; without the fix it fails
there with `Expected: [255, 255, 255, 255] Actual: [40, 200, 90, 255]` — the
inverted mask.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory.
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- `pdfGpuSoftMaskOf` is newly exported from `dart_pdf_editor` so the flutter_gpu
  backend can see the companion surface it must decline.
- The new CI job runs the flutter_gpu suite with the GPU flags. Every assertion
  in that package self-skips when the runner cannot open a GPU context, so it
  degrades to a no-op rather than a failure on a host without one.
- **Follow-ups, deliberately not in this PR:**
  - Broadening the Impeller CI job to more of the render suite. The engines
    differ by ~2/255 mean on antialiased content, so the pixel-baseline suites
    (Ghent, PDF.js) need their own tolerance before they can join it.
  - Recovering the GPU path for these pages by uploading the mask as its own
    texture (or multiplying it into the base's alpha in the readback branch of
    `_uploadImageTexture`, which already pays a `toByteData`).
  - The stencil (`/ImageMask`) branch of `drawImage` still sets
    `ColorFilter.mode(..., srcIn)` alongside `_elementBlend`, so Impeller will
    drop that blend when it is not `srcOver`. Left alone here: the layer rewrite
    that fixes the `/SMask` case would change knockout semantics (§11.4.5
    elements must replace only their own coverage, with no full-bounds layer),
    and no corpus page exercises the combination.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UA7oufbP7KSt7qRsL2Mb4q)_