### PR TITLE
Add DartPDF CLI, MCP server, and desktop sidecars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,21 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+      - name: Test dart_pdf_cli
+        working-directory: packages/dart_pdf_cli
+        run: |
+          dart test --coverage=coverage
+          dart pub global run coverage:format_coverage \
+            --lcov --in=coverage --out=coverage/lcov.info \
+            --report-on=lib --packages=../../.dart_tool/package_config.json
+      - name: Upload dart_pdf_cli coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: packages/dart_pdf_cli/coverage/lcov.info
+          flags: dart_pdf_cli
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: Test dart_pdf_editor
         working-directory: packages/dart_pdf_editor
         run: flutter test --coverage

--- a/.github/workflows/nightly-windows.yml
+++ b/.github/workflows/nightly-windows.yml
@@ -99,6 +99,8 @@ jobs:
             --build-number="${{ github.run_number }}" `
             --dart-define="PDF_BUILD_COMMIT=${{ needs.changes.outputs.head_sha }}"
           if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed ($LASTEXITCODE)" }
+          & build/windows/x64/runner/Release/dartpdf.exe --version
+          if ($LASTEXITCODE -ne 0) { throw "dartpdf.exe smoke check failed ($LASTEXITCODE)" }
 
       - name: Package portable build
         working-directory: app

--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -127,6 +127,7 @@ jobs:
           flatpak install --user --noninteractive -y \
             dartpdf-local "$FLATPAK_ID//stable"
           flatpak info --user "$FLATPAK_ID"
+          flatpak run --user --command=dartpdf-cli "$FLATPAK_ID" --version
           set +e
           timeout 12s dbus-run-session -- xvfb-run -a \
             flatpak run --user "$FLATPAK_ID" \

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -91,6 +91,7 @@ jobs:
           snap_file="$(find "$RUNNER_TEMP/snap-output" -name 'dartpdf_*.snap' -print -quit)"
           sudo snap install --dangerous "$snap_file"
           snap info "$SNAP_NAME"
+          sudo snap run "$SNAP_NAME.cli" --version
           set +e
           # GitHub hosts the runner inside a non-interactive system service,
           # so its user has no PAM-created session cgroup for snap-confine.
@@ -133,6 +134,7 @@ jobs:
           sudo snap install "$SNAP_NAME"
           [[ "$(snap info "$SNAP_NAME" | sed -n 's/^installed:[[:space:]]*\([^[:space:]]*\).*/\1/p')" == \
             "$EXPECTED_VERSION" ]]
+          sudo snap run "$SNAP_NAME.cli" --version
           set +e
           sudo install -d -m 700 /run/user/0 /root/snap/dartpdf/common
           sudo env XDG_RUNTIME_DIR=/run/user/0 \

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -178,7 +178,9 @@ jobs:
       - run: flutter pub get
       - name: Build Linux
         working-directory: app
-        run: flutter build linux --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
+        run: |
+          flutter build linux --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
+          build/linux/x64/release/bundle/dartpdf-cli --version
       - name: Tar bundle (portable folder)
         working-directory: app
         # The bundle now carries the desktop-integration files under share/
@@ -238,7 +240,12 @@ jobs:
       - run: flutter pub get
       - name: Build Windows
         working-directory: app
-        run: flutter build windows --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }} --dart-define=PDF_BUILD_COMMIT=${{ github.sha }}
+        shell: pwsh
+        run: |
+          flutter build windows --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }} --dart-define=PDF_BUILD_COMMIT=${{ github.sha }}
+          if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed ($LASTEXITCODE)" }
+          & build/windows/x64/runner/Release/dartpdf.exe --version
+          if ($LASTEXITCODE -ne 0) { throw "dartpdf.exe smoke check failed ($LASTEXITCODE)" }
       - name: Bundle MSVC runtime (makes the folder portable on clean PCs)
         working-directory: app
         shell: pwsh
@@ -370,9 +377,43 @@ jobs:
             app/dartpdf-windows-portable.exe
             app/dartpdf-windows-installer.exe
 
-  macos:
+  macos_cli:
+    name: Build macOS CLI (${{ matrix.arch }})
     needs: setup
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+      - run: flutter pub get
+      - name: Compile native CLI/MCP slice
+        run: |
+          dart tool/build_desktop_cli.dart \
+            --output app/build/dartpdf-cli/dartpdf-${{ matrix.arch }} \
+            --target-os macos \
+            --target-arch ${{ matrix.arch }}
+          file app/build/dartpdf-cli/dartpdf-${{ matrix.arch }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: macos-cli-${{ matrix.arch }}
+          path: app/build/dartpdf-cli/dartpdf-${{ matrix.arch }}
+
+  macos:
+    needs: [setup, macos_cli]
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -398,6 +439,21 @@ jobs:
       - name: Build macOS
         working-directory: app
         run: flutter build macos --release --build-name=${{ needs.setup.outputs.version }} --build-number=${{ github.run_number }}
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: macos-cli-*
+          path: app/build/dartpdf-cli-slices
+          merge-multiple: true
+      - name: Install universal CLI/MCP sidecar
+        working-directory: app
+        run: |
+          /usr/bin/lipo -create \
+            build/dartpdf-cli-slices/dartpdf-arm64 \
+            build/dartpdf-cli-slices/dartpdf-x64 \
+            -output build/macos/Build/Products/Release/DartPDF.app/Contents/MacOS/dartpdf-cli
+          chmod 755 build/macos/Build/Products/Release/DartPDF.app/Contents/MacOS/dartpdf-cli
+          /usr/bin/lipo -info build/macos/Build/Products/Release/DartPDF.app/Contents/MacOS/dartpdf-cli
+          build/macos/Build/Products/Release/DartPDF.app/Contents/MacOS/dartpdf-cli --version
       - name: Ad-hoc sign macOS app with distributable entitlements
         working-directory: app
         env:
@@ -456,7 +512,15 @@ jobs:
         with:
           name: DartPDF ${{ needs.setup.outputs.version }}
           draft: true
-          files: artifacts/**/*
+          # The macos-cli-* artifacts are internal slices used to create the
+          # universal sidecar; only user-facing package artifacts are released.
+          files: |
+            artifacts/android/**/*
+            artifacts/web/**/*
+            artifacts/linux/**/*
+            artifacts/windows/**/*
+            artifacts/macos/**/*
+            artifacts/ios/**/*
           body: |
             Standalone DartPDF ${{ needs.setup.outputs.version }}.
 

--- a/README.md
+++ b/README.md
@@ -86,14 +86,15 @@ offline harnesses and file-by-file diffs live in [`benchmark/`](benchmark).
 ## Architecture
 
 Strictly layered packages; `dart:ui` is only allowed in `dart_pdf_editor`, so
-the core runs on servers and in plain Dart tests. Each package is
-published on pub.dev under its directory name.
+the core runs on servers and in plain Dart tests. Published packages use their
+directory name on pub.dev.
 
 | Package | pub.dev | Role |
 |---|---|---|
 | [`pdf_cos`](packages/pdf_cos) | [![pub package](https://img.shields.io/pub/v/pdf_cos.svg)](https://pub.dev/packages/pdf_cos) | The PDF file format itself: tokenizer, parser, filters (incl. CCITT/JBIG2/JPX), encryption, cross-reference machinery, serializer, crypto primitives. |
 | [`pdf_document`](packages/pdf_document) | [![pub package](https://img.shields.io/pub/v/pdf_document.svg)](https://pub.dev/packages/pdf_document) | Document semantics: page tree, annotations, AcroForm, digital signatures, and the incremental-save `PdfEditor`. |
 | [`pdf_graphics`](packages/pdf_graphics) | [![pub package](https://img.shields.io/pub/v/pdf_graphics.svg)](https://pub.dev/packages/pdf_graphics) | Content-stream interpreter, device interface, font engine, ICC color, text extraction. |
+| [`dart_pdf_cli`](packages/dart_pdf_cli) | — | Pure-Dart `dartpdf` command line and stdio MCP server for bounded document inspection, text extraction, form listing, and annotation listing. |
 | [`dart_pdf_editor`](packages/dart_pdf_editor) | [![pub package](https://img.shields.io/pub/v/dart_pdf_editor.svg)](https://pub.dev/packages/dart_pdf_editor) | Flutter viewer and editing UI: canvas device, `PdfViewer`, tools, panels, forms. |
 | [`dart_pdf_editor_flutter_gpu`](packages/dart_pdf_editor_flutter_gpu) | [![pub package](https://img.shields.io/pub/v/dart_pdf_editor_flutter_gpu.svg)](https://pub.dev/packages/dart_pdf_editor_flutter_gpu) | Experimental opt-in Impeller/`flutter_gpu` tile renderer for supported native targets, with exact Canvas fallback for unsupported pages. |
 | [`dart_pdf_editor_assets`](packages/dart_pdf_editor_assets) | [![pub package](https://img.shields.io/pub/v/dart_pdf_editor_assets.svg)](https://pub.dev/packages/dart_pdf_editor_assets) | Optional bundled editor fonts + web render worker (~1.8 MB package download); depend on it and call `registerBundledEditorAssets()` for the full editor, omit for a size-minimal viewer. |
@@ -102,6 +103,19 @@ published on pub.dev under its directory name.
 | [`pdf_test_fixtures`](packages/pdf_test_fixtures) | [![pub package](https://img.shields.io/pub/v/pdf_test_fixtures.svg)](https://pub.dev/packages/pdf_test_fixtures) | Programmatic, structurally-correct PDF builders for tests. |
 
 ## Quick start
+
+For shell, CI, and local agent workflows, run the pure-Dart CLI directly from
+the workspace:
+
+```sh
+dart run packages/dart_pdf_cli/bin/dartpdf.dart inspect document.pdf --json
+dart run packages/dart_pdf_cli/bin/dartpdf.dart text document.pdf --pages 1-5 --json
+```
+
+The same handlers are exposed as bounded, read-only MCP tools through
+`dartpdf mcp`. See the [`dart_pdf_cli` guide](packages/dart_pdf_cli) for
+installation (including the copy bundled in desktop app builds), filesystem
+roots, password handling, and host registration.
 
 For a Flutter app, add the editor package:
 

--- a/app/README.md
+++ b/app/README.md
@@ -53,6 +53,10 @@ AppImage and portable tarball builds remain available from
   JSON. Web keeps Canvas through the companion's compile-time stub; pull-request
   web previews provide macOS, Windows, and Linux download buttons in this
   section for testing the native backend.
+- Desktop builds include the native `dartpdf` CLI and stdio MCP server for
+  bounded inspection, text extraction, form listing, and annotation listing.
+  See [`dart_pdf_cli`](../packages/dart_pdf_cli) for installed paths and agent
+  registration.
 - Dirty-state tracking with a save indicator and crash recovery: unsaved
   revisions are mirrored in the background and offered for restoration after
   a restart.
@@ -104,8 +108,10 @@ cd app && fvm flutter test
 
 ## Build
 
-`flutter build <apk|appbundle|ios|macos|windows|linux|web> --release`. Releases
-are automated on `app-v*` tags. See [RELEASING.md](RELEASING.md).
+`flutter build <apk|appbundle|ios|macos|windows|linux|web> --release`. The three
+desktop native projects compile and bundle the `dartpdf` CLI/MCP sidecar as part
+of the ordinary build. Releases are automated on `app-v*` tags. See
+[RELEASING.md](RELEASING.md).
 
 ## Manual device-test matrix
 

--- a/app/RELEASING.md
+++ b/app/RELEASING.md
@@ -101,6 +101,29 @@ always served fresh, so it skips the check.
 | Linux | `…-linux-x64.tar.gz`, `…-linux-x86_64.AppImage` | Flatpak repository is GPG-signed; raw artifacts are unsigned |
 | Web | `…-web.zip` | n/a |
 
+### Desktop CLI / MCP sidecar
+
+Every macOS, Windows, and Linux native build compiles the VM-only
+`packages/dart_pdf_cli/bin/dartpdf.dart` entrypoint into a self-contained target
+executable. It uses the same architecture as the Flutter runner; a universal
+macOS release compiles its arm64 and x64 slices on native GitHub runners and
+merges them with `lipo` before codesigning. (A local macOS build contains the
+host-native sidecar.) The native project files place it in:
+
+- macOS: `DartPDF.app/Contents/MacOS/dartpdf-cli` (the suffix avoids a
+  case-insensitive collision with the `DartPDF` GUI executable; it is signed as
+  nested code before the outer app bundle);
+- Windows: `dartpdf.exe` beside `dart_pdf_editor_app.exe`;
+- Linux: `dartpdf-cli` beside `dart_pdf_editor_app` (`dartpdf` remains the
+  established GUI launcher in Linux packages).
+
+Because the release packagers archive those native bundles, the sidecar also
+travels in the DMG, Windows installer/portable/MSIX outputs, Linux tarball, and
+AppImage. Linux store packages expose it as `/app/bin/dartpdf-cli` for Flatpak
+and `dartpdf.cli` for Snap; the AUR package installs `/usr/bin/dartpdf-cli`.
+The macOS and Windows installers deliberately do not alter `PATH`. See the CLI
+package README for MCP registration commands.
+
 ## The credential boundary
 
 DartPDF ships to the **RES (Railway Engineering Solutions) Google Play

--- a/app/cmake/dartpdf_cli.cmake
+++ b/app/cmake/dartpdf_cli.cmake
@@ -1,0 +1,62 @@
+# Builds the pure-Dart dartpdf CLI/MCP executable beside the Flutter runner.
+# The including platform file must set DARTPDF_CLI_TARGET_OS and
+# DARTPDF_CLI_OUTPUT_NAME, and must define BINARY_NAME/FLUTTER_MANAGED_DIR.
+
+if(NOT DEFINED DARTPDF_CLI_TARGET_OS OR
+   NOT DEFINED DARTPDF_CLI_OUTPUT_NAME)
+  message(FATAL_ERROR "dartpdf CLI target OS and output name are required")
+endif()
+
+# generated_config.cmake is produced by `flutter build` before CMake configures
+# the runner. The Flutter-managed subdirectory includes it in its own scope;
+# include it here as well so this parent scope can locate the bundled Dart SDK.
+include("${FLUTTER_MANAGED_DIR}/ephemeral/generated_config.cmake")
+
+if(FLUTTER_TARGET_PLATFORM MATCHES "-arm64$")
+  set(DARTPDF_CLI_TARGET_ARCH "arm64")
+elseif(FLUTTER_TARGET_PLATFORM MATCHES "-x64$")
+  set(DARTPDF_CLI_TARGET_ARCH "x64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+  set(DARTPDF_CLI_TARGET_ARCH "arm64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+  set(DARTPDF_CLI_TARGET_ARCH "x64")
+else()
+  message(FATAL_ERROR
+    "Unsupported dartpdf CLI architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+get_filename_component(DARTPDF_REPOSITORY_ROOT
+  "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(DARTPDF_CLI_BUILDER
+  "${DARTPDF_REPOSITORY_ROOT}/tool/build_desktop_cli.dart")
+set(DARTPDF_CLI_OUTPUT
+  "${CMAKE_CURRENT_BINARY_DIR}/dartpdf_cli/${DARTPDF_CLI_OUTPUT_NAME}")
+set(DARTPDF_EXECUTABLE
+  "${FLUTTER_ROOT}/bin/cache/dart-sdk/bin/dart${CMAKE_EXECUTABLE_SUFFIX}")
+
+# CONFIGURE_DEPENDS makes a changed CLI or engine source invalidate the native
+# executable without forcing every no-op desktop build to recompile it.
+file(GLOB_RECURSE DARTPDF_CLI_DART_INPUTS CONFIGURE_DEPENDS
+  "${DARTPDF_REPOSITORY_ROOT}/packages/dart_pdf_cli/*.dart"
+  "${DARTPDF_REPOSITORY_ROOT}/packages/pdf_cos/lib/*.dart"
+  "${DARTPDF_REPOSITORY_ROOT}/packages/pdf_document/lib/*.dart"
+  "${DARTPDF_REPOSITORY_ROOT}/packages/pdf_graphics/lib/*.dart")
+
+add_custom_command(
+  OUTPUT "${DARTPDF_CLI_OUTPUT}"
+  COMMAND "${DARTPDF_EXECUTABLE}" "${DARTPDF_CLI_BUILDER}"
+    --output "${DARTPDF_CLI_OUTPUT}"
+    --target-os "${DARTPDF_CLI_TARGET_OS}"
+    --target-arch "${DARTPDF_CLI_TARGET_ARCH}"
+  DEPENDS
+    "${DARTPDF_CLI_BUILDER}"
+    "${DARTPDF_REPOSITORY_ROOT}/pubspec.yaml"
+    "${DARTPDF_REPOSITORY_ROOT}/pubspec.lock"
+    ${DARTPDF_CLI_DART_INPUTS}
+  WORKING_DIRECTORY "${DARTPDF_REPOSITORY_ROOT}"
+  COMMENT
+    "Building dartpdf CLI (${DARTPDF_CLI_TARGET_OS}/${DARTPDF_CLI_TARGET_ARCH})"
+  VERBATIM)
+
+add_custom_target(dartpdf_cli ALL DEPENDS "${DARTPDF_CLI_OUTPUT}")
+add_dependencies(${BINARY_NAME} dartpdf_cli)

--- a/app/linux/CMakeLists.txt
+++ b/app/linux/CMakeLists.txt
@@ -60,6 +60,13 @@ add_subdirectory("runner")
 # Run the Flutter tool portions of the build. This must not be removed.
 add_dependencies(${BINARY_NAME} flutter_assemble)
 
+# Build the pure-Dart CLI/MCP sidecar for this Linux architecture. It is
+# installed at the bundle root as `dartpdf-cli`, beside the GUI runner. Linux
+# packages already reserve `dartpdf` as their public GUI launcher.
+set(DARTPDF_CLI_TARGET_OS "linux")
+set(DARTPDF_CLI_OUTPUT_NAME "dartpdf-cli")
+include("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/dartpdf_cli.cmake")
+
 # Only the install-generated bundle's copy of the executable will launch
 # correctly, since the resources must in the right relative locations. To avoid
 # people trying to run the unbundled copy, put it in a subdirectory instead of
@@ -92,6 +99,10 @@ set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
 set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
 
 install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(PROGRAMS "${DARTPDF_CLI_OUTPUT}"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}"
   COMPONENT Runtime)
 
 install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"

--- a/app/macos/Runner.xcodeproj/project.pbxproj
+++ b/app/macos/Runner.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 				5975975C07391F9DBA9A20E1 /* [CP] Embed Pods Frameworks */,
+				DA0CDD0F000000000000FB03 /* Build DartPDF CLI */,
 				8A6F08E62E11A00100DAD001 /* Normalize Embedded Code Signatures */,
 			);
 			buildRules = (
@@ -437,6 +438,31 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "bash \"$PROJECT_DIR/resign_embedded_code.sh\" \"$TARGET_BUILD_DIR/$WRAPPER_NAME\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DA0CDD0F000000000000FB03 /* Build DartPDF CLI */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(PROJECT_DIR)/build_dartpdf_cli.sh",
+				"$(PROJECT_DIR)/../../tool/build_desktop_cli.dart",
+				"$(PROJECT_DIR)/../../packages/dart_pdf_cli/bin/dartpdf.dart",
+				"$(PROJECT_DIR)/../../pubspec.lock",
+			);
+			name = "Build DartPDF CLI";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(WRAPPER_NAME)/Contents/MacOS/dartpdf-cli",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash \"$PROJECT_DIR/build_dartpdf_cli.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A405F26670DE5C0390092CB1 /* [CP] Check Pods Manifest.lock */ = {

--- a/app/macos/build_dartpdf_cli.sh
+++ b/app/macos/build_dartpdf_cli.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${FLUTTER_ROOT:-}" || -z "${TARGET_BUILD_DIR:-}" ||
+      -z "${WRAPPER_NAME:-}" ]]; then
+  echo "error: build_dartpdf_cli.sh must run from the macOS Runner target" >&2
+  exit 64
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_dir/../.." && pwd)"
+dart="$FLUTTER_ROOT/bin/cache/dart-sdk/bin/dart"
+# APFS is normally case-insensitive, so `dartpdf` would collide with the GUI's
+# `DartPDF` executable. macOS uses an explicit `dartpdf-cli` sidecar name.
+output="$TARGET_BUILD_DIR/$WRAPPER_NAME/Contents/MacOS/dartpdf-cli"
+
+# A Dart SDK compiles macOS executables for its native CPU. Local universal
+# Flutter builds therefore carry a host-native sidecar. Release CI builds a
+# second slice on the other native GitHub runner and replaces this file with a
+# universal lipo merge before signing the app.
+case "$(uname -m)" in
+  arm64|aarch64) target_arch=arm64 ;;
+  x86_64|amd64) target_arch=x64 ;;
+  *)
+    echo "error: unsupported DartPDF CLI host architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+"$dart" "$repository_root/tool/build_desktop_cli.dart" \
+  --output "$output" \
+  --target-os macos \
+  --target-arch "$target_arch"

--- a/app/macos/resign_embedded_code.sh
+++ b/app/macos/resign_embedded_code.sh
@@ -52,7 +52,10 @@ fi
 
 if [[ -d "$macos_dir" ]]; then
   while IFS= read -r -d '' file; do
-    if [[ "$file" == *.dylib ]] && /usr/bin/file -b "$file" | grep -q 'Mach-O'; then
+    # `dartpdf-cli` is the compiled CLI/MCP sidecar. Sign it as nested code
+    # before signing the outer app, like dylibs copied into this directory.
+    if [[ "$file" == *.dylib || "$(basename "$file")" == dartpdf-cli ]] &&
+        /usr/bin/file -b "$file" | grep -q 'Mach-O'; then
       sign_code "$file"
     fi
   done < <(find "$macos_dir" -maxdepth 1 -type f -print0)

--- a/app/packaging/aur/PKGBUILD
+++ b/app/packaging/aur/PKGBUILD
@@ -34,12 +34,14 @@ package() {
   # runner resolves its real path via readlink and finds data/ + lib/ next to
   # it, so a /usr/bin symlink works.
   install -d "${pkgdir}/opt/dartpdf"
-  cp -r "${srcdir}/dart_pdf_editor_app" "${srcdir}/data" "${srcdir}/lib" \
-        "${pkgdir}/opt/dartpdf/"
-  chmod 755 "${pkgdir}/opt/dartpdf/dart_pdf_editor_app"
+  cp -r "${srcdir}/dart_pdf_editor_app" "${srcdir}/dartpdf-cli" \
+        "${srcdir}/data" "${srcdir}/lib" "${pkgdir}/opt/dartpdf/"
+  chmod 755 "${pkgdir}/opt/dartpdf/dart_pdf_editor_app" \
+            "${pkgdir}/opt/dartpdf/dartpdf-cli"
 
   install -d "${pkgdir}/usr/bin"
   ln -s /opt/dartpdf/dart_pdf_editor_app "${pkgdir}/usr/bin/dartpdf"
+  ln -s /opt/dartpdf/dartpdf-cli "${pkgdir}/usr/bin/dartpdf-cli"
 
   install -d "${pkgdir}/usr/share"
   cp -r "${srcdir}/share/." "${pkgdir}/usr/share/"

--- a/app/packaging/aur/PKGBUILD
+++ b/app/packaging/aur/PKGBUILD
@@ -34,14 +34,20 @@ package() {
   # runner resolves its real path via readlink and finds data/ + lib/ next to
   # it, so a /usr/bin symlink works.
   install -d "${pkgdir}/opt/dartpdf"
-  cp -r "${srcdir}/dart_pdf_editor_app" "${srcdir}/dartpdf-cli" \
-        "${srcdir}/data" "${srcdir}/lib" "${pkgdir}/opt/dartpdf/"
-  chmod 755 "${pkgdir}/opt/dartpdf/dart_pdf_editor_app" \
-            "${pkgdir}/opt/dartpdf/dartpdf-cli"
+  cp -r "${srcdir}/dart_pdf_editor_app" "${srcdir}/data" "${srcdir}/lib" \
+        "${pkgdir}/opt/dartpdf/"
+  chmod 755 "${pkgdir}/opt/dartpdf/dart_pdf_editor_app"
 
   install -d "${pkgdir}/usr/bin"
   ln -s /opt/dartpdf/dart_pdf_editor_app "${pkgdir}/usr/bin/dartpdf"
-  ln -s /opt/dartpdf/dartpdf-cli "${pkgdir}/usr/bin/dartpdf-cli"
+  # The checked-in PKGBUILD remains pinned to the stable release while the
+  # next release is prepared. Install the sidecar as soon as that release
+  # archive contains it without breaking reproducible builds of the old pin.
+  if [[ -f "${srcdir}/dartpdf-cli" ]]; then
+    install -Dm755 "${srcdir}/dartpdf-cli" \
+      "${pkgdir}/opt/dartpdf/dartpdf-cli"
+    ln -s /opt/dartpdf/dartpdf-cli "${pkgdir}/usr/bin/dartpdf-cli"
+  fi
 
   install -d "${pkgdir}/usr/share"
   cp -r "${srcdir}/share/." "${pkgdir}/usr/share/"

--- a/app/packaging/aur/README.md
+++ b/app/packaging/aur/README.md
@@ -4,7 +4,8 @@
 derivatives, so users can `paru -S dartpdf-bin` / `yay -S dartpdf-bin`.
 
 - **Package:** binary (`-bin`) — installs the release bundle under
-  `/opt/dartpdf` and symlinks `/usr/bin/dartpdf`.
+  `/opt/dartpdf`, preserves the GUI launcher at `/usr/bin/dartpdf`, and exposes
+  the bundled CLI/MCP sidecar as `/usr/bin/dartpdf-cli`.
 - **Source of truth for the `PKGBUILD`:** this directory. The AUR git repo is a
   publish target; keep this copy authoritative and push from here.
 
@@ -29,7 +30,8 @@ from the matching release tag.
    makepkg -f                       # builds the package locally
    namcap PKGBUILD *.pkg.tar.zst    # lint (optional but recommended)
    ```
