### PR TITLE
fix(app): Android document scan — read results through the ContentResolver, and say why a scan failed

### DIFF
--- a/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/dev/milanko/dart_pdf_editor_app/MainActivity.kt
@@ -25,6 +25,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.util.concurrent.Executors
 
@@ -176,6 +177,23 @@ class MainActivity : FlutterActivity() {
                     }
                 }
             }
+            "readUri" -> {
+                val token = call.argument<String>("token")
+                if (token == null) {
+                    result.error("bad_args", "readUri expects a token", null)
+                    return
+                }
+                fileIoExecutor.execute {
+                    try {
+                        val bytes = readWhole(Uri.parse(token))
+                        runOnUiThread { result.success(bytes) }
+                    } catch (e: Exception) {
+                        runOnUiThread {
+                            result.error("read_failed", e.message, null)
+                        }
+                    }
+                }
+            }
             else -> result.notImplemented()
         }
     }
@@ -316,6 +334,17 @@ class MainActivity : FlutterActivity() {
             return if (read == length) buffer else buffer.copyOf(read)
         }
         return ByteArray(0)
+    }
+
+    /// Reads [uri] whole through the ContentResolver, which resolves `content://`
+    /// and `file://` alike. This is the read the document scanner needs: ML Kit
+    /// hands back a Uri into its own scratch space, and which scheme it carries
+    /// depends on the Play Services build, so the Dart side can't open it by
+    /// path. Throws when the Uri can't be opened, so the caller sees the reason
+    /// instead of an empty result.
+    private fun readWhole(uri: Uri): ByteArray {
+        return contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            ?: throw FileNotFoundException("Cannot open $uri")
     }
 
     /// Hands the whole PDF to Android's print framework, which renders it.

--- a/app/lib/doc_scan_io.dart
+++ b/app/lib/doc_scan_io.dart
@@ -1,7 +1,10 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_doc_scanner/flutter_doc_scanner.dart';
+
+import 'pdf_mobile_source.dart' show mobileFileChannel;
 
 /// The on-device document scanner is a phone/tablet feature - Google ML Kit's
 /// Document Scanner on Android, VisionKit's `VNDocumentCameraViewController` on
@@ -11,35 +14,104 @@ bool get documentScanSupported =>
     defaultTargetPlatform == TargetPlatform.android ||
     defaultTargetPlatform == TargetPlatform.iOS;
 
+/// Thrown when the scanner captured pages but the app could not read the PDF it
+/// wrote. Distinct from a cancelled scan (which is a null result and a silent
+/// no-op) so the caller can toast rather than appear to do nothing.
+class DocumentScanException implements Exception {
+  const DocumentScanException(this.location);
+
+  /// The scanner-returned location we failed to read, for the dev log.
+  final String location;
+
+  @override
+  String toString() => 'DocumentScanException: could not read the scan at '
+      '"$location"';
+}
+
 /// Launches the platform document scanner and returns the captured pages as a
-/// PDF. Returns null when the user cancels, when nothing readable comes back,
-/// or on an unsupported platform.
+/// PDF. Returns null when the user cancels; throws [DocumentScanException] when
+/// a scan completed but its PDF could not be read back.
 ///
 /// **One scan session only.** Each `FlutterDocScanner` method launches its own
 /// camera, so calling more than one re-opens the scanner after the user has
-/// already accepted their pages. We ask for the ready-made PDF export - a plain
-/// file path on iOS, a `file://` URI on Android - and read it back with
-/// [readScannedFile]. A failure to read degrades to null (a "couldn't scan"
-/// toast) rather than throwing.
+/// already accepted their pages. We ask for the ready-made PDF export and read
+/// it back with [readScannedFile], immediately - ML Kit writes into its own
+/// scratch space and reclaims it once the scanner activity is gone.
 Future<Uint8List?> scanDocumentToPdf() async {
   if (!documentScanSupported) return null;
   final result = await FlutterDocScanner().getScannedDocumentAsPdf();
   if (result == null) return null; // user cancelled
-  return readScannedFile(result.pdfUri);
+  final bytes = await readScannedFile(result.pdfUri);
+  if (bytes == null) throw DocumentScanException(result.pdfUri);
+  return bytes;
 }
 
-/// Reads a scanner-returned file location, normalising a `file://` URI to a
-/// path. `content://` URIs can't be read through `dart:io`, and a missing file
-/// yields null, so a stray entry degrades gracefully rather than throwing.
+/// Reads a scanner-returned file location.
+///
+/// iOS hands back a bare filesystem path. Android hands back whatever
+/// `GmsDocumentScanningResult.Pdf.getUri()` produced, which is *not* reliably a
+/// `dart:io`-readable path: depending on the Play Services build it is either a
+/// `file://` URI into the app's cache or a `content://` URI served by ML Kit's
+/// own FileProvider, and even the `file://` form points into a scratch
+/// directory the app has no business opening by path. Reading it by path is why
+/// scanning appeared to do nothing on Android - the read failed, the failure
+/// looked exactly like a cancelled scan, and no page ever arrived.
+///
+/// So: try the plain path first (the iOS shape, and the Android shape that
+/// happens to be readable), and on Android fall back to the runner's
+/// `ContentResolver`, which resolves `content://` and `file://` alike. Returns
+/// null when neither route yields bytes.
 @visibleForTesting