-4. Test-install: `sudo pacman -U dartpdf-bin-*.pkg.tar.zst`, then `dartpdf`.
+4. Test-install: `sudo pacman -U dartpdf-bin-*.pkg.tar.zst`, then launch
+   `dartpdf` and check the bundled CLI with `dartpdf-cli --version`.
 
 > **Note:** `.SRCINFO` in this repo is hand-maintained to mirror the `PKGBUILD`.
 > Always regenerate it with `makepkg --printsrcinfo > .SRCINFO` before pushing —

--- a/app/packaging/aur/README.md
+++ b/app/packaging/aur/README.md
@@ -4,8 +4,9 @@
 derivatives, so users can `paru -S dartpdf-bin` / `yay -S dartpdf-bin`.
 
 - **Package:** binary (`-bin`) — installs the release bundle under
-  `/opt/dartpdf`, preserves the GUI launcher at `/usr/bin/dartpdf`, and exposes
-  the bundled CLI/MCP sidecar as `/usr/bin/dartpdf-cli`.
+  `/opt/dartpdf`, preserves the GUI launcher at `/usr/bin/dartpdf`, and, for
+  sidecar-enabled releases, exposes the CLI/MCP executable as
+  `/usr/bin/dartpdf-cli`.
 - **Source of truth for the `PKGBUILD`:** this directory. The AUR git repo is a
   publish target; keep this copy authoritative and push from here.
 
@@ -15,6 +16,10 @@ As of `app-v3.4.0`, the official release tarball carries the runner, `data/`,
 `lib/`, and the complete desktop-integration `share/` tree. The `PKGBUILD`
 installs that immutable payload directly and fetches only the Apache license
 from the matching release tag.
+
+The checked-in `3.5.0` pin predates the CLI sidecar. Its install is conditional
+so this recipe remains reproducible until the first sidecar-enabled app release
+is published and the normal version/checksum bump is made.
 
 ## Per-release update
 

--- a/app/packaging/flatpak/README.md
+++ b/app/packaging/flatpak/README.md
@@ -67,6 +67,14 @@ flatpak-builder --user --install --force-clean \
 flatpak run dev.milanko.dartpdf
 ```
 
+The package also carries the CLI/MCP sidecar. Strict confinement has no broad
+filesystem grant, so explicitly expose the working tree used as an MCP root:
+
+```sh
+flatpak run --filesystem="$PWD" --command=dartpdf-cli \
+  dev.milanko.dartpdf inspect "$PWD/document.pdf" --json
+```
+
 After changing desktop metadata or icons, run:
 
 ```sh

--- a/app/packaging/flatpak/README.md
+++ b/app/packaging/flatpak/README.md
@@ -67,8 +67,11 @@ flatpak-builder --user --install --force-clean \
 flatpak run dev.milanko.dartpdf
 ```
 
-The package also carries the CLI/MCP sidecar. Strict confinement has no broad
-filesystem grant, so explicitly expose the working tree used as an MCP root:
+Sidecar-enabled releases also carry the CLI/MCP executable. The checked-in
+manifest remains pinned to the preceding stable archive, so its conditional
+install keeps that older local build reproducible. Strict confinement has no
+broad filesystem grant; with a sidecar-enabled archive, explicitly expose the
+working tree used as an MCP root:
 
 ```sh
 flatpak run --filesystem="$PWD" --command=dartpdf-cli \

--- a/app/packaging/flatpak/dev.milanko.dartpdf.yml
+++ b/app/packaging/flatpak/dev.milanko.dartpdf.yml
@@ -51,10 +51,14 @@ modules:
       # locate adjacent runtime data through their resolved executable paths.
       # Copy only bundle entries so staged desktop assets are not swept in.
       - install -d /app/dartpdf