-Future<Uint8List?> readScannedFile(String location) async {
+Future<Uint8List?> readScannedFile(String location,
+    {MethodChannel? channel}) async {
+  final direct = await _readLocalFile(location);
+  if (direct != null) return direct;
+  if (defaultTargetPlatform != TargetPlatform.android) return null;
+  return _readThroughContentResolver(location, channel ?? mobileFileChannel);
+}
+
+/// Reads [location] as a filesystem path, normalising a `file://` URI first.
+/// Null when the location isn't a path we can open (a `content://` URI, an
+/// unparseable URI, a missing file) or when the file is empty.
+Future<Uint8List?> _readLocalFile(String location) async {
   var path = location;
+  if (path.startsWith('content://')) return null;
   if (path.startsWith('file://')) {
-    path = Uri.parse(path).toFilePath();
-  } else if (path.startsWith('content://')) {
+    try {
+      path = Uri.parse(path).toFilePath();
+    } on FormatException {
+      return null;
+    } on UnsupportedError {
+      return null;
+    }
+  }
+  try {
+    final file = File(path);
+    if (!await file.exists()) return null;
+    final bytes = await file.readAsBytes();
+    return bytes.isEmpty ? null : bytes;
+  } on FileSystemException {
     return null;
   }
-  final file = File(path);
-  if (!await file.exists()) return null;
-  return file.readAsBytes();
+}
+
+/// Reads [location] whole through the Android runner's `ContentResolver`
+/// (`mobile_file`'s `readUri`), which opens `content://` and `file://` URIs the
+/// same way. Null on any failure - an older runner without the method included.
+Future<Uint8List?> _readThroughContentResolver(
+  String location,
+  MethodChannel channel,
+) async {
+  try {
+    final bytes = await channel.invokeMethod<Uint8List>(
+      'readUri',
+      {'token': location},
+    );
+    if (bytes == null || bytes.isEmpty) return null;
+    return bytes;
+  } on PlatformException {
+    return null;
+  } on MissingPluginException {
+    return null;
+  }
 }

--- a/app/lib/doc_scan_io.dart
+++ b/app/lib/doc_scan_io.dart
@@ -53,9 +53,9 @@ Future<Uint8List?> scanDocumentToPdf() async {
 /// `dart:io`-readable path: depending on the Play Services build it is either a
 /// `file://` URI into the app's cache or a `content://` URI served by ML Kit's
 /// own FileProvider, and even the `file://` form points into a scratch
-/// directory the app has no business opening by path. Reading it by path is why
-/// scanning appeared to do nothing on Android - the read failed, the failure
-/// looked exactly like a cancelled scan, and no page ever arrived.
+/// directory the app has no business opening by path. Reading it by path
+/// therefore fails on some devices, and (before this was split from a cancelled
+/// scan) failed silently: no page, no error.
 ///
 /// So: try the plain path first (the iOS shape, and the Android shape that
 /// happens to be readable), and on Android fall back to the runner's

--- a/app/lib/editor_screen.dart
+++ b/app/lib/editor_screen.dart
@@ -1286,20 +1286,49 @@ class _EditorScreenState extends State<EditorScreen>
     _addTab(tab);
   }
 
+  /// True while a device scan is up. The platform scanner runs one session at a
+  /// time - a second request while the camera is open comes straight back as an
+  /// error ("Another scan is already running") - so a second tap no-ops instead
+  /// of turning into a failure toast.
+  bool _scanInFlight = false;
+
+  /// Runs the device scanner. Null means "no pages": cancelled, unavailable, or
+  /// failed - a failure has already been logged and toasted by the time this
+  /// returns, so callers just stop.
+  ///
+  /// The toast carries the platform's own reason. "The camera never opened" and
+  /// "the capture couldn't be read back" are different bugs with the same
+  /// symptom, and the message has to say which one happened.
+  Future<Uint8List?> _runScan() async {
+    final scan = _documentScanner;
+    if (scan == null || _scanInFlight) return null;
+    _scanInFlight = true;
+    try {
+      return await scan();
+    } catch (e) {
+      AppDevTools.instance.addLog('scan failed: $e', level: DevLogLevel.error);
+      if (mounted) {
+        _toast(_scanFailureMessage(e), duration: const Duration(seconds: 6));
+      }
+      return null;
+    } finally {
+      _scanInFlight = false;
+    }
+  }
+
+  /// The localized "couldn't scan" sentence plus the underlying error, trimmed
+  /// to something a snack bar can hold.
+  String _scanFailureMessage(Object error) {
+    var detail = error.toString();
+    if (detail.length > 140) detail = '${detail.substring(0, 140)}…';
+    return '${appL10n(context).editorScanFailed} $detail';
+  }
+
   /// Scans a document with the device camera (mobile/tablet only) and opens
   /// the captured pages as a new tab. The scanner returns the pages as a PDF;
   /// a cancelled scan is a silent no-op, a failed one toasts.
   Future<void> _newDocumentFromScan() async {
-    final scan = _documentScanner;
-    if (scan == null) return;
-    final Uint8List? bytes;
-    try {
-      bytes = await scan();
-    } catch (e) {
-      AppDevTools.instance.addLog('scan failed: $e', level: DevLogLevel.error);
-      if (mounted) _toast(appL10n(context).editorScanFailed);
-      return;
-    }
+    final bytes = await _runScan();
     if (!mounted || bytes == null) return;
     final tab = DocumentTab.document(
       title: _nextUntitledTitle(),
@@ -1314,17 +1343,9 @@ class _EditorScreenState extends State<EditorScreen>
   /// Scans a document (mobile/tablet only) and inserts its pages into [tab]'s
   /// edit session, after the page currently in view. One undoable step.
   Future<void> _insertScan(DocumentTab tab) async {
-    final scan = _documentScanner;
     final session = tab.session;
-    if (scan == null || session == null) return;
-    final Uint8List? bytes;
-    try {
-      bytes = await scan();
-    } catch (e) {
-      AppDevTools.instance.addLog('scan failed: $e', level: DevLogLevel.error);
-      if (mounted) _toast(appL10n(context).editorScanFailed);
-      return;
-    }
+    if (session == null) return;
+    final bytes = await _runScan();
     if (!mounted || bytes == null) return;
     final insertedAt = (tab.viewer?.currentPage ?? 0) + 1;
     try {
@@ -2223,7 +2244,10 @@ class _EditorScreenState extends State<EditorScreen>
     ];
   }
 
-  void _toast(String message) {
+  /// Shows a transient message. [duration] overrides the default for the rare
+  /// toast that carries something to read rather than to acknowledge (an error
+  /// with the platform's reason in it).
+  void _toast(String message, {Duration? duration}) {
     // Toasts are transient; mirroring them into the devtools log keeps a
     // history (and puts them in the exported snapshot).
     AppDevTools.instance.addLog('toast: $message');
@@ -2233,7 +2257,7 @@ class _EditorScreenState extends State<EditorScreen>
         content: Text(message),
         behavior: SnackBarBehavior.floating,
         margin: pdfFloatingToastMargin(context),
-        duration: const Duration(seconds: 2),
+        duration: duration ?? const Duration(seconds: 2),
       ));
   }
 

--- a/app/test/doc_scan_io_test.dart
+++ b/app/test/doc_scan_io_test.dart
@@ -52,6 +52,13 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
+  test('DocumentScanException names the location it could not read', () {
+    // This string is what reaches the dev log behind the "Couldn't scan"
+    // toast, so it has to carry the URI that failed.
+    const e = DocumentScanException('content://media/document/1');
+    expect(e.toString(), contains('content://media/document/1'));
+  });
+
   group('readScannedFile', () {
     late Directory dir;
     setUp(() => dir = Directory.systemTemp.createTempSync('doc_scan_test'));
@@ -113,6 +120,21 @@ void main() {
         await readScannedFile('content://media/document/1', channel: channel),
         isNull,
       );
+    });
+
+    test('falls back for a file:// URI that is not a path at all', () async {
+      // An authority ("file://host/x.pdf") and a malformed one both blow up in
+      // toFilePath/parse; neither may take the read down with it.
+      final tokens = mockReadUri(Uint8List.fromList([37, 80, 68, 70]));
+      expect(
+        await readScannedFile('file://example.com/scan.pdf', channel: channel),
+        [37, 80, 68, 70],
+      );
+      expect(
+        await readScannedFile('file://[bad/scan.pdf', channel: channel),
+        [37, 80, 68, 70],
+      );
+      expect(tokens, ['file://example.com/scan.pdf', 'file://[bad/scan.pdf']);
     });
 
     test('treats an empty scan file as unreadable', () async {

--- a/app/test/doc_scan_io_test.dart
+++ b/app/test/doc_scan_io_test.dart
@@ -1,19 +1,52 @@
+// Reading back what the device document scanner produced. iOS hands over a
+// bare filesystem path; Android hands over a Uri into ML Kit's own scratch
+// space whose scheme depends on the Play Services build, so the plain-path read
+// is only the fast path there and the runner's ContentResolver
+// (`mobile_file`'s `readUri`) is the fallback. The native handler itself needs
+// on-device verification; these cover the Dart contract.
 @TestOn('vm')
 library;
 
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:dart_pdf_editor_app/doc_scan_io.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  const channel = MethodChannel('test/doc_scan_uri');
+
+  /// Installs a fake runner that serves [bytes] for any `readUri` call,
+  /// recording the tokens it was asked for. A null [bytes] fails the read.
+  List<String> mockReadUri(Uint8List? bytes) {
+    final tokens = <String>[];
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method != 'readUri') return null;
+      tokens.add(call.arguments['token'] as String);
+      if (bytes == null) {
+        throw PlatformException(code: 'read_failed', message: 'no such uri');
+      }
+      return bytes;
+    });
+    return tokens;
+  }
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
   test('documentScanSupported is true only on mobile', () {
     for (final platform in TargetPlatform.values) {
       debugDefaultTargetPlatformOverride = platform;
-      final expected = platform == TargetPlatform.android ||
-          platform == TargetPlatform.iOS;
+      final expected =
+          platform == TargetPlatform.android || platform == TargetPlatform.iOS;
       expect(documentScanSupported, expected, reason: '$platform');
     }
     debugDefaultTargetPlatformOverride = null;
@@ -27,16 +60,76 @@ void main() {
     test('reads a plain path (iOS) and a file:// URI (Android)', () async {
       final file = File('${dir.path}/scan.pdf')..writeAsBytesSync([37, 80, 68]);
       // iOS hands back a bare filesystem path; Android a file:// URI.
-      expect(await readScannedFile(file.path), [37, 80, 68]);
-      expect(await readScannedFile(file.uri.toString()), [37, 80, 68]);
+      expect(await readScannedFile(file.path, channel: channel), [37, 80, 68]);
+      expect(
+        await readScannedFile(file.uri.toString(), channel: channel),
+        [37, 80, 68],
+      );
     });
 
-    test('returns null for a content:// URI it cannot read', () async {
-      expect(await readScannedFile('content://media/document/1'), isNull);
+    test('reads a readable path without touching the runner', () async {
+      final file = File('${dir.path}/scan.pdf')..writeAsBytesSync([37, 80, 68]);
+      final tokens = mockReadUri(Uint8List.fromList([1, 2, 3]));
+      expect(await readScannedFile(file.path, channel: channel), [37, 80, 68]);
+      expect(tokens, isEmpty);
     });
 
-    test('returns null for a missing file', () async {
-      expect(await readScannedFile('${dir.path}/does-not-exist.pdf'), isNull);
+    test('reads a content:// URI through the runner', () async {
+      // The shape that made scanning look like a no-op on Android: dart:io
+      // can't open it, so the read has to go through the ContentResolver.
+      final tokens = mockReadUri(Uint8List.fromList([37, 80, 68, 70]));
+      expect(
+        await readScannedFile('content://media/document/1', channel: channel),
+        [37, 80, 68, 70],
+      );
+      expect(tokens, ['content://media/document/1']);
+    });
+
+    test('falls back to the runner for a file:// URI it cannot open', () async {
+      // ML Kit's cache Uri can name a path the app can't open by path; the
+      // ContentResolver still resolves it.
+      final missing = File('${dir.path}/gone.pdf').uri.toString();
+      final tokens = mockReadUri(Uint8List.fromList([37, 80, 68, 70]));
+      expect(
+        await readScannedFile(missing, channel: channel),
+        [37, 80, 68, 70],
+      );
+      expect(tokens, [missing]);
+    });
+
+    test('returns null when the runner cannot read it either', () async {
+      mockReadUri(null);
+      expect(
+        await readScannedFile('content://media/document/1', channel: channel),
+        isNull,
+      );
+      expect(await readScannedFile('${dir.path}/nope.pdf', channel: channel),
+          isNull);
+    });
+
+    test('returns null on an older runner without readUri', () async {
+      // No mock handler installed: invokeMethod throws MissingPluginException.
+      expect(
+        await readScannedFile('content://media/document/1', channel: channel),
+        isNull,
+      );
+    });
+
+    test('treats an empty scan file as unreadable', () async {
+      final empty = File('${dir.path}/empty.pdf')..writeAsBytesSync([]);
+      mockReadUri(null);
+      expect(await readScannedFile(empty.path, channel: channel), isNull);
+    });
+
+    test('does not reach for the runner off Android', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final tokens = mockReadUri(Uint8List.fromList([37, 80, 68]));
+      expect(
+        await readScannedFile('content://media/document/1', channel: channel),
+        isNull,
+      );
+      expect(tokens, isEmpty);
+      debugDefaultTargetPlatformOverride = null;
     });
   });
 }

--- a/app/test/doc_scan_menu_test.dart
+++ b/app/test/doc_scan_menu_test.dart
@@ -9,6 +9,8 @@
 // enables the semantics tree, and a later document swap (the insert path)
 // re-renders the viewer, which trips a debug semantics-build assertion. Keeping
 // semantics off sidesteps that framework check.
+import 'dart:async';
+
 import 'package:dart_pdf_editor/dart_pdf_editor.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -148,7 +150,13 @@ void main() {
     await tester.pump(); // reject the future
     await tester.pump(); // show the snack bar
 
-    expect(find.text("Couldn't scan the document."), findsOneWidget);
+    // The toast carries the platform's own reason after the sentence - which
+    // failure it was is the whole diagnostic value.
+    expect(
+      find.textContaining("Couldn't scan the document."),
+      findsOneWidget,
+    );
+    expect(find.textContaining('scanner unavailable'), findsOneWidget);
     expect(find.text('Untitled.pdf'), findsNothing);
   });
 
@@ -169,7 +177,43 @@ void main() {
     await tester.pump(); // reject the future
     await tester.pump(); // show the snack bar
 
-    expect(find.text("Couldn't scan the document."), findsOneWidget);
+    // The toast carries the platform's own reason after the sentence - which
+    // failure it was is the whole diagnostic value.
+    expect(
+      find.textContaining("Couldn't scan the document."),
+      findsOneWidget,
+    );
+    expect(find.textContaining('scanner unavailable'), findsOneWidget);
+  });
+
+  testWidgets('a second scan request while one is up is ignored',
+      (tester) async {
+    // The platform scanner runs one session at a time and answers a second
+    // request with an error instead of a camera, so the app must not make one.
+    var scanned = 0;
+    final gate = Completer<Uint8List?>();
+    await tester.pumpWidget(MaterialApp(
+      home: EditorScreen(
+        prefs: prefs,
+        documentScanner: () {
+          scanned++;
+          return gate.future;
+        },
+      ),
+    ));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    await openMenu(tester);
+    await tester.tap(find.byKey(const ValueKey('menu-scan-document')));
+    await tester.pump();
+    await openMenu(tester);
+    await tester.tap(find.byKey(const ValueKey('menu-scan-document')));
+    await tester.pump();
+
+    expect(scanned, 1);
+    gate.complete(null); // cancel, so the in-flight scan settles
+    await tester.pumpAndSettle();
   });
 
   testWidgets('no scan entries where scanning is unsupported', (tester) async {

--- a/doc/dev-log/2026-08-13-android-scan-read-back.md
+++ b/doc/dev-log/2026-08-13-android-scan-read-back.md
@@ -1,0 +1,61 @@
+# Android: "Scan to new document" produced nothing
+
+"Scan to new document" (and "Insert scan") appeared to do nothing on Android:
+the ML Kit scanner opened, the user captured and accepted pages, and no tab
+ever showed up - with no error either.
+
+## Cause
+
+The whole scan flow is platform-agnostic except one step: reading back the PDF
+the scanner wrote. `doc_scan_io.dart` did that with `dart:io`:
+
+```dart
+if (path.startsWith('file://')) path = Uri.parse(path).toFilePath();
+else if (path.startsWith('content://')) return null;   // <- Android
+final file = File(path);
+if (!await file.exists()) return null;                 // <- Android
+```
+
+Two problems, and they compound:
+
+1. **Android's location isn't reliably a path.** iOS hands back a bare
+   filesystem path, but Android hands back whatever
+   `GmsDocumentScanningResult.Pdf.getUri()` produced - a `content://` URI from
+   ML Kit's own FileProvider on some Play Services builds, a `file://` URI into
+   a scratch directory on others, and either way a location ML Kit owns rather
+   than one the app may open by path. The `content://` branch returned null
+   outright; the `file://` branch could miss too.
+2. **A failed read was indistinguishable from a cancelled scan.** Both came
+   back as `null`, and `_newDocumentFromScan` treats null as "the user backed
+   out" - a deliberate silent no-op. So the failure had no toast, no dev-log
+   line, nothing.
+
+## Fix
+
+- **Read through the ContentResolver on Android.** The app's runner already
+  owns a `mobile_file` method channel with `ContentResolver`-backed helpers
+  (`fileLength`/`readRange`, from the reference-based open work); it gained
+  `readUri`, a whole-file read via `contentResolver.openInputStream`, which
+  resolves `content://` and `file://` alike. `readScannedFile` tries the plain
+  path first (the iOS shape, and the Android shape that happens to be readable)
+  and falls back to `readUri` on Android only. An older runner without the
+  method (`MissingPluginException`) degrades to the previous behaviour rather
+  than throwing.
+- **Null now means cancelled, and only cancelled.** `scanDocumentToPdf` throws
+  `DocumentScanException` (carrying the location it couldn't read) when a scan
+  completed but its PDF couldn't be read back. The menu handlers already catch,
+  toast "Couldn't scan the document.", and log to `AppDevTools` - so the URI
+  that failed now lands in the dev log instead of vanishing.
+
+## Notes
+
+- Read the result **immediately**: ML Kit reclaims its scratch space once the
+  scanner activity is gone, so the bytes have to be pulled on the callback, not
+  held as a path for later. The flow already did this; keep it that way.
+- The Kotlin `readUri` handler mirrors the existing `readRange`/`fileLength`
+  ones (same `fileIoExecutor`, same `read_failed` error code) and, like them,
+  needs on-device verification - it can't run in `flutter test`.
+- `doc_scan_io_test.dart` covers the Dart contract with a mocked channel: plain
+  path wins without touching the runner, `content://` and unopenable `file://`
+  go through it, an empty file counts as unreadable, and non-Android platforms
+  never reach for it.

--- a/doc/dev-log/2026-08-13-android-scan-read-back.md
+++ b/doc/dev-log/2026-08-13-android-scan-read-back.md
@@ -1,10 +1,10 @@
-# Android: "Scan to new document" produced nothing
+# Android document scan: read-back, and making failures say what failed
 
-"Scan to new document" (and "Insert scan") appeared to do nothing on Android:
-the ML Kit scanner opened, the user captured and accepted pages, and no tab
-ever showed up - with no error either.
+Two separate things, both reported as "Scan to new document doesn't work on
+Android". Keeping them apart matters, because they have the same symptom from
+the outside and completely different causes.
 
-## Cause
+## 1. The read-back was wrong on Android (fixed)
 
 The whole scan flow is platform-agnostic except one step: reading back the PDF
 the scanner wrote. `doc_scan_io.dart` did that with `dart:io`:
@@ -16,46 +16,79 @@ final file = File(path);
 if (!await file.exists()) return null;                 // <- Android
 ```
 
-Two problems, and they compound:
+iOS hands back a bare filesystem path, but Android hands back whatever
+`GmsDocumentScanningResult.Pdf.getUri()` produced — a `content://` URI from ML
+Kit's own FileProvider on some Play Services builds, a `file://` URI into a
+scratch directory on others, and either way a location ML Kit owns rather than
+one the app may open by path. The `content://` branch bailed outright; the
+`file://` branch could miss too.
 
-1. **Android's location isn't reliably a path.** iOS hands back a bare
-   filesystem path, but Android hands back whatever
-   `GmsDocumentScanningResult.Pdf.getUri()` produced - a `content://` URI from
-   ML Kit's own FileProvider on some Play Services builds, a `file://` URI into
-   a scratch directory on others, and either way a location ML Kit owns rather
-   than one the app may open by path. The `content://` branch returned null
-   outright; the `file://` branch could miss too.
-2. **A failed read was indistinguishable from a cancelled scan.** Both came
-   back as `null`, and `_newDocumentFromScan` treats null as "the user backed
-   out" - a deliberate silent no-op. So the failure had no toast, no dev-log
-   line, nothing.
+Worse, **a failed read was indistinguishable from a cancelled scan**: both
+returned `null`, and `_newDocumentFromScan` treats `null` as "the user backed
+out" — a deliberate silent no-op. No tab, no toast, no dev-log line.
 
-## Fix
+Fix:
 
-- **Read through the ContentResolver on Android.** The app's runner already
-  owns a `mobile_file` method channel with `ContentResolver`-backed helpers
-  (`fileLength`/`readRange`, from the reference-based open work); it gained
-  `readUri`, a whole-file read via `contentResolver.openInputStream`, which
-  resolves `content://` and `file://` alike. `readScannedFile` tries the plain
-  path first (the iOS shape, and the Android shape that happens to be readable)
-  and falls back to `readUri` on Android only. An older runner without the
-  method (`MissingPluginException`) degrades to the previous behaviour rather
-  than throwing.
-- **Null now means cancelled, and only cancelled.** `scanDocumentToPdf` throws
-  `DocumentScanException` (carrying the location it couldn't read) when a scan
-  completed but its PDF couldn't be read back. The menu handlers already catch,
-  toast "Couldn't scan the document.", and log to `AppDevTools` - so the URI
-  that failed now lands in the dev log instead of vanishing.
+- `readUri` on the runner's `mobile_file` channel (`MainActivity.kt`): a
+  whole-file read via `contentResolver.openInputStream`, which resolves
+  `content://` and `file://` alike, on the same IO executor as the existing
+  ranged reads.
+- `readScannedFile` tries the plain path first (the iOS shape, and the Android
+  shape that happens to be readable) and falls back to `readUri` on Android
+  only. An older runner without the method degrades to the previous behaviour.
+- `scanDocumentToPdf` throws `DocumentScanException` (carrying the location)
+  when a scan completed but its PDF could not be read. `null` means cancelled
+  and only cancelled.
+
+Read the result **immediately**: ML Kit reclaims its scratch space once the
+scanner activity is gone, so the bytes have to be pulled on the callback, not
+held as a path for later. The flow already did this; keep it that way.
+
+## 2. The camera not opening at all is a *different* failure
+
+Reported after the above landed: pressing "Scan to new document" shows the
+error snack bar instantly and no camera ever appears. That is upstream of the
+read-back — `FlutterDocScanner().getScannedDocumentAsPdf()` threw before the
+scanner activity launched. The plugin's Android side can fail there in three
+ways, and the old UI could not tell them apart because the toast was a fixed
+sentence and the reason only went to `AppDevTools`:
+
+- `SCAN_FAILED` from `getStartScanIntent`'s failure listener — Google Play
+  services unavailable or too old (**every emulator image without the Play
+  Store**), the doc-scanner module not yet downloaded (it is fetched on demand,
+  so the first call can fail while it downloads), or `MlKitException UNSUPPORTED`
+  on a device with less than 1.7 GB total RAM, which the API requires.
+- `SCAN_IN_PROGRESS` — the plugin keeps a single `pendingResult` and rejects a
+  second request while one is outstanding. It is cleared on success, on error,
+  and on `onDetachedFromActivity`; a scan whose activity result never comes back
+  leaves it set, and then *every* later press errors instantly with no camera
+  until the process restarts. Force-stopping the app and pressing once
+  distinguishes this from the launch failures above.
+- `NO_ACTIVITY` — no foreground activity attached.
+
+So this session's second half is about making the failure legible rather than
+guessing:
+
+- `_runScan` in `editor_screen.dart` is now the single scan entry point for both
+  menu actions. Its toast appends the error's own `toString()` (trimmed to 140
+  chars) to the localized sentence — `DocScanException(SCAN_FAILED): Unable to
+  start document scanner` is exactly the string that identifies the cause — and
+  runs for 6s instead of 2 so it can be read. No new ARB keys, so no
+  20-locale churn.
+- `_scanInFlight` guards re-entrancy, so the app can never manufacture a
+  `SCAN_IN_PROGRESS` itself from a double tap.
+
+`_toast` gained an optional `duration` for this; everything else keeps the 2s
+default.
 
 ## Notes
 
-- Read the result **immediately**: ML Kit reclaims its scratch space once the
-  scanner activity is gone, so the bytes have to be pulled on the callback, not
-  held as a path for later. The flow already did this; keep it that way.
 - The Kotlin `readUri` handler mirrors the existing `readRange`/`fileLength`
-  ones (same `fileIoExecutor`, same `read_failed` error code) and, like them,
-  needs on-device verification - it can't run in `flutter test`.
-- `doc_scan_io_test.dart` covers the Dart contract with a mocked channel: plain
-  path wins without touching the runner, `content://` and unopenable `file://`
-  go through it, an empty file counts as unreadable, and non-Android platforms
-  never reach for it.
+  ones and, like them, needs on-device verification — it can't run in
+  `flutter test`.
+- `doc_scan_io_test.dart` covers the Dart read-back contract with a mocked
+  channel; `doc_scan_menu_test.dart` covers the toast carrying the reason and
+  the re-entrancy guard.
+- The ML Kit doc scanner has no `com.google.mlkit.vision.DEPENDENCIES`
+  manifest meta-data to pre-download it (that mechanism is for the bundled
+  vision APIs) — checked, don't add one.


### PR DESCRIPTION
## Summary

Two separate problems, both reported as "Scan to new document doesn't work on Android". They have the same symptom from the outside and completely different causes, so this PR keeps them apart.

### 1. The read-back was wrong on Android

The scan flow is platform-agnostic except one step: reading back the PDF the scanner wrote. `app/lib/doc_scan_io.dart` did that with `dart:io`, which is wrong on Android in two compounding ways:

1. **The location isn't reliably a path.** iOS hands back a bare filesystem path, but Android hands back whatever `GmsDocumentScanningResult.Pdf.getUri()` produced — a `content://` URI from ML Kit's own FileProvider on some Play Services builds, a `file://` URI into a scratch directory on others, and either way a location ML Kit owns rather than one the app may open by path. The old code returned `null` outright for `content://`, and the `file://` branch could miss too.
2. **A failed read looked exactly like a cancelled scan.** Both returned `null`, and `_newDocumentFromScan` treats `null` as "the user backed out" — a deliberate silent no-op. No tab, no toast, no dev-log line.

Fix:

- **`readUri` on the runner's `mobile_file` channel** (`MainActivity.kt`): a whole-file read via `contentResolver.openInputStream`, which resolves `content://` and `file://` alike, on the same IO executor and with the same `read_failed` error code as the existing `readRange`/`fileLength` handlers.
- **`readScannedFile`** tries the plain path first (the iOS shape, and the Android shape that happens to be readable) and falls back to `readUri` on Android only. An older runner without the method (`MissingPluginException`) degrades to the previous behaviour rather than throwing.
- **`scanDocumentToPdf` throws `DocumentScanException`**, carrying the location, when a scan completed but its PDF could not be read back. `null` means cancelled and only cancelled.

### 2. Failures now say what failed

Reported after the above landed: pressing "Scan to new document" shows the error snack bar **instantly and no camera ever opens**. That is upstream of the read-back — `getScannedDocumentAsPdf()` threw before the scanner activity launched. The plugin's Android side can fail there three ways, and the old UI could not tell them apart because the toast was a fixed sentence and the reason went only to `AppDevTools`:

| Error | Cause |
|---|---|
| `SCAN_FAILED` | `getStartScanIntent` failed — Play services unavailable or too old (any emulator image without the Play Store), the doc-scanner module not yet downloaded (fetched on demand, so the first call can fail while it downloads), or `MlKitException UNSUPPORTED` under the API's 1.7 GB total-RAM floor |
| `SCAN_IN_PROGRESS` | The plugin keeps one `pendingResult`; a scan whose activity result never comes back leaves it set, and every later press then errors instantly with no camera until the process restarts |
| `NO_ACTIVITY` | No foreground activity attached |

So:

- **`_runScan`** is now the single scan entry point for both menu actions. Its toast appends the error's own `toString()` (trimmed to 140 chars) to the localized sentence — `DocScanException(SCAN_FAILED): Unable to start document scanner` is exactly the string that identifies the cause — and runs for 6s instead of 2 so it can be read. No new ARB keys, so no 20-locale churn.
- **`_scanInFlight`** guards re-entrancy, so a double tap can't manufacture a `SCAN_IN_PROGRESS` from the app side.
- `_toast` gained an optional `duration`; the 2s default is unchanged.

Dev-log note: `doc/dev-log/2026-08-13-android-scan-read-back.md`. No API change outside the app; the `DocumentScanner` seam and both menu entries behave as before on iOS.

## Affected packages

- [ ] `pdf_cos`
- [ ] `pdf_document`
- [ ] `pdf_graphics`
- [ ] `dart_pdf_editor`
- [ ] `pdf_test_fixtures`
- [x] Example app <!-- the DartPDF app under app/ -->
- [x] Documentation / CI / repository metadata only <!-- dev-log entry -->

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Rendering change
- [ ] Editing behavior change
- [ ] Performance change
- [ ] Refactor / cleanup
- [ ] Tests / fixtures only
- [ ] Documentation only

## Validation

- [x] `fvm flutter pub get`
- [x] `fvm dart analyze` (clean over `app/`)
- [ ] `cd packages/pdf_cos && fvm dart test`
- [ ] `cd packages/pdf_document && fvm dart test`
- [ ] `cd packages/pdf_graphics && fvm dart test`
- [ ] `cd packages/dart_pdf_editor && fvm flutter test`
- [ ] Ghent corpus test or baseline update
- [ ] Real PDF corpus parse/render smoke test
- [ ] Example app smoke test

Ran `cd app && fvm flutter test test/doc_scan_io_test.dart test/doc_scan_menu_test.dart` — 21/21 pass. Full CI green.

If any relevant check was not run, explain why: the change touches only the app's document-scan path and the Android runner, so the parser/renderer suites and the corpus sweeps are unaffected. **The Kotlin `readUri` handler could not be compiled or exercised here** — this environment has no Android SDK and no device, and the ML Kit scanner needs a real camera plus Play Services. It needs an on-device pass before merge.

## PDF fixtures and screenshots

None — this is about launching the scanner and reading bytes back from it, not about PDF content.

## Compatibility checklist

- [x] No `dart:ui` or Flutter imports outside `packages/dart_pdf_editor`.
- [x] No `dart:io` imports in any `lib/` directory. <!-- unchanged: app/lib/doc_scan_io.dart is the app's native-only half, reached through a conditional export, and already imported dart:io; the packages' lib/ trees are untouched -->
- [x] Layering is preserved: `pdf_cos` <- `pdf_document` <- `pdf_graphics` <- `dart_pdf_editor`.
- [x] Parsers remain lenient on real-world input and writers remain strict on output.
- [x] Raw PDF stream bytes stay lazy/raw until decoding is required.
- [x] Test fixtures use builders/programmatic generation instead of hand-edited byte offsets.

## Notes for reviewers

- **Part 1 is a real bug but is not what the "no camera opens" report is describing** — that is part 2's territory, and part 2 is deliberately diagnostics rather than a speculative fix: which of the three launch failures it is can't be determined from here, and each has a different remedy. Once the on-device toast names the code, the follow-up is targeted.
- Ruled out from here: the plugin is registered normally for Android; `FlutterActivity extends Activity`, so the plugin's >16-bit request code and result delivery through `MainActivity.onActivityResult` are fine; and the ML Kit doc scanner has no `com.google.mlkit.vision.DEPENDENCIES` manifest meta-data to pre-download it (that mechanism is for the bundled vision APIs).
- ML Kit reclaims its scratch space once the scanner activity is gone, so the bytes must be pulled on the callback rather than held as a path for later. The flow already did that; the doc comments now say why it must stay that way.
- `getScannedDocumentAsPdf()` still uses the plugin's default page limit of 4 per scan session. Left alone to keep this tight — worth raising separately if longer scans are wanted.