-      - cp -r dart_pdf_editor_app dartpdf-cli data lib /app/dartpdf/
+      - cp -r dart_pdf_editor_app data lib /app/dartpdf/
+      # The checked-in source still pins the last stable archive, which
+      # predates the sidecar. Release publishing substitutes the new archive;
+      # keep local builds of the pinned release reproducible in the meantime.
+      - test ! -f dartpdf-cli || cp dartpdf-cli /app/dartpdf/
       - install -d /app/bin
       - ln -s /app/dartpdf/dart_pdf_editor_app /app/bin/dartpdf
-      - ln -s /app/dartpdf/dartpdf-cli /app/bin/dartpdf-cli
+      - test ! -f dartpdf-cli || ln -s /app/dartpdf/dartpdf-cli /app/bin/dartpdf-cli
       # Desktop integration, from the staged copies (see README "Desktop assets").
       - install -Dm644 dev.milanko.dartpdf.desktop
         /app/share/applications/dev.milanko.dartpdf.desktop

--- a/app/packaging/flatpak/dev.milanko.dartpdf.yml
+++ b/app/packaging/flatpak/dev.milanko.dartpdf.yml
@@ -46,15 +46,15 @@ modules:
   - name: dartpdf
     buildsystem: simple
     build-commands:
-      # Unpack the Flutter bundle under /app/dartpdf and expose the runner as
-      # `dartpdf`. The binary's RPATH is $ORIGIN/lib and it locates its data/
-      # dir relative to the resolved executable path, so a symlink in /app/bin
-      # works without moving the bundle apart. Copy only the bundle entries so
-      # the staged desktop-asset sources below are not swept in.
+      # Unpack the Flutter bundle under /app/dartpdf and expose the GUI runner
+      # and the pure-Dart CLI/MCP sidecar as separate commands. Both binaries
+      # locate adjacent runtime data through their resolved executable paths.
+      # Copy only bundle entries so staged desktop assets are not swept in.
       - install -d /app/dartpdf
-      - cp -r dart_pdf_editor_app data lib /app/dartpdf/
+      - cp -r dart_pdf_editor_app dartpdf-cli data lib /app/dartpdf/
       - install -d /app/bin
       - ln -s /app/dartpdf/dart_pdf_editor_app /app/bin/dartpdf
+      - ln -s /app/dartpdf/dartpdf-cli /app/bin/dartpdf-cli
       # Desktop integration, from the staged copies (see README "Desktop assets").
       - install -Dm644 dev.milanko.dartpdf.desktop
         /app/share/applications/dev.milanko.dartpdf.desktop

--- a/app/packaging/msstore/build-msix.ps1
+++ b/app/packaging/msstore/build-msix.ps1
@@ -104,6 +104,8 @@ try {
   & flutter build windows --release `
     --build-name=$Version --build-number=$BuildNumber
   if ($LASTEXITCODE -ne 0) { throw "flutter build windows failed ($LASTEXITCODE)" }
+  & build/windows/x64/runner/Release/dartpdf.exe --version
+  if ($LASTEXITCODE -ne 0) { throw "dartpdf.exe smoke check failed ($LASTEXITCODE)" }
 
   # The Release folder is what the portable zip ships; the MSIX runtime is
   # supplied by the OS, so no msvcp140/vcruntime140 copy is needed here (unlike

--- a/app/packaging/snap/README.md
+++ b/app/packaging/snap/README.md
@@ -21,6 +21,14 @@ sudo snap connect dartpdf:removable-media
 sudo snap connect dartpdf:password-manager-service
 ```
 
+The GUI owns the package's `dartpdf` command. The bundled CLI/MCP sidecar is
+available as `dartpdf.cli`:
+
+```sh
+dartpdf.cli inspect "$HOME/document.pdf" --json
+dartpdf.cli mcp --root "$HOME/PDFs"
+```
+
 ## Local build
 
 On Ubuntu 24.04 or newer:

--- a/app/packaging/snap/README.md
+++ b/app/packaging/snap/README.md
@@ -21,8 +21,8 @@ sudo snap connect dartpdf:removable-media
 sudo snap connect dartpdf:password-manager-service
 ```
 
-The GUI owns the package's `dartpdf` command. The bundled CLI/MCP sidecar is
-available as `dartpdf.cli`:
+The GUI owns the package's `dartpdf` command. Sidecar-enabled releases expose
+the bundled CLI/MCP executable as `dartpdf.cli`:
 
 ```sh
 dartpdf.cli inspect "$HOME/document.pdf" --json
@@ -44,8 +44,10 @@ snap run dartpdf
 ```
 
 The checked-in recipe pins the current stable GitHub release and SHA-256 for
-reproducible local builds. CI replaces that URL with the already-downloaded,
-digest-verified release archive.
+reproducible local builds. That pinned release predates the sidecar, so the
+release builder verifies that a newly supplied archive contains `dartpdf-cli`
+and adds the `dartpdf.cli` app entry only to that generated recipe. CI replaces
+the pinned URL with the already-downloaded, digest-verified release archive.
 
 ## Publishing
 

--- a/app/packaging/snap/build-release-snap.sh
+++ b/app/packaging/snap/build-release-snap.sh
@@ -78,6 +78,10 @@ mkdir -p "$work_dir/snap" "$output"
 cp "$script_dir/snap/snapcraft.yaml" "$work_dir/snap/snapcraft.yaml"
 mkdir -p "$work_dir/release-payload"
 tar -xzf "$archive" -C "$work_dir/release-payload"
+if [[ ! -x "$work_dir/release-payload/dartpdf-cli" ]]; then
+  echo "Release archive does not contain the dartpdf-cli sidecar: $archive" >&2
+  exit 1
+fi
 install -Dm644 "$metainfo" \
   "$work_dir/release-payload/share/metainfo/dev.milanko.dartpdf.metainfo.xml"
 tar -C "$work_dir/release-payload" -czf \
@@ -93,6 +97,20 @@ import sys
 
 path = Path(sys.argv[1])
 text = path.read_text()
+apps_marker = '''
+# Ask snapd to install the CUPS proxy'''
+cli_app = '''
+  # Snap reserves the package command `dartpdf` for the GUI. The bundled
+  # CLI/MCP sidecar is therefore exposed as `dartpdf.cli` in this channel.
+  cli:
+    command: dartpdf-cli
+    plugs:
+      - home
+      - removable-media
+'''
+if apps_marker not in text:
+    raise SystemExit('could not locate the snap apps insertion point')
+text = text.replace(apps_marker, cli_app + apps_marker, 1)
 text, count = re.subn(
     r'(?m)^    source: https://github\.com/[^\n]+\n'
     r'    source-type: tar\n'

--- a/app/packaging/snap/snap/snapcraft.yaml
+++ b/app/packaging/snap/snap/snapcraft.yaml
@@ -30,14 +30,6 @@ apps:
       - removable-media
       - password-manager-service
       - cups
-  # Snap reserves the package command `dartpdf` for the GUI. The bundled
-  # CLI/MCP sidecar is therefore exposed as `dartpdf.cli` in this channel.
-  cli:
-    command: dartpdf-cli
-    plugs:
-      - home
-      - removable-media
-
 # Ask snapd to install the CUPS proxy on systems that do not already provide a
 # compatible print service. The app only needs the non-administrative `cups`
 # interface above; it never requests `cups-control`.

--- a/app/packaging/snap/snap/snapcraft.yaml
+++ b/app/packaging/snap/snap/snapcraft.yaml
@@ -30,6 +30,13 @@ apps:
       - removable-media
       - password-manager-service
       - cups
+  # Snap reserves the package command `dartpdf` for the GUI. The bundled
+  # CLI/MCP sidecar is therefore exposed as `dartpdf.cli` in this channel.
+  cli:
+    command: dartpdf-cli
+    plugs:
+      - home
+      - removable-media
 
 # Ask snapd to install the CUPS proxy on systems that do not already provide a
 # compatible print service. The app only needs the non-administrative `cups`

--- a/app/windows/CMakeLists.txt
+++ b/app/windows/CMakeLists.txt
@@ -52,6 +52,12 @@ add_subdirectory(${FLUTTER_MANAGED_DIR})
 # Application build; see runner/CMakeLists.txt.
 add_subdirectory("runner")
 
+# Build the pure-Dart CLI/MCP sidecar for this Windows architecture. It is
+# installed as dartpdf.exe beside the GUI runner.
+set(DARTPDF_CLI_TARGET_OS "windows")
+set(DARTPDF_CLI_OUTPUT_NAME "dartpdf.exe")
+include("${CMAKE_CURRENT_SOURCE_DIR}/../cmake/dartpdf_cli.cmake")
+
 
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
@@ -73,6 +79,10 @@ set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
 set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}")
 
 install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(PROGRAMS "${DARTPDF_CLI_OUTPUT}"
+  DESTINATION "${CMAKE_INSTALL_PREFIX}"
   COMPONENT Runtime)
 
 install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"

--- a/packages/dart_pdf_cli/CHANGELOG.md
+++ b/packages/dart_pdf_cli/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+- Add the VM-only `dartpdf` executable with JSON `inspect`, bounded `text`,
+  `forms list`, and `annotations list` commands.
+- Add a stdio MCP adapter exposing the same handlers as four read-only tools.
+- Restrict MCP file access to configured roots and support passwords through
+  stdin, environment variables, or protected files rather than process
+  arguments.

--- a/packages/dart_pdf_cli/LICENSE
+++ b/packages/dart_pdf_cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/dart_pdf_cli/README.md
+++ b/packages/dart_pdf_cli/README.md
@@ -1,0 +1,143 @@
+# dart_pdf_cli
+
+Pure-Dart command line and Model Context Protocol tools for inspecting PDFs
+with the [dart-pdf](https://github.com/ben-milanko/dart-pdf) engine. The
+`dartpdf` executable runs on the Dart VM and does not import Flutter or
+`dart:ui`.
+
+The CLI and MCP adapter call the same transport-independent
+`DartPdfService` handlers. The MCP layer contains no duplicate PDF logic.
+
+## Installation
+
+From a checkout:
+
+```sh
+dart run packages/dart_pdf_cli/bin/dartpdf.dart --help
+```
+
+Once published, install the executable globally:
+
+```sh
+dart pub global activate dart_pdf_cli
+dartpdf --help
+```
+
+The DartPDF desktop app also ships the same self-contained native executable:
+
+| Desktop build | CLI/MCP executable |
+|---|---|
+| macOS app | `/Applications/DartPDF.app/Contents/MacOS/dartpdf-cli` |
+| Windows installer | `%LOCALAPPDATA%\Programs\DartPDF\dartpdf.exe` |
+| Windows portable | `dartpdf.exe` beside `dart_pdf_editor_app.exe` |
+| Linux tarball / AppImage payload | `dartpdf-cli` beside `dart_pdf_editor_app` |
+| Arch `dartpdf-bin` | `/usr/bin/dartpdf-cli` |
+| Flatpak | `flatpak run --command=dartpdf-cli dev.milanko.dartpdf` |
+| Snap | `dartpdf.cli` |
+
+The macOS and Windows app installers do not modify the user's shell `PATH`;
+use the explicit path above when registering their copy with an MCP host.
+
+## Commands
+
+All successful commands write JSON to stdout. Diagnostics go to stderr and
+failures use non-zero exit codes. Output is indented by default; `--json`
+selects compact JSON for scripts and agents.
+
+```sh
+dartpdf inspect input.pdf --json
+dartpdf text input.pdf --pages 1-5,8 --json
+dartpdf forms list input.pdf --json
+dartpdf annotations list input.pdf --pages 1-5 --json
+```
+
+Page numbers are one-based. A missing page range reads at most the configured
+page limit. An explicit range over that limit is rejected rather than silently
+changed.
+
+`inspect` returns the PDF version, information-dictionary metadata, page
+count, encryption state, form and annotation counts, and compact signature
+state. It does not perform trust-store validation.
+
+`text`, `forms list`, and `annotations list` have hard result limits. The JSON
+reports `truncated: true` when a page, character, field, annotation, or
+annotation-text limit was reached. Password-form values are never returned.
+
+## Passwords
+
+Passwords are deliberately not accepted as process arguments, where they can
+appear in shell history and process listings. Select at most one protected
+source:
+
+```sh
+printf '%s\n' "$PDF_PASSWORD" | dartpdf inspect secured.pdf --password-stdin --json
+dartpdf inspect secured.pdf --password-env PDF_PASSWORD --json
+dartpdf inspect secured.pdf --password-file /secure/password.txt --json
+```
+
+Only one trailing line ending is removed from stdin or password-file input;
+other whitespace remains part of the password.
+
+## JSON compatibility
+
+Every result carries `schemaVersion`. Version 1 has these compatibility rules:
+
+- existing keys keep their meaning and type within the major schema version;
+- new optional keys may be added;
+- array order is deterministic and follows document/page order unless the
+  requested page range specifies another order;
+- consumers must check `truncated` before assuming a result is complete.
+
+## MCP server
+
+Run the stdio adapter with one or more allowed filesystem roots:
+
+```sh
+dartpdf mcp --root /work/pdfs --root /work/contracts
+```
+
+With no `--root`, only the current directory is accessible. Input PDF and
+password-file paths are resolved through symlinks and rejected unless the
+resolved file is inside an allowed root. Relative paths are tried against the
+configured roots in command-line order. The server exposes four read-only,
+idempotent tools:
+
+- `inspect_pdf`
+- `extract_pdf_text`
+- `list_pdf_forms`
+- `list_pdf_annotations`
+
+Tools return structured JSON plus the MCP text fallback. They return paths and
+metadata only; complete PDFs are never base64-encoded into responses.
+
+Register a globally activated executable with Codex:
+
+```sh
+codex mcp add dartpdf -- dartpdf mcp --root "$PWD"
+```
+
+Or register the copy bundled with the macOS desktop app:
+
+```sh
+codex mcp add dartpdf -- \
+  /Applications/DartPDF.app/Contents/MacOS/dartpdf-cli mcp --root "$PWD"
+```
+
+For a source checkout, register the Dart invocation instead:
+
+```sh
+codex mcp add dartpdf -- \
+  dart run packages/dart_pdf_cli/bin/dartpdf.dart mcp --root "$PWD"
+```
+
+MCP password sources are `passwordEnv` or `passwordFile`; raw password tool
+arguments are not accepted. Hosts can therefore apply their own approval and
+secret policies without exposing the password in the server command.
+
+## Scope
+
+This first contract is read-only and VM-only. Editing commands can be added on
+top of the same service boundary after the JSON contract settles. Page raster
+export is intentionally outside this package until the pure-Dart software
+renderer work in [#684](https://github.com/ben-milanko/dart-pdf/issues/684)
+lands (the broader conversion roadmap is [#369](https://github.com/ben-milanko/dart-pdf/issues/369)).

--- a/packages/dart_pdf_cli/README.md
+++ b/packages/dart_pdf_cli/README.md
@@ -23,7 +23,9 @@ dart pub global activate dart_pdf_cli
 dartpdf --help
 ```
 
-The DartPDF desktop app also ships the same self-contained native executable:
+Sidecar-enabled DartPDF desktop releases ship the same self-contained native
+executable (older package-manager releases naturally do not gain it
+retroactively):
 
 | Desktop build | CLI/MCP executable |
 |---|---|
@@ -40,9 +42,10 @@ use the explicit path above when registering their copy with an MCP host.
 
 ## Commands
 
-All successful commands write JSON to stdout. Diagnostics go to stderr and
-failures use non-zero exit codes. Output is indented by default; `--json`
-selects compact JSON for scripts and agents.
+Successful PDF operations write JSON to stdout (`--help` and `--version` are
+human-readable). Diagnostics go to stderr and failures use non-zero exit codes.
+Output is indented by default; `--json` selects compact JSON for scripts and
+agents.
 
 ```sh
 dartpdf inspect input.pdf --json
@@ -59,9 +62,10 @@ changed.
 count, encryption state, form and annotation counts, and compact signature
 state. It does not perform trust-store validation.
 
-`text`, `forms list`, and `annotations list` have hard result limits. The JSON
-reports `truncated: true` when a page, character, field, annotation, or
-annotation-text limit was reached. Password-form values are never returned.
+Every operation has hard limits for variable strings and collections. The JSON
+reports `truncated: true` when a metadata, signature, subtype, page, character,
+field, widget, option, annotation, or annotation-text limit was reached.
+Password-form values are never returned.
 
 ## Passwords
 
@@ -76,7 +80,8 @@ dartpdf inspect secured.pdf --password-file /secure/password.txt --json
 ```
 
 Only one trailing line ending is removed from stdin or password-file input;
-other whitespace remains part of the password.
+other whitespace remains part of the password. Protected password inputs are
+limited to 4096 bytes and rejected rather than silently truncated.
 
 ## JSON compatibility
 
@@ -132,7 +137,9 @@ codex mcp add dartpdf -- \
 
 MCP password sources are `passwordEnv` or `passwordFile`; raw password tool
 arguments are not accepted. Hosts can therefore apply their own approval and
-secret policies without exposing the password in the server command.
+secret policies without exposing the password in the server command. Tool
+schemas also cap path, page-range, and environment-name strings, and MCP error
+text is bounded independently of parser diagnostics.
 
 ## Scope
 

--- a/packages/dart_pdf_cli/analysis_options.yaml
+++ b/packages/dart_pdf_cli/analysis_options.yaml
@@ -1,0 +1,14 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    avoid_print: true

--- a/packages/dart_pdf_cli/bin/dartpdf.dart
+++ b/packages/dart_pdf_cli/bin/dartpdf.dart
@@ -1,0 +1,313 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:args/args.dart';
+import 'package:dart_pdf_cli/dart_pdf_cli.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:path/path.dart' as p;
+import 'package:pdf_cos/pdf_cos.dart';
+
+const _version = '0.1.0';
+const _usageExit = 64;
+const _dataExit = 65;
+const _inputExit = 66;
+
+Future<void> main(List<String> arguments) async {
+  exitCode = await _DartPdfCli().run(arguments);
+}
+
+class _DartPdfCli {
+  _DartPdfCli() : parser = _buildParser();
+
+  final ArgParser parser;
+  final DartPdfService service = const DartPdfService();
+
+  Future<int> run(List<String> arguments) async {
+    try {
+      final results = parser.parse(arguments);
+      if (results['version'] as bool) {
+        stdout.writeln('dartpdf $_version');
+        return 0;
+      }
+      if (results['help'] as bool || results.command == null) {
+        _writeUsage();
+        return results.command == null && !(results['help'] as bool)
+            ? _usageExit
+            : 0;
+      }
+
+      final command = results.command!;
+      if (command.name == 'mcp') return await _runMcp(command);
+      if (command.name == 'forms' || command.name == 'annotations') {
+        if (command['help'] as bool) {
+          stdout.writeln(_usageFor(command.name!));
+          return 0;
+        }
+        final nested = command.command;
+        if (nested == null || nested.name != 'list') {
+          throw _UsageException(
+              '${command.name} requires the "list" command', parser.usage);
+        }
+        return await _runReadCommand('${command.name}.list', nested);
+      }
+      return await _runReadCommand(command.name!, command);
+    } on _UsageException catch (error) {
+      stderr.writeln(error.message);
+      stderr.writeln(error.usage);
+      return _usageExit;
+    } on FormatException catch (error) {
+      stderr.writeln(error.message);
+      stderr.writeln(parser.usage);
+      return _usageExit;
+    } on FileSystemException catch (error) {
+      stderr.writeln('dartpdf: ${error.message}'
+          '${error.path == null ? '' : ': ${error.path}'}');
+      return _inputExit;
+    } on CosPasswordException catch (error) {
+      stderr.writeln('dartpdf: $error');
+      return _dataExit;
+    } on CosParseException catch (error) {
+      stderr.writeln('dartpdf: $error');
+      return _dataExit;
+    } on DartPdfRequestException catch (error) {
+      stderr.writeln('dartpdf: ${error.message}');
+      return _usageExit;
+    } on Object catch (error) {
+      stderr.writeln('dartpdf: $error');
+      return _dataExit;
+    }
+  }
+
+  Future<int> _runReadCommand(String operation, ArgResults results) async {
+    if (results['help'] as bool) {
+      stdout.writeln(_usageFor(operation));
+      return 0;
+    }
+    if (results.rest.length != 1) {
+      throw _UsageException('$operation requires exactly one input PDF path',
+          _usageFor(operation));
+    }
+    final password = await _readCliPassword(results);
+    final bytes = await File(results.rest.single).readAsBytes();
+    final document = service.open(bytes, password: password);
+    final Map<String, Object?> output = switch (operation) {
+      'inspect' => document.inspect(),
+      'text' => document.extractText(pages: results['pages'] as String?),
+      'forms.list' => document.listForms(),
+      'annotations.list' =>
+        document.listAnnotations(pages: results['pages'] as String?),
+      _ => throw StateError('unknown operation $operation'),
+    };
+    final encoder = results['json'] as bool
+        ? const JsonEncoder()
+        : const JsonEncoder.withIndent('  ');
+    stdout.writeln(encoder.convert(output));
+    return 0;
+  }
+
+  Future<int> _runMcp(ArgResults results) async {
+    if (results['help'] as bool) {
+      stdout.writeln(_usageFor('mcp'));
+      return 0;
+    }
+    if (results.rest.isNotEmpty) {
+      throw _UsageException(
+          'mcp takes no positional arguments', _usageFor('mcp'));
+    }
+    final requestedRoots = (results['root'] as List<String>);
+    final access = await _RootedFileAccess.create(
+      requestedRoots.isEmpty ? [Directory.current.path] : requestedRoots,
+    );
+    final server = createDartPdfMcpServer(
+      readFile: access.readBytes,
+      readPassword: access.readPassword,
+      service: service,
+    );
+    await server.connect(StdioServerTransport());
+    return 0;
+  }
+
+  Future<String> _readCliPassword(ArgResults results) async {
+    final fromStdin = results['password-stdin'] as bool;
+    final envName = results['password-env'] as String?;
+    final fileName = results['password-file'] as String?;
+    final count = [fromStdin, envName != null, fileName != null]
+        .where((selected) => selected)
+        .length;
+    if (count > 1) {
+      throw const DartPdfRequestException(
+          'choose only one password source: stdin, environment, or file');
+    }
+    if (fromStdin) {
+      return _trimLineEnding(await stdin.transform(utf8.decoder).join());
+    }
+    if (envName != null) {
+      final value = Platform.environment[envName];
+      if (value == null) {
+        throw DartPdfRequestException(
+            'password environment variable "$envName" is not set');
+      }
+      return value;
+    }
+    if (fileName != null) {
+      return _trimLineEnding(await File(fileName).readAsString());
+    }
+    return '';
+  }
+
+  String _usageFor(String operation) {
+    ArgParser? current = parser;
+    for (final part in operation.split('.')) {
+      current = current?.commands[part];
+    }
+    return 'Usage: dartpdf ${operation.replaceAll('.', ' ')} [options] input.pdf\n'
+        '${current?.usage ?? ''}';
+  }
+
+  void _writeUsage() {
+    stdout.writeln('DartPDF command line and MCP tools\n\n'
+        'Usage: dartpdf <command> [arguments]\n\n${parser.usage}');
+  }
+}
+
+ArgParser _buildParser() {
+  final parser = ArgParser()
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Show this help.')
+    ..addFlag('version', negatable: false, help: 'Show the version.');
+  parser
+    ..addCommand('inspect', _pdfParser())
+    ..addCommand('text', _pdfParser(pages: true))
+    ..addCommand(
+      'forms',
+      _groupParser(_pdfParser()),
+    )
+    ..addCommand(
+      'annotations',
+      _groupParser(_pdfParser(pages: true)),
+    )
+    ..addCommand(
+      'mcp',
+      ArgParser()
+        ..addFlag('help', abbr: 'h', negatable: false)
+        ..addMultiOption(
+          'root',
+          help: 'Filesystem root accessible to MCP tools. Repeatable.',
+          splitCommas: false,
+        ),
+    );
+  return parser;
+}
+
+ArgParser _groupParser(ArgParser listParser) => ArgParser()
+  ..addFlag('help', abbr: 'h', negatable: false)
+  ..addCommand('list', listParser);
+
+ArgParser _pdfParser({bool pages = false}) {
+  final parser = ArgParser()
+    ..addFlag('help', abbr: 'h', negatable: false)
+    ..addFlag(
+      'json',
+      negatable: false,
+      help: 'Emit compact JSON instead of indented JSON.',
+    )
+    ..addFlag(
+      'password-stdin',
+      negatable: false,
+      help: 'Read the PDF password from stdin.',
+    )
+    ..addOption(
+      'password-env',
+      help: 'Read the PDF password from this environment variable.',
+    )
+    ..addOption(
+      'password-file',
+      help: 'Read the PDF password from a protected file.',
+    );
+  if (pages) {
+    parser.addOption(
+      'pages',
+      help: 'One-based pages/ranges, for example 1-5,8.',
+    );
+  }
+  return parser;
+}
+
+class _RootedFileAccess {
+  _RootedFileAccess._(this.roots);
+
+  final List<String> roots;
+
+  static Future<_RootedFileAccess> create(List<String> requestedRoots) async {
+    final roots = <String>[];
+    for (final requested in requestedRoots) {
+      final directory = Directory(p.absolute(requested));
+      final resolved = p.normalize(await directory.resolveSymbolicLinks());
+      if (!await Directory(resolved).exists()) {
+        throw FileSystemException('MCP root is not a directory', requested);
+      }
+      if (!roots.contains(resolved)) roots.add(resolved);
+    }
+    return _RootedFileAccess._(roots);
+  }
+
+  Future<Uint8List> readBytes(String requestedPath) async {
+    final file = await _resolveFile(requestedPath);
+    return file.readAsBytes();
+  }
+
+  Future<String> readPassword(Map<String, dynamic> arguments) async {
+    final envName = arguments['passwordEnv'] as String?;
+    final fileName = arguments['passwordFile'] as String?;
+    if (envName != null && fileName != null) {
+      throw const DartPdfRequestException(
+          'choose only one password source: environment or file');
+    }
+    if (envName != null) {
+      final value = Platform.environment[envName];
+      if (value == null) {
+        throw DartPdfRequestException(
+            'password environment variable "$envName" is not set');
+      }
+      return value;
+    }
+    if (fileName != null) {
+      return _trimLineEnding(
+          await (await _resolveFile(fileName)).readAsString());
+    }
+    return '';
+  }
+
+  Future<File> _resolveFile(String requestedPath) async {
+    if (requestedPath.trim().isEmpty) {
+      throw const DartPdfRequestException('path must not be empty');
+    }
+    final candidates = p.isAbsolute(requestedPath)
+        ? [requestedPath]
+        : [for (final root in roots) p.join(root, requestedPath)];
+    for (final candidate in candidates) {
+      final unresolved = File(candidate);
+      if (!await unresolved.exists()) continue;
+      final resolved = p.normalize(await unresolved.resolveSymbolicLinks());
+      final allowed = roots.any(
+          (root) => p.equals(root, resolved) || p.isWithin(root, resolved));
+      if (allowed) return File(resolved);
+      throw DartPdfRequestException(
+          'path is outside configured MCP filesystem roots: $requestedPath');
+    }
+    throw FileSystemException('file does not exist', requestedPath);
+  }
+}
+
+String _trimLineEnding(String value) {
+  if (value.endsWith('\r\n')) return value.substring(0, value.length - 2);
+  if (value.endsWith('\n')) return value.substring(0, value.length - 1);
+  return value;
+}
+
+class _UsageException implements Exception {
+  const _UsageException(this.message, this.usage);
+
+  final String message;
+  final String usage;
+}

--- a/packages/dart_pdf_cli/bin/dartpdf.dart
+++ b/packages/dart_pdf_cli/bin/dartpdf.dart
@@ -12,6 +12,7 @@ const _version = '0.1.0';
 const _usageExit = 64;
 const _dataExit = 65;
 const _inputExit = 66;
+const _maxPasswordBytes = 4096;
 
 Future<void> main(List<String> arguments) async {
   exitCode = await _DartPdfCli().run(arguments);
@@ -140,7 +141,7 @@ class _DartPdfCli {
           'choose only one password source: stdin, environment, or file');
     }
     if (fromStdin) {
-      return _trimLineEnding(await stdin.transform(utf8.decoder).join());
+      return _readPassword(await _boundedBytes(stdin));
     }
     if (envName != null) {
       final value = Platform.environment[envName];
@@ -151,7 +152,7 @@ class _DartPdfCli {
       return value;
     }
     if (fileName != null) {
-      return _trimLineEnding(await File(fileName).readAsString());
+      return _readPassword(await _boundedBytes(File(fileName).openRead()));
     }
     return '';
   }
@@ -272,8 +273,8 @@ class _RootedFileAccess {
       return value;
     }
     if (fileName != null) {
-      return _trimLineEnding(
-          await (await _resolveFile(fileName)).readAsString());
+      final file = await _resolveFile(fileName);
+      return _readPassword(await _boundedBytes(file.openRead()));
     }
     return '';
   }
@@ -304,6 +305,24 @@ String _trimLineEnding(String value) {
   if (value.endsWith('\n')) return value.substring(0, value.length - 1);
   return value;
 }
+
+Future<List<int>> _boundedBytes(Stream<List<int>> input) async {
+  final output = BytesBuilder(copy: false);
+  var length = 0;
+  await for (final chunk in input) {
+    length += chunk.length;
+    if (length > _maxPasswordBytes) {
+      throw const DartPdfRequestException(
+        'password input exceeds the 4096-byte limit',
+      );
+    }
+    output.add(chunk);
+  }
+  return output.takeBytes();
+}
+
+String _readPassword(List<int> bytes) =>
+    _trimLineEnding(utf8.decode(bytes, allowMalformed: false));
 
 class _UsageException implements Exception {
   const _UsageException(this.message, this.usage);

--- a/packages/dart_pdf_cli/lib/dart_pdf_cli.dart
+++ b/packages/dart_pdf_cli/lib/dart_pdf_cli.dart
@@ -1,0 +1,6 @@
+/// Transport-independent PDF inspection services used by the `dartpdf`
+/// command line executable and its MCP adapter.
+library;
+
+export 'src/service.dart';
+export 'src/mcp_server.dart';

--- a/packages/dart_pdf_cli/lib/src/mcp_server.dart
+++ b/packages/dart_pdf_cli/lib/src/mcp_server.dart
@@ -5,6 +5,11 @@ import 'package:mcp_dart/mcp_dart.dart';
 
 import 'service.dart';
 
+const _maxMcpPathChars = 32768;
+const _maxMcpPageSpecChars = 4096;
+const _maxMcpEnvironmentNameChars = 1024;
+const _maxMcpErrorChars = 4096;
+
 /// Reads one PDF path after the host has applied its filesystem policy.
 typedef DartPdfFileReader = Future<Uint8List> Function(String path);
 
@@ -34,12 +39,16 @@ McpServer createDartPdfMcpServer({
   final inputSchema = JsonSchema.object(
     properties: {
       'path': JsonSchema.string(
+        minLength: 1,
+        maxLength: _maxMcpPathChars,
         description: 'PDF path inside one of the server configured roots.',
       ),
       'passwordEnv': JsonSchema.string(
+        maxLength: _maxMcpEnvironmentNameChars,
         description: 'Environment variable holding the PDF password.',
       ),
       'passwordFile': JsonSchema.string(
+        maxLength: _maxMcpPathChars,
         description:
             'Protected password file inside a configured filesystem root.',
       ),
@@ -49,16 +58,21 @@ McpServer createDartPdfMcpServer({
   final pagedInputSchema = JsonSchema.object(
     properties: {
       'path': JsonSchema.string(
+        minLength: 1,
+        maxLength: _maxMcpPathChars,
         description: 'PDF path inside one of the server configured roots.',
       ),
       'pages': JsonSchema.string(
+        maxLength: _maxMcpPageSpecChars,
         description:
             'One-based pages/ranges such as "1-5,8". Defaults to a bounded prefix.',
       ),
       'passwordEnv': JsonSchema.string(
+        maxLength: _maxMcpEnvironmentNameChars,
         description: 'Environment variable holding the PDF password.',
       ),
       'passwordFile': JsonSchema.string(
+        maxLength: _maxMcpPathChars,
         description:
             'Protected password file inside a configured filesystem root.',
       ),
@@ -166,7 +180,16 @@ Future<CallToolResult> _runTool(
 }
 
 String _toolErrorMessage(Object error) {
-  final message =
+  var message =
       error is DartPdfRequestException ? error.message : error.toString();
+  if (message.length > _maxMcpErrorChars) {
+    var end = _maxMcpErrorChars;
+    final last = message.codeUnitAt(end - 1);
+    final next = message.codeUnitAt(end);
+    if (last >= 0xD800 && last <= 0xDBFF && next >= 0xDC00 && next <= 0xDFFF) {
+      end--;
+    }
+    message = '${message.substring(0, end)}…';
+  }
   return 'DartPDF request failed: $message';
 }

--- a/packages/dart_pdf_cli/lib/src/mcp_server.dart
+++ b/packages/dart_pdf_cli/lib/src/mcp_server.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:mcp_dart/mcp_dart.dart';
+
+import 'service.dart';
+
+/// Reads one PDF path after the host has applied its filesystem policy.
+typedef DartPdfFileReader = Future<Uint8List> Function(String path);
+
+/// Resolves a password source from MCP tool arguments.
+///
+/// Implementations should prefer environment variables or protected files and
+/// return an empty string when no password source was supplied.
+typedef DartPdfPasswordReader = Future<String> Function(
+    Map<String, dynamic> arguments);
+
+/// Creates the read-only DartPDF MCP server over transport-independent
+/// [DartPdfDocument] handlers.
+McpServer createDartPdfMcpServer({
+  required DartPdfFileReader readFile,
+  DartPdfPasswordReader? readPassword,
+  DartPdfService service = const DartPdfService(),
+}) {
+  final server = McpServer(
+    const Implementation(name: 'dartpdf', version: '0.1.0'),
+    options: const McpServerOptions(
+      capabilities: ServerCapabilities(
+        tools: ServerCapabilitiesTools(),
+      ),
+    ),
+  );
+  final passwordReader = readPassword ?? (_) async => '';
+  final inputSchema = JsonSchema.object(
+    properties: {
+      'path': JsonSchema.string(
+        description: 'PDF path inside one of the server configured roots.',
+      ),
+      'passwordEnv': JsonSchema.string(
+        description: 'Environment variable holding the PDF password.',
+      ),
+      'passwordFile': JsonSchema.string(
+        description:
+            'Protected password file inside a configured filesystem root.',
+      ),
+    },
+    required: const ['path'],
+  );
+  final pagedInputSchema = JsonSchema.object(
+    properties: {
+      'path': JsonSchema.string(
+        description: 'PDF path inside one of the server configured roots.',
+      ),
+      'pages': JsonSchema.string(
+        description:
+            'One-based pages/ranges such as "1-5,8". Defaults to a bounded prefix.',
+      ),
+      'passwordEnv': JsonSchema.string(
+        description: 'Environment variable holding the PDF password.',
+      ),
+      'passwordFile': JsonSchema.string(
+        description:
+            'Protected password file inside a configured filesystem root.',
+      ),
+    },
+    required: const ['path'],
+  );
+  const annotations = ToolAnnotations(
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  );
+
+  server.registerTool(
+    'inspect_pdf',
+    title: 'Inspect PDF',
+    description:
+        'Return compact document metadata, page/form/annotation counts, encryption state, and signature state.',
+    inputSchema: inputSchema,
+    annotations: annotations,
+    callback: (arguments, extra) => _runTool(
+      arguments,
+      readFile: readFile,
+      readPassword: passwordReader,
+      service: service,
+      operation: (document, _) => document.inspect(),
+    ),
+  );
+  server.registerTool(
+    'extract_pdf_text',
+    title: 'Extract PDF text',
+    description:
+        'Extract bounded, page-addressable text. Results are capped by the server page and character limits.',
+    inputSchema: pagedInputSchema,
+    annotations: annotations,
+    callback: (arguments, extra) => _runTool(
+      arguments,
+      readFile: readFile,
+      readPassword: passwordReader,
+      service: service,
+      operation: (document, args) =>
+          document.extractText(pages: args['pages'] as String?),
+    ),
+  );
+  server.registerTool(
+    'list_pdf_forms',
+    title: 'List PDF form fields',
+    description:
+        'List bounded AcroForm field metadata and values without Flutter.',
+    inputSchema: inputSchema,
+    annotations: annotations,
+    callback: (arguments, extra) => _runTool(
+      arguments,
+      readFile: readFile,
+      readPassword: passwordReader,
+      service: service,
+      operation: (document, _) => document.listForms(),
+    ),
+  );
+  server.registerTool(
+    'list_pdf_annotations',
+    title: 'List PDF annotations',
+    description:
+        'List bounded annotation metadata for selected pages without Flutter.',
+    inputSchema: pagedInputSchema,
+    annotations: annotations,
+    callback: (arguments, extra) => _runTool(
+      arguments,
+      readFile: readFile,
+      readPassword: passwordReader,
+      service: service,
+      operation: (document, args) =>
+          document.listAnnotations(pages: args['pages'] as String?),
+    ),
+  );
+  return server;
+}
+
+Future<CallToolResult> _runTool(
+  Map<String, dynamic> arguments, {
+  required DartPdfFileReader readFile,
+  required DartPdfPasswordReader readPassword,
+  required DartPdfService service,
+  required Map<String, Object?> Function(
+          DartPdfDocument document, Map<String, dynamic> arguments)
+      operation,
+}) async {
+  try {
+    final path = arguments['path'];
+    if (path is! String || path.trim().isEmpty) {
+      throw const DartPdfRequestException('path must be a non-empty string');
+    }
+    final bytes = await readFile(path);
+    final password = await readPassword(arguments);
+    final result =
+        operation(service.open(bytes, password: password), arguments);
+    return CallToolResult.fromStructuredContent(
+        Map<String, dynamic>.from(result));
+  } on Object catch (error) {
+    return CallToolResult(
+      isError: true,
+      content: [TextContent(text: _toolErrorMessage(error))],
+    );
+  }
+}
+
+String _toolErrorMessage(Object error) {
+  final message =
+      error is DartPdfRequestException ? error.message : error.toString();
+  return 'DartPDF request failed: $message';
+}

--- a/packages/dart_pdf_cli/lib/src/service.dart
+++ b/packages/dart_pdf_cli/lib/src/service.dart
@@ -12,20 +12,41 @@ class DartPdfLimits {
     this.maxPages = 50,
     this.maxTextCharsPerPage = 100000,
     this.maxTextChars = 500000,
+    this.maxInspectMetadataEntries = 100,
+    this.maxInspectSignatures = 100,
+    this.maxInspectAnnotationSubtypes = 100,
+    this.maxInspectTextChars = 100000,
     this.maxFields = 1000,
+    this.maxFormWidgets = 2000,
+    this.maxFormOptions = 5000,
+    this.maxFormTextChars = 200000,
     this.maxAnnotations = 1000,
     this.maxAnnotationTextChars = 20000,
   })  : assert(maxPages > 0),
         assert(maxTextCharsPerPage > 0),
         assert(maxTextChars > 0),
+        assert(maxInspectMetadataEntries > 0),
+        assert(maxInspectSignatures > 0),
+        assert(maxInspectAnnotationSubtypes > 0),
+        assert(maxInspectTextChars > 0),
         assert(maxFields > 0),
+        assert(maxFormWidgets > 0),
+        assert(maxFormOptions > 0),
+        assert(maxFormTextChars > 0),
         assert(maxAnnotations > 0),
         assert(maxAnnotationTextChars > 0);
 
   final int maxPages;
   final int maxTextCharsPerPage;
   final int maxTextChars;
+  final int maxInspectMetadataEntries;
+  final int maxInspectSignatures;
+  final int maxInspectAnnotationSubtypes;
+  final int maxInspectTextChars;
   final int maxFields;
+  final int maxFormWidgets;
+  final int maxFormOptions;
+  final int maxFormTextChars;
   final int maxAnnotations;
   final int maxAnnotationTextChars;
 }
@@ -141,19 +162,75 @@ class DartPdfDocument {
   Map<String, Object?> inspect() {
     final form = PdfAcroForm.of(document);
     final signatures = PdfSignature.of(document);
+    final textBudget = _TextBudget(limits.maxInspectTextChars);
+    final metadata = <String, String>{};
+    var metadataTruncated = false;
+    var metadataSeen = 0;
+    for (final entry in document.info.entries) {
+      if (metadataSeen >= limits.maxInspectMetadataEntries ||
+          textBudget.remaining == 0) {
+        metadataTruncated = true;
+        textBudget.markTruncated();
+        break;
+      }
+      metadataSeen++;
+      // Metadata keys become JSON object keys, so do not truncate them into a
+      // collision. Omit an oversized key and report the compact result as
+      // truncated instead.
+      if (!textBudget.canTake(entry.key)) {
+        metadataTruncated = true;
+        textBudget.markTruncated();
+        continue;
+      }
+      final key = textBudget.take(entry.key);
+      final value = textBudget.take(entry.value);
+      metadata[key] = value;
+      if (value.length < entry.value.length) metadataTruncated = true;
+    }
+
     var annotationCount = 0;
+    var otherAnnotationSubtypeCount = 0;
     final annotationTypes = <String, int>{};
     for (var pageIndex = 0; pageIndex < document.pageCount; pageIndex++) {
       for (final annotation in document.page(pageIndex).annotations) {
         annotationCount++;
-        annotationTypes.update(annotation.subtype, (count) => count + 1,
-            ifAbsent: () => 1);
+        final subtype = annotation.subtype;
+        final existing = annotationTypes[subtype];
+        if (existing != null) {
+          annotationTypes[subtype] = existing + 1;
+        } else if (annotationTypes.length <
+                limits.maxInspectAnnotationSubtypes &&
+            textBudget.canTake(subtype)) {
+          annotationTypes[textBudget.take(subtype)] = 1;
+        } else {
+          otherAnnotationSubtypeCount++;
+          textBudget.markTruncated();
+        }
       }
     }
 
+    final signatureItems = <Map<String, Object?>>[];
+    final signatureTake = signatures.length < limits.maxInspectSignatures
+        ? signatures.length
+        : limits.maxInspectSignatures;
+    for (final signature in signatures.take(signatureTake)) {
+      final item = <String, Object?>{
+        'documentTimestamp': signature.isDocumentTimeStamp,
+      };
+      textBudget.add(item, 'field', signature.field.name);
+      textBudget.add(item, 'signer', signature.signerName);
+      textBudget.add(item, 'subFilter', signature.subFilter);
+      if (signature.signingTime != null) {
+        item['signingTime'] = signature.signingTime!.toIso8601String();
+      }
+      signatureItems.add(item);
+    }
+    final signaturesTruncated = signatureTake < signatures.length;
+
     return _result('inspect', {
       'version': document.version,
-      'metadata': document.info,
+      'metadata': metadata,
+      if (metadataTruncated) 'metadataTruncated': true,
       'pageCount': document.pageCount,
       'encrypted': document.cos.isEncrypted,
       'forms': {
@@ -163,22 +240,21 @@ class DartPdfDocument {
       'annotations': {
         'count': annotationCount,
         'bySubtype': annotationTypes,
+        if (otherAnnotationSubtypeCount > 0)
+          'otherSubtypeCount': otherAnnotationSubtypeCount,
+        if (otherAnnotationSubtypeCount > 0) 'subtypesTruncated': true,
       },
       'signatures': {
         'signed': signatures.isNotEmpty,
         'count': signatures.length,
-        'items': [
-          for (final signature in signatures)
-            {
-              'field': signature.field.name,
-              if (signature.signerName != null) 'signer': signature.signerName,
-              if (signature.subFilter != null) 'subFilter': signature.subFilter,
-              if (signature.signingTime != null)
-                'signingTime': signature.signingTime!.toIso8601String(),
-              'documentTimestamp': signature.isDocumentTimeStamp,
-            },
-        ],
+        'items': signatureItems,
+        if (signaturesTruncated) 'truncated': true,
       },
+      if (metadataTruncated ||
+          otherAnnotationSubtypeCount > 0 ||
+          signaturesTruncated ||
+          textBudget.truncated)
+        'truncated': true,
     });
   }
 
@@ -200,7 +276,7 @@ class DartPdfDocument {
       final pageLimit = remaining < limits.maxTextCharsPerPage
           ? remaining
           : limits.maxTextCharsPerPage;
-      final take = extracted.length < pageLimit ? extracted.length : pageLimit;
+      final take = _safePrefixLength(extracted, pageLimit);
       final pageTruncated = take < extracted.length;
       output.add({
         'page': pageIndex + 1,
@@ -228,14 +304,17 @@ class DartPdfDocument {
     final fields = form?.fields ?? const <PdfFormField>[];
     final take =
         fields.length < limits.maxFields ? fields.length : limits.maxFields;
+    final budget = _FormBudget(limits);
+    final output = <Map<String, Object?>>[];
+    for (final field in fields.take(take)) {
+      output.add(_fieldJson(field, budget));
+    }
     return _result('forms.list', {
       'present': form != null,
       'total': fields.length,
       'returned': take,
-      'truncated': take < fields.length,
-      'fields': [
-        for (final field in fields.take(take)) _fieldJson(field),
-      ],
+      'truncated': take < fields.length || budget.truncated,
+      'fields': output,
     });
   }
 
@@ -247,15 +326,13 @@ class DartPdfDocument {
     );
     final annotations = <Map<String, Object?>>[];
     var total = 0;
-    var textBudget = limits.maxAnnotationTextChars;
-    var textTruncated = false;
+    final textBudget = _TextBudget(limits.maxAnnotationTextChars);
     for (final pageIndex in selection.indices) {
       for (final annotation in document.page(pageIndex).annotations) {
         total++;
         if (annotations.length >= limits.maxAnnotations) continue;
         final item = <String, Object?>{
           'page': pageIndex + 1,
-          'subtype': annotation.subtype,
           'rect': _rectJson(annotation.rect),
           'flags': annotation.flags,
           'hidden': annotation.isHidden,
@@ -263,20 +340,10 @@ class DartPdfDocument {
           'readOnly': annotation.isReadOnly,
           'locked': annotation.isLocked,
         };
-        void addBoundedText(String key, String? value) {
-          if (value == null) return;
-          final take = value.length < textBudget ? value.length : textBudget;
-          item[key] = value.substring(0, take);
-          if (take < value.length) {
-            item['${key}Truncated'] = true;
-            textTruncated = true;
-          }
-          textBudget -= take;
-        }
-
-        addBoundedText('name', annotation.name);
-        addBoundedText('author', annotation.author);
-        addBoundedText('contents', annotation.contents);
+        textBudget.add(item, 'subtype', annotation.subtype);
+        textBudget.add(item, 'name', annotation.name);
+        textBudget.add(item, 'author', annotation.author);
+        textBudget.add(item, 'contents', annotation.contents);
         annotations.add(item);
       }
     }
@@ -285,39 +352,61 @@ class DartPdfDocument {
       'selectedPages': [for (final index in selection.indices) index + 1],
       'total': total,
       'returned': annotations.length,
-      'truncated':
-          selection.truncated || annotations.length < total || textTruncated,
+      'truncated': selection.truncated ||
+          annotations.length < total ||
+          textBudget.truncated,
       'annotations': annotations,
     });
   }
 
-  Map<String, Object?> _fieldJson(PdfFormField field) {
-    final widgets = <Map<String, Object?>>[];
-    for (var index = 0; index < field.widgets.length; index++) {
-      final rect = field.widgetRect(index);
-      final pageIndex = field.widgetPageIndex(index);
-      widgets.add({
-        'page': pageIndex < 0 ? null : pageIndex + 1,
-        if (rect != null) 'rect': _rectJson(rect),
-        if (field.widgetOnState(index) != null)
-          'onState': field.widgetOnState(index),
-      });
-    }
-    return {
-      'name': field.name,
+  Map<String, Object?> _fieldJson(PdfFormField field, _FormBudget budget) {
+    final item = <String, Object?>{
       'type': field.type.name,
-      if (!field.isPassword && field.value != null) 'value': field.value,
-      if (field.isPassword && field.value != null) 'valueRedacted': true,
       'readOnly': field.isReadOnly,
       'required': field.isRequired,
       if (field.type == PdfFieldType.text) 'multiline': field.isMultiline,
-      if (field.options.isNotEmpty)
-        'options': [
-          for (final option in field.options)
-            {'value': option.$1, 'label': option.$2},
-        ],
-      'widgets': widgets,
     };
+    budget.text.add(item, 'name', field.name);
+    if (!field.isPassword) budget.text.add(item, 'value', field.value);
+    if (field.isPassword && field.value != null) item['valueRedacted'] = true;
+
+    final options = field.options;
+    if (options.isNotEmpty) {
+      final take = options.length < budget.optionsRemaining
+          ? options.length
+          : budget.optionsRemaining;
+      item['options'] = [
+        for (final option in options.take(take))
+          budget.optionJson(option.$1, option.$2),
+      ];
+      budget.optionsRemaining -= take;
+      if (take < options.length) {
+        item['optionsTruncated'] = true;
+        budget.markTruncated();
+      }
+    }
+
+    final widgets = <Map<String, Object?>>[];
+    final widgetTake = field.widgets.length < budget.widgetsRemaining
+        ? field.widgets.length
+        : budget.widgetsRemaining;
+    for (var index = 0; index < widgetTake; index++) {
+      final rect = field.widgetRect(index);
+      final pageIndex = field.widgetPageIndex(index);
+      final widget = <String, Object?>{
+        'page': pageIndex < 0 ? null : pageIndex + 1,
+        if (rect != null) 'rect': _rectJson(rect),
+      };
+      budget.text.add(widget, 'onState', field.widgetOnState(index));
+      widgets.add(widget);
+    }
+    budget.widgetsRemaining -= widgetTake;
+    if (widgetTake < field.widgets.length) {
+      item['widgetsTruncated'] = true;
+      budget.markTruncated();
+    }
+    item['widgets'] = widgets;
+    return item;
   }
 
   Map<String, Object?> _result(String operation, Map<String, Object?> data) => {
@@ -332,4 +421,65 @@ class DartPdfDocument {
         rect.right,
         rect.top,
       ];
+}
+
+class _TextBudget {
+  _TextBudget(this.remaining);
+
+  int remaining;
+  bool truncated = false;
+
+  bool canTake(String value) => value.length <= remaining;
+
+  String take(String value) {
+    final length = _safePrefixLength(value, remaining);
+    final result = value.substring(0, length);
+    remaining -= length;
+    if (length < value.length) truncated = true;
+    return result;
+  }
+
+  void add(Map<String, Object?> output, String key, String? value) {
+    if (value == null) return;
+    final bounded = take(value);
+    output[key] = bounded;
+    if (bounded.length < value.length) output['${key}Truncated'] = true;
+  }
+
+  void markTruncated() => truncated = true;
+}
+
+class _FormBudget {
+  _FormBudget(DartPdfLimits limits)
+      : text = _TextBudget(limits.maxFormTextChars),
+        widgetsRemaining = limits.maxFormWidgets,
+        optionsRemaining = limits.maxFormOptions;
+
+  final _TextBudget text;
+  int widgetsRemaining;
+  int optionsRemaining;
+  bool _collectionTruncated = false;
+
+  bool get truncated => _collectionTruncated || text.truncated;
+
+  Map<String, Object?> optionJson(String value, String label) {
+    final output = <String, Object?>{};
+    text.add(output, 'value', value);
+    text.add(output, 'label', label);
+    return output;
+  }
+
+  void markTruncated() => _collectionTruncated = true;
+}
+
+int _safePrefixLength(String value, int maximum) {
+  var length = value.length < maximum ? value.length : maximum;
+  if (length > 0 && length < value.length) {
+    final last = value.codeUnitAt(length - 1);
+    final next = value.codeUnitAt(length);
+    if (last >= 0xD800 && last <= 0xDBFF && next >= 0xDC00 && next <= 0xDFFF) {
+      length--;
+    }
+  }
+  return length;
 }

--- a/packages/dart_pdf_cli/lib/src/service.dart
+++ b/packages/dart_pdf_cli/lib/src/service.dart
@@ -1,0 +1,335 @@
+import 'dart:typed_data';
+
+import 'package:pdf_document/pdf_document.dart';
+import 'package:pdf_graphics/pdf_graphics.dart';
+
+/// Version of the JSON contract returned by all DartPDF read operations.
+const dartPdfJsonSchemaVersion = 1;
+
+/// Hard result bounds shared by CLI and MCP transports.
+class DartPdfLimits {
+  const DartPdfLimits({
+    this.maxPages = 50,
+    this.maxTextCharsPerPage = 100000,
+    this.maxTextChars = 500000,
+    this.maxFields = 1000,
+    this.maxAnnotations = 1000,
+    this.maxAnnotationTextChars = 20000,
+  })  : assert(maxPages > 0),
+        assert(maxTextCharsPerPage > 0),
+        assert(maxTextChars > 0),
+        assert(maxFields > 0),
+        assert(maxAnnotations > 0),
+        assert(maxAnnotationTextChars > 0);
+
+  final int maxPages;
+  final int maxTextCharsPerPage;
+  final int maxTextChars;
+  final int maxFields;
+  final int maxAnnotations;
+  final int maxAnnotationTextChars;
+}
+
+/// Invalid page selection or request that exceeds a configured result bound.
+class DartPdfRequestException implements Exception {
+  const DartPdfRequestException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// A parsed, one-based CLI page range resolved to zero-based page indices.
+class DartPdfPageSelection {
+  const DartPdfPageSelection({
+    required this.indices,
+    required this.truncated,
+  });
+
+  final List<int> indices;
+  final bool truncated;
+
+  /// Parses comma-separated pages and inclusive ranges such as `1-3,7`.
+  ///
+  /// A missing [specification] selects the first [maxPages] pages and reports
+  /// [truncated] when the document contains more. Explicit selections that
+  /// exceed [maxPages] are rejected rather than silently changing the request.
+  factory DartPdfPageSelection.parse(
+    String? specification, {
+    required int pageCount,
+    required int maxPages,
+  }) {
+    if (maxPages <= 0) {
+      throw const DartPdfRequestException('maxPages must be positive');
+    }
+    final spec = specification?.trim() ?? '';
+    if (spec.isEmpty) {
+      final count = pageCount < maxPages ? pageCount : maxPages;
+      return DartPdfPageSelection(
+        indices: List<int>.generate(count, (index) => index),
+        truncated: pageCount > count,
+      );
+    }
+
+    final indices = <int>[];
+    final seen = <int>{};
+    for (final rawPart in spec.split(',')) {
+      final part = rawPart.trim();
+      if (part.isEmpty) {
+        throw DartPdfRequestException('invalid page range "$spec"');
+      }
+      final dash = part.indexOf('-');
+      final int start;
+      final int end;
+      if (dash < 0) {
+        start = _parsePage(part, spec);
+        end = start;
+      } else {
+        if (part.indexOf('-', dash + 1) >= 0) {
+          throw DartPdfRequestException('invalid page range "$spec"');
+        }
+        start = _parsePage(part.substring(0, dash).trim(), spec);
+        end = _parsePage(part.substring(dash + 1).trim(), spec);
+        if (end < start) {
+          throw DartPdfRequestException(
+              'descending page range "$part" is not supported');
+        }
+      }
+      if (start > pageCount || end > pageCount) {
+        throw DartPdfRequestException(
+            'page range "$part" exceeds document page count $pageCount');
+      }
+      for (var page = start; page <= end; page++) {
+        final index = page - 1;
+        if (seen.add(index)) indices.add(index);
+        if (indices.length > maxPages) {
+          throw DartPdfRequestException(
+              'page selection exceeds the $maxPages-page limit');
+        }
+      }
+    }
+    return DartPdfPageSelection(indices: indices, truncated: false);
+  }
+
+  static int _parsePage(String value, String wholeSpec) {
+    final page = int.tryParse(value);
+    if (page == null || page < 1) {
+      throw DartPdfRequestException('invalid page range "$wholeSpec"');
+    }
+    return page;
+  }
+}
+
+/// Opens bytes once and exposes the read-only operations shared by transports.
+class DartPdfService {
+  const DartPdfService({this.limits = const DartPdfLimits()});
+
+  final DartPdfLimits limits;
+
+  DartPdfDocument open(Uint8List bytes, {String password = ''}) =>
+      DartPdfDocument._(PdfDocument.open(bytes, password: password), limits);
+}
+
+/// One open PDF document and the stable JSON-producing command handlers.
+class DartPdfDocument {
+  DartPdfDocument._(this.document, this.limits);
+
+  final PdfDocument document;
+  final DartPdfLimits limits;
+
+  Map<String, Object?> inspect() {
+    final form = PdfAcroForm.of(document);
+    final signatures = PdfSignature.of(document);
+    var annotationCount = 0;
+    final annotationTypes = <String, int>{};
+    for (var pageIndex = 0; pageIndex < document.pageCount; pageIndex++) {
+      for (final annotation in document.page(pageIndex).annotations) {
+        annotationCount++;
+        annotationTypes.update(annotation.subtype, (count) => count + 1,
+            ifAbsent: () => 1);
+      }
+    }
+
+    return _result('inspect', {
+      'version': document.version,
+      'metadata': document.info,
+      'pageCount': document.pageCount,
+      'encrypted': document.cos.isEncrypted,
+      'forms': {
+        'present': form != null,
+        'fieldCount': form?.fields.length ?? 0,
+      },
+      'annotations': {
+        'count': annotationCount,
+        'bySubtype': annotationTypes,
+      },
+      'signatures': {
+        'signed': signatures.isNotEmpty,
+        'count': signatures.length,
+        'items': [
+          for (final signature in signatures)
+            {
+              'field': signature.field.name,
+              if (signature.signerName != null) 'signer': signature.signerName,
+              if (signature.subFilter != null) 'subFilter': signature.subFilter,
+              if (signature.signingTime != null)
+                'signingTime': signature.signingTime!.toIso8601String(),
+              'documentTimestamp': signature.isDocumentTimeStamp,
+            },
+        ],
+      },
+    });
+  }
+
+  Map<String, Object?> extractText({String? pages}) {
+    final selection = DartPdfPageSelection.parse(
+      pages,
+      pageCount: document.pageCount,
+      maxPages: limits.maxPages,
+    );
+    final output = <Map<String, Object?>>[];
+    var remaining = limits.maxTextChars;
+    var truncated = selection.truncated;
+    for (final pageIndex in selection.indices) {
+      if (remaining <= 0) {
+        truncated = true;
+        break;
+      }
+      final extracted = PdfTextExtractor.reflowPage(document, pageIndex).text;
+      final pageLimit = remaining < limits.maxTextCharsPerPage
+          ? remaining
+          : limits.maxTextCharsPerPage;
+      final take = extracted.length < pageLimit ? extracted.length : pageLimit;
+      final pageTruncated = take < extracted.length;
+      output.add({
+        'page': pageIndex + 1,
+        'text': extracted.substring(0, take),
+        'characters': take,
+        if (pageTruncated) 'truncated': true,
+      });
+      remaining -= take;
+      truncated = truncated || pageTruncated;
+    }
+    if (output.length < selection.indices.length) truncated = true;
+
+    return _result('text', {
+      'pageCount': document.pageCount,
+      'selectedPages': [for (final index in selection.indices) index + 1],
+      'returnedPages': output.length,
+      'characters': limits.maxTextChars - remaining,
+      'truncated': truncated,
+      'pages': output,
+    });
+  }
+
+  Map<String, Object?> listForms() {
+    final form = PdfAcroForm.of(document);
+    final fields = form?.fields ?? const <PdfFormField>[];
+    final take =
+        fields.length < limits.maxFields ? fields.length : limits.maxFields;
+    return _result('forms.list', {
+      'present': form != null,
+      'total': fields.length,
+      'returned': take,
+      'truncated': take < fields.length,
+      'fields': [
+        for (final field in fields.take(take)) _fieldJson(field),
+      ],
+    });
+  }
+
+  Map<String, Object?> listAnnotations({String? pages}) {
+    final selection = DartPdfPageSelection.parse(
+      pages,
+      pageCount: document.pageCount,
+      maxPages: limits.maxPages,
+    );
+    final annotations = <Map<String, Object?>>[];
+    var total = 0;
+    var textBudget = limits.maxAnnotationTextChars;
+    var textTruncated = false;
+    for (final pageIndex in selection.indices) {
+      for (final annotation in document.page(pageIndex).annotations) {
+        total++;
+        if (annotations.length >= limits.maxAnnotations) continue;
+        final item = <String, Object?>{
+          'page': pageIndex + 1,
+          'subtype': annotation.subtype,
+          'rect': _rectJson(annotation.rect),
+          'flags': annotation.flags,
+          'hidden': annotation.isHidden,
+          'noView': annotation.isNoView,
+          'readOnly': annotation.isReadOnly,
+          'locked': annotation.isLocked,
+        };
+        void addBoundedText(String key, String? value) {
+          if (value == null) return;
+          final take = value.length < textBudget ? value.length : textBudget;
+          item[key] = value.substring(0, take);
+          if (take < value.length) {
+            item['${key}Truncated'] = true;
+            textTruncated = true;
+          }
+          textBudget -= take;
+        }
+
+        addBoundedText('name', annotation.name);
+        addBoundedText('author', annotation.author);
+        addBoundedText('contents', annotation.contents);
+        annotations.add(item);
+      }
+    }
+    return _result('annotations.list', {
+      'pageCount': document.pageCount,
+      'selectedPages': [for (final index in selection.indices) index + 1],
+      'total': total,
+      'returned': annotations.length,
+      'truncated':
+          selection.truncated || annotations.length < total || textTruncated,
+      'annotations': annotations,
+    });
+  }
+
+  Map<String, Object?> _fieldJson(PdfFormField field) {
+    final widgets = <Map<String, Object?>>[];
+    for (var index = 0; index < field.widgets.length; index++) {
+      final rect = field.widgetRect(index);
+      final pageIndex = field.widgetPageIndex(index);
+      widgets.add({
+        'page': pageIndex < 0 ? null : pageIndex + 1,
+        if (rect != null) 'rect': _rectJson(rect),
+        if (field.widgetOnState(index) != null)
+          'onState': field.widgetOnState(index),
+      });
+    }
+    return {
+      'name': field.name,
+      'type': field.type.name,
+      if (!field.isPassword && field.value != null) 'value': field.value,
+      if (field.isPassword && field.value != null) 'valueRedacted': true,
+      'readOnly': field.isReadOnly,
+      'required': field.isRequired,
+      if (field.type == PdfFieldType.text) 'multiline': field.isMultiline,
+      if (field.options.isNotEmpty)
+        'options': [
+          for (final option in field.options)
+            {'value': option.$1, 'label': option.$2},
+        ],
+      'widgets': widgets,
+    };
+  }
+
+  Map<String, Object?> _result(String operation, Map<String, Object?> data) => {
+        'schemaVersion': dartPdfJsonSchemaVersion,
+        'operation': operation,
+        ...data,
+      };
+
+  static List<double> _rectJson(PdfRect rect) => [
+        rect.left,
+        rect.bottom,
+        rect.right,
+        rect.top,
+      ];
+}

--- a/packages/dart_pdf_cli/pubspec.yaml
+++ b/packages/dart_pdf_cli/pubspec.yaml
@@ -1,0 +1,30 @@
+name: dart_pdf_cli
+description: Pure-Dart command line and MCP tools for inspecting PDF documents.
+version: 0.1.0
+repository: https://github.com/ben-milanko/dart-pdf/tree/main/packages/dart_pdf_cli
+issue_tracker: https://github.com/ben-milanko/dart-pdf/issues
+topics:
+  - pdf
+  - cli
+  - mcp
+  - automation
+resolution: workspace
+
+environment:
+  sdk: ^3.5.0
+
+executables:
+  dartpdf: dartpdf
+
+dependencies:
+  args: ^2.7.0
+  mcp_dart: ^2.4.0
+  path: ^1.9.0
+  pdf_cos: ^3.5.1
+  pdf_document: ^3.5.1
+  pdf_graphics: ^3.5.1
+
+dev_dependencies:
+  lints: ^6.1.0
+  pdf_test_fixtures: '>=1.4.0 <4.0.0'
+  test: ^1.25.0

--- a/packages/dart_pdf_cli/test/cli_integration_test.dart
+++ b/packages/dart_pdf_cli/test/cli_integration_test.dart
@@ -23,7 +23,7 @@ void main() {
       () async {
     final result = await Process.run(
       Platform.resolvedExecutable,
-      ['run', 'bin/dartpdf.dart', 'inspect', '--json', pdf.path],
+      ['run', 'bin/dartpdf.dart', 'inspect', pdf.path, '--json'],
       workingDirectory: Directory.current.path,
     );
 
@@ -44,6 +44,30 @@ void main() {
     expect(result.exitCode, 64);
     expect(result.stdout, isEmpty);
     expect(result.stderr, contains('requires exactly one input PDF path'));
+  });
+
+  test('password files are bounded instead of being read without limit',
+      () async {
+    final password = File('${temporary.path}/password.txt');
+    await password.writeAsString(List.filled(4097, 'x').join());
+    final result = await Process.run(
+      Platform.resolvedExecutable,
+      [
+        'run',
+        'bin/dartpdf.dart',
+        'inspect',
+        pdf.path,
+        '--password-file',
+        password.path,
+        '--json',
+      ],
+      workingDirectory: Directory.current.path,
+    );
+
+    expect(result.exitCode, 64);
+    expect(result.stdout, isEmpty);
+    expect(
+        result.stderr, contains('password input exceeds the 4096-byte limit'));
   });
 
   test('stdio MCP lists and calls the shared inspect handler', () async {
@@ -104,6 +128,15 @@ void main() {
           'list_pdf_annotations',
         ]),
       );
+      final inspectTool =
+          tools.singleWhere((tool) => tool['name'] == 'inspect_pdf');
+      final inspectSchema = inspectTool['inputSchema'] as Map<String, dynamic>;
+      final inspectProperties =
+          inspectSchema['properties'] as Map<String, dynamic>;
+      expect(
+        (inspectProperties['path'] as Map<String, dynamic>)['maxLength'],
+        32768,
+      );
 
       send({
         'jsonrpc': '2.0',
@@ -138,6 +171,22 @@ void main() {
             as Map<String, dynamic>)['text'],
         contains('outside configured MCP filesystem roots'),
       );
+
+      send({
+        'jsonrpc': '2.0',
+        'id': 5,
+        'method': 'tools/call',
+        'params': {
+          'name': 'inspect_pdf',
+          'arguments': {'path': List.filled(5000, 'x').join()},
+        },
+      });
+      final boundedError = await response(5);
+      final boundedResult = boundedError['result'] as Map<String, dynamic>;
+      expect(boundedResult['isError'], isTrue);
+      final errorText = ((boundedResult['content'] as List<dynamic>).single
+          as Map<String, dynamic>)['text'] as String;
+      expect(errorText.length, lessThanOrEqualTo(4130));
     } finally {
       process.kill();
       await process.stdin.close();

--- a/packages/dart_pdf_cli/test/cli_integration_test.dart
+++ b/packages/dart_pdf_cli/test/cli_integration_test.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory temporary;
+  late File pdf;
+
+  setUp(() async {
+    temporary = await Directory.systemTemp.createTemp('dartpdf-cli-test-');
+    pdf = File('${temporary.path}/sample.pdf');
+    await pdf.writeAsBytes(buildClassicPdf());
+  });
+
+  tearDown(() async {
+    if (await temporary.exists()) await temporary.delete(recursive: true);
+  });
+
+  test('inspect command emits compact JSON and keeps diagnostics off stdout',
+      () async {
+    final result = await Process.run(
+      Platform.resolvedExecutable,
+      ['run', 'bin/dartpdf.dart', 'inspect', '--json', pdf.path],
+      workingDirectory: Directory.current.path,
+    );
+
+    expect(result.exitCode, 0, reason: result.stderr as String);
+    expect(result.stderr, isEmpty);
+    final json = jsonDecode(result.stdout as String) as Map<String, dynamic>;
+    expect(json['operation'], 'inspect');
+    expect(json['pageCount'], 1);
+  });
+
+  test('missing input is a meaningful non-zero diagnostic', () async {
+    final result = await Process.run(
+      Platform.resolvedExecutable,
+      ['run', 'bin/dartpdf.dart', 'text', '--json'],
+      workingDirectory: Directory.current.path,
+    );
+
+    expect(result.exitCode, 64);
+    expect(result.stdout, isEmpty);
+    expect(result.stderr, contains('requires exactly one input PDF path'));
+  });
+
+  test('stdio MCP lists and calls the shared inspect handler', () async {
+    final process = await Process.start(
+      Platform.resolvedExecutable,
+      ['run', 'bin/dartpdf.dart', 'mcp', '--root', temporary.path],
+      workingDirectory: Directory.current.path,
+    );
+    final lines = StreamIterator<String>(
+      process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
+    );
+    final stderrBuffer = StringBuffer();
+    final stderrDone = process.stderr
+        .transform(utf8.decoder)
+        .listen(stderrBuffer.write)
+        .asFuture<void>();
+
+    Future<Map<String, dynamic>> response(int id) async {
+      while (await lines.moveNext().timeout(const Duration(seconds: 20))) {
+        final value = jsonDecode(lines.current) as Map<String, dynamic>;
+        if (value['id'] == id) return value;
+      }
+      throw StateError('MCP server closed before response $id');
+    }
+
+    void send(Map<String, Object?> message) {
+      process.stdin.writeln(jsonEncode(message));
+    }
+
+    try {
+      send({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'initialize',
+        'params': {
+          'protocolVersion': '2025-11-25',
+          'capabilities': <String, Object?>{},
+          'clientInfo': {'name': 'dartpdf-test', 'version': '1.0.0'},
+        },
+      });
+      final initialized = await response(1);
+      expect(initialized['error'], isNull);
+      send({
+        'jsonrpc': '2.0',
+        'method': 'notifications/initialized',
+      });
+      send({'jsonrpc': '2.0', 'id': 2, 'method': 'tools/list'});
+      final listed = await response(2);
+      final tools =
+          ((listed['result'] as Map<String, dynamic>)['tools'] as List<dynamic>)
+              .cast<Map<String, dynamic>>();
+      expect(
+        tools.map((tool) => tool['name']),
+        containsAll([
+          'inspect_pdf',
+          'extract_pdf_text',
+          'list_pdf_forms',
+          'list_pdf_annotations',
+        ]),
+      );
+
+      send({
+        'jsonrpc': '2.0',
+        'id': 3,
+        'method': 'tools/call',
+        'params': {
+          'name': 'inspect_pdf',
+          'arguments': {'path': 'sample.pdf'},
+        },
+      });
+      final called = await response(3);
+      final result = called['result'] as Map<String, dynamic>;
+      expect(result['isError'], isNot(true));
+      final structured = result['structuredContent'] as Map<String, dynamic>;
+      expect(structured['operation'], 'inspect');
+      expect(structured['pageCount'], 1);
+
+      send({
+        'jsonrpc': '2.0',
+        'id': 4,
+        'method': 'tools/call',
+        'params': {
+          'name': 'inspect_pdf',
+          'arguments': {'path': '${Directory.current.path}/pubspec.yaml'},
+        },
+      });
+      final denied = await response(4);
+      final deniedResult = denied['result'] as Map<String, dynamic>;
+      expect(deniedResult['isError'], isTrue);
+      expect(
+        ((deniedResult['content'] as List<dynamic>).single
+            as Map<String, dynamic>)['text'],
+        contains('outside configured MCP filesystem roots'),
+      );
+    } finally {
+      process.kill();
+      await process.stdin.close();
+      await process.exitCode;
+      await lines.cancel();
+      await stderrDone;
+    }
+  }, timeout: const Timeout(Duration(minutes: 1)));
+}

--- a/packages/dart_pdf_cli/test/service_test.dart
+++ b/packages/dart_pdf_cli/test/service_test.dart
@@ -1,0 +1,148 @@
+import 'package:dart_pdf_cli/dart_pdf_cli.dart';
+import 'package:pdf_test_fixtures/pdf_test_fixtures.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DartPdfPageSelection', () {
+    test('parses ranges, preserves order, and removes duplicates', () {
+      final selection = DartPdfPageSelection.parse(
+        '3,1-2,2',
+        pageCount: 4,
+        maxPages: 4,
+      );
+
+      expect(selection.indices, [2, 0, 1]);
+      expect(selection.truncated, isFalse);
+    });
+
+    test('bounds implicit and explicit selections', () {
+      final implicit = DartPdfPageSelection.parse(
+        null,
+        pageCount: 4,
+        maxPages: 2,
+      );
+      expect(implicit.indices, [0, 1]);
+      expect(implicit.truncated, isTrue);
+
+      expect(
+        () => DartPdfPageSelection.parse(
+          '1-3',
+          pageCount: 4,
+          maxPages: 2,
+        ),
+        throwsA(isA<DartPdfRequestException>()),
+      );
+    });
+
+    test('rejects invalid or out-of-range pages', () {
+      for (final pages in ['0', '2-1', '1,,2', '5']) {
+        expect(
+          () => DartPdfPageSelection.parse(
+            pages,
+            pageCount: 4,
+            maxPages: 4,
+          ),
+          throwsA(isA<DartPdfRequestException>()),
+          reason: pages,
+        );
+      }
+    });
+  });
+
+  group('DartPdfDocument', () {
+    test('inspect returns the stable document summary', () {
+      final result = const DartPdfService().open(buildClassicPdf()).inspect();
+
+      expect(result['schemaVersion'], dartPdfJsonSchemaVersion);
+      expect(result['operation'], 'inspect');
+      expect(result['version'], '1.4');
+      expect(result['pageCount'], 1);
+      expect(result['encrypted'], isFalse);
+      expect(result['forms'], {'present': false, 'fieldCount': 0});
+      expect(
+        result['annotations'],
+        {'count': 0, 'bySubtype': <String, int>{}},
+      );
+      expect(
+        result['signatures'],
+        {'signed': false, 'count': 0, 'items': <Object>[]},
+      );
+    });
+
+    test('inspect reports encryption after opening with a password', () {
+      final result = const DartPdfService()
+          .open(
+            buildEncryptedPdf(userPassword: 'secret'),
+            password: 'secret',
+          )
+          .inspect();
+
+      expect(result['encrypted'], isTrue);
+      expect(result['metadata'], containsPair('Title', 'Secret Title'));
+    });
+
+    test('text is page-addressable', () {
+      final result = const DartPdfService()
+          .open(buildMultiPagePdf(3))
+          .extractText(pages: '2-3');
+
+      expect(result['selectedPages'], [2, 3]);
+      expect(result['returnedPages'], 2);
+      final pages = result['pages']! as List<Object?>;
+      expect(pages[0], containsPair('page', 2));
+      expect(pages[0], containsPair('text', contains('Page 2')));
+      expect(pages[1], containsPair('page', 3));
+    });
+
+    test('text respects page and character limits', () {
+      const service = DartPdfService(
+        limits: DartPdfLimits(
+          maxPages: 1,
+          maxTextCharsPerPage: 4,
+          maxTextChars: 4,
+        ),
+      );
+      final result = service.open(buildMultiPagePdf(3)).extractText();
+
+      expect(result['selectedPages'], [1]);
+      expect(result['characters'], 4);
+      expect(result['truncated'], isTrue);
+      final page =
+          (result['pages']! as List<Object?>).single as Map<String, Object?>;
+      expect(page['text'], 'Page');
+      expect(page['truncated'], isTrue);
+    });
+
+    test('forms list is pure Dart and includes widgets/options', () {
+      final result =
+          const DartPdfService().open(buildAcroFormPdf()).listForms();
+
+      expect(result['present'], isTrue);
+      expect(result['total'], 6);
+      final fields =
+          (result['fields']! as List<Object?>).cast<Map<String, Object?>>();
+      final name = fields.singleWhere((field) => field['name'] == 'name');
+      expect(name['type'], 'text');
+      expect(name['value'], 'prefilled');
+      expect(name['widgets'], hasLength(1));
+      final size = fields.singleWhere((field) => field['name'] == 'size');
+      expect(size['type'], 'comboBox');
+      expect(size['options'], hasLength(3));
+    });
+
+    test('annotation list can select pages and is bounded', () {
+      const service = DartPdfService(
+        limits: DartPdfLimits(maxAnnotations: 2),
+      );
+      final result =
+          service.open(buildAnnotatedPdf()).listAnnotations(pages: '1');
+
+      expect(result['selectedPages'], [1]);
+      expect(result['total'], 6);
+      expect(result['returned'], 2);
+      expect(result['truncated'], isTrue);
+      final annotations = result['annotations']! as List<Object?>;
+      expect(annotations.first, containsPair('subtype', 'Link'));
+    });
+  });
+}

--- a/packages/dart_pdf_cli/test/service_test.dart
+++ b/packages/dart_pdf_cli/test/service_test.dart
@@ -81,6 +81,31 @@ void main() {
       expect(result['metadata'], containsPair('Title', 'Secret Title'));
     });
 
+    test('inspect bounds variable metadata and annotation subtype output', () {
+      const metadataService = DartPdfService(
+        limits: DartPdfLimits(maxInspectTextChars: 7),
+      );
+      final metadata = metadataService
+          .open(
+            buildEncryptedPdf(userPassword: 'secret'),
+            password: 'secret',
+          )
+          .inspect();
+      expect(metadata['metadata'], containsPair('Title', 'Se'));
+      expect(metadata['metadataTruncated'], isTrue);
+      expect(metadata['truncated'], isTrue);
+
+      const subtypeService = DartPdfService(
+        limits: DartPdfLimits(maxInspectAnnotationSubtypes: 1),
+      );
+      final result = subtypeService.open(buildAnnotatedPdf()).inspect();
+      final annotations = result['annotations']! as Map<String, Object?>;
+      expect(annotations['bySubtype'], hasLength(1));
+      expect(annotations['otherSubtypeCount'], greaterThan(0));
+      expect(annotations['subtypesTruncated'], isTrue);
+      expect(result['truncated'], isTrue);
+    });
+
     test('text is page-addressable', () {
       final result = const DartPdfService()
           .open(buildMultiPagePdf(3))
@@ -130,6 +155,41 @@ void main() {
       expect(size['options'], hasLength(3));
     });
 
+    test('forms list bounds nested widgets and options globally', () {
+      const service = DartPdfService(
+        limits: DartPdfLimits(
+          maxFormWidgets: 2,
+          maxFormOptions: 1,
+        ),
+      );
+      final result = service.open(buildAcroFormPdf()).listForms();
+      final fields =
+          (result['fields']! as List<Object?>).cast<Map<String, Object?>>();
+      final widgetCount = fields.fold<int>(
+        0,
+        (total, field) => total + (field['widgets']! as List<Object?>).length,
+      );
+      final optionCount = fields.fold<int>(
+        0,
+        (total, field) =>
+            total + ((field['options'] as List<Object?>?)?.length ?? 0),
+      );
+
+      expect(widgetCount, 2);
+      expect(optionCount, 1);
+      expect(
+          fields,
+          contains(predicate<Map<String, Object?>>(
+            (field) => field['widgetsTruncated'] == true,
+          )));
+      expect(
+          fields,
+          contains(predicate<Map<String, Object?>>(
+            (field) => field['optionsTruncated'] == true,
+          )));
+      expect(result['truncated'], isTrue);
+    });
+
     test('annotation list can select pages and is bounded', () {
       const service = DartPdfService(
         limits: DartPdfLimits(maxAnnotations: 2),
@@ -143,6 +203,22 @@ void main() {
       expect(result['truncated'], isTrue);
       final annotations = result['annotations']! as List<Object?>;
       expect(annotations.first, containsPair('subtype', 'Link'));
+    });
+
+    test('annotation list bounds subtype text as well as optional text', () {
+      const service = DartPdfService(
+        limits: DartPdfLimits(
+          maxAnnotations: 1,
+          maxAnnotationTextChars: 1,
+        ),
+      );
+      final result = service.open(buildAnnotatedPdf()).listAnnotations();
+      final annotation = (result['annotations']! as List<Object?>).single
+          as Map<String, Object?>;
+
+      expect(annotation['subtype'], 'L');
+      expect(annotation['subtypeTruncated'], isTrue);
+      expect(result['truncated'], isTrue);
     });
   });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -593,6 +593,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  mcp_dart:
+    dependency: transitive
+    description:
+      name: mcp_dart
+      sha256: "66a17878b76faee9655b8f74e9852fa9f2811e26a9aa8ec2ac2637f0324be3e8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - packages/pdf_cos
   - packages/pdf_document
   - packages/pdf_graphics
+  - packages/dart_pdf_cli
   - packages/pdf_ocr_vlm
   - packages/pdf_ocr_ondevice
   - packages/dart_pdf_editor

--- a/tool/build_desktop_cli.dart
+++ b/tool/build_desktop_cli.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+
+const _usage = '''
+Usage: dart tool/build_desktop_cli.dart \\
+  --output <path> \\
+  --target-os <linux|macos|windows> \\
+  --target-arch <arm64|x64>
+
+Compiles one native dartpdf CLI/MCP sidecar with the workspace package graph.
+Universal macOS release builds compile one sidecar on each native architecture
+and merge them in the release workflow.
+''';
+
+Future<void> main(List<String> arguments) async {
+  try {
+    final options = _Options.parse(arguments);
+    await _build(options);
+  } on _UsageError catch (error) {
+    stderr.writeln(error.message);
+    stderr.writeln(_usage);
+    exitCode = 64;
+  } on _BuildError catch (error) {
+    stderr.writeln('dartpdf sidecar build failed: ${error.message}');
+    exitCode = 1;
+  }
+}
+
+Future<void> _build(_Options options) async {
+  final script = File.fromUri(Platform.script).absolute;
+  final repository = script.parent.parent;
+  final entrypoint = File(
+    '${repository.path}${Platform.pathSeparator}'
+    'packages${Platform.pathSeparator}dart_pdf_cli${Platform.pathSeparator}'
+    'bin${Platform.pathSeparator}dartpdf.dart',
+  );
+  final packageConfig = File(
+    '${repository.path}${Platform.pathSeparator}'
+    '.dart_tool${Platform.pathSeparator}package_config.json',
+  );
+  final output = File(options.output).absolute;
+
+  if (!entrypoint.existsSync()) {
+    throw _BuildError('entrypoint not found: ${entrypoint.path}');
+  }
+  if (!packageConfig.existsSync()) {
+    throw _BuildError(
+      'workspace package config not found: ${packageConfig.path}\n'
+      'Run `flutter pub get` at the repository root first.',
+    );
+  }
+  output.parent.createSync(recursive: true);
+
+  await _compile(
+    repository: repository,
+    entrypoint: entrypoint,
+    packageConfig: packageConfig,
+    output: output,
+    targetOs: options.targetOs,
+    targetArch: options.targetArch,
+  );
+
+  stdout.writeln(
+    'Built ${output.path} (${options.targetOs}/${options.targetArch})',
+  );
+}
+
+Future<void> _compile({
+  required Directory repository,
+  required File entrypoint,
+  required File packageConfig,
+  required File output,
+  required String targetOs,
+  required String targetArch,
+}) {
+  return _run(
+    Platform.resolvedExecutable,
+    [
+      'compile',
+      'exe',
+      '--target-os',
+      targetOs,
+      '--target-arch',
+      targetArch,
+      '--packages=${packageConfig.path}',
+      '--output=${output.path}',
+      entrypoint.path,
+    ],
+    workingDirectory: repository.path,
+  );
+}
+
+Future<void> _run(
+  String executable,
+  List<String> arguments, {
+  required String workingDirectory,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+    mode: ProcessStartMode.inheritStdio,
+  );
+  final result = await process.exitCode;
+  if (result != 0) {
+    throw _BuildError('$executable exited with status $result');
+  }
+}
+
+final class _Options {
+  const _Options({
+    required this.output,
+    required this.targetOs,
+    required this.targetArch,
+  });
+
+  factory _Options.parse(List<String> arguments) {
+    String? output;
+    String? targetOs;
+    String? targetArch;
+
+    for (var index = 0; index < arguments.length; index++) {
+      final argument = arguments[index];
+      String valueAfter(String name) {
+        if (index + 1 >= arguments.length) {
+          throw _UsageError('missing value for $name');
+        }
+        return arguments[++index];
+      }
+
+      switch (argument) {
+        case '--output':
+          output = valueAfter(argument);
+        case '--target-os':
+          targetOs = valueAfter(argument);
+        case '--target-arch':
+          if (targetArch != null) {
+            throw _UsageError('--target-arch may only be supplied once');
+          }
+          targetArch = _normalizeArchitecture(valueAfter(argument));
+        case '-h':
+        case '--help':
+          stdout.writeln(_usage);
+          exit(0);
+        default:
+          throw _UsageError('unknown argument: $argument');
+      }
+    }
+
+    if (output == null || output.isEmpty) {
+      throw _UsageError('--output is required');
+    }
+    if (!const {'linux', 'macos', 'windows'}.contains(targetOs)) {
+      throw _UsageError('--target-os must be linux, macos, or windows');
+    }
+    if (targetArch == null) {
+      throw _UsageError('--target-arch is required');
+    }
+
+    return _Options(
+      output: output,
+      targetOs: targetOs!,
+      targetArch: targetArch,
+    );
+  }
+
+  final String output;
+  final String targetOs;
+  final String targetArch;
+}
+
+String _normalizeArchitecture(String architecture) {
+  return switch (architecture.toLowerCase()) {
+    'amd64' || 'x86_64' => 'x64',
+    'aarch64' => 'arm64',
+    'arm64' || 'x64' => architecture.toLowerCase(),
+    _ => throw _UsageError('unsupported target architecture: $architecture'),
+  };
+}
+
+final class _UsageError implements Exception {
+  const _UsageError(this.message);
+
+  final String message;
+}
+
+final class _BuildError implements Exception {
+  const _BuildError(this.message);
+
+  final String message;
+}


### PR DESCRIPTION
Closes #683.

## What

- add the `dart_pdf_cli` workspace package with inspect, bounded text extraction, form listing, annotation listing, and a stdio MCP server
- share one versioned JSON service layer between CLI and MCP, with password-safe inputs, output limits, and MCP filesystem roots
- compile the CLI into macOS, Windows, and Linux desktop app builds and carry it through DMG, MSIX, Flatpak, Snap, AUR, and nightly/release workflows
- document direct invocation, MCP registration, sidecar locations, and the desktop release matrix

## Why

DartPDF needs a scriptable, machine-readable surface for local automation and agent workflows. Shipping the same executable beside desktop builds makes that surface available without requiring a separate Dart SDK or package installation.

## Impact

This adds a VM-only package above the existing PDF layers and does not add Flutter or dart:io imports to library packages. Desktop artifacts gain one native sidecar executable: `dartpdf-cli` on macOS/Linux and `dartpdf.exe` on Windows.

## Adversarial review

The published PR diff was reviewed against hostile PDFs/clients, filesystem boundaries, native packaging, and release reproducibility. The follow-up commit addresses three findings:

- nested form/inspect strings and collections, MCP inputs/errors, Unicode truncation boundaries, and password streams are now explicitly bounded
- `dart_pdf_cli` tests now run with coverage in the repository CI
- checked-in Flatpak, Snap, and AUR recipes remain reproducible against the pinned pre-sidecar release while release-time packaging requires/exposes the new sidecar

The pre-fix PR revision also completed the full GitHub matrix successfully, including Linux, Windows, and macOS native preview builds.

## Checks

- `fvm dart analyze`
- `cd packages/dart_pdf_cli && fvm dart test` (16 tests, including real stdio MCP negotiation and adversarial bounds)
- `cd packages/dart_pdf_cli && fvm dart pub publish --dry-run` (0 warnings)
- lockstep workspace dependency check
- fresh macOS arm64 AOT build and inspection of a real Ghent corpus PDF
- macOS Release app build, ad-hoc resign, and deep codesign verification
- Linux x64 cross-compile smoke check
- workflow/packaging YAML parse, Snap release-recipe injection parse, shell syntax, Xcode project lint, desktop asset comparisons, and `git diff --check`